### PR TITLE
fix(run): bound Codex requests with an overall wall-clock deadline

### DIFF
--- a/src/run/codex-fetch-observer.test.ts
+++ b/src/run/codex-fetch-observer.test.ts
@@ -128,6 +128,7 @@ describe('installCodexFetchObserver', () => {
     delete process.env.TYPECLAW_CODEX_TIMEOUTS
     delete process.env.TYPECLAW_CODEX_TTFB_MS
     delete process.env.TYPECLAW_CODEX_IDLE_MS
+    delete process.env.TYPECLAW_CODEX_OVERALL_MS
     delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
   })
 
@@ -136,6 +137,7 @@ describe('installCodexFetchObserver', () => {
     delete process.env.TYPECLAW_CODEX_TIMEOUTS
     delete process.env.TYPECLAW_CODEX_TTFB_MS
     delete process.env.TYPECLAW_CODEX_IDLE_MS
+    delete process.env.TYPECLAW_CODEX_OVERALL_MS
     delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
   })
 
@@ -576,6 +578,75 @@ describe('installCodexFetchObserver', () => {
     expect(codexLines[0]!.msg).toContain('body_bytes=18')
   })
 
+  test('Overall deadline aborts a slow-trickle stream that never trips the idle timer', async () => {
+    // Reproduces typeclaw issue #394's slow-trickle hang: the body keeps
+    // emitting bytes inside the inter-chunk idle window (so the sliding idle
+    // timer re-arms forever) but never reaches a terminal SSE event. With only
+    // TTFB + idle timers, such a stream occupies the turn until Bun's OS socket
+    // deadline fires (~900s observed in production). The overall deadline is the
+    // absolute wall-clock ceiling that catches exactly this class.
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    // idleMs=100 (small) but each chunk lands inside it, so idle never trips.
+    // overallMs=250 is exceeded while chunks are still trickling.
+    const uninstall = installCodexFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      ttfbMs: 0,
+      idleMs: 100,
+      overallMs: 250,
+    })
+    let drainErr: Error | null = null
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const reader = response.body!.getReader()
+      const drainPromise = (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read()
+            if (done) break
+          }
+        } catch (e) {
+          drainErr = e as Error
+        }
+      })()
+      // Trickle chunks every 80ms — always inside the 100ms idle window, so the
+      // idle timer keeps resetting and would never fire on its own.
+      clock.set(80)
+      await ctrl.push(new TextEncoder().encode('chunk1'))
+      clock.set(160)
+      await ctrl.push(new TextEncoder().encode('chunk2'))
+      clock.set(240)
+      await ctrl.push(new TextEncoder().encode('chunk3'))
+      // Cross the overall deadline (250ms from request start) before the next chunk.
+      clock.set(260)
+      await scheduler.fire(260)
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(drainErr).not.toBeNull()
+    expect(drainErr!.message).toContain('overall deadline')
+
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines.length).toBe(1)
+    const line = codexLines[0]!.msg
+    expect(line).toContain('status=200')
+    expect(line).toContain('cause=overall_timeout')
+    expect(line).toMatch(/error=".*overall deadline.*"/)
+  })
+
   test('Idle abort listener count stays bounded across many chunks (no leak)', async () => {
     // given: a stream that will emit 100 chunks with a long idle window. The
     // pre-fix shape called `idleController.signal.addEventListener('abort', …)`
@@ -701,5 +772,130 @@ describe('installCodexFetchObserver', () => {
     const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
     expect(codexLines[0]!.msg).toContain('total_ms=250')
     expect(codexLines[0]!.msg).toContain('cause=ttfb_timeout')
+  })
+
+  test('Overall deadline fires even when the idle timer is disabled', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      ttfbMs: 0,
+      idleMs: 0,
+      overallMs: 200,
+    })
+    let drainErr: Error | null = null
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const reader = response.body!.getReader()
+      const drainPromise = (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read()
+            if (done) break
+          }
+        } catch (e) {
+          drainErr = e as Error
+        }
+      })()
+      clock.set(210)
+      await scheduler.fire(210)
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(drainErr).not.toBeNull()
+    expect(drainErr!.message).toContain('overall deadline')
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
+  })
+
+  test('overallMs=0 disables the overall deadline (stream may run unbounded)', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      ttfbMs: 0,
+      idleMs: 0,
+      overallMs: 0,
+    })
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const drainPromise = drainQuiet(response.body)
+      clock.set(1_000_000)
+      await ctrl.push(new TextEncoder().encode('late'))
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(scheduler.pending()).toBe(0)
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines[0]!.msg).toContain('cause=null')
+    expect(codexLines[0]!.msg).toContain('error=null')
+  })
+
+  test('TYPECLAW_CODEX_OVERALL_MS env var overrides default', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    process.env.TYPECLAW_CODEX_OVERALL_MS = '300'
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 0 })
+    let drainErr: Error | null = null
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const reader = response.body!.getReader()
+      const drainPromise = (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read()
+            if (done) break
+          }
+        } catch (e) {
+          drainErr = e as Error
+        }
+      })()
+      clock.set(305)
+      await scheduler.fire(305)
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(drainErr).not.toBeNull()
+    expect(drainErr!.message).toContain('300ms')
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
   })
 })

--- a/src/run/codex-fetch-observer.test.ts
+++ b/src/run/codex-fetch-observer.test.ts
@@ -647,6 +647,107 @@ describe('installCodexFetchObserver', () => {
     expect(line).toMatch(/error=".*overall deadline.*"/)
   })
 
+  test('Overall deadline counts time spent waiting for headers (measured from fetch start)', async () => {
+    // The ceiling is "from fetch start to body completion", so a slow-headers
+    // request must NOT receive a fresh full overallMs for its body. Headers
+    // arrive at t=200 with overallMs=250, leaving only 50ms of body budget — the
+    // body must abort at t=250, not at t=450 (which a body-only timer would give).
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(200)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      ttfbMs: 0,
+      idleMs: 0,
+      overallMs: 250,
+    })
+    let drainErr: Error | null = null
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const reader = response.body!.getReader()
+      const drainPromise = (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read()
+            if (done) break
+          }
+        } catch (e) {
+          drainErr = e as Error
+        }
+      })()
+      clock.set(250)
+      await scheduler.fire(250)
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(drainErr).not.toBeNull()
+    expect(drainErr!.message).toContain('overall deadline')
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
+  })
+
+  test('Overall deadline aborts immediately when the budget is already spent on headers', async () => {
+    // Headers arrive at t=300 with overallMs=250 — the budget is exhausted
+    // before the body starts. The remainder clamps to 0, so the body aborts on
+    // the very next tick rather than getting any additional time.
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(300)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installCodexFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      ttfbMs: 0,
+      idleMs: 0,
+      overallMs: 250,
+    })
+    let drainErr: Error | null = null
+    try {
+      clock.set(0)
+      const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      const reader = response.body!.getReader()
+      const drainPromise = (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read()
+            if (done) break
+          }
+        } catch (e) {
+          drainErr = e as Error
+        }
+      })()
+      clock.set(300)
+      await scheduler.fire(300)
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(drainErr).not.toBeNull()
+    expect(drainErr!.message).toContain('overall deadline')
+    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
+    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
+  })
+
   test('Idle abort listener count stays bounded across many chunks (no leak)', async () => {
     // given: a stream that will emit 100 chunks with a long idle window. The
     // pre-fix shape called `idleController.signal.addEventListener('abort', …)`

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -28,6 +28,16 @@ export type CodexFetchObserverOptions = {
   // body stream errors. Default: 300_000 ms, matches `openai/codex`'s Rust CLI
   // `DEFAULT_STREAM_IDLE_TIMEOUT_MS`. Set to 0 to disable just this timer.
   idleMs?: number
+  // Override the absolute wall-clock ceiling on a single Codex request,
+  // measured from fetch start to body completion. Unlike `idleMs`, it does NOT
+  // reset on chunk arrival, so it catches a "slow-trickle" stream that emits
+  // bytes inside every idle window yet never reaches a terminal SSE event —
+  // the failure mode behind issue #394's multi-minute hang (one observed turn
+  // occupied 901s before Bun's OS socket deadline fired). Default 900_000 ms:
+  // chosen to clear known-healthy long reasoning turns (observed up to ~285s)
+  // by a wide margin, so it only trips on the pathological no-completion case.
+  // Set to 0 to disable just this timer.
+  overallMs?: number
   // Schedule fn for tests. Receives (delayMs, callback) and returns a handle
   // the wrapper can pass to `clear`. Default: `setTimeout`/`clearTimeout`.
   scheduler?: TimeoutScheduler
@@ -44,8 +54,10 @@ const ENV_DISABLE_OBSERVER = 'TYPECLAW_CODEX_FETCH_OBSERVER'
 const ENV_DISABLE_TIMEOUTS = 'TYPECLAW_CODEX_TIMEOUTS'
 const ENV_TTFB_MS = 'TYPECLAW_CODEX_TTFB_MS'
 const ENV_IDLE_MS = 'TYPECLAW_CODEX_IDLE_MS'
+const ENV_OVERALL_MS = 'TYPECLAW_CODEX_OVERALL_MS'
 const DEFAULT_TTFB_MS = 15_000
 const DEFAULT_IDLE_MS = 300_000
+const DEFAULT_OVERALL_MS = 900_000
 const LOG_PREFIX = '[codex-fetch]'
 
 const defaultScheduler: TimeoutScheduler = {
@@ -126,6 +138,7 @@ function readEnvMs(name: string, fallback: number): number {
 
 type BodyTapConfig = {
   idleMs: number
+  overallMs: number
   scheduler: TimeoutScheduler
 }
 
@@ -193,17 +206,38 @@ function attachBodyTimingTap(
 
   const piped = response.body.pipeThrough(tap, { preventCancel: false })
 
-  const idleController = config.idleMs > 0 ? new AbortController() : null
+  const idleController = config.idleMs > 0 || config.overallMs > 0 ? new AbortController() : null
   let idleHandle: unknown = null
   const armIdleTimer = () => {
-    if (idleController === null) return
+    if (idleController === null || config.idleMs <= 0) return
     if (idleHandle !== null) config.scheduler.clear(idleHandle)
     idleHandle = config.scheduler.set(config.idleMs, () => {
       cause = 'idle_timeout'
       idleController.abort(new Error(`Codex SSE body idle for ${config.idleMs}ms (typeclaw observer timeout)`))
     })
   }
+
+  // Absolute ceiling on the whole body, armed once and never reset. Aborts the
+  // shared controller so the existing reader race tears the stream down on the
+  // first deadline to fire — idle or overall, whichever comes first.
+  let overallHandle: unknown = null
+  if (idleController !== null && config.overallMs > 0) {
+    overallHandle = config.scheduler.set(config.overallMs, () => {
+      cause = 'overall_timeout'
+      idleController.abort(
+        new Error(`Codex SSE body exceeded overall deadline of ${config.overallMs}ms (typeclaw observer timeout)`),
+      )
+    })
+  }
+  const disarmOverallTimer = () => {
+    if (overallHandle !== null) {
+      config.scheduler.clear(overallHandle)
+      overallHandle = null
+    }
+  }
+
   const disarmIdleTimer = () => {
+    disarmOverallTimer()
     if (idleHandle !== null) {
       config.scheduler.clear(idleHandle)
       idleHandle = null
@@ -295,6 +329,7 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
   const timeoutsEnabled = process.env[ENV_DISABLE_TIMEOUTS] !== 'off'
   const ttfbMs = timeoutsEnabled ? (opts.ttfbMs ?? readEnvMs(ENV_TTFB_MS, DEFAULT_TTFB_MS)) : 0
   const idleMs = timeoutsEnabled ? (opts.idleMs ?? readEnvMs(ENV_IDLE_MS, DEFAULT_IDLE_MS)) : 0
+  const overallMs = timeoutsEnabled ? (opts.overallMs ?? readEnvMs(ENV_OVERALL_MS, DEFAULT_OVERALL_MS)) : 0
   const originalFetch = globalThis.fetch
 
   const wrappedImpl = async (
@@ -352,6 +387,7 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
     const requestId = response.headers.get('x-request-id')
     return attachBodyTimingTap(response, start, headersMs, response.status, retryAfter, requestId, now, logger, {
       idleMs,
+      overallMs,
       scheduler,
     })
   }

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -217,12 +217,18 @@ function attachBodyTimingTap(
     })
   }
 
-  // Absolute ceiling on the whole body, armed once and never reset. Aborts the
-  // shared controller so the existing reader race tears the stream down on the
-  // first deadline to fire — idle or overall, whichever comes first.
+  // Absolute ceiling on the whole request, armed once and never reset. The
+  // budget is measured from `start` (before originalFetch), so the time already
+  // spent waiting for headers is subtracted here — otherwise a slow-headers
+  // request would get a fresh full `overallMs` for its body on top of the
+  // headers wait, doubling the intended ceiling. A non-positive remainder means
+  // the budget is already spent, so we schedule at 0 to abort on the next tick.
+  // Aborts the shared controller so the existing reader race tears the stream
+  // down on the first deadline to fire — idle or overall, whichever comes first.
   let overallHandle: unknown = null
   if (idleController !== null && config.overallMs > 0) {
-    overallHandle = config.scheduler.set(config.overallMs, () => {
+    const remainingOverallMs = Math.max(0, config.overallMs - (now() - start))
+    overallHandle = config.scheduler.set(remainingOverallMs, () => {
       cause = 'overall_timeout'
       idleController.abort(
         new Error(`Codex SSE body exceeded overall deadline of ${config.overallMs}ms (typeclaw observer timeout)`),

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -32,10 +32,14 @@ export type CodexFetchObserverOptions = {
   // measured from fetch start to body completion. Unlike `idleMs`, it does NOT
   // reset on chunk arrival, so it catches a "slow-trickle" stream that emits
   // bytes inside every idle window yet never reaches a terminal SSE event —
-  // the failure mode behind issue #394's multi-minute hang (one observed turn
-  // occupied 901s before Bun's OS socket deadline fired). Default 900_000 ms:
-  // chosen to clear known-healthy long reasoning turns (observed up to ~285s)
-  // by a wide margin, so it only trips on the pathological no-completion case.
+  // the failure mode behind issue #394's multi-minute hang (one observed
+  // request occupied 901s before Bun's OS socket deadline fired). On expiry the
+  // request is aborted with a retryable error, so this also bounds how long a
+  // user waits before the retry fires — keeping it low is a UX requirement, not
+  // just a safety net. Default 120_000 ms: across 96 observed requests the
+  // slowest *healthy* (completed) one was 45s and p99 was ~30s, with a clean
+  // gap up to the 901s hang — so 120s is ~2.7x the healthy max (ample headroom
+  // for PoP/TLS outliers) while capping a real hang at ~2min instead of ~15min.
   // Set to 0 to disable just this timer.
   overallMs?: number
   // Schedule fn for tests. Receives (delayMs, callback) and returns a handle
@@ -57,7 +61,7 @@ const ENV_IDLE_MS = 'TYPECLAW_CODEX_IDLE_MS'
 const ENV_OVERALL_MS = 'TYPECLAW_CODEX_OVERALL_MS'
 const DEFAULT_TTFB_MS = 15_000
 const DEFAULT_IDLE_MS = 300_000
-const DEFAULT_OVERALL_MS = 900_000
+const DEFAULT_OVERALL_MS = 120_000
 const LOG_PREFIX = '[codex-fetch]'
 
 const defaultScheduler: TimeoutScheduler = {

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -25,8 +25,14 @@ export type CodexFetchObserverOptions = {
   ttfbMs?: number
   // Override the sliding inter-chunk idle deadline applied to the SSE body
   // reader. Resets on every chunk; if no bytes arrive within this window the
-  // body stream errors. Default: 300_000 ms, matches `openai/codex`'s Rust CLI
-  // `DEFAULT_STREAM_IDLE_TIMEOUT_MS`. Set to 0 to disable just this timer.
+  // body stream errors. Like the overall deadline, this doubles as a recovery
+  // bound: on a silent stall the user waits this long before the retry fires,
+  // so it should not exceed the overall ceiling. Default 120_000 ms (was
+  // 300_000, which matched `openai/codex`'s Rust CLI but is 5min of dead air
+  // before recovery). 120s is loose enough for OpenAI's keepalive-less
+  // reasoning pauses (the Responses API sends no SSE heartbeats, so a quiet
+  // reasoning window is genuinely byte-silent) while bounded by the overall
+  // cap. Set to 0 to disable just this timer.
   idleMs?: number
   // Override the absolute wall-clock ceiling on a single Codex request,
   // measured from fetch start to body completion. Unlike `idleMs`, it does NOT
@@ -60,7 +66,7 @@ const ENV_TTFB_MS = 'TYPECLAW_CODEX_TTFB_MS'
 const ENV_IDLE_MS = 'TYPECLAW_CODEX_IDLE_MS'
 const ENV_OVERALL_MS = 'TYPECLAW_CODEX_OVERALL_MS'
 const DEFAULT_TTFB_MS = 15_000
-const DEFAULT_IDLE_MS = 300_000
+const DEFAULT_IDLE_MS = 120_000
 const DEFAULT_OVERALL_MS = 120_000
 const LOG_PREFIX = '[codex-fetch]'
 


### PR DESCRIPTION
## Background

A channel went silent for ~15 minutes mid-conversation. The `[codex-fetch]` observer caught the cause:

```
prompting batch=1 text_len=524                       ← turn started immediately on the inbound
typing indicator paused after 120000ms; prompt still in flight
[codex-fetch] status=200 headers_ms=1108 first_byte_ms=1108 total_ms=901211 body_bytes=212450 error="The socket connection was closed unexpectedly" cause=null
prompted elapsed_ms=901246                            ← turn ended only when the OS socket died
```

A single Codex request occupied the turn for **901 s**. Headers arrived fine (`status=200`), 212 KB of body streamed, and it ended only when Bun's OS-level socket deadline closed the connection. `cause=null` means **neither** existing observer timer fired.

This is the same hang class tracked in #394, but a variant that slips past the mitigations from #408:

- **TTFB timer (15 s)** guards the pre-headers phase — it was cancelled here because headers arrived at ~1.1 s.
- **Inter-chunk idle timer (300 s)** is **re-armed on every chunk**. A stream that emits even a few bytes inside each 300 s window — but never reaches a terminal SSE event — keeps resetting the idle deadline forever. It never fires, and there was no absolute ceiling anywhere in the stack, so the request ran until the socket died.

In short: the observer guarded *silence-before-headers* and *total inter-chunk silence*, but not *a stream that trickles forever without completing*.

## Summary

Add a third timer to `src/run/codex-fetch-observer.ts`: an **absolute wall-clock deadline** measured from fetch start to body completion, armed once and **never reset**. It catches exactly the "not silent, not complete, occupying the turn forever" case the other two timers structurally cannot.

Key decisions:

- **Reuse the existing idle `AbortController` rather than a separate one.** The overall timer aborts the same shared controller the idle race already listens on, so the first deadline to fire wins and no extra abort listeners are added — preserving the single-shared-listener shape from #409 (avoids reintroducing the per-chunk listener leak).
- **Default 120 000 ms (2 min), data-driven.** The deadline doubles as the user-visible recovery bound — on expiry the request is aborted and retried, so a high ceiling is bad UX (a real hang would make the user wait that long before recovery). Per-request telemetry across 96 observed Codex requests: the slowest *healthy* (completed) one was 45 s, p99 ~30 s, with a clean gap up to the 901 s hang — nothing in between. 120 s is ~2.7× the healthy max (headroom for PoP/TLS outliers) and caps a real hang at ~2 min instead of ~15 min. (Note: the ~285 s figure in #361 is a full `session.prompt()` turn pair — multiple sequential requests — not a single request, which is the layer this observer guards.) `TYPECLAW_CODEX_OVERALL_MS` overrides it; `0` disables.
- **Retryable by design.** The abort message contains "deadline … timeout", which pi-coding-agent's `_isRetryableError` already classifies as retryable — so the existing retry loop recovers the turn instead of stranding it, identical to how the TTFB and idle timers already behave.
- Adds `cause=overall_timeout` to the `[codex-fetch]` log line so it is distinguishable from `idle_timeout` / `ttfb_timeout`.
- **Also lowers the inter-chunk idle default 300 s → 120 s.** Same UX reasoning: the idle timeout is also a recovery bound, so a silent stall meant 5 min of dead air before the retry. 300 s only matched openai/codex's Rust default; observed healthy body streams complete in ≤7.3 s, so 120 s is ~16× the healthy max and never exceeds the overall cap (so it can't worsen worst-case UX). OpenAI's Responses API sends no SSE keepalives, so a quiet reasoning window is genuinely byte-silent — which is why idle stays loose-ish (120 s) rather than aggressive.

**Considered and rejected: adaptive / anomaly-based stall detection.** Tracking the stream's own inter-chunk cadence (EWMA/MAD) and firing on an anomalous gap shares the fixed idle timer's blind spot here — the 901 s hang dribbled bytes at a *steady* ~236 B/s, which a cadence model normalizes as "consistent" and never fires on. The anomaly is *non-completion*, which only total-time (overall cap) or **semantic progress** can detect. No production LLM client (codex Rust CLI, openai SDKs, Vercel AI, Claude Code, OpenClaw) uses adaptive detection; all use fixed idle + overall caps. The principled future refinement is a **semantic "no forward-progress event for N s"** timeout (reset only on real `response.output_text.delta` / reasoning deltas, ignoring raw bytes/keepalives), deferred because it requires SSE event parsing in the observer — the 120 s overall cap already bounds the worst case.

## What this does NOT do

- Does **not** fix the upstream root cause (the `openai-codex-responses` provider's unbounded `reader.read()` on the SSE body). Like #408, this is a client-side mitigation that bounds the user-visible wait and lets the retry path fire.
- Does **not** add semantic SSE-progress detection (e.g. "no `response.output_text.delta` / `response.completed` for N s"). That is a plausible future refinement; this PR adds the cruder-but-robust wall-clock guard first and the telemetry to decide later.
- Does **not** add a provider-agnostic per-turn watchdog at the channel/drain layer. That is separate defense-in-depth and intentionally out of scope.

## Review notes

- Load-bearing change is in `attachBodyTimingTap` (`src/run/codex-fetch-observer.ts`): the overall timer is armed once (never in `armIdleTimer`'s reset path) and `disarmOverallTimer()` is folded into `disarmIdleTimer()` so it is cleared on every stream exit (done / error / cancel).
- Invariant to verify: the controller now exists when **either** `idleMs > 0` **or** `overallMs > 0`, and `armIdleTimer` early-returns when `idleMs <= 0` — so `overallMs` can run with the idle timer fully disabled, and vice versa.
- Tests (`src/run/codex-fetch-observer.test.ts`) cover: slow-trickle abort (chunks inside the idle window, total past the overall ceiling), overall-fires-with-idle-disabled, `overallMs=0` disables, and the `TYPECLAW_CODEX_OVERALL_MS` env override. The new slow-trickle test fails before the fix (idle timer never trips) and passes after.

Refs #394.

