### PR TITLE
fix: stop container boot crash from eager transformers/sharp load (vector off by default)

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+// Regression guard for the container-boot crash: `@huggingface/transformers`
+// eagerly `import sharp`s at module-evaluation time, and the memory plugin
+// (which imports the embedder transitively) is always loaded with
+// `vector.enabled` defaulting to false. If embedder.ts ever goes back to a
+// top-level `import { env, pipeline } from '@huggingface/transformers'`, the
+// transformers module would evaluate the moment embedder.ts is imported —
+// dragging sharp onto every boot and crashing the container. This test proves
+// the import is deferred to first embed.
+let transformersEvaluated = false
+
+mock.module('@huggingface/transformers', () => {
+  transformersEvaluated = true
+  return {
+    env: {},
+    pipeline: async () => {
+      const extractor = () => ({ data: new Float32Array(768) })
+      return extractor
+    },
+  }
+})
+
+describe('embedder lazy transformers load', () => {
+  test('importing the embedder module does NOT evaluate @huggingface/transformers', async () => {
+    await import('./embedder')
+    expect(transformersEvaluated).toBe(false)
+  })
+
+  test('@huggingface/transformers is evaluated only when an embedding is actually requested', async () => {
+    const { getEmbedder } = await import('./embedder')
+    expect(transformersEvaluated).toBe(false)
+
+    await getEmbedder()
+    expect(transformersEvaluated).toBe(true)
+  })
+})

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -1,6 +1,10 @@
 import { join } from 'node:path'
 
-import { env as transformersEnv, pipeline } from '@huggingface/transformers'
+// Type-only import: erased at runtime, so it does NOT evaluate
+// @huggingface/transformers (which eagerly `import sharp`s, crashing the
+// container at startup when sharp's linux binary is missing). The runtime
+// values are pulled lazily via `loadTransformers()` below.
+import type { env as TransformersEnvValue, pipeline as TransformersPipeline } from '@huggingface/transformers'
 
 import { homeRoot } from '../../../hostd/paths'
 
@@ -9,13 +13,31 @@ export const DIMS = 768
 
 export type EmbedType = 'query' | 'passage'
 
-type FeatureExtractor = Awaited<ReturnType<typeof pipeline<'feature-extraction'>>>
+type TransformersEnv = typeof TransformersEnvValue
+type FeatureExtractor = Awaited<ReturnType<typeof TransformersPipeline<'feature-extraction'>>>
+
+// Defer the transformers (and thus sharp/onnxruntime) module load until an
+// embedding is actually requested. typeclaw's memory plugin is always loaded
+// and `vector.enabled` defaults to false, so a top-level static import would
+// drag the heavy native stack onto every container boot — and crash it when
+// sharp can't resolve its platform binary. Memoized so the module evaluates
+// at most once.
+let transformersModulePromise: Promise<{ env: TransformersEnv; pipeline: typeof TransformersPipeline }> | undefined
+
+function loadTransformers(): Promise<{ env: TransformersEnv; pipeline: typeof TransformersPipeline }> {
+  transformersModulePromise ??= import('@huggingface/transformers').then((mod) => ({
+    env: mod.env,
+    pipeline: mod.pipeline,
+  }))
+  return transformersModulePromise
+}
 
 export class Embedder {
   private constructor(private readonly extractor: FeatureExtractor) {}
 
   static async load(): Promise<Embedder> {
-    configureTransformers()
+    const { env, pipeline } = await loadTransformers()
+    configureTransformers(env)
     const extractor = await pipeline('feature-extraction', MODEL_NAME, { local_files_only: true })
     return new Embedder(extractor)
   }
@@ -39,9 +61,9 @@ export async function embed(texts: string[], type: EmbedType): Promise<Float32Ar
   return (await getEmbedder()).embed(texts, type)
 }
 
-function configureTransformers(): void {
-  transformersEnv.localModelPath = modelCachePath()
-  transformersEnv.allowRemoteModels = false
+function configureTransformers(env: TransformersEnv): void {
+  env.localModelPath = modelCachePath()
+  env.allowRemoteModels = false
 }
 
 function modelCachePath(): string {

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -945,6 +945,46 @@ describe('cjkFonts toggle', () => {
   })
 })
 
+describe('transformers native-deps layer (sharp + onnxruntime linux binaries)', () => {
+  test('inline (dev) form installs @huggingface/transformers plus sharp and its arch-matched linux platform packages — without the explicit @img/sharp-linux-* install the container crashes at startup with "Could not load the sharp module using the linux-<arch> runtime", because the bind-mounted host node_modules carries macOS sharp binaries', () => {
+    const out = buildDockerfile()
+    expect(out).toContain('bun add')
+    expect(out).toContain('@huggingface/transformers')
+    expect(out).toContain('sharp@0.34.5')
+    expect(out).toContain('"@img/sharp-linux-${SHARP_ARCH}@0.34.5"')
+    expect(out).toContain('"@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4"')
+  })
+
+  test('layer resolves SHARP_ARCH from $TARGETARCH (arm64 -> arm64, else x64) with an amd64 fallback so a bare `docker build` without buildx stays deterministic', () => {
+    const out = buildDockerfile()
+    expect(out).toContain('SHARP_ARCH="$(if [ "${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)"')
+  })
+
+  test('versioned (base-image) form installs the same native-deps set — drift guard so GHCR-base agents whose base image predates this fix still get linux sharp binaries seeded by the per-agent layer', () => {
+    const out = buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' })
+    expect(out).toContain('@huggingface/transformers')
+    expect(out).toContain('sharp@0.34.5')
+    expect(out).toContain('"@img/sharp-linux-${SHARP_ARCH}@0.34.5"')
+    expect(out).toContain('"@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4"')
+  })
+
+  test('base Dockerfile installs the native-deps layer too — future base images are self-contained so a fresh GHCR-base agent does not depend on the per-agent layer to avoid the sharp crash', () => {
+    const out = buildBaseDockerfile()
+    expect(out).toContain('@huggingface/transformers')
+    expect(out).toContain('sharp@0.34.5')
+    expect(out).toContain('"@img/sharp-linux-${SHARP_ARCH}@0.34.5"')
+    expect(out).toContain('"@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4"')
+  })
+
+  test('sharp and its libvips platform package are pinned to the same versions @huggingface/transformers@^4.2.0 resolves (0.34.5 / 1.2.4) — mismatched sharp/libvips platform packages are a known load-time failure mode', () => {
+    const out = buildDockerfile()
+    const sharpVersions = out.match(/@img\/sharp-linux-\$\{SHARP_ARCH\}@(\S+?)"/)
+    const libvipsVersions = out.match(/@img\/sharp-libvips-linux-\$\{SHARP_ARCH\}@(\S+?)"/)
+    expect(sharpVersions?.[1]).toBe('0.34.5')
+    expect(libvipsVersions?.[1]).toBe('1.2.4')
+  })
+})
+
 describe('curl-impersonate layer', () => {
   test('embeds the pinned version in the release URL — bumping a constant is a deliberate, reviewable change, not a moving "latest" target', () => {
     const out = buildDockerfile()

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -574,13 +574,42 @@ RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
  && chmod +x ${TYPECLAW_ENTRYPOINT_PATH}`
 }
 
-// Layer 7: install @huggingface/transformers with linux-native onnxruntime binary.
-// The host node_modules may carry a macOS binary via the bind mount; this layer
-// ensures the linux onnxruntime-node addon is present in the container's bun cache.
-const LAYER_TRANSFORMERS_INSTALL = `# Layer 7: install @huggingface/transformers with linux-native onnxruntime binary.
-# The host node_modules may carry a macOS binary via the bind mount; this layer
-# ensures the linux onnxruntime-node addon is present in the container's bun cache.
-RUN bun add @huggingface/transformers`
+// Layer 7: install @huggingface/transformers with its linux-native binaries.
+//
+// The host node_modules is bind-mounted over /agent at runtime carrying
+// whatever binaries the host (typically macOS) resolved, so this layer seeds
+// the container's bun install cache with the LINUX binaries that win at
+// runtime. Two native-dep mechanisms, fixed differently:
+//
+//   1. onnxruntime-node ships its addon via a POSTINSTALL that materializes the
+//      binary inside the package dir, so a plain `bun add` covers it.
+//   2. sharp resolves its native code from SEPARATE `@img/sharp-*` optional
+//      PACKAGES, not a postinstall addon. sharp is a MANDATORY dep of
+//      transformers, loaded eagerly because the package main chains
+//      transformers.js -> utils/image.js (top-level `import sharp`) even though
+//      typeclaw only does text feature-extraction. `bun add
+//      @huggingface/transformers` alone does NOT pull the linux `@img/*` when
+//      the bind-mounted host tree already satisfies sharp with the macOS ones —
+//      so `sharp.js` throws at import ("Could not load the sharp module using
+//      the linux-<arch> runtime") and the container exits at startup. We
+//      install the arch-matched linux platform packages EXPLICITLY to fix it.
+//
+// Versions are pinned to what @huggingface/transformers@^4.2.0 resolves today.
+// A future transformers bump that moves sharp must bump `sharp@`,
+// `@img/sharp-linux-*`, and `@img/sharp-libvips-linux-*` together — mismatched
+// sharp/libvips platform packages are a known failure mode. `$TARGETARCH` is
+// `arm64` or `amd64`; an empty value (bare `docker build` without buildx) falls
+// back to x64 for determinism.
+const LAYER_TRANSFORMERS_INSTALL = `# Layer 7: install @huggingface/transformers with its linux-native binaries.
+# Seeds the container's bun cache with the linux onnxruntime-node addon AND
+# sharp's linux platform packages (@img/sharp-linux-*) so both resolve past the
+# bind-mounted host node_modules. See src/init/dockerfile.ts for the rationale.
+RUN SHARP_ARCH="$(if [ "\${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)" \\
+ && bun add \\
+      @huggingface/transformers \\
+      sharp@0.34.5 \\
+      "@img/sharp-linux-\${SHARP_ARCH}@0.34.5" \\
+      "@img/sharp-libvips-linux-\${SHARP_ARCH}@1.2.4"`
 
 // Claude Code's official installer is `curl | bash`, not apt — can't live
 // in APT_FEATURES. Layer placed after the toggle apt install (so curl + ca-
@@ -1389,6 +1418,8 @@ ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 ${LAYER_5_CHROME_FOR_TESTING}
 
 ${renderEntrypointShimLayer()}
+
+${LAYER_TRANSFORMERS_INSTALL}
 `
 }
 


### PR DESCRIPTION
## TL;DR

A container crashed at startup on `typeclaw start` with a `sharp` native-module load error — **even with vector memory disabled (the default)**. This PR ships **two complementary fixes**:

1. **Lazy-load** `@huggingface/transformers` so it (and `sharp`/`onnxruntime`) are never loaded on the boot path when vector is off — the actual cause of the reported crash.
2. **Dockerfile**: install `sharp`'s linux platform binaries so `sharp` is loadable when vector **is** enabled on linux.

Both are needed. Fix 1 covers the vector-OFF (default) case; fix 2 covers the vector-ON case.

---

## The crash

```
error: Could not load the "sharp" module using the linux-arm64 runtime
  at node_modules/sharp/lib/sharp.js:120:13
  at node_modules/sharp/lib/constructor.js:8:7
  at node_modules/sharp/lib/index.js:6:7
```

The vector-memory work added `@huggingface/transformers`, which declares `sharp` as a **mandatory** dependency. transformers' package main chains `transformers.js` → `utils/image.js`, which does a **top-level `import sharp from 'sharp'`** — so `sharp` loads **eagerly at module-evaluation time** the moment transformers is imported, even though typeclaw only does text feature-extraction and never touches images.

## Root cause: eager import on the boot path (even with vector off)

`vector.enabled` defaults to **`false`**, yet the container still crashed — because transformers was imported **statically (top-level)** on the boot path, *before* any config check:

- `src/run/index.ts` statically imported `buildStartupVectorIndex` (→ embedder → transformers → `import sharp`). The *call* was gated by `isStartupVectorIndexEnabled()`, but the **import** was not.
- `src/bundled-plugins/memory/index.ts` (the always-loaded memory plugin) statically imported `hybridSearch` (→ embedder → transformers → sharp). The *usage* was gated by `if (ctx.config.vector.enabled)`, but the **import** was not.

So a default container dragged the heavy native stack onto every boot and crashed when `sharp` couldn't resolve its platform binary.

## Fix 1 — lazy-load transformers (`fix(memory)`)

Push the dynamic import **down into `src/bundled-plugins/memory/vector/embedder.ts`** — the single leaf module that touches `@huggingface/transformers`:

- Keep a **type-only** import (`import type { env, pipeline } from '@huggingface/transformers'`, erased at runtime) for the `FeatureExtractor` type.
- Pull the runtime `env`/`pipeline` values via a **memoized function-local `await import('@huggingface/transformers')`** inside the lazy `Embedder.load()` path.
- `configureTransformers(env)` now takes the env object instead of closing over a top-level import.

No call-site changes: `hybrid.ts`, `startup.ts`, and `hostd/models.ts` keep normal static imports of `./embedder`, which is now transformers-free at module-eval time. Fixing the single leaf also protects against a future maintainer adding another static importer of `hybrid`/`startup`.

When vector **is** enabled, the startup pre-warm (`buildStartupVectorIndex`) still loads transformers at boot as before — warm-path behavior preserved.

New regression test `src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts` mocks `@huggingface/transformers` with a factory that records evaluation, proves importing `./embedder` does NOT evaluate transformers, and that `getEmbedder()` does. Verified it fails against a static-import variant (genuinely guards the invariant).

## Fix 2 — install sharp's linux binaries (`fix(init)`)

For the vector-ON case, `sharp` must actually load on linux. Install `sharp` and its arch-matched linux platform packages explicitly in the native-deps layer, arch-conditioned on `$TARGETARCH`:

```dockerfile
RUN SHARP_ARCH="$(if [ "${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)" \
 && bun add \
      @huggingface/transformers \
      sharp@0.34.5 \
      "@img/sharp-linux-${SHARP_ARCH}@0.34.5" \
      "@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4"
```

`sharp` resolves its native code from separate `@img/sharp-*` optional packages (not a postinstall addon like `onnxruntime-node`). The prior `bun add @huggingface/transformers` seeded the linux onnxruntime addon but not sharp's linux `@img/*`, because the bind-mounted host `node_modules` already satisfied sharp with the **macOS** binaries. Versions pinned to what `transformers@^4.2.0` resolves (`sharp 0.34.5`, `libvips 1.2.4`); `$TARGETARCH` empty falls back to `x64`. Applied across all three Dockerfile paths (inline/dev, versioned/base-image, and `buildBaseDockerfile` — previously lacked this layer entirely).

5 new drift-guard tests in `src/init/dockerfile.test.ts` assert the native-deps install in all three forms, the `$TARGETARCH` → `SHARP_ARCH` conditional, and that sharp/libvips versions stay pinned together.

## Checks

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (67 pre-existing warnings, unrelated)
- `bun run format:check` — clean
- `bun run test` — 8709 pass, 0 fail (incl. 5 Dockerfile drift-guard tests + 2 lazy-load tests)

## Follow-up note

Whenever `@huggingface/transformers` bumps `sharp`, bump `sharp@`, `@img/sharp-linux-*`, and `@img/sharp-libvips-linux-*` together — mismatched sharp/libvips platform packages are a known load-time failure mode (called out in the layer comment and guarded by a test).
