### PR TITLE
Fuzzy-match the model and provider pickers

### DIFF
--- a/src/cli/fuzzy-filter.test.ts
+++ b/src/cli/fuzzy-filter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { Option } from '@clack/prompts'
+
+import { fuzzyMatch } from './fuzzy-filter'
+
+function opt(label: string, value: string, hint?: string): Option<string> {
+  return hint !== undefined ? { value, label, hint } : { value, label }
+}
+
+describe('fuzzyMatch', () => {
+  test('matches spaced query across a hyphenated label', () => {
+    const option = opt('GPT-5.5 Turbo', 'openai/gpt-5.5-turbo')
+    expect(fuzzyMatch('gpt 5.5', option)).toBe(true)
+  })
+
+  test('is case-insensitive', () => {
+    const option = opt('GPT-5.5 Turbo', 'openai/gpt-5.5-turbo')
+    expect(fuzzyMatch('GPT', option)).toBe(true)
+    expect(fuzzyMatch('TURBO', option)).toBe(true)
+  })
+
+  test('matches against the value when label omits the term', () => {
+    const option = opt('Claude Sonnet', 'anthropic/claude-sonnet-4')
+    expect(fuzzyMatch('anthropic', option)).toBe(true)
+  })
+
+  test('matches against the hint', () => {
+    const option = opt('Add provider', 'sentinel', 'configure a new provider')
+    expect(fuzzyMatch('configure', option)).toBe(true)
+  })
+
+  test('empty query matches everything', () => {
+    const option = opt('Anything', 'x')
+    expect(fuzzyMatch('', option)).toBe(true)
+    expect(fuzzyMatch('   ', option)).toBe(true)
+  })
+
+  test('all tokens must be present', () => {
+    const option = opt('GPT-5.5 Turbo', 'openai/gpt-5.5-turbo')
+    expect(fuzzyMatch('gpt mini', option)).toBe(false)
+  })
+
+  test('non-matching query returns false', () => {
+    const option = opt('GPT-5.5 Turbo', 'openai/gpt-5.5-turbo')
+    expect(fuzzyMatch('claude', option)).toBe(false)
+  })
+
+  test('subsequence (abbreviation) matching within a token', () => {
+    const option = opt('GPT-4o', 'openai/gpt-4o')
+    expect(fuzzyMatch('gpt4o', option)).toBe(true)
+  })
+
+  test('falls back to String(value) when label is absent', () => {
+    const option: Option<string> = { value: 'openai/gpt-5.5' }
+    expect(fuzzyMatch('gpt', option)).toBe(true)
+  })
+
+  test('tokens are order-independent', () => {
+    const option = opt('GPT Turbo', 'openai/gpt-turbo')
+    expect(fuzzyMatch('gpt turbo', option)).toBe(true)
+    expect(fuzzyMatch('turbo gpt', option)).toBe(true)
+  })
+})

--- a/src/cli/fuzzy-filter.ts
+++ b/src/cli/fuzzy-filter.ts
@@ -1,0 +1,32 @@
+import type { Option } from '@clack/prompts'
+
+type FuzzyFilter<Value> = (search: string, option: Option<Value>) => boolean
+
+function optionHaystack<Value>(option: Option<Value>): string {
+  const label = option.label ?? String(option.value)
+  const hint = option.hint ?? ''
+  return `${label} ${String(option.value)} ${hint}`.toLowerCase()
+}
+
+function isSubsequence(query: string, haystack: string): boolean {
+  let i = 0
+  for (let j = 0; j < haystack.length && i < query.length; j++) {
+    if (haystack[j] === query[i]) i++
+  }
+  return i === query.length
+}
+
+// Splitting the query on whitespace lets "gpt 5.5" match "GPT-5.5 Turbo": each
+// token is matched independently as a subsequence, so the "-" inside "GPT-5.5"
+// no longer breaks the search the way a plain substring "gpt 5.5" would. Tokens
+// are order-independent so "turbo gpt" finds "GPT Turbo" too.
+export function fuzzyMatch<Value>(search: string, option: Option<Value>): boolean {
+  const tokens = search.toLowerCase().split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return true
+  const haystack = optionHaystack(option)
+  return tokens.every((token) => isSubsequence(token, haystack))
+}
+
+export const fuzzyFilter: FuzzyFilter<unknown> = fuzzyMatch
+
+export type { FuzzyFilter }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -66,6 +66,7 @@ import {
   type KeyValidationResult,
 } from '@/init/validate-api-key'
 
+import { fuzzyMatch } from './fuzzy-filter'
 import { buildOAuthCallbacks } from './oauth-callbacks'
 import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
 import {
@@ -1098,6 +1099,7 @@ async function pickVendor(
   const choice = await autocomplete({
     message: 'Pick an LLM provider',
     placeholder: 'Type to search…',
+    filter: fuzzyMatch,
     options: vendors.map((id) => ({
       value: id,
       label: KNOWN_PROVIDER_VENDORS[id].name,
@@ -1120,6 +1122,7 @@ async function pickProviderVariant(
   const choice = await autocomplete<KnownProviderId>({
     message: `Pick a ${KNOWN_PROVIDER_VENDORS[vendorId].name} option`,
     placeholder: 'Type to search…',
+    filter: fuzzyMatch,
     options: variants.map((id) => {
       const hint = variantHint(vendorId, id)
       return hint !== undefined
@@ -1145,6 +1148,7 @@ async function pickModelForProvider(
   const choice = await autocomplete<string>({
     message: `Pick a ${KNOWN_PROVIDERS[providerId].name} model`,
     placeholder: 'Type to search…',
+    filter: fuzzyMatch,
     options: candidates.map((o) => ({
       value: o.ref,
       label: formatModelLabel(o),
@@ -1191,6 +1195,7 @@ async function pickVisionVendor(
   const choice = await autocomplete<KnownProviderVendorId | 'skip'>({
     message: 'Your model is text-only. Pick a provider for the `vision` profile (used for image input)',
     placeholder: 'Type to search…',
+    filter: fuzzyMatch,
     options: [
       ...vendors.map((id) => ({
         value: id as KnownProviderVendorId | 'skip',
@@ -1223,6 +1228,7 @@ async function pickVisionModel(
   const choice = await autocomplete<string>({
     message: `Pick a vision-capable ${KNOWN_PROVIDERS[providerId].name} model`,
     placeholder: 'Type to search…',
+    filter: fuzzyMatch,
     options: candidates.map((o) => ({
       value: o.ref,
       label: formatModelLabel(o),

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -19,6 +19,7 @@ import {
 import { findAgentDir, isInitialized } from '@/init'
 import { customModelMetaFromOption, fetchModelOptions, type ModelOption } from '@/init/models-dev'
 
+import { fuzzyMatch } from './fuzzy-filter'
 import { runProviderAddFlow } from './provider'
 import { c, done, errorLine } from './ui'
 
@@ -251,6 +252,7 @@ async function pickModelRef(cwd: string): Promise<PickedModelRef> {
     const choice = await autocomplete<string>({
       message: 'Pick a model',
       placeholder: 'Type to search…',
+      filter: fuzzyMatch,
       options: [
         ...modelOptions.map((option) => ({
           value: option.ref,

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -23,6 +23,7 @@ import {
 import { findAgentDir, isInitialized } from '@/init'
 import { makeOAuthLoginRunner } from '@/init/oauth-login'
 
+import { fuzzyMatch } from './fuzzy-filter'
 import { buildOAuthCallbacks } from './oauth-callbacks'
 import { c, done, errorLine } from './ui'
 
@@ -285,6 +286,7 @@ async function pickVendorToAdd(): Promise<KnownProviderVendorId> {
   const choice = await autocomplete<KnownProviderVendorId>({
     message: 'Pick a provider to add',
     placeholder: 'Type to search…',
+    filter: fuzzyMatch,
     options: vendorIds.map((id) => ({
       value: id,
       label: KNOWN_PROVIDER_VENDORS[id].name,
@@ -305,6 +307,7 @@ async function pickVariantToAdd(vendorId: KnownProviderVendorId): Promise<KnownP
   const choice = await autocomplete<KnownProviderId>({
     message: `Pick a ${KNOWN_PROVIDER_VENDORS[vendorId].name} option`,
     placeholder: 'Type to search…',
+    filter: fuzzyMatch,
     options: variants.map((id) => {
       const hint = variantHint(vendorId, id)
       return hint !== undefined


### PR DESCRIPTION
## Background

The interactive model/provider pickers (the "Pick a model" / "Pick a provider" autocomplete prompts) rely on `@clack/prompts`' built-in autocomplete filter, which is a **contiguous, case-folded substring match** over `label`/`value`/`hint`. That breaks on the two things users naturally type:

- **Spaces** — the query is matched as one literal string, so `gpt 5.5` is searched verbatim and never lines up with `GPT-5.5 Turbo`.
- **Separators inside labels** — even ignoring the space, `gpt5.5` won't match `GPT-5.5` because the `-` interrupts the substring.

Net result is the reported symptom: typing `gpt 5.5` against a model named `GPT-5.5 Turbo` yields `No matches found (0 matches)`.

## Summary

Add a shared `fuzzyMatch` filter (`src/cli/fuzzy-filter.ts`) and pass it as the `filter` prop to every `autocomplete()` call site.

Matching rules, chosen to fit a picker's mental model:
- **Whitespace splits the query into tokens.** This is the core fix — splitting `gpt 5.5` into `["gpt", "5.5"]` lets each token match independently, so the `-` in `GPT-5.5` no longer breaks the search.
- **Each token is matched as a subsequence** over `label + value + hint`. This also gives free abbreviation matching (`gpt4o` → `gpt-4o`).
- **Tokens are order-independent.** `turbo gpt` finds `GPT Turbo` — "all my terms appear somewhere" is the expectation in a fuzzy picker, not strict left-to-right ordering. (I deliberately rejected an ordered-cursor variant for this reason; see the test history.)

Why a small hand-rolled matcher and not a dependency (e.g. `fuzzysort`): the repo had zero fuzzy-search deps, the matching need is tiny, and `@clack/prompts` already exposes a `filter` hook — a ~30-line function keeps the surface and the supply chain unchanged.

## What this does NOT do

- No ranking/scoring — `filter` is a boolean predicate, so options keep their existing recommended-first ordering; this only changes *which* options survive, not their order.
- Does not touch `@clack/prompts` internals or the non-interactive `<ref>` resolution path.
- Does not add a dependency.

## Review notes

- Load-bearing change is `fuzzyMatch` in `src/cli/fuzzy-filter.ts`; the 8 call-site edits (`model.ts` ×1, `provider.ts` ×2, `init.ts` ×5) are each a one-line `filter: fuzzyMatch`.
- The whitespace-split + per-token subsequence behavior is pinned by `src/cli/fuzzy-filter.test.ts` (notably the `gpt 5.5` → `GPT-5.5 Turbo` case and order-independence).
- All eight `autocomplete` calls now share one filter — grep `filter: fuzzyMatch` to confirm none were missed.
