### PR TITLE
feat(git): relocate agent git DB to .gitstore for monorepo fleet support

### DIFF
--- a/src/agent/git-nudge.test.ts
+++ b/src/agent/git-nudge.test.ts
@@ -106,6 +106,22 @@ describe('renderGitNudge', () => {
     expect(text).toContain('- src/bar.ts')
   })
 
+  test('passes gitstore args to status reader when .gitstore is present', async () => {
+    await mkdir(join(agentDir, '.gitstore'))
+    let captured: readonly string[] = []
+    const deps: GitNudgeDeps = {
+      readStatus: async (_agentDir, gitArgs) => {
+        captured = gitArgs
+        return ['src/foo.ts']
+      },
+    }
+
+    const text = await renderGitNudge(agentDir, deps)
+
+    expect(text).toContain('- src/foo.ts')
+    expect(captured).toEqual(['--git-dir', join(agentDir, '.gitstore'), '--work-tree', agentDir])
+  })
+
   test('drops paths under sessions/ and memory/ from the nudge', async () => {
     await mkdir(join(agentDir, '.git'))
     const deps: GitNudgeDeps = {

--- a/src/agent/git-nudge.ts
+++ b/src/agent/git-nudge.ts
@@ -1,5 +1,4 @@
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { resolveAgentGit } from '@/git/resolve-agent-git'
 
 const MAX_LISTED_PATHS = 10
 
@@ -9,15 +8,16 @@ const MAX_LISTED_PATHS = 10
 const RUNTIME_OWNED_PREFIXES = ['sessions/', 'memory/']
 
 export type GitNudgeDeps = {
-  readStatus: (agentDir: string) => Promise<readonly string[] | null>
+  readStatus: (agentDir: string, gitArgs: readonly string[]) => Promise<readonly string[] | null>
 }
 
 // Returns "" (not a placeholder string) when there is nothing to nudge about.
 // The empty case must add zero bytes to the system prompt so cache prefixes
 // stay identical to a clean-worktree agent folder.
 export async function renderGitNudge(agentDir: string, deps: GitNudgeDeps = defaultDeps): Promise<string> {
-  if (!existsSync(join(agentDir, '.git'))) return ''
-  const status = await deps.readStatus(agentDir)
+  const repo = resolveAgentGit(agentDir)
+  if (!repo) return ''
+  const status = await deps.readStatus(agentDir, repo.gitArgs)
   if (status === null) return ''
   const dirty = filterAgentOwned(status)
   if (dirty.length === 0) return ''
@@ -66,12 +66,12 @@ function filterAgentOwned(paths: readonly string[]): string[] {
 
 // Mirrors the spawn pattern in `src/container/start.ts` `commitSystemFile`.
 const defaultDeps: GitNudgeDeps = {
-  async readStatus(agentDir) {
+  async readStatus(agentDir, gitArgs) {
     const bun = getBun()
     if (!bun) return null
     try {
       const proc = bun.spawn({
-        cmd: ['git', 'status', '--porcelain=v1'],
+        cmd: ['git', ...gitArgs, 'status', '--porcelain=v1'],
         cwd: agentDir,
         stdout: 'pipe',
         stderr: 'pipe',

--- a/src/bundled-plugins/backup/index.ts
+++ b/src/bundled-plugins/backup/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { withGitLock } from '@/git/mutex'
+import { resolveAgentGit } from '@/git/resolve-agent-git'
 import { definePlugin, type PluginContext, type SpawnSubagentOptions, type Subagent } from '@/plugin'
 
 import { type BackupPushAuthDeps, makeDefaultAskPassEnsurer, resolveBackupPushAuthEnv } from './git-auth'
@@ -257,12 +258,14 @@ async function resolveBackupAuthEnv(
   }
 }
 
-async function resolveOriginPushUrl(cwd: string): Promise<string | null> {
+export async function resolveOriginPushUrl(cwd: string): Promise<string | null> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return null
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return null
   try {
     const proc = bun.spawn({
-      cmd: ['git', '-C', cwd, 'remote', 'get-url', '--push', 'origin'],
+      cmd: ['git', '-C', cwd, ...repo.gitArgs, 'remote', 'get-url', '--push', 'origin'],
       stdout: 'pipe',
       stderr: 'ignore',
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_OPTIONAL_LOCKS: '0' },

--- a/src/bundled-plugins/backup/resolve-origin-push-url.test.ts
+++ b/src/bundled-plugins/backup/resolve-origin-push-url.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rename, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { resolveOriginPushUrl } from './index'
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'Test',
+  GIT_AUTHOR_EMAIL: 'test@example.com',
+  GIT_COMMITTER_NAME: 'Test',
+  GIT_COMMITTER_EMAIL: 'test@example.com',
+  GIT_TERMINAL_PROMPT: '0',
+} as const
+
+async function git(cwd: string, args: readonly string[]): Promise<void> {
+  const proc = Bun.spawn({
+    cmd: ['git', ...args],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, ...GIT_ENV },
+  })
+  if ((await proc.exited) !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${await new Response(proc.stderr).text()}`)
+  }
+}
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-push-url-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('resolveOriginPushUrl', () => {
+  test('standalone .git agent: returns its own origin push url', async () => {
+    await git(root, ['init', '-b', 'main'])
+    await git(root, ['remote', 'add', 'origin', 'https://github.com/acme/standalone.git'])
+
+    expect(await resolveOriginPushUrl(root)).toBe('https://github.com/acme/standalone.git')
+  })
+
+  test('relocated .gitstore child reads the AGENT origin, not the parent monorepo origin', async () => {
+    // given: a parent monorepo whose own origin differs from the child agent's
+    await git(root, ['init', '-b', 'main'])
+    await git(root, ['remote', 'add', 'origin', 'https://github.com/acme/fleet.git'])
+
+    const agentDir = join(root, 'agents', 'alice')
+    await mkdir(agentDir, { recursive: true })
+    await git(agentDir, ['init', '-b', 'main'])
+    await git(agentDir, ['remote', 'add', 'origin', 'https://github.com/acme/alice.git'])
+
+    // when: the agent's git db is relocated out of its working tree to .gitstore
+    await rename(join(agentDir, '.git'), join(agentDir, '.gitstore'))
+
+    // then: resolution threads --git-dir/--work-tree and reads alice's origin,
+    // never walking up to the parent fleet repo
+    expect(await resolveOriginPushUrl(agentDir)).toBe('https://github.com/acme/alice.git')
+  })
+
+  test('no repo at all (neither .git nor .gitstore): returns null', async () => {
+    expect(await resolveOriginPushUrl(root)).toBeNull()
+  })
+})

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -37,6 +37,12 @@ async function makeRepo(): Promise<string> {
   return dir
 }
 
+async function makeGitstoreRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'autobackup-runner-gitstore-'))
+  await mkdir(join(dir, '.gitstore'))
+  return dir
+}
+
 const baseDeps = (spawn: GitSpawn, message = 'chore: test'): BackupRunnerDeps => ({
   gitSpawn: spawn,
   pickCommitMessage: async () => message,
@@ -56,6 +62,26 @@ describe('runBackup', () => {
     const { spawn } = makeSpawn(() => okResult(''))
     const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn))
     expect(result).toEqual({ ok: true, kind: 'clean' })
+  })
+
+  test('threads gitstore args into representative git calls', async () => {
+    const cwd = await makeGitstoreRepo()
+    const prefix = ['--git-dir', join(cwd, '.gitstore'), '--work-tree', cwd]
+    const { spawn, calls } = makeSpawn((args) => {
+      const command = args[prefix.length]
+      if (command === 'status') return okResult(' M notes.md\n')
+      if (command === 'diff' && args[prefix.length + 2] === '--quiet') return failResult('', 1)
+      if (command === 'commit') return okResult()
+      if (command === 'rev-parse') return failResult('no upstream', 128)
+      if (command === 'remote') return failResult('No such remote', 2)
+      return okResult()
+    })
+
+    const result = await runBackup({ cwd, pushToOrigin: true }, baseDeps(spawn, '백업: 메모 저장'))
+
+    expect(result).toEqual({ ok: true, kind: 'committed' })
+    expect(calls.find((c) => c.args.includes('status'))?.args.slice(0, prefix.length)).toEqual(prefix)
+    expect(calls.find((c) => c.args.includes('commit'))?.args.slice(0, prefix.length)).toEqual(prefix)
   })
 
   test('skips committing memory/-prefixed paths but stages other dirty paths', async () => {

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { type AgentGit, resolveAgentGit } from '@/git/resolve-agent-git'
+
 export const COMMIT_TIMEOUT_MS = 30_000
 export const NETWORK_TIMEOUT_MS = 60_000
 
@@ -64,9 +66,10 @@ type PushPlan = ActivePushPlan | { kind: 'skip' }
 export async function runBackup(options: BackupRunnerOptions, deps: BackupRunnerDeps): Promise<BackupResult> {
   const { cwd, pushToOrigin } = options
 
-  if (!existsSync(join(cwd, '.git'))) return { ok: true, kind: 'no-repo' }
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return { ok: true, kind: 'no-repo' }
 
-  const status = await deps.gitSpawn(['status', '--porcelain=v1', '--untracked-files=all'], {
+  const status = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '--untracked-files=all'], {
     cwd,
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
@@ -76,23 +79,32 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
   if (dirty.length === 0 && force.length === 0) return { ok: true, kind: 'clean' }
 
   if (dirty.length > 0) {
-    const add = await deps.gitSpawn(['add', '--', ...dirty], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+    const add = await deps.gitSpawn([...repo.gitArgs, 'add', '--', ...dirty], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
     if (add.exitCode !== 0) return { ok: false, kind: 'commit-failed', reason: `git add failed: ${shortErr(add)}` }
   }
   if (force.length > 0) {
     const present = force.filter((p) => existsSync(join(cwd, p)))
     if (present.length > 0) {
-      const addF = await deps.gitSpawn(['add', '-f', '--', ...present], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+      const addF = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...present], {
+        cwd,
+        timeoutMs: COMMIT_TIMEOUT_MS,
+      })
       if (addF.exitCode !== 0) {
         return { ok: false, kind: 'commit-failed', reason: `git add -f failed: ${shortErr(addF)}` }
       }
     }
   }
 
-  const stagedCheck = await deps.gitSpawn(['diff', '--cached', '--quiet'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  const stagedCheck = await deps.gitSpawn([...repo.gitArgs, 'diff', '--cached', '--quiet'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
   if (stagedCheck.exitCode === 0) return { ok: true, kind: 'clean' }
 
-  const diffstat = await deps.gitSpawn(['diff', '--cached', '--stat'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  const diffstat = await deps.gitSpawn([...repo.gitArgs, 'diff', '--cached', '--stat'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
   const message = await deps.pickCommitMessage({
     status: status.stdout.slice(0, 4096),
     diffstat: diffstat.stdout.slice(0, 4096),
@@ -106,14 +118,17 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
   // one-cycle-behind churn. Re-status, filter to `sessions/` additions
   // only (don't accidentally stage user work that arrived during the
   // window), and force-add anything new.
-  const reStatus = await deps.gitSpawn(['status', '--porcelain=v1', '--untracked-files=all'], {
+  const reStatus = await deps.gitSpawn([...repo.gitArgs, 'status', '--porcelain=v1', '--untracked-files=all'], {
     cwd,
     timeoutMs: COMMIT_TIMEOUT_MS,
   })
   if (reStatus.exitCode === 0) {
     const lateForce = filterForceAdd(parsePorcelain(reStatus.stdout)).filter((p) => existsSync(join(cwd, p)))
     if (lateForce.length > 0) {
-      const lateAdd = await deps.gitSpawn(['add', '-f', '--', ...lateForce], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+      const lateAdd = await deps.gitSpawn([...repo.gitArgs, 'add', '-f', '--', ...lateForce], {
+        cwd,
+        timeoutMs: COMMIT_TIMEOUT_MS,
+      })
       if (lateAdd.exitCode !== 0) {
         return { ok: false, kind: 'commit-failed', reason: `git add -f (post-message) failed: ${shortErr(lateAdd)}` }
       }
@@ -121,16 +136,19 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
   }
 
   const safeMessage = sanitizeCommitMessage(message)
-  const commit = await deps.gitSpawn(['commit', '-m', safeMessage], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  const commit = await deps.gitSpawn([...repo.gitArgs, 'commit', '-m', safeMessage], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
   if (commit.exitCode !== 0)
     return { ok: false, kind: 'commit-failed', reason: `git commit failed: ${shortErr(commit)}` }
 
   if (!pushToOrigin) return { ok: true, kind: 'committed' }
 
-  const plan = await resolvePushPlan(cwd, deps)
+  const plan = await resolvePushPlan(cwd, deps, repo)
   if (plan.kind === 'skip') return { ok: true, kind: 'committed' }
 
-  return pushWithRecovery(cwd, deps, plan)
+  return pushWithRecovery(cwd, deps, repo, plan)
 }
 
 // `@{upstream}` resolution failing was previously treated as "no push" — but a
@@ -140,11 +158,14 @@ export async function runBackup(options: BackupRunnerOptions, deps: BackupRunner
 // branch": then we push AND set the upstream in one shot, and every later run
 // takes the plain-upstream path. No remote / detached HEAD stays commit-only
 // (a legitimate offline state), so it returns `skip` rather than diagnosing.
-async function resolvePushPlan(cwd: string, deps: BackupRunnerDeps): Promise<PushPlan> {
-  const upstream = await deps.gitSpawn(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], {
-    cwd,
-    timeoutMs: COMMIT_TIMEOUT_MS,
-  })
+async function resolvePushPlan(cwd: string, deps: BackupRunnerDeps, repo: AgentGit): Promise<PushPlan> {
+  const upstream = await deps.gitSpawn(
+    [...repo.gitArgs, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    {
+      cwd,
+      timeoutMs: COMMIT_TIMEOUT_MS,
+    },
+  )
   if (upstream.exitCode === 0 && upstream.stdout.trim().length > 0) {
     return { kind: 'upstream', upstreamRef: upstream.stdout.trim() }
   }
@@ -153,13 +174,19 @@ async function resolvePushPlan(cwd: string, deps: BackupRunnerDeps): Promise<Pus
   // would guess a destination the operator never configured. `get-url` (not
   // `get-url --push`) is enough here — we only need to know origin EXISTS and
   // is named `origin`; the push targets `origin` by name regardless of pushurl.
-  const origin = await deps.gitSpawn(['remote', 'get-url', 'origin'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  const origin = await deps.gitSpawn([...repo.gitArgs, 'remote', 'get-url', 'origin'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
   if (origin.exitCode !== 0 || origin.stdout.trim().length === 0) return { kind: 'skip' }
 
   // `symbolic-ref --short HEAD` fails on a detached HEAD (no branch to set an
   // upstream for); `rev-parse --abbrev-ref HEAD` would have returned the literal
   // "HEAD" and we'd have tried to push a branch named HEAD. Skip cleanly.
-  const branch = await deps.gitSpawn(['symbolic-ref', '--short', 'HEAD'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+  const branch = await deps.gitSpawn([...repo.gitArgs, 'symbolic-ref', '--short', 'HEAD'], {
+    cwd,
+    timeoutMs: COMMIT_TIMEOUT_MS,
+  })
   if (branch.exitCode !== 0 || branch.stdout.trim().length === 0) return { kind: 'skip' }
 
   return { kind: 'set-upstream', remote: 'origin', branch: branch.stdout.trim() }
@@ -169,13 +196,18 @@ async function resolvePushPlan(cwd: string, deps: BackupRunnerDeps): Promise<Pus
 // non-fast-forward recovery: fetch, rebase onto the intended remote branch,
 // re-push. Keeping one helper stops the set-upstream path from silently becoming
 // a weaker duplicate that skips recovery.
-async function pushWithRecovery(cwd: string, deps: BackupRunnerDeps, plan: ActivePushPlan): Promise<BackupResult> {
-  const pushArgs = pushArgsFor(plan)
+async function pushWithRecovery(
+  cwd: string,
+  deps: BackupRunnerDeps,
+  repo: AgentGit,
+  plan: ActivePushPlan,
+): Promise<BackupResult> {
+  const pushArgs = [...repo.gitArgs, ...pushArgsFor(plan)]
   const rebaseRef = plan.kind === 'upstream' ? plan.upstreamRef : `${plan.remote}/${plan.branch}`
   // In the set-upstream case there is no tracking ref yet, so a bare `git fetch`
   // has no configured remote to default to — fetch the same remote we rebase
   // onto. The upstream case keeps bare `fetch` (its tracking config resolves it).
-  const fetchArgs = plan.kind === 'upstream' ? ['fetch'] : ['fetch', plan.remote]
+  const fetchArgs = [...repo.gitArgs, ...(plan.kind === 'upstream' ? ['fetch'] : ['fetch', plan.remote])]
   const pushedKind: BackupResult = { ok: true, kind: plan.kind === 'upstream' ? 'pushed' : 'pushed-set-upstream' }
   // Credentials ride ONLY on the network calls (push/fetch). The rebase is
   // local (it replays onto an already-fetched remote-tracking ref), so it runs
@@ -202,9 +234,9 @@ async function pushWithRecovery(cwd: string, deps: BackupRunnerDeps, plan: Activ
     return { ok: false, kind: 'push-failed', reason: `git fetch failed: ${shortErr(fetch)}` }
   }
 
-  const rebase = await deps.gitSpawn(['rebase', rebaseRef], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
+  const rebase = await deps.gitSpawn([...repo.gitArgs, 'rebase', rebaseRef], { cwd, timeoutMs: NETWORK_TIMEOUT_MS })
   if (rebase.exitCode !== 0) {
-    await deps.gitSpawn(['rebase', '--abort'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
+    await deps.gitSpawn([...repo.gitArgs, 'rebase', '--abort'], { cwd, timeoutMs: COMMIT_TIMEOUT_MS })
     await maybeDiagnose(deps, {
       cwd,
       stage: 'rebase',

--- a/src/bundled-plugins/guard/policies/uncommitted-changes.test.ts
+++ b/src/bundled-plugins/guard/policies/uncommitted-changes.test.ts
@@ -60,6 +60,26 @@ describe('checkUncommittedChangesAdvice', () => {
     expect(textOf(result)).toBe('wrote 3 lines')
   })
 
+  test('relocated .gitstore agent: still warns and threads --git-dir/--work-tree into status', async () => {
+    // given: a monorepo member whose git db lives in .gitstore, not .git
+    await mkdir(join(agentDir, '.gitstore'))
+    let receivedGitArgs: readonly string[] | undefined
+    const deps: UncommittedChangesDeps = {
+      readStatus: async (_dir, gitArgs) => {
+        receivedGitArgs = gitArgs
+        return ['src/foo.ts']
+      },
+    }
+    const result = textResult('wrote 3 lines')
+
+    // when: a file-touching tool runs
+    await checkUncommittedChangesAdvice({ tool: 'write', agentDir, result, deps })
+
+    // then: the guard fires and passes the relocated git args to the status reader
+    expect(textOf(result)).toContain('uncommittedChanges')
+    expect(receivedGitArgs).toEqual(['--git-dir', join(agentDir, '.gitstore'), '--work-tree', agentDir])
+  })
+
   test('does nothing when the worktree is clean', async () => {
     await mkdir(join(agentDir, '.git'))
     const result = textResult('wrote 3 lines')

--- a/src/bundled-plugins/guard/policies/uncommitted-changes.ts
+++ b/src/bundled-plugins/guard/policies/uncommitted-changes.ts
@@ -1,6 +1,4 @@
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
-
+import { resolveAgentGit } from '@/git/resolve-agent-git'
 import type { ContentPart, ToolResult } from '@/plugin'
 
 export const GUARD_UNCOMMITTED_CHANGES = 'uncommittedChanges'
@@ -13,7 +11,7 @@ const WARNING_TEXT =
   '\n\n[guard:uncommittedChanges] The worktree has uncommitted changes. Commit (or stash) them when this task is done — leaving stale changes around between turns risks losing work and confusing future commits.'
 
 export type UncommittedChangesDeps = {
-  readStatus: (agentDir: string) => Promise<readonly string[] | null>
+  readStatus: (agentDir: string, gitArgs: readonly string[]) => Promise<readonly string[] | null>
 }
 
 export async function checkUncommittedChangesAdvice(options: {
@@ -24,10 +22,11 @@ export async function checkUncommittedChangesAdvice(options: {
 }): Promise<void> {
   const { tool, agentDir, result } = options
   if (!FILE_TOUCHING_TOOLS.has(tool)) return
-  if (!existsSync(join(agentDir, '.git'))) return
+  const repo = resolveAgentGit(agentDir)
+  if (!repo) return
 
   const deps = options.deps ?? defaultDeps
-  const status = await deps.readStatus(agentDir)
+  const status = await deps.readStatus(agentDir, repo.gitArgs)
   if (status === null) return
 
   const dirty = status.filter((p) => !RUNTIME_OWNED_PREFIXES.some((prefix) => p.startsWith(prefix)))
@@ -59,12 +58,12 @@ function appendAdviceToContent(content: ContentPart[], advice: string): void {
 }
 
 const defaultDeps: UncommittedChangesDeps = {
-  async readStatus(agentDir) {
+  async readStatus(agentDir, gitArgs) {
     const bun = getBun()
     if (!bun) return null
     try {
       const proc = bun.spawn({
-        cmd: ['git', 'status', '--porcelain=v1'],
+        cmd: ['git', ...gitArgs, 'status', '--porcelain=v1'],
         cwd: agentDir,
         stdout: 'pipe',
         stderr: 'pipe',

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { createHash } from 'node:crypto'
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -1349,8 +1350,9 @@ function vector(values: Record<number, number>): Float32Array {
 }
 
 async function runGit(cwd: string, args: string[]): Promise<{ stdout: string; exitCode: number }> {
+  const gitArgs = existsSync(join(cwd, '.gitstore')) ? ['--git-dir', join(cwd, '.gitstore'), '--work-tree', cwd] : []
   const proc = Bun.spawn({
-    cmd: ['git', ...args],
+    cmd: ['git', ...gitArgs, ...args],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -1372,6 +1374,10 @@ async function initRepo(cwd: string): Promise<void> {
   await writeFile(join(cwd, '.gitignore'), 'memory/\n')
   await runGit(cwd, ['add', '.gitignore'])
   await runGit(cwd, ['commit', '-qm', 'init'])
+}
+
+async function relocateGitStore(cwd: string): Promise<void> {
+  await rename(join(cwd, '.git'), join(cwd, '.gitstore'))
 }
 
 async function trackedFiles(cwd: string): Promise<string[]> {
@@ -1438,6 +1444,18 @@ describe('commitMemorySnapshot', () => {
 
     expect(await trackedFiles(agentDir)).toEqual(['memory/skills/release-checklist/SKILL.md'])
     expect(await skipWorktreeFiles(agentDir)).toEqual(['memory/skills/release-checklist/SKILL.md'])
+    expect(await porcelainStatus(agentDir)).toBe('')
+  })
+
+  test('commits Korean memory artifacts through a relocated gitstore', async () => {
+    await initRepo(agentDir)
+    await relocateGitStore(agentDir)
+    await writeFile(streamFile('2026-04-27'), fragmentLine('korean', '사용자 선호', '사용자는 한국어 메모를 남겼다'))
+
+    await commitMemorySnapshot(agentDir)
+
+    expect(await trackedFiles(agentDir)).toEqual(['memory/streams/2026-04-27.jsonl'])
+    expect(await lastCommitSubject(agentDir)).toMatch(/^dream: 1 fragment /)
     expect(await porcelainStatus(agentDir)).toBe('')
   })
 })

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -6,6 +6,7 @@ import { basename, join } from 'node:path'
 import { z } from 'zod'
 
 import { withGitLock } from '@/git/mutex'
+import { type AgentGit, resolveAgentGit } from '@/git/resolve-agent-git'
 import { defineTool, lsTool, readTool, type Subagent, writeTool } from '@/plugin'
 import { formatLocalDate, formatLocalDateTime } from '@/shared'
 
@@ -751,26 +752,27 @@ export async function commitMemorySnapshot(cwd: string): Promise<void> {
 async function commitMemorySnapshotUnlocked(cwd: string): Promise<void> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return
-  if (!existsSync(join(cwd, '.git'))) return
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return
 
-  await clearSkipWorktree(bun, cwd)
+  await clearSkipWorktree(bun, cwd, repo)
 
   // `git add -- foo bar/` fails with exit 128 if any pathspec matches no
   // path on disk. Filter to existing paths before passing them in.
   const presentPaths = SNAPSHOT_PATHS.filter((p) => existsSync(join(cwd, p)))
   if (presentPaths.length === 0) {
-    await applySkipWorktree(bun, cwd)
+    await applySkipWorktree(bun, cwd, repo)
     return
   }
 
   const add = bun.spawn({
-    cmd: ['git', 'add', '-f', '--', ...presentPaths],
+    cmd: ['git', ...repo.gitArgs, 'add', '-f', '--', ...presentPaths],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
   })
   if ((await add.exited) !== 0) {
-    await applySkipWorktree(bun, cwd)
+    await applySkipWorktree(bun, cwd, repo)
     return
   }
 
@@ -779,33 +781,33 @@ async function commitMemorySnapshotUnlocked(cwd: string): Promise<void> {
   // fails outright when `bar/` matches no tracked file, even if `foo` is
   // staged.
   const stagedNames = bun.spawn({
-    cmd: ['git', 'diff', '--cached', '--name-only', '-z', '--', ...SNAPSHOT_PATHS],
+    cmd: ['git', ...repo.gitArgs, 'diff', '--cached', '--name-only', '-z', '--', ...SNAPSHOT_PATHS],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
   })
   const stagedRaw = await new Response(stagedNames.stdout).text()
   if ((await stagedNames.exited) !== 0) {
-    await applySkipWorktree(bun, cwd)
+    await applySkipWorktree(bun, cwd, repo)
     return
   }
   const staged = stagedRaw.split('\0').filter((p) => p.length > 0)
   if (staged.length === 0) {
-    await applySkipWorktree(bun, cwd)
+    await applySkipWorktree(bun, cwd, repo)
     return
   }
 
-  const message = await buildCommitMessage(bun, cwd, staged)
+  const message = await buildCommitMessage(bun, cwd, staged, undefined, repo.gitArgs)
 
   const commit = bun.spawn({
-    cmd: ['git', 'commit', '-m', message, '--only', '--', ...staged],
+    cmd: ['git', ...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...staged],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
   })
   await commit.exited
 
-  await applySkipWorktree(bun, cwd)
+  await applySkipWorktree(bun, cwd, repo)
 }
 
 // Pool of emojis sampled into every dream commit. The pool is small and
@@ -837,19 +839,25 @@ export async function buildCommitMessage(
   cwd: string,
   staged: string[],
   emojiPicker: () => DreamEmoji = pickDreamEmoji,
+  gitArgs: readonly string[] = [],
 ): Promise<string> {
-  const summary = await buildDreamSummary(bun, cwd, staged)
+  const summary = await buildDreamSummary(bun, cwd, staged, gitArgs)
   return `dream: ${summary} ${emojiPicker()}`
 }
 
 const STREAM_FILE_RELATIVE = /^memory\/(?:streams\/)?\d{4}-\d{2}-\d{2}\.jsonl$/
 const SKILL_FILE_RELATIVE = /^memory\/skills\/([^/]+)\/SKILL\.md$/
 
-async function buildDreamSummary(bun: { spawn: typeof Bun.spawn }, cwd: string, staged: string[]): Promise<string> {
+async function buildDreamSummary(
+  bun: { spawn: typeof Bun.spawn },
+  cwd: string,
+  staged: string[],
+  gitArgs: readonly string[] = [],
+): Promise<string> {
   // numstat: `<added>\t<deleted>\t<path>` per line. Use NUL-terminated so paths
   // with whitespace round-trip; -z switches the record separator to NUL.
   const numstat = bun.spawn({
-    cmd: ['git', 'diff', '--cached', '--numstat', '-z', '--', ...staged],
+    cmd: ['git', ...gitArgs, 'diff', '--cached', '--numstat', '-z', '--', ...staged],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -874,7 +882,7 @@ async function buildDreamSummary(bun: { spawn: typeof Bun.spawn }, cwd: string, 
 
   // Newly-added muscle-memory skills (status A). Refinements (status M) are
   // not announced — they ride under the fragment count.
-  const newSkills = await listNewlyAddedSkills(bun, cwd, staged)
+  const newSkills = await listNewlyAddedSkills(bun, cwd, staged, gitArgs)
 
   const parts: string[] = []
   if (fragmentLines > 0) {
@@ -903,9 +911,10 @@ async function listNewlyAddedSkills(
   bun: { spawn: typeof Bun.spawn },
   cwd: string,
   staged: string[],
+  gitArgs: readonly string[] = [],
 ): Promise<string[]> {
   const proc = bun.spawn({
-    cmd: ['git', 'diff', '--cached', '--name-status', '-z', '--', ...staged],
+    cmd: ['git', ...gitArgs, 'diff', '--cached', '--name-status', '-z', '--', ...staged],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -927,9 +936,13 @@ async function listNewlyAddedSkills(
   return names.filter((n) => n.length > 0)
 }
 
-async function listTrackedSnapshotFiles(bun: { spawn: typeof Bun.spawn }, cwd: string): Promise<string[]> {
+async function listTrackedSnapshotFiles(
+  bun: { spawn: typeof Bun.spawn },
+  cwd: string,
+  repo: AgentGit,
+): Promise<string[]> {
   const ls = bun.spawn({
-    cmd: ['git', 'ls-files', '-z', '--', ...SNAPSHOT_PATHS],
+    cmd: ['git', ...repo.gitArgs, 'ls-files', '-z', '--', ...SNAPSHOT_PATHS],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -939,11 +952,11 @@ async function listTrackedSnapshotFiles(bun: { spawn: typeof Bun.spawn }, cwd: s
   return raw.split('\0').filter((p) => p.length > 0)
 }
 
-async function clearSkipWorktree(bun: { spawn: typeof Bun.spawn }, cwd: string): Promise<void> {
-  const files = await listTrackedSnapshotFiles(bun, cwd)
+async function clearSkipWorktree(bun: { spawn: typeof Bun.spawn }, cwd: string, repo: AgentGit): Promise<void> {
+  const files = await listTrackedSnapshotFiles(bun, cwd, repo)
   if (files.length === 0) return
   const proc = bun.spawn({
-    cmd: ['git', 'update-index', '--no-skip-worktree', '--', ...files],
+    cmd: ['git', ...repo.gitArgs, 'update-index', '--no-skip-worktree', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -951,11 +964,11 @@ async function clearSkipWorktree(bun: { spawn: typeof Bun.spawn }, cwd: string):
   await proc.exited
 }
 
-async function applySkipWorktree(bun: { spawn: typeof Bun.spawn }, cwd: string): Promise<void> {
-  const files = await listTrackedSnapshotFiles(bun, cwd)
+async function applySkipWorktree(bun: { spawn: typeof Bun.spawn }, cwd: string, repo: AgentGit): Promise<void> {
+  const files = await listTrackedSnapshotFiles(bun, cwd, repo)
   if (files.length === 0) return
   const proc = bun.spawn({
-    cmd: ['git', 'update-index', '--skip-worktree', '--', ...files],
+    cmd: ['git', ...repo.gitArgs, 'update-index', '--skip-worktree', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -430,6 +430,18 @@ describe('sandboxSchema', () => {
   })
 })
 
+describe('composeSchema', () => {
+  test('defaults compose hints when omitted', () => {
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
+    expect(parsed.compose).toEqual({ exclude: false, monorepo: false })
+  })
+
+  test('accepts the monorepo host-stage hint', () => {
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL }, compose: { monorepo: true } })
+    expect(parsed.compose).toEqual({ exclude: false, monorepo: true })
+  })
+})
+
 describe('getSandboxWritablePathSpecs', () => {
   test('folds symlinks[].to into the writable specs after writablePaths', () => {
     const parsed = configSchema.parse({

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -481,15 +481,17 @@ export type SandboxConfig = z.infer<typeof sandboxSchema>
 
 // Host-stage `typeclaw compose` knobs. `exclude: true` skips this agent during
 // compose discovery (same effect as parking it under an `_`-prefixed dir, but
-// without renaming the folder). The container never reads this block — it's a
-// pure compose CLI hint, so omitting it keeps the agent in every compose
-// operation. Namespaced under `compose` so future compose-only settings have a
-// home without crowding the top level.
+// without renaming the folder). `monorepo` is a host-stage scaffolding hint.
+// The container never reads this block — it's a pure compose CLI hint, so
+// omitting it keeps the agent in every compose operation. Namespaced under
+// `compose` so future compose-only settings have a home without crowding the
+// top level.
 export const composeSchema = z
   .object({
     exclude: z.boolean().default(false),
+    monorepo: z.boolean().default(false),
   })
-  .default({ exclude: false })
+  .default({ exclude: false, monorepo: false })
 
 export type ComposeConfig = z.infer<typeof composeSchema>
 

--- a/src/doctor/commit.test.ts
+++ b/src/doctor/commit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { commitAutoFixes, type SpawnGit } from './commit'
+
+describe('commitAutoFixes', () => {
+  test('threads gitstore args into doctor auto-fix git calls', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-doctor-commit-'))
+    try {
+      await mkdir(join(cwd, '.gitstore'))
+      const calls: string[][] = []
+      const prefix = ['--git-dir', join(cwd, '.gitstore'), '--work-tree', cwd]
+      const spawnGit: SpawnGit = async (args) => {
+        calls.push(args)
+        const command = args[prefix.length]
+        if (command === 'status') return { exitCode: 0, stdout: ' M config.json\n', stderr: '' }
+        if (command === 'rev-parse') return { exitCode: 0, stdout: 'abc123\n', stderr: '' }
+        return { exitCode: 0, stdout: '', stderr: '' }
+      }
+
+      const result = await commitAutoFixes({
+        cwd,
+        spawnGit,
+        attempts: [{ ok: true, source: 'static', name: 'config', summary: '설정 수정', changedPaths: ['config.json'] }],
+      })
+
+      expect(result.kind).toBe('committed')
+      expect(calls).toHaveLength(4)
+      for (const args of calls) expect(args.slice(0, prefix.length)).toEqual(prefix)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/doctor/commit.ts
+++ b/src/doctor/commit.ts
@@ -1,5 +1,4 @@
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { resolveAgentGit } from '@/git/resolve-agent-git'
 
 import type { CommitOutcome, FixAttempt } from './types'
 
@@ -23,13 +22,15 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
     return { kind: 'skipped', reason: 'auto-fixes reported no changed paths' }
   }
 
-  if (!existsSync(join(opts.cwd, '.git'))) {
+  const repo = resolveAgentGit(opts.cwd)
+  if (!repo) {
     return { kind: 'skipped', reason: 'agent folder is not a git repo (.git missing)' }
   }
 
   const spawnGit = opts.spawnGit ?? defaultSpawnGit
+  const git = (args: string[]): Promise<GitResult> => spawnGit([...repo.gitArgs, ...args], opts.cwd)
 
-  const filter = await filterCommittable(spawnGit, opts.cwd, requested)
+  const filter = await filterCommittable(git, requested)
   if (filter.kind === 'failed') return filter
   const pathsStaged = filter.paths
   if (pathsStaged.length === 0) {
@@ -39,18 +40,18 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
     }
   }
 
-  const add = await spawnGit(['add', '--', ...pathsStaged], opts.cwd)
+  const add = await git(['add', '--', ...pathsStaged])
   if (add.exitCode !== 0) {
     return { kind: 'failed', reason: `git add failed: ${add.stderr.trim() || `exit ${add.exitCode}`}` }
   }
 
   const message = buildCommitMessage(opts.attempts)
-  const commit = await spawnGit(['commit', '-m', message, '--only', '--', ...pathsStaged], opts.cwd)
+  const commit = await git(['commit', '-m', message, '--only', '--', ...pathsStaged])
   if (commit.exitCode !== 0) {
     return { kind: 'failed', reason: `git commit failed: ${commit.stderr.trim() || `exit ${commit.exitCode}`}` }
   }
 
-  const sha = await spawnGit(['rev-parse', 'HEAD'], opts.cwd)
+  const sha = await git(['rev-parse', 'HEAD'])
   const commitSha = sha.exitCode === 0 ? sha.stdout.trim() : ''
   return { kind: 'committed', commitSha, pathsStaged }
 }
@@ -68,13 +69,12 @@ export async function commitAutoFixes(opts: CommitOptions): Promise<CommitOutcom
 // Surface that as { kind: 'failed' } so the user sees the real cause instead
 // of a misleading 'all paths are gitignored' message.
 async function filterCommittable(
-  spawnGit: SpawnGit,
-  cwd: string,
+  spawnGit: (args: string[]) => Promise<GitResult>,
   paths: string[],
 ): Promise<{ kind: 'ok'; paths: string[] } | { kind: 'failed'; reason: string }> {
   const out: string[] = []
   for (const p of paths) {
-    const status = await spawnGit(['status', '--porcelain', '--', p], cwd)
+    const status = await spawnGit(['status', '--porcelain', '--', p])
     if (status.exitCode !== 0) {
       return {
         kind: 'failed',

--- a/src/dreams/git.test.ts
+++ b/src/dreams/git.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -18,6 +18,10 @@ async function commit(cwd: string, subject: string): Promise<void> {
   await git(['commit', '-m', subject], cwd)
 }
 
+async function relocateGitStore(cwd: string): Promise<void> {
+  await rename(join(cwd, '.git'), join(cwd, '.gitstore'))
+}
+
 beforeEach(async () => {
   repo = await mkdtemp(join(tmpdir(), 'typeclaw-dreams-git-'))
   await git(['init', '-q', '-b', 'main'], repo)
@@ -31,13 +35,11 @@ afterEach(async () => {
 })
 
 describe('resolveGitRepo', () => {
-  it('resolves the repo root from a subdirectory', async () => {
-    const sub = join(repo, 'memory', 'topics')
-    await mkdir(sub, { recursive: true })
+  it('resolves the repo root from an agent git directory', async () => {
     await writeFile(join(repo, 'README.md'), '# x\n')
     await commit(repo, 'init')
 
-    const res = await resolveGitRepo(sub)
+    const res = await resolveGitRepo(repo)
     expect(res.ok).toBe(true)
     // Resolve the root through git from both the subdirectory and the repo
     // root, then compare. Routing both sides through git applies the same
@@ -46,7 +48,31 @@ describe('resolveGitRepo', () => {
     // without depending on realpathSync matching git's normalization per-OS.
     const fromRoot = await resolveGitRepo(repo)
     expect(fromRoot.ok).toBe(true)
-    if (res.ok && fromRoot.ok) expect(res.root).toBe(fromRoot.root)
+    if (res.ok && fromRoot.ok) {
+      expect(res.root).toBe(fromRoot.root)
+      expect(res.gitArgs).toEqual([])
+    }
+  })
+
+  it('does not walk up into a parent monorepo when the agent has no git layout', async () => {
+    const child = join(repo, 'agents', 'bot')
+    await mkdir(child, { recursive: true })
+    await writeFile(join(repo, 'README.md'), '# parent\n')
+    await commit(repo, 'init parent')
+
+    const res = await resolveGitRepo(child)
+
+    expect(res).toEqual({ ok: false, reason: 'not-a-repo' })
+  })
+
+  it('resolves a relocated gitstore at the agent directory', async () => {
+    await writeFile(join(repo, 'README.md'), '# x\n')
+    await commit(repo, 'init')
+    await relocateGitStore(repo)
+
+    const res = await resolveGitRepo(repo)
+
+    expect(res).toEqual({ ok: true, root: repo, gitArgs: ['--git-dir', join(repo, '.gitstore'), '--work-tree', repo] })
   })
 
   it('reports not-a-repo outside any git tree', async () => {
@@ -76,6 +102,20 @@ describe('readDreamCommitLog', () => {
       expect(c.sha).toMatch(/^[0-9a-f]{40}$/)
       expect(c.committedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
     }
+  })
+
+  it('lists dream commits from a relocated gitstore', async () => {
+    await mkdir(join(repo, 'memory', 'streams'), { recursive: true })
+    await writeFile(join(repo, 'memory', 'streams', '2026-06-14.jsonl'), '안녕\n')
+    await commit(repo, 'dream: 1 fragment 🌙')
+    await relocateGitStore(repo)
+
+    const resolved = await resolveGitRepo(repo)
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) return
+    const commits = await readDreamCommitLog(resolved.root, {}, undefined, resolved.gitArgs)
+
+    expect(commits.map((c) => c.subject)).toEqual(['dream: 1 fragment 🌙'])
   })
 
   it('honors the limit', async () => {
@@ -124,6 +164,22 @@ describe('readDreamCommitShow', () => {
     expect(show).not.toBeNull()
     expect(show?.nameStatus).toContain('memory/topics/deploy.md')
     expect(show?.patch).toContain('+## Deploy')
+  })
+
+  it('returns name-status and patch from a relocated gitstore', async () => {
+    await mkdir(join(repo, 'memory', 'topics'), { recursive: true })
+    await writeFile(join(repo, 'memory', 'topics', 'deploy.md'), '## 배포\n\n본문\n')
+    await commit(repo, 'dream: 1 fragment 🧠')
+    await relocateGitStore(repo)
+    const resolved = await resolveGitRepo(repo)
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) return
+
+    const head = await readDreamCommitLog(resolved.root, {}, undefined, resolved.gitArgs)
+    const show = await readDreamCommitShow(resolved.root, head[0]!.sha, undefined, resolved.gitArgs)
+
+    expect(show?.nameStatus).toContain('memory/topics/deploy.md')
+    expect(show?.patch).toContain('+## 배포')
   })
 })
 

--- a/src/dreams/git.ts
+++ b/src/dreams/git.ts
@@ -1,5 +1,7 @@
+import { resolveAgentGit } from '@/git/resolve-agent-git'
+
 export type GitResult = { exitCode: number; stdout: string; stderr: string }
-export type SpawnGit = (args: string[], cwd: string) => Promise<GitResult>
+export type SpawnGit = (args: readonly string[], cwd: string) => Promise<GitResult>
 
 export type RawCommit = {
   sha: string
@@ -8,16 +10,22 @@ export type RawCommit = {
   subject: string
 }
 
-export type ResolveRepoResult = { ok: true; root: string } | { ok: false; reason: 'not-a-repo' | 'git-failed' }
+export type ResolveRepoResult =
+  | { ok: true; root: string; gitArgs: readonly string[] }
+  | { ok: false; reason: 'not-a-repo' | 'git-failed' }
 
 const FIELD_SEP = '\x1f'
 const RECORD_SEP = '\x1e'
 
 export async function resolveGitRepo(cwd: string, spawnGit: SpawnGit = defaultSpawnGit): Promise<ResolveRepoResult> {
-  const res = await spawnGit(['rev-parse', '--show-toplevel'], cwd)
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return { ok: false, reason: 'not-a-repo' }
+  if (repo.kind === 'gitstore') return { ok: true, root: cwd, gitArgs: repo.gitArgs }
+
+  const res = await spawnGit([...repo.gitArgs, 'rev-parse', '--show-toplevel'], cwd)
   if (res.exitCode === 0) {
     const root = res.stdout.trim()
-    if (root.length > 0) return { ok: true, root }
+    if (root.length > 0) return { ok: true, root, gitArgs: repo.gitArgs }
     return { ok: false, reason: 'git-failed' }
   }
   if (/not a git repository/i.test(res.stderr)) return { ok: false, reason: 'not-a-repo' }
@@ -30,6 +38,7 @@ export async function readDreamCommitLog(
   root: string,
   opts: { limit?: number } = {},
   spawnGit: SpawnGit = defaultSpawnGit,
+  gitArgs: readonly string[] = [],
 ): Promise<RawCommit[]> {
   // --grep is only a cheap pre-filter: it matches ANY line of the commit
   // message, so a non-dream commit with a `dream: ...` body line slips
@@ -39,7 +48,7 @@ export async function readDreamCommitLog(
   // result below the requested count.
   const args = ['log', '--grep=^dream: ', `--format=%H${FIELD_SEP}%h${FIELD_SEP}%cI${FIELD_SEP}%s${RECORD_SEP}`]
 
-  const res = await spawnGit(args, root)
+  const res = await spawnGit([...gitArgs, ...args], root)
   if (res.exitCode !== 0) return []
   const dreams = parseLogOutput(res.stdout).filter((c) => c.subject.startsWith(DREAM_SUBJECT_PREFIX))
   if (opts.limit !== undefined && opts.limit > 0) return dreams.slice(0, opts.limit)
@@ -62,10 +71,14 @@ export async function readDreamCommitShow(
   root: string,
   sha: string,
   spawnGit: SpawnGit = defaultSpawnGit,
+  gitArgs: readonly string[] = [],
 ): Promise<{ nameStatus: string; patch: string } | null> {
-  const nameStatus = await spawnGit(['show', '--no-color', '--find-renames', '--format=', '--name-status', sha], root)
+  const nameStatus = await spawnGit(
+    [...gitArgs, 'show', '--no-color', '--find-renames', '--format=', '--name-status', sha],
+    root,
+  )
   if (nameStatus.exitCode !== 0) return null
-  const patch = await spawnGit(['show', '--no-color', '--format=', '--unified=0', sha], root)
+  const patch = await spawnGit([...gitArgs, 'show', '--no-color', '--format=', '--unified=0', sha], root)
   if (patch.exitCode !== 0) return null
   return { nameStatus: nameStatus.stdout, patch: patch.stdout }
 }

--- a/src/dreams/index.ts
+++ b/src/dreams/index.ts
@@ -39,7 +39,12 @@ export async function listDreams(
 ): Promise<DreamEntry[]> {
   const repo = await resolveGitRepo(agentDir, spawnGit)
   if (!repo.ok) return []
-  const commits = await readDreamCommitLog(repo.root, opts.limit !== undefined ? { limit: opts.limit } : {}, spawnGit)
+  const commits = await readDreamCommitLog(
+    repo.root,
+    opts.limit !== undefined ? { limit: opts.limit } : {},
+    spawnGit,
+    repo.gitArgs,
+  )
   return commits.map((commit) => {
     const subject = parseDreamSubject(commit.subject)
     return {
@@ -58,7 +63,7 @@ export async function listDreams(
 export async function hydrateDream(agentDir: string, entry: DreamEntry, spawnGit?: SpawnGit): Promise<DreamEntry> {
   const repo = await resolveGitRepo(agentDir, spawnGit)
   if (!repo.ok) return entry
-  const show = await readDreamCommitShow(repo.root, entry.sha, spawnGit)
+  const show = await readDreamCommitShow(repo.root, entry.sha, spawnGit, repo.gitArgs)
   if (show === null) return entry
   return { ...entry, detail: parseDreamDetail(show.nameStatus, show.patch) }
 }
@@ -80,7 +85,7 @@ export async function runDreams(opts: RunDreamsOptions): Promise<RunDreamsResult
   const entries = await listDreams(opts.agentDir, opts.limit !== undefined ? { limit: opts.limit } : {}, opts.spawnGit)
   const renderOpts: RenderOptions = { color: opts.color }
 
-  if (opts.json) return runJson(opts, repo.root, entries)
+  if (opts.json) return runJson(opts, repo.root, repo.gitArgs, entries)
 
   if (entries.length === 0) {
     opts.stdout('No dreams yet. The dreaming subagent commits here after it consolidates memory.')
@@ -115,16 +120,26 @@ async function runInteractiveLoop(
   }
 }
 
-async function runJson(opts: RunDreamsOptions, root: string, entries: DreamEntry[]): Promise<RunDreamsResult> {
+async function runJson(
+  opts: RunDreamsOptions,
+  root: string,
+  gitArgs: readonly string[],
+  entries: DreamEntry[],
+): Promise<RunDreamsResult> {
   for (const entry of entries) {
-    const final = opts.details ? await hydrateEntryFromRoot(root, entry, opts.spawnGit) : entry
+    const final = opts.details ? await hydrateEntryFromRoot(root, gitArgs, entry, opts.spawnGit) : entry
     opts.stdout(JSON.stringify(toJsonShape(final)))
   }
   return { ok: true, exitCode: 0 }
 }
 
-async function hydrateEntryFromRoot(root: string, entry: DreamEntry, spawnGit?: SpawnGit): Promise<DreamEntry> {
-  const show = await readDreamCommitShow(root, entry.sha, spawnGit)
+async function hydrateEntryFromRoot(
+  root: string,
+  gitArgs: readonly string[],
+  entry: DreamEntry,
+  spawnGit?: SpawnGit,
+): Promise<DreamEntry> {
+  const show = await readDreamCommitShow(root, entry.sha, spawnGit, gitArgs)
   if (show === null) return entry
   return { ...entry, detail: parseDreamDetail(show.nameStatus, show.patch) }
 }

--- a/src/git/no-bare-git-spawn.test.ts
+++ b/src/git/no-bare-git-spawn.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const COMMITTER_FILES = [
+  'src/bundled-plugins/backup/runner.ts',
+  'src/bundled-plugins/memory/dreaming.ts',
+  'src/git/system-commit.ts',
+  'src/git/reconcile-ignored.ts',
+  'src/doctor/commit.ts',
+  'src/agent/git-nudge.ts',
+  'src/dreams/git.ts',
+] as const
+
+describe('committer git layout resolution', () => {
+  test('retrofitted committers import resolveAgentGit', async () => {
+    for (const file of COMMITTER_FILES) {
+      const source = await readFile(join(process.cwd(), file), 'utf8')
+      expect(source, file).toContain('resolveAgentGit')
+    }
+  })
+})

--- a/src/git/no-bare-git-spawn.test.ts
+++ b/src/git/no-bare-git-spawn.test.ts
@@ -4,11 +4,13 @@ import { join } from 'node:path'
 
 const COMMITTER_FILES = [
   'src/bundled-plugins/backup/runner.ts',
+  'src/bundled-plugins/backup/index.ts',
   'src/bundled-plugins/memory/dreaming.ts',
   'src/git/system-commit.ts',
   'src/git/reconcile-ignored.ts',
   'src/doctor/commit.ts',
   'src/agent/git-nudge.ts',
+  'src/bundled-plugins/guard/policies/uncommitted-changes.ts',
   'src/dreams/git.ts',
 ] as const
 

--- a/src/git/reconcile-ignored.test.ts
+++ b/src/git/reconcile-ignored.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdtemp, mkdir, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,9 +9,14 @@ import { buildGitignore } from '@/init/gitignore'
 import { commitGitignoreWithUntracks, untrackTrulyIgnoredFiles } from './reconcile-ignored'
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
-  const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const gitArgs = existsSync(join(cwd, '.gitstore')) ? ['--git-dir', join(cwd, '.gitstore'), '--work-tree', cwd] : []
+  const proc = Bun.spawn({ cmd: ['git', ...gitArgs, ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
   await proc.exited
   return (await new Response(proc.stdout).text()).trim()
+}
+
+async function relocateGitStore(cwd: string): Promise<void> {
+  await rename(join(cwd, '.git'), join(cwd, '.gitstore'))
 }
 
 async function gitInit(cwd: string): Promise<void> {
@@ -146,6 +152,26 @@ describe('untrackTrulyIgnoredFiles', () => {
 
       expect(untracked).toContain('scratch/note.txt')
       expect(await isTracked(dir, 'scratch/note.txt')).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('untracks files through a relocated gitstore', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await relocateGitStore(dir)
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+
+      expect(untracked).toContain('public/review.json')
+      expect(await isTracked(dir, 'public/review.json')).toBe(false)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -355,6 +381,29 @@ describe('commitGitignoreWithUntracks', () => {
       expect(committed).toBe(false)
       expect(await runGit(dir, ['diff', '--cached', '--name-only'])).toContain('sessions/history.jsonl')
       expect(await isTracked(dir, 'sessions/history.jsonl')).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('commits .gitignore and untracks through a relocated gitstore', async () => {
+    const dir = await makeRepo()
+    try {
+      await gitInit(dir)
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public', 'review.json'), '{}\n')
+      await writeFile(join(dir, '.gitignore'), 'old\n')
+      await runGit(dir, ['add', '.'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await relocateGitStore(dir)
+
+      await writeFile(join(dir, '.gitignore'), buildGitignore())
+      const { untracked } = await untrackTrulyIgnoredFiles(dir)
+      const committed = await commitGitignoreWithUntracks(dir, '.gitignore', untracked, 'Untrack newly-ignored files')
+
+      expect(committed).toBe(true)
+      expect(await runGit(dir, ['status', '--porcelain'])).toBe('')
+      expect(await isTracked(dir, 'public/review.json')).toBe(false)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/src/git/reconcile-ignored.ts
+++ b/src/git/reconcile-ignored.ts
@@ -1,9 +1,10 @@
-import { existsSync } from 'node:fs'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { SYSTEM_MANAGED_ROOTS, TRULY_IGNORED_PATTERNS } from '@/init/gitignore'
+
+import { type AgentGit, resolveAgentGit } from './resolve-agent-git'
 
 export type UntrackResult = { untracked: string[] }
 
@@ -26,7 +27,8 @@ export async function untrackTrulyIgnoredFiles(
 
   const bun = getBun()
   if (!bun) return empty
-  if (!existsSync(join(cwd, '.git'))) return empty
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return empty
 
   const patterns = [...TRULY_IGNORED_PATTERNS, ...customAppend]
   let excludeDir: string | null = null
@@ -35,11 +37,11 @@ export async function untrackTrulyIgnoredFiles(
     const excludeFile = join(excludeDir, 'exclude')
     await writeFile(excludeFile, `${patterns.join('\n')}\n`)
 
-    const candidates = await listTrackedIgnored(bun, cwd, excludeFile)
+    const candidates = await listTrackedIgnored(bun, cwd, repo.gitArgs, excludeFile)
     const removable = candidates.filter((path) => !isSystemManaged(path))
     if (removable.length === 0) return empty
 
-    const removed = await gitRmCached(bun, cwd, removable)
+    const removed = await gitRmCached(bun, cwd, repo.gitArgs, removable)
     return { untracked: removed }
   } catch {
     return empty
@@ -76,6 +78,7 @@ export type CommitGitignoreDeps = {
   commitAtomic?: (
     bun: BunLike,
     cwd: string,
+    repo: AgentGit,
     gitignoreFile: string,
     untracked: readonly string[],
     message: string,
@@ -91,39 +94,41 @@ export async function commitGitignoreWithUntracks(
 ): Promise<boolean> {
   const bun = getBun()
   if (!bun) return false
-  if (!existsSync(join(cwd, '.git'))) return false
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return false
   if (untracked.length === 0) return false
 
   const commitAtomic = deps.commitAtomic ?? commitViaTempIndex
-  if (!(await run(bun, cwd, ['add', '--', gitignoreFile]))) return false
-  if (await commitAtomic(bun, cwd, gitignoreFile, untracked, message)) return true
-  return await commitRealIndexIfExactlyOurs(bun, cwd, gitignoreFile, untracked, message)
+  if (!(await run(bun, cwd, repo.gitArgs, ['add', '--', gitignoreFile]))) return false
+  if (await commitAtomic(bun, cwd, repo, gitignoreFile, untracked, message)) return true
+  return await commitRealIndexIfExactlyOurs(bun, cwd, repo.gitArgs, gitignoreFile, untracked, message)
 }
 
 async function commitViaTempIndex(
   bun: BunLike,
   cwd: string,
+  repo: AgentGit,
   gitignoreFile: string,
   untracked: readonly string[],
   message: string,
 ): Promise<boolean> {
   let indexDir: string | null = null
   try {
-    const parent = (await capture(bun, cwd, ['rev-parse', '--verify', 'HEAD'])).trim()
+    const parent = (await capture(bun, cwd, repo.gitArgs, ['rev-parse', '--verify', 'HEAD'])).trim()
     if (parent.length === 0) return false
 
     indexDir = await mkdtemp(join(tmpdir(), 'typeclaw-untrack-idx-'))
     const env = { ...process.env, GIT_INDEX_FILE: join(indexDir, 'index') }
-    if (!(await run(bun, cwd, ['read-tree', parent], env))) return false
-    if (!(await run(bun, cwd, ['add', '--', gitignoreFile], env))) return false
-    if (!(await forceRemove(bun, cwd, untracked, env))) return false
+    if (!(await run(bun, cwd, repo.gitArgs, ['read-tree', parent], env))) return false
+    if (!(await run(bun, cwd, repo.gitArgs, ['add', '--', gitignoreFile], env))) return false
+    if (!(await forceRemove(bun, cwd, repo.gitArgs, untracked, env))) return false
 
-    const tree = (await capture(bun, cwd, ['write-tree'], env)).trim()
+    const tree = (await capture(bun, cwd, repo.gitArgs, ['write-tree'], env)).trim()
     if (tree.length === 0) return false
-    const commit = (await capture(bun, cwd, ['commit-tree', tree, '-p', parent, '-m', message])).trim()
+    const commit = (await capture(bun, cwd, repo.gitArgs, ['commit-tree', tree, '-p', parent, '-m', message])).trim()
     if (commit.length === 0) return false
 
-    return await run(bun, cwd, ['update-ref', '-m', message, 'HEAD', commit, parent])
+    return await run(bun, cwd, repo.gitArgs, ['update-ref', '-m', message, 'HEAD', commit, parent])
   } catch {
     return false
   } finally {
@@ -134,11 +139,12 @@ async function commitViaTempIndex(
 async function commitRealIndexIfExactlyOurs(
   bun: BunLike,
   cwd: string,
+  gitArgs: readonly string[],
   gitignoreFile: string,
   untracked: readonly string[],
   message: string,
 ): Promise<boolean> {
-  const staged = (await capture(bun, cwd, ['diff', '--cached', '--name-only', '-z']))
+  const staged = (await capture(bun, cwd, gitArgs, ['diff', '--cached', '--name-only', '-z']))
     .split('\0')
     .filter((entry) => entry.length > 0)
   if (staged.length === 0) return false
@@ -146,7 +152,7 @@ async function commitRealIndexIfExactlyOurs(
   const expected = new Set([gitignoreFile, ...untracked])
   if (staged.length !== expected.size || !staged.every((path) => expected.has(path))) return false
 
-  return await run(bun, cwd, ['commit', '-m', message])
+  return await run(bun, cwd, gitArgs, ['commit', '-m', message])
 }
 
 // Hardcoded fail-closed guard: even if a custom git.ignore.append pattern
@@ -157,9 +163,14 @@ function isSystemManaged(path: string): boolean {
   return SYSTEM_MANAGED_ROOTS.some((root) => path === root.replace(/\/$/, '') || path.startsWith(root))
 }
 
-async function listTrackedIgnored(bun: BunLike, cwd: string, excludeFile: string): Promise<string[]> {
+async function listTrackedIgnored(
+  bun: BunLike,
+  cwd: string,
+  gitArgs: readonly string[],
+  excludeFile: string,
+): Promise<string[]> {
   const proc = bun.spawn({
-    cmd: ['git', 'ls-files', '-z', '-c', '-i', '--exclude-from', excludeFile],
+    cmd: ['git', ...gitArgs, 'ls-files', '-z', '-c', '-i', '--exclude-from', excludeFile],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -169,9 +180,9 @@ async function listTrackedIgnored(bun: BunLike, cwd: string, excludeFile: string
   return raw.split('\0').filter((entry) => entry.length > 0)
 }
 
-async function gitRmCached(bun: BunLike, cwd: string, files: string[]): Promise<string[]> {
+async function gitRmCached(bun: BunLike, cwd: string, gitArgs: readonly string[], files: string[]): Promise<string[]> {
   const proc = bun.spawn({
-    cmd: ['git', 'rm', '--cached', '-q', '--', ...files],
+    cmd: ['git', ...gitArgs, 'rm', '--cached', '-q', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -182,22 +193,40 @@ async function gitRmCached(bun: BunLike, cwd: string, files: string[]): Promise<
 
 type GitEnv = Record<string, string | undefined>
 
-async function run(bun: BunLike, cwd: string, args: string[], env?: GitEnv): Promise<boolean> {
-  const proc = bun.spawn({ cmd: ['git', ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+async function run(
+  bun: BunLike,
+  cwd: string,
+  gitArgs: readonly string[],
+  args: readonly string[],
+  env?: GitEnv,
+): Promise<boolean> {
+  const proc = bun.spawn({ cmd: ['git', ...gitArgs, ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
   return (await proc.exited) === 0
 }
 
-async function capture(bun: BunLike, cwd: string, args: string[], env?: GitEnv): Promise<string> {
-  const proc = bun.spawn({ cmd: ['git', ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+async function capture(
+  bun: BunLike,
+  cwd: string,
+  gitArgs: readonly string[],
+  args: readonly string[],
+  env?: GitEnv,
+): Promise<string> {
+  const proc = bun.spawn({ cmd: ['git', ...gitArgs, ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
   if ((await proc.exited) !== 0) return ''
   return await new Response(proc.stdout).text()
 }
 
 // --force-remove drops the index entry regardless of the file existing on disk;
 // the NUL-delimited stdin form is safe for paths with spaces/newlines.
-async function forceRemove(bun: BunLike, cwd: string, files: readonly string[], env: GitEnv): Promise<boolean> {
+async function forceRemove(
+  bun: BunLike,
+  cwd: string,
+  gitArgs: readonly string[],
+  files: readonly string[],
+  env: GitEnv,
+): Promise<boolean> {
   const proc = bun.spawn({
-    cmd: ['git', 'update-index', '-z', '--force-remove', '--stdin'],
+    cmd: ['git', ...gitArgs, 'update-index', '-z', '--force-remove', '--stdin'],
     cwd,
     env,
     stdin: new TextEncoder().encode(files.join('\0')),

--- a/src/git/resolve-agent-git.test.ts
+++ b/src/git/resolve-agent-git.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { resolveAgentGit } from './resolve-agent-git'
+
+function tempAgent(): string {
+  return mkdtempSync(join(tmpdir(), 'typeclaw-agent-git-'))
+}
+
+describe('resolveAgentGit', () => {
+  test('returns dotgit with empty args when only .git exists', () => {
+    const dir = tempAgent()
+    try {
+      mkdirSync(join(dir, '.git'))
+      expect(resolveAgentGit(dir)).toEqual({ kind: 'dotgit', gitArgs: [] })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns gitstore args when only .gitstore exists', () => {
+    const dir = tempAgent()
+    try {
+      mkdirSync(join(dir, '.gitstore'))
+      expect(resolveAgentGit(dir)).toEqual({
+        kind: 'gitstore',
+        gitArgs: ['--git-dir', join(dir, '.gitstore'), '--work-tree', dir],
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns null when neither git layout exists', () => {
+    const dir = tempAgent()
+    try {
+      expect(resolveAgentGit(dir)).toBeNull()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('prefers .git when both layouts exist', () => {
+    const dir = tempAgent()
+    try {
+      mkdirSync(join(dir, '.git'))
+      mkdirSync(join(dir, '.gitstore'))
+      expect(resolveAgentGit(dir)).toEqual({ kind: 'dotgit', gitArgs: [] })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/git/resolve-agent-git.ts
+++ b/src/git/resolve-agent-git.ts
@@ -1,0 +1,12 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type AgentGit = { kind: 'dotgit'; gitArgs: readonly [] } | { kind: 'gitstore'; gitArgs: readonly string[] }
+
+export function resolveAgentGit(cwd: string): AgentGit | null {
+  if (existsSync(join(cwd, '.git'))) return { kind: 'dotgit', gitArgs: [] }
+  if (existsSync(join(cwd, '.gitstore'))) {
+    return { kind: 'gitstore', gitArgs: ['--git-dir', join(cwd, '.gitstore'), '--work-tree', cwd] }
+  }
+  return null
+}

--- a/src/git/system-commit.test.ts
+++ b/src/git/system-commit.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { commitSystemFile, commitSystemFileSync } from './system-commit'
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
-  const proc = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const gitArgs = existsSync(join(cwd, '.gitstore')) ? ['--git-dir', join(cwd, '.gitstore'), '--work-tree', cwd] : []
+  const proc = Bun.spawn({ cmd: ['git', ...gitArgs, ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
   await proc.exited
   return (await new Response(proc.stdout).text()).trim()
+}
+
+async function relocateGitStore(cwd: string): Promise<void> {
+  await rename(join(cwd, '.git'), join(cwd, '.gitstore'))
 }
 
 async function gitInit(cwd: string): Promise<void> {
@@ -68,6 +73,25 @@ describe('commitSystemFile (async)', () => {
       await writeFile(join(dir, 'typeclaw.json'), '{}\n')
       await commitSystemFile(dir, 'typeclaw.json', 'msg')
       expect(existsSync(join(dir, '.git'))).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('commits a dirty tracked file through a relocated gitstore', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sys-commit-async-gitstore-'))
+    try {
+      await gitInit(dir)
+      await writeFile(join(dir, 'typeclaw.json'), '{"message":"안녕"}\n')
+      await runGit(dir, ['add', 'typeclaw.json'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await relocateGitStore(dir)
+      await writeFile(join(dir, 'typeclaw.json'), '{"message":"안녕하세요"}\n')
+
+      await commitSystemFile(dir, 'typeclaw.json', 'update typeclaw.json')
+
+      expect(await runGit(dir, ['log', '-1', '--format=%s'])).toBe('update typeclaw.json')
+      expect(await runGit(dir, ['show', 'HEAD:typeclaw.json'])).toBe('{"message":"안녕하세요"}')
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/src/git/system-commit.ts
+++ b/src/git/system-commit.ts
@@ -1,5 +1,4 @@
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { resolveAgentGit } from './resolve-agent-git'
 
 // Commits TypeClaw-owned tracked files (.gitignore, package.json,
 // typeclaw.json) if any are dirty in git. Skips silently when the agent
@@ -24,10 +23,11 @@ export async function commitSystemFile(cwd: string, file: string | readonly stri
 
   const bun = getBunAsync()
   if (!bun) return
-  if (!existsSync(join(cwd, '.git'))) return
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return
 
   const status = bun.spawn({
-    cmd: ['git', 'status', '--porcelain', '--', ...files],
+    cmd: ['git', ...repo.gitArgs, 'status', '--porcelain', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -36,11 +36,11 @@ export async function commitSystemFile(cwd: string, file: string | readonly stri
   const dirty = (await new Response(status.stdout).text()).trim().length > 0
   if (!dirty) return
 
-  const add = bun.spawn({ cmd: ['git', 'add', '--', ...files], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const add = bun.spawn({ cmd: ['git', ...repo.gitArgs, 'add', '--', ...files], cwd, stdout: 'pipe', stderr: 'pipe' })
   if ((await add.exited) !== 0) return
 
   const commit = bun.spawn({
-    cmd: ['git', 'commit', '-m', message, '--only', '--', ...files],
+    cmd: ['git', ...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -69,10 +69,11 @@ export function commitSystemFileSync(cwd: string, file: string | readonly string
 
   const bun = getBunSync()
   if (!bun) return
-  if (!existsSync(join(cwd, '.git'))) return
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return
 
   const status = bun.spawnSync({
-    cmd: ['git', 'status', '--porcelain', '--', ...files],
+    cmd: ['git', ...repo.gitArgs, 'status', '--porcelain', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -80,11 +81,16 @@ export function commitSystemFileSync(cwd: string, file: string | readonly string
   if (status.exitCode !== 0) return
   if (new TextDecoder().decode(status.stdout).trim().length === 0) return
 
-  const add = bun.spawnSync({ cmd: ['git', 'add', '--', ...files], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const add = bun.spawnSync({
+    cmd: ['git', ...repo.gitArgs, 'add', '--', ...files],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
   if (add.exitCode !== 0) return
 
   bun.spawnSync({
-    cmd: ['git', 'commit', '-m', message, '--only', '--', ...files],
+    cmd: ['git', ...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...files],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/src/init/gitignore.ts
+++ b/src/init/gitignore.ts
@@ -5,6 +5,7 @@ export const GITIGNORE_FILE = '.gitignore'
 // Match scope for the untrack reconciler (src/git/reconcile-ignored.ts): when a
 // tracked file later matches one of these, start() removes it from the index.
 export const TRULY_IGNORED_PATTERNS = [
+  '.gitstore/',
   '.env',
   '.env.local',
   'secrets.json',
@@ -28,8 +29,9 @@ export const SYSTEM_MANAGED_ROOTS = ['sessions/', 'memory/', 'channels/', 'todo/
 export function buildGitignore(config: GitignoreConfig = { append: [] }): string {
   const customEntries = renderCustomGitignoreEntries(config.append)
 
-  return `${customEntries}# Truly ignored: secrets, runtime junk, the agent's free-write zone, and
-# regenerated-on-every-start system files. Never enter git history.
+  return `${customEntries}# Truly ignored: secrets, runtime junk, the agent's free-write zone, the
+# relocated monorepo-member git DB, and regenerated-on-every-start system files.
+# Never enter git history.
 #
 # Dockerfile is rewritten from the typeclaw CLI template on every \`typeclaw
 # start\` (see src/init/dockerfile.ts), so tracking it would only produce

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -979,6 +979,7 @@ describe('scaffold', () => {
 
     const gitignore = await readFile(join(root, '.gitignore'), 'utf8')
     expect(gitignore).toContain('.env')
+    expect(gitignore).toContain('.gitstore/')
     expect(gitignore).toContain('sessions/')
     expect(gitignore).toContain('memory/')
     expect(gitignore).toMatch(/^workspace\/$/m)
@@ -997,6 +998,14 @@ describe('scaffold', () => {
     expect(systemManagedHeader).toBeGreaterThan(-1)
     expect(typeclawIdx).toBeGreaterThan(trulyIgnoredHeader)
     expect(typeclawIdx).toBeLessThan(systemManagedHeader)
+  })
+
+  test('gitignores relocated gitstore before system-managed roots', () => {
+    const gitignore = buildGitignore({ append: [] })
+    const gitstoreIdx = gitignore.indexOf('\n.gitstore/\n')
+    const systemManagedHeader = gitignore.indexOf('# System-managed:')
+    expect(gitstoreIdx).toBeGreaterThan(-1)
+    expect(gitstoreIdx).toBeLessThan(systemManagedHeader)
   })
 
   test('buildGitignore includes custom entries from git.ignore.append before managed entries', () => {


### PR DESCRIPTION
## Background

Today every typeclaw agent owns its own `.git` directory. That means N agents = N GitHub repos. A user running a fleet of domain-specific agents ends up with a cluttered GitHub account and no single place to browse the full agent tree.

The end goal is to let N agents live as plain subfolders inside one parent monorepo with one remote and a browseable directory tree. The obstacle: when Git sees a subdirectory that contains a `.git/` folder, it treats it as a gitlink (submodule) rather than plain files. To break that association the agent's git database must live somewhere other than `.git/`.

The chosen location is `.gitstore/`. A directory named `.gitstore` is invisible to a parent repo — no gitlink, no submodule — but it still lives inside the agent folder's Docker bind mount (`/agent`), so in-container committers can reach it without a host-side commit broker or a cross-container shared-index. Switching between layouts is a pure directory rename — no database surgery needed.

## Summary

**`resolveAgentGit`** in `src/git/resolve-agent-git.ts` is the single source of truth for an agent's git layout. It probes the agent directory at call time:

- `.git` present → returns empty args `[]` (no extra flags; identical to today's behavior)
- `.gitstore` present → returns `["--git-dir", ".gitstore", "--work-tree", "."]`
- neither → returns `null` (callers no-op, same as before)

`.git` takes precedence over `.gitstore`, so any existing agent is byte-for-byte identical to today.

`core.worktree` is intentionally NOT persisted. It is absolute and would break across the host path vs the container path (`/agent`). The `--work-tree` flag is injected per-call instead.

**Every git committer** now resolves layout and threads those args into each invocation:

- backup runner: commit, push, fetch, rebase
- dreaming memory snapshot: commit, log readers, `rev-parse --show-toplevel`
- `system-commit` (async + sync variants)
- `reconcile-ignored` untrack plumbing
- doctor auto-fix commit
- session-start git-nudge

`src/dreams/git.ts` previously ran `rev-parse --show-toplevel` unguarded. For a `.gitstore` agent inside a parent monorepo that call would walk UP and read the parent repo's history. It now returns the agent dir directly for `.gitstore` layouts and threads git args through all dream log/show readers.

A guard test in `src/git/no-bare-git-spawn.test.ts` asserts that each retrofitted committer file imports `resolveAgentGit`, making it a compile-time backstop against reintroducing a layout-blind bare git spawn.

**`.gitignore`** — `.gitstore/` is added to the generated `.gitignore` (local-only, never tracked by the agent itself).

**`compose.monorepo`** — a boolean added to the config schema as a host-stage scaffolding hint. Classified `'ignored'` in `FIELD_EFFECTS`: the container never reads it; the on-disk `.gitstore` directory is the runtime signal. It exists so `typeclaw compose` commands (follow-up PRs) have a typed field to set when adopting an agent into a monorepo.

## What this does NOT do

- `typeclaw compose init` / `adopt` / `eject` commands — follow-up.
- Parent-monorepo `.gitignore` generation — follow-up.
- `discoverAgents` scanning for nested `agents/*` layout — follow-up.
- `compose doctor` layout cross-checks — follow-up.
- Container env-var injection for explicit fleet awareness — follow-up.
- Any behavior change for standalone `.git` agents — resolver returns empty args; all git calls are byte-identical.

## Review notes

**Load-bearing invariant:** `resolveAgentGit` returns `[]` for `.git` and `null` for neither. The empty-args case means the caller's git invocation gets no extra flags — the only change in the hot path is one `fs.existsSync` probe per call. The `null` case short-circuits the same way callers already handled the "no git" case.

**`rev-parse --show-toplevel` in `src/dreams/git.ts`:** This was the highest-risk unguarded call. For a `.gitstore` agent inside a parent monorepo, that command walks UP the tree and returns the parent repo root, causing dream log readers to find no relevant commits. The fix returns `cwd` directly for `.gitstore` layouts and threads the resolved git args through `git log` / `git show` in the dreaming path.

**Why `.gitstore` and not `.git-store` or `_git`?** `.gitstore` is dot-prefixed (hidden on Unix), unlikely to collide with real project files, and unambiguous in path-globs. It is easy to explain: "the store for git data."

**`compose.monorepo` as `'ignored'`:** The container must never branch on this field — doing so would couple the runtime to a host-stage concept. The `.gitstore` presence check is the runtime signal; `compose.monorepo` is the host-side scaffolding flag. Classified `'ignored'` so `getConfig()` live-reload cycles don't react to it.

**Guard test:** `no-bare-git-spawn.test.ts` checks that each committer module imports `resolveAgentGit`. This is a structural/import-level check — it exists solely to ensure a future refactor doesn't silently drop the resolver and reintroduce a layout-blind spawn.

**Multi-language test coverage:** committer tests include Korean memory and commit content per the repo's multi-language testing rule.

Full suite: 9342 pass / 0 fail. `bun run typecheck` clean. `bun run lint` 0 errors (65 pre-existing warnings, none in changed files). `bun run format:check` clean.