### PR TITLE
tui: brand banner, spinners, status bar, and init welcome

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -36,7 +36,16 @@ import { API_KEY_DASHBOARD_URL, validateApiKey, type KeyValidationResult } from 
 
 import { buildOAuthCallbacks } from './oauth-callbacks'
 import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
-import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup } from './ui'
+import {
+  c,
+  cornflower,
+  done,
+  errorLine,
+  printDiscordInviteHint,
+  printHatchedFlourish,
+  printInitWelcome,
+  printSlackAppManifestSetup,
+} from './ui'
 
 // ESC and Ctrl+C both produce clack's cancel symbol (the keypress layer
 // aliases both to the same "cancel" action — there's no way to tell them
@@ -119,6 +128,7 @@ export const init = defineCommand({
       }
     }
 
+    printInitWelcome()
     intro('Initializing TypeClaw...')
     log.info('Press ESC at any prompt to go back. Press ESC twice in a row to abort.')
 
@@ -272,7 +282,8 @@ export const init = defineCommand({
           'Claim ownership before chatting',
         )
       }
-      done({ title: c.green('Hatched. Your agent is ready.'), hints })
+      printHatchedFlourish()
+      done({ title: `${cornflower('✓')} ${c.bold('Hatched.')} Your agent is ready.`, hints })
     }
   },
 })

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -1,21 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import { SLACK_SLASH_COMMAND_NAMES } from '@/channels/adapters/slack-bot'
+import { WORDMARK_LINES } from '@/shared/wordmark'
 
 import {
   c,
+  cornflower,
   done,
   errorLine,
   link,
   prepareStdinForClack,
   printDiscordInviteHint,
   printSlackAppManifestSetup,
+  renderHatchedFlourish,
+  renderInitWelcome,
   renderStartSuccess,
   SLACK_APP_MANIFEST,
   spinner,
   successLine,
   type StartLikeResult,
 } from './ui'
+
+const CORNFLOWER_ESCAPE = '\x1b[38;2;91;127;212m'
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`)
 
 const ENV_KEYS = ['NO_COLOR', 'FORCE_COLOR'] as const
 
@@ -86,6 +93,67 @@ describe('link', () => {
   test('falls back to "text (url)" when NO_COLOR is set', () => {
     const out = withNoColor(() => link('Docs', 'https://example.com'))
     expect(out).toBe('Docs (https://example.com)')
+  })
+})
+
+describe('cornflower', () => {
+  test('wraps text in 24-bit cornflower SGR under forced color', () => {
+    const out = withForcedColor(() => cornflower('●'))
+    expect(out).toBe(`${CORNFLOWER_ESCAPE}●\x1b[0m`)
+  })
+
+  test('returns the raw string under NO_COLOR', () => {
+    expect(withNoColor(() => cornflower('●'))).toBe('●')
+  })
+})
+
+describe('renderInitWelcome', () => {
+  test('emits the full 6-row art with cornflower color when colors are on', () => {
+    const out = renderInitWelcome({ isTty: true, columns: 120, colorsEnabled: true })
+    expect(out).toContain(CORNFLOWER_ESCAPE)
+    expect(out).toContain(WORDMARK_LINES[0]!)
+    expect(out).toContain('the TypeScript-native agent runtime')
+  })
+
+  test('emits plain art with ZERO escapes when colors are off (NO_COLOR)', () => {
+    const out = renderInitWelcome({ isTty: true, columns: 120, colorsEnabled: false })
+    expect(out).toContain(WORDMARK_LINES[0]!)
+    expect(ANSI_PATTERN.test(out)).toBe(false)
+  })
+
+  test('falls back to the compact wordmark on a narrow terminal', () => {
+    const out = renderInitWelcome({ isTty: true, columns: 40, colorsEnabled: true })
+    expect(out).toContain('typeclaw')
+    expect(out).not.toContain(WORDMARK_LINES[0]!)
+  })
+
+  test('narrow + NO_COLOR yields a plain single-line wordmark with no escapes', () => {
+    const out = renderInitWelcome({ isTty: true, columns: 40, colorsEnabled: false })
+    expect(out.split('\n')[0]).toBe('typeclaw')
+    expect(ANSI_PATTERN.test(out)).toBe(false)
+  })
+
+  test('emits nothing when stdout is not a TTY (piped/CI)', () => {
+    expect(renderInitWelcome({ isTty: false, columns: 120, colorsEnabled: true })).toBe('')
+  })
+})
+
+describe('renderHatchedFlourish', () => {
+  test('emits a single brand-colored line when colors are on', () => {
+    const out = renderHatchedFlourish({ isTty: true, colorsEnabled: true })
+    expect(out).toContain('hatched!')
+    expect(out).toContain(CORNFLOWER_ESCAPE)
+    expect(out).not.toContain('\n')
+  })
+
+  test('emits a plain line with no escapes under NO_COLOR', () => {
+    const out = renderHatchedFlourish({ isTty: true, colorsEnabled: false })
+    expect(out).toBe('✦ hatched!')
+    expect(ANSI_PATTERN.test(out)).toBe(false)
+  })
+
+  test('emits nothing when stdout is not a TTY', () => {
+    expect(renderHatchedFlourish({ isTty: false, colorsEnabled: true })).toBe('')
   })
 })
 

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -4,6 +4,7 @@ import { cancel, intro, isCancel, log, note, outro, spinner as clackSpinner } fr
 
 import { buildDiscordInviteUrl, deriveAppIdFromBotToken } from '@/channels/adapters/discord-bot-invite'
 import { type AutoUpgradeOutcome, describeAutoUpgrade } from '@/init/auto-upgrade'
+import { COMPACT_WORDMARK, WORDMARK_LINES, WORDMARK_WIDTH } from '@/shared/wordmark'
 
 export { cancel, intro, isCancel, log, note, outro }
 
@@ -59,6 +60,69 @@ export const c = {
 export function link(text: string, url: string): string {
   if (!colorsEnabled()) return `${text} (${url})`
   return `\u001b]8;;${url}\u0007${text}\u001b]8;;\u0007`
+}
+
+// Brand truecolor sampled from the typeey mascot, matching src/tui/theme.ts.
+// `c`/styleText only carry the 16 named colors, so the cornflower/amber accents
+// are emitted as raw 24-bit SGR — gated on colorsEnabled() so NO_COLOR and
+// piped output never see an escape.
+const CORNFLOWER_FG = '\x1b[38;2;91;127;212m'
+const AMBER_FG = '\x1b[38;2;231;143;55m'
+const RESET = '\x1b[0m'
+const BOLD = '\x1b[1m'
+const DIM = '\x1b[2m'
+
+const INIT_TAGLINE = 'the TypeScript-native agent runtime'
+
+export function cornflower(s: string): string {
+  if (!colorsEnabled()) return s
+  return `${CORNFLOWER_FG}${s}${RESET}`
+}
+
+export type InitWelcomeOptions = {
+  isTty: boolean
+  columns: number
+  colorsEnabled: boolean
+}
+
+export function renderInitWelcome(opts: InitWelcomeOptions): string {
+  // Non-TTY (piped/CI): emit nothing so captured/redirected output stays clean.
+  if (!opts.isTty) return ''
+  const tagline = opts.colorsEnabled ? `${DIM}${INIT_TAGLINE}${RESET}` : INIT_TAGLINE
+  if (opts.columns < WORDMARK_WIDTH + 2) {
+    const mark = opts.colorsEnabled ? `${BOLD}${CORNFLOWER_FG}${COMPACT_WORDMARK}${RESET}` : COMPACT_WORDMARK
+    return `${mark}\n${tagline}`
+  }
+  const art = opts.colorsEnabled
+    ? WORDMARK_LINES.map((line) => `${CORNFLOWER_FG}${line}${RESET}`).join('\n')
+    : WORDMARK_LINES.join('\n')
+  return `${art}\n${tagline}`
+}
+
+export function printInitWelcome(output: NodeJS.WritableStream = process.stdout): void {
+  const banner = renderInitWelcome({
+    isTty: Boolean(process.stdout.isTTY),
+    columns: process.stdout.columns ?? 80,
+    colorsEnabled: colorsEnabled(),
+  })
+  if (banner === '') return
+  // Pad above (clear the shell prompt) and below (separate from clack's intro).
+  output.write(`\n${banner}\n\n`)
+}
+
+export function renderHatchedFlourish(opts: { isTty: boolean; colorsEnabled: boolean }): string {
+  if (!opts.isTty) return ''
+  if (!opts.colorsEnabled) return '✦ hatched!'
+  return `${AMBER_FG}✦${RESET} ${CORNFLOWER_FG}hatched!${RESET}`
+}
+
+export function printHatchedFlourish(output: NodeJS.WritableStream = process.stdout): void {
+  const line = renderHatchedFlourish({
+    isTty: Boolean(process.stdout.isTTY),
+    colorsEnabled: colorsEnabled(),
+  })
+  if (line === '') return
+  output.write(`${line}\n`)
 }
 
 export type Spinner = {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -184,6 +184,10 @@ type SessionState = {
   // not re-target this session's lifecycle hooks.
   runtimeSnapshot: PluginRuntimeState | null
   unsubTurnOutcome: Unsubscribe | null
+  // Latest turn's usage, captured from `message_end` by forwardSessionEvents and
+  // read at the `done` send site (which lives outside that subscriber). Reset at
+  // each turn start so a turn with no usage event sends a plain `done`.
+  lastUsage: { input: number; output: number; totalTokens: number; cost: number } | null
   dispose: () => Promise<void>
 }
 
@@ -520,6 +524,7 @@ export function createServer({
               activeClaimCode: null,
               runtimeSnapshot: runtimeSnapshot ?? null,
               unsubTurnOutcome: null,
+              lastUsage: null,
               dispose,
             }
             sessionStates.set(ws, state)
@@ -533,7 +538,7 @@ export function createServer({
             }
 
             liveSessionRegistry?.register({ sessionId: sessionFileId, session })
-            forwardSessionEvents(ws, session, logger, sessionFileId)
+            forwardSessionEvents(ws, state, logger, sessionFileId)
 
             if (stream) {
               state.unsubPrompts = stream.subscribe({ target: { kind: 'session', sessionId: sessionFileId } }, (msg) =>
@@ -759,9 +764,10 @@ export function createServer({
                 origin: state.origin,
               })
             }
+            state.lastUsage = null
             try {
               await state.session.prompt(`${renderTurnTimeAnchor()}\n\n${msg.text}`)
-              send(ws, { type: 'done' })
+              send(ws, doneMessage(state))
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err)
               logger.error(`[server] ${state.sessionFileId}: prompt failed: ${message}`)
@@ -859,10 +865,10 @@ function isWebSocketUpgrade(req: Request): boolean {
   return req.headers.get('upgrade')?.toLowerCase() === 'websocket'
 }
 
-function forwardSessionEvents(ws: Ws, session: AgentSession, logger: ServerLogger, sessionFileId: string): void {
+function forwardSessionEvents(ws: Ws, state: SessionState, logger: ServerLogger, sessionFileId: string): void {
   const toolStartedAt = new Map<string, number>()
 
-  session.subscribe((event) => {
+  state.session.subscribe((event) => {
     switch (event.type) {
       case 'message_update':
         if (event.assistantMessageEvent.type === 'text_delta') {
@@ -877,6 +883,7 @@ function forwardSessionEvents(ws: Ws, session: AgentSession, logger: ServerLogge
         // because no text deltas were ever emitted, which looks like a freeze.
         // The server's existing try/catch around `session.prompt()` only
         // catches throws, so it never sees these.
+        state.lastUsage = readDoneUsage(event.message)
         forwardAssistantError(ws, event.message, logger, sessionFileId)
         break
       case 'tool_execution_start':
@@ -1048,9 +1055,10 @@ async function drain(
       }
 
       await fireTurnStart(item.text)
+      state.lastUsage = null
       try {
         await state.session.prompt(`${renderTurnTimeAnchor()}\n\n${item.text}`)
-        send(ws, { type: 'done' })
+        send(ws, doneMessage(state))
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         logger.error(`[server] ${state.sessionFileId}: prompt failed: ${message}`)
@@ -1443,6 +1451,17 @@ function buildMessageEndPayload(sessionId: string, message: unknown): InspectFra
     ...(usage !== null ? { usage } : {}),
   }
   return payload
+}
+
+function doneMessage(state: SessionState): ServerMessage {
+  return state.lastUsage === null ? { type: 'done' } : { type: 'done', usage: state.lastUsage }
+}
+
+function readDoneUsage(message: unknown): { input: number; output: number; totalTokens: number; cost: number } | null {
+  if (typeof message !== 'object' || message === null) return null
+  const usage = readMessageUsage((message as Record<string, unknown>).usage)
+  if (usage === null) return null
+  return { input: usage.input, output: usage.output, totalTokens: usage.totalTokens, cost: usage.cost }
 }
 
 function readMessageUsage(

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -223,7 +223,7 @@ export type ServerMessage =
       durationMs: number
       ts?: number
     }
-  | { type: 'done'; ts?: number }
+  | { type: 'done'; ts?: number; usage?: { input: number; output: number; totalTokens: number; cost: number } }
   | { type: 'error'; message: string; ts?: number }
   | { type: 'reload_result'; results: ReloadResultPayload[] }
   | { type: 'restart_result'; status: 'accepted' | 'failed'; message?: string; error?: string }

--- a/src/shared/wordmark.test.ts
+++ b/src/shared/wordmark.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test'
+
+import { COMPACT_WORDMARK, WORDMARK_LINES, WORDMARK_WIDTH } from './wordmark'
+
+describe('wordmark', () => {
+  test('is the 6-row ANSI Shadow art', () => {
+    expect(WORDMARK_LINES).toHaveLength(6)
+    expect(WORDMARK_LINES[0]).toContain('█')
+  })
+
+  test('carries no ANSI escape sequences (color-agnostic source)', () => {
+    for (const line of WORDMARK_LINES) {
+      expect(line).not.toContain('\x1b')
+    }
+  })
+
+  test('WORDMARK_WIDTH equals the widest art line', () => {
+    expect(WORDMARK_WIDTH).toBe(Math.max(...WORDMARK_LINES.map((l) => l.length)))
+  })
+
+  test('preserves the trailing space on the last row (alignment-significant)', () => {
+    expect(WORDMARK_LINES[WORDMARK_LINES.length - 1]!.endsWith(' ')).toBe(true)
+  })
+
+  test('compact fallback is a single plain line', () => {
+    expect(COMPACT_WORDMARK).toBe('typeclaw')
+    expect(COMPACT_WORDMARK).not.toContain('\n')
+  })
+})

--- a/src/shared/wordmark.ts
+++ b/src/shared/wordmark.ts
@@ -1,0 +1,19 @@
+// Single source of truth for the "typeclaw" wordmark so the TUI banner and the
+// init CLI render the same art instead of drifting apart. This module is
+// color-agnostic: each consumer applies its own coloring layer (the TUI emits
+// raw truecolor; init gates color behind NO_COLOR/TTY), so the art here carries
+// zero escape sequences.
+
+// ANSI Shadow "typeclaw". Trailing whitespace is significant for alignment.
+export const WORDMARK_LINES: readonly string[] = [
+  '████████╗██╗   ██╗██████╗ ███████╗ ██████╗██╗      █████╗ ██╗    ██╗',
+  '╚══██╔══╝╚██╗ ██╔╝██╔══██╗██╔════╝██╔════╝██║     ██╔══██╗██║    ██║',
+  '   ██║    ╚████╔╝ ██████╔╝█████╗  ██║     ██║     ███████║██║ █╗ ██║',
+  '   ██║     ╚██╔╝  ██╔═══╝ ██╔══╝  ██║     ██║     ██╔══██║██║███╗██║',
+  '   ██║      ██║   ██║     ███████╗╚██████╗███████╗██║  ██║╚███╔███╔╝',
+  '   ╚═╝      ╚═╝   ╚═╝     ╚══════╝ ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ',
+]
+
+export const WORDMARK_WIDTH: number = Math.max(...WORDMARK_LINES.map((line) => line.length))
+
+export const COMPACT_WORDMARK = 'typeclaw'

--- a/src/tui/banner.ts
+++ b/src/tui/banner.ts
@@ -1,0 +1,19 @@
+import { WORDMARK_LINES } from '@/shared/wordmark'
+
+import { colors } from './theme'
+
+export type BannerInfo = {
+  sessionId: string
+  serverVersion?: string
+  displayUrl: string
+}
+
+export function formatBanner({ sessionId, serverVersion, displayUrl }: BannerInfo): string {
+  const logo = WORDMARK_LINES.map((line) => colors.accent(line)).join('\n')
+  const version = serverVersion === undefined ? '' : colors.dim(` v${serverVersion}`)
+  const card = [
+    `${colors.accent('●')} ${colors.bold('session')}${version}  ${colors.dim(sessionId)}`,
+    `${colors.dim('  ')}${colors.dim(displayUrl)}`,
+  ].join('\n')
+  return `${logo}\n\n${card}`
+}

--- a/src/tui/format.test.ts
+++ b/src/tui/format.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 
-import { formatTimestamp, formatToolEnd, formatToolStart, withTimestamp } from './format'
+import {
+  formatAssistantHeader,
+  formatCost,
+  formatTimestamp,
+  formatTokenCount,
+  formatToolEnd,
+  formatToolStart,
+  formatUsageSummary,
+  withTimestamp,
+} from './format'
 
 const stripAnsi = (s: string) =>
   // oxlint-disable-next-line no-control-regex -- intentionally strips ANSI sequences from rendered output
@@ -248,5 +257,41 @@ describe('formatTimestamp', () => {
   test('withTimestamp prefixes the body with the time', () => {
     const ts = new Date(2026, 0, 2, 23, 59, 59).getTime()
     expect(visible(withTimestamp(ts, 'hello'))).toBe('23:59:59 hello')
+  })
+})
+
+describe('formatAssistantHeader', () => {
+  test('renders a typeclaw box header carrying the timestamp', () => {
+    const ts = new Date(2026, 0, 2, 9, 5, 7).getTime()
+    const out = visible(formatAssistantHeader(ts))
+    expect(out).toContain('╭─ typeclaw · 09:05:07')
+  })
+
+  test('falls back to the placeholder clock for undefined ts', () => {
+    expect(visible(formatAssistantHeader(undefined))).toContain('--:--:--')
+  })
+})
+
+describe('token and cost formatting', () => {
+  test('sub-1k token counts render verbatim', () => {
+    expect(formatTokenCount(999)).toBe('999')
+  })
+
+  test('thousands render with a single decimal, trailing .0 stripped', () => {
+    expect(formatTokenCount(1500)).toBe('1.5k')
+    expect(formatTokenCount(12300)).toBe('12.3k')
+    expect(formatTokenCount(12000)).toBe('12k')
+  })
+
+  test('hundreds of thousands round to whole k', () => {
+    expect(formatTokenCount(125000)).toBe('125k')
+  })
+
+  test('cost renders to four decimals', () => {
+    expect(formatCost(0.0042)).toBe('$0.0042')
+  })
+
+  test('usage summary combines tokens and cost', () => {
+    expect(formatUsageSummary({ totalTokens: 12300, cost: 0.0042 })).toBe('⚡ 12.3k tok · $0.0042')
   })
 })

--- a/src/tui/format.ts
+++ b/src/tui/format.ts
@@ -37,6 +37,40 @@ export function withTimestamp(ts: number | undefined, body: string): string {
   return `${formatTimestamp(ts)} ${body}`
 }
 
+// Open-box top rule for an assistant turn. Only a header (no closing rule) so
+// the look survives streaming Markdown whose end is unknown at render time.
+export function formatAssistantHeader(ts: number | undefined): string {
+  const clock = plainTimestamp(ts)
+  const label = `╭─ typeclaw · ${clock} `
+  return colors.accent(`${label}${'─'.repeat(ASSISTANT_HEADER_RULE_WIDTH)}`)
+}
+
+const ASSISTANT_HEADER_RULE_WIDTH = 8
+
+function plainTimestamp(ts: number | undefined): string {
+  if (ts === undefined || ts === 0) return '--:--:--'
+  const d = new Date(ts)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return `${hh}:${mm}:${ss}`
+}
+
+export function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) return `${tokens}`
+  const k = tokens / 1000
+  const value = k < 100 ? k.toFixed(1) : String(Math.round(k))
+  return `${value.endsWith('.0') ? value.slice(0, -2) : value}k`
+}
+
+export function formatCost(cost: number): string {
+  return `$${cost.toFixed(4)}`
+}
+
+export function formatUsageSummary(usage: { totalTokens: number; cost: number }): string {
+  return `⚡ ${formatTokenCount(usage.totalTokens)} tok · ${formatCost(usage.cost)}`
+}
+
 function stripHiddenBlocks(text: string): string {
   return text.replace(/<hatching>[\s\S]*?<\/hatching>\s*/g, '').trimStart()
 }

--- a/src/tui/index.test.ts
+++ b/src/tui/index.test.ts
@@ -192,6 +192,54 @@ describe('createTui', () => {
     expect(terminal.visible()).not.toContain('secret')
   })
 
+  test('renders the startup banner with the session id on connect', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient()
+    client.emit({ type: 'connected', sessionId: 'sid-banner', serverVersion: '1.2.3' })
+
+    // when
+    const tui = createTui({ url: 'ws://ignored', createClient: async () => client, createTerminal: () => terminal })
+    const runPromise = tui.run()
+    await flush()
+
+    // then
+    const visible = terminal.visible()
+    expect(visible).toContain('session')
+    expect(visible).toContain('sid-banner')
+    expect(visible).toContain('v1.2.3')
+
+    client.triggerClose()
+    await runPromise
+  })
+
+  test('updates the bottom status bar with token usage when a turn completes', async () => {
+    // given
+    const terminal = new FakeTerminal()
+    const client = fakeClient({ autoDoneOnPrompt: false })
+    client.emit({ type: 'connected', sessionId: 'sid-usage' })
+    const tui = createTui({
+      url: 'ws://ignored',
+      initialPrompt: 'go',
+      createClient: async () => client,
+      createTerminal: () => terminal,
+    })
+    const runPromise = tui.run()
+    await flush()
+
+    // when
+    client.emit({ type: 'done', usage: { input: 1000, output: 11300, totalTokens: 12300, cost: 0.0042 } })
+    await flush()
+
+    // then
+    const visible = terminal.visible()
+    expect(visible).toContain('12.3k tok')
+    expect(visible).toContain('$0.0042')
+
+    client.triggerClose()
+    await runPromise
+  })
+
   test('streams assistant text into the chat history (user input is not overwritten)', async () => {
     // given: an in-flight stream that we drive chunk by chunk while the user types
     const terminal = new FakeTerminal()
@@ -516,7 +564,7 @@ describe('createTui', () => {
     expect(client.sent).toEqual([{ type: 'reload' }])
     expect(client.sent.some((msg) => msg.type === 'prompt')).toBe(false)
     const visible = terminal.visible()
-    expect(visible).toContain('reloading...')
+    expect(visible).toContain('reloading…')
     expect(visible).toContain('● [cron] loaded 1 job')
     expect(visible).toContain('● [channels] bad config')
 
@@ -591,7 +639,7 @@ describe('createTui', () => {
     expect(client.sent).toEqual([{ type: 'restart' }])
     expect(client.sent.some((msg) => msg.type === 'prompt')).toBe(false)
     const visible = terminal.visible()
-    expect(visible).toContain('restart requested... reconnecting when the new container is up')
+    expect(visible).toContain('restart requested… reconnecting when the new container is up')
     expect(visible).toContain('restart scheduled; reconnecting when the new container is up')
     expect(visible).toContain('restart failed: denied')
 

--- a/src/tui/index.test.ts
+++ b/src/tui/index.test.ts
@@ -53,6 +53,15 @@ class FakeTerminal implements Terminal {
   visible(): string {
     return stripAnsi(this.joined())
   }
+
+  // pi-tui repaints the whole viewport on each render and each repaint is one
+  // write, so counting frames that contain a substring distinguishes a widget
+  // that was removed (appears in a bounded number of frames) from one that
+  // lingers (appears in every later repaint too). `visible()` can't see this —
+  // it's the flattened byte history where removed widgets still show once.
+  frameCount(substring: string): number {
+    return this.written.filter((frame) => stripAnsi(frame).includes(substring)).length
+  }
 }
 
 type FakeClient = Client & {
@@ -642,6 +651,11 @@ describe('createTui', () => {
     expect(visible).toContain('restart requested… reconnecting when the new container is up')
     expect(visible).toContain('restart scheduled; reconnecting when the new container is up')
     expect(visible).toContain('restart failed: denied')
+    // Regression guard: the loader is torn down on the first restart_result, so
+    // it appears in exactly one repaint (the pre-result spin). If it leaked into
+    // later frames the restart status would read as still-in-flight after the
+    // server already replied.
+    expect(terminal.frameCount('restart requested…')).toBe(1)
 
     client.triggerClose()
     await runPromise

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -1,13 +1,25 @@
-import { Editor, Key, Markdown, matchesKey, ProcessTerminal, type Terminal, Text, TUI } from '@mariozechner/pi-tui'
+import {
+  Editor,
+  Key,
+  Loader,
+  Markdown,
+  matchesKey,
+  ProcessTerminal,
+  type Terminal,
+  Text,
+  TUI,
+} from '@mariozechner/pi-tui'
 
 import { parseCommand } from '@/commands'
 
+import { formatBanner } from './banner'
 import { createClient as createClientDefault, type Client } from './client'
 import {
+  formatAssistantHeader,
   formatQueuePanel,
-  formatTimestamp,
   formatToolEnd,
   formatToolStart,
+  formatUsageSummary,
   formatUserPromptHistory,
   withTimestamp,
 } from './format'
@@ -118,29 +130,58 @@ export function createTui({
     if (handshake === null) return { reason: 'connectFailed' }
 
     const { sessionId, serverVersion } = handshake
-    status.setText(colors.dim(`session: ${sessionId}`))
+    // The banner card already carries session id, version, and url, so it
+    // supersedes the old one-line session status in place (status is child[0],
+    // pinned above all scrollback).
+    status.setText(formatBanner({ sessionId, displayUrl, ...(serverVersion !== undefined ? { serverVersion } : {}) }))
     tui.requestRender()
 
     const editor = new Editor(tui, editorTheme, { paddingX: 0 })
+    const statusBar = new Text('', 0, 0)
     let replyInFlight = false
     let onReplyDone: (() => void) | null = null
     let currentAssistant: Markdown | null = null
     let currentAssistantText = ''
     let queuePanel: Text | null = null
+    let thinkingLoader: Loader | null = null
+    let reloadLoader: Loader | null = null
+    let restartLoader: Loader | null = null
+    let usageLabel: string | null = null
+    let connectionLabel = 'connected'
+
+    const shortSessionId = sessionId.length > 14 ? `${sessionId.slice(0, 14)}…` : sessionId
+    const refreshStatusBar = () => {
+      const parts = [
+        colors.dim(connectionLabel),
+        colors.dim(`session ${shortSessionId}`),
+        serverVersion !== undefined ? colors.dim(`v${serverVersion}`) : null,
+        usageLabel !== null ? colors.accent(usageLabel) : null,
+      ].filter((part): part is string => part !== null)
+      statusBar.setText(parts.join(colors.dim('  ·  ')))
+    }
+    refreshStatusBar()
 
     // Pi-tui's Container.addChild appends to the end of the children array.
-    // The editor must remain the LAST child at all times so it stays pinned
-    // to the bottom of the viewport, with chat history scrolling above it.
-    // The queue panel, when present, sits immediately ABOVE the editor (so
-    // the layout is [...history, queuePanel?, editor]). Any new history entry
-    // is inserted by stripping the queue panel + editor from the tail,
-    // appending the entry, then re-appending them in order.
-    const appendHistory = (component: Text | Markdown) => {
-      if (queuePanel) tui.removeChild(queuePanel)
-      tui.removeChild(editor)
-      tui.addChild(component)
+    // The bottom tail is pinned as [...history, queuePanel?, editor, statusBar]:
+    // the editor stays above the persistent status bar, and the queue panel,
+    // when present, sits just above the editor. Any new history entry is
+    // inserted by stripping that tail, appending the entry, then re-appending
+    // the tail in order so nothing ever renders below the status bar.
+    const reattachTail = () => {
       if (queuePanel) tui.addChild(queuePanel)
       tui.addChild(editor)
+      tui.addChild(statusBar)
+    }
+    const detachTail = () => {
+      if (queuePanel) tui.removeChild(queuePanel)
+      tui.removeChild(editor)
+      tui.removeChild(statusBar)
+    }
+
+    const appendHistory = (component: Text | Markdown) => {
+      detachTail()
+      tui.addChild(component)
+      reattachTail()
     }
 
     const updateQueuePanel = (pending: ReadonlyArray<{ id: string; text: string; ts: number }>) => {
@@ -156,12 +197,34 @@ export function createTui({
       if (queuePanel) {
         queuePanel.setText(text)
       } else {
-        queuePanel = new Text(text, 0, 0)
         tui.removeChild(editor)
+        tui.removeChild(statusBar)
+        queuePanel = new Text(text, 0, 0)
         tui.addChild(queuePanel)
         tui.addChild(editor)
+        tui.addChild(statusBar)
       }
       tui.requestRender()
+    }
+
+    const showThinking = () => {
+      if (thinkingLoader !== null) return
+      const loader = new Loader(tui, colors.accent, colors.dim, 'thinking…')
+      thinkingLoader = loader
+      appendHistory(loader)
+      loader.start()
+      tui.requestRender()
+    }
+    const hideThinking = () => {
+      if (thinkingLoader === null) return
+      thinkingLoader.stop()
+      tui.removeChild(thinkingLoader)
+      thinkingLoader = null
+    }
+    const stopAllLoaders = () => {
+      thinkingLoader?.stop()
+      reloadLoader?.stop()
+      restartLoader?.stop()
     }
 
     // Reset between text segments so a new Markdown block is created after
@@ -174,19 +237,20 @@ export function createTui({
     }
 
     const finishAssistantTurn = () => {
+      hideThinking()
       sealAssistantBlock()
       replyInFlight = false
       onReplyDone?.()
       onReplyDone = null
     }
 
-    // A Markdown block can't carry an ANSI timestamp prefix (it'd be parsed as
-    // markdown), so the assistant turn's timestamp is a separate dim Text line
-    // emitted just above the block when it's first created — stamped with the
-    // first delta's server `ts`.
+    // A Markdown block can't carry an ANSI header prefix (it'd be parsed as
+    // markdown), so the assistant turn's boxed header (label + timestamp) is a
+    // separate Text line emitted just above the block when it's first created —
+    // stamped with the first delta's server `ts`.
     const ensureAssistantBlock = (ts: number | undefined): Markdown => {
       if (currentAssistant) return currentAssistant
-      appendHistory(new Text(formatTimestamp(ts), 0, 0))
+      appendHistory(new Text(formatAssistantHeader(ts), 0, 0))
       const md = new Markdown('', 0, 0, markdownTheme)
       currentAssistant = md
       currentAssistantText = ''
@@ -198,10 +262,12 @@ export function createTui({
       switch (msg.type) {
         case 'prompt_started': {
           appendHistory(new Text(withTimestamp(msg.ts, formatUserPromptHistory(msg.text)), 0, 0))
+          if (replyInFlight) showThinking()
           tui.requestRender()
           break
         }
         case 'text_delta': {
+          hideThinking()
           const block = ensureAssistantBlock(msg.ts)
           currentAssistantText += msg.delta
           block.setText(currentAssistantText)
@@ -209,6 +275,7 @@ export function createTui({
           break
         }
         case 'tool_start': {
+          hideThinking()
           sealAssistantBlock()
           appendHistory(new Text(withTimestamp(msg.ts, formatToolStart(msg.name, msg.args)), 0, 0))
           tui.requestRender()
@@ -223,6 +290,10 @@ export function createTui({
           break
         }
         case 'done': {
+          if (msg.usage !== undefined) {
+            usageLabel = formatUsageSummary(msg.usage)
+            refreshStatusBar()
+          }
           finishAssistantTurn()
           tui.requestRender()
           break
@@ -238,6 +309,11 @@ export function createTui({
           break
         }
         case 'reload_result': {
+          if (reloadLoader !== null) {
+            reloadLoader.stop()
+            tui.removeChild(reloadLoader)
+            reloadLoader = null
+          }
           for (const result of msg.results) {
             const text = result.ok
               ? `${colors.green('●')} ${colors.bold(`[${result.scope}]`)} ${result.summary}`
@@ -271,6 +347,9 @@ export function createTui({
     }
 
     client.onClose(() => {
+      stopAllLoaders()
+      connectionLabel = 'disconnected'
+      refreshStatusBar()
       appendHistory(new Text(colors.dim('disconnected'), 0, 0))
       tui.requestRender()
       // A user-initiated detach/exit already closed the WS deliberately and
@@ -293,14 +372,27 @@ export function createTui({
       }
       if (command === 'reload') {
         client.send({ type: 'reload' })
-        appendHistory(new Text(colors.dim('reloading...'), 0, 0))
+        if (reloadLoader === null) {
+          const loader = new Loader(tui, colors.accent, colors.dim, 'reloading…')
+          reloadLoader = loader
+          appendHistory(loader)
+          loader.start()
+        }
         tui.requestRender()
         return true
       }
       client.send({ type: 'restart' })
-      appendHistory(
-        new Text(colors.yellow(colors.dim('restart requested... reconnecting when the new container is up')), 0, 0),
-      )
+      if (restartLoader === null) {
+        const loader = new Loader(
+          tui,
+          colors.yellow,
+          colors.dim,
+          'restart requested… reconnecting when the new container is up',
+        )
+        restartLoader = loader
+        appendHistory(loader)
+        loader.start()
+      }
       tui.requestRender()
       return true
     }
@@ -322,6 +414,7 @@ export function createTui({
     // settles 'lostConnection'. settle() is idempotent, so the first call wins —
     // settling the deliberate outcome first keeps the later onClose a no-op.
     const teardown = (): void => {
+      stopAllLoaders()
       tui.stop()
       client.close()
     }
@@ -365,6 +458,7 @@ export function createTui({
       void send(text)
     }
     tui.addChild(editor)
+    tui.addChild(statusBar)
     tui.setFocus(editor)
     tui.requestRender()
 

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -324,6 +324,11 @@ export function createTui({
           break
         }
         case 'restart_result': {
+          if (restartLoader !== null) {
+            restartLoader.stop()
+            tui.removeChild(restartLoader)
+            restartLoader = null
+          }
           const text =
             msg.status === 'accepted'
               ? colors.green(colors.dim(msg.message ?? 'restart scheduled; reconnecting when the new container is up'))

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -1,6 +1,7 @@
 import type { EditorTheme, MarkdownTheme } from '@mariozechner/pi-tui'
 
 const wrap = (code: string) => (text: string) => `\x1b[${code}m${text}\x1b[0m`
+const wrapRgb = (r: number, g: number, b: number) => (text: string) => `\x1b[38;2;${r};${g};${b}m${text}\x1b[0m`
 
 const dim = wrap('2')
 const bold = wrap('1')
@@ -9,8 +10,32 @@ const green = wrap('32')
 const yellow = wrap('33')
 const cyan = wrap('36')
 const gray = wrap('90')
+const brightGreen = wrap('92')
+const brightCyan = wrap('96')
+const brightMagenta = wrap('95')
 
-export const colors = { dim, bold, red, green, yellow, cyan, gray }
+// Sampled from the typeey mascot. True navy (#182A5B) is too dark to read on
+// dark terminals, so `accent` is a lifted cornflower of the same hue; amber is
+// the mascot's beak/feet highlight.
+const cornflower = wrapRgb(0x5b, 0x7f, 0xd4)
+const amber = wrapRgb(0xe7, 0x8f, 0x37)
+const accent = cornflower
+
+export const colors = {
+  dim,
+  bold,
+  red,
+  green,
+  yellow,
+  cyan,
+  gray,
+  brightGreen,
+  brightCyan,
+  brightMagenta,
+  cornflower,
+  amber,
+  accent,
+}
 
 export const editorTheme: EditorTheme = {
   borderColor: dim,


### PR DESCRIPTION
## Background

The TUI had no visual identity — a plain text stream with no version card, no
"thinking" signal between submit and first token, and no cost visibility after
a turn. The `typeclaw init` wizard likewise started with a bare
`Initializing TypeClaw...` line and ended with a plain success message. This
PR introduces a cohesive brand layer across both surfaces, built on the typeey
mascot palette (cornflower `#5B7FD4` / amber `#E78F37`).

A note on the accent choice: the mascot's true navy (`#182A5B`) is too dark to
read against dark terminals, so the accent lifts to a cornflower of the same
hue that passes minimum contrast on common default backgrounds.

## Summary

### TUI

- **Startup banner**: ANSI Shadow "typeclaw" wordmark + a session/version/URL
  card rendered immediately on `connected`.
- **Thinking loader**: animated "thinking…" indicator between prompt submit and
  first token, using `pi-tui`'s `Loader` — no hand-rolled `setInterval`.
  Reload and restart states get the same treatment.
- **Boxed assistant turn headers**: `╭─ typeclaw · HH:MM:SS ───────` before
  each assistant reply so turn boundaries are visually distinct.
- **Bottom status bar**: persistent `connection · session · version · ⚡ tok · $cost` line that updates live as turns complete.

### server (`src/server/index.ts`, `src/shared/protocol.ts`)

The `done` `ServerMessage` now carries an optional `usage` field
`{ input, output, totalTokens, cost }`. The server buffers usage from the
existing `message_end` event (via `readMessageUsage`) into
`SessionState.lastUsage` and attaches it to the outgoing `done` frame.
The change is backward compatible (the field is optional; old TUI versions
receive a plain `done`).

### init (`src/cli/ui.ts`, `src/cli/init.ts`)

- **Welcome banner**: cornflower wordmark + tagline printed before the clack
  wizard, fully NO_COLOR-aware (zero ANSI when set), width-aware (compact
  `typeclaw` fallback below ~70 cols), and suppressed on non-TTY/piped output.
- **Hatched outro**: `✦ hatched!` in amber/cornflower replaces the bare success
  line — same NO_COLOR and TTY guards.

### Shared wordmark (`src/shared/wordmark.ts`)

`WORDMARK_LINES` / `WORDMARK_WIDTH` / `COMPACT_WORDMARK` live once here and
are imported by both the TUI banner renderer and the init CLI. Neither
consumer duplicates the art; each applies its own color layer.

## What this does NOT do

- Does not change wire protocol semantics: `done.usage` is optional and
  ignored by clients that don't read it.
- Does not add a truecolor dependency: the `CORNFLOWER_FG` / `AMBER_FG` SGR
  strings are inlined as constants, gated on `colorsEnabled()`.
- Does not render the banner in piped/CI contexts (`isTTY` guard on every
  print path).

## Review notes

- Load-bearing: `state.lastUsage = null` is reset at each turn start (before
  `session.prompt()`), so a turn that produces no `message_end` sends a bare
  `done` rather than stale usage from the previous turn.
- `readDoneUsage` delegates to the existing `readMessageUsage` rather than
  re-implementing the usage-extraction logic — keeps the two in sync.
- The `forwardSessionEvents` signature changed from `(ws, session, …)` to
  `(ws, state, …)` to give the subscriber write access to `state.lastUsage`.
  All callers updated.
- `formatAssistantHeader` renders an open box top-rule only — no closing rule
  — because the assistant reply length is unknown at the start of a streaming
  turn.

## Testing

Full suite: 7363 pass / 0 fail / 1 pre-existing skip. `typecheck` clean.
`lint` 0 errors. `format:check` clean.

New test coverage:

- `src/shared/wordmark.test.ts`: shape (6 rows), no escapes in source art,
  `WORDMARK_WIDTH` derivation, trailing-space preservation, compact fallback.
- `src/cli/ui.test.ts`: `cornflower` colors under forced color / NO_COLOR;
  `renderInitWelcome` — full art vs compact (narrow), color vs no-color,
  non-TTY suppression; `renderHatchedFlourish` — branded vs plain vs non-TTY.
- `src/tui/format.test.ts`: `formatAssistantHeader` box label + timestamp
  fallback; `formatTokenCount` / `formatCost` / `formatUsageSummary` boundary
  values.
- `src/tui/index.test.ts`: banner renders on `connected` with session/version;
  `done.usage` updates the bottom status bar with token count and cost.