### PR TITLE
fix(agent): stop sandboxed /tmp redirect from stranding gh review submits

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -9,7 +9,7 @@ import { Type } from '@sinclair/typebox'
 import { z } from 'zod'
 
 import { createPermissionService } from '@/permissions/permissions'
-import { createHookBus, defineTool, type PluginRegistry } from '@/plugin'
+import { createHookBus, defineTool, type PluginRegistry, type ToolResult } from '@/plugin'
 import { _resetBwrapAvailabilityCacheForTests, SESSION_TMP_ROOT } from '@/sandbox'
 
 import {
@@ -518,6 +518,40 @@ describe('wrapSystemAgentTool', () => {
 
     await expect(wrapped.execute('c', { command: 'pwd' })).rejects.toThrow('blocked: no bash')
     expect(calls).toEqual([])
+  })
+
+  // pi's bash tool REJECTS on non-zero exit. Without a finally-style after-run,
+  // a tool.after hook that releases a reservation (the github approve guard)
+  // never fires, stranding the PR as "already approved" on retry (PR #672).
+  test('tool.after fires with an error result when a built-in agent tool throws, then rethrows', async () => {
+    const afterResults: unknown[] = []
+    const tool = {
+      name: 'bash',
+      label: 'bash',
+      description: '',
+      parameters: Type.Object({ command: Type.String() }),
+      async execute(_callId: string, _params: { command: string }) {
+        throw new Error('no such file or directory')
+      },
+    }
+    const hooks = createHookBus()
+    hooks.registerAll('p1', '/agent', noopLogger, {
+      'tool.after': (event) => {
+        afterResults.push(event.result)
+      },
+    })
+
+    const wrapped = wrapAgentToolAsCustomToolDefinition(tool, { agentDir: '/agent', sessionId: 's', hooks })
+
+    await expect(
+      wrapped.execute('c', { command: 'gh api --input /tmp/x' } as never, undefined, undefined, {} as never),
+    ).rejects.toThrow('no such file or directory')
+    expect(afterResults).toHaveLength(1)
+    const errorText = ((afterResults[0] as ToolResult).content as Array<{ type: string; text?: string }>)
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('\n')
+    expect(errorText).toContain('no such file or directory')
   })
 
   test('edit built-in agent tool exposes and strips guard acknowledgements before execution', async () => {
@@ -1089,6 +1123,70 @@ describe('wrapAgentToolAsCustomToolDefinition /tmp path redirect (per-session sc
       {} as never,
     )
     expect(record.path).toBe('workspace/out.json')
+  })
+
+  // Mirrors pi's real write tool, which echoes the path back ("Successfully
+  // wrote N bytes to <path>"). The leaked backing path does not exist inside
+  // the bwrap bash sandbox, so a model that pastes it into `gh api --input`
+  // hits "no such file or directory" (the PR #672 strand this guards).
+  function fakeWriteEchoingPath() {
+    return {
+      name: 'write',
+      label: 'write',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), content: Type.String() }),
+      async execute(_id: string, params: { path: string; content: string }) {
+        return {
+          content: [{ type: 'text' as const, text: `Successfully wrote 2 bytes to ${params.path}` }],
+          details: { path: params.path },
+        }
+      },
+    }
+  }
+
+  test('a sandboxed role sees its original /tmp path in the receipt, not the backing dir', async () => {
+    const wrapped = wrapAgentToolAsCustomToolDefinition(fakeWriteEchoingPath(), {
+      agentDir: '/agent',
+      sessionId: 'sid42',
+      hooks: createHookBus(),
+      getOrigin: () => guest,
+      permissions: createPermissionService(),
+    })
+    const result = await wrapped.execute(
+      'c',
+      { path: '/tmp/review.json', content: '{}' } as never,
+      undefined,
+      undefined,
+      {} as never,
+    )
+    const text = (result.content as Array<{ type: string; text?: string }>)
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('\n')
+    expect(text).toContain('/tmp/review.json')
+    expect(text).not.toContain(`${SESSION_TMP_ROOT}/sid42`)
+  })
+
+  test('an unsandboxed role keeps the real /tmp path in the receipt (no rewrite)', async () => {
+    const wrapped = wrapAgentToolAsCustomToolDefinition(fakeWriteEchoingPath(), {
+      agentDir: '/agent',
+      sessionId: 'sid42',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+    })
+    const result = await wrapped.execute(
+      'c',
+      { path: '/tmp/review.json', content: '{}' } as never,
+      undefined,
+      undefined,
+      {} as never,
+    )
+    const text = (result.content as Array<{ type: string; text?: string }>)
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text)
+      .join('\n')
+    expect(text).toContain('/tmp/review.json')
   })
 })
 

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -463,13 +463,24 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
         await applyBashSandbox(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId, bashEnvOverlay)
       }
 
-      if (TMP_REDIRECT_TOOLS.has(tool.name) && opts.permissions !== undefined) {
-        await applyTmpPathRedirect(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId)
-      }
+      const tmpRedirect =
+        TMP_REDIRECT_TOOLS.has(tool.name) && opts.permissions !== undefined
+          ? await applyTmpPathRedirect(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId)
+          : undefined
 
-      const result = await bashEnvStore.run(bashEnvOverlay, () =>
-        tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate),
-      )
+      let rawResult: ToolResult
+      try {
+        rawResult = await bashEnvStore.run(bashEnvOverlay, () =>
+          tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate),
+        )
+      } catch (error) {
+        // A throwing tool (pi's bash rejects on non-zero exit) must still run
+        // tool.after so cleanup hooks fire — e.g. the github approve guard's
+        // release, whose absence stranded a PR as "already approved" (PR #672).
+        await runToolAfterSafely(opts, tool.name, toolCallId, toErrorResult(error))
+        throw error
+      }
+      const result = tmpRedirect !== undefined ? restoreTmpPathInResult(rawResult, tmpRedirect) : rawResult
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
         fireLoopAbort(opts.getAbort)
@@ -488,6 +499,26 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       }
     },
   })
+}
+
+function toErrorResult(error: unknown): ToolResult {
+  const message = error instanceof Error ? error.message : String(error)
+  return { content: [{ type: 'text', text: message }], details: { error: message } }
+}
+
+// The original tool error must always propagate, so a failure inside the
+// after-hook itself is swallowed rather than masking the real cause.
+async function runToolAfterSafely(
+  opts: WrapSystemToolOptions,
+  tool: string,
+  callId: string,
+  result: ToolResult,
+): Promise<void> {
+  try {
+    await opts.hooks.runToolAfter({ tool, sessionId: opts.sessionId, callId, result })
+  } catch {
+    // intentionally ignored: never mask the originating tool error
+  }
 }
 
 export function defaultBuiltinPiAgentTools(): AgentTool<any, any>[] {
@@ -579,24 +610,47 @@ const TMP_REDIRECT_TOOLS = new Set(['read', 'write', 'edit', 'grep', 'find', 'ls
 // different files. Rewriting the file tool's on-disk path to the same session
 // backing dir makes every layer resolve /tmp/foo to one file. Unsandboxed roles
 // (empty masks) are left untouched: their bash already shares the real /tmp.
+type TmpRedirect = { original: string; backing: string }
+
 async function applyTmpPathRedirect(
   mutableArgs: Record<string, unknown>,
   permissions: PermissionService,
   origin: SessionOrigin | undefined,
   agentDir: string,
   sessionId: string,
-): Promise<void> {
+): Promise<TmpRedirect | undefined> {
   const rawPath = mutableArgs.path
-  if (typeof rawPath !== 'string') return
+  if (typeof rawPath !== 'string') return undefined
 
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
-  if (dirs.length === 0 && files.length === 0) return
+  if (dirs.length === 0 && files.length === 0) return undefined
 
   const backing = mapVirtualTmpPath(agentDir, sessionId, rawPath)
-  if (backing === undefined) return
+  if (backing === undefined || backing === rawPath) return undefined
 
   await ensureSessionTmpDir(sessionId)
   mutableArgs.path = backing
+  return { original: rawPath, backing }
+}
+
+// The redirect swaps the model-facing /tmp path for its session backing dir
+// before execution; the file tool then echoes that backing path in its receipt
+// text and details. Reverse it on the way out so the model only ever sees the
+// path it asked for — a leaked backing path is unreachable inside the bwrap
+// bash sandbox, so reusing it in `gh api --input` fails (the PR #672 strand).
+function restoreTmpPathInResult(result: ToolResult, redirect: TmpRedirect): ToolResult {
+  const content = (result.content as ContentPart[]).map((part) =>
+    part.type === 'text' ? { ...part, text: part.text.split(redirect.backing).join(redirect.original) } : part,
+  )
+  const details =
+    isRecord(result.details) && result.details.path === redirect.backing
+      ? { ...result.details, path: redirect.original }
+      : result.details
+  return { content, details }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }
 
 function appendLoopWarning(result: ToolResult, message: string): ToolResult {


### PR DESCRIPTION
## Background

A GitHub PR review request woke the agent. It wrote its review JSON to `/tmp/review.json` and tried to post it with `gh api --input /tmp/review.json`. The submit failed with "no such file or directory" and the retry was then blocked as "already approved", so the review never landed and the request sat unanswered.

Two bugs combined to produce this outcome:

1. **Path leak in tmp redirect.** The per-session `/tmp` redirect mutates the file tool's path to its backing dir (`/tmp/typeclaw-session/<sid>/...`) and the tool echoes that backing path in its receipt. The model reused it in sandboxed bash, where the path is unreachable (the session dir is bind-mounted over `/tmp`). The redirect now reverses the path in the tool result so the model only ever sees the `/tmp` path it asked for.

2. **Stranded reservation on tool throw.** pi's bash tool rejects on non-zero exit. The agent-tool wrapper only ran `tool.after` on the success path. The GitHub approve guard's release never fired, leaving the PR reserved so the retry self-blocked as a duplicate `APPROVE`. `tool.after` now runs (via `runToolAfterSafely`) with an error-shaped result when the tool throws, then rethrows — preserving the original error while ensuring cleanup hooks always execute.

## Summary

**Fix 1 — path reversal in `restoreTmpPathInResult`.**
`applyTmpPathRedirect` now returns a `TmpRedirect` token `{ original, backing }`. After execution, `restoreTmpPathInResult` replaces every occurrence of the backing path in result text and `details.path` with the original path. The model therefore never learns the session backing dir.

**Fix 2 — `tool.after` on throw path.**
The `try/catch` around `tool.execute` calls `runToolAfterSafely` with a synthetic error result before rethrowing. `runToolAfterSafely` swallows any hook error so the originating tool error is never masked — the after-hook is fire-and-forget on the throw path.

Both changes are in `src/agent/plugin-tools.ts`, covered by the new tests in `src/agent/plugin-tools.test.ts`.

## What this does NOT do

- Does not change the sandbox mount topology or `/tmp` visibility rules.
- Does not change which tools participate in the tmp redirect (`TMP_REDIRECT_TOOLS`).
- Does not address `filePath` (only `path`) in `details` — no known tool uses `filePath` in the redirect context.
- Does not retry the stranded review for PR #672; that requires a manual re-trigger.

## Review notes

The load-bearing changes are in `wrapAgentToolAsCustomToolDefinition` (~L463–L490 in the diff). The key invariant to verify: `restoreTmpPathInResult` must not be called when `tmpRedirect` is `undefined` (path was not redirected), and `runToolAfterSafely` must always rethrow the original error. Both are enforced structurally — `restoreTmpPathInResult` is only reachable via the `tmpRedirect !== undefined` branch, and `runToolAfterSafely` is `await`ed in a `catch` that ends with `throw error`.

The `applyTmpPathRedirect` early-return guard `backing === rawPath` (new) prevents a spurious `TmpRedirect` token when `mapVirtualTmpPath` echoes the input unchanged (non-tmp paths), avoiding a no-op string replace on every file tool result.
