### PR TITLE
fix: deflake portbroker e2e and cold local-plugin loading tests

### DIFF
--- a/src/cli/plugin-commands.test.ts
+++ b/src/cli/plugin-commands.test.ts
@@ -157,13 +157,16 @@ describe('discoverCommands', () => {
     expect(result.loadErrors).toEqual([])
   })
 
+  // 60s, not the global 30s: discoverCommands `await import()`s a temp plugin,
+  // paying Bun's cold transpile + `@/plugin` graph resolution (~400ms in
+  // isolation) that starves past 30s under full 18-worker contention.
   test('lists commands from a local plugin', async () => {
     const dir = await mkTempAgent(HOST_ECHO_PLUGIN)
     const result = await discoverCommands({ cwd: dir })
     expect(result.commands.map((c) => c.commandName)).toEqual(['host-echo'])
     expect(result.commands[0]?.command.surface).toBe('host')
     expect(result.loadErrors).toEqual([])
-  })
+  }, 60_000)
 
   test('records load errors and continues', async () => {
     const dir = await mkTempAgent()

--- a/src/plugin/loader.test.ts
+++ b/src/plugin/loader.test.ts
@@ -61,6 +61,10 @@ describe('derivePluginNameFromPackage', () => {
 })
 
 describe('loadPluginEntry — local path', () => {
+  // 60s, not the global 30s: this writes a temp plugin then `await import()`s it,
+  // paying Bun's cold transpile + module-resolution of the `@/plugin` graph. That
+  // is ~400ms in isolation but starves past 30s under full 18-worker contention.
+  // The budget absorbs the starvation while still failing loudly on a real hang.
   test('loads a relative-path plugin and derives name from basename', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'typeclaw-loader-'))
     try {
@@ -79,7 +83,7 @@ export default definePlugin({
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
-  })
+  }, 60_000)
 
   test('throws PluginNotFoundError when local path does not exist', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'typeclaw-loader-'))

--- a/src/portbroker/broker.test.ts
+++ b/src/portbroker/broker.test.ts
@@ -8,7 +8,7 @@ import {
   type UpstreamConnection,
   type UpstreamHandlers,
 } from './container-server'
-import { createBroker, type Broker } from './hostd-client'
+import { createBroker, defaultListenHost, type Broker, type ListenHostFn } from './hostd-client'
 import type { PortForwardEvent } from './protocol'
 
 type Harness = {
@@ -52,6 +52,14 @@ async function startHarness(opts: {
     return conn
   }
 
+  // Force the host-side bind onto an OS-assigned ephemeral port. The target
+  // port from the proc snapshot is the in-container port; binding it verbatim
+  // on the host means any worker (or local process — 5173 is Vite's default)
+  // already holding it loses the `Bun.listen` to EADDRINUSE, wedging the
+  // `port-forward-opened` waitFor until the 30s deadline. Callers read the real
+  // port back from the emitted event's `hostPort`.
+  const listenHostEphemeral: ListenHostFn = (host, _port, handlers) => defaultListenHost(host, 0, handlers)
+
   const containerBroker: ContainerBroker = createContainerBroker({
     expectedToken: 'shared-token',
     pollIntervalMs: 10,
@@ -90,6 +98,7 @@ async function startHarness(opts: {
     resolveHostPort: async () => containerServer.port ?? null,
     brokerToken: 'shared-token',
     onEvent: (e) => events.push(e),
+    listenHost: listenHostEphemeral,
     reconnectDelaysMs: [10, 10],
   })
 
@@ -108,6 +117,13 @@ async function startHarness(opts: {
 const procWith5173Loopback = `   0: 0100007F:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1`
 const procEmpty = ``
 
+type PortForwardOpened = Extract<PortForwardEvent, { kind: 'port-forward-opened' }>
+
+const findOpened = (events: PortForwardEvent[], port?: number): PortForwardOpened | undefined =>
+  events.find(
+    (e): e is PortForwardOpened => e.kind === 'port-forward-opened' && (port === undefined || e.port === port),
+  )
+
 describe('end-to-end portbroker pipeline', () => {
   let harness: Harness | null = null
 
@@ -121,14 +137,11 @@ describe('end-to-end portbroker pipeline', () => {
   test('full handshake → snapshot → forwarder bound → host connection → bytes flow → close', async () => {
     harness = await startHarness({ procSnapshots: [procWith5173Loopback], policy: { allow: '*' } })
     harness.broker.start()
-    await waitFor(() => harness!.events.find((e) => e.kind === 'port-forward-opened' && e.port === 5173))
-
-    const opened = harness.events.find((e) => e.kind === 'port-forward-opened' && e.port === 5173)
-    expect(opened).toBeDefined()
+    const opened = await waitFor(() => findOpened(harness!.events, 5173))
 
     const sock = await Bun.connect({
       hostname: '127.0.0.1',
-      port: 5173,
+      port: opened.hostPort,
       socket: {
         open(s) {
           s.write(new TextEncoder().encode('GET / HTTP/1.1\r\nHost: x\r\n\r\n'))
@@ -161,7 +174,7 @@ describe('end-to-end portbroker pipeline', () => {
     const closedEvents = harness.events.filter((e) => e.kind === 'port-forward-closed' && e.port === 5173)
     expect(closedEvents.length).toBeGreaterThanOrEqual(1)
     expect(closedEvents[0]).toMatchObject({ reason: 'container-released' })
-    expect(harness.broker.forwardedPorts()).not.toContain(5173)
+    expect(harness.broker.forwardedPorts()).toEqual([])
   })
 
   test('disabled by allow:[] — no events, no broker connect', async () => {
@@ -180,21 +193,22 @@ describe('end-to-end portbroker pipeline', () => {
       policy: { allow: '*', deny: [9229] },
     })
     harness.broker.start()
-    await waitFor(() => harness!.broker.forwardedPorts().length > 0)
+    const opened = await waitFor(() => findOpened(harness!.events))
 
-    expect(harness.broker.forwardedPorts()).toEqual([5173])
+    expect(opened.port).toBe(5173)
+    expect(findOpened(harness.events, 9229)).toBeUndefined()
   })
 
   test('bytes flow downstream — container-side data reaches host client', async () => {
     harness = await startHarness({ procSnapshots: [procWith5173Loopback], policy: { allow: '*' } })
     harness.broker.start()
-    await waitFor(() => harness!.broker.forwardedPorts().includes(5173))
+    const opened = await waitFor(() => findOpened(harness!.events, 5173))
 
     const received: Uint8Array[] = []
     let sockHandle: Awaited<ReturnType<typeof Bun.connect>> | null = null
     sockHandle = await Bun.connect({
       hostname: '127.0.0.1',
-      port: 5173,
+      port: opened.hostPort,
       socket: {
         open(s) {
           s.write(new TextEncoder().encode('hi'))

--- a/src/portbroker/hostd-client.test.ts
+++ b/src/portbroker/hostd-client.test.ts
@@ -100,21 +100,25 @@ function makeFakeListenHost(opts: {
   failPorts?: Set<number>
   listeners: Map<number, FakeListener>
   calls?: Array<{ host: string; port: number }>
+  // Remap requested → bound port to model an OS-assigned (port-0) bind where the
+  // listener's port diverges from the requested target.
+  boundPortFor?: (requestedPort: number) => number
 }): ListenHostFn {
   return async (host, port, handlers) => {
     opts.calls?.push({ host, port })
     if (opts.failPorts?.has(port)) throw new Error('EADDRINUSE')
+    const boundPort = opts.boundPortFor ? opts.boundPortFor(port) : port
     const sockets: FakeHostSocket[] = []
     const listener: FakeListener = {
-      port,
+      port: boundPort,
       stopped: false,
-      bound: { host, port },
+      bound: { host, port: boundPort },
       sockets,
       stop: () => {
         listener.stopped = true
       },
     }
-    opts.listeners.set(port, listener)
+    opts.listeners.set(boundPort, listener)
     ;(listener as unknown as { _accept: (s: FakeHostSocket) => void })._accept = (s) => {
       sockets.push(s)
       handlers.onConnection(s)
@@ -128,6 +132,7 @@ function setup(opts: {
   resolveHostPort?: () => Promise<number | null>
   failPorts?: Set<number>
   connectWs?: () => Promise<WsClient>
+  boundPortFor?: (requestedPort: number) => number
 }) {
   const ws = makeFakeWs()
   const listeners = new Map<number, FakeListener>()
@@ -145,6 +150,7 @@ function setup(opts: {
     connectWs: opts.connectWs ?? (async () => ws),
     listenHost: makeFakeListenHost({
       ...(opts.failPorts ? { failPorts: opts.failPorts } : {}),
+      ...(opts.boundPortFor ? { boundPortFor: opts.boundPortFor } : {}),
       listeners,
       calls: listenCalls,
     }),
@@ -432,6 +438,31 @@ describe('createBroker', () => {
     })
     await waitFor(() => broker.forwardedPorts().length === 2)
     expect(broker.forwardedPorts().sort()).toEqual([5173, 8080])
+    await broker.stop()
+  })
+
+  test('dedups a re-announced target when the bound host port differs from the target', async () => {
+    // The forwarders map is keyed by the bound host port, which diverges from
+    // the target on an OS-assigned bind. The duplicate guard must still dedup by
+    // target port, or a re-announced 5173 binds a second host listener.
+    const { broker, ws, listenCalls } = setup({
+      policy: { allow: '*' },
+      boundPortFor: (requested) => requested + 10_000,
+    })
+    broker.start()
+    await waitFor(() => ws.outbox.some((m) => m.type === 'broker-hello'))
+    ws.emit({ type: 'broker-hello-ack' })
+    ws.emit({ type: 'port-listen-snapshot', ports: [{ port: 5173, bindAddr: '127.0.0.1' }] })
+    await waitFor(() => broker.forwardedPorts().includes(15173))
+
+    ws.emit({ type: 'port-listen-opened', port: 5173, bindAddr: '127.0.0.1' })
+    await expectStable(() => listenCalls.filter((c) => c.port === 5173).length > 1, {
+      durationMs: 30,
+      description: 'duplicate auto-forward bind',
+    })
+
+    expect(listenCalls.filter((c) => c.port === 5173)).toHaveLength(1)
+    expect(broker.forwardedPorts()).toEqual([15173])
     await broker.stop()
   })
 

--- a/src/portbroker/hostd-client.ts
+++ b/src/portbroker/hostd-client.ts
@@ -180,13 +180,28 @@ export function createBroker(opts: BrokerOptions): Broker {
       return
     }
     try {
+      // The host listen port — not targetPort — is the forwarders map key, so
+      // the connection callback must look up by it. They coincide for ordinary
+      // 1:1 auto-forwards but diverge whenever the OS reassigns the bind (e.g. a
+      // port-0 ephemeral bind), at which point routing by targetPort misses the
+      // map and silently drops the connection. Captured after the await; a
+      // connection can only arrive once the listener is bound.
+      let boundHostPort: number | undefined
       const listener = await listenHost(hostBind, targetPort, {
-        onConnection: (sock) => handleHostConnection(targetPort, sock),
+        onConnection: (sock) => {
+          if (boundHostPort === undefined) {
+            try {
+              sock.end()
+            } catch {}
+            return
+          }
+          handleHostConnection(boundHostPort, sock)
+        },
       })
-      // Ordinary auto-forwards are 1:1, so targetPort and hostPort match.
-      forwarders.set(listener.port, {
+      boundHostPort = listener.port
+      forwarders.set(boundHostPort, {
         targetPort,
-        hostPort: listener.port,
+        hostPort: boundHostPort,
         bindAddr,
         reserved: false,
         listener,
@@ -196,10 +211,10 @@ export function createBroker(opts: BrokerOptions): Broker {
         kind: 'port-forward-opened',
         containerName: opts.containerName,
         port: targetPort,
-        hostPort: listener.port,
+        hostPort: boundHostPort,
         bindAddr,
       })
-      if (ws) ws.send({ type: 'port-forward-result', port: targetPort, ok: true, hostPort: listener.port })
+      if (ws) ws.send({ type: 'port-forward-result', port: targetPort, ok: true, hostPort: boundHostPort })
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)
       log(`forward bind ${targetPort}: ${reason}`)
@@ -227,29 +242,41 @@ export function createBroker(opts: BrokerOptions): Broker {
     let lastReason = 'no host candidates'
     for (const hostPort of hostCandidates) {
       try {
+        // `port` stays the in-container target; the host listen port is the
+        // forwarders map key the connection callback must route by. Reserved
+        // forwards deliberately allow the two to differ, so route by the actual
+        // bound port, captured after the await.
+        let boundHostPort: number | undefined
         const listener = await listenHost(hostBind, hostPort, {
-          onConnection: (sock) => handleHostConnection(hostPort, sock),
+          onConnection: (sock) => {
+            if (boundHostPort === undefined) {
+              try {
+                sock.end()
+              } catch {}
+              return
+            }
+            handleHostConnection(boundHostPort, sock)
+          },
         })
-        // `port` remains the in-container target; `hostPort` is what the host
-        // browser opens. Reserved forwards deliberately allow them to differ.
-        forwarders.set(listener.port, {
+        boundHostPort = listener.port
+        forwarders.set(boundHostPort, {
           targetPort,
-          hostPort: listener.port,
+          hostPort: boundHostPort,
           bindAddr: '127.0.0.1',
           reserved: true,
           listener,
           streams: new Map(),
         })
-        reservedTargets.set(targetPort, listener.port)
+        reservedTargets.set(targetPort, boundHostPort)
         pendingReservedTargets.delete(targetPort)
         emit({
           kind: 'port-forward-opened',
           containerName: opts.containerName,
           port: targetPort,
-          hostPort: listener.port,
+          hostPort: boundHostPort,
           bindAddr: '127.0.0.1',
         })
-        if (ws) ws.send({ type: 'port-forward-result', port: targetPort, ok: true, hostPort: listener.port })
+        if (ws) ws.send({ type: 'port-forward-result', port: targetPort, ok: true, hostPort: boundHostPort })
         return
       } catch (err) {
         lastReason = err instanceof Error ? err.message : String(err)
@@ -512,7 +539,7 @@ async function defaultConnectWs(url: string): Promise<WsClient> {
   })
 }
 
-function defaultListenHost(
+export function defaultListenHost(
   host: string,
   port: number,
   handlers: { onConnection: (sock: HostSocket) => void },

--- a/src/portbroker/hostd-client.ts
+++ b/src/portbroker/hostd-client.ts
@@ -170,9 +170,20 @@ export function createBroker(opts: BrokerOptions): Broker {
   const isReservedTarget = (targetPort: number): boolean =>
     reservedTargets.has(targetPort) || pendingReservedTargets.has(targetPort)
 
+  const hasAutoForwarderForTarget = (targetPort: number): boolean => {
+    for (const fwd of forwarders.values()) {
+      if (!fwd.reserved && fwd.targetPort === targetPort) return true
+    }
+    return false
+  }
+
   const installForwarder = async (targetPort: number, bindAddr: BindAddr): Promise<void> => {
     if (isReservedTarget(targetPort)) return
-    if (forwarders.has(targetPort)) return
+    // Dedup by targetPort, not the map key: the map is keyed by the bound host
+    // port, which diverges from targetPort on an ephemeral bind, so a
+    // `forwarders.has(targetPort)` guard would miss an existing forward and bind
+    // a second host listener for the same container port.
+    if (hasAutoForwarderForTarget(targetPort)) return
     if (!shouldForward({ policy: opts.policy, port: targetPort })) {
       // Policy excluded the port. Tell the container so consumers waiting on
       // port-forward-result can surface a diagnostic instead of hanging.

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -42,6 +42,10 @@ async function writePlugin(dir: string, body: string) {
 }
 
 describe('startAgent + plugin loading', () => {
+  // 60s, not the global 30s: this is the first test to boot a full agent
+  // (startAgent → server + agent-browser + memory plugins) and `await import()`
+  // a temp plugin, paying Bun's cold transpile + graph resolution. ~hundreds of
+  // ms in isolation, but starves past 30s under full 18-worker contention.
   test('loads a local plugin and merges its cron job under __plugin_<name>_<key>', async () => {
     agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
     await writeFile(
@@ -68,7 +72,7 @@ describe('startAgent + plugin loading', () => {
     expect(ids).toContain('__plugin_plugin_weekly-digest')
     expect(running.loadedPlugins.map((p) => p.name)).toContain('plugin')
     expect(running.loadedPlugins.map((p) => p.name)).toContain('memory')
-  })
+  }, 60_000)
 
   test('a user plugin whose factory throws is skipped — startAgent still boots, no leaked registrations', async () => {
     agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))


### PR DESCRIPTION
## Background

Two distinct flakes were surfacing intermittently under `bun test --parallel` (~18 workers).

**1. Portbroker e2e (`src/portbroker/broker.test.ts`).** The end-to-end test bound the host forwarder on a **hardcoded port 5173** (Vite's default), read from a `/proc/net/tcp` snapshot, then `Bun.connect`ed to it. When any parallel worker — or a local dev server — already held 5173, the broker's `Bun.listen({ port: 5173 })` threw `EADDRINUSE`, so `port-forward-opened` never fired and the test hung to its 30s `waitFor` deadline. Reproduced deterministically (0/15 passes) on a machine where 5173 was occupied; intermittent in CI as port contention varies.

**2. Cold local-plugin loading (3 tests** in `loader.test.ts`, `plugin-commands.test.ts`, `run/plugin.test.ts`**).** Each writes a temp plugin then `await import()`s it, paying Bun's cold transpile + `@/plugin` graph resolution (the `run/plugin` case boots a full agent via `startAgent`). ~400ms in isolation (10/10 pass), but CPU/IO-starved past the 30s default under full 18-worker contention — timing out at 31–49s in roughly 1 of 6 full runs.

## Summary

**Portbroker:** Bind the host side on an OS-assigned **ephemeral port (0)** in the test instead of a fixed number, and read the real port back from the emitted `port-forward-opened.hostPort`. This kept the real WS-server → broker → host-socket → byte round-trip but removed the only non-deterministic element.

Decoupling host≠target port **exposed a latent routing bug** in production: `installForwarder` / `installReservedForwarder` keyed the `forwarders` map by `listener.port` but routed `onConnection` through `targetPort`. They coincide for 1:1 auto-forwards, so the host connection landed on the right key *by accident*; the moment the bound port differs (ephemeral bind, or any reserved forward where host != target) the lookup missed the map and the connection was silently dropped. Fixed by routing `handleHostConnection` through the **actual bound port**, captured after the listen resolves. The relay still carries `fwd.targetPort` to the container, so the upstream dials the correct in-container port.

**Cold-boot tests:** Gave the three offending tests a targeted **60s per-test budget** (10x nominal under worst-case starvation). Why a budget and not pre-warming: pre-warming would hoist the cold-import cost out of the timed region, making the test less representative of first-use latency and able to hide regressions. A bounded 60s still fails loudly on a genuine deadlock. Mirrors the prior `a9e3491e` cron-handler poll-budget deflake.

## What this does NOT do

- Does not touch the global `setDefaultTimeout(30_000)` or reduce parallelism.
- Does not change reserved-forward semantics for the 1:1 case (behavior identical where `bound == target`); it *corrects* routing for the host≠target case.
- Does not add broad warmups or alter what the cold-loading tests exercise.

## Review notes

- **Load-bearing change:** `src/portbroker/hostd-client.ts` — `handleHostConnection` must be keyed by `listener.port` (the `forwarders` map key used by `closeStream`/`findStreamPort`/`removeForwarder`), not `targetPort`. The `boundHostPort` is captured after `await listenHost(...)`; the `onConnection` guard for `boundHostPort === undefined` is defensive against a test seam delivering a connection before assignment.
- Verified: portbroker test 25/25 in isolation (was 0/15), and **8/8 full-suite runs fully green** (8766 pass / 0 fail) after both fixes.
- `typecheck` / `lint` / `format:check` clean on changed files.