### PR TITLE
perf(memory): drop direct full-shard injection, always retrieval-based

### DIFF
--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -60,9 +60,9 @@ describe('vector session.turn.start hook', () => {
     expect(retrievalContext.results).not.toContain('## Retrieved memory')
   })
 
-  test('under-budget turn injects ALL shard bodies without hybrid search (direct mode)', async () => {
+  test('under-budget turn runs hybrid search instead of dumping all shard bodies', async () => {
     hybridSearchMock.mockClear()
-    // given: two small shards well under the budget → direct mode
+    // given: two small shards well under the budget
     await writeTopic(agentDir, 'first-topic', 'First Topic', 'first body')
     await writeTopic(agentDir, 'second-topic', 'Second Topic', 'second body')
     const exports = await bootVectorPlugin(16384)
@@ -73,19 +73,20 @@ describe('vector session.turn.start hook', () => {
       { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') },
     )
 
-    expect(hybridSearchMock).not.toHaveBeenCalled()
+    expect(hybridSearchMock).toHaveBeenCalledWith('anything', expect.anything(), agentDir, 10, expect.any(Function))
     expect(retrievalContext.results).toContain('# Memory')
-    expect(retrievalContext.results).toContain('## First Topic')
-    expect(retrievalContext.results).toContain('first body')
     expect(retrievalContext.results).toContain('## Second Topic')
-    expect(retrievalContext.results).toContain('second body')
+    expect(retrievalContext.results).toContain('Second topic excerpt from vector retrieval.')
+    expect(retrievalContext.results).not.toContain('first body')
+    expect(retrievalContext.results).not.toContain('second body')
   })
 
-  test('zero-shard direct mode still logs the mode=direct topics=0 signal', async () => {
-    hybridSearchMock.mockClear()
-    // given: a fresh agent with no topic shards → direct mode, zero shards
+  test('under-budget turn falls back to all headings when hybrid search returns nothing', async () => {
+    const emptySearch = mock(async () => [])
+    await writeTopic(agentDir, 'first-topic', 'First Topic', 'private first body')
+    await writeTopic(agentDir, 'second-topic', 'Second Topic', 'private second body')
     const infos: string[] = []
-    const exports = await bootVectorPlugin(16384, capturingLogger(infos))
+    const exports = await bootVectorPluginWith(emptySearch, 16384, capturingLogger(infos))
 
     const retrievalContext = { results: '' }
     await exports.hooks!['session.turn.start']!(
@@ -93,58 +94,76 @@ describe('vector session.turn.start hook', () => {
       { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') },
     )
 
-    // then: nothing injected, hybrid search skipped, but the signal is still logged
-    expect(retrievalContext.results).toBe('')
-    expect(hybridSearchMock).not.toHaveBeenCalled()
-    expect(infos).toContain('[vector-retrieval] mode=direct topics=0 full=0')
+    expect(emptySearch).toHaveBeenCalledWith('anything', expect.anything(), agentDir, 10, expect.any(Function))
+    expect(retrievalContext.results).toContain('# Memory')
+    expect(retrievalContext.results).toContain('## First Topic')
+    expect(retrievalContext.results).toContain('slug: `first-topic`')
+    expect(retrievalContext.results).toContain('## Second Topic')
+    expect(retrievalContext.results).toContain('slug: `second-topic`')
+    expect(retrievalContext.results).not.toContain('private first body')
+    expect(retrievalContext.results).not.toContain('private second body')
+    expect(infos.some((line) => line.includes('suppressed=1') && line.includes('fallback=topic-index'))).toBe(true)
   })
 
-  test('second direct-mode turn dedups unchanged bodies to slug references', async () => {
+  test('zero-shard turn still logs suppression without falling back to an empty index', async () => {
+    const emptySearch = mock(async () => [])
+    const infos: string[] = []
+    const exports = await bootVectorPluginWith(emptySearch, 16384, capturingLogger(infos))
+
+    const retrievalContext = { results: '' }
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_vector', agentDir, userPrompt: 'anything', retrievalContext },
+      { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') },
+    )
+
+    expect(retrievalContext.results).toBe('')
+    expect(emptySearch).toHaveBeenCalled()
+    expect(infos.some((line) => line.includes('suppressed=1') && !line.includes('fallback=topic-index'))).toBe(true)
+  })
+
+  test('second retrieval turn dedups unchanged excerpts to slug references', async () => {
     hybridSearchMock.mockClear()
-    await writeTopic(agentDir, 'first-topic', 'First Topic', 'first body')
     const exports = await bootVectorPlugin(16384)
     const hook = exports.hooks!['session.turn.start']!
     const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') }
 
-    // given: turn one injected the full body
+    // given: turn one injected the retrieved excerpt
     const first = { results: '' }
     await hook({ sessionId: 'ses_dedup', agentDir, userPrompt: 'turn one', retrievalContext: first }, ctx)
-    expect(first.results).toContain('first body')
+    expect(first.results).toContain('Second topic excerpt from vector retrieval.')
 
     // when: a second turn runs for the same session with the shard unchanged
     const second = { results: '' }
     await hook({ sessionId: 'ses_dedup', agentDir, userPrompt: 'turn two', retrievalContext: second }, ctx)
 
-    // then: the body is replaced by a recoverable slug reference, not re-sent
-    expect(second.results).toContain('## First Topic')
-    expect(second.results).not.toContain('first body')
-    expect(second.results).toContain('slug: `first-topic`')
-    expect(second.results).toContain('memory_search({ topic: "first-topic" })')
+    // then: the excerpt is replaced by a recoverable slug reference, not re-sent
+    expect(second.results).toContain('## Second Topic')
+    expect(second.results).not.toContain('Second topic excerpt from vector retrieval.')
+    expect(second.results).toContain('slug: `second-topic`')
+    expect(second.results).toContain('memory_search({ topic: "second-topic" })')
   })
 
-  test('a changed shard body re-injects in full on the next turn', async () => {
-    hybridSearchMock.mockClear()
-    await writeTopic(agentDir, 'topic', 'Topic', 'original body')
-    const exports = await bootVectorPlugin(16384)
+  test('a changed retrieved excerpt re-injects on the next turn', async () => {
+    const retrieved = mock(async () => [retrievedTopic('topic', 'Topic', 'original excerpt')])
+    const exports = await bootVectorPluginWith(retrieved, 16384)
     const hook = exports.hooks!['session.turn.start']!
     const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') }
 
     const first = { results: '' }
     await hook({ sessionId: 'ses_change', agentDir, userPrompt: 'turn one', retrievalContext: first }, ctx)
 
-    // when: the shard body changes (a dreaming pass rewrote it) before turn two
-    await writeTopic(agentDir, 'topic', 'Topic', 'rewritten body')
+    // when: retrieval returns changed content (a dreaming pass rewrote the shard)
+    retrieved.mockImplementation(async () => [retrievedTopic('topic', 'Topic', 'rewritten excerpt')])
     const second = { results: '' }
     await hook({ sessionId: 'ses_change', agentDir, userPrompt: 'turn two', retrievalContext: second }, ctx)
 
-    // then: the fresh body is injected in full, not a stale reference
-    expect(second.results).toContain('rewritten body')
+    // then: the fresh excerpt is injected, not a stale reference
+    expect(second.results).toContain('rewritten excerpt')
     expect(second.results).not.toContain('slug: `topic`')
   })
 
-  test('dedup state is per-session: a different session still gets the full body', async () => {
+  test('dedup state is per-session: a different session still gets the excerpt', async () => {
     hybridSearchMock.mockClear()
-    await writeTopic(agentDir, 'topic', 'Topic', 'shared body')
     const exports = await bootVectorPlugin(16384)
     const hook = exports.hooks!['session.turn.start']!
     const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') }
@@ -157,13 +176,12 @@ describe('vector session.turn.start hook', () => {
     const b = { results: '' }
     await hook({ sessionId: 'ses_b', agentDir, userPrompt: 'b1', retrievalContext: b }, ctx)
 
-    // then: it gets the full body — dedup state does not bleed across sessions
-    expect(b.results).toContain('shared body')
+    // then: it gets the excerpt — dedup state does not bleed across sessions
+    expect(b.results).toContain('Second topic excerpt from vector retrieval.')
   })
 
-  test('session.end clears dedup state so a resurrected session re-injects in full', async () => {
+  test('session.end clears dedup state so a resurrected session re-injects the excerpt', async () => {
     hybridSearchMock.mockClear()
-    await writeTopic(agentDir, 'topic', 'Topic', 'durable body')
     const exports = await bootVectorPlugin(16384)
     const hook = exports.hooks!['session.turn.start']!
     const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') }
@@ -175,9 +193,9 @@ describe('vector session.turn.start hook', () => {
     const after = { results: '' }
     await hook({ sessionId: 'ses_res', agentDir, userPrompt: 'turn two', retrievalContext: after }, ctx)
 
-    // then: the body is injected in full again — no dangling reference to a
-    // body the resurrected model context no longer holds
-    expect(after.results).toContain('durable body')
+    // then: the excerpt is injected again — no dangling reference to content the
+    // resurrected model context no longer holds
+    expect(after.results).toContain('Second topic excerpt from vector retrieval.')
   })
 
   test('channel direct-mode turn force-indexes every shard heading without hybrid search', async () => {
@@ -346,4 +364,8 @@ async function writeTopic(dir: string, slug: string, heading: string, body: stri
     topicShardPath(dir, slug),
     renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
   )
+}
+
+function retrievedTopic(key: string, heading: string, excerpt: string) {
+  return { source: 'topic' as const, key, heading, excerpt, rrfScore: 1 }
 }

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -14,9 +14,10 @@ import { buildInjectionPlan, DEFAULT_INJECTION_BUDGET_BYTES, MIN_INJECTION_BUDGE
 import {
   forceIndexForChannel,
   loadMemoryInjectionPlan,
-  renderDedupedMemorySection,
+  renderDedupedRetrievedMemorySection,
   renderMemorySection,
   renderRetrievedMemorySection,
+  renderTopicIndexMemorySection,
 } from './load-memory'
 import { loadAllShards } from './load-shards'
 import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-logger'
@@ -24,7 +25,7 @@ import { createMemoryRetrievalSubagent, type MemoryRetrievalPayload } from './me
 import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
 import { bumpReferenceAccess } from './references/load-references'
 import { createMemorySearchTool } from './search-tool'
-import { type InjectedShardState, partitionDirectShards } from './turn-dedup'
+import { type InjectedMemoryState, partitionRetrievedMemoryItems } from './turn-dedup'
 import { vectorConfigSchema } from './vector/config'
 import { runVectorIndexDoctor } from './vector/doctor'
 import { embed } from './vector/embedder'
@@ -163,21 +164,20 @@ type MemoryPluginDeps = {
 
 const defaultDeps: MemoryPluginDeps = { hybridSearch, queryEmbedFn: embed }
 
-// Builds the per-turn user-prompt memory block for a vector agent. Under budget
-// (direct mode) injects shard bodies, but de-duplicates across turns: a shard
-// whose body was already injected in full this session is rendered as a compact
-// slug reference (see `partitionDirectShards`) so a long conversation stops
-// re-sending identical bodies every turn while keeping every topic named and
-// recoverable. Over budget falls back to top-K hybrid search.
+// Builds the per-turn user-prompt memory block for a vector agent. Non-channel
+// turns always use top-K hybrid search, regardless of total shard size. Repeated
+// retrieved excerpts de-duplicate across turns, and an empty retrieval falls back
+// to an all-topic headings index so tiny memory sets are never silently hidden by
+// a relevance gate or stale vector index.
 //
 // Channel origins never carry bodies (memory-bleed defense). A channel direct-mode
-// turn is force-indexed to a headings/slugs-only section over EVERY shard, not run
+// turn is force-indexed to a headings-only section over EVERY shard, not run
 // through hybridSearch: hybrid is relevance-filtered top-K, so an off-topic turn or
 // stale vector index could silently drop headings that direct mode always had.
 async function renderVectorTurnMemory(
   event: { agentDir: string; userPrompt: string; origin?: SessionOrigin },
   injectionBudgetBytes: number,
-  injectedState: InjectedShardState,
+  injectedState: InjectedMemoryState,
   deps: MemoryPluginDeps,
   logger?: { info: (msg: string) => void },
 ): Promise<string> {
@@ -187,11 +187,6 @@ async function renderVectorTurnMemory(
     const indexed = forceIndexForChannel(plan, { origin: event.origin, injectionBudgetBytes })
     logger?.info(`[vector-retrieval] mode=index topics=${plan.shards.length} channel=forced`)
     return renderMemorySection(indexed, { origin: event.origin })
-  }
-  if (plan.mode === 'direct') {
-    const { full, unchanged } = partitionDirectShards(plan.shards, injectedState)
-    logger?.info(`[vector-retrieval] mode=direct topics=${plan.shards.length} full=${full.length}`)
-    return renderDedupedMemorySection(full, unchanged)
   }
   const store = VectorStore.open(join(event.agentDir, 'memory', '.vectors', 'index.db'))
   try {
@@ -214,9 +209,11 @@ async function renderVectorTurnMemory(
     // results.length === 0 on a non-empty query means the relevance gate suppressed
     // every candidate (or nothing matched) — an empty memory block, indistinguishable
     // from "no memory" without this explicit signal.
+    const shouldFallbackToTopicIndex = !isChannel && results.length === 0 && plan.shards.length > 0
     const suppressed = results.length === 0 ? ' suppressed=1' : ''
+    const fallback = shouldFallbackToTopicIndex ? ' fallback=topic-index' : ''
     logger?.info(
-      `[vector-retrieval] mode=index topic_results=${topicHits} stream_results=${streamHits} reference_results=${referenceHits} elapsed_ms=${elapsedMs}${suppressed}`,
+      `[vector-retrieval] mode=index topic_results=${topicHits} stream_results=${streamHits} reference_results=${referenceHits} elapsed_ms=${elapsedMs}${suppressed}${fallback}`,
     )
     // Count a vector-surfaced reference as an access so it survives dreaming's
     // time-decay the same way a memory_search hit does. Fire-and-forget: the
@@ -228,7 +225,10 @@ async function renderVectorTurnMemory(
         logger?.info(`[vector-retrieval] reference access bump failed: ${err instanceof Error ? err.message : err}`)
       })
     }
-    return renderRetrievedMemorySection(results, { origin: event.origin })
+    if (shouldFallbackToTopicIndex) return renderTopicIndexMemorySection(plan.shards, { origin: event.origin })
+    if (isChannel) return renderRetrievedMemorySection(results, { origin: event.origin })
+    const { fresh, unchanged } = partitionRetrievedMemoryItems(results, injectedState)
+    return renderDedupedRetrievedMemorySection(fresh, unchanged)
   } finally {
     store.close()
   }
@@ -255,10 +255,10 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
       // only when `date` matches today's date — yesterday's cursor points
       // into yesterday's file and the spawn's payload omits it.
       const streamCursorAtLastRun = new Map<string, { date: string; lineCount: number }>()
-      // Per-session record of shard bodies already injected in full this session,
-      // so direct-mode vector turns can de-duplicate unchanged bodies across turns.
+      // Per-session record of retrieved memory already injected this session,
+      // so vector turns can de-duplicate unchanged excerpts across turns.
       // Cleared on session.end alongside the other per-session bookkeeping below.
-      const injectedShards = new Map<string, InjectedShardState>()
+      const injectedMemory = new Map<string, InjectedMemoryState>()
 
       // memory-logger is coalesced per agentDir (not per parentSessionId) so that
       // two concurrent channel sessions for the same agent never write to the same
@@ -510,10 +510,10 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
               // memory via the system prompt either.
               if (event.retrievalContext === undefined) return
               try {
-                let injectedState = injectedShards.get(event.sessionId)
+                let injectedState = injectedMemory.get(event.sessionId)
                 if (injectedState === undefined) {
                   injectedState = new Map()
-                  injectedShards.set(event.sessionId, injectedState)
+                  injectedMemory.set(event.sessionId, injectedState)
                 }
                 event.retrievalContext.results = await renderVectorTurnMemory(
                   event,
@@ -563,7 +563,7 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
           'session.end': (event) => {
             // Dedup state is populated for every vector turn (subagents included),
             // so it must be cleared before the subagent-origin early-return below.
-            injectedShards.delete(event.sessionId)
+            injectedMemory.delete(event.sessionId)
             if (event.origin?.kind === 'subagent') return
             cancelTimer(event.sessionId)
             const sessionId = event.sessionId

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -227,8 +227,8 @@ async function renderVectorTurnMemory(
     }
     if (shouldFallbackToTopicIndex) return renderTopicIndexMemorySection(plan.shards, { origin: event.origin })
     if (isChannel) return renderRetrievedMemorySection(results, { origin: event.origin })
-    const { fresh, unchanged } = partitionRetrievedMemoryItems(results, injectedState)
-    return renderDedupedRetrievedMemorySection(fresh, unchanged)
+    const deduped = partitionRetrievedMemoryItems(results, injectedState)
+    return renderDedupedRetrievedMemorySection(deduped)
   } finally {
     store.close()
   }

--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -52,9 +52,9 @@ export async function loadMemory(agentDir: string, options: LoadMemoryOptions = 
   return appendRetrievalCache(renderSection(effectivePlan, options), agentDir, options)
 }
 
-// Returns the raw direct/index plan WITHOUT `forceIndexForChannel`, so a vector
-// agent's per-turn "all shards under budget" really means all shards. Callers
-// that need the channel-bleed defense re-apply it via `renderMemorySection`.
+// Returns the raw direct/index plan WITHOUT `forceIndexForChannel`. Vector
+// per-turn retrieval still needs the complete shard list for channel force-index
+// and for the non-channel headings fallback when retrieval returns nothing.
 export async function loadMemoryInjectionPlan(
   agentDir: string,
   options: Pick<LoadMemoryOptions, 'injectionBudgetBytes'> = {},
@@ -72,29 +72,6 @@ export function renderMemorySection(plan: InjectionPlan, options: Pick<LoadMemor
   return renderSection(plan, options)
 }
 
-// Direct-mode render: `unchangedShards` had their body injected earlier this
-// session, so it is replaced by a one-line slug reference the agent can re-fetch
-// on demand; `fullShards` (new or changed) keep their full body. Non-channel only
-// — channel turns are force-indexed upstream, so no channel-bleed boundary here.
-export function renderDedupedMemorySection(fullShards: TopicShard[], unchangedShards: TopicShard[]): string {
-  if (fullShards.length === 0 && unchangedShards.length === 0) return ''
-  const lines = ['# Memory', '', MEMORY_FRAMING, '']
-  for (const shard of fullShards) {
-    const topic = topicEntryFromShard(shard)
-    lines.push(`## ${topic.name}`)
-    lines.push(renderBody(topic), '')
-  }
-  for (const shard of unchangedShards) {
-    lines.push(`## ${shard.frontmatter.heading}`)
-    lines.push(unchangedShardReference(shard.slug), '')
-  }
-  return lines.join('\n').trimEnd()
-}
-
-function unchangedShardReference(slug: string): string {
-  return `slug: \`${slug}\` — unchanged since earlier this session; call \`memory_search({ topic: "${slug}" })\` to re-read the full body.`
-}
-
 export type RetrievedMemoryItem = {
   source: 'topic' | 'stream' | 'reference'
   key: string
@@ -102,8 +79,35 @@ export type RetrievedMemoryItem = {
   excerpt: string
 }
 
-// Over-budget vector turns inject the top-K relevant memories (not all shards).
-// Same `# Memory` framing + channel-bleed boundary as the direct path, so the
+// Per-turn vector retrieval keeps repeated content compact across a session: a
+// repeated result is still named and recoverable, but its unchanged excerpt is
+// not re-sent verbatim on every turn.
+export function renderDedupedRetrievedMemorySection(
+  freshItems: RetrievedMemoryItem[],
+  unchangedItems: RetrievedMemoryItem[],
+): string {
+  if (freshItems.length === 0 && unchangedItems.length === 0) return ''
+  const lines = ['# Memory', '', MEMORY_FRAMING, '']
+  for (const item of freshItems) {
+    lines.push(`## ${item.heading}`)
+    lines.push(item.excerpt.trimEnd(), '')
+  }
+  for (const item of unchangedItems) {
+    lines.push(`## ${item.heading}`)
+    lines.push(unchangedRetrievedItemReference(item), '')
+  }
+  return lines.join('\n').trimEnd()
+}
+
+function unchangedRetrievedItemReference(item: RetrievedMemoryItem): string {
+  if (item.source === 'topic' || item.source === 'reference') {
+    return `slug: \`${item.key}\` — unchanged since earlier this session; call \`memory_search({ topic: "${item.key}" })\` to re-read the full body.`
+  }
+  return 'recent observation — unchanged since earlier this session; call `memory_search({ query: ... })` with terms from this heading to re-read the full text.'
+}
+
+// Vector turns inject the top-K relevant memories (not all shards).
+// Same `# Memory` framing + channel-bleed boundary as the fallback index, so the
 // passive-context guarantees hold regardless of which branch ran.
 //
 // Channel origins get headings only (excerpt stripped, fetched on demand via
@@ -133,6 +137,31 @@ export function renderRetrievedMemorySection(
     }
   }
   return lines.join('\n').trimEnd()
+}
+
+// Non-channel vector turns run top-K retrieval even for tiny memory sets. If the
+// relevance gate suppresses every candidate (or the index is empty/stale), this
+// headings-only fallback preserves discoverability without dumping shard bodies.
+export function renderTopicIndexMemorySection(
+  shards: TopicShard[],
+  options: Pick<LoadMemoryOptions, 'origin'> = {},
+): string {
+  if (shards.length === 0) return ''
+  const lines = ['# Memory', '', MEMORY_FRAMING, '']
+  if (options.origin?.kind === 'channel') lines.push(...CHANNEL_MEMORY_BOUNDARY, '')
+  lines.push(topicIndexDirective(options), '')
+  for (const shard of shards) {
+    lines.push(`## ${shard.frontmatter.heading}`)
+    lines.push(`slug: \`${shard.slug}\``, '')
+  }
+  return lines.join('\n').trimEnd()
+}
+
+function topicIndexDirective(options: Pick<LoadMemoryOptions, 'origin'>): string {
+  if (options.origin?.kind === 'channel') {
+    return 'Memory shown as headings only in channels. Call `memory_search({ topic: "<slug>" })` with a slug below to read a full body.'
+  }
+  return 'No relevant memory cleared retrieval for this turn. All topic headings are shown so memory stays discoverable; call `memory_search({ topic: "<slug>" })` with a slug below to read a full body.'
 }
 
 function retrievedIndexDirective(): string {

--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -6,6 +6,7 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import { buildInjectionPlan, DEFAULT_INJECTION_BUDGET_BYTES, type InjectionPlan } from './injection-plan'
 import { loadAllShards, type TopicShard } from './load-shards'
 import { topicsDir } from './paths'
+import type { DedupedRetrievedItem } from './turn-dedup'
 
 const MAX_FILE_BYTES = 12 * 1024
 const MEMORY_FRAMING =
@@ -81,20 +82,15 @@ export type RetrievedMemoryItem = {
 
 // Per-turn vector retrieval keeps repeated content compact across a session: a
 // repeated result is still named and recoverable, but its unchanged excerpt is
-// not re-sent verbatim on every turn.
-export function renderDedupedRetrievedMemorySection(
-  freshItems: RetrievedMemoryItem[],
-  unchangedItems: RetrievedMemoryItem[],
-): string {
-  if (freshItems.length === 0 && unchangedItems.length === 0) return ''
+// not re-sent verbatim on every turn. Entries are rendered in the order given
+// (the hybridSearch relevance ranking); only each item's body-vs-reference
+// rendering varies, so a previously-seen top hit is never demoted.
+export function renderDedupedRetrievedMemorySection(entries: DedupedRetrievedItem[]): string {
+  if (entries.length === 0) return ''
   const lines = ['# Memory', '', MEMORY_FRAMING, '']
-  for (const item of freshItems) {
+  for (const { item, changed } of entries) {
     lines.push(`## ${item.heading}`)
-    lines.push(item.excerpt.trimEnd(), '')
-  }
-  for (const item of unchangedItems) {
-    lines.push(`## ${item.heading}`)
-    lines.push(unchangedRetrievedItemReference(item), '')
+    lines.push(changed ? item.excerpt.trimEnd() : unchangedRetrievedItemReference(item), '')
   }
   return lines.join('\n').trimEnd()
 }

--- a/src/bundled-plugins/memory/turn-dedup.test.ts
+++ b/src/bundled-plugins/memory/turn-dedup.test.ts
@@ -1,26 +1,24 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { RetrievedMemoryItem } from './load-memory'
-import { type InjectedMemoryState, partitionRetrievedMemoryItems } from './turn-dedup'
+import { renderDedupedRetrievedMemorySection, type RetrievedMemoryItem } from './load-memory'
+import { type DedupedRetrievedItem, type InjectedMemoryState, partitionRetrievedMemoryItems } from './turn-dedup'
 
 function item(key: string, excerpt: string): RetrievedMemoryItem {
-  return {
-    source: 'topic',
-    key,
-    heading: key,
-    excerpt,
-  }
+  return { source: 'topic', key, heading: key, excerpt }
 }
 
+const changedKeys = (entries: DedupedRetrievedItem[]) => entries.filter((e) => e.changed).map((e) => e.item.key)
+const unchangedKeys = (entries: DedupedRetrievedItem[]) => entries.filter((e) => !e.changed).map((e) => e.item.key)
+
 describe('partitionRetrievedMemoryItems', () => {
-  test('first turn renders every retrieved item and records it', () => {
+  test('first turn marks every retrieved item changed and records it', () => {
     const state: InjectedMemoryState = new Map()
     const items = [item('a', 'excerpt a'), item('b', 'excerpt b')]
 
-    const { fresh, unchanged } = partitionRetrievedMemoryItems(items, state)
+    const entries = partitionRetrievedMemoryItems(items, state)
 
-    expect(fresh.map((s) => s.key)).toEqual(['a', 'b'])
-    expect(unchanged).toHaveLength(0)
+    expect(changedKeys(entries)).toEqual(['a', 'b'])
+    expect(unchangedKeys(entries)).toHaveLength(0)
     expect(state.size).toBe(2)
   })
 
@@ -29,33 +27,30 @@ describe('partitionRetrievedMemoryItems', () => {
     const items = [item('a', 'excerpt a'), item('b', 'excerpt b')]
     partitionRetrievedMemoryItems(items, state)
 
-    const { fresh, unchanged } = partitionRetrievedMemoryItems(items, state)
+    const entries = partitionRetrievedMemoryItems(items, state)
 
-    expect(fresh).toHaveLength(0)
-    expect(unchanged.map((s) => s.key)).toEqual(['a', 'b'])
+    expect(changedKeys(entries)).toHaveLength(0)
+    expect(unchangedKeys(entries)).toEqual(['a', 'b'])
   })
 
   test('an item whose excerpt changed re-injects while siblings stay deduped', () => {
     const state: InjectedMemoryState = new Map()
     partitionRetrievedMemoryItems([item('a', 'excerpt a'), item('b', 'excerpt b')], state)
 
-    const { fresh, unchanged } = partitionRetrievedMemoryItems(
-      [item('a', 'excerpt a v2'), item('b', 'excerpt b')],
-      state,
-    )
+    const entries = partitionRetrievedMemoryItems([item('a', 'excerpt a v2'), item('b', 'excerpt b')], state)
 
-    expect(fresh.map((s) => s.key)).toEqual(['a'])
-    expect(unchanged.map((s) => s.key)).toEqual(['b'])
+    expect(changedKeys(entries)).toEqual(['a'])
+    expect(unchangedKeys(entries)).toEqual(['b'])
   })
 
   test('a never-seen item appearing on a later turn injects', () => {
     const state: InjectedMemoryState = new Map()
     partitionRetrievedMemoryItems([item('a', 'excerpt a')], state)
 
-    const { fresh, unchanged } = partitionRetrievedMemoryItems([item('a', 'excerpt a'), item('c', 'excerpt c')], state)
+    const entries = partitionRetrievedMemoryItems([item('a', 'excerpt a'), item('c', 'excerpt c')], state)
 
-    expect(fresh.map((s) => s.key)).toEqual(['c'])
-    expect(unchanged.map((s) => s.key)).toEqual(['a'])
+    expect(changedKeys(entries)).toEqual(['c'])
+    expect(unchangedKeys(entries)).toEqual(['a'])
   })
 
   test('a changed-then-stable excerpt dedups after the change turn', () => {
@@ -63,27 +58,63 @@ describe('partitionRetrievedMemoryItems', () => {
     partitionRetrievedMemoryItems([item('a', 'v1')], state)
     partitionRetrievedMemoryItems([item('a', 'v2')], state)
 
-    const { fresh, unchanged } = partitionRetrievedMemoryItems([item('a', 'v2')], state)
+    const entries = partitionRetrievedMemoryItems([item('a', 'v2')], state)
 
-    expect(fresh).toHaveLength(0)
-    expect(unchanged.map((s) => s.key)).toEqual(['a'])
+    expect(changedKeys(entries)).toHaveLength(0)
+    expect(unchangedKeys(entries)).toEqual(['a'])
   })
 
   test('distinct excerpts do not collide', () => {
     const state: InjectedMemoryState = new Map()
     partitionRetrievedMemoryItems([item('a', 'alpha'), item('b', 'beta')], state)
 
-    const { unchanged } = partitionRetrievedMemoryItems([item('a', 'alpha'), item('b', 'beta')], state)
+    const entries = partitionRetrievedMemoryItems([item('a', 'alpha'), item('b', 'beta')], state)
 
-    expect(unchanged.map((s) => s.key)).toEqual(['a', 'b'])
+    expect(unchangedKeys(entries)).toEqual(['a', 'b'])
   })
 
   test('same key with a changed heading re-injects', () => {
     const state: InjectedMemoryState = new Map()
     partitionRetrievedMemoryItems([item('a', 'alpha')], state)
 
-    const { fresh } = partitionRetrievedMemoryItems([{ ...item('a', 'alpha'), heading: 'renamed' }], state)
+    const entries = partitionRetrievedMemoryItems([{ ...item('a', 'alpha'), heading: 'renamed' }], state)
 
-    expect(fresh.map((s) => s.key)).toEqual(['a'])
+    expect(changedKeys(entries)).toEqual(['a'])
+  })
+
+  test('returns items in input (relevance) order, not grouped by changed status', () => {
+    // given: a previously-seen high-ranked item ahead of a fresh lower-ranked one
+    const state: InjectedMemoryState = new Map()
+    partitionRetrievedMemoryItems([item('top', 'top body')], state)
+
+    // when: hybridSearch ranks the seen item first, a new item second
+    const entries = partitionRetrievedMemoryItems([item('top', 'top body'), item('low', 'low body')], state)
+
+    // then: order is preserved (unchanged top stays first), only status differs
+    expect(entries.map((e) => e.item.key)).toEqual(['top', 'low'])
+    expect(entries[0]!.changed).toBe(false)
+    expect(entries[1]!.changed).toBe(true)
+  })
+})
+
+describe('renderDedupedRetrievedMemorySection', () => {
+  test('renders entries in input order regardless of changed status', () => {
+    // given: an unchanged top-ranked hit followed by a fresh lower-ranked hit
+    const state: InjectedMemoryState = new Map()
+    partitionRetrievedMemoryItems([item('top', 'top body')], state)
+    const deduped = partitionRetrievedMemoryItems([item('top', 'top body'), item('low', 'low body')], state)
+
+    // when
+    const rendered = renderDedupedRetrievedMemorySection(deduped)
+
+    // then: the high-ranked seen topic is not demoted below the fresh one
+    expect(rendered.indexOf('## top')).toBeGreaterThan(-1)
+    expect(rendered.indexOf('## top')).toBeLessThan(rendered.indexOf('## low'))
+    expect(rendered).toContain('low body')
+    expect(rendered).toContain('memory_search({ topic: "top" })')
+  })
+
+  test('returns empty string when there are no entries', () => {
+    expect(renderDedupedRetrievedMemorySection([])).toBe('')
   })
 })

--- a/src/bundled-plugins/memory/turn-dedup.test.ts
+++ b/src/bundled-plugins/memory/turn-dedup.test.ts
@@ -1,77 +1,89 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { TopicShard } from './load-shards'
-import { type InjectedShardState, partitionDirectShards } from './turn-dedup'
+import type { RetrievedMemoryItem } from './load-memory'
+import { type InjectedMemoryState, partitionRetrievedMemoryItems } from './turn-dedup'
 
-function shard(slug: string, body: string): TopicShard {
+function item(key: string, excerpt: string): RetrievedMemoryItem {
   return {
-    path: `/tmp/agent/memory/topics/${slug}.md`,
-    slug,
-    frontmatter: { heading: slug, cites: 1, days: 1, lastReinforced: '2026-06-11' },
-    body,
+    source: 'topic',
+    key,
+    heading: key,
+    excerpt,
   }
 }
 
-describe('partitionDirectShards', () => {
-  test('first turn renders every shard in full and records them', () => {
-    const state: InjectedShardState = new Map()
-    const shards = [shard('a', 'body a'), shard('b', 'body b')]
+describe('partitionRetrievedMemoryItems', () => {
+  test('first turn renders every retrieved item and records it', () => {
+    const state: InjectedMemoryState = new Map()
+    const items = [item('a', 'excerpt a'), item('b', 'excerpt b')]
 
-    const { full, unchanged } = partitionDirectShards(shards, state)
+    const { fresh, unchanged } = partitionRetrievedMemoryItems(items, state)
 
-    expect(full.map((s) => s.slug)).toEqual(['a', 'b'])
+    expect(fresh.map((s) => s.key)).toEqual(['a', 'b'])
     expect(unchanged).toHaveLength(0)
     expect(state.size).toBe(2)
   })
 
-  test('second turn with unchanged bodies dedups all shards to references', () => {
-    const state: InjectedShardState = new Map()
-    const shards = [shard('a', 'body a'), shard('b', 'body b')]
-    partitionDirectShards(shards, state)
+  test('second turn with unchanged excerpts dedups all items to references', () => {
+    const state: InjectedMemoryState = new Map()
+    const items = [item('a', 'excerpt a'), item('b', 'excerpt b')]
+    partitionRetrievedMemoryItems(items, state)
 
-    const { full, unchanged } = partitionDirectShards(shards, state)
+    const { fresh, unchanged } = partitionRetrievedMemoryItems(items, state)
 
-    expect(full).toHaveLength(0)
-    expect(unchanged.map((s) => s.slug)).toEqual(['a', 'b'])
+    expect(fresh).toHaveLength(0)
+    expect(unchanged.map((s) => s.key)).toEqual(['a', 'b'])
   })
 
-  test('a shard whose body changed re-injects in full while siblings stay deduped', () => {
-    const state: InjectedShardState = new Map()
-    partitionDirectShards([shard('a', 'body a'), shard('b', 'body b')], state)
+  test('an item whose excerpt changed re-injects while siblings stay deduped', () => {
+    const state: InjectedMemoryState = new Map()
+    partitionRetrievedMemoryItems([item('a', 'excerpt a'), item('b', 'excerpt b')], state)
 
-    const { full, unchanged } = partitionDirectShards([shard('a', 'body a v2'), shard('b', 'body b')], state)
+    const { fresh, unchanged } = partitionRetrievedMemoryItems(
+      [item('a', 'excerpt a v2'), item('b', 'excerpt b')],
+      state,
+    )
 
-    expect(full.map((s) => s.slug)).toEqual(['a'])
-    expect(unchanged.map((s) => s.slug)).toEqual(['b'])
+    expect(fresh.map((s) => s.key)).toEqual(['a'])
+    expect(unchanged.map((s) => s.key)).toEqual(['b'])
   })
 
-  test('a never-seen shard appearing on a later turn injects in full', () => {
-    const state: InjectedShardState = new Map()
-    partitionDirectShards([shard('a', 'body a')], state)
+  test('a never-seen item appearing on a later turn injects', () => {
+    const state: InjectedMemoryState = new Map()
+    partitionRetrievedMemoryItems([item('a', 'excerpt a')], state)
 
-    const { full, unchanged } = partitionDirectShards([shard('a', 'body a'), shard('c', 'body c')], state)
+    const { fresh, unchanged } = partitionRetrievedMemoryItems([item('a', 'excerpt a'), item('c', 'excerpt c')], state)
 
-    expect(full.map((s) => s.slug)).toEqual(['c'])
-    expect(unchanged.map((s) => s.slug)).toEqual(['a'])
+    expect(fresh.map((s) => s.key)).toEqual(['c'])
+    expect(unchanged.map((s) => s.key)).toEqual(['a'])
   })
 
-  test('a changed-then-reverted body re-injects in full after the change turn', () => {
-    const state: InjectedShardState = new Map()
-    partitionDirectShards([shard('a', 'v1')], state)
-    partitionDirectShards([shard('a', 'v2')], state)
+  test('a changed-then-stable excerpt dedups after the change turn', () => {
+    const state: InjectedMemoryState = new Map()
+    partitionRetrievedMemoryItems([item('a', 'v1')], state)
+    partitionRetrievedMemoryItems([item('a', 'v2')], state)
 
-    const { full, unchanged } = partitionDirectShards([shard('a', 'v2')], state)
+    const { fresh, unchanged } = partitionRetrievedMemoryItems([item('a', 'v2')], state)
 
-    expect(full).toHaveLength(0)
-    expect(unchanged.map((s) => s.slug)).toEqual(['a'])
+    expect(fresh).toHaveLength(0)
+    expect(unchanged.map((s) => s.key)).toEqual(['a'])
   })
 
-  test('distinct bodies do not collide', () => {
-    const state: InjectedShardState = new Map()
-    partitionDirectShards([shard('a', 'alpha'), shard('b', 'beta')], state)
+  test('distinct excerpts do not collide', () => {
+    const state: InjectedMemoryState = new Map()
+    partitionRetrievedMemoryItems([item('a', 'alpha'), item('b', 'beta')], state)
 
-    const { unchanged } = partitionDirectShards([shard('a', 'alpha'), shard('b', 'beta')], state)
+    const { unchanged } = partitionRetrievedMemoryItems([item('a', 'alpha'), item('b', 'beta')], state)
 
-    expect(unchanged.map((s) => s.slug)).toEqual(['a', 'b'])
+    expect(unchanged.map((s) => s.key)).toEqual(['a', 'b'])
+  })
+
+  test('same key with a changed heading re-injects', () => {
+    const state: InjectedMemoryState = new Map()
+    partitionRetrievedMemoryItems([item('a', 'alpha')], state)
+
+    const { fresh } = partitionRetrievedMemoryItems([{ ...item('a', 'alpha'), heading: 'renamed' }], state)
+
+    expect(fresh.map((s) => s.key)).toEqual(['a'])
   })
 })

--- a/src/bundled-plugins/memory/turn-dedup.ts
+++ b/src/bundled-plugins/memory/turn-dedup.ts
@@ -1,39 +1,46 @@
-import type { TopicShard } from './load-shards'
+import type { RetrievedMemoryItem } from './load-memory'
 
-export type InjectedShardState = Map<string, string>
+export type InjectedMemoryState = Map<string, string>
 
-export type DirectShardPartition = {
-  full: TopicShard[]
-  unchanged: TopicShard[]
+export type RetrievedMemoryPartition = {
+  fresh: RetrievedMemoryItem[]
+  unchanged: RetrievedMemoryItem[]
 }
 
-// Preserves the "nothing the agent always had vanishes on an off-topic turn"
-// guarantee by AVAILABILITY, not literal presence: an unchanged shard is still
-// named (heading + slug) and its body is recoverable via memory_search, while a
-// changed shard always re-injects in full so the agent never reads a stale body.
-// `state` is the session-scoped record the caller owns and clears on session.end.
-export function partitionDirectShards(shards: TopicShard[], state: InjectedShardState): DirectShardPartition {
-  const full: TopicShard[] = []
-  const unchanged: TopicShard[] = []
-  for (const shard of shards) {
-    const hash = hashBody(shard.body)
-    if (state.get(shard.slug) === hash) {
-      unchanged.push(shard)
+// Preserves the cross-turn dedup intent after vector turns moved to top-K
+// retrieval: an unchanged retrieved excerpt is still named and recoverable via
+// memory_search, while changed retrieved content re-injects so the model never
+// reasons over a stale excerpt.
+export function partitionRetrievedMemoryItems(
+  items: RetrievedMemoryItem[],
+  state: InjectedMemoryState,
+): RetrievedMemoryPartition {
+  const fresh: RetrievedMemoryItem[] = []
+  const unchanged: RetrievedMemoryItem[] = []
+  for (const item of items) {
+    const stateKey = `${item.source}:${item.key}`
+    const hash = hashItem(item)
+    if (state.get(stateKey) === hash) {
+      unchanged.push(item)
     } else {
-      full.push(shard)
-      state.set(shard.slug, hash)
+      fresh.push(item)
+      state.set(stateKey, hash)
     }
   }
-  return { full, unchanged }
+  return { fresh, unchanged }
 }
 
-// FNV-1a over the body. A hash collision only suppresses a body the agent can
-// still re-fetch by slug, so collision-tolerance buys a cheap one-string-per-slug
-// state map instead of retaining full bodies per session.
-function hashBody(body: string): string {
+function hashItem(item: RetrievedMemoryItem): string {
+  return hashContent(`${item.heading}\0${item.excerpt}`)
+}
+
+// FNV-1a over rendered retrieval content. A hash collision only suppresses an
+// excerpt the agent can still re-fetch, so collision-tolerance buys a cheap
+// one-string-per-result state map instead of retaining excerpts per session.
+function hashContent(content: string): string {
   let hash = 0x811c9dc5
-  for (let i = 0; i < body.length; i++) {
-    hash ^= body.charCodeAt(i)
+  for (let i = 0; i < content.length; i++) {
+    hash ^= content.charCodeAt(i)
     hash = Math.imul(hash, 0x01000193)
   }
   return (hash >>> 0).toString(16)

--- a/src/bundled-plugins/memory/turn-dedup.ts
+++ b/src/bundled-plugins/memory/turn-dedup.ts
@@ -2,32 +2,28 @@ import type { RetrievedMemoryItem } from './load-memory'
 
 export type InjectedMemoryState = Map<string, string>
 
-export type RetrievedMemoryPartition = {
-  fresh: RetrievedMemoryItem[]
-  unchanged: RetrievedMemoryItem[]
+export type DedupedRetrievedItem = {
+  item: RetrievedMemoryItem
+  changed: boolean
 }
 
-// Preserves the cross-turn dedup intent after vector turns moved to top-K
-// retrieval: an unchanged retrieved excerpt is still named and recoverable via
-// memory_search, while changed retrieved content re-injects so the model never
-// reasons over a stale excerpt.
+// Returns items in their input (relevance) order with a per-item `changed`
+// flag, never split into separate groups: a high-ranked but previously-seen
+// topic must stay ahead of a lower-ranked fresh one, since hybridSearch's
+// ranking drives per-turn relevance. `changed` is false when an identical
+// excerpt was already injected this session, so the renderer emits a
+// recoverable reference instead of re-sending the body.
 export function partitionRetrievedMemoryItems(
   items: RetrievedMemoryItem[],
   state: InjectedMemoryState,
-): RetrievedMemoryPartition {
-  const fresh: RetrievedMemoryItem[] = []
-  const unchanged: RetrievedMemoryItem[] = []
-  for (const item of items) {
+): DedupedRetrievedItem[] {
+  return items.map((item) => {
     const stateKey = `${item.source}:${item.key}`
     const hash = hashItem(item)
-    if (state.get(stateKey) === hash) {
-      unchanged.push(item)
-    } else {
-      fresh.push(item)
-      state.set(stateKey, hash)
-    }
-  }
-  return { fresh, unchanged }
+    const changed = state.get(stateKey) !== hash
+    if (changed) state.set(stateKey, hash)
+    return { item, changed }
+  })
 }
 
 function hashItem(item: RetrievedMemoryItem): string {


### PR DESCRIPTION
## What

Drops the "direct" full-shard memory-injection path. Non-channel vector turns now always use top-K hybrid retrieval instead of dumping every shard body whenever the total fit under the 16KB budget.

- `src/bundled-plugins/memory/index.ts`: removed the non-channel `direct` branch; non-channel turns always call `hybridSearch`. The channel forced-index path is unchanged.
- **Small-set fallback** (`renderTopicIndexMemorySection` in `load-memory.ts`): when non-channel retrieval returns nothing but topic shards exist, inject a headings+slugs index (no bodies) so memory is never silently dropped.
- `turn-dedup.ts` repurposed to dedup retrieved items across turns (repeated excerpts render as recoverable slug/search references).

## Why

Per-turn memory injection is ~44M tokens fleet-wide (~1,433 tok/turn). Direct mode injected ALL shard bodies every turn for under-budget agents — exactly the agents where memory grows steadily.

## ⚠️ Behavior change — please review

This changes what vector-memory agents see each turn. Tests assert: an under-budget set no longer dumps full bodies, still surfaces top-K (or a headings index when retrieval is empty), and the channel path is unchanged. `VECTOR_TURN_TOP_K` and excerpt sizing are intentionally untouched (separate concern).

## Test plan

`typecheck` / `format` / `lint` clean; full suite 0 fail (memory-plugin tests updated: `index-vector.test.ts`, `turn-dedup.test.ts`).

Refs #896.
