### PR TITLE
fix(github): block duplicate PR approval across GitHub's reviews read lag

### DIFF
--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -111,7 +111,7 @@ describe('review verdict idempotency guard', () => {
   test('releasing a failed verdict lets a later genuine verdict through', async () => {
     const g = makeGuard()
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 13, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: false })
+    await g.release({ callId: 'a1', succeeded: false })
     const retry = await g.guard({ callId: 'a2', workspace: WS, prNumber: 13, verdict: 'APPROVE' })
     expect(retry).toBeNull()
   })
@@ -119,7 +119,7 @@ describe('review verdict idempotency guard', () => {
   test('after a succeeded APPROVE the next attempt defers to the resolver, which blocks once GitHub reports APPROVED', async () => {
     const g = makeGuard({ [`${WS}#15`]: 'APPROVED' })
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 15, verdict: 'APPROVE' })
     expect(dup?.block).toBe(true)
   })
@@ -128,7 +128,7 @@ describe('review verdict idempotency guard', () => {
     // given: the first APPROVE landed and the in-flight lease was released
     const g = makeGuard({})
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 16, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     // when: GitHub's effective state has since moved off APPROVED (resolver defaults
     // to NONE) and a genuine re-approval fires — no headSha resolver, so the lag
     // shield cannot fire and GitHub stays authoritative
@@ -180,7 +180,7 @@ describe('review verdict idempotency guard', () => {
     clock += 5 * 60_000 + 1
     await g.guard({ callId: 'a2', workspace: WS, prNumber: 28, verdict: 'APPROVE' })
     // when: session 1's tool.after finally fires (stale)
-    g.release({ callId: 'a1', succeeded: false })
+    await g.release({ callId: 'a1', succeeded: false })
     // then: session 2 still holds the lease, so a third attempt is blocked
     const third = await g.guard({ callId: 'a3', workspace: WS, prNumber: 28, verdict: 'APPROVE' })
     expect(third?.block).toBe(true)
@@ -233,7 +233,7 @@ describe('review verdict idempotency guard', () => {
     // given: a first APPROVE landed and released, GitHub reviews read still stale (NONE)
     const g = makeShaGuard('sha-abc')
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 30, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     // when: a second engagement turn fires a fresh APPROVE on the same head
     const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 30, verdict: 'APPROVE' })
     // then: the lag shield resolves the NONE as a not-yet-indexed duplicate and blocks
@@ -248,7 +248,7 @@ describe('review verdict idempotency guard', () => {
     })
     let currentSha = 'sha-old'
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 31, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     // when: the author pushes a new commit and a re-review fires on the new head
     currentSha = 'sha-new'
     const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 31, verdict: 'APPROVE' })
@@ -259,15 +259,53 @@ describe('review verdict idempotency guard', () => {
   test('allows a flipped verdict on the same commit (APPROVE then REQUEST_CHANGES is a real supersession)', async () => {
     const g = makeShaGuard('sha-abc')
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 32, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     const flip = await g.guard({ callId: 'a2', workspace: WS, prNumber: 32, verdict: 'REQUEST_CHANGES' })
+    expect(flip).toBeNull()
+  })
+
+  test('push-during-review: head advances between guard and release, so the duplicate is still blocked on the new head', async () => {
+    // given: the head is sha-old when the review is authorized, but a push lands
+    // before the review does, so the post-submit re-resolve sees sha-new
+    let currentSha = 'sha-old'
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' }),
+      resolveHeadSha: async () => currentSha,
+    })
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 40, verdict: 'APPROVE' })
+    // when: the PR head advances before the successful submit is recorded
+    currentSha = 'sha-new'
+    await g.release({ callId: 'a1', succeeded: true })
+    // then: pre (sha-old) != post (sha-new), so the record stores the null
+    // uncertainty sentinel; a second same-verdict review on the current head is
+    // still caught as lag rather than slipping through on the SHA mismatch
+    const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 40, verdict: 'APPROVE' })
+    expect(dup?.block).toBe(true)
+  })
+
+  test('a genuine new push after the uncertain landing still allows a re-review once GitHub shows the prior review', async () => {
+    // given: an uncertain (null-head) landing, then GitHub catches up to APPROVED
+    let currentSha = 'sha-old'
+    let effective: EffectiveVerdict = 'NONE'
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective }),
+      resolveHeadSha: async () => currentSha,
+    })
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 41, verdict: 'APPROVE' })
+    currentSha = 'sha-new'
+    await g.release({ callId: 'a1', succeeded: true })
+    // when: GitHub now reports the standing APPROVED and the author asks for a
+    // re-review (REQUEST_CHANGES is a demotion) — layer 2 decides before the shield
+    effective = 'APPROVED'
+    const flip = await g.guard({ callId: 'a2', workspace: WS, prNumber: 41, verdict: 'REQUEST_CHANGES' })
+    // then: the demotion passes; the null-head shield never blocks a flipped verdict
     expect(flip).toBeNull()
   })
 
   test('a failed first verdict leaves no landed record, so a genuine retry passes', async () => {
     const g = makeShaGuard('sha-abc')
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 33, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: false })
+    await g.release({ callId: 'a1', succeeded: false })
     const retry = await g.guard({ callId: 'a2', workspace: WS, prNumber: 33, verdict: 'APPROVE' })
     expect(retry).toBeNull()
   })
@@ -276,7 +314,7 @@ describe('review verdict idempotency guard', () => {
     let clock = 1_000
     const g = makeShaGuard('sha-abc', () => clock)
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 34, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     clock += LAG_WINDOW_MS + 1
     // with the record expired and the resolver reporting NONE, a re-approve passes
     const after = await g.guard({ callId: 'a2', workspace: WS, prNumber: 34, verdict: 'APPROVE' })
@@ -287,7 +325,7 @@ describe('review verdict idempotency guard', () => {
     let clock = 1_000
     const g = makeShaGuard('sha-abc', () => clock)
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 39, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     clock += LAG_WINDOW_MS - 1
     const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 39, verdict: 'APPROVE' })
     expect(dup?.block).toBe(true)
@@ -301,7 +339,7 @@ describe('review verdict idempotency guard', () => {
     const instanceA = createApproveIdempotencyGuard(deps)
     const instanceB = createApproveIdempotencyGuard(deps)
     await instanceA.guard({ callId: 'a1', workspace: WS, prNumber: 35, verdict: 'APPROVE' })
-    instanceA.release({ callId: 'a1', succeeded: true })
+    await instanceA.release({ callId: 'a1', succeeded: true })
     const dup = await instanceB.guard({ callId: 'b1', workspace: WS, prNumber: 35, verdict: 'APPROVE' })
     expect(dup?.block).toBe(true)
   })
@@ -310,7 +348,7 @@ describe('review verdict idempotency guard', () => {
     // given: the head SHA could not be resolved on either attempt
     const g = makeShaGuard(null)
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 36, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     // when: a second same-verdict attempt arrives and GitHub reports NONE
     const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 36, verdict: 'APPROVE' })
     // then: with no resolvable head to prove same-commit lag, the lag shield does
@@ -326,7 +364,7 @@ describe('review verdict idempotency guard', () => {
     })
     // given: an APPROVE landed at sha-abc
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 37, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     // when: that approval is dismissed (GitHub now reports DISMISSED) and a
     // re-APPROVE on the SAME commit fires inside the lag window
     effective = 'DISMISSED'
@@ -343,7 +381,7 @@ describe('review verdict idempotency guard', () => {
       resolveHeadSha: async () => 'sha-abc',
     })
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 38, verdict: 'APPROVE' })
-    g.release({ callId: 'a1', succeeded: true })
+    await g.release({ callId: 'a1', succeeded: true })
     // GitHub now shows the standing APPROVED; a REQUEST_CHANGES is a demotion
     effective = 'APPROVED'
     const flip = await g.guard({ callId: 'a2', workspace: WS, prNumber: 38, verdict: 'REQUEST_CHANGES' })

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -124,14 +124,16 @@ describe('review verdict idempotency guard', () => {
     expect(dup?.block).toBe(true)
   })
 
-  test('a superseded approval no longer strands the bot: after a succeeded APPROVE is later demoted to CHANGES_REQUESTED, a re-APPROVE is allowed', async () => {
+  test('a superseded approval no longer strands the bot: after a succeeded APPROVE is later demoted to CHANGES_REQUESTED, a re-APPROVE is allowed (35287f99 invariant)', async () => {
     // given: the first APPROVE landed and the in-flight lease was released
-    const g = makeGuard()
+    const g = makeGuard({})
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 16, verdict: 'APPROVE' })
     g.release({ callId: 'a1', succeeded: true })
-    // when: GitHub's effective state has since moved off APPROVED (resolver defaults to NONE)
+    // when: GitHub's effective state has since moved off APPROVED (resolver defaults
+    // to NONE) and a genuine re-approval fires — no headSha resolver, so the lag
+    // shield cannot fire and GitHub stays authoritative
     const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 16, verdict: 'APPROVE' })
-    // then: no stale local lease blocks the genuine re-approval
+    // then: no stale local memory blocks the genuine re-approval
     expect(reapprove).toBeNull()
   })
 
@@ -212,5 +214,139 @@ describe('review verdict idempotency guard', () => {
     expect(first).toBeNull()
     const second = await g.guard({ callId: 'a2', workspace: WS, prNumber: 29, verdict: 'APPROVE' })
     expect(second?.block).toBe(true)
+  })
+
+  // The read-after-write-lag shield: a first verdict's lease is released (turn
+  // done) but GitHub's reviews read still lags, reporting NONE — the exact gap that
+  // landed two APPROVEs on PR #691. The resolver returns NONE so these exercise the
+  // raw-NONE path the shield is allowed to override.
+  const LAG_WINDOW_MS = 60_000
+  function makeShaGuard(headSha: string | null, now?: () => number) {
+    return createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' }),
+      resolveHeadSha: async () => headSha,
+      now,
+    })
+  }
+
+  test('blocks a second same-commit APPROVE inside the anti-lag window even when GitHub still reports NONE', async () => {
+    // given: a first APPROVE landed and released, GitHub reviews read still stale (NONE)
+    const g = makeShaGuard('sha-abc')
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 30, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    // when: a second engagement turn fires a fresh APPROVE on the same head
+    const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 30, verdict: 'APPROVE' })
+    // then: the lag shield resolves the NONE as a not-yet-indexed duplicate and blocks
+    expect(dup?.block).toBe(true)
+  })
+
+  test('allows a re-verdict on a NEW head SHA (a genuine re-review of a fresh push)', async () => {
+    // given: an APPROVE landed at one commit
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' }),
+      resolveHeadSha: async ({ prNumber }) => (prNumber === 31 ? currentSha : 'unused'),
+    })
+    let currentSha = 'sha-old'
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 31, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    // when: the author pushes a new commit and a re-review fires on the new head
+    currentSha = 'sha-new'
+    const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 31, verdict: 'APPROVE' })
+    // then: the new head misses the cache, so the genuine re-review is allowed
+    expect(reapprove).toBeNull()
+  })
+
+  test('allows a flipped verdict on the same commit (APPROVE then REQUEST_CHANGES is a real supersession)', async () => {
+    const g = makeShaGuard('sha-abc')
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 32, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    const flip = await g.guard({ callId: 'a2', workspace: WS, prNumber: 32, verdict: 'REQUEST_CHANGES' })
+    expect(flip).toBeNull()
+  })
+
+  test('a failed first verdict leaves no landed record, so a genuine retry passes', async () => {
+    const g = makeShaGuard('sha-abc')
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 33, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: false })
+    const retry = await g.guard({ callId: 'a2', workspace: WS, prNumber: 33, verdict: 'APPROVE' })
+    expect(retry).toBeNull()
+  })
+
+  test('the landed record expires after the anti-lag window so GitHub state retakes authority', async () => {
+    let clock = 1_000
+    const g = makeShaGuard('sha-abc', () => clock)
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 34, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    clock += LAG_WINDOW_MS + 1
+    // with the record expired and the resolver reporting NONE, a re-approve passes
+    const after = await g.guard({ callId: 'a2', workspace: WS, prNumber: 34, verdict: 'APPROVE' })
+    expect(after).toBeNull()
+  })
+
+  test('the lag shield still fires one tick before the window expires', async () => {
+    let clock = 1_000
+    const g = makeShaGuard('sha-abc', () => clock)
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 39, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    clock += LAG_WINDOW_MS - 1
+    const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 39, verdict: 'APPROVE' })
+    expect(dup?.block).toBe(true)
+  })
+
+  test('the landed cache is process-wide: a second plugin instance sees the first instance landed verdict', async () => {
+    const deps = {
+      resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' as EffectiveVerdict }),
+      resolveHeadSha: async () => 'sha-abc',
+    }
+    const instanceA = createApproveIdempotencyGuard(deps)
+    const instanceB = createApproveIdempotencyGuard(deps)
+    await instanceA.guard({ callId: 'a1', workspace: WS, prNumber: 35, verdict: 'APPROVE' })
+    instanceA.release({ callId: 'a1', succeeded: true })
+    const dup = await instanceB.guard({ callId: 'b1', workspace: WS, prNumber: 35, verdict: 'APPROVE' })
+    expect(dup?.block).toBe(true)
+  })
+
+  test('fails open to GitHub when the head SHA is unknown (resolver null) so a supersession is never blocked on local memory', async () => {
+    // given: the head SHA could not be resolved on either attempt
+    const g = makeShaGuard(null)
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 36, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    // when: a second same-verdict attempt arrives and GitHub reports NONE
+    const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 36, verdict: 'APPROVE' })
+    // then: with no resolvable head to prove same-commit lag, the lag shield does
+    // NOT fire — GitHub stays authoritative, preserving the supersession invariant
+    expect(dup).toBeNull()
+  })
+
+  test('a genuine DISMISSED is not treated as lag: a same-commit re-APPROVE within the window is allowed (no 35287f99 regression)', async () => {
+    let effective: EffectiveVerdict = 'NONE'
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective }),
+      resolveHeadSha: async () => 'sha-abc',
+    })
+    // given: an APPROVE landed at sha-abc
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 37, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    // when: that approval is dismissed (GitHub now reports DISMISSED) and a
+    // re-APPROVE on the SAME commit fires inside the lag window
+    effective = 'DISMISSED'
+    const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 37, verdict: 'APPROVE' })
+    // then: DISMISSED is decisive, not a bare NONE, so the lag shield is bypassed
+    // and the genuine re-approval is allowed
+    expect(reapprove).toBeNull()
+  })
+
+  test('a flipped verdict on the same commit is allowed even while GitHub still reports the prior standing verdict', async () => {
+    let effective: EffectiveVerdict = 'NONE'
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective }),
+      resolveHeadSha: async () => 'sha-abc',
+    })
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 38, verdict: 'APPROVE' })
+    g.release({ callId: 'a1', succeeded: true })
+    // GitHub now shows the standing APPROVED; a REQUEST_CHANGES is a demotion
+    effective = 'APPROVED'
+    const flip = await g.guard({ callId: 'a2', workspace: WS, prNumber: 38, verdict: 'REQUEST_CHANGES' })
+    expect(flip).toBeNull()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -1,13 +1,24 @@
 import type { ReviewVerdict } from '@/channels/github-review-turn-ledger'
 
-// `NONE` covers "never reviewed" and "last decisive review was DISMISSED" — both
-// mean a fresh verdict is legitimate (not a duplicate).
-export type EffectiveVerdict = 'APPROVED' | 'CHANGES_REQUESTED' | 'NONE'
+// Raw latest-decisive state. DISMISSED is kept DISTINCT from NONE on purpose: a
+// genuine dismissal means a fresh same-verdict re-review is legitimate and must
+// NOT be shadowed by the read-after-write-lag cache (which only overrides a bare
+// NONE — "GitHub shows no decisive review, but we just landed one"). Collapsing
+// DISMISSED into NONE would let the lag cache re-strand a dismiss-then-reapprove,
+// the exact failure 35287f99 removed.
+export type EffectiveVerdict = 'APPROVED' | 'CHANGES_REQUESTED' | 'DISMISSED' | 'NONE'
 
 export type EffectiveApprovalResolver = (target: {
   workspace: string
   prNumber: number
 }) => Promise<{ ok: true; effective: EffectiveVerdict } | { ok: false }>
+
+// Resolves the PR's current head commit SHA. The landed-verdict cache keys on it
+// so a genuine re-verdict on a NEW push is allowed while a same-commit duplicate
+// is blocked. Resolved AFTER the in-flight lease is acquired, so the await does
+// not widen the reserve-before-await race. Fails soft (null) — an unresolved SHA
+// degrades the cache to verdict-only matching, never strands a genuine verdict.
+export type HeadShaResolver = (target: { workspace: string; prNumber: number }) => Promise<string | null>
 
 export type ApproveBlock = { block: true; reason: string }
 
@@ -55,7 +66,21 @@ function duplicatesStanding(verdict: ReviewVerdict, effective: EffectiveVerdict)
 // never strand a PR for long.
 const LEASE_TTL_MS = 5 * 60_000
 
-type Reservation = { key: string; token: number; createdAt: number }
+// How long a just-landed verdict is trusted to explain a GitHub `NONE` as
+// read-after-write lag rather than a genuine absence. GitHub's `/pulls/<n>/reviews`
+// list lags a write by up to ~10s, so a second engagement turn firing in that
+// window reads NONE and would land a duplicate. Observed duplicates were ~10-18s
+// apart; 60s is a comfortable lag margin without making a legitimate re-verdict
+// wait long. This window only shadows a raw NONE on the SAME verdict + SAME head —
+// a DISMISSED/CHANGES_REQUESTED/flipped-verdict/new-head all bypass it.
+const RECENT_LANDED_TTL_MS = 60_000
+
+type Reservation = { key: string; token: number; createdAt: number; headSha: string | null; verdict: ReviewVerdict }
+
+// headSha is REQUIRED (never null): the cache is written only when the head was
+// resolved, so a same-head equality check is always meaningful. An unresolved
+// head skips the write entirely rather than storing a null that could never match.
+type LandedVerdict = { verdict: ReviewVerdict; headSha: string; landedAt: number }
 
 // MODULE-LEVEL singletons, shared by every plugin instance in this process. The
 // github-cli-auth plugin's `plugin: async (ctx) => ...` factory may run once per
@@ -65,10 +90,11 @@ type Reservation = { key: string; token: number; createdAt: number }
 // three sessions each landed an APPROVE on the same PR within ten seconds.
 const inFlightByPr = new Map<string, Reservation>()
 const reservationByCall = new Map<string, Reservation>()
+const recentLandedByPr = new Map<string, LandedVerdict>()
 let tokenSeq = 0
 
 // Makes a formal `gh ... event=APPROVE|REQUEST_CHANGES` idempotent per PR across
-// turns, sessions, and (in-process) concurrent fan-out. Two layers:
+// turns, sessions, and (in-process) concurrent fan-out. Three layers, in order:
 //
 //   1. A process-wide in-flight lease keyed by `workspace#prNumber`, held from
 //      tool.before through tool.after. While one verdict is mid-flight, every
@@ -77,12 +103,22 @@ let tokenSeq = 0
 //      closure-local Set could not provide: separate plugin instances meant
 //      separate Sets, so concurrent sessions never saw each other.
 //
-//   2. The authoritative GitHub effective-state read, consulted AFTER the lease
-//      is acquired. It catches the cross-restart case (lease lost) and tracks
-//      supersession: a later CHANGES_REQUESTED/DISMISSED demotes an earlier
-//      APPROVED, so a genuine re-verdict is allowed. Reads fail OPEN — a
-//      transient error must never strand a genuine first verdict; the lease
-//      still covers the concurrent case while the command runs.
+//   2. The authoritative GitHub effective-state read, consulted AFTER the lease.
+//      It is the SOLE source of truth for a standing verdict and for supersession:
+//      a later CHANGES_REQUESTED/DISMISSED demotes an earlier APPROVED, so a
+//      genuine re-verdict is allowed (the 35287f99 invariant — never block a
+//      re-verdict on stale LOCAL memory). A standing same verdict blocks; DISMISSED
+//      and the opposite decisive verdict pass. Reads fail OPEN.
+//
+//   3. A read-after-write-lag shield, consulted ONLY when layer 2 returns a raw
+//      NONE. The lease (layer 1) covers two OVERLAPPING in-flight commands, but a
+//      second engagement turn ~10s later starts after the first's lease released,
+//      and GitHub's reviews list still lags the write (reports NONE). A short-lived
+//      `recentLandedByPr` record — same verdict + same head, written on a succeeded
+//      release, RECENT_LANDED_TTL_MS — disambiguates "NONE because lag" from "NONE
+//      because genuinely absent": only the former blocks. Because it fires after a
+//      raw NONE, a real DISMISSED/CHANGES_REQUESTED already allowed the re-verdict
+//      at layer 2, so this cannot re-strand a supersession.
 //
 // The lease is released only in release() (tool.after) or on a terminal block,
 // never after the remote read — releasing early reopens the TOCTOU the lease
@@ -90,6 +126,7 @@ let tokenSeq = 0
 // tool.after for a superseded reservation cannot drop a newer session's lease.
 export function createApproveIdempotencyGuard(deps: {
   resolveEffectiveApproval: EffectiveApprovalResolver
+  resolveHeadSha?: HeadShaResolver
   now?: () => number
 }): ReviewVerdictGuard {
   const now = deps.now ?? Date.now
@@ -107,10 +144,25 @@ export function createApproveIdempotencyGuard(deps: {
       if (held !== undefined && now() - held.createdAt < LEASE_TTL_MS) {
         return { block: true, reason: CONCURRENT_REASON }
       }
-      const reservation: Reservation = { key, token: ++tokenSeq, createdAt: now() }
+      const reservation: Reservation = {
+        key,
+        token: ++tokenSeq,
+        createdAt: now(),
+        headSha: null,
+        verdict: args.verdict,
+      }
       inFlightByPr.set(key, reservation)
       reservationByCall.set(args.callId, reservation)
 
+      // Resolve the head SHA only AFTER the lease is held, so this await cannot
+      // widen the reserve-before-await race the lease closes above.
+      const headSha = (await deps.resolveHeadSha?.({ workspace: args.workspace, prNumber: args.prNumber })) ?? null
+      reservation.headSha = headSha
+
+      // Layer 2: GitHub is the authoritative, sole source of truth for a standing
+      // verdict. A standing same verdict is a real duplicate; DISMISSED and the
+      // opposite decisive verdict are genuine supersessions that must pass here
+      // (the 35287f99 invariant). A read error fails OPEN.
       const remote = await deps.resolveEffectiveApproval({ workspace: args.workspace, prNumber: args.prNumber })
       if (remote.ok && duplicatesStanding(args.verdict, remote.effective)) {
         // Standing verdict upstream already matches. Block, and release the lease
@@ -121,15 +173,44 @@ export function createApproveIdempotencyGuard(deps: {
         return { block: true, reason: duplicateReason(args.verdict) }
       }
 
+      // Layer 3: only a raw NONE from a successful read is ambiguous — it can mean
+      // "no review" or "our just-landed review not yet indexed". A recent same
+      // verdict on the same head resolves it to lag and blocks the duplicate. Any
+      // non-NONE state already decided above, so this never overrides a supersession.
+      if (remote.ok && remote.effective === 'NONE' && recentlyLandedSame(key, args.verdict, headSha, now)) {
+        releaseReservation(args.callId, reservation)
+        return { block: true, reason: duplicateReason(args.verdict) }
+      }
+
       return null
     },
 
     release(args): void {
       const reservation = reservationByCall.get(args.callId)
       if (reservation === undefined) return
+      // Record only when the head was resolved: an unresolved head cannot key a
+      // same-head lag check, so storing it would either never match or force a
+      // verdict-only block that regresses the supersession invariant.
+      if (args.succeeded && reservation.headSha !== null) {
+        recentLandedByPr.set(reservation.key, {
+          verdict: reservation.verdict,
+          headSha: reservation.headSha,
+          landedAt: now(),
+        })
+      }
       releaseReservation(args.callId, reservation)
     },
   }
+}
+
+// True only when a recently-landed record proves the GitHub NONE is read lag: same
+// verdict, same head, within the lag window. A flipped verdict, a new head, or an
+// expired/absent record all return false so the genuine re-verdict passes.
+function recentlyLandedSame(key: string, verdict: ReviewVerdict, headSha: string | null, now: () => number): boolean {
+  const landed = recentLandedByPr.get(key)
+  if (landed === undefined) return false
+  if (now() - landed.landedAt >= RECENT_LANDED_TTL_MS) return false
+  return verdict === landed.verdict && headSha !== null && headSha === landed.headSha
 }
 
 // Drop the lease only if THIS reservation still owns the key. A stale tool.after
@@ -151,5 +232,6 @@ function prKey(workspace: string, prNumber: number): string {
 export function __resetReviewVerdictGuardForTest(): void {
   inFlightByPr.clear()
   reservationByCall.clear()
+  recentLandedByPr.clear()
   tokenSeq = 0
 }

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -13,11 +13,14 @@ export type EffectiveApprovalResolver = (target: {
   prNumber: number
 }) => Promise<{ ok: true; effective: EffectiveVerdict } | { ok: false }>
 
-// Resolves the PR's current head commit SHA. The landed-verdict cache keys on it
-// so a genuine re-verdict on a NEW push is allowed while a same-commit duplicate
-// is blocked. Resolved AFTER the in-flight lease is acquired, so the await does
-// not widen the reserve-before-await race. Fails soft (null) — an unresolved SHA
-// degrades the cache to verdict-only matching, never strands a genuine verdict.
+// Resolves the PR's current head commit SHA. Called twice: once in guard() (the
+// pre-submit head, resolved AFTER the in-flight lease so the await cannot widen the
+// reserve-before-await race) and once in release() (the post-submit head, to detect
+// a push that landed during the review). Fails soft (null). A null PRE-submit head
+// skips the cache write entirely — the guard falls open to GitHub rather than ever
+// stranding a genuine verdict on local memory. A null POST-submit head (or one that
+// differs from the pre-submit head) is recorded as the uncertainty sentinel so a
+// push-during-review still blocks a same-verdict duplicate for the lag window.
 export type HeadShaResolver = (target: { workspace: string; prNumber: number }) => Promise<string | null>
 
 export type ApproveBlock = { block: true; reason: string }
@@ -29,7 +32,7 @@ export type ReviewVerdictGuard = {
     prNumber: number
     verdict: ReviewVerdict
   }) => Promise<ApproveBlock | null>
-  release: (args: { callId: string; succeeded: boolean }) => void
+  release: (args: { callId: string; succeeded: boolean }) => Promise<void>
 }
 
 // Back-compat alias: the guard now covers REQUEST_CHANGES too, not just APPROVE.
@@ -71,16 +74,27 @@ const LEASE_TTL_MS = 5 * 60_000
 // list lags a write by up to ~10s, so a second engagement turn firing in that
 // window reads NONE and would land a duplicate. Observed duplicates were ~10-18s
 // apart; 60s is a comfortable lag margin without making a legitimate re-verdict
-// wait long. This window only shadows a raw NONE on the SAME verdict + SAME head —
-// a DISMISSED/CHANGES_REQUESTED/flipped-verdict/new-head all bypass it.
+// wait long. This window only shadows a raw NONE on the SAME verdict (+ same or
+// uncertain head) — a DISMISSED/CHANGES_REQUESTED/flipped-verdict all bypass it.
 const RECENT_LANDED_TTL_MS = 60_000
 
-type Reservation = { key: string; token: number; createdAt: number; headSha: string | null; verdict: ReviewVerdict }
+type Reservation = {
+  key: string
+  token: number
+  createdAt: number
+  headSha: string | null
+  verdict: ReviewVerdict
+  workspace: string
+  prNumber: number
+}
 
-// headSha is REQUIRED (never null): the cache is written only when the head was
-// resolved, so a same-head equality check is always meaningful. An unresolved
-// head skips the write entirely rather than storing a null that could never match.
-type LandedVerdict = { verdict: ReviewVerdict; headSha: string; landedAt: number }
+// headSha === null is the UNCERTAINTY sentinel: the command succeeded but the head
+// the review actually attached to is unknown (the PR head advanced between the
+// pre-submit capture and the write, or the post-submit re-resolve failed). A null
+// record matches any current head for the window — same verdict + raw NONE only —
+// so a push-during-review cannot let a same-verdict duplicate slip past on the new
+// head. A resolved string keys precise same-head matching for the normal case.
+type LandedVerdict = { verdict: ReviewVerdict; headSha: string | null; landedAt: number }
 
 // MODULE-LEVEL singletons, shared by every plugin instance in this process. The
 // github-cli-auth plugin's `plugin: async (ctx) => ...` factory may run once per
@@ -114,11 +128,14 @@ let tokenSeq = 0
 //      NONE. The lease (layer 1) covers two OVERLAPPING in-flight commands, but a
 //      second engagement turn ~10s later starts after the first's lease released,
 //      and GitHub's reviews list still lags the write (reports NONE). A short-lived
-//      `recentLandedByPr` record — same verdict + same head, written on a succeeded
-//      release, RECENT_LANDED_TTL_MS — disambiguates "NONE because lag" from "NONE
-//      because genuinely absent": only the former blocks. Because it fires after a
-//      raw NONE, a real DISMISSED/CHANGES_REQUESTED already allowed the re-verdict
-//      at layer 2, so this cannot re-strand a supersession.
+//      `recentLandedByPr` record — same verdict + (same OR uncertain head), written
+//      on a succeeded release, RECENT_LANDED_TTL_MS — disambiguates "NONE because
+//      lag" from "NONE because genuinely absent": only the former blocks. The head
+//      is re-resolved at release time; if the PR head advanced during the submit the
+//      record stores a null head (uncertainty), which matches the current head so a
+//      push-during-review cannot leak a duplicate. Because it fires after a raw
+//      NONE, a real DISMISSED/CHANGES_REQUESTED already allowed the re-verdict at
+//      layer 2, so this cannot re-strand a supersession.
 //
 // The lease is released only in release() (tool.after) or on a terminal block,
 // never after the remote read — releasing early reopens the TOCTOU the lease
@@ -150,6 +167,8 @@ export function createApproveIdempotencyGuard(deps: {
         createdAt: now(),
         headSha: null,
         verdict: args.verdict,
+        workspace: args.workspace,
+        prNumber: args.prNumber,
       }
       inFlightByPr.set(key, reservation)
       reservationByCall.set(args.callId, reservation)
@@ -185,32 +204,48 @@ export function createApproveIdempotencyGuard(deps: {
       return null
     },
 
-    release(args): void {
+    async release(args): Promise<void> {
       const reservation = reservationByCall.get(args.callId)
       if (reservation === undefined) return
-      // Record only when the head was resolved: an unresolved head cannot key a
-      // same-head lag check, so storing it would either never match or force a
-      // verdict-only block that regresses the supersession invariant.
-      if (args.succeeded && reservation.headSha !== null) {
-        recentLandedByPr.set(reservation.key, {
-          verdict: reservation.verdict,
-          headSha: reservation.headSha,
-          landedAt: now(),
-        })
+      try {
+        // The pre-submit head can go stale: if the PR head advanced between the
+        // guard() capture and the review landing, GitHub attaches the review to the
+        // NEWER head while reservation.headSha holds the older one. Re-resolve the
+        // head AFTER a successful submit and store what we can prove: the resolved
+        // head only when pre==post, else the null uncertainty sentinel (matches any
+        // current head for the lag window) so a push-during-review cannot let a
+        // same-verdict duplicate slip past on the new head. The lease stays held
+        // across this await (finally below), so the window is not reopened.
+        if (args.succeeded && reservation.headSha !== null) {
+          const postHeadSha =
+            (await deps.resolveHeadSha?.({ workspace: reservation.workspace, prNumber: reservation.prNumber })) ?? null
+          const landedHeadSha = postHeadSha !== null && postHeadSha === reservation.headSha ? postHeadSha : null
+          recentLandedByPr.set(reservation.key, {
+            verdict: reservation.verdict,
+            headSha: landedHeadSha,
+            landedAt: now(),
+          })
+        }
+      } finally {
+        releaseReservation(args.callId, reservation)
       }
-      releaseReservation(args.callId, reservation)
     },
   }
 }
 
 // True only when a recently-landed record proves the GitHub NONE is read lag: same
-// verdict, same head, within the lag window. A flipped verdict, a new head, or an
-// expired/absent record all return false so the genuine re-verdict passes.
+// verdict, within the window, AND the heads agree. Head agreement holds when the
+// stored head equals the current head, OR the stored head is the null uncertainty
+// sentinel (the landed commit could not be pinned, so it conservatively matches the
+// current head for the window). A flipped verdict or an expired/absent record
+// returns false so the genuine re-verdict passes; a different KNOWN head also
+// returns false so a real new push is never blocked.
 function recentlyLandedSame(key: string, verdict: ReviewVerdict, headSha: string | null, now: () => number): boolean {
   const landed = recentLandedByPr.get(key)
   if (landed === undefined) return false
   if (now() - landed.landedAt >= RECENT_LANDED_TTL_MS) return false
-  return verdict === landed.verdict && headSha !== null && headSha === landed.headSha
+  if (verdict !== landed.verdict) return false
+  return landed.headSha === null || landed.headSha === headSha
 }
 
 // Drop the lease only if THIS reservation still owns the key. A stale tool.after

--- a/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { createGithubEffectiveApprovalResolver } from './effective-approval'
+import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
 
 const WS = 'acme/widgets'
 
@@ -135,5 +135,39 @@ describe('github effective-approval resolver', () => {
       fetchImpl: fetchStub({}),
     })
     expect(await resolve({ workspace: WS, prNumber: 11 })).toEqual({ ok: false })
+  })
+})
+
+describe('github head-sha resolver', () => {
+  test('returns head.sha from the single-PR endpoint', async () => {
+    const resolve = createGithubHeadShaResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({ '/pulls/5': jsonResponse({ head: { sha: 'deadbeef' } }) }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 5 })).toBe('deadbeef')
+  })
+
+  test('returns null on a non-ok response so the cache degrades rather than strands', async () => {
+    const resolve = createGithubHeadShaResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({ '/pulls/6': new Response('boom', { status: 500 }) }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 6 })).toBeNull()
+  })
+
+  test('returns null when no token is available', async () => {
+    const resolve = createGithubHeadShaResolver({
+      resolveToken: async () => null,
+      fetchImpl: fetchStub({}),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 7 })).toBeNull()
+  })
+
+  test('returns null when head.sha is missing or malformed', async () => {
+    const resolve = createGithubHeadShaResolver({
+      resolveToken: async () => 'tok',
+      fetchImpl: fetchStub({ '/pulls/8': jsonResponse({ head: {} }) }),
+    })
+    expect(await resolve({ workspace: WS, prNumber: 8 })).toBeNull()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/effective-approval.ts
+++ b/src/bundled-plugins/github-cli-auth/effective-approval.ts
@@ -1,6 +1,6 @@
 import { GITHUB_API_BASE, githubJsonHeaders } from '@/channels/adapters/github/auth-pat'
 
-import type { EffectiveApprovalResolver, EffectiveVerdict } from './approve-idempotency'
+import type { EffectiveApprovalResolver, EffectiveVerdict, HeadShaResolver } from './approve-idempotency'
 
 // Resolves THIS bot's standing decisive review on a PR, used by the review
 // verdict guard to stop a second formal verdict after a restart (the in-process
@@ -30,9 +30,40 @@ export function createGithubEffectiveApprovalResolver(deps: {
   }
 }
 
+// Reads the PR's current head commit SHA from `GET /pulls/<n>` (`head.sha`), the
+// strongly-consistent single-object endpoint — NOT the eventually-consistent
+// reviews list the duplicate bug rode in on. Returns null on any failure so the
+// landed-verdict cache degrades to verdict-only matching rather than stranding.
+export function createGithubHeadShaResolver(deps: {
+  resolveToken: (workspace: string) => Promise<string | null>
+  fetchImpl?: typeof fetch
+}): HeadShaResolver {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  return async ({ workspace, prNumber }) => {
+    const [owner, repo] = workspace.split('/')
+    if (owner === undefined || owner === '' || repo === undefined || repo === '') return null
+    const token = await deps.resolveToken(workspace).catch(() => null)
+    if (token === null || token === '') return null
+    try {
+      const url = `${GITHUB_API_BASE}/repos/${owner}/${repo}/pulls/${prNumber}`
+      const response = await fetchImpl(url, { headers: githubJsonHeaders(token) })
+      if (!response.ok) return null
+      const raw = (await response.json().catch(() => null)) as { head?: { sha?: unknown } } | null
+      const sha = raw?.head?.sha
+      return typeof sha === 'string' && sha !== '' ? sha : null
+    } catch {
+      return null
+    }
+  }
+}
+
+// DISMISSED is surfaced distinctly (not collapsed to NONE) so the verdict guard's
+// lag shield can tell a genuine dismissal — which legitimately allows a same-verdict
+// re-review — apart from a bare NONE that may just be an unindexed just-landed write.
 function toEffective(state: string | undefined): EffectiveVerdict {
   if (state === 'APPROVED') return 'APPROVED'
   if (state === 'CHANGES_REQUESTED') return 'CHANGES_REQUESTED'
+  if (state === 'DISMISSED') return 'DISMISSED'
   return 'NONE'
 }
 

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -2,7 +2,7 @@ import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
 import { definePlugin } from '@/plugin'
 
 import { createApproveIdempotencyGuard } from './approve-idempotency'
-import { createGithubEffectiveApprovalResolver } from './effective-approval'
+import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
 import { analyzeGhCommand } from './gh-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
@@ -11,13 +11,13 @@ import { classifyGhToken } from './token-class'
 export default definePlugin({
   plugin: async (ctx) => {
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
+    const resolveToken = async (workspace: string) => {
+      const result = await resolveTokenForRepo(workspace)
+      return result.kind === 'token' ? result.token : null
+    }
     const verdictGuard = createApproveIdempotencyGuard({
-      resolveEffectiveApproval: createGithubEffectiveApprovalResolver({
-        resolveToken: async (workspace) => {
-          const result = await resolveTokenForRepo(workspace)
-          return result.kind === 'token' ? result.token : null
-        },
-      }),
+      resolveEffectiveApproval: createGithubEffectiveApprovalResolver({ resolveToken }),
+      resolveHeadSha: createGithubHeadShaResolver({ resolveToken }),
     })
     return {
       hooks: {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -70,7 +70,7 @@ export default definePlugin({
             callId: event.callId,
             result: event.result,
           })
-          verdictGuard.release({ callId: event.callId, succeeded: committed })
+          await verdictGuard.release({ callId: event.callId, succeeded: committed })
         },
       },
     }


### PR DESCRIPTION
## What & why

While auditing the reviewer-subagent flow (#689, #691) I found the bot landing **two formal `APPROVED` reviews on the same commit, ~10–18s apart** — twice on a single PR. The review-verdict idempotency guard (`approve-idempotency.ts`) is meant to make a formal verdict idempotent per PR, but it had a window it could not close.

### The hole

The guard had two layers:

1. **Process-wide in-flight lease** keyed by `workspace#pr`, held only from `tool.before` to `tool.after` of *one* `gh` review command.
2. **Authoritative GitHub effective-state read** (`/pulls/<n>/reviews`).

The first verdict's lease is released the moment its `gh api` returns (end of turn 1). A **second engagement turn ~10s later** is past the lease, leaving only layer 2 — and GitHub's reviews list **lags a write by up to ~10s** (read-after-write replication). Inside that window the read returns `NONE`, both layers miss, and the second `APPROVE` lands.

Live evidence:

```
12:28:14 APPROVED  commit 07db4ab2  "Looks good — the two policy gaps are closed"
12:28:24 APPROVED  commit 07db4ab2  "Thanks — that resolves it for me"      <-- duplicate, +10s
12:41:59 APPROVED  commit 4f88af3c  "Verified the newline-separator fix"
12:42:17 APPROVED  commit 4f88af3c  "The previous blockers are resolved"    <-- duplicate, +18s
```

## The fix — and why it does NOT regress the prior fixes

This guard has a **history** I deliberately preserved (`git log` on the file): `3ed26acf` (original), `4be374ee` (TOCTOU reserve-before-await), `98f6adb2` (latest *decisive* review), **`35287f99` (removed a persistent local "already approved" memory because it *stranded* genuine re-approvals once GitHub state was superseded — declaring the GitHub read the SOLE source of truth)**, and `e92ddbab` (module-level lease for concurrent fan-out).

A naive "remember I already approved" cache would re-introduce exactly the bug `35287f99` removed. So the fix is ordered to keep GitHub authoritative:

1. **in-flight lease** (concurrent fan-out) — unchanged.
2. **GitHub effective-state read** — the **sole source of truth** for a standing verdict and supersession. A standing same verdict blocks; `DISMISSED` and the opposite decisive verdict **pass** (the `35287f99` invariant: never block a genuine re-verdict on stale local memory).
3. **Read-after-write-lag shield** — consulted **only when layer 2 returns a raw `NONE`**. A short-lived `recentLandedByPr` record (same verdict **+ same head SHA**, 60s) disambiguates *"NONE because read lag"* from *"NONE because genuinely absent"*. Only the former blocks.

Why this is safe against `35287f99`:

- A real dismissal surfaces as **`DISMISSED`** (now kept **distinct from `NONE`** in `effective-approval.ts`), so a same-commit **dismiss-then-reapprove** is allowed — layer 2 clears it before the shield runs.
- A **flipped verdict** (`APPROVE`→`REQUEST_CHANGES`) or a **new head SHA** bypass the shield (genuine re-verdicts).
- An **unresolved head SHA fails OPEN** to GitHub rather than broadening a local block.
- The shield only ever *resolves an ambiguous `NONE`*; it never overrides a decisive GitHub state.

### Implementation notes

- Head SHA from the **strongly-consistent `GET /pulls/<n>`** (`head.sha`), not the lagging reviews list. Resolved **after** the lease is held so its `await` can't widen the reserve race.
- `effective-approval.ts` now surfaces `DISMISSED` distinctly from `NONE`; `duplicatesStanding` is unchanged (only `APPROVED`/`CHANGES_REQUESTED` count as a standing duplicate).

## Tests

`approve-idempotency.test.ts` + `effective-approval.test.ts`:

- lag shield blocks a same-commit duplicate on raw `NONE` (the regression)
- **`DISMISSED` then re-`APPROVE` on the same commit is allowed** (no `35287f99` regression)
- flipped verdict on the same commit allowed even while GitHub still shows the prior standing verdict
- re-verdict on a **new head SHA** allowed (fresh push)
- **unresolved head SHA fails open** to GitHub (does not block)
- window boundary: shield fires at TTL−1, expires at TTL+1
- the original `35287f99` "superseded approval no longer strands the bot" test is **restored to immediate re-approval allowed** (the lag shield can't fire without a resolvable head)
- process-wide cache sharing; head-SHA resolver returns `head.sha` and fails soft to `null` on non-ok / no-token / malformed

## Checks

`bun run typecheck` clean · `bun run lint` 0 errors (66 pre-existing warnings in `dockerfile.ts`, untouched) · `bun run format` clean · `github-cli-auth` suite (148) + `reviewer`/ledger/false-receipt/rereview-guard suites (109) green.

## Context

Follow-up to the reviewer-subagent audit (#689, #691). This fixes a runtime idempotency hole the audit surfaced, layered so it preserves every prior fix in this file's history — especially `35287f99`'s "GitHub is the sole source of truth for supersession" invariant.