### PR TITLE
feat(inspect): surface in-flight sessions in the picker before reply

### DIFF
--- a/src/agent/live-sessions.test.ts
+++ b/src/agent/live-sessions.test.ts
@@ -42,4 +42,25 @@ describe('LiveSessionRegistry', () => {
     reg.clear()
     expect(reg.size()).toBe(0)
   })
+
+  test('listLive returns only entries that carry an origin', () => {
+    // given a registry with one origin-bearing and one subscribe-only entry
+    const reg = new LiveSessionRegistry()
+    reg.register({ sessionId: 'ses_disk', session: fakeSession })
+    reg.register({
+      sessionId: 'ses_live',
+      session: fakeSession,
+      origin: { kind: 'tui' },
+      registeredAtMs: 123,
+    })
+
+    // when listing live sessions
+    const live = reg.listLive()
+
+    // then the subscribe-only entry is excluded
+    expect(live).toHaveLength(1)
+    expect(live[0]?.sessionId).toBe('ses_live')
+    expect(live[0]?.origin).toEqual({ kind: 'tui' })
+    expect(live[0]?.registeredAtMs).toBe(123)
+  })
 })

--- a/src/agent/live-sessions.ts
+++ b/src/agent/live-sessions.ts
@@ -1,8 +1,16 @@
 import type { AgentSession } from './index'
+import type { MinimalSessionOrigin } from './session-meta'
 
 export type LiveAgentSession = {
   sessionId: string
   session: Pick<AgentSession, 'subscribe'>
+  // Surfaced by the inspect picker for sessions not yet on disk: pi-coding-agent
+  // defers the first .jsonl write until the first assistant message, so without
+  // these a mid-reply session is invisible. Optional so subscribe-only test
+  // harnesses can still register `{ sessionId, session }`; live-listing skips
+  // entries lacking an origin.
+  origin?: MinimalSessionOrigin
+  registeredAtMs?: number
 }
 
 export class LiveSessionRegistry {
@@ -22,6 +30,10 @@ export class LiveSessionRegistry {
 
   has(sessionId: string): boolean {
     return this.entries.has(sessionId)
+  }
+
+  listLive(): LiveAgentSession[] {
+    return [...this.entries.values()].filter((e) => e.origin !== undefined)
   }
 
   size(): number {

--- a/src/agent/session-meta.ts
+++ b/src/agent/session-meta.ts
@@ -1,4 +1,14 @@
+import type { LiveSessionOriginPayload } from '@/shared'
+
 import type { SessionOrigin } from './session-origin'
+
+// Bidirectional structural equality with the wire mirror in @/shared/protocol.
+// @/shared cannot import this module (it is a leaf), so the type cannot be
+// shared directly; these assignments fail typecheck if either side drifts.
+const _originIsWireCompatible: LiveSessionOriginPayload = null as unknown as MinimalSessionOrigin
+const _wireIsOriginCompatible: MinimalSessionOrigin = null as unknown as LiveSessionOriginPayload
+void _originIsWireCompatible
+void _wireIsOriginCompatible
 
 export const SESSION_META_CUSTOM_TYPE = 'typeclaw.session-meta'
 

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty'
 import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/container'
 import { findAgentDir } from '@/init'
 import {
+  fetchLiveSessions,
   listViewerItems,
   openViewerItem,
   parseDuration,
@@ -150,7 +151,8 @@ export async function runInspectViewer(opts: RunInspectViewerOptions): Promise<n
 
   const interactive = Boolean(process.stdin.isTTY)
   const liveHint = interactive ? escHintLine(color) : undefined
-  const liveSource = containerRunning ? await buildLiveSource(cwd) : undefined
+  const inspectUrl = containerRunning ? await resolveInspectUrl(cwd) : undefined
+  const liveSource = inspectUrl !== undefined ? buildLiveSource(inspectUrl) : undefined
 
   const stdout = (line: string): void => {
     process.stdout.write(`${line}\n`)
@@ -186,6 +188,7 @@ export async function runInspectViewer(opts: RunInspectViewerOptions): Promise<n
         onWarn: stderr,
       }
       if (sinceMs !== undefined) listOpts.sinceMs = sinceMs
+      if (inspectUrl !== undefined) listOpts.liveSessions = await fetchLiveSessions({ url: inspectUrl })
       return (await listViewerItems(listOpts)).items
     },
     keyOf: (item) => (item.kind === 'logs' ? 'logs' : item.summary.sessionId),
@@ -223,12 +226,15 @@ async function resolveTuiUrl(cwd: string): Promise<string> {
   return url.toString()
 }
 
-async function buildLiveSource(cwd: string): Promise<LiveSourceFactory | undefined> {
+async function resolveInspectUrl(cwd: string): Promise<string> {
   const port = await resolveHostPort({ cwd })
   const token = await resolveTuiToken({ cwd })
   const baseUrl = new URL(`ws://127.0.0.1:${port}/inspect`)
   if (token !== null) baseUrl.searchParams.set('token', token)
-  const url = baseUrl.toString()
+  return baseUrl.toString()
+}
+
+function buildLiveSource(url: string): LiveSourceFactory {
   return ({ sessionId, sinceMs, signal, onSubscribed }) =>
     streamLive({
       url,
@@ -325,8 +331,8 @@ function itemHint(item: ViewerItem): { hint: string } {
 function sessionRowLabel(s: SessionSummary): string {
   const id = shortSessionId(s.sessionId)
   const label = s.origin === null ? '(unknown origin)' : originLabel(s.origin)
-  const when = formatRelative(s.mtimeMs)
-  return `${c.cyan(id)}  ${label}  ${c.dim(when)}`
+  const when = s.live === true ? c.green('live · replying') : c.dim(formatRelative(s.mtimeMs))
+  return `${c.cyan(id)}  ${label}  ${when}`
 }
 
 function formatRelative(ms: number): string {

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -14,6 +14,8 @@ export { originLabel, shortSessionId } from './label'
 export { renderEvent } from './render'
 export { replayJsonl } from './replay'
 export { streamLive } from './live'
+export { fetchLiveSessions } from './live-list'
+export type { FetchLiveSessionsOptions } from './live-list'
 export { parseDuration, parseFilter } from './types'
 export type { InspectCategory, InspectEvent, InspectFilter } from './types'
 export { runInspectLoop, runViewerLoop } from './loop'
@@ -219,12 +221,17 @@ export async function streamSessionEvents(opts: StreamSessionEventsOptions): Pro
     opts.onEvent(event)
   }
 
-  for await (const event of replayJsonl(
-    opts.summary.sessionFile,
-    opts.onWarn !== undefined ? { onWarn: opts.onWarn } : {},
-  )) {
-    if (aborted()) return { escToPicker: true }
-    deliver(event)
+  // A live-only session (registry-derived, no .jsonl yet) has an empty
+  // sessionFile: skip replay and go straight to the live tail. Replaying ''
+  // would just emit a spurious "file does not exist" warning.
+  if (opts.summary.sessionFile !== '') {
+    for await (const event of replayJsonl(
+      opts.summary.sessionFile,
+      opts.onWarn !== undefined ? { onWarn: opts.onWarn } : {},
+    )) {
+      if (aborted()) return { escToPicker: true }
+      deliver(event)
+    }
   }
   opts.onPhase?.({ phase: 'replay-end' })
 

--- a/src/inspect/item-list.test.ts
+++ b/src/inspect/item-list.test.ts
@@ -97,4 +97,41 @@ describe('listViewerItems', () => {
     expect(writableSessionId).toBeNull()
     expect(items.filter((i) => i.kind === 'tui')).toHaveLength(0)
   })
+
+  test('overlays a live-only registry session not yet on disk', async () => {
+    // given one disk session and a registry session with no .jsonl yet
+    await seed(`a_${ID_A}.jsonl`, { kind: 'tui' }, 1000)
+
+    const { items } = await listViewerItems({
+      sessionsDir,
+      containerRunning: true,
+      liveSessions: [
+        { sessionId: ID_B, origin: { kind: 'cron', jobId: 'j', jobKind: 'prompt' }, registeredAtMs: 9_000_000 },
+      ],
+    })
+
+    // then the live session appears as a read-only session row flagged live
+    const liveItem = items.find((i) => i.kind !== 'logs' && i.summary.sessionId === ID_B)
+    expect(liveItem).toBeDefined()
+    if (liveItem === undefined || liveItem.kind === 'logs') throw new Error('unreachable')
+    expect(liveItem.summary.live).toBe(true)
+    expect(liveItem.writable).toBe(false)
+  })
+
+  test('a live tui session already flushed to disk is not duplicated', async () => {
+    // given a tui session present both on disk and in the registry
+    await seed(`a_${ID_A}.jsonl`, { kind: 'tui' }, 1000)
+
+    const { items } = await listViewerItems({
+      sessionsDir,
+      containerRunning: true,
+      liveSessions: [{ sessionId: ID_A, origin: { kind: 'tui' }, registeredAtMs: 9_000_000 }],
+    })
+
+    // then it appears exactly once, sourced from disk (no live flag)
+    const rows = items.filter((i) => i.kind !== 'logs' && i.summary.sessionId === ID_A)
+    expect(rows).toHaveLength(1)
+    if (rows[0]?.kind === 'logs') throw new Error('unreachable')
+    expect(rows[0]?.summary.live).toBeUndefined()
+  })
 })

--- a/src/inspect/item-list.ts
+++ b/src/inspect/item-list.ts
@@ -1,5 +1,7 @@
+import type { LiveSessionPayload } from '@/shared'
+
 import type { ViewerItem } from './item'
-import { listSessions, type ListSessionsOptions, type SessionSummary } from './session-list'
+import { listSessions, type ListSessionsOptions, mergeLiveSessions, type SessionSummary } from './session-list'
 
 export type ListViewerItemsOptions = ListSessionsOptions & {
   containerRunning: boolean
@@ -9,6 +11,9 @@ export type ListViewerItemsOptions = ListSessionsOptions & {
   // (most-recent) tui transcript — and any older tui transcript the heuristic
   // would otherwise promote — must NOT be offered as a writable live row.
   allowWritable?: boolean
+  // Registry sessions not yet flushed to disk, fetched by the CLI over the
+  // /inspect WS. The lib layer stays I/O-free; the caller owns the connection.
+  liveSessions?: LiveSessionPayload[]
 }
 
 export type ViewerList = {
@@ -23,7 +28,11 @@ export type ViewerList = {
 // sessions are read-only. The `logs` row is appended last (container stdout,
 // available offline) so it sits below the divider in the picker.
 export async function listViewerItems(opts: ListViewerItemsOptions): Promise<ViewerList> {
-  const sessions = await listSessions(opts)
+  const diskSessions = await listSessions(opts)
+  const sessions =
+    opts.liveSessions !== undefined && opts.liveSessions.length > 0
+      ? mergeLiveSessions(diskSessions, opts.liveSessions)
+      : diskSessions
   const allowWritable = opts.allowWritable !== false
   const writableSessionId = opts.containerRunning && allowWritable ? pickWritableSession(sessions) : null
 

--- a/src/inspect/live-list.ts
+++ b/src/inspect/live-list.ts
@@ -1,0 +1,65 @@
+import type { InspectClientMessage, InspectServerMessage, LiveSessionPayload } from '@/shared'
+
+export type FetchLiveSessionsOptions = {
+  url: string
+  signal?: AbortSignal
+  WebSocketImpl?: typeof WebSocket
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000
+
+// One-shot query of the container's in-memory session registry over the
+// /inspect WS: open, send list_live, read the single reply, close. Failure
+// (container down, timeout, abort) resolves to [] so the picker degrades to the
+// disk-only listing rather than erroring — the live overlay is best-effort.
+export async function fetchLiveSessions(opts: FetchLiveSessionsOptions): Promise<LiveSessionPayload[]> {
+  const WS = opts.WebSocketImpl ?? WebSocket
+  if (opts.signal?.aborted === true) return []
+
+  return new Promise<LiveSessionPayload[]>((resolve) => {
+    let settled = false
+    const ws = new WS(opts.url)
+
+    const finish = (result: LiveSessionPayload[]): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* ignore */
+      }
+      resolve(result)
+    }
+
+    const timer = setTimeout(() => finish([]), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+
+    if (opts.signal !== undefined) {
+      opts.signal.addEventListener('abort', () => finish([]), { once: true })
+    }
+
+    ws.addEventListener('open', () => {
+      const req: InspectClientMessage = { type: 'list_live' }
+      try {
+        ws.send(JSON.stringify(req))
+      } catch {
+        finish([])
+      }
+    })
+
+    ws.addEventListener('message', (e) => {
+      let msg: InspectServerMessage
+      try {
+        msg = JSON.parse(String((e as MessageEvent).data)) as InspectServerMessage
+      } catch {
+        return
+      }
+      if (msg.type === 'live_sessions') finish(msg.sessions)
+      else if (msg.type === 'error') finish([])
+    })
+
+    ws.addEventListener('error', () => finish([]))
+    ws.addEventListener('close', () => finish([]))
+  })
+}

--- a/src/inspect/open-item.test.ts
+++ b/src/inspect/open-item.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { reresolveLiveItem } from './open-item'
+import type { SessionSummary } from './session-list'
+
+let cwd: string
+let sessionsDir: string
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), 'typeclaw-open-item-'))
+  sessionsDir = join(cwd, 'sessions')
+  await mkdir(sessionsDir, { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(cwd, { recursive: true, force: true })
+})
+
+const ID = '019ee000-aaaa-7000-9000-00000000aaaa'
+
+function metaLine(origin: unknown): string {
+  return JSON.stringify({ type: 'custom', customType: 'typeclaw.session-meta', data: { origin }, timestamp: 0 })
+}
+
+function liveSummary(sessionId: string): SessionSummary {
+  return {
+    sessionId,
+    sessionFile: '',
+    basename: '',
+    mtimeMs: 9000,
+    origin: { kind: 'tui' },
+    firstPrompt: null,
+    live: true,
+  }
+}
+
+const noWarn = (): void => {}
+
+describe('reresolveLiveItem', () => {
+  test('swaps a live-only row for the disk summary once the transcript has flushed', async () => {
+    // given a live-only row whose session has since landed on disk
+    await writeFile(join(sessionsDir, `2026-06-12T00-00-00-000Z_${ID}.jsonl`), metaLine({ kind: 'tui' }) + '\n')
+    const item = { kind: 'session', summary: liveSummary(ID), writable: false } as const
+
+    // when re-resolving before opening
+    const resolved = await reresolveLiveItem(item, cwd, noWarn)
+
+    // then it now carries the real file path and drops the live flag
+    expect(resolved.kind).toBe('session')
+    if (resolved.kind === 'logs') throw new Error('unreachable')
+    expect(resolved.summary.sessionFile).not.toBe('')
+    expect(resolved.summary.live).toBeUndefined()
+  })
+
+  test('keeps the live-only row when the session is still not on disk', async () => {
+    // given a live-only row with no flushed transcript yet
+    const item = { kind: 'session', summary: liveSummary(ID), writable: false } as const
+
+    // when re-resolving
+    const resolved = await reresolveLiveItem(item, cwd, noWarn)
+
+    // then the original live summary is preserved so the live tail still works
+    expect(resolved).toBe(item)
+  })
+
+  test('passes through non-live rows untouched', async () => {
+    const disk: SessionSummary = {
+      sessionId: ID,
+      sessionFile: join(sessionsDir, `x_${ID}.jsonl`),
+      basename: `x_${ID}.jsonl`,
+      mtimeMs: 1000,
+      origin: { kind: 'tui' },
+      firstPrompt: 'hi',
+    }
+    const item = { kind: 'session', summary: disk, writable: false } as const
+    expect(await reresolveLiveItem(item, cwd, noWarn)).toBe(item)
+  })
+
+  test('passes through the logs row untouched', async () => {
+    const item = { kind: 'logs' } as const
+    expect(await reresolveLiveItem(item, cwd, noWarn)).toBe(item)
+  })
+})

--- a/src/inspect/open-item.ts
+++ b/src/inspect/open-item.ts
@@ -1,8 +1,11 @@
+import { join } from 'node:path'
+
 import type { LiveSourceFactory, RunInspectResult } from './index'
 import { createTranscriptView, streamInspectTarget } from './index'
 import type { ViewerItem } from './item'
 import { streamLogs } from './logs-item'
 import type { OpenItemContext, OpenItemResult, TailController } from './loop'
+import { resolveSession } from './session-list'
 import { runTuiViewer } from './tui-item'
 import type { InspectFilter } from './types'
 
@@ -28,7 +31,14 @@ export type OpenViewerDeps = {
 // would corrupt input). The line/JSON session path and logs run UNDER the tail
 // scope, which owns the raw-mode esc/q/ctrl-c handling.
 export function openViewerItem(deps: OpenViewerDeps) {
-  return async (item: ViewerItem, ctx: OpenItemContext): Promise<OpenItemResult> => {
+  return async (rawItem: ViewerItem, ctx: OpenItemContext): Promise<OpenItemResult> => {
+    // A live-only row captured `sessionFile: ''` when it was listed. By the time
+    // the user opens it the reply may have flushed to disk AND the registry
+    // entry may be gone — leaving the live tail broadcast-only and skipping the
+    // now-existing transcript. Re-resolve against the sessions dir so a
+    // flushed session opens as its real disk summary (replay + live tail).
+    const item = await reresolveLiveItem(rawItem, deps.cwd, deps.stderr)
+
     if (item.kind === 'tui') {
       const result = await runTuiViewer({
         resolveUrl: deps.resolveTuiUrl,
@@ -91,6 +101,17 @@ export function openViewerItem(deps: OpenViewerDeps) {
       scope.dispose()
     }
   }
+}
+
+export async function reresolveLiveItem(
+  item: ViewerItem,
+  cwd: string,
+  onWarn: (line: string) => void,
+): Promise<ViewerItem> {
+  if (item.kind === 'logs' || item.summary.live !== true) return item
+  const resolved = await resolveSession(join(cwd, 'sessions'), item.summary.sessionId, onWarn)
+  if (!resolved.ok) return item
+  return { kind: 'session', summary: resolved.summary, writable: false }
 }
 
 function toResult(escToPicker: boolean, scope: TailController): RunInspectResult {

--- a/src/inspect/session-list.test.ts
+++ b/src/inspect/session-list.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { listSessions, resolveSession } from './session-list'
+import type { SessionSummary } from './session-list'
+import { listSessions, mergeLiveSessions, resolveSession } from './session-list'
 
 let dir: string
 
@@ -268,5 +269,58 @@ describe('resolveSession', () => {
     expect(out.ok).toBe(false)
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toBe('not-found')
+  })
+})
+
+describe('mergeLiveSessions', () => {
+  const diskSummary = (sessionId: string, mtimeMs: number): SessionSummary => ({
+    sessionId,
+    sessionFile: `/tmp/${sessionId}.jsonl`,
+    basename: `${sessionId}.jsonl`,
+    mtimeMs,
+    origin: { kind: 'tui' },
+    firstPrompt: 'hi',
+  })
+
+  test('synthesizes a live-only row for a registry session with no disk file', () => {
+    // given one disk session and one registry-only session
+    const disk = [diskSummary('ses_disk', 5000)]
+    const merged = mergeLiveSessions(disk, [{ sessionId: 'ses_live', origin: { kind: 'tui' }, registeredAtMs: 9000 }])
+
+    // then the live session is added with an empty file path and live flag
+    const live = merged.find((s) => s.sessionId === 'ses_live')
+    expect(live).toMatchObject({ sessionFile: '', basename: '', live: true, mtimeMs: 9000, firstPrompt: null })
+    expect(live?.origin).toEqual({ kind: 'tui' })
+  })
+
+  test('a live session already on disk is not duplicated (disk summary wins)', () => {
+    // given the same id present on disk and in the registry
+    const disk = [diskSummary('ses_shared', 5000)]
+    const merged = mergeLiveSessions(disk, [{ sessionId: 'ses_shared', origin: { kind: 'tui' }, registeredAtMs: 9000 }])
+
+    // then only the disk summary survives, keeping its real mtime and prompt
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toMatchObject({ sessionId: 'ses_shared', mtimeMs: 5000, firstPrompt: 'hi' })
+    expect(merged[0]?.live).toBeUndefined()
+  })
+
+  test('result is sorted by mtime desc, surfacing an in-flight reply above older history', () => {
+    // given an old disk session and a freshly-registered live session
+    const disk = [diskSummary('ses_old', 1000)]
+    const merged = mergeLiveSessions(disk, [
+      {
+        sessionId: 'ses_live',
+        origin: { kind: 'channel', adapter: 'slack', workspace: 'w', chat: 'c', thread: null },
+        registeredAtMs: 8000,
+      },
+    ])
+
+    // then the live row sorts first
+    expect(merged.map((s) => s.sessionId)).toEqual(['ses_live', 'ses_old'])
+  })
+
+  test('empty live list returns the disk sessions (sorted mtime desc)', () => {
+    const disk = [diskSummary('ses_a', 1000), diskSummary('ses_b', 2000)]
+    expect(mergeLiveSessions(disk, []).map((s) => s.sessionId)).toEqual(['ses_b', 'ses_a'])
   })
 })

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -2,6 +2,7 @@ import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { MinimalSessionOrigin } from '@/agent/session-meta'
+import type { LiveSessionPayload } from '@/shared'
 
 import { previewForHint } from './preview'
 import { replayJsonl } from './replay'
@@ -13,6 +14,11 @@ export type SessionSummary = {
   mtimeMs: number
   origin: MinimalSessionOrigin | null
   firstPrompt: string | null
+  // True only for a registry-derived session with no .jsonl on disk yet (a
+  // reply is in flight). Disk sessions leave this undefined. Selecting one tails
+  // live-only: streamSessionEvents replays an empty file, then the WS delivers
+  // events as they happen.
+  live?: boolean
 }
 
 export type ListSessionsOptions = {
@@ -63,6 +69,29 @@ export async function listSessions(opts: ListSessionsOptions): Promise<SessionSu
       }
     }),
   )
+}
+
+// Overlay container-registry sessions onto the disk listing. A live session
+// already flushed to disk (post-reply) is dropped from the overlay — the disk
+// summary wins, carrying its real mtime and prompt preview. Only sessions with
+// no .jsonl yet become synthetic live rows, sorted to the top by registration
+// time so an in-flight reply surfaces above settled history.
+export function mergeLiveSessions(disk: SessionSummary[], live: LiveSessionPayload[]): SessionSummary[] {
+  const onDisk = new Set(disk.map((s) => s.sessionId))
+  const liveOnly = live
+    .filter((l) => !onDisk.has(l.sessionId))
+    .map(
+      (l): SessionSummary => ({
+        sessionId: l.sessionId,
+        sessionFile: '',
+        basename: '',
+        mtimeMs: l.registeredAtMs,
+        origin: l.origin,
+        firstPrompt: null,
+        live: true,
+      }),
+    )
+  return [...liveOnly, ...disk].sort((a, b) => b.mtimeMs - a.mtimeMs)
 }
 
 export type ResolveResult =

--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -3,6 +3,7 @@ import { SessionManager } from '@mariozechner/pi-coding-agent'
 import { createSession as defaultCreateSession } from '@/agent'
 import type { LiveSessionRegistry } from '@/agent/live-sessions'
 import type { LiveSubagentRegistry } from '@/agent/live-subagents'
+import { sessionMetaPayload } from '@/agent/session-meta'
 import type { CreateSessionForSubagent, SubagentRegistry } from '@/agent/subagents'
 import { capJsonlFileInPlace } from '@/bundled-plugins/tool-result-cap/cap-jsonl'
 import type { CapOptions } from '@/bundled-plugins/tool-result-cap/cap-result'
@@ -144,7 +145,12 @@ export function buildChannelSessionFactory(deps: BuildChannelSessionFactoryDeps)
     })
 
     const sessionId = sessionManager.getSessionId()
-    deps.liveSessionRegistry?.register({ sessionId, session })
+    deps.liveSessionRegistry?.register({
+      sessionId,
+      session,
+      origin: sessionMetaPayload(origin).origin,
+      registeredAtMs: Date.now(),
+    })
 
     return {
       session,

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -5,6 +5,7 @@ import { LiveSessionRegistry } from '@/agent/live-sessions'
 import { LiveSubagentRegistry } from '@/agent/live-subagents'
 import { requestContainerRestart } from '@/agent/restart'
 import { consumeRestartHandoff } from '@/agent/restart-handoff'
+import { sessionMetaPayload } from '@/agent/session-meta'
 import type { SessionOrigin } from '@/agent/session-origin'
 import {
   awaitWithSubagentTimeout,
@@ -406,7 +407,12 @@ export async function startAgent({
         ...(entry.pluginSubagent.bashPolicy !== undefined ? { bashPolicy: entry.pluginSubagent.bashPolicy } : {}),
         ...runtimeVersionOpt,
       })
-      liveSessionRegistry.register({ sessionId, session: created.session })
+      liveSessionRegistry.register({
+        sessionId,
+        session: created.session,
+        origin: sessionMetaPayload(origin).origin,
+        registeredAtMs: Date.now(),
+      })
       const originalDispose = created.dispose
       return {
         ...created,
@@ -557,7 +563,12 @@ export async function startAgent({
         ...runtimeVersionOpt,
         ...mcpManagerOpt,
       })
-      liveSessionRegistry.register({ sessionId, session })
+      liveSessionRegistry.register({
+        sessionId,
+        session,
+        origin: sessionMetaPayload(cronOrigin).origin,
+        registeredAtMs: Date.now(),
+      })
       return {
         prompt: (text) => session.prompt(text),
         dispose: () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
 import { detectProviderError } from '@/agent/provider-error'
 import { requestContainerRestart } from '@/agent/restart'
 import { consumeRestartHandoff, type RestartHandoff } from '@/agent/restart-handoff'
+import { sessionMetaPayload } from '@/agent/session-meta'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
 import type { CreateSessionForSubagent } from '@/agent/subagents'
@@ -541,7 +542,12 @@ export function createServer({
               state.unsubTurnOutcome = subscribeTurnOutcome(session, agentDir, origin, sessionFileId, logger)
             }
 
-            liveSessionRegistry?.register({ sessionId: sessionFileId, session })
+            liveSessionRegistry?.register({
+              sessionId: sessionFileId,
+              session,
+              origin: sessionMetaPayload(origin).origin,
+              registeredAtMs: Date.now(),
+            })
             forwardSessionEvents(ws, state, logger, sessionFileId)
 
             if (stream) {
@@ -1286,6 +1292,15 @@ function handleInspectMessage(
   }
   if (msg.type === 'ping') {
     sendInspect(ws, { type: 'pong', id: msg.id })
+    return
+  }
+  if (msg.type === 'list_live') {
+    const sessions = (liveSessionRegistry?.listLive() ?? []).map((e) => ({
+      sessionId: e.sessionId,
+      origin: e.origin!,
+      registeredAtMs: e.registeredAtMs ?? 0,
+    }))
+    sendInspect(ws, { type: 'live_sessions', sessions })
     return
   }
   if (msg.type !== 'subscribe' || typeof msg.sessionId !== 'string' || msg.sessionId === '') {

--- a/src/server/inspect-ws.test.ts
+++ b/src/server/inspect-ws.test.ts
@@ -142,6 +142,45 @@ describe('/inspect WS handler', () => {
     ws.close()
   })
 
+  test('list_live returns only registry sessions that carry an origin', async () => {
+    // given a registry with one origin-bearing live session and one subscribe-only entry
+    const registry = new LiveSessionRegistry()
+    registry.register({ sessionId: 'ses_subscribe_only', session: createFakeAgent() })
+    registry.register({
+      sessionId: 'ses_live',
+      session: createFakeAgent(),
+      origin: { kind: 'channel', adapter: 'slack', workspace: 'w', chat: 'c', thread: null },
+      registeredAtMs: 4242,
+    })
+
+    const { url } = await startServer({ liveSessionRegistry: registry })
+    const { ws, waitFor } = await connectInspect(url)
+
+    // when the client asks for the live listing
+    ws.send(JSON.stringify({ type: 'list_live' }))
+    const reply = await waitFor((m) => m.type === 'live_sessions')
+    if (reply.type !== 'live_sessions') throw new Error('unreachable')
+
+    // then only the origin-bearing session is returned
+    expect(reply.sessions).toHaveLength(1)
+    expect(reply.sessions[0]).toEqual({
+      sessionId: 'ses_live',
+      origin: { kind: 'channel', adapter: 'slack', workspace: 'w', chat: 'c', thread: null },
+      registeredAtMs: 4242,
+    })
+    ws.close()
+  })
+
+  test('list_live returns an empty list when no registry is wired', async () => {
+    const { url } = await startServer({})
+    const { ws, waitFor } = await connectInspect(url)
+    ws.send(JSON.stringify({ type: 'list_live' }))
+    const reply = await waitFor((m) => m.type === 'live_sessions')
+    if (reply.type !== 'live_sessions') throw new Error('unreachable')
+    expect(reply.sessions).toEqual([])
+    ws.close()
+  })
+
   test('text_delta events forward as frames', async () => {
     const registry = new LiveSessionRegistry()
     const session = createFakeAgent()

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -14,6 +14,8 @@ export {
   type InspectClientMessage,
   type InspectFramePayload,
   type InspectServerMessage,
+  type LiveSessionOriginPayload,
+  type LiveSessionPayload,
   type PromptDelivery,
   type QueueStateItem,
   type ReloadResultPayload,

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -60,6 +60,36 @@ export type InspectClientMessage =
   // distinguish "idle" from "dead"; a missed pong can. Guards a wedged
   // WebSocket that stays ESTABLISHED yet never fires 'close'/'error'.
   | { type: 'ping'; id: number }
+  // One-shot query for sessions live in the container's registry but not yet on
+  // disk (pi-coding-agent defers the first .jsonl write to the first assistant
+  // message). Lets the host-stage inspect picker show in-flight sessions before
+  // their reply lands. Answered with a single `live_sessions` reply.
+  | { type: 'list_live' }
+
+// Wire mirror of MinimalSessionOrigin (@/agent/session-meta). Duplicated rather
+// than imported because @/shared is a leaf module — @/agent depends on it, so
+// importing back would create a cycle. A compile-time assertion in session-meta
+// keeps the two structurally in sync; drift fails typecheck.
+export type LiveSessionOriginPayload =
+  | { kind: 'tui' }
+  | { kind: 'cron'; jobId: string; jobKind: 'prompt' | 'exec' | 'subagent' | 'handler' }
+  | {
+      kind: 'channel'
+      adapter: string
+      workspace: string
+      workspaceName?: string
+      chat: string
+      chatName?: string
+      thread: string | null
+    }
+  | { kind: 'subagent'; subagent: string; parentSessionId: string }
+  | { kind: 'system'; component: string }
+
+export type LiveSessionPayload = {
+  sessionId: string
+  origin: LiveSessionOriginPayload
+  registeredAtMs: number
+}
 
 export type InspectFramePayload =
   | { kind: 'text_delta'; sessionId: string; delta: string }
@@ -137,6 +167,7 @@ export type InspectServerMessage =
   | { type: 'frame'; ts: number; payload: InspectFramePayload }
   | { type: 'error'; message: string }
   | { type: 'pong'; id: number }
+  | { type: 'live_sessions'; sessions: LiveSessionPayload[] }
 
 export type ClientMessage =
   | { type: 'prompt'; text: string; delivery?: PromptDelivery }


### PR DESCRIPTION
## Background

A session was invisible to `typeclaw inspect` from the moment an inbound message arrived until the agent's reply finished. The root cause is in pi-coding-agent's `SessionManager._persist()`: it defers the **first** `.jsonl` write until the first assistant message lands (to avoid leaving orphan files for aborted sessions). The session header, the origin-meta stamp, and the user message all sit in memory until then.

`typeclaw inspect`'s picker is host-stage and builds its list purely from `readdir(sessions/)` — it cannot see the container's in-memory `LiveSessionRegistry`. So a mid-reply session has no file to list, and the operator stares at an empty/stale picker while a reply is in flight.

## Summary

Add a one-shot `list_live` query over the **existing** `/inspect` WebSocket. The host CLI fetches the sessions live in the container's registry and overlays the ones not yet on disk onto the disk listing. No `node_modules` patch, no new always-on connection, and the disk-only offline picker is preserved.

Key decisions a reviewer might otherwise ask about:

- **Why a WS query, not flush-on-create (the other option).** Flushing the header on create is ~10 lines but means patching a pinned dependency for every consumer, and it reintroduces the orphan-file problem the deferral exists to prevent. The WS overlay keeps the disk clean (in-memory only until reply) and stays entirely in-repo.
- **Why the wire origin type is mirrored, not imported.** `@/shared` is a leaf module and `@/agent` depends on it; importing `MinimalSessionOrigin` back would create a cycle. The mirror (`LiveSessionOriginPayload`) is kept honest by a bidirectional compile-time assertion in `session-meta.ts` — drift fails typecheck.
- **Why the lib layer takes `liveSessions` as a parameter.** `listViewerItems`/`mergeLiveSessions` stay I/O-free and unit-testable; the CLI owns the WS connection. Matches the repo's "test at the right layer" philosophy.
- **Dedupe rule.** A session that has since flushed to disk wins over its registry entry, keeping its real mtime and prompt preview. Only registry-only sessions become synthetic rows, sorted to the top by registration time so an in-flight reply surfaces above settled history.

## Preview

In the picker, a session mid-reply now appears immediately as a read-only row labelled `live · replying` (green), and selecting it tails straight from the WS. Once the reply lands and the `.jsonl` is flushed, the next refresh shows it as a normal disk row.

## What this does NOT do

- Does **not** change pi-coding-agent's flush timing — the `.jsonl` still appears only after the first assistant message; this just makes the in-memory session visible meanwhile.
- Does **not** add an always-on connection — `list_live` is a one-shot per list/refresh.
- Does **not** make live-only rows writable (except the existing single live-TUI heuristic).
- Container down / timeout / abort → silently degrades to the disk-only listing.

## Review notes

- Load-bearing invariant: `LiveSessionRegistry.listLive()` returns **only** origin-bearing entries, so subscribe-only test harnesses (which register `{ sessionId, session }`) never leak into the picker. The optionality of `origin`/`registeredAtMs` is what keeps ~20 existing register() call sites compiling untouched.
- The compile-time drift guard lives in `src/agent/session-meta.ts` (mirror of `LiveSessionOriginPayload`). If you add an origin kind, both sides must move or typecheck fails — by design.
- `streamSessionEvents` skips replay when `sessionFile === ''` (the live-only marker) to avoid a spurious "file does not exist" warning; the tail then comes entirely from the WS.
- Stacked as 4 atomic commits: registry model + wire types → serve `list_live` → host fetch + merge → picker wiring.