### PR TITLE
fix(channels): scope botInThread to our own thread participation

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6004,6 +6004,89 @@ describe('ChannelRouter cold-start prefetch', () => {
     expect(prompt).toContain('hey bot')
   })
 
+  test('a peer bot in prefetched history does NOT make botInThread true (stays quiet on a human-rooted reply-to-other)', async () => {
+    // Incident: dobby woke on a fresh thread cold-start whose prefetched
+    // history held a PEER bot's message. `hasBotParticipated` counted that
+    // peer bot as "we participated", flipping botInThread=true, which
+    // neutralized the replyToOtherMessageId suppressor and let dobby engage
+    // a thread aimed at another bot. botInThread must mean OUR participation,
+    // not "some bot spoke here".
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerSelfIdentity('discord-bot', () => ({ id: 'BOT_SELF_ID' }))
+    router.registerHistory('discord-bot', async () => ({
+      ok: true,
+      messages: [
+        historyMessage({
+          externalMessageId: 'peer-hist',
+          text: 'peer bot analysis',
+          authorId: 'peer1',
+          authorName: 'PeerBot',
+          isBot: true,
+        }),
+      ],
+    }))
+
+    // when: a human posts a thread reply whose parent (thread root) is another
+    // human — Slack's parent_user_id always points at the root, so this is the
+    // shape the suppressor exists to catch. No mention/alias/dm.
+    await router.route(
+      inbound({
+        thread: 't-A',
+        externalMessageId: 'human-followup',
+        text: 'follow-up between others',
+        authorId: 'human-asker',
+        authorName: 'human-asker',
+        isBotMention: false,
+        replyToBotMessageId: null,
+        replyToOtherMessageId: 't-A',
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A' })
+
+    // then: observed, not engaged (no prompt produced)
+    expect(sessions[0]!.prompts).toHaveLength(0)
+  })
+
+  test('our OWN message in prefetched history DOES make botInThread true (PR #58 cold-start participation survives)', async () => {
+    // The flip side of the fix: a cold-start that prefetches DOBBY's own past
+    // reply (authorId === self identity) must still count as participation, so
+    // a human follow-up in a thread we already answered engages rather than
+    // being dropped by the replyToOtherMessageId suppressor.
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerSelfIdentity('discord-bot', () => ({ id: 'BOT_SELF_ID' }))
+    router.registerHistory('discord-bot', async () => ({
+      ok: true,
+      messages: [
+        historyMessage({
+          externalMessageId: 'own-hist',
+          text: 'our earlier reply',
+          authorId: 'BOT_SELF_ID',
+          authorName: 'Dobby',
+          isBot: true,
+        }),
+      ],
+    }))
+
+    await router.route(
+      inbound({
+        thread: 't-A',
+        externalMessageId: 'human-followup',
+        text: 'thanks, one more thing',
+        authorId: 'human-asker',
+        authorName: 'human-asker',
+        isBotMention: false,
+        replyToBotMessageId: null,
+        replyToOtherMessageId: 't-A',
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A' })
+
+    // then: engaged (a prompt is produced) — our prior participation is honored
+    expect(sessions[0]!.prompts).toHaveLength(1)
+  })
+
   test('prefetches channel scrollback (tail-only) when session is not in a thread', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2389,8 +2389,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const hasBotParticipated = (live: LiveSession): boolean => {
     if (live.successfulChannelSends > 0) return true
+    // Only OUR own prefetched history counts as participation — matching any
+    // bot here let a PEER bot's buffered message flip botInThread=true,
+    // neutralizing the replyToOtherMessageId suppressor and engaging us in a
+    // thread aimed at another bot. Self id is unavailable during the startup
+    // identity race; then this falls back to successfulChannelSends, which is
+    // safe (conservative: we just don't claim participation we can't prove).
+    const selfId = resolveSelfIdentity(live.key)?.id
+    if (selfId === undefined) return false
     for (const item of live.contextBuffer) {
-      if (item.authorIsBot) return true
+      if (item.authorId === selfId) return true
     }
     return false
   }


### PR DESCRIPTION
## Background

In production, an agent woke on a brand-new Slack thread and replied to a **peer bot's** message — as its *first* message in a thread it had never joined — even though the thread was directed at that other bot (no mention, alias, DM, or reply-to-us). The peer bot had to ask it twice to stop.

Root cause is `hasBotParticipated`, which computes the `botInThread` signal. It treated **any** bot-authored message in `contextBuffer` as "we participated here":

```ts
for (const item of live.contextBuffer) {
  if (item.authorIsBot) return true
}
```

On a cold start, the thread's prefetched history seeded `contextBuffer` with a peer bot's message. That flipped `botInThread=true`, which neutralizes the `replyToOtherMessageId` suppressor in `engagement.ts` (`targetsSomeoneElse`). With the suppressor disabled, a reply whose Slack `parent_user_id` is the (human) thread root no longer reads as "aimed at someone else", and engagement proceeded on a conversation the agent was never part of.

`botInThread` is meant to signal **our own** participation. Its reason for existing (PR #58) is the inverse case: a human opens a thread by @-mentioning us, and because Slack's `parent_user_id` always points at the human thread root, the suppressor would otherwise silently drop every one of our follow-ups. That intent requires matching *our* messages — not any bot's.

## Summary

Scope the `contextBuffer` scan to messages authored by our own resolved self identity (`resolveSelfIdentity(live.key).id`) instead of any `authorIsBot`. `successfulChannelSends > 0` still short-circuits as before.

Why self-id and not "drop the buffer scan entirely": the scan exists to recover **our own prefetched history** on a cold start (a restart mid-thread where the runtime send counter is 0 but Slack history shows our prior replies). Matching self-id preserves that case while excluding peer bots and the `__typeclaw_system__` elision placeholder.

During the startup identity race `resolveSelfIdentity` can be undefined; we then fall back to `successfulChannelSends` only, which is conservative (we never claim participation we can't prove) and safe.

## What this does NOT do

- Does **not** change peer-bot sticky engagement. Credited peer bots still engage in both solo- and multi-human channels, with the peer-bot loop guard as the backstop. This deliberately respects the "do not firewall peer bots behind mention-only" design in `engagement.ts:189-199`.
- Does **not** alter the explicit triggers (mention/reply/dm), the sticky ledger, or the suppressor logic itself — only what `botInThread` is computed from.

## Review notes

- Load-bearing change: `hasBotParticipated` in `src/channels/router.ts`. Invariant to verify — `botInThread` is true **iff** we have actually sent in this thread (live counter) or our own message appears in prefetched history.
- Two regression tests in `router.test.ts` (cold-start prefetch block): a peer-bot history entry must NOT engage a human-rooted reply-to-other (observes); our own history entry MUST still engage it (PR #58 preserved).
