### PR TITLE
fix(channels): render a scannable QR for the LINE channel add flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "cron-parser": "^5.5.0",
         "jq-wasm": "^1.1.0-jq-1.8.1",
         "jsdom": "^29.0.2",
+        "qrcode": "^1.5.4",
         "turndown": "^7.2.4",
         "zod": "^4.3.6",
       },
@@ -24,6 +25,7 @@
         "@types/bun": "latest",
         "@types/jsdom": "^28.0.1",
         "@types/proper-lockfile": "^4.1.4",
+        "@types/qrcode": "^1.5.6",
         "@types/sinonjs__fake-timers": "^15.0.1",
         "@types/turndown": "^5.0.6",
         "@types/ws": "^8.18.1",
@@ -483,6 +485,8 @@
 
     "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
 
+    "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
+
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/sinonjs__fake-timers": ["@types/sinonjs__fake-timers@15.0.1", "", {}, "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w=="],
@@ -607,7 +611,7 @@
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
-    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+    "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -1223,7 +1227,7 @@
 
     "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1233,13 +1237,13 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+    "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
-    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+    "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
-    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+    "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
@@ -1275,6 +1279,8 @@
 
     "cli-highlight/parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
+    "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
@@ -1304,8 +1310,6 @@
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "qified/hookified": ["hookified@2.2.0", "", {}, "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA=="],
-
-    "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "socks/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1337,6 +1341,12 @@
 
     "cli-highlight/parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
+    "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "cli-highlight/yargs/y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
@@ -1346,12 +1356,6 @@
     "libsignal/protobufjs/@types/node": ["@types/node@10.17.60", "", {}, "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="],
 
     "libsignal/protobufjs/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
-
-    "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
-
-    "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1363,10 +1367,10 @@
 
     "axios/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "qrcode/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "cli-highlight/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "cli-highlight/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "qrcode/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cron-parser": "^5.5.0",
     "jq-wasm": "^1.1.0-jq-1.8.1",
     "jsdom": "^29.0.2",
+    "qrcode": "^1.5.4",
     "turndown": "^7.2.4",
     "zod": "^4.3.6"
   },
@@ -61,6 +62,7 @@
     "@types/bun": "latest",
     "@types/jsdom": "^28.0.1",
     "@types/proper-lockfile": "^4.1.4",
+    "@types/qrcode": "^1.5.6",
     "@types/sinonjs__fake-timers": "^15.0.1",
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1",

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1164,7 +1164,7 @@ async function presentLineQr(url: string, spinnerControl?: LineQrSpinnerControl)
   } else if (presentation.htmlPath !== null) {
     lines.push(`Open this file in a browser and scan it with the LINE app: ${presentation.htmlPath}`)
   }
-  note(lines.join('\n'), 'Scan to log in to LINE')
+  if (lines.length > 0) note(lines.join('\n'), 'Scan to log in to LINE')
 
   if (presentation.terminal === null && !presentation.opened && presentation.htmlPath === null) {
     printLineQrUrl(url)

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -29,6 +29,7 @@ import { runLineBootstrap } from '@/init/line-auth'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 
 import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
+import { displayQR } from './qr'
 import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup } from './ui'
 
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
@@ -66,14 +67,15 @@ const addSub = defineCommand({
 
     intro(`Adding channel: ${CHANNEL_LABELS[channel]}`)
 
-    const credentials = await collectCredentials(channel, cwd)
+    const lineSpinnerHolder: LineAuthSpinnerHolder = { current: null }
+    const credentials = await collectCredentials(channel, cwd, lineSpinnerHolder)
 
     const events: AddChannelStepEvent[] = []
     try {
       await runAddChannel({
         cwd,
         ...credentials,
-        onProgress: reportProgress(events),
+        onProgress: reportProgress(events, lineSpinnerHolder),
       })
       if (credentials.channel === 'github' && credentials.tunnelProvider === 'none') {
         log.warn(
@@ -256,10 +258,13 @@ async function runReauth(cwd: string, adapter: ReauthableAdapter): Promise<void>
 }
 
 async function runLineReauth(cwd: string): Promise<void> {
-  const login = await promptLineLogin()
+  const holder: LineAuthSpinnerHolder = { current: null }
+  const login = await promptLineLogin(holderSpinnerControl(holder))
   const s = spinner()
   s.start('Logging in to LINE...')
+  holder.current = s
   const result = await runLineBootstrap({ ...login, agentDir: cwd })
+  holder.current = null
   if (!result.ok) {
     s.stop(`LINE login failed: ${result.reason}`)
     process.exit(1)
@@ -607,7 +612,11 @@ type CollectedCredentials =
       auth: { type: 'pat'; pat: string } | { type: 'app'; appId: number; privateKey: string; installationId?: number }
     }
 
-async function collectCredentials(channel: ChannelKind, cwd: string): Promise<CollectedCredentials> {
+async function collectCredentials(
+  channel: ChannelKind,
+  cwd: string,
+  lineSpinnerHolder?: LineAuthSpinnerHolder,
+): Promise<CollectedCredentials> {
   switch (channel) {
     case 'discord-bot':
       return { channel, discordBotToken: await promptDiscordToken() }
@@ -618,7 +627,7 @@ async function collectCredentials(channel: ChannelKind, cwd: string): Promise<Co
     case 'telegram-bot':
       return { channel, telegramBotToken: await promptTelegramToken() }
     case 'line': {
-      const login = await promptLineLogin()
+      const login = await promptLineLogin(lineSpinnerHolder ? holderSpinnerControl(lineSpinnerHolder) : undefined)
       return {
         channel,
         runLineAuth: ({ cwd: agentDir }) => runLineBootstrap({ ...login, agentDir }),
@@ -1061,7 +1070,7 @@ async function promptKakaotalkCredentials(
 }
 
 type LinePromptResult =
-  | { method: 'qr'; callbacks: { onQRUrl: (url: string) => void; onPincode: (pin: string) => void } }
+  | { method: 'qr'; callbacks: { onQRUrl: (url: string) => Promise<void>; onPincode: (pin: string) => void } }
   | {
       method: 'email'
       email: string
@@ -1069,7 +1078,17 @@ type LinePromptResult =
       callbacks: { onPincode: (pin: string) => void }
     }
 
-async function promptLineLogin(): Promise<LinePromptResult> {
+// The LINE QR login blocks while the SDK long-polls for a scan. During that
+// wait the add-flow spinner ('Logging in to LINE...') would otherwise keep
+// animating on top of the multi-line QR, garbling it. The controller lets the
+// QR callback stop the live spinner, print the QR, then restart it with a
+// "waiting for scan" message so output stays legible.
+export type LineQrSpinnerControl = {
+  stop: () => void
+  waiting: () => void
+}
+
+async function promptLineLogin(spinnerControl?: LineQrSpinnerControl): Promise<LinePromptResult> {
   note(
     [
       'LINE authentication uses a personal account registered as a sub-device.',
@@ -1100,7 +1119,7 @@ async function promptLineLogin(): Promise<LinePromptResult> {
     return {
       method: 'qr',
       callbacks: {
-        onQRUrl: printLineQrUrl,
+        onQRUrl: (url) => presentLineQr(url, spinnerControl),
         onPincode,
       },
     }
@@ -1125,17 +1144,63 @@ async function promptLineLogin(): Promise<LinePromptResult> {
   return { method: 'email', email, password: pwd, callbacks: { onPincode } }
 }
 
-// URL stays OUT of note(): clack wraps long lines with a `│` gutter that
-// corrupts copy-pasted URLs, and this login URL always wraps (it carries
-// `?secret=...&e2eeVersion=...`). Same fix as src/cli/oauth-callbacks.ts.
-export function printLineQrUrl(url: string, output: NodeJS.WritableStream = process.stdout): void {
-  note('Open this URL on your phone (or scan the QR it renders):', 'Log in to LINE')
-  output.write(`${url}\n`)
-  output.write('\n')
+async function presentLineQr(url: string, spinnerControl?: LineQrSpinnerControl): Promise<void> {
+  spinnerControl?.stop()
+  const presentation = await displayQR(url, {
+    title: 'LINE login',
+    scanInstruction: 'Scan with the LINE app on your phone',
+  })
+
+  const lines: string[] = []
+  if (presentation.terminal !== null) {
+    lines.push(presentation.terminal)
+    lines.push('Scan the QR code above with the LINE app on your phone.')
+    lines.push('If it is too small to scan, enlarge the terminal (or zoom out) and re-run.')
+    if (presentation.opened) {
+      lines.push('A browser window with a larger QR code was also opened.')
+    }
+  } else if (presentation.opened) {
+    lines.push('A browser window with the QR code was opened. Scan it with the LINE app on your phone.')
+  } else if (presentation.htmlPath !== null) {
+    lines.push(`Open this file in a browser and scan it with the LINE app: ${presentation.htmlPath}`)
+  }
+  note(lines.join('\n'), 'Scan to log in to LINE')
+
+  if (presentation.terminal === null && !presentation.opened && presentation.htmlPath === null) {
+    printLineQrUrl(url)
+  }
+
+  spinnerControl?.waiting()
 }
 
-function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEvent) => void {
-  const spinners: Partial<Record<AddChannelStepEvent['step'], ReturnType<typeof spinner>>> = {}
+// Last-resort fallback when no QR could be rendered. The raw URL stays OUT of
+// note(): clack wraps long lines with a `│` gutter that corrupts the login URL
+// (it carries `?secret=...&e2eeVersion=...`). Same constraint as
+// src/cli/oauth-callbacks.ts.
+export function printLineQrUrl(url: string, output: NodeJS.WritableStream = process.stdout): void {
+  note('Open this URL on a device that can render it as a QR code:', 'Log in to LINE')
+  output.write(`${url}\n\n`)
+}
+
+type Spinner = ReturnType<typeof spinner>
+
+// `current` is the live `line-auth` spinner, shared between `reportProgress`
+// (which owns its lifecycle) and the QR callback (which must pause it to print
+// a legible QR). It is null whenever no LINE login spinner is active.
+export type LineAuthSpinnerHolder = { current: Spinner | null }
+
+function holderSpinnerControl(holder: LineAuthSpinnerHolder): LineQrSpinnerControl {
+  return {
+    stop: () => holder.current?.stop('QR code ready.'),
+    waiting: () => holder.current?.start('Waiting for you to scan the QR code with the LINE app...'),
+  }
+}
+
+function reportProgress(
+  events: AddChannelStepEvent[],
+  lineSpinnerHolder?: LineAuthSpinnerHolder,
+): (event: AddChannelStepEvent) => void {
+  const spinners: Partial<Record<AddChannelStepEvent['step'], Spinner>> = {}
 
   return (event) => {
     events.push(event)
@@ -1143,6 +1208,7 @@ function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEv
       const s = spinner()
       s.start(START_MESSAGES[event.step])
       spinners[event.step] = s
+      if (event.step === 'line-auth' && lineSpinnerHolder) lineSpinnerHolder.current = s
       return
     }
 
@@ -1151,6 +1217,7 @@ function reportProgress(events: AddChannelStepEvent[]): (event: AddChannelStepEv
 
     switch (event.step) {
       case 'line-auth':
+        if (lineSpinnerHolder) lineSpinnerHolder.current = null
         s.stop(reportLineAuth(event.result))
         break
       case 'kakaotalk-auth':

--- a/src/cli/qr.test.ts
+++ b/src/cli/qr.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { buildQRHtml, displayQR, renderTerminalQR } from './qr'
+
+async function withDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'typeclaw-qr-test-'))
+  try {
+    return await fn(root)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+const URL = 'https://line.me/R/au/q/EXAMPLE'
+
+describe('buildQRHtml', () => {
+  test('embeds an SVG QR and escapes the title/instruction', async () => {
+    const html = await buildQRHtml(URL, {
+      title: 'LINE <login>',
+      scanInstruction: 'Scan "now" & go',
+      brandColor: '#06C755',
+    })
+
+    expect(html).toContain('<svg')
+    expect(html).toContain('#06C755')
+    expect(html).toContain('LINE &lt;login&gt;')
+    expect(html).toContain('Scan &quot;now&quot; &amp; go')
+    expect(html).not.toContain('<login>')
+  })
+})
+
+describe('renderTerminalQR', () => {
+  test('returns a non-empty terminal rendering for a URL', async () => {
+    const rendered = await renderTerminalQR(URL)
+    expect(rendered.length).toBeGreaterThan(0)
+  })
+})
+
+describe('displayQR', () => {
+  test('on a TTY: writes an HTML file, opens it, and includes a terminal QR', async () => {
+    await withDir(async (dir) => {
+      const opened: string[] = []
+      const result = await displayQR(URL, {
+        title: 'LINE login',
+        scanInstruction: 'Scan with the LINE app',
+        isTty: true,
+        tmpDir: dir,
+        now: () => 1234,
+        opener: async (p) => {
+          opened.push(p)
+        },
+      })
+
+      expect(result.qrUrl).toBe(URL)
+      expect(result.htmlPath).toBe(join(dir, 'typeclaw-line-login-1234.html'))
+      expect(result.opened).toBe(true)
+      expect(opened).toEqual([result.htmlPath!])
+      expect(result.terminal).not.toBeNull()
+      expect(result.terminal!.length).toBeGreaterThan(0)
+
+      const written = await readFile(result.htmlPath!, 'utf8')
+      expect(written).toContain('<svg')
+    })
+  })
+
+  test('non-TTY: still writes the HTML page but omits the terminal QR', async () => {
+    await withDir(async (dir) => {
+      const result = await displayQR(URL, {
+        title: 'LINE login',
+        scanInstruction: 'Scan with the LINE app',
+        isTty: false,
+        tmpDir: dir,
+        now: () => 1,
+        opener: async () => {},
+      })
+
+      expect(result.terminal).toBeNull()
+      expect(result.htmlPath).not.toBeNull()
+      const written = await readFile(result.htmlPath!, 'utf8')
+      expect(written).toContain('<svg')
+    })
+  })
+
+  test('opener failure degrades to opened=false without throwing', async () => {
+    await withDir(async (dir) => {
+      const result = await displayQR(URL, {
+        title: 'LINE login',
+        scanInstruction: 'Scan with the LINE app',
+        isTty: true,
+        tmpDir: dir,
+        now: () => 2,
+        opener: async () => {
+          throw new Error('no browser')
+        },
+      })
+
+      expect(result.opened).toBe(false)
+      expect(result.htmlPath).not.toBeNull()
+      expect(result.terminal).not.toBeNull()
+    })
+  })
+
+  test('unwritable tmp dir degrades to htmlPath=null and skips the opener', async () => {
+    let openerCalled = false
+    const result = await displayQR(URL, {
+      title: 'LINE login',
+      scanInstruction: 'Scan with the LINE app',
+      isTty: false,
+      tmpDir: join(tmpdir(), 'typeclaw-qr-does-not-exist', 'nested', 'missing'),
+      now: () => 3,
+      opener: async () => {
+        openerCalled = true
+      },
+    })
+
+    expect(result.htmlPath).toBeNull()
+    expect(result.opened).toBe(false)
+    expect(openerCalled).toBe(false)
+  })
+})

--- a/src/cli/qr.test.ts
+++ b/src/cli/qr.test.ts
@@ -37,6 +37,15 @@ describe('renderTerminalQR', () => {
     const rendered = await renderTerminalQR(URL)
     expect(rendered.length).toBeGreaterThan(0)
   })
+
+  test('stays compact enough to scan from an SSH terminal', async () => {
+    // A long LINE auth URL must still fit a conventional 24-row terminal so it
+    // is scannable over SSH without resizing. The 'L' ECC tuning is what keeps
+    // it under that ceiling; a regression to higher ECC would overflow.
+    const longUrl = `https://line.me/R/au/q/${'a'.repeat(64)}`
+    const rendered = await renderTerminalQR(longUrl)
+    expect(rendered.split('\n').length).toBeLessThanOrEqual(24)
+  })
 })
 
 describe('displayQR', () => {

--- a/src/cli/qr.ts
+++ b/src/cli/qr.ts
@@ -1,0 +1,127 @@
+import { execFile } from 'node:child_process'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+import QRCode from 'qrcode'
+
+const execFileAsync = promisify(execFile)
+
+// The upstream LINE SDK's QR login hands back a raw auth URL
+// (https://line.me/R/au/q/...), which is not scannable on its own — the LINE
+// mobile app needs an actual QR image. This module renders that URL the way the
+// upstream `agent-line` CLI does: an HTML page opened in the browser plus, on a
+// TTY, an inline ASCII QR. Every external effect is best-effort so a non-TTY or
+// browserless host degrades to a machine-readable scan payload rather than
+// blocking login.
+
+export type QRPresentation = {
+  qrUrl: string
+  htmlPath: string | null
+  terminal: string | null
+  opened: boolean
+}
+
+export type DisplayQROptions = {
+  title: string
+  scanInstruction: string
+  brandColor?: string
+  isTty?: boolean
+  opener?: (filePath: string) => Promise<void>
+  tmpDir?: string
+  now?: () => number
+}
+
+export async function buildQRHtml(
+  url: string,
+  options: { title: string; scanInstruction: string; brandColor: string },
+): Promise<string> {
+  const svg = await QRCode.toString(url, { type: 'svg', margin: 2 })
+  const title = escapeHtml(options.title)
+  const instruction = escapeHtml(options.scanInstruction)
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${title}</title>
+<style>body{display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;margin:0;font-family:-apple-system,system-ui,sans-serif;background:${options.brandColor}}
+.card{background:#fff;border-radius:16px;padding:40px;text-align:center;box-shadow:0 4px 24px rgba(0,0,0,.15)}
+h1{margin:0 0 8px;font-size:22px;color:#111}p{margin:0 0 24px;color:#666;font-size:14px}
+svg{width:280px;height:280px}</style></head>
+<body><div class="card"><h1>${title}</h1><p>${instruction}</p>${svg}</div></body></html>`
+}
+
+export async function renderTerminalQR(url: string): Promise<string> {
+  return QRCode.toString(url, { type: 'terminal', small: true })
+}
+
+// Writes the QR HTML to a temp file and tries to open it in the default
+// browser, and (when on a TTY) renders an inline ASCII QR. Every external
+// effect is best-effort: a failure to write, open, or render degrades the
+// result rather than throwing, so login is never blocked by presentation.
+export async function displayQR(url: string, options: DisplayQROptions): Promise<QRPresentation> {
+  const brandColor = options.brandColor ?? '#06C755'
+  const isTty = options.isTty ?? process.stderr.isTTY === true
+  const now = options.now ?? Date.now
+  const dir = options.tmpDir ?? tmpdir()
+
+  const htmlPath = await writeQRHtmlFile(url, {
+    title: options.title,
+    scanInstruction: options.scanInstruction,
+    brandColor,
+    dir,
+    stamp: now(),
+  })
+
+  let opened = false
+  if (htmlPath !== null) {
+    const open = options.opener ?? openInBrowser
+    opened = await open(htmlPath).then(
+      () => true,
+      () => false,
+    )
+  }
+
+  const terminal = isTty ? await renderTerminalQR(url).catch(() => null) : null
+
+  return { qrUrl: url, htmlPath, terminal, opened }
+}
+
+async function writeQRHtmlFile(
+  url: string,
+  options: { title: string; scanInstruction: string; brandColor: string; dir: string; stamp: number },
+): Promise<string | null> {
+  try {
+    const html = await buildQRHtml(url, options)
+    const slug =
+      options.title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'qr'
+    const htmlPath = join(options.dir, `typeclaw-${slug}-${options.stamp}.html`)
+    await writeFile(htmlPath, html, { mode: 0o600 })
+    return htmlPath
+  } catch {
+    return null
+  }
+}
+
+async function openInBrowser(filePath: string): Promise<void> {
+  const platform = process.platform
+  if (platform === 'darwin') {
+    await execFileAsync('open', [filePath])
+    return
+  }
+  if (platform === 'win32') {
+    await execFileAsync('cmd', ['/c', 'start', '', filePath])
+    return
+  }
+  await execFileAsync('xdg-open', [filePath])
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/cli/qr.ts
+++ b/src/cli/qr.ts
@@ -50,7 +50,10 @@ svg{width:280px;height:280px}</style></head>
 }
 
 export async function renderTerminalQR(url: string): Promise<string> {
-  return QRCode.toString(url, { type: 'terminal', small: true })
+  // 'L' error correction yields the fewest modules, so the QR stays small
+  // enough to scan from a terminal over SSH where screen real estate is the
+  // binding constraint. A short-lived auth URL doesn't need higher ECC.
+  return QRCode.toString(url, { type: 'terminal', small: true, errorCorrectionLevel: 'L' })
 }
 
 // Writes the QR HTML to a temp file and tries to open it in the default

--- a/src/init/line-auth.ts
+++ b/src/init/line-auth.ts
@@ -7,7 +7,7 @@ import { SecretsLineCredentialStore } from '@/secrets/line-store'
 export type LineBootstrapStatus = { ok: true } | { ok: false; reason: string }
 
 export type LineLoginCallbacks = {
-  onQRUrl?: (url: string) => void
+  onQRUrl?: (url: string) => void | Promise<void>
   onPincode: (pin: string) => void
 }
 
@@ -33,7 +33,10 @@ export type LineLoginInput =
 // Structural subset of the upstream LineClient the bootstrap drives. Declared
 // here so tests can inject a fake without standing up the real LOCO client.
 export type LineLoginClient = {
-  loginWithQR(options: { onQRUrl: (url: string) => void; onPincode: (pin: string) => void }): Promise<LineLoginResult>
+  loginWithQR(options: {
+    onQRUrl: (url: string) => void | Promise<void>
+    onPincode: (pin: string) => void
+  }): Promise<LineLoginResult>
   loginWithEmail(options: {
     email: string
     password: string
@@ -58,7 +61,9 @@ export async function runLineBootstrap(input: LineLoginInput): Promise<LineBoots
     const result =
       input.method === 'qr'
         ? await client.loginWithQR({
-            onQRUrl: (url) => input.callbacks.onQRUrl?.(url),
+            onQRUrl: async (url) => {
+              await input.callbacks.onQRUrl?.(url)
+            },
             onPincode: input.callbacks.onPincode,
           })
         : await client.loginWithEmail({


### PR DESCRIPTION
## Background

`typeclaw channel add line` (and `typeclaw channel reauth line`) drive the upstream LINE SDK's QR login. The SDK hands the `onQRUrl` callback a raw auth URL (e.g. `https://line.me/R/au/q/...`), and our callback only did:

```ts
onQRUrl: (url) => note(url, 'Open this URL on your phone (or scan the QR it renders)')
```

It printed the raw URL as text. The hint claimed "(or scan the QR it renders)" but **nothing rendered a QR**. A raw LINE auth URL is not something the LINE mobile app can scan — it needs an actual QR image — so the operator had no way to complete login. The add flow was effectively broken.

The correct reference behavior is the upstream `agent-messenger` `agent-line` CLI, whose `auth login` renders the URL via a shared `displayQR` util (HTML page opened in the browser + an inline terminal QR). That util is not exported from the package's public API, so we can't import it; we replicate the behavior in typeclaw instead.

## Summary

- New `src/cli/qr.ts` presenter renders a URL as a scannable QR: writes an HTML page and opens it in the default browser, and on a TTY also prints an inline ASCII QR (`qrcode` package). Every external effect is best-effort, so a non-TTY/browserless host degrades to a machine-readable scan payload rather than throwing or blocking login.
- `promptLineLogin` routes `onQRUrl` through the presenter for both `channel add line` and `channel reauth line`.
- **Spinner coordination.** The SDK long-polls for the scan while the add-flow spinner (`Logging in to LINE...`) is animating, which would garble the multi-line QR. A small spinner controller stops the live spinner, prints the QR, then restarts it with a `Waiting for you to scan...` message. Chosen over "print into the active spinner" because clack animates over multi-line output.
- `onQRUrl` is widened to `void | Promise<void>` and awaited. The SDK emits `qrcall` fire-and-forget and then blocks on the scan long-poll, so the async rendering completes well within the wait window (same shape the upstream CLI relies on).
- `qrcode` is promoted to a **direct dependency** — typeclaw now renders QR codes itself rather than leaning on the transitive `agent-messenger` copy, which could break on any upstream bump.

## What this does NOT do

- No change to credential persistence, the secrets schema, the LINE runtime adapter, or the email/password login path.
- Does not export `displayQR` as a public/plugin API; it's an internal host-stage CLI helper.
- Does not add QR rendering to other channels (KakaoTalk keeps its passcode flow).

## Review notes

- Load-bearing change: `presentLineQr` + the `LineAuthSpinnerHolder` controller in `src/cli/channel.ts`, and the async-`onQRUrl` widening in `src/init/line-auth.ts`.
- `src/cli/qr.ts` is covered by behavior tests (`src/cli/qr.test.ts`): TTY vs non-TTY output, opener-failure degradation, and unwritable-tmpdir degradation, using injected `opener`/`tmpDir`/`now` and real temp files (no clack mocking).
- This is host-stage only (`channel add`/`reauth`), where a browser and TTY are available.
