### PR TITLE
fix(channels): flush pending session writes on router stop

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -602,6 +602,8 @@ describe('channel manager — reload detects missing tokens and stops adapter', 
     const promptsAfterAlias = prompts.length
     expect(promptsAfterAlias - promptsBeforeAlias).toBe(1)
     expect(prompts[prompts.length - 1]).toContain('모모야')
+
+    await mgr.stop()
   })
 
   test('forwards selfAliasesRef to the slack adapter so the classifier can anchor threads on alias-only inbounds', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, writeFile as writeFileFs } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile as writeFileFs } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 
@@ -606,6 +606,30 @@ describe('ChannelRouter session lifecycle', () => {
     await router.route(inbound({ externalMessageId: 'm2', text: 'second' }))
     await router.__testing!.flushDebounce(KEY)
     await waitForPersistedLastInboundAt(dir, 2000)
+  })
+
+  test('stop() flushes the fire-and-forget persist before returning', async () => {
+    // given: an engaged inbound schedules a fire-and-forget `void persist()`
+    //   (the lastInboundAt write) but we never poll or flushDebounce for it
+    const dir = await tempDir()
+    const logs: string[] = []
+    const nowRef = { value: 4242 }
+    const { router } = makeRouter(dir, { nowRef, logs })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+
+    // when: stop() returns
+    await router.stop()
+
+    // then: the write has already landed (no poll needed) — proving stop()
+    //   awaited the persist chain rather than leaving it racing teardown
+    const loaded = await loadChannelSessions(dir)
+    expect(loaded[0]?.lastInboundAt).toBe(4242)
+
+    // and: deleting the dir right after stop() — exactly what test afterEach
+    //   does — produces no "failed to persist" error, because nothing is
+    //   still writing into it
+    await rm(dir, { recursive: true, force: true })
+    expect(logs.some((l) => l.includes('failed to persist'))).toBe(false)
   })
 
   test('v3-loaded record with lastInboundAt=0 forces rollover on first inbound', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1173,6 +1173,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   let mappings: ChannelSessionRecord[] | null = null
   let loadOnce: Promise<void> | null = null
   let persistChain: Promise<void> = Promise.resolve()
+  // Sealed by teardown so no late fire-and-forget caller appends to persistChain
+  // after the flush captured it. `await persistChain` only drains what's enqueued
+  // when it evaluates; a write appended afterward would still race a caller that
+  // deletes the agent dir right after stop() resolves.
+  let closing = false
 
   const ensureLoaded = async (): Promise<void> => {
     if (mappings !== null) return
@@ -1185,12 +1190,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const persist = async (): Promise<void> => {
-    if (mappings === null) return
-    persistChain = persistChain.then(async () => {
+    if (mappings === null || closing) return
+    // Caller awaits `next` un-caught to observe write errors; the chain holds the
+    // caught version so one rejection can't poison it or escape as unhandled.
+    const next = persistChain.then(async () => {
       if (mappings === null) return
       await saveChannelSessions(options.agentDir, mappings, logger)
     })
-    await persistChain
+    persistChain = next.catch(() => {})
+    await next
   }
 
   const createForChannel: CreateSessionForChannel =
@@ -3613,6 +3621,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   gcTimer.unref?.()
 
   const stop = async (): Promise<void> => {
+    closing = true
     if (gcTimer) clearInterval(gcTimer)
     gcTimer = null
     liveGeneration++
@@ -3621,6 +3630,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     for (const live of all) {
       await tearDownLive(live)
     }
+    await persistChain
   }
 
   // Drops every in-memory session but KEEPS the on-disk records, so the next
@@ -3638,9 +3648,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     liveGeneration++
     const all = Array.from(liveSessions.values())
     liveSessions.clear()
+    // Seal only around the flush — unlike stop() the router keeps serving after a
+    // roles reload, so re-enable persist() once pending writes have drained.
+    closing = true
     for (const live of all) {
       await tearDownLive(live)
     }
+    await persistChain
+    closing = false
   }
 
   // Boot-time resume for a restart that originated from a channel session, in


### PR DESCRIPTION
## Background

Under `bun test --parallel`, every channels test run printed persistence noise and occasionally failed outright:

```
[channels] failed to persist sessions: ENOENT: no such file or directory,
  rename '.../typeclaw-kakao-adapter-XXXX/channels/sessions.json.tmp'
       -> '.../typeclaw-kakao-adapter-XXXX/channels/sessions.json'
[channels] failed to persist sessions: EINVAL: invalid argument, mkdir '.../channels'
```

Root cause is a teardown race, not test flakiness. The router persists channel→session mappings through a serialized `persistChain` (`persist()` chains each `saveChannelSessions` write — an atomic `writeFile(tmp)` + `rename(tmp, path)`). But `stop()` and `tearDownAllLive()` tore down live sessions **without awaiting that chain**, and the hot path fires writes fire-and-forget:

- `scheduleDebouncedDrain` → `void persist()` (the `lastInboundAt` bump on every engaged inbound)
- `route` → `void persistParticipants()` (on a new author)

So a write could still be mid-flight when a caller deleted the agent dir. In production no one deletes the dir, but **every adapter test's `afterEach` does** `rm(agentDir, { recursive: true })` right after `await router.stop()` — the rename then lands in a directory that no longer exists. The error was swallowed and logged, which is why it read as intermittent noise plus the rare hard failure. (The existing `waitForPersistedLastInboundAt` helper had already been widened from ~20 ms to a 2 s poll to paper over the same race — a symptom, not a fix.)

## Summary

Make a graceful router stop **own its background writes**: callers can rely on `await router.stop()` meaning "all my writes are on disk."

- **`stop()` seals then flushes.** It sets a `closing` flag (so no late fire-and-forget caller can append a *new* write after teardown begins) and then `await persistChain`. The seal matters because `await persistChain` only drains what's enqueued the moment it evaluates — a write appended afterward by an in-flight caller would still escape and race the dir deletion.
- **`tearDownAllLive()` seals only around the flush.** Unlike `stop()`, the router keeps serving after a roles reload, so `closing` is reset to `false` once pending writes drain.
- **`persistChain` no longer poisons or leaks.** It keeps a caught copy (`next.catch(() => {})`) so one rejected write can't break the chain or surface as an unhandled rejection — matching the serialized-write pattern already used in `secrets/kakao-store.ts`, `secrets/line-store.ts`, and `manager.ts`. Callers still `await` the un-caught promise, so write errors stay observable.
- **One test was relying on the missing flush.** The slack-alias manager test routed inbounds but never called `mgr.stop()`; it now stops like every sibling test.

`manager.stop()` already delegates to `router.stop()`, so the manager and all adapter paths are covered by the router fix.

## What this does NOT do

- No change to persistence *format*, the `persist()` serialization model, or `saveChannelSessions` itself (still atomic temp + rename, still error-swallowing-and-logging).
- No change to the debounce/drain timing or the fire-and-forget call sites — they stay fire-and-forget; `stop()` just guarantees they're flushed at the end.
- No new public API. `closing` is an internal closure flag; no `__testing` seam was added.

## Review notes

- **Load-bearing change:** the `closing` seal in `stop()`/`tearDownAllLive()`. Verify the invariant it documents — `await persistChain` alone is insufficient because a mid-flight caller can append after the await captures the chain; the seal is what makes the flush total.
- **`tearDownAllLive` resets `closing = false`** because the router survives a roles reload. Do not "consistency-fix" it to seal permanently like `stop()` — that would silently drop all persistence after every reload.
- **Regression test** (`router.test.ts`): asserts the on-disk record reflects the write immediately after `stop()` returns (no poll), then deletes the dir and asserts no "failed to persist" was logged. Verified it fails on `main` (the error fires) and passes with the fix.
- **Verification:** `bun run typecheck` clean, `bun run lint` 0 errors, `bun run format:check` clean, `bun run test` 8759 pass / 0 fail / 1 skip across 3 consecutive runs; channels suite alone 10× parallel with zero persistence errors.
