### PR TITLE
docs(landing): deepen feature sections and tell the self-improvement story

### DIFF
--- a/docs/src/app/_components/animated-terminal.tsx
+++ b/docs/src/app/_components/animated-terminal.tsx
@@ -11,20 +11,17 @@ const SCRIPT: Segment[] = [
   { text: '$ ', className: 'text-zinc-400 dark:text-zinc-600' },
   { text: 'typeclaw init', className: 'text-zinc-800 dark:text-zinc-100' },
   { text: '\n', className: '' },
-  { text: 'Egg laid. 🥚', className: 'text-zinc-600 dark:text-zinc-400' },
-  { text: '\n\n', className: '' },
-
-  { text: '$ ', className: 'text-zinc-400 dark:text-zinc-600' },
-  { text: 'typeclaw start', className: 'text-zinc-800 dark:text-zinc-100' },
+  { text: '? ', className: 'text-brand-700 dark:text-brand-300' },
+  { text: 'Provider  ', className: 'text-zinc-600 dark:text-zinc-400' },
+  { text: 'openai · gpt-5.5', className: 'text-zinc-500 dark:text-zinc-500' },
   { text: '\n', className: '' },
+  { text: '? ', className: 'text-brand-700 dark:text-brand-300' },
+  { text: 'Channel   ', className: 'text-zinc-600 dark:text-zinc-400' },
+  { text: 'slack-bot ✓ connected', className: 'text-zinc-500 dark:text-zinc-500' },
+  { text: '\n', className: '' },
+  { text: 'Egg laid. 🥚 ', className: 'text-zinc-600 dark:text-zinc-400' },
   { text: '●', className: 'text-brand-700 dark:text-brand-300' },
-  { text: ' my-agent started on host port 8973', className: 'text-zinc-600 dark:text-zinc-400' },
-  { text: '\n\n', className: '' },
-
-  { text: '$ ', className: 'text-zinc-400 dark:text-zinc-600' },
-  { text: 'typeclaw channel add slack-bot', className: 'text-zinc-800 dark:text-zinc-100' },
-  { text: '\n', className: '' },
-  { text: 'Slack channel added.', className: 'text-zinc-600 dark:text-zinc-400' },
+  { text: ' my-agent hatched on host port 8973', className: 'text-zinc-600 dark:text-zinc-400' },
   { text: '\n\n', className: '' },
 
   { text: '$ ', className: 'text-zinc-400 dark:text-zinc-600' },
@@ -90,7 +87,7 @@ export function AnimatedTerminal({ variant = 'default', title = 'my-agent', clas
       </div>
       <pre
         className="overflow-x-auto p-4 font-mono text-xs leading-relaxed sm:p-5 sm:text-[13px]"
-        aria-label="Animated terminal demo: typeclaw init, start, channel add, then git log"
+        aria-label="Animated terminal demo: typeclaw init wires a provider and channel and hatches the agent, then git log shows it already dreaming"
       >
         <code>
           {rendered.map((seg) => (

--- a/docs/src/app/_components/data.ts
+++ b/docs/src/app/_components/data.ts
@@ -30,14 +30,12 @@ export interface Competitor {
   strength: string
   tradeoff: string
   lang: string
-  readableMemory: CompetitorScore
   knowsWhenToTalk: CompetitorScore
   perAgentIsolation: CompetitorScore
   pluginsAsImports: CompetitorScore
   permissionsGuards: CompetitorScore
   perAgentGitRepo: CompetitorScore
   selfManaging: CompetitorScore
-  channels: CompetitorScore
   highlight?: boolean
 }
 
@@ -47,42 +45,36 @@ export const COMPETITORS: Competitor[] = [
     strength: 'Biggest ecosystem',
     tradeoff: 'a platform to learn, not a codebase to read',
     lang: 'TypeScript',
-    readableMemory: 'partial',
     knowsWhenToTalk: true,
     perAgentIsolation: true,
     pluginsAsImports: true,
     permissionsGuards: true,
     perAgentGitRepo: 'partial',
-    selfManaging: true,
-    channels: true,
+    selfManaging: 'partial',
   },
   {
     name: 'Hermes Agent',
     strength: 'Mature, self-improving',
     tradeoff: 'Python — a boundary if your stack is TS',
     lang: 'Python',
-    readableMemory: true,
     knowsWhenToTalk: 'partial',
     perAgentIsolation: 'partial',
     pluginsAsImports: false,
     permissionsGuards: true,
     perAgentGitRepo: true,
     selfManaging: true,
-    channels: true,
   },
   {
     name: 'TypeClaw',
     strength: 'One TS codebase, plugins as imports',
     tradeoff: 'younger, smaller ecosystem',
     lang: 'TypeScript',
-    readableMemory: true,
     knowsWhenToTalk: true,
     perAgentIsolation: true,
     pluginsAsImports: true,
     permissionsGuards: true,
     perAgentGitRepo: true,
     selfManaging: true,
-    channels: true,
     highlight: true,
   },
 ]
@@ -97,14 +89,12 @@ export interface ComparisonFeature {
 }
 
 export const COMPARISON_FEATURES: ComparisonFeature[] = [
-  { key: 'readableMemory', label: 'Memory you can read' },
   { key: 'knowsWhenToTalk', label: 'Knows when not to talk' },
   { key: 'perAgentIsolation', label: 'Per-agent isolation' },
   { key: 'pluginsAsImports', label: 'Plugins as imports' },
   { key: 'permissionsGuards', label: 'Permissions & guards' },
   { key: 'perAgentGitRepo', label: 'Per-agent git repo' },
   { key: 'selfManaging', label: 'Self-managing' },
-  { key: 'channels', label: 'Channels' },
 ]
 
 export interface MemoryStage {

--- a/docs/src/app/_components/use-case-tabs.tsx
+++ b/docs/src/app/_components/use-case-tabs.tsx
@@ -1,42 +1,165 @@
 'use client'
 
-import { User, Users, PenTool } from 'lucide-react'
+import {
+  Clock,
+  FileText,
+  GitPullRequest,
+  Github,
+  Globe,
+  type LucideIcon,
+  MessageCircle,
+  MessageSquare,
+  PenTool,
+  Send,
+  Share2,
+  Sparkles,
+  User,
+  Users,
+} from 'lucide-react'
 import { useState } from 'react'
 
-const USE_CASES = [
+interface UseCaseStep {
+  icon: LucideIcon
+  text: string
+}
+
+interface UseCase {
+  id: string
+  label: string
+  icon: LucideIcon
+  headline: string
+  channel: { label: string; icon: LucideIcon }
+  steps: UseCaseStep[]
+  footnote: string
+}
+
+const USE_CASES: UseCase[] = [
   {
     id: 'personal',
     label: 'Personal',
     icon: User,
-    text: 'Summarize newsletters, manage your calendar, remember how you like things done — and open memory/ in git to see exactly what it learned about you. Your assistant, your data, your folder.',
+    headline: 'Your newsletter digest, in your inbox by 8am.',
+    channel: { label: 'Telegram DM', icon: Send },
+    steps: [
+      { icon: Clock, text: 'A cron job fires a web-research subagent overnight.' },
+      { icon: Globe, text: 'It reads and summarizes the newsletters that landed.' },
+      { icon: Send, text: 'It posts the digest straight to your Telegram DM.' },
+    ],
+    footnote: 'Memory remembers which sources you skip, so the next digest skips them too.',
   },
   {
     id: 'team',
     label: 'Team',
     icon: Users,
-    text: 'Review PRs, triage issues, keep the standup notes. Add the one tool your team needs in a .ts file you actually own — no waiting on a marketplace, no plugin language to learn.',
+    headline: 'A PR reviewer on call around the clock.',
+    channel: { label: 'GitHub', icon: Github },
+    steps: [
+      { icon: GitPullRequest, text: 'Request @your-agent as a reviewer on the pull request.' },
+      { icon: FileText, text: 'It reads the diff line by line, as a participant in the thread.' },
+      { icon: MessageSquare, text: 'It posts a formal review back, with the reasoning attached.' },
+    ],
+    footnote: 'Add the one tool your team needs in a .ts file you own.',
   },
   {
     id: 'creator',
     label: 'Creator',
     icon: PenTool,
-    text: 'Pipeline content, cross-post to channels, reply to your audience. As it learns your voice, that memory is plain files you can read and edit — never a black box you have to trust.',
+    headline: 'Cross-post once, reply everywhere.',
+    channel: { label: 'Slack · Discord · Telegram', icon: Share2 },
+    steps: [
+      { icon: PenTool, text: 'Draft the post once, in your own words.' },
+      { icon: Sparkles, text: 'It adapts the tone to fit each channel before sending.' },
+      { icon: MessageCircle, text: 'It triages replies and drafts responses in your voice.' },
+    ],
+    footnote: 'The voice it learns is plain files you can read and edit.',
   },
 ]
+
+function UseCaseMock({ id }: { id: string }) {
+  if (id === 'personal') {
+    return (
+      <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-white/[0.08] dark:bg-zinc-900">
+        <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-2.5 dark:border-white/[0.06]">
+          <span className="flex size-6 items-center justify-center rounded-full bg-brand-600 text-white dark:bg-brand-500">
+            <Sparkles className="size-3" strokeWidth={2.4} aria-hidden />
+          </span>
+          <span className="font-mono text-xs text-zinc-600 dark:text-zinc-300">typeey</span>
+          <span className="ml-auto font-mono text-[11px] text-zinc-400 dark:text-zinc-600">08:00</span>
+        </div>
+        <div className="space-y-2 px-4 py-3 text-sm text-zinc-600 dark:text-zinc-400">
+          <p className="text-zinc-800 dark:text-zinc-200">Good morning. Here&apos;s what landed overnight:</p>
+          <p className="text-zinc-500 dark:text-zinc-500">— AI Weekly: new model benchmarks</p>
+          <p className="text-zinc-500 dark:text-zinc-500">— Frontend Digest: View Transitions ship</p>
+        </div>
+      </div>
+    )
+  }
+  if (id === 'team') {
+    return (
+      <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-white/[0.08] dark:bg-zinc-900">
+        <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-2.5 dark:border-white/[0.06]">
+          <Github className="size-4 text-zinc-500 dark:text-zinc-400" strokeWidth={1.8} aria-hidden />
+          <span className="font-mono text-xs text-zinc-600 dark:text-zinc-300">typeey reviewed</span>
+          <span className="ml-auto rounded-full bg-amber-50 px-2 py-0.5 font-mono text-[10px] font-medium tracking-wider text-amber-700 uppercase dark:bg-amber-900/30 dark:text-amber-300">
+            changes requested
+          </span>
+        </div>
+        <div className="space-y-1.5 px-4 py-3">
+          <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-600">src/auth.ts · line 42</p>
+          <p className="text-sm text-zinc-700 dark:text-zinc-300">
+            This token isn&apos;t scoped to the request — tighten it before merge.
+          </p>
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-white/[0.08] dark:bg-zinc-900">
+      <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-2.5 dark:border-white/[0.06]">
+        <PenTool className="size-4 text-brand-600 dark:text-brand-300" strokeWidth={2.2} aria-hidden />
+        <span className="font-mono text-xs text-zinc-600 dark:text-zinc-300">draft → adapted</span>
+      </div>
+      <div className="space-y-2 px-4 py-3 text-sm">
+        <p className="flex items-start gap-2 text-zinc-600 dark:text-zinc-400">
+          <span className="mt-0.5 shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] tracking-wider text-zinc-500 uppercase dark:bg-white/[0.06] dark:text-zinc-400">
+            slack
+          </span>
+          Shipped a thing today — quick thread below.
+        </p>
+        <p className="flex items-start gap-2 text-zinc-600 dark:text-zinc-400">
+          <span className="mt-0.5 shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] tracking-wider text-zinc-500 uppercase dark:bg-white/[0.06] dark:text-zinc-400">
+            telegram
+          </span>
+          New release is live. Here&apos;s what changed.
+        </p>
+      </div>
+    </div>
+  )
+}
 
 export function UseCaseTabs() {
   const [active, setActive] = useState('personal')
   const activeCase = USE_CASES.find((c) => c.id === active)!
+  const ChannelIcon = activeCase.channel.icon
 
   return (
     <div className="mx-auto max-w-3xl">
-      <div className="flex flex-wrap items-center justify-center gap-2 rounded-xl border border-zinc-200 bg-white p-1.5 shadow-sm dark:border-white/[0.08] dark:bg-zinc-900">
+      <div
+        role="tablist"
+        aria-label="Use cases"
+        className="flex flex-wrap items-center justify-center gap-2 rounded-xl border border-zinc-200 bg-white p-1.5 shadow-sm dark:border-white/[0.08] dark:bg-zinc-900"
+      >
         {USE_CASES.map((c) => {
           const Icon = c.icon
           const isActive = active === c.id
           return (
             <button
               key={c.id}
+              type="button"
+              role="tab"
+              id={`use-case-tab-${c.id}`}
+              aria-selected={isActive}
+              aria-controls={`use-case-panel-${c.id}`}
               onClick={() => setActive(c.id)}
               className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium transition-all min-[420px]:flex-none sm:px-4 ${
                 isActive
@@ -44,14 +167,51 @@ export function UseCaseTabs() {
                   : 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-200'
               }`}
             >
-              <Icon className="size-4" strokeWidth={2.4} />
+              <Icon className="size-4" strokeWidth={2.4} aria-hidden />
               {c.label}
             </button>
           )
         })}
       </div>
-      <div className="mt-6 rounded-2xl border border-zinc-200 bg-white p-8 text-center shadow-sm dark:border-white/[0.08] dark:bg-zinc-950">
-        <p className="mx-auto max-w-lg text-base leading-relaxed text-zinc-600 dark:text-zinc-400">{activeCase.text}</p>
+
+      <div
+        role="tabpanel"
+        id={`use-case-panel-${activeCase.id}`}
+        aria-labelledby={`use-case-tab-${activeCase.id}`}
+        tabIndex={0}
+        className="mt-6 grid grid-cols-1 gap-8 rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm sm:p-8 lg:grid-cols-2 lg:gap-10 dark:border-white/[0.08] dark:bg-zinc-950"
+      >
+        <div className="min-w-0">
+          <h3 className="text-balance text-xl font-semibold tracking-tight text-zinc-900 sm:text-2xl dark:text-zinc-100">
+            {activeCase.headline}
+          </h3>
+          <ol className="mt-6 space-y-4">
+            {activeCase.steps.map((step, i) => {
+              const StepIcon = step.icon
+              return (
+                <li key={i} className="flex items-start gap-3">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-brand-50 text-brand-700 dark:bg-brand-950/60 dark:text-brand-300">
+                    <StepIcon className="size-4" strokeWidth={2.2} aria-hidden />
+                  </span>
+                  <p className="pt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">{step.text}</p>
+                </li>
+              )
+            })}
+          </ol>
+          <p className="mt-6 border-t border-zinc-100 pt-4 text-sm leading-relaxed text-zinc-500 dark:border-white/[0.06] dark:text-zinc-500">
+            {activeCase.footnote}
+          </p>
+        </div>
+
+        <div className="min-w-0">
+          <div className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 font-mono text-[11px] font-medium tracking-wider text-zinc-500 uppercase dark:border-white/[0.08] dark:bg-white/[0.02] dark:text-zinc-400">
+            <ChannelIcon className="size-3.5" strokeWidth={2.2} aria-hidden />
+            {activeCase.channel.label}
+          </div>
+          <div className="mt-4">
+            <UseCaseMock id={activeCase.id} />
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -91,8 +91,129 @@
   );
 }
 
+/* Memory tiers: a subtle highlight travels tier-to-tier (streams → topics →
+   skills), then the loop-back pill fires and the cycle restarts. Each element
+   is offset by its tier index (--mem-i) across a shared cycle so the highlight
+   appears to flow. The cycle is split into four slots: three tiers plus the
+   loop-back. */
+.mem-loop {
+  --mem-cycle: 7s;
+  --mem-slot: calc(var(--mem-cycle) / 4);
+}
+
+.mem-tier {
+  animation: mem-tier-glow var(--mem-cycle) ease-in-out infinite;
+  animation-delay: calc(var(--mem-i) * var(--mem-slot));
+  will-change: transform, box-shadow;
+}
+
+.mem-flow {
+  animation: mem-flow-pulse var(--mem-cycle) ease-in-out infinite;
+  animation-delay: calc((var(--mem-i) + 0.5) * var(--mem-slot));
+}
+
+.mem-loopback {
+  animation: mem-loopback-pulse var(--mem-cycle) ease-in-out infinite;
+}
+
+@keyframes mem-tier-glow {
+  0%,
+  18%,
+  100% {
+    transform: translateY(0);
+    box-shadow: 0 0 0 0 rgba(54, 72, 132, 0);
+  }
+  8% {
+    transform: translateY(-3px);
+    box-shadow: 0 0 0 4px rgba(54, 72, 132, 0.12);
+  }
+}
+
+.dark .mem-tier {
+  animation-name: mem-tier-glow-dark;
+}
+
+@keyframes mem-tier-glow-dark {
+  0%,
+  18%,
+  100% {
+    transform: translateY(0);
+    box-shadow: 0 0 0 0 rgba(157, 167, 210, 0);
+  }
+  8% {
+    transform: translateY(-3px);
+    box-shadow: 0 0 0 4px rgba(157, 167, 210, 0.16);
+  }
+}
+
+@keyframes mem-flow-pulse {
+  0%,
+  18%,
+  100% {
+    opacity: 0.45;
+  }
+  8% {
+    opacity: 1;
+  }
+}
+
+@keyframes mem-loopback-pulse {
+  0%,
+  72%,
+  100% {
+    transform: scale(1);
+    background-color: var(--color-brand-50);
+  }
+  82% {
+    transform: scale(1.04);
+    background-color: var(--color-brand-100);
+  }
+}
+
+.dark .mem-loopback {
+  animation-name: mem-loopback-pulse-dark;
+}
+
+@keyframes mem-loopback-pulse-dark {
+  0%,
+  72%,
+  100% {
+    transform: scale(1);
+    background-color: color-mix(in srgb, var(--color-brand-950) 60%, transparent);
+  }
+  82% {
+    transform: scale(1.04);
+    background-color: color-mix(in srgb, var(--color-brand-900) 60%, transparent);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .hero-spotlight-glow {
     transition: none;
   }
+
+  .mem-tier,
+  .dark .mem-tier,
+  .mem-flow,
+  .mem-loopback,
+  .dark .mem-loopback {
+    animation: none;
+  }
+}
+
+/* Shiki dual-theme (defaultColor: false): tokens carry only --shiki-light and
+   --shiki-dark vars with no inline base color, so each theme is selected purely
+   by CSS. The card div owns the background, so the pre stays transparent. */
+.mem-code {
+  background-color: transparent;
+}
+
+.mem-code,
+.mem-code span {
+  color: var(--shiki-light);
+}
+
+.dark .mem-code,
+.dark .mem-code span {
+  color: var(--shiki-dark);
 }

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -1,37 +1,57 @@
-import { ArrowRight, BookOpen, Check, Container, Github, Lock, Minus, Shield, Sparkles, Star, X } from 'lucide-react'
+import { highlight } from 'fumadocs-core/highlight'
+import {
+  ArrowRight,
+  BookOpen,
+  Bot,
+  Check,
+  CheckCheck,
+  CircleDashed,
+  EyeOff,
+  FileText,
+  Github,
+  KeyRound,
+  Layers,
+  Lock,
+  Minus,
+  Network,
+  RefreshCw,
+  Search,
+  Shield,
+  Sparkles,
+  Star,
+  Terminal,
+  User,
+  Waves,
+  X,
+  Zap,
+} from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { Fragment } from 'react'
 
 import { AnimatedTerminal } from './_components/animated-terminal'
 import { CHANNELS } from './_components/channel-icons'
 import { CopyButton } from './_components/copy-button'
-import { COMPARISON_FEATURES, COMPETITORS, INSTALL_COMMAND, MEMORY_LOOP, VERSION } from './_components/data'
+import { COMPARISON_FEATURES, COMPETITORS, INSTALL_COMMAND, VERSION } from './_components/data'
 import { FEATURE_CATEGORIES } from './_components/features-data'
 import { HeroSpotlight } from './_components/hero-spotlight'
 import { Reveal } from './_components/reveal'
 import { ThemeToggle } from './_components/theme-toggle'
 import { UseCaseTabs } from './_components/use-case-tabs'
 
-const PLUGIN_CODE = `import { definePlugin } from 'typeclaw/plugin'
-import { z } from 'zod'
+const SELF_EXTEND_CODE = `import { definePlugin } from 'typeclaw/plugin'
 
 export default definePlugin({
-  configSchema: z.object({ webhook: z.string().url() }),
-  async plugin(ctx) {
-    const { webhook } = ctx.config
-    return {
-      tools: {
-        notify: {
-          description: 'Post a short notification',
-          parameters: z.object({ text: z.string() }),
-          async execute({ text }) {
-            await fetch(webhook, { method: 'POST', body: text })
-            return { content: [{ type: 'text', text: 'sent' }] }
-          },
+  plugin: () => ({
+    tools: {
+      postReview: {
+        description: 'Post a PR review to GitHub',
+        async execute({ url, body }) {
+          /* … */
         },
       },
-    }
-  },
+    },
+  }),
 })`
 
 function HeroInstall() {
@@ -99,27 +119,64 @@ function ChannelTrust() {
   )
 }
 
-function SandboxDiagram() {
+function GroupChatVisual() {
   return (
-    <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl border border-zinc-200 bg-gradient-to-br from-zinc-50 to-white p-5 sm:p-8 dark:border-white/[0.08] dark:from-white/[0.03] dark:to-zinc-950">
-      <div className="relative flex h-full items-center justify-center">
-        <div className="relative w-full max-w-xs">
-          <div className="absolute -inset-4 rounded-2xl border-2 border-dashed border-zinc-300 dark:border-white/[0.1]" />
-          <div className="absolute -top-3 left-4 bg-white px-2 font-mono text-[10px] tracking-widest text-zinc-400 uppercase dark:bg-zinc-950 dark:text-zinc-600">
-            your machine
+    <div className="relative w-full overflow-hidden rounded-2xl border border-zinc-200 bg-gradient-to-br from-zinc-50 to-white p-5 sm:p-7 dark:border-white/[0.08] dark:from-white/[0.03] dark:to-zinc-950">
+      <div className="flex flex-col gap-3.5">
+        <div className="flex items-start gap-2.5">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-zinc-500 dark:bg-white/[0.08] dark:text-zinc-400">
+            <User className="size-3.5" strokeWidth={2.2} aria-hidden />
           </div>
-          <div className="relative rounded-xl border border-brand-200 bg-white p-5 shadow-lg dark:border-brand-800/60 dark:bg-zinc-900">
-            <div className="absolute -top-3 left-4 inline-flex items-center gap-1.5 rounded-md bg-brand-700 px-2 py-0.5 font-mono text-[10px] tracking-wider text-white uppercase dark:bg-brand-600">
-              <Container className="size-3" strokeWidth={2.4} aria-hidden />
-              docker
+          <div className="min-w-0">
+            <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-600">alex</p>
+            <div className="mt-1 rounded-2xl rounded-tl-sm border border-zinc-200 bg-white px-3.5 py-2 text-sm text-zinc-700 dark:border-white/[0.08] dark:bg-zinc-900 dark:text-zinc-300">
+              @jordan can you take the deploy?
             </div>
-            <p className="mt-2 text-sm font-semibold text-zinc-800 dark:text-zinc-100">my-agent</p>
-            <ul className="mt-3 space-y-1.5 font-mono text-xs text-zinc-500 dark:text-zinc-500">
-              <li>~ typeclaw run</li>
-              <li>~ /agent mounted</li>
-              <li>~ slack-bot · up</li>
-              <li>~ cron · 3 jobs</li>
-            </ul>
+            <p className="mt-1.5 inline-flex items-center gap-1.5 font-mono text-[11px] text-zinc-400 dark:text-zinc-600">
+              <EyeOff className="size-3" strokeWidth={2.2} aria-hidden />
+              observing — not addressed to me
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2.5">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-zinc-500 dark:bg-white/[0.08] dark:text-zinc-400">
+            <Bot className="size-3.5" strokeWidth={2.2} aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-zinc-400 dark:text-zinc-600">
+              ci-bot
+              <span className="rounded bg-zinc-200 px-1 text-[9px] tracking-wider text-zinc-500 uppercase dark:bg-white/[0.08] dark:text-zinc-400">
+                bot
+              </span>
+            </p>
+            <div className="mt-1 rounded-2xl rounded-tl-sm border border-zinc-200 bg-white px-3.5 py-2 text-sm text-zinc-500 dark:border-white/[0.08] dark:bg-zinc-900 dark:text-zinc-500">
+              build passed
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2.5">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-zinc-500 dark:bg-white/[0.08] dark:text-zinc-400">
+            <User className="size-3.5" strokeWidth={2.2} aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-600">sam</p>
+            <div className="mt-1 rounded-2xl rounded-tl-sm border border-zinc-200 bg-white px-3.5 py-2 text-sm text-zinc-700 dark:border-white/[0.08] dark:bg-zinc-900 dark:text-zinc-300">
+              <span className="font-medium text-brand-700 dark:text-brand-300">@typeey</span> draft the changelog?
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2.5">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-brand-600 text-white dark:bg-brand-500">
+            <Sparkles className="size-3.5" strokeWidth={2.4} aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <p className="font-mono text-[11px] text-brand-600 dark:text-brand-300">typeey</p>
+            <div className="mt-1 rounded-2xl rounded-tl-sm border border-brand-200 bg-brand-50 px-3.5 py-2 text-sm text-brand-900 shadow-sm dark:border-brand-800/60 dark:bg-brand-950/50 dark:text-brand-100">
+              On it — drafting the changelog now.
+            </div>
           </div>
         </div>
       </div>
@@ -127,21 +184,202 @@ function SandboxDiagram() {
   )
 }
 
-function PluginCode() {
+function SubagentVisual() {
+  const children = [
+    { label: 'research', icon: Search },
+    { label: 'review', icon: CheckCheck },
+    { label: 'execute', icon: Terminal },
+  ]
+  return (
+    <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl border border-zinc-200 bg-gradient-to-br from-zinc-50 to-white p-5 sm:p-8 dark:border-white/[0.08] dark:from-white/[0.03] dark:to-zinc-950">
+      <div className="flex h-full flex-col items-center justify-center">
+        <div className="inline-flex items-center gap-2 rounded-xl border border-brand-200 bg-white px-4 py-2.5 shadow-sm dark:border-brand-800/60 dark:bg-zinc-900">
+          <Network className="size-4 text-brand-600 dark:text-brand-300" strokeWidth={2.4} aria-hidden />
+          <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100">main session</span>
+        </div>
+        <div
+          aria-hidden
+          className="h-6 w-px bg-gradient-to-b from-brand-300 to-brand-200 dark:from-brand-700 dark:to-brand-800/50"
+        />
+        <div
+          aria-hidden
+          className="h-px w-3/4 bg-gradient-to-r from-transparent via-brand-200 to-transparent dark:via-brand-800/60"
+        />
+        <div className="mt-5 grid w-full grid-cols-3 gap-2.5 sm:gap-3">
+          {children.map(({ label, icon: Icon }) => (
+            <div
+              key={label}
+              className="flex flex-col items-center gap-2 rounded-xl border border-zinc-200 bg-white px-2 py-3 text-center shadow-sm dark:border-white/[0.08] dark:bg-zinc-900"
+            >
+              <span className="inline-flex size-8 items-center justify-center rounded-lg bg-brand-50 text-brand-700 dark:bg-brand-950/60 dark:text-brand-300">
+                <Icon className="size-4" strokeWidth={2.2} aria-hidden />
+              </span>
+              <span className="font-mono text-xs font-medium text-zinc-700 dark:text-zinc-300">{label}</span>
+              <span className="text-[10px] leading-tight text-zinc-400 dark:text-zinc-600">own context</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SecurityVisual() {
+  const layers = [
+    { icon: Shield, label: 'Guards', detail: 'severity-classified policies' },
+    { icon: KeyRound, label: 'Roles', detail: 'who can bypass what' },
+    { icon: Lock, label: 'Sandbox', detail: 'each bash call isolated' },
+  ]
+  return (
+    <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl border border-zinc-200 bg-gradient-to-br from-zinc-50 to-white p-5 sm:p-8 dark:border-white/[0.08] dark:from-white/[0.03] dark:to-zinc-950">
+      <div className="flex h-full flex-col justify-center gap-2.5">
+        <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1 font-mono text-[11px] text-zinc-500 shadow-sm dark:border-white/[0.08] dark:bg-zinc-900 dark:text-zinc-400">
+          tool call
+        </div>
+        {layers.map(({ icon: Icon, label, detail }) => (
+          <div key={label} className="flex flex-col items-center gap-2.5">
+            <ArrowRight
+              className="size-3.5 rotate-90 text-brand-300 dark:text-brand-700"
+              strokeWidth={2.4}
+              aria-hidden
+            />
+            <div className="flex w-full items-center gap-3 rounded-xl border border-brand-200 bg-white px-4 py-2.5 shadow-sm dark:border-brand-800/60 dark:bg-zinc-900">
+              <Icon className="size-4 shrink-0 text-brand-600 dark:text-brand-300" strokeWidth={2.4} aria-hidden />
+              <div className="min-w-0">
+                <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100">{label}</span>
+                <span className="ml-2 text-xs text-zinc-400 dark:text-zinc-600">{detail}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+        <ArrowRight
+          className="mx-auto size-3.5 rotate-90 text-brand-300 dark:text-brand-700"
+          strokeWidth={2.4}
+          aria-hidden
+        />
+        <div className="mx-auto inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 font-mono text-[11px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
+          <Check className="size-3.5" strokeWidth={2.6} aria-hidden />
+          fires, contained
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SelfManagingVisual() {
+  const fields = [
+    { line: '"model": "gpt-5.5"', state: 'live' as const },
+    { line: '"cron": [ … ]', state: 'live' as const },
+    { line: '"channels": { … }', state: 'live' as const },
+    { line: '"sandbox": "proc-bind"', state: 'restart' as const },
+    { line: '"port": 8973', state: 'restart' as const },
+  ]
   return (
     <div className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-lg dark:border-white/[0.08] dark:bg-zinc-950">
       <div className="flex items-center justify-between border-b border-zinc-100 bg-zinc-50 px-4 py-2.5 dark:border-white/[0.04] dark:bg-white/[0.02]">
-        <div className="flex gap-1.5">
-          <span className="size-2.5 rounded-full bg-zinc-300 dark:bg-zinc-700" />
-          <span className="size-2.5 rounded-full bg-zinc-300 dark:bg-zinc-700" />
-          <span className="size-2.5 rounded-full bg-zinc-300 dark:bg-zinc-700" />
+        <div className="flex items-center gap-2">
+          <FileText className="size-3.5 text-brand-600 dark:text-brand-300" strokeWidth={2.2} aria-hidden />
+          <span className="font-mono text-xs text-zinc-500 dark:text-zinc-400">typeclaw.json</span>
         </div>
-        <span className="font-mono text-xs text-zinc-400 dark:text-zinc-600">plugins/pr-review.ts</span>
-        <span className="size-2.5" />
+        <div className="flex items-center gap-2 font-mono text-[10px] tracking-wider uppercase">
+          <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+            <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden />
+            live
+          </span>
+          <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+            <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />
+            restart
+          </span>
+        </div>
       </div>
-      <pre className="overflow-x-auto p-4 font-mono text-xs leading-relaxed text-zinc-700 sm:p-5 sm:text-[13px] dark:text-zinc-300">
-        <code>{PLUGIN_CODE}</code>
-      </pre>
+      <div className="divide-y divide-zinc-100 font-mono text-xs sm:text-[13px] dark:divide-white/[0.04]">
+        {fields.map(({ line, state }) => (
+          <div key={line} className="flex items-center justify-between gap-3 px-4 py-2.5 sm:px-5">
+            <span className="truncate text-zinc-700 dark:text-zinc-300">{line}</span>
+            {state === 'live' ? (
+              <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-medium tracking-wider text-emerald-700 uppercase dark:bg-emerald-900/30 dark:text-emerald-300">
+                live
+              </span>
+            ) : (
+              <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium tracking-wider text-amber-700 uppercase dark:bg-amber-900/30 dark:text-amber-300">
+                restart
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+async function SelfExtendVisual() {
+  const highlighted = await highlight(SELF_EXTEND_CODE, {
+    lang: 'typescript',
+    themes: { light: 'github-light', dark: 'github-dark' },
+    defaultColor: false,
+    components: {
+      pre: ({ children, ...props }) => (
+        <pre
+          {...props}
+          className="mem-code overflow-x-auto p-4 font-mono text-xs leading-relaxed sm:p-5 sm:text-[13px]"
+        >
+          {children}
+        </pre>
+      ),
+    },
+  })
+  return (
+    <div className="relative w-full overflow-hidden rounded-2xl border border-zinc-200 bg-gradient-to-br from-zinc-50 to-white p-5 sm:p-7 dark:border-white/[0.08] dark:from-white/[0.03] dark:to-zinc-950">
+      <div className="flex flex-col gap-2.5">
+        <div className="flex items-center gap-3 rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-3 dark:border-white/[0.12] dark:bg-white/[0.02]">
+          <CircleDashed className="size-4 shrink-0 text-zinc-400 dark:text-zinc-600" strokeWidth={2.2} aria-hidden />
+          <div className="min-w-0 flex-1">
+            <p className="font-mono text-[11px] tracking-wider text-zinc-400 uppercase dark:text-zinc-600">needs</p>
+            <p className="truncate text-sm text-zinc-600 dark:text-zinc-400">post PR reviews to GitHub</p>
+          </div>
+          <span className="shrink-0 rounded-full border border-zinc-200 bg-white px-2 py-0.5 font-mono text-[10px] tracking-wider text-zinc-400 uppercase dark:border-white/[0.08] dark:bg-zinc-900 dark:text-zinc-600">
+            no tool yet
+          </span>
+        </div>
+
+        <ArrowRight
+          className="mx-auto size-3.5 rotate-90 text-brand-300 dark:text-brand-700"
+          strokeWidth={2.4}
+          aria-hidden
+        />
+
+        <div className="overflow-hidden rounded-xl border border-brand-200 bg-white shadow-sm dark:border-brand-800/60 dark:bg-zinc-950">
+          <div className="flex items-center justify-between gap-2 border-b border-zinc-100 bg-zinc-50 px-3.5 py-2 dark:border-white/[0.04] dark:bg-white/[0.02]">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-50 px-2 py-0.5 font-mono text-[10px] font-medium text-brand-700 dark:bg-brand-950/60 dark:text-brand-300">
+              <Sparkles className="size-3" strokeWidth={2.4} aria-hidden />
+              written by my-agent
+            </span>
+            <span className="truncate font-mono text-[11px] text-zinc-400 dark:text-zinc-600">
+              plugins/pr-review.ts
+            </span>
+          </div>
+          {highlighted}
+        </div>
+
+        <ArrowRight
+          className="mx-auto size-3.5 rotate-90 text-brand-300 dark:text-brand-700"
+          strokeWidth={2.4}
+          aria-hidden
+        />
+
+        <div className="flex items-center gap-3 rounded-xl border border-brand-200 bg-brand-50 px-4 py-3 shadow-sm dark:border-brand-800/60 dark:bg-brand-950/50">
+          <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-lg bg-brand-600 text-white dark:bg-brand-500">
+            <Check className="size-4" strokeWidth={2.6} aria-hidden />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="font-mono text-sm font-medium text-brand-900 dark:text-brand-100">postReview</p>
+            <p className="text-[11px] text-brand-700/70 dark:text-brand-300/70">now in its toolset</p>
+          </div>
+          <span className="shrink-0 rounded-full bg-brand-600 px-2 py-0.5 font-mono text-[10px] font-medium tracking-wider text-white uppercase dark:bg-brand-500">
+            ready
+          </span>
+        </div>
+      </div>
     </div>
   )
 }
@@ -165,31 +403,87 @@ function CapabilityGrid() {
   )
 }
 
-function MemoryLoopVertical() {
+const MEMORY_TIERS = [
+  {
+    icon: Waves,
+    kind: 'Short-term',
+    label: 'Streams',
+    path: 'memory/streams/',
+    blurb: 'Every reply and tool call lands in a daily log as it happens — the raw record of what it just did.',
+  },
+  {
+    icon: Layers,
+    kind: 'Long-term',
+    label: 'Topics',
+    path: 'memory/topics/',
+    blurb:
+      'The dreaming subagent distills those days into sharded knowledge, one subject per file, that it can recall later.',
+  },
+  {
+    icon: Zap,
+    kind: 'Muscle memory',
+    label: 'Skills',
+    path: 'memory/skills/',
+    blurb:
+      'Recurring procedures get written into reusable skills it loads automatically — things it can do without thinking them through again.',
+    peak: true,
+  },
+]
+
+function MemoryTiers() {
   return (
-    <div className="relative">
-      <ol className="space-y-1">
-        {MEMORY_LOOP.map((stage, i) => (
-          <li key={stage.label} className="relative pl-12">
-            <div className="absolute top-0 left-0 flex size-9 items-center justify-center rounded-full border-2 border-brand-200 bg-white font-mono text-xs font-semibold text-brand-700 dark:border-brand-800/60 dark:bg-zinc-950 dark:text-brand-300">
-              {i + 1}
-            </div>
-            {i < MEMORY_LOOP.length - 1 && (
-              <div
-                aria-hidden
-                className="absolute top-9 left-[18px] h-12 w-px bg-gradient-to-b from-brand-300 to-brand-100 dark:from-brand-700 dark:to-brand-900/30"
-              />
+    <div className="mem-loop">
+      <div className="grid grid-cols-1 items-stretch gap-3 sm:grid-cols-[1fr_auto_1fr_auto_1fr]">
+        {MEMORY_TIERS.map(({ icon: Icon, kind, label, path, blurb, peak }, i) => (
+          <Fragment key={label}>
+            {i > 0 && (
+              <div aria-hidden className="flex items-center justify-center py-1 sm:py-0">
+                <ArrowRight
+                  className="mem-flow size-5 rotate-90 text-brand-400 sm:rotate-0 dark:text-brand-500"
+                  strokeWidth={2.4}
+                  style={{ '--mem-i': i - 1 } as React.CSSProperties}
+                />
+              </div>
             )}
-            <div className="pb-6">
-              <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{stage.label}</p>
-              <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">{stage.blurb}</p>
+            <div
+              style={{ '--mem-i': i } as React.CSSProperties}
+              className={`mem-tier relative flex flex-col rounded-2xl border p-5 shadow-sm ${
+                peak
+                  ? 'border-brand-300 bg-gradient-to-br from-brand-50 to-white dark:border-brand-700/70 dark:from-brand-950/60 dark:to-zinc-950'
+                  : 'border-zinc-200 bg-white dark:border-white/[0.08] dark:bg-white/[0.02]'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className={`inline-flex size-10 items-center justify-center rounded-xl ${
+                    peak
+                      ? 'bg-brand-600 text-white dark:bg-brand-500'
+                      : 'bg-brand-50 text-brand-700 dark:bg-brand-950/60 dark:text-brand-300'
+                  }`}
+                >
+                  <Icon className="size-5" strokeWidth={2.2} aria-hidden />
+                </span>
+                <span className="font-mono text-[11px] text-zinc-400 dark:text-zinc-600" aria-hidden>
+                  0{i + 1}
+                </span>
+              </div>
+              <p className="mt-4 font-mono text-[11px] tracking-[0.14em] text-brand-700 uppercase dark:text-brand-300">
+                {kind}
+              </p>
+              <p className="mt-1 text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{label}</p>
+              <code className="mt-1 font-mono text-[11px] text-zinc-400 dark:text-zinc-600">{path}</code>
+              <p className="mt-3 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">{blurb}</p>
             </div>
-          </li>
+          </Fragment>
         ))}
-      </ol>
-      <div className="mt-2 inline-flex items-center gap-2 rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 dark:bg-brand-950/60 dark:text-brand-300">
-        <ArrowRight className="size-3.5 -rotate-90" strokeWidth={2.4} aria-hidden />
-        loops back into the next session log
+      </div>
+      <div className="mt-5 flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-500">
+        <span aria-hidden className="h-px flex-1 bg-gradient-to-r from-transparent to-brand-200 dark:to-brand-800/60" />
+        <span className="mem-loopback inline-flex items-center gap-1.5 rounded-full bg-brand-50 px-3 py-1 font-medium text-brand-700 dark:bg-brand-950/60 dark:text-brand-300">
+          <RefreshCw className="size-3.5" strokeWidth={2.4} aria-hidden />
+          what it learns loops back into the next session
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-gradient-to-l from-transparent to-brand-200 dark:to-brand-800/60" />
       </div>
     </div>
   )
@@ -255,8 +549,15 @@ function MarketingTable() {
                 <div className="mt-1.5 font-mono text-[11px] font-normal tracking-normal text-zinc-400 normal-case dark:text-zinc-500">
                   {r.lang}
                 </div>
-                <p className="mx-auto mt-2 max-w-[13rem] text-xs font-normal leading-snug tracking-normal text-zinc-500 normal-case dark:text-zinc-500">
-                  {r.strength} · {r.tradeoff}
+                <p
+                  className={`mx-auto mt-3 max-w-[12rem] text-[13px] font-semibold leading-snug tracking-normal normal-case ${
+                    r.highlight ? 'text-brand-700 dark:text-brand-300' : 'text-zinc-700 dark:text-zinc-200'
+                  }`}
+                >
+                  {r.strength}
+                </p>
+                <p className="mx-auto mt-1.5 max-w-[12rem] text-[11px] font-normal leading-relaxed tracking-normal text-zinc-400 normal-case dark:text-zinc-500">
+                  {r.tradeoff}
                 </p>
               </th>
             ))}
@@ -310,23 +611,6 @@ function FeatureRow({ eyebrow, title, blurb, reverse, visual }: FeatureRowProps)
         <p className="mt-4 max-w-md text-base leading-relaxed text-zinc-600 dark:text-zinc-400">{blurb}</p>
       </div>
       <div className={reverse ? 'min-w-0 lg:order-1' : 'min-w-0'}>{visual}</div>
-    </div>
-  )
-}
-
-function PermissionsVisual() {
-  return (
-    <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl border border-zinc-200 bg-gradient-to-br from-zinc-50 to-white p-5 sm:p-8 dark:border-white/[0.08] dark:from-white/[0.03] dark:to-zinc-950">
-      <div className="flex h-full flex-col items-center justify-center gap-4">
-        <div className="flex items-center gap-3 rounded-xl border border-brand-200 bg-white px-5 py-3 shadow-sm dark:border-brand-800/60 dark:bg-zinc-900">
-          <Shield className="size-5 text-brand-600 dark:text-brand-300" strokeWidth={2.4} />
-          <div className="text-sm font-medium text-zinc-800 dark:text-zinc-100">Owner → Full access</div>
-        </div>
-        <div className="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white px-5 py-3 shadow-sm dark:border-white/[0.08] dark:bg-zinc-900">
-          <Lock className="size-5 text-zinc-400 dark:text-zinc-600" strokeWidth={2.4} />
-          <div className="text-sm font-medium text-zinc-800 dark:text-zinc-100">Guest → Read only</div>
-        </div>
-      </div>
     </div>
   )
 }
@@ -491,45 +775,61 @@ export default function Home() {
               Memory you can read
             </p>
             <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-              It gets sharper while you sleep — and you can read every word it learned.
+              It gets sharper while you sleep — building muscle memory you can read.
             </h2>
             <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-zinc-600 dark:text-zinc-400">
-              A dreaming subagent distills each day&apos;s work into long-term memory and reusable skills. It all lands
-              as plain files, committed to git — so you can review what it picked up, revert what it got wrong, and own
-              its memory like the rest of your code. Self-improving, never a black box.
+              A dreaming subagent distills each day&apos;s work into long-term memory, and the moves it makes often
+              become muscle memory — reusable skills it writes for itself and loads on later runs. It all lands as plain
+              files, committed to git, so you can review what it picked up, revert what it got wrong, and own its memory
+              like the rest of your code. Plain files you can read, not a black box.
             </p>
           </Reveal>
-          <Reveal className="mx-auto mt-12 max-w-lg" delay={120}>
-            <div className="rounded-2xl border border-brand-100 bg-gradient-to-br from-brand-50/80 to-white p-8 dark:border-brand-900/40 dark:from-brand-950/40 dark:to-zinc-950">
-              <MemoryLoopVertical />
-            </div>
+          <Reveal className="mt-14" delay={120}>
+            <MemoryTiers />
           </Reveal>
         </section>
 
         <section className="mx-auto max-w-6xl space-y-24 px-5 py-24 sm:space-y-36 sm:px-6 sm:py-36">
           <Reveal>
             <FeatureRow
-              eyebrow="Plugins are just imports"
-              title="Extend it from inside the language you already use."
-              blurb="No plugin DSL, no IPC, no FFI, no sidecar process. A plugin is a plain .ts file that imports the runtime and adds tools, skills, channels, and commands. The same TypeScript, all the way down — nothing to bolt on."
-              visual={<PluginCode />}
+              eyebrow="Knows when not to talk"
+              title="It reads the room — and stays quiet when the message wasn't for it."
+              blurb="In a busy channel it tells humans from bots, tracks who's present, and engages on a structural decision rather than a guess. When a message clearly targets someone else, it holds back; mid-thread with you, it stays engaged without being re-mentioned, then steps back when the conversation moves on. Peer-bot loop guards and flood filters keep it from spiraling."
+              visual={<GroupChatVisual />}
             />
           </Reveal>
           <Reveal>
             <FeatureRow
-              eyebrow="One folder, one container"
-              title="A whole agent you can hold in your head."
-              blurb="It lives in a single folder and runs in its own container — its own .env, its own memory, its own channels. The container is the trust boundary; nothing it does reaches the rest of your machine. Done with it? Delete the folder. It's gone, no residue."
+              eyebrow="A bench of specialists"
+              title="It delegates to focused specialists, each in a clean context."
+              blurb="It hands off research, planning, review, and hands-on execution to child sessions — each with its own system prompt, tools, and model. Spawn and wait for a result, or fan work out in the background and collect completions later. Coalescing drops duplicate concurrent runs and depth limits keep delegation chains bounded."
               reverse
-              visual={<SandboxDiagram />}
+              visual={<SubagentVisual />}
             />
           </Reveal>
           <Reveal>
             <FeatureRow
-              eyebrow="You hold the keys"
-              title="A stranger in Slack can't push to main. You can."
-              blurb="Owner, trusted, member, guest — role-based permissions gate every action, per channel. The agent knows who's in the room and exactly what they're allowed to ask for. Powerful in your hands, harmless in everyone else's."
-              visual={<PermissionsVisual />}
+              eyebrow="Defense in depth"
+              title="Every tool call runs a gauntlet before it fires."
+              blurb="Risky actions pass through layered guards classified by severity — secret exfiltration, SSRF, prompt injection, rogue git pushes, and silent privilege escalation get stopped before they happen. Roles gate who can bypass what, and each bash call runs inside its own sandbox. Powerful in trusted hands, contained everywhere else."
+              visual={<SecurityVisual />}
+            />
+          </Reveal>
+          <Reveal>
+            <FeatureRow
+              eyebrow="Operational autonomy"
+              title="It knows its own config — so it won't strand itself."
+              blurb="It can back itself up, rebuild, and restart its own container through the host daemon. The difference: it knows which settings take effect live and which need a restart, so it won't brick itself with a change that silently does nothing. When it does restart, it hands off to the rebooted container and picks the same conversation back up — no cold-starting into silence. And when it keeps working on its own, hard budgets on turns, tokens, and wall-clock keep it from spiraling."
+              reverse
+              visual={<SelfManagingVisual />}
+            />
+          </Reveal>
+          <Reveal>
+            <FeatureRow
+              eyebrow="Plugin system"
+              title="It writes its own tools — as TypeScript plugins."
+              blurb="When a recurring job needs more than it ships with — a custom tool, a scheduled hook, a new channel — it writes itself a plugin to do it. A plugin is just a TypeScript file that imports the runtime: no DSL, no IPC, no sidecar. The same language it already runs in, so the harness it builds for itself is code you can read and keep."
+              visual={<SelfExtendVisual />}
             />
           </Reveal>
         </section>
@@ -537,10 +837,10 @@ export default function Home() {
         <section className="mx-auto max-w-3xl px-5 pb-24 sm:px-6 sm:pb-36">
           <Reveal className="mb-10 text-center">
             <p className="font-mono text-xs tracking-[0.2em] text-brand-700 uppercase dark:text-brand-300">
-              one minute, end to end
+              one command to alive
             </p>
             <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-              Three commands in. It&apos;s already learning.
+              One <code className="font-mono text-3xl sm:text-4xl">init</code> — wired, hatched, already learning.
             </h2>
           </Reveal>
           <Reveal delay={120}>
@@ -601,10 +901,16 @@ export default function Home() {
           />
           <Reveal className="relative mx-auto max-w-3xl px-5 text-center sm:px-6">
             <Image src="/typeey-cutout.png" alt="" width={120} height={120} aria-hidden className="mx-auto" />
-            <h2 className="mt-4 text-balance text-5xl font-semibold tracking-tight sm:text-6xl">Make it yours.</h2>
-            <p className="mx-auto mt-4 max-w-lg text-balance text-base text-zinc-600 dark:text-zinc-400">
-              One folder, one container, one language you already know. Spin one up, read the whole thing, fork it if
-              you like. Trying it costs nothing.
+            <p className="font-mono text-xs tracking-[0.2em] text-brand-700 uppercase dark:text-brand-300">
+              built for people like you
+            </p>
+            <h2 className="mt-3 text-balance text-5xl font-semibold tracking-tight sm:text-6xl">
+              Made with care. Now make it yours.
+            </h2>
+            <p className="mx-auto mt-4 max-w-xl text-balance text-base leading-relaxed text-zinc-600 dark:text-zinc-400">
+              Every detail here was sweated over — because the details are the point. One folder, one container, one
+              language you already know. Spin one up, read it end to end, and shape it until it&apos;s exactly the agent
+              you wanted. Trying it costs nothing.
             </p>
             <div className="mt-8 flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
               <Link
@@ -638,7 +944,10 @@ export default function Home() {
             <p className="mt-3 max-w-xs text-sm leading-relaxed text-zinc-500 dark:text-zinc-500">
               Crafted in every detail — it behaves in your team&apos;s chat and gets sharper the longer it runs.
             </p>
-            <p className="mt-6 text-xs text-zinc-400 dark:text-zinc-600">© {new Date().getFullYear()} TypeClaw · MIT</p>
+            <p className="mt-6 text-xs text-zinc-400 dark:text-zinc-600">
+              © {new Date().getFullYear()} TypeClaw · Made with{' '}
+              <span className="text-rose-500 dark:text-rose-400">❤</span> from Seoul
+            </p>
           </div>
           <div>
             <p className="text-xs font-medium tracking-wider text-zinc-400 uppercase dark:text-zinc-500">Product</p>

--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -268,9 +268,9 @@ function SecurityVisual() {
 
 function SelfManagingVisual() {
   const fields = [
-    { line: '"model": "gpt-5.5"', state: 'live' as const },
-    { line: '"cron": [ … ]', state: 'live' as const },
+    { line: '"models": { … }', state: 'live' as const },
     { line: '"channels": { … }', state: 'live' as const },
+    { line: '"alias": { … }', state: 'live' as const },
     { line: '"sandbox": "proc-bind"', state: 'restart' as const },
     { line: '"port": 8973', state: 'restart' as const },
   ]
@@ -837,7 +837,7 @@ export default function Home() {
         <section className="mx-auto max-w-3xl px-5 pb-24 sm:px-6 sm:pb-36">
           <Reveal className="mb-10 text-center">
             <p className="font-mono text-xs tracking-[0.2em] text-brand-700 uppercase dark:text-brand-300">
-              one command to alive
+              one command to hatch
             </p>
             <h2 className="mt-3 text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
               One <code className="font-mono text-3xl sm:text-4xl">init</code> — wired, hatched, already learning.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "format:check": "oxfmt --check .",
     "check": "bun run typecheck && bun run lint && bun run format:check",
     "test": "bun test --parallel",
+    "dev:docs": "cd docs && bun run dev",
     "generate:schema": "bun run scripts/generate-schema.ts",
     "debug:prompt": "bun run scripts/dump-system-prompt.ts",
     "postinstall": "bun run scripts/generate-schema.ts"


### PR DESCRIPTION
## Background

The in-depth feature section of the landing page was built weeks ago and only covered three capabilities (plugins-as-imports, one-folder/one-container, permissions). TypeClaw has grown a lot since — the page wasn't showing the strongest, most differentiating features, and the use-case section had thinned to a few one-line blurbs. The memory story in particular was both under-sold and, after a first pass, duplicated across two diagrams.

## Summary

Reshapes the middle of the page around what actually makes TypeClaw distinct, keeping the existing section order (hero → channels → grid → in-depth → use cases → terminal → comparison → epilogue).

- **In-depth feature rows** rebuilt around the strongest capabilities: self-improving memory, group-chat awareness, subagents, defense-in-depth, and config-aware self-management ("it knows live vs restart-required config, so it won't strand itself"). Copy is grounded in the real mechanisms (engagement gate, subagent dispatch, security guard tiers, the config field fence) and follows the repo's honest-framing rules — no counting, no absolutes.
- **Memory** gets a three-tier "capability ladder" — short-term streams → long-term topics → muscle-memory skills — with a single animated loop visual. Why one visual and not two: the earlier version stacked a 4-step loop box *and* a 3-card ladder that explained the same pipeline twice; collapsing them removes the redundancy and keeps the loop concept in one place. Paths (`memory/streams |topics|skills`) are verified against the bundled memory plugin.
- **Plugins** reframed from "the plugin system" to "the agent extends itself": a gap → it writes its own TypeScript plugin → the tool is ready. The code peek now uses build-time Shiki highlighting (via `fumadocs-core/highlight`, dual light/dark, `defaultColor: false` so theme switching is pure CSS).
- **Use cases** upgraded to concrete per-channel scenarios with mock cards.
- **Comparison table** trimmed to real differentiators (dropped the Channels and Memory rows; OpenClaw self-managing → partial), and the column header split strength/tradeoff into a clean two-line hierarchy instead of a run-on.
- **Epilogue + footer** reworked to land the perfectionist/craft voice; footer now reads "Made with ❤ from Seoul".
- Adds a root `dev:docs` script so the docs site can be run from the repo root.

## Preview

UI changes across the landing page — best reviewed by running `bun run dev:docs`. The "three commands" terminal was also corrected to reflect reality: `typeclaw init` runs the wizard (wires a channel inline and hatches the container), rather than implying separate `start`/`channel add` steps.

## What this does NOT do

- No changes to `src/` or runtime behavior — docs-site only, plus the one root script.
- Does not touch `features-data.ts`/`data.ts` consumers beyond the comparison-table fields.
- Does not regenerate `typeclaw.schema.json` (a pre-existing drift-guard failure on `main` is unrelated to this PR — no schema/src files are touched here).

## Review notes

- The load-bearing visual detail is the Shiki dual-theme setup: with `defaultColor: false`, tokens emit only `--shiki-light`/`--shiki-dark` vars (no inline `color`/`background`), and the `.mem-code` CSS in `globals.css` selects per theme while the card div owns the background. Verified in the built HTML that no inline `background-color:#fff` leaks into the `pre`.
- Memory tier paths and the dreaming/self-extension framing are grounded in `src/bundled-plugins/memory/README.md`.