### PR TITLE
fix(restart): drop dead container->hostd Unix-socket fallback

### DIFF
--- a/src/agent/restart/index.test.ts
+++ b/src/agent/restart/index.test.ts
@@ -260,6 +260,30 @@ describe('requestContainerRestart', () => {
     expect(result).toEqual({ ok: true, containerName: 'coder', restartedAt: '2026-01-02T03:04:05.000Z' })
   })
 
+  test('fails explicitly without a hostd HTTP endpoint instead of dialing a dead socket', async () => {
+    // given: no hostdUrl/token and no TYPECLAW_HOSTD_URL/TOKEN in the env
+    const prevUrl = process.env.TYPECLAW_HOSTD_URL
+    const prevToken = process.env.TYPECLAW_HOSTD_TOKEN
+    delete process.env.TYPECLAW_HOSTD_URL
+    delete process.env.TYPECLAW_HOSTD_TOKEN
+
+    try {
+      // when
+      const result = await requestContainerRestart({
+        containerName: 'coder',
+        ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      })
+
+      // then
+      expect(result.ok).toBe(false)
+      expect(result).toMatchObject({ ok: false, containerName: 'coder' })
+      if (!result.ok) expect(result.reason).toContain('host daemon control endpoint unavailable')
+    } finally {
+      if (prevUrl !== undefined) process.env.TYPECLAW_HOSTD_URL = prevUrl
+      if (prevToken !== undefined) process.env.TYPECLAW_HOSTD_TOKEN = prevToken
+    }
+  })
+
   test('forwards build:true in the RPC body', async () => {
     // given
     const requests: unknown[] = []

--- a/src/agent/restart/index.ts
+++ b/src/agent/restart/index.ts
@@ -1,8 +1,7 @@
 import { basename } from 'node:path'
 
 import { type RestartHandoffOrigin, writeRestartHandoff } from '@/agent/restart-handoff'
-import { send, sendHttp } from '@/hostd/client'
-import { containerSocketPath } from '@/hostd/paths'
+import { sendHttp } from '@/hostd/client'
 import type { Stream } from '@/stream'
 
 const ACK_TIMEOUT_MS = 5_000
@@ -16,7 +15,6 @@ export type ContainerRestartingBroadcast = {
 export type RequestContainerRestartOptions = {
   containerName: string
   build?: boolean
-  socketPath?: string
   hostdUrl?: string
   hostdToken?: string
   ackTimeoutMs?: number
@@ -49,7 +47,6 @@ export type RequestContainerRestartResult =
 export async function requestContainerRestart({
   containerName,
   build,
-  socketPath,
   hostdUrl,
   hostdToken,
   ackTimeoutMs,
@@ -65,10 +62,22 @@ export async function requestContainerRestart({
   const httpUrl = hostdUrl ?? process.env.TYPECLAW_HOSTD_URL
   const httpToken = hostdToken ?? process.env.TYPECLAW_HOSTD_TOKEN
   const ackBudget = ackTimeoutMs ?? ACK_TIMEOUT_MS
-  const reply =
-    httpUrl && httpToken
-      ? await sendHttp(request, { timeoutMs: ackBudget, url: httpUrl, token: httpToken })
-      : await send(request, { timeoutMs: ackBudget, socket: socketPath ?? containerSocketPath() })
+
+  // HTTP/TCP is the only container->hostd transport (TYPECLAW_HOSTD_URL/TOKEN,
+  // injected by start.ts via host.docker.internal). There is no Unix-socket
+  // fallback: the host run dir is never bind-mounted, so the old
+  // `/run/typeclaw-host/hostd.sock` dial always silently failed — and on native
+  // Windows the host transport is a named pipe, not a socket. Fail loud here
+  // when the control env is absent (hostd unregistered/disabled).
+  if (!httpUrl || !httpToken) {
+    return {
+      ok: false,
+      containerName,
+      reason:
+        'host daemon control endpoint unavailable (TYPECLAW_HOSTD_URL/TYPECLAW_HOSTD_TOKEN not set); cannot request restart',
+    }
+  }
+  const reply = await sendHttp(request, { timeoutMs: ackBudget, url: httpUrl, token: httpToken })
 
   if (!reply.ok) return { ok: false, containerName, reason: reply.reason }
 

--- a/src/agent/tools/restart.ts
+++ b/src/agent/tools/restart.ts
@@ -10,7 +10,6 @@ const EXIT_DELAY_MS = 500
 export type CreateRestartToolOptions = {
   containerName: string
   exit?: (code: number) => void
-  socketPath?: string
   hostdUrl?: string
   hostdToken?: string
   // Optional so unit tests and ad-hoc tool construction keep working without
@@ -72,7 +71,6 @@ export type { ContainerRestartingBroadcast } from '@/agent/restart'
 export function createRestartTool({
   containerName,
   exit,
-  socketPath,
   hostdUrl,
   hostdToken,
   stream,
@@ -121,7 +119,6 @@ export function createRestartTool({
         containerName,
         build,
         originatingSessionId,
-        ...(socketPath !== undefined ? { socketPath } : {}),
         ...(hostdUrl !== undefined ? { hostdUrl } : {}),
         ...(hostdToken !== undefined ? { hostdToken } : {}),
         ...(ackTimeoutMs !== undefined ? { ackTimeoutMs } : {}),

--- a/src/hostd/index.ts
+++ b/src/hostd/index.ts
@@ -1,16 +1,6 @@
 export { isDaemonReachable, send } from './client'
 export { startDaemon, type Daemon, type DaemonLogEvent, type DaemonOptions } from './daemon'
-export {
-  containerSocketPath,
-  ensureDirs,
-  homeRoot,
-  lockfilePath,
-  logDir,
-  logfilePath,
-  pidfilePath,
-  runDir,
-  socketPath,
-} from './paths'
+export { ensureDirs, homeRoot, lockfilePath, logDir, logfilePath, pidfilePath, runDir, socketPath } from './paths'
 export type {
   ListResult,
   Request,

--- a/src/hostd/paths.ts
+++ b/src/hostd/paths.ts
@@ -5,11 +5,6 @@ import { join, resolve } from 'node:path'
 
 import { isWindows } from '@/shared'
 
-// Fixed in-container path where the host daemon's run dir is bind-mounted.
-// The agent uses this to reach the host daemon (e.g. for the `restart` tool).
-// Kept stable so the agent never has to discover the host's `~/.typeclaw`
-// location at runtime.
-const CONTAINER_HOST_RUN_DIR = '/run/typeclaw-host'
 const SOCKET_FILE = 'hostd.sock'
 const REGISTRATIONS_DIR = 'registrations'
 const KEYS_DIR = 'keys'
@@ -88,17 +83,6 @@ export function registrationFilePath(containerName: string): string {
     throw new Error(`invalid container name for registration file: ${JSON.stringify(containerName)}`)
   }
   return join(registrationsDir(), `${containerName}.json`)
-}
-
-// In-container path to the same socket the host daemon listens on. The
-// container-stage agent tool dials this path; the host bind-mounts the host
-// run dir at CONTAINER_HOST_RUN_DIR so the socket is reachable.
-export function containerSocketPath(): string {
-  return join(CONTAINER_HOST_RUN_DIR, SOCKET_FILE)
-}
-
-export function containerHostRunDir(): string {
-  return CONTAINER_HOST_RUN_DIR
 }
 
 export async function ensureDirs(): Promise<void> {


### PR DESCRIPTION
## What

The agent's `restart` tool reaches hostd over the **HTTP/TCP control leg only** (`TYPECLAW_HOSTD_URL` / `TYPECLAW_HOSTD_TOKEN`, injected by `start.ts` via `host.docker.internal`). It used to fall back to a Unix-domain socket at `/run/typeclaw-host/hostd.sock` when those env vars were absent.

That fallback was **dead code**: the host run dir is never bind-mounted into the container (there is no such `-v` in `start.ts`, and `start.test.ts` already asserts the absence of any `/run/typeclaw-host` mount). So the socket dial always failed silently. On **native Windows** the host-side transport is a named pipe rather than a Unix socket, so the dead path is also a cross-platform liability — exactly the "vestigial Unix-socket fallback" risk called out in the #899 audit.

## Change

- Remove the socket fallback from `requestContainerRestart`. When the control endpoint is unavailable (hostd unregistered/disabled), **fail loud** with a clear reason instead of dialing a socket that can never answer.
- Delete the now-unreferenced `containerSocketPath()` / `containerHostRunDir()` helpers in `src/hostd/paths.ts` and the `containerSocketPath` re-export in `src/hostd/index.ts`.
- Drop the vestigial `socketPath` option that only fed the dead path (production never passed it; the CLI↔hostd `socketPath()` seam is untouched).

The container→host HTTP leg and the CLI↔hostd Unix-socket/named-pipe seam are both unchanged.

## Tests

- New test asserts `requestContainerRestart` fails explicitly (no socket dial) when no HTTP URL/token is present.
- Existing restart-tool and hostd suites unchanged and green.
- Full suite: `9537 pass, 0 fail, 1 skip`. typecheck / lint / format clean.

Refs #899