### PR TITLE
fix(sandbox): dedup the bwrap + real-proc capability probes

### DIFF
--- a/src/sandbox/availability.test.ts
+++ b/src/sandbox/availability.test.ts
@@ -67,6 +67,25 @@ describe('canMountRealProc', () => {
     // fresh probe rather than the cache (no throw, deterministic).
     expect(after).toBe(before)
   })
+
+  test('dedups concurrent first calls onto one in-flight probe (same promise identity)', () => {
+    // Strong assertion: a second call BEFORE the first settles must return the
+    // exact same in-flight promise, proving only one `unshare` is spawned. (A
+    // value-equality check would pass even with two separate spawns, so it
+    // would not actually guard the dedup.)
+    const first = canMountRealProc()
+    const second = canMountRealProc()
+    expect(second).toBe(first)
+    return first
+  })
+
+  test('caches the result for the process so later calls never re-probe', async () => {
+    // The capability is a process-global fact; once resolved (true OR false) a
+    // subsequent call returns the cached value rather than spawning again.
+    const resolved = await canMountRealProc()
+    const cachedPromise = canMountRealProc()
+    expect(await cachedPromise).toBe(resolved)
+  })
 })
 
 describe('resolveProcSelfExe', () => {

--- a/src/sandbox/availability.ts
+++ b/src/sandbox/availability.ts
@@ -5,6 +5,13 @@ import { SandboxUnavailableError } from './errors'
 // resolved bwrap path so a test (or a consumer pinning a non-default path)
 // re-probes instead of reading another path's cached result.
 const availabilityCache = new Map<string, boolean>()
+// In-flight dedup: bash calls run concurrently (subagents, cron, parallel
+// tool calls), so without this two calls racing before the cache is populated
+// would each spawn a probe. The promise is cleared on settle so a probe that
+// was aborted (not "unavailable", just cancelled) does not poison the next
+// caller — the next call re-probes from scratch. Mirrors the channels
+// membership-cache in-flight pattern.
+const availabilityInFlight = new Map<string, Promise<boolean>>()
 
 export async function ensureBwrapAvailable(options?: { bwrapPath?: string }): Promise<void> {
   const bwrap = options?.bwrapPath ?? 'bwrap'
@@ -12,9 +19,27 @@ export async function ensureBwrapAvailable(options?: { bwrapPath?: string }): Pr
   if (cached === true) return
   if (cached === false) throw new SandboxUnavailableError()
 
-  const available = await probe(bwrap)
-  availabilityCache.set(bwrap, available)
+  const available = await dedupedProbe(bwrap)
   if (!available) throw new SandboxUnavailableError()
+}
+
+function dedupedProbe(bwrap: string): Promise<boolean> {
+  const existing = availabilityInFlight.get(bwrap)
+  if (existing !== undefined) return existing
+
+  const promise = probe(bwrap)
+    .then((available) => {
+      // Cache unconditionally, including false: a genuinely missing bwrap is a
+      // process-global fact, so the negative must stick rather than re-probe on
+      // every bash call. (No per-caller signal here — see canMountRealProc.)
+      availabilityCache.set(bwrap, available)
+      return available
+    })
+    .finally(() => {
+      availabilityInFlight.delete(bwrap)
+    })
+  availabilityInFlight.set(bwrap, promise)
+  return promise
 }
 
 async function probe(bwrap: string): Promise<boolean> {
@@ -32,6 +57,7 @@ async function probe(bwrap: string): Promise<boolean> {
 
 export function _resetBwrapAvailabilityCacheForTests(): void {
   availabilityCache.clear()
+  availabilityInFlight.clear()
 }
 
 // The 'real-proc' sandbox strategy prefixes bwrap with `unshare --pid --fork
@@ -48,11 +74,35 @@ export function _resetBwrapAvailabilityCacheForTests(): void {
 // low-trust bash call — restoring the pre-realProc behavior on unsupported
 // hosts (external-package execution still won't work there, exactly as before).
 let realProcProbeResult: boolean | undefined
+// In-flight dedup for the real-proc probe, same rationale as bwrap above:
+// concurrent first bash calls would otherwise each spawn `unshare`. A single
+// nullable promise suffices (no key — there is one probe), cleared on settle.
+//
+// Deliberately NOT abortable. The answer ("can THIS container mount a fresh
+// procfs?") is a process-global capability fact, not a per-request operation —
+// it does not vary with any one bash call's lifecycle. Threading a caller's
+// AbortSignal here is a category error: a deduped joiner would let the first
+// caller's abort decide a shared fact for everyone waiting on it. The payload
+// (`/bin/true`) exits in milliseconds and the result is cached for the process,
+// so cancellation buys nothing. If a supported environment ever made this probe
+// slow, add an INTERNAL timeout (the result is still global), never a caller
+// signal.
+let realProcProbeInFlight: Promise<boolean> | undefined
 
-export async function canMountRealProc(): Promise<boolean> {
-  if (realProcProbeResult !== undefined) return realProcProbeResult
-  realProcProbeResult = await probeRealProc()
-  return realProcProbeResult
+export function canMountRealProc(): Promise<boolean> {
+  if (realProcProbeResult !== undefined) return Promise.resolve(realProcProbeResult)
+  if (realProcProbeInFlight !== undefined) return realProcProbeInFlight
+
+  const promise = probeRealProc()
+    .then((canMount) => {
+      realProcProbeResult = canMount
+      return canMount
+    })
+    .finally(() => {
+      realProcProbeInFlight = undefined
+    })
+  realProcProbeInFlight = promise
+  return promise
 }
 
 async function probeRealProc(): Promise<boolean> {
@@ -74,6 +124,7 @@ async function probeRealProc(): Promise<boolean> {
 
 export function _resetRealProcProbeCacheForTests(): void {
   realProcProbeResult = undefined
+  realProcProbeInFlight = undefined
 }
 
 // The bun binary this process runs as (process.execPath). build.ts re-exposes


### PR DESCRIPTION
## Background

Follow-up to #696 (real-proc default + portability probe). A self-review flagged that both sandbox capability probes in `src/sandbox/availability.ts` (`ensureBwrapAvailable`, `canMountRealProc`) check a cache then `await` a spawn with no in-flight guard. Two concurrent first bash calls (subagents, cron, parallel tool calls) each spawn a probe. Harmless (deterministic result) but wasteful, and it scales with concurrency on a session's first calls.

## Summary

- **In-flight dedup** so concurrent first callers share one spawn: a per-path `Map<string, Promise<boolean>>` for `ensureBwrapAvailable` (keyed like its result cache) and a single nullable promise for the `canMountRealProc` singleton. Mirrors the established `src/channels/membership-cache.ts` pattern. In-flight entry is cleared on settle.
- **Unconditional caching** (including a negative result): the answer is a process-global capability fact, so a genuine "no bwrap" / "no mount-proc" must stick rather than re-probe on every bash call.

### Why this does NOT add AbortSignal

An earlier draft of this PR threaded the bash tool's `AbortSignal` into the probes "for consistency" with the codebase's other `Bun.spawn` call sites. **Self-review (and Oracle) found that was a category error** that introduced concurrency bugs, empirically reproduced on a `--cap-add SYS_ADMIN` container:

1. **Cross-caller poisoning** — with dedup, a joiner shares the first caller's promise; the first caller's abort then decided a *shared* fact for everyone waiting on it.
2. **Asymmetric signal** — the `.then` closure only inspected the first caller's signal; joiners' abort state was ignored.
3. **Late-abort suppressed valid caching** — an abort firing even *after* a successful probe flipped `signal.aborted` by `.then` time, so a correct `true` was never cached (`cached_after_abort=undefined` observed).

These probes answer a process-global question ("does this container allow `mount-proc` / have `bwrap`?"), not a request-scoped one — independent of any single bash call's lifecycle. The payload (`/bin/true`, `bwrap --version`) exits in milliseconds and the result is cached, so cancellation buys nothing. The signal is fully removed; `applyBashSandbox` and the probe signatures are back to their pre-draft (origin/main) shape. A code comment captures the rationale so the signal isn't re-added. If a supported environment ever makes a probe slow, the correct fix is an *internal* timeout, not a caller signal.

## What this does NOT do

- No behavior change to the real-proc-vs-tmpfs strategy decision itself.
- Does not touch `src/agent/plugin-tools.ts` (the draft's signal threading was fully reverted — the file is identical to `origin/main`).

## Review notes

- Net diff is two files: `src/sandbox/availability.ts` + its test.
- `canMountRealProc` is now a non-`async` function returning the cached value (`Promise.resolve`) or the shared in-flight promise directly, so the dedup is observable.
- Tests assert dedup by **promise identity** (a value-equality check would pass even with two separate spawns, so it would not guard the dedup) and that the result caches for the process.
- Full suite green: 7854 pass, 0 fail.