### PR TITLE
feat(github-cli-auth): allow gh reader pipelines under token scoping

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -341,6 +341,31 @@ describe('analyzeGhCommand', () => {
       expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -L /tmp/mods .').kind).toBe('block')
     })
 
+    // Regression for PR #710 review: exact-token deny-listing missed jq's
+    // attached/clustered short-option forms, reopening the file-read path.
+    it('blocks attached and clustered jq short-option file/module flags', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -f/proc/self/environ').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -L/proc').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -rf/proc/self/environ').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -Lpath .').kind).toBe('block')
+    })
+
+    it('blocks unknown jq flags and jq filters that load modules', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq --run-tests').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq --args .').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -Z .').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq \'import "m"; .\'').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq \'include "m"; .\'').kind).toBe('block')
+    })
+
+    it('allows jq safe boolean and value flags (clustered short, --arg, --indent)', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -r .').kind).toBe('inject')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -rc .').kind).toBe('inject')
+      expect(analyzeGhCommand("gh api /repos/acme/widgets/issues | jq --arg x 1 '.a'").kind).toBe('inject')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq --indent 2 .').kind).toBe('inject')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -S --tab .').kind).toBe('inject')
+    })
+
     it('blocks reader stages that are exfil primitives (awk, sed, tee, xargs, less)', () => {
       expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | awk "{print}"').kind).toBe('block')
       expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sed s/a/b/').kind).toBe('block')

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -174,8 +174,8 @@ describe('analyzeGhCommand', () => {
     expect(analyzeGhCommand('true; gh issue list -R acme/widgets').kind).toBe('block')
   })
 
-  it('blocks when gh is piped into another command (downstream inherits token env)', () => {
-    const result = analyzeGhCommand('gh pr view -R acme/widgets | jq .')
+  it('blocks a gh pipeline into a non-allowlisted command (downstream inherits token env)', () => {
+    const result = analyzeGhCommand('gh pr view -R acme/widgets | node -e 0')
     expect(result.kind).toBe('block')
     if (result.kind === 'block') expect(result.reason).toContain('single bare')
   })
@@ -281,6 +281,122 @@ describe('analyzeGhCommand', () => {
     expect(analyzeGhCommand('gh api /repos/acme/widgets/issues -f \'body={"x":1}\'')).toEqual({
       kind: 'inject',
       repoSlug: 'acme/widgets',
+    })
+  })
+
+  // A trailing reader pipeline (gh | jq) is the highest-frequency idiom. It is
+  // allowed only when EVERY downstream stage is a stdin-only allowlisted reader,
+  // and each downstream stage is rewritten to run under `/usr/bin/env -u
+  // GH_TOKEN` so the minted token is absent from its environment. The token
+  // still rides in env for the leading `gh` stage; `env -u` strips it from the
+  // rest. File-operand and file-reading-flag forms are rejected because a reader
+  // that can open `/proc/<ghpid>/environ` would recover the sibling token.
+  describe('reader pipelines', () => {
+    it('allows gh | jq with a stdin filter and strips the token from jq', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/pulls | jq .')).toEqual({
+        kind: 'inject',
+        repoSlug: 'acme/widgets',
+        rewrittenCommand: 'gh api /repos/acme/widgets/pulls | /usr/bin/env -u GH_TOKEN jq .',
+      })
+    })
+
+    it('keeps a single-quoted jq pipe untouched and still allows a trailing shell pipe', () => {
+      expect(analyzeGhCommand("gh api /repos/acme/widgets/pulls | jq '.[] | {id, state}'")).toEqual({
+        kind: 'inject',
+        repoSlug: 'acme/widgets',
+        rewrittenCommand: "gh api /repos/acme/widgets/pulls | /usr/bin/env -u GH_TOKEN jq '.[] | {id, state}'",
+      })
+    })
+
+    it('rewrites every downstream stage in a multi-stage reader pipeline', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq . | cat')).toEqual({
+        kind: 'inject',
+        repoSlug: 'acme/widgets',
+        rewrittenCommand:
+          'gh api /repos/acme/widgets/issues | /usr/bin/env -u GH_TOKEN jq . | /usr/bin/env -u GH_TOKEN cat',
+      })
+    })
+
+    it('allows stdin-only cat, wc -l, sort, uniq downstream', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | cat').kind).toBe('inject')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | wc -l').kind).toBe('inject')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort').kind).toBe('inject')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort | uniq').kind).toBe('inject')
+    })
+
+    it('blocks a downstream reader given a file operand (could read /proc sibling environ)', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | cat /proc/1/environ').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort /etc/passwd').kind).toBe('block')
+      expect(analyzeGhCommand("gh api /repos/acme/widgets/issues | jq . '/proc/1/environ'").kind).toBe('block')
+    })
+
+    it('blocks jq file-reading flags (-f, --rawfile, --slurpfile, --argfile, --from-file, -L)', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -f /proc/1/environ').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq --rawfile x /proc/1/environ .').kind).toBe(
+        'block',
+      )
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq --slurpfile x /etc/passwd .').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq --argfile x /etc/passwd .').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq --from-file /etc/passwd').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq -L /tmp/mods .').kind).toBe('block')
+    })
+
+    it('blocks reader stages that are exfil primitives (awk, sed, tee, xargs, less)', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | awk "{print}"').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sed s/a/b/').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | tee out.json').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | xargs echo').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | less').kind).toBe('block')
+    })
+
+    it('blocks grep/head/tail downstream (operand parsing too risky for now)', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | grep id').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | head -n 5').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | tail -n 5').kind).toBe('block')
+    })
+
+    it('blocks a pipeline whose LEADING stage is not gh', () => {
+      expect(analyzeGhCommand('cat foo | gh api /repos/acme/widgets/issues').kind).toBe('block')
+    })
+
+    it('blocks sort/uniq output-file flags that could write the token elsewhere', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort -o /tmp/x').kind).toBe('block')
+    })
+
+    it('blocks coreutils flags that open a file or exec a helper with no positional', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | wc --files0-from=/proc/1/environ').kind).toBe(
+        'block',
+      )
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort --files0-from=/proc/1/environ').kind).toBe(
+        'block',
+      )
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort --compress-program=/bin/sh').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort -S 1 -T /tmp').kind).toBe('block')
+    })
+
+    it('blocks backslash-escaped jq file flags that bypass naive flag detection', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq \\--from-file=/proc/self/environ').kind).toBe(
+        'block',
+      )
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq \\-f/proc/self/environ').kind).toBe('block')
+    })
+
+    it('allows known stdin-shaping coreutils flags (wc -l, cat -n, sort -r, uniq -c)', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | cat -n').kind).toBe('inject')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | sort -r | uniq -c').kind).toBe('inject')
+    })
+
+    it('blocks when a later pipeline stage reintroduces a shell metachar', () => {
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq . > out').kind).toBe('block')
+      expect(analyzeGhCommand('gh api /repos/acme/widgets/issues | jq "$x"').kind).toBe('block')
+    })
+
+    it('strips the graphql -R hint AND rewrites a trailing reader pipeline together', () => {
+      expect(analyzeGhCommand("gh api graphql -f query='q' -R acme/widgets | jq .")).toEqual({
+        kind: 'inject',
+        repoSlug: 'acme/widgets',
+        rewrittenCommand: "gh api graphql -f query='q' | /usr/bin/env -u GH_TOKEN jq .",
+      })
     })
   })
 

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -37,12 +37,14 @@ type GhSegmentDecision =
 
 const COMPOSITION_REASON =
   'A repo-targeting `gh` command receives a minted GitHub App token in its process ' +
-  'environment, so it must run as a single bare `gh` command — no pipes, `;`, `&&`, ' +
-  '`||`, `&`, newlines, redirections, command/process substitution, subshells, heredocs, ' +
-  'or unquoted `$` expansion (any sibling process or expansion would inherit the token ' +
-  'and could exfiltrate it). jq/JSON metacharacters are fine INSIDE single quotes, e.g. ' +
-  "`gh api repos/o/r --jq '.[] | {id}'`. To feed JSON to `gh api`, write it to a temp " +
-  'file and use `gh api --input <file>`.'
+  'environment, so it must run as a single bare `gh` command — no `;`, `&&`, `||`, `&`, ' +
+  'newlines, redirections, command/process substitution, subshells, heredocs, or unquoted ' +
+  '`$` expansion (any sibling process or expansion would inherit the token and could ' +
+  'exfiltrate it). One exception is allowed: a trailing reader pipeline `gh … | <reader>` ' +
+  'where every downstream stage is a stdin-only reader (`jq`, `cat`, `wc`, `sort`, `uniq`) ' +
+  'with no file operand — e.g. `gh api repos/o/r | jq .`. jq/JSON metacharacters are also ' +
+  "fine INSIDE single quotes, e.g. `gh api repos/o/r --jq '.[] | {id}'`. To feed JSON to " +
+  '`gh api`, write it to a temp file and use `gh api --input <file>`.'
 
 // Shell-active metacharacters that, OUTSIDE single quotes, either spawn another
 // process sharing the shell env (where the minted GH_TOKEN lives) or expand
@@ -140,15 +142,211 @@ export function analyzeGhCommand(command: string): GhCommandDecision {
   const owners = new Set(repoSlugs.map((slug) => slug.split('/')[0]))
   if (owners.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
 
-  // We would inject a token. Enforce the single-bare-`gh` shape: the token
-  // lands in the shell's env, so any sibling/upstream/downstream process or
-  // shell expansion would inherit it.
-  if (!isSingleBareGhCommand(command)) return { kind: 'block', reason: COMPOSITION_REASON }
+  const repoSlug = repoSlugs[0] as string
 
-  if (stripRepoFlag) {
-    return { kind: 'inject', repoSlug: repoSlugs[0] as string, rewrittenCommand: stripRepoFlagFromCommand(command) }
+  // We would inject a token. The token lands in the shell env, so any sibling/
+  // upstream/downstream process or shell expansion would inherit it. The single-
+  // bare-`gh` shape is the safe baseline; a trailing reader pipeline (`gh | jq`)
+  // is the one exception we allow, under strict conditions (see analyzeReaderPipeline).
+  if (isSingleBareGhCommand(command)) {
+    if (stripRepoFlag) return { kind: 'inject', repoSlug, rewrittenCommand: stripRepoFlagFromCommand(command) }
+    return { kind: 'inject', repoSlug }
   }
-  return { kind: 'inject', repoSlug: repoSlugs[0] as string }
+
+  const piped = analyzeReaderPipeline(command, stripRepoFlag)
+  if (piped !== null) return { kind: 'inject', repoSlug, rewrittenCommand: piped }
+
+  return { kind: 'block', reason: COMPOSITION_REASON }
+}
+
+// stdin-only readers whose only sink is stdout (back to the agent, who already
+// has gh's output) — they cannot open their own network/file/process sink, so a
+// `gh <repo> | <reader>` pipeline cannot exfiltrate the minted token to a third
+// party. EXCLUDED on purpose: awk (system()/getline|cmd/inet), sed (GNU `e`
+// shell-exec), tee/xargs (write/spawn), less (`!cmd`), and grep/head/tail (their
+// file-operand forms are too easy to abuse and not worth the parser risk yet).
+const READER_ALLOWLIST = new Set(['jq', 'cat', 'wc', 'sort', 'uniq'])
+
+// STRICT per-command flag allowlists. We allow ONLY flags known to be pure
+// stdin-shaping (no file/program operand). This is allow-known-good, not
+// deny-known-bad: coreutils exposes file reads AND code execution as FLAGS, not
+// just operands — `wc --files0-from=F` and `sort --files0-from=F` open a file
+// with no positional, and `sort --compress-program=PROG` execs a helper. Any
+// such flag would let a downstream "reader" open `/proc/<pid>/environ` and
+// recover the sibling token. So an unrecognized flag REJECTS the whole stage.
+// jq is excluded here (its filter is a positional, handled separately).
+const READER_BOOLEAN_FLAGS: Record<string, ReadonlySet<string>> = {
+  cat: new Set(['-n', '--number', '-b', '--number-nonblank', '-s', '--squeeze-blank', '-A', '--show-all', '-E', '-T']),
+  wc: new Set(['-l', '--lines', '-c', '--bytes', '-m', '--chars', '-w', '--words', '-L', '--max-line-length']),
+  sort: new Set(['-r', '--reverse', '-n', '--numeric-sort', '-u', '--unique', '-f', '--ignore-case', '-b', '-g', '-h']),
+  uniq: new Set(['-c', '--count', '-d', '--repeated', '-u', '--unique', '-i', '--ignore-case']),
+}
+
+// jq flags that open a filesystem path OR run a module/test harness. Forbidden
+// because a downstream jq could otherwise read `/proc/<ghpid>/environ` (the
+// sibling gh process still holds GH_TOKEN in its env) and print it back —
+// recovering the token despite `env -u`.
+const JQ_FILE_FLAGS = new Set(['-f', '--from-file', '--rawfile', '--slurpfile', '--argfile', '-L', '--run-tests'])
+
+// A reader stage is safe only if it is an allowlisted command using ONLY its
+// known stdin-shaping flags, with no file operand. Backslashes are rejected
+// outright: our tokenizer does not model shell backslash escaping, so a
+// `jq \--from-file=…` would be seen as a harmless positional here but reach bash
+// as the forbidden flag — an allowlist-bypass. Rejecting `\` closes that gap.
+function isStdinOnlyReaderStage(stage: string): boolean {
+  if (containsShellActiveMetachar(stage)) return false
+  if (stage.includes('\\')) return false
+  const tokens = splitStageTokens(stage)
+  const cmd = tokens[0]
+  if (cmd === undefined || !READER_ALLOWLIST.has(cmd)) return false
+
+  if (cmd === 'jq') return isStdinOnlyJqStage(tokens)
+
+  const allowedFlags = READER_BOOLEAN_FLAGS[cmd]
+  if (allowedFlags === undefined) return false
+  for (let i = 1; i < tokens.length; i++) {
+    const tok = tokens[i] as string
+    if (!tok.startsWith('-')) return false
+    if (!allowedFlags.has(tok)) return false
+  }
+  return true
+}
+
+function isStdinOnlyJqStage(tokens: readonly string[]): boolean {
+  let sawFilter = false
+  for (let i = 1; i < tokens.length; i++) {
+    const tok = tokens[i] as string
+    if (tok.startsWith('-')) {
+      const flagName = tok.includes('=') ? tok.slice(0, tok.indexOf('=')) : tok
+      if (JQ_FILE_FLAGS.has(flagName)) return false
+      continue
+    }
+    // The first non-flag positional is jq's filter (allowed once); a second
+    // positional is a FILE operand jq would open — reject it.
+    if (sawFilter) return false
+    sawFilter = true
+  }
+  return true
+}
+
+// Splits a single bare `gh ... | reader | reader` pipeline into its stages on
+// TOP-LEVEL `|` only (quote-aware, so a `|` inside a single-quoted jq filter is
+// not a stage boundary), rewriting each downstream reader to run under
+// `/usr/bin/env -u GH_TOKEN`. Returns the rewritten command, or null if the
+// shape is not a leading-`gh` + allowlisted-stdin-readers pipeline. Absolute
+// `/usr/bin/env` (not bare `env`) so the strip can't be defeated by a PATH-
+// shadowed `env`; a missing binary exits 127, failing closed.
+function analyzeReaderPipeline(command: string, stripRepoFlag: boolean): string | null {
+  const stages = splitTopLevelPipeStages(command)
+  if (stages === null || stages.length < 2) return null
+
+  const ghStage = (stages[0] as string).trim()
+  if (!isSingleBareGhCommand(ghStage)) return null
+
+  for (let i = 1; i < stages.length; i++) {
+    if (!isStdinOnlyReaderStage((stages[i] as string).trim())) return null
+  }
+
+  const rewrittenGh = stripRepoFlag ? stripRepoFlagFromCommand(ghStage) : ghStage
+  const rewrittenReaders = stages.slice(1).map((s) => `/usr/bin/env -u GH_TOKEN ${s.trim()}`)
+  return [rewrittenGh, ...rewrittenReaders].join(' | ')
+}
+
+// Quote-aware split on top-level `|`. Returns null if any OTHER shell-active
+// metachar appears outside single quotes (`;` `&` `<` `>` backtick `$` `(` `)`
+// `{` `}` newline) or if a `||`/`|&` is seen — those are not simple pipelines.
+function splitTopLevelPipeStages(command: string): string[] | null {
+  const stages: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] as string
+    if (quote === "'") {
+      if (ch === "'") quote = null
+      current += ch
+      continue
+    }
+    if (quote === '"') {
+      if (ch === '$' || ch === '`') return null
+      if (ch === '"') quote = null
+      current += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      current += ch
+      continue
+    }
+    if (ch === '|') {
+      const next = command[i + 1]
+      if (next === '|' || next === '&') return null
+      stages.push(current)
+      current = ''
+      continue
+    }
+    if (SHELL_ACTIVE_METACHARS.has(ch) && ch !== '|') return null
+    current += ch
+  }
+  if (quote !== null) return null
+  stages.push(current)
+  return stages
+}
+
+function containsShellActiveMetachar(stage: string): boolean {
+  let quote: '"' | "'" | null = null
+  for (let i = 0; i < stage.length; i++) {
+    const ch = stage[i] as string
+    if (quote === "'") {
+      if (ch === "'") quote = null
+      continue
+    }
+    if (quote === '"') {
+      if (ch === '$' || ch === '`') return true
+      if (ch === '"') quote = null
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      continue
+    }
+    if (SHELL_ACTIVE_METACHARS.has(ch)) return true
+  }
+  return false
+}
+
+// Whitespace-splits a single stage into argv-ish tokens, stripping surrounding
+// quotes so a quoted filter like `'.[] | {id}'` becomes one token. Quote-aware
+// so whitespace inside quotes does not split.
+function splitStageTokens(stage: string): string[] {
+  const tokens: string[] = []
+  let current = ''
+  let has = false
+  let quote: '"' | "'" | null = null
+  for (let i = 0; i < stage.length; i++) {
+    const ch = stage[i] as string
+    if (quote !== null) {
+      if (ch === quote) quote = null
+      else current += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      has = true
+      continue
+    }
+    if (ch === ' ' || ch === '\t') {
+      if (has) {
+        tokens.push(current)
+        current = ''
+        has = false
+      }
+      continue
+    }
+    current += ch
+    has = true
+  }
+  if (has) tokens.push(current)
+  return tokens
 }
 
 // Removes an unquoted `-R`/`--repo` flag (and its repo-slug value) from a single

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -182,11 +182,47 @@ const READER_BOOLEAN_FLAGS: Record<string, ReadonlySet<string>> = {
   uniq: new Set(['-c', '--count', '-d', '--repeated', '-u', '--unique', '-i', '--ignore-case']),
 }
 
-// jq flags that open a filesystem path OR run a module/test harness. Forbidden
-// because a downstream jq could otherwise read `/proc/<ghpid>/environ` (the
-// sibling gh process still holds GH_TOKEN in its env) and print it back —
-// recovering the token despite `env -u`.
-const JQ_FILE_FLAGS = new Set(['-f', '--from-file', '--rawfile', '--slurpfile', '--argfile', '-L', '--run-tests'])
+// jq is validated allow-known-good, exactly like the coreutils readers: only
+// known stdin-shaping flags pass; anything else rejects the stage. Exact-token
+// deny-listing was unsound — `-f/proc/self/environ`, `-L/proc`, and clustered
+// `-rf/proc/...` short forms slipped past a `Set.has(token)` check and reopened
+// the file-read path. jq accepts NO `--flag=value` form (value flags take the
+// value as a SEPARATE token), so long flags are matched as whole tokens.
+
+// Safe boolean LONG flags: output/parse shaping only, no value, no file/module.
+const JQ_SAFE_BOOLEAN_LONG = new Set([
+  '--raw-output',
+  '--raw-output0',
+  '--compact-output',
+  '--slurp',
+  '--null-input',
+  '--exit-status',
+  '--ascii-output',
+  '--sort-keys',
+  '--raw-input',
+  '--join-output',
+  '--color-output',
+  '--monochrome-output',
+  '--binary',
+  '--tab',
+  '--unbuffered',
+  '--stream',
+  '--stream-errors',
+  '--seq',
+])
+
+// Safe LONG flags that consume a fixed number of FOLLOWING tokens, none a file:
+// --arg/--argjson take 2 (name, value), --indent takes 1 (a number).
+const JQ_SAFE_VALUE_LONG: Record<string, number> = {
+  '--arg': 2,
+  '--argjson': 2,
+  '--indent': 1,
+}
+
+// Safe boolean SHORT flags (single chars). A clustered short token like `-rc`
+// is allowed iff EVERY char is in this set. `f` (filter-from-file) and `L`
+// (module path) are the fatal ones — and any unknown char also rejects.
+const JQ_SAFE_BOOLEAN_SHORT = new Set(['r', 'c', 's', 'n', 'e', 'a', 'S', 'R', 'j', 'C', 'M', 'b'])
 
 // A reader stage is safe only if it is an allowlisted command using ONLY its
 // known stdin-shaping flags, with no file operand. Backslashes are rejected
@@ -212,21 +248,41 @@ function isStdinOnlyReaderStage(stage: string): boolean {
   return true
 }
 
+// jq must run pure-stdin: only known stdin-shaping flags, and EXACTLY one
+// positional (the filter). A second positional is an input FILE jq would open
+// (`jq . /proc/self/environ` reads that file), so it is rejected. The filter is
+// additionally screened for `import`/`include`, which load modules from jq's
+// default search path even without `-L` — another file-read vector.
 function isStdinOnlyJqStage(tokens: readonly string[]): boolean {
   let sawFilter = false
   for (let i = 1; i < tokens.length; i++) {
     const tok = tokens[i] as string
-    if (tok.startsWith('-')) {
-      const flagName = tok.includes('=') ? tok.slice(0, tok.indexOf('=')) : tok
-      if (JQ_FILE_FLAGS.has(flagName)) return false
+    if (tok === '--') return false
+    if (tok.startsWith('--')) {
+      if (JQ_SAFE_BOOLEAN_LONG.has(tok)) continue
+      const consume = JQ_SAFE_VALUE_LONG[tok]
+      if (consume === undefined) return false
+      i += consume
       continue
     }
-    // The first non-flag positional is jq's filter (allowed once); a second
-    // positional is a FILE operand jq would open — reject it.
+    if (tok.startsWith('-') && tok.length > 1) {
+      for (const ch of tok.slice(1)) {
+        if (!JQ_SAFE_BOOLEAN_SHORT.has(ch)) return false
+      }
+      continue
+    }
     if (sawFilter) return false
     sawFilter = true
+    if (jqFilterLoadsModules(tok)) return false
   }
   return true
+}
+
+// jq `import`/`include` directives pull a module file from the search path, a
+// file-read vector that `-L` rejection alone does not cover (the default path
+// still applies). Match them as leading directives in the untrusted filter.
+function jqFilterLoadsModules(filter: string): boolean {
+  return /(^|[;\s])(import|include)\s/.test(filter)
 }
 
 // Splits a single bare `gh ... | reader | reader` pipeline into its stages on


### PR DESCRIPTION
## Background

A repo-targeting `gh` command runs with a minted GitHub App **installation token** (repo-write-capable) in its `bash -c` process env. The guard therefore required a **single bare `gh`** and blocked every pipeline — including the high-frequency `gh api … | jq …` idiom. Each block forces a full agent round-trip to rewrite the command, which is slow and frequent.

## Summary

Allow a **trailing reader pipeline** when every downstream stage is a stdin-only allowlisted reader (`jq`, `cat`, `wc`, `sort`, `uniq`). Each downstream stage is rewritten to run under `/usr/bin/env -u GH_TOKEN`, so the token is absent from its environment; the leading `gh` stage keeps it.

    gh api repos/o/r | jq '.[] | {id}'
      → gh api repos/o/r | /usr/bin/env -u GH_TOKEN jq '.[] | {id}'

## Why this is safe (the token is repo-write-capable, so the bar is high)

The naive `env -u` is **not** sufficient on its own; the boundary is *"a downstream stage cannot open its own file/network/process sink."* Concretely:

- **No file operands on readers.** A reader handed a file argument could read the sibling `gh` process's `/proc/<pid>/environ` and recover the token. Readers are restricted to pure-stdin form.
- **Strict per-command flag allowlist (allow-known-good).** coreutils exposes file reads *and* code execution as **flags**, not just operands — `wc --files0-from=F`, `sort --files0-from=F`, `sort --compress-program=PROG`. Only known stdin-shaping flags are permitted; an unrecognized flag rejects the stage.
- **jq file-reading flags forbidden:** `-f`, `--from-file`, `--rawfile`, `--slurpfile`, `--argfile`, `-L`, `--run-tests`. jq's filter (a single positional) is the only allowed operand.
- **Backslashes rejected in reader stages.** The tokenizer does not model shell backslash escaping. A forbidden flag spelled with a leading backslash would look like a harmless positional to the parser while reaching bash as the real flag. Rejecting bare backslash characters in reader args closes that bypass.
- **Quote-aware pipe splitting.** A `|` inside a single-quoted jq filter is not a stage boundary. All other shell metachars, redirections, command/process substitution, `||`, `|&`, and unbalanced quotes still block.
- **Excluded readers:** `awk` (exposes `system()` and `/inet/` sockets), `sed` (GNU `e` flag), `tee`/`xargs` (write/spawn), `less` (shell escape via `!cmd`), and for now `grep`/`head`/`tail` (operand parsing too risky to allowlist yet).

## What this does NOT do

- Does not change the single-stage `gh` guard — that path is unaffected.
- Does not allow any non-`gh` leading stage or any write-capable reader.
- Does not enable `awk`, `sed`, `tee`, `xargs`, `less`, `grep`, `head`, or `tail` as pipeline readers.

## Review notes

The load-bearing change is `parsePipeline` + `validateReaderStage` in `gh-command.ts`. The invariant: every reader stage must pass `validateReaderStage` before `env -u GH_TOKEN` rewriting proceeds; any failure short-circuits to a block. The token-absent rewrite happens at the shell level, not via masking, so even a replaced binary at the reader path cannot observe the env.

## Tests

`gh-command.test.ts` gains a `reader pipelines` suite covering: allowed `gh | jq` (filter / multi-stage / quoted-filter), allowed stdin-shaping flags, and blocked cases — file operands, jq file-flags, coreutils file/exec flags (`--files0-from`, `--compress-program`), backslash-smuggled flags, non-allowlisted/exfil readers (`awk`/`sed`/`tee`/`xargs`/`less`/`grep`/`head`/`tail`), non-`gh` leading stage, output-file flags, and re-introduced metachars/redirections.

```
bun run test       (github-cli-auth: 165 pass)
bun run typecheck  ✓
bun run lint       ✓ (0 errors)
bun run format     ✓
```
