### PR TITLE
webex: decode room ref in the conversation-line prose

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -646,6 +646,41 @@ describe('renderSessionOrigin', () => {
     expect(out).toContain('"chat": "C0DEPLOY"')
   })
 
+  test('webex channel origin decodes the room ref in prose but keeps the raw id in the origin JSON', () => {
+    // base64url of ciscospark://us/ROOM/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    const roomId = 'Y2lzY29zcGFyazovL3VzL1JPT00vYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVl'
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'webex',
+      workspace: roomId,
+      workspaceName: 'Engineering',
+      chat: roomId,
+      chatName: 'Standup',
+      thread: null,
+    })
+    // prose conversation line shows the decoded ref, not the base64 blob
+    expect(out).toContain('**Standup** (aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)')
+    expect(out).toContain('**Engineering** (aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)')
+    // the canonical origin JSON block keeps the raw base64 id the model copies into tool calls
+    expect(out).toContain(`"chat": ${JSON.stringify(roomId)}`)
+    expect(out).toContain(`"workspace": ${JSON.stringify(roomId)}`)
+  })
+
+  test('webex prose decodes the room ref even when no chatName is resolved', () => {
+    // base64url of ciscospark://us/ROOM/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    const roomId = 'Y2lzY29zcGFyazovL3VzL1JPT00vYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtZWVlZWVlZWVlZWVl'
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'webex',
+      workspace: roomId,
+      workspaceName: 'Engineering',
+      chat: roomId,
+      thread: null,
+    })
+    expect(out).toContain('`aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`')
+    expect(out).toContain(`"chat": ${JSON.stringify(roomId)}`)
+  })
+
   test('channel origin uses # prefix for Slack channels, bare name for Discord', () => {
     const slackOut = renderSessionOrigin({
       kind: 'channel',

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -1,3 +1,4 @@
+import { toRef } from '@/channels/adapters/webex-id-ref'
 import { MEMBERSHIP_FRESHNESS_MS, type MembershipCount } from '@/channels/membership'
 import type { AdapterId } from '@/channels/schema'
 import type { ChannelSelfIdentity, ReactionRef } from '@/channels/types'
@@ -631,6 +632,12 @@ function renderSelfMention(platformInfo: PlatformInfo, self: ChannelSelfIdentity
   }
 }
 
+const WEBEX_ADAPTERS = new Set<AdapterId>(['webex', 'webex-bot'])
+
+function readableChannelId(adapter: AdapterId, id: string): string {
+  return WEBEX_ADAPTERS.has(adapter) ? toRef(id) : id
+}
+
 function renderConversationLine(origin: {
   adapter: AdapterId
   workspace: string
@@ -643,8 +650,13 @@ function renderConversationLine(origin: {
   if (!hasChat && !hasWorkspace) return null
 
   const chatPrefix = origin.adapter === 'slack-bot' ? '#' : ''
-  const chatLabel = hasChat ? `**${chatPrefix}${origin.chatName!}** (${origin.chat})` : `\`${origin.chat}\``
-  const workspaceLabel = hasWorkspace ? `**${origin.workspaceName!}** (${origin.workspace})` : `\`${origin.workspace}\``
+  // The parenthetical/backtick id is a human-and-model disambiguator, NOT the
+  // send target — tools source the canonical room id from the JSON origin block,
+  // which stays raw. So decode webex base64 blobs to their readable ref here.
+  const chatId = readableChannelId(origin.adapter, origin.chat)
+  const workspaceId = readableChannelId(origin.adapter, origin.workspace)
+  const chatLabel = hasChat ? `**${chatPrefix}${origin.chatName!}** (${chatId})` : `\`${chatId}\``
+  const workspaceLabel = hasWorkspace ? `**${origin.workspaceName!}** (${workspaceId})` : `\`${workspaceId}\``
 
   return `Conversation: ${chatLabel} in ${workspaceLabel}.`
 }


### PR DESCRIPTION
## Background

Continuing the #969/#970/#972 effort to make Webex's opaque base64 REST ids readable on human-facing surfaces. The system prompt's origin block renders a prose conversation line:

```
Conversation: **Standup** (Y2lzY29zcGFyazovL3VzL1JPT00v...) in **Engineering** (Y2lz...).
```

The parenthetical room id is the same opaque blob the earlier PRs set out to eliminate — visible to both the operator (when debugging the prompt) and the model.

## Summary

Decode the chat/workspace room id in `renderConversationLine` to its readable UUID ref for Webex adapters, in both the name-present branch (`**Standup** (uuid-ref)`) and the name-absent fallback (`` `uuid-ref` ``). A small local `readableChannelId(adapter, id)` helper gates the decode to `webex`/`webex-bot` and falls through untouched for every other adapter.

## What this does NOT do — and why (the important part)

This PR is **deliberately narrow**. The audit flagged three system-prompt/tool surfaces; only one is a safe display decode. The other two are **left raw on purpose**:

- **`renderParticipantAddressing` `<@${authorId}>`** (participants block) — LEFT RAW.
- **`channel-history` tool output `${authorName} (<@${authorId}>)`** — LEFT RAW.

Both are **copyable mention/addressing tokens**, not passive labels. The code already documents (see the comment above `renderParticipantAddressing`) that the model copy-pastes the `<@id>` token verbatim to address a participant. Webex computes `isBotMention` as `event.mentionedPeople.includes(botPersonId)`, where `mentionedPeople` is a list of **raw base64 personIds** from the Webex API. Decoding the token to a UUID would emit something Webex's mention matching never recognizes — silently breaking mention detection. So these stay raw.

The distinction that makes the conversation line safe: its id is a **disambiguator**, not a send target. The model sources the canonical room id for `channel_send`/`channel_reply` from the separate JSON origin code block, which stays raw. (Validated this split with a reasoning pass before implementing.)

## Review notes

The load-bearing invariant: **prose conversation id = display (decode); mention tokens + JSON origin block = wire (raw).** The test `webex channel origin decodes the room ref in prose but keeps the raw id in the origin JSON` asserts both halves in one shot — start there. A second test covers the no-chatName fallback branch.

`bun run lint` (0 errors), `format:check` (clean), `typecheck` (clean), `bun run test` (9513 pass / 0 fail; my test file verified stable across repeated runs).
