### PR TITLE
perf(memory): drop blank line after topic headings in memory section

### DIFF
--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -81,11 +81,11 @@ export function renderDedupedMemorySection(fullShards: TopicShard[], unchangedSh
   const lines = ['# Memory', '', MEMORY_FRAMING, '']
   for (const shard of fullShards) {
     const topic = topicEntryFromShard(shard)
-    lines.push(`## ${topic.name}`, '')
+    lines.push(`## ${topic.name}`)
     lines.push(renderBody(topic), '')
   }
   for (const shard of unchangedShards) {
-    lines.push(`## ${shard.frontmatter.heading}`, '')
+    lines.push(`## ${shard.frontmatter.heading}`)
     lines.push(unchangedShardReference(shard.slug), '')
   }
   return lines.join('\n').trimEnd()
@@ -120,7 +120,7 @@ export function renderRetrievedMemorySection(
   const lines = ['# Memory', '', MEMORY_FRAMING, '']
   if (isChannel) lines.push(...CHANNEL_MEMORY_BOUNDARY, '', retrievedIndexDirective(), '')
   for (const item of items) {
-    lines.push(`## ${item.heading}`, '')
+    lines.push(`## ${item.heading}`)
     if (!isChannel) {
       lines.push(item.excerpt.trimEnd(), '')
     } else if (item.source === 'topic' || item.source === 'reference') {
@@ -209,12 +209,12 @@ function renderSection(plan: InjectionPlan, options: LoadMemoryOptions): string 
   } else if (plan.mode === 'index') {
     lines.push(indexDirective(options), '')
     for (const shard of plan.shards) {
-      lines.push(`## ${shard.frontmatter.heading}`, '')
+      lines.push(`## ${shard.frontmatter.heading}`)
       lines.push(renderShardMetadata(shard), '')
     }
   } else {
     for (const topic of plan.shards.map(topicEntryFromShard)) {
-      lines.push(`## ${topic.name}`, '')
+      lines.push(`## ${topic.name}`)
       lines.push(renderBody(topic), '')
     }
   }


### PR DESCRIPTION
## Background

The memory section renders each topic as a heading followed by a blank line before the body, slug, and directives. That blank line is pure Markdown formatting overhead with no semantic value: the `##` heading is sufficient whitespace for LLM parsing, and nothing in the retrieval pipeline keys on the blank line.

In system-prompt mode this cost is paid once per session and is cache-stable. In vector mode the memory block is injected per-turn into the user prompt — outside the cache prefix — so every topic heading carries an extra line every turn. At typical corpus sizes (tens of shards) the blank lines add up across turns.

## Summary

Remove the empty-string element pushed after each `## <heading>` in all three render paths:

- `renderDedupedMemorySection` — cross-turn dedup path (topic entries and unchanged-shard references)
- `renderRetrievedMemorySection` — vector per-turn retrieval path
- `renderSection` — system-prompt index and direct render paths

The heading marker is preserved. Bodies, slugs, and directives are unchanged. The only effect is collapsing the one blank line that separated each heading from its content.

Why not also strip the blank line that follows the body? That blank line acts as the inter-section separator — removing it conflates adjacent topics into one visual block and risks confusing the model's shard-boundary parsing. This change is the safe subset: heading-to-content gap only.

## Preview

Before:

```
## cooking-tips

Slug: cooking-tips
Always toast spices before grinding.
```

After:

```
## cooking-tips
Slug: cooking-tips
Always toast spices before grinding.
```

## What this does NOT do

- Does not change which headings, bodies, slugs, or directives are emitted.
- Does not alter retrieval quality — the `##` salience anchor is unchanged.
- Does not touch the system-prompt-mode cache prefix; the memory block there was already cached.
- Does not change any test fixtures (no format-contract test asserted the heading→content blank line).
- Does not affect any path outside `load-memory.ts`.

## Review notes

The load-bearing change is the removal of the empty string from the `lines.push(...)` call that emits each heading:

```ts
// Before
lines.push(`## ${topic.name}`, '')
// After
lines.push(`## ${topic.name}`)
```

Applied identically across all five heading sites in the three render functions listed in Summary above.

Verification: typecheck clean, lint 0 errors, format clean, `bun test --parallel src/bundled-plugins/memory/` 782 pass / 0 fail.