### PR TITLE
fix(channels): deflake ensureLive watchdog retry test

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -909,6 +909,10 @@ describe('ChannelRouter ensureLive watchdog', () => {
     const dir = await tempDir()
     const logs: string[] = []
     let callCount = 0
+    let firstCreationEntered: (() => void) | undefined
+    const firstCreation = new Promise<void>((resolve) => {
+      firstCreationEntered = resolve
+    })
     const router = createChannelRouter({
       agentDir: dir,
       configForAdapter: () => baseConfig,
@@ -920,7 +924,10 @@ describe('ChannelRouter ensureLive watchdog', () => {
       },
       createSessionForChannel: async () => {
         callCount++
-        if (callCount === 1) await new Promise(() => {})
+        if (callCount === 1) {
+          firstCreationEntered!()
+          await new Promise(() => {})
+        }
         const fake = new FakeSession()
         return {
           session: fake as unknown as AgentSession,
@@ -935,6 +942,12 @@ describe('ChannelRouter ensureLive watchdog', () => {
     // when first inbound times out, then a second inbound arrives
     await expect(router.route(inbound())).rejects.toThrow(/ensureLive timed out/)
     expect(logs.some((l) => l.includes('ensureLive failed'))).toBe(true)
+    // Gate the retry on the first creation actually reaching the factory and
+    // hanging. Under parallel-test load the watchdog can fire before the slow
+    // pre-factory chain (ensureLoaded + name/membership resolution) reaches the
+    // factory; without this barrier the hang races onto the SECOND call, which
+    // then times out too and rejects this retry.
+    await firstCreation
     await router.route(inbound({ externalMessageId: 'm2' }))
     await router.__testing!.flushDebounce(KEY)
 


### PR DESCRIPTION
## Background

CI failed once on the `ensureLive` watchdog test — "after a watchdog timeout, the next inbound retries instead of awaiting the dead promise" — (1 fail in 9151 tests, runtime ~143ms). Re-running passed; classic flake.

The intended scenario: the first factory call hangs forever; the 50ms watchdog kills route #1, the owner-checked finally-block evicts the creating-map entry, and a second inbound retries into a live session.

Root-cause mechanism: inside the ensureLive function, a pre-factory async chain runs **before** the factory is ever entered. That chain reads the channel-sessions file from disk, resolves channel names, and fetches membership. The 50ms test timeout races that entire chain. Under parallel test load (18 workers saturating libuv's threadpool — the same stall mode documented in the `waitForPersistedLastInboundAt` comment in this file), the pre-factory chain can exceed 50ms, so the watchdog fires before the factory is entered. The infinite hang lands on the **second** route instead of the first; that second route times out too, and the retry call rejects. The ~143ms runtime is the fingerprint: two stacked 50ms timeouts.

The 50ms ceiling is a test-only seam — the `ensureLiveTimeoutMs` fixture option. Production uses a 30-second default, so no production behavior is affected.

## Summary

Add a barrier promise (named `firstCreation`) in the test fixture. The factory resolves the barrier on the first call — before the infinite hang — and the second route call awaits that barrier before proceeding.

This makes the test's invariant explicit: the hang is always on call #1, the retry is always call #2, regardless of how long the pre-factory chain takes. The 50ms watchdog still fires; it just always races the same thing it was designed to race.

No alternative was viable: bumping the timeout would still lose to a sufficiently loaded threadpool and would paper over rather than fix the race. Making the pre-factory chain synchronous would require production changes.

## What this does NOT do

- No change to production code: the watchdog timeout, raceWithTimeout, and ensureLive logic are untouched.
- Does not weaken the assertions: the watchdog still fires, the creating-map entry is still evicted, and the retry still produces exactly one live session (callCount becomes 2, liveCount stays 1).
- Does not change the factory's hang behavior.
- Does not address other tests or other potential flakes in this describe block.

## Review notes

The load-bearing change is `await firstCreation` placed before the second route call.
The barrier resolves inside the factory's first-call branch, synchronously before the infinite hang.
If the barrier resolver (firstCreationEntered) did not fire before the hang, the second route would block forever — that would be a test-design bug, not a production issue.

The assertion values (callCount = 2, liveCount = 1) are unchanged — the barrier adjusts sequencing only, not what the test verifies.
