### PR TITLE
fix(channels): route non-text LINE inbound instead of dropping as empty_text

### DIFF
--- a/src/channels/adapters/line-attachment.test.ts
+++ b/src/channels/adapters/line-attachment.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { LinePushMessageEvent } from 'agent-messenger/line'
+
+import { normalizeLineContentType, splitInboundLine } from './line-attachment'
+
+function event(overrides: Partial<LinePushMessageEvent> = {}): LinePushMessageEvent {
+  return {
+    type: 'message',
+    chat_id: 'C1',
+    message_id: 'M1',
+    author_id: 'U_other',
+    text: null,
+    content_type: 'NONE',
+    sent_at: '2025-01-02T03:04:05.000Z',
+    ...overrides,
+  }
+}
+
+describe('normalizeLineContentType', () => {
+  test('maps numeric thrift enum forms to symbolic names', () => {
+    expect(normalizeLineContentType('7')).toBe('STICKER')
+    expect(normalizeLineContentType('1')).toBe('IMAGE')
+    expect(normalizeLineContentType('0')).toBe('NONE')
+  })
+
+  test('treats missing, blank, and TEXT spellings as NONE', () => {
+    expect(normalizeLineContentType(null)).toBe('NONE')
+    expect(normalizeLineContentType(undefined)).toBe('NONE')
+    expect(normalizeLineContentType('   ')).toBe('NONE')
+    expect(normalizeLineContentType('text')).toBe('NONE')
+    expect(normalizeLineContentType('TEXT')).toBe('NONE')
+  })
+
+  test('uppercases unknown symbolic types', () => {
+    expect(normalizeLineContentType('sticker')).toBe('STICKER')
+    expect(normalizeLineContentType('flex')).toBe('FLEX')
+  })
+})
+
+describe('splitInboundLine', () => {
+  test('passes text through untouched for NONE content', () => {
+    const result = splitInboundLine(event({ content_type: 'NONE', text: 'hello' }))
+    expect(result).toEqual({ text: 'hello', attachments: [] })
+  })
+
+  test('keeps NONE text empty so the classifier can drop it', () => {
+    const result = splitInboundLine(event({ content_type: 'NONE', text: null }))
+    expect(result).toEqual({ text: '', attachments: [] })
+  })
+
+  test('synthesizes a placeholder + ref-free attachment for stickers', () => {
+    const result = splitInboundLine(event({ content_type: 'STICKER' }))
+    expect(result.text).toBe('[LINE sticker]')
+    expect(result.attachments).toEqual([{ id: 1, kind: 'sticker', ref: '' }])
+  })
+
+  test('maps IMAGE/VIDEO/AUDIO/FILE to photo/video/audio/file kinds', () => {
+    expect(splitInboundLine(event({ content_type: 'IMAGE' })).attachments[0]?.kind).toBe('photo')
+    expect(splitInboundLine(event({ content_type: 'VIDEO' })).attachments[0]?.kind).toBe('video')
+    expect(splitInboundLine(event({ content_type: 'AUDIO' })).attachments[0]?.kind).toBe('audio')
+    expect(splitInboundLine(event({ content_type: 'FILE' })).attachments[0]?.kind).toBe('file')
+  })
+
+  test('appends the placeholder when the event also carries a caption', () => {
+    const result = splitInboundLine(event({ content_type: 'IMAGE', text: 'look at this' }))
+    expect(result.text).toBe('look at this\n[LINE photo]')
+    expect(result.attachments).toEqual([{ id: 1, kind: 'photo', ref: '' }])
+  })
+
+  test('routes contact and location as placeholder-only text, no attachment', () => {
+    expect(splitInboundLine(event({ content_type: 'CONTACT' }))).toEqual({
+      text: '[LINE contact]',
+      attachments: [],
+    })
+    expect(splitInboundLine(event({ content_type: 'LOCATION' }))).toEqual({
+      text: '[LINE location]',
+      attachments: [],
+    })
+  })
+
+  test('renders an unknown content type as a labeled placeholder with no attachment', () => {
+    const result = splitInboundLine(event({ content_type: 'FLEX' }))
+    expect(result).toEqual({ text: '[LINE message: FLEX]', attachments: [] })
+  })
+
+  test('honors a custom start id for the attachment', () => {
+    const result = splitInboundLine(event({ content_type: 'STICKER' }), 5)
+    expect(result.attachments[0]?.id).toBe(5)
+  })
+})

--- a/src/channels/adapters/line-attachment.ts
+++ b/src/channels/adapters/line-attachment.ts
@@ -1,0 +1,97 @@
+import type { LinePushMessageEvent } from 'agent-messenger/line'
+
+import type { InboundAttachment } from '@/channels/types'
+
+// Splits an inbound LINE event into (text, attachments[]). Text is what the
+// agent sees in its prompt; attachments[] carries the in-turn id + kind the
+// router uses to resolve `channel_fetch_attachment` / `look_at` by id.
+//
+// LINE differs from KakaoTalk in one load-bearing way: the upstream SDK
+// (`agent-messenger/line`) currently forwards only `content_type` on the push
+// event, NOT `contentMetadata`. So unlike the KakaoTalk splitter, this one has
+// no sticker id / file name / media URL to surface — every attachment is
+// REF-FREE (empty `ref`, no fetchable handle). The placeholder is therefore
+// coarse on purpose (`[LINE sticker]`, `[LINE image]`). When the SDK starts
+// forwarding metadata (agent-messenger#214), enrich this file only; the
+// adapter / classifier contract does not change.
+//
+// Keeping the ref out of the prompt text is the same invariant the KakaoTalk
+// splitter documents: there is exactly ONE way to fetch an attachment — by its
+// in-turn id — so a hallucinated/malformed ref can never reach a tool.
+
+export type SplitInboundLine = {
+  text: string
+  attachments: InboundAttachment[]
+}
+
+// LINE thrift ContentType. The SDK stringifies `msg.raw.contentType`, which the
+// thrift layer usually renders as the symbolic name, but the wire enum is
+// numeric (see @evex/linejs-types ContentType). Normalize defends against both
+// forms so a numeric leak ("7") still maps to STICKER rather than falling
+// through to the unknown bucket.
+const NUMERIC_CONTENT_TYPE: Record<string, string> = {
+  '0': 'NONE',
+  '1': 'IMAGE',
+  '2': 'VIDEO',
+  '3': 'AUDIO',
+  '7': 'STICKER',
+  '13': 'CONTACT',
+  '14': 'FILE',
+  '15': 'LOCATION',
+}
+
+// Non-text content types that map cleanly onto the fixed InboundAttachment.kind
+// union. Types with no clean mapping (CONTACT, LOCATION, and anything unknown)
+// route as placeholder-only text — an attachment with an empty ref and an
+// invented kind would offer the agent an unusable handle, so we don't make one.
+const CONTENT_TYPE_TO_KIND: Record<string, InboundAttachment['kind']> = {
+  STICKER: 'sticker',
+  IMAGE: 'photo',
+  VIDEO: 'video',
+  AUDIO: 'audio',
+  FILE: 'file',
+}
+
+const PLACEHOLDER_ONLY_LABEL: Record<string, string> = {
+  CONTACT: 'contact',
+  LOCATION: 'location',
+}
+
+export function normalizeLineContentType(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined) return 'NONE'
+  const trimmed = raw.trim()
+  if (trimmed === '') return 'NONE'
+  const numeric = NUMERIC_CONTENT_TYPE[trimmed]
+  if (numeric !== undefined) return numeric
+  const upper = trimmed.toUpperCase()
+  // LINE text is `NONE` on the wire; treat the `TEXT` spelling as the same so
+  // a genuine text message never falls into the placeholder path.
+  return upper === 'TEXT' ? 'NONE' : upper
+}
+
+export function splitInboundLine(event: LinePushMessageEvent, startId = 1): SplitInboundLine {
+  const contentType = normalizeLineContentType(event.content_type)
+
+  // NONE is LINE text; a blank NONE message stays an `empty_text` drop in the
+  // classifier, so synthesize nothing and pass the raw text through.
+  if (contentType === 'NONE') {
+    return { text: event.text ?? '', attachments: [] }
+  }
+
+  const kind = CONTENT_TYPE_TO_KIND[contentType]
+  const rawText = event.text ?? ''
+
+  if (kind !== undefined) {
+    const id = startId
+    const placeholder = `[LINE ${kind}]`
+    const text = rawText === '' ? placeholder : `${rawText}\n${placeholder}`
+    return { text, attachments: [{ id, kind, ref: '' }] }
+  }
+
+  // Placeholder-only types (contact, location, unknown/future). No attachment
+  // entry — there is nothing fetchable and no valid kind to assign.
+  const label = PLACEHOLDER_ONLY_LABEL[contentType] ?? `message: ${contentType}`
+  const placeholder = `[LINE ${label}]`
+  const text = rawText === '' ? placeholder : `${rawText}\n${placeholder}`
+  return { text, attachments: [] }
+}

--- a/src/channels/adapters/line-classify.test.ts
+++ b/src/channels/adapters/line-classify.test.ts
@@ -38,9 +38,57 @@ describe('classifyInbound', () => {
     expect(verdict).toEqual({ kind: 'drop', reason: 'self_author' })
   })
 
-  test('drops empty-text messages', () => {
-    const verdict = classifyInbound(event({ text: null }), CONFIG, { selfUserId: 'U_self', lookupChat: dmLookup })
+  test('drops empty-text messages with no attachments', () => {
+    const verdict = classifyInbound(event({ text: null }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: dmLookup,
+      text: '',
+    })
     expect(verdict).toEqual({ kind: 'drop', reason: 'empty_text' })
+  })
+
+  test('routes a non-text message when the adapter supplies a placeholder + attachment', () => {
+    const verdict = classifyInbound(event({ text: null, content_type: 'STICKER' }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: dmLookup,
+      text: '[LINE sticker]',
+      attachments: [{ id: 1, kind: 'sticker', ref: '' }],
+    })
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe('[LINE sticker]')
+    expect(verdict.payload.attachments).toEqual([{ id: 1, kind: 'sticker', ref: '' }])
+  })
+
+  test('routes a placeholder-only message (contact/location) with no attachments', () => {
+    const verdict = classifyInbound(event({ text: null, content_type: 'CONTACT' }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: dmLookup,
+      text: '[LINE contact]',
+      attachments: [],
+    })
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe('[LINE contact]')
+    expect(verdict.payload.attachments).toBeUndefined()
+  })
+
+  test('still drops a non-text message from an unknown chat', () => {
+    const verdict = classifyInbound(event({ chat_id: 'C_unknown', content_type: 'STICKER' }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: dmLookup,
+      text: '[LINE sticker]',
+      attachments: [{ id: 1, kind: 'sticker', ref: '' }],
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'unknown_chat' })
+  })
+
+  test('still drops a non-text message authored by the bot itself', () => {
+    const verdict = classifyInbound(event({ author_id: 'U_self', content_type: 'STICKER' }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: dmLookup,
+      text: '[LINE sticker]',
+      attachments: [{ id: 1, kind: 'sticker', ref: '' }],
+    })
+    expect(verdict).toEqual({ kind: 'drop', reason: 'self_author' })
   })
 
   test('drops messages from chats not yet in the resolver', () => {

--- a/src/channels/adapters/line-classify.ts
+++ b/src/channels/adapters/line-classify.ts
@@ -2,7 +2,7 @@ import type { LinePushMessageEvent } from 'agent-messenger/line'
 
 import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
-import type { InboundMessage } from '@/channels/types'
+import type { InboundAttachment, InboundMessage } from '@/channels/types'
 
 export type InboundDropReason = 'self_author' | 'empty_text' | 'unknown_chat' | 'pre_connect'
 
@@ -22,6 +22,13 @@ export type LineInboundContext = {
   // LINE push events lack `author_name`, so the adapter resolves it (best
   // effort) and passes it here; falls back to the raw author id.
   authorName?: string
+  // The adapter splits the raw event into prompt text + attachments (non-text
+  // content types become a placeholder string and a ref-free attachment) and
+  // passes the result here, so the classifier routes on the synthesized text
+  // rather than the raw `event.text`. Omitted for plain text inbounds, where
+  // `event.text` is authoritative.
+  text?: string
+  attachments?: readonly InboundAttachment[]
 }
 
 export function classifyInbound(
@@ -36,8 +43,11 @@ export function classifyInbound(
     return { kind: 'drop', reason: 'self_author' }
   }
 
-  const text = event.text ?? ''
-  if (text === '') return { kind: 'drop', reason: 'empty_text' }
+  const text = context.text ?? event.text ?? ''
+  const attachments = context.attachments ?? []
+  if (text === '' && attachments.length === 0) {
+    return { kind: 'drop', reason: 'empty_text' }
+  }
 
   const chatInfo = context.lookupChat(event.chat_id)
   if (chatInfo === null) {
@@ -65,6 +75,7 @@ export function classifyInbound(
       chat: event.chat_id,
       thread: null,
       text,
+      ...(attachments.length > 0 ? { attachments } : {}),
       externalMessageId: event.message_id,
       authorId: event.author_id,
       authorName,

--- a/src/channels/adapters/line.ts
+++ b/src/channels/adapters/line.ts
@@ -25,6 +25,7 @@ import type {
   SendResult,
 } from '@/channels/types'
 
+import { splitInboundLine } from './line-attachment'
 import { createLineChannelResolver } from './line-channel-resolver'
 import { classifyInbound } from './line-classify'
 import { toLinePlainText } from './line-format'
@@ -217,13 +218,16 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
 
       const bucket = channelResolver.lookupChat(event.chat_id)?.workspace ?? '@line-group'
       const inboundTag = await formatChannelTag(bucket, event.chat_id)
+      const { text, attachments } = splitInboundLine(event)
       logger.info(
-        `[line] inbound message_id=${event.message_id} author=${event.author_id} ${inboundTag} text_len=${(event.text ?? '').length}`,
+        `[line] inbound message_id=${event.message_id} author=${event.author_id} ${inboundTag} content_type=${event.content_type} text_len=${text.length} attachments=${attachments.length}`,
       )
 
       const verdict = classifyInbound(event, options.configRef(), {
         selfUserId,
         lookupChat: (id) => channelResolver.lookupChat(id),
+        text,
+        attachments,
         ...(options.selfAliasesRef ? { selfAliases: options.selfAliasesRef() } : {}),
       })
       if (verdict.kind === 'drop') {


### PR DESCRIPTION
## Background

Every non-text LINE inbound was being silently dropped. Production logs showed a real DM arriving and immediately disappearing:

```
[line] inbound message_id=617815213659652622 author=… bucket=@line-dm … text_len=0
[line] dropped message_id=617815213659652622 reason=empty_text
```

Root cause: LINE delivers stickers, images, videos, audio, files, contacts, and locations with `text = null`. `classifyInbound` decided solely on `event.text` and dropped anything empty as `empty_text` — it never looked at `content_type`. So only plain text messages ever reached the router; the agent was blind to every sticker and attachment a user sent. KakaoTalk already solves this (it synthesizes placeholder text + attachments for non-text content); LINE was the odd one out with zero handling.

(This is unrelated to the `Invalid response buffer <>` reconnect churn also seen in those logs — that's an upstream SDK long-poll issue tracked separately in agent-messenger#215.)

## Summary

New `line-attachment.ts` splits an inbound event into prompt `text` + `attachments[]` based on `content_type`, mirroring the KakaoTalk split-before-classify shape. The classifier stays a pure router: the adapter computes the split and passes `text`/`attachments` through context, and `empty_text` now fires only when text is blank **AND** there are no attachments — so a genuinely empty text message is still dropped.

Key decisions:

- **Coarse, ref-free placeholders (`[LINE sticker]`, `[LINE photo]`, …).** The upstream SDK forwards no `contentMetadata` yet (sticker id / file name / media URL), so there's nothing fetchable to surface. Attachments carry an empty `ref`, and — matching the KakaoTalk invariant — the ref is kept out of the prompt text so the agent can only fetch by in-turn attachment id, never by a hallucinated/malformed ref. When the SDK starts forwarding metadata (agent-messenger#214), only `line-attachment.ts` needs enriching; the adapter/classifier contract doesn't change.
- **Contact/location/unknown route as placeholder-only text, no attachment.** `InboundAttachment.kind` has no `contact`/`location` member, and inventing one with an empty ref would hand the agent an unusable handle. Better to let it see `[LINE contact]` than to fabricate a fake attachment — or to keep dropping it entirely.
- **Defensive `content_type` normalization.** The SDK stringifies the raw thrift enum, which is usually the symbolic name but can be numeric; `"7"` still maps to `STICKER`. `TEXT`/`text` are folded to LINE's wire spelling `NONE`.

## What this does NOT do

- Does **not** make attachments fetchable. No `ref`, no download — that needs `contentMetadata` from the SDK (agent-messenger#214).
- Does **not** touch the `Invalid response buffer <>` reconnect churn (agent-messenger#215).
- Does **not** change the self-author / unknown-chat / pre-connect drop gates: a sticker from yourself or from an unknown chat is still dropped for the same reason as before — the placeholder path runs only for messages that would otherwise route.

## Review notes

- Load-bearing change is the drop condition in `line-classify.ts`: `text === '' && attachments.length === 0`. Verify a blank `NONE` message still drops as `empty_text` (covered by tests) while a sticker routes.
- `splitInboundLine` is the single content-type→placeholder/kind mapping point; the table is small and explicit.
- Tests cover the helper, the classifier boundary (route sticker, route contact placeholder-only, still-drop empty/self/unknown-chat), and content-type normalization including the numeric-enum and `TEXT`→`NONE` cases.