### PR TITLE
Wait for proc-bind sentinel readiness

### DIFF
--- a/src/channels/adapters/line-attachment.test.ts
+++ b/src/channels/adapters/line-attachment.test.ts
@@ -5,6 +5,7 @@ import type { LinePushMessageEvent } from 'agent-messenger/line'
 import { normalizeLineContentType, splitInboundLine } from './line-attachment'
 
 function event(overrides: Partial<LinePushMessageEvent> = {}): LinePushMessageEvent {
+  const metadata = { content_metadata: {} as Record<string, string> }
   return {
     type: 'message',
     chat_id: 'C1',
@@ -13,6 +14,7 @@ function event(overrides: Partial<LinePushMessageEvent> = {}): LinePushMessageEv
     text: null,
     content_type: 'NONE',
     sent_at: '2025-01-02T03:04:05.000Z',
+    ...metadata,
     ...overrides,
   }
 }

--- a/src/channels/adapters/line-attachment.test.ts
+++ b/src/channels/adapters/line-attachment.test.ts
@@ -14,7 +14,6 @@ function event(overrides: Partial<LinePushMessageEvent> = {}): LinePushMessageEv
     content_type: 'NONE',
     sent_at: '2025-01-02T03:04:05.000Z',
     ...overrides,
-    content_metadata: overrides.content_metadata ?? {},
   }
 }
 

--- a/src/channels/adapters/line-classify.test.ts
+++ b/src/channels/adapters/line-classify.test.ts
@@ -9,6 +9,7 @@ import { classifyInbound, type LineChatLookup } from './line-classify'
 const CONFIG = {} as ChannelAdapterConfig
 
 function event(overrides: Partial<LinePushMessageEvent> = {}): LinePushMessageEvent {
+  const metadata = { content_metadata: {} as Record<string, string> }
   return {
     type: 'message',
     chat_id: 'C1',
@@ -17,6 +18,7 @@ function event(overrides: Partial<LinePushMessageEvent> = {}): LinePushMessageEv
     text: 'hello',
     content_type: 'text',
     sent_at: '2025-01-02T03:04:05.000Z',
+    ...metadata,
     ...overrides,
   }
 }

--- a/src/channels/adapters/line-classify.test.ts
+++ b/src/channels/adapters/line-classify.test.ts
@@ -18,7 +18,6 @@ function event(overrides: Partial<LinePushMessageEvent> = {}): LinePushMessageEv
     content_type: 'text',
     sent_at: '2025-01-02T03:04:05.000Z',
     ...overrides,
-    content_metadata: overrides.content_metadata ?? {},
   }
 }
 

--- a/src/channels/adapters/line.test.ts
+++ b/src/channels/adapters/line.test.ts
@@ -190,7 +190,6 @@ describe('createLineAdapter lifecycle', () => {
       author_id: 'U_other',
       text: 'hello bot',
       content_type: 'text',
-      content_metadata: {},
       sent_at: '2025-01-02T00:00:00.000Z',
     })
     await waitFor(() => routed.length > 0)

--- a/src/channels/adapters/line.test.ts
+++ b/src/channels/adapters/line.test.ts
@@ -183,15 +183,17 @@ describe('createLineAdapter lifecycle', () => {
     expect(router.registered.history).toBe(true)
     expect(router.registered.nameResolver).toBe(true)
 
-    listener.emit('message', {
-      type: 'message',
+    const message = {
+      type: 'message' as const,
       chat_id: 'C1',
       message_id: 'M1',
       author_id: 'U_other',
       text: 'hello bot',
       content_type: 'text',
+      content_metadata: {},
       sent_at: '2025-01-02T00:00:00.000Z',
-    })
+    }
+    listener.emit('message', message)
     await waitFor(() => routed.length > 0)
     expect(routed[0]!.text).toBe('hello bot')
     expect(routed[0]!.workspace).toBe('@line-dm')

--- a/src/sandbox/availability.test.ts
+++ b/src/sandbox/availability.test.ts
@@ -4,6 +4,7 @@ import {
   _resetBwrapAvailabilityCacheForTests,
   _resetProcBindProbeCacheForTests,
   _resetRealProcProbeCacheForTests,
+  _waitForSentinelMarkerForTests,
   buildProcBindProbeScript,
   canBindProcSafely,
   canMountRealProc,
@@ -342,5 +343,43 @@ describe('resolveProcBindSafetyWithRetry', () => {
       PROC_BIND_RETRY_BACKOFF_MS,
     )
     expect(result).toBe('safe')
+  })
+})
+
+describe('waitForSentinelMarker', () => {
+  test('polls through the spawn/exec race until the marker appears', async () => {
+    let reads = 0
+    const sleeps: number[] = []
+    const result = await _waitForSentinelMarkerForTests(
+      1234,
+      () => Promise.resolve(++reads === 3),
+      (ms) => (sleeps.push(ms), Promise.resolve()),
+      1_000,
+      25,
+    )
+
+    expect(result).toBe(true)
+    expect(reads).toBe(3)
+    expect(sleeps).toEqual([25, 25])
+  })
+
+  test('returns false when the marker never appears before the readiness deadline', async () => {
+    const sleeps: number[] = []
+    let now = 0
+    const result = await _waitForSentinelMarkerForTests(
+      1234,
+      () => Promise.resolve(false),
+      (ms) => {
+        sleeps.push(ms)
+        now += ms
+        return Promise.resolve()
+      },
+      50,
+      25,
+      () => now,
+    )
+
+    expect(result).toBe(false)
+    expect(sleeps).toEqual([25, 25])
   })
 })

--- a/src/sandbox/availability.ts
+++ b/src/sandbox/availability.ts
@@ -299,9 +299,14 @@ async function probeProcBind(bwrap: string): Promise<ProcBindProbe> {
     // marker: that proves the sentinel is dumpable, same-uid, AND that this pid is
     // OUR sentinel (not a reused pid), so the ONLY thing that can deny the read
     // from inside the sandbox is the child-userns boundary (rules out a false
-    // "blocked" from dumpable=0 / uid mismatch). If the parent can't read the
-    // marker, the sentinel setup is unsound — inconclusive, fail closed, no cache.
-    if (!(await parentReadsSentinelMarker(sentinelPid))) return INCONCLUSIVE
+    // "blocked" from dumpable=0 / uid mismatch). The marker can be absent for a
+    // moment right after Bun.spawn: the child pid exists before `/usr/bin/env -i
+    // SECRET=... /bin/sleep` has exec'd and replaced its environ. Treating that
+    // startup race as immediate INCONCLUSIVE made the retry budget collapse into
+    // pure backoff time (~7.25s) and produced the first-tool `bunx` degrade even
+    // though the same host proved safe on the next call. Wait briefly for the
+    // marker before deciding setup is unsound; a real failure still fails closed.
+    if (!(await waitForSentinelMarker(sentinelPid))) return INCONCLUSIVE
 
     const proc = Bun.spawn(
       [
@@ -404,6 +409,9 @@ async function probeProcBind(bwrap: string): Promise<ProcBindProbe> {
 // briefly-saturated box; a genuinely wedged runtime still trips it and degrades.
 const PROC_BIND_PROBE_TIMEOUT_MS = 12_000
 
+const PROC_BIND_SENTINEL_READY_TIMEOUT_MS = 1_000
+const PROC_BIND_SENTINEL_READY_POLL_MS = 25
+
 // Designated probe-script exit codes. ONLY these two are a cacheable verdict;
 // every other code (a setup failure, bwrap startup failure, a signal, 127, …) is
 // inconclusive and must NOT be cached — see the exit-code interpretation in
@@ -473,6 +481,24 @@ async function parentReadsSentinelMarker(sentinelPid: number): Promise<boolean> 
     return false
   }
 }
+
+async function waitForSentinelMarker(
+  sentinelPid: number,
+  readMarker: (pid: number) => Promise<boolean> = parentReadsSentinelMarker,
+  sleep: (ms: number) => Promise<void> = (ms) => Bun.sleep(ms),
+  timeoutMs: number = PROC_BIND_SENTINEL_READY_TIMEOUT_MS,
+  pollMs: number = PROC_BIND_SENTINEL_READY_POLL_MS,
+  now: () => number = Date.now,
+): Promise<boolean> {
+  const deadline = now() + timeoutMs
+  for (;;) {
+    if (await readMarker(sentinelPid)) return true
+    if (now() >= deadline) return false
+    await sleep(pollMs)
+  }
+}
+
+export const _waitForSentinelMarkerForTests = waitForSentinelMarker
 
 export function _resetProcBindProbeCacheForTests(): void {
   procBindProbeCache.clear()


### PR DESCRIPTION
## Summary
- wait briefly for the proc-bind sentinel marker before treating parent-side marker reads as inconclusive
- avoid false degraded tmpfs `/proc` mode during the child spawn/exec window that can break the first sandboxed `bunx` call
- remove stale LINE test fixture metadata fields so current `main` typechecks cleanly

## Context
PR #778 fixed the sticky-cache/retryable error handling path, but the recurring failure still pointed at a core probe race: the parent can observe the sentinel PID before `/usr/bin/env -i ... /bin/sleep` has installed the marker environment. This follow-up keeps the same fail-closed security invariant, but gives the sentinel a short readiness window before classifying the setup as inconclusive.

## Verification
- `bun test --parallel src/sandbox/availability.test.ts` — 32 pass, 1 skip, 0 fail
- `bun test --parallel src/channels/adapters/line-attachment.test.ts src/channels/adapters/line-classify.test.ts src/channels/adapters/line.test.ts` — 32 pass, 0 fail
- `bun run lint` — 0 errors (existing warnings only)
- `bun run format:check` — pass
- `bun run typecheck` — pass
- `bun run test` — 8612 pass, 1 skip, 0 fail
