### PR TITLE
feat(agent): escalate attention turns to xhigh instead of high

### DIFF
--- a/src/agent/attention-escalation.test.ts
+++ b/src/agent/attention-escalation.test.ts
@@ -110,9 +110,9 @@ describe('detectAttentionEscalation — negative', () => {
 })
 
 describe('resolveTurnThinkingLevel', () => {
-  test('escalation text bumps to high regardless of session default', () => {
-    expect(resolveTurnThinkingLevel('wtf', 'low')).toBe('high')
-    expect(resolveTurnThinkingLevel('제대로 해', undefined)).toBe('high')
+  test('escalation text bumps to xhigh regardless of session default', () => {
+    expect(resolveTurnThinkingLevel('wtf', 'low')).toBe('xhigh')
+    expect(resolveTurnThinkingLevel('제대로 해', undefined)).toBe('xhigh')
   })
 
   test('normal text falls back to the session default', () => {
@@ -135,10 +135,10 @@ describe('applyTurnThinkingLevel', () => {
     }
   }
 
-  test('escalation turn sets high', () => {
+  test('escalation turn sets xhigh', () => {
     const session = fakeSession()
     applyTurnThinkingLevel(session, 'ultrathink please', 'low')
-    expect(session.calls).toEqual(['high'])
+    expect(session.calls).toEqual(['xhigh'])
   })
 
   test('normal turn resets to the session default', () => {
@@ -157,6 +157,6 @@ describe('applyTurnThinkingLevel', () => {
     const session = fakeSession()
     applyTurnThinkingLevel(session, '뭐하는 거야', 'low')
     applyTurnThinkingLevel(session, 'thanks, looks good', 'low')
-    expect(session.calls).toEqual(['high', 'low'])
+    expect(session.calls).toEqual(['xhigh', 'low'])
   })
 })

--- a/src/agent/attention-escalation.ts
+++ b/src/agent/attention-escalation.ts
@@ -562,9 +562,10 @@ export function detectAttentionEscalation(text: string): boolean {
   return MORPHEME_PATTERNS.some((pattern) => pattern.test(normalized))
 }
 
-// Not `xhigh`: that level is OpenAI-family-only. `high` is universal and
-// `setThinkingLevel` clamps it down per-model, so it's safe to pass unconditionally.
-const ESCALATED_LEVEL: ThinkingLevel = 'high'
+// `xhigh` is the strongest level. It's OpenAI-family-only, but `setThinkingLevel`
+// clamps it per-model (down to `high` on non-OpenAI), so it's safe to pass
+// unconditionally and gives OpenAI models maximum effort on escalation turns.
+const ESCALATED_LEVEL: ThinkingLevel = 'xhigh'
 
 export function resolveTurnThinkingLevel(
   text: string,

--- a/src/cron/consumer.test.ts
+++ b/src/cron/consumer.test.ts
@@ -1138,7 +1138,7 @@ describe('createCronConsumer count gate', () => {
       } as unknown as AgentSession
     }
 
-    test('bumps thinking level to high on an escalation prompt and to the default otherwise', async () => {
+    test('bumps thinking level to xhigh on an escalation prompt and to the default otherwise', async () => {
       const levelsByJob = new Map<string, string[]>()
       const factory = {
         createSessionForCron: async (job: PromptJob): Promise<CronSession> => {
@@ -1163,7 +1163,7 @@ describe('createCronConsumer count gate', () => {
       publishCron(stream, promptJob('routine', 'post the daily summary'))
       await waitForConsumerIdle(consumer)
 
-      expect(levelsByJob.get('frustrated')).toEqual(['high'])
+      expect(levelsByJob.get('frustrated')).toEqual(['xhigh'])
       expect(levelsByJob.get('routine')).toEqual(['low'])
 
       consumer.stop()

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -483,7 +483,7 @@ describe('createServer abort handling (no stream — fallback path)', () => {
     ws.close()
   })
 
-  test('attention escalation bumps to high then resets to the captured default', async () => {
+  test('attention escalation bumps to xhigh then resets to the captured default', async () => {
     // The fallback path must reset from the session's CREATION-time level, not the
     // live getter — otherwise the first escalated turn poisons the second turn's
     // reset target. Enhance the fake with a real thinkingLevel getter that tracks
@@ -512,7 +512,7 @@ describe('createServer abort handling (no stream — fallback path)', () => {
     session.resolvePrompt()
     await waitFor((m) => m.type === 'done')
 
-    expect(thinkingCalls).toEqual(['high', 'low'])
+    expect(thinkingCalls).toEqual(['xhigh', 'low'])
     ws.close()
   })
 })


### PR DESCRIPTION
## Background

The attention-escalation detector bumps a turn's reasoning effort when a human signals they care about the result — frustration ("wtf", "제대로 해") or an explicit care/effort cue ("do it properly", "ultrathink"). That bump targeted `high`. We want escalation to reach the maximum effort the model supports, so OpenAI-family models go all the way to `xhigh` on these turns.

## Summary

`ESCALATED_LEVEL` changes from `high` to `xhigh`.

Why this is safe across providers: `xhigh` is OpenAI-family-only, but `setThinkingLevel` clamps it per-model — down to `high` on non-OpenAI — so non-OpenAI sessions behave exactly as before. Only OpenAI-family sessions gain the extra step. This mirrors the existing reasoning for why the old `high` value was already safe to pass unconditionally.

Updates the unit test (`attention-escalation.test.ts`) and the two integration tests that pinned the escalated level: the cron consumer and the server (TUI) fallback path.

## What this does NOT do

- Does not change what triggers escalation — the 15-language phrase tables are untouched.
- Does not change the non-escalated / default thinking level.
- Does not affect non-OpenAI-family sessions.

## Review notes

PR 2 of a 4-PR stack:

1. Drop OpenAI low default
2. Escalation `high` → `xhigh` (this PR)
3. `thinkingLevel` in typeclaw.json + runtime
4. CLI prompt + skill docs

Independent of PR 1 — both branch off main and touch disjoint files.

The load-bearing check: confirm `setThinkingLevel` clamps `xhigh` to `high` for non-OpenAI providers, preserving the no-regression guarantee.