### PR TITLE
fix(init): make Xvfb exit detection deterministic

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1360,9 +1360,20 @@ describe('network egress entrypoint shim', () => {
     )
   })
 
-  test('Xvfb startup failure is loud: helper polls liveness with kill -0 and exits non-zero with a stderr line on early exit or socket timeout', () => {
+  test('Xvfb startup failure is loud: helper detects an early exit via a status-file handshake (NOT kill -0, which reports zombies as alive) and exits non-zero with a stderr line on early exit or socket timeout', () => {
     const shim = buildEntrypointShim()
-    expect(shim).toContain('kill -0 "$xvfb_pid"')
+    // A monitor subshell waits for Xvfb and records its exit; the poll loop
+    // reads the status file. The liveness probe must NOT be `kill -0`: it
+    // returns success on an unreaped zombie, so an instantly-dead Xvfb was
+    // reported as alive until the 3s timeout (the flaky-test root cause).
+    expect(shim).not.toMatch(/^\s*if ! kill -0/m)
+    expect(shim).toContain('xvfb_status="/tmp/typeclaw-xvfb-status.$$"')
+    // The status-file check must precede the socket check, so a "created the
+    // socket then immediately died" Xvfb is still treated as a failure.
+    const statusIdx = shim.indexOf('[ -f "$xvfb_status" ]')
+    const socketIdx = shim.indexOf('[ -S /tmp/.X11-unix/X99 ]')
+    expect(statusIdx).toBeGreaterThan(-1)
+    expect(socketIdx).toBeGreaterThan(statusIdx)
     expect(shim).toMatch(/typeclaw-entrypoint: Xvfb exited immediately[^\n]+\n[^\n]+exit 1/)
     expect(shim).toMatch(/typeclaw-entrypoint: Xvfb did not create \/tmp\/\.X11-unix\/X99[^\n]+\n[^\n]+exit 1/)
   })

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -293,9 +293,20 @@ set -eu
 #    (missing library, port conflict, malformed args). Without the
 #    explicit liveness probe below, the shim would then export DISPLAY
 #    and exec bun, agent-browser launches would die with "cannot open
-#    display", and the operator would chase a phantom bug. We capture
-#    $! and \`kill -0\` it on every poll iteration so an early exit
-#    becomes a clear stderr line and a non-zero shim exit.
+#    display", and the operator would chase a phantom bug. A monitor
+#    subshell owns Xvfb, \`wait\`s for it, and drops a status file the
+#    instant it exits; the poll loop checks that file (before the socket
+#    check) so an early exit becomes a clear stderr line and a non-zero
+#    shim exit.
+#
+#    We do NOT probe liveness with \`kill -0 "\$xvfb_pid"\`. A backgrounded
+#    child that exits before the shell \`wait\`s for it becomes a zombie,
+#    and \`kill -0\` returns success on a zombie PID (it still exists in
+#    the process table). Under load the shell reaps the zombie lazily, so
+#    \`kill -0\` reported the dead Xvfb as alive for up to the full 3s
+#    window — the loop then timed out and printed the misleading "did not
+#    create socket within 3s" diagnostic instead of "exited immediately".
+#    The status-file handshake sidesteps zombie semantics entirely.
 #
 # We DO NOT use \`xvfb-run\`. xvfb-run hangs forever when it runs as
 # PID 1 inside a container: its SIGUSR1-based ready handshake races
@@ -451,30 +462,45 @@ start_xvfb() {
   if ! command -v Xvfb >/dev/null 2>&1; then
     return 0
   fi
-  setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin \\
-    -- Xvfb :99 -screen 0 1920x1080x24 -ac +extension RANDR -nolisten tcp \\
-    >/dev/null 2>&1 &
+  # A monitor subshell owns Xvfb and \`wait\`s for it (the bare command
+  # blocks until exit), then writes Xvfb's exit code to a status file.
+  # The poll loop below reads that file instead of probing \`kill -0\` —
+  # see invariant 2 above for why zombie semantics make \`kill -0\`
+  # unreliable. \`set +e\` inside the subshell keeps the outer \`set -e\`
+  # from killing the monitor before it records a non-zero Xvfb exit.
+  xvfb_status="/tmp/typeclaw-xvfb-status.$$"
+  rm -f "$xvfb_status"
+  (
+    set +e
+    setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin \\
+      -- Xvfb :99 -screen 0 1920x1080x24 -ac +extension RANDR -nolisten tcp \\
+      >/dev/null 2>&1
+    printf '%s\\n' "$?" > "$xvfb_status"
+  ) &
   xvfb_pid=$!
   export DISPLAY=:99
-  # Poll the socket every 10ms up to ~3s. Xvfb cold start is typically
-  # ~20-50ms on a modern host; 3s covers slow Docker Desktop VMs,
-  # Rosetta/QEMU emulation, and loaded CI runners. We also \`kill -0\`
-  # the pid each iteration so an Xvfb that died immediately surfaces
-  # as a clear error instead of a 3-second hang followed by silent
-  # "cannot open display" downstream.
+  # Poll every 10ms up to ~3s. Xvfb cold start is typically ~20-50ms on
+  # a modern host; 3s covers slow Docker Desktop VMs, Rosetta/QEMU
+  # emulation, and loaded CI runners. The status-file check comes FIRST
+  # so an Xvfb that creates the socket and then immediately dies is still
+  # treated as a startup failure.
   i=0
   while [ $i -lt 300 ]; do
-    if [ -S /tmp/.X11-unix/X99 ]; then
-      unset i xvfb_pid
-      return 0
-    fi
-    if ! kill -0 "$xvfb_pid" 2>/dev/null; then
+    if [ -f "$xvfb_status" ]; then
+      wait "$xvfb_pid" 2>/dev/null || true
+      rm -f "$xvfb_status"
       echo "typeclaw-entrypoint: Xvfb exited immediately; cannot start headed display (docker.file.xvfb=true)" >&2
       exit 1
+    fi
+    if [ -S /tmp/.X11-unix/X99 ]; then
+      rm -f "$xvfb_status"
+      unset i xvfb_pid xvfb_status
+      return 0
     fi
     sleep 0.01
     i=$((i + 1))
   done
+  rm -f "$xvfb_status"
   echo "typeclaw-entrypoint: Xvfb did not create /tmp/.X11-unix/X99 within 3s; refusing to continue (docker.file.xvfb=true)" >&2
   exit 1
 }


### PR DESCRIPTION
## Background

The executable shim test in src/init/dockerfile.test.ts intermittently failed under full-suite parallel load. The instant-exit Xvfb path sometimes took the full 3s poll budget and printed the socket-timeout diagnostic instead of the early-exit diagnostic.

This was a real container-stage bug, not only a test artifact: an Xvfb process that exits before the PID 1 shell waits for it can remain as a zombie. The `kill -0` probe still reports a zombie PID as alive until it is reaped.

Under heavy CPU contention the shell can reap that background child lazily, so the generated entrypoint shim in src/init/dockerfile.ts treated a dead Xvfb as alive and made operators wait for a misleading timeout. The reproduced failure mode was about 4392ms versus the normal about 370ms path.

## Summary

Replace the old liveness probe in buildEntrypointShim() with a dash-compatible status-file handshake. A monitor subshell now owns Xvfb, waits for it, and writes the exit code to a status file; the poll loop checks that file before checking the X11 socket.

This makes an instant Xvfb exit deterministic regardless of zombie-reaping timing, and it still treats a create-socket-then-die Xvfb as startup failure. The capability drop stays inside the monitor subshell. The `set +e` guard ensures a non-zero Xvfb exit is recorded instead of being swallowed by the outer strict shell mode.

## Preview

No visual output. The operator-facing change is that a dead-on-start Xvfb now fails fast with the existing early-exit diagnostic instead of hanging until the 3s socket timeout.

## What this does NOT do

- Does not reintroduce xvfb-run; PID 1 hang concerns still apply.
- Does not add bash-only shell features, procfs probing, wait-n semantics, or timeout wrappers.
- Does not change the executable flaky-regression test body; it now passes against the shim behavior.

## Review notes

- Load-bearing path: src/init/dockerfile.ts start_xvfb() checks the status file before the X11 socket path.
- Static coverage in src/init/dockerfile.test.ts now asserts the handshake, rejects an active kill-zero poll, and verifies status-before-socket ordering.
- Full parallel suite: 8679 pass, 1 skip, 0 fail.
- Pre-commit gate: typecheck clean, lint 0 errors with 67 pre-existing unrelated warnings, and format check clean.
- Stress under 8x CPU load: instant-exit Xvfb reported the early-exit diagnostic 60/60 times, with 0 timeouts, 0 zero-exits, and 39ms average runtime.
- Four consecutive full-suite runs had 0 failures of the previously flaky test.