### PR TITLE
fix(channels): require explicit continue on channel_reply

### DIFF
--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -71,9 +71,11 @@ function tool(onSend?: (msg: OutboundMessage) => SendResult, origin: ChannelRepl
 
 async function run(
   t: ReturnType<typeof createChannelReplyTool>,
-  params: Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[1],
+  params: Omit<Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[1], 'continue'> & {
+    continue?: boolean
+  },
 ) {
-  return t.execute('id', params, undefined, undefined, fakeCtx)
+  return t.execute('id', { ...params, continue: params.continue ?? false }, undefined, undefined, fakeCtx)
 }
 
 describe('channel_reply false-receipt guard', () => {

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -86,11 +86,15 @@ const slackChannelRootOrigin: ChannelReplyOrigin = {
 
 const fakeCtx = {} as Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[4]
 
+// `continue` is schema-required; this helper defaults it to `false` (terminal) so
+// tests not exercising the continue path stay terse. Keep the divergence.
 async function runTool(
   tool: ReturnType<typeof createChannelReplyTool>,
-  params: Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[1],
+  params: Omit<Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[1], 'continue'> & {
+    continue?: boolean
+  },
 ) {
-  return tool.execute('id', params, undefined, undefined, fakeCtx)
+  return tool.execute('id', { ...params, continue: params.continue ?? false }, undefined, undefined, fakeCtx)
 }
 
 describe('createChannelReplyTool', () => {
@@ -397,6 +401,14 @@ describe('createChannelReplyTool', () => {
       })
       const result = await runTool(tool, { text: 'nope', continue: true })
       expect(result.details).toEqual({ ok: false, error: 'denied by allow rules' })
+    })
+
+    test('continue is the one required parameter (so the schema rejects a reply that omits it)', () => {
+      const tool = createChannelReplyTool({
+        router: fakeRouter(async () => ({ ok: true })),
+        origin: slackThreadOrigin,
+      })
+      expect((tool.parameters as { required?: readonly string[] }).required).toEqual(['continue'])
     })
   })
 

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -78,15 +78,13 @@ export function createChannelReplyTool({
           },
         ),
       ),
-      continue: Type.Optional(
-        Type.Boolean({
-          description:
-            'Set `true` when this reply is a mid-turn status update (e.g. "working on it…") and you still have work to do THIS turn — fetching data, running a tool, spawning a subagent, then replying again. ' +
-            'Omitting it on such an ack silently truncates the turn: a successful reply ends the turn by default, so the fetch/subagent/answer you intended to do next never runs. ' +
-            'A normal final reply omits this (no wasted follow-up LLM call). ' +
-            'Do not set it just to seem responsive; only when genuine multi-step work follows in the same turn.',
-        }),
-      ),
+      continue: Type.Boolean({
+        description:
+          'REQUIRED on every channel_reply — you must explicitly choose, there is no default. Set `true` when this reply is a mid-turn status update (e.g. "working on it…") and you still have work to do THIS turn — fetching data, running a tool, spawning a subagent, then replying again; `true` keeps the turn alive so that follow-up actually runs. ' +
+          'Set `false` when this reply is your final message for the turn (the common case). ' +
+          'This choice is mandatory precisely because a missing value used to default to ending the turn silently: a successful reply ends the turn unless `continue` is `true`, so a `false` on an ack you meant to keep working from drops the work you promised. ' +
+          'Do not set `true` just to seem responsive; only when genuine multi-step work follows in the same turn.',
+      }),
       resolve_review_thread: Type.Optional(
         Type.Boolean({
           description:

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -164,21 +164,21 @@ describe('channel_reply failure logging', () => {
       origin,
       logger,
     })
-    await tool.execute('id', { text: 'hi' }, undefined, undefined, fakeCtx)
+    await tool.execute('id', { text: 'hi', continue: false }, undefined, undefined, fakeCtx)
     expect(logger.warnings).toEqual(['[channels] channel_reply failed: slack-bot:T0/C0: channel_not_found'])
   })
 
   test('logs early validation when text and attachments are both missing', async () => {
     const logger = captureLogger()
     const tool = createChannelReplyTool({ router: fakeRouter(), origin, logger })
-    await tool.execute('id', {}, undefined, undefined, fakeCtx)
+    await tool.execute('id', { continue: false }, undefined, undefined, fakeCtx)
     expect(logger.warnings).toEqual(['[channels] channel_reply failed: missing text and attachments'])
   })
 
   test('does NOT log on a successful reply', async () => {
     const logger = captureLogger()
     const tool = createChannelReplyTool({ router: fakeRouter({ send: async () => ({ ok: true }) }), origin, logger })
-    await tool.execute('id', { text: 'ok' }, undefined, undefined, fakeCtx)
+    await tool.execute('id', { text: 'ok', continue: false }, undefined, undefined, fakeCtx)
     expect(logger.warnings).toEqual([])
   })
 })

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -165,7 +165,13 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       logger: silent,
     })
 
-    const result = await tool.execute('id', { text: 'sure, here is the rationale' }, undefined, undefined, fakeCtx)
+    const result = await tool.execute(
+      'id',
+      { text: 'sure, here is the rationale', continue: false },
+      undefined,
+      undefined,
+      fakeCtx,
+    )
 
     expect(result.details).toEqual({ ok: true })
     expect(calls).toHaveLength(1)
@@ -205,7 +211,7 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       origin: { adapter: 'github', workspace: inbound.workspace, chat: inbound.chat, thread: inbound.thread },
       logger: silent,
     })
-    await tool.execute('id', { text: 'got it' }, undefined, undefined, fakeCtx)
+    await tool.execute('id', { text: 'got it', continue: false }, undefined, undefined, fakeCtx)
 
     expect(calls[0]?.url).toBe('https://api.github.com/repos/acme/project/pulls/7/comments/555/replies')
   })
@@ -237,7 +243,7 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       origin: { adapter: 'github', workspace: inbound.workspace, chat: inbound.chat, thread: inbound.thread },
       logger: silent,
     })
-    await tool.execute('id', { text: 'reply' }, undefined, undefined, fakeCtx)
+    await tool.execute('id', { text: 'reply', continue: false }, undefined, undefined, fakeCtx)
 
     expect(calls[0]?.url).toContain('/pulls/7/comments/200/replies')
     expect(calls[0]?.url).not.toContain('/issues/7/comments')


### PR DESCRIPTION
## Background

A successful `channel_reply` ends the turn unless `continue: true` is set (the router's `installChannelReplyTerminalHook`). `continue` was **optional**, so a missing value silently defaulted to "end the turn." That default quietly drops promised same-turn work: the model posts "on it, checking now…", the turn aborts, and the fetch/subagent/answer it intended next never runs.

This isn't hypothetical. Across ~3 weeks of production traffic (7 agents, **5,212** `channel_reply` calls):

- **93%** of replies omitted `continue` entirely (4,869); only 3.5% set `true`, 3.4% `false`. The model almost never makes the decision — it's silently defaulted.
- On chat adapters (discord/slack/kakaotalk/line; ~2,694 terminal replies), an estimated **~3.3% (~88)** were "ack, then keep working" promises that truncated mid-work.
- The `continuation-willingness` recovery nudge caught only **~3–4%** of them (≈1 in 29). Its deliberate false-negative bias is near-total in practice.

Root cause: the dominant failure mode is **silent omission** (the decision is never made), not misjudgment. The fix is to remove the silent default.

## Summary

Make `continue` a **required** boolean on `channel_reply` (`Type.Optional(Type.Boolean)` → `Type.Boolean`), forcing an explicit `true`/`false` on every reply. Enforcement rides the existing `safeParse` gate in `plugin-tools.ts` — a reply that omits `continue` is now rejected before `execute`. The parameter description is rewritten to frame the mandatory choice and the consequence of getting it wrong.

- **Why required vs. just widening the detector:** the data says this is a *presence* problem (93% omit), which a required field eliminates outright. The detector only retries after the fact and currently recovers ~4%. A detector overhaul / terminal-default flip are reasonable follow-ups, but they don't address the silent-default root cause.
- **Why a required boolean (not a rename/enum):** the router terminal hook already reads `details.continue`; keeping the name and semantics avoids touching the consumer and the GitHub `resolve_review_thread` flow.

## What this does NOT do

- Does not change the terminal-hook semantics — `continue: true` is still the only thing that keeps a turn alive.
- Does not touch `channel_send` (it has no `continue` param and never ends the turn).
- Does not overhaul or retire the `continuation-willingness` detector (separate follow-up; its ~4% recall is its own finding).
- Does not change GitHub `resolve_review_thread` behavior.

## Review notes

- **Load-bearing change:** the schema in `src/agent/tools/channel-reply.ts`. New guard test asserts `tool.parameters.required` is `['continue']`.
- **Runtime rejection path:** `plugin-tools.ts` `safeParse` now fails a `channel_reply` that omits `continue`, so the model must retry. Expect a transient adaptation cost while models learn to always emit it — acceptable against a ~3.3% silent-truncation rate that was otherwise unrecoverable 96% of the time.
- **Test churn is mechanical:** the two reply test helpers now default `continue: false` for cases that don't exercise the continue path (comment explains the intentional schema-required vs. helper-optional divergence); direct call sites pass `continue: false` explicitly.
