### PR TITLE
fix(github): route reviews on the agent's own PR

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -625,6 +625,107 @@ describe('classifyGithubInbound', () => {
   })
 })
 
+describe('classifyGithubInbound — review traffic on the bot-authored PR engages', () => {
+  // Regression: a peer reviewer (human or bot) reviewing the bot's OWN PR is
+  // directed at the bot — the inverse of review_requested — but review traffic
+  // is explicit-only (suppressSticky) and never @mentions the bot, so it was
+  // silently observed and the bot could not address the review. Self-PR review
+  // traffic must force the engagement trigger while staying sticky-free, so
+  // reviews on OTHER people's PRs remain observe-only (the PR #672 fix).
+  function reviewOnSelfPr(reviewer: Record<string, unknown>, state = 'COMMENTED', body = ''): Record<string, unknown> {
+    return {
+      action: 'submitted',
+      repository: repo(),
+      pull_request: {
+        number: 7,
+        id: 700,
+        title: 'Add the thing',
+        user: { login: 'typeclaw-bot', id: 99, type: 'Bot' },
+      },
+      review: { id: 5002, body, state, submitted_at: '2026-01-01T00:00:00Z', user: reviewer },
+    }
+  }
+
+  it('engages a peer-bot review on the bot-authored PR', () => {
+    const msg = classifyGithubInbound(
+      'pull_request_review',
+      reviewOnSelfPr({ login: 'peer-bot', id: 20, type: 'Bot' }),
+      'typeclaw-bot',
+    )
+    expect(msg?.isBotMention).toBe(true)
+    expect(msg?.suppressSticky).toBe(true)
+    expect(msg?.authorName).toBe('peer-bot')
+  })
+
+  it('engages a human review on the bot-authored PR', () => {
+    const msg = classifyGithubInbound('pull_request_review', reviewOnSelfPr(user()), 'typeclaw-bot')
+    expect(msg?.isBotMention).toBe(true)
+  })
+
+  it('keeps a review on someone else PR observe-only (no forced mention)', () => {
+    const payload = reviewOnSelfPr({ login: 'peer-bot', id: 20, type: 'Bot' })
+    ;(payload.pull_request as Record<string, unknown>).user = user()
+    const msg = classifyGithubInbound('pull_request_review', payload, 'typeclaw-bot')
+    expect(msg?.isBotMention).toBe(false)
+  })
+
+  it('does not force-engage an APPROVED review on the bot PR (no thanks churn)', () => {
+    const msg = classifyGithubInbound(
+      'pull_request_review',
+      reviewOnSelfPr({ login: 'peer-bot', id: 20, type: 'Bot' }, 'APPROVED'),
+      'typeclaw-bot',
+    )
+    expect(msg?.isBotMention).toBe(false)
+  })
+
+  it('engages a CHANGES_REQUESTED review on the bot PR', () => {
+    const msg = classifyGithubInbound(
+      'pull_request_review',
+      reviewOnSelfPr({ login: 'peer-bot', id: 20, type: 'Bot' }, 'CHANGES_REQUESTED'),
+      'typeclaw-bot',
+    )
+    expect(msg?.isBotMention).toBe(true)
+  })
+
+  it('recognizes the bot PR via the App decoy slug', () => {
+    const payload = reviewOnSelfPr({ login: 'peer-bot', id: 20, type: 'Bot' })
+    ;(payload.pull_request as Record<string, unknown>).user = { login: 'typeclaw', id: 42, type: 'User' }
+    const msg = classifyGithubInbound('pull_request_review', payload, 'typeclaw[bot]', { authType: 'app' })
+    expect(msg?.isBotMention).toBe(true)
+  })
+
+  it('engages a top-level review comment on the bot-authored PR', () => {
+    const payload = reviewCommentPayload({ inReplyToId: null })
+    ;(payload.pull_request as Record<string, unknown>) = {
+      number: 7,
+      user: { login: 'typeclaw-bot', id: 99, type: 'Bot' },
+    }
+    const msg = classifyGithubInbound('pull_request_review_comment', payload, 'typeclaw-bot')
+    expect(msg?.isBotMention).toBe(true)
+    expect(msg?.suppressSticky).toBe(true)
+  })
+
+  it('keeps a top-level review comment on someone else PR observe-only', () => {
+    const payload = reviewCommentPayload({ inReplyToId: null })
+    ;(payload.pull_request as Record<string, unknown>) = { number: 7, user: user() }
+    const msg = classifyGithubInbound('pull_request_review_comment', payload, 'typeclaw-bot')
+    expect(msg?.isBotMention).toBe(false)
+  })
+
+  it('leaves a reply to another reviewer on the bot PR observe-only (reply-target wins)', () => {
+    const payload = reviewCommentPayload({ inReplyToId: 101 })
+    ;(payload.pull_request as Record<string, unknown>) = {
+      number: 7,
+      user: { login: 'typeclaw-bot', id: 99, type: 'Bot' },
+    }
+    const msg = classifyGithubInbound('pull_request_review_comment', payload, 'typeclaw-bot', {
+      reviewCommentParent: { isSelf: false, parentId: 101 },
+    })
+    expect(msg?.isBotMention).toBe(false)
+    expect(msg?.replyToOtherMessageId).toBe('101')
+  })
+})
+
 describe('classifyGithubInbound — empty-body handling', () => {
   it('drops a pull_request_review_comment with an empty body', () => {
     const payload = reviewCommentPayload()

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -396,17 +396,24 @@ export function classifyGithubInbound(
     const root = parentId ?? id
     const parent =
       parentId !== null && options?.reviewCommentParent?.parentId === parentId ? options.reviewCommentParent : null
+    const commenter = readUser(comment.user)
+    const directedAtBot =
+      parentId === null &&
+      isSelfPr(readUser(pr.user), selfLogin, options?.authType ?? 'pat') &&
+      commenter !== null &&
+      !isSelfAuthor(commenter, null, selfLogin)
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: String(root) },
       comment.body,
       id,
-      readUser(comment.user),
+      commenter,
       mention,
       comment.created_at,
       { kind: 'pr-review-comment', owner: repository.owner, repo: repository.name, commentId: id },
       false,
       {
         suppressSticky: true,
+        ...(directedAtBot ? { forceBotMention: true } : {}),
         replyToBotMessageId: parent?.isSelf === true ? String(parent.parentId) : null,
         replyToOtherMessageId: parent?.isSelf === false ? String(parent.parentId) : null,
       },
@@ -533,6 +540,11 @@ export function classifyGithubInbound(
       : reviewer !== null
         ? synthesizeReviewStateText(reviewer.login, number, readString(pr, 'title'), readString(review, 'state'))
         : ''
+    const directedAtBot =
+      isSelfPr(readUser(pr.user), selfLogin, options?.authType ?? 'pat') &&
+      reviewer !== null &&
+      !isSelfAuthor(reviewer, null, selfLogin) &&
+      isActionableReviewState(readString(review, 'state'))
     return buildInbound(
       { ...base, chat: `pr:${number}`, thread: null },
       text,
@@ -542,7 +554,7 @@ export function classifyGithubInbound(
       review.submitted_at,
       null,
       !hasBody,
-      { suppressSticky: true },
+      { suppressSticky: true, ...(directedAtBot ? { forceBotMention: true } : {}) },
     )
   }
 
@@ -591,6 +603,12 @@ type BuildInboundOptions = {
   suppressSticky?: boolean
   replyToBotMessageId?: string | null
   replyToOtherMessageId?: string | null
+  // Forces isBotMention=true with no @-handle in the body. A review (or
+  // top-level review comment) on a PR the agent ITSELF authored is directed at
+  // the bot — the inverse of review_requested — so it engages even though the
+  // reviewer never types `@bot`. Paired with suppressSticky so reviews on OTHER
+  // people's PRs still observe-only (preserving the PR #672 fix).
+  forceBotMention?: boolean
 }
 
 // A GitHub App can never be a `requested_reviewer` — that field only holds
@@ -799,7 +817,7 @@ function buildInbound(
   // Synthesized awareness lines carry an `@author` prefix describing who acted;
   // that handle is the author, never a third-party mention of the bot, so the
   // body-text mention heuristic must not fire on it.
-  const isBotMention = !synthesizedAwareness && textMentionsBot(text, mention)
+  const isBotMention = options?.forceBotMention === true || (!synthesizedAwareness && textMentionsBot(text, mention))
   const replyToBotMessageId = options?.replyToBotMessageId ?? null
   const replyToOtherMessageId = options?.replyToOtherMessageId ?? key.replyToOtherMessageId
   return {
@@ -852,6 +870,15 @@ function synthesizeReviewStateText(
         ? 'requested changes on'
         : 'submitted a review on'
   return `@${reviewer} ${verb} PR #${number}${label}.`
+}
+
+// A review on the agent's own PR engages it only when there is something to act
+// on. APPROVED clears the PR and needs no reply, so engaging would just produce
+// "thanks" churn; it stays awareness-only. COMMENTED and CHANGES_REQUESTED (and
+// any non-approval state) carry feedback the agent should address. State case
+// varies by payload source (webhook vs REST), so normalize before matching.
+function isActionableReviewState(state: string | null): boolean {
+  return state?.toLowerCase() !== 'approved'
 }
 
 async function resolveTeamMembership(
@@ -979,6 +1006,17 @@ function isSelfAuthor(author: GithubUser, selfId: string | null, selfLogin: stri
   if (selfId !== null && String(author.id) === selfId) return true
   if (selfLogin !== null && author.login === selfLogin) return true
   return false
+}
+
+// Whether the PR's OPENER is this agent. Distinct from isSelfAuthor (which
+// guards self-loops on the event ACTOR by id/login): here we have only the
+// `pull_request.user` from a review payload, no id to compare, and under App
+// auth the bot opens PRs as the decoy account (login = slug, e.g. `typeey`),
+// not the actor login `typeey[bot]`. So this matches selfLogin AND the decoy
+// slug — mirroring resolveBotMentionLogins.
+function isSelfPr(prUser: GithubUser | null, selfLogin: string | null, authType: 'pat' | 'app'): boolean {
+  if (prUser === null || selfLogin === null) return false
+  return resolveBotMentionLogins(selfLogin, authType).includes(prUser.login)
 }
 
 type GithubUser = { login: string; id: number; type?: string }


### PR DESCRIPTION
## Problem

A review (or top-level review comment) left on a PR the **agent itself authored** was silently *observed* instead of waking the agent, so the agent could never address review feedback on its own PRs.

**Repro:** the agent opens a PR; another reviewer (human or peer bot) submits a review on it. The review never routes to a turn.

## Root cause

Commit `94e9efbb` ("treat PR review threads as group chat") marked `pull_request_review` and `pull_request_review_comment` as **explicit-only** (`suppressSticky`) to stop the bot replying to inline comments that didn't address it. That was correct for reviews on *other* people's PRs.

But review traffic never `@mentions` the PR author. So a review on the bot's **own** PR hit no explicit trigger (`isDm` / `isBotMention` / `replyToBotMessageId` all false), and when the reviewer is a peer bot it also misses the solo-human fallback (`!authorIsBot`). The event fell through to `observe` and was dropped from engagement.

## Fix

A review on the agent's own PR is the **inverse of `review_requested`** — it is inherently directed at the bot. Classify it as such:

- New `forceBotMention` build option sets `isBotMention=true` **without** spending content-blind sticky credit. Reviews on *other* people's PRs stay observe-only, so the `94e9efbb` fix is preserved.
- `isSelfPr()` matches the PR opener against `selfLogin` **and** the App decoy slug (under App auth the bot opens PRs as the decoy account, not the `slug[bot]` actor). Kept distinct from `isSelfAuthor` (which guards self-loops on the event *actor* by id/login).
- `APPROVED` reviews stay awareness-only (`isActionableReviewState`) to avoid needless "thanks" churn; `COMMENTED` / `CHANGES_REQUESTED` engage.
- Replies to another reviewer's inline comment keep their existing reply-target resolution (observe-only unless replying to the bot).

## Safety

- The handler-level self-author drop is **unchanged**, so the bot still never wakes on its **own** review (PR #460).
- The peer-bot loop guard still bounds any reviewer ping-pong — this only opens the *first* directed turn on self-authored PRs.

## Tests

9 new regression tests in `inbound.test.ts`: peer-bot review on self-PR engages; human review on self-PR engages; review on someone else's PR stays observe-only; APPROVED on self-PR stays awareness-only; CHANGES_REQUESTED engages; App decoy-slug self-PR recognized; top-level review comment on self-PR engages; top-level comment on other PR observe-only; reply to another reviewer stays observe-only.

All checks pass: `typecheck`, `lint` (0 errors), `format:check`, full suite (8215 pass, 0 fail).