### PR TITLE
fix(memory): capture durable facts about people in the memory-logger

### DIFF
--- a/src/bundled-plugins/memory/memory-logger.test.ts
+++ b/src/bundled-plugins/memory/memory-logger.test.ts
@@ -132,6 +132,36 @@ describe('MEMORY_LOGGER_SYSTEM_PROMPT', () => {
     expect(lower).toMatch(/single-occurrence|one event produces at most one fragment/)
   })
 
+  test('declares durable facts about non-user people as a capture-worthy category', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('collaborator/contact facts')
+    expect(lower).toMatch(/role|responsibility/)
+    expect(lower).toMatch(/working preference|communication preference|coordination/)
+    expect(lower).toMatch(/routing|coordinate|address|interpret/)
+  })
+
+  test('keeps a person introduction to one compact fragment instead of one-per-attribute', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/one compact fragment/i)
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/do not split .*"new participant".*"reaction"/is)
+  })
+
+  test('guards people capture against group-chat poisoning by requiring user/owner or self-described sourcing', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toMatch(/third-party facts must come from the user\/owner|describing their own role/)
+    expect(lower).toMatch(/reputational claims about another|one participant's reputational claims/)
+  })
+
+  test('qualifies social-graph trivia so operationally-relevant people facts are no longer blanket-skipped', () => {
+    const lower = MEMORY_LOGGER_SYSTEM_PROMPT.toLowerCase()
+    expect(lower).toContain('who knows whom')
+    expect(lower).toMatch(/capture a person fact only if it changes how the agent should/)
+  })
+
+  test('demonstrates people capture in a non-English (Korean) example so the rule is not English-bound', () => {
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toContain('민지는 결제 담당이고')
+    expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(/in any language/i)
+  })
+
   test('does not require fragments to articulate a future behavior change', () => {
     expect(MEMORY_LOGGER_SYSTEM_PROMPT).toMatch(
       /does(n't| not) need to articulate.*future agent|no.*Implication.*not required|implication is obvious/i,

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -105,7 +105,8 @@ The evidence can be the user's exact words, a command/output pair, a file diff t
 Capture-worthy categories:
 
 - **Explicit operating rules the user just gave the agent.** "Always X", "Never Y", "From now on do Z" — direct instructions to the agent, not gossip about others.
-- **Stable identity/role/tool facts that will keep mattering.** User/project/repo/tool/platform facts. Skip casual employment history, social-graph trivia, and membership churn unless the user says it matters.
+- **Stable identity/role/tool facts that will keep mattering.** User/project/repo/tool/platform facts. Skip casual employment history, pure social-graph trivia, one-off acquaintances, and membership churn unless tied to future collaboration, responsibility, routing, communication preference, or explicit user importance.
+- **Stable collaborator/contact facts.** Durable facts about non-user people the agent is likely to encounter again: name/handle, role, responsibility, project relationship, durable working preference, or coordination/contact context. Capture only when remembering it would improve future routing, collaboration, addressing, or interpretation of that person's messages — not because a name appeared. Keep one introduction to one compact fragment that bundles the person's core durable context (e.g. "Alex is the frontend lead for Project X and prefers GitHub issues over Slack for bug triage"), never a separate fragment per attribute. This is not a contact database: skip people who only passed through once. Third-party facts must come from the user/owner, or from that person describing their own role/preference in normal collaboration; do not persist one participant's reputational claims about another unless the user confirms or operationally relies on them.
 - **Decisions with reasoning.** "We chose X over Y because Z" when future sessions must honor X.
 - **Reproducible workarounds and debugging insights.** A config that worked, flag combination, procedure, root cause, or non-obvious fix.
 - **In-transcript changed minds.** Capture "actually, scratch that" only when the prior position is explicit. Do not compare against \`memory/topics/\`.
@@ -128,17 +129,19 @@ If taught content contains several distinct facts, write one topic per fragment,
 
 Use a simple decision rule. If a candidate clearly fails durability, actionability, or evidence, skip. If it clearly passes all three, capture. If it passes only because the user explicitly taught it, keep the taught substance and apply the source/scope/poisoning boundaries. Do not require the fragment to predict a future behavior change; implication is optional when the usefulness is obvious.
 
+The same triad governs people facts, in any language. "Jisoo owns the billing migration and prefers async design docs before calls" passes (durable role + working preference that changes future coordination). "민지는 결제 담당이고 PR은 오전에 보는 걸 선호해" ("Minji owns payments and prefers to review PRs in the morning") is the same shape — capture one compact fragment about Minji's responsibility and review preference. "Jisoo used to work with Omar" or "Mina joined the chat and seemed funny" fail (social history / one-off impression with no future operational consequence) — skip.
+
 Skip these anti-patterns:
 
 - **Conversational mechanics.** Questions asked, greetings, laughter/reactions, response-time tests, chat flow.
-- **Single-occurrence casual reactions.** Amusement, personality observations, vibes. Wait for recurrence; if it never recurs, it was never memory.
+- **Single-occurrence casual reactions.** Amusement, personality observations, vibes, or impressions of people. Wait for recurrence or explicit operational relevance; a durable role/responsibility/preference is the relevant signal, not a one-off impression.
 - **Group-chat membership events.** Invitations, joins, leaves, renames. Current channel context can supply this and it changes constantly.
-- **Casual social-graph trivia.** Friend/coworker history unless explicitly tied to future work.
+- **Casual social-graph trivia.** "Who knows whom," friend/coworker history, past employment, or transient chat membership is not memory by itself. Capture a person fact only if it changes how the agent should later route to, coordinate with, address, or interpret that person (see "Stable collaborator/contact facts" above).
 - **Latency / performance pings.** "How fast did you respond?" is not memory.
 - **The agent's own first-person observations.** The agent's persona, model confusion, or self-commentary is not memorable to itself.
 - **Re-derivable facts.** Anything obvious from the current system prompt, AGENTS.md, or channel context.
 - **Speculation untethered to a quote.** If no transcript line anchors it, skip.
-- **Multi-fragment expansions of one event.** One event produces at most one fragment. Splitting an intro into "new chat", "new participant", "job", "reaction" is over-writing.
+- **Multi-fragment expansions of one event.** One event produces at most one fragment. A teammate introduction may bundle that person's core durable role/responsibility/preference into one compact fragment, but do not split "new chat", "new participant", "job", "preference", "reaction" into separate memories.
 
 # Verbatim references (store_reference tool)
 


### PR DESCRIPTION
## Problem

The agent doesn't remember things about **people**. Users report that facts about collaborators — who owns what, how they prefer to be contacted, their role on a project — never make it into long-term memory, even when they'd obviously matter in a future session.

The root cause is entirely in the `memory-logger` subagent's system prompt (`MEMORY_LOGGER_SYSTEM_PROMPT`), which is the sole, 100% LLM-driven decision point for what gets logged (there is no programmatic taxonomy). Two problems compounded:

1. **No capture-worthy category for people existed.** The list covered operating rules, identity/tool facts, decisions, workarounds, corrections, and taught content — but never people the user works with.
2. **Three anti-patterns actively suppressed person facts:**
   - "Skip … social-graph trivia … unless the user says it matters"
   - "Single-occurrence casual reactions. … personality observations, vibes."
   - "Multi-fragment expansions of one event. Splitting an intro into 'new chat', 'new participant', 'job', 'reaction' is over-writing."

Net effect: the prompt told the model to drop people facts unless explicitly flagged as important.

## Fix

A **narrow, principled** addition — not a contact database. Designed to fix the omission without regressing the carefully-tuned anti-over-writing and anti-poisoning posture.

- **New category — "Stable collaborator/contact facts"** — gated on the same durability / actionability / evidence triad as every other category. Capture a person fact only when remembering it would change how the agent routes to, coordinates with, addresses, or interprets that person later — *not because a name appeared*.
- **Qualified the three suppressors** so they skip pure trivia ("who knows whom", past employment, one-off impressions, transient membership) while letting operationally-relevant facts through.
- **Preserved one-event-one-fragment.** An introduction bundles a person's core role/responsibility/preference into **one compact fragment**, never one-per-attribute.
- **Kept the poisoning defense intact.** Third-party facts must come from the user/owner or the person describing themselves — one participant can't write reputational claims about another into durable memory.
- **Multilingual.** Includes a non-Latin-script (Korean) example so the rule isn't English-bound, per the project's multilingual matching guidance.

## Capture vs. skip (the line this encodes)

| Capture | Skip |
| --- | --- |
| "Jisoo owns the billing migration and prefers async design docs before calls" | "Jisoo used to work with Omar" |
| "민지는 결제 담당이고 PR은 오전에 보는 걸 선호해" (Minji owns payments, reviews PRs in the morning) | "Mina joined the chat and seemed funny" |

## Tests

5 new assertions in `memory-logger.test.ts` covering: the new category, the one-compact-fragment rule, the poisoning-source guard, the qualified social-graph anti-pattern, and the Korean example.

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (65 pre-existing warnings, unrelated)
- `bun run format:check` — clean
- `bun run test` — **9552 pass, 0 fail**

## Scope

Prompt-only change to one subagent. No code paths, schemas, or contracts touched. The downstream `dreaming` consolidator and channel memory-bleed defenses are unaffected — the logger remains stingy, so people facts flow through the existing strength/saturation model like any other topic.
