### PR TITLE
fix(channels): block bare acks that drop committed same-turn work

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -398,6 +398,58 @@ describe('createChannelReplyTool', () => {
     })
   })
 
+  describe('committed-followup guard (bare ack that drops same-turn work)', () => {
+    const replyTool = (sent: { count: number }) =>
+      createChannelReplyTool({
+        router: fakeRouter(async () => {
+          sent.count += 1
+          return { ok: true }
+        }),
+        origin: slackThreadOrigin,
+      })
+
+    // The incident: a bare ack promising same-turn work without continue:true
+    // aborts the turn before the work runs. These two are the real production
+    // transcripts that motivated the guard.
+    test.each([
+      'ㅇㅇ 최신으로 다시 확인해볼게 ㅋㅋ',
+      'ㅅㅂ researcher가 죽음 ㅋㅋ 직접 찾아볼게 ㄱㄷ',
+      "I'll re-check the latest now",
+      'let me look into it',
+    ])('blocks the bare commitment %p and never posts it', async (text) => {
+      const sent = { count: 0 }
+      const result = await runTool(replyTool(sent), { text })
+      expect((result.details as { ok: boolean }).ok).toBe(false)
+      expect(sent.count).toBe(0)
+    })
+
+    test('allows the same commitment once continue:true is set (turn stays alive)', async () => {
+      const sent = { count: 0 }
+      const result = await runTool(replyTool(sent), { text: '최신으로 다시 확인해볼게', continue: true })
+      expect(result.details).toEqual({ ok: true, continue: true })
+      expect(sent.count).toBe(1)
+    })
+
+    // Real final replies sampled from production that must NOT be blocked:
+    // past-tense (work done), user-imperatives, conditionals, and substantive
+    // answers. A false positive here is worse than the bug being fixed.
+    test.each([
+      '검색해봤음 ㅇㅇ 6/3 지방선거에서 투표용지 부족 사태는 실제로 있었음',
+      '찾아봤음 ㅇㅇ MCP = Anthropic이 만든 AI용 USB-C 포트임',
+      '이미지 안 봐서 정확히 못 찾겠음 ㅋㅋ 어떤 내용인지 텍스트로 알려주면 찾아볼게 ㅇㅇ',
+      '가격이나 정책은 하루 사이에도 바뀌니까 결제 직전에 각 플랫폼 가격 페이지 한 번 더 확인해봐',
+      'Firepass v2 종료일이 6/9 맞는지도 대시보드에서 직접 체크해보셈',
+      '들어가면 써보면서 다시 평가함 ㅇㅇ',
+      'I already checked — the dedupe is scoped to the per-session turn boundary',
+      'done',
+    ])('does not block the legitimate final reply %p', async (text) => {
+      const sent = { count: 0 }
+      const result = await runTool(replyTool(sent), { text })
+      expect(result.details).toEqual({ ok: true })
+      expect(sent.count).toBe(1)
+    })
+  })
+
   describe('attachments', () => {
     test('forwards attachments and text to router.send', async () => {
       const calls: OutboundMessage[] = []

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -182,6 +182,20 @@ export function createChannelReplyTool({
         }
       }
 
+      // Runs before the resolve so a blocked ack never mutates the thread, and
+      // only when the model did NOT opt in with `continue: true` (matching the
+      // false-receipt / rereview precedent: an explicit keep-alive is trusted).
+      if (!keepTurnAlive) {
+        const droppedFollowupError = committedFollowupWithoutContinueError(text)
+        if (droppedFollowupError) {
+          logger.warn(formatChannelToolFailure('channel_reply', droppedFollowupError))
+          return {
+            content: [{ type: 'text' as const, text: `channel_reply denied: ${droppedFollowupError}` }],
+            details: { ok: false, error: droppedFollowupError },
+          }
+        }
+      }
+
       // Resolve BEFORE posting: a successful channel_reply ends the turn, so a
       // resolve attempted "after" the ack would never run (the exact bug this
       // flag fixes). Resolve-failure blocks the reply so the agent never posts
@@ -373,6 +387,70 @@ function kimiToolCallLeakError(text: string | undefined): string {
     'refusing to forward raw provider tool-call control tokens; these are chat-template ' +
     'delimiters that should have been parsed into a real tool call upstream. ' +
     'Re-issue the intended channel reply as plain user-visible text only.'
+  )
+}
+
+// Same-turn work-commitment markers: a FIRST-PERSON, IMMEDIATE promise to do
+// work right now ("I'll re-check", "let me look", "다시 확인해볼게", "찾아볼게").
+// Deliberately narrow — see the exclusion guards in `promisesSameTurnFollowup`
+// for why conditionals, imperatives-to-the-user, and past-tense statements must
+// NOT match.
+const SAME_TURN_COMMITMENT = [
+  // English: first-person future/immediate work verbs.
+  /\bi(?:'| a)?ll\s+(?:re-?)?(?:check|look|verify|confirm|research|find|search|dig|investigate|fetch|grab|pull|see)\b/i,
+  /\blet me\s+(?:re-?)?(?:check|look|verify|confirm|research|find|search|dig|investigate|fetch|grab|pull|see)\b/i,
+  /\b(?:on it|working on it|hold on|one sec|gimme a sec|gonna (?:check|look|research|find))\b/i,
+  // Korean: first-person immediate-commitment ending `~ㄹ게/~ㄹ게요` on a work
+  // verb (확인/찾아/알아보/검색/조회/볼/해보). Matches `확인해볼게`, `찾아볼게`,
+  // `검색해볼게`, `알아볼게`, `다시 볼게`.
+  /(?:확인|찾아|알아보|알아볼|검색|조회|뒤져|살펴)\S*(?:볼게|볼께|할게|할께|해볼게|해볼께)/,
+  /다시\s*(?:확인|찾아|볼게|볼께|체크)/,
+]
+
+// Past-tense / already-done markers. If the reply states the work is DONE, it
+// is a terminal answer carrying results, not a same-turn commitment — never block.
+// Korean past tense: `~했음/봤음/봄/찾음/완료`. English: "I checked/looked/found".
+const WORK_ALREADY_DONE = [
+  /(?:했음|봤음|찾았|찾아봤|찾아봄|확인했|검색했|알아봤|조회했|완료|끝냈|끝남)/,
+  /\bi\s+(?:already\s+)?(?:checked|looked|found|verified|confirmed|researched|searched|dug)\b/i,
+]
+
+// Imperative-to-the-user markers: the bot is telling the USER to go check, not
+// promising to do it itself. Korean `~해봐/~해보셈/~확인해봐/~체크해`. These are
+// terminal advice, never a same-turn commitment.
+const USER_IMPERATIVE = [/(?:확인해봐|확인해보셈|체크해보셈|체크해봐|해보셈|알아봐|찾아봐|봐바|보셈)/]
+
+// Conditional markers: `~(으)면 ...할게` ("if you ..., I'll ..."). A promise
+// gated on a future user action is not same-turn work — never block.
+const CONDITIONAL = [/(?:면|으면|주면|하면)\s*\S*(?:볼게|볼께|할게|할께|해볼게)/, /\bif you\b/i]
+
+// True only for a BARE ack that promises same-turn work but omits `continue: true`.
+// Without the flag a successful reply ends the turn (router terminal-abort hook),
+// so the work the model just promised never runs — a silently dropped task. We
+// refuse the ack so the model must set `continue: true` or do the work first;
+// the failed reply keeps `details.ok` false, so the turn stays alive. Tuned
+// conservative: false negatives are cheap, false positives (blocking a real final
+// reply) are not. The length/newline test below treats any substantive reply as
+// a real answer, not an ack.
+function promisesSameTurnFollowup(text: string | undefined): boolean {
+  if (text === undefined) return false
+  const trimmed = text.trim()
+  if (trimmed === '') return false
+  if (trimmed.length > 160) return false
+  if (trimmed.includes('\n')) return false
+  if (WORK_ALREADY_DONE.some((re) => re.test(trimmed))) return false
+  if (USER_IMPERATIVE.some((re) => re.test(trimmed))) return false
+  if (CONDITIONAL.some((re) => re.test(trimmed))) return false
+  return SAME_TURN_COMMITMENT.some((re) => re.test(trimmed))
+}
+
+function committedFollowupWithoutContinueError(text: string | undefined): string {
+  if (!promisesSameTurnFollowup(text)) return ''
+  return (
+    'this reply promises follow-up work THIS turn but omits `continue: true`. ' +
+    'A successful reply ends the turn, so the fetch/tool/subagent you just said ' +
+    "you'd do would never run. Either set `continue: true` on this reply and then " +
+    'do the work, or do the work first and reply once with the result.'
   )
 }
 


### PR DESCRIPTION
## Background

`channel_reply` accepts a `continue: true` flag that suppresses the router's terminal-abort hook — `installChannelReplyTerminalHook` in `src/channels/router.ts`. Without it, the hook fires `agent.abort()` on any *successful* reply. The post-tool follow-up LLM call then returns `stopReason: 'aborted'` with zero tokens, so any fetch/tool/subagent the model committed to in the same turn never runs.

Observed in production: a re-research promise — `다시 확인해볼게` — sent without `continue: true` aborted the turn before the researcher subagent could spawn. The transcript confirmed the abort signature: subsequent assistant records had `stopReason: 'aborted'` and zero token usage. The subagent registry and dispatch were never the problem — the spawn simply never got a turn step.

The model forgets to set `continue: true` when making same-turn commitments. It did so twice in one session, and the existing code comments already acknowledge this as a known failure mode.

## Summary

Add a `committedFollowupWithoutContinueError` guard to `src/agent/tools/channel-reply.ts` — the same deny-and-repair pattern as the existing `checkFalseReceipt` and `evaluateRereviewGuard` guards.

When a reply **lacks `continue: true`** AND its text is a bare same-turn work commitment, the tool returns `details.ok: false`. Because the router hook only aborts on *success*, a failed reply leaves the turn alive — the model must either set `continue: true` or do the work first before replying.

**Guard placement.** Inserted after the rereview guard and before `resolveReviewThreadBeforeReply`, so a blocked ack never triggers the thread-resolve side-effect.

**Conservative matcher (the load-bearing part).** Real-corpus sampling (148 production `channel_reply` calls) showed a naive future-work pattern false-positives on ~16% of replies — almost all legitimate final answers. The matcher explicitly excludes:

- Past-tense "work done" markers (`검색해봤음`, `I checked`)
- Imperatives to the *user* to check (`직접 확인해봐`, `체크해보셈`)
- Conditionals (`if you …, I'll …`)
- Substantive replies (>160 chars or multi-line)

Only short first-person *immediate* commitments match. Replies with `continue: true` are exempt, matching existing guard precedent.

## What this does NOT do

- Does not change `src/channels/router.ts` — the terminal-abort hook is unchanged.
- Does not eliminate false negatives: novel commitment phrasings will still slip through and abort. This shrinks the failure rate; the complete cure is fixing the model's empty-follow-up degeneration so the abort isn't needed — larger, separate work.

## Review notes

- `src/agent/tools/channel-reply.ts`: new guard function + call site.
- `src/agent/tools/channel-reply.test.ts`: test cases seeded from the real production corpus.
  - True-positive incidents (`최신으로 다시 확인해볼게`, `직접 찾아볼게 ㄱㄷ`, English equivalents) must block.
  - Sampled false-positive replies (past-tense, user-imperatives, conditionals, substantive answers) must all still send.
  - Replies with `continue: true` must exempt the same text.
- Full suite green: 7867 pass, 0 fail.