### PR TITLE
docs: document xAI (Grok) provider and fix stale provider lists

### DIFF
--- a/docs/content/docs/guides/add-a-provider.mdx
+++ b/docs/content/docs/guides/add-a-provider.mdx
@@ -17,10 +17,13 @@ Adding a provider is one command. Pick the one you have an account with:
 typeclaw provider add anthropic --key sk-ant-...
 typeclaw provider add openai-codex --oauth    # log in with a ChatGPT subscription
 typeclaw provider add fireworks --key fw_...
+typeclaw provider add zai --key ...            # Z.AI pay-as-you-go
+typeclaw provider add zai-coding --key ...     # Z.AI GLM Coding Plan
+typeclaw provider add xai --key xai-...        # xAI (Grok) — also supports --oauth
 typeclaw provider add minimax --key ...        # pay-as-you-go API key or Token Plan key (sk-cp-…)
 ```
 
-The supported providers are `openai`, `openai-codex`, `anthropic`, `fireworks`, `zai`, `zai-coding`, and `minimax`. The key (or browser login) is stored in `secrets.json`, git-ignored like the rest of your credentials.
+The supported providers are `openai`, `openai-codex`, `anthropic`, `fireworks`, `zai`, `zai-coding`, `xai`, and `minimax`. The key (or browser login) is stored in `secrets.json`, git-ignored like the rest of your credentials.
 
 <Callout type="info" title="MiniMax: pay-as-you-go or Token Plan">
   MiniMax sells one `minimax` provider under two billing surfaces — pay-as-you-go API keys and Token Plan Subscription
@@ -28,9 +31,15 @@ The supported providers are `openai`, `openai-codex`, `anthropic`, `fireworks`, 
   init` asks which one you have only so it can link you to the right dashboard.
 </Callout>
 
+<Callout type="info" title="xAI (Grok): API key or subscription">
+  `xai` is dual-auth like `anthropic`: pass `--key xai-…` for the developer API (`XAI_API_KEY`), or `--oauth` to log in
+  with a Grok subscription. When both exist, the on-disk OAuth credential wins — run `typeclaw provider remove xai` to
+  fall back to the key.
+</Callout>
+
 <Callout type="info" title="Use a subscription you already pay for">
-  `openai-codex` and `anthropic` support `--oauth` — log in through the browser with an existing ChatGPT or Claude
-  subscription instead of pasting an API key.
+  `openai-codex`, `anthropic`, and `xai` support `--oauth` — log in through the browser with an existing ChatGPT,
+  Claude, or Grok subscription instead of pasting an API key.
 </Callout>
 
 ## Point work at the right model

--- a/docs/content/docs/guides/quickstart.mdx
+++ b/docs/content/docs/guides/quickstart.mdx
@@ -16,7 +16,7 @@ You need two things installed:
 - **[Bun](https://bun.sh/)** (version 1.1 or newer) — the runtime TypeClaw is built on.
 - **[OrbStack](https://orbstack.dev/)** (recommended) or **[Docker](https://www.docker.com/)** — your agent runs inside a container. OrbStack is lighter and faster to start on macOS; Docker Desktop works just as well.
 
-You'll also need access to one AI provider — an API key from OpenAI, Anthropic, Fireworks, or Z.AI, or an existing ChatGPT or Claude subscription you can log in with (via the `openai-codex` or `anthropic` providers). The wizard in step 2 walks you through it.
+You'll also need access to one AI provider — an API key from OpenAI, Anthropic, Fireworks, Z.AI, xAI, or MiniMax, or an existing ChatGPT, Claude, or Grok subscription you can log in with (via the `openai-codex`, `anthropic`, or `xai` providers). The wizard in step 2 walks you through it.
 
 ## Five steps to your first reply
 
@@ -67,9 +67,10 @@ The provider step asks, in order: **which provider**, **which model**, then **AP
 Add a provider and pick a default model by hand:
 
 ```sh
-typeclaw provider add openai --key sk-...       # or anthropic, fireworks, zai, minimax
+typeclaw provider add openai --key sk-...       # or anthropic, fireworks, zai, zai-coding, xai, minimax
 typeclaw provider add openai-codex --oauth      # log in with a ChatGPT subscription
 typeclaw provider add anthropic --oauth         # log in with a Claude subscription
+typeclaw provider add xai --oauth               # log in with a Grok subscription
 typeclaw model set default openai/gpt-5.4-nano
 ```
 

--- a/docs/content/docs/guides/quickstart.mdx
+++ b/docs/content/docs/guides/quickstart.mdx
@@ -58,7 +58,7 @@ typeclaw init
 - a `Dockerfile` and `package.json` — so the agent can build its container
 - starter folders: `workspace/` (the agent's free-write space), `public/`, `sessions/`, `.agents/skills/`, `mounts/`, `packages/`
 
-The provider step asks, in order: **which provider**, **which model**, then **API key or OAuth**. If you pick a subscription-backed provider — **OpenAI Codex** (your ChatGPT plan) or **Anthropic** (your Claude plan) — you can log in through the browser instead of pasting a key. (Plain `openai` is API-key only.) It validates your key on the spot, so you'll know immediately if it's wrong. After the provider, it offers to set up a **channel** — pick one and it runs that channel's credential flow then and there, or skip and add channels later from [Add a channel](/docs/guides/add-a-channel).
+The provider step asks, in order: **which provider**, **which model**, then **API key or OAuth**. If you pick a subscription-backed provider — **OpenAI Codex** (your ChatGPT plan), **Anthropic** (your Claude plan), or **xAI** (your Grok plan) — you can log in through the browser instead of pasting a key. (Plain `openai` is API-key only.) It validates your key on the spot, so you'll know immediately if it's wrong. After the provider, it offers to set up a **channel** — pick one and it runs that channel's credential flow then and there, or skip and add channels later from [Add a channel](/docs/guides/add-a-channel).
 
 </Accordion>
 

--- a/docs/content/docs/reference/env-vars.mdx
+++ b/docs/content/docs/reference/env-vars.mdx
@@ -27,14 +27,16 @@ icon: Variable
 
 Set in the host stage; injected into the container via `--env-file .env`.
 
-| Variable            | Provider    | Notes                                                                                                    |
-| ------------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
-| `FIREWORKS_API_KEY` | `fireworks` |                                                                                                          |
-| `OPENAI_API_KEY`    | `openai`    |                                                                                                          |
-| `ANTHROPIC_API_KEY` | `anthropic` |                                                                                                          |
-| `MINIMAX_API_KEY`   | `minimax`   | Accepts either a pay-as-you-go API key or a Token Plan Subscription Key (`sk-cp-…`) — same slot.         |
-| `GOOGLE_API_KEY`    | `google`    |                                                                                                          |
-| (others)            |             | Each known provider has a canonical env var; see [/reference/secrets-json](/docs/reference/secrets-json) |
+| Variable             | Provider     | Notes                                                                                                    |
+| -------------------- | ------------ | -------------------------------------------------------------------------------------------------------- |
+| `FIREWORKS_API_KEY`  | `fireworks`  |                                                                                                          |
+| `OPENAI_API_KEY`     | `openai`     |                                                                                                          |
+| `ANTHROPIC_API_KEY`  | `anthropic`  | OAuth credential on disk wins over this env var (dual-auth provider).                                    |
+| `ZAI_API_KEY`        | `zai`        | Z.AI pay-as-you-go.                                                                                      |
+| `ZAI_CODING_API_KEY` | `zai-coding` | Z.AI GLM Coding Plan — separate billing surface from `zai`.                                              |
+| `XAI_API_KEY`        | `xai`        | xAI (Grok). OAuth credential on disk wins over this env var (dual-auth provider).                        |
+| `MINIMAX_API_KEY`    | `minimax`    | Accepts either a pay-as-you-go API key or a Token Plan Subscription Key (`sk-cp-…`) — same slot.         |
+| (others)             |              | Each known provider has a canonical env var; see [/reference/secrets-json](/docs/reference/secrets-json) |
 
 Custom env-var names are supported via the `Secret`'s `env` field — `{ "key": { "env": "MY_OPENAI" } }`. See [/concepts/secrets-policy](/docs/concepts/secrets-policy) for resolution order.
 

--- a/docs/content/docs/reference/env-vars.mdx
+++ b/docs/content/docs/reference/env-vars.mdx
@@ -23,9 +23,11 @@ icon: Variable
 | `TYPECLAW_NETWORK_BLOCK_INTERNAL` | when `network.blockInternal: true` | `1` — entrypoint shim installs the iptables egress filter                 |
 | `DISPLAY`                         | when `docker.file.xvfb` is enabled | `:99` — points at the in-container Xvfb server                            |
 
-## Provider credentials (env-wins)
+## Provider credentials
 
 Set in the host stage; injected into the container via `--env-file .env`.
+
+These env vars override a stored API-key credential in `secrets.json` (env-wins). The exception is dual-auth providers (`anthropic`, `xai`): a stored OAuth credential takes precedence over the env var, since OAuth is stateful and refreshed on disk. See [/concepts/secrets-policy](/docs/concepts/secrets-policy) for the full resolution order.
 
 | Variable             | Provider     | Notes                                                                                                    |
 | -------------------- | ------------ | -------------------------------------------------------------------------------------------------------- |

--- a/docs/content/docs/reference/typeclaw-json.mdx
+++ b/docs/content/docs/reference/typeclaw-json.mdx
@@ -32,9 +32,9 @@ Plugin-owned config blocks live at the top level under their plugin name and are
 ```json
 {
   "models": {
-    "default": "fireworks/kimi-k2",
+    "default": "openai/gpt-5.4-nano",
     "fast": "openai/gpt-5.4-mini",
-    "deep": ["anthropic/claude-opus-4-5", "fireworks/kimi-k2"],
+    "deep": ["anthropic/claude-opus-4-8", "fireworks/accounts/fireworks/routers/kimi-k2p6-turbo"],
     "vision": "openai/gpt-5.4"
   }
 }


### PR DESCRIPTION
## Background

The provider registry ships eight providers but the docs lagged. Notably `xai` was fully wired into the runtime — dual-auth via both an API key and an OAuth flow — yet documented nowhere. The original question was "do we have minimax and grok channel docs?" — the finding is that both are model providers, not channel adapters, so there are no channel docs to add; the real gap was stale provider docs.

## Summary

Audits every provider-facing doc page against the live registry and brings them in sync.

**guides/add-a-provider** — added xai, zai, and zai-coding to the supported-providers list and command examples; new xAI dual-auth callout (API key vs `--oauth`, precedence rules); updated the OAuth callout to include Grok subscriptions.

**reference/env-vars** — added three missing rows:
- `XAI_API_KEY` (xAI — dual-auth, OAuth credential on disk wins)
- `ZAI_API_KEY` (Z.AI pay-as-you-go)
- `ZAI_CODING_API_KEY` (Z.AI GLM Coding Plan)

Also removed the google / `GOOGLE_API_KEY` row — google is not a registered provider.

**guides/quickstart** — provider prose and "add one later" command examples updated to include xAI and MiniMax.

**reference/typeclaw-json** — two invalid model refs in the example corrected:

```
fireworks/kimi-k2              → fireworks/accounts/fireworks/routers/kimi-k2p6-turbo
anthropic/claude-opus-4-5      → anthropic/claude-opus-4-8
```

## What this does NOT do

- Does not add a separate per-provider reference page — repo convention keeps provider docs in the guide + registry file.
- No `.ts` touched; typecheck/test are unaffected.

## Review notes

No load-bearing changes. The `GOOGLE_API_KEY` removal is the one deletion worth a second look:
google is absent from the provider registry, so the row was dead text.