### PR TITLE
Strip redundant -R on gh api literal-path calls

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -75,6 +75,14 @@ describe('analyzeGhCommand', () => {
     })
   })
 
+  it('blocks when a SECOND -R mismatches the path even though the first one matches', () => {
+    // The strip removes every -R, so a redundant first flag must not mask a
+    // mismatching second one (mint-for-X-hit-Y via a trailing -R victim/private).
+    const result = analyzeGhCommand('gh api repos/acme/widgets/issues -R acme/widgets -R victim/private')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.reason).toContain('ignores `-R`')
+  })
+
   it('strips every redundant -R/--repo flag form from a literal-path gh api call', () => {
     const cases: Array<[string, string]> = [
       ['gh api repos/acme/widgets/issues -R acme/widgets', 'gh api repos/acme/widgets/issues'],

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -67,11 +67,25 @@ describe('analyzeGhCommand', () => {
     if (result.kind === 'block') expect(result.reason).toContain('ignores `-R`')
   })
 
-  it('allows gh api when -R matches the literal path repo', () => {
+  it('strips a redundant -R that matches the literal path repo (gh api rejects -R)', () => {
     expect(analyzeGhCommand('gh api /repos/acme/widgets/pulls/1 -R acme/widgets')).toEqual({
       kind: 'inject',
       repoSlug: 'acme/widgets',
+      rewrittenCommand: 'gh api /repos/acme/widgets/pulls/1',
     })
+  })
+
+  it('strips every redundant -R/--repo flag form from a literal-path gh api call', () => {
+    const cases: Array<[string, string]> = [
+      ['gh api repos/acme/widgets/issues -R acme/widgets', 'gh api repos/acme/widgets/issues'],
+      ['gh api repos/acme/widgets/issues --repo acme/widgets', 'gh api repos/acme/widgets/issues'],
+      ['gh api repos/acme/widgets/issues -R=acme/widgets', 'gh api repos/acme/widgets/issues'],
+      ['gh api repos/acme/widgets/issues --repo=acme/widgets', 'gh api repos/acme/widgets/issues'],
+      ['gh api -R acme/widgets repos/acme/widgets/issues', 'gh api repos/acme/widgets/issues'],
+    ]
+    for (const [input, expected] of cases) {
+      expect(analyzeGhCommand(input)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets', rewrittenCommand: expected })
+    }
   })
 
   it('still detects the path repo (and conflict) when -R precedes a /repos endpoint', () => {
@@ -136,6 +150,29 @@ describe('analyzeGhCommand', () => {
       repoSlug: 'acme/widgets',
       rewrittenCommand: 'gh api graphql -f query=\'mutation { x(input:"-R evil/repo") }\'',
     })
+  })
+
+  it('does not strip a -R inside a double-quoted value with escaped quotes (escape-aware)', () => {
+    const input = 'gh api repos/acme/widgets/issues -f body="{\\"text\\":\\"-R evil/repo\\"}" -R acme/widgets'
+    expect(analyzeGhCommand(input)).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+      rewrittenCommand: 'gh api repos/acme/widgets/issues -f body="{\\"text\\":\\"-R evil/repo\\"}"',
+    })
+  })
+
+  it('the strip rewrite never touches a -R/--repo whose value is not an owner/repo slug', () => {
+    // The graphql repo hint is taken from a valid slug; an attached `=` form
+    // whose value is NOT owner/repo must be left verbatim by the rewrite (the
+    // detection path already rejected it, so the rewrite must agree).
+    const noStrip = [
+      'gh api graphql -R=notaslug -f query=x',
+      'gh api graphql --repo=owner/repo/extra -f query=x',
+      'gh api graphql -R= -f query=x',
+    ]
+    for (const input of noStrip) {
+      expect(analyzeGhCommand(input)).toEqual({ kind: 'pass-through' })
+    }
   })
 
   it('passes through gh api graphql with no -R (nothing to mint for)', () => {

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -416,8 +416,7 @@ function stripRepoFlagFromCommand(command: string): string {
   while (i < command.length) {
     const ch = command[i] as string
     if (ch === '"' || ch === "'") {
-      const close = command.indexOf(ch, i + 1)
-      const endQuote = close === -1 ? command.length : close
+      const endQuote = findClosingQuote(command, i)
       out += command.slice(i, endQuote + 1)
       i = endQuote + 1
       continue
@@ -436,6 +435,24 @@ function stripRepoFlagFromCommand(command: string): string {
   return out
 }
 
+// Index of the quote that closes the one at `open`. Double quotes honor `\"` as
+// a literal (bash processes backslash escapes inside "..."), so a `-R o/r` buried
+// in a `-f body="{\"x\":\"-R o/r\"}"` value is not mistaken for an unquoted flag.
+// Single quotes take everything literally — no escapes — so the next `'` closes.
+// Unterminated quote returns the last index (strip nothing past it).
+function findClosingQuote(command: string, open: number): number {
+  const quote = command[open]
+  for (let i = open + 1; i < command.length; i++) {
+    const ch = command[i]
+    if (quote === '"' && ch === '\\') {
+      i += 1
+      continue
+    }
+    if (ch === quote) return i
+  }
+  return command.length - 1
+}
+
 // If `command` has an unquoted `-R`/`--repo` repo-flag token starting at `start`
 // (at a word boundary), returns the index just past the flag and its value;
 // otherwise null. Handles `-R o/r`, `--repo o/r`, `-R=o/r`, `--repo=o/r`.
@@ -447,10 +464,16 @@ function matchRepoFlagAt(command: string, start: number): number | null {
     if (!command.startsWith(flag, start)) continue
     let i = start + flag.length
     const sep = command[i]
+    // Both value forms validate the slug before stripping: the flag is only a
+    // repo flag if its value parses as owner/repo. Without this, the `=` form
+    // could strip a non-slug value the detection path would have rejected,
+    // diverging detection from rewrite.
     if (sep === '=') {
-      i += 1
-      while (i < command.length && command[i] !== ' ' && command[i] !== '\t') i += 1
-      return i
+      const valueStart = i + 1
+      let j = valueStart
+      while (j < command.length && command[j] !== ' ' && command[j] !== '\t') j += 1
+      if (!isRepoSlug(command.slice(valueStart, j))) return null
+      return j
     }
     if (sep === ' ' || sep === '\t') {
       let j = i
@@ -496,6 +519,12 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
     if (flagRepo !== null && !pathRepos.includes(flagRepo)) {
       return { kind: 'block', reason: API_REPO_CONFLICT_REASON }
     }
+    // `-R` here is redundant: it matches the repo already named in the literal
+    // path, which is authoritative. `gh api` rejects `-R` outright, so strip the
+    // flag rather than let `gh` fail with "unknown shorthand flag". Distinct from
+    // graphql (no path, -R IS the hint) — here the path mints the token and the
+    // flag is pure noise we remove for syntax.
+    if (flagRepo !== null) return { kind: 'inject', repoSlugs: pathRepos, stripRepoFlag: true }
     return { kind: 'inject', repoSlugs: pathRepos }
   }
 

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -516,15 +516,20 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
   const flagRepo = extractRepoFlag(args)
 
   if (pathRepos.length > 0) {
-    if (flagRepo !== null && !pathRepos.includes(flagRepo)) {
+    // Check EVERY repo flag, not just the first: the strip removes all of them,
+    // so a single non-redundant flag anywhere is a mint-for-X-hit-Y attempt and
+    // must block even when an earlier flag matches the path and would otherwise
+    // mask it.
+    const flagRepos = extractAllRepoFlags(args)
+    if (flagRepos.some((slug) => !pathRepos.includes(slug))) {
       return { kind: 'block', reason: API_REPO_CONFLICT_REASON }
     }
-    // `-R` here is redundant: it matches the repo already named in the literal
-    // path, which is authoritative. `gh api` rejects `-R` outright, so strip the
-    // flag rather than let `gh` fail with "unknown shorthand flag". Distinct from
-    // graphql (no path, -R IS the hint) — here the path mints the token and the
-    // flag is pure noise we remove for syntax.
-    if (flagRepo !== null) return { kind: 'inject', repoSlugs: pathRepos, stripRepoFlag: true }
+    // Every `-R` here is redundant: it matches the repo already named in the
+    // literal path, which is authoritative. `gh api` rejects `-R` outright, so
+    // strip the flag rather than let `gh` fail with "unknown shorthand flag".
+    // Distinct from graphql (no path, -R IS the hint) — here the path mints the
+    // token and the flag is pure noise we remove for syntax.
+    if (flagRepos.length > 0) return { kind: 'inject', repoSlugs: pathRepos, stripRepoFlag: true }
     return { kind: 'inject', repoSlugs: pathRepos }
   }
 
@@ -592,6 +597,29 @@ function extractRepoFlag(args: readonly string[]): string | null {
     }
   }
   return null
+}
+
+// Every valid `-R`/`--repo` slug in `args`, not just the first. The strip removes
+// ALL unquoted repo flags, so the conflict check must see ALL of them: a command
+// like `... -R path/repo -R victim/private` is a mint-for-X-hit-Y attempt where
+// the redundant first flag would otherwise mask the malicious second one.
+function extractAllRepoFlags(args: readonly string[]): string[] {
+  const slugs: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === undefined) continue
+    if (arg === '-R' || arg === '--repo') {
+      const value = args[i + 1]
+      if (value !== undefined && isRepoSlug(value)) slugs.push(value)
+    } else if (arg.startsWith('--repo=')) {
+      const value = arg.slice('--repo='.length)
+      if (isRepoSlug(value)) slugs.push(value)
+    } else if (arg.startsWith('-R=')) {
+      const value = arg.slice('-R='.length)
+      if (isRepoSlug(value)) slugs.push(value)
+    }
+  }
+  return slugs
 }
 
 // `gh api` flags that consume the FOLLOWING token as their value. The endpoint

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -118,6 +118,63 @@ describe('github-cli-auth plugin', () => {
     expect(resolverCalled).toBe(false)
   })
 
+  test('App auth: strips a redundant -R on a literal-path gh api call AND injects the minted token', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('gh api repos/acme/widgets/issues -R acme/widgets')
+
+    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh api repos/acme/widgets/issues')
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
+  })
+
+  test('classic PAT: strips a redundant -R on gh api without minting a token', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event = bashEvent('gh api repos/acme/widgets/issues -R acme/widgets')
+
+    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh api repos/acme/widgets/issues')
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('fine-grained PAT: strips a redundant -R on gh api without minting a token', async () => {
+    process.env.GH_TOKEN = 'github_pat_xyz'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event = bashEvent('gh api repos/acme/widgets/issues --repo=acme/widgets')
+
+    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh api repos/acme/widgets/issues')
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('App auth: blocks a gh api whose -R repo conflicts with the literal path (no strip)', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('gh api repos/victim/private/issues -R acme/widgets')
+
+    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+
+    expect(result).toMatchObject({ block: true })
+    expect(event.args.command).toBe('gh api repos/victim/private/issues -R acme/widgets')
+  })
+
   test('non-gh bash command passes through without touching the resolver', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     let resolverCalled = false

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -46,6 +46,15 @@ export default definePlugin({
       const decision = analyzeGhCommand(command)
       if (decision.kind === 'pass-through') return 'fall-through'
 
+      // The `-R` strip is a pure syntax fix (`gh api` rejects `-R`), independent
+      // of token minting, so apply it for EVERY token class — including the PAT
+      // paths below that return without injecting. Only `inject` decisions carry
+      // `rewrittenCommand`, and only after the single-bare/safe-pipeline gate in
+      // analyzeGhCommand, so this never rewrites a blocked or unsafe shape.
+      if (decision.kind === 'inject' && decision.rewrittenCommand !== undefined) {
+        event.args.command = decision.rewrittenCommand
+      }
+
       const tokenClass = classifyGhToken(process.env.GH_TOKEN)
       // Classic PATs reach every owner; nothing to inject or enforce.
       if (tokenClass === 'cross-owner') return
@@ -63,9 +72,6 @@ export default definePlugin({
       // --setenv by the bash wrapper) so the token never enters the command
       // string, where it could leak through logs or later hooks.
       event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: result.token }
-      // graphql consumed `-R/--repo` as a mint hint; `gh api` rejects it, so
-      // run the command with the flag stripped (token still rides in env).
-      if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
       return
     }
 


### PR DESCRIPTION
## Background

`gh api` does **not** accept the `-R/--repo` flag — it errors with `unknown shorthand flag: 'R' in -R`. But agents reach for `-R owner/repo` reflexively, because it *is* valid on `gh pr`/`gh issue`/`gh repo`, and TypeClaw itself teaches `gh api graphql -R owner/repo` (where the flag is consumed as the multi-owner mint hint and stripped). An agent in a container hit this loop repeatedly:

```
gh api repos/OWNER/REPO/git/ref/heads/... -R OWNER/REPO
  -> unknown shorthand flag: 'R' in -R
```

The mechanism: for a literal `/repos/{owner}/{repo}` endpoint the **path** is the authoritative repo (it's where the request actually goes), so a `-R` that names the *same* repo is pure redundancy. Previously TypeClaw recognized the call as valid but left the redundant `-R` in place, so `gh` still rejected it.

## Summary

Strip the redundant `-R/--repo` when its slug matches the repo already in the literal path, so the command runs instead of erroring.

- **Universal across token classes.** The strip is a pure syntax fix, independent of token minting, so it applies for App, classic PAT, fine-grained PAT, and no-token. It runs *before* the PAT early-returns and is guarded by `kind === 'inject'` — `block` decisions never carry a `rewrittenCommand`, so the placement can't rewrite a blocked or unsafe shape.
- **Why match-only, and why not the mismatch case.** A `-R` that names a *different* repo than the path stays a hard block (`API_REPO_CONFLICT_REASON`) — that's the mint-for-X-hit-Y guard and must surface loudly, never be silently rewritten away.
- **Parser hardening, since the strip now runs on far more commands** (every literal-path `gh api` with a redundant `-R`, including REST calls carrying JSON bodies):
  - `matchRepoFlagAt` now validates the slug for the attached `=` form, matching the space form and the detection path so rewrite can never diverge from detection.
  - `stripRepoFlagFromCommand` quote scanning is now backslash-escape-aware for double quotes, so a `-R owner/repo` buried in a `-f body="{\"...\"}"` value is never mistaken for an unquoted flag.

## What this does NOT do

- Does **not** touch the `{owner}/{repo}` *placeholder* endpoint case. There `-R` is semantic endpoint interpolation, not a redundant flag — different problem, out of scope.
- Does **not** change the mismatch block, the composition/token-leak guards, or any token-injection behavior. No token is ever injected on PAT paths.
- Does **not** add a runtime nudge; the silent rewrite makes the deterministic case Just Work.

## Review notes

- Load-bearing change: `index.ts` `handleGhCommand` — the strip moved to a single central application right after `analyzeGhCommand`, gated by `decision.kind === 'inject'`, ahead of the `cross-owner`/`fine-grained-pat` returns. Invariant to verify: no path that injects `TYPECLAW_INTERNAL_BASH_ENV` was reordered, and `block` still flows after the `cross-owner` return (classic-PAT block behavior unchanged).
- `gh-command.ts` `classifyGhApiSegment`: the matching case gains `stripRepoFlag: true`; the mismatch block directly above is untouched.
- Security-reviewed (incl. an escape-aware quote bug, caught in review and fixed here). Tests cover: all `-R/--repo` flag forms, `-R` before the endpoint, mismatch-still-blocks, non-slug values left verbatim, the escaped-double-quote body case, and per-token-class integration (App injects+strips; both PATs strip without minting).