### PR TITLE
feat(channels): strip leaked <think> blocks from outbound sends

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -36,6 +36,7 @@ import {
   SESSION_IDLE_MS,
   sliceHeadTail,
   StaleLiveSessionError,
+  stripThinkBlocks,
   TURN_CAP_ERROR,
   type ChannelRouter,
   type ClaimHandler,
@@ -1480,6 +1481,80 @@ describe('ChannelRouter outbound', () => {
     })
     expect(result.ok).toBe(false)
     expect(result.ok === false ? result.error : '').toContain('denied')
+  })
+
+  test('strips a leaked think block before forwarding to the adapter', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let captured = ''
+    router.registerOutbound('discord-bot', async (msg) => {
+      captured = msg.text ?? ''
+      return { ok: true }
+    })
+    const result = await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      text: '<think>let me figure out the tone here</think>Done — shipped it.',
+    })
+    expect(result.ok).toBe(true)
+    expect(captured).toBe('Done — shipped it.')
+  })
+
+  test('does not forward the reasoning when the whole body was a think block', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    let capturedText: string | undefined = 'UNSET'
+    router.registerOutbound('discord-bot', async (msg) => {
+      capturedText = msg.text
+      return { ok: true }
+    })
+    const result = await router.send({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      text: '<think>they are just laughing, no reply needed</think>',
+    })
+    expect(result.ok).toBe(true)
+    expect(capturedText === undefined || capturedText === '').toBe(true)
+  })
+})
+
+describe('stripThinkBlocks', () => {
+  test('removes a closed block and trims surrounding whitespace', () => {
+    expect(stripThinkBlocks('<think>plan the reply</think>\n\nHello there')).toBe('Hello there')
+  })
+
+  test('removes a block wrapped by real prose on both sides', () => {
+    expect(stripThinkBlocks('Sure.<think>internal</think> On it.')).toBe('Sure. On it.')
+  })
+
+  test('matches case-insensitively and tolerates attributes', () => {
+    expect(stripThinkBlocks('<Think foo="bar">x</THINK>kept')).toBe('kept')
+  })
+
+  test('drops an unclosed trailing think block (budget exhaustion)', () => {
+    expect(stripThinkBlocks('Visible answer.\n<think>ran out of room mid-thought')).toBe('Visible answer.')
+  })
+
+  test('removes multiple blocks in one message', () => {
+    expect(stripThinkBlocks('<think>a</think>one <think>b</think>two')).toBe('one two')
+  })
+
+  test('collapses blank-line runs left by excision', () => {
+    expect(stripThinkBlocks('line1\n\n<think>x</think>\n\nline2')).toBe('line1\n\nline2')
+  })
+
+  test('returns empty string when the whole body was a think block', () => {
+    expect(stripThinkBlocks('<think>nothing to say</think>')).toBe('')
+  })
+
+  test('leaves text without think tags unchanged (aside from trim)', () => {
+    expect(stripThinkBlocks('just a normal message')).toBe('just a normal message')
+  })
+
+  test('does not match a bare word "think" in prose', () => {
+    expect(stripThinkBlocks('I think this is fine')).toBe('I think this is fine')
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2923,7 +2923,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return { ok: false, error: `no adapter registered for "${msg.adapter}"`, code: 'no-adapter' }
     }
 
-    const authoredText = normalizeSendText(msg.text)
+    // Strip leaked `<think>` reasoning off the message itself, up front, so the
+    // stripped text flows through EVERY downstream consumer: the flood check,
+    // the duplicate guard, the quote-anchor prepend, and the adapter callback.
+    // A body that was nothing but a think block collapses to undefined and is
+    // delivered as a text-less send (attachments, if any, still go through).
+    if (msg.text !== undefined) {
+      msg = { ...msg, text: normalizeSendText(msg.text) }
+    }
+
+    const authoredText = msg.text
     if (authoredText !== undefined) {
       const flood = checkOutboundFlood(authoredText)
       if (!flood.ok) return { ok: false, error: OUTBOUND_FLOOD_ERROR, code: 'outbound-flood' }
@@ -4410,10 +4419,32 @@ export function resolveLiveSessionForCommand(
   return { kind: 'none' }
 }
 
+// Strips leaked `<think>…</think>` reasoning from outbound message text. Some
+// models (DeepSeek-R1 / Qwen-QwQ family) emit chain-of-thought inline as a
+// literal `<think>` span in `delta.content` rather than a dedicated `thinking`
+// content block, so it lands verbatim in the assistant body and — without this
+// — gets posted to the channel (production: a reasoning paragraph leaked into a
+// Slack thread). The whole block is removed, not just the tags.
+//
+// THINK_BLOCK_RE matches closed blocks (case-insensitive, attribute-tolerant,
+// multi-line). DANGLING_THINK_RE catches an UNCLOSED trailing `<think>` (model
+// ran out of budget mid-reasoning) by dropping open-tag-to-end. The final pass
+// collapses excision-left blank-line runs and trims.
+const THINK_BLOCK_RE = /<think\b[^>]*>[\s\S]*?<\/think\s*>/gi
+const DANGLING_THINK_RE = /<think\b[^>]*>[\s\S]*$/i
+
+export function stripThinkBlocks(text: string): string {
+  const withoutBlocks = text.replace(THINK_BLOCK_RE, '').replace(DANGLING_THINK_RE, '')
+  return withoutBlocks.replace(/\n{3,}/g, '\n\n').trim()
+}
+
 function normalizeSendText(text: string | undefined): string | undefined {
   if (text === undefined) return undefined
-  if (text === '') return undefined
-  return text
+  // Strip before the empty-collapse so a turn that was ONLY a think block
+  // resolves to `undefined` (suppressed) instead of posting an empty shell.
+  const stripped = stripThinkBlocks(text)
+  if (stripped === '') return undefined
+  return stripped
 }
 
 function recordSendTimestamp(live: LiveSession, sendKey: string, ts: number): number {


### PR DESCRIPTION
## Background

Some models in the DeepSeek-R1 / Qwen-QwQ family emit chain-of-thought reasoning inline as a literal `<think>` span in `delta.content` instead of a dedicated `thinking` content block. Because that text lands verbatim in the assistant message body, it was being forwarded straight to the channel — leaking raw reasoning into public threads.

## Summary

Adds a `stripThinkBlocks()` helper applied at the **top** of `ChannelRouter.send`, before any other consumer sees `msg.text`. Stripping at the entry point means the cleaned text flows uniformly through every downstream step: outbound flood check, per-turn duplicate guard, quote-anchor prepend, and the adapter callback — none of those consumers need to know about the problem.

A body that reduces to nothing after stripping is delivered as `undefined` (text-less). Attachments still go through; the turn produces a silent delivery rather than an empty shell.

**Stripping rules:**

- Closed `<think>…</think>` blocks: case-insensitive, attribute-tolerant (e.g. `<think type="…">`), multi-line, multiple per message.
- An unclosed trailing `<think>` from a budget-exhausted turn (model cut off mid-reasoning) is dropped from the open tag to end-of-text.
- Blank-line runs left by excision are collapsed and the result is trimmed.
- A bare word "think" in prose is untouched — only angle-bracket tags match.

**Why not strip at the model output layer?** The router is the right seam because it owns the outbound text contract. Stripping upstream (in the streaming layer) would discard token cost data and conflict with the TUI, which correctly renders thinking blocks in a dedicated UI surface. The channel is the only consumer that should never see them.

## What this does NOT do

- Does not affect the TUI or server-side streaming paths — only `ChannelRouter.send`.
- Does not strip `thinking` content blocks (the first-class Anthropic format) — those are already handled by existing content-block filtering.
- Does not modify how text is stored in session history — history is written before `send` is called.

## Review notes

- Load-bearing change: `stripThinkBlocks` in `src/channels/router.ts` and its call at the top of `send()`. Invariant to verify: the adapter callback receives the stripped text, not the original.
- Two new test surfaces in `src/channels/router.test.ts`:
  - A `describe('stripThinkBlocks')` unit block covering closed blocks, multiple blocks, attribute-tolerant matching, dangling open tags, blank-line collapse, and the prose-word non-match.
  - End-to-end `ChannelRouter` outbound tests asserting the adapter callback receives stripped text and that a pure-think body is not forwarded at all.