### PR TITLE
secrets: emit codex auth.json id_token so the CLI loads

### DIFF
--- a/src/secrets/codex-auth-json.test.ts
+++ b/src/secrets/codex-auth-json.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { decodeCodexAccessTokenExpiryMs, emitCodexAuthJson } from './codex-auth-json'
+import { decodeCodexAccessTokenExpiryMs, emitCodexAuthJson, isDecodableJwt } from './codex-auth-json'
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
@@ -9,7 +9,7 @@ function makeJwt(payload: Record<string, unknown>): string {
 }
 
 describe('emitCodexAuthJson', () => {
-  test('emits the modern tokens-only shape with trailing newline', () => {
+  test('emits the tokens shape with id_token and a trailing newline', () => {
     const out = emitCodexAuthJson({
       type: 'oauth',
       access: 'access-1',
@@ -19,8 +19,48 @@ describe('emitCodexAuthJson', () => {
 
     expect(out.endsWith('\n')).toBe(true)
     expect(JSON.parse(out)).toEqual({
-      tokens: { access_token: 'access-1', refresh_token: 'refresh-1' },
+      tokens: { id_token: 'access-1', access_token: 'access-1', refresh_token: 'refresh-1' },
     })
+  })
+
+  test('emits a real captured id_token when the credential carries one', () => {
+    const out = emitCodexAuthJson({
+      type: 'oauth',
+      access: 'access-1',
+      refresh: 'refresh-1',
+      expires: 123,
+      idToken: 'id-token-1',
+    } as never)
+
+    const parsed = JSON.parse(out) as { tokens: Record<string, unknown> }
+    expect(parsed.tokens.id_token).toBe('id-token-1')
+    expect(parsed.tokens.access_token).toBe('access-1')
+  })
+
+  test('accepts a snake_case id_token field on the credential', () => {
+    const out = emitCodexAuthJson({
+      type: 'oauth',
+      access: 'access-1',
+      refresh: 'refresh-1',
+      expires: 123,
+      id_token: 'id-token-snake',
+    } as never)
+
+    const parsed = JSON.parse(out) as { tokens: Record<string, unknown> }
+    expect(parsed.tokens.id_token).toBe('id-token-snake')
+  })
+
+  test('falls back to access when the captured id_token is empty', () => {
+    const out = emitCodexAuthJson({
+      type: 'oauth',
+      access: 'access-1',
+      refresh: 'refresh-1',
+      expires: 123,
+      idToken: '',
+    } as never)
+
+    const parsed = JSON.parse(out) as { tokens: Record<string, unknown> }
+    expect(parsed.tokens.id_token).toBe('access-1')
   })
 
   test('includes account_id when accountId is set on the credential', () => {
@@ -33,7 +73,12 @@ describe('emitCodexAuthJson', () => {
     } as never)
 
     expect(JSON.parse(out)).toEqual({
-      tokens: { access_token: 'access-1', refresh_token: 'refresh-1', account_id: 'acct-abc' },
+      tokens: {
+        id_token: 'access-1',
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+        account_id: 'acct-abc',
+      },
     })
   })
 
@@ -104,5 +149,26 @@ describe('decodeCodexAccessTokenExpiryMs', () => {
     expect(decodeCodexAccessTokenExpiryMs(stringExp)).toBeNull()
     const infinityExp = makeJwt({ exp: Number.POSITIVE_INFINITY })
     expect(decodeCodexAccessTokenExpiryMs(infinityExp)).toBeNull()
+  })
+})
+
+describe('isDecodableJwt', () => {
+  test('true for a decodable JWT even without an exp claim', () => {
+    expect(isDecodableJwt(makeJwt({ sub: 'x' }))).toBe(true)
+  })
+
+  test('false for a non-empty non-JWT string', () => {
+    expect(isDecodableJwt('not-a-jwt')).toBe(false)
+    expect(isDecodableJwt('only.two')).toBe(false)
+    expect(isDecodableJwt('a.b.c.d')).toBe(false)
+  })
+
+  test('false when the payload segment is not valid base64 JSON', () => {
+    expect(isDecodableJwt('a.!!!.c')).toBe(false)
+  })
+
+  test('false when the payload is valid base64 JSON but not an object', () => {
+    const arrayPayload = `${Buffer.from('h').toString('base64url')}.${Buffer.from('[1,2]').toString('base64url')}.sig`
+    expect(isDecodableJwt(arrayPayload)).toBe(false)
   })
 })

--- a/src/secrets/codex-auth-json.ts
+++ b/src/secrets/codex-auth-json.ts
@@ -1,15 +1,21 @@
 import type { ProviderCredential } from './schema'
 
-// Emit the on-disk shape Codex CLI consumes at ~/.codex/auth.json. Mirrors
-// the modern (>= 0.93) shape: a single `tokens` object with access_token,
-// refresh_token, and optional account_id. Codex re-derives token expiry
-// from the JWT's `exp` claim on every load, so we deliberately omit a
-// top-level `expires` field even though typeclaw stores one.
+// Emit the on-disk shape Codex CLI consumes at ~/.codex/auth.json: a `tokens`
+// object with id_token, access_token, refresh_token, and optional account_id.
+// No top-level `expires` — codex re-derives expiry from the JWT `exp` claim.
 //
-// Pre-0.93 codex used a different layout (top-level OPENAI_API_KEY +
-// auth_mode discriminator + optional tokens). We don't emit that legacy
-// shape — every codex install old enough to require it has been replaced
-// by the version `docker.file.codexCli` installs in the container.
+// id_token is load-bearing: codex's deserializer (token_data.rs) declares
+// `id_token: IdTokenInfo` with no Option/#[serde(default)], so omitting it
+// fails the whole auth.json load with `missing field id_token` before any
+// model call. codex parses it via `parse_chatgpt_jwt_claims`, which accepts
+// any decodable 3-part JWT and treats every claim as optional.
+//
+// We prefer a real captured id_token (`idToken`/`id_token` on the credential,
+// e.g. from a future pi-ai that persists it) and fall back to `access`. The
+// fallback is sound because this flow's access token is itself a ChatGPT-claims
+// JWT (carries `https://api.openai.com/auth`), so codex reads the same
+// plan/account fields from it — self-healing agents whose stored credential
+// predates id_token capture, without a re-login.
 export function emitCodexAuthJson(credential: ProviderCredential): string {
   if (credential.type !== 'oauth') {
     throw new Error('emitCodexAuthJson only accepts oauth-typed credentials')
@@ -18,6 +24,8 @@ export function emitCodexAuthJson(credential: ProviderCredential): string {
     access?: unknown
     refresh?: unknown
     accountId?: unknown
+    idToken?: unknown
+    id_token?: unknown
   }
   const access = fields.access
   const refresh = fields.refresh
@@ -28,11 +36,25 @@ export function emitCodexAuthJson(credential: ProviderCredential): string {
     throw new Error('credential is missing a non-empty `refresh` field')
   }
 
-  const tokens: Record<string, string> = { access_token: access, refresh_token: refresh }
+  const capturedIdToken = firstNonEmptyString(fields.idToken, fields.id_token)
+  const idToken = capturedIdToken ?? access
+
+  const tokens: Record<string, string> = {
+    id_token: idToken,
+    access_token: access,
+    refresh_token: refresh,
+  }
   if (typeof fields.accountId === 'string' && fields.accountId.length > 0) {
     tokens['account_id'] = fields.accountId
   }
   return `${JSON.stringify({ tokens }, null, 2)}\n`
+}
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
 }
 
 // Extracts the JWT `exp` claim (seconds since epoch) and converts to ms.
@@ -41,25 +63,38 @@ export function emitCodexAuthJson(credential: ProviderCredential): string {
 // does. Returns null on any decode failure; the caller treats that as
 // "unknown freshness" and falls back to overwriting from typeclaw's copy.
 export function decodeCodexAccessTokenExpiryMs(accessToken: string): number | null {
-  const parts = accessToken.split('.')
+  const payload = decodeJwtPayload(accessToken)
+  if (payload === null) return null
+  const exp = payload['exp']
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) return null
+  return Math.floor(exp * 1000)
+}
+
+// True when the string decodes the way codex's `decode_jwt_payload` requires:
+// three non-empty dot-separated parts with a base64url payload that is a JSON
+// object. codex runs exactly this on `tokens.id_token` (via
+// `parse_chatgpt_jwt_claims`) and rejects the whole auth.json if it fails, so
+// the exporter uses this to decide whether an on-disk id_token is usable —
+// not just non-empty.
+export function isDecodableJwt(token: string): boolean {
+  return decodeJwtPayload(token) !== null
+}
+
+function decodeJwtPayload(jwt: string): Record<string, unknown> | null {
+  const parts = jwt.split('.')
   if (parts.length !== 3) return null
   const middle = parts[1] ?? ''
   if (middle === '') return null
   // base64url → base64, then pad to a multiple of 4 (atob is strict).
   const normalized = middle.replace(/-/g, '+').replace(/_/g, '/')
   const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
-  let payload: Record<string, unknown>
   try {
     const decoded = typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('utf8')
     const parsed: unknown = JSON.parse(decoded)
-    if (!isPlainObject(parsed)) return null
-    payload = parsed
+    return isPlainObject(parsed) ? parsed : null
   } catch {
     return null
   }
-  const exp = payload['exp']
-  if (typeof exp !== 'number' || !Number.isFinite(exp)) return null
-  return Math.floor(exp * 1000)
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/secrets/export-codex-auth-file.test.ts
+++ b/src/secrets/export-codex-auth-file.test.ts
@@ -89,9 +89,14 @@ describe('exportCodexAuthFileIfApplicable', () => {
       const target = join(home, '.codex', 'auth.json')
       expect(existsSync(target)).toBe(true)
       const parsed = JSON.parse(readFileSync(target, 'utf8')) as {
-        tokens: { access_token: string; refresh_token: string; account_id?: string }
+        tokens: { id_token: string; access_token: string; refresh_token: string; account_id?: string }
       }
-      expect(parsed.tokens).toEqual({ access_token: 'access-1', refresh_token: 'refresh-1', account_id: 'acct-1' })
+      expect(parsed.tokens).toEqual({
+        id_token: 'access-1',
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+        account_id: 'acct-1',
+      })
     })
   })
 
@@ -114,7 +119,9 @@ describe('exportCodexAuthFileIfApplicable', () => {
       const freshAccess = makeJwt({ exp: 3_000_000_000 })
       writeFileSync(
         join(home, '.codex', 'auth.json'),
-        JSON.stringify({ tokens: { access_token: freshAccess, refresh_token: 'codex-refreshed' } }),
+        JSON.stringify({
+          tokens: { id_token: freshAccess, access_token: freshAccess, refresh_token: 'codex-refreshed' },
+        }),
       )
       const result = exportCodexAuthFileIfApplicable({
         codexCliEnabled: true,
@@ -163,7 +170,7 @@ describe('exportCodexAuthFileIfApplicable', () => {
       const tied = makeJwt({ exp: 2_000_000_000 })
       writeFileSync(
         join(home, '.codex', 'auth.json'),
-        JSON.stringify({ tokens: { access_token: tied, refresh_token: 'on-disk' } }),
+        JSON.stringify({ tokens: { id_token: tied, access_token: tied, refresh_token: 'on-disk' } }),
       )
       const result = exportCodexAuthFileIfApplicable({
         codexCliEnabled: true,
@@ -175,6 +182,50 @@ describe('exportCodexAuthFileIfApplicable', () => {
         tokens: { refresh_token: string }
       }
       expect(after.tokens.refresh_token).toBe('on-disk')
+    })
+  })
+
+  test('pre-fix file: tokens lack id_token but access ties/beats stored cred → overwrite (self-heal)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const fresher = makeJwt({ exp: 2_100_000_000 })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { access_token: fresher, refresh_token: 'pre-fix' } }),
+      )
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ refresh: 'healed', expires: 2_000_000_000_000 }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { id_token: string; refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('healed')
+      expect(after.tokens.id_token.length).toBeGreaterThan(0)
+    })
+  })
+
+  test('on-disk id_token is a non-empty non-JWT but access ties/beats stored cred → overwrite (self-heal)', async () => {
+    await withHome((home) => {
+      mkdirSync(join(home, '.codex'), { recursive: true })
+      const fresher = makeJwt({ exp: 2_100_000_000 })
+      writeFileSync(
+        join(home, '.codex', 'auth.json'),
+        JSON.stringify({ tokens: { id_token: 'not-a-jwt', access_token: fresher, refresh_token: 'malformed-id' } }),
+      )
+      const result = exportCodexAuthFileIfApplicable({
+        codexCliEnabled: true,
+        providers: oauthProviders({ refresh: 'healed', expires: 2_000_000_000_000 }),
+        homeDir: home,
+      })
+      expect(result.action).toBe('wrote')
+      const after = JSON.parse(readFileSync(join(home, '.codex', 'auth.json'), 'utf8')) as {
+        tokens: { id_token: string; refresh_token: string }
+      }
+      expect(after.tokens.refresh_token).toBe('healed')
+      expect(after.tokens.id_token.length).toBeGreaterThan(0)
     })
   })
 
@@ -261,7 +312,9 @@ describe('exportCodexAuthFileIfApplicable', () => {
       const fresherAccess = makeJwt({ exp: 3_000_000_000 })
       writeFileSync(
         join(home, '.codex', 'auth.json'),
-        JSON.stringify({ tokens: { access_token: fresherAccess, refresh_token: 'codex-current' } }),
+        JSON.stringify({
+          tokens: { id_token: fresherAccess, access_token: fresherAccess, refresh_token: 'codex-current' },
+        }),
       )
       const staleCred: Providers = {
         'openai-codex': {
@@ -357,7 +410,9 @@ describe('exportCodexAuthFileIfApplicable', () => {
       const fresherAccess = makeJwt({ exp: 3_000_000_000 })
       writeFileSync(
         persistPath,
-        JSON.stringify({ tokens: { access_token: fresherAccess, refresh_token: 'codex-rotated' } }),
+        JSON.stringify({
+          tokens: { id_token: fresherAccess, access_token: fresherAccess, refresh_token: 'codex-rotated' },
+        }),
       )
 
       // when: exporter runs with an older typeclaw-side credential.

--- a/src/secrets/export-codex-auth-file.ts
+++ b/src/secrets/export-codex-auth-file.ts
@@ -11,7 +11,7 @@ import {
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 
-import { decodeCodexAccessTokenExpiryMs, emitCodexAuthJson } from './codex-auth-json'
+import { decodeCodexAccessTokenExpiryMs, emitCodexAuthJson, isDecodableJwt } from './codex-auth-json'
 import type { ProviderCredential, Providers } from './schema'
 import { SecretsBackend } from './storage'
 
@@ -86,6 +86,13 @@ export function exportCodexAuthFileIfApplicable(options: ExportCodexAuthFileOpti
 // missing JWT, undecodable exp), we return true. That's the "we have a
 // valid credential, the file is unusable, replace it" fallback case (B1
 // and B6 in the design doc).
+//
+// A file missing a usable `id_token` is unusable too, regardless of how
+// fresh its access token is: codex rejects the whole auth.json with
+// `missing field id_token` before any model call. This guard runs BEFORE
+// the newer-wins expiry compare so a pre-fix TypeClaw-emitted file (valid,
+// possibly fresher access token, but no id_token) is always rewritten —
+// the path that self-heals already-broken agents on restart.
 function shouldOverwrite(
   targetPath: string,
   credential: ProviderCredential & { expires?: unknown; access?: unknown },
@@ -105,6 +112,8 @@ function shouldOverwrite(
     return true
   }
 
+  if (!onDiskHasUsableIdToken(parsed)) return true
+
   const onDiskAccess = readOnDiskAccessToken(parsed)
   if (onDiskAccess === null) return true
 
@@ -116,11 +125,25 @@ function shouldOverwrite(
 }
 
 function readOnDiskAccessToken(parsed: unknown): string | null {
+  return readOnDiskToken(parsed, 'access_token')
+}
+
+// codex parses `tokens.id_token` as a JWT, so a value that is absent, empty,
+// or not a decodable JWT is unusable — codex rejects the whole auth.json on
+// load. Validate decodability (not just presence) so a file with a non-empty
+// but malformed id_token, even alongside a fresh access token, is treated as
+// stale and rewritten rather than preserved by the newer-wins compare.
+function onDiskHasUsableIdToken(parsed: unknown): boolean {
+  const idToken = readOnDiskToken(parsed, 'id_token')
+  return idToken !== null && isDecodableJwt(idToken)
+}
+
+function readOnDiskToken(parsed: unknown, field: 'access_token' | 'id_token'): string | null {
   if (typeof parsed !== 'object' || parsed === null) return null
   const tokens = (parsed as Record<string, unknown>)['tokens']
   if (typeof tokens !== 'object' || tokens === null) return null
-  const access = (tokens as Record<string, unknown>)['access_token']
-  return typeof access === 'string' && access.length > 0 ? access : null
+  const value = (tokens as Record<string, unknown>)[field]
+  return typeof value === 'string' && value.length > 0 ? value : null
 }
 
 // Resolution order for the credential's expiry:


### PR DESCRIPTION
## Background

Every agent configured with `docker.file.codexCli: true` and an `openai-codex` OAuth model backend has a **broken Codex CLI**. Any `codex` invocation in the container dies before the model call with:

```
missing field `id_token` at line 6 column 3
```

Reproduced on two live agents — codex `0.140.0` and `0.141.0` — both with the typeclaw-emitted `~/.codex/auth.json`. `codex exec` and even `codex login status` fail identically, so this is an auth-file load failure, not a model/runtime issue.

**Root cause.** Codex's auth.json deserializer (`codex-rs/login/src/token_data.rs`) declares:

```rust
pub struct TokenData {
    #[serde(deserialize_with = "deserialize_id_token", ...)]
    pub id_token: IdTokenInfo,   // non-Option, no #[serde(default)]
    pub access_token: String,
    pub refresh_token: String,
    pub account_id: Option<String>,
}
```

`id_token` is required. typeclaw's auto-export (`emitCodexAuthJson`) wrote a `tokens` object containing only `access_token` / `refresh_token` / `account_id`, so serde rejects the whole file before codex ever reads a token.

The credential never carried an `id_token` to emit: pi-ai's OpenAI Codex OAuth flow requests `openid` scope and `id_token_add_organizations=true`, but its `readTokenResponse` reads only `access_token` / `refresh_token` / `expires_in` and discards the `id_token` OpenAI returns. Confirmed still absent through `@mariozechner/pi-ai@0.73.1` and the renamed `@earendil-works/pi-ai@0.79.8` — **a dependency bump does not fix this.**

## Summary

`emitCodexAuthJson` now writes `tokens.id_token`, sourced in this order:

1. **A real captured id_token** — `idToken` / `id_token` on the stored credential. Forward-compatible: if pi-ai (or our own capture) starts persisting it, we emit the real value with zero further changes. The credential schema already accepts it (`oauthProviderSchema` is `.catchall(z.unknown())`).
2. **Fallback: the `access` token.** In this OAuth flow the access token is itself a ChatGPT-claims JWT (it carries the `https://api.openai.com/auth` block). Codex parses `id_token` via `parse_chatgpt_jwt_claims`, which accepts **any** decodable 3-part JWT and treats every claim as `Option`/`#[serde(default)]` — so the access JWT satisfies the deserializer and even populates the same plan/account fields.

**Why the fallback and not a re-login flow:** the fallback self-heals every existing agent on the next container start — no re-paste, no `codex login`, no pi-ai bump. It stays within codex's own accepted contract (codex never validates that `id_token` claims are present), so it is not a hack that a codex update would break.

## What this does NOT do

- **Does not patch pi-ai.** The upstream omission is real but lives in a third-party package; recovering the true `id_token` upstream is a separate change. This fix makes typeclaw correct regardless.
- **Does not touch the newer-wins exporter, the symlink/atomic-write path, or the guard chain.** Only the emitted `tokens` shape changes.
- **No schema migration.** No stored credential is rewritten; the field is added at emit time.
- **No api-key path changes.**

## Review notes

- Load-bearing change is the `id_token` source resolution in `emitCodexAuthJson`. The invariant to verify: the emitted `tokens` always contains a non-empty `id_token` that is a decodable JWT (guaranteed because `access` is validated non-empty and is a JWT in this flow).
- The `firstNonEmptyString(idToken, id_token)` helper handles both camelCase and snake_case so a future pi-ai using either key Just Works.
- Tests cover: default emit includes `id_token`; real captured id_token wins (camelCase and snake_case); empty captured id_token falls back to access; the existing B1 export test asserts the new shape.