### PR TITLE
perf(channels): cost-aware grace window for session rollover

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -32,8 +32,10 @@ import {
   OUTBOUND_FLOOD_ERROR,
   SEND_RATE_WARN_THRESHOLD,
   SEND_RATE_WINDOW_MS,
+  isGraceWorthReusing,
   SESSION_GC_INTERVAL_MS,
   SESSION_FRESHNESS_TTL_MS,
+  SESSION_GRACE_HARD_TTL_MS,
   SESSION_IDLE_MS,
   sliceHeadTail,
   StaleLiveSessionError,
@@ -236,6 +238,7 @@ function makeRouter(
     origins?: SessionOrigin[]
     factoryCalls?: SessionFactoryArgs[]
     transcriptPathFor?: (sessionId: string) => string | undefined
+    measureTranscriptBytes?: (path: string) => number
     configuredAliases?: () => readonly string[]
     ensureLiveTimeoutMs?: number
     permissions?: PermissionService
@@ -253,6 +256,7 @@ function makeRouter(
     configForAdapter: () => options.config ?? baseConfig,
     ...(options.configuredAliases !== undefined ? { configuredAliases: options.configuredAliases } : {}),
     ...(options.ensureLiveTimeoutMs !== undefined ? { ensureLiveTimeoutMs: options.ensureLiveTimeoutMs } : {}),
+    ...(options.measureTranscriptBytes !== undefined ? { measureTranscriptBytes: options.measureTranscriptBytes } : {}),
     ...(options.claimHandler !== undefined ? { claimHandler: options.claimHandler } : {}),
     ...(options.onReload !== undefined ? { onReload: options.onReload } : {}),
     ...(options.onRestart !== undefined ? { onRestart: options.onRestart } : {}),
@@ -602,6 +606,96 @@ describe('ChannelRouter session lifecycle', () => {
 
     expect(events).toContain('end:ses_fake_1')
     expect(sessions[0]!.disposed).toBe(1)
+    expect(sessions).toHaveLength(2)
+  })
+
+  test('grace reuse: in soft→hard band, large base + small transcript reuses the live session', async () => {
+    // given: a session whose base context (10KB) dwarfs its transcript growth
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const bytesFor = new Map<string, number>()
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      transcriptPathFor: (sessionId) => `/fake/${sessionId}.jsonl`,
+      measureTranscriptBytes: (path) => bytesFor.get(path) ?? 0,
+    })
+    bytesFor.set('/fake/ses_fake_1.jsonl', 10_000) // base context at cold-start
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    bytesFor.set('/fake/ses_fake_1.jsonl', 11_000) // +1KB transcript < 10KB base
+
+    // when: a follow-up lands just inside the grace band (soft TTL + 1ms)
+    nowRef.value = 1000 + SESSION_FRESHNESS_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'still there?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the live session is reused, not rolled over
+    expect(sessions).toHaveLength(1)
+    expect(router.liveCount()).toBe(1)
+  })
+
+  test('grace decline: in soft→hard band, transcript exceeding base rolls over', async () => {
+    // given: a session whose transcript growth (15KB) now exceeds its base (10KB)
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const bytesFor = new Map<string, number>()
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      transcriptPathFor: (sessionId) => `/fake/${sessionId}.jsonl`,
+      measureTranscriptBytes: (path) => bytesFor.get(path) ?? 0,
+    })
+    bytesFor.set('/fake/ses_fake_1.jsonl', 10_000)
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    bytesFor.set('/fake/ses_fake_1.jsonl', 25_000) // delta 15KB > 10KB base
+
+    // when: a follow-up lands in the grace band
+    nowRef.value = 1000 + SESSION_FRESHNESS_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'long convo' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the bloated transcript makes rebuild cheaper, so it rolls over
+    expect(sessions).toHaveLength(2)
+  })
+
+  test('grace is bounded: past the hard cap, a large base still rolls over', async () => {
+    // given: a large base that would otherwise win the grace comparison
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const bytesFor = new Map<string, number>()
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      transcriptPathFor: (sessionId) => `/fake/${sessionId}.jsonl`,
+      measureTranscriptBytes: (path) => bytesFor.get(path) ?? 0,
+    })
+    bytesFor.set('/fake/ses_fake_1.jsonl', 10_000)
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    bytesFor.set('/fake/ses_fake_1.jsonl', 10_100) // tiny delta — grace would apply
+
+    // when: the follow-up lands PAST the hard cap
+    nowRef.value = 1000 + SESSION_GRACE_HARD_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'much later' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the hard cap forces rollover regardless of base vs delta
+    expect(sessions).toHaveLength(2)
+  })
+
+  test('grace fails closed: no transcript path (baseContextBytes=0) rolls over at soft TTL', async () => {
+    // given: a router with no transcript path (the prior default behavior)
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: a follow-up lands in what would be the grace band
+    nowRef.value = 1000 + SESSION_FRESHNESS_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'no base measured' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: with baseContextBytes=0, grace is disabled and it rolls over
     expect(sessions).toHaveLength(2)
   })
 
@@ -6727,6 +6821,22 @@ function historyMessage(over: Partial<ChannelHistoryMessage> = {}): ChannelHisto
     ...over,
   }
 }
+
+describe('isGraceWorthReusing', () => {
+  test('reuses when base context exceeds transcript delta', () => {
+    expect(isGraceWorthReusing(10_000, 1_000)).toBe(true)
+  })
+
+  test('rolls over when transcript delta meets or exceeds base context', () => {
+    expect(isGraceWorthReusing(10_000, 10_000)).toBe(false)
+    expect(isGraceWorthReusing(10_000, 15_000)).toBe(false)
+  })
+
+  test('fails closed when base context is unknown (0 or negative)', () => {
+    expect(isGraceWorthReusing(0, 0)).toBe(false)
+    expect(isGraceWorthReusing(-1, 0)).toBe(false)
+  })
+})
 
 describe('sliceHeadTail', () => {
   const m = (id: string): ChannelHistoryMessage => historyMessage({ externalMessageId: id, text: id })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1,3 +1,4 @@
+import { statSync } from 'node:fs'
 import { basename } from 'node:path'
 
 import type { AssistantMessage } from '@mariozechner/pi-ai'
@@ -291,16 +292,69 @@ export const SEND_RATE_WARN_THRESHOLD = 3
 export const OUTBOUND_FLOOD_ERROR = 'outbound message denied: content looks like a repeated-character flood'
 
 /**
- * Maximum age of the last engaged inbound before the next inbound triggers a fresh session.
- * Set to the LLM provider's KV-cache TTL (5 min) so the new session's system prompt is
- * guaranteed to be a cache hit on the provider side.
+ * Soft freshness boundary: the age of the last engaged inbound past which the
+ * provider's server-side KV prompt-cache for this session's prefix is assumed
+ * cold. Set to the LLM provider's KV-cache TTL (5 min) so a session reused
+ * WITHIN this window is guaranteed a cache hit on the provider side.
  *
- * Unlike SESSION_IDLE_MS (which evicts the in-memory entry without rollover), this constant
- * triggers a full tearDownLive + recreate on the next engaged inbound. The old session's
- * transcript is preserved on disk; only the in-memory live entry and sessions.json pointer
- * are replaced.
+ * Reaching this boundary no longer forces an immediate rollover. Between the
+ * soft boundary and SESSION_GRACE_HARD_TTL_MS, the live path defers to a
+ * cost-aware grace decision (see `isGraceWorthReusing`): a session whose fixed
+ * base context (rendered system prompt + injected memory + prefetched channel
+ * context) still costs more to rebuild than its accumulated transcript is
+ * reused for one more turn rather than torn down. This targets the common
+ * channel shape — a human replying a few minutes past the cache TTL — where a
+ * full cold-start rebuild of a large memory/index-mode base context dominates
+ * the cost of carrying a modest transcript forward.
+ *
+ * Unlike SESSION_IDLE_MS (which evicts the in-memory entry without rollover), a
+ * rollover triggers a full tearDownLive + recreate on the next engaged inbound.
+ * The old session's transcript is preserved on disk; only the in-memory live
+ * entry and sessions.json pointer are replaced.
  */
 export const SESSION_FRESHNESS_TTL_MS = 5 * 60 * 1000
+
+/**
+ * Hard ceiling on the cost-aware grace window. Past this age the live session is
+ * rolled over unconditionally regardless of base-vs-transcript cost: the grace
+ * decision only defers rollover, it never makes the session immortal. Bounding
+ * grace at 2x the soft TTL keeps a never-quite-idle session from accumulating an
+ * ever-growing, fully-uncached prefix (every turn past the soft boundary re-sends
+ * the whole prefix at no provider-cache discount) and prevents grace from
+ * silently becoming an unbounded TTL increase.
+ */
+export const SESSION_GRACE_HARD_TTL_MS = 10 * 60 * 1000
+
+/**
+ * Cost-aware grace decision for the soft→hard TTL band. Returns true when reusing
+ * the (now cache-cold) live session is cheaper than a fresh cold-start.
+ *
+ * After the soft TTL the provider prefix is cold either way, so the choice is:
+ *   - rollover: pay to rebuild the fixed base context (system prompt + memory +
+ *     prefetched context) plus a fresh first model call, OR
+ *   - reuse: re-send the cold base context PLUS the accumulated transcript.
+ *
+ * Rollover only wins once the transcript a reused session would carry forward
+ * exceeds the base context a rollover would rebuild. We approximate both with the
+ * session transcript file: `baseContextBytes` is its size captured right after
+ * cold-start (the rendered prompt before any user turn), and the live delta is
+ * the growth since. While `baseContextBytes > transcriptDeltaBytes`, the fixed
+ * rebuild is the larger cost and grace is worth it. A `baseContextBytes` of 0
+ * (no transcript path available) disables grace — fail closed to the prior
+ * roll-over-at-soft-TTL behavior.
+ */
+export function isGraceWorthReusing(baseContextBytes: number, transcriptDeltaBytes: number): boolean {
+  if (baseContextBytes <= 0) return false
+  return baseContextBytes > transcriptDeltaBytes
+}
+
+function defaultMeasureTranscriptBytes(path: string): number {
+  try {
+    return statSync(path).size
+  } catch {
+    return 0
+  }
+}
 
 // Watchdog ceiling for ensureLive's full async chain (resolve names →
 // fetch membership → open session manager → persist mapping → prefetch
@@ -500,6 +554,12 @@ type LiveSession = {
   typingTimedOut: boolean
   typingStopPromise: Promise<void> | null
   lastInboundAt: number
+  // Transcript-file size (bytes) captured immediately after cold-start, before
+  // any user turn — a proxy for the fixed base-context rebuild cost (rendered
+  // system prompt + injected memory + prefetched channel context). Read by the
+  // soft-TTL grace decision against the current transcript size to weigh reuse
+  // vs rollover. 0 when no transcript path is available, which disables grace.
+  baseContextBytes: number
   firstUnprocessedAt: number
   currentTurnAuthorId: string | null
   currentTurnAuthorIds: Set<string>
@@ -969,6 +1029,10 @@ export type CreateChannelRouterOptions = {
   logger?: RouterLogger
   // Test seam: clock for sticky/debounce/participants. Defaults to Date.now.
   now?: () => number
+  // Test seam: measure a transcript file's byte size for the soft-TTL grace
+  // decision. Defaults to a stat()-based reader returning 0 for a missing or
+  // unreadable file (grace then fails closed to roll-over-at-soft-TTL).
+  measureTranscriptBytes?: (path: string) => number
   // Test seam: override the ensureLive watchdog ceiling so the timeout path
   // is exercisable in <100ms instead of the 30s production default.
   ensureLiveTimeoutMs?: number
@@ -1067,6 +1131,7 @@ const GRANT_ALL_PERMISSIONS: PermissionService = {
 export function createChannelRouter(options: CreateChannelRouterOptions): ChannelRouter {
   const logger = options.logger ?? consoleLogger
   const now = options.now ?? Date.now
+  const measureTranscriptBytes = options.measureTranscriptBytes ?? defaultMeasureTranscriptBytes
   const ensureLiveTimeoutMs = options.ensureLiveTimeoutMs ?? ENSURE_LIVE_TIMEOUT_MS
   const resolveChannelNamesTimeoutMs = options.resolveChannelNamesTimeoutMs ?? RESOLVE_CHANNEL_NAMES_TIMEOUT_MS
   const fetchHistoryTimeoutMs = options.fetchHistoryTimeoutMs ?? FETCH_HISTORY_TIMEOUT_MS
@@ -1315,6 +1380,31 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return membership
   }
 
+  const shouldRolloverLive = (live: LiveSession, idleMs: number): boolean => {
+    // A session mid-prompt looks idle by lastInboundAt (only bumped on engaged
+    // inbounds) while session.prompt() is still in flight; rolling it over aborts
+    // that work. The runIdleGc path skips draining sessions for the same reason.
+    if (live.draining) return false
+    if (idleMs <= SESSION_FRESHNESS_TTL_MS) return false
+    if (idleMs > SESSION_GRACE_HARD_TTL_MS) {
+      logger.info(`[channels] ${live.keyId}: stale-rollover (live: ${idleMs}ms idle, past grace cap)`)
+      return true
+    }
+    const transcriptPath = live.getTranscriptPath?.()
+    const transcriptBytes = transcriptPath !== undefined ? measureTranscriptBytes(transcriptPath) : 0
+    const transcriptDeltaBytes = Math.max(0, transcriptBytes - live.baseContextBytes)
+    if (isGraceWorthReusing(live.baseContextBytes, transcriptDeltaBytes)) {
+      logger.info(
+        `[channels] ${live.keyId}: grace-reuse (live: ${idleMs}ms idle, base=${live.baseContextBytes}B delta=${transcriptDeltaBytes}B)`,
+      )
+      return false
+    }
+    logger.info(
+      `[channels] ${live.keyId}: stale-rollover (live: ${idleMs}ms idle, base=${live.baseContextBytes}B delta=${transcriptDeltaBytes}B)`,
+    )
+    return true
+  }
+
   const ensureLive = async (
     key: ChannelKey,
     triggeringMessageId?: string,
@@ -1333,22 +1423,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // A resume that finds the key already live is a no-op for reopening: the
       // session is up, so just hand it back and let the caller enqueue the wake.
       if (resumeTarget !== undefined) return existing
+      // Rollover decision (soft TTL → cost-aware grace → hard cap) lives in
+      // shouldRolloverLive, which also skips draining sessions so a mid-prompt
+      // turn is never aborted by a follow-up's idle check (PR #359 incident).
       const idleMs = now() - existing.lastInboundAt
-      // `lastInboundAt` is only bumped on engaged inbounds (see route()),
-      // so a session whose drain loop has been compiling a slow reply for
-      // 5+ minutes off a single inbound looks "idle" by this clock even
-      // though `session.prompt()` is mid-flight. Aborting that prompt to
-      // re-cold-start on the next user message wipes the in-flight work
-      // (observed against `openai-codex/gpt-5.5` in PR #359's incident:
-      // a 285s + 227s turn pair lost the second turn entirely to
-      // `tearDownLive` → `session.abort()` triggered by the user's
-      // follow-up at 5min idle). The `runIdleGc` path already skips
-      // draining sessions for the same reason; rollover must match.
-      // The skip is bounded: when the in-flight prompt completes or its
-      // own provider/transport timeout fires, `draining` clears and the
-      // next inbound's idle check picks up rollover normally.
-      if (idleMs > SESSION_FRESHNESS_TTL_MS && !existing.draining) {
-        logger.info(`[channels] ${keyId}: stale-rollover (live: ${idleMs}ms idle)`)
+      if (shouldRolloverLive(existing, idleMs)) {
         await tearDownLive(existing)
         liveSessions.delete(keyId)
         if (mappings) {
@@ -1527,6 +1606,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         typingTimedOut: false,
         typingStopPromise: null,
         lastInboundAt: now(),
+        baseContextBytes: 0,
         firstUnprocessedAt: 0,
         currentTurnAuthorId: null,
         currentTurnAuthorIds: new Set(),
@@ -1620,6 +1700,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           await prefetchChannelContext(live, adapterConfig, triggeringMessageId)
           logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
         }
+      }
+
+      // Snapshot the rendered base context size now, after prefetch and before
+      // any user turn, so the soft-TTL grace decision can later compare it
+      // against transcript growth. Only meaningful on cold-start (a rehydrated
+      // session's file already holds prior conversation, not a clean base).
+      const transcriptPathForBase = live.getTranscriptPath?.()
+      if (isColdStart && transcriptPathForBase !== undefined) {
+        live.baseContextBytes = measureTranscriptBytes(transcriptPathForBase)
       }
 
       logger.info(`[channels] ${keyId}: ensureLive done (${phase})`)


### PR DESCRIPTION
## Background

Channel sessions roll over to a fresh cold-start once `SESSION_FRESHNESS_TTL_MS` (5 min) of idle elapses since the last engaged inbound. That 5-min value is deliberately aligned to the LLM provider's server-side KV prompt-cache TTL: a session reused **within** the window is a guaranteed cache hit, and **past** it the prefix is cold anyway, so starting a fresh, cleanly-cacheable session is the cache-rational move. Naively raising the TTL would *hurt* — a session kept warm past 5 min re-sends an ever-growing, fully-uncached prefix every turn.

But the binary has a blind spot. Production logs from a GitHub PR-reviewer agent show where the real cost is:

- **207 sessions created, 206 cold-start** — almost zero warm reuse.
- **84 stale-rollovers**, idle-gap distribution: **36 in 5-10 min**, 16 in 10-30 min, 1 >30 min. The dominant cluster is humans replying to review comments just a few minutes past the cache TTL.
- The expensive part of a rollover is **not** the cache miss — it's rebuilding the fixed base context: **221 memory topic shards (154 KB, 9.4× over the 16 KB injection budget → permanent index-mode)** plus prefetched PR-diff context, from scratch, on every cold-start.

When a human replies at 5:30, the provider cache was only ~30s cold, yet we pay a full base-context rebuild. For a large-base/short-transcript session that rebuild dominates the cost of simply carrying the (now cache-cold) session forward one more turn.

## Summary

Replace the hard 5-min binary with a **soft TTL + cost-aware grace band**, bounded by a hard cap:

- **≤ soft TTL (5 min):** reuse — guaranteed cache hit. Unchanged.
- **soft..hard (5-10 min):** reuse **only when** the fixed base context still costs more to rebuild than the session's accumulated transcript delta (`isGraceWorthReusing`: `baseContextBytes > transcriptDeltaBytes`). Self-tunes per session — a big-base/short-transcript session stays warm; a session whose transcript has grown past its base rolls over (the bloated transcript is now the larger cost).
- **> hard cap (10 min):** roll over unconditionally, so grace defers rollover but never makes a session immortal or lets an uncached prefix grow without bound.

**Why cost-aware, not a predictive/EWMA TTL:** at inbound time we already know the actual idle gap, so there's nothing to predict; and the session only persists `lastInboundAt` (no rolling gap history), so EWMA would need new durable state to do worse than just observing the gap. The base-vs-transcript comparison is an explainable, non-flappy proxy for the actual rebuild-vs-carry tradeoff. No config knob — the policy adapts to each session's own cost shape.

`baseContextBytes` is snapshotted from the transcript file right after cold-start (after prefetch, before any user turn = rendered system prompt + injected memory + prefetched context); the live transcript delta is measured at decision time via an injectable `measureTranscriptBytes` (defaults to a `statSync`-based reader).

## What this does NOT do

- **Does not touch the persisted-mapping rollover** (cold-container path, still gated on `SESSION_FRESHNESS_TTL_MS`). That fires when no in-memory live session exists — there is nothing warm to preserve, so grace is irrelevant.
- **Does not address the root memory bloat** (221 shards / index-mode). That's separately fixable by enabling `memory.vector.enabled`, which moves memory out of the system prompt and shrinks `baseContextBytes` — composing correctly with this change (smaller base → grace fires less often, as it should).
- No config surface, no schema change, no new CLI flag.

## Review notes

- **Load-bearing invariant:** the soft TTL's KV-cache-TTL alignment is now documented on `SESSION_FRESHNESS_TTL_MS` so a future maintainer doesn't "just raise it" and silently regress cache behavior.
- **Fail-closed default:** when no transcript path is available, `baseContextBytes = 0` → `isGraceWorthReusing` returns false → exact prior roll-over-at-soft-TTL behavior. The existing `after SESSION_FRESHNESS_TTL_MS + 1ms idle` test (no `transcriptPathFor` in its harness) still passes unchanged, proving the default path is preserved.
- **Mid-prompt safety preserved:** `shouldRolloverLive` keeps the `!draining` skip (PR #359 incident: a follow-up at 5 min idle aborting an in-flight 227s turn). The condensed comment retains that citation.
- Decision is logged (`grace-reuse` / `stale-rollover` with `base=…B delta=…B`) so the breakeven is observable in production before any further tuning.
- 7 new tests: grace reuse, grace decline (bloated transcript), hard-cap bound, fail-closed default, plus `isGraceWorthReusing` unit tests. Full suite: 9015 pass / 0 fail.