### PR TITLE
fix(init): sync scaffolded agent-browser version + drop unused @types/ws

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,6 @@
         "@types/qrcode": "^1.5.6",
         "@types/sinonjs__fake-timers": "^15.0.1",
         "@types/turndown": "^5.0.6",
-        "@types/ws": "^8.18.1",
         "@typescript/native-preview": "^7.0.0-dev.20260416.1",
         "oxfmt": "^0.45.0",
         "oxlint": "^1.60.0",
@@ -503,8 +502,6 @@
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
-
-    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@types/qrcode": "^1.5.6",
     "@types/sinonjs__fake-timers": "^15.0.1",
     "@types/turndown": "^5.0.6",
-    "@types/ws": "^8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260416.1",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0"

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -583,7 +583,11 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
 // skills get core` at runtime, so the CLI must be installed for the skill
 // to function. The Dockerfile pre-downloads Chromium too, so the agent
 // can drive a browser without any first-run setup.
-const AGENT_BROWSER_VERSION = '^0.26.0'
+//
+// Must match the Dockerfile Layer 4 global install (dockerfile.ts); they are
+// two installs of the same CLI and a skew is silent. Enforced by a guard test
+// in packagejson.test.ts.
+export const AGENT_BROWSER_VERSION = '^0.27.0'
 function buildPackageJson(root: string, name: string): Record<string, unknown> {
   return {
     name,

--- a/src/init/packagejson.test.ts
+++ b/src/init/packagejson.test.ts
@@ -4,6 +4,8 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { buildBaseDockerfile } from './dockerfile'
+import { AGENT_BROWSER_VERSION } from './index'
 import { refreshPackageJson } from './packagejson'
 
 let root: string
@@ -72,7 +74,7 @@ describe('refreshPackageJson', () => {
       scripts: { test: 'bun test' },
       dependencies: {
         typeclaw: 'file:../typeclaw',
-        'agent-browser': '^0.26.0',
+        'agent-browser': '^0.27.0',
         'typeclaw-gws-multi-account': '^0.3.4',
       },
       devDependencies: { '@types/bun': 'latest' },
@@ -88,7 +90,7 @@ describe('refreshPackageJson', () => {
     expect(pkg.scripts).toEqual({ test: 'bun test' })
     expect(pkg.dependencies).toEqual({
       typeclaw: 'file:../typeclaw',
-      'agent-browser': '^0.26.0',
+      'agent-browser': '^0.27.0',
       'typeclaw-gws-multi-account': '^0.3.4',
     })
     expect(pkg.devDependencies).toEqual({ '@types/bun': 'latest' })
@@ -165,5 +167,14 @@ describe('refreshPackageJson', () => {
 
     expect(result.files).not.toContain('packages/.gitkeep')
     expect(await readFile(join(root, 'packages', '.gitkeep'), 'utf8')).toBe(customContent)
+  })
+})
+
+describe('agent-browser version lockstep', () => {
+  test('scaffolded agent-runtime dep matches the Dockerfile Layer 4 global install', () => {
+    const dockerfile = buildBaseDockerfile()
+    const match = dockerfile.match(/bun install -g agent-browser@(\S+)/)
+
+    expect(match?.[1]).toBe(AGENT_BROWSER_VERSION)
   })
 })


### PR DESCRIPTION
## Summary

Two small, independent fixes to the agent-browser dependency surface, surfaced while reviewing #847 in the context of #821.

**Commit 1 — `fix(init): sync scaffolded agent-browser dep to container version`**

#821 bumped the Dockerfile Layer 4 global install to `agent-browser@^0.27.0`, but the scaffolded agent-runtime dependency in `buildPackageJson` (`src/init/index.ts`) stayed at `^0.26.0`. These are two installs of the same CLI — the agent folder's `node_modules` range and the container-baked global bin — and the skew was silent (nothing tied them together).

- Bump `AGENT_BROWSER_VERSION` to `^0.27.0` and export it.
- Add a guard test in `packagejson.test.ts` that extracts the version rendered into the Dockerfile (`buildBaseDockerfile()`) and asserts it equals `AGENT_BROWSER_VERSION`, so the two can't drift again.
- Update the two fixture assertions that referenced the old `^0.26.0`.

**Commit 2 — `chore(deps): drop unused @types/ws`**

`ws` is not a dependency and is never imported anywhere in the source tree — typeclaw uses Bun's native `WebSocket` global and `Bun.serve()`'s websocket handler exclusively. `tsconfig` force-loads only the `bun` types (`"types": ["bun"]`), so `@types/ws` contributed nothing.

## What this does NOT do

- No runtime behavior change. The version bump only affects what `typeclaw init` scaffolds into a new agent's `package.json`; the container already installs `^0.27.0`.
- Does not touch `installShim`, the dashboard proxy removal from #821, or any control flow.
- Does not bump the typeclaw version — this is internal-only (no new/changed public surface).

## Review notes

- The guard test asserts against **rendered Dockerfile output**, not a duplicated literal, so it survives refactors of the version constant.
- The audit that found `@types/ws` checked every non-`@types` package in both dep lists by import site (prod = non-test `src/` + `scripts/`, accounting for `files` excluding `**/*.test.ts` and the `postinstall` schema script). No other misplacements and no missing prod deps were found — `@types/ws` was the only actionable item.

## Verification

`bun run typecheck` · `bun run lint` (0 errors) · `bun run format:check` · `bun run test` (8931 pass, 0 fail, 1 env-gated skip) — all green.
