### PR TITLE
fix(memory): batch the embed to stop the startup index OOM

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-batch.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-batch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+import { DIMS } from './embedder'
+
+// Records the size of every onnxruntime forward pass so the test can prove the
+// embed is chunked (bounding peak memory) rather than run as one giant batch.
+const batchSizes: number[] = []
+
+mock.module('@huggingface/transformers', () => ({
+  env: {},
+  pipeline: async () => {
+    return (texts: string[]) => {
+      const count = Array.isArray(texts) ? texts.length : 1
+      batchSizes.push(count)
+      // Stamp each row's first lane with a running global index so the caller
+      // can assert order is preserved across chunk boundaries.
+      const data = new Float32Array(count * DIMS)
+      const base = batchSizes.slice(0, -1).reduce((sum, n) => sum + n, 0)
+      for (let i = 0; i < count; i++) data[i * DIMS] = base + i
+      return { data }
+    }
+  },
+}))
+
+describe('embedder batching', () => {
+  test('splits a large input set into bounded forward passes and preserves order', async () => {
+    const { embed } = await import('./embedder')
+    const inputs = Array.from({ length: 150 }, (_, i) => `passage ${i}`)
+
+    const out = await embed(inputs, 'passage')
+
+    // given 150 inputs and a 64 batch → 64 + 64 + 22
+    expect(batchSizes).toEqual([64, 64, 22])
+    expect(batchSizes.every((n) => n <= 64)).toBe(true)
+    expect(out).toHaveLength(150)
+    // first lane carries the global index, so order is intact across chunks
+    expect(out.map((e) => e[0])).toEqual(inputs.map((_, i) => i))
+  })
+})

--- a/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
@@ -118,17 +118,17 @@ describe('embedder batch-size observability', () => {
     console.info = originalInfo
   })
 
-  test('logs the single-pass batch size at info for a small batch', async () => {
+  test('logs the total embed size and chunk width at info for a small build', async () => {
     const { embed } = await import('./embedder')
 
     await embed(['short a', 'short b'], 'passage')
 
-    const batchLine = notices.find((n) => n.includes('in a single pass'))
+    const batchLine = notices.find((n) => n.includes('vector embedding'))
     expect(batchLine).toContain('2 passage input(s)')
-    expect(warnings.some((w) => w.includes('in a single pass'))).toBe(false)
+    expect(batchLine).toContain('chunked at')
   })
 
-  test('warns when the single-pass batch is large enough to risk an OOM-killed boot', async () => {
+  test('notes a large build is slow but does not warn — chunking removed the OOM risk', async () => {
     const { embed } = await import('./embedder')
 
     await embed(
@@ -136,8 +136,8 @@ describe('embedder batch-size observability', () => {
       'passage',
     )
 
-    const batchWarn = warnings.find((w) => w.includes('in a single pass'))
-    expect(batchWarn).toContain('256 passage input(s)')
-    expect(batchWarn).toContain('OOM')
+    const batchLine = notices.find((n) => n.includes('256 passage input(s)'))
+    expect(batchLine).toContain('may take a while')
+    expect(warnings.some((w) => w.includes('vector embedding'))).toBe(false)
   })
 })

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -24,6 +24,14 @@ export const EMBEDDING_MODEL_ID = `${MODEL_NAME}@${MODEL_DTYPE}`
 
 export type EmbedType = 'query' | 'passage'
 
+// Passages per onnxruntime forward pass. The whole-array embed (a startup index
+// build over thousands of shards+fragments) otherwise allocates activation
+// tensors for every input at once, and that single spike OOM-kills the
+// container mid-build — the agent boots, then dies with only a SIGKILL. Chunking
+// caps peak memory at one batch's worth regardless of corpus size; the model is
+// loaded once and reused across chunks, so the only cost is sequential passes.
+const EMBED_BATCH_SIZE = 64
+
 type TransformersEnv = typeof TransformersEnvValue
 type FeatureExtractor = Awaited<ReturnType<typeof TransformersPipeline<'feature-extraction'>>>
 
@@ -68,25 +76,25 @@ export class Embedder {
     const results = texts.map((text) => boundEmbeddableText(text))
     warnIfBounded(results, type)
 
-    // The whole array is embedded in ONE onnxruntime pass — peak memory scales
-    // with batch size, and a large startup index build (thousands of passages)
-    // can OOM-kill the container mid-pass. Log the size first so that, if the
-    // process dies here, the last line names the batch that did it rather than
-    // leaving the embed call as a silent point of death. Warn above a threshold
-    // where the single-pass cost is the likely culprit for a missing agent.
+    // Log the total embed size up front so a process that dies mid-build still
+    // leaves a line naming how much it was embedding. The work is chunked below
+    // (EMBED_BATCH_SIZE per onnxruntime pass) so peak memory no longer scales
+    // with this total — but the count remains the useful breadcrumb for a slow
+    // or wedged build.
     logEmbedBatch(texts.length, type)
 
-    const output = await this.extractor(
-      prefixTexts(
-        results.map((r) => r.text),
-        type,
-      ),
-      {
-        pooling: 'mean',
-        normalize: true,
-      },
+    const prefixed = prefixTexts(
+      results.map((r) => r.text),
+      type,
     )
-    return toEmbeddings(output.data, texts.length)
+
+    const embeddings: Float32Array[] = []
+    for (let start = 0; start < prefixed.length; start += EMBED_BATCH_SIZE) {
+      const batch = prefixed.slice(start, start + EMBED_BATCH_SIZE)
+      const output = await this.extractor(batch, { pooling: 'mean', normalize: true })
+      embeddings.push(...toEmbeddings(output.data, batch.length))
+    }
+    return embeddings
   }
 }
 
@@ -115,16 +123,18 @@ function warnIfBounded(results: readonly BoundedText[], type: EmbedType): void {
   )
 }
 
-// Above this single-pass batch size, the embed is the prime suspect for a
-// container that boots, logs, then dies without an error — the onnxruntime
-// activation tensors for a batch this large are the memory spike that trips
-// the OOM killer.
-const LARGE_EMBED_BATCH = 256
+// A large embed (a startup index build over thousands of passages) used to be
+// the prime suspect for a container that boots, logs, then dies without an
+// error — the onnxruntime activation tensors spiked the OOM killer. The embed
+// is now chunked at EMBED_BATCH_SIZE, so this is no longer a fatal threshold;
+// it just marks where a build is large enough that its duration is worth noting
+// up front (the count remains the breadcrumb if the build wedges or is slow).
+const LARGE_EMBED = 256
 
 function logEmbedBatch(count: number, type: EmbedType): void {
-  const line = `[memory] vector embedding: ${count} ${type} input(s) in a single pass`
-  if (count >= LARGE_EMBED_BATCH) {
-    console.warn(`${line} — large batch, peak memory scales with this; an OOM kill here aborts the boot`)
+  const line = `[memory] vector embedding: ${count} ${type} input(s) (chunked at ${EMBED_BATCH_SIZE}/pass)`
+  if (count >= LARGE_EMBED) {
+    console.info(`${line} — large build, this may take a while`)
   } else {
     console.info(line)
   }


### PR DESCRIPTION
## Background

An agent container would not start. `docker inspect` showed OOMKilled=true, exit 137. The boot log told the story:

```
[memory] vector embedding: bounded 40/3283 passage input(s) ...
(~72 seconds later)
error: Failed to run "typeclaw" due to signal SIGKILL
```

The agent booted, logged the embed start, then died with only a SIGKILL and no error line.

**Root cause.** `buildStartupVectorIndex` collects every missing passage and calls embed() once with the entire array. The embedder ran the whole array through onnxruntime in a *single* forward pass. For 3 283 passages the activation tensors for that single batch spiked memory past the container ceiling and the kernel OOM-killed it mid-build.

## Summary

Chunk `Embedder.embed` into EMBED_BATCH_SIZE (64) forward passes and concatenate the results in order. Peak memory now scales with *one batch*, not the whole corpus, so the startup index build no longer OOMs regardless of how many passages accumulate over time.

Key properties:

- **Every caller is bounded transparently.** Batching lives entirely in `embedder.ts`, so the startup build, the on-write index (index-on-write.ts), and the query path (hybrid.ts) all get the fix with no changes at their call sites. The public (texts, type) → Promise<Float32Array[]> contract and input→output ordering are unchanged.
- **The model is loaded once.** The existing lazy-load is preserved; the only cost of chunking is sequential forward passes.
- **`boundEmbeddableText` is unchanged.** Token bounding runs once over all inputs before chunking, exactly as before.

### Companion PR #849

PR #849 (branch fix/embed-batch-oom-diagnostics) makes the OOM legible: it logs the single-pass batch size and warns above 256 inputs. This PR bounds the batch so that warn threshold is never reached during the startup build. Both can land; they touch different, non-conflicting additions to embed().

PR #848 (a different approach, now closed) was the earlier wrong-approach attempt. PR #847 is an unrelated sibling cosmetic log fix.

## Preview

N/A — no output or UI change.

## What this does NOT do

- Does not change container memory limits or `typeclaw.json`. After merging, the reporter rebuilds and restarts their agent to pick up the fix.
- Does not alter the public embed() signature or result ordering.
- Does not modify the token-bounding logic (`boundEmbeddableText`) or its warn log.

## Review notes

The load-bearing change is the chunked loop in `Embedder.embed`:

```ts
for (let start = 0; start < prefixed.length; start += EMBED_BATCH_SIZE) {
  const batch = prefixed.slice(start, start + EMBED_BATCH_SIZE)
  const output = await this.extractor(batch, { pooling: 'mean', normalize: true })
  embeddings.push(...toEmbeddings(output.data, batch.length))
}
```

Invariant to verify: `toEmbeddings` receives batch.length (not the original texts.length) so each chunk is counted correctly and the concatenation stays in input order.

`embedder-batch.test.ts` asserts:

- A 150-input embed runs as exactly [64, 64, 22] forward passes (each ≤ 64).
- All 150 embeddings come back in input order (global index stamped into each row's first lane across chunk boundaries).

The also-included `docs(prompt)` commit is an independent fix for the agent folder / project repo confusion; it has no relation to the OOM path and is safe to review separately.