### PR TITLE
fix(memory): strip citation lines from topic embedding text

### DIFF
--- a/src/bundled-plugins/memory/citations.test.ts
+++ b/src/bundled-plugins/memory/citations.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeCitation,
   parseCitations,
   splitCitationsBySection,
+  stripCitationLines,
 } from './citations'
 
 const ID_A = '019e2eca-6fc5-71ef-add9-67a0955a4b35'
@@ -191,5 +192,39 @@ describe('splitCitationsBySection', () => {
 
     expect(all.get('2026-05-21')).toEqual(new Set([ID_B]))
     expect(all.get('2026-05-20')).toEqual(new Set([ID_A]))
+  })
+})
+
+describe('stripCitationLines', () => {
+  test('removes citation lines and the fragments:/superseded: headings, keeping the belief', () => {
+    const body = [
+      'The user consistently uses pnpm.',
+      'fragments:',
+      `- streams/2026-05-21#${ID_A}`,
+      `- streams/2026-05-22#${ID_B}`,
+      'superseded:',
+      `- streams/2026-05-20#${ID_C}`,
+    ].join('\n')
+
+    expect(stripCitationLines(body)).toBe('The user consistently uses pnpm.')
+  })
+
+  test('preserves multi-paragraph prose while collapsing the blank run left by stripping', () => {
+    const body = [
+      'A proposal rationale.',
+      '',
+      'A second paragraph.',
+      '',
+      'fragments:',
+      `- streams/2026-05-21#${ID_A}`,
+    ].join('\n')
+
+    expect(stripCitationLines(body)).toBe('A proposal rationale.\n\nA second paragraph.')
+  })
+
+  test('returns an empty string for a citation-only body', () => {
+    const body = ['fragments:', `- streams/2026-05-21#${ID_A}`].join('\n')
+
+    expect(stripCitationLines(body)).toBe('')
   })
 })

--- a/src/bundled-plugins/memory/citations.ts
+++ b/src/bundled-plugins/memory/citations.ts
@@ -55,6 +55,29 @@ export function isCitationLine(line: string): boolean {
   return CITATION_LINE.test(line)
 }
 
+// Drops `fragments:`/`superseded:` headings and citation lines, leaving only the
+// belief prose. The embedding input must exclude them: mean-pooling a body of one
+// belief sentence + dozens of `streams/<date>#<uuidv7>` lines dilutes the belief
+// and pulls every topic vector toward the shared citation-list structure. The
+// citations stay in the on-disk body (the load-bearing parent-child links); only
+// the text handed to the embedder is stripped.
+export function stripCitationLines(body: string): string {
+  const kept = body.split('\n').filter((line) => !isCitationLine(line) && !SECTION_HEADING.test(line))
+  return collapseBlankRuns(kept).join('\n').trim()
+}
+
+function collapseBlankRuns(lines: string[]): string[] {
+  const out: string[] = []
+  let prevBlank = false
+  for (const line of lines) {
+    const blank = line.trim() === ''
+    if (blank && prevBlank) continue
+    out.push(line)
+    prevBlank = blank
+  }
+  return out
+}
+
 // Superseded citations stay cited (so the citation-superset GC invariant never
 // drops them) but must be excluded from retrieval, so a superseded "uses bun"
 // fragment can't surface as a hook for the current "uses pnpm" belief.

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -628,17 +628,10 @@ describe('dreaming subagent (compaction wiring)', () => {
           .map((row) => row.id)
           .sort(),
       ).toEqual(['topic:new', 'topic:old'])
-      expect(embeddedTexts).toContain(
-        [
-          'Old updated',
-          'Old updated.',
-          '',
-          'fragments:',
-          '- streams/2026-04-27#f-old',
-          '- streams/2026-04-27#f-gone',
-        ].join('\n'),
-      )
-      expect(embeddedTexts).toContain(['New', 'New.', '', 'fragments:', '- streams/2026-04-27#f-new'].join('\n'))
+      // The citation lines and `fragments:` heading are stripped before embedding;
+      // only the heading + belief prose reaches the embedder.
+      expect(embeddedTexts).toContain('Old updated\nOld updated.')
+      expect(embeddedTexts).toContain('New\nNew.')
     } finally {
       afterStore.close()
     }

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -20,7 +20,6 @@ import {
   loadDreamingState,
   saveDreamingState,
 } from './dreaming-state'
-import { fragmentContentHash } from './fragment-parser'
 import { parseShard, renderShard, type ShardFrontmatter } from './frontmatter'
 import { listShardSlugs, loadAllShards, loadShard } from './load-shards'
 import { streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
@@ -29,6 +28,7 @@ import type { StreamEvent } from './stream-events'
 import { readEvents, writeEventsAtomic } from './stream-io'
 import { embed, EMBEDDING_MODEL_ID } from './vector/embedder'
 import type { EmbedFn } from './vector/hybrid'
+import { topicPassage } from './vector/passages'
 import { VectorStore } from './vector/store'
 
 const STREAM_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.jsonl$/
@@ -261,17 +261,17 @@ export async function syncTopicVectorsFromSnapshotDiff(
       const slug = slugFromSnapshotPath(path)
       const shard = await loadShard(agentDir, slug)
       if (shard === null) continue
-      const text = `${shard.frontmatter.heading}\n${shard.body}`
-      const [embedding] = await embedFn([text], 'passage')
+      const passage = topicPassage(slug, shard.frontmatter.heading, shard.body)
+      const [embedding] = await embedFn([passage.text], 'passage')
       if (embedding === undefined) continue
       store.upsert({
-        id: `topic:${slug}`,
-        source: 'topic',
-        key: slug,
+        id: passage.id,
+        source: passage.source,
+        key: passage.key,
         model: EMBEDDING_MODEL_ID,
         dims: embedding.length,
         embedding,
-        contentHash: fragmentContentHash({ topic: shard.frontmatter.heading, body: shard.body }),
+        contentHash: passage.contentHash,
       })
     }
 

--- a/src/bundled-plugins/memory/vector/doctor.test.ts
+++ b/src/bundled-plugins/memory/vector/doctor.test.ts
@@ -5,11 +5,11 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { fragmentContentHash } from '../fragment-parser'
 import { renderShard } from '../frontmatter'
 import { runVectorIndexDoctor } from './doctor'
 import { DIMS, EMBEDDING_MODEL_ID } from './embedder'
 import { inspectVectorIndex } from './inspect'
+import { topicPassage } from './passages'
 import { VectorStore } from './store'
 
 const testDirs: string[] = []
@@ -211,7 +211,7 @@ function seedTopicVector(
     model,
     dims: DIMS,
     embedding: new Float32Array(DIMS),
-    contentHash: fragmentContentHash({ topic: heading, body }),
+    contentHash: topicPassage(slug, heading, body).contentHash,
   })
   store.close()
 }

--- a/src/bundled-plugins/memory/vector/passages.ts
+++ b/src/bundled-plugins/memory/vector/passages.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 
+import { stripCitationLines } from '../citations'
 import { fragmentContentHash } from '../fragment-parser'
 import { loadAllShards, type TopicShard } from '../load-shards'
 import { buildParentLinks } from '../parent-link'
@@ -13,6 +14,16 @@ export type Passage = {
   key: string
   text: string
   contentHash: string
+}
+
+// The single source of truth for a topic's embedded text + freshness hash, so the
+// startup index build and dreaming's per-pass refresh stay byte-identical. The
+// contentHash covers the EMBEDDED text (not the raw body): changing how the text
+// is derived must invalidate every existing topic row, but `fragmentContentHash`
+// over the unchanged raw body would not — `findMissingPassages` would skip them.
+export function topicPassage(slug: string, heading: string, body: string): Passage {
+  const text = `${heading}\n${stripCitationLines(body)}`
+  return { id: `topic:${slug}`, source: 'topic', key: slug, text, contentHash: hashContent(text) }
 }
 
 export async function collectPassages(agentDir: string): Promise<Passage[]> {
@@ -31,15 +42,7 @@ export function findMissingPassages(store: VectorStore, passages: Passage[]): Pa
 function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): Passage[] {
   const { supersededFragmentIds } = buildParentLinks(shards)
   return [
-    ...shards.map(
-      (shard): Passage => ({
-        id: `topic:${shard.slug}`,
-        source: 'topic',
-        key: shard.slug,
-        text: `${shard.frontmatter.heading}\n${shard.body}`,
-        contentHash: fragmentContentHash({ topic: shard.frontmatter.heading, body: shard.body }),
-      }),
-    ),
+    ...shards.map((shard): Passage => topicPassage(shard.slug, shard.frontmatter.heading, shard.body)),
     ...streamDays.flatMap((day) =>
       day.events.flatMap((event): Passage[] => {
         if (event.type === 'watermark') return []

--- a/src/bundled-plugins/memory/vector/startup.test.ts
+++ b/src/bundled-plugins/memory/vector/startup.test.ts
@@ -4,10 +4,10 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { fragmentContentHash } from '../fragment-parser'
 import { renderShard } from '../frontmatter'
 import { EMBEDDING_MODEL_ID } from './embedder'
 import type { EmbedFn } from './hybrid'
+import { topicPassage } from './passages'
 import { buildStartupVectorIndex } from './startup'
 import { VectorStore } from './store'
 
@@ -102,7 +102,7 @@ describe('buildStartupVectorIndex', () => {
       model: 'Xenova/multilingual-e5-base@fp32',
       dims: 8,
       embedding: vector({ 0: 1 }),
-      contentHash: fragmentContentHash({ topic: 'Carried Over', body: 'Content unchanged across a dtype switch.' }),
+      contentHash: topicPassage('carried-over', 'Carried Over', 'Content unchanged across a dtype switch.').contentHash,
     })
     seed.close()
     const embeddedTexts: string[] = []
@@ -125,6 +125,31 @@ describe('buildStartupVectorIndex', () => {
     } finally {
       store.close()
     }
+  })
+
+  it('embeds only the belief prose, stripping citation lines from the topic text', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(
+      agentDir,
+      'package-manager',
+      'Package Manager',
+      [
+        'The user consistently uses pnpm.',
+        'fragments:',
+        '- streams/2026-06-11#019e2eca-6fc5-71ef-add9-67a0955a4b35',
+        '- streams/2026-06-12#019e2ecf-f2d5-70ee-83f6-005fb5451c51',
+        'superseded:',
+        '- streams/2026-06-10#019e2ec0-1111-7000-8000-000000000000',
+      ].join('\n'),
+    )
+    const embeddedTexts: string[] = []
+
+    await buildStartupVectorIndex(agentDir, async (texts) => {
+      embeddedTexts.push(...texts)
+      return texts.map(() => vector({ 1: 1 }))
+    })
+
+    expect(embeddedTexts).toEqual(['Package Manager\nThe user consistently uses pnpm.'])
   })
 
   it('prunes superseded stream rows so they cannot crowd active candidates', async () => {


### PR DESCRIPTION
## Background

A topic shard body is one belief sentence followed by the `fragments:` / `superseded:` citation lists (one `streams/<date>#<uuidv7>` line per cited fragment). `passages.ts` embedded `heading\n${body}`, so with mean pooling a topic with 20 citations embedded ~2 lines of meaning against ~20 lines of dates and UUIDs. Three consequences:

1. Belief semantics were diluted so genuine matches scored lower.
2. Every topic shared the same citation-list structure, pulling all topic vectors toward each other and compressing the cosine band the relevance gate depends on for contrast.
3. Dilution grew with citation count, so the most-reinforced topics retrieved worst — the inverse of the strength model's intent.

Stream-fragment passages never had this problem (their body is real prose).

## Summary

Embed only `heading + belief prose` by stripping the `fragments:` / `superseded:` section headings and citation lines via a new `stripCitationLines` helper. Citations stay in the on-disk body where they remain the load-bearing parent-child links that `parent-link.ts` parses for hybrid-search collapse — only the embedder input is stripped, so retrieval topology is unchanged.

**Why hash the embedded text, not bump `EMBEDDING_MODEL_ID`:** `findMissingPassages` re-embeds when stored `contentHash` differs from the current passage. The old hash was `fragmentContentHash(topic, body)` over the unchanged raw body — stripping the embedded text alone would leave the hash identical and nothing would re-embed. The new `topicPassage` helper hashes the actual embedded text, invalidating every topic row so it re-embeds on the next index build. A model-id bump would needlessly invalidate the entire index including stream vectors and falsely signal a model change; hashing re-embeds only topics.

**Why route both embed paths through `topicPassage`:** startup `collectPassages` and dreaming's `syncTopicVectorsFromSnapshotDiff` must produce byte-identical vectors for the same topic. Without the dreaming path, the next dreaming pass would re-upsert diluted vectors right after startup fixed them.

## What this does NOT do

- Does not change stream-fragment passages (text or hash); `index-on-write` and its tests are untouched.
- Does not change the on-disk shard body, citation format, or `parseCitations` / `splitCitationsBySection` — GC and parent-child collapse still see the full citation lists.
- Does not bump `EMBEDDING_MODEL_ID`.

## Review notes

- **Load-bearing invariant:** `topicPassage` is the single source of truth for a topic's embedded text and freshness hash. Both the startup and dreaming call sites must route through it — verify no path produces a topic passage inline, bypassing the helper.
- **Hash migration:** `contentHash` now hashes the embedded (stripped) text, not the raw body. Startup/doctor test fixtures that seeded topic rows via `fragmentContentHash` were updated to `topicPassage(...).contentHash` so the doctor backfill check still treats them as up-to-date.
- **New regression coverage:** `stripCitationLines` unit tests (including multi-paragraph and citation-only bodies), a startup test asserting embedded topic text excludes citation lines, and updated dreaming assertions expecting stripped embed text.