### PR TITLE
docs: add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 <h3 align="center">TypeClaw: The agent for perfectionists</h3>
 <p align="center">Crafted in every detail – it behaves in your team's chat and<br />gets sharper the longer it runs. Sandboxed and self-managing.</p>
 
+<p align="center">
+  <a href="https://discord.gg/V4NQnbXpr"><img src="https://img.shields.io/badge/Discord-Chat%20with%20Typeey-5865F2?logo=discord&logoColor=white" alt="Chat with Typeey on Discord" /></a>
+</p>
+
 <br />
 <br />
 


### PR DESCRIPTION
## Background

New users landing on the README had no obvious path to the live community — the only link was "Chat with Typeey" buried in the tagline prose. The Discord server is where users ask questions and interact directly with Typeey, the running mascot agent, so a high-visibility badge at the top of the page lowers the barrier to entry.

## Summary

Add a centered Discord badge under the tagline. The badge links to the community server and renders the label "Chat with Typeey on Discord" with the Discord brand colour and logo, making the community touchpoint immediately visible without adding noise to the page.

No source code is touched — this is a four-line README-only change.

## Preview

The badge renders as:

[![Chat with Typeey on Discord](https://img.shields.io/badge/Discord-Chat%20with%20Typeey-5865F2?logo=discord&logoColor=white)](https://discord.gg/V4NQnbXpr)

(Centered via `<p align="center">` to match the surrounding header block.)

## What this does NOT do

- Does not touch any source files, configs, or tests.
- Does not change the Discord invite link or server.
- Does not add documentation beyond the badge itself.

## Review notes

The load-bearing detail is the invite URL — `https://discord.gg/V4NQnbXpr` — kept verbatim. The badge is a shields.io static URL with no server-side secret; it renders client-side in GitHub markdown.

Verification: typecheck, lint, format:check, and test (9536 pass, 0 fail) all pass on this branch.