### PR TITLE
fix(slack): resolve display names in history + reference context

### DIFF
--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -11,6 +11,7 @@ import {
   createOutboundCallback,
   createSlackHistoryCallback,
   createSlackMembershipResolver,
+  createSlackReferenceFetch,
   createSlackTypingTracker,
   createSlashCommandHandler,
   createThreadCommandHandler,
@@ -1189,6 +1190,139 @@ describe('createSlackHistoryCallback', () => {
     // then
     expect(calls).toHaveLength(1)
     expect(result.ok).toBe(true)
+  })
+
+  test('resolves authorName to display names when an authorResolver is provided', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        { ts: '1.1', user: 'UALICE', text: 'hi' },
+        { ts: '2.2', user: 'UBOB', text: 'yo' },
+      ],
+    })
+    const resolved: string[] = []
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      authorResolver: {
+        resolve: async (id) => {
+          resolved.push(id)
+          return id === 'UALICE' ? 'alice.s' : 'Bob Jones'
+        },
+      },
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    const byTs = Object.fromEntries(result.messages.map((m) => [m.externalMessageId, m.authorName]))
+    expect(byTs['1.1']).toBe('alice.s')
+    expect(byTs['2.2']).toBe('Bob Jones')
+    expect(resolved.sort()).toEqual(['UALICE', 'UBOB'])
+  })
+
+  test('leaves bot_id-only authors unresolved (no users.info entry exists)', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [{ ts: '1.1', subtype: 'bot_message', bot_id: 'B123', text: 'from a bot' }],
+    })
+    const resolved: string[] = []
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      authorResolver: {
+        resolve: async (id) => {
+          resolved.push(id)
+          return 'should-not-be-used'
+        },
+      },
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages[0]!.authorName).toBe('B123')
+    expect(resolved).toEqual([])
+  })
+
+  test('falls back to the raw id in authorName when no authorResolver is provided', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [{ ts: '1.1', user: 'UALICE', text: 'hi' }],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages[0]!.authorName).toBe('UALICE')
+  })
+})
+
+describe('createSlackReferenceFetch', () => {
+  function fakeFetch(response: unknown): typeof fetch {
+    return (async () =>
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+  }
+
+  test('resolves authorName to a display name when an authorResolver is provided', async () => {
+    // given
+    const fetchMessage = createSlackReferenceFetch({
+      token: 'tok',
+      fetchImpl: fakeFetch({ ok: true, messages: [{ user: 'UALICE', text: 'root text' }] }),
+      authorResolver: { resolve: async (id) => (id === 'UALICE' ? 'alice.s' : id) },
+    })
+    // when
+    const result = await fetchMessage('C1', '1700.000001')
+    // then
+    expect(result).toEqual({ authorId: 'UALICE', authorName: 'alice.s', text: 'root text' })
+  })
+
+  test('leaves bot_id authors unresolved (no users.info entry exists)', async () => {
+    // given
+    const resolved: string[] = []
+    const fetchMessage = createSlackReferenceFetch({
+      token: 'tok',
+      fetchImpl: fakeFetch({ ok: true, messages: [{ bot_id: 'B123', text: 'from a bot' }] }),
+      authorResolver: {
+        resolve: async (id) => {
+          resolved.push(id)
+          return 'should-not-be-used'
+        },
+      },
+    })
+    // when
+    const result = await fetchMessage('C1', '1700.000001')
+    // then
+    expect(result).toEqual({ authorId: 'B123', authorName: 'B123', text: 'from a bot' })
+    expect(resolved).toEqual([])
+  })
+
+  test('falls back to the raw id when no authorResolver is provided', async () => {
+    // given
+    const fetchMessage = createSlackReferenceFetch({
+      token: 'tok',
+      fetchImpl: fakeFetch({ ok: true, messages: [{ user: 'UALICE', text: 'root text' }] }),
+    })
+    // when
+    const result = await fetchMessage('C1', '1700.000001')
+    // then
+    expect(result).toEqual({ authorId: 'UALICE', authorName: 'UALICE', text: 'root text' })
   })
 })
 

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -32,7 +32,7 @@ import type {
 } from '@/channels/types'
 import { chunkMarkdown } from '@/markdown'
 
-import { createSlackAuthorResolver } from './slack-bot-author-resolver'
+import { createSlackAuthorResolver, type SlackAuthorResolver } from './slack-bot-author-resolver'
 import { createSlackChannelResolver } from './slack-bot-channel-resolver'
 import {
   classifyInbound,
@@ -650,9 +650,10 @@ export function createSlackHistoryCallback(deps: {
   token: string
   logger: SlackBotAdapterLogger
   botUserIdRef: () => string | null
+  authorResolver?: SlackAuthorResolver
   fetchImpl?: typeof fetch
 }): HistoryCallback {
-  const { token, logger, botUserIdRef } = deps
+  const { token, logger, botUserIdRef, authorResolver } = deps
   const fetchFn = deps.fetchImpl ?? fetch
   return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
     const limit = clampLimit(args.limit, SLACK_HISTORY_LIMIT_MAX)
@@ -687,6 +688,20 @@ export function createSlackHistoryCallback(deps: {
     const botUserId = botUserIdRef()
     const rawMessages = raw.messages ?? []
     const mapped = rawMessages.map((m) => mapSlackMessage(m, botUserId))
+    // History payloads carry no profile, so mapSlackMessage echoes the raw
+    // id into authorName; resolve it here so prompts show display names.
+    // Only msg.user authors are resolvable — bot_id-only messages have no
+    // users.info entry. The resolver caches/coalesces, so repeated authors
+    // cost one lookup each.
+    if (authorResolver !== undefined) {
+      await Promise.all(
+        mapped.map(async (message, index) => {
+          const userId = rawMessages[index]?.user
+          if (userId === undefined || userId === '') return
+          message.authorName = await authorResolver.resolve(userId)
+        }),
+      )
+    }
     // Slack's `conversations.history` returns newest-first; `replies`
     // returns oldest-first. Normalize to oldest-first so the agent always
     // reads chronological order regardless of scope.
@@ -905,7 +920,11 @@ export function createFetchAttachmentCallback(deps: {
   }
 }
 
-function createSlackReferenceFetch(deps: { token: string; fetchImpl: typeof fetch }) {
+export function createSlackReferenceFetch(deps: {
+  token: string
+  fetchImpl: typeof fetch
+  authorResolver?: SlackAuthorResolver
+}) {
   return async (channelId: string, messageTs: string) => {
     const url = new URL('https://slack.com/api/conversations.replies')
     url.searchParams.set('channel', channelId)
@@ -918,10 +937,13 @@ function createSlackReferenceFetch(deps: { token: string; fetchImpl: typeof fetc
     const messages = arrayField(body, 'messages')
     const first = recordValue(messages[0])
     if (first === null) return null
-    const authorId = stringField(first, 'user') ?? stringField(first, 'bot_id')
+    const userId = stringField(first, 'user')
+    const authorId = userId ?? stringField(first, 'bot_id')
     const text = stringField(first, 'text')
     if (authorId === null || text === null) return null
-    return { authorId, authorName: authorId, text }
+    const authorName =
+      userId !== null && deps.authorResolver !== undefined ? await deps.authorResolver.resolve(userId) : authorId
+    return { authorId, authorName, text }
   }
 }
 
@@ -981,6 +1003,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     token: options.token,
     logger,
     botUserIdRef: () => botUserId,
+    authorResolver,
   })
 
   const membershipResolver = createSlackMembershipResolver({
@@ -1108,7 +1131,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         ...(event.thread_ts !== undefined ? { threadTs: event.thread_ts } : {}),
         messageTs: event.ts,
         ...(slackAttachments !== undefined ? { attachments: slackAttachments } : {}),
-        fetchMessage: createSlackReferenceFetch({ token: options.token, fetchImpl }),
+        fetchMessage: createSlackReferenceFetch({ token: options.token, fetchImpl, authorResolver }),
       })
       const enriched = {
         ...verdict.payload,


### PR DESCRIPTION
## Background

In Slack, the agent's "Recent context" block rendered authors as raw user IDs — e.g. `[2026-06-08T02:00:05.897Z] <@U0B2KEJ7JRJ> (U0B2KEJ7JRJ) [bot]: …` — instead of human display names. The parenthetical `(authorName)` is what the agent reads as the name; when it equals the raw ID, the context is unreadable and `<@ID> (ID)` is pure noise.

Root cause: two code paths populate `authorName` and they diverged. Live inbounds resolve names through the existing `authorResolver` (`users.info`, fallback `display_name → real_name → name`, 1 h cache) — `slack-bot.ts` overwrites `authorName` with the resolved value. But prefetched history (`createSlackHistoryCallback` → `mapSlackMessage`) and reference/quote context (`createSlackReferenceFetch`) never called the resolver. Slack's `conversations.history`/`conversations.replies` only return the `msg.user` ID, not the profile, so `mapSlackMessage` echoed the raw ID into `authorName`. Those messages feed the context buffer, which is why "Recent context" showed IDs while live messages looked fine.

## Summary

Thread the already-instantiated `authorResolver` into both `createSlackHistoryCallback` and `createSlackReferenceFetch`; resolve `msg.user` → display name in each callback after the sync `mapSlackMessage` pass.

Key decisions:

- **Resolve in the callback, not in `mapSlackMessage`.** `mapSlackMessage` is synchronous and per-message; resolution is async and benefits from sharing the resolver's per-user cache and coalescing across a batch. Each callback resolves the whole mapped batch with `Promise.all`, so repeated authors across a batch cost one `users.info` round-trip each.
- **Skip `bot_id`-only authors.** `users.info` has no entry for a `bot_id`, so resolving would just echo the same ID back. Left unresolved intentionally; the guard is `msg.user !== undefined` (a real user ID) before calling the resolver.
- **`resolver` param is optional on both factories.** Existing callers and tests that don't pass a resolver keep prior raw-ID behavior — no forced churn on unrelated call sites.

No new Slack scope required — `users:read` is already in the app manifest.

## What this does NOT do

- Does not change the `<@id>` mention syntax in `formatAuthorReference`. The ping form is intentional; only the `(authorName)` portion changes.
- Does not touch other adapters. Discord already resolves names inline from its history payload; Telegram/KakaoTalk are out of scope.

## Review notes

Load-bearing changes in `slack-bot.ts`:

- The `authorResolver !== undefined` block in `createSlackHistoryCallback` — after `Promise.all`, indexes back into `rawMessages[index]?.user` to scope resolution to real users (not `bot_id`).
- The `userId !== null && deps.authorResolver !== undefined` branch in `createSlackReferenceFetch` — same pattern, applied per-message in the reference fetch.

New tests cover: history resolves display names and deduplicates lookups, `bot_id`-only authors stay unresolved, no-resolver fallback to raw ID — mirrored for the reference fetch path. All checks pass: typecheck, lint, format:check, and full test suite.