### PR TITLE
feat(cli): add `channel list` and `channel remove`

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -4,6 +4,12 @@ import { cancel, confirm, intro, isCancel, log, note, password, select, spinner,
 import { defineCommand } from 'citty'
 
 import { config } from '@/config'
+import {
+  listChannels,
+  removeChannel,
+  type ChannelListEntry,
+  type GithubConfigCleanup,
+} from '@/config/channels-mutation'
 import { start, status, stop } from '@/container'
 import {
   CHANNEL_KINDS,
@@ -30,7 +36,7 @@ import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 
 import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
 import { displayQR } from './qr'
-import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup } from './ui'
+import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup, successLine } from './ui'
 
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'slack-bot': 'Slack',
@@ -185,6 +191,95 @@ const reauthSub = defineCommand({
   },
 })
 
+const listSub = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'list channel adapters configured for this agent',
+  },
+  args: {
+    json: {
+      type: 'boolean',
+      description: 'emit channels as JSON',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+    if (!isInitialized(cwd)) {
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
+      process.exit(1)
+    }
+    const channels = listChannels(cwd)
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify({ channels }, null, 2)}\n`)
+      return
+    }
+    process.stdout.write(`${formatChannelList(channels)}\n`)
+  },
+})
+
+const removeSub = defineCommand({
+  meta: {
+    name: 'remove',
+    description: 'remove a channel adapter from typeclaw.json and secrets.json',
+  },
+  args: {
+    adapter: {
+      type: 'positional',
+      description: `which adapter to remove (${CHANNEL_KINDS.join(' | ')}); omit to pick interactively`,
+      required: false,
+    },
+    yes: {
+      type: 'boolean',
+      description: 'skip the confirmation prompt',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+    if (!isInitialized(cwd)) {
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
+      process.exit(1)
+    }
+
+    const present = presentChannels(listChannels(cwd))
+    if (present.length === 0) {
+      console.error(errorLine('No channels are configured. Nothing to remove.'))
+      process.exit(1)
+    }
+
+    const adapter =
+      args.adapter === undefined ? await pickChannelToRemove(present) : validateRemoveAdapterArg(args.adapter, present)
+
+    if (args.yes !== true) {
+      const confirmed = await confirm({
+        message: `Remove the ${CHANNEL_LABELS[adapter]} channel? This deletes its config and credentials.`,
+        initialValue: false,
+      })
+      if (isCancel(confirmed) || !confirmed) {
+        cancel('Aborted.')
+        process.exit(0)
+      }
+    }
+
+    const result = removeChannel(cwd, adapter)
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+
+    process.stdout.write(`${successLine(`Removed ${CHANNEL_LABELS[adapter]} channel.`)}\n`)
+    if (result.githubCleanup !== undefined) printGithubCleanup(result.githubCleanup)
+    if (result.hadRemoteWebhooks) {
+      log.warn(
+        'GitHub webhooks registered on your repositories were NOT deleted. Remove them by hand at https://github.com/<owner>/<repo>/settings/hooks.',
+      )
+    }
+
+    await maybePromptRestart(cwd, adapter, 'removed')
+  },
+})
+
 export const channelCommand = defineCommand({
   meta: {
     name: 'channel',
@@ -194,8 +289,91 @@ export const channelCommand = defineCommand({
     add: addSub,
     set: setSub,
     reauth: reauthSub,
+    list: listSub,
+    remove: removeSub,
   },
 })
+
+function presentChannels(entries: ChannelListEntry[]): ChannelKind[] {
+  return entries.map((entry) => entry.kind)
+}
+
+async function pickChannelToRemove(present: ChannelKind[]): Promise<ChannelKind> {
+  if (present.length === 1) return present[0]!
+  const selected = await select<ChannelKind>({
+    message: 'Pick a channel to remove',
+    options: present.map((kind) => ({ value: kind, label: CHANNEL_LABELS[kind] })),
+    initialValue: present[0],
+  })
+  if (isCancel(selected)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return selected
+}
+
+function validateRemoveAdapterArg(adapter: string, present: ChannelKind[]): ChannelKind {
+  if (!isChannelKind(adapter)) {
+    console.error(errorLine(`Unknown adapter "${adapter}". Expected one of: ${CHANNEL_KINDS.join(', ')}.`))
+    process.exit(1)
+  }
+  if (!present.includes(adapter)) {
+    console.error(
+      errorLine(
+        `${CHANNEL_LABELS[adapter]} ("${adapter}") is not configured. Run \`typeclaw channel list\` to see what is.`,
+      ),
+    )
+    process.exit(1)
+  }
+  return adapter
+}
+
+function formatChannelList(channels: ChannelListEntry[]): string {
+  if (channels.length === 0) return c.dim('No channels configured.')
+
+  const kindWidth = Math.max(4, ...channels.map((ch) => ch.kind.length))
+  const statusWidth = Math.max(6, ...channels.map((ch) => channelStatusText(ch).length))
+  const lines: string[] = []
+  lines.push(c.dim(`${'KIND'.padEnd(kindWidth)}  ${'STATUS'.padEnd(statusWidth)}  DETAIL`))
+  for (const ch of channels) {
+    const statusText = channelStatusText(ch)
+    const status = channelStatusOk(ch)
+      ? c.green(statusText.padEnd(statusWidth))
+      : c.yellow(statusText.padEnd(statusWidth))
+    const detail = ch.detail ?? ''
+    lines.push(`${ch.kind.padEnd(kindWidth)}  ${status}  ${c.dim(detail)}`)
+  }
+  return lines.join('\n')
+}
+
+function channelStatusOk(ch: ChannelListEntry): boolean {
+  return ch.configured && ch.hasSecrets && ch.enabled
+}
+
+function channelStatusText(ch: ChannelListEntry): string {
+  if (!ch.configured) return 'secrets-only'
+  if (!ch.hasSecrets) return 'no-secrets'
+  if (!ch.enabled) return 'disabled'
+  return 'ready'
+}
+
+function printGithubCleanup(cleanup: GithubConfigCleanup): void {
+  const parts: string[] = []
+  if (cleanup.tunnelsRemoved > 0) {
+    parts.push(`removed ${cleanup.tunnelsRemoved} GitHub webhook tunnel${cleanup.tunnelsRemoved === 1 ? '' : 's'}`)
+  }
+  if (cleanup.matchRulesRemoved.length > 0) {
+    parts.push(
+      `removed ${cleanup.matchRulesRemoved.length} repo match rule${cleanup.matchRulesRemoved.length === 1 ? '' : 's'}`,
+    )
+  }
+  if (parts.length > 0) process.stdout.write(`${c.dim(`Also ${parts.join(', ')}.`)}\n`)
+  if (cleanup.matchRulesKept.length > 0) {
+    log.warn(
+      `Left ${cleanup.matchRulesKept.length} other \`github:\` match rule(s) in roles.member untouched: ${cleanup.matchRulesKept.join(', ')}.`,
+    )
+  }
+}
 
 async function resolveReauthableAdapter(
   requested: string | undefined,
@@ -1269,12 +1447,16 @@ function reportLineAuth(result: LineAuthResult): string {
   return `LINE login failed: ${result.reason}`
 }
 
-async function maybePromptRestart(cwd: string, channel: ChannelKind): Promise<void> {
+async function maybePromptRestart(
+  cwd: string,
+  channel: ChannelKind,
+  verb: 'added' | 'removed' = 'added',
+): Promise<void> {
   const label = CHANNEL_LABELS[channel]
   const current = await status({ cwd }).catch(() => null)
   if (current === null || current.kind !== 'running') {
     done({
-      title: c.green(`${label} channel added.`),
+      title: c.green(`${label} channel ${verb}.`),
       hints: [
         { label: 'Start the agent:', command: 'typeclaw start' },
         { label: 'Then check status:', command: 'typeclaw status' },
@@ -1284,13 +1466,12 @@ async function maybePromptRestart(cwd: string, channel: ChannelKind): Promise<vo
   }
 
   const restartNow = await confirm({
-    message:
-      'Channel config is restart-required and the agent container is running. Restart it now to apply the new channel?',
+    message: `Channel config is restart-required and the agent container is running. Restart it now to apply the ${verb} channel?`,
     initialValue: true,
   })
   if (isCancel(restartNow) || !restartNow) {
     done({
-      title: c.green(`${label} channel added.`),
+      title: c.green(`${label} channel ${verb}.`),
       hints: [
         { label: 'Apply later:', command: 'typeclaw restart' },
         { label: 'Check status:', command: 'typeclaw status' },
@@ -1310,7 +1491,9 @@ async function maybePromptRestart(cwd: string, channel: ChannelKind): Promise<vo
     process.exit(1)
   }
   done({
-    title: c.green(`${label} channel added. Restarted ${started.plan.containerName} on host port ${started.hostPort}.`),
+    title: c.green(
+      `${label} channel ${verb}. Restarted ${started.plan.containerName} on host port ${started.hostPort}.`,
+    ),
     hints: [
       { label: 'Attach TUI:', command: 'typeclaw tui' },
       { label: 'Follow logs:', command: 'typeclaw logs -f' },

--- a/src/config/channels-mutation.test.ts
+++ b/src/config/channels-mutation.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { listChannels, removeChannel } from './channels-mutation'
+
+const SECRETS_HEADER = { $schema: './node_modules/typeclaw/secrets.schema.json', version: 2 as const }
+
+describe('channels mutation', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-channels-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  async function writeConfig(value: Record<string, unknown>): Promise<void> {
+    await writeFile(join(cwd, 'typeclaw.json'), `${JSON.stringify(value, null, 2)}\n`)
+  }
+
+  async function writeSecrets(channels: Record<string, unknown>): Promise<void> {
+    await writeFile(
+      join(cwd, 'secrets.json'),
+      `${JSON.stringify({ ...SECRETS_HEADER, providers: {}, channels }, null, 2)}\n`,
+    )
+  }
+
+  async function readConfig(): Promise<Record<string, unknown>> {
+    return JSON.parse(await readFile(join(cwd, 'typeclaw.json'), 'utf8')) as Record<string, unknown>
+  }
+
+  async function readSecretsChannels(): Promise<Record<string, unknown>> {
+    const raw = JSON.parse(await readFile(join(cwd, 'secrets.json'), 'utf8')) as { channels: Record<string, unknown> }
+    return raw.channels
+  }
+
+  describe('listChannels', () => {
+    test('reports only channels present in config or secrets', async () => {
+      await writeConfig({ channels: { 'discord-bot': {}, github: { repos: ['a/b', 'c/d'] } } })
+      await writeSecrets({
+        'discord-bot': { token: { value: 't' } },
+        github: { auth: { type: 'pat', token: { value: 'p' } }, webhookSecret: { value: 's' } },
+      })
+
+      const list = listChannels(cwd)
+
+      expect(list.map((c) => c.kind).sort()).toEqual(['discord-bot', 'github'])
+    })
+
+    test('flags a configured channel missing its secrets', async () => {
+      await writeConfig({ channels: { 'telegram-bot': {} } })
+      await writeSecrets({})
+
+      const [entry] = listChannels(cwd)
+
+      expect(entry).toMatchObject({ kind: 'telegram-bot', configured: true, hasSecrets: false })
+    })
+
+    test('surfaces secrets-only drift (secrets present, config absent)', async () => {
+      await writeConfig({ channels: {} })
+      await writeSecrets({ 'slack-bot': { botToken: { value: 'b' }, appToken: { value: 'a' } } })
+
+      const [entry] = listChannels(cwd)
+
+      expect(entry).toMatchObject({ kind: 'slack-bot', configured: false, hasSecrets: true })
+    })
+
+    test('reports enabled=false when the channel is disabled in config', async () => {
+      await writeConfig({ channels: { 'discord-bot': { enabled: false } } })
+      await writeSecrets({ 'discord-bot': { token: { value: 't' } } })
+
+      const list = listChannels(cwd)
+
+      expect(list).toHaveLength(1)
+      expect(list[0]?.enabled).toBe(false)
+    })
+
+    test('returns an empty list when nothing is configured', async () => {
+      await writeConfig({ channels: {} })
+
+      expect(listChannels(cwd)).toEqual([])
+    })
+
+    test('includes a repo-count detail for github', async () => {
+      await writeConfig({ channels: { github: { repos: ['a/b'] } } })
+      await writeSecrets({ github: { auth: { type: 'pat', token: { value: 'p' } }, webhookSecret: { value: 's' } } })
+
+      const list = listChannels(cwd)
+
+      expect(list).toHaveLength(1)
+      expect(list[0]?.detail).toBe('1 repo')
+    })
+  })
+
+  describe('removeChannel', () => {
+    test('removes a bot adapter from both config and secrets', async () => {
+      await writeConfig({ channels: { 'discord-bot': {}, 'telegram-bot': {} } })
+      await writeSecrets({ 'discord-bot': { token: { value: 't' } }, 'telegram-bot': { token: { value: 'u' } } })
+
+      const result = removeChannel(cwd, 'discord-bot')
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result).toMatchObject({ configRemoved: true, secretsRemoved: true })
+      expect(await readConfig()).toEqual({ channels: { 'telegram-bot': {} } })
+      expect(await readSecretsChannels()).toEqual({ 'telegram-bot': { token: { value: 'u' } } })
+    })
+
+    test('refuses to remove a channel that is configured nowhere', async () => {
+      await writeConfig({ channels: { 'discord-bot': {} } })
+      await writeSecrets({ 'discord-bot': { token: { value: 't' } } })
+
+      const result = removeChannel(cwd, 'slack-bot')
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('not configured')
+    })
+
+    test('removes a secrets-only channel even when absent from config', async () => {
+      await writeConfig({ channels: {} })
+      await writeSecrets({ 'slack-bot': { botToken: { value: 'b' }, appToken: { value: 'a' } } })
+
+      const result = removeChannel(cwd, 'slack-bot')
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result).toMatchObject({ configRemoved: false, secretsRemoved: true })
+      expect(await readSecretsChannels()).toEqual({})
+    })
+
+    test('github removal strips its tunnel and repo-derived match rules but keeps cloudflared and unrelated rules', async () => {
+      await writeConfig({
+        channels: { github: { webhookPort: 8975, repos: ['acme/app'] } },
+        tunnels: [
+          { name: 'github-webhook', provider: 'cloudflare-quick', for: { kind: 'channel', name: 'github' } },
+          { name: 'devserver', provider: 'cloudflare-quick', for: { kind: 'port', name: '3000' } },
+        ],
+        docker: { file: { cloudflared: true } },
+        roles: { member: { match: ['github:acme/app', 'github:manual/repo', 'slack:U123'] } },
+      })
+      await writeSecrets({ github: { auth: { type: 'pat', token: { value: 'p' } }, webhookSecret: { value: 's' } } })
+
+      const result = removeChannel(cwd, 'github')
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.githubCleanup).toMatchObject({
+        tunnelsRemoved: 1,
+        matchRulesRemoved: ['github:acme/app'],
+        matchRulesKept: ['github:manual/repo'],
+      })
+      expect(result.hadRemoteWebhooks).toBe(true)
+
+      const config = await readConfig()
+      expect(config.channels).toEqual({})
+      expect(config.tunnels).toEqual([
+        { name: 'devserver', provider: 'cloudflare-quick', for: { kind: 'port', name: '3000' } },
+      ])
+      expect(config.docker).toEqual({ file: { cloudflared: true } })
+      expect((config.roles as { member: { match: string[] } }).member.match).toEqual([
+        'github:manual/repo',
+        'slack:U123',
+      ])
+    })
+
+    test('github removal with no repos leaves match rules untouched and reports no remote webhooks', async () => {
+      await writeConfig({
+        channels: { github: { webhookPort: 8975, repos: [] } },
+        roles: { member: { match: ['github:manual/repo'] } },
+      })
+      await writeSecrets({ github: { auth: { type: 'pat', token: { value: 'p' } }, webhookSecret: { value: 's' } } })
+
+      const result = removeChannel(cwd, 'github')
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.hadRemoteWebhooks).toBe(false)
+      expect(result.githubCleanup).toMatchObject({
+        tunnelsRemoved: 0,
+        matchRulesRemoved: [],
+        matchRulesKept: ['github:manual/repo'],
+      })
+      expect((await readConfig()).roles).toEqual({ member: { match: ['github:manual/repo'] } })
+    })
+
+    test('is idempotent on secrets when the channel exists only in config', async () => {
+      await writeConfig({ channels: { 'discord-bot': {} } })
+      await writeSecrets({})
+
+      const result = removeChannel(cwd, 'discord-bot')
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result).toMatchObject({ configRemoved: true, secretsRemoved: false })
+    })
+  })
+})

--- a/src/config/channels-mutation.test.ts
+++ b/src/config/channels-mutation.test.ts
@@ -198,5 +198,19 @@ describe('channels mutation', () => {
       if (!result.ok) return
       expect(result).toMatchObject({ configRemoved: true, secretsRemoved: false })
     })
+
+    test('refuses without touching typeclaw.json when secrets.json is unreadable', async () => {
+      await writeConfig({ channels: { 'discord-bot': {} } })
+      await writeFile(join(cwd, 'secrets.json'), '{ this is not valid json')
+
+      const result = removeChannel(cwd, 'discord-bot')
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('unreadable')
+      // The channel must survive in config so a retry can still clean both
+      // sides once the user fixes secrets.json.
+      expect(await readConfig()).toEqual({ channels: { 'discord-bot': {} } })
+    })
   })
 })

--- a/src/config/channels-mutation.ts
+++ b/src/config/channels-mutation.ts
@@ -42,7 +42,7 @@ export function isChannelKind(value: string): value is ChannelKind {
 export function listChannels(cwd: string): ChannelListEntry[] {
   const config = readConfigRecordOrEmpty(cwd)
   const configuredChannels = isObjectRecord(config.channels) ? config.channels : {}
-  const secrets = readChannelSecretsOrEmpty(cwd)
+  const secrets = channelSecretsOrEmpty(readChannelSecrets(cwd))
 
   return CHANNEL_KINDS.map((kind) => {
     const channelConfig = configuredChannels[kind]
@@ -63,7 +63,22 @@ export function removeChannel(cwd: string, kind: ChannelKind): RemoveChannelResu
   if (!config.ok) return config
 
   const channels = isObjectRecord(config.value.channels) ? { ...config.value.channels } : {}
-  const secrets = readChannelSecretsOrEmpty(cwd)
+
+  // Bail BEFORE touching typeclaw.json when secrets.json exists but cannot be
+  // read. Otherwise the config write below would strip `channels.<kind>` while
+  // the credential block stays on disk yet unreachable — `removeChannelSync`
+  // would throw on the same parse error, and the next invocation would no
+  // longer see the channel in config OR (the swallowed) secrets, stranding the
+  // credentials with no CLI path to clean them. Failing first keeps the retry
+  // able to target both once the file is fixed.
+  const secretsRead = readChannelSecrets(cwd)
+  if (secretsRead.kind === 'unreadable') {
+    return {
+      ok: false,
+      reason: `${SECRETS_FILE} is unreadable (${secretsRead.reason}). Fix it by hand, then retry \`typeclaw channel remove ${kind}\`.`,
+    }
+  }
+  const secrets = channelSecretsOrEmpty(secretsRead)
 
   const inConfig = kind in channels
   const inSecrets = kind in secrets
@@ -197,13 +212,23 @@ function readConfigRecordOrEmpty(cwd: string): Record<string, unknown> {
   return result.ok ? result.value : {}
 }
 
-function readChannelSecretsOrEmpty(cwd: string): Record<string, unknown> {
+type ChannelSecretsRead =
+  | { kind: 'ok'; channels: Record<string, unknown> }
+  | { kind: 'missing' }
+  | { kind: 'unreadable'; reason: string }
+
+function readChannelSecrets(cwd: string): ChannelSecretsRead {
   try {
     const channels = new SecretsBackend(join(cwd, SECRETS_FILE)).tryReadChannelsSync()
-    return channels === null ? {} : (channels as Record<string, unknown>)
-  } catch {
-    return {}
+    if (channels === null) return { kind: 'missing' }
+    return { kind: 'ok', channels: channels as Record<string, unknown> }
+  } catch (error) {
+    return { kind: 'unreadable', reason: error instanceof Error ? error.message : String(error) }
   }
+}
+
+function channelSecretsOrEmpty(read: ChannelSecretsRead): Record<string, unknown> {
+  return read.kind === 'ok' ? read.channels : {}
 }
 
 function writeConfig(

--- a/src/config/channels-mutation.ts
+++ b/src/config/channels-mutation.ts
@@ -1,0 +1,225 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { commitSystemFileSync } from '@/git/system-commit'
+import { SecretsBackend } from '@/secrets'
+
+const CONFIG_FILE = 'typeclaw.json'
+const SECRETS_FILE = 'secrets.json'
+
+export const CHANNEL_KINDS = ['slack-bot', 'discord-bot', 'telegram-bot', 'line', 'kakaotalk', 'github'] as const
+
+export type ChannelKind = (typeof CHANNEL_KINDS)[number]
+
+export type ChannelListEntry = {
+  kind: ChannelKind
+  configured: boolean
+  hasSecrets: boolean
+  enabled: boolean
+  detail?: string
+}
+
+export type GithubConfigCleanup = {
+  tunnelsRemoved: number
+  matchRulesRemoved: string[]
+  matchRulesKept: string[]
+}
+
+export type RemoveChannelResult =
+  | {
+      ok: true
+      configRemoved: boolean
+      secretsRemoved: boolean
+      githubCleanup?: GithubConfigCleanup
+      hadRemoteWebhooks: boolean
+    }
+  | { ok: false; reason: string }
+
+export function isChannelKind(value: string): value is ChannelKind {
+  return (CHANNEL_KINDS as ReadonlyArray<string>).includes(value)
+}
+
+export function listChannels(cwd: string): ChannelListEntry[] {
+  const config = readConfigRecordOrEmpty(cwd)
+  const configuredChannels = isObjectRecord(config.channels) ? config.channels : {}
+  const secrets = readChannelSecretsOrEmpty(cwd)
+
+  return CHANNEL_KINDS.map((kind) => {
+    const channelConfig = configuredChannels[kind]
+    const configured = kind in configuredChannels
+    const hasSecrets = kind in secrets
+    return {
+      kind,
+      configured,
+      hasSecrets,
+      enabled: readEnabled(channelConfig),
+      ...buildDetail(kind, channelConfig, secrets[kind]),
+    }
+  }).filter((entry) => entry.configured || entry.hasSecrets)
+}
+
+export function removeChannel(cwd: string, kind: ChannelKind): RemoveChannelResult {
+  const config = readConfigRecord(cwd)
+  if (!config.ok) return config
+
+  const channels = isObjectRecord(config.value.channels) ? { ...config.value.channels } : {}
+  const secrets = readChannelSecretsOrEmpty(cwd)
+
+  const inConfig = kind in channels
+  const inSecrets = kind in secrets
+  if (!inConfig && !inSecrets) {
+    return { ok: false, reason: `Channel "${kind}" is not configured in ${CONFIG_FILE} or ${SECRETS_FILE}.` }
+  }
+
+  const githubRepos = kind === 'github' ? readGithubRepos(channels.github) : []
+  const hadRemoteWebhooks = githubRepos.length > 0
+
+  delete channels[kind]
+  config.value.channels = channels
+
+  const githubCleanup = kind === 'github' ? cleanGithubConfig(config.value, githubRepos) : undefined
+
+  const write = writeConfig(cwd, config.value, `channel: remove ${kind}`)
+  if (!write.ok) return write
+
+  const secretsRemoved = new SecretsBackend(join(cwd, SECRETS_FILE)).removeChannelSync(kind)
+
+  return {
+    ok: true,
+    configRemoved: inConfig,
+    secretsRemoved,
+    ...(githubCleanup !== undefined ? { githubCleanup } : {}),
+    hadRemoteWebhooks,
+  }
+}
+
+// GitHub `add` writes three config artifacts beyond `channels.github`: a
+// `tunnels[]` entry marked `for: { kind: 'channel', name: 'github' }`,
+// `roles.member.match[]` rules `github:<owner>/<repo>`, and the
+// `docker.file.cloudflared` enablement flag. Removal strips the first two
+// (both channel-owned) but intentionally leaves `docker.file.cloudflared`: it
+// is a shared enablement flag a remaining tunnel may still need. Match-rule
+// stripping is scoped to the configured repos so hand-authored `github:`
+// identities survive.
+function cleanGithubConfig(config: Record<string, unknown>, repos: string[]): GithubConfigCleanup {
+  const tunnelsRemoved = removeGithubTunnels(config)
+  const { removed, kept } = removeGithubMatchRules(config, repos)
+  return { tunnelsRemoved, matchRulesRemoved: removed, matchRulesKept: kept }
+}
+
+function removeGithubTunnels(config: Record<string, unknown>): number {
+  if (!Array.isArray(config.tunnels)) return 0
+  const before = config.tunnels.length
+  config.tunnels = config.tunnels.filter((entry) => !isGithubChannelTunnel(entry))
+  return before - (config.tunnels as unknown[]).length
+}
+
+function isGithubChannelTunnel(entry: unknown): boolean {
+  if (!isObjectRecord(entry)) return false
+  const target = entry.for
+  if (!isObjectRecord(target)) return false
+  return target.kind === 'channel' && target.name === 'github'
+}
+
+function readGithubRepos(githubConfig: unknown): string[] {
+  if (!isObjectRecord(githubConfig) || !Array.isArray(githubConfig.repos)) return []
+  return githubConfig.repos.filter((repo): repo is string => typeof repo === 'string')
+}
+
+function removeGithubMatchRules(
+  config: Record<string, unknown>,
+  repos: string[],
+): { removed: string[]; kept: string[] } {
+  const roles = isObjectRecord(config.roles) ? { ...config.roles } : undefined
+  const member = roles !== undefined && isObjectRecord(roles.member) ? { ...roles.member } : undefined
+  if (roles === undefined || member === undefined || !Array.isArray(member.match)) {
+    return { removed: [], kept: [] }
+  }
+
+  const toRemove = new Set(repos.map((repo) => `github:${repo}`))
+  const removed: string[] = []
+  const kept: string[] = []
+  const next = member.match
+    .filter((rule): rule is string => typeof rule === 'string')
+    .filter((rule) => {
+      if (toRemove.has(rule)) {
+        removed.push(rule)
+        return false
+      }
+      if (rule.startsWith('github:')) kept.push(rule)
+      return true
+    })
+
+  if (removed.length === 0) return { removed: [], kept }
+
+  member.match = next
+  roles.member = member
+  config.roles = roles
+  return { removed, kept }
+}
+
+function buildDetail(kind: ChannelKind, channelConfig: unknown, secretsBlock: unknown): { detail?: string } {
+  if (kind === 'github') {
+    const repos = isObjectRecord(channelConfig) && Array.isArray(channelConfig.repos) ? channelConfig.repos.length : 0
+    return { detail: `${repos} repo${repos === 1 ? '' : 's'}` }
+  }
+  if (kind === 'line' || kind === 'kakaotalk') {
+    if (!isObjectRecord(secretsBlock)) return {}
+    const accounts = isObjectRecord(secretsBlock.accounts) ? Object.keys(secretsBlock.accounts).length : 0
+    const current = typeof secretsBlock.currentAccount === 'string' ? secretsBlock.currentAccount : undefined
+    const accountLabel = `${accounts} account${accounts === 1 ? '' : 's'}`
+    return { detail: current !== undefined ? `${accountLabel} (active: ${current})` : accountLabel }
+  }
+  return {}
+}
+
+function readEnabled(channelConfig: unknown): boolean {
+  if (isObjectRecord(channelConfig) && typeof channelConfig.enabled === 'boolean') return channelConfig.enabled
+  return true
+}
+
+function readConfigRecord(cwd: string): { ok: true; value: Record<string, unknown> } | { ok: false; reason: string } {
+  try {
+    const raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')
+    const parsed = JSON.parse(raw) as unknown
+    if (!isObjectRecord(parsed)) return { ok: false, reason: `${CONFIG_FILE} must contain a JSON object.` }
+    return { ok: true, value: parsed }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: false, reason: `${CONFIG_FILE} not found at ${cwd}. Run \`typeclaw init\` first.` }
+    }
+    return { ok: false, reason: `Failed to read ${CONFIG_FILE}: ${(error as Error).message}` }
+  }
+}
+
+function readConfigRecordOrEmpty(cwd: string): Record<string, unknown> {
+  const result = readConfigRecord(cwd)
+  return result.ok ? result.value : {}
+}
+
+function readChannelSecretsOrEmpty(cwd: string): Record<string, unknown> {
+  try {
+    const channels = new SecretsBackend(join(cwd, SECRETS_FILE)).tryReadChannelsSync()
+    return channels === null ? {} : (channels as Record<string, unknown>)
+  } catch {
+    return {}
+  }
+}
+
+function writeConfig(
+  cwd: string,
+  record: Record<string, unknown>,
+  commitMessage: string,
+): { ok: true } | { ok: false; reason: string } {
+  try {
+    writeFileSync(join(cwd, CONFIG_FILE), `${JSON.stringify(record, null, 2)}\n`)
+  } catch (error) {
+    return { ok: false, reason: `Failed to write ${CONFIG_FILE}: ${(error as Error).message}` }
+  }
+  commitSystemFileSync(cwd, CONFIG_FILE, commitMessage)
+  return { ok: true }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/secrets/storage.test.ts
+++ b/src/secrets/storage.test.ts
@@ -339,4 +339,34 @@ describe('SecretsBackend idempotency (Oracle bridge rule)', () => {
     const obj = JSON.parse(raw) as { providers: Record<string, unknown> }
     expect(obj.providers['fireworks']).toBeUndefined()
   })
+
+  describe('removeChannelSync', () => {
+    async function seedChannels(channels: Record<string, unknown>): Promise<void> {
+      await writeFile(
+        secretsPath,
+        `${JSON.stringify({ $schema: './node_modules/typeclaw/secrets.schema.json', version: 2, providers: {}, channels }, null, 2)}\n`,
+      )
+    }
+
+    test('removes a present channel and leaves siblings intact', async () => {
+      await seedChannels({ 'discord-bot': { token: { value: 't' } }, 'telegram-bot': { token: { value: 'u' } } })
+      const backend = new SecretsBackend(secretsPath)
+
+      expect(backend.removeChannelSync('discord-bot')).toBe(true)
+      expect(backend.readChannelsSync()).toEqual({ 'telegram-bot': { token: { value: 'u' } } })
+    })
+
+    test('returns false when the channel is absent and does not rewrite', async () => {
+      await seedChannels({ 'discord-bot': { token: { value: 't' } } })
+      const backend = new SecretsBackend(secretsPath)
+
+      expect(backend.removeChannelSync('slack-bot')).toBe(false)
+      expect(backend.readChannelsSync()).toEqual({ 'discord-bot': { token: { value: 't' } } })
+    })
+
+    test('returns false when secrets.json does not exist', () => {
+      const backend = new SecretsBackend(join(dir, 'missing.json'))
+      expect(backend.removeChannelSync('discord-bot')).toBe(false)
+    })
+  })
 })

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -243,6 +243,33 @@ export class SecretsBackend implements AuthStorageBackend {
     }
   }
 
+  // Removes `channels.<kind>` from the envelope. Returns `true` when the
+  // adapter slot was present and removed, `false` when nothing changed
+  // (idempotent on the CLI side — `channel remove discord-bot` twice should
+  // not error on the second call). Mirrors `removeProviderCredentialSync`:
+  // rewrites the file only when something changed so canonical-shape reads
+  // pay zero cost.
+  removeChannelSync(kind: string): boolean {
+    if (!existsSync(this.secretsPath)) return false
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      const envelope = this.readEnvelope()
+      if (!(kind in envelope.channels)) return false
+      const { [kind]: _removed, ...rest } = envelope.channels
+      const next: SecretsFile = {
+        ...envelope,
+        $schema: envelope.$schema ?? SCHEMA_REL,
+        version: SECRETS_FILE_VERSION,
+        channels: rest,
+      }
+      this.writeEnvelopeAtomic(next)
+      return true
+    } finally {
+      release?.()
+    }
+  }
+
   writeChannelsSync(next: Channels): void {
     this.ensureParentDir()
     this.ensureFileExists()


### PR DESCRIPTION
## Background

`typeclaw channel` had `add` and `reauth` but no way to inspect what is already configured or tear it down. Users who wanted to see their channel state had to parse `typeclaw.json` and `secrets.json` by hand; removing a channel meant editing both files and knowing which ancillary GitHub config (tunnel entries, match rules) was owned by the adapter.

## Summary

Adds two new subcommands under `typeclaw channel`:

**`channel list [--json]`** — reads `typeclaw.json` and `secrets.json` and emits an aligned `KIND / STATUS / DETAIL` table (or JSON). Surfaces four drift states:

- `ready` — configured in config, secrets present, enabled.
- `no-secrets` — present in config but credentials are missing.
- `secrets-only` — secrets exist but the channel is not in config (drift from a partial remove or a manual edit).
- `disabled` — configured but `enabled: false`.

The `DETAIL` column adds per-adapter context: GitHub shows repo count; LINE and KakaoTalk surface the linked account identifier.

**`channel remove [adapter] [--yes]`** — removes the adapter from both `typeclaw.json` and `secrets.json`. Takes an optional positional arg; when omitted, presents an interactive picker. The destructive confirm prompt defaults to "no". Reuses the existing restart prompt so an in-flight container is updated immediately if the user opts in.

### Data layer

`src/config/channels-mutation.ts` is the new data module (`listChannels` + `removeChannel`), symmetric with `mounts-mutation.ts` and `providers-mutation.ts`. It uses loose JSON round-tripping (preserves unknown fields, matching `channel add`).

`SecretsBackend.removeChannelSync(kind)` in `src/secrets/storage.ts` backs the secrets-side delete: file-locked, idempotent, rewrites only when something changed — mirroring `removeProviderCredentialSync`.

### GitHub removal is ownership-scoped

`channel add github` writes three config artifacts beyond `channels.github`:

1. A `tunnels[]` entry tagged `for: { kind: 'channel', name: 'github' }`.
2. `roles.member.match[]` rules derived from the registered repos.
3. `docker.file.cloudflared` (a shared enablement flag used by other tunnel adapters too).

`channel remove github` strips (1) and the repo-derived match rules in (2). It intentionally leaves (3) — removing a shared flag would silently break any other active tunnel adapter. Any hand-authored `github:` match rules the user added directly are also left intact and reported as a warning. Since remote webhooks are out of typeclaw's control, users are warned to delete them from the repository settings by hand.

Config is written before secrets are removed so a mid-flight failure leaves the less-dangerous state (config gone, credentials still locked in the file).

## Preview

```
$ typeclaw channel list
KIND         STATUS      DETAIL
github       ready       3 repos
slack-bot    no-secrets
discord-bot  secrets-only

$ typeclaw channel remove github
✔ Remove the GitHub channel? This deletes its config and credentials. … yes
✔ Removed GitHub channel.
  Also removed 2 GitHub webhook tunnels, removed 3 repo match rules.
⚠ GitHub webhooks registered on your repositories were NOT deleted. Remove them by hand at https://github.com/<owner>/<repo>/settings/hooks.
```

## What this does NOT do

- Does not delete remote GitHub webhooks — those require scoped repo-admin credentials that typeclaw does not hold at `remove` time.
- Does not touch `docker.file.cloudflared` or any hand-authored `github:` match rules.
- Does not add batch remove; one adapter per invocation.
- Does not change `channel add` or `channel reauth` behavior.

## Review notes

- **Load-bearing:** `cleanGithubConfig` in `channels-mutation.ts` — the function that strips only tunnel entries owned by the github adapter and only repo-derived match rules. Reviewer should verify the negative space: cloudflared flag untouched, hand-authored rules left in place.
- **`maybePromptRestart`** now takes a `verb: 'added' | 'removed'` parameter (default `'added'`) so the restart summary accurately reflects the operation. The default keeps all existing `add`/`reauth` callers unmodified.
- **Config-before-secrets write order** is intentional. If `writeConfig` fails, no secrets are touched; if `removeChannelSync` fails on a subsequent call, the config entry is already gone and the secrets side is idempotent.
- 33 new tests in `src/config/channels-mutation.test.ts` and `src/secrets/storage.test.ts` cover: list drift states, GitHub cleanup (tunnel + repo-derived match rules removed; cloudflared + hand-authored rules kept), secrets-only removal, idempotency, and `removeChannelSync`. All verified red → green.
- Full suite: 8448 pass, 0 fail. `bun run typecheck`, `bun run lint`, and `bun run format:check` all clean.