### PR TITLE
fix(channels): keep typing alive during long tool-less replies

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5799,6 +5799,76 @@ describe('ChannelRouter typing indicator', () => {
     await draining
   })
 
+  test('a streamed text_delta resets the heartbeat clock so a long tool-less reply keeps typing alive', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { nowRef, logs })
+    const phases: Array<'tick' | 'stop'> = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+
+    await router.route(inbound({ text: 'write me a long essay' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // given: the model is streaming text (no tools) right at the cap edge
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS - 1
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'hello' } })
+    // when: we step past the original cap; the timer must NOT trip
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS + 100
+    await router.__testing!.fireTypingInterval(KEY)
+
+    // then: still active, still ticking, no cap warning logged
+    expect(router.__testing!.isTypingActive(KEY)).toBe(true)
+    expect(phases.at(-1)).toBe('tick')
+    expect(logs.some((m) => m.includes('typing indicator paused'))).toBe(false)
+
+    releasePrompt!()
+    await draining
+  })
+
+  test('a message_update that is not a text/thinking delta does NOT reset the cap', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    const phases: Array<'tick' | 'stop'> = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+
+    await router.route(inbound({ text: 'tool-call only turn' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // given: only a toolcall_delta arrives at the cap edge (not a signal of life)
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS - 1
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'toolcall_delta', delta: '{}' } })
+    // when: we step past the cap
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS + 100
+    await router.__testing!.fireTypingInterval(KEY)
+
+    // then: the cap tripped — the toolcall_delta did not refresh it
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+    expect(phases).toEqual(['tick', 'stop'])
+
+    releasePrompt!()
+    await draining
+  })
+
   test('cap still fires after MAX_TYPING_HEARTBEAT_MS of pure silence (no tool events)', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1000 }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5835,6 +5835,42 @@ describe('ChannelRouter typing indicator', () => {
     await draining
   })
 
+  test('a streamed thinking_delta resets the heartbeat clock so a long thinking phase keeps typing alive', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { nowRef, logs })
+    const phases: Array<'tick' | 'stop'> = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+
+    await router.route(inbound({ text: 'reason about this hard problem' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // given: the model is streaming extended thinking (no text, no tools) at the cap edge
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS - 1
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'thinking_delta', delta: 'hmm' } })
+    // when: we step past the original cap; the timer must NOT trip
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS + 100
+    await router.__testing!.fireTypingInterval(KEY)
+
+    // then: still active, still ticking, no cap warning logged
+    expect(router.__testing!.isTypingActive(KEY)).toBe(true)
+    expect(phases.at(-1)).toBe('tick')
+    expect(logs.some((m) => m.includes('typing indicator paused'))).toBe(false)
+
+    releasePrompt!()
+    await draining
+  })
+
   test('a message_update that is not a text/thinking delta does NOT reset the cap', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1000 }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -111,13 +111,18 @@ export const TYPING_HEARTBEAT_MS = 8000
 // turns a temporary status into a permanent-looking artifact.
 //
 // The cap is measured from `live.typingStartedAt`, which is refreshed by
-// two signals of life (see `bumpTypingActivity`):
+// these signals of life (see `bumpTypingActivity`):
 //   1. Each new `drain()` iteration (a new turn is starting).
 //   2. Each `tool_execution_end` from the agent session (a tool just
 //      completed — the prompt is progressing, not stuck).
-// A 2-minute bash command that emits no intermediate events still trips
-// the cap, but a chatty agent running long tools stays under it
-// indefinitely. The cap exists to catch *silence*, not duration.
+//   3. Each streaming token (`message_update` carrying a `text_delta` or
+//      `thinking_delta`) — the model is actively generating, even on a
+//      pure-text reply that calls no tools.
+// Signal 3 is what keeps a long conversational reply (no tool calls, just
+// minutes of streamed text or extended thinking) under the cap: without it,
+// such a turn emits no `tool_execution_end` and the indicator was paused
+// mid-generation. A genuinely stuck model call — no tokens, no tools — still
+// trips the cap. The cap exists to catch *silence*, not duration.
 export const MAX_TYPING_HEARTBEAT_MS = 2 * 60 * 1000
 
 // Idle GC: a LiveSession whose `lastInboundAt` is older than
@@ -1888,8 +1893,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const subscribeTypingActivity = (session: AgentSession, live: LiveSession): (() => void) => {
     return session.subscribe((event) => {
-      if (event.type !== 'tool_execution_end') return
-      bumpTypingActivity(live)
+      if (event.type === 'tool_execution_end') {
+        bumpTypingActivity(live)
+        return
+      }
+      if (event.type !== 'message_update') return
+      const streamed = event.assistantMessageEvent.type
+      if (streamed === 'text_delta' || streamed === 'thinking_delta') {
+        bumpTypingActivity(live)
+      }
     })
   }
 


### PR DESCRIPTION
## Background

The Discord (and Telegram) "typing…" indicator disappeared mid-reply on long turns, making the agent look frozen while it was still generating.

The root cause is the typing-heartbeat **silence cap**, `MAX_TYPING_HEARTBEAT_MS` (2 min) in `src/channels/router.ts`. The router re-fires the platform typing indicator every 8s, but it stops re-arming once `live.typingStartedAt` is older than the cap. That clock was refreshed by only two "signals of life":

1. each new `drain()` iteration (a new turn starting), and
2. each `tool_execution_end` (a tool just completed).

A turn that produces a **long, tool-less reply** — minutes of streamed text, or extended thinking, with no tool calls — emits neither signal. The cap trips at 2 minutes, the heartbeat stops, and the indicator vanishes even though the model is actively streaming. Since Discord's native indicator self-expires at ~10s, once the heartbeat stops the "typing…" is gone within seconds.

## Summary

Add a third signal of life: streamed-token activity. `subscribeTypingActivity` now also bumps the clock on a `message_update` event whose `assistantMessageEvent.type` is `text_delta` or `thinking_delta` — i.e. the model is actively emitting tokens.

- **Why `text_delta`/`thinking_delta` and not all `message_update`:** `message_update` also carries `toolcall_start`/`toolcall_delta` and lifecycle sub-events. Gating on the two streaming-content deltas matches the existing upstream filter in `forwardSessionEvents` (`src/server/index.ts`) and avoids bumping on non-generation noise. `thinking_delta` is included so an extended-thinking phase before any text also counts as progress.
- **Why keep the cap at all:** the cap's purpose is to catch *silence* (a genuinely stuck model call — no tokens, no tools — or an agent that never yields), not to bound duration. A stuck call still emits no deltas, so it still trips the cap as before. The fix only prevents the cap from firing while the model is demonstrably still working.

## What this does NOT do

- Does not change `TYPING_HEARTBEAT_MS` (8s re-fire cadence) or `MAX_TYPING_HEARTBEAT_MS` (2-min cap value).
- Does not touch any adapter (`discord-bot`, `telegram-bot`, `slack-bot`); the fix is entirely in the shared router layer, so all adapters benefit.
- Does not resurrect typing after the cap has already tripped, and does not keep typing alive for a truly silent/stuck turn.

## Review notes

- Load-bearing change: `subscribeTypingActivity` in `src/channels/router.ts`, and the updated rationale comment on `MAX_TYPING_HEARTBEAT_MS`.
- New tests in `src/channels/router.test.ts`:
  - a `text_delta` at the cap edge keeps typing active past the original cap;
  - a non-content `message_update` (`toolcall_delta`) does **not** reset the cap (so the silence-detection guarantee is preserved).
- All existing typing-indicator tests still pass; `typecheck`, `lint`, and `format` are clean.