### PR TITLE
fix(channels): raise output budget on empty-turn length retry

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -15,6 +15,7 @@ import type { HookBus, SessionIdleEvent } from '@/plugin'
 
 import { channelsSessionsPath, loadChannelSessions, saveChannelSessions } from './persistence'
 import {
+  CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS,
   CHANNEL_MAX_OUTPUT_TOKENS,
   createChannelRouter,
   DUPLICATE_SEND_ERROR,
@@ -146,6 +147,14 @@ class FakeSession {
 
 async function tempDir(): Promise<string> {
   return await mkdtemp(join(tmpdir(), 'channels-router-'))
+}
+
+async function streamOnce(session: FakeSession): Promise<void> {
+  await session.agent.streamFn(
+    {} as Parameters<StreamFn>[0],
+    { systemPrompt: '', messages: [], tools: [] } as Parameters<StreamFn>[1],
+    undefined as Parameters<StreamFn>[2],
+  )
 }
 
 function assistantMessage(text: string): AssistantMessage {
@@ -3119,6 +3128,76 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
     expect(logs.some((m) => m.includes(`empty_turn_retry attempt=${MAX_EMPTY_TURN_RETRIES}`))).toBe(true)
     expect(logs.some((m) => m.includes('empty_turn_fallback cause=retries_exhausted'))).toBe(true)
+  })
+
+  test('empty-turn guard: a length-truncated retry raises the output-token budget for the re-prompt', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ambiguous thing' }))
+    const budgetsPerPrompt: Array<number | undefined> = []
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      // Simulate the real session streaming under the installed output cap:
+      // every prompt makes a stream call whose maxTokens the cap fills in.
+      await streamOnce(sessions[0]!)
+      budgetsPerPrompt.push(sessions[0]!.lastStreamMaxTokens)
+      if (attempt === 1) {
+        // First turn burns its budget reasoning and truncates with no prose.
+        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'length')
+        return
+      }
+      // The raised-budget retry lets the model finish and reply.
+      sessions[0]!.setAssistantText('SENT')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here is your answer' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    // Original turn uses the default backstop; the length-retry re-prompt uses
+    // the raised budget so genuine reasoning has room to finish.
+    expect(budgetsPerPrompt[0]).toBe(CHANNEL_MAX_OUTPUT_TOKENS)
+    expect(budgetsPerPrompt[1]).toBe(CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS)
+    expect(sent.map((s) => s.text)).toEqual(['here is your answer'])
+    expect(sent.some((s) => s.text === EMPTY_TURN_FALLBACK_TEXT)).toBe(false)
+  })
+
+  test('empty-turn guard: the raised retry budget does not leak into the next fresh user turn', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: 'ambiguous thing' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      await streamOnce(sessions[0]!)
+      if (attempt < 1 + MAX_EMPTY_TURN_RETRIES) {
+        sessions[0]!.setAssistantMidTurn('thought-loop output', 'length')
+        return
+      }
+      // Final retry also truncates → fallback; budget stays raised this turn.
+      sessions[0]!.setAssistantMidTurn('thought-loop output', 'length')
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions[0]!.lastStreamMaxTokens).toBe(CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS)
+
+    // A brand-new user turn must reset back to the default backstop.
+    sessions[0]!.onPrompt = async () => {
+      await streamOnce(sessions[0]!)
+      sessions[0]!.setAssistantText('ok')
+    }
+    await router.route(inbound({ text: 'fresh question' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions[0]!.lastStreamMaxTokens).toBe(CHANNEL_MAX_OUTPUT_TOKENS)
   })
 
   test('empty-turn guard: a turn that thrashed the send path skips retry and posts the fallback once', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3200,6 +3200,30 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sessions[0]!.lastStreamMaxTokens).toBe(CHANNEL_MAX_OUTPUT_TOKENS)
   })
 
+  for (const stop of ['error', 'aborted'] as const) {
+    test(`empty-turn guard: a '${stop}' truncation retries under the DEFAULT cap, not the raised budget`, async () => {
+      const dir = await tempDir()
+      const logs: string[] = []
+      const { router, sessions } = makeRouter(dir, { logs })
+      router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+      await router.route(inbound({ text: 'ambiguous thing' }))
+      const budgetsPerPrompt: Array<number | undefined> = []
+      sessions[0]!.onPrompt = async () => {
+        await streamOnce(sessions[0]!)
+        budgetsPerPrompt.push(sessions[0]!.lastStreamMaxTokens)
+        // error/aborted are not budget exhaustion, so the raised reasoning
+        // budget is unjustified — the retry must stay on the default backstop.
+        sessions[0]!.setAssistantMidTurn('truncated output', stop)
+      }
+      await router.__testing!.flushDebounce(KEY)
+
+      expect(budgetsPerPrompt.every((b) => b === CHANNEL_MAX_OUTPUT_TOKENS)).toBe(true)
+      expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(true)
+      expect(logs.some((m) => m.includes(`max_tokens=${CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS}`))).toBe(false)
+    })
+  }
+
   test('empty-turn guard: a turn that thrashed the send path skips retry and posts the fallback once', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3074,14 +3074,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
       if (!attemptedSendThisTurn && live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
         live.emptyTurnRetries++
+        // Raise the re-prompt's budget ONLY for a `length` truncation: that is
+        // the budget-exhaustion case (reasoning ate the whole pool before any
+        // prose), so the retry needs room to finish thinking AND reply. `error`
+        // and `aborted` are not budget exhaustion — an upstream failure or the
+        // terminal-reply abort — so they retry under the default backstop.
+        // Consumed one-shot by installChannelOutputCap on the next prompt().
+        if (assistantLeafStopReason(live.session) === 'length') {
+          live.nextPromptMaxTokens = CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS
+        }
         logger.warn(
           `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
-            `max_tokens=${CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS}`,
+            `max_tokens=${live.nextPromptMaxTokens ?? CHANNEL_MAX_OUTPUT_TOKENS}`,
         )
-        // Give the re-prompt room to finish reasoning AND produce prose, since
-        // the truncation means the default backstop starved this turn. Consumed
-        // one-shot by installChannelOutputCap on the next session.prompt().
-        live.nextPromptMaxTokens = CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS
         live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
         return
       }
@@ -4397,18 +4402,25 @@ function recoverableAssistantText(
   return null
 }
 
-// True only when the leaf is an assistant message that was CUT OFF mid-output:
-// `length` (hit the token cap — the canonical kimi reasoning-loop), `error`, or
-// `aborted`. This is the precise signature of "the model was producing but got
-// truncated", as distinct from a turn that produced no assistant message at all
-// (leaf undefined / a non-assistant entry), which is a benign empty/cold turn —
-// NOT something to re-prompt. The empty-turn retry guard keys off this so it
-// fires for real degenerations and stays silent for cold sessions.
-function assistantLeafTruncated(session: AgentSession): boolean {
+// The truncation stop reason when the leaf is an assistant message that was CUT
+// OFF mid-output — `length` (hit the token cap, the canonical kimi reasoning-
+// loop), `error`, or `aborted` — else undefined. This is the precise signature
+// of "the model was producing but got truncated", as distinct from a turn that
+// produced no assistant message at all (leaf undefined / a non-assistant
+// entry), which is a benign empty/cold turn. Callers that only need the boolean
+// use `assistantLeafTruncated`; the retry guard reads the reason itself because
+// the raised reasoning budget is justified ONLY for `length` (budget
+// exhaustion), not for `error`/`aborted`.
+function assistantLeafStopReason(session: AgentSession): 'length' | 'error' | 'aborted' | undefined {
   const leaf = session.sessionManager.getLeafEntry()
-  if (!leaf || leaf.type !== 'message' || leaf.message.role !== 'assistant') return false
+  if (!leaf || leaf.type !== 'message' || leaf.message.role !== 'assistant') return undefined
   const stop = leaf.message.stopReason
-  return stop === 'length' || stop === 'error' || stop === 'aborted'
+  if (stop === 'length' || stop === 'error' || stop === 'aborted') return stop
+  return undefined
+}
+
+function assistantLeafTruncated(session: AgentSession): boolean {
+  return assistantLeafStopReason(session) !== undefined
 }
 
 function visibleAssistantText(message: AssistantMessage): string {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -183,6 +183,18 @@ export const MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN = 3
 // including reasoning). Deliberately NOT lowered in `providers.ts`, where
 // `maxTokens` is the model's true capability that compaction math reads.
 export const CHANNEL_MAX_OUTPUT_TOKENS = 4096
+// Raised output-token budget threaded into the ONE re-prompt that follows a
+// `stopReason:'length'` empty turn. The default 4096 backstop bounds kimi's
+// degenerate repetition loop, but it is the same ceiling a *legitimate*
+// reasoning-heavy turn hits when it spends the whole pool thinking and emits no
+// prose — re-prompting under the identical cap reproduces the truncation. A
+// `length` truncation that the byte-identical loop guard did NOT catch is
+// evidence of genuine reasoning starved for room, not a repetition loop, so the
+// retry grants 4x headroom for thinking + a reply. Bounded (not 32000) so a
+// turn that IS looping still can't burn the full pi-ai default. Consumed
+// one-shot via `LiveSession.nextPromptMaxTokens`, then reset at the next real
+// user turn so the raised budget never leaks past the turn that needed it.
+export const CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS = 16384
 // Ceiling on automatic re-prompts for a turn that ended with NO user-facing
 // reply AND no attempted send — the pure "the model burned its budget thinking
 // and produced nothing" failure. The canonical trigger is Fireworks'
@@ -200,18 +212,24 @@ export const CHANNEL_MAX_OUTPUT_TOKENS = 4096
 export const MAX_EMPTY_TURN_RETRIES = 2
 // Reminder-only nudge injected before an empty-turn retry. Uses the repo's
 // SYSTEM MESSAGE framing (see composeTurnPrompt) so persona-rich models do not
-// reply to the notice itself. Neutral by design: it asks for a direct reply
-// without prescribing length or tone, matching the chosen "just retry" posture.
+// reply to the notice itself. Names the actual failure (the prior turn ran out
+// of its output budget mid-reasoning and produced no reply) and asks the model
+// to keep its thinking short and answer directly — the empty turn was budget
+// exhaustion, not a forgotten tool call, so a "reply directly" nudge alone
+// would re-loop. The matching retry re-prompt also runs with a raised budget
+// (CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS) so the room actually exists.
 export const EMPTY_TURN_RETRY_NUDGE = [
   '---',
   '**[SYSTEM MESSAGE — not from a human]**',
   '',
-  'Your previous turn ended without sending any reply to the channel. This is',
+  'Your previous turn ran out of its output budget before sending a reply — it',
+  'spent the whole turn thinking and produced nothing for the channel. This is',
   'an automated signal from the channel router, not a message from anyone in',
   'the chat. **Do not acknowledge or reply to this notice itself.**',
   '',
-  'Respond to the last user message now with a direct answer via your channel',
-  'reply tool. If you genuinely have nothing to say, reply with `NO_REPLY`.',
+  'Answer the last user message now: keep any reasoning brief and send a direct',
+  'reply via your channel reply tool. If you genuinely have nothing to say,',
+  'reply with `NO_REPLY`.',
   '',
   '---',
 ].join('\n')
@@ -532,6 +550,13 @@ type LiveSession = {
   // increments it before injecting EMPTY_TURN_RETRY_NUDGE and reads it to decide
   // retry-vs-fallback. See the candidate===null branch.
   emptyTurnRetries: number
+  // One-shot output-token budget for the NEXT `session.prompt()` only.
+  // `installChannelOutputCap` reads and clears it per stream call, so it
+  // overrides the default backstop for exactly one re-prompt. Set by the
+  // empty-turn length-retry branch to CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS
+  // and reset to undefined at each fresh user turn so the raised budget cannot
+  // leak past the turn that needed it.
+  nextPromptMaxTokens: number | undefined
   // Stamped by `markTurnSkipped` (called from the `skip_response` tool)
   // with the current `turnSeq`. Read at the top of `validateChannelTurn`:
   // if it matches the just-completed turn, recovery is skipped entirely
@@ -1417,6 +1442,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
         emptyTurnRetries: 0,
+        nextPromptMaxTokens: undefined,
         skippedTurn: null,
         skipLockedSendTurn: null,
         pendingQuoteCandidate: null,
@@ -1704,14 +1730,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // Override pi-ai's hidden `Math.min(model.maxTokens, 32000)` output cap for
   // channel sessions by threading an explicit `maxTokens` into every stream
   // call. See CHANNEL_MAX_OUTPUT_TOKENS for why. Composes the existing streamFn
-  // (pi's default `streamSimple` unless a proxy was installed) and only fills
-  // `maxTokens` when the caller left it unset, so an explicit per-call value
-  // still wins.
+  // (pi's default `streamSimple` unless a proxy was installed). Precedence:
+  // an explicit per-call `maxTokens` always wins; otherwise a one-shot
+  // `live.nextPromptMaxTokens` (set by the empty-turn length-retry) is consumed
+  // and cleared so the raised budget applies to exactly one stream call;
+  // otherwise the default backstop.
   const installChannelOutputCap = (live: LiveSession): void => {
     const { agent } = live.session
     const inner = agent.streamFn
-    agent.streamFn = (model, context, options) =>
-      inner(model, context, { ...options, maxTokens: options?.maxTokens ?? CHANNEL_MAX_OUTPUT_TOKENS })
+    agent.streamFn = (model, context, options) => {
+      let maxTokens = options?.maxTokens
+      if (maxTokens === undefined && live.nextPromptMaxTokens !== undefined) {
+        maxTokens = live.nextPromptMaxTokens
+        live.nextPromptMaxTokens = undefined
+      }
+      return inner(model, context, { ...options, maxTokens: maxTokens ?? CHANNEL_MAX_OUTPUT_TOKENS })
+    }
   }
 
   const startTypingHeartbeat = (live: LiveSession): void => {
@@ -1904,10 +1938,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.lastSentText.clear()
           live.pendingQuoteCandidate = captureQuoteCandidate(live.key.adapter, batch, observed)
           // A real user batch starts a fresh logical turn → restore the full
-          // empty-turn retry budget. Reset here (batch.length > 0) and NOT in
-          // the per-prompt block below, so the reminder-only iterations the
-          // retry itself queues do not refill the budget and loop forever.
+          // empty-turn retry budget and drop any raised output-token budget left
+          // over from a prior turn's length-retry. Reset here (batch.length > 0)
+          // and NOT in the per-prompt block below, so the reminder-only
+          // iterations the retry itself queues do not refill the budget and loop
+          // forever (and the raised cap stays scoped to the turn that set it).
           live.emptyTurnRetries = 0
+          live.nextPromptMaxTokens = undefined
         } else if (live.lastTurnAuthorId !== null) {
           live.currentTurnEngageReactions = []
           // Reminder-only turn (batch.length === 0, reminders.length > 0):
@@ -3038,8 +3075,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (!attemptedSendThisTurn && live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
         live.emptyTurnRetries++
         logger.warn(
-          `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES}`,
+          `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
+            `max_tokens=${CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS}`,
         )
+        // Give the re-prompt room to finish reasoning AND produce prose, since
+        // the truncation means the default backstop starved this turn. Consumed
+        // one-shot by installChannelOutputCap on the next session.prompt().
+        live.nextPromptMaxTokens = CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS
         live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
         return
       }


### PR DESCRIPTION
## Background

Channel turns sometimes end with `EMPTY_TURN_FALLBACK_TEXT` ("⚠️ I got stuck putting together a reply…"). The root-cause mechanism: a reasoning-heavy model (the canonical case is Fireworks' `kimi-k2p6-turbo`) spends its **entire** output-token pool thinking and emits **no user-facing prose**, so the assistant leaf comes back `stopReason: 'length'`. The router detects this via `assistantLeafTruncated` and retries with `EMPTY_TURN_RETRY_NUDGE` — but the re-prompt ran under the **same** `CHANNEL_MAX_OUTPUT_TOKENS = 4096` cap that caused the truncation. A genuinely reasoning-heavy turn re-hit the identical ceiling, so the retry was theatre and the user got the fallback anyway.

The 4096 cap is not the bug — it was introduced in `4746f4a` *alongside* the `channel_reply` terminal hook to bound `kimi-k2p6-turbo`'s degenerate 32k-token repetition loop. The terminal hook removes the **known** trigger (the post-tool follow-up after `channel_reply`); the cap is the backstop for **every other** LLM-call path — notably the **initial turn**, which is exactly where the empty-turn fallback fires and which the hook does not cover. Removing the cap would re-expose ~116s/32k-token garbage runs. The real problem is that one static number serves two conflicting needs: *bound runaway garbage* (wants a low cap) vs. *give legitimate reasoning room to finish* (wants a high cap).

## Summary

Decouple the two needs instead of trading one off against the other:

- Keep `4096` as the default backstop for normal turns.
- When a turn truncates on `length` with no recoverable prose — evidence of **starved reasoning**, not a repetition loop (byte-identical loops are already caught by the loop guard) — thread a raised one-shot budget `CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS = 16384` into the retry's stream call.

Mechanism: a new `LiveSession.nextPromptMaxTokens` is set in the length-retry branch and **consumed-and-cleared** by `installChannelOutputCap` on the next `session.prompt()`, so the raised budget applies to exactly one stream call. It resets at each fresh user turn so it can never leak past the turn that needed it.

**Why 16384 and not removing/raising the static cap:** the static cap must stay low to bound garbage on uncovered paths; the evidence that a turn deserves more room (`length` + no prose + not a byte-identical loop) only exists *after* the first truncation, so the budget is granted adaptively on the retry rather than globally. 16384 gives 4x headroom for thinking + a reply while still being well under pi-ai's 32000 default, so a turn that *is* looping still can't burn the full pool.

`EMPTY_TURN_RETRY_NUDGE` is also reworded to name the real failure (budget exhaustion mid-reasoning) and ask the model to keep reasoning brief — the old wording implied a forgotten tool call, which a "reply directly" nudge alone would not fix.

## What this does NOT do

- Does **not** change the model catalog, provider config, or temperature.
- Does **not** raise or remove the default `CHANNEL_MAX_OUTPUT_TOKENS = 4096` backstop.
- Does **not** add a separate reasoning-vs-output token budget (the provider/SDK doesn't expose one).
- Does **not** touch the `channel_reply` terminal hook or the send-thrash path (those still skip retry and fall back once, unchanged).

## Review notes

- Load-bearing invariant: `nextPromptMaxTokens` must be **one-shot**. Verify it's cleared on consume (`installChannelOutputCap`) AND reset on every fresh user batch (`drain`, the `batch.length > 0` block) so the raised cap never leaks into a later turn. Two tests cover this: the raised-budget retry, and the no-leak-into-next-turn reset.
- Precedence in `installChannelOutputCap`: an explicit per-call `maxTokens` still wins over the one-shot, which wins over the default — preserves the existing "explicit caller wins" contract.
- Tests written TDD (red confirmed before implementation). Full suite green (7716 pass).