### PR TITLE
fix(channels): count webex humans from complete membership reads

### DIFF
--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { WebexBotListener } from 'agent-messenger/webexbot'
 
+import { MEMBERSHIP_ENUMERATION_CAP } from '@/channels/membership'
 import type { ChannelRouter } from '@/channels/router'
 import { channelsSchema } from '@/channels/schema'
 import type { OutboundMessage } from '@/channels/types'
@@ -115,6 +116,7 @@ describe('webex history and membership', () => {
       },
       logger: logger(),
       historyCallback: history,
+      botPersonIdRef: () => 'bot-1',
       now: () => 123,
     })
 
@@ -130,7 +132,8 @@ describe('webex history and membership', () => {
       humans: 2,
       bots: 1,
       fetchedAt: 123,
-      truncated: true,
+      truncated: false,
+      humanMemberIds: ['user-1', 'user-2'],
     })
     fail = true
     await expect(
@@ -138,6 +141,30 @@ describe('webex history and membership', () => {
     ).resolves.toEqual({
       humans: 1,
       bots: 1,
+      fetchedAt: 123,
+      truncated: true,
+    })
+  })
+
+  test('marks membership truncated and omits humanMemberIds when the read hits the enumeration cap', async () => {
+    const members = Array.from({ length: MEMBERSHIP_ENUMERATION_CAP }, (_, i) => membership(`user-${i}`))
+    const resolver = createWebexMembershipResolver({
+      client: { listMemberships: async () => members },
+      logger: logger(),
+      historyCallback: createWebexHistoryCallback({
+        client: { listMessages: async () => [] },
+        logger: logger(),
+        botPersonIdRef: () => 'bot-1',
+      }),
+      botPersonIdRef: () => 'bot-1',
+      now: () => 123,
+    })
+
+    await expect(
+      resolver({ adapter: 'webex-bot', workspace: 'room-1', chat: 'room-1', thread: null }),
+    ).resolves.toEqual({
+      humans: MEMBERSHIP_ENUMERATION_CAP,
+      bots: 0,
       fetchedAt: 123,
       truncated: true,
     })

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -7,7 +7,12 @@ import type {
   WebexPerson,
 } from 'agent-messenger/webexbot'
 
-import type { MembershipResolver, MembershipResolverFailure, MembershipResolverResult } from '@/channels/membership'
+import {
+  MEMBERSHIP_ENUMERATION_CAP,
+  type MembershipResolver,
+  type MembershipResolverFailure,
+  type MembershipResolverResult,
+} from '@/channels/membership'
 import { deriveMembershipFromHistory } from '@/channels/membership-from-history'
 import type { ChannelRouter } from '@/channels/router'
 import type { ChannelAdapterConfig } from '@/channels/schema'
@@ -123,6 +128,7 @@ export function createWebexMembershipResolver(deps: {
   client: Pick<WebexBotClient, 'listMemberships'>
   logger: WebexBotAdapterLogger
   historyCallback: HistoryCallback
+  botPersonIdRef: () => string | null
   now?: () => number
 }): MembershipResolver {
   const now = deps.now ?? Date.now
@@ -130,10 +136,29 @@ export function createWebexMembershipResolver(deps: {
     if (key.adapter !== 'webex-bot') return { kind: 'permanent' } satisfies MembershipResolverFailure
     if (key.workspace === '@dm') return { humans: 1, bots: 1, fetchedAt: now(), truncated: false }
     try {
-      const memberships: WebexMembership[] = await deps.client.listMemberships(key.chat, { max: 100 })
-      const total = Math.max(0, memberships.length)
-      const bots = 1
-      return { humans: Math.max(0, total - bots), bots, fetchedAt: now(), truncated: true }
+      const memberships: WebexMembership[] = await deps.client.listMemberships(key.chat, {
+        max: MEMBERSHIP_ENUMERATION_CAP,
+      })
+      // Below the cap the enumeration is complete and authoritative, so it must
+      // NOT be marked truncated: `resolveEffectiveHumans` only trusts a fresh
+      // untruncated read over persisted speakers, and the `Math.max()` truncated
+      // path lets a stale/legacy email-keyed participant double-count the same
+      // human and silence the solo-human fallback.
+      const truncated = memberships.length >= MEMBERSHIP_ENUMERATION_CAP
+      // WebexMembership has no bot/person type field, so only the self bot can be
+      // classified; peer bots count as humans here (they still reach the agent
+      // via mention/reply/sticky triggers regardless of this count).
+      const botPersonId = deps.botPersonIdRef()
+      const humanMemberIds: string[] = []
+      let bots = 0
+      for (const member of memberships) {
+        if (botPersonId !== null && member.personId === botPersonId) bots++
+        else humanMemberIds.push(member.personId)
+      }
+      if (truncated) {
+        return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated }
+      }
+      return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated, humanMemberIds }
     } catch (err) {
       deps.logger.warn(`[webex-bot] membership room=${key.chat} failed: ${describe(err)}; deriving from recent history`)
       return await deriveMembershipFromHistory({
@@ -221,7 +246,12 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
   }
 
   const historyCallback = createWebexHistoryCallback({ client, logger, botPersonIdRef: () => botPerson?.id ?? null })
-  const membershipResolver = createWebexMembershipResolver({ client, logger, historyCallback })
+  const membershipResolver = createWebexMembershipResolver({
+    client,
+    logger,
+    historyCallback,
+    botPersonIdRef: () => botPerson?.id ?? null,
+  })
   const outboundCallback = createOutboundCallback({ client, logger, formatChannelTag })
   const fetchAttachmentCallback = createFetchAttachmentCallback({ token: options.token, logger, fetchImpl })
 

--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -693,6 +693,27 @@ describe('decideEngagement (solo-human fallback)', () => {
     expect(resolveEffectiveHumans(2, { humans: 1, bots: 1, fetchedAt: 0, truncated: false }, 120_000)).toBe(2)
   })
 
+  test('fresh complete membership overrides a stale duplicate participant and engages the solo human', () => {
+    // Both participant rows are the SAME human under two keys (a legacy
+    // email-keyed entry plus the platform-id inbound), so the raw count looks
+    // like 2; a complete fresh membership read knows it is really 1 and wins.
+    const ledger = new StickyLedger()
+    const duplicatedSameHuman: readonly ChannelParticipant[] = [
+      participant('alice@example.com', 20_000),
+      participant('alice', 20_000),
+    ]
+    const decision = decideEngagement({
+      message: inbound({ authorId: 'alice', text: 'Typeey Hi' }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 20_000,
+      participants: duplicatedSameHuman,
+      membership: { humans: 1, bots: 1, fetchedAt: 20_000, truncated: false, humanMemberIds: ['alice'] },
+    })
+    expect(decision).toBe('engage')
+  })
+
   test('large truncated channels observe even with one persisted human', () => {
     const ledger = new StickyLedger()
     const decision = decideEngagement({


### PR DESCRIPTION
## Background

A Webex agent in a 2-member group space (one human + the bot) replied to the first message, then went silent for every subsequent message — including identical text. Observed in a real space: 7 messages sent (mix of English `Typeey Hi` and Korean `타이피야`), 1 reply. Container logs showed each message `routed mention=false reply=false` → `observed`, with no permission denial, so the engagement decision itself was suppressing.

Root cause is an identity-keying mismatch that inflates the human count:

- Webex inbound is keyed by `personId` (a UUID); a persisted/legacy participant entry for the same human was keyed by **email**. The two never dedupe, so `participants[]` holds two non-bot rows for one person.
- `resolveEffectiveHumans` only trusts a fresh, **untruncated** membership read over persisted speakers; otherwise it takes `Math.max(persistedHumans, membership.humans)`.
- The Webex membership resolver hardcoded `truncated: true` **even when `listMemberships` enumerated the entire room**. That forced the `Math.max()` path, the duplicate participant won, `effectiveHumans` became 2, and the solo-human "answer everything" fallback never fired.

The first message engaged only because the session was fresh (no persisted duplicate yet); once the human was persisted under both keys, every later message was counted as a 2-human room.

## Summary

Bring the Webex membership resolver in line with the `MembershipCount` contract already implemented by the Slack resolver:

- Mark a read `truncated` **only** when it hits `MEMBERSHIP_ENUMERATION_CAP` (i.e. may be incomplete) instead of unconditionally.
- Classify the self bot by `personId` (threaded in via `botPersonIdRef`) rather than hardcoding `bots = 1`.
- Emit `humanMemberIds` on complete reads, so a fresh authoritative count overrides inflated participant history.

**Why this and not dedup/migration:** the two keys (email vs person UUID) have no join key inside `ChannelParticipant`, so dedup can't merge them; a one-off migration wouldn't prevent recurrence from any future stale/malformed persisted state. Making a complete membership read authoritative — which `resolveEffectiveHumans` was already designed to honor — fixes the count at the source and lets existing rooms recover on the next membership refresh.

## What this does NOT do

- Does not add multi-language aliases. `타이피야` (Korean for "Typeey") still won't match the configured alias `TypeeyBot`; plain-text name addressing in non-English remains **operator config** (add `Typeey`, `타이피`, etc. to `alias`). This PR only restores the solo-human fallback so the agent answers plain messages in a 1-human room regardless of alias.
- Does not add exact peer-bot membership classification. `WebexMembership` exposes no bot/person type field, so only the self bot is classified; peer bots count as humans here. They still reach the agent via mention/reply/sticky triggers.

## Review notes

- Load-bearing change: `truncated = memberships.length >= MEMBERSHIP_ENUMERATION_CAP` in `createWebexMembershipResolver` (`src/channels/adapters/webex-bot.ts`). The invariant to preserve: a complete enumeration must be `truncated: false` with `humanMemberIds` populated, matching `slack-bot.ts`.
- Regression coverage: `webex-bot.test.ts` now asserts a complete read returns `truncated: false` + `humanMemberIds`, and a cap-sized read stays `truncated: true` without `humanMemberIds`. `engagement.test.ts` asserts a duplicate-keyed same-human participant list still engages when a fresh complete membership says 1 human.
