### PR TITLE
fix(github-cli-auth): surface missing GitHub auth to the agent instead of opaque failures

### DIFF
--- a/src/bundled-plugins/github-cli-auth/channel-misconfig.test.ts
+++ b/src/bundled-plugins/github-cli-auth/channel-misconfig.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  detectGithubChannelAuthState,
+  getGithubChannelAuthState,
+  resetGithubChannelAuthStateCacheForTests,
+} from './channel-misconfig'
+
+function agentDirWith(files: { typeclawJson?: string; secretsJson?: string }): string {
+  const dir = mkdtempSync(join(tmpdir(), 'typeclaw-misconfig-unit-'))
+  if (files.typeclawJson !== undefined) writeFileSync(join(dir, 'typeclaw.json'), files.typeclawJson)
+  if (files.secretsJson !== undefined) writeFileSync(join(dir, 'secrets.json'), files.secretsJson)
+  return dir
+}
+
+const githubChannel = JSON.stringify({ channels: { github: { repos: ['o/r'] } } })
+
+afterEach(() => resetGithubChannelAuthStateCacheForTests())
+
+describe('detectGithubChannelAuthState', () => {
+  it('returns not-configured when typeclaw.json is absent', () => {
+    expect(detectGithubChannelAuthState(agentDirWith({}))).toBe('not-configured')
+  })
+
+  it('returns not-configured when channels.github is absent', () => {
+    const dir = agentDirWith({ typeclawJson: JSON.stringify({ channels: { slack: {} } }) })
+    expect(detectGithubChannelAuthState(dir)).toBe('not-configured')
+  })
+
+  it('returns configured-without-credentials when channel exists but no secrets.json', () => {
+    expect(detectGithubChannelAuthState(agentDirWith({ typeclawJson: githubChannel }))).toBe(
+      'configured-without-credentials',
+    )
+  })
+
+  it('returns configured-without-credentials when secrets.json has no github auth', () => {
+    const dir = agentDirWith({ typeclawJson: githubChannel, secretsJson: JSON.stringify({ version: 2, channels: {} }) })
+    expect(detectGithubChannelAuthState(dir)).toBe('configured-without-credentials')
+  })
+
+  it('returns configured-with-credentials for a valid PAT auth block', () => {
+    const dir = agentDirWith({
+      typeclawJson: githubChannel,
+      secretsJson: JSON.stringify({
+        version: 2,
+        channels: { github: { auth: { type: 'pat', token: 'ghp_x' }, webhookSecret: 'whsec_x' } },
+      }),
+    })
+    expect(detectGithubChannelAuthState(dir)).toBe('configured-with-credentials')
+  })
+
+  it('returns configured-with-credentials for a valid App auth block', () => {
+    const dir = agentDirWith({
+      typeclawJson: githubChannel,
+      secretsJson: JSON.stringify({
+        version: 2,
+        channels: { github: { auth: { type: 'app', appId: 1, privateKey: 'x' }, webhookSecret: 'whsec_x' } },
+      }),
+    })
+    expect(detectGithubChannelAuthState(dir)).toBe('configured-with-credentials')
+  })
+
+  it('returns indeterminate when the github block is present but schema-invalid (missing webhookSecret)', () => {
+    const dir = agentDirWith({
+      typeclawJson: githubChannel,
+      secretsJson: JSON.stringify({ version: 2, channels: { github: { auth: { type: 'pat', token: 'ghp_x' } } } }),
+    })
+    expect(detectGithubChannelAuthState(dir)).toBe('indeterminate')
+  })
+
+  it('returns indeterminate when secrets.json is malformed', () => {
+    const dir = agentDirWith({ typeclawJson: githubChannel, secretsJson: '{ broken' })
+    expect(detectGithubChannelAuthState(dir)).toBe('indeterminate')
+  })
+
+  it('returns not-configured when typeclaw.json is malformed (cannot confirm a github channel)', () => {
+    expect(detectGithubChannelAuthState(agentDirWith({ typeclawJson: '{ broken' }))).toBe('not-configured')
+  })
+})
+
+describe('getGithubChannelAuthState (memoized)', () => {
+  it('caches the first computed state per agentDir', () => {
+    const dir = agentDirWith({ typeclawJson: githubChannel })
+    expect(getGithubChannelAuthState(dir)).toBe('configured-without-credentials')
+    // Adding creds after the first read must NOT change the memoized answer.
+    writeFileSync(
+      join(dir, 'secrets.json'),
+      JSON.stringify({ version: 2, channels: { github: { auth: { type: 'pat', token: 'ghp_x' } } } }),
+    )
+    expect(getGithubChannelAuthState(dir)).toBe('configured-without-credentials')
+  })
+})

--- a/src/bundled-plugins/github-cli-auth/channel-misconfig.ts
+++ b/src/bundled-plugins/github-cli-auth/channel-misconfig.ts
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { SecretsBackend } from '@/secrets/storage'
+
+// Why this exists: when a repo-targeting git/gh command runs with no TypeClaw-
+// managed credential, the *generic* outcome is "warn and pass through" — the
+// agent may have its own ambient auth (credential helper, ~/.netrc, `gh auth
+// login`, SSH). But there is one HIGH-CONFIDENCE misconfiguration we can name
+// exactly: typeclaw.json declares a `channels.github` block (so the operator
+// clearly intends TypeClaw-managed GitHub) yet `secrets.json#channels.github`
+// carries no usable auth — so the channel adapter was skipped at boot and no
+// token resolver is live. A github.com HTTPS write WILL fail. Detecting this
+// lets the hook block such a write with the precise root cause instead of
+// letting it fail opaquely. Presence/absence only — never reads token values.
+
+export type GithubChannelAuthState =
+  | 'configured-without-credentials'
+  | 'configured-with-credentials'
+  | 'not-configured'
+  // secrets.json exists but could not be parsed: we cannot confirm credentials,
+  // so we must not claim they are absent (avoids a false misconfig block).
+  | 'indeterminate'
+
+// A live secrets block only counts as credentials when its auth.type is one the
+// channel manager accepts (pat | app) — the same gate manager.ts uses to decide
+// whether to start the adapter. Anything else means no usable auth.
+function hasUsableGithubAuth(githubSecrets: unknown): boolean {
+  if (typeof githubSecrets !== 'object' || githubSecrets === null || Array.isArray(githubSecrets)) return false
+  const auth = (githubSecrets as Record<string, unknown>).auth
+  if (typeof auth !== 'object' || auth === null || Array.isArray(auth)) return false
+  const authType = (auth as Record<string, unknown>).type
+  return authType === 'pat' || authType === 'app'
+}
+
+function typeclawJsonHasGithubChannel(agentDir: string): boolean {
+  const path = join(agentDir, 'typeclaw.json')
+  if (!existsSync(path)) return false
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as { channels?: Record<string, unknown> }
+    const channels = parsed.channels
+    if (typeof channels !== 'object' || channels === null) return false
+    return Object.hasOwn(channels, 'github')
+  } catch {
+    return false
+  }
+}
+
+export function detectGithubChannelAuthState(agentDir: string): GithubChannelAuthState {
+  if (!typeclawJsonHasGithubChannel(agentDir)) return 'not-configured'
+
+  const secretsPath = join(agentDir, 'secrets.json')
+  if (!existsSync(secretsPath)) return 'configured-without-credentials'
+  try {
+    const githubSecrets = new SecretsBackend(secretsPath).tryReadChannelsSync()?.github
+    return hasUsableGithubAuth(githubSecrets) ? 'configured-with-credentials' : 'configured-without-credentials'
+  } catch {
+    return 'indeterminate'
+  }
+}
+
+// Per-agentDir memo: the on-disk config/secrets do not change within a session
+// without a restart (channels/secrets edits are restart-required for the boot
+// adapter decision), so one read per agentDir is enough and keeps this off the
+// hot path of every git/gh command.
+const cache = new Map<string, GithubChannelAuthState>()
+
+export function getGithubChannelAuthState(agentDir: string): GithubChannelAuthState {
+  const cached = cache.get(agentDir)
+  if (cached !== undefined) return cached
+  const state = detectGithubChannelAuthState(agentDir)
+  cache.set(agentDir, state)
+  return state
+}
+
+export function resetGithubChannelAuthStateCacheForTests(): void {
+  cache.clear()
+}

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -3,8 +3,32 @@ import { describe, expect, it } from 'bun:test'
 import {
   analyzeGhCommand,
   effectiveGhTokensForAuthenticatedUserEndpoint,
+  isGhCredentialRequiringWrite,
   usesGhApiAuthenticatedUserEndpoint,
 } from './gh-command'
+
+describe('isGhCredentialRequiringWrite', () => {
+  it('true for gh pr create (with or without flags)', () => {
+    expect(isGhCredentialRequiringWrite('gh pr create')).toBe(true)
+    expect(isGhCredentialRequiringWrite('gh pr create -R o/r --title x --body y')).toBe(true)
+  })
+
+  it('false for read-only and other gh subcommands', () => {
+    expect(isGhCredentialRequiringWrite('gh pr view -R o/r')).toBe(false)
+    expect(isGhCredentialRequiringWrite('gh pr list')).toBe(false)
+    expect(isGhCredentialRequiringWrite('gh auth status')).toBe(false)
+    expect(isGhCredentialRequiringWrite('gh api /repos/o/r')).toBe(false)
+  })
+
+  it('false for gh pr create --help / -h (no credential needed)', () => {
+    expect(isGhCredentialRequiringWrite('gh pr create --help')).toBe(false)
+    expect(isGhCredentialRequiringWrite('gh pr create -h')).toBe(false)
+  })
+
+  it('false for a non-gh command', () => {
+    expect(isGhCredentialRequiringWrite('git push origin main')).toBe(false)
+  })
+})
 
 describe('analyzeGhCommand', () => {
   it('passes through commands that do not invoke gh', () => {

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -159,6 +159,27 @@ export function analyzeGhCommand(command: string): GhCommandDecision {
   return { kind: 'block', reason: COMPOSITION_REASON }
 }
 
+// True for a `gh pr create` invocation — the canonical credential-requiring
+// write the misconfig block targets. Scans every gh invocation (an `&&` chain
+// could carry it) for the `pr` subcommand followed by `create`, skipping flags
+// and their values so `gh pr create --title x` still matches. Read-only `gh`
+// (pr view/list, auth status) returns false and is never blocked.
+export function isGhCredentialRequiringWrite(command: string): boolean {
+  const tokens = tokenize(command)
+  const ghStarts = findGhInvocations(tokens)
+  for (let i = 0; i < ghStarts.length; i++) {
+    const start = ghStarts[i] as number
+    const end = ghStarts[i + 1] ?? tokens.length
+    const args = tokens.slice(start + 1, end)
+    // `gh pr create --help`/`-h` only prints docs and needs no credential, so it
+    // must not trigger the misconfig block.
+    if (args.includes('--help') || args.includes('-h')) continue
+    const positionals = args.filter((t) => !t.startsWith('-'))
+    if (positionals[0] === 'pr' && positionals[1] === 'create') return true
+  }
+  return false
+}
+
 // stdin-only readers whose only sink is stdout (back to the agent, who already
 // has gh's output) — they cannot open their own network/file/process sink, so a
 // `gh <repo> | <reader>` pipeline cannot exfiltrate the minted token to a third

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -1,8 +1,35 @@
 import { describe, expect, test } from 'bun:test'
 
-import { analyzeGitCommand, type GitResolvers, parseGithubRepoFromGitUrl } from './git-command'
+import { analyzeGitCommand, type GitResolvers, isGitPushCommand, parseGithubRepoFromGitUrl } from './git-command'
 
 const CWD = '/agent'
+
+describe('isGitPushCommand', () => {
+  test('true for a bare git push', () => {
+    expect(isGitPushCommand('git push origin main')).toBe(true)
+    expect(isGitPushCommand('git push https://github.com/o/r.git main')).toBe(true)
+  })
+
+  test('true for a push inside a cd-prefix or && chain', () => {
+    expect(isGitPushCommand('cd /repo && git push origin main')).toBe(true)
+    expect(isGitPushCommand('git status && git push origin main')).toBe(true)
+  })
+
+  test('false for non-push git subcommands', () => {
+    expect(isGitPushCommand('git clone https://github.com/o/r.git')).toBe(false)
+    expect(isGitPushCommand('git fetch origin')).toBe(false)
+    expect(isGitPushCommand('git status')).toBe(false)
+  })
+
+  test('false for help invocations (no credential needed)', () => {
+    expect(isGitPushCommand('git push --help')).toBe(false)
+    expect(isGitPushCommand('git push -h')).toBe(false)
+  })
+
+  test('false for a non-git command', () => {
+    expect(isGitPushCommand('ls -la')).toBe(false)
+  })
+})
 
 function resolvers(overrides: Partial<GitResolvers> = {}): GitResolvers {
   return {

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -161,6 +161,34 @@ export async function analyzeGitCommand(
   return { kind: 'inject', repoSlug: representativeSlug }
 }
 
+// True when any `git` invocation in the command is a `push` — the credential-
+// requiring write the misconfig block targets. analyzeGitCommand has already
+// confirmed the command resolves to a github.com repo, so this only narrows the
+// remote subcommand to push (clone/fetch/pull/ls-remote return false). Reuses
+// the same cd-prefix-strip and `&&`-chain split so `cd x && git push` and
+// `git status && git push origin main` both match.
+export function isGitPushCommand(command: string): boolean {
+  const stripped = stripSafeCdPrefix(command)
+  if (stripped.unsafe) return commandHasGitPush(command)
+  const rest = stripped.cdDir !== null ? stripped.rest : command
+  return commandHasGitPush(rest)
+}
+
+function commandHasGitPush(command: string): boolean {
+  const chain = extractGitInvocationChain(command)
+  if (chain !== null) return chain.some((seg) => isPushInvocation(seg.args))
+  const single = extractSingleGitInvocation(command)
+  return single !== null && isPushInvocation(single.args)
+}
+
+// A `push` that actually contacts the remote — NOT `git push --help`/`-h`, which
+// only prints docs and needs no credential, so it must not trigger the misconfig
+// block. `git --help push` also resolves its subcommand to a help page.
+function isPushInvocation(args: readonly string[]): boolean {
+  if (findSubcommand(args) !== 'push') return false
+  return !args.includes('--help') && !args.includes('-h')
+}
+
 // The single-git `cd <path> && git …` shortcut. Kept separate (and single-git
 // only) so the cwd rewrite stays simple: the token-bearing command becomes one
 // bare `git -C <path> …`, with no sibling inheriting the env. A `cd` in a

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -126,20 +126,56 @@ describe('github-cli-auth plugin', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
   })
 
-  test('no App auth (GH_TOKEN unseeded, no minter): passes through without minting', async () => {
+  test('no managed auth (GH_TOKEN unseeded, no minter): repo-targeting gh passes through and warns once', async () => {
     delete process.env.GH_TOKEN
     let resolverCalled = false
-    const hook = await hookFor(async () => {
-      resolverCalled = true
-      return { kind: 'token', token: 'ghs_minted' }
-    }, false)
-    const event = bashEvent('gh pr view -R acme/widgets')
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      false,
+      { logger },
+    )
 
-    const result = await hook(event, { agentDir: '/agent', pluginName: 'github-cli-auth', logger: noopLogger })
+    const first = await hook(bashEvent('gh pr view -R acme/widgets'), hookCtx)
+    const second = await hook(bashEvent('gh pr view -R acme/other'), hookCtx)
+
+    // The command must still run (we cannot see the user's own ambient auth), but
+    // the formerly-silent pass-through now emits one diagnostic warning.
+    expect(first).toBeUndefined()
+    expect(second).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toContain('TypeClaw-managed GitHub credentials')
+  })
+
+  test('no managed auth: a repo-less gh command passes through silently (no warning)', async () => {
+    delete process.env.GH_TOKEN
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(tokenResolver('ghs_minted'), false, { logger })
+    const event = bashEvent('gh auth status')
+
+    const result = await hook(event, hookCtx)
 
     expect(result).toBeUndefined()
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(resolverCalled).toBe(false)
+    expect(warnings.length).toBe(0)
   })
 
   test('classic PAT (unsandboxed): injects the PAT for a repo-targeting gh, does not mint', async () => {
@@ -521,20 +557,76 @@ describe('github-cli-auth plugin — git path', () => {
     expect(overlay.GIT_ASKPASS).toBeDefined()
   })
 
-  test('no App auth (GH_TOKEN unseeded, no minter): git push passes through without minting', async () => {
+  test('no managed auth (GH_TOKEN unseeded, no minter): repo-targeting git push passes through and warns once', async () => {
     delete process.env.GH_TOKEN
     let resolverCalled = false
-    const hook = await hookFor(async () => {
-      resolverCalled = true
-      return { kind: 'token', token: 'ghs_minted' }
-    }, false)
-    const event = bashEvent('git push https://github.com/acme/widgets.git main')
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      false,
+      { logger },
+    )
+
+    const firstEvent = bashEvent('git push https://github.com/acme/widgets.git main')
+    const first = await hook(firstEvent, hookCtx)
+    const second = await hook(bashEvent('git push https://github.com/acme/other.git main'), hookCtx)
+
+    expect(first).toBeUndefined()
+    expect(second).toBeUndefined()
+    expect(firstEvent.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toContain('TypeClaw-managed GitHub credentials')
+  })
+
+  test('no managed auth: a non-remote git command passes through silently (no warning)', async () => {
+    delete process.env.GH_TOKEN
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(tokenResolver('ghs_minted'), false, { logger })
+    const event = bashEvent('git status')
 
     const result = await hook(event, hookCtx)
 
     expect(result).toBeUndefined()
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(resolverCalled).toBe(false)
+    expect(warnings.length).toBe(0)
+  })
+
+  test('no managed auth: a non-github git push passes through silently (no warning)', async () => {
+    delete process.env.GH_TOKEN
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(tokenResolver('ghs_minted'), false, { logger })
+    const event = bashEvent('git push https://gitlab.com/acme/widgets.git main')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(warnings.length).toBe(0)
   })
 
   test('App auth: blocks when the bridge is unavailable', async () => {

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -234,6 +234,49 @@ describe('github-cli-auth plugin', () => {
     expect(resolverCalled).toBe(false)
   })
 
+  test('GITHUB_TOKEN-only PAT (unsandboxed): repo-targeting gh injects it as GH_TOKEN, no warning, no mint', async () => {
+    delete process.env.GH_TOKEN
+    process.env.GITHUB_TOKEN = 'ghp_via_github_token'
+    let resolverCalled = false
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      false,
+      { permissions: unsandboxedPermissions, logger },
+    )
+    const event = bashEvent('gh pr view -R acme/widgets')
+
+    const result = await hook(event, hookCtx)
+
+    // gh natively honors GITHUB_TOKEN, so this IS auth — the warning must not fire.
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghp_via_github_token' })
+    expect(resolverCalled).toBe(false)
+    expect(warnings.length).toBe(0)
+  })
+
+  test('GH_TOKEN beats GITHUB_TOKEN (unsandboxed): gh overlay uses GH_TOKEN', async () => {
+    process.env.GH_TOKEN = 'ghp_primary'
+    process.env.GITHUB_TOKEN = 'ghp_secondary'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: unsandboxedPermissions })
+    const event = bashEvent('gh pr view -R acme/widgets')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghp_primary' })
+  })
+
   test('App auth: strips a redundant -R on a literal-path gh api call AND injects the minted token', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const hook = await hookFor(tokenResolver('ghs_minted'))
@@ -627,6 +670,80 @@ describe('github-cli-auth plugin — git path', () => {
     expect(result).toBeUndefined()
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
     expect(warnings.length).toBe(0)
+  })
+
+  test('GITHUB_TOKEN-only PAT (unsandboxed): repo-targeting git injects it via askpass, no warning, no mint', async () => {
+    delete process.env.GH_TOKEN
+    process.env.GITHUB_TOKEN = 'ghp_via_github_token'
+    let resolverCalled = false
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (m: string): void => {
+        warnings.push(m)
+      },
+      error: () => {},
+    }
+    const hook = await hookFor(
+      async () => {
+        resolverCalled = true
+        return { kind: 'token', token: 'ghs_minted' }
+      },
+      false,
+      { permissions: unsandboxedPermissions, logger },
+    )
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    // git has no native GITHUB_TOKEN support, but the askpass path supplies it,
+    // so this is real auth — no false warning, and the token rides askpass.
+    expect(result).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('ghp_via_github_token')
+    expect(overlay.GIT_ASKPASS).toBeDefined()
+    expect(resolverCalled).toBe(false)
+    expect(warnings.length).toBe(0)
+  })
+
+  test('GH_TOKEN beats GITHUB_TOKEN (unsandboxed): git askpass uses GH_TOKEN', async () => {
+    process.env.GH_TOKEN = 'ghp_primary'
+    process.env.GITHUB_TOKEN = 'ghp_secondary'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: unsandboxedPermissions })
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('ghp_primary')
+  })
+
+  test('GITHUB_TOKEN-only PAT (sandboxed) + App minter: mints an App token instead of the withheld PAT', async () => {
+    delete process.env.GH_TOKEN
+    process.env.GITHUB_TOKEN = 'ghp_via_github_token'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true)
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    const overlay = event.args[TYPECLAW_INTERNAL_BASH_ENV] as Record<string, string>
+    expect(overlay.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(overlay.GIT_ASKPASS).toBeDefined()
+  })
+
+  test('GITHUB_TOKEN-only PAT (sandboxed) + no App minter: blocks git with the withheld-PAT guidance', async () => {
+    delete process.env.GH_TOKEN
+    process.env.GITHUB_TOKEN = 'ghp_via_github_token'
+    const hook = await hookFor(tokenResolver('ghs_minted'), false)
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    expect((result as { reason: string }).reason).toContain('sandboxed')
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
   test('App auth: blocks when the bridge is unavailable', async () => {

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,6 +8,7 @@ import type { GithubTokenResolveResult } from '@/channels/github-token-bridge'
 import { noopPermissionService, type PermissionService } from '@/permissions'
 import type { PluginContext, PluginLogger, ToolBeforeEvent } from '@/plugin'
 
+import { resetGithubChannelAuthStateCacheForTests } from './channel-misconfig'
 import { resetGitAskPassHelperForTests } from './git-askpass'
 import githubCliAuthPlugin from './index'
 
@@ -31,7 +32,7 @@ afterEach(() => {
   else process.env.GITHUB_TOKEN = originalGithubToken
 })
 
-type HookOpts = { permissions?: PermissionService; logger?: PluginLogger }
+type HookOpts = { permissions?: PermissionService; logger?: PluginLogger; agentDir?: string }
 
 function pluginContext(
   resolve: (repoSlug: string) => Promise<GithubTokenResolveResult>,
@@ -41,7 +42,7 @@ function pluginContext(
   return {
     name: 'github-cli-auth',
     version: undefined,
-    agentDir: '/agent',
+    agentDir: opts.agentDir ?? '/agent',
     config: undefined,
     logger: opts.logger ?? noopLogger,
     permissions: opts.permissions ?? noopPermissionService,
@@ -877,5 +878,141 @@ describe('github-cli-auth plugin — git path', () => {
 
     expect(result).toBeUndefined()
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+  })
+})
+
+describe('github-cli-auth plugin — channels.github configured but no credentials', () => {
+  // A real agentDir on disk: the misconfig detector reads typeclaw.json +
+  // secrets.json from ctx.agentDir. No env token and no minter so the
+  // no-managed-auth branch is reached; the agentDir state then decides block vs
+  // warn. Cache is reset each test so the per-agentDir memo doesn't leak.
+  function makeAgentDir(files: { typeclawJson?: string; secretsJson?: string }): string {
+    const dir = mkdtempSync(join(tmpdir(), 'typeclaw-misconfig-'))
+    if (files.typeclawJson !== undefined) writeFileSync(join(dir, 'typeclaw.json'), files.typeclawJson)
+    if (files.secretsJson !== undefined) writeFileSync(join(dir, 'secrets.json'), files.secretsJson)
+    return dir
+  }
+
+  const githubChannelConfig = JSON.stringify({ channels: { github: { repos: ['acme/widgets'], webhookPort: 8975 } } })
+
+  afterEach(() => {
+    delete process.env.GH_TOKEN
+    delete process.env.GITHUB_TOKEN
+    resetGithubChannelAuthStateCacheForTests()
+  })
+
+  async function noAuthHookFor(agentDir: string) {
+    return hookFor(tokenResolver('ghs_minted'), false, { agentDir })
+  }
+
+  const ctxFor = (agentDir: string) => ({ agentDir, pluginName: 'github-cli-auth', logger: noopLogger })
+
+  test('git push (configured-without-credentials): blocks with the precise misconfig reason', async () => {
+    delete process.env.GH_TOKEN
+    const agentDir = makeAgentDir({ typeclawJson: githubChannelConfig })
+    const hook = await noAuthHookFor(agentDir)
+
+    const result = await hook(bashEvent('git push https://github.com/acme/widgets.git main'), ctxFor(agentDir))
+
+    expect(result).toMatchObject({ block: true })
+    const reason = (result as { reason: string }).reason
+    expect(reason).toContain('channels.github')
+    expect(reason).toContain('secrets.json#channels.github')
+  })
+
+  test('gh pr create (configured-without-credentials): blocks with the precise misconfig reason', async () => {
+    delete process.env.GH_TOKEN
+    const agentDir = makeAgentDir({ typeclawJson: githubChannelConfig })
+    const hook = await noAuthHookFor(agentDir)
+
+    const result = await hook(bashEvent('gh pr create -R acme/widgets --title x --body y'), ctxFor(agentDir))
+
+    expect(result).toMatchObject({ block: true })
+    expect((result as { reason: string }).reason).toContain('misconfigured')
+  })
+
+  test('git clone (configured-without-credentials): NOT blocked — read op falls back to warn-and-pass-through', async () => {
+    delete process.env.GH_TOKEN
+    const warnings: string[] = []
+    const logger = { info: () => {}, warn: (m: string) => warnings.push(m), error: () => {} }
+    const agentDir = makeAgentDir({ typeclawJson: githubChannelConfig })
+    const hook = await hookFor(tokenResolver('ghs_minted'), false, { agentDir, logger })
+
+    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git'), ctxFor(agentDir))
+
+    expect(result).toBeUndefined()
+    expect(warnings.length).toBe(1)
+  })
+
+  test('gh pr view (configured-without-credentials): NOT blocked — read op warns and passes through', async () => {
+    delete process.env.GH_TOKEN
+    const agentDir = makeAgentDir({ typeclawJson: githubChannelConfig })
+    const hook = await noAuthHookFor(agentDir)
+
+    const result = await hook(bashEvent('gh pr view -R acme/widgets'), ctxFor(agentDir))
+
+    expect(result).toBeUndefined()
+  })
+
+  test('gh auth status (configured-without-credentials): NOT blocked — repo-less command passes through', async () => {
+    delete process.env.GH_TOKEN
+    const agentDir = makeAgentDir({ typeclawJson: githubChannelConfig })
+    const hook = await noAuthHookFor(agentDir)
+
+    const result = await hook(bashEvent('gh auth status'), ctxFor(agentDir))
+
+    expect(result).toBeUndefined()
+  })
+
+  test('git push to a NON-github remote (configured-without-credentials): NOT blocked', async () => {
+    delete process.env.GH_TOKEN
+    const agentDir = makeAgentDir({ typeclawJson: githubChannelConfig })
+    const hook = await noAuthHookFor(agentDir)
+
+    const result = await hook(bashEvent('git push https://gitlab.com/acme/widgets.git main'), ctxFor(agentDir))
+
+    expect(result).toBeUndefined()
+  })
+
+  test('git push (channel configured WITH valid PAT secrets): NOT blocked by misconfig path', async () => {
+    delete process.env.GH_TOKEN
+    const agentDir = makeAgentDir({
+      typeclawJson: githubChannelConfig,
+      secretsJson: JSON.stringify({
+        version: 2,
+        channels: { github: { auth: { type: 'pat', token: 'ghp_x' }, webhookSecret: 'whsec_x' } },
+      }),
+    })
+    const hook = await noAuthHookFor(agentDir)
+
+    const result = await hook(bashEvent('git push https://github.com/acme/widgets.git main'), ctxFor(agentDir))
+
+    // Credentials ARE present on disk, so this is not the misconfig case; the
+    // generic no-resolver path warns and passes through (no block).
+    expect(result).toBeUndefined()
+  })
+
+  test('git push (NO github channel configured): NOT blocked — generic warn-and-pass-through', async () => {
+    delete process.env.GH_TOKEN
+    const warnings: string[] = []
+    const logger = { info: () => {}, warn: (m: string) => warnings.push(m), error: () => {} }
+    const agentDir = makeAgentDir({ typeclawJson: JSON.stringify({ channels: {} }) })
+    const hook = await hookFor(tokenResolver('ghs_minted'), false, { agentDir, logger })
+
+    const result = await hook(bashEvent('git push https://github.com/acme/widgets.git main'), ctxFor(agentDir))
+
+    expect(result).toBeUndefined()
+    expect(warnings.length).toBe(1)
+  })
+
+  test('git push (malformed secrets.json with github channel): NOT blocked — cannot confirm absence', async () => {
+    delete process.env.GH_TOKEN
+    const agentDir = makeAgentDir({ typeclawJson: githubChannelConfig, secretsJson: '{ not valid json' })
+    const hook = await noAuthHookFor(agentDir)
+
+    const result = await hook(bashEvent('git push https://github.com/acme/widgets.git main'), ctxFor(agentDir))
+
+    // Indeterminate auth state must not produce a false misconfig block.
+    expect(result).toBeUndefined()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -50,6 +50,29 @@ export default definePlugin({
           'for per-repo tokens that work in sandboxed roles.',
       )
     }
+
+    // A repo-targeting git/gh command reached us with NO TypeClaw-managed
+    // credential to inject: no .env PAT (cleared or unset), no sandboxed-PAT mint
+    // path, and no GitHub App resolver. We deliberately do NOT block — the agent
+    // may have configured its own auth we cannot observe (a credential helper,
+    // ~/.netrc, an in-container `gh auth login`, mounted gh config, or an SSH
+    // remote that needs no token). Blocking would break those legitimate flows.
+    // But a silent pass-through is what made the original failure undiagnosable
+    // ("could not read Username" with no hint), so we emit a one-shot warning
+    // that names the real situation and both TypeClaw remedies, then let the
+    // command run unchanged so honest success or honest failure can follow.
+    let warnedNoManagedAuth = false
+    const warnNoManagedAuthOnce = (): void => {
+      if (warnedNoManagedAuth) return
+      warnedNoManagedAuth = true
+      ctx.logger.warn(
+        'No TypeClaw-managed GitHub credentials are available for a repo-targeting git/gh command, ' +
+          'so TypeClaw cannot inject auth. The command runs unchanged and may still succeed if you ' +
+          'configured GitHub auth yourself inside the container (credential helper, ~/.netrc, ' +
+          '`gh auth login`, or an SSH remote). To enable TypeClaw-managed auth, set GH_TOKEN/GITHUB_TOKEN ' +
+          'in .env for roles allowed to receive it, or configure channels.github App authentication.',
+      )
+    }
     // `/user` resolves the caller's USER identity. An App installation token is not
     // a user, so GitHub rejects it on a token-class basis (403, or no-token error in
     // the sandbox) no matter how valid the token is. We block-and-guide so the agent
@@ -160,7 +183,13 @@ export default definePlugin({
       // No App auth (no App-class GH_TOKEN and no live minter): leave whatever
       // is seeded so `gh` fails honestly rather than us guessing a token. The
       // sandboxed-PAT mint path bypasses this PAT-class re-check via the flag.
-      if (!mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
+      // `decision` is necessarily `inject` here (block/pass-through returned
+      // above), i.e. a repo-targeting gh with no managed credential — warn so the
+      // pass-through is diagnosable, then let it run unchanged.
+      if (!mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) {
+        warnNoManagedAuthOnce()
+        return
+      }
 
       const result = await resolveTokenForRepo(decision.repoSlug)
       if (result.kind === 'unavailable') return { block: true, reason: result.reason }
@@ -203,12 +232,20 @@ export default definePlugin({
       // fails honestly rather than us guessing a token. App auth is detected by
       // the live minter too, not just an App-class GH_TOKEN: multi-owner /
       // no-repos App configs never seed GH_TOKEN yet can mint. The mintForSandboxedPat
-      // flag forces minting past this PAT-class re-check.
-      if (!useEnvPat && !mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
+      // flag forces minting past this PAT-class re-check. We still run the analyzer
+      // first so a repo-targeting command (which WOULD have needed a token) warns
+      // before passing through; a non-repo / non-github command stays silent.
+      const noManagedAuth =
+        !useEnvPat && !mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())
 
       const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
       if (decision.kind === 'pass-through') return
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
+
+      if (noManagedAuth) {
+        warnNoManagedAuthOnce()
+        return
+      }
 
       // The unsandboxed-PAT path uses the PAT directly; otherwise mint a per-repo
       // App token. Both ride TYPECLAW_GIT_TOKEN (read by the askpass helper),

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -10,7 +10,7 @@ import { ensureGitAskPassHelper } from './git-askpass'
 import { analyzeGitCommand, defaultGitResolvers } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
-import { classifyGhToken, shouldMintAppToken } from './token-class'
+import { classifyGhToken, effectiveProcessPat, shouldMintAppToken } from './token-class'
 
 export default definePlugin({
   plugin: async (ctx) => {
@@ -141,10 +141,14 @@ export default definePlugin({
         event.args.command = decision.rewrittenCommand
       }
 
-      const tokenClass = classifyGhToken(process.env.GH_TOKEN)
+      // The PAT gh/git would use, honoring gh precedence (GH_TOKEN over
+      // GITHUB_TOKEN). Keyed once and reused for every PAT branch so a
+      // GITHUB_TOKEN-only env is classified and injected like a GH_TOKEN one.
+      const processPat = effectiveProcessPat()
+      const tokenClass = classifyGhToken(processPat)
 
       // PAT classes (classic = cross-owner, fine-grained) are not re-minted per
-      // repo; the seeded GH_TOKEN is the only token we have. App minting, when
+      // repo; the seeded PAT is the only token we have. App minting, when
       // available, is still preferred for SANDBOXED roles (the PAT can't reach
       // them), so a PAT must NOT suppress minting there — only for unsandboxed
       // execution does the PAT win. Unsandboxed: the PAT already rides inherited
@@ -152,18 +156,19 @@ export default definePlugin({
       // GH_TOKEN explicit and consistent with the git path. Sandboxed PAT-only:
       // block with guidance instead of failing silently.
       // Set when a sandboxed PAT falls through to App minting: the tail's
-      // shouldMintAppToken(process.env.GH_TOKEN) re-check would see the PAT and
-      // bail, so this flag forces the mint that the PAT must not suppress.
+      // shouldMintAppToken(processPat) re-check would see the PAT and bail, so
+      // this flag forces the mint that the PAT must not suppress.
       let mintForSandboxedPat = false
       if (tokenClass === 'cross-owner' || tokenClass === 'fine-grained-pat') {
         // Unsandboxed: the PAT authenticates directly (it already rides inherited
         // process.env). For a repo-targeting command we re-assert it in the
-        // overlay so behavior is explicit and matches the git path; otherwise we
-        // pass through. The App-oriented missing-repo / multi-owner BLOCK does
-        // NOT apply — a PAT needs no per-repo mint — so we never surface it here.
+        // overlay as GH_TOKEN (the higher-precedence name) so behavior is explicit
+        // and matches the git path; otherwise we pass through. The App-oriented
+        // missing-repo / multi-owner BLOCK does NOT apply — a PAT needs no per-repo
+        // mint — so we never surface it here.
         if (runsUnsandboxed(event.origin)) {
           if (decision.kind === 'inject') {
-            event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: process.env.GH_TOKEN as string }
+            event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: processPat as string }
           }
           return
         }
@@ -180,13 +185,13 @@ export default definePlugin({
 
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
 
-      // No App auth (no App-class GH_TOKEN and no live minter): leave whatever
-      // is seeded so `gh` fails honestly rather than us guessing a token. The
+      // No App auth (no App-class PAT and no live minter): leave whatever is
+      // seeded so `gh` fails honestly rather than us guessing a token. The
       // sandboxed-PAT mint path bypasses this PAT-class re-check via the flag.
       // `decision` is necessarily `inject` here (block/pass-through returned
       // above), i.e. a repo-targeting gh with no managed credential — warn so the
       // pass-through is diagnosable, then let it run unchanged.
-      if (!mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) {
+      if (!mintForSandboxedPat && !shouldMintAppToken(processPat, hasAppTokenResolver())) {
         warnNoManagedAuthOnce()
         return
       }
@@ -206,7 +211,11 @@ export default definePlugin({
       agentDir: string
     }): Promise<HookResult> => {
       const { event, command, agentDir } = params
-      const tokenClass = classifyGhToken(process.env.GH_TOKEN)
+      // Same effective PAT (GH_TOKEN over GITHUB_TOKEN) the gh path keys off, so a
+      // GITHUB_TOKEN-only env authenticates git too — git has no native support
+      // for either name, but the askpass path below injects this value.
+      const processPat = effectiveProcessPat()
+      const tokenClass = classifyGhToken(processPat)
       const isPat = tokenClass === 'cross-owner' || tokenClass === 'fine-grained-pat'
 
       // A PAT is not re-mintable per repo. For unsandboxed roles it rides the
@@ -235,8 +244,7 @@ export default definePlugin({
       // flag forces minting past this PAT-class re-check. We still run the analyzer
       // first so a repo-targeting command (which WOULD have needed a token) warns
       // before passing through; a non-repo / non-github command stays silent.
-      const noManagedAuth =
-        !useEnvPat && !mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())
+      const noManagedAuth = !useEnvPat && !mintForSandboxedPat && !shouldMintAppToken(processPat, hasAppTokenResolver())
 
       const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
       if (decision.kind === 'pass-through') return
@@ -252,7 +260,7 @@ export default definePlugin({
       // never argv/config.
       let gitToken: string
       if (useEnvPat) {
-        gitToken = process.env.GH_TOKEN as string
+        gitToken = processPat as string
       } else {
         const result = await resolveTokenForRepo(decision.repoSlug)
         if (result.kind === 'unavailable') return { block: true, reason: result.reason }

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -4,10 +4,15 @@ import { definePlugin } from '@/plugin'
 import { resolveHiddenPaths } from '@/sandbox'
 
 import { createApproveIdempotencyGuard } from './approve-idempotency'
+import { getGithubChannelAuthState } from './channel-misconfig'
 import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
-import { analyzeGhCommand, effectiveGhTokensForAuthenticatedUserEndpoint } from './gh-command'
+import {
+  analyzeGhCommand,
+  effectiveGhTokensForAuthenticatedUserEndpoint,
+  isGhCredentialRequiringWrite,
+} from './gh-command'
 import { ensureGitAskPassHelper } from './git-askpass'
-import { analyzeGitCommand, defaultGitResolvers } from './git-command'
+import { analyzeGitCommand, defaultGitResolvers, isGitPushCommand } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
 import { classifyGhToken, effectiveProcessPat, shouldMintAppToken } from './token-class'
@@ -72,6 +77,35 @@ export default definePlugin({
           '`gh auth login`, or an SSH remote). To enable TypeClaw-managed auth, set GH_TOKEN/GITHUB_TOKEN ' +
           'in .env for roles allowed to receive it, or configure channels.github App authentication.',
       )
+    }
+
+    // The one high-confidence misconfiguration (see channel-misconfig.ts): a
+    // configured `channels.github` with no usable credential, so a github.com
+    // write WILL fail. This is the only no-managed-auth case worth surfacing to
+    // the AGENT (a block reason reaches the tool result; logger.warn does not),
+    // because here — unlike the generic case — we know auth is both intended and
+    // missing rather than possibly supplied out-of-band.
+    const channelMisconfigBlockReason =
+      'TypeClaw GitHub auth is misconfigured for this agent, so this credential-requiring command was blocked.\n' +
+      'Detected:\n' +
+      '- typeclaw.json has channels.github configured\n' +
+      '- GH_TOKEN/GITHUB_TOKEN are unset\n' +
+      '- no TypeClaw GitHub token resolver is active\n' +
+      '- secrets.json#channels.github has no usable auth credentials\n' +
+      'Fix: add GitHub credentials to secrets.json#channels.github (PAT or App), or set GH_TOKEN/GITHUB_TOKEN, ' +
+      'then restart the agent/container. If you intended to use your own ambient GitHub auth, remove the ' +
+      'channels.github block so TypeClaw does not treat this as a managed GitHub setup.'
+
+    // Resolves a repo-targeting, no-managed-auth command: block with the precise
+    // misconfig reason ONLY for a credential-requiring write to github.com when
+    // the channel is configured-without-credentials; otherwise fall back to the
+    // generic warn-and-pass-through (ambient auth may still carry it).
+    const resolveNoManagedAuth = (isCredentialRequiringWrite: boolean): HookResult => {
+      if (isCredentialRequiringWrite && getGithubChannelAuthState(ctx.agentDir) === 'configured-without-credentials') {
+        return { block: true, reason: channelMisconfigBlockReason }
+      }
+      warnNoManagedAuthOnce()
+      return
     }
     // `/user` resolves the caller's USER identity. An App installation token is not
     // a user, so GitHub rejects it on a token-class basis (403, or no-token error in
@@ -189,11 +223,12 @@ export default definePlugin({
       // seeded so `gh` fails honestly rather than us guessing a token. The
       // sandboxed-PAT mint path bypasses this PAT-class re-check via the flag.
       // `decision` is necessarily `inject` here (block/pass-through returned
-      // above), i.e. a repo-targeting gh with no managed credential — warn so the
-      // pass-through is diagnosable, then let it run unchanged.
+      // above), i.e. a repo-targeting gh with no managed credential. Block with
+      // the precise misconfig reason for a credential-requiring write (gh pr
+      // create) when the channel is configured-without-credentials; otherwise
+      // warn so the pass-through is diagnosable, then let it run unchanged.
       if (!mintForSandboxedPat && !shouldMintAppToken(processPat, hasAppTokenResolver())) {
-        warnNoManagedAuthOnce()
-        return
+        return resolveNoManagedAuth(isGhCredentialRequiringWrite(command))
       }
 
       const result = await resolveTokenForRepo(decision.repoSlug)
@@ -250,9 +285,12 @@ export default definePlugin({
       if (decision.kind === 'pass-through') return
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
 
+      // `decision` is `inject` here (a repo-targeting github command). A push is
+      // the credential-requiring write that gets the precise misconfig block when
+      // the channel is configured-without-credentials; clone/fetch/pull fall back
+      // to the generic warn-and-pass-through.
       if (noManagedAuth) {
-        warnNoManagedAuthOnce()
-        return
+        return resolveNoManagedAuth(isGitPushCommand(command))
       }
 
       // The unsandboxed-PAT path uses the PAT directly; otherwise mint a per-repo

--- a/src/bundled-plugins/github-cli-auth/token-class.test.ts
+++ b/src/bundled-plugins/github-cli-auth/token-class.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
-import { classifyGhToken, shouldMintAppToken } from './token-class'
+import { classifyGhToken, effectiveProcessPat, shouldMintAppToken } from './token-class'
 
 describe('classifyGhToken', () => {
   it('classifies a classic PAT as cross-owner', () => {
@@ -43,5 +43,21 @@ describe('shouldMintAppToken', () => {
   it('never re-mints for classic or fine-grained PATs, even with a live minter', () => {
     expect(shouldMintAppToken('ghp_classic', true)).toBe(false)
     expect(shouldMintAppToken('github_pat_xyz', true)).toBe(false)
+  })
+})
+
+describe('effectiveProcessPat', () => {
+  it('prefers GH_TOKEN over GITHUB_TOKEN (gh precedence)', () => {
+    expect(effectiveProcessPat({ GH_TOKEN: 'ghp_a', GITHUB_TOKEN: 'ghp_b' })).toBe('ghp_a')
+  })
+
+  it('falls back to GITHUB_TOKEN when GH_TOKEN is absent or empty', () => {
+    expect(effectiveProcessPat({ GITHUB_TOKEN: 'ghp_b' })).toBe('ghp_b')
+    expect(effectiveProcessPat({ GH_TOKEN: '', GITHUB_TOKEN: 'ghp_b' })).toBe('ghp_b')
+  })
+
+  it('is undefined when neither is set or both are empty', () => {
+    expect(effectiveProcessPat({})).toBeUndefined()
+    expect(effectiveProcessPat({ GH_TOKEN: '', GITHUB_TOKEN: '' })).toBeUndefined()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/token-class.ts
+++ b/src/bundled-plugins/github-cli-auth/token-class.ts
@@ -1,5 +1,19 @@
 export type GhTokenClass = 'cross-owner' | 'fine-grained-pat' | 'app' | 'none'
 
+// The PAT `gh`/`git` would actually use from the process env, following gh's own
+// precedence (`GH_TOKEN` over `GITHUB_TOKEN`). git has no native support for
+// either, but the plugin's askpass path injects this value, so both CLIs end up
+// honoring the same token. Used everywhere a process-env credential is
+// classified or checked for presence so a `GITHUB_TOKEN`-only env is not misread
+// as "no auth".
+export function effectiveProcessPat(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const ghToken = env.GH_TOKEN
+  if (ghToken !== undefined && ghToken !== '') return ghToken
+  const githubToken = env.GITHUB_TOKEN
+  if (githubToken !== undefined && githubToken !== '') return githubToken
+  return undefined
+}
+
 export function classifyGhToken(token: string | undefined): GhTokenClass {
   if (token === undefined || token === '') return 'none'
   if (token.startsWith('ghp_')) return 'cross-owner'


### PR DESCRIPTION
## Background

A typeclaw agent running inside a container on a GitHub repo could not push a branch or open a PR. Concrete symptoms:

- `gh auth status` → "You are not logged into any GitHub hosts."
- Running a push command → `fatal: could not read Username for 'https://github.com': No such device or address`

Two layered root causes:

1. **Silent pass-through on no managed auth.** The `github-cli-auth` hook (`tool.before` on `bash`) only injects a token when a `.env` PAT (`GH_TOKEN`/`GITHUB_TOKEN`) is present or a GitHub App per-repo minter is live. With neither, the hook returned early and let the command through untouched — leaving git/gh to fail with opaque, undiagnosable errors. Every *other* missing-auth case the plugin handles (sandboxed-PAT-withheld, missing-repo, multi-owner, unsafe composition, `gh api /user`) already emits block-with-guidance; the no-managed-auth case was the one remaining silent path.

2. **Agent-invisible channel misconfiguration.** When `typeclaw.json` declares a `channels.github` block but `secrets.json` carries no usable credential, the channel manager logs an operator-level error and skips the adapter entirely — the log goes to container stdout, which the LLM agent never sees. The agent only experienced the opaque git failure, with no path to learn the real cause.

## Summary

Three commits, each addressing a distinct layer:

**Commit 1 — warn, not block, for the generic no-managed-auth case.** When the hook classifies a command as repo-targeting (`inject`) but finds no managed credential, it now emits a one-shot `ctx.logger.warn` naming the situation and both remedies, then passes the command through unchanged. Why warn and not block: the agent may have configured its own auth typeclaw cannot observe (credential helper, `~/.netrc`, in-container `gh auth login`, mounted gh config, SSH remote). A hard block would break those legitimate flows. Ordering is load-bearing: the analyzer now runs *before* the no-auth early-return on the git path, so only true repo-targeting github commands warn; `gh auth status`, `git status`, and non-github remotes stay silent.

**Commit 2 (review follow-up) — fold `GITHUB_TOKEN` into the managed-auth decision.** The predicate and PAT classification keyed only off `GH_TOKEN`, so a command run with `GITHUB_TOKEN`-only falsely tripped the warning even though `gh` honors it natively. Introduced `effectiveProcessPat()` = `GH_TOKEN ?? GITHUB_TOKEN` (gh's own precedence) and keyed every process-env PAT branch off it: classification, the App-mint decision, warning suppression, the gh overlay (still injected under the higher-precedence `GH_TOKEN` name), and the git askpass token. Note the asymmetry: `gh` reads `GITHUB_TOKEN` natively but `git` does not, so folding it into the git path means the askpass helper now supplies it — making a `GITHUB_TOKEN`-only push authenticate rather than merely suppress a warning.

**Commit 3 — block the one high-confidence misconfiguration.** The only agent-visible signal from a `tool.before` hook is a block reason; a `logger.warn` is invisible to the LLM. So when `channels.github` is configured *and* secrets auth is absent *and* no env token exists *and* no live resolver is present, a credential-requiring write (push to github.com, `gh pr create`) is now blocked with the exact root cause and remedy instead of failing opaquely. This is the only case blocked: here — unlike the generic no-managed-auth case — typeclaw *knows* auth is both intended and missing.

## What this does NOT do

- Does not let an agent push without credentials — it converts an undiagnosable failure into an actionable, agent-visible one.
- Does not change any path where a PAT or GitHub App auth is configured — all existing inject/mint/block paths are unchanged.
- Does not block reads or ambiguous cases: only pushes to github.com and `gh pr create` block, and only in the configured-without-credentials state. `clone`/`fetch`/`pull`/`gh pr view`/`gh auth status`/non-github remotes/`--help` invocations are never blocked.
- Does not false-block on schema-invalid or unreadable `secrets.json` (treated as indeterminate) or when a live App resolver exists (multi-owner/no-repos App auth bypasses the path entirely).
- Does not touch the config/secrets schema, Dockerfile, or token-bridge wiring. The new detector reads `typeclaw.json`/`secrets.json` for presence/absence only — never token values.

## Review notes

- **Load-bearing changes:** the two no-managed-auth sites in `src/bundled-plugins/github-cli-auth/index.ts` (`handleGhCommand`/`handleGitCommand`) now route through a shared `resolveNoManagedAuth(isCredentialRequiringWrite: boolean)`; new `channel-misconfig.ts` is a memoized, per-agentDir state detector (presence-only); new predicates `isGitPushCommand` / `isGhCredentialRequiringWrite` both exclude `--help`/`-h`; `effectiveProcessPat` in `token-class.ts`.
- **Invariant to verify:** the misconfig block can only fire for `inject`-classified commands after the block/pass-through/PAT-inject branches have returned; a live App resolver bypasses it; only `configured-without-credentials` blocks — `indeterminate`/`with-credentials`/`not-configured` never block.
- **Tests:** full `github-cli-auth` suite (369 cases) green — adds `GITHUB_TOKEN`-only coverage for gh and git, precedence over `GH_TOKEN`, sandboxed `GITHUB_TOKEN`-only paths, the configured-without-credentials block and all the not-blocked guards (reads, non-github, `--help`, valid creds, no `channels.github`, malformed `secrets.json`), plus unit tests for the detector and predicates.
