### PR TITLE
fix(line): keep the QR login URL out of note() so it stays copyable

### DIFF
--- a/src/cli/channel.test.ts
+++ b/src/cli/channel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { Writable } from 'node:stream'
+
+import { printLineQrUrl } from './channel'
+
+function captureStream(): { stream: Writable; written: () => string } {
+  const chunks: string[] = []
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString())
+      callback()
+    },
+  })
+  return { stream, written: () => chunks.join('') }
+}
+
+describe('printLineQrUrl', () => {
+  const url = 'https://line.me/R/au/lgn/sq/aBcDeFgHiJ?secret=Zm9vYmFyL21lL3NlY3JldA%3D%3D&e2eeVersion=1'
+
+  test('writes the URL to the stream verbatim on its own line so it stays copyable', () => {
+    // given
+    const { stream, written } = captureStream()
+
+    // when
+    printLineQrUrl(url, stream)
+
+    // then: the raw URL is emitted intact (no box border `│` splicing it apart)
+    expect(written()).toContain(`${url}\n`)
+    expect(written()).not.toContain('│')
+  })
+})

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1100,7 +1100,7 @@ async function promptLineLogin(): Promise<LinePromptResult> {
     return {
       method: 'qr',
       callbacks: {
-        onQRUrl: (url) => note(url, 'Open this URL on your phone (or scan the QR it renders)'),
+        onQRUrl: printLineQrUrl,
         onPincode,
       },
     }
@@ -1123,6 +1123,15 @@ async function promptLineLogin(): Promise<LinePromptResult> {
     process.exit(0)
   }
   return { method: 'email', email, password: pwd, callbacks: { onPincode } }
+}
+
+// URL stays OUT of note(): clack wraps long lines with a `│` gutter that
+// corrupts copy-pasted URLs, and this login URL always wraps (it carries
+// `?secret=...&e2eeVersion=...`). Same fix as src/cli/oauth-callbacks.ts.
+export function printLineQrUrl(url: string, output: NodeJS.WritableStream = process.stdout): void {
+  note('Open this URL on your phone (or scan the QR it renders):', 'Log in to LINE')
+  output.write(`${url}\n`)
+  output.write('\n')
 }
 
 function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEvent) => void {


### PR DESCRIPTION
## Background

`typeclaw channel add line` (QR method) prints the LINE login URL so the
operator can open it on their phone or copy it elsewhere. The URL was passed
as the **body** of clack's `note()`:

```ts
onQRUrl: (url) => note(url, 'Open this URL on your phone (or scan the QR it renders)'),
```

`note()` renders its body inside a box, wrapping long lines and prefixing every
wrapped segment with a `│` gutter. The login URL is long — it carries
`?secret=...&e2eeVersion=1` query params — so it always wraps, and the gutter +
box border get spliced into the middle of the URL. Selecting and copying it
yields a mangled, unusable string:

```
◇  Open this URL on your phone (or scan the QR it renders) ──╮
│  https://line.me/R/au/lgn/sq/<id>  │
│  <rest>?secret=<...>%3D&e2eeVersion=1  │
├──╯
```

The codebase already established the fix for exactly this class of bug — see
`src/cli/oauth-callbacks.ts` (OAuth browser-login URL) and `printDiscordInviteHint`
/ `printSlackAppManifestSetup` in `src/cli/ui.ts`. The LINE QR path simply
missed it.

## Summary

Extract the callback into a named `printLineQrUrl(url, output?)` helper that
keeps the instructional text in the `note()` box but writes the URL itself as a
bare line to stdout, where any terminal hyperlinks and copies it intact. This
mirrors the existing OAuth/Discord/Slack pattern rather than inventing a new
one, and the injectable `output` stream makes it unit-testable.

I audited every other `note()` call (42 across 6 files). The rest either contain
no URL, or contain **short static reference URLs** (e.g. `https://api.slack.com/apps`,
`https://github.com/settings/...`) that fit on one line and never wrap — so they
don't have this defect. The LINE QR URL was the only dynamic, always-wrapping
URL still living inside a box.

## Preview

Before — URL boxed, `│` gutter corrupts it on copy:

```
◇  Open this URL on your phone (or scan the QR it renders) ──╮
│  https://line.me/R/au/lgn/sq/<id>?secret=<...>&e2eeVersion=1  │
├──╯
```

After — instruction stays boxed, URL printed clean on its own line:

```
◇  Log in to LINE ──────────────────────────────────────────╮
│                                                            │
│  Open this URL on your phone (or scan the QR it renders):  │
│                                                            │
├────────────────────────────────────────────────────────────╯

https://line.me/R/au/lgn/sq/<id>?secret=<...>&e2eeVersion=1
```

## What this does NOT do

- Does not touch the short static reference URLs in other `note()` boxes — they
  don't wrap, so they aren't affected.
- Does not change the QR rendering itself or the LINE auth flow/SDK contract.
- Does not alter the pincode/email login paths.

## Review notes

- Load-bearing change: the URL must be written **outside** `note()`. The new
  test (`src/cli/channel.test.ts`) asserts the emitted output contains the raw
  URL verbatim and no `│` box character, which is the regression guard.
- The explanatory comment on `printLineQrUrl` is deliberate — it prevents a
  future "simplification" back into `note(url, ...)` that would reintroduce the
  bug, matching the same comments in `oauth-callbacks.ts` / `ui.ts`.
