### PR TITLE
feat(hostd): preflight agent restart against dependency-resolution failures

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -87,6 +87,49 @@ describe('buildHostdRestart', () => {
     })
   })
 
+  test('restart preflight refuses when dependency validation fails', async () => {
+    const preflight = buildHostdRestartPreflight('/repo/src/cli/index.ts', 'unversioned', {
+      loadConfigSync: () => configSchema.parse({ port: 8973, plugins: [] }),
+      validateRestartDeps: async () => ({ ok: false, reason: 'workspace:* failed to resolve' }),
+    })
+
+    const result = await preflight({ containerName: 'agent', cwd: '/agent-dir', build: false })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'restart refused for agent: workspace:* failed to resolve',
+    })
+  })
+
+  test('restart preflight passes plugins from config into the dependency validator', async () => {
+    const seen: Array<{ cwd: string; plugins: readonly string[] }> = []
+    const preflight = buildHostdRestartPreflight('/repo/src/cli/index.ts', 'unversioned', {
+      loadConfigSync: () => configSchema.parse({ port: 8973, plugins: ['./packages/foo'] }),
+      validateRestartDeps: async (opts) => {
+        seen.push(opts)
+        return { ok: true }
+      },
+    })
+
+    const result = await preflight({ containerName: 'agent', cwd: '/agent-dir', build: false })
+
+    expect(result).toBeNull()
+    expect(seen).toEqual([{ cwd: '/agent-dir', plugins: ['./packages/foo'] }])
+  })
+
+  test('restart preflight proceeds when config cannot be read (start stays the fail-closed gate)', async () => {
+    const preflight = buildHostdRestartPreflight('/repo/src/cli/index.ts', 'unversioned', {
+      loadConfigSync: () => {
+        throw new Error('typeclaw.json unreadable')
+      },
+      validateRestartDeps: async () => ({ ok: false, reason: 'should not be called' }),
+    })
+
+    const result = await preflight({ containerName: 'agent', cwd: '/agent-dir', build: false })
+
+    expect(result).toBeNull()
+  })
+
   test('omitted build defaults to forceBuild:false', async () => {
     const starts: StartOptions[] = []
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -7,6 +7,7 @@ import { createKakaoRenewalManager } from '@/hostd/kakao-renewal-manager'
 import { createPortbrokerManager } from '@/hostd/portbroker-manager'
 import type { SupervisorLogEvent, SupervisorRestart } from '@/hostd/supervisor'
 import { computeSourceVersion, resolveSrcRoot, UNVERSIONED_SENTINEL } from '@/hostd/version'
+import { validateRestartDeps, type RestartDepsPreflightResult } from '@/init/restart-deps-preflight'
 
 export const hostdCommand = defineCommand({
   meta: {
@@ -43,7 +44,7 @@ export const hostdCommand = defineCommand({
       onShutdown: () => process.exit(0),
       portbroker,
       kakaoRenewal,
-      restartPreflight: buildHostdRestartPreflight(cliEntry, version),
+      restartPreflight: buildHostdRestartPreflight(cliEntry, version, defaultPreflightDeps),
       restart: hostdRestart,
     })
 
@@ -104,10 +105,42 @@ export function buildHostdRestart(
   }
 }
 
-export function buildHostdRestartPreflight(cliEntry: string, daemonVersion: string): RestartPreflight {
-  return async () => {
+export type HostdPreflightDeps = {
+  loadConfigSync: (cwd: string) => Config
+  validateRestartDeps: (opts: { cwd: string; plugins: readonly string[] }) => Promise<RestartDepsPreflightResult>
+}
+
+const defaultPreflightDeps: HostdPreflightDeps = {
+  loadConfigSync,
+  validateRestartDeps,
+}
+
+export function buildHostdRestartPreflight(
+  cliEntry: string,
+  daemonVersion: string,
+  deps: HostdPreflightDeps = defaultPreflightDeps,
+): RestartPreflight {
+  return async ({ containerName, cwd }) => {
     const drift = await detectSourceDrift(cliEntry, daemonVersion)
-    return drift ? { ok: false, reason: drift } : null
+    if (drift) return { ok: false, reason: drift }
+
+    // Read plugins through loadConfigSync, not validateConfig: a config that
+    // fails schema validation is caught later in buildHostdRestart (before
+    // stop). On read/parse failure we let the restart proceed — start() is the
+    // fail-closed gate, and a preflight that can't read config must not strand a
+    // healthy agent.
+    let plugins: readonly string[]
+    try {
+      plugins = deps.loadConfigSync(cwd).plugins
+    } catch {
+      return null
+    }
+
+    const depsCheck = await deps.validateRestartDeps({ cwd, plugins })
+    if (!depsCheck.ok) {
+      return { ok: false, reason: `restart refused for ${containerName}: ${depsCheck.reason}` }
+    }
+    return null
   }
 }
 

--- a/src/init/restart-deps-preflight.test.ts
+++ b/src/init/restart-deps-preflight.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { validateRestartDeps } from './restart-deps-preflight'
+
+async function makeAgentDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'restart-preflight-'))
+}
+
+async function writePackage(dir: string, name: string, pkg: unknown): Promise<void> {
+  const pkgDir = join(dir, 'packages', name)
+  await mkdir(pkgDir, { recursive: true })
+  await writeFile(join(pkgDir, 'package.json'), JSON.stringify(pkg, null, 2))
+}
+
+describe('validateRestartDeps', () => {
+  test('refuses when a workspace member pins a non-workspace dep via workspace:*', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      await writePackage(cwd, 'gws-multi-account', {
+        name: 'gws-multi-account',
+        dependencies: { typeclaw: 'workspace:*', zod: '^3.25.76' },
+      })
+
+      const result = await validateRestartDeps({ cwd, plugins: [] })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('typeclaw')
+      expect(result.reason).toContain('workspace:*')
+      expect(result.reason).toContain('gws-multi-account')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('allows workspace:* when the dep IS a workspace member', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      await writePackage(cwd, 'lib-core', { name: '@acme/core' })
+      await writePackage(cwd, 'app', {
+        name: 'app',
+        dependencies: { '@acme/core': 'workspace:*' },
+      })
+
+      const result = await validateRestartDeps({ cwd, plugins: [] })
+
+      expect(result.ok).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('allows a clean agent folder with registry-versioned deps', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      await writePackage(cwd, 'plugin-a', {
+        name: 'plugin-a',
+        dependencies: { typeclaw: '^0.36.1', zod: '^3.25.76' },
+      })
+
+      const result = await validateRestartDeps({ cwd, plugins: [] })
+
+      expect(result.ok).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('allows when there is no packages/ directory at all', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      const result = await validateRestartDeps({ cwd, plugins: [] })
+      expect(result.ok).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('skips (does not fail) a member with an unparseable manifest', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      const pkgDir = join(cwd, 'packages', 'broken')
+      await mkdir(pkgDir, { recursive: true })
+      await writeFile(join(pkgDir, 'package.json'), '{ not valid json')
+
+      const result = await validateRestartDeps({ cwd, plugins: [] })
+
+      expect(result.ok).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('detects workspace:* in devDependencies and peerDependencies too', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      await writePackage(cwd, 'tooling', {
+        name: 'tooling',
+        devDependencies: { 'not-a-member': 'workspace:^1.0.0' },
+      })
+
+      const result = await validateRestartDeps({ cwd, plugins: [] })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('not-a-member')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('refuses when a local plugin path in typeclaw.json#plugins is missing', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      const result = await validateRestartDeps({ cwd, plugins: ['./packages/ghost'] })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('./packages/ghost')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('allows a local plugin path that exists on disk', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      await writePackage(cwd, 'real', { name: 'real' })
+
+      const result = await validateRestartDeps({ cwd, plugins: ['./packages/real'] })
+
+      expect(result.ok).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('ignores bare (registry) plugin names — those are not local-path checked', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      const result = await validateRestartDeps({ cwd, plugins: ['typeclaw-gws-multi-account@0.3.2'] })
+
+      expect(result.ok).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/restart-deps-preflight.test.ts
+++ b/src/init/restart-deps-preflight.test.ts
@@ -148,4 +148,42 @@ describe('validateRestartDeps', () => {
       await rm(cwd, { recursive: true, force: true })
     }
   })
+
+  test('refuses an existing relative path that escapes the agent directory', async () => {
+    const cwd = await makeAgentDir()
+    try {
+      // sibling.ts exists one level above cwd; a bare existsSync would pass, but
+      // the loader confines local plugins to cwd and rejects this post-stop.
+      const siblingFile = join(cwd, '..', 'sibling.ts')
+      await writeFile(siblingFile, 'export default {}')
+
+      const result = await validateRestartDeps({ cwd, plugins: ['../sibling.ts'] })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('escapes the agent directory')
+
+      await rm(siblingFile, { force: true })
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('refuses an existing absolute path outside the agent directory', async () => {
+    const cwd = await makeAgentDir()
+    const outsideDir = await makeAgentDir()
+    try {
+      const abs = join(outsideDir, 'plugin.ts')
+      await writeFile(abs, 'export default {}')
+
+      const result = await validateRestartDeps({ cwd, plugins: [abs] })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('escapes the agent directory')
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/init/restart-deps-preflight.ts
+++ b/src/init/restart-deps-preflight.ts
@@ -1,0 +1,146 @@
+import { existsSync } from 'node:fs'
+import { readFile, readdir } from 'node:fs/promises'
+import { isAbsolute, join } from 'node:path'
+
+import { PACKAGE_FILE } from './packagejson'
+import { PACKAGES_DIR } from './paths'
+
+// The hostd restart path is destroy-then-recreate: it `docker rm -f`s the live
+// container BEFORE `start()` runs `bun install`. A bad agent edit to
+// typeclaw.json#plugins or a packages/* manifest aborts that install AFTER the
+// old container is gone, with no rollback and no client to report to — the agent
+// self-locks out. This runs BEFORE stop() (via RestartPreflight) so a bad edit
+// becomes "restart refused, agent keeps running" instead of "agent bricked".
+//
+// Mirrors PR #770: ONLY deterministic local config errors block. No bun
+// invocation, no network — a transient registry hiccup must never strand a
+// healthy agent. start() stays the real fail-closed gate for everything else.
+
+export type RestartDepsPreflightResult = { ok: true } | { ok: false; reason: string }
+
+export type RestartDepsPreflightOptions = {
+  cwd: string
+  plugins: readonly string[]
+}
+
+const WORKSPACE_PROTOCOL = 'workspace:'
+
+const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const
+
+export async function validateRestartDeps(options: RestartDepsPreflightOptions): Promise<RestartDepsPreflightResult> {
+  const { cwd, plugins } = options
+
+  const localPluginError = checkLocalPluginPaths(cwd, plugins)
+  if (localPluginError) return { ok: false, reason: localPluginError }
+
+  const workspaceError = await checkWorkspaceMembers(cwd)
+  if (workspaceError) return { ok: false, reason: workspaceError }
+
+  return { ok: true }
+}
+
+function checkLocalPluginPaths(cwd: string, plugins: readonly string[]): string | null {
+  for (const entry of plugins) {
+    if (!isLocalEntry(entry)) continue
+    const resolved = isAbsolute(entry) ? entry : join(cwd, entry)
+    if (!existsSync(resolved)) {
+      return `local plugin "${entry}" referenced in typeclaw.json#plugins does not exist on disk; restart would fail at dependency install. Remove the entry or restore the path before restarting.`
+    }
+  }
+  return null
+}
+
+function isLocalEntry(entry: string): boolean {
+  return entry.startsWith('./') || entry.startsWith('../') || isAbsolute(entry)
+}
+
+// Bun resolves the `workspace:` protocol strictly against the local workspace
+// set, so a member declaring `"<dep>": "workspace:*"` where `<dep>` is not
+// itself a workspace member aborts the WHOLE install with `<dep>@workspace:*
+// failed to resolve`. Canonical trigger: a half-migrated local plugin still
+// pinning `"typeclaw": "workspace:*"` after typeclaw became an external npm dep.
+async function checkWorkspaceMembers(cwd: string): Promise<string | null> {
+  const members = await readWorkspaceMembers(cwd)
+  if (members.length === 0) return null
+
+  const memberNames = new Set<string>()
+  for (const m of members) {
+    if (m.name !== null) memberNames.add(m.name)
+  }
+
+  for (const member of members) {
+    for (const field of DEPENDENCY_FIELDS) {
+      const deps = member.deps[field]
+      if (!deps) continue
+      for (const [depName, spec] of Object.entries(deps)) {
+        if (!spec.startsWith(WORKSPACE_PROTOCOL)) continue
+        if (!memberNames.has(depName)) {
+          return `local workspace package "${member.dirName}" depends on "${depName}": "${spec}", but "${depName}" is not a workspace package under ${PACKAGES_DIR}/. \`bun install\` would abort with "${depName}@${spec} failed to resolve", leaving the agent unable to restart. Fix ${PACKAGES_DIR}/${member.dirName}/${PACKAGE_FILE} (use a registry version range, or remove the package) before restarting.`
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+type WorkspaceMember = {
+  dirName: string
+  name: string | null
+  deps: Partial<Record<(typeof DEPENDENCY_FIELDS)[number], Record<string, string>>>
+}
+
+// A member whose manifest is missing/unparseable is skipped, not failed: bun may
+// tolerate it, and we only block on the workspace-resolution class above. No
+// packages/ dir at all returns [].
+async function readWorkspaceMembers(cwd: string): Promise<WorkspaceMember[]> {
+  const packagesDir = join(cwd, PACKAGES_DIR)
+  let entries: string[]
+  try {
+    entries = await readdir(packagesDir)
+  } catch {
+    return []
+  }
+
+  const members: WorkspaceMember[] = []
+  for (const dirName of entries) {
+    const manifestPath = join(packagesDir, dirName, PACKAGE_FILE)
+    if (!existsSync(manifestPath)) continue
+    let raw: string
+    try {
+      raw = await readFile(manifestPath, 'utf8')
+    } catch {
+      continue
+    }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      continue
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) continue
+    const pkg = parsed as Record<string, unknown>
+    members.push({
+      dirName,
+      name: typeof pkg.name === 'string' ? pkg.name : null,
+      deps: extractDeps(pkg),
+    })
+  }
+  return members
+}
+
+function extractDeps(
+  pkg: Record<string, unknown>,
+): Partial<Record<(typeof DEPENDENCY_FIELDS)[number], Record<string, string>>> {
+  const out: Partial<Record<(typeof DEPENDENCY_FIELDS)[number], Record<string, string>>> = {}
+  for (const field of DEPENDENCY_FIELDS) {
+    const value = pkg[field]
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) continue
+    const deps: Record<string, string> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof v === 'string') deps[k] = v
+    }
+    if (Object.keys(deps).length > 0) out[field] = deps
+  }
+  return out
+}

--- a/src/init/restart-deps-preflight.ts
+++ b/src/init/restart-deps-preflight.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { readFile, readdir } from 'node:fs/promises'
-import { isAbsolute, join } from 'node:path'
+import { isAbsolute, join, relative, resolve } from 'node:path'
 
 import { PACKAGE_FILE } from './packagejson'
 import { PACKAGES_DIR } from './paths'
@@ -39,10 +39,19 @@ export async function validateRestartDeps(options: RestartDepsPreflightOptions):
   return { ok: true }
 }
 
+// Mirrors loadLocal() in src/plugin/loader.ts: a local plugin entry is resolved
+// against cwd and confined to it (`rel.startsWith('..') || isAbsolute(rel)`
+// throws). An escaping entry (`../x`, `/abs/x`) that happens to EXIST passes a
+// bare existsSync but the loader rejects it post-stop — so the escape check must
+// run before, and independently of, the existence check.
 function checkLocalPluginPaths(cwd: string, plugins: readonly string[]): string | null {
   for (const entry of plugins) {
     if (!isLocalEntry(entry)) continue
-    const resolved = isAbsolute(entry) ? entry : join(cwd, entry)
+    const resolved = resolve(cwd, entry)
+    const rel = relative(cwd, resolved)
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      return `local plugin "${entry}" referenced in typeclaw.json#plugins escapes the agent directory; the plugin loader confines local plugins to the agent folder and would reject it after the container has stopped. Use a path inside the agent folder before restarting.`
+    }
     if (!existsSync(resolved)) {
       return `local plugin "${entry}" referenced in typeclaw.json#plugins does not exist on disk; restart would fail at dependency install. Remove the entry or restore the path before restarting.`
     }


### PR DESCRIPTION
## Background

The hostd restart path is **destroy-then-recreate**: when an agent calls the `restart` tool (or the TUI sends `/restart`), the host daemon ACKs, the container exits, and the supervisor runs `stop()` (`docker stop` + `docker rm -f` — the old container is **gone**) followed by `start()`. `start()` then runs `reconcilePluginDeps()` → `ensureDeps()` (`bun install`).

If the agent edited its own `typeclaw.json#plugins` or a `packages/*` manifest into a state bun can't resolve, that `bun install` aborts **after** the old container is already destroyed. There is no rollback, and `src/hostd/supervisor.ts` only logs `restart-failed` with no connected client to receive it — so **the agent self-locks out and stays stopped**.

The canonical trigger seen in the wild: a half-migrated local plugin under `packages/*` still pinning `"typeclaw": "workspace:*"` after `typeclaw` became an external npm dep. `bun install` aborts the whole transaction with `error: typeclaw@workspace:* failed to resolve`.

## Summary

Extend the **existing** `RestartPreflight` hook — already invoked in `src/hostd/daemon.ts` **before** `stop()`, while the healthy container is still alive — with a static check of the agent's on-disk manifests. When the check detects a deterministic dependency-resolution failure, the restart is **refused** and the running container keeps serving.

A bad self-edit now becomes **"restart refused, agent keeps running"** instead of **"agent bricked"**.

Detected failure classes (both deterministic, local, install-aborting):
- a `packages/*` workspace member declaring `"<dep>": "workspace:*"` where `<dep>` is **not** itself a workspace member (the canonical lockout, across `dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies`);
- a local-path plugin in `typeclaw.json#plugins` (`./`, `../`, or absolute) that doesn't exist on disk.

## Design notes

**Mirrors the warn-instead-of-block philosophy for unresolvable plugins:** only **deterministic local config errors** block the restart. The validator does **no bun invocation and no network access** — pure filesystem + JSON parsing — so a transient registry hiccup, a missing bun, or a cache flake can never strand a healthy agent.

**The preflight must never become a new lockout vector.** Every inconclusive state fails *open* (allows the restart):
- config unreadable/unparseable → proceed (read through `loadConfigSync`; schema-invalid configs are still caught later in `buildHostdRestart` before `stop()`);
- no `packages/` directory → proceed;
- a member manifest that's missing or unparseable → skipped, not failed.

`start()` remains the real fail-closed gate for everything the static check doesn't model.

## What this does NOT do

- Does not run `bun install` (real or `--dry-run`) — `--dry-run` still hits the registry and could turn a network blip into a false refusal.
- Does not mutate the live agent's `package.json` / `bun.lock` / `node_modules` (the running container is bind-mounted to the agent folder).
- Does not attempt rollback or retry after `stop()` — it prevents the destructive step from being reached at all.
- Does not change the host-side `typeclaw restart` CLI ordering or any other start-path behavior.

## Files changed

- **`src/init/restart-deps-preflight.ts`** (new) — `validateRestartDeps({ cwd, plugins })`: static, non-mutating detector for the two failure classes above.
- **`src/cli/hostd.ts`** — `buildHostdRestartPreflight` now takes an injectable `HostdPreflightDeps` (`loadConfigSync` + `validateRestartDeps`), reads `plugins` from config, and refuses the restart on a deterministic failure (after the existing source-drift check).
- **`src/init/restart-deps-preflight.test.ts`** (new) — 9 cases: refuses the `workspace:*` non-member class; allows real workspace members, registry-versioned deps, missing `packages/`, unparseable manifests (skip-not-fail), dev/peer-dep coverage, missing/existing local plugin paths, bare registry plugin names.
- **`src/cli/hostd.test.ts`** — 4 cases: preflight refuses on failed dep validation; passes `plugins` from config into the validator; proceeds when config can't be read.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings in untouched files)
- `bun run format:check` — all files correctly formatted
- `bun run test` — 8538 pass, 1 skip, 0 fail (433 files)
