### PR TITLE
docs(seo): match metadata copy with landing hero

### DIFF
--- a/docs/src/lib/seo.ts
+++ b/docs/src/lib/seo.ts
@@ -2,10 +2,10 @@ export const SITE_URL = 'https://typeclaw.dev'
 
 export const SITE_NAME = 'TypeClaw'
 
-export const SITE_TITLE = "TypeClaw — A self-hosted AI agent for your team's chat"
+export const SITE_TITLE = 'TypeClaw — The agent for perfectionists'
 
 export const SITE_DESCRIPTION =
-  "TypeClaw is a self-hosted, TypeScript-native AI agent that lives in your team's chat — Slack, Discord, Telegram, LINE, KakaoTalk, GitHub, or your terminal. Sandboxed by default, self-managing, and it gets sharper the longer it runs."
+  "TypeClaw is the AI agent for perfectionists — crafted in every detail. It behaves in your team's chat and gets sharper the longer it runs. Sandboxed and self-managing."
 
 export const SITE_KEYWORDS = [
   'TypeClaw',


### PR DESCRIPTION
## Why

#928 realigned the SEO surface to the "new landing copy" but led with a positioning the landing page never actually uses. The hero — repeated verbatim in the footer and the README — is:

> **The agent for perfectionists.**
> Crafted in every detail — it behaves in your team's chat and gets sharper the longer it runs. Sandboxed and self-managing.

The metadata from #928 instead opened with *"A self-hosted AI agent for your team's chat"* and said the agent *"lives"* in your chat. Two concrete mismatches:

- **"self-hosted" appears nowhere on the landing page** — it was the invented lead.
- The landing says the agent **"behaves"** in your team's chat (the perfectionist / well-behaved framing), not **"lives"**.

## What changed

`docs/src/lib/seo.ts` only — the single source of truth #928 introduced. The two visible strings now echo the hero:

**Title**
- before: `TypeClaw — A self-hosted AI agent for your team's chat`
- after: `TypeClaw — The agent for perfectionists`

**Description**
- before: `TypeClaw is a self-hosted, TypeScript-native AI agent that lives in your team's chat — Slack, Discord, Telegram, LINE, KakaoTalk, GitHub, or your terminal. Sandboxed by default, self-managing, and it gets sharper the longer it runs.`
- after: `TypeClaw is the AI agent for perfectionists — crafted in every detail. It behaves in your team's chat and gets sharper the longer it runs. Sandboxed and self-managing.`

These propagate automatically to `<title>`, description, OG, Twitter card, JSON-LD (`layout.tsx`), and the `/llms.txt` summary — all of which consume the shared constants.

`SITE_KEYWORDS` is intentionally left unchanged: it's a hidden SEO surface (not visible copy), and the terms — including `self-hosted AI agent` and the channel list — remain accurate for search breadth.

## Verification

- `bun run lint` (oxlint) — 0 warnings, 0 errors
- `bun run format:check` (oxfmt) — clean
- `tsc` — the change is string-literal-only (cannot affect types); the pre-existing Next/Fumadocs codegen errors are unchanged and resolved by `next build`, same as noted in #928.
