### PR TITLE
fix(agent): guard researcher missing `<report>` with bounded re-prompt

### DIFF
--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -1038,6 +1038,159 @@ describe('startSubagent', () => {
     }
   })
 
+  function scriptedResearcherSession(turns: { role?: string; content: unknown }[][]): {
+    session: AgentSession
+    prompts: string[]
+  } {
+    const prompts: string[] = []
+    let listener: ((event: unknown) => void) | null = null
+    let turnIndex = 0
+    const session = {
+      prompt: async (text: string) => {
+        prompts.push(text)
+        const messages = turns[turnIndex] ?? []
+        turnIndex++
+        for (const message of messages) listener?.({ type: 'message_end', message })
+      },
+      dispose: () => {},
+      subscribe: (l: (event: unknown) => void) => {
+        listener = l
+        return () => {
+          listener = null
+        }
+      },
+      abort: async () => {},
+    } as unknown as AgentSession
+    return { session, prompts }
+  }
+
+  async function runResearcher(turns: { role?: string; content: unknown }[][]) {
+    const { session, prompts } = scriptedResearcherSession(turns)
+    const registry = { researcher: { systemPrompt: 'X' } satisfies Subagent }
+    const { completion } = startSubagent('researcher', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_researcher',
+    })
+    const result = await completion
+    return { result, prompts }
+  }
+
+  function wedgeAfterEmitting(content: string): AgentSession {
+    let listener: ((event: unknown) => void) | null = null
+    return {
+      prompt: () =>
+        new Promise<void>(() => {
+          listener?.({ type: 'message_end', message: { role: 'assistant', content } })
+        }),
+      dispose: () => {},
+      subscribe: (l: (event: unknown) => void) => {
+        listener = l
+        return () => {
+          listener = null
+        }
+      },
+      abort: async () => {},
+    } as unknown as AgentSession
+  }
+
+  test('researcher: a <report> on the first turn is returned with no recovery nudge', async () => {
+    const report = '<report>\n<summary>done</summary>\n</report>'
+    const { result, prompts } = await runResearcher([
+      [{ role: 'assistant', content: `Writing it now.\n${report}\nFinished.` }],
+    ])
+    if (!result.ok) throw new Error(`expected ok=true, got error: ${result.error}`)
+    expect(result.finalMessage).toBe(report)
+    expect(prompts).toHaveLength(1)
+  })
+
+  test('researcher: the last <report> block wins within a turn', async () => {
+    const stale = '<report>\n<confidence>low</confidence>\n</report>'
+    const revised = '<report>\n<confidence>high</confidence>\n</report>'
+    const { result, prompts } = await runResearcher([[{ role: 'assistant', content: `${stale}\n${revised}` }]])
+    if (!result.ok) throw new Error(`expected ok=true, got error: ${result.error}`)
+    expect(result.finalMessage).toBe(revised)
+    expect(prompts).toHaveLength(1)
+  })
+
+  test('researcher: ends with <analysis> but no <report> → recovers on the nudge (guard, not loud failure)', async () => {
+    const report = '<report>\n<summary>recovered</summary>\n</report>'
+    const { result, prompts } = await runResearcher([
+      [{ role: 'assistant', content: '<analysis>\nplan\n</analysis>' }],
+      [{ role: 'assistant', content: report }],
+    ])
+    if (!result.ok) throw new Error(`expected ok=true, got error: ${result.error}`)
+    expect(result.finalMessage).toBe(report)
+    expect(prompts).toHaveLength(2) // initial + one recovery nudge
+  })
+
+  test('researcher: the recovery nudge asks for the <report> as text and forbids tools', async () => {
+    const { prompts } = await runResearcher([
+      [{ role: 'assistant', content: '<analysis>\nplan\n</analysis>' }],
+      [{ role: 'assistant', content: '<report>\n<summary>ok</summary>\n</report>' }],
+    ])
+    expect(prompts[1]).toContain('<report>')
+    expect(prompts[1]).toContain('Do NOT call any tools')
+    expect(prompts[1]).toContain('write_report')
+  })
+
+  test('researcher: exhausting the nudge budget installs an honest fallback <report> (not stale preamble, not loud failure)', async () => {
+    const analysis = '<analysis>\n**Literal Request**: ...\n</analysis>'
+    const { result, prompts } = await runResearcher([
+      [{ role: 'assistant', content: analysis }],
+      [{ role: 'assistant', content: 'still working, no block yet' }],
+      [{ role: 'assistant', content: 'still no block' }],
+    ])
+    if (!result.ok) throw new Error(`expected ok=true (guard, not loud failure), got error: ${result.error}`)
+    expect(prompts).toHaveLength(3) // initial + 2 nudges (MAX_REQUIRED_BLOCK_RETRIES)
+    expect(result.finalMessage).toContain('<report>')
+    expect(result.finalMessage).toContain('could not complete')
+    expect(result.finalMessage).toContain('low')
+    expect(result.finalMessage).not.toContain('<analysis>')
+  })
+
+  test('researcher: a timeout after a <report> was captured rides the report along (recoverable near-miss)', async () => {
+    const report = '<report>\n<summary>done before the ceiling</summary>\n</report>'
+    const registry = { researcher: { systemPrompt: 'X', timeoutMs: 20 } satisfies Subagent }
+    const { completion } = startSubagent('researcher', {
+      registry,
+      createSessionForSubagent: async () => wedgeAfterEmitting(report),
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_researcher_timeout',
+    })
+    const result = await completion
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('timed out')
+      expect(result.finalMessage).toBe(report)
+    }
+  })
+
+  test('researcher: a timeout with only an <analysis> preamble captured has no recoverable report', async () => {
+    const registry = { researcher: { systemPrompt: 'X', timeoutMs: 20 } satisfies Subagent }
+    const { completion } = startSubagent('researcher', {
+      registry,
+      createSessionForSubagent: async () => wedgeAfterEmitting('<analysis>\nplan\n</analysis>'),
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_researcher_timeout_norecover',
+    })
+    const result = await completion
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.finalMessage).toBeUndefined()
+    }
+  })
+
+  test('a <report> block from a non-researcher subagent is not specially extracted (returned as free-form text)', async () => {
+    const withReport = 'Here is my answer.\n<report>\n<summary>x</summary>\n</report>'
+    const final = await captureFinal([{ role: 'assistant', content: withReport }])
+    expect(final).toBe(withReport)
+  })
+
   test('without timeoutMs a slow prompt keeps completion pending (legacy unbounded behavior preserved)', async () => {
     // given: a session whose prompt has not resolved yet, and no timeout declared
     let resolvePrompt: () => void = () => {}

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -241,6 +241,11 @@ export type InvokeSubagentOptions = {
     sessionId: string | undefined
     abort: () => Promise<void>
   }) => void
+  // Sink for the subagent's captured final message (a reviewer `<review>` block,
+  // a researcher `<report>` block, or the last free-form assistant text).
+  // `runSession` owns the capture so the required-block guard can re-prompt
+  // before the result settles; `startSubagent` passes this to receive the output.
+  onFinalMessageCaptured?: (msg: string) => void
 }
 
 export async function invokeSubagent(name: string, options: InvokeSubagentOptions): Promise<void> {
@@ -261,6 +266,8 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
       normalizeSubagentSession(await createSessionForSubagent(subagent, sessionOptions))
     let aborted = false
     let drainWatch: SubagentDrainWatch | undefined
+    const requiredBlockTag = REQUIRED_FINAL_BLOCK[name]
+    const capture = attachFinalMessageCapture(session, requiredBlockTag, options.onFinalMessageCaptured ?? (() => {}))
     if (options.onSessionCreated !== undefined) {
       options.onSessionCreated({
         session,
@@ -311,6 +318,28 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           },
           cancelled: () => aborted,
         })
+      }
+      // Required-block guard (mirrors the channel empty-response guard): a subagent
+      // that owes a result block but ended without one gets a bounded re-prompt to
+      // emit it as text, then an honest fallback — never a silent stale-preamble
+      // result or a loud failure. Runs strictly after the drain settles so it is a
+      // final contract-repair pass, not another research phase; it deliberately
+      // does NOT re-run the drain.
+      if (requiredBlockTag !== undefined) {
+        for (
+          let attempt = 1;
+          !aborted && !capture.hasRequiredBlock() && attempt <= MAX_REQUIRED_BLOCK_RETRIES;
+          attempt++
+        ) {
+          console.warn(
+            `[subagent] ${name} required_block_retry attempt=${attempt}/${MAX_REQUIRED_BLOCK_RETRIES} tag=${requiredBlockTag}`,
+          )
+          await session.prompt(`${renderTurnTimeAnchor()}\n\n${renderRequiredBlockRetryNudge(requiredBlockTag)}`)
+        }
+        if (!aborted && !capture.hasRequiredBlock()) {
+          console.warn(`[subagent] ${name} required_block_fallback tag=${requiredBlockTag}`)
+          capture.setSyntheticFinalMessage(renderMissingRequiredBlockFallback(name, requiredBlockTag))
+        }
       }
       if (hooks && sessionId !== undefined) {
         await hooks.runSessionIdle({
@@ -432,6 +461,9 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
 
   const work = invokeSubagent(name, {
     ...options,
+    onFinalMessageCaptured: (msg) => {
+      finalMessage = msg
+    },
     onSessionCreated: (event) => {
       handleSettled = true
       abortSession = event.abort
@@ -439,9 +471,6 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
       if (options.onSession !== undefined) {
         options.onSession(event)
       }
-      attachFinalMessageCapture(event.session, (msg) => {
-        finalMessage = msg
-      })
     },
   })
     .then(() => ({ ok: true as const, ...(finalMessage !== undefined ? { finalMessage } : {}) }))
@@ -497,22 +526,102 @@ function raceSubagentCompletion(
   })
 }
 
-// A complete <review>...</review> block. The reviewer's contract is that this
-// block IS its result; same-message preamble/trailing chatter or a later
-// summary turn must not become the captured final message. `[\s\S]` spans
-// newlines (the block is multi-line); non-greedy stops at the first close so an
-// incidental `<review>` literal in reviewed text cannot swallow real content.
-// Global so a message with several blocks yields the last (the revision).
-const REVIEW_BLOCK_RE = /<review>[\s\S]*?<\/review>/g
+// The tags a subagent can use to wrap its structured result: the reviewer's
+// `<review>`, the researcher's `<report>`. Fixed literals — never user input —
+// so the per-tag patterns below are injection-safe.
+type FinalBlockTag = 'review' | 'report'
 
-function lastReviewBlock(text: string): string | null {
-  const matches = text.match(REVIEW_BLOCK_RE)
+// A complete <TAG>...</TAG> block. The block IS the result: same-message
+// preamble/trailing chatter or a later summary turn must not become the captured
+// final message. `[\s\S]` spans newlines (the block is multi-line); non-greedy
+// stops at the first close so an incidental `<TAG>` literal in the wrapped text
+// cannot swallow real content. Global so a message with several blocks yields the
+// last (the revision).
+const FINAL_BLOCK_RE: Readonly<Record<FinalBlockTag, RegExp>> = {
+  review: /<review>[\s\S]*?<\/review>/g,
+  report: /<report>[\s\S]*?<\/report>/g,
+}
+
+function lastTaggedBlock(text: string, tag: FinalBlockTag): string | null {
+  const matches = text.match(FINAL_BLOCK_RE[tag])
   return matches === null ? null : (matches[matches.length - 1] ?? null)
 }
 
-function attachFinalMessageCapture(session: AgentSession, onFinalMessage: (msg: string) => void): void {
+// Subagents whose result IS a REQUIRED tagged block — the parent must receive
+// that block or a loud failure, never a stale earlier turn. The researcher's
+// contract (src/bundled-plugins/researcher/researcher.ts) mandates a closing
+// `<report>` block; when an upstream provider retry loop ends the run on
+// unexecuted `write_report` tool calls, the researcher never emits it, and
+// without this gate the capture would silently return its earlier `<analysis>`
+// preamble as a "successful" result — the production regression this guards.
+// Keyed by the stable bundled-subagent registry name. This is STRICTER than the
+// reviewer's `<review>` (preferred, but falls back to free-form text): only the
+// subagents listed here fail loud when their block is absent.
+const REQUIRED_FINAL_BLOCK: Readonly<Record<string, FinalBlockTag>> = { researcher: 'report' }
+
+// Bounded re-prompt budget for the required-block guard, mirroring the channel
+// empty-response guard's MAX_EMPTY_TURN_RETRIES. A subagent that owes a result
+// block but ended without one is nudged at most this many times before the
+// honest fallback is installed.
+const MAX_REQUIRED_BLOCK_RETRIES = 2
+
+// The recovery nudge. It MUST forbid tools: the known failure mode is a provider
+// retry loop on the report-writing tool call, so re-driving the tool path would
+// just re-trigger the loop. Asking for the block as plain text is the repair.
+function renderRequiredBlockRetryNudge(tag: FinalBlockTag): string {
+  return `---
+**[SYSTEM MESSAGE — not from a human]**
+
+Your previous turn ended without the required <${tag}> block. This is an automated runtime recovery signal, not a human message.
+
+Emit the final <${tag}>...</${tag}> block NOW as plain assistant text. Do NOT call any tools — in particular do NOT call write_report. Do NOT continue researching or spawn more subagents.
+
+If the report file was not successfully written, still emit the block: set <report_file>none</report_file>, <confidence>low</confidence> (explain the report artifact was not completed), and note in <open_questions> that the run should be retried.
+
+Output exactly one <${tag}> block and nothing else.`
+}
+
+// The terminal graceful fallback when the nudges are exhausted. It fabricates NO
+// findings — only a structured, low-confidence "could not complete" notice — so
+// the parent gets a usable result instead of stale `<analysis>` or a hard error.
+function renderMissingRequiredBlockFallback(name: string, tag: FinalBlockTag): string {
+  if (tag === 'report') {
+    return `<report>
+<summary>
+The ${name} subagent could not complete a research report in this run: it ended without emitting the required <report> block (a known cause is the report tool not completing). Do not treat any earlier analysis text as findings — rerun the researcher or gather the sources directly if the answer is still needed.
+</summary>
+<report_file>
+none
+</report_file>
+<confidence>
+low — no complete research report artifact was produced.
+</confidence>
+<open_questions>
+The original research request remains unresolved; rerun the ${name} subagent or gather the sources directly.
+</open_questions>
+</report>`
+  }
+  return `<${tag}>\nThe ${name} subagent ended without emitting the required <${tag}> block and could not recover; rerun it or inspect the transcript.\n</${tag}>`
+}
+
+type SubagentCapture = {
+  // True once a required-block subagent (researcher) has emitted its `<report>`
+  // block; always false for subagents without a required block.
+  hasRequiredBlock: () => boolean
+  // Install a captured final message directly — used by the required-block guard
+  // to set an honest fallback when the block was never emitted, so the parent
+  // gets a structured result rather than stale preamble.
+  setSyntheticFinalMessage: (msg: string) => void
+}
+
+function attachFinalMessageCapture(
+  session: AgentSession,
+  requiredBlockTag: FinalBlockTag | undefined,
+  onFinalMessage: (msg: string) => void,
+): SubagentCapture {
   let lastAssistant: string | null = null
   let lastReview: string | null = null
+  let lastRequired: string | null = null
   try {
     session.subscribe((event: unknown) => {
       const ev = event as { type?: string; message?: { role?: string; content?: unknown } }
@@ -524,13 +633,36 @@ function attachFinalMessageCapture(session: AgentSession, onFinalMessage: (msg: 
       const text = extractFinalMessageText(ev.message?.content)
       if (text === null) return
       lastAssistant = text
-      const review = lastReviewBlock(text)
+
+      // Required-block contract (researcher): the result IS the block. A turn
+      // with text but no block — the `<analysis>` preamble, a process narrative —
+      // must NOT become the captured result, so `hasRequiredBlock` stays false and
+      // the guard in runSession re-prompts rather than returning stale preamble.
+      if (requiredBlockTag !== undefined) {
+        const block = lastTaggedBlock(text, requiredBlockTag)
+        if (block !== null) {
+          lastRequired = block
+          onFinalMessage(lastRequired)
+        }
+        return
+      }
+
+      // Preferred-block contract (reviewer) / free-form: a `<review>` block wins
+      // when present; otherwise the last free-form assistant text is the result.
+      const review = lastTaggedBlock(text, 'review')
       if (review !== null) lastReview = review
       onFinalMessage(lastReview ?? lastAssistant)
     })
   } catch {
     // session.subscribe is a stable upstream API; defensive try is for test
     // doubles that don't implement it.
+  }
+  return {
+    hasRequiredBlock: () => lastRequired !== null,
+    setSyntheticFinalMessage: (msg) => {
+      lastRequired = msg
+      onFinalMessage(msg)
+    },
   }
 }
 


### PR DESCRIPTION
## Background

A `researcher` subagent (running on the `openai-codex` provider) reported back to its parent with **only its `<analysis>` planning preamble — no report body**. The parent flagged it "research agent returned metadata only, no body" and redid the work itself. Production shape: the subagent "completed in ~11m" yet delivered ~700 chars of preamble instead of its ~12K-char report.

Two layers:

**Trigger — upstream, tracked separately.** On `openai-codex`, the researcher's `write_report` tool calls were never executed and never threaded back: across 4 consecutive assistant turns the model re-emitted `write_report` (same target path, ~12K chars each) with no tool result in between and no file written. This matches `pi-coding-agent`'s retry path — an assistant turn marked `stopReason:"error"` carrying the tool call is skipped before execution, removed from live state on retry, and dropped from the replay by `transformMessages` — so the model never sees a result and loops until the run ends. Belongs upstream; this PR does not touch vendored deps. The in-repo `llm-replay-sanitizer` was investigated and confirmed a bystander.

**Amplifier — this PR.** Because the run ended on tool-call-only turns, the researcher never emitted its closing `<report>` block. The final-message capture only captured assistant turns with a `text` part and had no `<report>`-aware extraction, so it silently fell back to the earlier `<analysis>` preamble — returned to the parent as a *success*.

## Summary

Guard the missing `<report>` block — mirroring the channel **empty-response / no-reply guard** (`validateChannelTurn` in `src/channels/router.ts`), which re-prompts a bounded number of times and then posts a graceful fallback rather than erroring.

- **Capture moves into `runSession`** (via a new `onFinalMessageCaptured` option) so the prompt loop can see whether the required `<report>` block was emitted (`capture.hasRequiredBlock()`). `startSubagent` just receives the captured output through the callback.
- **Bounded re-prompt guard** after the initial prompt + background drain settle: while no `<report>` was emitted, re-prompt up to `MAX_REQUIRED_BLOCK_RETRIES = 2` times (matching the channel's budget). The nudge asks for the `<report>` block **as plain text and forbids tools** — critically `write_report` — so it cannot re-trigger the upstream tool-call loop. It does **not** re-run the research drain (final contract-repair pass only).
- **Graceful terminal on exhaustion:** install an honest, low-confidence `<report>` ("could not complete", `report_file: none`, no fabricated findings) via `capture.setSyntheticFinalMessage`, and return `ok:true`. Never stale `<analysis>`, never a loud failure.
- Generalizes the reviewer's `<review>` extraction into `lastTaggedBlock`; reviewer and generic subagents are unchanged.

**Why mirror the channel guard (not fail loud)?** The common case is the model simply not emitting the closing block; a single text re-prompt recovers it cheaply, exactly as the channel recovers an empty turn. A hard failure threw away an otherwise-fine run.

**Why the nudge forbids tools?** The trigger is a provider retry loop on the `write_report` tool call; re-driving the tool path would just re-loop. Asking for the block as text is the repair.

**Why a synthesized fallback and not `ok:false`?** "Guard, not loud failure." The fallback fabricates no findings — only a structured low-confidence failure notice — so the parent gets a usable, honest result (it can choose to re-run), mirroring the channel's graceful fallback.

## What this does NOT do

- Does **not** fix the upstream `openai-codex` retry/tool-execution loop (the trigger) — tracked separately. This guards the symptom.
- Does **not** fabricate research findings — the exhaustion fallback is an explicit "could-not-complete" notice.
- Does **not** re-run the research/drain phase during recovery (bounded text-only nudges).
- Does **not** change reviewer or generic-subagent behavior, `write_report.ts`, or the `llm-replay-sanitizer`.

## Review notes

- **Seam:** capture ownership moved from `startSubagent` into `runSession`/`invokeSubagent` (new `onFinalMessageCaptured`). `attachFinalMessageCapture` now returns `{ hasRequiredBlock, setSyntheticFinalMessage }`. This is the load-bearing change — it lets the prompt loop both observe and repair the contract.
- **Anti-reloop:** the guard runs strictly **after** `runSubagentDrain` settles and is a fixed counter (≤2); it never re-enters the drain, so a nudge can't spiral into another research phase.
- **Timeout:** the 30-min `RESEARCHER_SPAWN_TIMEOUT_MS` remains the only wall-clock budget; nudge re-prompts respect `aborted`, and a timeout still settles `ok:false` (with any captured report as recoverable output). Covered by the two timeout tests.
- **Tests:** `subagents.test.ts` — report-on-first-turn (no nudge), last-block-wins, recovery-on-nudge, **nudge forbids tools/`write_report`**, exhaustion → honest fallback `<report>` (not stale `<analysis>`, not `ok:false`), plus the existing reviewer/generic/timeout tests unchanged. 55/55 green.

> Follow-up: file the upstream `pi-coding-agent` issue for the `openai-codex` error-turn retry loop (assistant turn `stopReason:"error"` carrying a tool call → tool never executed → dropped on replay → infinite re-synthesis), with the transcript evidence.
