### PR TITLE
feat(container): use docker --mount for bind mounts (native Windows paths)

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { isWindows } from '@/shared'
+
 import {
   buildxAvailable,
   checkDockerAvailable,
@@ -10,6 +12,7 @@ import {
   cleanupRunCorpse,
   containerNameFromCwd,
   DOCKER_NOT_FOUND_STDERR,
+  dockerBindMount,
   type DockerExec,
   imageTagFromCwd,
   isContainerNameConflict,
@@ -447,5 +450,45 @@ describe('buildxAvailable', () => {
   test('false when the buildx plugin is missing (non-zero exit)', async () => {
     const exec: DockerExec = async () => ({ exitCode: 1, stdout: '', stderr: 'unknown command "buildx"' })
     expect(await buildxAvailable(exec)).toBe(false)
+  })
+})
+
+describe('dockerBindMount', () => {
+  test('emits a single --mount argv pair (src never collides with the dst separator)', () => {
+    // given an absolute POSIX source
+    const args = dockerBindMount({ src: '/srv/agent', dst: '/agent' })
+
+    // then the whole spec is one argv element — no `:`-splitting like `-v`
+    expect(args).toEqual(['--mount', 'type=bind,src=/srv/agent,dst=/agent'])
+  })
+
+  test('keeps a colon-bearing absolute source intact instead of splitting on it (the Windows drive-letter case)', () => {
+    // given an already-absolute source containing a colon — the essence of a
+    // Windows drive letter (`C:\...`), which `-v src:dst` would mis-split. Use
+    // an absolute path so resolve() is a no-op and the test is platform-stable.
+    const drivePath = isWindows() ? 'C:\\Users\\me\\agent' : '/srv/a:b'
+    const args = dockerBindMount({ src: drivePath, dst: '/agent' })
+
+    // then the colon stays inside the src= field; dst is a separate CSV key
+    expect(args[0]).toBe('--mount')
+    expect(args[1]?.startsWith('type=bind,')).toBe(true)
+    expect(args[1]).toContain(`src=${drivePath}`)
+    expect(args[1]).toContain('dst=/agent')
+  })
+
+  test('appends the readonly field only when readonly is true', () => {
+    expect(dockerBindMount({ src: '/srv/x', dst: '/opt/models', readonly: true })[1]).toBe(
+      'type=bind,src=/srv/x,dst=/opt/models,readonly',
+    )
+    expect(dockerBindMount({ src: '/srv/x', dst: '/agent', readonly: false })[1]).not.toContain('readonly')
+  })
+
+  test('resolves a relative source to an absolute path (docker --mount rejects relative src)', () => {
+    const args = dockerBindMount({ src: 'rel/dir', dst: '/agent' })
+    expect(args[1]).toContain(`src=${join(process.cwd(), 'rel', 'dir')}`)
+  })
+
+  test('throws on a comma in a path because --mount cannot express it', () => {
+    expect(() => dockerBindMount({ src: '/srv/a,b', dst: '/agent' })).toThrow(/comma/)
   })
 })

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -108,6 +108,27 @@ export async function buildxAvailable(exec: DockerExec = defaultDockerExec): Pro
   return (await exec(['buildx', 'version'])).exitCode === 0
 }
 
+export type BindMountSpec = { src: string; dst: string; readonly?: boolean }
+
+// Emits `--mount type=bind,...` argv for a host->container bind mount, used in
+// place of the legacy `-v src:dst[:ro]` form. The `-v` short form splits on
+// `:`, which collides with a Windows drive letter (`C:\agent` parses as host
+// `C` + path `\agent`); `--mount`'s `key=value` CSV has no such ambiguity and
+// fails loud on an unknown/missing key instead of silently creating a phantom
+// host dir. Src is resolved to an absolute path because `--mount` (unlike `-v`)
+// rejects relative sources. A literal comma in a path would break the CSV;
+// it's rejected here rather than silently mis-parsed (paths with commas are
+// pathological and were never supported by the `-v` form either).
+export function dockerBindMount({ src, dst, readonly }: BindMountSpec): [string, string] {
+  const absSrc = resolve(src)
+  if (absSrc.includes(',') || dst.includes(',')) {
+    throw new Error(`bind mount path contains a comma, which docker --mount cannot express: ${absSrc} -> ${dst}`)
+  }
+  const fields = [`type=bind`, `src=${absSrc}`, `dst=${dst}`]
+  if (readonly) fields.push('readonly')
+  return ['--mount', fields.join(',')]
+}
+
 export function containerNameFromCwd(cwd: string): string {
   return sanitizeContainerName(basename(resolve(cwd)))
 }

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -10,7 +10,31 @@ import { buildDockerfile } from '@/init/dockerfile'
 import { buildGitignore } from '@/init/gitignore'
 
 import type { DockerExec } from './shared'
-import { commitSystemFile, planStart, refreshDockerfile, refreshGitignore, start } from './start'
+import { commitSystemFile, planStart, refreshDockerfile, refreshGitignore, shouldMirrorDevSource, start } from './start'
+
+type ParsedBindMount = { src: string; dst: string; readonly: boolean }
+
+// Parses `--mount type=bind,src=...,dst=...[,readonly]` argv pairs out of a
+// runArgs list so assertions can check bind mounts without hard-coding the
+// CSV field order or the `-v` legacy form.
+function bindMounts(runArgs: readonly string[]): ParsedBindMount[] {
+  const out: ParsedBindMount[] = []
+  for (let i = 0; i < runArgs.length - 1; i++) {
+    if (runArgs[i] !== '--mount') continue
+    const fields = (runArgs[i + 1] ?? '').split(',')
+    if (!fields.includes('type=bind')) continue
+    const src = fields.find((f) => f.startsWith('src='))?.slice(4) ?? ''
+    const dst = fields.find((f) => f.startsWith('dst='))?.slice(4) ?? ''
+    out.push({ src, dst, readonly: fields.includes('readonly') })
+  }
+  return out
+}
+
+function hasBindMount(runArgs: readonly string[], expected: ParsedBindMount): boolean {
+  return bindMounts(runArgs).some(
+    (m) => m.src === expected.src && m.dst === expected.dst && m.readonly === expected.readonly,
+  )
+}
 
 let root: string
 
@@ -154,7 +178,7 @@ describe('planStart', () => {
     expect(plan.runArgs).toContain('127.0.0.1:8973:8973')
     expect(plan.runArgs).toContain('--env-file')
     expect(plan.runArgs).toContain(join(root, '.env'))
-    expect(plan.runArgs).toContain(`${root}:/agent`)
+    expect(hasBindMount(plan.runArgs, { src: root, dst: '/agent', readonly: false })).toBe(true)
     expect(plan.runArgs.at(-1)).toBe(plan.imageTag)
   })
 
@@ -303,7 +327,7 @@ describe('planStart', () => {
 
       const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-      expect(plan.runArgs).toContain(`${typeclawRepo}:${typeclawRepo}:ro`)
+      expect(hasBindMount(plan.runArgs, { src: typeclawRepo, dst: typeclawRepo, readonly: true })).toBe(true)
     } finally {
       await rm(typeclawRepo, { recursive: true, force: true })
     }
@@ -316,7 +340,7 @@ describe('planStart', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    const mirrorMounts = plan.runArgs.filter((a) => a.endsWith(':ro') && !a.includes('/opt/models'))
+    const mirrorMounts = bindMounts(plan.runArgs).filter((m) => m.readonly && m.dst !== '/opt/models')
     expect(mirrorMounts).toHaveLength(0)
   })
 
@@ -326,7 +350,31 @@ describe('planStart', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs.filter((a) => a.endsWith(':ro') && !a.includes('/opt/models'))).toHaveLength(0)
+    expect(bindMounts(plan.runArgs).filter((m) => m.readonly && m.dst !== '/opt/models')).toHaveLength(0)
+  })
+
+  test('every emitted bind mount targets an absolute Linux container path (never a host dst)', async () => {
+    const typeclawRepo = await mkdtemp(join(tmpdir(), 'typeclaw-repo-'))
+    const projectDir = await mkdtemp(join(tmpdir(), 'typeclaw-mount-target-'))
+    try {
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: `file:${typeclawRepo}` })
+      await writeTypeclawConfig(root, {
+        mounts: [{ name: 'projects', path: projectDir }],
+        memory: { vector: { enabled: true } },
+      })
+
+      const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+
+      for (const m of bindMounts(plan.runArgs)) {
+        expect(m.dst.startsWith('/')).toBe(true)
+        expect(m.dst).not.toMatch(/^[A-Za-z]:[\\/]/)
+        expect(m.dst).not.toContain('\\')
+      }
+    } finally {
+      await rm(typeclawRepo, { recursive: true, force: true })
+      await rm(projectDir, { recursive: true, force: true })
+    }
   })
 
   test('reports needsBuild based on imageExists input', async () => {
@@ -362,6 +410,25 @@ describe('planStart', () => {
   })
 })
 
+describe('shouldMirrorDevSource', () => {
+  test('mirrors an out-of-cwd dev source on POSIX hosts', () => {
+    expect(shouldMirrorDevSource('/srv/src/typeclaw', '/srv/agents/coder', 'linux')).toBe(true)
+    expect(shouldMirrorDevSource('/srv/src/typeclaw', '/srv/agents/coder', 'darwin')).toBe(true)
+  })
+
+  test('does NOT mirror on native Windows (a C:\\ host path is not a valid Linux container dst)', () => {
+    expect(shouldMirrorDevSource('C:\\src\\typeclaw', 'C:\\agents\\coder', 'win32')).toBe(false)
+  })
+
+  test('does NOT mirror when there is no dev source', () => {
+    expect(shouldMirrorDevSource(null, '/srv/agents/coder', 'linux')).toBe(false)
+  })
+
+  test('does NOT mirror when the dev source lives inside the agent folder', () => {
+    expect(shouldMirrorDevSource('/srv/agents/coder/vendor/typeclaw', '/srv/agents/coder', 'linux')).toBe(false)
+  })
+})
+
 describe('planStart mounts', () => {
   test('emits no mount flags when typeclaw.json is missing', async () => {
     await writeDockerfile(root)
@@ -369,7 +436,7 @@ describe('planStart mounts', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs.filter((a) => a.includes(':/agent/mounts/'))).toHaveLength(0)
+    expect(bindMounts(plan.runArgs).filter((m) => m.dst.startsWith('/agent/mounts/'))).toHaveLength(0)
   })
 
   test('emits no mount flags when mounts array is empty', async () => {
@@ -379,10 +446,10 @@ describe('planStart mounts', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs.filter((a) => a.includes(':/agent/mounts/'))).toHaveLength(0)
+    expect(bindMounts(plan.runArgs).filter((m) => m.dst.startsWith('/agent/mounts/'))).toHaveLength(0)
   })
 
-  test('emits a -v flag for each mount, mapping to /agent/mounts/<name>', async () => {
+  test('emits a bind mount for each mount, mapping to /agent/mounts/<name>', async () => {
     const projectDir = await mkdtemp(join(tmpdir(), 'typeclaw-mount-target-'))
     try {
       await writeDockerfile(root)
@@ -391,14 +458,14 @@ describe('planStart mounts', () => {
 
       const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-      expect(plan.runArgs).toContain('-v')
-      expect(plan.runArgs).toContain(`${projectDir}:/agent/mounts/projects`)
+      expect(plan.runArgs).toContain('--mount')
+      expect(hasBindMount(plan.runArgs, { src: projectDir, dst: '/agent/mounts/projects', readonly: false })).toBe(true)
     } finally {
       await rm(projectDir, { recursive: true, force: true })
     }
   })
 
-  test('appends :ro suffix when readOnly is true', async () => {
+  test('marks the mount readonly when readOnly is true', async () => {
     const notesDir = await mkdtemp(join(tmpdir(), 'typeclaw-mount-target-'))
     try {
       await writeDockerfile(root)
@@ -407,7 +474,7 @@ describe('planStart mounts', () => {
 
       const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-      expect(plan.runArgs).toContain(`${notesDir}:/agent/mounts/notes:ro`)
+      expect(hasBindMount(plan.runArgs, { src: notesDir, dst: '/agent/mounts/notes', readonly: true })).toBe(true)
     } finally {
       await rm(notesDir, { recursive: true, force: true })
     }
@@ -420,8 +487,13 @@ describe('planStart mounts', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    const homeThingMount = `${join(homedir(), 'some-dir')}:/agent/mounts/home-thing`
-    expect(plan.runArgs).toContain(homeThingMount)
+    expect(
+      hasBindMount(plan.runArgs, {
+        src: join(homedir(), 'some-dir'),
+        dst: '/agent/mounts/home-thing',
+        readonly: false,
+      }),
+    ).toBe(true)
   })
 
   test('emits mounts in declared order', async () => {
@@ -439,8 +511,11 @@ describe('planStart mounts', () => {
 
       const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-      const mountFlags = plan.runArgs.filter((arg) => arg.includes(':/agent/mounts/'))
-      expect(mountFlags).toEqual([`${a}:/agent/mounts/first`, `${b}:/agent/mounts/second`])
+      const userMounts = bindMounts(plan.runArgs).filter((m) => m.dst.startsWith('/agent/mounts/'))
+      expect(userMounts).toEqual([
+        { src: a, dst: '/agent/mounts/first', readonly: false },
+        { src: b, dst: '/agent/mounts/second', readonly: false },
+      ])
     } finally {
       await rm(a, { recursive: true, force: true })
       await rm(b, { recursive: true, force: true })
@@ -457,9 +532,9 @@ describe('planStart mounts', () => {
       const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
       expect(plan.runArgs.at(-1)).toBe(plan.imageTag)
-      const mountIdx = plan.runArgs.indexOf(`${projectDir}:/agent/mounts/projects`)
-      expect(mountIdx).toBeGreaterThan(-1)
-      expect(mountIdx).toBeLessThan(plan.runArgs.length - 1)
+      const specIdx = plan.runArgs.findIndex((a) => a.includes('dst=/agent/mounts/projects'))
+      expect(specIdx).toBeGreaterThan(-1)
+      expect(specIdx).toBeLessThan(plan.runArgs.length - 1)
     } finally {
       await rm(projectDir, { recursive: true, force: true })
     }
@@ -483,7 +558,7 @@ describe('planStart mounts', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs.filter((a) => a.includes(':/agent/mounts/'))).toHaveLength(0)
+    expect(bindMounts(plan.runArgs).filter((m) => m.dst.startsWith('/agent/mounts/'))).toHaveLength(0)
   })
 
   test('throws when a mount name violates the pattern', async () => {
@@ -496,17 +571,21 @@ describe('planStart mounts', () => {
 })
 
 describe('planStart model mount', () => {
-  const modelsMount = `${join(homedir(), '.typeclaw', 'models')}:/opt/models:ro`
+  const modelsMount: ParsedBindMount = {
+    src: join(homedir(), '.typeclaw', 'models'),
+    dst: '/opt/models',
+    readonly: true,
+  }
 
-  test('adds shared model cache mount at /opt/models:ro when memory.vector.enabled', async () => {
+  test('adds shared readonly model cache mount at /opt/models when memory.vector.enabled', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
     await writeTypeclawConfig(root, { memory: { vector: { enabled: true } } })
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs).toContain('-v')
-    expect(plan.runArgs).toContain(modelsMount)
+    expect(plan.runArgs).toContain('--mount')
+    expect(hasBindMount(plan.runArgs, modelsMount)).toBe(true)
   })
 
   test('sets TYPECLAW_MODEL_CACHE env var to /opt/models when memory.vector.enabled', async () => {
@@ -528,9 +607,9 @@ describe('planStart model mount', () => {
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
     expect(plan.runArgs.at(-1)).toBe(plan.imageTag)
-    const mountIdx = plan.runArgs.indexOf(modelsMount)
-    expect(mountIdx).toBeGreaterThan(-1)
-    expect(mountIdx).toBeLessThan(plan.runArgs.length - 1)
+    const specIdx = plan.runArgs.findIndex((a) => a.includes('dst=/opt/models'))
+    expect(specIdx).toBeGreaterThan(-1)
+    expect(specIdx).toBeLessThan(plan.runArgs.length - 1)
   })
 
   test('omits model cache mount and TYPECLAW_MODEL_CACHE when vector is opted out', async () => {
@@ -540,7 +619,7 @@ describe('planStart model mount', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs).not.toContain(modelsMount)
+    expect(hasBindMount(plan.runArgs, modelsMount)).toBe(false)
     expect(plan.runArgs).not.toContain('TYPECLAW_MODEL_CACHE=/opt/models')
   })
 
@@ -551,7 +630,7 @@ describe('planStart model mount', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs).not.toContain(modelsMount)
+    expect(hasBindMount(plan.runArgs, modelsMount)).toBe(false)
     expect(plan.runArgs).not.toContain('TYPECLAW_MODEL_CACHE=/opt/models')
   })
 
@@ -561,7 +640,7 @@ describe('planStart model mount', () => {
 
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-    expect(plan.runArgs).not.toContain(modelsMount)
+    expect(hasBindMount(plan.runArgs, modelsMount)).toBe(false)
     expect(plan.runArgs).not.toContain('TYPECLAW_MODEL_CACHE=/opt/models')
   })
 })

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -26,6 +26,7 @@ import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
 import { reconcilePluginDeps } from '@/init/reconcile-plugin-deps'
 import { runBunUpdate, type UpdateRunner } from '@/init/run-bun-install'
+import { isWindows } from '@/shared'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
 
 import { CONTAINER_PORT, TUI_TOKEN_LABEL, findFreePort, isPortAllocatedError, resolveTuiToken } from './port'
@@ -37,6 +38,7 @@ import {
   defaultDockerExec,
   type DockerExec,
   type DockerExecResult,
+  dockerBindMount,
   imageTagFromCwd,
   isContainerNameConflict,
   sanitizeDockerStderr,
@@ -656,18 +658,16 @@ export async function planStart({
     runArgs.push('-e', `TYPECLAW_HOSTD_BROKER_TOKEN=${hostdControl.brokerToken}`)
   }
 
-  runArgs.push('-v', `${cwd}:/agent`)
+  runArgs.push(...dockerBindMount({ src: cwd, dst: '/agent' }))
 
-  // Dev mode: node_modules/typeclaw is a symlink to an absolute host path
-  // outside /agent. Mirror-mount that path so the symlink resolves in-container.
-  if (devSourcePath && !devSourcePath.startsWith(cwd)) {
-    runArgs.push('-v', `${devSourcePath}:${devSourcePath}:ro`)
+  if (shouldMirrorDevSource(devSourcePath, cwd)) {
+    runArgs.push(...dockerBindMount({ src: devSourcePath, dst: devSourcePath, readonly: true }))
   }
 
   for (const mount of mounts) {
     const hostPath = expandMountPath(mount.path, cwd)
     const target = `${MOUNT_TARGET_PREFIX}/${mount.name}`
-    runArgs.push('-v', mount.readOnly ? `${hostPath}:${target}:ro` : `${hostPath}:${target}`)
+    runArgs.push(...dockerBindMount({ src: hostPath, dst: target, readonly: mount.readOnly }))
   }
 
   // Shared model cache mount for embeddings. Gated on vector opt-in: a
@@ -676,7 +676,7 @@ export async function planStart({
   // so mounting an empty cache would only invite a confusing local_files_only
   // miss if something inside the container reached for the model anyway.
   if (agentUsesVector(cwd)) {
-    runArgs.push('-v', `${join(homeRoot(), 'models')}:/opt/models:ro`)
+    runArgs.push(...dockerBindMount({ src: join(homeRoot(), 'models'), dst: '/opt/models', readonly: true }))
     runArgs.push('-e', 'TYPECLAW_MODEL_CACHE=/opt/models')
   }
 
@@ -913,6 +913,24 @@ async function detectDevSource(cwd: string): Promise<string | null> {
   } catch {
     return null
   }
+}
+
+// Dev mode: node_modules/typeclaw is a symlink to an absolute host path outside
+// /agent. The mirror mount bind-mounts that path at the SAME path inside the
+// (Linux) container so the symlink resolves. That only works when the host path
+// is itself a valid Linux container path — true on POSIX, false on native
+// Windows where devSourcePath is `C:\...` (not an absolute Linux path, so it
+// cannot be a container mount `dst`, and the in-container symlink would point at
+// a Windows path regardless). Native-Windows dev-mode (file:/link: typeclaw dep)
+// needs the deferred symlink/junction translation in #899; until then we skip
+// the mirror mount rather than emit an invalid `dst`. End users install typeclaw
+// from npm (a registry spec, not file:), so they never hit this path.
+export function shouldMirrorDevSource(
+  devSourcePath: string | null,
+  cwd: string,
+  platform: NodeJS.Platform = process.platform,
+): devSourcePath is string {
+  return devSourcePath !== null && !devSourcePath.startsWith(cwd) && !isWindows(platform)
 }
 
 // True when the agent's package.json declares typeclaw via `file:` or


### PR DESCRIPTION
## What

`docker run` bind mounts were built with the legacy `-v src:dst[:ro]` short form, which splits on `:`. On **native Windows** a host path is `C:\...`, and the drive-letter colon collides with the `-v` field separator, so Docker Desktop has to guess where the host path ends — fragile, and a frequent source of phantom-host-dir mounts. This is the Phase 4 "Docker bind-mount path injection" item from the #899 audit.

## Change

- New `dockerBindMount({ src, dst, readonly })` helper in `src/container/shared.ts` that emits `--mount type=bind,src=…,dst=…[,readonly]` argv. The CSV `key=value` grammar has no colon ambiguity and fails **loud** on a bad/missing key instead of silently creating a phantom host dir.
- Converted all four bind-mount sites in `src/container/start.ts`:
  - agent folder → `/agent`
  - dev source **mirror mount** (previously put a Windows path on *both* sides of `:` — broken on Windows even via Docker Desktop)
  - user config mounts (`/agent/mounts/<name>`, readonly honored)
  - shared model cache → `/opt/models` (readonly)
- `--env-file` and the Docker **build context** are intentionally left untouched — they are plain path arguments, not colon-delimited mount specs.

## Why it's safe on existing POSIX users

`--mount` differs from `-v` in two ways and both are already satisfied:
- **Rejects relative sources** → the helper resolves `src` to absolute.
- **Does not auto-create a missing host dir** → all sources already exist at `docker run` time: `cwd` is the agent folder, config-mount sources pass through `validateMount`, the dev mirror source is a resolved symlink target, and the models dir is created by `ensureModels()` which is **awaited before** `docker run` (and the mount is gated by the same `agentUsesVector(cwd)` condition).

The helper also rejects the pathological comma-in-path case that `--mount`'s CSV cannot express (`-v` never supported it either).

## Tests

- `start.test.ts` now parses `--mount` argv back into structured specs (order-independent) instead of asserting the old `-v` strings.
- New `dockerBindMount` unit tests in `shared.test.ts`, including a colon-bearing absolute source standing in for a Windows drive letter, the readonly flag, relative→absolute resolution, and the comma-rejection guard.
- Full suite: `9541 pass, 0 fail, 1 skip`. typecheck / lint / format clean.

## Note for reviewers

`src/skills/typeclaw-config/SKILL.md` and a comment in `src/init/dockerfile.ts` still describe mounts using `-v` prose illustratively. Left as-is to keep this PR scoped to the launcher; can update the wording in a follow-up if preferred.

Refs #899