### PR TITLE
docs(seo): realign metadata + llms.txt with new landing copy

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -2,6 +2,8 @@ import { RootProvider } from 'fumadocs-ui/provider/next'
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 
+import { SITE_DESCRIPTION, SITE_KEYWORDS, SITE_NAME, SITE_TITLE, SITE_URL } from '@/lib/seo'
+
 import './globals.css'
 
 const geistSans = Geist({
@@ -14,35 +16,18 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 })
 
-const SITE_URL = 'https://typeclaw.dev'
-const SITE_TITLE = 'TypeClaw — A TypeScript-native agent runtime'
-const SITE_DESCRIPTION =
-  'TypeScript-native, Bun-powered, Docker-friendly general-purpose agent runtime. Sandboxed by default, plugins as plain TS modules, self-improving via memory.'
-
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
     default: SITE_TITLE,
-    template: '%s · TypeClaw',
+    template: `%s · ${SITE_NAME}`,
   },
   description: SITE_DESCRIPTION,
-  applicationName: 'TypeClaw',
-  keywords: [
-    'TypeClaw',
-    'AI agent runtime',
-    'TypeScript agent',
-    'Bun agent',
-    'Docker agent',
-    'self-hosted AI agent',
-    'agent framework',
-    'LLM agent',
-    'Slack bot',
-    'Discord bot',
-    'cron AI agent',
-  ],
-  authors: [{ name: 'TypeClaw' }],
-  creator: 'TypeClaw',
-  publisher: 'TypeClaw',
+  applicationName: SITE_NAME,
+  keywords: SITE_KEYWORDS,
+  authors: [{ name: SITE_NAME }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
   alternates: {
     canonical: '/',
   },
@@ -50,7 +35,7 @@ export const metadata: Metadata = {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     url: SITE_URL,
-    siteName: 'TypeClaw',
+    siteName: SITE_NAME,
     type: 'website',
     images: [{ url: '/typeclaw.png', width: 1000, height: 1000, alt: 'Typeey, the TypeClaw mascot' }],
   },
@@ -80,21 +65,21 @@ const jsonLd = {
       '@type': 'WebSite',
       '@id': `${SITE_URL}/#website`,
       url: SITE_URL,
-      name: 'TypeClaw',
+      name: SITE_NAME,
       description: SITE_DESCRIPTION,
       publisher: { '@id': `${SITE_URL}/#organization` },
     },
     {
       '@type': 'Organization',
       '@id': `${SITE_URL}/#organization`,
-      name: 'TypeClaw',
+      name: SITE_NAME,
       url: SITE_URL,
       logo: `${SITE_URL}/typeclaw.png`,
       sameAs: ['https://github.com/typeclaw/typeclaw'],
     },
     {
       '@type': 'SoftwareApplication',
-      name: 'TypeClaw',
+      name: SITE_NAME,
       applicationCategory: 'DeveloperApplication',
       operatingSystem: 'Linux, macOS, Windows (via Docker)',
       description: SITE_DESCRIPTION,

--- a/docs/src/app/llms.txt/route.ts
+++ b/docs/src/app/llms.txt/route.ts
@@ -1,11 +1,20 @@
 import { llms } from 'fumadocs-core/source'
 
+import { SITE_DESCRIPTION, SITE_NAME } from '@/lib/seo'
 import { source } from '@/lib/source'
 
 export const revalidate = false
 
 export function GET(): Response {
-  return new Response(llms(source).index(), {
+  // Fumadocs prefixes the index with a bare `# <root>` heading (the page tree has no
+  // root title, so it renders empty). Replace it with a branded title + summary so the
+  // llms.txt opens with what TypeClaw is, per the llmstxt.org convention.
+  const pageList = llms(source)
+    .index()
+    .replace(/^#[^\n]*\n+/, '')
+  const body = `# ${SITE_NAME}\n\n> ${SITE_DESCRIPTION}\n\n${pageList}`
+
+  return new Response(body, {
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },
   })
 }

--- a/docs/src/app/robots.ts
+++ b/docs/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-const BASE_URL = 'https://typeclaw.dev'
+import { SITE_URL } from '@/lib/seo'
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: `${BASE_URL}/sitemap.xml`,
-    host: BASE_URL,
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   }
 }

--- a/docs/src/app/sitemap.ts
+++ b/docs/src/app/sitemap.ts
@@ -1,18 +1,17 @@
 import type { MetadataRoute } from 'next'
 
+import { SITE_URL } from '@/lib/seo'
 import { source } from '@/lib/source'
-
-const BASE_URL = 'https://typeclaw.dev'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const home: MetadataRoute.Sitemap[number] = {
-    url: BASE_URL,
+    url: SITE_URL,
     changeFrequency: 'weekly',
     priority: 1,
   }
 
   const docs = source.getPages().map((page) => ({
-    url: `${BASE_URL}${page.url}`,
+    url: `${SITE_URL}${page.url}`,
     changeFrequency: 'weekly' as const,
     priority: page.url === '/docs' ? 0.9 : 0.7,
   }))

--- a/docs/src/lib/seo.ts
+++ b/docs/src/lib/seo.ts
@@ -1,0 +1,28 @@
+export const SITE_URL = 'https://typeclaw.dev'
+
+export const SITE_NAME = 'TypeClaw'
+
+export const SITE_TITLE = "TypeClaw — A self-hosted AI agent for your team's chat"
+
+export const SITE_DESCRIPTION =
+  "TypeClaw is a self-hosted, TypeScript-native AI agent that lives in your team's chat — Slack, Discord, Telegram, LINE, KakaoTalk, GitHub, or your terminal. Sandboxed by default, self-managing, and it gets sharper the longer it runs."
+
+export const SITE_KEYWORDS = [
+  'TypeClaw',
+  'self-hosted AI agent',
+  'AI agent for Slack',
+  'AI agent for Discord',
+  'TypeScript agent',
+  'Bun agent',
+  'Docker agent',
+  'sandboxed AI agent',
+  'self-improving agent',
+  'agent memory',
+  'AI subagents',
+  'AI pull request reviewer',
+  'Telegram bot',
+  'LINE bot',
+  'KakaoTalk bot',
+  'cron AI agent',
+  'group chat AI agent',
+]


### PR DESCRIPTION
## Why

The landing page was recently rewritten — hero is now **"The agent for perfectionists"**, the copy leads with *lives in your team's chat*, *self-improving*, *sandboxed/self-managing*, and a full multi-channel lineup (Slack, Discord, Telegram, LINE, KakaoTalk, GitHub). But the SEO surface still described the previous positioning:

- **Root metadata** (`layout.tsx`) titled the site *"A TypeScript-native agent runtime"* and the description talked about *"plugins as plain TS modules"* — accurate but no longer how the page sells itself.
- **Keywords** listed only `Slack bot`, `Discord bot`, `cron AI agent` — missing Telegram / LINE / KakaoTalk / GitHub, PR review, memory/self-improving, subagents, group-chat.
- **OG / Twitter cards / JSON-LD** all reused that stale description.
- **`/llms.txt`** opened with a bare page list and **no project overview at all** — an LLM crawling it learned nothing about what TypeClaw is.

The docs-derived `llms-full.txt`, `sitemap.xml`, and `robots.txt` were reviewed and are accurate; the only change there is de-duplication (below).

## What changed

- **New `docs/src/lib/seo.ts`** — single source of truth for `SITE_URL`, `SITE_NAME`, `SITE_TITLE`, `SITE_DESCRIPTION`, `SITE_KEYWORDS`. Previously the `typeclaw.dev` URL was hardcoded **three times** (layout, sitemap, robots) and the description twice — exactly the kind of drift that caused this gap. Now they can't diverge.
- **`layout.tsx`** — title/description/keywords/OG/Twitter/JSON-LD now consume the shared constants and reflect the current positioning. Kept the *TypeScript-native* phrasing inside the description so existing search equity isn't dropped.
- **`sitemap.ts` / `robots.ts`** — import `SITE_URL` from the shared module (no behavior change).
- **`llms.txt/route.ts`** — prepends a branded `# TypeClaw` + one-line `>` summary (per the llmstxt.org convention), replacing Fumadocs' empty leading heading. Page list is unchanged.

### New metadata copy
- **Title:** `TypeClaw — A self-hosted AI agent for your team's chat`
- **Description:** `TypeClaw is a self-hosted, TypeScript-native AI agent that lives in your team's chat — Slack, Discord, Telegram, LINE, KakaoTalk, GitHub, or your terminal. Sandboxed by default, self-managing, and it gets sharper the longer it runs.`

Copy is grounded in existing source-of-truth (`content/docs/index.mdx` canonical line + the landing hero/feature copy), not invented — easy to tweak wording in `seo.ts` if you'd prefer a different emphasis.

## Verification
- `bun run lint` (oxlint) — 0 warnings, 0 errors
- `bun run format:check` (oxfmt) — clean
- `tsc --noEmit` — clean on all changed files (the one pre-existing `RouteContext` error is a Next-build-generated global in an untouched route, resolved by `next build`)

## Out of scope (optional follow-ups, not gaps)
- A landscape `1200×630` OG image + switching Twitter card to `summary_large_image` (today: square `summary`).
- A `manifest.webmanifest` (no PWA metadata currently).
- Surfacing the landing page itself in `llms.txt` (currently docs-only, since the landing lives in `page.tsx`, not MDX).