### PR TITLE
fix(cli): make tunnel status/list/logs work from inside the container

### DIFF
--- a/src/cli/tunnel.test.ts
+++ b/src/cli/tunnel.test.ts
@@ -724,6 +724,50 @@ describe('tunnel live commands', () => {
 
     await expect(pending).resolves.toEqual({ ok: true, value: undefined })
   })
+
+  test('a rejected handshake surfaces a readable reason, never [object ErrorEvent]', async () => {
+    const built = createServer({
+      port: 0,
+      createSession: async () => fakeSession(),
+      tunnelManager: makeTunnelManager(),
+      tuiToken: 'correct-token',
+    }).start()
+    server = built
+
+    // given a URL whose token is wrong, the server rejects the WS upgrade (401),
+    // which the client sees as an 'error' ErrorEvent — the regression source
+    const result = await tunnel.fetchTunnelList({
+      cwd: process.cwd(),
+      url: `ws://localhost:${built.port}/?token=wrong-token`,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected the rejected handshake to fail')
+    expect(result.reason).not.toContain('[object ErrorEvent]')
+    expect(result.reason.length).toBeGreaterThan(0)
+  })
+})
+
+describe('resolveInContainerWsUrl', () => {
+  test('returns null on the host stage (no TYPECLAW_CONTAINER_NAME)', () => {
+    expect(tunnel.resolveInContainerWsUrl({})).toBeNull()
+    expect(tunnel.resolveInContainerWsUrl({ TYPECLAW_TUI_TOKEN: 'tok' })).toBeNull()
+  })
+
+  test('dials CONTAINER_PORT with the token and pathname from env', () => {
+    const url = tunnel.resolveInContainerWsUrl(
+      { TYPECLAW_CONTAINER_NAME: 'agent', TYPECLAW_TUI_TOKEN: 'tok' },
+      '/tunnel-logs',
+    )
+    expect(url).toBe('ws://127.0.0.1:8973/tunnel-logs?token=tok')
+  })
+
+  test('omits the token query when TYPECLAW_TUI_TOKEN is unset or empty', () => {
+    expect(tunnel.resolveInContainerWsUrl({ TYPECLAW_CONTAINER_NAME: 'agent' })).toBe('ws://127.0.0.1:8973/')
+    expect(tunnel.resolveInContainerWsUrl({ TYPECLAW_CONTAINER_NAME: 'agent', TYPECLAW_TUI_TOKEN: '' })).toBe(
+      'ws://127.0.0.1:8973/',
+    )
+  })
 })
 
 async function makeAgentDir(config: Record<string, unknown>): Promise<string> {

--- a/src/cli/tunnel.ts
+++ b/src/cli/tunnel.ts
@@ -5,7 +5,7 @@ import { select, text, password, isCancel, cancel, log } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { loadConfigSync, validateConfig } from '@/config'
-import { resolveHostPort, resolveTuiToken } from '@/container'
+import { CONTAINER_PORT, resolveHostPort, resolveTuiToken } from '@/container'
 import { appendOrReplaceEnvKey, findAgentDir, hasEnvKey, isInitialized } from '@/init'
 import type { ClientMessage, ServerMessage, TunnelLogsServerMessage, TunnelSnapshot } from '@/shared'
 import type { TunnelConfig, TunnelFor, TunnelProvider } from '@/tunnels'
@@ -921,18 +921,48 @@ async function withTuiSocket<T>(
   }
 }
 
-async function resolveWsUrl(cwd: string, input?: string, pathname = '/'): Promise<LiveResult<string>> {
+async function resolveWsUrl(
+  cwd: string,
+  input?: string,
+  pathname = '/',
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<LiveResult<string>> {
   try {
-    const url = input === undefined ? new URL(`ws://127.0.0.1:${await resolveHostPort({ cwd })}`) : new URL(input)
-    if (input === undefined) {
-      const token = await resolveTuiToken({ cwd })
-      if (token !== null) url.searchParams.set('token', token)
+    if (input !== undefined) {
+      const url = new URL(input)
+      url.pathname = pathname
+      return { ok: true, value: url.toString() }
     }
+    // In-container short-circuit: when the agent runs `typeclaw tunnel …` from
+    // inside its own container (the only way it CAN run it), `docker` is not on
+    // $PATH, so the host-side discovery below (resolveHostPort/resolveTuiToken,
+    // which both shell out to `docker`) fails and the websocket connect aborts
+    // with the opaque `[object ErrorEvent]`. typeclaw's `docker run` sets
+    // TYPECLAW_CONTAINER_NAME (always) and TYPECLAW_TUI_TOKEN (when configured),
+    // and the agent's WS server listens on CONTAINER_PORT on the container
+    // loopback — so we can dial directly without docker. Mirrors the same
+    // short-circuit in src/cron/bridge.ts (resolveInContainerUrl).
+    const inContainer = resolveInContainerWsUrl(env, pathname)
+    if (inContainer !== null) return { ok: true, value: inContainer }
+    const url = new URL(`ws://127.0.0.1:${await resolveHostPort({ cwd })}`)
+    const token = await resolveTuiToken({ cwd })
+    if (token !== null) url.searchParams.set('token', token)
     url.pathname = pathname
     return { ok: true, value: url.toString() }
   } catch (err) {
     return { ok: false, reason: err instanceof Error ? err.message : String(err) }
   }
+}
+
+// Returns null on the host stage (TYPECLAW_CONTAINER_NAME unset), where the
+// docker-based discovery in resolveWsUrl is the right path.
+export function resolveInContainerWsUrl(env: NodeJS.ProcessEnv, pathname = '/'): string | null {
+  if (env.TYPECLAW_CONTAINER_NAME === undefined) return null
+  const url = new URL(`ws://127.0.0.1:${CONTAINER_PORT}`)
+  const token = env.TYPECLAW_TUI_TOKEN
+  if (token !== undefined && token !== '') url.searchParams.set('token', token)
+  url.pathname = pathname
+  return url.toString()
 }
 
 function waitForOpen(ws: WebSocket, timeoutMs: number): Promise<void> {
@@ -948,13 +978,28 @@ function waitForOpen(ws: WebSocket, timeoutMs: number): Promise<void> {
     )
     ws.addEventListener(
       'error',
-      (err) => {
+      (event) => {
         clearTimeout(timer)
-        reject(err)
+        reject(new Error(describeWsErrorEvent(event)))
       },
       { once: true },
     )
   })
+}
+
+// A WebSocket 'error' listener fires with an ErrorEvent, NOT an Error. Passing
+// it straight to a catch site that does `String(err)` yields the useless
+// `[object ErrorEvent]`. Pull the real message out (`.message`, or the nested
+// `.error`) so failures read like `Expected 101 status code` / connection
+// refused instead.
+function describeWsErrorEvent(event: unknown): string {
+  if (event instanceof Error) return event.message
+  if (typeof event === 'object' && event !== null) {
+    const { message, error } = event as { message?: unknown; error?: unknown }
+    if (typeof message === 'string' && message !== '') return message
+    if (error instanceof Error && error.message !== '') return error.message
+  }
+  return 'websocket connection failed'
 }
 
 function waitForServerMessage(


### PR DESCRIPTION
## Background

A production agent was asked for its tunnel URL. It reported back that `typeclaw tunnel status/logs` was crashing with `✖ [object ErrorEvent]`, and gave up — surfacing a dead-end answer to the user instead of the real cause.

Root cause: when the **agent** runs `typeclaw tunnel status/list/logs`, it runs them **inside its own container** — the only place it can. `resolveWsUrl` discovers the agent websocket by shelling out to `docker port` (host port) and `docker inspect` (TUI token label). But there is no `docker` binary inside the container, so discovery fails and the websocket connect aborts. The WebSocket `'error'` listener in `waitForOpen` then rejected with a raw **`ErrorEvent`** (not an `Error`); the catch sites do `err instanceof Error ? err.message : String(err)`, and since `ErrorEvent` is not an `Error`, that collapses to `String(errorEvent)` → the useless `[object ErrorEvent]`. The real cause (`Expected 101 status code` / connection refused) was thrown away.

This was verified on a live agent: pre-fix, both `tunnel list` and `tunnel status` printed only `✖ [object ErrorEvent]`, even though the agent's own WS server answered HTTP 200 on the loopback. A websocket probe confirmed the server requires `?token=<TYPECLAW_TUI_TOKEN>` and rejects the handshake without it.

## Summary

Two fixes in `src/cli/tunnel.ts`:

- **In-container reachability.** `resolveWsUrl` now short-circuits to an in-container websocket URL built from `TYPECLAW_CONTAINER_NAME` / `TYPECLAW_TUI_TOKEN` — the env typeclaw injects at `docker run` — dialing `CONTAINER_PORT` on the loopback with no `docker` dependency. This is the **exact** pattern already proven in `src/cron/bridge.ts` (`resolveInContainerUrl`), which short-circuits for the same docker-not-on-PATH reason. Host-stage invocation is unchanged: with no `TYPECLAW_CONTAINER_NAME` set, it falls back to the existing docker-based discovery.

- **Readable errors.** `waitForOpen` unwraps the WebSocket `ErrorEvent` into a real `Error` before rejecting, so every downstream catch site reports the actual message. No need to touch the three `String(err)` sites — fixing it at the source covers all of them.

**Why short-circuit and not "make `--url` carry the token":** the agent's normal call is `typeclaw tunnel status` with no `--url`. The host-discovery path is what breaks in-container, so the fix belongs there. `--url` remains an explicit override (the caller supplies the full URL including any token).

Verified post-fix on the same live agent: `tunnel status browser-dashboard` now reaches the server and prints the real detail — `cloudflared binary not found in image; set docker.file.cloudflared: true in typeclaw.json and run typeclaw restart` — exactly the guidance the agent should have given originally.

## What this does NOT do

- Does not change host-stage behavior, the WS auth scheme, or the server.
- Does not install `cloudflared` or change the `docker.file.cloudflared` default — that opt-in (and the agent-facing guidance for it) is handled separately (skill PR #818).
- Does not touch the cron/reload in-container paths, which already had their own short-circuits.

## Review notes

- Load-bearing parity: the new `resolveInContainerWsUrl` mirrors `resolveInContainerUrl` in `src/cron/bridge.ts` (port = `CONTAINER_PORT`, token from env, omitted when empty). Kept local to `cli/tunnel.ts` rather than importing from `cron/` to avoid a cli→cron dependency; the logic is ~6 lines.
- The `describeWsErrorEvent` unwrap order is `.message` then nested `.error.message`, matching how browsers/undici populate `ErrorEvent`.
- New tests: a rejected handshake (wrong token) now asserts the reason is non-empty and never contains `[object ErrorEvent]`; `resolveInContainerWsUrl` is unit-tested for host-stage null, token+pathname dialing, and empty-token omission.
