### PR TITLE
ci(release): attribute release commit to Typeey

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,8 +236,8 @@ jobs:
         # ("repository rule violations") if anything below tried to push
         # via the default GITHUB_TOKEN.
         run: |
-          git config user.name "TypeClaw Release Bot"
-          git config user.email "release@typeclaw.dev"
+          git config user.name "Typeey"
+          git config user.email "typeeybird@gmail.com"
           git add package.json
           git diff --staged --quiet || git commit -m "${{ inputs.version }}"
           git push origin HEAD


### PR DESCRIPTION
## Background

Release commits (the version bump on `main`) and their tags were attributed to
`TypeClaw Release Bot <release@typeclaw.dev>` — a synthetic identity with no
corresponding GitHub account. GitHub therefore showed the commit author as an
unresolvable name rather than a linked contributor, making the release history
harder to trace.

## Summary

Change the `git config user.name / user.email` in the "Commit and tag" step to
match the maintainer's real GitHub account (`Typeey`). GitHub resolves the
commit author to the @typeey profile, so release commits are now attributed to
an actual contributor instead of a phantom bot identity.

**Push credential is unaffected.** Author identity is independent of the push
credential. The workflow still pushes over the SSH `DEPLOY_KEY` configured by
`actions/checkout` — the only credential allowed to bypass the `main` branch
ruleset. Swapping the author name/email has no effect on that bypass.

The unrelated "Configure git identity" step used by tests that shell out to git
is intentionally left untouched; it serves a different purpose and is not part
of the release path.

## What this does NOT do

- Does not change the push credential or branch-protection bypass mechanism.
- Does not touch any runtime code, test logic, or non-release CI steps.
- Does not affect the test-suite git identity used by the CI job.

## Review notes

YAML-only change; two lines in the "Commit and tag" step of
`.github/workflows/release.yml`. The only invariant to verify: the push still
goes over `DEPLOY_KEY` (unchanged, configured one step above in the same job)
and the new email resolves to @typeey on GitHub.

Pre-merge checks passing on this branch: `bun run lint` (0 errors),
`bun run format:check` (clean), `bun run typecheck` (clean),
`bun test --parallel` (8526 pass, 0 fail).