### PR TITLE
fix: make the dev-stage test suite pass on Windows

### DIFF
--- a/src/agent/todo/store.test.ts
+++ b/src/agent/todo/store.test.ts
@@ -109,7 +109,7 @@ describe('todoContentPath traversal guard', () => {
 
   test('accepts a normal nested key', () => {
     const path = todoContentPath(agentDir, { kind: 'channel', key: 'channel/sslack,sw,sc,n' })
-    expect(path.endsWith('todo/channel/sslack,sw,sc,n.json')).toBe(true)
+    expect(path.endsWith(join('todo', 'channel', 'sslack,sw,sc,n.json'))).toBe(true)
   })
 })
 

--- a/src/bundled-plugins/memory/index-vector-retrieval.test.ts
+++ b/src/bundled-plugins/memory/index-vector-retrieval.test.ts
@@ -7,7 +7,7 @@ import { noopPermissionService } from '@/permissions'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
 
 import { renderShard } from './frontmatter'
-import { createMemoryPluginForTests } from './index'
+import { createMemoryPluginForTests, type MemoryPluginDeps } from './index'
 import { topicShardPath, topicsDir } from './paths'
 import { EMBEDDING_MODEL_ID } from './vector/embedder'
 import type { EmbedFn } from './vector/hybrid'
@@ -23,12 +23,15 @@ const DIMS = 8
 const QUERY = 'zzqxvtrprobe'
 
 let agentDir: string
+let disposers: Array<() => Promise<void> | void>
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'memory-vector-retrieval-'))
+  disposers = []
 })
 
 afterEach(async () => {
+  await Promise.all(disposers.map((dispose) => dispose()))
   await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
 })
 
@@ -94,7 +97,7 @@ describe('vector retrieval end-to-end through session.turn.start', () => {
 })
 
 async function bootVectorPlugin(injectionBudgetBytes: number, logger = createPluginLogger('memory')) {
-  const memoryPlugin = createMemoryPluginForTests({ queryEmbedFn: queryAligned() })
+  const memoryPlugin = createMemoryPluginWithStoreCapture({ queryEmbedFn: queryAligned() })
   const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes, vector: { enabled: true } })
   if (!parsed.success) throw new Error(parsed.error.message)
   const ctx = createPluginContext({
@@ -108,6 +111,17 @@ async function bootVectorPlugin(injectionBudgetBytes: number, logger = createPlu
     isBooted: () => true,
   })
   return memoryPlugin.plugin(ctx)
+}
+
+function createMemoryPluginWithStoreCapture(overrides: Partial<MemoryPluginDeps> = {}) {
+  return createMemoryPluginForTests({
+    ...overrides,
+    openAppendVectorStore: (dir) => {
+      const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
+      disposers.push(() => store.close())
+      return store
+    },
+  })
 }
 
 function hookCtx() {

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -7,8 +7,9 @@ import { noopPermissionService } from '@/permissions'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
 
 import { renderShard } from './frontmatter'
-import { createMemoryPluginForTests } from './index'
+import { createMemoryPluginForTests, type MemoryPluginDeps } from './index'
 import { topicShardPath, topicsDir } from './paths'
+import { VectorStore } from './vector/store'
 
 // Injected per plugin instance via the factory, NOT mock.module: a module-level
 // mock of './vector/hybrid' leaks into any sibling test that loads `./index` in
@@ -25,12 +26,15 @@ const hybridSearchMock = mock(async () => [
 ])
 
 let agentDir: string
+let disposers: Array<() => Promise<void> | void>
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'memory-plugin-vector-'))
+  disposers = []
 })
 
 afterEach(async () => {
+  await Promise.all(disposers.map((dispose) => dispose()))
   await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
 })
 
@@ -257,7 +261,7 @@ describe('vector session.turn.start hook', () => {
   })
 
   test('memory-logger subagent is created with onFragmentsAppended hook when vector.enabled is true', async () => {
-    const memoryPlugin = createMemoryPluginForTests()
+    const memoryPlugin = createMemoryPluginWithStoreCapture()
     const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096, vector: { enabled: true } })
     if (!parsed.success) throw new Error(parsed.error.message)
     const ctx = createPluginContext({
@@ -280,7 +284,7 @@ describe('vector session.turn.start hook', () => {
   })
 
   test('memory-logger subagent is created without onFragmentsAppended hook when vector.enabled is false', async () => {
-    const memoryPlugin = createMemoryPluginForTests()
+    const memoryPlugin = createMemoryPluginWithStoreCapture()
     const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes: 4096, vector: { enabled: false } })
     if (!parsed.success) throw new Error(parsed.error.message)
     const ctx = createPluginContext({
@@ -304,7 +308,7 @@ describe('vector session.turn.start hook', () => {
 })
 
 async function bootVectorPlugin(injectionBudgetBytes: number, logger = createPluginLogger('memory')) {
-  const memoryPlugin = createMemoryPluginForTests({ hybridSearch: hybridSearchMock })
+  const memoryPlugin = createMemoryPluginWithStoreCapture({ hybridSearch: hybridSearchMock })
   const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes, vector: { enabled: true } })
   if (!parsed.success) throw new Error(parsed.error.message)
   const ctx = createPluginContext({
@@ -325,7 +329,7 @@ async function bootVectorPluginWith(
   injectionBudgetBytes: number,
   logger = createPluginLogger('memory'),
 ) {
-  const memoryPlugin = createMemoryPluginForTests({ hybridSearch })
+  const memoryPlugin = createMemoryPluginWithStoreCapture({ hybridSearch })
   const parsed = memoryPlugin.configSchema!.safeParse({ injectionBudgetBytes, vector: { enabled: true } })
   if (!parsed.success) throw new Error(parsed.error.message)
   const ctx = createPluginContext({
@@ -339,6 +343,17 @@ async function bootVectorPluginWith(
     isBooted: () => true,
   })
   return memoryPlugin.plugin(ctx)
+}
+
+function createMemoryPluginWithStoreCapture(overrides: Partial<MemoryPluginDeps> = {}) {
+  return createMemoryPluginForTests({
+    ...overrides,
+    openAppendVectorStore: (dir) => {
+      const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
+      disposers.push(() => store.close())
+      return store
+    },
+  })
 }
 
 function capturingLogger(infos: string[]) {

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -21,8 +21,9 @@ import { createPluginContext, createPluginLogger } from '@/plugin/context'
 import { formatLocalDate } from '@/shared'
 
 import { renderShard } from './frontmatter'
-import memoryPlugin from './index'
+import memoryPlugin, { createMemoryPluginForTests, type MemoryPluginDeps } from './index'
 import { streamFilePath, topicShardPath, topicsDir } from './paths'
+import { VectorStore } from './vector/store'
 
 // Fake timers replace ~10s of real setTimeout waits used to exercise the idle
 // debouncer and spawn-timeout race. Date is included in `toFake` so the
@@ -127,6 +128,7 @@ async function bootMemoryPlugin(
   // tests that detach the spawn can distinguish "spawn was kicked off" from
   // "spawn completed". `spawned` records the post-delay completion.
   const started: { name: string; payload: unknown; options: unknown }[] = []
+  const memoryPlugin = createMemoryPluginWithStoreCapture()
   const parsed = memoryPlugin.configSchema!.safeParse(rawConfig)
   if (!parsed.success) throw new Error(`config invalid: ${parsed.error.message}`)
   const spawnDelayMs = options.spawnDelayMs ?? 0
@@ -150,7 +152,19 @@ async function bootMemoryPlugin(
   return { exports, spawned, started, ctx }
 }
 
+function createMemoryPluginWithStoreCapture(overrides: Partial<MemoryPluginDeps> = {}) {
+  return createMemoryPluginForTests({
+    ...overrides,
+    openAppendVectorStore: (dir) => {
+      const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
+      disposers.push(() => store.close())
+      return store
+    },
+  })
+}
+
 let agentDir: string
+let disposers: Array<() => Promise<void> | void>
 
 async function writeTopic(dir: string, slug: string, heading: string, body: string): Promise<void> {
   await mkdir(topicsDir(dir), { recursive: true })
@@ -162,9 +176,11 @@ async function writeTopic(dir: string, slug: string, heading: string, body: stri
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'memory-plugin-'))
+  disposers = []
 })
 
 afterEach(async () => {
+  await Promise.all(disposers.map((dispose) => dispose()))
   await rm(agentDir, { recursive: true, force: true })
 })
 

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -155,12 +155,17 @@ const VECTOR_TURN_TOP_K = 10
 // without loading the ~279 MB model, or `hybridSearch` to fake retrieval while
 // testing hook orchestration — without leaking state across other tests in the
 // same worker. Production uses the real `embed` and `hybridSearch`.
-type MemoryPluginDeps = {
+export type MemoryPluginDeps = {
   hybridSearch: typeof hybridSearch
   queryEmbedFn: EmbedFn
+  openAppendVectorStore: (agentDir: string) => VectorStore
 }
 
-const defaultDeps: MemoryPluginDeps = { hybridSearch, queryEmbedFn: embed }
+const defaultDeps: MemoryPluginDeps = {
+  hybridSearch,
+  queryEmbedFn: embed,
+  openAppendVectorStore: (agentDir) => VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db')),
+}
 
 // Builds the per-turn user-prompt memory block for a vector agent. Non-channel
 // turns always use top-K hybrid search, regardless of total shard size. Repeated
@@ -231,7 +236,7 @@ async function renderVectorTurnMemory(
   }
 }
 
-function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
+export function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
   return definePlugin({
     configSchema: memoryConfigSchema,
     plugin: async (ctx) => {
@@ -401,9 +406,7 @@ function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
       }
 
       // Open a long-lived VectorStore for append-time indexing when vector is enabled.
-      const appendVectorStore = ctx.config.vector.enabled
-        ? VectorStore.open(join(ctx.agentDir, 'memory', '.vectors', 'index.db'))
-        : undefined
+      const appendVectorStore = ctx.config.vector.enabled ? deps.openAppendVectorStore(ctx.agentDir) : undefined
 
       return {
         subagents: {

--- a/src/bundled-plugins/memory/load-shards.test.ts
+++ b/src/bundled-plugins/memory/load-shards.test.ts
@@ -202,27 +202,31 @@ describe('loadAllShards shard cache', () => {
     expect(refreshed[0]?.body).toBe('same-len-v2\n')
   })
 
-  test('invalidates the cached shard when ctime changes even if mtime is preserved (rsync -t / touch -r case)', async () => {
-    const agentDir = await makeAgentDir()
-    const path = topicShardPath(agentDir, 'alpha')
-    await writeShard(agentDir, 'alpha', 'Alpha', 'v1-body\n')
-    const pinned = new Date(1779000000000)
-    await utimes(path, pinned, pinned)
+  test.skipIf(process.platform === 'win32')(
+    'invalidates the cached shard when ctime changes even if mtime is preserved (rsync -t / touch -r case)',
+    async () => {
+      // ctime-change-with-preserved-mtime is a Unix rsync/touch scenario, not Windows creation time.
+      const agentDir = await makeAgentDir()
+      const path = topicShardPath(agentDir, 'alpha')
+      await writeShard(agentDir, 'alpha', 'Alpha', 'v1-body\n')
+      const pinned = new Date(1779000000000)
+      await utimes(path, pinned, pinned)
 
-    const first = await loadAllShards(agentDir)
-    expect(first[0]?.body).toBe('v1-body\n')
+      const first = await loadAllShards(agentDir)
+      expect(first[0]?.body).toBe('v1-body\n')
 
-    // Simulate a metadata-preserving external edit: write new bytes, then
-    // restore mtime to the original value. ctime cannot be backdated via
-    // utimes -- the kernel always bumps it on inode content change -- so
-    // ctime is what catches this case. Without ctime in the cache key the
-    // next call would return stale v1 bytes (the bug Oracle flagged).
-    await writeFile(path, shardText('Alpha', 'v2-body\n'), 'utf8')
-    await utimes(path, pinned, pinned)
+      // Simulate a metadata-preserving external edit: write new bytes, then
+      // restore mtime to the original value. ctime cannot be backdated via
+      // utimes -- the kernel always bumps it on inode content change -- so
+      // ctime is what catches this case. Without ctime in the cache key the
+      // next call would return stale v1 bytes (the bug Oracle flagged).
+      await writeFile(path, shardText('Alpha', 'v2-body\n'), 'utf8')
+      await utimes(path, pinned, pinned)
 
-    const refreshed = await loadAllShards(agentDir)
-    expect(refreshed[0]?.body).toBe('v2-body\n')
-  })
+      const refreshed = await loadAllShards(agentDir)
+      expect(refreshed[0]?.body).toBe('v2-body\n')
+    },
+  )
 
   test('drops cache entries for shards that were deleted', async () => {
     const agentDir = await makeAgentDir()

--- a/src/cli/mount.test.ts
+++ b/src/cli/mount.test.ts
@@ -104,7 +104,9 @@ describe('typeclaw mount CLI', () => {
       targetPath: '/agent/mounts/downloads',
       status: 'ok',
     })
-    expect(normalizePath(parsed.mounts[0]!.resolvedPath)).toBe(normalizePath(resolvedDownloads))
+    const actualResolvedPath = await realpath(parsed.mounts[0]!.resolvedPath)
+    const expectedResolvedPath = await realpath(resolvedDownloads)
+    expect(normalizePath(actualResolvedPath)).toBe(normalizePath(expectedResolvedPath))
   })
 
   test('remove deletes the mount and tells the user to restart', async () => {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 
 import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
@@ -420,8 +420,8 @@ describe('planStart mounts', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    const home = process.env.HOME ?? ''
-    expect(plan.runArgs).toContain(`${home}/some-dir:/agent/mounts/home-thing`)
+    const homeThingMount = `${join(homedir(), 'some-dir')}:/agent/mounts/home-thing`
+    expect(plan.runArgs).toContain(homeThingMount)
   })
 
   test('emits mounts in declared order', async () => {
@@ -496,7 +496,7 @@ describe('planStart mounts', () => {
 })
 
 describe('planStart model mount', () => {
-  const modelsMount = `${process.env.HOME}/.typeclaw/models:/opt/models:ro`
+  const modelsMount = `${join(homedir(), '.typeclaw', 'models')}:/opt/models:ro`
 
   test('adds shared model cache mount at /opt/models:ro when memory.vector.enabled', async () => {
     await writeDockerfile(root)
@@ -1003,7 +1003,7 @@ describe('refreshGitignore', () => {
 })
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
-  const proc = Bun.spawn({ cmd: ['/usr/bin/git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
   const out = await new Response(proc.stdout).text()
   await proc.exited
   return out.trim()
@@ -1011,7 +1011,7 @@ async function runGit(cwd: string, args: string[]): Promise<string> {
 
 async function isGitIgnored(cwd: string, path: string): Promise<boolean> {
   const proc = Bun.spawn({
-    cmd: ['/usr/bin/git', 'check-ignore', '--quiet', path],
+    cmd: ['git', 'check-ignore', '--quiet', path],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -1028,7 +1028,7 @@ async function gitInit(cwd: string): Promise<void> {
     ['config', 'user.name', 'Test User'],
     ['config', 'user.email', 'test@example.com'],
   ]) {
-    const proc = Bun.spawn({ cmd: ['/usr/bin/git', ...cmd], cwd, stdout: 'pipe', stderr: 'pipe' })
+    const proc = Bun.spawn({ cmd: ['git', ...cmd], cwd, stdout: 'pipe', stderr: 'pipe' })
     await proc.exited
   }
 }

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -10,6 +10,21 @@ import { createStream } from '@/stream'
 import { createCronConsumer, type CronConsumerLogger, type CronSession } from './consumer'
 import type { CronJob, ExecJob, PromptJob } from './schema'
 
+async function waitForFile(path: string): Promise<string> {
+  for (let i = 0; i < 60; i++) {
+    if (await Bun.file(path).exists()) return Bun.file(path).text()
+    await Bun.sleep(50)
+  }
+  return Bun.file(path).text()
+}
+
+async function waitForCondition(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    if (predicate()) return
+    await Bun.sleep(50)
+  }
+}
+
 // Minimal AgentSession stub satisfying the surface the model-fallback helper
 // uses: `subscribe` for soft-error detection (returns a no-op unsubscribe)
 // and `prompt` for the actual turn call. Production code routes the prompt
@@ -128,10 +143,9 @@ describe('createCronConsumer', () => {
     })
     consumer.start()
 
-    publishCron(stream, execJob('touch', ['sh', '-c', 'echo hello > out.txt']))
-    await new Promise((r) => setTimeout(r, 50))
+    publishCron(stream, execJob('touch', [process.execPath, '-e', 'await Bun.write("out.txt", "hello")']))
+    const contents = await waitForFile(join(root, 'out.txt'))
 
-    const contents = await Bun.file(join(root, 'out.txt')).text()
     expect(contents.trim()).toBe('hello')
 
     consumer.stop()
@@ -153,13 +167,16 @@ describe('createCronConsumer', () => {
       schedule: '* * * * *',
       enabled: true,
       kind: 'exec',
-      command: ['sh', '-c', 'printf "%s" "$TYPECLAW_PARENT_ORIGIN_JSON" > origin.json'],
+      command: [
+        process.execPath,
+        '-e',
+        'await Bun.write("origin.json", process.env.TYPECLAW_PARENT_ORIGIN_JSON ?? "")',
+      ],
       scheduledByRole: 'member',
     }
     publishCron(stream, job)
-    await new Promise((r) => setTimeout(r, 80))
+    const captured = await waitForFile(join(root, 'origin.json'))
 
-    const captured = await Bun.file(join(root, 'origin.json')).text()
     const parsed = JSON.parse(captured) as { kind?: string; jobId?: string; scheduledByRole?: string }
     expect(parsed.kind).toBe('cron')
     expect(parsed.jobId).toBe('nightly-checks')
@@ -180,15 +197,14 @@ describe('createCronConsumer', () => {
     })
     consumer.start()
 
-    publishCron(stream, execJob('fail', ['sh', '-c', 'exit 3']))
-    await new Promise((r) => setTimeout(r, 50))
+    publishCron(stream, execJob('fail', [process.execPath, '-e', 'process.exit(3)']))
+    await waitForCondition(() => errors.some((e) => /exited with code 3/.test(e)))
 
     expect(errors.some((e) => /exited with code 3/.test(e))).toBe(true)
 
-    publishCron(stream, execJob('after', ['sh', '-c', 'echo ok > after.txt']))
-    await new Promise((r) => setTimeout(r, 50))
+    publishCron(stream, execJob('after', [process.execPath, '-e', 'await Bun.write("after.txt", "ok")']))
+    const contents = await waitForFile(join(root, 'after.txt'))
 
-    const contents = await Bun.file(join(root, 'after.txt')).text()
     expect(contents.trim()).toBe('ok')
 
     consumer.stop()

--- a/src/dreams/git.test.ts
+++ b/src/dreams/git.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { realpathSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -43,7 +44,7 @@ describe('resolveGitRepo', () => {
     expect(res.ok).toBe(true)
     // git canonicalizes the root (on macOS /var → /private/var), so assert the
     // resolved root is the git toplevel rather than byte-equal to the tmp path.
-    if (res.ok) expect(normalizePath(res.root).endsWith(normalizePath(repo))).toBe(true)
+    if (res.ok) expect(normalizePath(realpathSync(res.root)).endsWith(normalizePath(realpathSync(repo)))).toBe(true)
   })
 
   it('reports not-a-repo outside any git tree', async () => {

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -581,7 +581,9 @@ describe('startDaemon', () => {
     expect(existsSync(filePath)).toBe(true)
 
     const stats = await stat(filePath)
-    expect(stats.mode & 0o777).toBe(0o600)
+    if (process.platform !== 'win32') {
+      expect(stats.mode & 0o777).toBe(0o600)
+    }
 
     const contents = JSON.parse(await readFile(filePath, 'utf8'))
     expect(contents).toEqual({

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -206,12 +206,19 @@ function stringifyError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function errorCode(error: Error): unknown {
+  const direct = error as Error & { code?: unknown; cause?: unknown }
+  if (direct.code !== undefined) return direct.code
+  if (direct.cause instanceof Error) return errorCode(direct.cause)
+  return undefined
+}
+
 async function listenOnSocket(server: Server, path: string, onWindows: boolean): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const onError = (error: Error): void => {
       server.off('error', onError)
-      const code = (error as Error & { code?: unknown }).code
-      if (onWindows && code === 'EADDRINUSE') {
+      const code = errorCode(error)
+      if (code === 'EADDRINUSE' || (onWindows && error.message.includes('Failed to listen at'))) {
         reject(new Error(`another typeclaw host daemon is already listening at ${path}`))
         return
       }

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, statSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname, isAbsolute, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import * as z from 'zod'
@@ -959,7 +959,8 @@ describe('scaffold', () => {
     }
     const spec = pkg.dependencies.typeclaw ?? ''
     expect(spec.startsWith('file:')).toBe(true)
-    const target = join(root, spec.slice('file:'.length))
+    const rel = spec.slice('file:'.length)
+    const target = isAbsolute(rel) ? rel : join(root, rel)
     const targetPkg = JSON.parse(await readFile(join(target, 'package.json'), 'utf8')) as { name: string }
     expect(targetPkg.name).toBe('typeclaw')
   })

--- a/src/init/kakaotalk-auth.ts
+++ b/src/init/kakaotalk-auth.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'node:path'
+import { join, posix, resolve } from 'node:path'
 
 import { loginFlow as upstreamLoginFlow } from 'agent-messenger/kakaotalk'
 
@@ -34,7 +34,7 @@ export type LoginFlowOptions = Parameters<LoginFlowFn>[0]
 export type LoginFlowResult = Awaited<ReturnType<LoginFlowFn>>
 
 export function kakaotalkConfigDir(agentDir: string): string {
-  return join(agentDir, 'workspace', '.agent-messenger')
+  return posix.join(agentDir, 'workspace', '.agent-messenger')
 }
 
 export function kakaotalkSecretsPath(agentDir: string): string {

--- a/src/init/packagejson.ts
+++ b/src/init/packagejson.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, posix } from 'node:path'
 
 import { GITKEEP_FILE, PACKAGES_DIR } from './paths'
 
@@ -33,7 +33,7 @@ export async function refreshPackageJson(cwd: string): Promise<PackageJsonRefres
     if (updated) changed.push(PACKAGE_FILE)
   }
 
-  const gitkeepRel = join(PACKAGES_DIR, GITKEEP_FILE)
+  const gitkeepRel = posix.join(PACKAGES_DIR, GITKEEP_FILE)
   const gitkeepPath = join(cwd, gitkeepRel)
   if (!existsSync(gitkeepPath)) {
     await mkdir(join(cwd, PACKAGES_DIR), { recursive: true })

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -269,7 +269,7 @@ describe('startAgent', () => {
         id: 'boot-fire',
         schedule: '* * * * *',
         kind: 'exec',
-        command: ['sh', '-c', `echo fired > ${sentinel}`],
+        command: [process.execPath, '-e', `await Bun.write(${JSON.stringify(sentinel)}, "fired")`],
         enabled: true,
         scheduledByRole: 'owner',
       }
@@ -284,7 +284,7 @@ describe('startAgent', () => {
 
       running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron, createSchedulerFor })
 
-      await Bun.sleep(80)
+      for (let i = 0; i < 60 && !(await Bun.file(sentinel).exists()); i++) await Bun.sleep(50)
       expect(await Bun.file(sentinel).exists()).toBe(true)
     } finally {
       await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })

--- a/src/secrets/export-claude-credentials-file.ts
+++ b/src/secrets/export-claude-credentials-file.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, posix, resolve } from 'node:path'
 
 import { decodeClaudeAccessTokenExpiryMs, emitClaudeCredentialsJson } from './claude-credentials-json'
 import type { ProviderCredential, Providers } from './schema'
@@ -19,7 +19,7 @@ const FILE_MODE = 0o600
 const DIR_MODE = 0o700
 export const CLAUDE_CREDENTIALS_FILE_NAME = '.credentials.json'
 export const CLAUDE_DEFAULT_CONFIG_DIR_NAME = '.claude'
-export const CLAUDE_CREDENTIALS_RELATIVE_PATH = join(CLAUDE_DEFAULT_CONFIG_DIR_NAME, CLAUDE_CREDENTIALS_FILE_NAME)
+export const CLAUDE_CREDENTIALS_RELATIVE_PATH = posix.join(CLAUDE_DEFAULT_CONFIG_DIR_NAME, CLAUDE_CREDENTIALS_FILE_NAME)
 
 export type ExportClaudeCredentialsFileResult =
   | { action: 'skipped'; reason: SkipReason }

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -487,18 +487,21 @@ describe('createServer restart handling', () => {
     const session = createFakeSession()
     const { url } = await startWithSession(session)
     const { ws, waitFor } = await connect(url)
-    await waitFor((m) => m.type === 'connected')
+    try {
+      await waitFor((m) => m.type === 'connected')
 
-    // when
-    ws.send(JSON.stringify({ type: 'restart' }))
+      // when
+      ws.send(JSON.stringify({ type: 'restart' }))
 
-    // then
-    await expect(waitFor((m) => m.type === 'restart_result')).resolves.toEqual({
-      type: 'restart_result',
-      status: 'failed',
-      error: 'restart unavailable: no container name configured',
-    })
-    ws.close()
+      // then
+      await expect(waitFor((m) => m.type === 'restart_result', 5000)).resolves.toEqual({
+        type: 'restart_result',
+        status: 'failed',
+        error: 'restart unavailable: no container name configured',
+      })
+    } finally {
+      ws.close()
+    }
   })
 
   test('accepts restart when hostd ACKs the container restart RPC', async () => {
@@ -515,17 +518,20 @@ describe('createServer restart handling', () => {
     const oldToken = process.env.TYPECLAW_HOSTD_TOKEN
     process.env.TYPECLAW_HOSTD_URL = `http://127.0.0.1:${hostd.port}`
     process.env.TYPECLAW_HOSTD_TOKEN = 'secret'
+    let ws: WebSocket | null = null
     try {
       const session = createFakeSession()
       const { url } = await startWithSession(session, { containerName: 'coder' })
-      const { ws, waitFor } = await connect(url)
+      const connected = await connect(url)
+      ws = connected.ws
+      const { waitFor } = connected
       await waitFor((m) => m.type === 'connected')
 
       // when
       ws.send(JSON.stringify({ type: 'restart' }))
 
       // then
-      await expect(waitFor((m) => m.type === 'restart_result')).resolves.toEqual({
+      await expect(waitFor((m) => m.type === 'restart_result', 5000)).resolves.toEqual({
         type: 'restart_result',
         status: 'accepted',
         message: 'restart scheduled; reconnecting when the new container is up',
@@ -536,8 +542,8 @@ describe('createServer restart handling', () => {
           body: { kind: 'restart', containerName: 'coder', build: false },
         },
       ])
-      ws.close()
     } finally {
+      ws?.close()
       if (oldUrl === undefined) delete process.env.TYPECLAW_HOSTD_URL
       else process.env.TYPECLAW_HOSTD_URL = oldUrl
       if (oldToken === undefined) delete process.env.TYPECLAW_HOSTD_TOKEN

--- a/src/update/index.test.ts
+++ b/src/update/index.test.ts
@@ -286,7 +286,8 @@ describe('planSelfUpdate local installs', () => {
     })
   })
 
-  test('local install at filesystem root resolves install root to "/"', () => {
+  test.skipIf(process.platform === 'win32')('local install at filesystem root resolves install root to "/"', () => {
+    // POSIX filesystem root "/" does not model Windows drive roots.
     const packageJsonPath = join('/', 'node_modules', 'typeclaw', 'package.json')
 
     const plan = planSelfUpdate({ manager: 'auto', packageJsonPath, fileExists: neverExists })


### PR DESCRIPTION
## Background

The **`windows tests (informational triage)`** CI job ran `bun test` on Windows and reported **49 failures / 9255 tests** while Linux/macOS stayed 100% green ([failing run](https://github.com/typeclaw/typeclaw/actions/runs/27597591007/job/81591040809)).

The failures fell into a small, repeating set of root causes — mostly test-only POSIX assumptions that are harmless on Linux/macOS but fatal on Windows, plus a few genuine cross-platform bugs in host-stage code (which runs on the user's machine and can be Windows).

## Summary

8 atomic commits, each fixing one root-cause category:

| Area | Root cause | Fix |
|---|---|---|
| `start.test.ts` git helpers (~20 failures) | helpers spawned `/usr/bin/git` → `ENOENT` on Windows | resolve via PATH (`git`) |
| container `-v` mount assertions | expected paths built with hardcoded `/` | build expected host paths with OS `join`; container target stays POSIX |
| `cron`/`run` exec tests | spawned unix `sh -c` | spawn `process.execPath -e` (cross-platform) |
| path-sep / 8.3 short-path / cross-drive assertions | backslash vs `/` separator, `RUNNER~1` vs `runneradmin`, cross-drive `file:` specs | normalize via `path.join` / `fs.realpathSync`; resolve absolute specs |
| POSIX-only scenarios | Unix `0o600` mode, `/` filesystem root, ctime-without-mtime (`rsync -t`) | `test.skipIf(process.platform === 'win32')` with comments |
| vector memory tests | open SQLite handle blocks `rm` on Windows (`EBUSY`) | close the append store before cleanup via a defaulted DI seam (no public contract change) |
| server restart tests | `waitFor` timed out → promise rejected | robust 5 s wait + `finally` cleanup (kept cross-platform, not skipped) |

### Source changes (genuine cross-platform correctness)

Two commits touch production code rather than test code:

- **POSIX-invariant container-bound paths** — `CLAUDE_CREDENTIALS_RELATIVE_PATH` (embedded in the Linux entrypoint shim), `packages/.gitkeep` (a git pathspec), and `kakaotalkConfigDir` now use `posix.join`. A Windows host generating the Dockerfile / workspace would otherwise emit broken backslash paths. Host-side callers still wrap with `join(...)`, which re-normalizes for the local OS.
- **hostd double-bind on Windows named pipes** — a double-bind now reports the existing `"already listening"` error on Windows named pipes too (previously only Unix `EADDRINUSE`), by walking `error.code` / `error.cause.code`.

## What this does NOT do

- Does not change any container-runtime behavior — the agent always runs on Linux.
- Does not touch container-stage code; container paths remain POSIX regardless of where the host runs.
- Does not migrate pre-existing state or change any public plugin/CLI surface.

## Review notes

- An Oracle review caught an earlier over-reach: a proposed unwired `PluginExports.dispose` public-contract field was reverted and replaced with an internal, defaulted DI seam — **no public plugin surface change**, production behavior byte-for-byte unchanged.
- The server restart tests are deliberately **not** skipped — the failing case has no container/pipe dependency and should pass on every platform with a robust wait.
- `bun run lint` ✅ · `bun run format:check` ✅ · `bun run typecheck` ✅ · `bun run test` ✅ — **9250 pass / 0 fail** on macOS, no regressions. `win32`-only skips do not fire on other platforms.