### PR TITLE
fix(channels): clear stuck Slack DM typing indicator

### DIFF
--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -227,6 +227,39 @@ describe('slack-bot createTypingCallback', () => {
     expect(clears).toHaveLength(0)
     expect(infos).toHaveLength(0)
   })
+
+  test('flat DM tick then stop ends cleared even when the tick tag resolves last', async () => {
+    // Reproduces the router's call order after a reply: a re-arm 'tick' fires
+    // (fire-and-forget) then the turn-end 'stop' fires. The bug let a slow
+    // formatChannelTag on the tick defer its FIFO enqueue past the stop's
+    // clear, stranding "is typing...". The real FIFO is wired in to assert the
+    // observable Slack status, not an internal call order.
+    // given
+    const statuses: string[] = []
+    const tracker = createSlackTypingTracker({
+      client: { setAssistantStatus: async (_chat, _thread, status) => void statuses.push(status) },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    const tagGates: Array<() => void> = []
+    const cb = createTypingCallback({
+      typingTracker: tracker,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      formatChannelTag: () => new Promise<string>((resolve) => tagGates.push(() => resolve('tag'))),
+    })
+    const dm = { adapter: 'slack-bot' as const, workspace: '@dm', chat: 'D0DM', thread: null }
+    const anchor = '1700000000.000100'
+
+    // when: tick enters first, stop second (router order)
+    const tickDone = cb({ ...dm, typingThread: anchor, phase: 'tick' })
+    const stopDone = cb({ ...dm, typingThread: anchor, phase: 'stop' })
+    // resolve tags in REVERSE: stop's tag first, tick's tag last
+    tagGates[1]?.()
+    tagGates[0]?.()
+    await Promise.all([tickDone, stopDone])
+
+    // then: regardless of tag timing, the last status on the wire is the clear
+    expect(statuses.at(-1)).toBe('')
+  })
 })
 
 describe('createSlackTypingTracker', () => {

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -359,18 +359,26 @@ export function createTypingCallback(deps: {
     // threads keep using `thread`. Either way the status is keyed on one ts.
     const statusThread =
       target.typingThread !== undefined && target.typingThread !== '' ? target.typingThread : target.thread
-    const tag = formatChannelTag
-      ? await formatChannelTag(target.workspace, statusThread ?? target.chat)
-      : `channel=${statusThread ?? target.chat}`
     if (statusThread === undefined || statusThread === null || statusThread === '') {
-      if (target.phase === 'tick') logger.info(`[slack-bot] typing (no-op, top-level chat) ${tag}`)
+      if (target.phase === 'tick') {
+        const tag = formatChannelTag
+          ? await formatChannelTag(target.workspace, statusThread ?? target.chat)
+          : `channel=${statusThread ?? target.chat}`
+        logger.info(`[slack-bot] typing (no-op, top-level chat) ${tag}`)
+      }
       return
     }
-    if (target.phase === 'stop') {
-      await typingTracker.clearAfterSend(target.chat, statusThread)
-      return
-    }
-    await typingTracker.setStatus(target.chat, statusThread, 'is typing...')
+    // Append to the per-(chat,thread) FIFO BEFORE awaiting anything: the FIFO
+    // only orders calls once setStatus/clearAfterSend is reached, so awaiting
+    // `formatChannelTag` first opens an unordered gap where a fire-and-forget
+    // re-arm 'tick' (router send() after a reply) can enqueue "is typing..."
+    // AFTER the turn-end 'stop' clear. Flat DMs have no threaded-reply
+    // auto-clear, so that strands the indicator until Slack's ~2-min timeout.
+    const enqueued =
+      target.phase === 'stop'
+        ? typingTracker.clearAfterSend(target.chat, statusThread)
+        : typingTracker.setStatus(target.chat, statusThread, 'is typing...')
+    await enqueued
   }
 }
 


### PR DESCRIPTION
## Background

In Slack **DMs**, the "is typing…" indicator could get stuck on after the agent finished replying, lingering until Slack's ~2-minute server-side timeout cleared it. Regular channels were never affected.

Root cause is an async-ordering race in the Slack typing callback, not a FIFO-serialization failure:

- The per-`(chat, threadTs)` FIFO in `createSlackTypingTracker` only orders calls **from the point `setStatus`/`clearAfterSend` is reached**.
- `createTypingCallback` did `await formatChannelTag(...)` **before** calling the tracker, opening an unordered gap between when `fireTyping()` is invoked and when the call actually lands in the FIFO.
- After a successful reply, router `send()` fires a **fire-and-forget** re-arm `'tick'` (`void fireTyping(live, 'tick')`) so the indicator doesn't blink off for 8s between mid-turn sends. If that tick's `formatChannelTag` resolved *after* the turn-end `'stop'` (fired from `drain()`'s finally and awaited), the tick enqueued `"is typing…"` onto the FIFO **after** the stop's clear — leaving the status ON.

Why DM-specific: a flat DM has `thread === null`, so the synthetic `typingThread` (the inbound ts) is the only valid status key, and there is **no threaded-reply auto-clear**. In a real channel the thread key is always present and Slack auto-clears the assistant status when the bot posts its threaded reply, so a late tick is harmless.

## Summary

Make the FIFO append happen **synchronously before any `await`** in `createTypingCallback`: call `setStatus`/`clearAfterSend` first, then `await` the returned promise. This guarantees enqueue order matches `fireTyping()` call order, so a re-arm tick fired before the stop can never land after it. `formatChannelTag` is now awaited only in the no-op (top-level chat) log path, where there is no tracker call to order — and where it was the only place the tag was actually used.

Behavior is preserved for channels and for the mid-turn multi-send case the re-arm tick exists to serve.

## What this does NOT do

- Does not change the heartbeat cadence, the re-arm-after-send behavior, or `stopTypingHeartbeat` ordering (`currentTurnTypingThread` is still nulled after the stop fires).
- Does not address the separate, pre-existing gap where a fully/partially failed `postMessage`/`uploadFile` skips `clearAfterSend` — `drain()`'s final stop normally cleans that up; called out here as out of scope.

## Review notes

- Load-bearing change: `src/channels/adapters/slack-bot.ts` `createTypingCallback` — the tracker call must precede every `await`. A future refactor that hoists `formatChannelTag` back above the enqueue silently reintroduces the bug (comment added to guard this).
- Regression test (`flat DM tick then stop ends cleared even when the tick tag resolves last`) wires the **real** FIFO tracker to the callback and **inverts** tag-resolution timing (resolves the stop's tag before the tick's), asserting the last wire status is the clear (`""`). Verified red→green: it fails with `Received: "is typing..."` against the unfixed callback.
- Full `src/channels/` suite green (1820 tests); `typecheck`/`lint`/`format` clean.