### PR TITLE
feat(agent): drop OpenAI-family low thinking-level default

### DIFF
--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -450,39 +450,22 @@ describe('isOpenAiFamilyRef', () => {
 })
 
 describe('defaultThinkingLevelForRef', () => {
-  test('OpenAI api-key models default to low', () => {
-    expect(defaultThinkingLevelForRef('openai/gpt-5.4-nano')).toBe('low')
-    expect(defaultThinkingLevelForRef('openai/gpt-5.4-mini')).toBe('low')
-    expect(defaultThinkingLevelForRef('openai/gpt-5.4')).toBe('low')
-    expect(defaultThinkingLevelForRef('openai/gpt-5.5')).toBe('low')
-  })
-
-  test('OpenAI Codex (ChatGPT Plus/Pro OAuth) models also default to low', () => {
-    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.4-mini')).toBe('low')
-    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.4')).toBe('low')
-    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.5')).toBe('low')
+  test('OpenAI-family models no longer pin low; they defer to the SDK default', () => {
+    expect(defaultThinkingLevelForRef('openai/gpt-5.4-nano')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('openai/gpt-5.5')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.4')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('openai-codex/gpt-5.5')).toBeUndefined()
   })
 
   test('non-OpenAI providers defer to the SDK default (returns undefined)', () => {
-    expect(defaultThinkingLevelForRef('anthropic/claude-opus-4-7')).toBeUndefined()
     expect(defaultThinkingLevelForRef('anthropic/claude-opus-4-8')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('anthropic/claude-sonnet-4-6')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('anthropic/claude-haiku-4-5')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('fireworks/accounts/fireworks/routers/kimi-k2p6-turbo')).toBeUndefined()
     expect(defaultThinkingLevelForRef('zai/glm-4.6')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('zai-coding/glm-5.1')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('minimax/MiniMax-M3')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('deepseek/deepseek-v4-flash')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('deepseek/deepseek-v4-pro')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('moonshot/kimi-k2.7-code')).toBeUndefined()
     expect(defaultThinkingLevelForRef('moonshot/kimi-k2.5')).toBeUndefined()
-    expect(defaultThinkingLevelForRef('moonshot-coding/kimi-for-coding')).toBeUndefined()
   })
 
-  test('every known model ref is classified (no provider falls through unhandled)', () => {
+  test('every known model ref defers to the SDK default (no family is pinned)', () => {
     for (const ref of listKnownModelRefs()) {
-      const level = defaultThinkingLevelForRef(ref)
-      expect(level === 'low' || level === undefined, `${ref} returned unexpected ${String(level)}`).toBe(true)
+      expect(defaultThinkingLevelForRef(ref), `${ref} should defer to the SDK default`).toBeUndefined()
     }
   })
 })

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,3 +1,4 @@
+import type { ThinkingLevel } from '@mariozechner/pi-agent-core'
 import type { KnownApi, Model } from '@mariozechner/pi-ai'
 
 // Authentication mechanism a provider supports. `api-key` reads a static key
@@ -979,24 +980,15 @@ function knownProviderForModelRef(ref: string): KnownProviderId | null {
   return null
 }
 
-// Per-provider default for pi-coding-agent's `thinkingLevel` knob. Returning
-// `undefined` defers to the SDK default (`medium`); returning a level pins it
-// to that value at session-creation time.
-//
-// OpenAI-family providers (`openai`, `openai-codex`) pin to `low`: GPT-5.x at
-// `medium` pads reasoning tokens on routine tool-driven turns (code edits,
-// channel replies, cron prompts) with no observable quality delta on this
-// codebase's workloads. Applies to every session that resolves to a GPT model
-// regardless of profile, so the saving is uniform.
-//
-// Anthropic, GLM, and Kimi don't share the padding behavior, so they keep the
-// SDK default.
 export function isOpenAiFamilyRef(ref: KnownModelRef | ModelRef | string): boolean {
   return vendorForProviderId(providerForModelRef(ref)) === 'openai'
 }
 
-export function defaultThinkingLevelForRef(ref: KnownModelRef | ModelRef | string): 'low' | undefined {
-  if (isOpenAiFamilyRef(ref)) return 'low'
+// Returning `undefined` defers to pi-coding-agent's SDK default (`medium`);
+// returning a level pins it at session-creation time. No family is pinned: the
+// prior OpenAI `low` pin was dropped so GPT-5.x reasons at SDK strength like
+// every other vendor.
+export function defaultThinkingLevelForRef(_ref: KnownModelRef | ModelRef | string): ThinkingLevel | undefined {
   return undefined
 }
 


### PR DESCRIPTION
## Background

GPT-5.x sessions were pinned to `low` reasoning effort at session-creation time while every other vendor (Anthropic, GLM, Kimi) deferred to the SDK default of `medium`. The pin was a token-saving heuristic: GPT-5.x at `medium` was believed to pad reasoning tokens with no quality delta. We are dropping it — OpenAI models should reason at SDK strength like every other vendor, and per-model effort should become a user choice rather than a hardcoded family rule.

## Summary

`defaultThinkingLevelForRef` now returns `undefined` for every ref (no family pinned). `undefined` already means defer to the SDK default (`medium`), so the only behavior change is OpenAI-family sessions moving `low` to `medium`.

Two non-obvious decisions worth calling out:

- **Why keep the function instead of inlining a constant.** `defaultThinkingLevelForRef` is the seam where a user-configured per-model thinking level will plug in (a follow-up PR in this stack). Removing it now would force re-introducing a function boundary one PR later.
- **Why keep `isOpenAiFamilyRef`.** The helper still gates `proactiveNextStepNudge` — it is not dead code.

## What this does NOT do

- Does not add any config field (`thinkingLevel` in `typeclaw.json` is a follow-up PR).
- Does not touch the per-turn attention-escalation path (changed in a separate PR in the same stack).

## Review notes

This is PR 1 of a 4-PR stack:

1. Drop OpenAI `low` default **[this PR]**
2. Escalation `high` to `xhigh`
3. `thinkingLevel` in `typeclaw.json` + runtime
4. CLI prompt + skill docs

The load-bearing change is a single `return undefined` replacing a conditional that returned `"low"` for OpenAI-family refs. The test diff removes assertions that expected `"low"` and replaces them with `undefined` expectations — verify those match.