### PR TITLE
fix(todo): resume length-truncated turns via auto-continuation

### DIFF
--- a/src/agent/todo/continuation-policy.test.ts
+++ b/src/agent/todo/continuation-policy.test.ts
@@ -119,8 +119,13 @@ describe('parseContinuationState (fail-closed validation)', () => {
   })
 
   test('an unknown stopReason collapses the outcome to null (idle then fails closed)', () => {
-    const corrupt = { lastTurnOutcome: { turnId: 't', stopReason: 'length', endedAt: 1 } }
+    const corrupt = { lastTurnOutcome: { turnId: 't', stopReason: 'bananas', endedAt: 1 } }
     expect(parseContinuationState(corrupt).lastTurnOutcome).toBeNull()
+  })
+
+  test('a length stopReason round-trips (budget truncation is continuation-eligible)', () => {
+    const state = { lastTurnOutcome: { turnId: 't', stopReason: 'length', endedAt: 1 } }
+    expect(parseContinuationState(state).lastTurnOutcome).toEqual({ turnId: 't', stopReason: 'length', endedAt: 1 })
   })
 
   test('an unknown suppressor value is dropped', () => {
@@ -152,6 +157,11 @@ describe('decideContinuation', () => {
   test('skips when the last turn was a user abort', () => {
     const d = decide(baseState({ lastTurnOutcome: { turnId: 't', stopReason: 'aborted', endedAt: 1 } }))
     expect(d).toEqual({ kind: 'skip', reason: 'turn-not-safe' })
+  })
+
+  test('injects after a length truncation (budget exhaustion is continuation-eligible)', () => {
+    const d = decide(baseState({ lastTurnOutcome: { turnId: 't', stopReason: 'length', endedAt: 1 } }))
+    expect(d.kind).toBe('inject')
   })
 
   test('skips while the user-abort durable suppressor is set', () => {

--- a/src/agent/todo/continuation-policy.ts
+++ b/src/agent/todo/continuation-policy.ts
@@ -39,10 +39,13 @@ export type ContinuationEpisode = {
 // The outcome of the most recently completed turn, recorded from the
 // `message_end` subscription (authoritative) or a prompt `finally` fallback.
 // `stopReason: 'unknown'` is the fail-closed value: an idle that sees it does
-// not auto-inject.
+// not auto-inject. `'length'` is a budget truncation (the turn ran out of
+// output tokens, often mid-thinking) — a legitimate unfinished turn that the
+// continuation budget/stagnation guards are designed to bound, so it is
+// continuation-eligible, NOT fail-closed.
 export type TurnOutcome = {
   turnId: string
-  stopReason: 'stop' | 'aborted' | 'error' | 'unknown'
+  stopReason: 'stop' | 'length' | 'aborted' | 'error' | 'unknown'
   endedAt: number
   // Total tokens the just-completed turn consumed (from the assistant
   // message's usage). Accumulated into the episode's cumulativeTokens so the
@@ -73,7 +76,7 @@ export function emptyContinuationState(): ContinuationState {
   }
 }
 
-const STOP_REASONS = new Set<TurnOutcome['stopReason']>(['stop', 'aborted', 'error', 'unknown'])
+const STOP_REASONS = new Set<TurnOutcome['stopReason']>(['stop', 'length', 'aborted', 'error', 'unknown'])
 
 // Validate a persisted state object field-by-field and fail closed: any field
 // that does not match the expected shape is dropped to its empty value rather

--- a/src/agent/todo/continuation-wiring.test.ts
+++ b/src/agent/todo/continuation-wiring.test.ts
@@ -34,6 +34,7 @@ afterEach(async () => {
 describe('classifyStopReason', () => {
   test('passes through known reasons and collapses the rest to unknown', () => {
     expect(classifyStopReason('stop')).toBe('stop')
+    expect(classifyStopReason('length')).toBe('length')
     expect(classifyStopReason('aborted')).toBe('aborted')
     expect(classifyStopReason('error')).toBe('error')
     expect(classifyStopReason('tool_calls')).toBe('unknown')

--- a/src/agent/todo/continuation-wiring.ts
+++ b/src/agent/todo/continuation-wiring.ts
@@ -14,9 +14,11 @@ import { writeTodos } from './store'
 
 // Map a pi `message_end` event's stopReason onto the TurnOutcome stopReason
 // space. Anything we don't recognize collapses to 'unknown' so the idle path
-// fails closed (no auto-injection on an outcome we can't classify).
+// fails closed (no auto-injection on an outcome we can't classify). 'length'
+// is preserved (not collapsed) because a budget-truncated turn is a legitimate
+// unfinished turn the continuation guards should be allowed to resume.
 export function classifyStopReason(raw: unknown): TurnOutcome['stopReason'] {
-  if (raw === 'stop' || raw === 'aborted' || raw === 'error') return raw
+  if (raw === 'stop' || raw === 'length' || raw === 'aborted' || raw === 'error') return raw
   return 'unknown'
 }
 


### PR DESCRIPTION
## Background

When a TUI or cron turn exhausted its output-token budget, the model returned `stopReason: 'length'` — often mid-thinking, before producing a final reply. The todo auto-continuation guard was supposed to resume incomplete work, but instead it silently dropped these turns. The agent appeared to "stop with length while thinking" and never continued, even when todos were still open.

Root cause is two coupled gaps in the continuation subsystem (TUI + cron path):

1. `classifyStopReason` in `continuation-wiring.ts` only passed through `stop`, `aborted`, and `error`. The `length` reason collapsed to `'unknown'`.
2. `decideContinuation` in `continuation-policy.ts` treats `'unknown'` (alongside `null` and `'aborted'`) as `turn-not-safe` and skips continuation — so a turn cut off mid-work was deemed unsafe to resume.

Secondary: the persisted `STOP_REASONS` set omitted `'length'`, so a `length` outcome read back from disk after a restart was silently dropped to `null`, compounding the problem.

The channel path (`src/channels/router.ts`) was unaffected — it already handles `length` independently by retrying with a raised budget.

## Summary

`'length'` is now preserved end-to-end through the TUI/cron continuation path.

**Why `length` is continuation-eligible, not fail-closed:** `'unknown'` exists for outcomes the classifier cannot interpret. `'length'` is unambiguous — the model ran out of output tokens. A budget-truncated turn with incomplete todos is exactly the case auto-continuation is designed to handle. Treating it as fail-closed was a false positive.

**Why the gate code in `decideContinuation` is unchanged:** The `turn-not-safe` gate lists only `null`, `'unknown'`, and `'aborted'`. Adding `'length'` to the union is enough to make it pass through to the existing per-episode budget checks — no gate logic needed to change.

**Why `aborted` stays fail-closed:** `aborted` reflects deliberate user interruption and arms the durable `autoResumeBlockedUntilRealUserTurn` suppressor in `continuation-state.ts`. `length` carries no such intent.

**No runaway loop risk:** The existing per-episode bounds — `maxAutoTurns: 3`, cumulative-token ceiling of 25k, and a 30-minute wall-clock limit — still apply. The stagnation guard (incomplete-todo hash unchanged across two turns) provides a second circuit breaker. Both hold even when token usage from a length-truncated turn is unavailable.

**No disk-schema version bump needed:** this change widens the accepted enum values within the existing version. Older state files remain valid.

## What this does NOT do

- Does not touch the channel path (`src/channels/router.ts`) — it already handles `length` independently.
- Does not raise the next turn's output-token budget for a `length` continuation. Continuation only injects a text nudge; generation-option control is out of scope.
- Does not change the nudge wording for `length` vs `stop`.

## Review notes

- **Load-bearing:** `decideContinuation`'s `turn-not-safe` gate in `continuation-policy.ts` still lists only `null`, `'unknown'`, and `'aborted'`. The union widening is what makes `'length'` pass — verify the gate code is unchanged and that `'aborted'` remains blocked and keeps arming `autoResumeBlockedUntilRealUserTurn`.
- **Test repoint:** the existing test asserting `length → null` (persisted unknown reason drops to null) was repointed to `'bananas'` — a genuinely unrecognizable reason. The semantics of the assertion are preserved; only the fixture was wrong.
- **New tests:** `continuation-wiring.test.ts` pins `classifyStopReason('length') === 'length'`; `continuation-policy.test.ts` adds a persistence round-trip test and an `inject`-on-`length` decision test.