### PR TITLE
Add opt-in vector memory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@clack/core": "^1.2.0",
         "@clack/prompts": "^1.2.0",
+        "@huggingface/transformers": "^4.2.0",
         "@mariozechner/pi-coding-agent": "^0.67.3",
         "@mariozechner/pi-tui": "^0.67.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -17,6 +18,7 @@
         "cron-parser": "^5.5.0",
         "jq-wasm": "^1.1.0-jq-1.8.1",
         "jsdom": "^29.0.2",
+        "proper-lockfile": "^4.1.2",
         "qrcode": "^1.5.4",
         "turndown": "^7.2.4",
         "zod": "^4.3.6",
@@ -155,6 +157,12 @@
     "@hapi/hoek": ["@hapi/hoek@11.0.7", "", {}, "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
+
+    "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@4.2.0", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "@huggingface/tokenizers": "^0.1.3", "onnxruntime-node": "1.24.3", "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c", "sharp": "^0.34.5" } }, "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -522,6 +530,8 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agent-messenger": ["agent-messenger@2.20.1", "", { "dependencies": { "@hapi/boom": "^10.0.1", "@slack/web-api": "^6.9.0", "@whiskeysockets/baileys": "^7.0.0-rc.9", "better-sqlite3": "^12.0.0", "blessed": "^0.1.81", "bson": "^7.2.0", "classic-level": "^3.0.0", "commander": "^11.1.0", "crypto-js": "^4.2.0", "curve25519-js": "^0.0.4", "node-bignumber": "^1.2.2", "node-int64": "^0.4.0", "node-jose": "^2.2.0", "pino": "^10.3.1", "qrcode": "^1.5.4", "thrift": "^0.20.0", "tweetnacl": "^1.0.3", "ws": "^8.19.0", "zod": "^4.3.6" }, "optionalDependencies": { "koffi": "^2.15.2", "prebuilt-tdlib": "0.1008062.2" }, "bin": { "agent-channeltalk": "dist/src/platforms/channeltalk/cli.js", "agent-channeltalkbot": "dist/src/platforms/channeltalkbot/cli.js", "agent-discord": "dist/src/platforms/discord/cli.js", "agent-discordbot": "dist/src/platforms/discordbot/cli.js", "agent-instagram": "dist/src/platforms/instagram/cli.js", "agent-kakaotalk": "dist/src/platforms/kakaotalk/cli.js", "agent-line": "dist/src/platforms/line/cli.js", "agent-messenger": "dist/src/cli.js", "agent-slack": "dist/src/platforms/slack/cli.js", "agent-slackbot": "dist/src/platforms/slackbot/cli.js", "agent-teams": "dist/src/platforms/teams/cli.js", "agent-telegram": "dist/src/platforms/telegram/cli.js", "agent-telegrambot": "dist/src/platforms/telegrambot/cli.js", "agent-webex": "dist/src/platforms/webex/cli.js", "agent-wechatbot": "dist/src/platforms/wechatbot/cli.js", "agent-whatsapp": "dist/src/platforms/whatsapp/cli.js", "agent-whatsappbot": "dist/src/platforms/whatsappbot/cli.js", "amsg": "dist/src/cli.js" } }, "sha512-9cM04BA/tdYEv78So+2M8yZJTtHl6Tqkp0ha3+NyXTIq1XDZmxeZ4Z/4iJZTCjamjwsuR5RoBbXobq8rnlaH3g=="],
@@ -571,6 +581,8 @@
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
@@ -660,6 +672,10 @@
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
@@ -667,6 +683,8 @@
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
@@ -704,11 +722,15 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
     "es6-promise": ["es6-promise@4.2.8", "", {}, "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
@@ -762,6 +784,8 @@
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
@@ -796,6 +820,10 @@
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
@@ -804,7 +832,11 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -876,6 +908,8 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
@@ -901,6 +935,8 @@
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -964,11 +1000,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
@@ -1026,6 +1070,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
+
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
@@ -1078,6 +1124,8 @@
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -1090,7 +1138,11 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -1133,6 +1185,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1191,6 +1245,8 @@
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
+
+    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
@@ -1303,6 +1359,8 @@
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "node-jose/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
+    "@huggingface/transformers": "^4.2.0",
     "@mariozechner/pi-coding-agent": "^0.67.3",
     "@mariozechner/pi-tui": "^0.67.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -54,6 +55,7 @@
     "cron-parser": "^5.5.0",
     "jq-wasm": "^1.1.0-jq-1.8.1",
     "jsdom": "^29.0.2",
+    "proper-lockfile": "^4.1.2",
     "qrcode": "^1.5.4",
     "turndown": "^7.2.4",
     "zod": "^4.3.6"

--- a/src/bundled-plugins/guard/policies/memory-retrieval-cache-write.test.ts
+++ b/src/bundled-plugins/guard/policies/memory-retrieval-cache-write.test.ts
@@ -25,6 +25,24 @@ describe('memory-retrieval-cache-write guard helper', () => {
     ).resolves.toBe(false)
   })
 
+  test('allows in-process vector writer (system origin with component=memory-retrieval)', async () => {
+    await expect(
+      allowed('write', 'memory/.retrieval-cache/s1.md', {
+        kind: 'system',
+        component: 'memory-retrieval',
+      }),
+    ).resolves.toBe(true)
+  })
+
+  test('denies system origin with wrong component', async () => {
+    await expect(
+      allowed('write', 'memory/.retrieval-cache/s1.md', {
+        kind: 'system',
+        component: 'memory-logger',
+      }),
+    ).resolves.toBe(false)
+  })
+
   test('denies tui origin', async () => {
     await expect(allowed('write', 'memory/.retrieval-cache/s1.md', { kind: 'tui', sessionId: 's1' })).resolves.toBe(
       false,

--- a/src/bundled-plugins/guard/policies/memory-retrieval-cache-write.ts
+++ b/src/bundled-plugins/guard/policies/memory-retrieval-cache-write.ts
@@ -16,7 +16,13 @@ export async function isMemoryRetrievalCacheWriteAllowed(options: {
 }): Promise<boolean> {
   const { tool, args, agentDir, origin } = options
   if (tool !== 'write') return false
-  if (origin?.kind !== 'subagent' || origin.subagent !== 'memory-retrieval') return false
+  // Allow the memory-retrieval subagent (existing path) OR the in-process
+  // vector retrieval writer (system origin with component='memory-retrieval').
+  // The in-process path runs under the session origin, not a subagent, so we
+  // check for the system component name as the trusted internal actor.
+  const isMemoryRetrievalSubagent = origin?.kind === 'subagent' && origin.subagent === 'memory-retrieval'
+  const isInProcessWriter = origin?.kind === 'system' && origin.component === 'memory-retrieval'
+  if (!isMemoryRetrievalSubagent && !isInProcessWriter) return false
 
   const rawPath = args.path
   if (typeof rawPath !== 'string') return false

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { noopPermissionService } from '@/permissions'
+import { createPluginContext, createPluginLogger } from '@/plugin/context'
+
+import { renderShard } from './frontmatter'
+import { topicShardPath, topicsDir } from './paths'
+
+mock.module('@huggingface/transformers', () => ({
+  env: {},
+  pipeline: async () => async (texts: string[]) => {
+    const data = new Float32Array(texts.length * 768)
+    for (let i = 0; i < texts.length; i++) {
+      const text = texts[i] ?? ''
+      if (text.includes('slow first prompt')) await Bun.sleep(40)
+      data[i * 768] = text.includes('second prompt') || text.includes('Second Topic') ? 1 : 0
+      data[i * 768 + 1] = text.includes('slow first prompt') || text.includes('First Topic') ? 1 : 0
+    }
+    return { data }
+  },
+}))
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'memory-plugin-vector-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('vector session.turn.start hook', () => {
+  test('keeps an older vector retrieval from overwriting a newer cache write', async () => {
+    const memoryPlugin = (await import('./index')).default
+    await writeTopic(agentDir, 'first-topic', 'First Topic', 'a'.repeat(3000))
+    await writeTopic(agentDir, 'second-topic', 'Second Topic', 'b'.repeat(3000))
+    const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096, vector: { enabled: true } })
+    if (!parsed.success) throw new Error(parsed.error.message)
+    const ctx = createPluginContext({
+      name: 'memory',
+      version: undefined,
+      agentDir,
+      config: parsed.data,
+      logger: createPluginLogger('memory'),
+      permissions: noopPermissionService,
+      spawnSubagent: async () => {},
+      isBooted: () => true,
+    })
+    const exports = await memoryPlugin.plugin(ctx)
+
+    const hookCtx = { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') }
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_vector', agentDir, userPrompt: 'slow first prompt' },
+      hookCtx,
+    )
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_vector', agentDir, userPrompt: 'second prompt' },
+      hookCtx,
+    )
+
+    await waitFor(async () => {
+      const content = await readCache().catch(() => '')
+      return content.includes('Second Topic')
+    })
+    await Bun.sleep(80)
+
+    const content = await readCache()
+    expect(content).toStartWith('## Second Topic')
+  })
+})
+
+async function writeTopic(dir: string, slug: string, heading: string, body: string): Promise<void> {
+  await mkdir(topicsDir(dir), { recursive: true })
+  await writeFile(
+    topicShardPath(dir, slug),
+    renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
+  )
+}
+
+async function readCache(): Promise<string> {
+  return readFile(join(agentDir, 'memory', '.retrieval-cache', 'ses_vector.md'), 'utf8')
+}
+
+async function waitFor(predicate: () => Promise<boolean>): Promise<void> {
+  const deadline = performance.now() + 5_000
+  while (performance.now() < deadline) {
+    if (await predicate()) return
+    await Bun.sleep(10)
+  }
+  throw new Error('timed out waiting for predicate')
+}

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,20 +8,19 @@ import { createPluginContext, createPluginLogger } from '@/plugin/context'
 
 import { renderShard } from './frontmatter'
 import { topicShardPath, topicsDir } from './paths'
-import { buildStartupVectorIndex } from './vector/startup'
 
-mock.module('@huggingface/transformers', () => ({
-  env: {},
-  pipeline: async () => async (texts: string[]) => {
-    const data = new Float32Array(texts.length * 768)
-    for (let i = 0; i < texts.length; i++) {
-      const text = texts[i] ?? ''
-      if (text.includes('slow first prompt')) await Bun.sleep(40)
-      data[i * 768] = text.includes('second prompt') || text.includes('Second Topic') ? 1 : 0
-      data[i * 768 + 1] = text.includes('slow first prompt') || text.includes('First Topic') ? 1 : 0
-    }
-    return { data }
+const hybridSearchMock = mock(async () => [
+  {
+    source: 'topic' as const,
+    key: 'second-topic',
+    heading: 'Second Topic',
+    excerpt: 'Second topic excerpt from vector retrieval.',
+    rrfScore: 1,
   },
+])
+
+mock.module('./vector/hybrid', () => ({
+  hybridSearch: hybridSearchMock,
 }))
 
 let agentDir: string
@@ -35,11 +34,10 @@ afterEach(async () => {
 })
 
 describe('vector session.turn.start hook', () => {
-  test('coalesces overlapping vector retrievals so the in-flight cache write is not invalidated', async () => {
+  test('populates retrieval context synchronously for the current turn', async () => {
     const memoryPlugin = (await import('./index')).default
     await writeTopic(agentDir, 'first-topic', 'First Topic', 'a'.repeat(3000))
     await writeTopic(agentDir, 'second-topic', 'Second Topic', 'b'.repeat(3000))
-    await buildStartupVectorIndex(agentDir)
     const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096, vector: { enabled: true } })
     if (!parsed.success) throw new Error(parsed.error.message)
     const ctx = createPluginContext({
@@ -55,23 +53,16 @@ describe('vector session.turn.start hook', () => {
     const exports = await memoryPlugin.plugin(ctx)
 
     const hookCtx = { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') }
+    const retrievalContext = { results: '' }
     await exports.hooks!['session.turn.start']!(
-      { sessionId: 'ses_vector', agentDir, userPrompt: 'slow first prompt' },
-      hookCtx,
-    )
-    await exports.hooks!['session.turn.start']!(
-      { sessionId: 'ses_vector', agentDir, userPrompt: 'second prompt' },
+      { sessionId: 'ses_vector', agentDir, userPrompt: 'second prompt', retrievalContext },
       hookCtx,
     )
 
-    await waitFor(async () => {
-      const content = await readCache().catch(() => '')
-      return content.includes('First Topic')
-    })
-    await Bun.sleep(80)
-
-    const content = await readCache()
-    expect(content).toStartWith('## First Topic')
+    expect(hybridSearchMock).toHaveBeenCalledWith('second prompt', expect.anything(), agentDir, 10)
+    expect(retrievalContext.results).toBe(
+      '## Retrieved memory\n\n### Second Topic\n\nSecond topic excerpt from vector retrieval.',
+    )
   })
 })
 
@@ -81,17 +72,4 @@ async function writeTopic(dir: string, slug: string, heading: string, body: stri
     topicShardPath(dir, slug),
     renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
   )
-}
-
-async function readCache(): Promise<string> {
-  return readFile(join(agentDir, 'memory', '.retrieval-cache', 'ses_vector.md'), 'utf8')
-}
-
-async function waitFor(predicate: () => Promise<boolean>): Promise<void> {
-  const deadline = performance.now() + 5_000
-  while (performance.now() < deadline) {
-    if (await predicate()) return
-    await Bun.sleep(10)
-  }
-  throw new Error('timed out waiting for predicate')
 }

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -8,6 +8,7 @@ import { createPluginContext, createPluginLogger } from '@/plugin/context'
 
 import { renderShard } from './frontmatter'
 import { topicShardPath, topicsDir } from './paths'
+import { buildStartupVectorIndex } from './vector/startup'
 
 mock.module('@huggingface/transformers', () => ({
   env: {},
@@ -38,6 +39,7 @@ describe('vector session.turn.start hook', () => {
     const memoryPlugin = (await import('./index')).default
     await writeTopic(agentDir, 'first-topic', 'First Topic', 'a'.repeat(3000))
     await writeTopic(agentDir, 'second-topic', 'Second Topic', 'b'.repeat(3000))
+    await buildStartupVectorIndex(agentDir)
     const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096, vector: { enabled: true } })
     if (!parsed.success) throw new Error(parsed.error.message)
     const ctx = createPluginContext({

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -34,7 +34,7 @@ afterEach(async () => {
 })
 
 describe('vector session.turn.start hook', () => {
-  test('keeps an older vector retrieval from overwriting a newer cache write', async () => {
+  test('coalesces overlapping vector retrievals so the in-flight cache write is not invalidated', async () => {
     const memoryPlugin = (await import('./index')).default
     await writeTopic(agentDir, 'first-topic', 'First Topic', 'a'.repeat(3000))
     await writeTopic(agentDir, 'second-topic', 'Second Topic', 'b'.repeat(3000))
@@ -64,12 +64,12 @@ describe('vector session.turn.start hook', () => {
 
     await waitFor(async () => {
       const content = await readCache().catch(() => '')
-      return content.includes('Second Topic')
+      return content.includes('First Topic')
     })
     await Bun.sleep(80)
 
     const content = await readCache()
-    expect(content).toStartWith('## Second Topic')
+    expect(content).toStartWith('## First Topic')
   })
 })
 

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -16,7 +16,6 @@ import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-l
 import { createMemoryRetrievalSubagent, type MemoryRetrievalPayload } from './memory-retrieval'
 import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
 import { memorySearchTool } from './search-tool'
-import { writeRetrievalCache } from './vector/cache-write'
 import { vectorConfigSchema } from './vector/config'
 import { hybridSearch } from './vector/hybrid'
 import { makeAppendHook } from './vector/index-on-write'
@@ -151,7 +150,6 @@ export default definePlugin({
     const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined; origin?: SessionOrigin }>()
     const bytesAtLastRun = new Map<string, number>()
     const linesAtLastRun = new Map<string, number>()
-    const vectorRetrievalInFlight = new Set<string>()
     // Per-session stream-file cursor: the JSONL line count of the daily
     // stream file at the END of this session's most recent memory-logger
     // spawn. Keyed by sessionId, valued by `{ date, lineCount }`. Honored
@@ -292,26 +290,6 @@ export default definePlugin({
       await ctx.spawnSubagent('memory-retrieval', payload, retrievalSpawnOptions)
     }
 
-    const runVectorRetrieval = async (event: {
-      sessionId: string
-      agentDir: string
-      userPrompt: string
-    }): Promise<void> => {
-      const shards = await loadAllShards(event.agentDir)
-      const plan = buildInjectionPlan(shards, { budgetBytes: ctx.config.injectionBudgetBytes })
-      if (plan.mode === 'direct') return
-
-      const dbPath = join(event.agentDir, 'memory', '.vectors', 'index.db')
-      const store = VectorStore.open(dbPath)
-      try {
-        const results = await hybridSearch(event.userPrompt, store, event.agentDir, 10)
-        const content = results.map((result) => `## ${result.heading}\n\n${result.excerpt}`).join('\n\n')
-        await writeRetrievalCache(event.agentDir, event.sessionId, content)
-      } finally {
-        store.close()
-      }
-    }
-
     // Subagents are constructed at boot here (rather than imported as constants)
     // so their lifecycle logs route through the plugin logger and pick up the
     // `[plugin:memory]` prefix. Without this, they would write directly to
@@ -411,54 +389,27 @@ export default definePlugin({
         // before each `session.prompt(text)` call with the actual text the
         // session is about to receive.
         //
-        // The hook body is fully detached. `runSessionTurnStart` has no
-        // per-handler timeout (unlike session.prompt/idle/end), and the
-        // caller awaits it before `session.prompt(text)` runs — so an
-        // inline `await loadAllShards(...)` would gate every channel turn
-        // on N shard reads. Detaching mirrors PR #337's "fire-and-forget
-        // the slow work" pattern, pushed one level earlier to cover both
-        // the shard read AND the LLM spawn.
-        //
-        // Per-turn instead of per-session-creation means N spawns over the
-        // session's lifetime, but the subagent's own `inFlightKey` on
-        // `parentSessionId` (memory-retrieval.ts) coalesces overlapping
-        // fires: if turn N's retrieval is still running when turn N+1 fires,
-        // the second spawn is dropped with a warning, and the cache from
-        // turn N is still consumed by turn N+1 via the documented
-        // lag-by-one-prompt contract (load-memory.ts:appendRetrievalCache).
-        //
-        // Known limitation: a detached spawn can theoretically settle after
-        // `session.end` has unlinked the cache file, leaving a single ~5 KB
-        // file in memory/.retrieval-cache/ that never gets read. The next
-        // session.end that matches this sessionId would clean it up, but
-        // sessionIds are UUIDv7 so reuse is effectively never. Fix would
-        // serialize session.end behind the in-flight spawn, which
-        // re-introduces the cold-start blocking shape PR #337 fixed. The
-        // leaked file is bounded (one per disconnected session) and lives
-        // in a dir already marked transient.
-        //
-        // ctx.spawnSubagent IS reject-able in production: it wraps
-        // dispatchSpawnSubagent (src/run/index.ts) which calls invokeSubagent
-        // directly with no try/catch. SubagentConsumer's catch only protects
-        // stream-initiated spawns (target.kind === 'new-session'), not the
-        // direct ctx.spawnSubagent path the hooks use. Same for
-        // loadAllShards' fs errors. The .catch() on the void-discarded
-        // promise below is load-bearing — without it, every shard-read or
-        // handler failure (LLM provider error, payload validation throw)
-        // would surface as an unhandled rejection because nothing awaits
-        // the promise.
-        'session.turn.start': (event) => {
+        'session.turn.start': async (event) => {
           if (event.origin?.kind === 'subagent') return
           if (ctx.config.vector.enabled) {
-            if (vectorRetrievalInFlight.has(event.sessionId)) return
-            vectorRetrievalInFlight.add(event.sessionId)
-            void runVectorRetrieval(event)
-              .catch((err) => {
-                ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
-              })
-              .finally(() => {
-                vectorRetrievalInFlight.delete(event.sessionId)
-              })
+            if (event.retrievalContext === undefined) return
+            const shards = await loadAllShards(event.agentDir)
+            const plan = buildInjectionPlan(shards, { budgetBytes: ctx.config.injectionBudgetBytes })
+            if (plan.mode === 'direct') return
+            const dbPath = join(event.agentDir, 'memory', '.vectors', 'index.db')
+            const store = VectorStore.open(dbPath)
+            try {
+              const results = await hybridSearch(event.userPrompt, store, event.agentDir, 10)
+              if (results.length > 0) {
+                event.retrievalContext.results = `## Retrieved memory\n\n${results
+                  .map((result) => `### ${result.heading}\n\n${result.excerpt}`)
+                  .join('\n\n')}`
+              }
+            } catch (err) {
+              ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
+            } finally {
+              store.close()
+            }
           } else {
             void runMemoryRetrieval(event).catch((err) => {
               ctx.logger.error(`memory-retrieval spawn failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -151,7 +151,7 @@ export default definePlugin({
     const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined; origin?: SessionOrigin }>()
     const bytesAtLastRun = new Map<string, number>()
     const linesAtLastRun = new Map<string, number>()
-    const vectorRetrievalTurns = new Map<string, number>()
+    const vectorRetrievalInFlight = new Set<string>()
     // Per-session stream-file cursor: the JSONL line count of the daily
     // stream file at the END of this session's most recent memory-logger
     // spawn. Keyed by sessionId, valued by `{ date, lineCount }`. Honored
@@ -296,7 +296,6 @@ export default definePlugin({
       sessionId: string
       agentDir: string
       userPrompt: string
-      turn: number
     }): Promise<void> => {
       const shards = await loadAllShards(event.agentDir)
       const plan = buildInjectionPlan(shards, { budgetBytes: ctx.config.injectionBudgetBytes })
@@ -308,7 +307,6 @@ export default definePlugin({
         await buildLazyIndex(store, event.agentDir)
         const results = await hybridSearch(event.userPrompt, store, event.agentDir, 10)
         const content = results.map((result) => `## ${result.heading}\n\n${result.excerpt}`).join('\n\n')
-        if (vectorRetrievalTurns.get(event.sessionId) !== event.turn) return
         await writeRetrievalCache(event.agentDir, event.sessionId, content)
       } finally {
         store.close()
@@ -453,11 +451,15 @@ export default definePlugin({
         'session.turn.start': (event) => {
           if (event.origin?.kind === 'subagent') return
           if (ctx.config.vector.enabled) {
-            const turn = (vectorRetrievalTurns.get(event.sessionId) ?? 0) + 1
-            vectorRetrievalTurns.set(event.sessionId, turn)
-            void runVectorRetrieval({ ...event, turn }).catch((err) => {
-              ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
-            })
+            if (vectorRetrievalInFlight.has(event.sessionId)) return
+            vectorRetrievalInFlight.add(event.sessionId)
+            void runVectorRetrieval(event)
+              .catch((err) => {
+                ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
+              })
+              .finally(() => {
+                vectorRetrievalInFlight.delete(event.sessionId)
+              })
           } else {
             void runMemoryRetrieval(event).catch((err) => {
               ctx.logger.error(`memory-retrieval spawn failed: ${err instanceof Error ? err.message : String(err)}`)
@@ -492,7 +494,6 @@ export default definePlugin({
         'session.end': (event) => {
           if (event.origin?.kind === 'subagent') return
           cancelTimer(event.sessionId)
-          vectorRetrievalTurns.delete(event.sessionId)
           const sessionId = event.sessionId
           // The skip path detaches via `void (async () => …)()` because
           // readSize requires an await. fireMemoryLogger itself captures its

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -18,7 +18,6 @@ import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './pat
 import { memorySearchTool } from './search-tool'
 import { vectorConfigSchema } from './vector/config'
 import { hybridSearch } from './vector/hybrid'
-import { makeAppendHook } from './vector/index-on-write'
 import { VectorStore } from './vector/store'
 
 const DEFAULT_IDLE_MS = 60_000
@@ -299,15 +298,10 @@ export default definePlugin({
       warn: (m: string) => ctx.logger.warn(m),
       error: (m: string) => ctx.logger.error(m),
     }
-    const appendVectorStore = ctx.config.vector.enabled
-      ? VectorStore.open(join(ctx.agentDir, 'memory', '.vectors', 'index.db'))
-      : undefined
-
     return {
       subagents: {
         'memory-logger': createMemoryLoggerSubagent({
           logger: subagentLogger,
-          ...(appendVectorStore !== undefined ? { onFragmentsAppended: makeAppendHook(appendVectorStore) } : {}),
         }),
         'memory-retrieval': createMemoryRetrievalSubagent({
           logger: subagentLogger,

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -18,7 +18,7 @@ import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './pat
 import { memorySearchTool } from './search-tool'
 import { writeRetrievalCache } from './vector/cache-write'
 import { vectorConfigSchema } from './vector/config'
-import { buildLazyIndex, hybridSearch } from './vector/hybrid'
+import { hybridSearch } from './vector/hybrid'
 import { makeAppendHook } from './vector/index-on-write'
 import { VectorStore } from './vector/store'
 
@@ -304,7 +304,6 @@ export default definePlugin({
       const dbPath = join(event.agentDir, 'memory', '.vectors', 'index.db')
       const store = VectorStore.open(dbPath)
       try {
-        await buildLazyIndex(store, event.agentDir)
         const results = await hybridSearch(event.userPrompt, store, event.agentDir, 10)
         const content = results.map((result) => `## ${result.heading}\n\n${result.excerpt}`).join('\n\n')
         await writeRetrievalCache(event.agentDir, event.sessionId, content)

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -151,6 +151,7 @@ export default definePlugin({
     const lastIdleEvent = new Map<string, { parentTranscriptPath: string | undefined; origin?: SessionOrigin }>()
     const bytesAtLastRun = new Map<string, number>()
     const linesAtLastRun = new Map<string, number>()
+    const vectorRetrievalTurns = new Map<string, number>()
     // Per-session stream-file cursor: the JSONL line count of the daily
     // stream file at the END of this session's most recent memory-logger
     // spawn. Keyed by sessionId, valued by `{ date, lineCount }`. Honored
@@ -295,6 +296,7 @@ export default definePlugin({
       sessionId: string
       agentDir: string
       userPrompt: string
+      turn: number
     }): Promise<void> => {
       const shards = await loadAllShards(event.agentDir)
       const plan = buildInjectionPlan(shards, { budgetBytes: ctx.config.injectionBudgetBytes })
@@ -306,6 +308,7 @@ export default definePlugin({
         await buildLazyIndex(store, event.agentDir)
         const results = await hybridSearch(event.userPrompt, store, event.agentDir, 10)
         const content = results.map((result) => `## ${result.heading}\n\n${result.excerpt}`).join('\n\n')
+        if (vectorRetrievalTurns.get(event.sessionId) !== event.turn) return
         await writeRetrievalCache(event.agentDir, event.sessionId, content)
       } finally {
         store.close()
@@ -450,7 +453,9 @@ export default definePlugin({
         'session.turn.start': (event) => {
           if (event.origin?.kind === 'subagent') return
           if (ctx.config.vector.enabled) {
-            void runVectorRetrieval(event).catch((err) => {
+            const turn = (vectorRetrievalTurns.get(event.sessionId) ?? 0) + 1
+            vectorRetrievalTurns.set(event.sessionId, turn)
+            void runVectorRetrieval({ ...event, turn }).catch((err) => {
               ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
             })
           } else {
@@ -487,6 +492,7 @@ export default definePlugin({
         'session.end': (event) => {
           if (event.origin?.kind === 'subagent') return
           cancelTimer(event.sessionId)
+          vectorRetrievalTurns.delete(event.sessionId)
           const sessionId = event.sessionId
           // The skip path detaches via `void (async () => …)()` because
           // readSize requires an await. fireMemoryLogger itself captures its

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -16,6 +16,11 @@ import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-l
 import { createMemoryRetrievalSubagent, type MemoryRetrievalPayload } from './memory-retrieval'
 import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
 import { memorySearchTool } from './search-tool'
+import { writeRetrievalCache } from './vector/cache-write'
+import { vectorConfigSchema } from './vector/config'
+import { buildLazyIndex, hybridSearch } from './vector/hybrid'
+import { makeAppendHook } from './vector/index-on-write'
+import { VectorStore } from './vector/store'
 
 const DEFAULT_IDLE_MS = 60_000
 const DEFAULT_BUFFER_BYTES = 500_000
@@ -120,6 +125,7 @@ const memoryConfigSchema = z
     // in milliseconds instead of the production 30s.
     retrievalSpawnTimeoutMs: z.number().int().min(1).default(RETRIEVAL_SPAWN_TIMEOUT_MS),
     dreaming: dreamingConfigSchema.optional(),
+    vector: vectorConfigSchema,
   })
   .default({
     idleMs: DEFAULT_IDLE_MS,
@@ -128,6 +134,7 @@ const memoryConfigSchema = z
     minIdleDeltaLines: DEFAULT_MIN_IDLE_DELTA_LINES,
     spawnTimeoutMs: SPAWN_TIMEOUT_MS,
     retrievalSpawnTimeoutMs: RETRIEVAL_SPAWN_TIMEOUT_MS,
+    vector: { enabled: false },
   })
 
 export default definePlugin({
@@ -284,6 +291,27 @@ export default definePlugin({
       await ctx.spawnSubagent('memory-retrieval', payload, retrievalSpawnOptions)
     }
 
+    const runVectorRetrieval = async (event: {
+      sessionId: string
+      agentDir: string
+      userPrompt: string
+    }): Promise<void> => {
+      const shards = await loadAllShards(event.agentDir)
+      const plan = buildInjectionPlan(shards, { budgetBytes: ctx.config.injectionBudgetBytes })
+      if (plan.mode === 'direct') return
+
+      const dbPath = join(event.agentDir, 'memory', '.vectors', 'index.db')
+      const store = VectorStore.open(dbPath)
+      try {
+        await buildLazyIndex(store, event.agentDir)
+        const results = await hybridSearch(event.userPrompt, store, event.agentDir, 10)
+        const content = results.map((result) => `## ${result.heading}\n\n${result.excerpt}`).join('\n\n')
+        await writeRetrievalCache(event.agentDir, event.sessionId, content)
+      } finally {
+        store.close()
+      }
+    }
+
     // Subagents are constructed at boot here (rather than imported as constants)
     // so their lifecycle logs route through the plugin logger and pick up the
     // `[plugin:memory]` prefix. Without this, they would write directly to
@@ -293,10 +321,16 @@ export default definePlugin({
       warn: (m: string) => ctx.logger.warn(m),
       error: (m: string) => ctx.logger.error(m),
     }
+    const appendVectorStore = ctx.config.vector.enabled
+      ? VectorStore.open(join(ctx.agentDir, 'memory', '.vectors', 'index.db'))
+      : undefined
 
     return {
       subagents: {
-        'memory-logger': createMemoryLoggerSubagent({ logger: subagentLogger }),
+        'memory-logger': createMemoryLoggerSubagent({
+          logger: subagentLogger,
+          ...(appendVectorStore !== undefined ? { onFragmentsAppended: makeAppendHook(appendVectorStore) } : {}),
+        }),
         'memory-retrieval': createMemoryRetrievalSubagent({
           logger: subagentLogger,
           timeoutMs: retrievalSpawnTimeoutMs,
@@ -415,9 +449,15 @@ export default definePlugin({
         // the promise.
         'session.turn.start': (event) => {
           if (event.origin?.kind === 'subagent') return
-          void runMemoryRetrieval(event).catch((err) => {
-            ctx.logger.error(`memory-retrieval spawn failed: ${err instanceof Error ? err.message : String(err)}`)
-          })
+          if (ctx.config.vector.enabled) {
+            void runVectorRetrieval(event).catch((err) => {
+              ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
+            })
+          } else {
+            void runMemoryRetrieval(event).catch((err) => {
+              ctx.logger.error(`memory-retrieval spawn failed: ${err instanceof Error ? err.message : String(err)}`)
+            })
+          }
         },
         // The memory-logger spawn is intentionally detached (`void`) instead
         // of awaited. The channel router calls `tearDownLive` synchronously

--- a/src/bundled-plugins/memory/search-tool.ts
+++ b/src/bundled-plugins/memory/search-tool.ts
@@ -9,7 +9,7 @@ import { readAllUndreamedStreamDays, type UndreamedStreamDay } from './stream-io
 const DEFAULT_MAX_RESULTS = 10
 const EXCERPT_CONTEXT_LINES = 3
 
-type TopicMatch = {
+export type TopicMatch = {
   source: 'topic'
   shardPath: string
   slug: string
@@ -18,7 +18,7 @@ type TopicMatch = {
   fullBody?: string
 }
 
-type StreamMatch = {
+export type StreamMatch = {
   source: 'stream'
   streamPath: string
   date: string
@@ -28,11 +28,11 @@ type StreamMatch = {
   fullBody?: string
 }
 
-type MemorySearchMatch = TopicMatch | StreamMatch
+export type MemorySearchMatch = TopicMatch | StreamMatch
 
-type MemorySearchResult = { matches: MemorySearchMatch[]; truncatedAt?: number } | { error: string }
+export type MemorySearchResult = { matches: MemorySearchMatch[]; truncatedAt?: number } | { error: string }
 
-type Matcher = (haystack: string) => boolean
+export type Matcher = (haystack: string) => boolean
 
 export const memorySearchTool = defineTool({
   description:
@@ -101,7 +101,7 @@ function distinctTokens(query: string): string[] {
   ]
 }
 
-function buildMatcher(query: string, asRegex: boolean): Matcher | string {
+export function buildMatcher(query: string, asRegex: boolean): Matcher | string {
   if (asRegex) {
     try {
       const regex = new RegExp(query, 'i')
@@ -122,7 +122,7 @@ function buildMatcher(query: string, asRegex: boolean): Matcher | string {
 // before topic matches when `maxResults` is exhausted. The agent reading
 // results in this order sees long-term consolidated truth before recent
 // ephemeral fragments, which mirrors the injection-side rendering order.
-function searchAll(
+export function searchAll(
   shards: TopicShard[],
   streamDays: UndreamedStreamDay[],
   matcher: Matcher,
@@ -165,7 +165,7 @@ function searchAll(
 // natural enumeration order (topics first in loadAllShards order, then stream
 // days newest-first), so the established ordering contract holds within each
 // score band. maxResults truncation is applied last, after ranking.
-function searchAllRanked(
+export function searchAllRanked(
   shards: TopicShard[],
   streamDays: UndreamedStreamDay[],
   tokens: string[],

--- a/src/bundled-plugins/memory/vector/cache-write.test.ts
+++ b/src/bundled-plugins/memory/vector/cache-write.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { randomBytes } from 'node:crypto'
+import { mkdir, readFile, stat } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { writeRetrievalCache } from './cache-write'
+
+describe('writeRetrievalCache', () => {
+  let testAgentDir: string
+
+  beforeEach(async () => {
+    // Create a unique temp directory for this test
+    const suffix = randomBytes(8).toString('hex')
+    testAgentDir = join(tmpdir(), `typeclaw-test-cache-write-${suffix}`)
+    await mkdir(testAgentDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    // Clean up test directory
+    try {
+      await rm(testAgentDir, { recursive: true, force: true })
+    } catch {
+      // Ignore cleanup errors
+    }
+  })
+
+  it('writes content to memory/.retrieval-cache/<sessionId>.md', async () => {
+    // given: a session ID and content
+    const sessionId = 'ses_test123'
+    const content = '# Retrieved Memory\n\nSome cached content'
+
+    // when: writing the cache
+    await writeRetrievalCache(testAgentDir, sessionId, content)
+
+    // then: the file exists at the correct path with correct content
+    const cachePath = join(testAgentDir, 'memory', '.retrieval-cache', `${sessionId}.md`)
+    const readContent = await readFile(cachePath, 'utf8')
+    expect(readContent).toBe(content)
+  })
+
+  it('creates .retrieval-cache directory if it does not exist', async () => {
+    // given: a session ID and content
+    const sessionId = 'ses_test456'
+    const content = 'test content'
+
+    // when: writing the cache (directory does not exist yet)
+    await writeRetrievalCache(testAgentDir, sessionId, content)
+
+    // then: the directory was created
+    const cacheDir = join(testAgentDir, 'memory', '.retrieval-cache')
+    const dirStat = await stat(cacheDir)
+    expect(dirStat.isDirectory()).toBe(true)
+  })
+
+  it('does not leave .tmp file after write', async () => {
+    // given: a session ID and content
+    const sessionId = 'ses_test789'
+    const content = 'atomic write test'
+
+    // when: writing the cache
+    await writeRetrievalCache(testAgentDir, sessionId, content)
+
+    // then: no .tmp file remains (atomic rename succeeded)
+    const tmpPath = join(testAgentDir, 'memory', '.retrieval-cache', `${sessionId}.md.tmp`)
+    let tmpExists = false
+    try {
+      await stat(tmpPath)
+      tmpExists = true
+    } catch {
+      // Expected: file should not exist
+    }
+    expect(tmpExists).toBe(false)
+  })
+
+  it('overwrites existing cache file', async () => {
+    // given: a session ID with existing cache
+    const sessionId = 'ses_overwrite'
+    const oldContent = 'old content'
+    const newContent = 'new content'
+
+    // when: writing cache twice with different content
+    await writeRetrievalCache(testAgentDir, sessionId, oldContent)
+    await writeRetrievalCache(testAgentDir, sessionId, newContent)
+
+    // then: the file contains the new content
+    const cachePath = join(testAgentDir, 'memory', '.retrieval-cache', `${sessionId}.md`)
+    const readContent = await readFile(cachePath, 'utf8')
+    expect(readContent).toBe(newContent)
+  })
+})

--- a/src/bundled-plugins/memory/vector/cache-write.ts
+++ b/src/bundled-plugins/memory/vector/cache-write.ts
@@ -1,0 +1,19 @@
+import { mkdir, writeFile, rename } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/**
+ * Atomically write retrieval cache to memory/.retrieval-cache/<sessionId>.md
+ * using tmp+rename pattern for crash safety.
+ */
+export async function writeRetrievalCache(agentDir: string, sessionId: string, content: string): Promise<void> {
+  const cacheDir = join(agentDir, 'memory', '.retrieval-cache')
+  const cachePath = join(cacheDir, `${sessionId}.md`)
+  const tmpPath = `${cachePath}.tmp`
+
+  // Create directory if it doesn't exist
+  await mkdir(cacheDir, { recursive: true })
+
+  // Write to tmp file, then atomically rename
+  await writeFile(tmpPath, content, 'utf8')
+  await rename(tmpPath, cachePath)
+}

--- a/src/bundled-plugins/memory/vector/config.test.ts
+++ b/src/bundled-plugins/memory/vector/config.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'bun:test'
+
+import { vectorConfigSchema } from './config'
+
+describe('vectorConfigSchema', () => {
+  it('QA 1.1: no memory.vector block → enabled === false', () => {
+    // Given: empty object (no vector config provided)
+    const input = {}
+
+    // When: parsing with the schema
+    const result = vectorConfigSchema.parse(input)
+
+    // Then: enabled defaults to false
+    expect(result.enabled).toBe(false)
+  })
+
+  it('QA 1.2: memory.vector.enabled: true → enabled === true', () => {
+    // Given: explicit enabled: true
+    const input = { enabled: true }
+
+    // When: parsing with the schema
+    const result = vectorConfigSchema.parse(input)
+
+    // Then: enabled is true
+    expect(result.enabled).toBe(true)
+  })
+})

--- a/src/bundled-plugins/memory/vector/config.ts
+++ b/src/bundled-plugins/memory/vector/config.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const vectorConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false })
+
+export type VectorConfig = z.infer<typeof vectorConfigSchema>

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -1,0 +1,76 @@
+import { join } from 'node:path'
+
+import { env as transformersEnv, pipeline } from '@huggingface/transformers'
+
+import { homeRoot } from '../../../hostd/paths'
+
+export const MODEL_NAME = 'Xenova/multilingual-e5-base'
+export const DIMS = 768
+
+export type EmbedType = 'query' | 'passage'
+
+type FeatureExtractor = Awaited<ReturnType<typeof pipeline<'feature-extraction'>>>
+
+export class Embedder {
+  private constructor(private readonly extractor: FeatureExtractor) {}
+
+  static async load(): Promise<Embedder> {
+    configureTransformers()
+    const extractor = await pipeline('feature-extraction', MODEL_NAME, { local_files_only: true })
+    return new Embedder(extractor)
+  }
+
+  async embed(texts: string[], type: EmbedType): Promise<Float32Array[]> {
+    if (texts.length === 0) return []
+
+    const output = await this.extractor(prefixTexts(texts, type), { pooling: 'mean', normalize: true })
+    return toEmbeddings(output.data, texts.length)
+  }
+}
+
+let embedderInstance: Promise<Embedder> | null = null
+
+export function getEmbedder(): Promise<Embedder> {
+  embedderInstance ??= Embedder.load()
+  return embedderInstance
+}
+
+export async function embed(texts: string[], type: EmbedType): Promise<Float32Array[]> {
+  return (await getEmbedder()).embed(texts, type)
+}
+
+function configureTransformers(): void {
+  transformersEnv.localModelPath = modelCachePath()
+  transformersEnv.allowRemoteModels = false
+}
+
+function modelCachePath(): string {
+  const override = process.env.TYPECLAW_MODEL_CACHE
+  if (override && override.length > 0) return override
+  return join(homeRoot(), 'models')
+}
+
+function prefixTexts(texts: string[], type: EmbedType): string[] {
+  const prefix = type === 'query' ? 'query: ' : 'passage: '
+  return texts.map((text) => `${prefix}${text}`)
+}
+
+function toEmbeddings(data: unknown, count: number): Float32Array[] {
+  const values = toFloat32Array(data)
+  if (values.length !== count * DIMS) {
+    throw new Error(`unexpected ${MODEL_NAME} embedding size: got ${values.length}, expected ${count * DIMS}`)
+  }
+
+  return Array.from({ length: count }, (_, index) => values.slice(index * DIMS, (index + 1) * DIMS))
+}
+
+function toFloat32Array(data: unknown): Float32Array {
+  if (data instanceof Float32Array) return data
+  if (!isNumericArrayLike(data)) throw new Error(`${MODEL_NAME} returned non-numeric embeddings`)
+  return Float32Array.from(data)
+}
+
+function isNumericArrayLike(data: unknown): data is ArrayLike<number> {
+  if (!ArrayBuffer.isView(data) || !('length' in data)) return false
+  return !(data instanceof BigInt64Array) && !(data instanceof BigUint64Array)
+}

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { renderShard } from '../frontmatter'
+import { hybridSearch, buildLazyIndex, type EmbedFn } from './hybrid'
+import { VectorStore, type VectorRow } from './store'
+
+const MODEL = 'test-model'
+const testDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('hybridSearch', () => {
+  it('QA 1.6: fuses exact-ID keyword hits and semantic vector hits via RRF', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeTopic(agentDir, 'pr-651', 'PR 651 Review', 'PR #651 fixed channel reload handling.')
+      writeTopic(
+        agentDir,
+        'semantic-cache',
+        'Retrieval Cache',
+        'Vector memory writes focused summaries after retrieval.',
+      )
+      store.upsert(row('topic:pr-651', 'pr-651', vector({ 0: 1 })))
+      store.upsert(row('topic:semantic-cache', 'semantic-cache', vector({ 1: 1 })))
+
+      const exactResults = await hybridSearch('PR #651', store, agentDir, 3, embedFrom({ 0: 1 }))
+      const exact = exactResults.find((result) => result.key === 'pr-651')
+
+      expect(exactResults.slice(0, 3).map((result) => result.key)).toContain('pr-651')
+      expect(exact?.rrfScore).toBeCloseTo(1 / 61 + 1 / 61, 10)
+
+      const semanticResults = await hybridSearch(
+        'focused memory summary retrieval',
+        store,
+        agentDir,
+        3,
+        embedFrom({ 1: 1 }),
+      )
+      const semantic = semanticResults.find((result) => result.key === 'semantic-cache')
+
+      expect(semanticResults.slice(0, 3).map((result) => result.key)).toContain('semantic-cache')
+      expect(semantic?.rrfScore).toBeCloseTo(1 / 61, 10)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('QA 1.7: multilingual query can retrieve an English shard through the vector lane', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeTopic(
+        agentDir,
+        'english-i18n',
+        'Internationalization Notes',
+        'The UI supports Japanese and Korean locale routing.',
+      )
+      writeTopic(agentDir, 'docker-builds', 'Docker Builds', 'The base image build uses GHCR before npm publication.')
+      store.upsert(row('topic:english-i18n', 'english-i18n', vector({ 2: 1 })))
+      store.upsert(row('topic:docker-builds', 'docker-builds', vector({ 3: 1 })))
+
+      const results = await hybridSearch(
+        '한국어와 일본어 로케일은 어디에서 처리돼?',
+        store,
+        agentDir,
+        3,
+        embedFrom({ 2: 1 }),
+      )
+
+      expect(results.slice(0, 3).map((result) => result.key)).toContain('english-i18n')
+      expect(results.find((result) => result.key === 'english-i18n')?.rrfScore).toBeCloseTo(1 / 61, 10)
+    } finally {
+      store.close()
+    }
+  })
+})
+
+describe('buildLazyIndex', () => {
+  it('embeds topic shards as passages and skips rebuild when rows already exist', async () => {
+    const { agentDir, store } = createFixture()
+    let calls = 0
+    try {
+      writeTopic(agentDir, 'lazy-topic', 'Lazy Topic', 'This topic is indexed on first retrieval.')
+      const embedFn: EmbedFn = async (texts, type) => {
+        calls += 1
+        expect(type).toBe('passage')
+        expect(texts).toEqual(['Lazy Topic\nThis topic is indexed on first retrieval.'])
+        return [vector({ 4: 1 })]
+      }
+
+      await buildLazyIndex(store, agentDir, embedFn)
+      await buildLazyIndex(store, agentDir, embedFn)
+
+      expect(calls).toBe(1)
+      expect(store.getAll().map((stored) => [stored.id, stored.source, stored.key, stored.dims])).toEqual([
+        ['topic:lazy-topic', 'topic', 'lazy-topic', 8],
+      ])
+    } finally {
+      store.close()
+    }
+  })
+})
+
+function createFixture(): { agentDir: string; store: VectorStore } {
+  const agentDir = join(tmpdir(), `typeclaw-hybrid-${randomUUID()}`)
+  testDirs.push(agentDir)
+  mkdirSync(join(agentDir, 'memory', 'topics'), { recursive: true })
+  const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+  return { agentDir, store }
+}
+
+function writeTopic(agentDir: string, slug: string, heading: string, body: string): void {
+  writeFileSync(
+    join(agentDir, 'memory', 'topics', `${slug}.md`),
+    renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
+  )
+}
+
+function row(id: string, key: string, embedding: Float32Array): Omit<VectorRow, 'updatedAt'> {
+  return {
+    id,
+    source: 'topic',
+    key,
+    model: MODEL,
+    dims: embedding.length,
+    embedding,
+    contentHash: `hash:${id}`,
+  }
+}
+
+function embedFrom(values: Record<number, number>): EmbedFn {
+  return async () => [vector(values)]
+}
+
+function vector(values: Record<number, number>): Float32Array {
+  const result = new Float32Array(8)
+  for (const [index, value] of Object.entries(values)) {
+    result[Number(index)] = value
+  }
+  return result
+}

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -83,7 +83,7 @@ describe('hybridSearch', () => {
 })
 
 describe('buildLazyIndex', () => {
-  it('embeds topic shards as passages and skips rebuild when rows already exist', async () => {
+  it('embeds topic shards as passages and skips rebuild when rows are current', async () => {
     const { agentDir, store } = createFixture()
     let calls = 0
     try {
@@ -102,6 +102,37 @@ describe('buildLazyIndex', () => {
       expect(store.getAll().map((stored) => [stored.id, stored.source, stored.key, stored.dims])).toEqual([
         ['topic:lazy-topic', 'topic', 'lazy-topic', 8],
       ])
+    } finally {
+      store.close()
+    }
+  })
+
+  it('indexes missing topic shards even when append-time stream rows already exist', async () => {
+    const { agentDir, store } = createFixture()
+    let calls = 0
+    try {
+      writeTopic(agentDir, 'existing-topic', 'Existing Topic', 'This shard predates vector memory retrieval.')
+      store.upsert({
+        id: 'stream:2026-06-11#frag-1',
+        source: 'stream',
+        key: '2026-06-11#frag-1',
+        model: MODEL,
+        dims: 8,
+        embedding: vector({ 0: 1 }),
+        contentHash: 'append-time-stream-hash',
+      })
+
+      const embedFn: EmbedFn = async (texts, type) => {
+        calls += 1
+        expect(type).toBe('passage')
+        expect(texts).toEqual(['Existing Topic\nThis shard predates vector memory retrieval.'])
+        return [vector({ 5: 1 })]
+      }
+
+      await buildLazyIndex(store, agentDir, embedFn)
+
+      expect(calls).toBe(1)
+      expect(store.getAll().map((stored) => stored.id)).toEqual(['stream:2026-06-11#frag-1', 'topic:existing-topic'])
     } finally {
       store.close()
     }

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { renderShard } from '../frontmatter'
-import { hybridSearch, buildLazyIndex, type EmbedFn } from './hybrid'
+import { hybridSearch, type EmbedFn } from './hybrid'
 import { VectorStore, type VectorRow } from './store'
 
 const MODEL = 'test-model'
@@ -76,63 +76,6 @@ describe('hybridSearch', () => {
 
       expect(results.slice(0, 3).map((result) => result.key)).toContain('english-i18n')
       expect(results.find((result) => result.key === 'english-i18n')?.rrfScore).toBeCloseTo(1 / 61, 10)
-    } finally {
-      store.close()
-    }
-  })
-})
-
-describe('buildLazyIndex', () => {
-  it('embeds topic shards as passages and skips rebuild when rows are current', async () => {
-    const { agentDir, store } = createFixture()
-    let calls = 0
-    try {
-      writeTopic(agentDir, 'lazy-topic', 'Lazy Topic', 'This topic is indexed on first retrieval.')
-      const embedFn: EmbedFn = async (texts, type) => {
-        calls += 1
-        expect(type).toBe('passage')
-        expect(texts).toEqual(['Lazy Topic\nThis topic is indexed on first retrieval.'])
-        return [vector({ 4: 1 })]
-      }
-
-      await buildLazyIndex(store, agentDir, embedFn)
-      await buildLazyIndex(store, agentDir, embedFn)
-
-      expect(calls).toBe(1)
-      expect(store.getAll().map((stored) => [stored.id, stored.source, stored.key, stored.dims])).toEqual([
-        ['topic:lazy-topic', 'topic', 'lazy-topic', 8],
-      ])
-    } finally {
-      store.close()
-    }
-  })
-
-  it('indexes missing topic shards even when append-time stream rows already exist', async () => {
-    const { agentDir, store } = createFixture()
-    let calls = 0
-    try {
-      writeTopic(agentDir, 'existing-topic', 'Existing Topic', 'This shard predates vector memory retrieval.')
-      store.upsert({
-        id: 'stream:2026-06-11#frag-1',
-        source: 'stream',
-        key: '2026-06-11#frag-1',
-        model: MODEL,
-        dims: 8,
-        embedding: vector({ 0: 1 }),
-        contentHash: 'append-time-stream-hash',
-      })
-
-      const embedFn: EmbedFn = async (texts, type) => {
-        calls += 1
-        expect(type).toBe('passage')
-        expect(texts).toEqual(['Existing Topic\nThis shard predates vector memory retrieval.'])
-        return [vector({ 5: 1 })]
-      }
-
-      await buildLazyIndex(store, agentDir, embedFn)
-
-      expect(calls).toBe(1)
-      expect(store.getAll().map((stored) => stored.id)).toEqual(['stream:2026-06-11#frag-1', 'topic:existing-topic'])
     } finally {
       store.close()
     }

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 
+import { fragmentContentHash } from '../fragment-parser'
 import { loadAllShards, type TopicShard } from '../load-shards'
 import { buildMatcher, searchAll, type MemorySearchMatch, type StreamMatch } from '../search-tool'
 import type { StreamEvent } from '../stream-events'
@@ -50,7 +51,7 @@ export function findMissingPassages(store: VectorStore, passages: Passage[]): Pa
   const existing = new Map(store.getAll().map((row) => [row.id, row]))
   return passages.filter((passage) => {
     const row = existing.get(passage.id)
-    return row === undefined || row.model !== MODEL_NAME || row.contentHash !== hashContent(passage.text)
+    return row === undefined || row.model !== MODEL_NAME || row.contentHash !== passage.contentHash
   })
 }
 
@@ -136,6 +137,7 @@ function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): 
         source: 'topic',
         key: shard.slug,
         text: `${shard.frontmatter.heading}\n${shard.body}`,
+        contentHash: fragmentContentHash({ topic: shard.frontmatter.heading, body: shard.body }),
       }),
     ),
     ...streamDays.flatMap((day) =>
@@ -143,10 +145,18 @@ function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): 
         if (event.type === 'watermark') return []
         if (event.type === 'fragment') {
           const key = `${day.date}#${event.id}`
-          return [{ id: `stream:${key}`, source: 'stream', key, text: `${event.topic}\n${event.body}` }]
+          return [
+            {
+              id: `stream:${key}`,
+              source: 'stream',
+              key,
+              text: `${event.topic}\n${event.body}`,
+              contentHash: fragmentContentHash(event),
+            },
+          ]
         }
         const key = `${day.date}#legacy-${hashContent(event.text).slice(0, 12)}`
-        return [{ id: `stream:${key}`, source: 'stream', key, text: event.text }]
+        return [{ id: `stream:${key}`, source: 'stream', key, text: event.text, contentHash: hashContent(event.text) }]
       }),
     ),
   ]
@@ -199,4 +209,5 @@ export type Passage = {
   source: 'topic' | 'stream'
   key: string
   text: string
+  contentHash: string
 }

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -1,7 +1,5 @@
 import { createHash } from 'node:crypto'
 
-import { withGitLock } from '@/git/mutex'
-
 import { loadAllShards, type TopicShard } from '../load-shards'
 import { buildMatcher, searchAll, type MemorySearchMatch, type StreamMatch } from '../search-tool'
 import type { StreamEvent } from '../stream-events'
@@ -43,41 +41,12 @@ export async function hybridSearch(
   return fuseLanes(vectorRows, keywordMatches, index).slice(0, topK)
 }
 
-export async function buildLazyIndex(store: VectorStore, agentDir: string, embedFn: EmbedFn = embed): Promise<void> {
-  if (findMissingPassages(store, await collectPassages(agentDir)).length === 0) return
-
-  await withGitLock(agentDir, async () => {
-    const passages = findMissingPassages(store, await collectPassages(agentDir))
-    if (passages.length === 0) return
-
-    const embeddings = await embedFn(
-      passages.map((passage) => passage.text),
-      'passage',
-    )
-
-    for (let i = 0; i < passages.length; i++) {
-      const passage = passages[i]!
-      const embedding = embeddings[i]
-      if (embedding === undefined) continue
-      store.upsert({
-        id: passage.id,
-        source: passage.source,
-        key: passage.key,
-        model: MODEL_NAME,
-        dims: embedding.length,
-        embedding,
-        contentHash: hashContent(passage.text),
-      })
-    }
-  })
-}
-
-async function collectPassages(agentDir: string): Promise<Passage[]> {
+export async function collectPassages(agentDir: string): Promise<Passage[]> {
   const [shards, streamDays] = await Promise.all([loadAllShards(agentDir), readAllUndreamedStreamDays(agentDir)])
   return buildPassages(shards, streamDays)
 }
 
-function findMissingPassages(store: VectorStore, passages: Passage[]): Passage[] {
+export function findMissingPassages(store: VectorStore, passages: Passage[]): Passage[] {
   const existing = new Map(store.getAll().map((row) => [row.id, row]))
   return passages.filter((passage) => {
     const row = existing.get(passage.id)
@@ -225,7 +194,7 @@ function hashContent(content: string): string {
   return createHash('sha256').update(content).digest('hex')
 }
 
-type Passage = {
+export type Passage = {
   id: string
   source: 'topic' | 'stream'
   key: string

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -44,13 +44,12 @@ export async function hybridSearch(
 }
 
 export async function buildLazyIndex(store: VectorStore, agentDir: string, embedFn: EmbedFn = embed): Promise<void> {
-  if (store.getAll().length > 0) return
+  if (findMissingPassages(store, await collectPassages(agentDir)).length === 0) return
 
   await withGitLock(agentDir, async () => {
-    if (store.getAll().length > 0) return
+    const passages = findMissingPassages(store, await collectPassages(agentDir))
+    if (passages.length === 0) return
 
-    const [shards, streamDays] = await Promise.all([loadAllShards(agentDir), readAllUndreamedStreamDays(agentDir)])
-    const passages = buildPassages(shards, streamDays)
     const embeddings = await embedFn(
       passages.map((passage) => passage.text),
       'passage',
@@ -70,6 +69,19 @@ export async function buildLazyIndex(store: VectorStore, agentDir: string, embed
         contentHash: hashContent(passage.text),
       })
     }
+  })
+}
+
+async function collectPassages(agentDir: string): Promise<Passage[]> {
+  const [shards, streamDays] = await Promise.all([loadAllShards(agentDir), readAllUndreamedStreamDays(agentDir)])
+  return buildPassages(shards, streamDays)
+}
+
+function findMissingPassages(store: VectorStore, passages: Passage[]): Passage[] {
+  const existing = new Map(store.getAll().map((row) => [row.id, row]))
+  return passages.filter((passage) => {
+    const row = existing.get(passage.id)
+    return row === undefined || row.model !== MODEL_NAME || row.contentHash !== hashContent(passage.text)
   })
 }
 

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -1,0 +1,221 @@
+import { createHash } from 'node:crypto'
+
+import { withGitLock } from '@/git/mutex'
+
+import { loadAllShards, type TopicShard } from '../load-shards'
+import { buildMatcher, searchAll, type MemorySearchMatch, type StreamMatch } from '../search-tool'
+import type { StreamEvent } from '../stream-events'
+import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
+import { embed, MODEL_NAME, type EmbedType } from './embedder'
+import { VectorStore, type VectorRow } from './store'
+
+const RRF_K = 60
+
+export type HybridSearchResult = {
+  source: 'topic' | 'stream'
+  key: string
+  heading: string
+  excerpt: string
+  rrfScore: number
+}
+
+export type EmbedFn = (texts: string[], type: EmbedType) => Promise<Float32Array[]>
+
+export async function hybridSearch(
+  query: string,
+  store: VectorStore,
+  agentDir: string,
+  topK: number,
+  embedFn: EmbedFn = embed,
+): Promise<HybridSearchResult[]> {
+  if (topK <= 0) return []
+
+  const [shards, streamDays, queryEmbeddings] = await Promise.all([
+    loadAllShards(agentDir),
+    readAllUndreamedStreamDays(agentDir),
+    embedFn([query], 'query'),
+  ])
+
+  const index = buildContentIndex(shards, streamDays)
+  const vectorRows = queryEmbeddings[0] === undefined ? [] : store.query(queryEmbeddings[0], topK * 2)
+  const keywordMatches = keywordLane(query, shards, streamDays, topK * 2)
+
+  return fuseLanes(vectorRows, keywordMatches, index).slice(0, topK)
+}
+
+export async function buildLazyIndex(store: VectorStore, agentDir: string, embedFn: EmbedFn = embed): Promise<void> {
+  if (store.getAll().length > 0) return
+
+  await withGitLock(agentDir, async () => {
+    if (store.getAll().length > 0) return
+
+    const [shards, streamDays] = await Promise.all([loadAllShards(agentDir), readAllUndreamedStreamDays(agentDir)])
+    const passages = buildPassages(shards, streamDays)
+    const embeddings = await embedFn(
+      passages.map((passage) => passage.text),
+      'passage',
+    )
+
+    for (let i = 0; i < passages.length; i++) {
+      const passage = passages[i]!
+      const embedding = embeddings[i]
+      if (embedding === undefined) continue
+      store.upsert({
+        id: passage.id,
+        source: passage.source,
+        key: passage.key,
+        model: MODEL_NAME,
+        dims: embedding.length,
+        embedding,
+        contentHash: hashContent(passage.text),
+      })
+    }
+  })
+}
+
+function keywordLane(
+  query: string,
+  shards: TopicShard[],
+  streamDays: UndreamedStreamDay[],
+  maxResults: number,
+): MemorySearchMatch[] {
+  const matcher = buildMatcher(query, false)
+  if (typeof matcher === 'string') return []
+  const result = searchAll(shards, streamDays, matcher, { full: false, maxResults })
+  return 'matches' in result ? result.matches : []
+}
+
+function fuseLanes(
+  vectorRows: VectorRow[],
+  keywordMatches: MemorySearchMatch[],
+  index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
+): HybridSearchResult[] {
+  const fused = new Map<string, HybridSearchResult>()
+
+  for (let i = 0; i < vectorRows.length; i++) {
+    const row = vectorRows[i]!
+    addScore(fused, index, laneKey(row.source, row.key), 1 / (RRF_K + i + 1))
+  }
+
+  for (let i = 0; i < keywordMatches.length; i++) {
+    const match = keywordMatches[i]!
+    addScore(fused, index, laneKey(match.source, matchKey(match)), 1 / (RRF_K + i + 1))
+  }
+
+  return [...fused.values()].sort((a, b) => b.rrfScore - a.rrfScore || a.key.localeCompare(b.key))
+}
+
+function addScore(
+  fused: Map<string, HybridSearchResult>,
+  index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
+  key: string,
+  score: number,
+): void {
+  const existing = fused.get(key)
+  if (existing !== undefined) {
+    existing.rrfScore += score
+    return
+  }
+
+  const content = index.get(key)
+  if (content === undefined) return
+  fused.set(key, { ...content, rrfScore: score })
+}
+
+function buildContentIndex(
+  shards: TopicShard[],
+  streamDays: UndreamedStreamDay[],
+): Map<string, Omit<HybridSearchResult, 'rrfScore'>> {
+  const index = new Map<string, Omit<HybridSearchResult, 'rrfScore'>>()
+
+  for (const shard of shards) {
+    index.set(laneKey('topic', shard.slug), {
+      source: 'topic',
+      key: shard.slug,
+      heading: shard.frontmatter.heading,
+      excerpt: excerpt(shard.body, shard.frontmatter.heading),
+    })
+  }
+
+  for (const day of streamDays) {
+    for (const event of day.events) {
+      const item = streamIndexItem(day, event)
+      if (item !== null) index.set(laneKey('stream', item.key), item)
+    }
+  }
+
+  return index
+}
+
+function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): Passage[] {
+  return [
+    ...shards.map(
+      (shard): Passage => ({
+        id: `topic:${shard.slug}`,
+        source: 'topic',
+        key: shard.slug,
+        text: `${shard.frontmatter.heading}\n${shard.body}`,
+      }),
+    ),
+    ...streamDays.flatMap((day) =>
+      day.events.flatMap((event): Passage[] => {
+        if (event.type === 'watermark') return []
+        if (event.type === 'fragment') {
+          const key = `${day.date}#${event.id}`
+          return [{ id: `stream:${key}`, source: 'stream', key, text: `${event.topic}\n${event.body}` }]
+        }
+        const key = `${day.date}#legacy-${hashContent(event.text).slice(0, 12)}`
+        return [{ id: `stream:${key}`, source: 'stream', key, text: event.text }]
+      }),
+    ),
+  ]
+}
+
+function streamIndexItem(day: UndreamedStreamDay, event: StreamEvent): Omit<HybridSearchResult, 'rrfScore'> | null {
+  if (event.type === 'watermark') return null
+  if (event.type === 'fragment') {
+    return {
+      source: 'stream',
+      key: `${day.date}#${event.id}`,
+      heading: event.topic,
+      excerpt: excerpt(event.body, event.topic),
+    }
+  }
+  return {
+    source: 'stream',
+    key: `${day.date}#legacy-${hashContent(event.text).slice(0, 12)}`,
+    heading: '[legacy prose from pre-shard migration]',
+    excerpt: excerpt(event.text, '[legacy prose from pre-shard migration]'),
+  }
+}
+
+function matchKey(match: MemorySearchMatch): string {
+  if (match.source === 'topic') return match.slug
+  return streamMatchKey(match)
+}
+
+function streamMatchKey(match: StreamMatch): string {
+  if (match.eventId !== undefined) return match.eventId.replace(/^streams\//, '')
+  return `${match.date}#legacy-${hashContent(match.excerpt).slice(0, 12)}`
+}
+
+function laneKey(source: 'topic' | 'stream', key: string): string {
+  return `${source}:${key}`
+}
+
+function excerpt(body: string, fallback: string): string {
+  const trimmed = body.trim()
+  if (trimmed.length === 0) return fallback
+  return trimmed.split('\n').slice(0, 7).join('\n')
+}
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+type Passage = {
+  id: string
+  source: 'topic' | 'stream'
+  key: string
+  text: string
+}

--- a/src/bundled-plugins/memory/vector/startup.test.ts
+++ b/src/bundled-plugins/memory/vector/startup.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { randomUUID } from 'node:crypto'
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { syncTopicVectorsFromSnapshotDiff } from '../dreaming'
 import { renderShard } from '../frontmatter'
+import { streamFilePath } from '../paths'
+import type { FragmentEvent } from '../stream-events'
+import { appendEvents } from '../stream-io'
 import type { EmbedFn } from './hybrid'
+import { makeAppendHook } from './index-on-write'
 import { buildStartupVectorIndex } from './startup'
 import { VectorStore } from './store'
 
@@ -62,6 +67,41 @@ describe('buildStartupVectorIndex', () => {
     expect(calls).toBe(1)
   })
 
+  it('does not re-embed passages already indexed by append and dream writers on restart', async () => {
+    const agentDir = createAgentDir()
+    mkdirSync(join(agentDir, 'memory', 'streams'), { recursive: true })
+    const embeddedTexts: string[] = []
+    const embedFn: EmbedFn = async (texts, type) => {
+      expect(type).toBe('passage')
+      embeddedTexts.push(...texts)
+      return texts.map((_, index) => vector({ [index]: 1 }))
+    }
+    const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+    try {
+      await appendEvents(
+        streamFilePath(agentDir, '2026-06-11'),
+        [fragmentEvent('append-frag', 'Append Topic', 'Append body.')],
+        makeAppendHook(store, embedFn),
+      )
+    } finally {
+      store.close()
+    }
+    writeTopic(agentDir, 'dream-topic', 'Dream Topic', 'Dreamed body.')
+    const dreamTopicPath = join(agentDir, 'memory', 'topics', 'dream-topic.md')
+    await syncTopicVectorsFromSnapshotDiff(
+      agentDir,
+      new Map(),
+      new Map([[dreamTopicPath, readFileSync(dreamTopicPath)]]),
+      embedFn,
+    )
+    embeddedTexts.length = 0
+
+    const result = await buildStartupVectorIndex(agentDir, embedFn)
+
+    expect(result).toEqual({ built: false, count: 0 })
+    expect(embeddedTexts).toEqual([])
+  })
+
   it('embeds only missing passages when the startup index is partial', async () => {
     const agentDir = createAgentDir()
     writeTopic(agentDir, 'current-topic', 'Current Topic', 'Already indexed content.')
@@ -106,6 +146,18 @@ function writeFragment(agentDir: string, date: string, id: string, topic: string
     join(agentDir, 'memory', 'streams', `${date}.jsonl`),
     `${JSON.stringify({ type: 'fragment', id, ts: '2026-06-11T00:00:00.000Z', source: 'test', entry: 'test', topic, body })}\n`,
   )
+}
+
+function fragmentEvent(id: string, topic: string, body: string): FragmentEvent {
+  return {
+    type: 'fragment',
+    id,
+    ts: '2026-06-11T00:00:00.000Z',
+    source: 'test',
+    entry: 'test',
+    topic,
+    body,
+  }
 }
 
 function vector(values: Record<number, number>): Float32Array {

--- a/src/bundled-plugins/memory/vector/startup.test.ts
+++ b/src/bundled-plugins/memory/vector/startup.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { renderShard } from '../frontmatter'
+import type { EmbedFn } from './hybrid'
+import { buildStartupVectorIndex } from './startup'
+import { VectorStore } from './store'
+
+const testDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('buildStartupVectorIndex', () => {
+  it('builds an empty vector index with all topic and stream passages', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'startup-topic', 'Startup Topic', 'This topic is pre-warmed at boot.')
+    writeFragment(agentDir, '2026-06-11', 'frag-1', 'Recent Stream', 'This stream fragment is also indexed.')
+    const embeddedTexts: string[] = []
+
+    const result = await buildStartupVectorIndex(agentDir, async (texts, type) => {
+      expect(type).toBe('passage')
+      embeddedTexts.push(...texts)
+      return texts.map((_, index) => vector({ [index]: 1 }))
+    })
+
+    const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+    try {
+      expect(result).toEqual({ built: true, count: 2 })
+      expect(embeddedTexts).toEqual([
+        'Startup Topic\nThis topic is pre-warmed at boot.',
+        'Recent Stream\nThis stream fragment is also indexed.',
+      ])
+      expect(store.getAll().map((stored) => [stored.id, stored.source, stored.key, stored.dims])).toEqual([
+        ['stream:2026-06-11#frag-1', 'stream', '2026-06-11#frag-1', 8],
+        ['topic:startup-topic', 'topic', 'startup-topic', 8],
+      ])
+    } finally {
+      store.close()
+    }
+  })
+
+  it('no-ops when the startup index is already current', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'current-topic', 'Current Topic', 'Already indexed content.')
+    let calls = 0
+    const embedFn: EmbedFn = async (texts) => {
+      calls += 1
+      return texts.map(() => vector({ 0: 1 }))
+    }
+
+    await buildStartupVectorIndex(agentDir, embedFn)
+    const result = await buildStartupVectorIndex(agentDir, embedFn)
+
+    expect(result).toEqual({ built: false, count: 0 })
+    expect(calls).toBe(1)
+  })
+
+  it('embeds only missing passages when the startup index is partial', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'current-topic', 'Current Topic', 'Already indexed content.')
+    await buildStartupVectorIndex(agentDir, async (texts) => texts.map(() => vector({ 0: 1 })))
+    writeTopic(agentDir, 'missing-topic', 'Missing Topic', 'New content needs a vector.')
+    const embeddedTexts: string[] = []
+
+    const result = await buildStartupVectorIndex(agentDir, async (texts, type) => {
+      expect(type).toBe('passage')
+      embeddedTexts.push(...texts)
+      return texts.map(() => vector({ 1: 1 }))
+    })
+
+    const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+    try {
+      expect(result).toEqual({ built: true, count: 1 })
+      expect(embeddedTexts).toEqual(['Missing Topic\nNew content needs a vector.'])
+      expect(store.getAll().map((stored) => stored.id)).toEqual(['topic:current-topic', 'topic:missing-topic'])
+    } finally {
+      store.close()
+    }
+  })
+})
+
+function createAgentDir(): string {
+  const agentDir = join(tmpdir(), `typeclaw-startup-vector-${randomUUID()}`)
+  testDirs.push(agentDir)
+  mkdirSync(join(agentDir, 'memory', 'topics'), { recursive: true })
+  return agentDir
+}
+
+function writeTopic(agentDir: string, slug: string, heading: string, body: string): void {
+  writeFileSync(
+    join(agentDir, 'memory', 'topics', `${slug}.md`),
+    renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
+  )
+}
+
+function writeFragment(agentDir: string, date: string, id: string, topic: string, body: string): void {
+  mkdirSync(join(agentDir, 'memory', 'streams'), { recursive: true })
+  writeFileSync(
+    join(agentDir, 'memory', 'streams', `${date}.jsonl`),
+    `${JSON.stringify({ type: 'fragment', id, ts: '2026-06-11T00:00:00.000Z', source: 'test', entry: 'test', topic, body })}\n`,
+  )
+}
+
+function vector(values: Record<number, number>): Float32Array {
+  const result = new Float32Array(8)
+  for (const [index, value] of Object.entries(values)) {
+    result[Number(index)] = value
+  }
+  return result
+}

--- a/src/bundled-plugins/memory/vector/startup.test.ts
+++ b/src/bundled-plugins/memory/vector/startup.test.ts
@@ -1,16 +1,11 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { randomUUID } from 'node:crypto'
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { syncTopicVectorsFromSnapshotDiff } from '../dreaming'
 import { renderShard } from '../frontmatter'
-import { streamFilePath } from '../paths'
-import type { FragmentEvent } from '../stream-events'
-import { appendEvents } from '../stream-io'
 import type { EmbedFn } from './hybrid'
-import { makeAppendHook } from './index-on-write'
 import { buildStartupVectorIndex } from './startup'
 import { VectorStore } from './store'
 
@@ -67,41 +62,6 @@ describe('buildStartupVectorIndex', () => {
     expect(calls).toBe(1)
   })
 
-  it('does not re-embed passages already indexed by append and dream writers on restart', async () => {
-    const agentDir = createAgentDir()
-    mkdirSync(join(agentDir, 'memory', 'streams'), { recursive: true })
-    const embeddedTexts: string[] = []
-    const embedFn: EmbedFn = async (texts, type) => {
-      expect(type).toBe('passage')
-      embeddedTexts.push(...texts)
-      return texts.map((_, index) => vector({ [index]: 1 }))
-    }
-    const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
-    try {
-      await appendEvents(
-        streamFilePath(agentDir, '2026-06-11'),
-        [fragmentEvent('append-frag', 'Append Topic', 'Append body.')],
-        makeAppendHook(store, embedFn),
-      )
-    } finally {
-      store.close()
-    }
-    writeTopic(agentDir, 'dream-topic', 'Dream Topic', 'Dreamed body.')
-    const dreamTopicPath = join(agentDir, 'memory', 'topics', 'dream-topic.md')
-    await syncTopicVectorsFromSnapshotDiff(
-      agentDir,
-      new Map(),
-      new Map([[dreamTopicPath, readFileSync(dreamTopicPath)]]),
-      embedFn,
-    )
-    embeddedTexts.length = 0
-
-    const result = await buildStartupVectorIndex(agentDir, embedFn)
-
-    expect(result).toEqual({ built: false, count: 0 })
-    expect(embeddedTexts).toEqual([])
-  })
-
   it('embeds only missing passages when the startup index is partial', async () => {
     const agentDir = createAgentDir()
     writeTopic(agentDir, 'current-topic', 'Current Topic', 'Already indexed content.')
@@ -146,18 +106,6 @@ function writeFragment(agentDir: string, date: string, id: string, topic: string
     join(agentDir, 'memory', 'streams', `${date}.jsonl`),
     `${JSON.stringify({ type: 'fragment', id, ts: '2026-06-11T00:00:00.000Z', source: 'test', entry: 'test', topic, body })}\n`,
   )
-}
-
-function fragmentEvent(id: string, topic: string, body: string): FragmentEvent {
-  return {
-    type: 'fragment',
-    id,
-    ts: '2026-06-11T00:00:00.000Z',
-    source: 'test',
-    entry: 'test',
-    topic,
-    body,
-  }
 }
 
 function vector(values: Record<number, number>): Float32Array {

--- a/src/bundled-plugins/memory/vector/startup.ts
+++ b/src/bundled-plugins/memory/vector/startup.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto'
 import { join } from 'node:path'
 
 import { MODEL_NAME, embed } from './embedder'
@@ -32,7 +31,7 @@ export async function buildStartupVectorIndex(
         model: MODEL_NAME,
         dims: embedding.length,
         embedding,
-        contentHash: hashContent(passage.text),
+        contentHash: passage.contentHash,
       })
       count += 1
     }
@@ -41,8 +40,4 @@ export async function buildStartupVectorIndex(
   } finally {
     store.close()
   }
-}
-
-function hashContent(content: string): string {
-  return createHash('sha256').update(content).digest('hex')
 }

--- a/src/bundled-plugins/memory/vector/startup.ts
+++ b/src/bundled-plugins/memory/vector/startup.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto'
+import { join } from 'node:path'
+
+import { MODEL_NAME, embed } from './embedder'
+import { collectPassages, findMissingPassages, type EmbedFn } from './hybrid'
+import { VectorStore } from './store'
+
+export async function buildStartupVectorIndex(
+  agentDir: string,
+  embedFn: EmbedFn = embed,
+): Promise<{ built: boolean; count: number }> {
+  const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+  try {
+    const passages = findMissingPassages(store, await collectPassages(agentDir))
+    if (passages.length === 0) return { built: false, count: 0 }
+
+    const embeddings = await embedFn(
+      passages.map((passage) => passage.text),
+      'passage',
+    )
+
+    let count = 0
+    for (let i = 0; i < passages.length; i++) {
+      const passage = passages[i]!
+      const embedding = embeddings[i]
+      if (embedding === undefined) continue
+
+      store.upsert({
+        id: passage.id,
+        source: passage.source,
+        key: passage.key,
+        model: MODEL_NAME,
+        dims: embedding.length,
+        embedding,
+        contentHash: hashContent(passage.text),
+      })
+      count += 1
+    }
+
+    return count === 0 ? { built: false, count: 0 } : { built: true, count }
+  } finally {
+    store.close()
+  }
+}
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}

--- a/src/bundled-plugins/memory/vector/store.test.ts
+++ b/src/bundled-plugins/memory/vector/store.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { withGitLock } from '@/git/mutex'
+
+import { VectorStore, type VectorRow } from './store'
+
+const MODEL = 'Xenova/multilingual-e5-base'
+const testDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('VectorStore', () => {
+  it('QA 1.4: stores 768-dim model-stamped rows and returns semantic top-1', () => {
+    const store = openTestStore()
+    try {
+      store.upsert(row('topic:a', embedding(768, { 0: 0.99, 1: 1.01 })))
+      store.upsert(row('topic:b', embedding(768, { 0: -1, 1: -1 })))
+      store.upsert(row('stream:c', embedding(768, { 2: 1 })))
+
+      const results = store.query(embedding(768, { 0: 1, 1: 1 }), 1)
+
+      expect(results).toHaveLength(1)
+      expect(results[0]?.id).toBe('topic:a')
+      expect(results[0]?.dims).toBe(768)
+      expect(results[0]?.model).toBe(MODEL)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('QA 1.5: skips mismatched dimensions without attempting cross-dim cosine', () => {
+    const store = openTestStore()
+    try {
+      store.upsert(row('topic:a', embedding(768, { 0: 1 })))
+      store.upsert(row('topic:b', embedding(768, { 1: 1 })))
+
+      expect(() => store.query(embedding(384, { 0: 1 }), 10)).not.toThrow()
+      expect(store.query(embedding(384, { 0: 1 }), 10)).toEqual([])
+    } finally {
+      store.close()
+    }
+  })
+
+  it('QA 1.13: concurrent lazy index builds share a withGitLock-guarded build', async () => {
+    const store = openTestStore()
+    const agentDir = join(tmpdir(), `typeclaw-vector-agent-${randomUUID()}`)
+    const buildStarted = deferred<void>()
+    const buildCanFinish = deferred<void>()
+    let buildCalls = 0
+    let secondFinished = false
+
+    try {
+      const first = buildIndexIfNeeded(agentDir, store, async () => {
+        buildCalls += 1
+        buildStarted.resolve()
+        await buildCanFinish.promise
+        return [row('topic:a', embedding(768, { 0: 1 }))]
+      })
+      await buildStarted.promise
+
+      const second = buildIndexIfNeeded(agentDir, store, async () => {
+        buildCalls += 1
+        return [row('topic:b', embedding(768, { 1: 1 }))]
+      }).then(() => {
+        secondFinished = true
+      })
+      await Promise.resolve()
+
+      expect(buildCalls).toBe(1)
+      expect(secondFinished).toBe(false)
+
+      buildCanFinish.resolve()
+      await Promise.all([first, second])
+
+      expect(buildCalls).toBe(1)
+      expect(store.getAll().map((stored) => stored.id)).toEqual(['topic:a'])
+      expect(secondFinished).toBe(true)
+    } finally {
+      store.close()
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+})
+
+async function buildIndexIfNeeded(
+  agentDir: string,
+  store: VectorStore,
+  build: () => Promise<Array<Omit<VectorRow, 'updatedAt'>>>,
+): Promise<void> {
+  if (store.getAll().length > 0) return
+
+  await withGitLock(agentDir, async () => {
+    if (store.getAll().length > 0) return
+    for (const row of await build()) {
+      store.upsert(row)
+    }
+  })
+}
+
+function openTestStore(): VectorStore {
+  const dir = join(tmpdir(), `typeclaw-vector-store-${randomUUID()}`)
+  testDirs.push(dir)
+  return VectorStore.open(join(dir, 'index.db'))
+}
+
+function row(id: string, value: Float32Array): Omit<VectorRow, 'updatedAt'> {
+  return {
+    id,
+    source: id.startsWith('stream:') ? 'stream' : 'topic',
+    key: id,
+    model: MODEL,
+    dims: value.length,
+    embedding: value,
+    contentHash: `hash:${id}`,
+  }
+}
+
+function embedding(dims: number, values: Record<number, number>): Float32Array {
+  const result = new Float32Array(dims)
+  for (const [index, value] of Object.entries(values)) {
+    result[Number(index)] = value
+  }
+  return result
+}
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}

--- a/src/bundled-plugins/memory/vector/store.ts
+++ b/src/bundled-plugins/memory/vector/store.ts
@@ -1,0 +1,156 @@
+import { Database } from 'bun:sqlite'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+export type VectorRow = {
+  id: string
+  source: 'topic' | 'stream'
+  key: string
+  model: string
+  dims: number
+  embedding: Float32Array
+  contentHash: string
+  updatedAt: string
+}
+
+type StoredVectorRow = {
+  id: string
+  source: 'topic' | 'stream'
+  key: string
+  model: string
+  dims: number
+  embedding: Uint8Array
+  content_hash: string
+  updated_at: string
+}
+
+export class VectorStore {
+  static open(dbPath: string): VectorStore {
+    mkdirSync(dirname(dbPath), { recursive: true })
+    const db = new Database(dbPath)
+    db.run(`
+      CREATE TABLE IF NOT EXISTS vectors (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        key TEXT NOT NULL,
+        model TEXT NOT NULL,
+        dims INTEGER NOT NULL,
+        embedding BLOB NOT NULL,
+        content_hash TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `)
+    return new VectorStore(db)
+  }
+
+  private constructor(private readonly db: Database) {}
+
+  upsert(row: Omit<VectorRow, 'updatedAt'>): void {
+    const existing = this.db
+      .query<{ content_hash: string; model: string }, [string]>('SELECT content_hash, model FROM vectors WHERE id = ?')
+      .get(row.id)
+
+    if (existing?.content_hash === row.contentHash && existing.model === row.model) {
+      return
+    }
+
+    this.db
+      .query(
+        `INSERT INTO vectors (id, source, key, model, dims, embedding, content_hash, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           source = excluded.source,
+           key = excluded.key,
+           model = excluded.model,
+           dims = excluded.dims,
+           embedding = excluded.embedding,
+           content_hash = excluded.content_hash,
+           updated_at = excluded.updated_at`,
+      )
+      .run(
+        row.id,
+        row.source,
+        row.key,
+        row.model,
+        row.dims,
+        Buffer.from(row.embedding.buffer, row.embedding.byteOffset, row.embedding.byteLength),
+        row.contentHash,
+        new Date().toISOString(),
+      )
+  }
+
+  query(embedding: Float32Array, topK: number): VectorRow[] {
+    if (topK <= 0) return []
+
+    return this.getAll()
+      .filter((row) => row.dims === embedding.length)
+      .map((row) => ({ row, score: cosineSimilarity(embedding, row.embedding) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+      .map(({ row }) => row)
+  }
+
+  delete(id: string): void {
+    this.db.query('DELETE FROM vectors WHERE id = ?').run(id)
+  }
+
+  deleteMany(ids: string[]): void {
+    const statement = this.db.query('DELETE FROM vectors WHERE id = ?')
+    const remove = this.db.transaction((values: string[]) => {
+      for (const id of values) statement.run(id)
+    })
+    remove(ids)
+  }
+
+  getAll(): VectorRow[] {
+    return this.db.query<StoredVectorRow, []>('SELECT * FROM vectors ORDER BY id').all().map(toVectorRow)
+  }
+
+  getByIds(ids: string[]): VectorRow[] {
+    const statement = this.db.query<StoredVectorRow, [string]>('SELECT * FROM vectors WHERE id = ?')
+    return ids.flatMap((id) => {
+      const row = statement.get(id)
+      return row ? [toVectorRow(row)] : []
+    })
+  }
+
+  close(): void {
+    this.db.close()
+  }
+}
+
+function toVectorRow(row: StoredVectorRow): VectorRow {
+  return {
+    id: row.id,
+    source: row.source,
+    key: row.key,
+    model: row.model,
+    dims: row.dims,
+    embedding: blobToFloat32Array(row.embedding),
+    contentHash: row.content_hash,
+    updatedAt: row.updated_at,
+  }
+}
+
+function blobToFloat32Array(blob: Uint8Array): Float32Array {
+  const bytes = Buffer.from(blob)
+  const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+  return new Float32Array(buffer)
+}
+
+function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  let dot = 0
+  let aMagnitude = 0
+  let bMagnitude = 0
+
+  for (let i = 0; i < a.length; i++) {
+    const aValue = a[i] ?? 0
+    const bValue = b[i] ?? 0
+    dot += aValue * bValue
+    aMagnitude += aValue * aValue
+    bMagnitude += bValue * bValue
+  }
+
+  if (aMagnitude === 0 || bMagnitude === 0) return 0
+  return dot / (Math.sqrt(aMagnitude) * Math.sqrt(bMagnitude))
+}

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1917,18 +1917,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
-  const fireSessionTurnStart = async (live: LiveSession, userPrompt: string): Promise<void> => {
-    if (!live.hooks) return
+  const fireSessionTurnStart = async (live: LiveSession, userPrompt: string): Promise<{ results: string }> => {
+    const retrievalContext = { results: '' }
+    if (!live.hooks) return retrievalContext
     try {
       await live.hooks.runSessionTurnStart({
         sessionId: live.sessionId,
         agentDir: options.agentDir,
         userPrompt,
         origin: buildLiveOrigin(live),
+        retrievalContext,
       })
     } catch (err) {
       logger.warn(`[channels] session.turn.start hook threw for ${live.keyId}: ${describe(err)}`)
     }
+    return retrievalContext
   }
 
   const fireSessionTurnEnd = async (live: LiveSession): Promise<void> => {
@@ -2149,9 +2152,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.policyDeniedToolSendsThisTurn.clear()
         resetReviewTurn(live.sessionId)
         const isRealUserTurn = batch.length > 0
-        await fireSessionTurnStart(live, text)
+        const retrievalContext = await fireSessionTurnStart(live, text)
+        const promptText = retrievalContext.results.length > 0 ? `${text}\n\n${retrievalContext.results}` : text
         try {
-          await live.session.prompt(text)
+          await live.session.prompt(promptText)
           await validateChannelTurn(live, successfulSendsBeforePrompt)
           live.consecutiveAborts = 0
           logger.info(`[channels] ${live.keyId} prompted elapsed_ms=${now() - promptStart}`)

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -165,6 +165,8 @@ function formatLog(event: DaemonLogEvent | SupervisorLogEvent): string {
       return `[hostd] HTTP control listening on ${event.host}:${event.port}`
     case 'daemon-http-port-fallback':
       return `[hostd] HTTP preferred port ${event.preferred} busy; fell back to ${event.actual} (containers started on ${event.preferred} will see stale TYPECLAW_HOSTD_URL until restarted)`
+    case 'daemon-model-provision-warning':
+      return `[hostd] warning: model provisioning failed: ${event.reason}`
     case 'daemon-stopping':
       return `[hostd] stopping`
     case 'shutdown-requested':

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -314,7 +314,7 @@ describe('planStart', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    const mirrorMounts = plan.runArgs.filter((a) => a.endsWith(':ro'))
+    const mirrorMounts = plan.runArgs.filter((a) => a.endsWith(':ro') && !a.includes('/opt/models'))
     expect(mirrorMounts).toHaveLength(0)
   })
 
@@ -324,7 +324,7 @@ describe('planStart', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs.filter((a) => a.endsWith(':ro'))).toHaveLength(0)
+    expect(plan.runArgs.filter((a) => a.endsWith(':ro') && !a.includes('/opt/models'))).toHaveLength(0)
   })
 
   test('reports needsBuild based on imageExists input', async () => {
@@ -490,6 +490,40 @@ describe('planStart mounts', () => {
     await writeTypeclawConfig(root, { mounts: [{ name: 'BadName', path: '/x' }] })
 
     await expect(planStart({ cwd: root, hostPort: 8973, imageExists: true })).rejects.toThrow()
+  })
+})
+
+describe('planStart model mount', () => {
+  test('adds shared model cache mount at /opt/models:ro', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+
+    const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+    expect(plan.runArgs).toContain('-v')
+    expect(plan.runArgs).toContain(`${process.env.HOME}/.typeclaw/models:/opt/models:ro`)
+  })
+
+  test('sets TYPECLAW_MODEL_CACHE env var to /opt/models', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+
+    const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+    expect(plan.runArgs).toContain('-e')
+    expect(plan.runArgs).toContain('TYPECLAW_MODEL_CACHE=/opt/models')
+  })
+
+  test('model mount appears before imageTag (last positional arg)', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+
+    const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+    expect(plan.runArgs.at(-1)).toBe(plan.imageTag)
+    const mountIdx = plan.runArgs.indexOf(`${process.env.HOME}/.typeclaw/models:/opt/models:ro`)
+    expect(mountIdx).toBeGreaterThan(-1)
+    expect(mountIdx).toBeLessThan(plan.runArgs.length - 1)
   })
 })
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -7,6 +7,7 @@ import { expandMountPath, loadConfigSync, withDefaultPlugins, type Config } from
 import { commitGitignoreWithUntracks, untrackTrulyIgnoredFiles } from '@/git/reconcile-ignored'
 import { commitSystemFile as commitSystemFileShared } from '@/git/system-commit'
 import { send as sendToDaemon } from '@/hostd/client'
+import { homeRoot } from '@/hostd/paths'
 import type { HttpInfoResult } from '@/hostd/protocol'
 import { ensureDaemon } from '@/hostd/spawn'
 import {
@@ -622,6 +623,10 @@ export async function planStart({
     const target = `${MOUNT_TARGET_PREFIX}/${mount.name}`
     runArgs.push('-v', mount.readOnly ? `${hostPath}:${target}:ro` : `${hostPath}:${target}`)
   }
+
+  // Shared model cache mount for embeddings and other ML models
+  runArgs.push('-v', `${homeRoot()}/models:/opt/models:ro`)
+  runArgs.push('-e', 'TYPECLAW_MODEL_CACHE=/opt/models')
 
   runArgs.push(imageTag)
 

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -61,6 +61,7 @@ export type DaemonOptions = {
   // deregister. Omit to disable in tests / when the agent has no kakaotalk
   // channel configured.
   kakaoRenewal?: KakaoRenewalCallbacks
+  provisionModels?: boolean
 }
 
 export type RestartPreflight = (input: {
@@ -224,9 +225,11 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
 
   const log = opts.onLog ?? (() => {})
-  void ensureModels().catch((error: unknown) => {
-    log({ kind: 'daemon-model-provision-warning', reason: stringifyError(error) })
-  })
+  if (opts.provisionModels ?? process.env.NODE_ENV !== 'test') {
+    void ensureModels().catch((error: unknown) => {
+      log({ kind: 'daemon-model-provision-warning', reason: stringifyError(error) })
+    })
+  }
   const exec = opts.exec ?? defaultDockerExec
   const gcIntervalMs = opts.gcIntervalMs ?? DEFAULT_GC_INTERVAL_MS
   const gcMissesToDeregister = opts.gcMissesToDeregister ?? DEFAULT_GC_MISSES_TO_DEREGISTER

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -12,6 +12,7 @@ import { SecretsBackend } from '@/secrets/storage'
 
 import { isDaemonReachable } from './client'
 import type { KakaoRenewalCallbacks, KakaoRenewalLogEvent } from './kakao-renewal-manager'
+import { ensureModels } from './models'
 import { ensureDirs, registrationFilePath, registrationsDir, socketPath } from './paths'
 import type {
   HttpInfoResult,
@@ -94,6 +95,7 @@ export type DaemonLogEvent =
   | { kind: 'daemon-listening'; socket: string }
   | { kind: 'daemon-http-listening'; host: string; port: number }
   | { kind: 'daemon-http-port-fallback'; preferred: number; actual: number }
+  | { kind: 'daemon-model-provision-warning'; reason: string }
   | { kind: 'daemon-stopping' }
   | { kind: 'register'; containerName: string }
   | { kind: 'deregister'; containerName: string; reason: 'requested' | 'gone' }
@@ -222,6 +224,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
 
   const log = opts.onLog ?? (() => {})
+  void ensureModels().catch((error: unknown) => {
+    log({ kind: 'daemon-model-provision-warning', reason: stringifyError(error) })
+  })
   const exec = opts.exec ?? defaultDockerExec
   const gcIntervalMs = opts.gcIntervalMs ?? DEFAULT_GC_INTERVAL_MS
   const gcMissesToDeregister = opts.gcMissesToDeregister ?? DEFAULT_GC_MISSES_TO_DEREGISTER

--- a/src/hostd/ensure-models.test.ts
+++ b/src/hostd/ensure-models.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { mkdir, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const pipelineCalls: string[] = []
+let releasePipeline: (() => void) | null = null
+
+mock.module('@huggingface/transformers', () => ({
+  env: {},
+  pipeline: async (_task: string, model: string) => {
+    pipelineCalls.push(model)
+    await new Promise<void>((resolve) => {
+      releasePipeline = resolve
+    })
+    return () => undefined
+  },
+}))
+
+describe('ensureModels', () => {
+  const originalHome = process.env.TYPECLAW_HOME
+  const home = join(tmpdir(), `typeclaw-models-${crypto.randomUUID()}`)
+
+  beforeAll(async () => {
+    process.env.TYPECLAW_HOME = home
+    await mkdir(home, { recursive: true })
+  })
+
+  afterAll(async () => {
+    if (originalHome === undefined) delete process.env.TYPECLAW_HOME
+    else process.env.TYPECLAW_HOME = originalHome
+    await rm(home, { recursive: true, force: true })
+  })
+
+  test('concurrent callers share one model provisioning call', async () => {
+    const { ensureModels } = await import('./models')
+
+    const callers = Array.from({ length: 8 }, () => ensureModels())
+    await waitFor(() => pipelineCalls.length === 1)
+    releasePipeline?.()
+    await Promise.all(callers)
+
+    const { modelsDir } = await import('./paths')
+
+    expect(pipelineCalls).toEqual(['Xenova/multilingual-e5-base'])
+    expect((await stat(modelsDir())).isDirectory()).toBe(true)
+  })
+
+  test('modelsDir points under TYPECLAW_HOME', async () => {
+    const { modelsDir } = await import('./paths')
+
+    expect(modelsDir()).toBe(join(home, 'models'))
+  })
+})
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i += 1) {
+    if (predicate()) return
+    await Bun.sleep(10)
+  }
+  throw new Error('timed out waiting for condition')
+}

--- a/src/hostd/models.ts
+++ b/src/hostd/models.ts
@@ -1,0 +1,49 @@
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { env as transformersEnv, pipeline } from '@huggingface/transformers'
+import lockfile from 'proper-lockfile'
+
+import { modelsDir } from './paths'
+
+const MODEL_NAME = 'Xenova/multilingual-e5-base'
+const LOCK_RETRIES = { retries: 60, factor: 1, minTimeout: 100, maxTimeout: 100, randomize: false } as const
+
+let ensureModelsPromise: Promise<void> | null = null
+let ensureModelsPath: string | null = null
+
+export function ensureModels(): Promise<void> {
+  const dir = modelsDir()
+  if (ensureModelsPath !== dir) {
+    ensureModelsPath = dir
+    ensureModelsPromise = null
+  }
+  ensureModelsPromise ??= ensureModelsLocked().catch((error: unknown) => {
+    ensureModelsPromise = null
+    throw error
+  })
+  return ensureModelsPromise
+}
+
+async function ensureModelsLocked(): Promise<void> {
+  const dir = modelsDir()
+  await mkdir(dir, { recursive: true })
+
+  const release = await lockfile.lock(dir, {
+    lockfilePath: join(dir, '.lock'),
+    realpath: false,
+    retries: LOCK_RETRIES,
+    stale: 30_000,
+  })
+  try {
+    configureTransformers(dir)
+    await pipeline('feature-extraction', MODEL_NAME)
+  } finally {
+    await release()
+  }
+}
+
+function configureTransformers(dir: string): void {
+  transformersEnv.localModelPath = dir
+  ;(transformersEnv as typeof transformersEnv & { cacheDir: string }).cacheDir = dir
+}

--- a/src/hostd/paths.ts
+++ b/src/hostd/paths.ts
@@ -56,6 +56,10 @@ export function keysDir(): string {
   return join(homeRoot(), KEYS_DIR)
 }
 
+export function modelsDir(): string {
+  return join(homeRoot(), 'models')
+}
+
 // Throws on any name that could traverse out of registrationsDir() or
 // confuse the filesystem. Caller's responsibility to handle the error;
 // don't catch-and-ignore — an invalid name is a protocol violation.
@@ -82,8 +86,10 @@ export async function ensureDirs(): Promise<void> {
   await mkdir(logDir(), { recursive: true })
   await mkdir(registrationsDir(), { recursive: true })
   await mkdir(keysDir(), { recursive: true })
+  await mkdir(modelsDir(), { recursive: true })
   await chmod(runDir(), 0o700).catch(() => {})
   await chmod(logDir(), 0o700).catch(() => {})
   await chmod(registrationsDir(), 0o700).catch(() => {})
   await chmod(keysDir(), 0o700).catch(() => {})
+  await chmod(modelsDir(), 0o700).catch(() => {})
 }

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -112,7 +112,17 @@ describe('buildDockerfile feature toggles', () => {
         }),
       ),
     )
-    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap', 'jq'])
+    expect(pkgs).toEqual([
+      'git',
+      'ca-certificates',
+      'curl',
+      'gnupg',
+      'iptables',
+      'util-linux',
+      'bubblewrap',
+      'jq',
+      'libgomp1',
+    ])
   })
 
   test('xvfb: true (the default) adds xvfb to the toggle apt package list, after the baseline packages', () => {
@@ -1065,7 +1075,17 @@ describe('base ↔ per-agent Dockerfile drift guard', () => {
     const match = base.match(/apt-get install -y --no-install-recommends \\\n\s+([^\n]+?) \\\n/)
     if (!match || !match[1]) throw new Error('main apt-get install line not found in base Dockerfile')
     const pkgs = match[1].split(/\s+/).filter(Boolean)
-    expect(pkgs).toEqual(['git', 'ca-certificates', 'curl', 'gnupg', 'iptables', 'util-linux', 'bubblewrap', 'jq'])
+    expect(pkgs).toEqual([
+      'git',
+      'ca-certificates',
+      'curl',
+      'gnupg',
+      'iptables',
+      'util-linux',
+      'bubblewrap',
+      'jq',
+      'libgomp1',
+    ])
   })
 
   test('base Dockerfile uses the same BuildKit syntax pragma and base image as the per-agent Dockerfile so layer caching across the two is possible', () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -75,6 +75,7 @@ const BASELINE_APT_PACKAGES = [
   'util-linux',
   'bubblewrap',
   'jq',
+  'libgomp1',
 ] as const
 
 // curl-impersonate is the only currently-working way to query DuckDuckGo from
@@ -546,6 +547,14 @@ function renderEntrypointShimLayer(): string {
 RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
  && chmod +x ${TYPECLAW_ENTRYPOINT_PATH}`
 }
+
+// Layer 7: install @huggingface/transformers with linux-native onnxruntime binary.
+// The host node_modules may carry a macOS binary via the bind mount; this layer
+// ensures the linux onnxruntime-node addon is present in the container's bun cache.
+const LAYER_TRANSFORMERS_INSTALL = `# Layer 7: install @huggingface/transformers with linux-native onnxruntime binary.
+# The host node_modules may carry a macOS binary via the bind mount; this layer
+# ensures the linux onnxruntime-node addon is present in the container's bun cache.
+RUN bun add @huggingface/transformers`
 
 // Claude Code's official installer is `curl | bash`, not apt — can't live
 // in APT_FEATURES. Layer placed after the toggle apt install (so curl + ca-
@@ -1210,6 +1219,8 @@ ARG TARGETARCH
 
 ${ghKeyringLayer}${toggleAptLayer}${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderEntrypointShimLayer()}
 
+${LAYER_TRANSFORMERS_INSTALL}
+
 `
 }
 
@@ -1271,6 +1282,8 @@ ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 ${LAYER_5_CHROME_FOR_TESTING}
 
 ${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderEntrypointShimLayer()}
+
+${LAYER_TRANSFORMERS_INSTALL}
 
 `
 }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -182,6 +182,9 @@ export type SessionTurnStartEvent = {
   agentDir: string
   userPrompt: string
   origin?: SessionOrigin
+  // Mutable ref: plugin writes retrieval results here; server/router reads after hook returns.
+  // Only populated when vector.enabled and injection plan is index mode.
+  retrievalContext?: { results: string }
 }
 
 export type SessionTurnEndEvent = {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -18,6 +18,7 @@ import {
   type SubagentShared,
 } from '@/agent/subagents'
 import { clearTodosForOrigin } from '@/agent/todo/continuation-wiring'
+import { buildStartupVectorIndex } from '@/bundled-plugins/memory/vector/startup'
 import { resolveCapOptionsFromConfig } from '@/bundled-plugins/tool-result-cap'
 import {
   createChannelManager,
@@ -215,6 +216,11 @@ export async function startAgent({
   // v2-only parser rejects the file and hydrate below sees no channels. Runs
   // exactly once per folder; a folder already at v2 is a no-op.
   runStartupMigrations(cwd)
+  if (isStartupVectorIndexEnabled(pluginConfigsByName.memory)) {
+    await buildStartupVectorIndex(cwd).catch((err) => {
+      console.warn(`[vector] startup index build failed: ${err instanceof Error ? err.message : String(err)}`)
+    })
+  }
 
   // Channel adapters read `process.env[TOKEN_ENV]` (see channels/manager.ts).
   // Hydrate fills any unset env var from secrets.json#channels via env-wins:
@@ -833,6 +839,12 @@ export async function startAgent({
     channelManager,
     stop,
   }
+}
+
+function isStartupVectorIndexEnabled(config: unknown): boolean {
+  if (typeof config !== 'object' || config === null || !('vector' in config)) return false
+  const vector = (config as { vector?: unknown }).vector
+  return typeof vector === 'object' && vector !== null && (vector as { enabled?: unknown }).enabled === true
 }
 
 function buildLocalTuiUrl(port: number, token: string | null): string {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -1059,6 +1059,48 @@ describe('createServer with stream — input queueing bugfix', () => {
     expect(session.promptCalls).toEqual([expect.stringContaining('hello')])
 
     ws.close()
+  })
+
+  test('stream drain appends retrieval context populated by session.turn.start hooks', async () => {
+    // given
+    const session = createFakeSession()
+    const stream = createStream()
+    const agentDir = await mkdtemp(join(tmpdir(), 'server-retrieval-'))
+    const hooks = createHookBus()
+    hooks.registerAll(
+      'retriever',
+      agentDir,
+      { info: () => {}, warn: () => {}, error: () => {} },
+      {
+        'session.turn.start': (event) => {
+          expect(event.userPrompt).toBe('hello')
+          if (event.retrievalContext === undefined) throw new Error('missing retrievalContext')
+          event.retrievalContext.results = '## Retrieved memory\n\n### Topic\n\nExcerpt'
+        },
+      },
+    )
+    const { url } = await startWithSession(session, {
+      stream,
+      agentDir,
+      pluginRegistry: EMPTY_REGISTRY,
+      pluginHooks: hooks,
+    })
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    // when
+    ws.send(JSON.stringify({ type: 'prompt', text: 'hello' }))
+    await waitForState(() => session.promptCalls.length > 0)
+
+    // then
+    const prompt = session.promptCalls[0] ?? ''
+    expect(prompt).toContain('<current-time>')
+    expect(prompt).toContain('hello')
+    expect(prompt).toContain('## Retrieved memory\n\n### Topic\n\nExcerpt')
+
+    session.resolvePrompt()
+    ws.close()
+    await rm(agentDir, { recursive: true, force: true })
   })
 
   test('emits prompt_started before invoking session.prompt() so the TUI can render execution-order history', async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -760,17 +760,23 @@ export function createServer({
             }
             send(ws, { type: 'prompt_started', messageId: `local-${crypto.randomUUID()}`, text: msg.text })
             const fallbackHooks = state.runtimeSnapshot?.hooks
+            const retrievalContext: { results: string } = { results: '' }
             if (fallbackHooks !== undefined && agentDir !== undefined) {
               await fallbackHooks.runSessionTurnStart({
                 sessionId: state.sessionFileId,
                 agentDir,
                 userPrompt: msg.text,
                 origin: state.origin,
+                retrievalContext,
               })
             }
             state.lastUsage = null
             try {
-              await state.session.prompt(`${renderTurnTimeAnchor()}\n\n${msg.text}`)
+              const turnText =
+                retrievalContext.results.length > 0
+                  ? `${renderTurnTimeAnchor()}\n\n${msg.text}\n\n${retrievalContext.results}`
+                  : `${renderTurnTimeAnchor()}\n\n${msg.text}`
+              await state.session.prompt(turnText)
               send(ws, doneMessage(state))
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err)
@@ -1019,15 +1025,24 @@ function makeIdleHookCaller(state: SessionState): () => Promise<void> {
 function makeTurnHookCallers(
   state: SessionState,
   agentDir: string | undefined,
-): { fireTurnStart: (userPrompt: string) => Promise<void>; fireTurnEnd: () => Promise<void> } {
+): { fireTurnStart: (userPrompt: string) => Promise<{ results: string }>; fireTurnEnd: () => Promise<void> } {
   const hooks: HookBus | undefined = state.runtimeSnapshot?.hooks
   if (hooks === undefined || agentDir === undefined) {
-    return { fireTurnStart: async () => {}, fireTurnEnd: async () => {} }
+    return { fireTurnStart: async () => ({ results: '' }), fireTurnEnd: async () => {} }
   }
   const turnEndEvent = { sessionId: state.sessionFileId, agentDir, origin: state.origin }
   return {
-    fireTurnStart: (userPrompt) =>
-      hooks.runSessionTurnStart({ sessionId: state.sessionFileId, agentDir, userPrompt, origin: state.origin }),
+    fireTurnStart: async (userPrompt) => {
+      const retrievalContext = { results: '' }
+      await hooks.runSessionTurnStart({
+        sessionId: state.sessionFileId,
+        agentDir,
+        userPrompt,
+        origin: state.origin,
+        retrievalContext,
+      })
+      return retrievalContext
+    },
     fireTurnEnd: () => hooks.runSessionTurnEnd(turnEndEvent),
   }
 }
@@ -1058,10 +1073,14 @@ async function drain(
         }).catch((err) => logger.error(`[server] ${state.sessionFileId}: todo turn-start failed: ${describeErr(err)}`))
       }
 
-      await fireTurnStart(item.text)
+      const retrievalContext = await fireTurnStart(item.text)
       state.lastUsage = null
       try {
-        await state.session.prompt(`${renderTurnTimeAnchor()}\n\n${item.text}`)
+        const turnText =
+          retrievalContext.results.length > 0
+            ? `${renderTurnTimeAnchor()}\n\n${item.text}\n\n${retrievalContext.results}`
+            : `${renderTurnTimeAnchor()}\n\n${item.text}`
+        await state.session.prompt(turnText)
         send(ws, doneMessage(state))
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Background

Memory retrieval currently delegates to the `memory-retrieval` subagent, which makes every lookup pay a full agent round trip. That path keeps default behavior safe, but it makes recall expensive enough to feel interactive-latency bound: measured retrievals take 14–82 seconds even when the answer is already in local memory.

This PR adds an opt-in vector memory path so agents can retrieve memory in-process when the memory section is already in index mode. In the measured happy path, the in-process retrieval work is about 4 ms after the embedding model is warm, so the recall cost moves from agent-turn latency to local SQLite and embedding work.

The feature is gated by `memory.vector.enabled`. The default remains disabled, so existing agents keep the current subagent behavior unless they explicitly opt in.

Opt-in example:

```jsonc
{
  "memory": {
    "vector": {
      // Default is false. Set true to use in-process hybrid retrieval.
      "enabled": true
    }
  }
}
```

## Summary

The new vector memory subsystem stores stream fragments and topic shards in a SQLite index under the agent memory tree, embeds them with Xenova/multilingual-e5-base, and answers retrieval queries with reciprocal-rank fusion across semantic and keyword lanes. Hybrid search is deliberate: vectors recover paraphrases and cross-lingual matches, while keyword search preserves exact identifiers such as PR numbers, code symbols, and issue IDs.

End-to-end flow when vector memory is enabled:

1. A user prompt arrives and TypeClaw reaches the memory load path for that turn.
2. If the memory injection plan is direct mode, no retrieval is needed because shard bodies are already injected.
3. If the memory injection plan is index mode, the session turn-start hook starts in-process vector retrieval instead of spawning the `memory-retrieval` subagent.
4. On the first vector retrieval, the SQLite index is lazily populated from topic shards and undreamed stream fragments if it is empty.
5. The current user prompt is embedded as a query and sent through `hybridSearch`.
6. The vector lane queries cosine top-K from the SQLite store.
7. The keyword lane reuses the existing `memory_search` matcher over topic shards and undreamed stream fragments.
8. Reciprocal-rank fusion combines both lanes, so exact identifiers can still win while semantic matches can surface paraphrases.
9. The fused top results are written atomically to the retrieval cache.
10. The next `loadMemory` call for the same session appends that cache to the prompt, preserving the existing lag-by-one read contract.

Architecture sketch:

```text
user prompt
  |
  v
session.turn.start in index mode
  |
  v
hybridSearch
  |----------------------|
  v                      v
vector lane          keyword lane
cosine top-K         existing matcher
  |                      |
  |----------|-----------|
             v
      RRF fusion
             |
             v
memory/.retrieval-cache/<sessionId>.md
             |
             v
next-turn memory injection
```

Storage layout added by this PR:

```text
memory/
  .vectors/
    index.db
  .retrieval-cache/
    <sessionId>.md
```

The SQLite index stores one row per indexed topic shard or stream fragment, including source, key, model name, embedding dimensionality, content hash, and timestamp. Dimension checks prevent incompatible embeddings from being mixed in the same index.

The retrieval cache remains the existing transient handoff file. Vector retrieval writes the same cache shape that the subagent path writes, and `loadMemory` reads it on the next prompt for the same session.

Model selection:

| Model | Recall@3 | Recall@1 | Size | Warm embed latency | Decision |
| --- | ---: | ---: | ---: | ---: | --- |
| multilingual-e5-small | 27/32 | 17/32 | about 118 MB | about 2 ms | Rejected because the smaller footprint lost too many multilingual paraphrase matches. |
| multilingual-e5-base | 31/32 | 22/32 | about 286 MB | about 4 ms | Chosen as the best recall, size, and latency balance for local retrieval. |
| bge-m3 | 32/32 | 23/32 | about 2.2 GB | about 20 ms | Rejected because the recall gain was marginal for a much larger shared model mount. |

The model choice comes from a gold-set eval with 32 queries across 12 languages. E5-base is not the absolute largest or highest-recall option, but it gives most of the recall benefit while keeping the shared host download and per-query latency small enough for interactive use.

The model is provisioned once by the host daemon and shared read-only with containers. Hostd downloads the model under the TypeClaw home model cache. Every container gets the same cache mounted read-only at `/opt/models`.

The container also receives this environment variable:

```text
TYPECLAW_MODEL_CACHE=/opt/models
```

The effective Docker mount is:

```text
-v ~/.typeclaw/models:/opt/models:ro
```

This avoids one 286 MB model copy per agent and keeps the container runtime from mutating the host-provisioned cache.

Phase split:

- Phase 1 adds the opt-in config flag, lazy full-index build on first retrieval, the SQLite store, the embedder, hybrid RRF search, and atomic retrieval-cache writes.
- Phase 2 keeps the index fresh after the first build by embedding new stream fragments on append, re-embedding changed topic shards after dreaming, deleting vectors for removed topic shards, and garbage-collecting vectors for compacted stream fragments.

## Preview

No visual preview is attached because this is a memory-retrieval and runtime plumbing change. The reviewer-visible behavior is in the test coverage, the opt-in config flag, the storage layout above, and the unchanged default path.

## What this does NOT do

- Does not change default memory retrieval behavior, because vector memory remains disabled unless configured.
- Does not remove the existing `memory-retrieval` subagent fallback.
- Does not add a new CLI command or require users to re-run init.
- Does not make vector-only retrieval the default; exact-match keyword retrieval remains part of every vector-enabled search.
- Does not inject undreamed stream fragments directly into the system prompt; they remain retrievable through search and cache injection.
- Does not make the model cache writable from containers; the shared mount is read-only.
- Does not change the lag-by-one retrieval-cache contract, so the current turn still consumes the cache produced by the previous turn.

## Review notes

- The load-bearing safety invariant is that `memory.vector.enabled` defaults to false and preserves the existing subagent path when unset.
- The retrieval trigger should only replace the subagent in index mode. Direct-mode memory already has shard bodies available and should not pay retrieval work.
- The retrieval invariant is hybrid RRF search, not vector-only search, because exact identifiers must continue to rank reliably.
- The cache invariant is lag-by-one injection. Retrieval writes the cache for the current user prompt, and the next prompt for that session reads it.
- The storage invariant is one SQLite index in the agent memory tree, with model and dimensionality checks so incompatible embeddings cannot be mixed.
- The runtime invariant is one shared host-provisioned model cache mounted read-only into containers, which prevents repeated 286 MB downloads per agent.
- The guard-policy change intentionally permits only the trusted in-process memory retrieval component to write retrieval cache files.
- Phase 1 and Phase 2 have different freshness properties. Phase 1 can build the full index lazily, while Phase 2 is responsible for append-time indexing, dream-time reindexing, and stream-vector GC.
- Test coverage includes the vector config flag, SQLite store behavior, cosine top-K and dimension guards, hybrid RRF ranking, atomic retrieval-cache writes, append-time indexing, dream-time reindexing, stream-vector GC, host model provisioning, container model mounts, and Dockerfile dependency changes.
- Verification reported for this branch: 8689 tests pass and 0 fail across QA scenarios 1.1–1.13 and 2.1–2.5.