### PR TITLE
fix(channels): recover stuck channel adapters

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -195,6 +195,67 @@ describe('channel manager — connection recovery', () => {
 
     await mgr.stop()
   })
+  test('does not queue duplicate recovery restarts while the first restart is pending', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    let now = 1_000
+    let tick: (() => void) | null = null
+    const stopGate = deferred()
+    const firstAdapter = makeFakeAdapter()
+    firstAdapter.stop = async () => {
+      firstAdapter.stopCalls++
+      await stopGate.promise
+    }
+    const secondAdapter = makeFakeAdapter()
+    const thirdAdapter = makeFakeAdapter()
+    const adapters = [firstAdapter, secondAdapter, thirdAdapter]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => adapters.shift()!,
+      connectionRecovery: {
+        checkIntervalMs: 10,
+        disconnectedGraceMs: 100,
+        now: () => now,
+        setInterval: (fn) => {
+          tick = fn
+          return 'timer'
+        },
+        clearInterval: () => {},
+      },
+    })
+
+    await mgr.start()
+    const runTick = () => {
+      if (tick === null) throw new Error('recovery timer was not registered')
+      tick()
+    }
+
+    firstAdapter.connected = false
+    runTick()
+    now += 101
+    runTick()
+    await Promise.resolve()
+
+    expect(firstAdapter.stopCalls).toBe(1)
+    expect(secondAdapter.startCalls).toBe(0)
+
+    now += 101
+    runTick()
+    await Promise.resolve()
+
+    expect(firstAdapter.stopCalls).toBe(1)
+    expect(secondAdapter.startCalls).toBe(0)
+    expect(thirdAdapter.startCalls).toBe(0)
+
+    stopGate.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(secondAdapter.startCalls).toBe(1)
+    expect(thirdAdapter.startCalls).toBe(0)
+
+    await mgr.stop()
+  })
 })
 
 describe('channel manager — restartAdapter serialization', () => {

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -34,18 +34,20 @@ function deferred<T = void>(): Deferred<T> {
   return { promise, resolve, reject }
 }
 
-function makeFakeAdapter(): FakeAdapter {
+function makeFakeAdapter(): FakeAdapter & { connected: boolean } {
   const adapter = {
+    connected: true,
     startCalls: 0,
     stopCalls: 0,
     async start() {
       adapter.startCalls++
+      adapter.connected = true
     },
     async stop() {
       adapter.stopCalls++
     },
     isConnected() {
-      return true
+      return adapter.connected
     },
   }
   return adapter
@@ -137,6 +139,63 @@ function recordingLogger(): {
     messages,
   }
 }
+
+describe('channel manager — connection recovery', () => {
+  test('restarts a live adapter that remains disconnected past the grace period', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    let now = 1_000
+    let tick: (() => void) | null = null
+    const logger = recordingLogger()
+    const firstAdapter = makeFakeAdapter()
+    const secondAdapter = makeFakeAdapter()
+    const adapters = [firstAdapter, secondAdapter]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      logger,
+      createDiscordAdapter: () => adapters.shift()!,
+      connectionRecovery: {
+        checkIntervalMs: 10,
+        disconnectedGraceMs: 100,
+        now: () => now,
+        setInterval: (fn) => {
+          tick = fn
+          return 'timer'
+        },
+        clearInterval: () => {},
+      },
+    })
+
+    await mgr.start()
+    expect(firstAdapter.startCalls).toBe(1)
+    expect(secondAdapter.startCalls).toBe(0)
+    expect(tick).not.toBeNull()
+    const runTick = () => {
+      if (tick === null) throw new Error('recovery timer was not registered')
+      tick()
+    }
+
+    firstAdapter.connected = false
+    runTick()
+    await Promise.resolve()
+    expect(firstAdapter.stopCalls).toBe(0)
+    expect(secondAdapter.startCalls).toBe(0)
+    expect(logger.messages).toContain('warn:[channels] adapter "discord-bot" is disconnected; waiting for SDK recovery')
+
+    now += 101
+    runTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(firstAdapter.stopCalls).toBe(1)
+    expect(secondAdapter.startCalls).toBe(1)
+    expect(logger.messages).toContain(
+      'warn:[channels] adapter "discord-bot" disconnected for 101ms; restarting adapter',
+    )
+
+    await mgr.stop()
+  })
+})
 
 describe('channel manager — restartAdapter serialization', () => {
   test('restartAdapter stops a live github adapter before starting it again', async () => {

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -144,6 +144,7 @@ type AdapterEntry = {
   adapter: AnyAdapter
   credentialSignature: string
   disconnectedSinceMs: number | null
+  recoveryRestartQueued: boolean
 }
 
 export function createChannelManager(options: ChannelManagerOptions): ChannelManager {
@@ -295,6 +296,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         adapter,
         credentialSignature: signature,
         disconnectedSinceMs: adapter.isConnected() ? null : recoveryNow(),
+        recoveryRestartQueued: false,
       })
       logger.info(`[channels] adapter "${name}" started`)
       return true
@@ -321,6 +323,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     for (const [name, entry] of live) {
       if (entry.adapter.isConnected()) {
         entry.disconnectedSinceMs = null
+        entry.recoveryRestartQueued = false
         continue
       }
       if (entry.disconnectedSinceMs === null) {
@@ -329,23 +332,25 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         continue
       }
       const disconnectedForMs = now - entry.disconnectedSinceMs
-      if (disconnectedForMs < recoveryDisconnectedGraceMs) continue
-      // Mark the episode as handled before queueing the async restart so repeated
-      // timer ticks do not enqueue duplicate restarts while stop/start is pending.
-      entry.disconnectedSinceMs = now
+      if (disconnectedForMs < recoveryDisconnectedGraceMs || entry.recoveryRestartQueued) continue
+      entry.recoveryRestartQueued = true
       logger.warn(
         `[channels] adapter "${name}" disconnected for ${Math.round(disconnectedForMs)}ms; restarting adapter`,
       )
       void runSerially(name, async () => {
-        const current = live.get(name)
-        if (current !== entry) return
-        const currentCfg = options.channelsConfigRef()[name]
-        if (currentCfg === undefined || currentCfg.enabled === false) {
-          logger.info(`[channels] recovery restart for "${name}" skipped; adapter no longer enabled`)
-          return
+        try {
+          const current = live.get(name)
+          if (current !== entry) return
+          const currentCfg = options.channelsConfigRef()[name]
+          if (currentCfg === undefined || currentCfg.enabled === false) {
+            logger.info(`[channels] recovery restart for "${name}" skipped; adapter no longer enabled`)
+            return
+          }
+          await stopAdapter(name)
+          await startAdapter(name, currentCfg)
+        } finally {
+          if (live.get(name) === entry) entry.recoveryRestartQueued = false
         }
-        await stopAdapter(name)
-        await startAdapter(name, currentCfg)
       })
     }
   }

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -104,6 +104,17 @@ export type ChannelManagerOptions = {
   // unregistered. See CreateChannelRouterOptions.onReload/onRestart.
   onReload?: () => Promise<string>
   onRestart?: (ctx?: RestartCommandContext) => Promise<string>
+  // Persistent messenger SDKs usually reconnect themselves, but a host sleep/offline
+  // cycle can leave a socket half-dead forever. The manager watches live adapters
+  // and restarts one that stays disconnected past this grace period. Test seams are
+  // optional so production uses normal timers/time.
+  connectionRecovery?: {
+    checkIntervalMs?: number
+    disconnectedGraceMs?: number
+    now?: () => number
+    setInterval?: (fn: () => void, ms: number) => unknown
+    clearInterval?: (handle: unknown) => void
+  }
 }
 
 export type ChannelManager = {
@@ -132,6 +143,7 @@ type AnyAdapter =
 type AdapterEntry = {
   adapter: AnyAdapter
   credentialSignature: string
+  disconnectedSinceMs: number | null
 }
 
 export function createChannelManager(options: ChannelManagerOptions): ChannelManager {
@@ -158,6 +170,14 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 
   const live = new Map<AdapterId, AdapterEntry>()
   const perAdapterSerial = new Map<AdapterId, Promise<unknown>>()
+  const recovery = options.connectionRecovery ?? {}
+  const recoveryCheckIntervalMs = recovery.checkIntervalMs ?? 30_000
+  const recoveryDisconnectedGraceMs = recovery.disconnectedGraceMs ?? 90_000
+  const recoveryNow = recovery.now ?? (() => Date.now())
+  const recoverySetInterval = recovery.setInterval ?? ((fn: () => void, ms: number) => setInterval(fn, ms))
+  const recoveryClearInterval =
+    recovery.clearInterval ?? ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>))
+  let recoveryTimer: unknown = null
 
   const runSerially = <T>(name: AdapterId, op: () => Promise<T>): Promise<T> => {
     const prev = perAdapterSerial.get(name) ?? Promise.resolve()
@@ -271,7 +291,11 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     }
     try {
       await adapter.start()
-      live.set(name, { adapter, credentialSignature: signature })
+      live.set(name, {
+        adapter,
+        credentialSignature: signature,
+        disconnectedSinceMs: adapter.isConnected() ? null : recoveryNow(),
+      })
       logger.info(`[channels] adapter "${name}" started`)
       return true
     } catch (err) {
@@ -290,6 +314,51 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     } catch (err) {
       logger.error(`[channels] adapter "${name}" failed to stop: ${describe(err)}`)
     }
+  }
+
+  const checkConnectionRecovery = (): void => {
+    const now = recoveryNow()
+    for (const [name, entry] of live) {
+      if (entry.adapter.isConnected()) {
+        entry.disconnectedSinceMs = null
+        continue
+      }
+      if (entry.disconnectedSinceMs === null) {
+        entry.disconnectedSinceMs = now
+        logger.warn(`[channels] adapter "${name}" is disconnected; waiting for SDK recovery`)
+        continue
+      }
+      const disconnectedForMs = now - entry.disconnectedSinceMs
+      if (disconnectedForMs < recoveryDisconnectedGraceMs) continue
+      // Mark the episode as handled before queueing the async restart so repeated
+      // timer ticks do not enqueue duplicate restarts while stop/start is pending.
+      entry.disconnectedSinceMs = now
+      logger.warn(
+        `[channels] adapter "${name}" disconnected for ${Math.round(disconnectedForMs)}ms; restarting adapter`,
+      )
+      void runSerially(name, async () => {
+        const current = live.get(name)
+        if (current !== entry) return
+        const currentCfg = options.channelsConfigRef()[name]
+        if (currentCfg === undefined || currentCfg.enabled === false) {
+          logger.info(`[channels] recovery restart for "${name}" skipped; adapter no longer enabled`)
+          return
+        }
+        await stopAdapter(name)
+        await startAdapter(name, currentCfg)
+      })
+    }
+  }
+
+  const startRecoveryTimer = (): void => {
+    if (recoveryTimer !== null) return
+    recoveryTimer = recoverySetInterval(checkConnectionRecovery, recoveryCheckIntervalMs)
+  }
+
+  const stopRecoveryTimer = (): void => {
+    if (recoveryTimer === null) return
+    recoveryClearInterval(recoveryTimer)
+    recoveryTimer = null
   }
 
   return {
@@ -313,9 +382,11 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       const results = await Promise.allSettled(starts)
       const failure = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
       if (failure !== undefined) throw failure.reason
+      startRecoveryTimer()
     },
 
     async stop(): Promise<void> {
+      stopRecoveryTimer()
       for (const name of Array.from(live.keys())) await runSerially(name, () => stopAdapter(name))
       await router.stop()
     },


### PR DESCRIPTION
## Background

Channel adapters rely on their messenger SDKs to reconnect after disconnects, but host sleep/offline cycles can leave a socket in a half-dead state where the adapter remains started while `isConnected()` stays false. In that state TypeClaw does not rebuild the adapter, so Discord/Slack/Telegram/KakaoTalk channel delivery can remain lost until a manual restart.

## Summary

Add a channel-manager recovery watchdog for live adapters. It gives the SDK a grace window to recover by itself, then serializes a stop/start of the still-disconnected adapter using the existing per-adapter restart path. The watchdog is manager-level rather than adapter-specific so every persistent channel gets the same offline/sleep recovery behavior without duplicating timers in each adapter.

The recovery path rechecks the current live entry and config before restarting, so reload/disable races do not resurrect an adapter that was stopped or reconfigured while the timer was waiting.

## What this does NOT do

- It does not replace each SDK's built-in reconnect/backoff behavior; it only kicks in after the adapter remains disconnected past the grace period.
- It does not buffer or replay messages missed while the host was offline.
- It does not restart disabled or removed channel configs.

## Review notes

The load-bearing invariant is that repeated timer ticks must not queue duplicate restarts for the same disconnected episode. The implementation marks the episode handled before queueing the serialized restart, and the test covers the grace-period transition from observe-only to restart.

Validation run locally:

- `bun run typecheck`
- `bun run lint` (existing warnings only, zero errors)
- `bun run format:check`
- `bun test --parallel ./src/channels/manager.test.ts`
