### PR TITLE
feat(cli): offer to resume on start/restart when init is incomplete

### DIFF
--- a/src/cli/incomplete-init.test.ts
+++ b/src/cli/incomplete-init.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test'
+
+import { checkpointFromSelections, type WizardCheckpointStore } from '@/init/checkpoint'
+import type { InitProgressStatus } from '@/init/progress'
+
+import { guardIncompleteInit, resolveIncompleteInitDecision } from './incomplete-init'
+
+const incomplete: InitProgressStatus = {
+  kind: 'incomplete',
+  checkpoint: checkpointFromSelections({ cwd: '/agent', vendorId: 'fireworks' }),
+}
+const stale: InitProgressStatus = {
+  kind: 'complete-stale-checkpoint',
+  checkpoint: checkpointFromSelections({ cwd: '/agent', vendorId: 'fireworks' }),
+}
+const none: InitProgressStatus = { kind: 'none' }
+
+function fakeStore(initial?: ReturnType<typeof checkpointFromSelections>): {
+  store: WizardCheckpointStore
+  cleared: () => boolean
+} {
+  let current = initial
+  let cleared = false
+  return {
+    store: {
+      load: async () => current,
+      save: async (_cwd, checkpoint) => {
+        current = checkpoint
+      },
+      clear: async () => {
+        current = undefined
+        cleared = true
+      },
+    },
+    cleared: () => cleared,
+  }
+}
+
+describe('resolveIncompleteInitDecision', () => {
+  test('continue when no checkpoint', () => {
+    expect(resolveIncompleteInitDecision(none, true).kind).toBe('continue')
+    expect(resolveIncompleteInitDecision(none, false).kind).toBe('continue')
+  })
+
+  test('continue when checkpoint is stale on a hatched agent', () => {
+    expect(resolveIncompleteInitDecision(stale, true).kind).toBe('continue')
+    expect(resolveIncompleteInitDecision(stale, false).kind).toBe('continue')
+  })
+
+  test('prompt when incomplete and interactive', () => {
+    expect(resolveIncompleteInitDecision(incomplete, true).kind).toBe('prompt')
+  })
+
+  test('block when incomplete and non-interactive', () => {
+    const decision = resolveIncompleteInitDecision(incomplete, false)
+    expect(decision.kind).toBe('block')
+    if (decision.kind === 'block') {
+      expect(decision.message).toContain('typeclaw init')
+    }
+  })
+})
+
+describe('guardIncompleteInit', () => {
+  test('continues when there is no checkpoint', async () => {
+    const { store } = fakeStore()
+    const result = await guardIncompleteInit({
+      cwd: '/agent',
+      interactive: true,
+      confirmContinue: async () => true,
+      checkpointStore: store,
+    })
+    expect(result.action).toBe('continue')
+  })
+
+  test('blocks a non-interactive run with actionable guidance', async () => {
+    const { store } = fakeStore(checkpointFromSelections({ cwd: '/agent', vendorId: 'fireworks' }))
+    const result = await guardIncompleteInit({
+      cwd: '/agent',
+      interactive: false,
+      confirmContinue: async () => true,
+      checkpointStore: store,
+    })
+    expect(result.action).toBe('block')
+    if (result.action === 'block') expect(result.message).toContain('typeclaw init')
+  })
+
+  test('prompts interactively and continues when the user agrees', async () => {
+    const { store } = fakeStore(checkpointFromSelections({ cwd: '/agent', vendorId: 'fireworks' }))
+    let prompted = false
+    const result = await guardIncompleteInit({
+      cwd: '/agent',
+      interactive: true,
+      confirmContinue: async () => {
+        prompted = true
+        return true
+      },
+      checkpointStore: store,
+    })
+    expect(prompted).toBe(true)
+    expect(result.action).toBe('continue')
+  })
+
+  test('aborts interactively when the user declines', async () => {
+    const { store } = fakeStore(checkpointFromSelections({ cwd: '/agent', vendorId: 'fireworks' }))
+    const result = await guardIncompleteInit({
+      cwd: '/agent',
+      interactive: true,
+      confirmContinue: async () => false,
+      checkpointStore: store,
+    })
+    expect(result.action).toBe('abort')
+  })
+
+  test('opportunistically clears a stale checkpoint on a hatched agent and continues', async () => {
+    const fake = fakeStore(checkpointFromSelections({ cwd: '/agent', vendorId: 'fireworks' }))
+    const result = await guardIncompleteInit({
+      cwd: '/agent',
+      interactive: false,
+      confirmContinue: async () => false,
+      checkpointStore: fake.store,
+      detectProgress: async () => stale,
+    })
+    expect(result.action).toBe('continue')
+    expect(fake.cleared()).toBe(true)
+  })
+
+  test('does not clear the checkpoint on the incomplete path', async () => {
+    const fake = fakeStore(checkpointFromSelections({ cwd: '/agent', vendorId: 'fireworks' }))
+    await guardIncompleteInit({
+      cwd: '/agent',
+      interactive: true,
+      confirmContinue: async () => true,
+      checkpointStore: fake.store,
+      detectProgress: async () => incomplete,
+    })
+    expect(fake.cleared()).toBe(false)
+  })
+})

--- a/src/cli/incomplete-init.ts
+++ b/src/cli/incomplete-init.ts
@@ -1,0 +1,57 @@
+import { createLocalWizardCheckpointStore, type WizardCheckpointStore } from '@/init/checkpoint'
+import { detectInitProgress, type DetectInitProgressOptions, type InitProgressStatus } from '@/init/progress'
+
+export type IncompleteInitDecision = { kind: 'continue' } | { kind: 'block'; message: string } | { kind: 'prompt' }
+
+const BLOCK_MESSAGE =
+  'This agent looks half-initialized — a previous `typeclaw init` did not finish. ' +
+  'Run `typeclaw init` in this directory to resume setup, then try again.'
+
+// Pure policy: given the detected init progress and whether we have an
+// interactive TTY, decide what start/restart should do. Kept free of I/O so
+// the branch matrix is unit-testable without a real checkpoint or a TTY.
+//   - none / complete-stale-checkpoint -> continue (the agent is fine; a stale
+//     checkpoint is cleaned up by the caller, not a reason to block)
+//   - incomplete + interactive          -> prompt the user
+//   - incomplete + non-interactive      -> block with actionable guidance
+export function resolveIncompleteInitDecision(
+  status: InitProgressStatus,
+  interactive: boolean,
+): IncompleteInitDecision {
+  if (status.kind !== 'incomplete') return { kind: 'continue' }
+  return interactive ? { kind: 'prompt' } : { kind: 'block', message: BLOCK_MESSAGE }
+}
+
+export interface GuardIncompleteInitOptions {
+  cwd: string
+  interactive: boolean
+  // Returns true to proceed with start anyway, false to abort. Only called for
+  // the interactive `prompt` decision.
+  confirmContinue: () => Promise<boolean>
+  checkpointStore?: WizardCheckpointStore
+  detectProgress?: (options: DetectInitProgressOptions) => Promise<InitProgressStatus>
+}
+
+export type GuardIncompleteInitResult =
+  | { action: 'continue' }
+  | { action: 'block'; message: string }
+  | { action: 'abort' }
+
+export async function guardIncompleteInit(options: GuardIncompleteInitOptions): Promise<GuardIncompleteInitResult> {
+  const checkpointStore = options.checkpointStore ?? createLocalWizardCheckpointStore()
+  const detect = options.detectProgress ?? detectInitProgress
+  const status = await detect({ cwd: options.cwd, checkpointStore })
+
+  // A checkpoint that outlived a hatched agent is stale (clear failed after a
+  // successful init). Clean it up opportunistically so it never re-triggers.
+  if (status.kind === 'complete-stale-checkpoint') {
+    await checkpointStore.clear(options.cwd).catch(() => {})
+  }
+
+  const decision = resolveIncompleteInitDecision(status, options.interactive)
+  if (decision.kind === 'continue') return { action: 'continue' }
+  if (decision.kind === 'block') return { action: 'block', message: decision.message }
+
+  const proceed = await options.confirmContinue()
+  return proceed ? { action: 'continue' } : { action: 'abort' }
+}

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -29,14 +29,12 @@ export const restartCommand = defineCommand({
   async run({ args }) {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
 
-    if (!isInitialized(cwd)) {
-      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
-      process.exit(1)
-    }
-
-    // Check before stop: a half-initialized agent usually has no running
-    // container, so stopping first is noise. restart inherits the same
-    // incomplete-init UX as start.
+    // Runs before BOTH isInitialized and stop. A wizard abort persists a
+    // checkpoint before scaffold writes typeclaw.json, so a checkpoint-but-no-
+    // config dir is an incomplete init that should get resume guidance, not the
+    // generic config-missing error — and a half-init agent usually has no
+    // container to stop. A `continue` falls through to isInitialized, which
+    // still catches a truly uninitialized dir.
     const guard = await guardIncompleteInit({
       cwd,
       interactive: Boolean(process.stdout.isTTY),
@@ -51,6 +49,11 @@ export const restartCommand = defineCommand({
     }
     if (guard.action === 'abort') {
       process.exit(0)
+    }
+
+    if (!isInitialized(cwd)) {
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
+      process.exit(1)
     }
 
     const validated = validateConfig(cwd)

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -1,9 +1,11 @@
+import { confirm, isCancel } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { config, validateConfig } from '@/config'
 import { start, stop } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
+import { guardIncompleteInit } from './incomplete-init'
 import { c, errorLine, renderStartSuccess, spinner } from './ui'
 
 export const restartCommand = defineCommand({
@@ -30,6 +32,25 @@ export const restartCommand = defineCommand({
     if (!isInitialized(cwd)) {
       console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
       process.exit(1)
+    }
+
+    // Check before stop: a half-initialized agent usually has no running
+    // container, so stopping first is noise. restart inherits the same
+    // incomplete-init UX as start.
+    const guard = await guardIncompleteInit({
+      cwd,
+      interactive: Boolean(process.stdout.isTTY),
+      confirmContinue: async () => {
+        const proceed = await confirm({ message: 'Try restarting anyway?', initialValue: false })
+        return !isCancel(proceed) && proceed === true
+      },
+    })
+    if (guard.action === 'block') {
+      console.error(errorLine(guard.message))
+      process.exit(1)
+    }
+    if (guard.action === 'abort') {
+      process.exit(0)
     }
 
     const validated = validateConfig(cwd)

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,9 +1,11 @@
+import { confirm, isCancel } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { config, validateConfig } from '@/config'
 import { start } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
+import { guardIncompleteInit } from './incomplete-init'
 import { errorLine, renderStartSuccess, spinner } from './ui'
 
 export const startCommand = defineCommand({
@@ -30,6 +32,22 @@ export const startCommand = defineCommand({
     if (!isInitialized(cwd)) {
       console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
       process.exit(1)
+    }
+
+    const guard = await guardIncompleteInit({
+      cwd,
+      interactive: Boolean(process.stdout.isTTY),
+      confirmContinue: async () => {
+        const proceed = await confirm({ message: 'Try starting anyway?', initialValue: false })
+        return !isCancel(proceed) && proceed === true
+      },
+    })
+    if (guard.action === 'block') {
+      console.error(errorLine(guard.message))
+      process.exit(1)
+    }
+    if (guard.action === 'abort') {
+      process.exit(0)
     }
 
     const validated = validateConfig(cwd)

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -29,11 +29,12 @@ export const startCommand = defineCommand({
   async run({ args }) {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
 
-    if (!isInitialized(cwd)) {
-      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
-      process.exit(1)
-    }
-
+    // Runs BEFORE the isInitialized check: a wizard abort persists a checkpoint
+    // before scaffold writes typeclaw.json, so a checkpoint-but-no-config dir is
+    // an incomplete init, not a "never initialized" one. Guarding first means
+    // that case gets the resume guidance instead of the generic config-missing
+    // error. A `continue` (no incomplete checkpoint, or "try anyway") falls
+    // through to isInitialized, which still catches a truly uninitialized dir.
     const guard = await guardIncompleteInit({
       cwd,
       interactive: Boolean(process.stdout.isTTY),
@@ -48,6 +49,11 @@ export const startCommand = defineCommand({
     }
     if (guard.action === 'abort') {
       process.exit(0)
+    }
+
+    if (!isInitialized(cwd)) {
+      console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first.'))
+      process.exit(1)
     }
 
     const validated = validateConfig(cwd)


### PR DESCRIPTION
> **Stacked on #838** (`feat/init-resume-wizard-answers`). Review/merge that one first. This PR's diff is only its own 4 files.

## What

`typeclaw start` / `typeclaw restart` previously charged ahead on a half-initialized agent — one where `typeclaw init` was aborted (double-ESC) or failed after the wizard (install / dockerfile / git / hatching) — and then died deep inside the container preflight with a confusing low-level error (missing `node_modules`, missing `Dockerfile`, etc.).

Now both commands detect an incomplete init up front and offer to resume instead of failing cryptically.

## How

- Reuses **`detectInitProgress()`** from #838 — the shared "init incomplete" predicate (`a wizard checkpoint exists AND the agent never hatched`). No new detection logic; the two PRs key off the exact same signal so they can't drift.
- New `src/cli/incomplete-init.ts`:
  - `resolveIncompleteInitDecision(status, interactive)` — a **pure** policy function (continue / prompt / block), unit-tested across the full branch matrix.
  - `guardIncompleteInit(...)` — a thin orchestrator that detects progress, opportunistically clears a **stale** checkpoint (one that outlived a hatched agent, so a working agent is never falsely blocked), and returns continue / block / abort.
- **Interactive** (TTY): prompts `Try starting anyway?` (default **no**).
- **Non-interactive** (CI, hostd): fails fast with actionable guidance to run `typeclaw init`. TTY is detected via `process.stdout.isTTY`, matching the existing convention in `status.ts` / `usage.ts` / `doctor.ts`.
- `start.ts` / `restart.ts` stay thin shells; `restart` runs the check **before** `stop` (a half-init agent usually has no container to stop).

## What this does NOT do

- Does not auto-run `typeclaw init` from `start` (no CLI→CLI coupling); it guides the user to run it.
- Does not broaden "incomplete" to missing `node_modules` / `Dockerfile` on a *hatched* agent — those are start's job to regenerate. Only `checkpoint-exists AND not-hatched` counts.

## Testing

- `incomplete-init.test.ts`: 10 tests — the pure decision matrix (none / stale / incomplete × interactive / non-interactive) and the orchestrator (continue, block-non-interactive, prompt-continue, prompt-abort, stale-clear, no-clear-on-incomplete).
- `start.ts` / `restart.ts` are intentionally untested directly (thin CLI shells over the tested `guardIncompleteInit` + the already-tested domain `start()`), per the repo testing philosophy.
- Full suite: **8873 pass, 0 fail**. typecheck / lint (0 errors) / format:check clean.