### PR TITLE
fix(channels): re-prompt when a continue:true turn strands on an unanswered toolUse

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4358,6 +4358,78 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
   })
 
+  test('continue-reply guard: posts the fallback when every retry re-strands until the budget is exhausted', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    const strandOnUnansweredToolUse = (seq: number): void => {
+      const assistantMsg: AssistantMessage = {
+        role: 'assistant',
+        content: [
+          { type: 'toolCall', id: `t${seq}`, name: 'stream_snapshot', arguments: {} },
+        ] as AssistantMessage['content'],
+        api: 'openai-completions',
+        provider: 'openai',
+        model: 'gpt-5.5',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'toolUse',
+        timestamp: 1000,
+      }
+      const assistantEntry: SessionEntry = {
+        type: 'message',
+        id: `assistant-strand-${seq}`,
+        parentId: null,
+        timestamp: '2026-06-15T06:23:45.000Z',
+        message: assistantMsg,
+      }
+      const toolResultEntry: SessionEntry = {
+        type: 'message',
+        id: `tool-result-strand-${seq}`,
+        parentId: `assistant-strand-${seq}`,
+        timestamp: '2026-06-15T06:23:45.500Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: `t${seq}`,
+          toolName: 'stream_snapshot',
+          content: [{ type: 'text', text: 'x' }],
+          isError: false,
+          timestamp: 1000,
+        },
+      }
+      sessions[0]!.entriesById.set(assistantEntry.id, assistantEntry)
+      sessions[0]!.entriesById.set(toolResultEntry.id, toolResultEntry)
+      sessions[0]!.leafEntry = toolResultEntry
+    }
+
+    await router.route(inbound({ text: '반영했어?' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      // Each retry posts a DISTINCT status (a duplicate would be send-deduped
+      // and not count as a fresh send), then re-strands on the no-prose toolUse.
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: `확인 중… (${attempt})` })
+      strandOnUnansweredToolUse(attempt)
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(sent.filter((s) => s.text === EMPTY_TURN_FALLBACK_TEXT)).toHaveLength(1)
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=stranded_toolUse_retries_exhausted'))).toBe(true)
+  })
+
   test('silent-leaf observability: logs explicit reason instead of bailing silently', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -4231,6 +4231,133 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
+  // Regression for the "I'll check right now" → silence bug (Discord channel,
+  // 2026-06-15). The model posted a `continue: true` status reply ("지금 바로
+  // 확인할게"), kept working through several tool calls, then its post-tool
+  // follow-up stream was aborted before it could conclude. The session leaf was
+  // a toolResult under an unanswered `stopReason: 'toolUse'` assistant carrying
+  // NO visible prose (thinking + toolCall only), so pre-tool recovery had
+  // nothing to post. Because a send had already landed this turn, the recovery
+  // gate short-circuited and the turn ended silently — the promised follow-up
+  // never ran and the user got dead air after the status reply. The fix:
+  // re-prompt (empty-turn retry) so the model finishes the work it promised and
+  // actually replies.
+  test('continue-reply guard: re-prompts when the turn strands on an unanswered toolUse with no prose', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    const strandOnUnansweredToolUse = (): void => {
+      // A toolUse assistant with ONLY thinking + a toolCall (no visible text),
+      // whose post-tool follow-up never landed: leaf is the toolResult.
+      const assistantMsg: AssistantMessage = {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Investigating cron behavior…' },
+          { type: 'toolCall', id: 'functions.stream_snapshot:0', name: 'stream_snapshot', arguments: { limit: 20 } },
+        ] as AssistantMessage['content'],
+        api: 'openai-completions',
+        provider: 'openai',
+        model: 'gpt-5.5',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'toolUse',
+        timestamp: 1000,
+      }
+      const assistantEntry: SessionEntry = {
+        type: 'message',
+        id: 'assistant-strand',
+        parentId: null,
+        timestamp: '2026-06-15T06:23:45.000Z',
+        message: assistantMsg,
+      }
+      const toolResultEntry: SessionEntry = {
+        type: 'message',
+        id: 'tool-result-strand',
+        parentId: 'assistant-strand',
+        timestamp: '2026-06-15T06:23:45.500Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.stream_snapshot:0',
+          toolName: 'stream_snapshot',
+          content: [{ type: 'text', text: 'stream events here' }],
+          isError: false,
+          timestamp: 1000,
+        },
+      }
+      sessions[0]!.entriesById.set(assistantEntry.id, assistantEntry)
+      sessions[0]!.entriesById.set(toolResultEntry.id, toolResultEntry)
+      sessions[0]!.leafEntry = toolResultEntry
+    }
+
+    await router.route(inbound({ text: '반영했어?' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      attempt++
+      if (attempt === 1) {
+        // The status reply (the `continue: true` "I'll check now") lands as a
+        // real send, then the turn strands on the unanswered toolUse.
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '지금 바로 확인할게.' })
+        strandOnUnansweredToolUse()
+        return
+      }
+      // The retry nudge re-prompts the same logical turn; now the model
+      // finishes its investigation and posts the conclusion it promised, then
+      // ends cleanly (the leaf is the reply, not another stranded toolUse).
+      expect(text).toContain(EMPTY_TURN_RETRY_NUDGE)
+      await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'cron.json은 비어 있고, 요약은 플러그인에서 와. 재시작해야 반영돼.',
+      })
+      sessions[0]!.setAssistantText('cron.json은 비어 있고, 요약은 플러그인에서 와. 재시작해야 반영돼.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // The turn must NOT end after the bare status reply: a re-prompt fires and
+    // the real conclusion is delivered.
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent.map((s) => s.text)).toEqual([
+      '지금 바로 확인할게.',
+      'cron.json은 비어 있고, 요약은 플러그인에서 와. 재시작해야 반영돼.',
+    ])
+    expect(logs.some((m) => m.includes('empty_turn_retry attempt=1'))).toBe(true)
+  })
+
+  test('continue-reply guard: does NOT re-prompt when the trailing toolUse carries narration and a send landed', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'do the thing' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'real reply' })
+      sessions[0]!.setAssistantMidTurn('narration that accompanied the reply')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent.map((s) => s.text)).toEqual(['real reply'])
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
+  })
+
   test('silent-leaf observability: logs explicit reason instead of bailing silently', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3371,7 +3371,31 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live.successfulChannelSends > successfulSendsBeforePrompt) {
       maybeNudgeContinuationWillingness(live)
       const trailing = recoverableAssistantText(live.session)
-      if (trailing === null || trailing.source !== 'leaf') return
+      if (trailing === null || trailing.source !== 'leaf') {
+        // A `continue: true` status reply landed, then the turn stranded on an
+        // unanswered `toolUse` (the post-tool follow-up never produced an
+        // assistant message — aborted loop / cancelled stream). The promised
+        // work never finished, so the user is left with a bare "checking now…"
+        // and nothing after it. Re-prompt the same logical turn so the model
+        // completes its investigation and actually replies, instead of ending
+        // in silence. Bounded by MAX_EMPTY_TURN_RETRIES; on exhaustion the turn
+        // falls through to the normal recovery path below (which posts the
+        // fallback). Any postable pre-tool/mid-turn prose is still recovered by
+        // that path — this only adds a retry for the no-prose strand.
+        if (
+          leafIsStrandedToolUse(live.session) &&
+          live.currentTurnAuthorId !== null &&
+          live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES
+        ) {
+          live.emptyTurnRetries++
+          logger.warn(
+            `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
+              `cause=stranded_toolUse_after_send`,
+          )
+          live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
+        }
+        return
+      }
       if (live.session.sessionManager.getLeafEntry()?.id === live.lastSendLeafId) return
     }
 
@@ -4959,6 +4983,40 @@ function assistantLeafStopReason(session: AgentSession): 'length' | 'error' | 'a
   const stop = leaf.message.stopReason
   if (stop === 'length' || stop === 'error' || stop === 'aborted') return stop
   return undefined
+}
+
+// True when the branch ends on an UNANSWERED `toolUse` that left NO postable
+// prose — the model called a tool and the upstream pi-agent-core post-tool
+// follow-up never produced an assistant message (the loop was aborted, or the
+// follow-up stream cancelled). Two leaf shapes carry this signature: the leaf
+// IS a `toolUse` assistant, or the leaf is a `toolResult` whose nearest
+// assistant ancestor (reached before any user message) is `toolUse`. The
+// no-prose requirement is the discriminator from a model that narrated a reply
+// alongside its tool call and DID land a real send this turn (that trailing
+// `toolUse` is delivered narration, not a stranded promise — leave it alone).
+// Keys on the model having INTENDED to keep working with nothing yet said; used
+// to re-prompt a turn that strands mid-work after a `continue: true` status
+// reply instead of ending in silence.
+function leafIsStrandedToolUse(session: AgentSession): boolean {
+  const leaf = session.sessionManager.getLeafEntry()
+  if (!leaf || leaf.type !== 'message') return false
+  if (leaf.message.role === 'assistant') {
+    return leaf.message.stopReason === 'toolUse' && visibleAssistantText(leaf.message).trim() === ''
+  }
+  if (leaf.message.role !== 'toolResult') return false
+  let cursor: { parentId: string | null } | undefined = leaf
+  for (let depth = 0; depth < 32 && cursor?.parentId; depth++) {
+    const parent = session.sessionManager.getEntry(cursor.parentId)
+    if (!parent) return false
+    if (parent.type === 'message') {
+      if (parent.message.role === 'assistant') {
+        return parent.message.stopReason === 'toolUse' && visibleAssistantText(parent.message).trim() === ''
+      }
+      if (parent.message.role === 'user') return false
+    }
+    cursor = parent
+  }
+  return false
 }
 
 function visibleAssistantText(message: AssistantMessage): string {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3358,6 +3358,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.skippedTurn = null
       logger.info(`[channels] ${live.keyId} skip_contested_by_send recovering reply`)
     }
+    const postEmptyTurnFallback = async (cause: string): Promise<void> => {
+      logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)
+      const result = await send(
+        {
+          adapter: live.key.adapter,
+          workspace: live.key.workspace,
+          chat: live.key.chat,
+          thread: live.key.thread,
+          text: EMPTY_TURN_FALLBACK_TEXT,
+        },
+        { source: 'system' },
+      )
+      if (!result.ok) {
+        logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
+      }
+    }
+
     // A send landed this turn, but the model may have posted a `continue: true`
     // progress reply, kept working, then ENDED with its final answer as plain
     // prose — never calling a channel tool again. The terminal-reply abort fires
@@ -3378,42 +3395,27 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // work never finished, so the user is left with a bare "checking now…"
         // and nothing after it. Re-prompt the same logical turn so the model
         // completes its investigation and actually replies, instead of ending
-        // in silence. Bounded by MAX_EMPTY_TURN_RETRIES; on exhaustion the turn
-        // falls through to the normal recovery path below (which posts the
-        // fallback). Any postable pre-tool/mid-turn prose is still recovered by
-        // that path — this only adds a retry for the no-prose strand.
-        if (
-          leafIsStrandedToolUse(live.session) &&
-          live.currentTurnAuthorId !== null &&
-          live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES
-        ) {
-          live.emptyTurnRetries++
-          logger.warn(
-            `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
-              `cause=stranded_toolUse_after_send`,
-          )
-          live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
+        // in silence. On retry-exhaustion post the fallback rather than
+        // returning silently — a retry turn that re-sends a status and re-strands
+        // on the same no-prose shape must not deadair the user. Any postable
+        // pre-tool/mid-turn prose is suppressed here as before (it was narration
+        // that accompanied the already-landed reply); only the no-prose strand
+        // gets a retry-or-fallback.
+        if (leafIsStrandedToolUse(live.session) && live.currentTurnAuthorId !== null) {
+          if (live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
+            live.emptyTurnRetries++
+            logger.warn(
+              `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
+                `cause=stranded_toolUse_after_send`,
+            )
+            live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
+          } else {
+            await postEmptyTurnFallback('stranded_toolUse_retries_exhausted')
+          }
         }
         return
       }
       if (live.session.sessionManager.getLeafEntry()?.id === live.lastSendLeafId) return
-    }
-
-    const postEmptyTurnFallback = async (cause: string): Promise<void> => {
-      logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)
-      const result = await send(
-        {
-          adapter: live.key.adapter,
-          workspace: live.key.workspace,
-          chat: live.key.chat,
-          thread: live.key.thread,
-          text: EMPTY_TURN_FALLBACK_TEXT,
-        },
-        { source: 'system' },
-      )
-      if (!result.ok) {
-        logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
-      }
     }
 
     let candidate = recoverableAssistantText(live.session)


### PR DESCRIPTION
## Problem

A channel agent posted a `continue: true` status reply (e.g. "지금 바로 확인할게" / "checking now…"), kept working through several tool calls, then its post-tool follow-up stream was aborted before it could conclude. **The user got the bare status reply and then silence — the promised work never landed and no answer was ever posted.**

### Root cause

This is a recovery-net gap in `validateChannelTurn`, not a model decision:

1. A `continue: true` status reply counts as a **successful channel send**, which disarms the empty-turn / willingness-nudge recovery net for the rest of the turn (the gate at `successfulChannelSends > before`).
2. The model keeps working; its post-tool follow-up LLM stream is then aborted (loop aborted / stream cancelled). The session branch ends on an **unanswered `toolUse`** — leaf is a `toolResult` whose parent assistant has `stopReason: 'toolUse'` and carries no visible prose (thinking + toolCall only).
3. `recoverableAssistantText` returns a `pre-tool`/`mid-turn` shape (not `'leaf'`), so the gate **short-circuits with a silent `return`**. `prompt()` resolves normally (`prompted elapsed_ms=…` on the success path), the turn ends, and the promise is permanently stranded.

Evidence from the incident transcript: the leaf is a `toolResult` under an assistant with `stopReason: "toolUse"`, with **no following assistant message**; container logs show the final model stream `error="cancelled"` and **no** `terminal_after_channel_reply` / `willingness_nudge` / `empty_turn_retry` log — confirming no router recovery fired.

## Fix

Add `leafIsStrandedToolUse(session)` — true when the branch ends on an unanswered `toolUse` (leaf is a `toolUse` assistant, **or** a `toolResult` whose nearest assistant ancestor is `toolUse`) that left **no postable prose**. When a send already happened this turn and the turn strands on that shape, queue one `EMPTY_TURN_RETRY_NUDGE` re-prompt so the model finishes the work it promised and actually replies.

- Bounded by `MAX_EMPTY_TURN_RETRIES`; on exhaustion it falls through to the existing empty-turn fallback.
- The **no-prose** requirement is the discriminator: a model that narrated a reply alongside its tool call (and did land a real send) stays on the existing suppress-as-narration path — no behavior change there.

## Tests

- `continue-reply guard: re-prompts when the turn strands on an unanswered toolUse with no prose` — reproduces the incident (fails before the fix: only 1 prompt; passes after: re-prompts and delivers the conclusion).
- `continue-reply guard: does NOT re-prompt when the trailing toolUse carries narration and a send landed` — locks the no-prose boundary.
- Existing recovery tests (`mid-turn`/`pre-tool`/`leaf`, "does NOT fire when the model successfully replied") still pass.

## Checks

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (64 pre-existing warnings in unrelated files)
- `bun run format:check` — clean
- `bun run test` — 9043 pass, 0 fail