### PR TITLE
fix(agent): stop loop-guard false-blocking subagent_output fan-out polls

### DIFF
--- a/src/agent/loop-guard.test.ts
+++ b/src/agent/loop-guard.test.ts
@@ -42,7 +42,7 @@ describe('createLoopGuard', () => {
 
   test('emits a block decision at the hardBlock count and beyond', () => {
     const guard = createLoopGuard()
-    let lastDecision: ReturnType<typeof guard.check> = { kind: 'ok' }
+    let lastDecision: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
     for (let i = 1; i <= LOOP_HARD_BLOCK; i++) {
       lastDecision = guard.check('s1', 'bash', { command: 'ls' })
     }
@@ -130,7 +130,7 @@ describe('createLoopGuard', () => {
 
   test('consecutive-identical block reports reason "consecutive"', () => {
     const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
-    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
     for (let i = 0; i < 5; i++) last = guard.check('s1', 'bash', { command: 'ls' })
     expect(last.kind).toBe('block')
     if (last.kind === 'block') expect(last.reason).toBe('consecutive')
@@ -162,7 +162,7 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
       windowSoftWarn: 4,
       windowHardBlock: 6,
     })
-    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
     const seq = ['b', 'x', 'b', 'x', 'b', 'x', 'b', 'x', 'b', 'x', 'b']
     for (const cmd of seq) last = guard.check('s1', 'bash', { command: cmd })
     expect(last.kind).toBe('block')
@@ -197,7 +197,7 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
       windowHardBlock: 6,
     })
     const offsets = [49, 50, 51, 50, 51, 50]
-    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
     for (const offset of offsets) {
       last = guard.check('s1', 'read', { path: '/agent/transcript.jsonl', offset, limit: 100 })
     }
@@ -310,7 +310,7 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
         { pattern: 'e*' },
         { pattern: 'f*', limit: 5 },
       ]
-      let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+      let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
       for (const args of varyingArgs) last = guard.check('s1', tool, args)
       expect(last.kind).toBe('block')
       if (last.kind === 'block') expect(last.reason).toBe('windowed')
@@ -323,7 +323,7 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
         windowSoftWarn: 4,
         windowHardBlock: 6,
       })
-      let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+      let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
       for (let i = 0; i < 6; i++) last = guard.check('s1', tool, { path: '', pattern: `p${i}*` })
       expect(last.kind).toBe('block')
     })
@@ -368,9 +368,12 @@ describe('createLoopGuard — forgetTool', () => {
   // with other work, as it was in production — the windowed detector only sees
   // non-consecutive repeats) poisons the window, then a completion reminder
   // clears it so the next fetch is allowed.
-  function pollInterleaved(guard: ReturnType<typeof windowGuard>, times: number): ReturnType<typeof guard.check> {
+  function pollInterleaved(
+    guard: ReturnType<typeof windowGuard>,
+    times: number,
+  ): ReturnType<typeof guard.check> | { kind: 'ok' } {
     const args = { task_id: 'bg_x' }
-    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
     for (let i = 0; i < times; i++) {
       last = guard.check('s1', 'subagent_output', args)
       guard.check('s1', 'bash', { command: `step${i}` })
@@ -397,7 +400,7 @@ describe('createLoopGuard — forgetTool', () => {
   // keep each one's window count climbing without a consecutive run.
   test('does not clear another tool\u2019s accumulated window', () => {
     const guard = windowGuard()
-    let last: ReturnType<typeof guard.check> = { kind: 'ok' }
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
     for (let i = 0; i < 6; i++) {
       guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
       last = guard.check('s1', 'bash', { command: 'ls' })
@@ -436,5 +439,157 @@ describe('createLoopGuard — forgetTool', () => {
   test('is a no-op for an unknown session', () => {
     const guard = windowGuard()
     expect(() => guard.forgetTool('missing', 'subagent_output')).not.toThrow()
+  })
+})
+
+describe('createLoopGuard — retract', () => {
+  const noConsecutive = { softWarn: 1000, hardBlock: 1001 }
+
+  function windowGuard() {
+    return createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+  }
+
+  test('retracting a windowed observation drops it from the window count', () => {
+    const guard = windowGuard()
+    // given: five interleaved polls of one task_id poison the window
+    let receipt!: ReturnType<typeof guard.check>['receipt']
+    for (let i = 0; i < 5; i++) {
+      const d = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+      receipt = d.receipt
+      guard.check('s1', 'bash', { command: `step${i}` })
+    }
+    // when: the last observation is retracted
+    guard.retract(receipt)
+    // then: the next identical poll is the 5th in-window, not the 6th — no block
+    const next = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    expect(next.kind).not.toBe('block')
+  })
+
+  test('retracting every pending poll keeps a fan-out collect-loop unblocked', () => {
+    const guard = windowGuard()
+    const tasks = ['bg_1', 'bg_2', 'bg_3', 'bg_4', 'bg_5', 'bg_6']
+    let blocked = false
+    // 20 round-robin waves: every poll is "still running", so every one is retracted
+    for (let wave = 0; wave < 20; wave++) {
+      const live = tasks.slice(0, Math.max(2, tasks.length - Math.floor(wave / 3)))
+      for (const task_id of live) {
+        const d = guard.check('s1', 'subagent_output', { task_id })
+        if (d.kind === 'block') blocked = true
+        guard.retract(d.receipt)
+      }
+    }
+    expect(blocked).toBe(false)
+  })
+
+  test('retracting pending polls still lets a repeated TERMINAL-result poll block', () => {
+    const guard = windowGuard()
+    // pending polls of bg_a are retracted; terminal polls are NOT, so they accumulate
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
+    for (let i = 0; i < 7; i++) {
+      const d = guard.check('s1', 'subagent_output', { task_id: 'bg_a' })
+      last = d
+      // simulate: caller does NOT retract because the result was terminal
+      guard.check('s1', 'bash', { command: `between${i}` })
+    }
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  test('retract rewinds a consecutive streak so a pending poll never trips it', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    // back-to-back polls of one task_id; each pending poll is retracted
+    for (let i = 0; i < 10; i++) {
+      const d = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+      expect(d.kind).not.toBe('block')
+      guard.retract(d.receipt)
+    }
+  })
+
+  test('retracting one task_id leaves another task_id\u2019s accumulated signal intact', () => {
+    const guard = windowGuard()
+    // bg_keep accumulates 5 interleaved entries that are never retracted
+    for (let i = 0; i < 5; i++) {
+      guard.check('s1', 'subagent_output', { task_id: 'bg_keep' })
+      guard.check('s1', 'bash', { command: `f${i}` })
+    }
+    // bg_drop polls are all retracted
+    for (let i = 0; i < 5; i++) {
+      const d = guard.check('s1', 'subagent_output', { task_id: 'bg_drop' })
+      guard.retract(d.receipt)
+      guard.check('s1', 'bash', { command: `g${i}` })
+    }
+    // bg_keep's 6th interleaved entry still blocks; retracting bg_drop didn't help it
+    const keep = guard.check('s1', 'subagent_output', { task_id: 'bg_keep' })
+    expect(keep.kind).toBe('block')
+  })
+
+  test('is a no-op for an unknown session', () => {
+    const guard = windowGuard()
+    const receipt = { sessionId: 'missing', tool: 'subagent_output', signature: 'x', windowSignature: 'y' }
+    expect(() => guard.retract(receipt)).not.toThrow()
+  })
+})
+
+describe('createLoopGuard — noteResult / deferable', () => {
+  test('a subagent_output block is deferable until its signature is noted terminal', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    // five back-to-back polls of one task_id reach the consecutive hard block
+    let blocked!: ReturnType<typeof guard.check>
+    for (let i = 0; i < 5; i++) blocked = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    expect(blocked.kind).toBe('block')
+    if (blocked.kind === 'block') expect(blocked.deferable).toBe(true)
+
+    // once the signature is known terminal, the next identical block is NOT deferable
+    guard.noteResult(blocked.receipt, 'terminal')
+    const next = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    expect(next.kind).toBe('block')
+    if (next.kind === 'block') expect(next.deferable).toBe(false)
+  })
+
+  test('noteResult(running) clears a prior terminal mark so the block is deferable again', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    let d!: ReturnType<typeof guard.check>
+    for (let i = 0; i < 5; i++) d = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    guard.noteResult(d.receipt, 'terminal')
+    guard.noteResult(d.receipt, 'running')
+    const next = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    if (next.kind === 'block') expect(next.deferable).toBe(true)
+  })
+
+  test('terminal-known is per-signature: a different task_id stays deferable', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    let a!: ReturnType<typeof guard.check>
+    for (let i = 0; i < 5; i++) a = guard.check('s1', 'subagent_output', { task_id: 'bg_a' })
+    guard.noteResult(a.receipt, 'terminal')
+    // bg_b reaches its own consecutive block and is still deferable
+    let b!: ReturnType<typeof guard.check>
+    for (let i = 0; i < 5; i++) b = guard.check('s1', 'subagent_output', { task_id: 'bg_b' })
+    expect(b.kind).toBe('block')
+    if (b.kind === 'block') expect(b.deferable).toBe(true)
+  })
+
+  test('forgetTool clears terminal-known so a later episode defers again', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    let d!: ReturnType<typeof guard.check>
+    for (let i = 0; i < 5; i++) d = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    guard.noteResult(d.receipt, 'terminal')
+    guard.forgetTool('s1', 'subagent_output')
+    let again!: ReturnType<typeof guard.check>
+    for (let i = 0; i < 5; i++) again = guard.check('s1', 'subagent_output', { task_id: 'bg_x' })
+    if (again.kind === 'block') expect(again.deferable).toBe(true)
+  })
+
+  test('non-subagent_output blocks are never deferable', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    let d!: ReturnType<typeof guard.check>
+    for (let i = 0; i < 5; i++) d = guard.check('s1', 'bash', { command: 'ls' })
+    expect(d.kind).toBe('block')
+    if (d.kind === 'block') expect(d.deferable).toBe(false)
+  })
+
+  test('noteResult is a no-op for an unknown session', () => {
+    const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
+    const receipt = { sessionId: 'missing', tool: 'subagent_output', signature: 'x', windowSignature: 'y' }
+    expect(() => guard.noteResult(receipt, 'terminal')).not.toThrow()
   })
 })

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -52,9 +52,40 @@ const DEFAULT_PATH_TARGET = '.'
 
 const MAX_SESSIONS = 256
 
+// The one tool with result-sensitive loop semantics: a poll returning 'running'
+// is a legitimate wait, so its block is deferred until status is known (see
+// `noteResult` / `deferable`). Kept as a local literal rather than importing the
+// tool module to keep this primitive dependency-free; it must match
+// SUBAGENT_OUTPUT_TOOL_NAME in tools/subagent-output.ts.
+const SUBAGENT_OUTPUT_TOOL = 'subagent_output'
+
 export type LoopReason = 'consecutive' | 'windowed'
 
+// Identifies the single observation a `check` recorded so a caller can retract
+// exactly that one after learning post-execution it was not a loop (e.g. a
+// `subagent_output` poll that returned `status: 'running'`). Narrower than
+// `forgetTool`, which drops the whole tool window: retract undoes one call, so
+// unrelated task_ids and terminal-result polls keep their accumulated signal.
+export type LoopGuardReceipt = {
+  sessionId: string
+  tool: string
+  signature: string
+  windowSignature: string
+}
+
+// Post-execution classification of a `subagent_output` poll, fed back via
+// `noteResult`. 'running' is a still-pending wait; 'terminal' is completed/failed
+// — a repeated terminal poll is a real loop.
+export type LoopObservedResult = 'running' | 'terminal'
+
 export type LoopGuardDecision =
+  | { kind: 'ok'; receipt: LoopGuardReceipt }
+  | { kind: 'warn'; count: number; reason: LoopReason; message: string; receipt: LoopGuardReceipt }
+  | { kind: 'block'; count: number; reason: LoopReason; message: string; receipt: LoopGuardReceipt; deferable: boolean }
+
+// A decision before its receipt is attached. The detector helpers produce these;
+// `check` stamps the receipt on at its single return site.
+type Verdict =
   | { kind: 'ok' }
   | { kind: 'warn'; count: number; reason: LoopReason; message: string }
   | { kind: 'block'; count: number; reason: LoopReason; message: string }
@@ -71,6 +102,21 @@ export type LoopGuard = {
   // premature polls poisoned the window. Narrower than `forget`, so an
   // unrelated tool's accumulating loop on the same session is preserved.
   forgetTool: (sessionId: string, tool: string) => void
+  // Undoes the one observation a prior `check` recorded, identified by its
+  // receipt. Pops that signature from the windowed history and, when the
+  // current consecutive streak is the call this receipt named (it is the most
+  // recent `check` on the session, since tool execution within a turn is
+  // sequential), rewinds the streak by one. Used post-execution for a
+  // `subagent_output` poll that returned `status: 'running'` — a still-pending
+  // wait, not a loop — so it never accumulates toward either detector.
+  retract: (receipt: LoopGuardReceipt) => void
+  // Records the post-execution class of a `subagent_output` poll. Once a
+  // signature is seen 'terminal', `check` stops marking its blocks `deferable`,
+  // so further identical polls hard-block PRE-execute instead of running again
+  // just to re-confirm a completed task. 'running' clears any prior terminal
+  // mark for that signature (a task can only move running→terminal, but a
+  // signature can be reused across episodes).
+  noteResult: (receipt: LoopGuardReceipt, result: LoopObservedResult) => void
 }
 
 type SessionState = {
@@ -84,6 +130,10 @@ type SessionState = {
   // still present in the window.
   window: string[]
   windowWarned: Set<string>
+  // Exact signatures whose `subagent_output` poll has been observed terminal.
+  // A block on such a signature is enforced pre-execute (not deferred), so a
+  // completed task is not re-polled forever just to re-learn it is done.
+  termKnown: Set<string>
 }
 
 export type CreateLoopGuardOptions = {
@@ -134,7 +184,7 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
     }
   }
 
-  function evaluateConsecutive(state: SessionState, tool: string): LoopGuardDecision {
+  function evaluateConsecutive(state: SessionState, tool: string): Verdict {
     if (state.count >= hardBlock) {
       return {
         kind: 'block',
@@ -150,25 +200,30 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
     return { kind: 'ok' }
   }
 
-  function evaluateWindowed(state: SessionState, tool: string, windowSig: string): LoopGuardDecision {
+  function evaluateWindowed(state: SessionState, tool: string, windowSig: string): Verdict {
     const count = state.window.reduce((n, sig) => (sig === windowSig ? n + 1 : n), 0)
     if (count >= windowHardBlock) {
-      return {
-        kind: 'block',
-        count,
-        reason: 'windowed',
-        message: formatWindowedBlockMessage(tool, count),
-      }
+      return { kind: 'block', count, reason: 'windowed', message: formatWindowedBlockMessage(tool, count) }
     }
     if (count >= windowSoftWarn && !state.windowWarned.has(windowSig)) {
       state.windowWarned.add(windowSig)
-      return {
-        kind: 'warn',
-        count,
-        reason: 'windowed',
-        message: formatWindowedWarnMessage(tool, count),
-      }
+      return { kind: 'warn', count, reason: 'windowed', message: formatWindowedWarnMessage(tool, count) }
     }
+    return { kind: 'ok' }
+  }
+
+  function resolveVerdict(state: SessionState, tool: string, windowSig: string): Verdict {
+    const consecutive = evaluateConsecutive(state, tool)
+    if (consecutive.kind === 'block') return consecutive
+
+    // Back-to-back identical calls are the consecutive detector's domain; let
+    // it own them so a tight streak doesn't also trip the windowed detector.
+    // The windowed detector exists for INTERLEAVED cycles, so it only acts
+    // when this call breaks the immediate streak (count === 1).
+    const windowed = state.count === 1 ? evaluateWindowed(state, tool, windowSig) : { kind: 'ok' as const }
+    if (windowed.kind === 'block') return windowed
+    if (consecutive.kind === 'warn') return consecutive
+    if (windowed.kind === 'warn') return windowed
     return { kind: 'ok' }
   }
 
@@ -176,6 +231,7 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
     check(sessionId, tool, args) {
       const signature = makeCallSignature(tool, args)
       const windowSig = makeWindowSignature(tool, args)
+      const receipt: LoopGuardReceipt = { sessionId, tool, signature, windowSignature: windowSig }
       const existing = sessions.get(sessionId)
 
       const state: SessionState = existing ?? {
@@ -184,6 +240,7 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
         warned: false,
         window: [],
         windowWarned: new Set(),
+        termKnown: new Set(),
       }
 
       if (state.signature !== signature) {
@@ -204,18 +261,14 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
 
       touch(sessionId, state)
 
-      const consecutive = evaluateConsecutive(state, tool)
-      if (consecutive.kind === 'block') return consecutive
-
-      // Back-to-back identical calls are the consecutive detector's domain; let
-      // it own them so a tight streak doesn't also trip the windowed detector.
-      // The windowed detector exists for INTERLEAVED cycles, so it only acts
-      // when this call breaks the immediate streak (count === 1).
-      const windowed = state.count === 1 ? evaluateWindowed(state, tool, windowSig) : { kind: 'ok' as const }
-      if (windowed.kind === 'block') return windowed
-      if (consecutive.kind === 'warn') return consecutive
-      if (windowed.kind === 'warn') return windowed
-      return { kind: 'ok' }
+      const verdict = resolveVerdict(state, tool, windowSig)
+      if (verdict.kind === 'block') {
+        // A `subagent_output` block is deferable (let the boundary call execute
+        // to learn its status) only until this signature has proven terminal.
+        const deferable = tool === SUBAGENT_OUTPUT_TOOL && !state.termKnown.has(signature)
+        return { ...verdict, receipt, deferable }
+      }
+      return { ...verdict, receipt }
     },
     reset(sessionId) {
       sessions.delete(sessionId)
@@ -240,6 +293,39 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
         state.count = 0
         state.warned = false
       }
+      for (const sig of state.termKnown) {
+        if (signatureBelongsToTool(sig, tool)) state.termKnown.delete(sig)
+      }
+    },
+    retract(receipt) {
+      const state = sessions.get(receipt.sessionId)
+      if (state === undefined) return
+
+      // Pop the receipt's windowed observation. It is the most recent push for
+      // this signature (retraction runs immediately after the call's execute,
+      // before any other tool runs on the session), so remove the last match.
+      const lastIdx = state.window.lastIndexOf(receipt.windowSignature)
+      if (lastIdx !== -1) {
+        state.window.splice(lastIdx, 1)
+        if (!state.window.includes(receipt.windowSignature)) {
+          state.windowWarned.delete(receipt.windowSignature)
+        }
+      }
+
+      // Rewind the consecutive streak by one only if it is still the call this
+      // receipt named. A retracted soft-warned streak re-arms its warning so the
+      // next genuine repeat warns as if this call never happened.
+      if (state.signature === receipt.signature && state.count > 0) {
+        state.count -= 1
+        if (state.count < softWarn) state.warned = false
+        if (state.count === 0) state.signature = ''
+      }
+    },
+    noteResult(receipt, result) {
+      const state = sessions.get(receipt.sessionId)
+      if (state === undefined) return
+      if (result === 'terminal') state.termKnown.add(receipt.signature)
+      else state.termKnown.delete(receipt.signature)
     },
   }
 }

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1546,4 +1546,84 @@ describe('loop guard integration', () => {
     }
     expect(aborts).toBe(0)
   })
+
+  // A subagent_output poll that returns status:'running' is a still-pending
+  // wait, not a loop. The wrapper retracts it from the guard so round-robin
+  // fan-out polling never false-blocks (the production incident).
+  function makeSubagentOutputTool(statusFor: (taskId: string, callIdx: number) => 'running' | 'completed') {
+    let callIdx = 0
+    const calls: string[] = []
+    const tool = definePiTool({
+      name: 'subagent_output',
+      label: 'subagent_output',
+      description: '',
+      parameters: Type.Object({ task_id: Type.String() }),
+      async execute(_id, params: { task_id: string }) {
+        const status = statusFor(params.task_id, callIdx++)
+        calls.push(params.task_id)
+        return {
+          content: [{ type: 'text' as const, text: status }],
+          details: { ok: true, status, taskId: params.task_id, subagent: 'scout', durationMs: 1 },
+        }
+      },
+    })
+    return { tool, calls }
+  }
+
+  test('never blocks subagent_output polls that keep returning running', async () => {
+    const { tool, calls } = makeSubagentOutputTool(() => 'running')
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 'poll-running', hooks: createHookBus() })
+
+    // Replay the incident shape: 6 task_ids polled round-robin for many waves.
+    const tasks = ['bg_1', 'bg_2', 'bg_3', 'bg_4', 'bg_5', 'bg_6']
+    for (let wave = 0; wave < 12; wave++) {
+      for (const task_id of tasks) {
+        const r = (await wrapped.execute(`c${wave}`, { task_id }, undefined, undefined, {} as never)) as {
+          isError?: boolean
+        }
+        expect(r.isError).not.toBe(true)
+      }
+    }
+    expect(calls.length).toBe(72)
+  })
+
+  test('still blocks a subagent_output poll that repeats a terminal result', async () => {
+    // Every poll of bg_done returns 'completed' (terminal). The 5th poll is the
+    // block boundary: it executes once (deferred) to reveal 'completed', is
+    // marked terminal-known, then throws. From the 6th on the signature is known
+    // terminal, so the block is enforced PRE-execute and the tool stops running.
+    const { tool, calls } = makeSubagentOutputTool(() => 'completed')
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 'poll-terminal', hooks: createHookBus() })
+
+    // Four polls execute and each marks the signature terminal-known.
+    for (let i = 0; i < 4; i++) {
+      await wrapped.execute(`c${i}`, { task_id: 'bg_done' }, undefined, undefined, {} as never)
+    }
+    expect(calls.length).toBe(4)
+    // The 5th poll hits the hard-block threshold; because the signature is
+    // already terminal-known the block is NOT deferred — it fires pre-execute,
+    // so the tool does not run and never will for further identical polls.
+    for (let i = 5; i < 10; i++) {
+      await expect(wrapped.execute(`c${i}`, { task_id: 'bg_done' }, undefined, undefined, {} as never)).rejects.toThrow(
+        /loop-guard/,
+      )
+    }
+    expect(calls.length).toBe(4)
+  })
+
+  test('repeated back-to-back polls of one still-running task never block', async () => {
+    // A tight loop on ONE task_id (consecutive detector territory). Every poll
+    // returns 'running', so every one is retracted — the streak never sticks and
+    // the boundary poll past the hard-block threshold still executes.
+    const { tool, calls } = makeSubagentOutputTool(() => 'running')
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 'poll-consecutive', hooks: createHookBus() })
+
+    for (let i = 0; i < 10; i++) {
+      const r = (await wrapped.execute(`c${i}`, { task_id: 'bg_b' }, undefined, undefined, {} as never)) as {
+        isError?: boolean
+      }
+      expect(r.isError).not.toBe(true)
+    }
+    expect(calls.length).toBe(10)
+  })
 })

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -45,9 +45,10 @@ import {
   subtractMasked,
 } from '@/sandbox'
 
-import { createLoopGuard, type LoopGuard } from './loop-guard'
+import { createLoopGuard, type LoopGuard, type LoopGuardDecision } from './loop-guard'
 import { checkImageReadRedirect } from './multimodal/read-redirect'
 import type { SessionOrigin } from './session-origin'
+import { SUBAGENT_OUTPUT_TOOL_NAME, type SubagentOutputToolDetails } from './tools/subagent-output'
 import { webFetchTool } from './tools/webfetch'
 import { webSearchTool } from './tools/websearch'
 
@@ -241,10 +242,10 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         return errorResult(`blocked: ${blockResult.reason}`)
       }
 
-      const loopDecision = sharedLoopGuard.check(opts.sessionId, opts.toolName, before.args)
-      if (loopDecision.kind === 'block') {
+      const loopGate = gateLoopGuard(opts.sessionId, opts.toolName, before.args)
+      if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort)
-        return errorResult(loopDecision.message)
+        return errorResult(loopGate.message)
       }
 
       const toolCtx: ToolContext = {
@@ -262,9 +263,12 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         return errorResult(message)
       }
 
-      if (loopDecision.kind === 'warn') {
-        result = appendLoopWarning(result, loopDecision.message)
+      const resolved = loopGate.resolve(result)
+      if ('deferredBlock' in resolved) {
+        fireLoopAbort(opts.getAbort)
+        return errorResult(resolved.deferredBlock)
       }
+      result = resolved.result
 
       await opts.hooks.runToolAfter({
         tool: opts.toolName,
@@ -301,10 +305,10 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
-      const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
-      if (loopDecision.kind === 'block') {
+      const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
+      if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort)
-        throw new Error(loopDecision.message)
+        throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
         tool: tool.name,
@@ -321,15 +325,12 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       stripGuardAcknowledgements(mutableArgs)
 
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx)
-      const hookResult: ToolResult = {
-        content: result.content as ContentPart[],
-        details: result.details,
+      const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
+      if ('deferredBlock' in resolved) {
+        fireLoopAbort(opts.getAbort)
+        throw new Error(resolved.deferredBlock)
       }
-      if (loopDecision.kind === 'warn') {
-        const warned = appendLoopWarning(hookResult, loopDecision.message)
-        hookResult.content = warned.content
-        hookResult.details = warned.details
-      }
+      const hookResult = resolved.result
       await opts.hooks.runToolAfter({
         tool: tool.name,
         sessionId: opts.sessionId,
@@ -337,7 +338,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
         result: hookResult,
       })
       return {
-        content: hookResult.content,
+        content: hookResult.content as ContentPart[],
         details: hookResult.details as TDetails,
       }
     },
@@ -364,10 +365,10 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
-      const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
-      if (loopDecision.kind === 'block') {
+      const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
+      if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort)
-        throw new Error(loopDecision.message)
+        throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
         tool: tool.name,
@@ -384,15 +385,12 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       stripGuardAcknowledgements(mutableArgs)
 
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate)
-      const hookResult: ToolResult = {
-        content: result.content as ContentPart[],
-        details: result.details,
+      const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
+      if ('deferredBlock' in resolved) {
+        fireLoopAbort(opts.getAbort)
+        throw new Error(resolved.deferredBlock)
       }
-      if (loopDecision.kind === 'warn') {
-        const warned = appendLoopWarning(hookResult, loopDecision.message)
-        hookResult.content = warned.content
-        hookResult.details = warned.details
-      }
+      const hookResult = resolved.result
       await opts.hooks.runToolAfter({
         tool: tool.name,
         sessionId: opts.sessionId,
@@ -400,7 +398,7 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
         result: hookResult,
       })
       return {
-        content: hookResult.content,
+        content: hookResult.content as ContentPart[],
         details: hookResult.details as TDetails,
       }
     },
@@ -442,10 +440,10 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       // loop-detection state, or pi's execute.
       const bashEnvOverlay = readBashEnvOverlay(mutableArgs)
       delete mutableArgs[TYPECLAW_INTERNAL_BASH_ENV]
-      const loopDecision = sharedLoopGuard.check(opts.sessionId, tool.name, mutableArgs)
-      if (loopDecision.kind === 'block') {
+      const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
+      if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort)
-        throw new Error(loopDecision.message)
+        throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
         tool: tool.name,
@@ -472,15 +470,12 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       const result = await bashEnvStore.run(bashEnvOverlay, () =>
         tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate),
       )
-      const hookResult: ToolResult = {
-        content: result.content as ContentPart[],
-        details: result.details,
+      const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
+      if ('deferredBlock' in resolved) {
+        fireLoopAbort(opts.getAbort)
+        throw new Error(resolved.deferredBlock)
       }
-      if (loopDecision.kind === 'warn') {
-        const warned = appendLoopWarning(hookResult, loopDecision.message)
-        hookResult.content = warned.content
-        hookResult.details = warned.details
-      }
+      const hookResult = resolved.result
       await opts.hooks.runToolAfter({
         tool: tool.name,
         sessionId: opts.sessionId,
@@ -607,6 +602,72 @@ async function applyTmpPathRedirect(
 function appendLoopWarning(result: ToolResult, message: string): ToolResult {
   const content: ContentPart[] = [...(result.content as ContentPart[]), { type: 'text', text: message }]
   return { content, details: result.details }
+}
+
+// `subagent_output` is a read-only poll whose loop/no-loop classification only
+// becomes knowable AFTER execution: a result of `status: 'running'` is a
+// still-pending wait (legitimate), while a repeated terminal result is a real
+// loop. The loop guard's `check` is result-blind and pre-execution, so for this
+// one tool we DEFER enforcing a block until the status is known — otherwise the
+// exact poll that would reveal 'running' gets blocked before it can run (the
+// boundary-call hazard for round-robin fan-out polling). Every other tool
+// enforces its block immediately, as before.
+// A block is deferred only for a `subagent_output` poll the guard still marks
+// `deferable` — i.e. whose signature has not yet proven terminal. Once a poll of
+// that signature returns completed/failed, `deferable` is false and the block is
+// enforced pre-execute, so a finished task is not re-polled forever.
+function shouldDeferLoopBlock(toolName: string, decision: LoopGuardDecision): boolean {
+  return toolName === SUBAGENT_OUTPUT_TOOL_NAME && decision.kind === 'block' && decision.deferable
+}
+
+function subagentPollStatus(toolName: string, result: ToolResult): 'running' | 'terminal' | undefined {
+  if (toolName !== SUBAGENT_OUTPUT_TOOL_NAME) return undefined
+  const details = result.details as SubagentOutputToolDetails | undefined
+  if (details?.ok !== true) return undefined
+  return details.status === 'running' ? 'running' : 'terminal'
+}
+
+type LoopGuardGate = {
+  // True when the guard wants to block AND the block is enforced now (every tool
+  // except a deferable `subagent_output` poll). The caller aborts + errors.
+  blockNow: boolean
+  message: string
+  // Resolves the guard against the tool's result. Returns the result to surface
+  // (possibly warn-annotated), or `{ deferredBlock: message }` when a deferred
+  // `subagent_output` block must now be enforced because the poll did not return
+  // a still-running status.
+  resolve: (result: ToolResult) => { result: ToolResult } | { deferredBlock: string }
+}
+
+// Single chokepoint for the loop-guard pre-check + post-execute resolution so
+// all four tool wrappers share identical deferred-block / pending-retract
+// semantics. `check` runs here (recording the observation); the returned
+// `resolve` is called after execute with the tool's result, feeding the poll's
+// running/terminal status back to the guard so future blocks stop deferring.
+function gateLoopGuard(sessionId: string, toolName: string, args: unknown): LoopGuardGate {
+  const decision = sharedLoopGuard.check(sessionId, toolName, args)
+  const defer = shouldDeferLoopBlock(toolName, decision)
+  return {
+    blockNow: decision.kind === 'block' && !defer,
+    message: decision.kind === 'ok' ? '' : decision.message,
+    resolve(result) {
+      const pollStatus = subagentPollStatus(toolName, result)
+      if (pollStatus !== undefined) {
+        sharedLoopGuard.noteResult(decision.receipt, pollStatus)
+      }
+      if (pollStatus === 'running') {
+        sharedLoopGuard.retract(decision.receipt)
+        return { result }
+      }
+      if (defer && decision.kind === 'block') {
+        return { deferredBlock: decision.message }
+      }
+      if (decision.kind === 'warn') {
+        return { result: appendLoopWarning(result, decision.message) }
+      }
+      return { result }
+    },
+  }
 }
 
 // Clears one tool's loop-guard residue for a session on the process-wide shared

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -58,9 +58,13 @@ export function createSubagentOutputTool(options: CreateSubagentOutputToolOption
       'Fetch the current state of a subagent you previously spawned. Returns one of three statuses: ' +
       "'running' (with a human-readable status_summary and a tail of recent progress events), " +
       "'completed' (with the final message), or 'failed' (with the error). " +
-      'Returns immediately with a snapshot — never blocks. ' +
-      'For backgrounded spawns, end your turn after spawning and wait for the completion <system-reminder>; ' +
-      'then call this once to fetch the result. Use it for ad-hoc status checks too — never in a polling loop.',
+      'Returns immediately with a snapshot — never blocks, so calling it again right away just returns the same ' +
+      "'running' snapshot and wastes a turn. " +
+      'For backgrounded spawns, END YOUR TURN after spawning and wait for the completion <system-reminder>; ' +
+      'it arrives on its own when the subagent finishes — you do NOT need to poll for it. ' +
+      'Then call this once to fetch the result. ' +
+      'Do NOT poll in a loop, and do NOT round-robin across several task_ids while they run — ' +
+      'that is treated as a loop and will be blocked. Use it only for a single ad-hoc status check.',
     parameters: Type.Object({
       task_id: Type.String({
         description: 'The task_id returned by a previous spawn_subagent call.',


### PR DESCRIPTION
## Background

A subagent that fans out several backgrounded children and polls `subagent_output` round-robin while they run gets hard-blocked by the windowed loop detector — even though it is making progress.

Observed in production (researcher subagent, session `019e989a-c47c`): it spawned 6 `scout` children, then polled `subagent_output(task_id=…)` in waves of 6 every ~2s, ~75 polls over 35s. As scouts finished and dropped out of the poll set, the survivors were polled more *densely* inside the 16-call sliding window. With `WINDOW_HARD_BLOCK=6`, the last two surviving task_ids hit count 6 within the window and were refused:

```
loop-guard: refused `subagent_output` — called on the same target 6 times in a short span.
```

Every one of those polls had returned status `running` — the task simply wasn't done yet. The block told the agent to "produce the final answer with the data you already have," but the data legitimately wasn't ready.

Root-cause mechanism: the guard's `check` is **result-blind and pre-execution**, but the signal that separates "waiting" (legitimate) from "looping" (wasteful) is the poll's **post-execution status** (`running` vs `completed`/`failed`). The detector had no way to see it, so it counted a still-pending wait as a loop. The existing `forgetTool` rescue valve only fires when a *child completes and reminds its parent* — never while children are still running, which is exactly when this block lands.

## Summary

Make `subagent_output` loop detection result-aware without breaking the result-blind contract for every other tool.

- **`retract(receipt)`** on the guard undoes exactly one recorded observation — pops its windowed entry and rewinds the consecutive streak by one. Far narrower than `forgetTool` (which drops the whole tool window), so unrelated task_ids and terminal-result polls keep their accumulated signal.
- **Deferred block + `noteResult`.** A `subagent_output` block is `deferable` until its signature has proven terminal. The wrapper defers such a block, runs the boundary poll to learn its status, then:
  - `running` → `retract` the observation (never blocks, never accumulates);
  - `completed`/`failed` → `noteResult(terminal)` and enforce the block.
  Once a signature is terminal-known, further identical polls hard-block **pre-execute** — so a finished task is not re-polled forever just to re-confirm it's done.

Why deferral and not "just exempt `subagent_output` from the windowed detector": exemption loses protection against genuinely-stuck polling of an already-terminal task. Why not raise thresholds: papers over it and breaks again at higher fan-out. The deferred-classify approach is the only one that both never false-blocks a legitimate wait *and* still stops a real terminal-poll loop. (Design vetted with a read-only reasoning pass; the boundary-call hazard — the exact poll that reveals `running` getting blocked before it runs — is the reason enforcement is deferred rather than retraction alone.)

Also strengthens the `subagent_output` tool description: end the turn after spawning and wait for the completion `<system-reminder>`; do not round-robin poll. The busy-poll is the upstream behavioral trigger; the guard fix is defense-in-depth.

## What this does NOT do

- Does not change loop-guard behavior for any tool other than `subagent_output`. All other blocks stay pre-execute and result-blind, exactly as before.
- Does not touch the completion-reminder bridges (`router.ts` / `server`) beyond `forgetTool` now also clearing terminal-known marks.
- Does not change windowed/consecutive thresholds.

## Review notes

- Load-bearing invariant in `loop-guard.ts`: `retract` assumes the receipt names the **most recent** `check` on that session — true because tool execution within a turn is sequential, so "remove last match" is correct.
- The boundary terminal poll executes **once** (deferred) to learn its status, then blocks; from the next identical poll on, the block is pre-execute (tool never runs again). Both behaviors are pinned by tests in `plugin-tools.test.ts`.
- `SUBAGENT_OUTPUT_TOOL` is a local literal in `loop-guard.ts` (kept dependency-free) that must match `SUBAGENT_OUTPUT_TOOL_NAME` in `tools/subagent-output.ts`.
- New tests: `loop-guard.test.ts` (retract + noteResult/deferable, incl. the 6-task fan-out replay) and `plugin-tools.test.ts` (end-to-end wrapper: running never blocks, terminal still blocks).
