### PR TITLE
fix(init): bump agent-messenger for Bun hatching

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@mariozechner/pi-tui": "^0.67.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@mozilla/readability": "^0.6.0",
-        "agent-messenger": "2.20.1",
+        "agent-messenger": "2.20.5",
         "cheerio": "^1.2.0",
         "citty": "^0.2.2",
         "cron-parser": "^5.5.0",
@@ -531,7 +531,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "agent-messenger": ["agent-messenger@2.20.1", "", { "dependencies": { "@hapi/boom": "^10.0.1", "@slack/web-api": "^6.9.0", "@whiskeysockets/baileys": "^7.0.0-rc.9", "better-sqlite3": "^12.0.0", "blessed": "^0.1.81", "bson": "^7.2.0", "classic-level": "^3.0.0", "commander": "^11.1.0", "crypto-js": "^4.2.0", "curve25519-js": "^0.0.4", "node-bignumber": "^1.2.2", "node-int64": "^0.4.0", "node-jose": "^2.2.0", "pino": "^10.3.1", "qrcode": "^1.5.4", "thrift": "^0.20.0", "tweetnacl": "^1.0.3", "ws": "^8.19.0", "zod": "^4.3.6" }, "optionalDependencies": { "koffi": "^2.15.2", "prebuilt-tdlib": "0.1008062.2" }, "bin": { "agent-channeltalk": "dist/src/platforms/channeltalk/cli.js", "agent-channeltalkbot": "dist/src/platforms/channeltalkbot/cli.js", "agent-discord": "dist/src/platforms/discord/cli.js", "agent-discordbot": "dist/src/platforms/discordbot/cli.js", "agent-instagram": "dist/src/platforms/instagram/cli.js", "agent-kakaotalk": "dist/src/platforms/kakaotalk/cli.js", "agent-line": "dist/src/platforms/line/cli.js", "agent-messenger": "dist/src/cli.js", "agent-slack": "dist/src/platforms/slack/cli.js", "agent-slackbot": "dist/src/platforms/slackbot/cli.js", "agent-teams": "dist/src/platforms/teams/cli.js", "agent-telegram": "dist/src/platforms/telegram/cli.js", "agent-telegrambot": "dist/src/platforms/telegrambot/cli.js", "agent-webex": "dist/src/platforms/webex/cli.js", "agent-wechatbot": "dist/src/platforms/wechatbot/cli.js", "agent-whatsapp": "dist/src/platforms/whatsapp/cli.js", "agent-whatsappbot": "dist/src/platforms/whatsappbot/cli.js", "amsg": "dist/src/cli.js" } }, "sha512-9cM04BA/tdYEv78So+2M8yZJTtHl6Tqkp0ha3+NyXTIq1XDZmxeZ4Z/4iJZTCjamjwsuR5RoBbXobq8rnlaH3g=="],
+    "agent-messenger": ["agent-messenger@2.20.5", "", { "dependencies": { "@hapi/boom": "^10.0.1", "@slack/web-api": "^6.9.0", "@whiskeysockets/baileys": "^7.0.0-rc.9", "better-sqlite3": "^12.0.0", "blessed": "^0.1.81", "bson": "^6.10.4", "classic-level": "^3.0.0", "commander": "^11.1.0", "crypto-js": "^4.2.0", "curve25519-js": "^0.0.4", "node-bignumber": "^1.2.2", "node-int64": "^0.4.0", "node-jose": "^2.2.0", "pino": "^10.3.1", "qrcode": "^1.5.4", "thrift": "^0.20.0", "tweetnacl": "^1.0.3", "webex-message-handler": "^0.6.10", "ws": "^8.19.0", "zod": "^4.3.6" }, "optionalDependencies": { "koffi": "^2.15.2", "prebuilt-tdlib": "0.1008062.2" }, "bin": { "agent-channeltalk": "dist/src/platforms/channeltalk/cli.js", "agent-channeltalkbot": "dist/src/platforms/channeltalkbot/cli.js", "agent-discord": "dist/src/platforms/discord/cli.js", "agent-discordbot": "dist/src/platforms/discordbot/cli.js", "agent-instagram": "dist/src/platforms/instagram/cli.js", "agent-kakaotalk": "dist/src/platforms/kakaotalk/cli.js", "agent-line": "dist/src/platforms/line/cli.js", "agent-messenger": "dist/src/cli.js", "agent-slack": "dist/src/platforms/slack/cli.js", "agent-slackbot": "dist/src/platforms/slackbot/cli.js", "agent-teams": "dist/src/platforms/teams/cli.js", "agent-telegram": "dist/src/platforms/telegram/cli.js", "agent-telegrambot": "dist/src/platforms/telegrambot/cli.js", "agent-webex": "dist/src/platforms/webex/cli.js", "agent-wechatbot": "dist/src/platforms/wechatbot/cli.js", "agent-whatsapp": "dist/src/platforms/whatsapp/cli.js", "agent-whatsappbot": "dist/src/platforms/whatsappbot/cli.js", "amsg": "dist/src/cli.js" } }, "sha512-tRa9B7ECGWib7yztXFFBArDPozmZ21Mz0daQD5c4AWjlbWJdkU0Qekk8n34ZoGXLcn0Svb0egtBsa0J5LZG/LA=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -587,7 +587,7 @@
 
     "browser-or-node": ["browser-or-node@1.3.0", "", {}, "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg=="],
 
-    "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
+    "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -925,6 +925,34 @@
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
+    "lodash._arraycopy": ["lodash._arraycopy@3.0.0", "", {}, "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A=="],
+
+    "lodash._arrayeach": ["lodash._arrayeach@3.0.0", "", {}, "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ=="],
+
+    "lodash._baseassign": ["lodash._baseassign@3.2.0", "", { "dependencies": { "lodash._basecopy": "^3.0.0", "lodash.keys": "^3.0.0" } }, "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ=="],
+
+    "lodash._baseclone": ["lodash._baseclone@3.3.0", "", { "dependencies": { "lodash._arraycopy": "^3.0.0", "lodash._arrayeach": "^3.0.0", "lodash._baseassign": "^3.0.0", "lodash._basefor": "^3.0.0", "lodash.isarray": "^3.0.0", "lodash.keys": "^3.0.0" } }, "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q=="],
+
+    "lodash._basecopy": ["lodash._basecopy@3.0.1", "", {}, "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ=="],
+
+    "lodash._basefor": ["lodash._basefor@3.0.3", "", {}, "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A=="],
+
+    "lodash._bindcallback": ["lodash._bindcallback@3.0.1", "", {}, "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ=="],
+
+    "lodash._getnative": ["lodash._getnative@3.9.1", "", {}, "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA=="],
+
+    "lodash._isiterateecall": ["lodash._isiterateecall@3.0.9", "", {}, "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ=="],
+
+    "lodash.clone": ["lodash.clone@3.0.3", "", { "dependencies": { "lodash._baseclone": "^3.0.0", "lodash._bindcallback": "^3.0.0", "lodash._isiterateecall": "^3.0.0" } }, "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A=="],
+
+    "lodash.clonedeep": ["lodash.clonedeep@3.0.2", "", { "dependencies": { "lodash._baseclone": "^3.0.0", "lodash._bindcallback": "^3.0.0" } }, "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
+
+    "lodash.isarray": ["lodash.isarray@3.0.4", "", {}, "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ=="],
+
+    "lodash.keys": ["lodash.keys@3.1.2", "", { "dependencies": { "lodash._getnative": "^3.0.0", "lodash.isarguments": "^3.0.0", "lodash.isarray": "^3.0.0" } }, "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
@@ -990,6 +1018,8 @@
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
     "node-jose": ["node-jose@2.2.0", "", { "dependencies": { "base64url": "^3.0.1", "buffer": "^6.0.3", "es6-promise": "^4.2.8", "lodash": "^4.17.21", "long": "^5.2.0", "node-forge": "^1.2.1", "pako": "^2.0.4", "process": "^0.11.10", "uuid": "^9.0.0" } }, "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw=="],
+
+    "node-kms": ["node-kms@0.4.1", "", { "dependencies": { "es6-promise": "^2.0.1", "lodash.clone": "^3.0.2", "lodash.clonedeep": "^3.0.1", "node-jose": "^2.2.0", "uuid": "^2.0.1" } }, "sha512-qhrfrsEPooJCTDPc8yPaLIu8rHGKrSngK/X9eZziM0RUnMY3PtKU8PHmG5JokeNw7wokW8/dKtwEH5I24oW5ew=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
@@ -1267,6 +1297,8 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
+    "webex-message-handler": ["webex-message-handler@0.6.10", "", { "dependencies": { "node-jose": "^2.2.0", "node-kms": "^0.4.1", "undici": "^7.24.6", "uuid": "^11.1.0" } }, "sha512-7SO79EagduWMY/8cRViAyz3/Isvd5+l+nDT1+MPIviWbsYmlKF40vaOGuqFquIuwlgAiqw36Dgej3ZUE1y/74w=="],
+
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
@@ -1356,6 +1388,10 @@
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "node-jose/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "node-kms/es6-promise": ["es6-promise@2.3.0", "", {}, "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="],
+
+    "node-kms/uuid": ["uuid@2.0.3", "", {}, "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg=="],
 
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@mariozechner/pi-tui": "^0.67.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
-    "agent-messenger": "2.20.1",
+    "agent-messenger": "2.20.5",
     "cheerio": "^1.2.0",
     "citty": "^0.2.2",
     "cron-parser": "^5.5.0",


### PR DESCRIPTION
## Background

Freshly hatched TypeClaw agents can fail during container startup when the installed `agent-messenger` version resolves `bson@7.2.0`. That BSON release touches Bun's unimplemented `node:v8.startupSnapshot.isBuildingSnapshot()` during module initialization, so the process exits before TypeClaw binds.

We first worked around this in TypeClaw by adding a direct BSON override, but `agent-messenger@2.20.5` now carries the compatibility fix itself by depending on `bson@^6.10.4`.

## Summary

Bump TypeClaw's direct `agent-messenger` dependency from `2.20.1` to `2.20.5` and refresh `bun.lock`.

This keeps the fix at the package that owns the KakaoTalk/BSON dependency instead of adding TypeClaw-specific dependency override logic. The lockfile now resolves `bson@6.10.4` through `agent-messenger`, avoiding the Bun-incompatible import-time code path.

## What this does NOT do

This does not add a TypeClaw-level BSON override. If a future `agent-messenger` release moves back to a Bun-compatible BSON major, TypeClaw should only need another normal dependency bump.

## Review notes

Validation:

- `bun run typecheck`
- `bun test --parallel src/init/packagejson.test.ts src/init/ensure-deps.test.ts src/channels/adapters/kakaotalk.test.ts` progressed through targeted init tests and KakaoTalk adapter tests, but the KakaoTalk worker crashed at a router path that requires a configured model/API key in this local container.
- Direct import check passed: `bun -e "import('agent-messenger/kakaotalk').then(m=>console.log('kakao import ok', !!m.KakaoTalkClient || Object.keys(m).length))"`

The key invariant is that TypeClaw no longer resolves `bson@7.2.0` from `agent-messenger`; it resolves `bson@6.10.4` instead.
