### PR TITLE
fix(agent): tell Discord sessions to emit bare pipe tables, not fenced

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -205,6 +205,32 @@ describe('renderSessionOrigin', () => {
     expect(out).toMatch(/skip_response/)
   })
 
+  test('discord channel origin tells the bot to emit bare pipe tables, not fenced ones', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'discord-bot',
+      workspace: '111',
+      chat: '222',
+      thread: null,
+    })
+    // guards the real failure: agent fences its table, which disables the
+    // adapter's auto-conversion, so Discord renders ragged literal pipes
+    expect(out).toMatch(/bare `\| a \| b \|` blocks/i)
+    expect(out).toMatch(/never inside a code\s+fence/i)
+    expect(out).toMatch(/auto-reformats/i)
+  })
+
+  test('non-discord channel origin does not get the bare-table guidance', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+    })
+    expect(out).not.toContain('auto-reformats')
+  })
+
   test('non-github channel origin keeps the "On it." text ack', () => {
     const out = renderSessionOrigin({
       kind: 'channel',

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -384,6 +384,27 @@ function renderChannelOrigin(
     )
   }
 
+  // Discord renders no GFM tables — a raw `| a | b |` block shows as literal
+  // pipes. The discord-bot adapter rewrites BARE pipe tables into aligned
+  // inline-code rows for readability, but it skips any table inside a ``` /
+  // ~~~ fence (a fenced table is literal text by CommonMark). Models that have
+  // "learned" Discord mangles tables defensively wrap them in a fence, which is
+  // exactly what disables the auto-conversion — so the table renders ragged
+  // anyway. Tell the model to emit tables bare and let the adapter format them.
+  if (origin.adapter === 'discord-bot') {
+    lines.push(
+      '',
+      '**Emit Markdown tables as bare `| a | b |` blocks — never inside a code',
+      'fence.** Discord does not render Markdown tables, so this session',
+      'auto-reformats a bare pipe table (a `|`-row followed by a `|---|`',
+      'alignment row) into aligned, readable columns before it sends. That',
+      'reformatting only fires on raw Markdown: the moment you wrap the table in',
+      'a ``` or ~~~ fence it is treated as literal text and lands as ragged pipes.',
+      'So write the table directly in your reply with no surrounding fence. Use',
+      'fences only for actual code or output you want shown verbatim.',
+    )
+  }
+
   const conversationLine = renderConversationLine(origin)
   if (conversationLine !== null) lines.push('', conversationLine)
 


### PR DESCRIPTION
## Background

Discord agents posting recurring schedules were rendering tables as ragged literal pipe-soup, and over successive days some "learned" to stop emitting tables entirely — switching to `---` rules and inline code instead. The user-reported symptom: "Discord auto table conversion is broken."

The converter is not broken. `convertDiscordTables` in `src/channels/adapters/discord-bot-format.ts` correctly rewrites bare GFM pipe tables into aligned inline-code rows, is wired into the only Discord outbound call site, and all 25 of its unit tests pass. The root cause is a behavioral gap in the system prompt.

By design the converter skips any table inside a triple-backtick or `~~~` fence — a fenced table is literal text per CommonMark, and a passing test asserts this ("does not touch code fences that contain pipes"). Models that have "learned" Discord mangles tables defensively wrap them in a code fence, which is exactly what disables the auto-conversion. The table lands as ragged pipes anyway, and nothing in the system prompt told the agent to emit tables bare on Discord.

## Summary

Add a `discord-bot`-specific guidance block to `renderChannelOrigin` instructing the model to emit Markdown tables bare — no surrounding fence — so the adapter's reformatting fires.

**Why a prompt fix and not a converter change.** The converter is correct. Making it convert inside fences would clobber legitimately-fenced literal tables (docs, examples, verbatim output). The bad behavior originates from model self-correction against perceived rendering problems, so the fix belongs at the layer that shapes that behavior.

**Why gated on `origin.adapter === 'discord-bot'`.** Discord is the only adapter with this auto-conversion. The gate mirrors the existing `origin.adapter === 'github'` conditional in the same function (bold-imperative style), keeping per-adapter guidance isolated.

## Preview

The guidance block rendered into a `discord-bot` channel session (verified via `renderSessionOrigin`):

> **Emit Markdown tables as bare `| a | b |` blocks — never inside a code fence.** Discord does not render Markdown tables, so this session auto-reformats a bare pipe table (a `|`-row followed by a `|---|` alignment row) into aligned, readable columns before it sends. That reformatting only fires on raw Markdown: the moment you wrap the table in a code fence or `~~~` fence it is treated as literal text and lands as ragged pipes. So write the table directly in your reply with no surrounding fence. Use fences only for actual code or output you want shown verbatim.

A `slack-bot` channel prompt does NOT include this block (verified by the negative test).

## What this does NOT do

- Does not change `convertDiscordTables` or any adapter logic — the conversion already worked correctly.
- Does not add Discord message chunking. A latent risk worth a follow-up: the Discord path has no length-splitting (unlike Slack), and conversion can lengthen a table, so a very large table may exceed Discord's 2000-character limit and fail silently at send. Out of scope here.
- Does not touch Slack, Telegram, LINE, KakaoTalk, or GitHub guidance.

## Review notes

Load-bearing change: the new `if (origin.adapter === 'discord-bot')` block in `renderChannelOrigin` (`src/agent/session-origin.ts`). Invariant: guidance renders for `discord-bot` and is absent for every other adapter — covered by 2 new tests (positive discord-bot, negative slack-bot) in `src/agent/session-origin.test.ts`.

Pre-commit checks: `bun run typecheck` clean, `bun run lint` 0 errors (pre-existing unrelated warnings only), `bun run format` clean. 81/81 session-origin tests pass.