### PR TITLE
perf(memory): warm the vector embedder at boot so the first turn is fast

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-warm.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-warm.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// A controllable transformers fake whose pipeline load can be made to fail on
+// demand, so we can prove getEmbedder/warmEmbedder recover from a transient
+// load failure instead of caching the rejection forever. Kept in its own file
+// (separate from embedder-lazy-load.test.ts) because the embedder memoizes a
+// module-level singleton across a file's tests — a failable mock here must not
+// perturb the lazy-load regression guard there.
+let pipelineCalls = 0
+let failNextPipeline = false
+
+mock.module('@huggingface/transformers', () => ({
+  env: {},
+  pipeline: async () => {
+    pipelineCalls += 1
+    if (failNextPipeline) throw new Error('local_files_only: model weights missing')
+    return () => ({ data: new Float32Array(768) })
+  },
+}))
+
+beforeEach(() => {
+  pipelineCalls = 0
+  failNextPipeline = false
+})
+
+describe('embedder warm-up and retry-safe memoization', () => {
+  test('warmEmbedder loads the embedder so a later call reuses the singleton', async () => {
+    const { warmEmbedder, getEmbedder } = await freshEmbedderModule()
+
+    await warmEmbedder()
+    await getEmbedder()
+
+    expect(pipelineCalls).toBe(1)
+  })
+
+  test('a rejected load is not cached: the next call retries instead of replaying the rejection', async () => {
+    const { getEmbedder } = await freshEmbedderModule()
+
+    // given: the first load fails
+    failNextPipeline = true
+    await expect(getEmbedder()).rejects.toThrow('model weights missing')
+
+    // when: the underlying cause clears and the caller retries
+    failNextPipeline = false
+    await getEmbedder()
+
+    // then: the second attempt actually re-ran the load (rejection wasn't memoized)
+    expect(pipelineCalls).toBe(2)
+  })
+
+  test('warmEmbedder failure degrades to a working per-turn load on retry', async () => {
+    const { warmEmbedder, embed } = await freshEmbedderModule()
+
+    failNextPipeline = true
+    await expect(warmEmbedder()).rejects.toThrow('model weights missing')
+
+    failNextPipeline = false
+    const embeddings = await embed(['hello'], 'query')
+
+    expect(embeddings).toHaveLength(1)
+  })
+})
+
+// Bun's module registry memoizes embedder.ts across tests, so its singleton
+// would leak between the cases above. A cache-busting query string forces a
+// fresh module instance (and thus a fresh embedderInstance) per test.
+async function freshEmbedderModule(): Promise<typeof import('./embedder')> {
+  return import(`./embedder?warm=${crypto.randomUUID()}`)
+}

--- a/src/bundled-plugins/memory/vector/embedder-warm.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-warm.test.ts
@@ -1,11 +1,11 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { describe, expect, mock, test } from 'bun:test'
 
 // A controllable transformers fake whose pipeline load can be made to fail on
 // demand, so we can prove getEmbedder/warmEmbedder recover from a transient
-// load failure instead of caching the rejection forever. Kept in its own file
-// (separate from embedder-lazy-load.test.ts) because the embedder memoizes a
-// module-level singleton across a file's tests — a failable mock here must not
-// perturb the lazy-load regression guard there.
+// pipeline failure instead of caching the rejection forever. Kept in its own
+// file (separate from embedder-lazy-load.test.ts) because the embedder memoizes
+// a module-level singleton across a file's tests — a failable mock here must
+// not perturb the lazy-load regression guard there.
 let pipelineCalls = 0
 let failNextPipeline = false
 
@@ -18,14 +18,10 @@ mock.module('@huggingface/transformers', () => ({
   },
 }))
 
-beforeEach(() => {
-  pipelineCalls = 0
-  failNextPipeline = false
-})
-
 describe('embedder warm-up and retry-safe memoization', () => {
   test('warmEmbedder loads the embedder so a later call reuses the singleton', async () => {
     const { warmEmbedder, getEmbedder } = await freshEmbedderModule()
+    pipelineCalls = 0
 
     await warmEmbedder()
     await getEmbedder()
@@ -35,6 +31,7 @@ describe('embedder warm-up and retry-safe memoization', () => {
 
   test('a rejected load is not cached: the next call retries instead of replaying the rejection', async () => {
     const { getEmbedder } = await freshEmbedderModule()
+    pipelineCalls = 0
 
     // given: the first load fails
     failNextPipeline = true
@@ -58,6 +55,27 @@ describe('embedder warm-up and retry-safe memoization', () => {
     const embeddings = await embed(['hello'], 'query')
 
     expect(embeddings).toHaveLength(1)
+  })
+
+  test('a rejected transformers module load is not cached: the next call reloads', async () => {
+    const { getEmbedder, __setTransformersImporterForTests } = await freshEmbedderModule()
+
+    // given: the dynamic import / native module load itself fails the first time
+    // then succeeds — driven through the importer seam because Bun snapshots a
+    // mock.module namespace at registration and can't toggle import failure later
+    let importCalls = 0
+    __setTransformersImporterForTests(async () => {
+      importCalls += 1
+      if (importCalls === 1) throw new Error('Cannot find module: sharp platform binary missing')
+      return { env: {} as never, pipeline: (async () => () => ({ data: new Float32Array(768) })) as never }
+    })
+
+    // when: the first load fails and the caller retries after recovery
+    await expect(getEmbedder()).rejects.toThrow('sharp platform binary missing')
+    await getEmbedder()
+
+    // then: transformersModulePromise wasn't memoized as rejected — it reloaded
+    expect(importCalls).toBe(2)
   })
 })
 

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -41,13 +41,34 @@ type FeatureExtractor = Awaited<ReturnType<typeof TransformersPipeline<'feature-
 // drag the heavy native stack onto every container boot — and crash it when
 // sharp can't resolve its platform binary. Memoized so the module evaluates
 // at most once.
-let transformersModulePromise: Promise<{ env: TransformersEnv; pipeline: typeof TransformersPipeline }> | undefined
+type TransformersModule = { env: TransformersEnv; pipeline: typeof TransformersPipeline }
 
-function loadTransformers(): Promise<{ env: TransformersEnv; pipeline: typeof TransformersPipeline }> {
-  transformersModulePromise ??= import('@huggingface/transformers').then((mod) => ({
-    env: mod.env,
-    pipeline: mod.pipeline,
-  }))
+let transformersModulePromise: Promise<TransformersModule> | undefined
+
+const realTransformersImport = (): Promise<TransformersModule> =>
+  import('@huggingface/transformers').then((mod) => ({ env: mod.env, pipeline: mod.pipeline }))
+
+// Injectable importer seam. Defaults to the real dynamic import; a test can
+// swap it to drive the module-load layer (e.g. fail once, then succeed) without
+// fighting Bun's mock.module namespace snapshotting. Bun freezes the mocked
+// namespace at registration, so a runtime-toggled failure can't be expressed
+// through mock.module — this seam is the supported way to exercise it.
+let importTransformers: () => Promise<TransformersModule> = realTransformersImport
+
+export function __setTransformersImporterForTests(importer: (() => Promise<TransformersModule>) | undefined): void {
+  importTransformers = importer ?? realTransformersImport
+  transformersModulePromise = undefined
+}
+
+function loadTransformers(): Promise<TransformersModule> {
+  // Clear the memo on rejection (mirroring getEmbedder) so a transient failure
+  // of the dynamic import / native module load doesn't cache the rejected
+  // promise — otherwise every later getEmbedder() awaits the same dead promise
+  // and per-turn embedding stays poisoned for the life of the process.
+  transformersModulePromise ??= importTransformers().catch((err) => {
+    transformersModulePromise = undefined
+    throw err
+  })
   return transformersModulePromise
 }
 

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -108,8 +108,22 @@ export class Embedder {
 let embedderInstance: Promise<Embedder> | null = null
 
 export function getEmbedder(): Promise<Embedder> {
-  embedderInstance ??= Embedder.load()
+  // Clear the memo on rejection so a transient load failure (e.g. boot warm-up
+  // racing the host model mount) degrades to a retry on the next call instead
+  // of caching the rejected promise and poisoning every later per-turn embed.
+  embedderInstance ??= Embedder.load().catch((err) => {
+    embedderInstance = null
+    throw err
+  })
   return embedderInstance
+}
+
+// Boot-time readiness step: force the lazy embedder to load now so the first
+// per-turn query embed doesn't pay the ~2-5s ONNX init on the critical path.
+// Only called on the vector-enabled boot path (see src/run/index.ts), which
+// preserves embedder.ts's lazy-import guarantee for vector-off boots.
+export async function warmEmbedder(): Promise<void> {
+  await getEmbedder()
 }
 
 export async function embed(texts: string[], type: EmbedType): Promise<Float32Array[]> {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -20,7 +20,7 @@ import {
 } from '@/agent/subagents'
 import { clearTodosForOrigin } from '@/agent/todo/continuation-wiring'
 import { vectorEnabledFromMemoryConfig } from '@/bundled-plugins/memory/vector/config'
-import { embed } from '@/bundled-plugins/memory/vector/embedder'
+import { embed, warmEmbedder } from '@/bundled-plugins/memory/vector/embedder'
 import { buildStartupVectorIndex } from '@/bundled-plugins/memory/vector/startup'
 import { resolveCapOptionsFromConfig } from '@/bundled-plugins/tool-result-cap'
 import {
@@ -226,6 +226,14 @@ export async function startAgent({
   if (suppressSystemMemory) {
     await buildStartupVectorIndex(cwd, embed).catch((err) => {
       console.warn(`[vector] startup index build failed: ${err instanceof Error ? err.message : String(err)}`)
+    })
+
+    // Warm the embedder now (even when the index needed no rebuild above, which
+    // skips embed() entirely) so the first channel turn's query embed doesn't
+    // pay the one-time ONNX init on its critical path. Non-fatal: a failure here
+    // degrades to the per-turn lazy load, same as before this step existed.
+    await warmEmbedder().catch((err) => {
+      console.warn(`[vector] embedder warm-up failed: ${err instanceof Error ? err.message : String(err)}`)
     })
   }
 


### PR DESCRIPTION
## Problem

On a vector-enabled agent (`memory.vector.enabled: true`), the **first** channel turn after container start was paying a one-time ~2-5s cost to lazy-load the local ONNX embedding model (`Xenova/multilingual-e5-base` q8, ~279 MB) on the critical path — inside `hybridSearch`'s per-turn query embed.

The boot already calls `buildStartupVectorIndex` before channels accept traffic, which *would* load the embedder — but only as a side effect of embedding missing passages. In the steady state (index already current), `buildStartupVectorIndex` short-circuits at `findMissingPassages.length === 0` and returns `{ built: false }` **without ever calling `embed()`**. So the embedder stayed cold until the first user turn.

This is the dominant first-response delay for warm-index boots.

## Fix

- Add `warmEmbedder()` to `vector/embedder.ts` and call it at boot in `src/run/index.ts`, right after `buildStartupVectorIndex`, **inside the existing `suppressSystemMemory` (=== `vector.enabled`) block**, before `channelManager.start()`. This forces the embedder to load while channels are still gated, so the first turn's query embed is warm.
  - Kept as an **explicit boot step**, not hidden inside `buildStartupVectorIndex` — warming the query embedder is a boot-readiness concern, not an index-build concern.
  - **Non-fatal**: a warm-up failure logs `[vector] embedder warm-up failed: …` and degrades to the prior per-turn lazy load. Same failure posture as the existing startup index build.
  - Only runs on the vector-enabled path, preserving `embedder.ts`'s load-bearing lazy-import guarantee (a top-level transformers import drags `sharp`/onnxruntime onto every boot and crashes vector-off containers).

- Make `getEmbedder()` **clear its memoized singleton on a rejected load**. Previously `embedderInstance ??= Embedder.load()` cached the rejected promise, so a transient boot warm-up failure would poison *every* later per-turn embed for the life of the process. Now a failed load retries on the next call.

## Tests

New `vector/embedder-warm.test.ts` (mocks `@huggingface/transformers`, never loads the real 279 MB model):
- `warmEmbedder` loads the embedder; a later `getEmbedder` reuses the singleton (one pipeline load).
- A rejected load is **not** cached — the next call retries (asserts the load actually re-ran).
- A `warmEmbedder` failure degrades to a working per-turn `embed` on retry.

The existing `embedder-lazy-load.test.ts` regression guard (transformers not evaluated at import) still passes — the new failable mock lives in its own file so it can't perturb that singleton.

## Checks

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full `bun run test` (8979 pass, 0 fail) all green.