### PR TITLE
Fix git-askpass refusing the userinfo-host password prompt

### DIFF
--- a/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
@@ -72,6 +72,29 @@ describe('ensureGitAskPassHelper — host-scoped behavior (executed)', () => {
     expect(out).toBe('x-access-token')
   })
 
+  // The password prompt git actually sends: once the helper answers
+  // `x-access-token` to the username prompt, git folds that userinfo into the
+  // host of the password prompt. This is the exact string a real HTTPS clone
+  // produces; without the userinfo arm in the guard it falls through to exit 1
+  // and the clone dies with "unable to read askpass response".
+  test('emits the token for the userinfo-host password prompt git sends after the username', async () => {
+    const { code, out } = await run("Password for 'https://x-access-token@github.com': ")
+    expect(code).toBe(0)
+    expect(out).toBe('ghs_secret_token')
+  })
+
+  test('is not fooled by a userinfo prompt whose host is a suffix lookalike', async () => {
+    const { code, out } = await run("Password for 'https://x-access-token@github.com.evil.test': ")
+    expect(code).toBe(1)
+    expect(out).toBe('')
+  })
+
+  test('is not fooled by a userinfo prompt whose real host is not github.com', async () => {
+    const { code, out } = await run("Password for 'https://github.com@evil.example/': ")
+    expect(code).toBe(1)
+    expect(out).toBe('')
+  })
+
   test('refuses (exit 1, no token) for a non-github host prompt', async () => {
     const { code, out } = await run("Password for 'https://evil.example': ")
     expect(code).toBe(1)

--- a/src/bundled-plugins/github-cli-auth/git-askpass.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.ts
@@ -12,12 +12,22 @@ import { dirname, join } from 'node:path'
 // `insteadOf`/`pushurl` rewrite redirected to) we exit non-zero WITHOUT printing
 // the token, so a redirect can never exfiltrate it. The analyzer already blocks
 // the known redirect vectors; this is defense-in-depth at the credential edge.
-// The host match is on \`//github.com/\` and \`//github.com'\` (git wraps the URL
-// in quotes: \`Password for 'https://github.com': \`) so it cannot be fooled by
-// \`evil-github.com\` or \`github.com.evil/\`.
+//
+// Two prompt shapes must match, because git rewrites the host between the two
+// prompts of a single clone/fetch: it first asks `Username for
+// 'https://github.com': `, and AFTER we answer `x-access-token` it folds that
+// userinfo into the host of the SECOND prompt — `Password for
+// 'https://x-access-token@github.com': `. So we accept both bare-host
+// (\`//github.com/\` or \`//github.com'\`) and userinfo-host
+// (\`//<user>@github.com/\` or \`//<user>@github.com'\`). The anchor is the
+// literal \`github.com\` immediately followed by \`/\` or the closing quote git
+// wraps the URL in, so it cannot be fooled by \`evil-github.com\`,
+// \`github.com.evil/\`, or \`x@github.com.evil/\`. Without the userinfo arm the
+// password prompt falls through to \`exit 1\` and every HTTPS clone/fetch fails
+// with "unable to read askpass response".
 const ASKPASS_SCRIPT = `#!/bin/sh
 case "$1" in
-  *//github.com/*|*//github.com\\'*) : ;;
+  *//github.com/*|*//github.com\\'*|*//*@github.com/*|*//*@github.com\\'*) : ;;
   *) exit 1 ;;
 esac
 case "$1" in


### PR DESCRIPTION
## Background

An agent with a fully-configured GitHub channel (App auth, `repos` including the
target) tried to `git clone https://github.com/owner/repo.git` and failed:

```
error: unable to read askpass response from '/usr/local/bin/typeclaw-git-askpass'
fatal: could not read Password for 'https://x-access-token@github.com': terminal prompts disabled
```

The App token was minted correctly and the `github-cli-auth` hook injected
`GIT_ASKPASS` + `TYPECLAW_GIT_TOKEN` as designed. The failure was in the askpass
helper's host-scoping guard, which only accepted `//github.com/` and
`//github.com'`.

A single HTTPS clone produces **two** askpass prompts, and git rewrites the host
between them:

1. `Username for 'https://github.com': ` → matches `//github.com'` → helper answers `x-access-token` ✓
2. `Password for 'https://x-access-token@github.com': ` → git has folded the
   username into the host, so the host segment is now `x-access-token@github.com'`
   → matches **neither** pattern → guard hits `exit 1` → empty password → fatal ✗

So **every** HTTPS `clone`/`fetch`/`pull` routed through the helper was broken.
It went unnoticed because the PR-review path talks to the GitHub API via
`gh`/`GH_TOKEN` (injected directly into the command env), never through git's
password prompt — only plain-`git` HTTPS remote ops hit the bug.

I confirmed the two prompt strings empirically by running a logging askpass
helper against a real clone, and confirmed the patched guard accepts both while
still rejecting the lookalike hosts below.

## Summary

Add the userinfo-host shape to the guard's allow-list:

```sh
*//github.com/*|*//github.com'*|*//*@github.com/*|*//*@github.com'*) : ;;
```

The anchor is still the literal `github.com` immediately followed by `/` or the
closing quote git wraps the URL in, so it continues to reject `evil-github.com`,
`github.com.evil/`, `x@github.com.evil`, and `github.com@evil.example`. The new
arm only widens acceptance to `//<userinfo>@github.com<delimiter>` — the exact
shape git emits on the password prompt.

The pre-existing password test asserted `'https://github.com'` — a string git
**never** sends on the password prompt (it always carries the username it just
asked for) — which is why the bug shipped despite test coverage. This PR adds the
real userinfo-host prompt git actually emits, plus two userinfo lookalike
negatives. Mutation-checked: reverting the guard fails exactly the new
userinfo-host test and nothing else.

## What this does NOT do

- No change to token minting, the `gh` path, or the git-command analyzer — the
  token still rides only in `TYPECLAW_GIT_TOKEN` (env), never in argv or git config.
- Does not broaden host scope beyond github.com.
- Does not add a standalone GitHub-credential mechanism for agents without the
  GitHub channel configured (out of scope; tracked separately).

## Review notes

- Load-bearing change: the single guard line in `git-askpass.ts:ASKPASS_SCRIPT`.
  The invariant to verify is that the two new arms accept only
  `//<userinfo>@github.com` followed by `/` or `'`, and that the lookalike
  negatives (`*.evil`, `github.com@evil`) still exit 1 with no token — covered by
  the executed-helper tests in `git-askpass.test.ts`.
