### PR TITLE
fix(hostd,tests): native Windows test suite support

### DIFF
--- a/src/agent/todo/scope.test.ts
+++ b/src/agent/todo/scope.test.ts
@@ -25,7 +25,7 @@ describe('resolveTodoScope', () => {
       chat: 'C456',
       thread: '1700000000.0001',
     })
-    expect(scope).toEqual({ kind: 'channel', key: 'channel/sslack-bot:sT123:sC456:s1700000000.0001' })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/sslack-bot,sT123,sC456,s1700000000.0001' })
   })
 
   test('channel with null thread uses the distinct null-thread tag', () => {
@@ -36,7 +36,7 @@ describe('resolveTodoScope', () => {
       chat: 'C1',
       thread: null,
     })
-    expect(scope).toEqual({ kind: 'channel', key: 'channel/sdiscord-bot:sG1:sC1:n' })
+    expect(scope).toEqual({ kind: 'channel', key: 'channel/sdiscord-bot,sG1,sC1,n' })
   })
 
   test('channel ids with path-unsafe characters are encoded, not escaping the todo dir', () => {

--- a/src/agent/todo/scope.ts
+++ b/src/agent/todo/scope.ts
@@ -51,6 +51,8 @@ export function resolveTodoScope(origin: SessionOrigin): TodoScope | null {
   }
 }
 
+const CHANNEL_SCOPE_SEPARATOR = ','
+
 function channelScopeKey(origin: { adapter: string; workspace: string; chat: string; thread: string | null }): string {
   const parts = [
     encodeComponent(origin.adapter),
@@ -58,7 +60,7 @@ function channelScopeKey(origin: { adapter: string; workspace: string; chat: str
     encodeComponent(origin.chat),
     encodeComponent(origin.thread),
   ]
-  return `channel/${parts.join(':')}`
+  return `channel/${parts.join(CHANNEL_SCOPE_SEPARATOR)}`
 }
 
 // Encode one scope component injectively. Every component is emitted as a
@@ -69,7 +71,7 @@ function channelScopeKey(origin: { adapter: string; workspace: string; chat: str
 // confused: a null thread vs a literal "n" string, an empty string vs a
 // literal "_empty" string, and any value vs another whose unsafe chars happen
 // to map together. `encodeURIComponent` is itself injective and never emits
-// `/` or `:`, so the joined key is both a single filesystem-safe path segment
+// `/` or `,`, so the joined key is both a single filesystem-safe path segment
 // and a collision-free identity for the conversation whose todo file it names.
 function encodeComponent(value: string | null): string {
   if (value === null) return 'n'

--- a/src/agent/todo/store.test.ts
+++ b/src/agent/todo/store.test.ts
@@ -7,7 +7,7 @@ import type { TodoScope } from './scope'
 import { incompleteTodos, readTodos, type Todo, todoContentPath, writeTodos } from './store'
 
 const TUI_SCOPE: TodoScope = { kind: 'tui', key: 'tui' }
-const CHANNEL_SCOPE: TodoScope = { kind: 'channel', key: 'channel/slack-bot:T1:C1:_root' }
+const CHANNEL_SCOPE: TodoScope = { kind: 'channel', key: 'channel/slack-bot,T1,C1,_root' }
 
 let agentDir: string
 
@@ -108,8 +108,8 @@ describe('todoContentPath traversal guard', () => {
   })
 
   test('accepts a normal nested key', () => {
-    const path = todoContentPath(agentDir, { kind: 'channel', key: 'channel/sslack:sw:sc:n' })
-    expect(path.endsWith('todo/channel/sslack:sw:sc:n.json')).toBe(true)
+    const path = todoContentPath(agentDir, { kind: 'channel', key: 'channel/sslack,sw,sc,n' })
+    expect(path.endsWith('todo/channel/sslack,sw,sc,n.json')).toBe(true)
   })
 })
 

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -128,7 +128,7 @@ describe('channel_fetch_attachment', () => {
     const result = await runTool(tool, { attachment_id: 1, filename: 'renamed.bin' })
 
     expect(calls).toEqual([{ ref: 'F1', filename: 'renamed.bin' }])
-    expect(result.details?.path?.endsWith('/renamed.bin')).toBe(true)
+    expect(result.details?.path).toMatch(/[/\\]renamed\.bin$/)
   })
 
   test('rejects hallucinated attachment ids with a valid id list', async () => {

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { devNull, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { ChannelRouter } from '@/channels/router'
@@ -267,7 +267,7 @@ describe('channel_fetch_attachment failure logging', () => {
       origin: attachmentOrigin,
       // Pointing at a path that exists as a FILE forces mkdir(recursive) to throw ENOTDIR.
       // This exercises the write-failure branch without mocking node:fs.
-      inboxDir: '/dev/null/not-a-dir',
+      inboxDir: join(devNull, 'not-a-dir'),
       logger,
     })
     await tool.execute('id', { attachment_id: 1 }, undefined, undefined, fakeCtx)

--- a/src/agent/tools/curl-impersonate.test.ts
+++ b/src/agent/tools/curl-impersonate.test.ts
@@ -3,6 +3,8 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import {
   CurlImpersonateError,
   _resetAvailabilityCacheForTest,
@@ -12,6 +14,8 @@ import {
   isCurlExitTimeout,
   isCurlImpersonateAvailable,
 } from './curl-impersonate'
+
+const onWindows = isWindows()
 
 // We can't predict the per-request random sentinel from the test, so the
 // fake binary reads it out of argv (the value following '-w') and renders
@@ -35,7 +39,8 @@ printf '%s' '${body}'
 printf '%s' "$RENDERED"
 `
 
-describe('curlImpersonate', () => {
+// POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
+describe.skipIf(onWindows)('curlImpersonate', () => {
   let scratchDir: string
   let argvFile: string
 
@@ -265,7 +270,8 @@ describe('isCurlImpersonateAvailable', () => {
     _resetAvailabilityCacheForTest()
   })
 
-  test('returns true when the binary exits 0 on --version', async () => {
+  // POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
+  test.skipIf(onWindows)('returns true when the binary exits 0 on --version', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'curl-available-test-'))
     try {
       const path = join(dir, 'fake-curl')
@@ -289,7 +295,8 @@ describe('isCurlImpersonateAvailable', () => {
     expect(available).toBe(false)
   })
 
-  test('caches the result for the life of the process', async () => {
+  // POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
+  test.skipIf(onWindows)('caches the result for the life of the process', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'curl-cache-test-'))
     try {
       const path = join(dir, 'fake-curl')

--- a/src/agent/tools/ddg.test.ts
+++ b/src/agent/tools/ddg.test.ts
@@ -3,7 +3,11 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { _setCurlBinaryForTest, fetchDdgHtml, parseDdgHtml } from './ddg'
+
+const onWindows = isWindows()
 
 const REAL_RESULT_HTML = `
 <html><body><table>
@@ -125,7 +129,8 @@ describe('parseDdgHtml', () => {
   })
 })
 
-describe('fetchDdgHtml', () => {
+// POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
+describe.skipIf(onWindows)('fetchDdgHtml', () => {
   // We test the curl-impersonate spawn path against a fake binary in a
   // tmpdir. AGENTS.md §5 prefers real implementations with controlled inputs
   // over mocks, so we hand-roll a shell script that stands in for

--- a/src/agent/tools/webfetch/fetch.test.ts
+++ b/src/agent/tools/webfetch/fetch.test.ts
@@ -3,8 +3,12 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { _resetAvailabilityCacheForTest, _setCurlBinaryForTest } from '../curl-impersonate'
 import { _setForceFallbackForTest, fetchWithLimits, normalizeUrl, parseMimeType, WebFetchError } from './fetch'
+
+const onWindows = isWindows()
 
 type FetchInput = Parameters<typeof fetch>[0]
 type FetchArgs = { url: string; init: RequestInit | undefined }
@@ -154,7 +158,8 @@ describe('fetchWithLimits — Bun.fetch fallback path', () => {
   })
 })
 
-describe('fetchWithLimits — curl-impersonate path', () => {
+// POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
+describe.skipIf(onWindows)('fetchWithLimits — curl-impersonate path', () => {
   let scratchDir: string
 
   beforeEach(() => {

--- a/src/agent/tools/websearch.test.ts
+++ b/src/agent/tools/websearch.test.ts
@@ -3,8 +3,12 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { _setCurlBinaryForTest } from './ddg'
 import { webSearchTool } from './websearch'
+
+const onWindows = isWindows()
 
 type FetchInput = Parameters<typeof fetch>[0]
 type FetchArgs = { url: string; init: RequestInit | undefined }
@@ -38,7 +42,8 @@ const MINIMAL_DDG_HTML = `
 // via _setCurlBinaryForTest, so these end-to-end tests exercise the real
 // spawn codepath plus the webSearchTool's success/error orchestration
 // without depending on a real network or a real curl_chrome136 install.
-describe('websearch tool: web (DuckDuckGo)', () => {
+// POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
+describe.skipIf(onWindows)('websearch tool: web (DuckDuckGo)', () => {
   let scratchDir: string
 
   beforeEach(() => {

--- a/src/bundled-plugins/agent-browser/index.test.ts
+++ b/src/bundled-plugins/agent-browser/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { rmSync, readFileSync } from 'node:fs'
+import { sep } from 'node:path'
 
 import { noopPermissionService } from '@/permissions'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
@@ -30,7 +31,9 @@ describe('agent-browser plugin', () => {
     const exports = await bootPlugin('/agent')
 
     expect(Date.now() - factoryStart).toBeLessThan(500)
-    expect(exports.skillsDirs).toEqual([expect.stringContaining('bundled-plugins/agent-browser/skills')])
+    expect((exports.skillsDirs ?? []).map((dir) => dir.split(sep).join('/'))).toEqual([
+      expect.stringContaining('bundled-plugins/agent-browser/skills'),
+    ])
     expect(exports.tools).toBeUndefined()
     expect(exports.hooks).toBeUndefined()
   })

--- a/src/bundled-plugins/agent-browser/shim-install.test.ts
+++ b/src/bundled-plugins/agent-browser/shim-install.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 import { resolve as resolvePath } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { installShim, type ShimFs } from './shim-install'
+
+const onWindows = isWindows()
 
 type FakeFile = { kind: 'file'; data: string; mode: number } | { kind: 'symlink'; target: string }
 
@@ -67,7 +71,8 @@ class FakeFs {
   }
 }
 
-describe('installShim', () => {
+// POSIX symlink semantics, #899.
+describe.skipIf(onWindows)('installShim', () => {
   test('replaces an upstream symlink with an absolute-target stash so the link still resolves', () => {
     const fake = new FakeFs()
     fake.files.set('/usr/local/bin/agent-browser', {

--- a/src/bundled-plugins/doc-render/index.test.ts
+++ b/src/bundled-plugins/doc-render/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 
 import { noopPermissionService } from '@/permissions'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
@@ -12,7 +12,9 @@ describe('doc-render plugin', () => {
   test('contributes the skill directory and no tools or hooks', async () => {
     const exports = await bootPlugin()
 
-    expect(exports.skillsDirs).toEqual([expect.stringContaining('bundled-plugins/doc-render/skills')])
+    expect((exports.skillsDirs ?? []).map((dir) => dir.split(sep).join('/'))).toEqual([
+      expect.stringContaining('bundled-plugins/doc-render/skills'),
+    ])
     expect(exports.tools).toBeUndefined()
     expect(exports.hooks).toBeUndefined()
   })
@@ -25,7 +27,7 @@ describe('doc-render plugin', () => {
     // The container runs from node_modules/typeclaw/src/...; the agent-relative
     // path the skill uses must end at the same file this package ships.
     expect(RENDER_SCRIPT_AGENT_RELATIVE_PATH).toBe('node_modules/typeclaw/src/bundled-plugins/doc-render/render.ts')
-    expect(renderScriptPath().endsWith('/bundled-plugins/doc-render/render.ts')).toBe(true)
+    expect(renderScriptPath()).toMatch(/[\\/]bundled-plugins[\\/]doc-render[\\/]render\.ts$/)
   })
 })
 

--- a/src/bundled-plugins/doc-render/render.test.ts
+++ b/src/bundled-plugins/doc-render/render.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { COMPILER_PACKAGE, COMPILER_VERSION, isModuleNotFound, missingCompilerGuidance } from './render'
 
@@ -36,7 +37,7 @@ describe('missingCompilerGuidance', () => {
 })
 
 describe('render script CLI', () => {
-  const scriptPath = new URL('./render.ts', import.meta.url).pathname
+  const scriptPath = fileURLToPath(new URL('./render.ts', import.meta.url))
 
   test('exits 2 with usage when args are missing', async () => {
     const proc = Bun.spawn(['bun', 'run', scriptPath], { stdout: 'pipe', stderr: 'pipe' })
@@ -69,6 +70,6 @@ describe('compiler resolution from a nested document directory', () => {
     await mkdir(docDir, { recursive: true })
 
     const resolved = Bun.resolveSync('fake-renderer', docDir)
-    expect(resolved.endsWith('/node_modules/fake-renderer/index.js')).toBe(true)
+    expect(resolved).toMatch(/[\\/]node_modules[\\/]fake-renderer[\\/]index\.js$/)
   })
 })

--- a/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, readFile, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { ensureGitAskPassHelper, resetGitAskPassHelperForTests } from './git-askpass'
+
+const onWindows = isWindows()
 
 afterEach(() => {
   resetGitAskPassHelperForTests()
@@ -14,7 +18,8 @@ async function tmpHelperPath() {
   return join(dir, 'typeclaw-git-askpass')
 }
 
-describe('ensureGitAskPassHelper', () => {
+// POSIX shell helper, #899.
+describe.skipIf(onWindows)('ensureGitAskPassHelper', () => {
   test('writes the helper and returns its path', async () => {
     const path = await tmpHelperPath()
     expect(await ensureGitAskPassHelper(path)).toBe(path)
@@ -45,7 +50,8 @@ describe('ensureGitAskPassHelper', () => {
   })
 })
 
-describe('ensureGitAskPassHelper — host-scoped behavior (executed)', () => {
+// POSIX shell helper, #899.
+describe.skipIf(onWindows)('ensureGitAskPassHelper — host-scoped behavior (executed)', () => {
   async function run(promptArg: string): Promise<{ code: number; out: string }> {
     const path = await tmpHelperPath()
     await ensureGitAskPassHelper(path)

--- a/src/bundled-plugins/guard/index.test.ts
+++ b/src/bundled-plugins/guard/index.test.ts
@@ -26,8 +26,9 @@ describe('guard plugin', () => {
 
     expect(blocked).toEqual({
       block: true,
-      reason:
-        'Guard `nonWorkspaceWrite` blocked write outside the workspace: /agent/notes.md. The free-write zone is /agent/workspace. Retry with `acknowledgeGuards.nonWorkspaceWrite: true` only if this write is intentional.',
+      reason: expect.stringMatching(
+        /Guard `nonWorkspaceWrite` blocked write outside the workspace: (?:[A-Z]:)?[\\/]agent[\\/]notes\.md\. The free-write zone is (?:[A-Z]:)?[\\/]agent[\\/]workspace\. Retry with `acknowledgeGuards\.nonWorkspaceWrite: true` only if this write is intentional\./,
+      ),
     })
     expect(acknowledged).toBeUndefined()
   })

--- a/src/bundled-plugins/guard/policies/non-workspace-write.test.ts
+++ b/src/bundled-plugins/guard/policies/non-workspace-write.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { checkNonWorkspaceWriteGuard } from './non-workspace-write'
 
 describe('non-workspace-write guard policy', () => {
@@ -32,7 +34,8 @@ describe('non-workspace-write guard policy', () => {
     expect(result).toBeUndefined()
   })
 
-  test('allows unacknowledged writes under /tmp (virtual per-session scratch)', async () => {
+  // Container scratch is the Linux /tmp namespace; Windows host path semantics are tracked in #899.
+  test.skipIf(isWindows())('allows unacknowledged writes under /tmp (virtual per-session scratch)', async () => {
     const agentDir = await makeAgentDir()
 
     const result = await checkNonWorkspaceWriteGuard({

--- a/src/bundled-plugins/memory/index-vector-retrieval.test.ts
+++ b/src/bundled-plugins/memory/index-vector-retrieval.test.ts
@@ -29,7 +29,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(agentDir, { recursive: true, force: true })
+  await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
 })
 
 describe('vector retrieval end-to-end through session.turn.start', () => {

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(agentDir, { recursive: true, force: true })
+  await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
 })
 
 describe('vector session.turn.start hook', () => {

--- a/src/bundled-plugins/tool-result-cap/cap-jsonl.test.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-jsonl.test.ts
@@ -3,7 +3,11 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSyn
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { CapJsonlReadError, capJsonlFileInPlace } from './cap-jsonl'
+
+const onWindows = isWindows()
 
 const baseOptions = {
   imageMaxBytes: 100,
@@ -219,7 +223,8 @@ describe('capJsonlFileInPlace', () => {
     expect(() => capJsonlFileInPlace(subdir, baseOptions)).toThrow(CapJsonlReadError)
   })
 
-  test('preserves the original file mode across the temp+rename rewrite', () => {
+  // chmod/file-mode is a no-op on NTFS, so mode preservation is unobservable. #899
+  test.skipIf(onWindows)('preserves the original file mode across the temp+rename rewrite', () => {
     const path = makeTmpJsonl([
       { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
       {

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -1,3 +1,5 @@
+import { basename } from 'node:path'
+
 import {
   KakaoCredentialManager,
   KakaoTalkClient as RealKakaoTalkClient,
@@ -203,7 +205,9 @@ export function createOutboundCallback(deps: {
       try {
         items = await Promise.all(
           attachments.map(async (a) => {
-            const filename = a.filename ?? a.path.split('/').pop() ?? 'file'
+            // basename (not split('/')) so a native-Windows host's backslash
+            // attachment paths still yield just the filename (issue #899).
+            const filename = a.filename ?? (basename(a.path) || 'file')
             const data = await readFile(a.path)
             return { data, filename }
           }),

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2,11 +2,16 @@ import { afterAll, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve as resolvePath } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { isWindows } from '@/shared'
 
 import { BUILTIN_COMMAND_NAMES } from './builtins'
 
 const REPO_ROOT = resolvePath(import.meta.dir, '..', '..')
 const CLI_ENTRY = join(REPO_ROOT, 'src', 'cli', 'index.ts')
+const PLUGIN_IMPORT = pathToFileURL(join(REPO_ROOT, 'src', 'plugin', 'index.ts')).href
+const onWindows = isWindows()
 const tmpDirs: string[] = []
 
 afterAll(async () => {
@@ -39,7 +44,7 @@ async function runCli(args: string[], cwd: string): Promise<{ stdout: string; st
 }
 
 const ECHO_PLUGIN = `
-import { definePlugin, defineCommand } from '${join(REPO_ROOT, 'src', 'plugin')}'
+import { definePlugin, defineCommand } from '${PLUGIN_IMPORT}'
 import { z } from 'zod'
 
 export default definePlugin({
@@ -82,15 +87,18 @@ describe('BUILTIN_COMMAND_NAMES exposure', () => {
 // shared state between tests — so `.concurrent` runs them on the runner's
 // worker pool instead of serially. The 6 host-stage subprocess tests below
 // drop from ~1.8s sequential to ~0.4s in parallel.
+// Spawns POSIX shell plugin-command shim, #899.
+const pluginCommandTest = onWindows ? test.skip : test.concurrent
+
 describe('typeclaw <plugin-command> on host stage', () => {
-  test.concurrent('QA-5 end-to-end: dispatches a host command via CLI entrypoint', async () => {
+  pluginCommandTest('QA-5 end-to-end: dispatches a host command via CLI entrypoint', async () => {
     const dir = await mkAgent(ECHO_PLUGIN)
     const { stdout, code } = await runCli(['echo-host', '--msg=hello'], dir)
     expect(code).toBe(0)
     expect(stdout).toContain('got: hello')
   })
 
-  test.concurrent('exits 2 with stderr message when required arg is missing', async () => {
+  pluginCommandTest('exits 2 with stderr message when required arg is missing', async () => {
     const dir = await mkAgent(ECHO_PLUGIN)
     const { stderr, code } = await runCli(['echo-host'], dir)
     expect(code).toBe(2)
@@ -105,7 +113,7 @@ describe('typeclaw <plugin-command> on host stage', () => {
 })
 
 describe('typeclaw --help on host stage', () => {
-  test.concurrent('QA-16: appends a Plugin commands section listing discovered commands', async () => {
+  pluginCommandTest('QA-16: appends a Plugin commands section listing discovered commands', async () => {
     const dir = await mkAgent(ECHO_PLUGIN)
     const { stdout, code } = await runCli(['--help'], dir)
     expect(code).toBe(0)

--- a/src/cli/mount.test.ts
+++ b/src/cli/mount.test.ts
@@ -8,6 +8,7 @@ import { formatMountList } from './mount'
 const CLI_ENTRY = join(import.meta.dir, 'index.ts')
 const ANSI_SEQUENCE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[a-zA-Z]`, 'g')
 const stripAnsi = (s: string): string => s.replace(ANSI_SEQUENCE, '')
+const normalizePath = (s: string): string => s.split(/[\\/]/).join('/')
 
 describe('typeclaw mount CLI', () => {
   let cwd: string
@@ -100,10 +101,10 @@ describe('typeclaw mount CLI', () => {
     expect(parsed.mounts).toHaveLength(1)
     expect(parsed.mounts[0]).toMatchObject({
       name: 'downloads',
-      resolvedPath: resolvedDownloads,
       targetPath: '/agent/mounts/downloads',
       status: 'ok',
     })
+    expect(normalizePath(parsed.mounts[0]!.resolvedPath)).toBe(normalizePath(resolvedDownloads))
   })
 
   test('remove deletes the mount and tells the user to restart', async () => {

--- a/src/cli/plugin-commands.test.ts
+++ b/src/cli/plugin-commands.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve as resolvePath } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { renderCommandHelp, renderPluginCommandsSection } from './plugin-command-help'
 import { discoverCommands, resolveAgentDir } from './plugin-commands'
@@ -9,6 +10,7 @@ import { dispatchPluginCommand } from './plugin-commands-dispatch'
 
 const tmpDirs: string[] = []
 const REPO_ROOT = resolvePath(import.meta.dir, '..', '..')
+const PLUGIN_IMPORT = pathToFileURL(join(import.meta.dir, '..', 'plugin', 'index.ts')).href
 
 afterAll(async () => {
   await Promise.all(tmpDirs.map((d) => rm(d, { recursive: true, force: true })))
@@ -31,7 +33,7 @@ async function mkTempAgent(plugin?: string): Promise<string> {
 }
 
 const HOST_ECHO_PLUGIN = `
-import { definePlugin, defineCommand } from '${join(import.meta.dir, '..', 'plugin')}'
+import { definePlugin, defineCommand } from '${PLUGIN_IMPORT}'
 import { z } from 'zod'
 
 export default definePlugin({
@@ -53,7 +55,7 @@ export default definePlugin({
 `
 
 const EITHER_AGENTDIR_PLUGIN = `
-import { definePlugin, defineCommand } from '${join(import.meta.dir, '..', 'plugin')}'
+import { definePlugin, defineCommand } from '${PLUGIN_IMPORT}'
 
 export default definePlugin({
   commands: {
@@ -73,7 +75,7 @@ export default definePlugin({
 `
 
 const CONTAINER_ONLY_PLUGIN = `
-import { definePlugin, defineCommand } from '${join(import.meta.dir, '..', 'plugin')}'
+import { definePlugin, defineCommand } from '${PLUGIN_IMPORT}'
 
 export default definePlugin({
   commands: {
@@ -313,7 +315,7 @@ describe('dispatchPluginCommand', () => {
 describe('renderCommandHelp', () => {
   test('renders default values and required flags', async () => {
     const dir = await mkTempAgent(`
-import { definePlugin, defineCommand } from '${join(import.meta.dir, '..', 'plugin')}'
+import { definePlugin, defineCommand } from '${PLUGIN_IMPORT}'
 import { z } from 'zod'
 
 export default definePlugin({
@@ -347,7 +349,7 @@ export default definePlugin({
 
   test('renders "(no options)" for commands without args', async () => {
     const dir = await mkTempAgent(`
-import { definePlugin, defineCommand } from '${join(import.meta.dir, '..', 'plugin')}'
+import { definePlugin, defineCommand } from '${PLUGIN_IMPORT}'
 
 export default definePlugin({
   commands: {

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
+import { isWindows } from '@/shared'
 
 import {
   buildConfigMigrationCommitMessage,
@@ -30,6 +31,7 @@ import {
 import { isModelRef, type ModelRef } from './providers'
 
 const isRoot = typeof process.getuid === 'function' && process.getuid() === 0
+const onWindows = isWindows()
 
 const VALID_MODEL = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo'
 const VALID_MODEL_2 = 'openai/gpt-5.4-nano'
@@ -1596,7 +1598,8 @@ describe('validateMount', () => {
     }
   })
 
-  test.skipIf(isRoot)('fails when readOnly:false but path is read-only on disk', async () => {
+  // chmod read-only semantics are not meaningful on Windows; see #899.
+  test.skipIf(isRoot || onWindows)('fails when readOnly:false but path is read-only on disk', async () => {
     const dir = join(cwd, 'ro')
     await mkdir(dir)
     await chmod(dir, 0o555)
@@ -1623,7 +1626,8 @@ describe('validateMount', () => {
     }
   })
 
-  test.skipIf(isRoot)('fails when path is unreadable', async () => {
+  // chmod unreadable semantics are not meaningful on Windows; see #899.
+  test.skipIf(isRoot || onWindows)('fails when path is unreadable', async () => {
     const dir = join(cwd, 'noread')
     await mkdir(dir)
     await chmod(dir, 0o000)
@@ -1645,20 +1649,23 @@ describe('expandMountPath', () => {
   })
 
   test('resolves relative paths against cwd', () => {
-    expect(expandMountPath('./rel', '/cwd')).toBe('/cwd/rel')
-    expect(expandMountPath('rel', '/cwd')).toBe('/cwd/rel')
+    const cwd = join(tmpdir(), 'typeclaw-cwd')
+    expect(expandMountPath('./rel', cwd)).toBe(join(cwd, 'rel'))
+    expect(expandMountPath('rel', cwd)).toBe(join(cwd, 'rel'))
   })
 
   test('expands ~ to homedir', () => {
-    const expanded = expandMountPath('~/notes', '/cwd')
-    expect(expanded.endsWith('/notes')).toBe(true)
-    expect(expanded.startsWith('/cwd')).toBe(false)
+    const cwd = join(tmpdir(), 'typeclaw-cwd')
+    const expanded = expandMountPath('~/notes', cwd)
+    expect(expanded).toBe(join(homedir(), 'notes'))
+    expect(expanded.startsWith(cwd)).toBe(false)
   })
 
   test('expands bare ~ to homedir', () => {
-    const expanded = expandMountPath('~', '/cwd')
-    expect(expanded.startsWith('/cwd')).toBe(false)
-    expect(expanded.length).toBeGreaterThan(0)
+    const cwd = join(tmpdir(), 'typeclaw-cwd')
+    const expanded = expandMountPath('~', cwd)
+    expect(expanded).toBe(homedir())
+    expect(expanded.startsWith(cwd)).toBe(false)
   })
 })
 

--- a/src/dreams/git.test.ts
+++ b/src/dreams/git.test.ts
@@ -7,6 +7,8 @@ import { parseLogOutput, readDreamCommitLog, readDreamCommitShow, resolveGitRepo
 
 let repo: string
 
+const normalizePath = (s: string): string => s.split(/[\\/]/).join('/')
+
 async function git(args: string[], cwd: string): Promise<void> {
   const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
   const code = await proc.exited
@@ -41,7 +43,7 @@ describe('resolveGitRepo', () => {
     expect(res.ok).toBe(true)
     // git canonicalizes the root (on macOS /var → /private/var), so assert the
     // resolved root is the git toplevel rather than byte-equal to the tmp path.
-    if (res.ok) expect(res.root.endsWith(repo)).toBe(true)
+    if (res.ok) expect(normalizePath(res.root).endsWith(normalizePath(repo))).toBe(true)
   })
 
   it('reports not-a-repo outside any git tree', async () => {

--- a/src/hostd/client.test.ts
+++ b/src/hostd/client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { createServer, type Server, type Socket as NetSocket } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -22,7 +23,41 @@ afterEach(async () => {
   await rm(home, { recursive: true, force: true })
 })
 
-type State = { buf: string }
+async function listen(server: Server, path: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => {
+      server.off('error', onError)
+      reject(error)
+    }
+    server.once('error', onError)
+    server.listen(path, () => {
+      server.off('error', onError)
+      resolve()
+    })
+  })
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+}
+
+async function startSocketServer(onRequest: (socket: NetSocket, req: Request) => void): Promise<Server> {
+  await mkdir(join(home, 'run'), { recursive: true })
+
+  const server = createServer((socket) => {
+    let buf = ''
+    socket.on('data', (chunk: Buffer) => {
+      buf += chunk.toString('utf8')
+      const newline = buf.indexOf('\n')
+      if (newline < 0) return
+      const line = buf.slice(0, newline)
+      onRequest(socket, JSON.parse(line) as Request)
+    })
+    socket.on('error', () => {})
+  })
+  await listen(server, socketPath())
+  return server
+}
 
 describe('isDaemonReachable', () => {
   test('returns false when no socket file exists', async () => {
@@ -36,29 +71,12 @@ describe('send', () => {
     expect(reply.ok).toBe(false)
   })
 
-  test('roundtrips a register request through a real Unix socket server', async () => {
-    const { mkdir } = await import('node:fs/promises')
-    await mkdir(join(home, 'run'), { recursive: true })
-
+  test('roundtrips a register request through a real local socket server', async () => {
     let received: Request | null = null
-    const listener = Bun.listen<State>({
-      unix: socketPath(),
-      socket: {
-        open: (s) => {
-          s.data = { buf: '' }
-        },
-        data: (s, chunk) => {
-          s.data.buf += chunk.toString('utf8')
-          const newline = s.data.buf.indexOf('\n')
-          if (newline < 0) return
-          const line = s.data.buf.slice(0, newline)
-          received = JSON.parse(line) as Request
-          s.write(`${JSON.stringify({ ok: true, result: { echoed: received } })}\n`)
-          s.end()
-        },
-        close: () => {},
-        error: () => {},
-      },
+    const listener = await startSocketServer((socket, req) => {
+      received = req
+      socket.write(`${JSON.stringify({ ok: true, result: { echoed: received } })}\n`)
+      socket.end()
     })
     try {
       const reply = await send({ kind: 'register', containerName: 'coder', cwd: '/tmp/x' })
@@ -70,60 +88,31 @@ describe('send', () => {
         cwd: '/tmp/x',
       })
     } finally {
-      listener.stop(true)
+      await closeServer(listener)
     }
   })
 
   test('times out if the daemon never responds', async () => {
-    const { mkdir } = await import('node:fs/promises')
-    await mkdir(join(home, 'run'), { recursive: true })
-
-    const listener = Bun.listen<State>({
-      unix: socketPath(),
-      socket: {
-        open: (s) => {
-          s.data = { buf: '' }
-        },
-        data: () => {},
-        close: () => {},
-        error: () => {},
-      },
-    })
+    const listener = await startSocketServer(() => {})
     try {
       const reply = await send({ kind: 'list' }, { timeoutMs: 50 })
       expect(reply.ok).toBe(false)
       if (reply.ok) return
       expect(reply.reason).toContain('timeout')
     } finally {
-      listener.stop(true)
+      await closeServer(listener)
     }
   })
 
   test('isDaemonReachable returns true when the daemon answers list', async () => {
-    const { mkdir } = await import('node:fs/promises')
-    await mkdir(join(home, 'run'), { recursive: true })
-
-    const listener = Bun.listen<State>({
-      unix: socketPath(),
-      socket: {
-        open: (s) => {
-          s.data = { buf: '' }
-        },
-        data: (s, chunk) => {
-          s.data.buf += chunk.toString('utf8')
-          const newline = s.data.buf.indexOf('\n')
-          if (newline < 0) return
-          s.write(`${JSON.stringify({ ok: true, result: { registrations: [] } })}\n`)
-          s.end()
-        },
-        close: () => {},
-        error: () => {},
-      },
+    const listener = await startSocketServer((socket) => {
+      socket.write(`${JSON.stringify({ ok: true, result: { registrations: [] } })}\n`)
+      socket.end()
     })
     try {
       expect(await isDaemonReachable(500)).toBe(true)
     } finally {
-      listener.stop(true)
+      await closeServer(listener)
     }
   })
 })

--- a/src/hostd/client.ts
+++ b/src/hostd/client.ts
@@ -1,16 +1,21 @@
 import { existsSync } from 'node:fs'
+import { connect, type Socket as NetSocket } from 'node:net'
 
-import type { Socket } from 'bun'
+import { isWindows } from '@/shared'
 
 import { socketPath } from './paths'
 import type { Request, Response } from './protocol'
 
 const DEFAULT_TIMEOUT_MS = 3_000
 
-export async function isDaemonReachable(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<boolean> {
-  if (!existsSync(socketPath())) return false
+export async function isDaemonReachable(
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  opts: Pick<SendOptions, 'socket'> = {},
+): Promise<boolean> {
+  const path = opts.socket ?? socketPath()
+  if (!isWindows() && !existsSync(path)) return false
   try {
-    const reply = await send({ kind: 'list' }, { timeoutMs })
+    const reply = await send({ kind: 'list' }, { timeoutMs, socket: path })
     return reply.ok
   } catch {
     return false
@@ -58,56 +63,47 @@ export async function send(req: Request, opts: SendOptions = {}): Promise<Respon
   const path = opts.socket ?? socketPath()
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
 
-  type State = { buf: string; resolve: (r: Response) => void }
-  const state: State = {
-    buf: '',
-    resolve: () => {},
-  }
+  return new Promise<Response>((resolve) => {
+    let buf = ''
+    let settled = false
+    let sock: NetSocket | null = null
+    let timer: ReturnType<typeof setTimeout> | null = null
 
-  const replyPromise = new Promise<Response>((resolve) => {
-    state.resolve = resolve
-  })
+    const finish = (response: Response, destroy = false): void => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      if (sock) {
+        try {
+          if (destroy) sock.destroy()
+          else sock.end()
+        } catch {}
+      }
+      resolve(response)
+    }
 
-  let sock: Socket<State>
-  try {
-    sock = await Bun.connect<State>({
-      unix: path,
-      socket: {
-        data: (s, chunk) => {
-          s.data.buf += chunk.toString('utf8')
-          const newline = s.data.buf.indexOf('\n')
-          if (newline < 0) return
-          const line = s.data.buf.slice(0, newline)
-          try {
-            const parsed = JSON.parse(line) as Response
-            s.data.resolve(parsed)
-          } catch {
-            s.data.resolve({ ok: false, reason: 'invalid response from daemon' })
-          }
-          s.end()
-        },
-        close: () => {},
-        error: () => {
-          state.resolve({ ok: false, reason: 'socket error' })
-        },
-      },
+    timer = setTimeout(() => finish({ ok: false, reason: `daemon ack timeout after ${timeoutMs}ms` }, true), timeoutMs)
+    sock = connect(path)
+    sock.on('connect', () => {
+      try {
+        sock?.write(`${JSON.stringify(req)}\n`)
+      } catch (error) {
+        finish({ ok: false, reason: error instanceof Error ? error.message : String(error) }, true)
+      }
     })
-  } catch (error) {
-    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
-  }
-  sock.data = state
-  sock.write(`${JSON.stringify(req)}\n`)
-
-  let timer: ReturnType<typeof setTimeout> | null = null
-  const timeoutPromise = new Promise<Response>((resolve) => {
-    timer = setTimeout(() => resolve({ ok: false, reason: `daemon ack timeout after ${timeoutMs}ms` }), timeoutMs)
+    sock.on('data', (chunk: Buffer) => {
+      buf += chunk.toString('utf8')
+      const newline = buf.indexOf('\n')
+      if (newline < 0) return
+      const line = buf.slice(0, newline)
+      try {
+        finish(JSON.parse(line) as Response)
+      } catch {
+        finish({ ok: false, reason: 'invalid response from daemon' }, true)
+      }
+    })
+    sock.on('error', (error) => {
+      finish({ ok: false, reason: error instanceof Error ? error.message : String(error) }, true)
+    })
   })
-  try {
-    return await Promise.race([replyPromise, timeoutPromise])
-  } finally {
-    if (timer) clearTimeout(timer)
-    try {
-      sock.end()
-    } catch {}
-  }
 }

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -6,9 +6,10 @@ import { join } from 'node:path'
 
 import type { DockerExec } from '@/container'
 import type { KakaoChannelBlock } from '@/secrets/schema'
+import { isWindows } from '@/shared'
 import { expectStable, waitFor } from '@/test-helpers/wait-for'
 
-import { send, sendHttp } from './client'
+import { isDaemonReachable, send, sendHttp } from './client'
 import { startDaemon, type Daemon, type PortbrokerCallbacks, type PortbrokerStartInput } from './daemon'
 import type { KakaoRenewalCallbacks, KakaoRenewalStartInput } from './kakao-renewal-manager'
 import { registrationFilePath, registrationsDir, socketPath } from './paths'
@@ -61,6 +62,19 @@ function kakaoBlock(accountId: string): KakaoChannelBlock {
       },
     },
   }
+}
+
+async function expectDaemonEndpointListening(): Promise<void> {
+  if (isWindows()) {
+    expect(await isDaemonReachable(500)).toBe(true)
+    return
+  }
+  expect(existsSync(socketPath())).toBe(true)
+}
+
+async function daemonEndpointGone(): Promise<boolean> {
+  if (isWindows()) return !(await isDaemonReachable(50))
+  return !existsSync(socketPath())
 }
 
 describe('startDaemon', () => {
@@ -516,21 +530,21 @@ describe('startDaemon', () => {
         onShutdownCalls += 1
       },
     })
-    expect(existsSync(socketPath())).toBe(true)
+    await expectDaemonEndpointListening()
 
     const ack = await send({ kind: 'shutdown' })
     expect(ack.ok).toBe(true)
 
     const start = Date.now()
     while (Date.now() - start < 1500) {
-      if (!existsSync(socketPath()) && onShutdownCalls === 1) {
+      if ((await daemonEndpointGone()) && onShutdownCalls === 1) {
         daemon = null
         return
       }
       await new Promise((resolve) => setTimeout(resolve, 30))
     }
     throw new Error(
-      `shutdown did not complete in time (socket exists=${existsSync(socketPath())}, onShutdown calls=${onShutdownCalls})`,
+      `shutdown did not complete in time (endpoint gone=${await daemonEndpointGone()}, onShutdown calls=${onShutdownCalls})`,
     )
   })
 
@@ -540,7 +554,7 @@ describe('startDaemon', () => {
 
     const start = Date.now()
     while (Date.now() - start < 1500) {
-      if (!existsSync(socketPath())) {
+      if (await daemonEndpointGone()) {
         daemon = null
         return
       }

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -1,14 +1,14 @@
 import { existsSync } from 'node:fs'
 import { chmod, readdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { createServer, type Server, type Socket as NetSocket } from 'node:net'
 import { join } from 'node:path'
-
-import type { Socket, UnixSocketListener } from 'bun'
 
 import type { PortForward } from '@/config'
 import { defaultDockerExec, type DockerExec } from '@/container'
 import type { PortForwardEvent } from '@/portbroker'
 import { kakaoChannelBlockSchema, lineChannelBlockSchema } from '@/secrets/schema'
 import { SecretsBackend } from '@/secrets/storage'
+import { isWindows } from '@/shared'
 
 import { isDaemonReachable } from './client'
 import type { KakaoRenewalCallbacks, KakaoRenewalLogEvent } from './kakao-renewal-manager'
@@ -121,8 +121,6 @@ const MAX_HTTP_REQUEST_BYTES = 64 * 1024
 // it's already in use by some other local service.
 const STABLE_HTTP_PORT = 8974
 
-type ServerState = { buf: string }
-
 function json(response: RpcResponse, status = 200): globalThis.Response {
   return new Response(JSON.stringify(response), {
     status,
@@ -208,12 +206,47 @@ function stringifyError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+async function listenOnSocket(server: Server, path: string, onWindows: boolean): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => {
+      server.off('error', onError)
+      const code = (error as Error & { code?: unknown }).code
+      if (onWindows && code === 'EADDRINUSE') {
+        reject(new Error(`another typeclaw host daemon is already listening at ${path}`))
+        return
+      }
+      reject(error)
+    }
+    server.once('error', onError)
+    server.listen(path, () => {
+      server.off('error', onError)
+      resolve()
+    })
+  })
+}
+
+async function closeSocketServer(server: Server, sockets: Set<NetSocket>): Promise<void> {
+  await new Promise<void>((resolve) => {
+    try {
+      server.close(() => resolve())
+    } catch {
+      resolve()
+    }
+    for (const socket of sockets) {
+      try {
+        socket.destroy()
+      } catch {}
+    }
+  })
+}
+
 export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   await ensureDirs()
   const path = opts.socket ?? socketPath()
+  const onWindows = isWindows()
 
-  if (existsSync(path)) {
-    if (await isDaemonReachable(500)) {
+  if (!onWindows && existsSync(path)) {
+    if (await isDaemonReachable(500, { socket: path })) {
       throw new Error(`another typeclaw host daemon is already listening at ${path}`)
     }
     try {
@@ -488,37 +521,37 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     }
   }
 
-  const respond = (sock: Socket<ServerState>, response: RpcResponse): void => {
+  const respond = (socket: NetSocket, response: RpcResponse): void => {
     try {
-      sock.write(`${JSON.stringify(response)}\n`)
+      socket.write(`${JSON.stringify(response)}\n`)
     } catch {}
     try {
-      sock.end()
+      socket.end()
     } catch {}
   }
 
-  const handleData = (sock: Socket<ServerState>, chunk: Buffer): void => {
-    sock.data.buf += chunk.toString('utf8')
-    if (sock.data.buf.length > MAX_REQUEST_BUFFER_BYTES) {
-      respond(sock, { ok: false, reason: 'request exceeds buffer limit' })
+  const handleData = (socket: NetSocket, chunk: Buffer, state: { buf: string }): void => {
+    state.buf += chunk.toString('utf8')
+    if (state.buf.length > MAX_REQUEST_BUFFER_BYTES) {
+      respond(socket, { ok: false, reason: 'request exceeds buffer limit' })
       return
     }
-    let newline = sock.data.buf.indexOf('\n')
+    let newline = state.buf.indexOf('\n')
     while (newline >= 0) {
-      const line = sock.data.buf.slice(0, newline)
-      sock.data.buf = sock.data.buf.slice(newline + 1)
+      const line = state.buf.slice(0, newline)
+      state.buf = state.buf.slice(newline + 1)
       let req: Request
       try {
         req = JSON.parse(line) as Request
       } catch {
-        respond(sock, { ok: false, reason: 'invalid request json' })
+        respond(socket, { ok: false, reason: 'invalid request json' })
         return
       }
       void dispatch(req).then(
-        (response) => respond(sock, response),
-        (error) => respond(sock, { ok: false, reason: error instanceof Error ? error.message : String(error) }),
+        (response) => respond(socket, response),
+        (error) => respond(socket, { ok: false, reason: error instanceof Error ? error.message : String(error) }),
       )
-      newline = sock.data.buf.indexOf('\n')
+      newline = state.buf.indexOf('\n')
     }
   }
 
@@ -599,25 +632,28 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
 
   // Boot-time restore: replay every persisted registration into the in-memory
-  // maps and revive portbroker for it. Runs before Bun.listen so the socket
+  // maps and revive portbroker for it. Runs before the IPC listener so the socket
   // is never accepting RPCs against a half-restored registry. A bad file
   // (parse error, schema mismatch) is logged-and-skipped — one corrupt
   // registration must not gate every other container's recovery.
   await restorePersistedRegistrations(applyRegistration, log, probeContainerAlive, removeRegistrationFile)
 
-  const listener: UnixSocketListener<ServerState> = Bun.listen<ServerState>({
-    unix: path,
-    socket: {
-      open: (sock) => {
-        sock.data = { buf: '' }
-      },
-      data: handleData,
-      close: () => {},
-      error: () => {},
-    },
+  const sockets = new Set<NetSocket>()
+  const listener = createServer((socket) => {
+    const state = { buf: '' }
+    sockets.add(socket)
+    socket.on('data', (chunk: Buffer) => handleData(socket, chunk, state))
+    socket.on('close', () => sockets.delete(socket))
+    socket.on('error', () => {})
   })
-  // Restrict socket to the owning user; ~/.typeclaw/run is also 0700.
-  await chmod(path, 0o600).catch(() => {})
+  try {
+    await listenOnSocket(listener, path, onWindows)
+  } catch (error) {
+    httpServer.stop(true)
+    throw error
+  }
+  // Restrict POSIX sockets to the owning user; ~/.typeclaw/run is also 0700.
+  if (!onWindows) await chmod(path, 0o600).catch(() => {})
   log({ kind: 'daemon-listening', socket: path })
 
   const runGc = async (): Promise<void> => {
@@ -658,9 +694,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       stopped = true
       log({ kind: 'daemon-stopping' })
       clearInterval(gcTimer)
-      try {
-        listener.stop(true)
-      } catch {}
+      await closeSocketServer(listener, sockets)
       httpServer.stop(true)
       if (opts.portbroker) {
         const names = Array.from(cwds.keys())
@@ -672,9 +706,11 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       }
       cwds.clear()
       restartTokens.clear()
-      try {
-        if (existsSync(path)) await unlink(path)
-      } catch {}
+      if (!onWindows) {
+        try {
+          if (existsSync(path)) await unlink(path)
+        } catch {}
+      }
     },
   }
   return daemonHandle

--- a/src/hostd/paths.test.ts
+++ b/src/hostd/paths.test.ts
@@ -4,6 +4,8 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import {
   ensureDirs,
   homeRoot,
@@ -35,8 +37,9 @@ describe('paths', () => {
     expect(homeRoot()).toBe(home)
   })
 
-  test('all daemon paths land under TYPECLAW_HOME', () => {
-    expect(socketPath()).toBe(join(home, 'run', 'hostd.sock'))
+  test('daemon paths reflect platform IPC and TYPECLAW_HOME storage', () => {
+    if (isWindows()) expect(socketPath()).toMatch(/^\\\\\.\\pipe\\typeclaw-hostd-[a-f0-9]{32}$/)
+    else expect(socketPath()).toBe(join(home, 'run', 'hostd.sock'))
     expect(pidfilePath()).toBe(join(home, 'run', 'hostd.pid'))
     expect(lockfilePath()).toBe(join(home, 'run', 'hostd.lock'))
     expect(logfilePath()).toBe(join(home, 'log', 'hostd.log'))

--- a/src/hostd/paths.ts
+++ b/src/hostd/paths.ts
@@ -45,7 +45,9 @@ function windowsPipePath(): string {
     typeof process.getuid === 'function'
       ? `uid:${process.getuid()}`
       : `user:${process.env.USERDOMAIN ?? ''}\\${userInfo().username}`
-  const scopedHome = resolve(homeRoot()).toLocaleLowerCase()
+  // Locale-invariant lowercasing: toLocaleLowerCase under e.g. tr-TR would map
+  // 'I' to a dotless 'ı', hashing the same path differently per process locale.
+  const scopedHome = resolve(homeRoot()).toLowerCase()
   const hash = createHash('sha256').update(`${uid}\0${scopedHome}`).digest('hex').slice(0, 32)
 
   // Node's net named-pipe API has no portable ACL hook. TypeClaw accepts that

--- a/src/hostd/paths.ts
+++ b/src/hostd/paths.ts
@@ -1,6 +1,9 @@
+import { createHash } from 'node:crypto'
 import { chmod, mkdir } from 'node:fs/promises'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { homedir, userInfo } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { isWindows } from '@/shared'
 
 // Fixed in-container path where the host daemon's run dir is bind-mounted.
 // The agent uses this to reach the host daemon (e.g. for the `restart` tool).
@@ -33,7 +36,22 @@ export function logDir(): string {
 }
 
 export function socketPath(): string {
+  if (isWindows()) return windowsPipePath()
   return join(runDir(), SOCKET_FILE)
+}
+
+function windowsPipePath(): string {
+  const uid =
+    typeof process.getuid === 'function'
+      ? `uid:${process.getuid()}`
+      : `user:${process.env.USERDOMAIN ?? ''}\\${userInfo().username}`
+  const scopedHome = resolve(homeRoot()).toLocaleLowerCase()
+  const hash = createHash('sha256').update(`${uid}\0${scopedHome}`).digest('hex').slice(0, 32)
+
+  // Node's net named-pipe API has no portable ACL hook. TypeClaw accepts that
+  // under the single-tenant dev-box model; the per-user/per-home pipe name keeps
+  // the pipe scoped, while the separate HTTP leg remains restart/secrets-only.
+  return `\\\\.\\pipe\\typeclaw-hostd-${hash}`
 }
 
 export function pidfilePath(): string {

--- a/src/hostd/spawn.test.ts
+++ b/src/hostd/spawn.test.ts
@@ -4,6 +4,9 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
+import { isDaemonReachable } from './client'
 import { startDaemon, type Daemon } from './daemon'
 import { socketPath } from './paths'
 import { ensureDaemon } from './spawn'
@@ -25,6 +28,22 @@ afterEach(async () => {
   else process.env.TYPECLAW_HOME = prev
   await rm(home, { recursive: true, force: true })
 })
+
+async function expectDaemonEndpointListening(): Promise<void> {
+  if (isWindows()) {
+    expect(await isDaemonReachable(500)).toBe(true)
+    return
+  }
+  expect(existsSync(socketPath())).toBe(true)
+}
+
+async function expectDaemonEndpointGone(): Promise<void> {
+  if (isWindows()) {
+    expect(await isDaemonReachable(50)).toBe(false)
+    return
+  }
+  expect(existsSync(socketPath())).toBe(false)
+}
 
 describe('ensureDaemon', () => {
   test('reuses a reachable daemon when the version matches', async () => {
@@ -49,7 +68,7 @@ describe('ensureDaemon', () => {
       version: 'old',
       gcIntervalMs: 1_000_000,
     })
-    expect(existsSync(socketPath())).toBe(true)
+    await expectDaemonEndpointListening()
 
     const result = await ensureDaemon({
       cliEntry: '/nonexistent/cli.ts',
@@ -63,14 +82,14 @@ describe('ensureDaemon', () => {
     // fails. The end-to-end behavior we want to assert: the stale daemon was
     // torn down (socket gone) and ensureDaemon did NOT reuse it.
     daemon = null
-    expect(existsSync(socketPath())).toBe(false)
+    await expectDaemonEndpointGone()
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason.toLowerCase()).toContain('reachable')
   })
 
   test('happy path: socket missing -> spawns a new daemon (when cliEntry resolves)', async () => {
-    expect(existsSync(socketPath())).toBe(false)
+    await expectDaemonEndpointGone()
 
     const result = await ensureDaemon({
       cliEntry: '/nonexistent/cli.ts',

--- a/src/hostd/spawn.ts
+++ b/src/hostd/spawn.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'node:fs'
 import { open, readFile, unlink, writeFile } from 'node:fs/promises'
 
+import { isWindows } from '@/shared'
+
 import { isDaemonReachable, send } from './client'
 import { ensureDirs, lockfilePath, logfilePath, pidfilePath, socketPath } from './paths'
 import type { HttpInfoResult, VersionResult } from './protocol'
@@ -75,6 +77,11 @@ async function requestShutdownAndWait(): Promise<boolean> {
   if (!reply.ok) return false
   const deadline = Date.now() + SHUTDOWN_TIMEOUT_MS
   while (Date.now() < deadline) {
+    if (isWindows()) {
+      if (!(await isDaemonReachable(POLL_INTERVAL_MS))) return true
+      await sleep(POLL_INTERVAL_MS)
+      continue
+    }
     if (!existsSync(socketPath())) return true
     await sleep(POLL_INTERVAL_MS)
   }

--- a/src/hostd/version.test.ts
+++ b/src/hostd/version.test.ts
@@ -1,35 +1,34 @@
 import { describe, expect, test } from 'bun:test'
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { computeSourceVersion, resolveSrcRoot, UNVERSIONED_SENTINEL, type VersionFs } from './version'
 
 function fakeFs(files: Record<string, string>): VersionFs {
   const dirs = new Map<string, Set<string>>()
   for (const path of Object.keys(files)) {
-    const parts = path.split('/').filter((p) => p.length > 0)
-    for (let i = 0; i < parts.length - 1; i += 1) {
-      const dir = '/' + parts.slice(0, i + 1).join('/')
-      const parent = i === 0 ? '/' : '/' + parts.slice(0, i).join('/')
-      const childOfParent = parts[i]!
+    let dir = dirname(path)
+    const fileSet = dirs.get(dir) ?? new Set<string>()
+    fileSet.add(basename(path))
+    dirs.set(dir, fileSet)
+
+    while (true) {
+      const parent = dirname(dir)
+      if (parent === dir) break
       const parentSet = dirs.get(parent) ?? new Set<string>()
-      parentSet.add(childOfParent)
+      parentSet.add(basename(dir))
       dirs.set(parent, parentSet)
       if (!dirs.has(dir)) dirs.set(dir, new Set<string>())
+      dir = parent
     }
-    const fileDir = '/' + parts.slice(0, -1).join('/')
-    const fileName = parts[parts.length - 1]!
-    const set = dirs.get(fileDir) ?? new Set<string>()
-    set.add(fileName)
-    dirs.set(fileDir, set)
   }
   return {
     readdir: async (path) => {
       const children = dirs.get(path)
       if (!children) throw new Error(`ENOENT: ${path}`)
       return Array.from(children).map((name) => {
-        const childPath = `${path}/${name}`
+        const childPath = join(path, name)
         return { name, isDirectory: dirs.has(childPath) }
       })
     },
@@ -41,40 +40,46 @@ function fakeFs(files: Record<string, string>): VersionFs {
   }
 }
 
+const fakeSrcRoot = join(tmpdir(), 'typeclaw-version-src')
+
+function srcPath(...parts: string[]): string {
+  return join(fakeSrcRoot, ...parts)
+}
+
 describe('computeSourceVersion', () => {
   test('produces a stable hash for identical input', async () => {
     const fs = fakeFs({
-      '/src/a.ts': 'export const a = 1',
-      '/src/b.ts': 'export const b = 2',
+      [srcPath('a.ts')]: 'export const a = 1',
+      [srcPath('b.ts')]: 'export const b = 2',
     })
-    const v1 = await computeSourceVersion({ srcRoot: '/src', fs })
-    const v2 = await computeSourceVersion({ srcRoot: '/src', fs })
+    const v1 = await computeSourceVersion({ srcRoot: fakeSrcRoot, fs })
+    const v2 = await computeSourceVersion({ srcRoot: fakeSrcRoot, fs })
     expect(v1).toBe(v2)
     expect(v1.length).toBe(32)
   })
 
   test('changes when any source byte changes', async () => {
     const original = await computeSourceVersion({
-      srcRoot: '/src',
-      fs: fakeFs({ '/src/a.ts': 'export const a = 1' }),
+      srcRoot: fakeSrcRoot,
+      fs: fakeFs({ [srcPath('a.ts')]: 'export const a = 1' }),
     })
     const modified = await computeSourceVersion({
-      srcRoot: '/src',
-      fs: fakeFs({ '/src/a.ts': 'export const a = 2' }),
+      srcRoot: fakeSrcRoot,
+      fs: fakeFs({ [srcPath('a.ts')]: 'export const a = 2' }),
     })
     expect(original).not.toBe(modified)
   })
 
   test('ignores test files', async () => {
     const withoutTests = await computeSourceVersion({
-      srcRoot: '/src',
-      fs: fakeFs({ '/src/a.ts': 'export const a = 1' }),
+      srcRoot: fakeSrcRoot,
+      fs: fakeFs({ [srcPath('a.ts')]: 'export const a = 1' }),
     })
     const withTests = await computeSourceVersion({
-      srcRoot: '/src',
+      srcRoot: fakeSrcRoot,
       fs: fakeFs({
-        '/src/a.ts': 'export const a = 1',
-        '/src/a.test.ts': 'test stuff',
+        [srcPath('a.ts')]: 'export const a = 1',
+        [srcPath('a.test.ts')]: 'test stuff',
       }),
     })
     expect(withoutTests).toBe(withTests)
@@ -82,14 +87,14 @@ describe('computeSourceVersion', () => {
 
   test('ignores non-typescript files', async () => {
     const baseline = await computeSourceVersion({
-      srcRoot: '/src',
-      fs: fakeFs({ '/src/a.ts': 'export const a = 1' }),
+      srcRoot: fakeSrcRoot,
+      fs: fakeFs({ [srcPath('a.ts')]: 'export const a = 1' }),
     })
     const withReadme = await computeSourceVersion({
-      srcRoot: '/src',
+      srcRoot: fakeSrcRoot,
       fs: fakeFs({
-        '/src/a.ts': 'export const a = 1',
-        '/src/README.md': '# stuff',
+        [srcPath('a.ts')]: 'export const a = 1',
+        [srcPath('README.md')]: '# stuff',
       }),
     })
     expect(baseline).toBe(withReadme)
@@ -97,19 +102,19 @@ describe('computeSourceVersion', () => {
 
   test('walks nested directories deterministically', async () => {
     const v1 = await computeSourceVersion({
-      srcRoot: '/src',
+      srcRoot: fakeSrcRoot,
       fs: fakeFs({
-        '/src/a.ts': '1',
-        '/src/sub/b.ts': '2',
-        '/src/sub/deeper/c.ts': '3',
+        [srcPath('a.ts')]: '1',
+        [srcPath('sub', 'b.ts')]: '2',
+        [srcPath('sub', 'deeper', 'c.ts')]: '3',
       }),
     })
     const v2 = await computeSourceVersion({
-      srcRoot: '/src',
+      srcRoot: fakeSrcRoot,
       fs: fakeFs({
-        '/src/sub/deeper/c.ts': '3',
-        '/src/sub/b.ts': '2',
-        '/src/a.ts': '1',
+        [srcPath('sub', 'deeper', 'c.ts')]: '3',
+        [srcPath('sub', 'b.ts')]: '2',
+        [srcPath('a.ts')]: '1',
       }),
     })
     expect(v1).toBe(v2)
@@ -117,17 +122,17 @@ describe('computeSourceVersion', () => {
 
   test('moving content between files changes the hash (path is hashed)', async () => {
     const v1 = await computeSourceVersion({
-      srcRoot: '/src',
+      srcRoot: fakeSrcRoot,
       fs: fakeFs({
-        '/src/a.ts': 'foo',
-        '/src/b.ts': 'bar',
+        [srcPath('a.ts')]: 'foo',
+        [srcPath('b.ts')]: 'bar',
       }),
     })
     const v2 = await computeSourceVersion({
-      srcRoot: '/src',
+      srcRoot: fakeSrcRoot,
       fs: fakeFs({
-        '/src/a.ts': 'bar',
-        '/src/b.ts': 'foo',
+        [srcPath('a.ts')]: 'bar',
+        [srcPath('b.ts')]: 'foo',
       }),
     })
     expect(v1).not.toBe(v2)
@@ -150,13 +155,14 @@ describe('computeSourceVersion', () => {
 
 describe('resolveSrcRoot', () => {
   test('returns the src dir for a CLI entry inside src/', () => {
-    expect(resolveSrcRoot('/home/x/typeclaw/src/cli/index.ts')).toBe('/home/x/typeclaw/src')
-    expect(resolveSrcRoot('/home/x/typeclaw/src/hostd/spawn.ts')).toBe('/home/x/typeclaw/src')
+    const root = join(tmpdir(), 'typeclaw', 'src')
+    expect(resolveSrcRoot(join(root, 'cli', 'index.ts'))).toBe(root)
+    expect(resolveSrcRoot(join(root, 'hostd', 'spawn.ts'))).toBe(root)
   })
 
   test('returns null when no src/ ancestor exists', () => {
-    expect(resolveSrcRoot('/usr/local/bin/typeclaw')).toBeNull()
-    expect(resolveSrcRoot('/home/x/dist/index.js')).toBeNull()
+    expect(resolveSrcRoot(join(tmpdir(), 'bin', 'typeclaw'))).toBeNull()
+    expect(resolveSrcRoot(join(tmpdir(), 'typeclaw', 'dist', 'index.js'))).toBeNull()
   })
 })
 

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { dockerfileSchema } from '@/config/config'
+import { isWindows } from '@/shared'
 
 import { GHCR_BASE_IMAGE_REPO } from './cli-version'
 import {
@@ -27,6 +28,8 @@ import {
 // Layer ordering, cache-mount preservation, and on-disk write behavior are
 // covered by integration tests in src/init/index.test.ts. This file only
 // asserts the toggle-driven content of the rendered Dockerfile string.
+
+const onWindows = isWindows()
 
 // Pulls the package list passed to the main `apt-get install` line so
 // assertions are scoped to what actually gets installed and not to
@@ -1691,7 +1694,8 @@ describe('network egress entrypoint shim', () => {
   })
 })
 
-describe('entrypoint shim — executable behavior (Xvfb startup, fail-fast)', () => {
+// POSIX shell execution, #899.
+describe.skipIf(onWindows)('entrypoint shim — executable behavior (Xvfb startup, fail-fast)', () => {
   let workdir: string
   let bindir: string
   let logfile: string
@@ -2072,7 +2076,8 @@ describe('agent-browser headed-mode wrapper (Layer 4.5)', () => {
   })
 })
 
-describe('agent-browser headed-mode wrapper — executable behavior', () => {
+// POSIX shell execution, #899.
+describe.skipIf(onWindows)('agent-browser headed-mode wrapper — executable behavior', () => {
   let workdir: string
   let bindir: string
   let logfile: string

--- a/src/plugin/loader.test.ts
+++ b/src/plugin/loader.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { derivePluginNameFromPackage, loadPluginEntry, PluginNotFoundError, splitPluginEntrySpec } from './loader'
+
+const pluginIndexSpecifier = pathToFileURL(join(process.cwd(), 'src', 'plugin', 'index.ts')).href
 
 describe('splitPluginEntrySpec', () => {
   test('splits a versioned unscoped entry', () => {
@@ -71,7 +74,7 @@ describe('loadPluginEntry — local path', () => {
       await mkdir(join(dir, 'plugins'))
       await writeFile(
         join(dir, 'plugins', 'local-thing.ts'),
-        `import { definePlugin } from '${process.cwd()}/src/plugin/index.ts'
+        `import { definePlugin } from '${pluginIndexSpecifier}'
 export default definePlugin({
   plugin: async () => ({}),
 })`,
@@ -148,7 +151,7 @@ describe('loadPluginEntry — npm', () => {
       )
       await writeFile(
         join(pkgDir, 'index.js'),
-        `import { definePlugin } from '${process.cwd()}/src/plugin/index.ts'
+        `import { definePlugin } from '${pluginIndexSpecifier}'
 export default definePlugin({
   plugin: async () => ({}),
 })`,
@@ -177,7 +180,7 @@ export default definePlugin({
       )
       await writeFile(
         join(pkgDir, 'index.js'),
-        `import { definePlugin } from '${process.cwd()}/src/plugin/index.ts'
+        `import { definePlugin } from '${pluginIndexSpecifier}'
 export default definePlugin({
   plugin: async () => ({}),
 })`,

--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -61,8 +61,7 @@ async function loadLocal(entry: string, agentDir: string): Promise<ResolvedPlugi
   if (!existsSync(resolved)) {
     throw new PluginNotFoundError(entry, `plugin path does not exist: ${entry} (resolved to ${resolved})`)
   }
-  const url = pathToFileURL(resolved).href
-  const mod = (await import(url)) as { default?: unknown }
+  const mod = (await import(toModuleSpecifier(resolved))) as { default?: unknown }
   const defined = expectDefined(mod, entry)
   const name = basename(resolved).replace(/\.(ts|tsx|js|mjs|cjs)$/i, '')
   return { name, version: undefined, source: entry, defined }
@@ -108,10 +107,10 @@ async function loadNpm(entry: string, agentDir: string): Promise<ResolvedPlugin>
   // located on disk; the else branch lets Bun's resolver read `exports` maps.
   let importTarget: string
   if (entryPath !== null) {
-    importTarget = pathToFileURL(entryPath).href
+    importTarget = toModuleSpecifier(entryPath)
   } else {
     try {
-      importTarget = Bun.resolveSync(packageName, agentDir)
+      importTarget = toModuleSpecifier(Bun.resolveSync(packageName, agentDir))
     } catch (err) {
       throw new PluginNotFoundError(entry, `cannot resolve plugin "${entry}": ${describeError(err)}`, { cause: err })
     }
@@ -149,6 +148,10 @@ export function derivePluginNameFromPackage(packageName: string): string {
 
 function describeError(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+function toModuleSpecifier(target: string): string {
+  return isAbsolute(target) ? pathToFileURL(target).href : target
 }
 
 function findPackageJson(entry: string, agentDir: string): string | null {

--- a/src/run/channel-session-factory.test.ts
+++ b/src/run/channel-session-factory.test.ts
@@ -305,7 +305,7 @@ describe('buildChannelSessionFactory — production wiring contract', () => {
 
     expect(result.hooks).toBe(runtime.get().hooks)
     expect(typeof result.getTranscriptPath).toBe('function')
-    expect(result.getTranscriptPath?.()).toMatch(/sessions\//)
+    expect(result.getTranscriptPath?.()).toMatch(/sessions[/\\]/)
   })
 
   test('omits hooks when no plugin runtime content (matches existing plugin-omission policy)', async () => {

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -287,7 +287,7 @@ describe('startAgent', () => {
       await Bun.sleep(80)
       expect(await Bun.file(sentinel).exists()).toBe(true)
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
     }
   })
 

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -188,7 +188,7 @@ export default {
     expect(skillDirs).toContainEqual(
       expect.objectContaining({
         pluginName: 'agent-browser',
-        path: expect.stringContaining('bundled-plugins/agent-browser/skills'),
+        path: expect.stringMatching(/bundled-plugins[/\\]agent-browser[/\\]skills/),
       }),
     )
   })

--- a/src/sandbox/hidden-paths.test.ts
+++ b/src/sandbox/hidden-paths.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
 
 import type { SessionOrigin } from '@/agent/session-origin'
 import { createPermissionService } from '@/permissions/permissions'
@@ -7,6 +8,12 @@ import { rolesConfigSchema, type RolesConfig } from '@/permissions/schema'
 import { resolveHiddenPaths } from './hidden-paths'
 
 const AGENT = '/agent'
+const hiddenDirs = (agentDir: string) => [
+  join(agentDir, 'workspace'),
+  join(agentDir, 'memory'),
+  join(agentDir, 'sessions'),
+]
+const secretFiles = (agentDir: string) => [join(agentDir, '.env'), join(agentDir, 'secrets.json')]
 
 function parseRoles(raw: unknown): RolesConfig {
   const result = rolesConfigSchema.safeParse(raw)
@@ -51,20 +58,20 @@ describe('resolveHiddenPaths — builtin tiers', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('member'), AGENT)
     expect(dirs).toEqual([])
-    expect(files).toEqual(['/agent/.env', '/agent/secrets.json'])
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('guest hides the private surface AND the secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('guest'), AGENT)
-    expect(dirs).toEqual(['/agent/workspace', '/agent/memory', '/agent/sessions'])
-    expect(files).toEqual(['/agent/.env', '/agent/secrets.json'])
+    expect(dirs).toEqual(hiddenDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('guest never hides public/ — it is the guest-visible zone', () => {
     const svc = createPermissionService()
     const { dirs } = resolveHiddenPaths(svc, spawnedBy('guest'), AGENT)
-    expect(dirs).not.toContain('/agent/public')
+    expect(dirs).not.toContain(join(AGENT, 'public'))
   })
 })
 
@@ -72,8 +79,8 @@ describe('resolveHiddenPaths — fail-safe', () => {
   test('undefined origin is treated as guest (everything hidden)', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, undefined, AGENT)
-    expect(dirs).toEqual(['/agent/workspace', '/agent/memory', '/agent/sessions'])
-    expect(files).toEqual(['/agent/.env', '/agent/secrets.json'])
+    expect(dirs).toEqual(hiddenDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('unmatched channel author resolves to guest (everything hidden)', () => {
@@ -87,8 +94,8 @@ describe('resolveHiddenPaths — fail-safe', () => {
       lastInboundAuthorId: 'U_STRANGER',
     }
     const { dirs, files } = resolveHiddenPaths(svc, stranger, AGENT)
-    expect(dirs).toEqual(['/agent/workspace', '/agent/memory', '/agent/sessions'])
-    expect(files).toEqual(['/agent/.env', '/agent/secrets.json'])
+    expect(dirs).toEqual(hiddenDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 })
 
@@ -98,7 +105,7 @@ describe('resolveHiddenPaths — custom roles via fs.see grants', () => {
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('contributor'), AGENT)
     expect(dirs).toEqual([])
-    expect(files).toEqual(['/agent/.env', '/agent/secrets.json'])
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('custom role with both fs.see grants hides nothing', () => {
@@ -120,7 +127,7 @@ describe('resolveHiddenPaths — legacy security.bypass fallback', () => {
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('legacymember'), AGENT)
     expect(dirs).toEqual([])
-    expect(files).toEqual(['/agent/.env', '/agent/secrets.json'])
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('a role with bypass.medium (no fs.see.*) sees both private surface and secrets', () => {
@@ -138,7 +145,7 @@ describe('resolveHiddenPaths — agentDir relativity', () => {
   test('masks are rooted at the given agentDir, not a hardcoded /agent', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, undefined, '/srv/app')
-    expect(dirs).toEqual(['/srv/app/workspace', '/srv/app/memory', '/srv/app/sessions'])
-    expect(files).toEqual(['/srv/app/.env', '/srv/app/secrets.json'])
+    expect(dirs).toEqual(hiddenDirs('/srv/app'))
+    expect(files).toEqual(secretFiles('/srv/app'))
   })
 })

--- a/src/secrets/export-claude-credentials-file.test.ts
+++ b/src/secrets/export-claude-credentials-file.test.ts
@@ -4,8 +4,12 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { exportClaudeCredentialsFileIfApplicable } from './export-claude-credentials-file'
 import type { Providers } from './schema'
+
+const onWindows = isWindows()
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
@@ -132,7 +136,8 @@ describe('exportClaudeCredentialsFileIfApplicable', () => {
         homeDir: home,
       })
       const stat = statSync(join(home, '.claude', '.credentials.json'))
-      expect(stat.mode & 0o777).toBe(0o600)
+      // NTFS mode bits are not meaningful on Windows; see #899.
+      if (!onWindows) expect(stat.mode & 0o777).toBe(0o600)
     })
   })
 

--- a/src/secrets/export-codex-auth-file.test.ts
+++ b/src/secrets/export-codex-auth-file.test.ts
@@ -4,8 +4,12 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { exportCodexAuthFileIfApplicable } from './export-codex-auth-file'
 import type { Providers } from './schema'
+
+const onWindows = isWindows()
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
@@ -99,7 +103,8 @@ describe('exportCodexAuthFileIfApplicable', () => {
         homeDir: home,
       })
       const stat = statSync(join(home, '.codex', 'auth.json'))
-      expect(stat.mode & 0o777).toBe(0o600)
+      // NTFS mode bits are not meaningful on Windows; see #899.
+      if (!onWindows) expect(stat.mode & 0o777).toBe(0o600)
     })
   })
 

--- a/src/secrets/keys.test.ts
+++ b/src/secrets/keys.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, readFile, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import { createKeyStore, KeyStoreError } from './keys'
+
+const onWindows = isWindows()
 
 async function withTempKeysDir<T>(fn: (keysDir: string) => Promise<T>): Promise<T> {
   const root = await mkdtemp(join(tmpdir(), 'typeclaw-keys-'))
@@ -26,7 +30,8 @@ describe('keys store', () => {
       const store = createKeyStore({ keysDir })
       await store.ensure('kakao')
       const info = await stat(store.keyPath('kakao'))
-      expect(info.mode & 0o777).toBe(0o600)
+      // NTFS mode bits are not meaningful on Windows; see #899.
+      if (!onWindows) expect(info.mode & 0o777).toBe(0o600)
     })
   })
 

--- a/src/secrets/storage.test.ts
+++ b/src/secrets/storage.test.ts
@@ -5,8 +5,12 @@ import { join } from 'node:path'
 
 import { AuthStorage } from '@mariozechner/pi-coding-agent'
 
+import { isWindows } from '@/shared'
+
 import { parseSecretsFile } from './schema'
 import { createSecretsStoreForAgent, SecretsBackend } from './storage'
+
+const onWindows = isWindows()
 
 describe('SecretsBackend', () => {
   let dir: string
@@ -85,7 +89,8 @@ describe('SecretsBackend', () => {
 
     const stats = await stat(secretsPath)
     const perms = stats.mode & 0o777
-    expect(perms).toBe(0o600)
+    // NTFS mode bits are not meaningful on Windows; see #899.
+    if (!onWindows) expect(perms).toBe(0o600)
   })
 
   test('seed file is parseable as v2 envelope before any credential is written', async () => {

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -12,6 +12,7 @@ import { defineCommand } from '@/plugin/define'
 import { emptyRegistry, type RegisteredCommand } from '@/plugin/registry'
 import { createPluginRuntime, type PluginRuntime } from '@/run/plugin-runtime'
 import { createSessionFactory, type SessionFactory } from '@/sessions'
+import { isWindows } from '@/shared'
 
 import {
   bindSignalToSession,
@@ -21,6 +22,8 @@ import {
   type CommandOutbound,
   type CommandSpawnSubagent,
 } from './command-runner'
+
+const onWindows = isWindows()
 
 type CapturedFrame =
   | { kind: 'stdout'; callId: string; chunk: string }
@@ -482,7 +485,8 @@ describe('runExecForCommand', () => {
     expect(result.exitCode).toBe(3)
   })
 
-  test('aborts a long-running shell promptly via process-group SIGTERM', async () => {
+  // Windows lacks POSIX process-group signals; covered on Unix. #899
+  test.skipIf(onWindows)('aborts a long-running shell promptly via process-group SIGTERM', async () => {
     // Spawn a shell that sleeps for 30s with a background grandchild also
     // sleeping. Abort after 50ms and assert the process exits well before
     // the natural completion — this only happens if the process-group kill

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
@@ -798,7 +798,7 @@ describe('createServer restart-handoff consumption', () => {
     await writeHandoff(agentDir, {
       restartedAt: new Date().toISOString(),
       originatingSessionId: sessionId,
-      originatingSessionFile: sessionFile.split('/').pop()!,
+      originatingSessionFile: basename(sessionFile),
     })
 
     const session = createFakeSession()
@@ -867,7 +867,7 @@ describe('createServer restart-handoff consumption', () => {
     await writeHandoff(agentDir, {
       restartedAt: new Date(Date.now() - 90_000).toISOString(),
       originatingSessionId: sessionId,
-      originatingSessionFile: sessionFile.split('/').pop()!,
+      originatingSessionFile: basename(sessionFile),
     })
 
     const session = createFakeSession()
@@ -901,7 +901,7 @@ describe('createServer restart-handoff consumption', () => {
     await writeHandoff(agentDir, {
       restartedAt: new Date().toISOString(),
       originatingSessionId: sessionId,
-      originatingSessionFile: sessionFile.split('/').pop()!,
+      originatingSessionFile: basename(sessionFile),
     })
 
     const sessions: ReturnType<typeof createFakeSession>[] = []

--- a/src/tunnels/integration.test.ts
+++ b/src/tunnels/integration.test.ts
@@ -4,10 +4,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { createTunnelBridge } from '@/channels/tunnel-bridge'
+import { isWindows } from '@/shared'
 import { createStream } from '@/stream'
 import { waitFor } from '@/test-helpers/wait-for'
 
 import { createTunnelManager } from './manager'
+
+const onWindows = isWindows()
 
 function silentLogger(): { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void } {
   return { info: () => {}, warn: () => {}, error: () => {} }
@@ -28,43 +31,47 @@ echo "2026-01-01T00:00:00Z INF | https://integration.trycloudflare.com |" >&2
 }
 
 describe('tunnel URL to channel adapter restart integration', () => {
-  test('cloudflare quick URL broadcasts restart github and the fresh adapter sees tunnelUrl()', async () => {
-    const scratchDir = mkdtempSync(join(tmpdir(), 'typeclaw-tunnels-integration-'))
-    const stream = createStream()
-    const manager = createTunnelManager({
-      stream,
-      cloudflareQuickBinary: installFakeCloudflared(scratchDir),
-      resolveChannelUpstreamPort: (name) => (name === 'github' ? 8975 : null),
-      logger: silentLogger(),
-      tunnels: [
-        {
-          name: 'github-webhook',
-          provider: 'cloudflare-quick',
-          for: { kind: 'channel', name: 'github' },
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)(
+    'cloudflare quick URL broadcasts restart github and the fresh adapter sees tunnelUrl()',
+    async () => {
+      const scratchDir = mkdtempSync(join(tmpdir(), 'typeclaw-tunnels-integration-'))
+      const stream = createStream()
+      const manager = createTunnelManager({
+        stream,
+        cloudflareQuickBinary: installFakeCloudflared(scratchDir),
+        resolveChannelUpstreamPort: (name) => (name === 'github' ? 8975 : null),
+        logger: silentLogger(),
+        tunnels: [
+          {
+            name: 'github-webhook',
+            provider: 'cloudflare-quick',
+            for: { kind: 'channel', name: 'github' },
+          },
+        ],
+      })
+      const startedUrls: Array<string | null> = []
+      const bridge = createTunnelBridge({
+        stream,
+        logger: silentLogger(),
+        channelManager: {
+          restartAdapter: async (name) => {
+            if (name === 'github') startedUrls.push(manager.urlFor('github-webhook'))
+          },
         },
-      ],
-    })
-    const startedUrls: Array<string | null> = []
-    const bridge = createTunnelBridge({
-      stream,
-      logger: silentLogger(),
-      channelManager: {
-        restartAdapter: async (name) => {
-          if (name === 'github') startedUrls.push(manager.urlFor('github-webhook'))
-        },
-      },
-    })
+      })
 
-    try {
-      await manager.start()
-      await waitFor(() => startedUrls.length === 1, { description: 'github adapter restart from tunnel URL' })
+      try {
+        await manager.start()
+        await waitFor(() => startedUrls.length === 1, { description: 'github adapter restart from tunnel URL' })
 
-      expect(startedUrls).toEqual(['https://integration.trycloudflare.com'])
-      expect(manager.urlFor('github-webhook')).toBe('https://integration.trycloudflare.com')
-    } finally {
-      bridge.stop()
-      await manager.stop()
-      rmSync(scratchDir, { recursive: true, force: true })
-    }
-  })
+        expect(startedUrls).toEqual(['https://integration.trycloudflare.com'])
+        expect(manager.urlFor('github-webhook')).toBe('https://integration.trycloudflare.com')
+      } finally {
+        bridge.stop()
+        await manager.stop()
+        rmSync(scratchDir, { recursive: true, force: true })
+      }
+    },
+  )
 })

--- a/src/tunnels/manager.test.ts
+++ b/src/tunnels/manager.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
 import { createStream } from '@/stream'
 import { waitFor } from '@/test-helpers/wait-for'
 
@@ -11,6 +12,7 @@ import { createTunnelManager } from './manager'
 import type { TunnelConfig, TunnelUrlChangedPayload } from './types'
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {} }
+const onWindows = isWindows()
 
 function createScratchDir(): string {
   return mkdtempSync(join(tmpdir(), 'tunnel-manager-test-'))
@@ -187,7 +189,8 @@ describe('createTunnelManager (external provider)', () => {
 })
 
 describe('createTunnelManager (cloudflare-quick provider)', () => {
-  it('resolves channel-owned upstream ports before constructing the provider', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('resolves channel-owned upstream ports before constructing the provider', async () => {
     const scratchDir = createScratchDir()
     const argvFile = join(scratchDir, 'argv.txt')
     const binary = installFakeCloudflared(
@@ -228,7 +231,8 @@ printf '%s\n' "$@" > "${argvFile}"
     ).toThrow("tunnel 'github-webhook' (cloudflare-quick): no upstream port resolved for channel 'github'")
   })
 
-  it('uses manual upstreamPort without calling the channel resolver', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('uses manual upstreamPort without calling the channel resolver', async () => {
     const scratchDir = createScratchDir()
     const argvFile = join(scratchDir, 'argv.txt')
     const binary = installFakeCloudflared(

--- a/src/tunnels/providers/cloudflare-named.test.ts
+++ b/src/tunnels/providers/cloudflare-named.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
 import { waitFor } from '@/test-helpers/wait-for'
 
 import { createCloudflareNamedProvider } from './cloudflare-named'
+
+const onWindows = isWindows()
 
 const config = {
   name: 'github-webhook',
@@ -28,50 +31,54 @@ describe('createCloudflareNamedProvider', () => {
     return path
   }
 
-  it('emits the configured hostname synchronously at start and spawns cloudflared with the token', async () => {
-    const scratchDir = createScratchDir()
-    const argvFile = join(scratchDir, 'argv.txt')
-    const binary = installFakeCloudflared(
-      scratchDir,
-      `
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)(
+    'emits the configured hostname synchronously at start and spawns cloudflared with the token',
+    async () => {
+      const scratchDir = createScratchDir()
+      const argvFile = join(scratchDir, 'argv.txt')
+      const binary = installFakeCloudflared(
+        scratchDir,
+        `
 printf '%s\n' "$@" > "${argvFile}"
 echo "2026-01-01T00:00:00Z INF Connection registered" >&2
 trap 'exit 0' TERM
 sleep 30
 `,
-    )
-    const urls: string[] = []
-    const provider = createCloudflareNamedProvider({
-      config,
-      binary,
-      onUrlChange: (url) => urls.push(url),
-      resolveToken: () => 'eyJhIjoiZmFrZS10b2tlbiJ9',
-      stopGraceMs: 10,
-    })
+      )
+      const urls: string[] = []
+      const provider = createCloudflareNamedProvider({
+        config,
+        binary,
+        onUrlChange: (url) => urls.push(url),
+        resolveToken: () => 'eyJhIjoiZmFrZS10b2tlbiJ9',
+        stopGraceMs: 10,
+      })
 
-    try {
-      // URL must be emitted synchronously - subscribers wire up immediately,
-      // not after cloudflared comes up.
-      await provider.start()
-      expect(urls).toEqual(['https://agent.example.com'])
-      expect(provider.snapshot().url).toBe('https://agent.example.com')
+      try {
+        // URL must be emitted synchronously - subscribers wire up immediately,
+        // not after cloudflared comes up.
+        await provider.start()
+        expect(urls).toEqual(['https://agent.example.com'])
+        expect(provider.snapshot().url).toBe('https://agent.example.com')
 
-      await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy after first stderr' })
-      expect((await readFile(argvFile, 'utf8')).split('\n').filter(Boolean)).toEqual([
-        'tunnel',
-        '--no-autoupdate',
-        'run',
-        '--token',
-        'eyJhIjoiZmFrZS10b2tlbiJ9',
-      ])
+        await waitFor(() => provider.snapshot().status === 'healthy', { description: 'healthy after first stderr' })
+        expect((await readFile(argvFile, 'utf8')).split('\n').filter(Boolean)).toEqual([
+          'tunnel',
+          '--no-autoupdate',
+          'run',
+          '--token',
+          'eyJhIjoiZmFrZS10b2tlbiJ9',
+        ])
 
-      await provider.stop()
-      expect(provider.snapshot().status).toBe('stopped')
-    } finally {
-      await provider.stop()
-      rmSync(scratchDir, { recursive: true, force: true })
-    }
-  })
+        await provider.stop()
+        expect(provider.snapshot().status).toBe('stopped')
+      } finally {
+        await provider.stop()
+        rmSync(scratchDir, { recursive: true, force: true })
+      }
+    },
+  )
 
   it('flips to permanently-failed when the token env var is unset', async () => {
     const scratchDir = createScratchDir()
@@ -143,7 +150,8 @@ sleep 30
     }
   })
 
-  it('restarts a crashed process with backoff', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('restarts a crashed process with backoff', async () => {
     const scratchDir = createScratchDir()
     const countFile = join(scratchDir, 'count.txt')
     const binary = installFakeCloudflared(
@@ -195,7 +203,8 @@ sleep 30
     }
   })
 
-  it('stops retrying after the consecutive-crash cap is reached', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('stops retrying after the consecutive-crash cap is reached', async () => {
     const scratchDir = createScratchDir()
     const countFile = join(scratchDir, 'count.txt')
     const binary = installFakeCloudflared(
@@ -229,7 +238,8 @@ exit 3
     }
   })
 
-  it('SIGKILLs processes that ignore SIGTERM during stop', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('SIGKILLs processes that ignore SIGTERM during stop', async () => {
     const scratchDir = createScratchDir()
     const binary = installFakeCloudflared(
       scratchDir,
@@ -289,7 +299,8 @@ sleep 30
     ).toThrow(/provider must be 'cloudflare-named'/)
   })
 
-  it('subscribers receive future stderr lines without replay', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('subscribers receive future stderr lines without replay', async () => {
     const scratchDir = createScratchDir()
     // Gate `after` on subscription, not a wall-clock sleep: under load a fixed
     // delay can elapse before the subscriber registers, leaving `after` with

--- a/src/tunnels/providers/cloudflare-quick.test.ts
+++ b/src/tunnels/providers/cloudflare-quick.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
 import { waitFor } from '@/test-helpers/wait-for'
 
 import { createCloudflareQuickProvider } from './cloudflare-quick'
+
+const onWindows = isWindows()
 
 const config = {
   name: 'github-webhook',
@@ -26,7 +29,8 @@ describe('createCloudflareQuickProvider', () => {
     return path
   }
 
-  it('spawns cloudflared, captures stderr, and emits the quick tunnel URL', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('spawns cloudflared, captures stderr, and emits the quick tunnel URL', async () => {
     const scratchDir = createScratchDir()
     const argvFile = join(scratchDir, 'argv.txt')
     const binary = installFakeCloudflared(
@@ -74,7 +78,8 @@ sleep 30
     }
   })
 
-  it('subscribers receive future stderr lines without replay', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('subscribers receive future stderr lines without replay', async () => {
     const scratchDir = createScratchDir()
     // Gate `after` on subscription, not a wall-clock sleep: under load a fixed
     // delay can elapse before the subscriber registers, leaving `after` with
@@ -136,7 +141,8 @@ sleep 30
     }
   })
 
-  it('restarts a crashed process with backoff until a URL is emitted', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('restarts a crashed process with backoff until a URL is emitted', async () => {
     const scratchDir = createScratchDir()
     const countFile = join(scratchDir, 'count.txt')
     const binary = installFakeCloudflared(
@@ -179,7 +185,8 @@ sleep 30
     }
   })
 
-  it('stops retrying after the failure cap is reached before any URL is emitted', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('stops retrying after the failure cap is reached before any URL is emitted', async () => {
     const scratchDir = createScratchDir()
     const countFile = join(scratchDir, 'count.txt')
     const binary = installFakeCloudflared(
@@ -214,7 +221,8 @@ exit 3
     }
   })
 
-  it('SIGKILLs processes that ignore SIGTERM during stop', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('SIGKILLs processes that ignore SIGTERM during stop', async () => {
     const scratchDir = createScratchDir()
     const binary = installFakeCloudflared(
       scratchDir,
@@ -246,7 +254,8 @@ sleep 30
     }
   })
 
-  it('broadcasts the URL but stays unhealthy when the upstream is unreachable', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('broadcasts the URL but stays unhealthy when the upstream is unreachable', async () => {
     const scratchDir = createScratchDir()
     const binary = installFakeCloudflared(
       scratchDir,
@@ -283,7 +292,8 @@ sleep 30
     }
   })
 
-  it('flips to healthy on recheck once the upstream comes up', async () => {
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)('flips to healthy on recheck once the upstream comes up', async () => {
     const scratchDir = createScratchDir()
     const binary = installFakeCloudflared(
       scratchDir,
@@ -317,53 +327,59 @@ sleep 30
     }
   })
 
-  it('does not mark healthy when a probe resolves after cloudflared has already exited', async () => {
-    const scratchDir = createScratchDir()
-    const binary = installFakeCloudflared(
-      scratchDir,
-      `
+  // Spawns cloudflared; absent on the Windows runner. #899
+  test.skipIf(onWindows)(
+    'does not mark healthy when a probe resolves after cloudflared has already exited',
+    async () => {
+      const scratchDir = createScratchDir()
+      const binary = installFakeCloudflared(
+        scratchDir,
+        `
 echo "https://exited.trycloudflare.com" >&2
 exit 1
 `,
-    )
-    let releaseProbe!: () => void
-    const probeGate = new Promise<void>((resolve) => {
-      releaseProbe = resolve
-    })
-    let probeStarted = false
-    const provider = createCloudflareQuickProvider({
-      config,
-      upstreamPort: 4851,
-      binary,
-      onUrlChange: () => {},
-      // Probe blocks until released; by then the process has exited and the
-      // tunnel is in restart backoff. A reachable result must NOT win.
-      probeUpstream: async () => {
-        probeStarted = true
-        await probeGate
-        return true
-      },
-      restartBackoffMs: [30_000],
-      upstreamRecheckMs: 5,
-      stopGraceMs: 10,
-    })
+      )
+      let releaseProbe!: () => void
+      const probeGate = new Promise<void>((resolve) => {
+        releaseProbe = resolve
+      })
+      let probeStarted = false
+      const provider = createCloudflareQuickProvider({
+        config,
+        upstreamPort: 4851,
+        binary,
+        onUrlChange: () => {},
+        // Probe blocks until released; by then the process has exited and the
+        // tunnel is in restart backoff. A reachable result must NOT win.
+        probeUpstream: async () => {
+          probeStarted = true
+          await probeGate
+          return true
+        },
+        restartBackoffMs: [30_000],
+        upstreamRecheckMs: 5,
+        stopGraceMs: 10,
+      })
 
-    try {
-      await provider.start()
-      await waitFor(() => probeStarted, { description: 'probe started' })
-      await waitFor(() => provider.snapshot().detail.includes('restarting'), { description: 'restart backoff entered' })
+      try {
+        await provider.start()
+        await waitFor(() => probeStarted, { description: 'probe started' })
+        await waitFor(() => provider.snapshot().detail.includes('restarting'), {
+          description: 'restart backoff entered',
+        })
 
-      releaseProbe()
-      await Bun.sleep(20)
+        releaseProbe()
+        await Bun.sleep(20)
 
-      const snap = provider.snapshot()
-      expect(snap.status).not.toBe('healthy')
-      expect(snap.detail).toContain('restarting')
-      await provider.stop()
-    } finally {
-      releaseProbe()
-      await provider.stop()
-      rmSync(scratchDir, { recursive: true, force: true })
-    }
-  })
+        const snap = provider.snapshot()
+        expect(snap.status).not.toBe('healthy')
+        expect(snap.detail).toContain('restarting')
+        await provider.stop()
+      } finally {
+        releaseProbe()
+        await provider.stop()
+        rmSync(scratchDir, { recursive: true, force: true })
+      }
+    },
+  )
 })


### PR DESCRIPTION
## Background

Closes #899.

The windows-test informational-triage CI lane was failing ~180 tests. Failures fell into two buckets: (1) host-stage product code that assumed POSIX (unix sockets, `:` separators, raw import specifiers, split-on-slash), and (2) test-only assertions that assumed POSIX paths, executables, or filesystem semantics. The container stage is always Linux, so no container runtime behavior changes.

## Summary

Four host-stage product fixes ported the load-bearing assumptions to platform-aware paths; a sweep across ~30 test files hardened everything else to run on Windows without skewing coverage on macOS.

## Product fixes

### `fix(hostd)` — Unix socket → named pipe IPC (4 commits)

The hostd CLI↔daemon IPC used Bun's native unix-socket APIs, which do not exist on Windows. Both sides are now on a single `node:net` code path (same newline-JSON protocol). `socketPath()` is now platform-aware:

- **POSIX** — unchanged: returns the unix socket path; `listen()` keeps the stale-socket probe + unlink and `chmod 0600`.
- **Windows** — returns `\\.\pipe\typeclaw-hostd-<hash>` keyed on uid + `TYPECLAW_HOME`; EADDRINUSE is mapped to "daemon already listening"; file-only steps (unlink, chmod) are skipped.

The token-authed container HTTP `/rpc` leg is deliberately untouched — it remains a security boundary and is not widened by this change.

The post-shutdown wait is also ported: named pipes leave no socket file, so the POSIX stat-probe is replaced with a poll of `isDaemonReachable()`.

### `fix(todo)` — Comma separator for channel scope keys

Channel todo scope keys used `:` as a join separator. Colons are illegal in Windows filenames, so files like `todo/channel/slack:C123:T456.json` could not be created. The separator is now `,`; `encodeURIComponent` always escapes `,` to `%2C`, so the key stays injective and collision-free. Pre-existing POSIX channel todo files are orphaned (ephemeral continuation state — no migration).

### `fix(plugin)` — `file://` URL import specifiers

Dynamic `import()` of a raw absolute path (e.g. a bare Windows drive path) is not a valid import specifier. Plugin entry paths are now resolved as `file://` URLs before the dynamic import, which is valid on both platforms and a no-op on Linux.

### `fix(channels)` — KakaoTalk attachment filename via `basename`

The filename fallback used `split('/')`, yielding the full path on a non-POSIX host. Replaced with `node:path` `basename()`, which is correct on both platforms and identical at container runtime (always POSIX).

## Test-only changes

Across 51 files (~11 commits), mechanical hardening with no product behavior change:

- **Skip guards** — `test.skipIf(isWindows())` on tests that require `/bin/sh` shims, fake extensionless binaries, cloudflared, POSIX symlinks, process-group SIGTERM, `chmod`-effective mode assertions on NTFS, and `/tmp` container-scratch paths. Every skip cites #899.
- **Path normalization** — separator-agnostic assertions (`[/\\]` tolerant regex, `path.sep`, `path.posix`) where the product value is correct on both platforms but the assertion was POSIX-only.
- **EBUSY cleanup** — `fs.rm` with `maxRetries` / `retryDelay` in temp-dir teardown where Windows file locking can cause EBUSY on open handles.

All guards use `isWindows()` from `@/shared`, consistent with the existing convention (cbc4d6da, 73ff1d06).

## Security note

Native-Windows hostd IPC uses Node named pipes. Named pipes lack the POSIX unix-socket `chmod 0600` permission. This is accepted under TypeClaw's single-tenant dev-box trust model: the daemon only binds on the host, the token-authed `/rpc` container boundary is unchanged, and no new network surface is opened. Multi-user Windows host scenarios are out of scope for the existing threat model.

## What this does NOT do

- Does not change any container-runtime behavior — the agent always runs on Linux.
- Does not migrate pre-existing channel todo files (`:` → `,`) — the files are ephemeral continuation state.
- Does not suppress Windows-only skips from running on macOS — every guarded test still runs and passes there.

## Test plan

**macOS (verified):** `bun run typecheck` (0 errors), `bun run lint` (0 errors), `bun run format:check` (clean), `bun run test` (9214 pass / 1 pre-existing skip / 0 fail across 475 files). Windows-only skips do not fire on macOS.

**Windows:** confirmed by the windows-test CI lane on this PR.