### PR TITLE
docs(landing): link channels in the 'Talks to' row to their reference pages

### DIFF
--- a/docs/src/app/_components/channel-icons.tsx
+++ b/docs/src/app/_components/channel-icons.tsx
@@ -48,13 +48,14 @@ export interface ChannelDef {
   name: string
   Icon: ComponentType<IconProps>
   branded: boolean
+  href?: string
 }
 
 export const CHANNELS: ChannelDef[] = [
-  { name: 'Slack', Icon: SlackBrand, branded: true },
-  { name: 'Discord', Icon: Discord, branded: true },
-  { name: 'Telegram', Icon: Telegram, branded: true },
-  { name: 'KakaoTalk', Icon: KakaoTalk, branded: true },
-  { name: 'GitHub', Icon: GithubBrand, branded: true },
+  { name: 'Slack', Icon: SlackBrand, branded: true, href: '/docs/reference/slack-bot' },
+  { name: 'Discord', Icon: Discord, branded: true, href: '/docs/reference/discord-bot' },
+  { name: 'Telegram', Icon: Telegram, branded: true, href: '/docs/reference/telegram-bot' },
+  { name: 'KakaoTalk', Icon: KakaoTalk, branded: true, href: '/docs/reference/kakaotalk' },
+  { name: 'GitHub', Icon: GithubBrand, branded: true, href: '/docs/reference/github' },
   { name: 'TUI', Icon: TerminalBrand, branded: false },
 ]

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -78,15 +78,25 @@ function ChannelTrust() {
         Talks to — and a websocket TUI
       </p>
       <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-4">
-        {CHANNELS.map(({ name, Icon }) => (
-          <div
-            key={name}
-            className="flex items-center gap-2 text-zinc-500 grayscale transition-all hover:text-zinc-800 hover:grayscale-0 dark:text-zinc-500 dark:hover:text-zinc-200"
-          >
-            <Icon className="size-5" />
-            <span className="text-sm font-medium">{name}</span>
-          </div>
-        ))}
+        {CHANNELS.map(({ name, Icon, href }) => {
+          const className =
+            'flex items-center gap-2 text-zinc-500 grayscale transition-all hover:text-zinc-800 hover:grayscale-0 dark:text-zinc-500 dark:hover:text-zinc-200'
+          const content = (
+            <>
+              <Icon className="size-5" />
+              <span className="text-sm font-medium">{name}</span>
+            </>
+          )
+          return href ? (
+            <Link key={name} href={href} className={className}>
+              {content}
+            </Link>
+          ) : (
+            <div key={name} className={className}>
+              {content}
+            </div>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Background

The landing page's "Talks to — and a websocket TUI" row lists the channels typeclaw connects to (Slack, Discord, Telegram, KakaoTalk, GitHub, TUI). Each name was rendered as plain, unclickable text. The per-channel reference pages already exist and are cross-linked from the channel-adapters reference table and the docs index "Many inboxes" bullet — but the landing page's channel list didn't link to them, leaving the most visible entry point disconnected from the docs for each adapter.

## Summary

`ChannelDef` in `channel-icons.tsx` gains an optional `href` field. Each channel that has a dedicated reference page gets its target set; TUI is left without one (no dedicated reference page exists). In `page.tsx`, the `ChannelTrust` component now renders linked channels as `<Link>` (reusing the existing `next/link` import) and the unlinked TUI as a plain `<div>`. Styling and hover behavior are unchanged.

Link targets:

| Channel | Target |
|---|---|
| Slack | `/docs/reference/slack-bot` |
| Discord | `/docs/reference/discord-bot` |
| Telegram | `/docs/reference/telegram-bot` |
| KakaoTalk | `/docs/reference/kakaotalk` |
| GitHub | `/docs/reference/github` |
| TUI | *(no link — no dedicated reference page)* |

The targets are consistent with the channel-adapters reference table and the docs index.

## Preview

Before: channel names in the "Talks to" row are plain text.
After: Slack, Discord, Telegram, KakaoTalk, and GitHub are clickable links to their reference pages.

## What this does NOT do

- Does not add a reference page for TUI — that is a separate concern.
- Does not change any styling, layout, or hover state.
- Does not affect any other component that renders `ChannelDef` entries.

## Review notes

- `ChannelDef.href` is optional, so any callsite that doesn't set it continues to render a plain `<div>` — no regressions for existing uses.
- The `<Link>` vs `<div>` branch in `ChannelTrust` is the only behavioral change; the rest of the JSX tree is untouched.
- `oxlint` passes (exit 0) on the docs package; 3 pre-existing unused-import warnings in `page.tsx` (PenTool, User, Users) are unrelated to this change.
- `oxfmt --write .` produced no drift in the changed files.