### PR TITLE
fix(channels): re-seed restart-resume turn with the triggering author

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -383,6 +383,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
                     originatingSessionId: sessionManager.getSessionId(),
                     ...(options.stream ? { stream: options.stream } : {}),
                     ...buildRestartHandoffWiring(options, sessionManager),
+                    triggeringAuthorIdProvider: () => currentChannelAuthor(getOrigin),
                   }),
                 ]
               : []),
@@ -512,12 +513,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 export function buildRestartHandoffWiring(
   options: { origin?: SessionOrigin; plugins?: { agentDir: string } },
   sessionManager: SessionManager,
-): {
-  agentDir?: string
-  originatingSessionFile?: string
-  handoffOrigin?: RestartHandoffOrigin
-  triggeringAuthorId?: string
-} {
+): { agentDir?: string; originatingSessionFile?: string; handoffOrigin?: RestartHandoffOrigin } {
   const origin = options.origin
   if (origin === undefined) return {}
   const handoffOrigin = restartHandoffOriginFor(origin)
@@ -525,13 +521,17 @@ export function buildRestartHandoffWiring(
   const agentDir = options.plugins?.agentDir
   const sessionFile = sessionManager.getSessionFile()
   if (agentDir === undefined || sessionFile === undefined) return {}
-  const triggeringAuthorId = origin.kind === 'channel' ? origin.lastInboundAuthorId : undefined
-  return {
-    agentDir,
-    originatingSessionFile: sessionFile,
-    handoffOrigin,
-    ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
-  }
+  return { agentDir, originatingSessionFile: sessionFile, handoffOrigin }
+}
+
+// Reads the LIVE turn author at restart time, not the session-creation
+// snapshot. A channel session is long-lived and multi-principal: the
+// self-restart tool fires on whatever turn triggered it, so the handoff must
+// carry that turn's author (originRef.current), not whoever first opened the
+// session. Returns undefined for non-channel/no-author origins.
+export function currentChannelAuthor(getOrigin: () => SessionOrigin | undefined): string | undefined {
+  const origin = getOrigin()
+  return origin?.kind === 'channel' ? origin.lastInboundAuthorId : undefined
 }
 
 function restartHandoffOriginFor(origin: SessionOrigin): RestartHandoffOrigin | null {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -512,7 +512,12 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 export function buildRestartHandoffWiring(
   options: { origin?: SessionOrigin; plugins?: { agentDir: string } },
   sessionManager: SessionManager,
-): { agentDir?: string; originatingSessionFile?: string; handoffOrigin?: RestartHandoffOrigin } {
+): {
+  agentDir?: string
+  originatingSessionFile?: string
+  handoffOrigin?: RestartHandoffOrigin
+  triggeringAuthorId?: string
+} {
   const origin = options.origin
   if (origin === undefined) return {}
   const handoffOrigin = restartHandoffOriginFor(origin)
@@ -520,7 +525,13 @@ export function buildRestartHandoffWiring(
   const agentDir = options.plugins?.agentDir
   const sessionFile = sessionManager.getSessionFile()
   if (agentDir === undefined || sessionFile === undefined) return {}
-  return { agentDir, originatingSessionFile: sessionFile, handoffOrigin }
+  const triggeringAuthorId = origin.kind === 'channel' ? origin.lastInboundAuthorId : undefined
+  return {
+    agentDir,
+    originatingSessionFile: sessionFile,
+    handoffOrigin,
+    ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
+  }
 }
 
 function restartHandoffOriginFor(origin: SessionOrigin): RestartHandoffOrigin | null {

--- a/src/agent/restart-handoff-wiring.test.ts
+++ b/src/agent/restart-handoff-wiring.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { SessionManager } from '@mariozechner/pi-coding-agent'
 
-import { buildRestartHandoffWiring } from './index'
+import { buildRestartHandoffWiring, currentChannelAuthor } from './index'
 import type { SessionOrigin } from './session-origin'
 
 function fakeSessionManager(sessionFile: string | undefined): SessionManager {
@@ -43,14 +43,6 @@ describe('buildRestartHandoffWiring', () => {
     })
   })
 
-  test('carries the channel author into the handoff so a self-restart re-seeds the requester', () => {
-    const result = buildRestartHandoffWiring(
-      { origin: { ...channelOrigin, lastInboundAuthorId: 'U_OWNER' }, plugins: { agentDir: '/agent' } },
-      fakeSessionManager('/agent/sessions/ses-3.jsonl'),
-    )
-    expect(result.triggeringAuthorId).toBe('U_OWNER')
-  })
-
   test('emits nothing for cron / subagent / system origins', () => {
     const cron: SessionOrigin = { kind: 'cron', jobId: 'j1', jobKind: 'prompt' }
     const subagent: SessionOrigin = { kind: 'subagent', subagent: 'explorer', parentSessionId: 'p1' }
@@ -78,5 +70,28 @@ describe('buildRestartHandoffWiring', () => {
     expect(
       buildRestartHandoffWiring({ plugins: { agentDir: '/agent' } }, fakeSessionManager('/agent/sessions/ses-1.jsonl')),
     ).toEqual({})
+  })
+})
+
+describe('currentChannelAuthor', () => {
+  test('reads the LIVE turn author, not the session-creation author', () => {
+    // given: a live origin holder advanced to a SECOND author after creation
+    const ref: { current: SessionOrigin | undefined } = {
+      current: { ...channelOrigin, lastInboundAuthorId: 'U_OPENER' },
+    }
+    const getOrigin = (): SessionOrigin | undefined => ref.current
+    expect(currentChannelAuthor(getOrigin)).toBe('U_OPENER')
+
+    // when: a different speaker drives the current turn
+    ref.current = { ...channelOrigin, lastInboundAuthorId: 'U_LATER' }
+
+    // then: the provider reflects the current turn, not the opener
+    expect(currentChannelAuthor(getOrigin)).toBe('U_LATER')
+  })
+
+  test('returns undefined for tui and channel-without-author origins', () => {
+    expect(currentChannelAuthor(() => tuiOrigin)).toBeUndefined()
+    expect(currentChannelAuthor(() => channelOrigin)).toBeUndefined()
+    expect(currentChannelAuthor(() => undefined)).toBeUndefined()
   })
 })

--- a/src/agent/restart-handoff-wiring.test.ts
+++ b/src/agent/restart-handoff-wiring.test.ts
@@ -43,6 +43,14 @@ describe('buildRestartHandoffWiring', () => {
     })
   })
 
+  test('carries the channel author into the handoff so a self-restart re-seeds the requester', () => {
+    const result = buildRestartHandoffWiring(
+      { origin: { ...channelOrigin, lastInboundAuthorId: 'U_OWNER' }, plugins: { agentDir: '/agent' } },
+      fakeSessionManager('/agent/sessions/ses-3.jsonl'),
+    )
+    expect(result.triggeringAuthorId).toBe('U_OWNER')
+  })
+
   test('emits nothing for cron / subagent / system origins', () => {
     const cron: SessionOrigin = { kind: 'cron', jobId: 'j1', jobKind: 'prompt' }
     const subagent: SessionOrigin = { kind: 'subagent', subagent: 'explorer', parentSessionId: 'p1' }

--- a/src/agent/restart-handoff/index.test.ts
+++ b/src/agent/restart-handoff/index.test.ts
@@ -60,6 +60,14 @@ describe('writeRestartHandoff', () => {
     expect(result).toEqual(channelHandoff())
   })
 
+  test('round-trips a triggeringAuthorId so the resumed session re-seeds the requester', async () => {
+    await writeRestartHandoff(agentDir, channelHandoff({ triggeringAuthorId: 'U_OWNER' }))
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result?.triggeringAuthorId).toBe('U_OWNER')
+  })
+
   test('creates the .typeclaw/ directory on demand', async () => {
     expect(existsSync(join(agentDir, '.typeclaw'))).toBe(false)
     await writeRestartHandoff(agentDir, tuiHandoff())
@@ -165,6 +173,16 @@ describe('consumeRestartHandoff', () => {
 
     expect(result).toBeNull()
     expect(existsSync(path)).toBe(false)
+  })
+
+  test('ignores a non-string triggeringAuthorId instead of rejecting the handoff', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(path, JSON.stringify({ ...channelHandoff(), triggeringAuthorId: 42 }))
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result?.origin.kind).toBe('channel')
+    expect(result?.triggeringAuthorId).toBeUndefined()
   })
 
   test('returns null when a v2 channel handoff is missing its key', async () => {

--- a/src/agent/restart-handoff/index.ts
+++ b/src/agent/restart-handoff/index.ts
@@ -35,6 +35,13 @@ export type RestartHandoff = {
   originatingSessionId: string
   originatingSessionFile: string
   origin: RestartHandoffOrigin
+  // Author of the inbound that owned the originating session at restart time.
+  // The synthetic resume turn has no inbound of its own, so without this a
+  // multi-principal channel session re-seeds its turn author from nothing and
+  // an author-scoped role (`discord:* author:U_OWNER`) silently demotes to
+  // whatever bare-channel rule matches on every "I'm back" turn. Optional and
+  // additive: pre-field v2 handoffs and tui handoffs omit it.
+  triggeringAuthorId?: string
 }
 
 // Atomic write via `.tmp` + rename so a crash mid-write never leaves the
@@ -158,6 +165,9 @@ function parseHandoff(raw: string): RestartHandoff | null {
     originatingSessionId: obj.originatingSessionId,
     originatingSessionFile: obj.originatingSessionFile,
     origin,
+    ...(typeof obj.triggeringAuthorId === 'string' && obj.triggeringAuthorId !== ''
+      ? { triggeringAuthorId: obj.triggeringAuthorId }
+      : {}),
   }
 }
 

--- a/src/agent/restart/index.test.ts
+++ b/src/agent/restart/index.test.ts
@@ -142,6 +142,33 @@ describe('requestContainerRestart', () => {
     })
   })
 
+  test('writes triggeringAuthorId into the handoff so the resumed session re-seeds the requester', async () => {
+    // given: a hostd that accepts the restart
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+
+    // when: a channel restart carries the invoker's author
+    await requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      agentDir,
+      originatingSessionId: 'ses-origin',
+      originatingSessionFile: '/tmp/sessions/ses-origin.jsonl',
+      handoffOrigin: { kind: 'channel', key: { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null } },
+      triggeringAuthorId: 'U_OWNER',
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+
+    // then: the written handoff carries the author end-to-end
+    expect(JSON.parse(await readFile(restartHandoffPath(agentDir), 'utf8')).triggeringAuthorId).toBe('U_OWNER')
+  })
+
   test('publishes a container-restarting broadcast before writing the handoff on a successful ACK', async () => {
     // given: a stream whose subscriber records broadcasts, and a hostd that
     // accepts. The broadcast must carry the originating session id so the

--- a/src/agent/restart/index.ts
+++ b/src/agent/restart/index.ts
@@ -35,6 +35,10 @@ export type RequestContainerRestartOptions = {
   // startup). Required alongside agentDir + originatingSessionFile for the
   // handoff to be written; omitting it skips the handoff entirely.
   handoffOrigin?: RestartHandoffOrigin
+  // Author of the inbound that owned the restarting session, carried so the
+  // reopened channel session re-seeds the requester's identity on its resume
+  // turn (see RestartHandoff.triggeringAuthorId).
+  triggeringAuthorId?: string
   restartedAt?: string
 }
 
@@ -54,6 +58,7 @@ export async function requestContainerRestart({
   originatingSessionId,
   originatingSessionFile,
   handoffOrigin,
+  triggeringAuthorId,
   restartedAt,
 }: RequestContainerRestartOptions): Promise<RequestContainerRestartResult> {
   const request = { kind: 'restart' as const, containerName, build: build === true }
@@ -103,6 +108,7 @@ export async function requestContainerRestart({
         originatingSessionId,
         originatingSessionFile: basename(originatingSessionFile),
         origin: handoffOrigin,
+        ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
       })
     } catch {
       // intentional swallow — see the post-ACK rationale above

--- a/src/agent/tools/restart.test.ts
+++ b/src/agent/tools/restart.test.ts
@@ -372,6 +372,35 @@ describe('createRestartTool restart-pending handoff', () => {
     expect(parsed.originatingSessionFile).toBe('ses-channel.jsonl')
   })
 
+  test('writes the LIVE turn author into the handoff, not the session-creation author', async () => {
+    // given: the provider tracks a mutable holder advanced after construction
+    server = startOkServer()
+    const liveAuthor = { current: 'U_OPENER' as string | undefined }
+    const tool = createRestartTool({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      hostdToken: 'secret',
+      originatingSessionId: 'ses-channel',
+      exit: () => {},
+      agentDir,
+      originatingSessionFile: '/some/abs/path/ses-channel.jsonl',
+      handoffOrigin: {
+        kind: 'channel',
+        key: { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null },
+      },
+      triggeringAuthorIdProvider: () => liveAuthor.current,
+    })
+
+    // when: a different speaker drives the turn that fires the restart
+    liveAuthor.current = 'U_LATER'
+    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+
+    // then: the handoff carries the current-turn author, not the opener
+    const parsed = JSON.parse(await readFile(restartHandoffPath(agentDir), 'utf8'))
+    expect(parsed.triggeringAuthorId).toBe('U_LATER')
+  })
+
   test('skips the handoff when handoffOrigin is omitted (cron/subagent/system origins)', async () => {
     // given
     server = startOkServer()

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -57,10 +57,12 @@ export type CreateRestartToolOptions = {
   // alongside `originatingSessionFile` for the handoff to be written; omit to
   // skip the handoff. See buildRestartHandoffWiring in src/agent/index.ts.
   handoffOrigin?: RestartHandoffOrigin
-  // Author of the inbound that owned this session, carried into the handoff so
-  // a channel self-restart resumes under the requester's author-scoped role
-  // (see RestartHandoff.triggeringAuthorId). Omitted for tui/no-author origins.
-  triggeringAuthorId?: string
+  // Resolves the LIVE turn author at execute time (not session-creation), so a
+  // channel self-restart in a long-lived multi-principal session resumes under
+  // the author of the turn that triggered the restart — not whoever opened the
+  // session. Called inside execute(); returns undefined for tui/no-author
+  // origins. See RestartHandoff.triggeringAuthorId.
+  triggeringAuthorIdProvider?: () => string | undefined
 }
 
 export type RestartToolDetails = { ok: boolean; containerName: string; reason?: string }
@@ -79,7 +81,7 @@ export function createRestartTool({
   agentDir,
   originatingSessionFile,
   handoffOrigin,
-  triggeringAuthorId,
+  triggeringAuthorIdProvider,
 }: CreateRestartToolOptions) {
   const doExit = exit ?? ((code: number) => process.exit(code))
 
@@ -108,6 +110,7 @@ export function createRestartTool({
     }),
     async execute(_toolCallId, params) {
       const build = params.build === true
+      const triggeringAuthorId = triggeringAuthorIdProvider?.()
       // requestContainerRestart owns the post-ACK broadcast->handoff ordering:
       // on a successful ACK it publishes the container-restarting notice (which
       // every live session's subscribeRestartNotice turns into a transcript

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -57,6 +57,10 @@ export type CreateRestartToolOptions = {
   // alongside `originatingSessionFile` for the handoff to be written; omit to
   // skip the handoff. See buildRestartHandoffWiring in src/agent/index.ts.
   handoffOrigin?: RestartHandoffOrigin
+  // Author of the inbound that owned this session, carried into the handoff so
+  // a channel self-restart resumes under the requester's author-scoped role
+  // (see RestartHandoff.triggeringAuthorId). Omitted for tui/no-author origins.
+  triggeringAuthorId?: string
 }
 
 export type RestartToolDetails = { ok: boolean; containerName: string; reason?: string }
@@ -75,6 +79,7 @@ export function createRestartTool({
   agentDir,
   originatingSessionFile,
   handoffOrigin,
+  triggeringAuthorId,
 }: CreateRestartToolOptions) {
   const doExit = exit ?? ((code: number) => process.exit(code))
 
@@ -121,6 +126,7 @@ export function createRestartTool({
         ...(agentDir !== undefined ? { agentDir } : {}),
         ...(originatingSessionFile !== undefined ? { originatingSessionFile } : {}),
         ...(handoffOrigin !== undefined ? { handoffOrigin } : {}),
+        ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
       })
       if (!result.ok) {
         const details: RestartToolDetails = { ok: false, containerName, reason: result.reason }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -9140,4 +9140,31 @@ describe('resumeRestartHandoff', () => {
     expect(reservation.sawInbound).toBe(false)
     expect(sessions[0]?.prompts.some((p) => p.includes('container just restarted'))).toBe(true)
   })
+
+  test('resume wake turn re-seeds the handoff author so author-scoped roles survive restart', async () => {
+    // given: a handoff carrying the owner who issued /restart
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const { router, sessions } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+    const reservation = router.reserveRestartHandoff(channelHandoff({ triggeringAuthorId: 'U_OWNER' }))!
+
+    let originDuringWake: SessionOrigin | undefined
+    const captureOrigin = (): void => {
+      originDuringWake = router.__testing!.getLiveOriginSnapshot(KEY)
+    }
+
+    // when: the synthetic wake turn drains
+    await reservation.resume()
+    await waitFor(() => sessions.length > 0)
+    sessions[0]!.onPrompt = captureOrigin
+    if (sessions[0]!.prompts.length > 0) captureOrigin()
+    await waitFor(() => originDuringWake !== undefined)
+
+    // then: the wake turn's origin carries the handoff author, not nothing
+    expect(originDuringWake?.kind).toBe('channel')
+    if (originDuringWake?.kind !== 'channel') throw new Error('unreachable')
+    expect(originDuringWake.lastInboundAuthorId).toBe('U_OWNER')
+  })
 })

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7355,6 +7355,30 @@ describe('ChannelRouter /reload and /restart (session.admin gate)', () => {
     expect(captured?.handoffOrigin).toEqual({ kind: 'channel', key: KEY })
   })
 
+  test('/restart stamps triggeringAuthorId from the command invoker, not the last live-turn speaker', async () => {
+    // given: a session whose last turn was spoken by `stranger`, but /restart
+    // is invoked by `owner` — the resume must follow the invoker's role.
+    const dir = await tempDir()
+    let captured: RestartCommandContext | undefined
+    const { router } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-01-01T00-00-00-000Z_${sessionId}.jsonl`,
+      onRestart: async (ctx) => {
+        captured = ctx
+        return 'restarting'
+      },
+    })
+    await router.route(inbound({ authorId: 'stranger', authorName: 'stranger' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.liveCount()).toBe(1)
+
+    // when: the owner invokes /restart via the native dispatch path
+    await router.executeCommand(KEY, 'restart', { invokerId: 'owner' })
+
+    // then: the handoff carries the invoker, not the prior speaker
+    expect(captured?.originatingSessionId).toBe('ses_fake_1')
+    expect(captured?.triggeringAuthorId).toBe('owner')
+  })
+
   test('/restart passes undefined context when no session is live', async () => {
     // given: no live session for the channel
     const dir = await tempDir()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -691,6 +691,12 @@ type LiveSession = {
 type ChannelCommandContext = {
   live: LiveSession | null
   event: InboundMessage | null
+  // The user who actually invoked the command, supplied by BOTH dispatch
+  // paths (text: event.authorId; native slash: options.invokerId, where
+  // event is null). /restart stamps the resume handoff's triggeringAuthorId
+  // from this so a restart resumes under the INVOKER's author-scoped role,
+  // not whichever speaker happened to own the live turn.
+  invokerId: string | null
 }
 
 export type ExecuteCommandResult =
@@ -1126,8 +1132,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // Resolve the live session when one exists so the restart can write a
       // resume handoff for this conversation; still bounces from a cold channel.
       wantsLiveSession: true,
-      handler: async ({ live }) => ({
-        reply: await onRestart(live !== null ? buildRestartCommandContext(live) : undefined),
+      handler: async ({ live, invokerId }) => ({
+        reply: await onRestart(live !== null ? buildRestartCommandContext(live, invokerId) : undefined),
       }),
     })
   }
@@ -1924,8 +1930,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
-  const buildRestartCommandContext = (live: LiveSession): RestartCommandContext => {
-    const triggeringAuthorId = live.currentTurnAuthorId ?? live.lastTurnAuthorId ?? undefined
+  const buildRestartCommandContext = (live: LiveSession, invokerId: string | null): RestartCommandContext => {
+    // Prefer the command invoker: a restart resumes under the author who ran
+    // /restart, not whichever speaker last owned the live turn. Fall back to
+    // live turn state only when the dispatch path supplied no invoker.
+    const triggeringAuthorId = invokerId ?? live.currentTurnAuthorId ?? live.lastTurnAuthorId ?? undefined
     return {
       originatingSessionId: live.sessionId,
       ...(live.getTranscriptPath?.() !== undefined ? { originatingSessionFile: live.getTranscriptPath!()! } : {}),
@@ -2235,7 +2244,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // Gating (channel.respond / session.control) and live-session resolution stay
   // at the call sites — this helper only runs the handler and delivers the reply.
   const runChannelCommand = async (event: InboundMessage, live: LiveSession | null): Promise<CommandResult> => {
-    const result = await commands.execute(event.text, { live, event })
+    const result = await commands.execute(event.text, { live, event, invokerId: event.authorId })
     if (result.kind === 'handled' && result.reply !== undefined) {
       await send(
         {
@@ -3786,7 +3795,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const resolved = resolveLiveSessionForCommand(liveSessions, key)
       live = resolved.kind === 'found' ? resolved.session : null
     }
-    const result = await commands.execute(`/${lowered}`, { live, event: null })
+    const result = await commands.execute(`/${lowered}`, { live, event: null, invokerId: options.invokerId })
     if (result.kind === 'handled') {
       return result.reply !== undefined
         ? { kind: 'handled', name: result.name, reply: result.reply }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -999,6 +999,7 @@ export type RestartCommandContext = {
   originatingSessionId: string
   originatingSessionFile?: string
   handoffOrigin: { kind: 'channel'; key: ChannelKey }
+  triggeringAuthorId?: string
 }
 
 export type ClaimHandlerInput = {
@@ -1126,17 +1127,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // resume handoff for this conversation; still bounces from a cold channel.
       wantsLiveSession: true,
       handler: async ({ live }) => ({
-        reply: await onRestart(
-          live !== null
-            ? {
-                originatingSessionId: live.sessionId,
-                ...(live.getTranscriptPath?.() !== undefined
-                  ? { originatingSessionFile: live.getTranscriptPath!()! }
-                  : {}),
-                handoffOrigin: { kind: 'channel', key: live.key },
-              }
-            : undefined,
-        ),
+        reply: await onRestart(live !== null ? buildRestartCommandContext(live) : undefined),
       }),
     })
   }
@@ -1930,6 +1921,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       })
     } catch (err) {
       logger.warn(`[channels] session.turn.end hook threw for ${live.keyId}: ${describe(err)}`)
+    }
+  }
+
+  const buildRestartCommandContext = (live: LiveSession): RestartCommandContext => {
+    const triggeringAuthorId = live.currentTurnAuthorId ?? live.lastTurnAuthorId ?? undefined
+    return {
+      originatingSessionId: live.sessionId,
+      ...(live.getTranscriptPath?.() !== undefined ? { originatingSessionFile: live.getTranscriptPath!()! } : {}),
+      handoffOrigin: { kind: 'channel', key: live.key },
+      ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
     }
   }
 
@@ -3686,7 +3687,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
         let live: LiveSession
         try {
-          live = await ensureLive(key, undefined, undefined, {
+          live = await ensureLive(key, undefined, handoff.triggeringAuthorId, {
             sessionId: handoff.originatingSessionId,
             sessionFile: handoff.originatingSessionFile,
           })

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -321,6 +321,7 @@ export async function startAgent({
                 ? { originatingSessionFile: ctx.originatingSessionFile }
                 : {}),
               handoffOrigin: ctx.handoffOrigin,
+              ...(ctx.triggeringAuthorId !== undefined ? { triggeringAuthorId: ctx.triggeringAuthorId } : {}),
             }
           : {}),
       })


### PR DESCRIPTION
## Problem

A channel session is **multi-principal**: one session, many speakers. The per-turn author identity (`lastInboundAuthorId`) is what drives role resolution, so an author-scoped role like `discord:* author:U_OWNER` correctly resolves *per speaker* on normal turns.

But the **restart-resume wake turn** broke this. When the container restarts, the originating channel session is reopened via:

```ts
ensureLive(key, undefined, /* triggeringAuthorId */ undefined, { sessionId, sessionFile })
```

The synthetic "I'm back" turn has no inbound of its own, and `triggeringAuthorId` was `undefined`, so the reopened session seeded its turn author (`lastTurnAuthorId`, read by the reminder-only drain branch) from **nothing**. An author-scoped owner rule then resolved to whatever bare-channel rule matched (e.g. `member: ["*"]`), **silently demoting the operator to member on every resume turn**. Owner-only `tool.before` guards (e.g. `pluginAddition`) consequently blocked the operator after a restart, even though their config pins them as owner.

This is why an owner editing `plugins[]` from a channel kept getting:
```
blocked: Guard pluginAddition blocked edit on /agent/typeclaw.json …
```
right after each restart — the resume turn no longer carried their identity.

## Fix

Carry the originating session's author through the restart handoff and thread it back into `ensureLive` on resume, so the wake turn re-seeds the requester's identity and author-scoped roles **survive the restart**.

- `RestartHandoff` gains an optional, additive `triggeringAuthorId` (round-trips through write/parse; pre-field v2 handoffs and TUI handoffs simply omit it; non-string values are ignored, not rejected).
- `requestContainerRestart` accepts and persists `triggeringAuthorId`.
- The channel `/restart` command stamps it from the live session's current/last turn author.
- On resume, `handoff.triggeringAuthorId` is passed as `ensureLive`'s `triggeringAuthorId`, which re-seeds `lastTurnAuthorId` through the existing seeding path.

### Scope

Only the **restart-resume** path is changed. TUI, cron, and subagent origins are single-principal (no other user can jump into the session mid-flight), so they keep following their origin/provenance role unchanged. Subagent-completion and idle-continuation reminders already restore the prior speaker via existing, well-tested semantics and are intentionally left as-is.

## Tests

- `restart-handoff`: `triggeringAuthorId` round-trips; a non-string value is ignored rather than rejecting the handoff.
- `router`: the resume wake turn's live origin carries the handoff author. Verified red→green: reverting the `ensureLive` thread makes the new test fail with `undefined`.
- Full suite green (8529 pass / 0 fail). `typecheck`, `lint` (0 errors), `format` all clean.