### PR TITLE
fix(github): gate the review backstop on a submission attempt to stop crediting reads

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { detectReviewSubmission } from './gh-review-detect'
+import { detectReviewSubmission, detectReviewSubmissionAttempt } from './gh-review-detect'
 
 describe('detectReviewSubmission — REST --input', () => {
   test('APPROVE in the input file is detected', () => {
@@ -156,5 +156,38 @@ describe('detectReviewSubmission — non-matches', () => {
 
   test('a non-gh command is null', () => {
     expect(detectReviewSubmission({ command: 'echo gh api reviews event=APPROVE' })).toBeNull()
+  })
+})
+
+describe('detectReviewSubmissionAttempt — submission intent, verdict aside', () => {
+  test('a POST to the reviews endpoint is an attempt even with no extractable verdict', () => {
+    expect(
+      detectReviewSubmissionAttempt('gh api -X POST /repos/acme/widgets/pulls/12/reviews --input /tmp/r.json'),
+    ).toEqual({ workspace: 'acme/widgets', prNumber: 12 })
+  })
+
+  test('--method POST (and slash-less endpoint, after cd) is an attempt', () => {
+    expect(
+      detectReviewSubmissionAttempt('cd /agent && gh api --method POST repos/acme/widgets/pulls/13/reviews'),
+    ).toEqual({ workspace: 'acme/widgets', prNumber: 13 })
+  })
+
+  test('a bare reviews GET (no method) is NOT an attempt', () => {
+    expect(detectReviewSubmissionAttempt('gh api /repos/acme/widgets/pulls/12/reviews')).toBeNull()
+  })
+
+  test('an explicit GET on the reviews endpoint is NOT an attempt', () => {
+    expect(detectReviewSubmissionAttempt('gh api -X GET /repos/acme/widgets/pulls/12/reviews')).toBeNull()
+  })
+
+  test('gh pr review with a verdict flag is an attempt', () => {
+    expect(detectReviewSubmissionAttempt('gh pr review 42 --approve -R acme/widgets')).toEqual({
+      workspace: 'acme/widgets',
+      prNumber: 42,
+    })
+  })
+
+  test('a non-reviews POST is NOT an attempt', () => {
+    expect(detectReviewSubmissionAttempt('gh api -X POST /repos/acme/widgets/issues/12/comments -f body=hi')).toBeNull()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
@@ -57,6 +57,56 @@ function detectInGhSegment(args: readonly string[], fileContents: string | null)
   return null
 }
 
+export type ReviewSubmissionAttempt = { workspace: string; prNumber: number }
+
+// Submission INTENT, verdict aside: a `gh api .../pulls/N/reviews` with a POST
+// method, or a `gh pr review N` carrying a verdict flag. Gates the post-execution
+// backstop so it only fires for a command that actually tried to CREATE a review.
+// A bare `gh api .../pulls/N/reviews` is a GET that LISTS existing reviews; its
+// response array can contain `"state":"APPROVED"` and a pulls URL, which would
+// otherwise make the backstop credit a review that never landed this turn. A read
+// is not an attempt and returns null here.
+export function detectReviewSubmissionAttempt(command: string): ReviewSubmissionAttempt | null {
+  for (const args of ghSegments(command)) {
+    const attempt = attemptInGhSegment(args)
+    if (attempt !== null) return attempt
+  }
+  return null
+}
+
+function attemptInGhSegment(args: readonly string[]): ReviewSubmissionAttempt | null {
+  const sub = args[1]
+  if (sub === 'api') {
+    if (!isPostMethod(args)) return null
+    const endpoint = args.find((a) => REVIEWS_ENDPOINT.test(a))
+    if (endpoint === undefined) return null
+    const m = REVIEWS_ENDPOINT.exec(endpoint)
+    if (m === null) return null
+    const prNumber = Number(m[3])
+    if (!Number.isSafeInteger(prNumber)) return null
+    return { workspace: `${m[1]}/${m[2]}`, prNumber }
+  }
+  if (sub === 'pr' && args[2] === 'review') {
+    const detected = detectPrReview(args)
+    return detected === null ? null : { workspace: detected.workspace, prNumber: detected.prNumber }
+  }
+  return null
+}
+
+// `gh api` defaults to GET; creating a review is a POST. Accept `-X POST` /
+// `--method POST` in both `flag value` and `flag=value` shapes, case-insensitive.
+function isPostMethod(args: readonly string[]): boolean {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === undefined) continue
+    if ((a === '-X' || a === '--method') && (args[i + 1] ?? '').toUpperCase() === 'POST') return true
+    if ((a.startsWith('-X=') || a.startsWith('--method=')) && a.slice(a.indexOf('=') + 1).toUpperCase() === 'POST') {
+      return true
+    }
+  }
+  return false
+}
+
 function detectApiReview(args: readonly string[], fileContents: string | null): DetectedReview | null {
   const endpoint = args.find((a) => REVIEWS_ENDPOINT.test(a))
   if (endpoint === undefined) return null

--- a/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
@@ -107,30 +107,75 @@ describe('review recorder', () => {
   describe('post-execution backstop (pre-detection missed)', () => {
     const LANDED_APPROVED = `{"id":7,"node_id":"PRR_x","state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/77"}`
 
-    test('credits a landed APPROVE from the REST response when no pending entry exists', () => {
-      // no noteReviewCommand — simulates a command shape the before-detector missed
+    // The backstop now fires only after tool.before saw a real POST submission
+    // attempt whose verdict it could not extract. A heredoc-bodied POST with the
+    // payload in a separate file the before-detector did not resolve is the
+    // canonical "attempt seen, verdict missed" case used to arm these tests.
+    async function noteMissedAttempt(callId: string, prNumber: number): Promise<void> {
+      await noteReviewCommand({
+        callId,
+        command: `gh api -X POST /repos/${WS}/pulls/${prNumber}/reviews --input /tmp/missing-${prNumber}.json`,
+      })
+    }
+
+    test('credits a landed APPROVE from the REST response for an attempted POST whose verdict was missed', async () => {
+      await noteMissedAttempt('b1', 77)
       commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b1', result: textResult(LANDED_APPROVED) })
       expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 77, verdict: 'APPROVE' })).toBe(true)
     })
 
-    test('credits a landed CHANGES_REQUESTED from the REST response', () => {
+    test('credits a landed CHANGES_REQUESTED from the REST response', async () => {
+      await noteMissedAttempt('b2', 78)
       const out = `{"state":"CHANGES_REQUESTED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/78"}`
       commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b2', result: textResult(out) })
       expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 78, verdict: 'REQUEST_CHANGES' })).toBe(true)
     })
 
-    test('does NOT credit when the state is present but a failure marker is also present (fail closed)', () => {
+    test('does NOT credit a reviews-list READ whose response array carries a decisive state', async () => {
+      // given: a GET that LISTS existing reviews (no -X POST) — not a submission
+      await noteReviewCommand({ callId: 'bread', command: `gh api /repos/${WS}/pulls/84/reviews` })
+      // when: the response array contains an existing APPROVED review + a pulls URL
+      const out = `[{"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/84"}]`
+      const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'bread', result: textResult(out) })
+      // then: no attempt marker was recorded, so the backstop never runs
+      expect(result.committed).toBe(false)
+      expect(result.landedFromResult).toBeNull()
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 84, verdict: 'APPROVE' })).toBe(false)
+    })
+
+    test('does NOT credit when no submission attempt was recorded at all', () => {
+      const result = commitReviewIfSucceeded({
+        sessionId: SESSION,
+        callId: 'bnone',
+        result: textResult(LANDED_APPROVED),
+      })
+      expect(result.committed).toBe(false)
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 77, verdict: 'APPROVE' })).toBe(false)
+    })
+
+    test('does NOT credit when the attempted PR does not match the PR in the response', async () => {
+      await noteMissedAttempt('bmismatch', 85)
+      const out = `{"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/999"}`
+      const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'bmismatch', result: textResult(out) })
+      expect(result.committed).toBe(false)
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 999, verdict: 'APPROVE' })).toBe(false)
+    })
+
+    test('does NOT credit when the state is present but a failure marker is also present (fail closed)', async () => {
+      await noteMissedAttempt('b3', 79)
       const out = `gh: Validation Failed (HTTP 422) {"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/79"}`
       commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b3', result: textResult(out) })
       expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 79, verdict: 'APPROVE' })).toBe(false)
     })
 
-    test('does NOT credit a decisive state with no recoverable PR url', () => {
+    test('does NOT credit a decisive state with no recoverable PR url', async () => {
+      await noteMissedAttempt('b4', 77)
       commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b4', result: textResult('{"state":"APPROVED"}') })
       expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 77, verdict: 'APPROVE' })).toBe(false)
     })
 
-    test('does NOT credit a COMMENT review state', () => {
+    test('does NOT credit a COMMENT review state', async () => {
+      await noteMissedAttempt('b5', 80)
       const out = `{"state":"COMMENTED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/80"}`
       commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b5', result: textResult(out) })
       expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 80, verdict: 'APPROVE' })).toBe(false)
@@ -150,7 +195,8 @@ describe('review recorder', () => {
       expect(result.landedFromResult).toBeNull()
     })
 
-    test('the backstop result returns landedFromResult for the caller to arm the shield', () => {
+    test('the backstop result returns landedFromResult for the caller to arm the shield', async () => {
+      await noteMissedAttempt('b8', 83)
       const out = `{"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/83"}`
       const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'b8', result: textResult(out) })
       expect(result.committed).toBe(true)
@@ -172,8 +218,13 @@ describe('review recorder', () => {
 
     test('pre-detection missed, REST response detected, next same-commit APPROVE is blocked while GitHub returns NONE', async () => {
       const guard = makeGuard('sha-abc')
-      // given: a verdict landed via a shape the before-detector missed (no pending,
-      // no guard() reservation) — only the REST result proves it
+      // given: a POST create-review whose verdict the before-detector missed (no
+      // pending, no guard() reservation) but whose submission intent it DID record
+      await noteReviewCommand({
+        callId: 'i1',
+        command: `gh api -X POST /repos/${WS}/pulls/90/reviews --input /tmp/missing-90.json`,
+      })
+      // and: only the REST result proves the landed verdict
       const out = `{"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/90"}`
       const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'i1', result: textResult(out) })
       // when: the plugin wires the recovered verdict into the guard, as tool.after does

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -3,7 +3,12 @@ import { readFile } from 'node:fs/promises'
 import { recordReview } from '@/channels/github-review-turn-ledger'
 import type { ContentPart, ToolResult } from '@/plugin'
 
-import { detectReviewSubmission, type DetectedReview } from './gh-review-detect'
+import {
+  detectReviewSubmission,
+  detectReviewSubmissionAttempt,
+  type DetectedReview,
+  type ReviewSubmissionAttempt,
+} from './gh-review-detect'
 import { detectReviewDump, type ReviewDumpDecision } from './gh-review-inline-detect'
 
 // Bridges the bash `gh` interceptor to the false-receipt ledger: at tool.before
@@ -19,8 +24,11 @@ import { detectReviewDump, type ReviewDumpDecision } from './gh-review-inline-de
 // the before-detector. This only arms the dedupe window for the NEXT submission —
 // it cannot un-land a duplicate already posted — but that is precisely what the
 // sequential fan-out incident needed: the first landed APPROVE must arm the shield.
+// The backstop is gated on a tool.before submission-ATTEMPT marker so it never
+// fires for a reviews-list READ whose response happens to carry a decisive state.
 
 const pending = new Map<string, DetectedReview>()
+const submissionAttempts = new Map<string, ReviewSubmissionAttempt>()
 
 const MAX_INPUT_BYTES = 1_000_000
 
@@ -33,6 +41,13 @@ export async function noteReviewCommand(args: { callId: string; command: string 
   const inputFileContents = await readInputFile(args.command)
   const detected = detectReviewSubmission({ command: args.command, inputFileContents })
   if (detected !== null) pending.set(args.callId, detected)
+  // Record submission INTENT even when the verdict could not be extracted (a
+  // missed shape): only such a command may later arm the backstop, so a reviews
+  // READ — which is not an attempt — can never be miscredited as a landed review.
+  else {
+    const attempt = detectReviewSubmissionAttempt(args.command)
+    if (attempt !== null) submissionAttempts.set(args.callId, attempt)
+  }
   return { dump: detectReviewDump({ command: args.command, inputFileContents }), detected }
 }
 
@@ -64,8 +79,19 @@ export function commitReviewIfSucceeded(args: {
     return { committed: true, landedFromResult: null }
   }
 
+  // The backstop runs ONLY for a command that tool.before saw as a real
+  // submission attempt (POST create-review) but whose verdict it could not
+  // extract. This excludes a reviews-list READ outright, and the PR-match below
+  // rejects a stray pulls URL for a different PR in the output.
+  const attempt = submissionAttempts.get(args.callId)
+  if (attempt === undefined) return { committed: false, landedFromResult: null }
+  submissionAttempts.delete(args.callId)
+
   const landed = detectLandedReviewFromResult(text)
   if (landed === null) return { committed: false, landedFromResult: null }
+  if (landed.workspace !== attempt.workspace || landed.prNumber !== attempt.prNumber) {
+    return { committed: false, landedFromResult: null }
+  }
   recordReview({
     sessionId: args.sessionId,
     workspace: landed.workspace,


### PR DESCRIPTION
## Summary

Follow-up to #792. While reviewing #792, the bot flagged a false-positive in the post-execution backstop added there: the backstop credited any bash result containing a decisive review state and a pull-request URL, even when the command only **read** existing reviews rather than creating one.

A successful GET that lists reviews (gh api on the pulls/N/reviews endpoint with no POST method) returns an array whose objects carry a state of APPROVED and a pull-request URL, so the backstop would record a review and arm the lag shield even though no review landed this turn. That could then **block a genuine APPROVE**.

The bot is right. The backstop in #792 ran on any tool.after result containing a decisive state plus a pulls URL, with no check that the command was actually a review **submission**.

## Fix

Per the reviewer's suggestion, carry submission **intent** from tool.before and gate the backstop on it:

- **gh-review-detect** — new detectReviewSubmissionAttempt(command) recognises a real submission: a gh api POST to the reviews endpoint (via -X POST or --method POST), or gh pr review N with a verdict flag. A bare or explicit-GET reviews endpoint is **not** an attempt.
- **review-recorder** — at tool.before, when a command is a submission attempt but its verdict could not be extracted (a missed shape), record the attempt by callId. The backstop now runs **only** when such a marker exists, **consumes** it, and additionally requires the recovered PR to **match** the attempted PR. So neither a reviews read nor a stray pulls URL for a different PR can be miscredited.

The pending-detection path (the common case) is unchanged.

## Why this is the robust choice

The alternative — sniffing the JSON shape (single object vs array) — is fragile against jq-piped output, pretty-printing, and partial captures. Tying the backstop to a tool.before submission attempt keys it on genuine intent, which a read can never satisfy.

## Test plan

review-recorder tests:

- a reviews-list READ whose response array carries an APPROVED state is **not** credited
- a POST attempt whose verdict was missed **is** credited via the backstop
- no-attempt and PR-mismatch cases are rejected
- existing backstop cases updated to register the attempt first (the realistic flow)

gh-review-detect tests: unit coverage for the new attempt detector — POST vs GET, --method POST, slash-less endpoint after a cd prefix, gh pr review verdict, and a non-reviews POST.

All checks green: typecheck, lint (0 errors), format:check, and the full suite at 8668 pass / 0 fail.

Addresses the open review thread on #792: https://github.com/typeclaw/typeclaw/pull/792#discussion_r3395065864
