### PR TITLE
cli: fix misleading channel reauth help text

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -169,8 +169,7 @@ type ReauthableAdapter = (typeof REAUTHABLE_ADAPTERS)[number]
 const reauthSub = defineCommand({
   meta: {
     name: 'reauth',
-    description:
-      're-authenticate a channel adapter (currently only `kakaotalk`). Use after a stale-token 401 or to rotate the saved password.',
+    description: `re-authenticate a channel adapter (${REAUTHABLE_ADAPTERS.join(', ')}). Use after a stale-token 401 or to rotate the saved password.`,
   },
   args: {
     adapter: {


### PR DESCRIPTION
## Background

The channel reauth subcommand help text said "currently only kakaotalk" — a string that was accurate when reauth shipped but was never updated as line and webex were added. Any operator who consulted `typeclaw channel --help` would conclude reauth only worked for KakaoTalk and would not know to try it after a LINE or Webex stale-token 401.

## Summary

The reauthable adapter set is already declared as `REAUTHABLE_ADAPTERS` in src/cli/channel.ts.
The positional-arg description already derives from it — only the subcommand `meta.description` was a stale hardcoded string.
The fix replaces that string with a template literal that joins the array, so the description can never drift out of sync as adapters are added.

Rendered help before:

```
re-authenticate a channel adapter (currently only `kakaotalk`). Use after a stale-token 401 or to rotate the saved password.
```

Rendered help after:

```
re-authenticate a channel adapter (line, kakaotalk, webex). Use after a stale-token 401 or to rotate the saved password.
```

## Preview

N/A — no visual change beyond the help text string itself.

## What this does NOT do

- Does not change which adapters reauth actually supports (that set is unchanged).
- Does not add reauth support for any new adapter.
- Does not touch any runtime behavior, only the CLI description string.

## Review notes

The load-bearing change is a single line in src/cli/channel.ts: replacing the hardcoded `meta.description`
with a template literal over `REAUTHABLE_ADAPTERS`.
Confirm that array is the canonical source of truth for what reauth accepts
(it already drives the positional-arg description and the runtime guard) — if so, coupling the two is correct.

Verification: typecheck clean, lint 0 errors, format:check clean, channel.test.ts 4 pass.