### PR TITLE
docs(skills): guide the agent to diagnose tunnel root cause, not error lines

### DIFF
--- a/src/skills/typeclaw-tunnels/SKILL.md
+++ b/src/skills/typeclaw-tunnels/SKILL.md
@@ -113,7 +113,10 @@ When a tunnel has no public URL, **diagnose the root cause directly — don't st
 
 1. **Read `typeclaw.json`.** Look at `tunnels[]` (is the tunnel even configured? which `provider`?) and `docker.file.cloudflared` (is it `true`?).
 2. **Check the binary:** `command -v cloudflared`. If a `cloudflare-quick` / `cloudflare-named` tunnel is configured but this prints nothing, the cloudflared layer was never installed — that is the root cause (see "### `cloudflared` is not installed" below).
-3. **Check the upstream is alive:** the service the tunnel points at must be listening on its `upstreamPort` inside the container (e.g. `curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:<upstreamPort>/`).
+3. **Check the upstream is alive — but probe the right port per provider:**
+   - `cloudflare-quick`: the service must be listening on the tunnel's `upstreamPort` from `typeclaw.json` (e.g. `curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:<upstreamPort>/`).
+   - `cloudflare-named`: there is **no** `upstreamPort` (the schema rejects it; the dashboard's Public Hostname mapping `localhost:<port>` captures the upstream — see the named-tunnel section above). Ask the user which port the dashboard's Public Hostname points at, then probe `127.0.0.1:<that port>`.
+   - `external`: the upstream lives behind the user's own reverse proxy, so there is no container-local port to probe — skip this check unless the user names the upstream.
 
 Then tell the user honestly and offer the fix. For the common "hand-added tunnel, no `cloudflared`" case, send something like:
 

--- a/src/skills/typeclaw-tunnels/SKILL.md
+++ b/src/skills/typeclaw-tunnels/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typeclaw-tunnels
-description: Use when the user mentions tunnel, ngrok, webhook URL, cloudflared, expose to internet, show my friend, public URL, GitHub webhook, port forward to public, reverse proxy, trycloudflare, or making a container-local service reachable from the internet. Read it before suggesting tunnel add/remove/status/logs or editing typeclaw.json tunnels[].
+description: Use when the user mentions tunnel, ngrok, webhook URL, cloudflared, expose to internet, show my friend, public URL, GitHub webhook, port forward to public, reverse proxy, trycloudflare, or making a container-local service reachable from the internet. Read it before suggesting tunnel add/remove/status/logs or editing typeclaw.json tunnels[]. Also read it the moment a tunnel "doesn't work": a Cloudflare tunnel with no public URL usually means `cloudflared` was never baked into the image — it is opt-in (`docker.file.cloudflared`, default false), so a hand-added tunnel needs it set explicitly. Diagnose root cause by reading typeclaw.json + checking `command -v cloudflared` rather than trusting a single error line; tell the user to set `docker.file.cloudflared: true` and `typeclaw restart`; never curl/vendor cloudflared yourself or report a cryptic error as if the tunnel were down.
 ---
 
 # typeclaw-tunnels
@@ -106,6 +106,24 @@ Unhealthy logs often show:
 - no URL emission before the process exits.
 
 Use `typeclaw tunnel logs <name> -f` while restarting the agent if you need to watch URL discovery live.
+
+## Diagnosing "the tunnel doesn't work" (you, the agent)
+
+When a tunnel has no public URL, **diagnose the root cause directly — don't stop at a single error line.** The most common cause by far is that `cloudflared` was never baked into the image (it's opt-in; see below), not a runtime outage. These checks always work from your shell inside the container:
+
+1. **Read `typeclaw.json`.** Look at `tunnels[]` (is the tunnel even configured? which `provider`?) and `docker.file.cloudflared` (is it `true`?).
+2. **Check the binary:** `command -v cloudflared`. If a `cloudflare-quick` / `cloudflare-named` tunnel is configured but this prints nothing, the cloudflared layer was never installed — that is the root cause (see "### `cloudflared` is not installed" below).
+3. **Check the upstream is alive:** the service the tunnel points at must be listening on its `upstreamPort` inside the container (e.g. `curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:<upstreamPort>/`).
+
+Then tell the user honestly and offer the fix. For the common "hand-added tunnel, no `cloudflared`" case, send something like:
+
+> This agent has a `cloudflare-quick` tunnel configured, but `cloudflared` was never installed into the image — it's opt-in (`docker.file.cloudflared`, default `false`), and this tunnel was hand-added to `typeclaw.json` without enabling it. Want me to set `docker.file.cloudflared: true`? It's a boot setting, so after I edit it you'll run `typeclaw restart` from the host project directory, and the tunnel URL will come up.
+
+Only after the user agrees: edit `typeclaw.json` (use the `typeclaw-config` skill), ask them to `typeclaw restart` from the **host** stage, and confirm the URL once the rebuilt container is back. Never `curl`/vendor `cloudflared` yourself.
+
+### If `typeclaw tunnel status/list/logs` prints `✖ [object ErrorEvent]`
+
+On older containers the in-container CLI couldn't reach the agent websocket (it resolved the port/token via `docker`, which isn't on `$PATH` inside the container), so these commands failed at the handshake with the opaque line `✖ [object ErrorEvent]`. **That is a CLI-reachability quirk, not a tunnel outage** — do not report it to the user as "the tunnel is down" or "I can't get the URL." Fall back to the direct diagnosis above (read `typeclaw.json`, `command -v cloudflared`, probe the upstream). Current containers resolve the websocket from the in-container `TYPECLAW_*` env instead, so `tunnel status` works in-container and prints a real `detail` line; if you still see `[object ErrorEvent]`, the agent is running an older build and the direct checks are authoritative.
 
 ## Common failure modes
 


### PR DESCRIPTION
## Background

A typeclaw agent (running in production on Discord) was asked for its browser-dashboard tunnel URL. It reported it "couldn't get the tunnel URL," citing `typeclaw tunnel status/logs` crashing with `✖ [object ErrorEvent]` and `cloudflared` seeming absent from the container.

Both observations were correct, but the agent **misdiagnosed** them. Investigation on the host confirmed the real root cause: the agent's `typeclaw.json` had a hand-added `cloudflare-quick` tunnel, but `docker.file.cloudflared` was never set. That toggle is **opt-in (default `false`)** — `typeclaw tunnel add` flips it automatically, but a hand-edited `tunnels[]` entry must set it explicitly. So `cloudflared` was never baked into the image and the tunnel could never produce a URL.

The `✖ [object ErrorEvent]` line was a *second*, separate red herring: when the agent runs `typeclaw tunnel status` from inside its own container, the CLI resolves the agent websocket's port/token by shelling out to `docker` — which isn't on `$PATH` inside the container — so the command fails at the websocket handshake and prints an opaque stringified `ErrorEvent`. The agent read that as "the tunnel is down" and surfaced a dead-end answer to the user.

The `typeclaw-render-pdf` skill already guides the agent through the analogous opt-in for CJK fonts (render → detect tofu □□□ → offer `docker.file.cjkFonts: true` + restart, never vendor a font). Tunnels had no equivalent diagnosis discipline.

## Summary

Adds a "Diagnosing 'the tunnel doesn't work'" section to `typeclaw-tunnels/SKILL.md` mirroring the CJK pattern:

- Lead with the dominant root cause (cloudflared not baked in, because it's opt-in), not the error text.
- Tell the agent to diagnose **directly** — read `typeclaw.json`, `command -v cloudflared`, probe the upstream port — rather than trust a single CLI error line.
- Provide a ready-to-send user message offering the `docker.file.cloudflared: true` + `typeclaw restart` fix, and forbid curling/vendoring the binary.
- Document `✖ [object ErrorEvent]` explicitly as a CLI-reachability quirk (not a tunnel outage) so the agent never reports it as "the tunnel is down."

The frontmatter `description` is widened so the skill triggers on the "tunnel doesn't work / no public URL" failure case, not just on tunnel *setup*.

**Why this wording survives the companion CLI fix:** a sibling PR makes the in-container CLI actually reach the websocket (so `tunnel status` works in-container and the `[object ErrorEvent]` line disappears). This skill is written to stay correct in either merge order — the `[object ErrorEvent]` guidance is framed as a legacy/older-build fallback, and the direct checks are authoritative regardless.

## What this does NOT do

- No code changes — markdown-only. The underlying CLI bugs (in-container auth + `ErrorEvent` stringification) are fixed in a separate PR.
- Does not change tunnel behavior, the schema default, or `tunnel add` (which already sets `cloudflared: true`).

## Review notes

- Load-bearing claim to verify: `docker.file.cloudflared` is `false` by default (`src/config/config.ts` — `cloudflared: z.boolean().default(false)`), and `tunnel add` auto-sets it (`src/cli/tunnel.ts` add/set flows) while hand-edited configs don't.
- The new section is placed before "## Common failure modes" so the diagnosis discipline reads first, then links down into the existing "### `cloudflared` is not installed" entry for the fix detail.
