### PR TITLE
docs(landing): capability grid + honest comparison table

### DIFF
--- a/docs/src/app/_components/data.ts
+++ b/docs/src/app/_components/data.ts
@@ -30,12 +30,14 @@ export interface Competitor {
   strength: string
   tradeoff: string
   lang: string
-  dockerFirst: CompetitorScore
-  selfImproving: CompetitorScore
-  multiChannel: CompetitorScore
-  fullFeaturedPlugins: CompetitorScore
-  gitNative: CompetitorScore
-  permissionSystem: CompetitorScore
+  readableMemory: CompetitorScore
+  knowsWhenToTalk: CompetitorScore
+  perAgentIsolation: CompetitorScore
+  pluginsAsImports: CompetitorScore
+  permissionsGuards: CompetitorScore
+  perAgentGitRepo: CompetitorScore
+  selfManaging: CompetitorScore
+  channels: CompetitorScore
   highlight?: boolean
 }
 
@@ -45,74 +47,64 @@ export const COMPETITORS: Competitor[] = [
     strength: 'Biggest ecosystem',
     tradeoff: 'a platform to learn, not a codebase to read',
     lang: 'TypeScript',
-    dockerFirst: true,
-    selfImproving: 'partial',
-    multiChannel: true,
-    fullFeaturedPlugins: true,
-    gitNative: false,
-    permissionSystem: true,
-  },
-  {
-    name: 'NanoClaw',
-    strength: 'Minimal',
-    tradeoff: 'no real plugin system',
-    lang: 'TypeScript',
-    dockerFirst: false,
-    selfImproving: false,
-    multiChannel: false,
-    fullFeaturedPlugins: false,
-    gitNative: false,
-    permissionSystem: true,
-  },
-  {
-    name: 'PicoClaw',
-    strength: 'Ultralight',
-    tradeoff: 'plugins live outside the runtime',
-    lang: 'Go',
-    dockerFirst: false,
-    selfImproving: false,
-    multiChannel: 'partial',
-    fullFeaturedPlugins: 'partial',
-    gitNative: false,
-    permissionSystem: false,
-  },
-  {
-    name: 'ZeroClaw',
-    strength: 'Single binary',
-    tradeoff: 'plugins live outside the runtime',
-    lang: 'Rust',
-    dockerFirst: false,
-    selfImproving: false,
-    multiChannel: 'partial',
-    fullFeaturedPlugins: 'partial',
-    gitNative: false,
-    permissionSystem: true,
+    readableMemory: 'partial',
+    knowsWhenToTalk: true,
+    perAgentIsolation: true,
+    pluginsAsImports: true,
+    permissionsGuards: true,
+    perAgentGitRepo: 'partial',
+    selfManaging: true,
+    channels: true,
   },
   {
     name: 'Hermes Agent',
     strength: 'Mature, self-improving',
     tradeoff: 'Python — a boundary if your stack is TS',
     lang: 'Python',
-    dockerFirst: 'partial',
-    selfImproving: true,
-    multiChannel: true,
-    fullFeaturedPlugins: true,
-    gitNative: 'partial',
-    permissionSystem: false,
+    readableMemory: true,
+    knowsWhenToTalk: 'partial',
+    perAgentIsolation: 'partial',
+    pluginsAsImports: false,
+    permissionsGuards: true,
+    perAgentGitRepo: true,
+    selfManaging: true,
+    channels: true,
   },
   {
     name: 'TypeClaw',
     strength: 'One TS codebase, plugins as imports',
     tradeoff: 'younger, smaller ecosystem',
     lang: 'TypeScript',
-    dockerFirst: true,
-    selfImproving: true,
-    multiChannel: true,
-    fullFeaturedPlugins: true,
-    gitNative: true,
-    permissionSystem: true,
+    readableMemory: true,
+    knowsWhenToTalk: true,
+    perAgentIsolation: true,
+    pluginsAsImports: true,
+    permissionsGuards: true,
+    perAgentGitRepo: true,
+    selfManaging: true,
+    channels: true,
     highlight: true,
   },
+]
+
+type ScoreKey = {
+  [K in keyof Competitor]-?: Competitor[K] extends CompetitorScore ? K : never
+}[keyof Competitor]
+
+export interface ComparisonFeature {
+  key: ScoreKey
+  label: string
+}
+
+export const COMPARISON_FEATURES: ComparisonFeature[] = [
+  { key: 'readableMemory', label: 'Memory you can read' },
+  { key: 'knowsWhenToTalk', label: 'Knows when not to talk' },
+  { key: 'perAgentIsolation', label: 'Per-agent isolation' },
+  { key: 'pluginsAsImports', label: 'Plugins as imports' },
+  { key: 'permissionsGuards', label: 'Permissions & guards' },
+  { key: 'perAgentGitRepo', label: 'Per-agent git repo' },
+  { key: 'selfManaging', label: 'Self-managing' },
+  { key: 'channels', label: 'Channels' },
 ]
 
 export interface MemoryStage {

--- a/docs/src/app/_components/features-data.ts
+++ b/docs/src/app/_components/features-data.ts
@@ -1,0 +1,324 @@
+import {
+  Box,
+  Clock,
+  Globe,
+  Inbox,
+  LayoutGrid,
+  type LucideIcon,
+  MessagesSquare,
+  Network,
+  Plug,
+  RefreshCw,
+  Shield,
+  Sprout,
+  Terminal,
+  Users,
+} from 'lucide-react'
+
+export interface FeatureBullet {
+  title: string
+  detail: string
+}
+
+export interface FeatureCategory {
+  id: string
+  icon: LucideIcon
+  title: string
+  tagline: string
+  summary: string
+  bullets: FeatureBullet[]
+  featured?: boolean
+}
+
+export const FEATURE_CATEGORIES: FeatureCategory[] = [
+  {
+    id: 'self-improving',
+    icon: Sprout,
+    title: 'Self-improving',
+    tagline: 'a learning loop, not a black box',
+    summary: 'It distills each day of work into long-term memory and reusable skills you can read in git.',
+    featured: true,
+    bullets: [
+      { title: 'Memory', detail: 'logs its own work to a daily stream as it goes.' },
+      {
+        title: 'Dreaming',
+        detail:
+          "a subagent distills each day's work into long-term memory, committed to git as plain files you can read, diff, and revert.",
+      },
+      {
+        title: 'Muscle memory',
+        detail: 'recurring procedures become reusable skills it writes for itself and loads on later runs.',
+      },
+      {
+        title: 'Optional embedding recall',
+        detail:
+          'hybrid keyword-and-embedding search over the same markdown memory, off by default; the plain files remain the durable source of truth.',
+      },
+    ],
+  },
+  {
+    id: 'group-chat',
+    icon: MessagesSquare,
+    title: 'Group chat',
+    tagline: 'knows when not to talk',
+    summary: 'It reads the room, tells humans from bots, and stays quiet when a message was not meant for it.',
+    featured: true,
+    bullets: [
+      {
+        title: 'Room awareness',
+        detail:
+          "knows who's present and tells humans from bots, so it stays quiet when people are talking to each other rather than chiming in on messages it wasn't part of.",
+      },
+      {
+        title: 'Sticky engagement',
+        detail:
+          'holds an ongoing thread after replying without needing to be re-mentioned, then steps back when the conversation moves on. Multilingual continuation detection, peer-bot loop guards, and flood filters keep it from spiraling.',
+      },
+    ],
+  },
+  {
+    id: 'scheduling',
+    icon: Clock,
+    title: 'Scheduling',
+    tagline: 'on its own clock',
+    summary: 'Recurring prompts or shell commands and future reminders, fired at a timezone-safe instant.',
+    featured: true,
+    bullets: [
+      {
+        title: 'Recurring tasks',
+        detail: 'scheduled prompts or shell commands, with per-job coalescing and timezone support.',
+      },
+      {
+        title: 'Future reminders',
+        detail: 'schedule a prompt or command to fire later at a timezone-safe instant.',
+      },
+    ],
+  },
+  {
+    id: 'web-research',
+    icon: Globe,
+    title: 'Web & research',
+    tagline: 'reads the web like a person',
+    summary: 'It searches the live web, reads pages as articles, and drives a real browser when a site needs one.',
+    bullets: [
+      {
+        title: 'Live web search & fetch',
+        detail: 'pull a page as a readable article, a JSON query, a selected slice, a grep, or raw.',
+      },
+      {
+        title: 'Browser-like fetching',
+        detail: "replays a real browser fingerprint so requests aren't rejected by sites that block generic clients.",
+      },
+      {
+        title: 'Interactive browser sessions',
+        detail: 'drives a browser on live pages, with a dashboard you can step into for logins, 2FA, or CAPTCHA.',
+      },
+    ],
+  },
+  {
+    id: 'channels',
+    icon: Inbox,
+    title: 'Channels',
+    tagline: 'one agent, many inboxes',
+    summary: 'Slack, Discord, Telegram, LINE, KakaoTalk, GitHub, and a websocket TUI, driven by the same agent.',
+    bullets: [
+      {
+        title: 'Supported channels',
+        detail: 'Slack, Discord, Telegram, LINE, KakaoTalk, GitHub, and a websocket TUI, driven by the same agent.',
+      },
+      {
+        title: 'Pull-request review',
+        detail:
+          "treats a GitHub PR as a conversation, reviewing as a participant, with guards against claiming a verdict it didn't actually post and against leaving a PR stranded.",
+      },
+    ],
+  },
+  {
+    id: 'security',
+    icon: Shield,
+    title: 'Security',
+    tagline: 'defense-in-depth for risky actions',
+    summary: 'Layered guards, role gates, per-channel match rules, and encryption at rest for sensitive credentials.',
+    featured: true,
+    bullets: [
+      {
+        title: 'Layered guards',
+        detail:
+          'stop secret exfiltration, SSRF, prompt injection, rogue git pushes, and silent privilege escalation before they fire.',
+      },
+      {
+        title: 'Roles',
+        detail: 'owner, trusted, member, and guest gate privileged actions.',
+      },
+      {
+        title: 'Permissions',
+        detail:
+          "per-channel match rules decide who can ask for what; an untrusted channel user can't trigger privileged behavior.",
+      },
+      {
+        title: 'Encryption at rest',
+        detail:
+          'sensitive channel passwords are sealed with authenticated encryption; the key is host-held and is not passed into the container during normal operation.',
+      },
+    ],
+  },
+  {
+    id: 'isolation-sandbox',
+    icon: Box,
+    title: 'Isolation & Sandbox',
+    tagline: "runs clean, stays out of each other's way",
+    summary: 'Each agent lives in its own folder and container, so nothing installs globally and agents never collide.',
+    featured: true,
+    bullets: [
+      {
+        title: 'No machine clutter',
+        detail:
+          'an agent lives in its own folder and runs in its own container. Nothing installs globally on your system; stop it and the running pieces shut down, leaving a folder you can keep, copy, or delete.',
+      },
+      {
+        title: 'No cross-agent interference',
+        detail:
+          'run as many as you like; each gets its own container, its own files, memory, and even its own browser. One agent can be reading a page while another drives a different one — neither disturbs the other.',
+      },
+      {
+        title: 'Self-contained folder',
+        detail:
+          "settings, memory, and connections live together in the agent's folder, kept as a version history you can review, undo, or back up.",
+      },
+    ],
+  },
+  {
+    id: 'subagents',
+    icon: Users,
+    title: 'Subagents',
+    tagline: 'delegation in a fresh context',
+    summary:
+      'It hands off research, planning, review, and execution to focused child sessions, sync or in the background.',
+    featured: true,
+    bullets: [
+      {
+        title: 'A bench of specialists',
+        detail:
+          'it hands off research, planning, code review, and hands-on execution to focused child sessions, each with its own prompt, tools, and model.',
+      },
+      {
+        title: 'Sync or background',
+        detail:
+          'spawn and block for a result, or spawn in the background and collect completions later; coalescing prevents duplicate concurrent runs and depth limits keep delegation chains bounded.',
+      },
+    ],
+  },
+  {
+    id: 'extensibility',
+    icon: Plug,
+    title: 'Extensibility',
+    tagline: 'teach it new tricks in TypeScript',
+    summary: 'Plugins are plain TypeScript imports; add MCP servers, lazy skills, and hot-reloadable typed config.',
+    featured: true,
+    bullets: [
+      {
+        title: 'Plugins are just imports',
+        detail:
+          'a plugin is a plain TypeScript file that imports the runtime and adds tools, skills, channels, and commands. No IPC, no FFI, no plugin DSL. Distributed as packages and resolved like any dependency.',
+      },
+      {
+        title: 'MCP support',
+        detail: "connect external MCP servers over stdio or HTTP; their tools become the agent's tools.",
+      },
+      {
+        title: 'Skills on demand',
+        detail:
+          'markdown procedures load lazily when selected, so they avoid prompt-token cost until used. Skills layer from bundled, your own, and what the agent learns.',
+      },
+      {
+        title: 'Typed config with hot reload',
+        detail: 'most config changes take effect live; boot-only fields are flagged restart-required.',
+      },
+    ],
+  },
+  {
+    id: 'connectivity',
+    icon: Network,
+    title: 'Connectivity',
+    tagline: 'reachable wherever you need it',
+    summary: 'Container services appear on your localhost; a zero-signup public URL, or bring your own.',
+    bullets: [
+      {
+        title: 'Auto port-forward',
+        detail: 'services inside the container appear on your `localhost`, including loopback-only ones.',
+      },
+      {
+        title: 'Public tunnels',
+        detail:
+          'a zero-signup public URL out of the box, or bring your own; webhooks self-register at the resulting URL.',
+      },
+      {
+        title: 'Private network access',
+        detail: 'forwarded ports can publish to a private network when configured.',
+      },
+    ],
+  },
+  {
+    id: 'self-managing',
+    icon: RefreshCw,
+    title: 'Self-managing',
+    tagline: 'operational autonomy, on a budget',
+    summary: 'It backs up its own state, can restart its container, and keeps working through a budgeted task list.',
+    bullets: [
+      {
+        title: 'Self-backup',
+        detail: 'commits and pushes its own state during idle windows, with a generated commit message.',
+      },
+      {
+        title: 'Self-restart',
+        detail: 'can rebuild and restart its own container when it needs to, through the host daemon.',
+      },
+      {
+        title: 'Self-continuation',
+        detail:
+          'keeps working through an unfinished task list when you step away, bounded by a turn, token, and wall-clock budget.',
+      },
+    ],
+  },
+  {
+    id: 'operator-cli',
+    icon: Terminal,
+    title: 'Operator CLI',
+    tagline: 'see what it\u2019s doing and what it costs',
+    summary: 'doctor, usage, inspect, and logs show what the agent is doing, what it spends, and how it is wired.',
+    bullets: [
+      {
+        title: 'doctor',
+        detail: 'diagnoses host, agent folder, config, and channels, with auto-fix for managed files.',
+      },
+      {
+        title: 'usage',
+        detail: 'reports token and dollar spend by day, model, session, or origin.',
+      },
+      {
+        title: 'inspect',
+        detail: 'replays a session transcript and tails live activity.',
+      },
+      {
+        title: 'logs',
+        detail: 'streams container logs with local-time prefixes.',
+      },
+    ],
+  },
+  {
+    id: 'compose',
+    icon: LayoutGrid,
+    title: 'Compose',
+    tagline: 'manage a fleet from the CLI',
+    summary:
+      'Discover agent folders and start, stop, check, and diagnose them across your fleet from the command line.',
+    featured: true,
+    bullets: [
+      {
+        title: 'Fleet operations',
+        detail:
+          'discover agent folders and start, stop, restart, check status, tail logs, report usage, and run diagnostics across them from the command line.',
+      },
+    ],
+  },
+]

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,11 +1,12 @@
-import { ArrowRight, BookOpen, Check, Container, Github, Lock, Shield, Sparkles, Star, X } from 'lucide-react'
+import { ArrowRight, BookOpen, Check, Container, Github, Lock, Minus, Shield, Sparkles, Star, X } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 
 import { AnimatedTerminal } from './_components/animated-terminal'
 import { CHANNELS } from './_components/channel-icons'
 import { CopyButton } from './_components/copy-button'
-import { COMPETITORS, INSTALL_COMMAND, MEMORY_LOOP, VERSION } from './_components/data'
+import { COMPARISON_FEATURES, COMPETITORS, INSTALL_COMMAND, MEMORY_LOOP, VERSION } from './_components/data'
+import { FEATURE_CATEGORIES } from './_components/features-data'
 import { HeroSpotlight } from './_components/hero-spotlight'
 import { Reveal } from './_components/reveal'
 import { ThemeToggle } from './_components/theme-toggle'
@@ -145,6 +146,25 @@ function PluginCode() {
   )
 }
 
+function CapabilityGrid() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {FEATURE_CATEGORIES.filter((c) => c.featured).map(({ id, icon: Icon, title, summary }) => (
+        <div
+          key={id}
+          className="group rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm transition-all hover:translate-y-[-2px] hover:border-brand-200 hover:shadow-md dark:border-white/[0.08] dark:bg-white/[0.02] dark:hover:border-brand-800/60"
+        >
+          <div className="inline-flex size-10 items-center justify-center rounded-xl bg-brand-50 text-brand-700 transition-colors group-hover:bg-brand-100 dark:bg-brand-950/60 dark:text-brand-300 dark:group-hover:bg-brand-900/60">
+            <Icon className="size-5" strokeWidth={2.2} aria-hidden />
+          </div>
+          <h3 className="mt-4 text-base font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{title}</h3>
+          <p className="mt-2 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">{summary}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function MemoryLoopVertical() {
   return (
     <div className="relative">
@@ -178,84 +198,95 @@ function MemoryLoopVertical() {
 function CheckCell({ value }: { value: boolean | 'partial' }) {
   if (value === 'partial') {
     return (
-      <div className="inline-flex size-7 items-center justify-center rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
-        <span className="font-mono text-xs">~</span>
-      </div>
+      <span className="inline-flex items-center justify-center text-zinc-400 dark:text-zinc-600">
+        <Minus className="size-4" strokeWidth={2.5} aria-hidden />
+        <span className="sr-only">Partial</span>
+      </span>
     )
   }
   return value ? (
-    <div className="inline-flex size-7 items-center justify-center rounded-full bg-brand-100 text-brand-700 dark:bg-brand-900/50 dark:text-brand-300">
-      <Check className="size-4" strokeWidth={2.5} aria-hidden />
-    </div>
+    <span className="inline-flex items-center justify-center text-brand-600 dark:text-brand-400">
+      <Check className="size-[18px]" strokeWidth={2.75} aria-hidden />
+      <span className="sr-only">Yes</span>
+    </span>
   ) : (
-    <div className="inline-flex size-7 items-center justify-center rounded-full bg-zinc-100 text-zinc-400 dark:bg-white/[0.04] dark:text-zinc-600">
-      <X className="size-4" strokeWidth={2.5} aria-hidden />
-    </div>
+    <span className="inline-flex items-center justify-center text-zinc-300 dark:text-zinc-700">
+      <X className="size-4" strokeWidth={2.25} aria-hidden />
+      <span className="sr-only">No</span>
+    </span>
   )
 }
 
 function MarketingTable() {
+  const lastFeatureIndex = COMPARISON_FEATURES.length - 1
   return (
-    <div className="-mx-2 overflow-x-auto sm:mx-0">
-      <table className="w-full min-w-[940px] text-left text-sm">
+    <div className="overflow-x-auto rounded-2xl border border-zinc-200 dark:border-white/[0.08]">
+      <table className="w-full min-w-[680px] border-separate border-spacing-0 text-left text-sm">
         <thead>
-          <tr className="border-b border-zinc-200 text-xs tracking-wider text-zinc-500 uppercase dark:border-white/[0.06] dark:text-zinc-500">
-            <th className="px-4 py-4 font-medium">Runtime</th>
-            <th className="px-4 py-4 text-center font-medium">Docker-first</th>
-            <th className="px-4 py-4 text-center font-medium">Self-improving</th>
-            <th className="px-4 py-4 text-center font-medium">Multi-channel</th>
-            <th className="px-4 py-4 text-center font-medium">Full-featured plugins</th>
-            <th className="px-4 py-4 text-center font-medium">Auto-commit &amp; push</th>
-            <th className="px-4 py-4 text-center font-medium">Permission system</th>
-            <th className="px-4 py-4 font-medium">Notes</th>
+          <tr>
+            <th className="sticky left-0 z-10 border-b border-zinc-200 bg-white px-5 pt-6 pb-5 align-bottom font-mono text-[11px] font-medium tracking-[0.14em] text-zinc-400 uppercase dark:border-white/[0.08] dark:bg-zinc-950">
+              Feature
+            </th>
+            {COMPETITORS.map((r) => (
+              <th
+                key={r.name}
+                className={`border-b px-4 pt-6 pb-5 text-center align-top ${
+                  r.highlight
+                    ? 'border-brand-200 bg-brand-50/50 dark:border-brand-900/50 dark:bg-brand-950/30'
+                    : 'border-zinc-200 dark:border-white/[0.08]'
+                }`}
+              >
+                <div className="flex items-center justify-center gap-2">
+                  <span
+                    className={
+                      r.highlight
+                        ? 'text-base font-semibold tracking-tight text-brand-700 dark:text-brand-200'
+                        : 'text-base font-semibold tracking-tight text-zinc-800 dark:text-zinc-200'
+                    }
+                  >
+                    {r.name}
+                  </span>
+                  {r.highlight && (
+                    <span className="rounded-full bg-brand-600 px-2 py-0.5 font-mono text-[9px] font-semibold tracking-wider text-white uppercase dark:bg-brand-500">
+                      you are here
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1.5 font-mono text-[11px] font-normal tracking-normal text-zinc-400 normal-case dark:text-zinc-500">
+                  {r.lang}
+                </div>
+                <p className="mx-auto mt-2 max-w-[13rem] text-xs font-normal leading-snug tracking-normal text-zinc-500 normal-case dark:text-zinc-500">
+                  {r.strength} · {r.tradeoff}
+                </p>
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
-          {COMPETITORS.map((r) => (
-            <tr
-              key={r.name}
-              className={
-                r.highlight
-                  ? 'border-b border-brand-200/60 bg-brand-50/70 dark:border-brand-800/40 dark:bg-brand-950/30'
-                  : 'border-b border-zinc-100 dark:border-white/[0.04]'
-              }
-            >
-              <td className="px-4 py-5">
-                <div
-                  className={
-                    r.highlight
-                      ? 'font-semibold text-brand-800 dark:text-brand-100'
-                      : 'font-medium text-zinc-800 dark:text-zinc-200'
-                  }
+          {COMPARISON_FEATURES.map((feature, i) => {
+            const lastRow = i === lastFeatureIndex
+            const border = lastRow ? '' : 'border-b border-zinc-100 dark:border-white/[0.06]'
+            return (
+              <tr key={feature.key}>
+                <th
+                  scope="row"
+                  className={`sticky left-0 z-10 bg-white px-5 py-4 text-left text-[13px] font-medium whitespace-nowrap text-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 ${border}`}
                 >
-                  {r.name}
-                </div>
-                <div className="mt-0.5 font-mono text-[11px] text-zinc-500 dark:text-zinc-500">{r.lang}</div>
-              </td>
-              <td className="px-4 py-5 text-center">
-                <CheckCell value={r.dockerFirst} />
-              </td>
-              <td className="px-4 py-5 text-center">
-                <CheckCell value={r.selfImproving} />
-              </td>
-              <td className="px-4 py-5 text-center">
-                <CheckCell value={r.multiChannel} />
-              </td>
-              <td className="px-4 py-5 text-center">
-                <CheckCell value={r.fullFeaturedPlugins} />
-              </td>
-              <td className="px-4 py-5 text-center">
-                <CheckCell value={r.gitNative} />
-              </td>
-              <td className="px-4 py-5 text-center">
-                <CheckCell value={r.permissionSystem} />
-              </td>
-              <td className="px-4 py-5 text-zinc-600 dark:text-zinc-400">
-                <span className="font-medium text-zinc-700 dark:text-zinc-300">{r.strength}</span>
-                <span className="text-zinc-400 dark:text-zinc-600"> · {r.tradeoff}</span>
-              </td>
-            </tr>
-          ))}
+                  {feature.label}
+                </th>
+                {COMPETITORS.map((r) => (
+                  <td
+                    key={r.name}
+                    className={`px-4 py-4 text-center align-middle ${border} ${
+                      r.highlight ? 'bg-brand-50/50 dark:bg-brand-950/30' : ''
+                    }`}
+                  >
+                    <CheckCell value={r[feature.key]} />
+                  </td>
+                ))}
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>
@@ -437,6 +468,24 @@ export default function Home() {
         </section>
 
         <section className="mx-auto max-w-6xl px-6 py-36">
+          <Reveal className="mb-12 text-center">
+            <p className="font-mono text-xs tracking-[0.2em] text-brand-700 uppercase dark:text-brand-300">
+              everything it does
+            </p>
+            <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+              Features crafted for perfectionists.
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-zinc-600 dark:text-zinc-400">
+              From a self-improving memory loop to a sandbox per agent, here is the whole surface — one capability per
+              card.
+            </p>
+          </Reveal>
+          <Reveal delay={120}>
+            <CapabilityGrid />
+          </Reveal>
+        </section>
+
+        <section className="mx-auto max-w-6xl px-6 py-36">
           <Reveal className="text-center">
             <p className="font-mono text-xs tracking-[0.2em] text-brand-700 uppercase dark:text-brand-300">
               Memory you can read
@@ -521,16 +570,23 @@ export default function Home() {
               how it compares
             </p>
             <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-              OpenClaw is the platform. TypeClaw is the codebase.
+              Where TypeClaw is the right choice.
             </h2>
             <p className="mx-auto mt-4 max-w-2xl text-base text-zinc-600 dark:text-zinc-400">
               These are all good — genuinely. Reach for OpenClaw when you want the biggest ecosystem, Hermes when Python
-              is your stack, the lighter runtimes when you want a single binary. Reach for TypeClaw when you want a
-              runtime you can read end to end, extend with an import, and keep as your own.
+              is your stack. Reach for TypeClaw when you want a runtime you can read end to end, extend with an import,
+              and keep as your own.
             </p>
           </Reveal>
           <Reveal delay={120}>
             <MarketingTable />
+          </Reveal>
+          <Reveal delay={180}>
+            <p className="mx-auto mt-8 max-w-2xl text-center text-sm leading-relaxed text-zinc-500 dark:text-zinc-500">
+              These are all capable runtimes. OpenClaw is the broad platform; Hermes is the mature Python agent.
+              TypeClaw&apos;s edge is the combination: one readable TypeScript codebase you own — memory you can diff in
+              its own git repo, isolated per agent, and extended with a plain import.
+            </p>
           </Reveal>
         </section>
 


### PR DESCRIPTION
## Summary

Reshapes the landing-page feature story around TypeClaw's **real, code-verified differentiators** (sourced from the canonical feature inventory) and replaces the generic competitor comparison with an honest one.

Three changes, all under `docs/src/app/`:

1. **New capability grid** — an 8-card "everything it does" overview, added after the channels strip. Cards are data-driven from a new `features-data.ts` (the full 13-category inventory, with a `featured` flag selecting the 8 shown).
2. **Reshaped comparison table** — transposed to **features-as-rows × runtimes-as-columns**, with a calmer, simpler cell/hero treatment.
3. **Honest, differentiator-driven columns** — the comparison axes now reflect what actually sets TypeClaw apart, and the three runtimes are scored so capable rivals stay credible.

## Why

The old comparison table compared on generic, commodity axes (Docker-first, Multi-channel, Full-featured plugins…) and scored rivals in a way that contradicted their own established framing — e.g. marking the "feature-rich, biggest ecosystem" runtime ❌/partial across half the grid. That reads as cherry-picked to a skeptical developer.

This PR grounds the table in the canonical feature inventory and a self-consistent scoring: rivals score well where their identity says they should; TypeClaw leads only where its canon genuinely supports it. The real argument — *the combination*, plus "one readable TypeScript codebase you own" — is stated in prose below the grid, since a pure capability checklist naturally favors a broad incumbent.

## Comparison columns

`Memory you can read` · `Knows when not to talk` · `Per-agent isolation` · `Plugins as imports` · `Permissions & guards` · `Per-agent git repo` · `Self-managing` · `Channels`

| Feature | OpenClaw | Hermes Agent | TypeClaw |
|---|:--:|:--:|:--:|
| Memory you can read | partial | yes | yes |
| Knows when not to talk | yes | partial | yes |
| Per-agent isolation | yes | partial | yes |
| Plugins as imports | yes | no | yes |
| Permissions & guards | yes | yes | yes |
| Per-agent git repo | partial | yes | yes |
| Self-managing | yes | yes | yes |
| Channels | yes | yes | yes |

## Framing guardrails honored

Per the feature inventory's writing rules: dropped **"git-native"** (→ "per-agent git repo" / "memory you can diff in its own git repo"), and kept copy free of counts and absolute claims.

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (64 pre-existing warnings elsewhere, none in changed files)
- `bun run format` / `format:check` — clean
- `docs` build — compiles, 111/111 static pages generated

> Note: `bun run test` has one failing test — `typeclaw.schema.json` drift guard — which is **pre-existing and unrelated** (this PR is docs-only and touches no config schema).

## Scope

Docs-site only: `docs/src/app/_components/data.ts`, `docs/src/app/_components/features-data.ts` (new), `docs/src/app/page.tsx`. No runtime/CLI/plugin changes.
