### PR TITLE
feat(agent): surface configured channels in the system prompt

### DIFF
--- a/scripts/dump-system-prompt.test.ts
+++ b/scripts/dump-system-prompt.test.ts
@@ -61,6 +61,20 @@ describe('dumpSystemPrompt', () => {
     },
   )
 
+  test.each(fullKinds)('%s origin includes the configured-channels block', (kind) => {
+    const out = dumpSystemPrompt(kind)
+    expect(out).toContain('## Channels')
+    expect(out).toContain('**github**')
+  })
+
+  test('cron origin omits the configured-channels block (slim mode)', () => {
+    expect(dumpSystemPrompt('cron')).not.toContain('## Channels')
+  })
+
+  test('subagent origin omits the configured-channels block (override path)', () => {
+    expect(dumpSystemPrompt('subagent')).not.toContain('## Channels')
+  })
+
   test('cron origin omits the tmux shell-work guidance (slim base prompt)', () => {
     expect(dumpSystemPrompt('cron')).not.toContain('## Long-running and interactive shell work')
   })
@@ -178,6 +192,7 @@ describe('dumpSystemPrompt', () => {
       'Runtime block',
       'Session origin',
       'Role context',
+      'Channels',
       'Git nudge',
       'Memory (MEMORY.md + streams)',
     ])
@@ -236,7 +251,8 @@ describe('dumpSystemPrompt', () => {
     expect(idx('## IDENTITY.md')).toBeLessThan(idx('TypeClaw runtime version:'))
     expect(idx('TypeClaw runtime version:')).toBeLessThan(idx('## Session origin'))
     expect(idx('## Session origin')).toBeLessThan(idx('## Your role in this session'))
-    expect(idx('## Your role in this session')).toBeLessThan(idx('git reports 2 uncommitted files'))
+    expect(idx('## Your role in this session')).toBeLessThan(idx('## Channels'))
+    expect(idx('## Channels')).toBeLessThan(idx('git reports 2 uncommitted files'))
     expect(idx('git reports 2 uncommitted files')).toBeLessThan(idx('## MEMORY.md'))
   })
 

--- a/scripts/dump-system-prompt.ts
+++ b/scripts/dump-system-prompt.ts
@@ -4,6 +4,8 @@ import { parseArgs } from 'node:util'
 
 import { composeSystemPrompt, deriveSystemPromptMode, renderTurnTimeAnchor, type SystemPromptMode } from '@/agent'
 import type { SessionOrigin, SessionRoleContext } from '@/agent/session-origin'
+import { renderChannelsBlock } from '@/agent/system-prompt'
+import { channelsSchema } from '@/channels/schema'
 
 type OriginKind = 'tui' | 'cron' | 'channel' | 'subagent'
 const ALL_KINDS: readonly OriginKind[] = ['tui', 'cron', 'channel', 'subagent'] as const
@@ -41,6 +43,16 @@ const PLACEHOLDER_GIT_NUDGE = [
   '',
   "These are real, current modifications — not advice. Before declaring this session's task done, commit any of these you're responsible for, with `git add <paths>` and `git commit -m \"…\"` per the version-control rules above. If a listed path is from earlier work you didn't touch, leave it alone.",
 ].join('\n')
+
+const PLACEHOLDER_CHANNELS = renderChannelsBlock(
+  channelsSchema.parse({
+    'slack-bot': {},
+    github: {
+      repos: ['<PLACEHOLDER-owner>/<repo-a>', '<PLACEHOLDER-owner>/<repo-b>'],
+      review: { on: 'opened', approve: true },
+    },
+  }),
+)
 
 const PLACEHOLDER_MEMORY = [
   '# Memory',
@@ -263,12 +275,14 @@ function dumpDefaultLoaderPrompt(kind: Exclude<OriginKind, 'subagent'>, options:
   const fixture = buildFixture(kind)
   const mode: SystemPromptMode = deriveSystemPromptMode(fixture.origin)
   const wantGitNudge = options.gitNudge && mode === 'full'
+  const channelsSection = mode === 'full' ? PLACEHOLDER_CHANNELS : ''
   const parts = {
     mode,
     self: PLACEHOLDER_SELF,
     runtimeVersion: PLACEHOLDER_RUNTIME_VERSION,
     origin: fixture.origin,
     roleContext: fixture.roleContext,
+    channelsSection,
     gitNudge: wantGitNudge ? PLACEHOLDER_GIT_NUDGE : '',
     memorySection: fixture.memory,
   } as const
@@ -288,10 +302,26 @@ function dumpDefaultLoaderPrompt(kind: Exclude<OriginKind, 'subagent'>, options:
       extractSection(
         prompt,
         '## Your role in this session',
-        parts.gitNudge !== '' ? '## Uncommitted changes at session start' : '# Memory',
+        parts.channelsSection !== ''
+          ? '## Channels'
+          : parts.gitNudge !== ''
+            ? '## Uncommitted changes at session start'
+            : '# Memory',
       ),
     ),
   ]
+  if (parts.channelsSection !== '') {
+    sections.push(
+      mkSection(
+        'Channels',
+        extractSection(
+          prompt,
+          '## Channels',
+          parts.gitNudge !== '' ? '## Uncommitted changes at session start' : '# Memory',
+        ),
+      ),
+    )
+  }
   if (parts.gitNudge !== '') {
     sections.push(mkSection('Git nudge', parts.gitNudge))
   }

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -296,6 +296,7 @@ describe('createResourceLoader', () => {
   test('composeSystemPrompt does not accept or emit a `now` field (removed when the anchor moved to per-turn injection)', () => {
     const prompt = composeSystemPrompt({
       self: '# Identity\n\nfoo',
+      channelsSection: '',
       gitNudge: '',
       memorySection: '',
     })
@@ -309,6 +310,7 @@ describe('createResourceLoader', () => {
       self: '# Identity\n\nfoo',
       origin: { kind: 'tui', sessionId: 'ses_test' },
       mcpCatalog: catalog,
+      channelsSection: '',
       gitNudge: '',
       memorySection: '## Memory\n\nmemory-marker',
     })
@@ -1002,6 +1004,7 @@ describe('composeSystemPrompt slim mode', () => {
     const prompt = composeSystemPrompt({
       mode: 'slim',
       self: '# Identity\n\nfoo',
+      channelsSection: '',
       gitNudge: '',
       memorySection: '# Memory\n\nbar',
     })
@@ -1012,6 +1015,7 @@ describe('composeSystemPrompt slim mode', () => {
   test('uses DEFAULT_SYSTEM_PROMPT when mode is unset (back-compat)', () => {
     const prompt = composeSystemPrompt({
       self: '# Identity\n\nfoo',
+      channelsSection: '',
       gitNudge: '',
       memorySection: '# Memory\n\nbar',
     })
@@ -1022,6 +1026,7 @@ describe('composeSystemPrompt slim mode', () => {
     const prompt = composeSystemPrompt({
       mode: 'slim',
       self: '# Identity\n\nfoo',
+      channelsSection: '',
       gitNudge: '',
       memorySection: '',
     })

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -57,6 +57,7 @@ import type { CreateSessionForSubagent, SubagentRegistry } from './subagents'
 import {
   buildDefaultSystemPrompt,
   DEFAULT_SUBAGENT_ROSTER,
+  renderChannelsBlock,
   renderRuntimeBlock,
   SLIM_SYSTEM_PROMPT,
 } from './system-prompt'
@@ -995,6 +996,7 @@ export type SystemPromptComposition = {
   origin?: SessionOrigin
   roleContext?: SessionRoleContext
   mcpCatalog?: string
+  channelsSection: string
   gitNudge: string
   memorySection: string
 }
@@ -1037,6 +1039,12 @@ export function composeSystemPrompt(parts: SystemPromptComposition): string {
   }
   if (parts.mcpCatalog !== undefined && parts.mcpCatalog !== '') {
     prompt = `${prompt}\n\n${parts.mcpCatalog}`
+  }
+  // Configured-channels block sits after origin/role (which describe THIS
+  // session) and before gitNudge — stable prefix, gated empty for agents with
+  // no enabled channel so TUI-only setups pay zero bytes.
+  if (parts.channelsSection !== '') {
+    prompt = `${prompt}\n\n${parts.channelsSection}`
   }
   if (parts.gitNudge !== '') {
     prompt = `${prompt}\n\n${parts.gitNudge}`
@@ -1122,6 +1130,11 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   const gitNudge = unwrapSettled(gitNudgeResult)
   const memorySection = unwrapSettled(memoryResult)
 
+  // Full mode only: cron/subagent (slim) sessions are unattended and the origin
+  // block already scopes their narrow task, so the standing channel roster is
+  // noise there and would erode the slim token budgets the dump tests guard.
+  const channelsSection = mode === 'full' ? renderChannelsBlock(getConfig().channels) : ''
+
   const systemPrompt = composeSystemPrompt({
     mode,
     self,
@@ -1132,6 +1145,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
     ...(mode === 'full' && options.mcpManager !== undefined
       ? { mcpCatalog: renderMcpCatalog(options.mcpManager.listServers()) }
       : {}),
+    channelsSection,
     gitNudge,
     memorySection,
   })

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
+import { channelsSchema } from '@/channels/schema'
 import { formatLocalDateTime, resolveLocalTimezoneName } from '@/shared'
 
-import { DEFAULT_SYSTEM_PROMPT, renderTurnRoleAnchor, renderTurnTimeAnchor } from './system-prompt'
+import { DEFAULT_SYSTEM_PROMPT, renderChannelsBlock, renderTurnRoleAnchor, renderTurnTimeAnchor } from './system-prompt'
 
 describe('subagent orchestration — explicit research routing', () => {
   // Guards the regression where an explicit "do a research" directive was answered
@@ -128,5 +129,52 @@ describe('renderTurnRoleAnchor', () => {
     expect(renderTurnRoleAnchor('contributor')).toContain(
       '<your-role authority="current-speaker">contributor</your-role>',
     )
+  })
+})
+
+describe('renderChannelsBlock', () => {
+  test('renders github repos and review config so the agent knows its standing setup', () => {
+    const block = renderChannelsBlock(
+      channelsSchema.parse({
+        'slack-bot': {},
+        github: { repos: ['acme/api', 'acme/web'], review: { on: 'opened', approve: true } },
+      }),
+    )
+    expect(block).toContain('## Channels')
+    expect(block).toContain('**github**')
+    expect(block).toContain('acme/api, acme/web')
+    expect(block).toContain('on `opened`')
+    expect(block).toContain('may approve')
+    expect(block).toContain('**slack-bot** — enabled')
+  })
+
+  test('carries a disclosure guard so low-privilege channel speakers cannot extract the repo list', () => {
+    const block = renderChannelsBlock(channelsSchema.parse({ github: { repos: ['acme/private-svc'] } }))
+    expect(block).toContain('owner/trusted authority')
+    expect(block).toContain('decline')
+  })
+
+  test('returns empty string when no channel is enabled (TUI-only agents pay nothing)', () => {
+    expect(renderChannelsBlock(channelsSchema.parse({}))).toBe('')
+  })
+
+  test('omits disabled adapters', () => {
+    const block = renderChannelsBlock(channelsSchema.parse({ 'discord-bot': { enabled: false }, 'telegram-bot': {} }))
+    expect(block).not.toContain('discord-bot')
+    expect(block).toContain('**telegram-bot** — enabled')
+  })
+
+  test('renders comment-only and off review states distinctly', () => {
+    const commentOnly = renderChannelsBlock(
+      channelsSchema.parse({ github: { repos: ['a/b'], review: { on: 'opened', approve: false } } }),
+    )
+    expect(commentOnly).toContain('comment-only')
+    const off = renderChannelsBlock(channelsSchema.parse({ github: { repos: ['a/b'], review: { on: 'off' } } }))
+    expect(off).toContain('review: off')
+  })
+
+  test('handles a github channel with no repos configured', () => {
+    const block = renderChannelsBlock(channelsSchema.parse({ github: { repos: [] } }))
+    expect(block).toContain('(none configured)')
   })
 })

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,3 +1,4 @@
+import type { ChannelsConfig } from '@/channels/schema'
 import { formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from '@/shared'
 
 // The orchestration roster (the `Briefly: ...` enumeration of public subagents)
@@ -156,6 +157,46 @@ export function renderRuntimeBlock(version: string): string {
   return `## Runtime
 
 TypeClaw runtime version: ${version}.`
+}
+
+// Standing summary of the agent's CONFIGURED channels (typeclaw.json#channels),
+// distinct from the origin block which only describes the CURRENT conversation.
+// Without it, an agent answering in a Slack DM has no idea it also runs a GitHub
+// channel watching specific repos — it hallucinates setups it does not have
+// (e.g. "forward GitHub webhooks to a Slack channel", a flow TypeClaw has no
+// concept of). This block is the ground truth it reasons from.
+//
+// Cache placement: stable prefix. `channels` is `applied` (FIELD_EFFECTS), so a
+// reload updates live config, but this block — like every prompt section — is
+// composed once at session creation and only refreshes when the session is
+// recreated. Same staleness model as origin/identity; acceptable. Returns '' when
+// no channel is enabled so the composer can gate it like gitNudge/memory — a
+// TUI-only agent pays nothing. No secrets here: tokens/signing keys live in
+// .env/secrets.json, never in the `channels` block, so every field is safe to
+// surface verbatim (webhookUrl is deliberately omitted regardless).
+export function renderChannelsBlock(channels: ChannelsConfig): string {
+  const lines: string[] = []
+  for (const [name, cfg] of Object.entries(channels)) {
+    if (cfg === undefined || cfg.enabled === false) continue
+    if (name === 'github' && 'repos' in cfg) {
+      const repos = cfg.repos.length > 0 ? cfg.repos.join(', ') : '(none configured)'
+      const review =
+        cfg.review.on === 'off'
+          ? 'off'
+          : `on \`${cfg.review.on}\`${cfg.review.approve ? ', may approve' : ', comment-only'}`
+      lines.push(`- **github** — repos: ${repos}; review: ${review}`)
+    } else {
+      lines.push(`- **${name}** — enabled`)
+    }
+  }
+  if (lines.length === 0) return ''
+  return `## Channels
+
+These channels are configured for you (from \`typeclaw.json\`). This is your standing setup — the session origin above tells you which one THIS conversation is in.
+
+${lines.join('\n')}
+
+To change them (add/remove repos, toggle review), edit \`typeclaw.json\`; do not invent channels or destinations that are not listed here. This list (including repo names) is internal configuration: only disclose it to a current speaker with owner/trusted authority — if a member or guest asks, decline rather than reciting it.`
 }
 
 // Wall-clock anchor injected into the **user turn**, not the system prompt.

--- a/src/agent/tools/spawn-subagent.roster.test.ts
+++ b/src/agent/tools/spawn-subagent.roster.test.ts
@@ -109,6 +109,7 @@ describe('composeSystemPrompt with the registry-rendered roster', () => {
       mode: 'full',
       self: 'IDENTITY',
       subagentRoster: roster,
+      channelsSection: '',
       gitNudge: '',
       memorySection: '',
     })
@@ -126,6 +127,7 @@ describe('composeSystemPrompt with the registry-rendered roster', () => {
       mode: 'slim',
       self: 'IDENTITY',
       subagentRoster: renderPublicSubagentRoster(BUNDLED_PUBLIC),
+      channelsSection: '',
       gitNudge: '',
       memorySection: '',
     })


### PR DESCRIPTION
## Symptom

In a Slack DM, an operator asked the agent to set up its GitHub webhook/review config. The agent had **no idea it already runs a GitHub channel** watching specific repos with auto-review. Instead it invented a flow TypeClaw has no concept of — "forward GitHub webhooks to a **Slack channel**" — and kept asking for a webhook URL + destination channel. Its actual `channels.github` config (4 repos, `review.on: opened`, auto-approve, tunnel-registered webhook) was completely invisible to it.

## Root cause

The system prompt never describes the agent's **configured** channels. The origin block (`renderSessionOrigin`) only describes the **current** conversation ("you are in a Slack DM"); nothing tells the agent "you also run a GitHub channel watching repos X, Y, Z." `getConfig().channels` is available at prompt-compose time but was never read. Confirmed green-field — no existing prompt section, tool, or skill surfaces this.

## Fix

A new `renderChannelsBlock(channels)` renders a compact `## Channels` summary from `getConfig().channels`:

```
## Channels

These channels are configured for you (from `typeclaw.json`). This is your standing setup — the session origin above tells you which one THIS conversation is in.

- **github** — repos: owner/a, owner/b; review: on `opened`, may approve
- **slack-bot** — enabled

To change them … edit `typeclaw.json`; do not invent channels or destinations that are not listed here. This list (including repo names) is internal configuration: only disclose it to a current speaker with owner/trusted authority …
```

Wired into `composeSystemPrompt` between the origin/role block and gitNudge — the correct cache-suffix position (channels config is less volatile than git/memory, changes only on reload).

### Properties

- **Full mode only** (tui, channel). Slim sessions (cron, subagent) stay lean; the dump tests guard the <1000/<500 token budgets.
- **Gated empty** — returns `''` when no channel is enabled, so TUI-only agents pay zero bytes.
- **No secrets** — channel tokens/signing keys live in `secrets.json`/`.env`, never in the `channels` block; `webhookUrl` is deliberately omitted in case it embeds a token. (Self-review verified the schema has no secret-bearing fields.)
- **Disclosure guard** — channel sessions can carry low-privilege speakers, and repo slugs are internal metadata, so the block instructs the agent to decline reciting the list to a member/guest. (Self-review finding.)
- **Cache-stable** — zod `.parse` preserves schema-declared key order, so the rendered block is byte-stable for a given config.

## Commits

1. `feat(agent): add renderChannelsBlock …` — the pure renderer + its unit tests (lands self-contained, unused).
2. `feat(agent): render the configured-channels block …` — wires it into `composeSystemPrompt`, updates the debug dumper, pins ordering/breakdown.

## Verification

Self-reviewed (Oracle, adversarial) for cache position, credential leak, token budget, field-required choice, key-order stability, and subagent/cron paths — no blockers; the repo-slug disclosure concern was addressed with the guard line. Full gate green: `typecheck`, `lint` (0 errors), `format:check`, `test` (8038 pass / 0 fail).

`bun run debug:prompt --origin channel` shows the section in place; `--origin cron` confirms slim sessions omit it.
