### PR TITLE
channels: send Webex messages as plain text to fix HTML escaping leakage

### DIFF
--- a/src/channels/adapters/webex-bot-reference.ts
+++ b/src/channels/adapters/webex-bot-reference.ts
@@ -2,6 +2,8 @@ import type { WebexBotClient } from 'agent-messenger/webexbot'
 
 import type { InboundMessage, QuoteAnchorSource } from '@/channels/types'
 
+import { resolveWebexBodyText } from './webex-format'
+
 // Webex Mercury delivers only the parent message id inline, not its author,
 // so the classifier cannot tell whether a reply targets the bot. We fetch the
 // parent here (already needed for the quote anchor) and use its author to set
@@ -24,7 +26,7 @@ export async function enrichWebexMessageReference(args: {
       adapter: 'webex-bot',
       authorId: parent.personId,
       authorName: parent.personEmail,
-      text: parent.text ?? parent.markdown ?? parent.html ?? '',
+      text: resolveWebexBodyText(parent),
     }
     if (source.text.trim() === '') return attributed
     return { ...attributed, referenceContext: { kind: 'reply', sources: [source] } }

--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -57,15 +57,16 @@ describe('webex outbound', () => {
     }
   }
 
-  test('sends a markdown message with no parentId for a non-threaded reply', async () => {
+  test('sends a plain-text message with no parentId for a non-threaded reply', async () => {
     const { sends, uploads, client } = outboundClient()
     const cb = createOutboundCallback({ client, logger: logger(), formatChannelTag: async () => 'room=Room(room-1)' })
 
-    // given: Korean body to keep the markdown path script-agnostic
+    // given: Korean body to keep the path script-agnostic
     const result = await cb(outbound({ text: '**안녕하세요**' }))
 
     expect(result).toEqual({ ok: true })
-    expect(sends).toEqual([{ roomId: 'room-1', text: '**안녕하세요**', markdown: true, parentId: undefined }])
+    // markdown is omitted so Webex's E2E path does not render verbatim HTML
+    expect(sends).toEqual([{ roomId: 'room-1', text: '**안녕하세요**', markdown: undefined, parentId: undefined }])
     expect(uploads).toEqual([])
   })
 
@@ -75,7 +76,7 @@ describe('webex outbound', () => {
 
     await cb(outbound({ text: 'hi', thread: 'root-1' }))
 
-    expect(sends).toEqual([{ roomId: 'room-1', text: 'hi', markdown: true, parentId: 'root-1' }])
+    expect(sends).toEqual([{ roomId: 'room-1', text: 'hi', markdown: undefined, parentId: 'root-1' }])
   })
 
   test('prefers replyTo over msg.thread for the parentId anchor', async () => {

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -32,6 +32,7 @@ import type {
 import { createWebexChannelNameResolver } from './webex-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-bot-classify'
 import { enrichWebexMessageReference } from './webex-bot-reference'
+import { resolveWebexBodyText } from './webex-format'
 import { toRef } from './webex-id-ref'
 
 export type WebexBotAdapterLogger = {
@@ -113,7 +114,6 @@ export function createOutboundCallback(deps: {
           if (attachment.filename !== undefined) file.filename = attachment.filename
           const carriesText = index === 0 && text !== ''
           const sent = await client.uploadFile(msg.chat, file, {
-            markdown: true,
             ...(carriesText ? { text } : {}),
             ...(parentId !== undefined ? { parentId } : {}),
           })
@@ -122,10 +122,7 @@ export function createOutboundCallback(deps: {
         return { ok: true }
       }
 
-      const sent = await client.sendMessage(msg.chat, text, {
-        markdown: true,
-        ...(parentId !== undefined ? { parentId } : {}),
-      })
+      const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)
       logger.info(`[webex-bot] sent id=${sent.id} ${tag}`)
       return { ok: true }
     } catch (err) {
@@ -425,7 +422,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
 
 function mapWebexHistoryMessage(msg: WebexMessage, botPersonId: string | null): ChannelHistoryMessage {
   const attachments = (msg.files ?? []).map((ref, index) => ({ id: index + 1, kind: 'file' as const, ref }))
-  const body = msg.text ?? msg.markdown ?? msg.html ?? ''
+  const body = resolveWebexBodyText(msg)
   const text = attachments.length === 0 ? body : body === '' ? '[Webex attachment]' : `${body}\n[Webex attachment]`
   const ts = Date.parse(msg.created)
   return {

--- a/src/channels/adapters/webex-format.test.ts
+++ b/src/channels/adapters/webex-format.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+
+import { normalizeWebexHtmlFallbackText, resolveWebexBodyText } from './webex-format'
+
+describe('normalizeWebexHtmlFallbackText', () => {
+  test('decodes named and numeric entities', () => {
+    expect(normalizeWebexHtmlFallbackText('You&apos;re paired')).toBe("You're paired")
+    expect(normalizeWebexHtmlFallbackText('You&#39;re paired')).toBe("You're paired")
+    expect(normalizeWebexHtmlFallbackText('a &amp; b &lt; c &gt; d &quot;e&quot;')).toBe('a & b < c > d "e"')
+  })
+
+  test('converts <br/> to newlines and strips other tags', () => {
+    expect(normalizeWebexHtmlFallbackText('line 1<br/>line 2')).toBe('line 1\nline 2')
+    expect(normalizeWebexHtmlFallbackText('para 1<br/><br/>para 2')).toBe('para 1\n\npara 2')
+    expect(normalizeWebexHtmlFallbackText('<p>para 1</p><p>para 2</p>')).toBe('para 1\n\npara 2')
+    expect(normalizeWebexHtmlFallbackText('a <strong>bold</strong> b')).toBe('a bold b')
+  })
+
+  test('preserves non-Latin content while decoding entities and breaks', () => {
+    expect(normalizeWebexHtmlFallbackText('확인해볼게요<br/>안녕하세요')).toBe('확인해볼게요\n안녕하세요')
+    expect(normalizeWebexHtmlFallbackText('日本語&amp;テスト')).toBe('日本語&テスト')
+  })
+
+  test('combined real-world fallback', () => {
+    expect(normalizeWebexHtmlFallbackText('You&apos;re paired<br/><br/>혹시 맥락 있으면 알려주세요')).toBe(
+      "You're paired\n\n혹시 맥락 있으면 알려주세요",
+    )
+  })
+})
+
+describe('resolveWebexBodyText', () => {
+  test('prefers raw plain text without normalizing literal entities', () => {
+    expect(resolveWebexBodyText({ text: 'a & b < c', markdown: 'x', html: 'y' })).toBe('a & b < c')
+  })
+
+  test('falls back to raw markdown without normalizing', () => {
+    expect(resolveWebexBodyText({ text: undefined, markdown: '**bold** & raw', html: 'y' })).toBe('**bold** & raw')
+    expect(resolveWebexBodyText({ text: '', markdown: '**bold** & raw', html: 'y' })).toBe('**bold** & raw')
+  })
+
+  test('normalizes only the html fallback', () => {
+    expect(resolveWebexBodyText({ text: undefined, markdown: undefined, html: 'You&apos;re here<br/>line 2' })).toBe(
+      "You're here\nline 2",
+    )
+  })
+
+  test('returns empty string when no body present', () => {
+    expect(resolveWebexBodyText({ text: undefined, markdown: undefined, html: undefined })).toBe('')
+    expect(resolveWebexBodyText({ text: '', markdown: '', html: '' })).toBe('')
+  })
+})

--- a/src/channels/adapters/webex-format.ts
+++ b/src/channels/adapters/webex-format.ts
@@ -1,0 +1,53 @@
+import type { WebexMessage } from 'agent-messenger/webex'
+
+// Webex's E2E (internal conversation) path renders agent markdown as an HTML
+// `content` field that some clients display verbatim, so messages sent with
+// `markdown: true` leak literal `<br/>` and `&apos;`. typeclaw sends plain text
+// outbound; inbound we still read the HTML `html` field as a fallback, so this
+// undoes that HTML. Protocol HTML (not natural language) -> ASCII literal set.
+
+// Normalize ONLY the HTML `html` fallback: `text`/`markdown` are author-clean and
+// must stay raw, or literal `&`/`<` the user typed would be corrupted.
+export function resolveWebexBodyText(msg: Pick<WebexMessage, 'text' | 'markdown' | 'html'>): string {
+  if (msg.text !== undefined && msg.text !== '') return msg.text
+  if (msg.markdown !== undefined && msg.markdown !== '') return msg.markdown
+  if (msg.html !== undefined && msg.html !== '') return normalizeWebexHtmlFallbackText(msg.html)
+  return ''
+}
+
+export function normalizeWebexHtmlFallbackText(value: string): string {
+  const withBreaks = value
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>\s*<p[^>]*>/gi, '\n\n')
+    .replace(/<\/?[^>]+>/g, '')
+  return decodeHtmlEntities(withBreaks)
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x[0-9a-f]+|#\d+|amp|lt|gt|quot|apos|nbsp);/gi, (match, entity: string) => {
+    const lower = entity.toLowerCase()
+    if (lower.startsWith('#x')) return codePoint(Number.parseInt(lower.slice(2), 16))
+    if (lower.startsWith('#')) return codePoint(Number.parseInt(lower.slice(1), 10))
+    switch (lower) {
+      case 'amp':
+        return '&'
+      case 'lt':
+        return '<'
+      case 'gt':
+        return '>'
+      case 'quot':
+        return '"'
+      case 'apos':
+        return "'"
+      case 'nbsp':
+        return ' '
+      default:
+        return match
+    }
+  })
+}
+
+function codePoint(value: number): string {
+  if (!Number.isFinite(value) || value < 0 || value > 0x10ffff) return ''
+  return String.fromCodePoint(value)
+}

--- a/src/channels/adapters/webex-reference.ts
+++ b/src/channels/adapters/webex-reference.ts
@@ -2,6 +2,8 @@ import type { WebexClient } from 'agent-messenger/webex'
 
 import type { InboundMessage, QuoteAnchorSource } from '@/channels/types'
 
+import { resolveWebexBodyText } from './webex-format'
+
 // Webex Mercury delivers only the parent message id inline, not its author,
 // so the classifier cannot tell whether a reply targets the bot. We fetch the
 // parent here (already needed for the quote anchor) and use its author to set
@@ -24,7 +26,7 @@ export async function enrichWebexMessageReference(args: {
       adapter: 'webex',
       authorId: parent.personId,
       authorName: parent.personEmail,
-      text: parent.text ?? parent.markdown ?? parent.html ?? '',
+      text: resolveWebexBodyText(parent),
     }
     if (source.text.trim() === '') return attributed
     return { ...attributed, referenceContext: { kind: 'reply', sources: [source] } }

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -34,6 +34,7 @@ import type { WebexAccountRecord } from '@/secrets/schema'
 
 import { createWebexChannelNameResolver } from './webex-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-classify'
+import { resolveWebexBodyText } from './webex-format'
 import { toRef } from './webex-id-ref'
 import { enrichWebexMessageReference } from './webex-reference'
 
@@ -118,7 +119,6 @@ export function createOutboundCallback(deps: {
           if (attachment.filename !== undefined) file.filename = attachment.filename
           const carriesText = index === 0 && text !== ''
           const sent = await client.uploadFile(msg.chat, file, {
-            markdown: true,
             ...(carriesText ? { text } : {}),
             ...(parentId !== undefined ? { parentId } : {}),
           })
@@ -127,10 +127,7 @@ export function createOutboundCallback(deps: {
         return { ok: true }
       }
 
-      const sent = await client.sendMessage(msg.chat, text, {
-        markdown: true,
-        ...(parentId !== undefined ? { parentId } : {}),
-      })
+      const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)
       logger.info(`[webex] sent id=${sent.id} ${tag}`)
       return { ok: true }
     } catch (err) {
@@ -450,7 +447,7 @@ function mapWebexHistoryMessage(
   authorById: ReadonlyMap<string, string>,
 ): ChannelHistoryMessage {
   const attachments = (msg.files ?? []).map((ref, index) => ({ id: index + 1, kind: 'file' as const, ref }))
-  const body = msg.text ?? msg.markdown ?? msg.html ?? ''
+  const body = resolveWebexBodyText(msg)
   const text = attachments.length === 0 ? body : body === '' ? '[Webex attachment]' : `${body}\n[Webex attachment]`
   const ts = Date.parse(msg.created)
   return {


### PR DESCRIPTION
## Background

A Webex message the agent sent rendered with raw HTML in the human's client:

```
1. You&apos;re paired as owner. Welcome aboard!
2.
이 채널은 end-to-end 암호화돼 있어서 ...암호문(eyJlbmMi... blob)으로만 보여요...<br/><br/>혹시 Webex 앱에서...
```

`&apos;` (should be `'`) and literal `<br/><br/>` (should be line breaks) leak into the text the human reads.

**Root cause.** The Webex adapter sent outbound text with `{ markdown: true }`. On an end-to-end-encrypted space the upstream `agent-messenger` WebexClient takes its internal-conversation path, where `buildEncryptedObject` sets `content = markdownToHtml(text)` — HTML with `<br/><br/>` between paragraphs and entity-escaped punctuation — alongside a plain-text `displayName`. In this E2E/internal path the client surfaces the HTML `content` field verbatim instead of rendering it, so the human sees the HTML source. The two leaking artifacts appearing together (`&apos;` *and* `<br/>`) is the tell that the HTML content field is shown as-is. We can't change the upstream SDK, so the fix lives in the adapter layer.

## Summary

- **Outbound:** drop `markdown: true` from `sendMessage` and `uploadFile` on both the user-token (`webex.ts`) and bot-token (`webex-bot.ts`) adapters. With markdown off, the upstream sends only the clean plain-text body, so nothing HTML-encoded reaches the client. Trade-off: Webex messages lose bold/links/code rendering — chosen over occasionally shipping visibly broken HTML, per the same reasoning the other plain-text adapters (KakaoTalk/LINE) already follow.
- **Inbound (defensive):** add `resolveWebexBodyText`, used at the history-map and reply-reference readback sites. It returns the author-clean `text`/`markdown` fields untouched and only decodes HTML entities + converts `<br/>`/`<p>` to newlines when readback falls back to the HTML field — so old messages and any future content fallback read cleanly, while literal `&`/`<` a user actually typed are preserved.

## What this does NOT do

- Does not modify `agent-messenger` (the upstream HTML conversion is unchanged; we just stop requesting it).
- Does not add rich-text rendering for Webex — messages are plain text now.
- Does not touch any other channel adapter.

## Review notes

- Load-bearing: `resolveWebexBodyText` must **not** normalize the `text`/`markdown` branches, or user-typed literal `&`/`<` would be corrupted. Only the `html` fallback is normalized — covered by `webex-format.test.ts`.
- Entity/tag set is an ASCII literal list on purpose: this is protocol HTML produced by Webex/agent-messenger, not natural language, so multi-language matching rules don't apply.
- Tests assert non-Latin (Korean/CJK) bodies survive normalization.