### PR TITLE
fix(memory): sum reciprocal ranks across vector and keyword lanes

### DIFF
--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 })
 
 describe('hybridSearch', () => {
-  it('QA 1.6: fuses exact-ID keyword hits and semantic vector hits via MAX-child RRF', async () => {
+  it('QA 1.6: sums vector + keyword reciprocal ranks for a hit found by both lanes', async () => {
     const { agentDir, store } = createFixture()
     try {
       writeTopic(agentDir, 'pr-651', 'PR 651 Review', 'PR #651 fixed channel reload handling.')
@@ -36,8 +36,7 @@ describe('hybridSearch', () => {
       const exact = exactResults.find((result) => result.key === 'pr-651')
 
       expect(exactResults.slice(0, 3).map((result) => result.key)).toContain('pr-651')
-      // pr-651 is hit by both lanes; MAX fusion keeps the best lane score (1/61), not the sum.
-      expect(exact?.rrfScore).toBeCloseTo(1 / 61, 10)
+      expect(exact?.rrfScore).toBeCloseTo(1 / 61 + 1 / 61, 10)
 
       const semanticResults = await hybridSearch(
         'focused memory summary retrieval',
@@ -50,6 +49,26 @@ describe('hybridSearch', () => {
 
       expect(semanticResults.slice(0, 3).map((result) => result.key)).toContain('semantic-cache')
       expect(semantic?.rrfScore).toBeCloseTo(1 / 61, 10)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('lifts a low-vector-rank topic above pure-cosine noise when the keyword lane corroborates', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeTopic(agentDir, 'person-note', 'Person Note', 'Reply conventions for 홍길동 in the group chat.')
+      writeTopic(agentDir, 'noise-a', 'Noise A', 'Unrelated English PR review note about channel reload.')
+      writeTopic(agentDir, 'noise-b', 'Noise B', 'Another unrelated English note about docker builds.')
+
+      store.upsert(row('topic:noise-a', 'noise-a', vector({ 0: 0.9 })))
+      store.upsert(row('topic:noise-b', 'noise-b', vector({ 0: 0.8 })))
+      store.upsert(row('topic:person-note', 'person-note', vector({ 0: 0.1 })))
+
+      const results = await hybridSearch('홍길동', store, agentDir, 3, embedFrom({ 0: 1 }))
+
+      expect(results[0]?.key).toBe('person-note')
+      expect(results[0]?.rrfScore).toBeGreaterThan(results[1]?.rrfScore ?? 0)
     } finally {
       store.close()
     }

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -59,47 +59,69 @@ function keywordLane(
   return 'matches' in result ? result.matches : []
 }
 
-// Parent-child fusion. Each lane hit scores its node by RRF rank, then nodes
-// collapse to their parent topic via the citation link: a matched fragment
-// contributes to the topic that cites it, never as a standalone result. An
-// undreamed fragment (no citing topic yet) resolves to itself, preserving the
-// freshness window. Collapsed parents take the MAX of their members' scores,
-// not the sum — sum would over-rank often-revised topics purely for having more
-// historical citations to match (PARADE: max beats sum for concentrated relevance).
+// Reciprocal Rank Fusion across two rankers (vector + keyword). Each lane is
+// collapsed to per-parent scores INDEPENDENTLY (MAX over a parent's children
+// within that lane), then the two lanes' per-parent scores are SUMMED. The two
+// reductions are different on purpose:
+//
+//   - WITHIN a lane, a topic's children (the fragments citing it) collapse by
+//     MAX — summing would over-rank often-revised topics purely for having more
+//     historical citations to match (PARADE: max beats sum for concentrated
+//     relevance).
+//   - ACROSS lanes, the per-parent contributions SUM — cross-ranker agreement
+//     is the entire signal RRF exists to capture. A topic found by BOTH the
+//     vector and the keyword lane must outrank one found by a single lane, so
+//     its score is 1/(k+rankVector) + 1/(k+rankKeyword). Collapsing both lanes
+//     into one map and taking MAX (the previous behavior) discarded that
+//     agreement, leaving every result carrying a single lane's reciprocal rank.
 function fuseLanes(
   vectorRows: VectorRow[],
   keywordMatches: MemorySearchMatch[],
   index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
   parentSlugsByFragmentId: Map<string, Set<string>>,
 ): HybridSearchResult[] {
+  const vectorLane = collapseLane(
+    vectorRows.map((row, i) => ({ source: row.source, key: row.key, score: 1 / (RRF_K + i + 1) })),
+    index,
+    parentSlugsByFragmentId,
+  )
+  const keywordLane = collapseLane(
+    keywordMatches.map((match, i) => ({ source: match.source, key: matchKey(match), score: 1 / (RRF_K + i + 1) })),
+    index,
+    parentSlugsByFragmentId,
+  )
+
   const fused = new Map<string, HybridSearchResult>()
-
-  for (let i = 0; i < vectorRows.length; i++) {
-    const row = vectorRows[i]!
-    addScore(fused, index, row.source, row.key, 1 / (RRF_K + i + 1), parentSlugsByFragmentId)
-  }
-
-  for (let i = 0; i < keywordMatches.length; i++) {
-    const match = keywordMatches[i]!
-    addScore(fused, index, match.source, matchKey(match), 1 / (RRF_K + i + 1), parentSlugsByFragmentId)
+  for (const lane of [vectorLane, keywordLane]) {
+    for (const [fusedKey, { content, score }] of lane) {
+      const existing = fused.get(fusedKey)
+      if (existing !== undefined) existing.rrfScore += score
+      else fused.set(fusedKey, { ...content, rrfScore: score })
+    }
   }
 
   return [...fused.values()].sort((a, b) => b.rrfScore - a.rrfScore || a.key.localeCompare(b.key))
 }
 
-function addScore(
-  fused: Map<string, HybridSearchResult>,
+type LaneHit = { source: 'topic' | 'stream'; key: string; score: number }
+type LaneEntry = { content: Omit<HybridSearchResult, 'rrfScore'>; score: number }
+
+// Returns one lane's per-parent scores so the caller can SUM across lanes;
+// folding straight into a shared map would force a cross-lane MAX instead.
+function collapseLane(
+  hits: LaneHit[],
   index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
-  source: 'topic' | 'stream',
-  nodeKey: string,
-  score: number,
   parentSlugsByFragmentId: Map<string, Set<string>>,
-): void {
-  for (const { fusedKey, content } of resolveToParents(source, nodeKey, index, parentSlugsByFragmentId)) {
-    const existing = fused.get(fusedKey)
-    if (existing !== undefined) existing.rrfScore = Math.max(existing.rrfScore, score)
-    else fused.set(fusedKey, { ...content, rrfScore: score })
+): Map<string, LaneEntry> {
+  const lane = new Map<string, LaneEntry>()
+  for (const hit of hits) {
+    for (const { fusedKey, content } of resolveToParents(hit.source, hit.key, index, parentSlugsByFragmentId)) {
+      const existing = lane.get(fusedKey)
+      if (existing !== undefined) existing.score = Math.max(existing.score, hit.score)
+      else lane.set(fusedKey, { content, score: hit.score })
+    }
   }
+  return lane
 }
 
 // A matched fragment collapses to EVERY topic that cites it (a fragment can back


### PR DESCRIPTION
## Problem

For a vector-memory agent, the per-turn injected memory was frequently **irrelevant to the current message**. Asking about a person whose name appears verbatim in a topic shard would inject ~10 topics where ~9 were unrelated, and the matching shard was not reliably surfaced.

Root cause is in `hybridSearch`'s fusion. Both retrieval lanes (semantic **vector** + substring **keyword**) were folded into a single map, and collisions were collapsed with `Math.max`:

```ts
if (existing !== undefined) existing.rrfScore = Math.max(existing.rrfScore, score)
```

Reciprocal Rank Fusion's whole purpose is to reward **cross-ranker agreement** by *summing* reciprocal ranks: `score = 1/(k+rankVector) + 1/(k+rankKeyword)`. Taking `Math.max` across lanes discards that agreement — a topic found by **both** lanes scored identically to one found by a single lane. Every result ended up carrying just one lane's reciprocal rank, so ranking degraded to pure cosine order over coarse topic-belief summaries.

### Evidence (probe against a real 193-shard index)

Every query returned a clean single-fraction score per result — `1/61, 1/62, … 1/70` — i.e. one lane contributing at one rank, no summation. A shard that **literally contained** the queried term was a keyword hit at rank 1, but its keyword contribution (`1/61`) was discarded in favor of, or merely tied with, its lower vector rank — so it floated wherever cosine happened to place it (rank 1 in one phrasing, rank 8 in another).

## Fix

Collapse **each lane independently** to per-parent scores (taking `MAX` over a parent's citing fragments — the existing PARADE concentrated-relevance rule), then **`SUM`** the two lanes' per-parent contributions:

- **Within a lane** → `MAX` over children (unchanged; summing would over-rank often-revised topics for having more historical citations to match).
- **Across lanes** → `SUM` (restored; this is the RRF agreement signal).

A topic corroborated by both lanes now scores `1/(k+rankVector) + 1/(k+rankKeyword)` and rises above single-lane noise.

### Before / after (same real index)

| Query | Before (top-1) | After (top-1) |
| --- | --- | --- |
| name in a shard | wrong topic / unstable rank | **correct shard, rank 1**, summed score `≈0.031` clearly above the `≈0.0164` noise floor |
| another name in a shard | tied at `1/61` | **correct shard, rank 1**, `≈0.033` (`2/61`, both lanes agree) |

A query whose subject genuinely isn't in memory still returns no relevant match (correct — the agent should say it doesn't know).

## Scope / what this does NOT fix

This is the cross-lane fusion fix only. A separate, independent gap remains: the keyword lane uses a whole-query substring matcher with no phrase/token fallback or normalization, so a natural-language query with attached particles or punctuation (e.g. a name with a trailing grammatical particle) still produces **no** keyword hit and falls back to pure cosine. That requires keyword-lane normalization and is intentionally out of scope here. Filed as follow-up.

## Tests

- `hybrid.test.ts`: the both-lanes case now asserts the **summed** RRF score (was asserting the buggy `MAX`).
- New regression: a topic ranked **low** in the vector lane but corroborated by the keyword lane is lifted to **rank 1** after the cross-lane sum.
- The within-lane "rank a parent by the MAX of its children, not the sum" test is unchanged and still passes — confirming the two reductions stay distinct.
- Full suite green (`bun run typecheck` / `lint` / `format:check` / `test`).
