### PR TITLE
fix(github-cli-auth): make approve-idempotency lock in-flight-only

### DIFF
--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -83,13 +83,39 @@ describe('approve idempotency guard', () => {
     expect(retry).toBeNull()
   })
 
-  test('a succeeded APPROVE keeps the PR locked against duplicates', async () => {
-    const g = makeGuard({})
+  test('after a succeeded APPROVE the next attempt defers to the resolver, which blocks once GitHub reports APPROVED', async () => {
+    const g = makeGuard({ [`${WS}#15`]: 'APPROVED' })
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
     g.release({ callId: 'a1', succeeded: true })
     const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
     expect(dup).not.toBeNull()
     expect(dup?.block).toBe(true)
+  })
+
+  test('a superseded approval no longer strands the bot: after a succeeded APPROVE is later demoted to CHANGES_REQUESTED, a re-APPROVE is allowed', async () => {
+    // given: the first APPROVE landed and the in-flight lock was released
+    const g = makeGuard({})
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 16, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    // when: GitHub's effective state has since moved to CHANGES_REQUESTED (resolver defaults to NONE)
+    const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 16, verdict: 'APPROVE' })
+    // then: no stale local lock blocks the genuine re-approval
+    expect(reapprove).toBeNull()
+  })
+
+  test('a remote-already-approved block releases the in-flight lock so a later supersession can re-approve', async () => {
+    let approved = true
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, alreadyApproved: approved }),
+    })
+    guards.push(g)
+    const blocked = await g.guard({ callId: 'a1', workspace: WS, prNumber: 18, verdict: 'APPROVE' })
+    expect(blocked?.block).toBe(true)
+    // when: the standing approval is later superseded upstream
+    approved = false
+    const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 18, verdict: 'APPROVE' })
+    // then: the earlier block did not leave a stale lock behind
+    expect(reapprove).toBeNull()
   })
 
   test('ignores non-APPROVE verdicts (REQUEST_CHANGES is allowed to repeat)', async () => {

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -22,18 +22,30 @@ const DUPLICATE_REASON =
   'If you intended to change your verdict, request changes or dismiss the prior review instead of re-approving.'
 
 // Makes formal `gh ... event=APPROVE` idempotent per PR across turns, sessions,
-// and restarts. The per-turn review ledger only guards prose claims and resets
-// every turn, so without this an APPROVE can fire again whenever the same PR
-// fans out into a second session or a follow-up turn. We reserve the PR in an
-// in-process set before the command runs (stops same-container concurrent
-// double-approve) and consult GitHub for the bot's effective review state
-// (stops cross-restart re-approval). Reads fail OPEN: a transient GitHub error
-// must never permanently strand the bot from approving a PR it has not yet
-// approved — the in-process reservation still blocks the concurrent case.
+// and restarts. Two layers, each with a single job:
+//
+//   1. An in-process set of *in-flight* reservations (`pendingApprovals`) that
+//      blocks a second APPROVE while a first is still mid-flight in the same
+//      container — the concurrent-double-approve case the remote read can't see
+//      yet (GitHub hasn't recorded the in-flight review).
+//   2. The authoritative GitHub effective-state read, the SOLE source of truth
+//      for "the bot already holds a standing APPROVED review." It understands
+//      supersession: a later CHANGES_REQUESTED / DISMISSED demotes an earlier
+//      APPROVED, so the bot may legitimately re-approve.
+//
+// The set is strictly an in-flight lock — never a persistent "already approved"
+// memory. A completed APPROVE drops its reservation in release(), so the next
+// APPROVE re-consults GitHub instead of being shadowed by a stale local entry.
+// That separation fixes the strand bug: once a standing approval is superseded
+// (PR back to CHANGES_REQUESTED), a stale local lock must not keep blocking a
+// genuine re-approve — only the remote read decides, and it now reports
+// alreadyApproved=false. Reads fail OPEN: a transient GitHub error must never
+// permanently strand a first approval; the in-flight reservation still covers
+// the concurrent case.
 export function createApproveIdempotencyGuard(deps: {
   resolveEffectiveApproval: EffectiveApprovalResolver
 }): ApproveIdempotencyGuard {
-  const approvedOrPending = new Set<string>()
+  const pendingApprovals = new Set<string>()
   const reservedByCall = new Map<string, string>()
 
   return {
@@ -43,17 +55,21 @@ export function createApproveIdempotencyGuard(deps: {
 
       // Reserve BEFORE the await so two calls racing into guard() for the same
       // PR cannot both observe an empty set: the loser sees the winner's
-      // reservation and is blocked. The reservation is provisional until the
-      // remote check clears it.
-      if (approvedOrPending.has(key)) return { block: true, reason: DUPLICATE_REASON }
-      approvedOrPending.add(key)
+      // in-flight reservation and is blocked. The reservation is provisional
+      // and is always cleared on a terminal path (block below or release()).
+      if (pendingApprovals.has(key)) return { block: true, reason: DUPLICATE_REASON }
+      pendingApprovals.add(key)
       reservedByCall.set(args.callId, key)
 
       const remote = await deps.resolveEffectiveApproval({ workspace: args.workspace, prNumber: args.prNumber })
       if (remote.ok && remote.alreadyApproved) {
-        // Already approved upstream: keep the PR locked but drop this call's
-        // claim so release() won't later unlock a PR that is genuinely approved.
+        // Standing approval upstream. Block, and release the in-flight lock now:
+        // a blocked command never reaches tool.after, so release() won't run for
+        // this callId. Leaving the key set would resurrect the strand bug — the
+        // GitHub read is authoritative for the standing-approval case, not a
+        // lingering local entry.
         reservedByCall.delete(args.callId)
+        pendingApprovals.delete(key)
         return { block: true, reason: DUPLICATE_REASON }
       }
 
@@ -64,7 +80,11 @@ export function createApproveIdempotencyGuard(deps: {
       const key = reservedByCall.get(args.callId)
       if (key === undefined) return
       reservedByCall.delete(args.callId)
-      if (!args.succeeded) approvedOrPending.delete(key)
+      // Always drop the in-flight lock, success or fail. On success the standing
+      // approval now lives on GitHub, so future APPROVEs are caught by the remote
+      // read (which tracks supersession); the local lock must not outlive the
+      // in-flight window and shadow that read.
+      pendingApprovals.delete(key)
     },
   }
 }


### PR DESCRIPTION
## Background

On a real PR the bot was blocked from submitting an APPROVE via `gh api` with
"This bot has already approved this pull request" — even though the PR's
reviewDecision was CHANGES_REQUESTED. The bot's last decisive review was
CHANGES_REQUESTED, not APPROVED; GitHub's authoritative state said "not
approved". The guard disagreed, and the re-APPROVE was permanently stranded.

Root cause: the in-process Set in `approve-idempotency.ts` served two
conflicting roles.

1. **Concurrency lock** — prevent racing APPROVE calls in the same container
   (correct).
2. **Persistent approval memory** — `release({ succeeded: true })` kept the key
   in the set after a successful APPROVE, so guard() short-circuited on that
   key without ever reaching the authoritative GitHub effective-state read.

Once a standing approval was superseded (a new decisive review pushed the PR
back to CHANGES_REQUESTED or DISMISSED), the stale local entry permanently
blocked a legitimate re-APPROVE. The fail-open remote read — which correctly
tracks supersession via "last decisive review wins" — was never reached. The
local set shadowed the source of truth.

## Summary

Make the in-process set a **pure in-flight lock**: it gates concurrent calls
within one container, nothing more. After any terminal event the key is always
dropped, and GitHub's effective-state read is the sole source of truth for
whether a standing approval exists.

Changes in `src/bundled-plugins/github-cli-auth/approve-idempotency.ts`:

- **Renamed the set** from approvedOrPending to `pendingApprovals` to encode
  the new single-purpose semantics at the call site.
- **`release()`** now always deletes the key — success or fail. After a
  successful APPROVE the standing approval lives on GitHub; future APPROVEs are
  caught by `createGithubEffectiveApprovalResolver`, which understands
  supersession.
- **Remote-already-approved block path** now also deletes the key. A blocked
  command never reaches `tool.after`, so release won't run for it; leaving the
  key would reintroduce the strand bug on the next call.

**Trade-off:** there is a sub-second eventual-consistency window — APPROVE
lands → GitHub's reviews API briefly stale → a second sequential APPROVE in
the same container could slip through before GitHub reflects the first. This
was deliberately accepted: no TTL lock was added, because the correctness win
(never permanently stranding a legitimate re-APPROVE) dominates, and sequential
double-APPROVEs that fast are not a realistic model behavior. Design validated.

## What this does NOT do

- Does not add a TTL or grace-period lock to cover the sub-second
  eventual-consistency window; that complexity is not warranted by the failure
  rate.
- Does not change `createGithubEffectiveApprovalResolver` or the remote-read
  logic — only the in-process lock lifecycle.
- Does not address any other idempotency surface outside `approve-idempotency.ts`.

## Review notes

The load-bearing invariant: **every terminal path through `guard()` must drop
the pending key**. There are exactly three:

1. `release({ succeeded: true })` — APPROVE landed → key deleted (new
   behavior; previously kept).
2. `release({ succeeded: false })` — APPROVE failed → key deleted (unchanged).
3. Remote already-approved block inside guard() → key deleted inline (new;
   previously leaked).

If any path leaves the key in `pendingApprovals` after the command is no longer
in-flight, it reintroduces the strand bug. The test suite covers all three
paths, including the regression case: succeeded APPROVE → PR moves to
CHANGES_REQUESTED → re-APPROVE must be allowed.