### PR TITLE
feat(channels): convert markdown tables to Discord inline-code rows

### DIFF
--- a/src/channels/adapters/discord-bot-format.test.ts
+++ b/src/channels/adapters/discord-bot-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { convertDiscordTables } from './discord-bot-format'
+import { convertDiscordTables, displayWidth } from './discord-bot-format'
 
 describe('convertDiscordTables — passthrough', () => {
   test('returns empty string for empty input', () => {
@@ -99,5 +99,53 @@ describe('convertDiscordTables — multiple and mixed', () => {
   test('does not touch code fences that contain pipes', () => {
     const input = ['```', '| not | a | table |', '```'].join('\n')
     expect(convertDiscordTables(input)).toBe(input)
+  })
+})
+
+describe('displayWidth', () => {
+  test('counts ASCII as one column each', () => {
+    expect(displayWidth('abc')).toBe(3)
+  })
+
+  test('counts CJK ideographs as two columns each', () => {
+    expect(displayWidth('김철수')).toBe(6)
+    expect(displayWidth('日本語')).toBe(6)
+  })
+
+  test('counts emoji as two columns', () => {
+    expect(displayWidth('✅')).toBe(2)
+  })
+
+  test('ignores zero-width and combining marks', () => {
+    expect(displayWidth('a\u0301')).toBe(1)
+    expect(displayWidth('a\u200bb')).toBe(2)
+  })
+
+  test('mixes widths additively', () => {
+    expect(displayWidth('a김b')).toBe(4)
+  })
+})
+
+describe('convertDiscordTables — wide-character alignment', () => {
+  test('aligns columns by VISUAL width, not code-unit length', () => {
+    const input = ['| name | status |', '|------|--------|', '| 김철수 | ✅ ok |', '| bob | done |'].join('\n')
+
+    const lines = convertDiscordTables(input).split('\n')
+    const visualWidth = (line: string) =>
+      displayWidth(line.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, ''))
+
+    const widths = lines.map(visualWidth)
+    expect(new Set(widths).size).toBe(1)
+  })
+
+  test('a CJK cell wider than its header still aligns the body', () => {
+    const input = ['| id | n |', '|----|---|', '| 1 | 김철수 |', '| 22 | x |'].join('\n')
+
+    const lines = convertDiscordTables(input).split('\n')
+    const visualWidth = (line: string) =>
+      displayWidth(line.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, ''))
+
+    const widths = lines.map(visualWidth)
+    expect(new Set(widths).size).toBe(1)
   })
 })

--- a/src/channels/adapters/discord-bot-format.test.ts
+++ b/src/channels/adapters/discord-bot-format.test.ts
@@ -102,6 +102,45 @@ describe('convertDiscordTables — multiple and mixed', () => {
   })
 })
 
+describe('convertDiscordTables — fenced code blocks', () => {
+  test('leaves a full table inside a ``` fence unchanged', () => {
+    const input = ['```', '| not | table |', '|-----|-------|', '| keep | pipes |', '```'].join('\n')
+    expect(convertDiscordTables(input)).toBe(input)
+  })
+
+  test('leaves a full table inside a ~~~ fence unchanged', () => {
+    const input = ['~~~', '| a | b |', '|---|---|', '| 1 | 2 |', '~~~'].join('\n')
+    expect(convertDiscordTables(input)).toBe(input)
+  })
+
+  test('still converts a table that appears after a closed fence', () => {
+    const input = ['```', 'code', '```', '', '| a | b |', '|---|---|', '| 1 | 2 |'].join('\n')
+    const result = convertDiscordTables(input)
+    expect(result).toContain('```\ncode\n```')
+    expect(result).toContain('**`a  b`**')
+    expect(result).toContain('`1  2`')
+  })
+})
+
+describe('convertDiscordTables — backticks in cells', () => {
+  test('wraps a row containing inline code with a longer delimiter', () => {
+    const input = ['| cmd | result |', '|-----|--------|', '| bun `test` | ok |'].join('\n')
+    const lines = convertDiscordTables(input).split('\n')
+    expect(lines[0]!).toBe('**`cmd         result`**')
+    expect(lines[1]!.startsWith('``')).toBe(true)
+    expect(lines[1]!.endsWith('``')).toBe(true)
+    expect(lines[1]!).toContain('bun `test`')
+  })
+
+  test('escalates the delimiter past a double-backtick run and pads', () => {
+    const input = ['| a | b |', '|---|---|', '| ``x`` | y |'].join('\n')
+    const row = convertDiscordTables(input).split('\n')[1]!
+    expect(row.startsWith('``` ')).toBe(true)
+    expect(row.endsWith(' ```')).toBe(true)
+    expect(row).toContain('``x``')
+  })
+})
+
 describe('displayWidth', () => {
   test('counts ASCII as one column each', () => {
     expect(displayWidth('abc')).toBe(3)

--- a/src/channels/adapters/discord-bot-format.test.ts
+++ b/src/channels/adapters/discord-bot-format.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test'
+
+import { convertDiscordTables } from './discord-bot-format'
+
+describe('convertDiscordTables — passthrough', () => {
+  test('returns empty string for empty input', () => {
+    expect(convertDiscordTables('')).toBe('')
+  })
+
+  test('leaves prose without pipes untouched', () => {
+    expect(convertDiscordTables('hello world, no table here')).toBe('hello world, no table here')
+  })
+
+  test('leaves a lone pipe line untouched (no alignment row)', () => {
+    expect(convertDiscordTables('a | b | c\njust prose')).toBe('a | b | c\njust prose')
+  })
+
+  test('preserves surrounding prose and blank lines around a table', () => {
+    const input = ['intro line', '', '| h1 | h2 |', '|----|----|', '| a | b |', '', 'outro line'].join('\n')
+    const result = convertDiscordTables(input)
+    expect(result.startsWith('intro line\n\n')).toBe(true)
+    expect(result.endsWith('\n\noutro line')).toBe(true)
+  })
+})
+
+describe('convertDiscordTables — table conversion', () => {
+  test('converts a basic table to padded inline-code rows with a bold header', () => {
+    const input = [
+      '| header1 | header2 | header3 |',
+      '|---------|---------|---------|',
+      '| r1c1    | r1c2    | r1c3    |',
+      '| r2c1    | r2c2    | r2c3    |',
+    ].join('\n')
+
+    const expected = [
+      '**`header1  header2  header3`**',
+      '`r1c1     r1c2     r1c3   `',
+      '`r2c1     r2c2     r2c3   `',
+    ].join('\n')
+
+    expect(convertDiscordTables(input)).toBe(expected)
+  })
+
+  test('pads every column to the widest cell across header and body', () => {
+    const input = ['| a | name |', '|---|------|', '| x | bob |', '| yy | alice |'].join('\n')
+
+    const result = convertDiscordTables(input)
+    const lines = result.split('\n')
+
+    expect(lines[0]!.startsWith('**`')).toBe(true)
+    expect(lines[0]!.endsWith('`**')).toBe(true)
+    expect(lines[1]!.startsWith('`')).toBe(true)
+    expect(lines[1]!.startsWith('**')).toBe(false)
+
+    const visibleLengths = lines.map((l) => l.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, '').length)
+    expect(new Set(visibleLengths).size).toBe(1)
+  })
+
+  test('handles a header-only table (no body rows)', () => {
+    const input = ['| only | head |', '|------|------|'].join('\n')
+    expect(convertDiscordTables(input)).toBe('**`only  head`**')
+  })
+
+  test('tolerates missing trailing cells in a body row by padding them', () => {
+    const input = ['| a | b | c |', '|---|---|---|', '| 1 | 2 |'].join('\n')
+    const lines = convertDiscordTables(input).split('\n')
+    const headerLen = lines[0]!.replace(/^\*\*`|`\*\*$/g, '').length
+    const rowLen = lines[1]!.replace(/^`|`$/g, '').length
+    expect(rowLen).toBe(headerLen)
+  })
+
+  test('works without leading/trailing pipes', () => {
+    const input = ['h1 | h2', '---|---', 'a | b'].join('\n')
+    const expected = ['**`h1  h2`**', '`a   b `'].join('\n')
+    expect(convertDiscordTables(input)).toBe(expected)
+  })
+})
+
+describe('convertDiscordTables — multiple and mixed', () => {
+  test('converts multiple tables in one document', () => {
+    const input = [
+      '| a | b |',
+      '|---|---|',
+      '| 1 | 2 |',
+      '',
+      'separator prose',
+      '',
+      '| c | d |',
+      '|---|---|',
+      '| 3 | 4 |',
+    ].join('\n')
+
+    const result = convertDiscordTables(input)
+    expect(result).toContain('**`a  b`**')
+    expect(result).toContain('**`c  d`**')
+    expect(result).toContain('separator prose')
+  })
+
+  test('does not touch code fences that contain pipes', () => {
+    const input = ['```', '| not | a | table |', '```'].join('\n')
+    expect(convertDiscordTables(input)).toBe(input)
+  })
+})

--- a/src/channels/adapters/discord-bot-format.ts
+++ b/src/channels/adapters/discord-bot-format.ts
@@ -11,6 +11,7 @@
 // row) and leaves every other byte — prose, code fences, lists — untouched.
 
 const TABLE_SEP_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/
+const FENCE_RE = /^(\s*)(```+|~~~+)(.*)$/
 
 export function convertDiscordTables(input: string): string {
   if (input === '') return ''
@@ -19,9 +20,33 @@ export function convertDiscordTables(input: string): string {
   const lines = input.split('\n')
   const out: string[] = []
   let i = 0
+  let openFence: string | null = null
 
   while (i < lines.length) {
     const line = lines[i]!
+
+    // A code fence (``` / ~~~) suspends table detection until it closes — a
+    // table-shaped block inside a fence is literal text, not a table. The close
+    // must use the same fence char and be at least as long as the opener, per
+    // CommonMark.
+    const fence = FENCE_RE.exec(line)
+    if (fence !== null) {
+      const marker = fence[2]!
+      if (openFence === null) {
+        openFence = marker
+      } else if (marker[0] === openFence[0] && marker.length >= openFence.length) {
+        openFence = null
+      }
+      out.push(line)
+      i++
+      continue
+    }
+    if (openFence !== null) {
+      out.push(line)
+      i++
+      continue
+    }
+
     // A table needs a `|`-bearing header line immediately followed by the
     // alignment row; same disambiguation rule chunkMarkdown uses so a stray
     // leading `|` in prose is not mistaken for a table.
@@ -138,6 +163,29 @@ function isWide(cp: number): boolean {
   )
 }
 
+// CommonMark inline code: the delimiter must be a backtick run LONGER than any
+// run inside the content, otherwise an embedded `` ` `` (e.g. a cell holding
+// `bun test`) closes the span early and corrupts the row. When the content
+// begins or ends with a backtick, one space of padding is inserted on each side
+// so the delimiter is not adjacent to a content backtick; CommonMark strips that
+// single padding space on render, leaving our column widths intact.
 function wrapCode(text: string): string {
-  return `\`${text}\``
+  const fence = '`'.repeat(longestBacktickRun(text) + 1)
+  const needsPad = text.startsWith('`') || text.endsWith('`')
+  const pad = needsPad ? ' ' : ''
+  return `${fence}${pad}${text}${pad}${fence}`
+}
+
+function longestBacktickRun(text: string): number {
+  let longest = 0
+  let run = 0
+  for (const ch of text) {
+    if (ch === '`') {
+      run++
+      if (run > longest) longest = run
+    } else {
+      run = 0
+    }
+  }
+  return longest
 }

--- a/src/channels/adapters/discord-bot-format.ts
+++ b/src/channels/adapters/discord-bot-format.ts
@@ -1,0 +1,87 @@
+// Discord renders no GitHub-flavored Markdown tables — a `| a | b |` block
+// shows up as literal pipes and dashes, so an agent reply that leans on a table
+// (very common) becomes unreadable. Discord DOES preserve whitespace verbatim
+// inside inline code spans, so we re-emit each table row as a single
+// backtick-wrapped line with columns padded to a fixed width. Columns line up
+// because every row is the same monospaced inline-code span. The header row is
+// additionally wrapped in `**...**` so it reads as a bold caption above the body.
+//
+// This is a line-walker, not a Markdown parser: it only touches blocks that
+// match the pipe-table shape (a `|`-bearing line followed by a `|---|` alignment
+// row) and leaves every other byte — prose, code fences, lists — untouched.
+
+const TABLE_SEP_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/
+
+export function convertDiscordTables(input: string): string {
+  if (input === '') return ''
+  if (!input.includes('|')) return input
+
+  const lines = input.split('\n')
+  const out: string[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]!
+    // A table needs a `|`-bearing header line immediately followed by the
+    // alignment row; same disambiguation rule chunkMarkdown uses so a stray
+    // leading `|` in prose is not mistaken for a table.
+    if (line.includes('|') && i + 1 < lines.length && TABLE_SEP_RE.test(lines[i + 1]!)) {
+      const start = i
+      i += 2
+      while (i < lines.length && lines[i]!.includes('|') && lines[i]!.trim() !== '') {
+        i++
+      }
+      const tableLines = lines.slice(start, i)
+      out.push(renderTable(tableLines))
+      continue
+    }
+    out.push(line)
+    i++
+  }
+
+  return out.join('\n')
+}
+
+function renderTable(tableLines: string[]): string {
+  const headerCells = splitRow(tableLines[0]!)
+  const bodyRows = tableLines.slice(2).map(splitRow)
+  const widths = computeWidths([headerCells, ...bodyRows])
+
+  const header = wrapCode(padRow(headerCells, widths))
+  const renderedRows = [`**${header}**`, ...bodyRows.map((cells) => wrapCode(padRow(cells, widths)))]
+  return renderedRows.join('\n')
+}
+
+function splitRow(row: string): string[] {
+  // Trim one optional leading/trailing pipe, then split on the rest. A trailing
+  // backslash before a pipe escapes it, but GFM table escaping is rare in agent
+  // output — we keep it simple and split on bare pipes.
+  let trimmed = row.trim()
+  if (trimmed.startsWith('|')) trimmed = trimmed.slice(1)
+  if (trimmed.endsWith('|')) trimmed = trimmed.slice(0, -1)
+  return trimmed.split('|').map((cell) => cell.trim())
+}
+
+function computeWidths(rows: string[][]): number[] {
+  const widths: number[] = []
+  for (const row of rows) {
+    for (let c = 0; c < row.length; c++) {
+      const cellLen = row[c]!.length
+      if (widths[c] === undefined || cellLen > widths[c]!) {
+        widths[c] = cellLen
+      }
+    }
+  }
+  return widths
+}
+
+function padRow(cells: string[], widths: number[]): string {
+  const padded = widths.map((width, c) => (cells[c] ?? '').padEnd(width))
+  // Two spaces between columns keeps them visually distinct inside the
+  // monospaced span without a vertical-bar separator.
+  return padded.join('  ')
+}
+
+function wrapCode(text: string): string {
+  return `\`${text}\``
+}

--- a/src/channels/adapters/discord-bot-format.ts
+++ b/src/channels/adapters/discord-bot-format.ts
@@ -66,9 +66,9 @@ function computeWidths(rows: string[][]): number[] {
   const widths: number[] = []
   for (const row of rows) {
     for (let c = 0; c < row.length; c++) {
-      const cellLen = row[c]!.length
-      if (widths[c] === undefined || cellLen > widths[c]!) {
-        widths[c] = cellLen
+      const cellWidth = displayWidth(row[c]!)
+      if (widths[c] === undefined || cellWidth > widths[c]!) {
+        widths[c] = cellWidth
       }
     }
   }
@@ -76,10 +76,66 @@ function computeWidths(rows: string[][]): number[] {
 }
 
 function padRow(cells: string[], widths: number[]): string {
-  const padded = widths.map((width, c) => (cells[c] ?? '').padEnd(width))
+  const padded = widths.map((width, c) => padToWidth(cells[c] ?? '', width))
   // Two spaces between columns keeps them visually distinct inside the
   // monospaced span without a vertical-bar separator.
   return padded.join('  ')
+}
+
+function padToWidth(cell: string, width: number): string {
+  const pad = width - displayWidth(cell)
+  return pad > 0 ? cell + ' '.repeat(pad) : cell
+}
+
+// Discord's monospaced inline-code font renders CJK ideographs, full-width
+// punctuation, and most emoji at two columns, while combining/zero-width marks
+// take none. `String.prototype.padEnd` counts UTF-16 code units, so padding by
+// `.length` leaves wide-character tables visually ragged. We iterate by code
+// point and sum per-glyph column widths so every cell pads to the same VISUAL
+// width. The ranges below are the standard East-Asian-Wide / Wide blocks plus
+// the common emoji planes; this is the same wcwidth approximation editors use.
+export function displayWidth(text: string): number {
+  let width = 0
+  for (const ch of text) {
+    width += charWidth(ch.codePointAt(0)!)
+  }
+  return width
+}
+
+function charWidth(cp: number): number {
+  if (isZeroWidth(cp)) return 0
+  if (isWide(cp)) return 2
+  return 1
+}
+
+function isZeroWidth(cp: number): boolean {
+  return (
+    cp === 0x200b || // zero-width space
+    (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks
+    (cp >= 0x200c && cp <= 0x200f) || // ZWNJ/ZWJ/directional marks
+    (cp >= 0xfe00 && cp <= 0xfe0f) // variation selectors
+  )
+}
+
+function isWide(cp: number): boolean {
+  return (
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals, Kangxi
+    (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana, Katakana, CJK symbols
+    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Ext A
+    (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
+    (cp >= 0xa000 && cp <= 0xa4cf) || // Yi
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+    (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK Compatibility Forms
+    (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth Forms
+    (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+    (cp >= 0x2600 && cp <= 0x26ff) || // Miscellaneous Symbols (☀ ♻ ⚠ …)
+    (cp >= 0x2700 && cp <= 0x27bf) || // Dingbats (✅ ✔ ✨ ➡ …)
+    (cp >= 0x2b00 && cp <= 0x2bff) || // Misc Symbols and Arrows (⭐ …)
+    (cp >= 0x1f300 && cp <= 0x1faff) || // emoji, symbols, pictographs
+    (cp >= 0x20000 && cp <= 0x3fffd) // CJK Ext B+ (supplementary ideographic)
+  )
 }
 
 function wrapCode(text: string): string {

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -1261,6 +1261,14 @@ describe('discord-bot createOutboundCallback', () => {
     expect(sends).toEqual([{ chat: 'c1', content: 'hello', options: { thread_id: 't1' } }])
   })
 
+  test('converts a markdown table into Discord inline-code rows before sending', async () => {
+    const { client, sends } = makeFakeClient()
+    const cb = createOutboundCallback({ client, logger: silentLogger(), formatChannelTag: tag })
+    const table = ['| a | b |', '|---|---|', '| 1 | 2 |'].join('\n')
+    await cb(makeMsg({ text: table }))
+    expect(sends).toEqual([{ chat: 'c1', content: '**`a  b`**\n`1  2`', options: undefined }])
+  })
+
   test('forwards replyTo.externalMessageId as the reply_to send option (native reply)', async () => {
     const { client, sends } = makeFakeClient()
     const cb = createOutboundCallback({ client, logger: silentLogger(), formatChannelTag: tag })

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -39,6 +39,7 @@ import {
   type InboundDropReason,
   renderPlaceholder,
 } from './discord-bot-classify'
+import { convertDiscordTables } from './discord-bot-format'
 import { createDiscordReactionCallback, createDiscordRemoveReactionCallback } from './discord-bot-reactions'
 import { enrichDiscordMessageReferences } from './discord-bot-reference'
 import {
@@ -647,7 +648,7 @@ export function createOutboundCallback(deps: {
     if (msg.adapter !== 'discord-bot') {
       return { ok: false, error: `unknown adapter: ${msg.adapter}` }
     }
-    const text = msg.text ?? ''
+    const text = convertDiscordTables(msg.text ?? '')
     const attachments = msg.attachments ?? []
     if (text === '' && attachments.length === 0) {
       return { ok: false, error: 'message has neither text nor attachments' }


### PR DESCRIPTION
## Problem

Discord renders **no** GitHub-flavored Markdown tables. When an agent replies with a table (very common), Discord shows the raw source — literal pipes and dashes — so the result is unreadable:

```
| header1 | header2 | header3 |
|---------|---------|---------|
| r1c1    | r1c2    | r1c3    |
```

## Approach

Discord *does* preserve whitespace verbatim inside **inline code spans**. So each table row is re-emitted as a single backtick-wrapped line with columns padded to a fixed width. Every row is the same monospaced span, so columns line up. The header row is additionally wrapped in `**...**` so it reads as a bold caption above the body. Columns are padded by **display width** (CJK / fullwidth / emoji count as two columns) so wide-character tables stay aligned in the client.

The example above becomes:

> **`header1  header2  header3`**
> `r1c1     r1c2     r1c3   `
> `r2c1     r2c2     r2c3   `

## More examples

**Ragged columns** — body rows with missing or extra cells are padded to the widest row:

```
| Tool | Status | Notes |
|------|--------|-------|
| build | ok |
| lint | ok | 66 warnings | extra |
```

becomes

> **`Tool   Status  Notes             `**
> `build  ok                        `
> `lint   ok      66 warnings  extra`

**No outer pipes** — tables without leading/trailing `|` are handled too:

```
Name | Role
-----|-----
alice | admin
bo | user
```

becomes

> **`Name   Role `**
> `alice  admin`
> `bo     user `

**CJK + emoji** — padded by visual width, so columns line up in Discord's monospaced font even with double-width glyphs:

```
| 이름 | 상태 |
|------|------|
| 김철수 | ✅ 완료 |
| bob | ❌ |
```

becomes

> **`이름    상태   `**
> `김철수  ✅ 완료`
> `bob     ❌     `

**Mixed prose + table** — only the table block is rewritten; surrounding prose is untouched byte-for-byte:

```
Here are the results:

| metric | value |
|--------|-------|
| p50 | 12ms |
| p99 | 88ms |

Done.
```

becomes

> Here are the results:
>
> **`metric  value`**
> `p50     12ms `
> `p99     88ms `
>
> Done.

## Implementation

- **`discord-bot-format.ts`** — new `convertDiscordTables(input)` pure function. A line-walker (not a Markdown parser, matching the `chunkMarkdown` philosophy in `src/markdown/chunk.ts`): it only rewrites blocks matching the pipe-table shape — a `|`-bearing line immediately followed by a `|---|` alignment row — and leaves prose, code fences, and lists byte-for-byte untouched. Columns are padded to the widest cell across header and body (by display width); missing trailing cells are padded.
- **`displayWidth`** — wcwidth-style helper: iterates by code point and counts CJK / Hangul / fullwidth / emoji blocks as two columns, combining and zero-width marks as zero, everything else as one. Padding uses this instead of `String.prototype.padEnd` so wide-character tables align.
- **`discord-bot.ts`** — wired into `createOutboundCallback` at the single point where outbound text is prepared (`const text = convertDiscordTables(msg.text ?? '')`). Discord-only; Slack/Telegram/KakaoTalk paths are untouched.

## Tests

- `discord-bot-format.test.ts` — 18 cases: passthrough, basic conversion with bold header, column padding/alignment, header-only, missing/extra cells, no leading/trailing pipes, multiple tables, code-fence safety, `displayWidth` units (ASCII / CJK / emoji / combining marks), and CJK+emoji visual-alignment.
- `discord-bot.test.ts` — added an integration case asserting the outbound callback converts a table before `sendMessage`.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, unrelated files)
- `bun run format` — no changes to touched files
- `bun test --parallel` (relevant files) — 83 pass, 0 fail
