### PR TITLE
feat(agent): default researcher reports to PDF on attachment-capable channels

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -257,6 +257,40 @@ describe('renderSessionOrigin', () => {
     },
   )
 
+  test.each(['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk'] as const)(
+    'attachment-capable channel origin (%s) defaults researcher reports to a PDF attachment',
+    (adapter) => {
+      const out = renderSessionOrigin({
+        kind: 'channel',
+        adapter,
+        workspace: 'W0',
+        chat: 'C0',
+        thread: null,
+      })
+      expect(out).toMatch(/Ship `researcher` reports as a PDF by default/i)
+      expect(out).toContain('research-<slug>.md')
+      expect(out).toContain('typeclaw-markdown-pdf')
+      expect(out).toMatch(/channel_send\(\{ \.\.\., attachments:/)
+      expect(out).toMatch(/do not paste the full markdown into chat/i)
+    },
+  )
+
+  // GitHub's outbound callback hard-rejects attachments
+  // (`github-bot-does-not-support-attachments`), so the PDF default must be
+  // suppressed there — nudging the model toward an attachment send that always
+  // fails would be worse than no guidance at all.
+  test('github channel origin omits the researcher-PDF default (attachments unsupported)', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'pr:7',
+      thread: null,
+    })
+    expect(out).not.toMatch(/Ship `researcher` reports as a PDF by default/i)
+    expect(out).not.toContain('typeclaw-markdown-pdf')
+  })
+
   test('channel origin tells the model that plain-text narration is invisible and must go through channel_reply', () => {
     const out = renderSessionOrigin({
       kind: 'channel',

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -129,14 +129,34 @@ type PlatformInfo = {
   // the call would no-op. Keep in sync with the adapters that call
   // `router.registerReaction` (github, slack-bot, discord-bot today).
   supportsReactions: boolean
+  // Whether this adapter's OutboundCallback accepts file attachments. Gates the
+  // "ship a researcher report as a PDF by default" prompt guidance: a report is
+  // only worth converting to a downloadable file on channels that can actually
+  // receive one. GitHub's outbound callback hard-rejects attachments
+  // (`github-bot-does-not-support-attachments` in adapters/github/outbound.ts),
+  // so a PDF nudge there would train the model toward a call that always fails;
+  // the other four upload files (Slack `uploadFile`, Discord `uploadFile`,
+  // Telegram `sendDocument`, KakaoTalk `sendAttachment`). Keep in sync with the
+  // adapters' outbound callbacks.
+  supportsAttachments: boolean
 }
 
 const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
-  'slack-bot': { displayName: 'Slack', mentionMode: 'angle-id', supportsReactions: true },
-  'discord-bot': { displayName: 'Discord', mentionMode: 'angle-id', supportsReactions: true },
-  github: { displayName: 'GitHub', mentionMode: 'at-username', supportsReactions: true },
-  'telegram-bot': { displayName: 'Telegram', mentionMode: 'at-username', supportsReactions: false },
-  kakaotalk: { displayName: 'KakaoTalk', mentionMode: 'alias', supportsReactions: false },
+  'slack-bot': { displayName: 'Slack', mentionMode: 'angle-id', supportsReactions: true, supportsAttachments: true },
+  'discord-bot': {
+    displayName: 'Discord',
+    mentionMode: 'angle-id',
+    supportsReactions: true,
+    supportsAttachments: true,
+  },
+  github: { displayName: 'GitHub', mentionMode: 'at-username', supportsReactions: true, supportsAttachments: false },
+  'telegram-bot': {
+    displayName: 'Telegram',
+    mentionMode: 'at-username',
+    supportsReactions: false,
+    supportsAttachments: true,
+  },
+  kakaotalk: { displayName: 'KakaoTalk', mentionMode: 'alias', supportsReactions: false, supportsAttachments: true },
 }
 
 function getPlatformInfo(adapter: AdapterId): PlatformInfo {
@@ -461,6 +481,7 @@ function renderChannelOrigin(
     "matching the channel's `allow` rules are accepted (the tool returns",
     '`{ ok: false }` otherwise).',
     '',
+    ...renderResearchReportDeliveryGuidance(platformInfo),
     ...renderMentionGuidance(platformInfo, origin.participants ?? [], now, origin.self),
   )
 
@@ -494,6 +515,30 @@ function renderMembershipSummary(
     return `This channel has ${total} members: ${membership.humans} humans, ${membership.bots} bots.${caveat} The 10 most recent speakers are listed below.`
   }
   return `This channel has approximately ${total} members (about ${membership.humans} humans, ${membership.bots} bots — the bot count is approximate, the full member list was not enumerated because it exceeds the 50-member cap). The 10 most recent speakers are listed below.`
+}
+
+// The `researcher` subagent always hands back a markdown report file
+// (`research-<slug>.md`) and is itself read-only — it cannot produce the PDF.
+// Whoever delivers that report to a channel is the one who decides the format,
+// and on a channel that accepts file uploads the right default for a multi-page
+// research report is a downloadable PDF, not a wall of raw markdown dumped into
+// chat. This block makes that the default ONLY where it is actionable: gated on
+// `supportsAttachments` so GitHub (whose outbound callback rejects attachments)
+// never gets a nudge toward a `channel_send` call that would fail.
+function renderResearchReportDeliveryGuidance(platformInfo: PlatformInfo): string[] {
+  if (!platformInfo.supportsAttachments) return []
+  return [
+    `**Ship \`researcher\` reports as a PDF by default.** ${platformInfo.displayName} accepts file`,
+    'attachments. When you receive a `researcher` subagent result — a',
+    '`research-<slug>.md` report file path in its `<report>` block — convert that',
+    'markdown to a PDF with the `typeclaw-markdown-pdf` skill and deliver it with',
+    '`channel_send({ ..., attachments: [{ path, filename }] })`, with a one- or',
+    'two-line summary as the message text. A downloadable file is what a human',
+    'wants for a multi-page report; do not paste the full markdown into chat. Send',
+    'the report inline as plain text only if the caller explicitly asked for it in',
+    'the message, or the report is short enough that a file would be overkill.',
+    '',
+  ]
 }
 
 function renderMentionGuidance(


### PR DESCRIPTION
## Background

The bundled `researcher` subagent is read-only and emits a single output: a `research-<slug>.md` file written via its enforced `write_report` tool. The parent agent then decides how to deliver that file. Until now it had no default guidance, so on chat channels it tended to dump the full markdown inline — a poor deliverable for a multi-page report.

On channels whose outbound callbacks support file uploads (Slack, Discord, Telegram, KakaoTalk) a downloadable PDF is the right default. On channels that hard-reject attachments (GitHub) the PDF path must never be suggested.

## Summary

Two additions to `src/agent/session-origin.ts` and a corresponding test block in `src/agent/session-origin.test.ts`:

1. **`supportsAttachments` flag on `PlatformInfo`** — mirrors the existing `supportsReactions` pattern. Set `true` for Slack, Discord, Telegram, KakaoTalk (all route through callbacks that call `uploadFile` / `sendDocument` / `sendAttachment`). Set `false` for GitHub (whose outbound callback throws `github-bot-does-not-support-attachments` on any attachment send).

2. **`renderResearchReportDeliveryGuidance(platformInfo)`** — renders a channel-origin system-prompt block when `supportsAttachments` is `true`. The block instructs the agent: after receiving a `researcher` result (a `research-<slug>.md` path in the `<report>` block), convert it to PDF via the bundled `typeclaw-markdown-pdf` skill, then deliver via `channel_send({ ..., attachments: [{ path, filename }] })` with a short text summary. Inline markdown delivery is reserved for when the caller explicitly asked or the report is short. When `supportsAttachments` is `false` the function returns an empty string and nothing is injected.

Scope is intentionally narrow: `researcher` reports only (per product decision). No changes to the researcher subagent, no changes to channel adapters.

## Preview

N/A — prompt guidance change; no visual output.

## What this does NOT do

- Does not change the researcher subagent itself (still read-only, still only `write_report`).
- Does not change any channel adapter or `channel_send` API shape.
- Does not generalise to other document-style deliverables (explicit non-goal).
- Does not affect cron or TUI origins — `renderResearchReportDeliveryGuidance` is only called from the channel-origin system prompt path.

## Review notes

The load-bearing invariant: `supportsAttachments: false` on GitHub **must** keep the guidance block out of that origin's prompt. The new test asserts this directly (`expect(block).toBe('')` for GitHub). The `PLATFORM_INFO` registry is the single source of truth; if a new adapter lands with attachment support, it gets `supportsAttachments: true` there and the guidance auto-applies.

Five tests added:

```sh
bun run typecheck   # clean
bun run lint        # 0 errors
bun run format:check
bun run test        # 7849 pass, 0 fail (408 files)
```

Test coverage: a `test.each` over Slack/Discord/Telegram/KakaoTalk asserting the PDF-default block is rendered (mentions `typeclaw-markdown-pdf`, `research-<slug>.md`, the `channel_send` attachments shape, and the "do not paste full markdown" instruction) plus a GitHub assertion that the block is omitted entirely.