### PR TITLE
ci: retry bun install to survive transient api.github.com 504s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,23 @@ jobs:
           bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # GitHub tarball deps (e.g. libsignal-node, pinned via @whiskeysockets/baileys)
+        # are fetched from api.github.com, which intermittently 504s under GHA token
+        # contention and kills the whole run before any test executes. Retry the fetch;
+        # the lockfile stays frozen so each attempt is the same deterministic install.
+        # shell: bash so the loop runs identically on the windows-* jobs (Git Bash is
+        # present on windows-latest; the default shell there is pwsh, not bash).
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" = 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 20))
+          done
 
       - name: Typecheck
         run: bun run typecheck
@@ -80,7 +96,23 @@ jobs:
           bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # GitHub tarball deps (e.g. libsignal-node, pinned via @whiskeysockets/baileys)
+        # are fetched from api.github.com, which intermittently 504s under GHA token
+        # contention and kills the whole run before any test executes. Retry the fetch;
+        # the lockfile stays frozen so each attempt is the same deterministic install.
+        # shell: bash so the loop runs identically on the windows-* jobs (Git Bash is
+        # present on windows-latest; the default shell there is pwsh, not bash).
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" = 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 20))
+          done
 
       - name: Typecheck
         run: bun run typecheck
@@ -116,7 +148,23 @@ jobs:
           bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # GitHub tarball deps (e.g. libsignal-node, pinned via @whiskeysockets/baileys)
+        # are fetched from api.github.com, which intermittently 504s under GHA token
+        # contention and kills the whole run before any test executes. Retry the fetch;
+        # the lockfile stays frozen so each attempt is the same deterministic install.
+        # shell: bash so the loop runs identically on the windows-* jobs (Git Bash is
+        # present on windows-latest; the default shell there is pwsh, not bash).
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" = 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 20))
+          done
 
       - name: Configure git identity
         run: |


### PR DESCRIPTION
## Background

CI on `main` went red, but not because of a test. The `Install dependencies` step (`bun install --frozen-lockfile`) aborted the entire run before a single test executed:

```
error: GET https://api.github.com/repos/whiskeysockets/libsignal-node/tarball/1c30d7d - 504
```

Root cause: `libsignal` is a transitive dependency (via `@whiskeysockets/baileys`, our WhatsApp adapter) and is pinned in `bun.lock` to a GitHub tarball — `github:whiskeysockets/libsignal-node#1c30d7d`. Bun resolves that by fetching the tarball from `api.github.com`, which intermittently returns `504` under GitHub Actions token contention. When it does, the install fails and takes down the unix `ci` job and both `windows-*` triage jobs at once. This is a flaky-install failure, not a flaky test.

This is the same `api.github.com`-under-contention class of flake the workflow already guards against — the `bun-version` pin comment notes `setup-bun@v2` was switched off `latest` precisely to avoid an intermittent `api.github.com` lookup.

## Summary

Wrap the install in a 3-attempt retry loop with linear backoff (20s, 40s) so a transient `504` no longer kills the run.

- **Why a retry and not a token/auth fix:** Bun's GitHub-tarball fetch path can't be relied on to honor `GITHUB_TOKEN` for a higher rate limit, so authenticating the request isn't a dependable fix.
- **Why not a marketplace retry action:** an inline loop keeps the workflow dependency-free, matching the repo's deliberate minimalism.
- **Why `shell: bash`:** `windows-latest`'s default shell is `pwsh`, where this loop wouldn't parse. Git Bash ships on the Windows runners, so pinning `shell: bash` makes the step behave identically on all three jobs.
- `--frozen-lockfile` is preserved on every attempt — each retry is the same deterministic install, never a lockfile mutation.

## What this does NOT do

- Does not change any dependency, the lockfile, or pin `libsignal` to a registry version (out of scope; that's an upstream `baileys` decision).
- Does not touch test code, timeouts, or the `continue-on-error` posture of the Windows jobs.
- Does not eliminate the underlying `api.github.com` flakiness — it absorbs transient `504`s; a sustained GitHub outage will still fail after 3 attempts, preserving the original failure semantics.

## Review notes

The load-bearing details: `shell: bash` on each install step (so the loop runs on Windows), and that the final attempt still `exit 1`s so a real outage fails the job rather than silently passing. The same block is applied identically to all three jobs.
