### PR TITLE
fix(channels): recover a bare-empty stop on the first cold-start solo-human turn

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2360,6 +2360,125 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent).toHaveLength(0)
   })
 
+  test('cold-start solo-human fallback: a bare-empty stop retries, then the model answers', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // given: a non-mention direct question on a freshly cold-started solo channel
+    await router.route(inbound({ isBotMention: false, text: '일정 어떻게 되는 거더라' }))
+    let calls = 0
+    sessions[0]!.onPrompt = () => {
+      calls++
+      // when: the model whiffs an empty completion, then answers on the retry
+      if (calls === 1) sessions[0]!.setAssistantText('')
+      else sessions[0]!.setAssistantText('마감은 다음 주 화요일이야.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: it retried instead of dropping silently, and the answer landed
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(logs.some((m) => m.includes('empty_turn_retry') && m.includes('cause=cold_start_solo_bare_empty'))).toBe(
+      true,
+    )
+    expect(sent.map((s) => s.text)).toEqual(['마감은 다음 주 화요일이야.'])
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(false)
+  })
+
+  test('cold-start solo-human fallback: a persistent bare-empty stop exhausts to the visible fallback', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: false, text: '일정 알려줘' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('')
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(
+      logs.filter((m) => m.includes('empty_turn_retry') && m.includes('cause=cold_start_solo_bare_empty')).length,
+    ).toBe(MAX_EMPTY_TURN_RETRIES)
+    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=cold_start_solo_bare_empty_retries_exhausted'))).toBe(
+      true,
+    )
+  })
+
+  test('cold-start solo-human fallback: an explicit NO_REPLY stays silent (no retry)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: false, text: 'just chatter' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(logs.some((m) => m.includes('cold_start_solo_bare_empty'))).toBe(false)
+    expect(sent).toHaveLength(0)
+  })
+
+  test('cold-start bare-empty is NOT retried when the message @-mentions the bot (explicit address)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // given: a MENTION is explicit address, so the historical empty=silent path holds
+    await router.route(inbound({ isBotMention: true, text: 'hey bot' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('')
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(logs.some((m) => m.includes('cold_start_solo_bare_empty'))).toBe(false)
+  })
+
+  test('bare-empty is NOT retried on a later warm turn — only the first cold-start turn is armed', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // given: turn 1 (cold-start solo) answers normally, advancing turnSeq past 0
+    await router.route(inbound({ isBotMention: false, text: 'q1', externalMessageId: 'm1' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('answer 1')
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: a later turn whiffs a bare-empty stop
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('')
+    await router.route(inbound({ isBotMention: false, text: 'q2', externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the arm self-cleared — no retry, historical no_reply
+    expect(logs.some((m) => m.includes('cold_start_solo_bare_empty'))).toBe(false)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+  })
+
   test('suppresses recovery when assistant ends with NO_REPLY after leaked reasoning', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -265,6 +265,28 @@ export const EMPTY_TURN_RETRY_NUDGE = [
 // drop so the human is never left staring at dead air after a degenerate turn.
 export const EMPTY_TURN_FALLBACK_TEXT =
   "⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?"
+// Distinct from EMPTY_TURN_RETRY_NUDGE: that one diagnoses budget exhaustion
+// ("ran out of output budget"), which is FALSE for a clean `stop` with empty
+// text. This nudge names the real failure — a turn that ended sending nothing
+// to a message addressed to the agent in a one-on-one conversation — and steers
+// the model to either answer or record the silence explicitly (skip_response /
+// NO_REPLY) rather than ending empty again.
+export const COLD_START_REPLY_NUDGE = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'Your previous turn ended without sending anything, but the last message was',
+  'addressed to you in a direct, one-on-one conversation — ending silent there',
+  'reads as ignoring the person. This is an automated signal from the channel',
+  'router, not a message from anyone in the chat. **Do not acknowledge or reply',
+  'to this notice itself.**',
+  '',
+  'Answer the last user message now via your channel reply tool. If you truly',
+  'have nothing to add, call `skip_response({ reason })` (preferred) or end with',
+  'exactly `NO_REPLY` so the silence is recorded — do not just end empty.',
+  '',
+  '---',
+].join('\n')
 // At most one continuation nudge per logical turn. Stricter than the empty-turn
 // retry budget (2) because the turn ALREADY delivered a user-facing reply — this
 // is a one-shot correction offer, not recovery from no output.
@@ -777,6 +799,20 @@ type LiveSession = {
   // decision used, so the prompt nudge and sticky suppression agree on
   // "is this a multi-human group". Read by composeTurnPrompt().
   multiHumanGroup: boolean
+  // True when this live session was born from a cold-start (no persisted
+  // session existed — first contact or a stale-rollover after long idle), as
+  // opposed to rehydrating an existing session. Combined with `turnSeq === 0`
+  // it pinpoints the very first prompt of a freshly woken session.
+  createdFromColdStart: boolean
+  // Set in route() when the FIRST turn of a cold-start session engages via the
+  // solo-human "answer everything" fallback (not an explicit mention/reply/DM,
+  // not a multi-human group). Read by validateChannelTurn: a BARE-EMPTY stop on
+  // such a turn is a model whiff on a direct one-on-one question, not deliberate
+  // silence, so it earns an empty-turn retry instead of a silent no_reply.
+  // Recomputed on every engage, so it self-clears once turnSeq leaves the first
+  // turn; explicit NO_REPLY / skip_response and any turn that already sent stay
+  // on the historical silent path.
+  coldStartSoloFallbackTurnActive: boolean
   membershipFetch: Promise<MembershipCount | null> | null
   // Provider soft-error (`stopReason: 'error'`) captured during the current
   // turn, deferred to turn-end. Upstream surfaces transient errors (e.g.
@@ -1678,6 +1714,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         consecutiveEngagedPeerBotTurns: 0,
         loopGuardActive: false,
         multiHumanGroup: false,
+        createdFromColdStart: isColdStart,
+        coldStartSoloFallbackTurnActive: false,
         membershipFetch,
         pendingProviderError: null,
         destroyed: false,
@@ -2569,7 +2607,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     const membership = await membershipForEngagement(live)
 
-    live.multiHumanGroup = isMultiHumanGroup(event.isDm, countEffectiveHumans(live.participants, membership, now()))
+    const effectiveHumans = countEffectiveHumans(live.participants, membership, now())
+    live.multiHumanGroup = isMultiHumanGroup(event.isDm, effectiveHumans)
 
     const decision: EngagementDecision = decideEngagement({
       message: event,
@@ -2594,6 +2633,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
 
     publishInbound(event, 'engage', live.sessionId)
+
+    // Arm cold-start bare-empty recovery only for the exact incident shape: the
+    // FIRST prompt (`turnSeq === 0`) of a freshly cold-started session that
+    // engaged via the solo-human answer-everything fallback — a lone human, no
+    // explicit mention/reply/DM, not a multi-human group. Recomputed on every
+    // engage so it self-clears once the first turn advances `turnSeq`; explicit
+    // address (mention/reply/DM) keeps the historical silent-on-empty path.
+    live.coldStartSoloFallbackTurnActive =
+      live.createdFromColdStart &&
+      live.turnSeq === 0 &&
+      effectiveHumans <= 1 &&
+      !event.authorIsBot &&
+      !event.isDm &&
+      !event.isBotMention &&
+      event.replyToBotMessageId === null &&
+      !live.multiHumanGroup
 
     const engageReaction = autoReactOnEngage(event)
 
@@ -3609,6 +3664,36 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     let assistantText = candidateText
 
     if (endsWithNoReplySignal(assistantText)) {
+      // A BARE-EMPTY stop (no visible text, not an explicit NO_REPLY token) on
+      // the armed cold-start solo-human fallback turn is the production "dropped
+      // the owner's first question" shape — a model whiff on a direct one-on-one
+      // question, not a deliberate decline. Give it the bounded empty-turn retry
+      // with a dedicated nudge; on exhaustion post the visible fallback so the
+      // human is never stranded on silence. Gated hard so deliberate silence
+      // still stays silent: explicit NO_REPLY (non-empty trim), any turn that
+      // already sent (successfulChannelSends moved), a queued fresh inbound (the
+      // next drain answers it), and every turn outside the armed cold-start solo
+      // path all fall through to the historical no_reply below.
+      if (
+        assistantText.trim() === '' &&
+        source === 'leaf' &&
+        live.coldStartSoloFallbackTurnActive &&
+        live.currentTurnAuthorId !== null &&
+        live.successfulChannelSends === successfulSendsBeforePrompt &&
+        live.promptQueue.length === 0
+      ) {
+        if (live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
+          live.emptyTurnRetries++
+          logger.warn(
+            `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
+              `cause=cold_start_solo_bare_empty`,
+          )
+          live.pendingSystemReminders.push(COLD_START_REPLY_NUDGE)
+          return
+        }
+        await postEmptyTurnFallback('cold_start_solo_bare_empty_retries_exhausted')
+        return
+      }
       const leakedReasoning = !isNoReplySignal(assistantText)
       logger.info(`[channels] ${live.keyId} no_reply${leakedReasoning ? ' (with_leaked_reasoning)' : ''}`)
       return


### PR DESCRIPTION
## Background

On a freshly **cold-started** (stale-rollover after long idle) channel whose only human is the owner, engagement fires via the **solo-human "answer everything" fallback** (`engagement.ts`: `effectiveHumans <= 1 && !authorIsBot`). Being solo-human, no group-chat selectivity nudge is added.

In production, the owner's **first** message on such a session — a direct question that did **not** @-mention the bot — was silently dropped. The model ran read-only tools, then ended with a **bare-empty `stop`** (empty visible text, `stopReason: 'stop'`, ~4 output tokens — *not* the literal `NO_REPLY` token). `validateChannelTurn` recovers that as `{ text: '', source: 'leaf' }`, `endsWithNoReplySignal('')` is true, so the turn logs `no_reply` and posts nothing. The owner got silence until re-asking **with** an @-mention, after which every turn replied normally.

A bare empty completion on a one-on-one "answer everything" turn is a model **whiff**, not a deliberate decline — the model was given no selectivity nudge and the message was addressed to it.

## Summary

Only when a turn is the **first prompt of a cold-start session that engaged via the solo-human fallback**, a **bare-empty** `stop` now takes the existing bounded empty-turn retry instead of the silent `no_reply` drop:

- `createdFromColdStart` (from the existing `isColdStart` in `ensureLive`) + `turnSeq === 0` pinpoints the first prompt of a freshly woken session (`turnSeq` alone is insufficient — rehydrated sessions also reset to 0).
- `coldStartSoloFallbackTurnActive` is armed in `route()` only for the exact incident shape: cold-start, first turn, `engage`, `effectiveHumans <= 1`, non-bot author, **not** a mention/reply/DM, not a multi-human group. Recomputed on every engage, so it self-clears once `turnSeq` advances.
- In `validateChannelTurn`, a bare-empty (`assistantText.trim() === ''`) `leaf` on an armed turn — with no send this turn and no queued fresh inbound — retries with a **dedicated** `COLD_START_REPLY_NUDGE` up to `MAX_EMPTY_TURN_RETRIES`, then posts the visible `EMPTY_TURN_FALLBACK_TEXT` on exhaustion. The dedicated nudge names the real failure rather than reusing `EMPTY_TURN_RETRY_NUDGE`'s false "ran out of output budget" diagnosis.

## What this does NOT change

- **Explicit silence stays silent.** `NO_REPLY` / `(NO_REPLY)` / `skip_response` and leaked-reasoning terminators keep the historical `no_reply` path (only `trim() === ''` qualifies).
- **The documented "empty visible text may mean a silent turn" invariant is untouched** for every other case: mentions/replies/DMs, multi-human groups, any turn that already sent, later (warm) turns, and queued-fresh-inbound turns all fall through to `no_reply`.
- `isNoReplySignal` is **not** modified (shared with the `channel_send` / `channel_reply` misuse guards).

## Review notes

5 new tests in `router.test.ts`:
- cold-start solo fallback bare-empty → retries, then the model answers
- cold-start solo fallback bare-empty → exhausts to the visible fallback
- cold-start solo fallback explicit `NO_REPLY` → stays silent (no retry)
- bare-empty with an @-mention → not retried (historical `no_reply`)
- bare-empty on a later (warm) turn → not retried (arm self-clears)

Full suite green: `bun run test` → 9255 pass / 0 fail; `src/channels` → 1976 pass / 0 fail. lint / format / typecheck clean.

Fix design validated against the subsystem's pinned invariants before implementation. The affected code path is identical on the latest release and current `main`.