### PR TITLE
test(memory): pin vector-off opt-out leaves per-turn bag empty

### DIFF
--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -429,6 +429,40 @@ describe('session.turn.start hook', () => {
 
     expect(spawned).toHaveLength(0)
   })
+
+  // Opt-out invariant guard for `suppressSystemMemory === memory.vector.enabled`:
+  // with vector OFF (default) memory lives only in the system prompt, so the
+  // non-vector hook branch must never write the per-turn `retrievalContext` bag.
+  // Writing it would double-inject (system prompt + user turn). The sentinel
+  // surviving proves the opt-out path leaves the bag untouched in BOTH plans.
+  test('leaves retrievalContext.results empty when vector is off (index-mode plan)', async () => {
+    // given: over-budget shards → index mode (the branch that spawns memory-retrieval)
+    await writeTopic(agentDir, 'large-a', 'Large A', 'a'.repeat(3000))
+    await writeTopic(agentDir, 'large-b', 'Large B', 'b'.repeat(3000))
+    const { exports } = await bootMemoryPlugin(agentDir, { injectionBudgetBytes: 4096 })
+
+    const retrievalContext = { results: 'SENTINEL' }
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_optout_index', agentDir, userPrompt: 'what do I know?', retrievalContext },
+      { agentDir, pluginName: 'memory', logger: createPluginLogger('m') },
+    )
+
+    expect(retrievalContext.results).toBe('SENTINEL')
+  })
+
+  test('leaves retrievalContext.results empty when vector is off (direct-mode plan)', async () => {
+    // given: a small shard well under budget → direct mode (no spawn)
+    await writeTopic(agentDir, 'small-a', 'Small A', 'small body')
+    const { exports } = await bootMemoryPlugin(agentDir, {})
+
+    const retrievalContext = { results: 'SENTINEL' }
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_optout_direct', agentDir, userPrompt: 'small?', retrievalContext },
+      { agentDir, pluginName: 'memory', logger: createPluginLogger('m') },
+    )
+
+    expect(retrievalContext.results).toBe('SENTINEL')
+  })
 })
 
 describe('session.idle hook (debouncer)', () => {

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { appendFile, mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -435,11 +435,16 @@ describe('session.turn.start hook', () => {
   // non-vector hook branch must never write the per-turn `retrievalContext` bag.
   // Writing it would double-inject (system prompt + user turn). The sentinel
   // surviving proves the opt-out path leaves the bag untouched in BOTH plans.
+  //
+  // The non-vector retrieval runs DETACHED (`void runMemoryRetrieval`), so each
+  // test must wait for an observable completion point AFTER the plan decision
+  // before asserting — otherwise a future write inside the detached path (which
+  // awaits `loadAllShards` first) would race past the assertion unobserved.
   test('leaves retrievalContext.results empty when vector is off (index-mode plan)', async () => {
-    // given: over-budget shards → index mode (the branch that spawns memory-retrieval)
+    // given: over-budget shards → index mode, whose detached path ends in a spawn
     await writeTopic(agentDir, 'large-a', 'Large A', 'a'.repeat(3000))
     await writeTopic(agentDir, 'large-b', 'Large B', 'b'.repeat(3000))
-    const { exports } = await bootMemoryPlugin(agentDir, { injectionBudgetBytes: 4096 })
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { injectionBudgetBytes: 4096 })
 
     const retrievalContext = { results: 'SENTINEL' }
     await exports.hooks!['session.turn.start']!(
@@ -447,21 +452,45 @@ describe('session.turn.start hook', () => {
       { agentDir, pluginName: 'memory', logger: createPluginLogger('m') },
     )
 
+    // The spawn is the detached path's terminal step: once it lands, the hook has
+    // run past every line that could have touched the bag.
+    await waitFor(() => spawned.length >= 1, 'memory-retrieval spawn settles')
     expect(retrievalContext.results).toBe('SENTINEL')
   })
 
   test('leaves retrievalContext.results empty when vector is off (direct-mode plan)', async () => {
-    // given: a small shard well under budget → direct mode (no spawn)
+    // given: a small shard under budget → direct mode, which returns early with
+    // NO spawn and NO log. Its only observable is `loadAllShards` resolving, so
+    // wrap that module boundary as an observer (real impl preserved) and signal a
+    // barrier on the next macrotask — by then the plugin's microtask continuation
+    // (buildInjectionPlan + the direct-mode early return) has already run.
     await writeTopic(agentDir, 'small-a', 'Small A', 'small body')
-    const { exports } = await bootMemoryPlugin(agentDir, {})
+    const { loadAllShards: realLoadAllShards } = await import('./load-shards')
+    let signalDirectPathSettled: () => void = () => {}
+    const directPathSettled = new Promise<void>((resolve) => {
+      signalDirectPathSettled = resolve
+    })
+    mock.module('./load-shards', () => ({
+      loadAllShards: async (dir: string) => {
+        const shards = await realLoadAllShards(dir)
+        setImmediate(signalDirectPathSettled)
+        return shards
+      },
+    }))
+    try {
+      const { exports } = await bootMemoryPlugin(agentDir, {})
 
-    const retrievalContext = { results: 'SENTINEL' }
-    await exports.hooks!['session.turn.start']!(
-      { sessionId: 'ses_optout_direct', agentDir, userPrompt: 'small?', retrievalContext },
-      { agentDir, pluginName: 'memory', logger: createPluginLogger('m') },
-    )
+      const retrievalContext = { results: 'SENTINEL' }
+      await exports.hooks!['session.turn.start']!(
+        { sessionId: 'ses_optout_direct', agentDir, userPrompt: 'small?', retrievalContext },
+        { agentDir, pluginName: 'memory', logger: createPluginLogger('m') },
+      )
 
-    expect(retrievalContext.results).toBe('SENTINEL')
+      await directPathSettled
+      expect(retrievalContext.results).toBe('SENTINEL')
+    } finally {
+      mock.restore()
+    }
   })
 })
 


### PR DESCRIPTION
## Background

0.37.0 introduces opt-in vector memory. With vector **disabled** (the default,
`memory.vector.enabled: false`), long-term memory must keep its pre-vector
behavior exactly: it lives only in the system prompt via `loadMemory` at session
creation, and is **never** injected per-turn into the user prompt. The
load-bearing invariant is `suppressSystemMemory === memory.vector.enabled` — a
session must never carry memory in both places.

The runtime guarantees this in the `session.turn.start` hook: the vector branch
returns early after writing `event.retrievalContext.results`; the non-vector
branch falls through to the legacy detached `memory-retrieval` spawn and must
leave `retrievalContext.results` untouched. All turn-drivers append that bag to
the user text only when non-empty, so an accidental write on the opt-out path
would silently double-inject memory.

That opt-out guarantee was **unpinned**. The existing turn-start tests assert
the `memory-retrieval` spawn behavior on the non-vector path, but none asserted
that the per-turn bag stays empty. A future refactor could populate it on the
opt-out branch and every test would still pass.

## Summary

Add two regression tests in the existing `session.turn.start hook` block that
pass a sentinel-valued `retrievalContext` and assert the non-vector hook leaves
it untouched — across **both** injection plans (index-mode, the spawn branch;
and direct-mode, the no-spawn branch).

The sentinel (rather than asserting `=== ''`) distinguishes "hook left it alone"
from "hook wrote an empty string", so the test fails loudly if the bag is
touched at all. Verified the tests are meaningful by mutating the production
hook to write the bag on the non-vector path: both go red
(`Expected "SENTINEL", Received "MUTATION"`); reverting restores green.

## What this does NOT do

- No production-code changes — test-only.
- Does not touch the vector-on path (already covered by `index-vector.test.ts`).
- Does not assert system-prompt `# Memory` rendering (that's `agent/index.ts`'s
  `suppressSystemMemory` ternary and `load-memory.test.ts`); this PR pins the
  complementary half — that the per-turn bag stays empty when vector is off.

## Review notes

- The invariant under test: with `vector.enabled: false`, the
  `session.turn.start` hook in `src/bundled-plugins/memory/index.ts` must not
  write `event.retrievalContext.results`.
- Both new tests boot the plugin with vector off (default config) and only vary
  shard size to exercise the index-mode vs direct-mode branches.
- Full memory suite: 664 pass / 0 fail. typecheck / lint (0 errors) /
  format:check all clean.
