### PR TITLE
fix(channels): stop double-posting a PR review verdict as a duplicate comment

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -189,6 +189,22 @@ describe('renderSessionOrigin', () => {
     expect(out).toMatch(/Do not post an "On it" ack comment/i)
   })
 
+  test('github channel origin tells the bot a formal review verdict is the comment and must not be re-posted', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'pr:7',
+      thread: null,
+    })
+    // guards the real failure: an APPROVE review body and an identical plain
+    // comment posted seconds apart — the same verdict landing twice
+    expect(out).toMatch(/review verdict already IS the comment/i)
+    expect(out).toContain('APPROVE')
+    expect(out).toMatch(/never post it twice|visible duplicate/i)
+    expect(out).toMatch(/skip_response/)
+  })
+
   test('non-github channel origin keeps the "On it." text ack', () => {
     const out = renderSessionOrigin({
       kind: 'channel',

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -370,6 +370,17 @@ function renderChannelOrigin(
       'want to signal acknowledgment explicitly, use `channel_react({ emoji })`',
       '(it reacts, it does not comment) — never a text ack. Reserve `channel_reply`',
       'for the actual substantive answer.',
+      '',
+      '**A formal review verdict already IS the comment — never post it twice.**',
+      'When you submit a PR review (`APPROVE`, `REQUEST_CHANGES`, or `COMMENT`),',
+      'the review body renders on the PR as a comment, visually identical to a',
+      'plain comment. So put your entire verdict — the "approved", the praise,',
+      'the findings — in that review body. Do NOT then post the same (or',
+      'paraphrased) text again as a separate `channel_reply` / `gh pr comment`:',
+      'that is a visible duplicate, the exact same words landing twice seconds',
+      'apart. One verdict, one surface. If you have already submitted the review,',
+      'the PR has heard you — `skip_response({ reason: "verdict posted as review" })`',
+      'instead of echoing it as a comment.',
     )
   }
 


### PR DESCRIPTION
## Background

A GitHub channel bot was asked to approve a PR and posted the **same text twice**, seconds apart:

| Time | Surface | Body |
|------|---------|------|
| `10:51:46Z` | PR **review** (`state=APPROVED`) | "Approved — no more blocking issues from my side. Nice fix ✨" |
| `10:51:52Z` | plain PR **comment** | "Approved — no more blocking issues from my side. Nice fix ✨" *(byte-identical)* |

(Observed on #751 — `typeey[bot]` issue-comment id `4659012046` duplicating the approval review body 6s after it landed.)

Root cause is the github channel-origin prompt, not the router or any guard. A formal review body (`gh pr review --approve -b …` / `gh api … /reviews`) **already renders on the PR as a comment, visually identical to a plain comment.** The origin block had no guidance distinguishing the two surfaces, so the model treated "approve" and "leave my verdict as a comment" as two separate intents and did both — the approval *and* a redundant `channel_reply` / `gh pr comment` with the same words.

The existing approve-idempotency guard (`src/bundled-plugins/github-cli-auth/approve-idempotency.ts`) dedupes *two APPROVE submissions*, but it does not catch an APPROVE followed by a separate comment — different code path, no cross-check. So nothing in the system told the model the verdict body **is** the comment.

## Summary

Prompt-only fix (kept the blast radius minimal, matching the #751 precedent):

- **`session-origin.ts` (`renderChannelOrigin`, github branch):** add a directive that a formal verdict — `APPROVE` / `REQUEST_CHANGES` / `COMMENT` — IS the comment. Put the whole verdict in the review body; do **not** re-post the same (or paraphrased) text as a separate `channel_reply` / `gh pr comment`. If the review already landed, `skip_response` instead of echoing it.

Why prompt-only and not a deterministic guard: the failure is the model not *understanding* that the review body already serves as the comment, so strengthening the signal it reads is the targeted fix. A runtime hook that blocks a same-turn comment matching a just-submitted review body is a viable defense-in-depth backstop, but it's a larger, maintenance-heavy surface for a behavior the prompt can drive — left out unless this recurs.

The new guidance lives in the github-only branch of the channel-origin renderer, alongside the existing "`channel_reply` posts a public comment on this PR" and "don't post an 'On it' ack" directives — same audience, same surface.

## What this does NOT do

- No change to router engagement/stickiness, the approve-idempotency guard, or any bash policy.
- No deterministic keyword/comment auto-blocking — the model still decides; this only makes the right decision obvious.
- No change to non-github channel origins (Slack/Discord get the unchanged text).
- No change to `channel_reply` / `skip_response` semantics.

## Review notes

- Load-bearing change: the new `**A formal review verdict already IS the comment — never post it twice.**` block in `renderChannelOrigin`'s `origin.adapter === 'github'` branch (`src/agent/session-origin.ts`). It only renders for the github adapter.
- New regression test in `session-origin.test.ts` pins the "review verdict already IS the comment" framing, the verdict keywords, the "never post it twice" / "visible duplicate" wording, and the `skip_response` pointer. Adjacent non-github and `channel_disengage` tests are unchanged and still green.
- `bun run typecheck` / `lint` (0 errors; pre-existing warnings only) / `format:check` / full `test` (8412 pass, 0 fail) all pass.
