### PR TITLE
fix(inspect): stop live-tail freeze on a wedged WebSocket

### DIFF
--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -465,6 +465,73 @@ describe('streamLive — live session events', () => {
     await expect(drained).rejects.toThrow('websocket connect timed out')
   })
 
+  test('a wedged socket (bufferedAmount past ceiling) ends the generator cleanly', async () => {
+    // Regression: the live tail froze when its WebSocket wedged — ESTABLISHED at
+    // the TCP layer with a stuck send queue, never firing 'close'/'error'. The
+    // read loop parked forever (event loop idle) and the transcript viewer could
+    // never recover to the picker. The heartbeat watchdog detects the non-draining
+    // send queue via bufferedAmount and ends the generator as a clean close.
+    const fake = makeControllableWebSocket({ bufferedAmount: 2_000_000 })
+    const gen = streamLive({
+      url: 'ws://unused',
+      sessionId: 'ses_a',
+      WebSocketImpl: fake.ctor,
+      heartbeatIntervalMs: 5,
+      bufferedAmountCeiling: 1_048_576,
+    })
+
+    const events: InspectEvent[] = []
+    for await (const ev of gen) events.push(ev)
+    expect(events).toEqual([])
+    expect(fake.closed).toBe(true)
+  })
+
+  test('a ping with no pong within the deadline ends the generator cleanly', async () => {
+    // The pong-timeout branch covers a dead-but-quiet socket where bufferedAmount
+    // never climbs (no app writes pending) yet the peer is gone. A healthy idle
+    // tail keeps the connection because the server still pongs (next test).
+    const fake = makeControllableWebSocket({ pong: false })
+    const gen = streamLive({
+      url: 'ws://unused',
+      sessionId: 'ses_a',
+      WebSocketImpl: fake.ctor,
+      heartbeatIntervalMs: 5,
+      pongTimeoutMs: 15,
+    })
+
+    const events: InspectEvent[] = []
+    for await (const ev of gen) events.push(ev)
+    expect(events).toEqual([])
+    expect(fake.closed).toBe(true)
+    expect(fake.pingsReceived).toBeGreaterThan(0)
+  })
+
+  test('a healthy idle tail that pongs stays open until aborted', async () => {
+    const fake = makeControllableWebSocket({ pong: true })
+    const ctrl = new AbortController()
+    const gen = streamLive({
+      url: 'ws://unused',
+      sessionId: 'ses_a',
+      signal: ctrl.signal,
+      WebSocketImpl: fake.ctor,
+      heartbeatIntervalMs: 5,
+      pongTimeoutMs: 15,
+    })
+
+    const events: InspectEvent[] = []
+    const drained = (async () => {
+      for await (const ev of gen) events.push(ev)
+    })()
+    // Outlive several heartbeat cycles to prove the pongs keep the tail alive,
+    // then abort — the only thing that should end a healthy idle tail.
+    await new Promise((r) => setTimeout(r, 60))
+    expect(fake.closed).toBe(false)
+    expect(fake.pingsReceived).toBeGreaterThan(1)
+    ctrl.abort()
+    await drained
+    expect(events).toEqual([])
+  })
+
   test('unknown server message types are ignored without crashing', async () => {
     // Forward-compat: a future server may add new top-level message `type`
     // values. The client must not crash when it sees one — especially since
@@ -589,4 +656,74 @@ function makeNeverOpeningWebSocket(): typeof WebSocket {
     }
   }
   return FakeWS as unknown as typeof WebSocket
+}
+
+// Fake WebSocket that opens immediately, then drives the heartbeat branches: a
+// fixed `bufferedAmount` (to exercise the wedge ceiling) and optional pong
+// echoing (round-trip liveness). The returned handle exposes live state — read
+// via getters so assertions see updates after the generator runs, not a stale
+// snapshot.
+function makeControllableWebSocket(cfg: { bufferedAmount?: number; pong?: boolean }): {
+  ctor: typeof WebSocket
+  readonly closed: boolean
+  readonly pingsReceived: number
+} {
+  const state = { closed: false, pingsReceived: 0 }
+  class FakeWS {
+    readonly url: string
+    readyState = 0
+    bufferedAmount = cfg.bufferedAmount ?? 0
+    private readonly listeners = new Map<string, Set<(e: unknown) => void>>()
+
+    constructor(url: string) {
+      this.url = url
+      queueMicrotask(() => {
+        this.readyState = 1
+        this.dispatch('open', {})
+      })
+    }
+
+    addEventListener(type: string, fn: (e: unknown) => void, _opts?: unknown): void {
+      let set = this.listeners.get(type)
+      if (set === undefined) {
+        set = new Set()
+        this.listeners.set(type, set)
+      }
+      set.add(fn)
+    }
+
+    removeEventListener(type: string, fn: (e: unknown) => void): void {
+      this.listeners.get(type)?.delete(fn)
+    }
+
+    send(data: string): void {
+      const msg = JSON.parse(data) as { type: string; id?: number }
+      if (msg.type !== 'ping') return
+      state.pingsReceived += 1
+      if (cfg.pong === true) {
+        queueMicrotask(() => this.dispatch('message', { data: JSON.stringify({ type: 'pong', id: msg.id }) }))
+      }
+    }
+
+    close(): void {
+      state.closed = true
+      this.readyState = 3
+      queueMicrotask(() => this.dispatch('close', {}))
+    }
+
+    private dispatch(type: string, event: unknown): void {
+      const set = this.listeners.get(type)
+      if (set === undefined) return
+      for (const fn of set) fn(event)
+    }
+  }
+  return {
+    ctor: FakeWS as unknown as typeof WebSocket,
+    get closed() {
+      return state.closed
+    },
+    get pingsReceived() {
+      return state.pingsReceived
+    },
+  }
 }

--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -471,7 +471,9 @@ describe('streamLive — live session events', () => {
     // read loop parked forever (event loop idle) and the transcript viewer could
     // never recover to the picker. The heartbeat watchdog detects the non-draining
     // send queue via bufferedAmount and ends the generator as a clean close.
-    const fake = makeControllableWebSocket({ bufferedAmount: 2_000_000 })
+    // supportsPing:false proves this detection needs no server cooperation —
+    // it works even against a pre-heartbeat server that never pongs.
+    const fake = makeControllableWebSocket({ bufferedAmount: 2_000_000, supportsPing: false })
     const gen = streamLive({
       url: 'ws://unused',
       sessionId: 'ses_a',
@@ -484,6 +486,35 @@ describe('streamLive — live session events', () => {
     for await (const ev of gen) events.push(ev)
     expect(events).toEqual([])
     expect(fake.closed).toBe(true)
+    expect(fake.pingsReceived).toBe(0)
+  })
+
+  test('a pre-heartbeat server (no supportsPing) is never pinged and the tail stays open', async () => {
+    // Backward-compat: an old inspect server answers an unknown `ping` with an
+    // error + close, which would kill a healthy tail. The client must therefore
+    // never probe a server that did not advertise supportsPing on `subscribed`.
+    // Such a server degrades to bufferedAmount-only liveness (covered above).
+    const fake = makeControllableWebSocket({ supportsPing: false })
+    const ctrl = new AbortController()
+    const gen = streamLive({
+      url: 'ws://unused',
+      sessionId: 'ses_a',
+      signal: ctrl.signal,
+      WebSocketImpl: fake.ctor,
+      heartbeatIntervalMs: 5,
+      pongTimeoutMs: 15,
+    })
+
+    const events: InspectEvent[] = []
+    const drained = (async () => {
+      for await (const ev of gen) events.push(ev)
+    })()
+    await new Promise((r) => setTimeout(r, 60))
+    expect(fake.pingsReceived).toBe(0)
+    expect(fake.closed).toBe(false)
+    ctrl.abort()
+    await drained
+    expect(events).toEqual([])
   })
 
   test('a ping with no pong within the deadline ends the generator cleanly', async () => {
@@ -658,17 +689,20 @@ function makeNeverOpeningWebSocket(): typeof WebSocket {
   return FakeWS as unknown as typeof WebSocket
 }
 
-// Fake WebSocket that opens immediately, then drives the heartbeat branches: a
-// fixed `bufferedAmount` (to exercise the wedge ceiling) and optional pong
-// echoing (round-trip liveness). The returned handle exposes live state — read
-// via getters so assertions see updates after the generator runs, not a stale
-// snapshot.
-function makeControllableWebSocket(cfg: { bufferedAmount?: number; pong?: boolean }): {
+// Fake WebSocket that opens immediately, then drives the heartbeat branches.
+// On subscribe it replies `subscribed` advertising `supportsPing` (default
+// true, matching the current server) so the client arms ping probing; set it
+// false to emulate a pre-heartbeat server. Also models a fixed `bufferedAmount`
+// (wedge ceiling) and optional pong echoing (round-trip liveness). The returned
+// handle exposes live state via getters so assertions see post-run updates, not
+// a stale snapshot.
+function makeControllableWebSocket(cfg: { bufferedAmount?: number; pong?: boolean; supportsPing?: boolean }): {
   ctor: typeof WebSocket
   readonly closed: boolean
   readonly pingsReceived: number
 } {
   const state = { closed: false, pingsReceived: 0 }
+  const supportsPing = cfg.supportsPing ?? true
   class FakeWS {
     readonly url: string
     readyState = 0
@@ -698,6 +732,19 @@ function makeControllableWebSocket(cfg: { bufferedAmount?: number; pong?: boolea
 
     send(data: string): void {
       const msg = JSON.parse(data) as { type: string; id?: number }
+      if (msg.type === 'subscribe') {
+        queueMicrotask(() =>
+          this.dispatch('message', {
+            data: JSON.stringify({
+              type: 'subscribed',
+              sessionId: 'ses_a',
+              sessionLive: true,
+              ...(supportsPing ? { supportsPing: true } : {}),
+            }),
+          }),
+        )
+        return
+      }
       if (msg.type !== 'ping') return
       state.pingsReceived += 1
       if (cfg.pong === true) {

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -34,6 +34,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
 
   let heartbeat: ReturnType<typeof setInterval> | null = null
   let awaitingPongSince: number | null = null
+  let supportsPing = false
 
   const stopHeartbeat = (): void => {
     if (heartbeat !== null) {
@@ -59,6 +60,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
       return
     }
     if (msg.type === 'subscribed') {
+      supportsPing = msg.supportsPing === true
       opts.onSubscribed?.(msg.sessionLive)
       return
     }
@@ -162,6 +164,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
     intervalMs: opts.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
     pongTimeoutMs: opts.pongTimeoutMs ?? DEFAULT_PONG_TIMEOUT_MS,
     bufferedAmountCeiling: opts.bufferedAmountCeiling ?? DEFAULT_BUFFERED_AMOUNT_CEILING,
+    supportsPing: () => supportsPing,
     isAwaitingPongSince: () => awaitingPongSince,
     setAwaitingPongSince: (at) => {
       awaitingPongSince = at
@@ -220,6 +223,9 @@ type HeartbeatOptions = {
   intervalMs: number
   pongTimeoutMs: number
   bufferedAmountCeiling: number
+  // Read live: the `subscribed` reply that sets it arrives after the timer is
+  // armed, so a snapshot taken at startHeartbeat time would always be false.
+  supportsPing: () => boolean
   isAwaitingPongSince: () => number | null
   setAwaitingPongSince: (at: number | null) => void
   setTimer: (timer: ReturnType<typeof setInterval>) => void
@@ -230,11 +236,15 @@ type HeartbeatOptions = {
 // phase; once subscribed, a wedged socket (send queue not draining, no
 // 'close'/'error') would park the read loop forever. The interval fires on the
 // event-loop timer queue independent of the dead socket, so it always runs.
-// Two independent death signals, both treated as a clean close (return, never
-// throw) so the viewer recovers to the picker:
-//   1. bufferedAmount past a ceiling — our writes are not draining.
+// Two death signals, both treated as a clean close (return, never throw) so the
+// viewer recovers to the picker:
+//   1. bufferedAmount past a ceiling — our writes are not draining. Always on:
+//      it needs no server cooperation, so it works against any server version.
 //   2. a ping with no pong within the deadline — round-trip liveness lost,
-//      which also covers idle tails (a quiet-but-healthy tail still pongs).
+//      which also covers idle tails (a quiet-but-healthy tail still pongs). Only
+//      armed when the server advertised supportsPing; a pre-heartbeat server
+//      answers an unknown ping with error+close, so probing it would kill the
+//      tail. Such a server degrades to bufferedAmount-only detection.
 function startHeartbeat(opts: HeartbeatOptions): void {
   let pingId = 0
   const tick = (): void => {
@@ -242,6 +252,7 @@ function startHeartbeat(opts: HeartbeatOptions): void {
       opts.onDead()
       return
     }
+    if (!opts.supportsPing()) return
     const awaiting = opts.isAwaitingPongSince()
     if (awaiting !== null) {
       if (Date.now() - awaiting >= opts.pongTimeoutMs) opts.onDead()

--- a/src/inspect/live.ts
+++ b/src/inspect/live.ts
@@ -11,9 +11,15 @@ export type StreamLiveOptions = {
   onSubscribed?: (live: boolean) => void
   onError?: (message: string) => void
   connectTimeoutMs?: number
+  heartbeatIntervalMs?: number
+  pongTimeoutMs?: number
+  bufferedAmountCeiling?: number
 }
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 5_000
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 10_000
+const DEFAULT_PONG_TIMEOUT_MS = 30_000
+const DEFAULT_BUFFERED_AMOUNT_CEILING = 1_048_576
 
 export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<InspectEvent> {
   const WS = opts.WebSocketImpl ?? WebSocket
@@ -25,6 +31,16 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
 
   const accumulators = new Map<string, string>()
   const thinkingAccumulators = new Map<string, string>()
+
+  let heartbeat: ReturnType<typeof setInterval> | null = null
+  let awaitingPongSince: number | null = null
+
+  const stopHeartbeat = (): void => {
+    if (heartbeat !== null) {
+      clearInterval(heartbeat)
+      heartbeat = null
+    }
+  }
 
   const wake = (): void => {
     if (resolveNext !== null) {
@@ -46,10 +62,15 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
       opts.onSubscribed?.(msg.sessionLive)
       return
     }
+    if (msg.type === 'pong') {
+      awaitingPongSince = null
+      return
+    }
     if (msg.type === 'error') {
       opts.onError?.(msg.message)
       pendingError = msg.message
       closed = true
+      stopHeartbeat()
       try {
         ws.close()
       } catch {
@@ -84,6 +105,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
   })
   ws.addEventListener('close', () => {
     closed = true
+    stopHeartbeat()
     wake()
   })
 
@@ -99,6 +121,7 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
         'abort',
         () => {
           closed = true
+          stopHeartbeat()
           try {
             ws.close()
           } catch {
@@ -134,25 +157,106 @@ export async function* streamLive(opts: StreamLiveOptions): AsyncGenerator<Inspe
   }
   ws.send(JSON.stringify(subscribe))
 
-  while (true) {
-    if (buffer.length > 0) {
-      const next = buffer.shift()!
-      yield next
-      continue
+  startHeartbeat({
+    ws,
+    intervalMs: opts.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
+    pongTimeoutMs: opts.pongTimeoutMs ?? DEFAULT_PONG_TIMEOUT_MS,
+    bufferedAmountCeiling: opts.bufferedAmountCeiling ?? DEFAULT_BUFFERED_AMOUNT_CEILING,
+    isAwaitingPongSince: () => awaitingPongSince,
+    setAwaitingPongSince: (at) => {
+      awaitingPongSince = at
+    },
+    setTimer: (timer) => {
+      heartbeat = timer
+    },
+    onDead: () => {
+      closed = true
+      stopHeartbeat()
+      try {
+        ws.close()
+      } catch {
+        /* ignore */
+      }
+      wake()
+    },
+  })
+
+  try {
+    while (true) {
+      if (buffer.length > 0) {
+        const next = buffer.shift()!
+        yield next
+        continue
+      }
+      if (closed) {
+        if (pendingError !== null) throw new Error(pendingError)
+        return
+      }
+      const { event, done } = await new Promise<{ event: InspectEvent | null; done: boolean }>((resolve) => {
+        resolveNext = resolve
+      })
+      if (event !== null) yield event
+      if (done) {
+        if (pendingError !== null) throw new Error(pendingError)
+        return
+      }
     }
-    if (closed) {
-      if (pendingError !== null) throw new Error(pendingError)
-      return
-    }
-    const { event, done } = await new Promise<{ event: InspectEvent | null; done: boolean }>((resolve) => {
-      resolveNext = resolve
-    })
-    if (event !== null) yield event
-    if (done) {
-      if (pendingError !== null) throw new Error(pendingError)
-      return
+  } finally {
+    // Also fired when the consumer abandons the generator (break from a
+    // `for await` calls .return()): close the socket so it can't outlive the
+    // viewer, not just the heartbeat timer.
+    stopHeartbeat()
+    closed = true
+    try {
+      ws.close()
+    } catch {
+      /* ignore */
     }
   }
+}
+
+type HeartbeatOptions = {
+  ws: WebSocket
+  intervalMs: number
+  pongTimeoutMs: number
+  bufferedAmountCeiling: number
+  isAwaitingPongSince: () => number | null
+  setAwaitingPongSince: (at: number | null) => void
+  setTimer: (timer: ReturnType<typeof setInterval>) => void
+  onDead: () => void
+}
+
+// Steady-state liveness watchdog. The connect gate only bounds the OPENING
+// phase; once subscribed, a wedged socket (send queue not draining, no
+// 'close'/'error') would park the read loop forever. The interval fires on the
+// event-loop timer queue independent of the dead socket, so it always runs.
+// Two independent death signals, both treated as a clean close (return, never
+// throw) so the viewer recovers to the picker:
+//   1. bufferedAmount past a ceiling — our writes are not draining.
+//   2. a ping with no pong within the deadline — round-trip liveness lost,
+//      which also covers idle tails (a quiet-but-healthy tail still pongs).
+function startHeartbeat(opts: HeartbeatOptions): void {
+  let pingId = 0
+  const tick = (): void => {
+    if (opts.ws.bufferedAmount >= opts.bufferedAmountCeiling) {
+      opts.onDead()
+      return
+    }
+    const awaiting = opts.isAwaitingPongSince()
+    if (awaiting !== null) {
+      if (Date.now() - awaiting >= opts.pongTimeoutMs) opts.onDead()
+      return
+    }
+    pingId += 1
+    const ping: InspectClientMessage = { type: 'ping', id: pingId }
+    try {
+      opts.ws.send(JSON.stringify(ping))
+      opts.setAwaitingPongSince(Date.now())
+    } catch {
+      opts.onDead()
+    }
+  }
+  opts.setTimer(setInterval(tick, opts.intervalMs))
 }
 
 function frameToEvent(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1318,7 +1318,7 @@ function handleInspectMessage(
     })
   }
 
-  sendInspect(ws, { type: 'subscribed', sessionId: msg.sessionId, sessionLive: live !== undefined })
+  sendInspect(ws, { type: 'subscribed', sessionId: msg.sessionId, sessionLive: live !== undefined, supportsPing: true })
 }
 
 function extractJobId(target: StreamMessage['target']): string {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1265,6 +1265,10 @@ function handleInspectMessage(
     ws.close()
     return
   }
+  if (msg.type === 'ping') {
+    sendInspect(ws, { type: 'pong', id: msg.id })
+    return
+  }
   if (msg.type !== 'subscribe' || typeof msg.sessionId !== 'string' || msg.sessionId === '') {
     sendInspect(ws, { type: 'error', message: 'invalid inspect subscription' })
     ws.close()

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -44,16 +44,22 @@ export type TunnelLogsServerMessage =
   | { type: 'error'; message: string }
   | { type: 'end' }
 
-export type InspectClientMessage = {
-  type: 'subscribe'
-  sessionId: string
-  // sinceMs is a wall-clock cutoff for backfilling broadcasts from the
-  // in-process Stream ring buffer. The client uses Date.now() - duration;
-  // omit to skip broadcast backfill. AgentSession events are NEVER
-  // backfilled (the session's pi-coding-agent subscribe API delivers
-  // future events only).
-  sinceMs?: number
-}
+export type InspectClientMessage =
+  | {
+      type: 'subscribe'
+      sessionId: string
+      // sinceMs is a wall-clock cutoff for backfilling broadcasts from the
+      // in-process Stream ring buffer. The client uses Date.now() - duration;
+      // omit to skip broadcast backfill. AgentSession events are NEVER
+      // backfilled (the session's pi-coding-agent subscribe API delivers
+      // future events only).
+      sinceMs?: number
+    }
+  // Steady-state liveness probe echoed back as a pong. A live tail is
+  // legitimately quiet for long stretches, so absence of inbound frames cannot
+  // distinguish "idle" from "dead"; a missed pong can. Guards a wedged
+  // WebSocket that stays ESTABLISHED yet never fires 'close'/'error'.
+  | { type: 'ping'; id: number }
 
 export type InspectFramePayload =
   | { kind: 'text_delta'; sessionId: string; delta: string }
@@ -126,6 +132,7 @@ export type InspectServerMessage =
   | { type: 'subscribed'; sessionId: string; sessionLive: boolean }
   | { type: 'frame'; ts: number; payload: InspectFramePayload }
   | { type: 'error'; message: string }
+  | { type: 'pong'; id: number }
 
 export type ClientMessage =
   | { type: 'prompt'; text: string; delivery?: PromptDelivery }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -129,7 +129,11 @@ export type InspectFramePayload =
     }
 
 export type InspectServerMessage =
-  | { type: 'subscribed'; sessionId: string; sessionLive: boolean }
+  // supportsPing is the heartbeat capability flag. A pre-heartbeat server omits
+  // it; the client must treat its absence as "no ping support" and never send a
+  // ping (an old server answers an unknown ping with an error + close, killing
+  // the tail). Strict opt-in: only an explicit true arms round-trip probing.
+  | { type: 'subscribed'; sessionId: string; sessionLive: boolean; supportsPing?: true }
   | { type: 'frame'; ts: number; payload: InspectFramePayload }
   | { type: 'error'; message: string }
   | { type: 'pong'; id: number }


### PR DESCRIPTION
## Background

`typeclaw inspect` froze after a user selected a session and watched it live: the terminal stopped responding to keystrokes, never returned to the picker, and no shell prompt came back. Reproduced on a running agent (host stage), then diagnosed at the OS level:

- Process state `S+` (interruptible sleep), **not** `R` — no CPU spin, no busy loop.
- `sample` of the hung process: **1408/1414 stacks parked in `kevent64`** on the main thread. The event loop is idle, awaiting an event that never arrives — a promise that never resolves.
- `lsof` + `netstat`: the inspect client's `/inspect` WebSocket was still **ESTABLISHED** at the TCP layer, but with **~1MB stuck in its send queue, not draining** (a healthy concurrent TUI connection sat at ~1–2KB). Wedged socket; no `close`/`error` event ever fired.

Root-cause mechanism is in the inspect live-tail WebSocket client (`streamLive`). The connect gate has a 5s timeout, but the **steady-state read loop has none**. When the socket wedges (ESTABLISHED, send queue not draining, no `close`/`error`), `wake()` is never called and the read loop parks on its pending promise forever. The transcript viewer (`createTranscriptView`) drives that pump and only settles on a keystroke or on the pump ending — so once the socket wedges, the whole single-threaded CLI sits idle in `kevent64` and appears frozen.

## Summary

Add a client-side **heartbeat watchdog**, armed once the client has subscribed. It runs on the event-loop timer queue (`setInterval`), which fires independently of the wedged socket — the property that actually breaks the `kevent64` idle. It ends the generator as a **clean close** (return, not throw) so the viewer recovers to the picker, on either of two independent death signals:

1. `bufferedAmount` past a ceiling (default 1 MiB) — our own writes aren't draining. This matches the observed stuck-send-queue shape directly.
2. A ping with no pong within a deadline (default 30s, probed every 10s) — round-trip liveness lost.

**Why a ping/pong round-trip and not a plain receive-idle timeout:** a live tail is legitimately quiet for long stretches (an idle agent emits nothing). "No inbound frames" cannot distinguish *idle* from *dead*; a missed pong can. A naive receive-idle timeout would wrongly kill healthy quiet tails.

**Why a new `ping`/`pong` message and not reusing `subscribe`:** the standard `WebSocket` client exposes no ping-frame API, and a duplicate `subscribe` has real server-side side effects (unsubscribe/resubscribe + `sinceMs` backfill replay). The new inspect-only `ping`/`pong` pair is a side-effect-free probe; the server echoes it before subscribe validation.

The generator's `finally` now also closes the socket, so an abandoned stream (consumer breaks the `for await`, calling `.return()`) can't leave the WebSocket open past the viewer.

## What this does NOT do

- No server protocol changes beyond the side-effect-free `ping`/`pong` echo; no change to subscription, backfill, or frame semantics.
- Does not touch the container-logs viewer (`docker logs -f`) or the writable TUI path — only the session live-tail WebSocket client.
- Does not add TCP-level keepalive (not controllable from the JS `WebSocket` API).
- Does not change the existing 5s connect-gate timeout.

## Review notes

- Load-bearing change: `startHeartbeat` in `src/inspect/live.ts` and the `try/finally` around the read loop. The watchdog must always end as a *clean* return (the loop's `if (closed) return` / `done` paths), never a throw, or the viewer would surface an error instead of returning to the picker.
- Invariant to verify: only one ping is outstanding at a time (a new ping is sent only when `awaitingPongSince === null`), so ignoring the pong `id` is safe.
- `bufferedAmount` reflects outbound queued bytes only; this client sends just the subscribe frame + tiny pings, so a healthy connection stays near zero and won't false-positive from inbound traffic.
- Tests in `src/inspect/live.test.ts` use a controllable fake WebSocket (configurable `bufferedAmount` + optional pong echo). The two "ends the generator cleanly" tests were verified to hang without the fix (TDD red) and pass with it; a third asserts a healthy idle tail that pongs stays open until aborted.