### PR TITLE
fix(channels): defer provider-error notice to turn-end so recovered turns post nothing

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5303,6 +5303,114 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(totalNotices).toBe(2)
   })
 
+  test('suppresses the soft-error notice when the turn recovers and replies (no stranded false failure)', async () => {
+    // given: a turn that hits a transient provider error MID-stream (e.g.
+    // server_is_overloaded) but then recovers and produces a real reply — the
+    // exact huxley#1755 incident, where the "⚠️ provider failed" notice was
+    // stranded above a correct review posted ~83s later.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // when: error fires, then the turn recovers with assistant prose
+    await router.route(inbound({ text: 'review this PR' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          stopReason: 'error',
+          errorMessage:
+            'Codex error: {"error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded."}}',
+        },
+      })
+      sessions[0]!.setAssistantText('Review complete. Clean refactor, no issues.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the real reply lands and NO failure notice is posted
+    expect(sent.some((t) => /Review complete/.test(t))).toBe(true)
+    expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(false)
+  })
+
+  test('carries the soft-error across an empty-turn retry: no notice when the RETRY recovers and replies', async () => {
+    // given: the first prompt hits a provider error AND ends truncated with no
+    // send, so validateChannelTurn queues an EMPTY_TURN_RETRY_NUDGE (a fresh
+    // drain iteration with a new turnSeq). The retry then replies. The pending
+    // error must follow the logical turn — posting it at the first iteration's
+    // end would strand a false failure above the retry's reply.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ambiguous thing' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      attempt++
+      // when: first attempt errors + truncates (no send) → retry queued
+      if (attempt === 1) {
+        sessions[0]!.emit({
+          type: 'message_end',
+          message: { role: 'assistant', stopReason: 'error', errorMessage: 'transient server_is_overloaded' },
+        })
+        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'error')
+        return
+      }
+      // when: retry recovers and replies
+      expect(text).toContain(EMPTY_TURN_RETRY_NUDGE)
+      sessions[0]!.setAssistantText('SENT')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here is your answer' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: only the real reply; the carried-forward error is suppressed
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent.some((t) => /here is your answer/.test(t))).toBe(true)
+    expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(false)
+  })
+
+  test('exhausted empty-turn retries surface the generic fallback (not a duplicate provider notice) and never go silent', async () => {
+    // given: every attempt errors + truncates with no send, exhausting the
+    // empty-turn retry budget without ever replying. The exhausted path already
+    // posts EMPTY_TURN_FALLBACK_TEXT — a user-facing "I got stuck" notice that
+    // counts as a reply — so the provider notice is correctly suppressed as
+    // redundant. The human still sees exactly one notice (never dead air); the
+    // raw provider cause lives in the operator logs.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ambiguous thing' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'transient server_is_overloaded' },
+      })
+      sessions[0]!.setAssistantMidTurn('never-ending loop output', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: retries ran, the generic fallback surfaced exactly once, no
+    // duplicate provider notice, and the raw cause was logged for operators
+    expect(sessions[0]!.prompts.length).toBeGreaterThan(1)
+    expect(sent.filter((t) => t === EMPTY_TURN_FALLBACK_TEXT)).toHaveLength(1)
+    expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(false)
+    expect(logs.some((m) => /LLM call failed: .*server_is_overloaded/.test(m))).toBe(true)
+  })
+
   test('upgrades hard prompt-throws to logger.error (not warn) so `typeclaw logs` operators see them at the right level', async () => {
     // given
     const dir = await tempDir()

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5377,6 +5377,47 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(false)
   })
 
+  test('does NOT misattribute a carried provider error to a fresh user turn that coalesces with the retry nudge', async () => {
+    // given: turn A errors + truncates (no send) → empty-turn retry nudge queued
+    // AND carries the provider error forward. Before the reminder-only retry
+    // drains, a NEW user message (turn B) arrives. The drain loop splices
+    // promptQueue + pendingSystemReminders together, so turn B is a fresh user
+    // batch carrying the stale nudge. Turn B then produces no reply. The prior
+    // turn's provider notice must NOT post against turn B.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'turn A' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      // when: turn A errors + truncates (queues the retry nudge + carry), then a
+      // fresh user message lands while that nudge is still pending
+      if (attempt === 1) {
+        sessions[0]!.emit({
+          type: 'message_end',
+          message: { role: 'assistant', stopReason: 'error', errorMessage: 'transient server_is_overloaded' },
+        })
+        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'error')
+        await router.route(inbound({ externalMessageId: 'mB', text: 'turn B' }))
+        return
+      }
+      // when: turn B (fresh user batch + coalesced nudge) ends with no reply and
+      // no further error — a clean empty turn that must not inherit A's notice
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: A's stale provider notice is never posted against turn B
+    expect(sessions[0]!.prompts.length).toBeGreaterThanOrEqual(2)
+    expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(false)
+  })
+
   test('exhausted empty-turn retries surface the generic fallback (not a duplicate provider notice) and never go silent', async () => {
     // given: every attempt errors + truncates with no send, exhausting the
     // empty-turn retry budget without ever replying. The exhausted path already

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -618,6 +618,16 @@ type LiveSession = {
   // "is this a multi-human group". Read by composeTurnPrompt().
   multiHumanGroup: boolean
   membershipFetch: Promise<MembershipCount | null> | null
+  // Provider soft-error (`stopReason: 'error'`) captured during the current
+  // turn, deferred to turn-end. Upstream surfaces transient errors (e.g.
+  // `server_is_overloaded`) MID-turn and the turn often recovers, replying
+  // seconds later — posting the "⚠️ provider failed" notice on the spot strands
+  // a false failure above the eventual real reply. So the listener only RECORDS
+  // here (stamped with the firing turnSeq; raw text logged for operators); the
+  // turn-end finally posts `safeMessage` ONLY if no reply landed, else discards.
+  // First error per turn wins. Keyed by `turnSeq` so a stale record from a
+  // crashed prior turn can't leak into the next.
+  pendingProviderError: { turnSeq: number; safeMessage: string } | null
   destroyed: boolean
   unsubProviderErrors: (() => void) | null
   unsubTypingActivity: (() => void) | null
@@ -1472,49 +1482,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         loopGuardActive: false,
         multiHumanGroup: false,
         membershipFetch,
+        pendingProviderError: null,
         destroyed: false,
         unsubProviderErrors: null,
         unsubTypingActivity: null,
         unsubTodoOutcome: null,
       }
-      // Tracks the `turnSeq` a provider-error notice was last POSTED for, so the
-      // channel surfaces at most one notice per turn. The upstream SDK retries
-      // internally, and each retry emits its own `message_end` with
-      // `stopReason: 'error'` — without this gate a single failing turn posts N
-      // identical "⚠️ upstream provider failed" notices (one per retry). Logs
-      // still record every attempt; only the user-facing notice is deduped.
-      let lastProviderErrorNoticeTurn: number | undefined
+      // Raw text is logged on EVERY attempt for operators; the user-facing
+      // notice is deferred. The upstream SDK retries internally, and each retry
+      // emits its own `message_end` with `stopReason: 'error'` — but the turn
+      // frequently recovers and replies anyway. Recording the first error per
+      // turn (keyed by `turnSeq`) lets drain()'s turn-end decide: post the
+      // notice only if no reply landed, suppress it if the turn recovered. This
+      // both dedupes the retry storm AND prevents a stranded false-failure
+      // notice above a successful reply. See `pendingProviderError`.
       live.unsubProviderErrors = subscribeProviderErrors(created.session, (err) => {
         logger.error(`[channels] ${live.keyId}: LLM call failed: ${err.message}`)
-        // Suppress duplicate notices for the SAME turn (retry storm). Set the
-        // marker BEFORE the async send so a synchronous burst of retry events
-        // can't each slip past the check and enqueue their own notice.
-        if (lastProviderErrorNoticeTurn === live.turnSeq) return
-        lastProviderErrorNoticeTurn = live.turnSeq
-        // A provider soft-error (rate/usage limit, billing, malformed response)
-        // ends the turn with no assistant text, so the human otherwise sees
-        // silence. Surface the REDACTED `safeMessage` (never the raw provider
-        // text, which can carry response bodies / URLs / tokens) via a 'system'
-        // send — the same one-shot bypass path validateChannelTurn uses, so it
-        // lands regardless of per-turn send caps and skips the duplicate guard.
-        void send(
-          {
-            adapter: live.key.adapter,
-            workspace: live.key.workspace,
-            chat: live.key.chat,
-            thread: live.key.thread,
-            text: `⚠️ ${err.safeMessage}`,
-          },
-          { source: 'system' },
-        )
-          .then((result) => {
-            if (!result.ok) {
-              logger.warn(`[channels] ${live.keyId}: provider-error notice send failed: ${result.error}`)
-            }
-          })
-          .catch((sendErr) => {
-            logger.warn(`[channels] ${live.keyId}: provider-error notice send threw: ${describe(sendErr)}`)
-          })
+        if (live.pendingProviderError?.turnSeq === live.turnSeq) return
+        live.pendingProviderError = { turnSeq: live.turnSeq, safeMessage: err.safeMessage }
       })
       live.unsubTodoOutcome = created.session.subscribe((event: unknown) => {
         const usage = extractTurnUsage(event)
@@ -1931,6 +1916,56 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  const maybePostDeferredProviderError = async (
+    live: LiveSession,
+    sentReplyThisTurn: boolean,
+    retryQueued: boolean,
+  ): Promise<void> => {
+    const pending = live.pendingProviderError
+    if (pending === null || pending.turnSeq !== live.turnSeq) {
+      live.pendingProviderError = null
+      return
+    }
+    // The turn recovered and replied — the provider blip was transient, so a
+    // failure notice would be a false alarm stranded above the real reply.
+    if (sentReplyThisTurn) {
+      live.pendingProviderError = null
+      return
+    }
+    // An empty-turn retry was queued (validateChannelTurn pushed
+    // EMPTY_TURN_RETRY_NUDGE): the same logical turn re-prompts in the next
+    // drain iteration and may yet recover. Carry the pending error forward,
+    // re-stamping to that iteration's turnSeq (drain does `turnSeq++` once per
+    // iteration, so it will be exactly `turnSeq + 1`). Posting now would strand
+    // a false-failure notice above the retry's eventual reply — the same defect
+    // one logical turn later.
+    if (retryQueued) {
+      live.pendingProviderError = { turnSeq: live.turnSeq + 1, safeMessage: pending.safeMessage }
+      return
+    }
+    live.pendingProviderError = null
+    // Genuinely empty turn with no retry left: surface the REDACTED
+    // `safeMessage` (never raw provider text, which can carry response bodies /
+    // URLs / tokens) via a 'system' send — the one-shot bypass path that lands
+    // regardless of per-turn send caps — so the human doesn't just see silence.
+    const result = await send(
+      {
+        adapter: live.key.adapter,
+        workspace: live.key.workspace,
+        chat: live.key.chat,
+        thread: live.key.thread,
+        text: `⚠️ ${pending.safeMessage}`,
+      },
+      { source: 'system' },
+    ).catch((sendErr) => {
+      logger.warn(`[channels] ${live.keyId}: provider-error notice send threw: ${describe(sendErr)}`)
+      return null
+    })
+    if (result !== null && !result.ok) {
+      logger.warn(`[channels] ${live.keyId}: provider-error notice send failed: ${result.error}`)
+    }
+  }
+
   const drain = async (live: LiveSession): Promise<void> => {
     if (live.draining || live.destroyed) return
     live.draining = true
@@ -2010,6 +2045,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.info(`[channels] ${live.keyId} prompting batch=${batch.length} text_len=${text.length}`)
         const promptStart = now()
         const successfulSendsBeforePrompt = live.successfulChannelSends
+        const emptyTurnRetriesBeforePrompt = live.emptyTurnRetries
         const engageAddPromises = live.currentTurnEngageReactions
         live.turnSeq++
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
@@ -2030,6 +2066,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         } finally {
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
           if (sentReplyThisTurn) dropEngageReactionsAfterReply(live, engageAddPromises)
+          const emptyTurnRetryQueued = live.emptyTurnRetries > emptyTurnRetriesBeforePrompt
+          await maybePostDeferredProviderError(live, sentReplyThisTurn, emptyTurnRetryQueued)
           await fireSessionTurnEnd(live)
         }
         await fireSessionIdle(live)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1983,6 +1983,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.currentTurnAttachments = collectTurnAttachments(observed, batch)
 
         if (batch.length > 0) {
+          // A fresh user batch starts a NEW logical turn. Drop any provider
+          // error carried forward from a prior turn's empty-turn retry: the
+          // drain loop splices promptQueue AND pendingSystemReminders together,
+          // so a user message arriving while a retry nudge is pending coalesces
+          // into this iteration. Without this clear, the carried error (stamped
+          // `turnSeq + 1`) would match this fresh turn and post the prior turn's
+          // notice misattributed to an unrelated new message. Carry-forward stays
+          // intact for genuinely reminder-only iterations (batch.length === 0),
+          // which skip this branch.
+          live.pendingProviderError = null
           live.currentTurnAuthorId = batch[batch.length - 1]!.authorId
           live.currentTurnAuthorIds = new Set(batch.map((m) => m.authorId))
           live.currentTurnReactionRef = batch[batch.length - 1]!.reactionRef ?? null


### PR DESCRIPTION
## Background

A transient upstream error (e.g. Codex `server_is_overloaded`) is surfaced by pi-coding-agent as a **mid-turn** `message_end` with `stopReason: 'error'` — not a throw. The channel router subscribed to these and posted the `⚠️ The upstream LLM provider failed…` notice **the instant the soft error fired**. But the turn frequently keeps running and recovers, issuing a real reply seconds later.

Observed in production: on a GitHub PR the agent posted the failure notice at `T`, then a **correct review at `T+83s`**. Container logs showed the overload aborted one mid-stream fetch, after which ~20 more codex calls succeeded within the same `prompt()` call and the turn finished normally. The `⚠️` comment was left stranded above the successful review — a false alarm.

Root cause: `subscribeProviderErrors` fires on **every** `message_end` with `stopReason: 'error'`, including intermediate ones the turn recovers from. The old dedup gate only prevented *duplicate* notices per turn; it still posted **one** notice even when the turn ultimately succeeded.

## Summary

Record the first provider soft-error per turn instead of posting it immediately, then decide at **turn-end**:

- Raw provider text is still logged for operators on **every** attempt (unchanged operator visibility).
- The redacted `safeMessage` is posted to the channel **only if the turn produced no successful reply**. If it recovered, the pending error is discarded silently.

**Why defer rather than reword the message:** the message isn't the problem — the *timing* is. A turn that recovers should post nothing; rewording would still leave a confusing notice above a good reply.

**Empty-turn retry interaction (the subtle part):** `validateChannelTurn`'s empty-turn retries re-prompt the *same logical turn* in a fresh `drain` iteration with a new `turnSeq`. Posting at the first iteration's end would reproduce the same stranded-notice defect one logical turn later. So a pending error is **carried forward** (re-stamped to the next iteration's `turnSeq`) across retries rather than posted between attempts. When retries exhaust, the existing `EMPTY_TURN_FALLBACK_TEXT` already surfaces a user-facing notice, so the provider notice is correctly suppressed as redundant — the human never sees dead air, and the raw cause stays in the logs.

## What this does NOT do

- Does not add any cross-turn retry of its own — recovery is entirely the upstream SDK / agent loop's existing behavior.
- Does not touch the operator-facing TUI/server path (`src/server/index.ts`), which intentionally shows the raw message.
- Does not change `provider-error.ts` detection or `safeMessage` redaction.
- Does not rewire `postEmptyTurnFallback`; it relies on the existing fallback already counting as a reply.

## Review notes

- Load-bearing change: `maybePostDeferredProviderError` (`src/channels/router.ts`) and its call in `drain()`'s turn `finally`.
- Invariant to verify: `turnSeq` is a **per-prompt** counter (incremented once just before each `session.prompt()`), so within a single turn+finally it matches the value the listener stamped; the empty-turn retry is the only case where the logical turn spans multiple `turnSeq` values, handled by the carry-forward branch (`turnSeq + 1`).
- `retryQueued` is derived from an `emptyTurnRetries` delta, not raw `pendingSystemReminders.length`, so unrelated reminder pushes (restart-resume, etc.) can't falsely trigger carry-forward.
- Tests cover all three paths: recovered-within-prompt, recovered-via-retry, and retries-exhausted (fallback surfaces, provider notice suppressed, raw cause logged).