### PR TITLE
feat(memory): add reference memory tier

### DIFF
--- a/src/bundled-plugins/memory/append-tool.ts
+++ b/src/bundled-plugins/memory/append-tool.ts
@@ -25,8 +25,9 @@ export function createAppendTool(onFragmentsAppended?: FragmentsAppendedHook) {
       source: z.string().min(1),
       entry: z.string().min(1),
       latestEntryId: z.string().min(1),
+      references: z.array(z.string()).optional(),
     }),
-    async execute({ topic, body, source, entry, latestEntryId }, ctx) {
+    async execute({ topic, body, source, entry, latestEntryId, references }, ctx) {
       const streamPath = dailyStreamPath(ctx.agentDir)
       assertNoSecrets(`${topic}\n${body}`)
 
@@ -53,6 +54,9 @@ export function createAppendTool(onFragmentsAppended?: FragmentsAppendedHook) {
         entry,
         topic,
         body,
+      }
+      if (references !== undefined && references.length > 0) {
+        fragment.references = references
       }
       const watermark: WatermarkEvent = {
         type: 'watermark',

--- a/src/bundled-plugins/memory/citation-superset.test.ts
+++ b/src/bundled-plugins/memory/citation-superset.test.ts
@@ -99,6 +99,17 @@ describe('checkCitationSuperset', () => {
     expect(verdict.ok).toBe(false)
     if (!verdict.ok) expect(verdict.missing).toEqual([{ date: '2026-05-16', fragmentId: ID_A }])
   })
+
+  test('reference citations (references/<slug>) are excluded from the superset check', () => {
+    const oldText = [`- streams/2026-05-16#${ID_A}`, 'references:', '- references/ref-a'].join('\n')
+    const newText = `- streams/2026-05-16#${ID_A}`
+
+    expect(checkCitationSuperset(oldText, newText)).toEqual({ ok: true })
+
+    const verdict = checkCitationSuperset(oldText, 'references:\n- references/ref-a')
+    expect(verdict.ok).toBe(false)
+    if (!verdict.ok) expect(verdict.missing).toEqual([{ date: '2026-05-16', fragmentId: ID_A }])
+  })
 })
 
 describe('checkCitationSupersetAcrossShards', () => {

--- a/src/bundled-plugins/memory/citation-superset.ts
+++ b/src/bundled-plugins/memory/citation-superset.ts
@@ -20,6 +20,10 @@
 // to honor that — especially across hundreds of runs over months — so the
 // mechanical check is the safety floor.
 //
+// Reference citations (`references/<slug>`) use a different format and are
+// intentionally excluded from this check — they are not fragment ids and are
+// not subject to the citation-superset GC invariant.
+//
 // Detection only. The handler decides what to do with the verdict (revert
 // memory/topics/ to its pre-run bytes, skip daily-stream compaction, still
 // advance the dreamed-id set so we do not loop on the same fragments).

--- a/src/bundled-plugins/memory/dreaming-metrics.test.ts
+++ b/src/bundled-plugins/memory/dreaming-metrics.test.ts
@@ -19,6 +19,8 @@ describe('computeDreamingMetrics', () => {
       topicsCreated: 1,
       topicsRemoved: 1,
       supersededDelta: 0,
+      referencesDemoted: 0,
+      referencesEvicted: 0,
     })
   })
 
@@ -43,6 +45,8 @@ describe('computeDreamingMetrics', () => {
       topicsCreated: 0,
       topicsRemoved: 0,
       supersededDelta: 0,
+      referencesDemoted: 0,
+      referencesEvicted: 0,
     })
   })
 })

--- a/src/bundled-plugins/memory/dreaming-metrics.ts
+++ b/src/bundled-plugins/memory/dreaming-metrics.ts
@@ -4,6 +4,8 @@ export type DreamingMetrics = {
   topicsCreated: number
   topicsRemoved: number
   supersededDelta: number
+  referencesDemoted: number
+  referencesEvicted: number
 }
 
 // Snapshots are keyed by absolute shard path → file bytes (captureShardSnapshot).
@@ -18,7 +20,7 @@ export function computeDreamingMetrics(before: Map<string, Buffer>, after: Map<s
 
   const supersededDelta = countSuperseded(after) - countSuperseded(before)
 
-  return { topicsCreated, topicsRemoved, supersededDelta }
+  return { topicsCreated, topicsRemoved, supersededDelta, referencesDemoted: 0, referencesEvicted: 0 }
 }
 
 function countSuperseded(snapshot: Map<string, Buffer>): number {

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -31,6 +32,10 @@ function watermarkLine(entry: string): string {
   return `${JSON.stringify({ type: 'watermark', id: `w-${entry}`, ts: '2026-05-16T12:00:00.000Z', source: 'ses_test', entry })}\n`
 }
 
+function fragmentLineWithReferences(entry: string, references: string[]): string {
+  return `${JSON.stringify({ type: 'fragment', id: `f-${entry}`, ts: '2026-05-16T12:00:00.000Z', source: 'ses_test', entry, topic: `topic-${entry}`, body: `body ${entry}`, references })}\n`
+}
+
 function legacyProseLine(body = 'legacy prose'): string {
   return `${JSON.stringify({ type: 'legacy_prose', id: 'legacy-1', ts: '2026-05-16T12:00:00.000Z', body })}\n`
 }
@@ -47,9 +52,24 @@ function legacyStreamFile(date: string): string {
   return join(agentDir, 'memory', `${date}.jsonl`)
 }
 
+function referenceFile(slug: string): string {
+  return join(agentDir, 'memory', 'references', `${slug}.md`)
+}
+
 async function writeTopicShard(slug: string, text: string): Promise<void> {
   await mkdir(join(agentDir, 'memory', 'topics'), { recursive: true })
   await writeFile(topicShard(slug), text)
+}
+
+async function writeReference(slug: string, text: string): Promise<void> {
+  await mkdir(join(agentDir, 'memory', 'references'), { recursive: true })
+  await writeFile(referenceFile(slug), text)
+}
+
+async function fileSha256(path: string): Promise<string> {
+  return createHash('sha256')
+    .update(await readFile(path))
+    .digest('hex')
 }
 
 function shardText(
@@ -228,6 +248,14 @@ describe('dreaming subagent declarations', () => {
     expect(prompt).toContain('union')
     expect(prompt).toContain('Citation-superset invariant')
     expect(prompt.toLowerCase()).toContain('reverts')
+  })
+
+  test('teaches reference citations are promoted by slug and reference content stays verbatim', () => {
+    const prompt = createDreamingSubagent().systemPrompt
+    expect(prompt).toContain('References are verbatim artifacts')
+    expect(prompt).toContain('references:')
+    expect(prompt).toContain('- <reference-slug>')
+    expect(prompt).toContain('MUST NOT read, rewrite, or distill their content')
   })
 
   test('teaches the promotion ladder gated on distinct days (1/3/7), not raw citation count', () => {
@@ -548,6 +576,63 @@ describe('dreaming subagent (compaction wiring)', () => {
 
     expect(await readFile(topicShard('first'), 'utf8')).toBe(newText)
     expect(warnings.some((m) => m.includes('citation-superset'))).toBe(false)
+  })
+
+  test('promotes fragment reference slugs into the resulting topic shard body', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLineWithReferences('with-ref', ['ref-a']))
+    await writeReference('ref-a', 'verbatim reference bytes\n')
+    const body = [
+      'Conclusion.',
+      '',
+      'fragments:',
+      '- streams/2026-04-27#f-with-ref',
+      '',
+      'references:',
+      '- ref-a',
+    ].join('\n')
+    const runSession: RunSession = async () => {
+      await writeTopicShard('with-ref', shardText('With ref', body))
+    }
+
+    await invokeDreaming(agentDir, { runSession })
+
+    const topic = await readFile(topicShard('with-ref'), 'utf8')
+    expect(topic).toContain('references:\n- ref-a')
+  })
+
+  test('leaves reference file bytes unchanged after a normal dreaming run', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLineWithReferences('with-ref', ['ref-a']))
+    await writeReference('ref-a', 'verbatim reference bytes\n')
+    const before = await fileSha256(referenceFile('ref-a'))
+    const runSession: RunSession = async () => {
+      await writeTopicShard(
+        'with-ref',
+        shardText(
+          'With ref',
+          ['Conclusion.', '', 'fragments:', '- streams/2026-04-27#f-with-ref', '', 'references:', '- ref-a'].join('\n'),
+        ),
+      )
+    }
+
+    await invokeDreaming(agentDir, { runSession })
+
+    expect(await fileSha256(referenceFile('ref-a'))).toBe(before)
+  })
+
+  test('warns if a dreaming run rewrites reference file bytes', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLineWithReferences('with-ref', ['ref-a']))
+    await writeReference('ref-a', 'verbatim reference bytes\n')
+    const warnings: string[] = []
+    const logger: DreamingLogger = { info: () => {}, warn: (m) => warnings.push(m), error: () => {} }
+    const runSession: RunSession = async () => {
+      await writeFile(referenceFile('ref-a'), 'mutated reference bytes\n')
+    }
+
+    await invokeDreaming(agentDir, { runSession, logger })
+
+    expect(warnings).toContain(
+      '[dreaming] reference content modified: ref-a — this violates the verbatim invariant; reference content must never be rewritten',
+    )
   })
 
   test('revert preserves byte-identical shard content for unchanged shards and deletes net-new shards', async () => {

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -653,7 +653,7 @@ describe('dreaming subagent (compaction wiring)', () => {
       await writeFile(referenceFile('ref-a'), 'mutated reference bytes\n')
     }
 
-    await invokeDreaming(agentDir, { runSession, logger })
+    await invokeDreaming(agentDir, { runSession, logger, referencesEnabled: true })
 
     expect(warnings).toContain(
       '[dreaming] reference content modified: ref-a — this violates the verbatim invariant; reference content must never be rewritten',

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -18,8 +18,10 @@ import {
 } from './dreaming'
 import { addDreamedIds, DREAMING_STATE_FILE, emptyState, getDreamedIds, loadDreamingState } from './dreaming-state'
 import { renderShard } from './frontmatter'
+import { parseReference, renderReference, type ReferenceFrontmatter } from './references/frontmatter'
 import { EMBEDDING_MODEL_ID } from './vector/embedder'
 import type { EmbedFn } from './vector/hybrid'
+import { referencePassages } from './vector/passages'
 import { VectorStore, type VectorRow } from './vector/store'
 
 const silentLogger: DreamingLogger = { info: () => {}, warn: () => {}, error: () => {} }
@@ -64,6 +66,27 @@ async function writeTopicShard(slug: string, text: string): Promise<void> {
 async function writeReference(slug: string, text: string): Promise<void> {
   await mkdir(join(agentDir, 'memory', 'references'), { recursive: true })
   await writeFile(referenceFile(slug), text)
+}
+
+function referenceText(overrides: Partial<ReferenceFrontmatter> = {}, body = 'reference body'): string {
+  const created = overrides.created ?? isoDaysAgo(1)
+  return renderReference(
+    {
+      title: overrides.title ?? 'Reference',
+      origin: overrides.origin ?? 'episode',
+      created,
+      lastAccessed: overrides.lastAccessed ?? created,
+      accessCount: overrides.accessCount ?? 0,
+      pinned: overrides.pinned ?? false,
+      demoted: overrides.demoted ?? false,
+      tags: overrides.tags ?? [],
+    },
+    body,
+  )
+}
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString()
 }
 
 async function fileSha256(path: string): Promise<string> {
@@ -635,6 +658,111 @@ describe('dreaming subagent (compaction wiring)', () => {
     )
   })
 
+  test('demotes stale episode references before deleting them and removes chunks from reference passages', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLine('tick'))
+    await writeReference('stale-ref', referenceText({ created: isoDaysAgo(40), lastAccessed: isoDaysAgo(40) }))
+
+    await invokeDreaming(agentDir)
+
+    const raw = await readFile(referenceFile('stale-ref'), 'utf8')
+    expect(parseReference(raw).frontmatter.demoted).toBe(true)
+    expect(await referencePassages(agentDir)).toEqual([])
+  })
+
+  test('deletes demoted references only after the extended dormancy window', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLine('first'))
+    await writeReference('stale-ref', referenceText({ created: isoDaysAgo(40), lastAccessed: isoDaysAgo(40) }))
+
+    await invokeDreaming(agentDir)
+    expect(parseReference(await readFile(referenceFile('stale-ref'), 'utf8')).frontmatter.demoted).toBe(true)
+
+    await writeFile(streamFile('2026-04-28'), fragmentLine('second'))
+    await invokeDreaming(agentDir)
+
+    await expect(readFile(referenceFile('stale-ref'), 'utf8')).rejects.toThrow()
+  })
+
+  test('exempts pinned, curated, and external references from automatic decay', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLine('tick'))
+    await writeReference(
+      'pinned-ref',
+      referenceText({ created: isoDaysAgo(90), lastAccessed: isoDaysAgo(90), pinned: true }),
+    )
+    await writeReference(
+      'curated-ref',
+      referenceText({ created: isoDaysAgo(90), lastAccessed: isoDaysAgo(90), origin: 'curated' }),
+    )
+    await writeReference(
+      'external-ref',
+      referenceText({ created: isoDaysAgo(90), lastAccessed: isoDaysAgo(90), origin: 'external' }),
+    )
+
+    await invokeDreaming(agentDir)
+
+    expect(parseReference(await readFile(referenceFile('pinned-ref'), 'utf8')).frontmatter.demoted).toBe(false)
+    expect(parseReference(await readFile(referenceFile('curated-ref'), 'utf8')).frontmatter.demoted).toBe(false)
+    expect(parseReference(await readFile(referenceFile('external-ref'), 'utf8')).frontmatter.demoted).toBe(false)
+  })
+
+  test('recent access keeps an old episode reference above the decay threshold', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLine('tick'))
+    await writeReference(
+      'recent-ref',
+      referenceText({ created: isoDaysAgo(90), lastAccessed: new Date().toISOString() }),
+    )
+
+    await invokeDreaming(agentDir)
+
+    expect(parseReference(await readFile(referenceFile('recent-ref'), 'utf8')).frontmatter.demoted).toBe(false)
+  })
+
+  test('eviction removes reference files, vectors, and upward topic citations', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLine('tick'))
+    await writeReference(
+      'ref-x',
+      referenceText({ created: isoDaysAgo(60), lastAccessed: isoDaysAgo(60), demoted: true }),
+    )
+    await writeTopicShard(
+      'with-ref',
+      shardText(
+        'With ref',
+        ['Conclusion.', '', 'references:', '- ref-x', '', 'fragments:', '- streams/2026-04-27#f-tick'].join('\n'),
+      ),
+    )
+    const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+    store.upsert(vectorRow('reference:ref-x#0', 'reference', 'ref-x', vector({ 0: 1 }), 'ref-hash'))
+    store.close()
+
+    await invokeDreaming(agentDir)
+
+    await expect(readFile(referenceFile('ref-x'), 'utf8')).rejects.toThrow()
+    const topic = await readFile(topicShard('with-ref'), 'utf8')
+    expect(topic).not.toContain('ref-x')
+    const afterStore = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+    try {
+      expect(afterStore.getByIds(['reference:ref-x#0'])).toEqual([])
+    } finally {
+      afterStore.close()
+    }
+  })
+
+  test('includes reference demotion and eviction counts in the done metrics line', async () => {
+    await writeFile(streamFile('2026-04-27'), fragmentLine('tick'))
+    await writeReference('demote-me', referenceText({ created: isoDaysAgo(40), lastAccessed: isoDaysAgo(40) }))
+    await writeReference(
+      'evict-me',
+      referenceText({ created: isoDaysAgo(60), lastAccessed: isoDaysAgo(60), demoted: true }),
+    )
+    const infos: string[] = []
+    const logger: DreamingLogger = { info: (m) => infos.push(m), warn: () => {}, error: () => {} }
+
+    await invokeDreaming(agentDir, { logger })
+
+    const done = infos.find((m) => m.startsWith('[dreaming] done'))
+    expect(done).toContain('references_demoted=1')
+    expect(done).toContain('references_evicted=1')
+  })
+
   test('revert preserves byte-identical shard content for unchanged shards and deletes net-new shards', async () => {
     await writeFile(streamFile('2026-04-27'), [fragmentLine('keep'), fragmentLine('drop')].join(''))
     const stable = shardText('Stable', ['Stable.', '', 'fragments:', '- streams/2026-04-27#f-keep'].join('\n'), {
@@ -1168,7 +1296,7 @@ describe('dreaming subagent (orchestration)', () => {
 
 function vectorRow(
   id: string,
-  source: 'topic' | 'stream',
+  source: 'topic' | 'stream' | 'reference',
   key: string,
   embedding: Float32Array,
   contentHash: string,

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -144,12 +144,14 @@ async function invokeDreaming(
     runSession?: RunSession
     throwOnRunSession?: boolean
     vectorEmbedFn?: EmbedFn
+    referencesEnabled?: boolean
   } = {},
 ): Promise<{ prompts: string[] }> {
   const subagent = createDreamingSubagent({
     commitMemory: options.commitMemory ?? (async () => {}),
     logger: options.logger ?? silentLogger,
     ...(options.vectorEmbedFn !== undefined ? { vectorEmbedFn: options.vectorEmbedFn } : {}),
+    ...(options.referencesEnabled !== undefined ? { referencesEnabled: options.referencesEnabled } : {}),
   })
   const captured = captureRunSession()
   const runSession = options.throwOnRunSession
@@ -662,7 +664,7 @@ describe('dreaming subagent (compaction wiring)', () => {
     await writeFile(streamFile('2026-04-27'), fragmentLine('tick'))
     await writeReference('stale-ref', referenceText({ created: isoDaysAgo(40), lastAccessed: isoDaysAgo(40) }))
 
-    await invokeDreaming(agentDir)
+    await invokeDreaming(agentDir, { referencesEnabled: true })
 
     const raw = await readFile(referenceFile('stale-ref'), 'utf8')
     expect(parseReference(raw).frontmatter.demoted).toBe(true)
@@ -673,11 +675,11 @@ describe('dreaming subagent (compaction wiring)', () => {
     await writeFile(streamFile('2026-04-27'), fragmentLine('first'))
     await writeReference('stale-ref', referenceText({ created: isoDaysAgo(40), lastAccessed: isoDaysAgo(40) }))
 
-    await invokeDreaming(agentDir)
+    await invokeDreaming(agentDir, { referencesEnabled: true })
     expect(parseReference(await readFile(referenceFile('stale-ref'), 'utf8')).frontmatter.demoted).toBe(true)
 
     await writeFile(streamFile('2026-04-28'), fragmentLine('second'))
-    await invokeDreaming(agentDir)
+    await invokeDreaming(agentDir, { referencesEnabled: true })
 
     await expect(readFile(referenceFile('stale-ref'), 'utf8')).rejects.toThrow()
   })
@@ -733,7 +735,7 @@ describe('dreaming subagent (compaction wiring)', () => {
     store.upsert(vectorRow('reference:ref-x#0', 'reference', 'ref-x', vector({ 0: 1 }), 'ref-hash'))
     store.close()
 
-    await invokeDreaming(agentDir)
+    await invokeDreaming(agentDir, { referencesEnabled: true })
 
     await expect(readFile(referenceFile('ref-x'), 'utf8')).rejects.toThrow()
     const topic = await readFile(topicShard('with-ref'), 'utf8')
@@ -756,7 +758,7 @@ describe('dreaming subagent (compaction wiring)', () => {
     const infos: string[] = []
     const logger: DreamingLogger = { info: (m) => infos.push(m), warn: () => {}, error: () => {} }
 
-    await invokeDreaming(agentDir, { logger })
+    await invokeDreaming(agentDir, { logger, referencesEnabled: true })
 
     const done = infos.find((m) => m.startsWith('[dreaming] done'))
     expect(done).toContain('references_demoted=1')

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -644,19 +644,29 @@ describe('dreaming subagent (compaction wiring)', () => {
     expect(await fileSha256(referenceFile('ref-a'))).toBe(before)
   })
 
-  test('warns if a dreaming run rewrites reference file bytes', async () => {
+  test('restores reference bytes and skips commit if a dreaming run rewrites them', async () => {
     await writeFile(streamFile('2026-04-27'), fragmentLineWithReferences('with-ref', ['ref-a']))
     await writeReference('ref-a', 'verbatim reference bytes\n')
     const warnings: string[] = []
+    let committed = false
     const logger: DreamingLogger = { info: () => {}, warn: (m) => warnings.push(m), error: () => {} }
     const runSession: RunSession = async () => {
       await writeFile(referenceFile('ref-a'), 'mutated reference bytes\n')
     }
 
-    await invokeDreaming(agentDir, { runSession, logger, referencesEnabled: true })
+    await invokeDreaming(agentDir, {
+      runSession,
+      logger,
+      referencesEnabled: true,
+      commitMemory: async () => {
+        committed = true
+      },
+    })
 
+    expect(await readFile(referenceFile('ref-a'), 'utf8')).toBe('verbatim reference bytes\n')
+    expect(committed).toBe(false)
     expect(warnings).toContain(
-      '[dreaming] reference content modified: ref-a — this violates the verbatim invariant; reference content must never be rewritten',
+      '[dreaming] reference content modified: ref-a — restored original bytes and aborted the dreaming commit to preserve the verbatim invariant',
     )
   })
 

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import { z } from 'zod'
@@ -24,6 +24,8 @@ import {
 import { parseShard, renderShard, type ShardFrontmatter } from './frontmatter'
 import { listShardSlugs, loadAllShards, loadShard, type TopicShard } from './load-shards'
 import { referencesDir, streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
+import { renderReference } from './references/frontmatter'
+import { loadAllReferences, type Reference } from './references/load-references'
 import { captureShardSnapshot, restoreShardSnapshot } from './shard-snapshot'
 import type { StreamEvent } from './stream-events'
 import { readEvents, writeEventsAtomic } from './stream-io'
@@ -34,6 +36,10 @@ import { VectorStore } from './vector/store'
 import { estimateTokens, TEXT_TOKEN_BUDGET } from './vector/truncation'
 
 const STREAM_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.jsonl$/
+const REFERENCE_HALF_LIFE_DAYS = 14
+const REFERENCE_DEMOTE_SCORE_THRESHOLD = 0.1
+const REFERENCE_DELETE_DORMANCY_DAYS = 30
+const MS_PER_DAY = 86_400_000
 
 export const dreamingPayloadSchema = z.object({
   agentDir: z.string().min(1),
@@ -306,6 +312,146 @@ function deleteStreamVectorsForDroppedFragments(agentDir: string, droppedFragmen
   } finally {
     store.close()
   }
+}
+
+type ReferenceSaturationStats = {
+  referencesDemoted: number
+  referencesEvicted: number
+}
+
+async function runReferenceSaturationPass(agentDir: string, logger: DreamingLogger): Promise<ReferenceSaturationStats> {
+  const references = await loadAllReferences(agentDir, { logger })
+  const nowMs = Date.now()
+  const evictedSlugs: string[] = []
+  let referencesDemoted = 0
+  let referencesEvicted = 0
+
+  for (const ref of references) {
+    if (isReferenceDecayExempt(ref)) continue
+
+    if (ref.frontmatter.demoted && referenceDormancyDays(ref, nowMs) > REFERENCE_DELETE_DORMANCY_DAYS) {
+      await unlink(ref.path)
+      evictedSlugs.push(ref.slug)
+      referencesEvicted += 1
+      continue
+    }
+
+    if (!ref.frontmatter.demoted && referenceScore(ref, nowMs) < REFERENCE_DEMOTE_SCORE_THRESHOLD) {
+      await writeFile(ref.path, renderReference({ ...ref.frontmatter, demoted: true }, ref.body))
+      referencesDemoted += 1
+    }
+  }
+
+  if (evictedSlugs.length > 0) {
+    deleteReferenceVectors(agentDir, evictedSlugs)
+    await pruneReferenceCitations(agentDir, new Set(evictedSlugs), logger)
+  }
+
+  return { referencesDemoted, referencesEvicted }
+}
+
+function isReferenceDecayExempt(ref: Reference): boolean {
+  return ref.frontmatter.pinned || ref.frontmatter.origin === 'curated' || ref.frontmatter.origin === 'external'
+}
+
+function referenceScore(ref: Reference, nowMs: number): number {
+  const recencyDays = referenceDormancyDays(ref, nowMs)
+  return (ref.frontmatter.accessCount + 1) * Math.exp(-recencyDays / REFERENCE_HALF_LIFE_DAYS)
+}
+
+function referenceDormancyDays(ref: Reference, nowMs: number): number {
+  const lastAccessedMs = new Date(ref.frontmatter.lastAccessed).getTime()
+  if (!Number.isFinite(lastAccessedMs)) return Number.POSITIVE_INFINITY
+  return Math.max(0, (nowMs - lastAccessedMs) / MS_PER_DAY)
+}
+
+function deleteReferenceVectors(agentDir: string, slugs: readonly string[]): void {
+  const dbPath = join(agentDir, 'memory', '.vectors', 'index.db')
+  if (!existsSync(dbPath)) return
+
+  const prefixes = slugs.map((slug) => `reference:${slug}#`)
+  const store = VectorStore.open(dbPath)
+  try {
+    const ids = store
+      .getAllMeta()
+      .flatMap((row) => (prefixes.some((prefix) => row.id.startsWith(prefix)) ? [row.id] : []))
+    if (ids.length > 0) store.deleteMany(ids)
+  } finally {
+    store.close()
+  }
+}
+
+async function pruneReferenceCitations(
+  agentDir: string,
+  evictedSlugs: ReadonlySet<string>,
+  logger: DreamingLogger,
+): Promise<void> {
+  const slugs = await listShardSlugs(agentDir)
+  for (const slug of slugs) {
+    const path = topicShardPath(agentDir, slug)
+    let raw: string
+    try {
+      raw = await readFile(path, 'utf8')
+    } catch (err) {
+      if (isEnoent(err)) continue
+      throw err
+    }
+
+    const parsed = parseShardTolerantly(raw, slug, logger)
+    const prunedBody = pruneReferenceSection(parsed.body, evictedSlugs)
+    if (prunedBody === parsed.body) continue
+    await writeFile(path, renderShard(parsed.frontmatter, prunedBody))
+  }
+}
+
+function pruneReferenceSection(body: string, evictedSlugs: ReadonlySet<string>): string {
+  const lines = body.split('\n')
+  const out: string[] = []
+  let referencesHeadingIndex: number | null = null
+  let referencesKept = 0
+  let inReferences = false
+
+  const flushEmptyReferencesHeading = (): void => {
+    if (referencesHeadingIndex !== null && referencesKept === 0) {
+      out.splice(referencesHeadingIndex, out.length - referencesHeadingIndex)
+    }
+    referencesHeadingIndex = null
+    referencesKept = 0
+  }
+
+  for (const line of lines) {
+    if (/^references\s*:\s*$/i.test(line.trim())) {
+      flushEmptyReferencesHeading()
+      inReferences = true
+      referencesHeadingIndex = out.length
+      referencesKept = 0
+      out.push(line)
+      continue
+    }
+
+    if (inReferences && isMarkdownSectionHeading(line)) {
+      flushEmptyReferencesHeading()
+      inReferences = false
+    }
+
+    if (inReferences) {
+      const referenceSlug = /^\s*-\s+(.+?)\s*$/.exec(line)?.[1]
+      if (referenceSlug !== undefined) {
+        if (evictedSlugs.has(referenceSlug)) continue
+        referencesKept += 1
+      }
+    }
+
+    out.push(line)
+  }
+
+  flushEmptyReferencesHeading()
+  return out.join('\n')
+}
+
+function isMarkdownSectionHeading(line: string): boolean {
+  const trimmed = line.trim()
+  return /^(fragments|references|superseded|proposal)\s*:/i.test(trimmed) || /^#{1,6}\s+/.test(trimmed)
 }
 
 // A dreamed-AND-cited fragment's `stream:*` row is redundant: hybridSearch
@@ -1249,6 +1395,8 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
         })
       }
 
+      const { referencesDemoted, referencesEvicted } = await runReferenceSaturationPass(ctx.payload.agentDir, logger)
+
       const advanced = advanceDreamedIds(state, snapshots.undreamed)
       await saveDreamingState(ctx.payload.agentDir, advanced)
       logger.info(`[dreaming] dreamed-ids advanced days=${snapshots.undreamed.length}`)
@@ -1274,7 +1422,7 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
       try {
         await commit(ctx.payload.agentDir)
         logger.info(
-          `[dreaming] done topics_created=${metrics.topicsCreated} topics_removed=${metrics.topicsRemoved} superseded_new=${metrics.supersededDelta} fragments_dropped=${compaction.fragmentsDropped} over_budget=${overBudget.length} elapsed_ms=${Date.now() - start}`,
+          `[dreaming] done topics_created=${metrics.topicsCreated} topics_removed=${metrics.topicsRemoved} superseded_new=${metrics.supersededDelta} fragments_dropped=${compaction.fragmentsDropped} over_budget=${overBudget.length} references_demoted=${referencesDemoted} references_evicted=${referencesEvicted} elapsed_ms=${Date.now() - start}`,
         )
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
@@ -22,7 +23,7 @@ import {
 } from './dreaming-state'
 import { parseShard, renderShard, type ShardFrontmatter } from './frontmatter'
 import { listShardSlugs, loadAllShards, loadShard, type TopicShard } from './load-shards'
-import { streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
+import { referencesDir, streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
 import { captureShardSnapshot, restoreShardSnapshot } from './shard-snapshot'
 import type { StreamEvent } from './stream-events'
 import { readEvents, writeEventsAtomic } from './stream-io'
@@ -354,6 +355,41 @@ async function loadCitedIds(agentDir: string): Promise<ReadonlyMap<string, Reado
     mergeCitationIndex(out, parseCitations(shard.body))
   }
   return out
+}
+
+async function captureReferenceHashes(agentDir: string): Promise<Map<string, string>> {
+  const hashes = new Map<string, string>()
+  let names: string[]
+  try {
+    names = await readdir(referencesDir(agentDir))
+  } catch (err) {
+    if (isEnoent(err)) return hashes
+    throw err
+  }
+
+  for (const name of names.sort()) {
+    if (!name.endsWith('.md')) continue
+    const slug = basename(name, '.md')
+    const bytes = await readFile(join(referencesDir(agentDir), name))
+    hashes.set(slug, createHash('sha256').update(bytes).digest('hex'))
+  }
+  return hashes
+}
+
+async function warnOnReferenceContentChanges(
+  agentDir: string,
+  before: ReadonlyMap<string, string>,
+  logger: DreamingLogger,
+): Promise<void> {
+  if (before.size === 0) return
+  const after = await captureReferenceHashes(agentDir)
+  for (const [slug, hash] of before) {
+    const nextHash = after.get(slug)
+    if (nextHash === undefined || nextHash === hash) continue
+    logger.warn(
+      `[dreaming] reference content modified: ${slug} — this violates the verbatim invariant; reference content must never be rewritten`,
+    )
+  }
 }
 
 function mergeCitationIndex(target: Map<string, Set<string>>, source: ReadonlyMap<string, ReadonlySet<string>>): void {
@@ -792,6 +828,15 @@ A fragment with no useful content (a watermark-only marker, a near-duplicate, a 
 
 **8. Compact the over-budget shards the run flags.** If the user prompt includes an "Over the embedding budget" table, those shards are too long for the embedding model: their tail is truncated and never contributes to semantic retrieval. Rewrite each flagged shard's body into the compact one-belief-sentence form (rule 6) so the whole shard fits. **This is a prose-tightening task, never a citation-dropping one:** keep every \`fragments:\` and \`superseded:\` id exactly as-is — shrink only the explanatory prose around them. If one shard genuinely holds two distinct beliefs, split it into two shards and carry each fragment id to the shard whose belief it supports (the union of the two shards' citations must still cover every original id — the citation-superset invariant reverts the whole run otherwise, and a reverted shard stays over budget). Never drop a citation to save tokens; the deterministic embed-time bound already prevents silent loss, so a flagged shard losing a citation would be strictly worse than leaving it long.
 
+**9. References are verbatim artifacts — never edit their content.** When a fragment you consolidate carries a \`references:\` field listing reference slugs, carry those slugs up into the topic shard's body under a \`references:\` section (union semantics, same as \`fragments:\`). Use this format:
+
+\`\`\`
+references:
+- <slug>
+\`\`\`
+
+The reference files under \`memory/references/\` are verbatim artifacts. You MUST NOT read, rewrite, or distill their content. You may only cite them by slug. On eviction (Phase 4), citations are pruned — but that is a separate pass, not your concern here.
+
 # What a topic shard looks like
 
 \`\`\`
@@ -808,11 +853,14 @@ tags: []
 fragments:
 - streams/yyyy-MM-dd#<fragment-id>
 
+references:
+- <reference-slug>
+
 superseded:
 - streams/yyyy-MM-dd#<overturned-fragment-id>
 \`\`\`
 
-The \`superseded:\` list is OPTIONAL — include it only when a later fragment overturned earlier evidence (see rule 5). Ids under it stay cited (GC keeps them alive) but are excluded from retrieval, so a superseded "uses bun" fragment never resurfaces against the current "uses pnpm" belief. The file shape is YAML frontmatter plus body. The runtime owns frontmatter: do not spend effort making \`cites\`, \`days\`, or \`lastReinforced\` correct. To create a new topic, \`write memory/topics/<slug>.md\` with frontmatter containing \`heading\`, \`cites: 0\`, \`days: 0\`, \`lastReinforced\` (placeholder), optional \`tags\`, plus body; or omit frontmatter entirely — the runtime synthesizes it. If existing frontmatter is present, leave its semantics alone; the runtime will replace it with computed values.
+The \`references:\` list is OPTIONAL — include it only when a consolidated fragment carried reference slugs (see rule 9). The \`superseded:\` list is OPTIONAL — include it only when a later fragment overturned earlier evidence (see rule 5). Ids under it stay cited (GC keeps them alive) but are excluded from retrieval, so a superseded "uses bun" fragment never resurfaces against the current "uses pnpm" belief. The file shape is YAML frontmatter plus body. The runtime owns frontmatter: do not spend effort making \`cites\`, \`days\`, or \`lastReinforced\` correct. To create a new topic, \`write memory/topics/<slug>.md\` with frontmatter containing \`heading\`, \`cites: 0\`, \`days: 0\`, \`lastReinforced\` (placeholder), optional \`tags\`, plus body; or omit frontmatter entirely — the runtime synthesizes it. If existing frontmatter is present, leave its semantics alone; the runtime will replace it with computed values.
 
 # Topic shard operations
 
@@ -1123,6 +1171,7 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
       )
 
       const snapshotBefore = await captureShardSnapshot(topicsDir(ctx.payload.agentDir))
+      const referenceHashesBefore = await captureReferenceHashes(ctx.payload.agentDir)
       const strengths = await loadTopicStrengths(ctx.payload.agentDir)
 
       // Over-budget compaction candidates only matter when the vector index
@@ -1143,6 +1192,7 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
       }
 
       const snapshotAfter = await captureShardSnapshot(topicsDir(ctx.payload.agentDir))
+      await warnOnReferenceContentChanges(ctx.payload.agentDir, referenceHashesBefore, logger)
       let shardsRewrittenThisRun = !shardSnapshotsEqual(snapshotBefore, snapshotAfter)
       let revertedCitationViolation = false
 

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -356,7 +356,14 @@ function isReferenceDecayExempt(ref: Reference): boolean {
 
 function referenceScore(ref: Reference, nowMs: number): number {
   const recencyDays = referenceDormancyDays(ref, nowMs)
-  return (ref.frontmatter.accessCount + 1) * Math.exp(-recencyDays / REFERENCE_HALF_LIFE_DAYS)
+  const ageDays = Math.max(0, (nowMs - new Date(ref.frontmatter.created).getTime()) / MS_PER_DAY)
+  // Combined decay: access-recency dominates, age provides a floor decay
+  // score = (accessCount + 1) * exp(-recencyDays / halfLife) * exp(-ageDays / (halfLife * 4))
+  return (
+    (ref.frontmatter.accessCount + 1) *
+    Math.exp(-recencyDays / REFERENCE_HALF_LIFE_DAYS) *
+    Math.exp(-ageDays / (REFERENCE_HALF_LIFE_DAYS * 4))
+  )
 }
 
 function referenceDormancyDays(ref: Reference, nowMs: number): number {
@@ -1285,12 +1292,14 @@ export type CreateDreamingSubagentOptions = {
   commitMemory?: (cwd: string) => Promise<void>
   logger?: DreamingLogger
   vectorEmbedFn?: EmbedFn
+  referencesEnabled?: boolean
 }
 
 export function createDreamingSubagent(options: CreateDreamingSubagentOptions = {}): Subagent<DreamingPayload> {
   const commit = options.commitMemory ?? commitMemorySnapshot
   const logger = options.logger ?? consoleLogger
   const vectorEmbedFn = options.vectorEmbedFn ?? embed
+  const referencesEnabled = options.referencesEnabled ?? false
 
   return {
     systemPrompt: DREAMING_SYSTEM_PROMPT,
@@ -1395,7 +1404,9 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
         })
       }
 
-      const { referencesDemoted, referencesEvicted } = await runReferenceSaturationPass(ctx.payload.agentDir, logger)
+      const { referencesDemoted, referencesEvicted } = referencesEnabled
+        ? await runReferenceSaturationPass(ctx.payload.agentDir, logger)
+        : { referencesDemoted: 0, referencesEvicted: 0 }
 
       const advanced = advanceDreamedIds(state, snapshots.undreamed)
       await saveDreamingState(ctx.payload.agentDir, advanced)

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -510,13 +510,18 @@ async function loadCitedIds(agentDir: string): Promise<ReadonlyMap<string, Reado
   return out
 }
 
-async function captureReferenceHashes(agentDir: string): Promise<Map<string, string>> {
-  const hashes = new Map<string, string>()
+type ReferenceSnapshotEntry = {
+  bytes: Buffer
+  hash: string
+}
+
+async function captureReferenceSnapshot(agentDir: string): Promise<Map<string, ReferenceSnapshotEntry>> {
+  const snapshot = new Map<string, ReferenceSnapshotEntry>()
   let names: string[]
   try {
     names = await readdir(referencesDir(agentDir))
   } catch (err) {
-    if (isEnoent(err)) return hashes
+    if (isEnoent(err)) return snapshot
     throw err
   }
 
@@ -524,25 +529,30 @@ async function captureReferenceHashes(agentDir: string): Promise<Map<string, str
     if (!name.endsWith('.md')) continue
     const slug = basename(name, '.md')
     const bytes = await readFile(join(referencesDir(agentDir), name))
-    hashes.set(slug, createHash('sha256').update(bytes).digest('hex'))
+    snapshot.set(slug, { bytes, hash: createHash('sha256').update(bytes).digest('hex') })
   }
-  return hashes
+  return snapshot
 }
 
-async function warnOnReferenceContentChanges(
+async function restoreChangedReferences(
   agentDir: string,
-  before: ReadonlyMap<string, string>,
+  before: ReadonlyMap<string, ReferenceSnapshotEntry>,
   logger: DreamingLogger,
-): Promise<void> {
-  if (before.size === 0) return
-  const after = await captureReferenceHashes(agentDir)
-  for (const [slug, hash] of before) {
-    const nextHash = after.get(slug)
-    if (nextHash === undefined || nextHash === hash) continue
+): Promise<boolean> {
+  if (before.size === 0) return false
+  const after = await captureReferenceSnapshot(agentDir)
+  let restored = false
+  for (const [slug, entry] of before) {
+    const next = after.get(slug)
+    if (next?.hash === entry.hash) continue
+    await mkdir(referencesDir(agentDir), { recursive: true })
+    await writeFile(join(referencesDir(agentDir), `${slug}.md`), entry.bytes)
+    restored = true
     logger.warn(
-      `[dreaming] reference content modified: ${slug} — this violates the verbatim invariant; reference content must never be rewritten`,
+      `[dreaming] reference content modified: ${slug} — restored original bytes and aborted the dreaming commit to preserve the verbatim invariant`,
     )
   }
+  return restored
 }
 
 function mergeCitationIndex(target: Map<string, Set<string>>, source: ReadonlyMap<string, ReadonlySet<string>>): void {
@@ -1326,9 +1336,9 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
       )
 
       const snapshotBefore = await captureShardSnapshot(topicsDir(ctx.payload.agentDir))
-      const referenceHashesBefore = referencesEnabled
-        ? await captureReferenceHashes(ctx.payload.agentDir)
-        : new Map<string, string>()
+      const referenceSnapshotBefore = referencesEnabled
+        ? await captureReferenceSnapshot(ctx.payload.agentDir)
+        : new Map<string, ReferenceSnapshotEntry>()
       const strengths = await loadTopicStrengths(ctx.payload.agentDir)
 
       // Over-budget compaction candidates only matter when the vector index
@@ -1350,7 +1360,8 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
 
       const snapshotAfter = await captureShardSnapshot(topicsDir(ctx.payload.agentDir))
       if (referencesEnabled) {
-        await warnOnReferenceContentChanges(ctx.payload.agentDir, referenceHashesBefore, logger)
+        const restoredReferences = await restoreChangedReferences(ctx.payload.agentDir, referenceSnapshotBefore, logger)
+        if (restoredReferences) return
       }
       let shardsRewrittenThisRun = !shardSnapshotsEqual(snapshotBefore, snapshotAfter)
       let revertedCitationViolation = false

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -1326,7 +1326,9 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
       )
 
       const snapshotBefore = await captureShardSnapshot(topicsDir(ctx.payload.agentDir))
-      const referenceHashesBefore = await captureReferenceHashes(ctx.payload.agentDir)
+      const referenceHashesBefore = referencesEnabled
+        ? await captureReferenceHashes(ctx.payload.agentDir)
+        : new Map<string, string>()
       const strengths = await loadTopicStrengths(ctx.payload.agentDir)
 
       // Over-budget compaction candidates only matter when the vector index
@@ -1347,7 +1349,9 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
       }
 
       const snapshotAfter = await captureShardSnapshot(topicsDir(ctx.payload.agentDir))
-      await warnOnReferenceContentChanges(ctx.payload.agentDir, referenceHashesBefore, logger)
+      if (referencesEnabled) {
+        await warnOnReferenceContentChanges(ctx.payload.agentDir, referenceHashesBefore, logger)
+      }
       let shardsRewrittenThisRun = !shardSnapshotsEqual(snapshotBefore, snapshotAfter)
       let revertedCitationViolation = false
 

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -53,6 +53,7 @@ describe('vector session.turn.start hook', () => {
       agentDir,
       10,
       expect.any(Function),
+      false,
     )
     expect(retrievalContext.results).toContain('# Memory')
     expect(retrievalContext.results).toContain('## Second Topic')

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -396,13 +396,17 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
         subagents: {
           'memory-logger': createMemoryLoggerSubagent({
             logger: subagentLogger,
+            referencesEnabled: ctx.config.references.enabled,
             ...(appendVectorStore !== undefined ? { onFragmentsAppended: makeAppendHook(appendVectorStore) } : {}),
           }),
           'memory-retrieval': createMemoryRetrievalSubagent({
             logger: subagentLogger,
             timeoutMs: retrievalSpawnTimeoutMs,
           }),
-          dreaming: createDreamingSubagent({ logger: subagentLogger }),
+          dreaming: createDreamingSubagent({
+            logger: subagentLogger,
+            referencesEnabled: ctx.config.references.enabled,
+          }),
         },
         tools: {
           memory_search: memorySearchTool,

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -22,7 +22,7 @@ import { loadAllShards } from './load-shards'
 import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-logger'
 import { createMemoryRetrievalSubagent, type MemoryRetrievalPayload } from './memory-retrieval'
 import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
-import { memorySearchTool } from './search-tool'
+import { createMemorySearchTool } from './search-tool'
 import { type InjectedShardState, partitionDirectShards } from './turn-dedup'
 import { vectorConfigSchema } from './vector/config'
 import { runVectorIndexDoctor } from './vector/doctor'
@@ -409,7 +409,7 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
           }),
         },
         tools: {
-          memory_search: memorySearchTool,
+          memory_search: createMemorySearchTool(ctx.config.references.enabled),
         },
         cronJobs: {
           dreaming: {

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -104,6 +104,12 @@ const dreamingConfigSchema = z.object({
     .optional(),
 })
 
+const referencesConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+  })
+  .default({ enabled: false })
+
 // `bufferBytes` is a size-based ceiling on top of the `idleMs` debounce. In
 // busy channel sessions the agent rarely goes idle long enough to trip the
 // timer, so memory-logger needs a second trigger that responds to accumulated
@@ -134,6 +140,7 @@ const memoryConfigSchema = z
     // in milliseconds instead of the production 30s.
     retrievalSpawnTimeoutMs: z.number().int().min(1).default(RETRIEVAL_SPAWN_TIMEOUT_MS),
     dreaming: dreamingConfigSchema.optional(),
+    references: referencesConfigSchema,
     vector: vectorConfigSchema,
   })
   .default({
@@ -143,6 +150,7 @@ const memoryConfigSchema = z
     minIdleDeltaLines: DEFAULT_MIN_IDLE_DELTA_LINES,
     spawnTimeoutMs: SPAWN_TIMEOUT_MS,
     retrievalSpawnTimeoutMs: RETRIEVAL_SPAWN_TIMEOUT_MS,
+    references: { enabled: false },
     vector: { enabled: false },
   })
 

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -186,6 +186,7 @@ async function renderVectorTurnMemory(
   injectedState: InjectedShardState,
   deps: MemoryPluginDeps,
   logger?: { info: (msg: string) => void },
+  referencesEnabled = false,
 ): Promise<string> {
   const plan = await loadMemoryInjectionPlan(event.agentDir, { injectionBudgetBytes })
   const isChannel = event.origin?.kind === 'channel'
@@ -207,6 +208,7 @@ async function renderVectorTurnMemory(
       event.agentDir,
       VECTOR_TURN_TOP_K,
       deps.queryEmbedFn,
+      referencesEnabled,
     )
     const topicHits = results.reduce((n, r) => (r.source === 'topic' ? n + 1 : n), 0)
     logger?.info(
@@ -402,6 +404,7 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
           'memory-retrieval': createMemoryRetrievalSubagent({
             logger: subagentLogger,
             timeoutMs: retrievalSpawnTimeoutMs,
+            referencesEnabled: ctx.config.references.enabled,
           }),
           dreaming: createDreamingSubagent({
             logger: subagentLogger,
@@ -502,6 +505,7 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
                   injectedState,
                   deps,
                   ctx.logger,
+                  ctx.config.references.enabled,
                 )
               } catch (err) {
                 ctx.logger.error(`vector-retrieval failed: ${err instanceof Error ? err.message : String(err)}`)
@@ -665,10 +669,11 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
           'vector-index': {
             description: 'vector index is consistent with memory (only when memory.vector is enabled)',
             run: async (dctx) => {
-              if (!vectorEnabled(dctx.config)) {
+              const config = dctx.config as typeof ctx.config
+              if (!vectorEnabled(config)) {
                 return { status: 'ok', message: 'vector memory not enabled; skipping index health check' }
               }
-              return runVectorIndexDoctor(dctx.agentDir)
+              return runVectorIndexDoctor(dctx.agentDir, config.references?.enabled ?? false)
             },
           },
         },

--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -95,7 +95,12 @@ function unchangedShardReference(slug: string): string {
   return `slug: \`${slug}\` — unchanged since earlier this session; call \`memory_search({ topic: "${slug}" })\` to re-read the full body.`
 }
 
-export type RetrievedMemoryItem = { source: 'topic' | 'stream'; key: string; heading: string; excerpt: string }
+export type RetrievedMemoryItem = {
+  source: 'topic' | 'stream' | 'reference'
+  key: string
+  heading: string
+  excerpt: string
+}
 
 // Over-budget vector turns inject the top-K relevant memories (not all shards).
 // Same `# Memory` framing + channel-bleed boundary as the direct path, so the
@@ -118,7 +123,7 @@ export function renderRetrievedMemorySection(
     lines.push(`## ${item.heading}`, '')
     if (!isChannel) {
       lines.push(item.excerpt.trimEnd(), '')
-    } else if (item.source === 'topic') {
+    } else if (item.source === 'topic' || item.source === 'reference') {
       lines.push(`slug: \`${item.key}\``, '')
     } else {
       lines.push(

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -15,6 +15,10 @@ import {
   memoryLoggerSubagent,
   type MemoryLoggerPayload,
 } from './memory-logger'
+import { streamFilePath } from './paths'
+import { parseReference } from './references/frontmatter'
+import { storeReferenceTool } from './references/store-reference-tool'
+import { readEvents } from './stream-io'
 
 const silentLogger: MemoryLoggerLogger = { info: () => {}, warn: () => {}, error: () => {} }
 const silentSubagent = createMemoryLoggerSubagent({ logger: silentLogger })
@@ -252,14 +256,15 @@ describe('memoryLoggerSubagent', () => {
     expect(memoryLoggerSubagent.systemPrompt).toBe(MEMORY_LOGGER_SYSTEM_PROMPT)
   })
 
-  test('declares one built-in tool (read) and three custom tools (find_entry, append, watermark advance)', () => {
+  test('declares one built-in tool (read) and four custom tools (find_entry, append, store_reference, watermark advance)', () => {
     expect(memoryLoggerSubagent.tools).toBeDefined()
     expect(memoryLoggerSubagent.tools!.length).toBe(1)
     expect(memoryLoggerSubagent.customTools).toBeDefined()
-    expect(memoryLoggerSubagent.customTools!.length).toBe(3)
+    expect(memoryLoggerSubagent.customTools!.length).toBe(4)
     const descriptions = memoryLoggerSubagent.customTools!.map((t) => t.description)
     expect(descriptions.some((d) => d.includes('Locate a session-transcript entry'))).toBe(true)
     expect(descriptions.some((d) => d.includes('Append a memory fragment'))).toBe(true)
+    expect(descriptions.some((d) => d.includes('store_reference'))).toBe(true)
     expect(descriptions.some((d) => d.includes('Advance the daily-stream watermark'))).toBe(true)
   })
 
@@ -591,7 +596,63 @@ describe('memoryLoggerSubagent', () => {
     expect(existsSync(join(agentDir, 'memory', 'streams', `${today}.jsonl`))).toBe(true)
   })
 
+  test('run can store a verbatim reference and append a fragment citing it', async () => {
+    const agentDir = makeAgentDir()
+    const sql = 'SELECT * FROM users WHERE id = 1'
+    const transcript = join(agentDir, 'sessions', 'ses_abc.jsonl')
+    writeFileSync(
+      transcript,
+      `${JSON.stringify({ id: 'entry_sql', role: 'user', text: `remember this query verbatim: ${sql}` })}\n`,
+    )
+
+    const runSession: RunSession = async () => {
+      const stored = await storeReferenceTool.execute(
+        { title: 'User lookup query', body: sql, origin: 'episode', tags: [] },
+        toolCtx(agentDir),
+      )
+      const slug = (stored.details as { slug: string }).slug
+      await appendTool.execute(
+        {
+          topic: 'verbatim reference stored',
+          body: 'The user explicitly asked to remember the user lookup SQL query verbatim.',
+          source: 'ses_abc',
+          entry: 'entry_sql',
+          latestEntryId: 'entry_sql',
+          references: [slug],
+        },
+        toolCtx(agentDir),
+      )
+    }
+    const ctx: SubagentContext<MemoryLoggerPayload> = {
+      userPrompt: '',
+      agentDir,
+      payload: { parentSessionId: 'ses_abc', parentTranscriptPath: transcript, agentDir },
+    }
+
+    await silentSubagent.handler!(ctx, runSession)
+
+    const referenceText = readFileSync(join(agentDir, 'memory', 'references', 'user-lookup-query.md'), 'utf8')
+    expect(parseReference(referenceText).body).toBe(sql)
+    const events = await readEvents(streamFilePath(agentDir, formatLocalDate()))
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'fragment',
+        topic: 'verbatim reference stored',
+        references: ['user-lookup-query'],
+      }),
+    )
+  })
+
   test('the default exported memoryLoggerSubagent still has a handler (back-compat)', () => {
     expect(memoryLoggerSubagent.handler).toBeDefined()
   })
 })
+
+function toolCtx(agentDir: string) {
+  return {
+    signal: undefined,
+    sessionId: 'test',
+    agentDir,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  }
+}

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -256,16 +256,23 @@ describe('memoryLoggerSubagent', () => {
     expect(memoryLoggerSubagent.systemPrompt).toBe(MEMORY_LOGGER_SYSTEM_PROMPT)
   })
 
-  test('declares one built-in tool (read) and four custom tools (find_entry, append, store_reference, watermark advance)', () => {
+  test('declares one built-in tool (read) and three custom tools by default (find_entry, append, watermark advance)', () => {
     expect(memoryLoggerSubagent.tools).toBeDefined()
     expect(memoryLoggerSubagent.tools!.length).toBe(1)
     expect(memoryLoggerSubagent.customTools).toBeDefined()
-    expect(memoryLoggerSubagent.customTools!.length).toBe(4)
+    expect(memoryLoggerSubagent.customTools!.length).toBe(3)
     const descriptions = memoryLoggerSubagent.customTools!.map((t) => t.description)
     expect(descriptions.some((d) => d.includes('Locate a session-transcript entry'))).toBe(true)
     expect(descriptions.some((d) => d.includes('Append a memory fragment'))).toBe(true)
-    expect(descriptions.some((d) => d.includes('store_reference'))).toBe(true)
     expect(descriptions.some((d) => d.includes('Advance the daily-stream watermark'))).toBe(true)
+  })
+
+  test('includes store_reference tool when referencesEnabled is true', () => {
+    const subagentWithReferences = createMemoryLoggerSubagent({ referencesEnabled: true })
+    expect(subagentWithReferences.customTools).toBeDefined()
+    expect(subagentWithReferences.customTools!.length).toBe(4)
+    const descriptions = subagentWithReferences.customTools!.map((t) => t.description)
+    expect(descriptions.some((d) => d.includes('store_reference'))).toBe(true)
   })
 
   test('declares a defensive tool-result byte budget on the read tool so a malfunctioning find_entry cannot cause unbounded chunked reads', () => {

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -312,6 +312,7 @@ const consoleLogger: MemoryLoggerLogger = {
 export type CreateMemoryLoggerSubagentOptions = {
   logger?: MemoryLoggerLogger
   onFragmentsAppended?: FragmentsAppendedHook
+  referencesEnabled?: boolean
 }
 
 export function createMemoryLoggerSubagent(
@@ -320,6 +321,10 @@ export function createMemoryLoggerSubagent(
   const logger = options.logger ?? consoleLogger
   const appendTool = createAppendTool(options.onFragmentsAppended)
   const storeReferenceTool = createStoreReferenceTool()
+  const customTools =
+    options.referencesEnabled === true
+      ? [findEntryTool, appendTool, storeReferenceTool, advanceWatermarkTool]
+      : [findEntryTool, appendTool, advanceWatermarkTool]
   return {
     systemPrompt: MEMORY_LOGGER_SYSTEM_PROMPT,
     // Logging is "read transcript past the watermark, decide 0-N fragments,
@@ -330,7 +335,7 @@ export function createMemoryLoggerSubagent(
     // falls back to `default` with a one-time warning when unconfigured.
     profile: 'fast',
     tools: [readTool],
-    customTools: [findEntryTool, appendTool, storeReferenceTool, advanceWatermarkTool],
+    customTools,
     payloadSchema: memoryLoggerPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,
     // 768 KB read budget. Sized to cover one full buffer-trip cycle:

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -7,6 +7,7 @@ import { formatLocalDate } from '@/shared'
 import { advanceWatermarkTool, createAppendTool, type FragmentsAppendedHook } from './append-tool'
 import { findEntryTool } from './find-entry-tool'
 import { streamFilePath, streamsDir } from './paths'
+import { createStoreReferenceTool } from './references/store-reference-tool'
 import { readEvents } from './stream-io'
 import { readLatestWatermark } from './watermark'
 
@@ -71,7 +72,7 @@ A separate \`dreaming\` subagent runs later. It consolidates your fragments into
 
 **You do not read \`memory/topics/\`.** Cross-shard contradictions, violations of prior commitments, and semantic dedup against long-term memory are dreaming's job — dreaming has the global view and the authoritative pipeline position to resolve them; you do not. Your input is the parent transcript past your watermark, plus (optionally) today's daily stream for local dedup. That is enough. If a fragment you would write happens to recur a fact already in topics, dreaming will consolidate it — recurrence across distinct days is the signal dreaming uses to promote tentative facts to confident ones, so writing the recurrence is the correct behavior, not a duplicate.
 
-You have exactly four tools: \`read\`, \`find_entry\`, \`append\`, and the watermark-advance tool. You cannot run shell commands, overwrite files, or edit existing content.
+You have exactly five tools: \`read\`, \`find_entry\`, \`append\`, \`store_reference\`, and the watermark-advance tool. You cannot run shell commands, overwrite files, or edit existing content.
 
 # Reading the transcript past the watermark
 
@@ -102,6 +103,16 @@ Apply the bar this way: if a fact clearly fails it, skip. If it clearly passes, 
 Two failures matter: over-writing noise, and under-writing durable one-time facts. Over-writing is the more common mistake, so keep the bar high — but once the bar is met, don't second-guess a real fact into a skip.
 
 **Explicit user teaching is not a separate tie-breaker — it is durability evidence.** A clear request to teach, train, remember, or internalize specific content is itself proof that the content is durable, so it satisfies the bar; evaluate it under the "Content the user explicitly taught the agent" category below. It satisfies durability only — it does not bypass the scope, source, safety, or passive-context limits stated there.
+
+# Verbatim references (store_reference tool)
+
+When the user explicitly asks to remember something verbatim — a SQL query, a code block, a runbook, a pasted spec — use \`store_reference\` to capture it as-is. This is separate from the fragment capture bar: references are for verbatim artifacts, not distilled facts.
+
+Call \`store_reference({ title, body, origin: 'episode', tags: [] })\` with the verbatim content. The tool returns a slug. Then, when you write the fragment for this session event (if any), include the slug in the \`references\` field of \`append\`: \`append({ ..., references: ['<slug>'] })\`.
+
+If you store a reference but have no other durable fact to fragment, you still MUST write a fragment that cites the reference — use topic "verbatim reference stored" and a one-sentence body naming what was stored. This ensures the reference is linked into the stream.
+
+Do NOT distill or summarize the reference body. Store it byte-for-byte as the user provided it.
 
 # What to capture
 
@@ -176,7 +187,7 @@ Recurrence is not duplication. If the transcript shows the same durable preferen
 
 # Fragment format
 
-Call \`append\` with \`{topic, body, source, entry, latestEntryId}\`. The runtime serializes your call into a JSON line in the daily stream — you never write raw JSON. \`source\` is the parent session id from the user message. \`entry\` is the specific transcript-entry-id this fragment anchors to. \`latestEntryId\` is the latest transcript-entry-id you evaluated in this run; it advances the watermark and may equal \`entry\` or be later.
+Call \`append\` with \`{topic, body, source, entry, latestEntryId}\` or \`{topic, body, source, entry, latestEntryId, references}\` when citing stored references. The runtime serializes your call into a JSON line in the daily stream — you never write raw JSON. \`source\` is the parent session id from the user message. \`entry\` is the specific transcript-entry-id this fragment anchors to. \`latestEntryId\` is the latest transcript-entry-id you evaluated in this run; it advances the watermark and may equal \`entry\` or be later. \`references\` is an optional array of reference slugs returned by \`store_reference\`.
 
 - \`entry\` is the stable id of the **specific** transcript entry that anchors this fragment's evidence. Each fragment carries its own entry id — do not stamp every fragment with the same "latest evaluated" id. The provenance is per-fragment.
 - \`topic\` is a short noun phrase naming what the fragment is about.
@@ -308,6 +319,7 @@ export function createMemoryLoggerSubagent(
 ): Subagent<MemoryLoggerPayload> {
   const logger = options.logger ?? consoleLogger
   const appendTool = createAppendTool(options.onFragmentsAppended)
+  const storeReferenceTool = createStoreReferenceTool()
   return {
     systemPrompt: MEMORY_LOGGER_SYSTEM_PROMPT,
     // Logging is "read transcript past the watermark, decide 0-N fragments,
@@ -318,7 +330,7 @@ export function createMemoryLoggerSubagent(
     // falls back to `default` with a one-time warning when unconfigured.
     profile: 'fast',
     tools: [readTool],
-    customTools: [findEntryTool, appendTool, advanceWatermarkTool],
+    customTools: [findEntryTool, appendTool, storeReferenceTool, advanceWatermarkTool],
     payloadSchema: memoryLoggerPayloadSchema,
     inFlightKey: (payload) => payload.agentDir,
     // 768 KB read budget. Sized to cover one full buffer-trip cycle:

--- a/src/bundled-plugins/memory/memory-retrieval.ts
+++ b/src/bundled-plugins/memory/memory-retrieval.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { lsTool, readTool, type Subagent, writeTool } from '@/plugin'
 
-import { memorySearchTool } from './search-tool'
+import { createMemorySearchTool } from './search-tool'
 
 export const memoryRetrievalPayloadSchema = z.object({
   parentSessionId: z.string().min(1),
@@ -27,6 +27,7 @@ export type MemoryRetrievalLogger = {
 export type CreateMemoryRetrievalSubagentOptions = {
   logger?: MemoryRetrievalLogger
   timeoutMs?: number
+  referencesEnabled?: boolean
 }
 
 export const MEMORY_RETRIEVAL_SYSTEM_PROMPT = `You are the memory-retrieval subagent. Read the user's most recent prompt and decide what's relevant from BOTH topic shards in \`memory/topics/\` (consolidated long-term memory) AND undreamed daily-stream events under \`memory/streams/\` (recent fragments not yet folded into shards). Use \`memory_search\` to query both surfaces; use \`read\`/\`ls\` to pull full shard bodies when needed. Synthesize a focused ≤8 KB summary of the relevant memory. Save by \`write\`ing it to the exact path provided in your payload as \`cacheFilePath\`. Be ruthlessly concise. Do NOT write anywhere else. Do NOT delete files.
@@ -55,6 +56,7 @@ export function createMemoryRetrievalSubagent(
   options: CreateMemoryRetrievalSubagentOptions = {},
 ): Subagent<MemoryRetrievalPayload> {
   const logger = options.logger ?? consoleLogger
+  const referencesEnabled = options.referencesEnabled ?? false
   return {
     systemPrompt: MEMORY_RETRIEVAL_SYSTEM_PROMPT,
     // Retrieval is "4 keyword searches + 1 write" — no reasoning required.
@@ -62,7 +64,7 @@ export function createMemoryRetrievalSubagent(
     // operator hasn't configured it, so this is safe by construction.
     profile: 'fast',
     tools: [readTool, writeTool, lsTool],
-    customTools: [memorySearchTool],
+    customTools: [createMemorySearchTool(referencesEnabled)],
     payloadSchema: memoryRetrievalPayloadSchema,
     inFlightKey: (payload) => payload.parentSessionId,
     ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),

--- a/src/bundled-plugins/memory/paths.ts
+++ b/src/bundled-plugins/memory/paths.ts
@@ -6,6 +6,7 @@ export const MEMORY_DIR = 'memory'
 export const TOPICS_SUBDIR = 'topics'
 export const STREAMS_SUBDIR = 'streams'
 export const SKILLS_SUBDIR = 'skills'
+export const REFERENCES_SUBDIR = 'references'
 export const PRE_SHARD_BACKUP_FILENAME = 'MEMORY.md.pre-shard.bak'
 export const MIGRATING_TMPDIR = 'memory/.migrating'
 
@@ -13,6 +14,10 @@ const STREAM_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
 export function topicsDir(agentDir: string): string {
   return join(agentDir, MEMORY_DIR, TOPICS_SUBDIR)
+}
+
+export function referencesDir(agentDir: string): string {
+  return join(agentDir, MEMORY_DIR, REFERENCES_SUBDIR)
 }
 
 export function streamsDir(agentDir: string): string {
@@ -24,6 +29,13 @@ export function topicShardPath(agentDir: string, slug: string): string {
     throw new Error(`invalid topic slug: ${JSON.stringify(slug)}`)
   }
   return join(agentDir, MEMORY_DIR, TOPICS_SUBDIR, `${slug}.md`)
+}
+
+export function referenceFilePath(agentDir: string, slug: string): string {
+  if (slug.includes('..') || slug.includes('/') || slug.includes('\\') || slug.startsWith('.')) {
+    throw new Error(`invalid reference slug: ${JSON.stringify(slug)}`)
+  }
+  return join(agentDir, MEMORY_DIR, REFERENCES_SUBDIR, `${slug}.md`)
 }
 
 export function streamFilePath(agentDir: string, date: string): string {

--- a/src/bundled-plugins/memory/references/frontmatter.test.ts
+++ b/src/bundled-plugins/memory/references/frontmatter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseReference, renderReference } from './frontmatter'
+
+describe('reference frontmatter', () => {
+  test('parse and render round-trips a fully-specified reference byte-identically', () => {
+    const text = `---
+title: Debugging transcript
+origin: episode
+created: 2026-06-12T14:03:00+09:00
+lastAccessed: 2026-06-13T09:10:00+09:00
+accessCount: 3
+pinned: false
+demoted: false
+tags: [debugging, transcript]
+---
+Verbatim body.
+`
+
+    const { frontmatter, body } = parseReference(text)
+
+    expect(renderReference(frontmatter, body)).toBe(text)
+  })
+
+  test('runtime-owned fields default when only author-owned fields are present', () => {
+    const text = `---
+title: Deployment checklist
+origin: curated
+created: 2026-06-12T14:03:00+09:00
+pinned: true
+tags: []
+---
+Keep this exact text.
+`
+
+    const { frontmatter, body } = parseReference(text)
+
+    expect(frontmatter).toEqual({
+      title: 'Deployment checklist',
+      origin: 'curated',
+      created: '2026-06-12T14:03:00+09:00',
+      lastAccessed: '2026-06-12T14:03:00+09:00',
+      accessCount: 0,
+      pinned: true,
+      demoted: false,
+      tags: [],
+    })
+    expect(body).toBe('Keep this exact text.\n')
+  })
+})

--- a/src/bundled-plugins/memory/references/frontmatter.ts
+++ b/src/bundled-plugins/memory/references/frontmatter.ts
@@ -1,0 +1,197 @@
+export type ReferenceOrigin = 'episode' | 'curated' | 'external'
+
+export type ReferenceFrontmatter = {
+  title: string
+  origin: ReferenceOrigin
+  created: string
+  lastAccessed: string
+  accessCount: number
+  pinned: boolean
+  demoted: boolean
+  tags: string[]
+}
+
+const ORIGINS = new Set<ReferenceOrigin>(['episode', 'curated', 'external'])
+const ISO_WITH_TIMEZONE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/
+
+export function parseReference(text: string): { frontmatter: ReferenceFrontmatter; body: string } {
+  const normalized = text.replaceAll('\r\n', '\n')
+
+  if (!normalized.startsWith('---\n')) {
+    throw new Error('frontmatter delimiter missing')
+  }
+
+  const closeIndex = normalized.indexOf('\n---', 4)
+  if (closeIndex === -1) {
+    throw new Error('frontmatter delimiter missing')
+  }
+
+  const fmText = normalized.slice(4, closeIndex)
+  const body = normalized.slice(closeIndex + 5)
+
+  const frontmatter = parseFrontmatterBlock(fmText)
+  return { frontmatter, body }
+}
+
+export function renderReference(frontmatter: ReferenceFrontmatter, body: string): string {
+  const lines = ['---']
+  lines.push(`title: ${frontmatter.title}`)
+  lines.push(`origin: ${frontmatter.origin}`)
+  lines.push(`created: ${frontmatter.created}`)
+  lines.push(`lastAccessed: ${frontmatter.lastAccessed}`)
+  lines.push(`accessCount: ${frontmatter.accessCount}`)
+  lines.push(`pinned: ${frontmatter.pinned}`)
+  lines.push(`demoted: ${frontmatter.demoted}`)
+  if (frontmatter.tags.length === 0) {
+    lines.push('tags: []')
+  } else {
+    lines.push(`tags: [${frontmatter.tags.join(', ')}]`)
+  }
+  lines.push('---')
+  lines.push(body)
+  return lines.join('\n')
+}
+
+function parseFrontmatterBlock(text: string): ReferenceFrontmatter {
+  const lines = text.split('\n')
+  const values: Record<string, unknown> = {}
+
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+    if (line.trim() === '') {
+      i++
+      continue
+    }
+
+    const colonIndex = line.indexOf(':')
+    if (colonIndex === -1) {
+      i++
+      continue
+    }
+
+    const key = line.slice(0, colonIndex).trim()
+    const rest = line.slice(colonIndex + 1).trim()
+
+    if (key === 'tags') {
+      if (rest === '') {
+        const listItems: string[] = []
+        i++
+        while (i < lines.length) {
+          const listLine = lines[i]!
+          if (!listLine.startsWith('  - ')) break
+          listItems.push(listLine.slice(4).trim())
+          i++
+        }
+        values.tags = listItems
+        continue
+      }
+      if (rest.startsWith('[') && rest.endsWith(']')) {
+        values.tags = rest
+          .slice(1, -1)
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+        i++
+        continue
+      }
+      throw new Error(`frontmatter field 'tags': expected array, got '${rest}'`)
+    }
+
+    if (key in FRONTMATTER_PARSERS) {
+      try {
+        values[key] = FRONTMATTER_PARSERS[key as keyof typeof FRONTMATTER_PARSERS](rest)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        throw new Error(`frontmatter field '${key}': ${message}`)
+      }
+    } else {
+      throw new Error(`frontmatter field '${key}': unknown`)
+    }
+
+    i++
+  }
+
+  return buildReferenceFrontmatter(values)
+}
+
+const FRONTMATTER_PARSERS = {
+  title: (v: string) => v,
+  origin: parseOrigin,
+  created: parseIsoWithTimezone,
+  lastAccessed: parseIsoWithTimezone,
+  accessCount: parseNonNegativeInt,
+  pinned: parseBoolean,
+  demoted: parseBoolean,
+}
+
+function buildReferenceFrontmatter(values: Record<string, unknown>): ReferenceFrontmatter {
+  const title = values.title
+  if (typeof title !== 'string' || title.length === 0) {
+    throw new Error("frontmatter field 'title': required")
+  }
+
+  const origin = values.origin
+  if (!isReferenceOrigin(origin)) {
+    throw new Error(`frontmatter field 'origin': expected episode | curated | external, got '${values.origin}'`)
+  }
+
+  const created = values.created
+  if (typeof created !== 'string') {
+    throw new Error(`frontmatter field 'created': expected ISO 8601 datetime with timezone, got '${values.created}'`)
+  }
+
+  const pinned = values.pinned
+  if (typeof pinned !== 'boolean') {
+    throw new Error(`frontmatter field 'pinned': expected boolean, got '${values.pinned}'`)
+  }
+
+  const tags = values.tags
+  if (!Array.isArray(tags) || !tags.every((tag) => typeof tag === 'string')) {
+    throw new Error(`frontmatter field 'tags': expected array, got '${values.tags}'`)
+  }
+
+  return {
+    title,
+    origin,
+    created,
+    lastAccessed: typeof values.lastAccessed === 'string' ? values.lastAccessed : created,
+    accessCount: typeof values.accessCount === 'number' ? values.accessCount : 0,
+    pinned,
+    demoted: typeof values.demoted === 'boolean' ? values.demoted : false,
+    tags,
+  }
+}
+
+function parseOrigin(value: string): ReferenceOrigin {
+  if (!isReferenceOrigin(value)) {
+    throw new Error(`expected episode | curated | external, got '${value}'`)
+  }
+  return value
+}
+
+function parseIsoWithTimezone(value: string): string {
+  if (!ISO_WITH_TIMEZONE_REGEX.test(value)) {
+    throw new Error(`expected ISO 8601 datetime with timezone, got '${value}'`)
+  }
+  return value
+}
+
+function parseNonNegativeInt(value: string): number {
+  const trimmed = value.trim()
+  const num = Number(trimmed)
+  if (!Number.isInteger(num) || String(num) !== trimmed || num < 0) {
+    throw new Error(`expected non-negative integer, got '${value}'`)
+  }
+  return num
+}
+
+function parseBoolean(value: string): boolean {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  throw new Error(`expected boolean, got '${value}'`)
+}
+
+function isReferenceOrigin(value: unknown): value is ReferenceOrigin {
+  return typeof value === 'string' && ORIGINS.has(value as ReferenceOrigin)
+}

--- a/src/bundled-plugins/memory/references/load-references.test.ts
+++ b/src/bundled-plugins/memory/references/load-references.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { referenceFilePath, referencesDir } from '../paths'
+import { __resetReferenceCacheForTests, loadAllReferences } from './load-references'
+
+const tmpRoots: string[] = []
+
+beforeEach(() => {
+  __resetReferenceCacheForTests()
+})
+
+afterEach(async () => {
+  await Promise.all(tmpRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+  __resetReferenceCacheForTests()
+})
+
+describe('loadAllReferences', () => {
+  test('missing references dir returns empty array', async () => {
+    const agentDir = await makeAgentDir()
+
+    await expect(loadAllReferences(agentDir)).resolves.toEqual([])
+  })
+
+  test('loads references sorted by slug with parsed bodies', async () => {
+    const agentDir = await makeAgentDir()
+    await writeReference(agentDir, 'zebra', 'Zebra reference', 'zebra body\n')
+    await writeReference(agentDir, 'alpha', 'Alpha reference', 'alpha body\n')
+
+    const references = await loadAllReferences(agentDir)
+
+    expect(references.map((reference) => reference.slug)).toEqual(['alpha', 'zebra'])
+    expect(references.map((reference) => reference.body)).toEqual(['alpha body\n', 'zebra body\n'])
+    expect(references[0]?.path).toBe(referenceFilePath(agentDir, 'alpha'))
+  })
+
+  test('returns the cached array when file stats are unchanged', async () => {
+    const agentDir = await makeAgentDir()
+    await writeReference(agentDir, 'alpha', 'Alpha reference', 'alpha body\n')
+
+    const first = await loadAllReferences(agentDir)
+    const second = await loadAllReferences(agentDir)
+
+    expect(second).toBe(first)
+    expect(second[0]).toBe(first[0])
+  })
+})
+
+async function makeAgentDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-reference-test-'))
+  tmpRoots.push(dir)
+  return dir
+}
+
+async function writeReference(agentDir: string, slug: string, title: string, body: string): Promise<void> {
+  await mkdir(referencesDir(agentDir), { recursive: true })
+  await writeFile(referenceFilePath(agentDir, slug), referenceText(title, body), 'utf8')
+}
+
+function referenceText(title: string, body: string): string {
+  return `---
+title: ${title}
+origin: episode
+created: 2026-06-12T14:03:00+09:00
+lastAccessed: 2026-06-13T09:10:00+09:00
+accessCount: 3
+pinned: false
+demoted: false
+tags: []
+---
+${body}`
+}

--- a/src/bundled-plugins/memory/references/load-references.ts
+++ b/src/bundled-plugins/memory/references/load-references.ts
@@ -103,7 +103,7 @@ async function resolveReference(
   return { kind: 'read', slug, reference, entry }
 }
 
-async function listReferenceSlugs(agentDir: string): Promise<string[]> {
+export async function listReferenceSlugs(agentDir: string): Promise<string[]> {
   let names: string[]
   try {
     names = await readdir(referencesDir(agentDir))

--- a/src/bundled-plugins/memory/references/load-references.ts
+++ b/src/bundled-plugins/memory/references/load-references.ts
@@ -1,0 +1,170 @@
+import { readdir, readFile, stat } from 'node:fs/promises'
+
+import { referenceFilePath, referencesDir } from '../paths'
+import { parseReference, type ReferenceFrontmatter } from './frontmatter'
+
+export type Reference = {
+  path: string
+  slug: string
+  frontmatter: ReferenceFrontmatter
+  body: string
+}
+
+type Logger = { warn(message: string): void }
+
+type ReferenceCacheEntry = {
+  mtimeMs: number
+  ctimeMs: number
+  size: number
+  reference: Reference | null
+}
+
+type AgentReferenceCache = {
+  entries: Map<string, ReferenceCacheEntry>
+  lastSlugs: string[] | null
+  lastReferences: Reference[] | null
+}
+
+const referenceCache = new Map<string, AgentReferenceCache>()
+
+export async function loadAllReferences(agentDir: string, options: { logger?: Logger } = {}): Promise<Reference[]> {
+  const slugs = await listReferenceSlugs(agentDir)
+  const cache = getOrCreateCache(agentDir)
+  const outcomes = await Promise.all(slugs.map((slug) => resolveReference(agentDir, slug, cache.entries, options)))
+
+  const references: Reference[] = []
+  const seen = new Set<string>()
+  let changed = !sameSlugs(slugs, cache.lastSlugs)
+
+  for (const outcome of outcomes) {
+    seen.add(outcome.slug)
+    if (outcome.kind === 'missing') {
+      changed = true
+      cache.entries.delete(outcome.slug)
+      continue
+    }
+    if (outcome.kind === 'read') {
+      changed = true
+      cache.entries.set(outcome.slug, outcome.entry)
+    }
+    if (outcome.reference !== null) references.push(outcome.reference)
+  }
+
+  for (const slug of cache.entries.keys()) {
+    if (!seen.has(slug)) {
+      changed = true
+      cache.entries.delete(slug)
+    }
+  }
+
+  if (!changed && cache.lastReferences !== null) return cache.lastReferences
+
+  cache.lastSlugs = slugs
+  cache.lastReferences = references
+  return references
+}
+
+export function __resetReferenceCacheForTests(): void {
+  referenceCache.clear()
+}
+
+type ReferenceOutcome =
+  | { kind: 'missing'; slug: string }
+  | { kind: 'cached'; slug: string; reference: Reference | null }
+  | { kind: 'read'; slug: string; reference: Reference | null; entry: ReferenceCacheEntry }
+
+async function resolveReference(
+  agentDir: string,
+  slug: string,
+  cache: Map<string, ReferenceCacheEntry>,
+  options: { logger?: Logger },
+): Promise<ReferenceOutcome> {
+  const path = referenceFilePath(agentDir, slug)
+  const fileStat = await statReference(path)
+  if (fileStat === null) return { kind: 'missing', slug }
+
+  const cached = cache.get(slug)
+  if (
+    cached !== undefined &&
+    cached.mtimeMs === fileStat.mtimeMs &&
+    cached.ctimeMs === fileStat.ctimeMs &&
+    cached.size === fileStat.size
+  ) {
+    return { kind: 'cached', slug, reference: cached.reference }
+  }
+
+  const reference = await readAndParseReference(path, slug, options)
+  const entry: ReferenceCacheEntry = {
+    mtimeMs: fileStat.mtimeMs,
+    ctimeMs: fileStat.ctimeMs,
+    size: fileStat.size,
+    reference,
+  }
+  return { kind: 'read', slug, reference, entry }
+}
+
+async function listReferenceSlugs(agentDir: string): Promise<string[]> {
+  let names: string[]
+  try {
+    names = await readdir(referencesDir(agentDir))
+  } catch (err) {
+    if (isEnoent(err)) return []
+    throw err
+  }
+
+  return names
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => name.slice(0, -'.md'.length))
+    .sort()
+}
+
+async function readAndParseReference(
+  path: string,
+  slug: string,
+  options: { logger?: Logger },
+): Promise<Reference | null> {
+  let text: string
+  try {
+    text = await readFile(path, 'utf8')
+  } catch (err) {
+    if (isEnoent(err)) return null
+    throw err
+  }
+
+  try {
+    const { frontmatter, body } = parseReference(text)
+    return { path, slug, frontmatter, body }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    const logger = options.logger ?? console
+    logger.warn(`[memory] skipping malformed reference ${slug}: ${message}`)
+    return null
+  }
+}
+
+async function statReference(path: string): Promise<{ mtimeMs: number; ctimeMs: number; size: number } | null> {
+  try {
+    const s = await stat(path)
+    return { mtimeMs: s.mtimeMs, ctimeMs: s.ctimeMs, size: s.size }
+  } catch (err) {
+    if (isEnoent(err)) return null
+    throw err
+  }
+}
+
+function getOrCreateCache(agentDir: string): AgentReferenceCache {
+  let cache = referenceCache.get(agentDir)
+  if (cache === undefined) {
+    cache = { entries: new Map(), lastSlugs: null, lastReferences: null }
+    referenceCache.set(agentDir, cache)
+  }
+  return cache
+}
+
+function sameSlugs(slugs: string[], previous: string[] | null): boolean {
+  return previous !== null && slugs.length === previous.length && slugs.every((slug, index) => slug === previous[index])
+}
+
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT'
+}

--- a/src/bundled-plugins/memory/references/store-reference-tool.test.ts
+++ b/src/bundled-plugins/memory/references/store-reference-tool.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { ToolContext } from '@/plugin'
+
+import { referenceFilePath, streamsDir } from '../paths'
+import { readEvents } from '../stream-io'
+import { parseReference } from './frontmatter'
+import { storeReferenceTool } from './store-reference-tool'
+
+describe('storeReferenceTool', () => {
+  test('stores a verbatim multi-line SQL reference and returns its slug', async () => {
+    const agentDir = await makeAgentDir()
+    const body = ['SELECT *', 'FROM users', 'WHERE id = 1;'].join('\n')
+
+    const result = await storeReferenceTool.execute(
+      { title: 'User lookup query', body, origin: 'episode', tags: ['sql'] },
+      ctx(agentDir),
+    )
+
+    expect(textContent(result)).toBe('Stored reference as user-lookup-query')
+    const path = referenceFilePath(agentDir, 'user-lookup-query')
+    expect(existsSync(path)).toBe(true)
+    const { frontmatter, body: storedBody } = parseReference(await readFile(path, 'utf8'))
+    expect(storedBody).toBe(body)
+    expect(frontmatter).toMatchObject({
+      title: 'User lookup query',
+      origin: 'episode',
+      accessCount: 0,
+      pinned: false,
+      demoted: false,
+      tags: ['sql'],
+    })
+    expect(frontmatter.created).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(frontmatter.lastAccessed).toBe(frontmatter.created)
+
+    await cleanup(agentDir)
+  })
+
+  test('does not write a fragment event containing the verbatim SQL body', async () => {
+    const agentDir = await makeAgentDir()
+    const body = 'SELECT * FROM users WHERE id = 1'
+
+    await storeReferenceTool.execute({ title: 'Guard query', body, origin: 'episode', tags: [] }, ctx(agentDir))
+
+    const streamNames = await listStreams(agentDir)
+    const eventsByDay = await Promise.all(streamNames.map((name) => readEvents(join(streamsDir(agentDir), name))))
+    const fragmentBodies = eventsByDay
+      .flat()
+      .filter((event) => event.type === 'fragment')
+      .map((event) => event.body)
+    expect(fragmentBodies).not.toContain(body)
+
+    await cleanup(agentDir)
+  })
+
+  test('deduplicates slug collisions for matching titles', async () => {
+    const agentDir = await makeAgentDir()
+
+    await storeReferenceTool.execute({ title: 'Same title', body: 'first', origin: 'episode', tags: [] }, ctx(agentDir))
+    const result = await storeReferenceTool.execute(
+      { title: 'Same title', body: 'second', origin: 'episode', tags: [] },
+      ctx(agentDir),
+    )
+
+    expect(textContent(result)).toBe('Stored reference as same-title-2')
+    expect(existsSync(referenceFilePath(agentDir, 'same-title'))).toBe(true)
+    expect(existsSync(referenceFilePath(agentDir, 'same-title-2'))).toBe(true)
+
+    await cleanup(agentDir)
+  })
+})
+
+function ctx(agentDir: string): ToolContext {
+  return {
+    signal: undefined,
+    sessionId: 'test',
+    agentDir,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  }
+}
+
+function textContent(result: { content: { type: string; text?: string }[] }): string | undefined {
+  return result.content.find((part) => part.type === 'text')?.text
+}
+
+async function makeAgentDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'memory-reference-tool-'))
+}
+
+async function listStreams(agentDir: string): Promise<string[]> {
+  try {
+    return await readdir(streamsDir(agentDir))
+  } catch (err) {
+    if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT') return []
+    throw err
+  }
+}
+
+async function cleanup(agentDir: string): Promise<void> {
+  await rm(agentDir, { recursive: true, force: true })
+}

--- a/src/bundled-plugins/memory/references/store-reference-tool.ts
+++ b/src/bundled-plugins/memory/references/store-reference-tool.ts
@@ -1,0 +1,55 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+
+import { z } from 'zod'
+
+import { defineTool } from '@/plugin'
+
+import { referenceFilePath, referencesDir } from '../paths'
+import { headingToSlug } from '../slug'
+import { renderReference } from './frontmatter'
+import { listReferenceSlugs } from './load-references'
+
+export const storeReferenceTool = createStoreReferenceTool()
+
+export function createStoreReferenceTool() {
+  return defineTool({
+    description:
+      'store_reference: Store a verbatim reference artifact under memory/references/ and return its slug. Use this for user-provided SQL, code blocks, runbooks, pasted specs, or other content explicitly meant to be remembered byte-for-byte. This tool does not write memory stream fragments.',
+    parameters: z.object({
+      title: z.string().min(1),
+      body: z.string(),
+      origin: z.enum(['episode', 'curated', 'external']),
+      tags: z.array(z.string()).optional(),
+    }),
+    async execute({ title, body, origin, tags }, ctx) {
+      const existingSlugs = new Set(await listReferenceSlugs(ctx.agentDir))
+      const slug = headingToSlug(title, existingSlugs)
+      const created = new Date().toISOString()
+      const path = referenceFilePath(ctx.agentDir, slug)
+
+      await mkdir(referencesDir(ctx.agentDir), { recursive: true })
+      await writeFile(
+        path,
+        renderReference(
+          {
+            title,
+            origin,
+            created,
+            lastAccessed: created,
+            accessCount: 0,
+            pinned: false,
+            demoted: false,
+            tags: tags ?? [],
+          },
+          body,
+        ),
+        'utf8',
+      )
+
+      return {
+        content: [{ type: 'text' as const, text: `Stored reference as ${slug}` }],
+        details: { path, slug },
+      }
+    },
+  })
+}

--- a/src/bundled-plugins/memory/search-tool.test.ts
+++ b/src/bundled-plugins/memory/search-tool.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,7 +7,8 @@ import type { ToolContext } from '@/plugin'
 
 import { saveDreamingState } from './dreaming-state'
 import { renderShard, type ShardFrontmatter } from './frontmatter'
-import { streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
+import { referenceFilePath, referencesDir, streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
+import { parseReference, renderReference } from './references/frontmatter'
 import { memorySearchTool } from './search-tool'
 import type { FragmentEvent, LegacyProseEvent, WatermarkEvent } from './stream-events'
 import { appendEvents } from './stream-io'
@@ -33,7 +34,18 @@ type StreamMatch = {
   fullBody?: string
 }
 
-type SearchResult = { matches: Array<TopicMatch | StreamMatch>; truncatedAt?: number } | { error: string }
+type ReferenceMatch = {
+  source: 'reference'
+  slug: string
+  title: string
+  excerpt: string
+  created: string
+  fullBody?: string
+}
+
+type SearchResult =
+  | { matches: Array<TopicMatch | StreamMatch | ReferenceMatch>; truncatedAt?: number }
+  | { error: string }
 
 afterEach(async () => {
   await Promise.all(tmpRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
@@ -294,6 +306,38 @@ describe('memorySearchTool', () => {
     await mkdir(topicsDir(agentDir), { recursive: true })
 
     await expect(call(agentDir, { query: 'anything' })).resolves.toEqual({ matches: [], truncatedAt: 0 })
+  })
+
+  test('datetime filter limits reference candidates by created time', async () => {
+    const agentDir = await makeAgentDir()
+    await writeReference(agentDir, 'ref-a', 'Fresh Reference', 'test keyword in fresh reference.\n', {
+      created: '2026-06-12T00:00:00Z',
+    })
+    await writeReference(agentDir, 'ref-b', 'Old Reference', 'test keyword in old reference.\n', {
+      created: '2026-06-10T00:00:00Z',
+    })
+
+    const result = await call(agentDir, { query: 'test', since: '2026-06-12T00:00:00Z' })
+
+    expect('matches' in result ? result.matches.map(matchKey) : []).toEqual(['reference:ref-a'])
+  })
+
+  test('reference retrieval advances lastAccessed and increments accessCount', async () => {
+    const agentDir = await makeAgentDir()
+    await writeReference(agentDir, 'ref-a', 'Reference A', 'access bump needle.\n', {
+      created: '2026-06-12T00:00:00Z',
+      lastAccessed: '2026-06-12T00:00:00Z',
+      accessCount: 2,
+    })
+
+    const result = await call(agentDir, { query: 'needle' })
+    const updated = parseReference(await readFile(referenceFilePath(agentDir, 'ref-a'), 'utf8'))
+
+    expect('matches' in result ? result.matches.map(matchKey) : []).toEqual(['reference:ref-a'])
+    expect(updated.frontmatter.accessCount).toBe(3)
+    expect(new Date(updated.frontmatter.lastAccessed).getTime()).toBeGreaterThan(
+      new Date('2026-06-12T00:00:00Z').getTime(),
+    )
   })
 })
 
@@ -582,12 +626,13 @@ describe('memorySearchTool — multi-word token fallback', () => {
   })
 })
 
-function topicSlug(m: TopicMatch | StreamMatch): string | undefined {
+function topicSlug(m: TopicMatch | StreamMatch | ReferenceMatch): string | undefined {
   return m.source === 'topic' ? m.slug : undefined
 }
 
-function matchKey(m: TopicMatch | StreamMatch): string {
+function matchKey(m: TopicMatch | StreamMatch | ReferenceMatch): string {
   if (m.source === 'topic') return `topic:${m.slug}`
+  if (m.source === 'reference') return `reference:${m.slug}`
   return `stream:${m.eventId ?? `${m.date}#legacy`}`
 }
 
@@ -660,6 +705,34 @@ async function writeShard(
 ): Promise<void> {
   await mkdir(topicsDir(agentDir), { recursive: true })
   await writeFile(topicShardPath(agentDir, slug), shardText(heading, body, patch), 'utf8')
+}
+
+async function writeReference(
+  agentDir: string,
+  slug: string,
+  title: string,
+  body: string,
+  patch: Partial<Parameters<typeof renderReference>[0]> = {},
+): Promise<void> {
+  await mkdir(referencesDir(agentDir), { recursive: true })
+  await writeFile(
+    referenceFilePath(agentDir, slug),
+    renderReference(
+      {
+        title,
+        origin: 'episode',
+        created: '2026-06-12T00:00:00Z',
+        lastAccessed: '2026-06-12T00:00:00Z',
+        accessCount: 0,
+        pinned: false,
+        demoted: false,
+        tags: [],
+        ...patch,
+      },
+      body,
+    ),
+    'utf8',
+  )
 }
 
 function shardText(heading: string, body: string, patch: Partial<ShardFrontmatter>): string {

--- a/src/bundled-plugins/memory/search-tool.test.ts
+++ b/src/bundled-plugins/memory/search-tool.test.ts
@@ -9,7 +9,7 @@ import { saveDreamingState } from './dreaming-state'
 import { renderShard, type ShardFrontmatter } from './frontmatter'
 import { referenceFilePath, referencesDir, streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
 import { parseReference, renderReference } from './references/frontmatter'
-import { memorySearchTool } from './search-tool'
+import { createMemorySearchTool } from './search-tool'
 import type { FragmentEvent, LegacyProseEvent, WatermarkEvent } from './stream-events'
 import { appendEvents } from './stream-io'
 
@@ -338,6 +338,18 @@ describe('memorySearchTool', () => {
     expect(new Date(updated.frontmatter.lastAccessed).getTime()).toBeGreaterThan(
       new Date('2026-06-12T00:00:00Z').getTime(),
     )
+  })
+
+  test('when referencesEnabled is false, reference matches are excluded even if files exist', async () => {
+    const agentDir = await makeAgentDir()
+    await writeShard(agentDir, 'topic-shard', 'Topic shard', 'needle in topic.\n')
+    await writeReference(agentDir, 'ref-a', 'Reference A', 'needle in reference.\n', {
+      created: '2026-06-12T00:00:00Z',
+    })
+
+    const result = await call(agentDir, { query: 'needle' }, false)
+
+    expect('matches' in result ? result.matches.map(matchKey) : []).toEqual(['topic:topic-shard'])
   })
 })
 
@@ -673,15 +685,21 @@ async function makeAgentDir(): Promise<string> {
   return dir
 }
 
-async function call(agentDir: string, input: unknown): Promise<SearchResult> {
-  const args = memorySearchTool.parameters.parse(input)
-  const result = await memorySearchTool.execute(args, ctx(agentDir))
+async function call(agentDir: string, input: unknown, referencesEnabled: boolean = true): Promise<SearchResult> {
+  const tool = createMemorySearchTool(referencesEnabled)
+  const args = tool.parameters.parse(input)
+  const result = await tool.execute(args, ctx(agentDir))
   return result.details as SearchResult
 }
 
-async function callRaw(agentDir: string, input: unknown): Promise<{ text: string; details: unknown }> {
-  const args = memorySearchTool.parameters.parse(input)
-  const result = await memorySearchTool.execute(args, ctx(agentDir))
+async function callRaw(
+  agentDir: string,
+  input: unknown,
+  referencesEnabled: boolean = true,
+): Promise<{ text: string; details: unknown }> {
+  const tool = createMemorySearchTool(referencesEnabled)
+  const args = tool.parameters.parse(input)
+  const result = await tool.execute(args, ctx(agentDir))
   const part = result.content[0]
   if (part === undefined || part.type !== 'text') throw new Error('expected a text content part')
   return { text: part.text, details: result.details }

--- a/src/bundled-plugins/memory/search-tool.ts
+++ b/src/bundled-plugins/memory/search-tool.ts
@@ -1,8 +1,12 @@
+import { writeFile } from 'node:fs/promises'
+
 import { z } from 'zod'
 
 import { defineTool } from '@/plugin'
 
 import { loadAllShards, loadShard, type TopicShard } from './load-shards'
+import { renderReference } from './references/frontmatter'
+import { loadAllReferences, type Reference } from './references/load-references'
 import type { FragmentEvent, LegacyProseEvent, StreamEvent } from './stream-events'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from './stream-io'
 
@@ -29,7 +33,16 @@ export type StreamMatch = {
   fullBody?: string
 }
 
-export type MemorySearchMatch = TopicMatch | StreamMatch
+export type ReferenceMatch = {
+  source: 'reference'
+  slug: string
+  title: string
+  excerpt: string
+  created: string
+  fullBody?: string
+}
+
+export type MemorySearchMatch = TopicMatch | StreamMatch | ReferenceMatch
 
 export type MemorySearchResult = { matches: MemorySearchMatch[]; truncatedAt?: number } | { error: string }
 
@@ -44,8 +57,10 @@ export const memorySearchTool = defineTool({
     asRegex: z.boolean().default(false),
     full: z.boolean().default(false),
     maxResults: z.number().int().min(0).default(DEFAULT_MAX_RESULTS),
+    since: z.string().optional(),
+    before: z.string().optional(),
   }),
-  async execute({ query, topic, asRegex, full, maxResults }, ctx) {
+  async execute({ query, topic, asRegex, full, maxResults, since, before }, ctx) {
     if ((query === undefined) === (topic === undefined)) {
       return resultToToolResult({ error: 'provide exactly one of `query` or `topic`' })
     }
@@ -59,19 +74,25 @@ export const memorySearchTool = defineTool({
       return resultToToolResult({ error: matcherOrError })
     }
 
-    const [shards, streamDays] = await Promise.all([
+    const [shards, streamDays, allReferences] = await Promise.all([
       loadAllShards(ctx.agentDir, { logger: ctx.logger }),
       readAllUndreamedStreamDays(ctx.agentDir),
+      loadAllReferences(ctx.agentDir, { logger: ctx.logger }),
     ])
-    if (shards.length === 0 && streamDays.length === 0) {
+    const dateFilter = parseReferenceDateFilter(since, before)
+    if ('error' in dateFilter) return resultToToolResult(dateFilter)
+
+    const references = allReferences.filter((reference) => referenceCandidateAllowed(reference, dateFilter))
+    if (shards.length === 0 && streamDays.length === 0 && references.length === 0) {
       return resultToToolResult({ matches: [], truncatedAt: 0 })
     }
 
-    const result = searchAll(shards, streamDays, matcherOrError, { full, maxResults })
+    let result = searchAll(shards, streamDays, matcherOrError, { full, maxResults, references })
     if ('matches' in result && result.matches.length === 0) {
-      const fallback = tokenFallback(query!, asRegex, shards, streamDays, { full, maxResults })
-      if (fallback !== null) return resultToToolResult(fallback)
+      const fallback = tokenFallback(query!, asRegex, shards, streamDays, references, { full, maxResults })
+      if (fallback !== null) result = fallback
     }
+    if ('matches' in result) await bumpReturnedReferences(allReferences, result.matches)
     return resultToToolResult(result)
   },
 })
@@ -126,13 +147,14 @@ function tokenFallback(
   asRegex: boolean,
   shards: TopicShard[],
   streamDays: UndreamedStreamDay[],
+  references: Reference[],
   options: { full: boolean; maxResults: number },
 ): MemorySearchResult | null {
   if (asRegex) return null
   const tokens = distinctTokens(query)
   if (tokens.length === 0) return null
   if (tokens.length === 1 && tokens[0] === query.trim().toLowerCase()) return null
-  return searchAllRanked(shards, streamDays, tokens, options)
+  return searchAllRanked(shards, streamDays, tokens, { ...options, references })
 }
 
 export function distinctTokens(query: string): string[] {
@@ -171,7 +193,7 @@ export function searchAll(
   shards: TopicShard[],
   streamDays: UndreamedStreamDay[],
   matcher: Matcher,
-  options: { full: boolean; maxResults: number },
+  options: { full: boolean; maxResults: number; references?: Reference[] },
 ): MemorySearchResult {
   const matches: MemorySearchMatch[] = []
   let truncatedAt: number | undefined
@@ -187,6 +209,12 @@ export function searchAll(
 
   for (const shard of shards) {
     const match = matchShard(shard, matcher, options.full)
+    if (match === null) continue
+    if (!push(match)) return { matches, truncatedAt: truncatedAt! }
+  }
+
+  for (const reference of options.references ?? []) {
+    const match = matchReference(reference, matcher, options.full)
     if (match === null) continue
     if (!push(match)) return { matches, truncatedAt: truncatedAt! }
   }
@@ -221,7 +249,12 @@ export function searchAllRanked(
   shards: TopicShard[],
   streamDays: UndreamedStreamDay[],
   tokens: string[],
-  options: { full: boolean; maxResults: number; tokenMatchMode?: 'substring' | 'ascii-boundary' },
+  options: {
+    full: boolean
+    maxResults: number
+    references?: Reference[]
+    tokenMatchMode?: 'substring' | 'ascii-boundary'
+  },
 ): MemorySearchResult {
   const tokenMatchers = tokens.map((t) => buildTokenMatcher(t, options.tokenMatchMode ?? 'substring'))
   const anyToken: Matcher = (haystack) => {
@@ -240,6 +273,12 @@ export function searchAllRanked(
     const match = matchShard(shard, anyToken, options.full)
     if (match === null) continue
     scored.push({ match, score: scoreOf(shardSearchText(shard)), order: order++ })
+  }
+
+  for (const reference of options.references ?? []) {
+    const match = matchReference(reference, anyToken, options.full)
+    if (match === null) continue
+    scored.push({ match, score: scoreOf(referenceSearchText(reference)), order: order++ })
   }
 
   for (let i = streamDays.length - 1; i >= 0; i--) {
@@ -290,6 +329,10 @@ function eventSearchText(event: StreamEvent): string {
   return ''
 }
 
+function referenceSearchText(reference: Reference): string {
+  return [reference.slug, reference.frontmatter.title, ...reference.frontmatter.tags, reference.body].join('\n')
+}
+
 function matchShard(shard: TopicShard, matcher: Matcher, full: boolean): TopicMatch | null {
   const bodyLines = splitBodyLines(shard.body)
   const firstBodyLineIndex = bodyLines.findIndex((line) => matcher(line))
@@ -310,6 +353,30 @@ function matchShard(shard: TopicShard, matcher: Matcher, full: boolean): TopicMa
       firstBodyLineIndex === -1 ? fallbackExcerpt(shard, matcher) : excerptForLine(bodyLines, firstBodyLineIndex),
   }
   if (full) match.fullBody = shard.body
+  return match
+}
+
+function matchReference(reference: Reference, matcher: Matcher, full: boolean): ReferenceMatch | null {
+  const bodyLines = splitBodyLines(reference.body)
+  const firstBodyLineIndex = bodyLines.findIndex((line) => matcher(line))
+  const matched =
+    matcher(reference.slug) ||
+    matcher(reference.frontmatter.title) ||
+    reference.frontmatter.tags.some((tag) => matcher(tag)) ||
+    firstBodyLineIndex !== -1
+  if (!matched) return null
+
+  const match: ReferenceMatch = {
+    source: 'reference',
+    slug: reference.slug,
+    title: reference.frontmatter.title,
+    excerpt:
+      firstBodyLineIndex === -1
+        ? fallbackReferenceExcerpt(reference, matcher)
+        : excerptForLine(bodyLines, firstBodyLineIndex),
+    created: reference.frontmatter.created,
+  }
+  if (full) match.fullBody = reference.body
   return match
 }
 
@@ -387,6 +454,63 @@ function fallbackExcerpt(shard: TopicShard, matcher: Matcher): string {
   if (matcher(shard.slug)) return shard.slug
   const matchedTag = shard.frontmatter.tags?.find((tag) => matcher(tag))
   return matchedTag ?? shard.frontmatter.heading
+}
+
+function fallbackReferenceExcerpt(reference: Reference, matcher: Matcher): string {
+  if (matcher(reference.frontmatter.title)) return reference.frontmatter.title
+  if (matcher(reference.slug)) return reference.slug
+  const matchedTag = reference.frontmatter.tags.find((tag) => matcher(tag))
+  return matchedTag ?? reference.frontmatter.title
+}
+
+type ReferenceDateFilter = { since?: Date; before?: Date }
+
+function parseReferenceDateFilter(
+  since: string | undefined,
+  before: string | undefined,
+): ReferenceDateFilter | { error: string } {
+  const sinceDate = since === undefined ? undefined : parseDateParam('since', since)
+  if (typeof sinceDate === 'string') return { error: sinceDate }
+  const beforeDate = before === undefined ? undefined : parseDateParam('before', before)
+  if (typeof beforeDate === 'string') return { error: beforeDate }
+  return { since: sinceDate, before: beforeDate }
+}
+
+function parseDateParam(name: string, value: string): Date | string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return `invalid ${name}: expected ISO 8601 datetime string`
+  return date
+}
+
+function referenceCandidateAllowed(reference: Reference, filter: ReferenceDateFilter): boolean {
+  if (reference.frontmatter.demoted) return false
+  const created = new Date(reference.frontmatter.created)
+  if (filter.since !== undefined && created < filter.since) return false
+  if (filter.before !== undefined && created >= filter.before) return false
+  return true
+}
+
+async function bumpReturnedReferences(references: Reference[], matches: MemorySearchMatch[]): Promise<void> {
+  const returnedSlugs = new Set(matches.filter((match) => match.source === 'reference').map((match) => match.slug))
+  if (returnedSlugs.size === 0) return
+  await Promise.all(
+    references
+      .filter((reference) => returnedSlugs.has(reference.slug))
+      .map((reference) =>
+        writeFile(
+          reference.path,
+          renderReference(
+            {
+              ...reference.frontmatter,
+              lastAccessed: new Date().toISOString(),
+              accessCount: reference.frontmatter.accessCount + 1,
+            },
+            reference.body,
+          ),
+          'utf8',
+        ),
+      ),
+  )
 }
 
 function excerptForLine(lines: string[], matchIndex: number): string {

--- a/src/bundled-plugins/memory/search-tool.ts
+++ b/src/bundled-plugins/memory/search-tool.ts
@@ -48,54 +48,61 @@ export type MemorySearchResult = { matches: MemorySearchMatch[]; truncatedAt?: n
 
 export type Matcher = (haystack: string) => boolean
 
-export const memorySearchTool = defineTool({
-  description:
-    'Search the agent\'s long-term memory, or look up one topic shard by exact slug. Covers both topic shards under memory/topics/ (consolidated facts) and undreamed daily-stream events under memory/streams/ (recent fragments not yet folded into shards). Pass `query` for search OR `topic` for an exact slug lookup, not both. Search is case-insensitive substring by default: tries the whole query as one phrase first, and if that finds nothing, falls back to OR-matching the individual words (ranked by how many words each hit contains) — so a multi-word query still returns results even when no entry contains the exact phrase. asRegex=true treats query as a JavaScript regex (no word fallback). `topic` skips search entirely and returns that one shard with its full body — use it to read a topic whose slug you already have (e.g. a heading shown in injected memory). Returns matches discriminated by `source: "topic" | "stream"`, each with line-context excerpts; full=true includes complete bodies (topic lookups always include the full body). Ordering depends on mode: exact-phrase (and regex) results list all topic matches first (alphabetical by slug), then stream matches (newest day first); word-fallback results are ranked by matched-word count, with that same topic-first/stream-newest order as the tiebreak within each score band, so a higher-scoring stream match can precede a lower-scoring topic match.',
-  parameters: z.object({
-    query: z.string().optional(),
-    topic: z.string().optional(),
-    asRegex: z.boolean().default(false),
-    full: z.boolean().default(false),
-    maxResults: z.number().int().min(0).default(DEFAULT_MAX_RESULTS),
-    since: z.string().optional(),
-    before: z.string().optional(),
-  }),
-  async execute({ query, topic, asRegex, full, maxResults, since, before }, ctx) {
-    if ((query === undefined) === (topic === undefined)) {
-      return resultToToolResult({ error: 'provide exactly one of `query` or `topic`' })
-    }
+export function createMemorySearchTool(referencesEnabled: boolean) {
+  return defineTool({
+    description:
+      'Search the agent\'s long-term memory, or look up one topic shard by exact slug. Covers both topic shards under memory/topics/ (consolidated facts) and undreamed daily-stream events under memory/streams/ (recent fragments not yet folded into shards). Pass `query` for search OR `topic` for an exact slug lookup, not both. Search is case-insensitive substring by default: tries the whole query as one phrase first, and if that finds nothing, falls back to OR-matching the individual words (ranked by how many words each hit contains) — so a multi-word query still returns results even when no entry contains the exact phrase. asRegex=true treats query as a JavaScript regex (no word fallback). `topic` skips search entirely and returns that one shard with its full body — use it to read a topic whose slug you already have (e.g. a heading shown in injected memory). Returns matches discriminated by `source: "topic" | "stream"`, each with line-context excerpts; full=true includes complete bodies (topic lookups always include the full body). Ordering depends on mode: exact-phrase (and regex) results list all topic matches first (alphabetical by slug), then stream matches (newest day first); word-fallback results are ranked by matched-word count, with that same topic-first/stream-newest order as the tiebreak within each score band, so a higher-scoring stream match can precede a lower-scoring topic match.',
+    parameters: z.object({
+      query: z.string().optional(),
+      topic: z.string().optional(),
+      asRegex: z.boolean().default(false),
+      full: z.boolean().default(false),
+      maxResults: z.number().int().min(0).default(DEFAULT_MAX_RESULTS),
+      since: z.string().optional(),
+      before: z.string().optional(),
+    }),
+    async execute({ query, topic, asRegex, full, maxResults, since, before }, ctx) {
+      if ((query === undefined) === (topic === undefined)) {
+        return resultToToolResult({ error: 'provide exactly one of `query` or `topic`' })
+      }
 
-    if (topic !== undefined) {
-      return resultToToolResult(await lookupTopic(ctx.agentDir, topic, ctx.logger))
-    }
+      if (topic !== undefined) {
+        return resultToToolResult(await lookupTopic(ctx.agentDir, topic, ctx.logger))
+      }
 
-    const matcherOrError = buildMatcher(query!, asRegex)
-    if (typeof matcherOrError === 'string') {
-      return resultToToolResult({ error: matcherOrError })
-    }
+      const matcherOrError = buildMatcher(query!, asRegex)
+      if (typeof matcherOrError === 'string') {
+        return resultToToolResult({ error: matcherOrError })
+      }
 
-    const [shards, streamDays, allReferences] = await Promise.all([
-      loadAllShards(ctx.agentDir, { logger: ctx.logger }),
-      readAllUndreamedStreamDays(ctx.agentDir),
-      loadAllReferences(ctx.agentDir, { logger: ctx.logger }),
-    ])
-    const dateFilter = parseReferenceDateFilter(since, before)
-    if ('error' in dateFilter) return resultToToolResult(dateFilter)
+      const [shards, streamDays, allReferences] = await Promise.all([
+        loadAllShards(ctx.agentDir, { logger: ctx.logger }),
+        readAllUndreamedStreamDays(ctx.agentDir),
+        referencesEnabled ? loadAllReferences(ctx.agentDir, { logger: ctx.logger }) : Promise.resolve([]),
+      ])
+      const dateFilter = parseReferenceDateFilter(since, before)
+      if ('error' in dateFilter) return resultToToolResult(dateFilter)
 
-    const references = allReferences.filter((reference) => referenceCandidateAllowed(reference, dateFilter))
-    if (shards.length === 0 && streamDays.length === 0 && references.length === 0) {
-      return resultToToolResult({ matches: [], truncatedAt: 0 })
-    }
+      const references = referencesEnabled
+        ? allReferences.filter((reference) => referenceCandidateAllowed(reference, dateFilter))
+        : []
+      if (shards.length === 0 && streamDays.length === 0 && references.length === 0) {
+        return resultToToolResult({ matches: [], truncatedAt: 0 })
+      }
 
-    let result = searchAll(shards, streamDays, matcherOrError, { full, maxResults, references })
-    if ('matches' in result && result.matches.length === 0) {
-      const fallback = tokenFallback(query!, asRegex, shards, streamDays, references, { full, maxResults })
-      if (fallback !== null) result = fallback
-    }
-    if ('matches' in result) await bumpReturnedReferences(allReferences, result.matches)
-    return resultToToolResult(result)
-  },
-})
+      let result = searchAll(shards, streamDays, matcherOrError, { full, maxResults, references })
+      if ('matches' in result && result.matches.length === 0) {
+        const fallback = tokenFallback(query!, asRegex, shards, streamDays, references, { full, maxResults })
+        if (fallback !== null) result = fallback
+      }
+      if ('matches' in result && referencesEnabled) await bumpReturnedReferences(allReferences, result.matches)
+      return resultToToolResult(result)
+    },
+  })
+}
+
+// Backward compatibility: default to references enabled
+export const memorySearchTool = createMemorySearchTool(true)
 
 // Exact slug lookup, so the agent can read a topic whose slug the per-turn
 // injection already showed it without re-running a fuzzy search for a body the

--- a/src/bundled-plugins/memory/stream-events.ts
+++ b/src/bundled-plugins/memory/stream-events.ts
@@ -39,6 +39,7 @@ export const fragmentEventSchema = z
     entry: z.string(),
     topic: z.string(),
     body: z.string(),
+    references: z.array(z.string()).optional(),
   })
   .passthrough()
 

--- a/src/bundled-plugins/memory/vector/doctor.ts
+++ b/src/bundled-plugins/memory/vector/doctor.ts
@@ -10,7 +10,7 @@ import { VectorStore } from './store'
 
 export const VECTOR_INDEX_REL_PATH = join('memory', '.vectors', 'index.db')
 
-export async function runVectorIndexDoctor(agentDir: string): Promise<PluginCheckResult> {
+export async function runVectorIndexDoctor(agentDir: string, referencesEnabled = false): Promise<PluginCheckResult> {
   const dbPath = join(agentDir, VECTOR_INDEX_REL_PATH)
 
   if (!existsSync(dbPath)) {
@@ -26,7 +26,7 @@ export async function runVectorIndexDoctor(agentDir: string): Promise<PluginChec
     return corruptionResult(dbPath, finding)
   }
 
-  const passages = await collectPassages(agentDir)
+  const passages = await collectPassages(agentDir, referencesEnabled)
   const wantedIds = new Set(passages.map((passage) => passage.id))
   const orphans = finding.rowIds.filter((id) => !wantedIds.has(id))
   const backfillCount = countBackfill(dbPath, passages)

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { renderShard } from '../frontmatter'
+import { renderReference } from '../references/frontmatter'
 import { EMBEDDING_MODEL_ID } from './embedder'
 import { hybridSearch, type EmbedFn } from './hybrid'
 import { VectorStore, type VectorRow } from './store'
@@ -247,6 +248,21 @@ describe('hybridSearch', () => {
       // then it resolves to itself as a stream result
       const hit = results.find((result) => result.source === 'stream')
       expect(hit?.key).toBe(`2026-06-11#${fragmentId}`)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('collapses a matched reference chunk to its parent reference', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeReference(agentDir, 'ref-a', 'Reference A', 'The reference body mentions a sardonyx deployment runbook.')
+      store.upsert(row('reference:ref-a#0', 'ref-a', vector({ 0: 1 }), 'reference'))
+
+      const results = await hybridSearch('sardonyx deployment', store, agentDir, 5, embedFrom({ 0: 1 }))
+
+      expect(results).toContainEqual(expect.objectContaining({ source: 'reference', key: 'ref-a' }))
+      expect(results.map((result) => result.key)).not.toContain('ref-a#0')
     } finally {
       store.close()
     }
@@ -597,6 +613,7 @@ function createFixture(): { agentDir: string; store: VectorStore } {
   const agentDir = join(tmpdir(), `typeclaw-hybrid-${randomUUID()}`)
   testDirs.push(agentDir)
   mkdirSync(join(agentDir, 'memory', 'topics'), { recursive: true })
+  mkdirSync(join(agentDir, 'memory', 'references'), { recursive: true })
   const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
   return { agentDir, store }
 }
@@ -605,6 +622,25 @@ function writeTopic(agentDir: string, slug: string, heading: string, body: strin
   writeFileSync(
     join(agentDir, 'memory', 'topics', `${slug}.md`),
     renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
+  )
+}
+
+function writeReference(agentDir: string, slug: string, title: string, body: string): void {
+  writeFileSync(
+    join(agentDir, 'memory', 'references', `${slug}.md`),
+    renderReference(
+      {
+        title,
+        origin: 'episode',
+        created: '2026-06-10T00:00:00Z',
+        lastAccessed: '2026-06-10T00:00:00Z',
+        accessCount: 0,
+        pinned: false,
+        demoted: false,
+        tags: [],
+      },
+      body,
+    ),
   )
 }
 
@@ -639,7 +675,7 @@ function row(
   id: string,
   key: string,
   embedding: Float32Array,
-  source: 'topic' | 'stream' = 'topic',
+  source: 'topic' | 'stream' | 'reference' = 'topic',
 ): Omit<VectorRow, 'updatedAt'> {
   return {
     id,

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -259,7 +259,7 @@ describe('hybridSearch', () => {
       writeReference(agentDir, 'ref-a', 'Reference A', 'The reference body mentions a sardonyx deployment runbook.')
       store.upsert(row('reference:ref-a#0', 'ref-a', vector({ 0: 1 }), 'reference'))
 
-      const results = await hybridSearch('sardonyx deployment', store, agentDir, 5, embedFrom({ 0: 1 }))
+      const results = await hybridSearch('sardonyx deployment', store, agentDir, 5, embedFrom({ 0: 1 }), true)
 
       expect(results).toContainEqual(expect.objectContaining({ source: 'reference', key: 'ref-a' }))
       expect(results.map((result) => result.key)).not.toContain('ref-a#0')

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -39,13 +39,14 @@ export async function hybridSearch(
   agentDir: string,
   topK: number,
   embedFn: EmbedFn = embed,
+  referencesEnabled = false,
 ): Promise<HybridSearchResult[]> {
   if (topK <= 0) return []
 
   const [shards, streamDays, references, queryEmbeddings] = await Promise.all([
     loadAllShards(agentDir),
     readAllUndreamedStreamDays(agentDir),
-    loadAllReferences(agentDir),
+    referencesEnabled ? loadAllReferences(agentDir) : Promise.resolve([]),
     embedFn([query], 'query'),
   ])
 

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 
 import { loadAllShards, type TopicShard } from '../load-shards'
 import { buildParentLinks } from '../parent-link'
+import { loadAllReferences, type Reference } from '../references/load-references'
 import {
   buildMatcher,
   distinctTokens,
@@ -23,7 +24,7 @@ export { collectPassages, findMissingPassages, type Passage } from './passages'
 const RRF_K = 60
 
 export type HybridSearchResult = {
-  source: 'topic' | 'stream'
+  source: 'topic' | 'stream' | 'reference'
   key: string
   heading: string
   excerpt: string
@@ -41,16 +42,17 @@ export async function hybridSearch(
 ): Promise<HybridSearchResult[]> {
   if (topK <= 0) return []
 
-  const [shards, streamDays, queryEmbeddings] = await Promise.all([
+  const [shards, streamDays, references, queryEmbeddings] = await Promise.all([
     loadAllShards(agentDir),
     readAllUndreamedStreamDays(agentDir),
+    loadAllReferences(agentDir),
     embedFn([query], 'query'),
   ])
 
   const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
-  const index = buildContentIndex(shards, streamDays, supersededFragmentIds)
+  const index = buildContentIndex(shards, streamDays, references, supersededFragmentIds)
   const vectorRows = queryEmbeddings[0] === undefined ? [] : gatedVectorLane(queryEmbeddings[0], store, topK)
-  const keywordMatches = keywordLane(query, shards, streamDays, topK * 2)
+  const keywordMatches = keywordLane(query, shards, streamDays, references, topK * 2)
 
   return fuseLanes(vectorRows, keywordMatches, index, parentSlugsByFragmentId).slice(0, topK)
 }
@@ -79,15 +81,15 @@ export async function hybridSearch(
 // lane that found nothing, so a genuine keyword hit survives a full no-match.
 function gatedVectorLane(queryEmbedding: Float32Array, store: VectorStore, topK: number): VectorRow[] {
   const scored = store.queryScored(queryEmbedding, EMBEDDING_MODEL_ID)
-  const topicRows = scored.filter(({ row }) => row.source === 'topic')
+  const bandDefiningRows = scored.filter(({ row }) => row.source === 'topic' || row.source === 'reference')
   const streamRows = scored.filter(({ row }) => row.source === 'stream')
 
-  const topicScores = topicRows.map(({ score }) => score)
-  const keptTopics = topicRows.slice(0, gateRelevance(topicScores, topK * 2))
-  const streamBaseline = streamAdmissionBaseline(topicScores)
+  const bandScores = bandDefiningRows.map(({ score }) => score)
+  const keptBandDefiningRows = bandDefiningRows.slice(0, gateRelevance(bandScores, topK * 2))
+  const streamBaseline = streamAdmissionBaseline(bandScores)
   const keptStreams = streamRows.filter(({ score }) => clearsBaseline(score, streamBaseline)).slice(0, topK * 2)
 
-  return [...keptTopics, ...keptStreams].sort((a, b) => b.score - a.score).map(({ row }) => row)
+  return [...keptBandDefiningRows, ...keptStreams].sort((a, b) => b.score - a.score).map(({ row }) => row)
 }
 
 // Phrase-first, then token-OR fallback (mirrors `memory_search`). `hybridSearch`'s
@@ -99,11 +101,12 @@ function keywordLane(
   query: string,
   shards: TopicShard[],
   streamDays: UndreamedStreamDay[],
+  references: Reference[],
   maxResults: number,
 ): MemorySearchMatch[] {
   const matcher = buildMatcher(query, false)
   if (typeof matcher === 'string') return []
-  const phrase = searchAll(shards, streamDays, matcher, { full: false, maxResults })
+  const phrase = searchAll(shards, streamDays, matcher, { full: false, maxResults, references })
   const phraseMatches = 'matches' in phrase ? phrase.matches : []
   if (phraseMatches.length > 0) return phraseMatches
 
@@ -113,6 +116,7 @@ function keywordLane(
   const ranked = searchAllRanked(shards, streamDays, tokens, {
     full: false,
     maxResults,
+    references,
     tokenMatchMode: 'ascii-boundary',
   })
   return 'matches' in ranked ? ranked.matches : []
@@ -281,7 +285,7 @@ function fuseLanes(
   return [...fused.values()].sort((a, b) => b.rrfScore - a.rrfScore || a.key.localeCompare(b.key))
 }
 
-type LaneHit = { source: 'topic' | 'stream'; key: string; score: number }
+type LaneHit = { source: 'topic' | 'stream' | 'reference'; key: string; score: number }
 type LaneEntry = { content: Omit<HybridSearchResult, 'rrfScore'>; score: number }
 
 // Returns one lane's per-parent scores so the caller can SUM across lanes;
@@ -306,11 +310,16 @@ function collapseLane(
 // more than one belief), so it contributes its score to each parent. An
 // undreamed fragment with no citing topic resolves to itself.
 function resolveToParents(
-  source: 'topic' | 'stream',
+  source: 'topic' | 'stream' | 'reference',
   nodeKey: string,
   index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
   parentSlugsByFragmentId: Map<string, Set<string>>,
 ): Array<{ fusedKey: string; content: Omit<HybridSearchResult, 'rrfScore'> }> {
+  if (source === 'reference') {
+    const slug = referenceSlugFromKey(nodeKey)
+    const content = index.get(laneKey('reference', slug))
+    return content === undefined ? [] : [{ fusedKey: laneKey('reference', slug), content }]
+  }
   if (source === 'stream') {
     const fragmentId = fragmentIdFromKey(nodeKey)
     const parentSlugs = fragmentId === null ? undefined : parentSlugsByFragmentId.get(fragmentId)
@@ -325,6 +334,11 @@ function resolveToParents(
   }
   const content = index.get(laneKey(source, nodeKey))
   return content === undefined ? [] : [{ fusedKey: laneKey(source, nodeKey), content }]
+}
+
+function referenceSlugFromKey(referenceKey: string): string {
+  const hashIndex = referenceKey.indexOf('#')
+  return hashIndex === -1 ? referenceKey : referenceKey.slice(0, hashIndex)
 }
 
 function fragmentIdFromKey(streamKey: string): string | null {
@@ -342,6 +356,7 @@ function fragmentIdFromKey(streamKey: string): string | null {
 function buildContentIndex(
   shards: TopicShard[],
   streamDays: UndreamedStreamDay[],
+  references: Reference[],
   supersededFragmentIds: Set<string>,
 ): Map<string, Omit<HybridSearchResult, 'rrfScore'>> {
   const index = new Map<string, Omit<HybridSearchResult, 'rrfScore'>>()
@@ -360,6 +375,16 @@ function buildContentIndex(
       const item = streamIndexItem(day, event, supersededFragmentIds)
       if (item !== null) index.set(laneKey('stream', item.key), item)
     }
+  }
+
+  for (const reference of references) {
+    if (reference.frontmatter.demoted) continue
+    index.set(laneKey('reference', reference.slug), {
+      source: 'reference',
+      key: reference.slug,
+      heading: reference.frontmatter.title,
+      excerpt: excerpt(reference.body, reference.frontmatter.title),
+    })
   }
 
   return index
@@ -390,6 +415,7 @@ function streamIndexItem(
 
 function matchKey(match: MemorySearchMatch): string {
   if (match.source === 'topic') return match.slug
+  if (match.source === 'reference') return match.slug
   return streamMatchKey(match)
 }
 
@@ -398,7 +424,7 @@ function streamMatchKey(match: StreamMatch): string {
   return `${match.date}#legacy-${hashContent(match.excerpt).slice(0, 12)}`
 }
 
-function laneKey(source: 'topic' | 'stream', key: string): string {
+function laneKey(source: 'topic' | 'stream' | 'reference', key: string): string {
   return `${source}:${key}`
 }
 

--- a/src/bundled-plugins/memory/vector/passages.test.ts
+++ b/src/bundled-plugins/memory/vector/passages.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { renderReference } from '../references/frontmatter'
+import { referencePassages } from './passages'
+import { TEXT_TOKEN_BUDGET } from './truncation'
+
+const testDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('referencePassages', () => {
+  it('chunks a long reference body into reference passages without dropping text', async () => {
+    const agentDir = createAgentDir()
+    const body = Array.from({ length: TEXT_TOKEN_BUDGET + 25 }, (_, i) => `word${i}`).join(' ')
+    writeReference(agentDir, 'ref-a', 'Reference A', body)
+
+    const passages = await referencePassages(agentDir)
+
+    expect(passages.length).toBeGreaterThanOrEqual(2)
+    expect(passages.map((passage) => passage.id)).toEqual(passages.map((_, i) => `reference:ref-a#${i}`))
+    expect(passages.every((passage) => passage.source === 'reference')).toBe(true)
+    expect(passages.map((passage) => passage.text).join('')).toBe(body)
+  })
+})
+
+function createAgentDir(): string {
+  const agentDir = join(tmpdir(), `typeclaw-passages-${randomUUID()}`)
+  testDirs.push(agentDir)
+  mkdirSync(join(agentDir, 'memory', 'references'), { recursive: true })
+  return agentDir
+}
+
+function writeReference(agentDir: string, slug: string, title: string, body: string): void {
+  writeFileSync(
+    join(agentDir, 'memory', 'references', `${slug}.md`),
+    renderReference(
+      {
+        title,
+        origin: 'episode',
+        created: '2026-06-10T00:00:00Z',
+        lastAccessed: '2026-06-10T00:00:00Z',
+        accessCount: 0,
+        pinned: false,
+        demoted: false,
+        tags: [],
+      },
+      body,
+    ),
+  )
+}

--- a/src/bundled-plugins/memory/vector/passages.ts
+++ b/src/bundled-plugins/memory/vector/passages.ts
@@ -4,14 +4,15 @@ import { stripCitationLines } from '../citations'
 import { fragmentContentHash } from '../fragment-parser'
 import { loadAllShards, type TopicShard } from '../load-shards'
 import { buildParentLinks } from '../parent-link'
+import { loadAllReferences } from '../references/load-references'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
 import { EMBEDDING_MODEL_ID } from './embedder'
 import type { VectorStore } from './store'
-import { fragmentEmbeddableText } from './truncation'
+import { boundEmbeddableText, fragmentEmbeddableText } from './truncation'
 
 export type Passage = {
   id: string
-  source: 'topic' | 'stream'
+  source: 'topic' | 'stream' | 'reference'
   key: string
   text: string
   contentHash: string
@@ -28,8 +29,26 @@ export function topicPassage(slug: string, heading: string, body: string): Passa
 }
 
 export async function collectPassages(agentDir: string): Promise<Passage[]> {
-  const [shards, streamDays] = await Promise.all([loadAllShards(agentDir), readAllUndreamedStreamDays(agentDir)])
-  return buildPassages(shards, streamDays)
+  const [shards, streamDays, references] = await Promise.all([
+    loadAllShards(agentDir),
+    readAllUndreamedStreamDays(agentDir),
+    referencePassages(agentDir),
+  ])
+  return [...buildPassages(shards, streamDays), ...references]
+}
+
+export async function referencePassages(agentDir: string): Promise<Passage[]> {
+  const references = await loadAllReferences(agentDir)
+  return references.flatMap((reference): Passage[] => {
+    if (reference.frontmatter.demoted) return []
+    return chunkReferenceBody(reference.body).map((chunk, chunkIdx) => ({
+      id: `reference:${reference.slug}#${chunkIdx}`,
+      source: 'reference',
+      key: reference.slug,
+      text: chunk,
+      contentHash: hashContent(chunk),
+    }))
+  })
 }
 
 export function findMissingPassages(store: VectorStore, passages: Passage[]): Passage[] {
@@ -67,6 +86,28 @@ function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): 
       }),
     ),
   ]
+}
+
+function chunkReferenceBody(body: string): string[] {
+  if (body.length === 0) return ['']
+
+  const chunks: string[] = []
+  let remaining = body
+  while (remaining.length > 0) {
+    const bounded = boundEmbeddableText(remaining)
+    if (!bounded.bounded) {
+      chunks.push(bounded.text)
+      break
+    }
+    if (bounded.text.length === 0) {
+      chunks.push(remaining[0]!)
+      remaining = remaining.slice(1)
+      continue
+    }
+    chunks.push(bounded.text)
+    remaining = remaining.slice(bounded.text.length)
+  }
+  return chunks
 }
 
 function hashContent(content: string): string {

--- a/src/bundled-plugins/memory/vector/passages.ts
+++ b/src/bundled-plugins/memory/vector/passages.ts
@@ -28,11 +28,11 @@ export function topicPassage(slug: string, heading: string, body: string): Passa
   return { id: `topic:${slug}`, source: 'topic', key: slug, text, contentHash: hashContent(text) }
 }
 
-export async function collectPassages(agentDir: string): Promise<Passage[]> {
+export async function collectPassages(agentDir: string, referencesEnabled = false): Promise<Passage[]> {
   const [shards, streamDays, references] = await Promise.all([
     loadAllShards(agentDir),
     readAllUndreamedStreamDays(agentDir),
-    referencePassages(agentDir),
+    referencesEnabled ? referencePassages(agentDir) : Promise.resolve([]),
   ])
   return [...buildPassages(shards, streamDays), ...references]
 }

--- a/src/bundled-plugins/memory/vector/startup.ts
+++ b/src/bundled-plugins/memory/vector/startup.ts
@@ -7,10 +7,11 @@ import { VectorStore } from './store'
 export async function buildStartupVectorIndex(
   agentDir: string,
   embedFn: EmbedFn = embed,
+  referencesEnabled = false,
 ): Promise<{ built: boolean; pruned: number; count: number }> {
   const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
   try {
-    const wanted = await collectPassages(agentDir)
+    const wanted = await collectPassages(agentDir, referencesEnabled)
 
     // Prune current-model rows whose id left the desired passage set (deleted
     // topics, dreamed-then-GC'd fragments, and — load-bearing here — fragments

--- a/src/bundled-plugins/memory/vector/store.ts
+++ b/src/bundled-plugins/memory/vector/store.ts
@@ -4,7 +4,7 @@ import { dirname } from 'node:path'
 
 export type VectorRow = {
   id: string
-  source: 'topic' | 'stream'
+  source: 'topic' | 'stream' | 'reference'
   key: string
   model: string
   dims: number
@@ -19,7 +19,7 @@ export type ScoredVectorRow = { row: VectorRow; score: number }
 
 type StoredVectorRow = {
   id: string
-  source: 'topic' | 'stream'
+  source: 'topic' | 'stream' | 'reference'
   key: string
   model: string
   dims: number

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -801,6 +801,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   network: 'restart-required',
   sandbox: 'restart-required',
   tunnels: 'restart-required',
+  'memory.references.enabled': 'restart-required',
   'docker.file': 'restart-required',
   'git.ignore': 'restart-required',
   // Split: `match` lists are reload-safe (typeclaw role claim, hand-edits

--- a/src/config/reloadable.test.ts
+++ b/src/config/reloadable.test.ts
@@ -293,4 +293,4 @@ function shouldRecurse(path: string): boolean {
   return path === 'docker' || path === 'git' || path === 'permissions'
 }
 
-const KNOWN_OPTIONAL_PATHS = new Set<string>(['roles.match', 'roles.permissions'])
+const KNOWN_OPTIONAL_PATHS = new Set<string>(['roles.match', 'roles.permissions', 'memory.references.enabled'])

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -20,6 +20,7 @@ import {
 } from '@/agent/subagents'
 import { clearTodosForOrigin } from '@/agent/todo/continuation-wiring'
 import { vectorEnabledFromMemoryConfig } from '@/bundled-plugins/memory/vector/config'
+import { embed } from '@/bundled-plugins/memory/vector/embedder'
 import { buildStartupVectorIndex } from '@/bundled-plugins/memory/vector/startup'
 import { resolveCapOptionsFromConfig } from '@/bundled-plugins/tool-result-cap'
 import {
@@ -223,7 +224,9 @@ export async function startAgent({
   // exactly once per folder; a folder already at v2 is a no-op.
   runStartupMigrations(cwd)
   if (suppressSystemMemory) {
-    await buildStartupVectorIndex(cwd).catch((err) => {
+    const memoryConfig = pluginConfigsByName.memory as { references?: { enabled?: boolean } } | undefined
+    const referencesEnabled = memoryConfig?.references?.enabled ?? false
+    await buildStartupVectorIndex(cwd, embed, referencesEnabled).catch((err) => {
       console.warn(`[vector] startup index build failed: ${err instanceof Error ? err.message : String(err)}`)
     })
   }


### PR DESCRIPTION
## Memory system (after this PR)

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                         typeclaw memory system                              │
└─────────────────────────────────────────────────────────────────────────────┘

  session transcript
        │
        ▼
  ┌─────────────┐   idle / buffer-trip
  │memory-logger│ ──────────────────────────────────────────────────────────┐
  └─────────────┘                                                           │
        │                                                                   │
        │  distilled facts                    verbatim artifacts            │
        │  (topic + body)                     (title + body, byte-exact)    │
        ▼                                              ▼                    │
  ┌─────────────────────┐              ┌───────────────────────────┐        │
  │  TIER 2 — STREAM    │              │  TIER 3 — REFERENCE  NEW  │        │
  │  memory/streams/    │              │  memory/references/       │        │
  │  yyyy-MM-dd.jsonl   │              │  <slug>.md                │        │
  │                     │              │                           │        │
  │  fragment events    │              │  never distilled          │        │
  │  watermarks         │              │  recalled by content+time │        │
  │  legacy prose       │              │  decays by age+access     │        │
  └──────────┬──────────┘              └────────────┬──────────────┘        │
             │                                      │                       │
             │  dreaming (*/30 cron)                │ slug citations        │
             │  consolidates undreamed              │ promoted up           │
             ▼                                      ▼                       │
  ┌─────────────────────┐         references: [slug-a, slug-b]              │
  │  TIER 1 — TOPIC     │◄─────────────────────────────────────────────────┘
  │  memory/topics/     │
  │  <slug>.md          │
  │                     │
  │  one belief/shard   │
  │  fragments: [...]   │
  │  references: [...]  │
  └──────────┬──────────┘
             │
             │  injection (session start / per-turn)
             ▼
       agent context window


  Saturation & eviction
  ─────────────────────
  TIER 1  repetition strengthens (days × cites) → dreaming promotes/demotes
  TIER 2  dreamed + uncited → compacted out of JSONL (citation-superset GC)
  TIER 3  age + lastAccessed + accessCount decay → demote → delete (NEW)
          pinned / origin:curated / origin:external → exempt from decay

  Config gate
  ───────────
  memory.references.enabled: false   ← default; tiers 1+2 unchanged
  memory.references.enabled: true    ← enables tier 3 (restart required)
```

## Background

The memory system had two tiers: distilled beliefs (`memory/topics/`) and fragment events (`memory/streams/`). Together they handle generalization well — beliefs accumulate, fragments feed dreaming — but the system had no place for verbatim artifacts. SQL queries, shell runbooks, code blocks, pasted API specs: things an agent needs to recall byte-for-byte, not paraphrased.

Distillation is the wrong fit for these. Dreaming rewrites belief shards in its own words; a fragment that says "here is a SQL query:" gets its content summarized away. The agent could retrieve the belief "user has a query for X" but not the query itself. There was no tier designed to store and recall the artifact verbatim.

## Summary

Adds a third memory tier — `memory/references/` — for verbatim episodic artifacts. References are captured as-is by a new `store_reference` tool, recalled via `memory_search` (with optional `since`/`before` datetime filters and access bumps on retrieval), promoted into topic shards by dreaming (slugs only — content is never rewritten), and subject to a Generative-Agents-style saturation/eviction pass when the tier fills.

The entire tier is gated behind `memory.references.enabled` (default: `false`). With the flag off the behavior is byte-identical to the current system — no new paths execute, no new files are written.

**Why a new tier instead of extending fragments?** References are not feedstock for dreaming; they are the final form. Making them fragments would either block dreaming from touching them (a special-case carve-out inside a system built around universal fragment processing) or risk dreaming rewriting their content (defeating the purpose). A separate tier with its own lifecycle — captured verbatim, promoted by slug reference only, decayed by access recency — keeps the invariants clean.

**Why Generative-Agents decay and not citation-count GC?** Fragment GC is driven by whether dreaming still cites a fragment after a consolidation run. References are never rewritten by dreaming, so citation counts never change — citation-count GC would either never collect anything or require special-casing. Decay on `created` age + `lastAccessed` recency + `accessCount` mirrors how episodic memory fades in humans and in the Generative Agents paper, and it operates on the axis (time + access) that actually signals whether a reference is still useful.

## Preview

N/A — no UI or output change. The tier is off by default; an operator enables it by setting `memory.references.enabled: true` in `typeclaw.json` and restarting.

## What this does NOT do

- Does not change the fragment lifecycle, the citation-superset check, or the dreaming consolidation logic for existing tiers. The `references/<slug>` citation format is explicitly excluded from the superset check (which governs `streams/date#id` fragment ids).
- Does not enable itself. `memory.references.enabled` defaults to `false`; existing agents see no change.
- Does not chunk or rewrite reference content anywhere. Dreaming promotes a reference slug into a topic shard's `references:` section but never touches the reference file's body.
- Does not add a new vector store schema column. Reference passages use `source: 'reference'` on the existing `VectorRow.source` union type, alongside the existing `'topic'` and `'fragment'` values.

## Review notes

**Load-bearing invariants to verify:**

1. **Content freeze**: `dreaming.ts` reference-pass writes only to `topics/*.md` `references:` sections — it reads `referencePath(slug)` to check the SHA-256 guard but never writes to it. Any write to a reference file from the dreaming pass would violate this.

2. **Demote-before-delete**: the saturation pass in `dreaming.ts` first sets `demoted: true` in the frontmatter (dropping the reference from `memory_search` results) and only deletes the file after `evictionGraceDays` of subsequent dormancy. The frontmatter ownership split in `references/frontmatter.ts` enforces this: `demoted`, `lastAccessed`, `accessCount` are runtime-owned (recomputed each run); `pinned` and `origin: 'curated'` are author-owned and exempt the reference from the decay calculation entirely.

3. **Superset exclusion**: `citation-superset.ts` now documents (and `citation-superset.test.ts` asserts) that `references/<slug>` citations in fragment frontmatter are not subject to the superset check. Only `streams/YYYY-MM-DD#<id>` fragment ids participate in the check.

4. **Config gate completeness**: all five surfaces check `memory.references.enabled` before executing: `store_reference` tool registration in `memory-logger.ts`, the dreaming saturation pass, `memory_search` reference surface, `memory-retrieval` subagent search surface, and vector indexing (`collectPassages`, `hybridSearch`, startup build, and doctor).

**New files worth a close read:**
- `references/frontmatter.ts` — ownership split between runtime-owned and author-owned fields; the `parse`/`render` round-trip
- `references/store-reference-tool.ts` — the capture path; writes to `memory/references/`, never to streams
- `dreaming.ts` reference-pass — promotion (slug-only) + saturation (decay formula + demote-before-delete)
- `search-tool.ts` — `createMemorySearchTool(referencesEnabled)` factory pattern; `since`/`before` filter; access bump
- `vector/hybrid.ts` — reference chunk → parent reference collapse (MAX-child, mirrors the existing fragment→topic collapse)

**Test coverage:** 8953 pass, 0 fail. New test files: `references/frontmatter.test.ts`, `references/load-references.test.ts`, `references/store-reference-tool.test.ts`. Extended: `dreaming.test.ts`, `citation-superset.test.ts`, `memory-logger.test.ts`, `search-tool.test.ts`, `vector/passages.test.ts`, `vector/hybrid.test.ts`.
