### PR TITLE
feat(inspect): add `r` to refresh the session picker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "typeclaw",
       "dependencies": {
+        "@clack/core": "^1.2.0",
         "@clack/prompts": "^1.2.0",
         "@mariozechner/pi-coding-agent": "^0.67.3",
         "@mariozechner/pi-tui": "^0.67.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postinstall": "bun run scripts/generate-schema.ts"
   },
   "dependencies": {
+    "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
     "@mariozechner/pi-coding-agent": "^0.67.3",
     "@mariozechner/pi-tui": "^0.67.3",

--- a/src/cli/inspect-select.test.ts
+++ b/src/cli/inspect-select.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test'
+import { PassThrough } from 'node:stream'
+
+import { highlightAt, refreshableSelect, type RefreshableOption, REFRESH_KEY, toSelectResult } from './inspect-select'
+
+const CANCEL: symbol = Symbol('cancel')
+
+const opts: RefreshableOption<string>[] = [
+  { value: 'a', label: 'A' },
+  { value: 'b', label: 'B' },
+  { value: 'c', label: 'C' },
+]
+
+describe('highlightAt', () => {
+  test('returns the value at the cursor', () => {
+    expect(highlightAt(opts, 1)).toBe('b')
+  })
+
+  test('falls back to the first row when the cursor is out of range', () => {
+    expect(highlightAt(opts, 99)).toBe('a')
+  })
+
+  test('returns undefined for an empty list', () => {
+    expect(highlightAt([], 0)).toBeUndefined()
+  })
+})
+
+describe('toSelectResult', () => {
+  test('a picked value maps to picked', () => {
+    expect(toSelectResult('b', { refreshed: false })).toEqual({ kind: 'picked', value: 'b' })
+  })
+
+  test('the cancel symbol without refresh maps to cancelled', () => {
+    expect(toSelectResult(CANCEL, { refreshed: false })).toEqual({ kind: 'cancelled' })
+  })
+
+  test('refresh wins over the cancel symbol and carries the highlight', () => {
+    // The `r` abort resolves to the cancel symbol too, so `refreshed` must take
+    // precedence to avoid misreading a refresh as a quit.
+    expect(toSelectResult(CANCEL, { refreshed: true, highlightValue: 'c' })).toEqual({
+      kind: 'refresh',
+      highlightValue: 'c',
+    })
+  })
+})
+
+describe('REFRESH_KEY', () => {
+  test('is the lowercase r', () => {
+    expect(REFRESH_KEY).toBe('r')
+  })
+})
+
+describe('refreshableSelect (live clack seam)', () => {
+  function fakeTty(): { input: PassThrough; output: PassThrough } {
+    const input = new PassThrough()
+    const output = new PassThrough()
+    output.resume()
+    Object.assign(input, { isTTY: true, setRawMode: () => input })
+    return { input, output }
+  }
+
+  async function drive(
+    feed: (input: PassThrough) => void,
+    initialValue = 'a',
+  ): Promise<ReturnType<typeof toSelectResult<string>>> {
+    const { input, output } = fakeTty()
+    const result = refreshableSelect<string>({
+      message: 'pick',
+      options: [
+        { value: 'a', label: 'A' },
+        { value: 'b', label: 'B' },
+        { value: 'c', label: 'C' },
+      ],
+      initialValue,
+      input,
+      output,
+    })
+    feed(input)
+    return result
+  }
+
+  test('Enter resolves to the highlighted value', async () => {
+    const out = await drive((i) => setTimeout(() => i.write('\r'), 40))
+    expect(out).toEqual({ kind: 'picked', value: 'a' })
+  })
+
+  test('arrow-down then r refreshes carrying the moved highlight', async () => {
+    const out = await drive((i) => {
+      setTimeout(() => i.write('\x1b[B'), 40)
+      setTimeout(() => i.write('r'), 90)
+    })
+    expect(out).toEqual({ kind: 'refresh', highlightValue: 'b' })
+  })
+
+  test('Ctrl-C resolves to cancelled, not refresh', async () => {
+    const out = await drive((i) => setTimeout(() => i.write('\x03'), 40))
+    expect(out).toEqual({ kind: 'cancelled' })
+  })
+})

--- a/src/cli/inspect-select.ts
+++ b/src/cli/inspect-select.ts
@@ -1,0 +1,121 @@
+import type { Readable, Writable } from 'node:stream'
+import { styleText } from 'node:util'
+
+import { SelectPrompt, settings } from '@clack/core'
+import { limitOptions, S_BAR, S_BAR_END, S_RADIO_ACTIVE, S_RADIO_INACTIVE, symbolBar } from '@clack/prompts'
+
+export type RefreshableOption<Value> = { value: Value; label: string; hint?: string; disabled?: boolean }
+
+export type RefreshableSelectResult<Value> =
+  | { kind: 'picked'; value: Value }
+  | { kind: 'cancelled' }
+  | { kind: 'refresh'; highlightValue: Value }
+
+export type RefreshableSelectOptions<Value> = {
+  message: string
+  options: RefreshableOption<Value>[]
+  initialValue?: Value
+  maxItems?: number
+  input?: Readable
+  output?: Writable
+}
+
+export const REFRESH_KEY = 'r'
+
+// The cursor's value, falling back to the first row so a refresh on an empty
+// cursor still carries a stable highlight.
+export function highlightAt<Value>(options: RefreshableOption<Value>[], cursor: number): Value | undefined {
+  return options[cursor]?.value ?? options[0]?.value
+}
+
+// `refreshed` distinguishes an `r`-triggered abort (which also resolves to the
+// cancel symbol) from a genuine ESC/Ctrl-C cancel.
+export function toSelectResult<Value>(
+  result: Value | symbol,
+  refresh: { refreshed: boolean; highlightValue?: Value },
+): RefreshableSelectResult<Value> {
+  if (refresh.refreshed) return { kind: 'refresh', highlightValue: refresh.highlightValue as Value }
+  if (typeof result === 'symbol') return { kind: 'cancelled' }
+  return { kind: 'picked', value: result }
+}
+
+// A drop-in `select` that adds an `r`-to-refresh affordance. `@clack/prompts`'s
+// `select` hides its prompt instance, so it can't expose the `key` event or the
+// live cursor; dropping to `@clack/core`'s SelectPrompt is the only seam that
+// can observe `r` without racing clack's own raw-mode stdin handling. The render
+// below is ported from `@clack/prompts`'s select so the picker looks identical.
+export async function refreshableSelect<Value>(
+  opts: RefreshableSelectOptions<Value>,
+): Promise<RefreshableSelectResult<Value>> {
+  const optionsList = opts.options
+  const refreshController = new AbortController()
+  const refresh: { refreshed: boolean; highlightValue?: Value } = { refreshed: false }
+
+  const prompt = new SelectPrompt<RefreshableOption<Value>>({
+    options: optionsList,
+    initialValue: opts.initialValue,
+    signal: refreshController.signal,
+    ...(opts.input !== undefined ? { input: opts.input } : {}),
+    ...(opts.output !== undefined ? { output: opts.output } : {}),
+    render() {
+      return renderSelect(this as SelectPrompt<RefreshableOption<Value>>, opts.message, {
+        ...(opts.maxItems !== undefined ? { maxItems: opts.maxItems } : {}),
+        ...(opts.output !== undefined ? { output: opts.output } : {}),
+      })
+    },
+  })
+
+  prompt.on('key', (char) => {
+    if (char !== REFRESH_KEY) return
+    refresh.refreshed = true
+    refresh.highlightValue = highlightAt(optionsList, prompt.cursor)
+    // Reuse the prompt's own signal-abort cancel path: it sets state to cancel
+    // and runs close() (raw-mode + listener teardown), resolving `.prompt()`.
+    refreshController.abort()
+  })
+
+  const result = (await prompt.prompt()) as Value | symbol
+  return toSelectResult(result, refresh)
+}
+
+function renderSelect<Value>(
+  prompt: SelectPrompt<RefreshableOption<Value>>,
+  message: string,
+  limits: { maxItems?: number; output?: Writable },
+): string {
+  const hasGuide = settings.withGuide
+  const titlePrefixBar = `${symbolBar(prompt.state)}  `
+  const title = `${hasGuide ? `${styleText('gray', S_BAR)}\n` : ''}${titlePrefixBar}${message}\n`
+
+  if (prompt.state === 'submit' || prompt.state === 'cancel') {
+    const closePrefix = hasGuide ? `${styleText('gray', S_BAR)}  ` : ''
+    const label = prompt.options[prompt.cursor]?.label ?? ''
+    const closed = prompt.state === 'cancel' ? styleText(['strikethrough', 'dim'], label) : styleText('dim', label)
+    const tail = prompt.state === 'cancel' && hasGuide ? `\n${styleText('gray', S_BAR)}` : ''
+    return `${title}${closePrefix}${closed}${tail}`
+  }
+
+  const prefix = hasGuide ? `${styleText('cyan', S_BAR)}  ` : ''
+  const prefixEnd = hasGuide ? styleText('cyan', S_BAR_END) : ''
+  const rendered = limitOptions({
+    cursor: prompt.cursor,
+    options: prompt.options,
+    ...(limits.maxItems !== undefined ? { maxItems: limits.maxItems } : {}),
+    ...(limits.output !== undefined ? { output: limits.output } : {}),
+    style: (item, active) => optionLine(item, item.disabled === true ? 'disabled' : active ? 'active' : 'inactive'),
+  }).join(`\n${prefix}`)
+  return `${title}${prefix}${rendered}\n${prefixEnd}\n`
+}
+
+function optionLine<Value>(option: RefreshableOption<Value>, state: 'inactive' | 'active' | 'disabled'): string {
+  const { label } = option
+  if (state === 'disabled') {
+    const hint = option.hint !== undefined ? ` ${styleText('dim', `(${option.hint})`)}` : ''
+    return `${styleText('gray', S_RADIO_INACTIVE)} ${styleText('gray', label)}${hint}`
+  }
+  if (state === 'active') {
+    const hint = option.hint !== undefined ? ` ${styleText('dim', `(${option.hint})`)}` : ''
+    return `${styleText('green', S_RADIO_ACTIVE)} ${label}${hint}`
+  }
+  return `${styleText('dim', S_RADIO_INACTIVE)} ${styleText('dim', label)}`
+}

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -12,6 +12,7 @@ import {
   runViewerLoop,
   streamLive,
   type LiveSourceFactory,
+  type SelectOutcome,
   type SessionSummary,
   type ViewerItem,
 } from '@/inspect'
@@ -250,14 +251,17 @@ function useColor(): boolean {
   return Boolean(process.stdout.isTTY)
 }
 
-async function clackSelectItem(items: ViewerItem[], initialKey: string | undefined): Promise<ViewerItem | null> {
-  const { select } = await import('@clack/prompts')
+async function clackSelectItem(
+  items: ViewerItem[],
+  initialKey: string | undefined,
+): Promise<SelectOutcome<ViewerItem>> {
+  const { refreshableSelect } = await import('./inspect-select')
   prepareStdinForClack()
   const keyOf = (item: ViewerItem): string => (item.kind === 'logs' ? 'logs' : item.summary.sessionId)
   const preferred =
     initialKey !== undefined && items.some((i) => keyOf(i) === initialKey) ? initialKey : keyOf(items[0]!)
-  const picked = await select<string>({
-    message: `Pick what to view (showing ${items.length})`,
+  const outcome = await refreshableSelect<string>({
+    message: `Pick what to view (showing ${items.length}) ${c.dim('· r to refresh')}`,
     options: items.map((item) => ({
       value: keyOf(item),
       label: itemLabel(item),
@@ -265,11 +269,15 @@ async function clackSelectItem(items: ViewerItem[], initialKey: string | undefin
     })),
     initialValue: preferred,
   })
-  if (isCancel(picked)) {
+  if (outcome.kind === 'cancelled') {
     cancel('Cancelled.')
-    return null
+    return { kind: 'cancelled' }
   }
-  return items.find((i) => keyOf(i) === picked) ?? null
+  if (outcome.kind === 'refresh') {
+    return { kind: 'refresh', highlightKey: outcome.highlightValue }
+  }
+  const chosen = items.find((i) => keyOf(i) === outcome.value)
+  return chosen !== undefined ? { kind: 'picked', item: chosen } : { kind: 'cancelled' }
 }
 
 async function clackSelectSession(

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -23,6 +23,7 @@ export type {
   RunInspectLoopOptions,
   RunViewerLoopOptions,
   SelectItem,
+  SelectOutcome,
   TailController,
 } from './loop'
 export type { ViewerItem } from './item'

--- a/src/inspect/loop.ts
+++ b/src/inspect/loop.ts
@@ -10,7 +10,15 @@ export type OpenItemContext = {
   createTailScope: () => TailController
 }
 
-export type SelectItem<TItem> = (items: TItem[], opts: { initialKey?: string }) => Promise<TItem | null>
+// `refresh` (the `r` key) re-lists and re-renders the picker without opening
+// anything; `highlightKey` is the row highlighted when `r` was pressed, so the
+// selection survives the refresh.
+export type SelectOutcome<TItem> =
+  | { kind: 'picked'; item: TItem }
+  | { kind: 'cancelled' }
+  | { kind: 'refresh'; highlightKey?: string }
+
+export type SelectItem<TItem> = (items: TItem[], opts: { initialKey?: string }) => Promise<SelectOutcome<TItem>>
 
 export type OpenItemResult = {
   result: RunInspectResult
@@ -46,8 +54,12 @@ export type RunViewerLoopOptions<TItem> = {
 // inside `openItem` AFTER the picker resolves and disposed before the picker
 // re-opens, so clack always owns a clean cooked-mode stdin.
 export async function runViewerLoop<TItem>(opts: RunViewerLoopOptions<TItem>): Promise<RunInspectResult> {
+  // `preselectKey` auto-opens a row once (the `inspect <id>` arg). `highlightKey`
+  // only seeds the picker's initial highlight (esc-return + `r` refresh) and
+  // never bypasses the picker — keeping the two apart is what lets refresh
+  // re-render the list instead of re-opening the last viewer.
   let preselectKey = opts.preselectKey
-  let lastPickedKey: string | undefined
+  let highlightKey: string | undefined
   // Writable is only safe on the very first list. Returning to the picker means
   // a viewer was just opened and left — any writable session it might represent
   // is gone (detach ends the live session), so subsequent refreshes are
@@ -58,16 +70,21 @@ export async function runViewerLoop<TItem>(opts: RunViewerLoopOptions<TItem>): P
     const items = await opts.listItems({ allowWritable })
     if (items.length === 0) return opts.onEmpty()
 
-    let chosen: TItem | null
+    let chosen: TItem
     if (preselectKey !== undefined) {
-      chosen = items.find((i) => opts.keyOf(i) === preselectKey) ?? null
+      const match = items.find((i) => opts.keyOf(i) === preselectKey) ?? null
       preselectKey = undefined
-      if (chosen === null) return opts.onEmpty()
+      if (match === null) return opts.onEmpty()
+      chosen = match
     } else {
-      const hint = lastPickedKey
-      chosen = await opts.selectItem(items, hint !== undefined ? { initialKey: hint } : {})
-      if (chosen === null) return { ok: false, exitCode: 130, reason: 'cancelled' }
-      lastPickedKey = opts.keyOf(chosen)
+      const outcome = await opts.selectItem(items, highlightKey !== undefined ? { initialKey: highlightKey } : {})
+      if (outcome.kind === 'cancelled') return { ok: false, exitCode: 130, reason: 'cancelled' }
+      if (outcome.kind === 'refresh') {
+        if (outcome.highlightKey !== undefined) highlightKey = outcome.highlightKey
+        continue
+      }
+      chosen = outcome.item
+      highlightKey = opts.keyOf(chosen)
     }
 
     const opened = await opts.openItem(chosen, { createTailScope: opts.createTailScope })

--- a/src/inspect/viewer-loop.test.ts
+++ b/src/inspect/viewer-loop.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 
 import type { RunInspectResult } from './index'
-import { runViewerLoop, type TailController } from './loop'
+import { runViewerLoop, type SelectOutcome, type TailController } from './loop'
 
 type FakeItem = { key: string; kind: 'session' | 'tui' | 'logs' }
+
+const pick = (item: FakeItem): SelectOutcome<FakeItem> => ({ kind: 'picked', item })
+const cancelled: SelectOutcome<FakeItem> = { kind: 'cancelled' }
+const refresh = (highlightKey?: string): SelectOutcome<FakeItem> =>
+  highlightKey !== undefined ? { kind: 'refresh', highlightKey } : { kind: 'refresh' }
 
 function fakeScope(onDispose?: () => void): TailController {
   const ctrl = new AbortController()
@@ -42,7 +47,7 @@ describe('runViewerLoop', () => {
       preselectKey: 'logs',
       selectItem: async () => {
         pickerCalls++
-        return null
+        return cancelled
       },
       openItem: async (item) => {
         opened.push(item.key)
@@ -69,7 +74,8 @@ describe('runViewerLoop', () => {
       keyOf: (i) => i.key,
       selectItem: async (items) => {
         pickerCalls++
-        return items[pickerCalls - 1] ?? null
+        const item = items[pickerCalls - 1]
+        return item !== undefined ? pick(item) : cancelled
       },
       openItem: async (item) => {
         opened.push(item.key)
@@ -101,7 +107,8 @@ describe('runViewerLoop', () => {
       keyOf: (i) => i.key,
       selectItem: async (items) => {
         pickerCalls++
-        return items[pickerCalls - 1] ?? null
+        const item = items[pickerCalls - 1]
+        return item !== undefined ? pick(item) : cancelled
       },
       openItem: async () => (pickerCalls === 1 ? wrapWritable(back) : wrap(done)),
       createTailScope: () => fakeScope(),
@@ -128,7 +135,8 @@ describe('runViewerLoop', () => {
       keyOf: (i) => i.key,
       selectItem: async (items) => {
         pickerCalls++
-        return items[pickerCalls - 1] ?? null
+        const item = items[pickerCalls - 1]
+        return item !== undefined ? pick(item) : cancelled
       },
       // First open (logs) returns back WITHOUT endedWritableSession; second ends.
       openItem: async () => (pickerCalls === 1 ? wrap(back) : wrap(done)),
@@ -146,7 +154,7 @@ describe('runViewerLoop', () => {
       listItems: async () => [{ key: 'live', kind: 'tui' }],
       keyOf: (i) => i.key,
       preselectKey: 'live',
-      selectItem: async () => null,
+      selectItem: async () => cancelled,
       openItem: async (item, ctx) => {
         // A real tui opener never touches ctx.createTailScope; assert the loop
         // does not force one on the branch.
@@ -167,7 +175,7 @@ describe('runViewerLoop', () => {
     const result = await runViewerLoop<FakeItem>({
       listItems: async () => [{ key: 'a', kind: 'session' }],
       keyOf: (i) => i.key,
-      selectItem: async () => null,
+      selectItem: async () => cancelled,
       openItem: async () => wrap(done),
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
@@ -182,7 +190,7 @@ describe('runViewerLoop', () => {
     const result = await runViewerLoop<FakeItem>({
       listItems: async () => [],
       keyOf: (i) => i.key,
-      selectItem: async () => null,
+      selectItem: async () => cancelled,
       openItem: async () => wrap(done),
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'no sessions' }),
@@ -196,12 +204,83 @@ describe('runViewerLoop', () => {
       listItems: async () => [{ key: 'a', kind: 'session' }],
       keyOf: (i) => i.key,
       preselectKey: 'a',
-      selectItem: async () => null,
+      selectItem: async () => cancelled,
       openItem: async () => wrap({ ok: false, exitCode: 2, reason: 'boom' }),
       createTailScope: () => fakeScope(),
       onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
     })
 
     expect(result).toEqual({ ok: false, exitCode: 2, reason: 'boom' })
+  })
+
+  test('refresh re-lists and re-renders the picker without opening anything', async () => {
+    let listCalls = 0
+    let openCalls = 0
+    const result = await runViewerLoop<FakeItem>({
+      listItems: async () => {
+        listCalls++
+        return [{ key: 'a', kind: 'session' }]
+      },
+      keyOf: (i) => i.key,
+      selectItem: async (items) => (listCalls === 1 ? refresh('a') : pick(items[0]!)),
+      openItem: async () => {
+        openCalls++
+        return wrap(done)
+      },
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(result).toEqual(done)
+    expect(listCalls).toBe(2)
+    expect(openCalls).toBe(1)
+  })
+
+  test('refresh persists the highlighted key as the next picker initialKey', async () => {
+    const hints: (string | undefined)[] = []
+    let pickerCalls = 0
+    await runViewerLoop<FakeItem>({
+      listItems: async () => [
+        { key: 'a', kind: 'session' },
+        { key: 'b', kind: 'session' },
+      ],
+      keyOf: (i) => i.key,
+      selectItem: async (_items, opts) => {
+        pickerCalls++
+        hints.push(opts.initialKey)
+        return pickerCalls === 1 ? refresh('b') : cancelled
+      },
+      openItem: async () => wrap(done),
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(hints).toEqual([undefined, 'b'])
+  })
+
+  test('refresh without a highlightKey keeps the prior highlight', async () => {
+    const hints: (string | undefined)[] = []
+    let pickerCalls = 0
+    await runViewerLoop<FakeItem>({
+      listItems: async () => [
+        { key: 'a', kind: 'session' },
+        { key: 'b', kind: 'session' },
+      ],
+      keyOf: (i) => i.key,
+      selectItem: async (items, opts) => {
+        pickerCalls++
+        hints.push(opts.initialKey)
+        // 1st: open 'b' (sets highlight). 2nd (after esc-back): keyless refresh.
+        // 3rd: must still be highlighting 'b'.
+        if (pickerCalls === 1) return pick(items[1]!)
+        if (pickerCalls === 2) return refresh()
+        return cancelled
+      },
+      openItem: async () => wrap(back),
+      createTailScope: () => fakeScope(),
+      onEmpty: () => ({ ok: false, exitCode: 1, reason: 'empty' }),
+    })
+
+    expect(hints).toEqual([undefined, 'b', 'b'])
   })
 })


### PR DESCRIPTION
## Background

The interactive `typeclaw inspect` session picker is a static snapshot of `sessions/` taken when the picker opens. Sessions that arrive while the picker is open — a new TUI session, an inbound channel message, a cron fire — never appear. The only escape was to quit and re-run. There was no in-place refresh.

## Summary

Adds an `r` key binding to `typeclaw inspect` that reloads the session list without closing the picker, keeping the highlighted row at whatever session was selected when `r` was pressed.

### Why `refreshableSelect` instead of `@clack/prompts`'s `select`?

The high-level `select` hides its `SelectPrompt` instance, so it can neither expose the `key` event (to observe `r`) nor the live cursor (to capture the current highlight for re-seeding). Dropping to `@clack/core`'s `SelectPrompt` is the only seam that catches `r` without attaching a competing raw-mode `data` listener that would race clack's own stdin handling. `r` is safe to intercept: `SelectPrompt` is non-tracking, so a printable `r` never moves the cursor or gains type-ahead meaning. The render is ported from `@clack/prompts`'s `select` (via its exported primitives) so the picker looks pixel-identical.

### Why split `lastPickedKey` into `preselectKey` + `highlightKey` in `runViewerLoop`?

The old single key conflated two distinct intents: "auto-open this row without showing the picker" (the `inspect <id>` arg path) and "seed the picker's initial highlight" (esc-return). Reusing it for refresh would have auto-opened the last viewer row instead of re-rendering the list. Now `preselectKey` = auto-open-once; `highlightKey` only seeds the initial highlight on esc-return and on refresh, and never bypasses the picker.

The refresh reads the highlighted value from the live cursor at the moment `r` is pressed, so the selection genuinely survives — not just the last-opened item.

`@clack/core` is promoted from a transitive to an explicit dependency, pinned at `^1.2.0` to match `@clack/prompts`.

## Preview

```
│  Pick what to view (showing 3) · r to refresh
│  ● 019ee0…aaaa  tui  2m ago (fix the login bug)
│  ○ ▤ container logs
└
```

The only visible change is the trailing `r to refresh` hint in the picker header.

## What this does NOT do

- The scriptable JSON path (`typeclaw inspect <id> --json`) and its session picker are untouched — refresh is interactive-only.
- `r` is not bound in the replay, live-tail, or logs viewers; it only fires inside the picker.
- No auto-refresh or polling — refresh is manual, on `r`.
- Only lowercase `r`; uppercase/modified `R` is intentionally not bound.

## Review notes

- **Load-bearing change:** `runViewerLoop` in `src/inspect/loop.ts` — the `preselectKey` (auto-open) vs `highlightKey` (highlight-only) split. `src/inspect/viewer-loop.test.ts` pins the invariants: refresh re-lists without auto-opening; highlight persists across the refresh; a keyless refresh retains the prior highlight.
- **Riskiest seam:** that clack's `key` event fires for `r` and the signal-abort cancel path tears down raw mode cleanly. Covered by `src/cli/inspect-select.test.ts` — driven through a real `SelectPrompt` with a fake TTY stream: Enter→picked, ↓+`r`→refresh carrying the moved highlight, Ctrl-C→cancelled and NOT refresh.