### PR TITLE
feat(doctor): flag Windows bind-mount path issues

### DIFF
--- a/src/doctor/checks.test.ts
+++ b/src/doctor/checks.test.ts
@@ -10,8 +10,11 @@ import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 
 import {
   buildStaticChecks,
+  detectWindowsBindMountIssues,
+  windowsBindMount,
   windowsSecretPerms,
   wslDriveMount,
+  type WindowsBindMountDeps,
   type WindowsSecretPermsDeps,
   type WslDriveMountDeps,
 } from './checks'
@@ -99,6 +102,61 @@ describe('windowsSecretPerms', () => {
 
   test('is registered in the static check set', () => {
     expect(buildStaticChecks().some((c) => c.name === 'hostd.windows-secret-perms')).toBe(true)
+  })
+})
+
+describe('windowsBindMount', () => {
+  function winDeps(overrides: Partial<WindowsBindMountDeps> = {}): WindowsBindMountDeps {
+    return { isWindows: () => true, ...overrides }
+  }
+
+  test('passes when not on native Windows', async () => {
+    const check = windowsBindMount({ isWindows: () => false })
+    const result = await check.run({ cwd: '\\\\nas\\share\\agent', hasAgentFolder: true })
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('not running on native Windows')
+  })
+
+  test('passes for a clean local path', async () => {
+    const check = windowsBindMount(winDeps())
+    const result = await check.run({ cwd: 'C:\\agents\\my-agent', hasAgentFolder: true })
+    expect(result.status).toBe('ok')
+  })
+
+  test('warns on a UNC/network path', async () => {
+    const check = windowsBindMount(winDeps())
+    const result = await check.run({ cwd: '\\\\nas\\share\\agent', hasAgentFolder: true })
+    expect(result.status).toBe('warning')
+    expect(result.details?.some((d) => d.includes('UNC'))).toBe(true)
+  })
+
+  test('warns on a OneDrive path', async () => {
+    const check = windowsBindMount(winDeps())
+    const result = await check.run({ cwd: 'C:\\Users\\dev\\OneDrive\\agent', hasAgentFolder: true })
+    expect(result.status).toBe('warning')
+    expect(result.details?.some((d) => d.toLowerCase().includes('onedrive'))).toBe(true)
+  })
+
+  test('is registered in the static check set', () => {
+    expect(buildStaticChecks().some((c) => c.name === 'container.windows-bind-mount')).toBe(true)
+  })
+})
+
+describe('detectWindowsBindMountIssues', () => {
+  test('flags UNC paths', () => {
+    expect(detectWindowsBindMountIssues('\\\\nas\\share\\agent')).toHaveLength(1)
+  })
+
+  test('flags OneDrive business folders', () => {
+    expect(detectWindowsBindMountIssues('C:\\Users\\dev\\OneDrive - Acme\\agent')).toHaveLength(1)
+  })
+
+  test('flags paths over the MAX_PATH limit', () => {
+    expect(detectWindowsBindMountIssues(`C:\\${'a'.repeat(300)}`)).toHaveLength(1)
+  })
+
+  test('passes clean local paths', () => {
+    expect(detectWindowsBindMountIssues('C:\\agents\\my-agent')).toEqual([])
   })
 })
 

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -42,6 +42,7 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } = {}): Docto
     windowsSecretPerms(),
     hostdReachable(),
     hostdRegistration(),
+    windowsBindMount(),
     containerState(dockerExec),
     containerHostPort(),
     ...buildChannelChecks(),
@@ -324,6 +325,56 @@ export function windowsSecretPerms(deps: Partial<WindowsSecretPermsDeps> = {}): 
       }
     },
   }
+}
+
+export type WindowsBindMountDeps = {
+  isWindows: () => boolean
+}
+
+// Docker Desktop bind-mounts the agent folder into its Linux VM, and a few host
+// locations don't survive that translation: UNC/network paths (\\server\share)
+// aren't shareable, OneDrive-virtualized folders fail on placeholder files, and
+// paths near the legacy MAX_PATH (260) limit break mid-build. Flag them so
+// `typeclaw start` fails loudly here instead of cryptically at mount time.
+export function windowsBindMount(deps: Partial<WindowsBindMountDeps> = {}): DoctorCheck {
+  const onWindows = deps.isWindows ?? isWindows
+
+  return {
+    name: 'container.windows-bind-mount',
+    category: 'container',
+    description: 'agent folder is bind-mountable by Docker Desktop (native Windows)',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      if (!onWindows()) return { status: 'ok', message: 'not running on native Windows' }
+
+      const issues = detectWindowsBindMountIssues(ctx.cwd)
+      if (issues.length === 0) return { status: 'ok', message: 'agent folder path is bind-mountable' }
+
+      return {
+        status: 'warning',
+        message: 'agent folder may not bind-mount cleanly under Docker Desktop',
+        details: issues,
+        fix: {
+          description:
+            'Use a local, short, non-OneDrive path under your user profile (e.g. C:\\agents\\my-agent), then re-run typeclaw start.',
+        },
+      }
+    },
+  }
+}
+
+export function detectWindowsBindMountIssues(path: string): string[] {
+  const issues: string[] = []
+  if (path.startsWith('\\\\')) {
+    issues.push(`UNC/network path is not shareable with Docker Desktop: ${path}`)
+  }
+  if (path.split(/[\\/]/).some((seg) => /^onedrive(?: -.*)?$/i.test(seg))) {
+    issues.push(`path is under OneDrive, where virtualized files can break bind mounts: ${path}`)
+  }
+  if (path.length > 260) {
+    issues.push(`path length ${path.length} exceeds the legacy Windows MAX_PATH (260) limit`)
+  }
+  return issues
 }
 
 function hostdReachable(): DoctorCheck {


### PR DESCRIPTION
## What

Adds a `container.windows-bind-mount` doctor check that warns, on native Windows, when the agent folder is in a location Docker Desktop can't reliably bind-mount:

- a UNC / network path (`\\server\share`)
- a OneDrive-virtualized folder
- a path past the legacy `MAX_PATH` (260) limit

## Why

Part of native Windows host support (#899), plan item P5-T6. The architecture review flagged Docker Desktop file-sharing as a real failure mode that turns valid-looking Windows paths into cryptic mount errors at `typeclaw start`. This surfaces the problem at `doctor` time with an actionable fix instead.

## Scope / safety

- **Behavior-preserving off Windows** — returns `ok` ("not running on native Windows") on macOS/Linux; only `process.platform === 'win32'` produces a warning.
- Sibling to `hostd.wsl-drive-mount` / `hostd.windows-secret-perms`; builds on the `isWindows()` seam (#907).
- Detection (`detectWindowsBindMountIssues`) is a pure, exported, unit-tested helper.

## Verification

- `bun run format:check`, `bun run lint` (0 errors), `bun run typecheck` — clean
- `bun run test` — 9161 pass / 0 fail, incl. 9 new tests (5 check + 4 helper)

Part of #899.