### PR TITLE
fix(init): fail loudly, recover cleanly, and harden re-run

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
   KNOWN_PROVIDERS,
@@ -13,10 +16,35 @@ import type { ModelOption } from '@/init/models-dev'
 import {
   collectWizardInputs,
   formatModelLabel,
+  shouldConfirmNonEmptyDirectory,
   sortRecommendedFirst,
   WizardAbortedError,
   type WizardPrompts,
 } from './init'
+
+describe('init pre-wizard guards', () => {
+  test('confirms for foreign non-empty directories', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-guard-'))
+    try {
+      await writeFile(join(cwd, 'README.md'), '# existing project\n')
+
+      expect(shouldConfirmNonEmptyDirectory(cwd)).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('skips non-empty confirmation for partial TypeClaw init dirs', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-guard-'))
+    try {
+      await writeFile(join(cwd, 'typeclaw.json'), '{}\n')
+
+      expect(shouldConfirmNonEmptyDirectory(cwd)).toBe(false)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})
 
 describe('collectWizardInputs back-aware flow', () => {
   const fireworksModel: ModelOption = {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -39,6 +39,7 @@ import {
   hasExistingOAuthCredentials,
   isDirectoryNonEmpty,
   isHatched,
+  isInitialized,
   readExistingProviderApiKey,
   runInit,
   type GithubInitCredentials,
@@ -139,18 +140,22 @@ export const init = defineCommand({
     if (existingAgent !== null && existingAgent !== cwd) {
       console.error(
         errorLine(
-          `Refusing to init: a TypeClaw agent already exists at ${existingAgent}. Nested agents are not supported.`,
+          `Refusing to init: a TypeClaw agent already exists at ${existingAgent}. Nested agents are not supported. Run init from a directory that is not inside an existing agent.`,
         ),
       )
       process.exit(1)
     }
 
     if (await isHatched(cwd)) {
-      console.error(errorLine(`TypeClaw has already hatched in ${cwd}.`))
+      console.error(
+        errorLine(
+          `TypeClaw has already hatched in ${cwd}. Use \`typeclaw tui\` to attach or \`typeclaw start\` to run it; init in a different directory to create another agent.`,
+        ),
+      )
       process.exit(1)
     }
 
-    if (isDirectoryNonEmpty(cwd)) {
+    if (shouldConfirmNonEmptyDirectory(cwd)) {
       const proceed = await confirm({
         message: `You're at ${cwd}. The directory is not empty. Do you want to proceed?`,
         initialValue: false,
@@ -192,7 +197,7 @@ export const init = defineCommand({
             [
               'OAuth credentials were saved to `secrets.json` before you aborted.',
               'Re-run `typeclaw init` here to pick up where you left off (the credentials',
-              'will be reused), or delete `secrets.json` if you want a clean restart.',
+              'will be reused), or run `typeclaw init --reset` to start fresh.',
             ].join('\n'),
             'Saved OAuth credentials',
           )
@@ -288,11 +293,32 @@ export const init = defineCommand({
       })
     } catch (error) {
       console.error(errorLine(error instanceof Error ? error.message : String(error)))
+      note(
+        [
+          'Your answers are saved.',
+          'Re-run `typeclaw init` here to resume, or `typeclaw init --reset` to start fresh.',
+          'Run `typeclaw doctor` to diagnose host/Docker issues.',
+        ].join('\n'),
+        'init failed',
+      )
       process.exit(1)
     }
 
     if (preflightFailure !== null) {
       note(preflightFailureGuidance(preflightFailure).join('\n'), 'Docker check failed')
+      process.exit(1)
+    }
+
+    if (!hatchingOk) {
+      note(
+        [
+          'The container was built but the agent did not come up.',
+          'Check logs: `typeclaw logs`',
+          'Diagnose: `typeclaw doctor`',
+          'Retry once fixed: `typeclaw start` (your setup is saved).',
+        ].join('\n'),
+        'Hatching failed',
+      )
       process.exit(1)
     }
 
@@ -334,6 +360,10 @@ export const init = defineCommand({
     }
   },
 })
+
+export function shouldConfirmNonEmptyDirectory(cwd: string): boolean {
+  return isDirectoryNonEmpty(cwd) && !isInitialized(cwd)
+}
 
 interface WizardState {
   catalog?: { options: ModelOption[]; source: 'models.dev' | 'curated'; warning?: string }
@@ -1750,20 +1780,24 @@ function reportProgress(
         s.stop(event.result.ok ? 'Logged in.' : `OAuth login failed: ${event.result.reason}`)
         break
       case 'install':
-        s.stop(event.result.ok ? 'Dependencies installed.' : `Skipped bun install: ${event.result.reason}`)
+        if (event.result.ok) {
+          s.stop('Dependencies installed.')
+        } else {
+          s.error(`Dependency install failed: ${event.result.reason}`)
+        }
         break
       case 'dockerfile':
         if (event.result.ok) {
           s.stop(event.result.devMode ? 'Dockerfile written (dev mode).' : 'Dockerfile written.')
         } else {
-          s.stop(`Skipped Dockerfile: ${event.result.reason}`)
+          s.error(`Dockerfile generation failed: ${event.result.reason}`)
         }
         break
       case 'git':
         if (event.result.ok) {
           s.stop(event.result.skipped ? 'Git repository already exists.' : 'Git repository initialized.')
         } else {
-          s.stop(`Skipped git init: ${event.result.reason}`)
+          s.error(`git init failed — continuing without a repo: ${event.result.reason}`)
         }
         break
     }

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -313,8 +313,9 @@ describe('runInit', () => {
     expect(gitDone.result.skipped).toBe(false)
   })
 
-  test('skips git init when .git already exists', async () => {
-    await mkdir(join(root, '.git'))
+  test('skips git init when .git already has a commit', async () => {
+    await scaffold(root)
+    await initGitRepo(root)
     const events: InitStepEvent[] = []
 
     await runInit({
@@ -333,23 +334,48 @@ describe('runInit', () => {
     expect(gitDone.result.skipped).toBe(true)
   })
 
-  test('step failure is reported via event, not thrown, and later steps still run', async () => {
+  test('install failure is reported via event and aborts later steps', async () => {
+    const events: InitStepEvent[] = []
+
+    await expect(
+      runInit({
+        cwd: root,
+        apiKey: 'fw_test_key',
+        runHatching: okHatch,
+        runBunInstall: async () => ({ ok: false, reason: 'registry unavailable' }),
+        dockerExec: okDocker,
+        onProgress: (e) => events.push(e),
+      }),
+    ).rejects.toThrow('Dependency install failed: registry unavailable')
+
+    const installDone = events.find((e) => e.step === 'install' && e.phase === 'done')
+    if (!(installDone && installDone.step === 'install' && installDone.phase === 'done')) {
+      throw new Error('expected install:done')
+    }
+    expect(installDone.result).toEqual({ ok: false, reason: 'registry unavailable' })
+    expect(events.map((e) => `${e.step}:${e.phase}`)).not.toContain('dockerfile:start')
+    expect(events.map((e) => `${e.step}:${e.phase}`)).not.toContain('hatching:start')
+  })
+
+  test('dockerfile failure is reported via event and aborts later steps', async () => {
     // given: invalid package.json so writeDockerAssets fails to parse it.
     // scaffold preserves existing package.json, so this sticks through the pipeline.
     await writeFile(join(root, 'package.json'), '{ not valid json')
     const events: InitStepEvent[] = []
 
     // when
-    await runInit({
-      cwd: root,
-      apiKey: 'fw_test_key',
-      runHatching: okHatch,
-      runBunInstall: okInstall,
-      dockerExec: okDocker,
-      onProgress: (e) => events.push(e),
-    })
+    await expect(
+      runInit({
+        cwd: root,
+        apiKey: 'fw_test_key',
+        runHatching: okHatch,
+        runBunInstall: okInstall,
+        dockerExec: okDocker,
+        onProgress: (e) => events.push(e),
+      }),
+    ).rejects.toThrow(/Dockerfile generation failed:/)
 
-    // then: dockerfile failed softly, git and hatching still ran
+    // then: dockerfile failure is fatal, so git and hatching do not run
     const dockerDone = events.find((e) => e.step === 'dockerfile' && e.phase === 'done')
     if (!(dockerDone && dockerDone.step === 'dockerfile' && dockerDone.phase === 'done')) {
       throw new Error('expected dockerfile:done')
@@ -357,10 +383,8 @@ describe('runInit', () => {
     expect(dockerDone.result.ok).toBe(false)
 
     const steps = events.map((e) => `${e.step}:${e.phase}`)
-    expect(steps).toContain('git:start')
-    expect(steps).toContain('git:done')
-    expect(steps).toContain('hatching:start')
-    expect(steps).toContain('hatching:done')
+    expect(steps).not.toContain('git:start')
+    expect(steps).not.toContain('hatching:start')
   })
 
   test('works without onProgress callback', async () => {
@@ -1099,13 +1123,24 @@ describe('initGitRepo', () => {
     expect(tracked.split('\n')).not.toContain('.env')
   })
 
-  test('skips when .git already exists', async () => {
+  test('skips when .git already has a commit', async () => {
     await scaffold(root)
-    await mkdir(join(root, '.git'))
+    await initGitRepo(root)
 
     const result = await initGitRepo(root)
 
     expect(result).toEqual({ ok: true, skipped: true })
+  })
+
+  test('commits scaffolded files when prior git init has no commit', async () => {
+    await scaffold(root)
+    await runGit(root, ['init', '-b', 'main'])
+
+    const result = await initGitRepo(root)
+
+    expect(result).toEqual({ ok: true, skipped: false })
+    expect(await runGit(root, ['rev-parse', '--verify', 'HEAD'])).not.toBe('')
+    expect(await runGit(root, ['log', '--oneline'])).toContain('Initial commit 🥚')
   })
 })
 
@@ -2046,6 +2081,7 @@ describe('defaultRunHatching', () => {
 
   test('propagates start() failure as a hatching failure', async () => {
     const failingStart: typeof import('@/container').start = async () => ({ ok: false, reason: 'docker not running' })
+    const stopCalls: Array<{ cwd: string }> = []
 
     const result = await defaultRunHatching({
       cwd: '/agent',
@@ -2054,9 +2090,56 @@ describe('defaultRunHatching', () => {
       startContainer: failingStart,
       tui: fakeTui,
       waitForAgent: fakeWaitForAgent,
+      stopContainer: async (options) => {
+        stopCalls.push(options)
+        return { ok: true, containerName: 'fake', running: true }
+      },
     })
 
     expect(result).toEqual({ ok: false, reason: 'docker not running' })
+    expect(stopCalls).toEqual([])
+  })
+
+  test('stops the launched container when a post-start step fails', async () => {
+    const { fn: startFn } = fakeStart()
+    const stopCalls: Array<{ cwd: string }> = []
+
+    const result = await defaultRunHatching({
+      cwd: '/agent',
+      port: 8973,
+      startContainer: startFn,
+      waitForAgent: async () => {
+        throw new Error('agent never came up')
+      },
+      tui: fakeTui,
+      stopContainer: async (options) => {
+        stopCalls.push(options)
+        return { ok: true, containerName: 'fake', running: true }
+      },
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'agent never came up' })
+    expect(stopCalls).toEqual([{ cwd: '/agent' }])
+  })
+
+  test('does not stop the container on successful hatching', async () => {
+    const { fn: startFn } = fakeStart()
+    const stopCalls: Array<{ cwd: string }> = []
+
+    const result = await defaultRunHatching({
+      cwd: '/agent',
+      port: 8973,
+      startContainer: startFn,
+      waitForAgent: fakeWaitForAgent,
+      tui: fakeTui,
+      stopContainer: async (options) => {
+        stopCalls.push(options)
+        return { ok: true, containerName: 'fake', running: true }
+      },
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(stopCalls).toEqual([])
   })
 
   function capturingTui(): {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -20,7 +20,14 @@ import {
   type KnownProviderId,
   type ModelRef,
 } from '@/config/providers'
-import { checkDockerAvailable, type DockerAvailability, type DockerExec, start } from '@/container'
+import {
+  checkDockerAvailable,
+  type DockerAvailability,
+  type DockerExec,
+  start,
+  type StartResult,
+  stop,
+} from '@/container'
 import { commitSystemFile } from '@/git/system-commit'
 import { createSecretsStoreForAgent, type Channels, type Secret, SecretsBackend } from '@/secrets'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
@@ -376,10 +383,12 @@ export async function runInit({
   emit({ step: 'install', phase: 'start' })
   const install = await installRunner(cwd)
   emit({ step: 'install', phase: 'done', result: install })
+  if (!install.ok) throw new Error(`Dependency install failed: ${install.reason}`)
 
   emit({ step: 'dockerfile', phase: 'start' })
   const docker = await writeDockerAssets(cwd)
   emit({ step: 'dockerfile', phase: 'done', result: docker })
+  if (!docker.ok) throw new Error(`Dockerfile generation failed: ${docker.reason}`)
 
   emit({ step: 'git', phase: 'start' })
   const git = await initGitRepo(cwd)
@@ -417,6 +426,7 @@ export async function defaultRunHatching({
   tui: tuiFactory = createTui,
   waitForAgent: waitForAgentFn = waitForAgent,
   runClaim = defaultRunClaim,
+  stopContainer = stop,
 }: {
   cwd: string
   port: number
@@ -426,14 +436,17 @@ export async function defaultRunHatching({
   tui?: typeof createTui
   waitForAgent?: typeof waitForAgent
   runClaim?: ClaimRunner
+  stopContainer?: typeof stop
 }): Promise<HatchingResult> {
+  let launch: Extract<StartResult, { ok: true }> | null = null
   try {
-    const launch = await startContainer({
+    const startResult = await startContainer({
       cwd,
       preferredHostPort: port,
       ...(cliEntry !== undefined ? { cliEntry } : {}),
     })
-    if (!launch.ok) return { ok: false, reason: launch.reason }
+    if (!startResult.ok) return { ok: false, reason: startResult.reason }
+    launch = startResult
 
     // start() may have allocated a different host port (the preferred one was
     // bound). Use the actually-published port for the TUI handshake instead of
@@ -455,6 +468,9 @@ export async function defaultRunHatching({
     await tui.run()
     return { ok: true }
   } catch (error) {
+    if (launch !== null && !launch.alreadyRunning) {
+      await stopContainer({ cwd }).catch(() => {})
+    }
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
 }
@@ -709,7 +725,7 @@ export async function initGitRepo(cwd: string): Promise<GitInitResult> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
 
-  if (existsSync(join(cwd, '.git'))) return { ok: true, skipped: true }
+  const hasGit = existsSync(join(cwd, '.git'))
 
   // Author the initial commit as TypeClaw itself. The agent is still unnamed
   // (IDENTITY.md is empty and hatching hasn't run), so the agent identity will
@@ -724,10 +740,21 @@ export async function initGitRepo(cwd: string): Promise<GitInitResult> {
   }
 
   try {
-    const init = bun.spawn({ cmd: ['git', 'init', '-b', 'main'], cwd, env, stdout: 'pipe', stderr: 'pipe' })
-    if ((await init.exited) !== 0) {
-      const stderr = await new Response(init.stderr).text()
-      return { ok: false, reason: `git init failed: ${stderr.trim() || 'no stderr'}` }
+    if (hasGit) {
+      const head = bun.spawn({
+        cmd: ['git', 'rev-parse', '--verify', 'HEAD'],
+        cwd,
+        env,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
+      if ((await head.exited) === 0) return { ok: true, skipped: true }
+    } else {
+      const init = bun.spawn({ cmd: ['git', 'init', '-b', 'main'], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+      if ((await init.exited) !== 0) {
+        const stderr = await new Response(init.stderr).text()
+        return { ok: false, reason: `git init failed: ${stderr.trim() || 'no stderr'}` }
+      }
     }
 
     const add = bun.spawn({ cmd: ['git', 'add', '.'], cwd, env, stdout: 'pipe', stderr: 'pipe' })

--- a/src/init/run-bun-install.test.ts
+++ b/src/init/run-bun-install.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { runBunInstall, runBunUpdate } from './run-bun-install'
+
+describe('runBunInstall', () => {
+  test('times out a hung install process', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-bun-install-timeout-'))
+    try {
+      const spawnHungProcess: typeof Bun.spawn = () =>
+        Bun.spawn({ cmd: ['bun', '-e', 'setInterval(() => {}, 1000)'], cwd, stdout: 'pipe', stderr: 'pipe' })
+      await writeFile(join(cwd, 'package.json'), '{}\n')
+
+      const result = await runBunInstall(cwd, { timeoutMs: 50, spawn: spawnHungProcess })
+
+      expect(result).toEqual({ ok: false, reason: 'bun install timed out after 0.05s' })
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('runBunUpdate', () => {
+  test('times out a hung update process', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-bun-update-timeout-'))
+    try {
+      const spawnHungProcess: typeof Bun.spawn = () =>
+        Bun.spawn({ cmd: ['bun', '-e', 'setInterval(() => {}, 1000)'], cwd, stdout: 'pipe', stderr: 'pipe' })
+      await writeFile(join(cwd, 'package.json'), '{}\n')
+
+      const result = await runBunUpdate(cwd, 'typeclaw', { timeoutMs: 50, spawn: spawnHungProcess })
+
+      expect(result).toEqual({ ok: false, reason: 'bun update typeclaw timed out after 0.05s' })
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/run-bun-install.ts
+++ b/src/init/run-bun-install.ts
@@ -1,5 +1,7 @@
 export type InstallResult = { ok: true } | { ok: false; reason: string }
 
+const INSTALL_TIMEOUT_MS = 300_000
+
 export type InstallRunnerOptions = {
   // Append `--force` to the bun install argv to bypass the cache for
   // `file:` / `link:` deps. Bun treats name+version of a `file:` dep as a
@@ -7,6 +9,8 @@ export type InstallRunnerOptions = {
   // locally-linked typeclaw never propagate into <agent>/node_modules until
   // either the typeclaw version is bumped or the install is forced.
   force?: boolean
+  timeoutMs?: number
+  spawn?: typeof Bun.spawn
 }
 
 // Signature for the function `runInit` uses to materialize the agent folder's
@@ -19,31 +23,29 @@ export async function runBunInstall(cwd: string, opts?: InstallRunnerOptions): P
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
   try {
-    const proc = bun.spawn({
-      // `--linker=hoisted` sidesteps a deadlock in Bun 1.3.x's isolated linker
-      // (the default since 1.3.0). When any single package fetch fails — 401,
-      // SHA-512 mismatch, transient registry 5xx, the kind of flake that's
-      // routine on GitHub Actions shared-IP runners — the isolated linker
-      // hangs the process indefinitely instead of erroring out
-      // (oven-sh/bun#26341, oven-sh/bun#29646). `bun install` runs here over
-      // ~500 transitive packages with no lockfile, so the odds of triggering
-      // the bug are non-trivial. Hoisted is the fallback strategy bun shipped
-      // before 1.3 — slightly slower for huge monorepos, indistinguishable
-      // for an agent folder, and not affected by the bug.
-      //
-      // `--force` is conditional: it bypasses the package cache so file:/link:
-      // deps re-copy their current on-disk source into node_modules. Bun's
-      // file-dep cache is keyed on name+version, so without --force, edits to
-      // a `file:..` typeclaw never reach the container after the first install.
+    // `--linker=hoisted` sidesteps a deadlock in Bun 1.3.x's isolated linker
+    // (the default since 1.3.0). When any single package fetch fails — 401,
+    // SHA-512 mismatch, transient registry 5xx, the kind of flake that's
+    // routine on GitHub Actions shared-IP runners — the isolated linker
+    // hangs the process indefinitely instead of erroring out
+    // (oven-sh/bun#26341, oven-sh/bun#29646). `bun install` runs here over
+    // ~500 transitive packages with no lockfile, so the odds of triggering
+    // the bug are non-trivial. Hoisted is the fallback strategy bun shipped
+    // before 1.3 — slightly slower for huge monorepos, indistinguishable
+    // for an agent folder, and not affected by the bug.
+    //
+    // `--force` is conditional: it bypasses the package cache so file:/link:
+    // deps re-copy their current on-disk source into node_modules. Bun's
+    // file-dep cache is keyed on name+version, so without --force, edits to
+    // a `file:..` typeclaw never reach the container after the first install.
+    return await runTimedBunProcess({
       cmd: opts?.force ? ['bun', 'install', '--linker=hoisted', '--force'] : ['bun', 'install', '--linker=hoisted'],
       cwd,
-      stdout: 'pipe',
-      stderr: 'pipe',
+      timeoutMs: opts?.timeoutMs ?? INSTALL_TIMEOUT_MS,
+      spawn: opts?.spawn ?? bun.spawn,
+      timeoutReason: (seconds) => `bun install timed out after ${seconds}s`,
+      failureReason: (code, stderr) => `bun install exited with code ${code}: ${stderr.trim() || 'no stderr'}`,
     })
-    const code = await proc.exited
-    if (code === 0) return { ok: true }
-    const stderr = await new Response(proc.stderr).text()
-    return { ok: false, reason: `bun install exited with code ${code}: ${stderr.trim() || 'no stderr'}` }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }
@@ -55,30 +57,62 @@ export async function runBunInstall(cwd: string, opts?: InstallRunnerOptions): P
 // install` would no-op when the existing lockfile entry already satisfies
 // an in-range spec — which is the exact regression auto-upgrade exists to
 // prevent).
-export type UpdateRunner = (cwd: string, pkg: string) => Promise<InstallResult>
+export type UpdateRunnerOptions = Pick<InstallRunnerOptions, 'timeoutMs' | 'spawn'>
 
-export async function runBunUpdate(cwd: string, pkg: string): Promise<InstallResult> {
+export type UpdateRunner = (cwd: string, pkg: string, opts?: UpdateRunnerOptions) => Promise<InstallResult>
+
+export async function runBunUpdate(cwd: string, pkg: string, opts?: UpdateRunnerOptions): Promise<InstallResult> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return { ok: false, reason: 'bun runtime not available' }
   try {
-    const proc = bun.spawn({
-      // `bun update <pkg> --latest` re-resolves <pkg> against the registry,
-      // capped by the spec in package.json. For a caret/tilde range this
-      // pulls the highest in-range version (the case `bun install` won't
-      // upgrade because the lockfile already satisfies the spec). For an
-      // exact pin it's effectively a force re-fetch of that exact version.
-      // `--linker=hoisted` for the same Bun 1.3.x deadlock reason as
-      // runBunInstall above.
+    // `bun update <pkg> --latest` re-resolves <pkg> against the registry,
+    // capped by the spec in package.json. For a caret/tilde range this
+    // pulls the highest in-range version (the case `bun install` won't
+    // upgrade because the lockfile already satisfies the spec). For an
+    // exact pin it's effectively a force re-fetch of that exact version.
+    // `--linker=hoisted` for the same Bun 1.3.x deadlock reason as
+    // runBunInstall above.
+    return await runTimedBunProcess({
       cmd: ['bun', 'update', pkg, '--latest', '--linker=hoisted'],
       cwd,
-      stdout: 'pipe',
-      stderr: 'pipe',
+      timeoutMs: opts?.timeoutMs ?? INSTALL_TIMEOUT_MS,
+      spawn: opts?.spawn ?? bun.spawn,
+      timeoutReason: (seconds) => `bun update ${pkg} timed out after ${seconds}s`,
+      failureReason: (code, stderr) => `bun update ${pkg} exited with code ${code}: ${stderr.trim() || 'no stderr'}`,
     })
-    const code = await proc.exited
-    if (code === 0) return { ok: true }
-    const stderr = await new Response(proc.stderr).text()
-    return { ok: false, reason: `bun update ${pkg} exited with code ${code}: ${stderr.trim() || 'no stderr'}` }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+async function runTimedBunProcess({
+  cmd,
+  cwd,
+  timeoutMs,
+  spawn,
+  timeoutReason,
+  failureReason,
+}: {
+  cmd: string[]
+  cwd: string
+  timeoutMs: number
+  spawn: typeof Bun.spawn
+  timeoutReason: (seconds: number) => string
+  failureReason: (code: number, stderr: string) => string
+}): Promise<InstallResult> {
+  const proc = spawn({ cmd, cwd, stdout: 'pipe', stderr: 'pipe' })
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    proc.kill('SIGKILL')
+  }, timeoutMs)
+  try {
+    const code = await proc.exited
+    if (timedOut) return { ok: false, reason: timeoutReason(timeoutMs / 1000) }
+    if (code === 0) return { ok: true }
+    const stderr = await new Response(proc.stderr).text()
+    return { ok: false, reason: failureReason(code, stderr) }
+  } finally {
+    clearTimeout(timeout)
   }
 }


### PR DESCRIPTION
## Background

`typeclaw init` silently swallowed pipeline failures: a failed `bun install`, Dockerfile write, or git step was rendered as a benign "Skipped …" and the wizard marched into hatching anyway. A hatching failure then fell through to **exit 0** with no guidance, `bun install` could hang forever, a failed hatch left an orphaned container, and a partial `.git` blocked recovery on re-run.

## Summary

- **Fail fast on hard prerequisites** — `runInit` throws on install/Dockerfile failure; the CLI renders them with `s.error` (not "Skipped …") and exits 1 with remediation. Hatching failure now exits 1 with next-step guidance instead of exiting 0 silently. Git failure stays non-fatal but is reported honestly (the container boots without a repo).
- **Bound `bun install`/`bun update`** with an injectable timeout so a hung registry can't hang init forever.
- **Clean up the orphaned container** when hatching fails after a successful start (reuses `stop()`).
- **Recover partial git state** — `initGitRepo` detects a `.git` with no commit (a prior init that died before committing) and completes the initial commit instead of skipping it.
- **Smoother re-run UX** — re-running in an existing typeclaw folder no longer shows the "directory is not empty" warning (the resume prompt owns it); nested-agent / already-hatched errors gained remediation; `--reset` is surfaced.

## Preview

N/A — no visual output changes; behavior change is in error paths only.

## What this does NOT do

- Does not change the happy-path init flow or any configuration schema.
- Does not add new CLI flags beyond surfacing the existing `--reset` in error messages.
- Does not migrate existing agent folders — partial `.git` recovery is surgical (completes the first commit if absent, does nothing otherwise).

## Review notes

**Policy invariant.** install/Dockerfile/hatching = fatal; git = non-fatal-but-loud. Rationale: hatching bind-mounts `/agent/node_modules` to resolve `typeclaw`, so a failed hatch means the container cannot start at all. Git is not required for the container to run.

**Timeout injection.** `runBunInstall` accepts an optional `timeoutMs` parameter (default: 120 s) used in tests to exercise the timeout path without actually waiting. The production default is set in `src/init/index.ts`.

**Container cleanup.** The `stop()` reuse in the hatching-failure path assumes `stop()` is idempotent on a partially-started container — this is already guaranteed by the `docker stop && docker rm` sequence in `src/container/lifecycle.ts`.

**Tests.** New/updated tests in `src/init/index.test.ts`, `src/init/run-bun-install.test.ts`, `src/cli/init.test.ts` cover: timeout path, container cleanup on post-start failure, git partial-state recovery, re-run prompt skip. Full suite 9119 pass / 1 skip / 0 fail; `typecheck`, `lint`, `format` green.