### PR TITLE
fix(github): detect review submissions in any command shape to stop duplicate approvals

### DIFF
--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -358,6 +358,36 @@ describe('review verdict idempotency guard', () => {
     expect(after).toBeNull()
   })
 
+  test('noteLandedReview arms the shield with no prior reservation (backstop path)', async () => {
+    // given: a verdict landed via a command shape pre-detection missed — no guard()
+    // ran, so there is no reservation and release() could not arm the shield
+    const g = makeShaGuard('sha-abc')
+    await g.noteLandedReview({ workspace: WS, prNumber: 43, verdict: 'APPROVE' })
+    // when: the next same-commit APPROVE fires while GitHub still reports NONE
+    const dup = await g.guard({ callId: 'a1', workspace: WS, prNumber: 43, verdict: 'APPROVE' })
+    // then: the lag shield blocks it — the gap the backstop was meant to close
+    expect(dup?.block).toBe(true)
+  })
+
+  test('noteLandedReview respects head SHA: a re-review on a new head is still allowed', async () => {
+    let currentSha = 'sha-old'
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' }),
+      resolveHeadSha: async () => currentSha,
+    })
+    await g.noteLandedReview({ workspace: WS, prNumber: 44, verdict: 'APPROVE' })
+    currentSha = 'sha-new'
+    const reapprove = await g.guard({ callId: 'a1', workspace: WS, prNumber: 44, verdict: 'APPROVE' })
+    expect(reapprove).toBeNull()
+  })
+
+  test('noteLandedReview ignores a non-verdict event', async () => {
+    const g = makeShaGuard('sha-abc')
+    await g.noteLandedReview({ workspace: WS, prNumber: 45, verdict: 'COMMENT' as 'APPROVE' })
+    const next = await g.guard({ callId: 'a1', workspace: WS, prNumber: 45, verdict: 'APPROVE' })
+    expect(next).toBeNull()
+  })
+
   test('the landed cache is process-wide: a second plugin instance sees the first instance landed verdict', async () => {
     const deps = {
       resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' as EffectiveVerdict }),

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -220,7 +220,7 @@ describe('review verdict idempotency guard', () => {
   // done) but GitHub's reviews read still lags, reporting NONE — the exact gap that
   // landed two APPROVEs on PR #691. The resolver returns NONE so these exercise the
   // raw-NONE path the shield is allowed to override.
-  const LAG_WINDOW_MS = 60_000
+  const LAG_WINDOW_MS = 120_000
   function makeShaGuard(headSha: string | null, now?: () => number) {
     return createApproveIdempotencyGuard({
       resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' }),
@@ -329,6 +329,33 @@ describe('review verdict idempotency guard', () => {
     clock += LAG_WINDOW_MS - 1
     const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 39, verdict: 'APPROVE' })
     expect(dup?.block).toBe(true)
+  })
+
+  test('thread fan-out: four sequential same-commit APPROVEs ~5s apart land only the first', async () => {
+    // The real incident: one channel session per inline review thread each fired a
+    // formal APPROVE on the same head while GitHub's reviews read still lagged
+    // (NONE). With detection now arming the shield on the first landed verdict, the
+    // three followers within the window are blocked.
+    let clock = 1_000
+    const g = makeShaGuard('sha-abc', () => clock)
+    const first = await g.guard({ callId: 't1', workspace: WS, prNumber: 224, verdict: 'APPROVE' })
+    expect(first).toBeNull()
+    await g.release({ callId: 't1', succeeded: true })
+    for (const callId of ['t2', 't3', 't4']) {
+      clock += 5_000
+      const dup = await g.guard({ callId, workspace: WS, prNumber: 224, verdict: 'APPROVE' })
+      expect(dup?.block).toBe(true)
+    }
+  })
+
+  test('a legitimate re-APPROVE just past the 2-minute window is allowed', async () => {
+    let clock = 1_000
+    const g = makeShaGuard('sha-abc', () => clock)
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 42, verdict: 'APPROVE' })
+    await g.release({ callId: 'a1', succeeded: true })
+    clock += LAG_WINDOW_MS + 1
+    const after = await g.guard({ callId: 'a2', workspace: WS, prNumber: 42, verdict: 'APPROVE' })
+    expect(after).toBeNull()
   })
 
   test('the landed cache is process-wide: a second plugin instance sees the first instance landed verdict', async () => {

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -33,6 +33,13 @@ export type ReviewVerdictGuard = {
     verdict: ReviewVerdict
   }) => Promise<ApproveBlock | null>
   release: (args: { callId: string; succeeded: boolean }) => Promise<void>
+  // Arms the read-after-write lag shield for a verdict that landed WITHOUT a prior
+  // guard() reservation. The pre-execution detector can miss a review-submission
+  // command shape, so the verdict is only recovered post-hoc from the REST result
+  // (review-recorder's backstop). Without this, `release()` has no reservation for
+  // that callId and never writes `recentLandedByPr`, leaving the next same-commit
+  // submission undeduped — the exact gap the backstop was meant to close.
+  noteLandedReview: (args: { workspace: string; prNumber: number; verdict: ReviewVerdict }) => Promise<void>
 }
 
 // Back-compat alias: the guard now covers REQUEST_CHANGES too, not just APPROVE.
@@ -234,6 +241,20 @@ export function createApproveIdempotencyGuard(deps: {
       } finally {
         releaseReservation(args.callId, reservation)
       }
+    },
+
+    async noteLandedReview(args): Promise<void> {
+      if (args.verdict !== 'APPROVE' && args.verdict !== 'REQUEST_CHANGES') return
+      // No pre-submit head was captured (guard() never ran), so the best pin we
+      // can prove is the CURRENT head. A null resolve becomes the uncertainty
+      // sentinel, which still matches the current head for the lag window — the
+      // same conservative behaviour release() uses for a push-during-review.
+      const headSha = (await deps.resolveHeadSha?.({ workspace: args.workspace, prNumber: args.prNumber })) ?? null
+      recentLandedByPr.set(prKey(args.workspace, args.prNumber), {
+        verdict: args.verdict,
+        headSha,
+        landedAt: now(),
+      })
     },
   }
 }

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -73,10 +73,15 @@ const LEASE_TTL_MS = 5 * 60_000
 // read-after-write lag rather than a genuine absence. GitHub's `/pulls/<n>/reviews`
 // list lags a write by up to ~10s, so a second engagement turn firing in that
 // window reads NONE and would land a duplicate. Observed duplicates were ~10-18s
-// apart; 60s is a comfortable lag margin without making a legitimate re-verdict
-// wait long. This window only shadows a raw NONE on the SAME verdict (+ same or
+// apart originally; a later fan-out incident spread FOUR sequential APPROVEs over
+// ~15s (one channel session per inline review thread), each ~3-7s after the last —
+// well inside the read lag yet beyond a single turn. 120s gives margin for that
+// thread fan-out plus slow API indexing without turning the shield into a human-
+// facing rate limit (a legitimate re-verdict after a new push carries a new head
+// SHA and bypasses this entirely; staying under ~5min avoids blocking genuine
+// re-reviews). This window only shadows a raw NONE on the SAME verdict (+ same or
 // uncertain head) — a DISMISSED/CHANGES_REQUESTED/flipped-verdict all bypass it.
-const RECENT_LANDED_TTL_MS = 60_000
+const RECENT_LANDED_TTL_MS = 120_000
 
 type Reservation = {
   key: string

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
@@ -87,6 +87,56 @@ describe('detectReviewSubmission — gh pr review porcelain', () => {
   })
 })
 
+describe('detectReviewSubmission — gh not at the start of the command', () => {
+  test('compound: cd /agent && gh api ... -f event=APPROVE (slash-less endpoint)', () => {
+    const result = detectReviewSubmission({
+      command: "cd /agent && gh api -X POST repos/acme/widgets/pulls/224/reviews -f event=APPROVE -f body='ok'",
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 224, verdict: 'APPROVE', source: 'api' })
+  })
+
+  test('compound with semicolon: cd /agent; gh pr review N --request-changes', () => {
+    const result = detectReviewSubmission({
+      command: 'cd /agent; gh pr review 224 --repo acme/widgets --request-changes',
+    })
+    expect(result).toEqual({
+      workspace: 'acme/widgets',
+      prNumber: 224,
+      verdict: 'REQUEST_CHANGES',
+      source: 'pr-review',
+    })
+  })
+
+  test('var-prefixed: tmp=$(mktemp) && gh api ... --input "$tmp" resolves the file verdict', () => {
+    const result = detectReviewSubmission({
+      command:
+        'tmp=$(mktemp /tmp/review-XXXX.json) && gh api -X POST /repos/acme/widgets/pulls/224/reviews --input "$tmp"',
+      inputFileContents: '{"event":"APPROVE","body":"verified"}',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 224, verdict: 'APPROVE', source: 'api' })
+  })
+
+  test('heredoc payload then gh --input on a later line resolves the file verdict', () => {
+    const result = detectReviewSubmission({
+      command:
+        "cat > /tmp/review.json <<'JSON'\n" +
+        '{"event":"APPROVE","body":"looks good"}\n' +
+        'JSON\n' +
+        'gh api -X POST /repos/acme/widgets/pulls/224/reviews --input /tmp/review.json',
+      inputFileContents: '{"event":"APPROVE","body":"looks good"}',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 224, verdict: 'APPROVE', source: 'api' })
+  })
+
+  test('a quoted body containing "; gh" or a fake endpoint is not mistaken for a second invocation', () => {
+    const result = detectReviewSubmission({
+      command:
+        "gh api -X POST /repos/acme/widgets/pulls/3/reviews -f event=APPROVE -f body='see; gh api repos/x/y/pulls/9/reviews -f event=REQUEST_CHANGES'",
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 3, verdict: 'APPROVE', source: 'api' })
+  })
+})
+
 describe('detectReviewSubmission — non-matches', () => {
   test('a plain pr view is null', () => {
     expect(detectReviewSubmission({ command: 'gh pr view 12 -R acme/widgets' })).toBeNull()

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
@@ -6,6 +6,15 @@ import type { ReviewVerdict } from '@/channels/github-review-turn-ledger'
 // inline `-f/-F event=...`, and the `gh pr review` porcelain. Returns null when
 // the command is not a verdict-bearing review submission (incl. COMMENT reviews,
 // which carry no false-receipt risk and are not tracked).
+//
+// The `gh` invocation does NOT have to lead the command. The observed duplicate-
+// approval incident used four different shapes — `cd /agent && gh api …`,
+// `tmp=$(mktemp); … ; gh api --input "$tmp"`, a heredoc-then-`gh` two-stager, and
+// the canonical bare `gh api …`. Only the bare shape was detected, so the
+// idempotency guard never armed for the other three and the duplicates landed.
+// Detection therefore scans every shell-separated segment for a `gh` invocation,
+// independent of `analyzeGhCommand` (which is a token-injection-safety gate, not a
+// proxy for "will this command execute" — a classic PAT skips that block).
 
 // `source` drives success detection downstream: the REST endpoints echo the
 // created review JSON, while the `gh pr review` porcelain prints a plain
@@ -24,13 +33,26 @@ export type GhReviewDetectInput = {
   inputFileContents?: string | null
 }
 
-const REVIEWS_ENDPOINT = /\/repos\/([^/\s]+)\/([^/\s]+)\/pulls\/(\d+)\/reviews\b/
+// `gh api` accepts the endpoint with or without a leading slash
+// (`repos/o/r/pulls/N/reviews` and `/repos/…` both work), so the match is
+// anchored on a `repos/` boundary, not a slash. The observed compound shape
+// `cd /agent && gh api -X POST repos/o/r/pulls/224/reviews …` used the
+// slash-less form and was missed by the slash-anchored pattern.
+const REVIEWS_ENDPOINT = /(?:^|\/)repos\/([^/\s]+)\/([^/\s]+)\/pulls\/(\d+)\/reviews\b/
 
 export function detectReviewSubmission(input: GhReviewDetectInput): DetectedReview | null {
-  const args = splitArgs(input.command)
-  if (args[0] !== 'gh') return null
+  const fileContents = input.inputFileContents ?? null
+  for (const segment of ghSegments(input.command)) {
+    const detected = detectInGhSegment(segment, fileContents)
+    if (detected !== null) return detected
+  }
+  return null
+}
+
+// Each segment is the argv of one `gh` invocation found anywhere in the command.
+function detectInGhSegment(args: readonly string[], fileContents: string | null): DetectedReview | null {
   const sub = args[1]
-  if (sub === 'api') return detectApiReview(args, input.inputFileContents ?? null)
+  if (sub === 'api') return detectApiReview(args, fileContents)
   if (sub === 'pr' && args[2] === 'review') return detectPrReview(args)
   return null
 }
@@ -139,37 +161,84 @@ function isRepoSlug(value: string | undefined): boolean {
   return owner !== undefined && owner !== '' && name !== undefined && name !== '' && rest.length === 0
 }
 
-// Quote-aware whitespace split. The interceptor guarantees a single bare `gh`
-// command before we record (no pipes/substitution), so this only needs to honor
-// quotes, not full shell grammar.
-function splitArgs(command: string): string[] {
-  const out: string[] = []
-  let cur = ''
+// Yields the argv of every `gh` invocation in the command, one per shell-
+// separated segment. A segment runs from one command separator (`&&`, `||`, `;`,
+// `|`, newline) to the next; within it we strip leading `VAR=value` assignments
+// (so `tmp=$(mktemp) gh …` and a `VAR=…` prefix both still see `gh` first) and
+// recognise `gh` as the segment's command word. Quote-aware so an embedded `;`
+// or `gh` inside a quoted body (e.g. a review `-f body='…'`) is not mistaken for
+// a separator or a second invocation.
+function* ghSegments(command: string): Generator<readonly string[]> {
+  for (const segment of splitSegments(command)) {
+    const args = stripLeadingAssignments(segment)
+    if (args[0] === 'gh') yield args
+  }
+}
+
+// Drop leading `NAME=value` tokens (env-var prefixes) so the command word that
+// follows them is the one we classify. `tmp=$(mktemp)` tokenises to a single
+// `tmp=$(mktemp)` token here (the `$(…)` stays attached), which this skips.
+function stripLeadingAssignments(args: readonly string[]): readonly string[] {
+  let i = 0
+  while (i < args.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(args[i] as string)) i++
+  return args.slice(i)
+}
+
+// Quote-aware split into shell segments AND tokens. Segments break on top-level
+// `&&`, `||`, `;`, `|`, and newlines (outside quotes). Heredoc bodies are NOT
+// modelled — a heredoc writes a payload file consumed by a later `gh … --input`
+// segment, and that file's contents are resolved separately (review-recorder
+// reads it off disk); detection here only needs the `gh` segment itself.
+function splitSegments(command: string): string[][] {
+  const segments: string[][] = []
+  let cur: string[] = []
+  let tok = ''
   let quote: '"' | "'" | null = null
-  let has = false
-  for (const ch of command) {
+  let hasTok = false
+  const endTok = () => {
+    if (hasTok) {
+      cur.push(tok)
+      tok = ''
+      hasTok = false
+    }
+  }
+  const endSeg = () => {
+    endTok()
+    if (cur.length > 0) {
+      segments.push(cur)
+      cur = []
+    }
+  }
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] as string
     if (quote !== null) {
       if (ch === quote) quote = null
-      else cur += ch
-      has = true
+      else tok += ch
+      hasTok = true
       continue
     }
     if (ch === '"' || ch === "'") {
       quote = ch
-      has = true
+      hasTok = true
       continue
     }
-    if (ch === ' ' || ch === '\t' || ch === '\n') {
-      if (has) {
-        out.push(cur)
-        cur = ''
-        has = false
-      }
+    const next = command[i + 1]
+    if ((ch === '&' && next === '&') || (ch === '|' && next === '|')) {
+      endSeg()
+      i++
       continue
     }
-    cur += ch
-    has = true
+    if (ch === ';' || ch === '|' || ch === '\n') {
+      endSeg()
+      continue
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\r') {
+      endTok()
+      continue
+    }
+    tok += ch
+    hasTok = true
   }
-  if (has) out.push(cur)
-  return out
+  endSeg()
+  return segments
 }

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -165,12 +165,18 @@ export default definePlugin({
         },
         'tool.after': async (event) => {
           checkGraphqlAuthNudge({ tool: event.tool, result: event.result })
-          const committed = commitReviewIfSucceeded({
+          const review = commitReviewIfSucceeded({
             sessionId: event.sessionId,
             callId: event.callId,
             result: event.result,
           })
-          await verdictGuard.release({ callId: event.callId, succeeded: committed })
+          await verdictGuard.release({ callId: event.callId, succeeded: review.committed })
+          // A backstop-recovered verdict had no guard() reservation, so release()
+          // could not arm the lag shield — do it explicitly here so the next
+          // same-commit submission is deduped.
+          if (review.landedFromResult !== null) {
+            await verdictGuard.noteLandedReview(review.landedFromResult)
+          }
         },
       },
     }

--- a/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
@@ -99,4 +99,44 @@ describe('review recorder', () => {
     commitReviewIfSucceeded({ sessionId: SESSION, callId: 'c8', result: textResult('(no recognizable output)') })
     expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 42, verdict: 'APPROVE' })).toBe(false)
   })
+
+  describe('post-execution backstop (pre-detection missed)', () => {
+    const LANDED_APPROVED = `{"id":7,"node_id":"PRR_x","state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/77"}`
+
+    test('credits a landed APPROVE from the REST response when no pending entry exists', () => {
+      // no noteReviewCommand — simulates a command shape the before-detector missed
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b1', result: textResult(LANDED_APPROVED) })
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 77, verdict: 'APPROVE' })).toBe(true)
+    })
+
+    test('credits a landed CHANGES_REQUESTED from the REST response', () => {
+      const out = `{"state":"CHANGES_REQUESTED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/78"}`
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b2', result: textResult(out) })
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 78, verdict: 'REQUEST_CHANGES' })).toBe(true)
+    })
+
+    test('does NOT credit when the state is present but a failure marker is also present (fail closed)', () => {
+      const out = `gh: Validation Failed (HTTP 422) {"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/79"}`
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b3', result: textResult(out) })
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 79, verdict: 'APPROVE' })).toBe(false)
+    })
+
+    test('does NOT credit a decisive state with no recoverable PR url', () => {
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b4', result: textResult('{"state":"APPROVED"}') })
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 77, verdict: 'APPROVE' })).toBe(false)
+    })
+
+    test('does NOT credit a COMMENT review state', () => {
+      const out = `{"state":"COMMENTED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/80"}`
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b5', result: textResult(out) })
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 80, verdict: 'APPROVE' })).toBe(false)
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 80, verdict: 'REQUEST_CHANGES' })).toBe(false)
+    })
+
+    test('the pending-entry path takes precedence over the backstop', async () => {
+      await noteReviewCommand({ callId: 'b6', command: `gh api /repos/${WS}/pulls/81/reviews -f event=APPROVE` })
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b6', result: textResult(SUCCESS_OUTPUT) })
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 81, verdict: 'APPROVE' })).toBe(true)
+    })
+  })
 })

--- a/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
@@ -6,12 +6,16 @@ import { join } from 'node:path'
 import { hasReview, resetReviewTurn } from '@/channels/github-review-turn-ledger'
 import type { ToolResult } from '@/plugin'
 
+import { __resetReviewVerdictGuardForTest, createApproveIdempotencyGuard } from './approve-idempotency'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
 
 const SESSION = 'ses_recorder'
 const WS = 'acme/widgets'
 
-afterEach(() => resetReviewTurn(SESSION))
+afterEach(() => {
+  resetReviewTurn(SESSION)
+  __resetReviewVerdictGuardForTest()
+})
 
 function textResult(text: string): ToolResult {
   return { content: [{ type: 'text', text }] }
@@ -137,6 +141,48 @@ describe('review recorder', () => {
       await noteReviewCommand({ callId: 'b6', command: `gh api /repos/${WS}/pulls/81/reviews -f event=APPROVE` })
       commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b6', result: textResult(SUCCESS_OUTPUT) })
       expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 81, verdict: 'APPROVE' })).toBe(true)
+    })
+
+    test('a pending-path commit returns no landedFromResult (release arms the shield)', async () => {
+      await noteReviewCommand({ callId: 'b7', command: `gh api /repos/${WS}/pulls/82/reviews -f event=APPROVE` })
+      const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b7', result: textResult(SUCCESS_OUTPUT) })
+      expect(result.committed).toBe(true)
+      expect(result.landedFromResult).toBeNull()
+    })
+
+    test('the backstop result returns landedFromResult for the caller to arm the shield', () => {
+      const out = `{"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/83"}`
+      const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b8', result: textResult(out) })
+      expect(result.committed).toBe(true)
+      expect(result.landedFromResult).toEqual({ workspace: WS, prNumber: 83, verdict: 'APPROVE', source: 'api' })
+    })
+  })
+
+  // Mirrors the plugin's tool.after wiring (index.ts): commitReviewIfSucceeded ->
+  // verdictGuard.noteLandedReview for the backstop path, then the next submission
+  // hits guard(). Proves the advertised "arm the dedupe window" actually holds for
+  // the fallback path — the gap the reviewer flagged.
+  describe('integration: backstop arms the idempotency lag shield', () => {
+    function makeGuard(headSha: string | null) {
+      return createApproveIdempotencyGuard({
+        resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' }),
+        resolveHeadSha: async () => headSha,
+      })
+    }
+
+    test('pre-detection missed, REST response detected, next same-commit APPROVE is blocked while GitHub returns NONE', async () => {
+      const guard = makeGuard('sha-abc')
+      // given: a verdict landed via a shape the before-detector missed (no pending,
+      // no guard() reservation) — only the REST result proves it
+      const out = `{"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/90"}`
+      const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'i1', result: textResult(out) })
+      // when: the plugin wires the recovered verdict into the guard, as tool.after does
+      expect(result.landedFromResult).not.toBeNull()
+      if (result.landedFromResult !== null) await guard.noteLandedReview(result.landedFromResult)
+      // then: a second engagement turn's same-commit APPROVE is deduped even though
+      // GitHub's reviews read still lags (NONE)
+      const dup = await guard.guard({ callId: 'i2', workspace: WS, prNumber: 90, verdict: 'APPROVE' })
+      expect(dup?.block).toBe(true)
     })
   })
 })

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -36,30 +36,43 @@ export async function noteReviewCommand(args: { callId: string; command: string 
   return { dump: detectReviewDump({ command: args.command, inputFileContents }), detected }
 }
 
-export function commitReviewIfSucceeded(args: { sessionId: string; callId: string; result: ToolResult }): boolean {
+export type CommitReviewResult = {
+  // Whether a verdict was credited this turn (drives verdictGuard.release()).
+  committed: boolean
+  // Set ONLY on the backstop path (pre-detection missed): the caller must arm the
+  // idempotency lag shield with this, since no guard() reservation exists to do it
+  // via release(). Null on the pending path, where release() arms the shield.
+  landedFromResult: DetectedReview | null
+}
+
+export function commitReviewIfSucceeded(args: {
+  sessionId: string
+  callId: string
+  result: ToolResult
+}): CommitReviewResult {
   const text = collectText(args.result.content)
   const detected = pending.get(args.callId)
   if (detected !== undefined) {
     pending.delete(args.callId)
-    if (!looksSucceeded(detected, text)) return false
+    if (!looksSucceeded(detected, text)) return { committed: false, landedFromResult: null }
     recordReview({
       sessionId: args.sessionId,
       workspace: detected.workspace,
       prNumber: detected.prNumber,
       verdict: detected.verdict,
     })
-    return true
+    return { committed: true, landedFromResult: null }
   }
 
   const landed = detectLandedReviewFromResult(text)
-  if (landed === null) return false
+  if (landed === null) return { committed: false, landedFromResult: null }
   recordReview({
     sessionId: args.sessionId,
     workspace: landed.workspace,
     prNumber: landed.prNumber,
     verdict: landed.verdict,
   })
-  return true
+  return { committed: true, landedFromResult: landed }
 }
 
 // Authoritative post-execution credit from a REST create-review response, used

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -12,6 +12,13 @@ import { detectReviewDump, type ReviewDumpDecision } from './gh-review-inline-de
 // succeeded. Strict success detection is the safe bias here — wrongly crediting a
 // review that never landed would re-open the false-receipt hole, so an ambiguous
 // result is treated as "not landed" and left uncredited.
+//
+// A post-execution BACKSTOP runs when pre-detection produced no pending entry: the
+// REST create-review response is authoritative (it echoes the landed review's
+// `state` and the PR url), so we can credit a verdict whose command shape dodged
+// the before-detector. This only arms the dedupe window for the NEXT submission —
+// it cannot un-land a duplicate already posted — but that is precisely what the
+// sequential fan-out incident needed: the first landed APPROVE must arm the shield.
 
 const pending = new Map<string, DetectedReview>()
 
@@ -30,17 +37,65 @@ export async function noteReviewCommand(args: { callId: string; command: string 
 }
 
 export function commitReviewIfSucceeded(args: { sessionId: string; callId: string; result: ToolResult }): boolean {
+  const text = collectText(args.result.content)
   const detected = pending.get(args.callId)
-  if (detected === undefined) return false
-  pending.delete(args.callId)
-  if (!looksSucceeded(detected, collectText(args.result.content))) return false
+  if (detected !== undefined) {
+    pending.delete(args.callId)
+    if (!looksSucceeded(detected, text)) return false
+    recordReview({
+      sessionId: args.sessionId,
+      workspace: detected.workspace,
+      prNumber: detected.prNumber,
+      verdict: detected.verdict,
+    })
+    return true
+  }
+
+  const landed = detectLandedReviewFromResult(text)
+  if (landed === null) return false
   recordReview({
     sessionId: args.sessionId,
-    workspace: detected.workspace,
-    prNumber: detected.prNumber,
-    verdict: detected.verdict,
+    workspace: landed.workspace,
+    prNumber: landed.prNumber,
+    verdict: landed.verdict,
   })
   return true
+}
+
+// Authoritative post-execution credit from a REST create-review response, used
+// only when pre-detection missed (no pending entry). Requires ALL of: a decisive
+// landed `state`, a recoverable PR identity from the echoed `pull_request_url`,
+// and no failure marker — so a partial/garbled capture or an unrelated success
+// line cannot fabricate a verdict. COMMENT and DISMISSED are not decisive and are
+// ignored, matching the before-detector's scope.
+function detectLandedReviewFromResult(text: string): DetectedReview | null {
+  if (FAILURE_MARKERS.some((m) => text.includes(m))) return null
+  const verdict = landedVerdictFromState(text)
+  if (verdict === null) return null
+  const pr = prFromPullRequestUrl(text)
+  if (pr === null) return null
+  return { workspace: pr.workspace, prNumber: pr.prNumber, verdict, source: 'api' }
+}
+
+// The create-review response echoes `"state": "APPROVED" | "CHANGES_REQUESTED"`.
+// Tolerant of the spacing both `gh api` (compact) and a piped `jq .` (pretty)
+// produce.
+function landedVerdictFromState(text: string): DetectedReview['verdict'] | null {
+  if (/"state"\s*:\s*"APPROVED"/.test(text)) return 'APPROVE'
+  if (/"state"\s*:\s*"CHANGES_REQUESTED"/.test(text)) return 'REQUEST_CHANGES'
+  return null
+}
+
+// The review object carries `"pull_request_url":
+// "https://api.github.com/repos/<owner>/<repo>/pulls/<n>"`, the authoritative PR
+// identity for the landed review. Recovered here so a shape-dodging command is
+// still credited to the right PR.
+function prFromPullRequestUrl(text: string): { workspace: string; prNumber: number } | null {
+  const m = /\/repos\/([^/\s"]+)\/([^/\s"]+)\/pulls\/(\d+)\b/.exec(text)
+  if (m === null) return null
+  const prNumber = Number(m[3])
+  if (!Number.isSafeInteger(prNumber)) return null
+  return { workspace: `${m[1]}/${m[2]}`, prNumber }
 }
 
 async function readInputFile(command: string): Promise<string | null> {


### PR DESCRIPTION
## Summary

A typeclaw GitHub-review bot posted **six duplicate `APPROVED` reviews** on a single PR within ~30s. The PR-approval idempotency guard (`approve-idempotency.ts`) was already designed to prevent exactly this, but it **never armed** for the commands that landed the duplicates: it only fires when `gh-review-detect.ts` recognizes the review submission, and that detector required the command to *start* with `gh`.

In practice a review lands through several command shapes the detector missed:

| Shape | Why it was missed |
|---|---|
| `cd /agent && gh api .../reviews -f event=APPROVE` | leading token `cd`, compound |
| `tmp=$(mktemp); … ; gh api --input "$tmp"` | leading token `tmp=`, var-backed `--input` |
| `cat > /tmp/r.json <<'JSON' … JSON` then `gh api --input /tmp/r.json` | leading token `cat` (heredoc) |
| `gh api -X POST repos/o/r/pulls/N/reviews …` | slash-less endpoint form |

Because detection returned `null`, the in-flight lease and the read-after-write lag shield never recorded the landed verdict, so each subsequent engagement turn sailed through and posted another `APPROVE` inside GitHub's reviews-read lag window.

> Note: `analyzeGhCommand` is a token-injection-safety gate, **not** a proxy for "will this command execute" — a classic PAT skips that block, so a compound `cd … && gh …` can run. Detection must be independent of it.

## What changed

- **`gh-review-detect`** — scan every shell-separated segment (`&&`/`||`/`;`/`|`/newline) for a `gh` invocation, stripping leading `VAR=` assignments, so the submission is found wherever it sits. Endpoint matched on a `repos/` boundary (covers the slash-less form). Quote-aware so a `-f body='…; gh …'` cannot spoof a second invocation.
- **`review-recorder`** — post-execution backstop: when pre-detection missed, credit the verdict from the authoritative REST response (`state` + `pull_request_url`). This arms the dedupe window for the *next* turn (it cannot un-land a duplicate already posted — which is exactly what the sequential fan-out needed).
- **`approve-idempotency`** — widen the recent-landed lag-shield TTL `60s → 120s` to cover the sequential thread fan-out (~15s spread) plus slow API indexing. A re-review after a new push carries a new head SHA and still bypasses the window.

## Why not the other fixes

The session fan-out (one channel session per inline review thread) and the re-review stranding guard are **load-bearing** and deliberately left untouched:

- Per-thread session identity routes inline-thread replies to `/pulls/N/comments/{thread}/replies` and is locked by an end-to-end regression test (#251). Collapsing it would break inline replies and orphan persisted sessions.
- The re-review guard is session-generic by design — #645/#675/#685 widened it precisely because narrower scopes reintroduced PR stranding.

The bug is at the detection/idempotency seam, so the fix lives there.

## Invariants preserved

- **in-flight-only lease** (35287f99) — unchanged; still blocks only overlapping submissions.
- **GitHub authoritative for supersession** (#677) — DISMISSED / flipped verdict still pass; no block on stale local memory.
- **head-pinned lag shield** (#692) — new-push (new head SHA) still allows immediate re-review; uncertainty sentinel preserved.
- **fail-open** on read errors — unchanged.

## Test plan

- `gh-review-detect.test.ts` — +5 cases covering all four incident shapes and a quoted-body false-positive guard.
- `review-recorder.test.ts` — +6 cases for the post-execution backstop (credit landed APPROVE/REQUEST_CHANGES, fail-closed on failure marker / missing PR url / COMMENT, pending-path precedence).
- `approve-idempotency.test.ts` — fan-out reproduction (4 sequential same-commit APPROVEs ~5s apart → only the first lands) and the 2-minute window expiry.

All checks green: `typecheck` ✅ · `lint` (0 errors) ✅ · `format:check` ✅ · full suite **8650 pass / 0 fail**.
