### PR TITLE
fix(agent): deliver reports as rendered PDFs and gate CJK on opt-in fonts

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -1249,6 +1249,38 @@ describe('getBundledSkillsDir', () => {
       expect(frontmatter).toMatch(/^description:\s*\S/m)
     },
   )
+
+  test('typeclaw-markdown-pdf keeps CJK fonts opt-in: gates on font presence, never auto-downloads', async () => {
+    const path = join(getBundledSkillsDir(), 'typeclaw-markdown-pdf', 'SKILL.md')
+    const raw = await readFile(path, 'utf8')
+
+    expect(raw).toContain('## Handling CJK content')
+    expect(raw).toContain('fonts-noto-cjk')
+    expect(raw).toMatch(/CJK fonts are \*\*opt-in\*\*/)
+    expect(raw).toMatch(/docker\.file\.cjkFonts/)
+    expect(raw).toMatch(/typeclaw restart/)
+    // Auto-downloading a font would defeat the opt-in and hide the teachable failure.
+    expect(raw).not.toContain('NotoSerifKR-Regular.otf')
+    expect(raw).not.toContain('workspace/.tools/fonts')
+  })
+
+  test('typeclaw-markdown-pdf detection covers Hangul, Kana, and CJK ideograph ranges', async () => {
+    const path = join(getBundledSkillsDir(), 'typeclaw-markdown-pdf', 'SKILL.md')
+    const raw = await readFile(path, 'utf8')
+
+    expect(raw).toContain('\\x{AC00}-\\x{D7A3}')
+    expect(raw).toContain('\\x{3040}-\\x{30FF}')
+    expect(raw).toContain('\\x{4E00}-\\x{9FFF}')
+  })
+
+  test('typeclaw-markdown-pdf forbids ad-hoc PDF libraries', async () => {
+    const path = join(getBundledSkillsDir(), 'typeclaw-markdown-pdf', 'SKILL.md')
+    const raw = await readFile(path, 'utf8')
+
+    expect(raw).toMatch(/only supported way to make a PDF from Markdown/i)
+    expect(raw).toMatch(/jsPDF/)
+    expect(raw).toMatch(/pdfkit/)
+  })
 })
 
 describe('formatRestartNotice (sibling sessions: do not acknowledge unless asked)', () => {

--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -258,7 +258,7 @@ describe('renderSessionOrigin', () => {
   )
 
   test.each(['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk'] as const)(
-    'attachment-capable channel origin (%s) defaults researcher reports to a PDF attachment',
+    'attachment-capable channel origin (%s) defaults report/PDF requests to a PDF attachment',
     (adapter) => {
       const out = renderSessionOrigin({
         kind: 'channel',
@@ -267,11 +267,15 @@ describe('renderSessionOrigin', () => {
         chat: 'C0',
         thread: null,
       })
-      expect(out).toMatch(/Ship `researcher` reports as a PDF by default/i)
+      expect(out).toMatch(/Ship reports as a PDF by default/i)
+      expect(out).toMatch(/the user asks for a report, document, brief, or "the report"/i)
       expect(out).toContain('research-<slug>.md')
       expect(out).toContain('typeclaw-markdown-pdf')
       expect(out).toMatch(/channel_send\(\{ \.\.\., attachments:/)
-      expect(out).toMatch(/do not paste the full markdown into chat/i)
+      expect(out).toMatch(/do not paste\s+the full markdown into chat/i)
+      expect(out).toMatch(/`<summary>`[\s\S]*?NOT the deliverable/i)
+      expect(out).toMatch(/ad-hoc library \(jsPDF, pdfkit/i)
+      expect(out).toMatch(/do not attach the raw `\.md`/i)
     },
   )
 
@@ -279,7 +283,7 @@ describe('renderSessionOrigin', () => {
   // (`github-bot-does-not-support-attachments`), so the PDF default must be
   // suppressed there — nudging the model toward an attachment send that always
   // fails would be worse than no guidance at all.
-  test('github channel origin omits the researcher-PDF default (attachments unsupported)', () => {
+  test('github channel origin omits the report-PDF default (attachments unsupported)', () => {
     const out = renderSessionOrigin({
       kind: 'channel',
       adapter: 'github',
@@ -287,7 +291,7 @@ describe('renderSessionOrigin', () => {
       chat: 'pr:7',
       thread: null,
     })
-    expect(out).not.toMatch(/Ship `researcher` reports as a PDF by default/i)
+    expect(out).not.toMatch(/Ship reports as a PDF by default/i)
     expect(out).not.toContain('typeclaw-markdown-pdf')
   })
 

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -528,15 +528,21 @@ function renderMembershipSummary(
 function renderResearchReportDeliveryGuidance(platformInfo: PlatformInfo): string[] {
   if (!platformInfo.supportsAttachments) return []
   return [
-    `**Ship \`researcher\` reports as a PDF by default.** ${platformInfo.displayName} accepts file`,
-    'attachments. When you receive a `researcher` subagent result — a',
-    '`research-<slug>.md` report file path in its `<report>` block — convert that',
-    'markdown to a PDF with the `typeclaw-markdown-pdf` skill and deliver it with',
-    '`channel_send({ ..., attachments: [{ path, filename }] })`, with a one- or',
-    'two-line summary as the message text. A downloadable file is what a human',
-    'wants for a multi-page report; do not paste the full markdown into chat. Send',
-    'the report inline as plain text only if the caller explicitly asked for it in',
-    'the message, or the report is short enough that a file would be overkill.',
+    `**Ship reports as a PDF by default.** ${platformInfo.displayName} accepts file`,
+    'attachments. When the user asks for a report, document, brief, or "the report"',
+    '— or a `researcher` subagent hands you a `research-<slug>.md` file path in its',
+    '`<report>` block — convert that markdown to a PDF with the `typeclaw-markdown-pdf`',
+    'skill and deliver it with `channel_send({ ..., attachments: [{ path, filename }] })`,',
+    'with a one- or two-line summary as the message text. A `researcher` `<summary>`',
+    'is a teaser, NOT the deliverable: the deliverable is the report file rendered to',
+    'PDF. Never build the PDF with an ad-hoc library (jsPDF, pdfkit, a raw-text dump) —',
+    'that yields unrendered markdown and mojibake; the skill is the only correct path.',
+    "For CJK (Korean/Japanese/Chinese) reports, follow that skill's CJK font gate —",
+    'never ship a tofu-rendered PDF; ask before enabling the opt-in `cjkFonts`.',
+    'A downloadable file is what a human wants for a multi-page report; do not paste',
+    'the full markdown into chat, and do not attach the raw `.md` when asked for a',
+    'report or PDF. Send inline plain text only if the caller explicitly asked for it,',
+    'or the content is short enough that a file would be overkill.',
     '',
   ]
 }

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -24,6 +24,23 @@ describe('subagent orchestration — explicit research routing', () => {
   })
 })
 
+describe('delivering reports and documents', () => {
+  test('routes report/PDF/document requests to the typeclaw-markdown-pdf skill', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('## Delivering reports and documents')
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('typeclaw-markdown-pdf')
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/produce a polished file/i)
+  })
+
+  test('states the summary is a pointer, never the deliverable', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/summary[\s\S]*?never the deliverable/i)
+  })
+
+  test('forbids hand-rolling a PDF with an ad-hoc library', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/jsPDF, pdfkit/i)
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/mojibake/i)
+  })
+})
+
 describe('renderTurnTimeAnchor', () => {
   test('wraps the ISO timestamp, IANA zone, and weekday in a single <current-time> tag', () => {
     const now = new Date('2026-01-15T12:00:00+09:00')

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -59,6 +59,12 @@ For any multi-step or long-running task, maintain a todo list with \`todo_write\
 
 Do not narrate routine, low-risk tool calls. Just call the tool. Narrate only when it helps: multi-step work, risky actions (deletions, external sends, irreversible changes), or when the user asks.
 
+## Delivering reports and documents
+
+When the user asks for a *report*, *document*, *brief*, *PDF*, or asks you to *send/show/attach/export* a generated result — anything where the deliverable is a file a human would download, print, or forward — produce a polished file, not a wall of text pasted into chat and not a one-line summary that drops the substance. A summary (yours or a subagent's) is a pointer to the deliverable, never the deliverable itself; when the user asked for the report, ship the report.
+
+To turn Markdown into a PDF, use the bundled \`typeclaw-markdown-pdf\` skill — it is the only supported path and it renders Markdown properly (headings, lists, tables). **Never** hand-roll a PDF with an ad-hoc library (jsPDF, pdfkit, a canvas text dump, a headless-browser raw-text print): those produce unrendered raw \`##\`/\`**\` markup and mojibake for non-Latin text. CJK fonts are opt-in, so for Korean/Japanese/Chinese reports follow that skill's CJK gate — never ship a tofu-rendered PDF; ask before enabling opt-in CJK fonts. If a request is plainly satisfied by inline chat — a short answer, a snippet, a quick explanation — stay inline; this rule is for explicit document deliverables, not for every long reply.
+
 ## Long-running and interactive shell work
 
 Foreground \`bash\` blocks your turn until exit, so a command that runs for minutes or waits for input (dev server, REPL, watcher, \`docker compose up\`, interactive installer) freezes the conversation. \`tmux\` is in the container — run such programs detached so your turn stays free:

--- a/src/skills/typeclaw-markdown-pdf/SKILL.md
+++ b/src/skills/typeclaw-markdown-pdf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-markdown-pdf
-description: "Turn any Markdown into a polished, professional PDF and (optionally) attach it to a channel. Load this whenever you need to deliver a document as a PDF rather than raw markdown — reports, summaries, briefs, meeting notes, docs, anything a human would want to download, print, or forward. Triggers: 'make a PDF', 'export to PDF', 'markdown to PDF', 'PDF report', 'attach the report', 'send me a PDF', 'as a PDF', 'turn this into a document', a researcher/subagent result you want to ship as a file, 'PDF로', 'PDF로 만들어', 'PDF로 변환', 'PDF 첨부'. Also load before saying you cannot produce PDFs — you can: this skill installs a tiny Typst toolchain into workspace/ on first use, then renders. Covers the one-time setup, the styled wrapper, the render command, and how to attach the PDF to Slack/Discord/Telegram/KakaoTalk. For operating on EXISTING PDFs (merge, split, extract text, fill forms), this is not the skill — use pypdf/qpdf instead."
+description: "The ONLY supported way to turn Markdown into a polished, professional PDF (and optionally attach it to a channel). Load this whenever you need to deliver a document as a PDF rather than raw markdown — reports, summaries, briefs, meeting notes, docs, render report, export document, anything a human would want to download, print, or forward, including a researcher's report file shipped as a Slack/Discord attachment. Triggers: 'make a PDF', 'export to PDF', 'markdown to PDF', 'PDF report', 'render report', 'export document', 'the report', 'attach the report', 'send me a PDF', 'as a PDF', 'turn this into a document', a researcher/subagent result you want to ship as a file, 'PDF로', 'PDF로 만들어', 'PDF로 변환', 'PDF 첨부', '리포트', '보고서'. Handles CJK/Korean/Japanese/Chinese: CJK fonts are opt-in, so before rendering it checks whether a CJK font is present and, if not, asks the user to enable `docker.file.cjkFonts` and regenerate rather than shipping a tofu PDF — it never auto-downloads a font. Also load before saying you cannot produce PDFs — you can: this skill installs a tiny Typst toolchain into workspace/ on first use, then renders. NEVER build a PDF with jsPDF, pdfkit, a canvas text dump, or a headless-browser raw-text print — those produce unrendered markdown and broken CJK; this skill is the only correct path. Covers the one-time setup, the styled wrapper, the render command, and how to attach the PDF to Slack/Discord/Telegram/KakaoTalk. For operating on EXISTING PDFs (merge, split, extract text, fill forms), this is not the skill — use pypdf/qpdf instead."
 ---
 
 # typeclaw-markdown-pdf
@@ -21,6 +21,15 @@ You do **not** need to learn Typst markup. `cmarker` renders your CommonMark
 (headings, lists, tables, code, blockquotes, footnotes, links, images). The
 wrapper only sets _styling_ — fonts, margins, headings, page numbers — so the
 output looks deliberate, not like a default-template export.
+
+> **This is the only supported way to make a PDF from Markdown in TypeClaw.**
+> Do **not** reach for `jsPDF`, `pdfkit`, a `<canvas>` text dump, or a
+> headless-browser "print raw text" path. Those skip Markdown rendering (you get
+> literal `##` and `**` in the output) and ship no CJK font, so Korean/Japanese/
+> Chinese come out as mojibake. The Typst path below renders the Markdown properly;
+> for CJK it relies on the opt-in `cjkFonts` font and gates on its presence (see
+> "## Handling CJK content") rather than shipping tofu. If you catch yourself about
+> to `bun add` a PDF library, stop and use this skill instead.
 
 ## When to use this
 
@@ -141,10 +150,60 @@ Notes:
   wherever the Latin fonts have no glyph, leaving Latin runs untouched. It comes
   from `fonts-noto-cjk`, which Step 3's renderer loads from `/usr/share/fonts` via
   `fontPaths`. **The package is only present when the container's `cjkFonts` toggle
-  resolves to `true`.** Its default is `"auto"`, which installs the fonts only when
-  the host locale is CJK (`ja`/`ko`/`zh`) — so on a non-CJK host, CJK PDFs still
-  render as tofu until you set `docker.file.cjkFonts: true` in `typeclaw.json` and
-  rebuild. If your CJK font lives elsewhere, add its dir to the `fontPaths` list.
+  resolves to `true`** (default `"auto"` installs it only on a CJK host locale), so
+  on a non-CJK host CJK text renders as tofu — see "## Handling CJK content" below
+  for the pre-render check that catches this and asks the user before shipping a
+  broken PDF. If your CJK font lives elsewhere, add its dir to the `fontPaths` list.
+
+## Handling CJK content
+
+CJK fonts are **opt-in** (the `docker.file.cjkFonts` toggle). When they are off,
+Typst still renders — it just substitutes `.notdef` tofu boxes for every
+Korean/Japanese/Chinese glyph, so the render "succeeds" and you can ship a broken
+PDF without noticing. **Do not** download, vendor, or `curl` a font into the
+workspace to work around this, and **do not** silently deliver a tofu PDF. Instead,
+run this gate **before** Step 3 whenever the markdown might contain CJK:
+
+```sh
+# Run from workspace/. MD is the markdown you are about to render.
+MD="report.md"
+
+# Hangul, Kana, CJK ideographs + the common extensions. grep -P on Debian; perl
+# slurp as the fallback (BusyBox/macOS grep lack -P).
+CJK_RE='[\x{1100}-\x{11FF}\x{3130}-\x{318F}\x{AC00}-\x{D7A3}\x{3040}-\x{30FF}\x{31F0}-\x{31FF}\x{3400}-\x{4DBF}\x{4E00}-\x{9FFF}\x{F900}-\x{FAFF}\x{20000}-\x{2A6DF}\x{2A700}-\x{2B73F}\x{2B740}-\x{2B81F}\x{2B820}-\x{2CEAF}\x{2CEB0}-\x{2EBEF}\x{30000}-\x{3134F}]'
+if command -v grep >/dev/null && echo | grep -qP '' 2>/dev/null; then
+  LC_ALL=C.UTF-8 grep -qP "$CJK_RE" -- "$MD" && HAS_CJK=1 || HAS_CJK=0
+else
+  perl -CSDA -0777 -ne "exit(/$CJK_RE/ ? 0 : 1)" "$MD" && HAS_CJK=1 || HAS_CJK=0
+fi
+
+# A CJK font Typst can load. dpkg is the authoritative signal for the opt-in
+# fonts-noto-cjk package; the file scan covers a preinstalled or mounted font.
+# fontconfig/fc-list is NOT consulted — Typst reads fontPaths directly, not fc.
+has_cjk_font() {
+  dpkg-query -W -f='${Status}' fonts-noto-cjk 2>/dev/null | grep -q 'install ok installed' && return 0
+  find /usr/share/fonts /usr/local/share/fonts -type f \( -iname '*.otf' -o -iname '*.ttf' -o -iname '*.ttc' \) 2>/dev/null |
+    grep -Eiq '(Noto(Sans|Serif)CJK|Noto (Sans|Serif) CJK|SourceHan|Source Han|WenQuanYi|Nanum|Unifont|DroidSansFallback|AR PL)'
+}
+
+if [ "$HAS_CJK" = 1 ] && ! has_cjk_font; then
+  echo "CJK_FONT_MISSING"
+fi
+```
+
+If the gate prints `CJK_FONT_MISSING`, **stop — do not render or attach a PDF.**
+Tell the user, honestly, that this is a restart-required boot setting, e.g.:
+
+> This report has Korean/Japanese/Chinese text, but the container has no CJK font
+> — they're opt-in, so the PDF would come out as tofu boxes. Want me to set
+> `docker.file.cjkFonts: true` in `typeclaw.json`? It's a boot setting, so after I
+> edit it you'll need to run `typeclaw restart` from the host project directory,
+> and then I'll regenerate the PDF.
+
+Only after the user agrees: edit `typeclaw.json` to set `docker.file.cjkFonts:
+true` (use the `typeclaw-config` skill), ask them to `typeclaw restart`, and
+regenerate the PDF **after** the restarted container reports `has_cjk_font` true.
+If the markdown has no CJK, or a CJK font is present, skip straight to Step 3.
 
 ## Step 3 — render
 


### PR DESCRIPTION
## Background

Observed in a live Slack thread: an agent ran a research task and then failed to deliver the report three times in a row.

1. Asked for the result → posted a 3-sentence inline **summary**, not the report.
2. Asked for "the report" → attached the raw **`.md`** file (a PDF was expected).
3. Asked for a PDF → attached a PDF with **mojibake Korean** and **unrendered markdown** (literal `##` / `**`).

Forensics on the artifacts pinned the root causes:

- The source `.md` had perfect Korean, so corruption happened only at PDF time. The broken PDF embedded **only `/Helvetica`** (a base-14 font with zero CJK glyphs) and carried **no Typst/Chrome producer metadata** — meaning the agent never ran the sanctioned `typeclaw-markdown-pdf` (Typst) skill at all. It hand-rolled a PDF with an ad-hoc library and dumped raw markdown text.
- The only PDF-delivery guidance in the prompt was gated on `researcher` **subagent** results, so a generic "give me the report / as a PDF" request had no routing to the skill, and the researcher's 2-3 sentence `<summary>` was mistaken for the deliverable.
- Even when the skill *is* used, CJK fonts are **opt-in** (`docker.file.cjkFonts`, default off on non-CJK hosts). Typst doesn't *fail* on a missing CJK font — it substitutes `.notdef` tofu and the render "succeeds", so a broken PDF ships unnoticed.

## Summary

Two coupled fixes, one per commit:

- **Skill (`typeclaw-markdown-pdf`)**: keep CJK fonts opt-in, but stop shipping tofu. Before rendering, the skill now detects CJK text in the markdown (Hangul/Kana/CJK-ideograph codepoints, `grep -P` with a perl fallback) and checks whether a CJK font Typst can load is present (`fonts-noto-cjk` via `dpkg` + a `/usr/share/fonts` scan — not fontconfig, which Typst bypasses). If CJK text has no font, it **stops and asks the user** to enable `docker.file.cjkFonts` and `typeclaw restart` before regenerating, rather than delivering a broken PDF. It **never auto-downloads or vendors a font**. Also bans ad-hoc PDF libraries (jsPDF/pdfkit/raw-text) and surfaces report/PDF trigger terms in the description so these requests reliably load the skill.
- **Prompt routing**: add a general "Delivering reports and documents" block to the base system prompt, and broaden the channel report-delivery guidance from researcher-only to **any** report/document/PDF request. Both state a summary is a *pointer* (never the deliverable), route Markdown→PDF through the skill, forbid ad-hoc PDF libraries, and require the CJK gate (ask before shipping tofu).

**Why ask instead of auto-fixing the font:** CJK fonts are intentionally opt-in (the ~89 MB `fonts-noto-cjk` apt layer isn't paid for by users who never render CJK, mirroring the existing `cloudflared`/`xvfb` toggles). Auto-downloading a font would defeat the opt-in *and* hide the failure from the user. The right behavior is to make the failure observable and offer the one-line fix. `cjkFonts` is a restart-required boot setting, and the skill's wording is honest about that.

## Preview

On a host with no CJK font, the gate fires correctly: a Korean markdown doc → `CJK_FONT_MISSING` (stop + ask); an English-only doc → renders straight through (no false positive). This reproduces the broken-container scenario from the incident — the agent now asks instead of shipping tofu.

## What this does NOT do

- Does not change the `docker.file.cjkFonts` default or the Dockerfile font layer — CJK fonts stay opt-in.
- Does not auto-download, vendor, or bake any font.
- Does not add a runtime/tool-level hard block on ad-hoc PDF libraries; the deterrent is prompt + skill guidance (the skill is lazy-loaded by description match).
- Does not touch the `researcher` subagent's output contract.

## Review notes

- Load-bearing change is the new "## Handling CJK content" gate in `SKILL.md`: the CJK-codepoint detection regex and the `has_cjk_font` check (`dpkg` + file scan, deliberately not `fc-list`). Skill-content tests assert the gate exists, the opt-in/restart wording is present, the detection ranges cover Hangul/Kana/ideographs, and that **no** font download/vendoring sneaks back in.
- `renderResearchReportDeliveryGuidance` is now general; its tests assert the broadened wording, the summary-is-not-the-deliverable rule, the ad-hoc-lib ban, the CJK-gate line, and that GitHub (no attachments) still omits the block.
- Full suite green (7882 pass / 0 fail); typecheck, lint (0 errors), and format clean.
