### PR TITLE
ci: add informational windows test-triage lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,38 @@ jobs:
 
       - name: Format check
         run: bun run format:check
+
+  windows-test:
+    # Companion to windows-static: runs the full suite on native Windows to triage
+    # which tests assume POSIX (Docker, Unix sockets, chmod, /tmp). Many are
+    # expected to fail until guarded (#899), so it's continue-on-error and purely
+    # informational — read its logs for the Windows failure list. Gated to push
+    # (post-merge on main) to avoid the 2x Windows-runner cost on every PR;
+    # broaden the trigger and drop continue-on-error once the suite is green on
+    # Windows. The longer --timeout absorbs the slower Windows runner so failures
+    # reflect real incompatibilities, not timeouts.
+    name: windows tests (informational triage)
+    runs-on: windows-latest
+    if: github.event_name == 'push'
+    continue-on-error: true
+    env:
+      FIREWORKS_API_KEY: dummy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@typeclaw.dev"
+          git config --global user.name "TypeClaw CI"
+
+      - name: Test
+        run: bun test --parallel --timeout 60000


### PR DESCRIPTION
## What

Adds a non-blocking `windows-test` CI job that runs the full test suite on `windows-latest`, to triage which tests assume a POSIX environment (Docker, Unix sockets, `chmod`, `/tmp`).

## Why

Part of native Windows host support (#899). The `windows-static` lane (#911) proved the toolchain works on Windows; this lane produces the **test-suite triage data** (P0-T2) — the concrete list of tests that need `isWindows()` guards or platform-agnostic rewrites — which is the prerequisite for the deeper phases (IPC / lifecycle / `--mount`) being verifiable on Windows via CI.

## Scope / safety

- **Non-blocking + cost-gated.** `continue-on-error: true` (cannot block any PR) and `if: github.event_name == 'push'`, so it runs only post-merge on `main` — avoiding the 2× Windows-runner cost on every PR. The existing `ci` and `windows-static` jobs are untouched.
- **Expected to be red in its logs initially** — that is the triage output, not a regression. The job graduates to a required check (drop `continue-on-error`, broaden the trigger) once the suite is green on Windows.
- Longer `--timeout 60000` absorbs the slower Windows runner so failures reflect real incompatibilities, not timeouts.

Part of #899.