### PR TITLE
channels: post the provider-error notice once per turn, not per retry

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4962,6 +4962,58 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(sent.some((t) => /team plan/.test(t))).toBe(false)
   })
 
+  test('posts the LLM soft-error notice ONCE per turn even when the SDK retries (PR #652)', async () => {
+    // given: a single turn whose underlying SDK retries internally — each retry
+    // emits its own message_end with stopReason=error. The channel must surface
+    // one notice for the turn, not one per retry (PR #652 saw 5 duplicates).
+    const dir = await tempDir()
+    const sent: string[] = []
+    let promptCount = 0
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async (_text) => {
+          promptCount++
+          // Three retry errors within one prompt() call (one turn).
+          for (let i = 0; i < 3; i++) {
+            fake.emit({
+              type: 'message_end',
+              message: { role: 'assistant', stopReason: 'error', errorMessage: `transient upstream blip ${i}` },
+            })
+          }
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_retry_dedup',
+          dispose: async () => {},
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // when: one user turn that retries 3 times
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    const noticesAfterFirstTurn = sent.filter((t) => /upstream LLM provider failed/i.test(t)).length
+
+    // when: a second, separate user turn that also fails
+    await router.route(inbound({ text: 'still there?' }))
+    await router.__testing!.flushDebounce(KEY)
+    const totalNotices = sent.filter((t) => /upstream LLM provider failed/i.test(t)).length
+
+    // then: one notice per turn, not one per retry
+    expect(promptCount).toBe(2)
+    expect(noticesAfterFirstTurn).toBe(1)
+    expect(totalNotices).toBe(2)
+  })
+
   test('upgrades hard prompt-throws to logger.error (not warn) so `typeclaw logs` operators see them at the right level', async () => {
     // given
     const dir = await tempDir()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1422,8 +1422,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         unsubTypingActivity: null,
         unsubTodoOutcome: null,
       }
+      // Tracks the `turnSeq` a provider-error notice was last POSTED for, so the
+      // channel surfaces at most one notice per turn. The upstream SDK retries
+      // internally, and each retry emits its own `message_end` with
+      // `stopReason: 'error'` — without this gate a single failing turn posts N
+      // identical "⚠️ upstream provider failed" notices (one per retry). Logs
+      // still record every attempt; only the user-facing notice is deduped.
+      let lastProviderErrorNoticeTurn: number | undefined
       live.unsubProviderErrors = subscribeProviderErrors(created.session, (err) => {
         logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
+        // Suppress duplicate notices for the SAME turn (retry storm). Set the
+        // marker BEFORE the async send so a synchronous burst of retry events
+        // can't each slip past the check and enqueue their own notice.
+        if (lastProviderErrorNoticeTurn === live.turnSeq) return
+        lastProviderErrorNoticeTurn = live.turnSeq
         // A provider soft-error (rate/usage limit, billing, malformed response)
         // ends the turn with no assistant text, so the human otherwise sees
         // silence. Surface the REDACTED `safeMessage` (never the raw provider


### PR DESCRIPTION
## Background

When an upstream LLM call fails, the channel router surfaces a redacted notice so the human doesn't see silence:

> ⚠️ The upstream LLM provider failed. Operators can check `typeclaw logs` for details.

The underlying SDK (pi-coding-agent) **retries failing calls internally**. Each retry emits its own `message_end` with `stopReason: 'error'`. The router's `subscribeProviderErrors` listener fires once per event and posts a notice each time — so a **single** failing turn floods the channel with **N identical notices, one per retry**.

Observed on a real PR thread (#652): the bot posted the same notice **5 times** in a row for one stuck turn.

## Root cause

`src/channels/router.ts` registers the provider-error listener **once per live session**, but the callback posts unconditionally on every `message_end(stopReason: 'error')`. There was no per-turn dedup, so internal SDK retries — each a fresh error event — each posted their own comment.

`model-fallback.ts` (cron/subagents) is unaffected: it captures only the **first** soft error per attempt and unsubscribes after each attempt, so it never sees the duplicate stream. The bug is specific to the long-lived channel session listener.

## Fix

Gate the user-facing notice on `live.turnSeq` (the monotonic per-session turn counter already incremented just before each `session.prompt()`):

- Post **at most one** notice per turn, regardless of how many times the SDK retries within it.
- Set the dedup marker **before** the async `send()` so a synchronous burst of retry events can't each slip past the check.
- A later, **separate** turn that also fails still posts again (the counter advanced).
- **Operator logs are untouched** — `logger.error` still records every attempt; only the channel-facing notice is deduped.

The strictness lands on the objective turn boundary, not on guessing whether an error is a "duplicate" by content.

## Tests

`router.test.ts`: a named regression test for this incident — one turn that retries 3× posts exactly **one** notice; a second, separate failing turn posts a **second**. Verified red without the guard (3 notices), green with it.

## Checks

`typecheck`, `lint` (0 errors), `format:check` all clean. Full suite green except the pre-existing `resolveSelfPackageJsonPath > points at this package manifest` worktree-path artifact (asserts the checkout dir is named `typeclaw`; passes in a normal checkout and in CI).