### PR TITLE
docs(landing): new hero 'The agent for perfectionists' + accuracy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="./docs/public/typeclaw.png" alt="TypeClaw logo" width="240" />
 </p>
 
-> A TypeScript-native, Bun-powered, Docker-friendly general-purpose agent runtime.
+> The agent for perfectionists — crafted in every detail. It behaves in your team's chat and gets sharper the longer it runs. Sandboxed and self-managing.
 
 ## Why?
 

--- a/docs/src/app/_components/channel-icons.tsx
+++ b/docs/src/app/_components/channel-icons.tsx
@@ -29,6 +29,14 @@ function KakaoTalk({ className }: IconProps) {
   )
 }
 
+function Line({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className={className}>
+      <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .63.283.63.63 0 .344-.282.629-.63.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
+    </svg>
+  )
+}
+
 function SlackBrand({ className }: IconProps) {
   const Icon = Slack as unknown as ComponentType<SVGProps<SVGSVGElement>>
   return <Icon className={className} strokeWidth={1.8} aria-hidden />
@@ -55,6 +63,7 @@ export const CHANNELS: ChannelDef[] = [
   { name: 'Slack', Icon: SlackBrand, branded: true, href: '/docs/reference/slack-bot' },
   { name: 'Discord', Icon: Discord, branded: true, href: '/docs/reference/discord-bot' },
   { name: 'Telegram', Icon: Telegram, branded: true, href: '/docs/reference/telegram-bot' },
+  { name: 'LINE', Icon: Line, branded: true, href: '/docs/reference/line' },
   { name: 'KakaoTalk', Icon: KakaoTalk, branded: true, href: '/docs/reference/kakaotalk' },
   { name: 'GitHub', Icon: GithubBrand, branded: true, href: '/docs/reference/github' },
   { name: 'TUI', Icon: TerminalBrand, branded: false },

--- a/docs/src/app/_components/data.ts
+++ b/docs/src/app/_components/data.ts
@@ -4,26 +4,6 @@ export const INSTALL_COMMAND = 'bun add -g typeclaw'
 
 export const VERSION = `v${TYPECLAW_VERSION}`
 
-export interface Feature {
-  title: string
-  detail: string
-}
-
-export const FEATURES: Feature[] = [
-  { title: 'Sandboxed by default', detail: 'every agent runs in its own Docker container' },
-  { title: 'TypeScript end to end', detail: 'core, plugins, channels, CLI, TUI' },
-  { title: 'Plugins as TS modules', detail: 'plain .ts files; no IPC, no FFI' },
-  { title: 'Multi-channel', detail: 'Slack, Discord, Telegram, KakaoTalk, GitHub — plus a websocket TUI' },
-  { title: 'Cron', detail: 'scheduled prompts and shell commands, with coalescing' },
-  { title: 'Self-improving memory', detail: 'observes its own work and writes its own skills' },
-  { title: 'Hot reload', detail: 'most config reloads live; boot-only fields ask for a restart' },
-  { title: 'Auto port-forward', detail: 'dev servers in the container appear on localhost' },
-  { title: 'Public tunnels', detail: 'Cloudflare Quick or your own URL — built in' },
-  { title: 'Skills on demand', detail: 'markdown procedures with zero token cost until used' },
-  { title: 'Group-chat aware', detail: 'knows who is in the room and when to reply' },
-  { title: 'Roles and permissions', detail: 'platform-aware match rules gate every action' },
-]
-
 export interface DocLink {
   href: string
   title: string
@@ -62,8 +42,8 @@ export interface Competitor {
 export const COMPETITORS: Competitor[] = [
   {
     name: 'OpenClaw',
-    strength: 'Feature-rich',
-    tradeoff: 'Heavy',
+    strength: 'Biggest ecosystem',
+    tradeoff: 'a platform to learn, not a codebase to read',
     lang: 'TypeScript',
     dockerFirst: true,
     selfImproving: 'partial',
@@ -74,8 +54,8 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'NanoClaw',
-    strength: 'Simple',
-    tradeoff: 'No plugin system',
+    strength: 'Minimal',
+    tradeoff: 'no real plugin system',
     lang: 'TypeScript',
     dockerFirst: false,
     selfImproving: false,
@@ -86,8 +66,8 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'PicoClaw',
-    strength: 'Fast',
-    tradeoff: 'Plugins live outside the runtime',
+    strength: 'Ultralight',
+    tradeoff: 'plugins live outside the runtime',
     lang: 'Go',
     dockerFirst: false,
     selfImproving: false,
@@ -98,8 +78,8 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'ZeroClaw',
-    strength: 'Light',
-    tradeoff: 'Plugins live outside the runtime',
+    strength: 'Single binary',
+    tradeoff: 'plugins live outside the runtime',
     lang: 'Rust',
     dockerFirst: false,
     selfImproving: false,
@@ -110,8 +90,8 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'Hermes Agent',
-    strength: 'Awesome',
-    tradeoff: 'Python',
+    strength: 'Mature, self-improving',
+    tradeoff: 'Python — a boundary if your stack is TS',
     lang: 'Python',
     dockerFirst: 'partial',
     selfImproving: true,
@@ -122,8 +102,8 @@ export const COMPETITORS: Competitor[] = [
   },
   {
     name: 'TypeClaw',
-    strength: 'TypeScript end to end',
-    tradeoff: 'the answer',
+    strength: 'One TS codebase, plugins as imports',
+    tradeoff: 'younger, smaller ecosystem',
     lang: 'TypeScript',
     dockerFirst: true,
     selfImproving: true,

--- a/docs/src/app/_components/use-case-tabs.tsx
+++ b/docs/src/app/_components/use-case-tabs.tsx
@@ -8,19 +8,19 @@ const USE_CASES = [
     id: 'personal',
     label: 'Personal',
     icon: User,
-    text: 'Track your reading list, summarize newsletters, manage your calendar, remember your preferences — one agent that learns how you work.',
+    text: 'Summarize newsletters, manage your calendar, remember how you like things done — and open memory/ in git to see exactly what it learned about you. Your assistant, your data, your folder.',
   },
   {
     id: 'team',
     label: 'Team',
     icon: Users,
-    text: 'Review code, triage issues, deploy with confidence, keep the standup notes — your agent knows your codebase and your team.',
+    text: 'Review PRs, triage issues, keep the standup notes. Add the one tool your team needs in a .ts file you actually own — no waiting on a marketplace, no plugin language to learn.',
   },
   {
     id: 'creator',
     label: 'Creator',
     icon: PenTool,
-    text: 'Pipeline content, cross-post to channels, reply to audience, track analytics — an agent that grows with your brand.',
+    text: 'Pipeline content, cross-post to channels, reply to your audience. As it learns your voice, that memory is plain files you can read and edit — never a black box you have to trust.',
   },
 ]
 

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -14,15 +14,17 @@ const PLUGIN_CODE = `import { definePlugin } from 'typeclaw/plugin'
 import { z } from 'zod'
 
 export default definePlugin({
+  configSchema: z.object({ webhook: z.string().url() }),
   async plugin(ctx) {
+    const { webhook } = ctx.config
     return {
       tools: {
-        triage: {
-          description: 'Summarize a pull request diff',
-          parameters: z.object({ pr: z.number() }),
-          async execute({ pr }) {
-            const diff = await ctx.gh.getDiff(pr)
-            return { content: [{ type: 'text', text: summarize(diff) }] }
+        notify: {
+          description: 'Post a short notification',
+          parameters: z.object({ text: z.string() }),
+          async execute({ text }) {
+            await fetch(webhook, { method: 'POST', body: text })
+            return { content: [{ type: 'text', text: 'sent' }] }
           },
         },
       },

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,19 +1,4 @@
-import {
-  ArrowRight,
-  BookOpen,
-  Check,
-  Container,
-  Github,
-  Lock,
-  PenTool,
-  Quote,
-  Shield,
-  Sparkles,
-  Star,
-  User,
-  Users,
-  X,
-} from 'lucide-react'
+import { ArrowRight, BookOpen, Check, Container, Github, Lock, Shield, Sparkles, Star, X } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 
@@ -25,17 +10,24 @@ import { Reveal } from './_components/reveal'
 import { ThemeToggle } from './_components/theme-toggle'
 import { UseCaseTabs } from './_components/use-case-tabs'
 
-const PLUGIN_CODE = `import { definePlugin } from 'typeclaw'
+const PLUGIN_CODE = `import { definePlugin } from 'typeclaw/plugin'
+import { z } from 'zod'
 
 export default definePlugin({
-  name: 'pr-review',
-  tools: {
-    triage: async ({ pr }) => {
-      const diff = await gh.getDiff(pr)
-      return summarize(diff)
-    },
+  async plugin(ctx) {
+    return {
+      tools: {
+        triage: {
+          description: 'Summarize a pull request diff',
+          parameters: z.object({ pr: z.number() }),
+          async execute({ pr }) {
+            const diff = await ctx.gh.getDiff(pr)
+            return { content: [{ type: 'text', text: summarize(diff) }] }
+          },
+        },
+      },
+    }
   },
-  skills: ['skills/pr-review.md'],
 })`
 
 function HeroInstall() {
@@ -210,7 +202,7 @@ function MarketingTable() {
             <th className="px-4 py-4 text-center font-medium">Self-improving</th>
             <th className="px-4 py-4 text-center font-medium">Multi-channel</th>
             <th className="px-4 py-4 text-center font-medium">Full-featured plugins</th>
-            <th className="px-4 py-4 text-center font-medium">Git-native</th>
+            <th className="px-4 py-4 text-center font-medium">Auto-commit &amp; push</th>
             <th className="px-4 py-4 text-center font-medium">Permission system</th>
             <th className="px-4 py-4 font-medium">Notes</th>
           </tr>
@@ -305,22 +297,39 @@ function PermissionsVisual() {
   )
 }
 
-function Testimonial() {
+function LiveProof() {
   return (
     <div className="mx-auto max-w-3xl">
-      <div className="relative rounded-2xl border border-brand-100 bg-gradient-to-br from-brand-50/80 to-white p-10 dark:border-brand-900/40 dark:from-brand-950/40 dark:to-zinc-950">
-        <Quote
-          className="absolute top-6 left-6 size-8 text-brand-200 dark:text-brand-800"
-          strokeWidth={2.4}
-          aria-hidden
-        />
-        <blockquote className="relative pt-8 text-center">
-          <p className="text-xl font-medium leading-relaxed text-zinc-800 dark:text-zinc-100 sm:text-2xl">
-            &ldquo;Last week I told my agent I prefer kebab-case for filenames. Yesterday it suggested a rename without
-            me asking.&rdquo;
-          </p>
-          <footer className="mt-6 text-sm text-zinc-500 dark:text-zinc-500">— A TypeClaw user</footer>
-        </blockquote>
+      <div className="relative overflow-hidden rounded-2xl border border-brand-100 bg-gradient-to-br from-brand-50/80 to-white p-10 text-center dark:border-brand-900/40 dark:from-brand-950/40 dark:to-zinc-950">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 font-mono text-[11px] font-medium tracking-wider text-emerald-700 uppercase dark:bg-emerald-900/30 dark:text-emerald-300">
+          <span className="size-1.5 animate-pulse rounded-full bg-emerald-500" aria-hidden />
+          Live right now
+        </span>
+        <p className="mx-auto mt-6 max-w-xl text-balance text-xl font-medium leading-relaxed text-zinc-800 dark:text-zinc-100 sm:text-2xl">
+          This page&apos;s mascot reviews real pull requests on TypeClaw&apos;s own repo — unprompted, line by line.
+        </p>
+        <p className="mx-auto mt-4 max-w-lg text-balance text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+          Request{' '}
+          <a
+            href="https://github.com/typeey"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-brand-700 underline-offset-2 hover:underline dark:text-brand-300"
+          >
+            @typeey
+          </a>{' '}
+          as a reviewer and it reads the diff, thinks it through, and posts a formal review back. No human pressing a
+          button. The whole setup is one recipe you can copy.
+        </p>
+        <div className="mt-7">
+          <Link
+            href="/docs/recipes/code-reviewer"
+            className="inline-flex items-center gap-2 rounded-xl border border-brand-200 bg-white px-5 py-2.5 text-sm font-medium text-brand-800 shadow-sm transition-all hover:translate-y-[-1px] hover:shadow-md dark:border-brand-800/60 dark:bg-zinc-900 dark:text-brand-200"
+          >
+            See how it&apos;s wired
+            <ArrowRight className="size-4" strokeWidth={2.4} aria-hidden />
+          </Link>
+        </div>
       </div>
     </div>
   )
@@ -370,7 +379,7 @@ export default function Home() {
           <div className="relative z-10 mx-auto max-w-4xl px-6 pt-16 pb-32 text-center sm:pt-24">
             <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white/60 px-3 py-1 text-xs font-medium text-zinc-600 backdrop-blur dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-zinc-400">
               <Sparkles className="size-3.5 text-brand-600 dark:text-brand-300" strokeWidth={2.4} aria-hidden />
-              {VERSION} · TypeScript agent runtime
+              {VERSION} · crafted in every detail
             </div>
             <div className="relative mt-8">
               <Image
@@ -383,26 +392,26 @@ export default function Home() {
                 className="pointer-events-none absolute top-1/2 right-[-60px] -z-10 hidden w-44 -translate-y-1/2 -rotate-6 select-none lg:block xl:right-[-80px] xl:w-52"
               />
               <h1 className="text-balance text-6xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">
-                The agent that
+                The agent for
                 <br />
                 <span className="bg-gradient-to-br from-brand-700 to-brand-500 bg-clip-text text-transparent dark:from-brand-200 dark:to-brand-400">
-                  keeps its nest tidy.
+                  perfectionists.
                 </span>
               </h1>
             </div>
             <p className="mx-auto mt-7 max-w-xl text-balance text-lg leading-relaxed text-zinc-600 dark:text-zinc-400">
-              A TypeScript agent that lives in one folder, distills its own work into long-term memory, and gets sharper
-              the longer it runs.
+              Crafted in every detail — it behaves in your team&apos;s chat and gets sharper the longer it runs.
+              Sandboxed and self-managing.
             </p>
             <div className="mt-10">
               <HeroInstall />
             </div>
             <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <Link
-                href="/docs/guides/getting-started"
+                href="/docs/guides/quickstart"
                 className="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-5 py-3 text-sm font-medium text-white shadow-sm transition-all hover:translate-y-[-1px] hover:bg-brand-800 hover:shadow-md dark:bg-brand-600 dark:hover:bg-brand-500"
               >
-                Read the docs
+                Start in 5 minutes
                 <ArrowRight className="size-4" strokeWidth={2.4} aria-hidden />
               </Link>
               <a
@@ -427,14 +436,15 @@ export default function Home() {
         <section className="mx-auto max-w-6xl px-6 py-36">
           <Reveal className="text-center">
             <p className="font-mono text-xs tracking-[0.2em] text-brand-700 uppercase dark:text-brand-300">
-              Self-improving
+              Memory you can read
             </p>
             <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-              It remembers. It learns. It gets sharper while you sleep.
+              It gets sharper while you sleep — and you can read every word it learned.
             </h2>
             <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-zinc-600 dark:text-zinc-400">
-              Every conversation, every command, every insight — your agent watches its own work, then a dreaming
-              subagent distills it into long-term memory and reusable skills. No prompts to write. It just gets better.
+              A dreaming subagent distills each day&apos;s work into long-term memory and reusable skills. It all lands
+              as plain files, committed to git — so you can review what it picked up, revert what it got wrong, and own
+              its memory like the rest of your code. Self-improving, never a black box.
             </p>
           </Reveal>
           <Reveal className="mx-auto mt-12 max-w-lg" delay={120}>
@@ -447,27 +457,27 @@ export default function Home() {
         <section className="mx-auto max-w-6xl space-y-36 px-6 py-36">
           <Reveal>
             <FeatureRow
-              eyebrow="Just a folder"
-              title="One folder. One agent. No mess."
-              blurb="Drop it in any folder. One command, and it's alive. Its own .env, its own memory, its own channels. When you're done, delete the folder — it's gone. No global install, no residue."
+              eyebrow="Plugins are just imports"
+              title="Extend it from inside the language you already use."
+              blurb="No plugin DSL, no IPC, no FFI, no sidecar process. A plugin is a plain .ts file that imports the runtime and adds tools, skills, channels, and commands. The same TypeScript, all the way down — nothing to bolt on."
+              visual={<PluginCode />}
+            />
+          </Reveal>
+          <Reveal>
+            <FeatureRow
+              eyebrow="One folder, one container"
+              title="A whole agent you can hold in your head."
+              blurb="It lives in a single folder and runs in its own container — its own .env, its own memory, its own channels. The container is the trust boundary; nothing it does reaches the rest of your machine. Done with it? Delete the folder. It's gone, no residue."
+              reverse
               visual={<SandboxDiagram />}
             />
           </Reveal>
           <Reveal>
             <FeatureRow
-              eyebrow="Safe by design"
-              title="You're in control. Always."
-              blurb="Owner, trusted, member, guest — role-based permissions gate every action. A Slack stranger can't tell your agent to push to main. You can. The agent knows who's in the room and what they can do."
-              reverse
+              eyebrow="You hold the keys"
+              title="A stranger in Slack can't push to main. You can."
+              blurb="Owner, trusted, member, guest — role-based permissions gate every action, per channel. The agent knows who's in the room and exactly what they're allowed to ask for. Powerful in your hands, harmless in everyone else's."
               visual={<PermissionsVisual />}
-            />
-          </Reveal>
-          <Reveal>
-            <FeatureRow
-              eyebrow="Plugins as imports"
-              title="Teach it something new? Just write TypeScript."
-              blurb="No IPC, no FFI, no weird config files. Plain .ts files that contribute tools, skills, channels, and commands — all in the language you already write."
-              visual={<PluginCode />}
             />
           </Reveal>
         </section>
@@ -478,7 +488,7 @@ export default function Home() {
               one minute, end to end
             </p>
             <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-              Four commands. It&apos;s live.
+              Three commands in. It&apos;s already learning.
             </h2>
           </Reveal>
           <Reveal delay={120}>
@@ -498,7 +508,7 @@ export default function Home() {
 
         <section className="mx-auto max-w-6xl px-6 pb-36">
           <Reveal>
-            <Testimonial />
+            <LiveProof />
           </Reveal>
         </section>
 
@@ -508,10 +518,12 @@ export default function Home() {
               how it compares
             </p>
             <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-              There are great agents. None had the right shape.
+              OpenClaw is the platform. TypeClaw is the codebase.
             </h2>
-            <p className="mx-auto mt-4 max-w-xl text-base text-zinc-600 dark:text-zinc-400">
-              If you live in TypeScript and want plugins that are just imports, here&apos;s the honest landscape.
+            <p className="mx-auto mt-4 max-w-2xl text-base text-zinc-600 dark:text-zinc-400">
+              These are all good — genuinely. Reach for OpenClaw when you want the biggest ecosystem, Hermes when Python
+              is your stack, the lighter runtimes when you want a single binary. Reach for TypeClaw when you want a
+              runtime you can read end to end, extend with an import, and keep as your own.
             </p>
           </Reveal>
           <Reveal delay={120}>
@@ -530,17 +542,18 @@ export default function Home() {
           />
           <Reveal className="relative mx-auto max-w-3xl px-6 text-center">
             <Image src="/typeey-cutout.png" alt="" width={120} height={120} aria-hidden className="mx-auto" />
-            <h2 className="mt-4 text-balance text-5xl font-semibold tracking-tight sm:text-6xl">Ready to try it?</h2>
+            <h2 className="mt-4 text-balance text-5xl font-semibold tracking-tight sm:text-6xl">Make it yours.</h2>
             <p className="mx-auto mt-4 max-w-lg text-balance text-base text-zinc-600 dark:text-zinc-400">
-              One command, one folder, one container. Trying it costs nothing.
+              One folder, one container, one language you already know. Spin one up, read the whole thing, fork it if
+              you like. Trying it costs nothing.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <Link
-                href="/docs/guides/getting-started"
+                href="/docs/guides/quickstart"
                 className="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-6 py-3 text-sm font-medium text-white shadow-sm transition-all hover:translate-y-[-1px] hover:bg-brand-800 hover:shadow-md dark:bg-brand-600 dark:hover:bg-brand-500"
               >
                 <BookOpen className="size-4" strokeWidth={2.4} aria-hidden />
-                Read the docs
+                Start in 5 minutes
               </Link>
               <a
                 href="https://github.com/typeclaw/typeclaw"
@@ -564,7 +577,7 @@ export default function Home() {
               <span className="text-sm font-semibold tracking-tight">typeclaw</span>
             </div>
             <p className="mt-3 max-w-xs text-sm leading-relaxed text-zinc-500 dark:text-zinc-500">
-              A TypeScript-native, Bun-powered, Docker-friendly general-purpose agent runtime.
+              The agent runtime you can own — one TypeScript codebase, plugins as imports, memory you can read.
             </p>
             <p className="mt-6 text-xs text-zinc-400 dark:text-zinc-600">© {new Date().getFullYear()} typeclaw · MIT</p>
           </div>


### PR DESCRIPTION
## Background

The landing page hero was generic and its supporting content had three bugs introduced when copy drifted from the actual codebase.

## Summary

Reworks the landing-page hero around a sharper positioning, and fixes a few accuracy bugs found while auditing the page against the codebase.

### Hero
- **H1:** *The agent for perfectionists.*
- **Sub:** *Crafted in every detail — it behaves in your team's chat and gets sharper the longer it runs. Sandboxed and self-managing.*
- Badge updated to match the new tone.
- **README** tagline aligned with the new hero.

### Accuracy fixes (verified against `src/`)
- **LINE was missing** from the channels bar despite being a fully implemented adapter (`src/channels/adapters/line*`). Added it with a `/docs/reference/line` link.
- **Hero plugin code sample didn't compile** — wrong import path (`'typeclaw'` → `'typeclaw/plugin'`), a non-existent `name` field, and the wrong tool shape. Replaced with the real minimal `definePlugin` API from the plugin guide.
- **"Git-native" comparison column** overstated git's role (git is a persistence/backup layer, not the data model). Reworded to **"Auto-commit & push"**.

### Also included
- Competitor table + use-case copy refresh (from the same landing-page pass).

## Preview

Hero copy and plugin sample visible on the `/` route after `bun run build` (docs).

## What this does NOT do

- Does not touch any `src/` production code or config schema.
- Does not change the plugin API or LINE adapter behavior — only the docs and landing page reflect what already exists.

## Review notes

- Load-bearing: the plugin sample in the hero is now the real `definePlugin` signature from the plugin guide — reviewers should verify it still matches `typeclaw/plugin` exports if those change.
- `bun run lint` / `format` (docs): clean
- `bun run build` (docs, typechecks): passes; all routes generate including `/`
- Root `typecheck` / `lint` (0 errors) / `format:check`: clean
- **Note:** `bun run test` has one failing test — `typeclaw.schema.json … (drift guard)`. Confirmed pre-existing on `main` (fails identically on a clean checkout) and unrelated to this PR, which touches only `README.md` and `docs/`.