### PR TITLE
feat(github-cli-auth): mint via trusted repo fallback; actionable guidance for gh

### DIFF
--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -559,6 +559,51 @@ describe('analyzeGhCommand', () => {
     expect(analyzeGhCommand('gh api /user')).toEqual({ kind: 'pass-through' })
     expect(analyzeGhCommand("gh api /user --jq '.login'")).toEqual({ kind: 'pass-through' })
   })
+
+  it('tags each block with a structured code so the caller can react', () => {
+    const missing = analyzeGhCommand('gh label list')
+    expect(missing.kind === 'block' && missing.code).toBe('missing-repo')
+    const nonLiteral = analyzeGhCommand('gh label list -R "$repo"')
+    expect(nonLiteral.kind === 'block' && nonLiteral.code).toBe('non-literal-repo')
+    const composition = analyzeGhCommand('set -e; gh label list -R acme/widgets')
+    expect(composition.kind === 'block' && composition.code).toBe('composition')
+  })
+})
+
+describe('analyzeGhCommand with a trusted fallback repo', () => {
+  it('injects the fallback for a repo-less bare command', () => {
+    expect(analyzeGhCommand('gh label list', 'acme/widgets')).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+
+  it('STILL blocks a compound command even with a fallback (token would leak to siblings)', () => {
+    const result = analyzeGhCommand('set -euo pipefail; gh label list', 'acme/widgets')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.code).toBe('composition')
+  })
+
+  it('STILL blocks a non-literal -R even with a fallback (never papers over a user $var)', () => {
+    const result = analyzeGhCommand('gh label edit foo -R "$repo" --name x', 'acme/widgets')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.code).toBe('non-literal-repo')
+  })
+
+  it('lets an explicit literal -R win over the fallback', () => {
+    expect(analyzeGhCommand('gh label list -R real/repo', 'acme/widgets')).toEqual({
+      kind: 'inject',
+      repoSlug: 'real/repo',
+    })
+  })
+
+  it('does not apply the fallback to a gh api path (the path is authoritative)', () => {
+    expect(analyzeGhCommand('gh api repos/path/repo/labels', 'acme/widgets')).toEqual({
+      kind: 'inject',
+      repoSlug: 'path/repo',
+    })
+  })
+
+  it('never treats a non-literal fallback as a repo', () => {
+    expect(analyzeGhCommand('gh label list', '$owner/$repo').kind).toBe('block')
+  })
 })
 
 describe('usesGhApiAuthenticatedUserEndpoint', () => {

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -173,17 +173,20 @@ describe('analyzeGhCommand', () => {
     })
   })
 
-  it('the strip rewrite never touches a -R/--repo whose value is not an owner/repo slug', () => {
-    // The graphql repo hint is taken from a valid slug; an attached `=` form
-    // whose value is NOT owner/repo must be left verbatim by the rewrite (the
-    // detection path already rejected it, so the rewrite must agree).
-    const noStrip = [
+  it('blocks a graphql -R/--repo whose value is not an owner/repo slug (never injected or stripped)', () => {
+    // A graphql repo hint is taken only from a valid literal slug. An attached
+    // `=` form whose value is NOT owner/repo is never minted/stripped; instead of
+    // silently passing through to an unauthenticated `gh api`, it now blocks with
+    // an actionable reason so the agent knows the hint was unusable.
+    const nonLiteral = [
       'gh api graphql -R=notaslug -f query=x',
       'gh api graphql --repo=owner/repo/extra -f query=x',
       'gh api graphql -R= -f query=x',
     ]
-    for (const input of noStrip) {
-      expect(analyzeGhCommand(input)).toEqual({ kind: 'pass-through' })
+    for (const input of nonLiteral) {
+      const result = analyzeGhCommand(input)
+      expect(result.kind).toBe('block')
+      if (result.kind === 'block') expect(result.reason).toContain('not a literal')
     }
   })
 
@@ -205,6 +208,37 @@ describe('analyzeGhCommand', () => {
 
   it('blocks gh pr create without a repo', () => {
     expect(analyzeGhCommand('gh pr create --title x --body y').kind).toBe('block')
+  })
+
+  it('blocks -R with an unexpanded shell variable and says it is not literal', () => {
+    const result = analyzeGhCommand('gh label edit foo -R "$repo" --name x')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.reason).toContain('not a literal')
+  })
+
+  it('does NOT inject a single-quoted variable repo slug (must not mint for an unverifiable target)', () => {
+    const result = analyzeGhCommand("gh label list -R '$owner/$repo'")
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.reason).toContain('not a literal')
+  })
+
+  it('blocks --repo= with a variable value', () => {
+    const result = analyzeGhCommand('gh issue list --repo=$repo')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.reason).toContain('not a literal')
+  })
+
+  it('blocks a gh api graphql call whose -R hint is a shell variable', () => {
+    const result = analyzeGhCommand('gh api graphql -R "$repo" -f query=x')
+    expect(result.kind).toBe('block')
+    if (result.kind === 'block') expect(result.reason).toContain('not a literal')
+  })
+
+  it('still injects for a literal -R even though the var path now blocks', () => {
+    expect(analyzeGhCommand('gh label edit foo -R acme/widgets --name x')).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+    })
   })
 
   it('blocks a leading environment assignment before a repo-targeting gh', () => {

--- a/src/bundled-plugins/github-cli-auth/gh-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.test.ts
@@ -109,6 +109,24 @@ describe('analyzeGhCommand', () => {
     expect(analyzeGhCommand('gh api -R acme/widgets /repos/victim/private/issues').kind).toBe('block')
   })
 
+  it('blocks a literal /repos path gh api when -R/--repo is a non-literal value (never injects)', () => {
+    // A single-quoted `-R '$repo'` neutralizes the `$` (so the composition gate
+    // passes) and is dropped by extractAllRepoFlags (literal-only), which used to
+    // let the literal-path branch inject for the PATH repo while the unverifiable
+    // flag named something else. The non-literal guard must fire before that.
+    const attacks = [
+      "gh api /repos/acme/widgets/issues -R '$repo'",
+      'gh api /repos/acme/widgets/issues -R "$repo"',
+      "gh api /repos/acme/widgets/labels -R '$victim'",
+      'gh api repos/acme/widgets/issues --repo=$repo',
+    ]
+    for (const input of attacks) {
+      const result = analyzeGhCommand(input)
+      expect(result.kind).toBe('block')
+      if (result.kind === 'block') expect(result.code).toBe('non-literal-repo')
+    }
+  })
+
   it('uses -R for a quoted {owner}/{repo} placeholder endpoint', () => {
     expect(analyzeGhCommand("gh api 'repos/{owner}/{repo}/issues' -R acme/widgets")).toEqual({
       kind: 'inject',

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -9,8 +9,16 @@ export type GhCommandDecision =
 
 const MISSING_REPO_REASON =
   'This GitHub App spans multiple owners, so `gh` has no single correct token. ' +
-  'Re-run with an explicit repo: `gh <cmd> -R owner/repo` (or `gh api /repos/owner/repo/...`) ' +
-  'so the right installation token can be injected.'
+  'Re-run as a single bare command with a LITERAL repo: `gh <cmd> -R owner/repo` ' +
+  '(or `gh api /repos/owner/repo/...`) so the right installation token can be injected. ' +
+  'The repo must be a concrete `owner/repo` slug, not a shell variable.'
+
+const NON_LITERAL_REPO_REASON =
+  'The `-R/--repo` value is not a literal `owner/repo` slug TypeClaw can verify. ' +
+  'Shell variables like `-R "$repo"` are not readable by the static GitHub App token ' +
+  'guard (it never expands the shell). Re-run as a single bare command with a literal ' +
+  'repo: `gh <cmd> -R owner/repo`, or `gh api /repos/owner/repo/...`; only a trailing ' +
+  'stdin-only reader pipeline such as `| jq ...` may follow.'
 
 const MULTI_OWNER_REASON =
   'This command targets repos under more than one owner; a single GH_TOKEN cannot ' +
@@ -36,6 +44,9 @@ type GhSegmentDecision =
   | { kind: 'inject'; repoSlugs: readonly string[]; stripRepoFlag?: boolean }
 
 const COMPOSITION_REASON =
+  'Allowed shape: a single bare `gh <cmd> -R owner/repo` (or `gh api /repos/owner/repo/...`) ' +
+  'with a LITERAL repo slug, optionally followed by a trailing stdin-only reader pipeline ' +
+  'such as `| jq ...`. ' +
   'A repo-targeting `gh` command receives a minted GitHub App token in its process ' +
   'environment, so it must run as a single bare `gh` command — no `;`, `&&`, `||`, `&`, ' +
   'newlines, redirections, command/process substitution, subshells, heredocs, or unquoted ' +
@@ -500,6 +511,10 @@ function classifyGhSegment(args: readonly string[]): GhSegmentDecision {
   const explicit = extractRepoFlag(args)
   if (explicit !== null) return { kind: 'inject', repoSlugs: [explicit] }
 
+  // A `-R`/`--repo` IS present but its value isn't a literal slug (e.g. `-R "$repo"`):
+  // tell the user that, not the misleading "add -R" message — they already did.
+  if (repoFlagHasNonLiteralValue(args)) return { kind: 'block', reason: NON_LITERAL_REPO_REASON }
+
   if (REPO_LESS_SUBCOMMANDS.has(subcommand)) return { kind: 'pass-through' }
 
   return { kind: 'block', reason: MISSING_REPO_REASON }
@@ -544,6 +559,13 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
   // `gh api` rejects `-R`, so the flag must be stripped from the command.
   if (flagRepo !== null && isGraphqlEndpoint(args)) {
     return { kind: 'inject', repoSlugs: [flagRepo], stripRepoFlag: true }
+  }
+
+  // No literal path repo and no usable literal `-R`: if a `-R`/`--repo` was given
+  // with a non-literal value (e.g. `gh api graphql -R "$repo"`), say so rather
+  // than silently passing through to an unauthenticated `gh api`.
+  if (flagRepo === null && repoFlagHasNonLiteralValue(args)) {
+    return { kind: 'block', reason: NON_LITERAL_REPO_REASON }
   }
 
   return { kind: 'pass-through' }
@@ -660,6 +682,27 @@ function extractRepoFlag(args: readonly string[]): string | null {
   return null
 }
 
+// True when a `-R`/`--repo` flag is present but its value is not a literal slug
+// `extractRepoFlag` would accept (missing, a shell variable, a placeholder, or a
+// malformed slug). Lets the classifier emit NON_LITERAL_REPO_REASON instead of
+// the misleading "add -R" message when the user DID pass `-R` but with `$repo`.
+function repoFlagHasNonLiteralValue(args: readonly string[]): boolean {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === undefined) continue
+    if (arg === '-R' || arg === '--repo') {
+      const value = args[i + 1]
+      if (value === undefined || value.startsWith('-')) return true
+      if (!isRepoSlug(value)) return true
+    } else if (arg.startsWith('--repo=')) {
+      if (!isRepoSlug(arg.slice('--repo='.length))) return true
+    } else if (arg.startsWith('-R=')) {
+      if (!isRepoSlug(arg.slice('-R='.length))) return true
+    }
+  }
+  return false
+}
+
 // Every valid `-R`/`--repo` slug in `args`, not just the first. The strip removes
 // ALL unquoted repo flags, so the conflict check must see ALL of them: a command
 // like `... -R path/repo -R victim/private` is a mint-for-X-hit-Y attempt where
@@ -772,7 +815,13 @@ function apiEndpointHasOwnerRepoPlaceholder(args: readonly string[]): boolean {
   return endpoint.includes('{owner}') || endpoint.includes('{repo}')
 }
 
+// Security invariant: `extractRepoFlag` mints a token from this value, so only a
+// CONCRETE static `owner/name` may pass. A value carrying `$`/`${}` expansion or
+// `{owner}`/`{repo}` placeholders is rejected here so a `-R '$owner/$repo'`
+// (single-quoted, so it slips the composition gate) can never be injected and
+// mint for an unverifiable target; it surfaces as NON_LITERAL_REPO_REASON instead.
 function isRepoSlug(value: string): boolean {
+  if (value.includes('$') || value.includes('{') || value.includes('}')) return false
   const [owner, name, ...rest] = value.split('/')
   return owner !== undefined && owner !== '' && name !== undefined && name !== '' && rest.length === 0
 }

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -1,6 +1,12 @@
+// `code` classifies a block so the caller can react structurally instead of
+// string-matching the reason: only `missing-repo` is eligible for a trusted
+// repo-fallback (origin/cwd) that turns the block into a mint; `composition`,
+// `multi-owner`, `api-repo-conflict`, and `non-literal-repo` must stay blocks.
+export type GhBlockCode = 'missing-repo' | 'non-literal-repo' | 'composition' | 'multi-owner' | 'api-repo-conflict'
+
 export type GhCommandDecision =
   | { kind: 'pass-through' }
-  | { kind: 'block'; reason: string }
+  | { kind: 'block'; code: GhBlockCode; reason: string }
   // `rewrittenCommand`, when present, MUST replace the executed command: `gh api`
   // rejects `-R/--repo` ("unknown shorthand flag"), so for a graphql endpoint the
   // flag is consumed as our repo hint and stripped before exec. Other inject paths
@@ -38,7 +44,7 @@ const API_REPO_CONFLICT_REASON =
 // `gh api /repos/x/y` path slip past an `-R`-derived check.
 type GhSegmentDecision =
   | { kind: 'pass-through' }
-  | { kind: 'block'; reason: string }
+  | { kind: 'block'; code: GhBlockCode; reason: string }
   // `stripRepoFlag` marks a graphql inject whose `-R/--repo` is a TypeClaw-only
   // hint that `gh api` would reject, so it must be removed from the command.
   | { kind: 'inject'; repoSlugs: readonly string[]; stripRepoFlag?: boolean }
@@ -130,7 +136,16 @@ const REPO_LESS_SUBCOMMANDS = new Set([
 // installation). We therefore inspect EVERY `gh` invocation, not just the
 // first: a repo-targeting `gh` with no resolvable repo blocks (missing-repo),
 // and invocations spanning more than one owner block (multi-owner).
-export function analyzeGhCommand(command: string): GhCommandDecision {
+// `fallbackRepo`, when supplied, is a TRUSTED literal `owner/repo` the CALLER
+// resolved from a non-command source (GitHub session origin or the cwd git
+// remote) and already allowlist-checked. It fills in for a repo-less non-`api`
+// segment that would otherwise block `missing-repo`, so a bare `gh label list`
+// can mint. It deliberately flows through the SAME multi-owner + single-bare
+// composition gates below, so a compound command still blocks even with a
+// fallback (the token would leak to siblings). It NEVER overrides an explicit
+// `-R`/path repo, and is NOT applied to `non-literal-repo` (a `$var` the user
+// wrote) or `gh api` (path is authoritative).
+export function analyzeGhCommand(command: string, fallbackRepo?: string): GhCommandDecision {
   const tokens = tokenize(command)
   const ghStarts = findGhInvocations(tokens)
   if (ghStarts.length === 0) return { kind: 'pass-through' }
@@ -141,7 +156,7 @@ export function analyzeGhCommand(command: string): GhCommandDecision {
     const start = ghStarts[i] as number
     const end = ghStarts[i + 1] ?? tokens.length
     const args = tokens.slice(start + 1, end)
-    const segment = classifyGhSegment(args)
+    const segment = classifyGhSegment(args, fallbackRepo)
     if (segment.kind === 'block') return segment
     if (segment.kind === 'inject') {
       repoSlugs.push(...segment.repoSlugs)
@@ -151,7 +166,7 @@ export function analyzeGhCommand(command: string): GhCommandDecision {
 
   if (repoSlugs.length === 0) return { kind: 'pass-through' }
   const owners = new Set(repoSlugs.map((slug) => slug.split('/')[0]))
-  if (owners.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
+  if (owners.size > 1) return { kind: 'block', code: 'multi-owner', reason: MULTI_OWNER_REASON }
 
   const repoSlug = repoSlugs[0] as string
 
@@ -167,7 +182,7 @@ export function analyzeGhCommand(command: string): GhCommandDecision {
   const piped = analyzeReaderPipeline(command, stripRepoFlag)
   if (piped !== null) return { kind: 'inject', repoSlug, rewrittenCommand: piped }
 
-  return { kind: 'block', reason: COMPOSITION_REASON }
+  return { kind: 'block', code: 'composition', reason: COMPOSITION_REASON }
 }
 
 // stdin-only readers whose only sink is stdout (back to the agent, who already
@@ -498,7 +513,7 @@ function matchRepoFlagAt(command: string, start: number): number | null {
   return null
 }
 
-function classifyGhSegment(args: readonly string[]): GhSegmentDecision {
+function classifyGhSegment(args: readonly string[], fallbackRepo?: string): GhSegmentDecision {
   const subcommand = args.find((t) => !t.startsWith('-'))
   if (subcommand === undefined) return { kind: 'pass-through' }
 
@@ -513,11 +528,19 @@ function classifyGhSegment(args: readonly string[]): GhSegmentDecision {
 
   // A `-R`/`--repo` IS present but its value isn't a literal slug (e.g. `-R "$repo"`):
   // tell the user that, not the misleading "add -R" message — they already did.
-  if (repoFlagHasNonLiteralValue(args)) return { kind: 'block', reason: NON_LITERAL_REPO_REASON }
+  // A trusted fallback never papers over a value the user explicitly mistyped.
+  if (repoFlagHasNonLiteralValue(args))
+    return { kind: 'block', code: 'non-literal-repo', reason: NON_LITERAL_REPO_REASON }
 
   if (REPO_LESS_SUBCOMMANDS.has(subcommand)) return { kind: 'pass-through' }
 
-  return { kind: 'block', reason: MISSING_REPO_REASON }
+  // Repo-less repo-scoped subcommand. A caller-supplied trusted fallback repo
+  // (origin/cwd, already allowlisted) fills it so the command can mint; absent
+  // one, block missing-repo. The fallback still passes through the composition
+  // gate in analyzeGhCommand, so a compound command blocks regardless.
+  if (fallbackRepo !== undefined && isRepoSlug(fallbackRepo)) return { kind: 'inject', repoSlugs: [fallbackRepo] }
+
+  return { kind: 'block', code: 'missing-repo', reason: MISSING_REPO_REASON }
 }
 
 // Repo authority for `gh api`: the literal endpoint path wins. A `-R/--repo`
@@ -537,7 +560,7 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
     // mask it.
     const flagRepos = extractAllRepoFlags(args)
     if (flagRepos.some((slug) => !pathRepos.includes(slug))) {
-      return { kind: 'block', reason: API_REPO_CONFLICT_REASON }
+      return { kind: 'block', code: 'api-repo-conflict', reason: API_REPO_CONFLICT_REASON }
     }
     // Every `-R` here is redundant: it matches the repo already named in the
     // literal path, which is authoritative. `gh api` rejects `-R` outright, so
@@ -565,7 +588,7 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
   // with a non-literal value (e.g. `gh api graphql -R "$repo"`), say so rather
   // than silently passing through to an unauthenticated `gh api`.
   if (flagRepo === null && repoFlagHasNonLiteralValue(args)) {
-    return { kind: 'block', reason: NON_LITERAL_REPO_REASON }
+    return { kind: 'block', code: 'non-literal-repo', reason: NON_LITERAL_REPO_REASON }
   }
 
   return { kind: 'pass-through' }

--- a/src/bundled-plugins/github-cli-auth/gh-command.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-command.ts
@@ -553,6 +553,18 @@ function classifyGhApiSegment(args: readonly string[]): GhSegmentDecision {
   const pathRepos = extractReposFromApiPath(args)
   const flagRepo = extractRepoFlag(args)
 
+  // A non-literal `-R/--repo` (e.g. `-R '$repo'`) blocks BEFORE any inject path,
+  // including the literal `/repos/owner/repo` path branch below. Without this, a
+  // single-quoted `gh api /repos/acme/widgets/... -R '$repo'` slips the composition
+  // gate (single quotes neutralize `$`) AND is dropped by extractAllRepoFlags
+  // (which keeps literal slugs only), so the path branch would mint for the PATH
+  // repo while the unverifiable flag named something else — the exact mint-for-X-
+  // hit-Y the conflict guard exists to stop. We never inject when an unreadable
+  // repo flag is present.
+  if (repoFlagHasNonLiteralValue(args)) {
+    return { kind: 'block', code: 'non-literal-repo', reason: NON_LITERAL_REPO_REASON }
+  }
+
   if (pathRepos.length > 0) {
     // Check EVERY repo flag, not just the first: the strip removes all of them,
     // so a single non-redundant flag anywhere is a mint-for-X-hit-Y attempt and

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -271,6 +271,17 @@ async function resolveDefaultPushRemote(cwd: string, resolvers: GitResolvers): P
   return 'origin'
 }
 
+// The `gh`-side cwd default repo: the working tree's `origin` FETCH url only.
+// Unlike `git push`, `gh <cmd>` with no `-R` has no push semantics, so we do NOT
+// consult the branch.pushRemote/remote.pushDefault chain — origin is what `gh`
+// itself would infer. Returns a literal `owner/repo` slug or null; the caller
+// still gates it through the repos[] allowlist before minting.
+export async function resolveGhDefaultRepoFromCwd(cwd: string, resolvers: GitResolvers): Promise<string | null> {
+  const url = await resolvers.resolveRemoteUrl(cwd, 'origin', false)
+  if (url === null) return null
+  return parseGithubRepoFromGitUrl(url)
+}
+
 const HTTPS_GITHUB_RE = /^https:\/\/github\.com\/([^/\s:@]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
 const SCP_GITHUB_RE = /^git@github\.com:([^/\s:?#]+)\/([^/\s?#]+?)(?:\.git)?$/i
 const SSH_GITHUB_RE = /^ssh:\/\/git@github\.com(?::\d+)?\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -65,6 +65,16 @@ function bashEvent(command: string): ToolBeforeEvent {
   return { tool: 'bash', sessionId: 's', callId: 'c', args: { command } }
 }
 
+function githubOriginBashEvent(command: string, workspace: string): ToolBeforeEvent {
+  return {
+    tool: 'bash',
+    sessionId: 's',
+    callId: 'c',
+    args: { command },
+    origin: { kind: 'channel', adapter: 'github', workspace, chat: workspace, thread: null },
+  }
+}
+
 const tokenResolver = (token: string) => async (): Promise<GithubTokenResolveResult> => ({ kind: 'token', token })
 const unavailableResolver = async (): Promise<GithubTokenResolveResult> => ({
   kind: 'unavailable',
@@ -98,6 +108,62 @@ describe('github-cli-auth plugin', () => {
     })
 
     expect(result).toMatchObject({ block: true })
+  })
+
+  test('GitHub-origin: a repo-less bare gh mints for origin.workspace and sets GH_REPO', async () => {
+    delete process.env.GH_TOKEN
+    const seen: string[] = []
+    const hook = await hookFor(async (slug) => {
+      seen.push(slug)
+      return { kind: 'token', token: 'ghs_minted' }
+    }, true)
+    const event = githubOriginBashEvent('gh label list', 'acme/widgets')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(seen).toEqual(['acme/widgets'])
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted', GH_REPO: 'acme/widgets' })
+    expect(event.args.command).toBe('gh label list')
+  })
+
+  test('GitHub-origin: an explicit -R wins over the origin fallback and sets no GH_REPO', async () => {
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(tokenResolver('ghs_minted'), true)
+    const event = githubOriginBashEvent('gh label list -R real/repo', 'acme/widgets')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
+  })
+
+  test('GitHub-origin: a COMPOUND repo-less gh still blocks even though a fallback exists', async () => {
+    delete process.env.GH_TOKEN
+    const hook = await hookFor(tokenResolver('ghs_minted'), true)
+    const event = githubOriginBashEvent('set -e; gh label list', 'acme/widgets')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+  })
+
+  test('non-GitHub origin with no resolvable repo: blocks with an actionable rewrite, never guesses', async () => {
+    delete process.env.GH_TOKEN
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    }, true)
+    const event = bashEvent('gh label list')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    if (result && 'reason' in result) expect(result.reason).toContain('-R')
+    expect(resolverCalled).toBe(false)
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
   test('App auth: blocks when the bridge is unavailable', async () => {

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -7,7 +7,7 @@ import { createApproveIdempotencyGuard } from './approve-idempotency'
 import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
 import { analyzeGhCommand, effectiveGhTokensForAuthenticatedUserEndpoint } from './gh-command'
 import { ensureGitAskPassHelper } from './git-askpass'
-import { analyzeGitCommand, defaultGitResolvers } from './git-command'
+import { analyzeGitCommand, defaultGitResolvers, resolveGhDefaultRepoFromCwd } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
 import { classifyGhToken, shouldMintAppToken } from './token-class'
@@ -72,6 +72,35 @@ export default definePlugin({
 
     type HookResult = void | { block: true; reason: string }
 
+    // A TRUSTED repo to fill in for a repo-less `gh` command, resolved from
+    // sources the command author cannot forge: (1) a GitHub channel session's
+    // own repo (origin.workspace comes from the signed webhook payload), then
+    // (2) the working tree's `origin` remote. NOT from any `-R`/path in the
+    // command (that is the attacker-controllable input the parser already
+    // handles). The slug is still gated by the repos[] allowlist at mint time.
+    const resolveTrustedFallbackRepo = async (origin: SessionOrigin | undefined): Promise<string | undefined> => {
+      if (origin?.kind === 'channel' && origin.adapter === 'github' && origin.workspace !== '') {
+        return origin.workspace
+      }
+      const fromCwd = await resolveGhDefaultRepoFromCwd(ctx.agentDir, defaultGitResolvers)
+      return fromCwd ?? undefined
+    }
+
+    // When a repo-less `gh` is blocked but a trusted repo IS available, show the
+    // exact single-bare rewrite so the agent recovers in one step instead of
+    // guessing. Composition blocks get a split-the-script instruction. The
+    // returned text is appended to the block reason (synchronous, always seen).
+    const buildGhBlockGuidance = (code: string, fallbackRepo: string | undefined): string => {
+      const slug = fallbackRepo ?? 'owner/repo'
+      if (code === 'composition') {
+        return (
+          ` Run each gh as its own single bare command, e.g. \`gh label edit <name> -R ${slug} --name ...\` —` +
+          ' not inside a function, `if`/`then`, `&&`, `;`, or `$(...)`.'
+        )
+      }
+      return ` For example: \`gh <cmd> -R ${slug}\` as a single bare command.`
+    }
+
     // 'fall-through' means "not a repo-targeting gh command" so the caller can
     // try the git path on the same command (e.g. `git ... # gh` substrings).
     const handleGhCommand = async (params: {
@@ -91,7 +120,26 @@ export default definePlugin({
       }
       if (review.dump !== null) return review.dump
 
-      const decision = analyzeGhCommand(command)
+      // Analyze first WITHOUT the fallback: an explicit `-R`/path repo must win,
+      // and we only pay for fallback resolution (a git subprocess) when the
+      // command is otherwise repo-less. A trusted fallback is then applied ONLY to
+      // a `missing-repo` block (never to composition/non-literal/multi-owner/api),
+      // and re-analysis re-runs the SAME composition gate, so a compound command
+      // still blocks. `fallbackRepoUsed` marks an inject that came from the
+      // fallback so we also set GH_REPO (gh needs the repo, not just the token).
+      let decision = analyzeGhCommand(command)
+      let fallbackRepo: string | undefined
+      let fallbackRepoUsed = false
+      if (decision.kind === 'block' && decision.code === 'missing-repo') {
+        fallbackRepo = await resolveTrustedFallbackRepo(event.origin)
+        if (fallbackRepo !== undefined) {
+          const withFallback = analyzeGhCommand(command, fallbackRepo)
+          if (withFallback.kind === 'inject') {
+            decision = withFallback
+            fallbackRepoUsed = true
+          }
+        }
+      }
 
       // `/user` classifies as pass-through (no repo to mint for), so this block
       // must run BEFORE the pass-through return. Resolve the EFFECTIVE token per
@@ -140,7 +188,10 @@ export default definePlugin({
         // NOT apply — a PAT needs no per-repo mint — so we never surface it here.
         if (runsUnsandboxed(event.origin)) {
           if (decision.kind === 'inject') {
-            event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: process.env.GH_TOKEN as string }
+            event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
+              GH_TOKEN: process.env.GH_TOKEN as string,
+              ...(fallbackRepoUsed && fallbackRepo !== undefined ? { GH_REPO: fallbackRepo } : {}),
+            }
           }
           return
         }
@@ -148,14 +199,18 @@ export default definePlugin({
         // available (a PAT must NOT suppress it, or the original silent-failure
         // bug returns); otherwise block with guidance rather than failing mute.
         if (!shouldMintAppToken(undefined, hasAppTokenResolver())) {
-          if (decision.kind === 'block') return { block: true, reason: decision.reason }
+          if (decision.kind === 'block') {
+            return { block: true, reason: decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo) }
+          }
           warnSandboxedPatWithheldOnce()
           return { block: true, reason: sandboxedPatWithheldReason }
         }
         mintForSandboxedPat = true
       }
 
-      if (decision.kind === 'block') return { block: true, reason: decision.reason }
+      if (decision.kind === 'block') {
+        return { block: true, reason: decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo) }
+      }
 
       // No App auth (no App-class GH_TOKEN and no live minter): leave whatever
       // is seeded so `gh` fails honestly rather than us guessing a token. The
@@ -166,8 +221,14 @@ export default definePlugin({
       if (result.kind === 'unavailable') return { block: true, reason: result.reason }
       // Inject via the internal env overlay (delivered to the spawn / bwrap
       // --setenv by the bash wrapper) so the token never enters the command
-      // string, where it could leak through logs or later hooks.
-      event.args[TYPECLAW_INTERNAL_BASH_ENV] = { GH_TOKEN: result.token }
+      // string, where it could leak through logs or later hooks. When the repo
+      // came from a trusted fallback (not an explicit -R), also set GH_REPO so
+      // `gh` actually targets it — a token alone leaves the repo unresolved.
+      // GH_REPO is non-secret; the token still scopes reach to that repo.
+      event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
+        GH_TOKEN: result.token,
+        ...(fallbackRepoUsed ? { GH_REPO: decision.repoSlug } : {}),
+      }
       return
     }
 


### PR DESCRIPTION
## What

Makes the agent's GitHub `gh` commands actually **mint a per-repo GitHub App token and succeed** when the target repo is resolvable from a trusted source, and gives the agent an **actionable rewrite** when it isn't — instead of the misleading block loop from the original incident. The anti-exfiltration boundary is preserved.

## The incident

A multi-owner GitHub App agent (no env PAT) was asked in Discord to organize `typeclaw/typeclaw` labels. Every attempt failed:

```bash
repo=typeclaw/typeclaw
gh label edit 'web dashboard' -R "$repo" --name 'area: web-dashboard'   # -> "spans multiple owners, re-run with -R" (but it DID use -R)
```

Two root causes: (1) the static guard can't read `$repo`; (2) the agent wrapped everything in compound `if/then` scripts, which are blocked because a minted `GH_TOKEN` would be exposed to sibling processes in the shared shell env. The agent never discovered that a **single bare** `gh ... -R typeclaw/typeclaw` mints and works, and the error never told it.

## Changes

### Layer A — mint via a trusted repo fallback (no security relaxation)
- `analyzeGhCommand(command, fallbackRepo?)`: an optional trusted repo fills in **only** for a `missing-repo` block on a non-`api` segment, and **flows through the same multi-owner + single-bare composition gates** — so a compound command still blocks.
- `handleGhCommand` resolves the fallback from sources the command author cannot forge:
  1. a GitHub channel session's `origin.workspace` (signed webhook provenance), then
  2. the cwd `origin` git remote (`resolveGhDefaultRepoFromCwd`).
  Never from an inline `-R`/path.
- On a fallback mint, also set non-secret **`GH_REPO`** so `gh` actually targets the repo (a token alone leaves the repo unresolved). Every mint is still gated by the `channels.github.repos[]` allowlist.

Result: a bare `gh label list` in a PR/issue session or inside a repo checkout now mints and succeeds.

### Layer B — actionable block guidance (synchronous, always seen)
- Block decisions now carry a structured `code` (`missing-repo` / `non-literal-repo` / `composition` / `multi-owner` / `api-repo-conflict`).
- The hook appends the exact rewrite to the block reason: `gh <cmd> -R owner/repo` as a single bare command (inlining the resolved literal slug when known); for composition, "split the if/then script into separate single gh calls".

### Carried from the first commit
- `isRepoSlug` rejects `$`/`{`/`}` (a `$owner/$repo` can never mint); non-literal `-R` blocks with an accurate reason.

## Security invariants (unchanged boundary)
- A repo mints **only** after the `repos[]` allowlist gate.
- No `$`-bearing, inline, or compound value can ever mint.
- Compound `gh` minting stays **blocked** — the token is delivered via the shell-wide `bwrap --setenv` env, so siblings could read it. Supporting compound commands safely needs a per-invocation credential-delivery redesign and is intentionally **out of scope** (documented as a follow-up).

## Behavior

| Command | Before | After |
|---|---|---|
| `gh label edit -R "$repo" …` | "spans multiple owners" (misleading) | block + "use `gh <cmd> -R owner/repo`" |
| `gh label list` (GitHub PR/issue session) | block missing-repo | **mints** for `origin.workspace`, sets `GH_REPO` |
| `gh label list` (inside repo checkout) | block missing-repo | **mints** for cwd `origin` remote |
| `gh label list` (Discord, no remote) | block | block + actionable `-R` rewrite (never guesses) |
| `set -e; gh label list` (+ fallback) | block | **still blocks** composition (token-leak safety) |
| `gh label edit -R typeclaw/typeclaw …` (single bare) | mints | mints (unchanged) |

## Tests
- `gh-command.test.ts`: structured `code`s; fallback injects for bare; **compound + fallback still blocks**; non-literal + fallback still blocks; explicit `-R` overrides fallback; api path unaffected; non-literal fallback never minted.
- `index.test.ts`: GitHub-origin bare command mints + sets `GH_REPO`; explicit `-R` wins (no `GH_REPO`); compound + origin still blocks; non-GitHub origin with no remote blocks with `-R` guidance and never calls the resolver.

All 345 `github-cli-auth` tests pass. typecheck / lint (0 errors) / format:check clean. (The full-suite's 7 schema/scaffold failures are pre-existing and reproduce on pristine `origin/main` from a worktree checkout — unrelated.)

## Design
Validated with the Oracle: trusted-signal repo resolution + `GH_REPO` (token alone is insufficient), composition re-gating to keep the exfiltration boundary, and Layer C (compound minting) deferred as needing a credential-delivery redesign.
