### PR TITLE
fix(cli): drop duplicate status dot in inspect session picker

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -299,9 +299,12 @@ async function clackSelectSession(
 }
 
 function itemLabel(item: ViewerItem): string {
+  // clack's select already draws a radio dot (●/○) per option; a leading status
+  // dot here doubled it into a confusing "● ○". Keep rows glyph-free; the live
+  // row uses ▸ (not a dot) to stay distinct from the radio cursor.
   if (item.kind === 'logs') return `${c.dim('▤')} container logs`
-  if (item.kind === 'tui') return `${c.green('●')} ${c.bold('live TUI')}  ${sessionRowLabel(item.summary)}`
-  return `${c.dim('○')} ${sessionRowLabel(item.summary)}`
+  if (item.kind === 'tui') return `${c.green('▸')} ${c.bold('live TUI')}  ${sessionRowLabel(item.summary)}`
+  return sessionRowLabel(item.summary)
 }
 
 function itemHint(item: ViewerItem): { hint: string } {


### PR DESCRIPTION
## Problem

`typeclaw inspect`'s session picker showed a confusing **double dot** prefix on every row:

```
│  ● ○ 019ea58d-f35  Subagent scout  just now
│  ○ ○ 019ea58d-a37  Subagent researcher  just now
│  ○ ○ 019ea58d-f35  Subagent scout  just now
```

The first dot is **clack's own radio cursor** (`●` = highlighted row, `○` = others), which `@clack/prompts` `select` already renders in the gutter for every option. `itemLabel` then prepended a **second** status dot, producing the `● ○` / `○ ○` double marker.

## Fix

In `itemLabel` (`src/cli/inspect.ts`):

- **Plain session rows** — drop the redundant `c.dim('○')` prefix entirely. clack's radio dot is the single source of truth for selection state.
- **Live-TUI row** — swap the leading `●` for `▸`, so the "this row is live & writable" affordance stays visible (still green-tinted) without colliding with the radio cursor.

The `logs` row already used a non-dot glyph (`▤`) and is unchanged.

### Before → After

| | Before | After |
|---|---|---|
| highlighted session | `│  ● ○ 019ea…` | `│  ● 019ea…` |
| other session | `│  ○ ○ 019ea…` | `│  ○ 019ea…` |
| live TUI (highlighted) | `│  ● ● live TUI …` | `│  ● ▸ live TUI …` |

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings, none in `inspect.ts`)
- `bun run format` — clean

Single-file, 5-line change. No behavioral change beyond the rendered glyphs; selection, hints, and navigation are untouched.
