### PR TITLE
channels: engage on webex aliases

### DIFF
--- a/src/channels/adapters/webex-bot-classify.test.ts
+++ b/src/channels/adapters/webex-bot-classify.test.ts
@@ -53,6 +53,15 @@ describe('classifyInbound', () => {
     expect(verdict.payload.text).toBe('확인 부탁해요')
   })
 
+  test('marks alias-only messages as bot mentions', () => {
+    const verdict = classifyInbound(message({ text: '타이피야 확인해줘' }), config, 'bot-1', ['타이피', 'typeey'])
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+    expect(verdict.payload.replyToBotMessageId).toBeNull()
+  })
+
   test('marks mentionsOthers when only another person is mentioned', () => {
     const verdict = classifyInbound(message({ mentionedPeople: ['user-2'] }), config, 'bot-1')
 

--- a/src/channels/adapters/webex-bot-classify.ts
+++ b/src/channels/adapters/webex-bot-classify.ts
@@ -53,9 +53,11 @@ export function classifyInbound(
       authorIsBot: false,
       isBotMention,
       // Webex Mercury only exposes parentId inline, not the parent author. When
-      // the reply auto-mentions the bot we can identify it as bot-directed;
-      // otherwise leave the parent unattributed instead of guessing.
-      replyToBotMessageId: event.parentId !== undefined && isBotMention ? event.parentId : null,
+      // the reply has a structured bot mention we can identify it as bot-directed;
+      // otherwise leave the parent unattributed instead of guessing. Alias matches
+      // are mention-equivalent for engagement, but they do not prove the parent
+      // is bot-authored; enrichment fetches the parent and attributes it.
+      replyToBotMessageId: event.parentId !== undefined && structuredBotMention ? event.parentId : null,
       mentionsOthers,
       replyToOtherMessageId: null,
       isDm,

--- a/src/channels/adapters/webex-bot-classify.ts
+++ b/src/channels/adapters/webex-bot-classify.ts
@@ -1,5 +1,6 @@
 import type { WebexBotListenerEventMap } from 'agent-messenger/webexbot'
 
+import { matchesAnyAlias } from '@/channels/engagement'
 import type { ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundAttachment, InboundMessage } from '@/channels/types'
 
@@ -15,6 +16,7 @@ export function classifyInbound(
   event: WebexInboundMessage,
   _config: ChannelAdapterConfig,
   botPersonId: string | null,
+  selfAliases: readonly string[] = [],
 ): InboundClassification {
   if (botPersonId !== null && event.personId === botPersonId) {
     return { kind: 'drop', reason: 'self_author' }
@@ -28,7 +30,9 @@ export function classifyInbound(
   }
 
   const isDm = event.roomType === 'direct'
-  const isBotMention = event.mentionedPeople.includes(botPersonId) || event.mentionedGroups.includes('all')
+  const structuredBotMention = event.mentionedPeople.includes(botPersonId) || event.mentionedGroups.includes('all')
+  const aliasMatched = !structuredBotMention && matchesAnyAlias(text, selfAliases)
+  const isBotMention = structuredBotMention || aliasMatched
   const mentionsOthers = event.mentionedPeople.length > 0 && !event.mentionedPeople.includes(botPersonId)
   const ts = Date.parse(event.created)
 

--- a/src/channels/adapters/webex-bot-reference.test.ts
+++ b/src/channels/adapters/webex-bot-reference.test.ts
@@ -73,6 +73,21 @@ describe('enrichWebexMessageReference', () => {
     expect(enriched.replyToBotMessageId).toBeNull()
   })
 
+
+  test('classifies an alias-addressed reply to a non-bot parent as directed at the parent author', async () => {
+    const aliasAddressedReply = { ...inbound, text: '타이피야 확인해줘', isBotMention: true }
+    const enriched = await enrichWebexMessageReference({
+      inbound: aliasAddressedReply,
+      parentId: 'parent',
+      botPersonId: 'bot-1',
+      client: { getMessage: parentFrom('user-2') },
+    })
+
+    expect(enriched.isBotMention).toBe(true)
+    expect(enriched.replyToBotMessageId).toBeNull()
+    expect(enriched.replyToOtherMessageId).toBe('parent')
+  })
+
   test('attributes a bot-authored parent even when its text is empty', async () => {
     const enriched = await enrichWebexMessageReference({
       inbound,

--- a/src/channels/adapters/webex-bot-reference.test.ts
+++ b/src/channels/adapters/webex-bot-reference.test.ts
@@ -73,7 +73,6 @@ describe('enrichWebexMessageReference', () => {
     expect(enriched.replyToBotMessageId).toBeNull()
   })
 
-
   test('classifies an alias-addressed reply to a non-bot parent as directed at the parent author', async () => {
     const aliasAddressedReply = { ...inbound, text: '타이피야 확인해줘', isBotMention: true }
     const enriched = await enrichWebexMessageReference({

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -55,6 +55,7 @@ export type WebexBotAdapterOptions = {
   createClient?: WebexBotClientFactory
   createListener?: WebexBotListenerFactory
   listenerOptions?: Omit<WebexBotListenerOptions, 'ignoreSelfMessages'>
+  selfAliasesRef?: () => readonly string[]
 }
 
 export type WebexBotAdapter = {
@@ -230,7 +231,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
     try {
       const tag = await formatChannelTag(event.roomId)
       logger.info(`[webex-bot] inbound id=${event.id} author=${event.personEmail} ${tag} text_len=${event.text.length}`)
-      const verdict = classifyInbound(event, options.configRef(), botSnapshot?.id ?? null)
+      const verdict = classifyInbound(event, options.configRef(), botSnapshot?.id ?? null, options.selfAliasesRef?.() ?? [])
       if (verdict.kind === 'drop') {
         logger.info(`[webex-bot] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
         return

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -231,7 +231,12 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
     try {
       const tag = await formatChannelTag(event.roomId)
       logger.info(`[webex-bot] inbound id=${event.id} author=${event.personEmail} ${tag} text_len=${event.text.length}`)
-      const verdict = classifyInbound(event, options.configRef(), botSnapshot?.id ?? null, options.selfAliasesRef?.() ?? [])
+      const verdict = classifyInbound(
+        event,
+        options.configRef(),
+        botSnapshot?.id ?? null,
+        options.selfAliasesRef?.() ?? [],
+      )
       if (verdict.kind === 'drop') {
         logger.info(`[webex-bot] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
         return

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -726,6 +726,30 @@ describe('channel manager — reload detects missing tokens and stops adapter', 
     await mgr.stop()
   })
 
+  test('forwards selfAliasesRef to the webex adapter so alias-only inbounds engage like mentions', async () => {
+    cfg['webex-bot'] = enabledAdapterCfg()
+    let captured: { selfAliasesRef?: () => readonly string[] } | undefined
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      aliasesRef: () => ['타이피', 'typeey'],
+      env: { WEBEX_BOT_TOKEN: 'webex-token' },
+      createWebexAdapter: (opts) => {
+        captured = opts
+        return makeFakeAdapter()
+      },
+    })
+
+    await mgr.start()
+
+    expect(captured?.selfAliasesRef).toBeDefined()
+    const aliases = captured!.selfAliasesRef!()
+    expect(aliases).toContain('타이피')
+    expect(aliases).toContain('typeey')
+
+    await mgr.stop()
+  })
+
   test('forwards selfAliasesRef to the slack adapter so the classifier can anchor threads on alias-only inbounds', async () => {
     // given: a manager wired with `aliasesRef` returning ["모모", "momo"]
     //   AND a `createSlackAdapter` test seam that captures the options the

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -284,6 +284,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         token,
         logger,
+        selfAliasesRef: () => router.getSelfAliases(),
       })
     }
     return null


### PR DESCRIPTION
## Background

Webex alias-only messages were routed with `isBotMention=false` even when their text matched the agent's configured aliases. Slack, LINE, and KakaoTalk already pass live self-aliases into their adapter classifiers, but Webex did not, so the router could only engage on structured Webex mentions/replies/DMs.

## Summary

This wires Webex into the same alias path as the other chat adapters:

- Webex manager construction now passes `router.getSelfAliases()` into the adapter.
- The Webex adapter forwards the current alias snapshot into `classifyInbound()`.
- The Webex classifier treats `matchesAnyAlias(text, selfAliases)` as mention-equivalent when no structured bot mention is present.
- Regression coverage checks both classifier behavior and manager-to-adapter wiring.

## What this does NOT do

It does not change Webex delivery semantics or subscription behavior. It only fixes classification for alias-only Webex messages that already reach the adapter.

## Review notes

The load-bearing invariant is that Webex now mirrors Slack/LINE/KakaoTalk: configured aliases are resolved through the router at runtime, then interpreted by the adapter classifier as bot-directed engagement.

Checks run locally:

- `bun test --parallel ./src/channels/adapters/webex-bot-classify.test.ts ./src/channels/manager.test.ts`
- `bun run typecheck`
