### PR TITLE
docs(release): bias version bumps toward patch, narrow minor triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,10 @@ Use the **Release** GitHub Actions workflow (`workflow_dispatch`, see `.github/w
 
 The workflow is the only supported release path. The GHCR-first-then-npm ordering is load-bearing for the version-pin invariant: a user who `npm install`s before the base image lands cannot `typeclaw start`.
 
-**Version decision.** Specified version → use as-is. Otherwise decide bump level:
+**Version decision.** Specified version → use as-is. Otherwise **default to patch** and only escalate to minor when one of the explicit minor triggers below is clearly met. When in doubt, it's a patch.
 
-- **minor** — new features, new CLI subcommands, new plugin contract surface, breaking changes
-- **patch** — bug fixes, refactors, docs, deps, minor improvements
+- **patch** (the default) — bug fixes, refactors, docs, deps, internal-only changes, performance work, test changes, and any user-facing improvement that doesn't add a new public surface or break an existing one. Most releases are patches.
+- **minor** — reserve for a genuinely new _public_ surface or a breaking change. Specifically, exactly one of: (a) a new CLI subcommand or flag, (b) a new plugin contract surface (tool/skill/subagent/channel/command hook or config field plugins can rely on), (c) a backwards-incompatible change to any of the above. A "new feature" alone is NOT enough — if it doesn't expand or break the public surface in one of those ways, it's a patch.
 - Never bump major unless asked. Never ask the user which to bump.
 
 `package.json` is the single source of truth for the version.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ The workflow is the only supported release path. The GHCR-first-then-npm orderin
 **Version decision.** Specified version → use as-is. Otherwise **default to patch** and only escalate to minor when one of the explicit minor triggers below is clearly met. When in doubt, it's a patch.
 
 - **patch** (the default) — bug fixes, refactors, docs, deps, internal-only changes, performance work, test changes, and any user-facing improvement that doesn't add a new public surface or break an existing one. Most releases are patches.
-- **minor** — reserve for a genuinely new _public_ surface or a breaking change. Specifically, exactly one of: (a) a new CLI subcommand or flag, (b) a new plugin contract surface (tool/skill/subagent/channel/command hook or config field plugins can rely on), (c) a backwards-incompatible change to any of the above. A "new feature" alone is NOT enough — if it doesn't expand or break the public surface in one of those ways, it's a patch.
+- **minor** — reserve for a genuinely new _public_ surface or a breaking change. Specifically, at least one of: (a) a new CLI subcommand or flag, (b) a new plugin contract surface (tool/skill/subagent/channel/command hook or config field plugins can rely on), (c) a backwards-incompatible change to any of the above. A "new feature" alone is NOT enough — if it doesn't expand or break the public surface in one of those ways, it's a patch.
 - Never bump major unless asked. Never ask the user which to bump.
 
 `package.json` is the single source of truth for the version.


### PR DESCRIPTION
## Background

The project was bumping minor too easily — we reached `0.33.0` via a steady stream of "new feature" minor bumps. The root cause was the version-decision rule: it listed **"new features"** as a minor trigger, which is broad enough that nearly any user-visible improvement qualified. The rule said nothing about patch being the default, leaving the agent to round up on ambiguity.

## Summary

Two targeted edits to the "Version decision" paragraph in the Release section of AGENTS.md:

1. **Patch is now the explicit default.** The rule opens with "default to patch and only escalate to minor when one of the explicit minor triggers below is clearly met. When in doubt, it's a patch." Internal-only changes, refactors, performance work, test changes, and user-facing improvements that don't add a new public surface or break an existing one all land as patch.

2. **Minor is narrowed to three explicit triggers:** (a) a new CLI subcommand or flag, (b) a new plugin contract surface (tool/skill/subagent/channel/command hook or config field plugins can rely on), (c) a backwards-incompatible change to any of the above. The former catch-all "new features" trigger is gone, replaced by the explicit note: "A 'new feature' alone is NOT enough."

The `major` rule and the "never ask the user" rule are unchanged.

## What this does NOT do

- Does not change any release tooling, CI, or runtime behavior — docs only.
- Does not retroactively renumber existing releases.

## Review notes

- Only AGENTS.md is touched (3 insertions / 3 deletions). The Release section's "Version decision" paragraph is the only changed block.
- The before/after diff is the ground truth: the old two-liner (minor/patch bullets with no stated default) is replaced by a default-first ordering (patch default, then minor with exhaustive explicit triggers).