### PR TITLE
fix(channels): seed per-turn memory retrieval with the pure user message

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -979,6 +979,67 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(prompt.indexOf('unrelated')).toBeLessThan(prompt.indexOf('hey bot'))
   })
 
+  test('seeds the session.turn.start retrieval query with the pure user message, not recent context or framing', async () => {
+    const dir = await tempDir()
+    const turnStartPrompts: string[] = []
+    const hooks: HookBus = {
+      registerAll: () => {},
+      unregisterAll: () => {},
+      runSessionStart: async () => {},
+      runSessionEnd: async () => {},
+      runSessionIdle: async () => {},
+      runSessionPrompt: async () => {},
+      runSessionTurnStart: async (e) => {
+        turnStartPrompts.push(e.userPrompt)
+      },
+      runSessionTurnEnd: async () => {},
+      runToolBefore: async () => undefined,
+      runToolAfter: async () => {},
+      count: () => 0,
+    }
+    const { router } = makeRouter(dir, { hooks })
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    turnStartPrompts.length = 0
+    await router.route(inbound({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: 'unrelated chatter' }))
+    await router.route(inbound({ text: 'what was that PR about?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const query = turnStartPrompts[0]!
+    expect(query).toBe('what was that PR about?')
+    expect(query).not.toContain('Recent context')
+    expect(query).not.toContain('Current message')
+    expect(query).not.toContain('unrelated chatter')
+    expect(query).not.toContain(FIXED_INBOUND_ISO)
+    expect(query).not.toContain('<@alice>')
+  })
+
+  test('joins a multi-message batch into the retrieval query without author or timestamp framing', async () => {
+    const dir = await tempDir()
+    const turnStartPrompts: string[] = []
+    const hooks: HookBus = {
+      registerAll: () => {},
+      unregisterAll: () => {},
+      runSessionStart: async () => {},
+      runSessionEnd: async () => {},
+      runSessionIdle: async () => {},
+      runSessionPrompt: async () => {},
+      runSessionTurnStart: async (e) => {
+        turnStartPrompts.push(e.userPrompt)
+      },
+      runSessionTurnEnd: async () => {},
+      runToolBefore: async () => undefined,
+      runToolAfter: async () => {},
+      count: () => 0,
+    }
+    const { router } = makeRouter(dir, { hooks })
+    await router.route(inbound({ text: 'first line' }))
+    await router.route(inbound({ text: 'second line' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(turnStartPrompts[0]!).toBe('first line\nsecond line')
+  })
+
   test('labels the current message even when there is no recent context', async () => {
     // Regression: the `## Current message` header used to be gated on
     // observed.length > 0, so a turn carrying only the current message (no

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2170,7 +2170,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.policyDeniedToolSendsThisTurn.clear()
         resetReviewTurn(live.sessionId)
         const isRealUserTurn = batch.length > 0
-        const retrievalContext = await fireSessionTurnStart(live, text)
+        const retrievalContext = await fireSessionTurnStart(live, composeRetrievalQuery(batch))
         const promptText = retrievalContext.results.length > 0 ? `${text}\n\n${retrievalContext.results}` : text
         try {
           await live.session.prompt(promptText)
@@ -4307,6 +4307,21 @@ function composeTurnPrompt(
     }
   }
   return parts.join('\n')
+}
+
+// The per-turn memory hook must query on ONLY what the human typed this turn,
+// not the composeTurnPrompt envelope (time anchor, system reminders, and the
+// "## Recent context" block). That envelope dwarfs the actual message, so
+// embedding it lets recent-context drift dominate both retrieval lanes and the
+// injected memory tracks the scrollback topic instead of the current question.
+// Strip all framing — headings, author attribution, quote anchors — down to raw
+// text, one batch entry per line. A reminder-only drain yields '', which
+// hybridSearch no-ops: correct, since there is no new user message to match.
+function composeRetrievalQuery(batch: readonly QueuedInbound[]): string {
+  return batch
+    .map((b) => b.text.trim())
+    .filter((t) => t.length > 0)
+    .join('\n')
 }
 
 function formatAuthorLine(


### PR DESCRIPTION
## Background

When `memory.vector.enabled` is on, the `session.turn.start` hook performs a per-turn `hybridSearch` and injects the top-K long-term-memory shards into the user turn. The query for that search is supposed to be **what the user just asked**.

In the channel path it wasn't. Observed in a live Discord session: the user opened a turn with a bare greeting, but the injected `# Memory` block was full of shards matching the *recent scrollback* (PR-review chatter, cron edits) — not the greeting. The retrieved memories tracked the conversation's drift instead of the current message.

Root cause: the channel router's drain loop built the full turn prompt via `composeTurnPrompt(observed, batch, …)` and passed that **entire envelope** as the retrieval query (the `fireSessionTurnStart(live, text)` call in `router.ts`). That envelope leads with a time anchor, role anchor, system reminders, loop-guard / group-chat notices, and the whole `## Recent context (not addressed to you)` block — all of which dwarf the user's actual message. Embedding that blob let recent-context text dominate both the vector and keyword lanes of `hybridSearch`, so retrieval matched the scrollback topic.

Every other turn-driver (server TUI, cron consumer, subagent runner, command-runner) already passes only the raw user text as `userPrompt`. The channel router was the lone violator of the documented contract (`memory/README.md`: the hook "brackets every `session.prompt(text)` call with the user's literal text"). This is the same class of bug PR #340 fixed for the system-prompt path — re-surfacing here via recent-context instead of framing prose.

## Summary

Add `composeRetrievalQuery(batch)` — a pure function that strips every framing layer (headings, author attribution `[ts] <@id> (name):`, quote anchors) down to the raw message text, one batch entry per line — and feed *that* to `fireSessionTurnStart`. `session.prompt()` still receives the full composed `text`, so nothing the model sees in the actual turn changes.

Why query on `batch` only and not the `observed` recent context: recent context is awareness scaffolding, not the question. The user's intent for *this* turn is the batch text. This restores parity with the four other turn-drivers.

Reminder-only drains (`batch.length === 0`) yield an empty query, which `hybridSearch` no-ops — correct, since there is no new user message to retrieve against.

## What this does NOT do

- Does not change the prompt the model receives (`session.prompt` still gets the full `composeTurnPrompt` output + retrieval results).
- Does not touch the TUI / cron / subagent / command-runner drivers — they were already correct.
- Does not alter `hybridSearch`, the memory plugin, or the `SessionTurnStartEvent` contract. Channel-local fix only.
- Does not include `referenceContext` (quoted/replied-to text) in the query — that's what the user is replying *to*, not what they typed.

## Review notes

- Load-bearing change: `router.ts` — `fireSessionTurnStart(live, text)` → `fireSessionTurnStart(live, composeRetrievalQuery(batch))`. The `promptText` line below it is unchanged and still uses the full `text`.
- Invariant to verify: the retrieval query must contain none of the envelope. Both new tests assert this — one checks a single engaged message after observed chatter (query equals the bare message, no `## Recent context`, no author line, no ISO timestamp), the other checks a multi-message batch joins by newline.
- TDD-confirmed: reverting the one-line call-site change fails both new tests; restoring it passes them. Full suite green (8764 pass, 0 fail).