### PR TITLE
feat(memory): model-cache sentinel to fail loudly on host/container drift

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-batch.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-batch.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { beforeAll, describe, expect, mock, test } from 'bun:test'
 
-import { DIMS } from './embedder'
+import { __setModelCacheCheckForTests, DIMS } from './embedder'
 
 // Records the size of every onnxruntime forward pass so the test can prove the
 // embed is chunked (bounding peak memory) rather than run as one giant batch.
@@ -23,6 +23,10 @@ mock.module('@huggingface/transformers', () => ({
 }))
 
 describe('embedder batching', () => {
+  beforeAll(() => {
+    __setModelCacheCheckForTests(() => Promise.resolve())
+  })
+
   test('splits a large input set into bounded forward passes and preserves order', async () => {
     const { embed } = await import('./embedder')
     const inputs = Array.from({ length: 150 }, (_, i) => `passage ${i}`)

--- a/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { beforeAll, describe, expect, mock, test } from 'bun:test'
 
 // Regression guard for the container-boot crash: `@huggingface/transformers`
 // eagerly `import sharp`s at module-evaluation time, and the memory plugin
@@ -24,6 +24,14 @@ mock.module('@huggingface/transformers', () => {
 })
 
 describe('embedder lazy transformers load', () => {
+  // Importing the module to set the seam does NOT evaluate transformers (that is
+  // exactly what the first test asserts) — the cache check is a separate concern
+  // with its own coverage, so a no-op keeps these tests off a real model cache.
+  beforeAll(async () => {
+    const mod = await import('./embedder')
+    mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  })
+
   test('importing the embedder module does NOT evaluate @huggingface/transformers', async () => {
     await import('./embedder')
     expect(transformersEvaluated).toBe(false)

--- a/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 
-import { DIMS } from './embedder'
+import { __setModelCacheCheckForTests, DIMS } from './embedder'
 import { estimateTokens, TEXT_TOKEN_BUDGET } from './truncation'
+
+__setModelCacheCheckForTests(() => Promise.resolve())
 
 let lastExtractorInput: string[] | undefined
 let lastExtractorOptions: Record<string, unknown> | undefined

--- a/src/bundled-plugins/memory/vector/embedder-warm.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-warm.test.ts
@@ -83,5 +83,7 @@ describe('embedder warm-up and retry-safe memoization', () => {
 // would leak between the cases above. A cache-busting query string forces a
 // fresh module instance (and thus a fresh embedderInstance) per test.
 async function freshEmbedderModule(): Promise<typeof import('./embedder')> {
-  return import(`./embedder?warm=${crypto.randomUUID()}`)
+  const mod = await import(`./embedder?warm=${crypto.randomUUID()}`)
+  mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  return mod
 }

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -6,21 +6,24 @@ import { join } from 'node:path'
 // values are pulled lazily via `loadTransformers()` below.
 import type { env as TransformersEnvValue, pipeline as TransformersPipeline } from '@huggingface/transformers'
 
+import {
+  assertModelCacheCompatible,
+  EMBEDDING_DIMS,
+  EMBEDDING_MODEL_DTYPE,
+  EMBEDDING_MODEL_ID,
+  EMBEDDING_MODEL_NAME,
+} from '@/models/embedding-model'
+import { getResolvedTransformersVersion } from '@/models/transformers-version'
+
 import { homeRoot } from '../../../hostd/paths'
 import { type BoundedText, boundEmbeddableText, MAX_MODEL_TOKENS } from './truncation'
 
-export const MODEL_NAME = 'Xenova/multilingual-e5-base'
-export const DIMS = 768
-// MUST match src/hostd/models.ts MODEL_DTYPE: the host downloads exactly this
-// variant, and this loader runs local_files_only, so a mismatch loads nothing.
-// q8 → onnx/model_quantized.onnx (~279 MB); the default would be fp32 (1.11 GB).
-export const MODEL_DTYPE = 'q8'
-
-// The index identity. dtype changes the embedding values (q8 ≠ fp32) while
-// MODEL_NAME and DIMS stay constant, so neither alone detects a variant switch.
-// Vectors are stamped with this and retrieval filters on it — rows from a
-// different variant are stale and never compared against a query of this one.
-export const EMBEDDING_MODEL_ID = `${MODEL_NAME}@${MODEL_DTYPE}`
+// Re-exported for the vector subsystem's existing imports. The canonical
+// definitions live in @/models/embedding-model (shared host + container).
+export const MODEL_NAME = EMBEDDING_MODEL_NAME
+export const DIMS = EMBEDDING_DIMS
+export const MODEL_DTYPE = EMBEDDING_MODEL_DTYPE
+export { EMBEDDING_MODEL_ID }
 
 export type EmbedType = 'query' | 'passage'
 
@@ -60,6 +63,21 @@ export function __setTransformersImporterForTests(importer: (() => Promise<Trans
   transformersModulePromise = undefined
 }
 
+// Injectable cache-compatibility check, mirroring the importer seam above. In
+// production it asserts the host-stamped sentinel matches this container before
+// the local_files_only load. The embedder's own mechanics tests (batching,
+// lazy-load, warm-up) mock transformers and run against the default cache path
+// with no sentinel, so they swap in a no-op — the sentinel guard has its own
+// dedicated coverage in embedding-model.test.ts.
+const realModelCacheCheck = (): Promise<void> =>
+  assertModelCacheCompatible(modelCachePath(), { transformers: getResolvedTransformersVersion() })
+
+let verifyModelCache: () => Promise<void> = realModelCacheCheck
+
+export function __setModelCacheCheckForTests(check: (() => Promise<void>) | undefined): void {
+  verifyModelCache = check ?? realModelCacheCheck
+}
+
 function loadTransformers(): Promise<TransformersModule> {
   // Clear the memo on rejection (mirroring getEmbedder) so a transient failure
   // of the dynamic import / native module load doesn't cache the rejected
@@ -77,6 +95,10 @@ export class Embedder {
 
   static async load(): Promise<Embedder> {
     const { env, pipeline } = await loadTransformers()
+    // Guard the cache BEFORE local_files_only load: a host/container transformers
+    // drift (or a hand-copied cache) otherwise surfaces as a cryptic missing-file
+    // miss, or silently loads a stale variant. Fails loudly with a refresh hint.
+    await verifyModelCache()
     configureTransformers(env)
     const extractor = await pipeline('feature-extraction', MODEL_NAME, { local_files_only: true, dtype: MODEL_DTYPE })
     return new Embedder(extractor)

--- a/src/hostd/ensure-models.test.ts
+++ b/src/hostd/ensure-models.test.ts
@@ -53,6 +53,17 @@ describe('ensureModels', () => {
     expect(pipelineCalls[0]?.options?.dtype).toBe('q8')
   })
 
+  test('stamps a model-cache sentinel after the download so the container can verify producer/consumer compatibility', async () => {
+    const { modelsDir } = await import('./paths')
+    const { readModelSentinel } = await import('@/models/embedding-model')
+
+    const sentinel = await readModelSentinel(modelsDir())
+    expect(sentinel).not.toBeNull()
+    expect(sentinel?.model).toBe('Xenova/multilingual-e5-base')
+    expect(sentinel?.dtype).toBe('q8')
+    expect(sentinel?.transformers).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
   test('modelsDir points under TYPECLAW_HOME', async () => {
     const { modelsDir } = await import('./paths')
 

--- a/src/hostd/models.ts
+++ b/src/hostd/models.ts
@@ -4,17 +4,20 @@ import { join } from 'node:path'
 import { env as transformersEnv, pipeline } from '@huggingface/transformers'
 import lockfile from 'proper-lockfile'
 
+import { EMBEDDING_MODEL_DTYPE, EMBEDDING_MODEL_NAME, writeModelSentinel } from '@/models/embedding-model'
+import { getResolvedTransformersVersion } from '@/models/transformers-version'
+
 import { modelsDir } from './paths'
 
-const MODEL_NAME = 'Xenova/multilingual-e5-base'
 // q8 → onnx/model_quantized.onnx (~279 MB). Without this, dtype defaults to
 // 'auto', which resolves to fp32 (onnx/model.onnx, 1.11 GB) on CPU/non-WASM
 // devices — 4x the download for no quality gain at this corpus size. The
 // gold-set eval that chose e5-base (recall@3 96.9%) was run on this q8 variant.
-// MUST match the embedder's dtype (src/bundled-plugins/memory/vector/embedder.ts):
-// the host downloads what the container loads with local_files_only, so a
-// mismatch makes the container request a file that was never fetched.
-const MODEL_DTYPE = 'q8'
+// Shared with the container embedder via @/models/embedding-model: the host
+// downloads what the container loads with local_files_only, so a mismatch
+// makes the container request a file that was never fetched.
+const MODEL_NAME = EMBEDDING_MODEL_NAME
+const MODEL_DTYPE = EMBEDDING_MODEL_DTYPE
 const LOCK_RETRIES = { retries: 60, factor: 1, minTimeout: 100, maxTimeout: 100, randomize: false } as const
 
 let ensureModelsPromise: Promise<void> | null = null
@@ -46,6 +49,10 @@ async function ensureModelsLocked(): Promise<void> {
   try {
     configureTransformers(dir)
     await pipeline('feature-extraction', MODEL_NAME, { dtype: MODEL_DTYPE })
+    // Stamp the cache with the version that produced it, still under the lock,
+    // so the container can verify the producer matches its consumer before a
+    // local_files_only load (see assertModelCacheCompatible).
+    await writeModelSentinel(dir, { transformers: getResolvedTransformersVersion() })
   } finally {
     await release()
   }

--- a/src/models/embedding-model.test.ts
+++ b/src/models/embedding-model.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  assertModelCacheCompatible,
+  EMBEDDING_DIMS,
+  EMBEDDING_MODEL_DTYPE,
+  EMBEDDING_MODEL_NAME,
+  readModelSentinel,
+  writeModelSentinel,
+} from './embedding-model'
+
+async function tmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'typeclaw-sentinel-'))
+}
+
+describe('model sentinel write/read round-trip', () => {
+  test('writeModelSentinel stamps the full identity and readModelSentinel parses it back', async () => {
+    const dir = await tmpDir()
+
+    await writeModelSentinel(dir, { transformers: '4.2.0' })
+
+    const sentinel = await readModelSentinel(dir)
+    expect(sentinel).toEqual({
+      schemaVersion: 1,
+      model: EMBEDDING_MODEL_NAME,
+      dtype: EMBEDDING_MODEL_DTYPE,
+      dims: EMBEDDING_DIMS,
+      recipe: 'e5-prefix:mean-pool:l2-normalize',
+      transformers: '4.2.0',
+    })
+  })
+
+  test('the sentinel lands at .typeclaw-model.json so the container reads a stable filename', async () => {
+    const dir = await tmpDir()
+
+    await writeModelSentinel(dir, { transformers: '4.2.0' })
+
+    const raw = await readFile(join(dir, '.typeclaw-model.json'), 'utf8')
+    expect(JSON.parse(raw)).toMatchObject({ transformers: '4.2.0', model: EMBEDDING_MODEL_NAME })
+  })
+})
+
+describe('readModelSentinel resilience', () => {
+  test('returns null when the file is absent — never throws, so the caller decides the policy', async () => {
+    const dir = await tmpDir()
+
+    expect(await readModelSentinel(dir)).toBeNull()
+  })
+
+  test('returns null for malformed JSON instead of throwing a parse error', async () => {
+    const dir = await tmpDir()
+    await writeFile(join(dir, '.typeclaw-model.json'), '{not json', 'utf8')
+
+    expect(await readModelSentinel(dir)).toBeNull()
+  })
+
+  test('returns null for a wrong-schema sentinel (e.g. a future schemaVersion or missing field)', async () => {
+    const dir = await tmpDir()
+    await writeFile(join(dir, '.typeclaw-model.json'), JSON.stringify({ schemaVersion: 2, model: 'x' }), 'utf8')
+
+    expect(await readModelSentinel(dir)).toBeNull()
+  })
+})
+
+describe('assertModelCacheCompatible', () => {
+  test('passes when the cache identity matches the container expectation', async () => {
+    const dir = await tmpDir()
+    await writeModelSentinel(dir, { transformers: '4.2.0' })
+
+    await expect(assertModelCacheCompatible(dir, { transformers: '4.2.0' })).resolves.toBeUndefined()
+  })
+
+  test('throws naming the transformers drift when host produced a different version than the container expects', async () => {
+    const dir = await tmpDir()
+    await writeModelSentinel(dir, { transformers: '4.2.0' })
+
+    await expect(assertModelCacheCompatible(dir, { transformers: '4.3.0' })).rejects.toThrow(
+      /cache has "4\.2\.0", container expects "4\.3\.0"/,
+    )
+  })
+
+  test('throws with a refresh hint when the sentinel is absent — a stale/hand-copied cache must not silently load', async () => {
+    const dir = await tmpDir()
+
+    await expect(assertModelCacheCompatible(dir, { transformers: '4.2.0' })).rejects.toThrow(
+      /missing or has an unreadable .* Re-run `typeclaw start`/s,
+    )
+  })
+
+  test('detects a model/dtype drift even when the transformers version agrees', async () => {
+    const dir = await tmpDir()
+    await writeFile(
+      join(dir, '.typeclaw-model.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        model: 'some/other-model',
+        dtype: 'fp32',
+        dims: 1024,
+        recipe: 'e5-prefix:mean-pool:l2-normalize',
+        transformers: '4.2.0',
+      }),
+      'utf8',
+    )
+
+    await expect(assertModelCacheCompatible(dir, { transformers: '4.2.0' })).rejects.toThrow(/model:|dtype:|dims:/)
+  })
+})

--- a/src/models/embedding-model.ts
+++ b/src/models/embedding-model.ts
@@ -1,0 +1,114 @@
+import { readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const EMBEDDING_MODEL_NAME = 'Xenova/multilingual-e5-base'
+export const EMBEDDING_MODEL_DTYPE = 'q8'
+export const EMBEDDING_DIMS = 768
+
+// The embedding recipe that makes two vectors comparable: E5 query/passage
+// prefixing + mean pooling + L2 normalize. Stamped in the sentinel (not folded
+// into EMBEDDING_MODEL_ID, which is a stored-row filter — changing the ID would
+// invalidate every existing vector row). A future pooling/normalize change
+// bumps this string so a stale cache fails the sentinel loudly.
+export const EMBEDDING_RECIPE = 'e5-prefix:mean-pool:l2-normalize'
+
+// Stored-row identity = name@dtype. Used by the vector store to filter rows
+// from an incompatible model/dtype variant out of cosine scans.
+export const EMBEDDING_MODEL_ID = `${EMBEDDING_MODEL_NAME}@${EMBEDDING_MODEL_DTYPE}`
+
+const SENTINEL_FILE = '.typeclaw-model.json'
+
+export type ModelSentinel = {
+  schemaVersion: 1
+  model: string
+  dtype: string
+  dims: number
+  recipe: string
+  transformers: string
+}
+
+function sentinelPath(dir: string): string {
+  return join(dir, SENTINEL_FILE)
+}
+
+function expectedSentinel(transformers: string): Omit<ModelSentinel, 'transformers'> & { transformers: string } {
+  return {
+    schemaVersion: 1,
+    model: EMBEDDING_MODEL_NAME,
+    dtype: EMBEDDING_MODEL_DTYPE,
+    dims: EMBEDDING_DIMS,
+    recipe: EMBEDDING_RECIPE,
+    transformers,
+  }
+}
+
+// Atomic write-then-rename so a container reader can never observe a partial
+// JSON file mid-write. Called host-side after a successful model download,
+// inside the proper-lockfile critical section.
+export async function writeModelSentinel(dir: string, input: { transformers: string }): Promise<void> {
+  const sentinel = expectedSentinel(input.transformers)
+  const tmp = `${sentinelPath(dir)}.${process.pid}.tmp`
+  await writeFile(tmp, `${JSON.stringify(sentinel, null, 2)}\n`, 'utf8')
+  await rename(tmp, sentinelPath(dir))
+}
+
+export async function readModelSentinel(dir: string): Promise<ModelSentinel | null> {
+  let raw: string
+  try {
+    raw = await readFile(sentinelPath(dir), 'utf8')
+  } catch {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<ModelSentinel>
+    if (
+      parsed.schemaVersion !== 1 ||
+      typeof parsed.model !== 'string' ||
+      typeof parsed.dtype !== 'string' ||
+      typeof parsed.dims !== 'number' ||
+      typeof parsed.recipe !== 'string' ||
+      typeof parsed.transformers !== 'string'
+    ) {
+      return null
+    }
+    return parsed as ModelSentinel
+  } catch {
+    return null
+  }
+}
+
+// Throws a TypeClaw-authored error (naming observed vs expected identity, with
+// the fix) BEFORE the container's `local_files_only` pipeline load — so a
+// host/container drift surfaces as a clear "refresh the cache" message instead
+// of a cryptic missing-file miss, OR worse, a stale file that loads against a
+// different producer's layout and silently returns garbage vectors. Absent
+// sentinel is a hard failure: host ensureModels() writes it before `docker
+// run` in the same `typeclaw start`, so a missing one means the mount is wrong
+// or the cache was hand-copied — exactly the case we must not paper over.
+export async function assertModelCacheCompatible(dir: string, expected: { transformers: string }): Promise<void> {
+  const sentinel = await readModelSentinel(dir)
+  const want = expectedSentinel(expected.transformers)
+  if (sentinel === null) {
+    throw new Error(
+      `TypeClaw model cache at ${dir} is missing or has an unreadable ${SENTINEL_FILE}, so compatibility with ` +
+        `this container cannot be verified. Re-run \`typeclaw start\` to refresh the model cache; if it was copied ` +
+        `manually, delete it and start again.`,
+    )
+  }
+  const mismatches = describeMismatches(sentinel, want)
+  if (mismatches.length > 0) {
+    throw new Error(
+      `TypeClaw model cache at ${dir} is incompatible with this container (${mismatches.join('; ')}). ` +
+        `Re-run \`typeclaw start\` to refresh the model cache.`,
+    )
+  }
+}
+
+function describeMismatches(got: ModelSentinel, want: ModelSentinel): string[] {
+  const fields: Array<keyof ModelSentinel> = ['model', 'dtype', 'dims', 'recipe', 'transformers']
+  return fields
+    .filter((field) => got[field] !== want[field])
+    .map(
+      (field) => `${field}: cache has ${JSON.stringify(got[field])}, container expects ${JSON.stringify(want[field])}`,
+    )
+}

--- a/src/models/transformers-version.test.ts
+++ b/src/models/transformers-version.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, test } from 'bun:test'
 import { getResolvedTransformersVersion } from './transformers-version'
 
 describe('getResolvedTransformersVersion', () => {
-  test('returns the installed @huggingface/transformers semver from its own package.json (resolved, not a typeclaw constant)', () => {
+  test('resolves the installed @huggingface/transformers semver from its own package.json without throwing', () => {
+    // Guards the ERR_PACKAGE_PATH_NOT_EXPORTED hazard: the package does not
+    // export a ./package.json subpath, so the version must be derived from the
+    // resolved (exported) entry, not a direct subpath require.
     const version = getResolvedTransformersVersion()
 
     expect(version).toMatch(/^\d+\.\d+\.\d+/)

--- a/src/models/transformers-version.test.ts
+++ b/src/models/transformers-version.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getResolvedTransformersVersion } from './transformers-version'
+
+describe('getResolvedTransformersVersion', () => {
+  test('returns the installed @huggingface/transformers semver from its own package.json (resolved, not a typeclaw constant)', () => {
+    const version = getResolvedTransformersVersion()
+
+    expect(version).toMatch(/^\d+\.\d+\.\d+/)
+  })
+})

--- a/src/models/transformers-version.ts
+++ b/src/models/transformers-version.ts
@@ -1,0 +1,20 @@
+import { createRequire } from 'node:module'
+
+// The ACTUALLY-INSTALLED @huggingface/transformers version in the current
+// runtime, read from the resolved package's own package.json — NOT from
+// typeclaw's dependency spec (which is the intended version, not what is on
+// disk). The model-cache sentinel compares this across stages: the host
+// stamps the version that produced the download, the container checks the
+// version that will consume it. Comparing two intended constants would miss
+// exactly the drift this guards — "the installed runtime isn't what the build
+// said it should be" (e.g. a lockfile-free `bun add` resolving a newer
+// release). Resolution is isolated here so the package-internals access lives
+// in one place.
+export function getResolvedTransformersVersion(): string {
+  const require = createRequire(import.meta.url)
+  const pkg = require('@huggingface/transformers/package.json') as { version?: unknown }
+  if (typeof pkg.version !== 'string' || pkg.version.length === 0) {
+    throw new Error('could not resolve @huggingface/transformers version from its package.json')
+  }
+  return pkg.version
+}

--- a/src/models/transformers-version.ts
+++ b/src/models/transformers-version.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
+import { dirname, join, parse as parsePath } from 'node:path'
 
 // The ACTUALLY-INSTALLED @huggingface/transformers version in the current
 // runtime, read from the resolved package's own package.json — NOT from
@@ -10,11 +12,44 @@ import { createRequire } from 'node:module'
 // said it should be" (e.g. a lockfile-free `bun add` resolving a newer
 // release). Resolution is isolated here so the package-internals access lives
 // in one place.
+//
+// We resolve the package's EXPORTED entry and walk up to its package.json,
+// rather than `require('@huggingface/transformers/package.json')`: that subpath
+// is not in the package's `exports` map (only `node`/`default`), so a strict
+// Node-exports resolver throws ERR_PACKAGE_PATH_NOT_EXPORTED. The main entry IS
+// exported, and its package.json is the nearest one above the resolved file.
 export function getResolvedTransformersVersion(): string {
   const require = createRequire(import.meta.url)
-  const pkg = require('@huggingface/transformers/package.json') as { version?: unknown }
-  if (typeof pkg.version !== 'string' || pkg.version.length === 0) {
+  const entry = require.resolve('@huggingface/transformers')
+  const version = readNearestPackageVersion(dirname(entry))
+  if (version === null) {
     throw new Error('could not resolve @huggingface/transformers version from its package.json')
   }
-  return pkg.version
+  return version
+}
+
+function readNearestPackageVersion(startDir: string): string | null {
+  const root = parsePath(startDir).root
+  let dir = startDir
+  for (;;) {
+    const version = readPackageNameVersion(join(dir, 'package.json'))
+    if (version !== null) return version
+    if (dir === root) return null
+    dir = dirname(dir)
+  }
+}
+
+// Only accept the @huggingface/transformers package.json, never a nested
+// dependency's: the resolved entry can sit under dist/, and an intermediate
+// dir could in theory carry an unrelated package.json. Match on name.
+function readPackageNameVersion(pkgPath: string): string | null {
+  let parsed: { name?: unknown; version?: unknown }
+  try {
+    parsed = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: unknown; version?: unknown }
+  } catch {
+    return null
+  }
+  if (parsed.name !== '@huggingface/transformers') return null
+  if (typeof parsed.version !== 'string' || parsed.version.length === 0) return null
+  return parsed.version
 }


### PR DESCRIPTION
> Stacked on #865 (exact-pin transformers). Base is `fix/pin-transformers-version`; review/merge that first, or this PR's base auto-retargets to `main` once it lands.

## Background

`memory.vector.enabled` runs embeddings through `@huggingface/transformers`. The model is downloaded **host-side** (`src/hostd/models.ts`, with whatever transformers version the host has installed) into `~/.typeclaw/models`, then loaded **container-side** (`embedder.ts`, `local_files_only`) from a read-only bind mount, using the transformers version the Dockerfile's lockfile-free Layer 7 `bun add` installed.

#865 pins that version so the two *should* agree. But pinning is the root-cause fix, not a detector: if the two ever diverge anyway (a stale cache survives a CLI upgrade, a hand-copied `~/.typeclaw/models`, a future bump that lands on one side first), the symptom is ugly — either a cryptic `local_files_only` missing-file error, or, worse, transformers finds a file at the expected path that was produced by a *different* version's cache layout and the container silently embeds against a mismatched artifact. There was no signal distinguishing "cache is fine" from "cache was built by something else."

## Summary

Add a **model-cache sentinel**: the host stamps `~/.typeclaw/models/.typeclaw-model.json` = `{schemaVersion, model, dtype, dims, recipe, transformers}` right after a successful download (atomic write-then-rename, inside the existing `proper-lockfile` critical section), and the container asserts it matches **before** the `local_files_only` load. On mismatch or absence it throws a TypeClaw-authored error naming observed-vs-expected with a "re-run `typeclaw start`" hint.

Key decisions:

- **Compare actually-resolved versions, not constants.** Both sides read `@huggingface/transformers/package.json#version` from the installed package (`src/models/transformers-version.ts`). Comparing two hard-coded constants couldn't detect the drift we care about — "the installed runtime isn't what the build said." This is the whole point of the sentinel.
- **Absent sentinel → hard fail, not warn.** Within one `typeclaw start`, host `ensureModels()` writes the sentinel *before* `docker run`, so the container always sees a fresh one. A missing sentinel therefore means a wrong mount or a hand-copied cache — exactly the silent case this is meant to surface.
- **De-dup the identity.** `MODEL_NAME`/`MODEL_DTYPE`/`DIMS`/`EMBEDDING_MODEL_ID` were duplicated across the host downloader and container embedder (only a comment enforced the match). They now live in one shared `@/models/embedding-model` module both stages import — neutral location, no host↔plugin layering violation.
- **`recipe` is stamped but NOT folded into `EMBEDDING_MODEL_ID`.** The ID is a stored-row filter; changing it would invalidate every existing vector row and force a full re-embed. The recipe lives only in the sentinel, so a future pooling/normalize change can fail the cache check without nuking the index.

Commits are split: shared module first, then host-side write, then container-side verify.

## What this does NOT do

- Does not change embedding behavior, dims, dtype, or the stored-row identity — existing vector indexes keep working.
- Does not re-download or migrate existing caches; the host rewrites the sentinel on the next normal `typeclaw start`.
- Does not add the in-image embedding smoke test (the other deferred P1-2 item) — that's still a separate follow-up.

## Review notes

Load-bearing pieces: `assertModelCacheCompatible` (the throw-on-mismatch/absent policy) and its placement **before** `pipeline(local_files_only)` in `Embedder.load()`; and `writeModelSentinel` running **inside the host lock, after** a successful download. Invariant: host-writes-then-container-reads ordering within one `typeclaw start` is what makes "absent → throw" correct rather than hostile to first-run users.

The embedder's mechanics tests (batching/lazy-load/warm-up) mock transformers and run against the default cache path with no sentinel, so they swap in a no-op via a new `__setModelCacheCheckForTests` seam (mirrors the existing `__setTransformersImporterForTests`). The sentinel guard itself is covered directly in `src/models/embedding-model.test.ts` (match, transformers drift, model/dtype drift, absent, malformed, wrong-schema), and `ensure-models.test.ts` now asserts the host writes it after download.
