### PR TITLE
fix(channels): surface provider errors instead of "I got stuck" fallback

### DIFF
--- a/src/agent/provider-error.test.ts
+++ b/src/agent/provider-error.test.ts
@@ -63,6 +63,25 @@ describe('detectProviderError', () => {
 })
 
 describe('detectProviderError safeMessage redaction', () => {
+  test('maps a 401/unauthorized error to the auth-safe sentence without leaking a bearer token', () => {
+    const raw = '401 Unauthorized: invalid api key (Authorization: Bearer sk-live-LEAK)'
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })
+
+    expect(result?.safeMessage).toMatch(/unauthorized/i)
+    expect(result?.safeMessage).toMatch(/API key/i)
+    expect(result?.safeMessage).not.toContain('sk-live-LEAK')
+    expect(result?.safeMessage).not.toContain('Bearer')
+  })
+
+  test('the bare "401 Unauthorized" shape (the production incident) maps to the auth class, not the generic notice', () => {
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: '401 Unauthorized' })
+
+    expect(result?.safeMessage).toMatch(/unauthorized/i)
+    expect(result?.safeMessage).not.toBe(
+      'The upstream LLM provider failed. Operators can check `typeclaw logs` for details.',
+    )
+  })
+
   test('maps rate/usage-limit errors to a canonical channel-safe sentence', () => {
     const raw = 'You have hit your ChatGPT usage limit (team plan). Try again in ~40 min.'
     const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })

--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -32,6 +32,16 @@ const GENERIC_SAFE_NOTICE = 'The upstream LLM provider failed. Operators can che
 // text, so adding a new class is opt-in and never widens what we expose.
 const SAFE_CLASSES: ReadonlyArray<{ match: RegExp; safe: string }> = [
   {
+    // Auth failure: the provider rejected our credentials (bad/expired/missing
+    // API key). Matched first because a 401 body can also mention "account",
+    // which would otherwise fall into the billing class below. The safe text
+    // names the operator action (check the API key) without echoing the raw
+    // error, whose body can carry a Bearer token.
+    match:
+      /\b(401|unauthori[sz]ed|invalid[_ -]?api[_ -]?key|api key.*(?:invalid|expired|missing)|authentication failed|invalid bearer)\b/i,
+    safe: 'The upstream LLM provider rejected the request as unauthorized. Operators should check the provider API key configuration and `typeclaw logs`.',
+  },
+  {
     match: /\b(usage limit|rate limit|rate.?limited|too many requests|429)\b/i,
     safe: 'The upstream LLM provider is rate-limited (usage limit reached). Try again shortly.',
   },

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3424,29 +3424,29 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sessions[0]!.lastStreamMaxTokens).toBe(CHANNEL_MAX_OUTPUT_TOKENS)
   })
 
-  for (const stop of ['error', 'aborted'] as const) {
-    test(`empty-turn guard: a '${stop}' truncation retries under the DEFAULT cap, not the raised budget`, async () => {
-      const dir = await tempDir()
-      const logs: string[] = []
-      const { router, sessions } = makeRouter(dir, { logs })
-      router.registerOutbound('discord-bot', async () => ({ ok: true }))
+  test("empty-turn guard: an 'aborted' truncation retries under the DEFAULT cap, not the raised budget", async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
 
-      await router.route(inbound({ text: 'ambiguous thing' }))
-      const budgetsPerPrompt: Array<number | undefined> = []
-      sessions[0]!.onPrompt = async () => {
-        await streamOnce(sessions[0]!)
-        budgetsPerPrompt.push(sessions[0]!.lastStreamMaxTokens)
-        // error/aborted are not budget exhaustion, so the raised reasoning
-        // budget is unjustified — the retry must stay on the default backstop.
-        sessions[0]!.setAssistantMidTurn('truncated output', stop)
-      }
-      await router.__testing!.flushDebounce(KEY)
+    await router.route(inbound({ text: 'ambiguous thing' }))
+    const budgetsPerPrompt: Array<number | undefined> = []
+    sessions[0]!.onPrompt = async () => {
+      await streamOnce(sessions[0]!)
+      budgetsPerPrompt.push(sessions[0]!.lastStreamMaxTokens)
+      // `aborted` is the terminal-reply abort, not budget exhaustion, so the
+      // raised reasoning budget is unjustified — the retry must stay on the
+      // default backstop. (`error` no longer reaches the retry path at all: it
+      // diverts to the provider-error notice, covered by its own tests.)
+      sessions[0]!.setAssistantMidTurn('truncated output', 'aborted')
+    }
+    await router.__testing!.flushDebounce(KEY)
 
-      expect(budgetsPerPrompt.every((b) => b === CHANNEL_MAX_OUTPUT_TOKENS)).toBe(true)
-      expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(true)
-      expect(logs.some((m) => m.includes(`max_tokens=${CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS}`))).toBe(false)
-    })
-  }
+    expect(budgetsPerPrompt.every((b) => b === CHANNEL_MAX_OUTPUT_TOKENS)).toBe(true)
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(true)
+    expect(logs.some((m) => m.includes(`max_tokens=${CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS}`))).toBe(false)
+  })
 
   test('empty-turn guard: skip-locked send thrash stays silent (no fallback) — the model chose silence', async () => {
     // Regression for the production false alarm (thread 1780845903.114339): the
@@ -5562,13 +5562,16 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     let attempt = 0
     sessions[0]!.onPrompt = async (text) => {
       attempt++
-      // when: first attempt errors + truncates (no send) → retry queued
+      // when: a transient error fires mid-stream but the turn ends `length`-
+      // truncated with no send → retry queued (the carry-forward case). A
+      // `length` leaf retries; an `error` leaf would divert straight to the
+      // provider notice, which is a different path tested separately.
       if (attempt === 1) {
         sessions[0]!.emit({
           type: 'message_end',
           message: { role: 'assistant', stopReason: 'error', errorMessage: 'transient server_is_overloaded' },
         })
-        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'error')
+        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'length')
         return
       }
       // when: retry recovers and replies
@@ -5603,14 +5606,17 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     let attempt = 0
     sessions[0]!.onPrompt = async () => {
       attempt++
-      // when: turn A errors + truncates (queues the retry nudge + carry), then a
-      // fresh user message lands while that nudge is still pending
+      // when: turn A hits a transient error mid-stream and ends `length`-
+      // truncated (queues the retry nudge + carry), then a fresh user message
+      // lands while that nudge is still pending. The leaf is `length`, not
+      // `error`: an `error` leaf diverts straight to the provider notice, so it
+      // would never queue a carry-forward retry to misattribute in the first place.
       if (attempt === 1) {
         sessions[0]!.emit({
           type: 'message_end',
           message: { role: 'assistant', stopReason: 'error', errorMessage: 'transient server_is_overloaded' },
         })
-        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'error')
+        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'length')
         await router.route(inbound({ externalMessageId: 'mB', text: 'turn B' }))
         return
       }
@@ -5625,13 +5631,13 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(false)
   })
 
-  test('exhausted empty-turn retries surface the generic fallback (not a duplicate provider notice) and never go silent', async () => {
-    // given: every attempt errors + truncates with no send, exhausting the
-    // empty-turn retry budget without ever replying. The exhausted path already
-    // posts EMPTY_TURN_FALLBACK_TEXT — a user-facing "I got stuck" notice that
-    // counts as a reply — so the provider notice is correctly suppressed as
-    // redundant. The human still sees exactly one notice (never dead air); the
-    // raw provider cause lives in the operator logs.
+  test('an `error`-leaf turn surfaces the provider notice immediately — no empty-turn retries, no misleading "I got stuck" fallback', async () => {
+    // given: the turn ends with a `stopReason: 'error'` leaf (an upstream
+    // provider failure, e.g. a 401 or an overloaded server). This is NOT a
+    // reasoning loop, so it must NOT be re-prompted with EMPTY_TURN_RETRY_NUDGE
+    // and must NOT post EMPTY_TURN_FALLBACK_TEXT ("I got stuck…"), which would
+    // mask the real failure. The deferred provider-error path owns this turn and
+    // posts the REDACTED safeMessage instead. The raw cause stays in operator logs.
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
@@ -5651,12 +5657,49 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
-    // then: retries ran, the generic fallback surfaced exactly once, no
-    // duplicate provider notice, and the raw cause was logged for operators
-    expect(sessions[0]!.prompts.length).toBeGreaterThan(1)
-    expect(sent.filter((t) => t === EMPTY_TURN_FALLBACK_TEXT)).toHaveLength(1)
-    expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(false)
+    // then: exactly one prompt (no retries), the provider notice surfaced, the
+    // misleading fallback never posted, and the raw cause was logged for operators.
+    // `server_is_overloaded` is not a known safe class, so it collapses to the
+    // generic redacted notice (never the raw text).
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent.some((t) => t === EMPTY_TURN_FALLBACK_TEXT)).toBe(false)
+    expect(sent.some((t) => /upstream LLM provider failed/i.test(t))).toBe(true)
+    expect(sent.some((t) => /server_is_overloaded/.test(t))).toBe(false)
+    expect(logs.some((m) => /empty_turn_retry/.test(m))).toBe(false)
+    expect(logs.some((m) => /provider_error_turn/.test(m))).toBe(true)
     expect(logs.some((m) => /LLM call failed: .*server_is_overloaded/.test(m))).toBe(true)
+  })
+
+  test('a 401 provider error surfaces the auth notice (not the misleading "I got stuck" fallback)', async () => {
+    // given: the production failure — every turn ends with a
+    // `stopReason: 'error'` / `401 Unauthorized` leaf because the provider API
+    // key is bad/expired. The old code retried then posted EMPTY_TURN_FALLBACK_TEXT
+    // ("I got stuck…"), completely masking the auth failure. Now the auth-class
+    // safe message surfaces and the raw 401 stays in operator logs.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hey bot, you there?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: '401 Unauthorized' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: one prompt, the auth notice surfaced, no retries, no "I got stuck"
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent.some((t) => /unauthorized/i.test(t) && /API key/i.test(t))).toBe(true)
+    expect(sent.some((t) => t === EMPTY_TURN_FALLBACK_TEXT)).toBe(false)
+    expect(logs.some((m) => /empty_turn_retry/.test(m))).toBe(false)
   })
 
   test('upgrades hard prompt-throws to logger.error (not warn) so `typeclaw logs` operators see them at the right level', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3269,6 +3269,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // The legitimate empty-state case (a TUI-only check before any user
       // prompt, no inbound this turn) is excluded: no batch means no real turn
       // to retry or apologize for — keep the historical silent bail there.
+      const leafStopReason = assistantLeafStopReason(live.session)
+
+      // A `stopReason: 'error'` leaf is an upstream provider failure (401, billing,
+      // malformed response, etc.), NOT a reasoning-loop or budget exhaustion. It is
+      // already captured by subscribeProviderErrors into `pendingProviderError`
+      // (fired synchronously on `message_end` before `prompt()` resolves), and
+      // `maybePostDeferredProviderError` in drain()'s finally posts the REDACTED
+      // `safeMessage`. Retrying with EMPTY_TURN_RETRY_NUDGE would waste the budget
+      // nudging the model about output length when the real fault is the provider;
+      // posting EMPTY_TURN_FALLBACK_TEXT would mask the actual failure behind a
+      // misleading "I got stuck" notice. Return early so the provider-error path
+      // owns this turn's surface.
+      if (leafStopReason === 'error') {
+        logger.warn(`[channels] ${live.keyId} provider_error_turn deferring to provider-error notice`)
+        return
+      }
+
       const skipLockedThisTurn = live.skipLockedSendTurn === live.turnSeq
       const attemptedSendThisTurn = skipLockedThisTurn || live.policyDeniedToolSendsThisTurn.size > 0
 
@@ -3289,11 +3306,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         return
       }
 
-      // Only a TRUNCATED assistant leaf (length/error/aborted) from a real
-      // conversational turn is a degeneration worth retrying. A cold/empty turn
-      // (no inbound author, or no assistant message at all) keeps the historical
-      // silent bail — re-prompting it would manufacture replies to nothing.
-      if (live.currentTurnAuthorId === null || !assistantLeafTruncated(live.session)) {
+      // Only a TRUNCATED assistant leaf — `length` (budget exhaustion) or
+      // `aborted` (terminal-reply abort) — from a real conversational turn is a
+      // degeneration worth retrying. `error` was already diverted above to the
+      // provider-error path. A cold/empty turn (no inbound author, or no
+      // assistant message at all) keeps the historical silent bail —
+      // re-prompting it would manufacture replies to nothing.
+      if (live.currentTurnAuthorId === null || leafStopReason === undefined) {
         logger.info(`[channels] ${live.keyId}: no recoverable assistant text in branch`)
         return
       }
@@ -3301,11 +3320,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.emptyTurnRetries++
         // Raise the re-prompt's budget ONLY for a `length` truncation: that is
         // the budget-exhaustion case (reasoning ate the whole pool before any
-        // prose), so the retry needs room to finish thinking AND reply. `error`
-        // and `aborted` are not budget exhaustion — an upstream failure or the
-        // terminal-reply abort — so they retry under the default backstop.
-        // Consumed one-shot by installChannelOutputCap on the next prompt().
-        if (assistantLeafStopReason(live.session) === 'length') {
+        // prose), so the retry needs room to finish thinking AND reply. `aborted`
+        // is the terminal-reply abort, not budget exhaustion, so it retries under
+        // the default backstop. Consumed one-shot by installChannelOutputCap on
+        // the next prompt().
+        if (leafStopReason === 'length') {
           live.nextPromptMaxTokens = CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS
         }
         logger.warn(
@@ -4680,25 +4699,20 @@ function recoverableAssistantText(
   return null
 }
 
-// The truncation stop reason when the leaf is an assistant message that was CUT
-// OFF mid-output — `length` (hit the token cap, the canonical kimi reasoning-
-// loop), `error`, or `aborted` — else undefined. This is the precise signature
-// of "the model was producing but got truncated", as distinct from a turn that
-// produced no assistant message at all (leaf undefined / a non-assistant
-// entry), which is a benign empty/cold turn. Callers that only need the boolean
-// use `assistantLeafTruncated`; the retry guard reads the reason itself because
-// the raised reasoning budget is justified ONLY for `length` (budget
-// exhaustion), not for `error`/`aborted`.
+// The non-terminal stop reason when the leaf is an assistant message that did
+// NOT cleanly finish — `length` (hit the token cap, the canonical kimi
+// reasoning-loop), `error` (an upstream provider failure), or `aborted` (the
+// terminal-reply abort) — else undefined. `undefined` is the signature of a
+// benign empty/cold turn (leaf undefined / a non-assistant entry). The
+// validateChannelTurn recovery path branches on the specific reason: `error`
+// diverts to the provider-error notice, `length` gets a raised retry budget,
+// `aborted` retries under the default backstop.
 function assistantLeafStopReason(session: AgentSession): 'length' | 'error' | 'aborted' | undefined {
   const leaf = session.sessionManager.getLeafEntry()
   if (!leaf || leaf.type !== 'message' || leaf.message.role !== 'assistant') return undefined
   const stop = leaf.message.stopReason
   if (stop === 'length' || stop === 'error' || stop === 'aborted') return stop
   return undefined
-}
-
-function assistantLeafTruncated(session: AgentSession): boolean {
-  return assistantLeafStopReason(session) !== undefined
 }
 
 function visibleAssistantText(message: AssistantMessage): string {


### PR DESCRIPTION
## Background

When the LLM provider returns an error during a channel turn — most concretely a **401 Unauthorized** from a bad/expired API key — the channel posted a misleading user-facing notice:

> ⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?

A real session showed every assistant turn ending with `content: []`, `stopReason: "error"`, `errorMessage: "401 Unauthorized"`, repeated several times, then this fallback. The auth failure was completely hidden from the operator — the message reads like a model hiccup, so the natural reaction is "try again", which can never work.

**Root cause.** `validateChannelTurn` (`src/channels/router.ts`) classifies a turn with no recoverable assistant prose. An `error`-stopReason leaf has empty content, so `recoverableAssistantText` returns `null` and the turn falls into the empty-turn recovery branch. That branch was designed for the kimi reasoning-loop degeneration (`stopReason: 'length'`): it re-prompts up to `MAX_EMPTY_TURN_RETRIES` with `EMPTY_TURN_RETRY_NUDGE` (a "you ran out of output budget, answer directly" reminder), then on exhaustion posts `EMPTY_TURN_FALLBACK_TEXT`. For an `error` leaf this is doubly wrong: the retry nudge is nonsense (the fault is the provider, not the model's output length), and the fallback masks the real failure.

Meanwhile the correct machinery already exists: `subscribeProviderErrors` records the failure into `pendingProviderError`, and `maybePostDeferredProviderError` (in `drain()`'s `finally`) posts a **redacted** `safeMessage`. But it ran *after* the empty-turn path had already "handled" the turn, so the provider notice never won.

## Summary

Divert `stopReason: 'error'` leaves out of the empty-turn retry/fallback path with an early return in `validateChannelTurn`, so the existing deferred provider-error path owns the turn and posts the redacted `safeMessage`.

- **Why an early return, not a change to `assistantLeafTruncated`/the retry guard:** the minimal, local fix. Broadening the helper's semantics would ripple through other callers; a single guarded `return` keeps the blast radius to the one branch that was misrouting.
- `length` (budget exhaustion) and `aborted` (terminal-reply abort) keep their existing retry behavior unchanged.
- After the early return, `sentReplyThisTurn === false` and `emptyTurnRetryQueued === false`, so `maybePostDeferredProviderError` posts exactly one notice — no double-post, no missed-post.
- Added a **401/auth `SAFE_CLASS`** in `src/agent/provider-error.ts` so the channel notice names the operator action ("check the provider API key configuration") instead of collapsing to the generic notice. It is matched first because a 401 body can also mention "account" (which would otherwise hit the billing class), and the safe text never echoes the raw error, whose body can carry a `Bearer` token.

## What this does NOT do

- Does not change `length`/`aborted` recovery, the carry-forward-across-retry mechanism, or the per-turn "one notice" dedup.
- Does not retry on provider errors (a 401 won't fix itself on re-prompt; surfacing it immediately is the point).
- Does not touch cron/subagent/TUI surfaces — only the channels router path.
- Does not attempt to recover or re-auth; it surfaces the failure so an operator can fix the key.

## Review notes

- Load-bearing change: the `if (leafStopReason === 'error') return` early-return in `validateChannelTurn`. The invariant to verify is the ordering — `validateChannelTurn` runs before `maybePostDeferredProviderError`, and a `source:'system'` send does **not** increment `successfulChannelSends`, so the early return is what lets the provider path post.
- `assistantLeafTruncated` became dead after switching the cold-turn guard to `leafStopReason === undefined`; removed it and corrected the `assistantLeafStopReason` doc comment.
- Tests: the old test that asserted "exhausted retries surface the generic fallback" for an `error` leaf encoded the bug; it's rewritten to assert the immediate provider notice. Carry-forward tests now use a `length` leaf (the only path that still retries) while still firing a transient `error` `message_end`. New regression tests cover the 401 → auth-notice path and auth redaction (a planted `Bearer` token must not leak into `safeMessage`).
- Pre-commit `typecheck` / `lint` / `format:check` all clean; the 420 router + provider-error tests pass. (The repo's schema drift-guard tests fail identically on a pristine `origin/main` checkout — an environment artifact, unrelated to this change.)