### PR TITLE
Make .env PAT usable for git/gh, role-gated to unsandboxed roles

### DIFF
--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -5,13 +5,21 @@ import { join } from 'node:path'
 
 import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
 import type { GithubTokenResolveResult } from '@/channels/github-token-bridge'
-import { noopPermissionService } from '@/permissions'
-import type { PluginContext, ToolBeforeEvent } from '@/plugin'
+import { noopPermissionService, type PermissionService } from '@/permissions'
+import type { PluginContext, PluginLogger, ToolBeforeEvent } from '@/plugin'
 
 import { resetGitAskPassHelperForTests } from './git-askpass'
 import githubCliAuthPlugin from './index'
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+// resolveHiddenPaths checks fs.see.private + fs.see.secrets; granting both
+// yields empty masks => runsUnsandboxed() true, matching owner/trusted. The
+// default noopPermissionService grants nothing => sandboxed (member/guest).
+const unsandboxedPermissions: PermissionService = {
+  ...noopPermissionService,
+  has: (_origin, permission) => permission === 'fs.see.private' || permission === 'fs.see.secrets',
+}
 
 const originalToken = process.env.GH_TOKEN
 const originalGithubToken = process.env.GITHUB_TOKEN
@@ -23,24 +31,31 @@ afterEach(() => {
   else process.env.GITHUB_TOKEN = originalGithubToken
 })
 
+type HookOpts = { permissions?: PermissionService; logger?: PluginLogger }
+
 function pluginContext(
   resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>,
   hasAppTokenResolver = true,
+  opts: HookOpts = {},
 ): PluginContext<undefined> {
   return {
     name: 'github-cli-auth',
     version: undefined,
     agentDir: '/agent',
     config: undefined,
-    logger: noopLogger,
-    permissions: noopPermissionService,
+    logger: opts.logger ?? noopLogger,
+    permissions: opts.permissions ?? noopPermissionService,
     github: { resolveTokenForRepo: resolve, hasAppTokenResolver: () => hasAppTokenResolver },
     spawnSubagent: async () => {},
   }
 }
 
-async function hookFor(resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>, hasAppTokenResolver = true) {
-  const exports = await githubCliAuthPlugin.plugin(pluginContext(resolve, hasAppTokenResolver))
+async function hookFor(
+  resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>,
+  hasAppTokenResolver = true,
+  opts: HookOpts = {},
+) {
+  const exports = await githubCliAuthPlugin.plugin(pluginContext(resolve, hasAppTokenResolver, opts))
   const hook = exports.hooks?.['tool.before']
   if (!hook) throw new Error('plugin did not register tool.before')
   return hook
@@ -127,31 +142,59 @@ describe('github-cli-auth plugin', () => {
     expect(resolverCalled).toBe(false)
   })
 
-  test('classic PAT: passes through unchanged (cross-owner)', async () => {
+  test('classic PAT (unsandboxed): injects the PAT for a repo-targeting gh, does not mint', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
-    const hook = await hookFor(tokenResolver('ghs_minted'))
-    const event = bashEvent('gh pr view 12')
-
-    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
-
-    expect(result).toBeUndefined()
-    expect(event.args.command).toBe('gh pr view 12')
-  })
-
-  test('fine-grained PAT: leaves command as-is, does not mint', async () => {
-    process.env.GH_TOKEN = 'github_pat_xyz'
     let resolverCalled = false
-    const hook = await hookFor(async () => {
-      resolverCalled = true
-      return { kind: 'token', token: 'ghs_minted' }
-    })
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      true,
+      { permissions: unsandboxedPermissions },
+    )
     const event = bashEvent('gh pr view -R acme/widgets')
 
-    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+    const result = await hook(event, hookCtx)
 
     expect(result).toBeUndefined()
     expect(event.args.command).toBe('gh pr view -R acme/widgets')
+    // Unsandboxed: the PAT already rides inherited env; we re-assert it in the
+    // overlay (no minting) so behavior is explicit and matches the git path.
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghp_classic' })
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('classic PAT (unsandboxed): non-repo-targeting gh passes through (nothing to inject)', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: unsandboxedPermissions })
+    const event = bashEvent('gh pr view 12')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh pr view 12')
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+  })
+
+  test('fine-grained PAT (unsandboxed): leaves command as-is, injects the PAT, does not mint', async () => {
+    process.env.GH_TOKEN = 'github_pat_xyz'
+    let resolverCalled = false
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      true,
+      { permissions: unsandboxedPermissions },
+    )
+    const event = bashEvent('gh pr view -R acme/widgets')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args.command).toBe('gh pr view -R acme/widgets')
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'github_pat_xyz' })
     expect(resolverCalled).toBe(false)
   })
 
@@ -167,37 +210,45 @@ describe('github-cli-auth plugin', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
   })
 
-  test('classic PAT: strips a redundant -R on gh api without minting a token', async () => {
+  test('classic PAT (unsandboxed): strips a redundant -R on gh api, injects the PAT, no mint', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
     let resolverCalled = false
-    const hook = await hookFor(async () => {
-      resolverCalled = true
-      return { kind: 'token', token: 'ghs_minted' }
-    })
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      true,
+      { permissions: unsandboxedPermissions },
+    )
     const event = bashEvent('gh api repos/acme/widgets/issues -R acme/widgets')
 
-    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+    const result = await hook(event, hookCtx)
 
     expect(result).toBeUndefined()
     expect(event.args.command).toBe('gh api repos/acme/widgets/issues')
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghp_classic' })
     expect(resolverCalled).toBe(false)
   })
 
-  test('fine-grained PAT: strips a redundant -R on gh api without minting a token', async () => {
+  test('fine-grained PAT (unsandboxed): strips a redundant -R on gh api, injects the PAT, no mint', async () => {
     process.env.GH_TOKEN = 'github_pat_xyz'
     let resolverCalled = false
-    const hook = await hookFor(async () => {
-      resolverCalled = true
-      return { kind: 'token', token: 'ghs_minted' }
-    })
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      true,
+      { permissions: unsandboxedPermissions },
+    )
     const event = bashEvent('gh api repos/acme/widgets/issues --repo=acme/widgets')
 
-    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+    const result = await hook(event, hookCtx)
 
     expect(result).toBeUndefined()
     expect(event.args.command).toBe('gh api repos/acme/widgets/issues')
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'github_pat_xyz' })
     expect(resolverCalled).toBe(false)
   })
 
@@ -365,6 +416,58 @@ describe('github-cli-auth plugin', () => {
   })
 })
 
+describe('github-cli-auth plugin — .env PAT role gating (gh path)', () => {
+  test('PAT (sandboxed) + App minter: mints a per-repo App token instead of the withheld PAT', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const mintedSlugs: string[] = []
+    const hook = await hookFor(async (slug) => {
+      mintedSlugs.push(slug)
+      return { kind: 'token', token: 'ghs_minted' }
+    }, true)
+    const event = bashEvent('gh pr view -R acme/widgets')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
+    expect(mintedSlugs).toEqual(['acme/widgets'])
+  })
+
+  test('PAT (sandboxed) + no App minter: blocks with the withheld-PAT guidance and warns once', async () => {
+    process.env.GH_TOKEN = 'github_pat_xyz'
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(tokenResolver('ghs_minted'), false, { logger })
+
+    const first = await hook(bashEvent('gh pr view -R acme/widgets'), hookCtx)
+    const second = await hook(bashEvent('gh pr view -R acme/other'), hookCtx)
+
+    expect(first).toMatchObject({ block: true })
+    expect((first as { reason: string }).reason).toContain('sandboxed')
+    expect(second).toMatchObject({ block: true })
+    // warn is deduped to once per process to avoid log spam on every command.
+    expect(warnings.length).toBe(1)
+  })
+
+  test('PAT (sandboxed) + no minter: a malformed (block-class) gh command keeps its own block reason', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'), false)
+
+    // -R conflicts with the literal path => analyzer block; that reason wins over
+    // the withheld-PAT message because the command is unsafe regardless of auth.
+    const result = await hook(bashEvent('gh api repos/victim/private/issues -R acme/widgets'), hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    expect((result as { reason: string }).reason).not.toContain('sandboxed')
+  })
+})
+
 describe('github-cli-auth plugin — git path', () => {
   const askpassDir = mkdtempSync(join(tmpdir(), 'typeclaw-askpass-it-'))
   process.env.TYPECLAW_GIT_ASKPASS_PATH = join(askpassDir, 'typeclaw-git-askpass')
@@ -470,36 +573,74 @@ describe('github-cli-auth plugin — git path', () => {
     expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
   })
 
-  test('classic PAT: does not mint for git', async () => {
+  test('classic PAT (unsandboxed): injects GIT_ASKPASS with the PAT, does not mint', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
     let resolverCalled = false
-    const hook = await hookFor(async () => {
-      resolverCalled = true
-      return { kind: 'token', token: 'ghs_minted' }
-    })
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      true,
+      { permissions: unsandboxedPermissions },
+    )
     const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
     const result = await hook(event, hookCtx)
 
     expect(result).toBeUndefined()
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('ghp_classic')
+    expect(overlay.GIT_ASKPASS).toBeDefined()
+    expect(JSON.stringify(event.args.command)).not.toContain('ghp_classic')
     expect(resolverCalled).toBe(false)
   })
 
-  test('fine-grained PAT: does not mint for git', async () => {
+  test('fine-grained PAT (unsandboxed): injects GIT_ASKPASS with the PAT, does not mint', async () => {
     process.env.GH_TOKEN = 'github_pat_xyz'
     let resolverCalled = false
-    const hook = await hookFor(async () => {
-      resolverCalled = true
-      return { kind: 'token', token: 'ghs_minted' }
-    })
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      true,
+      { permissions: unsandboxedPermissions },
+    )
     const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
     const result = await hook(event, hookCtx)
 
     expect(result).toBeUndefined()
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('github_pat_xyz')
+    expect(overlay.GIT_ASKPASS).toBeDefined()
     expect(resolverCalled).toBe(false)
+  })
+
+  test('PAT (sandboxed) + App minter: mints a per-repo App token for git instead of the withheld PAT', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true)
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(overlay.GIT_ASKPASS).toBeDefined()
+  })
+
+  test('PAT (sandboxed) + no App minter: blocks git with the withheld-PAT guidance', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'), false)
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    expect((result as { reason: string }).reason).toContain('sandboxed')
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
   test('non-github explicit-URL git command passes through without minting', async () => {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -1,5 +1,7 @@
 import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
+import type { SessionOrigin } from '@/agent/session-origin'
 import { definePlugin } from '@/plugin'
+import { resolveHiddenPaths } from '@/sandbox'
 
 import { createApproveIdempotencyGuard } from './approve-idempotency'
 import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
@@ -14,6 +16,40 @@ export default definePlugin({
   plugin: async (ctx) => {
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
     const hasAppTokenResolver = ctx.github.hasAppTokenResolver
+
+    // A .env PAT is broad and long-lived, so it may only reach bash that runs
+    // WITHOUT bwrap's --clearenv — otherwise a low-trust, stranger-drivable
+    // sandbox could exfiltrate it. We gate on the SAME signal applyBashSandbox
+    // uses (resolveHiddenPaths empty => unsandboxed) rather than a role name, so
+    // the credential policy can never diverge from the actual sandbox decision
+    // and custom roles follow their real fs.see.secrets / security.bypass grant.
+    const runsUnsandboxed = (origin: SessionOrigin | undefined): boolean => {
+      const { dirs, files } = resolveHiddenPaths(ctx.permissions, origin, ctx.agentDir)
+      return dirs.length === 0 && files.length === 0
+    }
+
+    // The PAT is in the container env but stripped by --clearenv for this role,
+    // and a PAT is not re-mintable per repo, so there is no token to inject. Tell
+    // the AGENT (model-visible block) instead of letting git/gh fail ambiguously
+    // — the silent variant of this is exactly what caused a multi-day debugging
+    // hunt. App auth is the supported path for low-trust roles.
+    const sandboxedPatWithheldReason =
+      'A classic/fine-grained GitHub PAT is configured (via .env GH_TOKEN), but this command runs ' +
+      'in a sandboxed (low-trust) role whose environment is cleared before bash — so the PAT is ' +
+      'withheld here and is NOT available to git/gh. This is a deliberate guard, not missing auth: a ' +
+      'broad, long-lived PAT must not be reachable from a low-trust sandbox. Configure GitHub App auth ' +
+      '(channels.github) to grant per-repo, short-lived tokens that DO work for sandboxed roles.'
+
+    let warnedSandboxedPatWithheld = false
+    const warnSandboxedPatWithheldOnce = (): void => {
+      if (warnedSandboxedPatWithheld) return
+      warnedSandboxedPatWithheld = true
+      ctx.logger.warn(
+        'GH_TOKEN (classic/fine-grained PAT) withheld from a sandboxed role: the env is cleared for ' +
+          'low-trust bash, so git/gh have no credential. Configure GitHub App auth (channels.github) ' +
+          'for per-repo tokens that work in sandboxed roles.',
+      )
+    }
     // `/user` resolves the caller's USER identity. An App installation token is not
     // a user, so GitHub rejects it on a token-class basis (403, or no-token error in
     // the sandbox) no matter how valid the token is. We block-and-guide so the agent
@@ -39,7 +75,7 @@ export default definePlugin({
     // 'fall-through' means "not a repo-targeting gh command" so the caller can
     // try the git path on the same command (e.g. `git ... # gh` substrings).
     const handleGhCommand = async (params: {
-      event: { callId: string; args: Record<string, unknown> }
+      event: { callId: string; args: Record<string, unknown>; origin?: SessionOrigin }
       command: string
     }): Promise<HookResult | 'fall-through'> => {
       const { event, command } = params
@@ -83,19 +119,48 @@ export default definePlugin({
       }
 
       const tokenClass = classifyGhToken(process.env.GH_TOKEN)
-      // Classic PATs reach every owner; nothing to inject or enforce.
-      if (tokenClass === 'cross-owner') return
+
+      // PAT classes (classic = cross-owner, fine-grained) are not re-minted per
+      // repo; the seeded GH_TOKEN is the only token we have. App minting, when
+      // available, is still preferred for SANDBOXED roles (the PAT can't reach
+      // them), so a PAT must NOT suppress minting there — only for unsandboxed
+      // execution does the PAT win. Unsandboxed: the PAT already rides inherited
+      // process.env, but re-asserting it in the overlay keeps the command-local
+      // GH_TOKEN explicit and consistent with the git path. Sandboxed PAT-only:
+      // block with guidance instead of failing silently.
+      // Set when a sandboxed PAT falls through to App minting: the tail's
+      // shouldMintAppToken(process.env.GH_TOKEN) re-check would see the PAT and
+      // bail, so this flag forces the mint that the PAT must not suppress.
+      let mintForSandboxedPat = false
+      if (tokenClass === 'cross-owner' || tokenClass === 'fine-grained-pat') {
+        // Unsandboxed: the PAT authenticates directly (it already rides inherited
+        // process.env). For a repo-targeting command we re-assert it in the
+        // overlay so behavior is explicit and matches the git path; otherwise we
+        // pass through. The App-oriented missing-repo / multi-owner BLOCK does
+        // NOT apply — a PAT needs no per-repo mint — so we never surface it here.
+        if (runsUnsandboxed(event.origin)) {
+          if (decision.kind === 'inject') {
+            event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: process.env.GH_TOKEN as string }
+          }
+          return
+        }
+        // Sandboxed: the PAT is stripped by --clearenv. Prefer App minting when
+        // available (a PAT must NOT suppress it, or the original silent-failure
+        // bug returns); otherwise block with guidance rather than failing mute.
+        if (!shouldMintAppToken(undefined, hasAppTokenResolver())) {
+          if (decision.kind === 'block') return { block: true, reason: decision.reason }
+          warnSandboxedPatWithheldOnce()
+          return { block: true, reason: sandboxedPatWithheldReason }
+        }
+        mintForSandboxedPat = true
+      }
 
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
 
-      // Fine-grained PATs are single-owner but cannot be re-minted per repo;
-      // the seeded GH_TOKEN is the only token we have. Leave it in place so
-      // `gh` fails honestly if the named repo is under a different owner.
-      if (tokenClass === 'fine-grained-pat') return
-
       // No App auth (no App-class GH_TOKEN and no live minter): leave whatever
-      // is seeded so `gh` fails honestly rather than us guessing a token.
-      if (!shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
+      // is seeded so `gh` fails honestly rather than us guessing a token. The
+      // sandboxed-PAT mint path bypasses this PAT-class re-check via the flag.
+      if (!mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
 
       const result = await resolveTokenForRepo(decision.repoSlug)
       if (result.kind === 'unavailable') return { block: true, reason: result.reason }
@@ -107,34 +172,65 @@ export default definePlugin({
     }
 
     const handleGitCommand = async (params: {
-      event: { args: Record<string, unknown> }
+      event: { args: Record<string, unknown>; origin?: SessionOrigin }
       command: string
       agentDir: string
     }): Promise<HookResult> => {
       const { event, command, agentDir } = params
-      // Only App auth re-mints per repo. Classic/fine-grained PATs and absent
-      // tokens are left untouched, exactly as the gh path treats them. App auth
-      // is detected by the live minter too, not just an App-class GH_TOKEN:
-      // multi-owner / no-repos App configs never seed GH_TOKEN yet can mint.
-      if (!shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
+      const tokenClass = classifyGhToken(process.env.GH_TOKEN)
+      const isPat = tokenClass === 'cross-owner' || tokenClass === 'fine-grained-pat'
+
+      // A PAT is not re-mintable per repo. For unsandboxed roles it rides the
+      // git-askpass path so SSH/scp remotes get rewritten to https and clone
+      // works uniformly (matching the gh path). For sandboxed roles the PAT is
+      // withheld (env cleared): mint an App token instead if available, else
+      // block with guidance rather than letting git fail silently. App auth must
+      // still mint for sandboxed roles even when a PAT is present.
+      const useEnvPat = isPat && runsUnsandboxed(event.origin)
+      // Sandboxed PAT: the env is cleared, so the PAT can't reach git. Mint an
+      // App token instead when a minter is live (a PAT must NOT suppress it);
+      // otherwise block with guidance below rather than fail silently.
+      const mintForSandboxedPat = isPat && !useEnvPat && shouldMintAppToken(undefined, hasAppTokenResolver())
+      if (isPat && !useEnvPat && !mintForSandboxedPat) {
+        const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
+        if (decision.kind === 'pass-through') return
+        if (decision.kind === 'block') return { block: true, reason: decision.reason }
+        warnSandboxedPatWithheldOnce()
+        return { block: true, reason: sandboxedPatWithheldReason }
+      }
+
+      // Neither a usable PAT nor App auth: leave the command untouched so git
+      // fails honestly rather than us guessing a token. App auth is detected by
+      // the live minter too, not just an App-class GH_TOKEN: multi-owner /
+      // no-repos App configs never seed GH_TOKEN yet can mint. The mintForSandboxedPat
+      // flag forces minting past this PAT-class re-check.
+      if (!useEnvPat && !mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
 
       const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
       if (decision.kind === 'pass-through') return
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
 
-      const result = await resolveTokenForRepo(decision.repoSlug)
-      if (result.kind === 'unavailable') return { block: true, reason: result.reason }
+      // The unsandboxed-PAT path uses the PAT directly; otherwise mint a per-repo
+      // App token. Both ride TYPECLAW_GIT_TOKEN (read by the askpass helper),
+      // never argv/config.
+      let gitToken: string
+      if (useEnvPat) {
+        gitToken = process.env.GH_TOKEN as string
+      } else {
+        const result = await resolveTokenForRepo(decision.repoSlug)
+        if (result.kind === 'unavailable') return { block: true, reason: result.reason }
+        gitToken = result.token
+      }
 
       const askpass = await ensureGitAskPassHelper()
       const existing = event.args[TYPECLAW_INTERNAL_BASH_ENV]
       const overlay = existing !== null && typeof existing === 'object' ? (existing as Record<string, string>) : {}
-      // Token rides in TYPECLAW_GIT_TOKEN (read by the askpass helper), never in
-      // argv/config. insteadOf rewrites SSH/scp remotes to https so the helper's
-      // credential applies; GIT_TERMINAL_PROMPT=0 fails fast instead of hanging.
+      // insteadOf rewrites SSH/scp remotes to https so the helper's credential
+      // applies; GIT_TERMINAL_PROMPT=0 fails fast instead of hanging.
       event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
         ...overlay,
         GIT_ASKPASS: askpass,
-        TYPECLAW_GIT_TOKEN: result.token,
+        TYPECLAW_GIT_TOKEN: gitToken,
         GIT_TERMINAL_PROMPT: '0',
         GIT_CONFIG_COUNT: '2',
         GIT_CONFIG_KEY_0: 'url.https://github.com/.insteadOf',


### PR DESCRIPTION
## Background

A classic/fine-grained GitHub PAT set in `.env` (`GH_TOKEN=ghp_…` / `github_pat_…`)
silently did nothing for **sandboxed** roles. The container env holds the PAT, but
bwrap's `--clearenv` strips it for member/guest bash, and the `github-cli-auth`
plugin only re-injected **App-class** tokens — PAT-class tokens bailed. So a
sandboxed `git clone` / `gh` ran with no credential and failed with no
explanation. That silent failure is exactly the hard-to-debug variant that
recently cost a multi-day investigation.

For **unsandboxed** (owner/trusted) roles the PAT already worked, because their
bash inherits the full `process.env` — but only for plain `git`/`gh`; SSH-remote
rewrites (which ride the `GIT_ASKPASS` path) never applied, so behavior was
inconsistent across roles.

## Summary

Make the `.env` PAT a first-class credential, gated to the roles where it is safe.

The gate is the **same signal `applyBashSandbox` uses** —
`resolveHiddenPaths(...)` empty ⇒ unsandboxed — not a role name. This was a
deliberate choice (per design review): gating on the actual sandbox decision
means the credential policy can never diverge from `--clearenv`, and custom roles
automatically follow their real `fs.see.secrets` / `security.bypass` grant rather
than needing to be enumerated.

- **Unsandboxed PAT** → inject it for repo-targeting `git`/`gh`. `git` rides the
  `GIT_ASKPASS` path so SSH/scp remotes get rewritten to https and clone works
  uniformly. The App-oriented missing-repo / multi-owner *block* does **not**
  apply to a PAT (a PAT needs no per-repo mint). Non-repo-targeting commands pass
  through unchanged.
- **Sandboxed PAT + App minter** → mint a per-repo, short-lived App token instead
  of the withheld PAT. Critically, a PAT must **not** suppress minting here — a
  `mintForSandboxedPat` flag forces the mint past the PAT-class re-check —
  otherwise the original silent failure returns when both are configured.
- **Sandboxed PAT, no minter** → **block** with model-visible guidance (configure
  `channels.github` App auth) and warn the operator once. Blocking beats letting
  `git`/`gh` fail mute; the whole point is to make the failure legible.

**Why not just forward the PAT into the sandbox?** A classic/fine-grained PAT is
broad and long-lived; the `--clearenv` guard exists precisely so a stranger-
drivable low-trust bash can't exfiltrate it. App installation tokens are safe
there because they're per-repo and ~1h — which is why the sandboxed path mints
one instead.

## What this does NOT do

- Does not forward the `.env` PAT into sandboxed bash — that boundary is
  intentional. Sandboxed roles get a minted App token or a block, never the PAT.
- Adds no new leak surface for unsandboxed roles: the PAT only ever rides
  `TYPECLAW_GIT_TOKEN` / the env overlay (never argv or git config), and only for
  command shapes the existing `analyzeGhCommand` / `analyzeGitCommand`
  composition gates already cleared. Those roles already inherited the PAT via
  `process.env` anyway.
- No config schema, CLI, or plugin-contract changes.

## Review notes

- Load-bearing invariant: `runsUnsandboxed` (src/bundled-plugins/github-cli-auth/index.ts)
  must mirror `applyBashSandbox`'s `dirs.length === 0 && files.length === 0`
  predicate. If those drift, the credential gate drifts from the sandbox decision.
- Second load-bearing invariant: a sandboxed PAT must **not** suppress App
  minting (the `mintForSandboxedPat` flag in both the gh and git paths). Mutation-
  tested: forcing the flag off fails exactly the "mints instead of withheld"
  tests and nothing else; forcing `runsUnsandboxed` true fails exactly the five
  sandboxed-behavior tests.
- The existing PAT tests were updated to be explicit about role (they encoded the
  pre-change behavior incidentally via `noopPermissionService`); new tests cover
  unsandboxed inject, sandboxed-mint, sandboxed-block, and warn-once.
