### PR TITLE
fix(dockerfile): pin Bun to 1.3.13-slim to dodge 1.3.14 ARM64 crash

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -39,7 +39,9 @@ jobs:
           # Dockerfile this workflow emits doesn't itself depend on the
           # Bun version (only its TypeScript imports do); matches the pin
           # in ci.yml and release.yml so all three jobs use the same Bun.
-          bun-version: 1.3.14
+          # Held at 1.3.13 — see the dockerfile.ts BUN_IMAGE comment for the
+          # 1.3.14 ARM64 SIGABRT regressions (oven-sh/bun#30711, #30281).
+          bun-version: 1.3.13
 
       - name: Generate base Dockerfile
         # No `bun install` needed — scripts/emit-base-dockerfile.ts only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
           # to resolve the version, which intermittently 401s under GHA
           # token contention; a pinned version skips that lookup and goes
           # straight to the release download URL.
-          bun-version: 1.3.14
+          # Held at 1.3.13 (not 1.3.14) to match the container Bun pin in
+          # src/init/dockerfile.ts — 1.3.14 SIGABRTs on ARM64 Linux when
+          # launching external packages (oven-sh/bun#30711, #30281).
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
           # to resolve the version, which intermittently 401s under GHA
           # token contention; a pinned version skips that lookup and goes
           # straight to the release download URL.
-          bun-version: 1.3.14
+          # Held at 1.3.13 (not 1.3.14) to match the container Bun pin in
+          # src/init/dockerfile.ts — 1.3.14 SIGABRTs on ARM64 Linux when
+          # launching external packages (oven-sh/bun#30711, #30281).
+          bun-version: 1.3.13
 
       - uses: actions/setup-node@v4
         with:

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -687,7 +687,7 @@ describe('refreshDockerfile', () => {
       // then: the on-disk Dockerfile pins the INSTALLED version, not the spec
       const written = await readFile(join(dir, 'Dockerfile'), 'utf8')
       expect(written).toContain('FROM ghcr.io/typeclaw/typeclaw-base:0.1.0')
-      expect(written).not.toContain('FROM oven/bun:1-slim')
+      expect(written).not.toContain('FROM oven/bun:')
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -725,7 +725,7 @@ describe('refreshDockerfile', () => {
       // then: no GHCR pin (dev version doesn't exist on GHCR yet) — inline heavy stack on oven/bun
       const written = await readFile(join(dir, 'Dockerfile'), 'utf8')
       expect(written).not.toContain('ghcr.io/typeclaw/typeclaw-base')
-      expect(written).toContain('FROM oven/bun:1-slim')
+      expect(written).toContain('FROM oven/bun:1.3.13-slim')
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1071,7 +1071,7 @@ describe('base ↔ per-agent Dockerfile drift guard', () => {
   test('base Dockerfile uses the same BuildKit syntax pragma and base image as the per-agent Dockerfile so layer caching across the two is possible', () => {
     const base = buildBaseDockerfile()
     expect(base).toContain('# syntax=docker/dockerfile:1.7')
-    expect(base).toContain('FROM oven/bun:1-slim')
+    expect(base).toContain('FROM oven/bun:1.3.13-slim')
     expect(base).toContain('WORKDIR /agent')
   })
 
@@ -1096,7 +1096,7 @@ describe('versioned per-agent Dockerfile (base-image-pinning)', () => {
 
     // then: the FROM line pins the GHCR base image, not oven/bun
     expect(out).toContain(`FROM ${GHCR_BASE_IMAGE_REPO}:0.1.1`)
-    expect(out).not.toContain('FROM oven/bun:1-slim')
+    expect(out).not.toContain('FROM oven/bun:')
   })
 
   test('FROM tag is interpolated verbatim with no coercion', () => {
@@ -1227,7 +1227,7 @@ describe('versioned per-agent Dockerfile (base-image-pinning)', () => {
 
     // then: outputs are byte-identical and use oven/bun (not GHCR base)
     expect(inlineExplicit).toBe(inlineDefault)
-    expect(inlineExplicit).toContain('FROM oven/bun:1-slim')
+    expect(inlineExplicit).toContain('FROM oven/bun:1.3.13-slim')
     expect(inlineExplicit).not.toContain(GHCR_BASE_IMAGE_REPO)
   })
 })

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1149,8 +1149,9 @@ ${ghKeyringLayer}${toggleAptLayer}${cloudflaredBlock}${claudeCodeBlock}${codexCl
 `
 }
 
-// FROMs oven/bun:1-slim and rebuilds the full heavy stack inline. Used by
-// dev-mode runs (typeclaw installed via file: / link: spec) where the
+// FROMs the pinned oven/bun image (BUN_IMAGE) and rebuilds the full heavy
+// stack inline. Used by dev-mode runs (typeclaw installed via file: / link:
+// spec) where the
 // matching :version GHCR tag does not yet exist, and by the test suite to
 // keep coverage of the full-stack layers independent of GHCR availability.
 function renderInlineHead(
@@ -1296,7 +1297,17 @@ ${renderEntrypointShimLayer()}
 
 const BUILDKIT_HEADER = `# syntax=docker/dockerfile:1.7`
 
-const FROM_AND_WORKDIR = `FROM oven/bun:1-slim
+// Pinned to an exact patch, NOT the floating `1-slim` tag. `1-slim` rolled
+// onto Bun 1.3.14, whose ARM64 Linux regressions abort `bunx`/`bun add`/
+// `bun run <pkg>` with SIGABRT inside the container (a self-referencing
+// symlink in createFakeTemporaryNodeExecutable, oven-sh/bun#30711; plus a
+// require()-of-ESM PAC IB trap, oven-sh/bun#30281). 1.3.13-slim is the last
+// known-good release. Bump to the next stable once oven-sh/bun#30713 lands,
+// and keep it in lockstep with the CI Bun pin in
+// .github/workflows/{ci,release,base-image}.yml.
+const BUN_IMAGE = `oven/bun:1.3.13-slim`
+
+const FROM_AND_WORKDIR = `FROM ${BUN_IMAGE}
 
 WORKDIR /agent
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1083,7 +1083,7 @@ describe('writeDockerAssets', () => {
     await writeDockerAssets(root)
 
     const dockerfile = await readFile(join(root, 'Dockerfile'), 'utf8')
-    expect(dockerfile).toContain('FROM oven/bun:1-slim')
+    expect(dockerfile).toContain('FROM oven/bun:1.3.13-slim')
     expect(dockerfile).toContain('WORKDIR /agent')
     expect(dockerfile).toContain('typeclaw')
   })


### PR DESCRIPTION
## Background

A bug report from an Apple-silicon (ARM64) host: the container reports a Bun
version, but every attempt to run an external package crashes.

```
$ bun run dist/src/platforms/webex/cli.js --help
[1]    3 Aborted                 bun run dist/src/platforms/webex/cli.js --help
EXIT: 134
```

`bunx`, `bun add`, and `bun run <pkg>` all abort with SIGABRT (exit 134) or a
`NotDir` internal error; even `bun upgrade` self-fails with `StackOverflow`. The
agent-messenger CLIs (`agent-webex`, etc.) were effectively unrunnable inside the
container.

Root cause is upstream Bun, surfaced by our own tag policy. The base image
`FROM` used the **floating** `oven/bun:1-slim` tag, which silently rolled the
base onto **Bun 1.3.14**. That release has two ARM64 Linux regressions that hit
exactly the external-package launch path:

- A self-referencing symlink created in `createFakeTemporaryNodeExecutable`
  (`/tmp/bun-node-*/node -> bun -> bun -> ...`) -> ELOOP / SIGABRT
  ([oven-sh/bun#30711](https://github.com/oven-sh/bun/issues/30711)).
- `require()`-of-ESM aborting with a PAC IB trap (silent SIGTRAP/SIGABRT)
  ([oven-sh/bun#30281](https://github.com/oven-sh/bun/issues/30281)).

The fix for #30711 ([oven-sh/bun#30713](https://github.com/oven-sh/bun/pull/30713))
is not yet in any stable release, so there is no forward fix to roll to -- the only
remedy today is to stop landing on 1.3.14.

## Summary

Pin the base image to an **exact patch**, `oven/bun:1.3.13-slim` -- the last
known-good release -- instead of the floating `1-slim` tag. Floating tags make
base-image rebuilds non-deterministic; a single upstream patch release can break
every installed agent on the next rebuild, which is exactly what happened here.

The pin lives in one `BUN_IMAGE` constant that feeds **both** the prebuilt base
image (`buildBaseDockerfile`) and the inline dev/test path (`renderInlineHead`),
so production and dev mode can't drift onto different Bun versions.

The three CI Bun pins (`ci.yml`, `release.yml`, `base-image.yml`) move
`1.3.14 -> 1.3.13` so the runner validating/releasing the image uses the same Bun
as the container. They were already pinned (not `latest`); this just holds them
at the known-good patch and documents why.

## What this does NOT do

- Does **not** rebuild or publish a new `typeclaw-base` image. That happens via
  the Release workflow; this PR only changes what the next release will build.
- Does **not** touch the affected agent folders on hosts -- they pick up the fix
  on their next `typeclaw start` once a release ships the new base.
- Does **not** work around the upstream bug in our own code; it avoids the broken
  Bun version entirely.

## Review notes

- Load-bearing change: `src/init/dockerfile.ts` `BUN_IMAGE = oven/bun:1.3.13-slim`.
  Invariant to verify -- `bun run scripts/emit-base-dockerfile.ts | grep ^FROM`
  now prints `FROM oven/bun:1.3.13-slim`.
- The drift guard in `dockerfile.test.ts` asserts base and per-agent Dockerfiles
  share the same `FROM`; tests updated to the new tag. The two
  `not.toContain('FROM oven/bun:...')` assertions were widened to `FROM oven/bun:`
  so they stay meaningful regardless of the pinned patch.
- The two `start.test.ts` "stale Dockerfile" input fixtures still use `1-slim` on
  purpose -- they represent an *old* on-disk Dockerfile that `refreshDockerfile`
  overwrites.
- Bump to the next stable once oven-sh/bun#30713 lands; the `BUN_IMAGE` comment
  flags that follow-up.
