### PR TITLE
Nudge when a terminal reply promises to continue without continue:true

### DIFF
--- a/src/channels/continuation-willingness.test.ts
+++ b/src/channels/continuation-willingness.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+
+import { detectContinuationWillingness } from './continuation-willingness'
+
+describe('detectContinuationWillingness — positive (self-directed future intent)', () => {
+  const willing: readonly string[] = [
+    "I'll continue now.",
+    "I'll keep checking the diff.",
+    "I'll take a look at the rest.",
+    'let me check the other files',
+    'Let me verify that real quick',
+    'On it now — checking the logs',
+    'working on it now, one sec',
+    'give me a moment',
+    '죄송합니다. 바로 계속 확인하겠습니다.',
+    '바로 확인해볼게요',
+    '이어서 확인하겠습니다',
+    '계속 진행할게요',
+    '계속하겠습니다',
+    '나머지도 살펴볼게요',
+    '잠시만요, 확인 중이에요',
+    '바로 `gh`로 확인할게요',
+  ]
+
+  for (const text of willing) {
+    test(`detects: ${JSON.stringify(text)}`, () => {
+      expect(detectContinuationWillingness(text)).toBe(true)
+    })
+  }
+})
+
+describe('detectContinuationWillingness — negative (final / descriptive / other-directed)', () => {
+  const notWilling: readonly string[] = [
+    'Done. The diff looks good, no issues.',
+    'I checked and it is fine.',
+    'You can continue with the merge.',
+    'Looks good to me, approving.',
+    'ok',
+    'done',
+    '네',
+    '확인 결과 문제 없습니다.',
+    '계속 진행하세요.',
+    '이대로 진행하셔도 됩니다.',
+    '리뷰 완료했습니다. 승인합니다.',
+    '',
+    '...',
+  ]
+
+  for (const text of notWilling) {
+    test(`ignores: ${JSON.stringify(text)}`, () => {
+      expect(detectContinuationWillingness(text)).toBe(false)
+    })
+  }
+})

--- a/src/channels/continuation-willingness.ts
+++ b/src/channels/continuation-willingness.ts
@@ -1,0 +1,98 @@
+// A channel turn ends after a successful `channel_reply` (the terminal-reply
+// abort in router.ts). When the model's reply PROMISES to keep working this
+// turn ("바로 확인해볼게요", "let me check", "I'll continue now") but it forgot
+// to set `channel_reply({ continue: true })`, the turn aborts and the promised
+// follow-up never runs. The router uses this detector to inject ONE bounded
+// reminder nudge so the model gets a second chance. See the empty-turn retry
+// (router.ts) for the sibling mechanism this mirrors.
+//
+// Design bias: PREFER FALSE NEGATIVES. A miss leaves the status quo (turn ends,
+// recoverable by a later user message); a false positive costs one wasted
+// reminder-only turn that the model ends with NO_REPLY. So the phrase tables are
+// deliberately narrow — only self-directed FUTURE intent to act THIS turn, never
+// descriptive ("I checked and it's fine") or other-directed ("you can continue")
+// usage. This is a HINT, not a control-flow authority: the abort still fires
+// regardless; only the optional nudge is gated on it.
+
+// Strip markdown emphasis/code fences before matching so an inline `gh` span
+// inside "바로 `gh`로 확인할게요" does not split the phrase.
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[`*_~]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+// Self-directed future-intent phrases. Each asserts the SPEAKER will do more
+// work imminently. The leading "i" / "let me" anchors self-direction so
+// "you can continue" never matches.
+const EN_PHRASES: readonly string[] = [
+  "i'll continue",
+  'i will continue',
+  "i'll keep going",
+  "i'll keep checking",
+  "i'll keep looking",
+  "i'll take a look",
+  "i'll check",
+  "i'll look into",
+  "i'll dig in",
+  "i'll go ahead and",
+  'let me check',
+  'let me look',
+  'let me take a look',
+  'let me dig',
+  'let me continue',
+  'let me verify',
+  'checking now',
+  'looking into it now',
+  'working on it now',
+  'on it now',
+  'give me a moment',
+  'give me a sec',
+]
+
+// Korean: -ㄹ게요 / -겠습니다 future-volitional endings on check/look/continue/
+// proceed verbs. These endings are first-person volitional in Korean — they
+// cannot address the listener, so they are safe self-direction anchors that
+// descriptive or other-directed sentences do not produce. Bare "계속" is
+// excluded ("계속 진행하세요" = "you go ahead", terminal).
+const KO_PHRASES: readonly string[] = [
+  '확인해볼게요',
+  '확인해 볼게요',
+  '확인할게요',
+  '확인하겠습니다',
+  '확인해보겠습니다',
+  '확인해 보겠습니다',
+  '다시 확인하겠습니다',
+  '다시 확인해보겠습니다',
+  '이어서 확인',
+  '계속 확인',
+  '계속 진행할게요',
+  '계속 진행하겠습니다',
+  '계속하겠습니다',
+  '계속할게요',
+  '바로 확인',
+  '바로 볼게요',
+  '바로 진행',
+  '살펴볼게요',
+  '살펴보겠습니다',
+  '진행하겠습니다',
+  '잠시만요',
+  '잠깐만요',
+  '곧 알려',
+]
+
+const ALL_PHRASES: readonly string[] = [...EN_PHRASES, ...KO_PHRASES]
+
+// Reply texts shorter than this are almost always a complete final answer
+// ("네", "ok", "done") where a partial match would be noise. The shortest
+// legitimate intent phrases ("on it now", "확인할게요") clear this floor.
+const MIN_LENGTH = 4
+
+export function detectContinuationWillingness(text: string): boolean {
+  if (text.length < MIN_LENGTH) return false
+  const normalized = normalize(text)
+  if (normalized.length < MIN_LENGTH) return false
+  return ALL_PHRASES.some((phrase) => normalized.includes(phrase))
+}

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -38,6 +38,7 @@ import {
   StaleLiveSessionError,
   stripThinkBlocks,
   TURN_CAP_ERROR,
+  WILLINGNESS_NUDGE,
   type ChannelRouter,
   type ClaimHandler,
   type RestartCommandContext,
@@ -8479,15 +8480,17 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     toolName: string,
     result: { ok: boolean; continue?: boolean },
     isError: boolean,
+    replyText?: string,
   ): AfterToolCallContext {
     const toolResult = {
       content: [{ type: 'text' as const, text: 'ignored' }],
       details: result,
     }
+    const args = replyText !== undefined ? { text: replyText } : {}
     return {
       assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
-      toolCall: { type: 'toolCall', id: 'tc1', name: toolName, arguments: {} } as AfterToolCallContext['toolCall'],
-      args: {},
+      toolCall: { type: 'toolCall', id: 'tc1', name: toolName, arguments: args } as AfterToolCallContext['toolCall'],
+      args,
       result: toolResult as AfterToolCallContext['result'],
       isError,
       context: { systemPrompt: '', messages: [], tools: [] },
@@ -8541,6 +8544,108 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     const agent = await liveAgentAfterRoute(await tempDir())
     await agent.afterToolCall!(afterToolContext('channel_send', { ok: true }, false))
     expect(agent.signal.aborted).toBe(false)
+  })
+
+  test('stashes the reply text on a terminal channel_reply so the willingness nudge can read it', async () => {
+    const agent = await liveAgentAfterRoute(await tempDir())
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true }, false, '바로 계속 확인하겠습니다'))
+    expect(agent.signal.aborted).toBe(true)
+  })
+
+  test('does NOT stash when continue:true (the turn stays alive, no nudge needed)', async () => {
+    const agent = await liveAgentAfterRoute(await tempDir())
+    await agent.afterToolCall!(
+      afterToolContext('channel_reply', { ok: true, continue: true }, false, '바로 계속 확인하겠습니다'),
+    )
+    expect(agent.signal.aborted).toBe(false)
+  })
+})
+
+describe('ChannelRouter continuation willingness nudge', () => {
+  function afterReplyContext(replyText: string): AfterToolCallContext {
+    return {
+      assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
+      toolCall: {
+        type: 'toolCall',
+        id: 'tc1',
+        name: 'channel_reply',
+        arguments: { text: replyText },
+      } as AfterToolCallContext['toolCall'],
+      args: { text: replyText },
+      result: {
+        content: [{ type: 'text' as const, text: 'ignored' }],
+        details: { ok: true },
+      } as AfterToolCallContext['result'],
+      isError: false,
+      context: { systemPrompt: '', messages: [], tools: [] },
+    }
+  }
+
+  // Simulate a terminal channel_reply turn: the model fires channel_reply (the
+  // terminal hook stashes the record + aborts), the send lands, and the leaf is
+  // the resulting aborted assistant message.
+  async function replyTurn(session: FakeSession, router: ChannelRouter, replyText: string): Promise<void> {
+    await session.agent.afterToolCall!(afterReplyContext(replyText))
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: replyText })
+    session.setAssistantMidTurn(replyText, 'aborted')
+  }
+
+  test('queues a nudge when a terminal reply promises to continue without continue:true', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '다시 확인해봐' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      attempt++
+      // given: first turn replies with a continuation promise (no continue:true)
+      if (attempt === 1) {
+        await replyTurn(sessions[0]!, router, '바로 계속 확인하겠습니다')
+        return
+      }
+      // then: the nudge arrives as a reminder-only re-prompt; now do the work
+      expect(text).toContain(WILLINGNESS_NUDGE)
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+  })
+
+  test('does NOT queue a nudge for a final reply with no continuation intent', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: '리뷰해줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await replyTurn(sessions[0]!, router, '리뷰 완료했습니다. 문제 없습니다.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+  })
+
+  test('nudges at most once per logical turn even if the second reply also promises to continue', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: '확인해봐' }))
+    sessions[0]!.onPrompt = async () => {
+      // Every turn promises to continue without continue:true. Bound = 1, so
+      // only the first reply turn may queue a nudge; the nudge turn's own reply
+      // must NOT queue a second one.
+      await replyTurn(sessions[0]!, router, '바로 계속 확인하겠습니다')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -24,6 +24,7 @@ import { extractClaimCode } from '@/role-claim'
 import type { Stream } from '@/stream'
 
 import { formatChannelCommandHelp } from './commands'
+import { detectContinuationWillingness } from './continuation-willingness'
 import {
   countEffectiveHumans,
   decideEngagement,
@@ -239,6 +240,30 @@ export const EMPTY_TURN_RETRY_NUDGE = [
 // drop so the human is never left staring at dead air after a degenerate turn.
 export const EMPTY_TURN_FALLBACK_TEXT =
   "⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?"
+// At most one continuation nudge per logical turn. Stricter than the empty-turn
+// retry budget (2) because the turn ALREADY delivered a user-facing reply — this
+// is a one-shot correction offer, not recovery from no output.
+export const MAX_WILLINGNESS_NUDGES = 1
+// Injected when a reply that ended the turn (terminal-reply abort) promised to
+// keep working but omitted `continue: true`. Reminder-only, SYSTEM MESSAGE
+// framing so persona-rich models do not reply to the notice itself.
+export const WILLINGNESS_NUDGE = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'Your last reply said you would keep working this turn, but it ended right',
+  'after sending — a successful channel reply ends the turn unless you set',
+  '`continue: true` on it. This is an automated signal from the channel router,',
+  'not a message from anyone in the chat. **Do not acknowledge or reply to this',
+  'notice itself.**',
+  '',
+  'If you still have work to do (fetch data, run a tool, spawn a subagent, then',
+  'reply with the result), do it now — and on the status reply that precedes more',
+  'work this turn, set `continue: true`. If there is nothing left to do, reply',
+  'with `NO_REPLY`.',
+  '',
+  '---',
+].join('\n')
 // Rolling window for outbound send-rate telemetry. 5s matches Discord's
 // rate-limit shape (5 msg / 5 s / channel) and comfortably covers Slack's
 // 1 msg/s sustained. The window is observational; exceeding the burst
@@ -565,6 +590,18 @@ type LiveSession = {
   // increments it before injecting EMPTY_TURN_RETRY_NUDGE and reads it to decide
   // retry-vs-fallback. See the candidate===null branch.
   emptyTurnRetries: number
+  // Count of continuation nudges spent on the CURRENT logical turn, bounded by
+  // MAX_WILLINGNESS_NUDGES. Reset alongside `emptyTurnRetries` only when a real
+  // user batch starts (batch.length > 0), NOT on the reminder-only iteration the
+  // nudge itself queues — same anti-reloop discipline as the empty-turn budget.
+  willingnessNudges: number
+  // Stashed by `installChannelReplyTerminalHook` just before it aborts the turn
+  // after a successful `channel_reply` that omitted `continue: true`. Read once
+  // by `validateChannelTurn` to decide the continuation nudge. `turnSeq`-stamped
+  // (like `skippedTurn`/`skipLockedSendTurn`) so a stale record from an earlier
+  // turn can never trigger a nudge on a later one. `null` when no such reply
+  // ended this turn.
+  lastTerminalReplyAbort: { turnSeq: number; text: string } | null
   // One-shot output-token budget for the NEXT `session.prompt()` only.
   // `installChannelOutputCap` reads and clears it per stream call, so it
   // overrides the default backstop for exactly one re-prompt. Set by the
@@ -1491,6 +1528,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
         emptyTurnRetries: 0,
+        willingnessNudges: 0,
+        lastTerminalReplyAbort: null,
         nextPromptMaxTokens: undefined,
         skippedTurn: null,
         skipLockedSendTurn: null,
@@ -1746,6 +1785,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const keepTurnAlive = details?.continue === true
       if (succeeded && !keepTurnAlive && agent.signal?.aborted !== true) {
         logger.info(`[channels] ${live.keyId} terminal_after_channel_reply`)
+        const replyText = (context.toolCall.arguments as { text?: unknown } | undefined)?.text
+        live.lastTerminalReplyAbort = typeof replyText === 'string' ? { turnSeq: live.turnSeq, text: replyText } : null
         agent.abort()
       }
       return result
@@ -2029,6 +2070,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // iterations the retry itself queues do not refill the budget and loop
           // forever (and the raised cap stays scoped to the turn that set it).
           live.emptyTurnRetries = 0
+          live.willingnessNudges = 0
           live.nextPromptMaxTokens = undefined
         } else if (live.lastTurnAuthorId !== null) {
           live.currentTurnEngageReactions = []
@@ -3134,6 +3176,26 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return { ok: true }
   }
 
+  // The turn ended via the terminal-reply abort. If that reply promised to keep
+  // working but omitted `continue: true`, queue ONE reminder-only re-prompt so
+  // the model gets a second chance to actually do it. The abort already fired
+  // (safe default preserved); this only adds an optional nudge. Bounded by
+  // MAX_WILLINGNESS_NUDGES and gated on `promptQueue` being empty so a real
+  // inbound that coalesced into this turn is never answered with a stale nudge.
+  const maybeNudgeContinuationWillingness = (live: LiveSession): void => {
+    const record = live.lastTerminalReplyAbort
+    live.lastTerminalReplyAbort = null
+    if (record === null || record.turnSeq !== live.turnSeq) return
+    if (live.willingnessNudges >= MAX_WILLINGNESS_NUDGES) return
+    if (live.promptQueue.length > 0) return
+    if (!detectContinuationWillingness(record.text)) return
+    live.willingnessNudges++
+    logger.info(
+      `[channels] ${live.keyId} willingness_nudge attempt=${live.willingnessNudges}/${MAX_WILLINGNESS_NUDGES}`,
+    )
+    live.pendingSystemReminders.push(WILLINGNESS_NUDGE)
+  }
+
   const validateChannelTurn = async (live: LiveSession, successfulSendsBeforePrompt: number): Promise<void> => {
     // `skip_response` short-circuit. Honoring it bypasses recovery entirely.
     // Stale-flag protection: only honor when stamped on the just-completed
@@ -3159,7 +3221,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.skippedTurn = null
       logger.info(`[channels] ${live.keyId} skip_contested_by_send recovering reply`)
     }
-    if (live.successfulChannelSends > successfulSendsBeforePrompt) return
+    if (live.successfulChannelSends > successfulSendsBeforePrompt) {
+      maybeNudgeContinuationWillingness(live)
+      return
+    }
 
     const postEmptyTurnFallback = async (cause: string): Promise<void> => {
       logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)


### PR DESCRIPTION
## Background

A channel session ends a *turn* the moment a `channel_reply` succeeds. This is enforced by `installChannelReplyTerminalHook` (`src/channels/router.ts`): an `agent.afterToolCall` hook calls `agent.abort()` after a successful reply so the mandatory post-tool follow-up LLM stream observes an aborted signal and returns `stopReason: 'aborted'` without generating. That abort is load-bearing — without it, Fireworks' kimi degenerates the empty follow-up into a 32k-token repetition loop.

The tool exposes an opt-out: `channel_reply({ continue: true })` skips the abort so a multi-step turn keeps going. The bug: **models routinely say "I'll continue now" / "바로 계속 확인하겠습니다" / "let me check" in the reply text but forget to set `continue: true`.** The turn aborts, the promised follow-up never runs, and if no new inbound arrives the session goes idle with the work undone.

Observed in production: a PR-review session posted "실제로는 diff가 정상 동작했고… 바로 계속 확인하겠습니다" and then stopped. The session transcript shows the exact shape — a `channel_reply` toolResult immediately followed by an empty `stopReason: 'aborted'` assistant turn, with nothing to re-wake it. Every reply in that session ended this way; the earlier ones only resumed because the human kept messaging. The last one ("I'll continue") got no follow-up message, so the loop simply ended.

## Summary

Keep the safe default — **the abort still fires** — and add a bounded, channel-agnostic *nudge* (not an auto-continue):

- The terminal hook stashes the reply text in `live.lastTerminalReplyAbort` (turnSeq-stamped, like `skippedTurn`/`skipLockedSendTurn`) right before it aborts, only on the success + `continue!==true` path.
- `validateChannelTurn`, just before its `successfulChannelSends > before` early return, consumes that record: if the text shows self-directed continuation intent and the per-turn budget is unspent, it queues **one** `WILLINGNESS_NUDGE` into `pendingSystemReminders` — the same reminder-only re-prompt machinery the empty-turn retry already uses. The model gets one more turn to actually do the work (and set `continue: true`), or reply `NO_REPLY`.

**Why a nudge and not "treat the phrase as `continue: true`":** auto-continuing on a text match would *invert* the safe default and reopen the kimi loop on any false positive (e.g. a final reply that happens to contain "계속 진행하세요"). With the nudge, the worst case of a false positive is one wasted reminder-only turn ending in `NO_REPLY` — it can never reopen the loop. The asymmetry (cheap, recoverable false-positive vs. catastrophic loop) is the whole design.

**Why detection is conservative:** `detectContinuationWillingness` is a pure, dependency-free function biased toward false negatives, matching only self-directed *future* intent (EN `I'll …`/`let me …`; KO `-ㄹ게요`/`-겠습니다` volitional endings on check/look/continue verbs). Bare `계속` is excluded — it's terminal in "계속 진행하세요" (= "you go ahead"). The `continue: true` flag remains the real signal; the text is only a fallback hint.

**Prior art** (this is a known shape in agent runtimes; the nudge mirrors the strongest of them):
- **LangChain `AgentExecutor(early_stopping_method="generate")`** — when the loop would stop without a finish, do *one final LLM pass* rather than dropping. Our nudge is exactly this: one bounded extra prompt instead of dead air.
- **AutoGen `is_termination_msg`** — text-content inspection to decide a turn is done (the direct analog of detecting intent from reply prose), and **`max_consecutive_auto_reply`** — a bounded counter reset on human turn (mirrors our `MAX_WILLINGNESS_NUDGES` reset at the fresh-user-turn site).
- **AutoGen AgentChat `FunctionCallTermination` vs `TextMentionTermination`** — structured function-call termination is preferred over text matching, validating our "flag is authoritative, text is a hint" stance.

## What this does NOT do

- Does **not** change the terminal-reply abort default — a successful reply still ends the turn unless `continue: true`.
- Does **not** auto-continue or auto-execute anything; it only injects a reminder so the *model* decides.
- Does **not** guarantee the model does the work — it removes the forced stop and hands control back; the model can still `NO_REPLY`.
- Does **not** touch any other adapter code — it lives in the shared router hook + `validateChannelTurn`, so all channels benefit with zero per-adapter changes.
- Does **not** add Japanese/other-locale phrases (deferrable; EN+KO cover the observed cases and avoid CJK-collision false positives).

## Review notes

- **Load-bearing change:** `maybeNudgeContinuationWillingness` in `src/channels/router.ts`, called at the `successfulChannelSends > before` early return of `validateChannelTurn`.
- **Invariants to verify** (Oracle-reviewed):
  - `lastTerminalReplyAbort` is turnSeq-stamped and cleared on read, so a stale record can never nudge a later turn.
  - `willingnessNudges` resets only at the `batch.length > 0` (fresh user turn) site, alongside `emptyTurnRetries` — *not* on reminder-only iterations, which is what prevents an infinite re-loop.
  - `MAX_WILLINGNESS_NUDGES = 1` (stricter than empty-turn's 2) because the turn already delivered a user-facing reply; this is a correction offer, not recovery from no output.
  - The `promptQueue.length > 0` guard ensures a real inbound that coalesced into this turn is never answered with a stale nudge.
  - `consecutiveAborts` is currently a defined-but-unwired field (never incremented / never compared to `MAX_CONSECUTIVE_ABORTS`), so terminal-reply aborts — including the nudge turn's own abort — cannot trip any livelock guard.
- **Tests:** `continuation-willingness.test.ts` is a positive/negative phrase table; the router tests cover queue-on-intent, no-queue-on-final-reply, and at-most-once-per-turn. Verified non-vacuous via mutation (removing the nudge call fails the positive cases).
