### PR TITLE
perf(cli): defer the heavy plugin-dispatch graph off the startup path

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,11 +2,11 @@
 
 import { defineCommand, runMain } from 'citty'
 
-import { findAgentDir } from '../init'
 import { CLI_VERSION } from '../init/cli-version'
+import { findAgentDir } from '../init/find-agent-dir'
 import { runStartupMigrations } from '../migrations'
 import { BUILTIN_COMMAND_NAMES } from './builtins'
-import { dispatchPluginCommand, type PluginCommandDispatchOutcome } from './plugin-commands-dispatch'
+import type { PluginCommandDispatchOutcome } from './plugin-commands-dispatch'
 
 const main = defineCommand({
   meta: {
@@ -98,6 +98,10 @@ async function runWithPluginDispatch(): Promise<void> {
     !first.startsWith('-') &&
     !BUILTIN_COMMAND_NAMES.includes(first as (typeof BUILTIN_COMMAND_NAMES)[number])
   ) {
+    // Lazy: the dispatch chain statically pulls in @/config, @/plugin, zod, and
+    // @/container (~190ms). Only plugin (non-builtin) commands need it, so we
+    // defer the import to keep builtin commands and bare flags fast.
+    const { dispatchPluginCommand } = await import('./plugin-commands-dispatch')
     const outcome = await dispatchPluginCommand({ name: first, rawArgs: argv.slice(1), cwd: process.cwd() })
     if (outcome.kind === 'dispatched') {
       process.exit(outcome.exitCode)

--- a/src/init/find-agent-dir.test.ts
+++ b/src/init/find-agent-dir.test.ts
@@ -12,8 +12,13 @@ import { findAgentDir, isInitialized } from './find-agent-dir'
 describe('find-agent-dir dependency isolation', () => {
   test('imports nothing beyond node:fs and node:path', () => {
     const source = readFileSync(join(import.meta.dir, 'find-agent-dir.ts'), 'utf8')
-    const importSpecifiers = [...source.matchAll(/^import .* from ['"]([^'"]+)['"]/gm)].map((m) => m[1])
-    expect(importSpecifiers.sort()).toEqual(['node:fs', 'node:path'])
+    // Catch every static dependency form: `import ... from 'spec'`, bare
+    // side-effect `import 'spec'`, and re-exports `export ... from 'spec'` /
+    // `export * from 'spec'` — any of these would drag in the heavy graph.
+    const specifiers = [...source.matchAll(/^(?:import|export)\s+(?:[^'"]*\sfrom\s+)?['"]([^'"]+)['"]/gm)].map(
+      (m) => m[1],
+    )
+    expect(specifiers.sort()).toEqual(['node:fs', 'node:path'])
   })
 })
 

--- a/src/init/find-agent-dir.test.ts
+++ b/src/init/find-agent-dir.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { findAgentDir, isInitialized } from './find-agent-dir'
+
+// The whole point of this module's existence is that the host CLI entry can
+// import it WITHOUT dragging in the ~190ms init/config/container/plugin graph.
+// A future contributor adding a heavy import here would silently undo the
+// startup win while every behavioral test still passes — so guard the
+// dependency direction explicitly.
+describe('find-agent-dir dependency isolation', () => {
+  test('imports nothing beyond node:fs and node:path', () => {
+    const source = readFileSync(join(import.meta.dir, 'find-agent-dir.ts'), 'utf8')
+    const importSpecifiers = [...source.matchAll(/^import .* from ['"]([^'"]+)['"]/gm)].map((m) => m[1])
+    expect(importSpecifiers.sort()).toEqual(['node:fs', 'node:path'])
+  })
+})
+
+describe('find-agent-dir re-exports are wired', () => {
+  test('exposes findAgentDir and isInitialized as functions', () => {
+    expect(typeof findAgentDir).toBe('function')
+    expect(typeof isInitialized).toBe('function')
+  })
+})

--- a/src/init/find-agent-dir.ts
+++ b/src/init/find-agent-dir.ts
@@ -1,0 +1,44 @@
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+// Dependency-free agent-folder resolution. Kept out of `src/init/index.ts` so
+// the host CLI entry (`src/cli/index.ts`) can locate the agent folder at the
+// dispatch boundary WITHOUT pulling in the heavy init barrel (which statically
+// imports @/config, @/config/providers, @/container, @/secrets, @/tui — a
+// ~190ms module graph). This module MUST NOT import from the init barrel,
+// config, container, or plugin modules; keep the dependency direction one-way.
+
+export const CONFIG_FILE = 'typeclaw.json'
+
+export function isInitialized(dir: string): boolean {
+  return existsSync(join(dir, CONFIG_FILE))
+}
+
+// Walks upward from `start` looking for the agent folder (the dir containing
+// typeclaw.json). Returns the found dir, or null if nothing is found before
+// the walk hits a stop boundary.
+//
+// Stop boundaries (whichever comes first, checked at every level):
+//   1. The current dir contains typeclaw.json — return it.
+//   2. The current dir contains .git — return null. A .git boundary marks a
+//      project root; refusing to cross it prevents accidentally picking up an
+//      unrelated parent project, and matches how typeclaw itself initializes
+//      one .git per agent folder.
+//   3. We've reached the filesystem root — return null.
+//
+// The `.git` check fires AFTER the typeclaw.json check at the same level so
+// that walking up from a subdir of the agent (e.g. `<agent>/workspace/`) still
+// resolves to the agent root, even though the agent root itself contains both
+// typeclaw.json and .git.
+export function findAgentDir(start: string): string | null {
+  let dir = resolve(start)
+  const root = resolve(dir, '/')
+  while (true) {
+    if (existsSync(join(dir, CONFIG_FILE))) return dir
+    if (existsSync(join(dir, '.git'))) return null
+    if (dir === root) return null
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -36,7 +36,7 @@ export { GITKEEP_FILE, PACKAGES_DIR, PUBLIC_DIR } from './paths'
 
 export { appendOrReplaceEnvKey, hasEnvKey, readEnvFile } from './env-file'
 
-export { CONFIG_FILE, findAgentDir, isInitialized } from './find-agent-dir'
+export { CONFIG_FILE, findAgentDir, isInitialized }
 
 const CRON_FILE = 'cron.json'
 const PACKAGE_FILE = 'package.json'

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -19,6 +19,7 @@ import { createTui } from '@/tui'
 
 import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
+import { CONFIG_FILE, findAgentDir, isInitialized } from './find-agent-dir'
 import { installGithubWebhooksEagerly, type EagerGithubWebhookInstallResult } from './github-webhook-install'
 import { buildGitignore, GITIGNORE_FILE } from './gitignore'
 import { buildHatchingPrompt } from './hatching'
@@ -35,7 +36,8 @@ export { GITKEEP_FILE, PACKAGES_DIR, PUBLIC_DIR } from './paths'
 
 export { appendOrReplaceEnvKey, hasEnvKey, readEnvFile } from './env-file'
 
-const CONFIG_FILE = 'typeclaw.json'
+export { CONFIG_FILE, findAgentDir, isInitialized } from './find-agent-dir'
+
 const CRON_FILE = 'cron.json'
 const PACKAGE_FILE = 'package.json'
 
@@ -488,39 +490,6 @@ export function isDirectoryNonEmpty(dir: string): boolean {
     return readdirSync(dir).some((entry) => !entry.startsWith('.'))
   } catch {
     return false
-  }
-}
-
-export function isInitialized(dir: string): boolean {
-  return existsSync(join(dir, CONFIG_FILE))
-}
-
-// Walks upward from `start` looking for the agent folder (the dir containing
-// typeclaw.json). Returns the found dir, or null if nothing is found before
-// the walk hits a stop boundary.
-//
-// Stop boundaries (whichever comes first, checked at every level):
-//   1. The current dir contains typeclaw.json — return it.
-//   2. The current dir contains .git — return null. A .git boundary marks a
-//      project root; refusing to cross it prevents accidentally picking up an
-//      unrelated parent project, and matches how typeclaw itself initializes
-//      one .git per agent folder.
-//   3. We've reached the filesystem root — return null.
-//
-// The `.git` check fires AFTER the typeclaw.json check at the same level so
-// that walking up from a subdir of the agent (e.g. `<agent>/workspace/`) still
-// resolves to the agent root, even though the agent root itself contains both
-// typeclaw.json and .git.
-export function findAgentDir(start: string): string | null {
-  let dir = resolve(start)
-  const root = resolve(dir, '/')
-  while (true) {
-    if (existsSync(join(dir, CONFIG_FILE))) return dir
-    if (existsSync(join(dir, '.git'))) return null
-    if (dir === root) return null
-    const parent = dirname(dir)
-    if (parent === dir) return null
-    dir = parent
   }
 }
 


### PR DESCRIPTION
## Background

Every `typeclaw` host command paid ~190ms of module-load cost before doing any real work — including bare `typeclaw --version` and `--help`. The host CLI entry, `src/cli/index.ts`, statically imported two things that drag in the full heavy module graph (`@/config` + providers zod-schema, `@/plugin` loader, `zod`, `@/container`):

1. `./plugin-commands-dispatch` — but `dispatchPluginCommand` only ever runs for non-builtin (plugin) commands. Builtins and bare flags never call it, yet paid its full import cost.
2. `findAgentDir` from the `../init` barrel — a trivial fs walk, but the 1590-line barrel statically imports `@/config`, `@/container`, `@/secrets`, `@/tui`, so importing it forced the whole graph onto every real host subcommand before its own lazy command module even loaded.

Measurements (bun 1.3.14, warm transpile cache, steady state):

- Entry static dependency graph: ~190ms → ~20ms
- `typeclaw --version` full run: ~190ms → ~20ms
- The ~20ms residual is citty + migrations + cli-version, all cheap and genuinely needed.

## Summary

- Extract `findAgentDir`, `isInitialized`, and `CONFIG_FILE` into a dependency-free `src/init/find-agent-dir.ts` (imports only `node:fs` and `node:path`). The `../init` barrel re-exports them, so every existing importer — and the existing test blocks in `src/init/index.test.ts` — is untouched.
- Import `findAgentDir` in `src/cli/index.ts` from the tiny module instead of the barrel.
- Defer `dispatchPluginCommand` to a dynamic `import()` inside the non-builtin branch, after `runHostStartupMigrationsOnce(first)`.
- Add a guard test in `src/init/find-agent-dir.test.ts` asserting the new module imports nothing beyond `node:fs` and `node:path`, so a future heavy import can't silently reintroduce the regression.

## Preview

N/A — no visible output change. Performance improvement only.

## What this does NOT do

- Does not change any runtime behavior or command semantics.
- Does not change the test surface for any existing command — the `../init` barrel re-exports everything it used to, so existing import paths are unaffected.
- Does not touch the plugin dispatch logic itself, only where it is loaded.

## Review notes

**Invariant safety.** The documented v1→v2 secrets-migration ordering is preserved: for a non-builtin first arg, `runHostStartupMigrationsOnce(first)` still runs BEFORE the dynamic dispatch import and plugin execution. Bare flags and `run` still skip the migration exactly as before.

The new module keeps a one-way dependency direction — it never imports the init barrel, `@/config`, `@/container`, or `@/plugin`. The guard test fails CI if that invariant breaks.

Oracle reviewed module-init side-effect ordering and double-evaluation risk: Bun dedupes per resolved specifier, so `@/config` is not initialized twice even if both the lazy dispatch import and a later dynamic import reference it.

**The load-bearing changes are two:**

1. `src/init/find-agent-dir.ts` — the new dependency-free module.
2. `src/cli/index.ts` — import path swap + dynamic `import()` for dispatch.

`src/init/index.ts` is a net deletion (moved exports, no new logic).

## Tests

```
bun run typecheck            # exit 0
bun run lint                 # 0 errors; 66 pre-existing warnings in unrelated files
bun run format:check         # exit 0
bun test --parallel src/init src/cli src/plugin   # 965 pass, 0 fail
```

New guard test and barrel re-export tests pass. Behavior unchanged.