### PR TITLE
fix(channels): label the current message + stop re-attaching the Slack thread root every turn

### DIFF
--- a/src/channels/adapters/slack-bot-reference.test.ts
+++ b/src/channels/adapters/slack-bot-reference.test.ts
@@ -23,7 +23,10 @@ function fakeFetch(messages: ReadonlyMap<string, { authorId: string; authorName:
 }
 
 describe('enrichSlackReferenceContext', () => {
-  test('keeps raw text and adds thread-root reply context', async () => {
+  test('does not derive reply context from thread membership', async () => {
+    // Slack thread_ts is the thread root on EVERY in-thread message, so it is
+    // not a per-message reply signal. A plain in-thread reply must not fetch
+    // or attach the root as quote context.
     const { fetch, calls } = fakeFetch(
       new Map([['C1:1700.000001', { authorId: 'UBOB', authorName: 'Bob', text: 'root text' }]]),
     )
@@ -31,19 +34,12 @@ describe('enrichSlackReferenceContext', () => {
     const result = await enrichSlackReferenceContext({
       text: 'actual reply',
       channelId: 'C1',
-      threadTs: '1700.000001',
       messageTs: '1700.000002',
       fetchMessage: fetch,
     })
 
-    expect(result).toEqual({
-      text: 'actual reply',
-      referenceContext: {
-        kind: 'reply',
-        sources: [{ adapter: 'slack-bot', authorId: 'UBOB', authorName: 'Bob', text: 'root text' }],
-      },
-    })
-    expect(calls).toEqual([{ channelId: 'C1', messageTs: '1700.000001' }])
+    expect(result).toEqual({ text: 'actual reply' })
+    expect(calls).toEqual([])
   })
 
   test('keeps share-only raw text empty and adds quote context from share attachments', async () => {

--- a/src/channels/adapters/slack-bot-reference.ts
+++ b/src/channels/adapters/slack-bot-reference.ts
@@ -16,7 +16,6 @@ export type SlackMessagePointer = {
 export async function enrichSlackReferenceContext(args: {
   text: string
   channelId: string
-  threadTs?: string
   messageTs: string
   attachments?: readonly unknown[]
   fetchMessage: SlackReferenceFetch
@@ -25,17 +24,17 @@ export async function enrichSlackReferenceContext(args: {
   const sources: QuoteAnchorSource[] = []
   let kind: InboundReferenceContext['kind'] = 'link'
 
-  if (args.threadTs !== undefined && args.threadTs !== args.messageTs) {
-    const parent = await fetchSafely(args.fetchMessage, { channelId: args.channelId, messageTs: args.threadTs })
-    if (parent !== null) {
-      sources.push(toSource(parent))
-      kind = 'reply'
-    }
-  }
-
+  // Slack `thread_ts` is thread MEMBERSHIP, not a "reply-to this message"
+  // signal: every message in a thread carries the same root ts, so deriving
+  // reply context from it attached the thread root as a quote anchor on every
+  // in-thread message — repeated once per buffered message in a turn, and
+  // re-attached on every turn for the life of the thread. Only explicit
+  // message shares and archive links below carry a genuine referenced-message
+  // signal. If Slack ever exposes a distinct referenced-message id, add a new
+  // path for it rather than reusing `thread_ts`.
   for (const source of extractSlackShareSources(args.attachments ?? [])) {
     sources.push(source)
-    if (kind !== 'reply') kind = 'quote'
+    kind = 'quote'
   }
 
   const links = extractSlackMessageLinks(args.text).slice(0, args.linkLimit ?? 3)

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -1128,7 +1128,6 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       const referenceResult = await enrichSlackReferenceContext({
         text: verdict.payload.text,
         channelId: event.channel,
-        ...(event.thread_ts !== undefined ? { threadTs: event.thread_ts } : {}),
         messageTs: event.ts,
         ...(slackAttachments !== undefined ? { attachments: slackAttachments } : {}),
         fetchMessage: createSlackReferenceFetch({ token: options.token, fetchImpl, authorResolver }),

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -951,6 +951,22 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(prompt.indexOf('unrelated')).toBeLessThan(prompt.indexOf('hey bot'))
   })
 
+  test('labels the current message even when there is no recent context', async () => {
+    // Regression: the `## Current message` header used to be gated on
+    // observed.length > 0, so a turn carrying only the current message (no
+    // recent context) rendered the batch line bare. The group-chat nudge tells
+    // the model to identify "THIS latest message", so the latest message must
+    // be labeled regardless of whether recent context exists.
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ text: 'hey bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).not.toContain('Recent context')
+    expect(prompt).toContain('## Current message (addressed to you)')
+    expect(prompt).toContain('<@alice> (alice): hey bot')
+  })
+
   test('empty allow rules + observed-only burst produces no prompt and no crash', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir, {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3929,19 +3929,16 @@ function composeTurnPrompt(
     }
     parts.push('')
   }
-  // Only emit the `## Current message(s)` header when there is at least one
-  // queued inbound to live under it. A reminder-only wakeup (subagent
-  // completion firing while the prompt queue is empty) used to print the
-  // header with zero lines underneath; persona-rich models read the empty
-  // header as "there must be a current message addressed to me" and
-  // hallucinated content to reply to. The header is now batch-gated; the
-  // reminder block above and any observed context still render normally.
+  // Emit the `## Current message(s)` header whenever the batch is non-empty.
+  // It is batch-gated (a reminder-only wakeup with an empty promptQueue must
+  // not print a header with zero lines under it — persona-rich models read
+  // the dangling header as a message they're failing to see and hallucinate a
+  // reply). It must NOT also be gated on observed context: a turn carrying
+  // only the current message then rendered the batch line bare, or flush under
+  // the `## Recent context (not addressed to you …)` header — mislabeling the
+  // one line the model is supposed to answer as context it should ignore.
   if (batch.length > 0) {
-    if (observed.length > 0) {
-      parts.push(
-        batch.length === 1 ? '## Current message (addressed to you)' : '## Current messages (addressed to you)',
-      )
-    }
+    parts.push(batch.length === 1 ? '## Current message (addressed to you)' : '## Current messages (addressed to you)')
     for (const b of batch) {
       parts.push(formatInboundPromptLines(b, adapter))
     }


### PR DESCRIPTION
## Summary

Two independent group-chat prompt-composition bugs, surfaced by comparing a real Slack thread against its session log. Together they made the bot answer stale context and re-litigate the thread's opening question instead of the message in front of it.

### 1. The current message wasn't labeled (`fix(channels): always label the current message…`)

`composeTurnPrompt` gated the `## Current message (addressed to you)` header on `observed.length > 0`. So:

- A turn carrying **only** the current message (no recent context) rendered the batch line **bare** — no header at all.
- When recent context *did* land, the current message could sit flush under the `## Recent context (not addressed to you, for awareness only)` header.

Meanwhile the group-chat SYSTEM MESSAGE nudge instructs the model to *"identify who THIS latest message is aimed at."* With the latest message unlabeled — or visually grouped under the "not addressed to you" header — the model can't tell which line is the current turn. That's the "misleading SYSTEM MESSAGE" symptom.

**Fix:** emit the header whenever the batch is non-empty. The batch-gate (which suppresses a dangling header on reminder-only subagent-completion wakeups) is preserved; only the redundant `observed`-gate is dropped.

### 2. The thread-start message was re-attached on every turn (`fix(slack): stop treating thread membership as reply context`)

`enrichSlackReferenceContext` treated Slack `thread_ts` as a "reply-to this message" signal and attached the thread **root** as a quote anchor. But in Slack, `thread_ts` is thread **membership** — *every* in-thread message carries the same root ts. So the root got quoted:

- once **per buffered message** within a single turn (a deep thread rendered it 3–4× in one prompt), and
- **re-attached on every turn** for the life of the thread.

This drowned the actual current message under repeated copies of the thread's opening line.

**Fix:** drop the `thread_ts` path entirely (arg + parent fetch + `kind:'reply'`). Genuine referenced-message signals — explicit Slack message shares and archive links — are unchanged. If Slack later exposes a distinct referenced-message id, that gets its own path rather than reusing `thread_ts`.

## Out of scope (filed separately)

A third symptom from the same thread — the intermittent `:warning: I got stuck putting together a reply…` fallback firing even though a real reply already landed — is a distinct recovery-path bug (send-thrash / contested-skip interacting with the deliberate terminal-abort hook). #702 (`stay silent on skip-locked send thrash…`) already addresses one slice of it; the remaining cases will be investigated and fixed in a follow-up rather than muddying this PR.

## Testing

- New regression test: `labels the current message even when there is no recent context` (router.test.ts).
- Updated `enrichSlackReferenceContext` test to assert thread membership no longer fetches or attaches the root (`does not derive reply context from thread membership`).
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, `bun run test` (7867 pass, 0 fail) all green.
