### PR TITLE
feat: close WSL2 (Windows) compatibility gaps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Normalize line endings to LF so checkouts under Git for Windows
+# (core.autocrlf=true) don't rewrite source or runtime-managed template files
+# to CRLF. typeclaw emits Dockerfile/.gitignore with LF and compares them
+# byte-exactly in `typeclaw doctor`; a CRLF checkout would report false drift.
+* text=auto eol=lf
+
+# Binary assets must never be normalized.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.pdf binary
+*.mp4 binary
+*.webm binary
+*.gz binary
+*.zip binary

--- a/src/doctor/checks.test.ts
+++ b/src/doctor/checks.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+
+import { wslDriveMount, type WslDriveMountDeps } from './checks'
+import type { CheckContext } from './types'
+
+const agentCtx: CheckContext = { cwd: '/mnt/c/work/agent', hasAgentFolder: true }
+const linuxCtx: CheckContext = { cwd: '/home/dev/agent', hasAgentFolder: true }
+
+function deps(overrides: Partial<WslDriveMountDeps> = {}): WslDriveMountDeps {
+  return {
+    detect: () => ({ isWsl: true, version: 2 }),
+    isWindowsDriveMount: (p) => p.startsWith('/mnt/'),
+    typeclawHome: () => '/home/dev/.typeclaw',
+    ...overrides,
+  }
+}
+
+describe('wslDriveMount', () => {
+  test('passes when not running under WSL', async () => {
+    const check = wslDriveMount(deps({ detect: () => ({ isWsl: false, version: null }) }))
+    const result = await check.run(agentCtx)
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('not running under WSL')
+  })
+
+  test('passes when agent folder and home are on the Linux filesystem', async () => {
+    const check = wslDriveMount(deps())
+    const result = await check.run(linuxCtx)
+    expect(result.status).toBe('ok')
+  })
+
+  test('warns when the agent folder is on a Windows-drive mount', async () => {
+    const check = wslDriveMount(deps())
+    const result = await check.run(agentCtx)
+    expect(result.status).toBe('warning')
+    expect(result.details).toContain('agent folder: /mnt/c/work/agent')
+    expect(result.fix?.description).toContain('Linux filesystem')
+  })
+
+  test('warns when ~/.typeclaw is on a Windows-drive mount even if agent folder is fine', async () => {
+    const winHome = '/mnt/c/work/.typeclaw'
+    const check = wslDriveMount(deps({ typeclawHome: () => winHome }))
+    const result = await check.run(linuxCtx)
+    expect(result.status).toBe('warning')
+    expect(result.details).toContain(`hostd home: ${winHome}`)
+  })
+
+  test('does not inspect the agent folder when there is none', async () => {
+    const check = wslDriveMount(deps())
+    const result = await check.run({ cwd: '/mnt/c/work/agent', hasAgentFolder: false })
+    expect(result.status).toBe('ok')
+  })
+})

--- a/src/doctor/checks.test.ts
+++ b/src/doctor/checks.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { wslDriveMount, type WslDriveMountDeps } from './checks'
+import { loadConfigSync } from '@/config'
+import { resolveBaseImageVersion } from '@/init/cli-version'
+import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
+import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
+
+import { buildStaticChecks, wslDriveMount, type WslDriveMountDeps } from './checks'
 import type { CheckContext } from './types'
 
 const agentCtx: CheckContext = { cwd: '/mnt/c/work/agent', hasAgentFolder: true }
@@ -48,6 +56,42 @@ describe('wslDriveMount', () => {
   test('does not inspect the agent folder when there is none', async () => {
     const check = wslDriveMount(deps())
     const result = await check.run({ cwd: '/mnt/c/work/agent', hasAgentFolder: false })
+    expect(result.status).toBe('ok')
+  })
+})
+
+describe('managed-template checks tolerate CRLF line endings', () => {
+  function findCheck(name: string) {
+    const check = buildStaticChecks().find((c) => c.name === name)
+    if (!check) throw new Error(`missing check ${name}`)
+    return check
+  }
+
+  function makeAgentDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'typeclaw-crlf-test-'))
+    writeFileSync(join(dir, 'typeclaw.json'), JSON.stringify({}), 'utf8')
+    return dir
+  }
+
+  const ctx = (cwd: string): CheckContext => ({ cwd, hasAgentFolder: true })
+
+  test('.gitignore with CRLF is not reported as divergent', async () => {
+    const cwd = makeAgentDir()
+    const lf = buildGitignore({ append: [] })
+    writeFileSync(join(cwd, GITIGNORE_FILE), lf.replace(/\n/g, '\r\n'), 'utf8')
+
+    const result = await findCheck('agent-folder.gitignore-managed').run(ctx(cwd))
+    expect(result.status).toBe('ok')
+  })
+
+  test('Dockerfile with CRLF is not reported as divergent', async () => {
+    const cwd = makeAgentDir()
+    const lf = buildDockerfile(loadConfigSync(cwd).docker.file, {
+      baseImageVersion: resolveBaseImageVersion(cwd),
+    })
+    writeFileSync(join(cwd, DOCKERFILE), lf.replace(/\n/g, '\r\n'), 'utf8')
+
+    const result = await findCheck('agent-folder.dockerfile-managed').run(ctx(cwd))
     expect(result.status).toBe('ok')
   })
 })

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -15,11 +15,12 @@ import {
   resolveHostPort,
   type DockerExec,
 } from '@/container'
-import { isDaemonReachable, send } from '@/hostd'
+import { homeRoot, isDaemonReachable, send } from '@/hostd'
 import { resolveBaseImageVersion } from '@/init/cli-version'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { detectMissingDeps } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
+import { detectWsl, isWindowsDriveMount, type WslInfo } from '@/shared'
 
 import { buildChannelChecks } from './channel-checks'
 import type { DoctorCheck } from './types'
@@ -37,6 +38,7 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): Docto
     agentFolderGitRepo(),
     configValid(),
     hostdHomeWritable(),
+    wslDriveMount(),
     hostdReachable(),
     hostdRegistration(),
     containerState(dockerExec),
@@ -237,6 +239,53 @@ function hostdHomeWritable(): DoctorCheck {
   }
 }
 
+export type WslDriveMountDeps = {
+  detect: () => WslInfo
+  isWindowsDriveMount: (path: string) => boolean
+  typeclawHome: () => string
+}
+
+// Under WSL, files on a Windows-drive mount (/mnt/c/...) don't enforce Unix
+// permissions, so the 0600 chmod that protects secrets.json and the encryption
+// keys is silently ignored — they become readable by every local user. Warn
+// when either the agent folder or ~/.typeclaw lives on such a mount.
+export function wslDriveMount(deps: Partial<WslDriveMountDeps> = {}): DoctorCheck {
+  const detect = deps.detect ?? detectWsl
+  const onWindowsDrive = deps.isWindowsDriveMount ?? isWindowsDriveMount
+  const typeclawHome = deps.typeclawHome ?? homeRoot
+
+  return {
+    name: 'hostd.wsl-drive-mount',
+    category: 'hostd',
+    description: 'agent state is not on a Windows-drive mount under WSL',
+    async run(ctx) {
+      if (!detect().isWsl) return { status: 'ok', message: 'not running under WSL' }
+
+      const offenders: string[] = []
+      if (ctx.hasAgentFolder && onWindowsDrive(ctx.cwd)) offenders.push(`agent folder: ${ctx.cwd}`)
+      const home = typeclawHome()
+      if (onWindowsDrive(home)) offenders.push(`hostd home: ${home}`)
+
+      if (offenders.length === 0) {
+        return { status: 'ok', message: 'agent state is on the Linux filesystem' }
+      }
+
+      return {
+        status: 'warning',
+        message: 'agent state is on a Windows-drive mount; file permissions are not enforced',
+        details: [
+          ...offenders,
+          'chmod is a no-op on /mnt/<drive> (DrvFs/9p), so secrets.json and encryption keys become world-readable.',
+        ],
+        fix: {
+          description:
+            'Move the agent folder to the WSL Linux filesystem (e.g. ~/my-agent) and, if needed, set TYPECLAW_HOME to a Linux path.',
+        },
+      }
+    },
+  }
+}
+
 function hostdReachable(): DoctorCheck {
   return {
     name: 'hostd.reachable',
@@ -362,9 +411,12 @@ function loadConfigStrictForTemplate(
   return { dockerfile: cfg.docker.file, gitignore: cfg.git.ignore }
 }
 
+// Normalizes CRLF to LF: the managed templates are emitted with `\n`, but a
+// checkout under Git for Windows (core.autocrlf=true) rewrites them to `\r\n`,
+// which would make the byte-exact template comparison report a false divergence.
 async function safeRead(path: string): Promise<string | null> {
   try {
-    return await readFile(path, 'utf8')
+    return (await readFile(path, 'utf8')).replace(/\r\n/g, '\n')
   } catch {
     return null
   }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -27,3 +27,5 @@ export {
 } from './protocol'
 
 export { formatLocalDate, formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from './local-time'
+
+export { detectWsl, isWindowsDriveMount, type WslInfo, type WslVersion } from './wsl'

--- a/src/shared/wsl.test.ts
+++ b/src/shared/wsl.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test'
+
+import { detectWslWith, isWindowsDriveMountWith, readAutomountRootWith, type WslProbes } from './wsl'
+
+function makeProbes(overrides: Partial<WslProbes> = {}): WslProbes {
+  return {
+    platform: 'linux',
+    kernelRelease: () => '5.15.0-generic',
+    readFile: () => null,
+    fileExists: () => false,
+    env: {},
+    ...overrides,
+  }
+}
+
+describe('detectWslWith', () => {
+  test('non-linux platform is never WSL', () => {
+    expect(detectWslWith(makeProbes({ platform: 'win32' }))).toEqual({ isWsl: false, version: null })
+    expect(detectWslWith(makeProbes({ platform: 'darwin' }))).toEqual({ isWsl: false, version: null })
+  })
+
+  test('native linux is not WSL', () => {
+    const probes = makeProbes({
+      kernelRelease: () => '6.5.0-generic',
+      readFile: (p) => (p === '/proc/version' ? 'Linux version 6.5.0-generic (gcc ...)' : null),
+    })
+    expect(detectWslWith(probes)).toEqual({ isWsl: false, version: null })
+  })
+
+  test('detects WSL2 from microsoft-standard kernel release', () => {
+    const probes = makeProbes({ kernelRelease: () => '5.15.90.1-microsoft-standard-WSL2' })
+    expect(detectWslWith(probes)).toEqual({ isWsl: true, version: 2 })
+  })
+
+  test('detects WSL2 from /proc/version when kernel release is generic', () => {
+    const probes = makeProbes({
+      kernelRelease: () => '5.15.90.1',
+      readFile: (p) => (p === '/proc/version' ? 'Linux version 5.15.90.1-microsoft-standard-WSL2 (...)' : null),
+    })
+    expect(detectWslWith(probes)).toEqual({ isWsl: true, version: 2 })
+  })
+
+  test('WSL_INTEROP env forces version 2 even without standard in kernel string', () => {
+    const probes = makeProbes({
+      kernelRelease: () => '5.10.0-microsoft',
+      env: { WSL_INTEROP: '/run/WSL/8_interop' },
+    })
+    expect(detectWslWith(probes)).toEqual({ isWsl: true, version: 2 })
+  })
+
+  test('detects WSL1 from legacy Microsoft kernel (capital M, no standard)', () => {
+    const probes = makeProbes({ kernelRelease: () => '4.4.0-19041-Microsoft' })
+    expect(detectWslWith(probes)).toEqual({ isWsl: true, version: 1 })
+  })
+
+  test('custom kernel detected only via WSLInterop artifact has indeterminate version', () => {
+    const probes = makeProbes({
+      kernelRelease: () => '6.6.0-custom',
+      readFile: (p) => (p === '/proc/version' ? 'Linux version 6.6.0-custom (...)' : null),
+      fileExists: (p) => p === '/proc/sys/fs/binfmt_misc/WSLInterop',
+    })
+    expect(detectWslWith(probes)).toEqual({ isWsl: true, version: null })
+  })
+
+  test('detected via /run/WSL artifact alone', () => {
+    const probes = makeProbes({
+      kernelRelease: () => '6.6.0-custom',
+      fileExists: (p) => p === '/run/WSL',
+    })
+    expect(detectWslWith(probes).isWsl).toBe(true)
+  })
+})
+
+describe('readAutomountRootWith', () => {
+  test('defaults to /mnt/ when wsl.conf is absent', () => {
+    expect(readAutomountRootWith({ readFile: () => null })).toBe('/mnt/')
+  })
+
+  test('reads custom root from [automount] section and adds trailing slash', () => {
+    const conf = '[automount]\nroot = /windir\nenabled = true\n'
+    expect(readAutomountRootWith({ readFile: () => conf })).toBe('/windir/')
+  })
+
+  test('ignores root= outside the [automount] section', () => {
+    const conf = '[network]\nroot = /not-this\n'
+    expect(readAutomountRootWith({ readFile: () => conf })).toBe('/mnt/')
+  })
+
+  test('strips quotes and ignores comments', () => {
+    const conf = '# comment\n[automount]\nroot = "/custom/"  # inline\n'
+    expect(readAutomountRootWith({ readFile: () => conf })).toBe('/custom/')
+  })
+})
+
+describe('isWindowsDriveMountWith', () => {
+  const noConf = { readFile: () => null }
+
+  test.each(['/mnt/c/agent', '/mnt/c', '/mnt/d/work', '/mnt/Z/x'])('flags Windows drive mount %p', (path) => {
+    expect(isWindowsDriveMountWith(path, noConf)).toBe(true)
+  })
+
+  test.each(['/home/dev/agent', '/mnt/wsl/foo', '/mnt/wslg/bar', '/srv/data', '/mnt'])(
+    'does not flag native path %p',
+    (path) => {
+      expect(isWindowsDriveMountWith(path, noConf)).toBe(false)
+    },
+  )
+
+  test('respects a custom automount root from wsl.conf', () => {
+    const conf = { readFile: () => '[automount]\nroot = /windir/\n' }
+    expect(isWindowsDriveMountWith('/windir/c/agent', conf)).toBe(true)
+    expect(isWindowsDriveMountWith('/mnt/c/agent', conf)).toBe(false)
+  })
+})

--- a/src/shared/wsl.ts
+++ b/src/shared/wsl.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { release } from 'node:os'
+
+// Detection of WSL (Windows Subsystem for Linux) and Windows-drive mounts.
+//
+// Why this matters for typeclaw: inside WSL the kernel is real Linux, so the
+// host stage runs unchanged — EXCEPT when files live on a Windows-drive mount
+// (DrvFs on WSL1, 9p on WSL2, e.g. `/mnt/c/...`). On those mounts POSIX
+// permissions are NOT enforced: `chmod 0o600` silently succeeds but leaves the
+// file world-readable. typeclaw stores encryption keys and API tokens with
+// mode 0600 (src/secrets/*, src/hostd/paths.ts), so a secrets file on `/mnt/c`
+// loses its confidentiality guarantee. The doctor surfaces this as a warning.
+
+export type WslVersion = 1 | 2
+
+export type WslInfo = {
+  isWsl: boolean
+  // null when not WSL, or WSL but the version can't be determined (e.g. a
+  // custom kernel detected only via the binfmt/`/run/WSL` artifacts).
+  version: WslVersion | null
+}
+
+// Injectable so the pure detection logic is unit-testable without a real
+// `/proc` or `/etc/wsl.conf`; production uses the real-filesystem defaults.
+export type WslProbes = {
+  platform: NodeJS.Platform
+  kernelRelease: () => string
+  readFile: (path: string) => string | null
+  fileExists: (path: string) => boolean
+  env: NodeJS.ProcessEnv
+}
+
+function safeReadFile(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+const defaultProbes: WslProbes = {
+  platform: process.platform,
+  kernelRelease: release,
+  readFile: safeReadFile,
+  fileExists: existsSync,
+  env: process.env,
+}
+
+// Mirrors the is-wsl@3 cascade: os.release() → /proc/version → WSL runtime
+// artifacts. Matching is case-insensitive because WSL1 stamps `Microsoft`
+// (capital M) and WSL2 stamps `microsoft` (lowercase) into the kernel strings.
+// A user-compiled WSL2 kernel can omit the string entirely, which is why the
+// binfmt/`/run/WSL` artifacts are the final fallback.
+export function detectWslWith(probes: WslProbes): WslInfo {
+  if (probes.platform !== 'linux') return { isWsl: false, version: null }
+
+  const kernelRelease = probes.kernelRelease().toLowerCase()
+  const procVersion = (probes.readFile('/proc/version') ?? '').toLowerCase()
+
+  const kernelSaysMicrosoft = kernelRelease.includes('microsoft')
+  const procSaysMicrosoft = procVersion.includes('microsoft')
+  const hasArtifacts = probes.fileExists('/proc/sys/fs/binfmt_misc/WSLInterop') || probes.fileExists('/run/WSL')
+
+  if (!kernelSaysMicrosoft && !procSaysMicrosoft && !hasArtifacts) {
+    return { isWsl: false, version: null }
+  }
+
+  return { isWsl: true, version: resolveWslVersion({ kernelRelease, procVersion, env: probes.env }) }
+}
+
+// WSL_INTEROP is present only under WSL2 (Microsoft's own recommendation in
+// microsoft/WSL#4555). It can be stripped by `sudo`, so the kernel-string
+// heuristics back it up: WSL2 kernels are `*-microsoft-standard*` / contain
+// `wsl2`; WSL1 kernels are the older `*-Microsoft` form without "standard".
+function resolveWslVersion(args: {
+  kernelRelease: string
+  procVersion: string
+  env: NodeJS.ProcessEnv
+}): WslVersion | null {
+  if (args.env.WSL_INTEROP !== undefined && args.env.WSL_INTEROP !== '') return 2
+
+  const haystack = `${args.kernelRelease} ${args.procVersion}`
+  if (haystack.includes('wsl2') || haystack.includes('microsoft-standard')) return 2
+
+  // Older WSL1 kernels say `microsoft` but never `standard`/`wsl2`. If we only
+  // know it's WSL from the kernel/proc string (not the artifacts), call it v1.
+  if (args.kernelRelease.includes('microsoft') || args.procVersion.includes('microsoft')) return 1
+
+  return null
+}
+
+export function detectWsl(): WslInfo {
+  return detectWslWith(defaultProbes)
+}
+
+// The WSL automount root defaults to `/mnt/` but can be remapped via
+// `/etc/wsl.conf` ([automount] root = ...). Returns the configured root with a
+// guaranteed trailing slash, or `/mnt/` when unset/unreadable.
+export function readAutomountRootWith(probes: Pick<WslProbes, 'readFile'>): string {
+  const conf = probes.readFile('/etc/wsl.conf')
+  const parsed = conf === null ? null : parseAutomountRoot(conf)
+  const root = parsed ?? '/mnt/'
+  return root.endsWith('/') ? root : `${root}/`
+}
+
+function parseAutomountRoot(content: string): string | null {
+  let inAutomountSection = false
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (line.length === 0 || line.startsWith('#') || line.startsWith(';')) continue
+    const section = /^\[(?<name>[^\]]+)\]$/.exec(line)
+    if (section) {
+      inAutomountSection = section.groups?.name?.trim().toLowerCase() === 'automount'
+      continue
+    }
+    if (!inAutomountSection) continue
+    const match = /^root\s*=\s*(?<value>"[^"]*"|'[^']*'|[^#;]*)/.exec(line)
+    const raw = match?.groups?.value
+    if (raw === undefined) continue
+    const value = raw.trim().replace(/^["']|["']$/g, '')
+    if (value.length > 0) return value
+  }
+  return null
+}
+
+// True when `path` lives under the WSL Windows-drive automount (e.g.
+// `/mnt/c/...`), where Unix permissions are not enforced. The drive component
+// must be a single ASCII letter so `/mnt/wsl/...` (WSLg, not a Windows drive)
+// is correctly excluded.
+export function isWindowsDriveMountWith(path: string, probes: Pick<WslProbes, 'readFile'>): boolean {
+  const root = readAutomountRootWith(probes)
+  if (!path.startsWith(root)) return false
+  const rest = path.slice(root.length)
+  return /^[A-Za-z](?:\/|$)/.test(rest)
+}
+
+export function isWindowsDriveMount(path: string): boolean {
+  return isWindowsDriveMountWith(path, defaultProbes)
+}


### PR DESCRIPTION
## Background

TypeClaw's Windows support path is WSL2: the host stage runs on a real Linux kernel, so Unix-socket hostd IPC, the bwrap sandbox, signal handling, and the docker/git/bun toolchain all work unchanged. The native-Windows case (no WSL) is explicitly out of scope and would require replacing most of the host-stage infrastructure.

A host-stage audit found two WSL-specific footguns that fail silently with no user-visible warning:

1. **Secret-permission bypass on Windows-drive mounts.** When the agent folder or `~/.typeclaw` lives on a Windows-drive mount (DrvFs on WSL1, 9p on WSL2), `chmod` is a no-op. The `0600` mode that guards `secrets.json` and the channel encryption keys (in `src/secrets/` and `src/hostd/paths.ts`) is silently ignored, making those files world-readable with no diagnostic.

2. **False template-drift warnings from CRLF checkout.** `typeclaw doctor` compares the managed Dockerfile and `.gitignore` byte-exactly against LF templates. A Git for Windows checkout with `core.autocrlf=true` rewrites them to CRLF, causing spurious "diverges from template" warnings on every `doctor` run.

## Summary

**New WSL detection helpers (`src/shared/wsl.ts`).** `detectWsl()` mirrors the is-wsl-style cascade (kernel release string → `/proc/version` → WSL runtime artifacts, case-insensitive), and distinguishes WSL1/WSL2 via `WSL_INTEROP` with a kernel-string fallback. `isWindowsDriveMount()` checks whether a path falls under the WSL automount root and honors a custom `[automount] root` from `/etc/wsl.conf`. Both functions accept injected system calls so the pure logic is unit-tested without a real `/proc`.

**New doctor check (`hostd.wsl-drive-mount`).** Added to `src/doctor/checks.ts`. When the agent folder or `~/.typeclaw` is on a Windows-drive mount it emits a warning with the affected path and directs the user to move state to the Linux filesystem (e.g. `~/typeclaw/`).

**CRLF normalization in doctor.** `src/doctor/checks.ts` now strips `\r` before comparing managed-file content, so Git for Windows users no longer see false drift. The new `.gitattributes` enforces `eol=lf` for all text assets in source and in scaffolded agent folders so the problem does not regenerate on future checkouts.

Why `.gitattributes` over instructing users to set `core.autocrlf=false`: the repo already ships LF-only content; the attribute enforces that regardless of local Git config, and it also governs what `typeclaw init` scaffolds into agent folders.

## Preview

```
$ typeclaw doctor
✗ hostd.wsl-drive-mount  Agent folder is on a Windows-drive mount.
  chmod is a no-op on DrvFs/9p; secrets.json and encryption keys are world-readable.
  Move your agent folder to the Linux filesystem (e.g. ~/typeclaw/myagent) and re-run typeclaw init.
```

## What this does NOT do

- Does not add native Windows (no WSL) support — that remains explicitly out of scope.
- Does not change any secret storage format or encryption scheme.
- Does not migrate existing state — the check is diagnostic only; the user moves the folder.
- Does not affect any non-WSL host; all new code paths are gated on `detectWsl()`.

## Review notes

**Load-bearing: `isWindowsDriveMount()` must honor `/etc/wsl.conf`.** The default automount root is `/mnt`, but WSL allows overriding it. The implementation reads `wsl.conf` once at module load and matches against the configured root. Unit tests cover both the default and a custom root via injection.

**Doctor check ordering.** `hostd.wsl-drive-mount` runs before `hostd.secrets-permissions` so the user sees the root-cause warning before any downstream symptom.

**`.gitattributes` scope.** Marks `text eol=lf` for `*.ts`, `*.json`, `*.md`, `Dockerfile*`, and `.gitignore`. Binary assets (images, `*.wasm`) carry `binary` to prevent mangling. Verify with `git ls-files --eol` on the managed files.

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — 0 errors
- [ ] `bun run format:check` — clean
- [ ] `bun run test` — 9111 pass, 0 fail, 1 pre-existing skip
- [ ] On a WSL2 host: `typeclaw doctor` with agent folder on a Windows-drive mount emits the `hostd.wsl-drive-mount` warning.
- [ ] On a WSL2 host: `typeclaw doctor` with agent folder on the Linux filesystem emits no WSL warning.
- [ ] On a Git for Windows checkout: `typeclaw doctor` reports no Dockerfile/.gitignore drift.