### PR TITLE
fix(tunnels): deflake quick/named subscriber stderr test

### DIFF
--- a/src/tunnels/providers/cloudflare-named.test.ts
+++ b/src/tunnels/providers/cloudflare-named.test.ts
@@ -291,11 +291,15 @@ sleep 30
 
   it('subscribers receive future stderr lines without replay', async () => {
     const scratchDir = createScratchDir()
+    // Gate `after` on subscription, not a wall-clock sleep: under load a fixed
+    // delay can elapse before the subscriber registers, leaving `after` with
+    // zero subscribers so the late one never sees it (the 30s-timeout flake).
+    const gateFile = join(scratchDir, 'emit-after')
     const binary = installFakeCloudflared(
       scratchDir,
       `
 echo before >&2
-sleep 0.05
+while [ ! -f '${gateFile}' ]; do sleep 0.01; done
 echo after >&2
 trap 'exit 0' TERM
 sleep 30
@@ -314,6 +318,7 @@ sleep 30
       await waitFor(() => provider.tail().includes('before'), { description: 'first log line' })
       const received: string[] = []
       provider.subscribeToLogs((line) => received.push(line))
+      writeFileSync(gateFile, '')
       await waitFor(() => received.includes('after'), { description: 'future log line' })
 
       expect(received).toEqual(['after'])

--- a/src/tunnels/providers/cloudflare-quick.test.ts
+++ b/src/tunnels/providers/cloudflare-quick.test.ts
@@ -76,11 +76,15 @@ sleep 30
 
   it('subscribers receive future stderr lines without replay', async () => {
     const scratchDir = createScratchDir()
+    // Gate `after` on subscription, not a wall-clock sleep: under load a fixed
+    // delay can elapse before the subscriber registers, leaving `after` with
+    // zero subscribers so the late one never sees it (the 30s-timeout flake).
+    const gateFile = join(scratchDir, 'emit-after')
     const binary = installFakeCloudflared(
       scratchDir,
       `
 echo before >&2
-sleep 0.05
+while [ ! -f '${gateFile}' ]; do sleep 0.01; done
 echo after >&2
 trap 'exit 0' TERM
 sleep 30
@@ -99,6 +103,7 @@ sleep 30
       await waitFor(() => provider.tail().includes('before'), { description: 'first log line' })
       const received: string[] = []
       provider.subscribeToLogs((line) => received.push(line))
+      writeFileSync(gateFile, '')
       await waitFor(() => received.includes('after'), { description: 'future log line' })
 
       expect(received).toEqual(['after'])


### PR DESCRIPTION
## Background

`createCloudflareQuickProvider > subscribers receive future stderr lines without replay` (and its identical twin in `cloudflare-named.test.ts`) intermittently failed with a 30000ms timeout:

```
(fail) createCloudflareQuickProvider > subscribers receive future stderr lines without replay [30000.57ms]
  ^ this test timed out after 30000ms.
```

The test asserts that a subscriber registered *after* some stderr has already flowed receives only **future** lines, never a replay of past ones. To stage that, the fake `cloudflared` emitted `before`, slept `0.05s`, then emitted `after`; the test waited until `before` showed up in `tail()`, subscribed, and expected to receive `after`.

The 50ms gap was the bug. The "future" line was gated on wall-clock time, not on the subscription. Under full-suite contention (18 parallel workers), the gap could elapse before the subscriber registered — so `pumpStderr` appended `after` to the `LogRing` while the subscriber set was still empty. `LogRing` does not replay past lines to new subscribers, so the late subscriber never saw `after`, and `waitFor(() => received.includes('after'))` spun until the 30s deadline.

## Summary

Gate the `after` emission on the subscription instead of a timer. The fake script now blocks on a scratch-dir file (`emit-after`) and emits `after` only once it appears; the test writes that file **immediately after subscribing**:

```sh
echo before >&2
while [ ! -f '<scratchDir>/emit-after' ]; do sleep 0.01; done
echo after >&2
```

This makes `after` causally a future line — it cannot be appended before the subscriber exists — so the race is gone regardless of host load. The behavior under test is unchanged: `before` is still proven present in `tail()` before subscribing (so it must already be appended and is *not* delivered to the later subscriber, since `LogRing.append` pushes to the ring before notifying), and the subscriber still receives exactly `['after']`.

Why a gate file and not a longer sleep: a bigger fixed delay only widens the window, it doesn't close the race — any wall-clock gap can be lost to scheduling. The gate file removes time from the correctness argument entirely. Production code is untouched; the fix lives only in the test fixture.

The gate file lives inside the per-test `scratchDir` (not a shared path) so parallel workers can't cross-signal each other, and the trailing `trap`/`sleep 30` is kept so the provider still has a live process for `stop()` to exercise.

## What this does NOT do

- No production code changes — `LogRing`, `pumpStderr`, and the providers are untouched.
- Does not alter the no-replay contract being verified; only how the test stages a deterministic "future" line.
- Does not touch the pre-existing unrelated lint warnings in these files (e.g. unused `binary` in the empty-token test).

## Review notes

- Load-bearing invariant: waiting for `before` in `tail()` before subscribing guarantees `before` was already appended (append-then-notify order in `LogRing`), so the later subscriber legitimately receives only `after`.
- Applied identically to both `cloudflare-quick.test.ts` and `cloudflare-named.test.ts` so no flaky clone is left behind.
- Verified: full suite green (`9008 pass, 0 fail`), and the two provider files run clean across repeated parallel runs. typecheck / lint (0 errors) / format:check all pass.