### PR TITLE
fix(docs): derive landing-page version badge from root package.json

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .source
+
+# generated at build time from the root package.json
+/src/generated

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "gen:version": "bun run scripts/gen-version.ts",
+    "predev": "bun run gen:version",
     "dev": "next dev",
+    "prebuild": "bun run gen:version",
     "build": "next build",
     "start": "next start",
     "lint": "oxlint",

--- a/docs/scripts/gen-version.ts
+++ b/docs/scripts/gen-version.ts
@@ -1,0 +1,16 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+// The docs site builds with turbopack.root pinned to docs/, so page code cannot
+// import the repo-root package.json directly. This prebuild step copies the root
+// version into a generated module the landing page reads, keeping the badge in
+// sync with every release without a manual edit.
+const rootPackageJson = path.resolve(import.meta.dirname, '../../package.json')
+const outFile = path.resolve(import.meta.dirname, '../src/generated/version.ts')
+
+const { version } = (await import(rootPackageJson, { with: { type: 'json' } })).default as {
+  version: string
+}
+
+mkdirSync(path.dirname(outFile), { recursive: true })
+writeFileSync(outFile, `export const TYPECLAW_VERSION = '${version}'\n`)

--- a/docs/src/app/_components/data.ts
+++ b/docs/src/app/_components/data.ts
@@ -1,4 +1,8 @@
+import { TYPECLAW_VERSION } from '../../generated/version'
+
 export const INSTALL_COMMAND = 'bun add -g typeclaw'
+
+export const VERSION = `v${TYPECLAW_VERSION}`
 
 export interface Feature {
   title: string

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -20,7 +20,7 @@ import Link from 'next/link'
 import { AnimatedTerminal } from './_components/animated-terminal'
 import { CHANNELS } from './_components/channel-icons'
 import { CopyButton } from './_components/copy-button'
-import { COMPETITORS, INSTALL_COMMAND, MEMORY_LOOP } from './_components/data'
+import { COMPETITORS, INSTALL_COMMAND, MEMORY_LOOP, VERSION } from './_components/data'
 import { ThemeToggle } from './_components/theme-toggle'
 import { UseCaseTabs } from './_components/use-case-tabs'
 
@@ -330,7 +330,7 @@ export default function Home() {
             </div>
             typeclaw
             <span className="ml-1 rounded-md bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] text-zinc-500 dark:bg-white/[0.06] dark:text-zinc-400">
-              v0.11
+              {VERSION}
             </span>
           </Link>
           <div className="flex items-center gap-1 sm:gap-2">
@@ -359,7 +359,7 @@ export default function Home() {
           <div className="relative z-10 mx-auto max-w-4xl px-6 pt-24 pb-20 text-center sm:pt-32">
             <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white/60 px-3 py-1 text-xs font-medium text-zinc-600 backdrop-blur dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-zinc-400">
               <Sparkles className="size-3.5 text-brand-600 dark:text-brand-300" strokeWidth={2.4} aria-hidden />
-              v0.11 · TypeScript agent runtime
+              {VERSION} · TypeScript agent runtime
             </div>
             <div className="relative mt-8">
               <Image


### PR DESCRIPTION
## Problem

The typeclaw.dev landing page hardcoded `v0.11` in two spots — the nav badge and the hero pill ("v0.11 · TypeScript agent runtime") — while the published package is 0.31.0. The badge had drifted across many releases because nothing tied it to the real version.

## Root cause

Naively importing the root `package.json` from inside `docs/` does not work. The docs site sets `turbopack.root` to `docs/` in `next.config.ts`, so the Next.js/Turbopack bundler treats `docs/` as the project root and rejects module references that cross that boundary. An earlier attempt failed the build with:

```
Module not found: Can't resolve '../../../../package.json'
```

A constant in `data.ts` avoids the build failure but still requires a manual edit per release — the root cause of the drift.

## Fix

A prebuild generator closes the loop without crossing the Turbopack boundary:

- `docs/scripts/gen-version.ts` — new script that reads the root `package.json` and writes `docs/src/generated/version.ts` exporting `TYPECLAW_VERSION`.
- `docs/package.json` — adds `gen:version`, `predev`, and `prebuild` npm scripts so the generated file is always up-to-date before a dev server start or production build.
- `docs/.gitignore` — ignores `/src/generated` (generated at build time, not source-tracked).
- `docs/src/app/_components/data.ts` — imports `TYPECLAW_VERSION` from the generated file and re-exports it as `VERSION`.
- `docs/src/app/page.tsx` — replaces both `v0.11` literals with `{VERSION}`.

The release workflow already commits the bumped root `package.json` to `main`, and the docs site (Vercel) rebuilds on push — so the badge tracks every release automatically with zero manual steps.

## Verification

All checks run against the final commit:

- `bun run build` (docs) — after deleting `src/generated/`, prebuild regenerated it, build succeeded, all 54 pages prerendered. Confirmed `v0.31.0` appears in the rendered output end-to-end.
- `bun run lint` (docs) — pre-existing unused-import warnings only (PenTool, User, Users); none introduced.
- `bun run format:check` (docs) — clean.
- `bun run typecheck` (root) — pass.
- `bun run lint` (root) — 0 errors (66 pre-existing warnings in `src/` shell-policy code, unrelated).
- `bun run format:check` (root) — clean.
- `bun run test` (root) — 7828 pass, 1 skip, 0 fail.