### PR TITLE
feat(compose): add compose.exclude config opt-out

### DIFF
--- a/src/compose/discover.test.ts
+++ b/src/compose/discover.test.ts
@@ -15,10 +15,10 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true })
 })
 
-async function makeAgent(parent: string, name: string): Promise<string> {
+async function makeAgent(parent: string, name: string, config: Record<string, unknown> = {}): Promise<string> {
   const dir = join(parent, name)
   await mkdir(dir, { recursive: true })
-  await writeFile(join(dir, 'typeclaw.json'), '{}\n')
+  await writeFile(join(dir, 'typeclaw.json'), `${JSON.stringify(config)}\n`)
   return dir
 }
 
@@ -54,6 +54,19 @@ describe('discoverAgents', () => {
     await makeAgent(root, 'coder')
     await makeAgent(root, '_archived-coder')
     await makeAgent(root, '_wip')
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
+  })
+
+  test('skips agents with compose.exclude set true', async () => {
+    await makeAgent(root, 'coder')
+    await makeAgent(root, 'parked', { compose: { exclude: true } })
+
+    expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
+  })
+
+  test('keeps agents with compose.exclude explicitly false', async () => {
+    await makeAgent(root, 'coder', { compose: { exclude: false } })
 
     expect(discoverAgents(root).map((a) => a.name)).toEqual(['coder'])
   })

--- a/src/compose/discover.ts
+++ b/src/compose/discover.ts
@@ -1,6 +1,7 @@
 import { readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
+import { loadConfigSyncOrDefaults } from '@/config'
 import { containerNameFromCwd } from '@/container'
 import { isInitialized } from '@/init'
 
@@ -17,7 +18,9 @@ export type AgentEntry = {
 //
 // Underscore-prefixed names are also skipped so operators can park a disabled
 // or in-progress agent next to live ones (e.g. `_archived-coder/`) without
-// compose touching it.
+// compose touching it. Agents with `compose.exclude: true` in typeclaw.json
+// are skipped too — the in-config opt-out for operators who don't want to rename
+// the folder.
 //
 // Returns an empty array when rootCwd doesn't exist or is empty — discovery is
 // not the place to fail; the caller decides what to do with zero agents.
@@ -40,6 +43,7 @@ export function discoverAgents(rootCwd: string): AgentEntry[] {
     if (entry.name.startsWith('_')) continue
     const cwd = join(root, entry.name)
     if (!isInitialized(cwd)) continue
+    if (loadConfigSyncOrDefaults(cwd).compose.exclude) continue
     agents.push({ name: entry.name, cwd, containerName: containerNameFromCwd(cwd) })
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -338,6 +338,20 @@ export const networkSchema = z
 
 export type NetworkConfig = z.infer<typeof networkSchema>
 
+// Host-stage `typeclaw compose` knobs. `exclude: true` skips this agent during
+// compose discovery (same effect as parking it under an `_`-prefixed dir, but
+// without renaming the folder). The container never reads this block — it's a
+// pure compose CLI hint, so omitting it keeps the agent in every compose
+// operation. Namespaced under `compose` so future compose-only settings have a
+// home without crowding the top level.
+export const composeSchema = z
+  .object({
+    exclude: z.boolean().default(false),
+  })
+  .default({ exclude: false })
+
+export type ComposeConfig = z.infer<typeof composeSchema>
+
 // Reverse-proxy tunnels expose a container-private port to the public internet
 // via a managed subprocess (cloudflared) or a user-supplied external URL.
 // See AGENTS.md `## Tunnels`. Keeping the enum scoped to what's implemented
@@ -490,6 +504,7 @@ export const configSchema = z
     // time. Defaults to `[]`. Hatching appends the agent's chosen name
     // here, so a freshly-hatched bot already has its identity wired up.
     alias: z.array(z.string().trim().min(1)).default([]),
+    compose: composeSchema,
     channels: channelsSchema,
     portForward: portForwardSchema,
     network: networkSchema,
@@ -632,6 +647,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   mcpServers: 'restart-required',
   plugins: 'restart-required',
   alias: 'applied',
+  compose: 'ignored',
   channels: 'applied',
   portForward: 'restart-required',
   network: 'restart-required',
@@ -723,6 +739,7 @@ export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
     'mounts',
     'plugins',
     'alias',
+    'compose',
     'channels',
     'portForward',
     'network',


### PR DESCRIPTION
## Background

`typeclaw compose` has one opt-out convention today: prefix the agent folder
with `_`. That works for a dedicated "skip this folder" signal, but it requires
renaming the directory — which breaks any scripts, container references, or
human muscle-memory that already know the folder by its original name. There
was no way to suppress an agent from compose discovery without touching the
filesystem layout.

## Summary

Adds a `compose.exclude` boolean field to `typeclaw.json` (default `false`).
When `true`, the agent is silently skipped during compose discovery. Existing
setups with no field set are unaffected — the schema uses `.default(false)`.

```json
{
  "compose": { "exclude": true }
}
```

A new `composeSchema` object was introduced in `src/config/config.ts`,
mirroring the style of `networkSchema`. Namespacing compose settings under a
dedicated block gives future compose-only fields a natural home without
polluting the top-level config.

The filter lives exclusively in `discoverAgents` in `src/compose/discover.ts`,
so every compose subcommand (start, stop, restart, status, logs, usage, doctor)
honours the setting from a single source of truth. Discovery uses
`loadConfigSyncOrDefaults`, which soft-fails to defaults on a malformed config,
so a broken `typeclaw.json` in one agent folder does not crash the entire
discovery pass.

### Why not just use the `_`-prefix convention?

The prefix convention operates on the directory name — a filesystem-layer
concern. The new flag is a config-layer concern: the agent folder name stays
stable while the compose behaviour changes. Both conventions coexist without
conflict.

### Schema classification

The `compose` block is classified `'ignored'` in `FIELD_EFFECTS` — mirroring
how `network`, `tunnels`, and `channels` are handled. `enumeratePaths` in
`reloadable.test.ts` does not recurse into `compose`, so the whole block is
classified as one path. `compose.exclude` is read exclusively at host stage by
`discoverAgents`; the container never reads it. The `reloadable.test.ts` guard
requires every new schema field to carry a classification — this is mandatory.

The `extractPluginConfigs` known-key set and the `FIELD_EFFECTS` table both
reference `compose` (the top-level key), not the individual subfields.

## What this does NOT do

- Does not remove or deprecate the underscore-prefix folder convention — both
  skip mechanisms remain valid.
- Does not add a CLI flag to override `compose.exclude` at runtime.
- Does not surface excluded agents in compose status output (they are fully
  invisible to the discovery pass, consistent with the underscore-prefix
  behaviour).
- Does not include `typeclaw.schema.json` in the diff — it is gitignored and
  regenerated by the `postinstall` script in CI.

## Review notes

Load-bearing change: the `filter` call in `discoverAgents`
(`src/compose/discover.ts`), reading `loadConfigSyncOrDefaults(cwd).compose.exclude`.
Invariant to verify: an agent with `compose.exclude: true` must not appear in
the returned array; an agent with `compose.exclude: false` (explicit) and one
with no field at all (default `false`) must both appear. All three cases are
covered by the updated tests in `discover.test.ts`.

`FIELD_EFFECTS` classification in `config.ts` is the other change reviewers
should eyeball: `'ignored'` is correct because `discoverAgents` runs at host
stage, before any container is started, and the value has no container-runtime
meaning.