### PR TITLE
docs: fix plugin API reference to match src/plugin

### DIFF
--- a/docs/content/docs/concepts/plugins-and-stages.mdx
+++ b/docs/content/docs/concepts/plugins-and-stages.mdx
@@ -18,35 +18,43 @@ Pulling the boundary down to the plugin level would buy almost no extra security
 
 ## What plugins receive
 
-The `factory(ctx)` callback gets a `PluginContext` carrying:
+The `plugin(ctx)` factory is an async callback that gets a `PluginContext` carrying:
 
 - **`ctx.config`** — the parsed, frozen config block for this plugin (validated by your `configSchema`). Boot-only fields are snapshots; reloadable fields update on `typeclaw reload`.
 - **`ctx.permissions`** — the live permission service. Plugins query it (`ctx.permissions.has(origin, perm)`) rather than implementing their own checks.
-- **`ctx.stream`** — the in-process message stream. Plugins subscribe to broadcasts, publish to typed targets.
-- **`ctx.spawnSubagent(name, payload, options)`** — for plugins that contribute subagents and want to invoke them.
+- **`ctx.spawnSubagent(name, payload, options)`** — for plugins that contribute subagents and want to invoke them; provenance is resolved from the spawning origin.
 - **`ctx.agentDir`** — absolute path to the agent folder (mounted at `/agent` in the container).
+- **`ctx.name` / `ctx.version` / `ctx.logger` / `ctx.github`** — the plugin's derived name, its package version, a namespaced logger, and GitHub token resolution.
 
 Everything plugins talk to flows through this object. There are no module-global imports of agent state, no singletons reaching into the runtime — the surface is the `ctx`.
 
 ## What plugins can contribute
 
-A plugin's `factory` returns an object with optional fields:
+A plugin's factory returns a `PluginExports` object with optional fields:
 
 - **`tools`** — Zod-typed functions the agent can call
-- **`skills`** — markdown procedures the agent loads on demand
+- **`skills`** / **`skillsDirs`** — markdown procedures the agent loads on demand, inline or from directories
 - **`subagents`** — focused worker sessions with their own system prompt and payload schema
-- **`channels`** — new inbound/outbound message platforms
-- **`crons`** — scheduled prompts or exec commands contributed at boot
+- **`cronJobs`** — scheduled prompts, exec commands, or in-process handlers contributed at boot
+- **`hooks`** — session- and tool-lifecycle observers (see below)
+- **`doctorChecks`** — `typeclaw doctor` checks, optionally with a `--fix` apply step
 
-Plus, declared on the `definePlugin` envelope itself (not inside `factory`):
+Plus, declared on the `definePlugin` envelope itself (not inside the factory):
 
 - **`permissions`** — every permission this plugin both checks and contributes. Lifted out of the factory because the runtime reads it before invoking the factory, to expand the owner wildcard and validate user-declared `permissions[]` against the union of all plugin permissions.
+- **`commands`** — host- or container-stage CLI subcommands, declared by-value so the host CLI can dispatch them without booting plugin runtime state.
 
 The full signatures are at [/reference/plugin-api](/docs/reference/plugin-api).
 
+## Hooks intercept the agent's own tools
+
+Reactive work runs through `hooks`, not a message-stream subscription. The session hooks (`session.start` / `end` / `idle` / `prompt` / `turn.start` / `turn.end`) observe the agent's lifecycle; the bundled `memory` plugin debounces off `session.idle` to spawn its logger.
+
+The tool hooks are the important ones for security. `tool.before` and `tool.after` fire for **both** plugin-contributed tools **and** the agent's own built-in tools — `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`. A `tool.before` returning `{ block: true, reason }` aborts the call before it runs, including a `bash` shell command. This is exactly how the bundled `security` plugin enforces its policies (secret exfil, SSRF, git remote taint, prompt injection) — by inspecting the agent's own `bash` invocations at `tool.before`. So "plugins can't drive the agent" does **not** mean plugins can't intercept it: a plugin cannot _issue_ tool calls, but it can _gate_ every tool call the agent makes.
+
 ## What plugins cannot do
 
-Plugins can't drive the agent. They contribute tools the agent might call; they don't issue tool calls themselves. If you need scheduled work, contribute a cron. If you need reactive work, subscribe to the message stream. The agent's autonomy is the agent's; plugins are how you give it more capabilities, not how you put it on rails.
+Plugins can't drive the agent. They contribute tools the agent might call; they don't issue tool calls themselves. If you need scheduled work, contribute a cron. If you need reactive work, install a hook. The agent's autonomy is the agent's; plugins are how you give it more capabilities, not how you put it on rails.
 
 Plugins also can't change other plugins' contributions, mutate the Dockerfile, or open new mounts. These are container-stage facts captured at boot, owned by the host-stage launcher, and not exposed to plugin code.
 

--- a/docs/content/docs/concepts/plugins-and-stages.mdx
+++ b/docs/content/docs/concepts/plugins-and-stages.mdx
@@ -20,7 +20,7 @@ Pulling the boundary down to the plugin level would buy almost no extra security
 
 The `plugin(ctx)` factory is an async callback that gets a `PluginContext` carrying:
 
-- **`ctx.config`** — the parsed, frozen config block for this plugin (validated by your `configSchema`). Boot-only fields are snapshots; reloadable fields update on `typeclaw reload`.
+- **`ctx.config`** — the parsed config block for this plugin (validated by your `configSchema`). The `ctx` object is frozen, but the config object itself isn't, so treat it as read-only. Boot-only fields are snapshots; reloadable fields update on `typeclaw reload`.
 - **`ctx.permissions`** — the live permission service. Plugins query it (`ctx.permissions.has(origin, perm)`) rather than implementing their own checks.
 - **`ctx.spawnSubagent(name, payload, options)`** — for plugins that contribute subagents and want to invoke them; provenance is resolved from the spawning origin.
 - **`ctx.agentDir`** — absolute path to the agent folder (mounted at `/agent` in the container).

--- a/docs/content/docs/guides/write-a-plugin.mdx
+++ b/docs/content/docs/guides/write-a-plugin.mdx
@@ -80,10 +80,10 @@ export default definePlugin({
 })
 ```
 
-- The plugin's **name is not declared here** — it's derived from the package's `package.json#name`, and that name scopes both the config block and the permission strings.
+- The plugin's **name is not declared here** — the loader derives it from the entry. A local/path plugin (`./packages/notify`) is named from the resolved path's basename (here, `notify`); an npm plugin is named from `package.json#name`. That derived name scopes both the config block and the permission strings.
 - `permissions` — every permission this plugin declares and consumes; lets the runtime expand the `owner` wildcard and catch typos
-- `configSchema` — Zod schema for the config block, which lives at `typeclaw.json#<package-name>`
-- `plugin(ctx)` — an **async** factory returning the contributions; `ctx.config` is the parsed, frozen config block. A tool's `parameters` is a Zod schema and its `execute` returns a `ToolResult` (`{ content, details? }`).
+- `configSchema` — Zod schema for the config block, which lives at `typeclaw.json#<name>` (the derived name above)
+- `plugin(ctx)` — an **async** factory returning the contributions; `ctx.config` is the parsed config block (treat it as read-only — the `ctx` is frozen, the config object isn't). A tool's `parameters` is a Zod schema and its `execute` returns a `ToolResult` (`{ content, details? }`).
 
 Full contract: [plugin API reference](/docs/reference/plugin-api).
 
@@ -100,7 +100,7 @@ Custom plugins live under `packages/<plugin-name>/` — the agent folder is a bu
 }
 ```
 
-The config key (`notify`) is the plugin's derived name — its `package.json#name`, not its folder path. `plugins[]` is **restart-required** — plugins load once at container boot, so adding one needs a restart (which the agent does for you), not a `reload`.
+The config key (`notify`) is the plugin's derived name — for this local plugin, the basename of `./packages/notify`. `plugins[]` is **restart-required** — plugins load once at container boot, so adding one needs a restart (which the agent does for you), not a `reload`.
 
 </Accordion>
 

--- a/docs/content/docs/guides/write-a-plugin.mdx
+++ b/docs/content/docs/guides/write-a-plugin.mdx
@@ -47,30 +47,31 @@ The rest of this page is for when you want to understand — or hand-write — t
 
 <Accordion title="What a plugin actually looks like">
 
-A plugin is a single TypeScript module with one default export: a `definePlugin(...)` call. It runs in the same process as the agent — no IPC, no subprocess — and receives a `PluginContext` (the live permission service, the message stream, the agent folder path). A minimal one-tool plugin:
+A plugin is a single TypeScript module with one default export: a `definePlugin(...)` call. It runs in the same process as the agent — no IPC, no subprocess — and its async factory receives a `PluginContext` (the live permission service, the agent folder path, a logger, `spawnSubagent`). A minimal one-tool plugin:
 
 ```ts
 import { definePlugin } from 'typeclaw/plugin'
 import { z } from 'zod'
 
 export default definePlugin({
-  name: 'notify',
   permissions: ['notify.send.notification'],
   configSchema: z.object({ webhook: z.string().url() }),
-  factory(ctx) {
+  async plugin(ctx) {
     const { webhook } = ctx.config
     return {
       tools: {
         send_notification: {
           description: 'Post a short notification to the configured webhook',
-          inputSchema: z.object({ text: z.string().describe('the message body') }),
+          parameters: z.object({ text: z.string().describe('the message body') }),
           async execute({ text }) {
             const res = await fetch(webhook, {
               method: 'POST',
               headers: { 'content-type': 'application/json' },
               body: JSON.stringify({ text }),
             })
-            return { ok: res.ok, status: res.status }
+            return {
+              content: [{ type: 'text', text: res.ok ? `sent (${res.status})` : `failed (${res.status})` }],
+            }
           },
         },
       },
@@ -79,10 +80,10 @@ export default definePlugin({
 })
 ```
 
-- `name` — scopes the config block and the permission strings
+- The plugin's **name is not declared here** — it's derived from the package's `package.json#name`, and that name scopes both the config block and the permission strings.
 - `permissions` — every permission this plugin declares and consumes; lets the runtime expand the `owner` wildcard and catch typos
-- `configSchema` — Zod schema for the config block, which lives at `typeclaw.json#notify`
-- `factory(ctx)` — returns the contributions; `ctx.config` is the parsed, frozen config block
+- `configSchema` — Zod schema for the config block, which lives at `typeclaw.json#<package-name>`
+- `plugin(ctx)` — an **async** factory returning the contributions; `ctx.config` is the parsed, frozen config block. A tool's `parameters` is a Zod schema and its `execute` returns a `ToolResult` (`{ content, details? }`).
 
 Full contract: [plugin API reference](/docs/reference/plugin-api).
 
@@ -99,7 +100,7 @@ Custom plugins live under `packages/<plugin-name>/` — the agent folder is a bu
 }
 ```
 
-`plugins[]` is **restart-required** — plugins load once at container boot, so adding one needs a restart (which the agent does for you), not a `reload`.
+The config key (`notify`) is the plugin's derived name — its `package.json#name`, not its folder path. `plugins[]` is **restart-required** — plugins load once at container boot, so adding one needs a restart (which the agent does for you), not a `reload`.
 
 </Accordion>
 
@@ -107,7 +108,7 @@ Custom plugins live under `packages/<plugin-name>/` — the agent folder is a bu
 
 Plugins can't change which other plugins load, rewrite the Dockerfile, or escape the container — the trust boundary is the container, not the plugin ([plugins and stages](/docs/concepts/plugins-and-stages)).
 
-They also can't drive the agent. A plugin _defines_ tools the agent may call; it doesn't issue tool calls itself. For scheduled work, contribute a cron job; for reactive work, subscribe to the message stream.
+They also can't drive the agent. A plugin _defines_ tools the agent may call; it doesn't issue tool calls itself. For scheduled work, contribute a cron job; for reactive work, install a hook. A plugin can't _initiate_ a tool call — but it _can_ intercept every one the agent makes: a `tool.before` hook gates the agent's own built-in tools too, including `bash` (this is how the bundled `security` plugin blocks unsafe shell commands).
 
 </Accordion>
 

--- a/docs/content/docs/reference/plugin-api.mdx
+++ b/docs/content/docs/reference/plugin-api.mdx
@@ -22,7 +22,7 @@ export default definePlugin({
 })
 ```
 
-The plugin's **name is not declared here** — it is derived from the package's `package.json#name` (`derivePluginNameFromPackage`), and that name scopes the config block (`typeclaw.json#<name>`) and namespaces permissions.
+The plugin's **name is not declared here** — the loader derives it from the entry. For a local/path plugin (`./packages/foo`) the name is the resolved path's basename (minus a `.ts`/`.js`/… extension); for an npm plugin it's `package.json#name` run through `derivePluginNameFromPackage` (drops a `@scope/` and a `typeclaw-plugin-` prefix). That derived name scopes the config block (`typeclaw.json#<name>`) and namespaces permissions.
 
 | Field                     | Required | Notes                                                                                                                            |
 | ------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -39,7 +39,7 @@ type PluginContext<TConfig = never> = {
   readonly name: string // derived plugin name
   readonly version: string | undefined
   readonly agentDir: string // absolute; '/agent' in container
-  readonly config: TConfig // parsed per configSchema, frozen
+  readonly config: TConfig // parsed per configSchema (the ctx is frozen; the config object itself is not)
   readonly logger: PluginLogger // .info / .warn / .error
   readonly permissions: PermissionService // .has(origin, perm) etc.
   readonly github: PluginGithubServices // .resolveTokenForRepo

--- a/docs/content/docs/reference/plugin-api.mdx
+++ b/docs/content/docs/reference/plugin-api.mdx
@@ -4,132 +4,220 @@ description: definePlugin, PluginContext, contribution types
 icon: Plug
 ---
 
-The walkthrough is at [Add a plugin](/docs/guides/write-a-plugin). The shape is at [/concepts/plugins-and-stages](/docs/concepts/plugins-and-stages). This page is the contract.
+The walkthrough is at [Add a plugin](/docs/guides/write-a-plugin). The shape is at [/concepts/plugins-and-stages](/docs/concepts/plugins-and-stages). This page is the contract. The source of truth is `src/plugin/types.ts` and `src/plugin/define.ts`.
 
 ## `definePlugin`
 
 ```ts
 import { definePlugin } from 'typeclaw/plugin'
 
-export default definePlugin<TConfig = unknown>({
-  name: string,
-  permissions: string[],
-  configSchema?: z.ZodType<TConfig>,
-  factory: (ctx: PluginContext<TConfig>) => PluginContributions,
+export default definePlugin({
+  configSchema, // optional: z.ZodType<TConfig>
+  permissions, // optional: readonly string[]
+  ownerWildcardExclusions, // optional: readonly string[]
+  commands, // optional: Record<string, PluginCommand>
+  plugin: async (ctx) => {
+    return {} // PluginExports
+  },
 })
 ```
 
-| Field          | Required | Notes                                                                                 |
-| -------------- | -------- | ------------------------------------------------------------------------------------- |
-| `name`         | yes      | unique, used to scope config block (`typeclaw.json#<name>`) and namespace permissions |
-| `permissions`  | yes      | every permission this plugin both declares and consumes; read before `factory` runs   |
-| `configSchema` | no       | Zod schema for the plugin's config block; defaults to `unknown` if omitted            |
-| `factory`      | yes      | returns the plugin's contributions; receives the live `PluginContext`                 |
+The plugin's **name is not declared here** — it is derived from the package's `package.json#name` (`derivePluginNameFromPackage`), and that name scopes the config block (`typeclaw.json#<name>`) and namespaces permissions.
+
+| Field                     | Required | Notes                                                                                                                            |
+| ------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `configSchema`            | no       | Zod schema for the plugin's config block; parsed result is handed to `plugin` as `ctx.config`. Omit for `unknown`.               |
+| `permissions`             | no       | every permission this plugin both declares and consumes; read before `plugin` runs                                               |
+| `ownerWildcardExclusions` | no       | permission strings the owner wildcard sentinel MUST NOT auto-expand to (used by `security` to keep high-tier bypasses off owner) |
+| `commands`                | no       | declared by-value so the host-stage CLI can dispatch them without booting plugin runtime state                                   |
+| `plugin`                  | yes      | **async** factory; receives the live `PluginContext`, returns the plugin's `PluginExports`                                       |
 
 ## `PluginContext`
 
 ```ts
-type PluginContext<TConfig> = {
-  config: TConfig // parsed, frozen
-  permissions: PermissionService // .has(origin, perm) etc.
-  stream: MessageStream // .subscribe / .publish
-  spawnSubagent: (name: string, payload?: unknown, options?: SpawnOptions) => Promise<SubagentResult>
-  agentDir: string // absolute path, '/agent' in container
-  pluginDir: string // where the plugin's bundled assets live
-  containerName: string
-  logger: Logger
+type PluginContext<TConfig = never> = {
+  readonly name: string // derived plugin name
+  readonly version: string | undefined
+  readonly agentDir: string // absolute; '/agent' in container
+  readonly config: TConfig // parsed per configSchema, frozen
+  readonly logger: PluginLogger // .info / .warn / .error
+  readonly permissions: PermissionService // .has(origin, perm) etc.
+  readonly github: PluginGithubServices // .resolveTokenForRepo
+  spawnSubagent: (name: string, payload?: unknown, options?: SpawnSubagentOptions) => Promise<void>
+}
+
+type SpawnSubagentOptions = {
+  parentSessionId?: string
+  spawnedByOrigin?: SessionOrigin
 }
 ```
 
-## `PluginContributions`
+`spawnSubagent` resolves `spawnedByRole` from `spawnedByOrigin` via the `PermissionService`, so the spawning session's role is inherited rather than forged. Hook handlers that own an origin (e.g. `session.idle`, `session.turn.end`) should pass `parentSessionId` and `spawnedByOrigin: event.origin`.
 
-Returned from `factory(ctx)`. All fields optional.
+## `PluginExports`
+
+Returned from the `plugin(ctx)` factory. All fields optional.
 
 ```ts
-type PluginContributions = {
-  tools?: Record<string, Tool>
-  skills?: PluginSkill[]
-  subagents?: Record<string, Subagent>
-  channels?: Record<string, ChannelAdapter>
-  crons?: CronJob[]
-  hooks?: {
-    'session.idle'?: (event: SessionIdleEvent) => void | Promise<void>
-    'tool.before'?: (event: ToolBeforeEvent) => ToolBeforeResult | Promise<ToolBeforeResult>
-    'tool.after'?: (event: ToolAfterEvent) => void | Promise<void>
-  }
+type PluginExports = {
+  tools?: Record<string, Tool<any>>
+  subagents?: Record<string, Subagent<any>>
+  cronJobs?: Record<string, PluginCronJob>
+  skills?: Record<string, PluginSkill>
+  skillsDirs?: string[]
+  hooks?: Hooks
+  doctorChecks?: Record<string, PluginDoctorCheck>
 }
 ```
+
+Commands are declared on `definePlugin` (by-value), not returned here.
 
 ### Tool
 
 ```ts
-type Tool<TIn = unknown, TOut = unknown> = {
+type Tool<P = unknown> = {
   description: string
-  inputSchema: z.ZodType<TIn>
-  execute: (input: TIn, ctx: ToolExecuteContext) => Promise<TOut>
+  parameters: z.ZodType<P>
+  execute: (args: P, ctx: ToolContext) => Promise<ToolResult>
+}
+
+type ToolContext = {
+  signal: AbortSignal | undefined // fires when the agent cancels the call
+  sessionId: string
+  agentDir: string
+  logger: ToolLogger
+}
+
+type ToolResult = {
+  content: ContentPart[] // { type: 'text'; text } | { type: 'image'; mimeType; data }
+  details?: unknown
 }
 ```
 
-`ToolExecuteContext` carries the live `SessionOrigin`, the agent's working directory inside the container, and a `signal` (`AbortSignal`) that fires when the agent cancels the call.
+`defineTool(tool)` is an identity helper for type inference. Built-in tools are referenced by tagged ref (`readTool`, `bashTool`, `editTool`, `writeTool`, `grepTool`, `findTool`, `lsTool`, `webSearchTool`, `webFetchTool`) — useful when wiring a subagent's `tools` list.
 
 ### Subagent
 
 ```ts
-type Subagent<TPayload = unknown> = {
-  systemPrompt: string
-  payloadSchema?: z.ZodType<TPayload>
-  inFlightKey?: (payload: TPayload) => string // for per-payload coalescing
-  handler: (payload: TPayload, ctx: SubagentContext) => Promise<SubagentResult>
+type Subagent<P = unknown> = SubagentShared<P> & {
+  tools?: BuiltinToolRef[] // built-in tools, by tagged ref
+  customTools?: Tool<any>[] // plugin-contributed tools
+  inFlightKey?: (payload: P) => string // per-payload coalescing
 }
 ```
 
-`inFlightKey` is what makes two concurrent invocations with the same payload serialize instead of race. Memory's `memory-logger` and `dreaming` both key by `agentDir`.
-
-### ChannelAdapter
-
-Plugin-contributed channels follow the same contract as built-ins. See `src/channels/adapters/` for examples.
+A subagent inherits its system prompt and payload schema from `SubagentShared`. `inFlightKey` defaults to the subagent name alone (only one instance runs at a time); override it to allow per-payload concurrency. Memory's `memory-logger` keys by `parentSessionId` so different parent sessions run in parallel while duplicate runs against the same session deduplicate. `defineSubagent(subagent)` is the identity helper.
 
 ### Cron
 
+`cronJobs` is a `Record<string, PluginCronJob>`; the runtime prefixes each key with `__plugin_<plugin-name>_` to form the global cron id (no collision with `cron.json` user jobs or across plugins). `PluginCronJob` is a discriminated union on `kind`:
+
 ```ts
-type CronJob = {
-  id: string
+type PluginPromptCronJob = {
   schedule: string
-  kind: 'prompt' | 'exec'
-  prompt?: string // when kind === 'prompt'
-  subagent?: string // when kind === 'prompt', invokes a subagent instead
-  command?: string[] // when kind === 'exec'
-  scheduledByRole: string // defaults to 'owner' for plugin-contributed jobs
+  kind: 'prompt'
+  prompt: string
+  enabled?: boolean
+  timezone?: string
+  subagent?: string // invoke a subagent instead of prompting
+  payload?: unknown
+}
+
+type PluginExecCronJob = {
+  schedule: string
+  kind: 'exec'
+  command: string[]
+  enabled?: boolean
+  timezone?: string
+}
+
+type PluginHandlerCronJob = {
+  schedule: string
+  kind: 'handler'
+  handler: (ctx: CronHandlerContext) => Promise<void>
+  enabled?: boolean
+  timezone?: string
 }
 ```
 
-Plugin-contributed cron jobs default to `scheduledByRole: 'owner'` (they're bundled or operator-installed runtime, not user channel schedules).
+`kind: 'handler'` is plugin-only — a TypeScript function reference, so it cannot appear in `cron.json` (the schema gate limits user files to `prompt` and `exec`). Use it when a job needs imperative control flow (probe → maybe prompt → write file) in the same plugin as the logic. `CronHandlerContext` mirrors a command's LLM-call surface (`prompt`, `subagent`, `exec`) plus `jobId`, `name`, `agentDir`, `logger`, `signal`, `permissions`, and a cron-shaped `origin` that stamps provenance on anything the handler spawns.
+
+### Skills
+
+```ts
+type PluginSkill = {
+  description: string
+  content: string
+  frontmatter?: Record<string, unknown>
+}
+```
+
+Contribute skills inline via `skills: Record<string, PluginSkill>`, or point at on-disk skill directories with `skillsDirs: string[]`.
 
 ### Hooks
+
+```ts
+type Hooks = {
+  'session.start'?: (event: SessionStartEvent, ctx: HookContext) => void | Promise<void>
+  'session.end'?: (event: SessionEndEvent, ctx: HookContext) => void | Promise<void>
+  'session.idle'?: (event: SessionIdleEvent, ctx: HookContext) => void | Promise<void>
+  'session.prompt'?: (event: SessionPromptEvent, ctx: HookContext) => void | Promise<void>
+  'session.turn.start'?: (event: SessionTurnStartEvent, ctx: HookContext) => void | Promise<void>
+  'session.turn.end'?: (event: SessionTurnEndEvent, ctx: HookContext) => void | Promise<void>
+  'tool.before'?: (event: ToolBeforeEvent, ctx: HookContext) => ToolBeforeResult | Promise<ToolBeforeResult>
+  'tool.after'?: (event: ToolAfterEvent, ctx: HookContext) => void | Promise<void>
+}
+
+type HookContext = { agentDir: string; pluginName: string; logger: PluginLogger }
+```
 
 `tool.before` is the gate. Return:
 
 ```ts
-type ToolBeforeResult =
-  | { ok: true } // allow
-  | { ok: false; reason: string } // block
-  | { ok: 'ack'; severity: 'low' | 'medium' | 'high'; guard: string; message: string }
-// require operator acknowledgement
+type ToolBeforeResult = void | undefined | { block: true; reason: string }
 ```
 
-The `ack` variant is what the bundled `security` plugin uses for its tier-based bypasses.
+Return nothing (or `undefined`) to allow; return `{ block: true, reason }` to block. The bundled `security` plugin returns the block variant for its tier-based policies. It fires for plugin-defined tools and TypeClaw-exposed built-in tools (read/bash/edit/write/grep/find/ls).
 
 `tool.after` is read-only; use it for logging, metrics, and side-channel cleanup.
 
-`session.idle` fires synchronously after `session.prompt()` resolves. Plugins that want delayed reactions (e.g. memory-logger's idleMs window) install their own `setTimeout`.
+`session.prompt` brackets system-prompt assembly — mutate near the **end** of `event.prompt` to preserve provider prompt-cache hits; mutations near the start invalidate the cache on every call. `session.turn.start` / `session.turn.end` bracket every `session.prompt(...)` turn (distinct from `session.start` / `session.end`, which bracket session lifetime). `session.idle` carries an `idleMs` window; plugins wanting delayed reactions install their own `setTimeout`.
+
+### Doctor checks
+
+```ts
+type PluginDoctorCheck = {
+  description: string
+  category?: string
+  run: (ctx: PluginDoctorContext) => Promise<PluginCheckResult>
+}
+```
+
+Each check is read-only by default. Declaring `fix.apply` on the returned `PluginCheckResult` opts it into `typeclaw doctor --fix`, where the host serializes plugin fixes, validates each `changedPaths` entry stays inside the agent folder, and commits the union of all fixes in a single commit.
+
+## Commands
+
+Commands are declared by-value on `definePlugin#commands` so the host-stage CLI can dispatch them without booting plugin runtime state. `surface` controls where a command may run:
+
+```ts
+type PluginCommand = ContainerCommand | HostCommand | EitherCommand
+```
+
+| `surface`     | Runs                        | Context surface                                       |
+| ------------- | --------------------------- | ----------------------------------------------------- |
+| `'container'` | inside the agent runtime    | `prompt`, `subagent`, `exec`, `origin`, `permissions` |
+| `'host'`      | on the user's machine       | streams + `agentDir` (host path), `logger`, `signal`  |
+| `'either'`    | whichever stage was invoked | intersection of the two                               |
+
+`defineCommand(cmd)` infers the context type from `surface` and types `args` from a `z.ZodObject` (v1 constraint: primitive leaves so `--help` can render `--<name>=<type>`). Container commands may set `isolated: true` to spawn a fresh Bun subprocess (~150ms cold-start) for isolation from the agent.
 
 ## Lifecycle
 
 Plugins load once at container start. They can:
 
-- Mutate behavior at runtime via tool execution and stream subscriptions
+- Expose tools, subagents, cron jobs, skills, hooks, doctor checks, and commands
 - Read live config via `ctx.config` (boot-only fields are snapshots; reloadable fields are live)
-- Spawn subagents with provenance (`spawnedByRole` is stamped from the parent origin)
+- Spawn subagents with provenance (`spawnedByRole` is resolved from the parent origin)
 
 Plugins cannot:
 


### PR DESCRIPTION
## Background

The plugin docs had drifted far enough from `src/plugin/types.ts` and `src/plugin/define.ts` that they described an API that no longer exists. On `reference/plugin-api.mdx` every one of the eight code blocks was wrong, and the `Tool`, `Subagent`, `Cron`, `Hooks`, and `ToolBeforeResult` blocks would fail to typecheck if a plugin author copied them. The same drift had leaked into the concept page (`plugins-and-stages.mdx`) and the guide (`write-a-plugin.mdx`).

Concretely, the docs claimed:

- `definePlugin({ name, factory })` — but there is no `name` field (the name is derived from `package.json#name` via `derivePluginNameFromPackage`), and the factory key is `plugin` and is **async**.
- `PluginContext` exposes `stream` / `pluginDir` / `containerName` — none of which exist. The real context is `name`, `version`, `agentDir`, `config`, `logger`, `permissions`, `github`, `spawnSubagent`.
- A `PluginContributions` type with `channels` and array-shaped `skills`/`crons` — the real type is `PluginExports`, `skills`/`cronJobs` are `Record`s, there is no `channels` field, and `skillsDirs` / `hooks` / `doctorChecks` were missing entirely.
- `Tool` uses `inputSchema` and returns arbitrary `TOut` — it's `parameters` and returns a `ToolResult`.
- `ToolBeforeResult` has an `{ ok: 'ack'; severity; guard; message }` variant "used by the security plugin" — this was fabricated. The real shape is `void | { block: true; reason }`, and the `security` plugin returns the `block` variant (`src/bundled-plugins/security/index.ts:82`).
- Hooks: only 3 documented; there are 8, each taking a second `HookContext` arg.

This surfaced from a reader's question that conflated "plugins can't drive the agent" with "plugins can't intercept the agent's shell execution." The first is true; the second is false — and the docs didn't make that explicit, so the wrong inference was reasonable.

## Summary

Rewrote the three plugin docs against the actual source, which is now cited at the top of the reference page.

The reference page (`plugin-api.mdx`) is corrected block-by-block and gains the previously-undocumented surfaces: `commands` (the host/container/either `PluginCommand` split + `defineCommand`), `doctorChecks` (`--fix` flow), `skillsDirs`, the `handler` cron kind with `CronHandlerContext`, and the `defineTool`/`defineSubagent` + builtin-tool-ref helpers.

The concept page and guide get the matching `plugin`/`parameters`/`ToolResult`/`PluginExports` corrections, and the `ctx.stream` subscription guidance is replaced with the real reactive mechanism: hooks.

A new "Hooks intercept the agent's own tools" section makes the load-bearing fact explicit — `tool.before`/`tool.after` fire for the agent's **own** built-in tools (`read`/`bash`/`edit`/`write`/`grep`/`find`/`ls`), not just plugin tools, and a `tool.before` returning `{ block: true, reason }` aborts the call, including a `bash` command. This is verifiable in `src/agent/plugin-tools.ts`: `buildBuiltinPiToolOverrides` wraps every pi builtin via `wrapAgentToolAsCustomToolDefinition`, which runs `hooks.runToolBefore` before execute and throws on a block — and it's how the bundled `security` plugin guards shell execution.

## What this does NOT do

- No source changes. Docs only (`.mdx`).
- Does not touch the other reference pages whose `scheduledByRole` usage is correct (that field is real on `cron.json` user jobs / cron origins; it's only the plugin-contributed `PluginCronJob` type that omits it and defaults to `owner`).

## Review notes

The authority for every claim is `src/plugin/types.ts`, `src/plugin/define.ts`, and `src/agent/plugin-tools.ts`. The one previously-fabricated claim worth confirming is the `ToolBeforeResult` shape: it is `void | { block: true; reason }` (`types.ts:213`), and `security/index.ts:82` returns `{ block: true, ... }` — there is no `ack`/`severity` hook-return variant.

Pre-commit (`format:check`, `lint`, `typecheck`) passes. The only failing test on this branch is the pre-existing `typeclaw.schema.json` drift guard, which also fails on clean `main` and is unrelated to these doc-only changes.
