### PR TITLE
Reword landing page group-chat demo message

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -163,7 +163,7 @@ function GroupChatVisual() {
           <div className="min-w-0">
             <p className="font-mono text-[11px] text-zinc-400 dark:text-zinc-600">sam</p>
             <div className="mt-1 rounded-2xl rounded-tl-sm border border-zinc-200 bg-white px-3.5 py-2 text-sm text-zinc-700 dark:border-white/[0.08] dark:bg-zinc-900 dark:text-zinc-300">
-              <span className="font-medium text-brand-accent dark:text-brand-300">@typeey</span> draft the changelog?
+              typeey, draft the changelog
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

Rewords the group-chat demo message in the landing page's `GroupChatVisual` mockup so the human addresses the agent by name as plain text instead of an `@`-mention question.

| | |
|---|---|
| **Before** | `@typeey draft the changelog?` (with `@typeey` highlighted as a mention) |
| **After** | `typeey, draft the changelog` (plain text) |

## Scope

A single line in `docs/src/app/page.tsx`. Since it's no longer a mention, `typeey` drops the `text-brand-accent` highlight and renders as plain message text (`text-zinc-700 dark:text-zinc-300`) — consistent with the `@jordan can you take the deploy?` message directly above it, where the name isn't highlighted either.

## Verification

- `oxlint` — 0 warnings, 0 errors
- `oxfmt --check` — clean
- `next build` — succeeds
- LSP diagnostics — none
