### PR TITLE
docs(skill): correct github channel no-URL behavior

### DIFF
--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -249,7 +249,7 @@ This is the most common request ("review repo X too", "stop watching repo Y"). I
 
 > Why restart and not reload: GitHub webhooks are created/removed only in the adapter's `start()`/`stop()`. `reload` does not restart a running adapter for a `repos` change (it only handles enable/disable and credential rotation), so the new repo's webhook simply isn't created until the container restarts. `typeclaw restart` is the honest answer for "start reviewing repo X".
 
-**Webhook delivery requires a public URL.** GitHub must be able to reach the container. That URL comes from one of two places, and a repo added without it will register a hook that never receives events:
+**Webhook delivery requires a public URL.** GitHub must be able to reach the container. That URL comes from one of two places; without one the repo can be listed in config, but the adapter **skips webhook registration entirely** (it logs the skip) and no events arrive until a tunnel or `webhookUrl` is in place:
 
 - A **tunnel** entry: `tunnels: [{ name: "github-webhook", provider: "cloudflare-quick", for: { kind: "channel", name: "github" } }]`. The adapter pulls its URL from the tunnel manager automatically — leave `webhookUrl` unset. This is the normal setup. Adding/removing a tunnel is **restart-required** (`tunnels` is not live-reloadable) — see the `typeclaw-tunnels` skill.
 - An explicit `channels.github.webhookUrl` the operator manages by hand.


### PR DESCRIPTION
## Background

PR #730 ("docs(skill): teach typeclaw-config the GitHub channel") added a GitHub
channel section to the `typeclaw-config` skill and merged to main. A reviewer left
an accurate comment on #730 noting that the webhook-delivery paragraph was wrong —
the fix didn't land before merge, so this PR addresses it as a follow-up.

## Summary

The merged doc said:

> a repo added without [a public URL] will register a hook that never receives events.

That is the opposite of what the adapter does. The relevant guard is in
`src/channels/adapters/github/index.ts` at the null-effectiveUrl check (lines 307-312):
when no webhook URL is available, the adapter calls `logSkippedRegistration` and
returns early. Registration is skipped entirely and logged; `registerGithubWebhooks`
is never invoked, so no dead hook is created.

The one-line fix rewords the sentence to match the runtime: the repo can be listed
in config, but the adapter **skips webhook registration entirely** (it logs the skip)
until a tunnel or `webhookUrl` is in place. This is now consistent with the very
next sentence in the same paragraph.

## Preview

Docs-only change to one file (`src/skills/typeclaw-config/SKILL.md`),
1 insertion / 1 deletion.

**Before:**

```
a repo added without it will register a hook that never receives events
```

**After:**

```
without one the repo can be listed in config, but the adapter skips webhook
registration entirely (it logs the skip) and no events arrive until a tunnel
or webhookUrl is in place
```

## What this does NOT do

- Does not change any runtime code — docs-only fix.
- Does not rewrite the rest of the GitHub channel section added by #730.

## Review notes

The load-bearing fact to verify is the null-effectiveUrl guard in
`src/channels/adapters/github/index.ts` (lines 298-312). When effectiveUrl is null,
the adapter skips registration entirely via `logSkippedRegistration` — the
registerGithubWebhooks function is never reached. The original doc's "registers a
dead hook" claim had no basis in the code.

Checks: typecheck clean, lint 0 errors (66 pre-existing warnings),
format:check clean, test 8078 pass / 0 fail / 1 skip.