### PR TITLE
Write LINE E2EE keys to the agent workspace on host login

### DIFF
--- a/src/init/line-auth.test.ts
+++ b/src/init/line-auth.test.ts
@@ -7,7 +7,7 @@ import type { LineLoginResult } from 'agent-messenger/line'
 
 import { SecretsLineCredentialStore } from '@/secrets/line-store'
 
-import { runLineBootstrap, type LineLoginClient } from './line-auth'
+import { lineConfigDir, runLineBootstrap, type LineLoginClient } from './line-auth'
 
 async function withDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   const root = await mkdtemp(join(tmpdir(), 'typeclaw-line-auth-'))
@@ -117,6 +117,44 @@ function throwingLoggingClient(): LineLoginClient {
 }
 
 describe('runLineBootstrap', () => {
+  test('points the SDK E2EE storage at the agent workspace when the config dir is unset', async () => {
+    await withDir(async (dir) => {
+      const saved = process.env.AGENT_MESSENGER_CONFIG_DIR
+      delete process.env.AGENT_MESSENGER_CONFIG_DIR
+      try {
+        await runLineBootstrap({
+          method: 'qr',
+          agentDir: dir,
+          callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+          client: fakeClient(dir, { authenticated: true, account_id: 'mid-cfg' }),
+        })
+        expect(process.env.AGENT_MESSENGER_CONFIG_DIR ?? '').toBe(lineConfigDir(dir))
+      } finally {
+        if (saved === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+        else process.env.AGENT_MESSENGER_CONFIG_DIR = saved
+      }
+    })
+  })
+
+  test('does not override an already-set config dir (container stage owns it)', async () => {
+    await withDir(async (dir) => {
+      const saved = process.env.AGENT_MESSENGER_CONFIG_DIR
+      process.env.AGENT_MESSENGER_CONFIG_DIR = '/agent/workspace/.agent-messenger'
+      try {
+        await runLineBootstrap({
+          method: 'qr',
+          agentDir: dir,
+          callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+          client: fakeClient(dir, { authenticated: true, account_id: 'mid-cfg2' }),
+        })
+        expect(process.env.AGENT_MESSENGER_CONFIG_DIR ?? '').toBe('/agent/workspace/.agent-messenger')
+      } finally {
+        if (saved === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+        else process.env.AGENT_MESSENGER_CONFIG_DIR = saved
+      }
+    })
+  })
+
   test('persists the account and sets it current on a successful QR login', async () => {
     await withDir(async (dir) => {
       const status = await runLineBootstrap({

--- a/src/init/line-auth.test.ts
+++ b/src/init/line-auth.test.ts
@@ -41,6 +41,27 @@ function fakeClient(agentDir: string, result: LineLoginResult): LineLoginClient 
   }
 }
 
+// Like fakeClient, but invokes `onLogin` synchronously inside the login call so
+// a test can observe process state (e.g. AGENT_MESSENGER_CONFIG_DIR) while the
+// SDK would be constructing its storage.
+function observingClient(agentDir: string, result: LineLoginResult, onLogin: () => void): LineLoginClient {
+  const store = new SecretsLineCredentialStore({ mode: 'host', secretsPath: join(agentDir, 'secrets.json') })
+  const persist = async (): Promise<LineLoginResult> => {
+    onLogin()
+    if (result.authenticated && result.account_id !== undefined) {
+      await store.setAccount({
+        account_id: result.account_id,
+        auth_token: 'persisted-token',
+        device: 'DESKTOPMAC',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      })
+    }
+    return result
+  }
+  return { loginWithQR: persist, loginWithEmail: persist }
+}
+
 // Models an SDK that authenticates but never calls setAccount() — nothing
 // lands in secrets.json. runLineBootstrap must treat this as a failure rather
 // than a green "added".
@@ -117,22 +138,60 @@ function throwingLoggingClient(): LineLoginClient {
 }
 
 describe('runLineBootstrap', () => {
-  test('points the SDK E2EE storage at the agent workspace when the config dir is unset', async () => {
+  test('points the SDK E2EE storage at the agent workspace during login, then restores the env', async () => {
     await withDir(async (dir) => {
       const saved = process.env.AGENT_MESSENGER_CONFIG_DIR
       delete process.env.AGENT_MESSENGER_CONFIG_DIR
       try {
+        let duringLogin: string | undefined
         await runLineBootstrap({
           method: 'qr',
           agentDir: dir,
           callbacks: { onPincode: () => {}, onQRUrl: () => {} },
-          client: fakeClient(dir, { authenticated: true, account_id: 'mid-cfg' }),
+          client: observingClient(dir, { authenticated: true, account_id: 'mid-cfg' }, () => {
+            duringLogin = process.env.AGENT_MESSENGER_CONFIG_DIR
+          }),
         })
-        expect(process.env.AGENT_MESSENGER_CONFIG_DIR ?? '').toBe(lineConfigDir(dir))
+        // set for the SDK during login...
+        expect(duringLogin ?? '').toBe(lineConfigDir(dir))
+        // ...and restored afterward so it cannot leak into a later bootstrap
+        expect(process.env.AGENT_MESSENGER_CONFIG_DIR).toBeUndefined()
       } finally {
         if (saved === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
         else process.env.AGENT_MESSENGER_CONFIG_DIR = saved
       }
+    })
+  })
+
+  test('does not let a second bootstrap inherit the first agent dir', async () => {
+    await withDir(async (dirA) => {
+      await withDir(async (dirB) => {
+        const saved = process.env.AGENT_MESSENGER_CONFIG_DIR
+        delete process.env.AGENT_MESSENGER_CONFIG_DIR
+        try {
+          await runLineBootstrap({
+            method: 'qr',
+            agentDir: dirA,
+            callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+            client: fakeClient(dirA, { authenticated: true, account_id: 'mid-a' }),
+          })
+
+          let duringSecond: string | undefined
+          await runLineBootstrap({
+            method: 'qr',
+            agentDir: dirB,
+            callbacks: { onPincode: () => {}, onQRUrl: () => {} },
+            client: observingClient(dirB, { authenticated: true, account_id: 'mid-b' }, () => {
+              duringSecond = process.env.AGENT_MESSENGER_CONFIG_DIR
+            }),
+          })
+          // the second bootstrap uses its OWN agent dir, not the first's
+          expect(duringSecond ?? '').toBe(lineConfigDir(dirB))
+        } finally {
+          if (saved === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+          else process.env.AGENT_MESSENGER_CONFIG_DIR = saved
+        }
+      })
     })
   })
 
@@ -141,12 +200,16 @@ describe('runLineBootstrap', () => {
       const saved = process.env.AGENT_MESSENGER_CONFIG_DIR
       process.env.AGENT_MESSENGER_CONFIG_DIR = '/agent/workspace/.agent-messenger'
       try {
+        let duringLogin: string | undefined
         await runLineBootstrap({
           method: 'qr',
           agentDir: dir,
           callbacks: { onPincode: () => {}, onQRUrl: () => {} },
-          client: fakeClient(dir, { authenticated: true, account_id: 'mid-cfg2' }),
+          client: observingClient(dir, { authenticated: true, account_id: 'mid-cfg2' }, () => {
+            duringLogin = process.env.AGENT_MESSENGER_CONFIG_DIR
+          }),
         })
+        expect(duringLogin ?? '').toBe('/agent/workspace/.agent-messenger')
         expect(process.env.AGENT_MESSENGER_CONFIG_DIR ?? '').toBe('/agent/workspace/.agent-messenger')
       } finally {
         if (saved === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR

--- a/src/init/line-auth.ts
+++ b/src/init/line-auth.ts
@@ -63,29 +63,36 @@ export function lineConfigDir(agentDir: string): string {
 
 export async function runLineBootstrap(input: LineLoginInput): Promise<LineBootstrapStatus> {
   try {
-    process.env.AGENT_MESSENGER_CONFIG_DIR ??= lineConfigDir(input.agentDir)
     const store = new SecretsLineCredentialStore({ mode: 'host', secretsPath: lineSecretsPath(input.agentDir) })
-    // The LINE SDK persists the minted auth_token + certificate by calling
-    // setAccount() on whatever credential manager the client was built with.
-    // Wiring our secrets.json-backed store in here means a successful login
-    // writes straight to secrets.json#channels.line — no second copy in
-    // ~/.config/agent-messenger to keep in sync.
-    const client = input.client ?? buildLineClient(store)
 
-    const result = await suppressLineTokenInfoDump(() =>
-      input.method === 'qr'
-        ? client.loginWithQR({
-            onQRUrl: async (url) => {
-              await input.callbacks.onQRUrl?.(url)
-            },
-            onPincode: input.callbacks.onPincode,
-          })
-        : client.loginWithEmail({
-            email: input.email,
-            password: input.password,
-            onPincode: input.callbacks.onPincode,
-          }),
-    )
+    // The env is set only for the duration of client construction + login (when
+    // the SDK reads it to locate line-storage) and restored after, so a second
+    // bootstrap for a different agent in the same process can't inherit the
+    // first agent's path. An already-set value (the container's Dockerfile env)
+    // is left untouched.
+    const result = await withLineConfigDir(lineConfigDir(input.agentDir), () => {
+      // The LINE SDK persists the minted auth_token + certificate by calling
+      // setAccount() on whatever credential manager the client was built with.
+      // Wiring our secrets.json-backed store in here means a successful login
+      // writes straight to secrets.json#channels.line — no second copy in
+      // ~/.config/agent-messenger to keep in sync.
+      const client = input.client ?? buildLineClient(store)
+
+      return suppressLineTokenInfoDump(() =>
+        input.method === 'qr'
+          ? client.loginWithQR({
+              onQRUrl: async (url) => {
+                await input.callbacks.onQRUrl?.(url)
+              },
+              onPincode: input.callbacks.onPincode,
+            })
+          : client.loginWithEmail({
+              email: input.email,
+              password: input.password,
+              onPincode: input.callbacks.onPincode,
+            }),
+      )
+    })
 
     if (!result.authenticated || result.account_id === undefined) {
       const reason = result.message ?? result.error ?? 'LINE login did not authenticate'
@@ -115,6 +122,16 @@ function buildLineClient(store: SecretsLineCredentialStore): LineLoginClient {
   // calls, so it stands in as the credential manager via a structural cast.
   const credManager = store as unknown as LineCredentialManager
   return new RealLineClient(credManager) as unknown as LineLoginClient
+}
+
+async function withLineConfigDir<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.AGENT_MESSENGER_CONFIG_DIR
+  if (previous === undefined) process.env.AGENT_MESSENGER_CONFIG_DIR = dir
+  try {
+    return await fn()
+  } finally {
+    if (previous === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+  }
 }
 
 async function suppressLineTokenInfoDump<T>(fn: () => Promise<T>): Promise<T> {

--- a/src/init/line-auth.ts
+++ b/src/init/line-auth.ts
@@ -50,8 +50,20 @@ export function lineSecretsPath(agentDir: string): string {
   return join(agentDir, 'secrets.json')
 }
 
+// The SDK persists E2EE (Letter-Sealing) key material under
+// `<AGENT_MESSENGER_CONFIG_DIR>/line-storage/`. The container sets that env to
+// the agent workspace (src/init/dockerfile.ts), but a host-stage login (init /
+// `channel reauth line`) would otherwise fall back to `~/.config/agent-messenger`
+// — so the E2EE key gets written somewhere the container never reads, and inbound
+// Letter-Sealing messages stay undecryptable. Point the host login at the same
+// per-agent dir the container uses so the key lands where the runtime reads it.
+export function lineConfigDir(agentDir: string): string {
+  return join(agentDir, 'workspace', '.agent-messenger')
+}
+
 export async function runLineBootstrap(input: LineLoginInput): Promise<LineBootstrapStatus> {
   try {
+    process.env.AGENT_MESSENGER_CONFIG_DIR ??= lineConfigDir(input.agentDir)
     const store = new SecretsLineCredentialStore({ mode: 'host', secretsPath: lineSecretsPath(input.agentDir) })
     // The LINE SDK persists the minted auth_token + certificate by calling
     // setAccount() on whatever credential manager the client was built with.


### PR DESCRIPTION
## Background

Inbound LINE messages from a Letter-Sealing DM chat were dropped as `empty_text` even after a successful QR re-auth. Live inspection confirmed the root cause: the SDK persists the E2EE self-key under AGENT_MESSENGER_CONFIG_DIR/line-storage, while the host-stage LINE login did not set that env.

The container already sets the env to `/agent/workspace/.agent-messenger` via src/init/dockerfile.ts. But typeclaw init and typeclaw channel reauth line run QR login on the host, so the SDK wrote the key to its default user config directory instead. The container then read its own empty line-storage, so inbound Letter-Sealing messages arrived undecryptable with missing_e2ee_key, text null, and content type NONE, then were dropped as empty_text.

The auth credential persisted fine; only the E2EE key landed in the wrong directory. That is why reauth appeared to succeed while decryption stayed broken.

## Summary

Default `AGENT_MESSENGER_CONFIG_DIR` at the start of runLineBootstrap to the per-agent workspace config dir. This mirrors the existing kakaotalkConfigDir pattern and makes host-stage QR login write LINE storage to the same directory the container reads.

The default uses nullish assignment so an already-set value is left untouched. The container stage is unaffected because the Dockerfile already provides the env; only the host login path changes. A new exported lineConfigDir(agentDir) helper names the path.

## What this does NOT do

- Does not change the container runtime; it already reads the correct dir via the Dockerfile env.
- Does not recover past undecryptable messages; only messages received after a key is present in the correct dir decrypt.
- Does not change dependencies.

## Review notes

- Load-bearing: use nullish assignment, not plain assignment, so the container's Dockerfile-provided value is never overridden.
- Mirrors the existing kakaotalkConfigDir pattern of using the per-agent workspace config dir.
- Verified live: copying the existing key from the default dir into the agent workspace and restarting made all messages in the affected Letter-Sealing DM chat decrypt with zero errors. This fix makes reauth write the key there automatically, without a manual copy.
- TDD: a new test fails without the env default and passes with it; a second test asserts an already-set value is not overridden. Full suite, typecheck, lint, and format pass.