### PR TITLE
feat(planner): recommend a reviewer pass after a ready plan

### DIFF
--- a/src/bundled-plugins/planner/planner.test.ts
+++ b/src/bundled-plugins/planner/planner.test.ts
@@ -20,6 +20,7 @@ describe('planner subagent — load-bearing prompt phrases', () => {
       '<path>',
       '<summary>',
       '<verdict>',
+      '<review-suggestion>',
       '<questions>',
       'ready',
       'needs-input',
@@ -171,6 +172,31 @@ describe('planner subagent — load-bearing prompt phrases', () => {
     expect(lower).toContain('on every verdict')
     expect(lower).not.toContain('do not write a file')
     expect(PLANNER_SYSTEM_PROMPT).toContain('write a minimal partial draft')
+  })
+
+  test('prompt recommends spawning the reviewer subagent after a ready plan (the requested improvement)', () => {
+    // After producing a plan, the planner should hand the parent a second pair of
+    // eyes. It cannot review its own plan or talk to the user, so it RECOMMENDS a
+    // review via the <review-suggestion> signal rather than running one itself.
+    const lower = PLANNER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('suggesting a review')
+    expect(PLANNER_SYSTEM_PROMPT).toContain('<review-suggestion>')
+    expect(PLANNER_SYSTEM_PROMPT).toContain('`reviewer`')
+    expect(lower).toContain('plan-review')
+  })
+
+  test('prompt gates the review suggestion to a ready verdict (a partial/infeasible plan is not worth reviewing)', () => {
+    const lower = PLANNER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('only on a `ready` verdict')
+  })
+
+  test('prompt forbids the planner running the review itself (parent owns execution; no commission-and-discard)', () => {
+    // The planner is a one-shot headless session whose final message is relayed
+    // verbatim. It must RECOMMEND the review, not spawn the reviewer itself — a
+    // review it commissions and discards at end-of-run reaches no one.
+    const lower = PLANNER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('you do not run the review')
+    expect(lower).toContain('do not spawn `reviewer` yourself')
   })
 })
 

--- a/src/bundled-plugins/planner/planner.ts
+++ b/src/bundled-plugins/planner/planner.ts
@@ -178,6 +178,7 @@ Then END your response with a single \`<plan-summary>\` block. Use this exact st
 <path>relative/path/to/the/plan/file.md</path>
 <summary>Two or three sentences: your overall approach and the fact that justifies it. The parent may relay this to the user, so write it for them — do NOT narrate your process or which skill you loaded.</summary>
 <verdict>ready | needs-input | infeasible</verdict>
+<review-suggestion>yes | no</review-suggestion>
 <questions>
   <question id="short-id" blocking="true">A precise question the user must answer.</question>
   <!-- Include <questions> ONLY when verdict is needs-input. blocking="true" = the plan cannot proceed without it; blocking="false" = nice-to-have the parent may skip. -->
@@ -187,6 +188,16 @@ Then END your response with a single \`<plan-summary>\` block. Use this exact st
 \`ready\` = the plan is complete and actionable; the file is written. Omit \`<questions>\`.
 \`needs-input\` = blocked on user-only input (or the goal itself is absent); you wrote a partial draft with \`## Open Questions\`, and \`<questions>\` lists exactly what the parent must ask. The parent interviews the user and re-spawns you.
 \`infeasible\` = you understood the goal and it genuinely cannot be done as stated; write a short stub file whose body explains why, report its \`<path>\`, and say why in \`<summary>\` too. This is "the answer is no", not "I need more information".
+
+## Suggesting a review — hand the parent a second pair of eyes
+
+A plan you call \`ready\` is your best one-shot effort, but you are the only mind that has seen it. For any plan whose stakes justify a second pass — a multi-step project, an irreversible or costly move, a plan a human will execute against real money, time, or production state — the right next move is a REVIEW before execution, and the parent owns that call.
+
+You cannot review your own plan and you cannot talk to the user, so you do not run the review: you RECOMMEND it. TypeClaw ships a \`reviewer\` subagent — a deep, read-only specialist that loads a \`plan-review\` skill and returns a structured verdict (no side effects, never posts). When a review is worth it, set \`<review-suggestion>yes</review-suggestion>\` and add one short sentence to \`<summary>\` telling the parent it can spawn \`reviewer\` on the plan file before executing.
+
+- Suggest a review ONLY on a \`ready\` verdict. A \`needs-input\` plan is a partial skeleton and an \`infeasible\` one is a "no" — neither is a finished artifact worth reviewing, so set \`<review-suggestion>no</review-suggestion>\` for both.
+- Skip it for a trivially small or fully-reversible \`ready\` plan (a one-move errand, a throwaway draft) where a review buys nothing — set \`<review-suggestion>no</review-suggestion>\` and do not clutter \`<summary>\`.
+- The recommendation is the parent's to act on. Do NOT spawn \`reviewer\` yourself: the parent owns execution and the channel, and a review you commission and then discard at end-of-run helps no one.
 
 ## Rules
 


### PR DESCRIPTION
## Background

The `planner` subagent runs in a one-shot, headless session and is the only mind that ever sees the plan it produces — there's no built-in moment where a second pair of eyes checks a `ready` plan before the parent executes it. We already ship a domain-neutral `reviewer` subagent with a dedicated `plan-review` skill (deep, read-only, returns a structured verdict, never posts). Nothing connected the two: a freshly-planned, high-stakes piece of work went straight to execution unreviewed.

## Summary

After producing a `ready` plan, the planner now recommends a review pass. The recommendation is surfaced as a new `<review-suggestion>yes | no</review-suggestion>` element in the existing `<plan-summary>` block (the planner's final message is relayed to the parent verbatim, so that block is the only channel that reaches the parent), plus one short sentence in `<summary>` when a review is warranted.

Key decisions:

- **Recommend, don't run.** The planner can't review its own plan and can't talk to the user, and a review it commissions then discards at end-of-run reaches no one. So it hands the parent a `<review-suggestion>` signal and lets the parent — which owns execution and the channel — make the call.
- **Gated to `ready`.** A `needs-input` plan is a partial skeleton and an `infeasible` one is a "no"; neither is a finished artifact worth reviewing, so both emit `<review-suggestion>no</review-suggestion>`.
- **Stays in the base prompt, not the skills.** The suggestion logic is domain-neutral (it applies to a trip, a launch, or a code migration alike), and both planning skills already defer to the neutral `<plan-summary>` contract. Keeping it in the base prompt preserves the planner/skill separation the existing drift-guard tests enforce.

## What this does NOT do

- Does not auto-spawn the reviewer or wire any orchestration — the parent decides whether to act on the suggestion.
- Does not touch the `reviewer` subagent, the `plan-review` skill, or the planner's payload schema / output-path contract.
- Does not suggest a review for trivial or fully-reversible `ready` plans (a one-move errand, a throwaway draft).

## Review notes

The load-bearing change is the new `## Suggesting a review` section in `PLANNER_SYSTEM_PROMPT` and the `<review-suggestion>` element added to the `<plan-summary>` template. Drift-guard tests pin the load-bearing phrases (the `ready`-only gate, the "recommend not run" boundary, the `reviewer`/`plan-review` references) so a future prompt edit can't silently drop the behavior. All 131 planner + reviewer tests pass; typecheck, lint, and format are clean.
