### PR TITLE
perf(memory): parallelize per-shard reads in loadAllShards

### DIFF
--- a/src/bundled-plugins/memory/load-shards.test.ts
+++ b/src/bundled-plugins/memory/load-shards.test.ts
@@ -57,6 +57,37 @@ describe('loadAllShards', () => {
     expect(warnings).toHaveLength(1)
     expect(warnings[0]).toContain('broken')
   })
+
+  test('many shards stay slug-sorted and body-aligned regardless of parallel read completion order', async () => {
+    const agentDir = await makeAgentDir()
+    // Shuffled write order: proves the result order comes from the sorted slug
+    // listing, not from the order reads happen to settle in under concurrency.
+    const slugs = ['k', 'a', 'z', 'm', 'c', 't', 'b', 'q', 'e', 'r', 'd', 'n', 'g', 'p', 's']
+    for (const slug of slugs) await writeShard(agentDir, slug, slug.toUpperCase(), `${slug}-body\n`)
+
+    const shards = await loadAllShards(agentDir)
+
+    const sorted = [...slugs].sort()
+    expect(shards.map((shard) => shard.slug)).toEqual(sorted)
+    expect(shards.map((shard) => shard.body)).toEqual(sorted.map((slug) => `${slug}-body\n`))
+  })
+
+  test('a malformed shard anywhere in the set never shifts the ordering of valid shards', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'apple', 'Apple', 'apple\n')
+    // Malformed entry sorts into the MIDDLE of the slug listing; the parallel
+    // fan-out must drop it without displacing the neighbours that read fine.
+    await writeFile(topicShardPath(agentDir, 'mango'), '---\nheading: Mango\n', 'utf8')
+    await writeShard(agentDir, 'pear', 'Pear', 'pear\n')
+    await writeShard(agentDir, 'zebra', 'Zebra', 'zebra\n')
+    const warnings: string[] = []
+
+    const shards = await loadAllShards(agentDir, { logger: { warn: (m) => warnings.push(m) } })
+
+    expect(shards.map((shard) => shard.slug)).toEqual(['apple', 'pear', 'zebra'])
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('mango')
+  })
 })
 
 describe('loadShard', () => {

--- a/src/bundled-plugins/memory/load-shards.ts
+++ b/src/bundled-plugins/memory/load-shards.ts
@@ -38,32 +38,23 @@ const shardCache = new Map<string, Map<string, ShardCacheEntry>>()
 export async function loadAllShards(agentDir: string, options: { logger?: Logger } = {}): Promise<TopicShard[]> {
   const slugs = await listShardSlugs(agentDir)
   const cache = getOrCreateCache(agentDir)
+
+  // Per-shard stat+read fans out concurrently. resolveShard only READS the
+  // cache and returns the write it wants, so applying writes after all tasks
+  // settle keeps the parallel phase race-free. slugs is pre-sorted and
+  // Promise.all preserves input order, so the result stays slug-sorted.
+  const outcomes = await Promise.all(slugs.map((slug) => resolveShard(agentDir, slug, cache, options)))
+
   const shards: TopicShard[] = []
   const seen = new Set<string>()
-
-  for (const slug of slugs) {
-    seen.add(slug)
-    const path = topicShardPath(agentDir, slug)
-    const fileStat = await statShard(path)
-    if (fileStat === null) {
-      cache.delete(slug)
+  for (const outcome of outcomes) {
+    seen.add(outcome.slug)
+    if (outcome.kind === 'missing') {
+      cache.delete(outcome.slug)
       continue
     }
-
-    const cached = cache.get(slug)
-    if (
-      cached !== undefined &&
-      cached.mtimeMs === fileStat.mtimeMs &&
-      cached.ctimeMs === fileStat.ctimeMs &&
-      cached.size === fileStat.size
-    ) {
-      if (cached.shard !== null) shards.push(cached.shard)
-      continue
-    }
-
-    const shard = await readAndParseShard(path, slug, options)
-    cache.set(slug, { mtimeMs: fileStat.mtimeMs, ctimeMs: fileStat.ctimeMs, size: fileStat.size, shard })
-    if (shard !== null) shards.push(shard)
+    if (outcome.kind === 'read') cache.set(outcome.slug, outcome.entry)
+    if (outcome.shard !== null) shards.push(outcome.shard)
   }
 
   // Drop cache entries whose underlying files have disappeared so a later
@@ -73,6 +64,41 @@ export async function loadAllShards(agentDir: string, options: { logger?: Logger
   }
 
   return shards
+}
+
+type ShardOutcome =
+  | { kind: 'missing'; slug: string }
+  | { kind: 'cached'; slug: string; shard: TopicShard | null }
+  | { kind: 'read'; slug: string; shard: TopicShard | null; entry: ShardCacheEntry }
+
+async function resolveShard(
+  agentDir: string,
+  slug: string,
+  cache: Map<string, ShardCacheEntry>,
+  options: { logger?: Logger },
+): Promise<ShardOutcome> {
+  const path = topicShardPath(agentDir, slug)
+  const fileStat = await statShard(path)
+  if (fileStat === null) return { kind: 'missing', slug }
+
+  const cached = cache.get(slug)
+  if (
+    cached !== undefined &&
+    cached.mtimeMs === fileStat.mtimeMs &&
+    cached.ctimeMs === fileStat.ctimeMs &&
+    cached.size === fileStat.size
+  ) {
+    return { kind: 'cached', slug, shard: cached.shard }
+  }
+
+  const shard = await readAndParseShard(path, slug, options)
+  const entry: ShardCacheEntry = {
+    mtimeMs: fileStat.mtimeMs,
+    ctimeMs: fileStat.ctimeMs,
+    size: fileStat.size,
+    shard,
+  }
+  return { kind: 'read', slug, shard, entry }
 }
 
 export async function loadShard(


### PR DESCRIPTION
## Background

`loadAllShards` is on the hot path of every memory search — `hybridSearch`, the `memory_search` tool, and vector passage collection all call it to load `memory/topics/*.md`. It walked the sorted slug listing in a sequential `for`-loop, `await`ing `stat()` then `readFile()` one shard at a time. On a **cold cache** — the first turn after a container restart or after a dreaming pass rewrites shards (every `*/30 * * * *` by default) — a search paid the *sum* of all per-shard I/O latencies in series rather than overlapping them.

This was the one remaining genuine sequential bottleneck on the search read-path. The surrounding data-loading was already parallel: `hybridSearch` fans `loadAllShards` + `readAllUndreamedStreamDays` + `embed` out via `Promise.all`, and `stream-io.ts` reads each day concurrently. Shard loading was the odd one out.

## Summary

Fan the per-shard `stat`+`readFile` out concurrently with `Promise.all` over the slug listing.

The non-obvious part is **how the cache stays correct under concurrency**. The old loop both read and wrote the module-level shard cache inside the same iteration. Naively parallelizing that would interleave reads and writes across tasks. Instead the work is split:

- `resolveShard` (the per-slug task) only **reads** the cache for its hit-check and returns a tagged outcome (`missing` / `cached` / `read`) describing the mutation it wants.
- `loadAllShards` applies all `cache.set` / `cache.delete` **after** every task settles, in input order — so the parallel phase never mutates shared state.

Order is preserved for free: `slugs` is already sorted and `Promise.all` resolves in input order, so the rendered list stays slug-sorted with no re-sort.

**Why not a worker pool / batching?** This is I/O-bound, not CPU-bound — the event loop already overlaps the awaits; `Promise.all` is the whole fix. The synchronous lanes downstream (vector/keyword) were deliberately left alone: wrapping sync CPU work in `Promise.all` buys nothing in a single thread.

## What this does NOT do

- Does **not** touch `hybridSearch`'s lane logic, the `memory_search` tool, or any embedding/vector code.
- Does **not** change the cache invalidation contract (mtime/ctime/size key), the malformed-shard skip-and-warn behavior, deleted-shard GC, per-agent cache isolation, or the `loadShard` single-slug always-fresh bypass.
- Does **not** change `loadAllShards`'s signature or return shape — pure internal refactor.

## Review notes

The load-bearing invariant to verify is in `resolveShard` / the apply-loop split: **the cache must stay read-only during the `Promise.all` phase**. If a future edit moves a `cache.set` back inside `resolveShard`, it reintroduces the interleaved-write race the split exists to prevent. The inline comment flags this.

All 17 existing `load-shards.test.ts` cases pass unchanged (they pin the cache/ordering/GC contracts). Two regression tests were added to lock the concurrency-ordering guarantee specifically:
- a shuffled-write set of 15 shards must come back slug-sorted (order derives from the sorted listing, not parallel read-completion order);
- a malformed shard sorted into the middle of the set must drop without shifting its valid neighbours.