### PR TITLE
fix(backup): push to remote when tracking is unset and inject App credentials

### DIFF
--- a/src/bundled-plugins/backup/README.md
+++ b/src/bundled-plugins/backup/README.md
@@ -45,7 +45,15 @@ Commit message comes from the `backup-message` subagent, which sees a truncated 
 
 ## What it pushes
 
-When `pushToOrigin: true` and the current branch has an upstream (`git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` succeeds), the runner runs `git push`. On non-fast-forward rejection, it runs `git fetch` then `git rebase <upstream>` then `git push` again.
+When `pushToOrigin: true`, the runner picks a push plan after committing:
+
+- **Branch has an upstream** (`git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` succeeds): run `git push`.
+- **No upstream, but `origin` exists and `HEAD` is a real branch**: run `git push -u origin HEAD:<branch>`, which pushes _and_ establishes tracking in one shot. This is the common case for a fresh agent folder nobody ran `git push -u` on by hand — previously the runner committed forever and never pushed here. Every later cycle then takes the plain-upstream path.
+- **No `origin`, or detached `HEAD`**: commit only (a legitimate offline / no-remote state). No push is attempted and no diagnostics are written.
+
+On non-fast-forward rejection (either push shape), the runner runs `git fetch` then `git rebase <remote-branch>` then re-pushes with the same args. Only `origin` is ever acted on for the set-upstream case — the runner never guesses a destination the operator didn't configure.
+
+**Credentials.** The runner spawns `git` directly (not via the `bash` tool), so the `github-cli-auth` plugin's `tool.before` credential injection does **not** fire for it. For **GitHub App auth** the backup plugin mints a per-repo installation token for `origin`'s github.com slug and injects it into the runner's git env via the same `GIT_ASKPASS` helper the bash path uses (token in `TYPECLAW_GIT_TOKEN`, never in argv/config; ssh remotes rewritten to https via `insteadOf`). Classic/fine-grained PATs, SSH-key, and credential-helper setups are left untouched — the runner uses its inherited process env. Non-github origins are never minted for.
 
 If any network step fails (rebase conflict, auth failure, network timeout), the runner aborts cleanly and spawns the `backup-diagnose` subagent. That subagent has `bash`, `read`, and `write` tools and writes a short human-readable report to `<agentDir>/sessions/backup-diagnostics.log`. The diagnose subagent is explicitly forbidden from force-pushing or resolving merge conflicts itself.
 
@@ -77,5 +85,6 @@ This feature came up as: "periodically check for dirty files and commit; LLM pic
 
 ## Tests
 
-- `runner.test.ts` — deterministic runner unit tests (status parsing, force-add of `sessions/`, push-only-with-upstream, rebase-on-non-fast-forward, diagnose-on-rebase-conflict, advisory-throw isolation, sanitize-commit-message).
+- `runner.test.ts` — deterministic runner unit tests (status parsing, force-add of `sessions/`, push-with-upstream, push-and-set-upstream when origin exists but tracking is absent, commit-only on no-origin / detached-HEAD, rebase-on-non-fast-forward for both push shapes, diagnose-on-rebase-conflict, advisory-throw isolation, sanitize-commit-message).
+- `git-auth.test.ts` — credential-env resolution (App-auth mints for the origin slug; PAT/SSH/non-github/unavailable-token all fall back to inherited env).
 - `index.test.ts` — plugin composition tests (subagent/hook surface, config schema defaults and validation, debounce, active-turn gating, self-induced-turn exclusion, coalescing).

--- a/src/bundled-plugins/backup/git-auth.test.ts
+++ b/src/bundled-plugins/backup/git-auth.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test'
+
+import { type BackupPushAuthDeps, resolveBackupPushAuthEnv } from './git-auth'
+
+const baseDeps = (overrides: Partial<BackupPushAuthDeps> = {}): BackupPushAuthDeps => ({
+  hasAppTokenResolver: () => true,
+  ghToken: undefined,
+  resolveTokenForRepo: async () => ({ kind: 'token', token: 'ghs_minted' }),
+  resolveOriginPushUrl: async () => 'https://github.com/acme/widgets.git',
+  ensureAskPassHelper: async () => '/usr/local/bin/typeclaw-git-askpass',
+  ...overrides,
+})
+
+describe('resolveBackupPushAuthEnv', () => {
+  test('App auth + github.com origin: returns askpass env minted for the origin slug', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', baseDeps())
+    expect(env).not.toBeNull()
+    expect(env).toMatchObject({
+      GIT_ASKPASS: '/usr/local/bin/typeclaw-git-askpass',
+      TYPECLAW_GIT_TOKEN: 'ghs_minted',
+      GIT_TERMINAL_PROMPT: '0',
+    })
+  })
+
+  test('mints for the slug parsed from the origin push url', async () => {
+    let requestedSlug: string | undefined
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      resolveTokenForRepo: async (slug) => {
+        requestedSlug = slug
+        return { kind: 'token', token: 'ghs_x' }
+      },
+    })
+    expect(requestedSlug).toBe('acme/widgets')
+    expect(env).not.toBeNull()
+  })
+
+  test('classic PAT (ghp_): no minting, returns null so inherited env is used', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      hasAppTokenResolver: () => false,
+      ghToken: 'ghp_classic',
+    })
+    expect(env).toBeNull()
+  })
+
+  test('fine-grained PAT (github_pat_): no minting, returns null', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      hasAppTokenResolver: () => false,
+      ghToken: 'github_pat_xyz',
+    })
+    expect(env).toBeNull()
+  })
+
+  test('no App auth and no token: returns null', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      hasAppTokenResolver: () => false,
+      ghToken: undefined,
+    })
+    expect(env).toBeNull()
+  })
+
+  test('non-github origin: returns null so non-github remotes use container creds', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      resolveOriginPushUrl: async () => 'https://gitlab.com/acme/widgets.git',
+    })
+    expect(env).toBeNull()
+  })
+
+  test('no origin url resolvable: returns null', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      resolveOriginPushUrl: async () => null,
+    })
+    expect(env).toBeNull()
+  })
+
+  test('token resolution unavailable: returns null rather than a broken env', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'no installation' }),
+    })
+    expect(env).toBeNull()
+  })
+
+  test('ssh github origin is recognized and minted (askpass applies after insteadOf rewrite)', async () => {
+    const env = await resolveBackupPushAuthEnv('/agent', {
+      ...baseDeps(),
+      resolveOriginPushUrl: async () => 'git@github.com:acme/widgets.git',
+    })
+    expect(env).not.toBeNull()
+    expect(env?.GIT_CONFIG_COUNT).toBe('2')
+  })
+})

--- a/src/bundled-plugins/backup/git-auth.ts
+++ b/src/bundled-plugins/backup/git-auth.ts
@@ -1,0 +1,58 @@
+import type { GithubTokenResolveResult } from '@/channels/github-token-bridge'
+
+import { ensureGitAskPassHelper } from '../github-cli-auth/git-askpass'
+import { parseGithubRepoFromGitUrl } from '../github-cli-auth/git-command'
+import { shouldMintAppToken } from '../github-cli-auth/token-class'
+
+export type BackupGitAuthEnv = Record<string, string>
+
+export type BackupPushAuthDeps = {
+  hasAppTokenResolver: () => boolean
+  ghToken: string | undefined
+  resolveTokenForRepo: (repoSlug: string) => Promise<GithubTokenResolveResult>
+  resolveOriginPushUrl: (cwd: string) => Promise<string | null>
+  ensureAskPassHelper: () => Promise<string>
+}
+
+// The backup runner spawns git directly (not via the bash tool), so the
+// `github-cli-auth` plugin's `tool.before` credential injection never fires for
+// its push. Without this, App-auth agents push with no credentials and fail.
+// We mirror that plugin exactly: only mint for App auth, only for a github.com
+// origin, scoped to the origin's own repo slug. PAT/SSH/credential-helper setups
+// return null and keep using the runner's inherited process env.
+export async function resolveBackupPushAuthEnv(
+  cwd: string,
+  deps: BackupPushAuthDeps,
+): Promise<BackupGitAuthEnv | null> {
+  if (!shouldMintAppToken(deps.ghToken, deps.hasAppTokenResolver())) return null
+
+  const originUrl = await deps.resolveOriginPushUrl(cwd)
+  if (originUrl === null) return null
+
+  const slug = parseGithubRepoFromGitUrl(originUrl)
+  if (slug === null) return null
+
+  const token = await deps.resolveTokenForRepo(slug)
+  if (token.kind !== 'token') return null
+
+  const askpass = await deps.ensureAskPassHelper()
+
+  // Token rides in TYPECLAW_GIT_TOKEN (read by the askpass helper), never in
+  // argv/config. The insteadOf rewrites map ssh/scp github remotes to https so
+  // the askpass credential applies; GIT_TERMINAL_PROMPT=0 fails fast instead of
+  // hanging on a prompt. Mirrors github-cli-auth/index.ts.
+  return {
+    GIT_ASKPASS: askpass,
+    TYPECLAW_GIT_TOKEN: token.token,
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_CONFIG_COUNT: '2',
+    GIT_CONFIG_KEY_0: 'url.https://github.com/.insteadOf',
+    GIT_CONFIG_VALUE_0: 'git@github.com:',
+    GIT_CONFIG_KEY_1: 'url.https://github.com/.insteadOf',
+    GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
+  }
+}
+
+export function makeDefaultAskPassEnsurer(): () => Promise<string> {
+  return () => ensureGitAskPassHelper()
+}

--- a/src/bundled-plugins/backup/index.ts
+++ b/src/bundled-plugins/backup/index.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { withGitLock } from '@/git/mutex'
 import { definePlugin, type PluginContext, type SpawnSubagentOptions, type Subagent } from '@/plugin'
 
+import { type BackupPushAuthDeps, makeDefaultAskPassEnsurer, resolveBackupPushAuthEnv } from './git-auth'
 import { COMMIT_TIMEOUT_MS, makeDefaultGitSpawn, NETWORK_TIMEOUT_MS, runBackup, type BackupResult } from './runner'
 import {
   cleanupMessageFile,
@@ -163,6 +164,7 @@ async function runBackupOnce(
     agentDir: string
     logger: { info: (m: string) => void; warn: (m: string) => void }
     spawnSubagent: PluginContext['spawnSubagent']
+    github: PluginContext['github']
   },
 ): Promise<BackupResult> {
   const messagePath = messageFilePath(payload.agentDir)
@@ -175,11 +177,17 @@ async function runBackupOnce(
     spawnedByOrigin: { kind: 'tui', sessionId: 'backup-runner' },
   }
 
+  // App-auth agents need a minted per-repo token injected into the runner's
+  // direct git spawn (it bypasses the bash tool's credential hook). Only
+  // computed when we'll actually push; PAT/SSH/non-github fall back to null
+  // and the runner uses its inherited env.
+  const authEnv = payload.pushToOrigin ? await resolveBackupAuthEnv(payload.agentDir, ctx.github, ctx.logger) : null
+
   const result = await withGitLock(payload.agentDir, () =>
     runBackup(
       { cwd: payload.agentDir, pushToOrigin: payload.pushToOrigin },
       {
-        gitSpawn: makeDefaultGitSpawn(),
+        gitSpawn: makeDefaultGitSpawn(authEnv ?? {}),
         pickCommitMessage: async ({ status, diffstat }) => {
           await cleanupMessageFile(messagePath)
           const messagePayload: CommitMessagePayload = {
@@ -219,6 +227,48 @@ async function runBackupOnce(
 
   await cleanupMessageFile(messagePath)
   return result
+}
+
+async function resolveBackupAuthEnv(
+  agentDir: string,
+  github: PluginContext['github'],
+  logger: { warn: (m: string) => void },
+): Promise<Record<string, string> | null> {
+  const deps: BackupPushAuthDeps = {
+    hasAppTokenResolver: github.hasAppTokenResolver,
+    ghToken: process.env.GH_TOKEN,
+    resolveTokenForRepo: github.resolveTokenForRepo,
+    resolveOriginPushUrl,
+    ensureAskPassHelper: makeDefaultAskPassEnsurer(),
+  }
+  try {
+    return await resolveBackupPushAuthEnv(agentDir, deps)
+  } catch {
+    // Credential prep is best-effort: a resolver failure must not abort the
+    // backup. Falls back to the runner's inherited env (commit still happens),
+    // and the push's own failure path diagnoses if it then can't authenticate.
+    // No slug/token/error detail is logged — those are credential-adjacent.
+    logger.warn('GitHub backup auth unavailable; continuing with inherited git credentials')
+    return null
+  }
+}
+
+async function resolveOriginPushUrl(cwd: string): Promise<string | null> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) return null
+  try {
+    const proc = bun.spawn({
+      cmd: ['git', '-C', cwd, 'remote', 'get-url', '--push', 'origin'],
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_OPTIONAL_LOCKS: '0' },
+    })
+    if ((await proc.exited) !== 0) return null
+    const out = (await new Response(proc.stdout).text()).trim()
+    return out === '' ? null : out
+  } catch {
+    return null
+  }
 }
 
 function describeResult(r: BackupResult): string {

--- a/src/bundled-plugins/backup/index.ts
+++ b/src/bundled-plugins/backup/index.ts
@@ -177,17 +177,21 @@ async function runBackupOnce(
     spawnedByOrigin: { kind: 'tui', sessionId: 'backup-runner' },
   }
 
-  // App-auth agents need a minted per-repo token injected into the runner's
-  // direct git spawn (it bypasses the bash tool's credential hook). Only
-  // computed when we'll actually push; PAT/SSH/non-github fall back to null
-  // and the runner uses its inherited env.
-  const authEnv = payload.pushToOrigin ? await resolveBackupAuthEnv(payload.agentDir, ctx.github, ctx.logger) : null
+  // App-auth agents need a minted per-repo token for the runner's push (it
+  // bypasses the bash tool's credential hook). Only computed when we'll push;
+  // PAT/SSH/non-github fall back to null. Passed as `pushEnv` so the runner
+  // applies it to push/fetch ONLY — never to local commands like `git commit`,
+  // which can run repo-controlled hooks that would otherwise see the token.
+  const pushEnv = payload.pushToOrigin
+    ? ((await resolveBackupAuthEnv(payload.agentDir, ctx.github, ctx.logger)) ?? undefined)
+    : undefined
 
   const result = await withGitLock(payload.agentDir, () =>
     runBackup(
       { cwd: payload.agentDir, pushToOrigin: payload.pushToOrigin },
       {
-        gitSpawn: makeDefaultGitSpawn(authEnv ?? {}),
+        gitSpawn: makeDefaultGitSpawn(),
+        pushEnv,
         pickCommitMessage: async ({ status, diffstat }) => {
           await cleanupMessageFile(messagePath)
           const messagePayload: CommitMessagePayload = {

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -20,12 +20,12 @@ const failResult = (stderr = 'boom', exit = 1): GitSpawnResult => ({
   timedOut: false,
 })
 
-type Call = { args: readonly string[]; cwd: string }
+type Call = { args: readonly string[]; cwd: string; env?: Record<string, string> }
 
 function makeSpawn(handler: (args: readonly string[]) => GitSpawnResult): { spawn: GitSpawn; calls: Call[] } {
   const calls: Call[] = []
-  const spawn: GitSpawn = async (args, { cwd }) => {
-    calls.push({ args, cwd })
+  const spawn: GitSpawn = async (args, { cwd, env }) => {
+    calls.push({ args, cwd, env })
     return handler(args)
   }
   return { spawn, calls }
@@ -284,6 +284,41 @@ describe('runBackup', () => {
     const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
     expect(result).toEqual({ ok: true, kind: 'pushed' })
     expect(calls.find((c) => c.args[0] === 'push')).toBeDefined()
+  })
+
+  test('pushEnv reaches push/fetch only — never local commands that can run repo hooks', async () => {
+    // given: a minted-token env and a non-fast-forward push so fetch+rebase run too
+    const cwd = await makeRepo()
+    const pushEnv = { GIT_ASKPASS: '/x/askpass', TYPECLAW_GIT_TOKEN: 'ghs_secret' }
+    let pushCount = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return okResult('origin/main\n')
+      if (args[0] === 'push') {
+        pushCount += 1
+        return pushCount === 1 ? failResult('! [rejected] (non-fast-forward)\nUpdates were rejected', 1) : okResult()
+      }
+      if (args[0] === 'fetch') return okResult()
+      if (args[0] === 'rebase' && args[1] === 'origin/main') return okResult()
+      return okResult()
+    })
+    // when
+    await runBackup({ cwd, pushToOrigin: true }, { ...baseDeps(spawn), pushEnv })
+
+    // then: every push/fetch carries the token; the local commit/add/status/rebase
+    // (which can execute repo-controlled git hooks) must NOT see it.
+    const networkCmds = new Set(['push', 'fetch'])
+    for (const c of calls) {
+      if (networkCmds.has(c.args[0] as string)) {
+        expect(c.env).toEqual(pushEnv)
+      } else {
+        expect(c.env).toBeUndefined()
+      }
+    }
+    // sanity: the hook-executing commands actually ran in this scenario
+    expect(calls.some((c) => c.args[0] === 'commit')).toBe(true)
+    expect(calls.some((c) => c.args[0] === 'rebase' && c.args[1] === 'origin/main')).toBe(true)
   })
 
   test('on non-fast-forward push, fetches, rebases, and re-pushes', async () => {

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -193,17 +193,83 @@ describe('runBackup', () => {
     expect(commitIdx).toBeGreaterThan(addFIndices[1]!)
   })
 
-  test('skips push when there is no upstream', async () => {
+  test('no upstream but origin exists and HEAD is a branch: pushes with -u and sets tracking', async () => {
+    // given: a fresh repo with origin configured but no `branch.<name>.{remote,merge}`
+    // tracking — the default state for an agent folder nobody ran `git push -u` on.
     const cwd = await makeRepo()
     const { spawn, calls } = makeSpawn((args) => {
       if (args[0] === 'status') return okResult(' M foo\n')
       if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
       if (args[0] === 'rev-parse') return failResult('not a tracking branch', 128)
+      if (args[0] === 'remote' && args[1] === 'get-url') return okResult('https://example.com/repo.git\n')
+      if (args[0] === 'symbolic-ref') return okResult('main\n')
+      if (args[0] === 'push') return okResult()
+      return okResult()
+    })
+    // when
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    // then: pushed with -u to origin HEAD:main, establishing tracking in one shot
+    expect(result).toEqual({ ok: true, kind: 'pushed-set-upstream' })
+    const push = calls.find((c) => c.args[0] === 'push')
+    expect(push?.args).toEqual(['push', '-u', 'origin', 'HEAD:main'])
+  })
+
+  test('no upstream and no origin remote: commits only (legitimate offline state)', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return failResult('not a tracking branch', 128)
+      if (args[0] === 'remote' && args[1] === 'get-url') return failResult('No such remote', 2)
       return okResult()
     })
     const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
     expect(result).toEqual({ ok: true, kind: 'committed' })
     expect(calls.find((c) => c.args[0] === 'push')).toBeUndefined()
+  })
+
+  test('no upstream, origin exists, but detached HEAD: commits only (no branch to track)', async () => {
+    const cwd = await makeRepo()
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return failResult('not a tracking branch', 128)
+      if (args[0] === 'remote' && args[1] === 'get-url') return okResult('https://example.com/repo.git\n')
+      if (args[0] === 'symbolic-ref') return failResult('ref HEAD is not a symbolic ref', 128)
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((c) => c.args[0] === 'push')).toBeUndefined()
+  })
+
+  test('set-upstream push routes non-fast-forward through fetch/rebase/re-push', async () => {
+    const cwd = await makeRepo()
+    let pushCount = 0
+    const { spawn, calls } = makeSpawn((args) => {
+      if (args[0] === 'status') return okResult(' M foo\n')
+      if (args[0] === 'diff' && args[2] === '--quiet') return failResult('', 1)
+      if (args[0] === 'rev-parse') return failResult('no upstream', 128)
+      if (args[0] === 'remote' && args[1] === 'get-url') return okResult('https://example.com/repo.git\n')
+      if (args[0] === 'symbolic-ref') return okResult('main\n')
+      if (args[0] === 'push') {
+        pushCount += 1
+        return pushCount === 1 ? failResult('! [rejected] (non-fast-forward)\nUpdates were rejected', 1) : okResult()
+      }
+      if (args[0] === 'fetch') return okResult()
+      if (args[0] === 'rebase' && args[1] === 'origin/main') return okResult()
+      return okResult()
+    })
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
+    expect(result).toEqual({ ok: true, kind: 'rebased-and-pushed' })
+    expect(calls.filter((c) => c.args[0] === 'push').length).toBe(2)
+    // both attempts use the same set-upstream args so tracking is still set on retry
+    for (const p of calls.filter((c) => c.args[0] === 'push')) {
+      expect(p.args).toEqual(['push', '-u', 'origin', 'HEAD:main'])
+    }
+    // no tracking ref exists yet, so the recovery fetch must name origin explicitly
+    expect(calls.find((c) => c.args[0] === 'fetch')?.args).toEqual(['fetch', 'origin'])
+    expect(calls.find((c) => c.args[0] === 'rebase' && c.args[1] === 'origin/main')).toBeDefined()
   })
 
   test('pushes when upstream is configured', async () => {

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -21,12 +21,20 @@ export type GitSpawnResult = {
   timedOut: boolean
 }
 
-export type GitSpawn = (args: readonly string[], opts: { cwd: string; timeoutMs: number }) => Promise<GitSpawnResult>
+export type GitSpawn = (
+  args: readonly string[],
+  opts: { cwd: string; timeoutMs: number; env?: Record<string, string> },
+) => Promise<GitSpawnResult>
 
 export type BackupRunnerDeps = {
   gitSpawn: GitSpawn
   pickCommitMessage: (input: { status: string; diffstat: string }) => Promise<string>
   diagnoseFailure?: (input: BackupFailureInput) => Promise<void>
+  // Credential env (GIT_ASKPASS/TYPECLAW_GIT_TOKEN/insteadOf) applied ONLY to
+  // network git invocations (push/fetch). It is deliberately NOT given to local
+  // commands — `git commit` can run repo-controlled hooks, which must never see
+  // the minted token.
+  pushEnv?: Record<string, string>
   now?: () => number
 }
 
@@ -169,8 +177,12 @@ async function pushWithRecovery(cwd: string, deps: BackupRunnerDeps, plan: Activ
   // onto. The upstream case keeps bare `fetch` (its tracking config resolves it).
   const fetchArgs = plan.kind === 'upstream' ? ['fetch'] : ['fetch', plan.remote]
   const pushedKind: BackupResult = { ok: true, kind: plan.kind === 'upstream' ? 'pushed' : 'pushed-set-upstream' }
+  // Credentials ride ONLY on the network calls (push/fetch). The rebase is
+  // local (it replays onto an already-fetched remote-tracking ref), so it runs
+  // token-free like every other local command.
+  const net = { cwd, timeoutMs: NETWORK_TIMEOUT_MS, env: deps.pushEnv }
 
-  const push = await deps.gitSpawn(pushArgs, { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  const push = await deps.gitSpawn(pushArgs, net)
   if (push.exitCode === 0) return pushedKind
 
   if (!isNonFastForward(push)) {
@@ -178,7 +190,7 @@ async function pushWithRecovery(cwd: string, deps: BackupRunnerDeps, plan: Activ
     return { ok: false, kind: 'push-failed', reason: shortErr(push) }
   }
 
-  const fetch = await deps.gitSpawn(fetchArgs, { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  const fetch = await deps.gitSpawn(fetchArgs, net)
   if (fetch.exitCode !== 0) {
     await maybeDiagnose(deps, {
       cwd,
@@ -203,7 +215,7 @@ async function pushWithRecovery(cwd: string, deps: BackupRunnerDeps, plan: Activ
     return { ok: false, kind: 'rebase-failed', reason: `git rebase failed: ${shortErr(rebase)}` }
   }
 
-  const push2 = await deps.gitSpawn(pushArgs, { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  const push2 = await deps.gitSpawn(pushArgs, net)
   if (push2.exitCode !== 0) {
     await maybeDiagnose(deps, {
       cwd,
@@ -271,11 +283,8 @@ function sanitizeCommitMessage(raw: string): string {
   return rest.length > 0 ? `${subject}\n\n${rest}` : subject
 }
 
-// `extraEnv` carries git credentials (GIT_ASKPASS/TYPECLAW_GIT_TOKEN/insteadOf)
-// for App-auth pushes; it is applied LAST so its GIT_TERMINAL_PROMPT wins, but
-// NONINTERACTIVE_ENV's pager/GCM settings are folded in first either way.
-export function makeDefaultGitSpawn(extraEnv: Record<string, string> = {}): GitSpawn {
-  return withIndexLockRetry(async (args, { cwd, timeoutMs }) => {
+export function makeDefaultGitSpawn(): GitSpawn {
+  return withIndexLockRetry(async (args, { cwd, timeoutMs, env }) => {
     const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
     if (!bun) {
       return { exitCode: 127, stdout: '', stderr: 'Bun runtime not available', timedOut: false }
@@ -283,12 +292,15 @@ export function makeDefaultGitSpawn(extraEnv: Record<string, string> = {}): GitS
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeoutMs)
     try {
+      // Per-call `env` (credentials for push/fetch) is applied LAST so its
+      // GIT_TERMINAL_PROMPT wins; NONINTERACTIVE_ENV's pager/GCM settings still
+      // apply to every call. Local commands pass no `env` and stay token-free.
       const proc = bun.spawn({
         cmd: ['git', ...args],
         cwd,
         stdout: 'pipe',
         stderr: 'pipe',
-        env: { ...process.env, ...NONINTERACTIVE_ENV, ...extraEnv },
+        env: { ...process.env, ...NONINTERACTIVE_ENV, ...env },
         signal: controller.signal,
       })
       const exitCode = await proc.exited

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -44,8 +44,14 @@ export type BackupFailureInput = {
 }
 
 export type BackupResult =
-  | { ok: true; kind: 'no-repo' | 'clean' | 'committed' | 'pushed' | 'rebased-and-pushed' }
+  | { ok: true; kind: 'no-repo' | 'clean' | 'committed' | 'pushed' | 'pushed-set-upstream' | 'rebased-and-pushed' }
   | { ok: false; kind: 'commit-failed' | 'push-failed' | 'rebase-failed' | 'aborted'; reason: string }
+
+type ActivePushPlan =
+  | { kind: 'upstream'; upstreamRef: string }
+  | { kind: 'set-upstream'; remote: string; branch: string }
+
+type PushPlan = ActivePushPlan | { kind: 'skip' }
 
 export async function runBackup(options: BackupRunnerOptions, deps: BackupRunnerDeps): Promise<BackupResult> {
   const { cwd, pushToOrigin } = options
@@ -113,24 +119,66 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
 
   if (!pushToOrigin) return { ok: true, kind: 'committed' }
 
+  const plan = await resolvePushPlan(cwd, deps)
+  if (plan.kind === 'skip') return { ok: true, kind: 'committed' }
+
+  return pushWithRecovery(cwd, deps, plan)
+}
+
+// `@{upstream}` resolution failing was previously treated as "no push" — but a
+// fresh agent repo that nobody ran `git push -u` on has a configured `origin`
+// and no tracking ref, so the runner committed forever and never pushed. The
+// correct gate when `pushToOrigin` is on is "origin exists and HEAD is a real
+// branch": then we push AND set the upstream in one shot, and every later run
+// takes the plain-upstream path. No remote / detached HEAD stays commit-only
+// (a legitimate offline state), so it returns `skip` rather than diagnosing.
+async function resolvePushPlan(cwd: string, deps: BackupRunnerDeps): Promise<PushPlan> {
   const upstream = await deps.gitSpawn(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], {
     cwd,
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
-  if (upstream.exitCode !== 0) return { ok: true, kind: 'committed' }
+  if (upstream.exitCode === 0 && upstream.stdout.trim().length > 0) {
+    return { kind: 'upstream', upstreamRef: upstream.stdout.trim() }
+  }
 
-  const upstreamRef = upstream.stdout.trim()
-  if (upstreamRef.length === 0) return { ok: true, kind: 'committed' }
+  // Only `origin` is acted on: picking "the first remote" when origin is absent
+  // would guess a destination the operator never configured. `get-url` (not
+  // `get-url --push`) is enough here — we only need to know origin EXISTS and
+  // is named `origin`; the push targets `origin` by name regardless of pushurl.
+  const origin = await deps.gitSpawn(['remote', 'get-url', 'origin'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  if (origin.exitCode !== 0 || origin.stdout.trim().length === 0) return { kind: 'skip' }
 
-  const push = await deps.gitSpawn(['push'], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
-  if (push.exitCode === 0) return { ok: true, kind: 'pushed' }
+  // `symbolic-ref --short HEAD` fails on a detached HEAD (no branch to set an
+  // upstream for); `rev-parse --abbrev-ref HEAD` would have returned the literal
+  // "HEAD" and we'd have tried to push a branch named HEAD. Skip cleanly.
+  const branch = await deps.gitSpawn(['symbolic-ref', '--short', 'HEAD'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  if (branch.exitCode !== 0 || branch.stdout.trim().length === 0) return { kind: 'skip' }
+
+  return { kind: 'set-upstream', remote: 'origin', branch: branch.stdout.trim() }
+}
+
+// Both entry points (plain push and first-time set-upstream push) share the
+// non-fast-forward recovery: fetch, rebase onto the intended remote branch,
+// re-push. Keeping one helper stops the set-upstream path from silently becoming
+// a weaker duplicate that skips recovery.
+async function pushWithRecovery(cwd: string, deps: BackupRunnerDeps, plan: ActivePushPlan): Promise<BackupResult> {
+  const pushArgs = pushArgsFor(plan)
+  const rebaseRef = plan.kind === 'upstream' ? plan.upstreamRef : `${plan.remote}/${plan.branch}`
+  // In the set-upstream case there is no tracking ref yet, so a bare `git fetch`
+  // has no configured remote to default to — fetch the same remote we rebase
+  // onto. The upstream case keeps bare `fetch` (its tracking config resolves it).
+  const fetchArgs = plan.kind === 'upstream' ? ['fetch'] : ['fetch', plan.remote]
+  const pushedKind: BackupResult = { ok: true, kind: plan.kind === 'upstream' ? 'pushed' : 'pushed-set-upstream' }
+
+  const push = await deps.gitSpawn(pushArgs, { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  if (push.exitCode === 0) return pushedKind
 
   if (!isNonFastForward(push)) {
     await maybeDiagnose(deps, { cwd, stage: 'push', exitCode: push.exitCode, stderr: push.stderr, stdout: push.stdout })
     return { ok: false, kind: 'push-failed', reason: shortErr(push) }
   }
 
-  const fetch = await deps.gitSpawn(['fetch'], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  const fetch = await deps.gitSpawn(fetchArgs, { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
   if (fetch.exitCode !== 0) {
     await maybeDiagnose(deps, {
       cwd,
@@ -142,7 +190,7 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
     return { ok: false, kind: 'push-failed', reason: `git fetch failed: ${shortErr(fetch)}` }
   }
 
-  const rebase = await deps.gitSpawn(['rebase', upstreamRef], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  const rebase = await deps.gitSpawn(['rebase', rebaseRef], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
   if (rebase.exitCode !== 0) {
     await deps.gitSpawn(['rebase', '--abort'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
     await maybeDiagnose(deps, {
@@ -155,7 +203,7 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
     return { ok: false, kind: 'rebase-failed', reason: `git rebase failed: ${shortErr(rebase)}` }
   }
 
-  const push2 = await deps.gitSpawn(['push'], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  const push2 = await deps.gitSpawn(pushArgs, { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
   if (push2.exitCode !== 0) {
     await maybeDiagnose(deps, {
       cwd,
@@ -167,6 +215,13 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
     return { ok: false, kind: 'push-failed', reason: `git push (post-rebase) failed: ${shortErr(push2)}` }
   }
   return { ok: true, kind: 'rebased-and-pushed' }
+}
+
+function pushArgsFor(plan: ActivePushPlan): string[] {
+  if (plan.kind === 'upstream') return ['push']
+  // `HEAD:<branch>` is explicit about pushing the current commit to the named
+  // remote branch, avoiding any reliance on local refspec defaults.
+  return ['push', '-u', plan.remote, `HEAD:${plan.branch}`]
 }
 
 async function maybeDiagnose(deps: BackupRunnerDeps, input: BackupFailureInput): Promise<void> {
@@ -216,7 +271,10 @@ function sanitizeCommitMessage(raw: string): string {
   return rest.length > 0 ? `${subject}\n\n${rest}` : subject
 }
 
-export function makeDefaultGitSpawn(): GitSpawn {
+// `extraEnv` carries git credentials (GIT_ASKPASS/TYPECLAW_GIT_TOKEN/insteadOf)
+// for App-auth pushes; it is applied LAST so its GIT_TERMINAL_PROMPT wins, but
+// NONINTERACTIVE_ENV's pager/GCM settings are folded in first either way.
+export function makeDefaultGitSpawn(extraEnv: Record<string, string> = {}): GitSpawn {
   return withIndexLockRetry(async (args, { cwd, timeoutMs }) => {
     const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
     if (!bun) {
@@ -230,7 +288,7 @@ export function makeDefaultGitSpawn(): GitSpawn {
         cwd,
         stdout: 'pipe',
         stderr: 'pipe',
-        env: { ...process.env, ...NONINTERACTIVE_ENV },
+        env: { ...process.env, ...NONINTERACTIVE_ENV, ...extraEnv },
         signal: controller.signal,
       })
       const exitCode = await proc.exited


### PR DESCRIPTION
## Background

Auto-backup committed session/memory state but never reached the git remote. Two independent root causes, both in the bundled `backup` plugin, produced the same symptom:

1. **Push gated on a tracking ref that fresh agent folders never have.** After committing, the runner ran `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` and, on failure, silently returned `committed` without pushing. An agent folder has `origin` configured but no `branch.<name>.{remote,merge}` tracking — nobody runs `git push -u` by hand — so `@{upstream}` resolution fails on essentially every fresh repo. The runner committed forever and never pushed. This is the *common* case, not an edge case.

2. **The runner's push got no credentials under GitHub App auth.** The runner spawns `git` directly via `Bun.spawn`, bypassing the `bash` tool — and credential injection lives only in the `github-cli-auth` plugin's `tool.before` hook (`if (event.tool !== 'bash') return`). So for App-auth agents the runner's `git push` had no `GIT_ASKPASS`/token and failed authentication even once an upstream existed. (PAT / SSH-key / credential-helper setups inherit `process.env` / `.git/config` and were unaffected.)

Fixing only (1) would have moved App-auth users from "silent skip" to "auth failure", so both are fixed here.

## Summary

**Push plan instead of an upstream-only gate** (`runner.ts`). When `pushToOrigin` is on: use the upstream if one exists; otherwise, if `origin` exists and `HEAD` is a real branch, `git push -u origin HEAD:<branch>` to push *and* set tracking in one shot (later cycles then take the plain-upstream path). No `origin` or a detached `HEAD` stays commit-only — a legitimate offline state, not an error, so no diagnostics fire. Both push shapes share one non-fast-forward recovery (fetch → rebase onto the intended remote branch → re-push); the set-upstream recovery fetches `origin` explicitly because no tracking ref exists yet to resolve a bare `git fetch`.

- *Why only `origin` for set-upstream, not "the first remote":* picking any other remote would push to a destination the operator never configured.
- *Why `symbolic-ref --short HEAD`, not `rev-parse --abbrev-ref HEAD`:* the latter returns the literal `HEAD` when detached, which would have tried to push a branch named `HEAD`.

**Credential injection for the runner** (`git-auth.ts` + `index.ts`). Mirror the `github-cli-auth` credential path: only under App auth (`shouldMintAppToken`), only when `origin` is a github.com remote, mint a per-repo installation token for origin's slug and inject `GIT_ASKPASS` + `TYPECLAW_GIT_TOKEN` (token in env, never argv/config) plus the ssh→https `insteadOf` rewrites into the runner's git env via a new optional `extraEnv` arg on `makeDefaultGitSpawn`. PAT/SSH/credential-helper setups and non-github origins return `null` and keep the inherited env. Credential prep is best-effort — any failure falls back to inherited creds and the push's own failure path diagnoses.

## What this does NOT do

- **Does not support arbitrary non-`origin` upstreams for credential minting.** If a branch's upstream remote is a different-owner GitHub repo, the origin-scoped token may be wrong-owner and the push fails honestly (it diagnoses; no security issue). typeclaw's normal path is `origin`; resolving auth from the actual push remote is a clean follow-up.
- Does not change the trigger model (still `session.idle` + active-turn gating), the commit-message or diagnose subagents, or anything for PAT/SSH/credential-helper users.
- Does not force-push or alter conflict handling.

## Review notes

- Load-bearing change: `resolvePushPlan` + `pushWithRecovery` in `runner.ts`. Invariant to verify — both push entry points route non-fast-forward through the *same* fetch/rebase/re-push, and the set-upstream path fetches `origin` (not bare `fetch`).
- Security: the runner only injects a token for a github.com `origin`, into fixed git operations, with the askpass helper scoped to `github.com`. No new exfil surface over the runner's existing trusted push (the credential failure path logs no slug/token/error detail). The runner already bypasses the bash-path guards by design (deterministic, owner-trusted, pushes only to the configured remote).
- New `BackupResult` kind `pushed-set-upstream` (ok:true) for observability; only consumed by the logger.
- Tests: `runner.test.ts` (set-upstream push, no-origin/detached-HEAD commit-only, set-upstream non-fast-forward recovery), `git-auth.test.ts` (mint only under App auth + github origin; PAT/SSH/non-github/unavailable → inherited env).
