### PR TITLE
fix(agent): reduce unnecessary PDF delivery

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -300,7 +300,7 @@ describe('renderSessionOrigin', () => {
   )
 
   test.each(['slack-bot', 'discord-bot', 'telegram-bot', 'kakaotalk'] as const)(
-    'attachment-capable channel origin (%s) defaults report/PDF requests to a PDF attachment',
+    'attachment-capable channel origin (%s) defaults explicit deliverables to PDF attachments',
     (adapter) => {
       const out = renderSessionOrigin({
         kind: 'channel',
@@ -309,14 +309,17 @@ describe('renderSessionOrigin', () => {
         chat: 'C0',
         thread: null,
       })
-      expect(out).toMatch(/Ship reports as a PDF by default/i)
-      expect(out).toMatch(/the user asks for a report, document, brief, or "the report"/i)
+      expect(out).toMatch(/Ship explicit deliverables as PDFs/i)
+      expect(out).toMatch(/clearly asks for a PDF\/file\/export\/attachment/i)
+      expect(out).toMatch(/Do not treat the bare word "report" as enough/i)
+      expect(out).toMatch(/routine daily stats/i)
       expect(out).toContain('research-<slug>.md')
       expect(out).toContain('typeclaw-render-pdf')
       expect(out).toMatch(/channel_send\(\{ \.\.\., attachments:/)
       expect(out).toMatch(/do not paste\s+the full markdown into chat/i)
+      expect(out).toMatch(/inline text is right for routine updates/i)
       expect(out).toMatch(/`<summary>`[\s\S]*?NOT the deliverable/i)
-      expect(out).toMatch(/ad-hoc library \(jsPDF, pdfkit/i)
+      expect(out).toMatch(/ad-hoc library[\s\S]*?jsPDF, pdfkit/i)
       expect(out).toMatch(/do not attach the raw `\.md`/i)
     },
   )
@@ -333,7 +336,7 @@ describe('renderSessionOrigin', () => {
       chat: 'pr:7',
       thread: null,
     })
-    expect(out).not.toMatch(/Ship reports as a PDF by default/i)
+    expect(out).not.toMatch(/Ship explicit deliverables as PDFs/i)
     expect(out).not.toContain('typeclaw-render-pdf')
   })
 

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -538,16 +538,19 @@ function renderMembershipSummary(
 function renderResearchReportDeliveryGuidance(platformInfo: PlatformInfo): string[] {
   if (!platformInfo.supportsAttachments) return []
   return [
-    `**Ship reports as a PDF by default.** ${platformInfo.displayName} accepts file`,
-    'attachments. When the user asks for a report, document, brief, or "the report", or when a',
-    '`researcher` subagent returns `research-<slug>.md` in `<report>`, render the',
-    'markdown with `typeclaw-render-pdf` and deliver via',
+    `**Ship explicit deliverables as PDFs.** ${platformInfo.displayName} accepts file`,
+    'attachments. When the user clearly asks for a PDF/file/export/attachment, a standalone',
+    'document/brief, or when a `researcher` subagent returns `research-<slug>.md` in',
+    '`<report>`, render the markdown with `typeclaw-render-pdf` and deliver via',
     '`channel_send({ ..., attachments: [{ path, filename }] })` plus a 1–2 line',
-    'summary. A `researcher` `<summary>` is a teaser, NOT the deliverable. Never',
-    'use an ad-hoc library (jsPDF, pdfkit, raw-text dump); it breaks markdown/CJK.',
+    'summary. Do not treat the bare word "report" as enough: routine daily stats,',
+    'user trends, status reports, and other operational updates should stay inline',
+    'unless the user asks for a downloadable/exported artifact. A `researcher`',
+    '`<summary>` is a teaser, NOT the deliverable. Never use an ad-hoc library',
+    '(jsPDF, pdfkit, raw-text dump); it breaks markdown/CJK.',
     "For Korean/Japanese/Chinese, follow the skill's CJK guidance and never ship",
     'tofu boxes. Do not paste the full markdown into chat; do not attach the raw `.md`',
-    'unless explicitly asked; inline text is only for short content.',
+    'unless explicitly asked; inline text is right for routine updates.',
     '',
   ]
 }

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -28,11 +28,14 @@ describe('delivering reports and documents', () => {
   test('routes report/PDF/document requests to the typeclaw-render-pdf skill', () => {
     expect(DEFAULT_SYSTEM_PROMPT).toContain('## Delivering reports and documents')
     expect(DEFAULT_SYSTEM_PROMPT).toContain('typeclaw-render-pdf')
-    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/produce a polished file/i)
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/Produce a polished file only when/i)
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/Do \*\*not\*\* treat the bare word "report" as enough/i)
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/routine operational updates, daily stats, user trends/i)
   })
 
   test('states the summary is a pointer, never the deliverable', () => {
     expect(DEFAULT_SYSTEM_PROMPT).toMatch(/summary[\s\S]*?never the deliverable/i)
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/only after a deliverable was actually requested/i)
   })
 
   test('forbids hand-rolling a PDF with an ad-hoc library', () => {

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -62,9 +62,9 @@ Do not narrate routine low-risk tools. Narrate only for multi-step context, risk
 
 ## Delivering reports and documents
 
-When the user asks for a *report*, *document*, *brief*, *PDF*, or asks you to *send/show/attach/export* a generated result — anything a human would download, print, or forward — produce a polished file, not a chat wall or substance-dropping summary. A summary is a pointer to the deliverable, never the deliverable itself; when the user asked for the report, ship the report.
+Produce a polished file only when the user clearly asks for something a human would download, print, forward, attach, export, or keep as a standalone deliverable. Do **not** treat the bare word "report" as enough by itself: routine operational updates, daily stats, user trends, status reports, and other chat-native summaries should stay inline unless the user asks for a file/PDF/export. A summary is a pointer to the deliverable, never the deliverable itself, but only after a deliverable was actually requested.
 
-For Markdown-to-PDF, use the bundled \`typeclaw-render-pdf\` skill; it is the supported path and renders headings, lists, and tables. Never hand-roll PDFs with jsPDF, pdfkit, canvas text dumps, raw headless-browser prints, or ReportLab: they often emit raw markup and mojibake for non-Latin text. For Korean/Japanese/Chinese, follow the skill's CJK font guidance and do not ship tofu boxes. Short answers/snippets/explanations can stay inline.
+For Markdown-to-PDF, use the bundled \`typeclaw-render-pdf\` skill; it is the supported path and renders headings, lists, and tables. Never hand-roll PDFs with jsPDF, pdfkit, canvas text dumps, raw headless-browser prints, or ReportLab: they often emit raw markup and mojibake for non-Latin text. For Korean/Japanese/Chinese, follow the skill's CJK font guidance and do not ship tofu boxes. Short answers, snippets, explanations, and routine reports can stay inline.
 
 ## Long-running and interactive shell work
 


### PR DESCRIPTION
## Background

The current delivery guidance treats ordinary “report” wording too aggressively. In channel sessions, a routine request like “today’s stats/user trends report” can be turned into PDF attachments even when the user expected the usual inline operational update. That adds friction and lowers attention/readability for chat-native status summaries.

The root cause is prompt wording that equates the bare word “report” with a downloadable deliverable. The channel-specific attachment guidance repeats that default for attachment-capable adapters, so the model over-applies PDF rendering.

## Summary

This narrows the PDF default to explicit deliverables: PDF/file/export/attachment requests, standalone docs/briefs, or researcher-generated markdown artifacts. It also states that the bare word “report” is not sufficient by itself, and calls out daily stats, user trends, status reports, and routine operational updates as inline-by-default.

Why keep researcher artifacts as PDFs: those are still long-form, file-backed deliverables where a downloadable PDF is the intended channel behavior.

## What this does NOT do

- Does not remove the PDF renderer or the `typeclaw-render-pdf` skill guidance.
- Does not change attachment support by adapter.
- Does not change GitHub channel behavior; attachment guidance remains omitted there.

## Review notes

The load-bearing changes are in `src/agent/system-prompt.ts` and `renderResearchReportDeliveryGuidance` in `src/agent/session-origin.ts`. The invariant to verify is: explicit deliverables and researcher report files still route to PDF, while routine operational “reports” stay inline unless the user asks for an artifact.

Checks run:

- `bun run typecheck`
- `bun run lint` (repo has existing warnings outside this change; no new warning for touched files)
- `bun run format:check`
- `bun test --parallel src/agent/system-prompt.test.ts src/agent/session-origin.test.ts`
