### PR TITLE
fix(memory): count vector-surfaced references toward access decay

### DIFF
--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -22,6 +22,7 @@ import { loadAllShards } from './load-shards'
 import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-logger'
 import { createMemoryRetrievalSubagent, type MemoryRetrievalPayload } from './memory-retrieval'
 import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
+import { bumpReferenceAccess } from './references/load-references'
 import { createMemorySearchTool } from './search-tool'
 import { type InjectedShardState, partitionDirectShards } from './turn-dedup'
 import { vectorConfigSchema } from './vector/config'
@@ -217,6 +218,16 @@ async function renderVectorTurnMemory(
     logger?.info(
       `[vector-retrieval] mode=index topic_results=${topicHits} stream_results=${streamHits} reference_results=${referenceHits} elapsed_ms=${elapsedMs}${suppressed}`,
     )
+    // Count a vector-surfaced reference as an access so it survives dreaming's
+    // time-decay the same way a memory_search hit does. Fire-and-forget: the
+    // bump only feeds the 30-min dreaming saturation pass, so it must not add a
+    // frontmatter write to the per-turn response critical path.
+    const referenceSlugs = results.flatMap((r) => (r.source === 'reference' ? [r.key] : []))
+    if (referenceSlugs.length > 0) {
+      void bumpReferenceAccess(event.agentDir, referenceSlugs).catch((err) => {
+        logger?.info(`[vector-retrieval] reference access bump failed: ${err instanceof Error ? err.message : err}`)
+      })
+    }
     return renderRetrievedMemorySection(results, { origin: event.origin })
   } finally {
     store.close()

--- a/src/bundled-plugins/memory/references/load-references.test.ts
+++ b/src/bundled-plugins/memory/references/load-references.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { referenceFilePath, referencesDir } from '../paths'
-import { __resetReferenceCacheForTests, loadAllReferences } from './load-references'
+import { parseReference } from './frontmatter'
+import { __resetReferenceCacheForTests, bumpReferenceAccess, loadAllReferences } from './load-references'
 
 const tmpRoots: string[] = []
 
@@ -45,6 +46,36 @@ describe('loadAllReferences', () => {
 
     expect(second).toBe(first)
     expect(second[0]).toBe(first[0])
+  })
+})
+
+describe('bumpReferenceAccess', () => {
+  test('increments accessCount and advances lastAccessed while preserving the body', async () => {
+    const agentDir = await makeAgentDir()
+    await writeReference(agentDir, 'sql-query', 'SQL query', 'SELECT 1;\n')
+
+    await bumpReferenceAccess(agentDir, ['sql-query'])
+
+    const updated = parseReference(await readFile(referenceFilePath(agentDir, 'sql-query'), 'utf8'))
+    expect(updated.frontmatter.accessCount).toBe(4)
+    expect(updated.frontmatter.lastAccessed).not.toBe('2026-06-13T09:10:00+09:00')
+    expect(updated.body).toBe('SELECT 1;\n')
+  })
+
+  test('skips a missing slug without throwing', async () => {
+    const agentDir = await makeAgentDir()
+
+    await expect(bumpReferenceAccess(agentDir, ['does-not-exist'])).resolves.toBeUndefined()
+  })
+
+  test('deduplicates repeated slugs so accessCount advances by one', async () => {
+    const agentDir = await makeAgentDir()
+    await writeReference(agentDir, 'dup', 'Dup', 'body\n')
+
+    await bumpReferenceAccess(agentDir, ['dup', 'dup', 'dup'])
+
+    const updated = parseReference(await readFile(referenceFilePath(agentDir, 'dup'), 'utf8'))
+    expect(updated.frontmatter.accessCount).toBe(4)
   })
 })
 

--- a/src/bundled-plugins/memory/references/load-references.ts
+++ b/src/bundled-plugins/memory/references/load-references.ts
@@ -1,7 +1,7 @@
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises'
 
 import { referenceFilePath, referencesDir } from '../paths'
-import { parseReference, type ReferenceFrontmatter } from './frontmatter'
+import { parseReference, renderReference, type ReferenceFrontmatter } from './frontmatter'
 
 export type Reference = {
   path: string
@@ -70,6 +70,40 @@ export async function loadReference(
   options: { logger?: Logger } = {},
 ): Promise<Reference | null> {
   return readAndParseReference(referenceFilePath(agentDir, slug), slug, options)
+}
+
+// Records an access against the given reference slugs: bumps accessCount and
+// stamps lastAccessed. Used by both the memory_search hit path and the vector
+// retrieval path so a reference surfaced by either counts toward the dreaming
+// saturation model — otherwise a reference repeatedly injected by vector
+// retrieval (but never explicitly searched) decays on time alone and gets
+// evicted despite being actively useful. Best-effort: a missing or malformed
+// slug is skipped, never thrown, so a caller can fire-and-forget off the turn
+// critical path.
+export async function bumpReferenceAccess(
+  agentDir: string,
+  slugs: Iterable<string>,
+  options: { logger?: Logger } = {},
+): Promise<void> {
+  const unique = [...new Set(slugs)]
+  await Promise.all(
+    unique.map(async (slug) => {
+      const reference = await readAndParseReference(referenceFilePath(agentDir, slug), slug, options)
+      if (reference === null) return
+      await writeFile(
+        reference.path,
+        renderReference(
+          {
+            ...reference.frontmatter,
+            lastAccessed: new Date().toISOString(),
+            accessCount: reference.frontmatter.accessCount + 1,
+          },
+          reference.body,
+        ),
+        'utf8',
+      )
+    }),
+  )
 }
 
 export function __resetReferenceCacheForTests(): void {


### PR DESCRIPTION
## Background

References surface in the agent context window via two independent paths: an explicit `memory_search` call and the per-turn vector retrieval path (`renderVectorTurnMemory` → `hybridSearch`). Before this fix, `bumpReturnedReferences` in `search-tool.ts` recorded an access only on the first path. A reference that was repeatedly injected by vector retrieval — but never explicitly searched — accumulated no access history.

The dreaming saturation model scores references as `(accessCount + 1) × exp(−recency / 14d) × exp(−age / 56d)`. With `accessCount` frozen at zero and `lastAccessed` never advancing, such a reference decayed purely on wall-clock age and could be demoted (~14 days) then evicted (~44 days) despite being surfaced every turn. The reference was useful; the model had no way to know that.

## Summary

Add `bumpReferenceAccess(agentDir, slugs)` to `references/load-references.ts` and call it from the index-mode vector retrieval path for every returned reference slug.

**Why fire-and-forget:** the bump only feeds the 30-minute dreaming pass, so it must not add a synchronous frontmatter write to the per-turn response critical path. A failure is logged as `[vector-retrieval] reference access bump failed: …`, not thrown. The `memory_search` hit path keeps its existing synchronous `bumpReturnedReferences` — it already has the references loaded in memory, so no extra read is required; the two paths share identical `accessCount + 1` / `lastAccessed` semantics.

**Why deduplicate slugs:** `hybridSearch` can return multiple chunks from the same reference. Without deduplication, one retrieval event would increment `accessCount` once per chunk. The `new Set(slugs)` in `bumpReferenceAccess` collapses them to one bump per reference per turn.

## Preview

N/A — no output or UI surface change.

## What this does NOT do

- Does not change the dreaming saturation formula, decay constants, demotion threshold, or eviction grace period.
- Does not change the `memory_search` hit path — `bumpReturnedReferences` there remains synchronous as before.
- Does not alter the vector index, embedding logic, or hybrid-search scoring.

## Review notes

The load-bearing addition in `index.ts` is the fire-and-forget block in `renderVectorTurnMemory`, placed after the results are collected but before the section renders:

```ts
const referenceSlugs = results.flatMap((r) => (r.source === 'reference' ? [r.key] : []))
if (referenceSlugs.length > 0) {
  void bumpReferenceAccess(event.agentDir, referenceSlugs).catch((err) => {
    logger?.info(`[vector-retrieval] reference access bump failed: …`)
  })
}
```

Invariant to verify: `void` detaches the promise from the turn response; the `.catch` prevents an unhandled rejection. The bump runs concurrently with the return of the rendered section — it does not delay the response.

`bumpReferenceAccess` in `load-references.ts` reads each slug's file, increments `accessCount`, stamps `lastAccessed`, and writes back. A missing slug returns `null` from `readAndParseReference` and is skipped without throwing — best-effort contract is structural, not just documented.

Three new tests in `load-references.test.ts`:

- Bump increments `accessCount` and advances `lastAccessed` while preserving the reference body.
- Missing slug resolves without throwing.
- Repeated slugs deduplicate to a single increment.

All checks pass: typecheck, lint (0 errors), format, `bun run test` (8964 pass, 0 fail).