### PR TITLE
feat(memory): observability log lines for logger, dreaming, and retrieval

### DIFF
--- a/src/bundled-plugins/memory/README.md
+++ b/src/bundled-plugins/memory/README.md
@@ -106,6 +106,16 @@ A `[dreaming] citation-superset violation: …` warning logs the dropped ids and
 - **`memory/.dreaming-state.json`** — per-day dreamed-id sets.
 - **`memory/.retrieval-cache/<sessionId>.md`** — ephemeral retrieval summaries. Written by `memory-retrieval`, read by `loadMemory` on the next prompt of the same session, unlinked on `session.end`.
 
+## Observability
+
+The plugin emits structured `[plugin:memory]` log lines (no separate metrics infra). The load-bearing per-run signals:
+
+- **`[memory-logger] <session> done fragments_written=N elapsed_ms=…`** — how many fragments a logger run captured (delta of fragment events in today's stream).
+- **`[dreaming] done topics_created=N topics_removed=N superseded_new=N fragments_dropped=N elapsed_ms=…`** — consolidation activity per run: new/removed topic shards (by snapshot path diff), net citations moved into `superseded:`, and fragments GC'd. `topics_created` + reinforcement is the "is memory getting sharper" signal; `superseded_new` is contradiction-edit volume. Derived by `computeDreamingMetrics` from the pre/post shard snapshots.
+- **`[vector-retrieval] mode=index topic_results=N stream_results=N`** (or `mode=direct topics=N`) — per-turn retrieval breakdown. `stream_results` counts undreamed-fragment hits that self-resolved (no citing topic yet) — the freshness-window usage signal that informs whether the undreamed surface earns its keep.
+
+These are intentionally verbose for now so behavior is observable in logs; trim once the useful subset is known.
+
 ## How `session.idle` works
 
 Core fires `session.idle` immediately after every `session.prompt()` completion. The plugin owns the debounce: a `Map<sessionId, Timeout>` reset on every event. When the timer fires, the plugin spawns `memory-logger` for that session — unless the min-delta gate suppresses the spawn (see below).

--- a/src/bundled-plugins/memory/dreaming-metrics.test.ts
+++ b/src/bundled-plugins/memory/dreaming-metrics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+
+import { computeDreamingMetrics } from './dreaming-metrics'
+
+const ID_A = '019e2eca-6fc5-71ef-add9-67a0955a4b35'
+const ID_B = '019e2ecf-f2d5-70ee-83f6-005fb5451c51'
+
+function snap(entries: Record<string, string>): Map<string, Buffer> {
+  return new Map(Object.entries(entries).map(([path, body]) => [path, Buffer.from(body, 'utf8')]))
+}
+
+describe('computeDreamingMetrics', () => {
+  test('counts created and removed topics by path diff', () => {
+    // given: one topic survives, one is new, one was removed (merged away)
+    const before = snap({ '/t/keep.md': 'a', '/t/gone.md': 'b' })
+    const after = snap({ '/t/keep.md': 'a', '/t/new.md': 'c' })
+
+    expect(computeDreamingMetrics(before, after)).toEqual({
+      topicsCreated: 1,
+      topicsRemoved: 1,
+      supersededDelta: 0,
+    })
+  })
+
+  test('reports net superseded citations gained this run', () => {
+    // given: a belief switched, moving one fragment into superseded:
+    const before = snap({ '/t/pm.md': ['Uses bun.', 'fragments:', `- streams/2026-06-10#${ID_A}`].join('\n') })
+    const after = snap({
+      '/t/pm.md': [
+        'Uses pnpm.',
+        'fragments:',
+        `- streams/2026-06-11#${ID_B}`,
+        'superseded:',
+        `- streams/2026-06-10#${ID_A}`,
+      ].join('\n'),
+    })
+
+    expect(computeDreamingMetrics(before, after).supersededDelta).toBe(1)
+  })
+
+  test('empty before and after yield all zeros', () => {
+    expect(computeDreamingMetrics(new Map(), new Map())).toEqual({
+      topicsCreated: 0,
+      topicsRemoved: 0,
+      supersededDelta: 0,
+    })
+  })
+})

--- a/src/bundled-plugins/memory/dreaming-metrics.ts
+++ b/src/bundled-plugins/memory/dreaming-metrics.ts
@@ -1,0 +1,28 @@
+import { splitCitationsBySection } from './citations'
+
+export type DreamingMetrics = {
+  topicsCreated: number
+  topicsRemoved: number
+  supersededDelta: number
+}
+
+// Snapshots are keyed by absolute shard path → file bytes (captureShardSnapshot).
+// supersededDelta is the net change in citations under `superseded:` across all
+// shards, i.e. how many fragments were overturned this run.
+export function computeDreamingMetrics(before: Map<string, Buffer>, after: Map<string, Buffer>): DreamingMetrics {
+  let topicsCreated = 0
+  for (const path of after.keys()) if (!before.has(path)) topicsCreated += 1
+
+  let topicsRemoved = 0
+  for (const path of before.keys()) if (!after.has(path)) topicsRemoved += 1
+
+  const supersededDelta = countSuperseded(after) - countSuperseded(before)
+
+  return { topicsCreated, topicsRemoved, supersededDelta }
+}
+
+function countSuperseded(snapshot: Map<string, Buffer>): number {
+  let total = 0
+  for (const bytes of snapshot.values()) total += splitCitationsBySection(bytes.toString('utf8')).superseded.size
+  return total
+}

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -11,6 +11,7 @@ import { formatLocalDate, formatLocalDateTime } from '@/shared'
 import { checkCitationSupersetAcrossShards, summarizeMissingCitations } from './citation-superset'
 import { parseCitations } from './citations'
 import { deleteTopicShardTool } from './delete-tool'
+import { computeDreamingMetrics } from './dreaming-metrics'
 import {
   addDreamedIds,
   DREAMING_STATE_FILE,
@@ -1082,9 +1083,11 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
         }
       }
 
+      let metrics = computeDreamingMetrics(snapshotBefore, snapshotBefore)
       if (shardsRewrittenThisRun) {
         await recomputeFrontmatterForAllShards(ctx.payload.agentDir, logger)
         const snapshotAfterFrontmatter = await captureShardSnapshot(topicsDir(ctx.payload.agentDir))
+        metrics = computeDreamingMetrics(snapshotBefore, snapshotAfterFrontmatter)
         await syncTopicVectorsFromSnapshotDiff(
           ctx.payload.agentDir,
           snapshotBefore,
@@ -1117,7 +1120,9 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
 
       try {
         await commit(ctx.payload.agentDir)
-        logger.info(`[dreaming] done elapsed_ms=${Date.now() - start}`)
+        logger.info(
+          `[dreaming] done topics_created=${metrics.topicsCreated} topics_removed=${metrics.topicsRemoved} superseded_new=${metrics.supersededDelta} fragments_dropped=${compaction.fragmentsDropped} elapsed_ms=${Date.now() - start}`,
+        )
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         logger.warn(`[dreaming] commit failed: ${message} elapsed_ms=${Date.now() - start}`)

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -76,6 +76,25 @@ describe('vector session.turn.start hook', () => {
     expect(retrievalContext.results).toContain('second body')
   })
 
+  test('zero-shard direct mode still logs the mode=direct topics=0 signal', async () => {
+    hybridSearchMock.mockClear()
+    const memoryPlugin = (await import('./index')).default
+    // given: a fresh agent with no topic shards → direct mode, zero shards
+    const infos: string[] = []
+    const exports = await bootVectorPlugin(memoryPlugin, 16384, capturingLogger(infos))
+
+    const retrievalContext = { results: '' }
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_vector', agentDir, userPrompt: 'anything', retrievalContext },
+      { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') },
+    )
+
+    // then: nothing injected, hybrid search skipped, but the signal is still logged
+    expect(retrievalContext.results).toBe('')
+    expect(hybridSearchMock).not.toHaveBeenCalled()
+    expect(infos).toContain('[vector-retrieval] mode=direct topics=0')
+  })
+
   test('memory-logger subagent is created with onFragmentsAppended hook when vector.enabled is true', async () => {
     const memoryPlugin = (await import('./index')).default
     const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096, vector: { enabled: true } })
@@ -123,7 +142,11 @@ describe('vector session.turn.start hook', () => {
   })
 })
 
-async function bootVectorPlugin(memoryPlugin: typeof import('./index').default, injectionBudgetBytes: number) {
+async function bootVectorPlugin(
+  memoryPlugin: typeof import('./index').default,
+  injectionBudgetBytes: number,
+  logger = createPluginLogger('memory'),
+) {
   const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes, vector: { enabled: true } })
   if (!parsed.success) throw new Error(parsed.error.message)
   const ctx = createPluginContext({
@@ -131,12 +154,21 @@ async function bootVectorPlugin(memoryPlugin: typeof import('./index').default, 
     version: undefined,
     agentDir,
     config: parsed.data,
-    logger: createPluginLogger('memory'),
+    logger,
     permissions: noopPermissionService,
     spawnSubagent: async () => {},
     isBooted: () => true,
   })
   return memoryPlugin.plugin(ctx)
+}
+
+function capturingLogger(infos: string[]) {
+  return {
+    ...createPluginLogger('memory'),
+    info: (msg: string) => {
+      infos.push(msg)
+    },
+  }
 }
 
 async function writeTopic(dir: string, slug: string, heading: string, body: string): Promise<void> {

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -148,15 +148,21 @@ const VECTOR_TURN_TOP_K = 10
 async function renderVectorTurnMemory(
   event: { agentDir: string; userPrompt: string; origin?: SessionOrigin },
   injectionBudgetBytes: number,
+  logger?: { info: (msg: string) => void },
 ): Promise<string> {
   const plan = await loadMemoryInjectionPlan(event.agentDir, { injectionBudgetBytes })
   if (plan.mode === 'direct') {
     if (plan.shards.length === 0) return ''
+    logger?.info(`[vector-retrieval] mode=direct topics=${plan.shards.length}`)
     return renderMemorySection(plan, { origin: event.origin })
   }
   const store = VectorStore.open(join(event.agentDir, 'memory', '.vectors', 'index.db'))
   try {
     const results = await hybridSearch(event.userPrompt, store, event.agentDir, VECTOR_TURN_TOP_K)
+    const topicHits = results.reduce((n, r) => (r.source === 'topic' ? n + 1 : n), 0)
+    logger?.info(
+      `[vector-retrieval] mode=index topic_results=${topicHits} stream_results=${results.length - topicHits}`,
+    )
     return renderRetrievedMemorySection(results, { origin: event.origin })
   } finally {
     store.close()
@@ -427,7 +433,11 @@ export default definePlugin({
             // memory via the system prompt either.
             if (event.retrievalContext === undefined) return
             try {
-              event.retrievalContext.results = await renderVectorTurnMemory(event, ctx.config.injectionBudgetBytes)
+              event.retrievalContext.results = await renderVectorTurnMemory(
+                event,
+                ctx.config.injectionBudgetBytes,
+                ctx.logger,
+              )
             } catch (err) {
               ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
             }

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -152,8 +152,8 @@ async function renderVectorTurnMemory(
 ): Promise<string> {
   const plan = await loadMemoryInjectionPlan(event.agentDir, { injectionBudgetBytes })
   if (plan.mode === 'direct') {
-    if (plan.shards.length === 0) return ''
     logger?.info(`[vector-retrieval] mode=direct topics=${plan.shards.length}`)
+    if (plan.shards.length === 0) return ''
     return renderMemorySection(plan, { origin: event.origin })
   }
   const store = VectorStore.open(join(event.agentDir, 'memory', '.vectors', 'index.db'))

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -7,6 +7,7 @@ import { formatLocalDate } from '@/shared'
 import { advanceWatermarkTool, createAppendTool, type FragmentsAppendedHook } from './append-tool'
 import { findEntryTool } from './find-entry-tool'
 import { streamFilePath, streamsDir } from './paths'
+import { readEvents } from './stream-io'
 import { readLatestWatermark } from './watermark'
 
 export const memoryLoggerPayloadSchema = z.object({
@@ -339,13 +340,17 @@ export function createMemoryLoggerSubagent(
       const memoryDir = streamsDir(ctx.payload.agentDir)
       const streamFile = streamFilePath(ctx.payload.agentDir, today)
       const watermark = await readLatestWatermark(memoryDir, ctx.payload.parentSessionId)
+      const fragmentsBefore = await countFragments(streamFile)
       const start = Date.now()
       logger.info(
         `[memory-logger] ${ctx.payload.parentSessionId} start stream=${today}.jsonl watermark=${watermark ?? 'none'}`,
       )
       try {
         await runSession({ userPrompt: buildInitialPrompt(ctx.payload, streamFile, watermark) })
-        logger.info(`[memory-logger] ${ctx.payload.parentSessionId} done elapsed_ms=${Date.now() - start}`)
+        const fragmentsWritten = (await countFragments(streamFile)) - fragmentsBefore
+        logger.info(
+          `[memory-logger] ${ctx.payload.parentSessionId} done fragments_written=${fragmentsWritten} elapsed_ms=${Date.now() - start}`,
+        )
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         logger.warn(
@@ -355,6 +360,11 @@ export function createMemoryLoggerSubagent(
       }
     },
   }
+}
+
+async function countFragments(streamFile: string): Promise<number> {
+  const events = await readEvents(streamFile)
+  return events.reduce((n, event) => (event.type === 'fragment' ? n + 1 : n), 0)
 }
 
 export const memoryLoggerSubagent: Subagent<MemoryLoggerPayload> = createMemoryLoggerSubagent()


### PR DESCRIPTION
## Background

The memory subsystem had almost no per-run signal: the memory-logger and dreaming "done" lines reported only `elapsed_ms`, and vector retrieval logged nothing about what it returned. There was no way to answer operational questions like "is memory actually consolidating?", "how much is the logger capturing?", or "how often do undreamed fragments get retrieved?" — which we need before tuning or further simplifying the memory model.

There is no metrics/telemetry infrastructure in the repo (the `src/usage/` module is a post-hoc session scanner). So this PR follows the existing pattern: structured `[plugin:memory]` log lines via `ctx.logger.info`.

## What this does

Adds three per-run log lines, one per subsystem:

- **memory-logger** — `done fragments_written=N elapsed_ms=…`. `countFragments` counts fragment events in today's stream before and after the subagent run; the delta is what the run captured.
- **dreaming** — `done topics_created=N topics_removed=N superseded_new=N fragments_dropped=N elapsed_ms=…`. `computeDreamingMetrics` (new pure helper, unit-tested) diffs the pre/post shard snapshots: `topics_created`/`topics_removed` by snapshot path diff, `superseded_new` as the net change in citations under `superseded:`. This is the "is memory getting sharper" signal — consolidation activity + contradiction-edit volume.
- **vector retrieval** — `mode=direct topics=N` or `mode=index topic_results=N stream_results=N`. `stream_results` counts undreamed-fragment self-resolves (no citing topic yet) — the freshness-window usage signal that tells us whether the undreamed surface earns its keep.

## Why verbose for now

Intentionally logs all three sites so behavior is observable in real logs over time. Once the useful subset is known, the noisy ones can be trimmed. The README's new Observability section documents each line.

## What this does NOT do

- No new metrics/telemetry infra, no new command, no config. Pure `ctx.logger.info` lines.
- No behavior change to logging-existing paths beyond appending fields to the two `done` lines (existing tests assert `startsWith('… done')`, which still holds).
- No change to memory semantics (logger/dreaming/retrieval all behave identically; only their logging is richer).

## Tests

- `dreaming-metrics.test.ts` (new): created/removed by path diff, net superseded delta, empty case.
- Existing memory-logger and dreaming `done`-line assertions still pass (prefix unchanged).

## Verification

- `bun run typecheck` clean
- `bun run lint` 0 errors
- `bun run format:check` clean
- `bun run test` — 8786 pass / 0 fail / 1 skip