### PR TITLE
perf(tool-result-cap): lower default textMaxBytes to 32KB

### DIFF
--- a/src/bundled-plugins/tool-result-cap/README.md
+++ b/src/bundled-plugins/tool-result-cap/README.md
@@ -24,18 +24,18 @@ For sessions that already contain oversized tool results from before this plugin
   "tool-result-cap": {
     "enabled": true,
     "imageMaxBytes": 262144,
-    "textMaxBytes": 65536,
+    "textMaxBytes": 32768,
     "exemptTools": []
   }
 }
 ```
 
-| Field                           | Default  | Effect                                                                                                                                                                                                                                                                                   |
-| ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tool-result-cap.enabled`       | `true`   | Master switch. When `false`, the plugin returns no hooks at all and tool results pass through untouched.                                                                                                                                                                                 |
-| `tool-result-cap.imageMaxBytes` | `262144` | Maximum size (in bytes of the base64 string, not the decoded binary) for any `{type:"image"}` part in a tool result. Parts above this are replaced with a short text placeholder naming the original mime type and size. Default is ~256KB of base64 ≈ ~190KB of binary. Minimum `1024`. |
-| `tool-result-cap.textMaxBytes`  | `65536`  | Maximum length (in characters) for any `{type:"text"}` part. Parts above this are truncated: the first `textMaxBytes` characters are kept (so the LLM sees the shape of the output), and an elision marker is appended naming the byte count dropped. Minimum `1024`.                    |
-| `tool-result-cap.exemptTools`   | `[]`     | List of tool names to skip entirely. Use when a specific tool genuinely needs to return large payloads and you can absorb the per-turn cost.                                                                                                                                             |
+| Field                           | Default  | Effect                                                                                                                                                                                                                                                                                               |
+| ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tool-result-cap.enabled`       | `true`   | Master switch. When `false`, the plugin returns no hooks at all and tool results pass through untouched.                                                                                                                                                                                             |
+| `tool-result-cap.imageMaxBytes` | `262144` | Maximum size (in bytes of the base64 string, not the decoded binary) for any `{type:"image"}` part in a tool result. Parts above this are replaced with a short text placeholder naming the original mime type and size. Default is ~256KB of base64 ≈ ~190KB of binary. Minimum `1024`.             |
+| `tool-result-cap.textMaxBytes`  | `32768`  | Maximum length (in characters) for any `{type:"text"}` part. Parts above this are truncated: the first `textMaxBytes` characters are kept (so the LLM sees the shape of the output), and an elision marker is appended naming the byte count dropped. Default is ~32KB ≈ ~8K tokens. Minimum `1024`. |
+| `tool-result-cap.exemptTools`   | `[]`     | List of tool names to skip entirely. Use when a specific tool genuinely needs to return large payloads and you can absorb the per-turn cost.                                                                                                                                                         |
 
 All fields are **restart-required** — the plugin reads them once at boot.
 

--- a/src/bundled-plugins/tool-result-cap/index.test.ts
+++ b/src/bundled-plugins/tool-result-cap/index.test.ts
@@ -58,7 +58,7 @@ describe('tool-result-cap plugin', () => {
     expect(parsed).toEqual({
       enabled: true,
       imageMaxBytes: 262_144,
-      textMaxBytes: 65_536,
+      textMaxBytes: 32_768,
       exemptTools: [],
     })
   })
@@ -165,7 +165,7 @@ describe('resolveCapOptionsFromConfig', () => {
     const opts = resolveCapOptionsFromConfig(undefined)
     expect(opts).not.toBeNull()
     expect(opts!.imageMaxBytes).toBe(262_144)
-    expect(opts!.textMaxBytes).toBe(65_536)
+    expect(opts!.textMaxBytes).toBe(32_768)
     expect(opts!.exemptTools?.size).toBe(0)
   })
 

--- a/src/bundled-plugins/tool-result-cap/index.ts
+++ b/src/bundled-plugins/tool-result-cap/index.ts
@@ -5,7 +5,7 @@ import { definePlugin } from '@/plugin'
 import { type CapOptions, capToolResult } from './cap-result'
 
 const DEFAULT_IMAGE_MAX_BYTES = 262_144
-const DEFAULT_TEXT_MAX_BYTES = 65_536
+const DEFAULT_TEXT_MAX_BYTES = 32_768
 const MIN_IMAGE_MAX_BYTES = 1_024
 const MIN_TEXT_MAX_BYTES = 1_024
 


### PR DESCRIPTION
## What

Lowers the bundled `tool-result-cap` default `textMaxBytes` from 65536 (~16K tokens) to **32768** (~8K tokens). `imageMaxBytes`, the 1024 minimum, `exemptTools`, and the `enabled` switch are unchanged. Operators can still raise it in `typeclaw.json`.

## Why

`read` tool results are the #1 raw context consumer (~181M tokens fleet-wide, ~1,800 tok/call avg). The cap previously only caught pathological blobs (base64 images, binary fetches); normal large text outputs sailed under 64KB and accumulated, re-shipped as cacheRead every later turn. Halving the default bounds that accumulation while staying configurable.

## Test plan

`typecheck` / `format` / `lint` clean; full suite 0 fail (tool-result-cap default-assertion tests updated, README config table updated).

Refs #897.
