### PR TITLE
fix(channels): recover the final answer when a progress reply already landed

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3631,6 +3631,84 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
+  test('leaf recovery: DOES fire when a progress reply landed but the final answer ended as plain prose', async () => {
+    // The production bug: a `continue: true` progress reply lands, the model
+    // keeps working, then ENDS the turn with its conclusion as plain assistant
+    // text (a `stopReason: 'stop'` leaf) and never calls a channel tool again.
+    // The conclusion must be recovered and delivered, not dropped.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'fix the tunnel' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'On it — checking now.' })
+      sessions[0]!.setAssistantText('Fixed — you will need a restart for it to take effect.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.map((s) => s.text)).toEqual([
+      'On it — checking now.',
+      'Fixed — you will need a restart for it to take effect.',
+    ])
+    expect(
+      logs.some((m) => m.includes('recovering assistant_text_without_channel_tool') && m.includes('source=leaf')),
+    ).toBe(true)
+  })
+
+  test('leaf recovery: does NOT re-post when the trailing leaf duplicates the reply already sent', async () => {
+    // The model called channel_reply (recorded in lastSentText) and the same
+    // text is the `stop` leaf. Recovery must not echo a byte-identical re-post,
+    // even though the `source:'system'` recovery send bypasses send()'s dup guard.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'status?' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'All good, nothing to do.' })
+      sessions[0]!.setAssistantText('All good, nothing to do.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.map((s) => s.text)).toEqual(['All good, nothing to do.'])
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('leaf recovery after a send: still honors NO_REPLY on the trailing leaf', async () => {
+    // The recovered leaf flows through the shared guards: a NO_REPLY conclusion
+    // after a real progress reply must stay silent, not get posted.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'anything else?' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Done.' })
+      sessions[0]!.setAssistantText('Nothing more to add. NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.map((s) => s.text)).toEqual(['Done.'])
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+  })
+
   test('logs recovery send failures without crashing the drain loop', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3709,6 +3709,56 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
   })
 
+  test('leaf recovery: does NOT re-post when a leaked tool-call leaf EXTRACTS to the reply already sent', async () => {
+    // The dedupe must run on the FINAL outbound body, after plain-text-tool-call
+    // extraction. A turn sends `Done.`, then ends with a fresh leaked
+    // `channel_reply({"text":"Done."})` leaf: the raw leaf differs from `Done.`,
+    // but its extracted body equals the reply already sent — must not re-post.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'status?' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Done.' })
+      sessions[0]!.setAssistantText('channel_reply({"text":"Done."})')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.map((s) => s.text)).toEqual(['Done.'])
+    expect(logs.some((m) => m.includes('suppressed recovery (duplicate'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('leaf recovery: DOES recover a leaked tool-call leaf whose extracted body is NOT a duplicate', async () => {
+    // Guard against over-suppression: a leaked `channel_reply({...})` leaf whose
+    // extracted body differs from the sent reply is a real undelivered answer.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'status?' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'Checking now.' })
+      sessions[0]!.setAssistantText('channel_reply({"text":"All fixed — restart needed."})')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.map((s) => s.text)).toEqual(['Checking now.', 'All fixed — restart needed.'])
+    expect(logs.some((m) => m.includes('recovered plain_text_channel_tool_call kind=reply'))).toBe(true)
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+  })
+
   test('logs recovery send failures without crashing the drain loop', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2173,6 +2173,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           logger.error(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
           live.consecutiveSends.clear()
           live.lastSentText.clear()
+          live.lastSendLeafId = null
         } finally {
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
           if (sentReplyThisTurn) dropEngageReactionsAfterReply(live, engageAddPromises)
@@ -3275,12 +3276,6 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const trailing = recoverableAssistantText(live.session)
       if (trailing === null || trailing.source !== 'leaf') return
       if (live.session.sessionManager.getLeafEntry()?.id === live.lastSendLeafId) return
-      // Belt-and-suspenders: the recovery send is `source:'system'` and so skips
-      // send()'s duplicate guard. Reject a fresh leaf whose body is byte-identical
-      // to what already went out this turn, so an undelivered conclusion never
-      // echoes a reply the user already saw.
-      const sendKey = consecutiveSendKey(live.key.chat, live.key.thread)
-      if (live.lastSentText.get(sendKey) === normalizeSendText(trailing.text)) return
     }
 
     const postEmptyTurnFallback = async (cause: string): Promise<void> => {
@@ -3491,6 +3486,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger.warn(
         `[channels] ${live.keyId}: suppressed recovery (github review guard) reason=${JSON.stringify(recoveryBlock)} text_len=${assistantText.length}`,
       )
+      return
+    }
+
+    // Duplicate guard on the FINAL outbound body. Must run here, after the
+    // plain-text-tool-call extraction may have rewritten `assistantText` — a
+    // dedupe on the raw leaf would miss a fresh `channel_reply({"text":"X"})`
+    // leak leaf whose extracted body equals a reply already sent this turn. The
+    // recovery send is `source:'system'`, which bypasses send()'s own dup guard,
+    // so reject the byte-identical re-post here. No-op on the zero-send path:
+    // `lastSentText` is cleared at batch start and only filled by this turn's
+    // sends, so it never matches when nothing was sent.
+    const sendKey = consecutiveSendKey(live.key.chat, live.key.thread)
+    if (live.lastSentText.get(sendKey) === normalizeSendText(assistantText)) {
+      logger.info(`[channels] ${live.keyId}: suppressed recovery (duplicate of reply already sent this turn)`)
       return
     }
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -555,6 +555,14 @@ type LiveSession = {
   // sends never poison the tracker. The fuzzy-match upgrade is intentionally
   // deferred — exact-match has zero false-positive risk by construction.
   lastSentText: Map<string, string>
+  // Session leaf-entry id captured at the moment the most recent successful
+  // channel send landed this turn. `validateChannelTurn` compares it to the
+  // turn-end leaf: a DIFFERENT assistant `stop` leaf means the model replied,
+  // kept working, then ended with FRESH final prose it forgot to deliver
+  // (the `continue: true` progress-reply bug) — recover it. A leaf that still
+  // matches is narration the model emitted BEFORE/with the reply that already
+  // landed, so it stays suppressed. Reset to null on every new prompt batch.
+  lastSendLeafId: string | null
   // Per-(chat:thread) ring of send timestamps (epoch ms) within the rolling
   // SEND_RATE_WINDOW_MS window. Append-on-send, prune-on-read. Lifecycle is
   // wall-clock (NOT cleared on new prompt batches) because rate is a
@@ -1532,6 +1540,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         consecutiveAborts: 0,
         consecutiveSends: new Map(),
         lastSentText: new Map(),
+        lastSendLeafId: null,
         sendTimestamps: new Map(),
         successfulChannelSends: 0,
         turnSeq: 0,
@@ -2089,6 +2098,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           )
           live.consecutiveSends.clear()
           live.lastSentText.clear()
+          live.lastSendLeafId = null
           live.pendingQuoteCandidate = captureQuoteCandidate(live.key.adapter, batch, observed)
           // A real user batch starts a fresh logical turn → restore the full
           // empty-turn retry budget and drop any raised output-token budget left
@@ -3164,6 +3174,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     if (live) {
       live.successfulChannelSends++
+      live.lastSendLeafId = live.session.sessionManager.getLeafEntry()?.id ?? null
       live.policyDeniedToolSendsThisTurn.delete(sendKey)
       // Don't stop the heartbeat here: the agent may still be mid-turn and
       // about to send another reply. drain()'s finally block owns turn-end
@@ -3249,9 +3260,27 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.skippedTurn = null
       logger.info(`[channels] ${live.keyId} skip_contested_by_send recovering reply`)
     }
+    // A send landed this turn, but the model may have posted a `continue: true`
+    // progress reply, kept working, then ENDED with its final answer as plain
+    // prose — never calling a channel tool again. The terminal-reply abort fires
+    // only for a `channel_reply` WITHOUT `continue: true`, so that `stopReason:
+    // 'stop'` text leaf is left undelivered and unguarded (the false-receipt
+    // guard is github-only). The discriminator is leaf IDENTITY: only when the
+    // turn-end `stop` leaf is a DIFFERENT entry than the one in place at the last
+    // send did the model produce fresh post-reply prose. A leaf unchanged since
+    // the send is narration the model emitted with/before the reply that already
+    // landed — suppress it, as before.
     if (live.successfulChannelSends > successfulSendsBeforePrompt) {
       maybeNudgeContinuationWillingness(live)
-      return
+      const trailing = recoverableAssistantText(live.session)
+      if (trailing === null || trailing.source !== 'leaf') return
+      if (live.session.sessionManager.getLeafEntry()?.id === live.lastSendLeafId) return
+      // Belt-and-suspenders: the recovery send is `source:'system'` and so skips
+      // send()'s duplicate guard. Reject a fresh leaf whose body is byte-identical
+      // to what already went out this turn, so an undelivered conclusion never
+      // echoes a reply the user already saw.
+      const sendKey = consecutiveSendKey(live.key.chat, live.key.thread)
+      if (live.lastSentText.get(sendKey) === normalizeSendText(trailing.text)) return
     }
 
     const postEmptyTurnFallback = async (cause: string): Promise<void> => {


### PR DESCRIPTION
## Background

On a discord-bot channel, an agent diagnosed a docs-tunnel misconfig over one turn: it posted two `channel_reply` progress updates with `continue: true` ("On it — checking the bind/port now", then "Found it: the docs app is listening on 4851, updating the tunnel now"), edited `typeclaw.json`, committed the fix, and then ended the turn with its **conclusion as plain assistant text** — "Fixed — you'll need a `typeclaw restart` for the tunnel to pick up the new port" — **without calling a channel tool again**. That conclusion was never delivered. From the user's side the last thing they saw was the mid-work "updating now"; the actual resolution and the required follow-up action silently vanished. No guard fired.

Root cause: `validateChannelTurn` returned unconditionally the moment any send landed this turn (`successfulChannelSends > successfulSendsBeforePrompt`). The fallback-delivery / `recoverableAssistantText` net that would have surfaced the stranded `stopReason: 'stop'` leaf only ran when **zero** sends happened — it was built for "model forgot to call any channel tool at all", not "model replied mid-turn with `continue: true` then forgot the terminal reply". The terminal-reply abort hook only fires for a `channel_reply` **without** `continue: true`, so a progress reply followed by a clean `stop` leaf leaves the conclusion undelivered. The existing false-receipt guard is github-only, so nothing caught it on discord-bot.

## Summary

In the "a send already landed" branch, recover the trailing assistant prose — but only the clean `'leaf'` shape (the model deliberately ended the turn with text), gated by **leaf identity**.

The hard part is distinguishing two states that share the same end shape (a `stop` leaf + a prior send): (a) an undelivered final answer vs (b) narration the model emitted *with* the reply that already went out. Text comparison can't tell them apart. The discriminator is causality: capture the session leaf-entry id at each successful send (`lastSendLeafId`); at turn-end, recover only when the current `stop` leaf is a **different** entry — i.e. fresh prose produced *after* the reply. A leaf unchanged since the send is pre-reply narration and stays suppressed, which is what keeps the existing `mid-turn` and length/aborted empty-turn-retry paths intact.

Why also a byte-identical dedupe against `lastSentText`: the recovery send is `source:'system'`, which bypasses `send()`'s own duplicate guard, so a fresh-but-identical leaf could otherwise echo a reply the user just saw.

The recovered text still flows through the shared NO_REPLY / upstream-sentinel / Kimi-leak / plain-text-tool-call / github-review guards before delivery — recovery surfaces it through the same `source:'system'` send as the zero-send path.

## What this does NOT do

- Does not recover `mid-turn` (`toolUse` narration before a committed tool plan) or `pre-tool` (truncation) shapes after a send — those remain superseded scratch prose.
- Does not change the zero-send recovery path, the terminal-reply abort semantics, or the `continue: true` contract.
- Does not add a hard "every turn must end with a channel tool" guard or any prompt change; this is purely the delivery-side safety net.

## Review notes

- Load-bearing change is the discriminator in `validateChannelTurn` (`src/channels/router.ts`): `getLeafEntry()?.id !== lastSendLeafId`. Invariant to verify: a leaf unchanged since the last send must stay suppressed (covered by the now-passing `empty-turn guard: a length-truncated retry…` and `mid-turn recovery: does NOT fire…` tests).
- `lastSendLeafId` lifecycle: set on every successful send, reset to `null` on each new prompt batch (alongside `lastSentText.clear()`). Not reset in the prompt-threw catch — the next batch clears it and `validateChannelTurn` doesn't run after a throw.
- Three new regression tests cover: the bug (leaf recovered + delivered after a `continue:true` progress reply), the dedupe (identical leaf not re-posted), and the guards still running (NO_REPLY leaf after a send stays silent).
