### PR TITLE
fix(test): deflake cron-handler E2E by raising the poll budget

### DIFF
--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -361,8 +361,13 @@ export default {
     const registered = running.pluginRuntime.get().registry.cronJobs.find((j) => j.localId === 'watch')
     if (!registered) throw new Error('plugin handler cron job not registered')
     running.stream.publish({ target: { kind: 'cron', jobId: registered.globalId }, payload: registered.job })
-    for (let i = 0; i < 50 && !(await Bun.file(sentinelFile).exists()); i++) {
-      await new Promise((r) => setTimeout(r, 20))
+    // Budget must clear CI --parallel scheduling jitter against a real startAgent
+    // boot; a fixed 1 s window flaked (#763). Matches the session.start test above.
+    const TIMEOUT_MS = 5000
+    const POLL_MS = 25
+    const iterations = Math.ceil(TIMEOUT_MS / POLL_MS)
+    for (let i = 0; i < iterations && !(await Bun.file(sentinelFile).exists()); i++) {
+      await new Promise((r) => setTimeout(r, POLL_MS))
     }
 
     // then the handler observed a well-formed ctx


### PR DESCRIPTION
## What

The E2E test `src/run/plugin.test.ts:309` — *kind: handler cron job fires with a well-formed CronHandlerContext when published to the cron stream* — polled for its sentinel file with a fixed budget of **50 × 20 ms = 1 s** before asserting.

This change replaces that with a **5000 ms / 25 ms** poll budget, matching the `session.start` handler test directly above it in the same file (which already uses exactly this pattern).

## Why

The handler runs through a real `startAgent` boot (websocket server + plugin runtime). Under `--parallel` CI contention on a loaded runner, the async dispatch + file write can exceed the 1 s window, so the sentinel isn't present yet when the assertion runs. It's a timing-budget race, not a logic bug — reproduced once in CI (run 27220310771: `8448 pass, 1 fail`) and not reproducible locally.

Per the issue's suggested fix, this raises the poll budget to comfortably exceed CI scheduling jitter. The budget is intentionally identical to the sibling `session.start` test so the two stay consistent, and a short comment marks it as load-bearing to prevent a future contributor tidying it back to a tight window.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in this file)
- `bun run format` — clean
- `bun test --parallel src/run/plugin.test.ts` — **9 pass, 0 fail**, run 4× consecutively

Closes #763