### PR TITLE
cli: resume init from saved progress

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1361,8 +1361,9 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
   })
 
   test('prompts to resume when a checkpoint exists and seeds prior answers', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
     const existing = checkpointFromSelections({
-      cwd: '/agent',
+      cwd,
       vendorId: 'fireworks',
       providerId: 'fireworks',
       modelRef: FIREWORKS_REF as Parameters<typeof checkpointFromSelections>[0]['modelRef'],
@@ -1372,13 +1373,19 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
     const { store } = inMemoryStore(existing)
 
     let confirmCalls = 0
+    let vendorCalls = 0
     let modelInitial: string | undefined
     await collectWizardInputs(
-      '/agent',
+      cwd,
       basePrompts({
         confirmResumeCheckpoint: async () => {
           confirmCalls += 1
           return 'resume'
+        },
+        readExistingApiKey: async () => 'sk_existing',
+        pickVendor: async () => {
+          vendorCalls += 1
+          return { kind: 'value', value: 'fireworks' as KnownProviderVendorId }
         },
         pickModel: async (_options, _providerId, initial) => {
           modelInitial = initial
@@ -1389,7 +1396,48 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
     )
 
     expect(confirmCalls).toBe(1)
+    expect(vendorCalls).toBe(0)
     expect(modelInitial).toBe(FIREWORKS_REF)
+  })
+
+  test('resume reuses existing provider and channel secrets without credential prompts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
+    const existing = checkpointFromSelections({
+      cwd,
+      vendorId: 'fireworks',
+      providerId: 'fireworks',
+      modelRef: FIREWORKS_REF as Parameters<typeof checkpointFromSelections>[0]['modelRef'],
+      authMethod: 'api-key',
+      channelChoice: 'discord',
+    })
+    const { store } = inMemoryStore(existing)
+
+    let askApiKeyCalls = 0
+    let runChannelFlowCalls = 0
+    const result = await collectWizardInputs(
+      cwd,
+      basePrompts({
+        confirmResumeCheckpoint: async () => 'resume',
+        readExistingApiKey: async () => 'sk_existing',
+        pickChannel: async () => ({ kind: 'value', value: 'discord' }),
+        hasExistingChannelSecrets: async () => true,
+        askApiKey: async (provider) => {
+          askApiKeyCalls += 1
+          return { kind: 'value', value: `fresh-${provider.name}` }
+        },
+        runChannelFlow: async () => {
+          runChannelFlowCalls += 1
+          return { kind: 'value', value: { discordBotToken: 'fresh-discord' } }
+        },
+      }),
+      { checkpointStore: store },
+    )
+
+    expect(askApiKeyCalls).toBe(0)
+    expect(runChannelFlowCalls).toBe(0)
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_existing' })
+    expect(result.reuseExistingChannel).toBe(true)
+    expect(result.channelSecrets).toEqual({})
   })
 
   test('start-over discards the existing checkpoint without seeding', async () => {
@@ -1441,9 +1489,10 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
 
   test('sanitizes a stale provider out before the resume prompt sees it', async () => {
     // given: a checkpoint whose provider no longer exists in the live catalog
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
     const stale = {
       version: 1 as const,
-      cwd: '/agent',
+      cwd,
       updatedAt: 'now',
       vendorId: 'made-up-vendor',
       providerId: 'made-up-provider',
@@ -1453,7 +1502,7 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
 
     let seen: ReturnType<typeof checkpointFromSelections> | undefined
     await collectWizardInputs(
-      '/agent',
+      cwd,
       basePrompts({
         confirmResumeCheckpoint: async (checkpoint) => {
           seen = checkpoint

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -554,6 +554,7 @@ export async function collectWizardInputs(
       const decision = await prompts.confirmResumeCheckpoint(sanitized)
       if (decision === 'resume') {
         seedWizardState(state, sanitized)
+        step = resumeStep(state)
       } else {
         await checkpointStore.clear(cwd)
       }
@@ -1028,6 +1029,12 @@ function seedWizardState(state: WizardState, checkpoint: WizardAnswerCheckpointV
 function resolveModelOption(catalog: WizardState['catalog'], ref: string | undefined): ModelOption | undefined {
   if (catalog === undefined || ref === undefined) return undefined
   return catalog.options.find((option) => option.ref === ref)
+}
+
+function resumeStep(state: WizardState): StepId {
+  if (state.providerId !== undefined) return 'reuse-existing-key'
+  if (state.vendorId !== undefined) return 'pick-provider-variant'
+  return 'pick-vendor'
 }
 
 function projectCheckpoint(cwd: string, state: WizardState): WizardAnswerCheckpointV1 {


### PR DESCRIPTION
## Background

Resuming an unfinished `typeclaw init` loaded prior wizard answers only as prompt defaults. That meant a checkpoint could say the previous provider/channel selections would be reused, but the wizard still restarted at the first provider prompt and eventually re-entered the credential collection path instead of taking the existing-secret short-circuits.

The root cause was that `seedWizardState()` populated the saved selections but the state machine always kept `step = 'pick-vendor'` after accepting the resume prompt.

## Summary

On resume, choose the first step from the seeded checkpoint instead of always restarting at the vendor picker:

- provider present → resume at `reuse-existing-key`, so existing API key/OAuth detection can run before any credential prompt
- vendor-only checkpoint → resume at provider variant selection
- otherwise → keep the normal vendor picker

This preserves the existing credential reuse logic rather than duplicating secret-handling paths. The tests now cover both the prompt fast-forward and a provider+channel resume where neither provider nor channel credentials are re-requested.

## What this does NOT do

It does not change `--reset`; reset still ignores checkpoints and existing credentials. It also does not skip model/channel confirmation prompts beyond routing through the existing saved-answer defaults and reuse checks.

## Review notes

The load-bearing change is in `collectWizardInputs()` immediately after `seedWizardState()`: `resumeStep(state)` moves the state machine to the saved-progress boundary while still letting the existing `reuse-existing-key` and `reuse-existing-channel` cases own secret reuse.

Tested with:

- `bun test --parallel ./src/cli/init.test.ts`
- `bun run lint src/cli/init.ts src/cli/init.test.ts`
- `bun run format:check src/cli/init.ts src/cli/init.test.ts`
