### PR TITLE
channels: block LGTM closeouts when formal review is still required

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -960,4 +960,33 @@ describe('channel_reply re-review stranding guard', () => {
     expect(result.details.ok).toBe(true)
     expect(calls).toHaveLength(1)
   })
+
+  test('blocks a warn-tier LGTM PR comment while GitHub still requires formal review (PR #653)', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(
+        async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        },
+        {
+          getReviewState: async () => ({
+            ok: true,
+            selfBlocking: false,
+            approve: true,
+            reviewDecision: 'REVIEW_REQUIRED',
+          }),
+        },
+      ),
+      origin: { adapter: 'github', workspace: 'acme/widgets', chat: 'pr:653', thread: null },
+    })
+
+    const result = await runTool(tool, {
+      text: 'LGTM — the dedupe is scoped to the per-session turn boundary exactly as described.',
+    })
+
+    expect(result.details.ok).toBe(false)
+    expect(calls).toHaveLength(0)
+    expect((result.content[0] as { text: string }).text).toContain('formal GitHub review')
+  })
 })

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -356,4 +356,34 @@ describe('channel_send re-review stranding guard', () => {
     expect(sent).toBe(1)
     expect(queried).toBe(false)
   })
+
+  test('blocks a no-thread LGTM comment while GitHub still requires formal review', async () => {
+    let sent = 0
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onSend: () => {
+          sent += 1
+          return { ok: true }
+        },
+        getReviewState: async () => ({
+          ok: true,
+          selfBlocking: false,
+          approve: true,
+          reviewDecision: 'REVIEW_REQUIRED',
+        }),
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:653',
+      text: 'LGTM — the dedupe is scoped to the per-session turn boundary exactly as described.',
+    })
+
+    expect((result.details as { ok: boolean }).ok).toBe(false)
+    expect(sent).toBe(0)
+    expect((result.content[0] as { text: string }).text).toContain('formal GitHub review')
+  })
 })

--- a/src/channels/adapters/github/review-state.test.ts
+++ b/src/channels/adapters/github/review-state.test.ts
@@ -6,11 +6,20 @@ type ReviewFixture = { id: number; login: string; state: string; isBot?: boolean
 
 type Page = { reviews: ReviewFixture[]; hasNextPage: boolean }
 
-function fakeRest(options: { pages: Page[]; seen?: { urls: string[] } }) {
+function fakeRest(options: { pages: Page[]; seen?: { urls: string[] }; reviewDecision?: string | null }) {
   let pageIndex = 0
   return Object.assign(
     async (url: string | URL | Request): Promise<Response> => {
-      if (options.seen) options.seen.urls.push(String(url))
+      const href = String(url)
+      if (options.seen) options.seen.urls.push(href)
+      if (href.endsWith('/graphql')) {
+        return new Response(
+          JSON.stringify({
+            data: { repository: { pullRequest: { reviewDecision: options.reviewDecision ?? null } } },
+          }),
+          { status: 200 },
+        )
+      }
       const page = options.pages[Math.min(pageIndex, options.pages.length - 1)]
       pageIndex += 1
       const headers: Record<string, string> = {}
@@ -43,6 +52,17 @@ const req = (overrides: Partial<{ workspace: string; chat: string }> = {}) => ({
 })
 
 describe('github review-state resolver', () => {
+  it('carries GitHub reviewDecision when a formal review is still required', async () => {
+    const resolve = resolverFor(
+      fakeRest({
+        pages: [{ reviews: [], hasNextPage: false }],
+        reviewDecision: 'REVIEW_REQUIRED',
+      }),
+    )
+    const result = await resolve(req())
+    expect(result).toEqual({ ok: true, selfBlocking: false, approve: true, reviewDecision: 'REVIEW_REQUIRED' })
+  })
+
   it('reports selfBlocking when the bot’s latest formal review is CHANGES_REQUESTED', async () => {
     const resolve = resolverFor(
       fakeRest({
@@ -155,7 +175,8 @@ describe('github review-state resolver', () => {
     )
     const result = await resolve(req())
     expect(result).toEqual({ ok: true, selfBlocking: false, approve: true })
-    expect(seen.urls.length).toBe(2)
+    expect(seen.urls.some((url) => url.includes('/pulls/644/reviews'))).toBe(true)
+    expect(seen.urls).toContain('https://api.github.com/next')
   })
 
   it('carries the approval policy through to the result', async () => {

--- a/src/channels/adapters/github/review-state.ts
+++ b/src/channels/adapters/github/review-state.ts
@@ -31,11 +31,20 @@ export function createGithubReviewStateResolver(deps: {
     }
 
     const token = await deps.token({ repoSlug: `${target.owner}/${target.repo}` })
-    const reviews = await fetchSelfReviews(fetchImpl, token, target, selfLogin)
+    const [reviews, reviewDecision] = await Promise.all([
+      fetchSelfReviews(fetchImpl, token, target, selfLogin),
+      fetchReviewDecision(fetchImpl, token, target),
+    ])
     if (!reviews.ok) return { ok: false, error: reviews.error, code: reviews.code }
+    if (!reviewDecision.ok) return { ok: false, error: reviewDecision.error, code: reviewDecision.code }
 
     const lastDecisive = reviews.states.filter(isDecisive).at(-1) ?? null
-    return { ok: true, selfBlocking: lastDecisive === 'CHANGES_REQUESTED', approve }
+    return {
+      ok: true,
+      selfBlocking: lastDecisive === 'CHANGES_REQUESTED',
+      approve,
+      ...(reviewDecision.reviewDecision !== null ? { reviewDecision: reviewDecision.reviewDecision } : {}),
+    }
   }
 }
 
@@ -53,6 +62,12 @@ function parseTarget(workspace: string, chat: string): Target | null {
 
 type SelfReviewsResult =
   | { ok: true; states: string[] }
+  | { ok: false; error: string; code: 'not-found' | 'permission-denied' | 'transient' }
+
+type ReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED'
+
+type ReviewDecisionResult =
+  | { ok: true; reviewDecision: ReviewDecision | null }
   | { ok: false; error: string; code: 'not-found' | 'permission-denied' | 'transient' }
 
 async function fetchSelfReviews(
@@ -92,6 +107,47 @@ async function fetchSelfReviews(
     url = nextLink(response.headers.get('link'))
   }
   return { ok: true, states }
+}
+
+async function fetchReviewDecision(
+  fetchImpl: typeof fetch,
+  token: string,
+  target: Target,
+): Promise<ReviewDecisionResult> {
+  let response: Response
+  try {
+    response = await fetchImpl(`${GITHUB_API_BASE}/graphql`, {
+      method: 'POST',
+      headers: githubJsonHeaders(token),
+      body: JSON.stringify({
+        query:
+          'query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewDecision}}}',
+        variables: { owner: target.owner, repo: target.repo, number: target.prNumber },
+      }),
+    })
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), code: 'transient' }
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    return {
+      ok: false,
+      error: `GitHub reviewDecision ${response.status}${text !== '' ? `: ${text}` : ''}`,
+      code: classifyStatus(response.status),
+    }
+  }
+  const raw = (await response.json().catch(() => null)) as ReviewDecisionResponse | null
+  if (raw === null) return { ok: false, error: 'GitHub reviewDecision returned non-JSON', code: 'transient' }
+  if (Array.isArray(raw.errors) && raw.errors.length > 0) {
+    return {
+      ok: false,
+      error: `GitHub reviewDecision errors: ${raw.errors.map(describeGraphqlError).join('; ')}`,
+      code: 'transient',
+    }
+  }
+  const value = raw.data?.repository?.pullRequest?.reviewDecision ?? null
+  if (value === null || isReviewDecision(value)) return { ok: true, reviewDecision: value }
+  return { ok: false, error: `GitHub reviewDecision returned unknown value: ${String(value)}`, code: 'transient' }
 }
 
 // A formal CHANGES_REQUESTED is sticky until a later APPROVED/DISMISSED; only
@@ -135,3 +191,16 @@ function classifyStatus(status: number): 'not-found' | 'permission-denied' | 'tr
 }
 
 type ReviewRow = { id?: number; state?: unknown; user?: { login?: string; type?: string } }
+
+type ReviewDecisionResponse = {
+  data?: { repository?: { pullRequest?: { reviewDecision?: unknown } | null } | null }
+  errors?: Array<{ message?: unknown }>
+}
+
+function isReviewDecision(value: unknown): value is ReviewDecision {
+  return value === 'APPROVED' || value === 'CHANGES_REQUESTED' || value === 'REVIEW_REQUIRED'
+}
+
+function describeGraphqlError(error: { message?: unknown }): string {
+  return typeof error.message === 'string' ? error.message : JSON.stringify(error)
+}

--- a/src/channels/github-rereview-guard.test.ts
+++ b/src/channels/github-rereview-guard.test.ts
@@ -17,8 +17,12 @@ function input(overrides: Partial<RereviewGuardInput> = {}): RereviewGuardInput 
 }
 
 const stateOk =
-  (selfBlocking: boolean, approve = true): RereviewGuardInput['getReviewState'] =>
-  async () => ({ ok: true, selfBlocking, approve })
+  (
+    selfBlocking: boolean,
+    approve = true,
+    reviewDecision?: 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED',
+  ): RereviewGuardInput['getReviewState'] =>
+  async () => ({ ok: true, selfBlocking, approve, ...(reviewDecision !== undefined ? { reviewDecision } : {}) })
 
 describe('re-review stranding guard', () => {
   it('blocks a resolve while the bot holds a live CHANGES_REQUESTED (PR #644 scenario)', async () => {
@@ -123,6 +127,36 @@ describe('re-review stranding guard', () => {
       input({ thread: null, wantsResolve: false, text: 'lgtm, nice work', getReviewState: stateOk(false) }),
     )
     expect(decision).toEqual({ block: false })
+  })
+
+  it('blocks a warn-tier LGTM when GitHub still requires a formal review (PR #653)', async () => {
+    const decision = await evaluateRereviewGuard(
+      input({
+        thread: null,
+        wantsResolve: false,
+        text: 'LGTM — the dedupe is scoped to the per-session turn boundary exactly as described.',
+        getReviewState: stateOk(false, true, 'REVIEW_REQUIRED'),
+      }),
+    )
+    expect(decision.block).toBe(true)
+    if (decision.block) expect(decision.reason).toContain('formal GitHub review')
+  })
+
+  it('does not query review state for casual discussion even when reviews may be required', async () => {
+    let queried = false
+    const decision = await evaluateRereviewGuard(
+      input({
+        thread: null,
+        wantsResolve: false,
+        text: 'Thanks for the context — that makes sense.',
+        getReviewState: async () => {
+          queried = true
+          return { ok: true, selfBlocking: false, approve: true, reviewDecision: 'REVIEW_REQUIRED' }
+        },
+      }),
+    )
+    expect(decision).toEqual({ block: false })
+    expect(queried).toBe(false)
   })
 
   it('fails closed on a warn-tier reply when review state cannot be verified', async () => {

--- a/src/channels/github-rereview-guard.ts
+++ b/src/channels/github-rereview-guard.ts
@@ -43,7 +43,12 @@ export async function evaluateRereviewGuard(input: RereviewGuardInput): Promise<
   // Fail closed: an unverifiable review state is treated as a live block, so the
   // bot never strands a re-review on a transient API failure.
   if (!state.ok) return { block: true, reason: unverifiableReason(state.error) }
-  if (!state.selfBlocking) return ALLOW
+  if (!state.selfBlocking) {
+    if (state.reviewDecision === 'REVIEW_REQUIRED' && isPositiveWarnCloseout(input.text ?? '')) {
+      return { block: true, reason: INITIAL_REVIEW_REQUIRED }
+    }
+    return ALLOW
+  }
 
   return { block: true, reason: state.approve ? STICKY_BLOCK_APPROVE_ENABLED : STICKY_BLOCK_APPROVE_DISABLED }
 }
@@ -87,3 +92,9 @@ const STICKY_BLOCK_APPROVE_DISABLED =
   'dismiss your prior review via ' +
   '`gh api -X PUT /repos/<owner>/<repo>/pulls/<N>/reviews/<review_id>/dismissals -f message="..." -f event=DISMISS` ' +
   'if the blockers are fixed (or submit REQUEST_CHANGES if not), THEN resolve the thread / reply.'
+
+const INITIAL_REVIEW_REQUIRED =
+  'This PR still requires a formal GitHub review. A flat `LGTM` / `looks good` PR comment does not create ' +
+  'review state, so it leaves the PR awaiting review. Submit the reviewer verdict via ' +
+  '`gh api -X POST /repos/<owner>/<repo>/pulls/<N>/reviews` with event `APPROVE` when approval is enabled, ' +
+  'or event `COMMENT` when approval is disabled, then narrate only if needed.'

--- a/src/channels/github-review-claim.test.ts
+++ b/src/channels/github-review-claim.test.ts
@@ -38,6 +38,14 @@ const cases: ReadonlyArray<[string, ReviewClaim]> = [
   ['Going to review this shortly.', 'ignore'],
   ['I approved it earlier, in my last review.', 'ignore'],
   ['Yes, I requested changes yesterday.', 'ignore'],
+  ['not LGTM yet — tests are still red', 'ignore'],
+  ['This is not looks good territory yet.', 'ignore'],
+  ['Please do not just say `LGTM`; submit the review.', 'ignore'],
+  ['The comment "LGTM" is not enough here.', 'ignore'],
+  ['Was this approved already?', 'ignore'],
+  ['Who approved this?', 'ignore'],
+  ['The pre-approved template text is unrelated.', 'ignore'],
+  ['I confirmed the issue is not resolved yet.', 'ignore'],
   ['Can you clarify the second point?', 'ignore'],
   ['', 'ignore'],
 ]
@@ -58,6 +66,11 @@ describe('classifyReviewClaim', () => {
 
   test('negation demotes even when a block phrase is present', () => {
     expect(classifyReviewClaim("looks good but I haven't approved it")).toBe('ignore')
+  })
+
+  test('separate non-negated sentence can still carry the receipt', () => {
+    expect(classifyReviewClaim("I didn't approve the previous revision. This one is approved.")).toBe('block-approve')
+    expect(classifyReviewClaim("I haven't approved yet. LGTM on the current diff.")).toBe('warn')
   })
 })
 

--- a/src/channels/github-review-claim.ts
+++ b/src/channels/github-review-claim.ts
@@ -68,15 +68,40 @@ const DEMOTE_TO_IGNORE: readonly RegExp[] = [
   /\b(haven'?t|have not|did ?n'?t|did not|not yet|never)\b[^.!?]*\b(approv|request|resolv|block)/,
   /\b(can'?t|cannot|won'?t|will not|wouldn'?t)\b[^.!?]*\b(approv|request|resolv|block)/,
   /\bnot (approved|resolved|blocked|requesting)\b/,
+  /\b(not|no longer|hardly|barely)\b[^.!?]*\b(lgtm|looks good|looks fine|seems fine|should be (fine|good)|looks resolved|seems resolved)\b/,
   /\b(i'?ll|i will|going to|gonna|about to|planning to)\b[^.!?]*\b(approv|review|request|resolv)/,
   /\b(approved|resolved|requested changes)\b[^.!?]*\b(earlier|already|yesterday|before|last (review|time)|previously)\b/,
+  /\b(pre|self|co|re|un|non|ai|admin|user|machine|auto) approved\b/,
 ]
 
-export function classifyReviewClaim(rawText: string): ReviewClaim {
-  const text = normalize(rawText)
-  if (text === '') return 'ignore'
+const QUESTION_CONTEXT =
+  /(?:^|\b)(who|what|when|where|why|how|was|were|is|are|did|do|does|has|have|can|could|would|should)\b[^.!?]*\?/
 
+export function classifyReviewClaim(rawText: string): ReviewClaim {
+  const segments = claimSegments(rawText)
+  if (segments.length === 0) return 'ignore'
+
+  const claims = segments.map(classifySegment)
+
+  if (claims.includes('block-approve')) return 'block-approve'
+  if (claims.includes('block-request-changes')) return 'block-request-changes'
+  if (claims.includes('block-resolve')) return 'block-resolve'
+  if (claims.includes('warn')) return 'warn'
+  return 'ignore'
+}
+
+// True only for warn-tier replies whose phrasing reads as an approval/resolve
+// close-out (e.g. "looks good", "lgtm"), excluding negative warn phrases like
+// "needs changes" that re-assert a block. The re-review guard uses this to
+// escalate just the stranding-shaped warns, not the whole warn bucket.
+export function isPositiveWarnCloseout(rawText: string): boolean {
+  if (classifyReviewClaim(rawText) !== 'warn') return false
+  return claimSegments(rawText).some((segment) => WARN_POSITIVE_CLOSEOUT.some((re) => re.test(segment)))
+}
+
+function classifySegment(text: string): ReviewClaim {
   if (DEMOTE_TO_IGNORE.some((re) => re.test(text))) return 'ignore'
+  if (QUESTION_CONTEXT.test(text)) return 'ignore'
 
   // Block-tier wins over warn-tier: an unambiguous "approved" in a casual message
   // is still a formal claim.
@@ -87,13 +112,19 @@ export function classifyReviewClaim(rawText: string): ReviewClaim {
   return 'ignore'
 }
 
-// True only for warn-tier replies whose phrasing reads as an approval/resolve
-// close-out (e.g. "looks good", "lgtm"), excluding negative warn phrases like
-// "needs changes" that re-assert a block. The re-review guard uses this to
-// escalate just the stranding-shaped warns, not the whole warn bucket.
-export function isPositiveWarnCloseout(rawText: string): boolean {
-  if (classifyReviewClaim(rawText) !== 'warn') return false
-  return WARN_POSITIVE_CLOSEOUT.some((re) => re.test(normalize(rawText)))
+function claimSegments(text: string): string[] {
+  return redactQuotedAndCode(text)
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map(normalize)
+    .filter((segment) => segment !== '')
+}
+
+function redactQuotedAndCode(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`\n]*`/g, ' ')
+    .replace(/"[^"\n]*"|“[^”\n]*”|‘[^’\n]*’/g, ' ')
+    .replace(/^\s*>.*$/gm, ' ')
 }
 
 // Strips markdown/emoji noise so "**Approved!**" and "approved" classify alike,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -395,18 +395,23 @@ export type ReviewStateRequest = {
   chat: string
 }
 
-// `selfBlocking` is the answer the guard acts on: true means the bot's latest
-// effective formal review is its own CHANGES_REQUESTED (COMMENTED reviews are
-// ignored — they never clear the sticky block, GitHub's own rule). `approve`
-// mirrors `channels.github.review.approve` so the guard's denial text can tell
-// the model whether to land a fresh APPROVE or to DISMISS its prior review.
+// `selfBlocking` is the answer the guard acts on for re-reviews: true means the
+// bot's latest effective formal review is its own CHANGES_REQUESTED (COMMENTED
+// reviews are ignored — they never clear the sticky block, GitHub's own rule).
+// `reviewDecision` is GitHub's aggregate PR review status when GraphQL can
+// provide it; REVIEW_REQUIRED means an approval-shaped flat comment would still
+// leave the PR awaiting a formal review. `approve` mirrors
+// `channels.github.review.approve` so the guard's denial text can tell the model
+// whether to land a fresh APPROVE or to DISMISS its prior review.
 //
 // On `ok: false` the caller MUST fail closed: an unverifiable review state is
 // treated like a live block, so the bot never claims close-out when the runtime
 // could not confirm the platform-side verdict.
 export type ReviewStateResult =
-  | { ok: true; selfBlocking: boolean; approve: boolean }
+  | { ok: true; selfBlocking: boolean; approve: boolean; reviewDecision?: GithubReviewDecision }
   | { ok: false; error: string; code?: 'unsupported' | 'not-found' | 'permission-denied' | 'transient' }
+
+export type GithubReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED'
 
 // Registered per-adapter on the ChannelRouter, last-write-wins like the
 // review-thread resolver. Adapters that never register one make `getReviewState`

--- a/src/update/index.test.ts
+++ b/src/update/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { commandForInstall, formatCommand, planSelfUpdate, resolveSelfPackageJsonPath } from './index'
@@ -359,6 +360,9 @@ describe('formatCommand', () => {
 
 describe('resolveSelfPackageJsonPath', () => {
   test('points at this package manifest', () => {
-    expect(resolveSelfPackageJsonPath()).toEndWith(join('typeclaw', 'package.json'))
+    const packageJsonPath = resolveSelfPackageJsonPath()
+
+    expect(packageJsonPath).toEndWith('package.json')
+    expect(JSON.parse(readFileSync(packageJsonPath, 'utf8'))).toMatchObject({ name: 'typeclaw' })
   })
 })


### PR DESCRIPTION
## Background

A flat PR comment like `LGTM` or `looks good` does not create GitHub review state. When GitHub still reports `reviewDecision: REVIEW_REQUIRED`, that kind of comment can leave the PR stuck awaiting a formal review even though the bot sounded approving.

This is distinct from the sticky `CHANGES_REQUESTED` case: #644/#652 protect against closing out while the bot still owns an outstanding changes-request review. This PR also covers the initial-review case where there is no self block yet, but GitHub still requires a formal review.

## Summary

- Adds GitHub GraphQL `reviewDecision` to the review-state resolver, fetched in parallel with the existing REST self-review scan.
- Blocks positive warn-tier closeouts (`LGTM`, `looks good`, etc.) when `reviewDecision === 'REVIEW_REQUIRED'`.
- Preserves the existing selfBlocking / sticky-`CHANGES_REQUESTED` guard behavior.
- Hardens the review-claim classifier so quoted/code/example text, question-form approvals, negated `LGTM` / `looks good`, and hyphenated metadata like `pre-approved` do not trip the receipt path.
- Makes the update package-manifest test worktree-safe.

## Review notes

- The guard still skips review-state queries for ordinary discussion and negative warn phrases like `still needs work`.
- `continue:true` status text remains exempt from positive warn escalation, while explicit `resolve_review_thread` still blocks if review state requires it.
- `reviewDecision` is optional in `ReviewStateResult`, so non-GitHub or non-GraphQL paths remain compatible.

## Verification

- `bun run lint` passed with existing warnings only.
- `bun run format:check` passed.
- `bun typecheck` passed.
- `bun run test` passed: 7322 pass, 1 skip, 0 fail.
- LSP diagnostics clean on modified classifier files.
