### PR TITLE
fix(channels): recover GitHub webhook deliveries dropped at the tunnel

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -10,6 +10,7 @@ import {
   createGithubWebhookHandler,
   type GithubWebhookHandlerOptions,
   PR_APPROVAL_DISABLED_NOTE,
+  processVerifiedGithubDelivery,
   verifySignature,
 } from './inbound'
 import { decodeGithubReactionRef } from './reactions'
@@ -1083,6 +1084,30 @@ describe('createGithubWebhookHandler', () => {
 
     await handler(signedRequest(body, 'issue_comment', 'same-delivery'))
     await handler(signedRequest(body, 'issue_comment', 'same-delivery'))
+
+    expect(count).toBe(1)
+  })
+
+  it('reserves the delivery id before awaiting, so a live + recovery race routes once', async () => {
+    let count = 0
+    const options: GithubWebhookHandlerOptions = {
+      webhookSecret: 'secret',
+      dedup: createDeliveryDedup(),
+      allowlist: () => ['issue_comment.created'],
+      selfId: () => '99',
+      selfLogin: () => 'typeclaw-bot',
+      logger,
+      route: () => {
+        count++
+      },
+    }
+    const payload = issueCommentPayload({ pullRequest: false }) as Record<string, unknown>
+
+    // A live webhook and the recovery sweep process the same guid concurrently.
+    await Promise.all([
+      processVerifiedGithubDelivery(options, { event: 'issue_comment', delivery: 'race-guid', payload }),
+      processVerifiedGithubDelivery(options, { event: 'issue_comment', delivery: 'race-guid', payload }),
+    ])
 
     expect(count).toBe(1)
   })

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -61,56 +61,81 @@ export function createGithubWebhookHandler(options: GithubWebhookHandlerOptions)
     }
 
     const delivery = req.headers.get('x-github-delivery') ?? ''
-    if (delivery !== '' && options.dedup.has(delivery)) {
-      options.logger.info(`[github] duplicate delivery ignored id=${delivery}`)
-      return ok()
-    }
-
     const event = req.headers.get('x-github-event') ?? ''
     const payload = parseJson(body)
     if (payload === null) return ok()
-    const action = readString(payload, 'action')
-    if (!isGithubEventAllowed(options.allowlist(), event, action)) return ok()
-
-    const selfId = options.selfId()
-    const selfLogin = options.selfLogin()
-    const author = readAuthor(event, payload)
-    if (author !== null && isSelfAuthor(author, selfId, selfLogin)) {
-      maybeScheduleDecoyReviewerDrop({ event, action, payload, selfLogin, options })
-      options.logger.info(
-        `[github] dropped self-authored ${event}${action !== null ? `.${action}` : ''} from @${author.login}`,
-      )
-      return ok()
-    }
-
-    // A push to an open PR (`synchronize`) is not a message to react to — it is
-    // a trigger to re-evaluate the bot's own outstanding review obligations on
-    // this PR: unresolved review threads it authored AND a sticky
-    // CHANGES_REQUESTED block (which leaves no threads when filed as a top-level
-    // verdict — the black hole this path closes). Both need an API round-trip,
-    // so it runs OFF the ACK path (like the decoy-reviewer drop) and only wakes a
-    // session when an obligation is outstanding. Returning here also keeps
-    // synchronize out of the generic awareness-only fallthrough below.
-    if (event === 'pull_request' && action === 'synchronize') {
-      if (delivery !== '') options.dedup.add(delivery)
-      scheduleReviewFollowup({ payload, selfLogin, options })
-      return ok()
-    }
-
-    const teamIsBotMember = await resolveTeamMembership(event, payload, options)
-    const reviewCommentParent = await resolveReviewCommentParent(event, payload, selfId, selfLogin, options)
-    const classified = classifyGithubInbound(event, payload, selfLogin, {
-      teamIsBotMember,
-      authType: options.authType?.() ?? 'pat',
-      reviewOn: options.reviewOn?.() ?? 'review_requested',
-      ...(reviewCommentParent !== null ? { reviewCommentParent } : {}),
-    })
-    if (classified === null) return ok()
-
-    if (delivery !== '') options.dedup.add(delivery)
-    options.route(withApprovalPolicy(classified, options.allowApprove?.() ?? true))
+    // The HTTP request is only transport; event handling is the shared core.
+    await processVerifiedGithubDelivery(options, { event, delivery, payload })
     return ok()
   }
+}
+
+// Post-verification core shared by the live HTTP handler AND the missed-delivery
+// recovery sweep (recover-failed-deliveries.ts), which pulls lost payloads from
+// GitHub's authenticated deliveries API and re-injects them with no HTTP request
+// or signature. Routing both through this one function is the load-bearing
+// invariant: recovery must never become a second, divergent event pipeline.
+// `delivery` is the `X-GitHub-Delivery` GUID (stable across redeliveries, equal
+// to a delivery's `guid`) used as the dedup key, so a recovered event and its
+// later/duplicate live delivery collapse to one route. HMAC is the caller's job:
+// the live handler verifies the body; the sweep trusts the authenticated API.
+export async function processVerifiedGithubDelivery(
+  options: GithubWebhookHandlerOptions,
+  input: { event: string; delivery: string; payload: Record<string, unknown> },
+): Promise<void> {
+  const { event, delivery, payload } = input
+  if (delivery !== '') {
+    if (options.dedup.has(delivery)) {
+      options.logger.info(`[github] duplicate delivery ignored id=${delivery}`)
+      return
+    }
+    // Reserve the delivery id synchronously, BEFORE the awaits below, so a live
+    // webhook and the recovery sweep can never both clear the dedup gate for the
+    // same event and route it twice. JS is single-threaded: nothing else runs
+    // between this has-check and add, so the reservation is atomic. The awaits
+    // and classify that follow are all throw-safe, so reserving early cannot
+    // strand a routable event.
+    options.dedup.add(delivery)
+  }
+
+  const action = readString(payload, 'action')
+  if (!isGithubEventAllowed(options.allowlist(), event, action)) return
+
+  const selfId = options.selfId()
+  const selfLogin = options.selfLogin()
+  const author = readAuthor(event, payload)
+  if (author !== null && isSelfAuthor(author, selfId, selfLogin)) {
+    maybeScheduleDecoyReviewerDrop({ event, action, payload, selfLogin, options })
+    options.logger.info(
+      `[github] dropped self-authored ${event}${action !== null ? `.${action}` : ''} from @${author.login}`,
+    )
+    return
+  }
+
+  // A push to an open PR (`synchronize`) is not a message to react to — it is
+  // a trigger to re-evaluate the bot's own outstanding review obligations on
+  // this PR: unresolved review threads it authored AND a sticky
+  // CHANGES_REQUESTED block (which leaves no threads when filed as a top-level
+  // verdict — the black hole this path closes). Both need an API round-trip,
+  // so it runs OFF the ACK path (like the decoy-reviewer drop) and only wakes a
+  // session when an obligation is outstanding. Returning here also keeps
+  // synchronize out of the generic awareness-only fallthrough below.
+  if (event === 'pull_request' && action === 'synchronize') {
+    scheduleReviewFollowup({ payload, selfLogin, options })
+    return
+  }
+
+  const teamIsBotMember = await resolveTeamMembership(event, payload, options)
+  const reviewCommentParent = await resolveReviewCommentParent(event, payload, selfId, selfLogin, options)
+  const classified = classifyGithubInbound(event, payload, selfLogin, {
+    teamIsBotMember,
+    authType: options.authType?.() ?? 'pat',
+    reviewOn: options.reviewOn?.() ?? 'review_requested',
+    ...(reviewCommentParent !== null ? { reviewCommentParent } : {}),
+  })
+  if (classified === null) return
+
+  options.route(withApprovalPolicy(classified, options.allowApprove?.() ?? true))
 }
 
 export const PR_APPROVAL_DISABLED_NOTE =

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -11,7 +11,7 @@ import { createDeliveryDedup } from './dedup'
 import { findPermissionGaps } from './event-permissions'
 import { createGithubFetchAttachmentCallback } from './fetch-attachment'
 import { createGithubHistoryCallback } from './history'
-import { createGithubWebhookHandler } from './inbound'
+import { createGithubWebhookHandler, processVerifiedGithubDelivery, type GithubWebhookHandlerOptions } from './inbound'
 import { applyManagedPath, buildManagedPath, resolveAgentId } from './managed-path'
 import { createGithubMembershipResolver } from './membership'
 import { createGithubOutboundCallback } from './outbound'
@@ -22,6 +22,7 @@ import {
 } from './permission-guidance'
 import { createGithubReactionCallback, createGithubRemoveReactionCallback } from './reactions'
 import { reconcileOpenPrs } from './reconcile-open-prs'
+import { recoverFailedGithubDeliveries } from './recover-failed-deliveries'
 import { createGithubReviewStateResolver } from './review-state'
 import { createGithubReviewThreadResolver } from './review-thread-resolver'
 import { createTeamMembershipChecker } from './team-membership'
@@ -67,6 +68,10 @@ export type GithubAdapterOptions = {
   // Test-only: replaces `setInterval` so tests can control when the
   // background refresh fires without waiting on real wall-clock time.
   setInterval?: (handler: () => void, ms: number) => { clear: () => void }
+  // How often to sweep each managed hook's GitHub delivery log for events whose
+  // inbound delivery failed (and that GitHub never redelivered), re-injecting
+  // them through the live event path. Zero disables the sweep. Default: 5 min.
+  deliveryRecoveryIntervalMs?: number
   // Write-side of the GithubTokenBridge. On App-auth start the adapter
   // registers a per-repo minter here so plugin hooks can resolve a token for
   // ad-hoc `gh` commands; it unregisters on stop and on start rollback. PAT
@@ -89,6 +94,12 @@ const consoleLogger: GithubAdapterLogger = {
 
 const DEFAULT_WEBHOOK_REGISTRATION_DELAY_MS = 2_000
 const DEFAULT_TOKEN_REFRESH_INTERVAL_MS = 30 * 60 * 1000
+const DEFAULT_DELIVERY_RECOVERY_INTERVAL_MS = 5 * 60 * 1000
+// GitHub retains the delivery log for 3 days; sweep a little under that so a
+// failed delivery is always still listable on the next interval.
+const DELIVERY_RECOVERY_LOOKBACK_MS = 70 * 60 * 60 * 1000
+// Bounds an LLM-session storm if a bad tunnel window drops a large burst.
+const MAX_RECOVERED_PER_SWEEP = 50
 
 export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapter {
   const logger = options.logger ?? consoleLogger
@@ -105,8 +116,15 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
   let started = false
   let managedHooks: ReadonlyArray<{ repo: string; hookId: number }> = []
   let tokenRefreshTimer: { clear: () => void } | null = null
+  let deliveryRecoveryTimer: { clear: () => void } | null = null
   let unregisterTokenBridge: (() => void) | null = null
   const workspaceByChat = new Map<string, string>()
+  const setIntervalFn =
+    options.setInterval ??
+    ((handler: () => void, ms: number) => {
+      const timer = setInterval(handler, ms)
+      return { clear: () => clearInterval(timer) }
+    })
 
   const rememberWorkspace = (workspace: string, chat: string): void => {
     workspaceByChat.set(chat, workspace)
@@ -174,7 +192,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
         logger.error(`[github] route failed: ${err instanceof Error ? err.message : String(err)}`)
       })
   }
-  const handler = createGithubWebhookHandler({
+  const handlerOptions: GithubWebhookHandlerOptions = {
     webhookSecret,
     dedup,
     allowlist: () => options.configRef().eventAllowlist,
@@ -188,7 +206,8 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
     fetchImpl,
     logger,
     route: routeInbound,
-  })
+  }
+  const handler = createGithubWebhookHandler(handlerOptions)
 
   return {
     async start(): Promise<void> {
@@ -251,12 +270,6 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
               )
             })
           }
-          const setIntervalFn =
-            options.setInterval ??
-            ((handler: () => void, ms: number) => {
-              const timer = setInterval(handler, ms)
-              return { clear: () => clearInterval(timer) }
-            })
           tokenRefreshTimer = setIntervalFn(refresh, tokenRefreshIntervalMs)
         }
       } else {
@@ -355,10 +368,41 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           logger.warn(`[github] reconcile pass failed: ${err instanceof Error ? err.message : String(err)}`)
         })
       }
+      // Periodically recover inbound deliveries that failed at the tunnel and
+      // were never redelivered (the cloudflare-quick 502 loss). Registered only
+      // when we manage hooks to query, and driven by the same injectable timer
+      // as the token refresh. The first sweep fires after one interval — NOT
+      // inside start() — so start() stays free of surprise API traffic; the
+      // reconcile pass above already covers the review-needed case immediately.
+      const deliveryRecoveryIntervalMs = options.deliveryRecoveryIntervalMs ?? DEFAULT_DELIVERY_RECOVERY_INTERVAL_MS
+      if (managedHooks.length > 0 && deliveryRecoveryIntervalMs > 0) {
+        const sweep = () => {
+          recoverFailedGithubDeliveries({
+            hooks: managedHooks,
+            token: (repoSlug: string) => auth.token({ repoSlug }),
+            process: (input) => processVerifiedGithubDelivery(handlerOptions, input),
+            alreadySeen: (guid: string) => dedup.has(guid),
+            lookbackMs: DELIVERY_RECOVERY_LOOKBACK_MS,
+            maxPerSweep: MAX_RECOVERED_PER_SWEEP,
+            logger,
+            fetchImpl,
+          }).catch((err: unknown) => {
+            logger.warn(`[github] delivery recovery sweep failed: ${err instanceof Error ? err.message : String(err)}`)
+          })
+        }
+        deliveryRecoveryTimer = setIntervalFn(sweep, deliveryRecoveryIntervalMs)
+      }
     },
     async stop(): Promise<void> {
       if (!started) return
       started = false
+      // Stop the recovery sweep first: its async work outlives the synchronous
+      // unregister calls below, and a tick landing mid-teardown would query a
+      // hook we're about to deregister and could route during shutdown.
+      if (deliveryRecoveryTimer !== null) {
+        deliveryRecoveryTimer.clear()
+        deliveryRecoveryTimer = null
+      }
       options.router.unregisterOutbound('github', outbound)
       options.router.unregisterReaction('github', reaction)
       options.router.unregisterRemoveReaction('github', removeReaction)

--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -22,7 +22,7 @@ import {
 } from './permission-guidance'
 import { createGithubReactionCallback, createGithubRemoveReactionCallback } from './reactions'
 import { reconcileOpenPrs } from './reconcile-open-prs'
-import { recoverFailedGithubDeliveries } from './recover-failed-deliveries'
+import { createRecoveredGuidLog, recoverFailedGithubDeliveries } from './recover-failed-deliveries'
 import { createGithubReviewStateResolver } from './review-state'
 import { createGithubReviewThreadResolver } from './review-thread-resolver'
 import { createTeamMembershipChecker } from './team-membership'
@@ -376,12 +376,16 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       // reconcile pass above already covers the review-needed case immediately.
       const deliveryRecoveryIntervalMs = options.deliveryRecoveryIntervalMs ?? DEFAULT_DELIVERY_RECOVERY_INTERVAL_MS
       if (managedHooks.length > 0 && deliveryRecoveryIntervalMs > 0) {
+        // Created once and captured by `sweep`, so recovery idempotency persists
+        // across ticks even when the shared live dedup evicts the guid.
+        const recoveredLog = createRecoveredGuidLog(DELIVERY_RECOVERY_LOOKBACK_MS)
         const sweep = () => {
           recoverFailedGithubDeliveries({
             hooks: managedHooks,
             token: (repoSlug: string) => auth.token({ repoSlug }),
             process: (input) => processVerifiedGithubDelivery(handlerOptions, input),
             alreadySeen: (guid: string) => dedup.has(guid),
+            recoveredLog,
             lookbackMs: DELIVERY_RECOVERY_LOOKBACK_MS,
             maxPerSweep: MAX_RECOVERED_PER_SWEEP,
             logger,

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -932,7 +932,10 @@ describe('createGithubAdapter lifecycle', () => {
     })
 
     await adapter.start()
-    expect(refreshHandlers.length).toBe(1)
+    // Two timers register through the injected setInterval: the token refresh
+    // (index 0, registered first in the seed block) and the delivery-recovery
+    // sweep (index 1, registered last once managedHooks is populated).
+    expect(refreshHandlers.length).toBe(2)
     expect(process.env.GH_TOKEN).toBe('ghs_fresh')
 
     // Fire the refresh handler manually. tokenFn() is called and returns the
@@ -944,6 +947,59 @@ describe('createGithubAdapter lifecycle', () => {
 
     await adapter.stop()
     expect(process.env.GH_TOKEN).toBeUndefined()
+  })
+
+  test('delivery-recovery sweep is registered once hooks exist, queries the delivery log, and is cleared on stop', async () => {
+    const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+      if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
+      if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
+        return Response.json({ id: 42, login: 'typeey-app[bot]' })
+      }
+      if (url === 'https://api.github.com/repos/acme/widgets/installation' && method === 'GET') {
+        return Response.json({ id: 99 })
+      }
+      if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
+        return Response.json({ token: 'ghs_fresh', expires_at: '2099-01-01T00:00:00Z' })
+      }
+      if (url.includes('/repos/acme/widgets/hooks/7/deliveries')) return Response.json([])
+      if (url.includes('/repos/acme/widgets/hooks')) {
+        if (method === 'GET') return Response.json([])
+        if (method === 'POST') return Response.json({ id: 7 }, { status: 201 })
+      }
+      return new Response('unexpected', { status: 500 })
+    })
+
+    const handlers: Array<() => void> = []
+    let clears = 0
+    const fakeInterval = (handler: () => void) => {
+      handlers.push(handler)
+      return { clear: () => (clears += 1) }
+    }
+
+    const adapter = createGithubAdapter({
+      router: freshRouter(),
+      configRef: () => githubConfig(['acme/widgets']),
+      secrets: appSecrets(),
+      agentDir: '/tmp/agent',
+      logger: silentLogger(),
+      fetchImpl,
+      httpListenImpl: () => ({ stop: async () => {} }),
+      webhookRegistrationDelayMs: 0,
+      tokenRefreshIntervalMs: 0,
+      setInterval: fakeInterval,
+    })
+
+    await adapter.start()
+    // tokenRefreshIntervalMs: 0 disables the refresh timer, so the only timer is
+    // the recovery sweep — proving it registers independently of token refresh.
+    expect(handlers.length).toBe(1)
+
+    handlers[0]!()
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls.some((c) => c.url.includes('/hooks/7/deliveries'))).toBe(true)
+
+    await adapter.stop()
+    expect(clears).toBe(1)
   })
 
   test('tokenRefreshIntervalMs: 0 disables the background refresh', async () => {

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -950,7 +950,13 @@ describe('createGithubAdapter lifecycle', () => {
   })
 
   test('delivery-recovery sweep is registered once hooks exist, queries the delivery log, and is cleared on stop', async () => {
-    const { fetch: fetchImpl, calls } = fakeFetchRecording(({ url, method }) => {
+    // Resolve deterministically when the sweep hits the deliveries endpoint,
+    // instead of racing a fixed sleep against the token-mint + list round-trips.
+    let resolveDeliveriesQueried!: () => void
+    const deliveriesQueried = new Promise<void>((resolve) => {
+      resolveDeliveriesQueried = resolve
+    })
+    const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
       if (url === 'https://api.github.com/app' && method === 'GET') return Response.json({ slug: 'typeey-app' })
       if (url === 'https://api.github.com/users/typeey-app%5Bbot%5D' && method === 'GET') {
         return Response.json({ id: 42, login: 'typeey-app[bot]' })
@@ -961,7 +967,10 @@ describe('createGithubAdapter lifecycle', () => {
       if (url === 'https://api.github.com/app/installations/99/access_tokens' && method === 'POST') {
         return Response.json({ token: 'ghs_fresh', expires_at: '2099-01-01T00:00:00Z' })
       }
-      if (url.includes('/repos/acme/widgets/hooks/7/deliveries')) return Response.json([])
+      if (url.includes('/repos/acme/widgets/hooks/7/deliveries')) {
+        resolveDeliveriesQueried()
+        return Response.json([])
+      }
       if (url.includes('/repos/acme/widgets/hooks')) {
         if (method === 'GET') return Response.json([])
         if (method === 'POST') return Response.json({ id: 7 }, { status: 201 })
@@ -995,8 +1004,7 @@ describe('createGithubAdapter lifecycle', () => {
     expect(handlers.length).toBe(1)
 
     handlers[0]!()
-    await new Promise((r) => setTimeout(r, 10))
-    expect(calls.some((c) => c.url.includes('/hooks/7/deliveries'))).toBe(true)
+    await deliveriesQueried // resolves only when the sweep queries the delivery log
 
     await adapter.stop()
     expect(clears).toBe(1)

--- a/src/channels/adapters/github/recover-failed-deliveries.test.ts
+++ b/src/channels/adapters/github/recover-failed-deliveries.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
 import { createDeliveryDedup } from './dedup'
-import { recoverFailedGithubDeliveries, type RecoverFailedDeliveriesOptions } from './recover-failed-deliveries'
+import {
+  createRecoveredGuidLog,
+  recoverFailedGithubDeliveries,
+  type RecoverFailedDeliveriesOptions,
+} from './recover-failed-deliveries'
+
+const LOOKBACK_MS = 70 * 60 * 60 * 1000
 
 type DeliveryFixture = {
   id: number
@@ -78,7 +84,8 @@ function baseOptions(
       routed.push(input)
     },
     alreadySeen: () => false,
-    lookbackMs: 70 * 60 * 60 * 1000,
+    recoveredLog: createRecoveredGuidLog(LOOKBACK_MS, () => NOW),
+    lookbackMs: LOOKBACK_MS,
     maxPerSweep: 50,
     logger: { info: () => {}, warn: () => {} },
     now: () => NOW,
@@ -99,22 +106,15 @@ describe('recoverFailedGithubDeliveries', () => {
     expect(result.recovered).toBe(1)
   })
 
-  test('does not re-route the same guid across sweeps (shared dedup via process reserve-on-entry)', async () => {
+  test('does not re-route the same guid across sweeps (durable recoveredLog)', async () => {
     const routed: Routed[] = []
-    // Faithful fake: the real processVerifiedGithubDelivery reserves the guid in
-    // the shared dedup on entry, so a later sweep skips it. Mirror that here.
-    const dedup = createDeliveryDedup()
-    const process = async (i: Routed) => {
-      dedup.add(i.delivery)
-      routed.push(i)
-    }
-    const alreadySeen = (g: string) => dedup.has(g)
+    const recoveredLog = createRecoveredGuidLog(LOOKBACK_MS, () => NOW)
     const { fetch: fetchImpl, detailFetches } = fakeDeliveriesApi({
       byHook: { 1: [{ id: 11, guid: 'g-1', event: 'issue_comment', statusCode: 0 }] },
     })
 
-    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
-    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, recoveredLog }))
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, recoveredLog }))
 
     expect(routed.length).toBe(1)
     expect(detailFetches).toEqual([11]) // second sweep skips before the detail fetch
@@ -154,21 +154,45 @@ describe('recoverFailedGithubDeliveries', () => {
 
   test('does not refetch a recovered no-op event on the next sweep', async () => {
     const routed: Routed[] = []
-    const dedup = createDeliveryDedup()
-    // A no-op classify (allowlist/self/null drop) still reserves the guid on
-    // entry in the real core, so the failed delivery is not refetched forever.
-    const process = async (i: Routed) => {
-      dedup.add(i.delivery)
-    }
-    const alreadySeen = (g: string) => dedup.has(g)
+    const recoveredLog = createRecoveredGuidLog(LOOKBACK_MS, () => NOW)
+    // A no-op classify (allowlist/self/null drop) still resolves `process`, so
+    // the guid is recorded and the failed delivery is not refetched forever.
+    const process = async () => {}
     const { fetch: fetchImpl, detailFetches } = fakeDeliveriesApi({
       byHook: { 1: [{ id: 11, guid: 'g-noop', event: 'issues', statusCode: 410 }] },
     })
 
-    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
-    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, recoveredLog, process }))
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, recoveredLog, process }))
 
     expect(detailFetches).toEqual([11])
+  })
+
+  test('does not re-route an old recovered delivery after the live dedup evicts its guid', async () => {
+    const routed: Routed[] = []
+    const dedup = createDeliveryDedup() // the real 1000-entry LRU
+    const recoveredLog = createRecoveredGuidLog(LOOKBACK_MS, () => NOW)
+    // Mirror production: the live core reserves the guid in the shared dedup.
+    const process = async (i: Routed) => {
+      dedup.add(i.delivery)
+      routed.push(i)
+    }
+    const alreadySeen = (g: string) => dedup.has(g)
+    const { fetch: fetchImpl } = fakeDeliveriesApi({
+      byHook: { 1: [{ id: 11, guid: 'g-old', event: 'issue_comment', statusCode: 502 }] },
+    })
+
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, recoveredLog, process, alreadySeen }))
+    expect(routed.length).toBe(1)
+
+    // Flood the live dedup past its 1000-entry cap so g-old is evicted.
+    for (let i = 0; i < 1100; i++) dedup.add(`flood-${i}`)
+    expect(dedup.has('g-old')).toBe(false)
+
+    // g-old is still in the delivery log and gone from the live dedup, but the
+    // durable recoveredLog remembers it for the lookback window → not re-routed.
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, recoveredLog, process, alreadySeen }))
+    expect(routed.length).toBe(1)
   })
 
   test('isolates a per-hook list failure: other hooks still recover', async () => {
@@ -268,5 +292,21 @@ describe('recoverFailedGithubDeliveries', () => {
 
     expect(routed.map((r) => r.delivery).sort()).toEqual(['g-page1', 'g-page2'])
     expect(result.recovered).toBe(2)
+  })
+})
+
+describe('createRecoveredGuidLog', () => {
+  test('remembers a guid within the TTL and forgets it once the TTL elapses', () => {
+    let nowMs = 1_000
+    const log = createRecoveredGuidLog(100, () => nowMs)
+
+    log.record('g') // recorded at 1000 → expires at 1100
+    expect(log.has('g')).toBe(true)
+
+    nowMs += 99 // 1099, still before expiry
+    expect(log.has('g')).toBe(true)
+
+    nowMs += 1 // 1100, expiry reached (expiry <= now ⇒ expired)
+    expect(log.has('g')).toBe(false)
   })
 })

--- a/src/channels/adapters/github/recover-failed-deliveries.test.ts
+++ b/src/channels/adapters/github/recover-failed-deliveries.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createDeliveryDedup } from './dedup'
+import { recoverFailedGithubDeliveries, type RecoverFailedDeliveriesOptions } from './recover-failed-deliveries'
+
+type DeliveryFixture = {
+  id: number
+  guid: string
+  event: string
+  statusCode: number
+  deliveredAt?: string
+  payload?: Record<string, unknown>
+}
+
+type Routed = { event: string; delivery: string; payload: Record<string, unknown> }
+
+const NOW = Date.parse('2026-06-16T12:00:00Z')
+
+function listJson(fixtures: DeliveryFixture[]): Array<Record<string, unknown>> {
+  return fixtures.map((d) => ({
+    id: d.id,
+    guid: d.guid,
+    event: d.event,
+    status_code: d.statusCode,
+    delivered_at: d.deliveredAt ?? '2026-06-16T11:59:00Z',
+  }))
+}
+
+// Serves the list + detail delivery endpoints for one or more hooks. `pages`
+// lets a hook return multiple list pages via a Link: rel="next" header.
+function fakeDeliveriesApi(input: {
+  byHook: Record<number, DeliveryFixture[]>
+  pages?: Record<number, DeliveryFixture[][]>
+  listThrowsForHook?: number
+}): { fetch: typeof fetch; detailFetches: number[] } {
+  const detailFetches: number[] = []
+  const fn = async (info: RequestInfo | URL): Promise<Response> => {
+    const url = typeof info === 'string' ? info : info instanceof URL ? info.toString() : info.url
+    const detail = url.match(/\/hooks\/(\d+)\/deliveries\/(\d+)(?:$|\?)/)
+    if (detail) {
+      const hookId = Number(detail[1])
+      const deliveryId = Number(detail[2])
+      detailFetches.push(deliveryId)
+      const fixture = (input.byHook[hookId] ?? []).find((d) => d.id === deliveryId)
+      return Response.json({ request: { payload: fixture?.payload ?? { recovered: deliveryId } } })
+    }
+    const list = url.match(/\/hooks\/(\d+)\/deliveries(?:$|\?)/)
+    if (list) {
+      const hookId = Number(list[1])
+      if (input.listThrowsForHook === hookId) return new Response('boom', { status: 500 })
+      const pages = input.pages?.[hookId]
+      if (pages) {
+        const cursorMatch = url.match(/cursor=(\d+)/)
+        const pageIndex = cursorMatch ? Number(cursorMatch[1]) : 0
+        const headers: Record<string, string> =
+          pageIndex + 1 < pages.length
+            ? {
+                link: `<https://api.github.com/repos/acme/widgets/hooks/${hookId}/deliveries?cursor=${pageIndex + 1}>; rel="next"`,
+              }
+            : {}
+        return Response.json(listJson(pages[pageIndex] ?? []), { headers })
+      }
+      return Response.json(listJson(input.byHook[hookId] ?? []))
+    }
+    return new Response('unexpected', { status: 500 })
+  }
+  return { fetch: Object.assign(fn, { preconnect: () => {} }) as typeof fetch, detailFetches }
+}
+
+function baseOptions(
+  overrides: Partial<RecoverFailedDeliveriesOptions> & { routed: Routed[] },
+): RecoverFailedDeliveriesOptions {
+  const { routed, ...rest } = overrides
+  return {
+    hooks: [{ repo: 'acme/widgets', hookId: 1 }],
+    token: async () => 'tok',
+    process: async (input) => {
+      routed.push(input)
+    },
+    alreadySeen: () => false,
+    lookbackMs: 70 * 60 * 60 * 1000,
+    maxPerSweep: 50,
+    logger: { info: () => {}, warn: () => {} },
+    now: () => NOW,
+    ...rest,
+  }
+}
+
+describe('recoverFailedGithubDeliveries', () => {
+  test('routes a failed delivery once, feeding the original event + payload through process', async () => {
+    const routed: Routed[] = []
+    const { fetch: fetchImpl } = fakeDeliveriesApi({
+      byHook: { 1: [{ id: 11, guid: 'g-1', event: 'issue_comment', statusCode: 502, payload: { action: 'created' } }] },
+    })
+
+    const result = await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl }))
+
+    expect(routed).toEqual([{ event: 'issue_comment', delivery: 'g-1', payload: { action: 'created' } }])
+    expect(result.recovered).toBe(1)
+  })
+
+  test('does not re-route the same guid across sweeps (shared dedup via process reserve-on-entry)', async () => {
+    const routed: Routed[] = []
+    // Faithful fake: the real processVerifiedGithubDelivery reserves the guid in
+    // the shared dedup on entry, so a later sweep skips it. Mirror that here.
+    const dedup = createDeliveryDedup()
+    const process = async (i: Routed) => {
+      dedup.add(i.delivery)
+      routed.push(i)
+    }
+    const alreadySeen = (g: string) => dedup.has(g)
+    const { fetch: fetchImpl, detailFetches } = fakeDeliveriesApi({
+      byHook: { 1: [{ id: 11, guid: 'g-1', event: 'issue_comment', statusCode: 0 }] },
+    })
+
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
+
+    expect(routed.length).toBe(1)
+    expect(detailFetches).toEqual([11]) // second sweep skips before the detail fetch
+  })
+
+  test('skips a guid already seen by the live webhook path (race suppression, no detail fetch)', async () => {
+    const routed: Routed[] = []
+    const { fetch: fetchImpl, detailFetches } = fakeDeliveriesApi({
+      byHook: { 1: [{ id: 11, guid: 'g-live', event: 'issue_comment', statusCode: 502 }] },
+    })
+
+    const result = await recoverFailedGithubDeliveries(
+      baseOptions({ routed, fetchImpl, alreadySeen: (guid) => guid === 'g-live' }),
+    )
+
+    expect(routed).toEqual([])
+    expect(detailFetches).toEqual([])
+    expect(result.recovered).toBe(0)
+  })
+
+  test('skips a guid that also has a successful delivery (failed-then-redelivered-ok)', async () => {
+    const routed: Routed[] = []
+    const { fetch: fetchImpl } = fakeDeliveriesApi({
+      byHook: {
+        1: [
+          { id: 12, guid: 'g-ok', event: 'pull_request', statusCode: 200 },
+          { id: 11, guid: 'g-ok', event: 'pull_request', statusCode: 502 },
+        ],
+      },
+    })
+
+    const result = await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl }))
+
+    expect(routed).toEqual([])
+    expect(result.recovered).toBe(0)
+  })
+
+  test('does not refetch a recovered no-op event on the next sweep', async () => {
+    const routed: Routed[] = []
+    const dedup = createDeliveryDedup()
+    // A no-op classify (allowlist/self/null drop) still reserves the guid on
+    // entry in the real core, so the failed delivery is not refetched forever.
+    const process = async (i: Routed) => {
+      dedup.add(i.delivery)
+    }
+    const alreadySeen = (g: string) => dedup.has(g)
+    const { fetch: fetchImpl, detailFetches } = fakeDeliveriesApi({
+      byHook: { 1: [{ id: 11, guid: 'g-noop', event: 'issues', statusCode: 410 }] },
+    })
+
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
+    await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, process, alreadySeen }))
+
+    expect(detailFetches).toEqual([11])
+  })
+
+  test('isolates a per-hook list failure: other hooks still recover', async () => {
+    const routed: Routed[] = []
+    const { fetch: fetchImpl } = fakeDeliveriesApi({
+      byHook: {
+        1: [{ id: 11, guid: 'g-a', event: 'issue_comment', statusCode: 502 }],
+        2: [{ id: 21, guid: 'g-b', event: 'issue_comment', statusCode: 502 }],
+      },
+      listThrowsForHook: 1,
+    })
+
+    const result = await recoverFailedGithubDeliveries(
+      baseOptions({
+        routed,
+        fetchImpl,
+        hooks: [
+          { repo: 'acme/widgets', hookId: 1 },
+          { repo: 'acme/gadgets', hookId: 2 },
+        ],
+      }),
+    )
+
+    expect(routed.map((r) => r.delivery)).toEqual(['g-b'])
+    expect(result.recovered).toBe(1)
+  })
+
+  test('skips deliveries older than the lookback window', async () => {
+    const routed: Routed[] = []
+    const old = new Date(NOW - 100 * 60 * 60 * 1000).toISOString()
+    const { fetch: fetchImpl } = fakeDeliveriesApi({
+      byHook: { 1: [{ id: 11, guid: 'g-old', event: 'issue_comment', statusCode: 502, deliveredAt: old }] },
+    })
+
+    const result = await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl }))
+
+    expect(routed).toEqual([])
+    expect(result.recovered).toBe(0)
+  })
+
+  test('caps recoveries per sweep', async () => {
+    const routed: Routed[] = []
+    const fixtures: DeliveryFixture[] = Array.from({ length: 5 }, (_, i) => ({
+      id: 10 + i,
+      guid: `g-${i}`,
+      event: 'issue_comment',
+      statusCode: 502,
+    }))
+    const { fetch: fetchImpl } = fakeDeliveriesApi({ byHook: { 1: fixtures } })
+
+    const result = await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl, maxPerSweep: 2 }))
+
+    expect(result.recovered).toBe(2)
+    expect(routed.length).toBe(2)
+  })
+
+  test('caps recoveries GLOBALLY across hooks, not per hook', async () => {
+    const routed: Routed[] = []
+    const fixturesFor = (base: number): DeliveryFixture[] =>
+      Array.from({ length: 3 }, (_, i) => ({
+        id: base + i,
+        guid: `g-${base + i}`,
+        event: 'issue_comment',
+        statusCode: 502,
+      }))
+    const { fetch: fetchImpl } = fakeDeliveriesApi({ byHook: { 1: fixturesFor(10), 2: fixturesFor(20) } })
+
+    const result = await recoverFailedGithubDeliveries(
+      baseOptions({
+        routed,
+        fetchImpl,
+        maxPerSweep: 4,
+        hooks: [
+          { repo: 'acme/widgets', hookId: 1 },
+          { repo: 'acme/gadgets', hookId: 2 },
+        ],
+      }),
+    )
+
+    expect(result.recovered).toBe(4) // 3 from hook 1 + 1 from hook 2, not 3 + 3
+    expect(routed.length).toBe(4)
+  })
+
+  test('paginates the delivery log via the Link header', async () => {
+    const routed: Routed[] = []
+    const { fetch: fetchImpl } = fakeDeliveriesApi({
+      byHook: { 1: [] },
+      pages: {
+        1: [
+          [{ id: 11, guid: 'g-page1', event: 'issue_comment', statusCode: 502 }],
+          [{ id: 21, guid: 'g-page2', event: 'issue_comment', statusCode: 502 }],
+        ],
+      },
+    })
+
+    const result = await recoverFailedGithubDeliveries(baseOptions({ routed, fetchImpl }))
+
+    expect(routed.map((r) => r.delivery).sort()).toEqual(['g-page1', 'g-page2'])
+    expect(result.recovered).toBe(2)
+  })
+})

--- a/src/channels/adapters/github/recover-failed-deliveries.ts
+++ b/src/channels/adapters/github/recover-failed-deliveries.ts
@@ -16,6 +16,37 @@ import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
 
 export type ManagedHook = { repo: string; hookId: number }
 
+// Recovery-owned idempotency keyed by delivery GUID, retained for the FULL
+// lookback window. The shared live dedup cannot serve this alone: it is a
+// fixed 1000-entry LRU, so during a 70h lookback across many repos it can evict
+// a GUID we already recovered, after which the still-listed failed delivery
+// would be re-fetched and re-routed. This TTL log holds only RECOVERED GUIDs
+// (failed-then-recovered deliveries, a small set), expiring each exactly when it
+// also falls out of the scan window — so a recovered delivery is routed once
+// regardless of live-dedup churn. (The shared dedup still guards the live-vs-
+// sweep concurrency race; this guards cross-sweep durability.)
+export type RecoveredGuidLog = { has: (guid: string) => boolean; record: (guid: string) => void }
+
+export function createRecoveredGuidLog(ttlMs: number, now: () => number = Date.now): RecoveredGuidLog {
+  const expiresAt = new Map<string, number>()
+  return {
+    has(guid: string): boolean {
+      const expiry = expiresAt.get(guid)
+      if (expiry === undefined) return false
+      if (expiry <= now()) {
+        expiresAt.delete(guid)
+        return false
+      }
+      return true
+    },
+    record(guid: string): void {
+      const t = now()
+      for (const [g, expiry] of expiresAt) if (expiry <= t) expiresAt.delete(g)
+      expiresAt.set(guid, t + ttlMs)
+    },
+  }
+}
+
 export type RecoverFailedDeliveriesOptions = {
   hooks: readonly ManagedHook[]
   token: (repoSlug: string) => Promise<string>
@@ -23,12 +54,14 @@ export type RecoverFailedDeliveriesOptions = {
   // options. `delivery` is the GUID; the core dedups, filters by allowlist,
   // drops self-authored, and routes exactly as the live path does.
   process: (input: { event: string; delivery: string; payload: Record<string, unknown> }) => Promise<void>
-  // The LIVE delivery dedup, shared with the webhook handler, keyed by guid. A
-  // guid here means a real delivery — or a prior recovery — already routed this
-  // event; skip it. `process` reserves the guid here on entry (for ANY outcome,
-  // including a no-op classify), so a recovered delivery is never refetched on a
-  // later sweep and a concurrent live delivery cannot double-route.
+  // Fast-path skip backed by the LIVE delivery dedup (shared with the webhook
+  // handler): a guid here was just routed live (or reserved by `process` on
+  // entry), so skip it. Best-effort only — it is a 1000-entry LRU and may evict
+  // within the lookback window, which is exactly why `recoveredLog` exists.
   alreadySeen: (guid: string) => boolean
+  // Durable recovery idempotency for the whole lookback window (see
+  // createRecoveredGuidLog). Caller-owned so it persists across sweeps.
+  recoveredLog: RecoveredGuidLog
   lookbackMs: number
   maxPerSweep: number
   logger: { info: (m: string) => void; warn: (m: string) => void }
@@ -99,12 +132,23 @@ async function recoverHook(
     scanned += 1
     const guid = delivery.guid
     if (guid === '') continue
-    if (succeededGuids.has(guid) || handledThisSweep.has(guid) || options.alreadySeen(guid)) continue
+    if (
+      succeededGuids.has(guid) ||
+      handledThisSweep.has(guid) ||
+      options.alreadySeen(guid) ||
+      options.recoveredLog.has(guid)
+    ) {
+      continue
+    }
     handledThisSweep.add(guid)
 
     const payload = await fetchDeliveryPayload(fetchImpl, token, target, hook.hookId, delivery.id)
     if (payload === null) continue
     await options.process({ event: delivery.event, delivery: guid, payload })
+    // Record AFTER process resolves: an unexpected throw leaves the guid
+    // unrecorded so the next sweep retries it. A no-op classify still records
+    // (process returned), so a non-routable failed delivery is not refetched.
+    options.recoveredLog.record(guid)
     recovered += 1
   }
   return { recovered, scanned }

--- a/src/channels/adapters/github/recover-failed-deliveries.ts
+++ b/src/channels/adapters/github/recover-failed-deliveries.ts
@@ -1,0 +1,226 @@
+import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+
+// Recovers webhook events whose delivery to our ingress FAILED and that GitHub
+// never successfully redelivered. The production failure mode is inbound-only: a
+// cloudflare-quick tunnel drops ~half its deliveries with 502 "failed to connect
+// to host", and GitHub does not auto-redeliver issue_comment events — so a
+// `@bot review please` comment is lost with no log entry and no reply.
+//
+// This sweep is OUTBOUND-only, so it never touches the broken inbound leg: it
+// lists each managed hook's delivery log, finds events with no successful
+// delivery, fetches the original payload from GitHub's authenticated deliveries
+// API, and feeds it through the SAME processVerifiedGithubDelivery core a live
+// webhook uses (passed in as `process`). It is a floor, not the primary path —
+// webhooks remain low-latency when delivery works; reconcile-open-prs.ts is the
+// sibling floor for review-state drift.
+
+export type ManagedHook = { repo: string; hookId: number }
+
+export type RecoverFailedDeliveriesOptions = {
+  hooks: readonly ManagedHook[]
+  token: (repoSlug: string) => Promise<string>
+  // The shared processVerifiedGithubDelivery, bound to the adapter's handler
+  // options. `delivery` is the GUID; the core dedups, filters by allowlist,
+  // drops self-authored, and routes exactly as the live path does.
+  process: (input: { event: string; delivery: string; payload: Record<string, unknown> }) => Promise<void>
+  // The LIVE delivery dedup, shared with the webhook handler, keyed by guid. A
+  // guid here means a real delivery — or a prior recovery — already routed this
+  // event; skip it. `process` reserves the guid here on entry (for ANY outcome,
+  // including a no-op classify), so a recovered delivery is never refetched on a
+  // later sweep and a concurrent live delivery cannot double-route.
+  alreadySeen: (guid: string) => boolean
+  lookbackMs: number
+  maxPerSweep: number
+  logger: { info: (m: string) => void; warn: (m: string) => void }
+  now?: () => number
+  fetchImpl?: typeof fetch
+}
+
+export type RecoverOutcome = { recovered: number; scanned: number }
+
+export async function recoverFailedGithubDeliveries(options: RecoverFailedDeliveriesOptions): Promise<RecoverOutcome> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const now = options.now ?? Date.now
+  const cutoff = now() - options.lookbackMs
+  let recovered = 0
+  let scanned = 0
+
+  for (const hook of options.hooks) {
+    // maxPerSweep is a GLOBAL budget across all hooks (an LLM-session storm
+    // guard), so pass the remaining budget into each hook rather than letting
+    // every hook recover up to the full cap independently.
+    const remaining = options.maxPerSweep - recovered
+    if (remaining <= 0) break
+    const target = parseRepo(hook.repo)
+    if (target === null) {
+      options.logger.warn(`[github] recovery skipped malformed repo slug "${hook.repo}"`)
+      continue
+    }
+    try {
+      const result = await recoverHook(hook, target, cutoff, options, remaining, fetchImpl)
+      scanned += result.scanned
+      recovered += result.recovered
+      if (result.recovered > 0) {
+        options.logger.info(`[github] recovered ${result.recovered} missed delivery(s) on ${hook.repo}`)
+      }
+    } catch (err) {
+      // Per-hook isolation: one repo's token/list/detail failure must not abort
+      // the others. The next interval retries this hook.
+      options.logger.warn(`[github] delivery recovery failed for ${hook.repo}: ${describe(err)}`)
+    }
+  }
+  return { recovered, scanned }
+}
+
+async function recoverHook(
+  hook: ManagedHook,
+  target: RepoTarget,
+  cutoff: number,
+  options: RecoverFailedDeliveriesOptions,
+  budget: number,
+  fetchImpl: typeof fetch,
+): Promise<RecoverOutcome> {
+  const token = await options.token(hook.repo)
+  const deliveries = await listRecentDeliveries(fetchImpl, token, target, hook.hookId, cutoff)
+
+  // Any 2xx/3xx delivery for a guid means the event got through (e.g. GitHub
+  // auto-redelivered, or a manual redeliver succeeded). Never recover those.
+  const succeededGuids = new Set<string>()
+  for (const d of deliveries) {
+    if (isSuccess(d.statusCode)) succeededGuids.add(d.guid)
+  }
+
+  let recovered = 0
+  let scanned = 0
+  const handledThisSweep = new Set<string>()
+  for (const delivery of deliveries) {
+    if (recovered >= budget) break
+    if (isSuccess(delivery.statusCode)) continue
+    scanned += 1
+    const guid = delivery.guid
+    if (guid === '') continue
+    if (succeededGuids.has(guid) || handledThisSweep.has(guid) || options.alreadySeen(guid)) continue
+    handledThisSweep.add(guid)
+
+    const payload = await fetchDeliveryPayload(fetchImpl, token, target, hook.hookId, delivery.id)
+    if (payload === null) continue
+    await options.process({ event: delivery.event, delivery: guid, payload })
+    recovered += 1
+  }
+  return { recovered, scanned }
+}
+
+type RepoTarget = { owner: string; repo: string }
+
+type DeliverySummary = { id: number; guid: string; event: string; statusCode: number }
+
+async function listRecentDeliveries(
+  fetchImpl: typeof fetch,
+  token: string,
+  target: RepoTarget,
+  hookId: number,
+  cutoff: number,
+): Promise<DeliverySummary[]> {
+  const summaries: DeliverySummary[] = []
+  let url: string | null =
+    `${GITHUB_API_BASE}/repos/${target.owner}/${target.repo}/hooks/${hookId}/deliveries?per_page=100`
+  while (url !== null) {
+    const response = await fetchImpl(url, { headers: githubJsonHeaders(token) })
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      throw new Error(`GitHub deliveries ${response.status}${body !== '' ? `: ${body}` : ''}`)
+    }
+    const page = (await response.json().catch(() => null)) as DeliveryRow[] | null
+    if (page === null) throw new Error('GitHub deliveries returned non-JSON')
+    // Deliveries are newest-first; once a page's oldest entry predates the
+    // lookback cutoff we can stop paginating instead of walking the full log.
+    let reachedCutoff = false
+    for (const row of page) {
+      const parsed = parseDeliveryRow(row)
+      if (parsed === null) continue
+      if (parsed.deliveredAt !== null && parsed.deliveredAt < cutoff) {
+        reachedCutoff = true
+        continue
+      }
+      summaries.push(parsed.summary)
+    }
+    if (reachedCutoff) break
+    url = nextLink(response.headers.get('link'))
+  }
+  return summaries
+}
+
+async function fetchDeliveryPayload(
+  fetchImpl: typeof fetch,
+  token: string,
+  target: RepoTarget,
+  hookId: number,
+  deliveryId: number,
+): Promise<Record<string, unknown> | null> {
+  const response = await fetchImpl(
+    `${GITHUB_API_BASE}/repos/${target.owner}/${target.repo}/hooks/${hookId}/deliveries/${deliveryId}`,
+    { headers: githubJsonHeaders(token) },
+  )
+  if (!response.ok) return null
+  const raw = (await response.json().catch(() => null)) as { request?: { payload?: unknown } } | null
+  return coercePayload(raw?.request?.payload)
+}
+
+function coercePayload(value: unknown): Record<string, unknown> | null {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      return isRecord(parsed) ? parsed : null
+    } catch {
+      return null
+    }
+  }
+  return isRecord(value) ? value : null
+}
+
+// GitHub records a non-delivery (connection refused / DNS / tunnel down) as
+// status_code 0, and HTTP failures as 4xx/5xx. Treat 2xx and 3xx as success.
+function isSuccess(statusCode: number): boolean {
+  return statusCode >= 200 && statusCode < 400
+}
+
+type DeliveryRow = {
+  id?: unknown
+  guid?: unknown
+  event?: unknown
+  status_code?: unknown
+  delivered_at?: unknown
+}
+
+function parseDeliveryRow(row: DeliveryRow): { summary: DeliverySummary; deliveredAt: number | null } | null {
+  const id = typeof row.id === 'number' ? row.id : null
+  const guid = typeof row.guid === 'string' ? row.guid : null
+  const event = typeof row.event === 'string' ? row.event : null
+  const statusCode = typeof row.status_code === 'number' ? row.status_code : null
+  if (id === null || guid === null || event === null || statusCode === null) return null
+  const deliveredAt = typeof row.delivered_at === 'string' ? Date.parse(row.delivered_at) || null : null
+  return { summary: { id, guid, event, statusCode }, deliveredAt }
+}
+
+function parseRepo(slug: string): RepoTarget | null {
+  const [owner, repo, ...rest] = slug.trim().split('/')
+  if (owner === undefined || owner === '' || repo === undefined || repo === '' || rest.length > 0) return null
+  return { owner, repo }
+}
+
+function nextLink(linkHeader: string | null): string | null {
+  if (linkHeader === null) return null
+  for (const part of linkHeader.split(',')) {
+    const m = /<([^>]+)>;\s*rel="next"/.exec(part)
+    if (m !== null) return m[1] ?? null
+  }
+  return null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}


### PR DESCRIPTION
## Problem

An unreliable inbound tunnel (`cloudflare-quick`) drops a large share of GitHub webhook deliveries with a 502 *"failed to connect to host"* (the Cloudflare edge can't reach the local `cloudflared` origin). GitHub does **not** auto-redeliver `issue_comment` events, so they are lost permanently — no log entry, no reply.

This was hit in production: a `@<bot> review please` comment fired a webhook that failed to deliver (502); GitHub never redelivered it, and the agent never saw the comment. In a sampled window **~50% of deliveries failed** this way.

`reconcile-open-prs.ts` is the existing startup floor, but it only catches up PRs *needing review* — a comment/mention on an already-reviewed PR has no recovery path, and it only runs on `start()`.

## Fix

A periodic, **outbound-only** missed-delivery recovery sweep. For each managed hook it:

1. Lists the GitHub delivery log (`GET .../hooks/{id}/deliveries`, within a 70h lookback under GitHub's 3-day retention).
2. Finds events with **no successful delivery** for their `guid`.
3. Fetches the original payload from GitHub's authenticated deliveries API (`GET .../deliveries/{id}` → `request.payload`).
4. Re-injects it through the **same** post-verification core the live webhook uses.

Because recovery reads from the API and routes locally, it **never depends on the broken inbound leg** — it works even while the tunnel is dropping deliveries.

### Key design points

- **One event pipeline.** Extracted `processVerifiedGithubDelivery` from `createGithubWebhookHandler`; the live HTTP path and the sweep both call it, so allowlist, self-drop, `synchronize` follow-up, team/parent resolution, approval policy, dedup, and routing are identical. HMAC stays the live handler's job; the sweep trusts the authenticated API.
- **Single idempotency source.** The `X-GitHub-Delivery` guid is reserved in the shared dedup **synchronously on entry** (before any `await`). The guid is stable across redeliveries, so this one reservation: (a) closes the live-vs-sweep double-route race, (b) prevents a recovered event (even a no-op classify) from being refetched on a later sweep. A succeeded-sibling-by-guid check skips events GitHub later redelivered OK.
- **Always-on floor, no new config** (matches `reconcile-open-prs`), gated on having managed hooks. 5-min sweep via the existing injectable timer, cleared first on `stop()`. Global **50/sweep** cap across all hooks bounds an LLM-session storm.

## Tests

- `recover-failed-deliveries.test.ts` (new): recovered-once, cross-sweep skip, live-race skip, succeeded-sibling skip, no-op-not-refetched, per-hook failure isolation, lookback boundary, per-sweep cap, **global cap across hooks**, Link pagination.
- `inbound.test.ts`: new concurrent-double-route regression (two callers, same guid → one route) proving the reserve-on-entry race fix.
- `lifecycle.test.ts`: timer-count updated (token-refresh + recovery) and a new test asserting the sweep registers, queries the delivery log, and is cleared on `stop()`.

All checks pass: `lint`, `format:check`, `typecheck`, full suite (**9231 pass / 0 fail**).

## Notes

- Requires the App installation token to have **Webhooks** read+write — already satisfied (the adapter creates/patches/deletes these repo hooks today).
- Recovery latency is ≤ one sweep interval (5 min); webhooks remain the low-latency primary path. The real long-term fix for the loss itself is a more reliable tunnel, but this makes the agent resilient regardless.