### PR TITLE
feat(init): unify provider picker into vendor → variant follow-up

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, mock, test } from 'bun:test'
 
-import { KNOWN_PROVIDERS, supportsApiKey, supportsOAuth, type KnownProviderId } from '@/config/providers'
+import {
+  KNOWN_PROVIDERS,
+  supportsApiKey,
+  supportsOAuth,
+  type KnownProviderId,
+  type KnownProviderVendorId,
+} from '@/config/providers'
 import type { ModelOption } from '@/init/models-dev'
 
 import {
@@ -78,12 +84,14 @@ describe('collectWizardInputs back-aware flow', () => {
       loadCatalog: async () => ({ options: [fireworksModel, openaiModel, codexModel], source: 'curated' }),
       readExistingApiKey: async () => null,
       hasExistingOAuthCredentials: async () => false,
-      pickProvider: async () => ({ kind: 'value', value: 'fireworks' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'fireworks' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'fireworks' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: fireworksModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'api-key' }),
       askApiKey: async () => ({ kind: 'value', value: 'sk_test' }),
       validateApiKey: async () => ({ kind: 'ok' as const }),
-      pickVisionProvider: async () => ({ kind: 'value', value: 'skip' }),
+      pickVisionVendor: async () => ({ kind: 'value', value: 'skip' }),
+      pickVisionProviderVariant: async () => ({ kind: 'value', value: 'openai' as KnownProviderId, auto: true }),
       pickVisionModel: async () => ({ kind: 'value', value: openaiModel }),
       pickChannel: async () => ({ kind: 'value', value: 'none' }),
       hasExistingChannelSecrets: async () => false,
@@ -101,9 +109,9 @@ describe('collectWizardInputs back-aware flow', () => {
         record('load-catalog')
         return { options: [fireworksModel], source: 'curated' }
       },
-      pickProvider: async () => {
-        record('pick-provider')
-        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+      pickVendor: async () => {
+        record('pick-vendor')
+        return { kind: 'value', value: 'fireworks' as KnownProviderVendorId }
       },
       pickModel: async () => {
         record('pick-model')
@@ -131,9 +139,9 @@ describe('collectWizardInputs back-aware flow', () => {
 
     expect(steps).toEqual([
       'load-catalog',
-      'pick-provider',
-      'pick-model',
+      'pick-vendor',
       'pick-auth-method',
+      'pick-model',
       'enter-api-key',
       'pick-channel',
       'channel-flow',
@@ -143,32 +151,32 @@ describe('collectWizardInputs back-aware flow', () => {
     expect(result.channelSecrets).toEqual({})
   })
 
-  test('back from pick-provider re-asks the same prompt; cancelling twice aborts', async () => {
-    let providerCalls = 0
+  test('back from pick-vendor re-asks the same prompt; cancelling twice aborts', async () => {
+    let vendorCalls = 0
     const prompts = makePrompts({
-      pickProvider: async () => {
-        providerCalls += 1
+      pickVendor: async () => {
+        vendorCalls += 1
         return { kind: 'back' }
       },
     })
 
     await expect(collectWizardInputs('/agent', prompts)).rejects.toThrow(WizardAbortedError)
-    expect(providerCalls).toBe(2)
+    expect(vendorCalls).toBe(2)
   })
 
-  test('back from pick-provider then pick succeeds (single cancel is still a no-op)', async () => {
-    let providerCalls = 0
+  test('back from pick-vendor then pick succeeds (single cancel is still a no-op)', async () => {
+    let vendorCalls = 0
     const prompts = makePrompts({
-      pickProvider: async () => {
-        providerCalls += 1
-        if (providerCalls === 1) return { kind: 'back' }
-        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+      pickVendor: async () => {
+        vendorCalls += 1
+        if (vendorCalls === 1) return { kind: 'back' }
+        return { kind: 'value', value: 'fireworks' as KnownProviderVendorId }
       },
     })
 
     const result = await collectWizardInputs('/agent', prompts)
 
-    expect(providerCalls).toBe(2)
+    expect(vendorCalls).toBe(2)
     expect(result.model).toBe(fireworksModel)
   })
 
@@ -179,6 +187,7 @@ describe('collectWizardInputs back-aware flow', () => {
     let apiKeyCalls = 0
     const prompts = makePrompts({
       pickAuthMethod: async () => ({ kind: 'value', value: 'api-key', auto: true }),
+      pickModel: async () => ({ kind: 'value', value: fireworksModel, auto: true }),
       askApiKey: async () => {
         apiKeyCalls += 1
         return { kind: 'back' }
@@ -193,13 +202,13 @@ describe('collectWizardInputs back-aware flow', () => {
     expect(apiKeyCalls).toBe(2)
   })
 
-  test('back from pick-model returns to pick-provider, then advances', async () => {
+  test('back from pick-model returns to pick-vendor, then advances', async () => {
     const calls: string[] = []
     let modelBacked = false
     const prompts = makePrompts({
-      pickProvider: async () => {
-        calls.push('pick-provider')
-        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+      pickVendor: async () => {
+        calls.push('pick-vendor')
+        return { kind: 'value', value: 'fireworks' as KnownProviderVendorId }
       },
       pickModel: async () => {
         calls.push('pick-model')
@@ -213,7 +222,7 @@ describe('collectWizardInputs back-aware flow', () => {
 
     await collectWizardInputs('/agent', prompts)
 
-    expect(calls).toEqual(['pick-provider', 'pick-model', 'pick-provider', 'pick-model'])
+    expect(calls).toEqual(['pick-vendor', 'pick-model', 'pick-vendor', 'pick-model'])
   })
 
   test('back from pick-channel returns to enter-api-key when api-key was chosen', async () => {
@@ -247,7 +256,8 @@ describe('collectWizardInputs back-aware flow', () => {
     const calls: string[] = []
     let channelBacked = false
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async () => {
         calls.push('pick-auth-method')
@@ -265,7 +275,7 @@ describe('collectWizardInputs back-aware flow', () => {
 
     await collectWizardInputs('/agent', prompts)
 
-    expect(calls).toEqual(['pick-auth-method', 'pick-channel', 'pick-auth-method', 'pick-channel'])
+    expect(calls).toEqual(['pick-auth-method', 'pick-channel', 'pick-channel'])
   })
 
   test('auto-resume: existing api-key skips pick-auth-method and enter-api-key silently', async () => {
@@ -301,34 +311,40 @@ describe('collectWizardInputs back-aware flow', () => {
 
   test('changing provider clears the previously picked model so it is re-asked fresh', async () => {
     let providerCallCount = 0
-    let authBacked = false
+    let apiKeyBacked = false
+    let modelCalls = 0
     const modelInitials: (string | undefined)[] = []
     const prompts = makePrompts({
-      pickProvider: async () => {
+      pickVendor: async () => {
         providerCallCount += 1
-        return { kind: 'value', value: (providerCallCount === 1 ? 'fireworks' : 'openai') as KnownProviderId }
+        return { kind: 'value', value: (providerCallCount === 1 ? 'fireworks' : 'openai') as KnownProviderVendorId }
+      },
+      pickProviderVariant: async (vendorId) => {
+        return { kind: 'value', value: (vendorId === 'fireworks' ? 'fireworks' : 'openai') as KnownProviderId }
       },
       pickModel: async (_options, providerId, initial) => {
+        modelCalls += 1
         modelInitials.push(initial)
+        if (providerId === 'fireworks' && modelCalls === 2) return { kind: 'back' }
         return {
           kind: 'value',
           value: providerId === 'fireworks' ? fireworksModel : openaiModel,
         }
       },
-      pickAuthMethod: async () => {
-        if (!authBacked) {
-          authBacked = true
+      pickAuthMethod: async () => ({ kind: 'value', value: 'api-key' }),
+      askApiKey: async () => {
+        if (!apiKeyBacked) {
+          apiKeyBacked = true
           return { kind: 'back' }
         }
-        return { kind: 'value', value: 'api-key' }
+        return { kind: 'value', value: 'sk_test' }
       },
     })
 
     await collectWizardInputs('/agent', prompts)
 
-    expect(providerCallCount).toBe(1)
-    expect(modelInitials.length).toBeGreaterThanOrEqual(2)
-    expect(modelInitials[1]).toBe(fireworksModel.ref)
+    expect(providerCallCount).toBe(2)
+    expect(modelInitials).toEqual([undefined, fireworksModel.ref, undefined])
   })
 
   test('picking a different provider on retry discards the prior model selection', async () => {
@@ -336,9 +352,12 @@ describe('collectWizardInputs back-aware flow', () => {
     let modelBackedOnce = false
     const modelInitials: (string | undefined)[] = []
     const prompts = makePrompts({
-      pickProvider: async () => {
+      pickVendor: async () => {
         providerCallCount += 1
-        return { kind: 'value', value: (providerCallCount === 1 ? 'fireworks' : 'openai') as KnownProviderId }
+        return { kind: 'value', value: (providerCallCount === 1 ? 'fireworks' : 'openai') as KnownProviderVendorId }
+      },
+      pickProviderVariant: async (vendorId) => {
+        return { kind: 'value', value: (vendorId === 'fireworks' ? 'fireworks' : 'openai') as KnownProviderId }
       },
       pickModel: async (_options, providerId, initial) => {
         modelInitials.push(initial)
@@ -350,12 +369,13 @@ describe('collectWizardInputs back-aware flow', () => {
         }
         return { kind: 'value', value: openaiModel }
       },
-      pickAuthMethod: async () => {
+      pickAuthMethod: async () => ({ kind: 'value', value: 'api-key' }),
+      askApiKey: async () => {
         if (!modelBackedOnce) {
           modelBackedOnce = true
           return { kind: 'back' }
         }
-        return { kind: 'value', value: 'api-key' }
+        return { kind: 'value', value: 'sk_test' }
       },
     })
 
@@ -373,9 +393,9 @@ describe('collectWizardInputs back-aware flow', () => {
         catalogLoads += 1
         return { options: [fireworksModel], source: 'curated' }
       },
-      pickProvider: async () => {
+      pickVendor: async () => {
         providerCallCount += 1
-        return { kind: 'value', value: 'fireworks' as KnownProviderId }
+        return { kind: 'value', value: 'fireworks' as KnownProviderVendorId }
       },
       pickModel: async () => {
         if (providerCallCount === 1) return { kind: 'back' }
@@ -393,17 +413,21 @@ describe('collectWizardInputs back-aware flow', () => {
     const calls: string[] = []
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
       askApiKey: async () => {
         calls.push('enter-api-key')
         return { kind: 'value', value: 'zai_key' }
       },
-      pickVisionProvider: async (options) => {
-        calls.push('pick-vision-provider')
+      pickVisionVendor: async (options) => {
+        calls.push('pick-vision-vendor')
         // Vision picker MUST be fed only vision-capable models.
         expect(options.every((o) => o.supportsVision)).toBe(true)
         expect(options.some((o) => o.ref === zaiTextOnlyModel.ref)).toBe(false)
+        return { kind: 'value', value: 'openai' as KnownProviderVendorId }
+      },
+      pickVisionProviderVariant: async () => {
         return { kind: 'value', value: 'openai' as KnownProviderId }
       },
       pickVisionModel: async () => {
@@ -425,7 +449,7 @@ describe('collectWizardInputs back-aware flow', () => {
     expect(calls).toEqual([
       'pick-auth-method',
       'enter-api-key',
-      'pick-vision-provider',
+      'pick-vision-vendor',
       'pick-vision-model',
       'pick-auth-method',
       'enter-api-key',
@@ -438,10 +462,10 @@ describe('collectWizardInputs back-aware flow', () => {
   test('vision-capable default model: vision picker is skipped entirely', async () => {
     const calls: string[] = []
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'fireworks' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'fireworks' as KnownProviderVendorId }),
       pickModel: async () => ({ kind: 'value', value: fireworksModel }),
-      pickVisionProvider: async () => {
-        calls.push('pick-vision-provider')
+      pickVisionVendor: async () => {
+        calls.push('pick-vision-vendor')
         return { kind: 'value', value: 'skip' }
       },
       pickVisionModel: async () => {
@@ -459,9 +483,10 @@ describe('collectWizardInputs back-aware flow', () => {
   test('vision skip returns no vision profile', async () => {
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
-      pickVisionProvider: async () => ({ kind: 'value', value: 'skip' }),
+      pickVisionVendor: async () => ({ kind: 'value', value: 'skip' }),
     })
 
     const result = await collectWizardInputs('/agent', prompts)
@@ -474,13 +499,15 @@ describe('collectWizardInputs back-aware flow', () => {
     const visionOpenAI: ModelOption = { ...openaiModel, ref: 'openai/gpt-5.4', modelId: 'gpt-5.4' }
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [zaiTextOnlyModel, visionOpenAI], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
       askApiKey: async () => {
         calls.push('enter-api-key')
         return { kind: 'value', value: 'zai_key' }
       },
-      pickVisionProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVisionVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickVisionProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickVisionModel: async () => ({ kind: 'value', value: { ...zaiTextOnlyModel, supportsVision: true } }),
       pickAuthMethod: async () => {
         calls.push('pick-auth-method')
@@ -499,10 +526,12 @@ describe('collectWizardInputs back-aware flow', () => {
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
       readExistingApiKey: async (_cwd, providerId) => (providerId === 'openai' ? 'sk_existing_openai' : null),
-      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
       askApiKey: async () => ({ kind: 'value', value: 'zai_key' }),
-      pickVisionProvider: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
+      pickVisionVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickVisionProviderVariant: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
       pickVisionModel: async () => ({ kind: 'value', value: openaiModel }),
       pickAuthMethod: async () => {
         calls.push('pick-auth-method')
@@ -516,19 +545,20 @@ describe('collectWizardInputs back-aware flow', () => {
     expect(result!.vision?.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_existing_openai' })
   })
 
-  test('back from pick-vision-provider returns to the auth-finalizing step', async () => {
+  test('back from pick-vision-vendor returns to pick-model', async () => {
     const calls: string[] = []
     let backed = false
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [zaiTextOnlyModel, openaiModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
       askApiKey: async () => {
         calls.push('enter-api-key')
         return { kind: 'value', value: 'zai_key' }
       },
-      pickVisionProvider: async () => {
-        calls.push('pick-vision-provider')
+      pickVisionVendor: async () => {
+        calls.push('pick-vision-vendor')
         if (!backed) {
           backed = true
           return { kind: 'back' }
@@ -539,7 +569,7 @@ describe('collectWizardInputs back-aware flow', () => {
 
     await collectWizardInputs('/agent', prompts)
 
-    expect(calls).toEqual(['enter-api-key', 'pick-vision-provider', 'enter-api-key', 'pick-vision-provider'])
+    expect(calls).toEqual(['enter-api-key', 'pick-vision-vendor', 'enter-api-key', 'pick-vision-vendor'])
   })
 
   test('back from channel-flow returns to pick-channel', async () => {
@@ -682,7 +712,8 @@ describe('collectWizardInputs back-aware flow', () => {
     const calls: string[] = []
     const loginCalls: Array<{ cwd: string; model: string; providerName: string }> = []
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async () => {
         calls.push('pick-auth-method')
@@ -713,7 +744,8 @@ describe('collectWizardInputs back-aware flow', () => {
     let loginAttempt = 0
     let authMethodCalls = 0
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async () => {
         authMethodCalls += 1
@@ -752,7 +784,8 @@ describe('collectWizardInputs back-aware flow', () => {
   test('oauth path: login failure → user picks api-key fallback routes to enter-api-key', async () => {
     const calls: string[] = []
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: openaiModel }),
       pickAuthMethod: async () => {
         calls.push('pick-auth-method')
@@ -790,7 +823,8 @@ describe('collectWizardInputs back-aware flow', () => {
 
   test('oauth path: login failure → user picks abort throws WizardAbortedError', async () => {
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
       runOAuthLogin: async () => ({ ok: false, reason: 'cancelled' }),
@@ -803,7 +837,8 @@ describe('collectWizardInputs back-aware flow', () => {
   test('oauth path: oauth-only provider gets apiKeyAvailable=false in recovery prompt', async () => {
     let apiKeyAvailableSeen: boolean | undefined
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
       runOAuthLogin: async () => ({ ok: false, reason: 'whatever' }),
@@ -820,7 +855,8 @@ describe('collectWizardInputs back-aware flow', () => {
   test('oauth path: runner that throws is coerced to a failure recovery prompt (init never crashes)', async () => {
     const calls: string[] = []
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async () => {
         calls.push('pick-auth-method')
@@ -845,10 +881,12 @@ describe('collectWizardInputs back-aware flow', () => {
     const loginCalls: Array<{ cwd: string; model: string; providerName: string }> = []
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [zaiTextOnlyModel, codexModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
       askApiKey: async () => ({ kind: 'value', value: 'zai_key' }),
-      pickVisionProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVisionVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickVisionProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickVisionModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async (provider) => {
         calls.push(`pick-auth-method:${provider.id}`)
@@ -886,7 +924,8 @@ describe('collectWizardInputs back-aware flow', () => {
     let askApiKeyCalls = 0
     let askApiKeyBackCount = 0
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: openaiModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
       runOAuthLogin: async () => ({ ok: false, reason: 'failed' }),
@@ -916,8 +955,9 @@ describe('collectWizardInputs back-aware flow', () => {
     // can warn the user instead of exiting silently.
     let channelBacks = 0
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
-      pickModel: async () => ({ kind: 'value', value: codexModel }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickModel: async () => ({ kind: 'value', value: codexModel, auto: true }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth', auto: true }),
       runOAuthLogin: async () => ({ ok: true }),
       pickChannel: async () => {
@@ -938,7 +978,8 @@ describe('collectWizardInputs back-aware flow', () => {
 
   test('oauth path: WizardAbortedError.oauthCredentialsSaved is false when OAuth never succeeded', async () => {
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
       runOAuthLogin: async () => ({ ok: false, reason: 'nope' }),
@@ -964,7 +1005,8 @@ describe('collectWizardInputs back-aware flow', () => {
     let seenBothAuthModes: boolean | undefined
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [anthropicModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: anthropicModel }),
       pickAuthMethod: async (provider) => {
         seenProviderId = provider.id
@@ -985,7 +1027,8 @@ describe('collectWizardInputs back-aware flow', () => {
     const loginCalls: Array<{ cwd: string; model: string; providerId: string }> = []
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [anthropicModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: anthropicModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
       runOAuthLogin: async (provider, cwd, model) => {
@@ -996,7 +1039,7 @@ describe('collectWizardInputs back-aware flow', () => {
 
     const result = await collectWizardInputs('/agent', prompts)
 
-    expect(loginCalls).toEqual([{ cwd: '/agent', model: 'anthropic/claude-sonnet-4-6', providerId: 'anthropic' }])
+    expect(loginCalls).toEqual([{ cwd: '/agent', model: 'anthropic/claude-haiku-4-5', providerId: 'anthropic' }])
     expect(result.llmAuth).toEqual({ kind: 'oauth-completed' })
   })
 
@@ -1007,7 +1050,8 @@ describe('collectWizardInputs back-aware flow', () => {
     let apiKeyAvailableSeen: boolean | undefined
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [anthropicModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: anthropicModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth' }),
       runOAuthLogin: async () => ({ ok: false, reason: 'browser closed' }),
@@ -1027,7 +1071,8 @@ describe('collectWizardInputs back-aware flow', () => {
   test('auto-resume: existing OAuth credentials skip the browser login', async () => {
     const runOAuth = mock(async () => ({ ok: true as const }))
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       hasExistingOAuthCredentials: async (_cwd, providerId) => providerId === 'openai-codex',
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth', auto: true }),
@@ -1044,10 +1089,12 @@ describe('collectWizardInputs back-aware flow', () => {
     const runOAuth = mock(async () => ({ ok: true as const }))
     const prompts = makePrompts({
       loadCatalog: async () => ({ options: [zaiTextOnlyModel, codexModel], source: 'curated' }),
-      pickProvider: async () => ({ kind: 'value', value: 'zai' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'zai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'zai' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: zaiTextOnlyModel }),
       askApiKey: async () => ({ kind: 'value', value: 'zai_key' }),
-      pickVisionProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVisionVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickVisionProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickVisionModel: async () => ({ kind: 'value', value: codexModel }),
       hasExistingOAuthCredentials: async (_cwd, providerId) => providerId === 'openai-codex',
       pickAuthMethod: async (provider) => ({
@@ -1067,7 +1114,8 @@ describe('collectWizardInputs back-aware flow', () => {
     const runOAuth = mock(async () => ({ ok: true as const }))
     const hasOAuth = mock(async () => true)
     const prompts = makePrompts({
-      pickProvider: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'openai' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'openai-codex' as KnownProviderId }),
       pickModel: async () => ({ kind: 'value', value: codexModel }),
       hasExistingOAuthCredentials: hasOAuth,
       pickAuthMethod: async () => ({ kind: 'value', value: 'oauth', auto: true }),
@@ -1115,7 +1163,8 @@ describe('collectWizardInputs back-aware flow', () => {
       readExistingApiKey: readExisting,
       hasExistingOAuthCredentials: hasOAuth,
       hasExistingChannelSecrets: hasChannel,
-      pickProvider: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId }),
+      pickVendor: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderVendorId }),
+      pickProviderVariant: async () => ({ kind: 'value', value: 'anthropic' as KnownProviderId, auto: true }),
       pickModel: async () => ({ kind: 'value', value: anthropicModel }),
       pickAuthMethod: async () => ({ kind: 'value', value: 'api-key' }),
       askApiKey: async () => ({ kind: 'value', value: 'sk_fresh' }),

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -4,11 +4,18 @@ import { cancel, confirm, intro, isCancel, log, note, password, select, spinner,
 import { defineCommand } from 'citty'
 
 import {
+  KNOWN_PROVIDER_VENDORS,
   KNOWN_PROVIDERS,
+  listKnownProviderVendorIds,
+  providerIdsForVendor,
   supportsApiKey as providerSupportsApiKey,
   supportsOAuth as providerSupportsOAuth,
+  variantHint,
+  variantLabel,
+  vendorForProviderId,
   type KnownModelRef,
   type KnownProviderId,
+  type KnownProviderVendorId,
 } from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability } from '@/container'
 import {
@@ -290,11 +297,13 @@ export const init = defineCommand({
 
 interface WizardState {
   catalog?: { options: ModelOption[]; source: 'models.dev' | 'curated'; warning?: string }
+  vendorId?: KnownProviderVendorId
   providerId?: KnownProviderId
   model?: ModelOption
   reuseExisting?: boolean
   authMethod?: 'api-key' | 'oauth'
   llmAuth?: LLMAuth
+  visionVendorId?: KnownProviderVendorId
   visionProviderId?: KnownProviderId
   visionModel?: ModelOption
   visionReuseExisting?: boolean
@@ -336,14 +345,16 @@ interface CollectedInputs {
 }
 
 type StepId =
-  | 'pick-provider'
-  | 'pick-model'
+  | 'pick-vendor'
+  | 'pick-provider-variant'
   | 'reuse-existing-key'
   | 'pick-auth-method'
+  | 'pick-model'
   | 'enter-api-key'
-  | 'pick-vision-provider'
-  | 'pick-vision-model'
+  | 'pick-vision-vendor'
+  | 'pick-vision-provider-variant'
   | 'pick-vision-auth-method'
+  | 'pick-vision-model'
   | 'enter-vision-api-key'
   | 'pick-channel'
   | 'reuse-existing-channel'
@@ -353,7 +364,15 @@ export interface WizardPrompts {
   loadCatalog: () => Promise<NonNullable<WizardState['catalog']>>
   readExistingApiKey: (cwd: string, providerId: KnownProviderId) => Promise<string | null>
   hasExistingOAuthCredentials: (cwd: string, providerId: KnownProviderId) => Promise<boolean>
-  pickProvider: (options: ModelOption[], initial: KnownProviderId | undefined) => Promise<StepResult<KnownProviderId>>
+  pickVendor: (
+    options: ModelOption[],
+    initial: KnownProviderVendorId | undefined,
+  ) => Promise<StepResult<KnownProviderVendorId>>
+  pickProviderVariant: (
+    vendorId: KnownProviderVendorId,
+    options: ModelOption[],
+    initial: KnownProviderId | undefined,
+  ) => Promise<StepResult<KnownProviderId>>
   pickModel: (
     options: ModelOption[],
     providerId: KnownProviderId,
@@ -365,10 +384,15 @@ export interface WizardPrompts {
   ) => Promise<StepResult<'api-key' | 'oauth'>>
   askApiKey: (provider: (typeof KNOWN_PROVIDERS)[KnownProviderId]) => Promise<StepResult<string>>
   validateApiKey: (providerId: KnownProviderId, key: string) => Promise<KeyValidationResult>
-  pickVisionProvider: (
+  pickVisionVendor: (
+    options: ModelOption[],
+    initial: KnownProviderVendorId | undefined,
+  ) => Promise<StepResult<KnownProviderVendorId | 'skip'>>
+  pickVisionProviderVariant: (
+    vendorId: KnownProviderVendorId,
     options: ModelOption[],
     initial: KnownProviderId | undefined,
-  ) => Promise<StepResult<KnownProviderId | 'skip'>>
+  ) => Promise<StepResult<KnownProviderId>>
   pickVisionModel: (
     options: ModelOption[],
     providerId: KnownProviderId,
@@ -399,12 +423,14 @@ export const defaultWizardPrompts: WizardPrompts = {
   loadCatalog,
   readExistingApiKey: readExistingProviderApiKey,
   hasExistingOAuthCredentials,
-  pickProvider,
+  pickVendor,
+  pickProviderVariant,
   pickModel: pickModelForProvider,
   pickAuthMethod,
   askApiKey,
   validateApiKey,
-  pickVisionProvider,
+  pickVisionVendor,
+  pickVisionProviderVariant,
   pickVisionModel,
   pickChannel,
   hasExistingChannelSecrets,
@@ -428,7 +454,7 @@ export async function collectWizardInputs(
   const reset = options.reset === true
   const catalog = await prompts.loadCatalog()
   const state: WizardState = { catalog }
-  let step: StepId = 'pick-provider'
+  let step: StepId = 'pick-vendor'
   let pendingBackOrigin: StepId | null = null
   let oauthCredentialsSaved = false
 
@@ -463,9 +489,30 @@ export async function collectWizardInputs(
 
   while (true) {
     switch (step) {
-      case 'pick-provider': {
-        const result = onResult(step, await prompts.pickProvider(catalog.options, state.providerId))
+      case 'pick-vendor': {
+        const result = onResult(step, await prompts.pickVendor(catalog.options, state.vendorId))
         if (result.kind === 'back') {
+          break
+        }
+        if (state.vendorId !== result.value) {
+          state.providerId = undefined
+          state.model = undefined
+          state.reuseExisting = undefined
+          state.authMethod = undefined
+          state.llmAuth = undefined
+        }
+        state.vendorId = result.value
+        step = 'pick-provider-variant'
+        break
+      }
+
+      case 'pick-provider-variant': {
+        const result = onResult(
+          step,
+          await prompts.pickProviderVariant(state.vendorId!, catalog.options, state.providerId),
+        )
+        if (result.kind === 'back') {
+          step = 'pick-vendor'
           break
         }
         if (state.providerId !== result.value) {
@@ -475,17 +522,6 @@ export async function collectWizardInputs(
           state.llmAuth = undefined
         }
         state.providerId = result.value
-        step = 'pick-model'
-        break
-      }
-
-      case 'pick-model': {
-        const result = onResult(step, await prompts.pickModel(catalog.options, state.providerId!, state.model?.ref))
-        if (result.kind === 'back') {
-          step = 'pick-provider'
-          break
-        }
-        state.model = result.value
         step = 'reuse-existing-key'
         break
       }
@@ -503,7 +539,7 @@ export async function collectWizardInputs(
           log.info(`Reusing existing ${provider.name} API key from secrets.json.`)
           state.llmAuth = { kind: 'api-key', apiKey: existingApiKey }
           state.reuseExisting = true
-          step = stepAfterDefaultAuth(state)
+          step = 'pick-model'
           break
         }
         state.reuseExisting = false
@@ -517,12 +553,12 @@ export async function collectWizardInputs(
         const result = onResult(step, await prompts.pickAuthMethod(provider, state.authMethod))
         if (result.kind === 'back') {
           // Skip past `reuse-existing-key` — it is a silent auto-resume
-          // step with no user prompt, so unwind directly to pick-model
-          // (the prior user-visible step). This only fires when
-          // pickAuthMethod was an interactive choice (dual-auth providers);
-          // single-method providers return autoValue and never reach the
-          // back branch.
-          step = 'pick-model'
+          // step with no user prompt, so unwind directly to the prior
+          // user-visible step (the variant picker when it was interactive,
+          // else the vendor picker). This only fires when pickAuthMethod was
+          // an interactive choice (dual-auth providers); single-method
+          // providers return autoValue and never reach the back branch.
+          step = stepBeforeAuthMethod(state)
           break
         }
         state.authMethod = result.value
@@ -530,21 +566,24 @@ export async function collectWizardInputs(
           // Auto-resume: skip the browser flow when OAuth credentials are
           // already on disk from a prior partial run. The fresh-tokens path
           // and the resume path both leave `state.llmAuth = oauth-completed`,
-          // so downstream steps (vision, channel, scaffold) can't tell the
-          // difference. `--reset` short-circuits this by making
+          // so downstream steps (model, vision, channel, scaffold) can't tell
+          // the difference. `--reset` short-circuits this by making
           // `hasExistingOAuth` return false.
           if (await hasExistingOAuth(state.providerId!)) {
             log.info(`Reusing existing ${provider.name} OAuth credentials from secrets.json.`)
             state.llmAuth = { kind: 'oauth-completed' }
-            step = stepAfterDefaultAuth(state)
+            step = 'pick-model'
             break
           }
           // Run the browser login eagerly so the user sees the OAuth URL the
           // moment they pick "OAuth (browser login)" — not at the end of the
-          // wizard. On failure we ask the user how to recover (retry / fall
-          // back to API key / abort) instead of dumping them back into the
-          // auth method picker with no guidance.
-          const login = await runOAuthLoginSafely(prompts, provider, cwd, state.model!.ref)
+          // wizard. The model isn't picked yet at this point, so we hand the
+          // login the provider's first model ref purely to resolve its
+          // `oauthProviderId` (login ignores the model otherwise). On failure
+          // we ask the user how to recover (retry / fall back to API key /
+          // abort) instead of dumping them back into the auth method picker
+          // with no guidance.
+          const login = await runOAuthLoginSafely(prompts, provider, cwd, oauthDiscoveryRef(state.providerId!))
           if (!login.ok) {
             const recovery = await prompts.askOAuthFailureRecovery(
               provider,
@@ -560,15 +599,29 @@ export async function collectWizardInputs(
             if (recovery === 'abort') abort()
             state.authMethod = recovery === 'api-key' ? 'api-key' : undefined
             state.llmAuth = undefined
-            step = recovery === 'api-key' ? 'enter-api-key' : 'pick-auth-method'
+            step = recovery === 'api-key' ? 'pick-model' : 'pick-auth-method'
             break
           }
           oauthCredentialsSaved = true
           state.llmAuth = { kind: 'oauth-completed' }
-          step = stepAfterDefaultAuth(state)
+          step = 'pick-model'
         } else {
-          step = 'enter-api-key'
+          step = 'pick-model'
         }
+        break
+      }
+
+      case 'pick-model': {
+        const result = onResult(step, await prompts.pickModel(catalog.options, state.providerId!, state.model?.ref))
+        if (result.kind === 'back') {
+          step = stepBeforeModel(state)
+          break
+        }
+        state.model = result.value
+        // OAuth and reused api-key already minted `state.llmAuth`; only a
+        // freshly-chosen api-key still needs the key prompt.
+        step =
+          state.authMethod === 'api-key' && state.reuseExisting !== true ? 'enter-api-key' : stepAfterDefaultAuth(state)
         break
       }
 
@@ -577,7 +630,7 @@ export async function collectWizardInputs(
         const provider = KNOWN_PROVIDERS[providerId]
         const result = onResult(step, await prompts.askApiKey(provider))
         if (result.kind === 'back') {
-          step = 'pick-auth-method'
+          step = 'pick-model'
           break
         }
         const verdict = await runApiKeyValidation(prompts, providerId, result.value)
@@ -590,20 +643,43 @@ export async function collectWizardInputs(
         break
       }
 
-      case 'pick-vision-provider': {
+      case 'pick-vision-vendor': {
         const visionOptions = catalog.options.filter((o) => o.supportsVision)
-        const result = onResult(step, await prompts.pickVisionProvider(visionOptions, state.visionProviderId))
+        const result = onResult(step, await prompts.pickVisionVendor(visionOptions, state.visionVendorId))
         if (result.kind === 'back') {
           step = stepBeforeVision(state)
           break
         }
         if (result.value === 'skip') {
+          state.visionVendorId = undefined
           state.visionProviderId = undefined
           state.visionModel = undefined
           state.visionLlmAuth = undefined
           state.visionReuseExisting = undefined
           state.visionAuthMethod = undefined
           step = 'pick-channel'
+          break
+        }
+        if (state.visionVendorId !== result.value) {
+          state.visionProviderId = undefined
+          state.visionModel = undefined
+          state.visionReuseExisting = undefined
+          state.visionAuthMethod = undefined
+          state.visionLlmAuth = undefined
+        }
+        state.visionVendorId = result.value
+        step = 'pick-vision-provider-variant'
+        break
+      }
+
+      case 'pick-vision-provider-variant': {
+        const visionOptions = catalog.options.filter((o) => o.supportsVision)
+        const result = onResult(
+          step,
+          await prompts.pickVisionProviderVariant(state.visionVendorId!, visionOptions, state.visionProviderId),
+        )
+        if (result.kind === 'back') {
+          step = 'pick-vision-vendor'
           break
         }
         if (state.visionProviderId !== result.value) {
@@ -624,7 +700,7 @@ export async function collectWizardInputs(
           await prompts.pickVisionModel(visionOptions, state.visionProviderId!, state.visionModel?.ref),
         )
         if (result.kind === 'back') {
-          step = 'pick-vision-provider'
+          step = 'pick-vision-provider-variant'
           break
         }
         state.visionModel = result.value
@@ -806,14 +882,33 @@ function channelDisplayName(choice: Exclude<ChannelChoice, 'none'>): string {
   }
 }
 
+// Model is the last default-track step before the vision/channel branch, so
+// vendor/variant/auth all sit upstream of it. Reached after `pick-model`
+// (api-key path also passes through `enter-api-key` first).
 function stepAfterDefaultAuth(state: WizardState): StepId {
-  return state.model?.supportsVision === false ? 'pick-vision-provider' : 'pick-channel'
+  return state.model?.supportsVision === false ? 'pick-vision-vendor' : 'pick-channel'
 }
 
-function stepBeforeVision(state: WizardState): StepId {
-  if (state.reuseExisting === true) return 'reuse-existing-key'
-  if (state.authMethod === 'api-key') return 'enter-api-key'
-  return 'pick-auth-method'
+// Back-target when leaving `pick-auth-method`: the variant picker when it was
+// interactive (multi-provider vendor), else the vendor picker. The
+// `reuse-existing-key` step in between is a silent auto-resume with no prompt.
+function stepBeforeAuthMethod(state: WizardState): StepId {
+  return providerIdsForVendor(state.vendorId!).length > 1 ? 'pick-provider-variant' : 'pick-vendor'
+}
+
+// Back-target when leaving `pick-model`: the auth picker when it was
+// interactive (dual-auth provider), else fall back past the silent
+// auto-resume/auth steps to the prior user-visible picker.
+function stepBeforeModel(state: WizardState): StepId {
+  const provider = KNOWN_PROVIDERS[state.providerId!]
+  if (providerSupportsApiKey(provider) && providerSupportsOAuth(provider)) return 'pick-auth-method'
+  return stepBeforeAuthMethod(state)
+}
+
+// Back-target when leaving the vision track to the default track. With model
+// now the final default-track step, that is always `pick-model`.
+function stepBeforeVision(_state: WizardState): StepId {
+  return 'pick-model'
 }
 
 function stepBeforePickChannel(state: WizardState): StepId {
@@ -824,8 +919,16 @@ function stepBeforePickChannel(state: WizardState): StepId {
     if (state.visionAuthMethod === 'oauth') return 'pick-vision-auth-method'
     return 'pick-vision-model'
   }
-  if (state.model?.supportsVision === false) return 'pick-vision-provider'
+  if (state.model?.supportsVision === false) return 'pick-vision-vendor'
   return stepBeforeVision(state)
+}
+
+function oauthDiscoveryRef(providerId: KnownProviderId): KnownModelRef {
+  // OAuth login only reads the provider's `oauthProviderId` from the ref, so
+  // any registered model for the provider works as the discovery handle.
+  const modelId = Object.keys(KNOWN_PROVIDERS[providerId].models)[0]
+  if (modelId === undefined) throw new Error(`Provider ${providerId} has no registered models for OAuth discovery`)
+  return `${providerId}/${modelId}` as KnownModelRef
 }
 
 async function loadCatalog(): Promise<NonNullable<WizardState['catalog']>> {
@@ -840,15 +943,41 @@ async function loadCatalog(): Promise<NonNullable<WizardState['catalog']>> {
   return warning !== undefined ? { options, source, warning } : { options, source }
 }
 
-async function pickProvider(
+async function pickVendor(
+  options: ModelOption[],
+  initial: KnownProviderVendorId | undefined,
+): Promise<StepResult<KnownProviderVendorId>> {
+  const vendors = uniqueVendors(options)
+  const choice = await select({
+    message: 'Pick an LLM provider',
+    options: vendors.map((id) => ({
+      value: id,
+      label: KNOWN_PROVIDER_VENDORS[id].name,
+      hint: vendorHint(id, options),
+    })),
+    initialValue: initial ?? vendors[0],
+  })
+  if (isCancel(choice)) return back()
+  return value(choice)
+}
+
+async function pickProviderVariant(
+  vendorId: KnownProviderVendorId,
   options: ModelOption[],
   initial: KnownProviderId | undefined,
 ): Promise<StepResult<KnownProviderId>> {
-  const providers = uniqueProviders(options)
-  const choice = await select({
-    message: 'Pick an LLM provider',
-    options: providers.map((id) => ({ value: id, label: KNOWN_PROVIDERS[id].name, hint: providerAuthHint(id) })),
-    initialValue: initial ?? providers[0],
+  const variants = providersForVendorInCatalog(vendorId, options)
+  if (variants.length === 0) throw new Error(`Internal error: vendor ${vendorId} has no providers in the catalog`)
+  if (variants.length === 1) return autoValue(variants[0]!)
+  const choice = await select<KnownProviderId>({
+    message: `Pick a ${KNOWN_PROVIDER_VENDORS[vendorId].name} option`,
+    options: variants.map((id) => {
+      const hint = variantHint(vendorId, id)
+      return hint !== undefined
+        ? { value: id, label: variantLabel(vendorId, id), hint }
+        : { value: id, label: variantLabel(vendorId, id) }
+    }),
+    initialValue: initial ?? variants[0],
   })
   if (isCancel(choice)) return back()
   return value(choice)
@@ -896,29 +1025,37 @@ async function pickAuthMethod(
   return autoValue(supportsOAuth ? 'oauth' : 'api-key')
 }
 
-async function pickVisionProvider(
+async function pickVisionVendor(
   options: ModelOption[],
-  initial: KnownProviderId | undefined,
-): Promise<StepResult<KnownProviderId | 'skip'>> {
-  const providers = uniqueProviders(options)
-  if (providers.length === 0) {
+  initial: KnownProviderVendorId | undefined,
+): Promise<StepResult<KnownProviderVendorId | 'skip'>> {
+  const vendors = uniqueVendors(options)
+  if (vendors.length === 0) {
     log.warn('No vision-capable models available; skipping vision profile.')
     return autoValue('skip')
   }
-  const choice = await select<KnownProviderId | 'skip'>({
+  const choice = await select<KnownProviderVendorId | 'skip'>({
     message: 'Your model is text-only. Pick a provider for the `vision` profile (used for image input)',
     options: [
-      ...providers.map((id) => ({
-        value: id as KnownProviderId | 'skip',
-        label: KNOWN_PROVIDERS[id].name,
-        hint: providerAuthHint(id),
+      ...vendors.map((id) => ({
+        value: id as KnownProviderVendorId | 'skip',
+        label: KNOWN_PROVIDER_VENDORS[id].name,
+        hint: vendorHint(id, options),
       })),
       { value: 'skip', label: 'Skip — no vision support', hint: 'add later with `typeclaw model set vision <ref>`' },
     ],
-    initialValue: initial ?? providers[0],
+    initialValue: initial ?? vendors[0],
   })
   if (isCancel(choice)) return back()
   return value(choice)
+}
+
+async function pickVisionProviderVariant(
+  vendorId: KnownProviderVendorId,
+  options: ModelOption[],
+  initial: KnownProviderId | undefined,
+): Promise<StepResult<KnownProviderId>> {
+  return pickProviderVariant(vendorId, options, initial)
 }
 
 async function pickVisionModel(
@@ -1486,15 +1623,23 @@ function reportHatching(event: Extract<InitStepEvent, { step: 'hatching' }>): vo
   }
 }
 
-function uniqueProviders(options: ModelOption[]): KnownProviderId[] {
-  const seen = new Set<KnownProviderId>()
-  const out: KnownProviderId[] = []
-  for (const o of options) {
-    if (seen.has(o.providerId)) continue
-    seen.add(o.providerId)
-    out.push(o.providerId)
-  }
-  return out
+function providersInCatalog(options: ModelOption[]): Set<KnownProviderId> {
+  return new Set(options.map((o) => o.providerId))
+}
+
+// Vendors with at least one provider present in the catalog, ordered by the
+// product priority encoded in `KNOWN_PROVIDER_VENDORS` declaration order (not
+// catalog iteration order).
+function uniqueVendors(options: ModelOption[]): KnownProviderVendorId[] {
+  const present = providersInCatalog(options)
+  return listKnownProviderVendorIds().filter((vendorId) =>
+    providerIdsForVendor(vendorId).some((providerId) => present.has(providerId)),
+  )
+}
+
+function providersForVendorInCatalog(vendorId: KnownProviderVendorId, options: ModelOption[]): KnownProviderId[] {
+  const present = providersInCatalog(options)
+  return providerIdsForVendor(vendorId).filter((providerId) => present.has(providerId))
 }
 
 // Per-provider recommended model refs. Surfaces a "(Recommended)" suffix in
@@ -1528,10 +1673,10 @@ function formatModelHint(o: ModelOption): string {
   return parts.join(' · ')
 }
 
-function providerAuthHint(id: KnownProviderId): string {
-  const provider = KNOWN_PROVIDERS[id]
-  const apiKey = providerSupportsApiKey(provider)
-  const oauth = providerSupportsOAuth(provider)
+function vendorHint(vendorId: KnownProviderVendorId, options: ModelOption[]): string {
+  const providers = providersForVendorInCatalog(vendorId, options)
+  const apiKey = providers.some((id) => providerSupportsApiKey(KNOWN_PROVIDERS[id]))
+  const oauth = providers.some((id) => providerSupportsOAuth(KNOWN_PROVIDERS[id]))
   if (apiKey && oauth) return 'API key or OAuth'
   if (oauth) return 'OAuth login'
   return 'API key'

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -12,7 +12,6 @@ import {
   supportsOAuth as providerSupportsOAuth,
   variantHint,
   variantLabel,
-  vendorForProviderId,
   type KnownModelRef,
   type KnownProviderId,
   type KnownProviderVendorId,

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -2,10 +2,16 @@ import { cancel, intro, isCancel, log, password, select } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import {
+  KNOWN_PROVIDER_VENDORS,
   KNOWN_PROVIDERS,
+  listKnownProviderVendorIds,
+  providerIdsForVendor,
   supportsApiKey as providerSupportsApiKey,
   supportsOAuth as providerSupportsOAuth,
+  variantHint,
+  variantLabel,
   type KnownProviderId,
+  type KnownProviderVendorId,
 } from '@/config/providers'
 import {
   addProvider,
@@ -270,15 +276,40 @@ function validateKnownProvider(input: string): KnownProviderId {
 
 async function resolveProviderForAdd(input: string | undefined): Promise<KnownProviderId> {
   if (input !== undefined) return validateKnownProvider(input)
-  const ids = Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]
-  const choice = await select<KnownProviderId>({
+  const vendorId = await pickVendorToAdd()
+  return await pickVariantToAdd(vendorId)
+}
+
+async function pickVendorToAdd(): Promise<KnownProviderVendorId> {
+  const vendorIds = listKnownProviderVendorIds()
+  const choice = await select<KnownProviderVendorId>({
     message: 'Pick a provider to add',
-    options: ids.map((id) => ({
+    options: vendorIds.map((id) => ({
       value: id,
-      label: KNOWN_PROVIDERS[id].name,
-      hint: authHint(id),
+      label: KNOWN_PROVIDER_VENDORS[id].name,
+      hint: vendorAuthHint(id),
     })),
-    initialValue: ids[0],
+    initialValue: vendorIds[0],
+  })
+  if (isCancel(choice)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return choice
+}
+
+async function pickVariantToAdd(vendorId: KnownProviderVendorId): Promise<KnownProviderId> {
+  const variants = providerIdsForVendor(vendorId)
+  if (variants.length === 1) return variants[0]!
+  const choice = await select<KnownProviderId>({
+    message: `Pick a ${KNOWN_PROVIDER_VENDORS[vendorId].name} option`,
+    options: variants.map((id) => {
+      const hint = variantHint(vendorId, id)
+      return hint !== undefined
+        ? { value: id, label: variantLabel(vendorId, id), hint }
+        : { value: id, label: variantLabel(vendorId, id) }
+    }),
+    initialValue: variants[0],
   })
   if (isCancel(choice)) {
     cancel('Aborted.')
@@ -378,10 +409,10 @@ async function runOAuthLogin(cwd: string, providerId: KnownProviderId): Promise<
   }
 }
 
-function authHint(id: KnownProviderId): string {
-  const provider = KNOWN_PROVIDERS[id]
-  const apiKey = providerSupportsApiKey(provider)
-  const oauth = providerSupportsOAuth(provider)
+function vendorAuthHint(vendorId: KnownProviderVendorId): string {
+  const providers = providerIdsForVendor(vendorId)
+  const apiKey = providers.some((id) => providerSupportsApiKey(KNOWN_PROVIDERS[id]))
+  const oauth = providers.some((id) => providerSupportsOAuth(KNOWN_PROVIDERS[id]))
   if (apiKey && oauth) return 'API key or OAuth'
   if (oauth) return 'OAuth only'
   return 'API key'

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   defaultThinkingLevelForRef,
+  KNOWN_PROVIDER_VENDORS,
   KNOWN_PROVIDERS,
+  type KnownProviderId,
   listKnownModelRefs,
+  listKnownProviderVendorIds,
   providerForModelRef,
+  providerIdsForVendor,
   supportsApiKey,
   supportsOAuth,
+  variantLabel,
+  vendorForProviderId,
 } from './providers'
 
 describe('KNOWN_PROVIDERS', () => {
@@ -90,6 +96,65 @@ describe('KNOWN_PROVIDERS', () => {
     for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.anthropic.models)) {
       expect(model.api, `anthropic/${modelId} api drift`).toBe('anthropic-messages')
     }
+  })
+})
+
+describe('KNOWN_PROVIDER_VENDORS', () => {
+  test('every vendor references only known provider ids', () => {
+    for (const vendorId of listKnownProviderVendorIds()) {
+      for (const providerId of providerIdsForVendor(vendorId)) {
+        expect(providerId in KNOWN_PROVIDERS, `${vendorId} references unknown provider ${providerId}`).toBe(true)
+      }
+    }
+  })
+
+  test('every known provider belongs to exactly one vendor (full partition)', () => {
+    const assigned = new Map<KnownProviderId, number>()
+    for (const vendorId of listKnownProviderVendorIds()) {
+      for (const providerId of providerIdsForVendor(vendorId)) {
+        assigned.set(providerId, (assigned.get(providerId) ?? 0) + 1)
+      }
+    }
+    for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
+      expect(assigned.get(providerId), `${providerId} not assigned to exactly one vendor`).toBe(1)
+    }
+  })
+
+  test('vendorForProviderId is the inverse of providerIdsForVendor', () => {
+    for (const vendorId of listKnownProviderVendorIds()) {
+      for (const providerId of providerIdsForVendor(vendorId)) {
+        expect(vendorForProviderId(providerId)).toBe(vendorId)
+      }
+    }
+  })
+
+  test('multi-provider vendors supply variant copy for each of their providers', () => {
+    for (const vendorId of listKnownProviderVendorIds()) {
+      const providers = providerIdsForVendor(vendorId)
+      if (providers.length < 2) continue
+      for (const providerId of providers) {
+        expect(variantLabel(vendorId, providerId), `${vendorId}/${providerId} missing variant label`).not.toBe(
+          KNOWN_PROVIDERS[providerId].name,
+        )
+      }
+    }
+  })
+
+  test('OpenAI vendor splits API key (openai) from ChatGPT OAuth (openai-codex)', () => {
+    expect(providerIdsForVendor('openai')).toEqual(['openai', 'openai-codex'])
+    expect(variantLabel('openai', 'openai')).toBe('API key')
+    expect(variantLabel('openai', 'openai-codex')).toBe('OAuth (ChatGPT Plus/Pro)')
+  })
+
+  test('Z.AI vendor splits paygo (zai) from Coding Plan (zai-coding)', () => {
+    expect(providerIdsForVendor('zai')).toEqual(['zai', 'zai-coding'])
+    expect(variantLabel('zai', 'zai')).toBe('Pay-as-you-go')
+    expect(variantLabel('zai', 'zai-coding')).toBe('Coding Plan')
+  })
+
+  test('Anthropic and Fireworks are single-provider vendors (no variant step)', () => {
+    expect(providerIdsForVendor('anthropic')).toEqual(['anthropic'])
+    expect(providerIdsForVendor('fireworks')).toEqual(['fireworks'])
   })
 })
 

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -119,13 +119,12 @@ export const KNOWN_PROVIDERS = {
   // these ids work end-to-end as long as the Codex backend itself accepts
   // them, which it does for ChatGPT Plus/Pro accounts as of 2026-05-10.
   //
-  // Position-load-bearing: must stay adjacent to `openai`. The init wizard's
-  // provider picker, `provider --help`'s `id | id | ...` listing, and the
-  // generated JSON schema's model-ref enum all derive their ordering from
-  // Object.keys() iteration on this literal. Alphabetizing the registry
-  // would scatter `openai-codex` after `fireworks` and re-introduce the
-  // "OpenAI ... Anthropic ... OpenAI" picker order this comment exists to
-  // prevent.
+  // Position-load-bearing: must stay adjacent to `openai`. `provider --help`'s
+  // `id | id | ...` listing and the generated JSON schema's model-ref enum
+  // derive their ordering from Object.keys() iteration on this literal, so
+  // alphabetizing the registry would scatter `openai-codex` after `fireworks`.
+  // (The init wizard's picker no longer depends on this order — it groups by
+  // `KNOWN_PROVIDER_VENDORS` below.)
   'openai-codex': {
     id: 'openai-codex',
     name: 'OpenAI Codex (ChatGPT Plus/Pro)',
@@ -456,6 +455,95 @@ export const KNOWN_PROVIDERS = {
 } as const satisfies Record<string, KnownProvider>
 
 export type KnownProviderId = keyof typeof KNOWN_PROVIDERS
+
+// UX-only grouping of provider ids under one vendor for the init/`provider
+// add` pickers. Deliberately does NOT touch the runtime contract:
+// `KnownProviderId`, `KnownModelRef`, secrets.json keys, auth resolution, and
+// the generated schema all stay keyed on the flat ids in `KNOWN_PROVIDERS`.
+// The follow-up "variant" prompt resolves a concrete provider id, then
+// `pickAuthMethod` runs as before; it is auto-resolved for single-provider
+// vendors (Fireworks, Anthropic). `variants` copy lets the prompt read as an
+// auth choice for OpenAI but a plan choice for Z.AI (both api-key, different
+// billing surfaces).
+type KnownProviderVendor = {
+  id: string
+  name: string
+  providers: ReadonlyArray<KnownProviderId>
+  variants?: Partial<Record<KnownProviderId, { label: string; hint?: string }>>
+}
+
+// Ordered by product priority for the picker — independent of the
+// `KNOWN_PROVIDERS` declaration order (which stays load-bearing for the schema
+// enum and `provider --help` listing). Every provider id below MUST appear in
+// exactly one vendor; `providers.test.ts` enforces the partition.
+export const KNOWN_PROVIDER_VENDORS = {
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    providers: ['openai', 'openai-codex'],
+    variants: {
+      openai: { label: 'API key', hint: 'OpenAI API platform' },
+      'openai-codex': { label: 'OAuth (ChatGPT Plus/Pro)', hint: 'ChatGPT subscription' },
+    },
+  },
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    providers: ['anthropic'],
+  },
+  fireworks: {
+    id: 'fireworks',
+    name: 'Fireworks',
+    providers: ['fireworks'],
+  },
+  zai: {
+    id: 'zai',
+    name: 'Z.AI',
+    providers: ['zai', 'zai-coding'],
+    variants: {
+      zai: { label: 'Pay-as-you-go', hint: 'standard API billing' },
+      'zai-coding': { label: 'Coding Plan', hint: 'GLM Coding Plan subscription' },
+    },
+  },
+} as const satisfies Record<string, KnownProviderVendor>
+
+export type KnownProviderVendorId = keyof typeof KNOWN_PROVIDER_VENDORS
+
+export function listKnownProviderVendorIds(): KnownProviderVendorId[] {
+  return Object.keys(KNOWN_PROVIDER_VENDORS) as KnownProviderVendorId[]
+}
+
+export function providerIdsForVendor(vendorId: KnownProviderVendorId): ReadonlyArray<KnownProviderId> {
+  return KNOWN_PROVIDER_VENDORS[vendorId].providers
+}
+
+export function vendorForProviderId(providerId: KnownProviderId): KnownProviderVendorId {
+  for (const vendorId of listKnownProviderVendorIds()) {
+    if ((KNOWN_PROVIDER_VENDORS[vendorId].providers as ReadonlyArray<KnownProviderId>).includes(providerId)) {
+      return vendorId
+    }
+  }
+  throw new Error(`Provider ${providerId} is not assigned to any vendor in KNOWN_PROVIDER_VENDORS`)
+}
+
+function variantCopy(
+  vendorId: KnownProviderVendorId,
+  providerId: KnownProviderId,
+): { label: string; hint?: string } | undefined {
+  const vendor: KnownProviderVendor = KNOWN_PROVIDER_VENDORS[vendorId]
+  return vendor.variants?.[providerId]
+}
+
+// Falls back to the provider's own name when a vendor supplies no variant copy
+// (single-provider vendors never render this prompt, so the fallback only
+// guards against an incomplete `variants` map on a multi-provider vendor).
+export function variantLabel(vendorId: KnownProviderVendorId, providerId: KnownProviderId): string {
+  return variantCopy(vendorId, providerId)?.label ?? KNOWN_PROVIDERS[providerId].name
+}
+
+export function variantHint(vendorId: KnownProviderVendorId, providerId: KnownProviderId): string | undefined {
+  return variantCopy(vendorId, providerId)?.hint
+}
 
 export type KnownModelRef = {
   [P in KnownProviderId]: `${P}/${Extract<keyof (typeof KNOWN_PROVIDERS)[P]['models'], string>}`

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -41,6 +41,17 @@ type KnownProvider = {
 // e.g. `OPENAI_API_KEY`). For `oauth` providers, `oauthProviderId` MUST match
 // a pi-ai OAuth provider id exactly, otherwise `authStorage.login()` will
 // throw "Unknown OAuth provider".
+//
+// Granularity rule (split vs merge): a provider id is the runtime API surface,
+// not the brand. Different API call => different provider id; same API call =>
+// same provider id. "Same API call" means same endpoint + same wire transport.
+// So `anthropic` is ONE id because api-key and oauth hit the same
+// /v1/messages endpoint (only the auth header differs), while `openai` /
+// `openai-codex` and `zai` / `zai-coding` are SEPARATE ids because each pair
+// targets different endpoints (and env vars). The user-facing brand grouping
+// lives in `KNOWN_PROVIDER_VENDORS` below — keep it out of this decision.
+// Renaming an id is a breaking change to secrets.json keys and typeclaw.json
+// model refs; only do it behind a migration in a dedicated major-version PR.
 export const KNOWN_PROVIDERS = {
   openai: {
     id: 'openai',


### PR DESCRIPTION
## Background

The init provider picker was inconsistent about how it presented vendors that have more than one auth/billing surface. Some vendors were flattened into two top-level rows, others into one:

```
●  OpenAI (API key)
○  OpenAI Codex (ChatGPT Plus/Pro)
○  Anthropic
○  Fireworks
○  Z.AI
○  Z.AI (GLM Coding Plan)
```

So the same conceptual choice ("which OpenAI surface?") was modeled two different ways: OpenAI and Z.AI were pre-split into separate rows, while Anthropic showed a single row and asked api-key-vs-OAuth in a follow-up step. Six rows for four vendors, and no consistent mental model for the user.

The underlying reason is that `openai`/`openai-codex` and `zai`/`zai-coding` are genuinely distinct provider ids (different base URLs, env vars, model lists), whereas `anthropic` is one id with two auth methods on the same endpoint. The picker leaked that implementation distinction into the UX.

## Summary

Every multi-surface vendor now behaves like Anthropic: one row per vendor, then a follow-up step that resolves the concrete surface.

- New **UX-only** `KNOWN_PROVIDER_VENDORS` registry groups existing flat provider ids under a vendor. It is deliberately kept out of the runtime contract — nothing about a vendor is ever persisted.
- Wizard flow is now `vendor → provider-variant → auth-method → model`. The variant follow-up phrasing varies per vendor, as requested:
  - **OpenAI** → "API key" vs "OAuth (ChatGPT Plus/Pro)" (maps to `openai` / `openai-codex`)
  - **Z.AI** → "Pay-as-you-go" vs "Coding Plan" (maps to `zai` / `zai-coding`)
  - **Anthropic** → single row; still asks api-key-vs-OAuth in `pick-auth-method` (unchanged)
  - **Fireworks** → single row, no follow-up
- Single-provider vendors auto-resolve the variant and skip the extra prompt, mirroring how single-auth providers already auto-skip `pickAuthMethod`.
- **Why auth before model:** the picker now resolves the provider id (hence the reachable model set) before showing models, so a user never sees a model the chosen surface can't serve.
- `typeclaw provider add` (interactive) uses the same vendor → variant picker. The positional `provider add <id>` form still accepts flat provider ids verbatim, so scripts/docs don't break.

## Preview

The picker now shows one row per vendor:

```
◆  Pick an LLM provider
│  ● OpenAI       (API key or OAuth)
│  ○ Anthropic    (API key or OAuth)
│  ○ Fireworks    (API key)
│  ○ Z.AI         (API key)
```

**OpenAI — API-key surface** (`vendor → variant → auth → model`):

```
◆  Pick an LLM provider
│  ● OpenAI
◇  Pick a OpenAI option
│  ● API key                    (OpenAI API platform)
│  ○ OAuth (ChatGPT Plus/Pro)   (ChatGPT subscription)
◇  Pick a OpenAI model
│  ● GPT-5.4 mini (Recommended)
│  ○ GPT-5.4 nano
│  ○ GPT-5.4
◇  Put your OpenAI API key (will be saved to secrets.json)
│  ********
```

Picking `OAuth (ChatGPT Plus/Pro)` instead resolves to the `openai-codex` provider and runs the browser login before the model step — no API-key prompt.

**Z.AI — plan-style variant** (same shape, different phrasing):

```
◆  Pick an LLM provider
│  ● Z.AI
◇  Pick a Z.AI option
│  ● Pay-as-you-go   (standard API billing)
│  ○ Coding Plan     (GLM Coding Plan subscription)
◇  Pick a Z.AI model
│  ● GLM-4.6
│  ○ GLM-4.7
```

`Pay-as-you-go` → provider id `zai`; `Coding Plan` → `zai-coding` (distinct base URL + env var).

**Anthropic — single-provider vendor** (no variant step; the auth choice stays where it always was):

```
◆  Pick an LLM provider
│  ● Anthropic
◇  How do you want to authenticate to Anthropic?
│  ● API key                (saved to secrets.json)
│  ○ OAuth (browser login)  (saved to secrets.json)
◇  Pick a Anthropic model
│  ● Claude Sonnet 4.6 (Recommended)
│  ○ Claude Haiku 4.5
```

Fireworks (single provider, API-key only) skips straight from the vendor row to the model picker.

## What this does NOT do

- **No persisted data-model change, so no migration.** `secrets.json#providers.*`, `typeclaw.json` model refs (`KnownModelRef = providerId/modelId`), and the generated JSON schema all stay keyed on the flat provider ids. Regenerating all four schemas produces zero diff. Existing installs keep working byte-for-byte.
- No change to runtime auth resolution (`src/agent/auth.ts`), secrets storage, or the OAuth/credential export paths.
- `KNOWN_PROVIDERS` declaration order is unchanged (still load-bearing for `provider --help` and the schema enum); the picker order now comes from `KNOWN_PROVIDER_VENDORS` instead.

## Review notes

- Load-bearing invariant: `KNOWN_PROVIDER_VENDORS` must remain a full partition of `KNOWN_PROVIDERS` (every provider id in exactly one vendor). Enforced by new tests in `src/config/providers.test.ts`.
- State-machine reordering is the subtle part. OAuth login now runs before the model is picked, so it receives the provider's first model ref as an OAuth discovery handle (login only reads `oauthProviderId` from it). Back-navigation helpers (`stepBeforeAuthMethod`, `stepBeforeModel`, `stepBeforeVision`) encode which silent auto-resume steps to skip when unwinding.
- The vision track gains the same vendor → variant split but keeps its original model-before-auth order.

> Note: the TUI snippets above are illustrative renderings of the `@clack/prompts` flow (exact glyphs/spacing differ in a real terminal); the prompt messages and option labels are verbatim from `src/cli/init.ts`.
