### PR TITLE
fix(tunnels): gate quick-tunnel health on a real upstream probe

### DIFF
--- a/src/tunnels/providers/cloudflare-quick.test.ts
+++ b/src/tunnels/providers/cloudflare-quick.test.ts
@@ -45,6 +45,7 @@ sleep 30
       upstreamPort: 8975,
       binary,
       onUrlChange: (url) => urls.push(url),
+      probeUpstream: async () => true,
       stopGraceMs: 10,
     })
 
@@ -53,6 +54,7 @@ sleep 30
       await waitFor(() => urls.length === 1, { description: 'quick tunnel URL' })
 
       expect(urls).toEqual(['https://fake.trycloudflare.com'])
+      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy after probe' })
       expect(provider.snapshot()).toMatchObject({ status: 'healthy', url: 'https://fake.trycloudflare.com' })
       expect(provider.tail()).toContain('2026-01-01T00:00:00Z INF | https://fake.trycloudflare.com |')
       expect((await readFile(argvFile, 'utf8')).split('\n').filter(Boolean)).toEqual([
@@ -154,6 +156,7 @@ sleep 30
       upstreamPort: 8975,
       binary,
       onUrlChange: (url) => urls.push(url),
+      probeUpstream: async () => true,
       restartBackoffMs: [5],
       stopGraceMs: 10,
     })
@@ -163,7 +166,7 @@ sleep 30
       await waitFor(() => urls.length === 1, { description: 'URL after restart' })
 
       expect(await readFile(countFile, 'utf8')).toBe('2')
-      expect(provider.snapshot().status).toBe('healthy')
+      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy after restart probe' })
       await provider.stop()
     } finally {
       await provider.stop()
@@ -221,6 +224,7 @@ sleep 30
       upstreamPort: 8975,
       binary,
       onUrlChange: () => {},
+      probeUpstream: async () => true,
       stopGraceMs: 10,
     })
 
@@ -231,6 +235,77 @@ sleep 30
       await provider.stop()
 
       expect(provider.snapshot().status).toBe('stopped')
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('broadcasts the URL but stays unhealthy when the upstream is unreachable', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+echo "https://no-upstream.trycloudflare.com" >&2
+trap 'exit 0' TERM
+sleep 30
+`,
+    )
+    const urls: string[] = []
+    const provider = createCloudflareQuickProvider({
+      config,
+      upstreamPort: 4851,
+      binary,
+      onUrlChange: (url) => urls.push(url),
+      probeUpstream: async () => false,
+      upstreamRecheckMs: 5,
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+      await waitFor(() => provider.snapshot().status === 'unhealthy', { description: 'unhealthy on dead upstream' })
+
+      expect(urls).toEqual(['https://no-upstream.trycloudflare.com'])
+      const snap = provider.snapshot()
+      expect(snap.url).toBe('https://no-upstream.trycloudflare.com')
+      expect(snap.detail).toContain('4851')
+      expect(snap.detail).toContain('502')
+      await provider.stop()
+    } finally {
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('flips to healthy on recheck once the upstream comes up', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+echo "https://slow-upstream.trycloudflare.com" >&2
+trap 'exit 0' TERM
+sleep 30
+`,
+    )
+    let upstreamReady = false
+    const provider = createCloudflareQuickProvider({
+      config,
+      upstreamPort: 4851,
+      binary,
+      onUrlChange: () => {},
+      probeUpstream: async () => upstreamReady,
+      upstreamRecheckMs: 5,
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+      await waitFor(() => provider.snapshot().status === 'unhealthy', { description: 'unhealthy before upstream' })
+
+      upstreamReady = true
+      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy after upstream comes up' })
+      await provider.stop()
     } finally {
       await provider.stop()
       rmSync(scratchDir, { recursive: true, force: true })

--- a/src/tunnels/providers/cloudflare-quick.test.ts
+++ b/src/tunnels/providers/cloudflare-quick.test.ts
@@ -311,4 +311,54 @@ sleep 30
       rmSync(scratchDir, { recursive: true, force: true })
     }
   })
+
+  it('does not mark healthy when a probe resolves after cloudflared has already exited', async () => {
+    const scratchDir = createScratchDir()
+    const binary = installFakeCloudflared(
+      scratchDir,
+      `
+echo "https://exited.trycloudflare.com" >&2
+exit 1
+`,
+    )
+    let releaseProbe!: () => void
+    const probeGate = new Promise<void>((resolve) => {
+      releaseProbe = resolve
+    })
+    let probeStarted = false
+    const provider = createCloudflareQuickProvider({
+      config,
+      upstreamPort: 4851,
+      binary,
+      onUrlChange: () => {},
+      // Probe blocks until released; by then the process has exited and the
+      // tunnel is in restart backoff. A reachable result must NOT win.
+      probeUpstream: async () => {
+        probeStarted = true
+        await probeGate
+        return true
+      },
+      restartBackoffMs: [30_000],
+      upstreamRecheckMs: 5,
+      stopGraceMs: 10,
+    })
+
+    try {
+      await provider.start()
+      await waitFor(() => probeStarted, { description: 'probe started' })
+      await waitFor(() => provider.snapshot().detail.includes('restarting'), { description: 'restart backoff entered' })
+
+      releaseProbe()
+      await Bun.sleep(20)
+
+      const snap = provider.snapshot()
+      expect(snap.status).not.toBe('healthy')
+      expect(snap.detail).toContain('restarting')
+      await provider.stop()
+    } finally {
+      releaseProbe()
+      await provider.stop()
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/tunnels/providers/cloudflare-quick.ts
+++ b/src/tunnels/providers/cloudflare-quick.ts
@@ -63,6 +63,12 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   let restartFailuresWithoutUrl = 0
   let attemptEmittedUrl = false
   let broadcastedUrl: string | null = null
+  // Identifies the current live cloudflared attempt. Bumped on every launch, on
+  // process exit, and on stop. A probe captures the generation it was started
+  // under; if the process exits (into restart backoff) or the tunnel is stopped
+  // while a probe is in flight, the resolved probe sees a stale generation and
+  // bails — so it can never mark a dead process's tunnel healthy.
+  let launchGeneration = 0
 
   function clearRecheckTimer(): void {
     if (recheckTimer !== null) {
@@ -76,7 +82,8 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   // gate `healthy` on a real upstream probe, re-checking on an interval so the
   // status flips to healthy the moment the service comes up — and surfaces a
   // 502-explaining detail until then.
-  async function onQuickUrl(url: string): Promise<void> {
+  async function onQuickUrl(url: string, generation: number): Promise<void> {
+    if (generation !== launchGeneration) return
     attemptEmittedUrl = true
     restartFailuresWithoutUrl = 0
     state.url = url
@@ -85,13 +92,13 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
       broadcastedUrl = url
       onUrlChange(url)
     }
-    await reprobeUpstream()
+    await reprobeUpstream(generation)
   }
 
-  async function reprobeUpstream(): Promise<void> {
-    if (!started || stopping || state.url === null) return
+  async function reprobeUpstream(generation: number): Promise<void> {
+    if (generation !== launchGeneration || !started || stopping || state.url === null) return
     const reachable = await probeUpstream(upstreamPort)
-    if (!started || stopping || state.url === null) return
+    if (generation !== launchGeneration || !started || stopping || state.url === null) return
     if (reachable) {
       state.status = 'healthy'
       state.detail = 'quick tunnel URL emitted; upstream reachable'
@@ -103,13 +110,14 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
     clearRecheckTimer()
     recheckTimer = setTimeout(() => {
       recheckTimer = null
-      void reprobeUpstream()
+      void reprobeUpstream(generation)
     }, upstreamRecheckMs)
   }
 
   async function launch(): Promise<void> {
     if (!started || stopping) return
 
+    const generation = ++launchGeneration
     attemptEmittedUrl = false
     state.status = 'starting'
     state.detail = 'starting cloudflared'
@@ -132,7 +140,7 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
     void pumpStderr(spawned.stderr, logs, (line) => {
       const url = extractQuickTunnelUrl(line)
       if (url === null) return
-      void onQuickUrl(url)
+      void onQuickUrl(url, generation)
     })
 
     void spawned.exited.then((code) => {
@@ -144,6 +152,7 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   }
 
   function handleExit(code: number): void {
+    launchGeneration += 1
     clearRecheckTimer()
     if (!attemptEmittedUrl) restartFailuresWithoutUrl += 1
     if (restartFailuresWithoutUrl >= maxConsecutiveFailuresWithoutUrl) {
@@ -174,6 +183,7 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
       started = false
       stopping = true
       broadcastedUrl = null
+      launchGeneration += 1
       clearRecheckTimer()
       if (retryTimer !== null) {
         clearTimeout(retryTimer)

--- a/src/tunnels/providers/cloudflare-quick.ts
+++ b/src/tunnels/providers/cloudflare-quick.ts
@@ -3,12 +3,14 @@ import type { Unsubscribe } from '@/stream'
 import { createLogRing, type LogLineSubscriber, type LogRing } from '../log-ring'
 import { extractQuickTunnelUrl } from '../quick-url-parser'
 import type { TunnelConfig, TunnelProviderHandle, TunnelState } from '../types'
+import { isUpstreamReachable, type UpstreamProbe } from '../upstream-probe'
 import { isBinaryNotFound, MISSING_BINARY_DETAIL } from './cloudflared-binary'
 
 const DEFAULT_BINARY = 'cloudflared'
 const DEFAULT_RESTART_BACKOFF_MS = [1_000, 2_000, 4_000, 10_000, 30_000]
 const DEFAULT_MAX_FAILURES_WITHOUT_URL = 10
 const DEFAULT_STOP_GRACE_MS = 5_000
+const DEFAULT_UPSTREAM_RECHECK_MS = 2_000
 
 export type CloudflareQuickProviderOptions = {
   config: TunnelConfig
@@ -18,6 +20,8 @@ export type CloudflareQuickProviderOptions = {
   restartBackoffMs?: number[]
   maxConsecutiveFailuresWithoutUrl?: number
   stopGraceMs?: number
+  probeUpstream?: UpstreamProbe
+  upstreamRecheckMs?: number
 }
 
 export type CloudflareQuickProviderHandle = TunnelProviderHandle & {
@@ -38,6 +42,8 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   const restartBackoffMs = options.restartBackoffMs ?? DEFAULT_RESTART_BACKOFF_MS
   const maxConsecutiveFailuresWithoutUrl = options.maxConsecutiveFailuresWithoutUrl ?? DEFAULT_MAX_FAILURES_WITHOUT_URL
   const stopGraceMs = options.stopGraceMs ?? DEFAULT_STOP_GRACE_MS
+  const probeUpstream = options.probeUpstream ?? isUpstreamReachable
+  const upstreamRecheckMs = options.upstreamRecheckMs ?? DEFAULT_UPSTREAM_RECHECK_MS
   const logs = createLogRing()
   const state: TunnelState = {
     name: config.name,
@@ -53,8 +59,53 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   let stopping = false
   let proc: ReturnType<typeof Bun.spawn> | null = null
   let retryTimer: ReturnType<typeof setTimeout> | null = null
+  let recheckTimer: ReturnType<typeof setTimeout> | null = null
   let restartFailuresWithoutUrl = 0
   let attemptEmittedUrl = false
+  let broadcastedUrl: string | null = null
+
+  function clearRecheckTimer(): void {
+    if (recheckTimer !== null) {
+      clearTimeout(recheckTimer)
+      recheckTimer = null
+    }
+  }
+
+  // cloudflared emits the URL once, but the upstream service may still be
+  // booting. We broadcast the URL immediately (channel adapters need it) yet
+  // gate `healthy` on a real upstream probe, re-checking on an interval so the
+  // status flips to healthy the moment the service comes up — and surfaces a
+  // 502-explaining detail until then.
+  async function onQuickUrl(url: string): Promise<void> {
+    attemptEmittedUrl = true
+    restartFailuresWithoutUrl = 0
+    state.url = url
+    state.lastUrlAt = Date.now()
+    if (broadcastedUrl !== url) {
+      broadcastedUrl = url
+      onUrlChange(url)
+    }
+    await reprobeUpstream()
+  }
+
+  async function reprobeUpstream(): Promise<void> {
+    if (!started || stopping || state.url === null) return
+    const reachable = await probeUpstream(upstreamPort)
+    if (!started || stopping || state.url === null) return
+    if (reachable) {
+      state.status = 'healthy'
+      state.detail = 'quick tunnel URL emitted; upstream reachable'
+      clearRecheckTimer()
+      return
+    }
+    state.status = 'unhealthy'
+    state.detail = `quick tunnel URL emitted but upstream 127.0.0.1:${upstreamPort} is not reachable (requests will 502)`
+    clearRecheckTimer()
+    recheckTimer = setTimeout(() => {
+      recheckTimer = null
+      void reprobeUpstream()
+    }, upstreamRecheckMs)
+  }
 
   async function launch(): Promise<void> {
     if (!started || stopping) return
@@ -81,13 +132,7 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
     void pumpStderr(spawned.stderr, logs, (line) => {
       const url = extractQuickTunnelUrl(line)
       if (url === null) return
-      attemptEmittedUrl = true
-      restartFailuresWithoutUrl = 0
-      state.url = url
-      state.status = 'healthy'
-      state.lastUrlAt = Date.now()
-      state.detail = 'quick tunnel URL emitted'
-      onUrlChange(url)
+      void onQuickUrl(url)
     })
 
     void spawned.exited.then((code) => {
@@ -99,6 +144,7 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
   }
 
   function handleExit(code: number): void {
+    clearRecheckTimer()
     if (!attemptEmittedUrl) restartFailuresWithoutUrl += 1
     if (restartFailuresWithoutUrl >= maxConsecutiveFailuresWithoutUrl) {
       state.status = 'permanently-failed'
@@ -127,6 +173,8 @@ export function createCloudflareQuickProvider(options: CloudflareQuickProviderOp
       if (!started && proc === null) return
       started = false
       stopping = true
+      broadcastedUrl = null
+      clearRecheckTimer()
       if (retryTimer !== null) {
         clearTimeout(retryTimer)
         retryTimer = null

--- a/src/tunnels/upstream-probe.test.ts
+++ b/src/tunnels/upstream-probe.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test'
+
+import { isUpstreamReachable } from './upstream-probe'
+
+describe('isUpstreamReachable', () => {
+  it('resolves true when a server is listening on the port', async () => {
+    const server = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => new Response('ok') })
+    const port = server.port!
+    try {
+      expect(await isUpstreamReachable(port)).toBe(true)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  it('resolves false when nothing is listening on the port', async () => {
+    const server = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => new Response('ok') })
+    const closedPort = server.port!
+    server.stop(true)
+
+    expect(await isUpstreamReachable(closedPort)).toBe(false)
+  })
+
+  it('resolves false on timeout', async () => {
+    expect(await isUpstreamReachable(9, 50)).toBe(false)
+  })
+})

--- a/src/tunnels/upstream-probe.ts
+++ b/src/tunnels/upstream-probe.ts
@@ -1,0 +1,25 @@
+import { createConnection } from 'node:net'
+
+// cloudflared allocates a public quick-tunnel URL even when nothing is
+// listening upstream, so a "healthy" tunnel can still 502 every request. We
+// probe the upstream ourselves before claiming health; refused connections,
+// timeouts, and socket errors all count as unreachable.
+export async function isUpstreamReachable(port: number, timeoutMs = 1_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (reachable: boolean): void => {
+      if (settled) return
+      settled = true
+      socket.destroy()
+      resolve(reachable)
+    }
+
+    const socket = createConnection({ host: '127.0.0.1', port })
+    socket.setTimeout(timeoutMs)
+    socket.once('connect', () => finish(true))
+    socket.once('timeout', () => finish(false))
+    socket.once('error', () => finish(false))
+  })
+}
+
+export type UpstreamProbe = (port: number) => Promise<boolean>


### PR DESCRIPTION
## Background

A cloudflare-quick tunnel was configured with `upstreamPort: 3000`, but the docs dev server was actually listening on port 4851. The public trycloudflare.com URL came up and the tunnel reported **healthy** — yet every request returned **502 Bad Gateway** from Cloudflare's edge.

Root cause: cloudflared allocates and registers a public URL regardless of whether anything is listening upstream. The 502 only surfaces when real traffic arrives and the edge can't reach the dead upstream. The quick provider keyed healthy purely on "cloudflared printed a URL to stderr", so a wrong/closed `upstreamPort` was invisible until someone hit the URL. The tunnel state lied.

## Summary

Gate healthy on an actual upstream reachability probe instead of URL emission alone.

- New `isUpstreamReachable(port)` helper in src/tunnels/upstream-probe.ts: throwaway TCP connect to 127.0.0.1 on the configured port.
  Connect success → reachable; ECONNREFUSED / timeout / socket error → unreachable.
- On URL emission the quick provider now broadcasts the URL immediately (channel adapters need it the moment it exists) but probes the upstream before setting healthy. If unreachable, status stays unhealthy with a detail naming the port and explaining the 502, and re-checks on an interval so status flips to healthy once the upstream service finishes booting.
- Why broadcast-then-probe (not probe-then-broadcast): the upstream may legitimately be slow to start; withholding the URL would starve adapters that key off `tunnel-url-changed`. Decoupling URL availability from health keeps the URL while making the healthy signal truthful.
  The probe is injectable via `probeUpstream` so the existing fake-cloudflared test harness stays deterministic.

## What this does NOT do

- Does not touch cloudflare-named (URL is dashboard/config-bound, a different failure mode already documented in `types.ts`) or the external provider.
- Does not change how `upstreamPort` is resolved or defaulted. There is no 3000 default in the codebase — that value came from user config. This PR makes the misconfiguration observable; it does not guess the port.
- Does not do an HTTP-level health check (no GET / status assertion). A TCP connect is enough to distinguish "service up" from "nothing listening", which is the actual gap.

## Review notes

- Load-bearing change: `reprobeUpstream()` in cloudflare-quick.ts, and its call site in onQuickUrl().
  The recheck timer is cleared on stop() and handleExit() so a stopped/crashed tunnel never keeps probing a stale URL.
- `broadcastedUrl` dedupes so the recheck loop never re-fires onUrlChange for the same URL.
- Tests cover: reachable → healthy; unreachable → URL broadcast but unhealthy with 502 detail; unhealthy → healthy once upstream comes up. Full suite: 8763 pass / 0 fail.