### PR TITLE
fix(memory/vector): pin embedding model to q8, not fp32 (1.1GB→280MB)

### DIFF
--- a/src/bundled-plugins/memory/vector/config.ts
+++ b/src/bundled-plugins/memory/vector/config.ts
@@ -11,7 +11,7 @@ export const vectorConfigSchema = z
 export type VectorConfig = z.infer<typeof vectorConfigSchema>
 
 // Fails closed to `false`: a config we can't read/parse is treated as opted out,
-// so the ~1.4 GB model download never fires for an agent we can't prove wants
+// so the ~280 MB model download never fires for an agent we can't prove wants
 // it. The container-side index build is the fail-loud gate if it's truly needed.
 export function agentUsesVector(cwd: string): boolean {
   try {

--- a/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
@@ -9,12 +9,14 @@ import { describe, expect, mock, test } from 'bun:test'
 // dragging sharp onto every boot and crashing the container. This test proves
 // the import is deferred to first embed.
 let transformersEvaluated = false
+let lastPipelineOptions: Record<string, unknown> | undefined
 
 mock.module('@huggingface/transformers', () => {
   transformersEvaluated = true
   return {
     env: {},
-    pipeline: async () => {
+    pipeline: async (_task: string, _model: string, options?: Record<string, unknown>) => {
+      lastPipelineOptions = options
       const extractor = () => ({ data: new Float32Array(768) })
       return extractor
     },
@@ -33,5 +35,14 @@ describe('embedder lazy transformers load', () => {
 
     await getEmbedder()
     expect(transformersEvaluated).toBe(true)
+  })
+
+  test('loads the q8 variant locally (dtype pinned, local_files_only preserved)', async () => {
+    const { getEmbedder } = await import('./embedder')
+
+    await getEmbedder()
+
+    expect(lastPipelineOptions?.dtype).toBe('q8')
+    expect(lastPipelineOptions?.local_files_only).toBe(true)
   })
 })

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -10,6 +10,10 @@ import { homeRoot } from '../../../hostd/paths'
 
 export const MODEL_NAME = 'Xenova/multilingual-e5-base'
 export const DIMS = 768
+// MUST match src/hostd/models.ts MODEL_DTYPE: the host downloads exactly this
+// variant, and this loader runs local_files_only, so a mismatch loads nothing.
+// q8 → onnx/model_quantized.onnx (~279 MB); the default would be fp32 (1.11 GB).
+export const MODEL_DTYPE = 'q8'
 
 export type EmbedType = 'query' | 'passage'
 
@@ -38,7 +42,7 @@ export class Embedder {
   static async load(): Promise<Embedder> {
     const { env, pipeline } = await loadTransformers()
     configureTransformers(env)
-    const extractor = await pipeline('feature-extraction', MODEL_NAME, { local_files_only: true })
+    const extractor = await pipeline('feature-extraction', MODEL_NAME, { local_files_only: true, dtype: MODEL_DTYPE })
     return new Embedder(extractor)
   }
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -295,7 +295,7 @@ export async function start({
     // otherwise the startup vector index build fails. Kick the download off here
     // (idempotent + file-locked) so it overlaps the docker build, then await it
     // just before `docker run`. A vector-opted-out agent never reaches this, so
-    // a host whose containers are all opted out never downloads the ~1.4 GB
+    // a host whose containers are all opted out never downloads the ~280 MB
     // model — including every agent under `typeclaw compose`, since each agent's
     // start() makes this decision independently. The `.catch` swallow only keeps
     // an early return between here and the await from logging an unhandled

--- a/src/hostd/ensure-models.test.ts
+++ b/src/hostd/ensure-models.test.ts
@@ -3,13 +3,15 @@ import { mkdir, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const pipelineCalls: string[] = []
+type PipelineCall = { model: string; options: Record<string, unknown> | undefined }
+
+const pipelineCalls: PipelineCall[] = []
 let releasePipeline: (() => void) | null = null
 
 mock.module('@huggingface/transformers', () => ({
   env: {},
-  pipeline: async (_task: string, model: string) => {
-    pipelineCalls.push(model)
+  pipeline: async (_task: string, model: string, options?: Record<string, unknown>) => {
+    pipelineCalls.push({ model, options })
     await new Promise<void>((resolve) => {
       releasePipeline = resolve
     })
@@ -42,8 +44,13 @@ describe('ensureModels', () => {
 
     const { modelsDir } = await import('./paths')
 
-    expect(pipelineCalls).toEqual(['Xenova/multilingual-e5-base'])
+    expect(pipelineCalls.map((call) => call.model)).toEqual(['Xenova/multilingual-e5-base'])
     expect((await stat(modelsDir())).isDirectory()).toBe(true)
+  })
+
+  test('downloads the q8 (quantized) variant, not the fp32 default', async () => {
+    expect(pipelineCalls).toHaveLength(1)
+    expect(pipelineCalls[0]?.options?.dtype).toBe('q8')
   })
 
   test('modelsDir points under TYPECLAW_HOME', async () => {

--- a/src/hostd/models.ts
+++ b/src/hostd/models.ts
@@ -7,6 +7,14 @@ import lockfile from 'proper-lockfile'
 import { modelsDir } from './paths'
 
 const MODEL_NAME = 'Xenova/multilingual-e5-base'
+// q8 → onnx/model_quantized.onnx (~279 MB). Without this, dtype defaults to
+// 'auto', which resolves to fp32 (onnx/model.onnx, 1.11 GB) on CPU/non-WASM
+// devices — 4x the download for no quality gain at this corpus size. The
+// gold-set eval that chose e5-base (recall@3 96.9%) was run on this q8 variant.
+// MUST match the embedder's dtype (src/bundled-plugins/memory/vector/embedder.ts):
+// the host downloads what the container loads with local_files_only, so a
+// mismatch makes the container request a file that was never fetched.
+const MODEL_DTYPE = 'q8'
 const LOCK_RETRIES = { retries: 60, factor: 1, minTimeout: 100, maxTimeout: 100, randomize: false } as const
 
 let ensureModelsPromise: Promise<void> | null = null
@@ -37,7 +45,7 @@ async function ensureModelsLocked(): Promise<void> {
   })
   try {
     configureTransformers(dir)
-    await pipeline('feature-extraction', MODEL_NAME)
+    await pipeline('feature-extraction', MODEL_NAME, { dtype: MODEL_DTYPE })
   } finally {
     await release()
   }


### PR DESCRIPTION
## Background

Transformers.js v3 uses `dtype: 'auto'` when a feature-extraction pipeline omits an explicit dtype. On CPU and non-WASM devices, that resolves to fp32 and downloads the 1.11 GB ONNX model.

TypeClaw host and container stages both run this path on CPU, so vector memory silently fetched the fp32 model even though the vector-memory plan and gold-set evaluation targeted the quantized e5-base variant. That made first-run provisioning roughly 4x larger and used an unevaluated model variant.

## Summary

Pin both embedding pipeline call sites to `dtype: 'q8'`. Transformers.js v3 maps that dtype to the quantized ONNX filename, restoring the intended approximately 279 MB model file while preserving the same 768-dimensional embedding architecture.

The host-side downloader and container-side embedder now each declare a model dtype constant with comments documenting the coupling. The host downloads exactly one variant, while the container uses local-files-only mode, so those dtypes must stay aligned or container startup will request an ONNX file that was never fetched.

The stale model-size comments are also updated from approximately 1.4 GB to approximately 280 MB so the opt-in gating comments match the actual q8 download size.

## Preview

No UI or rendered output changes.

## What this does NOT do

- Does not change vector opt-in gating. Model download is still gated on `agentUsesVector`, so vector-opted-out agents do not change behavior.
- Does not change re-embed semantics. q8 and fp32 are the same architecture and emit 768-dimensional embeddings, and the index remains stamped by dimension and model.
- Does not use the int8 ONNX filename. In Transformers.js v3, q8 maps to the quantized ONNX filename, which is a distinct file and dtype mapping.

## Review notes

- Load-bearing invariant: the host model downloader and vector embedder must keep the same dtype because the host fetches the file the container later loads with local-files-only mode.
- Review the q8 mapping carefully: it relies on the Transformers.js v3 default dtype suffix mapping from q8 to the quantized ONNX filename.
- Verification completed: `bun run typecheck` clean.
- Verification completed: `bun run lint` reports 0 errors, with 67 pre-existing warnings and none in touched files.
- Verification completed: `bun run format:check` clean.
- Verification completed: `bun run test` reports 8731 pass, 0 fail, and 1 pre-existing unrelated bwrap skip.
