### PR TITLE
fix(memory): guide agent away from manual dig on empty memory_search

### DIFF
--- a/src/bundled-plugins/memory/search-tool.test.ts
+++ b/src/bundled-plugins/memory/search-tool.test.ts
@@ -72,6 +72,34 @@ describe('memorySearchTool', () => {
     await expect(call(agentDir, { query: 'absent' })).resolves.toEqual({ matches: [] })
   })
 
+  test('empty result carries a no-manual-dig note in the LLM text but not in details', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'daily-notes', 'Daily notes', 'A body about memory.\n')
+
+    const empty = await callRaw(agentDir, { query: 'absent' })
+    expect(empty.text).toContain('Do not fall back to grep')
+    expect(empty.details).toEqual({ matches: [] })
+    expect(JSON.parse(empty.text).note).toMatch(/Do not fall back/)
+  })
+
+  test('non-empty result text carries no dig note', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'daily-notes', 'Daily notes', 'A body about memory.\n')
+
+    const hit = await callRaw(agentDir, { query: 'memory' })
+    expect(hit.text).not.toContain('Do not fall back to grep')
+    expect(JSON.parse(hit.text).note).toBeUndefined()
+  })
+
+  test('empty topic lookup also carries the no-manual-dig note', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'present', 'Present', 'body\n')
+
+    const empty = await callRaw(agentDir, { topic: 'absent-slug' })
+    expect(empty.text).toContain('Do not fall back to grep')
+    expect(empty.details).toEqual({ matches: [] })
+  })
+
   test('topic lookup returns the one shard with its full body, no fuzzy search', async () => {
     const agentDir = await makeAgentDir()
     await writeShard(agentDir, 'kakaotalk-tone', 'KakaoTalk tone', 'Reply formally in this group.\nmore body.\n')
@@ -604,6 +632,14 @@ async function call(agentDir: string, input: unknown): Promise<SearchResult> {
   const args = memorySearchTool.parameters.parse(input)
   const result = await memorySearchTool.execute(args, ctx(agentDir))
   return result.details as SearchResult
+}
+
+async function callRaw(agentDir: string, input: unknown): Promise<{ text: string; details: unknown }> {
+  const args = memorySearchTool.parameters.parse(input)
+  const result = await memorySearchTool.execute(args, ctx(agentDir))
+  const part = result.content[0]
+  if (part === undefined || part.type !== 'text') throw new Error('expected a text content part')
+  return { text: part.text, details: result.details }
 }
 
 function ctx(agentDir: string): ToolContext {

--- a/src/bundled-plugins/memory/search-tool.ts
+++ b/src/bundled-plugins/memory/search-tool.ts
@@ -366,9 +366,17 @@ function excerptForLine(lines: string[], matchIndex: number): string {
   return lines.slice(start, end).join('\n')
 }
 
+const EMPTY_RESULT_GUIDANCE =
+  'No matching memory. This is the authoritative result — memory_search already covers both topic shards and undreamed stream events. Do not fall back to grep/find/bash or manually reading memory/topics, memory/streams, or sessions; accept that no relevant memory exists and proceed.'
+
+// The empty-set note rides in the LLM-facing `text` ONLY. `details` stays the
+// pure struct: `keywordLane` reads `searchAll` directly (never this layer) and
+// the structured tests assert on `details`, so both must see no `note`.
 function resultToToolResult(result: MemorySearchResult) {
+  const isEmpty = 'matches' in result && result.matches.length === 0
+  const text = isEmpty ? JSON.stringify({ ...result, note: EMPTY_RESULT_GUIDANCE }) : JSON.stringify(result)
   return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    content: [{ type: 'text' as const, text }],
     details: result,
   }
 }


### PR DESCRIPTION
## Background

When `memory_search` returns nothing, the agent does not stop — it falls back to manually grepping/reading `memory/topics/`, `memory/streams/`, and even `sessions/` by hand. This was found while profiling memory retrieval against a real agent (193 topic shards): the worst observed case fired **9 `memory_search` calls + ~24 `bash` greps + a read = 128.9s, 35 tool calls**, and still ended in "no relevant memory."

Across the session history, **27% of sessions hit this manual-dig path** (median 8.1s, p90 56.6s, max 132.2s). It is the single largest retrieval-related latency cost, and it is pure waste: the empty result already *was* the answer.

Root cause: nothing instructs this fallback. The `memory_search` tool description, every injection directive, and the memory skill only ever point at `memory_search`. The behavior is **emergent** — the LLM has `bash`/`grep`, knows `memory/topics/` exists (the system prompt lists it as readable), and there is **no stop-condition** telling it an empty result is authoritative.

## Summary

Attach an authoritative no-fallback note to the empty-`memory_search` result the LLM reads, stating that `memory_search` already covers both topic shards and undreamed stream events, so an empty set is the answer — do not grep/find/bash or hand-read the memory files.

**Why at the tool-serialization layer (`resultToToolResult`) and not a system-prompt line:** this is the single choke point every `memory_search` result flows through to the LLM. It covers query mode, topic mode, both empty paths, and fires regardless of `memory.vector.enabled` — so it is not vector-specific.

**Why `content.text` only, not `details`:** the note rides in the LLM-facing text; `details` stays the pure `{ matches: [] }` struct. This keeps `keywordLane` (which calls `searchAll` directly, never this layer) and the structured tests untouched — they read `details`.

## What this does NOT do

- Does not change retrieval ranking, the relevance gate, or the keyword/vector lanes.
- Does not touch `searchAll` / `buildMatcher` / the `MemorySearchResult` type — so `hybridSearch`'s keyword lane is byte-for-byte unaffected.
- Does not hard-block the dig at the tool boundary — it is a directive the model can still override; this is the lowest-risk, reversible first step, not an enforcement mechanism.

## Review notes

- Load-bearing invariant: the note must appear in `content.text` but **never** in `details`. A future "simplify" that folds it into `details` would break `keywordLane` and the six empty-result assertions (`toEqual({ matches: [] })`). The comment on `resultToToolResult` records this.
- New tests assert: empty query → note present + `details` pure; non-empty → no note; empty topic-lookup → note present.
- Validation gap: this is offline-grounded (session profiling + the tool's serialized output). It has not been A/B'd on the live agent end-to-end — a model could still ignore the directive. Worth confirming the dig actually stops in a follow-up live run.