### PR TITLE
fix(cron): drain exec jobs before marking complete

### DIFF
--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -11,18 +11,23 @@ import { createCronConsumer, type CronConsumerLogger, type CronSession } from '.
 import type { CronJob, ExecJob, PromptJob } from './schema'
 
 async function waitForFile(path: string): Promise<string> {
-  for (let i = 0; i < 60; i++) {
+  for (let i = 0; i < 200; i++) {
     if (await Bun.file(path).exists()) return Bun.file(path).text()
     await Bun.sleep(50)
   }
-  return Bun.file(path).text()
+  throw new Error(`file was not created before timeout: ${path}`)
 }
 
 async function waitForCondition(predicate: () => boolean): Promise<void> {
-  for (let i = 0; i < 60; i++) {
+  for (let i = 0; i < 200; i++) {
     if (predicate()) return
     await Bun.sleep(50)
   }
+  throw new Error('condition was not met before timeout')
+}
+
+async function waitForConsumerIdle(consumer: ReturnType<typeof createCronConsumer>): Promise<void> {
+  await waitForCondition(() => consumer.inFlightCount() === 0)
 }
 
 // Minimal AgentSession stub satisfying the surface the model-fallback helper
@@ -145,6 +150,7 @@ describe('createCronConsumer', () => {
 
     publishCron(stream, execJob('touch', [process.execPath, '-e', 'await Bun.write("out.txt", "hello")']))
     const contents = await waitForFile(join(root, 'out.txt'))
+    await waitForConsumerIdle(consumer)
 
     expect(contents.trim()).toBe('hello')
 
@@ -176,6 +182,7 @@ describe('createCronConsumer', () => {
     }
     publishCron(stream, job)
     const captured = await waitForFile(join(root, 'origin.json'))
+    await waitForConsumerIdle(consumer)
 
     const parsed = JSON.parse(captured) as { kind?: string; jobId?: string; scheduledByRole?: string }
     expect(parsed.kind).toBe('cron')
@@ -204,6 +211,7 @@ describe('createCronConsumer', () => {
 
     publishCron(stream, execJob('after', [process.execPath, '-e', 'await Bun.write("after.txt", "ok")']))
     const contents = await waitForFile(join(root, 'after.txt'))
+    await waitForConsumerIdle(consumer)
 
     expect(contents.trim()).toBe('ok')
 

--- a/src/cron/consumer.ts
+++ b/src/cron/consumer.ts
@@ -338,16 +338,16 @@ async function runExec(job: ExecJob, cwd: string): Promise<void> {
   const proc = Bun.spawn({
     cmd: [cmd, ...args],
     cwd,
-    stdout: 'pipe',
+    stdout: 'ignore',
     stderr: 'pipe',
     env: {
       ...process.env,
       TYPECLAW_PARENT_ORIGIN_JSON: JSON.stringify(parentOrigin),
     },
   })
-  const code = await proc.exited
+  const stderrText = new Response(proc.stderr).text()
+  const [code, stderr] = await Promise.all([proc.exited, stderrText])
   if (code !== 0) {
-    const stderr = await new Response(proc.stderr).text()
     throw new Error(`exec job ${job.id} exited with code ${code}: ${stderr.trim() || 'no stderr'}`)
   }
 }


### PR DESCRIPTION
## Summary
- ignore unused stdout for cron exec jobs and drain stderr concurrently with process exit
- make cron exec tests wait for the consumer to become idle before temp-dir cleanup
- expand bounded polling under heavy parallel test load with explicit timeout errors

## CI failure addressed
Windows informational triage job failed in run 27630085189 / job 81702394774 because `src/cron/consumer.test.ts` removed the temp cron cwd while an exec child could still hold it open, producing `EBUSY` during `afterEach` cleanup.

## Verification
- `bun test --parallel src/cron/consumer.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint` (65 existing warnings, 0 errors)
- `bun run format`
- `bun run format:check`