### PR TITLE
test(inspect): de-flake channel-inbound live tail tests

### DIFF
--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -253,9 +253,18 @@ describe('streamLive — live session events', () => {
     const stream = createStream()
     const { url } = await startServer({ stream })
     const ctrl = new AbortController()
-    const gen = streamLive({ url, sessionId: 'ses_anything', signal: ctrl.signal })
+    const subscribed = Promise.withResolvers<void>()
+    const gen = streamLive({
+      url,
+      sessionId: 'ses_anything',
+      signal: ctrl.signal,
+      onSubscribed: () => subscribed.resolve(),
+    })
 
-    setTimeout(() => {
+    // Regression: a fixed setTimeout raced the subscribe round-trip under CI
+    // load — the broadcast fired before the server wired its subscriber, the
+    // event was dropped, and the test hung to the 30s timeout. Gate on onSubscribed.
+    void subscribed.promise.then(() => {
       stream.publish({
         target: { kind: 'broadcast' },
         payload: {
@@ -276,7 +285,7 @@ describe('streamLive — live session events', () => {
           decision: 'engage',
         },
       })
-    }, 50)
+    })
 
     const events = await collectN(gen, 1)
     ctrl.abort()
@@ -296,14 +305,22 @@ describe('streamLive — live session events', () => {
     const stream = createStream()
     const { url } = await startServer({ stream })
     const ctrl = new AbortController()
-    const gen = streamLive({ url, sessionId: 'ses_anything', signal: ctrl.signal })
+    const subscribed = Promise.withResolvers<void>()
+    const gen = streamLive({
+      url,
+      sessionId: 'ses_anything',
+      signal: ctrl.signal,
+      onSubscribed: () => subscribed.resolve(),
+    })
 
-    setTimeout(() => {
+    // Same subscribe-round-trip race as the well-formed inbound test above:
+    // gate the publish on onSubscribed rather than a fixed timeout.
+    void subscribed.promise.then(() => {
       stream.publish({
         target: { kind: 'broadcast' },
         payload: { kind: 'channel-inbound', adapter: 'slack' },
       })
-    }, 50)
+    })
 
     const events = await collectN(gen, 1)
     ctrl.abort()


### PR DESCRIPTION
## Background

CI run [27703068183](https://github.com/typeclaw/typeclaw/actions/runs/27703068183/job/81944357606) failed with the `streamLive` test `channel-inbound broadcasts surface as InspectEvent.inbound with channel coords` timing out after 30000ms — a flake, not a real regression.

Root cause: that test (and its malformed-payload sibling) published the stream broadcast on a fixed `setTimeout(..., 50)` fired at generator creation. That 50ms timer races the full WebSocket connect → `open` → `ws.send(subscribe)` → server-side subscription wiring round-trip. The inspect server registers its `{ kind: 'broadcast' }` stream subscriber and only *then* sends the `subscribed` reply (`src/server/index.ts`). Under CI load the 50ms publish landed before that subscriber was wired, so the broadcast was dropped, `collectN` never received an event, and the test hung to the 30s ceiling.

## Summary

Gate the publish on the `onSubscribed` confirmation instead of a wall-clock timeout — the same pattern the passing sibling tests (`broadcast`, `cron-fire`) already use. Because the server wires the broadcast subscription before emitting `subscribed`, publishing after that callback guarantees delivery, making the test deterministic regardless of machine load.

Applied to both stream-broadcast publishers in the file (well-formed and malformed inbound); they share the identical race. The two `thinking_*` tests also use `setTimeout` but emit via `session.emit` on an already-registered fake session, a different and lower-risk path, so they're left untouched.

## What this does NOT do

- No production code change — `src/inspect/live.ts` and the server are untouched.
- Does not alter the `thinking_delta`/`thinking_end` tests.

## Review notes

Load-bearing invariant: the server must register the broadcast subscriber before sending `subscribed`. Verified against `src/server/index.ts` (subscription set up at the `stream.subscribe({ target: { kind: 'broadcast' } })` call, `subscribed` sent afterward). Ran the suite 5× in parallel locally — both tests now complete in single-digit ms (was a 30s timeout); `typecheck`, `lint` (0 errors), and `format` are clean.
