### PR TITLE
Fix reload when Docker host port stops accepting WebSockets

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -20,7 +20,7 @@ TypeClaw runs code in three stages with different filesystems ([/concepts/archit
 | `typeclaw tui`     | Attach an interactive TUI. Takes an optional one-shot prompt argument; `--url` to override the websocket URL.                    |
 | `typeclaw reload`  | Re-read `typeclaw.json` and apply hot-reloadable fields. Reports which fields require a restart.                                 |
 
-`--port` is the **preferred** host port. On bind conflict, `start` allocates an ephemeral port; subsequent commands resolve the actual port by querying Docker.
+`--port` is the **preferred** host port. On bind conflict, `start` allocates an ephemeral port; subsequent commands resolve the actual port by querying Docker. If Docker reports a published port but `typeclaw reload` cannot open that host websocket, reload falls back to a one-shot container-local websocket through `docker exec` and prints a repair hint; run `typeclaw restart --port 0` when safe to repair host TUI/reload connectivity.
 
 ## Providers
 

--- a/src/cli/reload.test.ts
+++ b/src/cli/reload.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test, type Mock } from 'bun:test'
+
+import { printReloadRecoveryHint } from './reload'
+
+describe('printReloadRecoveryHint', () => {
+  let consoleError: Mock<(...args: unknown[]) => void>
+
+  beforeEach(() => {
+    consoleError = spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleError.mockRestore()
+  })
+
+  test('prints the repair hint for container-local recovery', () => {
+    printReloadRecoveryHint('connection ended')
+
+    expect(consoleError).toHaveBeenCalledTimes(2)
+    expect(consoleError.mock.calls[0]?.[0]).toContain('Recovered via container-local reload')
+    expect(consoleError.mock.calls[0]?.[0]).toContain('connection ended')
+    expect(consoleError.mock.calls[1]?.[0]).toContain('typeclaw restart --port 0')
+  })
+
+  test('prints nothing when host reload succeeds', () => {
+    printReloadRecoveryHint(undefined)
+
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/reload.ts
+++ b/src/cli/reload.ts
@@ -2,7 +2,7 @@ import { defineCommand } from 'citty'
 
 import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
-import { requestReload, type ReloadResult } from '@/reload'
+import { requestReloadWithFallback, type ReloadResult } from '@/reload'
 
 import { c, errorLine, spinner } from './ui'
 
@@ -24,17 +24,28 @@ export const reload = defineCommand({
     },
   },
   async run({ args }) {
-    const url = args.url ?? (await defaultUrl())
+    const timeoutMs = Number(args.timeout)
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      console.error(errorLine(`invalid --timeout value: ${args.timeout}`))
+      process.exit(1)
+    }
+
+    const target = args.url === undefined ? await defaultTarget() : { url: args.url }
 
     const s = spinner()
     s.start('Reloading...')
     let results: ReloadResult[]
+    let recoveredHostError: string | undefined
     try {
-      results = await requestReload({ url, timeoutMs: Number(args.timeout) })
+      const response = await requestReloadWithFallback({ ...target, timeoutMs })
+      results = response.results
+      if (response.transport === 'container-local') recoveredHostError = response.hostError
     } catch (err) {
       s.error(`reload failed: ${err instanceof Error ? err.message : String(err)}`)
       process.exit(1)
     }
+
+    printReloadRecoveryHint(recoveredHostError)
 
     if (results.length === 0) {
       s.stop(c.dim('Nothing to reload.'))
@@ -61,7 +72,17 @@ export const reload = defineCommand({
   },
 })
 
-async function defaultUrl(): Promise<string> {
+export function printReloadRecoveryHint(recoveredHostError: string | undefined): void {
+  if (recoveredHostError === undefined) return
+  console.error(
+    c.yellow(
+      `Recovered via container-local reload because Docker's published host port is not accepting WebSockets (${recoveredHostError}).`,
+    ),
+  )
+  console.error(c.dim('Run `typeclaw restart --port 0` when safe to repair host TUI/reload connectivity.'))
+}
+
+async function defaultTarget(): Promise<{ url: string; cwd: string; token: string | null }> {
   const cwd = findAgentDir(process.cwd()) ?? process.cwd()
   const precheck = await requireContainerRunning({ cwd })
   if (!precheck.ok) {
@@ -72,5 +93,5 @@ async function defaultUrl(): Promise<string> {
   const token = await resolveTuiToken({ cwd })
   const url = new URL(`ws://127.0.0.1:${port}`)
   if (token !== null) url.searchParams.set('token', token)
-  return url.toString()
+  return { url: url.toString(), cwd, token }
 }

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -15,6 +15,7 @@ export {
   DOCKER_NOT_FOUND_STDERR,
   imageTagFromCwd,
   inspectContainer,
+  sanitizeDockerStderr,
   type ContainerState,
   type DockerAvailability,
   type DockerExec,

--- a/src/reload/client.test.ts
+++ b/src/reload/client.test.ts
@@ -4,7 +4,7 @@ import type { Server as BunServer, ServerWebSocket } from 'bun'
 
 import type { ClientMessage, ServerMessage } from '@/shared'
 
-import { requestReload } from './client'
+import { ReloadConnectionError, requestReload } from './client'
 import type { ReloadResult } from './types'
 
 type WsData = Record<string, never>
@@ -89,17 +89,17 @@ describe('requestReload', () => {
   })
 
   test('rejects when the server cannot be reached', async () => {
-    await expect(requestReload({ url: 'ws://localhost:1', timeoutMs: 200 })).rejects.toThrow()
+    await expect(requestReload({ url: 'ws://localhost:1', timeoutMs: 200 })).rejects.toThrow(ReloadConnectionError)
   })
 
   test('redacts tokenized URLs in connection errors', async () => {
     try {
-      await requestReload({ url: 'ws://localhost:1?token=secret-token', timeoutMs: 200 })
+      await requestReload({ url: 'ws://localhost:1?token=sample-value', timeoutMs: 200 })
       throw new Error('expected requestReload to reject')
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       expect(message).toContain('token=%3Credacted%3E')
-      expect(message).not.toContain('secret-token')
+      expect(message).not.toContain('sample-value')
     }
   })
 

--- a/src/reload/client.ts
+++ b/src/reload/client.ts
@@ -10,6 +10,13 @@ export type RequestReloadOptions = {
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
+export class ReloadConnectionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ReloadConnectionError'
+  }
+}
+
 export async function requestReload({
   url,
   scope,
@@ -26,11 +33,15 @@ export async function requestReload({
     }
     const onError = (err: unknown) => {
       cleanup()
-      reject(new Error(`failed to connect to ${displayUrl}: ${err instanceof Error ? err.message : String(err)}`))
+      reject(
+        new ReloadConnectionError(
+          `failed to connect to ${displayUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      )
     }
     const onClose = () => {
       cleanup()
-      reject(new Error(`connection to ${displayUrl} closed before opening`))
+      reject(new ReloadConnectionError(`connection to ${displayUrl} closed before opening`))
     }
     const cleanup = () => {
       if (timer !== undefined) clearTimeout(timer)
@@ -41,7 +52,7 @@ export async function requestReload({
     timer = setTimeout(() => {
       cleanup()
       ws.close()
-      reject(new Error(`timed out connecting to ${displayUrl} after ${timeoutMs}ms`))
+      reject(new ReloadConnectionError(`timed out connecting to ${displayUrl} after ${timeoutMs}ms`))
     }, timeoutMs)
     ws.addEventListener('open', onOpen, { once: true })
     ws.addEventListener('error', onError, { once: true })

--- a/src/reload/docker-exec-client.test.ts
+++ b/src/reload/docker-exec-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { DockerExec, DockerExecResult } from '@/container'
+
+import { requestReloadViaDockerExec } from './docker-exec-client'
+
+describe('requestReloadViaDockerExec', () => {
+  test('runs a container-local reload through docker exec', async () => {
+    const calls: string[][] = []
+    const exec: DockerExec = async (args) => {
+      calls.push(args)
+      return result({ stdout: JSON.stringify({ ok: true, results: [{ scope: 'config', ok: true, summary: 'ok' }] }) })
+    }
+
+    const results = await requestReloadViaDockerExec({
+      cwd: 'dobby',
+      token: 'sample-value',
+      scope: 'config',
+      timeoutMs: 1234,
+      exec,
+    })
+
+    expect(results).toEqual([{ scope: 'config', ok: true, summary: 'ok' }])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('dobby')
+    expect(calls[0]).toContain('TYPECLAW_TUI_TOKEN=sample-value')
+    expect(calls[0]).toContain('TYPECLAW_RELOAD_SCOPE=config')
+    expect(calls[0]).toContain('TYPECLAW_RELOAD_TIMEOUT_MS=1234')
+  })
+
+  test('omits token and scope env vars when absent', async () => {
+    const calls: string[][] = []
+    const exec: DockerExec = async (args) => {
+      calls.push(args)
+      return result({ stdout: JSON.stringify({ ok: true, results: [] }) })
+    }
+
+    await requestReloadViaDockerExec({ cwd: 'dobby', token: null, exec })
+
+    expect(calls[0]?.some((arg) => arg.startsWith('TYPECLAW_TUI_TOKEN='))).toBe(false)
+    expect(calls[0]?.some((arg) => arg.startsWith('TYPECLAW_RELOAD_SCOPE='))).toBe(false)
+  })
+
+  test('surfaces structured container-local reload failures', async () => {
+    const exec: DockerExec = async () =>
+      result({ exitCode: 1, stdout: JSON.stringify({ ok: false, reason: 'closed' }) })
+
+    await expect(requestReloadViaDockerExec({ cwd: 'dobby', token: null, exec })).rejects.toThrow('closed')
+  })
+
+  test('sanitizes docker stderr when docker exec itself fails', async () => {
+    const exec: DockerExec = async () =>
+      result({
+        exitCode: 125,
+        stderr: "docker: Error response from daemon: No such container\nRun 'docker run --help' for more information\n",
+      })
+
+    await expect(requestReloadViaDockerExec({ cwd: 'dobby', token: null, exec })).rejects.toThrow('No such container')
+  })
+
+  test('aborts docker exec when the host-side timeout expires', async () => {
+    const exec: DockerExec = async (_args, options) => {
+      await new Promise<void>((resolve) => options?.signal?.addEventListener('abort', () => resolve(), { once: true }))
+      return result({ stdout: JSON.stringify({ ok: true, results: [] }) })
+    }
+
+    await expect(requestReloadViaDockerExec({ cwd: 'dobby', token: null, timeoutMs: 1, exec })).rejects.toThrow(
+      'docker exec timed out after 1ms',
+    )
+  })
+})
+
+function result(overrides: Partial<DockerExecResult>): DockerExecResult {
+  return { exitCode: 0, stdout: '', stderr: '', ...overrides }
+}

--- a/src/reload/docker-exec-client.ts
+++ b/src/reload/docker-exec-client.ts
@@ -1,0 +1,109 @@
+import {
+  CONTAINER_PORT,
+  containerNameFromCwd,
+  defaultDockerExec,
+  sanitizeDockerStderr,
+  type DockerExec,
+  type DockerExecResult,
+} from '@/container'
+
+import type { ReloadResult } from './types'
+
+export type RequestReloadViaDockerExecOptions = {
+  cwd: string
+  token: string | null
+  scope?: string
+  timeoutMs?: number
+  exec?: DockerExec
+}
+
+type DockerExecReloadEnvelope = { ok: true; results: ReloadResult[] } | { ok: false; reason: string }
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+const RELOAD_SCRIPT = String.raw`
+const timeoutMs = Number(process.env.TYPECLAW_RELOAD_TIMEOUT_MS ?? '30000')
+const url = new URL('ws://127.0.0.1:' + (process.env.TYPECLAW_CONTAINER_PORT ?? '8973'))
+if (process.env.TYPECLAW_TUI_TOKEN) url.searchParams.set('token', process.env.TYPECLAW_TUI_TOKEN)
+const ws = new WebSocket(url.toString())
+let settled = false
+const finish = (payload, code) => {
+  if (settled) return
+  settled = true
+  console.log(JSON.stringify(payload))
+  if (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN) ws.close()
+  setTimeout(() => process.exit(code), 0)
+}
+const timer = setTimeout(() => finish({ ok: false, reason: 'timed out waiting for container-local reload_result after ' + timeoutMs + 'ms' }, 1), timeoutMs)
+ws.addEventListener('open', () => {
+  const scope = process.env.TYPECLAW_RELOAD_SCOPE
+  ws.send(JSON.stringify(scope ? { type: 'reload', scope } : { type: 'reload' }))
+})
+ws.addEventListener('message', (event) => {
+  const msg = JSON.parse(String(event.data))
+  if (msg.type !== 'reload_result') return
+  clearTimeout(timer)
+  finish({ ok: true, results: msg.results }, 0)
+})
+ws.addEventListener('error', (event) => finish({ ok: false, reason: String(event.message ?? event) }, 1))
+ws.addEventListener('close', () => finish({ ok: false, reason: 'container-local websocket closed before reload_result' }, 1))
+`
+
+export async function requestReloadViaDockerExec({
+  cwd,
+  token,
+  scope,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  exec = defaultDockerExec,
+}: RequestReloadViaDockerExecOptions): Promise<ReloadResult[]> {
+  const envArgs = ['-e', `TYPECLAW_CONTAINER_PORT=${CONTAINER_PORT}`, '-e', `TYPECLAW_RELOAD_TIMEOUT_MS=${timeoutMs}`]
+  if (token !== null) envArgs.push('-e', `TYPECLAW_TUI_TOKEN=${token}`)
+  if (scope !== undefined) envArgs.push('-e', `TYPECLAW_RELOAD_SCOPE=${scope}`)
+
+  const signal = AbortSignal.timeout(timeoutMs)
+  let result: DockerExecResult
+  try {
+    result = await exec(['exec', ...envArgs, containerNameFromCwd(cwd), 'bun', '-e', RELOAD_SCRIPT], { signal })
+  } catch (err) {
+    if (signal.aborted) throw new Error(`docker exec timed out after ${timeoutMs}ms`)
+    throw err
+  }
+  if (signal.aborted) throw new Error(`docker exec timed out after ${timeoutMs}ms`)
+  if (result.exitCode !== 0) {
+    const envelope = parseEnvelope(result.stdout)
+    if (envelope !== null && !envelope.ok) throw new Error(envelope.reason)
+    const reason =
+      sanitizeDockerStderr(result.stderr) || result.stdout.trim() || `docker exec exited with code ${result.exitCode}`
+    throw new Error(reason)
+  }
+
+  const envelope = parseEnvelope(result.stdout)
+  if (envelope === null) throw new Error('container-local reload returned invalid JSON')
+  if (!envelope.ok) throw new Error(envelope.reason)
+  return envelope.results
+}
+
+function parseEnvelope(stdout: string): DockerExecReloadEnvelope | null {
+  const line = stdout
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .at(-1)
+  if (line === undefined) return null
+  try {
+    const parsed: unknown = JSON.parse(line)
+    return isEnvelope(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function isEnvelope(value: unknown): value is DockerExecReloadEnvelope {
+  if (!isRecord(value) || typeof value.ok !== 'boolean') return false
+  if (value.ok) return Array.isArray(value.results)
+  return typeof value.reason === 'string'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/src/reload/index.ts
+++ b/src/reload/index.ts
@@ -1,4 +1,10 @@
-export { requestReload, type RequestReloadOptions } from './client'
+export { ReloadConnectionError, requestReload, type RequestReloadOptions } from './client'
+export { requestReloadViaDockerExec, type RequestReloadViaDockerExecOptions } from './docker-exec-client'
 export { formatChannelReloadSummary } from './format'
 export { ReloadRegistry } from './registry'
+export {
+  requestReloadWithFallback,
+  type RequestReloadWithFallbackOptions,
+  type RequestReloadWithFallbackResult,
+} from './recover'
 export type { Reloadable, ReloadAllResult, ReloadResult } from './types'

--- a/src/reload/recover.test.ts
+++ b/src/reload/recover.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test'
+
+import { ReloadConnectionError } from './client'
+import { requestReloadWithFallback } from './recover'
+import type { ReloadResult } from './types'
+
+describe('requestReloadWithFallback', () => {
+  test('returns host results when the host websocket succeeds', async () => {
+    const expected: ReloadResult[] = [{ scope: 'config', ok: true, summary: 'host' }]
+
+    const result = await requestReloadWithFallback({
+      url: 'ws://127.0.0.1:8973',
+      reload: async () => expected,
+      reloadViaDockerExec: async () => [{ scope: 'config', ok: true, summary: 'fallback' }],
+    })
+
+    expect(result).toEqual({ transport: 'host', results: expected })
+  })
+
+  test('falls back through docker exec for auto-discovered connection failures', async () => {
+    const expected: ReloadResult[] = [{ scope: 'config', ok: true, summary: 'container' }]
+    const calls: Array<{ cwd: string; token: string | null; timeoutMs: number | undefined }> = []
+
+    const result = await requestReloadWithFallback({
+      url: 'ws://127.0.0.1:8973?token=sample-value',
+      cwd: 'dobby',
+      token: 'sample-value',
+      timeoutMs: 5000,
+      reload: async () => {
+        throw new ReloadConnectionError('connection ended')
+      },
+      reloadViaDockerExec: async ({ cwd, token, timeoutMs }) => {
+        calls.push({ cwd, token, timeoutMs })
+        return expected
+      },
+    })
+
+    expect(result).toEqual({ transport: 'container-local', results: expected, hostError: 'connection ended' })
+    expect(calls).toEqual([{ cwd: 'dobby', token: 'sample-value', timeoutMs: 5000 }])
+  })
+
+  test('does not fall back for explicit urls without auto-discovered container context', async () => {
+    await expect(
+      requestReloadWithFallback({
+        url: 'ws://example.invalid',
+        reload: async () => {
+          throw new ReloadConnectionError('connection ended')
+        },
+      }),
+    ).rejects.toThrow('connection ended')
+  })
+
+  test('does not fall back after non-connection host errors', async () => {
+    await expect(
+      requestReloadWithFallback({
+        url: 'ws://127.0.0.1:8973',
+        cwd: 'dobby',
+        token: null,
+        reload: async () => {
+          throw new Error('timed out waiting for reload_result')
+        },
+        reloadViaDockerExec: async () => [],
+      }),
+    ).rejects.toThrow('timed out waiting for reload_result')
+  })
+})

--- a/src/reload/recover.ts
+++ b/src/reload/recover.ts
@@ -1,0 +1,38 @@
+import { ReloadConnectionError, requestReload } from './client'
+import { requestReloadViaDockerExec } from './docker-exec-client'
+import type { ReloadResult } from './types'
+
+export type RequestReloadWithFallbackOptions = {
+  url: string
+  cwd?: string
+  token?: string | null
+  scope?: string
+  timeoutMs?: number
+  reload?: typeof requestReload
+  reloadViaDockerExec?: typeof requestReloadViaDockerExec
+}
+
+export type RequestReloadWithFallbackResult =
+  | { transport: 'host'; results: ReloadResult[] }
+  | { transport: 'container-local'; results: ReloadResult[]; hostError: string }
+
+export async function requestReloadWithFallback({
+  url,
+  cwd,
+  token,
+  scope,
+  timeoutMs,
+  reload = requestReload,
+  reloadViaDockerExec = requestReloadViaDockerExec,
+}: RequestReloadWithFallbackOptions): Promise<RequestReloadWithFallbackResult> {
+  try {
+    return { transport: 'host', results: await reload({ url, scope, timeoutMs }) }
+  } catch (err) {
+    if (!(err instanceof ReloadConnectionError) || cwd === undefined || token === undefined) throw err
+    return {
+      transport: 'container-local',
+      results: await reloadViaDockerExec({ cwd, token, scope, timeoutMs }),
+      hostError: err.message,
+    }
+  }
+}


### PR DESCRIPTION
## Background

`typeclaw reload` resolves the published Docker host port for auto-discovered agents, but Docker can still report a mapping after that host port stops accepting WebSocket connections. In that state, reload should recover when TypeClaw has enough container context, while explicit operator-provided targets must keep failing directly so remote or custom endpoints are not masked.

## Summary

- Classify pre-open reload connection failures.
- Add bounded container-local docker exec reload transport.
- Fallback only for auto-discovered reload targets while preserving explicit `--url`.
- Print repair hint and update CLI docs.

## Preview

No UI preview. This changes CLI recovery behavior and its terminal repair hint.

## What this does NOT do

- Does not change the published Docker port selection or container startup path.
- Does not fall back for explicit `--url` targets.
- Does not hide non-connection reload failures after the WebSocket opens.

## Review notes

- Verify fallback is limited to classified pre-open connection failures with auto-discovered container context.
- Verify the container-local transport is bounded by the same reload timeout and does not leak tokenized URLs in user-facing errors.
- Verify the repair hint points operators to `typeclaw restart --port 0` without implying reload permanently repaired host TUI connectivity.

## Verification

- `bun test --parallel src/cli/reload.test.ts src/reload/client.test.ts src/reload/docker-exec-client.test.ts src/reload/recover.test.ts` — 18 pass.
- `bun run typecheck`.
- `bun run format:check`.
- `bun run lint` — 0 errors; existing unrelated warnings.
- `bun run test` — 8601 pass, 1 skip, 0 fail.
