### PR TITLE
fix(github): make PR approval idempotent to stop duplicate approves

### DIFF
--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -31,12 +31,35 @@ describe('approve idempotency guard', () => {
 
   test('blocks a second APPROVE while the first is still pending (concurrent sessions, same container)', async () => {
     const g = makeGuard({})
-    // First APPROVE reserves the PR but has not completed (tool.after not called yet).
+    // given: a first APPROVE that reserved the PR but has not completed (tool.after not called yet)
     const first = await g.guard({ callId: 'a1', workspace: WS, prNumber: 7, verdict: 'APPROVE' })
     expect(first).toBeNull()
     const second = await g.guard({ callId: 'a2', workspace: WS, prNumber: 7, verdict: 'APPROVE' })
     expect(second).not.toBeNull()
     expect(second?.block).toBe(true)
+  })
+
+  test('two APPROVE calls racing through guard() before either awaits the remote check yield exactly one allow', async () => {
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => {
+        await gate
+        return { ok: true, alreadyApproved: false }
+      },
+    })
+    const both = Promise.all([
+      g.guard({ callId: 'a1', workspace: WS, prNumber: 21, verdict: 'APPROVE' }),
+      g.guard({ callId: 'a2', workspace: WS, prNumber: 21, verdict: 'APPROVE' }),
+    ])
+    release()
+    const [r1, r2] = await both
+    const allowed = [r1, r2].filter((r) => r === null)
+    const blocked = [r1, r2].filter((r) => r !== null)
+    expect(allowed).toHaveLength(1)
+    expect(blocked).toHaveLength(1)
   })
 
   test('blocks an APPROVE when the bot already effectively approved the PR on GitHub', async () => {

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { createApproveIdempotencyGuard, type EffectiveApprovalResolver } from './approve-idempotency'
+
+const WS = 'acme/widgets'
+
+function resolver(map: Record<string, 'APPROVED' | 'CHANGES_REQUESTED' | 'NONE' | 'error'>): EffectiveApprovalResolver {
+  return async ({ workspace, prNumber }) => {
+    const state = map[`${workspace}#${prNumber}`] ?? 'NONE'
+    if (state === 'error') return { ok: false }
+    return { ok: true, alreadyApproved: state === 'APPROVED' }
+  }
+}
+
+describe('approve idempotency guard', () => {
+  let guards: Array<ReturnType<typeof createApproveIdempotencyGuard>> = []
+  afterEach(() => {
+    guards = []
+  })
+  function makeGuard(map: Record<string, 'APPROVED' | 'CHANGES_REQUESTED' | 'NONE' | 'error'>) {
+    const g = createApproveIdempotencyGuard({ resolveEffectiveApproval: resolver(map) })
+    guards.push(g)
+    return g
+  }
+
+  test('allows the first APPROVE when the bot has no prior approval', async () => {
+    const g = makeGuard({})
+    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 5, verdict: 'APPROVE' })
+    expect(decision).toBeNull()
+  })
+
+  test('blocks a second APPROVE while the first is still pending (concurrent sessions, same container)', async () => {
+    const g = makeGuard({})
+    // First APPROVE reserves the PR but has not completed (tool.after not called yet).
+    const first = await g.guard({ callId: 'a1', workspace: WS, prNumber: 7, verdict: 'APPROVE' })
+    expect(first).toBeNull()
+    const second = await g.guard({ callId: 'a2', workspace: WS, prNumber: 7, verdict: 'APPROVE' })
+    expect(second).not.toBeNull()
+    expect(second?.block).toBe(true)
+  })
+
+  test('blocks an APPROVE when the bot already effectively approved the PR on GitHub', async () => {
+    const g = makeGuard({ [`${WS}#9`]: 'APPROVED' })
+    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 9, verdict: 'APPROVE' })
+    expect(decision).not.toBeNull()
+    expect(decision?.block).toBe(true)
+  })
+
+  test('allows APPROVE when the bot previously requested changes (a real re-review)', async () => {
+    const g = makeGuard({ [`${WS}#11`]: 'CHANGES_REQUESTED' })
+    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 11, verdict: 'APPROVE' })
+    expect(decision).toBeNull()
+  })
+
+  test('releasing a failed APPROVE lets a later genuine APPROVE through', async () => {
+    const g = makeGuard({})
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 13, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: false })
+    const retry = await g.guard({ callId: 'a2', workspace: WS, prNumber: 13, verdict: 'APPROVE' })
+    expect(retry).toBeNull()
+  })
+
+  test('a succeeded APPROVE keeps the PR locked against duplicates', async () => {
+    const g = makeGuard({})
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
+    expect(dup).not.toBeNull()
+    expect(dup?.block).toBe(true)
+  })
+
+  test('ignores non-APPROVE verdicts (REQUEST_CHANGES is allowed to repeat)', async () => {
+    const g = makeGuard({ [`${WS}#17`]: 'APPROVED' })
+    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 17, verdict: 'REQUEST_CHANGES' })
+    expect(decision).toBeNull()
+  })
+
+  test('fails open on a resolver error so a genuine approval is never permanently blocked', async () => {
+    const g = makeGuard({ [`${WS}#19`]: 'error' })
+    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 19, verdict: 'APPROVE' })
+    // A transient GitHub read failure must not strand the bot from ever approving;
+    // the in-process pending set still guards the concurrent-duplicate case.
+    expect(decision).toBeNull()
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -40,16 +40,23 @@ export function createApproveIdempotencyGuard(deps: {
     async guard(args): Promise<ApproveBlock | null> {
       if (args.verdict !== 'APPROVE') return null
       const key = prKey(args.workspace, args.prNumber)
+
+      // Reserve BEFORE the await so two calls racing into guard() for the same
+      // PR cannot both observe an empty set: the loser sees the winner's
+      // reservation and is blocked. The reservation is provisional until the
+      // remote check clears it.
       if (approvedOrPending.has(key)) return { block: true, reason: DUPLICATE_REASON }
+      approvedOrPending.add(key)
+      reservedByCall.set(args.callId, key)
 
       const remote = await deps.resolveEffectiveApproval({ workspace: args.workspace, prNumber: args.prNumber })
       if (remote.ok && remote.alreadyApproved) {
-        approvedOrPending.add(key)
+        // Already approved upstream: keep the PR locked but drop this call's
+        // claim so release() won't later unlock a PR that is genuinely approved.
+        reservedByCall.delete(args.callId)
         return { block: true, reason: DUPLICATE_REASON }
       }
 
-      approvedOrPending.add(key)
-      reservedByCall.set(args.callId, key)
       return null
     },
 

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -1,0 +1,67 @@
+import type { ReviewVerdict } from '@/channels/github-review-turn-ledger'
+
+export type EffectiveApprovalResolver = (target: {
+  workspace: string
+  prNumber: number
+}) => Promise<{ ok: true; alreadyApproved: boolean } | { ok: false }>
+
+export type ApproveBlock = { block: true; reason: string }
+
+export type ApproveIdempotencyGuard = {
+  guard: (args: {
+    callId: string
+    workspace: string
+    prNumber: number
+    verdict: ReviewVerdict
+  }) => Promise<ApproveBlock | null>
+  release: (args: { callId: string; succeeded: boolean }) => void
+}
+
+const DUPLICATE_REASON =
+  'This bot has already approved this pull request. A second APPROVE would post a redundant review. ' +
+  'If you intended to change your verdict, request changes or dismiss the prior review instead of re-approving.'
+
+// Makes formal `gh ... event=APPROVE` idempotent per PR across turns, sessions,
+// and restarts. The per-turn review ledger only guards prose claims and resets
+// every turn, so without this an APPROVE can fire again whenever the same PR
+// fans out into a second session or a follow-up turn. We reserve the PR in an
+// in-process set before the command runs (stops same-container concurrent
+// double-approve) and consult GitHub for the bot's effective review state
+// (stops cross-restart re-approval). Reads fail OPEN: a transient GitHub error
+// must never permanently strand the bot from approving a PR it has not yet
+// approved — the in-process reservation still blocks the concurrent case.
+export function createApproveIdempotencyGuard(deps: {
+  resolveEffectiveApproval: EffectiveApprovalResolver
+}): ApproveIdempotencyGuard {
+  const approvedOrPending = new Set<string>()
+  const reservedByCall = new Map<string, string>()
+
+  return {
+    async guard(args): Promise<ApproveBlock | null> {
+      if (args.verdict !== 'APPROVE') return null
+      const key = prKey(args.workspace, args.prNumber)
+      if (approvedOrPending.has(key)) return { block: true, reason: DUPLICATE_REASON }
+
+      const remote = await deps.resolveEffectiveApproval({ workspace: args.workspace, prNumber: args.prNumber })
+      if (remote.ok && remote.alreadyApproved) {
+        approvedOrPending.add(key)
+        return { block: true, reason: DUPLICATE_REASON }
+      }
+
+      approvedOrPending.add(key)
+      reservedByCall.set(args.callId, key)
+      return null
+    },
+
+    release(args): void {
+      const key = reservedByCall.get(args.callId)
+      if (key === undefined) return
+      reservedByCall.delete(args.callId)
+      if (!args.succeeded) approvedOrPending.delete(key)
+    },
+  }
+}
+
+function prKey(workspace: string, prNumber: number): string {
+  return `${workspace}#${prNumber}`
+}

--- a/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createGithubEffectiveApprovalResolver } from './effective-approval'
+
+const WS = 'acme/widgets'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function fetchStub(routes: Record<string, Response>): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    for (const [needle, response] of Object.entries(routes)) {
+      if (url.includes(needle)) return response.clone()
+    }
+    return new Response('not stubbed', { status: 500 })
+  }) as typeof fetch
+}
+
+describe('github effective-approval resolver', () => {
+  test('reports alreadyApproved when the bot has an APPROVED review on the PR', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/5/reviews': jsonResponse([
+          { state: 'COMMENTED', user: { login: 'someone', type: 'User' } },
+          { state: 'APPROVED', user: { login: 'review-bot', type: 'User' } },
+        ]),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 5 })).toEqual({ ok: true, alreadyApproved: true })
+  })
+
+  test('reports not approved when only OTHER users approved', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/6/reviews': jsonResponse([{ state: 'APPROVED', user: { login: 'someone-else', type: 'User' } }]),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 6 })).toEqual({ ok: true, alreadyApproved: false })
+  })
+
+  test('reports not approved when the bot only commented', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/7/reviews': jsonResponse([{ state: 'COMMENTED', user: { login: 'review-bot', type: 'User' } }]),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 7 })).toEqual({ ok: true, alreadyApproved: false })
+  })
+
+  test('matches a GitHub App bot whose reviews login carries the [bot] suffix', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/8/reviews': jsonResponse([{ state: 'APPROVED', user: { login: 'review-bot[bot]', type: 'Bot' } }]),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 8 })).toEqual({ ok: true, alreadyApproved: true })
+  })
+
+  test('fails (ok:false) when the reviews fetch errors so the guard can fail open', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/9/reviews': new Response('boom', { status: 500 }),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 9 })).toEqual({ ok: false })
+  })
+
+  test('fails (ok:false) when identity cannot be resolved', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': new Response('no', { status: 403 }),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 10 })).toEqual({ ok: false })
+  })
+
+  test('fails (ok:false) when no token is available', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => null,
+      fetchImpl: fetchStub({}),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 11 })).toEqual({ ok: false })
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
@@ -55,6 +55,48 @@ describe('github effective-approval resolver', () => {
     expect(await resolve({ workspace: WS, prNumber: 7 })).toEqual({ ok: true, alreadyApproved: false })
   })
 
+  test('reports not approved when a later bot CHANGES_REQUESTED supersedes an earlier APPROVED', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/30/reviews': jsonResponse([
+          { state: 'APPROVED', user: { login: 'review-bot', type: 'User' } },
+          { state: 'CHANGES_REQUESTED', user: { login: 'review-bot', type: 'User' } },
+        ]),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 30 })).toEqual({ ok: true, alreadyApproved: false })
+  })
+
+  test('reports approved when a later bot APPROVED supersedes an earlier CHANGES_REQUESTED', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/31/reviews': jsonResponse([
+          { state: 'CHANGES_REQUESTED', user: { login: 'review-bot', type: 'User' } },
+          { state: 'APPROVED', user: { login: 'review-bot', type: 'User' } },
+        ]),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 31 })).toEqual({ ok: true, alreadyApproved: true })
+  })
+
+  test('a later bot COMMENTED does not clear an earlier bot APPROVED', async () => {
+    const resolve = createGithubEffectiveApprovalResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({
+        '/user': jsonResponse({ login: 'review-bot', id: 1 }),
+        '/pulls/32/reviews': jsonResponse([
+          { state: 'APPROVED', user: { login: 'review-bot', type: 'User' } },
+          { state: 'COMMENTED', user: { login: 'review-bot', type: 'User' } },
+        ]),
+      }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 32 })).toEqual({ ok: true, alreadyApproved: true })
+  })
+
   test('matches a GitHub App bot whose reviews login carries the [bot] suffix', async () => {
     const resolve = createGithubEffectiveApprovalResolver({
       resolveToken: async () => 'tok',

--- a/src/bundled-plugins/github-cli-auth/effective-approval.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.ts
@@ -1,0 +1,87 @@
+import { GITHUB_API_BASE, githubJsonHeaders } from '@/channels/adapters/github/auth-pat'
+
+import type { EffectiveApprovalResolver } from './approve-idempotency'
+
+// Resolves whether THIS bot already has a standing APPROVED review on a PR, used
+// by the approve-idempotency guard to stop a second formal APPROVE after a
+// restart (the in-process pending set covers the same-container case but is lost
+// when the container bounces). Every failure returns { ok: false } so the guard
+// fails open — a transient read error must never permanently block a genuine
+// first approval.
+export function createGithubEffectiveApprovalResolver(deps: {
+  resolveToken: (workspace: string) => Promise<string | null>
+  fetchImpl?: typeof fetch
+}): EffectiveApprovalResolver {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  return async ({ workspace, prNumber }) => {
+    const [owner, repo] = workspace.split('/')
+    if (owner === undefined || owner === '' || repo === undefined || repo === '') return { ok: false }
+
+    const token = await deps.resolveToken(workspace).catch(() => null)
+    if (token === null || token === '') return { ok: false }
+
+    const self = await fetchSelfLogin(fetchImpl, token)
+    if (self === null) return { ok: false }
+
+    const reviews = await fetchReviews(fetchImpl, token, owner, repo, prNumber)
+    if (reviews === null) return { ok: false }
+
+    const alreadyApproved = reviews.some((r) => r.state === 'APPROVED' && isSelf(r.login, r.isBot, self))
+    return { ok: true, alreadyApproved }
+  }
+}
+
+type ReviewRow = { state: string; login: string; isBot: boolean }
+
+async function fetchSelfLogin(fetchImpl: typeof fetch, token: string): Promise<string | null> {
+  try {
+    const response = await fetchImpl(`${GITHUB_API_BASE}/user`, { headers: githubJsonHeaders(token) })
+    if (!response.ok) return null
+    const raw = (await response.json().catch(() => null)) as { login?: unknown } | null
+    return typeof raw?.login === 'string' ? raw.login : null
+  } catch {
+    return null
+  }
+}
+
+async function fetchReviews(
+  fetchImpl: typeof fetch,
+  token: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<ReviewRow[] | null> {
+  try {
+    const url = `${GITHUB_API_BASE}/repos/${owner}/${repo}/pulls/${prNumber}/reviews?per_page=100`
+    const response = await fetchImpl(url, { headers: githubJsonHeaders(token) })
+    if (!response.ok) return null
+    const page = (await response.json().catch(() => null)) as RawReview[] | null
+    if (page === null) return null
+    const rows: ReviewRow[] = []
+    for (const row of page) {
+      if (typeof row.state !== 'string') continue
+      const login = row.user?.login
+      if (typeof login !== 'string') continue
+      rows.push({ state: row.state, login, isBot: row.user?.type === 'Bot' })
+    }
+    return rows
+  } catch {
+    return null
+  }
+}
+
+const BOT_LOGIN_SUFFIX = '[bot]'
+
+// A GitHub App's reviews login is `slug[bot]` while `/user` returns the bare
+// slug, so normalize before comparing — but only for actual Bot reviewers, since
+// a human could legitimately own a login matching the bare slug.
+function isSelf(login: string, isBot: boolean, selfLogin: string): boolean {
+  if (isBot) return normalizeBotLogin(login) === normalizeBotLogin(selfLogin)
+  return login === selfLogin
+}
+
+function normalizeBotLogin(login: string): string {
+  return login.endsWith(BOT_LOGIN_SUFFIX) ? login.slice(0, -BOT_LOGIN_SUFFIX.length) : login
+}
+
+type RawReview = { state?: unknown; user?: { login?: string; type?: string } }

--- a/src/bundled-plugins/github-cli-auth/effective-approval.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.ts
@@ -26,9 +26,20 @@ export function createGithubEffectiveApprovalResolver(deps: {
     const reviews = await fetchReviews(fetchImpl, token, owner, repo, prNumber)
     if (reviews === null) return { ok: false }
 
-    const alreadyApproved = reviews.some((r) => r.state === 'APPROVED' && isSelf(r.login, r.isBot, self))
-    return { ok: true, alreadyApproved }
+    const lastDecisive = reviews.filter((r) => isSelf(r.login, r.isBot, self) && isDecisive(r.state)).at(-1)
+    return { ok: true, alreadyApproved: lastDecisive?.state === 'APPROVED' }
   }
+}
+
+// A bot's effective review is its LATEST decisive one. COMMENTED/PENDING are
+// non-deciding noise that must not clear an earlier APPROVED/CHANGES_REQUESTED;
+// a later CHANGES_REQUESTED or DISMISSED supersedes an earlier APPROVED. The
+// reviews endpoint returns rows in chronological order, so the last decisive
+// row wins. Mirrors src/channels/adapters/github/review-state.ts.
+const DECISIVE = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'])
+
+function isDecisive(state: string): boolean {
+  return DECISIVE.has(state)
 }
 
 type ReviewRow = { state: string; login: string; isBot: boolean }

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -1,6 +1,8 @@
 import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
 import { definePlugin } from '@/plugin'
 
+import { createApproveIdempotencyGuard } from './approve-idempotency'
+import { createGithubEffectiveApprovalResolver } from './effective-approval'
 import { analyzeGhCommand } from './gh-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
@@ -9,6 +11,14 @@ import { classifyGhToken } from './token-class'
 export default definePlugin({
   plugin: async (ctx) => {
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
+    const approveGuard = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: createGithubEffectiveApprovalResolver({
+        resolveToken: async (workspace) => {
+          const result = await resolveTokenForRepo(workspace)
+          return result.kind === 'token' ? result.token : null
+        },
+      }),
+    })
     return {
       hooks: {
         'tool.before': async (event) => {
@@ -16,8 +26,17 @@ export default definePlugin({
           const command = event.args.command
           if (typeof command !== 'string' || !command.includes('gh')) return
 
-          const reviewDump = await noteReviewCommand({ callId: event.callId, command })
-          if (reviewDump !== null) return reviewDump
+          const review = await noteReviewCommand({ callId: event.callId, command })
+          if (review.detected !== null) {
+            const block = await approveGuard.guard({
+              callId: event.callId,
+              workspace: review.detected.workspace,
+              prNumber: review.detected.prNumber,
+              verdict: review.detected.verdict,
+            })
+            if (block !== null) return block
+          }
+          if (review.dump !== null) return review.dump
 
           const decision = analyzeGhCommand(command)
           if (decision.kind === 'pass-through') return
@@ -46,7 +65,12 @@ export default definePlugin({
         },
         'tool.after': async (event) => {
           checkGraphqlAuthNudge({ tool: event.tool, result: event.result })
-          commitReviewIfSucceeded({ sessionId: event.sessionId, callId: event.callId, result: event.result })
+          const committed = commitReviewIfSucceeded({
+            sessionId: event.sessionId,
+            callId: event.callId,
+            result: event.result,
+          })
+          approveGuard.release({ callId: event.callId, succeeded: committed })
         },
       },
     }

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -17,24 +17,30 @@ const pending = new Map<string, DetectedReview>()
 
 const MAX_INPUT_BYTES = 1_000_000
 
-export async function noteReviewCommand(args: { callId: string; command: string }): Promise<ReviewDumpDecision> {
+export type NoteReviewResult = {
+  dump: ReviewDumpDecision
+  detected: DetectedReview | null
+}
+
+export async function noteReviewCommand(args: { callId: string; command: string }): Promise<NoteReviewResult> {
   const inputFileContents = await readInputFile(args.command)
   const detected = detectReviewSubmission({ command: args.command, inputFileContents })
   if (detected !== null) pending.set(args.callId, detected)
-  return detectReviewDump({ command: args.command, inputFileContents })
+  return { dump: detectReviewDump({ command: args.command, inputFileContents }), detected }
 }
 
-export function commitReviewIfSucceeded(args: { sessionId: string; callId: string; result: ToolResult }): void {
+export function commitReviewIfSucceeded(args: { sessionId: string; callId: string; result: ToolResult }): boolean {
   const detected = pending.get(args.callId)
-  if (detected === undefined) return
+  if (detected === undefined) return false
   pending.delete(args.callId)
-  if (!looksSucceeded(detected, collectText(args.result.content))) return
+  if (!looksSucceeded(detected, collectText(args.result.content))) return false
   recordReview({
     sessionId: args.sessionId,
     workspace: detected.workspace,
     prNumber: detected.prNumber,
     verdict: detected.verdict,
   })
+  return true
 }
 
 async function readInputFile(command: string): Promise<string | null> {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1519,7 +1519,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger.error(`[channels] ${keyId}: ensureLive failed: ${describe(err)}`)
       throw err
     } finally {
-      creating.delete(keyId)
+      // Owner-checked delete: only clear the in-flight marker if it still points
+      // at THIS promise. A watchdog timeout can orphan a slow creation whose
+      // `finally` runs while a later inbound has already installed its own
+      // `creating` entry for the same key; an unconditional delete would drop
+      // that newer entry and let a third inbound cold-start a duplicate session
+      // (observed: 3 concurrent sessions approving the same PR).
+      if (creating.get(keyId) === promise) creating.delete(keyId)
     }
   }
 


### PR DESCRIPTION
## Background

A GitHub-channel agent posted **multiple `APPROVED` reviews on the same pull request** within seconds. Two independent root causes combined to produce it:

1. **No PR-scoped idempotency on the approve action.** A formal `gh ... event=APPROVE` (or `gh pr review --approve`) had nothing stopping it from running again. The per-turn review ledger (`github-review-turn-ledger`) only guards *prose* claims and is reset every turn, so the approve command itself could re-fire whenever the same PR was processed by a second session or a follow-up turn. Nothing made the action idempotent across turns, sessions, or restarts.

2. **`ensureLive` could fan out duplicate sessions for one channel key.** When the `ensureLive` watchdog timed out, it orphaned a slow session creation whose `finally` ran an unconditional `creating.delete(keyId)`. If a later inbound had already installed its own in-flight marker for the same key, that delete dropped the newer entry, letting a third inbound cold-start a *duplicate* live session for the same PR. Multiple concurrent sessions then each approved.

## Summary

**Action-layer idempotency guard (primary fix).**
A new `approve-idempotency` guard wired into the `github-cli-auth` `tool.before`/`tool.after` path:
- Reserves the PR in an in-process set before a detected APPROVE runs → blocks a concurrent double-approve within the same container.
- Consults the GitHub reviews API for the bot's **effective** review state (matching the bot's own login, including the App `slug[bot]` form) → blocks re-approval after a container restart, where the in-process set is gone.
- Releases the reservation if the command fails, keeps it on success.
- `REQUEST_CHANGES` / `COMMENT` are unaffected (re-requesting changes or commenting again is legitimate).
- GitHub reads **fail open**: a transient read error never permanently strands the bot from a genuine first approval; the in-process set still guards the concurrent case.

**Router defense-in-depth.**
`ensureLive`'s in-flight marker deletion is now **owner-checked** — it only clears the `creating` entry when it still points at *this* promise, so an orphaned slow creation can't drop a newer in-flight entry and cause session fan-out.

**Why two layers:** The router fix reduces duplicate *work* (fewer redundant sessions), but the bulletproof guarantee that one PR can never receive multiple approvals lives at the **action layer** — it holds regardless of how many sessions or turns fan out.

## Preview

_No visual output — this is a behaviour/correctness fix._

## What this does NOT do

- Does not change `REQUEST_CHANGES` or `COMMENT` review semantics.
- Does not add persistence beyond the container lifetime for anything other than the remote reviews API check.
- Does not touch the per-turn `github-review-turn-ledger` prose guard.

## Review notes

The load-bearing invariant: once a bot has posted an `APPROVED` review on a PR, no subsequent call — in the same session, a concurrent session, or a restarted container — can post another one. The two-layer design (in-process set + remote API check) is intentional and both layers are needed.

**Tests added:**
- `approve-idempotency.test.ts` — first approve allowed; concurrent second approve blocked; remote-already-approved blocked; prior `CHANGES_REQUESTED` allows a real re-review; failed approve releases the lock; succeeded approve keeps it; non-APPROVE passes through; resolver error fails open.
- `effective-approval.test.ts` — detects the bot's own APPROVED review (User and App `[bot]` forms); ignores other users' approvals and the bot's own COMMENTED reviews; fails closed on fetch/identity/token errors so the guard fails open.

Full suite: 7461 pass, 0 fail. `typecheck`, `lint` (0 errors), `format:check` all pass.