### PR TITLE
channels: de-flake idle hook watchdog test

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7099,20 +7099,17 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
 
     // when a first message engages the bot and a second arrives after the
     // idle-hook watchdog should have fired
-    const start = Date.now()
     await router.route(inbound({ text: 'first' }))
     await router.__testing!.flushDebounce(KEY)
     await router.route(inbound({ externalMessageId: 'm2', text: 'second' }))
     await router.__testing!.flushDebounce(KEY)
-    const elapsed = Date.now() - start
 
-    // then both prompts ran (the second is the real proof — without the
-    // watchdog the drain loop would still be parked inside the hung idle
-    // hook and `live.draining` would block enqueue from firing a new drain),
-    // the run completed within the watchdog window, and a warning naming
-    // the timeout was emitted so an operator can attribute the hang
+    // then both prompts ran. The second prompt is the real proof — without the
+    // watchdog the drain loop would still be parked inside the hung idle hook
+    // and `live.draining` would block enqueue from firing a new drain. Avoid a
+    // wall-clock ceiling here: Windows runners can stall the Bun event loop long
+    // enough to make timing assertions flaky even though the watchdog worked.
     expect(sessions[0]!.prompts).toHaveLength(2)
-    expect(elapsed).toBeLessThan(2000)
     const idleWarn = logs.find((l) => l.includes('warn:[channels]') && l.includes('session.idle hook threw'))
     expect(idleWarn).toBeDefined()
     expect(idleWarn).toMatch(/session\.idle timed out after 30ms/)


### PR DESCRIPTION
## Background

The Windows CI job failed in `ChannelRouter plugin lifecycle hooks > a hung session.idle hook does not wedge the drain loop forever` because the test asserted the whole scenario completed in under 2 seconds. The behavior under test was correct: the second prompt ran after the idle-hook watchdog fired, and the warning named the timeout. On the Windows runner, unrelated Bun event-loop stalls pushed the wall-clock measurement to ~2200ms, making the test flaky.

## Summary

This keeps the load-bearing assertions and removes the wall-clock ceiling. The second prompt remains the proof that the hung `session.idle` hook did not keep the drain loop wedged, while the warning assertion still verifies the watchdog fired with the configured timeout.

## What this does NOT do

This does not change runtime channel-router behavior. It only removes a CI-host timing assumption from the test.

## Review notes

The key invariant is that `sessions[0]!.prompts` reaches 2 after the second flush; without the watchdog, that second prompt would never run because `live.draining` would remain stuck behind the unresolved idle hook.
