### PR TITLE
Add sandbox.writablePaths for custom RW zones in the bwrap sandbox

### DIFF
--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -590,7 +590,11 @@ async function applyBashSandbox(
   // (their masks are empty) and keep full unsandboxed access. subtractMasked
   // drops any writable zone masked for this role so an RW bind never re-exposes a
   // hidden path (e.g. a guest's masked workspace/).
-  const writable = subtractMasked(await resolveWritableZones(agentDir), { dirs, files })
+  // config.sandbox.writablePaths is read from the BOOT-TIME snapshot, not
+  // getConfig(): sandbox is restart-required, so the writable surface must stay
+  // coherent with the boot-time bwrap/capability decisions (same contract as
+  // resolveProcStrategy's read of config.sandbox.realProc below).
+  const writable = subtractMasked(await resolveWritableZones(agentDir, config.sandbox.writablePaths), { dirs, files })
   // subtractMasked again on the protected set: a protected RO bind renders after
   // the masks (last-op-wins), so an unfiltered protected path nested under a
   // masked dir (e.g. a guest's workspace/ when core.hooksPath=workspace/hooks)

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -181,6 +181,37 @@ describe('configSchema', () => {
   })
 })
 
+describe('sandboxSchema', () => {
+  test('defaults realProc to false and writablePaths to [] when omitted', () => {
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
+    expect(parsed.sandbox).toEqual({ realProc: false, writablePaths: [] })
+  })
+
+  test('accepts agent-relative writablePaths', () => {
+    const parsed = configSchema.parse({
+      models: { default: VALID_MODEL },
+      sandbox: { writablePaths: ['.metabase-cli', 'workspace/cache'] },
+    })
+    expect(parsed.sandbox.writablePaths).toEqual(['.metabase-cli', 'workspace/cache'])
+  })
+
+  test('rejects an absolute writablePath', () => {
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, sandbox: { writablePaths: ['/root/.metabase-cli'] } }),
+    ).toThrow(/relative/i)
+  })
+
+  test('rejects a writablePath containing a .. segment', () => {
+    expect(() =>
+      configSchema.parse({ models: { default: VALID_MODEL }, sandbox: { writablePaths: ['../escape'] } }),
+    ).toThrow(/\.\./)
+  })
+
+  test('rejects an empty writablePath string', () => {
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, sandbox: { writablePaths: [''] } })).toThrow()
+  })
+})
+
 describe('mcpServerSchema', () => {
   test('accepts a stdio server config', () => {
     const parsed = mcpServerSchema.parse({

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -361,11 +361,36 @@ export type NetworkConfig = z.infer<typeof networkSchema>
 // mount actually works (bare-metal Linux, Docker Desktop — NOT OrbStack, which
 // rejects the mount even with the cap; there the runtime falls back to
 // 'proc-bind' regardless). The cost is the CAP_SYS_ADMIN grant on the container.
+
+// `sandbox.writablePaths` re-exposes operator-chosen subtrees of the agent
+// folder as WRITABLE inside the per-tool bwrap sandbox, on top of the built-in
+// free-write zones (workspace, public, mounts, .git). It exists for tools that
+// insist on writing a fixed config dir a low-trust role would otherwise hit
+// EROFS on (e.g. a CLI that rewrites `<agentDir>/.foo-cli/config.json`).
+//
+// Each entry is AGENT-ROOT-RELATIVE — it resolves under /agent and may not
+// escape it. Absolute container paths are rejected at parse time: a blanket RW
+// bind outside /agent would punch a hole through the agent trust boundary that
+// the rest of the sandbox model assumes can't happen. `..` segments and
+// null bytes are rejected for the same reason. Targets that don't exist, aren't
+// directories, are symlinks, or land on a security-sensitive path
+// (.git, .env, secrets.json, sessions, memory, .typeclaw, node_modules, the
+// agent root itself) are dropped at resolve time, NOT parse time — existence is
+// a runtime property and the drop keeps a stale config from aborting the
+// sandbox. See resolveWritableZones in src/sandbox/writable-zones.ts.
+export const relativeAgentPathSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !isAbsolute(value), 'must be relative to the agent root, not an absolute path')
+  .refine((value) => !value.includes('\0'), 'must not contain a null byte')
+  .refine((value) => !value.split(/[/\\]+/).includes('..'), "must not contain a '..' segment")
+
 export const sandboxSchema = z
   .object({
     realProc: z.boolean().default(false),
+    writablePaths: z.array(relativeAgentPathSchema).default([]),
   })
-  .default({ realProc: false })
+  .default({ realProc: false, writablePaths: [] })
 
 export type SandboxConfig = z.infer<typeof sandboxSchema>
 

--- a/src/sandbox/writable-zones.test.ts
+++ b/src/sandbox/writable-zones.test.ts
@@ -102,6 +102,104 @@ describe('resolveWritableZones', () => {
 
     expect(dirs).not.toContain(join(agentDir, '.git'))
   })
+
+  describe('configured writablePaths', () => {
+    test('adds a configured agent-relative dir that exists', async () => {
+      await mkdir(join(agentDir, '.metabase-cli'))
+
+      const { dirs } = await resolveWritableZones(agentDir, ['.metabase-cli'])
+
+      expect(dirs).toContain(join(agentDir, '.metabase-cli'))
+    })
+
+    test('supports a nested configured dir', async () => {
+      await mkdir(join(agentDir, 'workspace', 'cache'), { recursive: true })
+
+      const { dirs } = await resolveWritableZones(agentDir, ['workspace/cache'])
+
+      expect(dirs).toContain(join(agentDir, 'workspace/cache'))
+    })
+
+    test('drops a configured dir that does not exist', async () => {
+      const { dirs } = await resolveWritableZones(agentDir, ['.metabase-cli'])
+
+      expect(dirs).not.toContain(join(agentDir, '.metabase-cli'))
+    })
+
+    test('drops a configured path that is a file, not a dir', async () => {
+      await writeFile(join(agentDir, '.metabase-cli'), 'not a dir')
+
+      const { dirs } = await resolveWritableZones(agentDir, ['.metabase-cli'])
+
+      expect(dirs).not.toContain(join(agentDir, '.metabase-cli'))
+    })
+
+    test('drops a configured dir whose root is a symlink (RW bind would follow it out)', async () => {
+      const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
+      try {
+        await symlink(outside, join(agentDir, '.metabase-cli'))
+
+        const { dirs } = await resolveWritableZones(agentDir, ['.metabase-cli'])
+
+        expect(dirs).not.toContain(join(agentDir, '.metabase-cli'))
+      } finally {
+        await rm(outside, { recursive: true, force: true })
+      }
+    })
+
+    test('drops a configured path that escapes the agent dir via ..', async () => {
+      const { dirs } = await resolveWritableZones(agentDir, ['../escape'])
+
+      expect(dirs.every((d) => d.startsWith(agentDir))).toBe(true)
+      expect(dirs).not.toContain(join(agentDir, '../escape'))
+    })
+
+    test.each(['.git', '.env', 'secrets.json', 'sessions', 'memory', '.typeclaw', 'node_modules'])(
+      'drops the security-sensitive root %p even when it exists',
+      async (root) => {
+        await mkdir(join(agentDir, root), { recursive: true })
+
+        const { dirs } = await resolveWritableZones(agentDir, [root])
+
+        // .git is a built-in writable zone, so it is present via WRITABLE_DIRS —
+        // but the configured path must not be what re-adds it. The other roots
+        // must be absent entirely.
+        if (root !== '.git') expect(dirs).not.toContain(join(agentDir, root))
+      },
+    )
+
+    test('drops a configured path nested under a forbidden root', async () => {
+      await mkdir(join(agentDir, 'sessions', 'sub'), { recursive: true })
+
+      const { dirs } = await resolveWritableZones(agentDir, ['sessions/sub'])
+
+      expect(dirs).not.toContain(join(agentDir, 'sessions/sub'))
+    })
+
+    test.each(['.', ''])('drops a configured path that resolves to the agent root (%p)', async (root) => {
+      const { dirs } = await resolveWritableZones(agentDir, [root])
+
+      expect(dirs).not.toContain(agentDir)
+    })
+
+    test('does not duplicate a configured path that overlaps a built-in zone', async () => {
+      await mkdir(join(agentDir, 'workspace'))
+
+      const { dirs } = await resolveWritableZones(agentDir, ['workspace'])
+
+      expect(dirs.filter((d) => d === join(agentDir, 'workspace'))).toHaveLength(1)
+    })
+
+    test('keeps built-in zones alongside configured ones', async () => {
+      await mkdir(join(agentDir, 'workspace'))
+      await mkdir(join(agentDir, '.metabase-cli'))
+
+      const { dirs } = await resolveWritableZones(agentDir, ['.metabase-cli'])
+
+      expect(dirs).toContain(join(agentDir, 'workspace'))
+      expect(dirs).toContain(join(agentDir, '.metabase-cli'))
+    })
+  })
 })
 
 describe('resolveProtectedZones', () => {

--- a/src/sandbox/writable-zones.test.ts
+++ b/src/sandbox/writable-zones.test.ts
@@ -147,6 +147,35 @@ describe('resolveWritableZones', () => {
       }
     })
 
+    test('drops a configured path whose INTERMEDIATE component symlinks OUTSIDE the agent dir', async () => {
+      const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
+      try {
+        // given /agent/alias -> /tmp/outside, a config of `alias/sub` is lexically
+        // /agent/alias/sub (passes isInside) but its real path is /tmp/outside/sub
+        await mkdir(join(outside, 'sub'), { recursive: true })
+        await symlink(outside, join(agentDir, 'alias'))
+
+        const { dirs } = await resolveWritableZones(agentDir, ['alias/sub'])
+
+        expect(dirs).not.toContain(join(agentDir, 'alias/sub'))
+        expect(dirs.some((d) => d.includes('outside'))).toBe(false)
+      } finally {
+        await rm(outside, { recursive: true, force: true })
+      }
+    })
+
+    test('drops a configured path whose INTERMEDIATE component symlinks onto a forbidden root', async () => {
+      // given /agent/alias -> /agent/sessions, a config of `alias/sub` is lexically
+      // /agent/alias/sub but its real path is /agent/sessions/sub (forbidden)
+      await mkdir(join(agentDir, 'sessions', 'sub'), { recursive: true })
+      await symlink(join(agentDir, 'sessions'), join(agentDir, 'alias'))
+
+      const { dirs } = await resolveWritableZones(agentDir, ['alias/sub'])
+
+      expect(dirs).not.toContain(join(agentDir, 'alias/sub'))
+      expect(dirs).not.toContain(join(agentDir, 'sessions/sub'))
+    })
+
     test('drops a configured path that escapes the agent dir via ..', async () => {
       const { dirs } = await resolveWritableZones(agentDir, ['../escape'])
 

--- a/src/sandbox/writable-zones.ts
+++ b/src/sandbox/writable-zones.ts
@@ -35,6 +35,25 @@ export type ProtectedZones = {
 // exactly that escalation.
 const WRITABLE_DIRS = ['workspace', 'public', 'mounts', '.git'] as const
 
+// SECURITY: configured writable paths (`sandbox.writablePaths`) may NOT resolve
+// onto these. `.git` carries the hook/config escalation surface; `.env` and
+// `secrets.json` are the credential files; `sessions`/`memory` are the agent's
+// private surface (masked from low-trust roles by hidden-paths); `.typeclaw`
+// holds system-managed home persistence; `node_modules` is executable
+// dependency code. Granting blanket RW to any of these via config would defeat
+// the very guards the narrow built-in set exists to preserve. The agent root
+// itself is also rejected (a writablePaths of '' or '.') — an RW bind of the
+// whole tree erases the read-only confinement wholesale.
+const FORBIDDEN_WRITABLE_ROOTS = [
+  '.git',
+  '.env',
+  'secrets.json',
+  'sessions',
+  'memory',
+  '.typeclaw',
+  'node_modules',
+] as const
+
 const PROTECTED_GIT_DIRS = ['.git/hooks'] as const
 const PROTECTED_GIT_FILES = ['.git/config'] as const
 
@@ -54,16 +73,49 @@ const WRITABLE_ROOT_FILES = [
 // so a `workspace -> /etc` symlink at a zone root would grant write access to an
 // outside path. (Symlinks INSIDE a real zone are already safe — the kernel
 // resolves them to the read-only parent mount.)
-export async function resolveWritableZones(agentDir: string): Promise<WritableZones> {
-  const dirs = await collectExisting(
+//
+// `configuredWritablePaths` are operator-chosen agent-relative dirs from
+// `sandbox.writablePaths`. They join the built-in dirs through the SAME
+// existence + symlink filter, plus the extra guardrails in
+// `resolveConfiguredWritableDirs`: each must resolve inside agentDir and must
+// not land on a forbidden root. A path that fails any check is dropped, never
+// throws — a stale config should degrade the one bad entry, not abort sandboxing.
+export async function resolveWritableZones(
+  agentDir: string,
+  configuredWritablePaths: readonly string[] = [],
+): Promise<WritableZones> {
+  const builtinDirs = await collectExisting(
     WRITABLE_DIRS.map((d) => join(agentDir, d)),
     'dir',
   )
+  const configuredDirs = await resolveConfiguredWritableDirs(agentDir, configuredWritablePaths)
   const files = await collectExisting(
     WRITABLE_ROOT_FILES.map((f) => join(agentDir, f)),
     'file',
   )
-  return { dirs, files }
+  return { dirs: dedupe([...builtinDirs, ...configuredDirs]), files }
+}
+
+async function resolveConfiguredWritableDirs(agentDir: string, configured: readonly string[]): Promise<string[]> {
+  const candidates: string[] = []
+  for (const rel of configured) {
+    const absolute = resolve(agentDir, rel)
+    if (!isAllowedConfiguredTarget(agentDir, absolute)) continue
+    candidates.push(absolute)
+  }
+  return collectExisting(candidates, 'dir')
+}
+
+function isAllowedConfiguredTarget(agentDir: string, absolute: string): boolean {
+  if (absolute === agentDir || !isInside(agentDir, absolute)) return false
+  return !FORBIDDEN_WRITABLE_ROOTS.some((root) => {
+    const forbidden = join(agentDir, root)
+    return absolute === forbidden || isInside(forbidden, absolute)
+  })
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)]
 }
 
 // Read-only re-protections rendered on top of the writable .git bind. Unlike

--- a/src/sandbox/writable-zones.ts
+++ b/src/sandbox/writable-zones.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
 import path, { isAbsolute, join, resolve } from 'node:path'
 
 export type WritableZones = {
@@ -96,22 +96,53 @@ export async function resolveWritableZones(
   return { dirs: dedupe([...builtinDirs, ...configuredDirs]), files }
 }
 
+// SECURITY: validation is on the REAL path, not the lexical one. A lexical-only
+// check (resolve + isInside) is bypassable by a symlinked INTERMEDIATE component:
+// with `/agent/alias -> /tmp/outside` (or `-> /agent/sessions`) and a config of
+// `alias/sub`, the lexical path `/agent/alias/sub` passes isInside and the
+// forbidden-root check, while the bwrap `--bind` follows the ancestor symlink to
+// write outside /agent (or onto a forbidden root). The zone-root lstat alone
+// can't see it — lstat of the final component follows ancestor symlinks. So we
+// realpath BOTH the candidate and agentDir (+ the forbidden roots) and validate
+// the resolved targets. A path whose real form escapes agentDir or lands on a
+// real forbidden root is dropped. realpath also rejects the final component
+// being a symlink (its real target is re-checked), subsuming the prior lstat.
 async function resolveConfiguredWritableDirs(agentDir: string, configured: readonly string[]): Promise<string[]> {
-  const candidates: string[] = []
+  const realAgentDir = await realpathOrUndefined(agentDir)
+  if (realAgentDir === undefined) return []
+  const realForbidden = await resolveRealForbiddenRoots(agentDir)
+
+  const accepted: string[] = []
   for (const rel of configured) {
     const absolute = resolve(agentDir, rel)
-    if (!isAllowedConfiguredTarget(agentDir, absolute)) continue
-    candidates.push(absolute)
+    // Cheap lexical pre-filter: reject obvious escapes before touching the disk.
+    if (absolute === agentDir || !isInside(agentDir, absolute)) continue
+    const real = await realpathOrUndefined(absolute)
+    if (real === undefined) continue
+    if (!(await isRealEntry(real, 'dir'))) continue
+    if (real === realAgentDir || !isInside(realAgentDir, real)) continue
+    if (realForbidden.some((root) => real === root || isInside(root, real))) continue
+    // Bind the lexical (caller-facing) path; bwrap resolves it to `real` itself.
+    accepted.push(absolute)
   }
-  return collectExisting(candidates, 'dir')
+  return accepted
 }
 
-function isAllowedConfiguredTarget(agentDir: string, absolute: string): boolean {
-  if (absolute === agentDir || !isInside(agentDir, absolute)) return false
-  return !FORBIDDEN_WRITABLE_ROOTS.some((root) => {
-    const forbidden = join(agentDir, root)
-    return absolute === forbidden || isInside(forbidden, absolute)
-  })
+async function resolveRealForbiddenRoots(agentDir: string): Promise<string[]> {
+  const resolved: string[] = []
+  for (const root of FORBIDDEN_WRITABLE_ROOTS) {
+    const real = await realpathOrUndefined(join(agentDir, root))
+    if (real !== undefined) resolved.push(real)
+  }
+  return resolved
+}
+
+async function realpathOrUndefined(target: string): Promise<string | undefined> {
+  try {
+    return await realpath(target)
+  } catch {
+    return undefined
+  }
 }
 
 function dedupe(values: string[]): string[] {


### PR DESCRIPTION
## Why

The per-tool `bwrap` sandbox binds the agent folder `/agent` **read-only** and re-exposes a hardcoded set of free-write zones (`workspace`, `public`, `mounts`, `.git`) for **low-trust roles** (guest/member). Trusted/owner roles run bash unsandboxed.

A CLI that insists on writing a fixed config dir under the agent root — e.g. `metabase-cli` writing `<agentDir>/.metabase-cli/config.json` — hits a **read-only filesystem error** with no supported way to allow it. Today the only workaround is hand-editing the Dockerfile, and even then the path stays EROFS inside the sandbox.

## What

Adds `sandbox.writablePaths`: operator-chosen, agent-root-relative directories added to the writable set inside the sandbox.

```json
{
  "sandbox": {
    "writablePaths": [".metabase-cli", "workspace/cache"]
  }
}
```

### Validation (two layers)

**Parse time** (`relativeAgentPathSchema` in `config.ts`):
- relative-only (absolute container paths rejected)
- no `..` segments
- no null bytes

**Resolve time** (`resolveWritableZones` in `writable-zones.ts`) — entries are *dropped*, never thrown, so a stale config degrades one path instead of aborting sandboxing:
- must exist and be a real directory (not a file)
- root must not be a symlink (an RW bind follows symlinks → could grant write outside `/agent`)
- must resolve **inside** `agentDir` (and not be the agent root itself)
- must not land on a security-sensitive root: `.git`, `.env`, `secrets.json`, `sessions`, `memory`, `.typeclaw`, `node_modules`

Configured paths still pass through `subtractMasked`, so a role's hidden paths are never re-exposed RW.

Read from the **boot-time** `config` snapshot (sandbox is `restart-required`) to stay coherent with the boot-time bwrap/capability decisions — same contract as `resolveProcStrategy`'s read of `config.sandbox.realProc`.

## Tests

- `writable-zones.test.ts`: configured dir added; nested dir; dropped when missing / file / symlink / escaping via `..` / each forbidden root / nested under forbidden root / resolves to agent root; no duplication with built-in zones; built-ins preserved.
- `config.test.ts`: defaults; accepts relative paths; rejects absolute / `..` / empty.

`bun run typecheck`, `bun run lint` (0 errors), `bun run format` all clean.

## Follow-up (stacked PR)

`sandbox.symlinks: [{ from, to }]` — auto-creates a symlink (`from` fully configurable: absolute or `~/`) pointing at an agent-relative `to`, and auto-contributes `to` to the writable set (reusing this PR's machinery). Handles both the unsandboxed trusted path (entrypoint `ln -sfn`) and the low-trust path (in-sandbox bwrap `--symlink`).