### PR TITLE
refactor(agent): generate the subagent orchestration roster from the registry

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -77,6 +77,35 @@ describe('createResourceLoader', () => {
     expect(prompt.startsWith(DEFAULT_SYSTEM_PROMPT)).toBe(true)
   })
 
+  test('slim mode does not render or validate the public-subagent roster', async () => {
+    // given — a public subagent with a blank rosterDescription, which would
+    // make renderPublicSubagentRoster throw if it were called
+    const badRegistry: SubagentRegistry = {
+      offender: { systemPrompt: 'x', visibility: 'public', rosterDescription: '' },
+    }
+
+    // when / then — a slim session never shows the roster, so it must not throw
+    const loader = await createResourceLoader({
+      agentDir,
+      mode: 'slim',
+      subagentRegistry: badRegistry,
+    })
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt.startsWith(SLIM_SYSTEM_PROMPT)).toBe(true)
+  })
+
+  test('full mode surfaces a bad public rosterDescription as a thrown error', async () => {
+    // given
+    const badRegistry: SubagentRegistry = {
+      offender: { systemPrompt: 'x', visibility: 'public', rosterDescription: '' },
+    }
+
+    // when / then
+    await expect(createResourceLoader({ agentDir, mode: 'full', subagentRegistry: badRegistry })).rejects.toThrow(
+      /offender.*rosterDescription/,
+    )
+  })
+
   test('does not append SYSTEM.md files discovered by pi defaults', async () => {
     // Pi's DefaultResourceLoader auto-appends ~/.pi/agent/APPEND_SYSTEM.md and
     // .pi/APPEND_SYSTEM.md. Typeclaw owns the whole system prompt, so nothing

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1033,11 +1033,18 @@ export function composeSystemPrompt(parts: SystemPromptComposition): string {
 export async function createResourceLoader(options: CreateResourceLoaderOptions = {}): Promise<DefaultResourceLoader> {
   const agentDir = options.agentDir ?? process.cwd()
   const mode: SystemPromptMode = options.mode ?? deriveSystemPromptMode(options.origin)
+  // Slim mode (cron/subagent) has no orchestration section, so it never reads
+  // the roster. Skip rendering it there — `renderPublicSubagentRoster` throws on
+  // a public subagent with a missing/blank `rosterDescription`, and a slim
+  // session must not fail on a roster it will never show.
   const subagentRoster =
-    options.subagentRegistry !== undefined
-      ? renderPublicSubagentRoster(options.subagentRegistry)
-      : DEFAULT_SUBAGENT_ROSTER
-  const basePrompt = mode === 'slim' ? SLIM_SYSTEM_PROMPT : buildDefaultSystemPrompt(subagentRoster)
+    mode === 'slim'
+      ? undefined
+      : options.subagentRegistry !== undefined
+        ? renderPublicSubagentRoster(options.subagentRegistry)
+        : DEFAULT_SUBAGENT_ROSTER
+  const basePrompt =
+    mode === 'slim' ? SLIM_SYSTEM_PROMPT : buildDefaultSystemPrompt(subagentRoster ?? DEFAULT_SUBAGENT_ROSTER)
 
   // Kick off the three independent I/O paths concurrently. Sequential awaits
   // here used to be the dominant cold-start cost amplifier: loadSelf is 2

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -53,7 +53,12 @@ import { loadSelf } from './self'
 import { SESSION_META_CUSTOM_TYPE, sessionMetaPayload } from './session-meta'
 import { renderSessionOrigin, type SessionOrigin, type SessionRoleContext } from './session-origin'
 import type { CreateSessionForSubagent, SubagentRegistry } from './subagents'
-import { DEFAULT_SYSTEM_PROMPT, renderRuntimeBlock, SLIM_SYSTEM_PROMPT } from './system-prompt'
+import {
+  buildDefaultSystemPrompt,
+  DEFAULT_SUBAGENT_ROSTER,
+  renderRuntimeBlock,
+  SLIM_SYSTEM_PROMPT,
+} from './system-prompt'
 import { attachToolNotFoundNudge } from './tool-not-found-nudge'
 import {
   createBudgetState,
@@ -69,7 +74,7 @@ import { createChannelSendTool } from './tools/channel-send'
 import { createGrantRoleTool } from './tools/grant-role'
 import { createRestartTool } from './tools/restart'
 import { createSkipResponseTool } from './tools/skip-response'
-import { createSpawnSubagentTool } from './tools/spawn-subagent'
+import { createSpawnSubagentTool, renderPublicSubagentRoster } from './tools/spawn-subagent'
 import { createStreamSnapshotTool } from './tools/stream-snapshot'
 import { createSubagentCancelTool } from './tools/subagent-cancel'
 import { createSubagentOutputTool } from './tools/subagent-output'
@@ -256,6 +261,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
           ...(options.permissions ? { permissions: options.permissions } : {}),
           ...(options.runtimeVersion !== undefined ? { runtimeVersion: options.runtimeVersion } : {}),
           ...(options.mcpManager !== undefined ? { mcpManager: options.mcpManager } : {}),
+          ...(options.subagentRegistry !== undefined ? { subagentRegistry: options.subagentRegistry } : {}),
         })
 
   const getOrigin: () => SessionOrigin | undefined =
@@ -899,6 +905,12 @@ export type CreateResourceLoaderOptions = {
   mcpManager?: McpManager
   permissions?: PermissionService
   runtimeVersion?: string
+  // Public subagents whose names + `rosterDescription`s render the full-mode
+  // "## Subagent orchestration" roster. When omitted (no-registry callers, the
+  // debug dumper), the prompt falls back to `DEFAULT_SUBAGENT_ROSTER`. Threaded
+  // from `createSessionWithDispose`, where the merged registry is already in
+  // scope.
+  subagentRegistry?: SubagentRegistry
   // Explicit override for the prompt mode. When omitted, the mode is derived
   // from `origin.kind`: cron + subagent → slim, tui + channel → full. Pass
   // 'full' to force the heavy prompt even on an unattended origin (rarely
@@ -957,6 +969,11 @@ export type SystemPromptMode = 'full' | 'slim'
 export type SystemPromptComposition = {
   mode?: SystemPromptMode
   self: string
+  // Pre-rendered full-mode orchestration roster (from `renderPublicSubagentRoster`).
+  // Kept as a ready string so this composer stays pure and registry-free; the
+  // registry-aware caller renders it. Ignored in slim mode (no roster section).
+  // Falls back to `DEFAULT_SUBAGENT_ROSTER` when omitted.
+  subagentRoster?: string
   runtimeVersion?: string
   origin?: SessionOrigin
   roleContext?: SessionRoleContext
@@ -990,7 +1007,10 @@ export type SystemPromptComposition = {
 // suffix anyway — and removes the staleness failure mode where a session
 // opened Friday answered "today is Friday" on Thursday.
 export function composeSystemPrompt(parts: SystemPromptComposition): string {
-  const base = parts.mode === 'slim' ? SLIM_SYSTEM_PROMPT : DEFAULT_SYSTEM_PROMPT
+  const base =
+    parts.mode === 'slim'
+      ? SLIM_SYSTEM_PROMPT
+      : buildDefaultSystemPrompt(parts.subagentRoster ?? DEFAULT_SUBAGENT_ROSTER)
   let prompt = `${base}\n\n${parts.self}`
   if (parts.runtimeVersion !== undefined) {
     prompt = `${prompt}\n\n${renderRuntimeBlock(parts.runtimeVersion)}`
@@ -1013,7 +1033,11 @@ export function composeSystemPrompt(parts: SystemPromptComposition): string {
 export async function createResourceLoader(options: CreateResourceLoaderOptions = {}): Promise<DefaultResourceLoader> {
   const agentDir = options.agentDir ?? process.cwd()
   const mode: SystemPromptMode = options.mode ?? deriveSystemPromptMode(options.origin)
-  const basePrompt = mode === 'slim' ? SLIM_SYSTEM_PROMPT : DEFAULT_SYSTEM_PROMPT
+  const subagentRoster =
+    options.subagentRegistry !== undefined
+      ? renderPublicSubagentRoster(options.subagentRegistry)
+      : DEFAULT_SUBAGENT_ROSTER
+  const basePrompt = mode === 'slim' ? SLIM_SYSTEM_PROMPT : buildDefaultSystemPrompt(subagentRoster)
 
   // Kick off the three independent I/O paths concurrently. Sequential awaits
   // here used to be the dominant cold-start cost amplifier: loadSelf is 2
@@ -1077,6 +1101,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   const systemPrompt = composeSystemPrompt({
     mode,
     self,
+    subagentRoster,
     ...(options.runtimeVersion !== undefined ? { runtimeVersion: options.runtimeVersion } : {}),
     ...(options.origin !== undefined ? { origin: options.origin } : {}),
     ...(roleContext !== undefined ? { roleContext } : {}),

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -48,6 +48,13 @@ export type SubagentShared<P = unknown> = {
   handler?: (ctx: SubagentContext<P>, runSession: RunSession) => Promise<void>
   toolResultBudget?: ToolResultBudget
   visibility?: 'public' | 'internal'
+  // One-line purpose blurb for the main agent's "## Subagent orchestration"
+  // roster, rendered from the registry by `renderPublicSubagentRoster` instead
+  // of hand-maintained in the prompt (the drift that once left `researcher` and
+  // `planner` unlisted). Required for `visibility: 'public'`; ignored otherwise.
+  // On `SubagentShared` so the plugin→internal shim carries it via rest-spread
+  // (see `pluginSubagentShim`), like `visibility`.
+  rosterDescription?: string
   requiresSpecificPermission?: boolean
   // Opt-in: when true, this subagent's session is wired with the orchestration
   // tools (spawn_subagent/subagent_output/subagent_cancel) so it can delegate

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,6 +1,15 @@
 import { formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from '@/shared'
 
-export const DEFAULT_SYSTEM_PROMPT = `You are a general-purpose AI agent running inside TypeClaw.
+// The orchestration roster (the `Briefly: ...` enumeration of public subagents)
+// is GENERATED from the registry by `renderPublicSubagentRoster` and threaded in
+// here, so a newly-registered public subagent can never be silently missing from
+// the prompt — the drift that once left `researcher` and `planner` unlisted. The
+// rest of the prompt is static. `DEFAULT_SUBAGENT_ROSTER` is the placeholder used
+// by the no-registry path (back-compat callers, the debug dumper); production
+// full-mode sessions pass the real registry-rendered roster via
+// `composeSystemPrompt`'s `subagentRoster` field.
+export function buildDefaultSystemPrompt(subagentRoster: string): string {
+  return `You are a general-purpose AI agent running inside TypeClaw.
 
 TypeClaw is domain-agnostic — your purpose is defined by \`IDENTITY.md\`, your character by \`SOUL.md\`, and your operating manual by \`AGENTS.md\`. This system prompt only describes the runtime around you.
 
@@ -80,7 +89,7 @@ Your agent folder is a git repository.
 
 ## Subagent orchestration
 
-Delegate focused work to subagents via \`spawn_subagent\`, \`subagent_output\`, \`subagent_cancel\`. Each runs in its own context window with its own tool set. The available subagents and their purpose are listed in the \`spawn_subagent\` tool description — re-read it before delegating. Briefly: \`explorer\` (read-only local recon — code, sessions, memory, git, config; fire liberally), \`scout\` (fast single-pass web lookup in a fresh context), \`researcher\` (deep multi-source investigation in a fresh context — decomposes a fuzzy question, gathers from many sources, cross-validates, and returns a citation-backed report; the quality-over-speed counterpart to \`scout\`, for any research that needs more than one lookup), \`reviewer\` (deep read-only code/PR/plan review, returns a structured verdict; it does NOT post), \`operator\` (write-capable: bash-with-side-effects, write, edit — for browser sessions, refactors, deploys, batch ops, and Claude Code / Codex CLI driving; gated by \`subagent.spawn.operator\`, owner/trusted only — on denial, do the work yourself), \`planner\` (turns a goal — a trip, a launch, a migration, a feature — into an actionable, sequenced, risk-aware plan, writes it to a file, and returns a structured signal; domain-neutral and reasoning-heavy, for any multi-step goal worth thinking through before acting; consider a \`reviewer\` pass on the plan it produces).
+Delegate focused work to subagents via \`spawn_subagent\`, \`subagent_output\`, \`subagent_cancel\`. Each runs in its own context window with its own tool set. The available subagents and their purpose are listed in the \`spawn_subagent\` tool description — re-read it before delegating. Briefly: ${subagentRoster}.
 
 There are three delegation modes. Pick deliberately.
 
@@ -109,6 +118,22 @@ You have no independent goals. Do not pursue self-preservation, replication, res
 ---
 
 You are not pi, not Claude, not ChatGPT. You are the agent described by your own IDENTITY.md and SOUL.md. Let those files define your voice.`
+}
+
+// Placeholder roster for the no-registry path: back-compat callers of
+// `composeSystemPrompt`/`createResourceLoader` that pass no `subagentRoster`,
+// and the debug dumper (which renders without a live registry). Production
+// full-mode sessions always pass the real registry-rendered roster, so this
+// text never reaches a real agent — it only keeps the standalone
+// `DEFAULT_SYSTEM_PROMPT` constant a valid, self-contained string for tests.
+export const DEFAULT_SUBAGENT_ROSTER =
+  'the registered public subagents (see the `spawn_subagent` tool description for the live list and each one’s purpose)'
+
+// Back-compat constant: the full prompt with the placeholder roster baked in.
+// Retained because several tests assert `prompt.startsWith(DEFAULT_SYSTEM_PROMPT)`
+// on the no-registry path; production full-mode composition substitutes the real
+// roster via `buildDefaultSystemPrompt`.
+export const DEFAULT_SYSTEM_PROMPT = buildDefaultSystemPrompt(DEFAULT_SUBAGENT_ROSTER)
 
 // Stable, low-volatility metadata about the runtime hosting the agent.
 // Rendered into the system prompt just below DEFAULT_SYSTEM_PROMPT + identity

--- a/src/agent/tools/spawn-subagent.roster.test.ts
+++ b/src/agent/tools/spawn-subagent.roster.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createExplorerSubagent } from '@/bundled-plugins/explorer/explorer'
+import { createOperatorSubagent } from '@/bundled-plugins/operator/operator'
+import { createPlannerSubagent } from '@/bundled-plugins/planner/planner'
+import { createResearcherSubagent } from '@/bundled-plugins/researcher/researcher'
+import { createReviewerSubagent } from '@/bundled-plugins/reviewer/reviewer'
+import { createScoutSubagent } from '@/bundled-plugins/scout/scout'
+import type { Subagent as PluginSubagent } from '@/plugin'
+
+import { composeSystemPrompt } from '../index'
+import type { Subagent, SubagentRegistry } from '../subagents'
+import { renderPublicSubagentRoster } from './spawn-subagent'
+
+// Mirror the production plugin→internal shim (`pluginSubagentShim` in
+// src/run/index.ts): strip the plugin-only fields so the bundled factories'
+// plugin-shaped output becomes an internal `Subagent`. The renderer only reads
+// `SubagentShared` fields (`visibility`, `rosterDescription`), which ride this
+// rest-spread verbatim — exactly the runtime path under test.
+function toInternal<P>(sub: PluginSubagent<P>): Subagent<P> {
+  const { tools: _tools, customTools: _customTools, inFlightKey: _inFlightKey, ...shared } = sub
+  return shared
+}
+
+// The real bundled public subagents, assembled the way the runtime registers
+// them. This is the drift fixture: if a new public subagent is added to the
+// bundled set, adding it here makes the "every public subagent is in the roster"
+// test cover it; forgetting its `rosterDescription` makes the renderer throw.
+const BUNDLED_PUBLIC: SubagentRegistry = {
+  explorer: toInternal(createExplorerSubagent()),
+  scout: toInternal(createScoutSubagent()),
+  researcher: toInternal(createResearcherSubagent()),
+  reviewer: toInternal(createReviewerSubagent()),
+  operator: toInternal(createOperatorSubagent()),
+  planner: toInternal(createPlannerSubagent()),
+}
+
+const PUBLIC_NAMES = Object.keys(BUNDLED_PUBLIC)
+
+describe('renderPublicSubagentRoster', () => {
+  test('lists every public bundled subagent with its description', () => {
+    // when
+    const roster = renderPublicSubagentRoster(BUNDLED_PUBLIC)
+
+    // then
+    for (const name of PUBLIC_NAMES) {
+      expect(roster).toContain(`\`${name}\``)
+      const description = BUNDLED_PUBLIC[name]?.rosterDescription
+      expect(description).toBeDefined()
+      expect(roster).toContain(description as string)
+    }
+  })
+
+  test('would have caught the researcher/planner drift: both appear in the rendered roster', () => {
+    // given — the exact subagents that were silently missing from the
+    // hand-maintained prompt before this guard existed
+    const roster = renderPublicSubagentRoster(BUNDLED_PUBLIC)
+
+    // then
+    expect(roster).toContain('`researcher`')
+    expect(roster).toContain('`planner`')
+  })
+
+  test('omits internal subagents from the roster', () => {
+    // given
+    const internal: Subagent<unknown> = {
+      systemPrompt: 'internal worker',
+      visibility: 'internal',
+      rosterDescription: 'should never be shown',
+    }
+    const registry: SubagentRegistry = { ...BUNDLED_PUBLIC, 'memory-logger': internal }
+
+    // when
+    const roster = renderPublicSubagentRoster(registry)
+
+    // then
+    expect(roster).not.toContain('`memory-logger`')
+    expect(roster).not.toContain('should never be shown')
+  })
+
+  test('throws when a public subagent has no rosterDescription (fail-loud contract)', () => {
+    // given
+    const registry: SubagentRegistry = {
+      offender: { systemPrompt: 'x', visibility: 'public' },
+    }
+
+    // when / then
+    expect(() => renderPublicSubagentRoster(registry)).toThrow(/offender.*rosterDescription/)
+  })
+
+  test('throws when a public subagent has a blank rosterDescription', () => {
+    // given
+    const registry: SubagentRegistry = {
+      offender: { systemPrompt: 'x', visibility: 'public', rosterDescription: '   ' },
+    }
+
+    // when / then
+    expect(() => renderPublicSubagentRoster(registry)).toThrow(/offender.*rosterDescription/)
+  })
+})
+
+describe('composeSystemPrompt with the registry-rendered roster', () => {
+  test('the full prompt names every public subagent', () => {
+    // given
+    const roster = renderPublicSubagentRoster(BUNDLED_PUBLIC)
+
+    // when
+    const prompt = composeSystemPrompt({
+      mode: 'full',
+      self: 'IDENTITY',
+      subagentRoster: roster,
+      gitNudge: '',
+      memorySection: '',
+    })
+
+    // then
+    expect(prompt).toContain('## Subagent orchestration')
+    for (const name of PUBLIC_NAMES) {
+      expect(prompt).toContain(`\`${name}\``)
+    }
+  })
+
+  test('slim mode renders no orchestration roster', () => {
+    // when
+    const prompt = composeSystemPrompt({
+      mode: 'slim',
+      self: 'IDENTITY',
+      subagentRoster: renderPublicSubagentRoster(BUNDLED_PUBLIC),
+      gitNudge: '',
+      memorySection: '',
+    })
+
+    // then
+    expect(prompt).not.toContain('## Subagent orchestration')
+  })
+})

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -246,6 +246,27 @@ function publicSubagentNames(registry: SubagentRegistry): string[] {
     .sort()
 }
 
+// Render the "## Subagent orchestration" roster from the registry so it can
+// never drift from the actually-registered public subagents (the bug that left
+// `researcher`/`planner` unlisted). Same filter+sort as `publicSubagentNames`,
+// so this roster and the `spawn_subagent` tool description agree by
+// construction. Throws if a public subagent lacks `rosterDescription` — a
+// fail-loud contract that turns "silently missing from the prompt" into a build
+// error caught by the drift-guard test.
+export function renderPublicSubagentRoster(registry: SubagentRegistry): string {
+  return publicSubagentNames(registry)
+    .map((name) => {
+      const description = registry[name]?.rosterDescription?.trim()
+      if (description === undefined || description === '') {
+        throw new Error(
+          `public subagent "${name}" is missing rosterDescription (required for the orchestration roster)`,
+        )
+      }
+      return `\`${name}\` (${description})`
+    })
+    .join(', ')
+}
+
 function isPublicSubagent(sub: Subagent<unknown>): boolean {
   return sub.visibility === 'public'
 }

--- a/src/bundled-plugins/explorer/explorer.ts
+++ b/src/bundled-plugins/explorer/explorer.ts
@@ -94,6 +94,8 @@ export function createExplorerSubagent(): Subagent<ExplorerPayload> {
     tools: [readTool, grepTool, findTool, lsTool, bashTool],
     payloadSchema: explorerPayloadSchema,
     visibility: 'public',
+    rosterDescription:
+      'read-only local recon — code, sessions, memory, git, config; returns the paths and excerpts you need without you grepping the tree yourself; fire liberally',
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     toolResultBudget: {
       maxTotalBytes: 256_000,

--- a/src/bundled-plugins/operator/operator.ts
+++ b/src/bundled-plugins/operator/operator.ts
@@ -69,6 +69,8 @@ export function createOperatorSubagent(): Subagent<OperatorPayload> {
     tools: [readTool, grepTool, findTool, lsTool, bashTool, writeTool, editTool],
     payloadSchema: operatorPayloadSchema,
     visibility: 'public',
+    rosterDescription:
+      'write-capable: bash-with-side-effects, write, edit — for browser sessions, refactors, deploys, batch ops, and Claude Code / Codex CLI driving; gated by `subagent.spawn.operator`, owner/trusted only — on denial, do the work yourself',
     requiresSpecificPermission: true,
     canSpawnSubagents: true,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,

--- a/src/bundled-plugins/planner/planner.ts
+++ b/src/bundled-plugins/planner/planner.ts
@@ -266,6 +266,8 @@ If none of the listed skills fit the goal, load \`general\`. Keep the skill-sele
     customTools: [loadSkillTool],
     payloadSchema: plannerPayloadSchema,
     visibility: 'public',
+    rosterDescription:
+      'turns a goal — a trip, a launch, a migration, a feature — into an actionable, sequenced, risk-aware plan, writes it to a file, and returns a structured signal; domain-neutral and reasoning-heavy, for any multi-step goal worth thinking through before acting; consider a `reviewer` pass on the plan it produces',
     canSpawnSubagents: true,
     timeoutMs: PLANNER_SPAWN_TIMEOUT_MS,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,

--- a/src/bundled-plugins/researcher/researcher.ts
+++ b/src/bundled-plugins/researcher/researcher.ts
@@ -201,6 +201,8 @@ If none of the listed skills fit the question, load \`general\`. Keep the skill-
     customTools: [loadSkillTool, createWriteReportTool()],
     payloadSchema: researcherPayloadSchema,
     visibility: 'public',
+    rosterDescription:
+      'deep multi-source investigation in a fresh context — decomposes a fuzzy question, gathers from many sources, cross-validates, and returns a citation-backed report; the quality-over-speed counterpart to `scout`, for any research that needs more than one lookup',
     // No `requiresSpecificPermission`: unlike `operator` (generic write/edit +
     // side-effecting bash), the researcher's only write goes through the
     // `write_report` tool, which enforces "one report file under

--- a/src/bundled-plugins/reviewer/reviewer.ts
+++ b/src/bundled-plugins/reviewer/reviewer.ts
@@ -196,6 +196,8 @@ If none of the listed skills fit the target, load \`general\`. Keep the skill-se
     customTools: [loadSkillTool],
     payloadSchema: reviewerPayloadSchema,
     visibility: 'public',
+    rosterDescription:
+      'deep read-only code/PR/plan review in a fresh context, returns a structured verdict; it does NOT post — you act on its findings',
     canSpawnSubagents: true,
     timeoutMs: REVIEWER_SPAWN_TIMEOUT_MS,
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,

--- a/src/bundled-plugins/scout/scout.ts
+++ b/src/bundled-plugins/scout/scout.ts
@@ -85,6 +85,8 @@ export function createScoutSubagent(): Subagent<ScoutPayload> {
     tools: [webSearchTool, webFetchTool],
     payloadSchema: scoutPayloadSchema,
     visibility: 'public',
+    rosterDescription:
+      'fast single-pass web lookup in a fresh context — searches and fetches, returns citation-backed findings without the raw pages touching your context',
     inFlightKey: (payload) => payload?.requestId ?? `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     toolResultBudget: {
       maxTotalBytes: 512_000,


### PR DESCRIPTION
## Background

The main agent's "## Subagent orchestration" roster — the prose that tells the agent which subagents exist and what each is for — was hand-maintained inside `DEFAULT_SYSTEM_PROMPT`. It drifted from the actual registry twice: `researcher` and `planner` were both registered, `visibility: 'public'`, and spawnable, but were never listed in the prompt. The agent was literally never told they exist, so it never delegated to them (it defaulted to inline `web_search` for research, and never used the planner at all). #667 fixes the symptom by hand-adding both names. This PR fixes the bug class: a hand-maintained list that has to be kept in sync with the registry by memory will drift again.

The drift was invisible because the `spawn_subagent` tool's `subagent_type` param points the model at "the system prompt section 'Subagent orchestration' for the available list" — but that list was static prose, while the tool's OWN description was already generated from the registry. Two sources of truth, one of them stale.

## Summary

Make the roster a projection of the registry, so a registered public subagent can never be silently missing from the prompt.

- **`rosterDescription` on `SubagentShared`** (commit 1) — each public subagent owns its one-line, prompt-facing purpose blurb next to its code, populated on all six bundled public subagents. It lives on `SubagentShared`, so it rides the plugin→internal shim's rest-spread verbatim (like `visibility`) — no shim change.
- **`renderPublicSubagentRoster(registry)`** (commit 2) — builds the roster from the same filter+sort as the `spawn_subagent` tool description, so the prompt roster and the tool description agree by construction (collapsing the two-sources-of-truth split). It THROWS if a public subagent lacks `rosterDescription`, turning "silently missing from the prompt" into a loud build/test failure.
- **`buildDefaultSystemPrompt(roster)`** parameterizes only the roster line. The rest of the prompt is byte-for-byte unchanged, and the roster stays in the least-volatile base region — so the cache-suffix contract (enforced by `dump-system-prompt.test.ts`) is untouched. `DEFAULT_SYSTEM_PROMPT` is retained as a placeholder-roster constant for the no-registry path and the existing `startsWith` back-compat tests.
- **Threading**: `createResourceLoader` renders the roster from `subagentRegistry` (already in scope at `createSessionWithDispose`, where the merged registry lives) for full mode. Slim mode (cron/subagent) is unchanged — it has no orchestration section.

Why a pre-rendered string field on `SystemPromptComposition` rather than passing the registry into `composeSystemPrompt`: keeps the composer pure and registry-free (the dump script and tests can pass a placeholder), matching the existing "each field maps 1:1 to a rendered section" design.

## What this does NOT do

- Does not change the Mode A/B/C delegation prose or any wording beyond the generated roster line. #667 owns the per-mode mentions of `researcher`/`planner`; once both land, the roster is generated and the mode prose is editorial guidance.
- Does not touch the slim prompt — cron/subagent origins still have no roster section.
- Does not change permissions, dispatch, or the registry contents. Pure prompt-composition refactor.
- Does not auto-discover subagents from plugins at prompt-render time — it projects the already-merged registry that session creation hands it.

## Review notes

The load-bearing pieces: `renderPublicSubagentRoster` (the generator + fail-loud throw) in `src/agent/tools/spawn-subagent.ts`, and the `buildDefaultSystemPrompt` parameterization in `src/agent/system-prompt.ts`. Verify the cache-suffix contract is intact: the orchestration section is still inside the base region, so `dump-system-prompt.test.ts`'s ordering anchors are unchanged (they pass). The drift-guard test (`spawn-subagent.roster.test.ts`) builds the real bundled public subagents via the same field-strip the production shim does, renders the roster, and asserts every public name + blurb appears (explicitly `researcher`/`planner`), internal subagents are omitted, and a missing/blank `rosterDescription` throws. Production wiring confirmed: `src/run/index.ts` passes `subagentRegistry: pluginRuntime.get().subagents` into session creation, which now threads to the loader. Full suite: 7550 pass / 0 fail (7 new).

Builds on #667.