### PR TITLE
fix(config): strip unsafe docker.file.append lines instead of blocking start

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -170,5 +170,6 @@ function startOk(opts: StartOptions): StartResult {
     alreadyRunning: false,
     autoUpgrade: { kind: 'skipped-no-dep' },
     skippedPlugins: [],
+    dockerfileWarnings: [],
   }
 }

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -86,6 +86,7 @@ export const restartCommand = defineCommand({
     }
     startSpin.stop('Started.')
 
+    reportConfigWarnings(started.dockerfileWarnings)
     console.log(renderStartSuccess(started))
   },
 })

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -77,6 +77,7 @@ export const startCommand = defineCommand({
     }
     s.stop(result.alreadyRunning ? 'Already running.' : 'Started.')
 
+    reportConfigWarnings(result.dockerfileWarnings)
     console.log(renderStartSuccess(result))
   },
 })

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1518,17 +1518,13 @@ describe('validateDockerfileAppendLine', () => {
 
 describe('validateConfig', () => {
   let cwd: string
-  const ORIGINAL_ALLOW_UNSAFE = process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND
 
   beforeEach(async () => {
     cwd = await mkdtemp(join(tmpdir(), 'typeclaw-validate-'))
-    delete process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND
   })
 
   afterEach(async () => {
     await rm(cwd, { recursive: true, force: true })
-    if (ORIGINAL_ALLOW_UNSAFE === undefined) delete process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND
-    else process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND = ORIGINAL_ALLOW_UNSAFE
   })
 
   test('returns ok when typeclaw.json is missing', () => {
@@ -1622,7 +1618,7 @@ describe('validateConfig', () => {
     expect(result.ok).toBe(false)
   })
 
-  test('blocks a dangerous docker.file.append entry with an indexed reason', async () => {
+  test('warns (but stays ok) for a dangerous docker.file.append entry — fail-safe: stripped on start, never blocks', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
       JSON.stringify({
@@ -1635,10 +1631,13 @@ describe('validateConfig', () => {
       }),
     )
     const result = validateConfig(cwd)
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.reason).toContain('docker.file.append[1]')
-      expect(result.reason).toContain('decodes an opaque payload')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.warnings).toBeDefined()
+      const joined = (result.warnings ?? []).join('\n')
+      expect(joined).toContain('docker.file.append[1]')
+      expect(joined).toContain('will be stripped on start')
+      expect(joined).toContain('decodes an opaque payload')
     }
   })
 
@@ -1658,9 +1657,7 @@ describe('validateConfig', () => {
     }
   })
 
-  test('TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND=1 waives semantic blocks but not structural ones', async () => {
-    process.env.TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND = '1'
-
+  test('append lines never block start — both semantic and structural blocks stay ok with a strip warning', async () => {
     await writeFile(
       join(cwd, 'typeclaw.json'),
       JSON.stringify({
@@ -1668,7 +1665,9 @@ describe('validateConfig', () => {
         docker: { file: { append: ['RUN sed -i s/a/b/ /usr/local/bin/typeclaw-entrypoint'] } },
       }),
     )
-    expect(validateConfig(cwd).ok).toBe(true)
+    const semantic = validateConfig(cwd)
+    expect(semantic.ok).toBe(true)
+    if (semantic.ok) expect((semantic.warnings ?? []).join('\n')).toContain('will be stripped on start')
 
     await writeFile(
       join(cwd, 'typeclaw.json'),
@@ -1677,7 +1676,9 @@ describe('validateConfig', () => {
         docker: { file: { append: ['FROM alpine'] } },
       }),
     )
-    expect(validateConfig(cwd).ok).toBe(false)
+    const structural = validateConfig(cwd)
+    expect(structural.ok).toBe(true)
+    if (structural.ok) expect((structural.warnings ?? []).join('\n')).toContain('will be stripped on start')
   })
 })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1448,9 +1448,13 @@ export function validateDockerfileAppendLine(line: string): AppendLineCheck {
     }
   }
   if (!ALLOWED_APPEND_INSTRUCTIONS.has(instruction)) {
+    // Reason is intentionally input-free: this string is forwarded verbatim into
+    // operator-facing warnings (classifyDockerfileAppend -> dockerfileWarnings),
+    // and the offending token is user-controlled — echoing it could leak a
+    // secret/token-like first word from a malformed line into start/doctor output.
     return {
       ok: false,
-      reason: `does not begin with a recognized Dockerfile instruction (got "${instruction}")`,
+      reason: 'does not begin with a recognized Dockerfile instruction',
       kind: 'structural',
     }
   }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1200,14 +1200,18 @@ export function validateConfig(cwd: string, options: ValidateConfigOptions = {})
   const parsed = parseConfigJson(raw, { migrate: true, persistTarget: cwd })
   if (!parsed.ok) return parsed
 
-  const allowUnsafeAppend = process.env[ALLOW_UNSAFE_DOCKER_APPEND_ENV] === '1'
+  // Append lines are advisory here — never fatal. The Dockerfile renderer
+  // (renderCustomDockerfileLines) is the enforcement boundary: it STRIPS unsafe
+  // lines so the container still comes up, and a bad line written by the
+  // in-container agent can never brick `typeclaw start`. We surface the same
+  // strip/warn decisions as warnings so the operator sees them pre-build.
   const warnings: string[] = []
   const appendLines = parsed.config.docker.file.append
   for (let i = 0; i < appendLines.length; i++) {
     const check = validateDockerfileAppendLine(appendLines[i]!)
     if (!check.ok) {
-      if (check.kind === 'semantic' && allowUnsafeAppend) continue
-      return { ok: false, reason: `docker.file.append[${i}] ${check.reason}` }
+      warnings.push(`docker.file.append[${i}] will be stripped on start — ${check.reason}`)
+      continue
     }
     if (check.warning) warnings.push(`docker.file.append[${i}] ${check.warning}`)
   }
@@ -1316,12 +1320,6 @@ export function validateMount(mount: Mount, cwd: string): ValidateConfigResult {
 
   return { ok: true }
 }
-
-// Host env (not config) on purpose: an in-container agent can edit its own
-// typeclaw.json but cannot set the env of the host `typeclaw start` that runs
-// this gate, so it can never waive its own footgun. Only relaxes SEMANTIC
-// blocks; structural blocks always fire (they break Dockerfile generation).
-const ALLOW_UNSAFE_DOCKER_APPEND_ENV = 'TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND'
 
 // FROM/ENTRYPOINT/CMD/MAINTAINER are intentionally excluded — see the
 // structural blocks in validateDockerfileAppendLine for why.

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -930,6 +930,25 @@ describe('refreshDockerfile', () => {
       await rm(dir, { recursive: true, force: true })
     }
   })
+
+  test('returns warnings for unsafe docker.file.append lines and strips them from the written Dockerfile', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-refresh-strip-'))
+    try {
+      const dangerous = 'RUN python3 -c "import base64; exec(base64.b64decode(\'AA==\').decode())"'
+      await writeTypeclawConfig(dir, { docker: { file: { append: ['ENV SAFE=1', dangerous] } } })
+
+      const result = await refreshDockerfile(dir)
+
+      expect(result.changed).toBe(true)
+      expect(result.warnings.join('\n')).toContain('docker.file.append[1] stripped')
+      const written = await readFile(join(dir, 'Dockerfile'), 'utf8')
+      expect(written).toContain('ENV SAFE=1')
+      expect(written).not.toContain('exec(base64.b64decode')
+      expect(written).toContain('typeclaw stripped 1 unsafe docker.file.append line(s)')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('refreshGitignore', () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -20,7 +20,7 @@ import {
   readInstalledTypeclawVersionFromAgent,
 } from '@/init/auto-upgrade'
 import { resolveBaseImageVersion } from '@/init/cli-version'
-import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
+import { buildDockerfile, classifyDockerfileAppend, DOCKERFILE } from '@/init/dockerfile'
 import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
@@ -148,6 +148,10 @@ export type StartResult =
       // registry. Non-fatal by design: a typo'd or unpublished plugin warns
       // instead of blocking the launch.
       skippedPlugins: string[]
+      // Non-fatal warnings from docker.file.append: unsafe lines stripped from
+      // the generated Dockerfile, plus warn-but-allow lines (curl|bash, remote
+      // ADD). Surfaced by the CLI so a stripped line is never a silent no-op.
+      dockerfileWarnings: string[]
     }
   | { ok: false; reason: string }
 
@@ -485,6 +489,7 @@ export async function start({
       alreadyRunning: false,
       autoUpgrade: upgrade,
       skippedPlugins: pluginReconcile.skipped,
+      dockerfileWarnings: dockerfileRefresh.warnings,
     }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
@@ -701,18 +706,24 @@ async function resolvePublishHost(exec: DockerExec): Promise<string> {
 // the cheapest correct signal: the build context for `docker build` is the
 // Dockerfile itself, so equal contents definitionally produce an equivalent
 // image.
-export async function refreshDockerfile(cwd: string, opts: { buildKit?: boolean } = {}): Promise<{ changed: boolean }> {
+export async function refreshDockerfile(
+  cwd: string,
+  opts: { buildKit?: boolean } = {},
+): Promise<{ changed: boolean; warnings: string[] }> {
   const cfg = await loadTypeclawConfig(cwd)
   const next = buildDockerfile(cfg.docker.file, {
     baseImageVersion: resolveBaseImageVersion(cwd),
     cjkFontsAuto: hostLocaleIsCjk(),
     buildKit: opts.buildKit,
   })
+  // Reuse the renderer's classifier so reported warnings match exactly what was
+  // stripped/kept in the Dockerfile above (single source of truth).
+  const { warnings } = classifyDockerfileAppend(cfg.docker.file.append)
   const path = join(cwd, DOCKERFILE)
   const prev = await readFile(path, 'utf8').catch(() => null)
-  if (prev === next) return { changed: false }
+  if (prev === next) return { changed: false, warnings }
   await writeFile(path, next)
-  return { changed: true }
+  return { changed: true, warnings }
 }
 
 // Builds the agent image with a seamless buildx->legacy fallback. The preferred
@@ -836,6 +847,7 @@ async function reportAlreadyRunning(exec: DockerExec, cwd: string, containerName
   }
   const tuiToken = await resolveTuiToken({ cwd, exec })
   const plan = await planStart({ cwd, hostPort, imageExists: true, forceBuild: false, tuiToken })
+  const { warnings: dockerfileWarnings } = classifyDockerfileAppend((await loadTypeclawConfig(cwd)).docker.file.append)
   return {
     ok: true,
     plan,
@@ -847,6 +859,7 @@ async function reportAlreadyRunning(exec: DockerExec, cwd: string, containerName
     alreadyRunning: true,
     autoUpgrade: { kind: 'skipped-already-running' },
     skippedPlugins: [],
+    dockerfileWarnings,
   }
 }
 

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -210,7 +210,19 @@ function configValid(): DoctorCheck {
     applies: (ctx) => ctx.hasAgentFolder,
     async run(ctx) {
       const result = validateConfig(ctx.cwd)
-      if (result.ok) return { status: 'ok', message: 'typeclaw.json valid; mounts accessible' }
+      if (result.ok) {
+        if (result.warnings && result.warnings.length > 0) {
+          return {
+            status: 'warning',
+            message: `typeclaw.json valid; ${result.warnings.length} docker.file.append warning(s):\n${result.warnings.join('\n')}`,
+            fix: {
+              description:
+                'Review the docker.file.append entries above; unsafe lines are stripped from the Dockerfile on start.',
+            },
+          }
+        }
+        return { status: 'ok', message: 'typeclaw.json valid; mounts accessible' }
+      }
       return {
         status: 'error',
         message: result.reason,

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -12,6 +12,7 @@ import {
   buildBaseDockerfile,
   buildDockerfile,
   buildEntrypointShim,
+  classifyDockerfileAppend,
   CHROME_RUNTIME_APT_PACKAGES_AMD64,
   CLOUDFLARED_RELEASE_URL_BASE,
   CLOUDFLARED_VERSION,
@@ -152,6 +153,40 @@ describe('buildDockerfile feature toggles', () => {
     expect(entrypointIdx).toBeGreaterThan(-1)
     expect(ffmpegIdx).toBeLessThan(customIdx)
     expect(customIdx).toBeLessThan(entrypointIdx)
+  })
+
+  test('fail-safe: strips a decode-and-exec append line but keeps safe lines and still renders ENTRYPOINT', () => {
+    const dangerous = 'RUN python3 -c "import base64; exec(base64.b64decode(\'AA==\').decode())"'
+    const out = buildDockerfile(dockerfileSchema.parse({ append: ['ENV SAFE=1', dangerous] }))
+
+    expect(out).toContain('ENV SAFE=1')
+    expect(out).not.toContain('exec(base64.b64decode')
+    expect(out).toContain('typeclaw stripped 1 unsafe docker.file.append line(s)')
+    expect(out).toContain(`ENTRYPOINT ["${TYPECLAW_ENTRYPOINT_PATH}"]`)
+  })
+
+  test('fail-safe: never echoes stripped payload content into the Dockerfile (no secret leak)', () => {
+    const secretish = 'RUN echo c2VjcmV0LXRva2Vu | base64 -d | sh'
+    const out = buildDockerfile(dockerfileSchema.parse({ append: [secretish] }))
+
+    expect(out).not.toContain('c2VjcmV0LXRva2Vu')
+    expect(out).toContain('typeclaw stripped 1 unsafe docker.file.append line(s)')
+  })
+
+  test('classifyDockerfileAppend keeps warn-but-allow lines (curl|bash) while emitting a warning', () => {
+    const { kept, warnings, strippedCount } = classifyDockerfileAppend([
+      'RUN curl -fsSL https://example.com/i.sh | bash',
+    ])
+    expect(kept).toEqual(['RUN curl -fsSL https://example.com/i.sh | bash'])
+    expect(strippedCount).toBe(0)
+    expect(warnings.join('\n')).toContain('docker.file.append[0]')
+  })
+
+  test('classifyDockerfileAppend strips structural blocks (FROM) with an indexed warning', () => {
+    const { kept, warnings, strippedCount } = classifyDockerfileAppend(['ENV OK=1', 'FROM alpine'])
+    expect(kept).toEqual(['ENV OK=1'])
+    expect(strippedCount).toBe(1)
+    expect(warnings.join('\n')).toContain('docker.file.append[1] stripped')
   })
 
   test('rejects version strings containing whitespace or "=" (apt-injection guard)', () => {
@@ -2348,13 +2383,14 @@ describe('buildKit: false (legacy-builder Dockerfile for hosts without buildx)',
     expect(lg).toContain('RUN bun install -g agent-browser')
   })
 
-  test('legacy mode still emits ENTRYPOINT/CMD and preserves user append verbatim (incl. `<<` that would fool a text parser)', () => {
+  test('legacy mode strips structurally-unsafe append lines (heredoc `<<`) but still emits ENTRYPOINT/CMD', () => {
     const df = buildDockerfile(
       { append: ['RUN echo "usage: cat <<EOF"', 'LABEL note="x << y"'] } as Parameters<typeof buildDockerfile>[0],
       { baseImageVersion: '0.36.8', buildKit: false },
     )
-    expect(df).toContain('RUN echo "usage: cat <<EOF"')
-    expect(df).toContain('LABEL note="x << y"')
+    expect(df).not.toContain('RUN echo "usage: cat <<EOF"')
+    expect(df).not.toContain('LABEL note="x << y"')
+    expect(df).toContain('typeclaw stripped 2 unsafe docker.file.append line(s)')
     expect(df).toContain('ENTRYPOINT [')
     expect(df).toContain('CMD ["run"]')
   })

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -189,6 +189,16 @@ describe('buildDockerfile feature toggles', () => {
     expect(warnings.join('\n')).toContain('docker.file.append[1] stripped')
   })
 
+  test('classifyDockerfileAppend warning never echoes the offending token from a malformed line (no secret leak)', () => {
+    const secretishFirstToken = 'sk-live-abc123secret do-something'
+    const { kept, warnings, strippedCount } = classifyDockerfileAppend([secretishFirstToken])
+    expect(kept).toEqual([])
+    expect(strippedCount).toBe(1)
+    const joined = warnings.join('\n')
+    expect(joined).not.toContain('sk-live-abc123secret')
+    expect(joined).toContain('does not begin with a recognized Dockerfile instruction')
+  })
+
   test('rejects version strings containing whitespace or "=" (apt-injection guard)', () => {
     expect(() => dockerfileSchema.parse({ gh: '2.40.0 curl' })).toThrow(/must not contain whitespace/)
     expect(() => dockerfileSchema.parse({ tmux: '3.3a=evil' })).toThrow(/must not contain whitespace/)

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1,3 +1,4 @@
+import { validateDockerfileAppendLine } from '@/config/config'
 import type { DockerfileConfig, DockerfileFeatureToggle } from '@/config/config'
 import {
   CLAUDE_CREDENTIALS_FILE_NAME,
@@ -1700,10 +1701,57 @@ RUN ${aptCacheMount(buildKit)}apt-get update \\
 `
 }
 
+// Render-time enforcement is the security boundary: this is the sole bottleneck
+// where docker.file.append entries reach the generated Dockerfile, so unsafe
+// lines are STRIPPED here (never spliced into the build) rather than blocking
+// `typeclaw start`. docker.file.append is untrusted input even when the
+// in-container agent writes it — a bad line (e.g. the decode-and-exec footgun
+// that bricked a real build) becomes ineffective, not fatal. Validation
+// elsewhere only warns; this is what guarantees the line never runs.
 function renderCustomDockerfileLines(lines: string[]): string {
-  if (lines.length === 0) return ''
-  return `# Custom lines from typeclaw.json#docker.file.append.
-${lines.join('\n')}
+  const { kept, strippedCount } = classifyDockerfileAppend(lines)
+  if (kept.length === 0 && strippedCount === 0) return ''
+  // Durable, payload-free record so a stripped line isn't a silent no-op: the
+  // operator sees the Dockerfile itself note the count (full reasons surface as
+  // startup warnings). Never echo the stripped content — it may carry secrets.
+  const strippedNote =
+    strippedCount > 0
+      ? `# typeclaw stripped ${strippedCount} unsafe docker.file.append line(s); see startup warnings and typeclaw.json.
+`
+      : ''
+  if (kept.length === 0) return strippedNote ? `${strippedNote}\n` : ''
+  return `${strippedNote}# Custom lines from typeclaw.json#docker.file.append.
+${kept.join('\n')}
 
 `
+}
+
+export type DockerfileAppendClassification = {
+  kept: string[]
+  warnings: string[]
+  strippedCount: number
+}
+
+// Single source of truth for "what happens to each docker.file.append line",
+// reusing the config-layer classifier (validateDockerfileAppendLine). Both the
+// renderer (enforcement: drops unsafe lines) and refreshDockerfile (reporting:
+// surfaces warnings to the user) call this so the two never drift. Warn-but-
+// allow lines (curl|bash, remote ADD) are KEPT but produce a warning; structural
+// and semantic blocks are stripped with a warning.
+export function classifyDockerfileAppend(lines: string[]): DockerfileAppendClassification {
+  const kept: string[] = []
+  const warnings: string[] = []
+  let strippedCount = 0
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    const check = validateDockerfileAppendLine(line)
+    if (!check.ok) {
+      strippedCount++
+      warnings.push(`docker.file.append[${i}] stripped — ${check.reason}`)
+      continue
+    }
+    if (check.warning) warnings.push(`docker.file.append[${i}] ${check.warning}`)
+    kept.push(line)
+  }
+  return { kept, warnings, strippedCount }
 }

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -2036,6 +2036,7 @@ describe('defaultRunHatching', () => {
         alreadyRunning: false,
         autoUpgrade: { kind: 'skipped-already-running' },
         skippedPlugins: [],
+        dockerfileWarnings: [],
       }
     }
     return { fn, calls }


### PR DESCRIPTION
## Background

PR #948 added `validateDockerfileAppendLine` as a hard gate: a dangerous `docker.file.append` entry makes `typeclaw start`/`restart` call `process.exit(1)`, and the container never comes up until a human manually edits `typeclaw.json`. The original intent was a fail-safe guard. #948 inverted that intent into fail-closed.

The real incident that motivated both PRs: an in-container agent appended this line to `docker.file.append`, intending to patch the bash entrypoint shim:

```
RUN python3 -c "import base64; exec(base64.b64decode('...'))"
```

The single-line append constraint pushed toward a base64'd one-liner, which fed the shim to Python's `exec()` and bricked the build with a SyntaxError — after deps-install and auto-upgrade had already consumed a full build cycle. The agent had no malicious intent; the structural constraint created the footgun.

A self-inflicted bad append line must not brick startup. This PR makes that guarantee by construction.

## Summary

Rendering is the security boundary; validation is now advisory.

`renderCustomDockerfileLines` in `src/init/dockerfile.ts` is the enforcement point. It calls the new `classifyDockerfileAppend` helper, strips every line that `validateDockerfileAppendLine` would flag, and writes a payload-free comment `# typeclaw stripped N unsafe docker.file.append line(s)` in the generated Dockerfile so a strip is never a silent no-op. Stripped content is never echoed — a stripped line may contain base64'd secrets.

`classifyDockerfileAppend` takes a `lines` array and returns `{ kept, warnings, strippedCount }`. It is the single source of truth shared by both the renderer (enforcement) and `refreshDockerfile` (reporting), so warnings always match exactly what was stripped.

`refreshDockerfile` in `src/container/start.ts` now returns `{ changed, warnings }`. `StartResult` gains a non-fatal `dockerfileWarnings: string[]` (mirrors the existing `skippedPlugins` field). `cli/start.ts` and `cli/restart.ts` surface these through the existing `reportConfigWarnings` sink.

`validateConfig` in `src/config/config.ts` no longer returns `{ ok: false }` for append lines — they become advisory `warnings[]` ("will be stripped on start"). Schema-level newline rejection in `dockerfileLineSchema` is unchanged. An append line can never block start.

Doctor's config-valid check reports dangerous append entries as a WARNING ("stripped on start") instead of a hard error.

`TYPECLAW_ALLOW_UNSAFE_DOCKER_APPEND` is retired. With strip-at-render, the waiver is obsolete, and keeping it would leave an escape hatch back to brick-on-start semantics.

## What this does NOT do

- Does not change what lines are considered dangerous — the block/warn table from #948 is preserved; only the response changes from block to strip.
- Does not echo stripped content into the Dockerfile, logs, or CLI output.
- Does not affect any Dockerfile content TypeClaw itself generates.
- Does not restrict the in-container agent from editing `typeclaw.json` — the write path is unchanged; the strip fires at the next `start`.
- Does not add a new fail-closed path for any other config field.

## Review notes

**Load-bearing invariant:** rendering is the security boundary, validation is advisory. `docker.file.append` is untrusted input even when the in-container agent writes it; the generated Dockerfile is safe by construction at render time regardless of what `typeclaw.json` contains. `validateConfig` must never return `{ ok: false }` for an append-line reason after this PR — the advisory path is what keeps that guarantee.

**Why retire the env waiver rather than keep it?** With strip-at-render, the only thing the waiver could do is re-enable brick-on-start. There is no "unsafe but allowed" path left to waive; keeping the env var would be a misleading control with no beneficial use.

**`classifyDockerfileAppend` as the single source of truth:** both the renderer and `refreshDockerfile` must call the same classifier, or their warning lists can diverge. Tests in `dockerfile.test.ts` verify that the rendered Dockerfile comment count matches the classifier's `strippedCount`.

**`dockerfileWarnings` on `StartResult`** mirrors `skippedPlugins` intentionally. Non-fatal, surfaced to the operator, not thrown.

## Testing

New test assertions cover:

- A decode-and-exec line is stripped while a safe `ENV` line is kept and `ENTRYPOINT` still renders correctly.
- Stripped payload content is never present in the generated Dockerfile output.
- `classifyDockerfileAppend` keeps `curl | bash` warn-but-allow lines (with a warning) and strips a structural `FROM` line (with an indexed warning).
- `refreshDockerfile` returns strip warnings and writes a Dockerfile with the stripped-count comment.
- `validateConfig` returns `{ ok: true }` with a "will be stripped on start" advisory for both semantic and structural append entries.

Full suite: 9322 pass / 0 fail. `bun run typecheck` clean. `bun run lint` 0 errors (65 pre-existing warnings unrelated). `bun run format:check` clean.