### PR TITLE
webex: decode personId in the authentication log line

### DIFF
--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -399,6 +399,34 @@ describe('webex lifecycle', () => {
     expect(router.unregistered).toEqual(router.registered)
   })
 
+  test('auth log decodes the base64 personId to its readable ref', async () => {
+    const personId = 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9iMjc4ODgyZS1iMjhiLTRjYzQtYjA4Yi00YjA4ZGI3MzY5ZGI'
+    const log = logger()
+    const adapter = createWebexBotAdapter({
+      router: new FakeRouter().value,
+      configRef: () => config,
+      token: 'token-1',
+      logger: log,
+      createClient: () =>
+        ({
+          ...fakeClient(),
+          testAuth: async () => ({
+            id: personId,
+            emails: ['typeey@example.com'],
+            displayName: 'Typeey',
+            orgId: 'org-1',
+            type: 'bot',
+            created: '',
+          }),
+        }) as ReturnType<typeof fakeClient>,
+      createListener: () => new FakeListener().value,
+    })
+
+    await adapter.start()
+
+    expect(log.lines).toContain('info:[webex-bot] authenticated as Typeey (b278882e-b28b-4cc4-b08b-4b08db7369db)')
+  })
+
   test('rolls back registrations when listener start fails', async () => {
     const listener = new FakeListener({ failStart: true })
     const router = new FakeRouter()

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -32,6 +32,7 @@ import type {
 import { createWebexChannelNameResolver } from './webex-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-bot-classify'
 import { enrichWebexMessageReference } from './webex-bot-reference'
+import { toRef } from './webex-id-ref'
 
 export type WebexBotAdapterLogger = {
   info: (msg: string) => void
@@ -332,7 +333,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
       try {
         await client.login({ token: options.token })
         botPerson = await client.testAuth()
-        logger.info(`[webex-bot] authenticated as ${botPerson.displayName} (${botPerson.id})`)
+        logger.info(`[webex-bot] authenticated as ${botPerson.displayName} (${toRef(botPerson.id)})`)
       } catch (err) {
         started = false
         botPerson = null

--- a/src/channels/adapters/webex.test.ts
+++ b/src/channels/adapters/webex.test.ts
@@ -134,6 +134,32 @@ describe('createWebexAdapter', () => {
     ])
   })
 
+  test('auth log decodes the base64 personId to its readable ref', async () => {
+    // base64url of ciscospark://us/PEOPLE/b278882e-b28b-4cc4-b08b-4b08db7369db
+    const personId = 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9iMjc4ODgyZS1iMjhiLTRjYzQtYjA4Yi00YjA4ZGI3MzY5ZGI'
+    const log = logger()
+    const adapter = createWebexAdapter({
+      router: router(),
+      configRef: () => config,
+      logger: log,
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        ({
+          login: async () => {},
+          testAuth: async () => ({ id: personId, emails: ['typeey@example.com'], displayName: 'Typeey' }),
+          listMemberships: async () => [],
+          listMessages: async () => [],
+          sendMessage: async () => ({ id: 'sent' }),
+          uploadFile: async () => ({ id: 'uploaded' }),
+        }) as unknown as ReturnType<NonNullable<Parameters<typeof createWebexAdapter>[0]['createClient']>>,
+      createListener: () => new FakeListener() as unknown as WebexListener,
+    })
+
+    await adapter.start()
+
+    expect(log.lines).toContain('info:[webex] authenticated as Typeey (b278882e-b28b-4cc4-b08b-4b08db7369db)')
+  })
+
   test('missing account throws the documented error', async () => {
     const adapter = createWebexAdapter({
       router: router(),

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -34,6 +34,7 @@ import type { WebexAccountRecord } from '@/secrets/schema'
 
 import { createWebexChannelNameResolver } from './webex-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-classify'
+import { toRef } from './webex-id-ref'
 import { enrichWebexMessageReference } from './webex-reference'
 
 export type WebexAdapterLogger = {
@@ -347,7 +348,7 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
         currentToken = account.access_token
         await client.login({ token: account.access_token, deviceUrl: account.device_url, tokenType: 'password' })
         botPerson = await client.testAuth()
-        logger.info(`[webex] authenticated as ${botPerson.displayName} (${botPerson.id})`)
+        logger.info(`[webex] authenticated as ${botPerson.displayName} (${toRef(botPerson.id)})`)
       } catch (err) {
         started = false
         currentToken = null


### PR DESCRIPTION
## Background

#969 made Webex REST ids readable across the human-facing layer — permission rule matching, role-claim writing, and `inspect` labeling — by decoding the opaque base64 blob (`Y2lzY29zcGFyazov...`) to its trailing UUID ref. One human-facing surface slipped through: the adapter **authentication log line**.

On startup both Webex adapters emit:

```
[webex] authenticated as Typeey (Y2lzY29zcGFyazovL3VzL1BFT1BMRS9iMjc4ODgyZS1iMjhiLTRjYzQtYjA4Yi00YjA4ZGI3MzY5ZGI)
```

— the same opaque blob #969 set out to eliminate. An operator reading logs to confirm which identity the agent authenticated as still has to base64-decode by hand to correlate it with a real person.

## Summary

Route `botPerson.id` through `toRef` (`src/channels/adapters/webex-id-ref.ts`, the decoder #969 introduced) in both `webex.ts` and `webex-bot.ts` auth log lines. The line now reads:

```
[webex] authenticated as Typeey (b278882e-b28b-4cc4-b08b-4b08db7369db)
```

`toRef` is fall-open: a non-Webex value (or one already in ref form) passes through unchanged, so this is safe even if upstream ever returns a non-REST id.

This is **display-only**. The canonical base64 id remains the wire and session-key currency — the identity payload at `webex.ts:281` / `webex-bot.ts:271` (`{ id: botPerson.id, ... }`) is deliberately left raw, matching #969's "base64 stays the wire currency" invariant.

## What this does NOT do

- **Touch any id used as a key or identity.** Only the log string changes; routing, session keys, and the `selfIdentity` payload still carry the raw base64 id.
- **Re-audit the other adapters' auth logs.** Slack/Discord/Telegram/LINE/KakaoTalk log their own native ids, which are already human-readable — no decoder needed.

## Review notes

The load-bearing property is that `toRef` is **display-only and fall-open**: it must never be threaded into a code path that compares or keys on the id. Confirm the two changed lines are the only new `toRef` call sites and that the `{ id: botPerson.id }` identity objects are untouched.

New tests assert the decode end-to-end using the exact production id from the reported log (`Y2lzY29z…` → `b278882e-…`): `auth log decodes the base64 personId to its readable ref` in both `webex.test.ts` and `webex-bot.test.ts`.
