### PR TITLE
feat(config): persist XDG config in workspace

### DIFF
--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -576,6 +576,8 @@ async function applyBashSandbox(
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
   if (dirs.length === 0 && files.length === 0) return
 
+  const sandboxEnvOverlay = buildRoleScopedConfigEnv(agentDir, dirs, envOverlay)
+
   await ensureBwrapAvailable()
   // Per-session /tmp: bind this session's scratch dir over the default
   // --tmpfs /tmp so writes survive across the role's sandboxed bash calls AND
@@ -671,9 +673,29 @@ async function applyBashSandbox(
     cwd: agentDir,
     proc,
     procSelfExe: resolveProcSelfExe(),
-    ...(envOverlay !== undefined ? { env: { set: envOverlay } } : {}),
+    ...(sandboxEnvOverlay !== undefined ? { env: { set: sandboxEnvOverlay } } : {}),
   })
   mutableArgs.command = commandString
+}
+
+function buildRoleScopedConfigEnv(
+  agentDir: string,
+  hiddenDirs: string[],
+  envOverlay: BashEnvOverlay | undefined,
+): BashEnvOverlay | undefined {
+  // Low-trust roles have workspace/ masked. Do not let container-global config
+  // env vars point CLIs back at that private surface: apps that honor XDG should
+  // still run, but their config must land in the sandbox's per-session /tmp.
+  // Trusted/owner never get here (no hidden dirs), so their Dockerfile-level
+  // persistent GWS_CONFIG_HOME remains /agent/workspace/.config/gws.
+  const workspaceHidden = hiddenDirs.includes(join(agentDir, 'workspace'))
+  if (!workspaceHidden) return envOverlay
+
+  return {
+    ...envOverlay,
+    XDG_CONFIG_HOME: '/tmp/.config',
+    GWS_CONFIG_HOME: '/tmp/.config/gws',
+  }
 }
 
 function subtractMaskedProtected(

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1761,13 +1761,13 @@ exit 1
 `,
     )
 
-    const shim = buildEntrypointShim()
+    const testSocketPath = join(workdir, 'x11-socket-X99')
+    const shim = buildEntrypointShim().replaceAll('/tmp/.X11-unix/X99', testSocketPath)
     const failShimPath = join(workdir, 'shim-fail.sh')
     await writeShellScript(failShimPath, shim)
 
     const fakeHome = join(workdir, 'home-xvfb-fail')
     await mkdir(fakeHome, { recursive: true })
-    rmSync('/tmp/.X11-unix/X99', { force: true })
     const proc = Bun.spawn(['/bin/sh', failShimPath, 'run'], {
       env: {
         PATH: `${bindir}:${process.env['PATH'] ?? ''}`,

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1611,6 +1611,12 @@ describe('network egress entrypoint shim', () => {
     expect(shim.match(/^[ \t]*link_configured_symlinks$/gm)?.length).toBe(2)
   })
 
+  test('sets GWS_CONFIG_HOME without changing global XDG_CONFIG_HOME so git config lookup is untouched', () => {
+    const dockerfile = buildDockerfile(dockerfileSchema.parse({}))
+    expect(dockerfile).not.toContain('ENV XDG_CONFIG_HOME=')
+    expect(dockerfile).toContain('ENV GWS_CONFIG_HOME=/agent/workspace/.config/gws')
+  })
+
   test('also symlinks Claude Code .credentials.json into /agent/.typeclaw/home/ so OAuth credentials survive container restarts', () => {
     const shim = buildEntrypointShim()
     // Claude Code rotates tokens in-place by rewriting .credentials.json on
@@ -1747,6 +1753,7 @@ exit 0
     // Fake Xvfb that exits 1 the instant it starts. The shim's
     // `kill -0 $xvfb_pid` check should detect this on the next poll
     // iteration and `exit 1` with a clear stderr line.
+    await symlinkHostBinaries(bindir, ['mkdir', 'ln', 'readlink'])
     await writeShellScript(
       join(bindir, 'Xvfb'),
       `#!/bin/sh
@@ -1760,6 +1767,7 @@ exit 1
 
     const fakeHome = join(workdir, 'home-xvfb-fail')
     await mkdir(fakeHome, { recursive: true })
+    rmSync('/tmp/.X11-unix/X99', { force: true })
     const proc = Bun.spawn(['/bin/sh', failShimPath, 'run'], {
       env: {
         PATH: `${bindir}:${process.env['PATH'] ?? ''}`,
@@ -1783,7 +1791,7 @@ exit 1
 
     const noXvfbBin = join(workdir, 'bin-link-test')
     await mkdir(noXvfbBin, { recursive: true })
-    await symlinkHostBinaries(noXvfbBin, ['mkdir', 'ln'])
+    await symlinkHostBinaries(noXvfbBin, ['mkdir', 'ln', 'readlink'])
     await writeShellScript(join(noXvfbBin, 'bun'), `#!/bin/sh\nexit 0\n`)
     await writeShellScript(
       join(noXvfbBin, 'setpriv'),
@@ -1829,7 +1837,7 @@ exec "$@"
 
     const noXvfbBin = join(workdir, 'bin-idem-test')
     await mkdir(noXvfbBin, { recursive: true })
-    await symlinkHostBinaries(noXvfbBin, ['mkdir', 'ln'])
+    await symlinkHostBinaries(noXvfbBin, ['mkdir', 'ln', 'readlink'])
     await writeShellScript(join(noXvfbBin, 'bun'), `#!/bin/sh\nexit 0\n`)
     await writeShellScript(
       join(noXvfbBin, 'setpriv'),
@@ -1874,7 +1882,7 @@ exec "$@"
 
     const bin = join(workdir, 'bin-sym')
     await mkdir(bin, { recursive: true })
-    await symlinkHostBinaries(bin, ['mkdir', 'ln'])
+    await symlinkHostBinaries(bin, ['mkdir', 'ln', 'readlink'])
     // Fake `bun`: pass `-e <script>` through to the real bun (link_configured_symlinks
     // needs a real JSON parser + fs), but turn the final `bun run typeclaw` exec
     // into a no-op so the shim ends cleanly without launching the agent.
@@ -1922,7 +1930,7 @@ exec "$@"
 
     const bin = join(workdir, 'bin-noclobber')
     await mkdir(bin, { recursive: true })
-    await symlinkHostBinaries(bin, ['mkdir', 'ln'])
+    await symlinkHostBinaries(bin, ['mkdir', 'ln', 'readlink'])
     await writeShellScript(join(bin, 'bun'), `#!/bin/sh\nif [ "$1" = "-e" ]; then exec ${realBun} "$@"; fi\nexit 0\n`)
     await writeShellScript(
       join(bin, 'setpriv'),
@@ -1965,7 +1973,7 @@ exec "$@"
     // image so the helper's mkdir+ln calls work for the same reason.
     const isolatedBin = join(workdir, 'bin-no-xvfb')
     await mkdir(isolatedBin, { recursive: true })
-    await symlinkHostBinaries(isolatedBin, ['mkdir', 'ln'])
+    await symlinkHostBinaries(isolatedBin, ['mkdir', 'ln', 'readlink'])
     await writeShellScript(
       join(isolatedBin, 'bun'),
       `#!/bin/sh\necho "DISPLAY: \${DISPLAY:-<unset>}" > "${logfile}"\nexit 0\n`,

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -358,9 +358,9 @@ set -eu
 # The persist root lives under /agent/.typeclaw/home/ (bind-mounted
 # from the agent folder via the -v <cwd>:/agent flag in start.ts).
 # Namespacing under .typeclaw/ keeps the agent's top-level layout clean and reserves
-# a system-owned subtree we can extend later (e.g. ~/.gemini/,
-# ~/.config/<tool>/) without colliding with user files. The directory
-# is gitignored by buildGitignore() so credentials never enter history.
+# a system-owned subtree we can extend later (e.g. ~/.gemini/) without
+# colliding with user files. The directory is gitignored by buildGitignore()
+# so credentials never enter history.
 #
 # Three invariants this function enforces:
 #
@@ -372,11 +372,11 @@ set -eu
 #    if a previous container life happened to write a real ~/.codex/
 #    dir before this code shipped.
 #
-# 2. We symlink the FILE, not the directory. Codex writes other state
-#    to ~/.codex/ over time (history.jsonl, log/, config.toml). Linking
-#    only auth.json keeps the persistence scope tight to credentials;
-#    history/logs stay ephemeral by design. Future credentials get
-#    added file-by-file here, not by widening to a directory link.
+# 2. We symlink credential FILES for tools whose config dirs are mostly
+#    scratch/history (Codex, Claude). We do not redirect global config
+#    locations such as XDG_CONFIG_HOME or ~/.config here because tools like
+#    git also read config from those paths; first-party bundles that need
+#    persistence should set their own app-specific env vars instead.
 #
 # 3. We mkdir -p the target's parent on every boot. /agent is bind-
 #    mounted, so the host-side path may exist or not depending on
@@ -1263,6 +1263,9 @@ ${fromAndHeavyLayers}
 # tiny and lets edits on the host take effect without rebuilds.
 
 ENV NODE_ENV=production
+
+# Persist first-party GWS config without changing global XDG/git config lookup.
+ENV GWS_CONFIG_HOME=/agent/workspace/.config/gws
 
 # Keep agent-messenger's fallback config dir inside workspace/ for any future
 # SDK fallback paths. TypeClaw's KakaoTalk adapter does not write there:


### PR DESCRIPTION
## Background

The GWS bundle is the first first-party consumer that needs durable CLI config across container restarts, and many other CLIs already expect XDG-style config under `~/.config/<tool>`. The prior persistent-home helper only linked narrow credential files for Codex and Claude, so arbitrary app config could still fall back to the container overlay and disappear after `typeclaw stop` + `start`.

## Summary

This makes `workspace/.config` the default persistent XDG config root:

- exports `XDG_CONFIG_HOME=/agent/workspace/.config`
- exports `GWS_CONFIG_HOME=/agent/workspace/.config/gws` so the bundled GWS CLI is forced into the persistent tree
- links container `~/.config` to the same root for apps that ignore XDG env vars
- migrates an existing real `~/.config` directory into the persistent root before replacing it with the symlink
- refuses to clobber conflicting symlinks or non-directory paths

Workspace is intentional here: it is already permission-gated and keeps the persistence surface visible to the agent operator, while avoiding a separate hidden per-app persistence rule.

## What this does NOT do

- Does not dynamically switch `~/.config` between workspace and public per caller. The symlink is global container state, so per-turn switching would be racy.
- Does not move Codex/Claude credential-file persistence out of `.typeclaw/home`; those remain file-scoped by design.
- Does not make `public/.config` the default for OAuth/session material.

## Review notes

The load-bearing path is `link_persistent_home_files()` in `src/init/dockerfile.ts`: it should create or migrate `~/.config` before the agent starts, but should not overwrite an existing conflicting symlink. Tests cover the rendered env vars, fresh symlink creation, migration from a real directory, and the existing idempotent entrypoint behavior.
