### PR TITLE
test(inspect): deflake live + transcript-view tests under parallel CI

### DIFF
--- a/src/inspect/live.test.ts
+++ b/src/inspect/live.test.ts
@@ -178,9 +178,18 @@ describe('streamLive — live session events', () => {
     const { url } = await startServer({ registry })
 
     const ctrl = new AbortController()
-    const gen = streamLive({ url, sessionId: 'ses_a', signal: ctrl.signal })
+    const subscribed = Promise.withResolvers<void>()
+    const gen = streamLive({
+      url,
+      sessionId: 'ses_a',
+      signal: ctrl.signal,
+      onSubscribed: () => subscribed.resolve(),
+    })
 
-    setTimeout(() => {
+    // Regression: a fixed setTimeout raced the subscribe round-trip under CI
+    // load — the emit fired before the server wired its session subscriber, the
+    // event was dropped, and the test hung to the 30s timeout. Gate on onSubscribed.
+    void subscribed.promise.then(() => {
       session.emit({
         type: 'message_update',
         assistantMessageEvent: { type: 'thinking_delta', delta: 'Should I ' },
@@ -193,7 +202,7 @@ describe('streamLive — live session events', () => {
         type: 'message_update',
         assistantMessageEvent: { type: 'thinking_end', content: 'Should I read the file?' },
       })
-    }, 50)
+    })
 
     const events = await collectN(gen, 1)
     ctrl.abort()
@@ -210,14 +219,23 @@ describe('streamLive — live session events', () => {
     const { url } = await startServer({ registry })
 
     const ctrl = new AbortController()
-    const gen = streamLive({ url, sessionId: 'ses_a', signal: ctrl.signal })
+    const subscribed = Promise.withResolvers<void>()
+    const gen = streamLive({
+      url,
+      sessionId: 'ses_a',
+      signal: ctrl.signal,
+      onSubscribed: () => subscribed.resolve(),
+    })
 
-    setTimeout(() => {
+    // Same subscribe-round-trip race as the thinking_delta test above: gate the
+    // emit on onSubscribed rather than a fixed timeout so the server's session
+    // subscriber is wired before the one-shot thinking_end fires.
+    void subscribed.promise.then(() => {
       session.emit({
         type: 'message_update',
         assistantMessageEvent: { type: 'thinking_end', content: 'one-shot thought' },
       })
-    }, 50)
+    })
 
     const events = await collectN(gen, 1)
     ctrl.abort()

--- a/src/inspect/transcript-view.test.ts
+++ b/src/inspect/transcript-view.test.ts
@@ -47,6 +47,22 @@ class FakeTerminal implements Terminal {
 
 const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 10))
 
+// Polls accumulated terminal writes until the replay render has flushed the
+// expected content. Replaces a fixed `flush()` for the content-asserting tests:
+// a 10ms sleep raced the async pi-tui render under parallel CI load, feeding esc
+// before the frame painted so the asserted text/timestamp was absent.
+async function waitForFrame(
+  terminal: FakeTerminal,
+  predicate: (frame: string) => boolean,
+  timeoutMs = 5000,
+): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate(terminal.writes.join(''))) return
+    await new Promise((r) => setTimeout(r, 5))
+  }
+}
+
 describe('componentFor', () => {
   test('assistant text becomes a Markdown block', () => {
     const ev: InspectEvent = { cat: 'assistant', ts: 1, text: '# hi\n\nbody' }
@@ -245,7 +261,7 @@ describe('createTranscriptView run()', () => {
 
     // when: the viewer replays and we dismiss it
     const runPromise = view.run()
-    await flush()
+    await waitForFrame(terminal, (frame) => frame.includes('first thought') && frame.includes('second thought'))
     terminal.feed('\x1b')
     await runPromise
 
@@ -302,7 +318,7 @@ describe('createTranscriptView run()', () => {
 
     // when: the viewer tails the live run (which overflows the 2-entry window)
     const runPromise = view.run()
-    await flush()
+    await waitForFrame(terminal, (frame) => frame.includes(`thought ${count - 1}`))
     terminal.feed('\x1b')
     await runPromise
 


### PR DESCRIPTION
## Background

The required CI lane (`bun test --parallel`, job `typecheck / lint / format / test` in `.github/workflows/ci.yml`) went red on `main`. Two tests failed even though each passes in isolation, and the Linux and Windows jobs failed on *different* tests — the classic signature of timing flakiness rather than a logic regression.

Both are fixed-timer races against parallel-runner load:

1. **`streamLive` "thinking_*" tests** (`src/inspect/live.test.ts`) emitted their session events on a fixed `setTimeout(…, 50)`. That 50 ms raced the websocket subscribe round-trip: under load the emit fired before the server wired its session subscriber, the event was dropped, and `collectN(gen, 1)` then hung to the 30 000 ms test timeout. This is the exact race the sibling broadcast/inbound tests in the same file already document and guard against.

2. **`createTranscriptView` content tests** (`src/inspect/transcript-view.test.ts`) asserted on the rendered terminal frame after a fixed 10 ms `flush()`. Under load the async pi-tui render hadn't painted yet, so the asserted timestamp/body text was simply absent.

## Summary

Wait for the real signal instead of a wall-clock guess:

- Gate the thinking-event emits on the existing `onSubscribed` callback — the same pattern already used by the broadcast/inbound tests a few cases below — so the server-side subscriber is provably wired before the emit.
- Replace the fixed `flush()` in the two content-asserting transcript tests with a `waitForFrame()` poll that resolves once the expected content has been written, then dismisses the viewer. The esc/q/ctrl-c tests assert on outcome (not rendered content), so they keep `flush()`.

Test-only; no runtime/production code changed.

## What this does NOT do

- Doesn't touch the `windows tests (informational triage)` lane. That job is `continue-on-error: true` and push-only, so its separate failures don't gate the required check.
- Doesn't change `streamLive`/`createTranscriptView` runtime behavior, the test timeouts, or the parallel-runner config.

## Review notes

- The load-bearing change is *waiting on a real edge* (`onSubscribed` / frame content) instead of a fixed delay. Verify no `setTimeout(…)`-then-emit or `flush()`-then-assert-content pattern remains in the two touched tests.
- Verified green locally: `typecheck`, `lint` (0 errors), `format:check`, and `bun test --parallel --timeout 30000` three consecutive runs (9452 pass / 0 fail each).
