### PR TITLE
fix(init): resume reuses existing OAuth credential instead of re-running browser login

### DIFF
--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1519,14 +1519,21 @@ describe('hasExistingOAuthCredentials', () => {
   })
 
   test('returns false for providers without OAuth support', async () => {
-    await seedProviders({ openai: { type: 'oauth', access_token: 'tok-x' } })
+    await seedProviders({ openai: { type: 'oauth', access: 'tok-x' } })
     expect(await hasExistingOAuthCredentials(root, 'openai')).toBe(false)
     expect(await hasExistingOAuthCredentials(root, 'fireworks')).toBe(false)
   })
 
-  test('returns true when the OAuth slot has a non-empty access_token', async () => {
-    await seedProviders({ 'openai-codex': { type: 'oauth', access_token: 'tok-fresh', refresh_token: 'r' } })
+  test('returns true for the real pi-ai oauth shape persisted by the login runner', async () => {
+    await seedProviders({
+      'openai-codex': { type: 'oauth', access: 'tok-fresh', refresh: 'r', expires: 1, accountId: 'acct' },
+    })
     expect(await hasExistingOAuthCredentials(root, 'openai-codex')).toBe(true)
+  })
+
+  test('returns false for the codex auth.json shape (access_token instead of access)', async () => {
+    await seedProviders({ 'openai-codex': { type: 'oauth', access_token: 'tok-fresh', refresh_token: 'r' } })
+    expect(await hasExistingOAuthCredentials(root, 'openai-codex')).toBe(false)
   })
 
   test('returns false when the slot is api_key-shaped instead of oauth', async () => {
@@ -1534,15 +1541,15 @@ describe('hasExistingOAuthCredentials', () => {
     expect(await hasExistingOAuthCredentials(root, 'openai-codex')).toBe(false)
   })
 
-  test('returns false when access_token is missing', async () => {
+  test('returns false when access is missing', async () => {
     await seedProviders({ 'openai-codex': { type: 'oauth' } })
     expect(await hasExistingOAuthCredentials(root, 'openai-codex')).toBe(false)
   })
 
-  test('returns false when access_token is empty or whitespace', async () => {
-    await seedProviders({ 'openai-codex': { type: 'oauth', access_token: '' } })
+  test('returns false when access is empty or whitespace', async () => {
+    await seedProviders({ 'openai-codex': { type: 'oauth', access: '' } })
     expect(await hasExistingOAuthCredentials(root, 'openai-codex')).toBe(false)
-    await seedProviders({ 'openai-codex': { type: 'oauth', access_token: '   ' } })
+    await seedProviders({ 'openai-codex': { type: 'oauth', access: '   ' } })
     expect(await hasExistingOAuthCredentials(root, 'openai-codex')).toBe(false)
   })
 
@@ -1551,7 +1558,7 @@ describe('hasExistingOAuthCredentials', () => {
     // a sanity check rather than a mismatch case — but the test pins the
     // behavior so a future provider whose oauthProviderId diverges from
     // its id can't silently break this code path.
-    await seedProviders({ anthropic: { type: 'oauth', access_token: 'ant-tok' } })
+    await seedProviders({ anthropic: { type: 'oauth', access: 'ant-tok' } })
     expect(await hasExistingOAuthCredentials(root, 'anthropic')).toBe(true)
   })
 })

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -865,18 +865,19 @@ export async function readExistingProviderApiKey(root: string, providerId: Known
 // browser login entirely instead of dragging them through a second OAuth
 // flow.
 //
-// Mirrors `readExistingProviderApiKey`'s contract — returns `false` when:
-//   - The provider has no OAuth support (`oauthProviderId === null`)
-//   - The file doesn't exist
-//   - The slot exists but has the wrong shape (api-key instead of oauth, or
-//     missing access_token)
-//   - The token is empty / whitespace
+// Mirrors `readExistingProviderApiKey`'s contract — returns `false` when the
+// provider has no OAuth support, the file is missing, the slot is api-key
+// shaped, or the access token is absent/blank.
 //
-// We do NOT validate the token's freshness here. A stale access_token still
-// counts as "exists" — pi-ai's secrets store handles refresh on first use,
-// and surfacing an "expired token" check at init-time would require a
-// network call we'd rather not run during a wizard. The runtime will fall
-// back to OAuth login on use if refresh fails; that's a separate UX path.
+// The token lives under `access` — pi-ai's secrets.json shape (`{ type:
+// 'oauth', access, refresh, expires, accountId }`), the same field
+// `export-codex-auth-file.ts` reads. NOT `access_token`: that key belongs to
+// the unrelated `~/.codex/auth.json` export (`{ tokens: { access_token } }`).
+// Reading `access_token` here silently returned false for every real
+// credential, re-running the browser login on resume instead of reusing it.
+//
+// Freshness is intentionally not checked: pi-ai refreshes on first use, and a
+// network call mid-wizard isn't worth it.
 export async function hasExistingOAuthCredentials(root: string, providerId: KnownProviderId): Promise<boolean> {
   const provider = KNOWN_PROVIDERS[providerId]
   if (provider.oauthProviderId === null) return false
@@ -885,8 +886,8 @@ export async function hasExistingOAuthCredentials(root: string, providerId: Know
   const credential = providers[provider.oauthProviderId]
   if (credential === undefined) return false
   if (credential.type !== 'oauth') return false
-  const accessToken = (credential as { access_token?: unknown }).access_token
-  return typeof accessToken === 'string' && accessToken.trim().length > 0
+  const access = (credential as { access?: unknown }).access
+  return typeof access === 'string' && access.trim().length > 0
 }
 
 // Detects whether the requested channel already has usable credentials in


### PR DESCRIPTION
## Problem

Re-running `typeclaw init` and choosing **Resume** from a previous unfinished init re-runs the **OAuth browser login** every time, even when a valid OAuth credential is already on disk. The wizard correctly seeds `authMethod=oauth` from the checkpoint, but never recognizes the existing token, so it drags the user through the browser flow again.

Reproduced on a real agent folder whose `secrets.json` already held a valid `openai-codex` OAuth credential and whose `.typeclaw/init-progress.json` was:

```json
{"version":1,"vendorId":"openai","providerId":"openai-codex","modelRef":"openai-codex/gpt-5.5","authMethod":"oauth","channelChoice":"discord"}
```

## Root cause

`hasExistingOAuthCredentials` (`src/init/index.ts`) is the gate the wizard's auto-resume path depends on (`src/cli/init.ts`, the `pick-auth-method` → `hasExistingOAuth` check). It read the access token from a **non-existent `access_token` field**:

```ts
const accessToken = (credential as { access_token?: unknown }).access_token
```

But pi-ai persists the OAuth blob to `secrets.json` as:

```json
{ "type": "oauth", "access": "...", "refresh": "...", "expires": 0, "accountId": "..." }
```

— the same `access` field `src/secrets/export-codex-auth-file.ts` reads back. `access_token` is the unrelated **`~/.codex/auth.json`** export shape (`{ tokens: { access_token } }`). So the check returned `false` for **every real credential**, the auto-resume never fired, and the browser login re-ran on every resume.

The existing unit tests seeded `access_token` too, so they passed against the buggy code and never caught it — a test encoding the wrong collaborator shape.

## Fix

- Read `access` instead of `access_token` in `hasExistingOAuthCredentials`.
- Update the tests to use the real `access` shape, and add a regression test asserting the codex `access_token` shape is **NOT** accepted (so the two shapes can't be confused again).
- Document the `access` vs `access_token` distinction inline to prevent a future "rename it back" regression.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — 9400 pass, 0 fail

The new `returns true for the real pi-ai oauth shape persisted by the login runner` test fails against the old `access_token` code and passes with the fix, confirming it guards the real behavior.
