### PR TITLE
fix(tui): restore terminal on abnormal exit and unstick the SSH picker

### DIFF
--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -476,13 +476,15 @@ describe('prepareStdinForClack', () => {
     // when: handing stdin to clack
     prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
     // then: the stream is resumed so clack's keypress listener gets input
-    expect(stdin.resumed).toBe(1)
+    expect(stdin.resumed).toBeGreaterThanOrEqual(1)
   })
 
-  test('clears stale raw mode before the picker takes over', () => {
+  test('kicks stdin back to flowing with a raw-mode toggle, ending non-raw', () => {
+    // A pi-tui ProcessTerminal.stop() leaves stdin paused; on->off raw toggle
+    // re-flows it under Bun/SSH, and the final non-raw state is what clack owns.
     const stdin = fakeStdin({ isTTY: true })
     prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
-    expect(stdin.rawModeCalls).toEqual([false])
+    expect(stdin.rawModeCalls).toEqual([true, false])
   })
 
   test('is a no-op on a non-TTY stdin (piped/redirected input)', () => {
@@ -495,13 +497,13 @@ describe('prepareStdinForClack', () => {
   test('still resumes when setRawMode throws (terminal already torn down)', () => {
     const stdin = fakeStdin({ isTTY: true, rawModeThrows: true })
     expect(() => prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)).not.toThrow()
-    expect(stdin.resumed).toBe(1)
+    expect(stdin.resumed).toBeGreaterThanOrEqual(1)
   })
 
   test('resumes even when setRawMode is unavailable on the stream', () => {
     const stdin = fakeStdin({ isTTY: true, hasSetRawMode: false })
     expect(() => prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)).not.toThrow()
-    expect(stdin.resumed).toBe(1)
+    expect(stdin.resumed).toBeGreaterThanOrEqual(1)
   })
 })
 

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -14,14 +14,18 @@ type ClackInput = Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'resume'>
 // Bun's readline keypress wiring only transitions stdin into flowing raw mode
 // reliably once the stream has already been resumed; on a never-resumed stdin
 // the picker renders but arrow keys echo as raw `^[[B` and never advance it.
-// Local terminals dodge this because stdin was already flowing. So before every
-// picker: clear any stale raw mode for a clean baseline, then resume the stream.
-// Never pause() here — a previously-paused process.stdin does not reliably
-// re-flow under Bun, which is the same failure this resume() is fixing.
+// Local terminals dodge this because stdin was already flowing. Worse, after a
+// pi-tui viewer (ProcessTerminal.stop() calls process.stdin.pause()), a plain
+// resume() does NOT re-flow stdin under Bun, so the next picker is dead over
+// SSH. Toggling raw mode on->off forces the TTY read back into flowing mode;
+// the trailing resume() + non-raw state is the baseline clack expects.
+// Never pause() here — a paused process.stdin does not reliably re-flow.
 export function prepareStdinForClack(input: ClackInput = process.stdin): void {
   if (!input.isTTY) return
+  input.resume()
   if (typeof input.setRawMode === 'function') {
     try {
+      input.setRawMode(true)
       input.setRawMode(false)
     } catch {
       /* terminal already torn down */

--- a/src/inspect/transcript-view.ts
+++ b/src/inspect/transcript-view.ts
@@ -10,6 +10,7 @@ import {
 } from '@mariozechner/pi-tui'
 
 import { formatToolEnd, formatToolStart, formatUserPromptHistory } from '@/tui/format'
+import { armTerminalGuard } from '@/tui/terminal-guard'
 import { colors, markdownTheme } from '@/tui/theme'
 
 import { streamSessionEvents, type LiveSourceFactory, type StreamPhase } from './index'
@@ -46,6 +47,9 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     tui.addChild(new Text(header(opts.summary), 0, 0))
     tui.addChild(status)
     tui.start()
+    // Restores the terminal on an abnormal exit (SSH SIGHUP, kill, crash) that
+    // never reaches tui.stop(), so the shell isn't left in Kitty kbd mode.
+    const guard = armTerminalGuard()
     tui.requestRender()
 
     // The status line is pinned last (no editor to pin, unlike createTui). Each
@@ -71,12 +75,21 @@ export function createTranscriptView(opts: TranscriptViewOptions) {
     const outcome = new Promise<TranscriptViewOutcome>((resolve) => {
       settle = resolve
     })
+    // drainInput() before stop() swallows late Kitty key-release bytes so they
+    // don't leak to the shell over a slow SSH link; disarm() drops the abnormal-
+    // exit guard now that a clean teardown ran.
     const finish = (reason: TranscriptViewOutcome['reason']): void => {
       if (settle === null) return
       const fn = settle
       settle = null
-      tui.stop()
-      fn({ reason })
+      void terminal
+        .drainInput()
+        .catch(() => {})
+        .then(() => {
+          tui.stop()
+          guard.disarm()
+          fn({ reason })
+        })
     }
 
     tui.addInputListener((data) => {

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -23,6 +23,7 @@ import {
   formatUserPromptHistory,
   withTimestamp,
 } from './format'
+import { armTerminalGuard } from './terminal-guard'
 import { colors, editorTheme, markdownTheme } from './theme'
 
 export type ClientFactory = (url: string) => Promise<Client>
@@ -103,6 +104,10 @@ export function createTui({
     const status = new Text(colors.dim(`connecting to ${displayUrl}...`), 0, 0)
     tui.addChild(status)
     tui.start()
+    // Armed once the terminal is in raw mode + Kitty kbd protocol: restores the
+    // terminal on an abnormal exit (SSH SIGHUP, kill, crash) that never reaches
+    // tui.stop(), so the shell isn't left echoing Kitty key-release events.
+    const guard = armTerminalGuard()
     tui.requestRender()
 
     // Pre-handshake failures resolve 'connectFailed' (not throw): the standalone
@@ -113,6 +118,7 @@ export function createTui({
       status.setText(colors.red(`connection error: ${err instanceof Error ? err.message : String(err)}`))
       tui.requestRender()
       tui.stop()
+      guard.disarm()
       exit(1)
       return null
     })
@@ -124,6 +130,7 @@ export function createTui({
       tui.requestRender()
       client.close()
       tui.stop()
+      guard.disarm()
       exit(1)
       return null
     })
@@ -418,21 +425,32 @@ export function createTui({
     // Settle BEFORE closing the client: client.close() fires onClose, which
     // settles 'lostConnection'. settle() is idempotent, so the first call wins —
     // settling the deliberate outcome first keeps the later onClose a no-op.
-    const teardown = (): void => {
-      stopAllLoaders()
-      tui.stop()
-      client.close()
+    // drainInput() runs before stop() so late Kitty key-release bytes (the keys
+    // that triggered the exit) are swallowed instead of leaking to the shell
+    // over a slow SSH link. The promise is memoized so repeated callers (a
+    // fire-and-forget detach/exit plus the end-of-run await) share ONE teardown
+    // and the end-of-run await truly blocks until draining finishes — otherwise
+    // the next clack picker could start reading stdin mid-drain.
+    let teardownPromise: Promise<void> | null = null
+    const teardown = (): Promise<void> => {
+      teardownPromise ??= (async () => {
+        stopAllLoaders()
+        await terminal.drainInput().catch(() => {})
+        tui.stop()
+        client.close()
+        guard.disarm()
+      })()
+      return teardownPromise
     }
 
     const exitWith = (code: number): void => {
       settle({ reason: 'exit', exitCode: code })
-      teardown()
-      exit(code)
+      void teardown().finally(() => exit(code))
     }
 
     const detach = (): void => {
       settle({ reason: 'detach' })
-      teardown()
+      void teardown()
     }
 
     // Ctrl+C exits the client. In raw mode the kernel does NOT generate SIGINT,
@@ -490,7 +508,7 @@ export function createTui({
     }
 
     const result = await outcome
-    tui.stop()
+    await teardown()
     return result
   }
 

--- a/src/tui/terminal-guard.test.ts
+++ b/src/tui/terminal-guard.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createTerminalGuard, RESTORE_SEQUENCE, type TerminalGuardDeps } from './terminal-guard'
+
+type Listener = (...args: unknown[]) => void
+
+function fakeDeps(overrides: Partial<TerminalGuardDeps> = {}): {
+  deps: TerminalGuardDeps
+  writes: string[]
+  rawModes: boolean[]
+  listeners: Map<string, Set<Listener>>
+  killed: string[]
+  exited: number[]
+  emit: (event: string, ...args: unknown[]) => void
+} {
+  const writes: string[] = []
+  const rawModes: boolean[] = []
+  const listeners = new Map<string, Set<Listener>>()
+  const killed: string[] = []
+  const exited: number[] = []
+
+  const emit = (event: string, ...args: unknown[]): void => {
+    // oxlint-disable-next-line no-useless-spread -- snapshot so a handler can off() itself mid-emit
+    for (const fn of [...(listeners.get(event) ?? [])]) fn(...args)
+  }
+
+  const deps: TerminalGuardDeps = {
+    isTty: true,
+    writeStdout: (seq) => writes.push(seq),
+    setRawMode: (mode) => rawModes.push(mode),
+    on: (event, handler) => {
+      const set = listeners.get(event) ?? new Set<Listener>()
+      set.add(handler)
+      listeners.set(event, set)
+    },
+    off: (event, handler) => {
+      listeners.get(event)?.delete(handler)
+    },
+    killSelf: (sig) => killed.push(sig),
+    exit: (code) => {
+      exited.push(code)
+    },
+    ...overrides,
+  }
+
+  return { deps, writes, rawModes, listeners, killed, exited, emit }
+}
+
+describe('createTerminalGuard', () => {
+  test('arm installs an exit handler and the scoped signal handlers', () => {
+    const { deps, listeners } = fakeDeps()
+    const guard = createTerminalGuard(deps)
+
+    guard.arm()
+
+    expect(listeners.get('exit')?.size).toBe(1)
+    expect(listeners.get('SIGINT')?.size).toBe(1)
+    expect(listeners.get('SIGTERM')?.size).toBe(1)
+    expect(listeners.get('SIGHUP')?.size).toBe(1)
+  })
+
+  test('exit handler writes the restore sequence and clears raw mode', () => {
+    const { deps, writes, rawModes, emit } = fakeDeps()
+    createTerminalGuard(deps).arm()
+
+    emit('exit', 0)
+
+    expect(writes).toEqual([RESTORE_SEQUENCE])
+    expect(rawModes).toEqual([false])
+  })
+
+  test('restore sequence pops the Kitty keyboard protocol and shows the cursor', () => {
+    // The leak symptom is the shell receiving Kitty key-RELEASE events; the pop
+    // (\x1b[<u) is the load-bearing byte. Show-cursor and bracketed-paste-off
+    // round out a full pi-tui ProcessTerminal.stop() reset.
+    expect(RESTORE_SEQUENCE).toContain('\x1b[<u')
+    expect(RESTORE_SEQUENCE).toContain('\x1b[?25h')
+    expect(RESTORE_SEQUENCE).toContain('\x1b[?2004l')
+  })
+
+  test('a scoped signal restores, removes its own handler, then re-raises the signal', () => {
+    const { deps, writes, listeners, killed, emit } = fakeDeps()
+    createTerminalGuard(deps).arm()
+
+    emit('SIGHUP')
+
+    expect(writes).toEqual([RESTORE_SEQUENCE])
+    // Handler removed before re-raise so the re-raised signal isn't swallowed.
+    expect(listeners.get('SIGHUP')?.size ?? 0).toBe(0)
+    expect(killed).toEqual(['SIGHUP'])
+  })
+
+  test('disarm removes scoped signal handlers but keeps the process-lifetime exit handler', () => {
+    const { deps, listeners } = fakeDeps()
+    const guard = createTerminalGuard(deps)
+
+    guard.arm()
+    guard.disarm()
+
+    expect(listeners.get('SIGINT')?.size ?? 0).toBe(0)
+    expect(listeners.get('SIGTERM')?.size ?? 0).toBe(0)
+    expect(listeners.get('SIGHUP')?.size ?? 0).toBe(0)
+    // The exit handler is sync, idempotent, and harmless — it stays installed so
+    // a Bun process.exit() that drops pi-tui's buffered stop() writes is still
+    // covered.
+    expect(listeners.get('exit')?.size).toBe(1)
+  })
+
+  test('exit handler still restores after disarm (covers Bun-dropped clean-exit writes)', () => {
+    const { deps, writes, emit } = fakeDeps()
+    const guard = createTerminalGuard(deps)
+
+    guard.arm()
+    guard.disarm()
+    emit('exit', 0)
+
+    expect(writes).toEqual([RESTORE_SEQUENCE])
+  })
+
+  test('ref-counted arm/disarm keeps signal handlers until the last disarm', () => {
+    const { deps, listeners } = fakeDeps()
+    const guard = createTerminalGuard(deps)
+
+    guard.arm()
+    guard.arm()
+    guard.disarm()
+    expect(listeners.get('SIGINT')?.size).toBe(1)
+
+    guard.disarm()
+    expect(listeners.get('SIGINT')?.size ?? 0).toBe(0)
+  })
+
+  test('re-arming after a full disarm reinstalls scoped handlers without duplicating exit', () => {
+    const { deps, listeners } = fakeDeps()
+    const guard = createTerminalGuard(deps)
+
+    guard.arm()
+    guard.disarm()
+    guard.arm()
+
+    expect(listeners.get('exit')?.size).toBe(1)
+    expect(listeners.get('SIGINT')?.size).toBe(1)
+  })
+
+  test('stays inert when stdout is not a TTY (no handlers, no writes)', () => {
+    const { deps, writes, rawModes, listeners } = fakeDeps({ isTty: false })
+    createTerminalGuard(deps).arm()
+
+    expect(listeners.get('exit')?.size ?? 0).toBe(0)
+    expect(listeners.get('SIGINT')?.size ?? 0).toBe(0)
+    expect(writes).toEqual([])
+    expect(rawModes).toEqual([])
+  })
+})

--- a/src/tui/terminal-guard.ts
+++ b/src/tui/terminal-guard.ts
@@ -1,0 +1,139 @@
+import { writeSync } from 'node:fs'
+
+// Mirrors pi-tui ProcessTerminal.stop()'s resets so an abnormal exit (SSH
+// SIGHUP, a frozen TUI the user kills, a crash, or a Bun process.exit() that
+// drops pi-tui's buffered stop() writes) can't leave the parent shell with the
+// Kitty keyboard protocol still on. While on, the terminal emits CSI-u
+// key-RELEASE events (`;1:3u`) for every keystroke, corrupting the shell. Order
+// matches stop(): pop Kitty kbd protocol, disable xterm modifyOtherKeys, disable
+// bracketed paste, end synchronized output, show cursor.
+export const RESTORE_SEQUENCE = '\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[?2026l\x1b[?25h'
+
+const STDOUT_FD = 1
+
+const SCOPED_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const
+export type ScopedSignal = (typeof SCOPED_SIGNALS)[number]
+
+const SIGNAL_EXIT_CODE: Record<ScopedSignal, number> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+  SIGHUP: 129,
+}
+
+export type TerminalGuardDeps = {
+  isTty: boolean
+  writeStdout: (seq: string) => void
+  setRawMode: (mode: boolean) => void
+  on: (event: string, handler: (...args: unknown[]) => void) => void
+  off: (event: string, handler: (...args: unknown[]) => void) => void
+  killSelf: (signal: ScopedSignal) => void
+  exit: (code: number) => void
+}
+
+export type TerminalGuard = {
+  arm: () => void
+  disarm: () => void
+}
+
+export function createTerminalGuard(deps: TerminalGuardDeps): TerminalGuard {
+  let armed = 0
+  let exitInstalled = false
+  let signalHandlers: Map<ScopedSignal, (...args: unknown[]) => void> | null = null
+
+  const restore = (): void => {
+    if (!deps.isTty) return
+    deps.writeStdout(RESTORE_SEQUENCE)
+    deps.setRawMode(false)
+  }
+
+  const onExit = (): void => {
+    restore()
+  }
+
+  const installSignalHandlers = (): void => {
+    if (signalHandlers !== null) return
+    const handlers = new Map<ScopedSignal, (...args: unknown[]) => void>()
+    for (const sig of SCOPED_SIGNALS) {
+      const handler = (): void => {
+        // Restore the terminal, then let the signal terminate with default
+        // semantics. Remove our handlers first so the re-raised signal isn't
+        // swallowed by this same handler; fall back to an explicit exit if the
+        // re-raise somehow doesn't terminate.
+        removeSignalHandlers()
+        restore()
+        deps.killSelf(sig)
+        deps.exit(SIGNAL_EXIT_CODE[sig])
+      }
+      deps.on(sig, handler)
+      handlers.set(sig, handler)
+    }
+    signalHandlers = handlers
+  }
+
+  const removeSignalHandlers = (): void => {
+    if (signalHandlers === null) return
+    for (const [sig, handler] of signalHandlers) deps.off(sig, handler)
+    signalHandlers = null
+  }
+
+  return {
+    arm: () => {
+      // A non-TTY process (piped/redirected, or the test runner) has no terminal
+      // state to protect, so the guard stays fully inert — it never touches the
+      // real process signal/exit handlers.
+      if (!deps.isTty) return
+      armed += 1
+      if (!exitInstalled) {
+        deps.on('exit', onExit)
+        exitInstalled = true
+      }
+      installSignalHandlers()
+    },
+    disarm: () => {
+      if (!deps.isTty) return
+      if (armed > 0) armed -= 1
+      if (armed === 0) removeSignalHandlers()
+    },
+  }
+}
+
+let defaultGuard: TerminalGuard | null = null
+
+function getDefaultGuard(): TerminalGuard {
+  defaultGuard ??= createTerminalGuard({
+    isTty: Boolean(process.stdout.isTTY),
+    writeStdout: (seq) => {
+      try {
+        writeSync(STDOUT_FD, seq)
+      } catch {
+        /* fd closed mid-teardown */
+      }
+    },
+    setRawMode: (mode) => {
+      try {
+        process.stdin.setRawMode?.(mode)
+      } catch {
+        /* terminal already torn down */
+      }
+    },
+    on: (event, handler) => {
+      process.on(event as NodeJS.Signals, handler)
+    },
+    off: (event, handler) => {
+      process.off(event as NodeJS.Signals, handler)
+    },
+    killSelf: (signal) => {
+      process.kill(process.pid, signal)
+    },
+    exit: (code) => {
+      process.exit(code)
+    },
+  })
+  return defaultGuard
+}
+
+export function armTerminalGuard(): TerminalGuard {
+  const guard = getDefaultGuard()
+  guard.arm()
+  return guard
+}


### PR DESCRIPTION
## Problem

Over SSH, `typeclaw inspect` / `typeclaw tui` are unusable in two linked ways:

1. **It "easily freezes."** After viewing a session in a pi-tui viewer and pressing `esc` to return to the picker, the picker renders but accepts no keystrokes.
2. **The shell is corrupted after quitting.** Typing `typeclaw` echoes as garbage like `t6;1:3uy1;1:3upe2;1:3uc1;1:3u9;1:3ulaw7;1:3u`. Those `;1:3u` tokens are CSI-u **key-release** events (event type `3`) from the **Kitty keyboard protocol** — i.e. the protocol is still enabled in the shell.

## Root cause

`@mariozechner/pi-tui`'s `ProcessTerminal`:

- `start()` enables the Kitty keyboard protocol (`\x1b[>7u`, flags include **report key-release events**) and puts stdin in raw mode.
- `stop()` pops it (`\x1b[<u`) **only on a clean teardown**, and also calls `process.stdin.pause()`.

typeclaw had **no terminal-restoration safety net**:

- On an **abnormal exit** — a frozen TUI the user kills, an SSH disconnect (`SIGHUP`), or a crash — `stop()` never runs, so Kitty mode stays on and the shell echoes release events on every keystroke. This is the persistent corruption.
- pi-tui's purpose-built `drainInput()` ("prevent Kitty key release events from leaking to the parent shell over slow SSH connections") was **never called**, so in-flight release bytes leak even on a clean exit.
- The **freeze**: after `stop()` pauses stdin, a plain `resume()` does not re-flow it under Bun-over-SSH, so the next `@clack/prompts` picker is dead. The codebase already documents and works around this in its own `createTailScope` ("Deliberately NOT stdin.pause()") but couldn't control pi-tui's `stop()`.

(`node_modules/@mariozechner/pi-tui` is an upstream dependency and out of scope to patch here; the fix lives entirely in typeclaw's `src/`.)

## Fix

- **`src/tui/terminal-guard.ts` (new):** a process-level guard armed while a pi-tui terminal is live. It synchronously writes the restore sequence (`\x1b[<u` pop Kitty, `\x1b[>4;0m` modifyOtherKeys off, `\x1b[?2004l` bracketed paste off, `\x1b[?2026l`, `\x1b[?25h` show cursor) via `fs.writeSync(1, …)` so it survives Bun's `process.exit()` and signals. The `exit` handler is process-lifetime (also covers crashes and Bun dropping `stop()`'s buffered writes); `SIGINT`/`SIGTERM`/`SIGHUP` handlers are ref-counted to the armed period and re-raise the signal after restoring. Inert on a non-TTY stdout.
- **Wire it in** + call `terminal.drainInput()` before `tui.stop()` in `createTui` and `createTranscriptView`; the `createTui` teardown promise is memoized so the next picker can't read stdin mid-drain.
- **Unstick the picker:** `prepareStdinForClack` toggles raw mode on→off to kick stdin back into flowing mode after a pi-tui `pause()`.

## Testing

- New `src/tui/terminal-guard.test.ts` (9 tests): exit/signal restore, scoped re-raise, ref-counting, non-TTY inertness, restore-after-disarm.
- Updated `prepareStdinForClack` tests for the raw-mode-toggle re-flow.
- `bun run typecheck` ✓ · `bun run lint` ✓ (0 errors) · `bun run format:check` ✓ · `bun run test` ✓ (9161 pass / 0 fail).

> Note: there is a pre-existing `typeclaw.schema.json` drift-guard failure on `main` (unrelated generated-artifact drift); not touched here.