### PR TITLE
Require installs after dependency edits

### DIFF
--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { formatLocalDateTime, resolveLocalTimezoneName } from '@/shared'
 
-import { DEFAULT_SYSTEM_PROMPT, renderTurnRoleAnchor, renderTurnTimeAnchor } from './system-prompt'
+import { DEFAULT_SYSTEM_PROMPT, renderTurnRoleAnchor, renderTurnTimeAnchor, SLIM_SYSTEM_PROMPT } from './system-prompt'
 
 describe('subagent orchestration — explicit research routing', () => {
   // Guards the regression where an explicit "do a research" directive was answered
@@ -42,11 +42,14 @@ describe('delivering reports and documents', () => {
 })
 
 describe('version control dependency changes', () => {
-  test('requires package manager install after package.json dependency edits', () => {
-    expect(DEFAULT_SYSTEM_PROMPT).toContain('After editing `package.json`')
-    expect(DEFAULT_SYSTEM_PROMPT).toContain('bumping dependencies/plugins')
-    expect(DEFAULT_SYSTEM_PROMPT).toContain('matching the existing lockfile')
-    expect(DEFAULT_SYSTEM_PROMPT).toContain('Commit the lockfile change alongside the `package.json` edit')
+  test.each([
+    ['default prompt', DEFAULT_SYSTEM_PROMPT],
+    ['slim prompt', SLIM_SYSTEM_PROMPT],
+  ])('requires package manager install after package.json dependency edits in the %s', (_name, prompt) => {
+    expect(prompt).toContain('After editing `package.json`')
+    expect(prompt).toContain('bumping dependencies/plugins')
+    expect(prompt).toContain('matching the existing lockfile')
+    expect(prompt).toContain('Commit the lockfile change alongside the `package.json` edit')
   })
 })
 

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -41,6 +41,15 @@ describe('delivering reports and documents', () => {
   })
 })
 
+describe('version control dependency changes', () => {
+  test('requires package manager install after package.json dependency edits', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('After editing `package.json`')
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('bumping dependencies/plugins')
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('matching the existing lockfile')
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('Commit the lockfile change alongside the `package.json` edit')
+  })
+})
+
 describe('renderTurnTimeAnchor', () => {
   test('wraps the ISO timestamp, IANA zone, and weekday in a single <current-time> tag', () => {
     const now = new Date('2026-01-15T12:00:00+09:00')

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -83,6 +83,7 @@ Your agent folder is a git repository.
 - Commit any files you created, edited, or deleted before declaring a task done. One logical change = one commit; split unrelated changes.
 - Use \`git add <paths>\` (not \`git add -A\`). Imperative commit messages ("Update SOUL.md to be less formal"); explain *why* in the body if non-obvious.
 - Never commit \`secrets.json\`, \`.env\`, or anything under \`workspace/\` — truly-ignored by design. \`sessions/\` and \`memory/\` are gitignored but runtime-committed; don't \`git add\` them.
+- After editing \`package.json\` (adding, removing, or bumping dependencies/plugins), run the project's package manager to update the lockfile and installed dependency state — e.g. \`bun install\`, \`npm install\`, \`pnpm install\`, or \`yarn install\`, matching the existing lockfile. Commit the lockfile change alongside the \`package.json\` edit.
 - Never \`git push\`, \`git reset --hard\`, \`git rebase\`, or rewrite remote history unless the user explicitly asks.
 
 ## How to behave

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,5 +1,8 @@
 import { formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from '@/shared'
 
+const PACKAGE_JSON_INSTALL_RULE =
+  "After editing `package.json` (adding, removing, or bumping dependencies/plugins), run the project's package manager to update the lockfile and installed dependency state — e.g. `bun install`, `npm install`, `pnpm install`, or `yarn install`, matching the existing lockfile. Commit the lockfile change alongside the `package.json` edit."
+
 // The orchestration roster (the `Briefly: ...` enumeration of public subagents)
 // is GENERATED from the registry by `renderPublicSubagentRoster` and threaded in
 // here, so a newly-registered public subagent can never be silently missing from
@@ -83,7 +86,7 @@ Your agent folder is a git repository.
 - Commit any files you created, edited, or deleted before declaring a task done. One logical change = one commit; split unrelated changes.
 - Use \`git add <paths>\` (not \`git add -A\`). Imperative commit messages ("Update SOUL.md to be less formal"); explain *why* in the body if non-obvious.
 - Never commit \`secrets.json\`, \`.env\`, or anything under \`workspace/\` — truly-ignored by design. \`sessions/\` and \`memory/\` are gitignored but runtime-committed; don't \`git add\` them.
-- After editing \`package.json\` (adding, removing, or bumping dependencies/plugins), run the project's package manager to update the lockfile and installed dependency state — e.g. \`bun install\`, \`npm install\`, \`pnpm install\`, or \`yarn install\`, matching the existing lockfile. Commit the lockfile change alongside the \`package.json\` edit.
+- ${PACKAGE_JSON_INSTALL_RULE}
 - Never \`git push\`, \`git reset --hard\`, \`git rebase\`, or rewrite remote history unless the user explicitly asks.
 
 ## How to behave
@@ -251,6 +254,8 @@ Never echo secrets from \`secrets.json\` or \`.env\`, or any credential you see 
 Never suppress errors to make things "work", and never fabricate results. If something fails, report the failure clearly so the next run or the operator can act on it.
 
 Do not narrate routine, low-risk tool calls — just call the tool. Do not over-explain what you did unless asked.
+
+${PACKAGE_JSON_INSTALL_RULE}
 
 Your free-write zone is \`workspace/\`. Do not create files at the root of the agent folder unless the prompt names another path. \`public/\` is the guest-visible zone — write there anything meant to be shared with an untrusted caller (a \`guest\`-role turn cannot read \`workspace/\` but can read \`public/\`). Do not edit \`memory/topics/\` directly — the dreaming subagent owns it; to capture something memorable, surface it in your reply or let the memory-logger append to \`memory/streams/\`. Never stage or commit \`secrets.json\`, \`.env\`, \`sessions/\`, \`memory/\`, or \`workspace/\` — those are runtime- or user-managed.
 


### PR DESCRIPTION
## Background

Agents can edit package.json dependencies or plugin entries without running the matching package manager afterward. That leaves the lockfile and installed dependency state stale, so follow-up commands may fail even though the manifest change looks complete.

## Summary

Add a runtime prompt rule that tells agents to run the project package manager after adding, removing, or bumping dependencies/plugins in package.json. The rule also requires committing the lockfile update alongside the manifest edit so dependency changes stay reproducible for reviewers and future runs.

A regression test asserts the system prompt keeps the install, lockfile, and dependency/plugin guidance in place.

## Preview

Not applicable; this is a prompt-only behavior change.

## What this does NOT do

This does not change package manager detection, dependency installation code, or git behavior. It only updates the runtime guidance that agents receive.

## Review notes

Review the prompt wording for the invariant: after dependency or plugin edits in package.json, the matching package manager should run and the lockfile change should be committed with the manifest change.

## Verification

- `bun run lint` exited 0.
- `bun run format:check` exited 0.
- `bun typecheck` exited 0.
- `bun run test` exited 0.
- Full tests reported 8613 pass, 1 skip, 0 fail.