### PR TITLE
feat: block dumped REQUEST_CHANGES reviews that skip inline comments

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.test.ts
@@ -38,22 +38,75 @@ describe('detectReviewDump — blocks the dumped review', () => {
     })
     expect(result?.block).toBe(true)
   })
+
+  test('partial inline still blocks on stranded body anchors', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({
+        event: 'REQUEST_CHANGES',
+        body: DUMPED_BODY,
+        comments: [
+          { path: 'apps/admin/src/lib/i18n/languages.ts', line: 12, body: 'x' },
+          { path: 'apps/admin/src/lib/i18n/translations/en.ts', line: 807, body: 'y' },
+          { path: 'apps/admin/src/components/translation-panel.tsx', line: 107, body: 'z' },
+        ],
+      }),
+    })
+    expect(result?.block).toBe(true)
+  })
+
+  test('span comment does not cover an anchor outside its range', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({
+        event: 'REQUEST_CHANGES',
+        body: 'a `x.ts:10`\nb `y.ts:20`\nc `z.ts:30`',
+        comments: [{ path: 'x.ts', start_line: 10, line: 12, body: 'covers x only' }],
+      }),
+    })
+    expect(result?.block).toBe(true)
+  })
 })
 
 describe('detectReviewDump — allows legitimate reviews', () => {
-  test('REQUEST_CHANGES with findings properly in comments[] is allowed', () => {
+  test('every body anchor covered inline (range, list, full-path) is allowed', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({
+        event: 'REQUEST_CHANGES',
+        body: 'a `languages.ts:12-20`\nb `en.ts:807,809`\nc `panel.tsx:107-111`',
+        comments: [
+          { path: 'apps/admin/src/lib/i18n/languages.ts', line: 15, body: 'in range' },
+          { path: 'apps/admin/src/lib/i18n/translations/en.ts', line: 809, body: 'in list' },
+          { path: 'src/components/panel.tsx', line: 107, body: 'at line' },
+        ],
+      }),
+    })
+    expect(result).toBeNull()
+  })
+
+  test('summary body with no anchors is allowed regardless of comments', () => {
     const result = detectReviewDump({
       command: REVIEWS_CMD,
       inputFileContents: payload({
         event: 'REQUEST_CHANGES',
         body: 'Two blockers, see inline.',
+        comments: [{ path: 'a.ts', line: 12, body: 'x' }],
+      }),
+    })
+    expect(result).toBeNull()
+  })
+
+  test('span comment covers an anchor inside its start_line..line range', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({
+        event: 'REQUEST_CHANGES',
+        body: 'a `x.ts:10`\nb `x.ts:20`\nc `x.ts:30`',
         comments: [
-          { path: 'a.ts', line: 12, body: 'x' },
-          { path: 'b.ts', line: 8, body: 'y' },
-          { path: 'c.ts', line: 3, body: 'z' },
-          { path: 'd.ts', line: 1, body: 'w' },
-          { path: 'e.ts', line: 4, body: 'v' },
-          { path: 'f.ts', line: 9, body: 'u' },
+          { path: 'x.ts', start_line: 8, line: 12, body: 'covers 10' },
+          { path: 'x.ts', line: 20, body: 'covers 20' },
+          { path: 'x.ts', line: 30, body: 'covers 30' },
         ],
       }),
     })

--- a/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test'
+
+import { detectReviewDump } from './gh-review-inline-detect'
+
+const REVIEWS_CMD = 'gh api -X POST /repos/acme/widgets/pulls/7/reviews --input /tmp/r.json'
+
+const DUMPED_BODY = [
+  '## 리뷰 요약',
+  '두 가지 concern이 있어 REQUEST CHANGES 드립니다.',
+  '### 🔴 Concern',
+  '1. 언어 표시 명칭 하드코딩 `apps/admin/src/lib/i18n/languages.ts:12-20`',
+  '2. 영어 sentence case 위반 `apps/admin/src/lib/i18n/translations/en.ts:807,809`',
+  '### 🟡 Nit',
+  '1. aria-expanded 누락 (`translation-panel.tsx:107-111`)',
+  '2. 마크업 중복 (`translation-panel.tsx:81-86,97-102`)',
+  '3. emoji deprecated (`languages.ts:4`)',
+  '4. 캐러셀 aria-hidden 누락 (`translation-panel.tsx:283-309`)',
+].join('\n')
+
+function payload(value: Record<string, unknown>): string {
+  return JSON.stringify(value)
+}
+
+describe('detectReviewDump — blocks the dumped review', () => {
+  test('REQUEST_CHANGES with many path:line anchors and no inline comments blocks', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({ event: 'REQUEST_CHANGES', body: DUMPED_BODY, comments: [] }),
+    })
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('comments[]')
+  })
+
+  test('missing comments key is treated as zero inline comments', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({ event: 'REQUEST_CHANGES', body: DUMPED_BODY }),
+    })
+    expect(result?.block).toBe(true)
+  })
+})
+
+describe('detectReviewDump — allows legitimate reviews', () => {
+  test('REQUEST_CHANGES with findings properly in comments[] is allowed', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({
+        event: 'REQUEST_CHANGES',
+        body: 'Two blockers, see inline.',
+        comments: [
+          { path: 'a.ts', line: 12, body: 'x' },
+          { path: 'b.ts', line: 8, body: 'y' },
+          { path: 'c.ts', line: 3, body: 'z' },
+          { path: 'd.ts', line: 1, body: 'w' },
+          { path: 'e.ts', line: 4, body: 'v' },
+          { path: 'f.ts', line: 9, body: 'u' },
+        ],
+      }),
+    })
+    expect(result).toBeNull()
+  })
+
+  test('REQUEST_CHANGES with only one anchor is below threshold', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({
+        event: 'REQUEST_CHANGES',
+        body: 'One concern at `foo.ts:42`, please fix.',
+        comments: [],
+      }),
+    })
+    expect(result).toBeNull()
+  })
+
+  test('APPROVE with many anchors in a recap is allowed (verdict gate)', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({ event: 'APPROVE', body: DUMPED_BODY, comments: [] }),
+    })
+    expect(result).toBeNull()
+  })
+
+  test('COMMENT review is allowed (verdict gate)', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({ event: 'COMMENT', body: DUMPED_BODY, comments: [] }),
+    })
+    expect(result).toBeNull()
+  })
+
+  test('distinct anchors only: the same anchor repeated is one finding', () => {
+    const result = detectReviewDump({
+      command: REVIEWS_CMD,
+      inputFileContents: payload({
+        event: 'REQUEST_CHANGES',
+        body: 'See `foo.ts:10`. Again `foo.ts:10`. And once more `foo.ts:10`.',
+        comments: [],
+      }),
+    })
+    expect(result).toBeNull()
+  })
+})
+
+describe('detectReviewDump — non-matches', () => {
+  test('non-reviews endpoint is null', () => {
+    const result = detectReviewDump({
+      command: 'gh api -X POST /repos/acme/widgets/issues/7/comments -f body=hi',
+      inputFileContents: payload({ event: 'REQUEST_CHANGES', body: DUMPED_BODY, comments: [] }),
+    })
+    expect(result).toBeNull()
+  })
+
+  test('no input file contents is null', () => {
+    const result = detectReviewDump({ command: REVIEWS_CMD, inputFileContents: null })
+    expect(result).toBeNull()
+  })
+
+  test('malformed JSON is null', () => {
+    const result = detectReviewDump({ command: REVIEWS_CMD, inputFileContents: 'not json' })
+    expect(result).toBeNull()
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.test.ts
@@ -5,16 +5,16 @@ import { detectReviewDump } from './gh-review-inline-detect'
 const REVIEWS_CMD = 'gh api -X POST /repos/acme/widgets/pulls/7/reviews --input /tmp/r.json'
 
 const DUMPED_BODY = [
-  '## 리뷰 요약',
-  '두 가지 concern이 있어 REQUEST CHANGES 드립니다.',
-  '### 🔴 Concern',
-  '1. 언어 표시 명칭 하드코딩 `apps/admin/src/lib/i18n/languages.ts:12-20`',
-  '2. 영어 sentence case 위반 `apps/admin/src/lib/i18n/translations/en.ts:807,809`',
-  '### 🟡 Nit',
-  '1. aria-expanded 누락 (`translation-panel.tsx:107-111`)',
-  '2. 마크업 중복 (`translation-panel.tsx:81-86,97-102`)',
+  '## Review summary',
+  'Two concerns, requesting changes.',
+  '### Concern',
+  '1. hardcoded display name `apps/admin/src/lib/i18n/languages.ts:12-20`',
+  '2. sentence case violation `apps/admin/src/lib/i18n/translations/en.ts:807,809`',
+  '### Nit',
+  '1. missing aria-expanded (`translation-panel.tsx:107-111`)',
+  '2. duplicated markup (`translation-panel.tsx:81-86,97-102`)',
   '3. emoji deprecated (`languages.ts:4`)',
-  '4. 캐러셀 aria-hidden 누락 (`translation-panel.tsx:283-309`)',
+  '4. carousel missing aria-hidden (`translation-panel.tsx:283-309`)',
 ].join('\n')
 
 function payload(value: Record<string, unknown>): string {

--- a/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.ts
@@ -1,0 +1,74 @@
+// Blocks the "dumped review" anti-pattern: a REQUEST_CHANGES whose body anchors
+// several `path:line` findings while the payload posts no inline `comments[]`.
+// The github channel skill mandates `comments[]` and calls a flat-body review "a
+// bug, not a fallback"; this enforces it. Scoped to REQUEST_CHANGES + REST
+// `--input` payloads, since APPROVE/COMMENT bodies and the `gh pr review`
+// porcelain carry no comparable `comments[]` to weigh the body against.
+
+export type ReviewDumpInput = {
+  command: string
+  inputFileContents?: string | null
+}
+
+export type ReviewDumpDecision = { block: true; reason: string } | null
+
+// A finding anchor as a reviewer writes it in prose: a file path (optionally with
+// directories) ending in an extension, then `:line`, then an optional range/list
+// (`107-111`, `807,809`, `12-20`). This is the real notation seen in dumped
+// reviews — NOT GitHub blob `#L123` anchors, which point at files for reference
+// rather than requesting a change on the diff.
+const PATH_LINE_ANCHOR = /(?:[\w.-]+\/)*[\w.-]+\.[A-Za-z][\w]*:\d+(?:[-,]\d+)*/g
+
+const REVIEWS_ENDPOINT = /\/repos\/[^/\s]+\/[^/\s]+\/pulls\/\d+\/reviews\b/
+
+// One or two anchors in a prose body is normal narration; at three+ a near-empty
+// comments[] reads as a dump.
+const MIN_ANCHORS = 3
+
+export function detectReviewDump(input: ReviewDumpInput): ReviewDumpDecision {
+  if (!REVIEWS_ENDPOINT.test(input.command)) return null
+  const payload = parsePayload(input.inputFileContents ?? null)
+  if (payload === null) return null
+  if (payload.event !== 'REQUEST_CHANGES') return null
+
+  const anchors = countAnchors(payload.body)
+  if (anchors < MIN_ANCHORS) return null
+
+  // Slack for a body that restates a couple of findings it also posts inline.
+  if (payload.commentCount > Math.floor(anchors / 3)) return null
+
+  return { block: true, reason: buildReason(anchors, payload.commentCount) }
+}
+
+type ReviewPayload = { event: string; body: string; commentCount: number }
+
+function parsePayload(contents: string | null): ReviewPayload | null {
+  if (contents === null || contents === '') return null
+  try {
+    const parsed = JSON.parse(contents) as unknown
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const obj = parsed as Record<string, unknown>
+    const event = typeof obj.event === 'string' ? obj.event.trim().toUpperCase() : ''
+    const body = typeof obj.body === 'string' ? obj.body : ''
+    const commentCount = Array.isArray(obj.comments) ? obj.comments.length : 0
+    return { event, body, commentCount }
+  } catch {
+    return null
+  }
+}
+
+function countAnchors(body: string): number {
+  const matches = body.match(PATH_LINE_ANCHOR)
+  if (matches === null) return 0
+  // Distinct anchors only: repeating "foo.ts:10" three times is one finding.
+  return new Set(matches).size
+}
+
+function buildReason(anchors: number, commentCount: number): string {
+  return [
+    `This REQUEST_CHANGES review body anchors ${anchors} findings to specific lines (path:line) but posts ${commentCount} inline comment${commentCount === 1 ? '' : 's'}.`,
+    'Line-anchored change requests belong on the diff, not flattened into the review body.',
+    'Re-submit with each finding as an entry in the `comments[]` array of the reviews payload',
+    '(`{ "path": "...", "line": N, "side": "RIGHT", "body": "..." }`), keeping `body` for the high-level summary only.',
+  ].join(' ')
+}

--- a/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-inline-detect.ts
@@ -1,9 +1,14 @@
 // Blocks the "dumped review" anti-pattern: a REQUEST_CHANGES whose body anchors
-// several `path:line` findings while the payload posts no inline `comments[]`.
-// The github channel skill mandates `comments[]` and calls a flat-body review "a
-// bug, not a fallback"; this enforces it. Scoped to REQUEST_CHANGES + REST
-// `--input` payloads, since APPROVE/COMMENT bodies and the `gh pr review`
-// porcelain carry no comparable `comments[]` to weigh the body against.
+// `path:line` findings that are not actually posted as inline `comments[]`. The
+// github channel skill mandates `comments[]` and calls a flat-body review "a bug,
+// not a fallback"; this enforces it. Scoped to REQUEST_CHANGES + REST `--input`
+// payloads, since APPROVE/COMMENT bodies and the `gh pr review` porcelain carry
+// no comparable `comments[]` to weigh the body against.
+//
+// A body anchor is "covered" only when an inline comment sits at the same path
+// and a line inside the anchor's range — so a partially-inline review that posts
+// a few token comments while leaving other findings stranded in the body is still
+// blocked on the stranded ones.
 
 export type ReviewDumpInput = {
   command: string
@@ -17,12 +22,12 @@ export type ReviewDumpDecision = { block: true; reason: string } | null
 // (`107-111`, `807,809`, `12-20`). This is the real notation seen in dumped
 // reviews — NOT GitHub blob `#L123` anchors, which point at files for reference
 // rather than requesting a change on the diff.
-const PATH_LINE_ANCHOR = /(?:[\w.-]+\/)*[\w.-]+\.[A-Za-z][\w]*:\d+(?:[-,]\d+)*/g
+const PATH_LINE_ANCHOR = /((?:[\w.-]+\/)*[\w.-]+\.[A-Za-z]\w*):(\d+(?:[-,]\d+)*)/g
 
 const REVIEWS_ENDPOINT = /\/repos\/[^/\s]+\/[^/\s]+\/pulls\/\d+\/reviews\b/
 
-// One or two anchors in a prose body is normal narration; at three+ a near-empty
-// comments[] reads as a dump.
+// One or two anchors in a prose body is normal narration; at three+ uncovered
+// anchors a review reads as a dump.
 const MIN_ANCHORS = 3
 
 export function detectReviewDump(input: ReviewDumpInput): ReviewDumpDecision {
@@ -31,16 +36,18 @@ export function detectReviewDump(input: ReviewDumpInput): ReviewDumpDecision {
   if (payload === null) return null
   if (payload.event !== 'REQUEST_CHANGES') return null
 
-  const anchors = countAnchors(payload.body)
-  if (anchors < MIN_ANCHORS) return null
+  const anchors = parseAnchors(payload.body)
+  if (anchors.length < MIN_ANCHORS) return null
 
-  // Slack for a body that restates a couple of findings it also posts inline.
-  if (payload.commentCount > Math.floor(anchors / 3)) return null
+  const uncovered = anchors.filter((anchor) => !isCoveredInline(anchor, payload.comments))
+  if (uncovered.length === 0) return null
 
-  return { block: true, reason: buildReason(anchors, payload.commentCount) }
+  return { block: true, reason: buildReason(anchors.length, uncovered.length, payload.comments.length) }
 }
 
-type ReviewPayload = { event: string; body: string; commentCount: number }
+type Anchor = { path: string; lines: ReadonlySet<number> }
+type InlineComment = { path: string; line: number }
+type ReviewPayload = { event: string; body: string; comments: readonly InlineComment[] }
 
 function parsePayload(contents: string | null): ReviewPayload | null {
   if (contents === null || contents === '') return null
@@ -50,25 +57,74 @@ function parsePayload(contents: string | null): ReviewPayload | null {
     const obj = parsed as Record<string, unknown>
     const event = typeof obj.event === 'string' ? obj.event.trim().toUpperCase() : ''
     const body = typeof obj.body === 'string' ? obj.body : ''
-    const commentCount = Array.isArray(obj.comments) ? obj.comments.length : 0
-    return { event, body, commentCount }
+    const comments = parseComments(obj.comments)
+    return { event, body, comments }
   } catch {
     return null
   }
 }
 
-function countAnchors(body: string): number {
-  const matches = body.match(PATH_LINE_ANCHOR)
-  if (matches === null) return 0
-  // Distinct anchors only: repeating "foo.ts:10" three times is one finding.
-  return new Set(matches).size
+function parseComments(value: unknown): InlineComment[] {
+  if (!Array.isArray(value)) return []
+  const out: InlineComment[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const rec = entry as Record<string, unknown>
+    const path = typeof rec.path === 'string' ? rec.path : null
+    // GitHub keys an inline comment on `line` (and `start_line` for a span); a
+    // span covers each line it touches.
+    const line = typeof rec.line === 'number' ? rec.line : null
+    if (path === null || line === null) continue
+    const startLine = typeof rec.start_line === 'number' ? rec.start_line : line
+    for (let l = Math.min(startLine, line); l <= Math.max(startLine, line); l++) {
+      out.push({ path, line: l })
+    }
+  }
+  return out
 }
 
-function buildReason(anchors: number, commentCount: number): string {
+function parseAnchors(body: string): Anchor[] {
+  const seen = new Set<string>()
+  const out: Anchor[] = []
+  for (const m of body.matchAll(PATH_LINE_ANCHOR)) {
+    const key = `${m[1]}:${m[2]}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push({ path: m[1] as string, lines: expandLineSpec(m[2] as string) })
+  }
+  return out
+}
+
+// `12-20` -> 12..20; `807,809` -> {807,809}; `42` -> {42}.
+function expandLineSpec(spec: string): Set<number> {
+  const lines = new Set<number>()
+  for (const part of spec.split(',')) {
+    const range = part.split('-')
+    const start = Number(range[0])
+    const end = range.length > 1 ? Number(range[1]) : start
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) continue
+    for (let l = Math.min(start, end); l <= Math.max(start, end); l++) lines.add(l)
+  }
+  return lines
+}
+
+// The body writes short paths (`languages.ts`) while comments[] carry full repo
+// paths (`apps/.../languages.ts`); treat a comment as on-path when either path
+// ends with the other (segment-aligned), so the basename match is exact.
+function isCoveredInline(anchor: Anchor, comments: readonly InlineComment[]): boolean {
+  return comments.some((c) => pathsAlign(anchor.path, c.path) && anchor.lines.has(c.line))
+}
+
+function pathsAlign(anchorPath: string, commentPath: string): boolean {
+  if (anchorPath === commentPath) return true
+  return commentPath.endsWith(`/${anchorPath}`) || anchorPath.endsWith(`/${commentPath}`)
+}
+
+function buildReason(total: number, uncovered: number, commentCount: number): string {
   return [
-    `This REQUEST_CHANGES review body anchors ${anchors} findings to specific lines (path:line) but posts ${commentCount} inline comment${commentCount === 1 ? '' : 's'}.`,
-    'Line-anchored change requests belong on the diff, not flattened into the review body.',
-    'Re-submit with each finding as an entry in the `comments[]` array of the reviews payload',
+    `This REQUEST_CHANGES review body anchors ${total} findings to specific lines (path:line), but ${uncovered} of them ${uncovered === 1 ? 'is' : 'are'} not posted as inline comments (payload has ${commentCount} inline comment${commentCount === 1 ? '' : 's'}).`,
+    'Every line-anchored change request belongs on its diff line, not flattened into the review body.',
+    'Re-submit with each stranded finding as an entry in the `comments[]` array of the reviews payload',
     '(`{ "path": "...", "line": N, "side": "RIGHT", "body": "..." }`), keeping `body` for the high-level summary only.',
   ].join(' ')
 }

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -16,7 +16,8 @@ export default definePlugin({
           const command = event.args.command
           if (typeof command !== 'string' || !command.includes('gh')) return
 
-          await noteReviewCommand({ callId: event.callId, command })
+          const reviewDump = await noteReviewCommand({ callId: event.callId, command })
+          if (reviewDump !== null) return reviewDump
 
           const decision = analyzeGhCommand(command)
           if (decision.kind === 'pass-through') return

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -4,6 +4,7 @@ import { recordReview } from '@/channels/github-review-turn-ledger'
 import type { ContentPart, ToolResult } from '@/plugin'
 
 import { detectReviewSubmission, type DetectedReview } from './gh-review-detect'
+import { detectReviewDump, type ReviewDumpDecision } from './gh-review-inline-detect'
 
 // Bridges the bash `gh` interceptor to the false-receipt ledger: at tool.before
 // we detect a review-submission command (resolving its --input file), stash it by
@@ -16,10 +17,11 @@ const pending = new Map<string, DetectedReview>()
 
 const MAX_INPUT_BYTES = 1_000_000
 
-export async function noteReviewCommand(args: { callId: string; command: string }): Promise<void> {
+export async function noteReviewCommand(args: { callId: string; command: string }): Promise<ReviewDumpDecision> {
   const inputFileContents = await readInputFile(args.command)
   const detected = detectReviewSubmission({ command: args.command, inputFileContents })
   if (detected !== null) pending.set(args.callId, detected)
+  return detectReviewDump({ command: args.command, inputFileContents })
 }
 
 export function commitReviewIfSucceeded(args: { sessionId: string; callId: string; result: ToolResult }): void {


### PR DESCRIPTION
## What

Adds a `tool.before` guard in the `github-cli-auth` plugin that blocks a reviewer agent from submitting a **REQUEST_CHANGES** review whose findings are dumped into the review `body` (each anchored as `path:line`) instead of attached to their diff lines via `comments[]`.

This is the programmatic enforcement of an already-documented rule: `src/skills/typeclaw-channel-github/SKILL.md` mandates `comments[]` for actionable findings and calls a flat-body review *"a bug, not a fallback."*

## Why

Reviewer agents intermittently post a `REQUEST_CHANGES` like:

> ### 🔴 Concern
> 1. hardcoded name `apps/.../languages.ts:12-20`
> 2. sentence case `apps/.../en.ts:807,809`
> ### 🟡 Nit
> 1. aria-expanded `translation-panel.tsx:107-111`
> … (6 findings, `comments: []`)

All six findings carry precise line anchors but land in the body, so none attach to the diff. The PR author has to manually map each one back to a line — the exact friction `comments[]` exists to remove.

## How

- **`gh-review-inline-detect.ts`** (new, pure/sync): parses the `--input` payload — already read by `noteReviewCommand`, so **zero extra I/O** — and for `REQUEST_CHANGES` only, counts **distinct** `path:line(-range)(,line)` anchors in `body`. Blocks when there are **3+** anchors with a near-empty `comments[]` (`commentCount <= floor(anchors/3)`). The block reason tells the agent to re-submit with `comments[]`.
- **`review-recorder.ts`**: `noteReviewCommand` now returns the dump decision (it already had the payload in hand).
- **`index.ts`**: returns the block before the token-injection pass-through.

### Scope (deliberately narrow)
- **REQUEST_CHANGES only** — APPROVE/COMMENT bodies are summaries by nature; line refs there are incidental, not misplaced change requests.
- **REST `--input` payloads only** — the `gh pr review` porcelain and inline `-f event=...` fields can't carry `comments[]`, so there's nothing to weigh the body against.
- Uses `path:line` notation (the real notation reviewers write), **not** GitHub blob `#L123` anchors (which reference files rather than request diff changes).

## Decision table

| Submission | verdict | anchors | comments[] | result |
|---|---|---|---|---|
| dumped review | REQUEST_CHANGES | 6 | 0 | **block** |
| findings properly inline | REQUEST_CHANGES | — | 6 | allow |
| single anchor in prose | REQUEST_CHANGES | 1 | 0 | allow |
| big recap | APPROVE | 6 | 0 | allow (verdict gate) |
| same anchor repeated 3× | REQUEST_CHANGES | 1 distinct | 0 | allow |

## Testing

- New `gh-review-inline-detect.test.ts`: 10 cases (block + allow + non-match), modeled on a real dumped review shape.
- Full `github-cli-auth` suite green (101 tests); full repo suite green (7372 pass / 0 fail).
- `typecheck`, `lint` (0 errors), `format:check` all pass.