### PR TITLE
fix(readme): center header with align attrs; polish landing accent and mascot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <img src="./docs/public/typeclaw-transparent.png" alt="TypeClaw logo" width="240" />
 </p>
 
-<center><h3>The agent for perfectionists</h3></center>
-<center><blockquote>Crafted in every detail – it behaves in your team's chat and<br />gets sharper the longer it runs. Sandboxed and self-managing.</blockquote></center>
+<h3 align="center">The agent for perfectionists</h3>
+<p align="center">Crafted in every detail – it behaves in your team's chat and<br />gets sharper the longer it runs. Sandboxed and self-managing.</p>
 
 ## Why?
 


### PR DESCRIPTION
## Background

GitHub's HTML sanitizer strips `<center>` entirely — it is not on its allowlist. The typeclaw README used that element to center the "The agent for perfectionists" heading and the tagline beneath it, so both rendered left-aligned on github.com. The logo had already used the allowed align-attribute pattern correctly; the heading and tagline had not.

Separately, the hero mascot (typeey-cutout.png) was refreshed to a square 1310×1310 px version, but the landing page Image component still declared the old 895×858 intrinsic dimensions, causing Next.js to letterbox it smaller. The light-mode landing page also had an accessibility gap: the "now in its toolset" caption ran at 70% opacity over a brand-50 card, compositing to ~2.82:1 contrast at 11 px — below WCAG AA.

## Summary

**README centering.** The two center-element wrappers are replaced with the align attribute. Heading:

```html
<h3 align="center">…</h3>
```

Tagline uses a centered paragraph rather than a centered blockquote, because GitHub's sanitizer also strips align on blockquote elements. No content changes.

**Landing accent fix.** Drops the `/70` opacity modifier from the "now in its toolset" caption so the full accent color (#4f5ed7) is used (~4.84:1 on the brand-50 card, clears WCAG AA). Dark variant unchanged — the lightening there aided legibility and was not flagged.

**Hero mascot sizing.** Corrects the Image intrinsic dimensions to 1310×1310 and bumps the displayed width, carried over from the preceding landing-polish pass.

**Logo asset.** Adds a transparent-background logo variant and refreshes the cutout mascot.

## Preview

The README heading and tagline now render centered on github.com. The landing accent caption renders at full opacity. No visual change in dark mode.

## What this does NOT do

- Does not change any `src/` runtime code — docs and assets only.
- Does not touch the brand-* Tailwind scale or any dark-mode class.
- Does not re-tune contrast anywhere other than the one caption flagged in review.

## Review notes

**README allowlist invariant.** GitHub's allowlist accepts align on h3, p, img, and div, but not on blockquote. The old center-element wrapper around a blockquote failed on both counts: the center element was stripped, and align on blockquote would also be stripped. The `<p align="center">` pattern is the correct approach for centered prose on github.com.

**Accent fix scope.** Search page.tsx for the caption element — the only changed class is removal of the `/70` opacity modifier on the light-mode token. Every dark: variant in the file is byte-for-byte unchanged.