### PR TITLE
docs(memory): document memory.vector.enabled + add vector failure-path tests

### DIFF
--- a/docs/content/docs/internals/memory.mdx
+++ b/docs/content/docs/internals/memory.mdx
@@ -6,7 +6,7 @@ icon: BrainCircuit
 
 The bundled `memory` plugin is the self-improving loop: it watches sessions, distills them into long-term beliefs, and feeds those beliefs back into future prompts — no hand-written prompts, no human in the loop. This page is the contributor-facing companion to the [memory loop concept](/docs/concepts/memory-loop); for the exhaustive reference (config table, every hook, observability log lines) see [`src/bundled-plugins/memory/README.md`](https://github.com/typeclaw/typeclaw/blob/main/src/bundled-plugins/memory/README.md).
 
-The plugin is auto-loaded by every agent. There is no `plugins[]` entry to add and no opt-out — configure it via the `memory` block in `typeclaw.json`. All `memory.*` fields are **restart-required**: the plugin reads them once at boot.
+The plugin is auto-loaded by every agent. There is no `plugins[]` entry to add and no opt-out — configure it via the `memory` block in `typeclaw.json` (see the [config table in the memory README](https://github.com/typeclaw/typeclaw/blob/main/src/bundled-plugins/memory/README.md#config) for every field and default, including `memory.vector.enabled`, default `false`). All `memory.*` fields are **restart-required**: the plugin reads them once at boot. The `memory` block is plugin-owned config that passes through core's schema (`.catchall`), so it sits **outside the core `FIELD_EFFECTS` reload fence** — changing a `memory.*` field and running `typeclaw reload` silently no-ops with no "restart-required" warning. Restart the container to apply.
 
 ## Two surfaces, three subagents
 

--- a/src/bundled-plugins/memory/README.md
+++ b/src/bundled-plugins/memory/README.md
@@ -13,20 +13,22 @@ Auto-loaded by every TypeClaw agent. No `plugins[]` entry to add and no opt-out.
     "bufferBytes": 500000,
     "injectionBudgetBytes": 16384,
     "minIdleDeltaLines": 3,
-    "dreaming": { "schedule": "*/30 * * * *" }
+    "dreaming": { "schedule": "*/30 * * * *" },
+    "vector": { "enabled": false }
   }
 }
 ```
 
-| Field                         | Default          | Effect                                                                                                                                                                                                                                         |
-| ----------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `memory.idleMs`               | `60000`          | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                                                                        |
-| `memory.bufferBytes`          | `500000`         | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run. `0` disables. Minimum `10000` when non-zero.                                                                                       |
-| `memory.injectionBudgetBytes` | `16384`          | Total shard-body budget for direct-mode memory injection. Above this, `loadMemory` switches to index-mode (headings + metadata only) and the agent must call `memory_search` to fetch specific topics or recent stream events. Minimum `4096`. |
-| `memory.minIdleDeltaLines`    | `3`              | Minimum JSONL line growth since the last `memory-logger` run required to fire an idle spawn. Below this, the idle timer ticks but no spawn fires. `0` disables (legacy always-fire-on-idle behavior). Independent of `bufferBytes`.            |
-| `memory.dreaming.schedule`    | `"*/30 * * * *"` | Five-field cron expression for the dreaming subagent.                                                                                                                                                                                          |
+| Field                         | Default          | Effect                                                                                                                                                                                                                                                                                                                                                                                |
+| ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `memory.idleMs`               | `60000`          | Debounce window before `memory-logger` spawns after a prompt completes. Minimum `1000`.                                                                                                                                                                                                                                                                                               |
+| `memory.bufferBytes`          | `500000`         | Size-based ceiling: spawns `memory-logger` when the transcript grows by this many bytes since the last run. `0` disables. Minimum `10000` when non-zero.                                                                                                                                                                                                                              |
+| `memory.injectionBudgetBytes` | `16384`          | Total shard-body budget for direct-mode memory injection. Above this, `loadMemory` switches to index-mode (headings + metadata only) and the agent must call `memory_search` to fetch specific topics or recent stream events. Minimum `4096`.                                                                                                                                        |
+| `memory.minIdleDeltaLines`    | `3`              | Minimum JSONL line growth since the last `memory-logger` run required to fire an idle spawn. Below this, the idle timer ticks but no spawn fires. `0` disables (legacy always-fire-on-idle behavior). Independent of `bufferBytes`.                                                                                                                                                   |
+| `memory.dreaming.schedule`    | `"*/30 * * * *"` | Five-field cron expression for the dreaming subagent.                                                                                                                                                                                                                                                                                                                                 |
+| `memory.vector.enabled`       | `false`          | Master switch for per-turn vector memory. When `true`, the `# Memory` system-prompt section is suppressed and memory is injected per turn into the user prompt via `hybridSearch` (over budget) or direct shards (under budget); the host downloads the embedding model and mounts it into the container. When `false`, memory lives in the system prompt and no model is downloaded. |
 
-All fields are **restart-required** — the plugin reads them once at boot.
+All fields are **restart-required** — the plugin reads them once at boot. The `memory` block is plugin-owned config that passes through core's schema (`.catchall`), so it is **outside the core `FIELD_EFFECTS` reload fence**: changing any `memory.*` field and running `typeclaw reload` silently no-ops with no "restart-required" warning. Restart the container to apply.
 
 ## What it contributes
 

--- a/src/bundled-plugins/memory/index-vector-retrieval.test.ts
+++ b/src/bundled-plugins/memory/index-vector-retrieval.test.ts
@@ -11,6 +11,7 @@ import { createMemoryPluginForTests } from './index'
 import { topicShardPath, topicsDir } from './paths'
 import { EMBEDDING_MODEL_ID } from './vector/embedder'
 import type { EmbedFn } from './vector/hybrid'
+import { buildStartupVectorIndex } from './vector/startup'
 import { VectorStore, type VectorRow } from './vector/store'
 
 const DIMS = 8
@@ -62,6 +63,33 @@ describe('vector retrieval end-to-end through session.turn.start', () => {
     expect(retrievalContext.results).toContain('Satellites remain in orbit')
     expect(retrievalContext.results).not.toContain(QUERY)
     expect(retrievalContext.results).not.toContain('## Retrieved memory')
+  })
+
+  test('enabling vector on an agent with pre-existing topics builds the index at boot and retrieves on the first turn', async () => {
+    // given: an agent that ran with vector OFF — topic shards exist on disk but
+    // there is no `.vectors/index.db` yet (the migration entry condition)
+    await writeTopic(agentDir, 'orbital-mechanics', 'Orbital Mechanics', `Satellites remain in orbit. ${pad(5000)}`)
+
+    // when: the boot-time startup build runs (as src/run/index.ts does once vector
+    // is enabled), embedding every existing passage into a fresh index
+    const built = await buildStartupVectorIndex(agentDir, queryAligned())
+    expect(built).toEqual({ built: true, pruned: 0, count: 1 })
+
+    const infos: string[] = []
+    const exports = await bootVectorPlugin(4096, capturingLogger(infos))
+    const retrievalContext = { results: '' }
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_migrate', agentDir, userPrompt: QUERY, retrievalContext },
+      hookCtx(),
+    )
+
+    // then: the first turn retrieves the migrated topic through the real pipeline —
+    // no manual seedVector, the index came entirely from the startup build
+    const retrievalLog = infos.find((msg) => msg.startsWith('[vector-retrieval] mode=index '))
+    expect(retrievalLog).toContain('topic_results=1')
+    expect(retrievalContext.results).toContain('## Orbital Mechanics')
+    expect(retrievalContext.results).toContain('Satellites remain in orbit')
+    expect(retrievalContext.results).not.toContain(QUERY)
   })
 })
 

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -210,6 +210,33 @@ describe('vector session.turn.start hook', () => {
     expect(hybridSearchMock).not.toHaveBeenCalled()
   })
 
+  test('a failing hybrid search is caught: the turn yields empty memory instead of throwing', async () => {
+    // given: two over-budget shards (index mode) and a hybridSearch that rejects,
+    // simulating a runtime embed/store failure (OOM, corrupt DB, model crash)
+    await writeTopic(agentDir, 'first-topic', 'First Topic', 'a'.repeat(3000))
+    await writeTopic(agentDir, 'second-topic', 'Second Topic', 'b'.repeat(3000))
+    const errors: string[] = []
+    const failingSearch = mock(async () => {
+      throw new Error('embed failed: onnxruntime OOM')
+    })
+    const exports = await bootVectorPluginWith(failingSearch, 4096, errorCapturingLogger(errors))
+
+    // when: a turn runs over budget so the index path calls the failing search
+    const retrievalContext = { results: 'sentinel' }
+    const hook = exports.hooks!['session.turn.start']!
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') }
+
+    // then: the hook resolves (does not throw) and the turn is not crashed
+    await expect(
+      hook({ sessionId: 'ses_fail', agentDir, userPrompt: 'q', retrievalContext }, ctx),
+    ).resolves.toBeUndefined()
+    expect(failingSearch).toHaveBeenCalled()
+    // the pre-existing sentinel is left untouched (results was never reassigned),
+    // and the failure is logged through the plugin logger, not propagated
+    expect(retrievalContext.results).toBe('sentinel')
+    expect(errors.some((line) => line.includes('vector-retrieval failed'))).toBe(true)
+  })
+
   test('memory-logger subagent is created with onFragmentsAppended hook when vector.enabled is true', async () => {
     const memoryPlugin = createMemoryPluginForTests()
     const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096, vector: { enabled: true } })
@@ -274,11 +301,41 @@ async function bootVectorPlugin(injectionBudgetBytes: number, logger = createPlu
   return memoryPlugin.plugin(ctx)
 }
 
+async function bootVectorPluginWith(
+  hybridSearch: typeof hybridSearchMock,
+  injectionBudgetBytes: number,
+  logger = createPluginLogger('memory'),
+) {
+  const memoryPlugin = createMemoryPluginForTests({ hybridSearch })
+  const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes, vector: { enabled: true } })
+  if (!parsed.success) throw new Error(parsed.error.message)
+  const ctx = createPluginContext({
+    name: 'memory',
+    version: undefined,
+    agentDir,
+    config: parsed.data,
+    logger,
+    permissions: noopPermissionService,
+    spawnSubagent: async () => {},
+    isBooted: () => true,
+  })
+  return memoryPlugin.plugin(ctx)
+}
+
 function capturingLogger(infos: string[]) {
   return {
     ...createPluginLogger('memory'),
     info: (msg: string) => {
       infos.push(msg)
+    },
+  }
+}
+
+function errorCapturingLogger(errors: string[]) {
+  return {
+    ...createPluginLogger('memory'),
+    error: (msg: string) => {
+      errors.push(msg)
     },
   }
 }

--- a/src/bundled-plugins/memory/memory-retrieval.test.ts
+++ b/src/bundled-plugins/memory/memory-retrieval.test.ts
@@ -99,6 +99,25 @@ describe('memoryRetrievalSubagent', () => {
     expect(await Bun.file(path.join(agentDir, payload.cacheFilePath)).text()).toContain('Deploy summary')
   })
 
+  test('a wedged run rejection is logged and re-propagated so the coalescing key releases', async () => {
+    const agentDir = await makeAgentDir()
+    const warnings: string[] = []
+    const logger: MemoryRetrievalLogger = { info: () => {}, warn: (m) => warnings.push(m), error: () => {} }
+    const subagent = createMemoryRetrievalSubagent({ logger, timeoutMs: 30_000 })
+    const payload: MemoryRetrievalPayload = {
+      parentSessionId: 's1',
+      agentDir,
+      recentPrompt: 'What do we know about deploys?',
+      cacheFilePath: 'memory/.retrieval-cache/s1.md',
+    }
+    const timedOut: RunSession = async () => {
+      throw new Error('subagent run timed out after 30000ms')
+    }
+
+    await expect(subagent.handler!(context(agentDir, payload), timedOut)).rejects.toThrow('timed out')
+    expect(warnings.some((line) => line.includes('run threw') && line.includes('timed out'))).toBe(true)
+  })
+
   test('guard permits only the retrieval cache file, not other memory paths', async () => {
     const agentDir = await makeAgentDir()
     const origin = { kind: 'subagent' as const, subagent: 'memory-retrieval', parentSessionId: 's1' }

--- a/src/bundled-plugins/memory/vector/startup.test.ts
+++ b/src/bundled-plugins/memory/vector/startup.test.ts
@@ -152,6 +152,24 @@ describe('buildStartupVectorIndex', () => {
     expect(embeddedTexts).toEqual(['Package Manager\nThe user consistently uses pnpm.'])
   })
 
+  it('propagates a rejecting embedFn so the boot-time caller can log and continue', async () => {
+    const agentDir = createAgentDir()
+    writeTopic(agentDir, 'startup-topic', 'Startup Topic', 'This topic needs a vector at boot.')
+
+    const failing: EmbedFn = async () => {
+      throw new Error('model load failed: local_files_only missing weights')
+    }
+
+    await expect(buildStartupVectorIndex(agentDir, failing)).rejects.toThrow('model load failed')
+
+    const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+    try {
+      expect(store.getAll()).toEqual([])
+    } finally {
+      store.close()
+    }
+  })
+
   it('prunes superseded stream rows so they cannot crowd active candidates', async () => {
     const agentDir = createAgentDir()
     const activeId = '019e2eca-6fc5-71ef-add9-67a0955a4b35'


### PR DESCRIPTION
## Why

Release-readiness review of the vector memory system surfaced two doc gaps and four uncovered (but already-guarded) failure paths. This PR closes them. No production behavior changes — docs + tests only.

## What

### Docs
- **`memory.vector.enabled` (default `false`) is now in the config table.** It was documented only in prose, not in the canonical config table or JSON example in the memory plugin README.
- **Documented the memory-block reload no-op.** The `memory` block passes through core's schema (`.catchall`) and sits outside the `FIELD_EFFECTS` reload fence, so `typeclaw reload` silently no-ops on `memory.*` changes. Both the README and `docs/internals/memory.mdx` now state that a restart is required to apply them.

### Tests
These paths are guarded in production code but had no coverage:
- **`index-vector`** — a rejecting `hybridSearch` is caught so the turn yields empty memory instead of crashing the prompt (the per-turn `try/catch` in `index.ts`).
- **`startup`** — a rejecting `embedFn` propagates so the boot-time caller in `src/run/index.ts` can log and continue past a model-load failure.
- **`memory-retrieval`** — a wedged run rejection is logged and re-propagated so the per-session coalescing key releases instead of hanging.
- **`index-vector-retrieval`** — enabling vector on an agent with pre-existing topic shards builds the index at boot and retrieves on the first turn, through the real `hybridSearch` pipeline (the migration scenario).

## Verification
- `bun run typecheck` — clean
- `bun run lint` — 0 errors (67 pre-existing warnings, unrelated)
- `bun run format:check` — clean
- `bun run test` — 8976 pass, 0 fail