### PR TITLE
fix(memory/vector): collapse a matched fragment to every citing topic

### DIFF
--- a/src/bundled-plugins/memory/parent-link.test.ts
+++ b/src/bundled-plugins/memory/parent-link.test.ts
@@ -33,21 +33,26 @@ describe('buildParentLinks', () => {
     ]
 
     // when
-    const { parentSlugByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
+    const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
 
     // then
-    expect(parentSlugByFragmentId.get(ID_PNPM)).toBe('package-manager')
-    expect(parentSlugByFragmentId.has(ID_BUN)).toBe(false)
+    expect(parentSlugsByFragmentId.get(ID_PNPM)).toEqual(new Set(['package-manager']))
+    expect(parentSlugsByFragmentId.has(ID_BUN)).toBe(false)
     expect(supersededFragmentIds).toEqual(new Set([ID_BUN]))
   })
 
-  test('first active citation wins when two shards cite the same fragment', () => {
+  test('collects ALL citing topics when a fragment is cited by more than one', () => {
+    // given one fragment cited by two distinct topics (it backs both beliefs)
     const shards = [
-      shard('a-topic', ['A.', 'fragments:', `- streams/2026-05-20#${ID_OTHER}`].join('\n')),
-      shard('b-topic', ['B.', 'fragments:', `- streams/2026-05-20#${ID_OTHER}`].join('\n')),
+      shard('package-manager', ['Uses pnpm.', 'fragments:', `- streams/2026-05-20#${ID_OTHER}`].join('\n')),
+      shard('docker-preferences', ['Minimal images.', 'fragments:', `- streams/2026-05-20#${ID_OTHER}`].join('\n')),
     ]
 
-    expect(buildParentLinks(shards).parentSlugByFragmentId.get(ID_OTHER)).toBe('a-topic')
+    // when
+    const { parentSlugsByFragmentId } = buildParentLinks(shards)
+
+    // then both parents are kept, not just the first
+    expect(parentSlugsByFragmentId.get(ID_OTHER)).toEqual(new Set(['package-manager', 'docker-preferences']))
   })
 
   test('active in one shard outranks superseded in another', () => {
@@ -56,16 +61,16 @@ describe('buildParentLinks', () => {
       shard('history', ['History.', 'superseded:', `- streams/2026-05-21#${ID_PNPM}`].join('\n')),
     ]
 
-    const { parentSlugByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
+    const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
 
-    expect(parentSlugByFragmentId.get(ID_PNPM)).toBe('current')
+    expect(parentSlugsByFragmentId.get(ID_PNPM)).toEqual(new Set(['current']))
     expect(supersededFragmentIds.has(ID_PNPM)).toBe(false)
   })
 
   test('empty shards yield empty links', () => {
-    const { parentSlugByFragmentId, supersededFragmentIds } = buildParentLinks([])
+    const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks([])
 
-    expect(parentSlugByFragmentId.size).toBe(0)
+    expect(parentSlugsByFragmentId.size).toBe(0)
     expect(supersededFragmentIds.size).toBe(0)
   })
 })

--- a/src/bundled-plugins/memory/parent-link.ts
+++ b/src/bundled-plugins/memory/parent-link.ts
@@ -3,24 +3,31 @@ import type { TopicShard } from './load-shards'
 
 export type ParentLinks = {
   supersededFragmentIds: Set<string>
-  parentSlugByFragmentId: Map<string, string>
+  parentSlugsByFragmentId: Map<string, Set<string>>
 }
 
 export function buildParentLinks(shards: TopicShard[]): ParentLinks {
-  const parentSlugByFragmentId = new Map<string, string>()
+  const parentSlugsByFragmentId = new Map<string, Set<string>>()
   const supersededFragmentIds = new Set<string>()
 
   for (const shard of shards) {
     const { active, superseded } = splitCitationsBySection(shard.body)
-    for (const fragmentId of active) {
-      if (!parentSlugByFragmentId.has(fragmentId)) parentSlugByFragmentId.set(fragmentId, shard.slug)
-    }
+    // A fragment can be cited by multiple topics (it backs more than one belief),
+    // so collect every citing slug — first-wins would drop the fragment's other
+    // parents and a match would collapse to only one of them.
+    for (const fragmentId of active) addSlug(parentSlugsByFragmentId, fragmentId, shard.slug)
     for (const fragmentId of superseded) supersededFragmentIds.add(fragmentId)
   }
 
   // Active in one shard outranks superseded in another: the fragment still backs
   // a live belief, so it stays a valid retrieval hook.
-  for (const fragmentId of parentSlugByFragmentId.keys()) supersededFragmentIds.delete(fragmentId)
+  for (const fragmentId of parentSlugsByFragmentId.keys()) supersededFragmentIds.delete(fragmentId)
 
-  return { parentSlugByFragmentId, supersededFragmentIds }
+  return { parentSlugsByFragmentId, supersededFragmentIds }
+}
+
+function addSlug(map: Map<string, Set<string>>, fragmentId: string, slug: string): void {
+  const slugs = map.get(fragmentId)
+  if (slugs === undefined) map.set(fragmentId, new Set([slug]))
+  else slugs.add(slug)
 }

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -109,6 +109,39 @@ describe('hybridSearch', () => {
     }
   })
 
+  it('collapses a matched fragment to EVERY topic that cites it', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given one fragment cited by two distinct topics
+      const fragmentId = '019e2eca-6fc5-71ef-add9-67a0955a4b35'
+      writeTopic(
+        agentDir,
+        'package-manager',
+        'Package Manager',
+        ['User uses pnpm.', 'fragments:', `- streams/2026-06-10#${fragmentId}`].join('\n'),
+      )
+      writeTopic(
+        agentDir,
+        'docker-preferences',
+        'Docker Preferences',
+        ['User prefers minimal images.', 'fragments:', `- streams/2026-06-10#${fragmentId}`].join('\n'),
+      )
+      writeStreamFragment(agentDir, '2026-06-10', fragmentId, 'pnpm', 'Uses pnpm and minimal Docker images.')
+      store.upsert(row(`stream:2026-06-10#${fragmentId}`, `2026-06-10#${fragmentId}`, vector({ 0: 1 }), 'stream'))
+
+      // when the shared fragment matches by vector
+      const results = await hybridSearch('pnpm docker', store, agentDir, 5, embedFrom({ 0: 1 }))
+
+      // then BOTH citing topics surface, and the fragment never appears standalone
+      const keys = results.map((result) => result.key)
+      expect(keys).toContain('package-manager')
+      expect(keys).toContain('docker-preferences')
+      expect(results.find((result) => result.source === 'stream')).toBeUndefined()
+    } finally {
+      store.close()
+    }
+  })
+
   it('ranks a parent by the MAX of its children, not the sum', async () => {
     const { agentDir, store } = createFixture()
     try {

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -38,13 +38,13 @@ export async function hybridSearch(
     embedFn([query], 'query'),
   ])
 
-  const { parentSlugByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
+  const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
   const index = buildContentIndex(shards, streamDays, supersededFragmentIds)
   const vectorRows =
     queryEmbeddings[0] === undefined ? [] : store.query(queryEmbeddings[0], topK * 2, EMBEDDING_MODEL_ID)
   const keywordMatches = keywordLane(query, shards, streamDays, topK * 2)
 
-  return fuseLanes(vectorRows, keywordMatches, index, parentSlugByFragmentId).slice(0, topK)
+  return fuseLanes(vectorRows, keywordMatches, index, parentSlugsByFragmentId).slice(0, topK)
 }
 
 function keywordLane(
@@ -70,18 +70,18 @@ function fuseLanes(
   vectorRows: VectorRow[],
   keywordMatches: MemorySearchMatch[],
   index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
-  parentSlugByFragmentId: Map<string, string>,
+  parentSlugsByFragmentId: Map<string, Set<string>>,
 ): HybridSearchResult[] {
   const fused = new Map<string, HybridSearchResult>()
 
   for (let i = 0; i < vectorRows.length; i++) {
     const row = vectorRows[i]!
-    addScore(fused, index, row.source, row.key, 1 / (RRF_K + i + 1), parentSlugByFragmentId)
+    addScore(fused, index, row.source, row.key, 1 / (RRF_K + i + 1), parentSlugsByFragmentId)
   }
 
   for (let i = 0; i < keywordMatches.length; i++) {
     const match = keywordMatches[i]!
-    addScore(fused, index, match.source, matchKey(match), 1 / (RRF_K + i + 1), parentSlugByFragmentId)
+    addScore(fused, index, match.source, matchKey(match), 1 / (RRF_K + i + 1), parentSlugsByFragmentId)
   }
 
   return [...fused.values()].sort((a, b) => b.rrfScore - a.rrfScore || a.key.localeCompare(b.key))
@@ -93,36 +93,38 @@ function addScore(
   source: 'topic' | 'stream',
   nodeKey: string,
   score: number,
-  parentSlugByFragmentId: Map<string, string>,
+  parentSlugsByFragmentId: Map<string, Set<string>>,
 ): void {
-  const resolved = resolveToParent(source, nodeKey, index, parentSlugByFragmentId)
-  if (resolved === null) return
-  const { fusedKey, content } = resolved
-
-  const existing = fused.get(fusedKey)
-  if (existing !== undefined) {
-    existing.rrfScore = Math.max(existing.rrfScore, score)
-    return
+  for (const { fusedKey, content } of resolveToParents(source, nodeKey, index, parentSlugsByFragmentId)) {
+    const existing = fused.get(fusedKey)
+    if (existing !== undefined) existing.rrfScore = Math.max(existing.rrfScore, score)
+    else fused.set(fusedKey, { ...content, rrfScore: score })
   }
-  fused.set(fusedKey, { ...content, rrfScore: score })
 }
 
-function resolveToParent(
+// A matched fragment collapses to EVERY topic that cites it (a fragment can back
+// more than one belief), so it contributes its score to each parent. An
+// undreamed fragment with no citing topic resolves to itself.
+function resolveToParents(
   source: 'topic' | 'stream',
   nodeKey: string,
   index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
-  parentSlugByFragmentId: Map<string, string>,
-): { fusedKey: string; content: Omit<HybridSearchResult, 'rrfScore'> } | null {
+  parentSlugsByFragmentId: Map<string, Set<string>>,
+): Array<{ fusedKey: string; content: Omit<HybridSearchResult, 'rrfScore'> }> {
   if (source === 'stream') {
     const fragmentId = fragmentIdFromKey(nodeKey)
-    const parentSlug = fragmentId === null ? undefined : parentSlugByFragmentId.get(fragmentId)
-    if (parentSlug !== undefined) {
-      const topic = index.get(laneKey('topic', parentSlug))
-      if (topic !== undefined) return { fusedKey: laneKey('topic', parentSlug), content: topic }
+    const parentSlugs = fragmentId === null ? undefined : parentSlugsByFragmentId.get(fragmentId)
+    if (parentSlugs !== undefined && parentSlugs.size > 0) {
+      const parents: Array<{ fusedKey: string; content: Omit<HybridSearchResult, 'rrfScore'> }> = []
+      for (const parentSlug of parentSlugs) {
+        const topic = index.get(laneKey('topic', parentSlug))
+        if (topic !== undefined) parents.push({ fusedKey: laneKey('topic', parentSlug), content: topic })
+      }
+      if (parents.length > 0) return parents
     }
   }
   const content = index.get(laneKey(source, nodeKey))
-  return content === undefined ? null : { fusedKey: laneKey(source, nodeKey), content }
+  return content === undefined ? [] : [{ fusedKey: laneKey(source, nodeKey), content }]
 }
 
 function fragmentIdFromKey(streamKey: string): string | null {


### PR DESCRIPTION
## Background

Parent-child retrieval (#811) collapses a matched fragment to the topic that cites it. But the link index, `buildParentLinks` (`parent-link.ts`), mapped each fragment to a **single** parent slug with **first-wins**:

```ts
if (!parentSlugByFragmentId.has(fragmentId)) parentSlugByFragmentId.set(fragmentId, shard.slug)
```

A fragment can legitimately be cited by **more than one topic** — it backs multiple beliefs. Example: a fragment "uses pnpm and prefers minimal Docker images" is cited by both `package-manager` and `docker-preferences`. Under first-wins, only the shard that loaded first (alphabetical by slug) kept the link; the other topic silently lost the retrieval hook. A query matching that fragment would collapse to only one of its two parents.

## What this does

Make the topic↔fragment link **many-to-many**.

- **`parent-link.ts`**: `parentSlugByFragmentId: Map<string, string>` → `parentSlugsByFragmentId: Map<string, Set<string>>`. Every citing topic is collected (no first-wins). The active-outranks-superseded rule is unchanged.
- **`hybrid.ts`**: `resolveToParent` (single) → `resolveToParents` (list). A matched fragment fans out to **all** its citing topics, each receiving the child's score via the existing MAX-child rule. Undreamed fragments with no citing topic still self-resolve to a `stream` result; superseded exclusion is unchanged.

## Why

The first-wins map lost information: a fragment's link to its other parent topics was dropped at load time, so retrieval could never collapse a shared fragment to all the beliefs it supports. This is a correctness fix to the parent-child link, not a behavior tuning.

## What this does NOT do

- No change to ranking semantics (still MAX-child RRF).
- No change to superseded exclusion or undreamed self-resolution.
- No schema/format change — the link is still derived from the same `fragments:` / `superseded:` citations in topic shard bodies; only the in-memory index type widened.

## Tests

- `parent-link.test.ts`: replaced the old "first active citation wins" test with "collects ALL citing topics when a fragment is cited by more than one" (asserts the `Set` contains both slugs).
- `hybrid.test.ts`: new "collapses a matched fragment to EVERY topic that cites it" — one fragment cited by two topics surfaces BOTH, never as a standalone stream result.

## Verification

- `bun run typecheck` clean
- `bun run lint` 0 errors
- `bun run format:check` clean
- `bun run test` — 8784 pass / 0 fail / 1 skip