### PR TITLE
feat(docs): mouse-follow spotlight on landing hero

### DIFF
--- a/docs/src/app/_components/hero-spotlight.tsx
+++ b/docs/src/app/_components/hero-spotlight.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+interface HeroSpotlightProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function HeroSpotlight({ children, className = '' }: HeroSpotlightProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    let rafId = 0
+    let nextX = 50
+    let nextY = 30
+
+    const apply = () => {
+      rafId = 0
+      el.style.setProperty('--mx', `${nextX}%`)
+      el.style.setProperty('--my', `${nextY}%`)
+    }
+
+    const schedule = () => {
+      if (rafId === 0) rafId = requestAnimationFrame(apply)
+    }
+
+    const onMove = (e: PointerEvent) => {
+      const rect = el.getBoundingClientRect()
+      nextX = ((e.clientX - rect.left) / rect.width) * 100
+      nextY = ((e.clientY - rect.top) / rect.height) * 100
+      schedule()
+    }
+
+    const onLeave = () => {
+      nextX = 50
+      nextY = 30
+      schedule()
+    }
+
+    el.addEventListener('pointermove', onMove)
+    el.addEventListener('pointerleave', onLeave)
+    return () => {
+      el.removeEventListener('pointermove', onMove)
+      el.removeEventListener('pointerleave', onLeave)
+      if (rafId !== 0) cancelAnimationFrame(rafId)
+    }
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      className={`hero-spotlight ${className}`}
+      style={{ ['--mx' as string]: '50%', ['--my' as string]: '30%' }}
+    >
+      <div aria-hidden className="hero-spotlight-glow" />
+      {children}
+    </div>
+  )
+}

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -50,11 +50,7 @@
       rgba(111, 126, 184, 0.06) 45%,
       rgba(111, 126, 184, 0) 100%
     ),
-    radial-gradient(
-      80% 60% at 50% -10%,
-      rgba(195, 202, 230, 0.35) 0%,
-      rgba(195, 202, 230, 0) 70%
-    );
+    radial-gradient(80% 60% at 50% -10%, rgba(195, 202, 230, 0.35) 0%, rgba(195, 202, 230, 0) 70%);
   transition: background 240ms ease-out;
 }
 
@@ -66,11 +62,7 @@
       rgba(77, 93, 158, 0.06) 50%,
       rgba(13, 23, 54, 0) 100%
     ),
-    radial-gradient(
-      90% 60% at 50% -10%,
-      rgba(54, 72, 132, 0.28) 0%,
-      rgba(13, 23, 54, 0) 70%
-    );
+    radial-gradient(90% 60% at 50% -10%, rgba(54, 72, 132, 0.28) 0%, rgba(13, 23, 54, 0) 70%);
 }
 
 /* Lit headline: the gradient origin tracks the pointer so "perfectionists"

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -30,3 +30,77 @@
 .dark {
   --color-fd-primary: var(--color-brand-300);
 }
+
+/* Mouse-follow spotlight for the hero. --mx / --my are set by HeroSpotlight; the
+   defaults render a static top-center glow on SSR and for reduced-motion users. */
+.hero-spotlight {
+  position: relative;
+  isolation: isolate;
+}
+
+.hero-spotlight-glow {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(
+      28% 22% at var(--mx) var(--my),
+      rgba(111, 126, 184, 0.16) 0%,
+      rgba(111, 126, 184, 0.06) 45%,
+      rgba(111, 126, 184, 0) 100%
+    ),
+    radial-gradient(
+      80% 60% at 50% -10%,
+      rgba(195, 202, 230, 0.35) 0%,
+      rgba(195, 202, 230, 0) 70%
+    );
+  transition: background 240ms ease-out;
+}
+
+.dark .hero-spotlight-glow {
+  background:
+    radial-gradient(
+      26% 20% at var(--mx) var(--my),
+      rgba(157, 167, 210, 0.14) 0%,
+      rgba(77, 93, 158, 0.06) 50%,
+      rgba(13, 23, 54, 0) 100%
+    ),
+    radial-gradient(
+      90% 60% at 50% -10%,
+      rgba(54, 72, 132, 0.28) 0%,
+      rgba(13, 23, 54, 0) 70%
+    );
+}
+
+/* Lit headline: the gradient origin tracks the pointer so "perfectionists"
+   appears to catch a moving highlight. No outer glow — a uniform drop-shadow
+   would halo even the unlit side of the word, contradicting the gradient. */
+.hero-lit-text {
+  background-image: radial-gradient(
+    70% 120% at var(--mx) var(--my),
+    var(--color-brand-300) 0%,
+    var(--color-brand-500) 35%,
+    var(--color-brand-700) 70%
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+.dark .hero-lit-text {
+  background-image: radial-gradient(
+    70% 120% at var(--mx) var(--my),
+    #eef1fb 0%,
+    var(--color-brand-200) 30%,
+    var(--color-brand-400) 65%,
+    var(--color-brand-600) 100%
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-spotlight-glow {
+    transition: none;
+  }
+}

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -6,6 +6,7 @@ import { AnimatedTerminal } from './_components/animated-terminal'
 import { CHANNELS } from './_components/channel-icons'
 import { CopyButton } from './_components/copy-button'
 import { COMPETITORS, INSTALL_COMMAND, MEMORY_LOOP, VERSION } from './_components/data'
+import { HeroSpotlight } from './_components/hero-spotlight'
 import { Reveal } from './_components/reveal'
 import { ThemeToggle } from './_components/theme-toggle'
 import { UseCaseTabs } from './_components/use-case-tabs'
@@ -378,55 +379,55 @@ export default function Home() {
       <main>
         <section className="relative overflow-hidden">
           <DotGrid />
-          <div className="relative z-10 mx-auto max-w-4xl px-6 pt-16 pb-32 text-center sm:pt-24">
-            <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white/60 px-3 py-1 text-xs font-medium text-zinc-600 backdrop-blur dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-zinc-400">
-              <Sparkles className="size-3.5 text-brand-600 dark:text-brand-300" strokeWidth={2.4} aria-hidden />
-              {VERSION} · crafted in every detail
+          <HeroSpotlight>
+            <div className="relative z-10 mx-auto max-w-4xl px-6 pt-16 pb-32 text-center sm:pt-24">
+              <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white/60 px-3 py-1 text-xs font-medium text-zinc-600 backdrop-blur dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-zinc-400">
+                <Sparkles className="size-3.5 text-brand-600 dark:text-brand-300" strokeWidth={2.4} aria-hidden />
+                {VERSION} · crafted in every detail
+              </div>
+              <div className="relative mt-8">
+                <Image
+                  src="/typeey-cutout.png"
+                  alt=""
+                  width={895}
+                  height={858}
+                  aria-hidden
+                  priority
+                  className="pointer-events-none absolute top-1/2 right-[-60px] -z-10 hidden w-44 -translate-y-1/2 -rotate-6 select-none lg:block xl:right-[-80px] xl:w-52"
+                />
+                <h1 className="text-balance text-6xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">
+                  The agent for
+                  <br />
+                  <span className="hero-lit-text">perfectionists.</span>
+                </h1>
+              </div>
+              <p className="mx-auto mt-7 max-w-xl text-balance text-lg leading-relaxed text-zinc-600 dark:text-zinc-400">
+                Crafted in every detail — it behaves in your team&apos;s chat and gets sharper the longer it runs.
+                Sandboxed and self-managing.
+              </p>
+              <div className="mt-10">
+                <HeroInstall />
+              </div>
+              <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Link
+                  href="/docs/guides/quickstart"
+                  className="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-5 py-3 text-sm font-medium text-white shadow-sm transition-all hover:translate-y-[-1px] hover:bg-brand-800 hover:shadow-md dark:bg-brand-600 dark:hover:bg-brand-500"
+                >
+                  Start in 5 minutes
+                  <ArrowRight className="size-4" strokeWidth={2.4} aria-hidden />
+                </Link>
+                <a
+                  href="https://github.com/typeclaw/typeclaw"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-xl border border-zinc-300 bg-white px-5 py-3 text-sm font-medium text-zinc-800 transition-all hover:border-zinc-400 hover:shadow-sm dark:border-white/[0.12] dark:bg-white/[0.02] dark:text-zinc-200 dark:hover:border-white/[0.2]"
+                >
+                  <Star className="size-4" strokeWidth={2.4} aria-hidden />
+                  Star on GitHub
+                </a>
+              </div>
             </div>
-            <div className="relative mt-8">
-              <Image
-                src="/typeey-cutout.png"
-                alt=""
-                width={895}
-                height={858}
-                aria-hidden
-                priority
-                className="pointer-events-none absolute top-1/2 right-[-60px] -z-10 hidden w-44 -translate-y-1/2 -rotate-6 select-none lg:block xl:right-[-80px] xl:w-52"
-              />
-              <h1 className="text-balance text-6xl font-semibold tracking-tight sm:text-7xl lg:text-8xl">
-                The agent for
-                <br />
-                <span className="bg-gradient-to-br from-brand-700 to-brand-500 bg-clip-text text-transparent dark:from-brand-200 dark:to-brand-400">
-                  perfectionists.
-                </span>
-              </h1>
-            </div>
-            <p className="mx-auto mt-7 max-w-xl text-balance text-lg leading-relaxed text-zinc-600 dark:text-zinc-400">
-              Crafted in every detail — it behaves in your team&apos;s chat and gets sharper the longer it runs.
-              Sandboxed and self-managing.
-            </p>
-            <div className="mt-10">
-              <HeroInstall />
-            </div>
-            <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:flex-row">
-              <Link
-                href="/docs/guides/quickstart"
-                className="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-5 py-3 text-sm font-medium text-white shadow-sm transition-all hover:translate-y-[-1px] hover:bg-brand-800 hover:shadow-md dark:bg-brand-600 dark:hover:bg-brand-500"
-              >
-                Start in 5 minutes
-                <ArrowRight className="size-4" strokeWidth={2.4} aria-hidden />
-              </Link>
-              <a
-                href="https://github.com/typeclaw/typeclaw"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-xl border border-zinc-300 bg-white px-5 py-3 text-sm font-medium text-zinc-800 transition-all hover:border-zinc-400 hover:shadow-sm dark:border-white/[0.12] dark:bg-white/[0.02] dark:text-zinc-200 dark:hover:border-white/[0.2]"
-              >
-                <Star className="size-4" strokeWidth={2.4} aria-hidden />
-                Star on GitHub
-              </a>
-            </div>
-          </div>
+          </HeroSpotlight>
         </section>
 
         <section className="border-y border-zinc-100 bg-zinc-50/50 py-16 dark:border-white/[0.04] dark:bg-white/[0.01]">


### PR DESCRIPTION
## Summary

- Hero now has a soft pointer-following spotlight: small radial glow tracks `--mx` / `--my` CSS variables that a new `HeroSpotlight` client component updates on `pointermove`, rAF-throttled and cancelled on unmount.
- "perfectionists" picks up the same gradient via `background-clip:text`, so the lit side of the word brightens where the spotlight falls. No outer drop-shadow — a uniform halo glowed the unlit side too and read as a contradiction.
- Ambient top-center hue stays on as the static fallback for SSR, no-JS, and `prefers-reduced-motion` users (the move listener is skipped entirely in that case).

Tuning round after first cut: shrank the moving glow from `55% 45%` → `28% 22%` and halved its peak alpha so it feels like a hint of light instead of a roaming gradient.

## Test plan

- [ ] Light + dark mode: confirm the moving glow is subtle and the "perfectionists" gradient brightens toward the cursor
- [ ] `prefers-reduced-motion: reduce` set → spotlight stays at the static top-center position, no tracking
- [ ] JS disabled → static glow still renders (inline CSS-var defaults)
- [ ] Mobile / touch: confirm scrolling still works (pointermove fires but the effect is subtle on small viewports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)