### PR TITLE
Tolerate a missing public/ dir in researcher write_report

### DIFF
--- a/src/bundled-plugins/researcher/write-report.test.ts
+++ b/src/bundled-plugins/researcher/write-report.test.ts
@@ -125,6 +125,28 @@ describe('write_report tool — symlink and overwrite defenses', () => {
   })
 })
 
+describe('write_report tool — optional public/ dir', () => {
+  test('writes to workspace/ when public/ does not exist (the common agent layout)', async () => {
+    await rm(publicDir, { recursive: true, force: true })
+    const tool = createWriteReportTool()
+    const target = path.join(workspaceDir, 'research-no-public-dir.md')
+
+    await tool.execute({ path: target, content: 'report' }, makeCtx())
+
+    expect(await readFile(target, 'utf8')).toBe('report')
+  })
+
+  test('writes to public/ when workspace/ does not exist', async () => {
+    await rm(workspaceDir, { recursive: true, force: true })
+    const tool = createWriteReportTool()
+    const target = path.join(publicDir, 'research-no-workspace-dir.md')
+
+    await tool.execute({ path: target, content: 'report' }, makeCtx())
+
+    expect(await readFile(target, 'utf8')).toBe('report')
+  })
+})
+
 describe('write_report tool — one report per session', () => {
   test('rejects a second write in the same session', async () => {
     const tool = createWriteReportTool()

--- a/src/bundled-plugins/researcher/write-report.ts
+++ b/src/bundled-plugins/researcher/write-report.ts
@@ -75,12 +75,14 @@ Write to \`public/\` instead of \`workspace/\` when your resolved role lacks \`f
         )
       }
 
-      const [realParent, realWorkspace, realPublic] = await Promise.all([
-        realpath(parent),
-        realpath(workspaceDir),
-        realpath(publicDir),
-      ])
-      if (realParent !== realWorkspace && realParent !== realPublic) {
+      // Resolve ONLY the canonical dir `parent` lexically matched above. `public/`
+      // is optional (created only for guest-readable output), so an unconditional
+      // `realpath('<agent>/public')` throws ENOENT on agents that never made it,
+      // which would reject every valid write to `workspace/`. The symlink-escape
+      // defense is unchanged — the parent actually written to is still canonicalized.
+      const canonicalDir = parent === workspaceDir ? workspaceDir : publicDir
+      const [realParent, realCanonical] = await Promise.all([realpath(parent), realpath(canonicalDir)])
+      if (realParent !== realCanonical) {
         throw new Error(`Report parent directory resolves outside the allowed report directories: ${parent}.`)
       }
 


### PR DESCRIPTION
## Background

A production researcher subagent was asked to research a news topic. It did the research correctly in ~4 minutes (fanned out 5 `scout` children, all returned good sourced material), then spent the next ~6 minutes unable to save its report and was killed by the 10-minute spawn timeout. The user-visible symptom was the parent agent giving up: *"the researcher took 10 minutes and died — I'll search directly."*

Root cause is in `write_report`, the researcher's only file-write primitive. It validated the target's parent against both allowed report dirs by canonicalizing them together:

```ts
const [realParent, realWorkspace, realPublic] = await Promise.all([
  realpath(parent),
  realpath(workspaceDir),
  realpath(publicDir),   // throws ENOENT when <agent>/public doesn't exist
])
```

`public/` is **optional** — it only exists for the guest-untrusted fallback path. On any agent that never created it (the common layout — they only have `workspace/`), `realpath('<agent>/public')` rejects the whole `Promise.all` with `ENOENT: ... lstat '/agent/public'`, **even when the report correctly targets `workspace/`**. Because the filesystem is read-only, the subagent couldn't `mkdir` its way out; it retry-spun on the same error until the timeout guillotined it. The researcher was effectively unable to ever produce its sole deliverable on such agents.

## Summary

Resolve **only** the canonical dir that the target's parent lexically matched (the lexical `parent === workspaceDir || parent === publicDir` check already runs just above), instead of unconditionally resolving both:

```ts
const canonicalDir = parent === workspaceDir ? workspaceDir : publicDir
const [realParent, realCanonical] = await Promise.all([realpath(parent), realpath(canonicalDir)])
if (realParent !== realCanonical) { /* reject */ }
```

**Why not just create `public/` lazily, or swallow ENOENT?** Creating it is wrong (read-only FS; and the researcher must not have a side effect beyond its one report). Swallowing ENOENT broadly would weaken the symlink-escape defense. Resolving only the matched dir is the minimal change that keeps that defense intact: the dir the report is actually written under is still `realpath`'d and required to resolve to its canonical target — the unused, possibly-absent dir is simply never touched.

## What this does NOT do

- Does not change the symlink/overwrite/one-report-per-session guarantees — all existing boundary tests pass unchanged.
- Does not create or require `public/`. Agents without it now work; agents with it behave exactly as before.
- Does not touch the 10-minute spawn-timeout behavior, or make the subagent abort faster on an unrecoverable write error. That retry-spin-until-timeout pattern is a separate, orthogonal hardening worth a follow-up.

## Review notes

- Load-bearing change is the `canonicalDir` selection + two-way `realpath`. The invariant to verify: a report under `workspace/` (or `public/`) still resolves to the *real* `workspace/` (or `public/`), so a symlinked report dir is still rejected.
- The regression gap is why this shipped: the existing suite's `beforeEach` does `mkdir(publicDir)` **and** `mkdir(workspaceDir)` every time, so `realpath(publicDir)` never threw in tests. The two new tests drop one dir each and assert the write still succeeds — they fail against the old 3-way resolve with the exact production `ENOENT ... lstat '.../workspace'` / `'.../public'` error.
