### PR TITLE
docs(seo): maximize docs discoverability — llms.txt, sitemap, robots, structured metadata

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -6,6 +6,12 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(import.meta.dirname),
+    resolveAlias: {
+      'fumadocs-mdx:collections/server': './.source/server.ts',
+    },
+  },
+  async rewrites() {
+    return [{ source: '/docs/:path*.md', destination: '/llms.mdx/docs/:path*' }]
   },
 }
 

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -11,7 +11,10 @@ const nextConfig: NextConfig = {
     },
   },
   async rewrites() {
-    return [{ source: '/docs/:path*.md', destination: '/llms.mdx/docs/:path*' }]
+    return [
+      { source: '/docs.md', destination: '/llms.mdx/docs' },
+      { source: '/docs/:path*.md', destination: '/llms.mdx/docs/:path*' },
+    ]
   },
 }
 

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -3,6 +3,12 @@ import { defineDocs, defineConfig } from 'fumadocs-mdx/config'
 
 export const { docs, meta } = defineDocs({
   dir: 'content/docs',
+  docs: {
+    postprocess: {
+      // Required for `page.data.getText('processed')`, used by the llms.txt routes.
+      includeProcessedMarkdown: true,
+    },
+  },
 })
 
 export default defineConfig({

--- a/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/docs/src/app/docs/[[...slug]]/page.tsx
@@ -22,9 +22,25 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     return {}
   }
 
+  const { title, description } = page.data
+
   return {
-    title: page.data.title,
-    description: page.data.description,
+    title,
+    description,
+    alternates: {
+      canonical: page.url,
+    },
+    openGraph: {
+      type: 'article',
+      url: page.url,
+      title,
+      description,
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
   }
 }
 

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -14,21 +14,42 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 })
 
+const SITE_URL = 'https://typeclaw.dev'
 const SITE_TITLE = 'TypeClaw — A TypeScript-native agent runtime'
 const SITE_DESCRIPTION =
   'TypeScript-native, Bun-powered, Docker-friendly general-purpose agent runtime. Sandboxed by default, plugins as plain TS modules, self-improving via memory.'
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://typeclaw.dev'),
+  metadataBase: new URL(SITE_URL),
   title: {
     default: SITE_TITLE,
     template: '%s · TypeClaw',
   },
   description: SITE_DESCRIPTION,
+  applicationName: 'TypeClaw',
+  keywords: [
+    'TypeClaw',
+    'AI agent runtime',
+    'TypeScript agent',
+    'Bun agent',
+    'Docker agent',
+    'self-hosted AI agent',
+    'agent framework',
+    'LLM agent',
+    'Slack bot',
+    'Discord bot',
+    'cron AI agent',
+  ],
+  authors: [{ name: 'TypeClaw' }],
+  creator: 'TypeClaw',
+  publisher: 'TypeClaw',
+  alternates: {
+    canonical: '/',
+  },
   openGraph: {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
-    url: 'https://typeclaw.dev',
+    url: SITE_URL,
     siteName: 'TypeClaw',
     type: 'website',
     images: [{ url: '/typeclaw.png', width: 1000, height: 1000, alt: 'Typeey, the TypeClaw mascot' }],
@@ -39,6 +60,48 @@ export const metadata: Metadata = {
     description: SITE_DESCRIPTION,
     images: ['/typeclaw.png'],
   },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
+}
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': `${SITE_URL}/#website`,
+      url: SITE_URL,
+      name: 'TypeClaw',
+      description: SITE_DESCRIPTION,
+      publisher: { '@id': `${SITE_URL}/#organization` },
+    },
+    {
+      '@type': 'Organization',
+      '@id': `${SITE_URL}/#organization`,
+      name: 'TypeClaw',
+      url: SITE_URL,
+      logo: `${SITE_URL}/typeclaw.png`,
+      sameAs: ['https://github.com/typeclaw/typeclaw'],
+    },
+    {
+      '@type': 'SoftwareApplication',
+      name: 'TypeClaw',
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'Linux, macOS, Windows (via Docker)',
+      description: SITE_DESCRIPTION,
+      url: SITE_URL,
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    },
+  ],
 }
 
 export default function RootLayout({
@@ -49,6 +112,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col antialiased`}>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
         <RootProvider>{children}</RootProvider>
       </body>
     </html>

--- a/docs/src/app/llms-full.txt/route.ts
+++ b/docs/src/app/llms-full.txt/route.ts
@@ -1,0 +1,12 @@
+import { getLLMText } from '@/lib/get-llm-text'
+import { source } from '@/lib/source'
+
+export const revalidate = false
+
+export async function GET(): Promise<Response> {
+  const pages = await Promise.all(source.getPages().map(getLLMText))
+
+  return new Response(pages.join('\n\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}

--- a/docs/src/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/docs/src/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -1,0 +1,23 @@
+import { notFound } from 'next/navigation'
+
+import { getLLMText } from '@/lib/get-llm-text'
+import { source } from '@/lib/source'
+
+export const revalidate = false
+
+export async function GET(_req: Request, { params }: RouteContext<'/llms.mdx/docs/[[...slug]]'>): Promise<Response> {
+  const { slug } = await params
+  const page = source.getPage(slug)
+
+  if (!page) {
+    notFound()
+  }
+
+  return new Response(await getLLMText(page), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  })
+}
+
+export function generateStaticParams(): { slug: string[] }[] {
+  return source.generateParams()
+}

--- a/docs/src/app/llms.txt/route.ts
+++ b/docs/src/app/llms.txt/route.ts
@@ -1,0 +1,11 @@
+import { llms } from 'fumadocs-core/source'
+
+import { source } from '@/lib/source'
+
+export const revalidate = false
+
+export function GET(): Response {
+  return new Response(llms(source).index(), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}

--- a/docs/src/app/robots.ts
+++ b/docs/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://typeclaw.dev'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  }
+}

--- a/docs/src/app/sitemap.ts
+++ b/docs/src/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from 'next'
+
+import { source } from '@/lib/source'
+
+const BASE_URL = 'https://typeclaw.dev'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const home: MetadataRoute.Sitemap[number] = {
+    url: BASE_URL,
+    changeFrequency: 'weekly',
+    priority: 1,
+  }
+
+  const docs = source.getPages().map((page) => ({
+    url: `${BASE_URL}${page.url}`,
+    changeFrequency: 'weekly' as const,
+    priority: page.url === '/docs' ? 0.9 : 0.7,
+  }))
+
+  return [home, ...docs]
+}

--- a/docs/src/lib/get-llm-text.ts
+++ b/docs/src/lib/get-llm-text.ts
@@ -1,0 +1,12 @@
+import type { InferPageType } from 'fumadocs-core/source'
+
+import type { source } from '@/lib/source'
+
+export async function getLLMText(page: InferPageType<typeof source>): Promise<string> {
+  const processed = (await page.data.getText('processed')).trim()
+  const { title, description } = page.data
+
+  const header = [`# ${title}`, `URL: ${page.url}`, description].filter(Boolean).join('\n')
+
+  return `${header}\n\n${processed}`
+}


### PR DESCRIPTION
## Background

typeclaw.dev shipped solid base metadata (site title/description, OG, Twitter) but was missing the machine-facing surface search engines and LLM crawlers now expect: no `sitemap.xml`, no `robots.txt`, no `llms.txt`, and no per-page canonical/structured data. That leaves crawlers to guess the page inventory, leaves AI assistants without a clean text feed, and risks duplicate-content ambiguity once the docs grow.

This PR closes that gap end to end — discovery (sitemap/robots), LLM-readable content (`llms.txt` family + per-page raw Markdown), and richer per-page HTML metadata (canonical, OG, JSON-LD).

## Summary

Three independent pieces, split across four commits so each reverts cleanly:

- **LLM-readable text.** `/llms.txt` (curated index via `fumadocs-core`'s `llms(source).index()`), `/llms-full.txt` (every page concatenated), and per-page raw Markdown at `/docs/*.md` (rewritten to an internal `/llms.mdx/docs/*` route handler). A small `getLLMText` helper renders `title + URL + processed body`; it relies on `includeProcessedMarkdown` so `page.data.getText('processed')` is populated at build time.
- **Crawler discovery.** `app/sitemap.ts` enumerates the home page plus every docs page (home `priority 1`, `/docs` `0.9`, leaf pages `0.7`); `app/robots.ts` allows all agents and points at the sitemap.
- **HTML metadata.** Docs pages now emit a per-page canonical + OpenGraph/Twitter. The root layout adds a site canonical, keywords, explicit robots directives (`max-image-preview:large`, unbounded snippet), and a `WebSite` / `Organization` / `SoftwareApplication` JSON-LD `@graph`.

**Why `turbopack.resolveAlias` (the one non-obvious bit):** the route handlers import the source loader, which pulls the `fumadocs-mdx:collections/server` virtual module. That specifier is mapped only by `tsconfig.paths`, which is a typecheck-time alias — not a bundler alias. RSC pages bundle it fine, but Route Handlers are compiled as standalone server entries and Turbopack *externalizes* the `fumadocs-mdx:` specifier, so Node tries to `require('fumadocs-mdx:collections/server')` during "Collecting page data" and fails. Aliasing it in `turbopack.resolveAlias` resolves the specifier to `./.source/server.ts` *before* the externalization decision. The `tsconfig.paths` entry stays for editor/TS resolution.

## Preview

`/robots.txt`:
```
User-Agent: *
Allow: /
Host: https://typeclaw.dev
Sitemap: https://typeclaw.dev/sitemap.xml
```

`/sitemap.xml` (excerpt):
```xml
<url><loc>https://typeclaw.dev</loc><changefreq>weekly</changefreq><priority>1</priority></url>
<url><loc>https://typeclaw.dev/docs</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
```

`/llms.txt` (excerpt) — curated, section-grouped index:
```
# Docs
- [What is TypeClaw?](/docs): A general-purpose AI agent that lives in its own container…
- Guides
  - [Quickstart](/docs/guides/quickstart): Install TypeClaw, start it, and get your first reply…
```

`/docs/guides/quickstart.md` — raw Markdown for LLMs (`Content-Type: text/markdown`):
```
# Quickstart
URL: /docs/guides/quickstart
Install TypeClaw, start it, and get your first reply — in about five minutes
…
```

Build output confirms the new routes prerender statically: `/llms.txt`, `/llms-full.txt`, `/robots.txt`, `/sitemap.xml` are `○ (Static)` and `/llms.mdx/docs/[[...slug]]` is `● (SSG)` across all 49 docs pages.

## What this does NOT do

- No OG **image** generation per page (docs pages inherit the shared mascot image; no `opengraph-image.tsx`).
- No `lastModified` timestamps in the sitemap (the loader exposes frontmatter only; git-mtime wiring was out of scope).
- Does not touch the landing page (`page.tsx`) content or fix its three pre-existing unused-import lint warnings.

## Review notes

- **Load-bearing line:** `turbopack.resolveAlias` in `next.config.ts`. Remove it and the build fails at page-data collection for the `llms*` route handlers — verify the build still passes if you touch the MDX/Turbopack config.
- **Invariant:** `includeProcessedMarkdown: true` in `source.config.ts` is what makes `getText('processed')` work; deleting it silently breaks `/llms.txt` and `/docs/*.md`. There's a comment guarding this.
- Verified locally: `bun run lint` (only the 3 pre-existing `page.tsx` warnings), `bun run format:check`, and `bun run build` (typecheck) all pass; routes smoke-tested against `bun run start`.
