### PR TITLE
fix(tests): make path handling POSIX-stable on Windows runners

### DIFF
--- a/src/agent/doctor.ts
+++ b/src/agent/doctor.ts
@@ -1,4 +1,9 @@
-import { isAbsolute, normalize } from 'node:path'
+import { posix } from 'node:path'
+
+// changedPaths are a wire format: agentDir-relative POSIX paths the container
+// emits and the host re-validates. Resolved with `path.posix` so a win32 test
+// runner keeps `/`-separators instead of rewriting `memory/x.md` to `memory\x.md`.
+const { isAbsolute, normalize } = posix
 
 import type {
   PluginCheckResult,

--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -341,7 +341,7 @@ describe('memoryLoggerSubagent', () => {
     const prompt = runSessionCalls[0]!.userPrompt!
     expect(prompt).toContain(transcript)
     expect(prompt).toContain('ses_abc')
-    expect(prompt).toMatch(/memory\/streams\/\d{4}-\d{2}-\d{2}\.jsonl/)
+    expect(prompt).toMatch(/memory[/\\]streams[/\\]\d{4}-\d{2}-\d{2}\.jsonl/)
   })
 
   test('handler includes channel location and participants in the initial prompt', async () => {

--- a/src/bundled-plugins/memory/memory-retrieval.test.ts
+++ b/src/bundled-plugins/memory/memory-retrieval.test.ts
@@ -202,7 +202,7 @@ async function walk(root: string, dir: string, out: string[]): Promise<void> {
     if (entry.isDirectory()) {
       await walk(root, absolute, out)
     } else {
-      out.push(path.relative(root, absolute))
+      out.push(path.relative(root, absolute).split(path.sep).join('/'))
     }
   }
 }

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -178,7 +178,10 @@ function matchHidden(
   }
   for (const dir of deniedDirs) {
     const realDir = realpathRealIntendedPath(dir)
-    if (resolved === realDir || resolved.startsWith(`${realDir}/`)) return dir
+    // realpathRealIntendedPath joins with the platform separator, so the
+    // under-dir test must use path.sep too — a hardcoded "/" never matches the
+    // "\"-joined paths a win32 test runner produces.
+    if (resolved === realDir || resolved.startsWith(`${realDir}${path.sep}`)) return dir
   }
   return undefined
 }

--- a/src/sandbox/session-tmp.ts
+++ b/src/sandbox/session-tmp.ts
@@ -1,5 +1,10 @@
 import { mkdir } from 'node:fs/promises'
-import { isAbsolute, join, relative, resolve } from 'node:path'
+import { posix } from 'node:path'
+
+// Container-only code over the POSIX `/tmp`; pinned to `path.posix` so the test
+// suite produces the same backing paths on a win32 runner (default `node:path`
+// would yield `\tmp\…` and diverge from the Linux runtime).
+const { isAbsolute, join, relative, resolve } = posix
 
 // Per-session scratch lives on the REAL container /tmp, namespaced by session id.
 // It sits OUTSIDE the agent folder on purpose: the agent folder's `sessions/` is


### PR DESCRIPTION
## Background

The Windows CI job (`windows tests (informational triage)`, run [27592327077](https://github.com/typeclaw/typeclaw/actions/runs/27592327077/job/81575537567)) reported 10 failures. Every one is the same root cause: container-logical paths were resolved through the platform-default `node:path`, which switches to **win32 separators** on a Windows runner. Examples from the run:

- `private-surface-read.test.ts` — guard returned `undefined` (no block) because the under-hidden-dir check compared against a hardcoded `"/"`, which never matches the `"\"`-joined realpath.
- `plugin-tools.test.ts` — expected `/tmp/typeclaw-session/sid42/review.json`, got `\tmp\typeclaw-session\sid42\review.json`.
- `doctor.test.ts` — expected `memory/x.md`, got `memory\x.md`.
- `memory-retrieval.test.ts` / `memory-logger.test.ts` — `/`-only assertions against paths that carry the platform separator.

These paths are **always POSIX at runtime**: the agent runs only inside a Linux container (the host CLI never reaches this code). The win32 separator only appears on the Windows *test host*, so the fix is to make the path math platform-stable, not to teach the runtime about Windows.

## Summary

Two flavors of fix, matching what each path actually is:

- **Container-logical paths → pin to `path.posix`.** `session-tmp.ts` (the per-session `/tmp` backing path) and `doctor.ts` `sanitizeChangedPaths` (the agentDir-relative wire format) operate on paths that are POSIX by contract. Resolving them with `posix.{join,relative,resolve,normalize}` makes the output identical on every test host and matches the Linux runtime. This mirrors the existing precedent in `config.ts`, which already uses `posix.normalize` for the same reason. *Why posix and not `.replace(/\\/g,'/')`* — the inputs are also resolved/normalized, so a blanket string replace would still take win32 branches in `resolve`/`isAbsolute`.

- **Real on-disk paths → make the comparison separator-agnostic.** `private-surface-read.ts` realpaths against the live filesystem, so its output legitimately carries the platform separator; the fix is to compare with `path.sep` instead of a literal `"/"`. The two memory test helpers assert real on-disk paths (production correctly uses the platform `join` there), so they're made to tolerate either separator.

## What this does NOT do

- Does not change any runtime behavior on Linux — the produced strings are byte-identical to before on the container.
- Does not touch `paths.ts` (memory stream/topic paths): those build real agent-folder paths and correctly use the platform `join`; only the *tests* asserting them were `/`-only.
- Does not address the pre-existing `typeclaw.schema.json` drift-guard or the flaky Xvfb-shim timeout test surfaced locally — both are unrelated to path separators and reproduce on `main`.

## Review notes

- The load-bearing change is `private-surface-read.ts`: it's a **security guard**, so a separator mismatch is the difference between blocking and silently allowing a private-surface read. `path.sep` is correct because `realpathRealIntendedPath` joins with the platform separator on both sides of the comparison.
- All 178 tests across the six affected files pass; full suite is green apart from the two unrelated pre-existing items noted above.
