### PR TITLE
Filter Slack system messages

### DIFF
--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -86,6 +86,7 @@ describe('slack-bot classifyInbound — drop paths', () => {
 
   test('routes file-only uploads (empty text) with attachment summary so the agent sees the upload', () => {
     const event = buildEvent({
+      subtype: 'file_share',
       text: '',
       files: [
         {
@@ -113,6 +114,7 @@ describe('slack-bot classifyInbound — drop paths', () => {
 
   test('appends attachment summary to user text so the agent sees BOTH text and the file when the user typed something alongside the upload', () => {
     const event = buildEvent({
+      subtype: 'file_share',
       text: 'look at this',
       files: [
         {

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -301,6 +301,18 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.payload.thread).toBeNull()
   })
 
+  test('routes /me messages that mention the bot because they are user-authored messages', () => {
+    const event = buildEvent({ subtype: 'me_message', text: `waves at <@${BOT_USER_ID}>` })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+    expect(verdict.payload.text).toBe(`waves at <@${BOT_USER_ID}>`)
+  })
+
   test('top-level alias-only addressing anchors thread on the inbound ts so the bot can reply in-thread', () => {
     // given: a top-level message with no @mention and no thread_ts, but
     // containing one of the bot's plain-text aliases. Slack treats this

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -46,6 +46,14 @@ describe('slack-bot classifyInbound — drop paths', () => {
     expect(verdict).toEqual({ kind: 'drop', reason: 'no_user' })
   })
 
+  test('drops Slack system subtypes with a user because they are not replyable messages', () => {
+    const event = buildEvent({ subtype: 'channel_topic', text: 'set the channel topic:\nProject updates' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict).toEqual({ kind: 'drop', reason: 'slack_system_message' })
+  })
+
   test('drops messages with neither text nor files with reason=empty_text', () => {
     const event = buildEvent({ text: '' })
 

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -162,7 +162,7 @@ export function classifyInbound(
 }
 
 export function isRouteableSlackMessageSubtype(subtype: string | undefined): boolean {
-  return subtype === undefined || subtype === 'bot_message'
+  return subtype === undefined || subtype === 'bot_message' || subtype === 'file_share'
 }
 
 // Slack encodes user mentions inline as `<@U…>` (or `<@W…>` for some org

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -162,7 +162,7 @@ export function classifyInbound(
 }
 
 export function isRouteableSlackMessageSubtype(subtype: string | undefined): boolean {
-  return subtype === undefined || subtype === 'bot_message' || subtype === 'file_share'
+  return subtype === undefined || subtype === 'bot_message' || subtype === 'file_share' || subtype === 'me_message'
 }
 
 // Slack encodes user mentions inline as `<@U…>` (or `<@W…>` for some org

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -14,6 +14,7 @@ export type SlackInboundAppMentionEvent = SlackSocketModeAppMentionEvent
 export type InboundDropReason =
   | 'self_author' // event.user === botUserId; we never route our own messages back to ourselves
   | 'no_user' // event has no `user` field (e.g. system messages: channel_join, message_changed)
+  | 'slack_system_message' // non-replyable Slack message subtype events (e.g. channel_topic)
   | 'empty_text' // event has neither text nor files — nothing for the agent to act on
   | 'pre_connect' // bot identity is not known yet, so mention/self/reply classification cannot be trusted
 
@@ -60,6 +61,10 @@ export function classifyInbound(
     // subtype WITH a user (rare, but happens for legacy integrations) is
     // routed; subtype + no user still drops as `no_user`.
     return { kind: 'drop', reason: 'no_user' }
+  }
+
+  if (!isRouteableSlackMessageSubtype(event.subtype)) {
+    return { kind: 'drop', reason: 'slack_system_message' }
   }
 
   const rawText = event.text ?? ''
@@ -154,6 +159,10 @@ export function classifyInbound(
       ts: slackTsToMillis(event.ts),
     },
   }
+}
+
+export function isRouteableSlackMessageSubtype(subtype: string | undefined): boolean {
+  return subtype === undefined || subtype === 'bot_message'
 }
 
 // Slack encodes user mentions inline as `<@U…>` (or `<@W…>` for some org

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -1013,6 +1013,7 @@ describe('createSlackHistoryCallback', () => {
         {
           ts: '1700000000.000100',
           user: 'UALICE',
+          subtype: 'file_share',
           text: '이 사진 머임??',
           thread_ts: '1700000000.000100',
           files: [{ id: 'F123', name: 'photo.png', mimetype: 'image/png' }],

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -960,6 +960,29 @@ describe('createSlackHistoryCallback', () => {
     expect(result.messages.map((m) => m.text)).toEqual(['oldest', 'middle', 'newest'])
   })
 
+  test('omits Slack system subtypes from history context', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [
+        { ts: '1700000003.000300', user: 'UB', text: 'after topic' },
+        { ts: '1700000002.000200', user: 'UALICE', subtype: 'channel_topic', text: 'set the channel topic:\nUpdates' },
+        { ts: '1700000001.000100', user: 'UA', text: 'before topic' },
+      ],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => null,
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages.map((m) => m.text)).toEqual(['before topic', 'after topic'])
+  })
+
   test('preserves conversations.replies order (already oldest-first)', async () => {
     // given
     const { fn } = fakeFetch({

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -983,6 +983,25 @@ describe('createSlackHistoryCallback', () => {
     expect(result.messages.map((m) => m.text)).toEqual(['before topic', 'after topic'])
   })
 
+  test('keeps /me messages in history context', async () => {
+    // given
+    const { fn } = fakeFetch({
+      ok: true,
+      messages: [{ ts: '1700000001.000100', user: 'UALICE', subtype: 'me_message', text: '<@UBOT> waves' }],
+    })
+    const cb = createSlackHistoryCallback({
+      token: 'tok',
+      logger: silentLogger(),
+      botUserIdRef: () => 'UBOT',
+      fetchImpl: fn,
+    })
+    // when
+    const result = await cb({ chat: 'C0', thread: null, limit: 10 })
+    // then
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messages.map((m) => m.text)).toEqual(['<@UBOT> waves'])
+  })
+
   test('preserves conversations.replies order (already oldest-first)', async () => {
     // given
     const { fn } = fakeFetch({

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -1316,6 +1316,7 @@ function dropHint(reason: InboundDropReason): string {
     case 'no_user':
     case 'pre_connect':
     case 'self_author':
+    case 'slack_system_message':
       return ''
   }
 }

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -38,6 +38,7 @@ import {
   classifyInbound,
   describeSlackFile,
   type InboundDropReason,
+  isRouteableSlackMessageSubtype,
   renderPlaceholder,
   type SlackInboundAppMentionEvent,
   type SlackInboundMessageEvent,
@@ -694,7 +695,7 @@ export function createSlackHistoryCallback(deps: {
     }
 
     const botUserId = botUserIdRef()
-    const rawMessages = raw.messages ?? []
+    const rawMessages = (raw.messages ?? []).filter((message) => isRouteableSlackMessageSubtype(message.subtype))
     const mapped = rawMessages.map((m) => mapSlackMessage(m, botUserId))
     // History payloads carry no profile, so mapSlackMessage echoes the raw
     // id into authorName; resolve it here so prompts show display names.


### PR DESCRIPTION
## Background

Slack emits message subtype events for workspace system activity, including channel topic changes. Those events can include a user and text, so the live inbound path treated them like routeable conversation messages and the history path could carry the same notices into agent context.

Topic-change notices are not replyable user messages. Keeping them in either path can distract the agent with channel administration text instead of the human conversation it should answer.

## Summary

Add a shared Slack subtype classifier so both live inbound events and fetched history use the same routeability boundary. Plain messages and bot messages stay routeable, preserving peer bot behavior, while system subtypes such as channel topic changes are dropped before they can trigger or contextualize the agent.

Regression coverage exercises the live channel topic event path and the history filtering path so future Slack subtype handling stays consistent across both sources.

## Preview

Not applicable; this changes Slack adapter routing and context filtering behavior only.

## What this does NOT do

- Does not change peer bot message routing.
- Does not alter Slack API fetch limits or ordering behavior.
- Does not change non-Slack channel adapters.

## Review notes

The load-bearing invariant is that Slack subtype routeability is shared between live classification and history mapping. Review that bot messages remain routeable, while non-routeable system subtype events are excluded before they can become agent input.

## Verification

- `bun test --parallel src/channels/adapters/slack-bot-classify.test.ts src/channels/adapters/slack-bot.test.ts` passed with 138 pass and 0 fail.
- `bun run typecheck` passed.
- `bun run lint` completed with warnings only and 0 errors.
- `bun run format` completed.
- `bun run lint && bun run format:check && bun typecheck && bun run test` passed with 8627 pass, 1 skip, and 0 fail.