### PR TITLE
fix(sandbox): give bun a writable temp dir so sandboxed bunx works

### DIFF
--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -100,11 +100,17 @@ describe('buildSandboxedCommand network policy', () => {
 })
 
 describe('buildSandboxedCommand env policy', () => {
-  test('re-introduces only PATH, HOME, LANG by default after --clearenv', () => {
+  test('re-introduces only the default allowlist after --clearenv', () => {
     const argv = argvOf('true')
     expect(valueAfter(argv, '--setenv')).toBe('PATH')
     const setenvKeys = argv.filter((_, i) => argv[i - 1] === '--setenv')
-    expect(setenvKeys).toEqual(['PATH', 'HOME', 'LANG'])
+    expect(setenvKeys).toEqual(['PATH', 'HOME', 'LANG', 'BUN_TMPDIR', 'BUN_INSTALL'])
+  })
+
+  test('gives bun a writable temp/install dir under /tmp so bunx does not abort', () => {
+    const joined = argvOf('true').join(' ')
+    expect(joined).toContain('--setenv BUN_TMPDIR /tmp')
+    expect(joined).toContain('--setenv BUN_INSTALL /tmp/.bun')
   })
 
   test('applies explicit env.set entries', () => {

--- a/src/sandbox/policy.ts
+++ b/src/sandbox/policy.ts
@@ -142,8 +142,19 @@ export type SandboxPolicy = {
 // guard: the container env holds FIREWORKS_API_KEY and GH_TOKEN, and env
 // inheritance is the single highest-risk exfil path for prompt-injected bash.
 // HOME points at /tmp because the sandbox mounts /tmp as a fresh tmpfs.
+//
+// BUN_TMPDIR / BUN_INSTALL both point under /tmp because `--clearenv` strips
+// the host's TMPDIR, and bun refuses to run without a writable scratch dir it
+// can discover: `bunx`, `bun add`, and `bun run <pkg-bin>` abort with
+// "Unexpected accessing temporary directory. Please set $BUN_TMPDIR or
+// $BUN_INSTALL". /tmp is always writable inside the sandbox (fresh tmpfs, or
+// the per-session bind that overrides it), so both are safe targets. Without
+// these, every sandboxed bun invocation — the core subagent install path —
+// fails before it starts.
 export const DEFAULT_SANDBOX_ENV: Record<string, string> = {
   PATH: '/usr/local/bin:/usr/bin:/bin',
   HOME: '/tmp',
   LANG: 'C.UTF-8',
+  BUN_TMPDIR: '/tmp',
+  BUN_INSTALL: '/tmp/.bun',
 }


### PR DESCRIPTION
## Problem

Running any `bun` package command inside the per-tool bwrap sandbox fails:

```
error: Unexpected accessing temporary directory. Please set $BUN_TMPDIR or $BUN_INSTALL
```

The sandbox (`buildSandboxedCommand`, `src/sandbox/build.ts`) does `--clearenv` and re-introduces only `PATH`, `HOME`, `LANG` via `DEFAULT_SANDBOX_ENV`. That strips the host's `TMPDIR`, and Bun refuses to run without a writable scratch dir it can discover. This breaks `bunx`, `bun add`, and `bun run <pkg-bin>` — i.e. the **core subagent install path** (`bunx agent-*`, `bun add <pkg>`). For an agent, the failure is opaque and the recovery non-obvious: bad UX.

## Fix

Inject Bun's temp/install vars into `DEFAULT_SANDBOX_ENV` (`src/sandbox/policy.ts`):

```ts
BUN_TMPDIR: '/tmp',
BUN_INSTALL: '/tmp/.bun',
```

`/tmp` is **always writable** inside the sandbox — it starts as a fresh `--tmpfs /tmp` (`build.ts`), then the per-session scratch dir is bind-mounted over it (`applyBashSandbox`, `src/agent/plugin-tools.ts`). So both targets are valid with no mount changes needed.

## Why this is safe for the leak guard

`DEFAULT_SANDBOX_ENV` is the load-bearing leak guard (the container env holds `FIREWORKS_API_KEY`/`GH_TOKEN`; env inheritance is the top exfil path for prompt-injected bash). These two additions are **static, non-secret, sandbox-internal paths** — they don't pass through any host value and don't widen what's inherited from `process.env`. The leak guard's invariant ("nothing from the host env leaks unless explicitly named") is preserved.

## Tests

- Updated the default-allowlist assertion in `src/sandbox/build.test.ts` to include the new keys.
- Added a test asserting `--setenv BUN_TMPDIR /tmp` and `--setenv BUN_INSTALL /tmp/.bun` appear in the bwrap argv.
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format`: clean.
- Full `src/sandbox/` suite: 196 pass / 0 fail.
