### PR TITLE
fix(channels): stop weak models reading multi-turn history as a single turn

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -969,6 +969,23 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(prompt).toContain('<@alice> (alice): hey bot')
   })
 
+  test('engaged turn carries the history-interpretation note above the current-message header', async () => {
+    // Regression: the persisted `## Current message (addressed to you)` header
+    // is turn-local, but a chain of such turns made weak models believe only
+    // the latest turn existed (they denied seeing earlier user messages that
+    // were in their own transcript). The note re-anchors the header. It must
+    // sit ABOVE the header so the model reads it before the addressed line.
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ text: 'hey bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('if earlier turns appear above, they are real conversation history')
+    expect(prompt.indexOf('if earlier turns appear above')).toBeLessThan(
+      prompt.indexOf('## Current message (addressed to you)'),
+    )
+  })
+
   test('empty allow rules + observed-only burst produces no prompt and no crash', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir, {
@@ -7775,6 +7792,9 @@ describe('ChannelRouter injectSubagentCompletionReminder', () => {
     expect(reminderPrompt).toContain('## Recent context')
     expect(reminderPrompt).toContain('side chatter')
     expect(reminderPrompt).not.toContain('## Current message')
+    // The history-interpretation note is batch-gated like the header: a
+    // reminder-only drain has an empty promptQueue, so it must stay absent.
+    expect(reminderPrompt).not.toContain('if earlier turns appear above')
   })
 
   test('referenceContext renders quote lines above the current author line and truncates at render time', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4093,6 +4093,22 @@ function composeTurnPrompt(
   // the `## Recent context (not addressed to you …)` header — mislabeling the
   // one line the model is supposed to answer as context it should ignore.
   if (batch.length > 0) {
+    // The `## Current message` header is a WITHIN-turn label, but it also gets
+    // persisted into the transcript — so after many turns the model sees a
+    // chain of turns each headed "addressed to you" and a weak model collapses
+    // that into "only the latest turn exists", denying it can see what the user
+    // said earlier (those turns are in its own message history). This note
+    // re-anchors the header as turn-local. Conditional "if earlier turns
+    // appear" wording so it is not a false premise on turn 1 (a fresh session
+    // has no history). No leading `>` — that is this repo's quote-anchor syntax
+    // and would read as quoted content. Worded to NOT contain the literal
+    // `## Current message` heading — a pinned test asserts its absence on
+    // reminder-only drains, so it must stay batch-gated and substring-free.
+    parts.push(
+      'Note: if earlier turns appear above, they are real conversation history you can use.',
+      "The heading below marks this turn's new message, not the only message that may exist.",
+      '',
+    )
     parts.push(batch.length === 1 ? '## Current message (addressed to you)' : '## Current messages (addressed to you)')
     for (const b of batch) {
       parts.push(formatInboundPromptLines(b, adapter))


### PR DESCRIPTION
## Symptom

In a 1:1 Slack DM, a user listed repos across several turns and then asked the bot to register a webhook. The bot kept replying (paraphrased) *"I can't see those values — I only see the current turn and the message you just gave me"*, even though the user had clearly provided them earlier in the **same continuous DM session**.

## Root cause (not what it looks like)

This is **not** history loss. Ground-truth session JSONL confirms one continuous session, no rollover, and the prior user turns present in `agent.state.messages` and replayed to the model on every turn. **The model had the data in its context window and still denied seeing it.** So this is a cognition/framing failure, not a retrieval failure.

The cause is **prompt framing in the persisted transcript**:

- `composeTurnPrompt` labels each engaged turn `## Current message (addressed to you)` — a *within-turn* label that disambiguates the addressed message from `## Recent context` in the same turn.
- That header is persisted into the transcript. Over many turns the model sees a chain of turns each headed "addressed to you", interleaved with its own tool-call replies whose results are framed as "your OWN already-delivered message, NOT a new message".
- A weak, low-thinking model (here `gpt-5.4-mini`, thinking=low) collapses this into *"only the latest turn exists"* and denies seeing earlier user messages.

## Channel-agnostic

`composeTurnPrompt` is the **single shared turn builder** for every adapter (slack-bot, discord-bot, telegram, github, kakaotalk) — no adapter has its own. The flaw is channel-agnostic. **DMs amplify it**: a 1:1 chat engages every message, so `contextBuffer` drains empty and no `## Recent context` framing ever appears to hint older text is still usable.

## Fix

Add a short, **batch-gated** note immediately above the `## Current message` header, re-anchoring it as turn-local:

```
Note: if earlier turns appear above, they are real conversation history you can use.
The heading below marks this turn's new message, not the only message that may exist.
```

Constraints honored:
- **Batch-gated** (`batch.length > 0`) — reminder-only wakeups stay clean, preserving the pinned "no empty `## Current message` header" contract.
- **Conditional turn-1 wording** ("if earlier turns appear above") — on the first engaged turn of a fresh session there is no history, so an unconditional "earlier turns are real history" claim would be a false premise that could make a weak model hallucinate prior context. (Self-review finding.)
- **No leading `>`** — `>` is this repo's quote-anchor syntax (`> @user: …`); a `>`-prefixed note could read as quoted conversation content to a weak model. (Self-review finding.)
- **Substring-free** — does not contain the literal `## Current message` string, so the pinned reminder-only-drain test still holds.
- **Cache-neutral** — lives in the non-cacheable user-turn suffix; the system+tools prompt-prefix cache is untouched.
- Does **not** relabel `## Current message` (higher blast radius; many tests pin it) and does **not** touch the `runtime-notice` tool-result echo (not the root cause).

## Tests

- New: engaged turn carries the note **above** the `## Current message` header.
- Extended the pinned reminder-only-drain regression to also assert the note is **absent** on reminder-only wakeups (same batch-gating contract as the header).

## Verification

Reviewed for regressions/side-effects (parser collisions, transcript repetition, empty-batch, cache prefix, adapter outbound) — no blockers; the two flagged wording/`>` risks were fixed before merge. Full gate green: `typecheck`, `lint` (0 errors), `format:check`, `test` (8028 pass / 0 fail).
