### PR TITLE
fix(discord): surface the thread opener when a thread starts from a message

### DIFF
--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -797,6 +797,7 @@ describe('createDiscordHistoryCallback', () => {
       {
         id: 'starter-1',
         channel_id: 'thread-t1',
+        type: 21,
         author: { id: 'system-bot', username: 'Discord', bot: true },
         content: '',
         timestamp: '2026-04-27T00:00:01Z',
@@ -836,6 +837,7 @@ describe('createDiscordHistoryCallback', () => {
       {
         id: 'starter-1',
         channel_id: 'thread-t1',
+        type: 21,
         author: { id: 'system-bot', username: 'Discord', bot: true },
         content: '',
         timestamp: '2026-04-27T00:00:01Z',
@@ -874,6 +876,7 @@ describe('createDiscordHistoryCallback', () => {
       {
         id: 'reply-1',
         channel_id: 'c1',
+        type: 19,
         author: { id: 'u-bob', username: 'bob', bot: false },
         content: 'my reply text',
         timestamp: '2026-04-27T00:00:02Z',
@@ -903,12 +906,68 @@ describe('createDiscordHistoryCallback', () => {
     expect(msg.replyToBotMessageId).toBe('orig-1')
   })
 
+  test('does NOT remap an empty-body non-starter (type 19/23) carrying referenced_message', async () => {
+    // given: an empty-body REPLY (19) and CONTEXT_MENU_COMMAND (23) both carry
+    // referenced_message but are not thread starters; they must stay attributed
+    // to their own author, never the referenced message's
+    const { fn } = fakeFetch([
+      {
+        id: 'reply-1',
+        channel_id: 'c1',
+        type: 19,
+        author: { id: 'u-bob', username: 'bob', bot: false },
+        content: '',
+        timestamp: '2026-04-27T00:00:02Z',
+        message_reference: { message_id: 'orig-1', channel_id: 'c1' },
+        referenced_message: {
+          id: 'orig-1',
+          channel_id: 'c1',
+          author: { id: 'u-alice', username: 'alice', bot: false },
+          content: 'the original',
+          timestamp: '2026-04-27T00:00:01Z',
+        },
+      },
+      {
+        id: 'ctx-1',
+        channel_id: 'c1',
+        type: 23,
+        author: { id: 'u-carol', username: 'carol', bot: false },
+        content: '',
+        timestamp: '2026-04-27T00:00:03Z',
+        message_reference: { message_id: 'orig-1', channel_id: 'c1' },
+        referenced_message: {
+          id: 'orig-1',
+          channel_id: 'c1',
+          author: { id: 'u-alice', username: 'alice', bot: false },
+          content: 'the original',
+          timestamp: '2026-04-27T00:00:01Z',
+        },
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const byId = Object.fromEntries(result.messages.map((m) => [m.externalMessageId, m]))
+    expect(byId['reply-1']!.authorId).toBe('u-bob')
+    expect(byId['reply-1']!.text).toBe('')
+    expect(byId['ctx-1']!.authorId).toBe('u-carol')
+    expect(byId['ctx-1']!.text).toBe('')
+  })
+
   test('leaves an empty-body starter untouched when referenced_message is null (opener deleted)', async () => {
     // given
     const { fn } = fakeFetch([
       {
         id: 'starter-1',
         channel_id: 'thread-t1',
+        type: 21,
         author: { id: 'system-bot', username: 'Discord', bot: true },
         content: '',
         timestamp: '2026-04-27T00:00:01Z',

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -790,6 +790,147 @@ describe('createDiscordHistoryCallback', () => {
     expect(msg.attachments!.map((a) => a.id)).toEqual([1, 2])
   })
 
+  test('resolves a thread-starter (empty body + referenced_message) to the opener author and text', async () => {
+    // given: Discord returns the type-21 starter with empty content/bot author;
+    // the real opener lives only in referenced_message
+    const { fn } = fakeFetch([
+      {
+        id: 'starter-1',
+        channel_id: 'thread-t1',
+        author: { id: 'system-bot', username: 'Discord', bot: true },
+        content: '',
+        timestamp: '2026-04-27T00:00:01Z',
+        message_reference: { message_id: 'opener-1', channel_id: 'parent-c1' },
+        referenced_message: {
+          id: 'opener-1',
+          channel_id: 'parent-c1',
+          author: { id: 'u-human', username: 'alice', global_name: 'Alice', bot: false },
+          content: 'the question that started the thread',
+          timestamp: '2026-04-26T23:59:00Z',
+        },
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'thread-t1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.text).toBe('the question that started the thread')
+    expect(msg.authorId).toBe('u-human')
+    expect(msg.authorName).toBe('Alice')
+    expect(msg.isBot).toBe(false)
+    // keeps the starter's own id/ts so dedup and ordering stay correct
+    expect(msg.externalMessageId).toBe('starter-1')
+    expect(msg.ts).toBe(Date.parse('2026-04-27T00:00:01Z'))
+  })
+
+  test('carries the opener attachments when a thread-starter opener has media but no text', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: 'starter-1',
+        channel_id: 'thread-t1',
+        author: { id: 'system-bot', username: 'Discord', bot: true },
+        content: '',
+        timestamp: '2026-04-27T00:00:01Z',
+        message_reference: { message_id: 'opener-1', channel_id: 'parent-c1' },
+        referenced_message: {
+          id: 'opener-1',
+          channel_id: 'parent-c1',
+          author: { id: 'u-human', username: 'alice', bot: false },
+          content: '',
+          timestamp: '2026-04-26T23:59:00Z',
+          attachments: [{ url: 'https://cdn.example/p.png', filename: 'p.png', content_type: 'image/png' }],
+        },
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'thread-t1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.text).toBe('[Discord attachment #1: file image/png name=p.png]')
+    expect(msg.attachments).toEqual([
+      { id: 1, kind: 'file', ref: 'https://cdn.example/p.png', filename: 'p.png', mimetype: 'image/png' },
+    ])
+    expect(msg.authorId).toBe('u-human')
+  })
+
+  test('keeps the starter own body when it has content (does not override with referenced_message)', async () => {
+    // given: a normal reply (type 19) carries both its own content and a referenced_message
+    const { fn } = fakeFetch([
+      {
+        id: 'reply-1',
+        channel_id: 'c1',
+        author: { id: 'u-bob', username: 'bob', bot: false },
+        content: 'my reply text',
+        timestamp: '2026-04-27T00:00:02Z',
+        message_reference: { message_id: 'orig-1', channel_id: 'c1' },
+        referenced_message: {
+          id: 'orig-1',
+          channel_id: 'c1',
+          author: { id: 'u-alice', username: 'alice', bot: false },
+          content: 'the original',
+          timestamp: '2026-04-27T00:00:01Z',
+        },
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'c1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.text).toBe('my reply text')
+    expect(msg.authorId).toBe('u-bob')
+    expect(msg.replyToBotMessageId).toBe('orig-1')
+  })
+
+  test('leaves an empty-body starter untouched when referenced_message is null (opener deleted)', async () => {
+    // given
+    const { fn } = fakeFetch([
+      {
+        id: 'starter-1',
+        channel_id: 'thread-t1',
+        author: { id: 'system-bot', username: 'Discord', bot: true },
+        content: '',
+        timestamp: '2026-04-27T00:00:01Z',
+        message_reference: { message_id: 'opener-1', channel_id: 'parent-c1' },
+        referenced_message: null,
+      },
+    ])
+    const cb = createDiscordHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'thread-t1', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const msg = result.messages[0]!
+    expect(msg.text).toBe('')
+    expect(msg.authorId).toBe('system-bot')
+  })
+
   test('marks author.bot as isBot', async () => {
     // given
     const { fn } = fakeFetch([

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -499,10 +499,14 @@ type DiscordRawHistoryMessage = {
   author: { id: string; username?: string; global_name?: string | null; bot?: boolean }
   content: string
   timestamp: string
-  message_reference?: { message_id?: string }
+  message_reference?: { message_id?: string; channel_id?: string }
   attachments?: DiscordFile[]
   embeds?: DiscordGatewayEmbed[]
   sticker_items?: DiscordGatewayStickerItem[]
+  // A thread started from an existing message has a type-21 starter whose
+  // top-level content/author are empty; the real opener lives only here.
+  // `null` = referenced message deleted; absent = API did not resolve it.
+  referenced_message?: DiscordRawHistoryMessage | null
 }
 
 // Discord treats threads as separate channels with their own snowflake ids,
@@ -565,7 +569,17 @@ export function createDiscordHistoryCallback(deps: {
 }
 
 function mapDiscordMessage(msg: DiscordRawHistoryMessage, botUserId: string | null): ChannelHistoryMessage {
-  const isBot = msg.author.bot === true || (botUserId !== null && msg.author.id === botUserId)
+  // A thread started from an existing message exposes that opener only as the
+  // type-21 starter's `referenced_message` — the starter itself has empty
+  // content and a bot/system author. Without this, the agent never sees the
+  // message the thread was created from. Take the opener's author and body
+  // (the live inbound path does the equivalent via enrichDiscordMessageReferences),
+  // while keeping the starter's own id/timestamp so dedup against the triggering
+  // message and chronological ordering stay correct.
+  const opener = msg.referenced_message ?? undefined
+  const source = opener !== undefined && bodyOf(msg) === '' ? opener : msg
+
+  const isBot = source.author.bot === true || (botUserId !== null && source.author.id === botUserId)
   const ts = Date.parse(msg.timestamp)
   // The REST history fetch bypasses the inbound classifier, so attachments,
   // embeds, and stickers on already-posted messages (e.g. an image on a thread
@@ -573,23 +587,25 @@ function mapDiscordMessage(msg: DiscordRawHistoryMessage, botUserId: string | nu
   // otherwise they are silently dropped and look_at_channel_attachment can
   // never resolve them. Mirror the classifier's splitInbound: bake placeholders
   // into text and carry the structured attachments so the router can resolve ids.
-  const attachments = describeDiscordMedia(msg)
-  const text =
-    attachments.length === 0
-      ? msg.content
-      : msg.content === ''
-        ? attachments.map(renderPlaceholder).join('\n')
-        : `${msg.content}\n${attachments.map(renderPlaceholder).join('\n')}`
+  const attachments = describeDiscordMedia(source)
+  const text = bodyOf(source)
   return {
     externalMessageId: msg.id,
-    authorId: msg.author.id,
-    authorName: msg.author.global_name ?? msg.author.username ?? msg.author.id,
+    authorId: source.author.id,
+    authorName: source.author.global_name ?? source.author.username ?? source.author.id,
     text,
     ts: Number.isFinite(ts) ? ts : 0,
     isBot,
     replyToBotMessageId: msg.message_reference?.message_id ?? null,
     ...(attachments.length > 0 ? { attachments } : {}),
   }
+}
+
+function bodyOf(msg: DiscordRawHistoryMessage): string {
+  const attachments = describeDiscordMedia(msg)
+  if (attachments.length === 0) return msg.content
+  const placeholders = attachments.map(renderPlaceholder).join('\n')
+  return msg.content === '' ? placeholders : `${msg.content}\n${placeholders}`
 }
 
 function clampLimit(requested: number, max: number): number {

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -493,9 +493,16 @@ function discordFailureForStatus(status: number): MembershipResolverFailure {
   return { kind: 'transient' }
 }
 
+// Discord message type for THREAD_STARTER_MESSAGE — the first message in a
+// thread created from an existing message. `referenced_message` is also
+// populated for type 19 (REPLY) and 23 (CONTEXT_MENU_COMMAND), so the opener
+// fallback below must gate on this type alone, not on the field's presence.
+const DISCORD_MESSAGE_TYPE_THREAD_STARTER = 21
+
 type DiscordRawHistoryMessage = {
   id: string
   channel_id: string
+  type?: number
   author: { id: string; username?: string; global_name?: string | null; bot?: boolean }
   content: string
   timestamp: string
@@ -577,7 +584,8 @@ function mapDiscordMessage(msg: DiscordRawHistoryMessage, botUserId: string | nu
   // while keeping the starter's own id/timestamp so dedup against the triggering
   // message and chronological ordering stay correct.
   const opener = msg.referenced_message ?? undefined
-  const source = opener !== undefined && bodyOf(msg) === '' ? opener : msg
+  const isThreadStarter = msg.type === DISCORD_MESSAGE_TYPE_THREAD_STARTER
+  const source = isThreadStarter && opener !== undefined && bodyOf(msg) === '' ? opener : msg
 
   const isBot = source.author.bot === true || (botUserId !== null && source.author.id === botUserId)
   const ts = Date.parse(msg.timestamp)


### PR DESCRIPTION
## Background

When a Discord thread is created **from an existing message**, the agent could not see that originating first message — the premise of the entire thread was missing from its context.

Root cause is a Discord API shape, not a logic slip. Per the Discord docs (resources/message, message types), a thread started from a message gets a type-21 `THREAD_STARTER_MESSAGE` as its first message, and "these messages will never have content, embeds, or attachments, mainly just the `message_reference` and `referenced_message` fields." The real opener is carried inline in `referenced_message`; the starter's own top-level `content`/`author` are empty/system.

`createDiscordHistoryCallback`'s `mapDiscordMessage` mapped only the starter's empty top-level fields. So when the agent is later @-mentioned in the thread and cold-starts, `router.prefetchChannelContext` seeds the context buffer with a blank message — the agent never sees what the thread was created from. The live inbound path already handled this via `enrichDiscordMessageReferences`; the history-fetch path did not. This PR closes that asymmetry.

## Summary

`mapDiscordMessage` now falls back to `referenced_message` for author and body whenever the message has no body of its own, while preserving the starter's own `id` and `timestamp`.

- Why keep the starter's id/ts, not the opener's? The router dedups prefetched history against the triggering message by `externalMessageId` and orders by `ts`. Using the opener's id/ts would break dedup and could reorder the first slot. We swap in only the content-bearing fields (author, text, attachments).
- Why inline `referenced_message` and not a separate `GET /channels/{parent}/messages/{thread_id}` fetch? Discord already resolves and inlines it for type 19/21/23 — no extra round-trip per cold start, and no need to discover the parent channel id.
- Deleted opener: `referenced_message: null` means the source was deleted; the starter is left untouched (renders empty, as before).

The body-derivation logic (content + attachment placeholders) is extracted into a `bodyOf` helper so the "has its own body?" check and the final mapping share one definition.

## What this does NOT do

- Does not change the live gateway path (`handleMessageCreate` / classifier). The in-thread starter that arrives live with content is still routed as before; only the REST history-fetch mapping changed.
- Does not touch the thread-vs-channel prefetch keying (Discord threads still key with `thread: null`, thread id in `chat`).
- Does not add a fallback REST fetch for the rare case where Discord omits `referenced_message` entirely (field absent rather than null). Left as-is to avoid a per-cold-start round trip; can follow up if observed.

## Review notes

- Load-bearing change: `discord-bot.ts` `mapDiscordMessage` — the `source = opener && bodyOf(msg) === '' ? opener : msg` selection. Invariant: id/ts always come from the starter (`msg`); author/text/attachments come from `source`.
- New tests cover starter→opener resolution (text + author + id/ts preserved), opener media-only body, a normal type-19 reply keeping its own body (no override), and deleted-opener (`null`) left untouched.
- Local checks all pass: typecheck, lint (0 errors), format:check, test (7382 pass).