### PR TITLE
feat(github-cli-auth): block and guide gh api /user under App auth

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
-import { analyzeGhCommand } from './gh-command'
+import { analyzeGhCommand, usesGhApiAuthenticatedUserEndpoint } from './gh-command'
 
 describe('analyzeGhCommand', () => {
   it('passes through commands that do not invoke gh', () => {
@@ -515,5 +515,32 @@ describe('analyzeGhCommand', () => {
     expect(analyzeGhCommand('gh search repos cli')).toEqual({ kind: 'pass-through' })
     expect(analyzeGhCommand('gh gist list')).toEqual({ kind: 'pass-through' })
     expect(analyzeGhCommand('gh codespace list')).toEqual({ kind: 'pass-through' })
+  })
+
+  it('keeps classifying the authenticated-user endpoint as pass-through (block lives in the caller)', () => {
+    expect(analyzeGhCommand('gh api /user')).toEqual({ kind: 'pass-through' })
+    expect(analyzeGhCommand("gh api /user --jq '.login'")).toEqual({ kind: 'pass-through' })
+  })
+})
+
+describe('usesGhApiAuthenticatedUserEndpoint', () => {
+  it('detects the authenticated-user endpoint and its descendants', () => {
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api /user')).toBe(true)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api user')).toBe(true)
+    expect(usesGhApiAuthenticatedUserEndpoint("gh api /user --jq '.login'")).toBe(true)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api /user/emails')).toBe(true)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api user/orgs')).toBe(true)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api -H "Accept: application/json" /user')).toBe(true)
+  })
+
+  it('does not match third-party, meta, or repo endpoints', () => {
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api /users/octocat')).toBe(false)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api /users/octocat/repos')).toBe(false)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api /meta')).toBe(false)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api /rate_limit')).toBe(false)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api graphql -f query=x')).toBe(false)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh api /repos/acme/widgets/issues')).toBe(false)
+    expect(usesGhApiAuthenticatedUserEndpoint('gh pr view -R acme/widgets')).toBe(false)
+    expect(usesGhApiAuthenticatedUserEndpoint('echo gh api /user')).toBe(false)
   })
 })

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test'
 
-import { analyzeGhCommand, usesGhApiAuthenticatedUserEndpoint } from './gh-command'
+import {
+  analyzeGhCommand,
+  effectiveGhTokensForAuthenticatedUserEndpoint,
+  usesGhApiAuthenticatedUserEndpoint,
+} from './gh-command'
 
 describe('analyzeGhCommand', () => {
   it('passes through commands that do not invoke gh', () => {
@@ -542,5 +546,51 @@ describe('usesGhApiAuthenticatedUserEndpoint', () => {
     expect(usesGhApiAuthenticatedUserEndpoint('gh api /repos/acme/widgets/issues')).toBe(false)
     expect(usesGhApiAuthenticatedUserEndpoint('gh pr view -R acme/widgets')).toBe(false)
     expect(usesGhApiAuthenticatedUserEndpoint('echo gh api /user')).toBe(false)
+  })
+})
+
+describe('effectiveGhTokensForAuthenticatedUserEndpoint', () => {
+  it('returns no tokens when no invocation targets /user', () => {
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint('gh api /repos/acme/widgets', {})).toEqual([])
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint('gh api /users/octocat', { GH_TOKEN: 'ghs_x' })).toEqual([])
+  })
+
+  it('falls back to process env when there is no command-local override', () => {
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint('gh api /user', { GH_TOKEN: 'ghs_x' })).toEqual(['ghs_x'])
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint('gh api /user', {})).toEqual([undefined])
+  })
+
+  it('prefers a command-local override over process env', () => {
+    expect(
+      effectiveGhTokensForAuthenticatedUserEndpoint('GH_TOKEN=ghp_local gh api /user', { GH_TOKEN: 'ghs_proc' }),
+    ).toEqual(['ghp_local'])
+  })
+
+  it('strips quotes and keeps a value containing =', () => {
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint("GH_TOKEN='ghp_local' gh api /user", {})).toEqual([
+      'ghp_local',
+    ])
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint("GH_TOKEN='ghp_a=b' gh api /user", {})).toEqual(['ghp_a=b'])
+  })
+
+  it('applies gh precedence: GH_TOKEN beats GITHUB_TOKEN at the same level', () => {
+    // process GH_TOKEN wins over a command-local GITHUB_TOKEN
+    expect(
+      effectiveGhTokensForAuthenticatedUserEndpoint('GITHUB_TOKEN=ghp_local gh api /user', { GH_TOKEN: 'ghs_proc' }),
+    ).toEqual(['ghs_proc'])
+    // command-local GH_TOKEN wins over command-local GITHUB_TOKEN
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint('GH_TOKEN=ghp_a GITHUB_TOKEN=ghp_b gh api /user', {})).toEqual(
+      ['ghp_a'],
+    )
+    // GITHUB_TOKEN used only when no GH_TOKEN anywhere
+    expect(effectiveGhTokensForAuthenticatedUserEndpoint('GITHUB_TOKEN=ghp_local gh api /user', {})).toEqual([
+      'ghp_local',
+    ])
+  })
+
+  it('resolves each /user invocation independently in a compound command', () => {
+    expect(
+      effectiveGhTokensForAuthenticatedUserEndpoint('GH_TOKEN=ghp_a gh api /user && GH_TOKEN=ghs_b gh api /user', {}),
+    ).toEqual(['ghp_a', 'ghs_b'])
   })
 })

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -553,6 +553,29 @@ function isGraphqlEndpoint(args: readonly string[]): boolean {
   return findApiEndpoint(args) === 'graphql'
 }
 
+// True when any `gh api` invocation targets the authenticated-user endpoint
+// (`/user`, `user`, or a `/user/...` descendant). This is a token-CLASS mismatch,
+// not an auth failure: an App installation token is not a user identity, so GitHub
+// rejects `/user` regardless of how valid the token is. The caller blocks-and-
+// guides for App/none classes only (a PAT IS a user identity and works), so this
+// stays a pure shape detector. Narrow by design: `/users/{username}`, `/meta`,
+// `/rate_limit` are not user-identity endpoints and must not match.
+export function usesGhApiAuthenticatedUserEndpoint(command: string): boolean {
+  const tokens = tokenize(command)
+  const ghStarts = findGhInvocations(tokens)
+  for (let i = 0; i < ghStarts.length; i++) {
+    const start = ghStarts[i] as number
+    const end = ghStarts[i + 1] ?? tokens.length
+    const args = tokens.slice(start + 1, end)
+    if (args[0] !== 'api') continue
+    const endpoint = findApiEndpoint(args)
+    if (endpoint === null) continue
+    const normalized = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint
+    if (normalized === 'user' || normalized.startsWith('user/')) return true
+  }
+  return false
+}
+
 function findGhInvocations(tokens: readonly string[]): number[] {
   const starts: number[] = []
   for (let i = 0; i < tokens.length; i++) {

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -553,27 +553,65 @@ function isGraphqlEndpoint(args: readonly string[]): boolean {
   return findApiEndpoint(args) === 'graphql'
 }
 
-// True when any `gh api` invocation targets the authenticated-user endpoint
-// (`/user`, `user`, or a `/user/...` descendant). This is a token-CLASS mismatch,
-// not an auth failure: an App installation token is not a user identity, so GitHub
-// rejects `/user` regardless of how valid the token is. The caller blocks-and-
-// guides for App/none classes only (a PAT IS a user identity and works), so this
-// stays a pure shape detector. Narrow by design: `/users/{username}`, `/meta`,
-// `/rate_limit` are not user-identity endpoints and must not match.
-export function usesGhApiAuthenticatedUserEndpoint(command: string): boolean {
+export type GhAuthEnv = {
+  GH_TOKEN?: string | undefined
+  GITHUB_TOKEN?: string | undefined
+}
+
+const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
+
+// The effective token `gh` would use for EACH `gh api` invocation that targets the
+// authenticated-user endpoint (`/user`, `user`, or a `/user/...` descendant). The
+// caller classifies each: an App installation token is not a user identity, so
+// GitHub rejects `/user` for it (token-CLASS mismatch, not an auth failure) — but a
+// PAT IS a user identity and works, so the guard must respect a command-local
+// `GH_TOKEN=…`/`GITHUB_TOKEN=…` override on that invocation, not just process env.
+// Precedence mirrors gh: local GH_TOKEN > process GH_TOKEN > local GITHUB_TOKEN >
+// process GITHUB_TOKEN. Narrow endpoint scope: `/users/{username}`, `/meta`,
+// `/rate_limit` are not user-identity endpoints and never match.
+export function effectiveGhTokensForAuthenticatedUserEndpoint(
+  command: string,
+  env: GhAuthEnv,
+): Array<string | undefined> {
   const tokens = tokenize(command)
   const ghStarts = findGhInvocations(tokens)
+  const result: Array<string | undefined> = []
   for (let i = 0; i < ghStarts.length; i++) {
     const start = ghStarts[i] as number
     const end = ghStarts[i + 1] ?? tokens.length
-    const args = tokens.slice(start + 1, end)
-    if (args[0] !== 'api') continue
-    const endpoint = findApiEndpoint(args)
-    if (endpoint === null) continue
-    const normalized = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint
-    if (normalized === 'user' || normalized.startsWith('user/')) return true
+    if (!isAuthenticatedUserEndpointArgs(tokens.slice(start + 1, end))) continue
+    result.push(effectiveGhTokenForInvocation(tokens, start, env))
   }
-  return false
+  return result
+}
+
+export function usesGhApiAuthenticatedUserEndpoint(command: string): boolean {
+  return effectiveGhTokensForAuthenticatedUserEndpoint(command, {}).length > 0
+}
+
+function isAuthenticatedUserEndpointArgs(args: readonly string[]): boolean {
+  if (args[0] !== 'api') return false
+  const endpoint = findApiEndpoint(args)
+  if (endpoint === null) return false
+  const normalized = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint
+  return normalized === 'user' || normalized.startsWith('user/')
+}
+
+// Walks the contiguous `VAR=val` assignments immediately before `gh` (the same
+// shape findGhInvocations skips) and applies gh's token precedence over env.
+function effectiveGhTokenForInvocation(tokens: readonly string[], ghStart: number, env: GhAuthEnv): string | undefined {
+  const local: GhAuthEnv = {}
+  for (let i = ghStart - 1; i >= 0 && ENV_ASSIGNMENT_RE.test(tokens[i] as string); i--) {
+    const token = tokens[i] as string
+    const name = token.slice(0, token.indexOf('='))
+    const value = token.slice(token.indexOf('=') + 1)
+    // Iterating right-to-left, so only record the first (leftmost wins on dup).
+    if (name === 'GH_TOKEN' && local.GH_TOKEN === undefined) local.GH_TOKEN = value
+    if (name === 'GITHUB_TOKEN' && local.GITHUB_TOKEN === undefined) local.GITHUB_TOKEN = value
+  }
+  const ghToken = local.GH_TOKEN ?? env.GH_TOKEN
+  if (ghToken !== undefined && ghToken !== '') return ghToken
+  return local.GITHUB_TOKEN ?? env.GITHUB_TOKEN
 }
 
 function findGhInvocations(tokens: readonly string[]): number[] {

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -53,6 +53,8 @@ const unavailableResolver = async (): Promise<GithubTokenResolveResult> => ({
   reason: 'adapter down',
 })
 
+const hookCtx = { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger }
+
 describe('github-cli-auth plugin', () => {
   test('App auth: sets the env overlay with the minted token, leaving the command untouched', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
@@ -207,6 +209,63 @@ describe('github-cli-auth plugin', () => {
     expect(event.args.command).toBe('gh api repos/victim/private/issues -R acme/widgets')
   })
 
+  test('App auth: blocks gh api /user with a guiding reason and does not call the resolver', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+
+    const result = await hook(bashEvent("gh api /user --jq '.login'"), hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    expect((result as { reason: string }).reason).toContain('/user')
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('multi-owner App (no seeded token): blocks gh api /user', async () => {
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    const result = await hook(bashEvent('gh api /user'), hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+  })
+
+  test('classic PAT: gh api /user passes through (user identity works)', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('gh api /user')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh api /user')
+  })
+
+  test('fine-grained PAT: gh api /user passes through (user identity works)', async () => {
+    process.env.GH_TOKEN = 'github_pat_xyz'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('gh api /user')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh api /user')
+  })
+
+  test('App auth: gh api /users/octocat (third-party) is not blocked', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('gh api /users/octocat')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh api /users/octocat')
+  })
+
   test('non-gh bash command passes through without touching the resolver', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     let resolverCalled = false
@@ -235,8 +294,6 @@ describe('github-cli-auth plugin', () => {
     expect(result).toBeUndefined()
   })
 })
-
-const hookCtx = { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger }
 
 describe('github-cli-auth plugin — git path', () => {
   const askpassDir = mkdtempSync(join(tmpdir(), 'typeclaw-askpass-it-'))

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -14,10 +14,13 @@ import githubCliAuthPlugin from './index'
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
 
 const originalToken = process.env.GH_TOKEN
+const originalGithubToken = process.env.GITHUB_TOKEN
 
 afterEach(() => {
   if (originalToken === undefined) delete process.env.GH_TOKEN
   else process.env.GH_TOKEN = originalToken
+  if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN
+  else process.env.GITHUB_TOKEN = originalGithubToken
 })
 
 function pluginContext(
@@ -264,6 +267,73 @@ describe('github-cli-auth plugin', () => {
 
     expect(result).toBeUndefined()
     expect(event.args.command).toBe('gh api /users/octocat')
+  })
+
+  test('App process token + command-local classic PAT: gh api /user is NOT blocked', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('GH_TOKEN=ghp_classic gh api /user')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('GH_TOKEN=ghp_classic gh api /user')
+  })
+
+  test('App process token + command-local fine-grained PAT: gh api /user is NOT blocked', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('GH_TOKEN=github_pat_xyz gh api /user')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+  })
+
+  test('App process token + quoted command-local PAT: gh api /user is NOT blocked', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    const result = await hook(bashEvent("GH_TOKEN='ghp_classic' gh api /user"), hookCtx)
+
+    expect(result).toBeUndefined()
+  })
+
+  test('command-local App token: gh api /user IS blocked', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    const result = await hook(bashEvent('GH_TOKEN=ghs_child gh api /user'), hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+  })
+
+  test('command-local GITHUB_TOKEN PAT (no GH_TOKEN): gh api /user is NOT blocked', async () => {
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    const result = await hook(bashEvent('GITHUB_TOKEN=ghp_classic gh api /user'), hookCtx)
+
+    expect(result).toBeUndefined()
+  })
+
+  test('process GH_TOKEN (App) beats command-local GITHUB_TOKEN PAT: gh api /user IS blocked', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    const result = await hook(bashEvent('GITHUB_TOKEN=ghp_classic gh api /user'), hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+  })
+
+  test('process GITHUB_TOKEN PAT (no GH_TOKEN): gh api /user is NOT blocked', async () => {
+    delete process.env.GH_TOKEN
+    process.env.GITHUB_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    const result = await hook(bashEvent('gh api /user'), hookCtx)
+
+    expect(result).toBeUndefined()
   })
 
   test('non-gh bash command passes through without touching the resolver', async () => {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -3,7 +3,7 @@ import { definePlugin } from '@/plugin'
 
 import { createApproveIdempotencyGuard } from './approve-idempotency'
 import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
-import { analyzeGhCommand, usesGhApiAuthenticatedUserEndpoint } from './gh-command'
+import { analyzeGhCommand, effectiveGhTokensForAuthenticatedUserEndpoint } from './gh-command'
 import { ensureGitAskPassHelper } from './git-askpass'
 import { analyzeGitCommand, defaultGitResolvers } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
@@ -58,14 +58,16 @@ export default definePlugin({
       const decision = analyzeGhCommand(command)
 
       // `/user` classifies as pass-through (no repo to mint for), so this block
-      // must run BEFORE the pass-through return. shouldMintAppToken is the App-auth
-      // signal — true for an App-class token OR a live minter (multi-owner / no-repos
-      // App configs never seed GH_TOKEN yet can mint). PATs carry a user identity, so
-      // `/user` works for them and shouldMintAppToken returns false: not blocked.
-      if (
-        shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver()) &&
-        usesGhApiAuthenticatedUserEndpoint(command)
-      ) {
+      // must run BEFORE the pass-through return. Resolve the EFFECTIVE token per
+      // `/user` invocation (a command-local `GH_TOKEN=…`/`GITHUB_TOKEN=…` overrides
+      // process env, matching gh) and block only when that token is App / none-with-
+      // minter — a command-local PAT override carries a user identity, so `/user`
+      // works for it and must not be blocked.
+      const userEndpointTokens = effectiveGhTokensForAuthenticatedUserEndpoint(command, {
+        GH_TOKEN: process.env.GH_TOKEN,
+        GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      })
+      if (userEndpointTokens.some((token) => shouldMintAppToken(token, hasAppTokenResolver()))) {
         return { block: true, reason: appUserEndpointReason }
       }
 

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -3,7 +3,7 @@ import { definePlugin } from '@/plugin'
 
 import { createApproveIdempotencyGuard } from './approve-idempotency'
 import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
-import { analyzeGhCommand } from './gh-command'
+import { analyzeGhCommand, usesGhApiAuthenticatedUserEndpoint } from './gh-command'
 import { ensureGitAskPassHelper } from './git-askpass'
 import { analyzeGitCommand, defaultGitResolvers } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
@@ -14,6 +14,17 @@ export default definePlugin({
   plugin: async (ctx) => {
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
     const hasAppTokenResolver = ctx.github.hasAppTokenResolver
+    // `/user` resolves the caller's USER identity. An App installation token is not
+    // a user, so GitHub rejects it on a token-class basis (403, or no-token error in
+    // the sandbox) no matter how valid the token is. We block-and-guide so the agent
+    // does not misread this as "I have no auth" — it does, for repo-scoped calls.
+    const appUserEndpointReason =
+      '`gh api /user` (and `/user/...`) resolves the calling USER. This agent authenticates ' +
+      'as a GitHub App with a per-repo installation token, which is not a user identity — so ' +
+      '`/user` cannot work here, and this failure is NOT a sign that auth is missing (repo-' +
+      'scoped calls still work). It is not a valid auth/login check. For repo data use ' +
+      '`gh <cmd> -R owner/repo` or `gh api /repos/owner/repo/...`; for the actor, read the ' +
+      'PR/issue/comment context you were given instead of `gh api /user`.'
     const resolveToken = async (workspace: string) => {
       const result = await resolveTokenForRepo(workspace)
       return result.kind === 'token' ? result.token : null
@@ -45,6 +56,19 @@ export default definePlugin({
       if (review.dump !== null) return review.dump
 
       const decision = analyzeGhCommand(command)
+
+      // `/user` classifies as pass-through (no repo to mint for), so this block
+      // must run BEFORE the pass-through return. shouldMintAppToken is the App-auth
+      // signal — true for an App-class token OR a live minter (multi-owner / no-repos
+      // App configs never seed GH_TOKEN yet can mint). PATs carry a user identity, so
+      // `/user` works for them and shouldMintAppToken returns false: not blocked.
+      if (
+        shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver()) &&
+        usesGhApiAuthenticatedUserEndpoint(command)
+      ) {
+        return { block: true, reason: appUserEndpointReason }
+      }
+
       if (decision.kind === 'pass-through') return 'fall-through'
 
       // The `-R` strip is a pure syntax fix (`gh api` rejects `-R`), independent


### PR DESCRIPTION
## Background

A PR-review agent running under GitHub App auth ran `gh api /user --jq '.login'` as a self-identity check. It got an error (`Resource not accessible by integration`, or in the bwrap sandbox a "set GH_TOKEN" message), misread it as "I have no auth at all", and aborted the review — even though a `gh pr view -R owner/repo` call had succeeded moments earlier. The agent posted a comment claiming it couldn't access the diff due to missing GitHub CLI auth.

## Summary

`gh api /user` resolves the **calling user's** identity. A GitHub App installation token is not a user identity — GitHub rejects `/user` on a **token-class** basis regardless of whether the token is valid. This is not an auth failure. It is not a regression of the `git` token-mint path added in #733; it predates that PR and is inherent to the per-repo App-token minting model.

**Root cause:** the `gh api` pass-through path in `index.ts` had no guard for the identity-model mismatch, so the App token was forwarded to an endpoint the token class can never satisfy.

**Fix:** two touch points in `src/bundled-plugins/github-cli-auth/`.

`gh-command.ts` — new exported pure helper `usesGhApiAuthenticatedUserEndpoint(command)`: detects `gh api /user`, `gh api user`, and any `gh api /user/...` descendant across every `gh` invocation in the command string. Narrow by design: `/users/{username}`, `/meta`, `/rate_limit`, `graphql`, and repo endpoints do not match. No token-class policy here — it is a pure shape detector.

`index.ts` — token-class-scoped hard block in `tool.before`, gated on `tokenClass === 'app' || tokenClass === 'none'` only. A classic or fine-grained PAT is a real user identity and works, so those pass through untouched. `none` covers the multi-owner App case where `GH_TOKEN` is intentionally unseeded. The block returns a guiding reason string that tells the agent this is **not** a missing-auth signal (repo-scoped calls still work) and points to `-R owner/repo` / `/repos/owner/repo/...` and the PR/issue/comment context for the actor identity.

The block lives in `index.ts`, not in the classifier. Moving it into the classifier would surface it before the fine-grained-PAT early-return and wrongly block `/user` for PAT users, who have a valid user identity.

## What this does NOT do

- Does not affect classic or fine-grained PAT auth — `/user` passes through for both.
- Does not match `/users/{username}`, `/meta`, `/rate_limit`, `graphql`, or any repo endpoint — only the authenticated-user family.
- Does not change the `git` token-mint path or any other plugin.
- Does not change behavior when the agent uses repo-scoped `gh` commands.

## Review notes

**Load-bearing invariant:** the `tokenClass` check must precede the `usesGhApiAuthenticatedUserEndpoint` call for correctness, and both must remain downstream of `analyzeGhCommand` (which handles compound-command blocks and the `pass-through` early-return that exits before the mint path). The existing `tool.before` ordering is preserved; this guard was inserted at the App-token decision point, after `analyzeGhCommand` returns and before `resolveToken` is called.

**Test coverage (`gh-command.test.ts`):** true cases — `gh api /user`, `gh api user`, `gh api /user/emails`, `gh api user/orgs`, with a `-H` header flag; false cases — `/users/octocat`, `/users/octocat/repos`, `/meta`, `/rate_limit`, `graphql`, repo endpoints, `echo gh api /user`. Plus a test asserting `analyzeGhCommand` still returns `pass-through` for `/user` (the block lives in the caller, not the classifier).

**Test coverage (`index.test.ts`):** App seeded token blocks `/user` with a guiding reason and does not call the resolver; multi-owner App (no seeded token) blocks; classic PAT passes through; fine-grained PAT passes through; App + `/users/octocat` is not blocked.

Checks: typecheck clean, lint 0 errors (66 pre-existing warnings, none in changed files), format:check clean, test 8163 pass / 0 fail.