### PR TITLE
Run the v1->v2 secrets migration on host CLI commands, not just at boot

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,9 @@
 
 import { defineCommand, runMain } from 'citty'
 
+import { findAgentDir } from '../init'
 import { CLI_VERSION } from '../init/cli-version'
+import { runStartupMigrations } from '../migrations'
 import { BUILTIN_COMMAND_NAMES } from './builtins'
 import { dispatchPluginCommand, type PluginCommandDispatchOutcome } from './plugin-commands-dispatch'
 
@@ -40,11 +42,34 @@ const main = defineCommand({
   },
 })
 
-await runWithPluginDispatch()
+// #673's v1->v2 secrets migration was wired only into the container-stage boot
+// path (src/run/index.ts), so host CLI commands that read secrets.json directly
+// (model/provider list -> tryReadProvidersSync -> v2-only parser) still hard-fail
+// on a never-booted v1 folder. Run it once per host invocation here — at the
+// dispatch boundary, NOT in the parse path, which would recreate the read-time
+// shim #638 deliberately removed. `run` is the container stage and owns its own.
+let hostStartupMigrationsDone = false
+
+function runHostStartupMigrationsOnce(commandName: string | undefined): void {
+  if (hostStartupMigrationsDone) return
+  hostStartupMigrationsDone = true
+  if (commandName === 'run') return
+  const agentDir = findAgentDir(process.cwd())
+  if (agentDir === null) return
+  try {
+    runStartupMigrations(agentDir)
+  } catch (err) {
+    // runStartupMigrations isolates per-migration throws; this guards only the
+    // unexpected so a migration error can never block the host command itself.
+    console.warn(`[migration] host startup migration error: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
 
 async function runWithPluginDispatch(): Promise<void> {
   const argv = process.argv.slice(2)
   const first = argv[0]
+
+  runHostStartupMigrationsOnce(first)
 
   if (first === '--help' || first === '-h') {
     // citty calls process.exit() after rendering help, so anything we print
@@ -78,3 +103,5 @@ async function runWithPluginDispatch(): Promise<void> {
 }
 
 export type { PluginCommandDispatchOutcome }
+
+await runWithPluginDispatch()

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,13 +47,22 @@ const main = defineCommand({
 // (model/provider list -> tryReadProvidersSync -> v2-only parser) still hard-fail
 // on a never-booted v1 folder. Run it once per host invocation here — at the
 // dispatch boundary, NOT in the parse path, which would recreate the read-time
-// shim #638 deliberately removed. `run` is the container stage and owns its own.
+// shim #638 deliberately removed.
 let hostStartupMigrationsDone = false
+
+// `run` is the container stage and owns its own migration. Bare flag
+// invocations (`--help`, `-h`, `--version`, `-v`, no command) are
+// informational, exit before reading secrets, and must NOT rewrite secrets.json
+// or emit migration warnings — so only a real subcommand triggers the migration.
+function shouldRunHostStartupMigrations(commandName: string | undefined): boolean {
+  if (commandName === undefined || commandName === 'run') return false
+  return !commandName.startsWith('-')
+}
 
 function runHostStartupMigrationsOnce(commandName: string | undefined): void {
   if (hostStartupMigrationsDone) return
   hostStartupMigrationsDone = true
-  if (commandName === 'run') return
+  if (!shouldRunHostStartupMigrations(commandName)) return
   const agentDir = findAgentDir(process.cwd())
   if (agentDir === null) return
   try {

--- a/src/cli/model.test.ts
+++ b/src/cli/model.test.ts
@@ -63,9 +63,9 @@ describe('typeclaw model list migrates a pre-0.20.0 v1 secrets.json on first hos
     await rm(cwd, { recursive: true, force: true })
   })
 
-  async function runModelList(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  async function runCli(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
     const proc = Bun.spawn({
-      cmd: ['bun', CLI_ENTRY, 'model', 'list'],
+      cmd: ['bun', CLI_ENTRY, ...args],
       cwd,
       stdout: 'pipe',
       stderr: 'pipe',
@@ -76,8 +76,10 @@ describe('typeclaw model list migrates a pre-0.20.0 v1 secrets.json on first hos
     return { exitCode, stdout, stderr }
   }
 
-  test('exits 0 and rewrites secrets.json to the v2 envelope on disk', async () => {
-    await writeFile(
+  const runModelList = () => runCli(['model', 'list'])
+
+  const writeV1Secrets = () =>
+    writeFile(
       join(cwd, 'secrets.json'),
       JSON.stringify({
         version: 1,
@@ -85,6 +87,9 @@ describe('typeclaw model list migrates a pre-0.20.0 v1 secrets.json on first hos
         channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'dtok' } },
       }),
     )
+
+  test('exits 0 and rewrites secrets.json to the v2 envelope on disk', async () => {
+    await writeV1Secrets()
 
     const { exitCode, stdout } = await runModelList()
 
@@ -105,5 +110,16 @@ describe('typeclaw model list migrates a pre-0.20.0 v1 secrets.json on first hos
     expect(exitCode).toBe(0)
     const after = JSON.parse(await readFile(join(cwd, 'secrets.json'), 'utf8'))
     expect(after).toEqual(v2)
+  })
+
+  test('does not migrate or warn on informational --help invocations', async () => {
+    await writeV1Secrets()
+
+    const { exitCode, stderr } = await runCli(['--help'])
+
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toMatch(/migration/i)
+    const untouched = JSON.parse(await readFile(join(cwd, 'secrets.json'), 'utf8'))
+    expect(untouched.version).toBe(1)
   })
 })

--- a/src/cli/model.test.ts
+++ b/src/cli/model.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 const CLI_ENTRY = join(import.meta.dir, 'index.ts')
+const REPO_ROOT = resolve(import.meta.dir, '..', '..')
 
 describe('typeclaw model list survives broken typeclaw.json', () => {
   let cwd: string
@@ -46,5 +47,63 @@ describe('typeclaw model list survives broken typeclaw.json', () => {
     expect(stdout).toContain('PROFILE')
     expect(stdout).toContain('default')
     expect(stderr).toMatch(/typeclaw\.json is invalid/)
+  })
+})
+
+describe('typeclaw model list migrates a pre-0.20.0 v1 secrets.json on first host invocation', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-model-list-v1-secrets-'))
+    await symlink(join(REPO_ROOT, 'node_modules'), join(cwd, 'node_modules'), 'dir')
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({}))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  async function runModelList(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn({
+      cmd: ['bun', CLI_ENTRY, 'model', 'list'],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, NO_COLOR: '1' },
+    })
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+    const exitCode = await proc.exited
+    return { exitCode, stdout, stderr }
+  }
+
+  test('exits 0 and rewrites secrets.json to the v2 envelope on disk', async () => {
+    await writeFile(
+      join(cwd, 'secrets.json'),
+      JSON.stringify({
+        version: 1,
+        llm: { fireworks: { type: 'api_key', key: 'fpk_test' } },
+        channels: { 'discord-bot': { DISCORD_BOT_TOKEN: 'dtok' } },
+      }),
+    )
+
+    const { exitCode, stdout } = await runModelList()
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('PROFILE')
+    const migrated = JSON.parse(await readFile(join(cwd, 'secrets.json'), 'utf8'))
+    expect(migrated.version).toBe(2)
+    expect(migrated.providers.fireworks).toEqual({ type: 'api_key', key: { value: 'fpk_test' } })
+    expect(migrated.channels['discord-bot']).toEqual({ token: { value: 'dtok' } })
+  })
+
+  test('leaves an already-v2 secrets.json untouched', async () => {
+    const v2 = { version: 2, providers: {}, channels: {} }
+    await writeFile(join(cwd, 'secrets.json'), JSON.stringify(v2))
+
+    const { exitCode } = await runModelList()
+
+    expect(exitCode).toBe(0)
+    const after = JSON.parse(await readFile(join(cwd, 'secrets.json'), 'utf8'))
+    expect(after).toEqual(v2)
   })
 })


### PR DESCRIPTION
## Problem

After #638 made `parseSecretsFile` v2-only and #673 added the on-disk v1→v2 migration, a pre-0.20.0 agent folder whose `secrets.json` is still in the v1 envelope **fails every host-stage CLI command that reads secrets** — until the container is booted at least once.

Repro on a real v1 folder:

```
$ typeclaw model list
error: secrets file is not a valid TypeClaw secrets file: version: Invalid input: expected 2
    at readEnvelope (src/secrets/storage.ts)
    at tryReadProvidersSync (src/secrets/storage.ts)
    at isProviderConfigured (src/config/providers-mutation.ts)
    at listModelProfiles (src/config/models-mutation.ts)
    at run (src/cli/model.ts)
```

#673 wired `runStartupMigrations` into **exactly one** place: `src/run/index.ts` (the container-stage boot path). Host-stage CLI commands (`model list`, `provider list`, …) never go through `typeclaw run`, so they never migrate — they read `secrets.json` directly via `tryReadProvidersSync → readEnvelope → parseSecretsFile` (v2-only) and hard-fail.

## Fix

Run the **same** one-shot migration once per host CLI invocation, at the dispatch boundary in `src/cli/index.ts` (`runWithPluginDispatch`), before any subcommand can read secrets.

- **Not in the parse path.** It runs at the CLI boundary, never inside `parseSecretsFile`/`readEnvelope`/`tryReadProvidersSync`, so the read-time shim #638 deliberately removed is **not** reintroduced.
- **`run` is skipped.** The container stage owns its own migration (`src/run/index.ts`) and resolves the agent dir differently.
- **Once per invocation.** A module-level guard ensures a single attempt even if the dispatcher is re-entered.
- **Idempotent + self-guarding.** `migrateSecretsV1ToV2` already no-ops cheaply on absent/already-v2 files (existsSync + version check before any lock/write), and isolates throws per-migration, so a migration error can never block the host command.
- Agent dir resolved with `findAgentDir(process.cwd())`; outside an agent folder it's a no-op.

## Tests

`src/cli/model.test.ts` (real CLI subprocess, real tmp dir, no mocks):

- a v1 `secrets.json` → `model list` exits 0 and `secrets.json` is rewritten to the v2 envelope on disk (provider + field-keyed channel secret).
- an already-v2 `secrets.json` is left byte-for-byte untouched.

Verified manually against a real pre-0.20.0 folder's `secrets.json` (copied to a tmp dir): migrates `fireworks` provider + `slack-bot`/`discord-bot` channel tokens to v2, `model list` exits 0.

Checks: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check` all pass. Full suite green except one pre-existing `typeclaw.schema.json` drift-guard failure on `main`, unrelated to this change (touches no schema/config).

## Scope

Two files: the wiring (`src/cli/index.ts`) and its behavior test (`src/cli/model.test.ts`). No format-version bump, no on-disk format change, no new migration logic — reuses #673's `runStartupMigrations`.
