### PR TITLE
docs(prompt): distinguish agent backup repo from project repos

### DIFF
--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -53,6 +53,31 @@ describe('version control dependency changes', () => {
   })
 })
 
+describe('agent folder vs project repo', () => {
+  // Guards the confusion where the agent treats its own backup repo as the
+  // project under development — tries to push it as a PR, or claims it has no
+  // remote so it "can't open the PR". Both prompts must keep the distinction:
+  // the agent folder is a private, remote-less backup repo; project work and PRs
+  // happen in a separate clone (e.g. /tmp/<repo>).
+  test.each([
+    ['default prompt', DEFAULT_SYSTEM_PROMPT],
+    ['slim prompt', SLIM_SYSTEM_PROMPT],
+  ])('states the agent folder is a backup repo, not a project checkout, in the %s', (_name, prompt) => {
+    expect(prompt).toMatch(/no (github )?remote/i)
+    expect(prompt).toMatch(/clone[\s\S]*?\/tmp/i)
+    expect(prompt).toMatch(/not a (software )?project (checkout|you develop)|not a checkout of any project/i)
+  })
+
+  test('the default prompt explicitly tells the agent where project work and PRs happen', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('it is your own private backup repo')
+    expect(start).toBeGreaterThan(-1)
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 900)
+    expect(section).toMatch(/not\*{0,2} a checkout of any project/i)
+    expect(section).toMatch(/open the PR from that clone/i)
+    expect(section).toMatch(/ask the user where it lives/i)
+  })
+})
+
 describe('renderTurnTimeAnchor', () => {
   test('wraps the ISO timestamp, IANA zone, and weekday in a single <current-time> tag', () => {
     const now = new Date('2026-01-15T12:00:00+09:00')

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -81,13 +81,17 @@ Use this only when the work belongs in *your* session. For self-contained long w
 
 ## Version control
 
-Your agent folder is a git repository.
+Your agent folder is a git repository, but **it is your own private backup repo — not a software project you develop.** It exists so TypeClaw can snapshot your identity files, \`sessions/\`, and \`memory/\` over time. It has no GitHub remote, nothing is pushed anywhere, and it is **not** a checkout of any project's source code. So when you commit here, you are saving your own state — not contributing to a codebase.
+
+This matters when the user asks you to work on an actual software project — fix a bug, build a feature, open a pull request. **That work does not happen in your agent folder.** Clone the project's repo somewhere else first (e.g. \`/tmp/<repo>\`), do the work there, and open the PR from that clone with \`gh\`. Never \`git init\`, add a remote, or try to push your agent folder as if it were the project — and if you can't find the project repo or its remote, ask the user where it lives instead of treating this folder as the project. The two are separate: this folder is *where you live*, the project clone is *where you work*.
+
+Commits to your agent folder (your own state):
 
 - Commit any files you created, edited, or deleted before declaring a task done. One logical change = one commit; split unrelated changes.
 - Use \`git add <paths>\` (not \`git add -A\`). Imperative commit messages ("Update SOUL.md to be less formal"); explain *why* in the body if non-obvious.
 - Never commit \`secrets.json\`, \`.env\`, or anything under \`workspace/\` — truly-ignored by design. \`sessions/\` and \`memory/\` are gitignored but runtime-committed; don't \`git add\` them.
 - ${PACKAGE_JSON_INSTALL_RULE}
-- Never \`git push\`, \`git reset --hard\`, \`git rebase\`, or rewrite remote history unless the user explicitly asks.
+- Never \`git push\`, \`git reset --hard\`, \`git rebase\`, or rewrite remote history in this folder unless the user explicitly asks. (Pushing a project clone you made elsewhere to open a PR is fine when the user asked for the PR.)
 
 ## How to behave
 
@@ -258,5 +262,7 @@ Do not narrate routine, low-risk tool calls — just call the tool. Do not over-
 ${PACKAGE_JSON_INSTALL_RULE}
 
 Your free-write zone is \`workspace/\`. Do not create files at the root of the agent folder unless the prompt names another path. \`public/\` is the guest-visible zone — write there anything meant to be shared with an untrusted caller (a \`guest\`-role turn cannot read \`workspace/\` but can read \`public/\`). Do not edit \`memory/topics/\` directly — the dreaming subagent owns it; to capture something memorable, surface it in your reply or let the memory-logger append to \`memory/streams/\`. Never stage or commit \`secrets.json\`, \`.env\`, \`sessions/\`, \`memory/\`, or \`workspace/\` — those are runtime- or user-managed.
+
+The agent folder is a private backup repo with no remote, not a project checkout. To work on a software project (fix a bug, open a PR), clone its repo elsewhere (e.g. \`/tmp/<repo>\`) and work there — never push the agent folder as if it were the project.
 
 See the session-origin block below for what kind of session this is and what's expected of you.`


### PR DESCRIPTION
## Problem

A TypeClaw agent ("Typeey") running inside its own bind-mounted `/agent` folder got tangled up in a Discord thread: when asked to open a PR, it reported it *couldn't* — "this checkout has no Git remote configured, so there's nowhere to push" — and then went in circles about **which repo it was even in** ("what repo?", "isn't your repo Typeey?"). It was treating its own agent folder as the project under development.

Root cause is a prompt gap. The `## Version control` section said only:

> Your agent folder is a git repository.

…and then gave commit discipline. It never told the agent that this repo is a **local-only backup repo with no remote** (existing purely so TypeClaw can snapshot identity files, `sessions/`, and `memory/`), nor that **project work and PRs happen in a separate clone**. So the agent conflated "where I live" with "where I work."

## Fix

Clarify the distinction in both prompts (`src/agent/system-prompt.ts`):

- **Full prompt** (`buildDefaultSystemPrompt`, `## Version control`): the agent folder is a private, remote-less backup repo — **not** a checkout of any project's source. For actual software work (fix a bug, build a feature, open a PR), clone the project repo elsewhere (e.g. `/tmp/<repo>`), work there, and open the PR from that clone with `gh`. If the project repo / its remote can't be found, **ask the user where it lives** instead of treating the agent folder as the project.
- **Slim prompt** (`SLIM_SYSTEM_PROMPT`, used by cron): one-sentence mirror of the same rule.

This aligns the main prompt with guidance the `reviewer` subagent skill already carries (`code-review.ts`: "You run in the agent folder (`/agent`), **not** a checkout of the PR's target repository").

## Tests

Added a guard test (`agent folder vs project repo`) asserting the distinction survives in both the full and slim prompts, and that the full prompt keeps the "clone elsewhere / open PR from that clone / ask the user where it lives" instructions.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only)
- `bun run format:check` — clean
- `bun run test` — 8930 pass, 0 fail (incl. the section-ordering / cache-suffix contract test, unaffected — change is in the base prompt)
- `bun run debug:prompt --origin tui|cron` — verified the new prose renders correctly
