### PR TITLE
test(run): deflake the cron arm-time-fire test on Windows CI

### DIFF
--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -262,33 +262,44 @@ describe('startAgent', () => {
   })
 
   test('a fire emitted while the scheduler is being armed is not lost (consumer subscribes first)', async () => {
-    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-cron-boot-'))
-    try {
-      const sentinel = join(agentDir, 'fired.txt')
-      const job: CronJob = {
-        id: 'boot-fire',
-        schedule: '* * * * *',
-        kind: 'exec',
-        command: [process.execPath, '-e', `await Bun.write(${JSON.stringify(sentinel)}, "fired")`],
-        enabled: true,
-        scheduledByRole: 'owner',
-      }
-      const loadCron: LoadCronFn = async () => ({ ok: true, file: { jobs: [job] } }) as LoadCronResult
-      // Fire synchronously at arm time. If the consumer hadn't subscribed yet,
-      // this fire would be dropped (the stream has no replay) and the sentinel
-      // would never be written.
-      const createSchedulerFor: SchedulerFactory = ({ onFire }) => {
-        onFire(job)
-        return stubScheduler()
-      }
-
-      running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron, createSchedulerFor })
-
-      for (let i = 0; i < 60 && !(await Bun.file(sentinel).exists()); i++) await Bun.sleep(50)
-      expect(await Bun.file(sentinel).exists()).toBe(true)
-    } finally {
-      await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+    let resolveFired!: () => void
+    const fired = new Promise<void>((resolve) => {
+      resolveFired = resolve
+    })
+    // Observe delivery in-process via a `handler` job. Do NOT revert to an
+    // `exec` job + sentinel file + filesystem poll: that observation was a
+    // Windows CI flake (a cold `bun -e` runtime under parallel load missed the
+    // poll budget) even though the subscription-order behavior is correct.
+    const job: CronJob = {
+      id: 'boot-fire',
+      schedule: '* * * * *',
+      kind: 'handler',
+      enabled: true,
+      scheduledByRole: 'owner',
+      handler: async () => {
+        resolveFired()
+      },
     }
+    // `jobs` is typed for parsed (prompt/exec) jobs; a handler job is a valid
+    // CronJob the consumer dispatches, so widen the array element for the fake.
+    const loadCron: LoadCronFn = async () => ({ ok: true, file: { jobs: [job] as CronJob[] } }) as LoadCronResult
+    // Fire synchronously at arm time. If the consumer hadn't subscribed yet, the
+    // stream (no replay) would drop this fire and the handler would never run.
+    const createSchedulerFor: SchedulerFactory = ({ onFire }) => {
+      onFire(job)
+      return stubScheduler()
+    }
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: testCwd, loadCron, createSchedulerFor })
+
+    await Promise.race([
+      fired,
+      Bun.sleep(5000).then(() => {
+        throw new Error(
+          'cron handler not invoked within 5s — the arm-time fire was lost (consumer subscribed too late)',
+        )
+      }),
+    ])
   })
 
   test('cronConsumer is started when bundled memory plugin contributes a default dreaming cron job (no cron.json)', async () => {


### PR DESCRIPTION
## What

Follow-up to #934 / #939. The `windows tests (informational triage)` job on `main` had one remaining red test ([CI run](https://github.com/typeclaw/typeclaw/actions/runs/27606470861/job/81619629121)):

```
(fail) startAgent > a fire emitted while the scheduler is being armed is not lost (consumer subscribes first)
```

#939 punted it as an out-of-scope "flaky cron/scheduler timing test." This makes it green properly rather than skipping or padding a timeout.

## Root cause

The test guards a real, working invariant: the cron **consumer subscribes before the scheduler arms** (`src/run/index.ts` — `cronConsumer.start()` runs before `startScheduler()`), so a fire emitted synchronously at arm time isn't dropped by the no-replay stream.

The production behavior is correct — it passes on POSIX, and the failed CI log contains **no `[cron] boot-fire failed:` line**, so the exec never errored. The flake is in the test's *observation* mechanism: it spawned a cold `bun -e` subprocess to write a sentinel file, then polled the filesystem for 3s. On Windows CI (tests run `--parallel`), a fresh Bun runtime didn't finish writing within that budget → false failure on a behavior the code actually satisfies.

## Fix

Observe delivery **in-process** via a `handler` cron job that resolves a promise when the consumer dispatches it. Stream delivery is synchronous and `invokeHandler` is already wired into `startAgent`, so the handler runs deterministically at arm time — no subprocess, no filesystem, cross-platform.

The regression guard is preserved exactly: if the consumer subscribed *after* the scheduler armed, the synchronous arm-time fire would be dropped, the handler would never run, and the test fails fast with an explicit timeout error.

## Notes

- Test-only change; one file (`src/run/index.test.ts`), no production code touched.
- A code comment explicitly warns against reverting to the `exec` + sentinel + poll pattern that flaked across the prior attempts.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run format:check` clean.
- `bun run test` on macOS (POSIX): **9271 pass, 0 fail** (1 expected Linux-only `bwrap` skip). The deflaked test and its `src/run/index.test.ts` siblings pass under `--parallel`.