### PR TITLE
fix(subagent): run plugin tool hooks for built-in subagents (GitHub token minting + security guards)

### DIFF
--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -1,14 +1,16 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, spyOn, test } from 'bun:test'
 
 import { z } from 'zod'
 
-import type { HookBus } from '@/plugin'
+import type { HookBus, PluginRegistry } from '@/plugin'
 import { createStream } from '@/stream'
 
-import type { AgentSession } from './index'
+import * as agentIndex from './index'
+import type { AgentSession, PluginSessionWiring } from './index'
 import { LiveSubagentRegistry } from './live-subagents'
 import {
   createSubagentConsumer,
+  defaultCreateSessionForSubagent,
   invokeSubagent,
   startSubagent,
   type Subagent,
@@ -1283,5 +1285,47 @@ describe('invokeSubagent — background drain lifecycle', () => {
     // then: exactly one prompt, no drain.
     expect(calls.prompt.length).toBe(1)
     expect(calls.disposed).toBe(1)
+  })
+})
+
+describe('defaultCreateSessionForSubagent — plugin hook wiring', () => {
+  const subagent: Subagent<unknown> = { systemPrompt: 'X', payloadSchema: z.unknown() }
+
+  function fakePluginWiring(): PluginSessionWiring {
+    return {
+      registry: { skills: [] } as unknown as PluginRegistry,
+      hooks: makeFakeHookBus([]),
+      sessionId: 'ses_sub',
+      agentDir: '/agent',
+    }
+  }
+
+  test('forwards plugins wiring into createSession so the subagent runs tool hooks', async () => {
+    // given: a built-in subagent created WITH plugin wiring
+    const spy = spyOn(agentIndex, 'createSession').mockResolvedValue(fakeSession().session)
+    const plugins = fakePluginWiring()
+    try {
+      // when
+      await defaultCreateSessionForSubagent(subagent, { name: 'explore', plugins })
+
+      // then: createSession receives the same plugin wiring (so its builtin bash
+      // is wrapped with tool.before — security guards + github-cli-auth token).
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0]?.[0]?.plugins).toBe(plugins)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  test('omits plugins when none supplied (standalone/test callers stay unwrapped)', async () => {
+    const spy = spyOn(agentIndex, 'createSession').mockResolvedValue(fakeSession().session)
+    try {
+      await defaultCreateSessionForSubagent(subagent, { name: 'explore' })
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0]?.[0]?.plugins).toBeUndefined()
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, spyOn, test } from 'bun:test'
 
 import { z } from 'zod'
 
+import { noopPermissionService } from '@/permissions'
 import type { HookBus, PluginRegistry } from '@/plugin'
 import { createStream } from '@/stream'
 
@@ -1300,30 +1301,35 @@ describe('defaultCreateSessionForSubagent — plugin hook wiring', () => {
     }
   }
 
-  test('forwards plugins wiring into createSession so the subagent runs tool hooks', async () => {
-    // given: a built-in subagent created WITH plugin wiring
+  test('forwards plugins AND permissions into createSession so the subagent runs tool hooks WITH sandboxing', async () => {
+    // given: a built-in subagent created WITH plugin wiring + the permission service
     const spy = spyOn(agentIndex, 'createSession').mockResolvedValue(fakeSession().session)
     const plugins = fakePluginWiring()
+    const permissions = noopPermissionService
     try {
       // when
-      await defaultCreateSessionForSubagent(subagent, { name: 'explore', plugins })
+      await defaultCreateSessionForSubagent(subagent, { name: 'explore', plugins, permissions })
 
-      // then: createSession receives the same plugin wiring (so its builtin bash
-      // is wrapped with tool.before — security guards + github-cli-auth token).
+      // then: createSession receives BOTH. plugins wraps builtin bash with
+      // tool.before (token + guards); permissions is what makes that wrapper
+      // apply applyBashSandbox/applyTmpPathRedirect — both are required or the
+      // subagent gets the token with the sandbox off.
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy.mock.calls[0]?.[0]?.plugins).toBe(plugins)
+      expect(spy.mock.calls[0]?.[0]?.permissions).toBe(permissions)
     } finally {
       spy.mockRestore()
     }
   })
 
-  test('omits plugins when none supplied (standalone/test callers stay unwrapped)', async () => {
+  test('omits plugins and permissions when none supplied (standalone/test callers stay unwrapped)', async () => {
     const spy = spyOn(agentIndex, 'createSession').mockResolvedValue(fakeSession().session)
     try {
       await defaultCreateSessionForSubagent(subagent, { name: 'explore' })
 
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy.mock.calls[0]?.[0]?.plugins).toBeUndefined()
+      expect(spy.mock.calls[0]?.[0]?.permissions).toBeUndefined()
     } finally {
       spy.mockRestore()
     }

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -1,6 +1,7 @@
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
 import type { z } from 'zod'
 
+import type { PermissionService } from '@/permissions'
 import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
@@ -152,6 +153,12 @@ export type CreateSessionForSubagentOptions = {
   // task-spawned subagent's `git push`/`gh` gets a minted token instead of
   // failing with "could not read Username".
   plugins?: PluginSessionWiring
+  // The role/permission service that drives builtin-bash sandboxing. It MUST be
+  // forwarded alongside `plugins`: buildBuiltinPiToolOverrides only applies
+  // applyBashSandbox / applyTmpPathRedirect when `permissions` is present, so
+  // wiring hooks without permissions would inject the GitHub token yet leave the
+  // sandbox OFF — strictly weaker than the plugin-subagent branch this matches.
+  permissions?: PermissionService
 }
 export type CreateSessionForSubagent = (
   subagent: Subagent<any>,
@@ -171,6 +178,7 @@ export const defaultCreateSessionForSubagent: CreateSessionForSubagent = (subage
     ...(subagent.tools ? { tools: subagent.tools } : {}),
     customTools: subagent.customTools ?? [],
     ...(options?.plugins !== undefined ? { plugins: options.plugins } : {}),
+    ...(options?.permissions !== undefined ? { permissions: options.permissions } : {}),
     ...(subagent.profile !== undefined ? { profile: subagent.profile } : {}),
     ...(subagent.toolResultBudget !== undefined ? { toolResultBudget: subagent.toolResultBudget } : {}),
     ...(subagent.bashPolicy !== undefined ? { bashPolicy: subagent.bashPolicy } : {}),

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -4,7 +4,7 @@ import type { z } from 'zod'
 import type { HookBus } from '@/plugin'
 import type { Stream, Unsubscribe } from '@/stream'
 
-import { type AgentSession, createSession } from './index'
+import { type AgentSession, createSession, type PluginSessionWiring } from './index'
 import { subscribeProviderErrors } from './provider-error'
 import type { SubagentBashPolicy } from './reviewer-bash-policy'
 import type { SessionOrigin } from './session-origin'
@@ -143,6 +143,15 @@ export type CreateSessionForSubagentOptions = {
   parentSessionId?: string
   spawnedByRole?: string
   spawnedByOrigin?: SessionOrigin
+  // Plugin hook wiring for the subagent's tools. When present, the subagent's
+  // builtin bash/read/edit/write run through the plugin `tool.before`/`tool.after`
+  // hooks (security guards AND github-cli-auth GitHub-token injection) exactly
+  // like the main and plugin-subagent sessions. Without it, the builtin tools run
+  // raw (the prior behavior) — so standalone/test callers stay unaffected. The
+  // production runtime always supplies it (src/run/index.ts) so a generic
+  // task-spawned subagent's `git push`/`gh` gets a minted token instead of
+  // failing with "could not read Username".
+  plugins?: PluginSessionWiring
 }
 export type CreateSessionForSubagent = (
   subagent: Subagent<any>,
@@ -161,6 +170,7 @@ export const defaultCreateSessionForSubagent: CreateSessionForSubagent = (subage
     },
     ...(subagent.tools ? { tools: subagent.tools } : {}),
     customTools: subagent.customTools ?? [],
+    ...(options?.plugins !== undefined ? { plugins: options.plugins } : {}),
     ...(subagent.profile !== undefined ? { profile: subagent.profile } : {}),
     ...(subagent.toolResultBudget !== undefined ? { toolResultBudget: subagent.toolResultBudget } : {}),
     ...(subagent.bashPolicy !== undefined ? { bashPolicy: subagent.bashPolicy } : {}),

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -457,6 +457,11 @@ export async function startAgent({
         sessionId: sessionManager.getSessionId(),
         agentDir: cwd,
       },
+      // Pass permissions alongside plugins (same as the plugin-subagent branch
+      // at line 384): without it the builtin-bash sandbox (applyBashSandbox /
+      // applyTmpPathRedirect) stays off and the subagent would get the injected
+      // token but no role-derived sandboxing.
+      permissions: pluginsLoaded.permissions,
     })
   }
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -439,7 +439,25 @@ export async function startAgent({
           : {}),
       }
     }
-    return defaultCreateSessionForSubagent(subagent, subagentOptions)
+    // Non-plugin (built-in) subagents — general/explore/scout/memory-logger/
+    // dreaming and anything spawned through the generic task path. They used to
+    // run with NO plugin tool.before/tool.after coverage, so their bash skipped
+    // the security guards AND the github-cli-auth GitHub-token injection — a
+    // generic subagent's `git push` got no minted token and died with "could
+    // not read Username" even when a GitHub App was configured. Thread the same
+    // hook bus the plugin-subagent branch uses, against a freshly allocated
+    // subagent session id (never the parent's, so hooks/audit/permission
+    // attribution stay per-session).
+    const sessionManager = SessionManager.create(cwd, sessionFactory.sessionDir())
+    return defaultCreateSessionForSubagent(subagent, {
+      ...subagentOptions,
+      plugins: {
+        registry: snap.registry,
+        hooks: snap.hooks,
+        sessionId: sessionManager.getSessionId(),
+        agentDir: cwd,
+      },
+    })
   }
 
   const subagentConsumer = createSubagentConsumer({


### PR DESCRIPTION
## Background

Built-in subagents (general/explore/scout/memory-logger/dreaming, and anything spawned through the generic task path) ran their built-in bash/read/edit/write tools WITHOUT the plugin `tool.before`/`tool.after` hooks. The production subagent factory (`createSessionForSubagent` in `src/run/index.ts`) wired the hook bus only for plugin-registered subagents (operator, reviewer, …); everything else fell through to `defaultCreateSessionForSubagent` in `src/agent/subagents.ts`, which called `createSession` with no `plugins` field — so built-in tools ran raw.

The visible consequence: the github-cli-auth bundled plugin injects the minted GitHub token (PAT, or a per-repo GitHub App installation token) into git/gh bash commands via a `tool.before` hook. For a built-in subagent that hook never fired, so `git push` / `gh pr create` got no credential and died with `fatal: could not read Username for 'https://github.com'` — even when a GitHub App was correctly configured and minting worked fine for the main agent. The same gap silently skipped every security `tool.before` guard (secret-exfil, SSRF, prompt-injection, tainted git remote, role/cron escalation) for built-in subagents.

## Summary

Give `defaultCreateSessionForSubagent` an optional `plugins` (`PluginSessionWiring`) parameter and forward it to `createSession` when present. In the production factory's fallback path (`src/run/index.ts`), thread the same `{ registry: snap.registry, hooks: snap.hooks }` the plugin-subagent branch already uses, against a freshly allocated subagent session id — never the parent's, so hook/audit/permission attribution stay per-session — and `agentDir: cwd`.

Key decisions:

- **`plugins` stays optional** — standalone and test callers of `defaultCreateSessionForSubagent` keep the prior raw-bash behavior; only the production runtime supplies it.
- **Wire the full hook bus, not just the github-cli-auth hook** — the raw-bash path was an oversight, not a security boundary, so built-in subagents now get the same guard coverage as main and plugin-subagent sessions.
- **Layer split preserved** — `src/run/index.ts` owns the decision to supply plugins (it owns the plugin snapshot, hook bus, and session allocation); `src/agent/subagents.ts` stays usable without a production plugin environment.

## What this does NOT do

- Does not let an agent push without credentials — it makes the existing minting reach subagent bash; an unconfigured agent still has no token.
- Does not change plugin-registered subagents (operator/reviewer) — they already had hook coverage.
- Does not change behavior for standalone/test callers that pass no `plugins`.
- Does not touch the github-cli-auth plugin, the token bridge, config/secrets schema, or the Dockerfile.

## Review notes

- Load-bearing: the optional `plugins` forward in `defaultCreateSessionForSubagent` (`src/agent/subagents.ts`) and the fallback wiring in `createSessionForSubagent` (`src/run/index.ts`). The fallback now allocates a SessionManager session id and passes `plugins` exactly like the plugin-subagent branch above it.
- Invariant: each built-in subagent gets a fresh per-subagent session id (not the parent's), `agentDir: cwd`, and `origin: { kind: 'subagent' }`. The github-cli-auth credential decision and `applyBashSandbox` both key off the same origin/permissions signal, so they stay coherent.
- Tests: `defaultCreateSessionForSubagent` forwards `plugins` when supplied and omits it when not (spy on `createSession`). Full agent/run/security suites (1788 tests) pass unchanged, confirming that enabling guards for built-in subagents does not regress them (dreaming/memory-logger/scout all still work).
- Note: the repo's checked-in `typeclaw.schema.json` drift-guard test fails on a pre-existing, unrelated drift; this PR adds no config fields. CI regenerates the schema first so it passes there.
