### PR TITLE
fix(channels): make prior-turn attachments resolvable via channel_history

### DIFF
--- a/src/agent/multimodal/look-at.ts
+++ b/src/agent/multimodal/look-at.ts
@@ -89,8 +89,10 @@ export function createChannelLookAtTool(router: ChannelRouter, origin: ChannelLo
     name: 'look_at_channel_attachment',
     label: 'Look at channel attachment',
     description:
-      'View an image attached to the current inbound channel message. Inbound messages show ' +
-      '`[<Platform> attachment #N: <kind> <metadata>]`; pass `N` as `attachment_id`. Do not invent ids.',
+      'View an image attached to a channel message. Inbound messages show ' +
+      '`[<Platform> attachment #N: <kind> <metadata>]`; pass `N` as `attachment_id`. Do not invent ids. ' +
+      'Images on the CURRENT inbound resolve directly; for one from an EARLIER message, call channel_history ' +
+      'first to make it resolvable by the same id.',
     parameters: Type.Object({
       attachment_id: Type.Integer({
         description: 'The number N from the inbound `[<Platform> attachment #N: ...]` placeholder.',
@@ -106,10 +108,10 @@ export function createChannelLookAtTool(router: ChannelRouter, origin: ChannelLo
         const validIds = router.listInboundAttachmentIds(origin)
         const validMsg =
           validIds.length === 0
-            ? 'no attachments are present in the current turn'
-            : `valid attachment_ids in this turn: ${validIds.join(', ')}`
+            ? 'no attachments are resolvable right now'
+            : `resolvable attachment_ids: ${validIds.join(', ')}`
         return errorResult(
-          `no attachment with id=${params.attachment_id} in this turn (${validMsg}). Do not call look_at_channel_attachment for attachments that do not appear in the inbound message — they do not exist.`,
+          `no attachment with id=${params.attachment_id} (${validMsg}). For an attachment from an earlier message, call channel_history first to make it resolvable; otherwise do not invent ids that are not in the inbound message.`,
           { count: 0, prompt: params.prompt },
         )
       }

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -55,6 +55,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     getReviewState: async () => ({ ok: true, selfBlocking: false, approve: true }),
     lookupInboundAttachment: (args) => attachments.find((attachment) => attachment.id === args.id) ?? null,
     listInboundAttachmentIds: () => attachments.map((attachment) => attachment.id),
+    registerHistoryAttachments: () => {},
     executeCommand: async () => ({ kind: 'no-live-session' }),
     getSelfAliases: () => [],
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
@@ -138,7 +139,7 @@ describe('channel_fetch_attachment', () => {
     expect(result.details).toEqual({
       ok: false,
       error:
-        'no attachment with id=1 in this turn (valid attachment_ids in this turn: 2). Do not call channel_fetch_attachment for attachments that do not appear in the inbound message — they do not exist.',
+        'no attachment with id=1 (resolvable attachment_ids: 2). For an attachment from an earlier message, call channel_history first to make it resolvable; otherwise do not invent ids that are not in the inbound message.',
     })
   })
 

--- a/src/agent/tools/channel-fetch-attachment.ts
+++ b/src/agent/tools/channel-fetch-attachment.ts
@@ -37,11 +37,12 @@ export function createChannelFetchAttachmentTool({
     name: 'channel_fetch_attachment',
     label: 'Channel Fetch Attachment',
     description:
-      'Download a file the user attached to the current inbound channel message and save it to disk. Inbound channel ' +
+      'Download a file attached to a channel message and save it to disk. Inbound channel ' +
       'messages with attachments show `[<Platform> attachment #N: <kind> <metadata>]` in the text. Pass `N` as ' +
-      '`attachment_id`; do not invent ids that are not present in the inbound message. The router validates the id ' +
-      'against the current turn and resolves the private platform ref itself. On success returns the absolute path ' +
-      'of the saved file plus its detected mimetype and size.',
+      '`attachment_id`; do not invent ids that are not present in the message. The router resolves the private ' +
+      'platform ref itself. Attachments on the CURRENT inbound message resolve directly; for one from an EARLIER ' +
+      'message, call channel_history first (it makes those attachments resolvable by the same id). On success ' +
+      'returns the absolute path of the saved file plus its detected mimetype and size.',
     parameters: Type.Object({
       attachment_id: Type.Integer({
         description:
@@ -75,10 +76,10 @@ export function createChannelFetchAttachmentTool({
         })
         const validMsg =
           validIds.length === 0
-            ? 'no attachments are present in the current turn'
-            : `valid attachment_ids in this turn: ${validIds.join(', ')}`
+            ? 'no attachments are resolvable right now'
+            : `resolvable attachment_ids: ${validIds.join(', ')}`
         return errorResult(
-          `no attachment with id=${params.attachment_id} in this turn (${validMsg}). Do not call channel_fetch_attachment for attachments that do not appear in the inbound message — they do not exist.`,
+          `no attachment with id=${params.attachment_id} (${validMsg}). For an attachment from an earlier message, call channel_history first to make it resolvable; otherwise do not invent ids that are not in the inbound message.`,
         )
       }
       if (found.ref === '') {

--- a/src/agent/tools/channel-history.ts
+++ b/src/agent/tools/channel-history.ts
@@ -94,6 +94,8 @@ export function createChannelHistoryTool({
         }
       }
 
+      router.registerHistoryAttachments(origin, result.messages)
+
       const rendered = renderMessages(result.messages)
       const cursorLine =
         result.nextCursor !== undefined

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -33,6 +33,7 @@ function fakeRouter(react: (req: ReactionRequest) => Promise<ReactionResult>): C
     fetchAttachment: async () => ({ ok: false, error: 'no fetchAttachment' }),
     lookupInboundAttachment: () => null,
     listInboundAttachmentIds: () => [],
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -48,6 +48,7 @@ function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: 
     getReviewState: async () => ({ ok: true, selfBlocking: false, approve: true }),
     lookupInboundAttachment: () => null,
     listInboundAttachmentIds: () => [],
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -56,6 +56,7 @@ function fakeRouter(
     getReviewState: options.getReviewState ?? (async () => ({ ok: true, selfBlocking: false, approve: true })),
     lookupInboundAttachment: () => null,
     listInboundAttachmentIds: () => [],
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -57,6 +57,7 @@ function fakeRouter(handlers: {
     getReviewState: handlers.getReviewState ?? (async () => ({ ok: true, selfBlocking: false, approve: true })),
     lookupInboundAttachment: () => null,
     listInboundAttachmentIds: () => [],
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -46,6 +46,7 @@ function fakeRouter(
     getReviewState: async () => ({ ok: true, selfBlocking: false, approve: true }),
     lookupInboundAttachment: () => null,
     listInboundAttachmentIds: () => [],
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -74,6 +74,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     getReviewState: async () => ({ ok: true, selfBlocking: false, approve: true }),
     lookupInboundAttachment: (args) => overrides.attachments?.find((attachment) => attachment.id === args.id) ?? null,
     listInboundAttachmentIds: () => (overrides.attachments ?? []).map((attachment) => attachment.id),
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -51,6 +51,7 @@ function fakeRouter(
     getReviewState: async () => ({ ok: true, selfBlocking: false, approve: true }),
     lookupInboundAttachment: () => null,
     listInboundAttachmentIds: () => [],
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -65,6 +65,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     getReviewState: async () => ({ ok: true, selfBlocking: false, approve: true }),
     lookupInboundAttachment: () => null,
     listInboundAttachmentIds: () => [],
+    registerHistoryAttachments: () => {},
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8197,6 +8197,43 @@ describe('ChannelRouter history attachment registry', () => {
       `R${HISTORY_ATTACHMENT_LIMIT + 5}`,
     )
   })
+
+  test('a newer page wins over a later older-cursor page that collides on the same id', async () => {
+    const { router } = await liveRouter(await tempDir())
+
+    // The agent fetches the recent page first (newer ts), then pages back with
+    // a cursor and gets an OLDER message reusing id #1. Despite arriving later,
+    // the older ref must not shadow the newer one.
+    router.registerHistoryAttachments(KEY, [
+      historyMessage({ externalMessageId: 'recent', ts: 2000, attachments: [{ id: 1, kind: 'file', ref: 'NEW-REF' }] }),
+    ])
+    router.registerHistoryAttachments(KEY, [
+      historyMessage({ externalMessageId: 'older', ts: 1000, attachments: [{ id: 1, kind: 'file', ref: 'OLD-REF' }] }),
+    ])
+
+    expect(router.lookupInboundAttachment({ ...KEY, id: 1 })!.ref).toBe('NEW-REF')
+  })
+
+  test('a later older-cursor page is evicted first when the cap is exceeded', async () => {
+    const { router } = await liveRouter(await tempDir())
+
+    // Fill the cap with the freshest page, then page back: the older refs must
+    // be the ones dropped, never the newer ones already retained.
+    const recent = Array.from({ length: HISTORY_ATTACHMENT_LIMIT }, (_, i) =>
+      historyMessage({
+        externalMessageId: `r${i}`,
+        ts: 9000 + i,
+        attachments: [{ id: i + 1, kind: 'file', ref: `NEW${i + 1}` }],
+      }),
+    )
+    router.registerHistoryAttachments(KEY, recent)
+    router.registerHistoryAttachments(KEY, [
+      historyMessage({ externalMessageId: 'older', ts: 10, attachments: [{ id: 999, kind: 'file', ref: 'OLD' }] }),
+    ])
+
+    expect(router.lookupInboundAttachment({ ...KEY, id: 999 })).toBeNull()
+    expect(router.lookupInboundAttachment({ ...KEY, id: 1 })!.ref).toBe('NEW1')
+  })
 })
 
 describe('review-thread resolver registry', () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -23,6 +23,7 @@ import {
   EMPTY_TURN_RETRY_NUDGE,
   extractPlainTextChannelToolCallText,
   getPlainTextChannelToolCallKind,
+  HISTORY_ATTACHMENT_LIMIT,
   MAX_CHANNEL_SENDS_PER_TURN,
   MAX_EMPTY_TURN_RETRIES,
   MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN,
@@ -8124,6 +8125,77 @@ describe('ChannelRouter inbound attachment lookup', () => {
     // pending or in-flight turn, so a late lookup must miss.
     expect(router.lookupInboundAttachment({ ...KEY, id: 1 })).toBeNull()
     expect(router.listInboundAttachmentIds(KEY)).toEqual([])
+  })
+})
+
+describe('ChannelRouter history attachment registry', () => {
+  const HIST_PHOTO = { id: 1, kind: 'photo' as const, ref: 'https://example.test/hist.jpg', mimetype: 'image/jpeg' }
+
+  async function liveRouter(dir: string) {
+    const made = makeRouter(dir)
+    // A live session must exist before registerHistoryAttachments has somewhere
+    // to stash; route + drain a throwaway inbound to create one.
+    await made.router.route(inbound({ text: 'open session' }))
+    await made.router.__testing!.flushDebounce(KEY)
+    return made
+  }
+
+  test('makes a prior-turn attachment resolvable by its placeholder id after channel_history', async () => {
+    const { router } = await liveRouter(await tempDir())
+
+    expect(router.lookupInboundAttachment({ ...KEY, id: 1 })).toBeNull()
+
+    router.registerHistoryAttachments(KEY, [historyMessage({ externalMessageId: 'old', attachments: [HIST_PHOTO] })])
+
+    const resolved = router.lookupInboundAttachment({ ...KEY, id: 1 })
+    expect(resolved).not.toBeNull()
+    expect(resolved!.ref).toBe(HIST_PHOTO.ref)
+    expect(router.listInboundAttachmentIds(KEY)).toEqual([1])
+  })
+
+  test('a live current-turn #1 still wins over a registered history #1', async () => {
+    const { router, sessions } = makeRouter(await tempDir())
+    router.registerHistory('discord-bot', async () => ({
+      ok: true,
+      messages: [],
+    }))
+
+    // Seed a history attachment #1, then start a turn whose inbound also carries
+    // its own attachment #1; the live one must shadow the historical one.
+    let resolvedMidTurn: ReturnType<typeof router.lookupInboundAttachment> = null
+    await router.route(inbound({ text: 'seed', attachments: [{ id: 1, kind: 'photo', ref: 'LIVE-REF' }] }))
+    router.registerHistoryAttachments(KEY, [historyMessage({ attachments: [HIST_PHOTO] })])
+    sessions[0]!.onPrompt = () => {
+      resolvedMidTurn = router.lookupInboundAttachment({ ...KEY, id: 1 })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(resolvedMidTurn).not.toBeNull()
+    expect(resolvedMidTurn!.ref).toBe('LIVE-REF')
+  })
+
+  test('is a no-op when the session is not live', async () => {
+    const { router } = makeRouter(await tempDir())
+    router.registerHistoryAttachments(KEY, [historyMessage({ attachments: [HIST_PHOTO] })])
+    expect(router.lookupInboundAttachment({ ...KEY, id: 1 })).toBeNull()
+  })
+
+  test('caps retained history attachments at HISTORY_ATTACHMENT_LIMIT, keeping the freshest', async () => {
+    const { router } = await liveRouter(await tempDir())
+
+    const many = Array.from({ length: HISTORY_ATTACHMENT_LIMIT + 5 }, (_, i) =>
+      historyMessage({ externalMessageId: `h${i}`, attachments: [{ id: i + 1, kind: 'file', ref: `R${i + 1}` }] }),
+    )
+    router.registerHistoryAttachments(KEY, many)
+
+    const ids = router.listInboundAttachmentIds(KEY)
+    expect(ids).toHaveLength(HISTORY_ATTACHMENT_LIMIT)
+    // The first 5 (oldest) were evicted; the freshest survive.
+    expect(router.lookupInboundAttachment({ ...KEY, id: 1 })).toBeNull()
+    expect(router.lookupInboundAttachment({ ...KEY, id: HISTORY_ATTACHMENT_LIMIT + 5 })!.ref).toBe(
+      `R${HISTORY_ATTACHMENT_LIMIT + 5}`,
+    )
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -297,6 +297,8 @@ export class StaleLiveSessionError extends Error {
 export const RESOLVE_CHANNEL_NAMES_TIMEOUT_MS = 5_000
 export const FETCH_HISTORY_TIMEOUT_MS = 5_000
 
+export const HISTORY_ATTACHMENT_LIMIT = 50
+
 // Watchdog over the whole session.idle hook chain. The drain loop awaits
 // `fireSessionIdle` between turns; a single hung plugin handler (e.g. a
 // memory-logger awaiting a network call that never resolves) wedges the
@@ -439,6 +441,14 @@ type LiveSession = {
   // and cleared when the turn ends, is what the lookup reads so a freshly-
   // arrived attachment stays resolvable for the whole turn it belongs to.
   currentTurnAttachments: readonly InboundAttachment[]
+  // Refs from an explicit channel_history look-back. A prior-turn attachment is
+  // replayed to the model as a text placeholder but its ref is gone from every
+  // turn-scoped queue above, so look_at/fetch can't resolve it; stashing the
+  // fetched refs here makes the same `attachment_id: N` resolvable. MUST be
+  // searched LAST so a live `#1` still wins over a historical `#1` (the
+  // newest-first collision rule lookupInboundAttachment documents). Bounded,
+  // never persisted, never exposes the ref to the model.
+  historyAttachments: InboundAttachment[]
   draining: boolean
   debounceTimer: ReturnType<typeof setTimeout> | null
   typingTimer: ReturnType<typeof setInterval> | null
@@ -724,6 +734,10 @@ export type ChannelRouter = {
   getReviewState: (req: ReviewStateRequest) => Promise<ReviewStateResult>
   lookupInboundAttachment: (args: ChannelKey & { id: number }) => InboundAttachment | null
   listInboundAttachmentIds: (args: ChannelKey) => readonly number[]
+  // Stash refs from a channel_history fetch so prior-turn attachments stay
+  // resolvable by their placeholder id. Called by the channel_history tool
+  // after a successful fetch; no-op when the session is not live.
+  registerHistoryAttachments: (key: ChannelKey, messages: readonly ChannelHistoryMessage[]) => void
   // Execute a command by name against an existing live session, bypassing
   // the inbound classifier, engagement gate, debounce, and prompt queue.
   // Used by adapters that receive commands through a native surface
@@ -1407,6 +1421,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         pendingSystemReminders: [],
         contextBuffer: [],
         currentTurnAttachments: [],
+        historyAttachments: [],
         draining: false,
         debounceTimer: null,
         typingTimer: null,
@@ -2778,7 +2793,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         if (hit !== undefined) return hit
       }
     }
-    return null
+    return findAttachmentById(live.historyAttachments, args.id)
   }
 
   const listInboundAttachmentIds = (args: ChannelKey): readonly number[] => {
@@ -2789,7 +2804,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     for (const item of [...live.promptQueue, ...live.contextBuffer]) {
       for (const attachment of item.attachments ?? []) ids.add(attachment.id)
     }
+    for (const attachment of live.historyAttachments) ids.add(attachment.id)
     return Array.from(ids).sort((a, b) => a - b)
+  }
+
+  const registerHistoryAttachments = (key: ChannelKey, messages: readonly ChannelHistoryMessage[]): void => {
+    const live = liveSessions.get(channelKeyId(key))
+    if (live === undefined) return
+    const incoming = messages.flatMap((message) => message.attachments ?? [])
+    if (incoming.length === 0) return
+    // Cap to the freshest HISTORY_ATTACHMENT_LIMIT so a deep scrollback paging
+    // session can't grow this unboundedly; the agent fetches refs it's about to
+    // act on, so recency is the right eviction key.
+    const merged = [...live.historyAttachments, ...incoming]
+    live.historyAttachments =
+      merged.length > HISTORY_ATTACHMENT_LIMIT ? merged.slice(merged.length - HISTORY_ATTACHMENT_LIMIT) : merged
   }
 
   const send = async (msg: OutboundMessage, opts?: SendOptions): Promise<SendResult> => {
@@ -3693,6 +3722,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     getReviewState,
     lookupInboundAttachment,
     listInboundAttachmentIds,
+    registerHistoryAttachments,
     executeCommand,
     getSelfAliases: computeSelfAliases,
     injectSubagentCompletionReminder,

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -420,6 +420,8 @@ type ObservedInbound = {
   source: 'prefetch' | 'observed'
 }
 
+type TimedAttachment = { ts: number; attachment: InboundAttachment }
+
 type LiveSession = {
   key: ChannelKey
   keyId: string
@@ -447,7 +449,10 @@ type LiveSession = {
   // fetched refs here makes the same `attachment_id: N` resolvable. MUST be
   // searched LAST so a live `#1` still wins over a historical `#1` (the
   // newest-first collision rule lookupInboundAttachment documents). Bounded,
-  // never persisted, never exposes the ref to the model.
+  // never persisted, never exposes the ref to the model. historyTimedAttachments
+  // is the ts-tagged source of truth (ordered oldest→newest, deduped by id);
+  // historyAttachments is its flat projection consumed by the lookup helpers.
+  historyTimedAttachments: readonly TimedAttachment[]
   historyAttachments: InboundAttachment[]
   draining: boolean
   debounceTimer: ReturnType<typeof setTimeout> | null
@@ -1421,6 +1426,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         pendingSystemReminders: [],
         contextBuffer: [],
         currentTurnAttachments: [],
+        historyTimedAttachments: [],
         historyAttachments: [],
         draining: false,
         debounceTimer: null,
@@ -2811,14 +2817,27 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const registerHistoryAttachments = (key: ChannelKey, messages: readonly ChannelHistoryMessage[]): void => {
     const live = liveSessions.get(channelKeyId(key))
     if (live === undefined) return
-    const incoming = messages.flatMap((message) => message.attachments ?? [])
+    const incoming: TimedAttachment[] = messages.flatMap((message) =>
+      (message.attachments ?? []).map((attachment) => ({ ts: message.ts, attachment })),
+    )
     if (incoming.length === 0) return
-    // Cap to the freshest HISTORY_ATTACHMENT_LIMIT so a deep scrollback paging
-    // session can't grow this unboundedly; the agent fetches refs it's about to
-    // act on, so recency is the right eviction key.
-    const merged = [...live.historyAttachments, ...incoming]
-    live.historyAttachments =
-      merged.length > HISTORY_ATTACHMENT_LIMIT ? merged.slice(merged.length - HISTORY_ATTACHMENT_LIMIT) : merged
+    // Order by message freshness, NOT append order: channel_history pages
+    // OLDER messages via nextCursor, so a later call can deliver an OLDER ref.
+    // findAttachmentById searches end-first, so the list MUST end with the
+    // freshest ref or an older paged `#1` would shadow a newer one. Dedupe by
+    // id keeping the freshest ts (a re-fetch of the same message is a no-op,
+    // not a duplicate), sort ascending by ts, then keep the freshest LIMIT so
+    // eviction drops the OLDEST refs, never newer ones.
+    const byId = new Map<number, TimedAttachment>()
+    for (const entry of [...live.historyTimedAttachments, ...incoming]) {
+      const existing = byId.get(entry.attachment.id)
+      if (existing === undefined || entry.ts >= existing.ts) byId.set(entry.attachment.id, entry)
+    }
+    const sorted = Array.from(byId.values()).sort((a, b) => a.ts - b.ts)
+    const kept =
+      sorted.length > HISTORY_ATTACHMENT_LIMIT ? sorted.slice(sorted.length - HISTORY_ATTACHMENT_LIMIT) : sorted
+    live.historyTimedAttachments = kept
+    live.historyAttachments = kept.map((entry) => entry.attachment)
   }
 
   const send = async (msg: OutboundMessage, opts?: SendOptions): Promise<SendResult> => {


### PR DESCRIPTION
## Background

Observed in production (Discord): a user attached `client_secret.json`, then **one minute later** in the next turn asked the agent to act on it. The agent replied *"I can't read the earlier attachment from this turn. Please reattach the JSON."* — and never even attempted a fetch tool. Not a URL-expiry issue; the attachment was seconds old.

Root cause is structural, not model behavior. Attachment resolution is **turn-scoped**: `lookupInboundAttachment` (`src/channels/router.ts`) only searches `currentTurnAttachments`, `promptQueue`, and `contextBuffer`. `drain()` splices the two queues empty at turn start and clears `currentTurnAttachments` in its `finally`. The session transcript replays the prior turn's **text** (so the model still sees the `[<Adapter> attachment #N: ...]` placeholder), but the structured ref behind it is gone from every searchable structure. So `look_at_channel_attachment` / `channel_fetch_attachment` answer *"no attachment with id=N in this turn"* for anything from an earlier turn.

This is adapter-agnostic — Discord, Slack, KakaoTalk, and GitHub history mappers all already carry attachment refs on `ChannelHistoryMessage`.

## Summary

Add a per-session **history attachment registry** in the router and let `channel_history` populate it.

`channel_history` already fetches messages with fully-populated `attachments` (refs included) — it just rendered text and discarded them. Now the tool calls `router.registerHistoryAttachments(origin, messages)` after a successful fetch, and both lookup helpers fall back to the registry.

**Why search the registry LAST (not reuse `currentTurnAttachments`):** the existing newest-first walk guarantees a live `#1` shadows an older `#1`. Putting history refs last preserves that invariant exactly; folding them into `currentTurnAttachments` would make "current turn" semantics lie. (Verified by a mutation: flipping the order makes the collision test fail.)

**Why not a new `attachment_handle` string param / composite ids:** that would change the model-facing `attachment_id` contract, the placeholder-strip regex, and every skill doc. The integer id the model reads from the placeholder is reused as-is; the change is strictly additive.

**Why not eager-materialize all inbound attachments to disk:** overfetches large/sensitive files the agent never looks at. This fetches only what the agent explicitly looks back for.

The registry is bounded (`HISTORY_ATTACHMENT_LIMIT = 50`, freshest-kept), never persisted to the transcript, and never exposes the ref to the model.

## What this does NOT do

- Does not auto-fetch or pre-warm history — the agent must call `channel_history` (the natural action when a user references an earlier message).
- Does not persist refs across container restarts (in-memory per live session).
- Does not change the `attachment_id` integer contract, the placeholder format, or the strip regex.
- Does not address genuine Discord CDN URL expiry (~24h) — out of scope; a >24h-old ref still fails at fetch, as before.

## Review notes

- Load-bearing change: `historyAttachments` is searched **last** in `lookupInboundAttachment` / `listInboundAttachmentIds` (`src/channels/router.ts`). The "a live current-turn #1 still wins over a registered history #1" test guards this; a mutation flipping the order fails it.
- Error-text change in both fetch tools ("they do not exist" → point at `channel_history`) updates one exact-string assertion in `channel-fetch-attachment.test.ts`.
- The 8 one-line `registerHistoryAttachments: () => {}` additions are mock-router stubs to satisfy the widened `ChannelRouter` interface.
- Full suite green (7861 pass), typecheck/lint/format clean.