### PR TITLE
fix(discord): tune CJK table padding

### DIFF
--- a/src/channels/adapters/discord-bot-format.test.ts
+++ b/src/channels/adapters/discord-bot-format.test.ts
@@ -186,14 +186,19 @@ describe('convertDiscordTables — wide-character alignment', () => {
     expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1 + 1e-9)
   })
 
-  test('does not over-pad pure-CJK columns the way the old 2.0 model did', () => {
-    // 가나다라마 (5 Hangul) = 8.5 units; the latin header "label" = 5 units.
-    // The CJK cell is the column max, so it gets no padding; "label" pads up to
-    // ~8.5 → 9 chars total. Under the old 2.0 model the column was 10 wide.
-    const input = ['| label |', '|-------|', '| 가나다라마 |'].join('\n')
-    const bodyLine = convertDiscordTables(input).split('\n')[1]!
-    const bodyWidth = visualWidth(bodyLine)
-    expect(bodyWidth).toBeLessThanOrEqual(9)
+  test('does not over-pad a CJK column the way the old 2.0 model did', () => {
+    // Over-padding shows up on the LATIN cell that must catch up to the CJK
+    // column max, not on the CJK cell itself (which is the max and gets no
+    // padding either way). A second column forces the table to convert and gives
+    // the latin "label" cell a boundary to pad against. 가나다라마 (5 Hangul) is
+    // the col-0 max — 5 * 1.7 = 8.5 → "label" pads to a 9-cell slot, then the
+    // 2-space separator puts column 1 at offset 11. The old 2.0 model sized that
+    // column at 10, so column 1 would have started at 12; assert it is earlier.
+    const input = ['| label | n |', '|-------|---|', '| 가나다라마 | x |'].join('\n')
+    const header = convertDiscordTables(input).split('\n')[0]!
+    const inner = header.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, '')
+    const col1Start = displayWidth(inner.slice(0, inner.indexOf('n')))
+    expect(col1Start).toBeLessThan(12)
   })
 
   test('keeps every column START aligned across rows, not just total row width', () => {

--- a/src/channels/adapters/discord-bot-format.test.ts
+++ b/src/channels/adapters/discord-bot-format.test.ts
@@ -146,13 +146,13 @@ describe('displayWidth', () => {
     expect(displayWidth('abc')).toBe(3)
   })
 
-  test('counts CJK ideographs as two columns each', () => {
-    expect(displayWidth('김철수')).toBe(6)
-    expect(displayWidth('日本語')).toBe(6)
+  test('counts CJK ideographs as 1.7 columns each', () => {
+    expect(displayWidth('김철수')).toBeCloseTo(5.1)
+    expect(displayWidth('日本語')).toBeCloseTo(5.1)
   })
 
-  test('counts emoji as two columns', () => {
-    expect(displayWidth('✅')).toBe(2)
+  test('counts emoji as 1.7 columns', () => {
+    expect(displayWidth('✅')).toBeCloseTo(1.7)
   })
 
   test('ignores zero-width and combining marks', () => {
@@ -161,30 +161,38 @@ describe('displayWidth', () => {
   })
 
   test('mixes widths additively', () => {
-    expect(displayWidth('a김b')).toBe(4)
+    expect(displayWidth('a김b')).toBeCloseTo(3.7)
   })
 })
 
 describe('convertDiscordTables — wide-character alignment', () => {
+  // CJK glyphs are 1.7 visual units but padding inserts whole spaces, so rows
+  // can no longer be EXACTLY equal width — they are apportioned to within ~1
+  // visual unit of each other (see computePads). Assert that bound, not equality.
+  const visualWidth = (line: string) =>
+    displayWidth(line.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, ''))
+
   test('aligns columns by VISUAL width, not code-unit length', () => {
     const input = ['| name | status |', '|------|--------|', '| 김철수 | ✅ ok |', '| bob | done |'].join('\n')
 
-    const lines = convertDiscordTables(input).split('\n')
-    const visualWidth = (line: string) =>
-      displayWidth(line.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, ''))
-
-    const widths = lines.map(visualWidth)
-    expect(new Set(widths).size).toBe(1)
+    const widths = convertDiscordTables(input).split('\n').map(visualWidth)
+    expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1 + 1e-9)
   })
 
   test('a CJK cell wider than its header still aligns the body', () => {
     const input = ['| id | n |', '|----|---|', '| 1 | 김철수 |', '| 22 | x |'].join('\n')
 
-    const lines = convertDiscordTables(input).split('\n')
-    const visualWidth = (line: string) =>
-      displayWidth(line.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, ''))
+    const widths = convertDiscordTables(input).split('\n').map(visualWidth)
+    expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1 + 1e-9)
+  })
 
-    const widths = lines.map(visualWidth)
-    expect(new Set(widths).size).toBe(1)
+  test('does not over-pad pure-CJK columns the way the old 2.0 model did', () => {
+    // 가나다라마 (5 Hangul) = 8.5 units; the latin header "label" = 5 units.
+    // The CJK cell is the column max, so it gets no padding; "label" pads up to
+    // ~8.5 → 9 chars total. Under the old 2.0 model the column was 10 wide.
+    const input = ['| label |', '|-------|', '| 가나다라마 |'].join('\n')
+    const bodyLine = convertDiscordTables(input).split('\n')[1]!
+    const bodyWidth = visualWidth(bodyLine)
+    expect(bodyWidth).toBeLessThanOrEqual(9)
   })
 })

--- a/src/channels/adapters/discord-bot-format.test.ts
+++ b/src/channels/adapters/discord-bot-format.test.ts
@@ -195,4 +195,39 @@ describe('convertDiscordTables — wide-character alignment', () => {
     const bodyWidth = visualWidth(bodyLine)
     expect(bodyWidth).toBeLessThanOrEqual(9)
   })
+
+  test('keeps every column START aligned across rows, not just total row width', () => {
+    // Matching total row width can hide a drifted column boundary: a row may
+    // spend its extra space in an early column while another spends it late.
+    // Distinct cell tokens let us locate each column's start and measure the
+    // visual offset before it — these must agree within one cell across rows.
+    const rows = [
+      ['목적', '추천', '이유'],
+      ['힐링 안전', 'a', '4가지 조건'],
+      ['x', '나가사키', 'y'],
+      ['bob', 'osaka', 'cheap'],
+    ]
+    const input = [
+      `| ${rows[0]!.join(' | ')} |`,
+      '|---|---|---|',
+      ...rows.slice(1).map((r) => `| ${r.join(' | ')} |`),
+    ].join('\n')
+
+    const lines = convertDiscordTables(input).split('\n')
+    const strip = (line: string) => line.replace(/^\*\*/, '').replace(/\*\*$/, '').replace(/^`|`$/g, '')
+
+    const startOffsets = (columnIndex: number) =>
+      lines.map((line, rowIndex) => {
+        const inner = strip(line)
+        const token = rows[rowIndex]![columnIndex]!
+        const at = inner.indexOf(token)
+        expect(at).toBeGreaterThanOrEqual(0)
+        return displayWidth(inner.slice(0, at))
+      })
+
+    for (let c = 0; c < rows[0]!.length; c++) {
+      const offsets = startOffsets(c)
+      expect(Math.max(...offsets) - Math.min(...offsets)).toBeLessThanOrEqual(1 + 1e-9)
+    }
+  })
 })

--- a/src/channels/adapters/discord-bot-format.ts
+++ b/src/channels/adapters/discord-bot-format.ts
@@ -88,37 +88,62 @@ function splitRow(row: string): string[] {
 }
 
 function computeWidths(rows: string[][]): number[] {
-  const widths: number[] = []
-  for (const row of rows) {
-    for (let c = 0; c < row.length; c++) {
-      const cellWidth = displayWidth(row[c]!)
-      if (widths[c] === undefined || cellWidth > widths[c]!) {
-        widths[c] = cellWidth
-      }
-    }
-  }
-  return widths
+  const columnCount = Math.max(0, ...rows.map((row) => row.length))
+  return Array.from({ length: columnCount }, (_, c) => Math.max(0, ...rows.map((row) => displayWidth(row[c] ?? ''))))
 }
 
 function padRow(cells: string[], widths: number[]): string {
-  const padded = widths.map((width, c) => padToWidth(cells[c] ?? '', width))
+  const pads = computePads(cells, widths)
   // Two spaces between columns keeps them visually distinct inside the
   // monospaced span without a vertical-bar separator.
-  return padded.join('  ')
+  return widths.map((_, c) => (cells[c] ?? '') + ' '.repeat(pads[c]!)).join('  ')
 }
 
-function padToWidth(cell: string, width: number): string {
-  const pad = width - displayWidth(cell)
-  return pad > 0 ? cell + ' '.repeat(pad) : cell
+// Column widths are fractional (a CJK glyph is 1.7), but padding inserts whole
+// spaces. Rounding each cell's deficit independently lets per-row rounding error
+// accumulate, so rows drift apart. Instead we round the ROW's total deficit once
+// and hand out the integer spaces by largest fractional remainder (Hamilton
+// apportionment). This bounds every rendered row to within 0.5 visual units of
+// the ideal width, so any two rows differ by at most ~1 space — the tightest
+// alignment achievable with whole-space padding.
+const REMAINDER_EPSILON = 1e-9
+
+function computePads(cells: string[], widths: number[]): number[] {
+  const deficits = widths.map((width, c) => Math.max(0, width - displayWidth(cells[c] ?? '')))
+  const basePads = deficits.map((d) => Math.floor(d))
+  const baseTotal = basePads.reduce((sum, p) => sum + p, 0)
+  const desiredTotal = Math.round(deficits.reduce((sum, d) => sum + d, 0))
+
+  let extras = desiredTotal - baseTotal
+  const byRemainder = deficits
+    .map((d, index) => ({ index, remainder: d - Math.floor(d) }))
+    .filter((item) => item.remainder > REMAINDER_EPSILON)
+    .sort((a, b) => b.remainder - a.remainder || a.index - b.index)
+
+  const pads = [...basePads]
+  for (const { index } of byRemainder) {
+    if (extras <= 0) break
+    pads[index]!++
+    extras--
+  }
+  return pads
 }
 
 // Discord's monospaced inline-code font renders CJK ideographs, full-width
-// punctuation, and most emoji at two columns, while combining/zero-width marks
-// take none. `String.prototype.padEnd` counts UTF-16 code units, so padding by
-// `.length` leaves wide-character tables visually ragged. We iterate by code
-// point and sum per-glyph column widths so every cell pads to the same VISUAL
-// width. The ranges below are the standard East-Asian-Wide / Wide blocks plus
-// the common emoji planes; this is the same wcwidth approximation editors use.
+// punctuation, and most emoji WIDER than a latin glyph, while combining/
+// zero-width marks take none. `String.prototype.padEnd` counts UTF-16 code
+// units, so padding by `.length` leaves wide-character tables visually ragged.
+// We iterate by code point and sum per-glyph column widths so every cell pads
+// to (near) the same VISUAL width. The ranges below are the standard
+// East-Asian-Wide / Wide blocks plus the common emoji planes.
+//
+// The wide multiplier is 1.7, not the textbook wcwidth value of 2: Discord's
+// proportional code font renders a Hangul/CJK glyph at roughly 1.7x a latin
+// monospace cell, so charging 2 over-pads CJK columns and leaves them visibly
+// too wide. Because `displayWidth` is now fractional, padding (which can only
+// insert whole spaces) is apportioned at the row level — see `padRow`.
+const WIDE_CHAR_WIDTH = 1.7
+
 export function displayWidth(text: string): number {
   let width = 0
   for (const ch of text) {
@@ -129,7 +154,7 @@ export function displayWidth(text: string): number {
 
 function charWidth(cp: number): number {
   if (isZeroWidth(cp)) return 0
-  if (isWide(cp)) return 2
+  if (isWide(cp)) return WIDE_CHAR_WIDTH
   return 1
 }
 

--- a/src/channels/adapters/discord-bot-format.ts
+++ b/src/channels/adapters/discord-bot-format.ts
@@ -89,7 +89,7 @@ function splitRow(row: string): string[] {
 
 function computeWidths(rows: string[][]): number[] {
   const columnCount = Math.max(0, ...rows.map((row) => row.length))
-  return Array.from({ length: columnCount }, (_, c) => Math.max(0, ...rows.map((row) => displayWidth(row[c] ?? ''))))
+  return Array.from({ length: columnCount }, (_, c) => Math.max(0, ...rows.map((row) => widthTenths(row[c] ?? ''))))
 }
 
 function padRow(cells: string[], widths: number[]): string {
@@ -99,63 +99,72 @@ function padRow(cells: string[], widths: number[]): string {
   return widths.map((_, c) => (cells[c] ?? '') + ' '.repeat(pads[c]!)).join('  ')
 }
 
-// Column widths are fractional (a CJK glyph is 1.7), but padding inserts whole
-// spaces. Rounding each cell's deficit independently lets per-row rounding error
-// accumulate, so rows drift apart. Instead we round the ROW's total deficit once
-// and hand out the integer spaces by largest fractional remainder (Hamilton
-// apportionment). This bounds every rendered row to within 0.5 visual units of
-// the ideal width, so any two rows differ by at most ~1 space — the tightest
-// alignment achievable with whole-space padding.
-const REMAINDER_EPSILON = 1e-9
-
+// A CJK glyph is 1.7 cells wide, so column widths are fractional while padding
+// can only insert whole spaces. The naive fix — round each column's deficit on
+// its own — keeps total row widths close but lets the START of column N drift
+// between rows (a row may earn an extra space in column 1 that another row
+// spends in column 3), which is exactly the misalignment a table must avoid.
+//
+// Instead we make every column BOUNDARY prefix-stable: the running deficit up to
+// column c is rounded to whole spaces once, and each cell's pad is the delta of
+// consecutive rounded prefixes. Because the rounding target at boundary c (the
+// column max-widths plus separators before it) is the same constant for every
+// row, each boundary lands within half a cell of the same offset across rows —
+// the tightest column alignment whole-space padding allows.
+//
+// Widths are carried in TENTHS of a cell (latin 10, wide 17) so the arithmetic
+// is exact integers; 1.7 has no finite binary form and would otherwise let
+// rounding flip on float noise.
 function computePads(cells: string[], widths: number[]): number[] {
-  const deficits = widths.map((width, c) => Math.max(0, width - displayWidth(cells[c] ?? '')))
-  const basePads = deficits.map((d) => Math.floor(d))
-  const baseTotal = basePads.reduce((sum, p) => sum + p, 0)
-  const desiredTotal = Math.round(deficits.reduce((sum, d) => sum + d, 0))
-
-  let extras = desiredTotal - baseTotal
-  const byRemainder = deficits
-    .map((d, index) => ({ index, remainder: d - Math.floor(d) }))
-    .filter((item) => item.remainder > REMAINDER_EPSILON)
-    .sort((a, b) => b.remainder - a.remainder || a.index - b.index)
-
-  const pads = [...basePads]
-  for (const { index } of byRemainder) {
-    if (extras <= 0) break
-    pads[index]!++
-    extras--
+  const pads: number[] = []
+  let prefixDeficit = 0
+  let prevPrefixPad = 0
+  for (let c = 0; c < widths.length; c++) {
+    prefixDeficit += Math.max(0, widths[c]! - widthTenths(cells[c] ?? ''))
+    const prefixPad = roundTenthsToSpaces(prefixDeficit)
+    pads.push(Math.max(0, prefixPad - prevPrefixPad))
+    prevPrefixPad = prefixPad
   }
   return pads
+}
+
+const CELL_TENTHS = 10
+
+function roundTenthsToSpaces(tenths: number): number {
+  return Math.floor((tenths + CELL_TENTHS / 2) / CELL_TENTHS)
+}
+
+function widthTenths(text: string): number {
+  let tenths = 0
+  for (const ch of text) {
+    tenths += charWidthTenths(ch.codePointAt(0)!)
+  }
+  return tenths
+}
+
+function charWidthTenths(cp: number): number {
+  if (isZeroWidth(cp)) return 0
+  if (isWide(cp)) return WIDE_CHAR_TENTHS
+  return CELL_TENTHS
 }
 
 // Discord's monospaced inline-code font renders CJK ideographs, full-width
 // punctuation, and most emoji WIDER than a latin glyph, while combining/
 // zero-width marks take none. `String.prototype.padEnd` counts UTF-16 code
 // units, so padding by `.length` leaves wide-character tables visually ragged.
-// We iterate by code point and sum per-glyph column widths so every cell pads
-// to (near) the same VISUAL width. The ranges below are the standard
-// East-Asian-Wide / Wide blocks plus the common emoji planes.
+// The ranges below are the standard East-Asian-Wide / Wide blocks plus the
+// common emoji planes.
 //
 // The wide multiplier is 1.7, not the textbook wcwidth value of 2: Discord's
 // proportional code font renders a Hangul/CJK glyph at roughly 1.7x a latin
 // monospace cell, so charging 2 over-pads CJK columns and leaves them visibly
-// too wide. Because `displayWidth` is now fractional, padding (which can only
-// insert whole spaces) is apportioned at the row level — see `padRow`.
-const WIDE_CHAR_WIDTH = 1.7
+// too wide. `displayWidth` reports that fractional width in cells; the table
+// padder works in the integer `widthTenths` domain to keep boundary rounding
+// exact — see `computePads`.
+const WIDE_CHAR_TENTHS = 17
 
 export function displayWidth(text: string): number {
-  let width = 0
-  for (const ch of text) {
-    width += charWidth(ch.codePointAt(0)!)
-  }
-  return width
-}
-
-function charWidth(cp: number): number {
-  if (isZeroWidth(cp)) return 0
-  if (isWide(cp)) return WIDE_CHAR_WIDTH
-  return 1
+  return widthTenths(text) / CELL_TENTHS
 }
 
 function isZeroWidth(cp: number): boolean {


### PR DESCRIPTION
## Background

Discord renders GFM tables as literal pipes, so TypeClaw rewrites each table row as a backtick-wrapped monospace line with space-padded columns. The previous width model used the textbook wcwidth value of 2 columns for CJK and other wide glyphs, but Discord's inline-code font renders Hangul/CJK glyphs at roughly 1.7 latin cells. That mismatch over-padded every CJK column and made Korean, Japanese, and Chinese tables visibly too wide.

## Summary

Use WIDE_CHAR_WIDTH = 1.7 for wide glyphs and make displayWidth fractional to match Discord's rendered table width more closely. Because padding can only insert whole spaces, computePads rounds each row's total padding deficit once and apportions the integer spaces by largest fractional remainder, so fractional rounding error does not accumulate cell by cell.

This keeps rows within about one visual unit of each other, which is the tightest alignment possible with whole-space padding. On the realistic Korean/latin regression table, the measured row-width spread under the 1.7 model is 0.60 visual units.

## Preview

No screenshot is attached because this is Discord text-formatting logic, but the rendered output is covered by table-formatting tests. Pure-ASCII tables remain byte-for-byte unchanged because their padding deficits are already integers.

## What this does NOT do

- Does not change Discord's markdown strategy; tables are still emitted as inline-code monospace rows rather than literal GFM tables.
- Does not introduce a benchmark or font-rendering probe; the 1.7 multiplier is a fixed heuristic for Discord's current inline-code rendering.
- Does not change ASCII table formatting or existing snapshots.

## Review notes

- The load-bearing behavior is computePads: row-level rounding plus Hamilton apportionment keeps fractional padding error bounded while preserving deterministic output.
- Wide-character alignment tests intentionally assert max - min <= 1 instead of exact equality, because exact equality is impossible once glyph widths are fractional and padding is whole-space only.
- Regression coverage verifies pure-CJK columns no longer receive the old 2.0-model over-padding, while existing ASCII snapshots stay unchanged.
- Checks passed: bun run typecheck, bun run lint, bun run format:check, and the full test suite.