### PR TITLE
fix(github): share the review-verdict lock across concurrent sessions

### DIFF
--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -1,45 +1,61 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 
-import { createApproveIdempotencyGuard, type EffectiveApprovalResolver } from './approve-idempotency'
+import {
+  __resetReviewVerdictGuardForTest,
+  createApproveIdempotencyGuard,
+  type EffectiveApprovalResolver,
+  type EffectiveVerdict,
+} from './approve-idempotency'
 
 const WS = 'acme/widgets'
 
-function resolver(map: Record<string, 'APPROVED' | 'CHANGES_REQUESTED' | 'NONE' | 'error'>): EffectiveApprovalResolver {
+function resolver(map: Record<string, EffectiveVerdict | 'error'>): EffectiveApprovalResolver {
   return async ({ workspace, prNumber }) => {
     const state = map[`${workspace}#${prNumber}`] ?? 'NONE'
     if (state === 'error') return { ok: false }
-    return { ok: true, alreadyApproved: state === 'APPROVED' }
+    return { ok: true, effective: state }
   }
 }
 
-describe('approve idempotency guard', () => {
-  let guards: Array<ReturnType<typeof createApproveIdempotencyGuard>> = []
+describe('review verdict idempotency guard', () => {
   afterEach(() => {
-    guards = []
+    __resetReviewVerdictGuardForTest()
   })
-  function makeGuard(map: Record<string, 'APPROVED' | 'CHANGES_REQUESTED' | 'NONE' | 'error'>) {
-    const g = createApproveIdempotencyGuard({ resolveEffectiveApproval: resolver(map) })
-    guards.push(g)
-    return g
+  function makeGuard(map: Record<string, EffectiveVerdict | 'error'> = {}, now?: () => number) {
+    return createApproveIdempotencyGuard({ resolveEffectiveApproval: resolver(map), now })
   }
 
-  test('allows the first APPROVE when the bot has no prior approval', async () => {
-    const g = makeGuard({})
+  test('allows the first APPROVE when the bot has no prior verdict', async () => {
+    const g = makeGuard()
     const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 5, verdict: 'APPROVE' })
     expect(decision).toBeNull()
   })
 
-  test('blocks a second APPROVE while the first is still pending (concurrent sessions, same container)', async () => {
-    const g = makeGuard({})
+  test('blocks a second verdict while the first is still in flight (concurrent sessions, same container)', async () => {
+    const g = makeGuard()
     // given: a first APPROVE that reserved the PR but has not completed (tool.after not called yet)
     const first = await g.guard({ callId: 'a1', workspace: WS, prNumber: 7, verdict: 'APPROVE' })
     expect(first).toBeNull()
+    // when: a second session attempts any formal verdict for the same PR
     const second = await g.guard({ callId: 'a2', workspace: WS, prNumber: 7, verdict: 'APPROVE' })
-    expect(second).not.toBeNull()
+    // then: it is blocked while the first is mid-flight
     expect(second?.block).toBe(true)
   })
 
-  test('two APPROVE calls racing through guard() before either awaits the remote check yield exactly one allow', async () => {
+  test('separate plugin instances share the in-flight lease (process-wide singleton)', async () => {
+    // given: two guards as two different plugin instances would create them
+    const instanceA = makeGuard()
+    const instanceB = makeGuard()
+    // when: instance A reserves an APPROVE and never calls tool.after
+    const a = await instanceA.guard({ callId: 'a1', workspace: WS, prNumber: 8, verdict: 'APPROVE' })
+    expect(a).toBeNull()
+    // then: instance B sees the in-flight lease and blocks — the regression that
+    // let three concurrent sessions each land an APPROVE on the same PR
+    const b = await instanceB.guard({ callId: 'b1', workspace: WS, prNumber: 8, verdict: 'APPROVE' })
+    expect(b?.block).toBe(true)
+  })
+
+  test('two verdict calls racing through guard() before either awaits the remote check yield exactly one allow', async () => {
     let release: () => void = () => {}
     const gate = new Promise<void>((resolve) => {
       release = resolve
@@ -47,7 +63,7 @@ describe('approve idempotency guard', () => {
     const g = createApproveIdempotencyGuard({
       resolveEffectiveApproval: async () => {
         await gate
-        return { ok: true, alreadyApproved: false }
+        return { ok: true, effective: 'NONE' }
       },
     })
     const both = Promise.all([
@@ -56,16 +72,13 @@ describe('approve idempotency guard', () => {
     ])
     release()
     const [r1, r2] = await both
-    const allowed = [r1, r2].filter((r) => r === null)
-    const blocked = [r1, r2].filter((r) => r !== null)
-    expect(allowed).toHaveLength(1)
-    expect(blocked).toHaveLength(1)
+    expect([r1, r2].filter((r) => r === null)).toHaveLength(1)
+    expect([r1, r2].filter((r) => r !== null)).toHaveLength(1)
   })
 
   test('blocks an APPROVE when the bot already effectively approved the PR on GitHub', async () => {
     const g = makeGuard({ [`${WS}#9`]: 'APPROVED' })
     const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 9, verdict: 'APPROVE' })
-    expect(decision).not.toBeNull()
     expect(decision?.block).toBe(true)
   })
 
@@ -75,8 +88,28 @@ describe('approve idempotency guard', () => {
     expect(decision).toBeNull()
   })
 
-  test('releasing a failed APPROVE lets a later genuine APPROVE through', async () => {
-    const g = makeGuard({})
+  test('blocks a REQUEST_CHANGES when the bot already holds a standing CHANGES_REQUESTED', async () => {
+    const g = makeGuard({ [`${WS}#23`]: 'CHANGES_REQUESTED' })
+    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 23, verdict: 'REQUEST_CHANGES' })
+    expect(decision?.block).toBe(true)
+  })
+
+  test('allows REQUEST_CHANGES when the bot previously approved (a real demotion)', async () => {
+    const g = makeGuard({ [`${WS}#24`]: 'APPROVED' })
+    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 24, verdict: 'REQUEST_CHANGES' })
+    expect(decision).toBeNull()
+  })
+
+  test('blocks a concurrent REQUEST_CHANGES while the first is in flight (symmetry with APPROVE)', async () => {
+    const g = makeGuard()
+    const first = await g.guard({ callId: 'a1', workspace: WS, prNumber: 25, verdict: 'REQUEST_CHANGES' })
+    expect(first).toBeNull()
+    const second = await g.guard({ callId: 'a2', workspace: WS, prNumber: 25, verdict: 'REQUEST_CHANGES' })
+    expect(second?.block).toBe(true)
+  })
+
+  test('releasing a failed verdict lets a later genuine verdict through', async () => {
+    const g = makeGuard()
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 13, verdict: 'APPROVE' })
     g.release({ callId: 'a1', succeeded: false })
     const retry = await g.guard({ callId: 'a2', workspace: WS, prNumber: 13, verdict: 'APPROVE' })
@@ -88,47 +121,96 @@ describe('approve idempotency guard', () => {
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
     g.release({ callId: 'a1', succeeded: true })
     const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
-    expect(dup).not.toBeNull()
     expect(dup?.block).toBe(true)
   })
 
   test('a superseded approval no longer strands the bot: after a succeeded APPROVE is later demoted to CHANGES_REQUESTED, a re-APPROVE is allowed', async () => {
-    // given: the first APPROVE landed and the in-flight lock was released
-    const g = makeGuard({})
+    // given: the first APPROVE landed and the in-flight lease was released
+    const g = makeGuard()
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 16, verdict: 'APPROVE' })
     g.release({ callId: 'a1', succeeded: true })
-    // when: GitHub's effective state has since moved to CHANGES_REQUESTED (resolver defaults to NONE)
+    // when: GitHub's effective state has since moved off APPROVED (resolver defaults to NONE)
     const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 16, verdict: 'APPROVE' })
-    // then: no stale local lock blocks the genuine re-approval
+    // then: no stale local lease blocks the genuine re-approval
     expect(reapprove).toBeNull()
   })
 
-  test('a remote-already-approved block releases the in-flight lock so a later supersession can re-approve', async () => {
-    let approved = true
+  test('a remote-already-approved block releases the in-flight lease so a later supersession can re-approve', async () => {
+    let effective: EffectiveVerdict = 'APPROVED'
     const g = createApproveIdempotencyGuard({
-      resolveEffectiveApproval: async () => ({ ok: true, alreadyApproved: approved }),
+      resolveEffectiveApproval: async () => ({ ok: true, effective }),
     })
-    guards.push(g)
     const blocked = await g.guard({ callId: 'a1', workspace: WS, prNumber: 18, verdict: 'APPROVE' })
     expect(blocked?.block).toBe(true)
     // when: the standing approval is later superseded upstream
-    approved = false
+    effective = 'NONE'
     const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 18, verdict: 'APPROVE' })
-    // then: the earlier block did not leave a stale lock behind
+    // then: the earlier block did not leave a stale lease behind
     expect(reapprove).toBeNull()
   })
 
-  test('ignores non-APPROVE verdicts (REQUEST_CHANGES is allowed to repeat)', async () => {
+  test('an expired lease is reclaimable so a crashed tool.after never strands the PR forever', async () => {
+    let clock = 1_000
+    const g = makeGuard({}, () => clock)
+    // given: a verdict reserved the PR but tool.after never fired (crash)
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 26, verdict: 'APPROVE' })
+    // when: more than the lease TTL elapses
+    clock += 5 * 60_000 + 1
+    // then: a fresh verdict can reclaim the abandoned lease
+    const reclaimed = await g.guard({ callId: 'a2', workspace: WS, prNumber: 26, verdict: 'APPROVE' })
+    expect(reclaimed).toBeNull()
+  })
+
+  test('a fresh lease is not reclaimable before the TTL elapses', async () => {
+    let clock = 1_000
+    const g = makeGuard({}, () => clock)
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 27, verdict: 'APPROVE' })
+    clock += 5 * 60_000 - 1
+    const blocked = await g.guard({ callId: 'a2', workspace: WS, prNumber: 27, verdict: 'APPROVE' })
+    expect(blocked?.block).toBe(true)
+  })
+
+  test('a stale tool.after for a reclaimed reservation does not drop the live session lease', async () => {
+    let clock = 1_000
+    const g = makeGuard({}, () => clock)
+    // given: session 1 reserves, then its lease is reclaimed after TTL by session 2
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 28, verdict: 'APPROVE' })
+    clock += 5 * 60_000 + 1
+    await g.guard({ callId: 'a2', workspace: WS, prNumber: 28, verdict: 'APPROVE' })
+    // when: session 1's tool.after finally fires (stale)
+    g.release({ callId: 'a1', succeeded: false })
+    // then: session 2 still holds the lease, so a third attempt is blocked
+    const third = await g.guard({ callId: 'a3', workspace: WS, prNumber: 28, verdict: 'APPROVE' })
+    expect(third?.block).toBe(true)
+  })
+
+  test('ignores COMMENT-only / non-verdict review events', async () => {
     const g = makeGuard({ [`${WS}#17`]: 'APPROVED' })
-    const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 17, verdict: 'REQUEST_CHANGES' })
+    // The guard's caller only passes APPROVE / REQUEST_CHANGES; a non-verdict
+    // value must never be treated as a duplicate. Cast simulates a future verdict
+    // type slipping through.
+    const decision = await g.guard({
+      callId: 'a1',
+      workspace: WS,
+      prNumber: 17,
+      verdict: 'COMMENT' as 'APPROVE',
+    })
     expect(decision).toBeNull()
   })
 
-  test('fails open on a resolver error so a genuine approval is never permanently blocked', async () => {
+  test('fails open on a resolver error so a genuine verdict is never permanently blocked', async () => {
     const g = makeGuard({ [`${WS}#19`]: 'error' })
     const decision = await g.guard({ callId: 'a1', workspace: WS, prNumber: 19, verdict: 'APPROVE' })
-    // A transient GitHub read failure must not strand the bot from ever approving;
-    // the in-process pending set still guards the concurrent-duplicate case.
+    // A transient GitHub read failure must not strand the bot; the in-flight
+    // lease still guards the concurrent-duplicate case.
     expect(decision).toBeNull()
+  })
+
+  test('a concurrent verdict still blocks even when the remote read fails open', async () => {
+    const g = makeGuard({ [`${WS}#29`]: 'error' })
+    const first = await g.guard({ callId: 'a1', workspace: WS, prNumber: 29, verdict: 'APPROVE' })
+    expect(first).toBeNull()
+    const second = await g.guard({ callId: 'a2', workspace: WS, prNumber: 29, verdict: 'APPROVE' })
+    expect(second?.block).toBe(true)
   })
 })

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -1,13 +1,17 @@
 import type { ReviewVerdict } from '@/channels/github-review-turn-ledger'
 
+// `NONE` covers "never reviewed" and "last decisive review was DISMISSED" — both
+// mean a fresh verdict is legitimate (not a duplicate).
+export type EffectiveVerdict = 'APPROVED' | 'CHANGES_REQUESTED' | 'NONE'
+
 export type EffectiveApprovalResolver = (target: {
   workspace: string
   prNumber: number
-}) => Promise<{ ok: true; alreadyApproved: boolean } | { ok: false }>
+}) => Promise<{ ok: true; effective: EffectiveVerdict } | { ok: false }>
 
 export type ApproveBlock = { block: true; reason: string }
 
-export type ApproveIdempotencyGuard = {
+export type ReviewVerdictGuard = {
   guard: (args: {
     callId: string
     workspace: string
@@ -17,78 +21,135 @@ export type ApproveIdempotencyGuard = {
   release: (args: { callId: string; succeeded: boolean }) => void
 }
 
-const DUPLICATE_REASON =
-  'This bot has already approved this pull request. A second APPROVE would post a redundant review. ' +
-  'If you intended to change your verdict, request changes or dismiss the prior review instead of re-approving.'
+// Back-compat alias: the guard now covers REQUEST_CHANGES too, not just APPROVE.
+export type ApproveIdempotencyGuard = ReviewVerdictGuard
 
-// Makes formal `gh ... event=APPROVE` idempotent per PR across turns, sessions,
-// and restarts. Two layers, each with a single job:
+function duplicateReason(verdict: ReviewVerdict): string {
+  if (verdict === 'APPROVE') {
+    return (
+      'This bot already holds a standing APPROVED review on this pull request. A second APPROVE would ' +
+      'post a redundant review. If you intended to change your verdict, request changes or dismiss the ' +
+      'prior review instead of re-approving.'
+    )
+  }
+  return (
+    'This bot already holds a standing CHANGES_REQUESTED review on this pull request. A second ' +
+    'REQUEST_CHANGES would post a redundant blocking review. The prior review is still live — push a fix ' +
+    'and APPROVE, or reply in the existing thread, instead of re-requesting changes.'
+  )
+}
+
+const CONCURRENT_REASON =
+  'Another session in this agent is already submitting a formal review verdict for this pull request. ' +
+  'Only one verdict may land per PR — do not submit a second review; the in-flight one will post.'
+
+// The standing verdict a fresh attempt would duplicate. APPROVE duplicates a
+// standing APPROVED; REQUEST_CHANGES duplicates a standing CHANGES_REQUESTED.
+function duplicatesStanding(verdict: ReviewVerdict, effective: EffectiveVerdict): boolean {
+  return verdict === 'APPROVE' ? effective === 'APPROVED' : effective === 'CHANGES_REQUESTED'
+}
+
+// How long a reservation may sit before it is treated as abandoned. A normal
+// `gh` review submit completes in seconds; this only guards against a tool.after
+// that never fires (crash mid-command), so it must outlast a slow command yet
+// never strand a PR for long.
+const LEASE_TTL_MS = 5 * 60_000
+
+type Reservation = { key: string; token: number; createdAt: number }
+
+// MODULE-LEVEL singletons, shared by every plugin instance in this process. The
+// github-cli-auth plugin's `plugin: async (ctx) => ...` factory may run once per
+// session, giving each its own closure — but all of those closures import THIS
+// module, so they coordinate through one Map. A closure-local Set (the prior
+// design) could not see a concurrent session's in-flight verdict, which is how
+// three sessions each landed an APPROVE on the same PR within ten seconds.
+const inFlightByPr = new Map<string, Reservation>()
+const reservationByCall = new Map<string, Reservation>()
+let tokenSeq = 0
+
+// Makes a formal `gh ... event=APPROVE|REQUEST_CHANGES` idempotent per PR across
+// turns, sessions, and (in-process) concurrent fan-out. Two layers:
 //
-//   1. An in-process set of *in-flight* reservations (`pendingApprovals`) that
-//      blocks a second APPROVE while a first is still mid-flight in the same
-//      container — the concurrent-double-approve case the remote read can't see
-//      yet (GitHub hasn't recorded the in-flight review).
-//   2. The authoritative GitHub effective-state read, the SOLE source of truth
-//      for "the bot already holds a standing APPROVED review." It understands
-//      supersession: a later CHANGES_REQUESTED / DISMISSED demotes an earlier
-//      APPROVED, so the bot may legitimately re-approve.
+//   1. A process-wide in-flight lease keyed by `workspace#prNumber`, held from
+//      tool.before through tool.after. While one verdict is mid-flight, every
+//      other session's verdict for the same PR is blocked — even though GitHub
+//      has not yet recorded the in-flight review. This is the layer the old
+//      closure-local Set could not provide: separate plugin instances meant
+//      separate Sets, so concurrent sessions never saw each other.
 //
-// The set is strictly an in-flight lock — never a persistent "already approved"
-// memory. A completed APPROVE drops its reservation in release(), so the next
-// APPROVE re-consults GitHub instead of being shadowed by a stale local entry.
-// That separation fixes the strand bug: once a standing approval is superseded
-// (PR back to CHANGES_REQUESTED), a stale local lock must not keep blocking a
-// genuine re-approve — only the remote read decides, and it now reports
-// alreadyApproved=false. Reads fail OPEN: a transient GitHub error must never
-// permanently strand a first approval; the in-flight reservation still covers
-// the concurrent case.
+//   2. The authoritative GitHub effective-state read, consulted AFTER the lease
+//      is acquired. It catches the cross-restart case (lease lost) and tracks
+//      supersession: a later CHANGES_REQUESTED/DISMISSED demotes an earlier
+//      APPROVED, so a genuine re-verdict is allowed. Reads fail OPEN — a
+//      transient error must never strand a genuine first verdict; the lease
+//      still covers the concurrent case while the command runs.
+//
+// The lease is released only in release() (tool.after) or on a terminal block,
+// never after the remote read — releasing early reopens the TOCTOU the lease
+// exists to close. Release is keyed by a per-call token so a late/stale
+// tool.after for a superseded reservation cannot drop a newer session's lease.
 export function createApproveIdempotencyGuard(deps: {
   resolveEffectiveApproval: EffectiveApprovalResolver
-}): ApproveIdempotencyGuard {
-  const pendingApprovals = new Set<string>()
-  const reservedByCall = new Map<string, string>()
+  now?: () => number
+}): ReviewVerdictGuard {
+  const now = deps.now ?? Date.now
 
   return {
     async guard(args): Promise<ApproveBlock | null> {
-      if (args.verdict !== 'APPROVE') return null
+      if (args.verdict !== 'APPROVE' && args.verdict !== 'REQUEST_CHANGES') return null
       const key = prKey(args.workspace, args.prNumber)
 
-      // Reserve BEFORE the await so two calls racing into guard() for the same
-      // PR cannot both observe an empty set: the loser sees the winner's
-      // in-flight reservation and is blocked. The reservation is provisional
-      // and is always cleared on a terminal path (block below or release()).
-      if (pendingApprovals.has(key)) return { block: true, reason: DUPLICATE_REASON }
-      pendingApprovals.add(key)
-      reservedByCall.set(args.callId, key)
+      // Reserve BEFORE the await so two calls racing into guard() for the same PR
+      // cannot both observe an empty map: the loser sees the winner's in-flight
+      // lease and is blocked. An expired lease (tool.after never fired) is
+      // reclaimable so a crash cannot permanently strand the PR.
+      const held = inFlightByPr.get(key)
+      if (held !== undefined && now() - held.createdAt < LEASE_TTL_MS) {
+        return { block: true, reason: CONCURRENT_REASON }
+      }
+      const reservation: Reservation = { key, token: ++tokenSeq, createdAt: now() }
+      inFlightByPr.set(key, reservation)
+      reservationByCall.set(args.callId, reservation)
 
       const remote = await deps.resolveEffectiveApproval({ workspace: args.workspace, prNumber: args.prNumber })
-      if (remote.ok && remote.alreadyApproved) {
-        // Standing approval upstream. Block, and release the in-flight lock now:
-        // a blocked command never reaches tool.after, so release() won't run for
-        // this callId. Leaving the key set would resurrect the strand bug — the
-        // GitHub read is authoritative for the standing-approval case, not a
-        // lingering local entry.
-        reservedByCall.delete(args.callId)
-        pendingApprovals.delete(key)
-        return { block: true, reason: DUPLICATE_REASON }
+      if (remote.ok && duplicatesStanding(args.verdict, remote.effective)) {
+        // Standing verdict upstream already matches. Block, and release the lease
+        // now: a blocked command never reaches tool.after, so release() won't run
+        // for this callId. Leaving the lease set would resurrect the strand bug —
+        // the GitHub read is authoritative for the standing case.
+        releaseReservation(args.callId, reservation)
+        return { block: true, reason: duplicateReason(args.verdict) }
       }
 
       return null
     },
 
     release(args): void {
-      const key = reservedByCall.get(args.callId)
-      if (key === undefined) return
-      reservedByCall.delete(args.callId)
-      // Always drop the in-flight lock, success or fail. On success the standing
-      // approval now lives on GitHub, so future APPROVEs are caught by the remote
-      // read (which tracks supersession); the local lock must not outlive the
-      // in-flight window and shadow that read.
-      pendingApprovals.delete(key)
+      const reservation = reservationByCall.get(args.callId)
+      if (reservation === undefined) return
+      releaseReservation(args.callId, reservation)
     },
+  }
+}
+
+// Drop the lease only if THIS reservation still owns the key. A stale tool.after
+// for a reservation that was already superseded (e.g. reclaimed after TTL by a
+// newer session) must not yank the live session's lease.
+function releaseReservation(callId: string, reservation: Reservation): void {
+  reservationByCall.delete(callId)
+  const current = inFlightByPr.get(reservation.key)
+  if (current !== undefined && current.token === reservation.token) {
+    inFlightByPr.delete(reservation.key)
   }
 }
 
 function prKey(workspace: string, prNumber: number): string {
   return `${workspace}#${prNumber}`
+}
+
+// Test-only: clear the process-wide lease state between cases.
+export function __resetReviewVerdictGuardForTest(): void {
+  inFlightByPr.clear()
+  reservationByCall.clear()
+  tokenSeq = 0
 }

--- a/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
@@ -19,7 +19,7 @@ function fetchStub(routes: Record<string, Response>): typeof fetch {
 }
 
 describe('github effective-approval resolver', () => {
-  test('reports alreadyApproved when the bot has an APPROVED review on the PR', async () => {
+  test('reports APPROVED when the bot has an APPROVED review on the PR', async () => {
     const resolve = createGithubEffectiveApprovalResolver({
       resolveToken: async () => 'tok',
       fetchImpl: fetchStub({
@@ -30,10 +30,10 @@ describe('github effective-approval resolver', () => {
         ]),
       }),
     })
-    expect(await resolve({ workspace: WS, prNumber: 5 })).toEqual({ ok: true, alreadyApproved: true })
+    expect(await resolve({ workspace: WS, prNumber: 5 })).toEqual({ ok: true, effective: 'APPROVED' })
   })
 
-  test('reports not approved when only OTHER users approved', async () => {
+  test('reports NONE when only OTHER users approved', async () => {
     const resolve = createGithubEffectiveApprovalResolver({
       resolveToken: async () => 'tok',
       fetchImpl: fetchStub({
@@ -41,10 +41,10 @@ describe('github effective-approval resolver', () => {
         '/pulls/6/reviews': jsonResponse([{ state: 'APPROVED', user: { login: 'someone-else', type: 'User' } }]),
       }),
     })
-    expect(await resolve({ workspace: WS, prNumber: 6 })).toEqual({ ok: true, alreadyApproved: false })
+    expect(await resolve({ workspace: WS, prNumber: 6 })).toEqual({ ok: true, effective: 'NONE' })
   })
 
-  test('reports not approved when the bot only commented', async () => {
+  test('reports NONE when the bot only commented', async () => {
     const resolve = createGithubEffectiveApprovalResolver({
       resolveToken: async () => 'tok',
       fetchImpl: fetchStub({
@@ -52,10 +52,10 @@ describe('github effective-approval resolver', () => {
         '/pulls/7/reviews': jsonResponse([{ state: 'COMMENTED', user: { login: 'review-bot', type: 'User' } }]),
       }),
     })
-    expect(await resolve({ workspace: WS, prNumber: 7 })).toEqual({ ok: true, alreadyApproved: false })
+    expect(await resolve({ workspace: WS, prNumber: 7 })).toEqual({ ok: true, effective: 'NONE' })
   })
 
-  test('reports not approved when a later bot CHANGES_REQUESTED supersedes an earlier APPROVED', async () => {
+  test('reports CHANGES_REQUESTED when a later bot CHANGES_REQUESTED supersedes an earlier APPROVED', async () => {
     const resolve = createGithubEffectiveApprovalResolver({
       resolveToken: async () => 'tok',
       fetchImpl: fetchStub({
@@ -66,10 +66,10 @@ describe('github effective-approval resolver', () => {
         ]),
       }),
     })
-    expect(await resolve({ workspace: WS, prNumber: 30 })).toEqual({ ok: true, alreadyApproved: false })
+    expect(await resolve({ workspace: WS, prNumber: 30 })).toEqual({ ok: true, effective: 'CHANGES_REQUESTED' })
   })
 
-  test('reports approved when a later bot APPROVED supersedes an earlier CHANGES_REQUESTED', async () => {
+  test('reports APPROVED when a later bot APPROVED supersedes an earlier CHANGES_REQUESTED', async () => {
     const resolve = createGithubEffectiveApprovalResolver({
       resolveToken: async () => 'tok',
       fetchImpl: fetchStub({
@@ -80,7 +80,7 @@ describe('github effective-approval resolver', () => {
         ]),
       }),
     })
-    expect(await resolve({ workspace: WS, prNumber: 31 })).toEqual({ ok: true, alreadyApproved: true })
+    expect(await resolve({ workspace: WS, prNumber: 31 })).toEqual({ ok: true, effective: 'APPROVED' })
   })
 
   test('a later bot COMMENTED does not clear an earlier bot APPROVED', async () => {
@@ -94,7 +94,7 @@ describe('github effective-approval resolver', () => {
         ]),
       }),
     })
-    expect(await resolve({ workspace: WS, prNumber: 32 })).toEqual({ ok: true, alreadyApproved: true })
+    expect(await resolve({ workspace: WS, prNumber: 32 })).toEqual({ ok: true, effective: 'APPROVED' })
   })
 
   test('matches a GitHub App bot whose reviews login carries the [bot] suffix', async () => {
@@ -105,7 +105,7 @@ describe('github effective-approval resolver', () => {
         '/pulls/8/reviews': jsonResponse([{ state: 'APPROVED', user: { login: 'review-bot[bot]', type: 'Bot' } }]),
       }),
     })
-    expect(await resolve({ workspace: WS, prNumber: 8 })).toEqual({ ok: true, alreadyApproved: true })
+    expect(await resolve({ workspace: WS, prNumber: 8 })).toEqual({ ok: true, effective: 'APPROVED' })
   })
 
   test('fails (ok:false) when the reviews fetch errors so the guard can fail open', async () => {

--- a/src/bundled-plugins/github-cli-auth/effective-approval.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.ts
@@ -1,13 +1,12 @@
 import { GITHUB_API_BASE, githubJsonHeaders } from '@/channels/adapters/github/auth-pat'
 
-import type { EffectiveApprovalResolver } from './approve-idempotency'
+import type { EffectiveApprovalResolver, EffectiveVerdict } from './approve-idempotency'
 
-// Resolves whether THIS bot already has a standing APPROVED review on a PR, used
-// by the approve-idempotency guard to stop a second formal APPROVE after a
-// restart (the in-process pending set covers the same-container case but is lost
-// when the container bounces). Every failure returns { ok: false } so the guard
-// fails open — a transient read error must never permanently block a genuine
-// first approval.
+// Resolves THIS bot's standing decisive review on a PR, used by the review
+// verdict guard to stop a second formal verdict after a restart (the in-process
+// lease covers the same-container case but is lost when the container bounces).
+// Every failure returns { ok: false } so the guard fails open — a transient read
+// error must never permanently block a genuine first verdict.
 export function createGithubEffectiveApprovalResolver(deps: {
   resolveToken: (workspace: string) => Promise<string | null>
   fetchImpl?: typeof fetch
@@ -27,8 +26,14 @@ export function createGithubEffectiveApprovalResolver(deps: {
     if (reviews === null) return { ok: false }
 
     const lastDecisive = reviews.filter((r) => isSelf(r.login, r.isBot, self) && isDecisive(r.state)).at(-1)
-    return { ok: true, alreadyApproved: lastDecisive?.state === 'APPROVED' }
+    return { ok: true, effective: toEffective(lastDecisive?.state) }
   }
+}
+
+function toEffective(state: string | undefined): EffectiveVerdict {
+  if (state === 'APPROVED') return 'APPROVED'
+  if (state === 'CHANGES_REQUESTED') return 'CHANGES_REQUESTED'
+  return 'NONE'
 }
 
 // A bot's effective review is its LATEST decisive one. COMMENTED/PENDING are

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -11,7 +11,7 @@ import { classifyGhToken } from './token-class'
 export default definePlugin({
   plugin: async (ctx) => {
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
-    const approveGuard = createApproveIdempotencyGuard({
+    const verdictGuard = createApproveIdempotencyGuard({
       resolveEffectiveApproval: createGithubEffectiveApprovalResolver({
         resolveToken: async (workspace) => {
           const result = await resolveTokenForRepo(workspace)
@@ -28,7 +28,7 @@ export default definePlugin({
 
           const review = await noteReviewCommand({ callId: event.callId, command })
           if (review.detected !== null) {
-            const block = await approveGuard.guard({
+            const block = await verdictGuard.guard({
               callId: event.callId,
               workspace: review.detected.workspace,
               prNumber: review.detected.prNumber,
@@ -70,7 +70,7 @@ export default definePlugin({
             callId: event.callId,
             result: event.result,
           })
-          approveGuard.release({ callId: event.callId, succeeded: committed })
+          verdictGuard.release({ callId: event.callId, succeeded: committed })
         },
       },
     }


### PR DESCRIPTION
## Problem

The bot posted **three duplicate `APPROVED` reviews** on the same PR within ten seconds (observed on #680: review IDs at 16:49:34, :38, :44, all by `typeey[bot]`, each with different body text). The recently-added approve-idempotency guard did not block the 2nd and 3rd.

### Root cause

A PR can fan out into several near-simultaneous `AgentSession`s (webhook + reconcile-open-prs + review-thread recheck). The `approve-idempotency` guard held its in-flight reservation in a `Set` **captured by the plugin-factory closure**. Because `github-cli-auth` is instantiated per session, each concurrent session got its **own** `Set` and could not see the others' in-flight verdict.

So all three sessions:

1. were correctly blocked from posting a prose close-out while holding `CHANGES_REQUESTED`, so each reacted by submitting a formal `APPROVE`;
2. read the GitHub reviews list **before any of the three approves were visible upstream** — a classic read-before-write TOCTOU — each seeing `alreadyApproved=false`;
3. landed a distinct `APPROVED` review.

The remote read can never close a same-instant race: the competing writes aren't visible yet. Only a process-wide in-flight lease can.

## Fix

- **Module-level singleton lease.** Move the reservation maps out of the plugin-factory closure to module scope, so every plugin instance in the process coordinates through one map. This is the missing layer.
- **Hold the lease across the command.** Reserve in `tool.before`, release only in `tool.after` (or on a terminal block) — never after the remote read. A second session is blocked while the first `gh` command is mid-flight, regardless of GitHub visibility.
- **Symmetric for both verdicts.** Generalize from `APPROVE`-only to formal verdicts. A duplicate `REQUEST_CHANGES` posts a redundant *blocking* review just like a duplicate approve, so the guard now covers both. The effective-state resolver returns the standing decisive verdict (`APPROVED` / `CHANGES_REQUESTED` / `NONE`) instead of a bare `alreadyApproved` boolean.
- **Crash safety.** A 5-minute TTL lets a crashed `tool.after` be reclaimed so a PR is never stranded forever; release is keyed by a per-call token so a stale/late `tool.after` cannot drop a newer session's lease.
- **Fail-open preserved.** A transient GitHub read error never blocks a genuine first verdict; the in-flight lease still covers the concurrent case.

## Tests

`approve-idempotency.test.ts` (now 19 cases) adds:
- two **separate plugin instances** share the in-flight lease (the regression that let three sessions each approve)
- `REQUEST_CHANGES` symmetry (standing-duplicate block + concurrent block)
- TTL reclamation of an abandoned lease, and non-reclaim before TTL
- a stale `tool.after` for a reclaimed reservation does not drop the live lease
- a concurrent verdict still blocks even when the remote read fails open

`effective-approval.test.ts` updated to assert the `effective` verdict shape (incl. a `CHANGES_REQUESTED` supersession case).

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, unrelated files)
- `bun run format:check` — clean
- `bun run test` — 7686 pass, 0 fail

## Out of scope (follow-up)

A related symptom on #679 — the bot posted a plain close-out comment while holding `CHANGES_REQUESTED` and never converted it into a formal verdict, leaving the PR stranded — is a **decision/policy** concern (ensuring the agent *chooses* to submit a verdict), not a duplication race. This PR serializes the verdict path so exactly one lands; forcing one to be attempted belongs in the re-review/channel-reply guard and is left for a separate change.