### PR TITLE
feat(channels): engage users the agent @-mentions

### DIFF
--- a/src/channels/adapters/mention-hints.test.ts
+++ b/src/channels/adapters/mention-hints.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { addDiscordMentionHints, addSlackMentionHints } from './mention-hints'
+import { addDiscordMentionHints, addSlackMentionHints, extractMentionedUserIds } from './mention-hints'
 
 describe('addSlackMentionHints', () => {
   const resolver = (names: Record<string, string>) => async (id: string) => names[id] ?? id
@@ -103,5 +103,30 @@ describe('addDiscordMentionHints', () => {
   test('returns text unchanged when there are no mentions', () => {
     const out = addDiscordMentionHints('just plain text', users([]))
     expect(out).toBe('just plain text')
+  })
+})
+
+describe('extractMentionedUserIds', () => {
+  test('slack: extracts ids, dedupes, drops legacy labels, handles W ids', () => {
+    expect(extractMentionedUserIds('slack-bot', 'hi <@U1> and <@U1|old> and <@W2>')).toEqual(['U1', 'W2'])
+  })
+
+  test('slack: extracts the id regardless of surrounding non-Latin script', () => {
+    expect(extractMentionedUserIds('slack-bot', '안녕하세요 <@U0TEST1A2B> 확인 부탁해요')).toEqual(['U0TEST1A2B'])
+  })
+
+  test('discord: extracts ids from both <@id> and <@!id>', () => {
+    expect(extractMentionedUserIds('discord-bot', 'yo <@123> and <@!456> again <@123>')).toEqual(['123', '456'])
+  })
+
+  test('returns [] for adapters without id-token mentions', () => {
+    for (const adapter of ['telegram-bot', 'github', 'line', 'kakaotalk'] as const) {
+      expect(extractMentionedUserIds(adapter, 'hey @someone <@U1> <@123>')).toEqual([])
+    }
+  })
+
+  test('returns [] when no mentions are present', () => {
+    expect(extractMentionedUserIds('slack-bot', 'just plain text')).toEqual([])
+    expect(extractMentionedUserIds('discord-bot', 'just plain text')).toEqual([])
   })
 })

--- a/src/channels/adapters/mention-hints.ts
+++ b/src/channels/adapters/mention-hints.ts
@@ -1,3 +1,5 @@
+import type { AdapterId } from '../schema'
+
 export type DiscordMentionUser = { id: string; username?: string; global_name?: string | null }
 
 export type MentionHintOptions = { botUserId?: string | null }
@@ -11,6 +13,21 @@ const SLACK_MENTION_PATTERN = /<@([UW][A-Z0-9]+)(?:\|[^>]*)?>/g
 // Discord uses `<@id>` and the nickname form `<@!id>`; the `!` is optional and
 // irrelevant to the target user, so it is captured but discarded on rewrite.
 const DISCORD_MENTION_PATTERN = /<@!?(\d+)>/g
+
+// User ids the agent addressed by @-mention in an outbound message, so the
+// router can grant them sticky credit (their reply answers us without a
+// re-mention). Only Slack (`<@U…>`) and Discord (`<@id>`) encode mentions as
+// raw id tokens that map 1:1 to an inbound `authorId`; Telegram (`@username`),
+// GitHub (`@login`), LINE and KakaoTalk have no token→authorId mapping here, so
+// they return [] by design and the caller falls back to existing rules.
+export function extractMentionedUserIds(adapter: AdapterId, text: string): string[] {
+  const pattern =
+    adapter === 'slack-bot' ? SLACK_MENTION_PATTERN : adapter === 'discord-bot' ? DISCORD_MENTION_PATTERN : null
+  if (pattern === null) return []
+  const ids = new Set<string>()
+  for (const match of text.matchAll(pattern)) ids.add(match[1]!)
+  return Array.from(ids)
+}
 
 export async function addSlackMentionHints(
   text: string,

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1689,6 +1689,145 @@ describe('ChannelRouter sticky credits', () => {
     await router.__testing!.flushDebounce(KEY)
     expect(sessions[0]!.prompts).toHaveLength(1)
   })
+
+  test('a user the agent @-mentions auto-engages on their next plain reply', async () => {
+    // given a 2-human group (alice + bob both seen) so the solo-human fallback is
+    // off — an untriggered plain message would otherwise be observed
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(
+      inbound({ authorId: '111', authorName: 'alice', externalMessageId: 'p1', isBotMention: true, text: 'bot hi' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value = 1100
+    await router.route(
+      inbound({ authorId: '777', authorName: 'bob', externalMessageId: 'n0', isBotMention: false, text: 'hi all' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+
+    // when alice triggers a turn and the agent's reply @-mentions bob, a third party
+    nowRef.value = 1500
+    sessions[0]!.onPrompt = async () => {
+      await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: 'good question — <@777> can you confirm?',
+      })
+    }
+    await router.route(
+      inbound({
+        authorId: '111',
+        authorName: 'alice',
+        externalMessageId: 'p2',
+        isBotMention: true,
+        text: 'bot what about X?',
+      }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.onPrompt = undefined
+    sessions[0]!.prompts.length = 0
+
+    // then bob's plain reply (no mention of the bot) engages: the @-mention granted bob a sticky credit
+    nowRef.value = 2000
+    await router.route(
+      inbound({
+        authorId: '777',
+        authorName: 'bob',
+        externalMessageId: 'n1',
+        isBotMention: false,
+        text: 'sure, it is Y',
+      }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sessions[0]!.prompts[0]).toContain('sure, it is Y')
+  })
+
+  test('a user the agent did NOT mention stays observed on a plain reply', async () => {
+    // given the same 2-human group, but the agent's reply mentions nobody
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(
+      inbound({ authorId: '111', authorName: 'alice', externalMessageId: 'p1', isBotMention: true, text: 'bot hi' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    nowRef.value = 1100
+    await router.route(
+      inbound({ authorId: '777', authorName: 'bob', externalMessageId: 'n0', isBotMention: false, text: 'hi all' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+
+    // when alice triggers a turn and the agent replies without any @-mention
+    nowRef.value = 1500
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'good question, let me check' })
+    }
+    await router.route(
+      inbound({
+        authorId: '111',
+        authorName: 'alice',
+        externalMessageId: 'p2',
+        isBotMention: true,
+        text: 'bot what about X?',
+      }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.onPrompt = undefined
+    sessions[0]!.prompts.length = 0
+
+    // then bob's unrelated plain reply is observed, not engaged — only alice (the turn author) holds a credit
+    nowRef.value = 2000
+    await router.route(
+      inbound({
+        authorId: '777',
+        authorName: 'bob',
+        externalMessageId: 'n1',
+        isBotMention: false,
+        text: 'sure, it is Y',
+      }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions[0]!.prompts).toHaveLength(0)
+  })
+
+  test('the bot does not grant itself sticky when its reply contains a self-mention', async () => {
+    // given a registered self-identity and a turn authored by alice (111)
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    router.registerSelfIdentity('discord-bot', () => ({ id: '999' }))
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(
+      inbound({ authorId: '111', authorName: 'alice', externalMessageId: 'p1', isBotMention: true, text: 'bot hi' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+
+    // when the agent's reply mentions both the bot itself (999) and bob (777),
+    // e.g. a quoted inbound that @-pinged the bot
+    nowRef.value = 1500
+    sessions[0]!.onPrompt = async () => {
+      await router.send({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        text: '> <@999> ping\n<@777> thoughts?',
+      })
+    }
+    await router.route(
+      inbound({ authorId: '111', authorName: 'alice', externalMessageId: 'p2', isBotMention: true, text: 'bot go' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+
+    // then only alice (111, turn author) and bob (777, mentioned) hold credits — self (999) is excluded
+    expect(router.clearSticky(KEY).cleared).toBe(2)
+  })
 })
 
 describe('ChannelRouter outbound', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -24,6 +24,7 @@ import type { HookBus } from '@/plugin'
 import { extractClaimCode } from '@/role-claim'
 import type { Stream } from '@/stream'
 
+import { extractMentionedUserIds } from './adapters/mention-hints'
 import { formatChannelCommandHelp } from './commands'
 import { detectContinuationWillingness } from './continuation-willingness'
 import {
@@ -3332,11 +3333,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const disengagedThisTurn = live.disengagedTurn !== null && live.disengagedTurn === live.turnSeq
       const adapterConfig = options.configForAdapter(msg.adapter)
       if (adapterConfig && !disengagedThisTurn) {
-        const targetIds = Array.from(
-          live.currentTurnAuthorIds.size > 0 ? live.currentTurnAuthorIds : live.lastTurnAuthorIds,
-        )
-        if (targetIds.length > 0) {
-          grantStickyForReplyTargets(stickyLedger, keyId, targetIds, adapterConfig.engagement, now())
+        const targets = new Set(live.currentTurnAuthorIds.size > 0 ? live.currentTurnAuthorIds : live.lastTurnAuthorIds)
+        // A user the agent addresses by @-mention is a reply target too: their
+        // next message answers us without re-mentioning the bot. Granting them
+        // sticky closes the gap where the agent asks "<@U123> can you confirm?"
+        // and that user's plain reply was observed until they re-pinged.
+        // Self-mentions (e.g. a quoted inbound) are excluded — we credit the
+        // OTHERS we addressed, not ourselves.
+        if (text !== undefined) {
+          const selfId = resolveSelfIdentity(live.key)?.id
+          for (const id of extractMentionedUserIds(msg.adapter, text)) {
+            if (id !== selfId) targets.add(id)
+          }
+        }
+        if (targets.size > 0) {
+          grantStickyForReplyTargets(stickyLedger, keyId, Array.from(targets), adapterConfig.engagement, now())
         }
       }
       const turnCount = live.consecutiveSends.get(sendKey) ?? 0


### PR DESCRIPTION
## Problem

When the agent **@-mentions a user** and asks them something — e.g. *"<@U123> can you confirm?"* — and that user replies **without re-mentioning the bot**, the reply was `observe`d, not `engage`d. The user effectively had to ping the bot a *second* time (a bare `@bot`) just to get a response to an answer the bot itself solicited.

Root cause: sticky credit (`grantStickyForReplyTargets`) was granted only to the **turn's authors** (`currentTurnAuthorIds`). A user the agent addressed by @-mention in its reply — but who wasn't the one who triggered the turn — never received a credit, so in a multi-human channel their plain follow-up fell through to `observe`.

## Fix

Extend the send-time sticky grant so users the agent **@-mentions in its outbound text** also receive a sticky credit. This rides the existing sticky machinery (window TTL, one-shot consumption, the multi-human pre-check, `channel_disengage`) — **no new engagement gate**, and it stays **content-blind** (structural token extraction, no text interpretation), per the engagement design philosophy.

- New `extractMentionedUserIds(adapter, text)` in `adapters/mention-hints.ts`, reusing the existing Slack/Discord mention regexes.
- `router.send()` merges those ids into the grant targets, **excluding self** (a quoted inbound may echo `<@self>`).
- Slack `<@U…>` and Discord `<@id>` tokens map 1:1 to an inbound `authorId`. Telegram (`@username`), GitHub (`@login`), LINE and KakaoTalk have no token→authorId mapping, so they return `[]` and behavior is unchanged there.

Because the feature rides sticky, it's a no-op when `stickiness: 'off'` (the operator's explicit strict-mode choice) — consistent with the existing model.

## Tests

- `mention-hints.test.ts` — `extractMentionedUserIds`: Slack/Discord extraction (dedupe, legacy `|label`, `W` ids, `<@!id>`), non-Latin surrounding script, `[]` for non-token adapters and no-mention text.
- `router.test.ts` (sticky credits), written TDD red-first:
  - a user the agent @-mentions **auto-engages** on their next plain reply;
  - a user the agent did **not** mention stays **observed** (proves the change is scoped to addressed users);
  - the bot does **not** grant itself a credit on a self-mention.

Full suite green: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, `bun run test` (9257 pass / 0 fail).