### PR TITLE
fix(memory): surface single-pass embed batch size to diagnose OOM boots

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
@@ -74,23 +74,70 @@ describe('embedder bounding observability', () => {
     console.warn = originalWarn
   })
 
-  test('emits a content-free warning naming the type and count when an input is bounded', async () => {
+  test('warns content-free with the type and count when an input is bounded', async () => {
     const { embed } = await import('./embedder')
 
     await embed(['in budget', overBudgetText], 'query')
 
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]).toContain('[memory]')
-    expect(warnings[0]).toContain('query')
-    expect(warnings[0]).toContain('1/2')
-    expect(warnings[0]).not.toContain('word')
+    const bounded = warnings.filter((w) => w.includes('bounded'))
+    expect(bounded).toHaveLength(1)
+    expect(bounded[0]).toContain('[memory]')
+    expect(bounded[0]).toContain('query')
+    expect(bounded[0]).toContain('1/2')
+    expect(bounded[0]).not.toContain('word')
   })
 
-  test('does not warn when every input is within budget', async () => {
+  test('does not warn about bounding when every input is within budget', async () => {
     const { embed } = await import('./embedder')
 
     await embed(['short a', 'short b'], 'passage')
 
-    expect(warnings).toHaveLength(0)
+    expect(warnings.filter((w) => w.includes('bounded'))).toHaveLength(0)
+  })
+})
+
+describe('embedder batch-size observability', () => {
+  let warnings: string[]
+  let notices: string[]
+  const originalWarn = console.warn
+  const originalInfo = console.info
+
+  beforeEach(() => {
+    warnings = []
+    notices = []
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message))
+    }
+    console.info = (message?: unknown) => {
+      notices.push(String(message))
+    }
+  })
+
+  afterEach(() => {
+    console.warn = originalWarn
+    console.info = originalInfo
+  })
+
+  test('logs the single-pass batch size at info for a small batch', async () => {
+    const { embed } = await import('./embedder')
+
+    await embed(['short a', 'short b'], 'passage')
+
+    const batchLine = notices.find((n) => n.includes('in a single pass'))
+    expect(batchLine).toContain('2 passage input(s)')
+    expect(warnings.some((w) => w.includes('in a single pass'))).toBe(false)
+  })
+
+  test('warns when the single-pass batch is large enough to risk an OOM-killed boot', async () => {
+    const { embed } = await import('./embedder')
+
+    await embed(
+      Array.from({ length: 256 }, (_, i) => `passage ${i}`),
+      'passage',
+    )
+
+    const batchWarn = warnings.find((w) => w.includes('in a single pass'))
+    expect(batchWarn).toContain('256 passage input(s)')
+    expect(batchWarn).toContain('OOM')
   })
 })

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -68,6 +68,14 @@ export class Embedder {
     const results = texts.map((text) => boundEmbeddableText(text))
     warnIfBounded(results, type)
 
+    // The whole array is embedded in ONE onnxruntime pass — peak memory scales
+    // with batch size, and a large startup index build (thousands of passages)
+    // can OOM-kill the container mid-pass. Log the size first so that, if the
+    // process dies here, the last line names the batch that did it rather than
+    // leaving the embed call as a silent point of death. Warn above a threshold
+    // where the single-pass cost is the likely culprit for a missing agent.
+    logEmbedBatch(texts.length, type)
+
     const output = await this.extractor(
       prefixTexts(
         results.map((r) => r.text),
@@ -105,6 +113,21 @@ function warnIfBounded(results: readonly BoundedText[], type: EmbedType): void {
     `[memory] vector embedding: bounded ${trimmed.length}/${results.length} ${type} input(s) to the ` +
       `${MAX_MODEL_TOKENS}-token model limit (worst ~${worst} est. tokens); their tail is not embedded`,
   )
+}
+
+// Above this single-pass batch size, the embed is the prime suspect for a
+// container that boots, logs, then dies without an error — the onnxruntime
+// activation tensors for a batch this large are the memory spike that trips
+// the OOM killer.
+const LARGE_EMBED_BATCH = 256
+
+function logEmbedBatch(count: number, type: EmbedType): void {
+  const line = `[memory] vector embedding: ${count} ${type} input(s) in a single pass`
+  if (count >= LARGE_EMBED_BATCH) {
+    console.warn(`${line} — large batch, peak memory scales with this; an OOM kill here aborts the boot`)
+  } else {
+    console.info(line)
+  }
 }
 
 function configureTransformers(env: TransformersEnv): void {


### PR DESCRIPTION
## Background

On a production agent container the service would not start. `docker inspect` showed `OOMKilled=true`, exit 137. The last lines of `docker logs` before the kill were:

```
05:36:14  [memory] vector embedding: bounded 40/3283 passage input(s) ...   ← embed starts
05:37:26  error: Failed to run "typeclaw" due to signal SIGKILL              ← killed ~72s later
```

**Root cause.** `buildStartupVectorIndex` in `startup.ts` collects every missing passage and passes the whole array to `embed()` in a single call. `embed()` runs it through onnxruntime's transformer pipeline in one `this.extractor(...)` pass. For 3 283 passages the activation tensors for that single batch spike memory enough to trip the OOM killer mid-pass — the agent booted, logged, then died with only a SIGKILL and no error line naming the cause.

The two pre-existing logs (the onnxruntime `cpuid_info warning` and the `bounded N/M` embed-bound notice) were the only breadcrumbs, and neither named the batch that caused the spike. The embed call was a silent point of death.

## Summary

Log the single-pass batch size **before** `this.extractor(...)` runs, so a process that dies inside the embed leaves a line naming the batch instead of an unexplained SIGKILL.

- New `logEmbedBatch(count, type)` helper called at the top of `embed()`, before the extractor.
- Below `LARGE_EMBED_BATCH` (256): logs at `console.info` — `[memory] vector embedding: N <type> input(s) in a single pass`.
- At or above 256: logs at `console.warn` with an explicit OOM hint — `large batch, peak memory scales with this; an OOM kill here aborts the boot`. 256 is the threshold where a single-pass activation spike is the likely culprit for a missing agent.

**Why keep the bounded N/M warn at `warn` (reverting #848's downgrade)?** The `bounded 40/3283` line is the load-bearing breadcrumb — the N/M count is what reveals the batch magnitude behind the OOM. Downgrading it to `info` would have hidden the only clue. This PR explicitly does NOT suppress it.

**Why no onnxruntime log suppression (reverting #848's silencing)?** The `Unknown CPU vendor` line is a native C++ cpuinfo warning. Muting it at the onnx backend log level would also hide the separate, genuine `cpuinfo init failed — perf degradation` warning. Suppression was the wrong approach.

## What this does NOT do

The actual memory fix — batching `buildStartupVectorIndex` / `embed()` into chunks (32–64 passages per pass) so peak memory is bounded regardless of corpus size — is a deliberate follow-up PR. This PR is the diagnostic half: the OOM is now legible before that fix lands.

## Review notes

- **Supersedes #848** (`fix(memory): quiet onnxruntime cpuid warning and downgrade embed-bound log`), which was closed because its premise was wrong — it treated the boot-log lines as noise to suppress rather than signal to amplify.
- **Sibling:** PR #847 (`fix(agent-browser): report stash path and clarify skip log on boot`) ships the other split log-noise fix for the same boot sequence.
- Load-bearing ordering: `logEmbedBatch` is called **before** `this.extractor(...)`. If it were moved after, the log would never survive a pass that kills the process.
- The bounding test (`embedder bounding observability`) was updated to filter for the `bounded` substring specifically, since `logEmbedBatch` now co-emits a batch-size line to the same console on every call.

## Testing

- `bun run test --parallel` on `embedder-truncation.test.ts` + `embedder-lazy-load.test.ts` — 11 pass, 0 fail (includes new `embedder batch-size observability` describe: info-level for a small batch, warn + OOM hint for a 256-item batch; bounding test still asserts the warn-level `bounded` line)
- `bun run typecheck` — clean
- `bun run lint` — 0 errors (67 pre-existing warnings, unrelated)
- `bun run format` — clean