### PR TITLE
fix(memory): gate vector retrieval on per-query relevance to suppress no-match injection

### DIFF
--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -243,6 +243,85 @@ describe('hybridSearch', () => {
   })
 })
 
+describe('hybridSearch relevance gate', () => {
+  it('suppresses the vector lane when no topic clears the per-query baseline (no-match)', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: a flat band of topics, none meaningfully closer to the query than
+      // the rest — the E5 no-match shape. Query has no keyword hit either.
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.78 + (i % 3) * 0.001)))
+      }
+
+      const results = await hybridSearch('zxqw nonexistent gibberish token', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      expect(results).toHaveLength(0)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('keeps a topic whose vector clearly stands above the baseline (real match)', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: a flat band plus one topic that aligns strongly with the query
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.78 + (i % 3) * 0.001)))
+      }
+      writeTopic(agentDir, 'winner', 'Winner', 'The clearly matching topic for the query.')
+      store.upsert(row('topic:winner', 'winner', vector({ 0: 1 })))
+
+      const results = await hybridSearch('the matching query', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      expect(results[0]?.key).toBe('winner')
+    } finally {
+      store.close()
+    }
+  })
+
+  it('lets a keyword hit survive even when the vector lane is fully suppressed', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: a flat no-match vector band, but ONE topic literally contains the
+      // rare token the user typed — high-precision lexical evidence must survive
+      // the cosine no-match veto.
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.78 + (i % 3) * 0.001)))
+      }
+      writeTopic(agentDir, 'pr-851', 'PR 851', 'Notes about PR #851 zxqw-marker handling.')
+      store.upsert(row('topic:pr-851', 'pr-851', bandedVector(0.779)))
+
+      const results = await hybridSearch('zxqw-marker', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      expect(results.map((r) => r.key)).toContain('pr-851')
+    } finally {
+      store.close()
+    }
+  })
+
+  it('never suppresses a below-floor corpus to zero', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: only 3 shards — too few to estimate a baseline
+      writeTopic(agentDir, 'a', 'A', 'Note A.')
+      writeTopic(agentDir, 'b', 'B', 'Note B.')
+      writeTopic(agentDir, 'c', 'C', 'Note C.')
+      store.upsert(row('topic:a', 'a', bandedVector(0.78)))
+      store.upsert(row('topic:b', 'b', bandedVector(0.779)))
+      store.upsert(row('topic:c', 'c', bandedVector(0.778)))
+
+      const results = await hybridSearch('anything', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      expect(results.length).toBeGreaterThan(0)
+    } finally {
+      store.close()
+    }
+  })
+})
+
 function createFixture(): { agentDir: string; store: VectorStore } {
   const agentDir = join(tmpdir(), `typeclaw-hybrid-${randomUUID()}`)
   testDirs.push(agentDir)
@@ -304,6 +383,17 @@ function row(
 
 function embedFrom(values: Record<number, number>): EmbedFn {
   return async () => [vector(values)]
+}
+
+// A unit vector whose cosine against the query unit vector vector({ 0: 1 }) is
+// exactly `target`: put `target` on axis 0 and the remaining magnitude on a
+// shared off-query axis, so a whole band of these sits at near-identical cosine
+// to the query — the flat E5 no-match distribution.
+function bandedVector(target: number): Float32Array {
+  const result = new Float32Array(8)
+  result[0] = target
+  result[1] = Math.sqrt(Math.max(0, 1 - target * target))
+  return result
 }
 
 function vector(values: Record<number, number>): Float32Array {

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -320,6 +320,30 @@ describe('hybridSearch relevance gate', () => {
       store.close()
     }
   })
+
+  it('keeps a stream-vector match even when the topic distribution is a flat no-match', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: a full flat topic band (no topic clears the baseline) PLUS one
+      // undreamed stream fragment that the query semantically matches, and NO
+      // keyword hit — the freshness-window case. The topic no-match must not
+      // veto the relevant stream candidate.
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.78 + (i % 3) * 0.001)))
+      }
+      const fragmentId = '019e2ee8-bcc4-772f-8821-876162c5e601'
+      writeStreamFragment(agentDir, '2026-06-11', fragmentId, 'fresh', 'A brand new undreamed observation.')
+      store.upsert(row(`stream:2026-06-11#${fragmentId}`, `2026-06-11#${fragmentId}`, vector({ 0: 1 }), 'stream'))
+
+      const results = await hybridSearch('zxqw nonexistent gibberish token', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      const streamHit = results.find((r) => r.source === 'stream')
+      expect(streamHit?.key).toBe(`2026-06-11#${fragmentId}`)
+    } finally {
+      store.close()
+    }
+  })
 })
 
 function createFixture(): { agentDir: string; store: VectorStore } {

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -115,6 +115,9 @@ describe('hybridSearch', () => {
       )
       writeStreamFragment(agentDir, '2026-06-10', fragmentId, 'pnpm', 'User installs with pnpm.')
       store.upsert(row(`stream:2026-06-10#${fragmentId}`, `2026-06-10#${fragmentId}`, vector({ 0: 1 }), 'stream'))
+      // production always embeds every shard, so the citing topic has a vector;
+      // it is off-query here so the stream hit (cosine 1) clearly stands above it
+      store.upsert(row('topic:package-manager', 'package-manager', vector({ 5: 1 })))
 
       // when the fragment matches by vector
       const results = await hybridSearch('pnpm', store, agentDir, 5, embedFrom({ 0: 1 }))
@@ -147,6 +150,10 @@ describe('hybridSearch', () => {
       )
       writeStreamFragment(agentDir, '2026-06-10', fragmentId, 'pnpm', 'Uses pnpm and minimal Docker images.')
       store.upsert(row(`stream:2026-06-10#${fragmentId}`, `2026-06-10#${fragmentId}`, vector({ 0: 1 }), 'stream'))
+      // production always embeds every shard; both citing topics carry off-query
+      // vectors so the stream hit (cosine 1) clearly stands above them
+      store.upsert(row('topic:package-manager', 'package-manager', vector({ 5: 1 })))
+      store.upsert(row('topic:docker-preferences', 'docker-preferences', vector({ 6: 1 })))
 
       // when the shared fragment matches by vector
       const results = await hybridSearch('pnpm docker', store, agentDir, 5, embedFrom({ 0: 1 }))
@@ -340,6 +347,51 @@ describe('hybridSearch relevance gate', () => {
 
       const streamHit = results.find((r) => r.source === 'stream')
       expect(streamHit?.key).toBe(`2026-06-11#${fragmentId}`)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('suppresses an in-band stream neighbor on a no-match query (no closest-neighbor leak)', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: a flat topic no-match band AND a stream fragment that also sits
+      // inside the band (an irrelevant nearest neighbor, not a real match), with
+      // no keyword hit. The stream row must NOT inject — otherwise the no-match
+      // query leaks closest-neighbors-regardless through the stream partition.
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.78 + (i % 3) * 0.001)))
+      }
+      const fragmentId = '019e2ee8-bcc4-772f-8821-876162c5e601'
+      writeStreamFragment(agentDir, '2026-06-11', fragmentId, 'noise', 'An unrelated undreamed fragment.')
+      store.upsert(row(`stream:2026-06-11#${fragmentId}`, `2026-06-11#${fragmentId}`, bandedVector(0.781), 'stream'))
+
+      const results = await hybridSearch('zxqw nonexistent gibberish token', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      expect(results).toHaveLength(0)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('drops a semantic-only stream row when there is no topic baseline to judge it', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: too few topics to form a baseline, plus an in-band stream neighbor
+      // with no keyword corroboration — with no band to measure against, an
+      // uncorroborated semantic-only stream row must not inject on a no-match.
+      writeTopic(agentDir, 'a', 'A', 'Note A.')
+      writeTopic(agentDir, 'b', 'B', 'Note B.')
+      store.upsert(row('topic:a', 'a', bandedVector(0.5)))
+      store.upsert(row('topic:b', 'b', bandedVector(0.49)))
+      const fragmentId = '019e2ee8-bcc4-772f-8821-876162c5e601'
+      writeStreamFragment(agentDir, '2026-06-11', fragmentId, 'noise', 'An unrelated undreamed fragment.')
+      store.upsert(row(`stream:2026-06-11#${fragmentId}`, `2026-06-11#${fragmentId}`, bandedVector(0.5), 'stream'))
+
+      const results = await hybridSearch('zxqw nonexistent gibberish token', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      expect(results.some((r) => r.source === 'stream')).toBe(false)
     } finally {
       store.close()
     }

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -7,6 +7,7 @@ import type { StreamEvent } from '../stream-events'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
 import { embed, EMBEDDING_MODEL_ID, type EmbedType } from './embedder'
 import type { Passage } from './passages'
+import { gateRelevance } from './relevance-gate'
 import { VectorStore, type VectorRow } from './store'
 
 export { collectPassages, findMissingPassages, type Passage } from './passages'
@@ -40,11 +41,34 @@ export async function hybridSearch(
 
   const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
   const index = buildContentIndex(shards, streamDays, supersededFragmentIds)
-  const vectorRows =
-    queryEmbeddings[0] === undefined ? [] : store.query(queryEmbeddings[0], topK * 2, EMBEDDING_MODEL_ID)
+  const vectorRows = queryEmbeddings[0] === undefined ? [] : gatedVectorLane(queryEmbeddings[0], store, topK)
   const keywordMatches = keywordLane(query, shards, streamDays, topK * 2)
 
   return fuseLanes(vectorRows, keywordMatches, index, parentSlugsByFragmentId).slice(0, topK)
+}
+
+// The vector lane, gated by per-query relevance. The relevance gate reads the
+// full TOPIC score distribution (E5's no-match band is a topic-level property;
+// stream fragments are sparse and would skew the baseline) and decides how many
+// candidates clear this query's baseline — zero when nothing does, which empties
+// the vector lane. An empty vector lane composes with RRF exactly like a lane
+// that found nothing, so a genuine keyword hit still survives a cosine no-match.
+//
+// The gate only has a baseline to judge against when topic vectors are present.
+// Below the gate's own small-corpus floor (including the freshness-window case
+// where the only vectors are undreamed stream fragments and no topic is indexed
+// yet) there is no band to measure, so the lane falls back to the ungated
+// top-(topK*2) — suppressing here would drop a legitimate stream-only match.
+const GATE_TOPIC_FLOOR = 6
+
+function gatedVectorLane(queryEmbedding: Float32Array, store: VectorStore, topK: number): VectorRow[] {
+  const scored = store.queryScored(queryEmbedding, EMBEDDING_MODEL_ID)
+  const topicScores = scored.filter(({ row }) => row.source === 'topic').map(({ score }) => score)
+  if (topicScores.length < GATE_TOPIC_FLOOR) return scored.slice(0, topK * 2).map(({ row }) => row)
+
+  const keep = gateRelevance(topicScores, topK * 2)
+  if (keep === 0) return []
+  return scored.slice(0, keep).map(({ row }) => row)
 }
 
 function keywordLane(

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -47,28 +47,42 @@ export async function hybridSearch(
   return fuseLanes(vectorRows, keywordMatches, index, parentSlugsByFragmentId).slice(0, topK)
 }
 
-// The vector lane, gated by per-query relevance. The relevance gate reads the
-// full TOPIC score distribution (E5's no-match band is a topic-level property;
-// stream fragments are sparse and would skew the baseline) and decides how many
-// candidates clear this query's baseline — zero when nothing does, which empties
-// the vector lane. An empty vector lane composes with RRF exactly like a lane
-// that found nothing, so a genuine keyword hit still survives a cosine no-match.
+// The vector lane, gated by per-query relevance. Topic and stream rows are
+// gated SEPARATELY: only the topic partition is subject to the no-match veto.
 //
-// The gate only has a baseline to judge against when topic vectors are present.
-// Below the gate's own small-corpus floor (including the freshness-window case
-// where the only vectors are undreamed stream fragments and no topic is indexed
-// yet) there is no band to measure, so the lane falls back to the ungated
-// top-(topK*2) — suppressing here would drop a legitimate stream-only match.
+// The relevance gate reads the full TOPIC score distribution (E5's no-match
+// band is a topic-level property; stream fragments are sparse and would skew
+// the baseline) and decides how many topic candidates clear this query's
+// baseline — zero when nothing does. Stream rows are NEVER vetoed by that
+// topic-distribution verdict: a flat topic band means "no consolidated topic
+// matches," not "the relevant undreamed fragment doesn't match." Letting a
+// topic no-match drop stream candidates would silently break the freshness
+// window — the common case where the only relevant content for a query is a
+// stream fragment no topic cites yet. Stream rows keep the ungated top-(topK*2).
+//
+// When the topic partition is below the gate's small-corpus floor there is no
+// band to measure, so topics also pass ungated. An empty merged lane composes
+// with RRF exactly like a lane that found nothing, so a genuine keyword hit
+// still survives a full cosine no-match.
 const GATE_TOPIC_FLOOR = 6
 
 function gatedVectorLane(queryEmbedding: Float32Array, store: VectorStore, topK: number): VectorRow[] {
   const scored = store.queryScored(queryEmbedding, EMBEDDING_MODEL_ID)
-  const topicScores = scored.filter(({ row }) => row.source === 'topic').map(({ score }) => score)
-  if (topicScores.length < GATE_TOPIC_FLOOR) return scored.slice(0, topK * 2).map(({ row }) => row)
+  const topicRows = scored.filter(({ row }) => row.source === 'topic')
+  const streamRows = scored.filter(({ row }) => row.source === 'stream').slice(0, topK * 2)
 
-  const keep = gateRelevance(topicScores, topK * 2)
-  if (keep === 0) return []
-  return scored.slice(0, keep).map(({ row }) => row)
+  const keptTopics =
+    topicRows.length < GATE_TOPIC_FLOOR
+      ? topicRows.slice(0, topK * 2)
+      : topicRows.slice(
+          0,
+          gateRelevance(
+            topicRows.map(({ score }) => score),
+            topK * 2,
+          ),
+        )
+
+  return [...keptTopics, ...streamRows].sort((a, b) => b.score - a.score).map(({ row }) => row)
 }
 
 function keywordLane(

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -7,7 +7,7 @@ import type { StreamEvent } from '../stream-events'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
 import { embed, EMBEDDING_MODEL_ID, type EmbedType } from './embedder'
 import type { Passage } from './passages'
-import { gateRelevance } from './relevance-gate'
+import { clearsBaseline, gateRelevance, streamAdmissionBaseline } from './relevance-gate'
 import { VectorStore, type VectorRow } from './store'
 
 export { collectPassages, findMissingPassages, type Passage } from './passages'
@@ -47,42 +47,39 @@ export async function hybridSearch(
   return fuseLanes(vectorRows, keywordMatches, index, parentSlugsByFragmentId).slice(0, topK)
 }
 
-// The vector lane, gated by per-query relevance. Topic and stream rows are
-// gated SEPARATELY: only the topic partition is subject to the no-match veto.
+// The vector lane, gated by per-query relevance. Both row kinds are judged
+// against ONE query-local no-match band, derived from the TOPIC score
+// distribution alone (topics are the only stable-enough corpus to estimate the
+// ambient band; sparse streams consume the band but never define it, so a
+// nearest-neighbour cluster of fragments can't move the bar).
 //
-// The relevance gate reads the full TOPIC score distribution (E5's no-match
-// band is a topic-level property; stream fragments are sparse and would skew
-// the baseline) and decides how many topic candidates clear this query's
-// baseline — zero when nothing does. Stream rows are NEVER vetoed by that
-// topic-distribution verdict: a flat topic band means "no consolidated topic
-// matches," not "the relevant undreamed fragment doesn't match." Letting a
-// topic no-match drop stream candidates would silently break the freshness
-// window — the common case where the only relevant content for a query is a
-// stream fragment no topic cites yet. Stream rows keep the ungated top-(topK*2).
+//   - Topic rows: the gate keeps the knee above the band, or empties the topic
+//     partition entirely when no topic clears it.
+//   - Stream rows: admitted one-by-one only when they clear the SAME band by
+//     the shared margin. A genuine fresh fragment (well above the band) survives
+//     the freshness window; an irrelevant in-band neighbour is dropped, so a
+//     no-match query can't leak closest-neighbours-regardless through streams.
 //
-// When the topic partition is below the gate's small-corpus floor there is no
-// band to measure, so topics also pass ungated. An empty merged lane composes
-// with RRF exactly like a lane that found nothing, so a genuine keyword hit
-// still survives a full cosine no-match.
-const GATE_TOPIC_FLOOR = 6
-
+// Topic suppression uses the floor-gated verdict (gateRelevance): below the
+// floor topics pass ungated, since a tiny index can't form a reliable band and
+// a false negative is cheaper than suppressing the only memory. Stream
+// admission uses streamAdmissionBaseline, which tolerates a below-floor topic
+// set — even a few topics give the contrast a vector-only fragment match needs,
+// and it returns null (dropping uncorroborated streams) only when NO topics
+// exist at all. A lexically-corroborated fragment still reaches RRF via the
+// separate keyword lane. An empty merged lane composes with RRF exactly like a
+// lane that found nothing, so a genuine keyword hit survives a full no-match.
 function gatedVectorLane(queryEmbedding: Float32Array, store: VectorStore, topK: number): VectorRow[] {
   const scored = store.queryScored(queryEmbedding, EMBEDDING_MODEL_ID)
   const topicRows = scored.filter(({ row }) => row.source === 'topic')
-  const streamRows = scored.filter(({ row }) => row.source === 'stream').slice(0, topK * 2)
+  const streamRows = scored.filter(({ row }) => row.source === 'stream')
 
-  const keptTopics =
-    topicRows.length < GATE_TOPIC_FLOOR
-      ? topicRows.slice(0, topK * 2)
-      : topicRows.slice(
-          0,
-          gateRelevance(
-            topicRows.map(({ score }) => score),
-            topK * 2,
-          ),
-        )
+  const topicScores = topicRows.map(({ score }) => score)
+  const keptTopics = topicRows.slice(0, gateRelevance(topicScores, topK * 2))
+  const streamBaseline = streamAdmissionBaseline(topicScores)
+  const keptStreams = streamRows.filter(({ score }) => clearsBaseline(score, streamBaseline)).slice(0, topK * 2)
 
-  return [...keptTopics, ...streamRows].sort((a, b) => b.score - a.score).map(({ row }) => row)
+  return [...keptTopics, ...keptStreams].sort((a, b) => b.score - a.score).map(({ row }) => row)
 }
 
 function keywordLane(

--- a/src/bundled-plugins/memory/vector/relevance-gate.test.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'bun:test'
 
-import { gateRelevance } from './relevance-gate'
+import { clearsBaseline, gateRelevance, streamAdmissionBaseline } from './relevance-gate'
 
-// Score fixtures reproduced from the live typeeybot index (193 topics,
-// multilingual-e5-base@q8). E5 compresses unrelated cosines into a ~0.70-0.85
-// band, so the discriminating signal is top1 - baseline(pack), NOT absolute
-// value. NO-MATCH queries land top1-baseline <= 0.051; HAS-MATCH queries land
-// >= 0.074. See PR description for the full battery.
+// Score fixtures reproduced from a live ~193-topic index (multilingual-e5-base
+// @q8). E5 compresses unrelated cosines into a ~0.70-0.85 band, so the
+// discriminating signal is top1 - baseline(pack), NOT absolute value. NO-MATCH
+// queries land top1-baseline <= 0.051; HAS-MATCH queries land >= 0.074. See PR
+// description for the full battery.
 function band(top: number, baseline: number, n: number): number[] {
   const scores = [top]
   for (let i = 1; i < n; i++) scores.push(baseline + (Math.random() - 0.5) * 0.004)
@@ -83,5 +83,29 @@ describe('gateRelevance', () => {
     const kept = gateRelevance(scores, 10)
 
     expect(kept).toBeGreaterThan(0)
+  })
+})
+
+describe('streamAdmissionBaseline + clearsBaseline', () => {
+  it('returns null when no topic scores exist (nothing to contrast against)', () => {
+    expect(streamAdmissionBaseline([])).toBeNull()
+    expect(clearsBaseline(0.99, null)).toBe(false)
+  })
+
+  it('tolerates a below-floor topic set (a few topics still give a contrast signal)', () => {
+    const baseline = streamAdmissionBaseline([0.5, 0.49])
+
+    expect(baseline).not.toBeNull()
+    // a clear stream winner stands above the small topic band
+    expect(clearsBaseline(1.0, baseline)).toBe(true)
+    // an in-band stream neighbor does not
+    expect(clearsBaseline(0.5, baseline)).toBe(false)
+  })
+
+  it('admits a stream row only when it clears the topic band by the margin', () => {
+    const baseline = streamAdmissionBaseline(Array.from({ length: 30 }, () => 0.78))
+
+    expect(clearsBaseline(0.781, baseline)).toBe(false)
+    expect(clearsBaseline(0.78 + 0.06, baseline)).toBe(true)
   })
 })

--- a/src/bundled-plugins/memory/vector/relevance-gate.test.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test'
+
+import { gateRelevance } from './relevance-gate'
+
+// Score fixtures reproduced from the live typeeybot index (193 topics,
+// multilingual-e5-base@q8). E5 compresses unrelated cosines into a ~0.70-0.85
+// band, so the discriminating signal is top1 - baseline(pack), NOT absolute
+// value. NO-MATCH queries land top1-baseline <= 0.051; HAS-MATCH queries land
+// >= 0.074. See PR description for the full battery.
+function band(top: number, baseline: number, n: number): number[] {
+  const scores = [top]
+  for (let i = 1; i < n; i++) scores.push(baseline + (Math.random() - 0.5) * 0.004)
+  return scores.sort((a, b) => b - a)
+}
+
+describe('gateRelevance', () => {
+  it('suppresses the whole set when top1 barely clears the baseline (no-match)', () => {
+    // given: election-query distribution — top 0.8055, baseline ~0.755 (gap 0.051)
+    const scores = band(0.8055, 0.755, 193)
+
+    const kept = gateRelevance(scores, 10)
+
+    expect(kept).toBe(0)
+  })
+
+  it('keeps a clearly-elevated top (real semantic match)', () => {
+    // given: idonghyeop-query distribution — top 0.851, baseline ~0.744 (gap 0.107)
+    const scores = band(0.851, 0.744, 193)
+
+    const kept = gateRelevance(scores, 10)
+
+    expect(kept).toBeGreaterThan(0)
+  })
+
+  it('caps survivors at topK even when many clear the knee', () => {
+    const scores = [0.95, ...Array.from({ length: 50 }, () => 0.9), ...Array.from({ length: 142 }, () => 0.7)]
+
+    const kept = gateRelevance(scores, 10)
+
+    expect(kept).toBeLessThanOrEqual(10)
+  })
+
+  it('keeps only the knee — survivors are the elevated head, not the flat pack', () => {
+    // given: one sharp winner over a flat pack (idonghyeop shape: 0.851 then ~0.78)
+    const scores = [0.851, 0.79, 0.789, ...Array.from({ length: 190 }, () => 0.744)]
+
+    const kept = gateRelevance(scores, 10)
+
+    expect(kept).toBeGreaterThanOrEqual(1)
+    expect(kept).toBeLessThan(10)
+  })
+
+  it('skips set-level suppression for a tiny corpus (n < 6)', () => {
+    // given: 3 shards — too few to estimate a baseline; never suppress to zero
+    const scores = [0.78, 0.77, 0.76]
+
+    const kept = gateRelevance(scores, 10)
+
+    expect(kept).toBeGreaterThan(0)
+  })
+
+  it('returns zero for an empty score list', () => {
+    expect(gateRelevance([], 10)).toBe(0)
+  })
+
+  it('uses a median baseline for a mid-size corpus (6 <= n < 20) and still suppresses a flat band', () => {
+    // given: 10 shards all in a flat ~0.78 band (no real match)
+    const scores = [0.792, ...Array.from({ length: 9 }, () => 0.78)]
+
+    const kept = gateRelevance(scores, 10)
+
+    expect(kept).toBe(0)
+  })
+
+  it('is robust to a near-duplicate cluster inflating the mean (real match survives)', () => {
+    // given: a clear winner 0.86 plus a dense cluster of near-dupes at ~0.80,
+    // then the long flat tail — a raw mean would be inflated by the cluster, but
+    // a trimmed/percentile baseline must still let the 0.86 winner through.
+    const cluster = Array.from({ length: 15 }, () => 0.8)
+    const tail = Array.from({ length: 177 }, () => 0.75)
+    const scores = [0.86, ...cluster, ...tail]
+
+    const kept = gateRelevance(scores, 10)
+
+    expect(kept).toBeGreaterThan(0)
+  })
+})

--- a/src/bundled-plugins/memory/vector/relevance-gate.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.ts
@@ -1,0 +1,44 @@
+// E5 embeddings (multilingual-e5-base) compress cosine similarity into a narrow
+// ~0.70-0.85 band even for unrelated pairs — a documented consequence of the
+// low InfoNCE training temperature (tau=0.01). Absolute thresholds therefore
+// cannot tell a real match from baseline noise: an unrelated query's top hit
+// (0.8055) can outscore a genuine match's top hit (0.7786) on a different query.
+//
+// The discriminating signal is QUERY-LOCAL CONTRAST: how far the best score
+// stands above this query's own baseline cluster. A real match lifts top1 well
+// clear of the pack; a no-match leaves top1 buried in the band. Measured on a
+// live 193-topic index, no-match queries land top1-baseline <= 0.051 and
+// has-match queries land >= 0.074, so a 0.06 margin separates them cleanly.
+//
+// The baseline is the MEDIAN of the non-head scores (robust to a near-duplicate
+// cluster inflating a raw mean), which keeps a genuine winner above a crowd of
+// similar topics. Below SMALL_CORPUS_FLOOR there are too few scores to estimate
+// a baseline, so suppression is skipped — a false negative (injecting one
+// obvious shard) is cheaper than wrongly suppressing the only relevant memory.
+const MARGIN = 0.06
+const SMALL_CORPUS_FLOOR = 6
+const HEAD_EXCLUDED_FROM_BASELINE = 5
+
+// Returns how many of the sorted-descending cosine scores survive the gate.
+// Zero means "no relevant memory matched" — a valid, expected outcome the
+// caller injects as an empty memory block. `scores` MUST be sorted descending.
+export function gateRelevance(scores: number[], topK: number): number {
+  if (scores.length === 0 || topK <= 0) return 0
+  if (scores.length < SMALL_CORPUS_FLOOR) return Math.min(scores.length, topK)
+
+  const top = scores[0]!
+  const baseline = median(scores.slice(HEAD_EXCLUDED_FROM_BASELINE))
+  const margin = top - baseline
+  if (margin < MARGIN) return 0
+
+  const knee = top - 0.5 * margin
+  const survivors = scores.filter((score) => score >= knee).length
+  return Math.min(survivors, topK)
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!
+}

--- a/src/bundled-plugins/memory/vector/relevance-gate.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.ts
@@ -19,16 +19,43 @@ const MARGIN = 0.06
 const SMALL_CORPUS_FLOOR = 6
 const HEAD_EXCLUDED_FROM_BASELINE = 5
 
-// Returns how many of the sorted-descending cosine scores survive the gate.
-// Zero means "no relevant memory matched" — a valid, expected outcome the
-// caller injects as an empty memory block. `scores` MUST be sorted descending.
+// The contrast reference for ADMITTING stream rows: the median of the available
+// topic scores (head excluded once there are enough to trim). Topics define the
+// ambient cosine band; sparse streams consume it but never define it, so a
+// nearest-neighbour cluster of fragments can't move the bar. Returns null only
+// when NO topic scores exist — with nothing to contrast against, an
+// uncorroborated semantic-only stream must not inject (it can still reach RRF
+// via the keyword lane). Unlike topic suppression, this tolerates a below-floor
+// topic set: even a few topics give a usable "is this stream clearly elevated?"
+// signal, which is exactly the contrast a vector-only fragment match needs.
+// `topicScores` MUST be sorted descending.
+export function streamAdmissionBaseline(topicScores: number[]): number | null {
+  if (topicScores.length === 0) return null
+  const pack =
+    topicScores.length > HEAD_EXCLUDED_FROM_BASELINE ? topicScores.slice(HEAD_EXCLUDED_FROM_BASELINE) : topicScores
+  return median(pack)
+}
+
+// Whether a single cosine score clears the band by the shared margin. Used to
+// admit stream rows against the topic contrast reference: a stream candidate
+// survives only if it stands as far above the band as a real topic match would.
+// A null baseline (no topics at all) admits nothing.
+export function clearsBaseline(score: number, baseline: number | null): boolean {
+  return baseline !== null && score - baseline >= MARGIN
+}
+
+// Returns how many of the sorted-descending topic cosine scores survive the
+// gate. Zero means "no relevant memory matched" — a valid, expected outcome the
+// caller injects as an empty memory block. Below SMALL_CORPUS_FLOOR there are
+// too few topics for a reliable suppression verdict, so topics pass ungated (a
+// false negative of one obvious shard is cheaper than suppressing the only
+// memory). `scores` MUST be sorted descending.
 export function gateRelevance(scores: number[], topK: number): number {
   if (scores.length === 0 || topK <= 0) return 0
   if (scores.length < SMALL_CORPUS_FLOOR) return Math.min(scores.length, topK)
 
   const top = scores[0]!
-  const baseline = median(scores.slice(HEAD_EXCLUDED_FROM_BASELINE))
-  const margin = top - baseline
+  const margin = top - median(scores.slice(HEAD_EXCLUDED_FROM_BASELINE))
   if (margin < MARGIN) return 0
 
   const knee = top - 0.5 * margin

--- a/src/bundled-plugins/memory/vector/store.ts
+++ b/src/bundled-plugins/memory/vector/store.ts
@@ -15,6 +15,8 @@ export type VectorRow = {
 
 export type VectorMeta = { id: string; model: string; contentHash: string }
 
+export type ScoredVectorRow = { row: VectorRow; score: number }
+
 type StoredVectorRow = {
   id: string
   source: 'topic' | 'stream'
@@ -83,20 +85,27 @@ export class VectorStore {
 
   query(embedding: Float32Array, topK: number, modelId: string): VectorRow[] {
     if (topK <= 0) return []
+    return this.queryScored(embedding, modelId)
+      .slice(0, topK)
+      .map(({ row }) => row)
+  }
 
-    // Filter by embedding identity, not dims alone: a stale row from a different
-    // model/dtype variant can share the same dims but lives in an incompatible
-    // vector space, so cosine against it is garbage. Excluding it here keeps a
-    // partial re-embed (mixed variants mid-rebuild) at reduced recall, never
-    // wrong scores.
+  // Same cosine scan as `query` but returns every compatible row WITH its score
+  // and unsliced, so a caller can reason about the full score distribution (the
+  // relevance gate's per-query baseline) before deciding how many to keep.
+  //
+  // Filter by embedding identity, not dims alone: a stale row from a different
+  // model/dtype variant can share the same dims but lives in an incompatible
+  // vector space, so cosine against it is garbage. Excluding it here keeps a
+  // partial re-embed (mixed variants mid-rebuild) at reduced recall, never
+  // wrong scores.
+  queryScored(embedding: Float32Array, modelId: string): ScoredVectorRow[] {
     return this.db
       .query<StoredVectorRow, [string, number]>('SELECT * FROM vectors WHERE model = ? AND dims = ?')
       .all(modelId, embedding.length)
       .map(toVectorRow)
       .map((row) => ({ row, score: cosineSimilarity(embedding, row.embedding) }))
       .sort((a, b) => b.score - a.score)
-      .slice(0, topK)
-      .map(({ row }) => row)
   }
 
   deleteOtherModels(modelId: string): void {


### PR DESCRIPTION
## Background

A channel user asked the agent to recall a past conversation about a topic that was **never consolidated into a memory shard** (a June local-election chat that only ever lived in undreamed daily streams). Instead of saying "I don't have that," the agent injected its usual ~10 topic headings — GitHub PR notes, KakaoTalk tone conventions, opensoma reviews — **none related to the query** — and reported them to the user as "this turn's injected memory." It looked broken.

It isn't a wiring bug. The query embedding is clean (channel turns embed only the raw user text, not the recent-context envelope). The root cause is the embedding model plus a missing relevance floor:

- The index uses `intfloat/multilingual-e5-base`, which by design (low InfoNCE temperature, τ=0.01 — documented in the model-card FAQ) compresses cosine similarity into a **~0.70–0.85 band even for unrelated pairs**. Reproduced against the live index: the election query scored every one of 193 topics between 0.695 and 0.806.
- `hybridSearch` had **no relevance floor** — it always returned `.slice(0, topK)`. With no real match, the top-10 is just the model's baseline cluster.

Because the band floats per query, an **absolute** threshold is impossible: the no-match election query's top hit (0.8055) outscores a genuine match's top hit on another query (Korean-EV: 0.7786). I verified this empirically — z-score and absolute-margin gates both fail the no-match cases (the election #1 sits at 3.0σ and 0.8055 absolute).

## Summary

Add a **query-local relevance gate** on the vector lane (`relevance-gate.ts`), run before RRF fusion in `hybridSearch`.

- **The signal is contrast, not magnitude:** `top1 − baseline`, where baseline = **median of the non-head topic scores**. On the live battery, no-match queries land `top1 − baseline ≤ 0.051` and has-match queries `≥ 0.074`; a **0.06 margin** separates them (8/8 correct across 3 no-match + 5 has-match queries).
- **Why median, not mean:** a near-duplicate cluster of topics would inflate a raw mean and falsely suppress a real winner; the median of the non-head is robust to that (covered by a test).
- **Why gate the vector lane, not the fused result (Oracle-reviewed):** RRF scores are rank-only and discard the cosine geometry the gate needs. A set-level veto on fused results would also let weak vector evidence suppress strong keyword evidence. So the gate lives in the vector lane; **suppression empties that lane, which composes with RRF exactly like a lane that found nothing.**
- **Keyword hits survive a cosine no-match:** a flat embedding distribution means "no semantic match," not "no lexical match." An exact substring hit (slug, PR number, rare proper noun) is independent, higher-precision evidence and is never vetoed by the cosine gate.
- **Empty is a valid outcome:** when nothing clears the bar the vector lane is empty and (if keyword is also empty) the memory block is empty — so "no relevant memory" becomes injectable as *nothing*, instead of the closest-10-regardless.

`store.queryScored` is added so the gate can see the full score distribution; the existing `store.query` is reimplemented on top of it (sliced), unchanged for all other callers.

## What this does NOT do

- Does not change the embedding model, add whitening, or add a reranker (all considered and deferred as higher-complexity, silent-failure-prone — Oracle's recommendation was to start with query-local contrast).
- Does not touch the under-budget "inject all shards" path — only the over-budget hybrid-search path.
- Does not add a "no memory matched" sentinel to the prompt (deliberately: it would burn budget and teach the model that absence is salient). Empty stays empty; observability belongs in logs.
- Does not fix the channel **reporting** path (where the agent narrates injected memory to users) — out of scope here; this PR makes the underlying set correct ("nothing injected" instead of "10 unrelated").
- `δ = 0.06` and the corpus floors are calibrated from one agent's index (n=8 battery). They're named constants, intended to be revisited if telemetry shows misses — not claimed as universal truths.

## Review notes

- **Load-bearing invariant:** suppression must not veto keyword evidence. See `gatedVectorLane` in `hybrid.ts` (empty vector lane → keyword-only RRF) and the test *"lets a keyword hit survive even when the vector lane is fully suppressed."*
- **Subtle edge (caught by an existing test):** when only **stream** fragments are indexed and no topic vectors exist (freshness window, or any corpus below `GATE_TOPIC_FLOOR`), the gate is skipped and the lane falls back to ungated top-(topK*2). Otherwise a legitimate stream-only match would be wrongly suppressed. The baseline is computed over **topic** scores only — stream fragments are sparse and would skew it.
- **Calibration provenance:** `relevance-gate.test.ts` fixtures encode the reproduced live distributions; the magic constants (0.8055/0.051 etc.) are documented there and in the gate's header comment. End-to-end re-verified against the live index: election → 0 kept, cookies → 0 kept, idonghyeop → `idonghyeop-speech-level`, "PR 800" → `pr-797`/`pr-800`.
