### PR TITLE
feat(reviewer): expand domain-neutral review skills beyond code

### DIFF
--- a/src/bundled-plugins/reviewer/reviewer.test.ts
+++ b/src/bundled-plugins/reviewer/reviewer.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from 'bun:test'
 
 import { REVIEWER_SKILLS, REVIEWER_SYSTEM_PROMPT, createReviewerSubagent, reviewerPayloadSchema } from './reviewer'
 import { CODE_REVIEW_SKILL } from './skills/code-review'
+import { DATA_REVIEW_SKILL } from './skills/data-review'
+import { DOC_REVIEW_SKILL } from './skills/doc-review'
 import { GENERAL_REVIEW_SKILL } from './skills/general'
+import { PLAN_REVIEW_SKILL } from './skills/plan-review'
+import { SECURITY_AUDIT_SKILL } from './skills/security-audit'
+import { WRITING_REVIEW_SKILL } from './skills/writing-review'
 
 describe('reviewer subagent — load-bearing prompt phrases', () => {
   test.each(
@@ -152,22 +157,35 @@ describe('reviewer subagent declaration', () => {
     // names surface so the model can pick from the prompt-visible enum.
     expect(loadSkill.description).toContain('`code-review`')
     expect(loadSkill.description).toContain('`general`')
+    expect(loadSkill.description).toContain('`security-audit`')
   })
 
-  test('load_skill parameter schema accepts the shipped skill names and rejects unknown ones', () => {
+  test('load_skill parameter schema accepts every shipped skill name and rejects unknown ones', () => {
     const sub = createReviewerSubagent()
     const loadSkill = sub.customTools?.[0]
     if (loadSkill === undefined) throw new Error('load_skill tool missing')
-    expect(loadSkill.parameters.safeParse({ name: 'code-review' }).success).toBe(true)
-    expect(loadSkill.parameters.safeParse({ name: 'general' }).success).toBe(true)
-    expect(loadSkill.parameters.safeParse({ name: 'plan-review' }).success).toBe(false)
+    for (const skill of REVIEWER_SKILLS) {
+      expect(loadSkill.parameters.safeParse({ name: skill.name }).success).toBe(true)
+    }
+    expect(loadSkill.parameters.safeParse({ name: 'not-a-real-skill' }).success).toBe(false)
     expect(loadSkill.parameters.safeParse({ name: '' }).success).toBe(false)
   })
 
-  test('REVIEWER_SKILLS includes code-review and general (initial ship set)', () => {
+  test('REVIEWER_SKILLS ships the domain-neutral review set with general last as the fallback', () => {
     const names = REVIEWER_SKILLS.map((s) => s.name)
     expect(names).toContain('code-review')
+    expect(names).toContain('doc-review')
+    expect(names).toContain('plan-review')
+    expect(names).toContain('security-audit')
+    expect(names).toContain('writing-review')
+    expect(names).toContain('data-review')
     expect(names).toContain('general')
+    expect(names.at(-1)).toBe('general')
+  })
+
+  test('REVIEWER_SKILLS has no duplicate names (load_skill enum stays unambiguous)', () => {
+    const names = REVIEWER_SKILLS.map((s) => s.name)
+    expect(new Set(names).size).toBe(names.length)
   })
 
   test('declares a tool-result budget so a runaway subagent cannot exhaust parent context', () => {
@@ -285,9 +303,72 @@ describe('reviewer skill content', () => {
     expect(lower).toContain('hidden assumptions')
   })
 
+  test('doc-review skill teaches doc-type fit and runnable-sample craft (drift guard)', () => {
+    expect(DOC_REVIEW_SKILL.name).toBe('doc-review')
+    expect(DOC_REVIEW_SKILL.description.length).toBeGreaterThan(0)
+    const lower = DOC_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('diátaxis')
+    expect(lower).toContain('prerequisite')
+    expect(lower).toContain('code sample')
+  })
+
+  test('plan-review skill teaches reversibility and measurable success (drift guard)', () => {
+    expect(PLAN_REVIEW_SKILL.name).toBe('plan-review')
+    expect(PLAN_REVIEW_SKILL.description.length).toBeGreaterThan(0)
+    const lower = PLAN_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('one-way')
+    expect(lower).toContain('success criteria')
+    expect(lower).toContain('alternatives considered')
+  })
+
+  test('plan-review skill enforces bias-free maturity-neutral review (the load-bearing first-review rule)', () => {
+    // Without this, the reviewer guesses whether a plan is draft-vs-final and
+    // either blocker-spams a sketch or rubber-stamps a flawed proposal. The
+    // rule is to review the idea as written and fold missing context into ONE
+    // finding, not N blockers.
+    const lower = PLAN_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('do not guess its maturity')
+    expect(lower).toContain('missing context is missing context, not a defect')
+  })
+
+  test('security-audit skill teaches the input-to-sink threat lens with OWASP/CWE anchors (drift guard)', () => {
+    expect(SECURITY_AUDIT_SKILL.name).toBe('security-audit')
+    expect(SECURITY_AUDIT_SKILL.description.length).toBeGreaterThan(0)
+    const lower = SECURITY_AUDIT_SKILL.content.toLowerCase()
+    expect(lower).toContain('injection')
+    expect(lower).toContain('ssrf')
+    expect(lower).toContain('owasp')
+    expect(lower).toContain('exploitab')
+  })
+
+  test('writing-review skill teaches editorial craft beyond grammar (drift guard)', () => {
+    expect(WRITING_REVIEW_SKILL.name).toBe('writing-review')
+    expect(WRITING_REVIEW_SKILL.description.length).toBeGreaterThan(0)
+    const lower = WRITING_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('lede')
+    expect(lower).toContain('audience')
+    expect(lower).toContain('unsupported claim')
+  })
+
+  test('data-review skill covers both the shape (schema/migration) and the data itself (drift guard)', () => {
+    expect(DATA_REVIEW_SKILL.name).toBe('data-review')
+    expect(DATA_REVIEW_SKILL.description.length).toBeGreaterThan(0)
+    const lower = DATA_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('migration')
+    expect(lower).toContain('referential integrity')
+    expect(lower).toContain('schema-invalid')
+    expect(lower).toContain('not null')
+  })
+
   test('every shipped skill references the reviewer neutral output contract (so domain skills compose with the universal shape)', () => {
     for (const skill of REVIEWER_SKILLS) {
       expect(skill.content).toContain('<review>')
+    }
+  })
+
+  test('every shipped skill closes by deferring to the neutral output block (no domain skill invents its own format)', () => {
+    for (const skill of REVIEWER_SKILLS) {
+      expect(skill.content).toContain('Do NOT invent your own output format')
     }
   })
 })

--- a/src/bundled-plugins/reviewer/reviewer.test.ts
+++ b/src/bundled-plugins/reviewer/reviewer.test.ts
@@ -303,15 +303,18 @@ describe('reviewer skill content', () => {
     expect(lower).toContain('hidden assumptions')
   })
 
-  test('doc-review skill covers any document, not only technical docs (drift guard against re-narrowing)', () => {
-    // The skill must lead with universal doc craft so policy/process/onboarding/
-    // help-center/legal docs fit, with the Diátaxis + runnable-sample lens scoped
-    // to the technical-docs sub-case rather than framing the whole skill.
+  test('doc-review leads with universal craft and does not prime a document-type taxonomy (anti-bias guard)', () => {
+    // Enumerating kinds (README/policy/onboarding/...) in the description or
+    // opening biases the reviewer toward the named kinds and against the
+    // unnamed ones — the same enumeration bias plan-review forbids. The skill
+    // must route by function ("a document written to inform or instruct") and
+    // tell the reviewer not to assume a kind, then carry it with universal
+    // craft.
     expect(DOC_REVIEW_SKILL.name).toBe('doc-review')
-    expect(DOC_REVIEW_SKILL.description.length).toBeGreaterThan(0)
+    expect(DOC_REVIEW_SKILL.description).toContain('inform or instruct')
     const lower = DOC_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('do not assume a kind')
     expect(lower).toContain('audience fit')
-    expect(lower).toContain('policy')
     expect(lower).toContain('examples and claims')
     expect(lower).toContain('prerequisite')
   })

--- a/src/bundled-plugins/reviewer/reviewer.test.ts
+++ b/src/bundled-plugins/reviewer/reviewer.test.ts
@@ -303,13 +303,24 @@ describe('reviewer skill content', () => {
     expect(lower).toContain('hidden assumptions')
   })
 
-  test('doc-review skill teaches doc-type fit and runnable-sample craft (drift guard)', () => {
+  test('doc-review skill covers any document, not only technical docs (drift guard against re-narrowing)', () => {
+    // The skill must lead with universal doc craft so policy/process/onboarding/
+    // help-center/legal docs fit, with the Diátaxis + runnable-sample lens scoped
+    // to the technical-docs sub-case rather than framing the whole skill.
     expect(DOC_REVIEW_SKILL.name).toBe('doc-review')
     expect(DOC_REVIEW_SKILL.description.length).toBeGreaterThan(0)
     const lower = DOC_REVIEW_SKILL.content.toLowerCase()
-    expect(lower).toContain('diátaxis')
+    expect(lower).toContain('audience fit')
+    expect(lower).toContain('policy')
+    expect(lower).toContain('examples and claims')
     expect(lower).toContain('prerequisite')
-    expect(lower).toContain('code sample')
+  })
+
+  test('doc-review keeps the technical-doc specialization as a scoped sub-case (Diátaxis + runnable samples)', () => {
+    const lower = DOC_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('diátaxis')
+    expect(lower).toContain('when the target is technical documentation')
+    expect(lower).toContain('do not force a policy')
   })
 
   test('plan-review skill teaches reversibility and measurable success (drift guard)', () => {

--- a/src/bundled-plugins/reviewer/reviewer.ts
+++ b/src/bundled-plugins/reviewer/reviewer.ts
@@ -14,17 +14,31 @@ import {
 } from '@/plugin'
 
 import { CODE_REVIEW_SKILL } from './skills/code-review'
+import { DATA_REVIEW_SKILL } from './skills/data-review'
+import { DOC_REVIEW_SKILL } from './skills/doc-review'
 import { GENERAL_REVIEW_SKILL } from './skills/general'
+import { PLAN_REVIEW_SKILL } from './skills/plan-review'
+import { SECURITY_AUDIT_SKILL } from './skills/security-audit'
+import { WRITING_REVIEW_SKILL } from './skills/writing-review'
 
 // The curated set of review-domain skills the reviewer can load on
 // demand via its `load_skill` tool. Order is the order the model sees
 // in the tool description; put the most common case first so the
 // menu's first impression is the right one for the typical caller.
+// `general` stays last: it is the fallback the model reaches for only
+// when no domain skill fits.
 //
-// Ship list is intentionally small for the first release. Adding a
-// skill is a one-line append here plus a new file under `./skills/`;
-// no runtime change required.
-export const REVIEWER_SKILLS: readonly LoadableSkill[] = [CODE_REVIEW_SKILL, GENERAL_REVIEW_SKILL]
+// Adding a skill is a one-line append here plus a new file under
+// `./skills/`; no runtime change required.
+export const REVIEWER_SKILLS: readonly LoadableSkill[] = [
+  CODE_REVIEW_SKILL,
+  DOC_REVIEW_SKILL,
+  PLAN_REVIEW_SKILL,
+  SECURITY_AUDIT_SKILL,
+  WRITING_REVIEW_SKILL,
+  DATA_REVIEW_SKILL,
+  GENERAL_REVIEW_SKILL,
+]
 
 // Without a ceiling, a reviewer whose `session.prompt` stalls mid-turn (model
 // wedges after a tool error, never emits a terminal message) leaves `completion`
@@ -137,9 +151,11 @@ End every response with a single \`<review>\` block. Use this exact structure:
 <verdict>approve | request-changes | comment</verdict>
 </review>
 
-\`approve\` = no blockers; concerns are minor or already addressed.
-\`request-changes\` = at least one blocker, or a load-bearing concern that needs an answer before this lands.
-\`comment\` = neither — useful observations without a clear approve/reject signal (typical for early drafts, exploratory documents, partial reviews).
+These three tokens are the universal verdict vocabulary — they apply whether the target is a code change, a plan, a document, or a dataset. Keep the tokens exactly; the loaded skill tells you what each one means for its domain.
+
+\`approve\` = no blockers; the target is sound and any concerns are minor or already addressed.
+\`request-changes\` = at least one blocker, or a load-bearing concern that needs an answer before the target should be accepted, shipped, or executed.
+\`comment\` = neither — useful observations that do not resolve to a clear accept/reject signal (typical for early drafts, exploratory documents, partial reviews).
 
 ## Rules
 

--- a/src/bundled-plugins/reviewer/skills/data-review.ts
+++ b/src/bundled-plugins/reviewer/skills/data-review.ts
@@ -1,0 +1,77 @@
+import type { LoadableSkill } from '@/plugin'
+
+export const DATA_REVIEW_SKILL_NAME = 'data-review'
+
+export const DATA_REVIEW_SKILL_DESCRIPTION =
+  'Review structured data and its shape: a database schema or migration, a dataset, a query result, a spreadsheet, a data contract. Covers constraints, nullability, types, indexing, migration safety, and dataset integrity (duplicates, referential integrity, mixed types, aggregate errors).'
+
+export const DATA_REVIEW_SKILL_CONTENT = `# data-review
+
+You have been asked to review structured data — a database schema, a migration, a dataset, a query result, a spreadsheet, or a data contract. Two kinds of target live here and they need different lenses: **the shape** (schema/migration/contract — the rules data must follow) and **the data itself** (a dataset/file — whether the values obey those rules). Identify which you are reviewing, then apply the matching section below on top of the reviewer's neutral output contract.
+
+## How to acquire the target
+
+- **A migration or schema file** — \`read\` it; \`grep\` the surrounding migrations for the current state of the table being altered, because migration safety depends on what already exists.
+- **A dataset / CSV / JSONL** — \`read\` a representative slice (head and a sample of the middle), not just the first rows. Defects hide past the part that looks clean.
+- **A data contract (dbt model, ODCS YAML, JSON Schema)** — \`read\` it and confirm every field declares a type and a nullability/required flag.
+- **A query result in the payload** — read it carefully; quote the offending rows as evidence.
+
+## Reviewing the shape: schema, migration, contract
+
+The shape's job is to make invalid states unrepresentable. A finding here is a rule that is missing, wrong, or unsafe to apply.
+
+1. **Constraints that should exist but do not.** A business-key column (email, SKU, order id) with no \`UNIQUE\`. A required column left nullable. A relationship enforced only in application code with no \`FOREIGN KEY\`. A bounded value (\`status\`, \`price >= 0\`) with no \`CHECK\` or enum. Each missing constraint is a way for schema-invalid data to enter and survive.
+2. **Wrong types.** Money in \`FLOAT\`/\`DOUBLE\` instead of fixed-point \`NUMERIC\` — guarantees rounding drift. Dates or timestamps stored as strings. \`timestamp\` without time zone where UTC-aware (\`timestamptz\`) is meant. A numeric type with no precision/scale that silently coerces.
+3. **Nullability mistakes.** A nullable foreign key for a relationship that is logically required; a NOT NULL on a column the data sometimes genuinely lacks (forcing sentinel values like empty string that confuse "missing" with "blank").
+4. **Indexing.** A foreign key with no supporting index (JOINs and cascade deletes table-scan). A frequently-filtered column with no index. Over-indexing a write-heavy table.
+5. **Migration safety.** This is where a schema change becomes an outage:
+   - Adding a \`NOT NULL\` column to a populated table with no default or backfill — the migration aborts on existing rows. The safe form is additive-then-tighten: add nullable, backfill, set NOT NULL in a later step.
+   - A destructive single-step change (drop/rename a column live) instead of expand-then-contract.
+   - \`CREATE INDEX\` without \`CONCURRENTLY\` on a live table — locks writes for the duration.
+   - A migration with no reverse/rollback path.
+6. **Contract completeness.** For a data contract: every field declares a type and required-flag, the primary key is declared, references resolve to real fields, quality thresholds are realistic, and breaking changes (column removal/rename/type change) are versioned, not silent.
+
+## Reviewing the data itself: dataset, file, spreadsheet
+
+Here the rules may be implicit; your job is to find values that violate what the data clearly intends. Borrow the runtime's own vocabulary: data that fails its intended shape is **schema-invalid**, and a strict consumer is **fail-closed** — it drops or rejects bad rows rather than silently half-accepting them, so a defect that looks cosmetic can erase real records.
+
+1. **Mixed types in one column.** A single column carrying integers, currency-formatted strings ("$1,200"), and blanks. A consumer expecting a number is schema-invalid against these rows; a fail-closed parser drops them silently and the totals are quietly wrong.
+2. **Completeness.** Required fields that are NULL or blank. Watch the empty-string-vs-NULL confusion — they are not the same "missing" and treating them alike corrupts counts.
+3. **Uniqueness.** Duplicate rows, or duplicate business keys where the data plainly intends one row per key.
+4. **Referential integrity.** Orphan rows pointing at parent keys that do not exist; this is a foreign-key violation the file format did not enforce.
+5. **Aggregate errors.** The classic, high-impact dataset bug: a grand-total whose range includes the subtotal rows (double-counting), or an average/sum whose range silently omits rows that belong in it. State which rows are wrongly included or excluded — this is the Reinhart-Rogoff class of defect and it is almost always a blocker.
+6. **Identifier corruption from auto-formatting.** Spreadsheet date/number coercion mangling identifiers (gene names like \`SEPT2\` becoming \`2-Sep\`, leading zeros stripped from zip codes / IDs). Flag any identifier column stored in a general/auto format.
+7. **Distribution and freshness anomalies.** Out-of-range values (negative ages, future timestamps), a sudden volume drop or spike, data older than its freshness expectation.
+8. **PII / secret leakage.** Emails, phone numbers, tokens, or keys appearing in columns not marked sensitive, or stored in plaintext where the surrounding data is classified.
+
+## What NOT to find
+
+- **Formatter / tooling territory.** SQL keyword casing, trailing commas in a migration, CSV quoting style a parser handles — not your concern.
+- **Settled project conventions the target follows.** If the codebase uses \`snake_case\` columns, UUIDv7 keys, or \`.passthrough()\` to tolerate extra columns by design, matching that is not a finding; only deviation is.
+- **Cosmetic dataset quirks with no consumer impact.** A harmless trailing blank line, column order that no consumer depends on. If nothing breaks, do not raise it.
+- **Restating the schema or data.** "This table stores users" / "this column has numbers" is not a finding.
+- **Generic "add validation".** Without naming the specific column and the specific invalid state it admits, "needs more validation" is noise.
+
+## Severity hints specific to data
+
+- **blocker** — Money in floating-point, a migration that aborts or locks production, a missing constraint that admits corrupt rows, an aggregate that double-counts or silently drops rows, identifier corruption, PII in plaintext. Data defects are often blockers because they are silent and compounding.
+- **concern** — A missing index that will degrade as the table grows, a nullable FK that should be required, a freshness/volume anomaly that needs explanation, schema drift from the declared contract.
+- **nit** — A naming inconsistency, a missing audit column, a tolerable-but-suboptimal type. Optional.
+- **praise** — A constraint set that makes an invalid state genuinely unrepresentable, a migration written safely as expand-then-contract, a contract whose quality thresholds are realistic. Rare.
+
+## Verdict mapping
+
+- **approve** — The shape is sound or the data is clean; any issues are nits.
+- **request-changes** — At least one blocker: a corrupting type choice, an unsafe migration, an aggregate error, a constraint gap that admits bad data.
+- **comment** — Useful observations without a clean accept/reject. Common for a partial dataset audit or an early-stage schema sketch.
+
+## Final output
+
+Return findings inside the reviewer's neutral \`<review>\` block. Do NOT invent your own output format.
+`
+
+export const DATA_REVIEW_SKILL: LoadableSkill = {
+  name: DATA_REVIEW_SKILL_NAME,
+  description: DATA_REVIEW_SKILL_DESCRIPTION,
+  content: DATA_REVIEW_SKILL_CONTENT,
+}

--- a/src/bundled-plugins/reviewer/skills/doc-review.ts
+++ b/src/bundled-plugins/reviewer/skills/doc-review.ts
@@ -1,0 +1,71 @@
+import type { LoadableSkill } from '@/plugin'
+
+export const DOC_REVIEW_SKILL_NAME = 'doc-review'
+
+export const DOC_REVIEW_SKILL_DESCRIPTION =
+  'Review technical documentation: a README, a guide, an API reference, a tutorial, a how-to. Covers doc-type fit, prerequisites, runnable examples, cross-references, version drift, terminology consistency, and accessibility.'
+
+export const DOC_REVIEW_SKILL_CONTENT = `# doc-review
+
+You have been asked to review technical documentation. Apply this guidance on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
+
+## How to acquire the target
+
+- **A file path** — \`read\` it. \`ls\` the docs directory to see how this page fits the larger set; a page is reviewed in the context of its neighbors.
+- **A URL** — \`web_fetch\` it. If it is a private docs site the fetch cannot reach, say so in \`<summary>\` and review what the payload provided.
+- **A PR that touches docs** — \`gh pr diff <n>\` for the changed pages; \`read\` the surrounding sections the diff did not touch, because a doc edit is judged against the whole page's flow, not the hunk alone.
+- **A doc set / directory** — \`ls\` and \`grep\` for the navigation/index file; a finding about findability needs the table of contents, not just one page.
+
+## Identify the doc type first
+
+Most documentation defects are really one defect: the page is the wrong *type* for what the reader needs. Before looking for anything else, classify the target against the four Diátaxis modes, because the right content for one is wrong for another:
+
+- **Tutorial** — learning-oriented. A guaranteed-to-succeed lesson for a newcomer. Concrete, linear, no detours.
+- **How-to guide** — task-oriented. Steps to achieve one stated goal for someone who already knows the basics.
+- **Reference** — information-oriented. Dry, complete, accurate description of the API/CLI/config. No teaching.
+- **Explanation** — understanding-oriented. The "why" and the trade-offs. No step-by-step.
+
+A page that mixes modes — a tutorial padded with architecture explanation, a reference that drifts into opinion — fails the reader who came for one of them. Naming the type-mismatch is usually the highest-value finding you can make.
+
+## What to look for
+
+1. **Doc-type bleed.** Conceptual explanation injected into a first-run tutorial; a how-to guide that stops to teach theory; a reference page editorializing. State which mode the page is and which content belongs elsewhere.
+2. **Missing prerequisites.** The page assumes a tool, a version, an account, or a prior step that is never stated before the reader needs it. A first \`install\` step that silently requires Docker running is a prerequisite gap.
+3. **Untested or broken code samples.** Examples that will not run as written: deprecated flags, wrong import paths, a command that references a removed subcommand. When you can, trace the sample against the real CLI/API surface in the repo and cite the contradiction.
+4. **Broken or stale cross-references.** Links that 404, "see the section below" pointing at a section that no longer exists, references to a renamed page. Internal anchors that drifted after a heading was retitled.
+5. **Version drift.** Text, flags, screenshots, or output that describe an older release than the one the docs ship with. Cite the current value (from the repo, the CLI help, the changelog) against the stale one.
+6. **Terminology inconsistency.** The same concept called three names across the page ("workspace" / "project" / "folder") with no statement that they are the same. Pick the canonical term and flag the drift.
+7. **Accessibility defects.** Images with no alt text, heading levels that skip (h1 → h3), meaning carried by color alone, link text that is bare "click here". These are real findings, not nits, when they block a reader using assistive tech.
+8. **Findability.** A page that cannot be reached from the index, a missing "next step" at the end of a tutorial, a reference with no anchor for the field a reader will search for.
+
+## What NOT to find
+
+- **Formatter / linter territory.** Trailing whitespace, line length, fenced-block language tags, Markdown table alignment. Assume a docs linter ran. Do not raise it.
+- **House-style preferences the page follows.** If the project writes in second person, or uses sentence-case headings, or prefers "e.g." over "for example", and the page matches, that is not a finding. Only the deviation is.
+- **Restating the doc as a finding.** "This page documents the start command" is not a review.
+- **Rewriting for taste.** A sentence you would have phrased differently but that reads clearly for the intended audience is not a finding. Clarity is the bar, not your preferred cadence.
+- **Generic "add more examples".** Without naming the specific step or field that is under-documented, "could use more examples" is noise.
+
+## Severity hints specific to docs
+
+- **blocker** — A code sample that fails for everyone who runs it. A prerequisite gap that strands the reader at step one. A reference value that is factually wrong (wrong default, wrong type) and will cause the reader to misconfigure the system. Doc-type bleed so severe the page does not serve the reader it is for.
+- **concern** — A stale flag or version reference that still mostly works but will mislead. A missing prerequisite for a later (not first) step. Terminology drift that will confuse a newcomer. An accessibility defect that degrades but does not block.
+- **nit** — A single awkward sentence, a missing "next step" link, a minor terminology wobble in an aside. Optional.
+- **praise** — A tutorial that genuinely lands a beginner at a working state, a reference table that is complete and scannable, an explanation that makes a hard concept click. Rare.
+
+## Verdict mapping
+
+- **approve** — Publishable. The page serves its reader; any gaps are nits.
+- **request-changes** — At least one blocker: a sample that fails, a factually wrong reference, a prerequisite gap that strands the reader.
+- **comment** — Useful observations without a clean accept/reject. Common for an early docs draft or a partial review of a large doc set.
+
+## Final output
+
+Return findings inside the reviewer's neutral \`<review>\` block. Do NOT invent your own output format.
+`
+
+export const DOC_REVIEW_SKILL: LoadableSkill = {
+  name: DOC_REVIEW_SKILL_NAME,
+  description: DOC_REVIEW_SKILL_DESCRIPTION,
+  content: DOC_REVIEW_SKILL_CONTENT,
+}

--- a/src/bundled-plugins/reviewer/skills/doc-review.ts
+++ b/src/bundled-plugins/reviewer/skills/doc-review.ts
@@ -3,11 +3,11 @@ import type { LoadableSkill } from '@/plugin'
 export const DOC_REVIEW_SKILL_NAME = 'doc-review'
 
 export const DOC_REVIEW_SKILL_DESCRIPTION =
-  'Review any document for its reader: technical docs (README, API reference, tutorial), but also policy, process, onboarding, help-center, legal-lite, specs, and knowledge-base pages. Covers purpose/audience fit, completeness, accuracy of examples and claims, navigability, staleness, terminology consistency, and accessibility.'
+  'Review a document written to inform or instruct a reader. Covers purpose and audience fit, completeness for the stated job, accuracy of examples and claims, navigability, staleness, terminology consistency, and accessibility — for any kind of document, with a scoped lens for technical docs when the target is one.'
 
 export const DOC_REVIEW_SKILL_CONTENT = `# doc-review
 
-You have been asked to review a document. "Document" is broad on purpose: a README or API reference, but equally a policy, a runbook, an onboarding guide, a help-center article, a spec, a contract summary, a knowledge-base page. The craft below is universal; the technical-docs section near the end is one specialization you apply only when the target is developer documentation. Apply all of this on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
+You have been asked to review a document — anything written to inform or instruct a reader. Do not assume a kind. The craft below is universal and applies whatever the document turns out to be; the technical-docs section near the end is one specialization you apply only when the target is in fact developer documentation. Read the target, let it tell you what it is, and review it on its own terms. Apply all of this on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
 
 ## How to acquire the target
 

--- a/src/bundled-plugins/reviewer/skills/doc-review.ts
+++ b/src/bundled-plugins/reviewer/skills/doc-review.ts
@@ -3,61 +3,69 @@ import type { LoadableSkill } from '@/plugin'
 export const DOC_REVIEW_SKILL_NAME = 'doc-review'
 
 export const DOC_REVIEW_SKILL_DESCRIPTION =
-  'Review technical documentation: a README, a guide, an API reference, a tutorial, a how-to. Covers doc-type fit, prerequisites, runnable examples, cross-references, version drift, terminology consistency, and accessibility.'
+  'Review any document for its reader: technical docs (README, API reference, tutorial), but also policy, process, onboarding, help-center, legal-lite, specs, and knowledge-base pages. Covers purpose/audience fit, completeness, accuracy of examples and claims, navigability, staleness, terminology consistency, and accessibility.'
 
 export const DOC_REVIEW_SKILL_CONTENT = `# doc-review
 
-You have been asked to review technical documentation. Apply this guidance on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
+You have been asked to review a document. "Document" is broad on purpose: a README or API reference, but equally a policy, a runbook, an onboarding guide, a help-center article, a spec, a contract summary, a knowledge-base page. The craft below is universal; the technical-docs section near the end is one specialization you apply only when the target is developer documentation. Apply all of this on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
 
 ## How to acquire the target
 
-- **A file path** — \`read\` it. \`ls\` the docs directory to see how this page fits the larger set; a page is reviewed in the context of its neighbors.
-- **A URL** — \`web_fetch\` it. If it is a private docs site the fetch cannot reach, say so in \`<summary>\` and review what the payload provided.
-- **A PR that touches docs** — \`gh pr diff <n>\` for the changed pages; \`read\` the surrounding sections the diff did not touch, because a doc edit is judged against the whole page's flow, not the hunk alone.
-- **A doc set / directory** — \`ls\` and \`grep\` for the navigation/index file; a finding about findability needs the table of contents, not just one page.
+- **A file path** — \`read\` it. \`ls\` the surrounding directory to see how this page fits the larger set; a document is reviewed in the context of the set it belongs to.
+- **A URL** — \`web_fetch\` it. If it is a private site the fetch cannot reach, say so in \`<summary>\` and review what the payload provided.
+- **A PR or diff that touches docs** — \`gh pr diff <n>\` for the changed pages; \`read\` the surrounding sections the diff did not touch, because a doc edit is judged against the whole page's flow, not the hunk alone.
+- **A doc set / directory** — \`ls\` and \`grep\` for the navigation or index file; a finding about findability needs the table of contents, not just one page.
+- **Verify external claims.** If the document cites a law, a standard, a price, an SLA, a statistic, or a linked source, check it with \`web_search\`/\`web_fetch\` before letting it stand.
 
-## Identify the doc type first
+## State the document's job before reading for defects
 
-Most documentation defects are really one defect: the page is the wrong *type* for what the reader needs. Before looking for anything else, classify the target against the four Diátaxis modes, because the right content for one is wrong for another:
+Every document exists to let a specific reader do or understand a specific thing. Before looking for problems, answer two questions and hold them while you read: **Who is this for?** and **What should they be able to do or know after reading it?** Most documentation defects are a mismatch between the page and the answer to one of those. A finding is strongest when it names which reader the document fails and why. This is your private grounding — keep the restatement out of \`<summary>\`.
+
+## What to look for
+
+These apply to any document:
+
+1. **Purpose / audience fit.** The document is pitched at the wrong reader: jargon and unexplained acronyms for a lay audience, or hand-holding for an expert one; a policy written for lawyers handed to new hires. Name the mismatch.
+2. **Completeness for the stated job.** A missing step, an undocumented edge case, a process that stops before the reader's actual goal, a policy that does not say what happens on violation. The gap is a finding when it leaves the reader unable to finish what the document promised.
+3. **Accuracy of examples and claims.** Anything the document asserts as fact must be correct: a quoted figure, a referenced rule or standard, a worked example, a screenshot, a sample. A wrong example or an unsupported load-bearing claim is a real defect regardless of document type — for code docs this means samples that do not run; for a policy it means a cited regulation that says something else.
+4. **Missing prerequisites or assumptions.** The document assumes access, a prior step, a role, a tool, or background the reader does not have and is never told to get. State the assumption the reader cannot meet.
+5. **Navigability / findability.** A page unreachable from the index, no clear next step where the reader needs one, no anchor for the thing a reader will search for, a long document with no structure to scan. Hard-to-navigate is a defect when it blocks the reader from reaching the part they need.
+6. **Broken or stale cross-references.** Links that 404, "see the section below" pointing at a section that no longer exists, references to a renamed page or a superseded policy version.
+7. **Staleness.** Content that describes an older state than the one in force: an old release's flags, a deprecated process, a price or date that has moved, a screenshot of a UI that changed. Cite the current value against the stale one.
+8. **Terminology / consistency.** The same concept called several names with no statement they are the same ("workspace" / "project" / "folder"; "member" / "user" / "seat"). Pick the canonical term and flag the drift.
+9. **Accessibility.** Images with no alt text, heading levels that skip (h1 → h3), meaning carried by color alone, bare "click here" link text. Real findings, not nits, when they block a reader using assistive tech.
+
+## When the target is technical documentation
+
+Developer docs have a failure mode worth naming explicitly: the page is the wrong *type* for what the reader needs. When reviewing technical docs, classify the page against the four Diátaxis modes, because the right content for one is wrong for another:
 
 - **Tutorial** — learning-oriented. A guaranteed-to-succeed lesson for a newcomer. Concrete, linear, no detours.
 - **How-to guide** — task-oriented. Steps to achieve one stated goal for someone who already knows the basics.
 - **Reference** — information-oriented. Dry, complete, accurate description of the API/CLI/config. No teaching.
 - **Explanation** — understanding-oriented. The "why" and the trade-offs. No step-by-step.
 
-A page that mixes modes — a tutorial padded with architecture explanation, a reference that drifts into opinion — fails the reader who came for one of them. Naming the type-mismatch is usually the highest-value finding you can make.
-
-## What to look for
-
-1. **Doc-type bleed.** Conceptual explanation injected into a first-run tutorial; a how-to guide that stops to teach theory; a reference page editorializing. State which mode the page is and which content belongs elsewhere.
-2. **Missing prerequisites.** The page assumes a tool, a version, an account, or a prior step that is never stated before the reader needs it. A first \`install\` step that silently requires Docker running is a prerequisite gap.
-3. **Untested or broken code samples.** Examples that will not run as written: deprecated flags, wrong import paths, a command that references a removed subcommand. When you can, trace the sample against the real CLI/API surface in the repo and cite the contradiction.
-4. **Broken or stale cross-references.** Links that 404, "see the section below" pointing at a section that no longer exists, references to a renamed page. Internal anchors that drifted after a heading was retitled.
-5. **Version drift.** Text, flags, screenshots, or output that describe an older release than the one the docs ship with. Cite the current value (from the repo, the CLI help, the changelog) against the stale one.
-6. **Terminology inconsistency.** The same concept called three names across the page ("workspace" / "project" / "folder") with no statement that they are the same. Pick the canonical term and flag the drift.
-7. **Accessibility defects.** Images with no alt text, heading levels that skip (h1 → h3), meaning carried by color alone, link text that is bare "click here". These are real findings, not nits, when they block a reader using assistive tech.
-8. **Findability.** A page that cannot be reached from the index, a missing "next step" at the end of a tutorial, a reference with no anchor for the field a reader will search for.
+A page that mixes modes — a tutorial padded with architecture explanation, a reference that drifts into opinion — fails the reader who came for one of them. For technical docs, also hold examples to a higher bar: a code sample is a *claim that it runs*, so trace it against the real CLI/API surface (\`read\` the source, \`gh pr diff\`, the changelog) and cite any sample that uses a removed flag, a wrong import, or a renamed subcommand. This Diátaxis lens and runnable-sample check do NOT apply to non-technical documents — do not force a policy or an onboarding page into a "tutorial vs reference" frame.
 
 ## What NOT to find
 
-- **Formatter / linter territory.** Trailing whitespace, line length, fenced-block language tags, Markdown table alignment. Assume a docs linter ran. Do not raise it.
-- **House-style preferences the page follows.** If the project writes in second person, or uses sentence-case headings, or prefers "e.g." over "for example", and the page matches, that is not a finding. Only the deviation is.
-- **Restating the doc as a finding.** "This page documents the start command" is not a review.
-- **Rewriting for taste.** A sentence you would have phrased differently but that reads clearly for the intended audience is not a finding. Clarity is the bar, not your preferred cadence.
-- **Generic "add more examples".** Without naming the specific step or field that is under-documented, "could use more examples" is noise.
+- **Formatter / linter territory.** Trailing whitespace, line length, fenced-block language tags, table alignment. Assume a docs linter ran.
+- **House-style the page follows.** Second person, sentence-case headings, "e.g." vs "for example" — if the document is consistent with its house style, that is not a finding. Only the deviation is.
+- **Restating the document as a finding.** "This page documents the start command" / "this policy covers expenses" is not a review.
+- **Rewriting for taste.** A sentence you would have phrased differently but that reads clearly for its reader is not a finding. Clarity is the bar, not your preferred cadence.
+- **Generic "add more examples" / "make it clearer".** Without naming the specific step, field, or passage that is under-documented or unclear, it is noise.
 
 ## Severity hints specific to docs
 
-- **blocker** — A code sample that fails for everyone who runs it. A prerequisite gap that strands the reader at step one. A reference value that is factually wrong (wrong default, wrong type) and will cause the reader to misconfigure the system. Doc-type bleed so severe the page does not serve the reader it is for.
-- **concern** — A stale flag or version reference that still mostly works but will mislead. A missing prerequisite for a later (not first) step. Terminology drift that will confuse a newcomer. An accessibility defect that degrades but does not block.
+- **blocker** — An example or claim that is factually wrong and will lead the reader astray (a sample that fails for everyone, a cited rule that says the opposite). A prerequisite gap that strands the reader at step one. An audience mismatch so severe the intended reader cannot use the document at all.
+- **concern** — A stale reference that still mostly works but will mislead, a missing prerequisite for a later step, a completeness gap that blocks an edge case, terminology drift that will confuse a newcomer, an accessibility defect that degrades but does not block.
 - **nit** — A single awkward sentence, a missing "next step" link, a minor terminology wobble in an aside. Optional.
-- **praise** — A tutorial that genuinely lands a beginner at a working state, a reference table that is complete and scannable, an explanation that makes a hard concept click. Rare.
+- **praise** — A document that genuinely lands its reader: a tutorial that reaches a working state, a policy that is unambiguous on the hard case, an explanation that makes a difficult concept click. Rare.
 
 ## Verdict mapping
 
-- **approve** — Publishable. The page serves its reader; any gaps are nits.
-- **request-changes** — At least one blocker: a sample that fails, a factually wrong reference, a prerequisite gap that strands the reader.
-- **comment** — Useful observations without a clean accept/reject. Common for an early docs draft or a partial review of a large doc set.
+- **approve** — Publishable. The document serves its reader; any gaps are nits.
+- **request-changes** — At least one blocker: a wrong example or claim, an audience mismatch that defeats the purpose, a prerequisite gap that strands the reader.
+- **comment** — Useful observations without a clean accept/reject. Common for an early draft or a partial review of a large doc set.
 
 ## Final output
 

--- a/src/bundled-plugins/reviewer/skills/plan-review.ts
+++ b/src/bundled-plugins/reviewer/skills/plan-review.ts
@@ -1,0 +1,64 @@
+import type { LoadableSkill } from '@/plugin'
+
+export const PLAN_REVIEW_SKILL_NAME = 'plan-review'
+
+export const PLAN_REVIEW_SKILL_DESCRIPTION =
+  'Review a plan, RFC, design doc, PRFAQ, or task breakdown. Covers problem framing, measurable success criteria, alternatives considered, reversibility (one-way vs two-way doors), risk and dependency analysis, and RFC-2119 requirement-keyword discipline.'
+
+export const PLAN_REVIEW_SKILL_CONTENT = `# plan-review
+
+You have been asked to review a plan — an RFC, a design doc, a PRFAQ, a roadmap, a todo breakdown, or any document that proposes a course of action. Apply this guidance on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
+
+## How to acquire the target
+
+- **A file path** — \`read\` it. \`ls\` the directory for a template or sibling RFCs that establish the expected shape; deviation from an established plan template is itself worth noting.
+- **A URL or doc** — \`web_fetch\` it. If it is a private doc the fetch cannot reach, say so in \`<summary>\` and review what the payload provided.
+- **A PR that adds a design doc** — \`gh pr diff <n>\`, then \`read\` the linked issue or prior discussion if one is referenced; a plan is judged partly on whether it answers the question that prompted it.
+- **An inline plan in the payload** — read it carefully and quote from it when forming evidence.
+
+## What to look for
+
+1. **Problem framing.** Does the plan state the problem before the solution? Who feels the pain, and what does "solved" look like for them? A plan that opens with the solution and never names the problem cannot be evaluated — that gap is the first finding.
+2. **Measurable success criteria.** Goals must be checkable. "Improve performance" is unverifiable; "P95 latency under 200ms on the checkout path" is. Flag every load-bearing goal that has no metric, threshold, or acceptance condition.
+3. **Alternatives considered.** A serious proposal names the approaches it rejected and why. A plan that presents one path as if it were the only path has hidden its reasoning — ask for the alternatives, because the rejected ones are where the real trade-off lives.
+4. **Reversibility — one-way vs two-way doors.** Identify the decisions that are hard or impossible to undo: public API contracts, on-disk schema changes, data migrations, anything external parties will depend on. A plan that makes a one-way-door decision without acknowledging it as irreversible has under-weighted its own risk. This is frequently the single most important finding.
+5. **Risk and dependency analysis.** External dependencies, blocking teams, legal or compliance constraints, the order in which steps must land. A plan whose step 3 silently depends on a team that has not agreed is carrying unpriced risk.
+6. **Scope boundaries.** What is explicitly in scope and out of scope? A plan that conflates several unrelated changes, or whose title promises A but whose body spends half its bytes on B, has a scope problem — either the scope is wrong or the framing is.
+7. **Requirement-keyword discipline (RFC-2119).** If the plan uses MUST / SHOULD / MAY, are they used in their precise senses, or interchangeably? A "SHOULD" that is actually a "MUST" will be implemented as optional and bite later. Flag normative keywords whose strength does not match their intent.
+8. **Rollback / recovery.** For a plan that changes a running system, how is it undone if it fails, and how long does that take? Absence of a rollback story is a finding when the change is risky enough to need one.
+
+## Review every plan as a first review — do not guess its maturity
+
+You are almost never told whether a plan is a first draft, a final RFC, or something between. Do NOT guess, and do NOT let the absence of that signal bias you — neither toward over-blocking (treating a sketch as a contract) nor toward over-softening (treating a serious proposal as throwaway). Review what is actually on the page, every time, as if you are seeing it fresh with no prior history. This neutrality is the point: a plan's verdict should come from the plan, not from an assumption about its stage you had to invent.
+
+In practice:
+
+- **Judge the idea, not the polish.** A plan can be early and still sound, or finished and still wrong. Your findings target whether the *approach* holds up — internal consistency, reversibility, measurable success, acknowledged alternatives — not how complete the document looks.
+- **Missing context is missing context, not a defect.** A plan reviewed cold will omit things a real org would supply: who owns it, the deadline, the budget, the constraint that rules out option B. Do NOT raise each absence as its own blocker — that is exactly the generic-review noise the contract forbids. Fold what you would genuinely need into a single \`comment\`-level finding: "To judge this as ready-to-execute I'd need the owning team, a success metric, and the rollback constraint." One finding, not ten.
+- **An unfilled section is only a finding if its absence breaks the idea.** A plan with no rollback section is not automatically blocked — unless the plan's viability *depends* on a rollback that may be impossible, in which case the gap is the finding and you say why. Empty-by-stage is not the same as flawed. Test each gap: does this missing piece change whether the approach is sound, or is it just not written yet?
+- **Real flaws are still blockers, regardless of stage.** Reviewing cold does not mean reviewing soft. An internal contradiction, a one-way-door decision the plan does not acknowledge as irreversible, a success criterion that is unmeasurable *as written*, or a recommendation with no alternatives considered — these are flaws in the idea itself. Raise them at full severity whether the plan is draft or final.
+- **State your footing in \`<summary>\`, once.** Open with one clause naming what you could and could not assess: "Reviewed on its own terms; no constraints or finality were stated, so the verdict reflects the idea as written, not its fit to an unstated bar." This keeps the review honest about the context it lacked instead of pretending to a certainty it does not have — without guessing at a maturity label. Keep this to one clause; it is grounding, not a process narration.
+
+## Severity hints specific to plans
+
+- **blocker** — A load-bearing flaw in the approach: an internal contradiction, a one-way-door decision treated as reversible, a goal that cannot be verified as written, a plan whose central mechanism cannot work. The kind of problem that makes executing the plan a mistake.
+- **concern** — A weakness that should be answered before commitment: a missing alternative that undercuts the recommendation, an unpriced dependency, a scope ambiguity that will mislead implementers, a normative keyword whose strength is wrong.
+- **nit** — A small clarity or structure issue, a section that could be tightened, a stage-normal gap worth a one-line mention.
+- **praise** — A non-obvious risk surfaced and handled, a reversibility analysis done honestly, a success metric that is genuinely measurable. Rare.
+
+## Verdict mapping
+
+- **approve** — The idea holds and the gaps are stage-normal. No load-bearing flaw in the approach.
+- **request-changes** — At least one blocker: a flaw in the approach that needs an answer before this should be committed to.
+- **comment** — Useful observations that do not resolve to a clean accept/reject. Common when reviewing a plan cold, where your job is to surface what is unverified rather than to gate it.
+
+## Final output
+
+Return findings inside the reviewer's neutral \`<review>\` block. Do NOT invent your own output format.
+`
+
+export const PLAN_REVIEW_SKILL: LoadableSkill = {
+  name: PLAN_REVIEW_SKILL_NAME,
+  description: PLAN_REVIEW_SKILL_DESCRIPTION,
+  content: PLAN_REVIEW_SKILL_CONTENT,
+}

--- a/src/bundled-plugins/reviewer/skills/security-audit.ts
+++ b/src/bundled-plugins/reviewer/skills/security-audit.ts
@@ -1,0 +1,70 @@
+import type { LoadableSkill } from '@/plugin'
+
+export const SECURITY_AUDIT_SKILL_NAME = 'security-audit'
+
+export const SECURITY_AUDIT_SKILL_DESCRIPTION =
+  'Audit code or configuration through a threat-model lens: injection, broken access control, SSRF, insecure deserialization, secrets exposure, path traversal, TOCTOU, and cryptographic failures. Maps findings to OWASP/CWE and reasons about exploitability, not style.'
+
+export const SECURITY_AUDIT_SKILL_CONTENT = `# security-audit
+
+You have been asked to audit a target for security defects. This is not a general code review with a security flavor — it is an adversarial read. Assume an attacker controls every input the target does not prove it controls, and ask what they can make happen. Apply this on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
+
+## How to acquire the target
+
+- **A PR or diff** — \`gh pr diff <n>\` for the change; then \`read\` the surrounding code, because a vulnerability often lives in the interaction between the changed line and an untouched caller.
+- **A file or module** — \`read\` it, then \`grep\` for the entry points: where does external input enter, and where does it reach a sink (a shell, a query, a file path, a deserializer, an outbound request)?
+- **Config / infra** — \`read\` the manifest, Dockerfile, CI workflow, or IaC. Misconfiguration is a vulnerability class of its own (default credentials, over-broad permissions, secrets in plaintext).
+- **Verify with primary sources.** When you cite a class (OWASP A03, CWE-89, an RFC), confirm the current definition with \`web_search\`/\`web_fetch\` before asserting it. Cite by identifier.
+
+## Trace input to sink
+
+A security finding is a *path*: untrusted input → (insufficient validation) → dangerous sink. Name both ends and the missing control between them. A finding that only says "this looks unsafe" without tracing the path is not actionable. For each entry point, follow the data: where does it go, what touches it on the way, and what does it reach?
+
+## What to look for
+
+Prioritize by exploitability, roughly in this order:
+
+1. **Injection (CWE-78/89/79/90).** Untrusted input concatenated into a shell command, SQL/NoSQL query, LDAP filter, or HTML sink without parameterization or escaping. OS-command injection via string-interpolated \`bash\` is the highest-value catch.
+2. **Broken access control (OWASP A01).** Missing authorization checks, IDOR (a user can read/write another user's object by changing an ID), endpoints that trust a client-supplied role, path-based bypass.
+3. **SSRF (OWASP A10 / CWE-918).** The server fetches a user-supplied URL with no allowlist, letting an attacker reach internal services or cloud metadata endpoints (\`169.254.169.254\`). Flag any outbound request whose destination is attacker-influenced.
+4. **Insecure deserialization / data-integrity (OWASP A08).** Untrusted bytes fed to a deserializer that can instantiate arbitrary types; unsigned updates; a pipeline that trusts input it did not verify.
+5. **Cryptographic failures (OWASP A02).** Secrets at rest in plaintext, weak or broken hashes (MD5/SHA1 for passwords), missing TLS on sensitive transit, hardcoded keys, predictable tokens.
+6. **Secrets exposure.** API keys, tokens, or passwords in logs, error messages, committed config, or echoed in responses. A stack trace returned to the client is an information-disclosure finding.
+7. **Path traversal (CWE-22).** User input builds a filesystem path without canonicalization, allowing \`../\` escape out of the intended directory.
+8. **TOCTOU (CWE-367).** A check (file exists, permission ok) separated from the use by a window an attacker can exploit to swap the target.
+9. **Authentication weaknesses (OWASP A07).** No brute-force protection, session fixation, missing re-auth on sensitive actions, tokens that never expire.
+
+## Severity via exploitability (CVSS-style reasoning)
+
+Anchor severity to *what an attacker gains and how easily*, not to how the code reads:
+
+- **blocker** — Exploitable now with serious impact: remote code execution, auth bypass, injection reachable from an unauthenticated path, secret disclosure. CVSS roughly High/Critical (7.0+). Do not ship.
+- **concern** — A real weakness that requires a precondition (authenticated attacker, user interaction, an unlikely-but-possible input) or whose impact is bounded. CVSS roughly Medium (4.0–6.9).
+- **nit** — Defense-in-depth hardening with no demonstrated exploit path: a missing security header, a slightly-too-broad scope that is not currently reachable. Optional.
+- **praise** — A non-obvious control done right: input correctly parameterized at a tricky sink, an allowlist that closes an SSRF that an obvious implementation would have left open. Rare.
+
+For blocker and concern findings, state the attack in one sentence: who, with what access, can make what happen. That sentence is what separates a security finding from a style opinion.
+
+## What NOT to find
+
+- **Style and formatting.** Linter territory. A security audit is not the place for naming or spacing.
+- **Performance without a security angle.** A slow loop is not a security finding unless it is a denial-of-service vector you can demonstrate.
+- **Theoretical issues with no reachable path.** "This *could* be unsafe if someone later calls it with attacker input" — only raise it if such a caller exists or is plausible. Name the path or drop the finding; un-anchored "could be exploited" is the security flavor of generic review noise.
+- **Re-flagging controls that are present.** If validation, escaping, or an allowlist already guards the sink, that is not a finding — and if it is done well, it may be a \`praise\`.
+
+## Verdict mapping
+
+- **approve** — No exploitable finding. Any issues are defense-in-depth nits.
+- **request-changes** — At least one blocker, or a concern serious enough to answer before this lands.
+- **comment** — Observations without a clear gate: a partial audit of a large surface, or hardening advice on code that has no demonstrated vulnerability.
+
+## Final output
+
+Return findings inside the reviewer's neutral \`<review>\` block. Do NOT invent your own output format.
+`
+
+export const SECURITY_AUDIT_SKILL: LoadableSkill = {
+  name: SECURITY_AUDIT_SKILL_NAME,
+  description: SECURITY_AUDIT_SKILL_DESCRIPTION,
+  content: SECURITY_AUDIT_SKILL_CONTENT,
+}

--- a/src/bundled-plugins/reviewer/skills/writing-review.ts
+++ b/src/bundled-plugins/reviewer/skills/writing-review.ts
@@ -1,0 +1,63 @@
+import type { LoadableSkill } from '@/plugin'
+
+export const WRITING_REVIEW_SKILL_NAME = 'writing-review'
+
+export const WRITING_REVIEW_SKILL_DESCRIPTION =
+  'Review prose for an audience: a blog post, an announcement, marketing copy, an email, an essay. Covers clarity, audience fit, lede placement, claim-evidence support, tone consistency, and jargon — the editorial craft beyond grammar.'
+
+export const WRITING_REVIEW_SKILL_CONTENT = `# writing-review
+
+You have been asked to review a piece of writing meant for a reader — a blog post, a launch announcement, marketing copy, an email, an essay. You are an editor, not a proofreader: grammar and spelling are the floor, not the job. Apply this on top of the reviewer's neutral output contract (severity-tagged findings, evidence quotes, suggestions, verdict).
+
+## How to acquire the target
+
+- **A file or inline text** — \`read\` it (or read the payload) in full before forming any finding. Prose is judged as a whole; a paragraph that works alone can still break the piece's flow.
+- **A URL** — \`web_fetch\` it. If a published page, also note whether the lede survives the reader's first screen.
+- **Verify factual claims.** If the piece asserts a number, a comparison, a "first/fastest/only", or a cited source, check it with \`web_search\`/\`web_fetch\` before letting it stand. An unsupported superlative is the most common defect in persuasive writing.
+
+## Read for the reader, not for yourself
+
+Before looking for defects, answer two questions and hold them while you read: **Who is this for?** and **What should they do or believe after reading?** Most writing failures are a mismatch between the prose and the answer to one of those. A finding is strong when it names which reader the passage fails and why.
+
+## What to look for
+
+1. **Buried lede.** The most important thing — the news, the point, the ask — should arrive early (inverted pyramid). If the reader must wade through throat-clearing to find why the piece exists, the lede is buried. Name where the real lede currently sits.
+2. **Audience mismatch.** Jargon and unexplained acronyms for a general audience; over-explanation for an expert one. The register should match who is reading.
+3. **Unsupported claims.** Every load-bearing assertion needs backing. "The fastest runtime", "customers love it", "the industry standard" — without a benchmark, a quote, or a source, these are assertions the reader has no reason to believe. Flag the claim and say what evidence it needs.
+4. **Tone inconsistency.** A piece that starts formal and drifts casual, or whose brand voice wobbles, loses the reader's trust. Point at the shift.
+5. **Clarity / muddy thinking.** Sentences the reader must re-read: ambiguous pronouns, a clause whose subject is lost, a paragraph that says three things and lands none. Unclear prose is usually unclear thinking — point at the sentence.
+6. **Undefined jargon.** A term or acronym used before it is defined, with no gloss and no link. First use should orient the reader.
+7. **Terminology drift.** The same thing named three ways ("dashboard" / "console" / "control panel") confuses; pick one and flag the rest.
+8. **Structure and flow.** Ideas that do not build, missing transitions, a piece that ends without telling the reader what to do next when it clearly wants them to act.
+
+## What NOT to find
+
+- **Taste dressed as error.** A sentence you would have phrased differently but that reads clearly and serves the audience is not a finding. "I prefer shorter paragraphs" is not a defect.
+- **Valid style/dialect choices.** British vs American spelling, the Oxford comma, em-dash vs parentheses — when the piece is internally consistent and the house style permits it, leave it.
+- **Grammar a proofreader owns.** A genuine grammar error is fair, but do not pad the review with comma surgery; your value is editorial, not mechanical.
+- **Restating the piece.** "This post announces the new feature" is not a review.
+- **Generic "make it clearer".** Without pointing at the specific passage that is unclear, "could be clearer" is noise.
+
+## Severity hints specific to writing
+
+- **blocker** — A factual claim that is verifiably wrong, an audience mismatch so severe the intended reader cannot use the piece, a lede so buried the piece fails its purpose. The kind of problem that means this should not publish as-is.
+- **concern** — An unsupported load-bearing claim, a tone break that undercuts trust, a structural gap that loses the reader partway. Should fix before publishing.
+- **nit** — A single muddy sentence, a minor terminology wobble, a missing transition. Optional; the author can decline.
+- **praise** — A passage that makes a complex thing plain, a lede that lands, a claim backed cleanly with evidence. Rare; call out writing that earns the reader's trust.
+
+## Verdict mapping
+
+- **approve** — Ready for its reader. Any issues are nits the author can take or leave.
+- **request-changes** — At least one blocker: a wrong claim, a buried lede that defeats the purpose, an audience mismatch.
+- **comment** — Useful observations without a clean accept/reject. Common for an early draft where the author wants direction more than a gate.
+
+## Final output
+
+Return findings inside the reviewer's neutral \`<review>\` block. Do NOT invent your own output format.
+`
+
+export const WRITING_REVIEW_SKILL: LoadableSkill = {
+  name: WRITING_REVIEW_SKILL_NAME,
+  description: WRITING_REVIEW_SKILL_DESCRIPTION,
+  content: WRITING_REVIEW_SKILL_CONTENT,
+}


### PR DESCRIPTION
## Background

The `reviewer` subagent's base prompt is already domain-neutral — it says it reviews "a code change, a written plan, a design document, a docs update, a draft argument, or anything else." But it shipped with only two loadable skills, `code-review` and `general`, so in practice it was a code reviewer with a generic fallback. TypeClaw is a general-purpose agent runtime, not a coding agent, and the reviewer should be able to bring real craft to any artifact a caller hands it.

The skill-loading spine was already the right abstraction (domain craft lives in `skills/*.ts`, selected on demand via `load_skill`); it was just under-populated. This PR exercises that spine.

## Summary

Adds five domain skills and neutralizes the one place the base prompt still leaked code-review shape.

- **doc-review** — Diátaxis doc-type fit, runnable samples, prerequisites, version drift, accessibility.
- **plan-review** — reversibility (one-way vs two-way doors), measurable success criteria, alternatives considered, RFC-2119 keyword discipline. Carries a deliberate **"review every plan as a first review"** rule: the reviewer never guesses a plan's maturity (draft vs final) and never lets absent context bias it — it judges the idea as written and folds missing context into *one* finding rather than blocker-spamming a sketch or rubber-stamping a flawed proposal. This bias-prevention framing was the explicit design ask.
- **security-audit** — input-to-sink threat lens with OWASP/CWE anchors and exploitability-based (CVSS-style) severity, distinct from a code review's shallow security pass.
- **writing-review** — editorial craft (lede placement, audience fit, claim-evidence support, tone) beyond grammar.
- **data-review** — covers both *the shape* (schema/migration/contract safety) and *the data itself* (duplicates, referential integrity, mixed-type columns, aggregate double-counting), reusing the runtime's own `schema-invalid` / `fail-closed` vocabulary so it reads as native.

**Why keep the literal verdict tokens?** The base prompt's verdict gloss was reworded to read across domains (a plan, a dataset, a doc), but `approve | request-changes | comment` stay verbatim — the GitHub adapter maps `approve→APPROVE` and the `code-review` re-review rule depends on those exact strings. Neutralizing the *gloss* without touching the *tokens* keeps every existing consumer working.

**Why one `data-review` and not a `schema-review`/`data-review` split?** The two sub-domains share acquisition and verdict logic; one skill with two clearly-marked sections (mirroring how `code-review` holds both correctness and hygiene) is simpler and splits cleanly later if usage warrants.

## What this does NOT do

- No rename of `reviewer` → `analyst`; the name stays.
- No change to the generic subagent machinery — `REVIEW_BLOCK_RE`, the `<review>` extractor, and the `GITHUB_REVIEW_NUDGE` completion carve-out are untouched (one universal contract, so they remain correct).
- No new `typeclaw.json` config surface.
- No new subagent archetypes (a `synthesizer`/`monitor` were considered and intentionally deferred — they don't fit the read-only-verdict shape).

## Review notes

- Load-bearing invariant: every shipped skill must reference the neutral `<review>` contract and defer its output format to it. Two loop-based drift-guards in `reviewer.test.ts` enforce this across all seven skills, so a future skill that invents its own format fails CI.
- `REVIEWER_SKILLS` ordering is the `load_skill` menu order; `general` is pinned last as the fallback (asserted by test).
- The `plan-review` "first review" rule is guarded by a dedicated test on its two load-bearing phrases, so the bias-prevention intent can't silently erode.
- Each skill follows the existing `skills/*.ts` template (same heading sequence, same export shape) — no structural novelty to review, just content.
- Commits are split: skills+registration first, drift-guard tests second.