### PR TITLE
ci: add windows-latest static-checks lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,36 @@ jobs:
         # `bun install` and run 4-5s locally; that crosses the 5s default on
         # the slower GitHub Actions runners.
         run: bun test --parallel --timeout 30000
+
+  windows-static:
+    # Native-Windows host support (#899) is experimental. This lane proves the
+    # toolchain (bun install + typecheck/lint/format) runs on native Windows. It
+    # omits `bun run test` on purpose — many tests need Docker/Unix sockets that a
+    # Windows runner lacks and require a separate triage (#899) first.
+    # continue-on-error keeps it informational until the Windows toolchain is
+    # proven stable, then it graduates to a required check.
+    name: windows static checks (typecheck / lint / format)
+    runs-on: windows-latest
+    continue-on-error: true
+    env:
+      FIREWORKS_API_KEY: dummy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Format check
+        run: bun run format:check


### PR DESCRIPTION
## What

Adds a non-blocking `windows-static` CI job that runs the toolchain — `bun install --frozen-lockfile`, `typecheck`, `lint`, `format:check` — on `windows-latest`.

## Why

Establishes the native-Windows feedback loop (#899, plan item P0-T1): it proves bun + the static toolchain (tsgo / oxlint / oxfmt) install and run on native Windows, so future Windows-facing changes get caught in CI.

## Scope / safety

- **Additive and non-blocking.** The existing `ci` (ubuntu) job is untouched. The new job is `continue-on-error: true`, so it's informational and cannot block any PR while the Windows toolchain is still being proven.
- **Omits `bun run test` on purpose.** Many tests depend on Docker / Unix sockets a Windows runner lacks; running the suite on Windows needs a separate triage (tracked in #899). A test lane is a deliberate follow-up.
- Mirrors the existing job (same pinned `bun-version: 1.3.14`, same step shape).

## Follow-up

Once the Windows static lane is consistently green, a follow-up promotes it to a required check and adds a (initially non-blocking) Windows test lane to drive the test-suite triage.

Part of #899.