### PR TITLE
feat(memory): collapse echo topic headings to slug alone

### DIFF
--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -96,8 +96,8 @@ describe('vector session.turn.start hook', () => {
 
     expect(emptySearch).toHaveBeenCalledWith('anything', expect.anything(), agentDir, 10, expect.any(Function))
     expect(retrievalContext.results).toContain('# Memory')
-    expect(retrievalContext.results).toContain('- First Topic `first-topic`')
-    expect(retrievalContext.results).toContain('- Second Topic `second-topic`')
+    expect(retrievalContext.results).toContain('- `first-topic`')
+    expect(retrievalContext.results).toContain('- `second-topic`')
     expect(retrievalContext.results).not.toContain('private first body')
     expect(retrievalContext.results).not.toContain('private second body')
     expect(infos.some((line) => line.includes('suppressed=1') && line.includes('fallback=topic-index'))).toBe(true)
@@ -215,11 +215,12 @@ describe('vector session.turn.start hook', () => {
     const first = { results: '' }
     await hook({ sessionId: 'ses_ch', agentDir, userPrompt: 'q1', origin, retrievalContext: first }, ctx)
 
-    // then: BOTH headings survive (no relevance-filtering drop), bodies are stripped,
+    // then: BOTH topics survive (no relevance-filtering drop), bodies are stripped,
     // the channel boundary is present, and hybrid search is never consulted — so a
-    // stale/empty vector index can never silently omit a topic on a channel turn
-    expect(first.results).toContain('- First Topic `first-topic`')
-    expect(first.results).toContain('- Second Topic `second-topic`')
+    // stale/empty vector index can never silently omit a topic on a channel turn.
+    // Both headings echo their slug, so each collapses to a slug-only line.
+    expect(first.results).toContain('- `first-topic`')
+    expect(first.results).toContain('- `second-topic`')
     expect(first.results).not.toContain('## First Topic')
     expect(first.results).not.toContain('cites=')
     expect(first.results).not.toContain('channel-private body one')

--- a/src/bundled-plugins/memory/load-memory.test.ts
+++ b/src/bundled-plugins/memory/load-memory.test.ts
@@ -6,7 +6,13 @@ import { join } from 'node:path'
 import type { SessionOrigin } from '@/agent/session-origin'
 
 import { renderShard } from './frontmatter'
-import { loadMemory, renderRetrievedMemorySection, type RetrievedMemoryItem } from './load-memory'
+import {
+  loadMemory,
+  renderRetrievedMemorySection,
+  renderTopicIndexMemorySection,
+  type RetrievedMemoryItem,
+} from './load-memory'
+import type { TopicShard } from './load-shards'
 import { streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
 import type { StreamEvent } from './stream-events'
 
@@ -395,8 +401,8 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
     },
     {
       source: 'topic',
-      key: 'github-channel-role-configuration',
-      heading: 'GitHub channel role configuration',
+      key: 'gh-api-labels-array-syntax',
+      heading: 'GitHub API label management in the agent environment',
       excerpt: 'roles-are-keyed-on-first-message body excerpt',
     },
   ]
@@ -406,11 +412,14 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
     expect(renderRetrievedMemorySection([])).toBe('')
   })
 
-  test('channel origin strips excerpt bodies, keeping only headings', () => {
+  test('channel origin strips excerpt bodies, collapsing echo headings to the slug alone', () => {
     const section = renderRetrievedMemorySection(items, { origin: channelOrigin })
 
-    expect(section).toContain('- KakaoTalk reply conventions `kakaotalk-reply-conventions`')
-    expect(section).toContain('- GitHub channel role configuration `github-channel-role-configuration`')
+    // an echo heading (headingToSlug === key) collapses to the slug alone
+    expect(section).toContain('- `kakaotalk-reply-conventions`')
+    expect(section).not.toContain('KakaoTalk reply conventions')
+    // a divergent heading is retained alongside its slug
+    expect(section).toContain('- GitHub API label management in the agent environment `gh-api-labels-array-syntax`')
     expect(section).not.toContain('the-user-prefers-formal-speech body excerpt')
     expect(section).not.toContain('roles-are-keyed-on-first-message body excerpt')
   })
@@ -425,7 +434,22 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
     const section = renderRetrievedMemorySection(items, { origin: channelOrigin })
 
     expect(section).toContain('kakaotalk-reply-conventions')
-    expect(section).toContain('github-channel-role-configuration')
+    expect(section).toContain('gh-api-labels-array-syntax')
+  })
+
+  test('a non-Latin heading is always retained because its ASCII slug can never echo it', () => {
+    const koreanItems: RetrievedMemoryItem[] = [
+      {
+        source: 'topic',
+        key: 'kakaotalk-korean-formality',
+        heading: '포멀한 한국어를 선호',
+        excerpt: 'formal-korean body excerpt',
+      },
+    ]
+
+    const section = renderRetrievedMemorySection(koreanItems, { origin: channelOrigin })
+
+    expect(section).toContain('- 포멀한 한국어를 선호 `kakaotalk-korean-formality`')
   })
 
   test('channel directive names both the topic-lookup and query-search calls', () => {
@@ -494,5 +518,33 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
 
     expect(section).toContain('Memory shown as index only in channels')
     expect(section).toContain('memory_search')
+  })
+})
+
+describe('renderTopicIndexMemorySection (headings fallback)', () => {
+  function shard(slug: string, heading: string): TopicShard {
+    return {
+      path: `/x/${slug}.md`,
+      slug,
+      frontmatter: { heading, cites: 1, days: 1, lastReinforced: '2026-05-16' },
+      body: 'body',
+    }
+  }
+
+  test('collapses an echo heading to the slug alone but keeps a divergent one', () => {
+    const section = renderTopicIndexMemorySection([
+      shard('pr-review-checkout-workflow', 'PR review checkout workflow'),
+      shard('gh-api-labels-array-syntax', 'GitHub API label management in the agent environment'),
+    ])
+
+    expect(section).toContain('- `pr-review-checkout-workflow`')
+    expect(section).not.toContain('PR review checkout workflow')
+    expect(section).toContain('- GitHub API label management in the agent environment `gh-api-labels-array-syntax`')
+  })
+
+  test('keeps a non-Latin heading whose ASCII slug can never echo it', () => {
+    const section = renderTopicIndexMemorySection([shard('kakaotalk-korean-formality', '포멀한 한국어를 선호')])
+
+    expect(section).toContain('- 포멀한 한국어를 선호 `kakaotalk-korean-formality`')
   })
 })

--- a/src/bundled-plugins/memory/load-memory.test.ts
+++ b/src/bundled-plugins/memory/load-memory.test.ts
@@ -464,6 +464,14 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
     expect(section).toContain(`- 한글 메모 \`${fallbackSlug}\``)
   })
 
+  test('keeps a mixed-script heading whose slug dropped the non-ASCII part', () => {
+    const items: RetrievedMemoryItem[] = [{ source: 'topic', key: 'memo', heading: '한글 memo', excerpt: 'body' }]
+
+    const section = renderRetrievedMemorySection(items, { origin: channelOrigin })
+
+    expect(section).toContain('- 한글 memo `memo`')
+  })
+
   test('channel directive names both the topic-lookup and query-search calls', () => {
     const section = renderRetrievedMemorySection(items, { origin: channelOrigin })
 
@@ -566,5 +574,11 @@ describe('renderTopicIndexMemorySection (headings fallback)', () => {
     const section = renderTopicIndexMemorySection([shard(fallbackSlug, '한글 메모')])
 
     expect(section).toContain(`- 한글 메모 \`${fallbackSlug}\``)
+  })
+
+  test('keeps a mixed-script heading whose slug dropped the non-ASCII part', () => {
+    const section = renderTopicIndexMemorySection([shard('memo', '한글 memo')])
+
+    expect(section).toContain('- 한글 memo `memo`')
   })
 })

--- a/src/bundled-plugins/memory/load-memory.test.ts
+++ b/src/bundled-plugins/memory/load-memory.test.ts
@@ -14,6 +14,7 @@ import {
 } from './load-memory'
 import type { TopicShard } from './load-shards'
 import { streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
+import { headingToSlug } from './slug'
 import type { StreamEvent } from './stream-events'
 
 const TS = '2026-05-16T12:00:00.000Z'
@@ -452,6 +453,17 @@ describe('renderRetrievedMemorySection (vector per-turn injection)', () => {
     expect(section).toContain('- 포멀한 한국어를 선호 `kakaotalk-korean-formality`')
   })
 
+  test('keeps a non-Latin heading even when its slug is the headingToSlug untitled fallback', () => {
+    const fallbackSlug = headingToSlug('한글 메모', new Set())
+    const koreanItems: RetrievedMemoryItem[] = [
+      { source: 'topic', key: fallbackSlug, heading: '한글 메모', excerpt: 'body' },
+    ]
+
+    const section = renderRetrievedMemorySection(koreanItems, { origin: channelOrigin })
+
+    expect(section).toContain(`- 한글 메모 \`${fallbackSlug}\``)
+  })
+
   test('channel directive names both the topic-lookup and query-search calls', () => {
     const section = renderRetrievedMemorySection(items, { origin: channelOrigin })
 
@@ -546,5 +558,13 @@ describe('renderTopicIndexMemorySection (headings fallback)', () => {
     const section = renderTopicIndexMemorySection([shard('kakaotalk-korean-formality', '포멀한 한국어를 선호')])
 
     expect(section).toContain('- 포멀한 한국어를 선호 `kakaotalk-korean-formality`')
+  })
+
+  test('keeps a non-Latin heading even when its slug is the headingToSlug untitled fallback', () => {
+    const fallbackSlug = headingToSlug('한글 메모', new Set())
+
+    const section = renderTopicIndexMemorySection([shard(fallbackSlug, '한글 메모')])
+
+    expect(section).toContain(`- 한글 메모 \`${fallbackSlug}\``)
   })
 })

--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -6,6 +6,7 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import { buildInjectionPlan, DEFAULT_INJECTION_BUDGET_BYTES, type InjectionPlan } from './injection-plan'
 import { loadAllShards, type TopicShard } from './load-shards'
 import { topicsDir } from './paths'
+import { headingToSlug } from './slug'
 import type { DedupedRetrievedItem } from './turn-dedup'
 
 const MAX_FILE_BYTES = 12 * 1024
@@ -130,7 +131,7 @@ export function renderRetrievedMemorySection(
       lines.push(`## ${item.heading}`)
       lines.push(item.excerpt.trimEnd(), '')
     } else if (item.source === 'topic' || item.source === 'reference') {
-      lines.push(`- ${item.heading} \`${item.key}\``)
+      lines.push(topicIndexEntry(item.heading, item.key))
     } else {
       lines.push(`- ${item.heading} _(recent observation)_`)
     }
@@ -150,9 +151,23 @@ export function renderTopicIndexMemorySection(
   if (options.origin?.kind === 'channel') lines.push(...CHANNEL_MEMORY_BOUNDARY, '')
   lines.push(topicIndexDirective(options), '')
   for (const shard of shards) {
-    lines.push(`- ${shard.frontmatter.heading} \`${shard.slug}\``)
+    lines.push(topicIndexEntry(shard.frontmatter.heading, shard.slug))
   }
   return lines.join('\n').trimEnd()
+}
+
+// A topic-index line names a topic for the model to decide whether to open it
+// (the slug is the `memory_search({ topic })` key). When the heading is just a
+// title-cased echo of the slug it adds no signal, so drop it and render the slug
+// alone. Keep both only when they diverge — the heading then carries a facet the
+// kebab slug dropped (e.g. `gh-api-labels-array-syntax` vs "GitHub API label
+// management in the agent environment"), and a non-Latin heading never echoes its
+// (ASCII-only) slug, so its readable form is always retained.
+function topicIndexEntry(heading: string, slug: string): string {
+  if (headingToSlug(heading, new Set<string>()) === slug) {
+    return `- \`${slug}\``
+  }
+  return `- ${heading} \`${slug}\``
 }
 
 function topicIndexDirective(options: Pick<LoadMemoryOptions, 'origin'>): string {

--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -6,7 +6,7 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import { buildInjectionPlan, DEFAULT_INJECTION_BUDGET_BYTES, type InjectionPlan } from './injection-plan'
 import { loadAllShards, type TopicShard } from './load-shards'
 import { topicsDir } from './paths'
-import { headingToSlug } from './slug'
+import { slugIsHeadingEcho } from './slug'
 import type { DedupedRetrievedItem } from './turn-dedup'
 
 const MAX_FILE_BYTES = 12 * 1024
@@ -156,15 +156,14 @@ export function renderTopicIndexMemorySection(
   return lines.join('\n').trimEnd()
 }
 
-// A topic-index line names a topic for the model to decide whether to open it
-// (the slug is the `memory_search({ topic })` key). When the heading is just a
-// title-cased echo of the slug it adds no signal, so drop it and render the slug
-// alone. Keep both only when they diverge — the heading then carries a facet the
-// kebab slug dropped (e.g. `gh-api-labels-array-syntax` vs "GitHub API label
-// management in the agent environment"), and a non-Latin heading never echoes its
-// (ASCII-only) slug, so its readable form is always retained.
+// A topic-index line names a topic so the model can decide whether to open it
+// (the slug is the `memory_search({ topic })` key). When the slug is just a kebab
+// echo of the heading the heading adds no signal, so render the slug alone; keep
+// both when they diverge (e.g. `gh-api-labels-array-syntax` vs "GitHub API label
+// management in the agent environment") or when the heading has no ASCII form
+// (e.g. CJK), where `slugIsHeadingEcho` returns false and the readable name stays.
 function topicIndexEntry(heading: string, slug: string): string {
-  if (headingToSlug(heading, new Set<string>()) === slug) {
+  if (slugIsHeadingEcho(heading, slug)) {
     return `- \`${slug}\``
   }
   return `- ${heading} \`${slug}\``

--- a/src/bundled-plugins/memory/slug.test.ts
+++ b/src/bundled-plugins/memory/slug.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
-import { headingToSlug, isValidSlug, SLUG_REGEX } from './slug'
+import { headingToSlug, isValidSlug, slugIsHeadingEcho, SLUG_REGEX } from './slug'
 
 describe('headingToSlug', () => {
   it('lowercases and replaces spaces with dashes', () => {
@@ -56,6 +56,28 @@ describe('headingToSlug', () => {
   it('deduplicates when slug is added to set between calls', () => {
     const existing = new Set<string>(['bar'])
     expect(headingToSlug('Bar', existing)).toBe('bar-2')
+  })
+})
+
+describe('slugIsHeadingEcho', () => {
+  it('is true when the slug is the kebab echo of the heading', () => {
+    expect(slugIsHeadingEcho('PR review checkout workflow', 'pr-review-checkout-workflow')).toBe(true)
+  })
+
+  it('is false when the heading carries a facet the slug dropped', () => {
+    expect(
+      slugIsHeadingEcho('GitHub API label management in the agent environment', 'gh-api-labels-array-syntax'),
+    ).toBe(false)
+  })
+
+  it('is false for an all-CJK heading even against its own untitled fallback slug', () => {
+    const fallbackSlug = headingToSlug('한글 메모', new Set())
+    expect(slugIsHeadingEcho('한글 메모', fallbackSlug)).toBe(false)
+  })
+
+  it('is false for an emoji-only heading against its own untitled fallback slug', () => {
+    const fallbackSlug = headingToSlug('🎉🎊', new Set())
+    expect(slugIsHeadingEcho('🎉🎊', fallbackSlug)).toBe(false)
   })
 })
 

--- a/src/bundled-plugins/memory/slug.test.ts
+++ b/src/bundled-plugins/memory/slug.test.ts
@@ -75,6 +75,15 @@ describe('slugIsHeadingEcho', () => {
     expect(slugIsHeadingEcho('한글 메모', fallbackSlug)).toBe(false)
   })
 
+  it('is false for a mixed heading whose non-ASCII content normalization dropped', () => {
+    // headingToSlug('한글 memo') === 'memo', dropping the Korean text
+    expect(slugIsHeadingEcho('한글 memo', 'memo')).toBe(false)
+  })
+
+  it('still collapses an accented heading because diacritics transliterate, not drop', () => {
+    expect(slugIsHeadingEcho('café résumé', 'cafe-resume')).toBe(true)
+  })
+
   it('is false for an emoji-only heading against its own untitled fallback slug', () => {
     const fallbackSlug = headingToSlug('🎉🎊', new Set())
     expect(slugIsHeadingEcho('🎉🎊', fallbackSlug)).toBe(false)

--- a/src/bundled-plugins/memory/slug.ts
+++ b/src/bundled-plugins/memory/slug.ts
@@ -21,13 +21,19 @@ export function headingToSlug(heading: string, existingSlugs: Set<string>): stri
 }
 
 // True only when `slug` is a clean kebab echo of `heading` (the readable form
-// adds nothing the slug doesn't). A heading with no ASCII/kebab form (all-CJK,
-// emoji, pure punctuation) normalizes to empty and `headingToSlug` substitutes a
-// deterministic `untitled-<hash>`; a shard carrying exactly that fallback slug
-// would satisfy the round-trip equality and wrongly collapse away the only
-// human-readable name, so an empty normalization is never an echo.
+// adds nothing the slug doesn't). `headingToSlug` maps every non-ASCII letter,
+// ideograph, or symbol to `-` (or to an `untitled-<hash>` when nothing survives),
+// so a heading like `한글 memo` slugifies to `memo` and an all-CJK/emoji heading to
+// the fallback — collapsing either would drop the only human-readable name. Guard
+// by requiring the diacritic-folded heading to consist solely of ASCII
+// alphanumerics and separators/punctuation; any surviving CJK/emoji/symbol means
+// normalization discarded content, so it is never an echo. (Diacritics are
+// transliterated, not dropped — `café` → `cafe` stays a legitimate echo.)
+const ECHO_SAFE_HEADING = /^[A-Za-z0-9\s\p{P}]*$/u
+
 export function slugIsHeadingEcho(heading: string, slug: string): boolean {
-  if (normalizeHeading(heading).length === 0) {
+  const folded = heading.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+  if (!ECHO_SAFE_HEADING.test(folded)) {
     return false
   }
   return headingToSlug(heading, new Set<string>()) === slug

--- a/src/bundled-plugins/memory/slug.ts
+++ b/src/bundled-plugins/memory/slug.ts
@@ -20,6 +20,19 @@ export function headingToSlug(heading: string, existingSlugs: Set<string>): stri
   return slug
 }
 
+// True only when `slug` is a clean kebab echo of `heading` (the readable form
+// adds nothing the slug doesn't). A heading with no ASCII/kebab form (all-CJK,
+// emoji, pure punctuation) normalizes to empty and `headingToSlug` substitutes a
+// deterministic `untitled-<hash>`; a shard carrying exactly that fallback slug
+// would satisfy the round-trip equality and wrongly collapse away the only
+// human-readable name, so an empty normalization is never an echo.
+export function slugIsHeadingEcho(heading: string, slug: string): boolean {
+  if (normalizeHeading(heading).length === 0) {
+    return false
+  }
+  return headingToSlug(heading, new Set<string>()) === slug
+}
+
 function normalizeHeading(heading: string): string {
   let normalized = heading.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
 


### PR DESCRIPTION
## Background

The per-turn memory injection renders a topic-index line as heading + slug
at two sites: `renderRetrievedMemorySection` (vector retrieval) and
`renderTopicIndexMemorySection` (channel index). When the heading is just a
title-cased echo of the slug — "PR review checkout workflow" maps to
`pr-review-checkout-workflow` — the two tokens carry identical information.
The heading is dead weight on a line that rides every message turn and is
uncacheable in vector mode.

## Summary

A new `topicIndexEntry(heading, slug)` helper shared by both render sites
calls `headingToSlug(heading)` and compares the result to the slug at
render time. If they match, only the slug is emitted:

```
- `pr-review-checkout-workflow`
```

If they diverge, both are kept:

```
- GitHub API label management in the agent environment `gh-api-labels-array-syntax`
```

Non-Latin headings (e.g. Korean) can never echo their ASCII-only slug, so
their readable form is always preserved. The `headingToSlug` round-trip is
the canonical rule — no separate exception list.

## What this does NOT do

- Does not change the system-prompt (non-vector) `renderSection` path;
  topic headings there are untouched.
- Does not modify dreaming subagent output, shard frontmatter, or slug
  generation.
- Does not affect the `_(recent observation)_` branch of
  `renderRetrievedMemorySection`.
- Does not change how headings are stored; this is purely a render-time
  decision.

## Review notes

The load-bearing invariant: `topicIndexEntry(h, s)` returns the slug alone
when `headingToSlug(h, new Set()) === s`; otherwise it returns both heading
and slug. Tests cover the echo-collapse case (slug only), a divergent-heading
case (both kept), and a Korean heading (both kept because the ASCII slug can
never match the Hangul heading).

Checks clean: typecheck, lint, format. 52 tests pass, including new cases
in load-memory.test.ts and updated expectations in index-vector.test.ts.