### PR TITLE
feat(channels): annotate user mentions with display-name hints

### DIFF
--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -48,6 +48,7 @@ import {
   registerCommands,
   type DiscordCommandDeclaration,
 } from './discord-bot-slash-commands'
+import { addDiscordMentionHints, type DiscordMentionUser } from './mention-hints'
 
 // One declared slash command per logical agent gesture. /stop maps to the
 // existing channel-command of the same name in the router. Adding new
@@ -507,6 +508,7 @@ type DiscordRawHistoryMessage = {
   author: { id: string; username?: string; global_name?: string | null; bot?: boolean }
   content: string
   timestamp: string
+  mentions?: DiscordMentionUser[]
   message_reference?: { message_id?: string; channel_id?: string }
   attachments?: DiscordFile[]
   embeds?: DiscordGatewayEmbed[]
@@ -597,7 +599,7 @@ function mapDiscordMessage(msg: DiscordRawHistoryMessage, botUserId: string | nu
   // never resolve them. Mirror the classifier's splitInbound: bake placeholders
   // into text and carry the structured attachments so the router can resolve ids.
   const attachments = describeDiscordMedia(source)
-  const text = bodyOf(source)
+  const text = addDiscordMentionHints(bodyOf(source), mentionUserMap(source.mentions), { botUserId })
   return {
     externalMessageId: msg.id,
     authorId: source.author.id,
@@ -615,6 +617,10 @@ function bodyOf(msg: DiscordRawHistoryMessage): string {
   if (attachments.length === 0) return msg.content
   const placeholders = attachments.map(renderPlaceholder).join('\n')
   return msg.content === '' ? placeholders : `${msg.content}\n${placeholders}`
+}
+
+function mentionUserMap(mentions: readonly DiscordMentionUser[] | undefined): Map<string, DiscordMentionUser> {
+  return new Map((mentions ?? []).map((user) => [user.id, user]))
 }
 
 function clampLimit(requested: number, max: number): number {
@@ -932,9 +938,10 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         return
       }
 
+      const hintedText = addDiscordMentionHints(verdict.payload.text, mentionUserMap(event.mentions), { botUserId })
       const replyMessageId = event.message_reference?.message_id
       const referenceResult = await enrichDiscordMessageReferences({
-        text: verdict.payload.text,
+        text: hintedText,
         ...(replyMessageId !== undefined
           ? { reply: { channelId: event.message_reference?.channel_id ?? event.channel_id, messageId: replyMessageId } }
           : {}),
@@ -950,8 +957,8 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       })
       const payload =
         referenceResult.referenceContext === undefined
-          ? verdict.payload
-          : { ...verdict.payload, referenceContext: referenceResult.referenceContext }
+          ? { ...verdict.payload, text: hintedText }
+          : { ...verdict.payload, text: hintedText, referenceContext: referenceResult.referenceContext }
 
       const routedTag = await formatChannelTag(payload.workspace, payload.chat)
       logger.info(

--- a/src/channels/adapters/mention-hints.test.ts
+++ b/src/channels/adapters/mention-hints.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test'
+
+import { addDiscordMentionHints, addSlackMentionHints } from './mention-hints'
+
+describe('addSlackMentionHints', () => {
+  const resolver = (names: Record<string, string>) => async (id: string) => names[id] ?? id
+
+  test('appends a display-name hint after the bare mention token', async () => {
+    const out = await addSlackMentionHints("Yo <@U0B4JR0KPFH>, what's up?", resolver({ U0B4JR0KPFH: 'johndoe' }))
+    expect(out).toBe("Yo <@U0B4JR0KPFH> (johndoe), what's up?")
+  })
+
+  test('keeps the original token intact so it round-trips as a real mention', async () => {
+    const out = await addSlackMentionHints('<@U1>', resolver({ U1: 'alice' }))
+    expect(out).toContain('<@U1>')
+  })
+
+  test('labels the bot’s own mention as (you)', async () => {
+    const out = await addSlackMentionHints('hey <@UBOT> here', resolver({ UBOT: 'Momo' }), { botUserId: 'UBOT' })
+    expect(out).toBe('hey <@UBOT> (you) here')
+  })
+
+  test('leaves the token unchanged when the name cannot be resolved', async () => {
+    // SlackAuthorResolver echoes the id back on lookup failure; an empty map mimics that
+    const out = await addSlackMentionHints('ping <@U404>', resolver({}))
+    expect(out).toBe('ping <@U404>')
+  })
+
+  test('resolves a repeated mention once and rewrites every occurrence', async () => {
+    let calls = 0
+    const counting = async (id: string) => {
+      calls++
+      return id === 'U1' ? 'alice' : id
+    }
+    const out = await addSlackMentionHints('<@U1> and <@U1> again', counting)
+    expect(out).toBe('<@U1> (alice) and <@U1> (alice) again')
+    expect(calls).toBe(1)
+  })
+
+  test('normalizes Slack’s native <@id|label> form to the shared hint format', async () => {
+    const out = await addSlackMentionHints('hi <@U1|legacy>', resolver({ U1: 'alice' }))
+    expect(out).toBe('hi <@U1> (alice)')
+  })
+
+  test('handles W-prefixed org-account ids', async () => {
+    const out = await addSlackMentionHints('<@W123ABC>', resolver({ W123ABC: 'orguser' }))
+    expect(out).toBe('<@W123ABC> (orguser)')
+  })
+
+  test('supports non-Latin display names', async () => {
+    const out = await addSlackMentionHints('안녕 <@U1>', resolver({ U1: '영규' }))
+    expect(out).toBe('안녕 <@U1> (영규)')
+  })
+
+  test('returns text unchanged when there are no mentions', async () => {
+    const out = await addSlackMentionHints('just plain text', resolver({}))
+    expect(out).toBe('just plain text')
+  })
+})
+
+describe('addDiscordMentionHints', () => {
+  const users = (entries: Array<{ id: string; username?: string; global_name?: string | null }>) =>
+    new Map(entries.map((u) => [u.id, u]))
+
+  test('appends a display-name hint after the bare mention token', () => {
+    const out = addDiscordMentionHints(
+      "Yo <@123456789012345678>, what's up?",
+      users([{ id: '123456789012345678', username: 'johndoe' }]),
+    )
+    expect(out).toBe("Yo <@123456789012345678> (johndoe), what's up?")
+  })
+
+  test('prefers global_name over username', () => {
+    const out = addDiscordMentionHints('<@1>', users([{ id: '1', username: 'jdoe', global_name: 'John Doe' }]))
+    expect(out).toBe('<@1> (John Doe)')
+  })
+
+  test('rewrites the nickname form <@!id> too', () => {
+    const out = addDiscordMentionHints('hey <@!1>', users([{ id: '1', username: 'alice' }]))
+    expect(out).toBe('hey <@!1> (alice)')
+  })
+
+  test('labels the bot’s own mention as (you)', () => {
+    const out = addDiscordMentionHints('<@9> ping', users([{ id: '9', username: 'Momo' }]), { botUserId: '9' })
+    expect(out).toBe('<@9> (you) ping')
+  })
+
+  test('leaves the token unchanged when the user is not in the mentions map', () => {
+    const out = addDiscordMentionHints('ping <@404>', users([]))
+    expect(out).toBe('ping <@404>')
+  })
+
+  test('rewrites every occurrence of a repeated mention', () => {
+    const out = addDiscordMentionHints('<@1> and <@1>', users([{ id: '1', username: 'alice' }]))
+    expect(out).toBe('<@1> (alice) and <@1> (alice)')
+  })
+
+  test('supports non-Latin display names', () => {
+    const out = addDiscordMentionHints('안녕 <@1>', users([{ id: '1', username: 'yeongyu', global_name: '영규' }]))
+    expect(out).toBe('안녕 <@1> (영규)')
+  })
+
+  test('returns text unchanged when there are no mentions', () => {
+    const out = addDiscordMentionHints('just plain text', users([]))
+    expect(out).toBe('just plain text')
+  })
+})

--- a/src/channels/adapters/mention-hints.ts
+++ b/src/channels/adapters/mention-hints.ts
@@ -1,0 +1,58 @@
+export type DiscordMentionUser = { id: string; username?: string; global_name?: string | null }
+
+export type MentionHintOptions = { botUserId?: string | null }
+
+// Slack encodes user mentions as `<@U…>`/`<@W…>`, optionally with a native
+// `|label` fallback suffix. We capture the id and the whole token so the bare
+// `<@id>` can be reconstructed (dropping any legacy label) and a resolved hint
+// appended after it.
+const SLACK_MENTION_PATTERN = /<@([UW][A-Z0-9]+)(?:\|[^>]*)?>/g
+
+// Discord uses `<@id>` and the nickname form `<@!id>`; the `!` is optional and
+// irrelevant to the target user, so it is captured but discarded on rewrite.
+const DISCORD_MENTION_PATTERN = /<@!?(\d+)>/g
+
+export async function addSlackMentionHints(
+  text: string,
+  resolveUserName: (id: string) => Promise<string>,
+  options: MentionHintOptions = {},
+): Promise<string> {
+  const ids = new Set<string>()
+  for (const match of text.matchAll(SLACK_MENTION_PATTERN)) ids.add(match[1]!)
+  if (ids.size === 0) return text
+
+  const hints = new Map<string, string>()
+  await Promise.all(
+    Array.from(ids).map(async (id) => {
+      const hint = resolveHint(id, await resolveUserName(id), options.botUserId)
+      if (hint !== null) hints.set(id, hint)
+    }),
+  )
+
+  return text.replace(SLACK_MENTION_PATTERN, (_token, id: string) => renderToken(id, hints.get(id)))
+}
+
+export function addDiscordMentionHints(
+  text: string,
+  usersById: Map<string, DiscordMentionUser>,
+  options: MentionHintOptions = {},
+): string {
+  return text.replace(DISCORD_MENTION_PATTERN, (token, id: string) => {
+    const user = usersById.get(id)
+    const name = user === undefined ? id : (user.global_name ?? user.username ?? id)
+    const hint = resolveHint(id, name, options.botUserId)
+    return hint === null ? token : `${token} (${hint})`
+  })
+}
+
+function resolveHint(id: string, resolvedName: string, botUserId: string | null | undefined): string | null {
+  if (id === botUserId) return 'you'
+  // The resolver echoes the id back when it cannot find a name; a bare id is
+  // not a useful hint, so leave the token unannotated in that case.
+  if (resolvedName === id || resolvedName === '') return null
+  return resolvedName
+}
+
+function renderToken(id: string, hint: string | undefined): string {
+  return hint === undefined ? `<@${id}>` : `<@${id}> (${hint})`
+}

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -32,6 +32,7 @@ import type {
 } from '@/channels/types'
 import { chunkMarkdown } from '@/markdown'
 
+import { addSlackMentionHints } from './mention-hints'
 import { createSlackAuthorResolver, type SlackAuthorResolver } from './slack-bot-author-resolver'
 import { createSlackChannelResolver } from './slack-bot-channel-resolver'
 import {
@@ -703,11 +704,14 @@ export function createSlackHistoryCallback(deps: {
     // users.info entry. The resolver caches/coalesces, so repeated authors
     // cost one lookup each.
     if (authorResolver !== undefined) {
+      const resolver = authorResolver
+      const botId = botUserIdRef()
       await Promise.all(
         mapped.map(async (message, index) => {
+          message.text = await addSlackMentionHints(message.text, resolver.resolve, { botUserId: botId })
           const userId = rawMessages[index]?.user
           if (userId === undefined || userId === '') return
-          message.authorName = await authorResolver.resolve(userId)
+          message.authorName = await resolver.resolve(userId)
         }),
       )
     }
@@ -1133,9 +1137,10 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       }
 
       dedupe.mark(event)
+      const hintedText = await addSlackMentionHints(verdict.payload.text, authorResolver.resolve, { botUserId })
       const slackAttachments = Array.isArray(event.attachments) ? event.attachments : undefined
       const referenceResult = await enrichSlackReferenceContext({
-        text: verdict.payload.text,
+        text: hintedText,
         channelId: event.channel,
         messageTs: event.ts,
         ...(slackAttachments !== undefined ? { attachments: slackAttachments } : {}),
@@ -1143,6 +1148,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       })
       const enriched = {
         ...verdict.payload,
+        text: hintedText,
         authorName: resolvedUserName,
         ...(referenceResult.referenceContext !== undefined
           ? { referenceContext: referenceResult.referenceContext }


### PR DESCRIPTION
## Background

Inbound Slack and Discord messages carry opaque mention tokens the agent cannot resolve to a person. A Slack message like "Yo <@U0B4JR0KPFH>, what's up?" tells the model nothing about who is being addressed. Discord has the same problem with its plain and nickname-prefixed mention forms.

Without a hint the agent cannot distinguish between addressing a user, a colleague, or itself — a real problem for engagement logic and reply quality.

GitHub @login and Telegram @username are already human-readable. KakaoTalk and LINE have no mention syntax. Only Slack and Discord need fixing.

## Summary

After each opaque mention token, append a parenthetical display-name hint — e.g. `<@U0B4JR0KPFH> (johndoe)`. The format is identical across both platforms so the model has a consistent mental model.

Key decisions:

**Preserve the bare token verbatim.** The hint is appended *after* the token, not embedded in it. This means the raw token survives byte-for-byte and still round-trips as a real mention if the agent echoes it back on the outbound path. Slack's native pipe-label form was considered and rejected: it ties the format to one platform and some Slack renderers strip the label anyway. A plain @name replacement was rejected because it breaks the outbound round-trip.

**(you) for the bot's own mention.** The model needs to know when it is the target. This label is unambiguous regardless of what the bot's display name happens to be.

**Silent no-op on unresolvable ids.** A failed lookup must not add noise or imply a false identity, so the token is left untouched.

**Platform-native resolution, zero new infra.** Slack reuses the existing cached `SlackAuthorResolver`: one lookup per unique id per message, not per occurrence. Discord reads names inline from the gateway/REST mentions array already present on every message event and history item, so no extra API calls are needed.

**Shared helper, pure classifiers.** `mention-hints.ts` owns the rewrite and format rules for both platforms. The isBotMention check in the engagement classifier reads raw text *before* any rewrite, so engagement classification is unaffected.

Applied to both live-inbound and channel-history paths for Slack and Discord.

## What this does NOT do

- No change to GitHub, Telegram, KakaoTalk, or LINE adapters.
- Does not skip mentions inside code spans or fenced code blocks (rare in chat; deferred).
- Does not touch the outbound path — raw mention tokens the agent emits are sent as-is.
- Does not add any new API clients, caches, or background resolvers.

## Review notes

- **Load-bearing: the bare mention token is preserved on rewrite.** The outbound path assumes the agent can echo its own text and have the platform render a real mention.
  Verify that `renderToken` always reconstructs the bare token from the captured id group, never echoing the full matched string (which might carry a pipe-label suffix).
- **Slack legacy pipe-label is normalized.** `SLACK_MENTION_PATTERN` captures the id and discards the label; renderToken rebuilds the bare token. Confirm the optional pipe group in the regex is correct.
- **Dedup before resolving on Slack.** `addSlackMentionHints` collects unique ids into a Set before firing Promise.all, so a message with ten occurrences of the same mention triggers one resolver call.
- **Unit tests cover:** bot (you), unresolvable id (left untouched), repeated mention (resolved once), Slack native pipe-label, Discord nickname form, and non-Latin display names (Korean 영규).