### PR TITLE
perf(agent): cap compaction trigger at an absolute token budget

### DIFF
--- a/src/agent/compaction.test.ts
+++ b/src/agent/compaction.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from 'bun:test'
 import type { Model } from '@mariozechner/pi-ai'
 
 import {
+  COMPACTION_ABSOLUTE_TRIGGER_TOKENS,
   COMPACTION_KEEP_RECENT_TOKENS,
   COMPACTION_TRIGGER_PERCENT,
+  compactionTriggerTokens,
   createCompactionSettingsManager,
   reserveTokensForModel,
 } from './compaction'
@@ -24,32 +26,53 @@ function fakeModel(contextWindow: number): Model<'openai-completions'> {
   } as unknown as Model<'openai-completions'>
 }
 
-describe('reserveTokensForModel', () => {
-  test('reserves the (1 - COMPACTION_TRIGGER_PERCENT) fraction of the window', () => {
-    // given
-    const window = 256_000
+describe('compactionTriggerTokens', () => {
+  test('small windows keep the 80% window-relative trigger', () => {
+    // given: a window whose 80% sits below the absolute cap
+    const window = 64_000
     const model = fakeModel(window)
+
+    // when
+    const trigger = compactionTriggerTokens(model)
+
+    // then
+    expect(trigger).toBe(Math.round(window * COMPACTION_TRIGGER_PERCENT))
+    expect(trigger).toBe(51_200)
+  })
+
+  test('large windows cap the trigger at the absolute budget instead of 80%', () => {
+    // given: 80% of 256K (204_800) is well above the absolute cap
+    const model = fakeModel(256_000)
+
+    // when
+    const trigger = compactionTriggerTokens(model)
+
+    // then
+    expect(trigger).toBe(COMPACTION_ABSOLUTE_TRIGGER_TOKENS)
+  })
+
+  test('very large windows still cap at the same absolute trigger', () => {
+    // given
+    const a = fakeModel(256_000)
+    const b = fakeModel(1_000_000)
+
+    // then: trigger does not scale with the window once past the crossover
+    expect(compactionTriggerTokens(a)).toBe(COMPACTION_ABSOLUTE_TRIGGER_TOKENS)
+    expect(compactionTriggerTokens(b)).toBe(COMPACTION_ABSOLUTE_TRIGGER_TOKENS)
+  })
+})
+
+describe('reserveTokensForModel', () => {
+  test('derives reserve as window minus the (capped) trigger', () => {
+    // given
+    const model = fakeModel(256_000)
 
     // when
     const reserve = reserveTokensForModel(model)
 
-    // then
-    expect(reserve).toBe(Math.round(window * (1 - COMPACTION_TRIGGER_PERCENT)))
-    expect(reserve).toBe(51_200)
-  })
-
-  test('scales with the model context window so trigger fraction stays constant', () => {
-    // given
-    const small = fakeModel(200_000)
-    const large = fakeModel(1_000_000)
-
-    // when
-    const triggerSmall = small.contextWindow - reserveTokensForModel(small)
-    const triggerLarge = large.contextWindow - reserveTokensForModel(large)
-
-    // then: both trip at ~80% of their own window
-    expect(triggerSmall / small.contextWindow).toBeCloseTo(COMPACTION_TRIGGER_PERCENT, 3)
-    expect(triggerLarge / large.contextWindow).toBeCloseTo(COMPACTION_TRIGGER_PERCENT, 3)
+    // then: 256K - 64K cap = 192K reserved, so compaction fires at 64K not 80%
+    expect(reserve).toBe(256_000 - COMPACTION_ABSOLUTE_TRIGGER_TOKENS)
+    expect(reserve).toBe(192_000)
   })
 
   test('clamps to at least 1 so a degenerate zero-window model never produces a non-positive reserve', () => {
@@ -64,14 +87,21 @@ describe('reserveTokensForModel', () => {
   })
 })
 
+describe('compaction budget invariant', () => {
+  test('absolute trigger stays >=3x the recent-window floor to avoid thrashing', () => {
+    // a trigger too close to keepRecent would re-compact almost immediately
+    // after each compaction; keep headroom so a compacted session can grow
+    expect(COMPACTION_ABSOLUTE_TRIGGER_TOKENS).toBeGreaterThanOrEqual(COMPACTION_KEEP_RECENT_TOKENS * 3)
+  })
+})
+
 describe('createCompactionSettingsManager', () => {
   test('produces a SettingsManager whose getCompactionSettings() reflects our chosen values', () => {
     // given
     const model = fakeModel(256_000)
 
     // when
-    const sm = createCompactionSettingsManager(model)
-    const settings = sm.getCompactionSettings()
+    const settings = createCompactionSettingsManager(model).getCompactionSettings()
 
     // then
     expect(settings.enabled).toBe(true)
@@ -79,7 +109,7 @@ describe('createCompactionSettingsManager', () => {
     expect(settings.keepRecentTokens).toBe(COMPACTION_KEEP_RECENT_TOKENS)
   })
 
-  test('different models produce different reserveTokens but the same keepRecentTokens', () => {
+  test('different-window models reserve different amounts but keep the same recent window', () => {
     // given
     const a = fakeModel(200_000)
     const b = fakeModel(1_000_000)

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1,27 +1,36 @@
 import type { KnownApi, Model } from '@mariozechner/pi-ai'
 import { SettingsManager } from '@mariozechner/pi-coding-agent'
 
-// Compaction trigger threshold expressed as a percentage of the model's
-// context window. pi-coding-agent's auto-compaction fires when
-// `contextTokens > contextWindow - reserveTokens`. To honor a percentage-
-// based intent across models with very different window sizes (200K Claude
-// vs. 1M Gemini vs. 256K Kimi), we derive `reserveTokens` per-model from
-// the model's `contextWindow`. SDK defaults (16384 reserve) are a fixed
-// number of tokens that drift in relative terms across models — at 256K
-// that's ~6% headroom (94% trigger), at 1M it's ~1.6% (98% trigger). A
-// percentage-derived reserve trips at the same fraction regardless of
-// model, which is what we actually want.
+// Compaction trigger expressed as a fraction of the model's context window.
+// pi-coding-agent auto-compaction fires when `contextTokens > contextWindow -
+// reserveTokens`; deriving `reserveTokens` from the window keeps the trigger at
+// the same fraction across models with very different windows (200K Claude vs.
+// 1M Gemini vs. 256K Kimi) instead of the SDK's fixed 16384 reserve, which
+// drifts to ~94% on a 256K window and ~98% on 1M.
 export const COMPACTION_TRIGGER_PERCENT = 0.8
 
+// Absolute ceiling on the compaction trigger, independent of window size. The
+// window-relative trigger alone optimizes for overflow avoidance, not token
+// cost: at 80% of a large window a session accumulates ~160K (200K window) to
+// ~800K (1M window) tokens of history that get re-shipped as `cacheRead` every
+// turn before compaction ever fires. Capping the trigger bounds that
+// steady-state re-read on big-window models; `min()` keeps the 80% behavior on
+// small ones. 64K is 3x keepRecent (invariant asserted in the test), leaving
+// growth room after a compaction so it does not retrigger immediately.
+export const COMPACTION_ABSOLUTE_TRIGGER_TOKENS = 64_000
+
 // Tokens to keep in the recent window after compaction. Fixed (not a
-// percentage) because "recent context" is a property of conversation
-// shape, not model capacity — the same recent ~20K is roughly the right
-// amount of history regardless of whether the model has 200K or 1M total.
-// Mirrors pi's DEFAULT_COMPACTION_SETTINGS.keepRecentTokens.
+// percentage) because "recent context" is a property of conversation shape, not
+// model capacity. Mirrors pi's DEFAULT_COMPACTION_SETTINGS.keepRecentTokens.
 export const COMPACTION_KEEP_RECENT_TOKENS = 20_000
 
+export function compactionTriggerTokens<TApi extends KnownApi>(model: Model<TApi>): number {
+  const windowRelative = Math.round(model.contextWindow * COMPACTION_TRIGGER_PERCENT)
+  return Math.min(windowRelative, COMPACTION_ABSOLUTE_TRIGGER_TOKENS)
+}
+
 export function reserveTokensForModel<TApi extends KnownApi>(model: Model<TApi>): number {
-  return Math.max(1, Math.round(model.contextWindow * (1 - COMPACTION_TRIGGER_PERCENT)))
+  return Math.max(1, model.contextWindow - compactionTriggerTokens(model))
 }
 
 export function createCompactionSettingsManager<TApi extends KnownApi>(model: Model<TApi>): SettingsManager {


### PR DESCRIPTION
## What

Auto-compaction already exists and is enabled (`src/agent/index.ts:446`), but it fired at **80% of the model's context window**. On large-window models that lets a session accumulate a huge history before compaction kicks in — and that history is re-shipped as `cacheRead` on **every turn** until then.

This caps the trigger at an absolute token budget:

```
triggerTokens = min(round(contextWindow * 0.8), COMPACTION_ABSOLUTE_TRIGGER_TOKENS)  // 64K
reserveTokens = contextWindow - triggerTokens
```

- **Small-window models** (≤80K) keep the existing 80% behavior via `min()`.
- **Large-window models** (256K–1M) now compact at a fixed ~64K instead of ~205K–800K.
- `keepRecentTokens` unchanged at 20K; 64K is 3× that, leaving growth room so compaction doesn't retrigger immediately.

## Why

From production token analysis across the fleet:

- **83% of all prompt tokens are `cacheRead`** — re-processing accumulated history every turn.
- On one high-volume agent, **7% of sessions (>15 turns) carry 63% of all `cacheRead`** (~843M tokens); longest session 1,468 turns.

The window-relative trigger optimized for overflow avoidance, not token cost. The break-even strongly favors the long-session tail this targets: early compaction saves `cacheReadDiscount × tokens_saved` every later turn, so for sessions with dozens–hundreds of turns the savings dominate the one-time summarization + cache-rewrite cost.

## Tradeoff

Compaction rewrites history → busts the cached prefix for the next turn. For the long sessions that dominate the cost this is a clear net win; for sessions that end right after hitting 64K it may lose slightly. 64K (not lower) is chosen to avoid thrash.

## Test plan

- `bun run test` (`compaction.test.ts`): small windows keep 80%, large windows cap at 64K, reserve = window − trigger, ≥3× keepRecent invariant.
- `bun run typecheck` / `lint` / `format` clean.

## Follow-up (not in this PR)

- Expose `COMPACTION_ABSOLUTE_TRIGGER_TOKENS` as `typeclaw.json` config (the issue's "configurable" criterion). Deferred to keep this PR focused and avoid the restart-required config-fence surface; the default already delivers the savings.
- Before/after telemetry (compaction count, `cacheRead` by session-length bucket).

Refs #894.
