### PR TITLE
fix(agent-browser): report stash path and clarify skip log on boot

### DIFF
--- a/src/bundled-plugins/agent-browser/index.ts
+++ b/src/bundled-plugins/agent-browser/index.ts
@@ -89,7 +89,7 @@ function logInstallResult(
   result: SafeResult,
 ): void {
   if (result.kind === 'installed') {
-    logger.info(`installed agent-browser shim at ${result.binPath} (real bin: ${result.realBin})`)
+    logger.info(`installed agent-browser shim at ${result.binPath} (real bin stashed at ${result.stashTarget})`)
     return
   }
   if (result.kind === 'already-installed') {
@@ -97,7 +97,7 @@ function logInstallResult(
     return
   }
   if (result.kind === 'no-upstream') {
-    logger.info(`no agent-browser binary at ${result.binPath}; skipping`)
+    logger.info(`no agent-browser binary at ${result.binPath}; nothing to shim here`)
     return
   }
   logger.warn(`failed to install agent-browser shim at ${result.binPath}: ${String(result.error)}`)


### PR DESCRIPTION
## Background

Container boot logs from the agent-browser shim-install path confused operators reading
`typeclaw logs -f`. Two lines appeared next to each other and looked contradictory:

```
[plugin:agent-browser] installed agent-browser shim at /usr/local/bin/agent-browser (real bin: /usr/local/bin/agent-browser)
[plugin:agent-browser] no agent-browser binary at /agent/node_modules/.bin/agent-browser; skipping
```

Neither line described a bug. The plugin walks two paths in `KNOWN_BIN_PATHS`:

- global `/usr/local/bin/agent-browser` — has a real upstream binary, gets shimmed
- local `/agent/node_modules/.bin/agent-browser` — does not exist in the container, correctly skipped

Both outcomes are expected. But the messages described what happened badly enough that
operators filed a suspected-bug report.

## Summary

Two log-string fixes in `logInstallResult`, no control-flow or behavior change.

**1. `installed` line reported the wrong path for the real binary.**

After `installShim` runs, the upstream binary has already been moved into the stash dir.
The old log reported `real bin: <binPath>` — the same path the shim was just written to,
not where the executable actually was. The fix reads `result.stashTarget` instead:
that field holds the stash-dir path where the binary lives after the move.

**2. No-upstream line read like an error.**

The local node_modules path legitimately does not exist inside the container — that is
the expected case. The word "skipping" next to a successful "installed" line implied
something went wrong. Rewording to "nothing to shim here" conveys the path was
intentionally a no-op.

**After:**
```
[plugin:agent-browser] installed agent-browser shim at /usr/local/bin/agent-browser (real bin stashed at /usr/local/lib/typeclaw-agent-browser/.../agent-browser-real)
[plugin:agent-browser] no agent-browser binary at /agent/node_modules/.bin/agent-browser; nothing to shim here
```

## What this does NOT do

- No change to shim-install control flow, stash behavior, or any side effect.
- Does not touch path enumeration, `installShim`, or any other plugin entry point.
- The already-installed and failed log branches are unchanged.

## Review notes

`result.stashTarget` is already a typed field on the installed-result variant — no new
fields, type-safe. The only changed lines are the two logger.info calls inside
`logInstallResult`. The load-bearing thing to verify: at the point the log fires,
stashTarget holds the stash-dir path and binPath holds the shim path — they should now
point to different locations.

This is part of a set of container-boot log-noise fixes split per subsystem.
Memory/onnxruntime changes ship in separate PRs.