### PR TITLE
feat(cli): add type-to-search to model and provider pickers

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,18 @@
 import { randomBytes } from 'node:crypto'
 
-import { cancel, confirm, intro, isCancel, log, note, password, select, spinner, text } from '@clack/prompts'
+import {
+  autocomplete,
+  cancel,
+  confirm,
+  intro,
+  isCancel,
+  log,
+  note,
+  password,
+  select,
+  spinner,
+  text,
+} from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import {
@@ -1083,8 +1095,9 @@ async function pickVendor(
   initial: KnownProviderVendorId | undefined,
 ): Promise<StepResult<KnownProviderVendorId>> {
   const vendors = uniqueVendors(options)
-  const choice = await select({
+  const choice = await autocomplete({
     message: 'Pick an LLM provider',
+    placeholder: 'Type to search…',
     options: vendors.map((id) => ({
       value: id,
       label: KNOWN_PROVIDER_VENDORS[id].name,
@@ -1104,8 +1117,9 @@ async function pickProviderVariant(
   const variants = providersForVendorInCatalog(vendorId, options)
   if (variants.length === 0) throw new Error(`Internal error: vendor ${vendorId} has no providers in the catalog`)
   if (variants.length === 1) return autoValue(variants[0]!)
-  const choice = await select<KnownProviderId>({
+  const choice = await autocomplete<KnownProviderId>({
     message: `Pick a ${KNOWN_PROVIDER_VENDORS[vendorId].name} option`,
+    placeholder: 'Type to search…',
     options: variants.map((id) => {
       const hint = variantHint(vendorId, id)
       return hint !== undefined
@@ -1128,8 +1142,9 @@ async function pickModelForProvider(
   // distributive conditional type, so a large KnownModelRef union explodes into
   // a per-literal option union that no longer accepts `value: ref`. The runtime
   // value is the ref string and is re-narrowed via `candidates.find` below.
-  const choice = await select<string>({
+  const choice = await autocomplete<string>({
     message: `Pick a ${KNOWN_PROVIDERS[providerId].name} model`,
+    placeholder: 'Type to search…',
     options: candidates.map((o) => ({
       value: o.ref,
       label: formatModelLabel(o),
@@ -1173,8 +1188,9 @@ async function pickVisionVendor(
     log.warn('No vision-capable models available; skipping vision profile.')
     return autoValue('skip')
   }
-  const choice = await select<KnownProviderVendorId | 'skip'>({
+  const choice = await autocomplete<KnownProviderVendorId | 'skip'>({
     message: 'Your model is text-only. Pick a provider for the `vision` profile (used for image input)',
+    placeholder: 'Type to search…',
     options: [
       ...vendors.map((id) => ({
         value: id as KnownProviderVendorId | 'skip',
@@ -1204,8 +1220,9 @@ async function pickVisionModel(
 ): Promise<StepResult<ModelOption>> {
   const candidates = sortRecommendedFirst(options.filter((o) => o.providerId === providerId))
   // select<string> for the same distributive-Option reason as pickModelForProvider.
-  const choice = await select<string>({
+  const choice = await autocomplete<string>({
     message: `Pick a vision-capable ${KNOWN_PROVIDERS[providerId].name} model`,
+    placeholder: 'Type to search…',
     options: candidates.map((o) => ({
       value: o.ref,
       label: formatModelLabel(o),

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,4 +1,4 @@
-import { cancel, intro, isCancel, log, select } from '@clack/prompts'
+import { autocomplete, cancel, intro, isCancel, log, select } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import type { CustomModelMeta } from '@/config'
@@ -248,8 +248,9 @@ async function pickModelRef(cwd: string): Promise<PickedModelRef> {
     // assignability. Values are ref strings (+ the sentinel) and stay correct
     // at runtime — the sentinel check and `return choice` below are unaffected.
     const modelOptions = await listCredentialedModelOptions(refs)
-    const choice = await select<string>({
+    const choice = await autocomplete<string>({
       message: 'Pick a model',
+      placeholder: 'Type to search…',
       options: [
         ...modelOptions.map((option) => ({
           value: option.ref,

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -1,4 +1,4 @@
-import { cancel, intro, isCancel, log, password, select } from '@clack/prompts'
+import { autocomplete, cancel, intro, isCancel, log, password, select } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import {
@@ -282,8 +282,9 @@ async function resolveProviderForAdd(input: string | undefined): Promise<KnownPr
 
 async function pickVendorToAdd(): Promise<KnownProviderVendorId> {
   const vendorIds = listKnownProviderVendorIds()
-  const choice = await select<KnownProviderVendorId>({
+  const choice = await autocomplete<KnownProviderVendorId>({
     message: 'Pick a provider to add',
+    placeholder: 'Type to search…',
     options: vendorIds.map((id) => ({
       value: id,
       label: KNOWN_PROVIDER_VENDORS[id].name,
@@ -301,8 +302,9 @@ async function pickVendorToAdd(): Promise<KnownProviderVendorId> {
 async function pickVariantToAdd(vendorId: KnownProviderVendorId): Promise<KnownProviderId> {
   const variants = providerIdsForVendor(vendorId)
   if (variants.length === 1) return variants[0]!
-  const choice = await select<KnownProviderId>({
+  const choice = await autocomplete<KnownProviderId>({
     message: `Pick a ${KNOWN_PROVIDER_VENDORS[vendorId].name} option`,
+    placeholder: 'Type to search…',
     options: variants.map((id) => {
       const hint = variantHint(vendorId, id)
       return hint !== undefined


### PR DESCRIPTION
## Background

Arrow-key-only navigation in the model and provider pickers becomes impractical once a few providers are configured. `typeclaw model set` renders a flat list of every credentialed model across all vendors; the `init` wizard scrolls through every vendor and variant in sequence. With real-world provider setups the list is long enough that finding "claude-sonnet-4-5" or "gpt-4o" by scrolling is noticeably slow.

## Summary

Swaps the long/medium `@clack/prompts` `select()` pickers for `autocomplete()`, which filters the list by **label, hint, and value** as you type. The search affordance is surfaced via a `placeholder: 'Type to search…'` hint on each converted picker.

`autocomplete()` returns the same `Value | symbol` union as `select()`, so every existing `isCancel` guard and post-pick return narrowing works without modification.

Short fixed lists — profile name, auth method — intentionally stay on `select()`. Type-to-search adds nothing for 2–4 static items.

Converted pickers:

| File | Function | List |
|---|---|---|
| `src/cli/model.ts` | `pickModelRef` | all credentialed models (longest list) |
| `src/cli/init.ts` | `pickVendor` | LLM vendors |
| `src/cli/init.ts` | `pickProviderVariant` | provider variants |
| `src/cli/init.ts` | `pickModelForProvider` | models for a provider |
| `src/cli/init.ts` | `pickVisionVendor` | vision vendors |
| `src/cli/init.ts` | `pickVisionModel` | vision models |
| `src/cli/provider.ts` | `pickVendorToAdd` | vendors (`provider add`) |
| `src/cli/provider.ts` | `pickVariantToAdd` | provider variants |

## Preview

Terminal interaction before: arrow-key scroll through the full model list.

Terminal interaction after: type `sonnet`, `gpt`, or a provider name to narrow instantly; Enter selects the highlighted item.

(No rendered UI screenshot — this is an interactive terminal prompt change.)

## What this does NOT do

- Does not change any non-interactive path (`typeclaw model set <ref>` with an explicit arg still bypasses the picker entirely).
- Does not change the return type or downstream narrowing logic for any picker.
- Does not add search to short fixed lists (profile name, auth method, yes/no gates).
- Does not add fuzzy matching — the default `autocomplete()` filter is substring on label + hint + value, which is sufficient for model/provider names.

## Review notes

The load-bearing change is the `select()` → `autocomplete()` swap in `pickModelRef` (`src/cli/model.ts`) and the six pickers in `src/cli/init.ts`. The `@clack/prompts` `autocomplete()` API is already a direct dependency — no new packages.

All four pre-commit checks pass: `typecheck` clean, `lint` 0 errors, `format:check` clean, `test` 9032 pass. The single timeout in the portbroker end-to-end pipeline is a pre-existing flaky test under heavy parallel load and is unrelated to this change.