### PR TITLE
fix(inspect): bound the live transcript window to stop render-stall freeze

### DIFF
--- a/src/inspect/transcript-view.test.ts
+++ b/src/inspect/transcript-view.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 import { Markdown, type Terminal, Text } from '@mariozechner/pi-tui'
 
 import type { SessionSummary } from './session-list'
-import { createTranscriptView, componentFor } from './transcript-view'
+import { BoundedComponentWindow, createTranscriptView, componentFor } from './transcript-view'
 import type { InspectEvent } from './types'
 import { parseFilter } from './types'
 
@@ -64,6 +64,43 @@ describe('componentFor', () => {
       { cat: 'error', ts: 1, message: 'boom' },
     ]
     for (const ev of cases) expect(componentFor(ev)).toBeInstanceOf(Text)
+  })
+})
+
+describe('BoundedComponentWindow', () => {
+  test('keeps every entry until the cap is reached', () => {
+    const window = new BoundedComponentWindow(3)
+    expect(window.push([new Text('a', 0, 0)])).toBeNull()
+    expect(window.push([new Text('b', 0, 0)])).toBeNull()
+    expect(window.push([new Text('c', 0, 0)])).toBeNull()
+    expect(window.size).toBe(3)
+  })
+
+  test('evicts the oldest entry once the cap is exceeded', () => {
+    const window = new BoundedComponentWindow(2)
+    const first = [new Text('first', 0, 0)]
+    const second = [new Text('second', 0, 0)]
+    const third = [new Text('third', 0, 0)]
+
+    expect(window.push(first)).toBeNull()
+    expect(window.push(second)).toBeNull()
+    expect(window.push(third)).toBe(first)
+    expect(window.size).toBe(2)
+  })
+
+  test('evicts the whole entry so a timestamp never outlives its body', () => {
+    const window = new BoundedComponentWindow(1)
+    const timestamp = new Text('12:00:00', 0, 0)
+    const body = new Text('assistant reply', 0, 0)
+    const firstEntry = [timestamp, body]
+    const secondEntry = [new Text('12:00:01', 0, 0), new Text('next', 0, 0)]
+
+    expect(window.push(firstEntry)).toBeNull()
+    const evicted = window.push(secondEntry)
+    expect(evicted).toBe(firstEntry)
+    expect(evicted).toContain(timestamp)
+    expect(evicted).toContain(body)
+    expect(window.size).toBe(1)
   })
 })
 

--- a/src/inspect/transcript-view.ts
+++ b/src/inspect/transcript-view.ts
@@ -27,6 +27,8 @@ export type TranscriptViewOptions = {
   createTerminal?: () => Terminal
 }
 
+export const MAX_LIVE_HISTORY_ENTRIES = 250
+
 // Read-only pi-tui transcript viewer: the rich counterpart to the line
 // renderer, matching the live TUI's look (markdown assistant blocks, formatted
 // tool panels) but with NO editor and NO websocket writes. It owns its own
@@ -45,11 +47,18 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     tui.requestRender()
 
     // The status line is pinned last (no editor to pin, unlike createTui). Each
-    // appended history entry is inserted before it: strip status, add entry,
-    // re-add status.
-    const append = (component: Component): void => {
+    // event's components are inserted before it: strip status, add them, re-add
+    // status. pi-tui re-renders (and re-lays out every Markdown block in) the
+    // whole child list each frame, so an unbounded live tail makes per-frame cost
+    // grow until the viewer stalls; the window evicts the oldest entry to keep
+    // render cost bounded. Components are evicted per event so a timestamp never
+    // outlives its body. Header and pinned status are never evicted.
+    const history = new BoundedComponentWindow(MAX_LIVE_HISTORY_ENTRIES)
+    const appendEntry = (components: HistoryEntry): void => {
       tui.removeChild(status)
-      tui.addChild(component)
+      const evicted = history.push(components)
+      if (evicted !== null) for (const component of evicted) tui.removeChild(component)
+      for (const component of components) tui.addChild(component)
       tui.addChild(status)
     }
 
@@ -83,15 +92,14 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     // transcripts; render per event once live.
     let live = false
     const onEvent = (event: InspectEvent): void => {
-      append(new Text(formatEventTime(event.ts), 0, 0))
-      append(componentFor(event))
+      appendEntry([new Text(formatEventTime(event.ts), 0, 0), componentFor(event)])
       if (live) tui.requestRender()
     }
     const onPhase = (phase: StreamPhase): void => {
       if (phase.phase === 'replay-end') {
         tui.requestRender()
       } else if (phase.phase === 'live-start') {
-        append(new Text(divider(phase.sessionLive ? 'live' : 'live (broadcasts only)'), 0, 0))
+        appendEntry([new Text(divider(phase.sessionLive ? 'live' : 'live (broadcasts only)'), 0, 0)])
         live = true
         tui.requestRender()
       }
@@ -189,4 +197,22 @@ function statusLine(_phase: 'replay'): string {
 
 function divider(text: string): string {
   return colors.dim(`─── ${text} ───`)
+}
+
+export type HistoryEntry = readonly Component[]
+
+export class BoundedComponentWindow {
+  private readonly entries: HistoryEntry[] = []
+
+  constructor(private readonly maxEntries: number) {}
+
+  push(entry: HistoryEntry): HistoryEntry | null {
+    this.entries.push(entry)
+    if (this.entries.length <= this.maxEntries) return null
+    return this.entries.shift() ?? null
+  }
+
+  get size(): number {
+    return this.entries.length
+  }
 }


### PR DESCRIPTION
## Background

`typeclaw inspect`'s interactive transcript viewer (`src/inspect/transcript-view.ts`) freezes during long-lived or busy live tails. The live tail is WebSocket-driven (not file-watching), so the freeze is not a disk/IO race — it's render cost.

Root cause: the viewer appended a pi-tui component to the TUI child list for **every** inbound event with no upper bound (one `Text` for the timestamp, one `Text`/`Markdown` for the content). pi-tui's `doRender()` re-renders the **entire** child list on each frame — and re-lays out every `Markdown` assistant block — so as events stream in, the transcript tree grows without bound and per-frame render cost grows O(entries). On a busy session the viewer progressively slows until it visibly stalls.

Note: pi-tui's `requestRender()` already coalesces/throttles renders (`MIN_RENDER_INTERVAL_MS`), so render *frequency* was never the problem — the unbounded component tree was.

## Summary

Cap the retained transcript history to a sliding window of events (`MAX_LIVE_HISTORY_ENTRIES = 250`). A small `BoundedComponentWindow` tracks appended event entries (each entry is the group of components a single event produced) and returns the oldest entry once the cap is exceeded; the viewer's `appendEntry` helper removes every component of that evicted entry from the TUI before adding the new one. This bounds the child-list length, so per-frame render cost stays flat regardless of session length.

Eviction is per **event**, not per component, so a timestamp is never evicted without its body — the window boundary never shows a half entry. The window logic is an exported, unit-tested class (eviction policy tested directly) rather than only through the full TUI run loop.

Why a sliding window and not render throttling: pi-tui already throttles renders; the cost is in the tree size, so the fix has to bound the tree. Why evict during replay too (not just live): a giant historical transcript triggers the same O(entries) render cost, so a uniform cap protects both paths.

## What this does NOT do

- Does not add file-watching or change how live events are sourced (still WebSocket).
- Does not touch the writable live TUI branch (`tui-item.ts`) or the scriptable line renderer.
- Does not address the unrelated edges noted during investigation (server-side `stream.scan` on the subscribe handshake; non-atomic session-file rewrites). Those are separate.

## Review notes

- Load-bearing change: `appendEntry()` in `createTranscriptView` evicts whole entries via `BoundedComponentWindow`. Invariant: the header (first child) and the pinned `status` line (last child) are never tracked by the window, so they're never evicted; timestamp+body evict atomically.
- `MAX_LIVE_HISTORY_ENTRIES = 250` events. Once eviction begins, the oldest scrolled-off events are dropped from the tree (terminal scrollback is already lost on redraw in a differential TUI). Adjustable if reviewers prefer a different bound.
- Trade-off accepted (self-reviewed with the oracle): once the cap is hit, eviction happens near the top of the rendered buffer, so pi-tui's differential renderer redraws a larger region per event. This is still **bounded** work (O(cap)) versus the previous unbounded growth, which is the property that fixes the freeze. A virtualized transcript view would avoid the wide redraw entirely but is a much larger change than this bug needs.
