### PR TITLE
fix(channels): recover final answer from length-truncated turn

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -147,6 +147,18 @@ class FakeSession {
   setAssistantMessage(message: AssistantMessage): void {
     this.leafEntry = messageEntry(message)
   }
+
+  // A `length`-truncated leaf with ONLY text blocks (no synthetic toolCall),
+  // matching the production shape: the model interleaved leaked `<think>` prose
+  // with its real answer and hit the output cap. Each string becomes its own
+  // text block so visibleAssistantText joins them exactly as in production.
+  setAssistantLengthLeaf(...texts: string[]): void {
+    this.leafEntry = messageEntry({
+      ...assistantMessage(''),
+      content: texts.map((text) => ({ type: 'text', text })),
+      stopReason: 'length',
+    })
+  }
 }
 
 async function tempDir(): Promise<string> {
@@ -3604,6 +3616,86 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.route(inbound({ text: 'fresh question' }))
     await router.__testing!.flushDebounce(KEY)
     expect(sessions[0]!.lastStreamMaxTokens).toBe(CHANNEL_MAX_OUTPUT_TOKENS)
+  })
+
+  test('length-leaf recovery: strips leaked think blocks and posts the surviving answer (no retry)', async () => {
+    // Regression for the production silent-drop (2026-06-12): a channel turn hit
+    // the output cap after interleaving leaked `<think>` reasoning with a
+    // complete final answer; the old recoverableAssistantText threw it all away
+    // as an unrecoverable 'length' leaf and the turn fell silent.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ask something hard' }))
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantLengthLeaf('<think>long reasoning</think>', '\n\nHere is the real answer.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent.map((s) => s.text)).toEqual(['Here is the real answer.'])
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+  })
+
+  test('length-leaf recovery: a think-only length leaf retries with the raised budget (nothing to post)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ask something hard' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      await streamOnce(sessions[0]!)
+      if (attempt === 1) {
+        // Pure leaked reasoning, no answer after stripping → must retry, not post.
+        sessions[0]!.setAssistantLengthLeaf('<think>never-ending reasoning</think>')
+        return
+      }
+      sessions[0]!.setAssistantText('recovered answer')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'recovered answer' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent.map((s) => s.text)).toEqual(['recovered answer'])
+    expect(logs.some((m) => m.includes('empty_turn_retry attempt=1'))).toBe(true)
+    expect(sessions[0]!.lastStreamMaxTokens).toBe(CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS)
+  })
+
+  test('length-leaf recovery: plain length text with NO think evidence stays on the retry path (not posted)', async () => {
+    // A truncated 'length' leaf with no `<think>` span is genuinely ambiguous
+    // (possibly a broken partial), so it keeps the historical retry behavior
+    // rather than posting raw truncated output.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'ask something hard' }))
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantLengthLeaf('plain truncated output with no think tags')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.some((s) => s.text === 'plain truncated output with no think tags')).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(true)
   })
 
   test("empty-turn guard: an 'aborted' truncation retries under the DEFAULT cap, not the raised budget", async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3303,7 +3303,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
     }
 
-    const candidate = recoverableAssistantText(live.session)
+    let candidate = recoverableAssistantText(live.session)
+    // A `length` leaf is recovered ONLY when stripping leaked `<think>…</think>`
+    // spans actually removed something AND leaves a postable reply. The removal
+    // is the positive signal that this was leaked-reasoning-plus-real-prose (the
+    // production shape: interleaved think-text ending in a complete answer) — a
+    // truncated `length` leaf with no think evidence is genuinely ambiguous and
+    // stays on the raised-budget empty-turn retry below, exactly as before.
+    if (candidate?.source === 'length-leaf') {
+      const stripped = stripThinkBlocks(candidate.text)
+      const removedThink = stripped !== candidate.text
+      candidate =
+        removedThink &&
+        stripped !== '' &&
+        !endsWithNoReplySignal(stripped) &&
+        !isUpstreamEmptyResponseSentinel(stripped)
+          ? { ...candidate, text: stripped }
+          : null
+    }
     if (candidate === null) {
       // No recoverable assistant prose: the turn ended with no usable reply.
       // Three distinct shapes, handled differently:
@@ -4737,13 +4754,21 @@ async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): 
 // assistant message — i.e., text the user should see but didn't, because the
 // model failed to call `channel_reply`/`channel_send` before its turn ended.
 //
-// Three recovery shapes:
+// Four recovery shapes:
 //
 //   - source: 'leaf'
 //     The leaf entry IS an assistant message with `stopReason === 'stop'`.
 //     The model finished its turn with visible text but never called a channel
 //     tool. Pre-existing behavior; this is what the historical
 //     `latestAssistantText` covered.
+//
+//   - source: 'length-leaf'
+//     The leaf IS an assistant message with `stopReason === 'length'` — the
+//     model hit the output cap, typically after interleaving reasoning past the
+//     budget, but its text blocks usually hold a complete answer. Returned raw;
+//     validateChannelTurn strips leaked `<think>` spans and posts the remainder
+//     only if a real reply survives, else diverts to the raised-budget retry.
+//     Observed against claude on a channel turn that fell silent (2026-06-12).
 //
 //   - source: 'mid-turn'
 //     The leaf IS an assistant message with `stopReason === 'toolUse'` that
@@ -4770,11 +4795,10 @@ async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): 
 //
 // Returns null when no recovery is appropriate:
 //   - No leaf, no messages in branch, branch is malformed
-//   - Leaf is an assistant with `stopReason` of 'length' / 'error' / 'aborted'
-//     and is NOT preceded by a toolResult pattern — we don't recover partial
-//     errored output because it's typically a truncation, not a deliberate
-//     reply. Only 'stop' (turn-complete) and 'toolUse' (committed to a tool
-//     plan, prose stranded) signal text the model meant for the user.
+//   - Leaf is an assistant with `stopReason` of 'error' / 'aborted' and is NOT
+//     preceded by a toolResult pattern — we don't recover an upstream provider
+//     failure ('error') or a terminal-reply abort ('aborted'); neither is a
+//     deliberate reply. ('length' IS recovered now — see 'length-leaf' above.)
 //   - Leaf is a user/system message (model hasn't responded yet)
 //
 // `visibleAssistantText` returning '' (empty string) is a valid recovery
@@ -4782,7 +4806,7 @@ async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): 
 // true) handle the no-content case explicitly via the `no_reply` log.
 function recoverableAssistantText(
   session: AgentSession,
-): { text: string; source: 'leaf' | 'mid-turn' | 'pre-tool' } | null {
+): { text: string; source: 'leaf' | 'mid-turn' | 'pre-tool' | 'length-leaf' } | null {
   const leaf = session.sessionManager.getLeafEntry()
   if (!leaf) return null
 
@@ -4792,10 +4816,20 @@ function recoverableAssistantText(
     }
     // The model committed to a tool plan but its visible prose never reached
     // the channel and no follow-up message that would have called a channel
-    // tool was persisted. Recover the stranded prose. Other non-'stop' stop
-    // reasons (length/error/aborted) are truncations, not deliberate replies.
+    // tool was persisted. Recover the stranded prose.
     if (leaf.message.stopReason === 'toolUse') {
       return { text: visibleAssistantText(leaf.message), source: 'mid-turn' }
+    }
+    // A `length` leaf hit the output cap but routinely carries a complete (or
+    // near-complete) answer in its text blocks — the model just kept reasoning
+    // past the budget. Surfacing it as 'length-leaf' lets validateChannelTurn
+    // strip leaked think-spans and post the answer if any survives, while still
+    // diverting a think-only `length` turn to the raised-budget retry. A leaf
+    // that also carries a toolCall block was truncated mid-tool-planning, not on
+    // a final answer, so it is NOT the recoverable shape. `error` (provider
+    // failure) and `aborted` (terminal-reply abort) stay unrecoverable too.
+    if (leaf.message.stopReason === 'length' && !hasToolCall(leaf.message)) {
+      return { text: visibleAssistantText(leaf.message), source: 'length-leaf' }
     }
     return null
   }
@@ -4843,6 +4877,10 @@ function visibleAssistantText(message: AssistantMessage): string {
     .filter((block) => block.type === 'text')
     .map((block) => block.text)
     .join('')
+}
+
+function hasToolCall(message: AssistantMessage): boolean {
+  return message.content.some((block) => block.type === 'toolCall')
 }
 
 // Lenient on purpose: distilled / smaller models routinely drift off the


### PR DESCRIPTION
## Background

A channel agent (Slack/Discord) hit the output-token cap mid-turn and fell silent — the turn never reached the user and they had to re-message. Confirmed from a production session JSONL: the assistant leaf had `stopReason: 'length'` with 237 interleaved text/thinking blocks. The model had leaked its chain-of-thought as literal `<think>…</think>` text blocks interleaved with real `thinking` blocks, and the final text block held a complete answer. The whole turn was discarded.

Root cause: `recoverableAssistantText` in `router.ts` returned `null` for any leaf whose stop reason was not `stop` or `toolUse`. A `length` leaf — even one carrying a complete reply — hit that null path, so `validateChannelTurn` ran the empty-turn retry/fallback path instead of delivering the answer the model had already written.

## Summary

`recoverableAssistantText` now recovers a `length` leaf as source `'length-leaf'` (raw text), except when the leaf also carries a `toolCall` block — that shape is a mid-tool-planning truncation, not a final answer. `error` and `aborted` stay unrecoverable as before.

In `validateChannelTurn`, a `'length-leaf'` candidate has its leaked `<think>…</think>` spans stripped. The stripped reply is posted **only when** stripping actually removed a think span AND a postable reply survives (non-empty, not `NO_REPLY`, not the upstream-empty sentinel). If neither condition holds, the candidate collapses to `null` and the existing raised-budget empty-turn retry takes over — unchanged.

**Why `removedThink` as the discriminator and not "post any non-empty length text":** a `length` leaf with no `<think>` evidence is genuinely ambiguous — possibly a broken partial. Requiring that stripping actually changed the text keeps the historical retry behavior for that case and avoids spamming raw truncated output. This is also why all nine pre-existing plain-text `length` tests pass unchanged.

**Why strip and decide in `validateChannelTurn`, not inside `recoverableAssistantText`:** the retry semantics depend on `validateChannelTurn` state (`emptyTurnRetries`, `currentTurnAuthorId`, `nextPromptMaxTokens`). The helper stays a pure text extractor.

**Why skip recovery when a `toolCall` block is present:** that shape is an interrupted tool-planning turn, not a final user-facing answer.

## What this does NOT do

- Does not change the empty-turn retry/raised-budget mechanism for think-only `length` turns.
- Does not change `error` or `aborted` recovery.
- Does not add a min-length or sentence-boundary heuristic — if a reply survives think-stripping and the existing `NO_REPLY`/sentinel/leak guards, it is posted as-is.
- Does not touch the todo auto-continuation subsystem (a separate change, PR #834, addressed `length` classification there).

## Review notes

- **Load-bearing:** the `removedThink && stripped !== '' && !NO_REPLY && !sentinel` discriminator in `validateChannelTurn` (just before the `candidate === null` branch). If it collapses to `null`, the existing length-retry must still own the turn — verify the think-only path still logs `empty_turn_retry` and raises the budget.
- New test helper `setAssistantLengthLeaf` builds a text-blocks-only `length` leaf (no synthetic toolCall) to model the production shape; the existing `setAssistantMidTurn` injects a toolCall, which now correctly suppresses recovery.
- Three new regression tests: (1) leaked-think + real answer → posts the stripped answer, no retry; (2) think-only → retries with raised budget; (3) plain length text with no think evidence → stays on retry, not posted.