### PR TITLE
feat(memory/vector): add a vector-index doctor check (opt-in only)

### DIFF
--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -1503,4 +1503,31 @@ describe('doctor checks', () => {
     expect(fixResult.summary).toContain('deleted')
     expect(existsSync(backupPath)).toBe(false)
   })
+
+  test('vector-index: no-op ok when memory.vector is not enabled', async () => {
+    const { exports } = await bootMemoryPlugin(agentDir, {})
+
+    const check = exports.doctorChecks?.['vector-index']
+    expect(check).toBeDefined()
+
+    const { logger } = makeCapturingLogger()
+    const result = await check!.run({ pluginName: 'memory', agentDir, config: { vector: { enabled: false } }, logger })
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('not enabled')
+    expect(result.fix).toBeUndefined()
+  })
+
+  test('vector-index: when enabled, runs the real index check (ok for an empty agent)', async () => {
+    // Booting with vector enabled opens the store, which creates the index DB,
+    // so the realistic enabled-but-empty agent is healthy (nothing to index).
+    const { exports } = await bootMemoryPlugin(agentDir, { vector: { enabled: true } })
+
+    const check = exports.doctorChecks?.['vector-index']
+    expect(check).toBeDefined()
+
+    const { logger } = makeCapturingLogger()
+    const result = await check!.run({ pluginName: 'memory', agentDir, config: { vector: { enabled: true } }, logger })
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('0/0')
+  })
 })

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -17,6 +17,7 @@ import { createMemoryRetrievalSubagent, type MemoryRetrievalPayload } from './me
 import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
 import { memorySearchTool } from './search-tool'
 import { vectorConfigSchema } from './vector/config'
+import { runVectorIndexDoctor } from './vector/doctor'
 import { hybridSearch } from './vector/hybrid'
 import { makeAppendHook } from './vector/index-on-write'
 import { VectorStore } from './vector/store'
@@ -559,10 +560,25 @@ export default definePlugin({
             }
           },
         },
+        'vector-index': {
+          description: 'vector index is consistent with memory (only when memory.vector is enabled)',
+          run: async (dctx) => {
+            if (!vectorEnabled(dctx.config)) {
+              return { status: 'ok', message: 'vector memory not enabled; skipping index health check' }
+            }
+            return runVectorIndexDoctor(dctx.agentDir)
+          },
+        },
       },
     }
   },
 })
+
+function vectorEnabled(config: unknown): boolean {
+  if (typeof config !== 'object' || config === null) return false
+  const parsed = vectorConfigSchema.safeParse((config as Record<string, unknown>).vector)
+  return parsed.success && parsed.data.enabled
+}
 
 async function readSize(path: string): Promise<number> {
   try {

--- a/src/bundled-plugins/memory/vector/doctor.test.ts
+++ b/src/bundled-plugins/memory/vector/doctor.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { fragmentContentHash } from '../fragment-parser'
+import { renderShard } from '../frontmatter'
+import { runVectorIndexDoctor } from './doctor'
+import { DIMS, EMBEDDING_MODEL_ID } from './embedder'
+import { inspectVectorIndex } from './inspect'
+import { VectorStore } from './store'
+
+const testDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('runVectorIndexDoctor', () => {
+  it('warns without a fix when the index DB does not exist yet', async () => {
+    const agentDir = createAgentDir()
+
+    const result = await runVectorIndexDoctor(agentDir)
+
+    expect(result.status).toBe('warning')
+    expect(result.message).toContain('missing')
+    expect(result.fix).toBeUndefined()
+  })
+
+  it('reports ok when every memory passage is indexed and consistent', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+
+    const result = await runVectorIndexDoctor(agentDir)
+
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('1/1')
+  })
+
+  it('warns (advisory, no fix) when a topic has no vector yet — backfill needed', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    writeTopic(agentDir, 'beta', 'Beta', 'Body of beta is not embedded.')
+
+    const result = await runVectorIndexDoctor(agentDir)
+
+    expect(result.status).toBe('warning')
+    expect(result.details).toContainEqual('1 memory passage(s) need (re)indexing')
+    expect(result.fix).toBeUndefined()
+  })
+
+  it('warns with a pruning fix when a vector row has no backing topic (orphan)', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'ghost', 'Ghost', 'Topic file was deleted.')
+
+    const result = await runVectorIndexDoctor(agentDir)
+
+    expect(result.status).toBe('warning')
+    expect(result.details).toContainEqual('1 orphaned row(s) for deleted topics/fragments')
+    expect(result.fix?.apply).toBeDefined()
+
+    const fixOutcome = await result.fix!.apply!({ pluginName: 'memory', agentDir, config: {}, logger: noopLogger() })
+    expect(fixOutcome.changedPaths).toEqual([])
+
+    const store = VectorStore.open(dbPath(agentDir))
+    const ids = store.getAll().map((row) => row.id)
+    store.close()
+    expect(ids).toEqual(['topic:alpha'])
+  })
+
+  it('warns with a pruning fix when a row is stamped with a different model variant', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.', 'Xenova/multilingual-e5-base@fp32')
+
+    const before = inspectVectorIndex(dbPath(agentDir))
+    if (before.kind !== 'ok') throw new Error('expected ok seed')
+    expect(before.modelMismatch.length).toBe(1)
+
+    const result = await runVectorIndexDoctor(agentDir)
+    expect(result.status).toBe('warning')
+    expect(result.details).toContainEqual('1 row(s) from a different embedding model/dims')
+    expect(result.fix?.apply).toBeDefined()
+
+    await result.fix!.apply!({ pluginName: 'memory', agentDir, config: {}, logger: noopLogger() })
+
+    const after = inspectVectorIndex(dbPath(agentDir))
+    if (after.kind !== 'ok') throw new Error('expected ok after fix')
+    expect(after.modelMismatch).toEqual([])
+  })
+
+  it('errors with a delete fix when the index DB is corrupted', async () => {
+    const agentDir = createAgentDir()
+    mkdirSync(join(agentDir, 'memory', '.vectors'), { recursive: true })
+    writeFileSync(dbPath(agentDir), 'not a sqlite file at all')
+
+    const result = await runVectorIndexDoctor(agentDir)
+
+    expect(result.status).toBe('error')
+    expect(result.fix?.apply).toBeDefined()
+
+    const fixOutcome = await result.fix!.apply!({ pluginName: 'memory', agentDir, config: {}, logger: noopLogger() })
+    expect(fixOutcome.changedPaths).toEqual([])
+    expect(existsSync(dbPath(agentDir))).toBe(false)
+  })
+})
+
+function createAgentDir(): string {
+  const agentDir = join(tmpdir(), `typeclaw-vector-doctor-${randomUUID()}`)
+  testDirs.push(agentDir)
+  mkdirSync(join(agentDir, 'memory', 'topics'), { recursive: true })
+  return agentDir
+}
+
+function dbPath(agentDir: string): string {
+  return join(agentDir, 'memory', '.vectors', 'index.db')
+}
+
+function writeTopic(agentDir: string, slug: string, heading: string, body: string): void {
+  writeFileSync(
+    join(agentDir, 'memory', 'topics', `${slug}.md`),
+    renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
+  )
+}
+
+function seedTopicVector(
+  agentDir: string,
+  slug: string,
+  heading: string,
+  body: string,
+  model = EMBEDDING_MODEL_ID,
+): void {
+  const store = VectorStore.open(dbPath(agentDir))
+  store.upsert({
+    id: `topic:${slug}`,
+    source: 'topic',
+    key: slug,
+    model,
+    dims: DIMS,
+    embedding: new Float32Array(DIMS),
+    contentHash: fragmentContentHash({ topic: heading, body }),
+  })
+  store.close()
+}
+
+function noopLogger() {
+  return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+}

--- a/src/bundled-plugins/memory/vector/doctor.test.ts
+++ b/src/bundled-plugins/memory/vector/doctor.test.ts
@@ -1,3 +1,4 @@
+import { Database } from 'bun:sqlite'
 import { afterEach, describe, expect, it } from 'bun:test'
 import { randomUUID } from 'node:crypto'
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
@@ -109,6 +110,50 @@ describe('runVectorIndexDoctor', () => {
     expect(fixOutcome.changedPaths).toEqual([])
     expect(existsSync(dbPath(agentDir))).toBe(false)
   })
+
+  it('warns with a pruning fix (no crash) when a row has a malformed embedding blob', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    // A blob whose byte length is not a multiple of 4 throws in Float32Array
+    // decode; the doctor must still report it instead of crashing.
+    insertRawRow(agentDir, { id: 'topic:broken', model: EMBEDDING_MODEL_ID, dims: DIMS, blobBytes: DIMS * 4 - 3 })
+
+    const result = await runVectorIndexDoctor(agentDir)
+
+    expect(result.status).toBe('warning')
+    expect(result.details).toContainEqual('1 row(s) with a malformed embedding blob')
+    expect(result.fix?.apply).toBeDefined()
+
+    await result.fix!.apply!({ pluginName: 'memory', agentDir, config: {}, logger: noopLogger() })
+
+    const after = inspectVectorIndex(dbPath(agentDir))
+    if (after.kind !== 'ok') throw new Error('expected ok after fix')
+    expect(after.malformed).toEqual([])
+    expect(after.rowIds).toEqual(['topic:alpha'])
+  })
+
+  it('prunes a current-model row whose dims differ from DIMS', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    insertRawRow(agentDir, { id: 'topic:wrongdims', model: EMBEDDING_MODEL_ID, dims: 256, blobBytes: 256 * 4 })
+
+    const before = inspectVectorIndex(dbPath(agentDir))
+    if (before.kind !== 'ok') throw new Error('expected ok seed')
+    expect(before.modelMismatch).toEqual(['topic:wrongdims'])
+
+    const result = await runVectorIndexDoctor(agentDir)
+    expect(result.status).toBe('warning')
+    expect(result.details).toContainEqual('1 row(s) from a different embedding model/dims')
+
+    await result.fix!.apply!({ pluginName: 'memory', agentDir, config: {}, logger: noopLogger() })
+
+    const after = inspectVectorIndex(dbPath(agentDir))
+    if (after.kind !== 'ok') throw new Error('expected ok after fix')
+    expect(after.modelMismatch).toEqual([])
+    expect(after.rowIds).toEqual(['topic:alpha'])
+  })
 })
 
 function createAgentDir(): string {
@@ -147,6 +192,23 @@ function seedTopicVector(
     contentHash: fragmentContentHash({ topic: heading, body }),
   })
   store.close()
+}
+
+function insertRawRow(agentDir: string, row: { id: string; model: string; dims: number; blobBytes: number }): void {
+  const db = new Database(dbPath(agentDir))
+  db.query(
+    'INSERT INTO vectors (id, source, key, model, dims, embedding, content_hash, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+  ).run(
+    row.id,
+    'topic',
+    row.id.replace(/^topic:/, ''),
+    row.model,
+    row.dims,
+    Buffer.alloc(row.blobBytes),
+    row.id,
+    '2026-06-11T00:00:00.000Z',
+  )
+  db.close()
 }
 
 function noopLogger() {

--- a/src/bundled-plugins/memory/vector/doctor.test.ts
+++ b/src/bundled-plugins/memory/vector/doctor.test.ts
@@ -154,6 +154,28 @@ describe('runVectorIndexDoctor', () => {
     expect(after.modelMismatch).toEqual([])
     expect(after.rowIds).toEqual(['topic:alpha'])
   })
+
+  it('counts a row that is both orphaned and malformed once, not twice', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    seedTopicVector(agentDir, 'alpha', 'Alpha', 'Body of alpha.')
+    // No topic file backs this row (orphaned) AND its blob is malformed; it
+    // lands in both buckets, so the prune count must dedupe to 1.
+    insertRawRow(agentDir, { id: 'topic:ghost', model: EMBEDDING_MODEL_ID, dims: DIMS, blobBytes: DIMS * 4 - 3 })
+
+    const result = await runVectorIndexDoctor(agentDir)
+
+    expect(result.status).toBe('warning')
+    expect(result.fix?.description).toContain('Delete 1 ')
+
+    const fixOutcome = await result.fix!.apply!({ pluginName: 'memory', agentDir, config: {}, logger: noopLogger() })
+    expect(fixOutcome.summary).toContain('pruned 1 ')
+    expect(fixOutcome.changedPaths).toEqual([])
+
+    const after = inspectVectorIndex(dbPath(agentDir))
+    if (after.kind !== 'ok') throw new Error('expected ok after fix')
+    expect(after.rowIds).toEqual(['topic:alpha'])
+  })
 })
 
 function createAgentDir(): string {

--- a/src/bundled-plugins/memory/vector/doctor.ts
+++ b/src/bundled-plugins/memory/vector/doctor.ts
@@ -1,0 +1,124 @@
+import { existsSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { PluginCheckResult } from '@/plugin'
+
+import { EMBEDDING_MODEL_ID } from './embedder'
+import { inspectVectorIndex, type VectorIndexProblem } from './inspect'
+import { collectPassages, findMissingPassages } from './passages'
+import { VectorStore } from './store'
+
+export const VECTOR_INDEX_REL_PATH = join('memory', '.vectors', 'index.db')
+
+export async function runVectorIndexDoctor(agentDir: string): Promise<PluginCheckResult> {
+  const dbPath = join(agentDir, VECTOR_INDEX_REL_PATH)
+
+  if (!existsSync(dbPath)) {
+    return {
+      status: 'warning',
+      message: 'vector memory is enabled but the index DB is missing; it rebuilds on the next startup',
+    }
+  }
+
+  const finding = inspectVectorIndex(dbPath)
+
+  if (finding.kind === 'unreadable' || finding.kind === 'corrupt' || finding.kind === 'schema-missing') {
+    return corruptionResult(dbPath, finding)
+  }
+
+  const passages = await collectPassages(agentDir)
+  const wantedIds = new Set(passages.map((passage) => passage.id))
+  const orphans = finding.rowIds.filter((id) => !wantedIds.has(id))
+  const backfillCount = countBackfill(dbPath, passages)
+
+  return summarize(dbPath, {
+    rowCount: finding.rowCount,
+    orphans,
+    modelMismatch: finding.modelMismatch,
+    malformed: finding.malformed,
+    backfillCount,
+    indexedCount: passages.length - backfillCount,
+    wantedCount: passages.length,
+  })
+}
+
+function countBackfill(dbPath: string, passages: Awaited<ReturnType<typeof collectPassages>>): number {
+  const store = VectorStore.open(dbPath)
+  try {
+    return findMissingPassages(store, passages).length
+  } finally {
+    store.close()
+  }
+}
+
+type Summary = {
+  rowCount: number
+  orphans: string[]
+  modelMismatch: string[]
+  malformed: string[]
+  backfillCount: number
+  indexedCount: number
+  wantedCount: number
+}
+
+function summarize(dbPath: string, s: Summary): PluginCheckResult {
+  const repairable = [...s.orphans, ...s.modelMismatch, ...s.malformed]
+  const details: string[] = []
+  if (s.orphans.length > 0) details.push(`${s.orphans.length} orphaned row(s) for deleted topics/fragments`)
+  if (s.modelMismatch.length > 0) {
+    details.push(`${s.modelMismatch.length} row(s) from a different embedding model/dims`)
+  }
+  if (s.malformed.length > 0) details.push(`${s.malformed.length} row(s) with a malformed embedding blob`)
+  if (s.backfillCount > 0) details.push(`${s.backfillCount} memory passage(s) need (re)indexing`)
+
+  if (details.length === 0) {
+    return { status: 'ok', message: `vector index healthy: ${s.indexedCount}/${s.wantedCount} memory passages indexed` }
+  }
+
+  const result: PluginCheckResult = {
+    status: 'warning',
+    message: `vector index has ${details.length} issue(s); ${s.rowCount} row(s) stored`,
+    details,
+  }
+
+  if (repairable.length > 0) {
+    result.fix = {
+      description: `Delete ${repairable.length} orphaned/incompatible vector row(s); backfill happens on the next startup`,
+      apply: async () => {
+        const store = VectorStore.open(dbPath)
+        try {
+          store.deleteOtherModels(EMBEDDING_MODEL_ID)
+          store.deleteMany([...s.orphans, ...s.malformed])
+        } finally {
+          store.close()
+        }
+        return {
+          summary: `pruned ${repairable.length} stale vector row(s) from ${VECTOR_INDEX_REL_PATH}`,
+          changedPaths: [],
+        }
+      },
+    }
+  }
+
+  return result
+}
+
+function corruptionResult(dbPath: string, finding: VectorIndexProblem): PluginCheckResult {
+  const details = finding.kind === 'corrupt' ? finding.detail : [finding.detail]
+  return {
+    status: 'error',
+    message:
+      finding.kind === 'schema-missing'
+        ? 'vector index DB has an invalid schema'
+        : 'vector index DB is unreadable or corrupted',
+    details,
+    fix: {
+      description: `Delete the corrupted ${VECTOR_INDEX_REL_PATH}; it rebuilds from memory on the next startup`,
+      apply: async () => {
+        await rm(dbPath, { force: true })
+        return { summary: `deleted corrupted ${VECTOR_INDEX_REL_PATH}`, changedPaths: [] }
+      },
+    },
+  }
+}

--- a/src/bundled-plugins/memory/vector/doctor.ts
+++ b/src/bundled-plugins/memory/vector/doctor.ts
@@ -62,7 +62,9 @@ type Summary = {
 }
 
 function summarize(dbPath: string, s: Summary): PluginCheckResult {
-  const repairable = [...s.orphans, ...s.modelMismatch, ...s.malformed]
+  // Dedupe: a row can be both orphaned and malformed/variant, so the union by
+  // id keeps the count and the deletion list honest.
+  const repairable = [...new Set([...s.orphans, ...s.modelMismatch, ...s.malformed])]
   const details: string[] = []
   if (s.orphans.length > 0) details.push(`${s.orphans.length} orphaned row(s) for deleted topics/fragments`)
   if (s.modelMismatch.length > 0) {

--- a/src/bundled-plugins/memory/vector/doctor.ts
+++ b/src/bundled-plugins/memory/vector/doctor.ts
@@ -4,7 +4,6 @@ import { join } from 'node:path'
 
 import type { PluginCheckResult } from '@/plugin'
 
-import { EMBEDDING_MODEL_ID } from './embedder'
 import { inspectVectorIndex, type VectorIndexProblem } from './inspect'
 import { collectPassages, findMissingPassages } from './passages'
 import { VectorStore } from './store'
@@ -88,8 +87,7 @@ function summarize(dbPath: string, s: Summary): PluginCheckResult {
       apply: async () => {
         const store = VectorStore.open(dbPath)
         try {
-          store.deleteOtherModels(EMBEDDING_MODEL_ID)
-          store.deleteMany([...s.orphans, ...s.malformed])
+          store.deleteMany(repairable)
         } finally {
           store.close()
         }

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -1,12 +1,14 @@
 import { createHash } from 'node:crypto'
 
-import { fragmentContentHash } from '../fragment-parser'
 import { loadAllShards, type TopicShard } from '../load-shards'
 import { buildMatcher, searchAll, type MemorySearchMatch, type StreamMatch } from '../search-tool'
 import type { StreamEvent } from '../stream-events'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
 import { embed, EMBEDDING_MODEL_ID, type EmbedType } from './embedder'
+import type { Passage } from './passages'
 import { VectorStore, type VectorRow } from './store'
+
+export { collectPassages, findMissingPassages, type Passage } from './passages'
 
 const RRF_K = 60
 
@@ -41,19 +43,6 @@ export async function hybridSearch(
   const keywordMatches = keywordLane(query, shards, streamDays, topK * 2)
 
   return fuseLanes(vectorRows, keywordMatches, index).slice(0, topK)
-}
-
-export async function collectPassages(agentDir: string): Promise<Passage[]> {
-  const [shards, streamDays] = await Promise.all([loadAllShards(agentDir), readAllUndreamedStreamDays(agentDir)])
-  return buildPassages(shards, streamDays)
-}
-
-export function findMissingPassages(store: VectorStore, passages: Passage[]): Passage[] {
-  const existing = new Map(store.getAll().map((row) => [row.id, row]))
-  return passages.filter((passage) => {
-    const row = existing.get(passage.id)
-    return row === undefined || row.model !== EMBEDDING_MODEL_ID || row.contentHash !== passage.contentHash
-  })
 }
 
 function keywordLane(
@@ -130,39 +119,6 @@ function buildContentIndex(
   return index
 }
 
-function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): Passage[] {
-  return [
-    ...shards.map(
-      (shard): Passage => ({
-        id: `topic:${shard.slug}`,
-        source: 'topic',
-        key: shard.slug,
-        text: `${shard.frontmatter.heading}\n${shard.body}`,
-        contentHash: fragmentContentHash({ topic: shard.frontmatter.heading, body: shard.body }),
-      }),
-    ),
-    ...streamDays.flatMap((day) =>
-      day.events.flatMap((event): Passage[] => {
-        if (event.type === 'watermark') return []
-        if (event.type === 'fragment') {
-          const key = `${day.date}#${event.id}`
-          return [
-            {
-              id: `stream:${key}`,
-              source: 'stream',
-              key,
-              text: `${event.topic}\n${event.body}`,
-              contentHash: fragmentContentHash(event),
-            },
-          ]
-        }
-        const key = `${day.date}#legacy-${hashContent(event.text).slice(0, 12)}`
-        return [{ id: `stream:${key}`, source: 'stream', key, text: event.text, contentHash: hashContent(event.text) }]
-      }),
-    ),
-  ]
-}
-
 function streamIndexItem(day: UndreamedStreamDay, event: StreamEvent): Omit<HybridSearchResult, 'rrfScore'> | null {
   if (event.type === 'watermark') return null
   if (event.type === 'fragment') {
@@ -203,12 +159,4 @@ function excerpt(body: string, fallback: string): string {
 
 function hashContent(content: string): string {
   return createHash('sha256').update(content).digest('hex')
-}
-
-export type Passage = {
-  id: string
-  source: 'topic' | 'stream'
-  key: string
-  text: string
-  contentHash: string
 }

--- a/src/bundled-plugins/memory/vector/inspect.test.ts
+++ b/src/bundled-plugins/memory/vector/inspect.test.ts
@@ -1,0 +1,136 @@
+import { Database } from 'bun:sqlite'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { DIMS, EMBEDDING_MODEL_ID } from './embedder'
+import { inspectVectorIndex } from './inspect'
+import { VectorStore } from './store'
+
+const testDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('inspectVectorIndex', () => {
+  it('reports ok with row ids for a healthy index', () => {
+    const dbPath = newDbPath()
+    const store = VectorStore.open(dbPath)
+    store.upsert(healthyRow('topic:a', 'topic', 'a'))
+    store.upsert(healthyRow('stream:2026-06-11#frag-1', 'stream', '2026-06-11#frag-1'))
+    store.close()
+
+    const finding = inspectVectorIndex(dbPath)
+
+    expect(finding.kind).toBe('ok')
+    if (finding.kind !== 'ok') throw new Error('expected ok')
+    expect(finding.rowCount).toBe(2)
+    expect(finding.rowIds).toEqual(['stream:2026-06-11#frag-1', 'topic:a'])
+    expect(finding.modelMismatch).toEqual([])
+    expect(finding.malformed).toEqual([])
+  })
+
+  it('does NOT create the vectors table when probing an empty DB (read-only)', () => {
+    const dbPath = newDbPath()
+    new Database(dbPath).close()
+
+    const finding = inspectVectorIndex(dbPath)
+
+    expect(finding.kind).toBe('schema-missing')
+    const after = new Database(dbPath, { readonly: true })
+    const table = after
+      .query<{ name: string }, [string]>("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get('vectors')
+    after.close()
+    expect(table).toBeNull()
+  })
+
+  it('flags rows stamped with a different model/dtype variant', () => {
+    const dbPath = newDbPath()
+    const db = openVectorsTable(dbPath)
+    insertRaw(db, { id: 'topic:legacy', model: 'Xenova/multilingual-e5-base@fp32', dims: DIMS, bytes: DIMS * 4 })
+    insertRaw(db, { id: 'topic:current', model: EMBEDDING_MODEL_ID, dims: DIMS, bytes: DIMS * 4 })
+    db.close()
+
+    const finding = inspectVectorIndex(dbPath)
+
+    if (finding.kind !== 'ok') throw new Error('expected ok')
+    expect(finding.modelMismatch).toEqual(['topic:legacy'])
+    expect(finding.malformed).toEqual([])
+  })
+
+  it('flags rows whose embedding blob byte length disagrees with dims', () => {
+    const dbPath = newDbPath()
+    const db = openVectorsTable(dbPath)
+    insertRaw(db, { id: 'topic:truncated', model: EMBEDDING_MODEL_ID, dims: DIMS, bytes: DIMS * 4 - 16 })
+    db.close()
+
+    const finding = inspectVectorIndex(dbPath)
+
+    if (finding.kind !== 'ok') throw new Error('expected ok')
+    expect(finding.modelMismatch).toEqual([])
+    expect(finding.malformed).toEqual(['topic:truncated'])
+  })
+
+  it('reports schema-missing when the vectors table lacks expected columns', () => {
+    const dbPath = newDbPath()
+    const db = new Database(dbPath)
+    db.run('CREATE TABLE vectors (id TEXT PRIMARY KEY, model TEXT)')
+    db.close()
+
+    const finding = inspectVectorIndex(dbPath)
+
+    expect(finding.kind).toBe('schema-missing')
+    if (finding.kind !== 'schema-missing') throw new Error('expected schema-missing')
+    expect(finding.detail).toContain('embedding')
+  })
+
+  it('reports corrupt for a file that is not a valid SQLite database', () => {
+    const dbPath = newDbPath()
+    writeFileSync(dbPath, 'this is not a sqlite database, just plain garbage bytes')
+
+    const finding = inspectVectorIndex(dbPath)
+
+    expect(finding.kind === 'corrupt' || finding.kind === 'unreadable').toBe(true)
+  })
+})
+
+function newDbPath(): string {
+  const dir = join(tmpdir(), `typeclaw-inspect-${randomUUID()}`)
+  testDirs.push(dir)
+  mkdirSync(dir, { recursive: true })
+  return join(dir, 'index.db')
+}
+
+function healthyRow(id: string, source: 'topic' | 'stream', key: string) {
+  return { id, source, key, model: EMBEDDING_MODEL_ID, dims: DIMS, embedding: new Float32Array(DIMS), contentHash: id }
+}
+
+function openVectorsTable(dbPath: string): Database {
+  const db = new Database(dbPath)
+  db.run(`
+    CREATE TABLE vectors (
+      id TEXT PRIMARY KEY, source TEXT NOT NULL, key TEXT NOT NULL, model TEXT NOT NULL,
+      dims INTEGER NOT NULL, embedding BLOB NOT NULL, content_hash TEXT NOT NULL, updated_at TEXT NOT NULL
+    )
+  `)
+  return db
+}
+
+function insertRaw(db: Database, row: { id: string; model: string; dims: number; bytes: number }): void {
+  db.query(
+    'INSERT INTO vectors (id, source, key, model, dims, embedding, content_hash, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+  ).run(
+    row.id,
+    'topic',
+    row.id.replace(/^topic:/, ''),
+    row.model,
+    row.dims,
+    Buffer.alloc(row.bytes),
+    row.id,
+    '2026-06-11T00:00:00.000Z',
+  )
+}

--- a/src/bundled-plugins/memory/vector/inspect.ts
+++ b/src/bundled-plugins/memory/vector/inspect.ts
@@ -1,0 +1,111 @@
+import { Database } from 'bun:sqlite'
+
+import { DIMS, EMBEDDING_MODEL_ID } from './embedder'
+
+// Read-only health probe for the vector index DB. Deliberately does NOT go
+// through `VectorStore.open`: that path runs `CREATE TABLE IF NOT EXISTS`,
+// which would silently "heal" a DB whose `vectors` table is missing — turning
+// a corruption signal into a no-op. The doctor must observe state, not mutate
+// it, so we open raw, validate the schema ourselves, and never write.
+
+const EXPECTED_COLUMNS = ['id', 'source', 'key', 'model', 'dims', 'embedding', 'content_hash', 'updated_at'] as const
+
+export type VectorIndexProblem =
+  | { kind: 'unreadable'; detail: string }
+  | { kind: 'corrupt'; detail: string[] }
+  | { kind: 'schema-missing'; detail: string }
+
+export type VectorIndexFinding =
+  | VectorIndexProblem
+  | { kind: 'ok'; rowCount: number; rowIds: string[]; modelMismatch: string[]; malformed: string[] }
+
+type IntegrityRow = { result: string }
+type SchemaRow = { name: string }
+type RowMeta = { id: string; model: string; dims: number; embeddingBytes: number }
+
+export function inspectVectorIndex(dbPath: string): VectorIndexFinding {
+  let db: Database
+  try {
+    db = new Database(dbPath, { readonly: true })
+  } catch (err) {
+    return { kind: 'unreadable', detail: messageOf(err) }
+  }
+
+  try {
+    const corruption = runQuickCheck(db)
+    if (corruption !== null) return { kind: 'corrupt', detail: corruption }
+
+    if (!hasVectorsTable(db)) {
+      return { kind: 'schema-missing', detail: 'vectors table is absent' }
+    }
+
+    const missingColumns = missingVectorColumns(db)
+    if (missingColumns.length > 0) {
+      return { kind: 'schema-missing', detail: `vectors table missing columns: ${missingColumns.join(', ')}` }
+    }
+
+    return classifyRows(db)
+  } catch (err) {
+    // A read that throws after the DB opened (e.g. a malformed page surfaced
+    // mid-scan that quick_check's sampling missed) is corruption, not an
+    // unreadable file — the file opened fine.
+    return { kind: 'corrupt', detail: [messageOf(err)] }
+  } finally {
+    db.close()
+  }
+}
+
+function runQuickCheck(db: Database): string[] | null {
+  // quick_check over integrity_check: integrity_check is O(db size) and can
+  // blow the 5s doctor budget on a large index; quick_check skips the
+  // expensive UNIQUE/foreign-key scans while still catching page-level
+  // corruption. A healthy DB returns exactly one row: "ok". SQLite names the
+  // result column after the pragma, hence `quick_check`, aliased to `result`.
+  const rows = db.query<IntegrityRow, []>('SELECT quick_check AS result FROM pragma_quick_check').all()
+  if (rows.length === 1 && rows[0]?.result === 'ok') return null
+  return rows.map((row) => row.result)
+}
+
+function hasVectorsTable(db: Database): boolean {
+  const row = db
+    .query<SchemaRow, [string]>("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get('vectors')
+  return row !== null
+}
+
+function missingVectorColumns(db: Database): string[] {
+  const present = new Set(
+    db
+      .query<SchemaRow, []>('PRAGMA table_info(vectors)')
+      .all()
+      .map((row) => row.name),
+  )
+  return EXPECTED_COLUMNS.filter((column) => !present.has(column))
+}
+
+function classifyRows(db: Database): VectorIndexFinding {
+  const rows = db
+    .query<RowMeta, []>('SELECT id, model, dims, length(embedding) AS embeddingBytes FROM vectors ORDER BY id')
+    .all()
+
+  const rowIds: string[] = []
+  const modelMismatch: string[] = []
+  const malformed: string[] = []
+
+  for (const row of rows) {
+    rowIds.push(row.id)
+    if (row.model !== EMBEDDING_MODEL_ID || row.dims !== DIMS) {
+      modelMismatch.push(row.id)
+      continue
+    }
+    // Float32 → 4 bytes per dim. A stored BLOB that disagrees can't decode to
+    // a valid embedding, so cosine against it would be garbage.
+    if (row.embeddingBytes !== row.dims * 4) malformed.push(row.id)
+  }
+
+  return { kind: 'ok', rowCount: rows.length, rowIds, modelMismatch, malformed }
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/bundled-plugins/memory/vector/passages.ts
+++ b/src/bundled-plugins/memory/vector/passages.ts
@@ -1,0 +1,65 @@
+import { createHash } from 'node:crypto'
+
+import { fragmentContentHash } from '../fragment-parser'
+import { loadAllShards, type TopicShard } from '../load-shards'
+import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
+import { EMBEDDING_MODEL_ID } from './embedder'
+import type { VectorStore } from './store'
+
+export type Passage = {
+  id: string
+  source: 'topic' | 'stream'
+  key: string
+  text: string
+  contentHash: string
+}
+
+export async function collectPassages(agentDir: string): Promise<Passage[]> {
+  const [shards, streamDays] = await Promise.all([loadAllShards(agentDir), readAllUndreamedStreamDays(agentDir)])
+  return buildPassages(shards, streamDays)
+}
+
+export function findMissingPassages(store: VectorStore, passages: Passage[]): Passage[] {
+  const existing = new Map(store.getAll().map((row) => [row.id, row]))
+  return passages.filter((passage) => {
+    const row = existing.get(passage.id)
+    return row === undefined || row.model !== EMBEDDING_MODEL_ID || row.contentHash !== passage.contentHash
+  })
+}
+
+function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): Passage[] {
+  return [
+    ...shards.map(
+      (shard): Passage => ({
+        id: `topic:${shard.slug}`,
+        source: 'topic',
+        key: shard.slug,
+        text: `${shard.frontmatter.heading}\n${shard.body}`,
+        contentHash: fragmentContentHash({ topic: shard.frontmatter.heading, body: shard.body }),
+      }),
+    ),
+    ...streamDays.flatMap((day) =>
+      day.events.flatMap((event): Passage[] => {
+        if (event.type === 'watermark') return []
+        if (event.type === 'fragment') {
+          const key = `${day.date}#${event.id}`
+          return [
+            {
+              id: `stream:${key}`,
+              source: 'stream',
+              key,
+              text: `${event.topic}\n${event.body}`,
+              contentHash: fragmentContentHash(event),
+            },
+          ]
+        }
+        const key = `${day.date}#legacy-${hashContent(event.text).slice(0, 12)}`
+        return [{ id: `stream:${key}`, source: 'stream', key, text: event.text, contentHash: hashContent(event.text) }]
+      }),
+    ),
+  ]
+}
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}

--- a/src/bundled-plugins/memory/vector/passages.ts
+++ b/src/bundled-plugins/memory/vector/passages.ts
@@ -20,7 +20,7 @@ export async function collectPassages(agentDir: string): Promise<Passage[]> {
 }
 
 export function findMissingPassages(store: VectorStore, passages: Passage[]): Passage[] {
-  const existing = new Map(store.getAll().map((row) => [row.id, row]))
+  const existing = new Map(store.getAllMeta().map((row) => [row.id, row]))
   return passages.filter((passage) => {
     const row = existing.get(passage.id)
     return row === undefined || row.model !== EMBEDDING_MODEL_ID || row.contentHash !== passage.contentHash

--- a/src/bundled-plugins/memory/vector/store.ts
+++ b/src/bundled-plugins/memory/vector/store.ts
@@ -13,6 +13,8 @@ export type VectorRow = {
   updatedAt: string
 }
 
+export type VectorMeta = { id: string; model: string; contentHash: string }
+
 type StoredVectorRow = {
   id: string
   source: 'topic' | 'stream'
@@ -115,6 +117,18 @@ export class VectorStore {
 
   getAll(): VectorRow[] {
     return this.db.query<StoredVectorRow, []>('SELECT * FROM vectors ORDER BY id').all().map(toVectorRow)
+  }
+
+  // Metadata only — never decodes the embedding BLOB, so a row whose blob is
+  // malformed (byte length not a multiple of 4) can't throw here the way
+  // getAll's Float32Array decode would.
+  getAllMeta(): VectorMeta[] {
+    return this.db
+      .query<{ id: string; model: string; content_hash: string }, []>(
+        'SELECT id, model, content_hash FROM vectors ORDER BY id',
+      )
+      .all()
+      .map((row) => ({ id: row.id, model: row.model, contentHash: row.content_hash }))
   }
 
   getByIds(ids: string[]): VectorRow[] {


### PR DESCRIPTION
## Background

`typeclaw doctor` already diagnoses the host, the agent folder, and plugin state, and the memory plugin contributes three checks (`dir-writable`, `daily-stream-current`, `pre-shard-backup-age`). But once `memory.vector` is opted in, there is a whole new piece of runtime state with no health signal: the SQLite vector index at `memory/.vectors/index.db`.

That index can drift out of sync with memory in ways that silently degrade retrieval and never surface to the operator:

- **Corruption** — a partially-written or damaged DB file.
- **Orphaned rows** — vectors for topics the user deleted or stream fragments the dreaming subagent GC'd.
- **Variant rows** — vectors stamped with a different embedding model/dtype (e.g. a leftover `…@fp32` row after the `q8` pin), which live in an incompatible vector space and are never compared against `q8` queries.
- **Malformed embeddings** — a stored BLOB whose byte length disagrees with `dims`, which can't decode to a valid vector.
- **Backfill gaps** — topics/fragments that exist in memory but have no vector yet.

None of these are caught today. This PR adds a doctor check that catches all of them — but only when the feature is actually in use.

## Summary

A new `vector-index` plugin doctor check, gated on `memory.vector.enabled`. When vector memory is off it is a no-op `ok` (no DB open, no work), so agents that never opted in pay nothing.

Key decisions a reviewer would otherwise have to ask about:

- **One check, not four.** Corruption, orphans, variant rows, and backfill gaps are all facets of one question — "is the index consistent with memory?" — and share the same DB open + passage enumeration. Splitting them would duplicate that work and produce noisier doctor output.

- **A read-only probe (`inspect.ts`) that deliberately does *not* reuse `VectorStore.open`.** `VectorStore.open` runs `CREATE TABLE IF NOT EXISTS`, which would silently *heal* a DB whose `vectors` table is missing — turning a corruption signal into a no-op. The doctor must observe, not mutate, so the probe opens raw and read-only.

- **`PRAGMA quick_check`, not `integrity_check`.** `integrity_check` is O(db size) and can blow the per-check 5s doctor budget on a large index; `quick_check` still catches page-level corruption.

- **Fixes never write to git.** The index DB is generated runtime state. Even though the memory snapshot force-adds `memory/`, this PR treats the index as rebuildable and reports **empty `changedPaths`**: corruption deletes the DB (startup rebuilds it), orphan/variant rows are pruned in place. Backfill-needed is advisory-only — embedding requires loading the ~280 MB model, which can't run inside the doctor window.

A small **refactor lands first**: `collectPassages` / `findMissingPassages` move out of `hybrid.ts` into a focused `passages.ts` (re-exported for existing importers). This keeps `hybrid.ts` about search/fusion and lets the doctor depend on passage collection without dragging in the search lane — which also matters for test isolation (see Review notes).

## What this does NOT do

- Does **not** embed or backfill missing passages — that stays with `buildStartupVectorIndex` at boot. The check only *reports* the gap.
- Does **not** add a new CLI subcommand or flag; it plugs into the existing `typeclaw doctor` pipeline via the plugin `doctorChecks` surface.
- Does **not** change any vector indexing, retrieval, or dreaming behavior.
- Does **not** touch host-stage doctor checks.

## Review notes

- Load-bearing file: `src/bundled-plugins/memory/vector/inspect.ts` — the read-only probe and its corruption/schema/row classification. The invariant to verify is that it never mutates the DB (open is `{ readonly: true }`, and it does not go through `VectorStore.open`).
- `src/bundled-plugins/memory/vector/doctor.ts` — the aggregation and fix policy (error vs warning, which findings get an `apply`, empty `changedPaths`).
- The `passages.ts` extraction is a pure move with re-exports; `hybrid.ts`'s public surface is unchanged. It also fixes a latent coupling: `index-vector.test.ts` does `mock.module('./vector/hybrid', …)` with a partial mock, so any new `index.ts` import from `hybrid` would break that mock. Routing the doctor through `passages.ts` keeps the mock valid.
- One SQLite gotcha worth a second look: `PRAGMA quick_check` returns a column named after the pragma (`quick_check`), not `result` — the probe aliases it explicitly.