### PR TITLE
webex: decode ids in adapter logs and inspect renderer

### DIFF
--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -852,6 +852,43 @@ describe('createKakaotalkAdapter — author name resolution', () => {
     await router.stop()
   })
 
+  test('inbound log prefers author_name over the opaque author_id', async () => {
+    const lines: string[] = []
+    const client = new FakeClient()
+    const listener = new FakeListener()
+    const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    const adapter = createKakaotalkAdapter({
+      router,
+      configRef: () => adapterCfg(),
+      client,
+      listenerFactory: () => listener,
+      logger: { info: (m) => lines.push(m), warn: () => {}, error: () => {} },
+    })
+    client.chats = [groupChat('111', 4)]
+    await adapter.start()
+    listener.emit('connected', { userId: '999' })
+
+    listener.emit('message', {
+      type: 'MSG',
+      chat_id: '111',
+      log_id: 'L42',
+      author_id: 222,
+      author_name: 'Alice',
+      message: 'hello',
+      message_type: 1,
+      attachment: null,
+      sent_at: 1_730_000_000_000,
+    })
+    await new Promise((r) => setTimeout(r, 10))
+
+    const inboundLine = lines.find((l) => l.includes('inbound log_id='))
+    expect(inboundLine).toContain('author=Alice')
+    expect(inboundLine).not.toContain('author=222')
+
+    await adapter.stop()
+    await router.stop()
+  })
+
   test('falls back to GETMEM when event.author_name is null', async () => {
     const client = new FakeClient()
     const listener = new FakeListener()

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -436,7 +436,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         event.chat_id,
       )
       logger.info(
-        `[kakaotalk] inbound log_id=${event.log_id} author=${event.author_id} ${inboundTag} type=${event.message_type} text_len=${event.message.length}`,
+        `[kakaotalk] inbound log_id=${event.log_id} author=${event.author_name ?? event.author_id} ${inboundTag} type=${event.message_type} text_len=${event.message.length}`,
       )
 
       // Ack the message BEFORE classify/route so the sender's unread "1"

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -103,7 +103,7 @@ export function createOutboundCallback(deps: {
     const tag = await formatChannelTag(msg.chat)
     const parentId = msg.replyTo?.externalMessageId ?? msg.thread ?? undefined
     logger.info(
-      `[webex-bot] outbound ${tag} text_len=${text.length} attachments=${attachments.length}${parentId !== undefined ? ` parent=${parentId}` : ''}`,
+      `[webex-bot] outbound ${tag} text_len=${text.length} attachments=${attachments.length}${parentId !== undefined ? ` parent=${toRef(parentId)}` : ''}`,
     )
 
     try {
@@ -117,13 +117,13 @@ export function createOutboundCallback(deps: {
             ...(carriesText ? { text } : {}),
             ...(parentId !== undefined ? { parentId } : {}),
           })
-          logger.info(`[webex-bot] uploaded id=${sent.id} filename=${file.filename} ${tag}`)
+          logger.info(`[webex-bot] uploaded id=${toRef(sent.id)} filename=${file.filename} ${tag}`)
         }
         return { ok: true }
       }
 
       const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)
-      logger.info(`[webex-bot] sent id=${sent.id} ${tag}`)
+      logger.info(`[webex-bot] sent id=${toRef(sent.id)} ${tag}`)
       return { ok: true }
     } catch (err) {
       const message = describe(err)
@@ -190,7 +190,9 @@ export function createWebexMembershipResolver(deps: {
       }
       return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated, humanMemberIds }
     } catch (err) {
-      deps.logger.warn(`[webex-bot] membership room=${key.chat} failed: ${describe(err)}; deriving from recent history`)
+      deps.logger.warn(
+        `[webex-bot] membership room=${toRef(key.chat)} failed: ${describe(err)}; deriving from recent history`,
+      )
       return await deriveMembershipFromHistory({
         fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
         now,
@@ -272,7 +274,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
       (): ResolvedChannelNames => ({}),
     )
     const label = names.chatName ?? null
-    return label === null || label === chat ? `room=${chat}` : `room=${label}(${chat})`
+    return label === null || label === chat ? `room=${toRef(chat)}` : `room=${label}(${toRef(chat)})`
   }
 
   const historyCallback = createWebexHistoryCallback({ client, logger, botPersonIdRef: () => botPerson?.id ?? null })
@@ -290,7 +292,9 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
     const botSnapshot = botPerson
     try {
       const tag = await formatChannelTag(event.roomId)
-      logger.info(`[webex-bot] inbound id=${event.id} author=${event.personEmail} ${tag} text_len=${event.text.length}`)
+      logger.info(
+        `[webex-bot] inbound id=${toRef(event.id)} author=${event.personEmail} ${tag} text_len=${event.text.length}`,
+      )
       const verdict = classifyInbound(
         event,
         options.configRef(),
@@ -298,7 +302,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
         options.selfAliasesRef?.() ?? [],
       )
       if (verdict.kind === 'drop') {
-        logger.info(`[webex-bot] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+        logger.info(`[webex-bot] dropped id=${toRef(event.id)} reason=${verdict.reason}${dropHint(verdict.reason)}`)
         return
       }
       const payload = await enrichWebexMessageReference({
@@ -308,7 +312,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
         botPersonId: botSnapshot?.id ?? null,
       })
       logger.info(
-        `[webex-bot] routed id=${event.id} ${tag} mention=${payload.isBotMention} reply=${payload.replyToBotMessageId !== null}`,
+        `[webex-bot] routed id=${toRef(event.id)} ${tag} mention=${payload.isBotMention} reply=${payload.replyToBotMessageId !== null}`,
       )
       await options.router.route(payload)
     } catch (err) {

--- a/src/channels/adapters/webex.test.ts
+++ b/src/channels/adapters/webex.test.ts
@@ -202,6 +202,41 @@ describe('createWebexAdapter', () => {
     expect(listener.stopped).toBe(true)
     expect(r.unregistered).toContain('outbound:webex')
   })
+
+  test('inbound/routed logs decode the base64 room and message ids', async () => {
+    // base64url of ciscospark://us/ROOM/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    const roomId = 'Y2lzY29zcGFyazovL3VzL1JPT00vYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVl'
+    // base64url of ciscospark://us/MESSAGE/99999999-8888-7777-6666-555555555555
+    const msgId = 'Y2lzY29zcGFyazovL3VzL01FU1NBR0UvOTk5OTk5OTktODg4OC03Nzc3LTY2NjYtNTU1NTU1NTU1NTU1'
+    const log = logger()
+    const listener = new FakeListener()
+    const adapter = createWebexAdapter({
+      router: router(),
+      configRef: () => config,
+      logger: log,
+      selfAliasesRef: () => ['typeclaw'],
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        ({
+          login: async () => {},
+          testAuth: async () => ({ id: 'self-1', emails: ['self@example.com'], displayName: 'Self' }),
+          listMemberships: async () => [],
+          listMessages: async () => [],
+          sendMessage: async () => ({ id: 'sent' }),
+          uploadFile: async () => ({ id: 'uploaded' }),
+        }) as unknown as ReturnType<NonNullable<Parameters<typeof createWebexAdapter>[0]['createClient']>>,
+      createListener: () => listener as unknown as WebexListener,
+    })
+
+    await adapter.start()
+    listener.emit('message_created', inbound({ id: msgId, roomId, text: 'hello typeclaw' }))
+    await adapter.stop()
+
+    const inboundLine = log.lines.find((l) => l.includes('inbound id='))
+    expect(inboundLine).toContain('id=99999999-8888-7777-6666-555555555555')
+    expect(inboundLine).toContain('room=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+    expect(inboundLine).not.toContain('Y2lz')
+  })
 })
 
 describe('createWebexHistoryCallback reply attribution', () => {

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -108,7 +108,7 @@ export function createOutboundCallback(deps: {
     const tag = await formatChannelTag(msg.chat)
     const parentId = msg.replyTo?.externalMessageId ?? msg.thread ?? undefined
     logger.info(
-      `[webex] outbound ${tag} text_len=${text.length} attachments=${attachments.length}${parentId !== undefined ? ` parent=${parentId}` : ''}`,
+      `[webex] outbound ${tag} text_len=${text.length} attachments=${attachments.length}${parentId !== undefined ? ` parent=${toRef(parentId)}` : ''}`,
     )
 
     try {
@@ -122,13 +122,13 @@ export function createOutboundCallback(deps: {
             ...(carriesText ? { text } : {}),
             ...(parentId !== undefined ? { parentId } : {}),
           })
-          logger.info(`[webex] uploaded id=${sent.id} filename=${file.filename} ${tag}`)
+          logger.info(`[webex] uploaded id=${toRef(sent.id)} filename=${file.filename} ${tag}`)
         }
         return { ok: true }
       }
 
       const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)
-      logger.info(`[webex] sent id=${sent.id} ${tag}`)
+      logger.info(`[webex] sent id=${toRef(sent.id)} ${tag}`)
       return { ok: true }
     } catch (err) {
       const message = describe(err)
@@ -197,7 +197,9 @@ export function createWebexMembershipResolver(deps: {
       }
       return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated, humanMemberIds }
     } catch (err) {
-      deps.logger.warn(`[webex] membership room=${key.chat} failed: ${describe(err)}; deriving from recent history`)
+      deps.logger.warn(
+        `[webex] membership room=${toRef(key.chat)} failed: ${describe(err)}; deriving from recent history`,
+      )
       return await deriveMembershipFromHistory({
         fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
         now,
@@ -282,7 +284,7 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
       (): ResolvedChannelNames => ({}),
     )
     const label = names.chatName ?? null
-    return label === null || label === chat ? `room=${chat}` : `room=${label}(${chat})`
+    return label === null || label === chat ? `room=${toRef(chat)}` : `room=${label}(${toRef(chat)})`
   }
 
   const historyCallback = createWebexHistoryCallback({ client, logger, botPersonIdRef: () => botPerson?.id ?? null })
@@ -300,7 +302,9 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
     const botSnapshot = botPerson
     try {
       const tag = await formatChannelTag(event.roomId)
-      logger.info(`[webex] inbound id=${event.id} author=${event.personEmail} ${tag} text_len=${event.text.length}`)
+      logger.info(
+        `[webex] inbound id=${toRef(event.id)} author=${event.personEmail} ${tag} text_len=${event.text.length}`,
+      )
       const verdict = classifyInbound(
         event,
         options.configRef(),
@@ -308,7 +312,7 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
         options.selfAliasesRef?.() ?? [],
       )
       if (verdict.kind === 'drop') {
-        logger.info(`[webex] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+        logger.info(`[webex] dropped id=${toRef(event.id)} reason=${verdict.reason}${dropHint(verdict.reason)}`)
         return
       }
       const payload = await enrichWebexMessageReference({
@@ -318,7 +322,7 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
         botPersonId: botSnapshot?.id ?? null,
       })
       logger.info(
-        `[webex] routed id=${event.id} ${tag} mention=${payload.isBotMention} reply=${payload.replyToBotMessageId !== null}`,
+        `[webex] routed id=${toRef(event.id)} ${tag} mention=${payload.isBotMention} reply=${payload.replyToBotMessageId !== null}`,
       )
       await options.router.route(payload)
     } catch (err) {

--- a/src/inspect/label.ts
+++ b/src/inspect/label.ts
@@ -51,10 +51,10 @@ function renderWorkspace(origin: Extract<MinimalSessionOrigin, { kind: 'channel'
   return readableId(origin.adapter, origin.workspace)
 }
 
-// Webex room/workspace ids are base64 `ciscospark://` blobs that read as
-// gibberish in the picker. With no resolved title, decode to the trailing ref
-// (a UUID) so the row is at least skimmable; non-Webex ids pass through.
-function readableId(adapter: string, id: string): string {
+// Webex room/workspace/person ids are base64 `ciscospark://` blobs that read as
+// gibberish. With no resolved title, decode to the trailing ref (a UUID) so the
+// row is at least skimmable; non-Webex ids pass through.
+export function readableId(adapter: string, id: string): string {
   return WEBEX_ADAPTERS.has(adapter) ? toRef(id) : id
 }
 

--- a/src/inspect/render.test.ts
+++ b/src/inspect/render.test.ts
@@ -158,6 +158,30 @@ describe('renderEvent (plain, no color)', () => {
     )
   })
 
+  test('inbound webex event decodes base64 room/person ids in the coord and author fallback', () => {
+    const ev: InspectEvent = {
+      cat: 'inbound',
+      ts: dateMs('15:08:42'),
+      adapter: 'webex',
+      // base64url of ciscospark://us/ROOM/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+      workspace: 'Y2lzY29zcGFyazovL3VzL1JPT00vYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVl',
+      chat: 'Y2lzY29zcGFyazovL3VzL1JPT00vYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVl',
+      thread: null,
+      // base64url of ciscospark://us/PEOPLE/11111111-2222-3333-4444-555555555555
+      authorId: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS8xMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTU',
+      authorName: '',
+      authorIsBot: false,
+      isDm: false,
+      isBotMention: true,
+      text: 'hello',
+      externalMessageId: 'm1',
+      decision: 'engage',
+    }
+    expect(stripTime(renderEvent(ev, PLAIN))).toBe(
+      'HH:MM:SS  inbound    [engage] webex:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee 11111111-2222-3333-4444-555555555555: hello',
+    )
+  })
+
   test('inbound observe shows [observe] tag', () => {
     const ev: InspectEvent = {
       cat: 'inbound',

--- a/src/inspect/render.ts
+++ b/src/inspect/render.ts
@@ -1,6 +1,6 @@
 import { styleText } from 'node:util'
 
-import { originLabel } from './label'
+import { originLabel, readableId } from './label'
 import type { InspectEvent } from './types'
 
 export type RenderOptions = {
@@ -120,8 +120,10 @@ function renderBody(event: InspectEvent, opts: RenderOptions): string {
 }
 
 function renderInboundBody(event: Extract<InspectEvent, { cat: 'inbound' }>, opts: RenderOptions): string {
-  const coord = `${event.adapter}:${event.workspace}/${event.chat}${event.thread === null ? '' : `#${event.thread}`}`
-  const who = event.authorName !== '' ? event.authorName : event.authorId
+  const workspace = readableId(event.adapter, event.workspace)
+  const chat = readableId(event.adapter, event.chat)
+  const coord = `${event.adapter}:${workspace}/${chat}${event.thread === null ? '' : `#${event.thread}`}`
+  const who = event.authorName !== '' ? event.authorName : readableId(event.adapter, event.authorId)
   const decisionTag = tint(opts, decisionColor(event.decision), `[${event.decision}]`)
   const text = truncate(singleLine(event.text), opts.maxTextLength ?? DEFAULT_MAX_TEXT)
   return `${decisionTag} ${tint(opts, 'dim', coord)} ${who}: ${text}`


### PR DESCRIPTION
## Background

#969 + #970 set out to make Webex's opaque base64 REST ids (`Y2lzY29zcGFyazov...`) readable on every human-facing surface — permissions, role-claims, inspect labels, and the auth log. A follow-up audit found the decoder was applied to only a subset of those surfaces. This PR closes the two biggest gaps that remained.

**Adapter logs.** Both `webex` and `webex-bot` build a channel tag via `formatChannelTag`, which fell back to the raw base64 roomId:

```ts
return label === null || label === chat ? `room=${chat}` : `room=${label}(${chat})`
```

That tag is interpolated into **every** operational log line — `inbound`, `dropped`, `routed`, `sent`, `uploaded`, outbound, and the membership-failure warn. So an operator running `typeclaw logs` saw `room=Y2lzY29zcGFyazov...` on essentially every Webex log line, plus raw base64 message ids in `id=`/`parent=`.

**Inspect line renderer.** `#969` decoded the session-picker label (`label.ts`), but `inspect`'s line renderer (`render.ts`) has its own path that built the coord from raw `workspace`/`chat` and fell back to a raw `authorId` — so the same opaque blob showed up in `typeclaw inspect` replay and live tail.

## Summary

Three atomic commits:

1. **`channels: decode webex ids in adapter log lines`** — route the roomId (and the message ids in those same lines) through `toRef` in both adapters' `formatChannelTag` and log statements.
2. **`inspect: decode webex ids in the line renderer`** — export the existing `readableId(adapter, id)` helper from `label.ts` and reuse it in `renderInboundBody`, so both inspect surfaces decode identically (no second copy of the webex-adapter check).
3. **`channels: log kakaotalk author name instead of opaque id`** — a sibling find from the same audit: the KakaoTalk inbound log printed the opaque numeric `author_id` while `event.author_name` was already on the event (and used a few lines later). Prefer the name, matching the readable-author pattern every other adapter follows.

All decoding is **display-only**. `toRef` falls open on non-Webex values, and the canonical base64 id remains the wire/session-key currency.

## What this does NOT do

- **Touch `inspect --json`.** Left raw on purpose — it's a machine/scripting surface where consumers join on the canonical id, exactly like the system-prompt origin JSON block the model copies into tool calls.
- **Decode the system-prompt conversation/participant rendering or the `channel_history` tool output.** Those surfaces (also flagged by the audit) feed the model and touch a wider blast radius; they're a separate follow-up.
- **Change `channelKeyId`.** It doubles as a Map key; making the router log prefixes readable needs a separate display formatter, not a change to the key function.

## Review notes

The load-bearing invariant is unchanged from #969/#970: **decode is display-only, `toRef` falls open, raw base64 stays the wire currency.** The one judgment call is leaving `inspect --json` raw — start there if you disagree.

New tests assert decode end-to-end with real base64 fixtures: `inbound/routed logs decode the base64 room and message ids` (webex.test.ts), `inbound webex event decodes base64 room/person ids in the coord and author fallback` (render.test.ts), and `inbound log prefers author_name over the opaque author_id` (kakaotalk.test.ts). 9514 tests pass / 0 fail.
