### PR TITLE
fix(inspect): show the timestamp once per turn, not per event

### DIFF
--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -82,6 +82,7 @@ const ID_PICK1 = '019dda40-3333-7000-9000-000000003333'
 const ID_PICK2 = '019dda40-4444-7000-9000-000000004444'
 const ID_AMB_1 = '019dda40-5555-7000-9000-000000000001'
 const ID_AMB_2 = '019dda40-5555-7000-9000-000000000002'
+const ID_RESETBND = '019dda40-6666-7000-9000-000000006666'
 const AMB_PREFIX = '019dda40-5555'
 
 describe('runInspect — direct session id (replay-then-exit)', () => {
@@ -283,6 +284,43 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
     expect(body.map(hasTime)).toEqual([true, true, false, true, false])
     expect(sink.out.find((l) => l.includes('─── live ───'))).toBeDefined()
     expect(sink.out.at(-1)!).toContain('end of transcript')
+  })
+
+  test('the live divider resets the gate so the first live row is stamped even when it shares the last replayed category', async () => {
+    // given: a replay ending in a tool event, then a same-category live tool event
+    const toolMsg = JSON.stringify({
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'toolCall', id: 'c0', name: 'read', arguments: { path: 'x' } }],
+        timestamp: 1_000_005,
+      },
+    })
+    await seedSession(`a_${ID_RESETBND}.jsonl`, [metaLine({ kind: 'tui' }), toolMsg], 1000)
+    const sink = captureSink()
+    async function* fakeLive(): AsyncGenerator<import('./types').InspectEvent> {
+      yield { cat: 'tool', ts: Date.now(), phase: 'start', toolCallId: 'c1', name: 'grep' }
+    }
+
+    // when: the stream replays then tails the live tool event
+    const result = await runInspect({
+      agentDir,
+      sessionIdOrPrefix: ID_RESETBND,
+      color: false,
+      selectSession: neverPick,
+      liveSource: (o) => {
+        o.onSubscribed?.(true)
+        return fakeLive()
+      },
+      ...sink.push,
+    })
+    expect(result.ok).toBe(true)
+
+    // then: the live tool row (after the divider) carries a timestamp, not a blank
+    const liveIdx = sink.out.findIndex((l) => l.includes('─── live ───'))
+    const liveToolLine = sink.out.slice(liveIdx + 1).find((l) => l.includes('grep'))
+    expect(liveToolLine).toBeDefined()
+    expect(/^\d{2}:\d{2}:\d{2}/.test(liveToolLine!)).toBe(true)
   })
 
   test('reports "session not in registry" divider when liveSource onSubscribed says sessionLive=false', async () => {

--- a/src/inspect/index.test.ts
+++ b/src/inspect/index.test.ts
@@ -269,9 +269,18 @@ describe('runInspect — live tail (when liveSource is provided)', () => {
       ...sink.push,
     })
     expect(result.ok).toBe(true)
-    const stripTime = (l: string) => l.replace(/\d{2}:\d{2}:\d{2}/, 'HH:MM:SS')
-    const tags = sink.out.slice(1, -1).map((l) => stripTime(l).split('  ')[1]?.trim())
+    const tagOf = (l: string) => {
+      const m = /^(?:\d{2}:\d{2}:\d{2}|\s{8})  (.{9})/.exec(l)
+      return m === null ? undefined : m[1]!.trim()
+    }
+    const hasTime = (l: string) => /^\d{2}:\d{2}:\d{2}/.test(l)
+    const body = sink.out.slice(1, -1)
+    const tags = body.map(tagOf)
     expect(tags).toEqual(['meta', 'user', undefined, 'tool ▸', 'tool ◂'])
+    // meta, user and the first tool of the run carry a timestamp; the second
+    // consecutive tool line is blanked (same-category grouping). The divider is
+    // the undefined-tag line and is not timestamped.
+    expect(body.map(hasTime)).toEqual([true, true, false, true, false])
     expect(sink.out.find((l) => l.includes('─── live ───'))).toBeDefined()
     expect(sink.out.at(-1)!).toContain('end of transcript')
   })

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -310,6 +310,7 @@ async function streamSession(opts: {
       printFooter()
       emitHint()
     } else if (p.phase === 'live-start') {
+      timeGate.reset()
       opts.stdout(
         divider(opts.color, p.sessionLive ? '─── live ───' : '─── live (session not in registry; broadcasts only) ───'),
       )

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 
 import { originLabel, shortSessionId } from './label'
-import { renderEvent } from './render'
+import { renderEvent, TimeGate } from './render'
 import { replayJsonl } from './replay'
 import type { SessionSummary } from './session-list'
 import { isSessionIdShape, listSessions, resolveSession } from './session-list'
@@ -283,9 +283,10 @@ async function streamSession(opts: {
 }): Promise<{ escToPicker: boolean }> {
   if (!opts.json) writeHeader(opts.summary, opts.color, opts.stdout)
 
+  const timeGate = new TimeGate()
   const onEvent = (event: InspectEvent): void => {
     if (opts.json) opts.stdout(JSON.stringify({ sessionId: opts.summary.sessionId, ...event }))
-    else opts.stdout(renderEvent(event, { color: opts.color }))
+    else opts.stdout(renderEvent(event, { color: opts.color, showTime: timeGate.shouldShow(event.cat) }))
   }
 
   const emitHint = (): void => {

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -250,6 +250,14 @@ describe('TimeGate', () => {
     expect(gate.shouldShow('tool')).toBe(false)
     expect(gate.shouldShow('assistant')).toBe(true)
   })
+
+  test('reset() forces the next same-category event to show its timestamp again', () => {
+    const gate = new TimeGate()
+    expect(gate.shouldShow('tool')).toBe(true)
+    expect(gate.shouldShow('tool')).toBe(false)
+    gate.reset()
+    expect(gate.shouldShow('tool')).toBe(true)
+  })
 })
 
 describe('renderEvent (with color)', () => {

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { renderEvent } from './render'
+import { renderEvent, TimeGate } from './render'
 import type { InspectEvent } from './types'
 
 const PLAIN = { color: false }
@@ -220,6 +220,35 @@ describe('renderEvent (plain, no color)', () => {
       decision: 'observe',
     }
     expect(stripTime(renderEvent(ev, PLAIN))).toBe('HH:MM:SS  inbound    [observe] kakaotalk:kk/g1 k_user_123: hi')
+  })
+})
+
+describe('renderEvent showTime=false (suppressed timestamp keeps column alignment)', () => {
+  test('blanks the time column while leaving tag and body aligned with a shown line', () => {
+    const ev: InspectEvent = { cat: 'user', ts: dateMs('15:08:42'), text: 'hi' }
+    const shown = renderEvent(ev, { color: false })
+    const hidden = renderEvent(ev, { color: false, showTime: false })
+    expect(hidden).toBe(shown.replace(/^\d{2}:\d{2}:\d{2}/, '        '))
+    expect(hidden.startsWith('        ')).toBe(true)
+  })
+})
+
+describe('TimeGate', () => {
+  test('shows the first event then suppresses consecutive same-category events', () => {
+    const gate = new TimeGate()
+    expect(gate.shouldShow('thinking')).toBe(true)
+    expect(gate.shouldShow('thinking')).toBe(false)
+    expect(gate.shouldShow('thinking')).toBe(false)
+  })
+
+  test('shows again whenever the category changes', () => {
+    const gate = new TimeGate()
+    expect(gate.shouldShow('user')).toBe(true)
+    expect(gate.shouldShow('thinking')).toBe(true)
+    expect(gate.shouldShow('thinking')).toBe(false)
+    expect(gate.shouldShow('tool')).toBe(true)
+    expect(gate.shouldShow('tool')).toBe(false)
+    expect(gate.shouldShow('assistant')).toBe(true)
   })
 })
 

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -33,6 +33,13 @@ export class TimeGate {
     this.prevCat = cat
     return show
   }
+
+  // Clear the running category so the next event always shows its timestamp.
+  // Called at a visible section boundary (the live divider) so the first live
+  // row is stamped even when it shares the last replayed event's category.
+  reset(): void {
+    this.prevCat = null
+  }
 }
 
 const DEFAULT_MAX_TEXT = 200

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -6,13 +6,33 @@ import type { InspectEvent } from './types'
 export type RenderOptions = {
   color: boolean
   maxTextLength?: number
+  // When false, the timestamp column is blanked (kept the same width so the tag
+  // column stays aligned). The line view passes this from a TimeGate so a run of
+  // same-category events shows the timestamp only on its first line.
+  showTime?: boolean
 }
 
+const TIME_WIDTH = '--:--:--'.length
+
 export function renderEvent(event: InspectEvent, opts: RenderOptions): string {
-  const time = renderTime(event.ts, opts)
+  const time = opts.showTime === false ? ' '.repeat(TIME_WIDTH) : renderTime(event.ts, opts)
   const tag = renderTag(event, opts)
   const body = renderBody(event, opts)
   return `${time}  ${tag}  ${body}`
+}
+
+// Decides whether an event's timestamp should be shown, given the running render
+// position: a timestamp prints only when the event's category differs from the
+// previous one, so a run of same-category events (e.g. back-to-back thinking
+// blocks or a tool start/end pair) carries a single timestamp at its start.
+export class TimeGate {
+  private prevCat: InspectEvent['cat'] | null = null
+
+  shouldShow(cat: InspectEvent['cat']): boolean {
+    const show = cat !== this.prevCat
+    this.prevCat = cat
+    return show
+  }
 }
 
 const DEFAULT_MAX_TEXT = 200

--- a/src/inspect/transcript-view.test.ts
+++ b/src/inspect/transcript-view.test.ts
@@ -6,9 +6,14 @@ import { join } from 'node:path'
 import { Markdown, type Terminal, Text } from '@mariozechner/pi-tui'
 
 import type { SessionSummary } from './session-list'
-import { BoundedComponentWindow, createTranscriptView, componentFor } from './transcript-view'
+import { BoundedComponentWindow, createTranscriptView, componentFor, type HistoryEntry } from './transcript-view'
 import type { InspectEvent } from './types'
 import { parseFilter } from './types'
+
+function eventEntry(cat: InspectEvent['cat'], stamped: boolean, ts = 1): HistoryEntry {
+  const time = new Text(stamped ? '12:00:00' : '', 0, 0)
+  return { kind: 'event', cat, ts, time, stamped, components: [time, new Text(`${cat} body`, 0, 0)] }
+}
 
 class FakeTerminal implements Terminal {
   rows = 30
@@ -72,18 +77,18 @@ describe('componentFor', () => {
 
 describe('BoundedComponentWindow', () => {
   test('keeps every entry until the cap is reached', () => {
-    const window = new BoundedComponentWindow(3)
-    expect(window.push([new Text('a', 0, 0)])).toBeNull()
-    expect(window.push([new Text('b', 0, 0)])).toBeNull()
-    expect(window.push([new Text('c', 0, 0)])).toBeNull()
+    const window = new BoundedComponentWindow<HistoryEntry>(3)
+    expect(window.push(eventEntry('user', true))).toBeNull()
+    expect(window.push(eventEntry('thinking', true))).toBeNull()
+    expect(window.push(eventEntry('tool', true))).toBeNull()
     expect(window.size).toBe(3)
   })
 
   test('evicts the oldest entry once the cap is exceeded', () => {
-    const window = new BoundedComponentWindow(2)
-    const first = [new Text('first', 0, 0)]
-    const second = [new Text('second', 0, 0)]
-    const third = [new Text('third', 0, 0)]
+    const window = new BoundedComponentWindow<HistoryEntry>(2)
+    const first = eventEntry('user', true)
+    const second = eventEntry('thinking', true)
+    const third = eventEntry('tool', true)
 
     expect(window.push(first)).toBeNull()
     expect(window.push(second)).toBeNull()
@@ -92,18 +97,27 @@ describe('BoundedComponentWindow', () => {
   })
 
   test('evicts the whole entry so a timestamp never outlives its body', () => {
-    const window = new BoundedComponentWindow(1)
-    const timestamp = new Text('12:00:00', 0, 0)
-    const body = new Text('assistant reply', 0, 0)
-    const firstEntry = [timestamp, body]
-    const secondEntry = [new Text('12:00:01', 0, 0), new Text('next', 0, 0)]
+    const window = new BoundedComponentWindow<HistoryEntry>(1)
+    const firstEntry = eventEntry('assistant', true)
+    const secondEntry = eventEntry('user', true)
 
     expect(window.push(firstEntry)).toBeNull()
     const evicted = window.push(secondEntry)
     expect(evicted).toBe(firstEntry)
-    expect(evicted).toContain(timestamp)
-    expect(evicted).toContain(body)
     expect(window.size).toBe(1)
+  })
+
+  test('first() returns the oldest still-visible entry', () => {
+    const window = new BoundedComponentWindow<HistoryEntry>(2)
+    expect(window.first()).toBeUndefined()
+    const a = eventEntry('user', true)
+    const b = eventEntry('thinking', true)
+    const c = eventEntry('tool', true)
+    window.push(a)
+    window.push(b)
+    expect(window.first()).toBe(a)
+    window.push(c)
+    expect(window.first()).toBe(b)
   })
 })
 
@@ -243,5 +257,66 @@ describe('createTranscriptView run()', () => {
     expect(frame).toContain('first thought')
     expect(frame).toContain('second thought')
     expect(frame.split(stamp).length - 1).toBe(1)
+  })
+
+  test('evicting the stamped head of a same-category run re-stamps the new first visible row', async () => {
+    // given: a session with no replay events, then a live run of same-category
+    // thinking events long enough to evict the originally-stamped head
+    const file = join(dir, 'evict.jsonl')
+    await writeFile(
+      file,
+      JSON.stringify({
+        type: 'custom',
+        customType: 'typeclaw.session-meta',
+        data: { origin: { kind: 'tui' } },
+        timestamp: 1,
+      }) + '\n',
+    )
+    const summary: SessionSummary = {
+      sessionId: 'e',
+      sessionFile: file,
+      basename: 'evict.jsonl',
+      mtimeMs: 1,
+      origin: { kind: 'tui' },
+      firstPrompt: null,
+    }
+
+    const base = Date.parse('2026-06-10T09:00:00.000Z')
+    const count = 5
+    async function* live(o: { onSubscribed?: (live: boolean) => void }): AsyncGenerator<InspectEvent> {
+      o.onSubscribed?.(true)
+      for (let i = 0; i < count; i++) {
+        yield { cat: 'thinking', ts: base + i * 1000, text: `thought ${i}` }
+      }
+    }
+
+    const terminal = new FakeTerminal()
+    const view = createTranscriptView({
+      summary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      createTerminal: () => terminal,
+      liveSource: (o) => live(o),
+      maxHistoryEntries: 2,
+    })
+
+    // when: the viewer tails the live run (which overflows the 2-entry window)
+    const runPromise = view.run()
+    await flush()
+    terminal.feed('\x1b')
+    await runPromise
+
+    // then: the final frame still carries a timestamp for the run even though the
+    // first thinking event (and its stamp) was evicted — the new first visible
+    // row was promoted. The meta divider's '--:--:--' must not be the only stamp.
+    const p = (n: number): string => String(n).padStart(2, '0')
+    const hhmmss = (ms: number): string => {
+      const d = new Date(ms)
+      return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+    }
+    const frame = terminal.writes.join('')
+    const survivor = base + (count - 2) * 1000
+    expect(frame).toContain(`thought ${count - 1}`)
+    expect(frame).toContain(hhmmss(survivor))
   })
 })

--- a/src/inspect/transcript-view.test.ts
+++ b/src/inspect/transcript-view.test.ts
@@ -15,6 +15,7 @@ class FakeTerminal implements Terminal {
   columns = 80
   kittyProtocolActive = false
   stopped = false
+  readonly writes: string[] = []
   private inputHandler: ((data: string) => void) | null = null
 
   start(onInput: (data: string) => void): void {
@@ -24,7 +25,9 @@ class FakeTerminal implements Terminal {
     this.stopped = true
   }
   async drainInput(): Promise<void> {}
-  write(): void {}
+  write(data: string): void {
+    this.writes.push(data)
+  }
   moveBy(): void {}
   hideCursor(): void {}
   showCursor(): void {}
@@ -189,5 +192,56 @@ describe('createTranscriptView run()', () => {
     terminal.feed('\x03')
 
     await expect(runPromise).resolves.toEqual({ reason: 'exit' })
+  })
+
+  test('a run of same-category events renders the timestamp on the first block only, not the second', async () => {
+    // given: an assistant turn with two consecutive thinking blocks (one shared ts)
+    const ts = Date.parse('2026-06-10T08:00:00.000Z')
+    const file = join(dir, 'group.jsonl')
+    await writeFile(
+      file,
+      JSON.stringify({
+        type: 'message',
+        timestamp: new Date(ts).toISOString(),
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'first thought' },
+            { type: 'thinking', thinking: 'second thought' },
+          ],
+          timestamp: ts,
+        },
+      }) + '\n',
+    )
+    const groupSummary: SessionSummary = {
+      sessionId: 'g',
+      sessionFile: file,
+      basename: 'group.jsonl',
+      mtimeMs: 1,
+      origin: { kind: 'tui' },
+      firstPrompt: null,
+    }
+    const terminal = new FakeTerminal()
+    const view = createTranscriptView({
+      summary: groupSummary,
+      filter: FILTER.filter,
+      sinceMs: undefined,
+      createTerminal: () => terminal,
+    })
+
+    // when: the viewer replays and we dismiss it
+    const runPromise = view.run()
+    await flush()
+    terminal.feed('\x1b')
+    await runPromise
+
+    // then: the final frame shows both thoughts but the HH:MM:SS stamp exactly once
+    const p = (n: number): string => String(n).padStart(2, '0')
+    const d = new Date(ts)
+    const stamp = `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+    const frame = terminal.writes.join('')
+    expect(frame).toContain('first thought')
+    expect(frame).toContain('second thought')
+    expect(frame.split(stamp).length - 1).toBe(1)
   })
 })

--- a/src/inspect/transcript-view.ts
+++ b/src/inspect/transcript-view.ts
@@ -14,6 +14,7 @@ import { colors, markdownTheme } from '@/tui/theme'
 
 import { streamSessionEvents, type LiveSourceFactory, type StreamPhase } from './index'
 import { originLabel, shortSessionId } from './label'
+import { TimeGate } from './render'
 import type { SessionSummary } from './session-list'
 import type { InspectEvent, InspectFilter } from './types'
 
@@ -91,8 +92,11 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     // during replay (one render at replay-end) to avoid redraw storms on long
     // transcripts; render per event once live.
     let live = false
+    const timeGate = new TimeGate()
     const onEvent = (event: InspectEvent): void => {
-      appendEntry([new Text(formatEventTime(event.ts), 0, 0), componentFor(event)])
+      const body = componentFor(event)
+      const entry = timeGate.shouldShow(event.cat) ? [new Text(formatEventTime(event.ts), 0, 0), body] : [body]
+      appendEntry(entry)
       if (live) tui.requestRender()
     }
     const onPhase = (phase: StreamPhase): void => {

--- a/src/inspect/transcript-view.ts
+++ b/src/inspect/transcript-view.ts
@@ -26,6 +26,7 @@ export type TranscriptViewOptions = {
   sinceMs: number | undefined
   liveSource?: LiveSourceFactory
   createTerminal?: () => Terminal
+  maxHistoryEntries?: number
 }
 
 export const MAX_LIVE_HISTORY_ENTRIES = 250
@@ -54,12 +55,15 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     // grow until the viewer stalls; the window evicts the oldest entry to keep
     // render cost bounded. Components are evicted per event so a timestamp never
     // outlives its body. Header and pinned status are never evicted.
-    const history = new BoundedComponentWindow(MAX_LIVE_HISTORY_ENTRIES)
-    const appendEntry = (components: HistoryEntry): void => {
+    const history = new BoundedComponentWindow<HistoryEntry>(opts.maxHistoryEntries ?? MAX_LIVE_HISTORY_ENTRIES)
+    const appendEntry = (entry: HistoryEntry): void => {
       tui.removeChild(status)
-      const evicted = history.push(components)
-      if (evicted !== null) for (const component of evicted) tui.removeChild(component)
-      for (const component of components) tui.addChild(component)
+      const evicted = history.push(entry)
+      if (evicted !== null) {
+        for (const component of evicted.components) tui.removeChild(component)
+        promoteVisibleRunHead(history, evicted)
+      }
+      for (const component of entry.components) tui.addChild(component)
       tui.addChild(status)
     }
 
@@ -95,15 +99,20 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     const timeGate = new TimeGate()
     const onEvent = (event: InspectEvent): void => {
       const body = componentFor(event)
-      const entry = timeGate.shouldShow(event.cat) ? [new Text(formatEventTime(event.ts), 0, 0), body] : [body]
-      appendEntry(entry)
+      const stamped = timeGate.shouldShow(event.cat)
+      const time = new Text(stamped ? formatEventTime(event.ts) : '', 0, 0)
+      appendEntry({ kind: 'event', cat: event.cat, ts: event.ts, time, stamped, components: [time, body] })
       if (live) tui.requestRender()
     }
     const onPhase = (phase: StreamPhase): void => {
       if (phase.phase === 'replay-end') {
         tui.requestRender()
       } else if (phase.phase === 'live-start') {
-        appendEntry([new Text(divider(phase.sessionLive ? 'live' : 'live (broadcasts only)'), 0, 0)])
+        timeGate.reset()
+        appendEntry({
+          kind: 'divider',
+          components: [new Text(divider(phase.sessionLive ? 'live' : 'live (broadcasts only)'), 0, 0)],
+        })
         live = true
         tui.requestRender()
       }
@@ -203,17 +212,45 @@ function divider(text: string): string {
   return colors.dim(`─── ${text} ───`)
 }
 
-export type HistoryEntry = readonly Component[]
+// After the stamped head of a same-category run is evicted, the new first
+// visible row of that run would have a blank timestamp. Fill its already-present
+// (blank) Text so the visible window never shows a run with no timestamp at all.
+// Mutates text in place — no child add/remove/reorder.
+function promoteVisibleRunHead(history: BoundedComponentWindow<HistoryEntry>, evicted: HistoryEntry): void {
+  if (evicted.kind !== 'event' || !evicted.stamped) return
+  const first = history.first()
+  if (first === undefined || first.kind !== 'event' || first.stamped || first.cat !== evicted.cat) return
+  first.time.setText(formatEventTime(first.ts))
+  first.stamped = true
+}
 
-export class BoundedComponentWindow {
-  private readonly entries: HistoryEntry[] = []
+// An event row carries its category + ts + the (possibly blank) timestamp Text
+// so the window can re-stamp the visible run head after eviction. Non-event rows
+// (the live divider) have no category and never participate in re-stamping.
+export type HistoryEntry =
+  | {
+      kind: 'event'
+      cat: InspectEvent['cat']
+      ts: number
+      time: Text
+      stamped: boolean
+      components: readonly Component[]
+    }
+  | { kind: 'divider'; components: readonly Component[] }
+
+export class BoundedComponentWindow<T> {
+  private readonly entries: T[] = []
 
   constructor(private readonly maxEntries: number) {}
 
-  push(entry: HistoryEntry): HistoryEntry | null {
+  push(entry: T): T | null {
     this.entries.push(entry)
     if (this.entries.length <= this.maxEntries) return null
     return this.entries.shift() ?? null
+  }
+
+  first(): T | undefined {
+    return this.entries[0]
   }
 
   get size(): number {


### PR DESCRIPTION
## Background

`typeclaw inspect` stamped a `HH:MM:SS` on **every** rendered event — `user`,
each `thinking` block, both `tool` start/end lines, `assistant`, and `done`.
On a real turn that means a wall of timestamps: a run of three consecutive
thinking blocks printed three near-identical times, and every tool call carried
a timestamp no one reads. The noise is worst in the live TUI transcript view,
where each component (including back-to-back thinking) got its own time prefix.

The redundancy is structural: within a turn, most consecutive events share the
same category, so their timestamps add no information over the first one.

## Summary

Introduce a small `TimeGate` (in `src/inspect/render.ts`) that emits the
timestamp only when an event's category differs from the previous line. A run
of same-category events (consecutive thinking blocks, a tool start/end pair)
now carries a single leading stamp; a new role marks a new stamp.

Both renderers thread the same gate:

- **Line view** (`index.ts`) passes `showTime` into `renderEvent`. When false,
  the time column is **blanked to the same width** rather than dropped, so the
  tag column stays aligned.
- **TUI transcript view** (`transcript-view.ts`) drops the time `Text`
  component entirely for suppressed entries (vertical stack, no alignment
  concern).

Why category-change as the boundary (and not "only on user messages" or "every
event"): it matches how a reader scans the transcript — one timestamp per
visible role switch (user → assistant/think → tool → assistant), which is the
turn structure the report asked for, while collapsing the repetition that
prompted this.

## Preview

```
=== BEFORE (timestamp on every event) ===
11:07:39  user       curate Model X accessories
11:07:40  think      Researcher is running in background. I should end my turn.
11:07:41  think      Re-reading: the system will not surface the subagent result on its own.
11:07:42  think      I already sent my ack reply. Wait for completion.
11:07:43  tool ▸     spawn_subagent({"subagent_type":"researcher"})
11:07:43  tool ◂     spawn_subagent → ok "Spawned researcher. task_id=bg_c51b" (15ms)
11:07:45  assist     Researcher is running in the background; I will reply when it completes.
11:07:45  done       tokens: 100 in / 50 out · $0.0012

=== AFTER (timestamp once per same-category run) ===
11:07:39  user       curate Model X accessories
11:07:40  think      Researcher is running in background. I should end my turn.
          think      Re-reading: the system will not surface the subagent result on its own.
          think      I already sent my ack reply. Wait for completion.
11:07:43  tool ▸     spawn_subagent({"subagent_type":"researcher"})
          tool ◂     spawn_subagent → ok "Spawned researcher. task_id=bg_c51b" (15ms)
11:07:45  assist     Researcher is running in the background; I will reply when it completes.
11:07:45  done       tokens: 100 in / 50 out · $0.0012
```

## What this does NOT do

- Does not change the JSON output path (`--json` still emits the full `ts` per
  event).
- Does not change event ordering, filtering, `--since`, or the header/footer.
- Does not merge categories: `assistant`, `thinking`, and `done` remain
  distinct, so an assistant turn can still show a few stamps at its role
  switches — only *consecutive same-category* runs collapse.

## Review notes

- Load-bearing change: `TimeGate.shouldShow(cat)` in `render.ts`. Both render
  paths share one instance per stream so suppression is consistent.
- The line view blanks the column (`' '.repeat(TIME_WIDTH)`) instead of
  dropping it — verify alignment holds with the `showTime=false` test in
  `render.test.ts`.
- `index.test.ts` asserts the end-to-end pattern `[true,true,false,true,false]`
  for a meta/user/divider/tool/tool sequence; the transcript-view test asserts
  the stamp appears exactly once across two consecutive thinking blocks (and
  fails on the pre-change renderer).