### PR TITLE
fix(channels): re-review a held CHANGES_REQUESTED on PR synchronize

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -1581,6 +1581,7 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(msg.text).toContain('deadbee')
     expect(msg.text).toContain('100, 200')
     expect(msg.externalMessageId).toBe('pr-7-recheck-deadbeef999')
+    expect(msg.text).toContain('end your turn without replying')
   })
 
   it('does not route a self-authored synchronize (bot pushed its own PR)', async () => {
@@ -1666,6 +1667,10 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(msg.text).toContain('CHANGES_REQUESTED')
     expect(msg.text).toContain('beef111')
     expect(msg.externalMessageId).toBe('pr-7-recheck-beef111')
+    // A held block never self-clears, so the inbound must demand a fresh verdict
+    // and must NOT offer the silent-exit escape hatch that would strand the block.
+    expect(msg.text).toContain('always end with a new verdict')
+    expect(msg.text).not.toContain('end your turn without replying')
   })
 
   it('does not route when the latest self review is APPROVED and no threads remain', async () => {
@@ -1704,6 +1709,7 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(routed).toHaveLength(1)
     expect(routed[0]!.text).toContain('100')
     expect(routed[0]!.text).toContain('CHANGES_REQUESTED')
+    expect(routed[0]!.text).not.toContain('end your turn without replying')
   })
 
   it('skips the CHANGES_REQUESTED re-review when review.on is off', async () => {

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -1443,37 +1443,57 @@ function fakeFetch(fn: (input: string, init?: RequestInit) => Response): typeof 
 
 describe('createGithubWebhookHandler — pull_request.synchronize recheck', () => {
   type ThreadNode = { id: string; isResolved: boolean; rootCommentId: number; login: string; isBot?: boolean }
+  type SelfReviewRow = { state: string; login?: string; type?: string }
 
-  function threadsFetch(threads: ThreadNode[]): typeof fetch {
-    return fakeFetch(
-      () =>
-        new Response(
-          JSON.stringify({
-            data: {
-              repository: {
-                pullRequest: {
-                  reviewThreads: {
-                    pageInfo: { hasNextPage: false, endCursor: null },
-                    nodes: threads.map((t) => ({
-                      id: t.id,
-                      isResolved: t.isResolved,
-                      comments: {
-                        nodes: [
-                          {
-                            databaseId: t.rootCommentId,
-                            author: { __typename: t.isBot === false ? 'User' : 'Bot', login: t.login },
-                          },
-                        ],
+  function threadsResponse(threads: ThreadNode[]): Response {
+    return new Response(
+      JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: threads.map((t) => ({
+                  id: t.id,
+                  isResolved: t.isResolved,
+                  comments: {
+                    nodes: [
+                      {
+                        databaseId: t.rootCommentId,
+                        author: { __typename: t.isBot === false ? 'User' : 'Bot', login: t.login },
                       },
-                    })),
+                    ],
                   },
-                },
+                })),
               },
             },
-          }),
-          { status: 200 },
-        ),
+          },
+        },
+      }),
+      { status: 200 },
     )
+  }
+
+  function reviewsResponse(reviews: SelfReviewRow[]): Response {
+    return new Response(
+      JSON.stringify(
+        reviews.map((r) => ({ state: r.state, user: { login: r.login ?? 'typeclaw-bot', type: r.type ?? 'Bot' } })),
+      ),
+      { status: 200 },
+    )
+  }
+
+  // The followup mints one GraphQL call (unresolved threads) and one REST call
+  // (latest self review state). Route by URL so each query gets its own fixture.
+  function followupFetch(input: { threads?: ThreadNode[]; reviews?: SelfReviewRow[] }): typeof fetch {
+    return fakeFetch((url) => {
+      if (url.includes('/pulls/') && url.includes('/reviews')) return reviewsResponse(input.reviews ?? [])
+      return threadsResponse(input.threads ?? [])
+    })
+  }
+
+  function threadsFetch(threads: ThreadNode[]): typeof fetch {
+    return followupFetch({ threads })
   }
 
   function recheckHandler(input: {
@@ -1625,6 +1645,195 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
 
     expect(routed).toHaveLength(0)
     expect(warns.some((w) => w.includes('review-thread recheck failed'))).toBe(true)
+  })
+
+  it('re-reviews a held CHANGES_REQUESTED even with no unresolved threads', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = recheckHandler({
+      fetchImpl: followupFetch({ threads: [], reviews: [{ state: 'CHANGES_REQUESTED' }] }),
+      routed,
+      tasks,
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload('beef111')), 'pull_request', 'sync-cr'))
+    await tasks[0]?.()
+
+    expect(routed).toHaveLength(1)
+    const msg = routed[0]!
+    expect(msg.chat).toBe('pr:7')
+    expect(msg.isBotMention).toBe(true)
+    expect(msg.text).toContain('CHANGES_REQUESTED')
+    expect(msg.text).toContain('beef111')
+    expect(msg.externalMessageId).toBe('pr-7-recheck-beef111')
+  })
+
+  it('does not route when the latest self review is APPROVED and no threads remain', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = recheckHandler({
+      fetchImpl: followupFetch({
+        threads: [],
+        reviews: [{ state: 'CHANGES_REQUESTED' }, { state: 'APPROVED' }],
+      }),
+      routed,
+      tasks,
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-approved'))
+    await tasks[0]?.()
+
+    expect(routed).toHaveLength(0)
+  })
+
+  it('combines unresolved threads and a held CHANGES_REQUESTED into one inbound', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = recheckHandler({
+      fetchImpl: followupFetch({
+        threads: [{ id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' }],
+        reviews: [{ state: 'CHANGES_REQUESTED' }],
+      }),
+      routed,
+      tasks,
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-both'))
+    await tasks[0]?.()
+
+    expect(routed).toHaveLength(1)
+    expect(routed[0]!.text).toContain('100')
+    expect(routed[0]!.text).toContain('CHANGES_REQUESTED')
+  })
+
+  it('skips the CHANGES_REQUESTED re-review when review.on is off', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['pull_request.synchronize'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot[bot]',
+      authType: () => 'app',
+      reviewOn: () => 'off',
+      authToken: async () => 'tok',
+      fetchImpl: followupFetch({ threads: [], reviews: [{ state: 'CHANGES_REQUESTED' }] }),
+      scheduleBackgroundTask: (task) => {
+        tasks.push(task)
+      },
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-off'))
+    await tasks[0]?.()
+
+    expect(routed).toHaveLength(0)
+  })
+
+  it('dedups two deliveries with the same head sha to one followup', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const dedup = createDeliveryDedup()
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup,
+      allowlist: () => ['pull_request.synchronize'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot[bot]',
+      authType: () => 'app',
+      authToken: async () => 'tok',
+      fetchImpl: followupFetch({ reviews: [{ state: 'CHANGES_REQUESTED' }] }),
+      scheduleBackgroundTask: (task) => {
+        tasks.push(task)
+      },
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    const body = JSON.stringify(synchronizePayload('samesha777'))
+    await handler(signedRequest(body, 'pull_request', 'sync-sha-1'))
+    await handler(signedRequest(body, 'pull_request', 'sync-sha-2'))
+
+    expect(tasks).toHaveLength(1)
+    await tasks[0]?.()
+    expect(routed).toHaveLength(1)
+  })
+
+  it('runs the followup again for a new head sha', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const dedup = createDeliveryDedup()
+    const handler = createGithubWebhookHandler({
+      webhookSecret: 'secret',
+      dedup,
+      allowlist: () => ['pull_request.synchronize'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot[bot]',
+      authType: () => 'app',
+      authToken: async () => 'tok',
+      fetchImpl: followupFetch({ reviews: [{ state: 'CHANGES_REQUESTED' }] }),
+      scheduleBackgroundTask: (task) => {
+        tasks.push(task)
+      },
+      logger,
+      route: (msg) => {
+        routed.push(msg)
+      },
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload('sha-aaa')), 'pull_request', 'sync-new-1'))
+    await handler(signedRequest(JSON.stringify(synchronizePayload('sha-bbb')), 'pull_request', 'sync-new-2'))
+
+    expect(tasks).toHaveLength(2)
+  })
+
+  it('skips the followup when the synchronize carries no head sha', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const warns: string[] = []
+    const payload = synchronizePayload()
+    const pr = payload.pull_request as Record<string, unknown>
+    pr.head = { ref: 'feature' }
+    const handler = recheckHandler({
+      fetchImpl: followupFetch({ reviews: [{ state: 'CHANGES_REQUESTED' }] }),
+      routed,
+      tasks,
+      warns,
+    })
+
+    await handler(signedRequest(JSON.stringify(payload), 'pull_request', 'sync-no-sha'))
+
+    expect(tasks).toHaveLength(0)
+    expect(routed).toHaveLength(0)
+    expect(warns.some((w) => w.includes('no head sha'))).toBe(true)
+  })
+
+  it('still routes threads when the review-state lookup fails', async () => {
+    const routed: InboundMessage[] = []
+    const tasks: Array<() => Promise<void>> = []
+    const warns: string[] = []
+    const handler = recheckHandler({
+      fetchImpl: fakeFetch((url) => {
+        if (url.includes('/reviews')) return new Response('boom', { status: 500 })
+        return threadsResponse([{ id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' }])
+      }),
+      routed,
+      tasks,
+      warns,
+    })
+
+    await handler(signedRequest(JSON.stringify(synchronizePayload()), 'pull_request', 'sync-state-fail'))
+    await tasks[0]?.()
+
+    expect(routed).toHaveLength(1)
+    expect(routed[0]!.text).toContain('100')
+    expect(warns.some((w) => w.includes('review-state recheck failed'))).toBe(true)
   })
 })
 

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -9,6 +9,7 @@ import { removeRequestedReviewer } from './decoy-reviewer'
 import type { DeliveryDedup } from './dedup'
 import { isGithubEventAllowed } from './event-allowlist'
 import { encodeGithubReactionRef, type GithubReactionTarget } from './reactions'
+import { fetchSelfReviewBlocking } from './review-state'
 import { listUnresolvedSelfReviewThreads } from './review-thread-resolver'
 
 export type GithubInboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
@@ -83,14 +84,16 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     }
 
     // A push to an open PR (`synchronize`) is not a message to react to — it is
-    // a trigger to re-check whether the new commits addressed the bot's own
-    // still-open review threads. The check needs a GraphQL round-trip, so it
-    // runs OFF the ACK path (like the decoy-reviewer drop) and only wakes a
-    // session when there is at least one such thread. Returning here also keeps
+    // a trigger to re-evaluate the bot's own outstanding review obligations on
+    // this PR: unresolved review threads it authored AND a sticky
+    // CHANGES_REQUESTED block (which leaves no threads when filed as a top-level
+    // verdict — the black hole this path closes). Both need an API round-trip,
+    // so it runs OFF the ACK path (like the decoy-reviewer drop) and only wakes a
+    // session when an obligation is outstanding. Returning here also keeps
     // synchronize out of the generic awareness-only fallthrough below.
     if (event === 'pull_request' && action === 'synchronize') {
       if (delivery !== '') options.dedup.add(delivery)
-      scheduleReviewThreadRecheck({ payload, selfLogin, options })
+      scheduleReviewFollowup({ payload, selfLogin, options })
       return ok()
     }
 
@@ -187,7 +190,7 @@ function defaultScheduleBackgroundTask(task: () => Promise<void>): void {
   void task().catch(() => {})
 }
 
-function scheduleReviewThreadRecheck(input: {
+function scheduleReviewFollowup(input: {
   payload: Record<string, unknown>
   selfLogin: string | null
   options: GithubWebhookHandlerOptions
@@ -203,13 +206,27 @@ function scheduleReviewThreadRecheck(input: {
   if (repository === null || pullNumber === null) return
   const headSha = readString(readRecord(pr?.head), 'sha')
 
+  // Same webhook head SHA can arrive on several deliveries (a multi-commit push
+  // emits one synchronize per ref update). Dedup the follow-up on the head SHA
+  // so a single push wakes at most one re-review, distinct from the per-delivery
+  // dedup above. When headSha is absent we cannot dedup, so we skip the followup
+  // rather than risk a re-review storm.
+  if (headSha === null) {
+    options.logger.warn(`[github] synchronize for ${repository.owner}/${repository.name}#${pullNumber} has no head sha`)
+    return
+  }
+  const followupKey = `synchronize-followup:${repository.owner}/${repository.name}#${pullNumber}:${headSha}`
+  if (options.dedup.has(followupKey)) return
+  options.dedup.add(followupKey)
+
+  const reviewOn = options.reviewOn?.() ?? 'review_requested'
   const fetchImpl = options.fetchImpl ?? fetch
   const schedule = options.scheduleBackgroundTask ?? defaultScheduleBackgroundTask
   const target = `${repository.owner}/${repository.name}#${pullNumber}`
   schedule(async () => {
     try {
       const token = await authToken({ repoSlug: `${repository.owner}/${repository.name}` })
-      const result = await listUnresolvedSelfReviewThreads({
+      const threads = await listUnresolvedSelfReviewThreads({
         token,
         selfLogin,
         owner: repository.owner,
@@ -217,46 +234,63 @@ function scheduleReviewThreadRecheck(input: {
         prNumber: pullNumber,
         fetchImpl,
       })
-      if (!result.ok) {
-        options.logger.warn(`[github] review-thread recheck failed for ${target}: ${result.error}`)
+      if (!threads.ok) {
+        options.logger.warn(`[github] review-thread recheck failed for ${target}: ${threads.error}`)
         return
       }
-      if (result.threads.length === 0) return
+
+      // A held CHANGES_REQUESTED is the bot's own obligation regardless of how
+      // reviews are triggered, so re-evaluate it on push unless review is off.
+      let selfBlocking = false
+      if (reviewOn !== 'off') {
+        const blocking = await fetchSelfReviewBlocking({
+          token,
+          selfLogin,
+          owner: repository.owner,
+          repo: repository.name,
+          prNumber: pullNumber,
+          fetchImpl,
+        })
+        if (blocking.ok) selfBlocking = blocking.selfBlocking
+        else options.logger.warn(`[github] review-state recheck failed for ${target}: ${blocking.error}`)
+      }
+
+      const rootCommentIds = threads.threads.map((t) => t.rootCommentId)
+      if (rootCommentIds.length === 0 && !selfBlocking) return
       options.route(
-        buildRecheckInbound({
-          repository,
-          pullNumber,
-          headSha,
-          rootCommentIds: result.threads.map((t) => t.rootCommentId),
-          title: readString(pr, 'title'),
-        }),
+        withApprovalPolicy(
+          buildReviewFollowupInbound({
+            repository,
+            pullNumber,
+            headSha,
+            rootCommentIds,
+            selfBlocking,
+            title: readString(pr, 'title'),
+          }),
+          options.allowApprove?.() ?? true,
+        ),
       )
     } catch (err) {
       options.logger.warn(
-        `[github] review-thread recheck failed for ${target}: ${err instanceof Error ? err.message : String(err)}`,
+        `[github] review followup failed for ${target}: ${err instanceof Error ? err.message : String(err)}`,
       )
     }
   })
 }
 
-function buildRecheckInbound(input: {
+function buildReviewFollowupInbound(input: {
   repository: { owner: string; name: string }
   pullNumber: number
-  headSha: string | null
+  headSha: string
   rootCommentIds: readonly number[]
+  selfBlocking: boolean
   title: string | null
 }): InboundMessage {
-  const { repository, pullNumber, headSha, rootCommentIds, title } = input
+  const { repository, pullNumber, headSha, rootCommentIds, selfBlocking, title } = input
   const titleSegment = title !== null && title.trim() !== '' ? `: "${title}"` : ''
-  const shaSegment = headSha !== null ? ` (now at ${headSha.slice(0, 7)})` : ''
-  const idList = rootCommentIds.join(', ')
   const text =
-    `PR #${pullNumber}${titleSegment} received new commits${shaSegment}. ` +
-    `You have ${rootCommentIds.length} unresolved review thread(s) you authored on this PR ` +
-    `(root comment id(s): ${idList}). For each, check whether the new commits addressed your ` +
-    `concern. If addressed, reply on that thread via channel_send with a short acknowledgement ` +
-    `and resolve_review_thread: true (the thread id is the root comment id). If not addressed, ` +
-    `leave it open. If none are addressed, end your turn without replying.`
+    `PR #${pullNumber}${titleSegment} received new commits (now at ${headSha.slice(0, 7)}). ` +
+    followupInstruction(rootCommentIds, selfBlocking)
 
   return {
     adapter: 'github',
@@ -264,7 +298,7 @@ function buildRecheckInbound(input: {
     chat: `pr:${pullNumber}`,
     thread: null,
     text,
-    externalMessageId: `pr-${pullNumber}-recheck-${headSha ?? 'unknown'}`,
+    externalMessageId: `pr-${pullNumber}-recheck-${headSha}`,
     authorId: 'github-system',
     authorName: 'github',
     authorIsBot: false,
@@ -275,6 +309,28 @@ function buildRecheckInbound(input: {
     isDm: false,
     ts: 0,
   }
+}
+
+function followupInstruction(rootCommentIds: readonly number[], selfBlocking: boolean): string {
+  const threadPart =
+    rootCommentIds.length > 0
+      ? `You have ${rootCommentIds.length} unresolved review thread(s) you authored on this PR ` +
+        `(root comment id(s): ${rootCommentIds.join(', ')}). For each, check whether the new commits ` +
+        `addressed your concern. If addressed, reply on that thread via channel_send with a short ` +
+        `acknowledgement and resolve_review_thread: true (the thread id is the root comment id); ` +
+        `if not, leave it open. `
+      : ''
+  const blockingPart = selfBlocking
+    ? `Your latest review on this PR is still CHANGES_REQUESTED. Re-review the current head against the ` +
+      `concerns from that blocking review. If the new commits resolve them, submit a fresh review that ` +
+      `clears the block (APPROVE when appropriate, or COMMENT if approval is disabled). If concerns ` +
+      `remain, submit a new CHANGES_REQUESTED review explaining what is still blocking. `
+    : ''
+  const tail =
+    rootCommentIds.length > 0 && !selfBlocking
+      ? 'If none are addressed, end your turn without replying.'
+      : 'If nothing needs changing, end your turn without replying.'
+  return `${threadPart}${blockingPart}${tail}`
 }
 
 export async function verifySignature(body: string, secret: string, sigHeader: string): Promise<boolean> {

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -320,16 +320,18 @@ function followupInstruction(rootCommentIds: readonly number[], selfBlocking: bo
         `acknowledgement and resolve_review_thread: true (the thread id is the root comment id); ` +
         `if not, leave it open. `
       : ''
+  // A held CHANGES_REQUESTED never clears itself: GitHub keeps the block until a
+  // fresh APPROVE/COMMENT/dismiss, so a blocking follow-up must always end with a
+  // submitted verdict — the "end without replying" escape hatch is reserved for
+  // the thread-only path, where leaving every thread open is a valid no-op.
   const blockingPart = selfBlocking
-    ? `Your latest review on this PR is still CHANGES_REQUESTED. Re-review the current head against the ` +
-      `concerns from that blocking review. If the new commits resolve them, submit a fresh review that ` +
-      `clears the block (APPROVE when appropriate, or COMMENT if approval is disabled). If concerns ` +
-      `remain, submit a new CHANGES_REQUESTED review explaining what is still blocking. `
+    ? `Your latest review on this PR is still CHANGES_REQUESTED, which keeps the PR blocked until you ` +
+      `submit a fresh review. Re-review the current head against the concerns from that blocking review ` +
+      `and always end with a new verdict: if the commits resolve your concerns, submit an APPROVE ` +
+      `(or COMMENT if approval is disabled) to clear the block; if concerns remain, submit a new ` +
+      `CHANGES_REQUESTED explaining what is still blocking. `
     : ''
-  const tail =
-    rootCommentIds.length > 0 && !selfBlocking
-      ? 'If none are addressed, end your turn without replying.'
-      : 'If nothing needs changing, end your turn without replying.'
+  const tail = selfBlocking ? '' : 'If none are addressed, end your turn without replying.'
   return `${threadPart}${blockingPart}${tail}`
 }
 

--- a/src/channels/adapters/github/review-state.ts
+++ b/src/channels/adapters/github/review-state.ts
@@ -48,6 +48,33 @@ export function createGithubReviewStateResolver(deps: {
   }
 }
 
+export type SelfReviewBlockingResult =
+  | { ok: true; selfBlocking: boolean }
+  | { ok: false; error: string; code: 'not-found' | 'permission-denied' | 'transient' }
+
+// Last DECISIVE self review == CHANGES_REQUESTED? (COMMENTED/PENDING ignored, as
+// in createGithubReviewStateResolver.) Standalone so the synchronize follow-up
+// skips the reviewDecision round-trip the stranding guard needs but this doesn't.
+export async function fetchSelfReviewBlocking(deps: {
+  token: string
+  selfLogin: string
+  owner: string
+  repo: string
+  prNumber: number
+  fetchImpl?: typeof fetch
+}): Promise<SelfReviewBlockingResult> {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const reviews = await fetchSelfReviews(
+    fetchImpl,
+    deps.token,
+    { owner: deps.owner, repo: deps.repo, prNumber: deps.prNumber },
+    deps.selfLogin,
+  )
+  if (!reviews.ok) return { ok: false, error: reviews.error, code: reviews.code }
+  const lastDecisive = reviews.states.filter(isDecisive).at(-1) ?? null
+  return { ok: true, selfBlocking: lastDecisive === 'CHANGES_REQUESTED' }
+}
+
 type Target = { owner: string; repo: string; prNumber: number }
 
 function parseTarget(workspace: string, chat: string): Target | null {


### PR DESCRIPTION
## Background

A reviewer agent (typeey) blocked PR #679 with a `CHANGES_REQUESTED` review, the author pushed a fix commit, and the bot **never re-reviewed** — the PR sat blocked while the addressing commit went unreviewed. The bot only later replied to a manual "Addressed in `<sha>`" comment; it never submitted a fresh verdict.

Root cause: the `pull_request.synchronize` handler (`src/channels/adapters/github/inbound.ts`) routes a push **exclusively** to a review-*thread* recheck. It calls `listUnresolvedSelfReviewThreads()` and bails on `threads.length === 0`. typeey's block was filed as a **top-level `CHANGES_REQUESTED` verdict with zero inline comments** (confirmed via GraphQL: `reviewThreads: []`, `inline_comments: 0`). So the recheck found nothing, returned early, and the sticky block was never re-evaluated. A blocking review with no inline threads was a black hole: GitHub clears a same-reviewer `CHANGES_REQUESTED` only on a later `APPROVED`/`DISMISSED`, and new commits don't auto-dismiss it — so the PR stays blocked forever.

## Summary

Broaden the synchronize follow-up to also re-evaluate the bot's **own latest formal review state**, not just its open threads. If the last decisive self review is `CHANGES_REQUESTED`, wake a session to re-review the new head even when no threads remain.

- **Detection reuses existing logic.** New `fetchSelfReviewBlocking` in `review-state.ts` wraps the same chronological self-review walk the re-review stranding guard already uses (last DECISIVE state wins; `COMMENTED`/`PENDING` ignored). Standalone so it skips the `reviewDecision` GraphQL round-trip it doesn't need.
- **Why fire regardless of `review.on`.** A held block is the bot's own outstanding obligation, independent of how reviews are triggered — so it re-evaluates on every push *unless* `review.on: 'off'`. Normal review triggers (`review_requested`/`opened`) are untouched.
- **One combined inbound.** Unresolved threads + a held block produce a single synthetic inbound (thread instructions + re-review instructions), routed through `withApprovalPolicy` like every other review trigger so `approve: false` still downgrades to `COMMENT`.
- **Per-head-SHA dedup.** A multi-commit push emits one `synchronize` per ref update; the follow-up dedups on `owner/repo#pr:headSha` (distinct from the per-delivery dedup) so one push wakes at most one re-review. A new SHA re-arms it.

## What this does NOT do

- Does not change normal review triggers (`review_requested`, `opened`, `ready_for_review`).
- Does not re-review when the latest self review is `APPROVED`/`COMMENTED`/`DISMISSED` and no threads remain.
- Does not fire when `review.on: 'off'`, or when the bot itself pushed the commits (the self-author drop still runs first), or when the `synchronize` carries no head SHA (skips closed rather than risk a re-review storm).

## Review notes

- Load-bearing change: `scheduleReviewFollowup` in `src/channels/adapters/github/inbound.ts` (renamed from `scheduleReviewThreadRecheck`). Verify the early-return invariant: route iff `rootCommentIds.length > 0 || selfBlocking`.
- A failed review-state lookup is non-fatal: threads still route, with a `review-state recheck failed` warning. Covered by a test.
- `externalMessageId` stays `pr-${n}-recheck-${headSha}` (head SHA is now required, so no `unknown` fallback).
- 8 new tests cover: no-thread `CHANGES_REQUESTED` re-review, `APPROVED` no-op, combined thread+block, `review.on: off`, same-SHA dedup, new-SHA re-arm, missing-SHA skip, and review-state-failure fallthrough.