### PR TITLE
fix(container): disambiguate non-ASCII agent folder names

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -48,6 +48,57 @@ describe('containerNameFromCwd', () => {
 
     expect(containerNameFromCwd(folder)).toBe('tc-.hidden')
   })
+
+  test('produces a valid Docker name for an all-non-ASCII folder (Korean)', async () => {
+    const folder = join(root, '봇')
+    await mkdir(folder)
+
+    const name = containerNameFromCwd(folder)
+
+    expect(name).toMatch(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+    expect(name).toMatch(/^tc-[0-9a-f]{8}$/)
+  })
+
+  test('distinct non-ASCII folder names never collide (the core bug)', async () => {
+    // given: two single-character CJK/Korean names that the old charset filter
+    // collapsed to the same 'tc--' string — distinct agents, same container key.
+    const bot = join(root, '봇')
+    const house = join(root, '집')
+    const cn = join(root, '中文')
+    const jp = join(root, '日本')
+    await Promise.all([mkdir(bot), mkdir(house), mkdir(cn), mkdir(jp)])
+
+    const names = [
+      containerNameFromCwd(bot),
+      containerNameFromCwd(house),
+      containerNameFromCwd(cn),
+      containerNameFromCwd(jp),
+    ]
+
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  test('keeps surviving ASCII as a readable prefix and disambiguates by hash', async () => {
+    // given: two folders that share an ASCII suffix but differ only in their
+    // CJK prefix — the old filter mapped both to 'tc-------Agent'.
+    const cn = join(root, '中文Agent')
+    const jp = join(root, '日本Agent')
+    await Promise.all([mkdir(cn), mkdir(jp)])
+
+    const cnName = containerNameFromCwd(cn)
+    const jpName = containerNameFromCwd(jp)
+
+    expect(cnName).toMatch(/^Agent-[0-9a-f]{8}$/)
+    expect(jpName).toMatch(/^Agent-[0-9a-f]{8}$/)
+    expect(cnName).not.toBe(jpName)
+  })
+
+  test('is deterministic for the same non-ASCII folder name', async () => {
+    const folder = join(root, '한글에이전트')
+    await mkdir(folder)
+
+    expect(containerNameFromCwd(folder)).toBe(containerNameFromCwd(folder))
+  })
 })
 
 describe('imageTagFromCwd', () => {

--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -59,8 +59,8 @@ describe('containerNameFromCwd', () => {
     expect(name).toMatch(/^tc-[0-9a-f]{8}$/)
   })
 
-  test('distinct non-ASCII folder names never collide (the core bug)', async () => {
-    // given: two single-character CJK/Korean names that the old charset filter
+  test('disambiguates the sampled non-ASCII folder names that previously collided (the core bug)', async () => {
+    // given: single-character CJK/Korean names that the old charset filter
     // collapsed to the same 'tc--' string — distinct agents, same container key.
     const bot = join(root, '봇')
     const house = join(root, '집')

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { basename, resolve } from 'node:path'
 
 export type DockerExecResult = { exitCode: number; stdout: string; stderr: string }
@@ -249,8 +250,25 @@ export function imageTagFromCwd(cwd: string): string {
 }
 
 // Docker container names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*.
+//
+// Non-ASCII names (Korean/CJK/Cyrillic/accented Latin — the common Windows case
+// where the profile folder is a localized display name, e.g. C:\Users\사용자\봇)
+// have every out-of-charset character collapsed to a dash, so distinct folders
+// reduce to the SAME string: '봇' and '집' both → 'tc--'. The container name keys
+// hostd registration and the secrets key path, so that collision is silent
+// host-side state clobbering, not cosmetics. For any name carrying a non-ASCII
+// char we append a deterministic hash of the original (cf. makeUntitledSlug in
+// the memory plugin) to keep distinct folders distinct; surviving ASCII stays a
+// readable prefix. ASCII-only names take the original branch — never renamed.
 function sanitizeContainerName(name: string): string {
   const cleaned = name.replace(/[^a-zA-Z0-9_.-]/g, '-')
+  if (/[^\u0000-\u007f]/.test(name)) {
+    const hash = createHash('sha256').update(name).digest('hex').slice(0, 8)
+    const remnant = cleaned.replace(/-+/g, '-').replace(/^-+|-+$/g, '')
+    if (remnant === '') return `tc-${hash}`
+    const base = /^[a-zA-Z0-9]/.test(remnant) ? remnant : `tc-${remnant}`
+    return `${base}-${hash}`
+  }
   if (cleaned === '' || !/^[a-zA-Z0-9]/.test(cleaned)) {
     return `tc-${cleaned || 'agent'}`
   }


### PR DESCRIPTION
## Background

`sanitizeContainerName` derives the Docker container name from the agent folder basename by collapsing every out-of-charset character to a dash. Non-English folder names — common on Windows where the profile folder is a localized display name — collapsed to identical strings: the Korean characters '봇' and '집' both produced "tc--", and '中文Agent'/'日本Agent' both produced "-------Agent".

The container name is not cosmetic. It keys hostd registration and the secrets key path, so two distinct agents under non-English folder names would silently clobber each other's host-side state.

## Summary

When the original folder name carries any non-ASCII character, a short deterministic SHA-256 hash of the original is appended (mirroring `makeUntitledSlug` in the memory plugin) so distinct folders stay distinct. Any surviving ASCII is kept as a readable prefix; the hash keeps the name Docker-valid. ASCII-only names take the original branch unchanged — no existing container is ever renamed.

## What this does NOT do

- Does not change ASCII-only container naming (existing containers are unaffected).
- Does not touch path validation, mount expansion, or Docker invocation. Config and mount validation paths, along with all Docker volume/env-file arguments constructed via Bun.spawn argv arrays (no shell interpolation), were already Unicode-safe. This container-name derivation was the one real non-English path-name gap.

## Review notes

The load-bearing change is the non-ASCII branch added to `sanitizeContainerName` in src/container/shared.ts. Key invariants:

- All-non-ASCII name (remnant collapses to empty): yields "tc-<hash>", a valid Docker name.
- Remnant starts with a dash: a "tc-" prefix is prepended before appending the hash.
- Remnant starts with letter/digit: the remnant is used directly as the prefix.

Regression tests in src/container/shared.test.ts cover: all-non-ASCII Korean name (Docker name validity), Korean/CJK collision (the core bug), shared-ASCII-suffix disambiguation, and determinism. The pre-existing ASCII-only tests are unchanged.

All checks pass: typecheck, lint (0 errors), format:check, and test suite (9214 pass / 0 fail).