### PR TITLE
fix(memory): pin transformers to an exact version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@clack/core": "^1.2.0",
         "@clack/prompts": "^1.2.0",
-        "@huggingface/transformers": "^4.2.0",
+        "@huggingface/transformers": "4.2.0",
         "@mariozechner/pi-coding-agent": "^0.67.3",
         "@mariozechner/pi-tui": "^0.67.3",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
-    "@huggingface/transformers": "^4.2.0",
+    "@huggingface/transformers": "4.2.0",
     "@mariozechner/pi-coding-agent": "^0.67.3",
     "@mariozechner/pi-tui": "^0.67.3",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -20,6 +20,7 @@ import {
   CURL_IMPERSONATE_VERSION,
   NETWORK_BLOCK_IPV4_NETS,
   NETWORK_BLOCK_IPV6_NETS,
+  TRANSFORMERS_VERSION,
   TYPECLAW_ENTRYPOINT_PATH,
 } from './dockerfile'
 
@@ -976,12 +977,38 @@ describe('transformers native-deps layer (sharp + onnxruntime linux binaries)', 
     expect(out).toContain('"@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4"')
   })
 
-  test('sharp and its libvips platform package are pinned to the same versions @huggingface/transformers@^4.2.0 resolves (0.34.5 / 1.2.4) — mismatched sharp/libvips platform packages are a known load-time failure mode', () => {
+  test('sharp and its libvips platform package are pinned to the same versions @huggingface/transformers@4.2.0 resolves (0.34.5 / 1.2.4) — mismatched sharp/libvips platform packages are a known load-time failure mode', () => {
     const out = buildDockerfile()
     const sharpVersions = out.match(/@img\/sharp-linux-\$\{SHARP_ARCH\}@(\S+?)"/)
     const libvipsVersions = out.match(/@img\/sharp-libvips-linux-\$\{SHARP_ARCH\}@(\S+?)"/)
     expect(sharpVersions?.[1]).toBe('0.34.5')
     expect(libvipsVersions?.[1]).toBe('1.2.4')
+  })
+
+  // The Layer 7 `bun add` runs at WORKDIR / with no project lockfile, so the
+  // repo bun.lock does NOT constrain it. A bare `@huggingface/transformers`
+  // (no version) resolves npm `latest` at build time and would drift past the
+  // hard-pinned sharp/libvips below — the day a newer transformers ships, the
+  // container installs it against the fixed sharp pins and crashes at import.
+  // These guards fail if the version is ever dropped back to a caret/bare name.
+  for (const [label, render] of [
+    ['inline (dev)', () => buildDockerfile()],
+    ['versioned (base-image)', () => buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' })],
+    ['base', () => buildBaseDockerfile()],
+  ] as const) {
+    test(`${label} form pins @huggingface/transformers to an EXACT version (not a caret/bare name) so the lockfile-free Layer 7 install can't drift past the sharp pins`, () => {
+      const out = render()
+      expect(out).toContain(`@huggingface/transformers@${TRANSFORMERS_VERSION}`)
+      expect(out).not.toContain('@huggingface/transformers \\')
+      expect(out).not.toContain('@huggingface/transformers@^')
+    })
+  }
+
+  test('TRANSFORMERS_VERSION matches the @huggingface/transformers pin in package.json — host download (models.ts) and container install (Layer 7) must resolve the same library, and the package.json pin is exact (no caret) so the repo install agrees', () => {
+    const pkg = JSON.parse(readFileSync(join(import.meta.dir, '..', '..', 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies['@huggingface/transformers']).toBe(TRANSFORMERS_VERSION)
   })
 
   // Regression guard for the bind-mount masking failure. `typeclaw start`

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -610,21 +610,35 @@ RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
 // so the linux binary resolves. WORKDIR is restored to /agent afterwards so
 // later layers and the runtime CWD are unchanged.
 //
-// Versions are pinned to what @huggingface/transformers@^4.2.0 resolves today.
-// A future transformers bump that moves sharp must bump `sharp@`,
-// `@img/sharp-linux-*`, and `@img/sharp-libvips-linux-*` together — mismatched
-// sharp/libvips platform packages are a known failure mode. `$TARGETARCH` is
-// `arm64` or `amd64`; an empty value (bare `docker build` without buildx) falls
-// back to x64 for determinism.
+// EXACT transformers version this image installs. Must stay in lockstep with
+// `@huggingface/transformers` in the repo package.json (a guard test in
+// dockerfile.test.ts asserts the two agree). The pin is EXACT — not a caret —
+// because this layer's `bun add` runs at `WORKDIR /` with NO project lockfile,
+// so the repo `bun.lock` does NOT constrain it. A bare `@huggingface/
+// transformers` (no version) would resolve npm `latest` at BUILD time: the day
+// a newer transformers ships, the container would install it while the
+// sharp/libvips pins below stay fixed, and the mismatched sharp platform
+// packages crash at container import ("Could not load the sharp module using
+// the linux-<arch> runtime"). Pinning the version closes that drift.
+export const TRANSFORMERS_VERSION = '4.2.0'
+
+// sharp + libvips versions are pinned to what @huggingface/transformers@4.2.0
+// resolves. A future transformers bump that moves sharp must bump
+// TRANSFORMERS_VERSION, `sharp@`, `@img/sharp-linux-*`, and
+// `@img/sharp-libvips-linux-*` together — mismatched sharp/libvips platform
+// packages are a known failure mode. `$TARGETARCH` is `arm64` or `amd64`; an
+// empty value (bare `docker build` without buildx) falls back to x64 for
+// determinism.
 const LAYER_TRANSFORMERS_INSTALL = `# Layer 7: install @huggingface/transformers with its linux-native binaries.
 # Installs the linux onnxruntime-node addon AND sharp's linux platform packages
 # (@img/sharp-linux-*) into the image's /node_modules so they survive the
 # runtime /agent bind mount and still win Node/Bun resolution from
-# /agent/node_modules/sharp. See src/init/dockerfile.ts for the rationale.
+# /agent/node_modules/sharp. The transformers version is pinned EXACT (this
+# bun add has no lockfile) — see src/init/dockerfile.ts for the rationale.
 WORKDIR /
 RUN SHARP_ARCH="$(if [ "\${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)" \\
  && bun add \\
-      @huggingface/transformers \\
+      @huggingface/transformers@${TRANSFORMERS_VERSION} \\
       sharp@0.34.5 \\
       "@img/sharp-linux-\${SHARP_ARCH}@0.34.5" \\
       "@img/sharp-libvips-linux-\${SHARP_ARCH}@1.2.4"


### PR DESCRIPTION
## Background

`memory.vector.enabled` runs text embeddings through `@huggingface/transformers` (transformers.js → onnxruntime-node CPU + sharp). The native binary stack is installed by the per-agent Dockerfile's **Layer 7** (`LAYER_TRANSFORMERS_INSTALL`), which `bun add`s transformers plus its arch-matched `sharp@0.34.5` / `@img/sharp-libvips-linux-*@1.2.4` platform packages.

The problem: that `bun add` runs at `WORKDIR /` (so the linux binaries land in the unmasked `/node_modules`, surviving the runtime `-v <cwd>:/agent` bind mount) — **with no project lockfile present**. So the repo `bun.lock` does not constrain it. The transformers package was specified with no version, which resolves npm `latest` at build time.

`4.2.0` is npm `latest` today, so nothing is broken right now. But the moment a transformers `>4.2.0` ships, Layer 7 would install it against the still-hard-pinned `sharp@0.34.5` / `libvips@1.2.4`. Mismatched sharp/libvips platform packages are a known load-time failure: the container crashes at first `import('@huggingface/transformers')` with `Could not load the sharp module using the linux-<arch> runtime` (or a silent `local_files_only` model-cache miss if the cache layout moved). The existing tests guarded the literal pin *strings*, not the *resolution*, so they would not have caught this.

## Summary

Pin `@huggingface/transformers` to an **exact** `4.2.0` (no caret) in both places that install it:

- `package.json` dependency (also propagated into `bun.lock`).
- Dockerfile Layer 7 `bun add`, via a new exported `TRANSFORMERS_VERSION` constant so the literal can't drift between the comment, the install line, and the guard test.

Why exact and not a caret: the Layer 7 install is lockfile-free, so a caret would still float to the newest matching release at build time — the exact pin is the only thing that makes the container install deterministic and keeps it aligned with the hard-coded sharp/libvips pins. Bumping transformers is now a deliberate, reviewable change to one constant (the existing comment already documents the "bump sharp + libvips together" invariant; it now also names `TRANSFORMERS_VERSION`).

Guard tests added: the inline/versioned/base Dockerfile forms must carry `@huggingface/transformers@<exact>` (and must NOT carry a bare or caret form), and `TRANSFORMERS_VERSION` must equal the `package.json` dependency so the host downloader (`src/hostd/models.ts`) and the container install resolve the same library.

## What this does NOT do

- Does not bump any version — `4.2.0` is exactly what was resolving before; this only freezes it.
- Does not touch sharp/libvips/onnxruntime pins (already exact).
- Does not add the host/container model-cache sentinel or the in-image embedding smoke test discussed during review — those are deferred follow-ups (see review notes).

## Review notes

Load-bearing change is the single Dockerfile line `@huggingface/transformers@${TRANSFORMERS_VERSION}` plus the exact `package.json` pin. Invariant to verify: `TRANSFORMERS_VERSION` (dockerfile.ts) === `dependencies["@huggingface/transformers"]` (package.json) === the sharp version's resolved transformers — the new `dockerfile.test.ts` guards assert the first two; the third stays a documented manual-bump invariant.

Deferred (raised in review, intentionally out of scope here): a model-cache sentinel to make host/container transformers drift fail loudly, and a real in-image embedding smoke test (one 768-dim embedding against the mounted q8 model on amd64+arm64) to assert the onnxruntime-node N-API-v6-under-Bun + q8 CPU path actually works rather than only that the Dockerfile strings are correct.
