### PR TITLE
feat(memory): log per-chunk progress during vector index build

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
@@ -141,3 +141,42 @@ describe('embedder batch-size observability', () => {
     expect(warnings.some((w) => w.includes('vector embedding'))).toBe(false)
   })
 })
+
+describe('embedder progress observability', () => {
+  let notices: string[]
+  const originalInfo = console.info
+
+  beforeEach(() => {
+    notices = []
+    console.info = (message?: unknown) => {
+      notices.push(String(message))
+    }
+  })
+
+  afterEach(() => {
+    console.info = originalInfo
+  })
+
+  test('reports per-chunk progress for a large build, ending at 100%', async () => {
+    const { embed } = await import('./embedder')
+
+    await embed(
+      Array.from({ length: 256 }, (_, i) => `passage ${i}`),
+      'passage',
+    )
+
+    const progress = notices.filter((n) => n.includes('embedded'))
+    // 256 inputs at 64/pass → 4 chunks → 4 progress lines.
+    expect(progress).toHaveLength(4)
+    expect(progress[0]).toContain('[memory]')
+    expect(progress.at(-1)).toContain('256/256 passage input(s) embedded (100%)')
+  })
+
+  test('does not report per-chunk progress for a small build', async () => {
+    const { embed } = await import('./embedder')
+
+    await embed(['short a', 'short b'], 'passage')
+
+    expect(notices.filter((n) => n.includes('embedded'))).toHaveLength(0)
+  })
+})

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -88,11 +88,18 @@ export class Embedder {
       type,
     )
 
+    // Gate per-chunk progress on the same LARGE_EMBED threshold as the up-front
+    // line: only the startup index migration runs long enough for "wedged or
+    // just slow?" to be a real question. Smaller embeds (queries, per-write
+    // upserts) finish in a pass or two and would only spam the logs.
+    const reportProgress = prefixed.length >= LARGE_EMBED
+
     const embeddings: Float32Array[] = []
     for (let start = 0; start < prefixed.length; start += EMBED_BATCH_SIZE) {
       const batch = prefixed.slice(start, start + EMBED_BATCH_SIZE)
       const output = await this.extractor(batch, { pooling: 'mean', normalize: true })
       embeddings.push(...toEmbeddings(output.data, batch.length))
+      if (reportProgress) logEmbedProgress(embeddings.length, prefixed.length, type)
     }
     return embeddings
   }
@@ -138,6 +145,11 @@ function logEmbedBatch(count: number, type: EmbedType): void {
   } else {
     console.info(line)
   }
+}
+
+function logEmbedProgress(done: number, total: number, type: EmbedType): void {
+  const pct = Math.floor((done / total) * 100)
+  console.info(`[memory] vector embedding: ${done}/${total} ${type} input(s) embedded (${pct}%)`)
 }
 
 function configureTransformers(env: TransformersEnv): void {


### PR DESCRIPTION
## Background

The startup vector index migration emits its total passage count up front:

```
[memory] vector embedding: 3283 passage input(s) (chunked at 64/pass) — large build, this may take a while
```

…then runs the chunked embed loop (`EMBED_BATCH_SIZE = 64` per onnxruntime pass) with **no further output until it finishes**. On a multi-thousand-passage corpus that loop runs for minutes, during which an operator watching the logs has no way to distinguish a slow build from a wedged one.

This adds a progress line after each chunk completes:

```
[memory] vector embedding: 64/3283 passage input(s) embedded (1%)
[memory] vector embedding: 128/3283 passage input(s) embedded (3%)
...
[memory] vector embedding: 3283/3283 passage input(s) embedded (100%)
```

## Summary

Emit a `done/total … embedded (pct%)` line after each chunk completes, gated on the same `LARGE_EMBED` (256) threshold as the up-front "large build" suffix. The same threshold that decides whether to warn the operator about a slow build also decides whether per-chunk progress is worth logging — smaller embeds (single-text queries, per-write upserts) finish in one or two passes and would just spam the logs.

`[memory]` prefix and `done/total … (pct%)` format matches the embedder's existing `console.info` convention; timestamps are added externally by `typeclaw logs`.

No content is logged — counts only, consistent with the content-free observability rule the bounding warning already follows.

## Preview

N/A — log-only change, no UI or output surface change.

## What this does NOT do

- Does not change the embed batch size or chunking logic.
- Does not affect small embeds (queries, per-write upserts) — those never cross the `LARGE_EMBED` threshold.
- Does not log passage content or metadata, only counts.

## Review notes

The load-bearing addition in `embedder.ts` is the `logProgress` call inside the chunk loop, after `embeddings.push(...)` but before the next iteration. It must fire after each chunk completes, not before, so the logged count reflects work already done.

The new `embedder progress observability` block in `embedder-truncation.test.ts` asserts:
- A 256-input build emits exactly 4 progress lines (256 ÷ 64), the last reading `256/256 … (100%)`.
- A 2-input build emits none.