### PR TITLE
Skip vector model download when opted out

### DIFF
--- a/src/bundled-plugins/memory/vector/config.test.ts
+++ b/src/bundled-plugins/memory/vector/config.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'bun:test'
+import { afterEach, beforeEach, describe, it, expect } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { vectorConfigSchema } from './config'
+import { agentUsesVector, vectorConfigSchema } from './config'
 
 describe('vectorConfigSchema', () => {
   it('QA 1.1: no memory.vector block → enabled === false', () => {
@@ -23,5 +26,55 @@ describe('vectorConfigSchema', () => {
 
     // Then: enabled is true
     expect(result.enabled).toBe(true)
+  })
+})
+
+describe('agentUsesVector', () => {
+  let dir: string
+
+  async function writeConfig(value: unknown): Promise<void> {
+    await writeFile(join(dir, 'typeclaw.json'), JSON.stringify(value))
+  }
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'typeclaw-vector-config-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('returns true when memory.vector.enabled is true', async () => {
+    await writeConfig({ memory: { vector: { enabled: true } } })
+    expect(agentUsesVector(dir)).toBe(true)
+  })
+
+  it('returns false when memory.vector.enabled is false', async () => {
+    await writeConfig({ memory: { vector: { enabled: false } } })
+    expect(agentUsesVector(dir)).toBe(false)
+  })
+
+  it('returns false when the memory.vector block is absent', async () => {
+    await writeConfig({ memory: {} })
+    expect(agentUsesVector(dir)).toBe(false)
+  })
+
+  it('returns false when the memory block is absent', async () => {
+    await writeConfig({ models: { default: 'x' } })
+    expect(agentUsesVector(dir)).toBe(false)
+  })
+
+  it('fails closed to false when typeclaw.json is missing', () => {
+    expect(agentUsesVector(dir)).toBe(false)
+  })
+
+  it('fails closed to false when typeclaw.json is malformed JSON', async () => {
+    await writeFile(join(dir, 'typeclaw.json'), '{ not json')
+    expect(agentUsesVector(dir)).toBe(false)
+  })
+
+  it('fails closed to false when memory.vector.enabled has a non-boolean type', async () => {
+    await writeConfig({ memory: { vector: { enabled: 'yes' } } })
+    expect(agentUsesVector(dir)).toBe(false)
   })
 })

--- a/src/bundled-plugins/memory/vector/config.ts
+++ b/src/bundled-plugins/memory/vector/config.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { loadPluginConfigsSync } from '@/config'
+
 export const vectorConfigSchema = z
   .object({
     enabled: z.boolean().default(false),
@@ -7,3 +9,17 @@ export const vectorConfigSchema = z
   .default({ enabled: false })
 
 export type VectorConfig = z.infer<typeof vectorConfigSchema>
+
+// Fails closed to `false`: a config we can't read/parse is treated as opted out,
+// so the ~1.4 GB model download never fires for an agent we can't prove wants
+// it. The container-side index build is the fail-loud gate if it's truly needed.
+export function agentUsesVector(cwd: string): boolean {
+  try {
+    const memory = loadPluginConfigsSync(cwd).memory
+    if (typeof memory !== 'object' || memory === null) return false
+    const parsed = vectorConfigSchema.safeParse((memory as Record<string, unknown>).vector)
+    return parsed.success && parsed.data.enabled
+  } catch {
+    return false
+  }
+}

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -165,8 +165,6 @@ function formatLog(event: DaemonLogEvent | SupervisorLogEvent): string {
       return `[hostd] HTTP control listening on ${event.host}:${event.port}`
     case 'daemon-http-port-fallback':
       return `[hostd] HTTP preferred port ${event.preferred} busy; fell back to ${event.actual} (containers started on ${event.preferred} will see stale TYPECLAW_HOSTD_URL until restarted)`
-    case 'daemon-model-provision-warning':
-      return `[hostd] warning: model provisioning failed: ${event.reason}`
     case 'daemon-stopping':
       return `[hostd] stopping`
     case 'shutdown-requested':

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -94,6 +94,7 @@ type ScaffoldedConfig = {
   git?: { ignore?: GitignoreBlock }
   network?: { blockInternal?: boolean; autoAllowResolvers?: boolean; allow?: string[] }
   sandbox?: { realProc?: boolean; writablePaths?: string[]; symlinks?: Array<{ from: string; to: string }> }
+  memory?: { vector?: { enabled?: boolean } }
 }
 
 async function writeTypeclawConfig(dir: string, overrides: ScaffoldedConfig = {}): Promise<void> {
@@ -105,6 +106,7 @@ async function writeTypeclawConfig(dir: string, overrides: ScaffoldedConfig = {}
     ...(overrides.git ? { git: overrides.git } : {}),
     ...(overrides.network ? { network: overrides.network } : {}),
     ...(overrides.sandbox ? { sandbox: overrides.sandbox } : {}),
+    ...(overrides.memory ? { memory: overrides.memory } : {}),
   }
   await writeFile(join(dir, 'typeclaw.json'), `${JSON.stringify(config, null, 2)}\n`)
 }
@@ -494,19 +496,23 @@ describe('planStart mounts', () => {
 })
 
 describe('planStart model mount', () => {
-  test('adds shared model cache mount at /opt/models:ro', async () => {
+  const modelsMount = `${process.env.HOME}/.typeclaw/models:/opt/models:ro`
+
+  test('adds shared model cache mount at /opt/models:ro when memory.vector.enabled', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root, { memory: { vector: { enabled: true } } })
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
     expect(plan.runArgs).toContain('-v')
-    expect(plan.runArgs).toContain(`${process.env.HOME}/.typeclaw/models:/opt/models:ro`)
+    expect(plan.runArgs).toContain(modelsMount)
   })
 
-  test('sets TYPECLAW_MODEL_CACHE env var to /opt/models', async () => {
+  test('sets TYPECLAW_MODEL_CACHE env var to /opt/models when memory.vector.enabled', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root, { memory: { vector: { enabled: true } } })
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
@@ -517,13 +523,46 @@ describe('planStart model mount', () => {
   test('model mount appears before imageTag (last positional arg)', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root, { memory: { vector: { enabled: true } } })
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
     expect(plan.runArgs.at(-1)).toBe(plan.imageTag)
-    const mountIdx = plan.runArgs.indexOf(`${process.env.HOME}/.typeclaw/models:/opt/models:ro`)
+    const mountIdx = plan.runArgs.indexOf(modelsMount)
     expect(mountIdx).toBeGreaterThan(-1)
     expect(mountIdx).toBeLessThan(plan.runArgs.length - 1)
+  })
+
+  test('omits model cache mount and TYPECLAW_MODEL_CACHE when vector is opted out', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root, { memory: { vector: { enabled: false } } })
+
+    const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+    expect(plan.runArgs).not.toContain(modelsMount)
+    expect(plan.runArgs).not.toContain('TYPECLAW_MODEL_CACHE=/opt/models')
+  })
+
+  test('omits model cache mount when memory.vector block is absent (default opt-out)', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+
+    const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+    expect(plan.runArgs).not.toContain(modelsMount)
+    expect(plan.runArgs).not.toContain('TYPECLAW_MODEL_CACHE=/opt/models')
+  })
+
+  test('omits model cache mount when typeclaw.json is missing entirely', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+
+    const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+    expect(plan.runArgs).not.toContain(modelsMount)
+    expect(plan.runArgs).not.toContain('TYPECLAW_MODEL_CACHE=/opt/models')
   })
 })
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -3,10 +3,12 @@ import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { isAbsolute, join, resolve } from 'node:path'
 
+import { agentUsesVector } from '@/bundled-plugins/memory/vector/config'
 import { expandMountPath, loadConfigSync, withDefaultPlugins, type Config } from '@/config'
 import { commitGitignoreWithUntracks, untrackTrulyIgnoredFiles } from '@/git/reconcile-ignored'
 import { commitSystemFile as commitSystemFileShared } from '@/git/system-commit'
 import { send as sendToDaemon } from '@/hostd/client'
+import { ensureModels } from '@/hostd/models'
 import { homeRoot } from '@/hostd/paths'
 import type { HttpInfoResult } from '@/hostd/protocol'
 import { ensureDaemon } from '@/hostd/spawn'
@@ -287,6 +289,20 @@ export async function start({
     // container will actually load.
     const dockerfileRefresh = await refreshDockerfile(cwd)
 
+    // Provision the embedding model only when THIS agent opts into vector. The
+    // container embedder runs with local_files_only, so the model must already
+    // be on the host's ~/.typeclaw/models cache before the container boots —
+    // otherwise the startup vector index build fails. Kick the download off here
+    // (idempotent + file-locked) so it overlaps the docker build, then await it
+    // just before `docker run`. A vector-opted-out agent never reaches this, so
+    // a host whose containers are all opted out never downloads the ~1.4 GB
+    // model — including every agent under `typeclaw compose`, since each agent's
+    // start() makes this decision independently. The `.catch` swallow only keeps
+    // an early return between here and the await from logging an unhandled
+    // rejection; the real error is surfaced when we await at the run site below.
+    const modelsReady = agentUsesVector(cwd) ? ensureModels() : null
+    modelsReady?.catch(() => {})
+
     if (state.exists) {
       // Container holds the name but is not running. Without `--rm`, this is
       // now the normal post-stop / post-crash state: the corpse stays around
@@ -369,6 +385,18 @@ export async function start({
         return { ok: false, reason: 'docker build failed' }
       }
       built = true
+    }
+
+    if (modelsReady) {
+      try {
+        await modelsReady
+      } catch (error) {
+        await cleanupHostDaemonRegistration(containerName, hostd)
+        return {
+          ok: false,
+          reason: `embedding model provisioning failed (memory.vector.enabled): ${error instanceof Error ? error.message : String(error)}`,
+        }
+      }
     }
 
     let run = await execRunWithConflictRetry(exec, plan.runArgs, cwd, containerName)
@@ -624,9 +652,15 @@ export async function planStart({
     runArgs.push('-v', mount.readOnly ? `${hostPath}:${target}:ro` : `${hostPath}:${target}`)
   }
 
-  // Shared model cache mount for embeddings and other ML models
-  runArgs.push('-v', `${homeRoot()}/models:/opt/models:ro`)
-  runArgs.push('-e', 'TYPECLAW_MODEL_CACHE=/opt/models')
+  // Shared model cache mount for embeddings. Gated on vector opt-in: a
+  // vector-opted-out container has no embedder to feed, and the host never
+  // populates ~/.typeclaw/models for it (see ensureModels gating in start()),
+  // so mounting an empty cache would only invite a confusing local_files_only
+  // miss if something inside the container reached for the model anyway.
+  if (agentUsesVector(cwd)) {
+    runArgs.push('-v', `${homeRoot()}/models:/opt/models:ro`)
+    runArgs.push('-e', 'TYPECLAW_MODEL_CACHE=/opt/models')
+  }
 
   runArgs.push(imageTag)
 

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -12,7 +12,6 @@ import { SecretsBackend } from '@/secrets/storage'
 
 import { isDaemonReachable } from './client'
 import type { KakaoRenewalCallbacks, KakaoRenewalLogEvent } from './kakao-renewal-manager'
-import { ensureModels } from './models'
 import { ensureDirs, registrationFilePath, registrationsDir, socketPath } from './paths'
 import type {
   HttpInfoResult,
@@ -61,7 +60,6 @@ export type DaemonOptions = {
   // deregister. Omit to disable in tests / when the agent has no kakaotalk
   // channel configured.
   kakaoRenewal?: KakaoRenewalCallbacks
-  provisionModels?: boolean
 }
 
 export type RestartPreflight = (input: {
@@ -96,7 +94,6 @@ export type DaemonLogEvent =
   | { kind: 'daemon-listening'; socket: string }
   | { kind: 'daemon-http-listening'; host: string; port: number }
   | { kind: 'daemon-http-port-fallback'; preferred: number; actual: number }
-  | { kind: 'daemon-model-provision-warning'; reason: string }
   | { kind: 'daemon-stopping' }
   | { kind: 'register'; containerName: string }
   | { kind: 'deregister'; containerName: string; reason: 'requested' | 'gone' }
@@ -225,11 +222,6 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
 
   const log = opts.onLog ?? (() => {})
-  if (opts.provisionModels ?? process.env.NODE_ENV !== 'test') {
-    void ensureModels().catch((error: unknown) => {
-      log({ kind: 'daemon-model-provision-warning', reason: stringifyError(error) })
-    })
-  }
   const exec = opts.exec ?? defaultDockerExec
   const gcIntervalMs = opts.gcIntervalMs ?? DEFAULT_GC_INTERVAL_MS
   const gcMissesToDeregister = opts.gcMissesToDeregister ?? DEFAULT_GC_MISSES_TO_DEREGISTER


### PR DESCRIPTION
## Background

The host daemon downloaded the ~1.4 GB embedding model into the TypeClaw model cache unconditionally at boot, even when no container on the host would ever use it. The model is `Xenova/multilingual-e5-base`.

`memory.vector.enabled` defaults to false, so the common all-opted-out case still paid the full download.

The root cause is that the daemon is a singleton shared across all agents and starts before any agent registers. It starts through `ensureDaemon()`.

When startDaemon fired model provisioning, it had no per-agent config to consult and was gated only on the test environment.

This was most visible under `typeclaw compose`, where a folder of agents with vector disabled still triggered the 1.4 GB pull on first daemon boot.

## Summary

Move model provisioning out of daemon boot and into the host-side per-agent start path, gated on that agent's own vector setting.

- `agentUsesVector(cwd)` reads the agent's host-stage config and fails closed.
- If the config cannot be read or parsed, the agent counts as opted out, so TypeClaw never downloads the model for an agent it cannot prove wants vector memory.
- `start()` calls model provisioning only when the agent opts in.
- Each agent start decides independently, so a host whose containers are all opted out never downloads the model, including compose starts.
- The container embedder runs with `local_files_only`, so the model must be in the host cache before the container boots.
- Start kicks off provisioning right after the Dockerfile refresh so it can overlap the Docker build.
- It then awaits provisioning just before `docker run` and fails the start with a clear reason if provisioning fails.
- The shared model-cache volume mount in `planStart()` is also gated on opt-in, so opted-out containers do not mount an empty cache.

This keeps the decision at the host-side per-agent start boundary rather than teaching the daemon about agents. The daemon has no agent context at boot; start already runs host-side on the same filesystem as the TypeClaw model cache, runs once per agent, and model provisioning is idempotent, promise-deduped, and file-locked, so concurrent compose starts remain safe.

## What this does NOT do

- Does not remove the transformers dependency from the container Dockerfile. Enabling vector is restart-required and goes through `start()`, which now provisions the model on that restart, so the dependency must stay available for a later opt-in.
- Does not change the container-side embedder, the startup vector index build, or model provisioning itself.
- Does not touch directory creation. The empty TypeClaw model cache directory remains cheap to create and keeps the mount path valid when vector is opted in.

## Review notes

- Load-bearing change: start must await `modelsReady` before Docker runs the container. If that await moves after the run, an opted-in container can boot before the model lands and the startup index build can fail because the embedder uses local-files-only mode.
- The catch handler right after kickoff is intentional. It suppresses an unhandled-rejection warning only if an early return happens between kickoff and the await; the real error is still surfaced at the await site.
- The now-dead daemon model-provisioning option and warning log event were removed, including the formatter case in the hostd CLI formatter.
- Tests cover enabled, disabled, absent, missing-file, malformed, and non-boolean vector opt-in inputs.
- Model-mount tests now assert the mount is present only when opted in and absent otherwise.
- Pre-commit checks pass: typecheck, lint, format:check, and the full test suite with 8721 pass, 0 fail, and 1 skip.