### PR TITLE
feat(config): allow single-file mounts, not just directories

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -118,7 +118,7 @@ typeclaw mount add work ./workspace --description "local worktree"
 typeclaw mount remove downloads
 ```
 
-Mounts expose host directories inside the container at `/agent/mounts/<name>`. Names must be lowercase alphanumeric with `-` or `_`. Adding/removing a mount updates `typeclaw.json`; restart the running agent with `typeclaw restart` for Docker to apply the bind mount.
+Mounts expose host files or directories inside the container at `/agent/mounts/<name>`. Names must be lowercase alphanumeric with `-` or `_`. Adding/removing a mount updates `typeclaw.json`; restart the running agent with `typeclaw restart` for Docker to apply the bind mount.
 
 ## Compose
 

--- a/docs/content/docs/reference/typeclaw-json.mdx
+++ b/docs/content/docs/reference/typeclaw-json.mdx
@@ -12,7 +12,7 @@ JSON Schema–validated. `typeclaw init` scaffolds a `$schema` pointer at `./nod
 | ----------------------- | -------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------- |
 | `models`                | `Record<string, ref \| ref[]>`   | live                                         | model profile → ref or fallback chain                                                  |
 | `port`                  | `number`                         | restart-required                             | preferred host port; CLI falls back to ephemeral on conflict                           |
-| `mounts`                | `Mount[]`                        | restart-required                             | host directories exposed inside the container                                          |
+| `mounts`                | `Mount[]`                        | restart-required                             | host files or directories exposed inside the container                                 |
 | `plugins`               | `string[]`                       | restart-required                             | plugin module specifiers                                                               |
 | `alias`                 | `string[]`                       | live                                         | additional names the agent answers to in channels                                      |
 | `channels`              | `Record<adapter, AdapterConfig>` | live                                         | per-adapter config                                                                     |
@@ -95,7 +95,7 @@ Provider-family defaults override the SDK's reasoning level at session creation:
 }
 ```
 
-Each mount maps a host directory to `/agent/mounts/<name>` inside the container. `path` accepts absolute paths, relative paths resolved from the agent folder, and `~`/`~/...`. `readOnly` defaults to `false`; use `true` for reference data the agent should inspect but not edit. Mount changes are restart-required because Docker bind mounts are fixed when the container starts.
+Each mount maps a host **file or directory** to `/agent/mounts/<name>` inside the container. `path` accepts absolute paths, relative paths resolved from the agent folder, and `~`/`~/...`. `readOnly` defaults to `false`; use `true` for reference data the agent should inspect but not edit — the natural choice for exposing a single credential such as an SSH private key. Sockets, FIFOs, and devices are rejected. Mount changes are restart-required because Docker bind mounts are fixed when the container starts. Note that a single-file bind tracks the file's inode, so replacing the host file via write-temp-then-rename (most editors, some key-rotation tools) is not seen by the container until the next restart; mount the parent directory if you need live updates.
 
 The CLI can manage this block:
 

--- a/src/cli/mount.ts
+++ b/src/cli/mount.ts
@@ -8,7 +8,7 @@ import { c, errorLine, successLine } from './ui'
 const listSub = defineCommand({
   meta: {
     name: 'list',
-    description: 'list host directories mounted into the agent container',
+    description: 'list host files and directories mounted into the agent container',
   },
   args: {
     json: {
@@ -31,7 +31,7 @@ const listSub = defineCommand({
 const addSub = defineCommand({
   meta: {
     name: 'add',
-    description: 'add a host directory mount to typeclaw.json',
+    description: 'add a host file or directory mount to typeclaw.json',
   },
   args: {
     name: {
@@ -41,7 +41,7 @@ const addSub = defineCommand({
     },
     path: {
       type: 'positional',
-      description: 'host directory path to expose inside the container',
+      description: 'host file or directory path to expose inside the container',
       required: true,
     },
     'read-only': {
@@ -74,7 +74,7 @@ const addSub = defineCommand({
 const removeSub = defineCommand({
   meta: {
     name: 'remove',
-    description: 'remove a host directory mount from typeclaw.json',
+    description: 'remove a host mount from typeclaw.json',
   },
   args: {
     name: {
@@ -98,7 +98,7 @@ const removeSub = defineCommand({
 export const mountCommand = defineCommand({
   meta: {
     name: 'mount',
-    description: 'manage host directories mounted into the agent container',
+    description: 'manage host files and directories mounted into the agent container',
   },
   subCommands: {
     list: listSub,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer, type Server } from 'node:net'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -1578,14 +1579,55 @@ describe('validateMount', () => {
     }
   })
 
-  test('fails with "not a directory" when the path is a regular file', async () => {
-    const filePath = join(cwd, 'file.txt')
-    await writeFile(filePath, 'hi')
-    const result = validateMount({ name: 'data', path: filePath, readOnly: false }, cwd)
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.reason).toContain('mount "data"')
-      expect(result.reason).toContain('not a directory')
+  test('ok when path is a regular file (read-write)', async () => {
+    const filePath = join(cwd, 'key')
+    await writeFile(filePath, 'secret')
+    const result = validateMount({ name: 'key', path: filePath, readOnly: false }, cwd)
+    expect(result.ok).toBe(true)
+  })
+
+  test.skipIf(isRoot)('ok when readOnly:true and path is a read-only file', async () => {
+    const filePath = join(cwd, 'key')
+    await writeFile(filePath, 'secret')
+    await chmod(filePath, 0o400)
+    try {
+      const result = validateMount({ name: 'key', path: filePath, readOnly: true }, cwd)
+      expect(result.ok).toBe(true)
+    } finally {
+      await chmod(filePath, 0o600)
+    }
+  })
+
+  test.skipIf(isRoot || onWindows)('fails when readOnly:false but the file is read-only on disk', async () => {
+    const filePath = join(cwd, 'key')
+    await writeFile(filePath, 'secret')
+    await chmod(filePath, 0o400)
+    try {
+      const result = validateMount({ name: 'key', path: filePath, readOnly: false }, cwd)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('not writable')
+      }
+    } finally {
+      await chmod(filePath, 0o600)
+    }
+  })
+
+  // A unix socket is neither a regular file nor a directory; exposing sockets,
+  // FIFOs, and devices is an advanced case we reject rather than mount blindly.
+  test.skipIf(onWindows)('fails when the path is neither a file nor a directory', async () => {
+    const socketPath = join(cwd, 'sock')
+    const server: Server = createServer()
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve))
+    try {
+      const result = validateMount({ name: 'sock', path: socketPath, readOnly: true }, cwd)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('mount "sock"')
+        expect(result.reason).toContain('not a file or directory')
+      }
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
     }
   })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1253,11 +1253,15 @@ export function parseConfigJson(raw: string, options: ParseConfigJsonOptions = {
   return { ok: true, config: result.data }
 }
 
-// Verifies a mount's host path: exists, is a directory, is readable, and is
-// writable when not declared `readOnly`. Symlinks are followed (statSync's
-// default) so a broken symlink reads as "does not exist". Permission checks
-// are skipped when running as root (uid 0) — euidaccess returns success
-// regardless, so the test would be vacuous and inconsistent with non-root.
+// Verifies a mount's host path: exists, is a regular file or directory, is
+// readable, and is writable when not declared `readOnly`. Symlinks are
+// followed (statSync's default) so a broken symlink reads as "does not exist".
+// File mounts are allowed so credentials and config can be exposed as a single
+// path (e.g. an SSH private key); sockets, FIFOs, and devices are rejected
+// because exposing them is an advanced, security-sensitive case we don't take
+// implicitly. Permission checks are skipped when running as root (uid 0) —
+// euidaccess returns success regardless, so the test would be vacuous and
+// inconsistent with non-root.
 export function validateMount(mount: Mount, cwd: string): ValidateConfigResult {
   const resolved = expandMountPath(mount.path, cwd)
   const label = `mount "${mount.name}"`
@@ -1274,8 +1278,8 @@ export function validateMount(mount: Mount, cwd: string): ValidateConfigResult {
     return { ok: false, reason: `${label}: cannot stat ${resolved}: ${detail}` }
   }
 
-  if (!stats.isDirectory()) {
-    return { ok: false, reason: `${label}: path ${resolved} is not a directory` }
+  if (!stats.isDirectory() && !stats.isFile()) {
+    return { ok: false, reason: `${label}: path ${resolved} is not a file or directory` }
   }
 
   const isRoot = typeof process.getuid === 'function' && process.getuid() === 0


### PR DESCRIPTION
## Why

`validateMount` rejected every host path that wasn't a directory:

```ts
if (!stats.isDirectory()) {
  return { ok: false, reason: `${label}: path ${resolved} is not a directory` }
}
```

So exposing a **single credential** — e.g. an SSH private key — as a mount was impossible. The only workaround was wrapping the key in a throwaway directory and symlinking inside the container. Worse, when an agent added such a mount and self-restarted, the invalid config was only caught *after* the container had already been torn down (host-side validation runs post-teardown), stranding the agent with nothing running.

## What

- Accept **regular files** alongside directories in `validateMount`.
- Keep **sockets, FIFOs, and devices rejected** — exposing those is an advanced, security-sensitive case we don't take on implicitly. The check becomes `!isDirectory() && !isFile()`, message `is not a file or directory`.
- The existing readability / writability (`R_OK` / `W_OK`) checks already work unchanged on files.

The docker `-v` generation (`src/container/start.ts`) is already type-agnostic (`${hostPath}:${target}` with optional `:ro`), so **no bind changes are needed** — only the validation gate and user-facing copy.

## Caveat (documented)

A single-file bind tracks the file's **inode**. Replacing the host file via write-temp-then-rename (most editors, some key-rotation tools) isn't seen by the container until the next restart. The reference docs now note this and suggest mounting the parent directory when live updates are needed.

## Tests

`validateMount` suite extended:
- file mount OK (read-write)
- `readOnly: true` on a read-only file OK
- `readOnly: false` against a read-only file → `not writable`
- a unix socket (neither file nor directory) → rejected with `not a file or directory`

The previous "regular file is rejected" test is inverted to assert acceptance.

Full suite: **9278 pass, 0 fail**. `typecheck`, `lint` (0 errors), `format:check` all clean.

## Scope note

This fixes the *mount-validation* class of the problem directly. The orthogonal "self-restart tears down a healthy container before host-side config validation" gap (any other invalid config still strands the agent) is intentionally **not** addressed here and can be a follow-up.