### PR TITLE
fix(channels): run github review guards on the turn-recovery egress path

### DIFF
--- a/src/channels/github-review-claim.test.ts
+++ b/src/channels/github-review-claim.test.ts
@@ -48,6 +48,17 @@ const cases: ReadonlyArray<[string, ReviewClaim]> = [
   ['I confirmed the issue is not resolved yet.', 'ignore'],
   ['Can you clarify the second point?', 'ignore'],
   ['', 'ignore'],
+
+  // "addresses the concern" close-out family (PR #672) escalates as a positive warn.
+  ['That addresses the concern nicely.', 'warn'],
+  ['Thanks — addressed your feedback well.', 'warn'],
+  // ...but genuine future/obligation "address" prose stays ignore.
+  ["I'll address your feedback in the next push.", 'ignore'],
+  ['Still need to address the concern before this lands.', 'ignore'],
+  ['Going to address your review comments shortly.', 'ignore'],
+  // A bare `to address` clause must NOT demote a hard claim in the same sentence (PR #675).
+  ['Approved — thanks for updating the docs to address my feedback.', 'block-approve'],
+  ['Requesting changes; please update the tests to address the leak.', 'block-request-changes'],
 ]
 
 describe('classifyReviewClaim', () => {

--- a/src/channels/github-review-claim.ts
+++ b/src/channels/github-review-claim.ts
@@ -75,7 +75,13 @@ const DEMOTE_TO_IGNORE: readonly RegExp[] = [
   /\b(can'?t|cannot|won'?t|will not|wouldn'?t)\b[^.!?]*\b(approv|request|resolv|block|address)/,
   /\bnot (approved|resolved|blocked|requesting|addressed)\b/,
   /\b(not|no longer|hardly|barely)\b[^.!?]*\b(lgtm|looks good|looks fine|seems fine|should be (fine|good)|looks resolved|seems resolved)\b/,
-  /\b(i'?ll|i will|going to|gonna|about to|planning to|need(s)? to|have to|to)\b[^.!?]*\b(approv|review|request|resolv|address)/,
+  /\b(i'?ll|i will|going to|gonna|about to|planning to)\b[^.!?]*\b(approv|review|request|resolv)/,
+  // "address" demotion is restricted to explicit future/obligation forms only.
+  // A standalone `to` marker (e.g. "...to address my feedback") would match
+  // hard-claim prose like "Approved — thanks for updating the docs to address
+  // my feedback" and demote it to ignore BEFORE the BLOCK_APPROVE check, hiding
+  // a real verdict (the recovery path would then post it unguarded — PR #675).
+  /\b(i'?ll|i will|going to|gonna|about to|planning to|need(s)? to|have to|want(s)? to|trying to)\b[^.!?]*\baddress/,
   /\b(approved|resolved|requested changes)\b[^.!?]*\b(earlier|already|yesterday|before|last (review|time)|previously)\b/,
   /\b(pre|self|co|re|un|non|ai|admin|user|machine|auto) approved\b/,
 ]

--- a/src/channels/github-review-claim.ts
+++ b/src/channels/github-review-claim.ts
@@ -53,6 +53,12 @@ const WARN_POSITIVE_CLOSEOUT: readonly RegExp[] = [
   /\bshould be (fine|good)\b/,
   /\blooks resolved\b/,
   /\bseems resolved\b/,
+  // The canonical PR #672 close-out: "that addresses the concern", "addressed
+  // your feedback". On a PR the bot still blocks, this READS as a verdict and
+  // strands the block, so it escalates through the re-review guard. Demoted to
+  // ignore by the negation/future markers below ("haven't addressed", "to
+  // address").
+  /\baddress(es|ed)\b[^.!?]*\b(concern|feedback|review|comment|issue|point)/,
 ]
 
 // Negative warn phrases re-assert a block ("not done yet") instead of closing it
@@ -65,11 +71,11 @@ const WARN: readonly RegExp[] = [...WARN_POSITIVE_CLOSEOUT, ...WARN_NEGATIVE]
 // ignore. Blocking "I haven't approved" / "I'll approve" / "approved it earlier"
 // (answering a question) is the worst false-positive class, so it is checked first.
 const DEMOTE_TO_IGNORE: readonly RegExp[] = [
-  /\b(haven'?t|have not|did ?n'?t|did not|not yet|never)\b[^.!?]*\b(approv|request|resolv|block)/,
-  /\b(can'?t|cannot|won'?t|will not|wouldn'?t)\b[^.!?]*\b(approv|request|resolv|block)/,
-  /\bnot (approved|resolved|blocked|requesting)\b/,
+  /\b(haven'?t|have not|did ?n'?t|did not|not yet|never)\b[^.!?]*\b(approv|request|resolv|block|address)/,
+  /\b(can'?t|cannot|won'?t|will not|wouldn'?t)\b[^.!?]*\b(approv|request|resolv|block|address)/,
+  /\bnot (approved|resolved|blocked|requesting|addressed)\b/,
   /\b(not|no longer|hardly|barely)\b[^.!?]*\b(lgtm|looks good|looks fine|seems fine|should be (fine|good)|looks resolved|seems resolved)\b/,
-  /\b(i'?ll|i will|going to|gonna|about to|planning to)\b[^.!?]*\b(approv|review|request|resolv)/,
+  /\b(i'?ll|i will|going to|gonna|about to|planning to|need(s)? to|have to|to)\b[^.!?]*\b(approv|review|request|resolv|address)/,
   /\b(approved|resolved|requested changes)\b[^.!?]*\b(earlier|already|yesterday|before|last (review|time)|previously)\b/,
   /\b(pre|self|co|re|un|non|ai|admin|user|machine|auto) approved\b/,
 ]

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2934,6 +2934,85 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
+  test('recovery suppresses a github close-out ack while the bot holds CHANGES_REQUESTED (PR #672)', async () => {
+    // Regression for PR #672: the bot held a live CHANGES_REQUESTED, the author
+    // pushed a fix, and the model ended its turn with "that addresses the
+    // concern nicely" as PLAIN PROSE — no channel_reply / channel_send. The
+    // re-review guard lives only in those tool handlers, so the recovery path
+    // surfaced the verdict-shaped ack via a source:'system' send, stranding the
+    // PR's reviewDecision at CHANGES_REQUESTED. The egress guard must suppress.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const githubKey: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('github', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+    router.registerReviewStateResolver('github', async () => ({ ok: true, selfBlocking: true, approve: true }))
+
+    await router.route(inbound({ adapter: 'github', workspace: 'acme/repo', chat: 'pr:672' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Thanks — that addresses the concern nicely. ✅')
+    }
+    await router.__testing!.flushDebounce(githubKey)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed recovery (github review guard)'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('recovery still surfaces a github reply when the bot does NOT hold a live block', async () => {
+    // The egress guard is scoped: an unblocked PR (no sticky CHANGES_REQUESTED)
+    // must not have ordinary recovered prose dropped. Only a close-out claim
+    // against a live self-block is suppressed.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const githubKey: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('github', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+    router.registerReviewStateResolver('github', async () => ({ ok: true, selfBlocking: false, approve: true }))
+
+    await router.route(inbound({ adapter: 'github', workspace: 'acme/repo', chat: 'pr:672' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Looking into the new commits now — will follow up shortly.')
+    }
+    await router.__testing!.flushDebounce(githubKey)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('Looking into the new commits now — will follow up shortly.')
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+  })
+
+  test('recovery review guard is a no-op for non-github channels', async () => {
+    // The guard must not perturb discord/slack recovery: a close-out-shaped ack
+    // on a non-github channel carries no review semantics and surfaces normally.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'did you fix it?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Yep — that resolves it, looks good. ✅')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('Yep — that resolves it, looks good. ✅')
+    expect(logs.some((m) => m.includes('suppressed recovery (github review guard)'))).toBe(false)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+  })
+
   test('mid-turn recovery: applies the upstream empty-response sentinel guard to recovered prose', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -32,6 +32,8 @@ import {
   StickyLedger,
   type EngagementDecision,
 } from './engagement'
+import { checkFalseReceipt } from './github-false-receipt'
+import { evaluateRereviewGuard } from './github-rereview-guard'
 import { resetReviewTurn } from './github-review-turn-ledger'
 import {
   MEMBERSHIP_COLD_FETCH_TIMEOUT_MS,
@@ -3125,6 +3127,25 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     //     the model's pre-tool commentary is the only user-facing text we have.
     //     Recovering it means the user gets *something* — strictly better than
     //     the historical silent drop.
+    // Egress-level GitHub review guards. The false-receipt and re-review
+    // stranding guards live inside the channel_reply / channel_send tool
+    // handlers, but recovery surfaces trailing assistant prose through a
+    // `source:'system'` send that never touches those handlers. A model that
+    // ends its turn with a close-out ack ("that addresses the concern") instead
+    // of calling a channel tool would otherwise post a verdict-shaped comment
+    // while still holding its own CHANGES_REQUESTED — stranding the PR (PR #672).
+    // Re-run the guards here and SUPPRESS on block: recovery cannot land the
+    // missing formal review on the model's behalf, and posting the unguarded ack
+    // is worse than dropping it — the next inbound re-prompts the model, which
+    // can then land the verdict properly.
+    const recoveryBlock = await evaluateRecoveryReviewGuards(live, assistantText)
+    if (recoveryBlock !== null) {
+      logger.warn(
+        `[channels] ${live.keyId}: suppressed recovery (github review guard) reason=${JSON.stringify(recoveryBlock)} text_len=${assistantText.length}`,
+      )
+      return
+    }
+
     logger.warn(
       `[channels] ${live.keyId}: recovering assistant_text_without_channel_tool source=${source} text_len=${assistantText.length}`,
     )
@@ -3141,6 +3162,38 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (!result.ok) {
       logger.warn(`[channels] ${live.keyId}: recovery send failed: ${result.error}`)
     }
+  }
+
+  // Returns a block reason when the recovered text would be denied by a github
+  // review guard, or null when it is safe to surface. Non-github channels and
+  // non-PR chats short-circuit inside each guard (adapter / `pr:\d+` checks), so
+  // this is a no-op for everything except GitHub PR sessions.
+  const evaluateRecoveryReviewGuards = async (live: LiveSession, text: string): Promise<string | null> => {
+    const falseReceipt = checkFalseReceipt({
+      sessionId: live.sessionId,
+      adapter: live.key.adapter,
+      workspace: live.key.workspace,
+      chat: live.key.chat,
+      thread: live.key.thread,
+      text,
+      isContinue: false,
+      resolveReviewThread: false,
+    })
+    if (falseReceipt.kind === 'block') return falseReceipt.reason
+
+    const rereview = await evaluateRereviewGuard({
+      adapter: live.key.adapter,
+      workspace: live.key.workspace,
+      chat: live.key.chat,
+      thread: live.key.thread,
+      text,
+      wantsResolve: false,
+      isContinue: false,
+      getReviewState: (req) => getReviewState(req),
+    })
+    if (rereview.block) return rereview.reason
+
+    return null
   }
 
   const getConsecutiveSendCount = (target: {


### PR DESCRIPTION
## Background

On a real PR review, the bot held a live `CHANGES_REQUESTED`, the author pushed a fix, and the bot replied **"Thanks — that addresses the concern nicely ✅"** as an ordinary PR comment. It never submitted a formal re-review, so GitHub's `reviewDecision` stayed stranded at `CHANGES_REQUESTED` — the PR is blocked even though the bot verbally signed off. (Observed on typeclaw/typeclaw#672, where `reviewDecision` is still `CHANGES_REQUESTED` after the ✅ ack.)

Root cause is two stacked gaps:

1. **The guards are attached to tools, not to channel egress.** `checkFalseReceipt` and `evaluateRereviewGuard` only run inside the `channel_reply` / `channel_send` tool handlers. In the incident the model ended its turn with the ack as **plain assistant prose and no tool call at all** (confirmed in the session transcript: the terminal assistant message has a `thinking` part and a `text` part, zero tool calls). `validateChannelTurn` then recovered that trailing prose and posted it via a `send(..., { source: 'system' })` — a path that bypasses both guards entirely.

2. **The classifier didn't recognize the phrasing.** Even on the tool path the re-review guard would have missed it: `classifyReviewClaim("that addresses the concern nicely")` returns `ignore` — "addresses the concern" matches neither `BLOCK_RESOLVE` ("that resolves it" / "closes it") nor `WARN_POSITIVE_CLOSEOUT` ("looks good" / "lgtm").

## Summary

- **Egress guard.** Re-run `checkFalseReceipt` + `evaluateRereviewGuard` in the `validateChannelTurn` recovery branch, just before the system-source send, and **suppress** on block rather than post. Suppress-not-block is the right call here: recovery cannot land the missing formal review on the model's behalf, and dropping the ack is strictly safer than publishing a verdict-shaped comment that strands the PR — the next inbound re-prompts the model, which can then submit the verdict properly. Both guards already short-circuit for non-github / non-`pr:\d+` chats, so this is a no-op for everything except GitHub PR sessions.
- **Classifier.** Teach the review-claim classifier the "addresses the concern" / "addressed your feedback" close-out family as a positive-warn closeout (escalated by the re-review guard only when the bot actually holds a live block). Added matching negation/future-intent demotions ("haven't addressed", "I'll address", "to address") so legitimate non-closeout prose still passes.

Why suppress and not auto-submit a review: the runtime cannot prove a semantic approval from one stray ack — same principle the existing tool-path guards follow (block and instruct, never act on the model's behalf).

## What this does NOT do

- Does not change the tool-path guards (`channel_reply` / `channel_send`) — they already block correctly; this only closes the recovery bypass.
- Does not auto-convert the ack into a formal `APPROVE` / dismissal. Suppression defers the verdict to the model on the next turn.
- Does not touch the other `source:'system'` send path semantics (skip-lock / turn-cap exemptions are unchanged).

## Review notes

- Load-bearing change: `src/channels/router.ts` — the new `evaluateRecoveryReviewGuards` call in the recovery branch and the helper below it. Invariant to verify: a github PR session that holds `selfBlocking: true` and ends a turn with a close-out-shaped ack (no channel tool) must NOT post, and must log `suppressed recovery (github review guard)`.
- Scoping invariant: an **unblocked** PR (`selfBlocking: false`) and all **non-github** channels must still recover normally — covered by two of the three new tests in `router.test.ts`.
- The classifier demotion list now includes a bare `to` before `address` (for "to address the concern"); the full claim-classifier suite passes, confirming no regression to the existing approve/resolve phrase coverage.
- Full gate green locally: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, `bun run test` (7587 pass / 0 fail).