### PR TITLE
feat(shared): add isWindows/isMacOS platform seam

### DIFF
--- a/src/cli/qr.ts
+++ b/src/cli/qr.ts
@@ -6,6 +6,8 @@ import { promisify } from 'node:util'
 
 import QRCode from 'qrcode'
 
+import { isMacOS, isWindows } from '@/shared'
+
 const execFileAsync = promisify(execFile)
 
 // The upstream LINE SDK's QR login hands back a raw auth URL
@@ -108,12 +110,11 @@ async function writeQRHtmlFile(
 }
 
 async function openInBrowser(filePath: string): Promise<void> {
-  const platform = process.platform
-  if (platform === 'darwin') {
+  if (isMacOS()) {
     await execFileAsync('open', [filePath])
     return
   }
-  if (platform === 'win32') {
+  if (isWindows()) {
     await execFileAsync('cmd', ['/c', 'start', '', filePath])
     return
   }

--- a/src/hostd/tailscale.ts
+++ b/src/hostd/tailscale.ts
@@ -1,4 +1,5 @@
 import { getBun } from '@/container/shared'
+import { isMacOS } from '@/shared'
 
 export type TailscaleExecResult = { exitCode: number; stdout: string; stderr: string }
 export type TailscaleExec = (args: string[]) => Promise<TailscaleExecResult>
@@ -130,7 +131,7 @@ async function checkRunning(exec: TailscaleExec): Promise<{ ok: true } | { ok: f
 }
 
 export const defaultTailscaleExec: TailscaleExec = async (args) => {
-  const candidates = process.platform === 'darwin' ? ['tailscale', MACOS_APP_CLI] : ['tailscale']
+  const candidates = isMacOS() ? ['tailscale', MACOS_APP_CLI] : ['tailscale']
   let lastError = 'tailscale command not found'
 
   for (const candidate of candidates) {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -29,3 +29,5 @@ export {
 export { formatLocalDate, formatLocalDateTime, formatLocalWeekday, resolveLocalTimezoneName } from './local-time'
 
 export { detectWsl, isWindowsDriveMount, type WslInfo, type WslVersion } from './wsl'
+
+export { isMacOS, isWindows } from './platform'

--- a/src/shared/platform.test.ts
+++ b/src/shared/platform.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+
+import { isMacOS, isWindows } from './platform'
+
+describe('isWindows', () => {
+  test('is true only on win32', () => {
+    expect(isWindows('win32')).toBe(true)
+    expect(isWindows('darwin')).toBe(false)
+    expect(isWindows('linux')).toBe(false)
+  })
+})
+
+describe('isMacOS', () => {
+  test('is true only on darwin', () => {
+    expect(isMacOS('darwin')).toBe(true)
+    expect(isMacOS('win32')).toBe(false)
+    expect(isMacOS('linux')).toBe(false)
+  })
+})

--- a/src/shared/platform.ts
+++ b/src/shared/platform.ts
@@ -1,0 +1,11 @@
+// Centralized seam so host-stage macOS/Linux/Windows branches stay greppable as
+// native-Windows support lands; the default arg lets tests pass a platform
+// without mutating the read-only `process.platform`.
+
+export function isWindows(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === 'win32'
+}
+
+export function isMacOS(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === 'darwin'
+}


### PR DESCRIPTION
## What

Introduces `src/shared/platform.ts` — a small host-platform seam (`isWindows`, `isMacOS`) — and routes the two existing host-stage `process.platform` branch points through it:

- `src/cli/qr.ts` — browser opener (`open` / `cmd /c start` / `xdg-open`)
- `src/hostd/tailscale.ts` — Tailscale CLI candidate resolution

## Why

First, foundational step toward native Windows host support (#899). Centralizing platform checks behind one greppable, unit-testable seam is the prerequisite the later phases (IPC transport, daemon lifecycle, Docker `--mount` paths) build on. The default-arg parameter (`platform: NodeJS.Platform = process.platform`) lets tests inject a platform without mutating the read-only `process.platform`.

## Scope / safety

- **Behavior-preserving on every OS** — pure refactor of existing branches; no new Windows-only behavior is introduced here.
- Mirrors the existing `src/shared/wsl.ts` convention (pure functions, injectable input, named exports via `src/shared/index.ts`).

## Verification

- `bun run format:check`, `bun run lint` (0 errors), `bun run typecheck` — all clean
- `bun run test` — 9124 pass / 0 fail (incl. new `platform.test.ts` plus `qr` / `tailscale` regression)

Part of #899. Container-stage code is always Linux and intentionally does not use this seam.