### PR TITLE
fix(init): install sharp linux binaries to /node_modules so they survive the /agent bind mount

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -983,6 +983,35 @@ describe('transformers native-deps layer (sharp + onnxruntime linux binaries)', 
     expect(sharpVersions?.[1]).toBe('0.34.5')
     expect(libvipsVersions?.[1]).toBe('1.2.4')
   })
+
+  // Regression guard for the bind-mount masking failure. `typeclaw start`
+  // bind-mounts the host agent folder over /agent at runtime, so a `bun add`
+  // run under WORKDIR /agent populates /agent/node_modules — which is hidden
+  // behind the mount at runtime, so the linux sharp binaries never resolve and
+  // the container crashes ("Could not load the sharp module"). The install MUST
+  // run from WORKDIR / (landing in the unmasked /node_modules) and then restore
+  // WORKDIR /agent. These tests fail if either WORKDIR is dropped.
+  for (const [label, render] of [
+    ['inline (dev)', () => buildDockerfile()],
+    ['versioned (base-image)', () => buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' })],
+    ['base', () => buildBaseDockerfile()],
+  ] as const) {
+    test(`${label} form installs the native deps from / (unmasked by the /agent bind mount) and restores WORKDIR /agent`, () => {
+      const out = render()
+      const installIdx = out.indexOf('@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4')
+      expect(installIdx).toBeGreaterThan(-1)
+
+      const beforeInstall = out.slice(0, installIdx)
+      const afterInstall = out.slice(installIdx)
+
+      // WORKDIR / must immediately precede the install (no intervening WORKDIR).
+      const lastWorkdirBefore = beforeInstall.lastIndexOf('\nWORKDIR ')
+      expect(beforeInstall.slice(lastWorkdirBefore)).toContain('\nWORKDIR /\n')
+
+      // WORKDIR /agent must be restored right after the install.
+      expect(afterInstall).toContain('\nWORKDIR /agent')
+    })
+  }
 })
 
 describe('curl-impersonate layer', () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -578,8 +578,8 @@ RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
 //
 // The host node_modules is bind-mounted over /agent at runtime carrying
 // whatever binaries the host (typically macOS) resolved, so this layer seeds
-// the container's bun install cache with the LINUX binaries that win at
-// runtime. Two native-dep mechanisms, fixed differently:
+// LINUX binaries into an image path that survives the bind mount and still
+// wins Node/Bun resolution. Two native-dep mechanisms, fixed differently:
 //
 //   1. onnxruntime-node ships its addon via a POSTINSTALL that materializes the
 //      binary inside the package dir, so a plain `bun add` covers it.
@@ -594,6 +594,18 @@ RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
 //      the linux-<arch> runtime") and the container exits at startup. We
 //      install the arch-matched linux platform packages EXPLICITLY to fix it.
 //
+// CRITICAL — install location. `typeclaw start` bind-mounts the host agent
+// folder over /agent at runtime (`-v <cwd>:/agent`), so anything written under
+// /agent/node_modules at BUILD time is MASKED at runtime and can never win.
+// The prior fix ran this `bun add` under `WORKDIR /agent`, populating
+// /agent/node_modules — invisible behind the bind mount, so the sharp crash
+// persisted. We install from `WORKDIR /` instead: the linux packages land in
+// the IMAGE's /node_modules, which is NOT masked by the /agent mount. Node/Bun
+// resolution for `require('@img/sharp-linux-<arch>')` ascends from
+// /agent/node_modules/sharp up the directory chain and finds /node_modules,
+// so the linux binary resolves. WORKDIR is restored to /agent afterwards so
+// later layers and the runtime CWD are unchanged.
+//
 // Versions are pinned to what @huggingface/transformers@^4.2.0 resolves today.
 // A future transformers bump that moves sharp must bump `sharp@`,
 // `@img/sharp-linux-*`, and `@img/sharp-libvips-linux-*` together — mismatched
@@ -601,15 +613,18 @@ RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
 // `arm64` or `amd64`; an empty value (bare `docker build` without buildx) falls
 // back to x64 for determinism.
 const LAYER_TRANSFORMERS_INSTALL = `# Layer 7: install @huggingface/transformers with its linux-native binaries.
-# Seeds the container's bun cache with the linux onnxruntime-node addon AND
-# sharp's linux platform packages (@img/sharp-linux-*) so both resolve past the
-# bind-mounted host node_modules. See src/init/dockerfile.ts for the rationale.
+# Installs the linux onnxruntime-node addon AND sharp's linux platform packages
+# (@img/sharp-linux-*) into the image's /node_modules so they survive the
+# runtime /agent bind mount and still win Node/Bun resolution from
+# /agent/node_modules/sharp. See src/init/dockerfile.ts for the rationale.
+WORKDIR /
 RUN SHARP_ARCH="$(if [ "\${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)" \\
  && bun add \\
       @huggingface/transformers \\
       sharp@0.34.5 \\
       "@img/sharp-linux-\${SHARP_ARCH}@0.34.5" \\
-      "@img/sharp-libvips-linux-\${SHARP_ARCH}@1.2.4"`
+      "@img/sharp-libvips-linux-\${SHARP_ARCH}@1.2.4"
+WORKDIR /agent`
 
 // Claude Code's official installer is `curl | bash`, not apt — can't live
 // in APT_FEATURES. Layer placed after the toggle apt install (so curl + ca-


### PR DESCRIPTION
## Background

A vector-memory–enabled agent crashes at container startup:

```
[vector] startup index build failed: Could not load the "sharp" module using the linux-arm64 runtime
```

`@huggingface/transformers` (a prod dependency) eagerly `import sharp` through its
`transformers.js → utils/image.js` chain, even though typeclaw only does text
feature-extraction. `sharp` resolves its native code from separate
`@img/sharp-linux-<arch>` optional packages — not a postinstall addon — so the
linux binary must be physically present at a path Node/Bun resolution will find.

The prior fix (#802 / `c32c9a37`) installed those packages, but with the
Dockerfile's `WORKDIR` at `/agent`, so they landed in `/agent/node_modules`.
At runtime `typeclaw start` bind-mounts the host agent folder over `/agent`
(`-v <cwd>:/agent`), which **masks the entire build-time install**. The host's
macOS `@img/sharp-darwin-*` binaries win and the linux ones are never visible —
so the fix could never take effect, and the crash persisted on arm64 hosts.

`$TARGETARCH` was a red herring: BuildKit-backed `docker build` populates it
correctly on native arm64. The bug is purely *where* the packages were written.

## Summary

Install the native deps from `WORKDIR /` instead of `/agent`, so they
materialize in the image's `/node_modules`, which is **not** masked by the
`/agent` bind mount. Node/Bun resolution for `require('@img/sharp-linux-<arch>')`
ascends from `/agent/node_modules/sharp` up the directory chain and finds
`/node_modules`. `WORKDIR` is restored to `/agent` immediately after so later
layers and the runtime CWD are unchanged.

Why `/node_modules` and not `/opt/...` + `NODE_PATH`: the root `node_modules`
is a natural ancestor in the standard resolution walk, so no env wiring is
needed and ESM/Bun behavior stays predictable.

Applied to all three Dockerfile assembly paths — inline (dev/test), versioned
(GHCR base-image production), and the base image itself — so dev/prod parity
holds and a fresh base image is self-contained.

## What this does NOT do

- Does not change the package set or pinned versions (`sharp@0.34.5`,
  `@img/sharp-*@0.34.5`, `@img/sharp-libvips-*@1.2.4`).
- Does not add `--platform` / `--build-arg TARGETARCH` to `docker build`; arch
  selection already works.
- Does not pollute the host's macOS `node_modules` with linux binaries.
- Does not touch the runtime resolution / vector code path.

## Review notes

Load-bearing change: the `WORKDIR /` … install … `WORKDIR /agent` sandwich in
`LAYER_TRANSFORMERS_INSTALL`. If either `WORKDIR` is dropped the install falls
back into the masked `/agent/node_modules` and the crash returns. The new
regression tests assert this sandwich across all three branches.

Verified: `bun run typecheck` clean, `bun run lint` 0 errors (67 pre-existing
warnings unchanged), 221 `dockerfile.test.ts` tests pass.
