### PR TITLE
feat(hostd): add win32 Tailscale CLI fallback

### DIFF
--- a/src/hostd/tailscale.test.ts
+++ b/src/hostd/tailscale.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 
-import { createTailscaleServeManager, type TailscaleExec, type TailscaleServeEvent } from './tailscale'
+import {
+  createTailscaleServeManager,
+  tailscaleCandidates,
+  type TailscaleExec,
+  type TailscaleServeEvent,
+} from './tailscale'
 
 type ExecCall = { args: string[] }
 
@@ -116,5 +121,23 @@ describe('createTailscaleServeManager', () => {
         reason: 'serve failed',
       },
     ])
+  })
+})
+
+describe('tailscaleCandidates', () => {
+  test('macOS includes the app-bundle CLI fallback after PATH', () => {
+    const candidates = tailscaleCandidates('darwin')
+    expect(candidates[0]).toBe('tailscale')
+    expect(candidates.some((c) => c.includes('Tailscale.app'))).toBe(true)
+  })
+
+  test('Windows includes the default install path fallback after PATH', () => {
+    const candidates = tailscaleCandidates('win32')
+    expect(candidates[0]).toBe('tailscale')
+    expect(candidates.some((c) => c.toLowerCase().endsWith('tailscale.exe'))).toBe(true)
+  })
+
+  test('Linux uses PATH only', () => {
+    expect(tailscaleCandidates('linux')).toEqual(['tailscale'])
   })
 })

--- a/src/hostd/tailscale.ts
+++ b/src/hostd/tailscale.ts
@@ -1,5 +1,5 @@
 import { getBun } from '@/container/shared'
-import { isMacOS } from '@/shared'
+import { isMacOS, isWindows } from '@/shared'
 
 export type TailscaleExecResult = { exitCode: number; stdout: string; stderr: string }
 export type TailscaleExec = (args: string[]) => Promise<TailscaleExecResult>
@@ -34,6 +34,7 @@ type TailscaleStatus = {
 }
 
 const MACOS_APP_CLI = '/Applications/Tailscale.app/Contents/MacOS/Tailscale'
+const WINDOWS_CLI = 'C:\\Program Files\\Tailscale\\tailscale.exe'
 
 export function createTailscaleServeManager(opts: TailscaleServeManagerOptions): TailscaleServeManager {
   const exec = opts.exec ?? defaultTailscaleExec
@@ -130,8 +131,17 @@ async function checkRunning(exec: TailscaleExec): Promise<{ ok: true } | { ok: f
   return { ok: true }
 }
 
+// `tailscale` on PATH is tried first everywhere; the platform-specific absolute
+// path is a fallback for GUI installs that leave the CLI off PATH (the macOS app
+// bundle, the Windows default install dir).
+export function tailscaleCandidates(platform: NodeJS.Platform = process.platform): string[] {
+  if (isMacOS(platform)) return ['tailscale', MACOS_APP_CLI]
+  if (isWindows(platform)) return ['tailscale', WINDOWS_CLI]
+  return ['tailscale']
+}
+
 export const defaultTailscaleExec: TailscaleExec = async (args) => {
-  const candidates = isMacOS() ? ['tailscale', MACOS_APP_CLI] : ['tailscale']
+  const candidates = tailscaleCandidates()
   let lastError = 'tailscale command not found'
 
   for (const candidate of candidates) {


### PR DESCRIPTION
## What

Extracts a pure `tailscaleCandidates(platform)` helper and adds the Windows default install path (`C:\Program Files\Tailscale\tailscale.exe`) as a fallback when resolving the Tailscale CLI, mirroring the existing macOS app-bundle fallback.

## Why

Part of native Windows host support (#899), plan item P5-T3. On Windows, Tailscale's GUI installer doesn't always put `tailscale` on `PATH`; a default-install-path fallback lets hostd's `tailscale serve` integration find it.

## Scope / safety

- **PATH-first, strictly additive.** `tailscale` (on PATH) is still tried first on every platform, so behavior is unchanged wherever it's on PATH. The absolute-path fallback only helps when PATH resolution fails — never worse than today.
- Builds on the `isWindows()` / `isMacOS()` seam (#907).
- `tailscaleCandidates` is a pure, exported, unit-tested helper.

## Verification

- `bun run format:check`, `bun run lint` (0 errors), `bun run typecheck` — clean
- `bun run test` — 9155 pass / 0 fail, incl. 3 new `tailscaleCandidates` tests

Part of #899.