### PR TITLE
Suppress LINE auth token dump

### DIFF
--- a/src/init/line-auth.test.ts
+++ b/src/init/line-auth.test.ts
@@ -49,6 +49,73 @@ function nonPersistingClient(result: LineLoginResult): LineLoginClient {
   return { loginWithQR: login, loginWithEmail: login }
 }
 
+function loggingClient(agentDir: string): LineLoginClient {
+  const store = new SecretsLineCredentialStore({ mode: 'host', secretsPath: join(agentDir, 'secrets.json') })
+  const login = async (): Promise<LineLoginResult> => {
+    console.log(lineTokenInfoDump())
+    console.log('visible login progress')
+    await store.setAccount({
+      account_id: 'mid-logged',
+      auth_token: 'persisted-token',
+      device: 'DESKTOPMAC',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    })
+    return { authenticated: true, account_id: 'mid-logged' }
+  }
+  return { loginWithQR: login, loginWithEmail: login }
+}
+
+function lineTokenInfoDump(): Record<string, unknown> {
+  return {
+    1: 'header.payload.signature',
+    2: 'refresh.header.payload',
+    3: 3600,
+    4: { 1: 200 },
+    5: 'session-id',
+    6: 1781093119,
+  }
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {}
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+function controlledLoggingClient(
+  agentDir: string,
+  accountId: string,
+  entered: string[],
+  release: Promise<void>,
+): LineLoginClient {
+  const store = new SecretsLineCredentialStore({ mode: 'host', secretsPath: join(agentDir, 'secrets.json') })
+  const login = async (): Promise<LineLoginResult> => {
+    entered.push(accountId)
+    console.log(lineTokenInfoDump())
+    await release
+    await store.setAccount({
+      account_id: accountId,
+      auth_token: 'persisted-token',
+      device: 'DESKTOPMAC',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    })
+    return { authenticated: true, account_id: accountId }
+  }
+  return { loginWithQR: login, loginWithEmail: login }
+}
+
+function throwingLoggingClient(): LineLoginClient {
+  const login = async (): Promise<LineLoginResult> => {
+    console.log(lineTokenInfoDump())
+    throw new Error('login exploded')
+  }
+  return { loginWithQR: login, loginWithEmail: login }
+}
+
 describe('runLineBootstrap', () => {
   test('persists the account and sets it current on a successful QR login', async () => {
     await withDir(async (dir) => {
@@ -102,6 +169,104 @@ describe('runLineBootstrap', () => {
         client: nonPersistingClient({ authenticated: true, account_id: 'mid-1' }),
       })
       expect(status).toEqual({ ok: false, reason: 'LINE login authenticated but did not persist credentials' })
+    })
+  })
+
+  test('suppresses the upstream LINE token info dump without muting other logs', async () => {
+    await withDir(async (dir) => {
+      const originalLog = console.log
+      const logged: unknown[][] = []
+      const captureLog = (...args: unknown[]) => {
+        logged.push(args)
+      }
+      console.log = captureLog
+      try {
+        const status = await runLineBootstrap({
+          method: 'qr',
+          agentDir: dir,
+          callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+          client: loggingClient(dir),
+        })
+
+        expect(status).toEqual({ ok: true })
+        expect(console.log).toBe(captureLog)
+      } finally {
+        console.log = originalLog
+      }
+
+      expect(logged).toEqual([['visible login progress']])
+    })
+  })
+
+  test('serializes overlapping token dump suppression and restores console.log', async () => {
+    await withDir(async (firstDir) => {
+      await withDir(async (secondDir) => {
+        const originalLog = console.log
+        const logged: unknown[][] = []
+        const entered: string[] = []
+        const firstRelease = deferred()
+        const secondRelease = deferred()
+        const captureLog = (...args: unknown[]) => {
+          logged.push(args)
+        }
+        console.log = captureLog
+        try {
+          const first = runLineBootstrap({
+            method: 'qr',
+            agentDir: firstDir,
+            callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+            client: controlledLoggingClient(firstDir, 'mid-first', entered, firstRelease.promise),
+          })
+          const second = runLineBootstrap({
+            method: 'qr',
+            agentDir: secondDir,
+            callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+            client: controlledLoggingClient(secondDir, 'mid-second', entered, secondRelease.promise),
+          })
+
+          await Promise.resolve()
+          expect(entered).toEqual(['mid-first'])
+
+          firstRelease.resolve()
+          await expect(first).resolves.toEqual({ ok: true })
+          await Promise.resolve()
+          expect(entered).toEqual(['mid-first', 'mid-second'])
+
+          secondRelease.resolve()
+          await expect(second).resolves.toEqual({ ok: true })
+          expect(console.log).toBe(captureLog)
+        } finally {
+          console.log = originalLog
+        }
+
+        expect(logged).toEqual([])
+      })
+    })
+  })
+
+  test('restores console.log when LINE login throws', async () => {
+    await withDir(async (dir) => {
+      const originalLog = console.log
+      const logged: unknown[][] = []
+      const captureLog = (...args: unknown[]) => {
+        logged.push(args)
+      }
+      console.log = captureLog
+      try {
+        const status = await runLineBootstrap({
+          method: 'qr',
+          agentDir: dir,
+          callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+          client: throwingLoggingClient(),
+        })
+
+        expect(status).toEqual({ ok: false, reason: 'login exploded' })
+        expect(console.log).toBe(captureLog)
+      } finally {
+        console.log = originalLog
+      }
+
+      expect(logged).toEqual([])
     })
   })
 })

--- a/src/init/line-auth.ts
+++ b/src/init/line-auth.ts
@@ -44,6 +44,8 @@ export type LineLoginClient = {
   }): Promise<LineLoginResult>
 }
 
+let lineTokenInfoSuppressionQueue: Promise<void> = Promise.resolve()
+
 export function lineSecretsPath(agentDir: string): string {
   return join(agentDir, 'secrets.json')
 }
@@ -58,19 +60,20 @@ export async function runLineBootstrap(input: LineLoginInput): Promise<LineBoots
     // ~/.config/agent-messenger to keep in sync.
     const client = input.client ?? buildLineClient(store)
 
-    const result =
+    const result = await suppressLineTokenInfoDump(() =>
       input.method === 'qr'
-        ? await client.loginWithQR({
+        ? client.loginWithQR({
             onQRUrl: async (url) => {
               await input.callbacks.onQRUrl?.(url)
             },
             onPincode: input.callbacks.onPincode,
           })
-        : await client.loginWithEmail({
+        : client.loginWithEmail({
             email: input.email,
             password: input.password,
             onPincode: input.callbacks.onPincode,
-          })
+          }),
+    )
 
     if (!result.authenticated || result.account_id === undefined) {
       const reason = result.message ?? result.error ?? 'LINE login did not authenticate'
@@ -100,4 +103,46 @@ function buildLineClient(store: SecretsLineCredentialStore): LineLoginClient {
   // calls, so it stands in as the credential manager via a structural cast.
   const credManager = store as unknown as LineCredentialManager
   return new RealLineClient(credManager) as unknown as LineLoginClient
+}
+
+async function suppressLineTokenInfoDump<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = lineTokenInfoSuppressionQueue
+  let release: () => void = () => {}
+  lineTokenInfoSuppressionQueue = new Promise((resolve) => {
+    release = resolve
+  })
+  await previous
+
+  const originalLog = console.log
+  console.log = (...args: unknown[]) => {
+    if (isLineTokenInfoDump(args)) return
+    originalLog(...args)
+  }
+  try {
+    return await fn()
+  } finally {
+    console.log = originalLog
+    release()
+  }
+}
+
+function isLineTokenInfoDump(args: unknown[]): boolean {
+  if (args.length !== 1) return false
+  const value = args[0]
+  if (value === null || typeof value !== 'object') return false
+
+  const record = value as Record<string, unknown>
+  return (
+    looksLikeJwt(record['1']) &&
+    looksLikeJwt(record['2']) &&
+    typeof record['3'] === 'number' &&
+    typeof record['4'] === 'object' &&
+    typeof record['5'] === 'string' &&
+    typeof record['6'] === 'number'
+  )
+}
+
+function looksLikeJwt(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  return /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value)
 }


### PR DESCRIPTION
## Summary
- suppress the upstream LINE token-info debug dump during TypeClaw LINE auth
- keep non-token console output visible while the auth call runs
- serialize the suppression wrapper so overlapping LINE logins restore console.log safely

## Verification
- bun test --parallel src/init/line-auth.test.ts
- bun run format
- bun run typecheck
- bun run lint
- bun run test
- bun run format:check
- bun typecheck