### PR TITLE
feat: add xAI (Grok) provider with API-key and OAuth support

### DIFF
--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -167,9 +167,15 @@ describe('KNOWN_PROVIDER_VENDORS', () => {
     expect(variantLabel('zai', 'zai-coding')).toBe('Coding Plan')
   })
 
-  test('Anthropic and Fireworks are single-provider vendors (no variant step)', () => {
+  test('Anthropic, Fireworks, and xAI are single-provider vendors (no variant step)', () => {
     expect(providerIdsForVendor('anthropic')).toEqual(['anthropic'])
     expect(providerIdsForVendor('fireworks')).toEqual(['fireworks'])
+    expect(providerIdsForVendor('xai')).toEqual(['xai'])
+  })
+
+  test('xAI vendor resolves to the single dual-auth xai provider', () => {
+    expect(vendorForProviderId('xai')).toBe('xai')
+    expect(KNOWN_PROVIDER_VENDORS.xai.name).toBe('xAI (Grok)')
   })
 })
 

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -203,11 +203,19 @@ describe('listKnownModelRefs', () => {
     expect(refs).toContain('anthropic/claude-opus-4-8')
   })
 
-  test('includes the xai Grok models', () => {
+  test('includes the current xai Grok models', () => {
     const refs = listKnownModelRefs()
-    expect(refs).toContain('xai/grok-4-fast')
-    expect(refs).toContain('xai/grok-4')
-    expect(refs).toContain('xai/grok-code-fast-1')
+    expect(refs).toContain('xai/grok-4.3')
+    expect(refs).toContain('xai/grok-4.20-0309-reasoning')
+    expect(refs).toContain('xai/grok-4.20-0309-non-reasoning')
+    expect(refs).toContain('xai/grok-build-0.1')
+  })
+
+  test('does not list xai models retired on 2026-05-15', () => {
+    const refs = listKnownModelRefs()
+    expect(refs).not.toContain('xai/grok-4-fast')
+    expect(refs).not.toContain('xai/grok-4')
+    expect(refs).not.toContain('xai/grok-code-fast-1')
   })
 })
 

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -97,6 +97,21 @@ describe('KNOWN_PROVIDERS', () => {
       expect(model.api, `anthropic/${modelId} api drift`).toBe('anthropic-messages')
     }
   })
+
+  test('xai supports both api-key and oauth against the native x.ai endpoint', () => {
+    const xai = KNOWN_PROVIDERS.xai
+    expect(xai.baseUrl).toBe('https://api.x.ai/v1')
+    expect(xai.apiKeyEnv).toBe('XAI_API_KEY')
+    expect(xai.oauthProviderId).toBe('xai')
+    expect(supportsApiKey(xai)).toBe(true)
+    expect(supportsOAuth(xai)).toBe(true)
+  })
+
+  test('every xai model uses the openai-completions api (x.ai is OpenAI-compatible)', () => {
+    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.xai.models)) {
+      expect(model.api, `xai/${modelId} api drift`).toBe('openai-completions')
+    }
+  })
 })
 
 describe('KNOWN_PROVIDER_VENDORS', () => {
@@ -186,6 +201,13 @@ describe('listKnownModelRefs', () => {
     expect(refs).toContain('anthropic/claude-sonnet-4-6')
     expect(refs).toContain('anthropic/claude-opus-4-7')
     expect(refs).toContain('anthropic/claude-opus-4-8')
+  })
+
+  test('includes the xai Grok models', () => {
+    const refs = listKnownModelRefs()
+    expect(refs).toContain('xai/grok-4-fast')
+    expect(refs).toContain('xai/grok-4')
+    expect(refs).toContain('xai/grok-code-fast-1')
   })
 })
 

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -477,9 +477,21 @@ export const KNOWN_PROVIDERS = {
   //     XAI_API_KEY in .env — remove it (`typeclaw provider remove xai`) to fall
   //     back to the key.
   //
-  // Costs and context windows mirror the xAI pricing/models docs as of
-  // 2026-06-08. Grok 4 Fast is the cheap default; grok-code-fast-1 is the
-  // coding-tuned model. When refreshing, rerun `scripts/generate-schema.ts`.
+  // Costs and context windows mirror docs.x.ai/developers/models and the raw
+  // /v1/models price fields as of 2026-06-08 (xAI quotes prices in cents per
+  // 100M tokens; e.g. grok-4.3 prompt 12500 = $1.25/1M). grok-4.3 is the
+  // flagship default; grok-build-0.1 is the coding-tuned model. The
+  // grok-4.20-0309 snapshots are pinned weights for reproducible runs.
+  //
+  // The earlier grok-4 / grok-4-fast / grok-code-fast-1 ids were RETIRED on
+  // 2026-05-15 — they still resolve but silently redirect (and bill) at the
+  // grok-4.3 / grok-build-0.1 rates, so they are intentionally NOT listed.
+  //
+  // cacheWrite is 0: xAI publishes no cache-write price (caching is implicit,
+  // billed only at the cacheRead rate). Models 1-4 also carry a long-context
+  // tier (2x rates above a 200k-token request); pi-ai's Model shape can't
+  // express tiered pricing, so the standard rate is used and the breakpoint is
+  // noted here. When refreshing, rerun `scripts/generate-schema.ts`.
   xai: {
     id: 'xai',
     name: 'xAI (Grok)',
@@ -488,39 +500,51 @@ export const KNOWN_PROVIDERS = {
     apiKeyEnv: 'XAI_API_KEY',
     oauthProviderId: 'xai',
     models: {
-      'grok-4-fast': {
-        id: 'grok-4-fast',
-        name: 'Grok 4 Fast',
+      'grok-4.3': {
+        id: 'grok-4.3',
+        name: 'Grok 4.3',
         api: 'openai-completions',
         provider: 'xai',
         baseUrl: 'https://api.x.ai/v1',
         reasoning: true,
         input: ['text', 'image'],
-        cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0 },
-        contextWindow: 2000000,
-        maxTokens: 30000,
-      },
-      'grok-4': {
-        id: 'grok-4',
-        name: 'Grok 4',
-        api: 'openai-completions',
-        provider: 'xai',
-        baseUrl: 'https://api.x.ai/v1',
-        reasoning: true,
-        input: ['text', 'image'],
-        cost: { input: 3, output: 15, cacheRead: 0.75, cacheWrite: 0 },
-        contextWindow: 256000,
+        cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+        contextWindow: 1000000,
         maxTokens: 64000,
       },
-      'grok-code-fast-1': {
-        id: 'grok-code-fast-1',
-        name: 'Grok Code Fast 1',
+      'grok-4.20-0309-reasoning': {
+        id: 'grok-4.20-0309-reasoning',
+        name: 'Grok 4.20 (Reasoning)',
         api: 'openai-completions',
         provider: 'xai',
         baseUrl: 'https://api.x.ai/v1',
         reasoning: true,
-        input: ['text'],
-        cost: { input: 0.2, output: 1.5, cacheRead: 0.02, cacheWrite: 0 },
+        input: ['text', 'image'],
+        cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 64000,
+      },
+      'grok-4.20-0309-non-reasoning': {
+        id: 'grok-4.20-0309-non-reasoning',
+        name: 'Grok 4.20 (Non-Reasoning)',
+        api: 'openai-completions',
+        provider: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        reasoning: false,
+        input: ['text', 'image'],
+        cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 64000,
+      },
+      'grok-build-0.1': {
+        id: 'grok-build-0.1',
+        name: 'Grok Build 0.1',
+        api: 'openai-completions',
+        provider: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 1.0, output: 2.0, cacheRead: 0.2, cacheWrite: 0 },
         contextWindow: 256000,
         maxTokens: 64000,
       },

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -463,6 +463,69 @@ export const KNOWN_PROVIDERS = {
       },
     },
   },
+  // xAI (Grok). The native developer API at api.x.ai/v1 is OpenAI-compatible
+  // (Bearer auth + /chat/completions shape), so models go through pi-ai's
+  // `openai-completions` adapter with a custom baseUrl — same trick as
+  // Fireworks and Z.AI. This is a DUAL-AUTH provider like `anthropic`:
+  //   * api-key — XAI_API_KEY (the standard xAI env var), a plain Bearer token.
+  //   * oauth — Grok subscription login via xAI's OIDC server (auth.x.ai),
+  //     authorization-code + PKCE. pi-ai ships no built-in xAI OAuth provider,
+  //     so `oauthProviderId: 'xai'` resolves to the custom provider registered
+  //     in src/secrets/oauth-xai.ts (registered from createSecretsStoreForAgent
+  //     so both init-login and runtime-refresh see it). The dual-auth runtime
+  //     rule in src/agent/auth.ts applies: an OAuth credential on disk wins over
+  //     XAI_API_KEY in .env — remove it (`typeclaw provider remove xai`) to fall
+  //     back to the key.
+  //
+  // Costs and context windows mirror the xAI pricing/models docs as of
+  // 2026-06-08. Grok 4 Fast is the cheap default; grok-code-fast-1 is the
+  // coding-tuned model. When refreshing, rerun `scripts/generate-schema.ts`.
+  xai: {
+    id: 'xai',
+    name: 'xAI (Grok)',
+    baseUrl: 'https://api.x.ai/v1',
+    auth: ['api-key', 'oauth'],
+    apiKeyEnv: 'XAI_API_KEY',
+    oauthProviderId: 'xai',
+    models: {
+      'grok-4-fast': {
+        id: 'grok-4-fast',
+        name: 'Grok 4 Fast',
+        api: 'openai-completions',
+        provider: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0 },
+        contextWindow: 2000000,
+        maxTokens: 30000,
+      },
+      'grok-4': {
+        id: 'grok-4',
+        name: 'Grok 4',
+        api: 'openai-completions',
+        provider: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 3, output: 15, cacheRead: 0.75, cacheWrite: 0 },
+        contextWindow: 256000,
+        maxTokens: 64000,
+      },
+      'grok-code-fast-1': {
+        id: 'grok-code-fast-1',
+        name: 'Grok Code Fast 1',
+        api: 'openai-completions',
+        provider: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 0.2, output: 1.5, cacheRead: 0.02, cacheWrite: 0 },
+        contextWindow: 256000,
+        maxTokens: 64000,
+      },
+    },
+  },
 } as const satisfies Record<string, KnownProvider>
 
 export type KnownProviderId = keyof typeof KNOWN_PROVIDERS

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -603,6 +603,11 @@ export const KNOWN_PROVIDER_VENDORS = {
       'zai-coding': { label: 'Coding Plan', hint: 'GLM Coding Plan subscription' },
     },
   },
+  xai: {
+    id: 'xai',
+    name: 'xAI (Grok)',
+    providers: ['xai'],
+  },
 } as const satisfies Record<string, KnownProviderVendor>
 
 export type KnownProviderVendorId = keyof typeof KNOWN_PROVIDER_VENDORS

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -20,6 +20,7 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
   // catalog. models.dev tracks the underlying model metadata under `zai`,
   // so we route lookups there. The curated entries still get surfaced.
   'zai-coding': 'zai',
+  xai: 'xai',
 }
 
 export type ModelOption = {

--- a/src/init/validate-api-key.ts
+++ b/src/init/validate-api-key.ts
@@ -7,6 +7,7 @@ const PROVIDER_PROBE: Partial<Record<KnownProviderId, { url: string; authHeader:
   fireworks: { url: 'https://api.fireworks.ai/inference/v1/models', authHeader: 'bearer' },
   zai: { url: 'https://api.z.ai/api/paas/v4/models', authHeader: 'bearer' },
   'zai-coding': { url: 'https://api.z.ai/api/coding/paas/v4/models', authHeader: 'bearer' },
+  xai: { url: 'https://api.x.ai/v1/models', authHeader: 'bearer' },
 }
 
 // When a base-URL override (ANTHROPIC_BASE_URL / OPENAI_BASE_URL) points at a
@@ -159,6 +160,7 @@ export const API_KEY_DASHBOARD_URL: Partial<Record<KnownProviderId, string>> = {
   fireworks: 'https://fireworks.ai/account/api-keys',
   zai: 'https://docs.z.ai/devpack/tool/claude#api-key',
   'zai-coding': 'https://docs.z.ai/devpack/tool/claude#api-key',
+  xai: 'https://console.x.ai',
 }
 
 export function providersWithApiKeyProbe(): KnownProviderId[] {

--- a/src/secrets/oauth-xai.test.ts
+++ b/src/secrets/oauth-xai.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { getOAuthProvider, unregisterOAuthProvider } from '@mariozechner/pi-ai/oauth'
+
+import {
+  refreshXaiToken,
+  registerXaiOAuthProvider,
+  xaiOAuthProvider,
+  XAI_OAUTH_PROVIDER_ID,
+  type FetchFn,
+} from './oauth-xai'
+
+function fakeFetch(responder: (url: string, init: RequestInit) => Response | Promise<Response>): FetchFn {
+  return async (url, init) => responder(url, init)
+}
+
+describe('registerXaiOAuthProvider', () => {
+  afterEach(() => {
+    unregisterOAuthProvider(XAI_OAUTH_PROVIDER_ID)
+  })
+
+  test('registers a provider resolvable by getOAuthProvider("xai")', () => {
+    registerXaiOAuthProvider()
+    const provider = getOAuthProvider(XAI_OAUTH_PROVIDER_ID)
+    expect(provider?.id).toBe('xai')
+    expect(provider?.name).toBe('xAI (Grok)')
+    expect(provider?.usesCallbackServer).toBe(true)
+  })
+})
+
+describe('xaiOAuthProvider.getApiKey', () => {
+  test('returns the access token as the bearer api key', () => {
+    expect(xaiOAuthProvider.getApiKey({ access: 'tok', refresh: 'r', expires: 1 })).toBe('tok')
+  })
+})
+
+describe('refreshXaiToken', () => {
+  test('POSTs form-encoded refresh_token grant to the xAI token endpoint', async () => {
+    let capturedUrl: string | undefined
+    let capturedBody: string | undefined
+    let capturedContentType: string | undefined
+
+    await refreshXaiToken(
+      'old-refresh',
+      fakeFetch((url, init) => {
+        capturedUrl = url
+        capturedBody = init.body as string
+        capturedContentType = (init.headers as Record<string, string>)['Content-Type']
+        return new Response(
+          JSON.stringify({ access_token: 'new-access', refresh_token: 'new-refresh', expires_in: 3600 }),
+          { status: 200 },
+        )
+      }),
+    )
+
+    expect(capturedUrl).toBe('https://auth.x.ai/oauth2/token')
+    expect(capturedContentType).toBe('application/x-www-form-urlencoded')
+    const params = new URLSearchParams(capturedBody)
+    expect(params.get('grant_type')).toBe('refresh_token')
+    expect(params.get('refresh_token')).toBe('old-refresh')
+    expect(params.get('client_id')).toBe('b1a00492-073a-47ea-816f-4c329264a828')
+  })
+
+  test('returns rotated credentials with an early-skewed expiry', async () => {
+    const before = Date.now()
+    const creds = await refreshXaiToken(
+      'old-refresh',
+      fakeFetch(
+        () =>
+          new Response(JSON.stringify({ access_token: 'new-access', refresh_token: 'new-refresh', expires_in: 3600 }), {
+            status: 200,
+          }),
+      ),
+    )
+    expect(creds.access).toBe('new-access')
+    expect(creds.refresh).toBe('new-refresh')
+    // 3600s minus the 5-minute skew = 3300s out, give or take test wall time.
+    expect(creds.expires).toBeGreaterThan(before + 3200 * 1000)
+    expect(creds.expires).toBeLessThanOrEqual(Date.now() + 3300 * 1000)
+  })
+
+  test('keeps the prior refresh token when the server omits a rotated one', async () => {
+    const creds = await refreshXaiToken(
+      'old-refresh',
+      fakeFetch(() => new Response(JSON.stringify({ access_token: 'new-access', expires_in: 3600 }), { status: 200 })),
+    )
+    expect(creds.refresh).toBe('old-refresh')
+  })
+
+  test('throws with status and body context on a non-2xx response', async () => {
+    await expect(
+      refreshXaiToken(
+        'old-refresh',
+        fakeFetch(() => new Response('{"error":"invalid_grant"}', { status: 400 })),
+      ),
+    ).rejects.toThrow(/status=400/)
+  })
+})

--- a/src/secrets/oauth-xai.test.ts
+++ b/src/secrets/oauth-xai.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import { createServer, type Server } from 'node:http'
 
 import { getOAuthProvider, unregisterOAuthProvider } from '@mariozechner/pi-ai/oauth'
 
 import {
+  errorHtml,
+  loginXai,
   refreshXaiToken,
   registerXaiOAuthProvider,
   xaiOAuthProvider,
@@ -94,5 +97,65 @@ describe('refreshXaiToken', () => {
         fakeFetch(() => new Response('{"error":"invalid_grant"}', { status: 400 })),
       ),
     ).rejects.toThrow(/status=400/)
+  })
+})
+
+describe('errorHtml', () => {
+  test('escapes a provider-supplied OAuth error so a crafted callback cannot inject markup', () => {
+    const html = errorHtml('Error: <script>alert(1)</script>')
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+})
+
+describe('loginXai callback-server fallback', () => {
+  const CALLBACK_PORT = 56121
+  let blocker: Server | undefined
+
+  afterEach(async () => {
+    if (blocker) {
+      await new Promise<void>((resolve) => blocker!.close(() => resolve()))
+      blocker = undefined
+    }
+  })
+
+  test('falls back to manual paste when the loopback port cannot be bound', async () => {
+    // given: the fixed callback port is already occupied, so startCallbackServer fails to bind
+    blocker = createServer()
+    await new Promise<void>((resolve, reject) => {
+      blocker!.once('error', reject)
+      blocker!.listen(CALLBACK_PORT, '127.0.0.1', () => resolve())
+    })
+
+    let authUrlShown: string | undefined
+    let manualPromptShown = false
+
+    // when: the user pastes the redirect URL via onManualCodeInput
+    const creds = await loginXai(
+      {
+        onAuth: (info) => {
+          authUrlShown = info.url
+        },
+        onManualCodeInput: async () => {
+          manualPromptShown = true
+          return 'manual-code'
+        },
+        onPrompt: async () => {
+          throw new Error('onPrompt should not be reached when onManualCodeInput yields a code')
+        },
+      },
+      fakeFetch((url, init) => {
+        expect(url).toBe('https://auth.x.ai/oauth2/token')
+        expect(new URLSearchParams(init.body as string).get('code')).toBe('manual-code')
+        return new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', expires_in: 3600 }), {
+          status: 200,
+        })
+      }),
+    )
+
+    // then: the auth URL was still shown and the pasted code drove the token exchange
+    expect(authUrlShown).toContain('https://auth.x.ai/oauth2/authorize')
+    expect(manualPromptShown).toBe(true)
+    expect(creds.access).toBe('a')
   })
 })

--- a/src/secrets/oauth-xai.ts
+++ b/src/secrets/oauth-xai.ts
@@ -87,12 +87,28 @@ function successHtml(): string {
   return '<!doctype html><html><body style="font-family:sans-serif;padding:2rem"><h2>xAI authentication complete.</h2><p>You can close this window and return to the terminal.</p></body></html>'
 }
 
-function errorHtml(message: string): string {
-  return `<!doctype html><html><body style="font-family:sans-serif;padding:2rem"><h2>xAI authentication failed.</h2><p>${message}</p></body></html>`
+// The OAuth `error` query param is provider-supplied and reflected into the
+// callback page, so escape it to keep a crafted callback URL
+// (`?error=<script>…`) from injecting markup into the local page.
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
 }
 
-function startCallbackServer(expectedState: string): Promise<CallbackServer> {
-  return new Promise((resolve, reject) => {
+export function errorHtml(message: string): string {
+  return `<!doctype html><html><body style="font-family:sans-serif;padding:2rem"><h2>xAI authentication failed.</h2><p>${escapeHtml(message)}</p></body></html>`
+}
+
+// Resolves to `null` when the fixed loopback port can't be bound (EADDRINUSE,
+// sandbox bind restriction). The caller then falls back to manual-paste mode
+// rather than failing the whole login — the browser callback is a convenience,
+// not a hard requirement, since the user can always paste the redirect URL.
+function startCallbackServer(expectedState: string): Promise<CallbackServer | null> {
+  return new Promise((resolve) => {
     let settle: ((value: { code: string; state: string | null } | null) => void) | undefined
     const waitForCodePromise = new Promise<{ code: string; state: string | null } | null>((resolveWait) => {
       let settled = false
@@ -138,7 +154,10 @@ function startCallbackServer(expectedState: string): Promise<CallbackServer> {
       }
     })
 
-    server.on('error', (err) => reject(err))
+    server.on('error', () => {
+      server.close()
+      resolve(null)
+    })
     server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
       resolve({
         server,
@@ -224,7 +243,9 @@ export async function loginXai(callbacks: OAuthLoginCallbacks, fetchImpl: FetchF
         'Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.',
     })
 
-    if (callbacks.onManualCodeInput) {
+    if (server && callbacks.onManualCodeInput) {
+      // Race the local callback server against a manual paste: whichever lands
+      // a code first wins (cross-device/SSH logins can't reach the loopback).
       let manualInput: string | undefined
       let manualError: Error | undefined
       const manualPromise = callbacks
@@ -243,22 +264,21 @@ export async function loginXai(callbacks: OAuthLoginCallbacks, fetchImpl: FetchF
       if (result?.code) {
         code = result.code
       } else if (manualInput) {
-        const parsed = parseAuthorizationInput(manualInput)
-        if (parsed.state && parsed.state !== verifier) throw new Error('OAuth state mismatch')
-        code = parsed.code
+        code = parseManualCode(manualInput, verifier)
       }
       if (!code) {
         await manualPromise
         if (manualError) throw manualError
         if (manualInput) {
-          const parsed = parseAuthorizationInput(manualInput)
-          if (parsed.state && parsed.state !== verifier) throw new Error('OAuth state mismatch')
-          code = parsed.code
+          code = parseManualCode(manualInput, verifier)
         }
       }
-    } else {
+    } else if (server) {
       const result = await server.waitForCode()
       if (result?.code) code = result.code
+    } else if (callbacks.onManualCodeInput) {
+      // No callback server bound — manual paste is the only path to a code.
+      code = parseManualCode(await callbacks.onManualCodeInput(), verifier)
     }
 
     if (!code) {
@@ -266,9 +286,7 @@ export async function loginXai(callbacks: OAuthLoginCallbacks, fetchImpl: FetchF
         message: 'Paste the authorization code or full redirect URL:',
         placeholder: REDIRECT_URI,
       })
-      const parsed = parseAuthorizationInput(input)
-      if (parsed.state && parsed.state !== verifier) throw new Error('OAuth state mismatch')
-      code = parsed.code
+      code = parseManualCode(input, verifier)
     }
 
     if (!code) throw new Error('Missing authorization code')
@@ -276,8 +294,14 @@ export async function loginXai(callbacks: OAuthLoginCallbacks, fetchImpl: FetchF
     callbacks.onProgress?.('Exchanging authorization code for tokens...')
     return await exchangeAuthorizationCode(code, verifier, fetchImpl)
   } finally {
-    server.server.close()
+    server?.server.close()
   }
+}
+
+function parseManualCode(input: string, verifier: string): string | undefined {
+  const parsed = parseAuthorizationInput(input)
+  if (parsed.state && parsed.state !== verifier) throw new Error('OAuth state mismatch')
+  return parsed.code
 }
 
 export async function refreshXaiToken(refreshToken: string, fetchImpl: FetchFn = fetch): Promise<OAuthCredentials> {

--- a/src/secrets/oauth-xai.ts
+++ b/src/secrets/oauth-xai.ts
@@ -1,0 +1,318 @@
+import { createServer, type Server } from 'node:http'
+
+import { registerOAuthProvider } from '@mariozechner/pi-ai/oauth'
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from '@mariozechner/pi-ai/oauth'
+
+// xAI (Grok) OAuth 2.0. xAI runs a standard OIDC authorization server at
+// auth.x.ai that supports BOTH authorization-code + PKCE (loopback callback)
+// and the device-authorization grant. We implement the auth-code path with a
+// localhost callback server (same UX as pi-ai's anthropic provider) plus a
+// manual-paste fallback for cross-device/SSH flows.
+//
+// There is no public developer console to register a third-party OAuth client,
+// so — like every OSS Grok integration (Grok CLI, opencode, hermes-agent,
+// pi-xai-oauth) — we reuse the Grok CLI's public client id. The `plan=generic`
+// query param is load-bearing: loopback OAuth against this client id is
+// rejected without it. `referrer` is attribution only.
+//
+// Endpoints below are the live values from
+// https://auth.x.ai/.well-known/openid-configuration. The token endpoint speaks
+// application/x-www-form-urlencoded (OAuth2 default) — NOT JSON like Anthropic.
+export const XAI_OAUTH_PROVIDER_ID = 'xai'
+
+const CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828'
+const AUTHORIZE_URL = 'https://auth.x.ai/oauth2/authorize'
+const TOKEN_URL = 'https://auth.x.ai/oauth2/token'
+const CALLBACK_HOST = '127.0.0.1'
+const CALLBACK_PORT = 56121
+const CALLBACK_PATH = '/callback'
+const REDIRECT_URI = `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`
+const SCOPES = 'openid profile email offline_access grok-cli:access api:access'
+const REFERRER = 'typeclaw'
+// Refresh slightly early so an in-flight request never races expiry.
+const EXPIRY_SKEW_MS = 5 * 60 * 1000
+const REQUEST_TIMEOUT_MS = 30_000
+
+type XaiTokenResponse = {
+  access_token?: string
+  refresh_token?: string
+  expires_in?: number
+  token_type?: string
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// PKCE (RFC 7636, S256). pi-ai keeps its `generatePKCE` helper out of the
+// public `/oauth` barrel, so we generate the verifier/challenge with Web Crypto
+// directly — available in both Node and Bun.
+async function generatePkce(): Promise<{ verifier: string; challenge: string }> {
+  const verifier = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)))
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
+  return { verifier, challenge: base64UrlEncode(new Uint8Array(digest)) }
+}
+
+function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+  const value = input.trim()
+  if (!value) return {}
+  try {
+    const url = new URL(value)
+    return {
+      code: url.searchParams.get('code') ?? undefined,
+      state: url.searchParams.get('state') ?? undefined,
+    }
+  } catch {
+    // Not a full URL — fall through to query-string / bare-code handling.
+  }
+  if (value.includes('code=')) {
+    const params = new URLSearchParams(value)
+    return {
+      code: params.get('code') ?? undefined,
+      state: params.get('state') ?? undefined,
+    }
+  }
+  return { code: value }
+}
+
+type CallbackServer = {
+  server: Server
+  cancelWait: () => void
+  waitForCode: () => Promise<{ code: string; state: string | null } | null>
+}
+
+function successHtml(): string {
+  return '<!doctype html><html><body style="font-family:sans-serif;padding:2rem"><h2>xAI authentication complete.</h2><p>You can close this window and return to the terminal.</p></body></html>'
+}
+
+function errorHtml(message: string): string {
+  return `<!doctype html><html><body style="font-family:sans-serif;padding:2rem"><h2>xAI authentication failed.</h2><p>${message}</p></body></html>`
+}
+
+function startCallbackServer(expectedState: string): Promise<CallbackServer> {
+  return new Promise((resolve, reject) => {
+    let settle: ((value: { code: string; state: string | null } | null) => void) | undefined
+    const waitForCodePromise = new Promise<{ code: string; state: string | null } | null>((resolveWait) => {
+      let settled = false
+      settle = (value) => {
+        if (settled) return
+        settled = true
+        resolveWait(value)
+      }
+    })
+
+    const server = createServer((req, res) => {
+      try {
+        const url = new URL(req.url || '', `http://${CALLBACK_HOST}`)
+        if (url.pathname !== CALLBACK_PATH) {
+          res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(errorHtml('Callback route not found.'))
+          return
+        }
+        const code = url.searchParams.get('code')
+        const state = url.searchParams.get('state')
+        const error = url.searchParams.get('error')
+        if (error) {
+          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(errorHtml(`Error: ${error}`))
+          return
+        }
+        if (!code) {
+          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(errorHtml('Missing code parameter.'))
+          return
+        }
+        if (state !== expectedState) {
+          res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(errorHtml('State mismatch.'))
+          return
+        }
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(successHtml())
+        settle?.({ code, state })
+      } catch {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' })
+        res.end('Internal error')
+      }
+    })
+
+    server.on('error', (err) => reject(err))
+    server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
+      resolve({
+        server,
+        cancelWait: () => settle?.(null),
+        waitForCode: () => waitForCodePromise,
+      })
+    })
+  })
+}
+
+export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
+
+async function postForm(url: string, body: Record<string, string>, fetchImpl: FetchFn): Promise<XaiTokenResponse> {
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: new URLSearchParams(body).toString(),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`xAI OAuth request failed. status=${response.status}; url=${url}; body=${text}`)
+  }
+  try {
+    return JSON.parse(text) as XaiTokenResponse
+  } catch {
+    throw new Error(`xAI OAuth returned invalid JSON. url=${url}; body=${text}`)
+  }
+}
+
+function toCredentials(token: XaiTokenResponse): OAuthCredentials {
+  if (!token.access_token || !token.refresh_token || token.expires_in === undefined) {
+    throw new Error('xAI OAuth response missing access_token, refresh_token, or expires_in')
+  }
+  return {
+    access: token.access_token,
+    refresh: token.refresh_token,
+    expires: Date.now() + token.expires_in * 1000 - EXPIRY_SKEW_MS,
+  }
+}
+
+async function exchangeAuthorizationCode(
+  code: string,
+  verifier: string,
+  fetchImpl: FetchFn,
+): Promise<OAuthCredentials> {
+  const token = await postForm(
+    TOKEN_URL,
+    {
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: verifier,
+    },
+    fetchImpl,
+  )
+  return toCredentials(token)
+}
+
+export async function loginXai(callbacks: OAuthLoginCallbacks, fetchImpl: FetchFn = fetch): Promise<OAuthCredentials> {
+  const { verifier, challenge } = await generatePkce()
+  const server = await startCallbackServer(verifier)
+  let code: string | undefined
+  try {
+    const authParams = new URLSearchParams({
+      client_id: CLIENT_ID,
+      response_type: 'code',
+      redirect_uri: REDIRECT_URI,
+      scope: SCOPES,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      state: verifier,
+      plan: 'generic',
+      referrer: REFERRER,
+    })
+    callbacks.onAuth({
+      url: `${AUTHORIZE_URL}?${authParams.toString()}`,
+      instructions:
+        'Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.',
+    })
+
+    if (callbacks.onManualCodeInput) {
+      let manualInput: string | undefined
+      let manualError: Error | undefined
+      const manualPromise = callbacks
+        .onManualCodeInput()
+        .then((input) => {
+          manualInput = input
+          server.cancelWait()
+        })
+        .catch((err) => {
+          manualError = err instanceof Error ? err : new Error(String(err))
+          server.cancelWait()
+        })
+
+      const result = await server.waitForCode()
+      if (manualError) throw manualError
+      if (result?.code) {
+        code = result.code
+      } else if (manualInput) {
+        const parsed = parseAuthorizationInput(manualInput)
+        if (parsed.state && parsed.state !== verifier) throw new Error('OAuth state mismatch')
+        code = parsed.code
+      }
+      if (!code) {
+        await manualPromise
+        if (manualError) throw manualError
+        if (manualInput) {
+          const parsed = parseAuthorizationInput(manualInput)
+          if (parsed.state && parsed.state !== verifier) throw new Error('OAuth state mismatch')
+          code = parsed.code
+        }
+      }
+    } else {
+      const result = await server.waitForCode()
+      if (result?.code) code = result.code
+    }
+
+    if (!code) {
+      const input = await callbacks.onPrompt({
+        message: 'Paste the authorization code or full redirect URL:',
+        placeholder: REDIRECT_URI,
+      })
+      const parsed = parseAuthorizationInput(input)
+      if (parsed.state && parsed.state !== verifier) throw new Error('OAuth state mismatch')
+      code = parsed.code
+    }
+
+    if (!code) throw new Error('Missing authorization code')
+
+    callbacks.onProgress?.('Exchanging authorization code for tokens...')
+    return await exchangeAuthorizationCode(code, verifier, fetchImpl)
+  } finally {
+    server.server.close()
+  }
+}
+
+export async function refreshXaiToken(refreshToken: string, fetchImpl: FetchFn = fetch): Promise<OAuthCredentials> {
+  const token = await postForm(
+    TOKEN_URL,
+    {
+      grant_type: 'refresh_token',
+      client_id: CLIENT_ID,
+      refresh_token: refreshToken,
+    },
+    fetchImpl,
+  )
+  // Some OAuth servers omit a rotated refresh token on refresh; keep the prior
+  // one so the credential stays usable across the next cycle.
+  return toCredentials({ ...token, refresh_token: token.refresh_token ?? refreshToken })
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+  id: XAI_OAUTH_PROVIDER_ID,
+  name: 'xAI (Grok)',
+  usesCallbackServer: true,
+  login: loginXai,
+  refreshToken: (credentials) => refreshXaiToken(credentials.refresh),
+  getApiKey: (credentials) => credentials.access,
+}
+
+let registered = false
+
+// pi-ai ships no built-in xAI OAuth provider, so we register ours. Idempotent
+// and called from `createSecretsStoreForAgent` — the single chokepoint both the
+// init-time login path and the container-runtime auth/refresh path go through —
+// so the provider is always present before `AuthStorage.login()` /
+// `getApiKey()` look it up via `getOAuthProvider('xai')`.
+export function registerXaiOAuthProvider(): void {
+  if (registered) return
+  registerOAuthProvider(xaiOAuthProvider)
+  registered = true
+}

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -9,6 +9,7 @@ import {
 import lockfile from 'proper-lockfile'
 
 import { providerKeyDefaultEnv } from './defaults'
+import { registerXaiOAuthProvider } from './oauth-xai'
 import { resolveSecret, type Secret } from './resolve'
 import {
   type Channels,
@@ -374,6 +375,7 @@ export class SecretsBackend implements AuthStorageBackend {
 }
 
 export function createSecretsStoreForAgent(secretsPath: string): AuthStorage {
+  registerXaiOAuthProvider()
   return AuthStorageImpl.fromStorage(new SecretsBackend(secretsPath))
 }
 


### PR DESCRIPTION
## Background

TypeClaw had no first-class xAI/Grok support. Users wanting Grok had to route through OpenRouter or GitHub Copilot (how pi-ai's catalog ships Grok), which is neither the native endpoint nor the subscription most Grok users actually hold. This adds `xai` as a first-class provider with **both** auth paths xAI offers: a plain `XAI_API_KEY` and the Grok subscription OAuth flow.

The wrinkle: pi-ai (which TypeClaw delegates all OAuth to) registers OAuth providers only for Anthropic, GitHub Copilot, Google, and OpenAI Codex — there is no built-in xAI provider. Setting `oauthProviderId: 'xai'` alone would make `AuthStorage.login('xai')` throw "Unknown OAuth provider" at runtime. So OAuth support required implementing and registering a custom provider, not just a table entry.

## Summary

`xai` is added to `KNOWN_PROVIDERS` as a **dual-auth** provider, mirroring `anthropic`:

- **API key** — `XAI_API_KEY` → `https://api.x.ai/v1`. The endpoint is OpenAI-compatible, so Grok models route through pi-ai's `openai-completions` adapter with a custom `baseUrl` (same trick as Fireworks/Z.AI). Models reflect the current xAI lineup: `grok-4.3` (flagship default, 1M ctx), the pinned `grok-4.20-0309-reasoning` / `grok-4.20-0309-non-reasoning` snapshots, and `grok-build-0.1` (coding-tuned). The earlier `grok-4` / `grok-4-fast` / `grok-code-fast-1` ids were retired by xAI on 2026-05-15 (they silently redirect and rebill), so they are intentionally not listed.
- **OAuth** — a custom `OAuthProviderInterface` (`src/secrets/oauth-xai.ts`): authorization-code + PKCE (S256) against xAI's OIDC server `auth.x.ai`, with a loopback callback server and a manual-paste fallback for cross-device/SSH logins. Refresh + `getApiKey` included.

**Why register from `createSecretsStoreForAgent`:** that function is the single chokepoint both the init-time login path *and* the container-runtime auth/refresh path go through to build `AuthStorage`. Registering there (idempotently) guarantees `getOAuthProvider('xai')` resolves before any `login()`, `getApiKey()`, or token refresh — without scattering registration calls across both stages.

**Why reuse the Grok-CLI client id:** xAI publishes no developer console to register a third-party OAuth client. Every OSS Grok integration (Grok CLI, opencode, hermes-agent, pi-xai-oauth) reuses the same public client id `b1a00492-...`, with the `plan=generic` query param (load-bearing — loopback OAuth is rejected without it).

**Picker integration (rebased onto #713):** #713 landed the vendor → variant picker, where every `KNOWN_PROVIDERS` id must belong to exactly one `KNOWN_PROVIDER_VENDORS` entry (a partition enforced by tests). `xai` is registered as a single-provider, dual-auth vendor — one picker row, no variant follow-up — exactly like Anthropic; `pickAuthMethod` resolves API-key vs OAuth afterward.


## Preview

`xai` surfaces in the **provider** flows (`typeclaw provider add` / `typeclaw init`), not `channel add` (that command is for messaging adapters only). Both branches of the dual-auth picker:

### API-key branch — `typeclaw provider add`

```text
◆  Adding provider: xAI (Grok)
│
◇  Pick a provider to add
│  OpenAI                          API key
│  OpenAI Codex (ChatGPT Plus/Pro) OAuth only
│  Anthropic                       API key or OAuth
│  Fireworks                       API key
│  Z.AI                            API key
│  Z.AI (GLM Coding Plan)          API key
│  ❯ xAI (Grok)                    API key or OAuth
│
◇  How do you want to authenticate to xAI (Grok)?
│  ❯ API key                  saved to secrets.json
│    OAuth (browser login)    saved to secrets.json
│
◇  Put your xAI (Grok) API key (will be saved to secrets.json)
│  ••••••••••••••••••••••••
│
◇  Checking your xAI (Grok) key...
│  xAI (Grok) key looks good.
│
◇  Added xAI (Grok) credentials to secrets.json.
│  If the agent is running:  typeclaw reload
│
└  Done.
```

### OAuth branch — `typeclaw provider add` → "OAuth (browser login)"

```text
◇  How do you want to authenticate to xAI (Grok)?
│    API key                  saved to secrets.json
│  ❯ OAuth (browser login)    saved to secrets.json
│
◇  Browser login
│  Open this URL in your browser to sign in to xAI (Grok).
│
│  If your browser shows "this site can't be reached" after you sign in,
│  copy the full address from the top of the browser and paste it below.

https://auth.x.ai/oauth2/authorize?client_id=b1a00492-…&response_type=code&redirect_uri=http://127.0.0.1:56121/callback&scope=openid+profile+email+offline_access+grok-cli:access+api:access&code_challenge=…&code_challenge_method=S256&state=…&plan=generic&referrer=typeclaw

◇  Exchanging authorization code for tokens...
│
◇  Logged in to xAI (Grok).
│  If the agent is running:  typeclaw reload
│
└  Done.
```

### Model picker — `typeclaw init` (after selecting xAI (Grok))

```text
◇  Pick a xAI (Grok) model
│  ❯ Grok 4.3                       1000K ctx · reasoning
│    Grok 4.20 (Reasoning)          1000K ctx · reasoning
│    Grok 4.20 (Non-Reasoning)      1000K ctx
│    Grok Build 0.1                 256K ctx · reasoning
```

*(Glyphs are illustrative @clack/prompts rendering; option labels/hints are the literal strings from `src/cli/provider.ts`, `src/cli/init.ts`, and `src/cli/oauth-callbacks.ts`.)*

## What this does NOT do

- No **device-code** flow (xAI supports it; only authorization-code is wired here). Headless/remote logins use the manual-paste fallback instead.
- No base-URL override env (`XAI_BASE_URL`) — `xai` is not added to `PROVIDER_BASE_URL_ENV`. Easy to add later if a gateway use-case appears.
- Does not change the default model; `xai/*` is opt-in via `typeclaw.json#models`.

## Review notes

- **Load-bearing:** the registration call in `createSecretsStoreForAgent` (`src/secrets/storage.ts`). If a future refactor moves OAuth-provider registration elsewhere, runtime token refresh for `xai` silently breaks (returns `undefined`, model call fails). The provider table comment in `providers.ts` documents this.
- **Dual-auth precedence:** same rule as `anthropic` — an OAuth credential on disk wins over `XAI_API_KEY` in `.env`. Run `typeclaw provider remove xai` to fall back to the key.
- **ToS caveat:** reusing the Grok-CLI public client id may run afoul of xAI's terms; this matches every other OSS Grok client but is worth a maintainer's awareness.
- Schema (`typeclaw.schema.json`) is a gitignored generated artifact; regenerate with `bun run scripts/generate-schema.ts` (verified the `xai/*` refs land in the enum).
- **Vendor partition:** the new `KNOWN_PROVIDER_VENDORS.xai` entry (`providers: ['xai']`) keeps the #713 partition invariant whole; the partition test would fail if `xai` were left unassigned.


