### PR TITLE
perf(channels): start adapters concurrently instead of serially

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -313,6 +313,37 @@ describe('channel manager — restartAdapter serialization', () => {
     await mgr.stop()
   })
 
+  test('start() failure waits for in-flight siblings so none orphan past stop()', async () => {
+    cfg['slack-bot'] = enabledAdapterCfg()
+    cfg['telegram-bot'] = enabledAdapterCfg()
+    const events: string[] = []
+    const slackStartGate = deferred()
+    const slack = makeRecordingAdapter(events, 'slack', { start: slackStartGate.promise })
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b', TELEGRAM_BOT_TOKEN: 'tg-a' },
+      createSlackAdapter: () => slack,
+      createTelegramAdapter: () => {
+        throw new Error('hostd env missing')
+      },
+    })
+
+    const startCall = mgr.start()
+    // Let the telegram factory throw while slack's start() is still gated open.
+    await Promise.resolve()
+    expect(events).toEqual(['slack:start:begin'])
+
+    // Releasing slack lets it register in `live`; start() must not reject until
+    // that settles, otherwise the late registration would orphan slack.
+    slackStartGate.resolve()
+    await expect(startCall).rejects.toThrow('hostd env missing')
+    expect(slack.startCalls).toBe(1)
+
+    await mgr.stop()
+    expect(events).toContain('slack:stop:begin')
+  })
+
   test('passes tunnelUrlForChannel through to the github adapter', async () => {
     cfg.github = enabledGithubCfg()
     await writeGithubSecrets(agentDir)

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -268,6 +268,36 @@ describe('channel manager — restartAdapter serialization', () => {
     await mgr.stop()
   })
 
+  test('starts adapters concurrently rather than serially', async () => {
+    cfg['slack-bot'] = enabledAdapterCfg()
+    cfg['telegram-bot'] = enabledAdapterCfg()
+    const events: string[] = []
+    const slackStartGate = deferred()
+    const telegramStartGate = deferred()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b', TELEGRAM_BOT_TOKEN: 'tg-a' },
+      createSlackAdapter: () => makeRecordingAdapter(events, 'slack', { start: slackStartGate.promise }),
+      createTelegramAdapter: () => makeRecordingAdapter(events, 'telegram', { start: telegramStartGate.promise }),
+    })
+
+    const startCall = mgr.start()
+    await Promise.resolve()
+
+    // Both adapters have begun starting while neither has finished — impossible
+    // under serial start, where slack would block telegram until its gate opens.
+    expect(events).toEqual(['slack:start:begin', 'telegram:start:begin'])
+
+    slackStartGate.resolve()
+    telegramStartGate.resolve()
+    await startCall
+
+    expect(events).toContain('slack:start:end')
+    expect(events).toContain('telegram:start:end')
+    await mgr.stop()
+  })
+
   test('passes tunnelUrlForChannel through to the github adapter', async () => {
     cfg.github = enabledGithubCfg()
     await writeGithubSecrets(agentDir)

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -298,6 +298,21 @@ describe('channel manager — restartAdapter serialization', () => {
     await mgr.stop()
   })
 
+  test('start() rejects when adapter construction throws outside startAdapter catch', async () => {
+    cfg['slack-bot'] = enabledAdapterCfg()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { SLACK_BOT_TOKEN: 'xoxb-a', SLACK_APP_TOKEN: 'xapp-b' },
+      createSlackAdapter: () => {
+        throw new Error('hostd env missing')
+      },
+    })
+
+    await expect(mgr.start()).rejects.toThrow('hostd env missing')
+    await mgr.stop()
+  })
+
   test('passes tunnelUrlForChannel through to the github adapter', async () => {
     cfg.github = enabledGithubCfg()
     await writeGithubSecrets(agentDir)

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -300,16 +300,19 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       // Safe to fan out: `live` and every router registry are keyed by adapter
       // name, so concurrent starts never collide. Serial start would otherwise pay
       // the sum of each adapter's connect latency instead of just the slowest.
-      // `Promise.all` (not `allSettled`) keeps the prior fail-fast contract:
-      // `startAdapter` already converts expected per-adapter failures to `false`,
-      // so a rejection here is an unexpected throw (e.g. `buildAdapter`) that must
-      // still surface rather than be swallowed.
-      await Promise.all(
-        ADAPTER_IDS.flatMap((name) => {
-          const adapterCfg = cfg[name]
-          return adapterCfg === undefined ? [] : [runSerially(name, () => startAdapter(name, adapterCfg))]
-        }),
-      )
+      const starts = ADAPTER_IDS.flatMap((name) => {
+        const adapterCfg = cfg[name]
+        return adapterCfg === undefined ? [] : [runSerially(name, () => startAdapter(name, adapterCfg))]
+      })
+      // Await every launched start to settle BEFORE surfacing a failure.
+      // `startAdapter` converts expected per-adapter failures to `false`, so a
+      // rejection is an unexpected throw (e.g. `buildAdapter`) that must still
+      // fail-fast. But bailing on the first rejection (plain `Promise.all`) would
+      // leave sibling starts in flight, letting a late `live.set` orphan an adapter
+      // that the caller's subsequent `stop()` never sees. Settle all, then rethrow.
+      const results = await Promise.allSettled(starts)
+      const failure = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+      if (failure !== undefined) throw failure.reason
     },
 
     async stop(): Promise<void> {

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -300,7 +300,11 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       // Safe to fan out: `live` and every router registry are keyed by adapter
       // name, so concurrent starts never collide. Serial start would otherwise pay
       // the sum of each adapter's connect latency instead of just the slowest.
-      await Promise.allSettled(
+      // `Promise.all` (not `allSettled`) keeps the prior fail-fast contract:
+      // `startAdapter` already converts expected per-adapter failures to `false`,
+      // so a rejection here is an unexpected throw (e.g. `buildAdapter`) that must
+      // still surface rather than be swallowed.
+      await Promise.all(
         ADAPTER_IDS.flatMap((name) => {
           const adapterCfg = cfg[name]
           return adapterCfg === undefined ? [] : [runSerially(name, () => startAdapter(name, adapterCfg))]

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -297,10 +297,15 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 
     async start(): Promise<void> {
       const cfg = options.channelsConfigRef()
-      for (const name of ADAPTER_IDS) {
-        const adapterCfg = cfg[name]
-        if (adapterCfg !== undefined) await runSerially(name, () => startAdapter(name, adapterCfg))
-      }
+      // Safe to fan out: `live` and every router registry are keyed by adapter
+      // name, so concurrent starts never collide. Serial start would otherwise pay
+      // the sum of each adapter's connect latency instead of just the slowest.
+      await Promise.allSettled(
+        ADAPTER_IDS.flatMap((name) => {
+          const adapterCfg = cfg[name]
+          return adapterCfg === undefined ? [] : [runSerially(name, () => startAdapter(name, adapterCfg))]
+        }),
+      )
     },
 
     async stop(): Promise<void> {


### PR DESCRIPTION
## Background

Channel adapter bootup was serial. `createChannelManager().start()` iterated `ADAPTER_IDS` in a `for...of` loop and `await`ed each `startAdapter()` one at a time, so visible boot time was the **sum** of every configured adapter's connect latency — Discord gateway handshake, GitHub webhook registration, LINE, KakaoTalk, etc. With several channels configured this added multiple seconds of dead wait on every `typeclaw start`.

## Summary

Fan out per-adapter starts with `Promise.allSettled` so the wall-clock cost is the slowest single adapter, not the sum.

```ts
await Promise.allSettled(
  ADAPTER_IDS.flatMap((name) => {
    const adapterCfg = cfg[name]
    return adapterCfg === undefined ? [] : [runSerially(name, () => startAdapter(name, adapterCfg))]
  }),
)
```

This is safe because there is no cross-adapter startup ordering:

- The live-adapter `Map` and every router callback registry (outbound, reaction, typing, membership, history, etc.) are keyed by adapter **name**, so concurrent starts never collide on a shared key.
- `startAdapter` already catches per-adapter errors internally and returns `false`, so one adapter failing never aborts the others — `Promise.allSettled` preserves that isolation.
- The only process-global written during start (`process.env.GH_TOKEN`) is written solely by the GitHub adapter.
- The per-adapter `runSerially` gate is **kept**: it still serializes operations targeting the same adapter name, so a tunnel-bridge `restartAdapter('github')` cannot race the initial `start()` for the same adapter.

## What this does NOT do

- Does not change per-adapter error handling or the `false`/`true` return contract of `startAdapter`.
- Does not remove the `runSerially` gate — intra-adapter serialization is unchanged.
- Does not change any channel adapter implementation; only the fan-out in `manager.ts` changes.

## Review notes

- Load-bearing change: the `Promise.allSettled` fan-out in `src/channels/manager.ts`. The invariant to verify: concurrent starts cannot race on any shared mutable state — confirmed by the name-keyed registry structure above.
- New test `"starts adapters concurrently rather than serially"` in `src/channels/manager.test.ts` gates two adapters' `start()` so neither can finish, then asserts both `:start:begin` events appear before either resolves — impossible under the old serial loop.