### PR TITLE
fix(oauth): ask for the copyable code, not the redirect URL

### DIFF
--- a/src/cli/oauth-callbacks.ts
+++ b/src/cli/oauth-callbacks.ts
@@ -44,8 +44,9 @@ export function buildOAuthCallbacks(providerName: string): OAuthCallbackHandle {
         const preamble = [
           `Open this URL in your browser to sign in to ${providerName}.`,
           '',
-          'If your browser shows "this site can\'t be reached" after you sign in,',
-          'copy the full address from the top of the browser and paste it below.',
+          'If the page after sign-in shows a code to copy (or a "this site can\'t',
+          'be reached" / "could not establish connection" error), copy that code —',
+          'or the full address from the top of the browser — and paste it below.',
         ]
         if (instructions) preamble.push('', instructions)
         note(preamble.join('\n'), 'Browser login')
@@ -67,8 +68,8 @@ export function buildOAuthCallbacks(providerName: string): OAuthCallbackHandle {
       onManualCodeInput: async () => {
         const value = await text({
           message:
-            'If your browser shows "this site can\'t be reached" after you sign in, copy the full address from the top of the browser and paste it here:',
-          placeholder: 'http://localhost:1455/auth/callback?code=...&state=...',
+            'After signing in, paste the code shown on the page (some providers offer a copy button), or the full redirect address from the top of the browser:',
+          placeholder: 'code, or http://localhost:1455/auth/callback?code=...&state=...',
           signal,
         })
         if (isCancel(value)) throw new Error('Login cancelled by user')

--- a/src/secrets/oauth-xai.ts
+++ b/src/secrets/oauth-xai.ts
@@ -240,7 +240,7 @@ export async function loginXai(callbacks: OAuthLoginCallbacks, fetchImpl: FetchF
     callbacks.onAuth({
       url: `${AUTHORIZE_URL}?${authParams.toString()}`,
       instructions:
-        'Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.',
+        'Complete login in your browser. Grok shows a code to copy on the "could not establish connection" page — paste that code here. If the browser is on another machine, paste the code (or the final redirect URL) here.',
     })
 
     if (server && callbacks.onManualCodeInput) {


### PR DESCRIPTION
## Background

When signing in to Grok (xAI) via OAuth, the loopback callback often cannot be reached — common in remote, SSH, or container setups where the browser host differs from the CLI host. Instead of completing the redirect, Grok renders a "could not establish connection" page that surfaces the authorization code directly with a one-click copy button (e.g. `nqndq3YLPa2iyb5two4s-y_DpsGw_…`).

The old prompts told users to "copy the full address from the top of the browser" — misdirecting them away from the copyable code the page actually offers. On that error page there is often no useful address in the bar; the code is the intended artifact.

## Summary

Wording-only fix across three user-facing strings: the `onAuth` note in `buildOAuthCallbacks`, the `onManualCodeInput` prompt message and placeholder, and the Grok-specific `instructions` string in `oauth-xai.ts`.

Each now leads with "paste the code shown on the page (some providers offer a copy button)" and keeps the full-URL path as a fallback for loopback providers (e.g. Anthropic) that redirect cleanly and show no code.

**No backend change needed.** `parseAuthorizationInput` already accepts a bare code, a query string, or a full URL — its final `return { code: value }` branch handles bare tokens. Pasting the code already worked; users just were not told to use it.

**Why the shared copy stays generic.** `buildOAuthCallbacks` is shared by all OAuth providers, not just Grok. Anthropic-style providers land on a reachable redirect with no copyable code, so the full-address instruction still applies. The shared string says "the code … or the full redirect address" to cover both without per-provider branching. Only the Grok-specific `instructions` string calls out the code explicitly.

Before:
```
If your browser shows "this site can't be reached" after you sign in,
copy the full address from the top of the browser and paste it below.
```

After:
```
If the page after sign-in shows a code to copy (or a "this site can't
be reached" / "could not establish connection" error), copy that code —
or the full address from the top of the browser — and paste it below.
```

## What this does NOT do

- No change to OAuth token exchange, PKCE, state validation, or the loopback callback server.
- No new per-provider branching in `oauth-callbacks.ts`.
- Does not touch the happy path (browser reaches loopback and completes automatically).

## Review notes

The load-bearing claim: no parsing change is required — confirm `parseAuthorizationInput` in `src/secrets/oauth-xai.ts` already returns `{ code: value }` for a bare token. All three edited strings are pure copy; behavior is unchanged.

CI: typecheck clean, lint 0 errors, format:check clean, 7946 tests pass / 0 fail.