### PR TITLE
feat(config): guard dangerous docker.file.append entries before build

### DIFF
--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -325,7 +325,8 @@ function makeBoard(header: string): Board {
 function formatStartDone<T extends { alreadyRunning?: boolean; hostPort: number }>(result: AgentResult<T>): string {
   if (!result.ok) return `${c.red('✖')} ${c.red('failed:')} ${result.reason}`
   const verb = result.data.alreadyRunning ? 'already running' : 'started'
-  return `${c.green('✔')} ${verb} on host port ${c.cyan(String(result.data.hostPort))}`
+  const head = `${c.green('✔')} ${verb} on host port ${c.cyan(String(result.data.hostPort))}`
+  return appendWarnings(head, result.warnings)
 }
 
 function formatStopDone<T extends { running: boolean }>(result: AgentResult<T>): string {
@@ -336,7 +337,15 @@ function formatStopDone<T extends { running: boolean }>(result: AgentResult<T>):
 
 function formatRestartDone<T extends { start: { hostPort: number } }>(result: AgentResult<T>): string {
   if (!result.ok) return `${c.red('✖')} ${c.red('failed:')} ${result.reason}`
-  return `${c.green('✔')} restarted on host port ${c.cyan(String(result.data.start.hostPort))}`
+  const head = `${c.green('✔')} restarted on host port ${c.cyan(String(result.data.start.hostPort))}`
+  return appendWarnings(head, result.warnings)
+}
+
+// Surface non-fatal validateConfig warnings under the per-agent compose status
+// line so compose start/restart don't silently drop what `typeclaw start` prints.
+function appendWarnings(head: string, warnings: string[] | undefined): string {
+  if (warnings === undefined || warnings.length === 0) return head
+  return [head, ...warnings.map((w) => `  ${c.yellow('⚠')} ${w}`)].join('\n')
 }
 
 function emitComposeDoctor(report: ComposeDoctorReport, opts: { verbose: boolean; json: boolean }): void {

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -6,7 +6,7 @@ import { start, stop } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
 import { guardIncompleteInit } from './incomplete-init'
-import { c, errorLine, renderStartSuccess, spinner } from './ui'
+import { c, errorLine, renderStartSuccess, reportConfigWarnings, spinner } from './ui'
 
 export const restartCommand = defineCommand({
   meta: {
@@ -61,6 +61,7 @@ export const restartCommand = defineCommand({
       console.error(errorLine(validated.reason))
       process.exit(1)
     }
+    reportConfigWarnings(validated.warnings)
 
     const stopSpin = spinner()
     stopSpin.start('Stopping container...')

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -6,7 +6,7 @@ import { start } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
 import { guardIncompleteInit } from './incomplete-init'
-import { errorLine, renderStartSuccess, spinner, warnLine } from './ui'
+import { errorLine, renderStartSuccess, reportConfigWarnings, spinner } from './ui'
 
 export const startCommand = defineCommand({
   meta: {
@@ -61,9 +61,7 @@ export const startCommand = defineCommand({
       console.error(errorLine(validated.reason))
       process.exit(1)
     }
-    for (const warning of validated.warnings ?? []) {
-      console.warn(warnLine(warning))
-    }
+    reportConfigWarnings(validated.warnings)
 
     const s = spinner()
     s.start('Starting container...')

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -6,7 +6,7 @@ import { start } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
 import { guardIncompleteInit } from './incomplete-init'
-import { errorLine, renderStartSuccess, spinner } from './ui'
+import { errorLine, renderStartSuccess, spinner, warnLine } from './ui'
 
 export const startCommand = defineCommand({
   meta: {
@@ -60,6 +60,9 @@ export const startCommand = defineCommand({
     if (!validated.ok) {
       console.error(errorLine(validated.reason))
       process.exit(1)
+    }
+    for (const warning of validated.warnings ?? []) {
+      console.warn(warnLine(warning))
     }
 
     const s = spinner()

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -222,6 +222,10 @@ export function successLine(message: string): string {
   return `${c.green('●')} ${message}`
 }
 
+export function warnLine(message: string): string {
+  return `${c.yellow('⚠')} ${message}`
+}
+
 // The exact JSON manifest a user pastes into
 // https://api.slack.com/apps → From a manifest. Kept as a typed object so
 // the file stays a single source of truth and `JSON.stringify` guarantees

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -226,6 +226,15 @@ export function warnLine(message: string): string {
   return `${c.yellow('⚠')} ${message}`
 }
 
+// Single host-side sink for non-fatal validateConfig warnings (e.g. a
+// curl|bash docker.file.append line). Every CLI gate that calls validateConfig
+// before a start/rebuild routes through this so no path silently drops them.
+export function reportConfigWarnings(warnings: string[] | undefined): void {
+  for (const warning of warnings ?? []) {
+    console.warn(warnLine(warning))
+  }
+}
+
 // The exact JSON manifest a user pastes into
 // https://api.slack.com/apps → From a manifest. Kept as a typed object so
 // the file stays a single source of truth and `JSON.stringify` guarantees

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -62,7 +62,7 @@ async function runOne(
     onStopped()
     const started = await start({ cwd, preferredHostPort, forceBuild, cliEntry })
     if (!started.ok) return { name, ok: false, reason: started.reason }
-    return { name, ok: true, data: { stop: stopped, start: started } }
+    return { name, ok: true, data: { stop: stopped, start: started }, warnings: validated.warnings }
   } catch (error) {
     return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
   }

--- a/src/compose/start.ts
+++ b/src/compose/start.ts
@@ -3,7 +3,9 @@ import { start, type StartResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 
-export type AgentResult<T> = { name: string; ok: true; data: T } | { name: string; ok: false; reason: string }
+export type AgentResult<T> =
+  | { name: string; ok: true; data: T; warnings?: string[] }
+  | { name: string; ok: false; reason: string }
 
 export type StartSuccess = Extract<StartResult, { ok: true }>
 
@@ -55,7 +57,7 @@ async function runOne(
   try {
     const data = await start({ cwd, preferredHostPort, forceBuild, cliEntry })
     if (!data.ok) return { name, ok: false, reason: data.reason }
-    return { name, ok: true, data }
+    return { name, ok: true, data, warnings: validated.warnings }
   } catch (error) {
     return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
   }

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -25,6 +25,7 @@ import {
   resolveModel,
   resolveProfile,
   validateConfig,
+  validateDockerfileAppendLine,
   validateMount,
   withDefaultPlugins,
   type Models,
@@ -1442,15 +1443,92 @@ describe('mountSchema path validation', () => {
   })
 })
 
+describe('validateDockerfileAppendLine', () => {
+  test('allows a recognized instruction (case-insensitive)', () => {
+    expect(validateDockerfileAppendLine('RUN apt-get update').ok).toBe(true)
+    expect(validateDockerfileAppendLine('env FOO=bar').ok).toBe(true)
+    expect(validateDockerfileAppendLine('# a plain comment').ok).toBe(true)
+  })
+
+  test('allows a benign python3 -c without execution of decoded content', () => {
+    expect(validateDockerfileAppendLine('RUN python3 -c "print(1)"').ok).toBe(true)
+    expect(validateDockerfileAppendLine('RUN python3 -c "import base64; print(base64.b64encode(b\'x\'))"').ok).toBe(
+      true,
+    )
+  })
+
+  test('blocks the decode-and-execute anti-pattern as semantic', () => {
+    const result = validateDockerfileAppendLine(
+      'RUN python3 -c "import base64; exec(base64.b64decode(\'AA==\').decode())"',
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.kind).toBe('semantic')
+      expect(result.reason).toContain('decodes an opaque payload')
+    }
+  })
+
+  test('blocks node -e eval of a base64 Buffer as semantic', () => {
+    const result = validateDockerfileAppendLine('RUN node -e "eval(Buffer.from(x,\'base64\').toString())"')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.kind).toBe('semantic')
+  })
+
+  test('blocks references to the TypeClaw-owned entrypoint as semantic', () => {
+    const result = validateDockerfileAppendLine('RUN sed -i s/a/b/ /usr/local/bin/typeclaw-entrypoint')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.kind).toBe('semantic')
+      expect(result.reason).toContain('typeclaw-entrypoint')
+    }
+  })
+
+  test('blocks FROM, ENTRYPOINT, and CMD as structural', () => {
+    for (const line of ['FROM alpine', 'ENTRYPOINT ["/bin/sh"]', 'CMD ["run"]']) {
+      const result = validateDockerfileAppendLine(line)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.kind).toBe('structural')
+    }
+  })
+
+  test('blocks unknown instructions, trailing backslash, heredoc, parser directives, and empty lines as structural', () => {
+    for (const line of [
+      'NOTANINSTRUCTION foo',
+      'RUN echo hi \\',
+      'RUN cat <<EOF',
+      '# syntax=docker/dockerfile:1',
+      '   ',
+    ]) {
+      const result = validateDockerfileAppendLine(line)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.kind).toBe('structural')
+    }
+  })
+
+  test('warns (but allows) curl piped to a shell and remote ADD', () => {
+    const curl = validateDockerfileAppendLine('RUN curl -fsSL https://example.com/i.sh | bash')
+    expect(curl.ok).toBe(true)
+    if (curl.ok) expect(curl.warning).toContain('remote script')
+
+    const add = validateDockerfileAppendLine('ADD https://example.com/x.tar.gz /tmp/x.tar.gz')
+    expect(add.ok).toBe(true)
+    if (add.ok) expect(add.warning).toContain('remote')
+  })
+})
+
 describe('validateConfig', () => {
   let cwd: string
+  const ORIGINAL_ALLOW_UNSAFE = process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND
 
   beforeEach(async () => {
     cwd = await mkdtemp(join(tmpdir(), 'typeclaw-validate-'))
+    delete process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND
   })
 
   afterEach(async () => {
     await rm(cwd, { recursive: true, force: true })
+    if (ORIGINAL_ALLOW_UNSAFE === undefined) delete process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND
+    else process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND = ORIGINAL_ALLOW_UNSAFE
   })
 
   test('returns ok when typeclaw.json is missing', () => {
@@ -1542,6 +1620,64 @@ describe('validateConfig', () => {
     )
     const result = validateConfig(cwd)
     expect(result.ok).toBe(false)
+  })
+
+  test('blocks a dangerous docker.file.append entry with an indexed reason', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: VALID_MODEL },
+        docker: {
+          file: {
+            append: ['RUN echo ok', 'RUN python3 -c "import base64; exec(base64.b64decode(\'AA==\').decode())"'],
+          },
+        },
+      }),
+    )
+    const result = validateConfig(cwd)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toContain('docker.file.append[1]')
+      expect(result.reason).toContain('decodes an opaque payload')
+    }
+  })
+
+  test('surfaces a warning (but stays ok) for a curl|bash docker.file.append entry', async () => {
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: VALID_MODEL },
+        docker: { file: { append: ['RUN curl -fsSL https://example.com/i.sh | sh'] } },
+      }),
+    )
+    const result = validateConfig(cwd)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings?.[0]).toContain('docker.file.append[0]')
+    }
+  })
+
+  test('TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND=1 waives semantic blocks but not structural ones', async () => {
+    process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND = '1'
+
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: VALID_MODEL },
+        docker: { file: { append: ['RUN sed -i s/a/b/ /usr/local/bin/typeclaw-entrypoint'] } },
+      }),
+    )
+    expect(validateConfig(cwd).ok).toBe(true)
+
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: VALID_MODEL },
+        docker: { file: { append: ['FROM alpine'] } },
+      }),
+    )
+    expect(validateConfig(cwd).ok).toBe(false)
   })
 })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1168,7 +1168,7 @@ function persistMigratedConfig(cwd: string, json: unknown, applied: readonly Mig
   }
 }
 
-export type ValidateConfigResult = { ok: true } | { ok: false; reason: string }
+export type ValidateConfigResult = { ok: true; warnings?: string[] } | { ok: false; reason: string }
 
 // Missing file → ok (matches `loadMounts` in src/container/up.ts; `isInitialized`
 // is the dedicated check for "not initialized"). Present but invalid → fail, so
@@ -1200,6 +1200,18 @@ export function validateConfig(cwd: string, options: ValidateConfigOptions = {})
   const parsed = parseConfigJson(raw, { migrate: true, persistTarget: cwd })
   if (!parsed.ok) return parsed
 
+  const allowUnsafeAppend = process.env[ALLOW_UNSAFE_DOCKER_APPEND_ENV] === '1'
+  const warnings: string[] = []
+  const appendLines = parsed.config.docker.file.append
+  for (let i = 0; i < appendLines.length; i++) {
+    const check = validateDockerfileAppendLine(appendLines[i]!)
+    if (!check.ok) {
+      if (check.kind === 'semantic' && allowUnsafeAppend) continue
+      return { ok: false, reason: `docker.file.append[${i}] ${check.reason}` }
+    }
+    if (check.warning) warnings.push(`docker.file.append[${i}] ${check.warning}`)
+  }
+
   if (!options.skipMounts) {
     for (const mount of parsed.config.mounts) {
       const check = validateMount(mount, cwd)
@@ -1207,7 +1219,7 @@ export function validateConfig(cwd: string, options: ValidateConfigOptions = {})
     }
   }
 
-  return { ok: true }
+  return warnings.length > 0 ? { ok: true, warnings } : { ok: true }
 }
 
 export type ParseConfigJsonResult = { ok: true; config: Config } | { ok: false; reason: string }
@@ -1300,6 +1312,181 @@ export function validateMount(mount: Mount, cwd: string): ValidateConfigResult {
         reason: `${label}: path ${resolved} is not writable (declare readOnly: true if read-only access is intended)`,
       }
     }
+  }
+
+  return { ok: true }
+}
+
+// Host env (not config) on purpose: an in-container agent can edit its own
+// typeclaw.json but cannot set the env of the host `typeclaw start` that runs
+// this gate, so it can never waive its own footgun. Only relaxes SEMANTIC
+// blocks; structural blocks always fire (they break Dockerfile generation).
+const ALLOW_UNSAFE_DOCKER_APPEND_ENV = 'TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND'
+
+// FROM/ENTRYPOINT/CMD/MAINTAINER are intentionally excluded — see the
+// structural blocks in validateDockerfileAppendLine for why.
+const ALLOWED_APPEND_INSTRUCTIONS = new Set([
+  'RUN',
+  'ENV',
+  'ARG',
+  'LABEL',
+  'COPY',
+  'ADD',
+  'USER',
+  'WORKDIR',
+  'SHELL',
+  'EXPOSE',
+  'VOLUME',
+  'STOPSIGNAL',
+  'HEALTHCHECK',
+  'ONBUILD',
+])
+
+// Decode primitives that, paired with dynamic execution on the same line, form
+// the "decode an opaque blob and run it" anti-pattern that bricked a real build
+// (an agent base64-decoded the bash entrypoint shim and fed it to python3
+// exec). Matching is substring/case-insensitive — these are code tokens the
+// agent emits, not natural-language, so English literals are correct here (cf.
+// the protocol-token exception in AGENTS.md).
+const DECODE_PRIMITIVES = ['base64', 'b64decode', 'atob(', 'unhexlify', '.fromhex(', 'xxd -r']
+
+// True dynamic-execution sinks — language constructs that run a STRING as code.
+// Deliberately NOT including interpreter flags like `python3 -c`/`node -e`: a
+// benign `python3 -c "print(base64.b64encode(...))"` legitimately mentions a
+// decode primitive without ever executing the decoded bytes. The footgun is
+// decode + a real exec sink (or decode piped to an interpreter, below).
+const EXEC_PRIMITIVES = ['exec(', 'eval(', 'new function(', 'function(']
+
+// Decoded stdout piped straight into an interpreter: `base64 -d ... | sh`,
+// `... | python3`, etc. The pipe is the execution step here, so it pairs with
+// DECODE_PRIMITIVES independently of the EXEC_PRIMITIVES sinks above.
+const DECODE_PIPED_TO_INTERPRETER =
+  /\|\s*(?:sudo\s+)?(?:ba)?sh\b|\|\s*(?:sudo\s+)?python3?\b|\|\s*(?:sudo\s+)?(?:node|perl|ruby)\b/i
+
+// Risky-but-legitimate operator patterns: piping a remote script straight into
+// a shell, or ADDing a remote URL. Common enough in real build steps that a
+// hard block would frustrate power users, dangerous enough to flag.
+const APPEND_WARN_PATTERNS: Array<{ test: RegExp; note: string }> = [
+  {
+    test: /\b(?:curl|wget)\b[^|]*\|\s*(?:sudo\s+)?(?:ba)?sh\b/i,
+    note: 'pipes a remote script directly into a shell (curl|bash); verify the source is trusted',
+  },
+  {
+    test: /<\(\s*(?:curl|wget)\b/i,
+    note: 'executes a remote script via process substitution; verify the source is trusted',
+  },
+  {
+    test: /^ADD\s+https?:\/\//i,
+    note: 'ADD of a remote URL fetches an unpinned artifact at build time; prefer a pinned COPY or checksum-verified RUN',
+  },
+]
+
+export type AppendLineCheck =
+  | { ok: true; warning?: string }
+  // `structural` blocks are unconditional (they break Dockerfile generation);
+  // `semantic` blocks are waivable via the host env override.
+  | { ok: false; reason: string; kind: 'structural' | 'semantic' }
+
+// Pure, side-effect-free validator for ONE docker.file.append entry. The newline
+// rejection stays in the zod schema (dockerfileLineSchema) so it fires on every
+// parse including the agent's own config-write guard; this adds the contextual
+// policy the schema can't express cheaply. Returns the first problem found.
+export function validateDockerfileAppendLine(line: string): AppendLineCheck {
+  const trimmed = line.trim()
+
+  if (trimmed === '') {
+    return { ok: false, reason: 'is empty or whitespace-only', kind: 'structural' }
+  }
+
+  // A trailing backslash is a line continuation: it would merge the generated
+  // ENTRYPOINT (spliced right after the append block) into this instruction.
+  if (/\\\s*$/.test(line)) {
+    return {
+      ok: false,
+      reason:
+        'ends with a line-continuation backslash, which would swallow the generated ENTRYPOINT; keep each entry self-contained',
+      kind: 'structural',
+    }
+  }
+
+  // Heredoc syntax spans multiple lines by definition and cannot work in a
+  // single spliced entry — it would consume the following generated lines.
+  if (/<<-?\s*['"]?\w/.test(trimmed)) {
+    return {
+      ok: false,
+      reason: 'uses heredoc syntax (<<EOF), which cannot be expressed as a single Dockerfile line',
+      kind: 'structural',
+    }
+  }
+
+  if (trimmed.startsWith('#')) {
+    // Parser directives (`# syntax=`, `# escape=`) only have meaning at the top
+    // of a Dockerfile; spliced before ENTRYPOINT they are at best inert and at
+    // worst confusing. Plain comments are fine.
+    if (/^#\s*(syntax|escape|check)\s*=/i.test(trimmed)) {
+      return {
+        ok: false,
+        reason: 'is a parser directive (# syntax=/# escape=), which is only valid at the top of a Dockerfile',
+        kind: 'structural',
+      }
+    }
+    return { ok: true }
+  }
+
+  const instruction = trimmed.split(/\s+/, 1)[0]?.toUpperCase() ?? ''
+
+  if (instruction === 'FROM') {
+    return {
+      ok: false,
+      reason: 'starts a new build stage (FROM), discarding everything TypeClaw layered before it',
+      kind: 'structural',
+    }
+  }
+  if (instruction === 'ENTRYPOINT' || instruction === 'CMD') {
+    return {
+      ok: false,
+      reason: `overrides the container ${instruction}, which TypeClaw owns (the entrypoint shim is appended right after this block)`,
+      kind: 'structural',
+    }
+  }
+  if (!ALLOWED_APPEND_INSTRUCTIONS.has(instruction)) {
+    return {
+      ok: false,
+      reason: `does not begin with a recognized Dockerfile instruction (got "${instruction}")`,
+      kind: 'structural',
+    }
+  }
+
+  const lower = trimmed.toLowerCase()
+
+  // The actual incident: mutating TypeClaw's own entrypoint shim. This is never
+  // a supported customization surface — entrypoint changes belong in TypeClaw
+  // source, not in a build-time patch script.
+  if (lower.includes('typeclaw-entrypoint')) {
+    return {
+      ok: false,
+      reason:
+        'references the TypeClaw-owned entrypoint (typeclaw-entrypoint); patching it from docker.file.append is unsupported and brittle',
+      kind: 'semantic',
+    }
+  }
+
+  // Decode-an-opaque-blob-and-execute-it. A benign decode (encoding output,
+  // writing a file) or a bare `python3 -c "print(...)"` both pass; only decode
+  // PAIRED with a real exec sink — or piped into an interpreter — is blocked.
+  const hasDecode = DECODE_PRIMITIVES.some((p) => lower.includes(p))
+  const hasExec = EXEC_PRIMITIVES.some((p) => lower.includes(p)) || DECODE_PIPED_TO_INTERPRETER.test(lower)
+  if (hasDecode && hasExec) {
+    return {
+      ok: false,
+      reason:
+        'decodes an opaque payload and executes it (e.g. base64 + exec/eval), an obfuscated-code anti-pattern that has bricked builds',
+      kind: 'semantic',
+    }
+  }
+
+  for (const { test, note } of APPEND_WARN_PATTERNS) {
+    if (test.test(trimmed)) return { ok: true, warning: note }
   }
 
   return { ok: true }


### PR DESCRIPTION
## Background

`docker.file.append` lines are spliced verbatim into the generated Dockerfile right before ENTRYPOINT, then `docker build` runs. Both operators and the in-container agent (which can write its own `typeclaw.json`) contribute to this field. A real incident made the risk concrete: an agent appended a `RUN python3 -c "import base64; exec(base64.b64decode('...'))"` line intended to patch the bash entrypoint shim, fed the shim to Python's `exec()`, and bricked the build with a SyntaxError — after deps-install and auto-upgrade had already consumed a full build cycle.

The agent had no malicious intent; it was trying to solve a problem and reached for a pattern that happens to be catastrophic in a Dockerfile context. The issue is structural: there was no gate.

## Summary

Add a fail-closed semantic validator — `validateDockerfileAppendLine` in `src/config/config.ts` — wired into the host-side `validateConfig` gate, which is the single path every `typeclaw start` routes through before any expensive steps.

Two tiers of blocks:

**Structural (never waivable):** empty lines, unknown instruction verbs, `FROM`/`ENTRYPOINT`/`CMD`, trailing line-continuation backslash, heredoc syntax, and parser directives. These break Dockerfile generation regardless of intent — they either collide with the spliced ENTRYPOINT or produce a syntactically malformed file.

**Semantic (waivable):** the decode-and-execute anti-pattern — a decode primitive (`base64`, `b64decode`, `atob`, etc.) paired with a real exec sink (`exec()`, `eval()`) or piped into an interpreter — and any reference to the TypeClaw-owned `typeclaw-entrypoint` binary. These are footguns an agent is likely to fire accidentally.

A benign `RUN python3 -c "print(base64.b64encode(b'x'))"` passes: only decode **paired with execution** is blocked, not interpreter flags alone. This keeps false positives low enough that the validator doesn't fight legitimate build steps.

Semantic blocks are waivable via host env `TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND=1`. Host-only by design: an in-container agent can edit `typeclaw.json` but cannot set the env of the host process that runs `validateConfig`, so it cannot waive its own footgun. A human operator running `typeclaw start` can.

Two patterns warn but allow: `curl | bash` and remote `ADD https://...`. Common enough in real build steps that a hard block would be too restrictive; dangerous enough to surface.

`ValidateConfigResult` gains an optional `warnings[]` on the `ok` branch (backward-compatible). `typeclaw start` surfaces them via a new `warnLine` helper added to `src/cli/ui.ts`.

## What this does NOT do

- Does not block agents from editing `typeclaw.json` at runtime — the write path is unchanged; the block fires at the next `start`.
- Does not affect any Dockerfile content TypeClaw itself generates (the ENTRYPOINT, deps-install layer, etc.).
- Does not add a waive mechanism for structural blocks — those break generation unconditionally and cannot be made safe by operator intent.
- Does not touch the Docker build invocation or the container runtime.

## Review notes

The load-bearing invariant is the semantic-only scope of `TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND`. The env is intentionally **not** read from `typeclaw.json` or any file the agent controls. `validateDockerfileAppendLine` is pure and exported so it can be tested independently of the full config parse; the 24 new cases in `config.test.ts` cover the full block/warn table, the env override, and the indexed `docker.file.append[N]` reason format that lets operators pinpoint which entry triggered the block.

The `EXEC_PRIMITIVES` list deliberately excludes interpreter invocation flags (`python3 -c`, `node -e`). Those flags alone are not execution of decoded content — adding them would block `RUN python3 -c "print(...)"`, a common and harmless pattern. The footgun requires the decode AND an exec sink (or a pipe to an interpreter via `DECODE_PIPED_TO_INTERPRETER`).