### PR TITLE
fix(memory): quiet onnxruntime cpuid warning and downgrade embed-bound log

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-onnx-loglevel.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-onnx-loglevel.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+// Guards the onnxruntime cpuid-warning suppression: configureTransformers must
+// drop the onnx backend log level to 'error' BEFORE pipeline() creates the
+// inference session (where onnxruntime-node reads the level and runs the cpuid
+// probe). The mock captures the env onnxruntime sees at session-creation time.
+let onnxAtPipeline: { logLevel?: string; setLogLevelArg?: number } | undefined
+
+const onnx: { logLevel?: string; setLogLevel: (level: number) => void; setLogLevelArg?: number } = {
+  setLogLevel(level: number) {
+    this.setLogLevelArg = level
+  },
+}
+
+mock.module('@huggingface/transformers', () => ({
+  env: { backends: { onnx } },
+  pipeline: async () => {
+    onnxAtPipeline = { logLevel: onnx.logLevel, setLogLevelArg: onnx.setLogLevelArg }
+    return () => ({ data: new Float32Array(768) })
+  },
+}))
+
+describe('onnxruntime log-level suppression', () => {
+  test("lowers the onnx backend to 'error' and mirrors via setLogLevel before the session is created", async () => {
+    const { getEmbedder } = await import('./embedder')
+
+    await getEmbedder()
+
+    expect(onnxAtPipeline?.logLevel).toBe('error')
+    expect(onnxAtPipeline?.setLogLevelArg).toBe(3)
+  })
+})

--- a/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
@@ -60,37 +60,37 @@ describe('embedder bounding', () => {
 })
 
 describe('embedder bounding observability', () => {
-  let warnings: string[]
-  const originalWarn = console.warn
+  let notices: string[]
+  const originalInfo = console.info
 
   beforeEach(() => {
-    warnings = []
-    console.warn = (message?: unknown) => {
-      warnings.push(String(message))
+    notices = []
+    console.info = (message?: unknown) => {
+      notices.push(String(message))
     }
   })
 
   afterEach(() => {
-    console.warn = originalWarn
+    console.info = originalInfo
   })
 
-  test('emits a content-free warning naming the type and count when an input is bounded', async () => {
+  test('emits a content-free notice naming the type and count when an input is bounded', async () => {
     const { embed } = await import('./embedder')
 
     await embed(['in budget', overBudgetText], 'query')
 
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('[memory]')
-    expect(warnings[0]).toContain('query')
-    expect(warnings[0]).toContain('1/2')
-    expect(warnings[0]).not.toContain('word')
+    expect(notices).toHaveLength(1)
+    expect(notices[0]).toContain('[memory]')
+    expect(notices[0]).toContain('query')
+    expect(notices[0]).toContain('1/2')
+    expect(notices[0]).not.toContain('word')
   })
 
-  test('does not warn when every input is within budget', async () => {
+  test('does not log when every input is within budget', async () => {
     const { embed } = await import('./embedder')
 
     await embed(['short a', 'short b'], 'passage')
 
-    expect(warnings).toHaveLength(0)
+    expect(notices).toHaveLength(0)
   })
 })

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -97,11 +97,14 @@ export async function embed(texts: string[], type: EmbedType): Promise<Float32Ar
 // is observable in logs (the dreaming over_budget table only covers topic
 // shards — this is the only path for queries and stream fragments). Logs counts
 // and the worst estimate only, never the text, so memory content can't leak.
+// Emitted at info, not warn: bounding is the designed, deterministic remediation
+// (dreaming compacts the over-budget topic shards on its own schedule), so a
+// non-zero count on a routine boot index build is expected, not actionable.
 function warnIfBounded(results: readonly BoundedText[], type: EmbedType): void {
   const trimmed = results.filter((r) => r.bounded)
   if (trimmed.length === 0) return
   const worst = trimmed.reduce((max, r) => Math.max(max, r.estimatedTokens), 0)
-  console.warn(
+  console.info(
     `[memory] vector embedding: bounded ${trimmed.length}/${results.length} ${type} input(s) to the ` +
       `${MAX_MODEL_TOKENS}-token model limit (worst ~${worst} est. tokens); their tail is not embedded`,
   )
@@ -110,6 +113,26 @@ function warnIfBounded(results: readonly BoundedText[], type: EmbedType): void {
 function configureTransformers(env: TransformersEnv): void {
   env.localModelPath = modelCachePath()
   env.allowRemoteModels = false
+  // Silence onnxruntime's "cpuid_info warning: Unknown CPU vendor" at every
+  // boot index build. It fires when cpuinfo initializes but can't match the
+  // CPUID vendor string — the norm for our container under emulated/virtualized
+  // CPUs (Rosetta/QEMU on Apple Silicon hosts). The vendor string is purely
+  // informational: SIMD kernel dispatch (AVX/NEON/...) is detected on an
+  // independent codepath, so vendor=unknown has no perf or correctness impact.
+  // onnxruntime itself already suppresses this same warning on wasm.
+  // onnxruntime-node reads this onnxruntime-common env at session creation —
+  // inside pipeline() below, AFTER this runs — so 'error' takes effect before
+  // the cpuid probe fires. Guarded because the backend object is absent under
+  // the test mock; setLogLevel mirrors the level so it lands regardless of
+  // which hook the installed build honors. Tradeoff: 'error' also hides the
+  // separate "cpuinfo init FAILED — perf degradation" warning, acceptable
+  // because that one does not fire here (vendor=0 means init succeeded), and
+  // real session/inference errors still surface.
+  const onnx = env.backends?.onnx
+  if (onnx) {
+    onnx.logLevel = 'error'
+    onnx.setLogLevel?.(3)
+  }
 }
 
 function modelCachePath(): string {


### PR DESCRIPTION
## Background

Two separate log lines spammed container boot on every vector index build,
both tied to `configureTransformers` / `embed` in the memory plugin embedder.
Neither represents a real problem — quieting them makes the remaining signal
(real errors, `[dreaming] done over_budget=N`) legible again.

---

### Fix A — suppress onnxruntime `cpuid_info warning: Unknown CPU vendor`

```
onnxruntime cpuid_info warning: Unknown CPU vendor. cpuinfo_vendor value: 0
```

**Root cause.** onnxruntime-node runs a cpuid probe when it creates an inference
session. The probe uses pytorch/cpuinfo, which initializes successfully but cannot
match the CPUID vendor string against its known-vendor table when the container
runs on an emulated/virtualized CPU — Rosetta 2 / QEMU on Apple Silicon hosts
present a non-standard CPUID string. On success with unknown vendor it logs this
warning and sets `vendor=0`.

**Why it is safe to suppress.** The vendor field is purely informational: device-info
reporting only. SIMD kernel dispatch (AVX, AVX2, AVX512, NEON, F16C, …) is detected
on a completely independent codepath (`X86Init` via raw CPUID instructions,
`ArmLinuxInit` via auxval/hwcap) — vendor=unknown has zero perf or correctness
impact. onnxruntime already suppresses this same warning on wasm
(`cpuid_info_vendor.cc`), and upstream issue microsoft/onnxruntime#27336 was closed
with no code fix needed.

**Fix.** In `configureTransformers`, set the onnx backend log level to `'error'`
(`env.backends.onnx.logLevel = 'error'`, mirrored via `setLogLevel(3)`) before
calling `pipeline()`. onnxruntime-node reads the level when it creates the
inference session — inside `pipeline()` — so the level is in place before the
cpuid probe fires. Guarded with optional chaining because the backend object is
absent under the test mock.

**Tradeoff.** Setting `'error'` also hides a separate, genuinely serious
onnxruntime warning: "Failed to initialize PyTorch cpuinfo library. May cause CPU
EP performance degradation." That warning does NOT fire in our container — `vendor=0`
proves cpuinfo init succeeded. Real session/inference errors still surface at
`'error'` level, so the tradeoff is acceptable. Reviewers should keep this in mind
if the cpuinfo-init-failure warning is ever needed for diagnosis.

---

### Fix B — downgrade per-embed bound log `warn` → `info`

```
[memory] vector embedding: bounded 40/3283 passage input(s) to the 512-token model
limit (worst ~1538 est. tokens); their tail is not embedded
```

**Why it was a false alarm.** Bounding is the designed, deterministic path
(`boundEmbeddableText`). The real remediation for over-budget shards is the dreaming
subagent, which compacts verbose topic shards on its own schedule
(`*/30 * * * *` default). A non-zero bounded count on a routine boot index build is
expected and non-actionable — legacy verbose shards, long fragments, and long queries
all trigger it by design until dreaming catches up. The actionable signal is the
separate `[dreaming] done over_budget=N` line, not this per-embed count.

**Fix.** `console.warn` → `console.info` in `warnIfBounded`. Message is unchanged
(still content-free: counts + worst-case token estimate only, never the text itself).

---

## What this does NOT do

- Does not change any embedding logic, SIMD dispatch, vector store schema, or
  relevance scoring.
- Does not remove the embed-bound log line — it stays at `info` for debugging.
- Does not suppress real onnxruntime session or inference errors (those surface at
  `'error'` level).
- Does not change dreaming's compaction schedule or over-budget routing (see the
  `fix(memory): bound embedding inputs` PR for that).

---

## Review notes

- **Timing invariant (Fix A):** `configureTransformers` runs before `pipeline()`
  creates the inference session. That ordering is what makes the log-level write
  effective — if it were moved inside `pipeline()`'s callback, it would be too late.
  `embedder-onnx-loglevel.test.ts` guards this: the mock captures the onnx env at
  session-creation time and asserts `logLevel === 'error'` and `setLogLevelArg === 3`.
- **Tradeoff (Fix A):** `'error'` also suppresses the cpuinfo-init-FAILURE warning.
  Acceptable because that warning does not fire here (vendor=0 means init succeeded),
  but worth knowing if symptoms ever suggest cpuinfo did NOT initialize.
- **Test update (Fix B):** `embedder-truncation.test.ts` now spies on `console.info`
  instead of `console.warn`. Assertions are otherwise unchanged.
- **Sibling PR:** the agent-browser plugin log-noise fix ships in PR #847.

---

## Testing

- `bun run test --parallel` on the three embedder files — 10 pass, 0 fail
  (includes new `embedder-onnx-loglevel.test.ts` and updated
  `embedder-truncation.test.ts`)
- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format` — clean