### PR TITLE
fix(github): treat PR review threads as group chat

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -42,6 +42,69 @@ describe('classifyGithubInbound', () => {
     expect(msg?.thread).toBe('101')
   })
 
+  describe('PR review-thread explicit-only engagement fields', () => {
+    it('marks a reply to the bot review comment as explicit-only and reply-to-bot', () => {
+      const msg = classifyGithubInbound('pull_request_review_comment', reviewCommentPayload(), 'typeclaw-bot', {
+        reviewCommentParent: { isSelf: true, parentId: 101 },
+      })
+      expect(msg?.replyToBotMessageId).toBe('101')
+      expect(msg?.replyToOtherMessageId).toBe(null)
+      expect(msg?.suppressSticky).toBe(true)
+    })
+
+    it('marks a reply to someone else review comment as explicit-only and reply-to-other', () => {
+      const msg = classifyGithubInbound('pull_request_review_comment', reviewCommentPayload(), 'typeclaw-bot', {
+        reviewCommentParent: { isSelf: false, parentId: 101 },
+      })
+      expect(msg?.replyToBotMessageId).toBe(null)
+      expect(msg?.replyToOtherMessageId).toBe('101')
+      expect(msg?.suppressSticky).toBe(true)
+    })
+
+    it('marks a top-level review comment as explicit-only without reply fields', () => {
+      const msg = classifyGithubInbound(
+        'pull_request_review_comment',
+        reviewCommentPayload({ inReplyToId: null }),
+        'typeclaw-bot',
+      )
+      expect(msg?.thread).toBe('102')
+      expect(msg?.replyToBotMessageId).toBe(null)
+      expect(msg?.replyToOtherMessageId).toBe(null)
+      expect(msg?.suppressSticky).toBe(true)
+    })
+
+    it('preserves @mention detection on explicit-only review comments', () => {
+      const msg = classifyGithubInbound(
+        'pull_request_review_comment',
+        reviewCommentPayload({ body: '@typeclaw-bot please look' }),
+        'typeclaw-bot',
+      )
+      expect(msg?.isBotMention).toBe(true)
+      expect(msg?.suppressSticky).toBe(true)
+    })
+
+    it('marks top-level submitted reviews as explicit-only without reply fields', () => {
+      const msg = classifyGithubInbound(
+        'pull_request_review',
+        {
+          action: 'submitted',
+          repository: repo(),
+          pull_request: { number: 7, id: 700, user: user() },
+          review: { id: 5002, body: 'please fix', submitted_at: '2026-01-01T00:00:00Z', user: user() },
+        },
+        'typeclaw-bot',
+      )
+      expect(msg?.replyToBotMessageId).toBe(null)
+      expect(msg?.replyToOtherMessageId).toBe(null)
+      expect(msg?.suppressSticky).toBe(true)
+    })
+
+    it('leaves PR issue comments on normal engagement behavior', () => {
+      const msg = classifyGithubInbound('issue_comment', issueCommentPayload({ pullRequest: true }), 'typeclaw-bot')
+      expect(msg?.suppressSticky).toBeUndefined()
+    })
+  })
+
   describe('reactionRef stamping', () => {
     it('stamps an issue-comment ref for a comment on a PR (reacts to the comment, not the PR body)', () => {
       const msg = classifyGithubInbound('issue_comment', issueCommentPayload({ pullRequest: true }), 'typeclaw-bot')
@@ -924,6 +987,55 @@ describe('createGithubWebhookHandler', () => {
   })
 })
 
+describe('createGithubWebhookHandler — review comment parent lookup', () => {
+  function handlerWithParentLookup(
+    routed: InboundMessage[],
+    parentUser: Record<string, unknown>,
+  ): (req: Request) => Promise<Response> {
+    return createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request_review_comment.created'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot[bot]',
+      authToken: async () => 'tok',
+      fetchImpl: fakeFetch((url, init) => {
+        expect(url).toBe('https://api.github.com/repos/acme/project/pulls/comments/101')
+        expect(init?.method ?? 'GET').toBe('GET')
+        return new Response(JSON.stringify({ id: 101, user: parentUser }), { status: 200 })
+      }),
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+  }
+
+  it('routes review-comment replies to self with replyToBotMessageId', async () => {
+    const routed: InboundMessage[] = []
+    const handler = handlerWithParentLookup(routed, { login: 'typeclaw-bot[bot]', id: 99, type: 'Bot' })
+
+    await handler(signedRequest(JSON.stringify(reviewCommentPayload()), 'pull_request_review_comment', 'parent-self'))
+
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.replyToBotMessageId).toBe('101')
+    expect(routed[0]?.replyToOtherMessageId).toBe(null)
+    expect(routed[0]?.suppressSticky).toBe(true)
+  })
+
+  it('routes review-comment replies to other authors with replyToOtherMessageId', async () => {
+    const routed: InboundMessage[] = []
+    const handler = handlerWithParentLookup(routed, { login: 'alice', id: 10, type: 'User' })
+
+    await handler(signedRequest(JSON.stringify(reviewCommentPayload()), 'pull_request_review_comment', 'parent-other'))
+
+    expect(routed).toHaveLength(1)
+    expect(routed[0]?.replyToBotMessageId).toBe(null)
+    expect(routed[0]?.replyToOtherMessageId).toBe('101')
+    expect(routed[0]?.suppressSticky).toBe(true)
+  })
+})
+
 describe('createGithubWebhookHandler — self-author drop', () => {
   function selfAuthoredHandler(
     routed: InboundMessage[],
@@ -1604,12 +1716,19 @@ function issueCommentPayload(options: { pullRequest: boolean; body?: string }): 
   }
 }
 
-function reviewCommentPayload(): Record<string, unknown> {
+function reviewCommentPayload(options: { inReplyToId?: number | null; body?: string } = {}): Record<string, unknown> {
+  const inReplyToId = options.inReplyToId === undefined ? 101 : options.inReplyToId
   return {
     action: 'created',
     repository: repo(),
     pull_request: { number: 7 },
-    comment: { id: 102, in_reply_to_id: 101, body: 'review', created_at: '2026-01-01T00:00:00Z', user: user() },
+    comment: {
+      id: 102,
+      ...(inReplyToId !== null ? { in_reply_to_id: inReplyToId } : {}),
+      body: options.body ?? 'review',
+      created_at: '2026-01-01T00:00:00Z',
+      user: user(),
+    },
   }
 }
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -4,6 +4,7 @@ import type { GithubReviewOn } from '@/channels/schema'
 import type { InboundMessage } from '@/channels/types'
 
 import type { GithubAuthContext } from './auth'
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 import { removeRequestedReviewer } from './decoy-reviewer'
 import type { DeliveryDedup } from './dedup'
 import { isGithubEventAllowed } from './event-allowlist'
@@ -94,10 +95,12 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     }
 
     const teamIsBotMember = await resolveTeamMembership(event, payload, options)
+    const reviewCommentParent = await resolveReviewCommentParent(event, payload, selfId, selfLogin, options)
     const classified = classifyGithubInbound(event, payload, selfLogin, {
       teamIsBotMember,
       authType: options.authType?.() ?? 'pat',
       reviewOn: options.reviewOn?.() ?? 'review_requested',
+      ...(reviewCommentParent !== null ? { reviewCommentParent } : {}),
     })
     if (classified === null) return ok()
 
@@ -286,7 +289,12 @@ export function classifyGithubInbound(
   event: string,
   payload: Record<string, unknown>,
   selfLogin: string | null,
-  options?: { teamIsBotMember?: boolean; authType?: 'pat' | 'app'; reviewOn?: GithubReviewOn },
+  options?: {
+    teamIsBotMember?: boolean
+    authType?: 'pat' | 'app'
+    reviewOn?: GithubReviewOn
+    reviewCommentParent?: ReviewCommentParent
+  },
 ): InboundMessage | null {
   const repository = readRepository(payload)
   if (repository === null) return null
@@ -326,7 +334,10 @@ export function classifyGithubInbound(
     const number = readNumber(pr, 'number')
     const id = readNumber(comment, 'id')
     if (number === null || id === null) return null
-    const root = readNumber(comment, 'in_reply_to_id') ?? id
+    const parentId = readNumber(comment, 'in_reply_to_id')
+    const root = parentId ?? id
+    const parent =
+      parentId !== null && options?.reviewCommentParent?.parentId === parentId ? options.reviewCommentParent : null
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: String(root) },
       comment.body,
@@ -335,6 +346,12 @@ export function classifyGithubInbound(
       mention,
       comment.created_at,
       { kind: 'pr-review-comment', owner: repository.owner, repo: repository.name, commentId: id },
+      false,
+      {
+        suppressSticky: true,
+        replyToBotMessageId: parent?.isSelf === true ? String(parent.parentId) : null,
+        replyToOtherMessageId: parent?.isSelf === false ? String(parent.parentId) : null,
+      },
     )
   }
 
@@ -467,6 +484,7 @@ export function classifyGithubInbound(
       review.submitted_at,
       null,
       !hasBody,
+      { suppressSticky: true },
     )
   }
 
@@ -507,6 +525,14 @@ type ReviewRequestInput = {
   selfLogin: string | null
   authType: 'pat' | 'app'
   teamIsBotMember: boolean | undefined
+}
+
+type ReviewCommentParent = { isSelf: boolean; parentId: number }
+
+type BuildInboundOptions = {
+  suppressSticky?: boolean
+  replyToBotMessageId?: string | null
+  replyToOtherMessageId?: string | null
 }
 
 // A GitHub App can never be a `requested_reviewer` — that field only holds
@@ -701,6 +727,7 @@ function buildInbound(
   rawTs: unknown,
   reactionTarget: GithubReactionTarget | null,
   synthesizedAwareness = false,
+  options?: BuildInboundOptions,
 ): InboundMessage | null {
   if (user === null) return null
   const text = typeof rawText === 'string' ? rawText : ''
@@ -715,6 +742,8 @@ function buildInbound(
   // that handle is the author, never a third-party mention of the bot, so the
   // body-text mention heuristic must not fire on it.
   const isBotMention = !synthesizedAwareness && textMentionsBot(text, mention)
+  const replyToBotMessageId = options?.replyToBotMessageId ?? null
+  const replyToOtherMessageId = options?.replyToOtherMessageId ?? key.replyToOtherMessageId
   return {
     ...key,
     text,
@@ -724,7 +753,9 @@ function buildInbound(
     authorName: user.login,
     authorIsBot: user.type === 'Bot',
     isBotMention,
-    replyToBotMessageId: null,
+    ...(options?.suppressSticky === true ? { suppressSticky: true } : {}),
+    replyToBotMessageId,
+    replyToOtherMessageId,
     ts: typeof rawTs === 'string' ? Date.parse(rawTs) || 0 : 0,
   }
 }
@@ -788,6 +819,39 @@ async function resolveTeamMembership(
   } catch (err) {
     options.logger.warn(`[github] team membership lookup failed: ${describe(err)}`)
     return false
+  }
+}
+
+async function resolveReviewCommentParent(
+  event: string,
+  payload: Record<string, unknown>,
+  selfId: string | null,
+  selfLogin: string | null,
+  options: GithubWebhookHandlerOptions,
+): Promise<ReviewCommentParent | null> {
+  if (event !== 'pull_request_review_comment') return null
+  const comment = readRecord(payload.comment)
+  const parentId = readNumber(comment, 'in_reply_to_id')
+  if (parentId === null) return null
+  const repository = readRepository(payload)
+  if (repository === null) return null
+  const authToken = options.authToken
+  if (authToken === undefined) return null
+
+  try {
+    const token = await authToken({ repoSlug: `${repository.owner}/${repository.name}` })
+    const fetchImpl = options.fetchImpl ?? fetch
+    const response = await fetchImpl(
+      `${GITHUB_API_BASE}/repos/${repository.owner}/${repository.name}/pulls/comments/${parentId}`,
+      { headers: githubJsonHeaders(token) },
+    )
+    if (!response.ok) return null
+    const raw = (await response.json().catch(() => null)) as unknown
+    const user = readUser(readRecord(raw)?.user)
+    if (user === null) return null
+    return { parentId, isSelf: isSelfAuthor(user, selfId, selfLogin) }
+  } catch {
+    return null
   }
 }
 

--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -126,6 +126,91 @@ describe('decideEngagement (explicit triggers)', () => {
   })
 })
 
+describe('decideEngagement (explicit-only inbounds)', () => {
+  test('engages an explicit-only inbound when it mentions the bot', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ suppressSticky: true, isBotMention: true }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: crowded,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('engages an explicit-only inbound when it replies to the bot', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ suppressSticky: true, replyToBotMessageId: 'parent-1' }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: crowded,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('observes an explicit-only inbound with sticky credit and preserves the credit', () => {
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 10_000)
+    const decision = decideEngagement({
+      message: inbound({ suppressSticky: true }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 1000,
+      participants: crowded,
+    })
+    expect(decision).toBe('observe')
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(true)
+  })
+
+  test('observes an explicit-only inbound whose text matches an alias', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ suppressSticky: true, text: 'Toto please look' }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: crowded,
+      selfAliases: ['toto'],
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('observes an explicit-only inbound authored by a peer bot', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ suppressSticky: true, authorId: 'peer-bot', authorName: 'peer-bot', authorIsBot: true }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 0,
+      participants: crowded,
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('non-explicit sticky credit still engages a normal inbound', () => {
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 10_000)
+    const decision = decideEngagement({
+      message: inbound(),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 1000,
+      participants: crowded,
+    })
+    expect(decision).toBe('engage')
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(false)
+  })
+})
+
 describe('decideEngagement (alias)', () => {
   test('engages when text contains a self-alias (case-insensitive)', () => {
     const ledger = new StickyLedger()

--- a/src/channels/engagement.ts
+++ b/src/channels/engagement.ts
@@ -89,6 +89,8 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   if (config.trigger.includes('mention') && message.isBotMention) return 'engage'
   if (config.trigger.includes('reply') && message.replyToBotMessageId !== null) return 'engage'
 
+  const explicitOnly = message.suppressSticky === true
+
   // Multi-human pre-sticky target check. In a busy group the conversational
   // target shifts every message: the author we're mid-exchange with (and hold
   // a sticky credit for) may, on THIS turn, structurally address a third party
@@ -118,6 +120,7 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   if (
     effectiveHumans > 1 &&
     config.stickiness !== 'off' &&
+    !explicitOnly &&
     !matchesAnyAlias(message.text, selfAliases) &&
     targetsSomeoneElse(message, participants, botInThread)
   ) {
@@ -134,7 +137,9 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   // groups wholesale (the prior approach) dropped genuine follow-ups outright;
   // the pre-check above is narrower — it only steps aside when the message is
   // STRUCTURALLY addressed elsewhere, leaving plain follow-ups engaged.
-  if (config.stickiness !== 'off' && ledger.consume(key, message.authorId, now)) {
+  // GitHub review-thread traffic must not spend content-blind sticky credit
+  // unless the bot was explicitly addressed.
+  if (!explicitOnly && config.stickiness !== 'off' && ledger.consume(key, message.authorId, now)) {
     return 'engage'
   }
 
@@ -148,7 +153,7 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   // aliases, so cross-bot suppression isn't possible at this layer
   // anyway — the router-side peer-name suppression in the solo-human
   // fallback handles that case (follow-up).
-  if (matchesAnyAlias(message.text, selfAliases)) return 'engage'
+  if (!explicitOnly && matchesAnyAlias(message.text, selfAliases)) return 'engage'
 
   // Solo-human fallback: the strict mention/reply/dm gate keeps the bot
   // quiet in multi-human conversations, but in a 1-human channel that

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -70,6 +70,12 @@ export type InboundMessage = {
   // bounded loop guard so two or more bots cannot ping-pong forever.
   authorIsBot: boolean
   isBotMention: boolean
+  // When true, engagement treats this inbound as explicit-only: it skips
+  // content-blind sticky credit AND plain-text alias matching, leaving only
+  // structural DM / @mention / reply triggers. Used for GitHub PR review-thread
+  // traffic so the bot observes review comments unless explicitly addressed.
+  // Adapters that omit this keep the normal sticky + alias behavior.
+  suppressSticky?: boolean
   replyToBotMessageId: string | null
   // True when the message contains at least one user mention AND none of
   // those mentions resolve to the bot. Used by the engagement layer to


### PR DESCRIPTION
## Background

Our bot was replying to **other people's inline PR review comments** even when those comments did not address it. The concrete trigger: on a PR, a peer review bot left an inline review comment that did **not** `@mention` us — and we still replied to it.

Root cause is in the engagement layer, not GitHub-specific. After the bot comments on its own PR, it grants itself a **sticky credit** for that thread. Sticky is *content-blind* by design (it answers "am I mid-conversation with this author?", not "does this message address me?"). A later review comment in that thread — even from someone else — consumes the credit and force-engages. GitHub review comments also never carried reply-to-bot information (`replyToBotMessageId` was hardcoded `null`), so the engagement layer had no structural signal that a review comment was, or was not, addressed to us.

## Summary

Treat GitHub PR review threads as **group chat** and reuse the existing engagement mechanism, rather than bolting on a GitHub-specific "ignore other authors" filter.

- New optional `InboundMessage.suppressSticky` flag marks an inbound **explicit-only**: the engagement layer skips the content-blind sticky gate **and** plain-text alias matching, leaving only the structural DM / `@mention` / reply-to-bot triggers. Sticky is skipped **without consuming** the credit (no silent burn).
- `pull_request_review_comment` and `pull_request_review` inbounds are marked explicit-only.
- To keep "reply to the bot's own review comment" working, the webhook handler resolves the parent comment's author via a cheap REST lookup (`GET /repos/{o}/{r}/pulls/comments/{in_reply_to_id}`) and sets `replyToBotMessageId` (parent is us) or `replyToOtherMessageId` (parent is someone else) — mirroring the existing Discord reply-target pattern. The lookup degrades gracefully: any failure leaves the reply fields null, so the comment can still engage via `@mention` but never over-engages.

**Why suppress sticky and not just rely on reply tracking?** Sticky is content-blind, so even with correct reply attribution it would still force-engage on an unaddressed review comment whenever a credit happens to be live. Both pieces are needed.

**Why resolve the parent author in the handler (async) and not in the classifier?** `classifyGithubInbound` is kept synchronous and pure so it stays unit-testable; the async REST resolution happens in the handler (like the existing `resolveTeamMembership`) and is passed in as data.

## What this does NOT do

- Does **not** add a "drop comments from other bots/authors" filter — engagement remains symmetric for humans and bots.
- Does **not** change normal PR `issue_comment` conversation.
- Does **not** touch review-request automation (`classifyReviewRequest`), opened-review triggers, the decoy-reviewer flow, or the review-thread recheck.
- Does **not** change behavior when the bot is explicitly `@mentioned` or when someone replies to the bot's own review comment — both still engage.

## Review notes

- Load-bearing change: `decideEngagement` in `src/channels/engagement.ts`. Verify the invariant **explicit address (DM/mention/reply) is evaluated before any suppression** and that the sticky credit is *not* consumed when `suppressSticky` is set.
- Parent-author self-check uses numeric `selfId` comparison (via `isSelfAuthor`), which sidesteps the GitHub App `slug[bot]` vs `slug` login mismatch.
- Tests cover: mention engages, reply-to-bot engages, sticky-only observes (credit preserved), alias-only observes, peer-bot observes, and the three review-comment classification cases (parent self / parent other / top-level), plus a regression that normal sticky still engages.