### PR TITLE
docs(typeclaw-config): use model placeholder in non-default examples

### DIFF
--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -93,6 +93,7 @@ Example with mounts:
 ```json
 {
   "$schema": "./node_modules/typeclaw/typeclaw.schema.json",
+  "model": "<provider>/<model-id>",
   "mounts": [
     { "name": "typeclaw", "path": "~/workspace/typeclaw", "description": "the typeclaw source repo" },
     { "name": "notes", "path": "~/notes", "readOnly": true, "description": "personal notes (read-only)" }
@@ -210,7 +211,8 @@ Default (no `portForward` field at all): forward every LISTEN.
 
 ```json
 {
-  "$schema": "./node_modules/typeclaw/typeclaw.schema.json"
+  "$schema": "./node_modules/typeclaw/typeclaw.schema.json",
+  "model": "<provider>/<model-id>"
 }
 ```
 

--- a/src/skills/typeclaw-config/SKILL.md
+++ b/src/skills/typeclaw-config/SKILL.md
@@ -93,7 +93,6 @@ Example with mounts:
 ```json
 {
   "$schema": "./node_modules/typeclaw/typeclaw.schema.json",
-  "model": "openai/gpt-5.4-nano",
   "mounts": [
     { "name": "typeclaw", "path": "~/workspace/typeclaw", "description": "the typeclaw source repo" },
     { "name": "notes", "path": "~/notes", "readOnly": true, "description": "personal notes (read-only)" }
@@ -211,8 +210,7 @@ Default (no `portForward` field at all): forward every LISTEN.
 
 ```json
 {
-  "$schema": "./node_modules/typeclaw/typeclaw.schema.json",
-  "model": "openai/gpt-5.4-nano"
+  "$schema": "./node_modules/typeclaw/typeclaw.schema.json"
 }
 ```
 
@@ -532,7 +530,7 @@ Never echo, log, or commit values from `secrets.json` or `.env`. Both are gitign
 
 1. **Read `typeclaw.json`.** Don't guess from prior conversation — the user may have changed it since you last looked.
 2. Report the `model` field verbatim, plus the human-readable name from the **Allowed models** table.
-3. If `model` is missing from the file, say so and report the default (`openai/gpt-5.4-nano` → GPT-5.4 nano).
+3. If `model` is missing from the file, say so and report the registry default — the entry marked **Default** in the **Allowed models** table.
 
 ## When the user says "switch to <model>"
 


### PR DESCRIPTION
## Background

The `typeclaw-config` SKILL.md repeated the default model string (`openai/gpt-5.4-nano`) in six places: the schema-default cell, the allowed-models registry row, the scaffold example, and then three more incidental spots — the mounts example, the portForward default example, and the "what model are you running" step. The first three are canonical and must stay. The last three are noise: the literal shows up where the model is not the subject of the example at all.

That repetition over-weights the literal in the runtime agent's attention. When asked unrelated config questions, the agent biases toward emitting `gpt-5.4-nano` — i.e. it hallucinates the model string into answers it has no business appearing in.

## Summary

Stop re-stamping the literal default in spots where the model is not the subject, while keeping the field visible where it helps:

- **mounts example** — replace the incidental literal with the `<provider>/<model-id>` placeholder (the same notation already defined at the top of the skill). `model` stays present as a settable key without re-stamping the default.
- **portForward default example** — same placeholder. The block still illustrates "a file with no `portForward` field" without dragging the literal along.
- **"what model are you running" step** — report the registry default by pointing at the **Default**-marked row in the Allowed models table instead of restating the literal inline. One source of truth for the default, not two.

Net: the literal `openai/gpt-5.4-nano` drops from six occurrences to three — the schema-default cell, the scaffold example (which must show the real default), and the registry row. The two example blocks keep a `model` line, now as a placeholder.

## What this does NOT do

- Does not change the actual default model or the registry — the canonical mentions are untouched.
- Does not alter any schema, runtime behavior, or example correctness (both edited JSON blocks still parse; the placeholder uses the skill's own `<provider>/<model-id>` notation).
- Touches only `src/skills/typeclaw-config/SKILL.md`; no TS, no tests, no other skills.

## Review notes

The load-bearing question is whether each touched occurrence was non-canonical. The three kept literals each serve a distinct, necessary role (documents the default / scaffold shows the real default / registry is the source of truth). The placeholder `<provider>/<model-id>` is already established at line 17, so it won't be mistaken for a copyable literal — the real default sits right above it in the scaffold example. Verified both edited JSON blocks still parse (`jq`), and lint/format:check/typecheck/test (9547 pass) are green.
