### PR TITLE
Route undecryptable LINE messages instead of dropping them as empty_text

### DIFF
--- a/src/channels/adapters/line-attachment.test.ts
+++ b/src/channels/adapters/line-attachment.test.ts
@@ -51,6 +51,18 @@ describe('splitInboundLine', () => {
     expect(result).toEqual({ text: '', attachments: [] })
   })
 
+  test('routes an undecryptable message with a placeholder instead of dropping it', () => {
+    const missingKey = splitInboundLine(
+      event({ content_type: 'NONE', text: null, decryption_error: { code: 'missing_e2ee_key', message: 'no key' } }),
+    )
+    expect(missingKey).toEqual({ text: '[LINE message could not be decrypted: missing E2EE key]', attachments: [] })
+
+    const failed = splitInboundLine(
+      event({ content_type: 'NONE', text: null, decryption_error: { code: 'decrypt_failed', message: 'boom' } }),
+    )
+    expect(failed).toEqual({ text: '[LINE message could not be decrypted]', attachments: [] })
+  })
+
   test('synthesizes a placeholder + ref-free attachment for stickers', () => {
     const result = splitInboundLine(event({ content_type: 'STICKER' }))
     expect(result.text).toBe('[LINE sticker]')

--- a/src/channels/adapters/line-attachment.ts
+++ b/src/channels/adapters/line-attachment.ts
@@ -57,6 +57,21 @@ const PLACEHOLDER_ONLY_LABEL: Record<string, string> = {
   LOCATION: 'location',
 }
 
+// Letter-Sealing (E2EE) messages this session cannot decrypt arrive as
+// `text: null, content_type: NONE` with a `decryption_error` set — wire-
+// identical to a genuinely empty message. Without surfacing them the agent
+// silently drops real user messages as empty_text and looks dead. Map the
+// codes to a stable, agent-readable phrase instead of forwarding the SDK's
+// verbose/localized message verbatim.
+const DECRYPTION_ERROR_PLACEHOLDER: Record<string, string> = {
+  missing_e2ee_key: '[LINE message could not be decrypted: missing E2EE key]',
+  decrypt_failed: '[LINE message could not be decrypted]',
+}
+
+export function lineDecryptionPlaceholder(code: string): string {
+  return DECRYPTION_ERROR_PLACEHOLDER[code] ?? '[LINE message could not be decrypted]'
+}
+
 export function normalizeLineContentType(raw: string | null | undefined): string {
   if (raw === null || raw === undefined) return 'NONE'
   const trimmed = raw.trim()
@@ -70,6 +85,10 @@ export function normalizeLineContentType(raw: string | null | undefined): string
 }
 
 export function splitInboundLine(event: LinePushMessageEvent, startId = 1): SplitInboundLine {
+  if (event.decryption_error !== undefined) {
+    return { text: lineDecryptionPlaceholder(event.decryption_error.code), attachments: [] }
+  }
+
   const contentType = normalizeLineContentType(event.content_type)
 
   // NONE is LINE text; a blank NONE message stays an `empty_text` drop in the

--- a/src/channels/adapters/line.test.ts
+++ b/src/channels/adapters/line.test.ts
@@ -203,6 +203,52 @@ describe('createLineAdapter lifecycle', () => {
     expect(router.registered.outbound).toBe(false)
   })
 
+  test('routes an undecryptable inbound with a placeholder and logs it instead of dropping as empty', async () => {
+    const listener = new FakeListener()
+    const routed: InboundMessage[] = []
+    const warnings: string[] = []
+    const router = makeRouterStub((m) => routed.push(m))
+
+    const adapter = createLineAdapter({
+      router,
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: { info: () => {}, warn: (m) => warnings.push(m), error: () => {} },
+      client: fakeClient(),
+      listenerFactory: () => listener,
+      credentialsStore: {
+        load: async () => ({ current_account: 'U_self', accounts: {} }),
+        getAccount: async () => ({
+          account_id: 'U_self',
+          auth_token: 't',
+          device: 'DESKTOPMAC',
+          created_at: '',
+          updated_at: '',
+        }),
+      },
+    })
+
+    await adapter.start()
+    listener.emit('connected', { account_id: 'U_self' })
+
+    listener.emit('message', {
+      type: 'message' as const,
+      chat_id: 'C1',
+      message_id: 'M_enc',
+      author_id: 'U_other',
+      text: null,
+      content_type: 'NONE',
+      content_metadata: {},
+      decryption_error: { code: 'missing_e2ee_key', message: 'no key' },
+      sent_at: '2025-01-02T00:00:00.000Z',
+    })
+    await waitFor(() => routed.length > 0)
+
+    expect(routed[0]!.text).toBe('[LINE message could not be decrypted: missing E2EE key]')
+    expect(warnings.some((w) => w.includes('undecryptable') && w.includes('missing_e2ee_key'))).toBe(true)
+
+    await adapter.stop()
+  })
+
   test('wires the credentials store as the client credential manager so listener re-login resolves it', async () => {
     // given a store-backed client whose no-arg login() (the LineListener reconnect
     // path) resolves credentials only through its injected credential manager

--- a/src/channels/adapters/line.ts
+++ b/src/channels/adapters/line.ts
@@ -222,6 +222,11 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
       logger.info(
         `[line] inbound message_id=${event.message_id} author=${event.author_id} ${inboundTag} content_type=${event.content_type} text_len=${text.length} attachments=${attachments.length}`,
       )
+      if (event.decryption_error !== undefined) {
+        logger.warn(
+          `[line] undecryptable message_id=${event.message_id} code=${event.decryption_error.code} content_type=${event.content_type}`,
+        )
+      }
 
       const verdict = classifyInbound(event, options.configRef(), {
         selfUserId,


### PR DESCRIPTION
## Background

Inbound LINE messages from a real DM chat were silently dropped: [line] inbound ... content_type=NONE text_len=0 attachments=0, then [line] dropped ... reason=empty_text. Investigation against the live session proved the chat uses Letter Sealing E2EE and this auth-token session has no E2EE self-key. Empty key storage makes the SDK return missing_e2ee_key for every message. The SDK version shipped in current main surfaces these events as text: null, content_type: NONE, with decryption_error set, which is wire-identical to a genuinely empty message. The LINE adapter had no decryption_error handling, so every undecryptable message was dropped as empty_text with no distinct log, making the agent look dead.

## Summary

When event.decryption_error is present, splitInboundLine now synthesizes a stable, agent-readable placeholder before the NONE short-circuit, for example [LINE message could not be decrypted: missing E2EE key]. This lets the message route instead of dropping. The adapter also logs a distinct [line] undecryptable ... warning for operator diagnosis. Codes are mapped to safe phrases rather than forwarding the SDK's verbose or localized message verbatim.

## What this does NOT do

- Does not make undecryptable messages readable. That requires provisioning an E2EE self-key via QR re-auth, which an auth-token session cannot do. This change only ensures such messages are surfaced with a placeholder instead of silently lost.
- Genuinely-empty NONE messages without decryption_error or attachments still drop as empty_text, unchanged.
- No dependency bump. Main already ships agent-messenger 2.20.1.

## Review notes

- Load-bearing: the decryption_error check in splitInboundLine must come before the content_type === NONE short-circuit. Otherwise the empty-string synthesis re-triggers empty_text.
- Codes are mapped via a small table. Unknown codes fall back to a generic phrase.
- Verified: 34 LINE adapter tests, full channels suite with 1855 tests, and full repo suite with 8679 tests pass. Typecheck, lint, and format are clean. New tests cover splitter placeholder, classifier routing, and an end-to-end adapter test asserting the warning log and placeholder route.
