### PR TITLE
feat(provider): allow selecting models beyond the curated list

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -15,7 +15,7 @@ import { loadMemory } from '@/bundled-plugins/memory/load-memory'
 import type { ChannelRouter } from '@/channels/router'
 import type { ReactionRef } from '@/channels/types'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
-import { defaultThinkingLevelForRef, providerForModelRef, type KnownModelRef } from '@/config/providers'
+import { defaultThinkingLevelForRef, providerForModelRef, type ModelRef } from '@/config/providers'
 import { renderMcpCatalog } from '@/mcp/catalog'
 import type { McpManager } from '@/mcp/manager'
 import { createMcpDispatcherTools, MCP_DISPATCHER_TOOL_NAMES } from '@/mcp/tools'
@@ -196,7 +196,7 @@ export type CreateSessionOptions = {
   // pinned to the next ref in the chain after the previous one failed. When
   // set, `profile` is still recorded for the fallback-warning bookkeeping;
   // the profile→refs resolution is skipped.
-  refOverride?: KnownModelRef
+  refOverride?: ModelRef
   // Defensive ceiling on cumulative bytes of tool-result text per session,
   // applied to the named tools only. See `src/agent/tool-result-budget.ts`
   // for the rationale. Intended for subagents that read large files
@@ -247,7 +247,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   // exactly what they're doing.
   // `refOverride` lets the model-fallback helper pin a specific entry from
   // the chain when it recreates a session after the previous ref failed.
-  const activeRef: KnownModelRef = options.refOverride ?? resolved.ref
+  const activeRef: ModelRef = options.refOverride ?? resolved.ref
   const { authStorage, modelRegistry } = getAuthFor(providerForModelRef(activeRef))
 
   const materializedSkills =

--- a/src/agent/model-fallback.test.ts
+++ b/src/agent/model-fallback.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { Models } from '@/config/config'
+import { configSchema, type Models } from '@/config/config'
 import type { KnownModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
@@ -9,6 +9,10 @@ import { promptWithFallback, resolveFallbackChain } from './model-fallback'
 const REF_A = 'openai/gpt-5.4-nano' as KnownModelRef
 const REF_B = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' as KnownModelRef
 const REF_C = 'zai/glm-4.6' as KnownModelRef
+
+function parseModels(models: Record<string, string | string[]>): Models {
+  return configSchema.parse({ models }).models
+}
 
 type SessionFake = {
   ref: KnownModelRef
@@ -67,24 +71,24 @@ function fakeSession(opts: {
 
 describe('resolveFallbackChain', () => {
   test('returns single-element chain for single-ref profile', () => {
-    const models: Models = { default: [REF_A] }
-    expect(resolveFallbackChain(models, undefined)).toEqual([REF_A])
-    expect(resolveFallbackChain(models, 'default')).toEqual([REF_A])
+    const models = parseModels({ default: REF_A })
+    expect(resolveFallbackChain(models, undefined).map(String)).toEqual([REF_A])
+    expect(resolveFallbackChain(models, 'default').map(String)).toEqual([REF_A])
   })
 
   test('returns multi-element chain for multi-ref profile', () => {
-    const models: Models = { default: [REF_A, REF_B, REF_C] }
-    expect(resolveFallbackChain(models, undefined)).toEqual([REF_A, REF_B, REF_C])
+    const models = parseModels({ default: [REF_A, REF_B, REF_C] })
+    expect(resolveFallbackChain(models, undefined).map(String)).toEqual([REF_A, REF_B, REF_C])
   })
 
   test('falls back to default chain for unknown profile', () => {
-    const models: Models = { default: [REF_A, REF_B] }
-    expect(resolveFallbackChain(models, 'nonexistent')).toEqual([REF_A, REF_B])
+    const models = parseModels({ default: [REF_A, REF_B] })
+    expect(resolveFallbackChain(models, 'nonexistent').map(String)).toEqual([REF_A, REF_B])
   })
 
   test('returns the named profile chain when defined', () => {
-    const models: Models = { default: [REF_A], fast: [REF_B, REF_C] }
-    expect(resolveFallbackChain(models, 'fast')).toEqual([REF_B, REF_C])
+    const models = parseModels({ default: REF_A, fast: [REF_B, REF_C] })
+    expect(resolveFallbackChain(models, 'fast').map(String)).toEqual([REF_B, REF_C])
   })
 })
 

--- a/src/agent/model-fallback.ts
+++ b/src/agent/model-fallback.ts
@@ -1,6 +1,6 @@
 import { resolveProfile } from '@/config'
 import type { Models } from '@/config/config'
-import type { KnownModelRef } from '@/config/providers'
+import type { KnownModelRef, ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
 import { subscribeProviderErrors } from './provider-error'
@@ -15,18 +15,20 @@ import { renderTurnTimeAnchor } from './system-prompt'
 //   the final entry, on full-chain failure). Callers that need to keep using
 //   the session for subsequent turns store these in their state; callers that
 //   tear down per-turn (cron) just call `dispose()` and discard.
-export type FallbackPromptResult = {
+type FallbackModelRef = KnownModelRef | ModelRef
+
+export type FallbackPromptResult<TRef extends FallbackModelRef = ModelRef> = {
   success: boolean
-  refUsed: KnownModelRef
-  attempts: FallbackAttempt[]
+  refUsed: TRef
+  attempts: FallbackAttempt<TRef>[]
   session: AgentSession
   dispose: () => Promise<void>
   // When `success === false`, this is the error from the final attempt.
   lastError?: Error
 }
 
-export type FallbackAttempt = {
-  ref: KnownModelRef
+export type FallbackAttempt<TRef extends FallbackModelRef = ModelRef> = {
+  ref: TRef
   // 'hard' = session.prompt() threw. 'soft' = pi-coding-agent surfaced an
   // upstream error via stopReason: 'error' on the final assistant message.
   // 'success' = the turn finished cleanly.
@@ -40,7 +42,7 @@ export type FallbackAttempt = {
 //
 // Exported so callers can introspect the chain (e.g. logs, telemetry) before
 // firing the prompt — useful for `[cron] ${jobId}: trying chain a → b → c`.
-export function resolveFallbackChain(models: Models, profile: string | undefined): KnownModelRef[] {
+export function resolveFallbackChain(models: Models, profile: string | undefined): ModelRef[] {
   return resolveProfile(models, profile).refs
 }
 
@@ -62,18 +64,18 @@ export function resolveFallbackChain(models: Models, profile: string | undefined
 // (console.error in the server drain, channel reaction in the router,
 // cron-job status). This keeps the helper composable with the existing
 // error-handling code at each call site.
-export async function promptWithFallback(opts: {
-  refs: KnownModelRef[]
+export async function promptWithFallback<TRef extends FallbackModelRef>(opts: {
+  refs: TRef[]
   text: string
-  createSessionForRef: (ref: KnownModelRef) => Promise<{ session: AgentSession; dispose: () => Promise<void> }>
+  createSessionForRef: (ref: TRef) => Promise<{ session: AgentSession; dispose: () => Promise<void> }>
   // Called after each non-final attempt so callers can log the per-attempt
   // failure with their own context (sessionId, channel key, job id, ...).
-  onAttemptFailed?: (attempt: FallbackAttempt) => void
-}): Promise<FallbackPromptResult> {
+  onAttemptFailed?: (attempt: FallbackAttempt<TRef>) => void
+}): Promise<FallbackPromptResult<TRef>> {
   if (opts.refs.length === 0) {
     throw new Error('promptWithFallback: refs[] must be non-empty')
   }
-  const attempts: FallbackAttempt[] = []
+  const attempts: FallbackAttempt<TRef>[] = []
   let lastError: Error | undefined
   for (let i = 0; i < opts.refs.length; i++) {
     const ref = opts.refs[i]!
@@ -92,7 +94,7 @@ export async function promptWithFallback(opts: {
         await session.prompt(`${renderTurnTimeAnchor()}\n\n${opts.text}`)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
-        const attempt: FallbackAttempt = { ref, outcome: 'hard', errorMessage: error.message }
+        const attempt: FallbackAttempt<TRef> = { ref, outcome: 'hard', errorMessage: error.message }
         attempts.push(attempt)
         lastError = error
         if (!isLast) opts.onAttemptFailed?.(attempt)
@@ -104,7 +106,7 @@ export async function promptWithFallback(opts: {
         continue
       }
       if (softError !== undefined) {
-        const attempt: FallbackAttempt = { ref, outcome: 'soft', errorMessage: softError.message }
+        const attempt: FallbackAttempt<TRef> = { ref, outcome: 'soft', errorMessage: softError.message }
         attempts.push(attempt)
         lastError = softError
         if (!isLast) opts.onAttemptFailed?.(attempt)

--- a/src/agent/model-overrides.ts
+++ b/src/agent/model-overrides.ts
@@ -1,6 +1,6 @@
 import type { Api, Model } from '@mariozechner/pi-ai'
 
-import { providerForModelRef, type KnownModelRef, type KnownProviderId } from '@/config/providers'
+import { providerForModelRef, type KnownModelRef, type KnownProviderId, type ModelRef } from '@/config/providers'
 
 // Providers whose base URL can be swapped to an upstream-compatible gateway at
 // runtime. Each env var mirrors the upstream SDK's own name so a credential /
@@ -26,7 +26,7 @@ type OverridableProviderId = keyof typeof PROVIDER_BASE_URL_ENV
 // data that must never be mutated.
 export function applyModelRuntimeOverrides<TApi extends Api>(
   model: Model<TApi>,
-  ref: KnownModelRef,
+  ref: KnownModelRef | ModelRef | string,
   env: NodeJS.ProcessEnv = process.env,
 ): Model<TApi> {
   const providerId = providerForModelRef(ref)

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,6 +6,7 @@ import { defineCommand } from 'citty'
 import {
   KNOWN_PROVIDER_VENDORS,
   KNOWN_PROVIDERS,
+  isKnownModelRef,
   listKnownProviderVendorIds,
   providerIdsForVendor,
   supportsApiKey as providerSupportsApiKey,
@@ -43,7 +44,7 @@ import {
   type WizardCheckpointStore,
 } from '@/init/checkpoint'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
-import { fetchModelOptions, type ModelOption } from '@/init/models-dev'
+import { customModelMetaFromOption, fetchModelOptions, type ModelOption } from '@/init/models-dev'
 import { makeOAuthLoginRunner, type OAuthLoginResult } from '@/init/oauth-login'
 import { detectInitProgress } from '@/init/progress'
 import {
@@ -198,6 +199,8 @@ export const init = defineCommand({
       kakaotalkPassword,
       github: githubCredentials,
     } = channelSecrets
+    const modelMeta = customModelMetaFromOption(model)
+    const visionModelMeta = vision !== undefined ? customModelMetaFromOption(vision.model) : undefined
 
     // TODO: add remaining wizard steps from TypeClaw.md once their runtime lands:
     //   - git backup (url + PAT) — Phase 10
@@ -222,7 +225,14 @@ export const init = defineCommand({
         cwd,
         llmAuth,
         model: model.ref,
-        ...(vision !== undefined ? { visionModel: vision.model.ref, visionAuth: vision.llmAuth } : {}),
+        ...(modelMeta !== undefined ? { modelMeta } : {}),
+        ...(vision !== undefined
+          ? {
+              visionModel: vision.model.ref,
+              ...(visionModelMeta !== undefined ? { visionModelMeta } : {}),
+              visionAuth: vision.llmAuth,
+            }
+          : {}),
         cliEntry: process.argv[1],
         ...(discordBotToken !== undefined ? { discordBotToken } : {}),
         ...(slackBotToken !== undefined ? { slackBotToken, slackAppToken } : {}),
@@ -393,7 +403,7 @@ export interface WizardPrompts {
   pickModel: (
     options: ModelOption[],
     providerId: KnownProviderId,
-    initial: KnownModelRef | undefined,
+    initial: string | undefined,
   ) => Promise<StepResult<ModelOption>>
   pickAuthMethod: (
     provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
@@ -413,7 +423,7 @@ export interface WizardPrompts {
   pickVisionModel: (
     options: ModelOption[],
     providerId: KnownProviderId,
-    initial: KnownModelRef | undefined,
+    initial: string | undefined,
   ) => Promise<StepResult<ModelOption>>
   pickChannel: (initial: ChannelChoice | undefined) => Promise<StepResult<ChannelChoice>>
   hasExistingChannelSecrets: (cwd: string, channel: Exclude<ChannelChoice, 'none'>) => Promise<boolean>
@@ -421,7 +431,7 @@ export interface WizardPrompts {
   runOAuthLogin: (
     provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
     cwd: string,
-    model: KnownModelRef,
+    model: string,
   ) => Promise<OAuthLoginResult>
   askOAuthFailureRecovery: (
     provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
@@ -904,7 +914,7 @@ async function runOAuthLoginSafely(
   prompts: WizardPrompts,
   provider: (typeof KNOWN_PROVIDERS)[KnownProviderId],
   cwd: string,
-  model: KnownModelRef,
+  model: string,
 ): Promise<OAuthLoginResult> {
   try {
     return await prompts.runOAuthLogin(provider, cwd, model)
@@ -972,7 +982,7 @@ function seedWizardState(state: WizardState, checkpoint: WizardAnswerCheckpointV
   state.channelChoice = checkpoint.channelChoice
 }
 
-function resolveModelOption(catalog: WizardState['catalog'], ref: KnownModelRef | undefined): ModelOption | undefined {
+function resolveModelOption(catalog: WizardState['catalog'], ref: string | undefined): ModelOption | undefined {
   if (catalog === undefined || ref === undefined) return undefined
   return catalog.options.find((option) => option.ref === ref)
 }
@@ -1111,7 +1121,7 @@ async function pickProviderVariant(
 async function pickModelForProvider(
   options: ModelOption[],
   providerId: KnownProviderId,
-  initial: KnownModelRef | undefined,
+  initial: string | undefined,
 ): Promise<StepResult<ModelOption>> {
   const candidates = sortRecommendedFirst(options.filter((o) => o.providerId === providerId))
   // select<string>, not select<KnownModelRef>: clack's Option<Value> is a
@@ -1190,7 +1200,7 @@ async function pickVisionProviderVariant(
 async function pickVisionModel(
   options: ModelOption[],
   providerId: KnownProviderId,
-  initial: KnownModelRef | undefined,
+  initial: string | undefined,
 ): Promise<StepResult<ModelOption>> {
   const candidates = sortRecommendedFirst(options.filter((o) => o.providerId === providerId))
   // select<string> for the same distributive-Option reason as pickModelForProvider.
@@ -1818,12 +1828,12 @@ const RECOMMENDED_MODEL_REFS: ReadonlySet<KnownModelRef> = new Set<KnownModelRef
 ])
 
 export function formatModelLabel(o: ModelOption): string {
-  return RECOMMENDED_MODEL_REFS.has(o.ref) ? `${o.modelName} (Recommended)` : o.modelName
+  return isKnownModelRef(o.ref) && RECOMMENDED_MODEL_REFS.has(o.ref) ? `${o.modelName} (Recommended)` : o.modelName
 }
 
 export function sortRecommendedFirst(options: ModelOption[]): ModelOption[] {
-  const recommended = options.filter((o) => RECOMMENDED_MODEL_REFS.has(o.ref))
-  const rest = options.filter((o) => !RECOMMENDED_MODEL_REFS.has(o.ref))
+  const recommended = options.filter((o) => isKnownModelRef(o.ref) && RECOMMENDED_MODEL_REFS.has(o.ref))
+  const rest = options.filter((o) => !isKnownModelRef(o.ref) || !RECOMMENDED_MODEL_REFS.has(o.ref))
   return [...recommended, ...rest]
 }
 

--- a/src/cli/model.test.ts
+++ b/src/cli/model.test.ts
@@ -3,8 +3,57 @@ import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
+import type { ModelOption } from '@/init/models-dev'
+
+import { resolveExplicitRef } from './model'
+
 const CLI_ENTRY = join(import.meta.dir, 'index.ts')
 const REPO_ROOT = resolve(import.meta.dir, '..', '..')
+
+describe('resolveExplicitRef carries catalog metadata for non-interactive set/add', () => {
+  function catalogWith(option: ModelOption): () => Promise<{ options: ModelOption[] }> {
+    return async () => ({ options: [option] })
+  }
+
+  const liveOption: ModelOption = {
+    ref: 'fireworks/brand-new-model',
+    providerId: 'fireworks',
+    providerName: 'Fireworks',
+    modelId: 'brand-new-model',
+    modelName: 'Brand New Model',
+    reasoning: true,
+    contextWindow: 256000,
+    maxTokens: 32000,
+    cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+    curated: false,
+    supportsVision: true,
+  }
+
+  test('curated ref persists no custom metadata (resolves from KNOWN_PROVIDERS)', async () => {
+    const picked = await resolveExplicitRef('openai/gpt-5.4-nano', catalogWith(liveOption))
+    expect(picked.ref).toBe('openai/gpt-5.4-nano')
+    expect(picked.meta).toBeUndefined()
+  })
+
+  test('non-curated ref found in the catalog carries its metadata', async () => {
+    const picked = await resolveExplicitRef('fireworks/brand-new-model', catalogWith(liveOption))
+    expect(picked.ref).toBe('fireworks/brand-new-model')
+    expect(picked.meta).toEqual({
+      name: 'Brand New Model',
+      reasoning: true,
+      input: ['text', 'image'],
+      contextWindow: 256000,
+      maxTokens: 32000,
+      cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+    })
+  })
+
+  test('non-curated ref missing from the catalog persists the ref without metadata', async () => {
+    const picked = await resolveExplicitRef('fireworks/unknown-model', catalogWith(liveOption))
+    expect(picked.ref).toBe('fireworks/unknown-model')
+    expect(picked.meta).toBeUndefined()
+  })
+})
 
 describe('typeclaw model list survives broken typeclaw.json', () => {
   let cwd: string

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -9,7 +9,13 @@ import {
   removeProfile,
   setProfile,
 } from '@/config/models-mutation'
-import { KNOWN_PROVIDERS, providerForModelRef, type KnownModelRef, type KnownProviderId } from '@/config/providers'
+import {
+  isKnownModelRef,
+  KNOWN_PROVIDERS,
+  providerForModelRef,
+  type KnownModelRef,
+  type KnownProviderId,
+} from '@/config/providers'
 import { findAgentDir, isInitialized } from '@/init'
 import { customModelMetaFromOption, fetchModelOptions, type ModelOption } from '@/init/models-dev'
 
@@ -48,7 +54,7 @@ const setSub = defineCommand({
   async run({ args }) {
     const cwd = ensureAgentDir()
     const profile = args.profile ?? (await pickProfileName())
-    const picked = args.ref !== undefined ? { ref: args.ref } : await pickModelRef(cwd)
+    const picked = args.ref !== undefined ? await resolveExplicitRef(args.ref) : await pickModelRef(cwd)
 
     intro(`Setting model profile: ${profile} → ${picked.ref}`)
 
@@ -92,7 +98,7 @@ const addSub = defineCommand({
   },
   async run({ args }) {
     const cwd = ensureAgentDir()
-    const picked = args.ref !== undefined ? { ref: args.ref } : await pickModelRef(cwd)
+    const picked = args.ref !== undefined ? await resolveExplicitRef(args.ref) : await pickModelRef(cwd)
 
     intro(`Adding model profile: ${args.profile} → ${picked.ref}`)
 
@@ -275,6 +281,31 @@ async function pickModelRef(cwd: string): Promise<PickedModelRef> {
     }
   }
 }
+
+// Non-interactive `<ref>` path. Curated refs resolve from KNOWN_PROVIDERS, so
+// they need no metadata. Non-curated refs are looked up in the live catalog so
+// `customModels[ref]` carries the same metadata the interactive picker would
+// persist; without it `resolveModel` silently falls back to defaults. A
+// catalog miss (offline / unknown id) still writes the ref, but warns first.
+export async function resolveExplicitRef(
+  ref: string,
+  loadCatalog: () => Promise<{ options: ModelOption[] }> = fetchModelOptions,
+): Promise<PickedModelRef> {
+  if (isKnownModelRef(ref)) return { ref }
+  const { options } = await loadCatalog()
+  const option = options.find((candidate) => candidate.ref === ref)
+  if (option === undefined) {
+    log.warn(
+      `"${ref}" isn't in the live catalog; saving the ref without metadata. ` +
+        `The agent will use fallback defaults (reasoning off, text-only input, zero cost, provider-default context).`,
+    )
+    return { ref }
+  }
+  const meta = customModelMetaFromOption(option)
+  return { ref, ...(meta !== undefined ? { meta } : {}) }
+}
+
+export type { PickedModelRef }
 
 async function listCredentialedModelOptions(refs: KnownModelRef[]): Promise<ModelOption[]> {
   const credentialedProviders = new Set<KnownProviderId>(refs.map((ref) => providerForModelRef(ref)))

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,6 +1,7 @@
 import { cancel, intro, isCancel, log, select } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
+import type { CustomModelMeta } from '@/config'
 import {
   addProfile,
   listModelProfiles,
@@ -8,19 +9,19 @@ import {
   removeProfile,
   setProfile,
 } from '@/config/models-mutation'
-import {
-  KNOWN_PROVIDERS,
-  listKnownModelRefs,
-  providerForModelRef,
-  type KnownModelRef,
-  type KnownProviderId,
-} from '@/config/providers'
+import { KNOWN_PROVIDERS, providerForModelRef, type KnownModelRef, type KnownProviderId } from '@/config/providers'
 import { findAgentDir, isInitialized } from '@/init'
+import { customModelMetaFromOption, fetchModelOptions, type ModelOption } from '@/init/models-dev'
 
 import { runProviderAddFlow } from './provider'
 import { c, done, errorLine } from './ui'
 
 const ADD_PROVIDER_SENTINEL = '__add-provider__'
+
+type PickedModelRef = {
+  ref: string
+  meta?: CustomModelMeta
+}
 
 const setSub = defineCommand({
   meta: {
@@ -47,18 +48,21 @@ const setSub = defineCommand({
   async run({ args }) {
     const cwd = ensureAgentDir()
     const profile = args.profile ?? (await pickProfileName())
-    const ref = args.ref ?? (await pickModelRef(cwd))
+    const picked = args.ref !== undefined ? { ref: args.ref } : await pickModelRef(cwd)
 
-    intro(`Setting model profile: ${profile} → ${ref}`)
+    intro(`Setting model profile: ${profile} → ${picked.ref}`)
 
-    const result = setProfile(cwd, profile, ref, { force: args.force === true })
+    const result = setProfile(cwd, profile, picked.ref, {
+      force: args.force === true,
+      ...(picked.meta !== undefined ? { meta: picked.meta } : {}),
+    })
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)
     }
     done({
       title: c.green(`Profile "${profile}" set.`),
-      details: `${profile} → ${ref}`,
+      details: `${profile} → ${picked.ref}`,
       hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
     })
   },
@@ -88,18 +92,21 @@ const addSub = defineCommand({
   },
   async run({ args }) {
     const cwd = ensureAgentDir()
-    const ref = args.ref ?? (await pickModelRef(cwd))
+    const picked = args.ref !== undefined ? { ref: args.ref } : await pickModelRef(cwd)
 
-    intro(`Adding model profile: ${args.profile} → ${ref}`)
+    intro(`Adding model profile: ${args.profile} → ${picked.ref}`)
 
-    const result = addProfile(cwd, args.profile, ref, { force: args.force === true })
+    const result = addProfile(cwd, args.profile, picked.ref, {
+      force: args.force === true,
+      ...(picked.meta !== undefined ? { meta: picked.meta } : {}),
+    })
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)
     }
     done({
       title: c.green(`Profile "${args.profile}" added.`),
-      details: `${args.profile} → ${ref}`,
+      details: `${args.profile} → ${picked.ref}`,
       hints: [{ label: 'If the agent is running:', command: 'typeclaw reload' }],
     })
   },
@@ -146,7 +153,7 @@ const listSub = defineCommand({
   },
   async run({ args }) {
     if (args.available === true) {
-      printAvailableRefs()
+      await printAvailableRefs()
       return
     }
     const cwd = ensureAgentDir()
@@ -218,7 +225,7 @@ async function pickProfileName(): Promise<string> {
   return choice
 }
 
-async function pickModelRef(cwd: string): Promise<string> {
+async function pickModelRef(cwd: string): Promise<PickedModelRef> {
   while (true) {
     const refs = listRegisteredModelRefs(cwd)
     if (refs.length === 0) {
@@ -234,13 +241,14 @@ async function pickModelRef(cwd: string): Promise<string> {
     // distributive conditional type and a large ref union breaks `value: ref`
     // assignability. Values are ref strings (+ the sentinel) and stay correct
     // at runtime — the sentinel check and `return choice` below are unaffected.
+    const modelOptions = await listCredentialedModelOptions(refs)
     const choice = await select<string>({
       message: 'Pick a model',
       options: [
-        ...refs.map((ref) => ({
-          value: ref,
-          label: describeRef(ref),
-          hint: ref,
+        ...modelOptions.map((option) => ({
+          value: option.ref,
+          label: describeRef(option.ref),
+          hint: option.curated ? option.ref : `${option.ref} ${c.dim('(live)')}`,
         })),
         {
           value: ADD_PROVIDER_SENTINEL,
@@ -248,13 +256,18 @@ async function pickModelRef(cwd: string): Promise<string> {
           hint: 'configure a new provider',
         },
       ],
-      initialValue: refs[0],
+      initialValue: modelOptions[0]?.ref ?? refs[0],
     })
     if (isCancel(choice)) {
       cancel('Aborted.')
       process.exit(0)
     }
-    if (choice !== ADD_PROVIDER_SENTINEL) return choice
+    if (choice !== ADD_PROVIDER_SENTINEL) {
+      const option = modelOptions.find((candidate) => candidate.ref === choice)
+      if (option === undefined) return { ref: choice }
+      const meta = customModelMetaFromOption(option)
+      return { ref: option.ref, ...(meta !== undefined ? { meta } : {}) }
+    }
     const added = await runProviderAddFlow(cwd, {})
     if (!added.ok) {
       console.error(errorLine(added.reason))
@@ -263,29 +276,64 @@ async function pickModelRef(cwd: string): Promise<string> {
   }
 }
 
-function describeRef(ref: KnownModelRef): string {
-  const providerId = providerForModelRef(ref)
-  const modelId = ref.slice(providerId.length + 1)
-  const provider = KNOWN_PROVIDERS[providerId]
-  const model = (provider.models as Record<string, { name: string }>)[modelId]
-  return model ? `${provider.name} · ${model.name}` : ref
+async function listCredentialedModelOptions(refs: KnownModelRef[]): Promise<ModelOption[]> {
+  const credentialedProviders = new Set<KnownProviderId>(refs.map((ref) => providerForModelRef(ref)))
+  const catalog = await fetchModelOptions()
+  const options = catalog.options.filter((option) => credentialedProviders.has(option.providerId))
+  if (options.length > 0) return options
+  return refs.map((ref) => {
+    const providerId = providerForModelRef(ref)
+    const modelId = ref.slice(providerId.length + 1)
+    const model = (
+      KNOWN_PROVIDERS[providerId].models as Record<
+        string,
+        { name: string; reasoning?: boolean; contextWindow?: number; input?: ReadonlyArray<string> }
+      >
+    )[modelId]
+    return {
+      ref,
+      providerId,
+      providerName: KNOWN_PROVIDERS[providerId].name,
+      modelId,
+      modelName: model?.name ?? modelId,
+      reasoning: model?.reasoning ?? false,
+      contextWindow: model?.contextWindow ?? null,
+      curated: true,
+      supportsVision: model?.input?.includes('image') ?? false,
+    }
+  })
 }
 
-function printAvailableRefs(): void {
-  const refs = listKnownModelRefs()
-  if (refs.length === 0) {
+function describeRef(ref: string): string {
+  try {
+    const providerId = providerForModelRef(ref)
+    const modelId = ref.slice(providerId.length + 1)
+    const provider = KNOWN_PROVIDERS[providerId]
+    const model = (provider.models as Record<string, { name: string }>)[modelId]
+    return `${provider.name} · ${model?.name ?? modelId}`
+  } catch {
+    return ref
+  }
+}
+
+async function printAvailableRefs(): Promise<void> {
+  const { options, source, warning } = await fetchModelOptions()
+  if (options.length === 0) {
     console.log(c.dim('No models registered.'))
     return
   }
   console.log(c.dim('Use `typeclaw model set <profile> <ref>` to apply.'))
-  let lastProvider: KnownProviderId | null = null
-  for (const ref of refs) {
-    const providerId = providerForModelRef(ref)
-    if (providerId !== lastProvider) {
-      console.log('')
-      console.log(c.cyan(KNOWN_PROVIDERS[providerId].name))
-      lastProvider = providerId
+  if (source === 'curated' && warning !== undefined) {
+    console.log(c.dim(`Using built-in catalog (models.dev unavailable: ${warning}).`))
+  }
+  for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
+    const providerOptions = options.filter((option) => option.providerId === providerId)
+    if (providerOptions.length === 0) continue
+    console.log('')
+    console.log(c.cyan(KNOWN_PROVIDERS[providerId].name))
+    for (const option of providerOptions) {
+      const marker = option.curated ? '' : ` ${c.dim('(live)')}`
+      console.log(`  ${option.ref}${marker}`)
     }
-    console.log(`  ${ref}`)
   }
 }

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -254,7 +254,7 @@ async function pickModelRef(cwd: string): Promise<PickedModelRef> {
         ...modelOptions.map((option) => ({
           value: option.ref,
           label: describeRef(option.ref),
-          hint: option.curated ? option.ref : `${option.ref} ${c.dim('(live)')}`,
+          hint: option.ref,
         })),
         {
           value: ADD_PROVIDER_SENTINEL,
@@ -363,8 +363,7 @@ async function printAvailableRefs(): Promise<void> {
     console.log('')
     console.log(c.cyan(KNOWN_PROVIDERS[providerId].name))
     for (const option of providerOptions) {
-      const marker = option.curated ? '' : ` ${c.dim('(live)')}`
-      console.log(`  ${option.ref}${marker}`)
+      console.log(`  ${option.ref}`)
     }
   }
 }

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -8,6 +8,7 @@ import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
 
 import {
   buildConfigMigrationCommitMessage,
+  __resetConfigForTesting,
   configSchema,
   extractPluginConfigs,
   expandMountPath,
@@ -18,51 +19,77 @@ import {
   migrateLegacyConfigShape,
   mcpServerSchema,
   mountSchema,
+  reloadConfig,
+  resolveModel,
   resolveProfile,
   validateConfig,
   validateMount,
   withDefaultPlugins,
   type Models,
 } from './config'
+import { isModelRef, type ModelRef } from './providers'
 
 const isRoot = typeof process.getuid === 'function' && process.getuid() === 0
 
 const VALID_MODEL = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'
 const VALID_MODEL_2 = 'openai/gpt-5.4-nano'
 
+function parseModels(models: Record<string, string | string[]>): Models {
+  return configSchema.parse({ models }).models
+}
+
+function modelRef(value: string): ModelRef {
+  if (isModelRef(value)) return value
+  throw new Error(`expected valid model ref in test: ${value}`)
+}
+
+function modelRefList(...values: string[]): ModelRef[] {
+  return values.map(modelRef)
+}
+
 describe('configSchema models field', () => {
   test('defaults to { default: [<DEFAULT_MODEL_REF>] } when omitted', () => {
     const parsed = configSchema.parse({})
-    expect(parsed.models).toEqual({ default: ['openai/gpt-5.4-nano'] })
+    expect(parsed.models).toEqual({ default: modelRefList('openai/gpt-5.4-nano') })
   })
 
   test('normalises a single-ref string input to a one-element array', () => {
     const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
-    expect(parsed.models).toEqual({ default: [VALID_MODEL] })
+    expect(parsed.models).toEqual({ default: modelRefList(VALID_MODEL) })
   })
 
   test('accepts multiple profiles in either shape and normalises both', () => {
     const parsed = configSchema.parse({
       models: { default: VALID_MODEL, fast: [VALID_MODEL_2], deep: VALID_MODEL, vision: VALID_MODEL_2 },
     })
-    expect(parsed.models.default).toEqual([VALID_MODEL])
-    expect(parsed.models.fast).toEqual([VALID_MODEL_2])
-    expect(parsed.models.deep).toEqual([VALID_MODEL])
-    expect(parsed.models.vision).toEqual([VALID_MODEL_2])
+    expect(parsed.models.default).toEqual(modelRefList(VALID_MODEL))
+    expect(parsed.models.fast).toEqual(modelRefList(VALID_MODEL_2))
+    expect(parsed.models.deep).toEqual(modelRefList(VALID_MODEL))
+    expect(parsed.models.vision).toEqual(modelRefList(VALID_MODEL_2))
   })
 
   test('accepts a fallback chain as an array', () => {
     const parsed = configSchema.parse({
       models: { default: [VALID_MODEL, VALID_MODEL_2] },
     })
-    expect(parsed.models.default).toEqual([VALID_MODEL, VALID_MODEL_2])
+    expect(parsed.models.default).toEqual(modelRefList(VALID_MODEL, VALID_MODEL_2))
   })
 
   test('accepts user-defined profile names alongside well-known ones', () => {
     const parsed = configSchema.parse({
       models: { default: VALID_MODEL, 'cheap-batch': VALID_MODEL_2 },
     })
-    expect(parsed.models['cheap-batch']).toEqual([VALID_MODEL_2])
+    expect(parsed.models['cheap-batch']).toEqual(modelRefList(VALID_MODEL_2))
+  })
+
+  test('accepts custom model refs for known providers', () => {
+    const parsed = configSchema.parse({ models: { default: 'openai/gpt-6-live' } })
+    expect(parsed.models.default).toEqual(modelRefList('openai/gpt-6-live'))
+  })
+
+  test('accepts custom model refs inside fallback chains', () => {
+    const parsed = configSchema.parse({ models: { default: [VALID_MODEL_2, 'openai/gpt-6-live'] } })
+    expect(parsed.models.default).toEqual(modelRefList(VALID_MODEL_2, 'openai/gpt-6-live'))
   })
 
   test('rejects models map without default', () => {
@@ -75,6 +102,10 @@ describe('configSchema models field', () => {
 
   test('rejects unknown model refs inside a chain', () => {
     expect(() => configSchema.parse({ models: { default: [VALID_MODEL, 'not-a-real-model'] } })).toThrow()
+  })
+
+  test('rejects custom model refs for unknown providers', () => {
+    expect(() => configSchema.parse({ models: { default: 'mystery/gpt-6-live' } })).toThrow(/known provider/i)
   })
 
   test('rejects empty arrays', () => {
@@ -93,56 +124,145 @@ describe('configSchema models field', () => {
     const parsed = configSchema.parse({
       models: { default: ['openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'] },
     })
-    expect(parsed.models.default).toEqual(['openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'])
+    expect(parsed.models.default).toEqual(modelRefList('openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'))
+  })
+})
+
+describe('customModels field', () => {
+  test('defaults to an empty map', () => {
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
+    expect(parsed.customModels).toEqual({})
+  })
+
+  test('accepts compact metadata keyed by model ref', () => {
+    const parsed = configSchema.parse({
+      models: { default: 'openai/gpt-6-live' },
+      customModels: {
+        'openai/gpt-6-live': {
+          name: 'GPT-6 Live',
+          reasoning: true,
+          input: ['text', 'image'],
+          contextWindow: 500000,
+          maxTokens: 128000,
+          cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+        },
+      },
+    })
+    expect(parsed.customModels['openai/gpt-6-live']?.name).toBe('GPT-6 Live')
+    expect(parsed.customModels['openai/gpt-6-live']?.input).toEqual(['text', 'image'])
+  })
+})
+
+describe('resolveModel', () => {
+  afterEach(() => {
+    __resetConfigForTesting()
+  })
+
+  test('returns curated model literals unchanged', () => {
+    const model = resolveModel('openai/gpt-5.4-nano')
+    expect(model.id).toBe('gpt-5.4-nano')
+    expect(model.cost.input).toBeGreaterThan(0)
+  })
+
+  test('synthesizes a custom model from the provider transport with safe defaults', () => {
+    const model = resolveModel('openai/gpt-6-live')
+    expect(model).toMatchObject({
+      id: 'gpt-6-live',
+      name: 'gpt-6-live',
+      provider: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      api: 'openai-responses',
+      reasoning: false,
+      input: ['text'],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    })
+    expect(model.contextWindow).toBe(400000)
+    expect(model.maxTokens).toBe(128000)
+  })
+
+  test('uses customModels metadata when synthesizing a custom model', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-resolve-model-'))
+    try {
+      await writeFile(
+        join(cwd, 'typeclaw.json'),
+        JSON.stringify({
+          models: { default: 'openai/gpt-6-live' },
+          customModels: {
+            'openai/gpt-6-live': {
+              name: 'GPT-6 Live',
+              reasoning: true,
+              input: ['text', 'image'],
+              contextWindow: 123456,
+              maxTokens: 6543,
+              cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 },
+            },
+          },
+        }),
+      )
+      reloadConfig(cwd)
+
+      const model = resolveModel('openai/gpt-6-live')
+
+      expect(model).toMatchObject({
+        name: 'GPT-6 Live',
+        reasoning: true,
+        input: ['text', 'image'],
+        contextWindow: 123456,
+        maxTokens: 6543,
+        cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 },
+      })
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
   })
 })
 
 describe('resolveProfile', () => {
-  const models: Models = { default: [VALID_MODEL], fast: [VALID_MODEL_2] }
+  const models = parseModels({ default: VALID_MODEL, fast: VALID_MODEL_2 })
 
   test('returns the requested profile when present', () => {
     const result = resolveProfile(models, 'fast')
-    expect(result.ref).toBe(VALID_MODEL_2)
-    expect(result.refs).toEqual([VALID_MODEL_2])
+    expect(result.ref).toBe(modelRef(VALID_MODEL_2))
+    expect(result.refs).toEqual(modelRefList(VALID_MODEL_2))
     expect(result.profile).toBe('fast')
     expect(result.fellBackToDefault).toBe(false)
   })
 
   test('returns default when name is undefined', () => {
     const result = resolveProfile(models, undefined)
-    expect(result.ref).toBe(VALID_MODEL)
-    expect(result.refs).toEqual([VALID_MODEL])
+    expect(result.ref).toBe(modelRef(VALID_MODEL))
+    expect(result.refs).toEqual(modelRefList(VALID_MODEL))
     expect(result.profile).toBe('default')
     expect(result.fellBackToDefault).toBe(false)
   })
 
   test('returns default when name is "default"', () => {
     const result = resolveProfile(models, 'default')
-    expect(result.ref).toBe(VALID_MODEL)
-    expect(result.refs).toEqual([VALID_MODEL])
+    expect(result.ref).toBe(modelRef(VALID_MODEL))
+    expect(result.refs).toEqual(modelRefList(VALID_MODEL))
     expect(result.profile).toBe('default')
     expect(result.fellBackToDefault).toBe(false)
   })
 
   test('falls back to default when requested profile is missing, flagging the fallback', () => {
     const result = resolveProfile(models, 'deep')
-    expect(result.ref).toBe(VALID_MODEL)
-    expect(result.refs).toEqual([VALID_MODEL])
+    expect(result.ref).toBe(modelRef(VALID_MODEL))
+    expect(result.refs).toEqual(modelRefList(VALID_MODEL))
     expect(result.profile).toBe('default')
     expect(result.fellBackToDefault).toBe(true)
   })
 
   test('exposes the full chain when the profile is a multi-ref fallback', () => {
-    const chain: Models = { default: [VALID_MODEL, VALID_MODEL_2] }
+    const chain = parseModels({ default: [VALID_MODEL, VALID_MODEL_2] })
     const result = resolveProfile(chain, 'default')
-    expect(result.ref).toBe(VALID_MODEL)
-    expect(result.refs).toEqual([VALID_MODEL, VALID_MODEL_2])
+    expect(result.ref).toBe(modelRef(VALID_MODEL))
+    expect(result.refs).toEqual(modelRefList(VALID_MODEL, VALID_MODEL_2))
   })
 
   test('inherits the default chain when falling back, preserving every fallback ref', () => {
-    const chain: Models = { default: [VALID_MODEL, VALID_MODEL_2] }
+    const chain = parseModels({ default: [VALID_MODEL, VALID_MODEL_2] })
     const result = resolveProfile(chain, 'deep')
-    expect(result.refs).toEqual([VALID_MODEL, VALID_MODEL_2])
+    expect(result.refs).toEqual(modelRefList(VALID_MODEL, VALID_MODEL_2))
     expect(result.fellBackToDefault).toBe(true)
   })
 })

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@ import { accessSync, constants as fsConstants, readFileSync, statSync, writeFile
 import { homedir } from 'node:os'
 import { isAbsolute, join, posix, resolve } from 'node:path'
 
-import type { Model } from '@mariozechner/pi-ai'
+import type { KnownApi, Model } from '@mariozechner/pi-ai'
 import { z } from 'zod'
 
 import { channelsSchema, SEEDED_GITHUB_EVENT_ALLOWLISTS } from '@/channels/schema'
@@ -13,9 +13,12 @@ import { secretFieldSchema } from '@/secrets/resolve'
 import {
   DEFAULT_MODEL_REF,
   KNOWN_PROVIDERS,
+  isKnownModelRef,
+  isModelRef,
   listKnownModelRefs,
   type KnownModelRef,
-  type KnownProviderId,
+  type ModelRef,
+  providerForModelRef,
 } from './providers'
 
 const CONFIG_FILE = 'typeclaw.json'
@@ -574,16 +577,55 @@ const tunnelsArraySchema = z
     }
   })
 
-// `models` maps a profile name to one or more curated model refs. The
+const customModelCostSchema = z
+  .object({
+    input: z.number().optional(),
+    output: z.number().optional(),
+    cacheRead: z.number().optional(),
+    cacheWrite: z.number().optional(),
+  })
+  .catchall(z.unknown())
+
+export const customModelMetaSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    reasoning: z.boolean().optional(),
+    input: z.array(z.string().min(1)).optional(),
+    contextWindow: z.number().optional(),
+    maxTokens: z.number().optional(),
+    cost: customModelCostSchema.optional(),
+  })
+  .catchall(z.unknown())
+
+export type CustomModelMeta = z.infer<typeof customModelMetaSchema>
+
+export const customModelsSchema = z.record(z.string().min(1), customModelMetaSchema).default({})
+
+export type CustomModels = z.infer<typeof customModelsSchema>
+
+const customModelRefSchema = z.string().refine((ref) => isModelRef(ref), {
+  message: 'model ref must be "<known-provider>/<model-id>" with a known provider',
+})
+
+const singleModelRef = z.union([z.enum(knownModelRefs), customModelRefSchema])
+
+function asModelRef(value: string): ModelRef {
+  if (isModelRef(value)) return value
+  throw new Error(`Invalid model ref: ${value}`)
+}
+
+// `models` maps a profile name to one or more model refs. Curated refs keep
+// editor autocomplete through the enum branch, while custom refs are allowed
+// when they target a known provider.
 // `default` profile is mandatory; every other profile is optional and falls
 // back to `default` at resolution time (see `resolveProfile`).
 //
-// Each value is either a single `KnownModelRef` or a non-empty array of refs
+// Each value is either a single model ref or a non-empty array of refs
 // forming a fallback chain: when a turn against the first ref fails (hard
 // throw or a soft provider error), the runtime disposes the failed session
 // and replays the same prompt against the next ref. Schema accepts both
 // shapes for ergonomics; the parsed value is always normalised to a
-// non-empty array so downstream consumers read a uniform `KnownModelRef[]`.
+// non-empty array so downstream consumers read a uniform `ModelRef[]`.
 //
 // Profile names are open strings; the runtime recognizes a handful of
 // well-known names by convention (`default`, `fast`, `deep`, `vision`) but
@@ -596,9 +638,9 @@ const tunnelsArraySchema = z
 // `persistMigratedConfig`), so every downstream consumer sees the new shape.
 const modelRefOrChainSchema = z
   .union([
-    z.enum(knownModelRefs),
+    singleModelRef,
     z
-      .array(z.enum(knownModelRefs))
+      .array(singleModelRef)
       .min(1)
       // Reject exact duplicates in a chain — retrying the same ref after the
       // same class of failure is almost certainly a config typo, and silently
@@ -609,7 +651,7 @@ const modelRefOrChainSchema = z
         message: 'models chain must not contain duplicate refs',
       }),
   ])
-  .transform((value) => (Array.isArray(value) ? value : [value]))
+  .transform((value) => (Array.isArray(value) ? value : [value]).map((ref) => asModelRef(ref)))
 export const modelsSchema = z
   .record(z.string().min(1), modelRefOrChainSchema)
   .refine((m) => 'default' in m, { message: 'models.default is required' })
@@ -617,7 +659,7 @@ export const modelsSchema = z
 // Zod's `z.record(..., refine)` doesn't refine the inferred type. The
 // `default` key is schema-enforced, so we narrow it here to spare every
 // consumer the `T | undefined` assertion noise.
-export type Models = Record<string, KnownModelRef[]> & { default: KnownModelRef[] }
+export type Models = Record<string, ModelRef[]> & { default: ModelRef[] }
 
 export const configSchema = z
   .object({
@@ -626,9 +668,10 @@ export const configSchema = z
     // `default(() => ...)` ensures every parsed config has at least
     // `models.default`. Direct `.default({ default: ... })` would short-circuit
     // the refinement, so we lean on the lazy thunk form. The default value is
-    // shaped to match the post-transform output (always `KnownModelRef[]`),
+    // shaped to match the post-transform output (always `ModelRef[]`),
     // not the user-facing input shape.
-    models: modelsSchema.default(() => ({ default: [DEFAULT_MODEL_REF] })) as unknown as z.ZodType<Models>,
+    models: modelsSchema.default(() => ({ default: [asModelRef(DEFAULT_MODEL_REF)] })) as unknown as z.ZodType<Models>,
+    customModels: customModelsSchema,
     // Defaults to `[]` so the field can be omitted from `typeclaw.json` (no
     // host paths exposed) without failing the whole config load. `typeclaw
     // init` omits this field so users don't see noise for the empty case.
@@ -656,12 +699,58 @@ export const configSchema = z
 
 export type Config = z.infer<typeof configSchema>
 
-export function resolveModel(ref: KnownModelRef): Model<'openai-completions'> | Model<'openai-responses'> {
-  // Model IDs can contain '/', so split only on the first separator.
-  const slash = ref.indexOf('/')
-  const providerId = ref.slice(0, slash) as KnownProviderId
-  const modelId = ref.slice(slash + 1)
-  return KNOWN_PROVIDERS[providerId].models[modelId as never]
+export function resolveModel(ref: KnownModelRef | ModelRef | string): Model<KnownApi> {
+  const providerId = providerForModelRef(ref)
+  const modelId = ref.slice(providerId.length + 1)
+  const provider = KNOWN_PROVIDERS[providerId]
+  if (isKnownModelRef(ref)) {
+    const model = (provider.models as Record<string, Model<KnownApi>>)[modelId]
+    if (model !== undefined) return model
+  }
+
+  if (!isModelRef(ref)) {
+    throw new Error(`Invalid model ref "${ref}". Expected "<known-provider>/<model-id>".`)
+  }
+
+  const templateModelId = Object.keys(provider.models)[0]
+  if (templateModelId === undefined) {
+    throw new Error(`Provider ${providerId} has no curated models to use as a transport template`)
+  }
+  const template = (provider.models as Record<string, Model<KnownApi>>)[templateModelId]
+  if (template === undefined) {
+    throw new Error(`Provider ${providerId} has no curated models to use as a transport template`)
+  }
+
+  const meta = getConfig().customModels[ref]
+  return {
+    id: modelId,
+    provider: providerId,
+    baseUrl: provider.baseUrl ?? template.baseUrl,
+    api: template.api,
+    name: meta?.name ?? modelId,
+    reasoning: meta?.reasoning ?? false,
+    input: resolveCustomModelInput(meta?.input),
+    contextWindow: meta?.contextWindow ?? template.contextWindow,
+    maxTokens: meta?.maxTokens ?? template.maxTokens,
+    cost: resolveCustomModelCost(meta?.cost),
+  }
+}
+
+function resolveCustomModelInput(input: readonly string[] | undefined): Model<KnownApi>['input'] {
+  if (input === undefined) return ['text']
+  const supported = input.filter(
+    (value): value is Model<KnownApi>['input'][number] => value === 'text' || value === 'image',
+  )
+  return supported.length > 0 ? supported : ['text']
+}
+
+function resolveCustomModelCost(cost: CustomModelMeta['cost']): Model<KnownApi>['cost'] {
+  return {
+    input: cost?.input ?? 0,
+    output: cost?.output ?? 0,
+    cacheRead: cost?.cacheRead ?? 0,
+    cacheWrite: cost?.cacheWrite ?? 0,
+  }
 }
 
 // Resolves a profile name (e.g. `fast`, `deep`, `vision`) to its fallback
@@ -672,8 +761,8 @@ export function resolveModel(ref: KnownModelRef): Model<'openai-completions'> | 
 // session is created with first. Callers that don't implement fallback can
 // keep reading `ref`; fallback-aware callers iterate `refs`.
 export type ResolvedProfile = {
-  ref: KnownModelRef
-  refs: KnownModelRef[]
+  ref: ModelRef
+  refs: ModelRef[]
   profile: string
   fellBackToDefault: boolean
 }
@@ -790,6 +879,7 @@ export type FieldEffect = 'applied' | 'restart-required' | 'ignored'
 export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   $schema: 'ignored',
   models: 'applied',
+  customModels: 'applied',
   port: 'restart-required',
   mounts: 'restart-required',
   mcpServers: 'restart-required',
@@ -885,6 +975,7 @@ export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
     '$schema',
     'port',
     'models',
+    'customModels',
     'mounts',
     'plugins',
     'alias',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,8 @@ export {
   buildConfigMigrationCommitMessage,
   config,
   configSchema,
+  customModelMetaSchema,
+  customModelsSchema,
   DEFAULT_PLUGINS,
   dockerSchema,
   dockerfileSchema,
@@ -29,6 +31,8 @@ export {
   type Config,
   type ConfigChange,
   type ConfigReloadDiff,
+  type CustomModelMeta,
+  type CustomModels,
   type DockerConfig,
   type DockerfileConfig,
   type GitConfig,
@@ -43,5 +47,5 @@ export {
   type ResolvedProfile,
   type ValidateConfigResult,
 } from './config'
-export { type KnownModelRef, type KnownProviderId } from './providers'
+export { type KnownModelRef, type KnownProviderId, type ModelRef } from './providers'
 export { createConfigReloadable, type CreateConfigReloadableOptions } from './reloadable'

--- a/src/config/models-mutation.test.ts
+++ b/src/config/models-mutation.test.ts
@@ -36,6 +36,12 @@ async function readModels(): Promise<Record<string, string>> {
   return parsed.models ?? {}
 }
 
+async function readCustomModels(): Promise<Record<string, unknown>> {
+  const raw = await readFile(join(root, 'typeclaw.json'), 'utf8')
+  const parsed = JSON.parse(raw) as { customModels?: Record<string, unknown> }
+  return parsed.customModels ?? {}
+}
+
 describe('listAvailableModelRefs', () => {
   test('returns all KNOWN_PROVIDERS model refs', () => {
     const refs = listAvailableModelRefs()
@@ -134,6 +140,40 @@ describe('setProfile', () => {
     expect(result.ok).toBe(true)
   })
 
+  test('accepts a custom model ref for a known provider without metadata', async () => {
+    const env: NodeJS.ProcessEnv = { OPENAI_API_KEY: 'sk-from-env' }
+    const result = setProfile(root, 'default', 'openai/gpt-6-live', { env })
+    expect(result.ok).toBe(true)
+    expect((await readModels()).default).toBe('openai/gpt-6-live')
+    expect(await readCustomModels()).toEqual({})
+  })
+
+  test('writes customModels metadata for a custom model ref in the same mutation', async () => {
+    const ref = 'fireworks/accounts/fireworks/models/qwen3-next'
+    const result = setProfile(root, 'default', ref, {
+      meta: {
+        name: 'Qwen3 Next',
+        reasoning: true,
+        input: ['text', 'image'],
+        contextWindow: 262144,
+        maxTokens: 32768,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    })
+    expect(result.ok).toBe(true)
+    expect((await readModels()).default).toBe(ref)
+    expect(await readCustomModels()).toEqual({
+      [ref]: {
+        name: 'Qwen3 Next',
+        reasoning: true,
+        input: ['text', 'image'],
+        contextWindow: 262144,
+        maxTokens: 32768,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    })
+  })
+
   test('force=true writes even without credentials', () => {
     const env: NodeJS.ProcessEnv = {}
     const result = setProfile(root, 'default', 'openai/gpt-5.4-nano', { env, force: true })
@@ -227,8 +267,11 @@ describe('listModelProfiles', () => {
     const env: NodeJS.ProcessEnv = {}
     const entries = listModelProfiles(root, env)
     const dflt = entries.find((e) => e.profile === 'default')
-    expect(dflt?.ref).toBe('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
-    expect(dflt?.refs).toEqual(['fireworks/accounts/fireworks/routers/kimi-k2p6-turbo', 'openai/gpt-5.4-nano'])
+    expect(String(dflt?.ref)).toBe('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')
+    expect(dflt?.refs.map(String)).toEqual([
+      'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo',
+      'openai/gpt-5.4-nano',
+    ])
     expect(dflt?.credentialStatus).toBe('missing-credentials')
     expect(dflt?.missingProviders).toEqual(['openai'])
   })

--- a/src/config/models-mutation.ts
+++ b/src/config/models-mutation.ts
@@ -3,13 +3,16 @@ import { join } from 'node:path'
 
 import { commitSystemFileSync } from '@/git/system-commit'
 
-import { configSchema, loadConfigSyncOrDefaults, validateConfig } from './config'
+import { configSchema, loadConfigSyncOrDefaults, validateConfig, type CustomModelMeta } from './config'
 import {
   KNOWN_PROVIDERS,
+  isKnownModelRef,
+  isModelRef,
   listKnownModelRefs,
   providerForModelRef,
   type KnownModelRef,
   type KnownProviderId,
+  type ModelRef,
 } from './providers'
 import { isProviderConfigured, listConfiguredProviders } from './providers-mutation'
 
@@ -20,8 +23,8 @@ export type ModelProfileEntry = {
   // Head of the fallback chain. Kept under the legacy `ref` name so callers
   // that only care about the active model (the common case) don't need to
   // dereference `refs[0]`. The chain itself is exposed as `refs`.
-  ref: KnownModelRef
-  refs: KnownModelRef[]
+  ref: ModelRef
+  refs: ModelRef[]
   providerId: KnownProviderId
   // Credential status for every provider referenced by the chain. The chain's
   // overall status is `available` only when every entry resolves; otherwise
@@ -67,7 +70,7 @@ export function listModelProfiles(cwd: string, env: NodeJS.ProcessEnv = process.
   return out
 }
 
-function uniqueProviders(refs: ReadonlyArray<KnownModelRef>): KnownProviderId[] {
+function uniqueProviders(refs: ReadonlyArray<ModelRef>): KnownProviderId[] {
   const seen = new Set<KnownProviderId>()
   const out: KnownProviderId[] = []
   for (const r of refs) {
@@ -103,9 +106,7 @@ export function listRegisteredModelRefs(cwd: string, env: NodeJS.ProcessEnv = pr
   return listKnownModelRefs().filter((ref) => registered.has(providerForModelRef(ref)))
 }
 
-export function isKnownModelRef(value: string): value is KnownModelRef {
-  return (listKnownModelRefs() as ReadonlyArray<string>).includes(value)
-}
+export { isKnownModelRef }
 
 // `set` is the canonical mutation for both creating a new profile and updating
 // an existing one (mirrors how `models.<profile>` works in the schema).
@@ -115,6 +116,7 @@ export function isKnownModelRef(value: string): value is KnownModelRef {
 export type SetProfileOptions = {
   force?: boolean
   env?: NodeJS.ProcessEnv
+  meta?: CustomModelMeta
 }
 
 export function setProfile(
@@ -127,7 +129,7 @@ export function setProfile(
   if (trimmed.length === 0) {
     return { ok: false, reason: 'Profile name cannot be empty.' }
   }
-  if (!isKnownModelRef(ref)) {
+  if (!isModelRef(ref)) {
     return {
       ok: false,
       reason: `Unknown model "${ref}". Run \`typeclaw model list --available\` to see valid options.`,
@@ -143,7 +145,8 @@ export function setProfile(
 
   const existingBefore = readModelsRaw(cwd)
   const verb = existingBefore !== null && trimmed in existingBefore ? 'set' : 'add'
-  return writeProfile(cwd, trimmed, ref, `model: ${verb} ${trimmed} → ${ref}`)
+  const customModel = !isKnownModelRef(ref) && options.meta !== undefined ? { ref, meta: options.meta } : undefined
+  return writeProfile(cwd, trimmed, ref, `model: ${verb} ${trimmed} → ${ref}`, customModel)
 }
 
 // `add` is just `set` with a uniqueness guard; users who want "update" should
@@ -189,19 +192,26 @@ export function removeProfile(cwd: string, profile: string): ModelMutationResult
   return writeModels(cwd, next, `model: remove ${profile}`)
 }
 
-function writeProfile(cwd: string, profile: string, ref: KnownModelRef, message: string): ModelMutationResult {
+function writeProfile(
+  cwd: string,
+  profile: string,
+  ref: ModelRef,
+  message: string,
+  customModel?: { ref: ModelRef; meta: CustomModelMeta },
+): ModelMutationResult {
   const existing = readModelsRaw(cwd)
   const next: Record<string, string | string[]> = existing === null ? { default: ref } : { ...existing, [profile]: ref }
   if (existing === null && profile !== 'default') {
     next.default = ref
   }
-  return writeModels(cwd, next, message)
+  return writeModels(cwd, next, message, customModel)
 }
 
 function writeModels(
   cwd: string,
   models: Record<string, string | string[]>,
   commitMessage: string,
+  customModel?: { ref: ModelRef; meta: CustomModelMeta },
 ): ModelMutationResult {
   const path = join(cwd, CONFIG_FILE)
   let parsed: Record<string, unknown>
@@ -215,6 +225,10 @@ function writeModels(
     return { ok: false, reason: `Failed to read ${CONFIG_FILE}: ${(error as Error).message}` }
   }
   parsed.models = models
+  if (customModel !== undefined) {
+    const existingCustomModels = isObjectRecord(parsed.customModels) ? parsed.customModels : {}
+    parsed.customModels = { ...existingCustomModels, [customModel.ref]: customModel.meta }
+  }
   const check = configSchema.safeParse(parsed)
   if (!check.success) {
     return {
@@ -242,6 +256,10 @@ function writeModels(
   // Bun, and clean files, so callers outside a git repo pay zero cost.
   commitSystemFileSync(cwd, CONFIG_FILE, commitMessage)
   return { ok: true }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 // Returns the raw `models` block from disk in its on-disk shape: each value

--- a/src/config/providers-mutation.ts
+++ b/src/config/providers-mutation.ts
@@ -5,7 +5,7 @@ import { providerKeyDefaultEnv } from '@/secrets/defaults'
 import type { ProviderCredential, Providers } from '@/secrets/schema'
 
 import { type Models, loadConfigSync } from './config'
-import { KNOWN_PROVIDERS, type KnownModelRef, type KnownProviderId, providerForModelRef } from './providers'
+import { KNOWN_PROVIDERS, type KnownProviderId, type ModelRef, providerForModelRef } from './providers'
 
 // Where a configured credential resolves from at runtime. Reported by
 // `typeclaw provider list` so users can tell whether their key is coming from
@@ -230,7 +230,7 @@ function refTargetsProvider(ref: string, providerId: string): boolean {
   return ref.startsWith(`${providerId}/`)
 }
 
-function safeProviderForRef(ref: KnownModelRef): KnownProviderId | null {
+function safeProviderForRef(ref: ModelRef): KnownProviderId | null {
   try {
     return providerForModelRef(ref)
   } catch {

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   defaultThinkingLevelForRef,
+  isKnownModelRef,
+  isModelRef,
   KNOWN_PROVIDER_VENDORS,
   KNOWN_PROVIDERS,
   type KnownProviderId,
@@ -352,6 +354,25 @@ describe('providerForModelRef', () => {
   test('distinguishes moonshot from moonshot-coding by the slash-prefixed match (not substring)', () => {
     expect(providerForModelRef('moonshot-coding/kimi-for-coding')).toBe('moonshot-coding')
     expect(providerForModelRef('moonshot/kimi-k2.6')).toBe('moonshot')
+  })
+})
+
+describe('model ref predicates', () => {
+  test('isKnownModelRef accepts curated refs only', () => {
+    expect(isKnownModelRef('openai/gpt-5.4-nano')).toBe(true)
+    expect(isKnownModelRef('openai/gpt-6-live')).toBe(false)
+  })
+
+  test('isModelRef accepts custom refs for known providers', () => {
+    expect(isModelRef('openai/gpt-6-live')).toBe(true)
+    expect(isModelRef('fireworks/accounts/fireworks/models/qwen3-next')).toBe(true)
+  })
+
+  test('isModelRef rejects unknown providers and malformed refs', () => {
+    expect(isModelRef('unknown/gpt-6-live')).toBe(false)
+    expect(isModelRef('openai/')).toBe(false)
+    expect(isModelRef('OpenAI/gpt-6-live')).toBe(false)
+    expect(isModelRef('openai/gpt 6')).toBe(false)
   })
 })
 

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,4 +1,4 @@
-import type { Api, Model } from '@mariozechner/pi-ai'
+import type { KnownApi, Model } from '@mariozechner/pi-ai'
 
 // Authentication mechanism a provider supports. `api-key` reads a static key
 // from .env (the original path); `oauth` runs a browser flow at init time and
@@ -18,16 +18,13 @@ type KnownProvider = {
   auth: ReadonlyArray<AuthMethod>
   apiKeyEnv: string | null
   oauthProviderId: string | null
-  models: Record<string, Model<Api>>
+  models: Record<string, Model<KnownApi>>
 }
 
-// Curated allowlist of providers + models that are wired into the agent
-// runtime. The values here back the Zod enum on every entry in
-// `configSchema.models`, so any model the user can put in `typeclaw.json`
-// (under any profile name) MUST appear here verbatim. The
-// init-time picker may surface additional models from models.dev, but it
-// resolves them through this list before scaffolding (anything missing falls
-// back to a curated default).
+// Curated provider + model table. Provider ids remain the allowlist for
+// `typeclaw.json` refs, while the model entries are the tested defaults and
+// JSON-schema autocomplete set. The init/model pickers may surface additional
+// models from models.dev as long as the provider prefix is one of these ids.
 //
 // Adding a new model: append it to the matching provider's `models` map. Each
 // model object is the literal `Model<...>` that pi-ai consumes — keep it
@@ -941,6 +938,8 @@ export type KnownModelRef = {
   [P in KnownProviderId]: `${P}/${Extract<keyof (typeof KNOWN_PROVIDERS)[P]['models'], string>}`
 }[KnownProviderId]
 
+export type ModelRef = string & { readonly __modelRef: unique symbol }
+
 export function listKnownModelRefs(): KnownModelRef[] {
   const refs: string[] = []
   for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
@@ -951,19 +950,33 @@ export function listKnownModelRefs(): KnownModelRef[] {
   return refs as KnownModelRef[]
 }
 
+export function isKnownModelRef(value: string): value is KnownModelRef {
+  return (listKnownModelRefs() as ReadonlyArray<string>).includes(value)
+}
+
+export function isModelRef(value: string): value is ModelRef {
+  return /^[a-z0-9][a-z0-9-]*\/[^\s/][^\s]*$/.test(value) && knownProviderForModelRef(value) !== null
+}
+
 // The default we hand to scaffolded `typeclaw.json` and the schema's
 // `model.default`. Lives here (next to the provider table) so adding a model
 // can't drift from the field default — both come from the same module.
 export const DEFAULT_MODEL_REF: KnownModelRef = 'openai/gpt-5.4-nano'
 
-export function providerForModelRef(ref: KnownModelRef): KnownProviderId {
+export function providerForModelRef(ref: KnownModelRef | ModelRef | string): KnownProviderId {
   // KnownModelRef is `${provider}/${modelId}`, but provider IDs themselves can
   // contain '-' and model IDs can contain '/' (Fireworks). We split on the
   // first slash that follows a registered provider id.
+  const providerId = knownProviderForModelRef(ref)
+  if (providerId !== null) return providerId
+  throw new Error(`Unknown provider in model ref: ${ref}`)
+}
+
+function knownProviderForModelRef(ref: string): KnownProviderId | null {
   for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
     if (ref.startsWith(`${providerId}/`)) return providerId
   }
-  throw new Error(`Unknown provider in model ref: ${ref}`)
+  return null
 }
 
 // Per-provider default for pi-coding-agent's `thinkingLevel` knob. Returning
@@ -978,7 +991,7 @@ export function providerForModelRef(ref: KnownModelRef): KnownProviderId {
 //
 // Anthropic, GLM, and Kimi don't share the padding behavior, so they keep the
 // SDK default.
-export function defaultThinkingLevelForRef(ref: KnownModelRef): 'low' | undefined {
+export function defaultThinkingLevelForRef(ref: KnownModelRef | ModelRef | string): 'low' | undefined {
   const providerId = providerForModelRef(ref)
   if (providerId === 'openai' || providerId === 'openai-codex') return 'low'
   return undefined

--- a/src/config/reloadable.test.ts
+++ b/src/config/reloadable.test.ts
@@ -230,6 +230,32 @@ describe('createConfigReloadable', () => {
     expect(diff.ignored.map((c) => c.path)).toEqual(['$schema'])
   })
 
+  test('field fence: customModels changes land in `applied`', async () => {
+    await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'openai/gpt-6-live' } }))
+    const reloadable = createConfigReloadable({ cwd })
+    await reloadable.reload()
+
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: 'openai/gpt-6-live' },
+        customModels: { 'openai/gpt-6-live': { name: 'GPT-6 Live', reasoning: true } },
+      }),
+    )
+    const result = await reloadable.reload()
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const diff = result.details as {
+      applied: { path: string }[]
+      restartRequired: unknown[]
+      ignored: unknown[]
+    }
+    expect(diff.applied.map((c) => c.path)).toEqual(['customModels'])
+    expect(diff.restartRequired).toHaveLength(0)
+    expect(diff.ignored).toHaveLength(0)
+  })
+
   test('summary string reports counts in each bucket', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -2,7 +2,7 @@ import type { AgentSession } from '@/agent'
 import { promptWithFallback, resolveFallbackChain } from '@/agent/model-fallback'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { getConfig } from '@/config'
-import type { KnownModelRef } from '@/config/providers'
+import type { ModelRef } from '@/config/providers'
 import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
@@ -48,7 +48,7 @@ export type CreateCronConsumerOptions = {
   // each attempt to the specified model. Factories that don't honor the
   // override silently lose fallback semantics, so production wiring threads
   // it through to `createSession({ refOverride })`.
-  createSessionForCron: (job: PromptJob, refOverride?: KnownModelRef) => Promise<CronSession>
+  createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>
   // Builds the `CronHandlerContext` for the job and awaits its `handler`.
   // Wired by `src/run/index.ts` to reuse `runPromptForCommand` /
   // `runExecForCommand` from the command runner so plugin cron handlers and
@@ -161,7 +161,7 @@ export function createCronConsumer({
 
 async function runPrompt(
   job: PromptJob,
-  createSessionForCron: (job: PromptJob, refOverride?: KnownModelRef) => Promise<CronSession>,
+  createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>,
   stream: Stream,
   logger: CronConsumerLogger,
 ): Promise<void> {
@@ -198,8 +198,8 @@ async function runPrompt(
 
 async function runPromptOnce(
   job: PromptJob,
-  refs: KnownModelRef[],
-  createSessionForCron: (job: PromptJob, refOverride?: KnownModelRef) => Promise<CronSession>,
+  refs: ModelRef[],
+  createSessionForCron: (job: PromptJob, refOverride?: ModelRef) => Promise<CronSession>,
   logger: CronConsumerLogger,
 ): Promise<void> {
   // Per-attempt lifecycle: every session we create gets full

--- a/src/init/checkpoint.ts
+++ b/src/init/checkpoint.ts
@@ -6,9 +6,9 @@ import {
   listKnownModelRefs,
   listKnownProviderVendorIds,
   providerIdsForVendor,
-  type KnownModelRef,
   type KnownProviderId,
   type KnownProviderVendorId,
+  type ModelRef,
 } from '@/config/providers'
 
 // In-folder scratch for an in-progress `typeclaw init`, co-located with the
@@ -35,11 +35,11 @@ export interface WizardAnswerCheckpointV1 {
   updatedAt: string
   vendorId?: KnownProviderVendorId
   providerId?: KnownProviderId
-  modelRef?: KnownModelRef
+  modelRef?: ModelRef | string
   authMethod?: AuthMethod
   visionVendorId?: KnownProviderVendorId
   visionProviderId?: KnownProviderId
-  visionModelRef?: KnownModelRef
+  visionModelRef?: ModelRef | string
   visionAuthMethod?: AuthMethod
   channelChoice?: WizardChannelChoice
 }
@@ -57,11 +57,11 @@ export interface WizardCheckpointSelections {
   cwd: string
   vendorId?: KnownProviderVendorId
   providerId?: KnownProviderId
-  modelRef?: KnownModelRef
+  modelRef?: ModelRef | string
   authMethod?: AuthMethod
   visionVendorId?: KnownProviderVendorId
   visionProviderId?: KnownProviderId
-  visionModelRef?: KnownModelRef
+  visionModelRef?: ModelRef | string
   visionAuthMethod?: AuthMethod
   channelChoice?: WizardChannelChoice
 }
@@ -89,7 +89,7 @@ export function checkpointFromSelections(selections: WizardCheckpointSelections)
 // exists. Returns a sanitized copy; never throws on drift.
 export function sanitizeCheckpointAgainstCatalog(
   checkpoint: WizardAnswerCheckpointV1,
-  validModelRefs: ReadonlySet<KnownModelRef> = new Set(listKnownModelRefs()),
+  validModelRefs: ReadonlySet<string> = new Set(listKnownModelRefs()),
 ): WizardAnswerCheckpointV1 {
   const sanitized: WizardAnswerCheckpointV1 = {
     version: WIZARD_CHECKPOINT_VERSION,

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -801,6 +801,28 @@ describe('scaffold', () => {
     expect(cfg.models).toEqual({ default: 'zai/glm-4.6', vision: 'openai/gpt-5.4-nano' })
   })
 
+  test('writes customModels metadata for non-curated scaffolded models', async () => {
+    await scaffold(root, {
+      model: 'openai/gpt-6-live',
+      modelMeta: { name: 'GPT-6 Live', reasoning: true, input: ['text'], contextWindow: 500000 },
+      visionModel: 'fireworks/accounts/fireworks/models/qwen3-vl-live',
+      visionModelMeta: { name: 'Qwen3 VL Live', input: ['text', 'image'] },
+    })
+
+    const cfg = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      models: Record<string, string>
+      customModels: Record<string, unknown>
+    }
+    expect(cfg.models).toEqual({
+      default: 'openai/gpt-6-live',
+      vision: 'fireworks/accounts/fireworks/models/qwen3-vl-live',
+    })
+    expect(cfg.customModels).toEqual({
+      'openai/gpt-6-live': { name: 'GPT-6 Live', reasoning: true, input: ['text'], contextWindow: 500000 },
+      'fireworks/accounts/fireworks/models/qwen3-vl-live': { name: 'Qwen3 VL Live', input: ['text', 'image'] },
+    })
+  })
+
   test('omits every field whose default is already provided by configSchema or a bundled plugin', async () => {
     await scaffold(root)
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -10,13 +10,15 @@ import {
   GWS_MULTI_ACCOUNT_PLUGIN_VERSION,
   migrateLegacyConfigShape,
   type Config,
+  type CustomModelMeta,
 } from '@/config'
 import {
   DEFAULT_MODEL_REF,
   KNOWN_PROVIDERS,
+  isKnownModelRef,
   providerForModelRef,
-  type KnownModelRef,
   type KnownProviderId,
+  type ModelRef,
 } from '@/config/providers'
 import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
 import { commitSystemFile } from '@/git/system-commit'
@@ -171,7 +173,8 @@ export type InitOptions = {
   cwd: string
   // Selected `provider/model` ref written into typeclaw.json. Defaults to
   // DEFAULT_MODEL_REF when callers (or older test fixtures) omit it.
-  model?: KnownModelRef
+  model?: ModelRef | string
+  modelMeta?: CustomModelMeta
   // How the agent will authenticate to the LLM provider. When omitted,
   // defaults to the api-key path with `apiKey` (legacy field, still
   // supported for backwards compat with the old `runInit` signature).
@@ -181,7 +184,8 @@ export type InitOptions = {
   // when both refer to the same provider; the wizard enforces this
   // pairing rule, so by the time we get here `visionAuth` is either
   // (a) absent, or (b) the right auth for `visionModel`'s provider.
-  visionModel?: KnownModelRef
+  visionModel?: ModelRef | string
+  visionModelMeta?: CustomModelMeta
   visionAuth?: LLMAuth
   apiKey?: string
   discordBotToken?: string
@@ -224,7 +228,9 @@ export async function runInit({
   apiKey,
   llmAuth,
   model = DEFAULT_MODEL_REF,
+  modelMeta,
   visionModel,
+  visionModelMeta,
   visionAuth,
   discordBotToken,
   slackBotToken,
@@ -304,7 +310,9 @@ export async function runInit({
   emit({ step: 'scaffold', phase: 'start' })
   await scaffold(cwd, {
     model,
+    ...(modelMeta !== undefined ? { modelMeta } : {}),
     ...(visionModel !== undefined ? { visionModel } : {}),
+    ...(visionModelMeta !== undefined ? { visionModelMeta } : {}),
     withDiscord: wantsDiscord,
     withSlack: wantsSlack,
     withTelegram: wantsTelegram,
@@ -520,8 +528,10 @@ export async function isHatched(dir: string): Promise<boolean> {
 }
 
 export type ScaffoldOptions = {
-  model?: KnownModelRef
-  visionModel?: KnownModelRef
+  model?: ModelRef | string
+  modelMeta?: CustomModelMeta
+  visionModel?: ModelRef | string
+  visionModelMeta?: CustomModelMeta
   withDiscord?: boolean
   withSlack?: boolean
   withTelegram?: boolean
@@ -545,12 +555,14 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   // `memory.*`) is omitted to keep the scaffold minimal — duplicating defaults
   // here would mean every schema change has to be mirrored in two places, and
   // users would feel obligated to maintain values they never set.
-  const models: Record<string, KnownModelRef> = { default: options.model ?? DEFAULT_MODEL_REF }
+  const models: Record<string, string> = { default: options.model ?? DEFAULT_MODEL_REF }
   if (options.visionModel !== undefined) models.vision = options.visionModel
   const config: Record<string, unknown> = {
     $schema: './node_modules/typeclaw/typeclaw.schema.json',
     models,
   }
+  const customModels = collectCustomModels(options)
+  if (Object.keys(customModels).length > 0) config.customModels = customModels
   const channels: Record<string, Record<string, never>> = {}
   if (options.withDiscord) channels['discord-bot'] = {}
   if (options.withSlack) channels['slack-bot'] = {}
@@ -576,6 +588,22 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   await Promise.all(MARKDOWN_FILES.map((file) => writeFile(join(root, file), '', { flag: 'wx' }).catch(ignoreExists)))
 
   await writeFile(join(root, GITIGNORE_FILE), buildGitignore(), { flag: 'wx' }).catch(ignoreExists)
+}
+
+function collectCustomModels(options: ScaffoldOptions): Record<string, CustomModelMeta> {
+  const customModels: Record<string, CustomModelMeta> = {}
+  addCustomModel(customModels, options.model ?? DEFAULT_MODEL_REF, options.modelMeta)
+  if (options.visionModel !== undefined) addCustomModel(customModels, options.visionModel, options.visionModelMeta)
+  return customModels
+}
+
+function addCustomModel(
+  customModels: Record<string, CustomModelMeta>,
+  ref: string,
+  meta: CustomModelMeta | undefined,
+): void {
+  if (isKnownModelRef(ref)) return
+  customModels[ref] = meta ?? {}
 }
 
 // agent-browser ships in every agent: the bundled SKILL.md (src/skills/
@@ -742,10 +770,10 @@ export async function writeSecrets(
     slackAppToken,
     telegramBotToken,
   }: {
-    model?: KnownModelRef
+    model?: ModelRef | string
     // Omitted on the OAuth path — credentials live in secrets.json via the OAuth runner.
     apiKey?: string
-    visionModel?: KnownModelRef
+    visionModel?: ModelRef | string
     visionApiKey?: string
     discordBotToken?: string
     slackBotToken?: string

--- a/src/init/models-dev.test.ts
+++ b/src/init/models-dev.test.ts
@@ -53,8 +53,8 @@ describe('fetchModelOptions', () => {
     expect(result.warning).toContain('502')
   })
 
-  test('merges live data with curated allowlist when fetch succeeds', async () => {
-    // given: a stub response with a richer name for one curated model.
+  test('merges live data with curated entries when fetch succeeds', async () => {
+    // given: a stub response with a richer name for one curated model and a new upstream model.
     const stub = {
       openai: {
         id: 'openai',
@@ -64,7 +64,19 @@ describe('fetchModelOptions', () => {
             id: 'gpt-5.4-nano',
             name: 'GPT-5.4 nano (live)',
             reasoning: true,
-            limit: { context: 400000 },
+            limit: { context: 400000, output: 128000 },
+          },
+          'gpt-6-live': {
+            id: 'gpt-6-live',
+            name: 'GPT-6 Live',
+            reasoning: true,
+            modalities: { input: ['text', 'image'], output: ['text'] },
+            limit: { context: 500000, output: 64000 },
+            cost: { input: 1, output: 2, cache_read: 0.1, cache_write: 0.2 },
+          },
+          invalid: {
+            id: '',
+            name: 'Invalid',
           },
         },
       },
@@ -85,6 +97,18 @@ describe('fetchModelOptions', () => {
     expect(result.source).toBe('models.dev')
     const nano = result.options.find((o) => o.ref === 'openai/gpt-5.4-nano')
     expect(nano?.modelName).toBe('GPT-5.4 nano (live)')
+    const live = result.options.find((o) => o.ref === 'openai/gpt-6-live')
+    expect(live).toMatchObject({
+      modelName: 'GPT-6 Live',
+      providerId: 'openai',
+      curated: false,
+      reasoning: true,
+      supportsVision: true,
+      contextWindow: 500000,
+      maxTokens: 64000,
+      cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },
+    })
+    expect(result.options.some((o) => o.modelName === 'Invalid')).toBe(false)
     // kimi-k2p6-turbo is curated-only; must still appear even though models.dev didn't list it.
     expect(result.options.some((o) => o.modelId === 'accounts/fireworks/routers/kimi-k2p6-turbo')).toBe(true)
   })

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -1,4 +1,13 @@
-import { KNOWN_PROVIDERS, type KnownModelRef, type KnownProviderId, listKnownModelRefs } from '@/config/providers'
+import type { CustomModelMeta } from '@/config'
+import {
+  KNOWN_PROVIDERS,
+  isKnownModelRef,
+  isModelRef,
+  listKnownModelRefs,
+  providerForModelRef,
+  type KnownProviderId,
+  type ModelRef,
+} from '@/config/providers'
 
 const MODELS_DEV_URL = 'https://models.dev/api.json'
 const REQUEST_TIMEOUT_MS = 10_000
@@ -32,13 +41,15 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
 }
 
 export type ModelOption = {
-  ref: KnownModelRef
+  ref: ModelRef | string
   providerId: KnownProviderId
   providerName: string
   modelId: string
   modelName: string
   reasoning: boolean
   contextWindow: number | null
+  maxTokens?: number | null
+  cost?: ModelOptionCost | null
   curated: boolean
   // True iff the model accepts image input. Sourced from the curated
   // `Model.input` array (which is the source of truth — pi-ai consumes it
@@ -49,6 +60,13 @@ export type ModelOption = {
   supportsVision: boolean
 }
 
+export type ModelOptionCost = {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+}
+
 type ModelsDevModel = {
   id?: string
   name?: string
@@ -57,7 +75,15 @@ type ModelsDevModel = {
   status?: string
   release_date?: string
   modalities?: { input?: string[]; output?: string[] }
-  limit?: { context?: number }
+  limit?: { context?: number; output?: number }
+  cost?: {
+    input?: number
+    output?: number
+    cacheRead?: number
+    cacheWrite?: number
+    cache_read?: number
+    cache_write?: number
+  }
 }
 
 type ModelsDevProvider = {
@@ -105,22 +131,47 @@ export function curatedOptions(): ModelOption[] {
   return refs.map((ref) => buildOption(ref, { curated: true }))
 }
 
-// `data` is the parsed models.dev JSON. We walk only the providers we care
-// about (openai, fireworks-ai) and only emit options for models that are
-// also in our curated allowlist — anything outside the allowlist would fail
-// schema validation when written to typeclaw.json. Curated entries that
-// models.dev doesn't list (e.g. kimi-k2p6-turbo) are still surfaced so the
-// user can pick them.
+export function customModelMetaFromOption(option: ModelOption): CustomModelMeta | undefined {
+  if (isKnownModelRef(option.ref)) return undefined
+  if (!isModelRef(option.ref)) return undefined
+  return {
+    name: option.modelName,
+    reasoning: option.reasoning,
+    input: option.supportsVision ? ['text', 'image'] : ['text'],
+    ...(option.contextWindow !== null ? { contextWindow: option.contextWindow } : {}),
+    ...(option.maxTokens !== undefined && option.maxTokens !== null ? { maxTokens: option.maxTokens } : {}),
+    ...(option.cost !== undefined && option.cost !== null ? { cost: option.cost } : {}),
+  }
+}
+
+// `data` is the parsed models.dev JSON. We keep every curated entry first
+// (including provider-specific aliases models.dev does not list), then append
+// live upstream models whose refs validate against a known TypeClaw provider.
 function mergeWithCurated(data: Record<string, ModelsDevProvider>): ModelOption[] {
   const out: ModelOption[] = []
+  const seen = new Set<string>()
   for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
     const known = KNOWN_PROVIDERS[providerId]
     const upstream = data[PROVIDER_TO_MODELS_DEV[providerId]]
     const upstreamModels = upstream?.models ?? {}
     for (const modelId of Object.keys(known.models)) {
       const upstreamModel = upstreamModels[modelId]
-      const ref = `${providerId}/${modelId}` as KnownModelRef
+      const ref = `${providerId}/${modelId}`
       out.push(buildOption(ref, { curated: true, upstream: upstreamModel }))
+      seen.add(ref)
+    }
+  }
+
+  for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
+    const upstream = data[PROVIDER_TO_MODELS_DEV[providerId]]
+    const upstreamModels = upstream?.models ?? {}
+    for (const [fallbackModelId, upstreamModel] of Object.entries(upstreamModels)) {
+      const modelId = upstreamModel.id ?? fallbackModelId
+      if (modelId.trim().length === 0) continue
+      const ref = `${providerId}/${modelId}`
+      if (seen.has(ref) || !isModelRef(ref)) continue
+      out.push(buildOption(ref, { curated: isKnownModelRef(ref), upstream: upstreamModel }))
+      seen.add(ref)
     }
   }
   return out
@@ -131,17 +182,23 @@ type BuildOptionOpts = {
   upstream?: ModelsDevModel
 }
 
-function buildOption(ref: KnownModelRef, opts: BuildOptionOpts): ModelOption {
-  const slash = ref.indexOf('/')
-  const providerId = ref.slice(0, slash) as KnownProviderId
-  const modelId = ref.slice(slash + 1)
+function buildOption(ref: ModelRef | string, opts: BuildOptionOpts): ModelOption {
+  const providerId = providerForModelRef(ref)
+  const modelId = ref.slice(providerId.length + 1)
   const provider = KNOWN_PROVIDERS[providerId]
   const curatedModel = (
     provider.models as Record<
       string,
-      { name: string; contextWindow?: number; reasoning?: boolean; input?: ReadonlyArray<string> }
+      {
+        name: string
+        contextWindow?: number
+        maxTokens?: number
+        reasoning?: boolean
+        input?: ReadonlyArray<string>
+      }
     >
   )[modelId]
+  const input = resolveInput(curatedModel?.input, opts.upstream?.modalities?.input)
   return {
     ref,
     providerId,
@@ -150,16 +207,28 @@ function buildOption(ref: KnownModelRef, opts: BuildOptionOpts): ModelOption {
     modelName: opts.upstream?.name ?? curatedModel?.name ?? modelId,
     reasoning: opts.upstream?.reasoning ?? curatedModel?.reasoning ?? false,
     contextWindow: opts.upstream?.limit?.context ?? curatedModel?.contextWindow ?? null,
+    maxTokens: opts.upstream?.limit?.output ?? curatedModel?.maxTokens ?? null,
+    cost: resolveCost(opts.upstream?.cost),
     curated: opts.curated,
-    supportsVision: resolveSupportsVision(curatedModel?.input, opts.upstream?.modalities?.input),
+    supportsVision: input.includes('image'),
   }
 }
 
-function resolveSupportsVision(
+function resolveInput(
   curatedInput: ReadonlyArray<string> | undefined,
   upstreamInput: ReadonlyArray<string> | undefined,
-): boolean {
-  if (curatedInput !== undefined) return curatedInput.includes('image')
-  if (upstreamInput !== undefined) return upstreamInput.includes('image')
-  return false
+): string[] {
+  if (curatedInput !== undefined) return [...curatedInput]
+  if (upstreamInput !== undefined && upstreamInput.length > 0) return [...upstreamInput]
+  return ['text']
+}
+
+function resolveCost(cost: ModelsDevModel['cost']): ModelOptionCost | null {
+  if (cost === undefined) return null
+  return {
+    input: cost.input ?? 0,
+    output: cost.output ?? 0,
+    cacheRead: cost.cacheRead ?? cost.cache_read ?? 0,
+    cacheWrite: cost.cacheWrite ?? cost.cache_write ?? 0,
+  }
 }

--- a/src/init/oauth-login.ts
+++ b/src/init/oauth-login.ts
@@ -4,14 +4,14 @@ import {
   KNOWN_PROVIDERS,
   providerForModelRef,
   supportsOAuth,
-  type KnownModelRef,
   type KnownProviderId,
+  type ModelRef,
 } from '@/config/providers'
 import { createSecretsStoreForAgent } from '@/secrets'
 
 export type OAuthLoginResult = { ok: true } | { ok: false; reason: string }
 
-export type OAuthLoginRunner = (options: { cwd: string; model: KnownModelRef }) => Promise<OAuthLoginResult>
+export type OAuthLoginRunner = (options: { cwd: string; model: ModelRef | string }) => Promise<OAuthLoginResult>
 
 // Wrap pi-ai's OAuth callbacks so the CLI doesn't have to know about the
 // upstream callback shape. The CLI sees four lifecycle events:
@@ -76,7 +76,7 @@ export function makeOAuthLoginRunner(callbacks: OAuthCallbacks): OAuthLoginRunne
 // params" without spinning up a real secrets store / browser callback server.
 export type FakeOAuthLoginRunnerOptions = {
   result?: OAuthLoginResult
-  onCalled?: (options: { cwd: string; model: KnownModelRef; providerId: KnownProviderId }) => void
+  onCalled?: (options: { cwd: string; model: ModelRef | string; providerId: KnownProviderId }) => void
 }
 
 export function makeFakeOAuthLoginRunner(options: FakeOAuthLoginRunnerOptions = {}): OAuthLoginRunner {


### PR DESCRIPTION
## Background

Model selection has been gated by a hardcoded allowlist. `KNOWN_PROVIDERS` (`src/config/providers.ts`) is the single source of truth, and its refs back a Zod enum (`z.enum(knownModelRefs)` in `src/config/config.ts`). Any `<provider>/<model>` ref outside that table fails schema validation the moment it is written to `typeclaw.json` — at `model set`/`add`, at init scaffolding, and at every config load. The init wizard and `model list --available` only ever surfaced curated models too, even though `src/init/models-dev.ts` already fetched the full models.dev catalog and then discarded everything not in the allowlist.

Net effect: a user could not pick a model a provider had just released (or any model we hadn't yet hand-added) without editing the source and cutting a release. This PR makes discovery dynamic and lets users actually select and run non-curated models.

## Summary

- **Two-tier ref types.** Keep `KnownModelRef` (the curated template-literal union) for curated-only APIs and editor autocomplete; add a broad `ModelRef` brand plus `isModelRef` (validates `<known-provider>/<model-id>` shape — the provider must still be one we know, so we have a `baseUrl`/`api`/auth surface).
- **Loosened gate, preserved autocomplete.** The config schema becomes a union of the curated enum **and** a validated custom-ref branch. Why a union and not a bare `z.string().refine`: the enum branch keeps the curated refs in the generated JSON Schema, so editors still autocomplete them.
- **Synchronous runtime synthesis.** `resolveModel` stays sync (it runs at session creation, no fetch). For a custom ref it synthesizes a pi-ai `Model<>`: inherits `api`/`baseUrl` from the provider's first curated model (the wire transport is per-provider, not per-model), and fills name/reasoning/input/context/maxTokens from a new reloadable `customModels` config map, written at selection time when the async catalog is in hand.
- **Cost is explicit zero when unknown** — never a guessed or copied price.
- **Discovery for all probed providers** via models.dev, surfaced in the wizard and `model list --available`, offline-safe via the existing curated fallback.
- **Both selection paths persist metadata.** Interactive picking and the explicit `model set/add <profile> <ref>` flow both write `customModels[ref]` from the catalog; the non-interactive path warns when a ref isn't in the catalog so the fallback-default synthesis is never silent.

Split into reviewable commits: the `ModelRef`/`isModelRef` primitive; the config gate + `customModels` + `resolveModel` (with the mechanical `ModelRef` type ripple to runtime call sites); the models.dev broadening; the persistence layer; the CLI/init wiring; and the review follow-up for the explicit-ref metadata path.

## Usage — per provider

`typeclaw model list --available` now lists the live models.dev catalog for every provider in `KNOWN_PROVIDERS`, not just the curated allowlist. The listing below shows the curated refs that ship today; when models.dev is reachable, any newer model each provider has published is appended under the same provider heading and is selectable with `typeclaw model set <profile> <ref>`:

```text
$ typeclaw model list --available
Use `typeclaw model set <profile> <ref>` to apply.

OpenAI
  openai/gpt-5.4-nano
  openai/gpt-5.4-mini
  openai/gpt-5.4
  openai/gpt-5.5

OpenAI Codex (ChatGPT Plus/Pro)
  openai-codex/gpt-5.4-mini
  openai-codex/gpt-5.4
  openai-codex/gpt-5.5

Anthropic
  anthropic/claude-haiku-4-5
  anthropic/claude-sonnet-4-6
  anthropic/claude-opus-4-7
  anthropic/claude-opus-4-8

Fireworks
  fireworks/accounts/fireworks/routers/kimi-k2p6-turbo

Z.AI
  zai/glm-4.5-air
  zai/glm-4.6
  zai/glm-4.7

Z.AI (GLM Coding Plan)
  zai-coding/glm-4.5-air
  zai-coding/glm-4.7
  zai-coding/glm-5
  zai-coding/glm-5-turbo
  zai-coding/glm-5.1

xAI (Grok)
  xai/grok-4.3
  xai/grok-4.20-0309-reasoning
  xai/grok-4.20-0309-non-reasoning
  xai/grok-build-0.1

MiniMax
  minimax/MiniMax-M3
  minimax/MiniMax-M2.7
  minimax/MiniMax-M2.5
  minimax/MiniMax-M2.1
  minimax/MiniMax-M2

DeepSeek
  deepseek/deepseek-v4-flash
  deepseek/deepseek-v4-pro

Moonshot (Kimi)
  moonshot/kimi-k2.7-code
  moonshot/kimi-k2.6
  moonshot/kimi-k2.5

Moonshot (Kimi Coding Plan)
  moonshot-coding/kimi-for-coding
```

Before this PR a user could only pick a ref from that curated set; now they can also pick any newer `<provider>/<model-id>` models.dev surfaces for a known provider (e.g. a fresh OpenAI or Anthropic release that hasn't been hand-added to `KNOWN_PROVIDERS` yet) without a source edit.

Offline (or when models.dev is unreachable) the command falls back to exactly the curated list above and prints a `Using built-in catalog (models.dev unavailable: …)` note. Each provider's env var: `OPENAI_API_KEY`, OAuth for `openai-codex`, `ANTHROPIC_API_KEY` (or OAuth), `FIREWORKS_API_KEY`, `ZAI_API_KEY`, `ZAI_CODING_API_KEY`, `XAI_API_KEY` (or OAuth), `MINIMAX_API_KEY`, `DEEPSEEK_API_KEY`, `MOONSHOT_API_KEY`, `MOONSHOT_CODING_API_KEY`.

Picking a non-curated ref records its catalog metadata into `typeclaw.json#customModels`; curated refs need no entry. Fallback chains mix curated and custom freely, e.g. `"default": ["anthropic/claude-opus-4-8", "anthropic/claude-sonnet-4-6"]`.

## What this does NOT do

- **Does not validate upstream availability.** A ref is checked for shape and a known provider only — never "does this provider actually serve this model". If it doesn't, the turn fails at runtime; fallback chains remain the safety net.
- **Does not add new providers.** The provider must already exist in `KNOWN_PROVIDERS` (so auth/baseUrl/api are known). Only the *model* is dynamic.
- **Does not infer pricing.** Unknown cost is zero, not estimated, so usage reporting under-reports rather than lies.
- **Does not reorder `KNOWN_PROVIDERS`** (order is load-bearing for the schema enum and `provider --help`).

## Review notes

- Load-bearing: `resolveModel` synthesis (`src/config/config.ts`) and `isModelRef` (`src/config/providers.ts`). Verify the synthesized `Model<>` carries every field pi-ai needs (id, name, api, provider, baseUrl, reasoning, input, cost, contextWindow, maxTokens).
- The explicit `model set/add <ref>` path routes through `resolveExplicitRef` (`src/cli/model.ts`): curated refs resolve from `KNOWN_PROVIDERS`; non-curated refs are looked up in the live catalog so `customModels[ref]` matches the interactive picker; a catalog miss still writes the ref but warns about the fallback. Covered by new unit tests in `src/cli/model.test.ts`.
- `customModels` is classified `applied` (reloadable) in `FIELD_EFFECTS` — the guard test in `src/config/reloadable.test.ts` enforces a classification exists.
- The `isModelRef` regex intentionally allows `/` in the model-id segment so Fireworks paths (`fireworks/accounts/fireworks/models/...`) validate; only the provider segment is constrained.
- `typeclaw.schema.json` regenerates with no further diff (already current on the branch). `bun run typecheck` / `lint` (0 new warnings) / `format` / `test` (9026 pass, 0 fail) all green.
