### PR TITLE
perf(channels): cap observed Recent-context message text per turn

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1110,6 +1110,29 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(prompt).toContain(longCurrent)
   })
 
+  test('truncates observed text on whole code points, never splitting a surrogate pair', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+
+    // each 😀 is one code point but two UTF-16 code units, so a code-unit slice
+    // at the cap would leave a dangling surrogate half
+    const emoji = '😀'.repeat(OBSERVED_MESSAGE_MAX_CHARS + 100)
+    await router.route(inbound({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: emoji }))
+    await router.route(inbound({ text: 'hey bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('[…truncated]')
+    expect(prompt).not.toContain('\uFFFD')
+    // exactly the cap worth of whole emoji survives — a code-unit split would
+    // break this contiguous-emoji substring with a dangling surrogate
+    expect(prompt).toContain('😀'.repeat(OBSERVED_MESSAGE_MAX_CHARS))
+    expect(prompt).not.toContain('😀'.repeat(OBSERVED_MESSAGE_MAX_CHARS + 1))
+  })
+
   test('seeds the session.turn.start retrieval query with the pure user message, not recent context or framing', async () => {
     const dir = await tempDir()
     const turnStartPrompts: string[] = []

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -37,6 +37,7 @@ import {
   isGraceWorthReusing,
   SESSION_GC_INTERVAL_MS,
   SESSION_FRESHNESS_TTL_MS,
+  OBSERVED_MESSAGE_MAX_CHARS,
   SESSION_GRACE_HARD_TTL_MS,
   SESSION_IDLE_MS,
   sliceHeadTail,
@@ -1085,6 +1086,28 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(prompt).toContain('Current message')
     expect(prompt).toContain('<@alice> (alice): hey bot')
     expect(prompt.indexOf('unrelated')).toBeLessThan(prompt.indexOf('hey bot'))
+  })
+
+  test('caps observed Recent-context message text but never the addressed current message', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+
+    const longObserved = 'A'.repeat(OBSERVED_MESSAGE_MAX_CHARS + 500)
+    const longCurrent = 'B'.repeat(OBSERVED_MESSAGE_MAX_CHARS + 500)
+    await router.route(inbound({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: longObserved }))
+    await router.route(inbound({ text: longCurrent }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    // observed (awareness-only) message is truncated to the cap with a marker
+    expect(prompt).toContain('[…truncated]')
+    expect(prompt).toContain('A'.repeat(OBSERVED_MESSAGE_MAX_CHARS))
+    expect(prompt).not.toContain('A'.repeat(OBSERVED_MESSAGE_MAX_CHARS + 1))
+    // the addressed current message is preserved in full
+    expect(prompt).toContain(longCurrent)
   })
 
   test('seeds the session.turn.start retrieval query with the pure user message, not recent context or framing', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -97,6 +97,11 @@ export const MAX_DEBOUNCE_MS = 4000
 export const HOT_THRESHOLD_MS = 3000
 export const MAX_CONSECUTIVE_ABORTS = 3
 export const CONTEXT_BUFFER_SIZE = 20
+// Observed ("Recent context") messages are awareness-only and replayed in full
+// on every turn (uncached), so one long paste would otherwise re-bloat every
+// subsequent turn until it ages out. Cap each observed message's text; the
+// addressed current message is never capped (it's the actual request).
+export const OBSERVED_MESSAGE_MAX_CHARS = 800
 // Discord's typing indicator expires after ~10s; an 8s heartbeat keeps it
 // continuously visible while we debounce + generate without spamming the API.
 export const TYPING_HEARTBEAT_MS = 8000
@@ -4462,7 +4467,7 @@ function composeTurnPrompt(
   if (observed.length > 0) {
     parts.push('## Recent context (not addressed to you, for awareness only)')
     for (const o of observed) {
-      parts.push(formatInboundPromptLines(o, adapter))
+      parts.push(formatInboundPromptLines(o, adapter, OBSERVED_MESSAGE_MAX_CHARS))
     }
     parts.push('')
   }
@@ -4521,10 +4526,12 @@ function formatAuthorLine(
   authorName: string,
   authorIsBot: boolean,
   text: string,
+  maxChars?: number,
 ): string {
   const tag = authorIsBot ? ' [bot]' : ''
   const stamp = ts > 0 ? `[${new Date(ts).toISOString()}] ` : ''
-  return `${stamp}${formatAuthorReference(adapter, authorId, authorName)} (${authorName})${tag}: ${text}`
+  const body = maxChars !== undefined && text.length > maxChars ? `${text.slice(0, maxChars)} […truncated]` : text
+  return `${stamp}${formatAuthorReference(adapter, authorId, authorName)} (${authorName})${tag}: ${body}`
 }
 
 function formatInboundPromptLines(
@@ -4537,10 +4544,19 @@ function formatInboundPromptLines(
     referenceContext?: InboundReferenceContext
   },
   adapter: AdapterId,
+  maxTextChars?: number,
 ): string {
   const lines = inbound.referenceContext?.sources.map(renderQuoteAnchor) ?? []
   lines.push(
-    formatAuthorLine(inbound.ts, adapter, inbound.authorId, inbound.authorName, inbound.authorIsBot, inbound.text),
+    formatAuthorLine(
+      inbound.ts,
+      adapter,
+      inbound.authorId,
+      inbound.authorName,
+      inbound.authorIsBot,
+      inbound.text,
+      maxTextChars,
+    ),
   )
   return lines.join('\n')
 }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4530,8 +4530,18 @@ function formatAuthorLine(
 ): string {
   const tag = authorIsBot ? ' [bot]' : ''
   const stamp = ts > 0 ? `[${new Date(ts).toISOString()}] ` : ''
-  const body = maxChars !== undefined && text.length > maxChars ? `${text.slice(0, maxChars)} […truncated]` : text
-  return `${stamp}${formatAuthorReference(adapter, authorId, authorName)} (${authorName})${tag}: ${body}`
+  return `${stamp}${formatAuthorReference(adapter, authorId, authorName)} (${authorName})${tag}: ${capObservedText(text, maxChars)}`
+}
+
+// Cap by whole code points so truncation never splits a surrogate pair (emoji,
+// astral-plane chars) into a dangling half. `text.length` (UTF-16 code units) is
+// a cheap upper bound on the code-point count, so a string already within the
+// cap skips the array build.
+function capObservedText(text: string, maxChars: number | undefined): string {
+  if (maxChars === undefined || text.length <= maxChars) return text
+  const points = Array.from(text)
+  if (points.length <= maxChars) return text
+  return `${points.slice(0, maxChars).join('')} […truncated]`
 }
 
 function formatInboundPromptLines(


### PR DESCRIPTION
## What

Caps the text of each observed ("Recent context") channel message at `OBSERVED_MESSAGE_MAX_CHARS = 800`, with a `[…truncated]` marker. Applied **only** to observed/awareness-only messages — the addressed **current message is never capped**.

## Why

`composeTurnPrompt` replays up to `CONTEXT_BUFFER_SIZE = 20` observed messages **in full** into every turn's user message (the **uncached** suffix, paid at full input price every turn), with **no per-message cap**. In a busy channel — typeclaw's core use case — a single long paste (stack trace, log dump) re-bloated every subsequent turn until it aged out of the buffer. This bounds the worst-case Recent-context block from unbounded to ~20 × 800 chars; normal short chat messages are unaffected.

Same "bound an unbounded uncached injection" class as the compaction / read-cap / retrieval-cache work.

## Implementation

Threaded an optional `maxChars` through `formatInboundPromptLines`/`formatAuthorLine`, passed only in the observed loop. The current-message loop is untouched.

## Test plan

`typecheck` / `format` / `lint` clean; full suite 0 fail. New `router.test.ts` case asserts a long observed message is truncated with the marker while a long *current* message is preserved in full. Existing Recent-context tests (short fixtures) unaffected.

Closes #919.
