### PR TITLE
cli: mention Discord guild members intent

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1116,7 +1116,7 @@ async function promptDiscordToken(): Promise<string> {
     [
       'https://discord.com/developers/applications',
       'New Application → Bot tab → Reset Token.',
-      'Enable the MESSAGE CONTENT intent.',
+      'Under Privileged Gateway Intents, enable MESSAGE CONTENT and GUILD MEMBERS.',
     ].join('\n'),
     'Get a Discord bot token',
   )

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1429,7 +1429,7 @@ async function runDiscordFlow(): Promise<StepResult<CollectedInputs['channelSecr
     [
       'https://discord.com/developers/applications',
       'New Application → Bot tab → Reset Token.',
-      'Enable the MESSAGE CONTENT intent.',
+      'Under Privileged Gateway Intents, enable MESSAGE CONTENT and GUILD MEMBERS.',
     ].join('\n'),
     'Get a Discord bot token',
   )


### PR DESCRIPTION
## Background

The Discord bot setup prompt currently tells users to enable only the MESSAGE CONTENT privileged intent. Guild channel setups also need GUILD MEMBERS enabled so member/user handling works reliably once the bot is installed in a server.

## Summary

Update both Discord token guidance prompts to point users at Privileged Gateway Intents and tell them to enable MESSAGE CONTENT and GUILD MEMBERS together.

## Preview

The setup note now says:

> Under Privileged Gateway Intents, enable MESSAGE CONTENT and GUILD MEMBERS.

## What this does NOT do

This only changes the CLI guidance text. It does not change Discord adapter behavior or permission validation.

## Review notes

The same copy appears in both the standalone channel setup flow and the init Discord flow; both were updated to stay consistent.
