### PR TITLE
github: block a warn-tier "looks good" reply that strands a CHANGES_REQUESTED

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -919,4 +919,45 @@ describe('channel_reply re-review stranding guard', () => {
     expect(result.details.ok).toBe(true)
     expect(queried).toBe(false)
   })
+
+  test('blocks a warn-tier "Looks good" PR comment while the bot still blocks the PR (PR #649)', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(
+        async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        },
+        { getReviewState: async () => ({ ok: true, selfBlocking: true, approve: true }) },
+      ),
+      origin: { adapter: 'github', workspace: 'acme/widgets', chat: 'pr:649', thread: null },
+    })
+
+    const result = await runTool(tool, {
+      text: 'Looks good — the remaining leak paths are fixed. Tests are green, so this is a solid cleanup. ✨',
+    })
+
+    expect(result.details.ok).toBe(false)
+    expect(calls).toHaveLength(0)
+    expect((result.content[0] as { text: string }).text).toContain('APPROVE')
+  })
+
+  test('allows a warn-tier "Looks good" PR comment when the bot holds no block', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(
+        async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        },
+        { getReviewState: async () => ({ ok: true, selfBlocking: false, approve: true }) },
+      ),
+      origin: { adapter: 'github', workspace: 'acme/widgets', chat: 'pr:649', thread: null },
+    })
+
+    const result = await runTool(tool, { text: 'Looks good, nice work!' })
+
+    expect(result.details.ok).toBe(true)
+    expect(calls).toHaveLength(1)
+  })
 })

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -171,6 +171,7 @@ export function createChannelReplyTool({
         thread: origin.thread,
         text,
         wantsResolve: params.resolve_review_thread === true,
+        isContinue: keepTurnAlive,
         getReviewState: (req) => router.getReviewState(req),
       })
       if (rereview.block) {

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -187,6 +187,7 @@ export function createChannelSendTool({
         thread: params.thread ?? null,
         text: bodyText,
         wantsResolve,
+        isContinue: false,
         getReviewState: (req) => router.getReviewState(req),
       })
       if (rereview.block) {

--- a/src/channels/github-rereview-guard.test.ts
+++ b/src/channels/github-rereview-guard.test.ts
@@ -162,4 +162,27 @@ describe('re-review stranding guard', () => {
     )
     expect(decision.block).toBe(true)
   })
+
+  // A negative warn phrase re-asserts the block instead of stranding it, so the
+  // guard must not query state or block it (PR #652 review). Only positive,
+  // approval-shaped warns are closeout attempts.
+  it.each(['still needs work', 'this needs changes before it lands'])(
+    'does not fire on a negative warn reply that re-asserts the block: %p',
+    async (text) => {
+      let queried = false
+      const decision = await evaluateRereviewGuard(
+        input({
+          thread: null,
+          wantsResolve: false,
+          text,
+          getReviewState: async () => {
+            queried = true
+            return { ok: true, selfBlocking: true, approve: true }
+          },
+        }),
+      )
+      expect(decision).toEqual({ block: false })
+      expect(queried).toBe(false)
+    },
+  )
 })

--- a/src/channels/github-rereview-guard.test.ts
+++ b/src/channels/github-rereview-guard.test.ts
@@ -9,6 +9,7 @@ function input(overrides: Partial<RereviewGuardInput> = {}): RereviewGuardInput 
     thread: '12345',
     text: 'Verified — that closes it, thanks!',
     wantsResolve: true,
+    isContinue: false,
     workspace: 'acme/widgets',
     getReviewState: async () => ({ ok: true, selfBlocking: true, approve: true }),
     ...overrides,
@@ -96,6 +97,68 @@ describe('re-review stranding guard', () => {
         text: 'Verified — that resolves it, thanks!',
         getReviewState: stateOk(true),
       }),
+    )
+    expect(decision.block).toBe(true)
+  })
+
+  // Regression: PR #649. The bot held a live CHANGES_REQUESTED, the author said
+  // "Addressed", and the bot replied "Looks good — … solid cleanup ✨" as a plain
+  // PR comment. That text classifies as warn-tier, not block-approve, so the old
+  // guard short-circuited to ALLOW and the comment stranded the block.
+  it('blocks a warn-tier "looks good" re-review reply while the bot still blocks the PR', async () => {
+    const decision = await evaluateRereviewGuard(
+      input({
+        thread: null,
+        wantsResolve: false,
+        text: 'Looks good — the remaining leak paths are fixed. Tests are green, so this is a solid cleanup. ✨',
+        getReviewState: stateOk(true),
+      }),
+    )
+    expect(decision.block).toBe(true)
+    if (decision.block) expect(decision.reason).toContain('APPROVE')
+  })
+
+  it('allows a warn-tier "looks good" when the bot holds no outstanding block', async () => {
+    const decision = await evaluateRereviewGuard(
+      input({ thread: null, wantsResolve: false, text: 'lgtm, nice work', getReviewState: stateOk(false) }),
+    )
+    expect(decision).toEqual({ block: false })
+  })
+
+  it('fails closed on a warn-tier reply when review state cannot be verified', async () => {
+    const decision = await evaluateRereviewGuard(
+      input({
+        thread: null,
+        wantsResolve: false,
+        text: 'looks good to me',
+        getReviewState: async () => ({ ok: false, error: 'GitHub reviews 503', code: 'transient' }),
+      }),
+    )
+    expect(decision.block).toBe(true)
+    if (decision.block) expect(decision.reason).toContain('Could not verify')
+  })
+
+  it('exempts a mid-turn warn-tier status reply (continue:true) from the state query', async () => {
+    let queried = false
+    const decision = await evaluateRereviewGuard(
+      input({
+        thread: null,
+        wantsResolve: false,
+        isContinue: true,
+        text: 'Looks good so far — spawning the reviewer now, back shortly.',
+        getReviewState: async () => {
+          queried = true
+          return { ok: true, selfBlocking: true, approve: true }
+        },
+      }),
+    )
+    expect(decision).toEqual({ block: false })
+    expect(queried).toBe(false)
+  })
+
+  it('still resolves-blocks an explicit thread resolve even mid-turn (continue:true)', async () => {
+    const decision = await evaluateRereviewGuard(
+      input({ thread: '999', wantsResolve: true, isContinue: true, text: 'one sec', getReviewState: stateOk(true) }),
     )
     expect(decision.block).toBe(true)
   })

--- a/src/channels/github-rereview-guard.ts
+++ b/src/channels/github-rereview-guard.ts
@@ -17,6 +17,10 @@ export type RereviewGuardInput = {
   thread: string | null
   text: string | undefined
   wantsResolve: boolean
+  // A mid-turn status reply (continue:true) is not the turn's receipt, so it
+  // suppresses the warn-tier escalation below — but never the explicit resolve,
+  // which is a real mutation. Mirrors the false-receipt guard's continue rule.
+  isContinue: boolean
   getReviewState: (req: { adapter: 'github'; workspace: string; chat: string }) => Promise<ReviewStateResult>
   workspace: string
 }
@@ -32,7 +36,7 @@ export async function evaluateRereviewGuard(input: RereviewGuardInput): Promise<
   // a close-out ack in it ("Verified — that closes it") strands the block just
   // as a thread reply would. Only the resolve ACTION needs a thread; the
   // text-claim path fires regardless (caught by isCloseoutAttempt below).
-  if (!isCloseoutAttempt(input.wantsResolve, input.thread, input.text)) return ALLOW
+  if (!isCloseoutAttempt(input)) return ALLOW
 
   const state = await input.getReviewState({ adapter: 'github', workspace: input.workspace, chat: input.chat })
 
@@ -47,11 +51,17 @@ export async function evaluateRereviewGuard(input: RereviewGuardInput): Promise<
 // Trigger when the model asks to resolve a thread (only meaningful with a
 // thread), OR when its reply reads as a close-out/verdict claim — the latter
 // strands the block whether or not it sits in a thread, so it fires for any PR
-// chat. Plain discussion replies (ignore/warn) do not fire.
-function isCloseoutAttempt(wantsResolve: boolean, thread: string | null, text: string | undefined): boolean {
-  if (wantsResolve && thread !== null) return true
-  const claim = classifyReviewClaim(text ?? '')
-  return claim === 'block-resolve' || claim === 'block-approve'
+// chat. Unlike the pure false-receipt classifier, this guard has the objective
+// review state available, so a warn-tier "looks good"/"lgtm" reply is escalated
+// to a closeout too: it only blocks when the bot actually holds a live
+// CHANGES_REQUESTED, so casual approval-shaped chatter on an unblocked PR still
+// posts. `continue:true` exempts warn-tier (mid-turn planning, not the receipt),
+// but never the explicit resolve action. Plain `ignore` text never fires.
+function isCloseoutAttempt(input: RereviewGuardInput): boolean {
+  if (input.wantsResolve && input.thread !== null) return true
+  const claim = classifyReviewClaim(input.text ?? '')
+  if (claim === 'block-resolve' || claim === 'block-approve') return true
+  return claim === 'warn' && !input.isContinue
 }
 
 function unverifiableReason(error: string): string {

--- a/src/channels/github-rereview-guard.ts
+++ b/src/channels/github-rereview-guard.ts
@@ -1,4 +1,4 @@
-import { classifyReviewClaim } from './github-review-claim'
+import { classifyReviewClaim, isPositiveWarnCloseout } from './github-review-claim'
 import type { ReviewStateResult } from './types'
 
 // The re-review stranding guard. A bot that resolves a review thread (or posts a
@@ -52,16 +52,19 @@ export async function evaluateRereviewGuard(input: RereviewGuardInput): Promise<
 // thread), OR when its reply reads as a close-out/verdict claim — the latter
 // strands the block whether or not it sits in a thread, so it fires for any PR
 // chat. Unlike the pure false-receipt classifier, this guard has the objective
-// review state available, so a warn-tier "looks good"/"lgtm" reply is escalated
-// to a closeout too: it only blocks when the bot actually holds a live
-// CHANGES_REQUESTED, so casual approval-shaped chatter on an unblocked PR still
-// posts. `continue:true` exempts warn-tier (mid-turn planning, not the receipt),
-// but never the explicit resolve action. Plain `ignore` text never fires.
+// review state available, so an approval-shaped warn reply ("looks good"/"lgtm")
+// is escalated to a closeout too: it only blocks when the bot actually holds a
+// live CHANGES_REQUESTED, so casual approval-shaped chatter on an unblocked PR
+// still posts. Only POSITIVE warn phrases escalate — negative ones ("needs
+// changes", "still needs work") re-assert a block rather than strand it, so they
+// stay non-firing. `continue:true` exempts the warn escalation (mid-turn
+// planning, not the receipt), but never the explicit resolve action. Plain
+// `ignore` text never fires.
 function isCloseoutAttempt(input: RereviewGuardInput): boolean {
   if (input.wantsResolve && input.thread !== null) return true
   const claim = classifyReviewClaim(input.text ?? '')
   if (claim === 'block-resolve' || claim === 'block-approve') return true
-  return claim === 'warn' && !input.isContinue
+  return !input.isContinue && isPositiveWarnCloseout(input.text ?? '')
 }
 
 function unverifiableReason(error: string): string {

--- a/src/channels/github-review-claim.test.ts
+++ b/src/channels/github-review-claim.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { classifyReviewClaim, type ReviewClaim } from './github-review-claim'
+import { classifyReviewClaim, isPositiveWarnCloseout, type ReviewClaim } from './github-review-claim'
 
 const cases: ReadonlyArray<[string, ReviewClaim]> = [
   ['Approved!', 'block-approve'],
@@ -59,4 +59,27 @@ describe('classifyReviewClaim', () => {
   test('negation demotes even when a block phrase is present', () => {
     expect(classifyReviewClaim("looks good but I haven't approved it")).toBe('ignore')
   })
+})
+
+describe('isPositiveWarnCloseout', () => {
+  test.each(['LGTM', 'looks good', 'looks fine', 'seems fine', 'should be good', 'looks resolved'])(
+    'true for approval/resolve-shaped warn: %p',
+    (text) => {
+      expect(isPositiveWarnCloseout(text)).toBe(true)
+    },
+  )
+
+  test.each(['this needs changes IMO', 'still needs work here'])(
+    'false for negative warn that re-asserts a block: %p',
+    (text) => {
+      expect(isPositiveWarnCloseout(text)).toBe(false)
+    },
+  )
+
+  test.each(['Approved!', 'Confirmed fixed.', 'Can you clarify the second point?', ''])(
+    'false for non-warn tiers: %p',
+    (text) => {
+      expect(isPositiveWarnCloseout(text)).toBe(false)
+    },
+  )
 })

--- a/src/channels/github-review-claim.ts
+++ b/src/channels/github-review-claim.ts
@@ -41,18 +41,25 @@ const BLOCK_RESOLVE: readonly RegExp[] = [
   /\b(thanks,?|fixed,?) (looks )?resolved\b/,
 ]
 
-// Casual phrasing that might be chatter, not a formal close-out: allow + nudge.
-const WARN: readonly RegExp[] = [
+// Approval/resolve-shaped warn phrases: casual chatter that, on a PR the bot is
+// still blocking, READS as a close-out and so can strand the block. Split out so
+// the re-review guard can escalate only these — never the negative warn phrases
+// below, which re-assert a block rather than strand it.
+const WARN_POSITIVE_CLOSEOUT: readonly RegExp[] = [
   /\blgtm\b/,
   /\blooks good\b/,
   /\blooks fine\b/,
   /\bseems fine\b/,
   /\bshould be (fine|good)\b/,
-  /\bneeds changes\b/,
-  /\bstill needs work\b/,
   /\blooks resolved\b/,
   /\bseems resolved\b/,
 ]
+
+// Negative warn phrases re-assert a block ("not done yet") instead of closing it
+// out, so they are NOT close-out attempts — the re-review guard must ignore them.
+const WARN_NEGATIVE: readonly RegExp[] = [/\bneeds changes\b/, /\bstill needs work\b/]
+
+const WARN: readonly RegExp[] = [...WARN_POSITIVE_CLOSEOUT, ...WARN_NEGATIVE]
 
 // Negation / future-intent / past-reference markers DEMOTE a positive match to
 // ignore. Blocking "I haven't approved" / "I'll approve" / "approved it earlier"
@@ -78,6 +85,15 @@ export function classifyReviewClaim(rawText: string): ReviewClaim {
   if (BLOCK_RESOLVE.some((re) => re.test(text))) return 'block-resolve'
   if (WARN.some((re) => re.test(text))) return 'warn'
   return 'ignore'
+}
+
+// True only for warn-tier replies whose phrasing reads as an approval/resolve
+// close-out (e.g. "looks good", "lgtm"), excluding negative warn phrases like
+// "needs changes" that re-assert a block. The re-review guard uses this to
+// escalate just the stranding-shaped warns, not the whole warn bucket.
+export function isPositiveWarnCloseout(rawText: string): boolean {
+  if (classifyReviewClaim(rawText) !== 'warn') return false
+  return WARN_POSITIVE_CLOSEOUT.some((re) => re.test(normalize(rawText)))
 }
 
 // Strips markdown/emoji noise so "**Approved!**" and "approved" classify alike,


### PR DESCRIPTION
## Background

The agent is supposed to land a **formal** GitHub review (`APPROVE` / `REQUEST_CHANGES`) on a re-review — the case where the author pushed fixes after the bot previously blocked the PR. Observed on a real PR ([#649](https://github.com/typeclaw/typeclaw/pull/649)): the bot held a live `CHANGES_REQUESTED`, the author commented *"Addressed in `<sha>`. Both remaining paths are fixed…"*, and the bot replied:

> Looks good — the remaining `<summary>` leak paths are fixed, and the fallback/general route now keeps skill-selection internal instead of narrating it. Tests are green, so this is a solid cleanup. ✨

That is a **plain PR comment**. It carries no review state, so GitHub's `reviewDecision` stays `CHANGES_REQUESTED` and the PR sits *"awaiting review"* forever — the exact stranding the re-review guard exists to prevent.

## Root cause

The re-review stranding guard (`src/channels/github-rereview-guard.ts`) already had the objective signal to catch this: it queries the bot's **live review state** (`router.getReviewState`) and blocks a close-out while the bot still holds its own `CHANGES_REQUESTED`. But `isCloseoutAttempt()` only fired on an explicit `resolve_review_thread` or a **block-tier** verdict claim from the pure text classifier.

`"Looks good"` / `"lgtm"` / `"seems fine"` classify as **warn-tier** in `github-review-claim.ts` — deliberately, because that classifier is text-only and has no state, so it errs toward warn over block to avoid false-positives. Result: a warn-tier `"Looks good"` reply short-circuited the guard to `ALLOW` **before** it ever queried review state, and the comment posted and stranded the block.

This is not a model issue — it is a gap in the deterministic harness. More prompt prose won't help: the session log shows the model read the GitHub skill in full and still pattern-matched `"they fixed it → looks good"`.

## Fix

Escalate **warn-tier** to a closeout attempt **in `evaluateRereviewGuard` only** (not in the pure text classifier, which stays conservative). The guard then proceeds to query review state and blocks **only** when the bot actually holds a live self-blocking `CHANGES_REQUESTED`:

- Casual `"looks good"` on an **unblocked** PR → still posts (state says not self-blocking).
- `"looks good"` while the bot **holds a block** → denied, with the same `APPROVE`/dismiss instruction as the block-tier path.
- The strictness lands on the **objective, queryable fact**, not on the fuzzy text tier — which is exactly the right place to be strict.

Two contracts preserved per design review:

- **`continue: true` exempts warn-tier.** A mid-turn status reply (*"looks good so far, spawning the reviewer now"*) is not the turn's receipt, so it is not escalated — mirrors the false-receipt guard's `continue` rule. An explicit `resolve_review_thread` is **never** exempt (it's a real mutation).
- **Plain `ignore`-tier discussion still skips the state query** — no new false-positives, common case stays cheap.

`isContinue` is threaded through `channel_reply` (from `keepTurnAlive`) and `channel_send` (always `false`; it has no continue mode).

## Tests

- `github-rereview-guard.test.ts`: warn-tier × {selfBlocking, not-blocking, unverifiable, continue:true} + explicit-resolve-still-blocks-mid-turn. Includes a named regression test for the PR #649 incident.
- `channel-reply.test.ts`: end-to-end — `"Looks good …"` on a `pr:N` is **denied and posts nothing** when `getReviewState` returns a live block; **posts** when it doesn't.

## Checks

`typecheck`, `lint` (0 errors), `format:check` all clean. Full suite green except the pre-existing `resolveSelfPackageJsonPath > points at this package manifest` worktree-path artifact (asserts the checkout dir is named `typeclaw`; passes in a normal checkout and in CI).