### PR TITLE
feat(memory/vector): rebuild index when the embedding variant changes

### DIFF
--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -16,7 +16,7 @@ import {
 } from './dreaming'
 import { addDreamedIds, DREAMING_STATE_FILE, emptyState, getDreamedIds, loadDreamingState } from './dreaming-state'
 import { renderShard } from './frontmatter'
-import { MODEL_NAME } from './vector/embedder'
+import { EMBEDDING_MODEL_ID } from './vector/embedder'
 import type { EmbedFn } from './vector/hybrid'
 import { VectorStore, type VectorRow } from './vector/store'
 
@@ -1046,7 +1046,7 @@ function vectorRow(
   embedding: Float32Array,
   contentHash: string,
 ): Omit<VectorRow, 'updatedAt'> {
-  return { id, source, key, model: MODEL_NAME, dims: embedding.length, embedding, contentHash }
+  return { id, source, key, model: EMBEDDING_MODEL_ID, dims: embedding.length, embedding, contentHash }
 }
 
 function embedRecording(texts: string[]): EmbedFn {

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -26,7 +26,7 @@ import { streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
 import { captureShardSnapshot, restoreShardSnapshot } from './shard-snapshot'
 import type { StreamEvent } from './stream-events'
 import { readEvents, writeEventsAtomic } from './stream-io'
-import { embed, MODEL_NAME } from './vector/embedder'
+import { embed, EMBEDDING_MODEL_ID } from './vector/embedder'
 import type { EmbedFn } from './vector/hybrid'
 import { VectorStore } from './vector/store'
 
@@ -267,7 +267,7 @@ export async function syncTopicVectorsFromSnapshotDiff(
         id: `topic:${slug}`,
         source: 'topic',
         key: slug,
-        model: MODEL_NAME,
+        model: EMBEDDING_MODEL_ID,
         dims: embedding.length,
         embedding,
         contentHash: fragmentContentHash({ topic: shard.frontmatter.heading, body: shard.body }),

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -15,6 +15,12 @@ export const DIMS = 768
 // q8 → onnx/model_quantized.onnx (~279 MB); the default would be fp32 (1.11 GB).
 export const MODEL_DTYPE = 'q8'
 
+// The index identity. dtype changes the embedding values (q8 ≠ fp32) while
+// MODEL_NAME and DIMS stay constant, so neither alone detects a variant switch.
+// Vectors are stamped with this and retrieval filters on it — rows from a
+// different variant are stale and never compared against a query of this one.
+export const EMBEDDING_MODEL_ID = `${MODEL_NAME}@${MODEL_DTYPE}`
+
 export type EmbedType = 'query' | 'passage'
 
 type TransformersEnv = typeof TransformersEnvValue

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -5,10 +5,11 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { renderShard } from '../frontmatter'
+import { EMBEDDING_MODEL_ID } from './embedder'
 import { hybridSearch, type EmbedFn } from './hybrid'
 import { VectorStore, type VectorRow } from './store'
 
-const MODEL = 'test-model'
+const MODEL = EMBEDDING_MODEL_ID
 const testDirs: string[] = []
 
 afterEach(() => {

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -5,7 +5,7 @@ import { loadAllShards, type TopicShard } from '../load-shards'
 import { buildMatcher, searchAll, type MemorySearchMatch, type StreamMatch } from '../search-tool'
 import type { StreamEvent } from '../stream-events'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
-import { embed, MODEL_NAME, type EmbedType } from './embedder'
+import { embed, EMBEDDING_MODEL_ID, type EmbedType } from './embedder'
 import { VectorStore, type VectorRow } from './store'
 
 const RRF_K = 60
@@ -36,7 +36,8 @@ export async function hybridSearch(
   ])
 
   const index = buildContentIndex(shards, streamDays)
-  const vectorRows = queryEmbeddings[0] === undefined ? [] : store.query(queryEmbeddings[0], topK * 2)
+  const vectorRows =
+    queryEmbeddings[0] === undefined ? [] : store.query(queryEmbeddings[0], topK * 2, EMBEDDING_MODEL_ID)
   const keywordMatches = keywordLane(query, shards, streamDays, topK * 2)
 
   return fuseLanes(vectorRows, keywordMatches, index).slice(0, topK)
@@ -51,7 +52,7 @@ export function findMissingPassages(store: VectorStore, passages: Passage[]): Pa
   const existing = new Map(store.getAll().map((row) => [row.id, row]))
   return passages.filter((passage) => {
     const row = existing.get(passage.id)
-    return row === undefined || row.model !== MODEL_NAME || row.contentHash !== passage.contentHash
+    return row === undefined || row.model !== EMBEDDING_MODEL_ID || row.contentHash !== passage.contentHash
   })
 }
 

--- a/src/bundled-plugins/memory/vector/index-on-write.ts
+++ b/src/bundled-plugins/memory/vector/index-on-write.ts
@@ -1,7 +1,7 @@
 import { fragmentContentHash } from '../fragment-parser'
 import type { FragmentEvent } from '../stream-events'
 import type { FragmentsAppendedContext } from '../stream-io'
-import { embed, MODEL_NAME } from './embedder'
+import { embed, EMBEDDING_MODEL_ID } from './embedder'
 import type { EmbedFn } from './hybrid'
 import type { VectorStore } from './store'
 
@@ -15,7 +15,7 @@ export function makeAppendHook(
       const id = `stream:${key}`
       const contentHash = fragmentContentHash(fragment)
       const existing = store.getByIds([id])[0]
-      if (existing?.contentHash === contentHash && existing.model === MODEL_NAME) continue
+      if (existing?.contentHash === contentHash && existing.model === EMBEDDING_MODEL_ID) continue
 
       const text = `${fragment.topic}\n${fragment.body}`
       const [embedding] = await embedFn([text], 'passage')
@@ -24,7 +24,7 @@ export function makeAppendHook(
         id,
         source: 'stream',
         key,
-        model: MODEL_NAME,
+        model: EMBEDDING_MODEL_ID,
         dims: embedding.length,
         embedding,
         contentHash,

--- a/src/bundled-plugins/memory/vector/startup.test.ts
+++ b/src/bundled-plugins/memory/vector/startup.test.ts
@@ -4,7 +4,9 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { fragmentContentHash } from '../fragment-parser'
 import { renderShard } from '../frontmatter'
+import { EMBEDDING_MODEL_ID } from './embedder'
 import type { EmbedFn } from './hybrid'
 import { buildStartupVectorIndex } from './startup'
 import { VectorStore } from './store'
@@ -80,6 +82,46 @@ describe('buildStartupVectorIndex', () => {
       expect(result).toEqual({ built: true, count: 1 })
       expect(embeddedTexts).toEqual(['Missing Topic\nNew content needs a vector.'])
       expect(store.getAll().map((stored) => stored.id)).toEqual(['topic:current-topic', 'topic:missing-topic'])
+    } finally {
+      store.close()
+    }
+  })
+
+  it('re-embeds and purges rows from a previous model/dtype variant', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'carried-over', 'Carried Over', 'Content unchanged across a dtype switch.')
+
+    // given: an index built by a previous embedding variant (e.g. fp32), same
+    // content, stamped with a different model id
+    const dbPath = join(agentDir, 'memory', '.vectors', 'index.db')
+    const seed = VectorStore.open(dbPath)
+    seed.upsert({
+      id: 'topic:carried-over',
+      source: 'topic',
+      key: 'carried-over',
+      model: 'Xenova/multilingual-e5-base@fp32',
+      dims: 8,
+      embedding: vector({ 0: 1 }),
+      contentHash: fragmentContentHash({ topic: 'Carried Over', body: 'Content unchanged across a dtype switch.' }),
+    })
+    seed.close()
+    const embeddedTexts: string[] = []
+
+    // when: the new variant builds the startup index
+    const result = await buildStartupVectorIndex(agentDir, async (texts) => {
+      embeddedTexts.push(...texts)
+      return texts.map(() => vector({ 1: 1 }))
+    })
+
+    const store = VectorStore.open(dbPath)
+    try {
+      // then: the unchanged content is re-embedded under the new stamp, and the
+      // stale fp32 row is gone (one row, current variant only)
+      expect(result).toEqual({ built: true, count: 1 })
+      expect(embeddedTexts).toEqual(['Carried Over\nContent unchanged across a dtype switch.'])
+      const rows = store.getAll()
+      expect(rows.map((stored) => stored.id)).toEqual(['topic:carried-over'])
+      expect(rows[0]?.model).toBe(EMBEDDING_MODEL_ID)
     } finally {
       store.close()
     }

--- a/src/bundled-plugins/memory/vector/startup.ts
+++ b/src/bundled-plugins/memory/vector/startup.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 
-import { MODEL_NAME, embed } from './embedder'
+import { EMBEDDING_MODEL_ID, embed } from './embedder'
 import { collectPassages, findMissingPassages, type EmbedFn } from './hybrid'
 import { VectorStore } from './store'
 
@@ -28,7 +28,7 @@ export async function buildStartupVectorIndex(
         id: passage.id,
         source: passage.source,
         key: passage.key,
-        model: MODEL_NAME,
+        model: EMBEDDING_MODEL_ID,
         dims: embedding.length,
         embedding,
         contentHash: passage.contentHash,
@@ -36,7 +36,16 @@ export async function buildStartupVectorIndex(
       count += 1
     }
 
-    return count === 0 ? { built: false, count: 0 } : { built: true, count }
+    if (count === 0) return { built: false, count: 0 }
+
+    // After a model/dtype switch, the prior variant's rows linger with a stale
+    // `model` stamp (re-embedded passages upsert by id, but rows for the same id
+    // already matched the new stamp, and orphans from removed content would not).
+    // query() already excludes them, so this is hygiene — bound DB growth across
+    // variant switches — not correctness. Runs only after a successful re-embed.
+    store.deleteOtherModels(EMBEDDING_MODEL_ID)
+
+    return { built: true, count }
   } finally {
     store.close()
   }

--- a/src/bundled-plugins/memory/vector/store.test.ts
+++ b/src/bundled-plugins/memory/vector/store.test.ts
@@ -6,9 +6,10 @@ import { join } from 'node:path'
 
 import { withGitLock } from '@/git/mutex'
 
+import { EMBEDDING_MODEL_ID } from './embedder'
 import { VectorStore, type VectorRow } from './store'
 
-const MODEL = 'Xenova/multilingual-e5-base'
+const MODEL = EMBEDDING_MODEL_ID
 const testDirs: string[] = []
 
 afterEach(() => {
@@ -25,7 +26,7 @@ describe('VectorStore', () => {
       store.upsert(row('topic:b', embedding(768, { 0: -1, 1: -1 })))
       store.upsert(row('stream:c', embedding(768, { 2: 1 })))
 
-      const results = store.query(embedding(768, { 0: 1, 1: 1 }), 1)
+      const results = store.query(embedding(768, { 0: 1, 1: 1 }), 1, MODEL)
 
       expect(results).toHaveLength(1)
       expect(results[0]?.id).toBe('topic:a')
@@ -42,8 +43,39 @@ describe('VectorStore', () => {
       store.upsert(row('topic:a', embedding(768, { 0: 1 })))
       store.upsert(row('topic:b', embedding(768, { 1: 1 })))
 
-      expect(() => store.query(embedding(384, { 0: 1 }), 10)).not.toThrow()
-      expect(store.query(embedding(384, { 0: 1 }), 10)).toEqual([])
+      expect(() => store.query(embedding(384, { 0: 1 }), 10, MODEL)).not.toThrow()
+      expect(store.query(embedding(384, { 0: 1 }), 10, MODEL)).toEqual([])
+    } finally {
+      store.close()
+    }
+  })
+
+  it('query excludes rows from a different model/dtype variant (same dims)', () => {
+    const store = openTestStore()
+    try {
+      // given: a stale fp32 row and a current q8 row, same id-space, same dims
+      store.upsert({ ...row('topic:stale', embedding(768, { 0: 1 })), model: 'Xenova/multilingual-e5-base@fp32' })
+      store.upsert(row('topic:current', embedding(768, { 0: 1 })))
+
+      // when: querying with the current variant id
+      const results = store.query(embedding(768, { 0: 1 }), 10, MODEL)
+
+      // then: only the current-variant row is scored; the fp32 row never appears
+      expect(results.map((r) => r.id)).toEqual(['topic:current'])
+    } finally {
+      store.close()
+    }
+  })
+
+  it('deleteOtherModels purges rows whose model != current, keeps current', () => {
+    const store = openTestStore()
+    try {
+      store.upsert({ ...row('topic:stale', embedding(768, { 0: 1 })), model: 'Xenova/multilingual-e5-base@fp32' })
+      store.upsert(row('topic:current', embedding(768, { 1: 1 })))
+
+      store.deleteOtherModels(MODEL)
+
+      expect(store.getAll().map((r) => r.id)).toEqual(['topic:current'])
     } finally {
       store.close()
     }

--- a/src/bundled-plugins/memory/vector/store.ts
+++ b/src/bundled-plugins/memory/vector/store.ts
@@ -79,15 +79,26 @@ export class VectorStore {
       )
   }
 
-  query(embedding: Float32Array, topK: number): VectorRow[] {
+  query(embedding: Float32Array, topK: number, modelId: string): VectorRow[] {
     if (topK <= 0) return []
 
-    return this.getAll()
-      .filter((row) => row.dims === embedding.length)
+    // Filter by embedding identity, not dims alone: a stale row from a different
+    // model/dtype variant can share the same dims but lives in an incompatible
+    // vector space, so cosine against it is garbage. Excluding it here keeps a
+    // partial re-embed (mixed variants mid-rebuild) at reduced recall, never
+    // wrong scores.
+    return this.db
+      .query<StoredVectorRow, [string, number]>('SELECT * FROM vectors WHERE model = ? AND dims = ?')
+      .all(modelId, embedding.length)
+      .map(toVectorRow)
       .map((row) => ({ row, score: cosineSimilarity(embedding, row.embedding) }))
       .sort((a, b) => b.score - a.score)
       .slice(0, topK)
       .map(({ row }) => row)
+  }
+
+  deleteOtherModels(modelId: string): void {
+    this.db.query('DELETE FROM vectors WHERE model != ?').run(modelId)
   }
 
   delete(id: string): void {


### PR DESCRIPTION
## Background

Follow-up to #806 (now merged). #806 switched the embedding dtype fp32 → q8; this PR makes the index detect that switch and re-embed, so existing fp32-built indexes do not silently serve stale vectors.

The dtype change matters because fp32 and q8 produce different embedding values for the same model. Quantization shifts the vectors, so rows produced by those two variants are not comparable even though they share the same Hugging Face model name and 768 dimensions.

The previous index identity used only the bare model name and dimensions. Both stay identical across fp32 and q8, so `findMissingPassages` could not detect a variant switch. A git-committed index built with fp32 vectors could survive restarts through the bind-mounted memory database and keep serving degraded retrieval scores forever.

## Summary

Introduce a canonical embedding index identity, `EMBEDDING_MODEL_ID`, that includes both the model name and dtype. Dtype changes the vector values while the model name and dimensions stay constant, so the dtype must be part of the identity.

All vector writers now stamp rows with that identity. Startup builds, embed-on-append, and re-embed-on-dream all write the same canonical stamp, while missing-passage detection compares against it so a variant switch marks existing passages missing and re-embeds them.

The Oracle-reviewed correctness invariant is on the query path. `VectorStore.query` filters in SQL by embedding identity and dimensions before scoring, so a stale row from a same-dimensional but incompatible vector space is never compared against the current query embedding.

That means partial or interrupted re-embeds reduce recall instead of producing wrong scores. Correctness does not depend on rebuild atomicity or startup timing.

After a successful startup rebuild, `deleteOtherModels` purges rows from prior variants. This is storage hygiene only because the query path already excludes those rows, but it bounds database growth across repeated variant switches.

## Preview

No UI or rendered output changes.

## What this does NOT do

- Does not change the embedding architecture, dimensions, or q8 dtype selection from #806.
- Does not make startup rebuilds transactional. Query-path filtering is the correctness boundary instead.
- Does not compare vectors across fp32 and q8 variants, even when their dimensions match.
- Does not preserve prior-variant rows after a successful startup rebuild.

## Review notes

- Load-bearing invariant: every writer must stamp `EMBEDDING_MODEL_ID`, and every query must filter by that identity before cosine scoring.
- Review `src/bundled-plugins/memory/vector/store.ts` carefully. Same-dimension stale rows must be excluded in SQL, not filtered after scoring.
- Review `src/bundled-plugins/memory/vector/startup.ts` for the order of operations. Prior-variant rows are purged only after a successful rebuild attempt.
- `store.test.ts` covers same-dimension stale-row query exclusion and prior-variant cleanup.
- `startup.test.ts` covers re-embedding an unchanged fp32-stamped row under the new identity and purging the stale row.
- Hybrid and dreaming fixture helpers now stamp the canonical identity so test data matches the production query filter.
- Verification completed: `bun run typecheck` clean.
- Verification completed: `bun run lint` reports 0 errors, with 67 pre-existing warnings and none in touched files.
- Verification completed: `bun run format:check` clean.
- Verification completed: `bun run test` reports 8736 pass, 0 fail, and 1 pre-existing skip.