### PR TITLE
address review: fix small-corpus baseline noise in the vector relevance gate

### DIFF
--- a/src/bundled-plugins/memory/vector/relevance-gate.test.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.test.ts
@@ -59,12 +59,24 @@ describe('gateRelevance', () => {
     expect(kept).toBeGreaterThan(0)
   })
 
+  it('passes ungated when the non-head tail is too short to trust (n=6..9)', () => {
+    // given: 9 shards in a flat band — once the top 5 are dropped, only 4 scores
+    // remain. A zero-suppression verdict off a 1-4 score median is too noisy, so
+    // a flat band that WOULD suppress at n>=10 must instead pass ungated here.
+    for (const n of [6, 7, 8, 9]) {
+      const scores = [0.792, ...Array.from({ length: n - 1 }, () => 0.78)]
+
+      expect(gateRelevance(scores, 10)).toBeGreaterThan(0)
+    }
+  })
+
   it('returns zero for an empty score list', () => {
     expect(gateRelevance([], 10)).toBe(0)
   })
 
-  it('uses a median baseline for a mid-size corpus (6 <= n < 20) and still suppresses a flat band', () => {
-    // given: 10 shards all in a flat ~0.78 band (no real match)
+  it('suppresses a flat band once the non-head tail is long enough (n>=10)', () => {
+    // given: 10 shards all in a flat ~0.78 band (no real match) — exactly at the
+    // gated floor, so the gate now runs and the flat band suppresses to zero.
     const scores = [0.792, ...Array.from({ length: 9 }, () => 0.78)]
 
     const kept = gateRelevance(scores, 10)
@@ -100,6 +112,25 @@ describe('streamAdmissionBaseline + clearsBaseline', () => {
     expect(clearsBaseline(1.0, baseline)).toBe(true)
     // an in-band stream neighbor does not
     expect(clearsBaseline(0.5, baseline)).toBe(false)
+  })
+
+  it('returns null for a single topic (one score is not an ambient band)', () => {
+    expect(streamAdmissionBaseline([0.9])).toBeNull()
+    expect(clearsBaseline(0.99, streamAdmissionBaseline([0.9]))).toBe(false)
+  })
+
+  it('excludes a strong top topic from the small-corpus band so fresh streams can still inject (n=2..5)', () => {
+    // given: a strong top topic over an ambient band. The old rule kept the head
+    // in the pack on n<=5, so a fresh fragment had to beat the BEST topic by the
+    // margin and never injected. Trimming top1 contrasts against the band, so a
+    // fragment clearing the AMBIENT topics by the margin is admitted.
+    const topicScores = [0.9, 0.78, 0.77, 0.76]
+    const baseline = streamAdmissionBaseline(topicScores)
+
+    // a fragment well clear of the ambient ~0.77 band injects despite the 0.9 top
+    expect(clearsBaseline(0.84, baseline)).toBe(true)
+    // an in-band fragment still does not
+    expect(clearsBaseline(0.78, baseline)).toBe(false)
   })
 
   it('admits a stream row only when it clears the topic band by the margin', () => {

--- a/src/bundled-plugins/memory/vector/relevance-gate.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.ts
@@ -12,28 +12,50 @@
 //
 // The baseline is the MEDIAN of the non-head scores (robust to a near-duplicate
 // cluster inflating a raw mean), which keeps a genuine winner above a crowd of
-// similar topics. Below SMALL_CORPUS_FLOOR there are too few scores to estimate
-// a baseline, so suppression is skipped — a false negative (injecting one
-// obvious shard) is cheaper than wrongly suppressing the only relevant memory.
+// similar topics. Suppression only fires once the non-head pack is large enough
+// to estimate the band: the top HEAD_EXCLUDED_FROM_BASELINE scores are dropped,
+// and at least MIN_BASELINE_PACK must remain. Below that, suppression is skipped
+// — a false negative (injecting one obvious shard) is cheaper than wrongly
+// suppressing the only relevant memory off a noisy 1-4 score tail.
+//
+// The contrast is top1 - median(non-head). A UNIFORM upward shift of the whole
+// band (the "single-domain memory, everything is somewhat related" case) cancels
+// out of that difference and leaves the verdict unchanged, so a concentrated
+// corpus does NOT structurally compress the gap. Only a genuine reduction in
+// rank SPREAD would, and a spread-normalized gate (gap >= k*MAD, or a z-score)
+// is rejected on purpose: a no-match query can also produce a tight non-head
+// pack plus one order-statistic outlier, which is exactly the case the absolute
+// MARGIN suppresses. We keep the absolute margin as the vector-only no-match
+// guard; recovery for a genuinely-suppressed single-domain match belongs in the
+// corroborating keyword lane, not in a weaker semantic threshold.
 const MARGIN = 0.06
-const SMALL_CORPUS_FLOOR = 6
 const HEAD_EXCLUDED_FROM_BASELINE = 5
+// Minimum non-head scores required to trust a suppression verdict. A median over
+// 1-4 scores (n=6..9 once the head is dropped) is too noisy to zero out the only
+// memory on, so the gated path needs HEAD_EXCLUDED_FROM_BASELINE + this many.
+const MIN_BASELINE_PACK = 5
+const GATED_TOPIC_FLOOR = HEAD_EXCLUDED_FROM_BASELINE + MIN_BASELINE_PACK
 
 // The contrast reference for ADMITTING stream rows: the median of the available
-// topic scores (head excluded once there are enough to trim). Topics define the
-// ambient cosine band; sparse streams consume it but never define it, so a
-// nearest-neighbour cluster of fragments can't move the bar. Returns null only
-// when NO topic scores exist — with nothing to contrast against, an
-// uncorroborated semantic-only stream must not inject (it can still reach RRF
-// via the keyword lane). Unlike topic suppression, this tolerates a below-floor
-// topic set: even a few topics give a usable "is this stream clearly elevated?"
-// signal, which is exactly the contrast a vector-only fragment match needs.
+// topic scores with the head trimmed. Topics define the ambient cosine band;
+// sparse streams consume it but never define it, so a nearest-neighbour cluster
+// of fragments can't move the bar. Returns null when fewer than two topic scores
+// exist — one score is not an ambient band, so an uncorroborated semantic-only
+// stream must not inject off it (it can still reach RRF via the keyword lane).
+//
+// The head trim is ADAPTIVE because streams never pass ungated: a strong top
+// topic must NOT raise the stream bar, or a genuinely-fresh fragment would have
+// to beat your best existing topic by the full margin and so never inject on a
+// small corpus. So we always drop at least top1, scaling the exclusion up to
+// HEAD_EXCLUDED_FROM_BASELINE only while a MIN_BASELINE_PACK-size tail survives.
+//   n=2..5  → drop top1, contrast against the remaining ambient topics
+//   n=6..9  → drop enough head to keep a MIN_BASELINE_PACK tail
+//   n>=10   → drop the full top HEAD_EXCLUDED_FROM_BASELINE
 // `topicScores` MUST be sorted descending.
 export function streamAdmissionBaseline(topicScores: number[]): number | null {
-  if (topicScores.length === 0) return null
-  const pack =
-    topicScores.length > HEAD_EXCLUDED_FROM_BASELINE ? topicScores.slice(HEAD_EXCLUDED_FROM_BASELINE) : topicScores
-  return median(pack)
+  if (topicScores.length <= 1) return null
+  const excluded = Math.min(HEAD_EXCLUDED_FROM_BASELINE, Math.max(1, topicScores.length - MIN_BASELINE_PACK))
+  return median(topicScores.slice(excluded))
 }
 
 // Whether a single cosine score clears the band by the shared margin. Used to
@@ -46,13 +68,13 @@ export function clearsBaseline(score: number, baseline: number | null): boolean 
 
 // Returns how many of the sorted-descending topic cosine scores survive the
 // gate. Zero means "no relevant memory matched" — a valid, expected outcome the
-// caller injects as an empty memory block. Below SMALL_CORPUS_FLOOR there are
-// too few topics for a reliable suppression verdict, so topics pass ungated (a
-// false negative of one obvious shard is cheaper than suppressing the only
-// memory). `scores` MUST be sorted descending.
+// caller injects as an empty memory block. Below GATED_TOPIC_FLOOR the non-head
+// tail is too short (1-4 scores) for a reliable suppression verdict, so topics
+// pass ungated (a false negative of one obvious shard is cheaper than
+// suppressing the only memory). `scores` MUST be sorted descending.
 export function gateRelevance(scores: number[], topK: number): number {
   if (scores.length === 0 || topK <= 0) return 0
-  if (scores.length < SMALL_CORPUS_FLOOR) return Math.min(scores.length, topK)
+  if (scores.length < GATED_TOPIC_FLOOR) return Math.min(scores.length, topK)
 
   const top = scores[0]!
   const margin = top - median(scores.slice(HEAD_EXCLUDED_FROM_BASELINE))


### PR DESCRIPTION
## Background

Review of the per-query relevance gate (`src/bundled-plugins/memory/vector/relevance-gate.ts`, shipped in #833) flagged three concerns about how the gate behaves on small / concentrated memory. Two are real small-corpus bugs; the third rests on a mechanism that does not hold for this statistic.

The gate's discriminating signal is query-local contrast: `top1 - median(non-head scores)`, with `MARGIN = 0.06` measured on a live 193-topic index (no-match ≤ 0.051, has-match ≥ 0.074). Two boundary cases made that verdict unreliable on a small corpus:

1. **Topic gate, n=6..9.** With `HEAD_EXCLUDED_FROM_BASELINE = 5`, the median baseline at n=6..9 is computed over just **1–4 scores**. A hard zero-suppression verdict (which injects an *empty* memory block) off so few samples is statistically too noisy — a flat band that legitimately suppresses at n≥10 was zeroing out the only memory on a near-coin-flip baseline.

2. **Stream gate, n≤5.** `streamAdmissionBaseline` kept the head in the pack when `length ≤ 5`. A strongly-matching top topic then raised the stream bar, so a genuinely-fresh fragment had to beat your *best existing topic* by the full margin — meaning vector-only stream fragments effectively **never injected** on a small corpus.

## Summary

- **Topic gate:** raise the gated floor to `HEAD_EXCLUDED_FROM_BASELINE + MIN_BASELINE_PACK` (= 10). Below it, topics pass **ungated** — the same "too little corpus to estimate a band, a false negative is cheaper than suppressing the only memory" stance the old `n < 6` floor took, now extended to cover the noisy 1–4 score tail. Chose a higher floor over *adaptive head exclusion* because shrinking the excluded head on n=6..9 reintroduces exactly the near-duplicate-cluster inflation the fixed head-exclusion exists to avoid.

- **Stream gate:** make the head trim **adaptive** — always drop at least `top1`, scaling up to the full top 5 only while a `MIN_BASELINE_PACK`-size tail survives. Returns `null` at n≤1 (one score is not an ambient band). Adaptive trim is safe here precisely because streams never pass ungated, so there is no "inject the only shard" fallback to protect.

**On the third concern (single-domain corpus collapses the gate to zero): declined as stated.** The proposed mechanism — "the median is high because everything is related, so the gap shrinks" — does not hold: `top1 - median(non-head)` is **invariant to a uniform upward shift** of the whole band, so "everything is somewhat related" cancels out of the difference and leaves the verdict unchanged. Only a genuine reduction in rank *spread* would compress the gap, and the suggested spread-normalized gate (`gap ≥ k·MAD`, or a z-score) is the wrong fix: a no-match query can also produce a tight non-head pack plus one order-statistic outlier — the exact case the absolute `MARGIN` is there to suppress. Weakening it would re-open no-match leakage. If a real single-domain match with `gap < 0.06` is ever observed, the right recovery path is the corroborating **keyword lane**, not a weaker semantic threshold. The rationale is recorded in the gate's header comment so a future reader doesn't "fix" it back.

## What this does NOT do

- Does not change `MARGIN` (0.06), the knee logic, or the has-match/no-match suppression on the 193-topic battery — all existing fixtures still pass.
- Does not add a spread-adaptive / z-score gate (intentionally rejected above).
- Does not touch the keyword lane or RRF fusion.

## Review notes

- Load-bearing constant: `GATED_TOPIC_FLOOR = HEAD_EXCLUDED_FROM_BASELINE + MIN_BASELINE_PACK = 10`. Invariant to verify: a flat no-match band suppresses to zero at **n≥10** but passes ungated at **n=6..9**. The mid-size suppression test now sits exactly at the floor (n=10).
- `streamAdmissionBaseline` trim ranges: n≤1 → null; n=2..5 → drop top1; n=6..9 → drop enough head to keep a 5-score tail; n≥10 → drop top 5.
- New tests cover all four boundaries; the existing 193-topic no-match / has-match fixtures are unchanged and still green.