### PR TITLE
fix(channels): stay silent on skip-locked send thrash instead of the stuck-reply fallback

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3224,7 +3224,14 @@ describe('ChannelRouter channel-turn protocol', () => {
     })
   }
 
-  test('empty-turn guard: a turn that thrashed the send path skips retry and posts the fallback once', async () => {
+  test('empty-turn guard: skip-locked send thrash stays silent (no fallback) — the model chose silence', async () => {
+    // Regression for the production false alarm (thread 1780845903.114339): the
+    // model called skip_response (committing to silence), then tried channel_reply
+    // anyway. Each send was denied skip-locked; past the cap the run aborted with
+    // no recoverable prose (the reply text was a denied tool ARG). The old guard
+    // posted "I got stuck putting together a reply…" — a misleading system-failure
+    // message for what is the model's own silence decision. Honor the skip: stay
+    // silent, log skip_locked_send_thrash_suppressed for production signal.
     const dir = await tempDir()
     const logs: string[] = []
     const sent: Array<{ text: string }> = []
@@ -3236,9 +3243,6 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     await router.route(inbound({ text: 'say something' }))
     sessions[0]!.onPrompt = async () => {
-      // The model committed to silence, then thrashed the send path (denied
-      // skip-locked) and left no recoverable prose. Re-prompting would just
-      // re-thrash, so the guard skips retry and posts the fallback once.
       router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'changed my mind' })
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'denied attempt' })
       sessions[0]!.setAssistantMidTurn('stranded loop output', 'length')
@@ -3246,9 +3250,42 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(sessions[0]!.prompts).toHaveLength(1)
-    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(sent).toHaveLength(0)
     expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
-    expect(logs.some((m) => m.includes('empty_turn_fallback cause=send_thrash'))).toBe(true)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+    expect(logs.some((m) => m.includes('skip_locked_send_thrash_suppressed'))).toBe(true)
+  })
+
+  test('empty-turn guard: duplicate-loop thrash WITHOUT skip_response does not reach the fallback (a real send landed)', async () => {
+    // The non-skip thrash counterpart. A duplicate/turn-cap denial can only
+    // accumulate AFTER a send actually landed (the dup-guard reads lastSentText,
+    // which is only set by a delivered send; turn-cap needs the full quota first).
+    // That successful send makes validateChannelTurn exit early — so the suppression
+    // change cannot strand this path, and it never emitted the skip-only fallback.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'say something' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'first' })
+      let i = 0
+      while (!sessions[0]!.agent.signal.aborted && i < 100) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'first' })
+        i++
+      }
+      sessions[0]!.setAssistantMidTurn('stranded loop output', 'length')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.map((s) => s.text)).toEqual(['first'])
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+    expect(logs.some((m) => m.includes('skip_locked_send_thrash_suppressed'))).toBe(false)
   })
 
   test('mid-turn recovery: does NOT fire when the model successfully replied (channel send happened)', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3043,13 +3043,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const candidate = recoverableAssistantText(live.session)
     if (candidate === null) {
       // No recoverable assistant prose: the turn ended with no usable reply.
-      // Two distinct shapes, handled differently (Option B):
+      // Three distinct shapes, handled differently:
       //
-      //   1. The model THRASHED the send path this turn — it tried to send but
-      //      every attempt was denied (skip-locked, or policy-denied/duplicate/
-      //      cap, tracked on skipLockedSendTurn / policyDeniedToolSendsThisTurn).
-      //      Re-prompting would just re-thrash, so skip retry and post the
-      //      user-facing fallback once.
+      //   1a. SKIP-LOCKED thrash — the model called `skip_response` (committed to
+      //       silence) then tried to send; every attempt was denied skip-locked
+      //       (skipLockedSendTurn === turnSeq). Honor the silence decision: stay
+      //       silent, no fallback. Handled first, below.
+      //
+      //   1b. The model THRASHED the send path WITHOUT a skip commitment — denials
+      //       tracked on policyDeniedToolSendsThisTurn (duplicate/cap). In practice
+      //       these only accumulate after a real send landed, so the early return
+      //       above usually fires first; if one ever reaches here, re-prompting
+      //       would just re-thrash, so skip retry and post the fallback once.
       //
       //   2. The PURE reasoning-loop — no send was ever attempted; the model
       //      burned its budget thinking and produced nothing (the canonical
@@ -3061,8 +3066,25 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // The legitimate empty-state case (a TUI-only check before any user
       // prompt, no inbound this turn) is excluded: no batch means no real turn
       // to retry or apologize for — keep the historical silent bail there.
-      const attemptedSendThisTurn =
-        live.skipLockedSendTurn === live.turnSeq || live.policyDeniedToolSendsThisTurn.size > 0
+      const skipLockedThisTurn = live.skipLockedSendTurn === live.turnSeq
+      const attemptedSendThisTurn = skipLockedThisTurn || live.policyDeniedToolSendsThisTurn.size > 0
+
+      // Skip-locked thrash honors the skip with SILENCE, not the fallback. The
+      // model called `skip_response` (committed to silence) then tried to send;
+      // the send was denied skip-locked and a retry loop aborts the run, leaving
+      // an `aborted` leaf whose reply text was a denied tool ARG — never
+      // recoverable prose. EMPTY_TURN_FALLBACK_TEXT would be a false alarm here:
+      // it reads as a system failure when the real state is the model's own
+      // silence decision contradicted by a late reply. The pure turn-cap/duplicate
+      // thrash below (no `skip_response`) never committed to silence, so it still
+      // gets the fallback. Distinct log line keeps production signal.
+      if (skipLockedThisTurn) {
+        logger.warn(
+          `[channels] ${live.keyId} skip_locked_send_thrash_suppressed ` +
+            `denied_targets=${live.policyDeniedToolSendsThisTurn.size}`,
+        )
+        return
+      }
 
       // Only a TRUNCATED assistant leaf (length/error/aborted) from a real
       // conversational turn is a degeneration worth retrying. A cold/empty turn


### PR DESCRIPTION
## Background

In a production Slack channel (#typeclaw, thread 1780845903.114339) the agent posted "⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?" even though nothing was broken — it had been replying fine all session.

Container logs for the failing turn (typeclaw 0.32.0, model fireworks/.../kimi-k2p6-turbo):
```
prompting batch=1 text_len=1913
aborting turn — 3 policy-denied channel sends (last: skip-locked)
skip_contested_by_send recovering reply
empty_turn_fallback cause=send_thrash
send source=system text_len=93        ← the fallback hit the channel
```

Root cause: the model called skip_response (committing to silence), then called channel_reply anyway.
Every send was denied skip-locked — commit-to-silence is binding on the live path.
Past MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN the run aborted via `agent.abort()`,
leaving an aborted assistant leaf whose reply text lived only as a denied tool argument,
never persisted as recoverable prose.
recoverableAssistantText() returned null; validateChannelTurn saw candidate===null,
attemptedSendThisTurn, and a truncated leaf, then fell through to `postEmptyTurnFallback('send_thrash')`.
The fallback exists to avoid dead air after a genuine degeneration (the kimi reasoning-loop),
but this path is the opposite: the model CHOSE silence and contradicted itself.
"I got stuck" reads as a system failure when the real state is the model's own silence decision.

## Summary

Split the candidate===null thrash case in `validateChannelTurn` in two:

- **Skip-locked thrash** (where skipLockedSendTurn===turnSeq): the model called `skip_response` first.
  Honor the silence — return without posting. Log `skip_locked_send_thrash_suppressed`
  (with denied-target count) for production signal.
- **Pure turn-cap/duplicate thrash** (no skip_response): unchanged — still posts the fallback
  if it ever reaches that branch.

Why suppress and not recover the denied text: recovering/posting the denied channel_reply
argument would undermine the skip lock — the system denied that send precisely because the model
committed to silence. Dead air is correct when the model explicitly chose silence.
Mirrors the existing skipped_by_tool short-circuit: a contested skip with recoverable prose
is already surfaced via `source:'system'`; this covers the sibling case where the contest left
nothing recoverable (run aborted), which previously leaked the generic fallback.

## What this does NOT do

- Does not touch the abort-after-3-denials guard (MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN) —
  stopping the invalid retry loop is still correct; only the post-abort fallback was wrong.
- Does not change the pure reasoning-loop retry/fallback path (`cause=retries_exhausted`).
- Does not change `skip_after_send` (reply-first skip): a real send that landed still stands
  and is never suppressed.
- Does not recover or replay denied tool-arg text around the skip lock.

## Review notes

- Verified against the real incident logs on the affected host.
- Tests: updated the existing "a turn that thrashed the send path…" test to assert silence
  + the new log line (it previously asserted the buggy fallback), and added a companion test
  proving the non-skip duplicate/turn-cap thrash never reaches the fallback (exits early
  because a real send must land first).
- Full suite green: 7853 pass / 0 fail; typecheck, lint (0 errors), format:check all clean.