### PR TITLE
fix(channels): revive typing after the silence cap trips mid-turn

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6357,6 +6357,53 @@ describe('ChannelRouter typing indicator', () => {
     await Promise.all([interval, draining])
   })
 
+  test('a revival queued while the turn ends does NOT re-arm typing after the turn', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    const phases: Array<'tick' | 'stop'> = []
+    let releaseCapStop: (() => void) | undefined
+    let releasePrompt: (() => void) | undefined
+    let stopCount = 0
+    // Block ONLY the cap-trip 'stop' so a revival can be queued behind it while
+    // the turn finishes; the turn-end 'stop' must pass through.
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+      if (target.phase === 'stop' && ++stopCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseCapStop = resolve
+        })
+      }
+    })
+
+    await router.route(inbound({ text: 'race then end' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // given: the cap trips and its 'stop' clear is in flight (blocked)
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS
+    const interval = router.__testing!.fireTypingInterval(KEY)
+    await waitFor(() => releaseCapStop !== undefined)
+
+    // given: a late delta queues a revival behind the still-blocked stop
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'late' } })
+
+    // when: the prompt completes (turn ends) while the stop is still blocked,
+    // then the blocked stop is released so the queued revival can run
+    releasePrompt!()
+    releaseCapStop!()
+    await Promise.all([interval, draining])
+
+    // then: the queued revival is a no-op — no heartbeat is re-armed post-turn
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+    expect(phases).toEqual(['tick', 'stop'])
+  })
+
   test('a revived heartbeat trips the cap again after another silent window', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1000 }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6228,7 +6228,7 @@ describe('ChannelRouter typing indicator', () => {
     await draining
   })
 
-  test('tool_execution_end after the cap has already tripped does NOT resurrect typing', async () => {
+  test('a streamed text_delta after the cap has tripped revives typing', async () => {
     const dir = await tempDir()
     const nowRef = { value: 1000 }
     const { router, sessions } = makeRouter(dir, { nowRef })
@@ -6238,7 +6238,7 @@ describe('ChannelRouter typing indicator', () => {
       phases.push(target.phase)
     })
 
-    await router.route(inbound({ text: 'silent then loud' }))
+    await router.route(inbound({ text: 'silent then streaming' }))
     sessions[0]!.onPrompt = async () => {
       await new Promise<void>((resolve) => {
         releasePrompt = resolve
@@ -6247,19 +6247,149 @@ describe('ChannelRouter typing indicator', () => {
     const draining = router.__testing!.flushDebounce(KEY)
     await waitFor(() => releasePrompt !== undefined)
 
+    // given: a >2-min silent gap trips the cap and stops the heartbeat
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS
+    await router.__testing!.fireTypingInterval(KEY)
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+    expect(phases).toEqual(['tick', 'stop'])
+
+    // when: the model resumes streaming text after the timeout
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'back' } })
+
+    // then: the heartbeat is re-armed and a fresh tick fires
+    expect(router.__testing!.isTypingActive(KEY)).toBe(true)
+    expect(phases).toEqual(['tick', 'stop', 'tick'])
+
+    releasePrompt!()
+    await draining
+  })
+
+  test('a tool_execution_end after the cap has tripped revives typing', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    const phases: Array<'tick' | 'stop'> = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+
+    await router.route(inbound({ text: 'long tool then resume' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // given: a long tool call exceeds the cap and the heartbeat stops
     nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS
     await router.__testing!.fireTypingInterval(KEY)
     expect(router.__testing!.isTypingActive(KEY)).toBe(false)
 
+    // when: that tool finally finishes after the timeout
     sessions[0]!.emit({
       type: 'tool_execution_end',
-      toolCallId: 'late',
+      toolCallId: 'slow',
       toolName: 'bash',
       result: 'ok',
       isError: false,
     })
-    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+
+    // then: the heartbeat revives
+    expect(router.__testing!.isTypingActive(KEY)).toBe(true)
+    expect(phases).toEqual(['tick', 'stop', 'tick'])
+
+    releasePrompt!()
+    await draining
+  })
+
+  test('revival defers the fresh tick until an in-flight stop clear settles', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    const phases: Array<'tick' | 'stop'> = []
+    let releaseCapStop: (() => void) | undefined
+    let releasePrompt: (() => void) | undefined
+    let stopCount = 0
+    // Block ONLY the cap-trip 'stop' so the revival race window stays open;
+    // the turn-end 'stop' (after the prompt resolves) must pass through freely.
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+      if (target.phase === 'stop' && ++stopCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseCapStop = resolve
+        })
+      }
+    })
+
+    await router.route(inbound({ text: 'race' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // given: the cap trips and the 'stop' clear is still in flight (blocked)
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS
+    const interval = router.__testing!.fireTypingInterval(KEY)
+    await waitFor(() => releaseCapStop !== undefined)
     expect(phases).toEqual(['tick', 'stop'])
+
+    // when: deltas arrive while the stop clear has not yet completed
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'a' } })
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'b' } })
+
+    // then: no revived tick lands before the clear is released
+    expect(phases).toEqual(['tick', 'stop'])
+
+    // when: the stop clear finally settles
+    releaseCapStop!()
+    await waitFor(() => router.__testing!.isTypingActive(KEY))
+
+    // then: exactly one revived tick fires (queued revivals collapse)
+    expect(phases).toEqual(['tick', 'stop', 'tick'])
+
+    releasePrompt!()
+    await Promise.all([interval, draining])
+  })
+
+  test('a revived heartbeat trips the cap again after another silent window', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { nowRef, logs })
+    const phases: Array<'tick' | 'stop'> = []
+    let releasePrompt: (() => void) | undefined
+    router.registerTyping('discord-bot', async (target) => {
+      phases.push(target.phase)
+    })
+
+    await router.route(inbound({ text: 'silent, loud, silent' }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => releasePrompt !== undefined)
+
+    // given: the cap trips, then a delta revives the heartbeat
+    nowRef.value = 1000 + MAX_TYPING_HEARTBEAT_MS
+    await router.__testing!.fireTypingInterval(KEY)
+    sessions[0]!.emit({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'back' } })
+    expect(router.__testing!.isTypingActive(KEY)).toBe(true)
+
+    // when: another full silent window elapses with no activity
+    nowRef.value += MAX_TYPING_HEARTBEAT_MS
+    await router.__testing!.fireTypingInterval(KEY)
+
+    // then: the cap trips again (silence detection preserved)
+    expect(router.__testing!.isTypingActive(KEY)).toBe(false)
+    expect(phases).toEqual(['tick', 'stop', 'tick', 'stop'])
 
     releasePrompt!()
     await draining

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -607,6 +607,11 @@ type LiveSession = {
   typingStartedAt: number
   typingTimedOut: boolean
   typingStopPromise: Promise<void> | null
+  // True only while `live.session.prompt()` is actively running. Gates the
+  // deferred typing revival: a revival queued behind an in-flight cap-trip
+  // 'stop' must NOT re-arm the heartbeat once the prompt has finished, or it
+  // leaks a timer that fires past the turn's end.
+  promptInFlight: boolean
   lastInboundAt: number
   // Transcript-file size (bytes) captured immediately after cold-start, before
   // any user turn — a proxy for the fixed base-context rebuild cost (rendered
@@ -1673,6 +1678,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         typingStartedAt: 0,
         typingTimedOut: false,
         typingStopPromise: null,
+        promptInFlight: false,
         lastInboundAt: now(),
         baseContextBytes: 0,
         firstUnprocessedAt: 0,
@@ -1967,11 +1973,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const restartTypingAfterTimeout = (live: LiveSession): void => {
-    // Re-checked after the awaited stop: the session may have been destroyed,
-    // or an earlier queued revival may have already cleared the flag and
-    // re-armed the heartbeat (so this one becomes a no-op — no double interval,
-    // no duplicate tick).
-    if (live.destroyed || !live.typingTimedOut) return
+    // Re-checked after the awaited stop:
+    //  - `destroyed`: the session may have been torn down.
+    //  - `!typingTimedOut`: an earlier queued revival already cleared the flag
+    //    and re-armed (so this one is a no-op — no double interval/tick).
+    //  - `!promptInFlight`: the prompt finished while the cap-trip 'stop' was
+    //    still in flight. A revival queued by a late delta would otherwise
+    //    re-arm a heartbeat after generation ended — a timer nothing stops
+    //    (drain()'s turn-end stop already ran with `typingTimer === null`).
+    //    `draining` is too coarse: it stays true through the turn-end hook tail
+    //    (turn-end/idle/todos) after `prompt()` returns, so a revival running
+    //    in that window would still leak. Gate on active generation instead.
+    if (live.destroyed || !live.promptInFlight || !live.typingTimedOut) return
     live.typingTimedOut = false
     startTypingHeartbeat(live)
   }
@@ -2384,6 +2397,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const isRealUserTurn = batch.length > 0
         const retrievalContext = await fireSessionTurnStart(live, composeRetrievalQuery(batch))
         const promptText = retrievalContext.results.length > 0 ? `${text}\n\n${retrievalContext.results}` : text
+        live.promptInFlight = true
         try {
           await live.session.prompt(promptText)
           await validateChannelTurn(live, successfulSendsBeforePrompt)
@@ -2395,6 +2409,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.lastSentText.clear()
           live.lastSendLeafId = null
         } finally {
+          live.promptInFlight = false
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
           if (sentReplyThisTurn) dropEngageReactionsAfterReply(live, engageAddPromises)
           const emptyTurnRetryQueued = live.emptyTurnRetries > emptyTurnRetriesBeforePrompt

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1930,16 +1930,62 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.typingStartedAt = now()
   }
 
+  // Re-arm a heartbeat that the silence cap already stopped. PR #930 made
+  // streamed deltas refresh the clock, but only via `bumpTypingActivity`,
+  // which no-ops once `typingTimer` is null. So a turn that goes silent for
+  // >MAX_TYPING_HEARTBEAT_MS (a long single tool call, a slow provider, an
+  // extended-thinking phase that emits no deltas) trips the cap, and the
+  // delta/tool signals that arrive afterwards can no longer revive it —
+  // `startTypingHeartbeat` short-circuits on `typingTimedOut`, which only
+  // resets at the next drain() iteration (i.e. never, within one long turn).
+  // Reviving here lets demonstrable progress after a timeout bring the
+  // indicator back. The revival is gated on streamed activity ONLY, never on
+  // a new inbound (a later inbound during the same in-flight turn must stay
+  // silenced — see the matching router test).
+  //
+  // On Slack this is the visible bug: its `'stop'` phase sends a permanent
+  // empty-string `setStatus` clear that does not auto-expire, so a tripped
+  // indicator stays gone. Discord/Telegram mask the same defect because their
+  // native indicators auto-expire and self-heal on the next tick.
+  const reviveTypingActivity = (live: LiveSession): void => {
+    if (live.destroyed) return
+    if (!live.typingTimedOut) {
+      bumpTypingActivity(live)
+      return
+    }
+    // A `'stop'` clear may still be in flight. Starting a new heartbeat now
+    // would short-circuit on the non-null `typingStopPromise` (losing the
+    // revival), and firing a fresh `'tick'` before Slack's empty-string clear
+    // lands would let the clear wipe the just-revived status. Defer until the
+    // stop settles so the new `'tick'` is ordered strictly after the clear.
+    const stopPromise = live.typingStopPromise
+    if (stopPromise) {
+      void stopPromise.catch(() => undefined).then(() => restartTypingAfterTimeout(live))
+      return
+    }
+    restartTypingAfterTimeout(live)
+  }
+
+  const restartTypingAfterTimeout = (live: LiveSession): void => {
+    // Re-checked after the awaited stop: the session may have been destroyed,
+    // or an earlier queued revival may have already cleared the flag and
+    // re-armed the heartbeat (so this one becomes a no-op — no double interval,
+    // no duplicate tick).
+    if (live.destroyed || !live.typingTimedOut) return
+    live.typingTimedOut = false
+    startTypingHeartbeat(live)
+  }
+
   const subscribeTypingActivity = (session: AgentSession, live: LiveSession): (() => void) => {
     return session.subscribe((event) => {
       if (event.type === 'tool_execution_end') {
-        bumpTypingActivity(live)
+        reviveTypingActivity(live)
         return
       }
       if (event.type !== 'message_update') return
       const streamed = event.assistantMessageEvent.type
       if (streamed === 'text_delta' || streamed === 'thinking_delta') {
-        bumpTypingActivity(live)
+        reviveTypingActivity(live)
       }
     })
   }


### PR DESCRIPTION
## Background

Follow-up to #930. That PR fixed the "typing… indicator disappears mid-reply" bug for Discord/Telegram by adding three signals of life — `tool_execution_end`, `text_delta`, and `thinking_delta` — that refresh the typing-heartbeat silence clock (`MAX_TYPING_HEARTBEAT_MS`, 2 min) in the shared router. The user reports **Slack still drops the indicator** on long turns.

## Root cause

#930's signals only refresh an **already-running** heartbeat: they call `bumpTypingActivity`, which `return`s early when `live.typingTimer === null`. So #930 prevents the cap from tripping *while* deltas keep arriving within each 2-minute window, but it cannot **revive** a heartbeat the cap has already stopped.

A turn that goes genuinely silent for longer than `MAX_TYPING_HEARTBEAT_MS` — a long single tool call, a slow provider stall, or an extended-thinking phase that emits no deltas — still trips the cap. The trip sets `live.typingTimedOut = true` and nulls the timer. From then on:

- `bumpTypingActivity` is a no-op (timer is null), so the post-timeout deltas/tool-end events #930 added can no longer do anything, and
- `startTypingHeartbeat` short-circuits on `typingTimedOut`, which only resets at the **next `drain()` iteration** — and a single long turn is exactly one drain iteration.

Net: once the cap trips mid-turn, typing stays dead for the rest of the turn even though the model resumes streaming.

### Why this presents as Slack-specific

Discord and Telegram **mask** the same defect: their native indicators auto-expire (~5–10s) and self-heal on the next tick, so a tripped-then-resumed turn looks fine. Slack's `'stop'` phase sends a permanent empty-string `assistant.threads.setStatus` clear that does **not** auto-expire, so a tripped indicator stays visibly gone until a new tick arrives — which never comes. The bug is shared; only Slack surfaces it.

## Fix

Add `reviveTypingActivity` (used by `subscribeTypingActivity` for `tool_execution_end` / `text_delta` / `thinking_delta`):

- If the heartbeat is still running → bump as before (unchanged #930 behavior).
- If the cap has tripped → clear `typingTimedOut` and **re-arm** the heartbeat.

Concurrency handling:

- **In-flight `'stop'` race:** if a `'stop'` clear is still in flight (`typingStopPromise` set), revival **defers** the re-arm until the stop settles, so the fresh `'tick'` is ordered strictly **after** the clear. This preserves Slack's per-(chat,thread) FIFO contract — firing a tick before the empty-string clear landed would let the clear wipe the just-revived status.
- **Collapse + re-entrancy:** after the awaited stop, `restartTypingAfterTimeout` re-checks `destroyed` / `typingTimedOut`, so multiple queued revivals collapse to a single re-arm (no double interval, no duplicate tick).
- **Silence detection preserved:** a revived heartbeat re-trips the cap after each subsequent silent window; a genuinely stuck/silent turn still goes quiet as before.
- **Inbound gating unchanged:** revival is driven by streamed activity only — a later *inbound* during the same in-flight turn stays silenced (existing behavior/test intact).

The change is entirely in the shared router layer. No adapter (`slack-bot`, `discord-bot`, `telegram-bot`) is touched; all three benefit.

## Tests

`src/channels/router.test.ts`:

- a post-cap `text_delta` revives typing (`tick → stop → tick`);
- a post-cap `tool_execution_end` revives typing;
- revival **defers** the fresh tick until an in-flight `'stop'` clear settles, and queued revivals collapse to exactly one tick;
- a revived heartbeat **re-trips** the cap after another silent window (silence detection preserved).

The obsolete #930 test that asserted "tool_execution_end after the cap does NOT resurrect typing" encoded the bug; it's replaced by the revival assertions above. All other typing tests still pass.

`bun run typecheck`, `bun run lint` (0 errors), and `bun run format:check` are clean. Full suite passes except two pre-existing `createCronConsumer` process-spawn flakes that pass in isolation and are unrelated to this change.