### PR TITLE
fix(plugins): a broken plugin must not brick the agent

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -126,5 +126,6 @@ function startOk(opts: StartOptions): StartResult {
     hostd: { state: 'registered' },
     alreadyRunning: false,
     autoUpgrade: { kind: 'skipped-no-dep' },
+    skippedPlugins: [],
   }
 }

--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -279,6 +279,28 @@ describe('renderStartSuccess', () => {
     expect(upgradeIdx).toBeGreaterThanOrEqual(0)
     expect(startedIdx).toBeGreaterThan(upgradeIdx)
   })
+
+  test('renders a yellow warning listing plugins skipped as not found', () => {
+    const out = withForcedColor(() =>
+      renderStartSuccess(baseResult({ skippedPlugins: ['foo-bar', 'typeclaw-plugin-missing'] })),
+    )
+    expect(out).toContain('Skipped plugins not found in the registry:')
+    expect(out).toContain('foo-bar')
+    expect(out).toContain('typeclaw-plugin-missing')
+    expect(out).toContain('\u001b[33m')
+  })
+
+  test('omits the skipped-plugins line when none were skipped', () => {
+    const emptyOut = withNoColor(() => renderStartSuccess(baseResult({ skippedPlugins: [] })))
+    const undefinedOut = withNoColor(() => renderStartSuccess(baseResult()))
+    expect(emptyOut).not.toContain('Skipped plugins')
+    expect(undefinedOut).not.toContain('Skipped plugins')
+  })
+
+  test('still reports start success even when a plugin was skipped', () => {
+    const out = withNoColor(() => renderStartSuccess(baseResult({ skippedPlugins: ['foo-bar'] })))
+    expect(out).toContain('started on host port 8973')
+  })
 })
 
 describe('errorLine / successLine', () => {

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -152,6 +152,7 @@ export type StartLikeResult = {
   containerId: string
   hostd: { state: 'registered' } | { state: 'unavailable'; reason: string } | { state: 'disabled' }
   autoUpgrade?: AutoUpgradeOutcome
+  skippedPlugins?: string[]
 }
 
 export function renderStartSuccess(result: StartLikeResult): string {
@@ -165,6 +166,11 @@ export function renderStartSuccess(result: StartLikeResult): string {
       const tint = result.autoUpgrade.kind === 'exact-pin-respected' ? c.yellow : c.cyan
       lines.push(tint(message))
     }
+  }
+
+  if (result.skippedPlugins && result.skippedPlugins.length > 0) {
+    const list = result.skippedPlugins.join(', ')
+    lines.push(`${c.yellow('Skipped plugins not found in the registry:')} ${list}`)
   }
 
   if (result.alreadyRunning) {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -140,6 +140,10 @@ export type StartResult =
       // path — that one rebuilds the container from scratch.
       alreadyRunning: boolean
       autoUpgrade: AutoUpgradeOutcome
+      // npm plugins dropped this start because their package 404s in the
+      // registry. Non-fatal by design: a typo'd or unpublished plugin warns
+      // instead of blocking the launch.
+      skippedPlugins: string[]
     }
   | { ok: false; reason: string }
 
@@ -438,6 +442,7 @@ export async function start({
       hostd: stripHostDaemonControl(hostd),
       alreadyRunning: false,
       autoUpgrade: upgrade,
+      skippedPlugins: pluginReconcile.skipped,
     }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
@@ -758,6 +763,7 @@ async function reportAlreadyRunning(exec: DockerExec, cwd: string, containerName
     hostd: { state: 'disabled' },
     alreadyRunning: true,
     autoUpgrade: { kind: 'skipped-already-running' },
+    skippedPlugins: [],
   }
 }
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1966,6 +1966,7 @@ describe('defaultRunHatching', () => {
         hostd: { state: 'disabled' },
         alreadyRunning: false,
         autoUpgrade: { kind: 'skipped-already-running' },
+        skippedPlugins: [],
       }
     }
     return { fn, calls }

--- a/src/init/reconcile-plugin-deps.test.ts
+++ b/src/init/reconcile-plugin-deps.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { reconcilePluginDeps } from './reconcile-plugin-deps'
+import { isPackageNotFound, reconcilePluginDeps } from './reconcile-plugin-deps'
 
 async function makeAgentDir(pkg: unknown): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'typeclaw-reconcile-'))
@@ -193,6 +193,86 @@ describe('reconcilePluginDeps', () => {
       expect(result.files).toEqual([])
     } finally {
       await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('skips a bare-name plugin that does not exist in the registry and reports it', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: { typeclaw: '0.35.0' } })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['foo-bar'],
+        resolveLatest: async () => null,
+      })
+      expect(result.skipped).toEqual(['foo-bar'])
+      expect(result.changed).toBe(false)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['foo-bar']).toBeUndefined()
+      expect((pkg.dependencies as Record<string, string>).typeclaw).toBe('0.35.0')
+      expect(pkg.typeclaw).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('still materializes resolvable plugins when a sibling plugin is not found', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['foo-bar', 'typeclaw-plugin-ok'],
+        resolveLatest: async (name) => (name === 'foo-bar' ? null : '2.0.0'),
+      })
+      expect(result.changed).toBe(true)
+      expect(result.skipped).toEqual(['foo-bar'])
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-ok']).toBe('2.0.0')
+      expect((pkg.dependencies as Record<string, string>)['foo-bar']).toBeUndefined()
+      expect((pkg.typeclaw as Record<string, unknown>).managedPlugins).toEqual({ 'typeclaw-plugin-ok': '2.0.0' })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('propagates a hard resolver failure instead of skipping (network errors still block)', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      await expect(
+        reconcilePluginDeps({
+          cwd: dir,
+          plugins: ['typeclaw-plugin-foo'],
+          resolveLatest: async () => {
+            throw new Error('network down')
+          },
+        }),
+      ).rejects.toThrow('network down')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('isPackageNotFound', () => {
+  test('treats registry 404 signals as not-found', () => {
+    for (const stderr of [
+      'error: package "foo-bar" not found',
+      'GET https://registry.npmjs.org/foo-bar - 404 Not Found',
+      'npm error code E404',
+      '404 Not Found - GET https://registry.npmjs.org/foo-bar',
+    ]) {
+      expect(isPackageNotFound(stderr)).toBe(true)
+    }
+  })
+
+  test('does NOT treat transient/auth failures as not-found', () => {
+    for (const stderr of [
+      'error: getaddrinfo ENOTFOUND registry.npmjs.org',
+      'connect ETIMEDOUT 1.2.3.4:443',
+      'npm error code E401 Unauthorized',
+      'error: socket hang up',
+      '',
+    ]) {
+      expect(isPackageNotFound(stderr)).toBe(false)
     }
   })
 })

--- a/src/init/reconcile-plugin-deps.ts
+++ b/src/init/reconcile-plugin-deps.ts
@@ -6,12 +6,23 @@ import { splitPluginEntrySpec } from '@/plugin'
 
 const PACKAGE_FILE = 'package.json'
 
+const NOOP: ReconcilePluginDepsResult = { changed: false, files: [], skipped: [] }
+
 export type ReconcilePluginDepsResult = {
   changed: boolean
   files: string[]
+  // Plugins skipped because their package could not be found in the registry
+  // (npm 404 / E404). A missing plugin must not block `start`: the entry is
+  // dropped from this reconcile pass and surfaced here so the caller can warn.
+  skipped: string[]
 }
 
-export type ResolveLatestVersion = (packageName: string) => Promise<string>
+// Resolves a bare plugin name to its latest published version. Returns null
+// when the package genuinely does not exist in the registry (404 / E404) so
+// the caller can skip it without blocking start. Throws on every other failure
+// (network outage, missing bun runtime, empty registry response) — those are
+// transient or environmental, not "plugin not found", and must still block.
+export type ResolveLatestVersion = (packageName: string) => Promise<string | null>
 
 export type ReconcilePluginDepsOptions = {
   cwd: string
@@ -31,27 +42,27 @@ export async function reconcilePluginDeps(options: ReconcilePluginDepsOptions): 
   const resolveLatest = options.resolveLatest ?? resolveLatestFromRegistry
 
   const pkgPath = join(cwd, PACKAGE_FILE)
-  if (!existsSync(pkgPath)) return { changed: false, files: [] }
+  if (!existsSync(pkgPath)) return NOOP
 
   let raw: string
   try {
     raw = await readFile(pkgPath, 'utf8')
   } catch {
-    return { changed: false, files: [] }
+    return NOOP
   }
 
   let pkg: PackageJsonShape
   try {
     const parsed = JSON.parse(raw) as unknown
-    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return { changed: false, files: [] }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return NOOP
     pkg = parsed as PackageJsonShape
   } catch {
-    return { changed: false, files: [] }
+    return NOOP
   }
 
   const dependencies = { ...pkg.dependencies }
   const previousManaged = readManagedPlugins(pkg)
-  const desired = await resolveDesiredManaged(plugins, previousManaged, resolveLatest)
+  const { desired, skipped } = await resolveDesiredManaged(plugins, previousManaged, resolveLatest)
 
   let changed = false
 
@@ -73,11 +84,11 @@ export async function reconcilePluginDeps(options: ReconcilePluginDepsOptions): 
 
   if (!managedEqual(previousManaged, desired)) changed = true
 
-  if (!changed) return { changed: false, files: [] }
+  if (!changed) return { changed: false, files: [], skipped }
 
   const next = withManagedPlugins({ ...pkg, dependencies: sortKeys(dependencies) }, desired)
   await writeFile(pkgPath, `${JSON.stringify(next, null, 2)}\n`)
-  return { changed: true, files: [PACKAGE_FILE] }
+  return { changed: true, files: [PACKAGE_FILE], skipped }
 }
 
 type PackageJsonShape = {
@@ -97,19 +108,30 @@ async function resolveDesiredManaged(
   plugins: readonly string[],
   previousManaged: Record<string, string>,
   resolveLatest: ResolveLatestVersion,
-): Promise<Record<string, string>> {
+): Promise<{ desired: Record<string, string>; skipped: string[] }> {
   const desired: Record<string, string> = {}
+  const skipped: string[] = []
   for (const entry of plugins) {
     if (isLocalEntry(entry)) continue
     const { name, versionSpec } = splitPluginEntrySpec(entry)
     if (name.length === 0) continue
     if (versionSpec !== undefined) {
       desired[name] = versionSpec
-    } else {
-      desired[name] = previousManaged[name] ?? (await resolveLatest(name))
+      continue
     }
+    const pinned = previousManaged[name]
+    if (pinned !== undefined) {
+      desired[name] = pinned
+      continue
+    }
+    const resolved = await resolveLatest(name)
+    if (resolved === null) {
+      skipped.push(name)
+      continue
+    }
+    desired[name] = resolved
   }
-  return sortKeys(desired)
+  return { desired: sortKeys(desired), skipped }
 }
 
 function isLocalEntry(entry: string): boolean {
@@ -154,7 +176,7 @@ function sortKeys(obj: Record<string, string>): Record<string, string> {
   return out
 }
 
-async function resolveLatestFromRegistry(packageName: string): Promise<string> {
+async function resolveLatestFromRegistry(packageName: string): Promise<string | null> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) throw new Error(`cannot resolve latest version for ${packageName}: bun runtime not available`)
   const proc = bun.spawn({
@@ -164,10 +186,18 @@ async function resolveLatestFromRegistry(packageName: string): Promise<string> {
   })
   const code = await proc.exited
   if (code !== 0) {
-    const stderr = await new Response(proc.stderr).text()
-    throw new Error(`failed to resolve latest version for ${packageName}: ${stderr.trim() || `exit ${code}`}`)
+    const stderr = (await new Response(proc.stderr).text()).trim()
+    if (isPackageNotFound(stderr)) return null
+    throw new Error(`failed to resolve latest version for ${packageName}: ${stderr || `exit ${code}`}`)
   }
   const version = (await new Response(proc.stdout).text()).trim().replace(/^["']|["']$/g, '')
   if (version.length === 0) throw new Error(`registry returned no version for ${packageName}`)
   return version
+}
+
+// A registry 404 means the package does not exist — a user typo or an
+// unpublished plugin — which `start` must tolerate, not abort on. Network and
+// auth failures are deliberately NOT matched here so they keep throwing.
+export function isPackageNotFound(stderr: string): boolean {
+  return /\bE404\b/.test(stderr) || /\b404\b/.test(stderr) || /not found/i.test(stderr)
 }

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -20,6 +20,17 @@ export type PermissionService = {
   // the config reloadable so role match-rule edits (typeclaw role claim,
   // hand-edits to typeclaw.json) take effect without a container restart.
   replaceRoles(roles: RolesConfig | undefined): void
+  // Rebuilds the role table with a new plugin-permission set, preserving the
+  // object identity that plugin factories captured. The plugin manager calls
+  // this AFTER the load loop to finalize the permission model from only the
+  // plugins that survived: a user plugin that failed to load must not leave
+  // its declared permissions or owner-wildcard exclusions in the live service.
+  // Optional so the many partial test stubs and the channel-respond stub need
+  // not implement it; the real service from createPermissionService always does.
+  replacePluginPermissions?(opts: {
+    pluginPermissions: readonly string[]
+    ownerWildcardExclusions: readonly string[]
+  }): void
 }
 
 export type UnknownPermissionWarning = {
@@ -34,6 +45,7 @@ export const noopPermissionService: PermissionService = {
   compareRoleSeverity: () => undefined,
   describe: () => ({ role: 'guest', permissions: [] }),
   replaceRoles: () => {},
+  replacePluginPermissions: () => {},
 }
 
 type ResolvedRole = {
@@ -109,9 +121,10 @@ function levenshtein(a: string, b: string): number {
 }
 
 export function createPermissionService(opts: CreatePermissionServiceOptions = {}): PermissionService {
-  const pluginPermissions = opts.pluginPermissions ?? []
-  const ownerWildcardExclusions = opts.ownerWildcardExclusions ?? []
-  let resolved = buildRoleTable(opts.roles ?? {}, pluginPermissions, ownerWildcardExclusions)
+  let pluginPermissions = opts.pluginPermissions ?? []
+  let ownerWildcardExclusions = opts.ownerWildcardExclusions ?? []
+  let lastRoles = opts.roles ?? {}
+  let resolved = buildRoleTable(lastRoles, pluginPermissions, ownerWildcardExclusions)
   let byName = new Map(resolved.map((r) => [r.name, r]))
 
   function resolveRole(origin: SessionOrigin | undefined): string {
@@ -186,7 +199,14 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
       return { role: name, permissions: role?.permissions ?? [] }
     },
     replaceRoles(roles) {
-      resolved = buildRoleTable(roles ?? {}, pluginPermissions, ownerWildcardExclusions)
+      lastRoles = roles ?? {}
+      resolved = buildRoleTable(lastRoles, pluginPermissions, ownerWildcardExclusions)
+      byName = new Map(resolved.map((r) => [r.name, r]))
+    },
+    replacePluginPermissions(next) {
+      pluginPermissions = next.pluginPermissions
+      ownerWildcardExclusions = next.ownerWildcardExclusions
+      resolved = buildRoleTable(lastRoles, pluginPermissions, ownerWildcardExclusions)
       byName = new Map(resolved.map((r) => [r.name, r]))
     },
   }

--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -15,14 +15,26 @@ export type LoadPluginEntryFn = (entry: string, agentDir: string) => Promise<Res
 
 // Thrown only when a plugin entry cannot be resolved at all (uninstalled
 // package, missing local file, unresolvable export subpath). The manager
-// treats this as non-fatal and skips the entry. Every other failure --
-// path-escape, import-time evaluation throws, invalid definition -- stays a
-// plain Error so it remains a hard boot error.
+// treats this as non-fatal and skips the entry.
 export class PluginNotFoundError extends Error {
   readonly entry: string
   constructor(entry: string, message: string, options?: { cause?: unknown }) {
     super(message, options)
     this.name = 'PluginNotFoundError'
+    this.entry = entry
+  }
+}
+
+// Thrown when a plugin entry violates a security boundary (e.g. a local path
+// escaping the agent directory). Stays fatal for ALL plugins — even the
+// per-plugin tolerance for user plugin bugs MUST NOT swallow this, or a
+// malicious typeclaw.json could point at arbitrary host files and have the
+// failure silently downgraded to a warning.
+export class PluginSecurityError extends Error {
+  readonly entry: string
+  constructor(entry: string, message: string) {
+    super(message)
+    this.name = 'PluginSecurityError'
     this.entry = entry
   }
 }
@@ -44,7 +56,7 @@ async function loadLocal(entry: string, agentDir: string): Promise<ResolvedPlugi
   // cannot point at arbitrary files on the host.
   const rel = relative(agentDir, resolved)
   if (rel.startsWith('..') || isAbsolute(rel)) {
-    throw new Error(`plugin path escapes agent directory: ${entry} (resolved to ${resolved})`)
+    throw new PluginSecurityError(entry, `plugin path escapes agent directory: ${entry} (resolved to ${resolved})`)
   }
   if (!existsSync(resolved)) {
     throw new PluginNotFoundError(entry, `plugin path does not exist: ${entry} (resolved to ${resolved})`)

--- a/src/plugin/manager.test.ts
+++ b/src/plugin/manager.test.ts
@@ -3,76 +3,148 @@ import { describe, expect, test } from 'bun:test'
 import { z } from 'zod'
 
 import { defineTool } from './define'
-import { type LoadPluginEntryFn, PluginNotFoundError } from './loader'
+import { type LoadPluginEntryFn, PluginNotFoundError, PluginSecurityError } from './loader'
 import { loadPlugins, summarizeLoaded, pluginCronJobs } from './manager'
 
-describe('loadPlugins — atomic rollback', () => {
-  test('throws and discards all registrations if a factory throws', async () => {
-    const tool = defineTool({
-      description: '',
-      parameters: z.object({}),
-      async execute() {
-        return { content: [] }
-      },
-    })
+function noopTool() {
+  return defineTool({
+    description: '',
+    parameters: z.object({}),
+    async execute() {
+      return { content: [] }
+    },
+  })
+}
+
+function captureWarnings(): { warnings: string[]; restore: () => void } {
+  const warnings: string[] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args.join(' '))
+  return { warnings, restore: () => (console.warn = original) }
+}
+
+describe('loadPlugins — user plugin failures are isolated', () => {
+  test('a user plugin whose factory throws is skipped + recorded, the rest still load', async () => {
+    const tool = noopTool()
     const loadEntry: LoadPluginEntryFn = async (entry) => {
-      if (entry === 'good') {
+      if (entry === 'bad') {
         return {
-          name: 'good',
+          name: 'bad',
           version: undefined,
-          source: 'good',
+          source: 'bad',
           defined: {
-            plugin: async () => ({ tools: { ok: tool } }),
+            plugin: async () => {
+              throw new Error('factory failed')
+            },
           },
         }
       }
       return {
-        name: 'bad',
+        name: entry,
         version: undefined,
-        source: 'bad',
-        defined: {
-          plugin: async () => {
-            throw new Error('factory failed')
-          },
-        },
+        source: entry,
+        defined: { plugin: async () => ({ tools: { [entry]: tool } }) },
       }
     }
 
-    await expect(
-      loadPlugins({ entries: ['good', 'bad'], agentDir: '/tmp', configsByName: {}, loadEntry }),
-    ).rejects.toThrow(/bad: factory threw: factory failed/)
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({ entries: ['good', 'bad'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    } finally {
+      cap.restore()
+    }
+
+    expect(result.loadedPlugins.map((p) => p.name)).toEqual(['good'])
+    expect(result.failedPlugins).toEqual([
+      { entry: 'bad', phase: 'factory', error: expect.stringContaining('factory threw: factory failed') },
+    ])
+    expect(cap.warnings.some((w) => w.includes('bad') && w.includes('skipping'))).toBe(true)
   })
 
-  test('throws on conflicting tool registration mid-load and rolls back the offending plugin', async () => {
-    const tool = defineTool({
-      description: '',
-      parameters: z.object({}),
-      async execute() {
-        return { content: [] }
-      },
-    })
+  test('a user plugin with an import-time throw is skipped, not fatal', async () => {
+    const loadEntry: LoadPluginEntryFn = async (entry) => {
+      if (entry === 'broken') throw new Error(`plugin ${entry}: default export is not a definePlugin(...) result`)
+      return { name: entry, version: undefined, source: entry, defined: { plugin: async () => ({}) } }
+    }
+
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({ entries: ['good', 'broken'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    } finally {
+      cap.restore()
+    }
+
+    expect(result.loadedPlugins.map((p) => p.name)).toEqual(['good'])
+    expect(result.failedPlugins.map((f) => ({ entry: f.entry, phase: f.phase }))).toEqual([
+      { entry: 'broken', phase: 'resolve' },
+    ])
+  })
+
+  test('a user plugin with an invalid config block is skipped, not fatal', async () => {
     const loadEntry: LoadPluginEntryFn = async (entry) => ({
       name: entry,
       version: undefined,
       source: entry,
-      defined: {
-        plugin: async () => ({ tools: { same: tool } }),
-      },
+      defined: { configSchema: z.object({ schedule: z.string() }), plugin: async () => ({}) },
     })
 
-    await expect(
-      loadPlugins({ entries: ['p1', 'p2'], agentDir: '/tmp', configsByName: {}, loadEntry }),
-    ).rejects.toThrow(/already registered by plugin p1/)
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({
+        entries: ['bad-config'],
+        agentDir: '/tmp',
+        configsByName: { 'bad-config': { schedule: 42 } },
+        loadEntry,
+      })
+    } finally {
+      cap.restore()
+    }
+
+    expect(result.loadedPlugins).toEqual([])
+    expect(result.failedPlugins).toEqual([
+      { entry: 'bad-config', phase: 'config', error: expect.stringContaining('config invalid: schedule:') },
+    ])
   })
 
-  test('rejects duplicate plugin names', async () => {
-    const tool = defineTool({
-      description: '',
-      parameters: z.object({}),
-      async execute() {
-        return { content: [] }
-      },
-    })
+  test('earlier successfully-loaded user plugins survive a later plugin failure', async () => {
+    const tool = noopTool()
+    const loadEntry: LoadPluginEntryFn = async (entry) => {
+      if (entry === 'p2')
+        return {
+          name: 'p2',
+          version: undefined,
+          source: 'p2',
+          defined: {
+            plugin: async () => {
+              throw new Error('boom')
+            },
+          },
+        }
+      return {
+        name: entry,
+        version: undefined,
+        source: entry,
+        defined: { plugin: async () => ({ tools: { [entry]: tool } }) },
+      }
+    }
+
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({ entries: ['p1', 'p2', 'p3'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    } finally {
+      cap.restore()
+    }
+
+    expect(result.loadedPlugins.map((p) => p.name)).toEqual(['p1', 'p3'])
+    expect(result.registry.tools.map((t) => t.toolName).sort()).toEqual(['p1', 'p3'])
+  })
+
+  test('duplicate plugin names stay fatal (global invariant, not a per-plugin skip)', async () => {
+    const tool = noopTool()
     const loadEntry: LoadPluginEntryFn = async () => ({
       name: 'same',
       version: undefined,
@@ -83,6 +155,56 @@ describe('loadPlugins — atomic rollback', () => {
     await expect(loadPlugins({ entries: ['x', 'y'], agentDir: '/tmp', configsByName: {}, loadEntry })).rejects.toThrow(
       /plugin name conflict: same/,
     )
+  })
+})
+
+describe('loadPlugins — bundled plugin failures stay fatal', () => {
+  test('a bundled plugin whose factory throws aborts boot (typeclaw bug, fail loud)', async () => {
+    const bundled = [
+      {
+        name: 'security',
+        version: undefined,
+        source: '<bundled>',
+        defined: {
+          plugin: async () => {
+            throw new Error('bundled boom')
+          },
+        },
+      },
+    ]
+    await expect(
+      loadPlugins({
+        entries: [],
+        agentDir: '/tmp',
+        configsByName: {},
+        loadEntry: async () => {
+          throw new Error('unused')
+        },
+        bundled,
+      }),
+    ).rejects.toThrow(/bundled boom/)
+  })
+
+  test('a bundled plugin with an invalid config block aborts boot', async () => {
+    const bundled = [
+      {
+        name: 'memory',
+        version: undefined,
+        source: '<bundled>',
+        defined: { configSchema: z.object({ n: z.number() }), plugin: async () => ({}) },
+      },
+    ]
+    await expect(
+      loadPlugins({
+        entries: [],
+        agentDir: '/tmp',
+        configsByName: { memory: { n: 'nope' } },
+        loadEntry: async () => {
+          throw new Error('unused')
+        },
+        bundled,
+      }),
+    ).rejects.toThrow(/memory: config invalid/)
   })
 })
 
@@ -126,17 +248,17 @@ describe('loadPlugins — unresolvable entry is non-fatal', () => {
     expect(warnings.some((w) => w.includes('typeclaw-plugin-missing') && w.includes('Cannot find package'))).toBe(true)
   })
 
-  test('does NOT swallow a non-resolution failure (invalid plugin stays fatal)', async () => {
+  test('a PluginSecurityError stays fatal even for a user plugin (path escape is never skipped)', async () => {
     const loadEntry: LoadPluginEntryFn = async (entry) => {
-      if (entry === 'broken') {
-        throw new Error(`plugin ${entry}: default export is not a definePlugin(...) result`)
+      if (entry === './escape.ts') {
+        throw new PluginSecurityError(entry, `plugin path escapes agent directory: ${entry}`)
       }
       return { name: entry, version: undefined, source: entry, defined: { plugin: async () => ({}) } }
     }
 
     await expect(
-      loadPlugins({ entries: ['good', 'broken'], agentDir: '/tmp', configsByName: {}, loadEntry }),
-    ).rejects.toThrow(/default export is not a definePlugin/)
+      loadPlugins({ entries: ['good', './escape.ts'], agentDir: '/tmp', configsByName: {}, loadEntry }),
+    ).rejects.toThrow(/escapes agent directory/)
   })
 })
 
@@ -185,7 +307,7 @@ describe('loadPlugins — config validation', () => {
     expect(captured.value).toEqual({ schedule: '0 9 * * 1' })
   })
 
-  test('rejects invalid config with plugin name + field path in the error', async () => {
+  test('records invalid config with plugin name + field path in failedPlugins (skipped, not fatal)', async () => {
     const loadEntry: LoadPluginEntryFn = async () => ({
       name: 'standup-log',
       version: undefined,
@@ -196,17 +318,24 @@ describe('loadPlugins — config validation', () => {
       },
     })
 
-    await expect(
-      loadPlugins({
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({
         entries: ['s'],
         agentDir: '/tmp',
         configsByName: { 'standup-log': { schedule: 42 } },
         loadEntry,
-      }),
-    ).rejects.toThrow(/standup-log: config invalid: schedule:/)
+      })
+    } finally {
+      cap.restore()
+    }
+
+    expect(result.loadedPlugins).toEqual([])
+    expect(result.failedPlugins[0]?.error).toMatch(/standup-log: config invalid: schedule:/)
   })
 
-  test('rejects config block when plugin declares no configSchema', async () => {
+  test('records a config block present without a configSchema in failedPlugins (skipped, not fatal)', async () => {
     const loadEntry: LoadPluginEntryFn = async () => ({
       name: 'no-config-plugin',
       version: undefined,
@@ -216,14 +345,21 @@ describe('loadPlugins — config validation', () => {
       },
     })
 
-    await expect(
-      loadPlugins({
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({
         entries: ['s'],
         agentDir: '/tmp',
         configsByName: { 'no-config-plugin': { foo: 1 } },
         loadEntry,
-      }),
-    ).rejects.toThrow(/declares no configSchema/)
+      })
+    } finally {
+      cap.restore()
+    }
+
+    expect(result.loadedPlugins).toEqual([])
+    expect(result.failedPlugins[0]?.error).toMatch(/declares no configSchema/)
   })
 })
 
@@ -262,7 +398,7 @@ describe('loadPlugins — markBooted gates spawnSubagent', () => {
     expect(calls).toEqual(['worker'])
   })
 
-  test('spawnSubagent inside the factory throws synchronously', async () => {
+  test('a factory that calls spawnSubagent before boot fails that plugin (recorded, not fatal)', async () => {
     const loadEntry: LoadPluginEntryFn = async () => ({
       name: 'p1',
       version: undefined,
@@ -275,9 +411,17 @@ describe('loadPlugins — markBooted gates spawnSubagent', () => {
       },
     })
 
-    await expect(loadPlugins({ entries: ['p1'], agentDir: '/tmp', configsByName: {}, loadEntry })).rejects.toThrow(
-      /before boot completed/,
-    )
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({ entries: ['p1'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    } finally {
+      cap.restore()
+    }
+
+    expect(result.loadedPlugins).toEqual([])
+    expect(result.failedPlugins[0]?.phase).toBe('factory')
+    expect(result.failedPlugins[0]?.error).toMatch(/before boot completed/)
   })
 
   test('forwards the SpawnSubagentOptions arg to the wired implementation', async () => {

--- a/src/plugin/manager.test.ts
+++ b/src/plugin/manager.test.ts
@@ -208,6 +208,56 @@ describe('loadPlugins — bundled plugin failures stay fatal', () => {
   })
 })
 
+describe('loadPlugins — a failed plugin does not influence the permission model', () => {
+  test("a skipped user plugin's permissions + ownerWildcardExclusions never reach the live service", async () => {
+    const ownerOrigin = { kind: 'system', component: 'test' } as const
+    const loadEntry: LoadPluginEntryFn = async (entry) => {
+      if (entry === 'failed') {
+        return {
+          name: 'failed',
+          version: undefined,
+          source: 'failed',
+          defined: {
+            permissions: ['security.bypass.failedPlugin'],
+            ownerWildcardExclusions: ['security.bypass.allowedPlugin'],
+            plugin: async () => {
+              throw new Error('boom')
+            },
+          },
+        }
+      }
+      return {
+        name: 'survivor',
+        version: undefined,
+        source: 'survivor',
+        defined: { permissions: ['security.bypass.allowedPlugin'], plugin: async () => ({}) },
+      }
+    }
+
+    const cap = captureWarnings()
+    let result
+    try {
+      result = await loadPlugins({ entries: ['survivor', 'failed'], agentDir: '/tmp', configsByName: {}, loadEntry })
+    } finally {
+      cap.restore()
+    }
+
+    // given the failed plugin is reported disabled and absent from the loaded set
+    expect(result.failedPlugins.map((f) => f.entry)).toEqual(['failed'])
+    expect(result.loadedPlugins.map((p) => p.name)).toEqual(['survivor'])
+
+    // then its declared permission is NOT in the known universe
+    expect(result.declaredPermissions).toContain('security.bypass.allowedPlugin')
+    expect(result.declaredPermissions).not.toContain('security.bypass.failedPlugin')
+
+    // and the live service reflects survivors only
+    expect(result.permissions.has(ownerOrigin, 'security.bypass.failedPlugin')).toBe(false)
+    // the security-critical assertion: the failed plugin's exclusion must NOT
+    // have stripped the surviving plugin's owner-wildcard bypass.
+    expect(result.permissions.has(ownerOrigin, 'security.bypass.allowedPlugin')).toBe(true)
+  })
+})
+
 describe('loadPlugins — unresolvable entry is non-fatal', () => {
   test('warns and skips an entry that fails to resolve, still loading the rest', async () => {
     const tool = defineTool({

--- a/src/plugin/manager.ts
+++ b/src/plugin/manager.ts
@@ -11,9 +11,21 @@ import {
 
 import { createPluginContext, createPluginLogger, type SpawnSubagentFn } from './context'
 import { createHookBus, type HookBus } from './hooks'
-import { loadPluginEntry, type LoadPluginEntryFn, PluginNotFoundError, type ResolvedPlugin } from './loader'
+import { loadPluginEntry, type LoadPluginEntryFn, PluginSecurityError, type ResolvedPlugin } from './loader'
 import { discardRegistrationsBy, emptyRegistry, type PluginRegistry, registerContributions } from './registry'
 import type { PluginExports } from './types'
+
+export type FailedPlugin = { entry: string; phase: 'resolve' | 'config' | 'factory' | 'register'; error: string }
+
+// A user (typeclaw.json / local / npm) plugin that fails to load must not brick
+// the agent: the agent can edit its own plugins, and a self-introduced bug would
+// otherwise leave the container unable to boot and repair itself. Such failures
+// are isolated (skip + warn, keep the rest). Bundled plugins are part of the
+// trusted runtime, so their failure stays fatal — and PluginSecurityError stays
+// fatal for everyone.
+function isToleratedUserError(err: unknown): boolean {
+  return !(err instanceof PluginSecurityError)
+}
 
 export type LoadPluginsOptions = {
   entries: string[]
@@ -36,6 +48,7 @@ export type LoadPluginsResult = {
   permissions: PermissionService
   declaredPermissions: readonly string[]
   loadedPlugins: { name: string; version: string | undefined; source: string }[]
+  failedPlugins: FailedPlugin[]
   markBooted: () => void
   setSpawnSubagent: (fn: SpawnSubagentFn) => void
 }
@@ -51,25 +64,30 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
     throw new Error('plugin: spawnSubagent is not yet wired')
   }
 
-  // Non-fatal: a single unresolvable entry (uninstalled package, typo) must
-  // not abort boot for every other plugin -- warn and skip it. Only genuine
-  // resolution failures (PluginNotFoundError) are swallowed; path-escape,
-  // import-time throws, and invalid definitions stay fatal so a broken or
-  // malicious plugin still hard-fails boot.
+  const failed: FailedPlugin[] = []
+
+  // A user entry that fails to resolve OR throws at import time (typo,
+  // uninstalled package, syntax error in a local plugin the agent just edited)
+  // is isolated: warn, record, skip — the rest still boot. PluginSecurityError
+  // (path escape) is the one exception and stays fatal.
   const resolvedEntries = await Promise.all(
     opts.entries.map(async (entry) => {
       try {
         return { entry, resolved: await loadEntry(entry, opts.agentDir) }
       } catch (err) {
-        if (!(err instanceof PluginNotFoundError)) throw err
-        console.warn(`[plugin] failed to load "${entry}", ignoring: ${err.message}`)
+        if (!isToleratedUserError(err)) throw err
+        const message = err instanceof Error ? err.message : String(err)
+        console.warn(`[plugin] failed to load "${entry}", skipping: ${message}`)
+        failed.push({ entry, phase: 'resolve', error: message })
         return null
       }
     }),
   )
-  const allPlugins: { entry: string; resolved: ResolvedPlugin }[] = [
-    ...(opts.bundled?.map((resolved) => ({ entry: `<bundled:${resolved.name}>`, resolved })) ?? []),
-    ...resolvedEntries.filter((e): e is { entry: string; resolved: ResolvedPlugin } => e !== null),
+  const allPlugins: { entry: string; resolved: ResolvedPlugin; isBundled: boolean }[] = [
+    ...(opts.bundled?.map((resolved) => ({ entry: `<bundled:${resolved.name}>`, resolved, isBundled: true })) ?? []),
+    ...resolvedEntries
+      .filter((e): e is { entry: string; resolved: ResolvedPlugin } => e !== null)
+      .map((e) => ({ ...e, isBundled: false })),
   ]
 
   const declaredPermissions = collectDeclaredPermissions(allPlugins)
@@ -91,62 +109,41 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
     )
   }
 
-  for (const { entry, resolved } of allPlugins) {
+  for (const { entry, resolved, isBundled } of allPlugins) {
+    // Name conflict is a global invariant (two plugins claiming one name make
+    // every later name-keyed lookup ambiguous), so it stays fatal regardless of
+    // origin — never demoted to a per-plugin skip.
     if (loaded.find((l) => l.name === resolved.name)) {
       throw new Error(`plugin name conflict: ${resolved.name} (entry ${entry}) already loaded`)
     }
 
-    let validatedConfig: unknown = undefined
-    if (resolved.defined.configSchema) {
-      const raw = opts.configsByName[resolved.name]
-      const parsed = (resolved.defined.configSchema as z.ZodType<unknown>).safeParse(raw ?? {})
-      if (!parsed.success) {
-        throw new Error(`plugin ${resolved.name}: config invalid: ${formatZodIssues(parsed.error)}`)
-      }
-      validatedConfig = parsed.data
-    } else if (opts.configsByName[resolved.name] !== undefined) {
-      throw new Error(
-        `plugin ${resolved.name}: config block "${resolved.name}" present in typeclaw.json but plugin declares no configSchema`,
-      )
-    }
-
-    const logger = createPluginLogger(resolved.name)
-    const ctx = createPluginContext({
-      name: resolved.name,
-      version: resolved.version,
-      agentDir: opts.agentDir,
-      config: validatedConfig as never,
-      logger,
-      permissions,
-      resolveGithubTokenForRepo: opts.resolveGithubTokenForRepo,
-      hasGithubAppTokenResolver: opts.hasGithubAppTokenResolver,
-      spawnSubagent: (name, payload, options) => spawnSubagentImpl(name, payload, options),
-      isBooted: () => booted,
-    })
-
-    let exports: PluginExports
     try {
-      exports = await resolved.defined.plugin(ctx)
-    } catch (err) {
-      discardRegistrationsBy(resolved.name, registry, hooks)
-      const message = err instanceof Error ? err.message : String(err)
-      throw new Error(`plugin ${resolved.name}: factory threw: ${message}`)
-    }
-
-    try {
-      registerContributions({
-        pluginName: resolved.name,
-        logger,
-        exports,
-        ...(resolved.defined.commands !== undefined ? { commands: resolved.defined.commands } : {}),
+      await registerOnePlugin({
+        resolved,
+        config: opts.configsByName[resolved.name],
+        agentDir: opts.agentDir,
         registry,
         hooks,
-        agentDir: opts.agentDir,
-        pluginConfig: validatedConfig,
+        permissions,
+        ctxDeps: {
+          resolveGithubTokenForRepo: opts.resolveGithubTokenForRepo,
+          hasGithubAppTokenResolver: opts.hasGithubAppTokenResolver,
+          spawnSubagent: (name, payload, options) => spawnSubagentImpl(name, payload, options),
+          isBooted: () => booted,
+        },
       })
     } catch (err) {
+      const phase = err instanceof PluginPhaseError ? err.phase : 'factory'
+      const message = err instanceof PluginPhaseError ? err.detail : err instanceof Error ? err.message : String(err)
+      // Bundled/core plugin failures are typeclaw bugs (or a compromised
+      // runtime) — fail loud. Only user plugin failures are isolated.
+      if (isBundled || !isToleratedUserError(err instanceof PluginPhaseError ? err.original : err)) {
+        throw err instanceof PluginPhaseError ? err.original : err
+      }
       discardRegistrationsBy(resolved.name, registry, hooks)
-      throw err
+      console.warn(`[plugin] failed to load "${entry}", skipping: ${message}`)
+      failed.push({ entry, phase, error: message })
+      continue
     }
 
     loaded.push({ name: resolved.name, version: resolved.version, source: resolved.source })
@@ -158,12 +155,100 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
     permissions,
     declaredPermissions,
     loadedPlugins: loaded,
+    failedPlugins: failed,
     markBooted: () => {
       booted = true
     },
     setSpawnSubagent: (fn) => {
       spawnSubagentImpl = fn
     },
+  }
+}
+
+// Tags WHICH sub-phase failed (for the failedPlugins report) while preserving
+// the ORIGINAL error so the caller can keep PluginSecurityError fatal even when
+// it surfaces deep inside registration.
+class PluginPhaseError extends Error {
+  readonly phase: FailedPlugin['phase']
+  readonly detail: string
+  readonly original: unknown
+  constructor(phase: FailedPlugin['phase'], detail: string, original: unknown) {
+    super(detail)
+    this.name = 'PluginPhaseError'
+    this.phase = phase
+    this.detail = detail
+    this.original = original
+  }
+}
+
+type RegisterOnePluginArgs = {
+  resolved: ResolvedPlugin
+  config: unknown
+  agentDir: string
+  registry: PluginRegistry
+  hooks: HookBus
+  permissions: PermissionService
+  ctxDeps: {
+    resolveGithubTokenForRepo?: ResolveGithubTokenForRepo
+    hasGithubAppTokenResolver?: () => boolean
+    spawnSubagent: SpawnSubagentFn
+    isBooted: () => boolean
+  }
+}
+
+async function registerOnePlugin(args: RegisterOnePluginArgs): Promise<void> {
+  const { resolved, registry, hooks } = args
+
+  let validatedConfig: unknown = undefined
+  if (resolved.defined.configSchema) {
+    const parsed = (resolved.defined.configSchema as z.ZodType<unknown>).safeParse(args.config ?? {})
+    if (!parsed.success) {
+      const message = `plugin ${resolved.name}: config invalid: ${formatZodIssues(parsed.error)}`
+      throw new PluginPhaseError('config', message, new Error(message))
+    }
+    validatedConfig = parsed.data
+  } else if (args.config !== undefined) {
+    const message = `plugin ${resolved.name}: config block "${resolved.name}" present in typeclaw.json but plugin declares no configSchema`
+    throw new PluginPhaseError('config', message, new Error(message))
+  }
+
+  const logger = createPluginLogger(resolved.name)
+  const ctx = createPluginContext({
+    name: resolved.name,
+    version: resolved.version,
+    agentDir: args.agentDir,
+    config: validatedConfig as never,
+    logger,
+    permissions: args.permissions,
+    resolveGithubTokenForRepo: args.ctxDeps.resolveGithubTokenForRepo,
+    hasGithubAppTokenResolver: args.ctxDeps.hasGithubAppTokenResolver,
+    spawnSubagent: args.ctxDeps.spawnSubagent,
+    isBooted: args.ctxDeps.isBooted,
+  })
+
+  let exports: PluginExports
+  try {
+    exports = await resolved.defined.plugin(ctx)
+  } catch (err) {
+    discardRegistrationsBy(resolved.name, registry, hooks)
+    const message = `plugin ${resolved.name}: factory threw: ${err instanceof Error ? err.message : String(err)}`
+    throw new PluginPhaseError('factory', message, err)
+  }
+
+  try {
+    registerContributions({
+      pluginName: resolved.name,
+      logger,
+      exports,
+      ...(resolved.defined.commands !== undefined ? { commands: resolved.defined.commands } : {}),
+      registry,
+      hooks,
+      agentDir: args.agentDir,
+      pluginConfig: validatedConfig,
+    })
+  } catch (err) {
+    discardRegistrationsBy(resolved.name, registry, hooks)
+    throw new PluginPhaseError('register', err instanceof Error ? err.message : String(err), err)
   }
 }
 

--- a/src/plugin/manager.ts
+++ b/src/plugin/manager.ts
@@ -90,26 +90,23 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
       .map((e) => ({ ...e, isBundled: false })),
   ]
 
-  const declaredPermissions = collectDeclaredPermissions(allPlugins)
-  const ownerWildcardExclusions = collectOwnerWildcardExclusions(allPlugins)
+  // Seed the permission service from BUNDLED plugins only. A user plugin's
+  // declared permissions / owner-wildcard exclusions must not enter the live
+  // service until the plugin actually survives registration — otherwise a
+  // plugin reported as disabled could still widen the allowed set or (worse)
+  // strip an owner-wildcard bypass. Bundled plugins are always survivors:
+  // their failure is fatal, so the boot aborts before this service is used.
+  const bundledPlugins = allPlugins.filter((p) => p.isBundled)
   const permissions = createPermissionService({
     ...(opts.roles !== undefined ? { roles: opts.roles } : {}),
-    pluginPermissions: declaredPermissions,
-    ownerWildcardExclusions,
+    pluginPermissions: collectDeclaredPermissions(bundledPlugins),
+    ownerWildcardExclusions: collectOwnerWildcardExclusions(bundledPlugins),
   })
 
-  // Non-fatal: surface user-declared `permissions[]` strings that aren't in
-  // the known set, so a typo like `security.bypass.secretExfilBach` is
-  // visible at boot rather than silently failing to bypass the matching
-  // guard. We log instead of throw because the runtime still functions --
-  // the unknown string just never matches anything.
-  for (const warning of findUnknownPermissions(opts.roles, declaredPermissions)) {
-    console.warn(
-      `[permissions] role "${warning.role}" declares unknown permission "${warning.permission}" — ${warning.hint}`,
-    )
-  }
+  const survivors: { entry: string; resolved: ResolvedPlugin; isBundled: boolean }[] = []
 
-  for (const { entry, resolved, isBundled } of allPlugins) {
+  for (const plugin of allPlugins) {
+    const { entry, resolved, isBundled } = plugin
     // Name conflict is a global invariant (two plugins claiming one name make
     // every later name-keyed lookup ambiguous), so it stays fatal regardless of
     // origin — never demoted to a per-plugin skip.
@@ -146,7 +143,29 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
       continue
     }
 
+    survivors.push(plugin)
     loaded.push({ name: resolved.name, version: resolved.version, source: resolved.source })
+  }
+
+  // Finalize the permission model from the survivor set only. Plugin factories
+  // captured `permissions` by reference (their hooks read it at request time),
+  // so we mutate that same object in place rather than returning a new one.
+  const declaredPermissions = collectDeclaredPermissions(survivors)
+  permissions.replacePluginPermissions?.({
+    pluginPermissions: declaredPermissions,
+    ownerWildcardExclusions: collectOwnerWildcardExclusions(survivors),
+  })
+
+  // Non-fatal: surface user-declared `permissions[]` strings that aren't in
+  // the known set, so a typo like `security.bypass.secretExfilBach` is
+  // visible at boot rather than silently failing to bypass the matching
+  // guard. We log instead of throw because the runtime still functions --
+  // the unknown string just never matches anything. Run AFTER finalization so
+  // a failed plugin's declarations don't make a role's permission look known.
+  for (const warning of findUnknownPermissions(opts.roles, declaredPermissions)) {
+    console.warn(
+      `[permissions] role "${warning.role}" declares unknown permission "${warning.permission}" — ${warning.hint}`,
+    )
   }
 
   return {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -701,6 +701,10 @@ export async function startAgent({
     console.log(`[plugin] loaded ${summarizeLoaded(pluginsLoaded.loadedPlugins, pluginRegistry)}`)
   }
 
+  for (const f of pluginsLoaded.failedPlugins) {
+    console.warn(`[plugin] DEGRADED: "${f.entry}" disabled (${f.phase}): ${f.error}`)
+  }
+
   // Container-side portbroker is instantiated only when the host plumbed a
   // broker token in via env var. Outside the container (tests, ad-hoc dev
   // runs), the env var is absent and the broker stays off — same fence as

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -81,7 +81,7 @@ describe('startAgent + plugin loading', () => {
     expect(running.loadedPlugins.map((p) => p.name)).toContain('memory')
   })
 
-  test('plugin factory exception aborts startAgent and does not leak partial registrations', async () => {
+  test('a user plugin whose factory throws is skipped — startAgent still boots, no leaked registrations', async () => {
     agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
     await writeFile(
       join(agentDir, 'typeclaw.json'),
@@ -99,9 +99,13 @@ describe('startAgent + plugin loading', () => {
 }`,
     )
 
-    await expect(startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })).rejects.toThrow(
-      /factory threw: boom/,
-    )
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+    // The broken user plugin is skipped: startAgent boots, the plugin is absent
+    // from the loaded set, and it leaked no registrations keyed to its name.
+    expect(running.loadedPlugins.map((p) => p.name)).not.toContain('plugin')
+    const registry = running.pluginRuntime.get().registry
+    expect(registry.tools.filter((t) => t.pluginName === 'plugin')).toEqual([])
+    expect(registry.cronJobs.filter((j) => j.pluginName === 'plugin')).toEqual([])
   })
 
   test('plugin session.start hook fires when a websocket session opens', async () => {


### PR DESCRIPTION
## Background

TypeClaw agents can edit their own `typeclaw.json` and local plugin files at runtime. This creates a self-lockout hazard: a self-introduced plugin bug that aborts the container boot leaves the agent unable to start — and therefore unable to undo the change that caused the problem.

This PR closes the self-lockout vector across two surfaces by making **user** plugin failures non-blocking, while keeping security and first-party runtime boundaries strict.

The guiding axis is **bundled = strict, user = tolerant.** An agent silently running without its security or permissions plugin is at least as bad as one that fails to boot; the isolation only applies where the risk is a user typo or a locally-broken plugin, not where the runtime itself is compromised.

---

## What changed

### Surface 1 — registry 404 on start (host stage)

**File:** `src/init/reconcile-plugin-deps.ts`

During `typeclaw start` / `typeclaw restart`, the plugin reconcile step resolves bare-name plugins to their latest version via `bun pm view`. When a package 404s (a typo or an unpublished plugin), the reconcile threw and the entire launch aborted.

Now:

- `resolveLatestFromRegistry` returns `null` on E404 / 404 / "not found" (new exported `isPackageNotFound` predicate).
- The plugin is skipped (dropped from package.json materialization) and recorded in a new `skipped: string[]` field on `ReconcilePluginDepsResult`.
- `StartResult` (ok: true) gains `skippedPlugins: string[]`; `renderStartSuccess` prints a yellow warning when non-empty.
- Start proceeds. Transient / environmental failures — network `ENOTFOUND`/`ETIMEDOUT`, auth `E401`, missing bun runtime, empty registry response — still throw and block. A plugin is never silently dropped because of a temporary registry problem.

### Surface 2 — user plugin load failure on run (container stage)

**Files:** `src/plugin/manager.ts`, `src/plugin/loader.ts`, `src/run/index.ts`

Inside `typeclaw run`, `loadPlugins` resolves, imports, validates config, calls the factory, and registers contributions for each plugin. Previously any throw in any of those phases — import-time syntax error, bad default export, invalid config block, factory throw, registration error — aborted ALL plugin loading, and `startAgent` had no catch, so the container crashed.

Now `loadPlugins` isolates **user** (typeclaw.json / local / npm) plugin failures:

- Warn and record in a new `failedPlugins: FailedPlugin[]` result. Each entry carries `{ entry, phase, error }` where `phase` is one of `resolve`, `config`, `factory`, or `register`.
- Skip that plugin, keep the rest, keep booting.
- Earlier successfully-loaded plugins survive a later plugin's failure — no more all-or-nothing behavior for user plugins.
- `startAgent` logs each degraded plugin as `[plugin] DEGRADED: "<entry>" disabled (<phase>): <error>` so a degraded boot is visible to the operator.

---

## Stays strict (by design)

These three boundaries remain fatal for **all** plugins, including user plugins:

1. **Bundled / core plugins.** They form the trusted runtime (security, permissions, memory, etc.). A failure there is a typeclaw bug, not a user misconfiguration — it should fail loud. Distinguished via an `isBundled` flag; bundled plugins come from `opts.bundled` and are tagged with the `<bundled:…>` prefix.

2. **`PluginSecurityError`.** New error type in `loader.ts`, thrown when a local plugin path escapes the agent directory (path-containment check). The broadened catch re-throws it for all plugins so the security boundary can never be silently downgraded to a skip. A `PluginPhaseError` wrapper preserves the original error through the config/factory/register sub-phases so this check works even when the security error surfaces mid-registration.

3. **Plugin name conflicts.** Two plugins claiming the same name create global ambiguity in every name-keyed lookup — still fatal.

---

## Not in this PR

- **Host-stage `bun install`:** a plugin with a valid name but an uninstallable dependency still blocks start, because `bun install` is all-or-nothing. This is intentional — partial install would introduce a second package-management policy inside typeclaw and leave `package.json` in a confusing state.
- **Safe-mode boot:** per-plugin isolation already solves the self-lockout for plugin-code bugs; a full safe mode is not needed to close this gap.

---

## Files changed

- **`src/init/reconcile-plugin-deps.ts`** — `resolveLatestFromRegistry` returns `null` on 404; new `isPackageNotFound` export; `resolveDesiredManaged` returns `{ desired, skipped }`.
- **`src/container/start.ts`** — `StartResult` gains `skippedPlugins: string[]`.
- **`src/cli/ui.ts`** — `renderStartSuccess` prints a yellow warning when `skippedPlugins` is non-empty.
- **`src/plugin/loader.ts`** — new `PluginSecurityError`; `PluginPhaseError` wrapper for sub-phase isolation.
- **`src/plugin/manager.ts`** — `loadPlugins` isolates user plugin failures; `failedPlugins: FailedPlugin[]` result field; `isBundled` flag distinguishes bundled from user plugins.
- **`src/run/index.ts`** — `startAgent` threads `failedPlugins` from `loadPlugins`; logs DEGRADED entries.
- **`src/init/reconcile-plugin-deps.test.ts`**, **`src/cli/ui.test.ts`** — new coverage for skip-on-null, sibling-still-materializes, hard-failure-still-throws, `isPackageNotFound` classification, warning rendering.
- **`src/plugin/manager.test.ts`**, **`src/run/plugin.test.ts`** — rewritten / new tests pinning the new contract: user factory / config / import errors are skipped and recorded; bundled failures stay fatal; `PluginSecurityError` stays fatal even for a user plugin; name conflicts stay fatal; earlier plugins survive a later failure; the E2E test now asserts `startAgent` boots when a user plugin's factory throws.
- **`src/cli/hostd.test.ts`**, **`src/init/index.test.ts`** — minor fixture updates.

---

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings in untouched files)
- `bun run format:check` — clean
- `bun run test` — 8538 pass, 1 skip, 0 fail (432 files)