### PR TITLE
feat(doctor): warn on native-Windows secret perms

### DIFF
--- a/src/doctor/checks.test.ts
+++ b/src/doctor/checks.test.ts
@@ -8,7 +8,13 @@ import { resolveBaseImageVersion } from '@/init/cli-version'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 
-import { buildStaticChecks, wslDriveMount, type WslDriveMountDeps } from './checks'
+import {
+  buildStaticChecks,
+  windowsSecretPerms,
+  wslDriveMount,
+  type WindowsSecretPermsDeps,
+  type WslDriveMountDeps,
+} from './checks'
 import type { CheckContext } from './types'
 
 const agentCtx: CheckContext = { cwd: '/mnt/c/work/agent', hasAgentFolder: true }
@@ -57,6 +63,42 @@ describe('wslDriveMount', () => {
     const check = wslDriveMount(deps())
     const result = await check.run({ cwd: '/mnt/c/work/agent', hasAgentFolder: false })
     expect(result.status).toBe('ok')
+  })
+})
+
+describe('windowsSecretPerms', () => {
+  function winDeps(overrides: Partial<WindowsSecretPermsDeps> = {}): WindowsSecretPermsDeps {
+    return {
+      isWindows: () => true,
+      typeclawHome: () => 'C:\\Users\\dev\\.typeclaw',
+      ...overrides,
+    }
+  }
+
+  test('passes when not on native Windows', async () => {
+    const check = windowsSecretPerms({ isWindows: () => false })
+    const result = await check.run(linuxCtx)
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('not running on native Windows')
+  })
+
+  test('warns on native Windows that file modes are not enforced', async () => {
+    const check = windowsSecretPerms(winDeps())
+    const result = await check.run({ cwd: 'C:\\work\\agent', hasAgentFolder: true })
+    expect(result.status).toBe('warning')
+    expect(result.details).toContain('agent folder: C:\\work\\agent')
+    expect(result.details?.some((d) => d.includes('NTFS'))).toBe(true)
+  })
+
+  test('reports the hostd home even without an agent folder', async () => {
+    const check = windowsSecretPerms(winDeps())
+    const result = await check.run({ cwd: 'C:\\work\\agent', hasAgentFolder: false })
+    expect(result.status).toBe('warning')
+    expect(result.details).toContain('hostd home: C:\\Users\\dev\\.typeclaw')
+  })
+
+  test('is registered in the static check set', () => {
+    expect(buildStaticChecks().some((c) => c.name === 'hostd.windows-secret-perms')).toBe(true)
   })
 })
 

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -20,7 +20,7 @@ import { resolveBaseImageVersion } from '@/init/cli-version'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { detectMissingDeps } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
-import { detectWsl, isWindowsDriveMount, type WslInfo } from '@/shared'
+import { detectWsl, isWindows, isWindowsDriveMount, type WslInfo } from '@/shared'
 
 import { buildChannelChecks } from './channel-checks'
 import type { DoctorCheck } from './types'
@@ -39,6 +39,7 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): Docto
     configValid(),
     hostdHomeWritable(),
     wslDriveMount(),
+    windowsSecretPerms(),
     hostdReachable(),
     hostdRegistration(),
     containerState(dockerExec),
@@ -280,6 +281,45 @@ export function wslDriveMount(deps: Partial<WslDriveMountDeps> = {}): DoctorChec
         fix: {
           description:
             'Move the agent folder to the WSL Linux filesystem (e.g. ~/my-agent) and, if needed, set TYPECLAW_HOME to a Linux path.',
+        },
+      }
+    },
+  }
+}
+
+export type WindowsSecretPermsDeps = {
+  isWindows: () => boolean
+  typeclawHome: () => string
+}
+
+// On native Windows the 0600/0700 modes typeclaw sets on secrets.json and the
+// encryption keys are no-ops — NTFS uses ACLs, not Unix modes — so their
+// confidentiality rests on the inherited %USERPROFILE% ACLs rather than the
+// hardening typeclaw enforces on POSIX. Surface that as a warning.
+export function windowsSecretPerms(deps: Partial<WindowsSecretPermsDeps> = {}): DoctorCheck {
+  const onWindows = deps.isWindows ?? isWindows
+  const typeclawHome = deps.typeclawHome ?? homeRoot
+
+  return {
+    name: 'hostd.windows-secret-perms',
+    category: 'hostd',
+    description: 'secrets rely on enforced file permissions (native Windows)',
+    async run(ctx) {
+      if (!onWindows()) return { status: 'ok', message: 'not running on native Windows' }
+
+      const details = [`hostd home: ${typeclawHome()}`]
+      if (ctx.hasAgentFolder) details.push(`agent folder: ${ctx.cwd}`)
+      details.push(
+        'NTFS ignores the 0600/0700 chmod typeclaw applies to secrets.json and encryption keys; their confidentiality relies on the inherited %USERPROFILE% ACLs instead.',
+      )
+
+      return {
+        status: 'warning',
+        message: 'native Windows does not enforce the file modes that protect agent secrets',
+        details,
+        fix: {
+          description:
+            'Keep the agent folder and ~/.typeclaw under your user profile, where default ACLs restrict access to your account; avoid a shared or everyone-readable location.',
         },
       }
     },


### PR DESCRIPTION
## What

Adds a `hostd.windows-secret-perms` doctor check that warns, on native Windows, that the `0600`/`0700` file modes typeclaw applies to `secrets.json` and the encryption keys are **not enforced by NTFS** — their confidentiality relies on the inherited `%USERPROFILE%` ACLs instead.

It's a sibling to the existing `hostd.wsl-drive-mount` check and follows the same shape (exported, injectable deps, short-circuits `ok` when it doesn't apply).

## Why

Part of native Windows host support (#899), plan item P5-T1. On POSIX, typeclaw's secret-confidentiality model rests on enforced Unix modes; on native Windows NTFS those `chmod`s are silent no-ops, so `doctor` should surface the deviation (the model degrades to OS ACLs rather than typeclaw's explicit hardening).

## Scope / safety

- **Behavior-preserving off Windows** — on macOS/Linux the check returns `ok` ("not running on native Windows"); only `process.platform === 'win32'` produces the warning.
- Builds on the `isWindows()` seam from #907; reuses `homeRoot()` for the reported path.
- Message is technically accurate: NTFS uses ACLs (not "world-readable" like the WSL `/mnt/c` case).

## Verification

- `bun run format:check`, `bun run lint` (0 errors), `bun run typecheck` — clean
- `bun run test` — 9130 pass / 0 fail, incl. 4 new `windowsSecretPerms` tests (injected `isWindows`) plus the existing WSL / CRLF doctor tests

Part of #899.