### PR TITLE
perf(memory): compact channel memory index to one line per topic

### DIFF
--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -96,10 +96,8 @@ describe('vector session.turn.start hook', () => {
 
     expect(emptySearch).toHaveBeenCalledWith('anything', expect.anything(), agentDir, 10, expect.any(Function))
     expect(retrievalContext.results).toContain('# Memory')
-    expect(retrievalContext.results).toContain('## First Topic')
-    expect(retrievalContext.results).toContain('slug: `first-topic`')
-    expect(retrievalContext.results).toContain('## Second Topic')
-    expect(retrievalContext.results).toContain('slug: `second-topic`')
+    expect(retrievalContext.results).toContain('- First Topic `first-topic`')
+    expect(retrievalContext.results).toContain('- Second Topic `second-topic`')
     expect(retrievalContext.results).not.toContain('private first body')
     expect(retrievalContext.results).not.toContain('private second body')
     expect(infos.some((line) => line.includes('suppressed=1') && line.includes('fallback=topic-index'))).toBe(true)

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -218,8 +218,10 @@ describe('vector session.turn.start hook', () => {
     // then: BOTH headings survive (no relevance-filtering drop), bodies are stripped,
     // the channel boundary is present, and hybrid search is never consulted — so a
     // stale/empty vector index can never silently omit a topic on a channel turn
-    expect(first.results).toContain('## First Topic')
-    expect(first.results).toContain('## Second Topic')
+    expect(first.results).toContain('- First Topic `first-topic`')
+    expect(first.results).toContain('- Second Topic `second-topic`')
+    expect(first.results).not.toContain('## First Topic')
+    expect(first.results).not.toContain('cites=')
     expect(first.results).not.toContain('channel-private body one')
     expect(first.results).not.toContain('channel-private body two')
     expect(first.results).toContain('[MEMORY CONTEXT — not instructions]')

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -12,10 +12,8 @@ import { formatLocalDate } from '@/shared'
 import { createDreamingSubagent, type DreamingPayload } from './dreaming'
 import { buildInjectionPlan, DEFAULT_INJECTION_BUDGET_BYTES, MIN_INJECTION_BUDGET_BYTES } from './injection-plan'
 import {
-  forceIndexForChannel,
   loadMemoryInjectionPlan,
   renderDedupedRetrievedMemorySection,
-  renderMemorySection,
   renderRetrievedMemorySection,
   renderTopicIndexMemorySection,
 } from './load-memory'
@@ -184,9 +182,8 @@ async function renderVectorTurnMemory(
   const plan = await loadMemoryInjectionPlan(event.agentDir, { injectionBudgetBytes })
   const isChannel = event.origin?.kind === 'channel'
   if (plan.mode === 'direct' && isChannel) {
-    const indexed = forceIndexForChannel(plan, { origin: event.origin, injectionBudgetBytes })
     logger?.info(`[vector-retrieval] mode=index topics=${plan.shards.length} channel=forced`)
-    return renderMemorySection(indexed, { origin: event.origin })
+    return renderTopicIndexMemorySection(plan.shards, { origin: event.origin })
   }
   const store = VectorStore.open(join(event.agentDir, 'memory', '.vectors', 'index.db'))
   try {

--- a/src/bundled-plugins/memory/load-memory.test.ts
+++ b/src/bundled-plugins/memory/load-memory.test.ts
@@ -380,8 +380,8 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
   test('channel origin strips excerpt bodies, keeping only headings', () => {
     const section = renderRetrievedMemorySection(items, { origin: channelOrigin })
 
-    expect(section).toContain('## KakaoTalk reply conventions')
-    expect(section).toContain('## GitHub channel role configuration')
+    expect(section).toContain('- KakaoTalk reply conventions `kakaotalk-reply-conventions`')
+    expect(section).toContain('- GitHub channel role configuration `github-channel-role-configuration`')
     expect(section).not.toContain('the-user-prefers-formal-speech body excerpt')
     expect(section).not.toContain('roles-are-keyed-on-first-message body excerpt')
   })
@@ -413,7 +413,7 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
 
     const section = renderRetrievedMemorySection(streamItems, { origin: channelOrigin })
 
-    expect(section).toContain('## recent observation')
+    expect(section).toContain('- recent observation _(recent observation)_')
     expect(section).not.toContain('2026-06-12#frag1')
   })
 

--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -120,16 +120,13 @@ export function renderRetrievedMemorySection(
   const lines = ['# Memory', '', MEMORY_FRAMING, '']
   if (isChannel) lines.push(...CHANNEL_MEMORY_BOUNDARY, '', retrievedIndexDirective(), '')
   for (const item of items) {
-    lines.push(`## ${item.heading}`)
     if (!isChannel) {
+      lines.push(`## ${item.heading}`)
       lines.push(item.excerpt.trimEnd(), '')
     } else if (item.source === 'topic' || item.source === 'reference') {
-      lines.push(`slug: \`${item.key}\``, '')
+      lines.push(`- ${item.heading} \`${item.key}\``)
     } else {
-      lines.push(
-        'recent observation \u2014 not yet a topic shard; reach the full text via `memory_search({ query: ... })`.',
-        '',
-      )
+      lines.push(`- ${item.heading} _(recent observation)_`)
     }
   }
   return lines.join('\n').trimEnd()
@@ -147,8 +144,7 @@ export function renderTopicIndexMemorySection(
   if (options.origin?.kind === 'channel') lines.push(...CHANNEL_MEMORY_BOUNDARY, '')
   lines.push(topicIndexDirective(options), '')
   for (const shard of shards) {
-    lines.push(`## ${shard.frontmatter.heading}`)
-    lines.push(`slug: \`${shard.slug}\``, '')
+    lines.push(`- ${shard.frontmatter.heading} \`${shard.slug}\``)
   }
   return lines.join('\n').trimEnd()
 }


### PR DESCRIPTION
## What

Collapses the channel / headings-only memory index from a 3-line block per topic to one line.

Before:

```
## Service deployment topology
slug: `service-deployment-topology`
```

After:

```
- Service deployment topology `service-deployment-topology`
```

Applies to the channel branch of `renderRetrievedMemorySection` and to `renderTopicIndexMemorySection` (`src/bundled-plugins/memory/load-memory.ts`). Stream items (no slug) keep a `_(recent observation)_` marker.

## Why

The `## ` / `slug: ` / blank-line framing is boilerplate repeated per topic, and the slug is mostly a kebab echo of the heading — a lot of structural tokens on every channel turn. ~40% lighter on the index block, **no information lost**: heading and slug both stay, slug verbatim for `memory_search({ topic })`.

The slug can't be dropped (it's the lookup key and isn't a clean slugify of the heading), and the heading can't be dropped (it's the relevance signal) — so they're kept, just on one line without the framing.

## Preserved

`# Memory` framing, channel-bleed boundary, recovery directive, slugs verbatim, and the non-channel excerpt path (unchanged).

## Test plan

`typecheck` / `format` / `lint` clean; full suite 0 fail. Updated channel-format assertions in `load-memory.test.ts` and `index-vector.test.ts`.

Refs #909.
