### PR TITLE
Mint App tokens for git/gh under multi-owner App auth

### DIFF
--- a/src/bundled-plugins/backup/index.test.ts
+++ b/src/bundled-plugins/backup/index.test.ts
@@ -24,7 +24,10 @@ function makeCtx(overrides: { config: unknown }): {
       error: (m) => logs.push(`error:${m}`),
     },
     permissions: noopPermissionService,
-    github: { resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }) },
+    github: {
+      resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }),
+      hasAppTokenResolver: () => false,
+    },
     spawnSubagent: async (name, payload) => {
       spawnCalls.push({ name, payload })
     },

--- a/src/bundled-plugins/bun-hygiene/index.test.ts
+++ b/src/bundled-plugins/bun-hygiene/index.test.ts
@@ -67,7 +67,10 @@ function pluginContext(): PluginContext<undefined> {
     config: undefined,
     logger: noopLogger,
     permissions: noopPermissionService,
-    github: { resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }) },
+    github: {
+      resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }),
+      hasAppTokenResolver: () => false,
+    },
     spawnSubagent: async () => {},
   }
 }

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -20,7 +20,10 @@ afterEach(() => {
   else process.env.GH_TOKEN = originalToken
 })
 
-function pluginContext(resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>): PluginContext<undefined> {
+function pluginContext(
+  resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>,
+  hasAppTokenResolver = true,
+): PluginContext<undefined> {
   return {
     name: 'github-cli-auth',
     version: undefined,
@@ -28,13 +31,13 @@ function pluginContext(resolve: (repoSlug: string) => Promise<GithubTokenResolve
     config: undefined,
     logger: noopLogger,
     permissions: noopPermissionService,
-    github: { resolveTokenForRepo: resolve },
+    github: { resolveTokenForRepo: resolve, hasAppTokenResolver: () => hasAppTokenResolver },
     spawnSubagent: async () => {},
   }
 }
 
-async function hookFor(resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>) {
-  const exports = await githubCliAuthPlugin.plugin(pluginContext(resolve))
+async function hookFor(resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>, hasAppTokenResolver = true) {
+  const exports = await githubCliAuthPlugin.plugin(pluginContext(resolve, hasAppTokenResolver))
   const hook = exports.hooks?.['tool.before']
   if (!hook) throw new Error('plugin did not register tool.before')
   return hook
@@ -88,6 +91,35 @@ describe('github-cli-auth plugin', () => {
     })
 
     expect(result).toEqual({ block: true, reason: 'adapter down' })
+  })
+
+  test('multi-owner App auth (GH_TOKEN unseeded, minter live): still injects the minted token', async () => {
+    // given: a multi-owner / no-repos App config never seeds GH_TOKEN, but the
+    // per-repo minter is registered. App auth must be detected via the minter.
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(tokenResolver('ghs_minted'), true)
+    const event = bashEvent('gh pr view -R acme/widgets')
+
+    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
+  })
+
+  test('no App auth (GH_TOKEN unseeded, no minter): passes through without minting', async () => {
+    delete process.env.GH_TOKEN
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    }, false)
+    const event = bashEvent('gh pr view -R acme/widgets')
+
+    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
   })
 
   test('classic PAT: passes through unchanged (cross-owner)', async () => {
@@ -184,6 +216,38 @@ describe('github-cli-auth plugin — git path', () => {
     await hook(bashEvent('git clone https://github.com/acme/widgets.git'), hookCtx)
 
     expect(seen).toEqual(['acme/widgets'])
+  })
+
+  test('multi-owner App auth (GH_TOKEN unseeded, minter live): injects GIT_ASKPASS for git push', async () => {
+    // given: the reported #733 failure — a push under a multi-owner App where
+    // GH_TOKEN is never seeded, so the old `classifyGhToken(GH_TOKEN) === app`
+    // gate dropped the credential and git died with "could not read Username".
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(tokenResolver('ghs_minted'), true)
+    const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(overlay.GIT_ASKPASS).toBeDefined()
+  })
+
+  test('no App auth (GH_TOKEN unseeded, no minter): git push passes through without minting', async () => {
+    delete process.env.GH_TOKEN
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    }, false)
+    const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
   })
 
   test('App auth: blocks when the bridge is unavailable', async () => {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -8,11 +8,12 @@ import { ensureGitAskPassHelper } from './git-askpass'
 import { analyzeGitCommand, defaultGitResolvers } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
-import { classifyGhToken } from './token-class'
+import { classifyGhToken, shouldMintAppToken } from './token-class'
 
 export default definePlugin({
   plugin: async (ctx) => {
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
+    const hasAppTokenResolver = ctx.github.hasAppTokenResolver
     const resolveToken = async (workspace: string) => {
       const result = await resolveTokenForRepo(workspace)
       return result.kind === 'token' ? result.token : null
@@ -57,6 +58,10 @@ export default definePlugin({
       // `gh` fails honestly if the named repo is under a different owner.
       if (tokenClass === 'fine-grained-pat') return
 
+      // No App auth (no App-class GH_TOKEN and no live minter): leave whatever
+      // is seeded so `gh` fails honestly rather than us guessing a token.
+      if (!shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
+
       const result = await resolveTokenForRepo(decision.repoSlug)
       if (result.kind === 'unavailable') return { block: true, reason: result.reason }
       // Inject via the internal env overlay (delivered to the spawn / bwrap
@@ -76,8 +81,10 @@ export default definePlugin({
     }): Promise<HookResult> => {
       const { event, command, agentDir } = params
       // Only App auth re-mints per repo. Classic/fine-grained PATs and absent
-      // tokens are left untouched, exactly as the gh path treats them.
-      if (classifyGhToken(process.env.GH_TOKEN) !== 'app') return
+      // tokens are left untouched, exactly as the gh path treats them. App auth
+      // is detected by the live minter too, not just an App-class GH_TOKEN:
+      // multi-owner / no-repos App configs never seed GH_TOKEN yet can mint.
+      if (!shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
 
       const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
       if (decision.kind === 'pass-through') return

--- a/src/bundled-plugins/github-cli-auth/token-class.test.ts
+++ b/src/bundled-plugins/github-cli-auth/token-class.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
-import { classifyGhToken } from './token-class'
+import { classifyGhToken, shouldMintAppToken } from './token-class'
 
 describe('classifyGhToken', () => {
   it('classifies a classic PAT as cross-owner', () => {
@@ -22,5 +22,26 @@ describe('classifyGhToken', () => {
 
   it('treats an unknown prefix as app (conservative per-repo resolution)', () => {
     expect(classifyGhToken('gho_oauthtoken')).toBe('app')
+  })
+})
+
+describe('shouldMintAppToken', () => {
+  it('mints for an App-class GH_TOKEN regardless of resolver presence', () => {
+    expect(shouldMintAppToken('ghs_abc', false)).toBe(true)
+    expect(shouldMintAppToken('ghs_abc', true)).toBe(true)
+  })
+
+  it('mints when GH_TOKEN is unseeded but a live minter is registered', () => {
+    expect(shouldMintAppToken(undefined, true)).toBe(true)
+    expect(shouldMintAppToken('', true)).toBe(true)
+  })
+
+  it('does not mint when GH_TOKEN is unseeded and no minter is registered', () => {
+    expect(shouldMintAppToken(undefined, false)).toBe(false)
+  })
+
+  it('never re-mints for classic or fine-grained PATs, even with a live minter', () => {
+    expect(shouldMintAppToken('ghp_classic', true)).toBe(false)
+    expect(shouldMintAppToken('github_pat_xyz', true)).toBe(false)
   })
 })

--- a/src/bundled-plugins/github-cli-auth/token-class.ts
+++ b/src/bundled-plugins/github-cli-auth/token-class.ts
@@ -9,3 +9,16 @@ export function classifyGhToken(token: string | undefined): GhTokenClass {
   // a per-repo token rather than silently using a possibly-wrong global one.
   return 'app'
 }
+
+// Whether the per-repo App minter should fire for a repo-targeting command.
+// App auth is detected via EITHER a seeded App-class GH_TOKEN OR a live App
+// token resolver — the latter is the authority because multi-owner / no-repos
+// App configs intentionally leave GH_TOKEN unseeded (the prefix would read
+// 'none'), yet the per-repo minter is still registered and able to mint. Classic
+// and fine-grained PATs are never re-minted: they pass through with whatever
+// GH_TOKEN is seeded, exactly as before.
+export function shouldMintAppToken(token: string | undefined, hasAppTokenResolver: boolean): boolean {
+  const tokenClass = classifyGhToken(token)
+  if (tokenClass === 'cross-owner' || tokenClass === 'fine-grained-pat') return false
+  return tokenClass === 'app' || hasAppTokenResolver
+}

--- a/src/bundled-plugins/guard/index.test.ts
+++ b/src/bundled-plugins/guard/index.test.ts
@@ -437,7 +437,10 @@ function pluginContext(agentDir: string): PluginContext<undefined> {
     config: undefined,
     logger: noopLogger,
     permissions: noopPermissionService,
-    github: { resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }) },
+    github: {
+      resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }),
+      hasAppTokenResolver: () => false,
+    },
     spawnSubagent: async () => {},
   }
 }

--- a/src/bundled-plugins/security/index.test.ts
+++ b/src/bundled-plugins/security/index.test.ts
@@ -833,7 +833,10 @@ function pluginContext(agentDir: string): PluginContext<undefined> {
     config: undefined,
     logger: noopLogger,
     permissions: noopPermissionService,
-    github: { resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }) },
+    github: {
+      resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }),
+      hasAppTokenResolver: () => false,
+    },
     spawnSubagent: async () => {},
   }
 }

--- a/src/bundled-plugins/tool-result-cap/index.test.ts
+++ b/src/bundled-plugins/tool-result-cap/index.test.ts
@@ -21,7 +21,10 @@ function makeCtx(overrides: { config: unknown }): {
       error: (m) => logs.push(`error:${m}`),
     },
     permissions: noopPermissionService,
-    github: { resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }) },
+    github: {
+      resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }),
+      hasAppTokenResolver: () => false,
+    },
     spawnSubagent: async () => {},
   }
   return { ctx, logs }

--- a/src/channels/github-token-bridge.test.ts
+++ b/src/channels/github-token-bridge.test.ts
@@ -62,4 +62,15 @@ describe('createGithubTokenBridge', () => {
 
     expect(result).toEqual({ kind: 'token', token: 'ghs_second' })
   })
+
+  it('hasAppTokenResolver tracks resolver registration', () => {
+    const bridge = createGithubTokenBridge()
+    expect(bridge.hasAppTokenResolver()).toBe(false)
+
+    const unregister = bridge.registerResolver(async () => 'ghs_x')
+    expect(bridge.hasAppTokenResolver()).toBe(true)
+
+    unregister()
+    expect(bridge.hasAppTokenResolver()).toBe(false)
+  })
 })

--- a/src/channels/github-token-bridge.ts
+++ b/src/channels/github-token-bridge.ts
@@ -9,6 +9,12 @@ export type ResolveGithubTokenForRepo = (repoSlug: string) => Promise<GithubToke
 
 export type GithubTokenBridge = {
   resolveTokenForRepo: ResolveGithubTokenForRepo
+  // True when a per-repo App-token minter is registered (only the GitHub App
+  // adapter registers one). This is the non-secret "App auth with per-repo
+  // minting is available" signal: it stays true for multi-owner / no-repos App
+  // configs where the process-wide GH_TOKEN is intentionally NOT seeded, so the
+  // git/gh mint paths can no longer rely on GH_TOKEN's prefix to detect App auth.
+  hasAppTokenResolver: () => boolean
   registerResolver: (resolver: (repoSlug: string) => Promise<string>) => () => void
 }
 
@@ -30,6 +36,7 @@ export function createGithubTokenBridge(): GithubTokenBridge {
         return { kind: 'unavailable', reason: err instanceof Error ? err.message : String(err) }
       }
     },
+    hasAppTokenResolver: () => current !== null,
     registerResolver: (resolver) => {
       current = resolver
       return () => {

--- a/src/plugin/context.ts
+++ b/src/plugin/context.ts
@@ -13,6 +13,7 @@ export type CreatePluginContextOptions<TConfig> = {
   logger: PluginLogger
   permissions: PermissionService
   resolveGithubTokenForRepo?: ResolveGithubTokenForRepo
+  hasGithubAppTokenResolver?: () => boolean
   spawnSubagent: SpawnSubagentFn
   isBooted: () => boolean
 }
@@ -30,7 +31,10 @@ export function createPluginContext<TConfig>(opts: CreatePluginContextOptions<TC
     config: opts.config,
     logger: opts.logger,
     permissions: opts.permissions,
-    github: { resolveTokenForRepo: opts.resolveGithubTokenForRepo ?? githubTokenUnavailable },
+    github: {
+      resolveTokenForRepo: opts.resolveGithubTokenForRepo ?? githubTokenUnavailable,
+      hasAppTokenResolver: opts.hasGithubAppTokenResolver ?? (() => false),
+    },
     spawnSubagent: async (name: string, payload?: unknown, options?: SpawnSubagentOptions) => {
       if (!opts.isBooted()) {
         throw new Error(

--- a/src/plugin/define.test.ts
+++ b/src/plugin/define.test.ts
@@ -39,7 +39,10 @@ describe('definePlugin', () => {
       config: { count: 42 },
       logger: { info: () => {}, warn: () => {}, error: () => {} },
       permissions: noopPermissionService,
-      github: { resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }) },
+      github: {
+        resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }),
+        hasAppTokenResolver: () => false,
+      },
       spawnSubagent: async () => {},
     })
     expect(captured.value).toBe(42)

--- a/src/plugin/manager.ts
+++ b/src/plugin/manager.ts
@@ -22,6 +22,7 @@ export type LoadPluginsOptions = {
   loadEntry?: LoadPluginEntryFn
   roles?: RolesConfig
   resolveGithubTokenForRepo?: ResolveGithubTokenForRepo
+  hasGithubAppTokenResolver?: () => boolean
   // Bundled plugins resolved by the runtime (not from typeclaw.json). Loaded
   // before user-declared `entries` so a config block named after a bundled
   // plugin (e.g. "memory") is consumed by the bundled plugin, and so plugin-
@@ -104,6 +105,7 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
       logger,
       permissions,
       resolveGithubTokenForRepo: opts.resolveGithubTokenForRepo,
+      hasGithubAppTokenResolver: opts.hasGithubAppTokenResolver,
       spawnSubagent: (name, payload, options) => spawnSubagentImpl(name, payload, options),
       isBooted: () => booted,
     })

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -280,6 +280,7 @@ export type PluginContext<TConfig = never> = {
 
 export type PluginGithubServices = {
   resolveTokenForRepo: ResolveGithubTokenForRepo
+  hasAppTokenResolver: () => boolean
 }
 
 export type PluginExports = {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -167,6 +167,7 @@ export async function startAgent({
     configsByName: pluginConfigsByName,
     bundled: BUNDLED_PLUGINS,
     resolveGithubTokenForRepo: githubTokenBridge.resolveTokenForRepo,
+    hasGithubAppTokenResolver: githubTokenBridge.hasAppTokenResolver,
     ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
   })
 


### PR DESCRIPTION
## Background

Follow-up to #733 (mint GitHub App tokens for plain `git` commands). In a GitHub App-authenticated session, a plain `git push` to a private repo still failed with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

No credential reached git at all — the `GIT_ASKPASS` helper and minted token were never injected.

**Root cause.** Both mint paths in `github-cli-auth` detect "is this App auth?" by reading the seeded `process.env.GH_TOKEN` prefix (`classifyGhToken(...) === 'app'`). But the GitHub adapter only seeds `GH_TOKEN` when it can prove a single installation applies — `ghTokenSeedDecision` deliberately **skips** seeding for a **multi-owner** App (more than one installation) or a **no-repos** config, because no single token is correct. In those configs `classifyGhToken(undefined) === 'none'`, so both `handleGitCommand` and `handleGhCommand` returned early and injected nothing.

Meanwhile the per-repo token bridge minter is registered for **all** App auth regardless of owner count, so `resolveTokenForRepo('owner/repo')` would have succeeded — the minting capability was live the whole time; only the gate was blind to it. The `gh` path carries the same latent bug (its `MISSING_REPO_REASON` even documents the multi-owner App as a supported config).

## Summary

Detect App auth via the **live minter**, not `GH_TOKEN`'s prefix.

- Add a non-secret `hasAppTokenResolver()` to `GithubTokenBridge` (`true` iff a per-repo minter is registered — only the GitHub App adapter registers one) and thread it through `ctx.github`.
- Replace both gates with `shouldMintAppToken(GH_TOKEN, hasAppTokenResolver())`, which mints when `GH_TOKEN` is App-class **or** a minter is registered.

**Why the bridge signal and not a sentinel `GH_TOKEN`:** a single seeded token cannot represent a multi-owner App without being wrong for some owner, and a fake/sentinel value would leak into git config / process listings. The bridge registration is the actual authority for "App minting is available," so that is what the gate consults. `GH_TOKEN` is left strictly real-token-or-absent.

Classic and fine-grained PATs still pass through unchanged (they cannot be safely re-minted per repo), exactly as before.

Split into two commits: the capability signal + wiring first (lands cleanly on its own), then the gate fix that consumes it.

## What this does NOT do

- Does not change `GH_TOKEN` seeding (`ghTokenSeedDecision` is untouched).
- Does not weaken classic/fine-grained PAT pass-through.
- Does not relax the bridge's `repos[]` allowlist, the analyzer's compound-command / dangerous-`-c` / multi-owner blocks, or the env-overlay-only token delivery.
- Does not introduce a sentinel/placeholder `GH_TOKEN`.

## Review notes

- Load-bearing change: the gate in `src/bundled-plugins/github-cli-auth/index.ts` now calls `shouldMintAppToken(...)`. Invariant to verify: a multi-owner / no-repos App config (where `GH_TOKEN` is unseeded) still injects, while classic/fine-grained PATs still do not mint.
- `hasAppTokenResolver()` means only "an App minter exists" — it does **not** imply any repo is allowed. `resolveTokenForRepo` still enforces `repos[]` and fails closed with an actionable reason.
- Regression coverage: `index.test.ts` adds git-push and `gh` cases with `GH_TOKEN` unset + minter live (inject) and minter absent (pass-through); `token-class.test.ts` covers `shouldMintAppToken`; `github-token-bridge.test.ts` covers the new signal.
