### PR TITLE
fix(subagents): recover timed-out researcher reports and stop spawn starvation

### DIFF
--- a/src/agent/subagent-completion-reminder.test.ts
+++ b/src/agent/subagent-completion-reminder.test.ts
@@ -47,6 +47,30 @@ describe('renderSubagentCompletionReminder', () => {
     expect(text).toContain('unknown error')
   })
 
+  test('ok=false with hasRecoverableOutput steers the parent to recover, not redo, the work', () => {
+    const recoverable = renderSubagentCompletionReminder({
+      subagent: 'researcher',
+      taskId: 'bg_to',
+      ok: false,
+      durationMs: 600_000,
+      error: 'spawn timed out after 1800000ms',
+      hasRecoverableOutput: true,
+    })
+    expect(recoverable).toContain('produced output before failing')
+    expect(recoverable).toContain('subagent_output')
+
+    // when the flag is absent, the wording stays the plain "inspect" guidance
+    const plain = renderSubagentCompletionReminder({
+      subagent: 'researcher',
+      taskId: 'bg_to',
+      ok: false,
+      durationMs: 600_000,
+      error: 'spawn timed out after 1800000ms',
+    })
+    expect(plain).not.toContain('produced output before failing')
+    expect(plain).toContain('subagent_output to inspect')
+  })
+
   test('channel=true appends the channel_reply nudge so a channel-session reminder steers the model to surface via tool, not plain text', () => {
     const text = renderSubagentCompletionReminder({
       subagent: 'explorer',

--- a/src/agent/subagent-completion-reminder.ts
+++ b/src/agent/subagent-completion-reminder.ts
@@ -15,6 +15,7 @@ export type CompletionReminderArgs = {
   ok: boolean
   durationMs: number
   error?: string
+  hasRecoverableOutput?: boolean
   channel?: boolean
   adapter?: string
 }
@@ -55,10 +56,14 @@ export function renderSubagentCompletionReminder(args: CompletionReminderArgs): 
     )
   }
   const err = args.error ?? 'unknown error'
+  const recoveryHint =
+    args.hasRecoverableOutput === true
+      ? `It produced output before failing — call subagent_output to recover it instead of redoing the work. `
+      : `Use subagent_output to inspect. `
   return (
     `<system-reminder>\n` +
     `Subagent \`${args.subagent}\` (${args.taskId}) FAILED after ${durationStr}: ${err}. ` +
-    `Use subagent_output to inspect. If this work was tracked in your todo list, ` +
+    `${recoveryHint}If this work was tracked in your todo list, ` +
     `keep the item pending (or add a recovery item) via todo_write so it is not ` +
     `dropped.${channelTail}\n` +
     `</system-reminder>`
@@ -88,6 +93,12 @@ export type SubagentCompletedPayload = {
   ok: boolean
   durationMs: number
   error?: string
+  // A failed subagent can still carry a recoverable result (e.g. a researcher
+  // that produced its `<report>` then timed out). The boolean — not the content
+  // — rides the broadcast so the reminder can tell the parent to fetch it via
+  // subagent_output; the body stays in the registry retrieval path, off the
+  // broadcast bus, to keep large/sensitive output out of every subscriber.
+  hasRecoverableOutput?: boolean
   // Present when the parent was a channel session. Lets the router fall back
   // to the live successor session for the same channel key when the parent
   // rolled over (SESSION_FRESHNESS_TTL_MS) or was idle-evicted while the
@@ -109,6 +120,7 @@ export function parseSubagentCompletedPayload(payload: unknown): SubagentComplet
     ok?: unknown
     durationMs?: unknown
     error?: unknown
+    hasRecoverableOutput?: unknown
     channelKey?: unknown
   }
   if (p.kind !== 'subagent.completed') return null
@@ -121,6 +133,7 @@ export function parseSubagentCompletedPayload(payload: unknown): SubagentComplet
     ok: p.ok === true,
     durationMs: typeof p.durationMs === 'number' ? p.durationMs : 0,
     ...(typeof p.error === 'string' ? { error: p.error } : {}),
+    ...(p.hasRecoverableOutput === true ? { hasRecoverableOutput: true } : {}),
     ...(channelKey !== null ? { channelKey } : {}),
   }
 }

--- a/src/agent/subagent-drain.ts
+++ b/src/agent/subagent-drain.ts
@@ -71,12 +71,14 @@ function collectPendingReminders(drain: SubagentBackgroundDrain, delivered: Set<
     if (child.status === 'running') continue
     if (delivered.has(child.taskId)) continue
     const completion = child.completion
+    const hasRecoverableOutput = child.status !== 'completed' && completion?.finalMessage !== undefined
     const text = renderSubagentCompletionReminder({
       subagent: child.subagentName,
       taskId: child.taskId,
       ok: child.status === 'completed',
       durationMs: completion?.durationMs ?? 0,
       ...(completion?.error !== undefined ? { error: completion.error } : {}),
+      ...(hasRecoverableOutput ? { hasRecoverableOutput: true } : {}),
     })
     pending.push({ taskId: child.taskId, text })
   }

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -947,6 +947,71 @@ describe('startSubagent', () => {
     expect(abortCount).toBe(1)
   })
 
+  test('a timeout preserves an already-captured final message so a near-miss result is not discarded', async () => {
+    // given: a session that emits a final report, then wedges before settling — the
+    // production shape of a researcher that produced its <report> then hit the ceiling
+    let listener: ((event: unknown) => void) | null = null
+    const session = {
+      prompt: () =>
+        new Promise<void>(() => {
+          listener?.({ type: 'message_end', message: { role: 'assistant', content: 'The finished report body.' } })
+        }),
+      dispose: () => {},
+      subscribe: (l: (event: unknown) => void) => {
+        listener = l
+        return () => {
+          listener = null
+        }
+      },
+      abort: async () => {},
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X', timeoutMs: 20 } satisfies Subagent }
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_recover',
+    })
+    const result = await completion
+
+    // then: still a failure (the contract was not honored), but the report rides along
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('timed out')
+      expect(result.finalMessage).toBe('The finished report body.')
+    }
+  })
+
+  test('a timeout with no captured message yields ok=false and no finalMessage', async () => {
+    // given: a wedge that never emits any assistant message before the ceiling
+    const session = {
+      prompt: () => new Promise<void>(() => {}),
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X', timeoutMs: 20 } satisfies Subagent }
+
+    // when
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_no_recover',
+    })
+    const result = await completion
+
+    // then
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.finalMessage).toBeUndefined()
+    }
+  })
+
   test('without timeoutMs a slow prompt keeps completion pending (legacy unbounded behavior preserved)', async () => {
     // given: a session whose prompt has not resolved yet, and no timeout declared
     let resolvePrompt: () => void = () => {}

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -360,7 +360,7 @@ export type SubagentHandle = {
 
 export type StartSubagentResult = {
   handle: Promise<SubagentHandle>
-  completion: Promise<{ ok: true; finalMessage?: string } | { ok: false; error: string }>
+  completion: Promise<{ ok: true; finalMessage?: string } | { ok: false; error: string; finalMessage?: string }>
 }
 
 export type StartSubagentOptions = InvokeSubagentOptions & {
@@ -427,7 +427,8 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
     })
 
   const timeoutMs = options.registry[name]?.timeoutMs
-  const completion = timeoutMs === undefined ? work : raceSubagentCompletion(work, name, options.taskId, timeoutMs)
+  const completion =
+    timeoutMs === undefined ? work : raceSubagentCompletion(work, name, options.taskId, timeoutMs, () => finalMessage)
 
   void completion.then(() => {
     if (timeoutMs !== undefined) void abortSession?.()
@@ -436,20 +437,33 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
   return { handle, completion }
 }
 
-type SubagentCompletion = { ok: true; finalMessage?: string } | { ok: false; error: string }
+type SubagentCompletion = { ok: true; finalMessage?: string } | { ok: false; error: string; finalMessage?: string }
 
+// `getFinalMessage` is read INSIDE the timeout callback, not at race-construction
+// time, so the timed-out result carries whatever the subagent had captured by the
+// moment the timer fired (e.g. a researcher's `<report>` block emitted just before
+// the kill). JS is single-threaded, so this read is torn-free; it preserves only
+// what an assistant `message_end` already committed — a result still mid-stream
+// when the timer fires cannot be recovered. The outcome stays `ok: false`: a
+// timeout is a lifecycle failure, and `finalMessage` here is recovery data for
+// the parent to inspect/re-persist, not proof the subagent honored its contract.
 function raceSubagentCompletion(
   work: Promise<SubagentCompletion>,
   name: string,
   taskId: string,
   timeoutMs: number,
+  getFinalMessage: () => string | undefined,
 ): Promise<SubagentCompletion> {
   let timer: ReturnType<typeof setTimeout> | null = null
   const timeout = new Promise<SubagentCompletion>((resolve) => {
-    timer = setTimeout(
-      () => resolve({ ok: false, error: new SubagentTimeoutError(name, taskId, timeoutMs).message }),
-      timeoutMs,
-    )
+    timer = setTimeout(() => {
+      const finalMessage = getFinalMessage()
+      resolve({
+        ok: false,
+        error: new SubagentTimeoutError(name, taskId, timeoutMs).message,
+        ...(finalMessage !== undefined ? { finalMessage } : {}),
+      })
+    }, timeoutMs)
   })
   return Promise.race([work, timeout]).finally(() => {
     if (timer !== null) clearTimeout(timer)

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -29,7 +29,7 @@ export type SpawnSubagentToolDetails =
       taskId: string
       sessionId: string | undefined
     }
-  | { ok: false; error: string }
+  | { ok: false; error: string; finalMessage?: string }
 
 export type CreateSpawnSubagentToolOptions = {
   registry: SubagentRegistry
@@ -167,6 +167,7 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
         const durationMs = now() - startedAt
         liveRegistry.recordCompletion(taskId, completionToFinalShape(c, durationMs))
         if (stream && background) {
+          const hasRecoverableOutput = !c.ok && c.finalMessage !== undefined
           stream.publish({
             target: { kind: 'broadcast' },
             payload: {
@@ -177,6 +178,7 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
               ok: c.ok,
               durationMs,
               ...(c.ok ? {} : { error: c.error }),
+              ...(hasRecoverableOutput ? { hasRecoverableOutput: true } : {}),
               ...(channelKey !== undefined ? { channelKey } : {}),
             },
           })
@@ -205,9 +207,22 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
       const result = await completion
       const durationMs = now() - startedAt
       if (!result.ok) {
-        const details: SpawnSubagentToolDetails = { ok: false, error: result.error }
+        const details: SpawnSubagentToolDetails = {
+          ok: false,
+          error: result.error,
+          ...(result.finalMessage !== undefined ? { finalMessage: result.finalMessage } : {}),
+        }
+        const recovered =
+          result.finalMessage !== undefined
+            ? ` It produced output before failing; recover it below instead of redoing the work:\n\n${result.finalMessage}`
+            : ''
         return {
-          content: [{ type: 'text' as const, text: `${subagentName} failed after ${durationMs}ms: ${result.error}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `${subagentName} failed after ${durationMs}ms: ${result.error}.${recovered}`,
+            },
+          ],
           details,
         }
       }
@@ -312,13 +327,18 @@ function hasPermissionForSubagent(
 }
 
 function completionToFinalShape(
-  c: { ok: true; finalMessage?: string } | { ok: false; error: string },
+  c: { ok: true; finalMessage?: string } | { ok: false; error: string; finalMessage?: string },
   durationMs: number,
 ): SubagentCompletion {
   if (c.ok) {
     return { ok: true, durationMs, ...(c.finalMessage !== undefined ? { finalMessage: c.finalMessage } : {}) }
   }
-  return { ok: false, error: c.error, durationMs }
+  return {
+    ok: false,
+    error: c.error,
+    durationMs,
+    ...(c.finalMessage !== undefined ? { finalMessage: c.finalMessage } : {}),
+  }
 }
 
 type ToolReturn = {

--- a/src/agent/tools/subagent-output.ts
+++ b/src/agent/tools/subagent-output.ts
@@ -37,6 +37,7 @@ export type SubagentOutputToolDetails =
       subagent: string
       durationMs: number
       error: string
+      finalMessage?: string
     }
   | { ok: false; error: string }
 
@@ -137,6 +138,7 @@ function renderSnapshot(snap: StatusSnapshot): ToolReturn {
     }
   }
   const error = snap.completion?.error ?? 'unknown error'
+  const finalMessage = snap.completion?.finalMessage
   const details: SubagentOutputToolDetails = {
     ok: true,
     status: 'failed',
@@ -144,9 +146,19 @@ function renderSnapshot(snap: StatusSnapshot): ToolReturn {
     subagent: snap.subagentName,
     durationMs: snap.completion?.durationMs ?? snap.elapsedMs,
     error,
+    ...(finalMessage !== undefined ? { finalMessage } : {}),
   }
+  const recovered =
+    finalMessage !== undefined
+      ? ` It produced output before failing; recover it below instead of redoing the work:\n\n${finalMessage}`
+      : ''
   return {
-    content: [{ type: 'text' as const, text: `${snap.subagentName} failed after ${details.durationMs}ms: ${error}` }],
+    content: [
+      {
+        type: 'text' as const,
+        text: `${snap.subagentName} failed after ${details.durationMs}ms: ${error}.${recovered}`,
+      },
+    ],
     details,
   }
 }

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -280,6 +280,10 @@ describe('memoryLoggerSubagent', () => {
     expect(msg).toContain('Do not invent or reuse a watermark id')
   })
 
+  test("runs on the 'fast' profile so it does not share the slow default model a researcher saturates", () => {
+    expect(memoryLoggerSubagent.profile).toBe('fast')
+  })
+
   test('declares an inFlightKey that keys on agentDir (so two concurrent sessions for the same agent serialize)', () => {
     expect(memoryLoggerSubagent.inFlightKey).toBeDefined()
     const key = memoryLoggerSubagent.inFlightKey!({

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -307,6 +307,13 @@ export function createMemoryLoggerSubagent(
   const logger = options.logger ?? consoleLogger
   return {
     systemPrompt: MEMORY_LOGGER_SYSTEM_PROMPT,
+    // Logging is "read transcript past the watermark, decide 0-N fragments,
+    // append" — mechanical extraction, no deep reasoning. Without this it fell
+    // back to `default`, sharing the slow reasoning model that a concurrent
+    // `researcher` pass saturates, which made the 50s spawn timeout fire under
+    // load. `fast` matches `memory-retrieval` (same I/O-bound shape) and itself
+    // falls back to `default` with a one-time warning when unconfigured.
+    profile: 'fast',
     tools: [readTool],
     customTools: [findEntryTool, appendTool, advanceWatermarkTool],
     payloadSchema: memoryLoggerPayloadSchema,

--- a/src/bundled-plugins/researcher/researcher.ts
+++ b/src/bundled-plugins/researcher/researcher.ts
@@ -25,17 +25,20 @@ import { createWriteReportTool } from './write-report'
 // `./skills/`; no runtime change required.
 export const RESEARCHER_SKILLS: readonly LoadableSkill[] = [GENERAL_RESEARCH_SKILL]
 
-// Mirrors the reviewer ceiling. A researcher whose `session.prompt` stalls
-// mid-turn would otherwise leave `completion` pending forever — the
-// `subagent.completed` broadcast never fires and the parent is never woken to
-// read the report. The ceiling makes `awaitWithSubagentTimeout` settle with
-// SubagentTimeoutError, surfacing a FAILED completion reminder so the request
-// fails loudly instead of vanishing. Sized for a thorough `deep`-model pass
-// (multi-source gathering, a few delegated workers, writing a report file),
-// well above a typical sub-minute lookup. This is liveness for the parent, not
-// hard cancellation: pi's `session.prompt` takes no AbortSignal, so the LLM
-// stream may run until the OS reaps it. See src/agent/subagents.ts `timeoutMs`.
-export const RESEARCHER_SPAWN_TIMEOUT_MS = 600_000
+// A researcher whose `session.prompt` stalls mid-turn would otherwise leave
+// `completion` pending forever and never wake the parent. This ceiling makes
+// the spawn settle with SubagentTimeoutError, surfacing a completion reminder
+// so the request resolves loudly instead of vanishing.
+//
+// 30m, not the prior 10m: a real pass spent ~2.5m composing its scout fan-out,
+// ~4–7m on 4 parallel scouts, then was killed ~2s into the final `write_report`
+// — discarding a finished report. The `deep` profile trades speed for quality,
+// so nested scout warmup + multi-source gathering + synthesis routinely exceed
+// 10m. This is liveness, not hard cancellation: `session.prompt` takes no
+// AbortSignal, so the stream may run until the OS reaps it. A report produced
+// before the ceiling is no longer lost — see startSubagent's finalMessage
+// preservation in src/agent/subagents.ts.
+export const RESEARCHER_SPAWN_TIMEOUT_MS = 1_800_000
 
 // TODO(#452): Restrict the researcher's `bash` to a curated read-only allowlist
 // once per-subagent bash allowlist support lands. Today the read-only contract

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3713,6 +3713,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       ok: boolean
       durationMs: number
       error?: string
+      hasRecoverableOutput?: boolean
     },
   ): { kind: 'delivered'; keyId: string } => {
     const adapter = live.keyId.split(':', 1)[0] ?? ''
@@ -3722,6 +3723,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       ok: args.ok,
       durationMs: args.durationMs,
       ...(args.error !== undefined ? { error: args.error } : {}),
+      ...(args.hasRecoverableOutput === true ? { hasRecoverableOutput: true } : {}),
       channel: true,
       adapter,
     })
@@ -3754,6 +3756,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     ok: boolean
     durationMs: number
     error?: string
+    hasRecoverableOutput?: boolean
     channelKey?: { adapter: string; workspace: string; chat: string; thread: string | null }
   }): { kind: 'delivered'; keyId: string } | { kind: 'no-live-session' } => {
     for (const live of liveSessions.values()) {


### PR DESCRIPTION
## Background

A user asked the agent to research a topic and produce a PDF. The agent spawned the `researcher` subagent in the background, then 12 minutes later reported `FAILED`:

```
subagent researcher (key=bg_d244ff4bdb38) spawn timed out after 600000ms
```

Reconstructing from the session logs, this was **not** a stuck researcher. The run lasted exactly 10m2s and was productive the entire time:

| Time | Step |
|---|---|
| +0:00 | researcher starts, loads skill, reads house-style example |
| +2:38 | composes and fans out **4 parallel `scout` subagents** |
| +4:08–7:30 | all 4 scouts return citation-backed findings |
| +10:00 | researcher has all data, emits *"Now synthesizing the report"*, calls `write_report` — **killed ~2s in** |

The report was **finished** — the `write_report` call carried a complete, cross-validated body — but the 10-minute liveness ceiling (`RESEARCHER_SPAWN_TIMEOUT_MS = 600_000`) fired during the final write. The parent received a bare `FAILED`, **discarded the completed work**, and redid the entire research from scratch.

Two root causes, plus a contributing degradation found while investigating:

1. **The ceiling was empirically too tight.** The `deep` profile is chosen for quality (slow models); nested-scout warmup + multi-source gathering + synthesis routinely exceeds 10m.
2. **A timeout meant total loss.** The researcher's final message was captured into a `startSubagent` closure, but `raceSubagentCompletion` resolved `{ ok: false, error }` and never read it — so a near-miss threw away recoverable output.
3. **memory-logger was starving under the same load.** Container logs showed `memory-logger spawn timed out after 50000ms` firing repeatedly. It declares no `profile`, so it fell back to `default` — the same slow model the researcher saturates.

## Summary

Three coupled commits:

- **`fix(researcher)`** — raise the spawn timeout 10m → 30m. Headroom for the real pipeline; still bounds a genuinely wedged stream.
- **`fix(subagents)`** — preserve an already-produced final message when a spawn times out. The timeout callback now reads the closure at timer-fire and resolves `{ ok: false, error, finalMessage }`, threaded through `completionToFinalShape`, the sync spawn return, `subagent_output`, and the completion reminder so the parent recovers the output instead of redoing the work.
- **`fix(memory)`** — give `memory-logger` `profile: 'fast'`, matching `memory-retrieval`'s identical I/O-bound shape, so it stops competing with the researcher for the slow `default` model.

**Why `ok: false` and not `ok: true`** for a timed-out-but-produced result: the timeout *is* a lifecycle failure — `write_report` never persisted, the contract was not honored. `finalMessage` is recovery data for the parent to inspect/re-persist, not proof of success. Flipping to `ok: true` would mask real timeouts.

**Why only a boolean on the broadcast:** the `subagent.completed` broadcast carries a `hasRecoverableOutput` flag, not the body. The report text stays in the registry retrieval path (`subagent_output`) to keep large/possibly-sensitive content off every broadcast subscriber.

**Why these are three commits, not one:** each is independently revertable and addresses a distinct mechanism (a constant, the completion contract, a subagent profile).

## What this does NOT do

- **No hard cancellation.** `session.prompt` still takes no `AbortSignal`, so a timed-out stream may run until the OS reaps it. This PR makes the timeout *recoverable*, not *interruptible*.
- **Does not capture `write_report` tool input.** Recovery preserves the last assistant `message_end`; a result still mid-stream when the timer fires is unrecoverable. The 30m bump is what prevents the original incident; recovery is the safety net for the next near-miss.
- **No new config surface.** The timeout stays a constant (sibling to `reviewer`/`planner`); a configurable `subagents.*.timeoutMs` is left for later.

## Review notes

- **Load-bearing change:** `raceSubagentCompletion` in `src/agent/subagents.ts` now takes a `() => finalMessage` getter read *inside* the timeout callback (latest-value, torn-free on JS's single thread). Reading at race-construction time would capture `undefined`.
- **Invariant to verify:** timed-out completions stay `ok: false` everywhere; `finalMessage` is additive. New tests in `subagents.test.ts` pin both the recovery and the no-capture-no-finalMessage cases.
- The `hasRecoverableOutput` flag threads through both delivery paths (`router.ts` channel sessions, `server/index.ts` TUI, `subagent-drain.ts` nested subagents) — dropping it on any path would silently lose the recovery hint.
- Full suite green (7969 pass), typecheck + lint (0 errors) + format clean.