### PR TITLE
fix(channels): wire LINE credential store into client so reconnect re-login works

### DIFF
--- a/src/channels/adapters/line.test.ts
+++ b/src/channels/adapters/line.test.ts
@@ -201,6 +201,52 @@ describe('createLineAdapter lifecycle', () => {
     expect(router.registered.outbound).toBe(false)
   })
 
+  test('wires the credentials store as the client credential manager so listener re-login resolves it', async () => {
+    // given a store-backed client whose no-arg login() (the LineListener reconnect
+    // path) resolves credentials only through its injected credential manager
+    const store = {
+      load: async () => ({ current_account: 'U_self', accounts: {} }),
+      getAccount: async () => ({
+        account_id: 'U_self',
+        auth_token: 't',
+        device: 'DESKTOPMAC' as const,
+        created_at: '',
+        updated_at: '',
+      }),
+    }
+    let factoryCredManager: unknown
+    const buildStoreBackedClient = (credManager?: unknown): LineClient => {
+      factoryCredManager = credManager
+      return fakeClient({
+        login: async function (this: LineClient, credentials) {
+          if (credentials === undefined) {
+            const account = await (credManager as typeof store | undefined)?.getAccount()
+            if (!account) throw new Error('No account found. Call loginWithQR() or loginWithEmail() first.')
+          }
+          return this
+        },
+      })
+    }
+
+    const adapter = createLineAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      clientFactory: buildStoreBackedClient as never,
+      listenerFactory: () => new FakeListener(),
+      credentialsStore: store,
+    })
+
+    // when the adapter starts (no explicit client injected)
+    await adapter.start()
+
+    // then the factory received the credentials store as the credential manager,
+    // so an argument-less re-login resolves the account instead of throwing
+    expect(factoryCredManager).toBe(store)
+    const reLoginClient = buildStoreBackedClient(factoryCredManager)
+    await expect(reLoginClient.login()).resolves.toBeDefined()
+  })
+
   test('start throws when no account is stored', async () => {
     const adapter = createLineAdapter({
       router: makeRouterStub(() => {}),

--- a/src/channels/adapters/line.ts
+++ b/src/channels/adapters/line.ts
@@ -1,5 +1,6 @@
 import {
   LineClient as RealLineClient,
+  type LineCredentialManager,
   LineListener as RealLineListener,
   type LineAccountCredentials,
   type LineChat,
@@ -53,7 +54,7 @@ export type LineCredentialStore = {
   getAccount(id?: string): Promise<LineAccountCredentials | null>
 }
 
-const LineClient = RealLineClient as unknown as new () => LineClient
+const LineClient = RealLineClient as unknown as new (credManager?: LineCredentialManager) => LineClient
 const LineListener = RealLineListener as unknown as new (client: LineClient) => LineListener
 
 export type LineAdapterLogger = {
@@ -75,6 +76,7 @@ export type LineAdapterOptions = {
   selfAliasesRef?: () => readonly string[]
   credentialsStore?: LineCredentialStore
   client?: LineClient
+  clientFactory?: (credManager?: LineCredentialManager) => LineClient
   listenerFactory?: (client: LineClient) => LineListener
 }
 
@@ -163,7 +165,15 @@ function clampLimit(requested: number, max: number): number {
 
 export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
   const logger = options.logger ?? consoleLogger
-  const client = options.client ?? new LineClient()
+  // LineListener.connect() re-calls client.login() with NO arguments on every
+  // (re)connect, which resolves credentials via the client's credential manager
+  // rather than the explicit account start() passes. Wire the secrets.json store
+  // in as that manager (same structural cast as src/init/line-auth.ts) so the
+  // reconnect path doesn't fall through to the SDK's default file-based manager
+  // and loop forever on "No account found".
+  const credManager = options.credentialsStore as unknown as LineCredentialManager | undefined
+  const buildClient = options.clientFactory ?? ((cm?: LineCredentialManager) => new LineClient(cm))
+  const client = options.client ?? buildClient(credManager)
   let listener: LineListener | null = null
   let selfUserId: string | null = null
   let connected = false


### PR DESCRIPTION
## Background

A freshly re-authenticated LINE agent never establishes a session. After `typeclaw` LINE re-auth completes successfully — QR scanned, PIN confirmed, "LINE credentials refreshed in secrets.json", container restarted — the runtime adapter logs a tight reconnect loop:

```
[line] listener error: No account found. Call loginWithQR() or loginWithEmail() first.
```

The credentials in `secrets.json#channels.line` are valid (the stored `auth_token` decodes to exactly the access token LINE issued, with a far-future `exp`). The bug is entirely in the runtime read path.

**Root cause.** The adapter built its `LineClient` with **no credential manager** (`new LineClient()`), so it defaulted to the SDK's file-based `LineCredentialManager`, which reads `~/.config/agent-messenger/...` and never sees typeclaw's `secrets.json`. The adapter's own `start()` worked around this by passing credentials *explicitly* to the first `client.login(account)` call — that path skips the credential-manager lookup, so the initial login succeeded.

But `LineListener.connect()` (in `agent-messenger`) re-calls `client.login()` with **no arguments** on every connect and reconnect. That argument-less path resolves credentials through the client's credential manager — the default one — which returns null and throws `No account found`. The listener catches it, emits `error`, and schedules an exponential-backoff reconnect. The backoff cadence in the field logs (1s, 1s, 2s, 4s, 8s, 16s) matches the SDK's `RECONNECT_BASE_DELAY * 2**attempts` exactly, confirming the mechanism.

The init bootstrap (`src/init/line-auth.ts`) already wires the `secrets.json` store in as the client's credential manager — which is why login *writes* to `secrets.json` correctly. The runtime adapter simply never did the same on the read side.

## Summary

Pass the `secrets.json`-backed credential store into the `LineClient` constructor as its credential manager, using the same structural cast `src/init/line-auth.ts` already uses. Now the listener's argument-less re-login resolves the stored account on every (re)connect instead of falling through to the SDK default.

A `clientFactory` seam (mirroring the existing `listenerFactory` option) is added so the wiring is testable without standing up a real LOCO client. The test was verified red: reverting the production change to `new LineClient()` makes it fail with `credManager === undefined`.

## What this does NOT do

- No change to the LINE auth/login CLI flow or the `secrets.json` schema — credentials were always stored correctly.
- No change to KakaoTalk/Slack/Discord adapters; this is LINE-specific.
- Does not touch the upstream `agent-messenger` reconnect behavior — it adapts to it.

## Review notes

- Load-bearing change: `src/channels/adapters/line.ts` — `new LineClient(credManager)` where `credManager = options.credentialsStore`. The invariant to preserve: the runtime `LineClient` must carry the `secrets.json` store as its credential manager, otherwise the listener's no-arg re-login regresses to the infinite "No account found" loop. The inline comment documents this so a future "simplification" back to `new LineClient()` doesn't silently reintroduce it.
- All 8435 tests pass; the LINE adapter suite covers the new wiring.
