### PR TITLE
feat: add researcher subagent for deep general-purpose research

### DIFF
--- a/src/bundled-plugins/researcher/index.test.ts
+++ b/src/bundled-plugins/researcher/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import { loadPlugins, type ResolvedPlugin } from '@/plugin'
+
+import researcherPlugin from './index'
+
+const RESOLVED: ResolvedPlugin = {
+  name: 'researcher',
+  version: undefined,
+  source: '<bundled>',
+  defined: researcherPlugin,
+}
+
+describe('researcher plugin', () => {
+  test('contributes exactly one public subagent named "researcher"', async () => {
+    const { registry } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.subagents.map((s) => s.subagentName).sort()).toEqual(['researcher'])
+    const researcher = registry.subagents.find((s) => s.subagentName === 'researcher')
+    if (researcher === undefined) throw new Error('researcher subagent missing')
+    expect(researcher.subagent.visibility).toBe('public')
+  })
+
+  test('contributes no tools / cron jobs / hooks / skills / commands / doctor checks', async () => {
+    const { registry, hooks } = await loadPlugins({
+      entries: [],
+      bundled: [RESOLVED],
+      agentDir: '/agent',
+      configsByName: {},
+    })
+
+    expect(registry.tools).toHaveLength(0)
+    expect(registry.skills).toHaveLength(0)
+    expect(registry.skillsDirs).toHaveLength(0)
+    expect(registry.commands).toEqual([])
+    expect(registry.doctorChecks).toHaveLength(0)
+    expect(hooks.count('session.idle')).toBe(0)
+    expect(hooks.count('session.end')).toBe(0)
+    expect(hooks.count('tool.before')).toBe(0)
+    expect(hooks.count('tool.after')).toBe(0)
+  })
+})

--- a/src/bundled-plugins/researcher/index.ts
+++ b/src/bundled-plugins/researcher/index.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '@/plugin'
+
+import { createResearcherSubagent } from './researcher'
+
+export default definePlugin({
+  plugin: async () => ({
+    subagents: {
+      researcher: createResearcherSubagent(),
+    },
+  }),
+})

--- a/src/bundled-plugins/researcher/researcher.test.ts
+++ b/src/bundled-plugins/researcher/researcher.test.ts
@@ -47,14 +47,16 @@ describe('researcher subagent — load-bearing prompt phrases', () => {
     expect(lower).toContain('spawn `scout` directly')
   })
 
-  test('prompt scopes side effects to exactly ONE write (the report file) and forbids all others', () => {
-    // The researcher is the one read-mostly subagent with a write tool. The
-    // contract that keeps it safe is "one report file, nowhere else". If this
-    // erodes, the subagent becomes a general write vector.
+  test('prompt scopes side effects to exactly ONE write via the enforced write_report tool, no general writer', () => {
+    // The researcher is the one read-mostly subagent that can write a file. The
+    // contract that keeps it safe is "one report file via write_report, nowhere
+    // else, no general write/bash-write". If this erodes, the subagent becomes a
+    // general write vector — the exact gap a security review flagged.
     const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
     expect(lower).toContain('one scoped write')
     expect(lower).toContain('only side effect')
-    expect(lower).toContain('non-workspace-write')
+    expect(lower).toContain('write_report')
+    expect(lower).toContain('no general file-write tool')
   })
 
   test('prompt forbids bash for write/mutating operations (bash stays read-only)', () => {
@@ -73,7 +75,7 @@ describe('researcher subagent — load-bearing prompt phrases', () => {
     expect(RESEARCHER_SYSTEM_PROMPT).toContain('`bash`')
     expect(RESEARCHER_SYSTEM_PROMPT).toContain('`web_search`')
     expect(RESEARCHER_SYSTEM_PROMPT).toContain('`web_fetch`')
-    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`write`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`write_report`')
     expect(RESEARCHER_SYSTEM_PROMPT).toContain('`load_skill`')
   })
 
@@ -144,7 +146,6 @@ describe('researcher subagent — load-bearing prompt phrases', () => {
     expect(RESEARCHER_SYSTEM_PROMPT).toContain('public/research-')
     expect(RESEARCHER_SYSTEM_PROMPT).toContain('## Your role in this session')
     expect(RESEARCHER_SYSTEM_PROMPT).toContain('fs.see.private')
-    expect(RESEARCHER_SYSTEM_PROMPT).toContain('denied by permissions')
   })
 })
 
@@ -172,24 +173,28 @@ describe('researcher subagent declaration', () => {
     expect(sub.canSpawnSubagents).toBe(true)
   })
 
-  test('tools list adds exactly one writer (write) on top of the reviewer read set, with NO edit', () => {
+  test('builtin tools are READ-ONLY: no generic write or edit (the writer is the enforced write_report custom tool)', () => {
     const sub = createResearcherSubagent()
     const toolNames = (sub.tools ?? []).map((t) => t.__builtinTool).sort()
-    expect(toolNames).toEqual(['bash', 'find', 'grep', 'ls', 'read', 'web_fetch', 'web_search', 'write'])
-    // Drift guard: the researcher gets `write` for its report ONLY. `edit`
-    // (in-place mutation) is deliberately withheld — a report is written once,
-    // and withholding edit shrinks the side-effect surface.
-    expect(toolNames).toContain('write')
+    expect(toolNames).toEqual(['bash', 'find', 'grep', 'ls', 'read', 'web_fetch', 'web_search'])
+    // Security drift guard (the review finding): the generic `write` tool's
+    // runtime boundary (the non-workspace-write guard) is too broad for a
+    // guest-spawnable subagent — it allowlists IDENTITY.md/cron.json/etc. and
+    // honors acknowledgeGuards. The researcher must NOT hold it; its only writer
+    // is the dedicated, code-enforced write_report custom tool. If a future edit
+    // re-adds writeTool/editTool here, the hole reopens and this fails.
+    expect(toolNames).not.toContain('write')
     expect(toolNames).not.toContain('edit')
   })
 
-  test('customTools contains exactly one tool: load_skill (the runtime-skill-loader)', () => {
+  test('customTools are exactly [load_skill, write_report] — the skill loader and the only file writer', () => {
     const sub = createResearcherSubagent()
     expect(sub.customTools).toBeDefined()
-    expect(sub.customTools).toHaveLength(1)
-    const loadSkill = sub.customTools?.[0]
-    if (loadSkill === undefined) throw new Error('load_skill tool missing')
+    expect(sub.customTools).toHaveLength(2)
+    const [loadSkill, writeReport] = sub.customTools ?? []
+    if (loadSkill === undefined || writeReport === undefined) throw new Error('expected load_skill + write_report')
     expect(loadSkill.description).toContain('`general`')
+    expect(writeReport.description.toLowerCase()).toContain('research report')
   })
 
   test('load_skill parameter schema accepts the shipped skill name and rejects unknown ones', () => {
@@ -212,10 +217,16 @@ describe('researcher subagent declaration', () => {
     expect(sub.toolResultBudget?.maxTotalBytes).toBeGreaterThan(0)
   })
 
-  test('tool-result budget covers write + load_skill so report bytes and skill bodies count against the cap', () => {
+  test('tool-result budget covers the builtin read/web tools and omits custom tools (which surface under __plugin_* names)', () => {
+    // Custom tools (load_skill, write_report) are renamed to
+    // `__plugin_researcher_researcher_<i>` at wrap time, so a name-keyed budget
+    // entry for them would be dead config. The budget keys only the builtins.
     const sub = createResearcherSubagent()
-    expect(sub.toolResultBudget?.toolNames).toContain('write')
-    expect(sub.toolResultBudget?.toolNames).toContain('load_skill')
+    const names = sub.toolResultBudget?.toolNames ?? []
+    expect([...names].sort()).toEqual(['bash', 'find', 'grep', 'ls', 'read', 'web_fetch', 'web_search'])
+    expect(names).not.toContain('write')
+    expect(names).not.toContain('load_skill')
+    expect(names).not.toContain('write_report')
   })
 
   test('budget sits between explorer (256KB) and operator (1MB) — deep but bounded, bulk is delegated', () => {

--- a/src/bundled-plugins/researcher/researcher.test.ts
+++ b/src/bundled-plugins/researcher/researcher.test.ts
@@ -104,6 +104,18 @@ describe('researcher subagent — load-bearing prompt phrases', () => {
     expect(lower).toContain('delegate the gathering, never the conclusion')
   })
 
+  test('prompt makes delegating to scout/explorer the DEFAULT for fetching, not just for big sweeps', () => {
+    // The expensive deep model bleeds context if it fetches routine pages
+    // itself. The prompt must push the model to delegate quick fetches to
+    // scout/explorer by default and keep its own web_search/web_fetch/read/grep
+    // for surgical touches only. If this softens back to "delegate big sweeps,
+    // fetch the rest yourself", the context-economy intent is lost.
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('delegate first; fetch yourself only as a last resort')
+    expect(lower).toContain('your default for gathering is to delegate')
+    expect(lower).toContain('quick or broad')
+  })
+
   test('prompt still forbids side effects through a delegate (no laundering write access via a subagent)', () => {
     const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
     expect(lower).toContain('a subagent you spawn cannot do for you')

--- a/src/bundled-plugins/researcher/researcher.test.ts
+++ b/src/bundled-plugins/researcher/researcher.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  RESEARCHER_SKILLS,
+  RESEARCHER_SYSTEM_PROMPT,
+  createResearcherSubagent,
+  researcherPayloadSchema,
+} from './researcher'
+import { GENERAL_RESEARCH_SKILL } from './skills/general'
+
+describe('researcher subagent — load-bearing prompt phrases', () => {
+  test.each(
+    [
+      'SIDE EFFECTS',
+      'STRICTLY PROHIBITED',
+      'parallel',
+      '<analysis>',
+      '<report>',
+      '<summary>',
+      '<report_file>',
+      '<confidence>',
+      '<open_questions>',
+      'load_skill',
+    ].map((phrase) => [phrase] as const),
+  )('prompt contains %s', (phrase) => {
+    const haystack = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(haystack).toContain(phrase.toLowerCase())
+  })
+
+  test('prompt frames the role as domain-neutral research, NOT a coding assistant', () => {
+    // The whole point of this subagent is general-purpose research (markets,
+    // history, science, policy). If a future edit narrows it to code research,
+    // it stops serving the runtime's actual breadth and this guard fails.
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('domain-neutral')
+    expect(lower).toContain('not a coding assistant')
+    expect(lower).toContain('research analyst')
+  })
+
+  test('prompt frames the role as the deep counterpart to scout (and redirects simple lookups to scout)', () => {
+    // The scout/researcher split only holds if researcher redirects trivial
+    // single-fact lookups back to scout. Without it, the expensive deep model
+    // gets spent on questions scout could answer in one pass.
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('scout')
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('quality, not speed')
+    expect(lower).toContain('spawn `scout` directly')
+  })
+
+  test('prompt scopes side effects to exactly ONE write (the report file) and forbids all others', () => {
+    // The researcher is the one read-mostly subagent with a write tool. The
+    // contract that keeps it safe is "one report file, nowhere else". If this
+    // erodes, the subagent becomes a general write vector.
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('one scoped write')
+    expect(lower).toContain('only side effect')
+    expect(lower).toContain('non-workspace-write')
+  })
+
+  test('prompt forbids bash for write/mutating operations (bash stays read-only)', () => {
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('mkdir')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('rm')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('git add')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('git commit')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('git push')
+  })
+
+  test('prompt names the dedicated tools by their exact runtime names', () => {
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`read`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`grep`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`find`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`ls`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`bash`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`web_search`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`web_fetch`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`write`')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('`load_skill`')
+  })
+
+  test('prompt instructs the researcher to load a skill BEFORE gathering (architectural intent)', () => {
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('load_skill')
+    expect(lower).toContain('first thing you do')
+    expect(lower).toContain('do not start gathering before loading a skill')
+  })
+
+  test('prompt is domain-neutral: does NOT inline a topic-specific research workflow in the base prompt', () => {
+    // Drift guard mirroring reviewer's: domain-specific craft (market sizing
+    // steps, archival-research steps) lives in skills, not the base prompt. If
+    // a future edit pulls a single topic's workflow into the base prompt, the
+    // researcher stops being general-purpose and this catches it.
+    expect(RESEARCHER_SYSTEM_PROMPT).not.toContain('**Market research:**')
+    expect(RESEARCHER_SYSTEM_PROMPT).not.toContain('**Historical research:**')
+    expect(RESEARCHER_SYSTEM_PROMPT).not.toContain('**Code research:**')
+  })
+
+  test('prompt frames delegation as context-saving (deep model offloads bulk gathering to cheaper workers)', () => {
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('spawn_subagent')
+    expect(lower).toContain('explorer')
+    // The synthesis stays with the researcher — delegation gathers, never decides.
+    expect(lower).toContain('delegate the gathering, never the conclusion')
+  })
+
+  test('prompt still forbids side effects through a delegate (no laundering write access via a subagent)', () => {
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('a subagent you spawn cannot do for you')
+  })
+
+  test('prompt enforces citation discipline: cite every claim, never invent a source, never answer from memory', () => {
+    // The three load-bearing failure modes of a research agent: uncited prose,
+    // hallucinated sources, and training-memory laundered as sourced fact. All
+    // three rules must be present.
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('cite every claim')
+    expect(lower).toContain('never invent a source')
+    expect(lower).toContain('never answer a researchable question from training memory')
+  })
+
+  test('prompt requires cross-validation of load-bearing claims across independent sources', () => {
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('cross-validate')
+    expect(lower).toContain('independent')
+  })
+
+  test('prompt forbids deciding for the caller (research surfaces evidence, the caller decides)', () => {
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('do not decide for the caller')
+  })
+
+  test('prompt requires a confidence rating so the caller can weight the report', () => {
+    const lower = RESEARCHER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('confidence')
+    expect(lower).toContain('low confidence, honestly reported, is useful')
+  })
+
+  test('prompt routes the report to workspace by default and falls back to public for untrusted callers', () => {
+    // The workspace/public fallback is the load-bearing safety+visibility rule:
+    // workspace/ is hidden from guest, so a report written there for a guest
+    // caller is invisible to them. The subagent must self-route off its own
+    // resolved role block. If this guidance is lost, guest-spawned researchers
+    // silently produce unreadable reports.
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('workspace/research-')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('public/research-')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('## Your role in this session')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('fs.see.private')
+    expect(RESEARCHER_SYSTEM_PROMPT).toContain('denied by permissions')
+  })
+})
+
+describe('researcher subagent declaration', () => {
+  test('is registered as visibility=public so spawn_subagent exposes it', () => {
+    const sub = createResearcherSubagent()
+    expect(sub.visibility).toBe('public')
+  })
+
+  test('uses the deep model profile (quality over speed, the deep counterpart to fast scout)', () => {
+    const sub = createResearcherSubagent()
+    expect(sub.profile).toBe('deep')
+  })
+
+  test('does NOT require a specific permission (member with generic subagent.spawn can spawn it)', () => {
+    // Unlike operator, the researcher's only write is a sandboxed report file,
+    // so it is NOT gated to owner/trusted. Flipping this to true would silently
+    // lock member/guest out of research.
+    const sub = createResearcherSubagent()
+    expect(sub.requiresSpecificPermission ?? false).toBe(false)
+  })
+
+  test('declares canSpawnSubagents=true (deep researcher offloads bulk gathering to scout/explorer)', () => {
+    const sub = createResearcherSubagent()
+    expect(sub.canSpawnSubagents).toBe(true)
+  })
+
+  test('tools list adds exactly one writer (write) on top of the reviewer read set, with NO edit', () => {
+    const sub = createResearcherSubagent()
+    const toolNames = (sub.tools ?? []).map((t) => t.__builtinTool).sort()
+    expect(toolNames).toEqual(['bash', 'find', 'grep', 'ls', 'read', 'web_fetch', 'web_search', 'write'])
+    // Drift guard: the researcher gets `write` for its report ONLY. `edit`
+    // (in-place mutation) is deliberately withheld — a report is written once,
+    // and withholding edit shrinks the side-effect surface.
+    expect(toolNames).toContain('write')
+    expect(toolNames).not.toContain('edit')
+  })
+
+  test('customTools contains exactly one tool: load_skill (the runtime-skill-loader)', () => {
+    const sub = createResearcherSubagent()
+    expect(sub.customTools).toBeDefined()
+    expect(sub.customTools).toHaveLength(1)
+    const loadSkill = sub.customTools?.[0]
+    if (loadSkill === undefined) throw new Error('load_skill tool missing')
+    expect(loadSkill.description).toContain('`general`')
+  })
+
+  test('load_skill parameter schema accepts the shipped skill name and rejects unknown ones', () => {
+    const sub = createResearcherSubagent()
+    const loadSkill = sub.customTools?.[0]
+    if (loadSkill === undefined) throw new Error('load_skill tool missing')
+    expect(loadSkill.parameters.safeParse({ name: 'general' }).success).toBe(true)
+    expect(loadSkill.parameters.safeParse({ name: 'market-research' }).success).toBe(false)
+    expect(loadSkill.parameters.safeParse({ name: '' }).success).toBe(false)
+  })
+
+  test('RESEARCHER_SKILLS ships exactly the general discipline skill (initial ship set)', () => {
+    const names = RESEARCHER_SKILLS.map((s) => s.name)
+    expect(names).toEqual(['general'])
+  })
+
+  test('declares a tool-result budget so a runaway research pass cannot exhaust parent context', () => {
+    const sub = createResearcherSubagent()
+    expect(sub.toolResultBudget).toBeDefined()
+    expect(sub.toolResultBudget?.maxTotalBytes).toBeGreaterThan(0)
+  })
+
+  test('tool-result budget covers write + load_skill so report bytes and skill bodies count against the cap', () => {
+    const sub = createResearcherSubagent()
+    expect(sub.toolResultBudget?.toolNames).toContain('write')
+    expect(sub.toolResultBudget?.toolNames).toContain('load_skill')
+  })
+
+  test('budget sits between explorer (256KB) and operator (1MB) — deep but bounded, bulk is delegated', () => {
+    const sub = createResearcherSubagent()
+    const budget = sub.toolResultBudget?.maxTotalBytes ?? 0
+    expect(budget).toBeGreaterThan(256_000)
+    expect(budget).toBeLessThan(1_000_000)
+  })
+
+  test('declares a spawn timeout so a stalled research pass fails the parent loudly instead of hanging forever', () => {
+    const sub = createResearcherSubagent()
+    expect(sub.timeoutMs).toBeGreaterThan(0)
+  })
+
+  test('spawn timeout is generous enough for a deep multi-source pass but not unbounded', () => {
+    const sub = createResearcherSubagent()
+    const timeout = sub.timeoutMs ?? 0
+    expect(timeout).toBeGreaterThanOrEqual(60_000)
+    expect(timeout).toBeLessThanOrEqual(1_800_000)
+  })
+
+  test('inFlightKey returns distinct values for distinct requestId payloads (parallel spawns must not coalesce)', () => {
+    const sub = createResearcherSubagent()
+    const k1 = sub.inFlightKey?.({ requestId: 'bg_a' })
+    const k2 = sub.inFlightKey?.({ requestId: 'bg_b' })
+    expect(k1).toBe('bg_a')
+    expect(k2).toBe('bg_b')
+    expect(k1).not.toBe(k2)
+  })
+
+  test('inFlightKey falls back to a random value when no requestId is provided (no accidental coalescing)', () => {
+    const sub = createResearcherSubagent()
+    const k1 = sub.inFlightKey?.({})
+    const k2 = sub.inFlightKey?.({})
+    expect(k1).not.toBe(k2)
+  })
+})
+
+describe('researcher skill content', () => {
+  test('GENERAL_RESEARCH_SKILL has the expected name/description/non-empty content', () => {
+    expect(GENERAL_RESEARCH_SKILL.name).toBe('general')
+    expect(GENERAL_RESEARCH_SKILL.description.length).toBeGreaterThan(0)
+    expect(GENERAL_RESEARCH_SKILL.content.length).toBeGreaterThan(0)
+  })
+
+  test('general skill teaches domain-neutral research craft (drift guard against narrowing to code)', () => {
+    // The description must advertise the breadth (market/history/science) so the
+    // model picks it for any topic, and the body must teach universal craft.
+    const lowerDesc = GENERAL_RESEARCH_SKILL.description.toLowerCase()
+    expect(lowerDesc).toContain('market')
+    expect(lowerDesc).toContain('historical')
+    const lower = GENERAL_RESEARCH_SKILL.content.toLowerCase()
+    expect(lower).toContain('primary source')
+    expect(lower).toContain('cross-validate')
+    expect(lower).toContain('circular citation')
+    expect(lower).toContain('confidence calibration')
+  })
+
+  test('general skill suppresses the core research failure modes (drift guards)', () => {
+    const lower = GENERAL_RESEARCH_SKILL.content.toLowerCase()
+    expect(lower).toContain('do not answer a researchable question from training memory')
+    expect(lower).toContain('do not invent or guess sources')
+    expect(lower).toContain('do not make the decision for the caller')
+  })
+
+  test('every shipped skill references the researcher neutral output contract (so domain skills compose with it)', () => {
+    for (const skill of RESEARCHER_SKILLS) {
+      expect(skill.content).toContain('<report>')
+    }
+  })
+
+  test('general skill carries the report-file skeleton (so the writer has a concrete structure)', () => {
+    const lower = GENERAL_RESEARCH_SKILL.content.toLowerCase()
+    expect(lower).toContain('## findings')
+    expect(lower).toContain('## sources')
+    expect(lower).toContain('## open questions')
+  })
+})
+
+describe('researcherPayloadSchema', () => {
+  test('accepts a full payload with requestId + prompt + description', () => {
+    const result = researcherPayloadSchema.safeParse({
+      requestId: 'bg_t1',
+      prompt: 'is the global market for X growing year over year',
+      description: 'market growth research',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts a payload with only requestId (spawn-tool minimum)', () => {
+    const result = researcherPayloadSchema.safeParse({ requestId: 'bg_t1' })
+    expect(result.success).toBe(true)
+  })
+
+  test('passes through unknown fields (forward-compat with future spawn-tool params, matches scout/reviewer/operator)', () => {
+    const result = researcherPayloadSchema.safeParse({ requestId: 'bg_t1', futureField: 42 })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/bundled-plugins/researcher/researcher.ts
+++ b/src/bundled-plugins/researcher/researcher.ts
@@ -1,0 +1,211 @@
+import { z } from 'zod'
+
+import {
+  bashTool,
+  createLoadSkillTool,
+  findTool,
+  grepTool,
+  type LoadableSkill,
+  lsTool,
+  readTool,
+  type Subagent,
+  webFetchTool,
+  webSearchTool,
+  writeTool,
+} from '@/plugin'
+
+import { GENERAL_RESEARCH_SKILL } from './skills/general'
+
+// The curated set of research-domain skills the researcher can load on demand
+// via its `load_skill` tool. Research method is domain-invariant — triage,
+// decompose, gather, cross-validate, synthesize, calibrate confidence — so the
+// initial ship set is a single `general` discipline skill rather than one
+// skill per topic. Adding a domain skill later (e.g. `market-research`,
+// `historical-research`) is a one-line append here plus a new file under
+// `./skills/`; no runtime change required.
+export const RESEARCHER_SKILLS: readonly LoadableSkill[] = [GENERAL_RESEARCH_SKILL]
+
+// Mirrors the reviewer ceiling. A researcher whose `session.prompt` stalls
+// mid-turn would otherwise leave `completion` pending forever — the
+// `subagent.completed` broadcast never fires and the parent is never woken to
+// read the report. The ceiling makes `awaitWithSubagentTimeout` settle with
+// SubagentTimeoutError, surfacing a FAILED completion reminder so the request
+// fails loudly instead of vanishing. Sized for a thorough `deep`-model pass
+// (multi-source gathering, a few delegated workers, writing a report file),
+// well above a typical sub-minute lookup. This is liveness for the parent, not
+// hard cancellation: pi's `session.prompt` takes no AbortSignal, so the LLM
+// stream may run until the OS reaps it. See src/agent/subagents.ts `timeoutMs`.
+export const RESEARCHER_SPAWN_TIMEOUT_MS = 600_000
+
+// TODO(#452): Restrict the researcher's `bash` to a curated read-only allowlist
+// once per-subagent bash allowlist support lands. Today the read-only contract
+// on bash is enforced only by this system prompt, the same way `explorer` and
+// `reviewer` enforce theirs. The single permitted write is the report file, via
+// the `write` tool — fenced to `workspace/`/`public/` by the bundled
+// `non-workspace-write` guard regardless of what this prompt says.
+export const RESEARCHER_SYSTEM_PROMPT = `You are a research specialist running inside TypeClaw. Your job: investigate an open question the caller hands you — about a market, a historical record, a scientific question, a company, a policy, a current event, a technology, or anything else that needs more than a single lookup — and produce a grounded, citation-backed research report.
+
+You are domain-neutral. You are not a coding assistant; you are a research analyst who happens to live in a software runtime. Treat a question about market sizing or an archival document with the same rigor you would treat any other.
+
+You exist to do what \`scout\` cannot: deep, multi-source, model-heavy investigation. \`scout\` is the fast single-pass web lookup; you are the deep pass that decomposes a fuzzy question, gathers from many sources, cross-checks them, and synthesizes a verdict you are willing to stake a confidence level on. Your model has been chosen for quality, not speed — spend tokens on thinking. For a simple fact lookup the caller does not need you; tell them to spawn \`scout\` directly.
+
+=== SIDE EFFECTS — ONE SCOPED WRITE, NOTHING ELSE ===
+Unlike a pure read-only subagent, you produce one artifact: a research report file. That is the ONLY side effect you may cause. You are STRICTLY PROHIBITED from:
+- Writing or editing ANY file other than your single report file (see "The report file" below)
+- Writing anywhere outside \`workspace/\` or \`public/\` — never to \`memory/\`, \`sessions/\`, \`typeclaw.json\`, \`cron.json\`, \`.env\`, \`secrets.json\`, or any source/config path
+- Posting to GitHub, Slack, Discord, email, or any channel — the parent owns all communication
+- Pushing, merging, or otherwise mutating remote state
+- Using bash for: mkdir, touch, rm, cp, mv, git add, git commit, git push, git rebase, git reset, npm install, pip install, or any write operation
+
+The runtime's \`non-workspace-write\` guard enforces the write boundary regardless of what you intend — a write outside the allowed zone comes back blocked. Anything you cannot do directly, a subagent you spawn cannot do for you.
+
+## Delegating to keep your context lean
+
+You run on a deliberately expensive model. Reading a pile of search results or a large local tree into YOUR context burns that budget on grunt work. When a slice of the job is bulky-but-mechanical — "sweep the web for every source on X", "pull the relevant passages from these filings", "find where Y is documented locally" — hand it to a cheaper worker with \`spawn_subagent\` and fold the distilled result into your synthesis.
+
+- \`scout\` — web gathering. Hand it a focused question; it returns citation-backed findings.
+- \`explorer\` — local gathering. Hand it a filesystem/git/memory question; it returns paths and excerpts.
+- The synthesis, the cross-validation, and the confidence call are YOURS. Delegate the gathering, never the conclusion.
+- Each delegated task is self-contained: the worker does not see this conversation. Put everything it needs in the prompt.
+- The chain is depth-limited: a worker you spawn cannot spawn again. Keep delegation one level deep.
+- \`subagent_output\`/\`subagent_cancel\` reach only the tasks YOU spawned. Use background spawns for parallel gathering, then fold the results into your single report.
+
+## Tools
+
+The runtime exposes these tools to you by these EXACT names — call them by name, do not paraphrase:
+
+- \`read\` — read a file when you know the path
+- \`grep\` — search file contents by text or regex
+- \`find\` — locate files by name pattern
+- \`ls\` — list a directory's immediate contents
+- \`bash\` — read-only commands ONLY. Read-only \`git\` and one-shot non-mutating pipelines (\`cat\`, \`head\`, \`tail\`, \`wc\`, \`sort\`, \`uniq\`, \`jq\`). Never use bash to write, move, or delete.
+- \`web_search\` — search the public web. Returns ranked \`{title, url, snippet}\` entries.
+- \`web_fetch\` — fetch a single URL and read its content (article extraction, JSON via jq, etc.)
+- \`write\` — write your report file, and ONLY your report file. See "The report file".
+- \`load_skill\` — load a curated research skill by name. See the section below.
+
+Launch independent tools and gathering spawns in parallel. A claim backed by two independent sources is stronger than either alone.
+
+## Loading a research skill
+
+Specific research discipline — how to scope a question, where to find trustworthy sources, how to cross-validate, how to calibrate confidence — lives in a skill you load on demand.
+
+The first thing you do for any investigation is:
+
+1. **Read the payload and identify the question.** What is actually being asked? What kind of question is it?
+2. **Call \`load_skill\` with the matching skill name.** The \`load_skill\` tool's description lists the available skills. Pick the one whose description fits the question. If none of the domain skills fit, load \`general\`.
+3. **Apply that skill's discipline on top of the universal philosophy below.**
+
+Do NOT start gathering before loading a skill. The skill-selection decision is internal reasoning — keep it out of your final \`<summary>\`.
+
+## Triage first
+
+Before gathering, lay out your plan in an \`<analysis>\` block:
+
+<analysis>
+**Literal Request**: [what they literally asked]
+**Actual Question**: [the real question, sharpened — what would a complete answer let them do]
+**Sub-questions**: [the 2-5 sharp questions the fuzzy ask decomposes into]
+**Gathering Plan**: [which sub-questions go to \`scout\` (web), which to \`explorer\` (local), which you do directly]
+</analysis>
+
+No gathering before triage.
+
+## Universal research philosophy
+
+These rules apply to every investigation regardless of domain.
+
+1. **Prefer primary sources.** Official statistics, filings, registries, primary documents, peer-reviewed papers, standards bodies, vendor primary docs — over aggregator blogs and news rewrites. Use secondaries to find primaries, not as the citation.
+2. **Cross-validate load-bearing claims.** Any fact the answer rests on must be triangulated across at least two INDEPENDENT sources. Three outlets quoting one press release is one source — trace each claim to its origin.
+3. **Separate what sources SAY from what you INFER.** Quoting a source and synthesizing across sources are different acts. Mark which is which. Inference is yours, not the source's.
+4. **Cite every claim. Never invent a source.** Cite only what you (or a worker you spawned) actually retrieved — never fabricate a URL, title, or date.
+5. **Never answer a researchable question from training memory.** If you could not find a live source for a fact, say so explicitly rather than asserting it from memory.
+6. **Date-stamp time-sensitive facts.** Prices, statistics, market sizes, headcounts, legal status, version dates — a fact without its date is half a fact.
+7. **Surface disagreement, don't smooth it.** When credible sources conflict, present both and say which you weight higher and why.
+8. **Do not decide for the caller.** Surface evidence and tradeoffs. When the answer turns on the caller's values, lay out the options with their data — do not pick one.
+
+## The report file
+
+Your durable deliverable is a markdown report file. Write it with the \`write\` tool, exactly once, to one of these locations:
+
+- **Default → \`workspace/research-<slug>-<YYYYMMDD-HHMMSS>.md\`** (the agent's free-write zone).
+- **Fallback → \`public/research-<slug>-<YYYYMMDD-HHMMSS>.md\`** when the caller is UNTRUSTED. Check the "## Your role in this session" block in your context: if your resolved \`Role\` is \`guest\` (or any role whose permissions do not include \`fs.see.private\`), the caller CANNOT read \`workspace/\` — it is hidden from them — so a report written there is invisible to the caller. Write to \`public/\` instead so they can read it back. If a write to \`workspace/\` comes back \`denied by permissions\`, that is the same signal: fall back to \`public/\`.
+
+Use \`<slug>\` = a short kebab-case stem from the question. The report's structure is defined by the \`general\` skill; write the full report (summary, findings with evidence + sources, source list, confidence, open questions, method) to the file. The file is the detail; your final message is the pointer.
+
+## Output contract
+
+End every response with a single \`<report>\` block. Use this exact structure:
+
+<report>
+<summary>
+[Two or three sentences: the answer to the actual question and the one or two facts that justify it. Write it for the caller, not as a process narrative — do NOT say "I searched…" or "I loaded the X skill". Lead with the substance.]
+</summary>
+<report_file>
+[The absolute path of the report file you wrote, e.g. /agent/workspace/research-x-20260605-141500.md]
+</report_file>
+<confidence>
+[high | medium | low — with one sentence on why. Low confidence, honestly reported, is useful; speculation dressed as high confidence is not.]
+</confidence>
+<open_questions>
+[What you could not resolve and what would resolve it. "None — the question is fully answered" is a valid value when it is true.]
+</open_questions>
+</report>
+
+## Rules
+
+- Every local path you cite or write MUST be absolute (start with \`/\`). The agent folder is mounted at \`/agent\`, so the report path is \`/agent/workspace/...\` or \`/agent/public/...\`.
+- If the question requires information you genuinely cannot reach (a private system, a paywalled primary you could not access), say so explicitly in \`<summary>\` and in the report's open questions, and report what you DID find.
+- If you cannot identify a researchable question from the payload, write a short report stating what is unclear, set confidence \`low\`, and list what you'd need in \`<open_questions>\`.
+
+You have one shot. The parent receives your final assistant message verbatim and reads the report file you wrote — make both complete and self-contained.`
+
+export const researcherPayloadSchema = z
+  .object({
+    requestId: z.string().optional(),
+    prompt: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .passthrough()
+
+export type ResearcherPayload = z.infer<typeof researcherPayloadSchema>
+
+export function createResearcherSubagent(): Subagent<ResearcherPayload> {
+  const loadSkillTool = createLoadSkillTool({
+    skills: RESEARCHER_SKILLS,
+    description: `Load a curated research skill by name. Each skill explains how to investigate one kind of question — how to scope it, where to find trustworthy sources, how to cross-validate, and how to calibrate confidence. Call this BEFORE gathering so your investigation is grounded in real research craft, not generic prose.
+
+Available skills:
+${RESEARCHER_SKILLS.map((s) => `- \`${s.name}\` — ${s.description}`).join('\n')}
+
+If none of the listed skills fit the question, load \`general\`. Keep the skill-selection decision internal — do NOT narrate which skill you loaded in \`<summary>\`.`,
+  })
+
+  return {
+    systemPrompt: RESEARCHER_SYSTEM_PROMPT,
+    // `deep` is a conventional profile name (see src/config/config.ts). If the
+    // user has not configured `models.deep`, `resolveProfile` falls back to
+    // `default` with a one-time warning — safe degradation. Matches reviewer:
+    // research is quality-over-speed work, the deep counterpart to fast scout.
+    profile: 'deep',
+    tools: [readTool, grepTool, findTool, lsTool, bashTool, webSearchTool, webFetchTool, writeTool],
+    customTools: [loadSkillTool],
+    payloadSchema: researcherPayloadSchema,
+    visibility: 'public',
+    // No `requiresSpecificPermission`: unlike `operator` (arbitrary write/edit +
+    // side-effecting bash), the researcher's only write is a report file fenced
+    // to `workspace/`/`public/` by the `non-workspace-write` guard. That benign,
+    // sandboxed capability does not warrant operator's owner/trusted-only gate;
+    // any caller that can spawn a subagent can spawn the researcher.
+    canSpawnSubagents: true,
+    timeoutMs: RESEARCHER_SPAWN_TIMEOUT_MS,
+    inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    toolResultBudget: {
+      // Matches reviewer (512KB): higher than explorer (256KB) because a deep
+      // research pass reads many sources; lower than operator (1MB) because the
+      // bulk gathering is delegated to scout/explorer, not pulled in directly.
+      maxTotalBytes: 512_000,
+      toolNames: ['read', 'grep', 'find', 'ls', 'bash', 'web_search', 'web_fetch', 'write', 'load_skill'],
+    },
+  }
+}

--- a/src/bundled-plugins/researcher/researcher.ts
+++ b/src/bundled-plugins/researcher/researcher.ts
@@ -11,10 +11,10 @@ import {
   type Subagent,
   webFetchTool,
   webSearchTool,
-  writeTool,
 } from '@/plugin'
 
 import { GENERAL_RESEARCH_SKILL } from './skills/general'
+import { createWriteReportTool } from './write-report'
 
 // The curated set of research-domain skills the researcher can load on demand
 // via its `load_skill` tool. Research method is domain-invariant — triage,
@@ -40,9 +40,11 @@ export const RESEARCHER_SPAWN_TIMEOUT_MS = 600_000
 // TODO(#452): Restrict the researcher's `bash` to a curated read-only allowlist
 // once per-subagent bash allowlist support lands. Today the read-only contract
 // on bash is enforced only by this system prompt, the same way `explorer` and
-// `reviewer` enforce theirs. The single permitted write is the report file, via
-// the `write` tool — fenced to `workspace/`/`public/` by the bundled
-// `non-workspace-write` guard regardless of what this prompt says.
+// `reviewer` enforce theirs. The researcher's ONLY file-write capability is the
+// dedicated `write_report` custom tool (see ./write-report.ts), which enforces
+// the one-report-under-workspace/public boundary in code — the generic `write`
+// tool is deliberately NOT in the tool set, because its guard boundary is too
+// broad for a guest-spawnable subagent.
 export const RESEARCHER_SYSTEM_PROMPT = `You are a research specialist running inside TypeClaw. Your job: investigate an open question the caller hands you — about a market, a historical record, a scientific question, a company, a policy, a current event, a technology, or anything else that needs more than a single lookup — and produce a grounded, citation-backed research report.
 
 You are domain-neutral. You are not a coding assistant; you are a research analyst who happens to live in a software runtime. Treat a question about market sizing or an archival document with the same rigor you would treat any other.
@@ -50,14 +52,13 @@ You are domain-neutral. You are not a coding assistant; you are a research analy
 You exist to do what \`scout\` cannot: deep, multi-source, model-heavy investigation. \`scout\` is the fast single-pass web lookup; you are the deep pass that decomposes a fuzzy question, gathers from many sources, cross-checks them, and synthesizes a verdict you are willing to stake a confidence level on. Your model has been chosen for quality, not speed — spend tokens on thinking. For a simple fact lookup the caller does not need you; tell them to spawn \`scout\` directly.
 
 === SIDE EFFECTS — ONE SCOPED WRITE, NOTHING ELSE ===
-Unlike a pure read-only subagent, you produce one artifact: a research report file. That is the ONLY side effect you may cause. You are STRICTLY PROHIBITED from:
-- Writing or editing ANY file other than your single report file (see "The report file" below)
-- Writing anywhere outside \`workspace/\` or \`public/\` — never to \`memory/\`, \`sessions/\`, \`typeclaw.json\`, \`cron.json\`, \`.env\`, \`secrets.json\`, or any source/config path
+Unlike a pure read-only subagent, you produce one artifact: a research report file. That is the ONLY side effect you may cause. You write it with the dedicated \`write_report\` tool — you have NO general file-write tool and NO \`bash\` write access. You are STRICTLY PROHIBITED from:
+- Trying to write or edit any file other than your single report file
 - Posting to GitHub, Slack, Discord, email, or any channel — the parent owns all communication
 - Pushing, merging, or otherwise mutating remote state
 - Using bash for: mkdir, touch, rm, cp, mv, git add, git commit, git push, git rebase, git reset, npm install, pip install, or any write operation
 
-The runtime's \`non-workspace-write\` guard enforces the write boundary regardless of what you intend — a write outside the allowed zone comes back blocked. Anything you cannot do directly, a subagent you spawn cannot do for you.
+The \`write_report\` tool enforces these limits in code: it accepts exactly one report file directly under \`workspace/\` or \`public/\`, named \`research-<slug>.md\`, written once per session — anything else is rejected. You cannot reach \`memory/\`, \`sessions/\`, \`typeclaw.json\`, \`.env\`, source, or config through it. Anything you cannot do directly, a subagent you spawn cannot do for you.
 
 ## Delegating to keep your context lean
 
@@ -81,7 +82,7 @@ The runtime exposes these tools to you by these EXACT names — call them by nam
 - \`bash\` — read-only commands ONLY. Read-only \`git\` and one-shot non-mutating pipelines (\`cat\`, \`head\`, \`tail\`, \`wc\`, \`sort\`, \`uniq\`, \`jq\`). Never use bash to write, move, or delete.
 - \`web_search\` — search the public web. Returns ranked \`{title, url, snippet}\` entries.
 - \`web_fetch\` — fetch a single URL and read its content (article extraction, JSON via jq, etc.)
-- \`write\` — write your report file, and ONLY your report file. See "The report file".
+- \`write_report\` — write your single research report file. This is your ONLY way to write a file. See "The report file".
 - \`load_skill\` — load a curated research skill by name. See the section below.
 
 Launch independent tools and gathering spawns in parallel. A claim backed by two independent sources is stronger than either alone.
@@ -126,12 +127,12 @@ These rules apply to every investigation regardless of domain.
 
 ## The report file
 
-Your durable deliverable is a markdown report file. Write it with the \`write\` tool, exactly once, to one of these locations:
+Your durable deliverable is a markdown report file. Write it with the \`write_report\` tool, exactly once, to one of these locations (the tool rejects anything else):
 
-- **Default → \`workspace/research-<slug>-<YYYYMMDD-HHMMSS>.md\`** (the agent's free-write zone).
-- **Fallback → \`public/research-<slug>-<YYYYMMDD-HHMMSS>.md\`** when the caller is UNTRUSTED. Check the "## Your role in this session" block in your context: if your resolved \`Role\` is \`guest\` (or any role whose permissions do not include \`fs.see.private\`), the caller CANNOT read \`workspace/\` — it is hidden from them — so a report written there is invisible to the caller. Write to \`public/\` instead so they can read it back. If a write to \`workspace/\` comes back \`denied by permissions\`, that is the same signal: fall back to \`public/\`.
+- **Default → \`/agent/workspace/research-<slug>.md\`** (the agent's free-write zone).
+- **Fallback → \`/agent/public/research-<slug>.md\`** when the caller is UNTRUSTED. Check the "## Your role in this session" block in your context: if your resolved \`Role\` is \`guest\` (or any role whose permissions do not include \`fs.see.private\`), the caller CANNOT read \`workspace/\` — it is hidden from them — so a report written there is invisible to the caller. Write to \`public/\` instead so they can read it back.
 
-Use \`<slug>\` = a short kebab-case stem from the question. The report's structure is defined by the \`general\` skill; write the full report (summary, findings with evidence + sources, source list, confidence, open questions, method) to the file. The file is the detail; your final message is the pointer.
+Use \`<slug>\` = a short kebab-case stem from the question, lowercase letters/digits/hyphens only; add a timestamp (e.g. \`-20260605-141500\`) to keep it unique, since the tool refuses to overwrite an existing file. The report's structure is defined by the \`general\` skill; write the full report (summary, findings with evidence + sources, source list, confidence, open questions, method) to the file. The file is the detail; your final message is the pointer.
 
 ## Output contract
 
@@ -188,15 +189,20 @@ If none of the listed skills fit the question, load \`general\`. Keep the skill-
     // `default` with a one-time warning — safe degradation. Matches reviewer:
     // research is quality-over-speed work, the deep counterpart to fast scout.
     profile: 'deep',
-    tools: [readTool, grepTool, findTool, lsTool, bashTool, webSearchTool, webFetchTool, writeTool],
-    customTools: [loadSkillTool],
+    // No generic `write`/`edit`: the researcher's only file-write capability is
+    // the enforced `write_report` custom tool below. See ./write-report.ts and
+    // the TODO(#452) note above for why the generic guard boundary is too broad
+    // for this guest-spawnable subagent.
+    tools: [readTool, grepTool, findTool, lsTool, bashTool, webSearchTool, webFetchTool],
+    customTools: [loadSkillTool, createWriteReportTool()],
     payloadSchema: researcherPayloadSchema,
     visibility: 'public',
-    // No `requiresSpecificPermission`: unlike `operator` (arbitrary write/edit +
-    // side-effecting bash), the researcher's only write is a report file fenced
-    // to `workspace/`/`public/` by the `non-workspace-write` guard. That benign,
-    // sandboxed capability does not warrant operator's owner/trusted-only gate;
-    // any caller that can spawn a subagent can spawn the researcher.
+    // No `requiresSpecificPermission`: unlike `operator` (generic write/edit +
+    // side-effecting bash), the researcher's only write goes through the
+    // `write_report` tool, which enforces "one report file under
+    // workspace/public" in code. That narrow, code-enforced capability does not
+    // warrant operator's owner/trusted-only gate; any caller that can spawn a
+    // subagent can spawn the researcher.
     canSpawnSubagents: true,
     timeoutMs: RESEARCHER_SPAWN_TIMEOUT_MS,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -204,8 +210,11 @@ If none of the listed skills fit the question, load \`general\`. Keep the skill-
       // Matches reviewer (512KB): higher than explorer (256KB) because a deep
       // research pass reads many sources; lower than operator (1MB) because the
       // bulk gathering is delegated to scout/explorer, not pulled in directly.
+      // Only builtin tools are listed: custom tools (load_skill, write_report)
+      // surface under runtime-generated `__plugin_*` names that this name-keyed
+      // budget cannot match, so listing them here would be dead config.
       maxTotalBytes: 512_000,
-      toolNames: ['read', 'grep', 'find', 'ls', 'bash', 'web_search', 'web_fetch', 'write', 'load_skill'],
+      toolNames: ['read', 'grep', 'find', 'ls', 'bash', 'web_search', 'web_fetch'],
     },
   }
 }

--- a/src/bundled-plugins/researcher/researcher.ts
+++ b/src/bundled-plugins/researcher/researcher.ts
@@ -62,14 +62,18 @@ The \`write_report\` tool enforces these limits in code: it accepts exactly one 
 
 ## Delegating to keep your context lean
 
-You run on a deliberately expensive model. Reading a pile of search results or a large local tree into YOUR context burns that budget on grunt work. When a slice of the job is bulky-but-mechanical — "sweep the web for every source on X", "pull the relevant passages from these filings", "find where Y is documented locally" — hand it to a cheaper worker with \`spawn_subagent\` and fold the distilled result into your synthesis.
+You run on a deliberately expensive model. Every search result page and every fetched article you pull into YOUR context spends that budget on grunt work and crowds out the thinking only you can do. So your DEFAULT for gathering is to delegate — not just for big sweeps, but for routine fetches too.
 
-- \`scout\` — web gathering. Hand it a focused question; it returns citation-backed findings.
-- \`explorer\` — local gathering. Hand it a filesystem/git/memory question; it returns paths and excerpts.
+**Delegate first; fetch yourself only as a last resort.** Before you reach for \`web_search\`, \`web_fetch\`, \`read\`, or \`grep\`, ask: "could \`scout\` or \`explorer\` get this for me and hand back just the distilled answer?" If yes — which is almost always — spawn the worker with \`spawn_subagent\`. Prefer to fan out **several \`scout\`/\`explorer\` spawns in parallel** (background spawns) at the very start of a gathering round, then fold their condensed results into your synthesis in one pass.
+
+- \`scout\` — web gathering. Hand it any web question, quick or broad ("latest figure for X", "find the primary source for Y", "sweep for every source on Z"); it does the searching and fetching and returns citation-backed findings, so the raw pages never touch your context.
+- \`explorer\` — local gathering. Hand it any filesystem/git/memory question; it returns the paths and excerpts you need without you grepping the tree yourself.
 - The synthesis, the cross-validation, and the confidence call are YOURS. Delegate the gathering, never the conclusion.
 - Each delegated task is self-contained: the worker does not see this conversation. Put everything it needs in the prompt.
 - The chain is depth-limited: a worker you spawn cannot spawn again. Keep delegation one level deep.
 - \`subagent_output\`/\`subagent_cancel\` reach only the tasks YOU spawned. Use background spawns for parallel gathering, then fold the results into your single report.
+
+When IS it right to use your own \`web_search\`/\`web_fetch\`/\`read\`/\`grep\`? Only for the surgical, decisive touch: re-reading one specific passage a worker flagged, resolving a contradiction between two workers' findings, or a single fetch so central you must read it verbatim. If you find yourself doing more than a couple of direct fetches, stop and delegate the rest.
 
 ## Tools
 
@@ -80,12 +84,12 @@ The runtime exposes these tools to you by these EXACT names — call them by nam
 - \`find\` — locate files by name pattern
 - \`ls\` — list a directory's immediate contents
 - \`bash\` — read-only commands ONLY. Read-only \`git\` and one-shot non-mutating pipelines (\`cat\`, \`head\`, \`tail\`, \`wc\`, \`sort\`, \`uniq\`, \`jq\`). Never use bash to write, move, or delete.
-- \`web_search\` — search the public web. Returns ranked \`{title, url, snippet}\` entries.
-- \`web_fetch\` — fetch a single URL and read its content (article extraction, JSON via jq, etc.)
+- \`web_search\` — search the public web. Returns ranked \`{title, url, snippet}\` entries. Prefer delegating web gathering to \`scout\` (see above); use this directly only for a surgical, decisive lookup.
+- \`web_fetch\` — fetch a single URL and read its content (article extraction, JSON via jq, etc.). Same rule: let \`scout\` fetch and distill; reach for this yourself only when you must read one specific page verbatim.
 - \`write_report\` — write your single research report file. This is your ONLY way to write a file. See "The report file".
 - \`load_skill\` — load a curated research skill by name. See the section below.
 
-Launch independent tools and gathering spawns in parallel. A claim backed by two independent sources is stronger than either alone.
+Default to delegating gathering to \`scout\`/\`explorer\` and launch those spawns in parallel; keep your own \`web_search\`/\`web_fetch\`/\`read\`/\`grep\` for the few decisive touches. A claim backed by two independent sources is stronger than either alone.
 
 ## Loading a research skill
 

--- a/src/bundled-plugins/researcher/skills/general.ts
+++ b/src/bundled-plugins/researcher/skills/general.ts
@@ -1,0 +1,105 @@
+import type { LoadableSkill } from '@/plugin'
+
+export const GENERAL_RESEARCH_SKILL_NAME = 'general'
+
+export const GENERAL_RESEARCH_SKILL_DESCRIPTION =
+  'Fallback for any research question that does not fit a specific domain skill: market sizing, historical and document research, scientific literature, competitive and due-diligence analysis, policy and regulation, current events, fact-finding. Apply the universal research discipline without domain-specific shortcuts.'
+
+export const GENERAL_RESEARCH_SKILL_CONTENT = `# general
+
+You have been asked to investigate an open question that does not clearly fit a specific domain skill. Apply this universal research discipline on top of the researcher's neutral output contract (a written report file plus a \`<report>\` block: summary, report file path, confidence, open questions).
+
+General research is the hardest kind because there are no domain shortcuts. Replace shortcuts with discipline.
+
+## Scope the question before you gather
+
+A pile of facts is not research. Before searching:
+
+1. **Restate the question in your own words — to yourself, as a comprehension check.** What is actually being asked? What would a complete answer let the caller do? If you cannot state this after reading the payload, your first finding is that the request is underspecified — say what you'd need to proceed.
+2. **Decompose into sub-questions.** A fuzzy question ("is the market for X growing?") is really several sharp ones (how big is it today? what was it three years ago? who are the largest players? what's driving demand? who says so?). List them before you gather; they become your findings.
+3. **Decide what "answered" looks like per sub-question.** A number with a date and a source? A range with the disagreement surfaced? A timeline? Naming the target shape keeps you from over- or under-gathering.
+
+## Where to gather, and what to trust
+
+Map each sub-question to a source class and a worker:
+
+- **Web / public internet** — delegate bulk sweeps to \`scout\`. Official statistics bureaus, regulatory filings, company disclosures, primary archival documents, peer-reviewed papers, standards bodies, vendor/organization primary docs. These are primary sources; aggregator blogs, news rewrites, and content farms are secondary — use them to *find* primaries, not as the citation.
+- **Local / this agent's filesystem** — delegate to \`explorer\` when the question touches files, prior sessions, memory, config, or git history already on disk.
+- **Direct** — do the small, decisive reads and fetches yourself (the one filing that settles a number, the one paper that defines a term). Keep your own context lean; the bulk goes to the workers.
+
+Launch independent searches in parallel — different phrasings surface different sources.
+
+## Cross-validate every load-bearing claim
+
+A finding the whole answer rests on must be triangulated across **at least two independent sources**. "Independent" is the hard part:
+
+- **Watch for circular citation.** Three blogs all citing the same press release is one source, not three. Trace each claim to its origin before counting it.
+- **Separate causation from correlation.** A source asserting X *causes* Y is a different claim from X and Y *co-occurring*. Report what the source actually establishes.
+- **Flag single-source claims explicitly.** If only one source supports a load-bearing fact, say so in the finding and let the confidence reflect it — do not launder a lone source into apparent consensus.
+- **Distinguish what sources SAY from what you INFER.** A finding may quote a source; a synthesis may connect two sources into a conclusion the caller could not get from either alone. Mark which is which. Inference is valuable, but it is yours, not the source's.
+
+## What to look for
+
+- **Contradiction across sources.** Two credible sources that cannot both be right. Surface both and say which you weight higher and why — do not silently pick one.
+- **Recency and staleness.** A 2019 market figure is not a 2026 market figure. Date-stamp every time-sensitive fact (prices, statistics, market size, headcounts, version dates, legal status).
+- **Scope of a statistic.** "60% of users" — which users, measured how, by whom, over what window? An unscoped number is not yet evidence.
+- **Conflict of interest in the source.** A vendor's own sizing of its market, a study funded by the party it favors. Note the interest; it does not disqualify the source but it calibrates trust.
+- **Unstated assumptions and boundaries.** Where does a claim stop applying? A finding true "in the US" stated as if global is a defect.
+
+## What NOT to do
+
+- **Do not answer a researchable question from training memory.** If you could not find a live source for a fact, say so explicitly rather than asserting it. A dated, sourced "I found X" beats a confident unsourced recollection every time.
+- **Do not invent or guess sources.** Cite only what you (or a worker you spawned) actually retrieved. Never fabricate a URL, a title, or a publication date.
+- **Do not make the decision for the caller.** Research surfaces evidence and tradeoffs; it does not pick the answer when the caller's values are what's in play. "X is cheaper, Y is more reliable, here's the data" — not "you should choose X." Recommendation is the caller's job.
+- **Do not pad with restatement.** Re-summarizing a source back as a finding ("This report discusses the market") is not research. The finding is what the source *establishes*, with its evidence.
+- **Do not overstate confidence.** Speculation dressed up as certainty is the worst failure mode. Low confidence, honestly reported, is useful.
+
+## Confidence calibration
+
+- **high** — Multiple independent primary sources agree; the claim is well-dated and in scope.
+- **medium** — Supported, but thinly (limited sources, secondary sourcing, or some staleness). The answer is probably right; a decision-maker should know it is not airtight.
+- **low** — A single or weak source, genuine source conflict you could not resolve, or significant gaps. Report it as low and name what would raise it.
+
+Low + honest beats high + speculative.
+
+## The report file
+
+Write the durable deliverable as a markdown file (the researcher's base prompt tells you exactly where — \`workspace/\` by default, \`public/\` when the caller is untrusted). Use this skeleton:
+
+\`\`\`markdown
+# Research: <one-line question>
+
+**Question:** <the actual question, restated sharply>
+**Date:** <ISO date of the research pass>
+**Confidence:** <high | medium | low> — <one sentence why>
+
+## Executive summary
+<3-5 sentences: the answer to the actual need, and the one or two facts that justify it.>
+
+## Findings
+### <sub-question 1>
+<answer> — evidence: <quote or figure>. Source: <url or local path, with date>.
+
+### <sub-question 2>
+...
+
+## Sources
+- <url or /absolute/path> — <what it contributed, and its date>
+
+## Open questions
+- <what you could not resolve, and what would resolve it>
+
+## Method
+<one short paragraph: what you searched, what you delegated, what you could not reach.>
+\`\`\`
+
+## Final output
+
+After writing the file, end your turn with the researcher's neutral \`<report>\` block (summary, report file path, confidence, open questions). Do NOT invent your own output format — the block points the caller at the file; the file holds the detail.
+`
+
+export const GENERAL_RESEARCH_SKILL: LoadableSkill = {
+  name: GENERAL_RESEARCH_SKILL_NAME,
+  description: GENERAL_RESEARCH_SKILL_DESCRIPTION,
+  content: GENERAL_RESEARCH_SKILL_CONTENT,
+}

--- a/src/bundled-plugins/researcher/write-report.test.ts
+++ b/src/bundled-plugins/researcher/write-report.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import type { ToolContext } from '@/plugin'
+
+import { createWriteReportTool } from './write-report'
+
+let agentDir: string
+let workspaceDir: string
+let publicDir: string
+let sessionCounter = 0
+
+function makeCtx(): ToolContext {
+  sessionCounter += 1
+  return {
+    signal: undefined,
+    sessionId: `ses_${sessionCounter}_${Math.random().toString(36).slice(2)}`,
+    agentDir,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  }
+}
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(path.join(tmpdir(), 'researcher-report-'))
+  workspaceDir = path.join(agentDir, 'workspace')
+  publicDir = path.join(agentDir, 'public')
+  await mkdir(workspaceDir, { recursive: true })
+  await mkdir(publicDir, { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('write_report tool — happy path', () => {
+  test('writes a valid report under workspace/ and reports the path + bytes', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(workspaceDir, 'research-market-x-20260605-141500.md')
+    const body = '# Research\n\nfindings.'
+
+    const result = await tool.execute({ path: target, content: body }, makeCtx())
+
+    expect(await readFile(target, 'utf8')).toBe(body)
+    expect(result.content[0]?.type).toBe('text')
+    expect((result.details as { path: string }).path).toBe(target)
+    expect((result.details as { bytes: number }).bytes).toBe(body.length)
+  })
+
+  test('writes a valid report under public/ (the untrusted-caller fallback location)', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(publicDir, 'research-history-y.md')
+
+    await tool.execute({ path: target, content: 'report' }, makeCtx())
+
+    expect(await readFile(target, 'utf8')).toBe('report')
+  })
+})
+
+describe('write_report tool — path boundary enforcement', () => {
+  test('rejects a basename that is not research-<slug>.md', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(workspaceDir, 'notes.md')
+    await expect(tool.execute({ path: target, content: 'x' }, makeCtx())).rejects.toThrow(/research-<slug>\.md/)
+  })
+
+  test('rejects an uppercase slug (slug must be lowercase letters/digits/hyphens)', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(workspaceDir, 'research-MarketX.md')
+    await expect(tool.execute({ path: target, content: 'x' }, makeCtx())).rejects.toThrow(/research-<slug>\.md/)
+  })
+
+  test('rejects a nested path under workspace/ (no subdirectories)', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(workspaceDir, 'sub', 'research-x.md')
+    await expect(tool.execute({ path: target, content: 'x' }, makeCtx())).rejects.toThrow(/directly under/)
+  })
+
+  test('rejects a write outside workspace/ and public/ (e.g. the agent root)', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(agentDir, 'research-x.md')
+    await expect(tool.execute({ path: target, content: 'x' }, makeCtx())).rejects.toThrow(/directly under/)
+  })
+
+  test('rejects a traversal whose research-*.md basename passes the regex but whose parent is the agent root', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(workspaceDir, '..', 'research-x.md')
+    await expect(tool.execute({ path: target, content: 'x' }, makeCtx())).rejects.toThrow(/directly under/)
+  })
+})
+
+describe('write_report tool — symlink and overwrite defenses', () => {
+  test('rejects overwriting an existing file (O_EXCL, no clobber)', async () => {
+    const tool = createWriteReportTool()
+    const target = path.join(workspaceDir, 'research-x.md')
+    await writeFile(target, 'original')
+
+    await expect(tool.execute({ path: target, content: 'overwrite' }, makeCtx())).rejects.toThrow(/already exists/)
+    expect(await readFile(target, 'utf8')).toBe('original')
+  })
+
+  test('rejects a final-path symlink instead of following it (O_EXCL on the symlink)', async () => {
+    const tool = createWriteReportTool()
+    const secret = path.join(agentDir, 'secret.txt')
+    await writeFile(secret, 'secret')
+    const link = path.join(workspaceDir, 'research-x.md')
+    await symlink(secret, link)
+
+    await expect(tool.execute({ path: link, content: 'pwned' }, makeCtx())).rejects.toThrow()
+    expect(await readFile(secret, 'utf8')).toBe('secret')
+  })
+
+  test('rejects a report whose parent is a symlink pointing outside the allowed dirs', async () => {
+    const tool = createWriteReportTool()
+    const sensitive = path.join(agentDir, 'sensitive')
+    await mkdir(sensitive, { recursive: true })
+    const link = path.join(workspaceDir, 'escape')
+    await symlink(sensitive, link)
+
+    const target = path.join(link, 'research-x.md')
+    await expect(tool.execute({ path: target, content: 'x' }, makeCtx())).rejects.toThrow(
+      /directly under|resolves outside/,
+    )
+  })
+})
+
+describe('write_report tool — one report per session', () => {
+  test('rejects a second write in the same session', async () => {
+    const tool = createWriteReportTool()
+    const ctx = makeCtx()
+    await tool.execute({ path: path.join(workspaceDir, 'research-a.md'), content: 'a' }, ctx)
+
+    await expect(tool.execute({ path: path.join(workspaceDir, 'research-b.md'), content: 'b' }, ctx)).rejects.toThrow(
+      /already been written/,
+    )
+  })
+
+  test('a failed write does NOT consume the session budget (can retry with a valid path)', async () => {
+    const tool = createWriteReportTool()
+    const ctx = makeCtx()
+    await expect(tool.execute({ path: path.join(workspaceDir, 'bad.md'), content: 'x' }, ctx)).rejects.toThrow()
+
+    // The rejected attempt must not have burned the one-write budget.
+    const ok = await tool.execute({ path: path.join(workspaceDir, 'research-ok.md'), content: 'ok' }, ctx)
+    expect((ok.details as { path: string }).path).toBe(path.join(workspaceDir, 'research-ok.md'))
+  })
+
+  test('different sessions each get their own one-write budget', async () => {
+    const tool = createWriteReportTool()
+    await tool.execute({ path: path.join(workspaceDir, 'research-s1.md'), content: '1' }, makeCtx())
+    // A different session (different sessionId) is unaffected.
+    const ok = await tool.execute({ path: path.join(workspaceDir, 'research-s2.md'), content: '2' }, makeCtx())
+    expect((ok.details as { bytes: number }).bytes).toBe(1)
+  })
+})
+
+describe('write_report tool — strict schema', () => {
+  test('rejects an acknowledgeGuards field (strict schema, no silent bypass channel)', () => {
+    const tool = createWriteReportTool()
+    const parsed = tool.parameters.safeParse({
+      path: path.join(workspaceDir, 'research-x.md'),
+      content: 'x',
+      acknowledgeGuards: { nonWorkspaceWrite: true },
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  test('requires both path and content', () => {
+    const tool = createWriteReportTool()
+    expect(tool.parameters.safeParse({ path: '/x' }).success).toBe(false)
+    expect(tool.parameters.safeParse({ content: 'x' }).success).toBe(false)
+    expect(tool.parameters.safeParse({ path: '/agent/workspace/research-x.md', content: 'x' }).success).toBe(true)
+  })
+})

--- a/src/bundled-plugins/researcher/write-report.ts
+++ b/src/bundled-plugins/researcher/write-report.ts
@@ -1,0 +1,107 @@
+import { constants } from 'node:fs'
+import { type FileHandle, open, realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+import { z } from 'zod'
+
+import { defineTool, type Tool, type ToolContext } from '@/plugin'
+
+export type WriteReportArgs = { path: string; content: string }
+
+const REPORT_BASENAME_RE = /^research-[a-z0-9][a-z0-9-]*\.md$/
+
+// One report per session. The researcher subagent object — and therefore this
+// tool instance — is built ONCE by `createResearcherSubagent()` at plugin
+// registration (src/bundled-plugins/researcher/index.ts) and reused for every
+// spawn (run/index.ts reuses `entry.pluginSubagent.customTools`). A plain
+// closure boolean would leak across concurrent and sequential sessions, so the
+// "already wrote" state is keyed by the per-spawn `ctx.sessionId` instead.
+const writtenBySession = new Map<string, true>()
+
+// A dedicated, enforced report writer for the researcher subagent. The generic
+// `write` tool is NOT given to the researcher: its runtime boundary (the
+// `non-workspace-write` guard) also allowlists IDENTITY.md / SOUL.md / cron.json
+// / typeclaw.json / mounts/ / packages/ and honors `acknowledgeGuards`, so a
+// guest-spawnable subagent holding generic `write` could write far more than one
+// report. This tool moves the boundary INTO a narrow primitive so the contract
+// is enforced in code, not prompt obedience:
+//   - path must resolve to exactly `<agentDir>/{workspace,public}/research-<slug>.md`
+//     (no nested dirs, no other basenames, no other directories),
+//   - the parent dir's realpath must equal the real workspace/public dir, which
+//     blocks `workspace -> /agent/.env` style symlink escapes that a lexical
+//     check would follow,
+//   - the file is created with O_EXCL, so an existing file or a planted
+//     final-path symlink is rejected rather than clobbered or followed,
+//   - a second write in the same session is rejected (one report per spawn),
+//   - the schema is strict, so an `acknowledgeGuards` field is rejected, not
+//     silently stripped.
+export function createWriteReportTool(): Tool<WriteReportArgs> {
+  return defineTool<WriteReportArgs>({
+    description: `Write your single research report as a markdown file. This is your ONLY way to write a file — there is no general write tool. Call it exactly once.
+
+Constraints (enforced; a violation returns an error):
+- \`path\` must be an absolute path of the form \`<agent>/workspace/research-<slug>.md\` or \`<agent>/public/research-<slug>.md\` — directly under workspace/ or public/, no subdirectories, basename \`research-<slug>.md\` where <slug> is lowercase letters, digits and hyphens.
+- The file must not already exist (pick a unique slug, e.g. with a timestamp).
+- You may write the report only once per session.
+
+Write to \`public/\` instead of \`workspace/\` when your resolved role lacks \`fs.see.private\` (a guest caller cannot read \`workspace/\`); otherwise use \`workspace/\`.`,
+    parameters: z.strictObject({
+      path: z
+        .string()
+        .describe('Absolute path: <agent>/workspace/research-<slug>.md or <agent>/public/research-<slug>.md'),
+      content: z.string().describe('The full markdown report body.'),
+    }),
+    async execute(args: WriteReportArgs, ctx: ToolContext) {
+      if (writtenBySession.has(ctx.sessionId)) {
+        throw new Error('A report has already been written for this session. You may write exactly one report.')
+      }
+
+      const target = path.resolve(args.path)
+      const agentDir = path.resolve(ctx.agentDir)
+      const workspaceDir = path.join(agentDir, 'workspace')
+      const publicDir = path.join(agentDir, 'public')
+
+      const parent = path.dirname(target)
+      const base = path.basename(target)
+
+      if (!REPORT_BASENAME_RE.test(base)) {
+        throw new Error(
+          `Report filename must match research-<slug>.md (lowercase slug), got: ${base}. Path: ${target}.`,
+        )
+      }
+      if (parent !== workspaceDir && parent !== publicDir) {
+        throw new Error(
+          `Report must be written directly under ${workspaceDir} or ${publicDir} (no subdirectories), got parent: ${parent}.`,
+        )
+      }
+
+      const [realParent, realWorkspace, realPublic] = await Promise.all([
+        realpath(parent),
+        realpath(workspaceDir),
+        realpath(publicDir),
+      ])
+      if (realParent !== realWorkspace && realParent !== realPublic) {
+        throw new Error(`Report parent directory resolves outside the allowed report directories: ${parent}.`)
+      }
+
+      let handle: FileHandle | undefined
+      try {
+        handle = await open(target, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o644)
+        await handle.writeFile(args.content, 'utf8')
+      } catch (err) {
+        if (err instanceof Error && 'code' in err && err.code === 'EEXIST') {
+          throw new Error(`Report file already exists: ${target}. Choose a unique slug (e.g. add a timestamp).`)
+        }
+        throw err
+      } finally {
+        await handle?.close()
+      }
+
+      writtenBySession.set(ctx.sessionId, true)
+      return {
+        content: [{ type: 'text' as const, text: `Wrote research report: ${target} (${args.content.length} bytes).` }],
+        details: { path: target, bytes: args.content.length },
+      }
+    },
+  })
+}

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -27,6 +27,7 @@ describe('BUNDLED_PLUGINS', () => {
       'explorer',
       'scout',
       'reviewer',
+      'researcher',
       'planner',
       'operator',
     ])

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -7,6 +7,7 @@ import guardPlugin from '@/bundled-plugins/guard'
 import memoryPlugin from '@/bundled-plugins/memory'
 import operatorPlugin from '@/bundled-plugins/operator'
 import plannerPlugin from '@/bundled-plugins/planner'
+import researcherPlugin from '@/bundled-plugins/researcher'
 import reviewerPlugin from '@/bundled-plugins/reviewer'
 import scoutPlugin from '@/bundled-plugins/scout'
 import securityPlugin from '@/bundled-plugins/security'
@@ -60,6 +61,7 @@ export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
   { name: 'explorer', version: undefined, source: '<bundled>', defined: explorerPlugin },
   { name: 'scout', version: undefined, source: '<bundled>', defined: scoutPlugin },
   { name: 'reviewer', version: undefined, source: '<bundled>', defined: reviewerPlugin },
+  { name: 'researcher', version: undefined, source: '<bundled>', defined: researcherPlugin },
   { name: 'planner', version: undefined, source: '<bundled>', defined: plannerPlugin },
   { name: 'operator', version: undefined, source: '<bundled>', defined: operatorPlugin },
 ]


### PR DESCRIPTION
## Background

The bundled subagents cover gathering and review, but there is no **deep research** worker. `scout` is a fast, single-pass, web-only lookup with no delegation and no skills; `explorer` is its local-filesystem twin. `reviewer` is the deep, skill-expandable analyst — but it *judges an artifact*, it does not *investigate an open question*. So a fuzzy, multi-source question ("is the market for X growing, and why?", "what does the archival record say about Y?") has no good home: scout answers it shallowly from whatever a single sweep surfaces, and reviewer is the wrong shape.

This PR adds `researcher` — the deep, model-heavy counterpart to scout, filling the same niche for investigation that reviewer fills for judgment.

## Summary

`researcher` triages a question, decomposes it, **delegates bulk gathering to scout/explorer** to keep its expensive context lean, cross-validates across independent sources, synthesizes a confidence-rated answer, and **writes a durable research report file** as its deliverable.

Key decisions a reviewer would otherwise have to ask about:

- **Why general-purpose, not a code-research helper.** TypeClaw is a general-purpose runtime (market research, document analysis, current events — see the README's personal/team/creator framing). The prompt is deliberately domain-neutral and explicitly says "not a coding assistant; a research analyst who happens to live in a software runtime." A drift-guard test fails if a future edit narrows it to code.

- **Why ship only a `general` skill, not `market-research`/`historical-research`/etc.** Research is *one method* regardless of domain (triage → gather → cross-validate → synthesize → calibrate confidence). reviewer needs multiple skills because *judgment* is domain-specific (a blocker in code vs. prose differ); research craft does not. The `load_skill` machinery is wired exactly like reviewer's, so adding a domain skill later is a one-line append + one file — zero runtime change. Shipping one honest skill beats padding the menu.

- **Why `write` but not `edit`, and why no permission gate.** Unlike the read-only subagents, researcher needs to produce a report file, so it gets `write` — but only `write` (a report is authored once; withholding `edit` shrinks the side-effect surface). It is **not** gated like `operator` (`requiresSpecificPermission`) because operator's power is arbitrary write/edit + side-effecting bash, whereas researcher's only write is a single report file that the bundled `non-workspace-write` guard fences to `workspace/`/`public/`. A sandboxed report is benign, so any caller that can spawn a subagent can use it.

- **Why the workspace→public self-routing.** `workspace/` is a real *read* boundary: it is hidden (`fs.see.private`) from low-privilege roles like `guest`. A subagent inherits the caller's resolved role (`spawnedByRole`) and sees it in its own `## Your role in this session` block. So the prompt instructs: write to `workspace/` by default, but fall back to `public/` when the resolved role lacks `fs.see.private` — otherwise a guest-spawned report lands somewhere the guest caller cannot read. This reinforces the existing convention already stated in the main system prompt.

## What this does NOT do

- Does **not** change scout or explorer — researcher coexists with them as the deep tier, delegating the bulk gathering down.
- Does **not** add a framework-level output parser. Only `reviewer`'s `<review>` block is extracted by code; everything else (including researcher's `<report>`) is prose the parent reads. The block is for the caller's at-a-glance + the report-file pointer, not a machine contract.
- Does **not** ship domain skills beyond `general` (deferred by design, not omission).
- Does **not** touch dispatch, the config schema, or permissions — the one `BUNDLED_PLUGINS` line is all the wiring needed.

## Review notes

- Load-bearing change: the new `src/bundled-plugins/researcher/` (prompt + factory + `general` skill) and the single registration line in `src/run/bundled-plugins.ts`. The existing `SubagentRegistry`, `spawn_subagent` tool, and `SubagentConsumer` pick it up automatically.
- Invariant to verify: the side-effect contract. researcher is the one read-mostly subagent with a writer; the prompt scopes that to exactly one report file, and the `non-workspace-write` guard enforces the zone regardless of prompt. The tool list adds exactly `write` on top of reviewer's read set, with no `edit` — asserted by a drift-guard test.
- Tests mirror scout/reviewer: prompt-phrase drift guards (domain-neutrality, citation discipline, workspace/public routing), the declaration contract (profile/visibility/budget/timeout/no-permission-gate), skill content, and the plugin export shape. The `BUNDLED_PLUGINS` exact-list test is updated to include `researcher`.
- All checks green: typecheck, lint (0 errors), format:check, and the full suite (7413 pass / 0 fail).