### PR TITLE
feat: auto-sync npm plugins from typeclaw.json into package.json

### DIFF
--- a/docs/content/docs/guides/write-a-plugin.mdx
+++ b/docs/content/docs/guides/write-a-plugin.mdx
@@ -102,6 +102,16 @@ Custom plugins live under `packages/<plugin-name>/` — the agent folder is a bu
 
 The config key (`notify`) is the plugin's derived name — for this local plugin, the basename of `./packages/notify`. `plugins[]` is **restart-required** — plugins load once at container boot, so adding one needs a restart (which the agent does for you), not a `reload`.
 
+**npm plugins** are registered by package name instead of path, optionally pinned with an npm-style version suffix:
+
+```json
+{
+  "plugins": ["typeclaw-plugin-standup@1.2.3", "@acme/typeclaw-plugin-helicone"]
+}
+```
+
+`typeclaw.json` is the single source of truth — you don't edit `package.json`. On the next `typeclaw start`, the npm entries are materialized into `package.json#dependencies` and installed; removing an entry prunes it. A bare name (no `@version`) resolves to the current latest and is pinned, the same way `bun add <name>` writes a concrete version. Provenance is tracked under `package.json#typeclaw.managedPlugins`, so the sync only ever touches plugins it added — never your own dependencies. The agent itself can only add or version-bump a plugin entry when running at `owner`/`trusted` trust; lower-trust channel input is blocked by the bundled `security` plugin's `pluginAddition` guard, since installing a package runs host-side code.
+
 </Accordion>
 
 <Accordion title="What plugins can't do">

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -12,6 +12,7 @@ import {
   recordGitRemoteTaintIfAny,
 } from './policies/git-exfil'
 import { GUARD_OUTBOUND_SECRET_SEVERITY, checkOutboundSecretGuard } from './policies/outbound-secret-scan'
+import { GUARD_PLUGIN_ADDITION_SEVERITY, checkPluginAdditionGuard } from './policies/plugin-addition'
 import { checkPrivateSurfaceReadGuard } from './policies/private-surface-read'
 import { applyPromptInjectionDefense } from './policies/prompt-injection'
 import { clearSessionTaints } from './policies/remote-taint-state'
@@ -68,6 +69,8 @@ const BYPASS_ROLE_HINT = {
     'owner and trusted have it by default (medium tier); member and guest do not. The privilege-escalation defense for trusted now depends on operator review of `typeclaw.json` backup commits — `roles` is restart-required, so the operator has wall-clock time to revert before the new role table takes effect. Operators who do not review can re-tighten by replacing `roles.trusted.permissions[]` with an explicit list that omits `security.bypass.medium`.',
   [SECURITY_PERMISSIONS.bypassCronPromotion]:
     'owner and trusted have it by default (medium tier); member and guest do not. Same shape as rolePromotion but deferred: a new cron job (or a changed scheduledByRole) fires at schedule-time as the stamped role. The operator-review window between write and execution is the trusted-tier defense.',
+  [SECURITY_PERMISSIONS.bypassPluginAddition]:
+    'owner and trusted have it by default (medium tier); member and guest do not. Same shape as cronPromotion but for host-side install: a new (or version-bumped) plugins[] entry is materialized into package.json and installed by the next host `typeclaw start`, running npm lifecycle scripts as the operator. The operator-review window between the typeclaw.json write and the next start is the trusted-tier defense.',
 } as const satisfies Record<PerGuardSecurityPermission, string>
 
 function withPermissionHint(
@@ -120,6 +123,18 @@ export default definePlugin({
               GUARD_CRON_PROMOTION_SEVERITY,
             )
         if (cronPromotionResult) return cronPromotionResult
+
+        const pluginAdditionResult = canBypass(
+          GUARD_PLUGIN_ADDITION_SEVERITY,
+          SECURITY_PERMISSIONS.bypassPluginAddition,
+        )
+          ? undefined
+          : withPermissionHint(
+              await checkPluginAdditionGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir }),
+              SECURITY_PERMISSIONS.bypassPluginAddition,
+              GUARD_PLUGIN_ADDITION_SEVERITY,
+            )
+        if (pluginAdditionResult) return pluginAdditionResult
 
         // Taint-recording runs FIRST, independently of the gitExfil guard.
         // The gitRemoteTainted defense depends on it. We pass through

--- a/src/bundled-plugins/security/permissions.test.ts
+++ b/src/bundled-plugins/security/permissions.test.ts
@@ -4,6 +4,7 @@ import { HIGH_TIER_PER_GUARD_PERMISSIONS, SECURITY_PERMISSIONS, SEVERITY_PERMISS
 import { GUARD_CRON_PROMOTION_SEVERITY } from './policies/cron-promotion'
 import { GUARD_GIT_EXFIL_SEVERITY, GUARD_GIT_REMOTE_TAINTED_SEVERITY } from './policies/git-exfil'
 import { GUARD_OUTBOUND_SECRET_SEVERITY } from './policies/outbound-secret-scan'
+import { GUARD_PLUGIN_ADDITION_SEVERITY } from './policies/plugin-addition'
 import { GUARD_ROLE_PROMOTION_SEVERITY } from './policies/role-promotion'
 import { GUARD_SECRET_EXFIL_BASH_SEVERITY } from './policies/secret-exfil-bash'
 import { GUARD_SECRET_EXFIL_READ_SEVERITY } from './policies/secret-exfil-read'
@@ -45,7 +46,7 @@ describe('per-guard severity classification', () => {
     expect(GUARD_GIT_REMOTE_TAINTED_SEVERITY).toBe('high')
   })
 
-  test('medium-tier guards (silent-attack + operator-reviewable-state axes): secretExfilBash, secretExfilRead, ssrf, sessionSearchSecrets, gitExfil, rolePromotion, cronPromotion', () => {
+  test('medium-tier guards (silent-attack + operator-reviewable-state axes): secretExfilBash, secretExfilRead, ssrf, sessionSearchSecrets, gitExfil, rolePromotion, cronPromotion, pluginAddition', () => {
     expect(GUARD_SECRET_EXFIL_BASH_SEVERITY).toBe('medium')
     expect(GUARD_SECRET_EXFIL_READ_SEVERITY).toBe('medium')
     expect(GUARD_SSRF_SEVERITY).toBe('medium')
@@ -53,6 +54,7 @@ describe('per-guard severity classification', () => {
     expect(GUARD_GIT_EXFIL_SEVERITY).toBe('medium')
     expect(GUARD_ROLE_PROMOTION_SEVERITY).toBe('medium')
     expect(GUARD_CRON_PROMOTION_SEVERITY).toBe('medium')
+    expect(GUARD_PLUGIN_ADDITION_SEVERITY).toBe('medium')
   })
 
   test('no guards are classified low today (tier reserved for noisy, immediately-recoverable side effects)', () => {
@@ -67,6 +69,7 @@ describe('per-guard severity classification', () => {
       GUARD_SESSION_SEARCH_SECRETS_SEVERITY,
       GUARD_ROLE_PROMOTION_SEVERITY,
       GUARD_CRON_PROMOTION_SEVERITY,
+      GUARD_PLUGIN_ADDITION_SEVERITY,
     ]
     expect(severities.filter((s) => s === 'low')).toEqual([])
   })

--- a/src/bundled-plugins/security/permissions.ts
+++ b/src/bundled-plugins/security/permissions.ts
@@ -11,6 +11,7 @@ export const SECURITY_PERMISSIONS = {
   bypassGitRemoteTainted: 'security.bypass.gitRemoteTainted',
   bypassRolePromotion: 'security.bypass.rolePromotion',
   bypassCronPromotion: 'security.bypass.cronPromotion',
+  bypassPluginAddition: 'security.bypass.pluginAddition',
   // Severity-tier bypasses. Tiers classify guards on a two-axis policy:
   //   high   — bypass sends data to a third-party audience outside the
   //            operator's control loop (channel readers, remote git host).

--- a/src/bundled-plugins/security/policies/plugin-addition.test.ts
+++ b/src/bundled-plugins/security/policies/plugin-addition.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { ACKNOWLEDGE_GUARDS } from '../policy'
+import { checkPluginAdditionGuard, diffPlugins, GUARD_PLUGIN_ADDITION } from './plugin-addition'
+
+async function makeAgentDir(config: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-guard-'))
+  await writeFile(join(dir, 'typeclaw.json'), `${JSON.stringify(config, null, 2)}\n`)
+  return dir
+}
+
+function writeArgs(config: unknown): Record<string, unknown> {
+  return { path: 'typeclaw.json', content: `${JSON.stringify(config, null, 2)}\n` }
+}
+
+describe('diffPlugins', () => {
+  test('flags a newly added plugin', () => {
+    expect(diffPlugins([], ['typeclaw-plugin-foo@1.2.3'])).toEqual([
+      { kind: 'plugin-added', name: 'typeclaw-plugin-foo', versionSpec: '1.2.3' },
+    ])
+  })
+
+  test('flags a version change on an existing plugin', () => {
+    expect(diffPlugins(['typeclaw-plugin-foo@1.0.0'], ['typeclaw-plugin-foo@2.0.0'])).toEqual([
+      { kind: 'version-changed', name: 'typeclaw-plugin-foo', from: '1.0.0', to: '2.0.0' },
+    ])
+  })
+
+  test('does not flag a removal', () => {
+    expect(diffPlugins(['typeclaw-plugin-foo@1.0.0'], [])).toEqual([])
+  })
+
+  test('does not flag a reorder', () => {
+    expect(diffPlugins(['a@1', 'b@2'], ['b@2', 'a@1'])).toEqual([])
+  })
+
+  test('ignores local-path entries entirely', () => {
+    expect(diffPlugins([], ['./plugins/local.ts', '../x.ts', '/abs.ts'])).toEqual([])
+  })
+})
+
+describe('checkPluginAdditionGuard', () => {
+  test('blocks adding a plugin via write', async () => {
+    const dir = await makeAgentDir({ plugins: [] })
+    try {
+      const result = await checkPluginAdditionGuard({
+        tool: 'write',
+        args: writeArgs({ plugins: ['typeclaw-plugin-foo@1.2.3'] }),
+        agentDir: dir,
+      })
+      expect(result?.block).toBe(true)
+      expect(result?.reason).toContain('typeclaw-plugin-foo')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('allows removing a plugin', async () => {
+    const dir = await makeAgentDir({ plugins: ['typeclaw-plugin-foo@1.2.3'] })
+    try {
+      const result = await checkPluginAdditionGuard({
+        tool: 'write',
+        args: writeArgs({ plugins: [] }),
+        agentDir: dir,
+      })
+      expect(result).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('blocks a version bump of an existing plugin', async () => {
+    const dir = await makeAgentDir({ plugins: ['typeclaw-plugin-foo@1.0.0'] })
+    try {
+      const result = await checkPluginAdditionGuard({
+        tool: 'write',
+        args: writeArgs({ plugins: ['typeclaw-plugin-foo@2.0.0'] }),
+        agentDir: dir,
+      })
+      expect(result?.block).toBe(true)
+      expect(result?.reason).toContain('version changes')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('passes through when the acknowledgement is present', async () => {
+    const dir = await makeAgentDir({ plugins: [] })
+    try {
+      const result = await checkPluginAdditionGuard({
+        tool: 'write',
+        args: {
+          ...writeArgs({ plugins: ['typeclaw-plugin-foo@1.2.3'] }),
+          [ACKNOWLEDGE_GUARDS]: { [GUARD_PLUGIN_ADDITION]: true },
+        },
+        agentDir: dir,
+      })
+      expect(result).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('ignores writes to files other than typeclaw.json', async () => {
+    const dir = await makeAgentDir({ plugins: [] })
+    try {
+      const result = await checkPluginAdditionGuard({
+        tool: 'write',
+        args: { path: 'README.md', content: 'plugins: typeclaw-plugin-foo' },
+        agentDir: dir,
+      })
+      expect(result).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('allows adding a local-path plugin without acknowledgement', async () => {
+    const dir = await makeAgentDir({ plugins: [] })
+    try {
+      const result = await checkPluginAdditionGuard({
+        tool: 'write',
+        args: writeArgs({ plugins: ['./plugins/local.ts'] }),
+        agentDir: dir,
+      })
+      expect(result).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('refuses multi-edit on typeclaw.json', async () => {
+    const dir = await makeAgentDir({ plugins: [] })
+    try {
+      const result = await checkPluginAdditionGuard({
+        tool: 'edit',
+        args: {
+          path: 'typeclaw.json',
+          edits: [
+            { oldText: 'a', newText: 'b' },
+            { oldText: 'c', newText: 'd' },
+          ],
+        },
+        agentDir: dir,
+      })
+      expect(result?.block).toBe(true)
+      expect(result?.reason).toContain('refuses multi-edit')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/bundled-plugins/security/policies/plugin-addition.ts
+++ b/src/bundled-plugins/security/policies/plugin-addition.ts
@@ -1,0 +1,240 @@
+import { readFile, realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+import { parseConfigJson } from '@/config'
+import { splitPluginEntrySpec } from '@/plugin'
+
+import type { SecuritySeverity } from '../permissions'
+import { ACKNOWLEDGE_GUARDS, type SecurityBlock, isGuardAcknowledged } from '../policy'
+
+export const GUARD_PLUGIN_ADDITION = 'pluginAddition'
+// Classified `medium` (silent-attack axis), same tier and rationale as
+// `rolePromotion` and `cronPromotion`. Adding (or version-bumping) a plugin in
+// typeclaw.json is a deferred host-code-execution grant: the entry is
+// materialized into package.json by `reconcilePluginDeps` and installed by the
+// next host `typeclaw start`, at which point npm lifecycle scripts run as the
+// operator on the host. `plugins` is restart-required and typeclaw.json is
+// force-committed by auto-backup, so the operator sees the change in `git log`
+// and backup commits BEFORE any install fires — an operator-reviewable window
+// between the privileged write and the privileged execution. Owner and trusted
+// bypass without ack; member and guest are blocked.
+//
+// What counts as a plugin addition (any of):
+//   1. A new entry appeared in `plugins[]` (by package name).
+//   2. An existing entry's pinned version spec changed (`foo@1` -> `foo@2`):
+//      a different package version is a different body of host code, the same
+//      shape as cron's body-changed finding.
+//
+// What does NOT count (allowed without ack):
+//   - Removing an entry from `plugins[]` (a privilege REDUCTION; uninstalling
+//     runs no untrusted code).
+//   - Reordering entries.
+//   - Local-path entries (`./`, `../`, absolute): these are never installed
+//     from a registry, so there is no lifecycle-script execution to gate. They
+//     are confined to the agent dir by the loader.
+//
+// Failure-open is deliberate, same direction as the sibling guards: an
+// unreadable/unparseable existing typeclaw.json makes every proposed entry look
+// new and blocks. The only false positive is an operator authoring a fresh
+// config with plugins, which they ack in the same call.
+export const GUARD_PLUGIN_ADDITION_SEVERITY: SecuritySeverity = 'medium'
+
+export type PluginAdditionFinding =
+  | { kind: 'plugin-added'; name: string; versionSpec: string }
+  | { kind: 'version-changed'; name: string; from: string; to: string }
+
+export async function checkPluginAdditionGuard(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): Promise<SecurityBlock | undefined> {
+  const { tool, args, agentDir } = options
+  if (tool !== 'write' && tool !== 'edit') return undefined
+
+  const rawPath = args.path
+  if (typeof rawPath !== 'string') return undefined
+
+  const targetPath = path.resolve(agentDir, rawPath)
+  if (!(await pathIsTypeclawJson(agentDir, targetPath))) return undefined
+
+  if (isGuardAcknowledged(args, GUARD_PLUGIN_ADDITION)) return undefined
+
+  const editRefusal = refuseRiskyEdit(tool, args, targetPath)
+  if (editRefusal) return editRefusal
+
+  const newContent = await intendedContent(tool, args, targetPath)
+  if (newContent === undefined) return undefined
+
+  const newPlugins = parsePluginsFromContent(newContent)
+  if (newPlugins === undefined) return undefined
+
+  const oldPlugins = await readExistingPlugins(targetPath)
+  const findings = diffPlugins(oldPlugins, newPlugins)
+  if (findings.length === 0) return undefined
+
+  return {
+    block: true,
+    reason: buildBlockReason(tool, targetPath, findings),
+  }
+}
+
+export function diffPlugins(before: readonly string[], after: readonly string[]): PluginAdditionFinding[] {
+  const findings: PluginAdditionFinding[] = []
+  const beforeByName = new Map<string, string | undefined>()
+  for (const entry of before) {
+    if (isLocalEntry(entry)) continue
+    const { name, versionSpec } = splitPluginEntrySpec(entry)
+    beforeByName.set(name, versionSpec)
+  }
+
+  for (const entry of after) {
+    if (isLocalEntry(entry)) continue
+    const { name, versionSpec } = splitPluginEntrySpec(entry)
+    if (!beforeByName.has(name)) {
+      findings.push({ kind: 'plugin-added', name, versionSpec: versionSpec ?? '<latest>' })
+      continue
+    }
+    const priorSpec = beforeByName.get(name)
+    if (priorSpec !== versionSpec) {
+      findings.push({
+        kind: 'version-changed',
+        name,
+        from: priorSpec ?? '<latest>',
+        to: versionSpec ?? '<latest>',
+      })
+    }
+  }
+  return findings
+}
+
+function isLocalEntry(entry: string): boolean {
+  return entry.startsWith('./') || entry.startsWith('../') || path.isAbsolute(entry)
+}
+
+function parsePluginsFromContent(content: string): readonly string[] | undefined {
+  const result = parseConfigJson(content, { migrate: false })
+  if (!result.ok) return undefined
+  return result.config.plugins ?? []
+}
+
+async function readExistingPlugins(targetPath: string): Promise<readonly string[]> {
+  let raw: string
+  try {
+    raw = await readFile(targetPath, 'utf8')
+  } catch {
+    return []
+  }
+  const result = parseConfigJson(raw, { migrate: false })
+  if (!result.ok) return []
+  return result.config.plugins ?? []
+}
+
+// See the parallel rationale block in role-promotion.ts — Oracle PR #305
+// findings #5 and #6 (symlinked managed file + case-insensitive FS).
+async function pathIsTypeclawJson(agentDir: string, targetPath: string): Promise<boolean> {
+  const resolvedAgentDir = path.resolve(agentDir)
+  const canonicalManagedPath = path.join(resolvedAgentDir, 'typeclaw.json')
+  const resolvedTarget = path.resolve(targetPath)
+  if (canonicalManagedPath === resolvedTarget) return true
+  const realCanonical = await resolveRealPath(canonicalManagedPath)
+  const realTarget = await resolveRealPath(resolvedTarget)
+  return realCanonical === realTarget
+}
+
+// Symmetric with role/cron-promotion's refuseRiskyEdit. See Oracle PR #305
+// finding #4: simulator-vs-real divergence on multi-edit, plus non-unique
+// oldText ambiguity. Conservative refusal keeps the guard honest without
+// re-implementing the edit-diff semantics inside the security plugin.
+function refuseRiskyEdit(tool: string, args: Record<string, unknown>, targetPath: string): SecurityBlock | undefined {
+  if (tool !== 'edit') return undefined
+  const edits = args.edits
+  if (!Array.isArray(edits)) return undefined
+  if (edits.length > 1) {
+    return {
+      block: true,
+      reason: [
+        `Guard \`${GUARD_PLUGIN_ADDITION}\` refuses multi-edit on ${targetPath}: the security guard's edit simulator cannot match the pi-coding-agent edit tool's original-content semantics for multi-edit calls.`,
+        'Use `write` with the full file content instead — this is the canonical workflow for managed config files.',
+      ].join(' '),
+    }
+  }
+  return undefined
+}
+
+async function intendedContent(
+  tool: string,
+  args: Record<string, unknown>,
+  targetPath: string,
+): Promise<string | undefined> {
+  if (tool === 'write') {
+    return typeof args.content === 'string' ? args.content : undefined
+  }
+  const edits = args.edits
+  if (!Array.isArray(edits)) return undefined
+  let content: string
+  try {
+    content = await readFile(targetPath, 'utf8')
+  } catch {
+    return undefined
+  }
+  for (const edit of edits) {
+    if (!edit || typeof edit !== 'object') return undefined
+    const { oldText, newText } = edit as Record<string, unknown>
+    if (typeof oldText !== 'string' || typeof newText !== 'string') return undefined
+    if (oldText.length === 0) return undefined
+    const firstIdx = content.indexOf(oldText)
+    if (firstIdx === -1) return undefined
+    if (content.indexOf(oldText, firstIdx + 1) !== -1) return undefined
+    content = content.slice(0, firstIdx) + newText + content.slice(firstIdx + oldText.length)
+  }
+  return content
+}
+
+function buildBlockReason(tool: string, targetPath: string, findings: readonly PluginAdditionFinding[]): string {
+  const lines: string[] = []
+  for (const f of findings) {
+    const name = sanitizeForReason(f.name)
+    if (f.kind === 'plugin-added') {
+      lines.push(`new plugin \`${name}\` (${sanitizeForReason(f.versionSpec)}) would be installed on the host`)
+    } else {
+      lines.push(
+        `plugin \`${name}\` version changes \`${sanitizeForReason(f.from)}\` -> \`${sanitizeForReason(f.to)}\``,
+      )
+    }
+  }
+  return [
+    `Guard \`${GUARD_PLUGIN_ADDITION}\` blocked ${tool} on ${sanitizeForReason(targetPath)}: this change introduces a deferred host-code-execution grant — ${lines.join('; ')}.`,
+    "Plugin entries in typeclaw.json#plugins are materialized into package.json and installed by the next host `typeclaw start`, where npm lifecycle scripts run as the operator on the host. Even an `owner` operating from TUI must not silently add plugins on behalf of a channel message: the canonical attack is a prompt-injected agent writing a malicious package name into plugins[] so the operator's next start runs its postinstall.",
+    `If this is genuinely intentional and the operator explicitly asked for it (not a channel message), retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_PLUGIN_ADDITION}: true\` in the tool arguments.`,
+  ].join(' ')
+}
+
+const MAX_REASON_TOKEN_LEN = 200
+
+function sanitizeForReason(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  const cleaned = value.replace(/[\u0000-\u001f\u007f]/g, '').replace(/`/g, "'")
+  if (cleaned.length <= MAX_REASON_TOKEN_LEN) return cleaned
+  return `${cleaned.slice(0, MAX_REASON_TOKEN_LEN)}...`
+}
+
+async function resolveRealPath(absolutePath: string): Promise<string> {
+  const pending: string[] = []
+  let current = absolutePath
+  while (true) {
+    try {
+      const real = await realpath(current)
+      return path.join(real, ...pending.reverse())
+    } catch (err) {
+      if (!isNotFound(err)) throw err
+    }
+    const parent = path.dirname(current)
+    if (parent === current) return absolutePath
+    pending.push(path.basename(current))
+    current = parent
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && (err as { code: unknown }).code === 'ENOENT'
+}

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1709,6 +1709,96 @@ describe('start (composition)', () => {
     expect(ensureCalls).toEqual([{ force: true }])
   })
 
+  test('managed plugin version bump in typeclaw.json -> ensureDeps forced even without --build', async () => {
+    // given: package.json already has the plugin installed at an older pinned
+    // version, and typeclaw.json bumps it. The drift detector would NOT catch
+    // this (the dependency name is still present), so reconcile must force.
+    await writeDockerfile(root)
+    const pkg = {
+      name: basename(root),
+      private: true,
+      type: 'module',
+      workspaces: ['packages/*'],
+      dependencies: { typeclaw: '^0.3.4', 'typeclaw-plugin-foo': '1.0.0' },
+      typeclaw: { managedPlugins: { 'typeclaw-plugin-foo': '1.0.0' } },
+    }
+    await writeFile(join(root, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`)
+    await mkdir(join(root, 'packages'), { recursive: true })
+    await writeFile(join(root, 'packages', '.gitkeep'), '')
+    const config = {
+      models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+      plugins: ['typeclaw-plugin-foo@2.0.0'],
+    }
+    await writeFile(join(root, 'typeclaw.json'), `${JSON.stringify(config, null, 2)}\n`)
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // when: start runs WITHOUT --build
+    const ensureCalls: Array<{ force?: boolean } | undefined> = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: async (_cwd, opts) => {
+        ensureCalls.push(opts)
+        return { ok: true, installed: true }
+      },
+      ...bypassVerify,
+    })
+
+    // then: reconcile rewrote package.json, so ensureDeps was forced
+    expect(result.ok).toBe(true)
+    expect(ensureCalls).toEqual([{ force: true }])
+    const written = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(written.dependencies['typeclaw-plugin-foo']).toBe('2.0.0')
+  })
+
+  test('managed plugin removal from typeclaw.json -> ensureDeps forced even without --build', async () => {
+    // given: a managed plugin is installed but no longer listed in typeclaw.json
+    await writeDockerfile(root)
+    const pkg = {
+      name: basename(root),
+      private: true,
+      type: 'module',
+      workspaces: ['packages/*'],
+      dependencies: { typeclaw: '^0.3.4', 'typeclaw-plugin-foo': '1.0.0' },
+      typeclaw: { managedPlugins: { 'typeclaw-plugin-foo': '1.0.0' } },
+    }
+    await writeFile(join(root, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`)
+    await mkdir(join(root, 'packages'), { recursive: true })
+    await writeFile(join(root, 'packages', '.gitkeep'), '')
+    const config = {
+      models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+      plugins: [],
+    }
+    await writeFile(join(root, 'typeclaw.json'), `${JSON.stringify(config, null, 2)}\n`)
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    // when
+    const ensureCalls: Array<{ force?: boolean } | undefined> = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: async (_cwd, opts) => {
+        ensureCalls.push(opts)
+        return { ok: true, installed: true }
+      },
+      ...bypassVerify,
+    })
+
+    // then: the prune rewrote package.json, so ensureDeps was forced
+    expect(result.ok).toBe(true)
+    expect(ensureCalls).toEqual([{ force: true }])
+    const written = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(written.dependencies['typeclaw-plugin-foo']).toBeUndefined()
+  })
+
   test('forceBuild + registry typeclaw dep -> ensureDeps called with force=false', async () => {
     // given: agent is on a published registry version (the normal user case);
     // the force-reinstall would be expensive AND meaningless because bun's

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -21,6 +21,7 @@ import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
+import { reconcilePluginDeps } from '@/init/reconcile-plugin-deps'
 import { runBunUpdate, type UpdateRunner } from '@/init/run-bun-install'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
 
@@ -247,6 +248,22 @@ export async function start({
     // subsequent installs (PR #243 dogfooding wasted three rebuilds + a
     // manual version bump before this gate existed). Registry-spec users
     // skip the force path because their install is already cache-correct.
+    // Materialize typeclaw.json#plugins into package.json BEFORE ensureDeps so
+    // the drift detector below sees the newly-written deps as missing and
+    // installs them in the same pass. This makes the plugin list a single
+    // source of truth: the user edits typeclaw.json and never touches
+    // package.json. The agent cannot abuse this to install arbitrary host code —
+    // the security plugin's `pluginAddition` guard gates writes to the plugins
+    // field at owner/trusted trust, so by the time this host-side step runs the
+    // field is trustworthy by construction.
+    const pluginReconcile = await reconcilePluginDeps({
+      cwd,
+      plugins: (await loadTypeclawConfig(cwd)).plugins,
+    }).catch((error: unknown) => ({ error: error instanceof Error ? error.message : String(error) }) as const)
+    if ('error' in pluginReconcile) {
+      return { ok: false, reason: `plugin dependency reconcile failed: ${pluginReconcile.error}` }
+    }
+
     const forceDepsReinstall = forceBuild && (await hasLocallyLinkedTypeclawDep(cwd))
     const deps = await ensureDeps(cwd, { force: forceDepsReinstall })
     if (!deps.ok) {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -248,6 +248,7 @@ export async function start({
     // subsequent installs (PR #243 dogfooding wasted three rebuilds + a
     // manual version bump before this gate existed). Registry-spec users
     // skip the force path because their install is already cache-correct.
+
     // Materialize typeclaw.json#plugins into package.json BEFORE ensureDeps so
     // the drift detector below sees the newly-written deps as missing and
     // installs them in the same pass. This makes the plugin list a single
@@ -264,7 +265,12 @@ export async function start({
       return { ok: false, reason: `plugin dependency reconcile failed: ${pluginReconcile.error}` }
     }
 
-    const forceDepsReinstall = forceBuild && (await hasLocallyLinkedTypeclawDep(cwd))
+    // Force install when reconcile rewrote package.json. ensureDeps' drift
+    // detector only checks for MISSING dependency names, so a managed plugin's
+    // version bump (dir already present) or a removal (stale dir left behind)
+    // would otherwise leave bun.lock/node_modules out of sync with the
+    // reconciled package.json.
+    const forceDepsReinstall = (forceBuild && (await hasLocallyLinkedTypeclawDep(cwd))) || pluginReconcile.changed
     const deps = await ensureDeps(cwd, { force: forceDepsReinstall })
     if (!deps.ok) {
       return { ok: false, reason: `dependency install failed: ${deps.reason}` }

--- a/src/init/reconcile-plugin-deps.test.ts
+++ b/src/init/reconcile-plugin-deps.test.ts
@@ -55,6 +55,27 @@ describe('reconcilePluginDeps', () => {
     }
   })
 
+  test('reuses the existing pin for a bare name instead of re-resolving latest', async () => {
+    const dir = await makeAgentDir({
+      name: 'agent',
+      dependencies: { 'typeclaw-plugin-foo': '1.0.0' },
+      typeclaw: { managedPlugins: { 'typeclaw-plugin-foo': '1.0.0' } },
+    })
+    try {
+      // resolveLatest must NOT be called: an unchanged bare entry stays pinned.
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo'],
+        resolveLatest: neverResolve,
+      })
+      expect(result.changed).toBe(false)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('1.0.0')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   test('prunes a managed dep when the plugin is removed from config', async () => {
     const dir = await makeAgentDir({
       name: 'agent',

--- a/src/init/reconcile-plugin-deps.test.ts
+++ b/src/init/reconcile-plugin-deps.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { reconcilePluginDeps } from './reconcile-plugin-deps'
+
+async function makeAgentDir(pkg: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-reconcile-'))
+  await writeFile(join(dir, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`)
+  return dir
+}
+
+async function readPkg(dir: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(dir, 'package.json'), 'utf8'))
+}
+
+const neverResolve = async (name: string): Promise<string> => {
+  throw new Error(`unexpected registry resolution for ${name}`)
+}
+
+describe('reconcilePluginDeps', () => {
+  test('adds a versioned npm plugin to dependencies and records provenance', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: { typeclaw: '0.35.0' } })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo@1.2.3'],
+        resolveLatest: neverResolve,
+      })
+      expect(result.changed).toBe(true)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('1.2.3')
+      expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('0.35.0')
+      expect((pkg.typeclaw as Record<string, unknown>).managedPlugins).toEqual({ 'typeclaw-plugin-foo': '1.2.3' })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('resolves a bare name to a pinned version once', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo'],
+        resolveLatest: async () => '4.5.6',
+      })
+      expect(result.changed).toBe(true)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('4.5.6')
+      expect((pkg.typeclaw as Record<string, unknown>).managedPlugins).toEqual({ 'typeclaw-plugin-foo': '4.5.6' })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('prunes a managed dep when the plugin is removed from config', async () => {
+    const dir = await makeAgentDir({
+      name: 'agent',
+      dependencies: { typeclaw: '0.35.0', 'typeclaw-plugin-foo': '1.2.3' },
+      typeclaw: { managedPlugins: { 'typeclaw-plugin-foo': '1.2.3' } },
+    })
+    try {
+      const result = await reconcilePluginDeps({ cwd: dir, plugins: [], resolveLatest: neverResolve })
+      expect(result.changed).toBe(true)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBeUndefined()
+      expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('0.35.0')
+      expect(pkg.typeclaw).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('never prunes a dep the user added that was not managed', async () => {
+    const dir = await makeAgentDir({
+      name: 'agent',
+      dependencies: { typeclaw: '0.35.0', 'typeclaw-plugin-foo': '9.9.9' },
+      typeclaw: {},
+    })
+    try {
+      const result = await reconcilePluginDeps({ cwd: dir, plugins: [], resolveLatest: neverResolve })
+      expect(result.changed).toBe(false)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('9.9.9')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('updates the pinned version when a managed plugin spec changes', async () => {
+    const dir = await makeAgentDir({
+      name: 'agent',
+      dependencies: { 'typeclaw-plugin-foo': '1.0.0' },
+      typeclaw: { managedPlugins: { 'typeclaw-plugin-foo': '1.0.0' } },
+    })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo@2.0.0'],
+        resolveLatest: neverResolve,
+      })
+      expect(result.changed).toBe(true)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('2.0.0')
+      expect((pkg.typeclaw as Record<string, unknown>).managedPlugins).toEqual({ 'typeclaw-plugin-foo': '2.0.0' })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('skips local-path plugin entries', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['./plugins/local.ts', '../shared/plugin.ts', '/abs/plugin.ts'],
+        resolveLatest: neverResolve,
+      })
+      expect(result.changed).toBe(false)
+      const pkg = await readPkg(dir)
+      expect(pkg.dependencies).toEqual({})
+      expect(pkg.typeclaw).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('handles scoped versioned entries', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['@acme/typeclaw-plugin-foo@3.1.0'],
+        resolveLatest: neverResolve,
+      })
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['@acme/typeclaw-plugin-foo']).toBe('3.1.0')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('is idempotent when config already matches package.json', async () => {
+    const dir = await makeAgentDir({
+      name: 'agent',
+      dependencies: { 'typeclaw-plugin-foo': '1.2.3' },
+      typeclaw: { managedPlugins: { 'typeclaw-plugin-foo': '1.2.3' } },
+    })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo@1.2.3'],
+        resolveLatest: neverResolve,
+      })
+      expect(result.changed).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns unchanged when package.json is absent', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-reconcile-'))
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo@1.2.3'],
+        resolveLatest: neverResolve,
+      })
+      expect(result.changed).toBe(false)
+      expect(result.files).toEqual([])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/reconcile-plugin-deps.ts
+++ b/src/init/reconcile-plugin-deps.ts
@@ -49,9 +49,9 @@ export async function reconcilePluginDeps(options: ReconcilePluginDepsOptions): 
     return { changed: false, files: [] }
   }
 
-  const desired = await resolveDesiredManaged(plugins, resolveLatest)
   const dependencies = { ...pkg.dependencies }
   const previousManaged = readManagedPlugins(pkg)
+  const desired = await resolveDesiredManaged(plugins, previousManaged, resolveLatest)
 
   let changed = false
 
@@ -86,11 +86,16 @@ type PackageJsonShape = {
 } & Record<string, unknown>
 
 // Classifies config.plugins entries and resolves the version each managed dep
-// should pin to. Local paths and bundled-style entries are not npm packages, so
-// they are skipped. A bare name resolves its current latest version once and
-// pins it, mirroring `npm/bun add <name>` writing a concrete version.
+// should pin to. Local paths are skipped (not npm packages). A bare name (no
+// `@version`) is pinned ONCE: it reuses the version already pinned in the
+// managed set on subsequent starts, and only resolves `latest` for a genuinely
+// new, unmanaged plugin. Without this reuse, an unchanged `typeclaw.json` would
+// re-resolve `latest` on every start and silently rewrite package.json when the
+// registry moves — bypassing the pluginAddition security gate, which only fires
+// on a guarded config write.
 async function resolveDesiredManaged(
   plugins: readonly string[],
+  previousManaged: Record<string, string>,
   resolveLatest: ResolveLatestVersion,
 ): Promise<Record<string, string>> {
   const desired: Record<string, string> = {}
@@ -98,7 +103,11 @@ async function resolveDesiredManaged(
     if (isLocalEntry(entry)) continue
     const { name, versionSpec } = splitPluginEntrySpec(entry)
     if (name.length === 0) continue
-    desired[name] = versionSpec ?? (await resolveLatest(name))
+    if (versionSpec !== undefined) {
+      desired[name] = versionSpec
+    } else {
+      desired[name] = previousManaged[name] ?? (await resolveLatest(name))
+    }
   }
   return sortKeys(desired)
 }

--- a/src/init/reconcile-plugin-deps.ts
+++ b/src/init/reconcile-plugin-deps.ts
@@ -1,0 +1,164 @@
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { isAbsolute, join } from 'node:path'
+
+import { splitPluginEntrySpec } from '@/plugin'
+
+const PACKAGE_FILE = 'package.json'
+
+export type ReconcilePluginDepsResult = {
+  changed: boolean
+  files: string[]
+}
+
+export type ResolveLatestVersion = (packageName: string) => Promise<string>
+
+export type ReconcilePluginDepsOptions = {
+  cwd: string
+  plugins: readonly string[]
+  resolveLatest?: ResolveLatestVersion
+}
+
+// Materializes typeclaw.json#plugins into package.json#dependencies so the
+// plugin list is the single source of truth: the user edits typeclaw.json and
+// `start` keeps package.json in sync. The sync is one-way (config → manifest)
+// and bidirectional in effect (entries added to config are written; entries
+// removed from config are pruned). Provenance lives in
+// package.json#typeclaw.managedPlugins so pruning only ever touches deps this
+// step added — never the user's own dependencies or the typeclaw runtime dep.
+export async function reconcilePluginDeps(options: ReconcilePluginDepsOptions): Promise<ReconcilePluginDepsResult> {
+  const { cwd, plugins } = options
+  const resolveLatest = options.resolveLatest ?? resolveLatestFromRegistry
+
+  const pkgPath = join(cwd, PACKAGE_FILE)
+  if (!existsSync(pkgPath)) return { changed: false, files: [] }
+
+  let raw: string
+  try {
+    raw = await readFile(pkgPath, 'utf8')
+  } catch {
+    return { changed: false, files: [] }
+  }
+
+  let pkg: PackageJsonShape
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return { changed: false, files: [] }
+    pkg = parsed as PackageJsonShape
+  } catch {
+    return { changed: false, files: [] }
+  }
+
+  const desired = await resolveDesiredManaged(plugins, resolveLatest)
+  const dependencies = { ...pkg.dependencies }
+  const previousManaged = readManagedPlugins(pkg)
+
+  let changed = false
+
+  for (const [name, version] of Object.entries(desired)) {
+    if (dependencies[name] !== version) {
+      dependencies[name] = version
+      changed = true
+    }
+  }
+
+  // Prune scoped strictly to the prior managed set: a dep the user hand-added
+  // or a runtime dep is never removed even if its name shape looks plugin-like.
+  for (const name of Object.keys(previousManaged)) {
+    if (!(name in desired) && name in dependencies) {
+      delete dependencies[name]
+      changed = true
+    }
+  }
+
+  if (!managedEqual(previousManaged, desired)) changed = true
+
+  if (!changed) return { changed: false, files: [] }
+
+  const next = withManagedPlugins({ ...pkg, dependencies: sortKeys(dependencies) }, desired)
+  await writeFile(pkgPath, `${JSON.stringify(next, null, 2)}\n`)
+  return { changed: true, files: [PACKAGE_FILE] }
+}
+
+type PackageJsonShape = {
+  dependencies?: Record<string, string>
+  typeclaw?: { managedPlugins?: Record<string, string> } & Record<string, unknown>
+} & Record<string, unknown>
+
+// Classifies config.plugins entries and resolves the version each managed dep
+// should pin to. Local paths and bundled-style entries are not npm packages, so
+// they are skipped. A bare name resolves its current latest version once and
+// pins it, mirroring `npm/bun add <name>` writing a concrete version.
+async function resolveDesiredManaged(
+  plugins: readonly string[],
+  resolveLatest: ResolveLatestVersion,
+): Promise<Record<string, string>> {
+  const desired: Record<string, string> = {}
+  for (const entry of plugins) {
+    if (isLocalEntry(entry)) continue
+    const { name, versionSpec } = splitPluginEntrySpec(entry)
+    if (name.length === 0) continue
+    desired[name] = versionSpec ?? (await resolveLatest(name))
+  }
+  return sortKeys(desired)
+}
+
+function isLocalEntry(entry: string): boolean {
+  return entry.startsWith('./') || entry.startsWith('../') || isAbsolute(entry)
+}
+
+function readManagedPlugins(pkg: PackageJsonShape): Record<string, string> {
+  const managed = pkg.typeclaw?.managedPlugins
+  if (managed === undefined || managed === null || typeof managed !== 'object') return {}
+  const out: Record<string, string> = {}
+  for (const [name, version] of Object.entries(managed)) {
+    if (typeof version === 'string') out[name] = version
+  }
+  return out
+}
+
+function withManagedPlugins(pkg: PackageJsonShape, managed: Record<string, string>): PackageJsonShape {
+  const typeclaw = { ...pkg.typeclaw }
+  if (Object.keys(managed).length === 0) {
+    delete typeclaw.managedPlugins
+  } else {
+    typeclaw.managedPlugins = managed
+  }
+  if (Object.keys(typeclaw).length === 0) {
+    const { typeclaw: _omit, ...rest } = pkg
+    return rest as PackageJsonShape
+  }
+  return { ...pkg, typeclaw }
+}
+
+function managedEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  const ak = Object.keys(a)
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  for (const k of ak) if (a[k] !== b[k]) return false
+  return true
+}
+
+function sortKeys(obj: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of Object.keys(obj).sort()) out[k] = obj[k] as string
+  return out
+}
+
+async function resolveLatestFromRegistry(packageName: string): Promise<string> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) throw new Error(`cannot resolve latest version for ${packageName}: bun runtime not available`)
+  const proc = bun.spawn({
+    cmd: ['bun', 'pm', 'view', packageName, 'version'],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const code = await proc.exited
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text()
+    throw new Error(`failed to resolve latest version for ${packageName}: ${stderr.trim() || `exit ${code}`}`)
+  }
+  const version = (await new Response(proc.stdout).text()).trim().replace(/^["']|["']$/g, '')
+  if (version.length === 0) throw new Error(`registry returned no version for ${packageName}`)
+  return version
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -72,8 +72,8 @@ export {
   type LoadPluginsResult,
 } from './manager'
 export type { PermissionService } from '@/permissions'
-export type { LoadPluginEntryFn, ResolvedPlugin } from './loader'
-export { loadPluginEntry, derivePluginNameFromPackage } from './loader'
+export type { LoadPluginEntryFn, PluginEntrySpec, ResolvedPlugin } from './loader'
+export { loadPluginEntry, derivePluginNameFromPackage, splitPluginEntrySpec } from './loader'
 export { materializeSkills, type MaterializedSkills, type SkillEntry } from './skills'
 export {
   createLoadSkillTool,

--- a/src/plugin/loader.test.ts
+++ b/src/plugin/loader.test.ts
@@ -3,7 +3,44 @@ import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { derivePluginNameFromPackage, loadPluginEntry } from './loader'
+import { derivePluginNameFromPackage, loadPluginEntry, splitPluginEntrySpec } from './loader'
+
+describe('splitPluginEntrySpec', () => {
+  test('splits a versioned unscoped entry', () => {
+    expect(splitPluginEntrySpec('typeclaw-plugin-foo@1.2.3')).toEqual({
+      name: 'typeclaw-plugin-foo',
+      versionSpec: '1.2.3',
+    })
+  })
+
+  test('leaves a bare unscoped entry without a version', () => {
+    expect(splitPluginEntrySpec('typeclaw-plugin-foo')).toEqual({
+      name: 'typeclaw-plugin-foo',
+      versionSpec: undefined,
+    })
+  })
+
+  test('splits a versioned scoped entry on the last @', () => {
+    expect(splitPluginEntrySpec('@acme/typeclaw-plugin-foo@2.0.0')).toEqual({
+      name: '@acme/typeclaw-plugin-foo',
+      versionSpec: '2.0.0',
+    })
+  })
+
+  test('does not treat the leading scope @ as a version delimiter', () => {
+    expect(splitPluginEntrySpec('@acme/typeclaw-plugin-foo')).toEqual({
+      name: '@acme/typeclaw-plugin-foo',
+      versionSpec: undefined,
+    })
+  })
+
+  test('preserves dist-tag version specs', () => {
+    expect(splitPluginEntrySpec('typeclaw-plugin-foo@latest')).toEqual({
+      name: 'typeclaw-plugin-foo',
+      versionSpec: 'latest',
+    })
+  })
+})
 
 describe('derivePluginNameFromPackage', () => {
   test('strips typeclaw-plugin- prefix', () => {
@@ -90,6 +127,36 @@ export default definePlugin({
       const resolved = await loadPluginEntry('typeclaw-plugin-standup-log', dir)
       expect(resolved.name).toBe('standup-log')
       expect(resolved.version).toBe('0.1.2')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('resolves a versioned entry from node_modules under its bare name', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-loader-npm-'))
+    try {
+      const pkgDir = join(dir, 'node_modules', 'typeclaw-plugin-standup-log')
+      await mkdir(pkgDir, { recursive: true })
+      await writeFile(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: 'typeclaw-plugin-standup-log',
+          version: '0.1.2',
+          type: 'module',
+          main: 'index.js',
+        }),
+      )
+      await writeFile(
+        join(pkgDir, 'index.js'),
+        `import { definePlugin } from '${process.cwd()}/src/plugin/index.ts'
+export default definePlugin({
+  plugin: async () => ({}),
+})`,
+      )
+      const resolved = await loadPluginEntry('typeclaw-plugin-standup-log@0.1.2', dir)
+      expect(resolved.name).toBe('standup-log')
+      expect(resolved.version).toBe('0.1.2')
+      expect(resolved.source).toBe('typeclaw-plugin-standup-log@0.1.2')
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -43,8 +43,14 @@ async function loadLocal(entry: string, agentDir: string): Promise<ResolvedPlugi
 }
 
 async function loadNpm(entry: string, agentDir: string): Promise<ResolvedPlugin> {
-  const pkgJsonPath = findPackageJson(entry, agentDir)
-  let pkgName = entry
+  // The version suffix (`name@1.2.3`, `@scope/name@1.2.3`) is consumed by the
+  // host reconcile step when materializing the entry into package.json. By load
+  // time the package is installed at `node_modules/<name>/` under its bare name,
+  // so passing the raw `name@version` here would miss the dir and fail the
+  // bare-import fallback too.
+  const { name: packageName } = splitPluginEntrySpec(entry)
+  const pkgJsonPath = findPackageJson(packageName, agentDir)
+  let pkgName = packageName
   let version: string | undefined
   let entryPath: string | null = null
   if (pkgJsonPath !== null) {
@@ -76,6 +82,24 @@ async function loadNpm(entry: string, agentDir: string): Promise<ResolvedPlugin>
   const defined = expectDefined(mod, entry)
   const name = derivePluginNameFromPackage(pkgName)
   return { name, version, source: entry, defined }
+}
+
+export type PluginEntrySpec = { name: string; versionSpec: string | undefined }
+
+// Splits an npm-style entry into package name and optional version spec. The
+// version delimiter is the LAST `@` that isn't the leading scope marker, so
+// `@scope/pkg@1.2.3` → { name: '@scope/pkg', versionSpec: '1.2.3' } while
+// `@scope/pkg` → { name: '@scope/pkg', versionSpec: undefined }.
+export function splitPluginEntrySpec(entry: string): PluginEntrySpec {
+  const scoped = entry.startsWith('@')
+  const searchFrom = scoped ? entry.indexOf('/') + 1 : 0
+  const at = entry.indexOf('@', searchFrom)
+  if (at <= 0) return { name: entry, versionSpec: undefined }
+  const versionSpec = entry.slice(at + 1)
+  return {
+    name: entry.slice(0, at),
+    versionSpec: versionSpec.length > 0 ? versionSpec : undefined,
+  }
 }
 
 export function derivePluginNameFromPackage(packageName: string): string {


### PR DESCRIPTION
## Background

Today a user must declare an npm plugin in **both** `typeclaw.json#plugins` *and* `package.json#dependencies` — the loader only ever reads `node_modules`, so the two files must be kept in sync by hand. There is no enforcement; they drift silently and the mismatch is only discovered at agent boot.

## Summary

Makes `typeclaw.json#plugins` the **single source of truth** for npm-distributed plugins. After this PR, the user edits only `typeclaw.json`; `typeclaw start` materializes npm entries into `package.json` and installs them.

```json
{
  "plugins": ["typeclaw-plugin-standup@1.2.3", "@acme/typeclaw-plugin-helicone"]
}
```

Removing an entry prunes it. A bare name (no `@version`) resolves to the current latest and is pinned, exactly like `bun add <name>`. The resting state stays the clean Bun-native `package.json` + `bun.lock` layout.

### 3 atomic commits (dependency order)

1. **`feat(plugin): parse name[@version]`** — `splitPluginEntrySpec` splits an entry into name + optional version (scoped packages split on the last `@`). The loader resolves/imports under the bare name, so `typeclaw-plugin-foo@1.2.3` still finds `node_modules/typeclaw-plugin-foo`.
2. **`feat(init): materialize plugins into package.json on start`** — `reconcilePluginDeps` runs before `ensureDeps` so the existing drift detector installs the new deps in the same pass. Bidirectional: adds/updates what the config lists, prunes what it previously managed. Provenance under `package.json#typeclaw.managedPlugins` ensures the prune **only ever touches deps this step added** — never user or runtime deps. Reconcile failures abort `start` cleanly.
3. **`feat(security): gate plugin additions behind owner/trusted`** — new `pluginAddition` guard (medium tier; owner+trusted bypass).

### Security model

Adding/version-bumping a plugin in `typeclaw.json` is a **deferred host-code-execution grant**: the entry is installed by the next host `typeclaw start`, where npm lifecycle scripts run as the operator. The agent can write `/agent/typeclaw.json` under prompt injection, so the dangerous write is gated **where role context exists** (the container `tool.before` boundary), by the same mechanism as the existing `rolePromotion` / `cronPromotion` guards:

- **Blocked for member/guest** (and prompt-injected low-trust input): adding a new plugin entry, or changing an existing entry's version. Ack-overridable for genuine operator intent.
- **Allowed for everyone**: removal, reorder, and local-path entries (`./`, `../`, absolute) — none of these install registry code.

Because the write is trust-gated upstream, the host-side reconcile runs **seamlessly with no prompts** — the `plugins` field is trustworthy by construction. The role model can't gate the host install directly because that happens later, outside channel/session provenance — so we gate the write instead.

## Preview

None — no UI or output changes.

## What this does NOT do

- Does not affect local-path plugin entries (`./`, `../`, absolute paths) — those are never touched by the reconciler.
- Does not change the loader's resolution contract: plugins are always imported under the bare package name regardless of whether a version suffix was declared.
- Does not add any interactive prompts on the host side; the security gate lives exclusively in the container at write time.

## Review notes

- Load-bearing change: `reconcilePluginDeps` in `src/init/reconcile-plugin-deps.ts` and its call site in `src/container/start.ts` (runs before `ensureDeps`). The provenance key under `typeclaw.managedPlugins` in `package.json` is what makes pruning safe — it scopes removals to only what this step ever wrote.
- Security invariant to verify: `src/bundled-plugins/security/policies/plugin-addition.ts` uses the same path-identity + diff + ack shape as `rolePromotion`; multi-edit is refused conservatively (no ack path) to prevent array-rewrite tricks.
- Tests: `src/plugin/loader.test.ts` (parse edge cases), `src/init/reconcile-plugin-deps.test.ts` (add/remove/update/idempotence/never-prunes-user-deps), `src/bundled-plugins/security/policies/plugin-addition.test.ts` (block/allow/ack matrix), `permissions.test.ts` drift guard updated for the new medium-tier entry. All checks green: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, `bun run test` (8455 pass / 0 fail).