### PR TITLE
fix(secrets): migrate pre-0.20.0 secrets.json to v2 on disk

### DIFF
--- a/src/migrations/index.test.ts
+++ b/src/migrations/index.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { MIGRATION_ID, runStartupMigrations } from './index'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tc-mig-runner-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('runStartupMigrations', () => {
+  test('reports the secrets migration as changed when a v1 file is upgraded', () => {
+    writeFileSync(
+      join(dir, 'secrets.json'),
+      JSON.stringify({ version: 1, llm: {}, channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'd' } } }),
+    )
+
+    const outcomes = runStartupMigrations(dir, () => {})
+
+    const secrets = outcomes.find((o) => o.id === MIGRATION_ID)
+    expect(secrets?.changed).toBe(true)
+    expect(secrets?.error).toBeUndefined()
+  })
+
+  test('captures a migration throw as a per-migration error without propagating', () => {
+    writeFileSync(
+      join(dir, 'auth.json'),
+      JSON.stringify({ version: 1, llm: { openai: { type: 'api_key', key: 'a' } }, channels: {} }),
+    )
+    writeFileSync(
+      join(dir, 'secrets.json'),
+      JSON.stringify({ version: 2, providers: { openai: { type: 'api_key', key: { value: 's' } } }, channels: {} }),
+    )
+
+    const logged: string[] = []
+    const outcomes = runStartupMigrations(dir, (m) => logged.push(m))
+
+    const secrets = outcomes.find((o) => o.id === MIGRATION_ID)
+    expect(secrets?.changed).toBe(false)
+    expect(secrets?.error).toBeDefined()
+    expect(logged.some((m) => /failed/.test(m))).toBe(true)
+  })
+
+  test('a clean v2 folder produces no changes and logs nothing', () => {
+    writeFileSync(join(dir, 'secrets.json'), JSON.stringify({ version: 2, providers: {}, channels: {} }))
+
+    const logged: string[] = []
+    const outcomes = runStartupMigrations(dir, (m) => logged.push(m))
+
+    expect(outcomes.every((o) => !o.changed)).toBe(true)
+    expect(logged).toEqual([])
+    expect(JSON.parse(readFileSync(join(dir, 'secrets.json'), 'utf8')).version).toBe(2)
+  })
+})

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,35 @@
+import { MIGRATION_ID, migrateSecretsV1ToV2, type SecretsMigrationResult } from './secrets-v1-to-v2'
+
+export { MIGRATION_ID, migrateSecretsV1ToV2, type SecretsMigrationResult }
+
+export type Migration = {
+  id: string
+  run: (agentDir: string) => SecretsMigrationResult
+}
+
+export type MigrationOutcome = { id: string; changed: boolean; summary: string; error?: string }
+
+const MIGRATIONS: readonly Migration[] = [{ id: MIGRATION_ID, run: migrateSecretsV1ToV2 }]
+
+// Each migration is isolated: a throw is captured per-migration so one folder's
+// unsafe state (e.g. both auth.json and a non-empty secrets.json) is reported
+// loudly without aborting boot or blocking later migrations. Returns one
+// outcome per registered migration so the caller can log what happened.
+export function runStartupMigrations(
+  agentDir: string,
+  log: (message: string) => void = (m) => console.warn(m),
+): MigrationOutcome[] {
+  const outcomes: MigrationOutcome[] = []
+  for (const migration of MIGRATIONS) {
+    try {
+      const result = migration.run(agentDir)
+      if (result.changed) log(`migration ${migration.id}: ${result.summary}`)
+      outcomes.push({ id: migration.id, changed: result.changed, summary: result.summary })
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      log(`migration ${migration.id} failed: ${error}`)
+      outcomes.push({ id: migration.id, changed: false, summary: 'failed', error })
+    }
+  }
+  return outcomes
+}

--- a/src/migrations/secrets-v1-to-v2.test.ts
+++ b/src/migrations/secrets-v1-to-v2.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parseSecretsFile } from '@/secrets/schema'
+
+import { migrateSecretsV1ToV2 } from './secrets-v1-to-v2'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tc-secrets-mig-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeSecrets(name: string, value: unknown): void {
+  writeFileSync(join(dir, name), `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function readSecrets(name = 'secrets.json'): unknown {
+  return JSON.parse(readFileSync(join(dir, name), 'utf8'))
+}
+
+describe('migrateSecretsV1ToV2 — v1 envelope', () => {
+  test('upgrades env-keyed discord channel to field-keyed v2 Secret so the bot reconnects', () => {
+    writeSecrets('secrets.json', {
+      version: 1,
+      llm: {},
+      channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'discord-secret' } },
+    })
+
+    const result = migrateSecretsV1ToV2(dir)
+
+    expect(result.changed).toBe(true)
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.channels['discord-bot']).toEqual({ token: { value: 'discord-secret' } })
+  })
+
+  test('upgrades both slack token fields to their v2 field names', () => {
+    writeSecrets('secrets.json', {
+      version: 1,
+      llm: {},
+      channels: { 'slack-bot': { SLACK_BOT_TOKEN: 'xoxb', SLACK_APP_TOKEN: 'xapp' } },
+    })
+
+    migrateSecretsV1ToV2(dir)
+
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.channels['slack-bot']).toEqual({
+      botToken: { value: 'xoxb' },
+      appToken: { value: 'xapp' },
+    })
+  })
+
+  test('renames llm to providers and wraps api-key string into a Secret', () => {
+    writeSecrets('secrets.json', {
+      version: 1,
+      llm: { openai: { type: 'api_key', key: 'sk-legacy' } },
+      channels: {},
+    })
+
+    migrateSecretsV1ToV2(dir)
+
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.providers.openai).toEqual({ type: 'api_key', key: { value: 'sk-legacy' } })
+  })
+
+  test('passes oauth provider credentials through verbatim', () => {
+    writeSecrets('secrets.json', {
+      version: 1,
+      llm: { anthropic: { type: 'oauth', access: 'a', refresh: 'r', expires: 123 } },
+      channels: {},
+    })
+
+    migrateSecretsV1ToV2(dir)
+
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.providers.anthropic).toEqual({ type: 'oauth', access: 'a', refresh: 'r', expires: 123 })
+  })
+
+  test('keeps the mapped token but lets v2 validation drop an unknown field on a known adapter', () => {
+    writeSecrets('secrets.json', {
+      version: 1,
+      llm: {},
+      channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 't', WEIRD_EXTRA: 'x' } },
+    })
+
+    migrateSecretsV1ToV2(dir)
+
+    const slot = (readSecrets() as { channels: Record<string, Record<string, unknown>> }).channels['discord-bot']
+    expect(slot).toEqual({ token: { value: 't' } })
+  })
+
+  test('preserves an unknown adapter id, wrapping its string fields as Secrets', () => {
+    writeSecrets('secrets.json', {
+      version: 1,
+      llm: {},
+      channels: { 'future-bot': { SOME_TOKEN: 'v' } },
+    })
+
+    migrateSecretsV1ToV2(dir)
+
+    const channels = (readSecrets() as { channels: Record<string, unknown> }).channels
+    expect(channels['future-bot']).toEqual({ SOME_TOKEN: { value: 'v' } })
+  })
+
+  test('preserves a structured (non-string) channel block such as kakaotalk verbatim', () => {
+    const kakao = { currentAccount: null, accounts: {} }
+    writeSecrets('secrets.json', { version: 1, llm: {}, channels: { kakaotalk: kakao } })
+
+    migrateSecretsV1ToV2(dir)
+
+    const channels = (readSecrets() as { channels: Record<string, unknown> }).channels
+    expect(channels.kakaotalk).toEqual(kakao)
+  })
+
+  test('writes the v2 version stamp', () => {
+    writeSecrets('secrets.json', { version: 1, llm: {}, channels: {} })
+
+    migrateSecretsV1ToV2(dir)
+
+    expect((readSecrets() as { version: number }).version).toBe(2)
+  })
+})
+
+describe('migrateSecretsV1ToV2 — pre-envelope flat shape', () => {
+  test('treats a top-level provider record as v1 llm and upgrades it', () => {
+    writeSecrets('secrets.json', { openai: { type: 'api_key', key: 'sk-flat' } })
+
+    const result = migrateSecretsV1ToV2(dir)
+
+    expect(result.changed).toBe(true)
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.providers.openai).toEqual({ type: 'api_key', key: { value: 'sk-flat' } })
+    expect(parsed.file.channels).toEqual({})
+  })
+})
+
+describe('migrateSecretsV1ToV2 — idempotency & no-op', () => {
+  test('a v2 file is left unchanged', () => {
+    const v2 = {
+      $schema: './node_modules/typeclaw/secrets.schema.json',
+      version: 2,
+      providers: { openai: { type: 'api_key', key: { value: 'sk' } } },
+      channels: { 'discord-bot': { token: { value: 't' } } },
+    }
+    writeSecrets('secrets.json', v2)
+    const before = readFileSync(join(dir, 'secrets.json'), 'utf8')
+
+    const result = migrateSecretsV1ToV2(dir)
+
+    expect(result.changed).toBe(false)
+    expect(readFileSync(join(dir, 'secrets.json'), 'utf8')).toBe(before)
+  })
+
+  test('running twice on a v1 file is stable', () => {
+    writeSecrets('secrets.json', {
+      version: 1,
+      llm: {},
+      channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'd' } },
+    })
+
+    const first = migrateSecretsV1ToV2(dir)
+    const afterFirst = readFileSync(join(dir, 'secrets.json'), 'utf8')
+    const second = migrateSecretsV1ToV2(dir)
+
+    expect(first.changed).toBe(true)
+    expect(second.changed).toBe(false)
+    expect(readFileSync(join(dir, 'secrets.json'), 'utf8')).toBe(afterFirst)
+  })
+
+  test('no secrets file at all is a no-op', () => {
+    const result = migrateSecretsV1ToV2(dir)
+    expect(result.changed).toBe(false)
+    expect(existsSync(join(dir, 'secrets.json'))).toBe(false)
+  })
+})
+
+describe('migrateSecretsV1ToV2 — legacy auth.json precedence', () => {
+  test('only auth.json: renames to secrets.json and upgrades it', () => {
+    writeSecrets('auth.json', {
+      version: 1,
+      llm: {},
+      channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'd' } },
+    })
+
+    const result = migrateSecretsV1ToV2(dir)
+
+    expect(result.changed).toBe(true)
+    expect(existsSync(join(dir, 'auth.json'))).toBe(false)
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.channels['discord-bot']).toEqual({ token: { value: 'd' } })
+  })
+
+  test('both files, auth.json empty: drops auth.json and keeps secrets.json', () => {
+    writeSecrets('auth.json', { version: 2, providers: {}, channels: {} })
+    writeSecrets('secrets.json', {
+      version: 2,
+      providers: { openai: { type: 'api_key', key: { value: 'sk' } } },
+      channels: {},
+    })
+
+    migrateSecretsV1ToV2(dir)
+
+    expect(existsSync(join(dir, 'auth.json'))).toBe(false)
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.providers.openai).toBeDefined()
+  })
+
+  test('both files, secrets.json empty: auth.json wins and is upgraded', () => {
+    writeSecrets('auth.json', {
+      version: 1,
+      llm: {},
+      channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'from-auth' } },
+    })
+    writeSecrets('secrets.json', { version: 2, providers: {}, channels: {} })
+
+    migrateSecretsV1ToV2(dir)
+
+    expect(existsSync(join(dir, 'auth.json'))).toBe(false)
+    const parsed = parseSecretsFile(readSecrets())
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.file.channels['discord-bot']).toEqual({ token: { value: 'from-auth' } })
+  })
+
+  test('both files non-empty: throws rather than guess a source of truth', () => {
+    writeSecrets('auth.json', {
+      version: 1,
+      llm: { openai: { type: 'api_key', key: 'from-auth' } },
+      channels: {},
+    })
+    writeSecrets('secrets.json', {
+      version: 2,
+      providers: { openai: { type: 'api_key', key: { value: 'from-secrets' } } },
+      channels: {},
+    })
+
+    expect(() => migrateSecretsV1ToV2(dir)).toThrow(/both/i)
+  })
+})
+
+describe('migrateSecretsV1ToV2 — unsafe / unrecognized input', () => {
+  test('throws on a non-empty file that is neither v2 nor a known legacy shape', () => {
+    writeSecrets('secrets.json', { version: 1, channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 42 } }, junk: true })
+    writeFileSync(join(dir, 'secrets.json'), JSON.stringify({ totally: 'unknown', nested: { a: 1 } }))
+
+    expect(() => migrateSecretsV1ToV2(dir)).toThrow()
+  })
+
+  test('throws on invalid JSON rather than silently dropping the file', () => {
+    writeFileSync(join(dir, 'secrets.json'), '{ not valid json')
+
+    expect(() => migrateSecretsV1ToV2(dir)).toThrow(/JSON/i)
+  })
+})

--- a/src/migrations/secrets-v1-to-v2.test.ts
+++ b/src/migrations/secrets-v1-to-v2.test.ts
@@ -284,3 +284,33 @@ describe('migrateSecretsV1ToV2 — unsafe / unrecognized input', () => {
     expect(() => migrateSecretsV1ToV2(dir)).toThrow(/JSON/i)
   })
 })
+
+describe('migrateSecretsV1ToV2 — concurrency', () => {
+  test('releases the secrets.json lock after a successful migration', () => {
+    writeSecrets('auth.json', {
+      version: 1,
+      llm: {},
+      channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'd' } },
+    })
+
+    migrateSecretsV1ToV2(dir)
+
+    expect(existsSync(join(dir, 'secrets.json.lock'))).toBe(false)
+  })
+
+  test('seeding never overwrites an existing non-empty secrets.json (no clobber when only that file is present)', () => {
+    const v2 = {
+      $schema: './node_modules/typeclaw/secrets.schema.json',
+      version: 2,
+      providers: { openai: { type: 'api_key', key: { value: 'keep-me' } } },
+      channels: {},
+    }
+    writeSecrets('secrets.json', v2)
+    const before = readFileSync(join(dir, 'secrets.json'), 'utf8')
+
+    const result = migrateSecretsV1ToV2(dir)
+
+    expect(result.changed).toBe(false)
+    expect(readFileSync(join(dir, 'secrets.json'), 'utf8')).toBe(before)
+  })
+})

--- a/src/migrations/secrets-v1-to-v2.test.ts
+++ b/src/migrations/secrets-v1-to-v2.test.ts
@@ -256,6 +256,18 @@ describe('migrateSecretsV1ToV2 — legacy auth.json precedence', () => {
 
     expect(() => migrateSecretsV1ToV2(dir)).toThrow(/both/i)
   })
+
+  test('both files, auth.json parseable-but-unrecognized: throws and keeps auth.json instead of dropping it', () => {
+    writeSecrets('auth.json', { something: 'we do not recognize', nested: { a: 1 } })
+    writeSecrets('secrets.json', {
+      version: 2,
+      providers: { openai: { type: 'api_key', key: { value: 'from-secrets' } } },
+      channels: {},
+    })
+
+    expect(() => migrateSecretsV1ToV2(dir)).toThrow(/both/i)
+    expect(existsSync(join(dir, 'auth.json'))).toBe(true)
+  })
 })
 
 describe('migrateSecretsV1ToV2 — unsafe / unrecognized input', () => {

--- a/src/migrations/secrets-v1-to-v2.ts
+++ b/src/migrations/secrets-v1-to-v2.ts
@@ -1,0 +1,324 @@
+import { chmodSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import lockfile from 'proper-lockfile'
+
+import { parseSecretsFile, SECRETS_FILE_VERSION } from '@/secrets/schema'
+
+// PR #638 removed the in-memory v1->v2 upgrade that `parseSecretsFile` used to
+// perform, so a `secrets.json` still in v1 now fails to parse:
+// `hydrateChannelEnvFromSecrets` swallows the failure as `{}`, no token env vars
+// are injected, and channel adapters (Discord, Slack, Telegram) never connect.
+// This is the one-shot on-disk replacement, run once at boot rather than on
+// every parse, so the v2-only runtime keeps working without a read-time shim.
+
+const SCHEMA_REL = './node_modules/typeclaw/secrets.schema.json'
+const FILE_MODE = 0o600
+
+const LEGACY_FILENAME = 'auth.json'
+const TARGET_FILENAME = 'secrets.json'
+
+// Frozen, migration-local reverse map (env-var name -> { adapterId, field }).
+// Intentionally a private copy rather than an inversion of
+// `CHANNEL_FIELD_ENV` in src/secrets/defaults.ts: re-importing live runtime
+// defaults would (a) re-couple current code to deleted legacy surface area,
+// and (b) let a future change to the runtime env-var names silently rewrite
+// the semantics of this historical migration. A v1 file written years ago must
+// migrate the same way regardless of what the live adapters key off today.
+const LEGACY_CHANNEL_ENV_TO_FIELD: Record<string, { adapterId: string; field: string }> = {
+  DISCORD_BOT_TOKEN: { adapterId: 'discord-bot', field: 'token' },
+  SLACK_BOT_TOKEN: { adapterId: 'slack-bot', field: 'botToken' },
+  SLACK_APP_TOKEN: { adapterId: 'slack-bot', field: 'appToken' },
+  TELEGRAM_BOT_TOKEN: { adapterId: 'telegram-bot', field: 'token' },
+}
+
+export const MIGRATION_ID = '0001-secrets-v1-to-v2'
+
+export type SecretsMigrationResult = { changed: boolean; summary: string }
+
+// Detect-and-apply in one call so detect and apply can never disagree about
+// the on-disk shape (no TOCTOU between a separate detect() read and the apply
+// read). Idempotent: a folder already at v2 (or with no legacy file) returns
+// `changed: false`. Errors that indicate ambiguous/unsafe state throw with an
+// actionable message rather than guessing.
+export function migrateSecretsV1ToV2(agentDir: string): SecretsMigrationResult {
+  const legacyPath = join(agentDir, LEGACY_FILENAME)
+  const targetPath = join(agentDir, TARGET_FILENAME)
+
+  // Resolve the auth.json -> secrets.json filename precedence first, under a
+  // lock on whichever file we end up operating on, so a concurrent boot-time
+  // writer (SecretsBackend, hostd, credential exporters) can't interleave.
+  const resolvedPath = resolveLegacyFilename(legacyPath, targetPath)
+  if (resolvedPath === null) return { changed: false, summary: 'no secrets file to migrate' }
+
+  return withFileLock(resolvedPath, () => upgradeFileInPlace(resolvedPath))
+}
+
+// auth.json precedence, preserving the exact semantics of the deleted
+// migrateLegacyAuthJson so no credential is ever silently dropped:
+//   - only auth.json            -> rename to secrets.json, operate on it
+//   - only secrets.json         -> operate on secrets.json
+//   - neither                   -> nothing to do
+//   - both, auth.json empty     -> unlink auth.json, operate on secrets.json
+//   - both, secrets.json empty  -> auth.json wins (rename over the empty seed)
+//   - both non-empty            -> hard error (can't pick a source of truth)
+function resolveLegacyFilename(legacyPath: string, targetPath: string): string | null {
+  const hasLegacy = existsSync(legacyPath)
+  const hasTarget = existsSync(targetPath)
+
+  if (!hasLegacy) return hasTarget ? targetPath : null
+
+  if (!hasTarget) {
+    renameWithRaceFallback(legacyPath, targetPath)
+    return targetPath
+  }
+
+  if (isEmptyOrUnparseableEnvelope(legacyPath)) {
+    unlinkSync(legacyPath)
+    return targetPath
+  }
+
+  if (isEmptyEnvelope(targetPath)) {
+    renameWithRaceFallback(legacyPath, targetPath)
+    return targetPath
+  }
+
+  throw new Error(
+    `Both ${LEGACY_FILENAME} and a non-empty ${TARGET_FILENAME} exist in the agent folder. ` +
+      `Inspect manually and remove the stale file before re-running.`,
+  )
+}
+
+function upgradeFileInPlace(path: string): SecretsMigrationResult {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch {
+    return { changed: false, summary: 'secrets file unreadable; skipped' }
+  }
+  if (raw.trim() === '') return { changed: false, summary: 'secrets file empty; skipped' }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`secrets file is not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  // Already current: parseSecretsFile only accepts v2 post-#638, so a successful
+  // parse means there is nothing to do.
+  if (parseSecretsFile(parsed).ok) return { changed: false, summary: 'already v2; no change' }
+
+  const upgraded = upgradeToV2(parsed)
+  if (upgraded === null) {
+    throw new Error(
+      'secrets file is neither a valid v2 envelope nor a recognized legacy (v1 / pre-envelope) shape; ' +
+        'leaving it untouched for manual inspection',
+    )
+  }
+
+  // Re-validate the product of our own transform before persisting. A transform
+  // that emitted an invalid v2 file would brick the next read; failing here is
+  // strictly safer than writing garbage.
+  const check = parseSecretsFile(upgraded)
+  if (!check.ok) {
+    throw new Error(`internal: migrated secrets file failed v2 validation: ${check.reason}`)
+  }
+
+  writeEnvelopeAtomic(path, check.file)
+  return { changed: true, summary: `upgraded secrets file to v${SECRETS_FILE_VERSION}` }
+}
+
+// Recognizes the two pre-v2 shapes the deleted parseSecretsFile branches used
+// to accept and returns a v2-shaped object. Returns null when the input matches
+// neither (caller turns that into a loud, no-write error).
+//
+//   v1 envelope:      { version: 1, llm: {...}, channels: { adapter: { ENV: value } } }
+//   pre-envelope flat: { providerId: { type, key } } at the top level
+function upgradeToV2(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null
+  const obj = raw as Record<string, unknown>
+
+  if (obj.version === 1) {
+    return upgradeV1Envelope(obj)
+  }
+
+  if (looksLikeFlatProviders(obj)) {
+    return upgradeV1Envelope({ version: 1, llm: obj, channels: {} })
+  }
+
+  return null
+}
+
+function upgradeV1Envelope(obj: Record<string, unknown>): Record<string, unknown> {
+  const llm = isPlainObject(obj.llm) ? obj.llm : {}
+  const legacyChannels = isPlainObject(obj.channels) ? obj.channels : {}
+
+  const providers: Record<string, unknown> = {}
+  for (const [providerId, cred] of Object.entries(llm)) {
+    if (!isPlainObject(cred)) continue
+    if (cred.type === 'api_key' && typeof cred.key === 'string') {
+      providers[providerId] = { type: 'api_key', key: { value: cred.key } }
+    } else {
+      // OAuth and any unknown credential type pass through verbatim — they are
+      // not env-injectable and the v2 schema accepts them via catchall.
+      providers[providerId] = cred
+    }
+  }
+
+  const channels: Record<string, Record<string, unknown>> = {}
+  for (const [adapterId, slot] of Object.entries(legacyChannels)) {
+    if (!isPlainObject(slot)) continue
+    const upgradedSlot: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(slot)) {
+      if (typeof value !== 'string') {
+        // A non-string value means this isn't the flat env-keyed v1 channel
+        // shape (e.g. a kakaotalk block, which is structured). Preserve it
+        // verbatim so the catchall keeps it valid; do not try to reshape.
+        upgradedSlot[key] = value
+        continue
+      }
+      const mapping = LEGACY_CHANNEL_ENV_TO_FIELD[key]
+      if (mapping && mapping.adapterId === adapterId) {
+        upgradedSlot[mapping.field] = { value }
+      } else {
+        // Unknown env-var key on a known adapter, or an unknown adapter:
+        // preserve under the original key but still wrap as a v2 Secret so the
+        // resulting file is valid v2.
+        upgradedSlot[key] = { value }
+      }
+    }
+    channels[adapterId] = upgradedSlot
+  }
+
+  const result: Record<string, unknown> = {
+    $schema: typeof obj.$schema === 'string' ? obj.$schema : SCHEMA_REL,
+    version: SECRETS_FILE_VERSION,
+    providers,
+    channels,
+  }
+  return result
+}
+
+// A flat pre-envelope file is a top-level record of provider credentials. Every
+// value must be a credential object with a `type` field; anything else means we
+// don't recognize the shape and should not guess.
+function looksLikeFlatProviders(obj: Record<string, unknown>): boolean {
+  const entries = Object.entries(obj).filter(([k]) => k !== '$schema')
+  if (entries.length === 0) return false
+  return entries.every(([, value]) => isPlainObject(value) && typeof value.type === 'string')
+}
+
+function isEmptyEnvelope(path: string): boolean {
+  const parsed = readJsonOrNull(path)
+  if (parsed === undefined) return true
+  if (parsed === null) return false
+  const result = parseSecretsFile(parsed)
+  if (!result.ok) return false
+  return Object.keys(result.file.providers).length === 0 && Object.keys(result.file.channels).length === 0
+}
+
+// Looser variant for the legacy file: an auth.json that is empty, blank, or
+// no-longer-parseable carries no recoverable credentials, so it is safe to drop
+// in favor of an existing secrets.json. We do NOT treat a parseable-but-legacy
+// auth.json as empty — that still has credentials worth migrating, which is the
+// both-non-empty hard-error path.
+function isEmptyOrUnparseableEnvelope(path: string): boolean {
+  const parsed = readJsonOrNull(path)
+  if (parsed === undefined) return true
+  if (parsed === null) return false
+  const v2 = parseSecretsFile(parsed)
+  if (v2.ok) {
+    return Object.keys(v2.file.providers).length === 0 && Object.keys(v2.file.channels).length === 0
+  }
+  // Parseable JSON in a known legacy shape => has migratable content.
+  return upgradeToV2(parsed) === null
+}
+
+// undefined = file missing/blank (treat as empty); null = present but invalid
+// JSON (treat as "has content we can't safely drop").
+function readJsonOrNull(path: string): unknown {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch {
+    return undefined
+  }
+  if (raw.trim() === '') return undefined
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function writeEnvelopeAtomic(path: string, envelope: unknown): void {
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(tmp, `${JSON.stringify(envelope, null, 2)}\n`, { encoding: 'utf8', mode: FILE_MODE })
+  try {
+    renameSync(tmp, path)
+  } catch (err) {
+    try {
+      unlinkSync(tmp)
+    } catch {
+      // best-effort cleanup of the temp file when rename fails
+    }
+    throw err
+  }
+  chmodSync(path, FILE_MODE)
+}
+
+// renameSync is atomic per syscall, but two concurrent migration runs can both
+// observe auth.json exists and secrets.json does not, then race on the rename.
+// One wins; the loser gets ENOENT because the source is already gone — that is
+// a successful migration from its POV, so recheck the target and swallow it.
+function renameWithRaceFallback(from: string, to: string): void {
+  try {
+    renameSync(from, to)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT' && existsSync(to)) return
+    throw err
+  }
+}
+
+// Mirror SecretsBackend's lock discipline so a concurrent credential write
+// (provider add, OAuth refresh, channel add) can't interleave with the
+// read-transform-write. proper-lockfile needs the target to exist; the target
+// always exists by the time we lock (resolveLegacyFilename guarantees it).
+function withFileLock<T>(path: string, fn: () => T): T {
+  let release: (() => void) | undefined
+  try {
+    release = acquireSyncLockWithRetry(path)
+    return fn()
+  } finally {
+    release?.()
+  }
+}
+
+const SYNC_LOCK_RETRIES = 10
+const SYNC_LOCK_DELAY_MS = 20
+
+function acquireSyncLockWithRetry(path: string): () => void {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= SYNC_LOCK_RETRIES; attempt++) {
+    try {
+      return lockfile.lockSync(path, { realpath: false })
+    } catch (error) {
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? String((error as { code: unknown }).code)
+          : undefined
+      if (code !== 'ELOCKED' || attempt === SYNC_LOCK_RETRIES) throw error
+      lastError = error
+      const start = Date.now()
+      while (Date.now() - start < SYNC_LOCK_DELAY_MS) {
+        // intentionally empty: synchronous busy-wait to match SecretsBackend
+      }
+    }
+  }
+  throw (lastError as Error | undefined) ?? new Error('Failed to acquire secrets store lock')
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/migrations/secrets-v1-to-v2.ts
+++ b/src/migrations/secrets-v1-to-v2.ts
@@ -36,51 +36,69 @@ export const MIGRATION_ID = '0001-secrets-v1-to-v2'
 
 export type SecretsMigrationResult = { changed: boolean; summary: string }
 
-// Detect-and-apply in one call so detect and apply can never disagree about
-// the on-disk shape (no TOCTOU between a separate detect() read and the apply
-// read). Idempotent: a folder already at v2 (or with no legacy file) returns
+// Idempotent: a folder already at v2 (or with no legacy file) returns
 // `changed: false`. Errors that indicate ambiguous/unsafe state throw with an
 // actionable message rather than guessing.
+//
+// Concurrency: secrets.json is the lock resource SecretsBackend (provider add,
+// OAuth refresh, channel add) and credential exporters use, so we hold ITS lock
+// across the entire precedence resolution AND upgrade. The lock requires the
+// file to exist, so when only auth.json is present we first seed secrets.json
+// with exclusive create-if-absent semantics (never overwriting a file a
+// concurrent writer may have just written), then lock, then re-read precedence
+// from fresh on-disk state under the lock.
 export function migrateSecretsV1ToV2(agentDir: string): SecretsMigrationResult {
   const legacyPath = join(agentDir, LEGACY_FILENAME)
   const targetPath = join(agentDir, TARGET_FILENAME)
 
-  // Resolve the auth.json -> secrets.json filename precedence first, under a
-  // lock on whichever file we end up operating on, so a concurrent boot-time
-  // writer (SecretsBackend, hostd, credential exporters) can't interleave.
-  const resolvedPath = resolveLegacyFilename(legacyPath, targetPath)
-  if (resolvedPath === null) return { changed: false, summary: 'no secrets file to migrate' }
+  if (!existsSync(legacyPath) && !existsSync(targetPath)) {
+    return { changed: false, summary: 'no secrets file to migrate' }
+  }
 
-  return withFileLock(resolvedPath, () => upgradeFileInPlace(resolvedPath))
+  seedTargetIfAbsent(targetPath)
+
+  return withFileLock(targetPath, () => {
+    resolvePrecedenceUnderLock(legacyPath, targetPath)
+    return upgradeFileInPlace(targetPath)
+  })
 }
 
-// auth.json precedence, preserving the exact semantics of the deleted
-// migrateLegacyAuthJson so no credential is ever silently dropped:
-//   - only auth.json            -> rename to secrets.json, operate on it
-//   - only secrets.json         -> operate on secrets.json
-//   - neither                   -> nothing to do
-//   - both, auth.json empty     -> unlink auth.json, operate on secrets.json
-//   - both, secrets.json empty  -> auth.json wins (rename over the empty seed)
-//   - both non-empty            -> hard error (can't pick a source of truth)
-function resolveLegacyFilename(legacyPath: string, targetPath: string): string | null {
-  const hasLegacy = existsSync(legacyPath)
-  const hasTarget = existsSync(targetPath)
-
-  if (!hasLegacy) return hasTarget ? targetPath : null
-
-  if (!hasTarget) {
-    renameWithRaceFallback(legacyPath, targetPath)
-    return targetPath
+// Creates an empty v2 envelope at secrets.json only if it does not already
+// exist, using exclusive create ('wx') so a concurrent writer that wrote real
+// credentials between our existsSync check and here is never clobbered — the
+// EEXIST is swallowed because the file we need to lock now exists, which is all
+// we required. A freshly-seeded empty envelope is indistinguishable from "no
+// target" to resolvePrecedenceUnderLock (isEmptyEnvelope returns true), so
+// "only auth.json" collapses into the "secrets.json empty -> auth wins" branch.
+function seedTargetIfAbsent(targetPath: string): void {
+  if (existsSync(targetPath)) return
+  try {
+    writeFileSync(targetPath, stringifyEmptyEnvelope(), { encoding: 'utf8', mode: FILE_MODE, flag: 'wx' })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
   }
+}
+
+// auth.json precedence, run ENTIRELY under the secrets.json lock so the read,
+// the rename/unlink decision, and the rename itself can't interleave with a
+// concurrent secrets.json writer. Preserves the deleted migrateLegacyAuthJson
+// semantics so no credential is ever silently dropped:
+//   - no auth.json              -> operate on secrets.json as-is
+//   - droppable auth.json       -> unlink auth.json, operate on secrets.json
+//   - secrets.json empty seed   -> auth.json wins (rename over the empty seed)
+//   - both non-empty            -> hard error (can't pick a source of truth)
+function resolvePrecedenceUnderLock(legacyPath: string, targetPath: string): void {
+  if (!existsSync(legacyPath)) return
 
   if (isDroppableLegacyFile(legacyPath)) {
     unlinkSync(legacyPath)
-    return targetPath
+    return
   }
 
   if (isEmptyEnvelope(targetPath)) {
     renameWithRaceFallback(legacyPath, targetPath)
-    return targetPath
+    chmodSync(targetPath, FILE_MODE)
+    return
   }
 
   throw new Error(
@@ -248,6 +266,10 @@ function readJsonOrNull(path: string): unknown {
   } catch {
     return null
   }
+}
+
+function stringifyEmptyEnvelope(): string {
+  return `${JSON.stringify({ $schema: SCHEMA_REL, version: SECRETS_FILE_VERSION, providers: {}, channels: {} }, null, 2)}\n`
 }
 
 function writeEnvelopeAtomic(path: string, envelope: unknown): void {

--- a/src/migrations/secrets-v1-to-v2.ts
+++ b/src/migrations/secrets-v1-to-v2.ts
@@ -73,7 +73,7 @@ function resolveLegacyFilename(legacyPath: string, targetPath: string): string |
     return targetPath
   }
 
-  if (isEmptyOrUnparseableEnvelope(legacyPath)) {
+  if (isDroppableLegacyFile(legacyPath)) {
     unlinkSync(legacyPath)
     return targetPath
   }
@@ -218,21 +218,19 @@ function isEmptyEnvelope(path: string): boolean {
   return Object.keys(result.file.providers).length === 0 && Object.keys(result.file.channels).length === 0
 }
 
-// Looser variant for the legacy file: an auth.json that is empty, blank, or
-// no-longer-parseable carries no recoverable credentials, so it is safe to drop
-// in favor of an existing secrets.json. We do NOT treat a parseable-but-legacy
-// auth.json as empty — that still has credentials worth migrating, which is the
-// both-non-empty hard-error path.
-function isEmptyOrUnparseableEnvelope(path: string): boolean {
+// True only when a legacy auth.json carries nothing worth keeping, so dropping
+// it in favor of an existing secrets.json is safe: a missing/blank file, or a
+// valid-but-empty v2 envelope. Anything else parseable — a legacy shape with
+// credentials OR a parseable-but-unrecognized object — returns false so
+// resolveLegacyFilename falls through to the both-non-empty hard error rather
+// than silently deleting a file whose contents we can't account for.
+function isDroppableLegacyFile(path: string): boolean {
   const parsed = readJsonOrNull(path)
   if (parsed === undefined) return true
   if (parsed === null) return false
   const v2 = parseSecretsFile(parsed)
-  if (v2.ok) {
-    return Object.keys(v2.file.providers).length === 0 && Object.keys(v2.file.channels).length === 0
-  }
-  // Parseable JSON in a known legacy shape => has migratable content.
-  return upgradeToV2(parsed) === null
+  if (!v2.ok) return false
+  return Object.keys(v2.file.providers).length === 0 && Object.keys(v2.file.channels).length === 0
 }
 
 // undefined = file missing/blank (treat as empty); null = present but invalid

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -42,6 +42,7 @@ import {
 } from '@/cron'
 import { CLI_VERSION } from '@/init/cli-version'
 import { createMcpManager } from '@/mcp'
+import { runStartupMigrations } from '@/migrations'
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createPluginLogger } from '@/plugin/context'
 import type { CronHandlerContext } from '@/plugin/types'
@@ -193,6 +194,12 @@ export async function startAgent({
     loadedPlugins: pluginsLoaded.loadedPlugins,
     materializedSkills: null,
   })
+
+  // Graduate any pre-0.20.0 on-disk shapes (v1 secrets.json, legacy auth.json)
+  // to the current v2 envelope before anything reads secrets — otherwise the
+  // v2-only parser rejects the file and hydrate below sees no channels. Runs
+  // exactly once per folder; a folder already at v2 is a no-op.
+  runStartupMigrations(cwd)
 
   // Channel adapters read `process.env[TOKEN_ENV]` (see channels/manager.ts).
   // Hydrate fills any unset env var from secrets.json#channels via env-wins:


### PR DESCRIPTION
## Problem

After #638 ("drop migrations for pre-0.20.0 agent folders"), Discord bots on pre-0.20.0 agent folders stopped connecting.

#638 removed the in-memory `v1 -> v2` upgrade that `parseSecretsFile` used to perform. That upgrade was a **read-time shim**: it reshaped the file in memory but never persisted it to disk. Post-#638, `parseSecretsFile` is **v2-only**, so a folder whose `secrets.json` is still in the v1 envelope shape now fails to parse entirely. The failure chain:

1. `parseSecretsFile` returns `ok: false` for the v1 file.
2. `hydrateChannelEnvFromSecrets` (boot-time) catches the failure and returns `{}` — empty channels.
3. `process.env.DISCORD_BOT_TOKEN` (and Slack/Telegram equivalents) is never injected.
4. `src/channels/manager.ts` reads the env var, sees nothing, and never constructs the adapter.
5. The bot silently stops connecting.

So the legacy values were never migrated on disk — they were only *shimmed* at read time, and #638 removed the shim without an on-disk replacement.

## Fix

A one-shot, on-disk migration under a new `src/migrations/` directory that graduates the legacy shapes to the current v2 envelope:

- **v1 envelope** (`{ version: 1, llm, channels: { adapter: { ENV_VAR: value } } }`): `llm -> providers` (api-key `string -> { value }`, OAuth passthrough), and env-var-keyed channel slots -> field-keyed v2 `Secret`s (`DISCORD_BOT_TOKEN -> token`, `SLACK_BOT_TOKEN -> botToken`, etc.).
- **pre-envelope flat** (top-level provider record): treated as `{ version: 1, llm: <flat>, channels: {} }`.
- **legacy `auth.json`**: preserves the exact rename precedence of the deleted `migrateLegacyAuthJson`, including the **both-non-empty hard error** so no credential is ever silently dropped.

### Design decisions

- **`src/migrations/`, not top-level `migrations/`** — these modules run at container boot inside `typeclaw run`, so they must ship in the published npm package. Placing them under `src/` keeps them in the build and matches the repo's domain-code convention.
- **Boot chokepoint** — runs once in `src/run/index.ts`, immediately before `hydrateChannelEnvFromSecrets`. It is **not** wired into any parse/read path; the per-parse shim is not reintroduced.
- **No git commit** — `secrets.json`/`auth.json` are in `TRULY_IGNORED_PATTERNS` (credentials, never enter git). The migration rewrites atomically (temp+rename, `0o600`) under the same `proper-lockfile` discipline as `SecretsBackend`, and never calls `commitSystemFileSync`.
- **Frozen migration-local env->field map** — a private copy rather than inverting `CHANNEL_FIELD_ENV` from `src/secrets/defaults.ts`, so a future change to the live runtime env-var names can't silently rewrite the semantics of this historical migration.
- **Idempotent** — a folder already at v2 (or with no legacy file) is a no-op.

### Scope note

KakaoTalk env-keyed channel blocks are preserved verbatim but **not** promoted to the account-credential shape — that is a separate migration (the deleted `migrate-kakaotalk.ts`), out of scope here.

## Tests

New behavior tests (real tmp dirs, no mocks) covering: v1 envelope (Discord/Slack/provider/OAuth), pre-envelope flat, unknown env keys on known/unknown adapters, structured (kakaotalk) blocks, idempotency, all four `auth.json` precedence cases incl. the both-non-empty hard error, invalid JSON, and the runner's fail-isolation.

Checks: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full suite (7602 pass, 0 fail) all pass.