### PR TITLE
fix(init): resume auto-skips already-answered model/vision/channel prompts

### DIFF
--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1360,7 +1360,7 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
     expect(serialized).not.toContain('llmAuth')
   })
 
-  test('prompts to resume when a checkpoint exists and seeds prior answers', async () => {
+  test('resume auto-skips every checkpoint-covered choice prompt, not just the upstream ones', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
     const existing = checkpointFromSelections({
       cwd,
@@ -1374,8 +1374,9 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
 
     let confirmCalls = 0
     let vendorCalls = 0
-    let modelInitial: string | undefined
-    await collectWizardInputs(
+    let modelCalls = 0
+    let channelCalls = 0
+    const result = await collectWizardInputs(
       cwd,
       basePrompts({
         confirmResumeCheckpoint: async () => {
@@ -1387,9 +1388,13 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
           vendorCalls += 1
           return { kind: 'value', value: 'fireworks' as KnownProviderVendorId }
         },
-        pickModel: async (_options, _providerId, initial) => {
-          modelInitial = initial
+        pickModel: async () => {
+          modelCalls += 1
           return { kind: 'value', value: fireworksModel }
+        },
+        pickChannel: async () => {
+          channelCalls += 1
+          return { kind: 'value', value: 'none' }
         },
       }),
       { checkpointStore: store },
@@ -1397,7 +1402,200 @@ describe('collectWizardInputs wizard-answer checkpoint', () => {
 
     expect(confirmCalls).toBe(1)
     expect(vendorCalls).toBe(0)
-    expect(modelInitial).toBe(FIREWORKS_REF)
+    expect(modelCalls).toBe(0)
+    expect(channelCalls).toBe(0)
+    // The seeded model still drives the result even though no prompt fired.
+    expect(result.model).toBe(fireworksModel)
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_existing' })
+    expect(result.channelChoice).toBe('none')
+  })
+
+  test('resume stops interactively at the first un-checkpointed step (model saved, channel not)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
+    const existing = checkpointFromSelections({
+      cwd,
+      vendorId: 'fireworks',
+      providerId: 'fireworks',
+      modelRef: FIREWORKS_REF as Parameters<typeof checkpointFromSelections>[0]['modelRef'],
+      authMethod: 'api-key',
+    })
+    const { store } = inMemoryStore(existing)
+
+    let modelCalls = 0
+    let channelCalls = 0
+    let channelInitialWasUndefined = false
+    const result = await collectWizardInputs(
+      cwd,
+      basePrompts({
+        confirmResumeCheckpoint: async () => 'resume',
+        readExistingApiKey: async () => 'sk_existing',
+        pickModel: async () => {
+          modelCalls += 1
+          return { kind: 'value', value: fireworksModel }
+        },
+        pickChannel: async (initial) => {
+          channelCalls += 1
+          channelInitialWasUndefined = initial === undefined
+          return { kind: 'value', value: 'none' }
+        },
+      }),
+      { checkpointStore: store },
+    )
+
+    // given the model is checkpoint-covered but channelChoice is not:
+    expect(modelCalls).toBe(0) // model auto-skipped
+    expect(channelCalls).toBe(1) // channel prompt fired for real
+    expect(channelInitialWasUndefined).toBe(true) // no saved choice to pre-fill
+    expect(result.model).toBe(fireworksModel)
+  })
+
+  test('resume does NOT auto-skip the api-key prompt when no key is on disk', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
+    const existing = checkpointFromSelections({
+      cwd,
+      vendorId: 'fireworks',
+      providerId: 'fireworks',
+      modelRef: FIREWORKS_REF as Parameters<typeof checkpointFromSelections>[0]['modelRef'],
+      authMethod: 'api-key',
+      channelChoice: 'none',
+    })
+    const { store } = inMemoryStore(existing)
+
+    let askApiKeyCalls = 0
+    const result = await collectWizardInputs(
+      cwd,
+      basePrompts({
+        confirmResumeCheckpoint: async () => 'resume',
+        readExistingApiKey: async () => null, // key value is never checkpointed
+        askApiKey: async () => {
+          askApiKeyCalls += 1
+          return { kind: 'value', value: 'sk_freshly_entered' }
+        },
+      }),
+      { checkpointStore: store },
+    )
+
+    expect(askApiKeyCalls).toBe(1) // secret entry still required
+    expect(result.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_freshly_entered' })
+  })
+
+  test('backing out of the first interactive prompt ends replay and re-shows the seeded prior step', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
+    // channelChoice is intentionally NOT checkpointed, so pick-channel is the
+    // first genuinely interactive step after the auto-skipped model.
+    const existing = checkpointFromSelections({
+      cwd,
+      vendorId: 'fireworks',
+      providerId: 'fireworks',
+      modelRef: FIREWORKS_REF as Parameters<typeof checkpointFromSelections>[0]['modelRef'],
+      authMethod: 'api-key',
+    })
+    const { store } = inMemoryStore(existing)
+
+    let channelCalls = 0
+    let modelCalls = 0
+    const result = await collectWizardInputs(
+      cwd,
+      basePrompts({
+        confirmResumeCheckpoint: async () => 'resume',
+        readExistingApiKey: async () => 'sk_existing',
+        pickModel: async () => {
+          modelCalls += 1
+          return { kind: 'value', value: fireworksModel }
+        },
+        pickChannel: async () => {
+          channelCalls += 1
+          // First call (real prompt, model already auto-skipped) backs once;
+          // that must re-render pick-model as a real prompt (replay now off),
+          // so on the second pick-channel call we commit.
+          return channelCalls === 1 ? { kind: 'back' } : { kind: 'value', value: 'none' }
+        },
+      }),
+      { checkpointStore: store },
+    )
+
+    // model was auto-skipped on the forward pass, then re-prompted after the
+    // back from pick-channel (proving replay ended on the interactive prompt).
+    expect(modelCalls).toBe(1)
+    expect(channelCalls).toBe(2)
+    expect(result.channelChoice).toBe('none')
+  })
+
+  test('resume auto-skips the whole vision sub-flow when it was checkpointed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-init-resume-'))
+    const zaiTextOnly: ModelOption = {
+      providerId: 'zai',
+      providerName: 'Z.AI',
+      modelId: 'glm-4.6',
+      modelName: 'GLM-4.6',
+      ref: 'zai/glm-4.6',
+      contextWindow: 200000,
+      reasoning: true,
+      curated: true,
+      supportsVision: false,
+    }
+    const openaiVision: ModelOption = {
+      providerId: 'openai',
+      providerName: 'OpenAI',
+      modelId: 'gpt-5.4-nano',
+      modelName: 'GPT-5.4 Nano',
+      ref: 'openai/gpt-5.4-nano',
+      contextWindow: 128000,
+      reasoning: false,
+      curated: true,
+      supportsVision: true,
+    }
+    const existing = checkpointFromSelections({
+      cwd,
+      vendorId: 'zai',
+      providerId: 'zai',
+      modelRef: zaiTextOnly.ref as Parameters<typeof checkpointFromSelections>[0]['modelRef'],
+      authMethod: 'api-key',
+      visionVendorId: 'openai',
+      visionProviderId: 'openai',
+      visionModelRef: openaiVision.ref as Parameters<typeof checkpointFromSelections>[0]['visionModelRef'],
+      visionAuthMethod: 'api-key',
+      channelChoice: 'none',
+    })
+    const { store } = inMemoryStore(existing)
+
+    const fired: string[] = []
+    const result = await collectWizardInputs(
+      cwd,
+      basePrompts({
+        loadCatalog: async () => ({ options: [zaiTextOnly, openaiVision], source: 'curated' }),
+        confirmResumeCheckpoint: async () => 'resume',
+        readExistingApiKey: async () => 'sk_existing',
+        pickModel: async () => {
+          fired.push('pick-model')
+          return { kind: 'value', value: zaiTextOnly }
+        },
+        pickVisionVendor: async () => {
+          fired.push('pick-vision-vendor')
+          return { kind: 'value', value: 'openai' }
+        },
+        pickVisionProviderVariant: async () => {
+          fired.push('pick-vision-provider-variant')
+          return { kind: 'value', value: 'openai' as KnownProviderId }
+        },
+        pickVisionModel: async () => {
+          fired.push('pick-vision-model')
+          return { kind: 'value', value: openaiVision }
+        },
+        pickChannel: async () => {
+          fired.push('pick-channel')
+          return { kind: 'value', value: 'none' }
+        },
+      }),
+      { checkpointStore: store },
+    )
+
+    // No choice prompt fires: model, the entire vision sub-flow, and channel
+    // were all checkpoint-covered and auto-skipped.
+    expect(fired).toEqual([])
+    expect(result.model.ref).toBe(zaiTextOnly.ref)
+    expect(result.vision?.model.ref).toBe(openaiVision.ref)
+    expect(result.vision?.llmAuth).toEqual({ kind: 'api-key', apiKey: 'sk_existing' })
   })
 
   test('resume reuses existing provider and channel secrets without credential prompts', async () => {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -532,6 +532,15 @@ export async function collectWizardInputs(
   let pendingBackOrigin: StepId | null = null
   let oauthCredentialsSaved = false
 
+  // One-shot replay of checkpoint answers: while active, choice steps whose
+  // answer was seeded auto-advance (running their normal tail) instead of
+  // re-prompting. The first interactive prompt or any Back ends the replay
+  // (cleared in `onResult`), so back-navigation behaves like a fresh wizard.
+  // Secret-entry steps are never in `resumeCovered`, so a checkpointed
+  // `authMethod` still drops to its key/login prompt when nothing is on disk.
+  const resumeReplay = { active: false }
+  const resumeCovered = new Set<StepId>()
+
   // Resume saved wizard answers from a prior unfinished init. `--reset` skips
   // this entirely (the user asked to re-answer everything). Route through the
   // shared detectInitProgress() predicate so init/start/restart classify a
@@ -555,6 +564,8 @@ export async function collectWizardInputs(
       if (decision === 'resume') {
         seedWizardState(state, sanitized)
         step = resumeStep(state)
+        resumeReplay.active = true
+        for (const covered of resumeCoveredSteps(state)) resumeCovered.add(covered)
       } else {
         await checkpointStore.clear(cwd)
       }
@@ -571,6 +582,11 @@ export async function collectWizardInputs(
   }
 
   const onResult = <T>(currentStep: StepId, result: StepResult<T>): StepResult<T> => {
+    // Any Back, or any non-auto (interactive) answer, ends the resume replay:
+    // from here on the user is driving, so downstream seeded steps prompt
+    // normally. Synthesized auto-skips keep replay alive and, as before, leave
+    // `pendingBackOrigin` untouched so they never affect double-back abort.
+    if (result.kind === 'back' || !result.auto) resumeReplay.active = false
     if (result.kind === 'back') {
       if (pendingBackOrigin === currentStep) abort()
       pendingBackOrigin = currentStep
@@ -578,6 +594,16 @@ export async function collectWizardInputs(
       pendingBackOrigin = null
     }
     return result
+  }
+
+  // Synthesize a step's seeded answer as an auto-advance result during resume
+  // replay, so the step runs its normal tail (state assignment, on-disk
+  // credential reconstruction, routing) without re-prompting. Returns
+  // undefined when replay is off, this step isn't checkpoint-covered, or the
+  // value is unset — callers fall back to the real prompt.
+  const resumeSkip = <T>(currentStep: StepId, value: T | undefined): StepResult<T> | undefined => {
+    if (!resumeReplay.active || !resumeCovered.has(currentStep) || value === undefined) return undefined
+    return { kind: 'value', value, auto: true }
   }
 
   const readExistingApiKey = async (providerId: KnownProviderId): Promise<string | null> => {
@@ -725,7 +751,11 @@ export async function collectWizardInputs(
       }
 
       case 'pick-model': {
-        const result = onResult(step, await prompts.pickModel(catalog.options, state.providerId!, state.model?.ref))
+        const result = onResult(
+          step,
+          resumeSkip(step, state.model) ??
+            (await prompts.pickModel(catalog.options, state.providerId!, state.model?.ref)),
+        )
         if (result.kind === 'back') {
           step = stepBeforeModel(state)
           break
@@ -758,7 +788,11 @@ export async function collectWizardInputs(
 
       case 'pick-vision-vendor': {
         const visionOptions = catalog.options.filter((o) => o.supportsVision)
-        const result = onResult(step, await prompts.pickVisionVendor(visionOptions, state.visionVendorId))
+        const result: StepResult<KnownProviderVendorId | 'skip'> = onResult(
+          step,
+          resumeSkip<KnownProviderVendorId | 'skip'>(step, state.visionVendorId) ??
+            (await prompts.pickVisionVendor(visionOptions, state.visionVendorId)),
+        )
         if (result.kind === 'back') {
           step = stepBeforeVision(state)
           break
@@ -789,7 +823,8 @@ export async function collectWizardInputs(
         const visionOptions = catalog.options.filter((o) => o.supportsVision)
         const result = onResult(
           step,
-          await prompts.pickVisionProviderVariant(state.visionVendorId!, visionOptions, state.visionProviderId),
+          resumeSkip(step, state.visionProviderId) ??
+            (await prompts.pickVisionProviderVariant(state.visionVendorId!, visionOptions, state.visionProviderId)),
         )
         if (result.kind === 'back') {
           step = 'pick-vision-vendor'
@@ -810,7 +845,8 @@ export async function collectWizardInputs(
         const visionOptions = catalog.options.filter((o) => o.supportsVision)
         const result = onResult(
           step,
-          await prompts.pickVisionModel(visionOptions, state.visionProviderId!, state.visionModel?.ref),
+          resumeSkip(step, state.visionModel) ??
+            (await prompts.pickVisionModel(visionOptions, state.visionProviderId!, state.visionModel?.ref)),
         )
         if (result.kind === 'back') {
           step = 'pick-vision-provider-variant'
@@ -902,7 +938,10 @@ export async function collectWizardInputs(
       }
 
       case 'pick-channel': {
-        const result: StepResult<ChannelChoice> = onResult(step, await prompts.pickChannel(state.channelChoice))
+        const result: StepResult<ChannelChoice> = onResult(
+          step,
+          resumeSkip(step, state.channelChoice) ?? (await prompts.pickChannel(state.channelChoice)),
+        )
         if (result.kind === 'back') {
           step = stepBeforePickChannel(state)
           break
@@ -1035,6 +1074,21 @@ function resumeStep(state: WizardState): StepId {
   if (state.providerId !== undefined) return 'reuse-existing-key'
   if (state.vendorId !== undefined) return 'pick-provider-variant'
   return 'pick-vendor'
+}
+
+// Choice steps whose seeded answer lets resume replay auto-advance them. Only
+// non-secret picks the checkpoint actually carries — never `enter-api-key` /
+// `enter-vision-api-key` (key values aren't checkpointed) and never the
+// reuse-* / channel-flow steps (those reconstruct from disk or collect secrets,
+// so they must run their own logic, not replay a stored answer).
+function resumeCoveredSteps(state: WizardState): StepId[] {
+  const covered: StepId[] = []
+  if (state.model !== undefined) covered.push('pick-model')
+  if (state.visionVendorId !== undefined) covered.push('pick-vision-vendor')
+  if (state.visionProviderId !== undefined) covered.push('pick-vision-provider-variant')
+  if (state.visionModel !== undefined) covered.push('pick-vision-model')
+  if (state.channelChoice !== undefined) covered.push('pick-channel')
+  return covered
 }
 
 function projectCheckpoint(cwd: string, state: WizardState): WizardAnswerCheckpointV1 {


### PR DESCRIPTION
## Problem

On resume from a previous unfinished `typeclaw init` (the "Found answers from a previous, unfinished init. Resume from them?" path), the wizard still **re-prompted** for `pick-model`, the entire vision sub-flow, and `pick-channel` — even though those answers are saved in the checkpoint. The saved value was only used as the prompt's pre-selected `initialValue`, so the user had to press Enter on each step they'd already answered.

This is the lower-severity sibling of #960 (which fixed the OAuth browser-login re-running on resume). Found during the follow-up audit of "what else does resume fail to skip".

## Root cause

`resumeStep` only fast-forwarded past `vendor` / `provider` / `auth` (it lands at `reuse-existing-key` once `providerId` is set). Every downstream choice step still called its prompt unconditionally; the checkpoint value was passed only as `initialValue`.

## Fix

A one-shot **resume replay**, following the same auto-advance pattern the wizard already uses for `reuse-existing-key` / `hasExistingOAuth`:

- After seeding state from the checkpoint, mark `resumeReplay.active = true` and compute the set of checkpoint-covered choice steps (`resumeCoveredSteps`).
- For each covered choice step, `resumeSkip(step, value)` synthesizes an `{ kind: 'value', value, auto: true }` result **instead of** prompting. Crucially, the step's **tail still runs unchanged** — state assignment, on-disk credential reconstruction (api-key / OAuth / vision), and routing all behave exactly as if the user had pressed Enter. This avoids inventing a parallel reconstruction path.
- The replay is **one-shot**: the first interactive (non-`auto`) answer or any **Back** clears `resumeReplay.active` in `onResult`, so from that point every step prompts normally and back-navigation is unchanged.
- `auto: true` results never touch `pendingBackOrigin`, so the double-back-to-abort behavior is preserved.

### Deliberately NOT auto-skipped (safety)

- `enter-api-key` / `enter-vision-api-key` and OAuth browser login — the **key/token value is never checkpointed**, so a checkpointed `authMethod` still drops to its prompt when no credential is on disk.
- `reuse-existing-key` / `reuse-existing-channel` / `channel-flow` — these reconstruct from disk or collect secrets; they must run their own logic, not replay a stored answer.

## Tests

Added to the `collectWizardInputs wizard-answer checkpoint` suite:
- Full checkpoint → **no** choice prompt fires (model + channel auto-skipped), seeded model still drives the result.
- Checkpoint with model but **no** `channelChoice` → model auto-skipped, `pick-channel` fires fresh (no pre-fill).
- `authMethod: 'api-key'` but **no key on disk** → `enter-api-key` still fires (secret re-entry preserved).
- **Back** out of the first interactive prompt → replay ends and the seeded prior step (`pick-model`) re-renders as a real prompt.
- Full **vision** sub-flow checkpointed → vision vendor/model and channel all auto-skip, `visionLlmAuth` reconstructed from disk.

Updated one existing test that asserted the old (buggy) "re-prompts with pre-selected value" behavior to assert the new "auto-skipped, not called" contract.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — 9403 pass, 0 fail

## Relation to #960

Independent fix, branched off `main` (does not stack on #960). #960 fixes the OAuth credential detection (the hard blocker); this fixes the remaining "press Enter on already-answered prompts" UX gap.
