### PR TITLE
feat(agent): add completion + parallel-tool-call steering to base prompt

### DIFF
--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -81,6 +81,70 @@ describe('agent folder vs project repo', () => {
   })
 })
 
+describe('finishing the job — completion + anti-fabrication steer', () => {
+  // Ported from hermes-agent's TASK_COMPLETION_GUIDANCE: deliverable is a
+  // working artifact backed by real tool output, and the agent must never
+  // substitute fabricated output for a result it could not actually produce.
+  test('the default prompt tells the agent the deliverable is a real artifact, not a description of one', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('## Finishing the job')
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/working artifact backed by real tool output/i)
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/do not stop after writing a stub/i)
+  })
+
+  test('the default prompt forbids fabricating output when the real path is blocked', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Finishing the job')
+    expect(start).toBeGreaterThan(-1)
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 900)
+    expect(section).toMatch(/never substitute .*fabricated output|never fabricate/i)
+    expect(section).toMatch(/report(ing)? .*blocker|say so directly/i)
+  })
+
+  test.each([
+    ['default prompt', DEFAULT_SYSTEM_PROMPT],
+    ['slim prompt', SLIM_SYSTEM_PROMPT],
+  ])(
+    'the %s keeps the anti-fabrication invariant (cron/subagent are where fabrication is most dangerous)',
+    (_name, prompt) => {
+      expect(prompt).toMatch(/never fabricate|fabricated output/i)
+    },
+  )
+
+  // Cache-suffix contract: steering blocks must live in the least-volatile
+  // base prefix, AHEAD of the per-agent identity block, so they never
+  // invalidate cached bytes when IDENTITY.md / SOUL.md change.
+  test('the finishing-the-job steer sits inside the base prompt (no per-agent placeholders)', () => {
+    expect(DEFAULT_SYSTEM_PROMPT.indexOf('## Finishing the job')).toBeLessThan(
+      DEFAULT_SYSTEM_PROMPT.indexOf('You are not pi, not Claude, not ChatGPT.'),
+    )
+  })
+})
+
+describe('parallel tool calls steer', () => {
+  // Ported from hermes-agent's PARALLEL_TOOL_CALL_GUIDANCE (universal, all
+  // models). typeclaw's runtime base prompt never told the model to batch
+  // independent reads/searches; only the orchestration section mentioned
+  // parallel subagent fan-out. This makes the batching steer explicit for the
+  // model's own direct tool calls.
+  test('the default prompt tells the agent to batch independent tool calls into one turn', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('## Parallel tool calls')
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/independent (reads|tool calls|calls)/i)
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/single (response|turn)|same (response|turn)/i)
+  })
+
+  test('the parallel steer carves out the dependency exception (serialize only when a later call depends on an earlier result)', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Parallel tool calls')
+    expect(start).toBeGreaterThan(-1)
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 700)
+    expect(section).toMatch(/depend|serialize/i)
+  })
+
+  test('the parallel steer sits inside the cacheable base prefix, ahead of the identity block', () => {
+    expect(DEFAULT_SYSTEM_PROMPT.indexOf('## Parallel tool calls')).toBeLessThan(
+      DEFAULT_SYSTEM_PROMPT.indexOf('You are not pi, not Claude, not ChatGPT.'),
+    )
+  })
+})
+
 describe('renderTurnTimeAnchor', () => {
   test('wraps the ISO timestamp, IANA zone, and weekday in a single <current-time> tag', () => {
     const now = new Date('2026-01-15T12:00:00+09:00')

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -52,6 +52,16 @@ If it describes how you sound, use SOUL.md; how you work, AGENTS.md. **Edit disc
 
 Start work in the same turn when the next action is clear; do not answer with only a plan. For multi-step work, give one short progress update, not narration.
 
+## Finishing the job
+
+When the user asks you to build, run, fix, or verify something, the deliverable is a working artifact backed by real tool output — not a description of one. Do not stop after writing a stub, a plan, or a single command; keep working until you have actually exercised the code or produced the requested result, then report what real execution returned.
+
+If a tool, install, or network call fails and blocks the real path, say so directly and try an alternative (different approach, different package, ask the user). Never substitute plausible-looking fabricated output (made-up data, invented file contents, synthesised tool results) for a result you could not actually produce — reporting a blocker honestly is always better than inventing a result.
+
+## Parallel tool calls
+
+When you need several pieces of information that don't depend on each other, request them in a single response instead of one tool call per turn. Independent reads, searches, and read-only commands should be batched into the same turn — the runtime runs independent calls concurrently, and batching avoids re-sending the whole conversation on every extra round-trip. Only serialize when a later call genuinely depends on an earlier call's result (e.g. read a file before patching it).
+
 ## Tracking your work
 
 For multi-step or long-running tasks, use \`todo_write\` when you start and mark items complete as you finish; incomplete items let the runtime resume after interruptions. Use \`todo_clear\` only to abandon remaining work. Single-step requests need no todo list.


### PR DESCRIPTION
## Why

The runtime **base** system prompt's execution guidance was a single sentence — *"Start work in the same turn when the next action is clear; do not answer with only a plan."* It had no completion-discipline, no anti-fabrication steer, and no parallel-tool-call steer for the model's **own** direct tool calls (the only parallelism mention was subagent fan-out in `## Subagent orchestration`).

On the same model, that reads as *less agentic* than agents that explicitly steer those behaviors: the model stalls after writing a stub, narrates instead of acting, or fabricates plausible-looking output when a real path is blocked. This ports the two **universal** (all-model) steering blocks that close that gap.

## What

Two new sections added to `buildDefaultSystemPrompt` in `src/agent/system-prompt.ts`:

- **`## Finishing the job`** — the deliverable is a working artifact backed by real tool output, not a description of one; don't stop after a stub/plan/single command; and **never substitute fabricated output** for a result that couldn't actually be produced (report the blocker instead).
- **`## Parallel tool calls`** — batch independent reads/searches/read-only commands into a single turn; serialize only on a genuine data dependency.

## Cache-suffix contract

Both blocks live in the **least-volatile base prefix**, ahead of the per-agent identity block (`IDENTITY.md`/`SOUL.md`). After the first turn they cost **zero extra cached bytes** via provider prefix caching, and they do not perturb the least-volatile-first ordering the `dump-system-prompt` section-order + token-budget guards enforce.

- Base prompt: ~2428 → ~2749 tok (+321, in the cacheable prefix).
- Slim cron/subagent prompt is **unchanged** — it already carries the anti-fabrication invariant; the new token budget delta only widens the tui−cron gap the guard checks.

## Scope notes

- **Universal, not model-gated.** These mirror the all-model steers, not the per-family ones. typeclaw already gates `PROACTIVE_NEXT_STEP_NUDGE` on the OpenAI family (`isOpenAiFamilyRef`) as its model-specific mechanism; this PR deliberately does not add a parallel gating mechanism.
- The slim prompt's existing *"never fabricate results"* line is retained and now asserted by a shared test across both prompts.

## Tests (TDD)

Added to `src/agent/system-prompt.test.ts` (written failing first, then implemented):

- finishing-the-job: artifact-not-description, anti-fabrication-on-blocker, shared anti-fabrication invariant across default + slim, base-prefix placement.
- parallel-tool-calls: batch-independent-calls, dependency-exception carve-out, base-prefix placement.

```
bun run typecheck   # clean
bun run lint        # 0 errors (pre-existing warnings only, unrelated files)
bun run format      # clean
bun test --parallel scripts/dump-system-prompt.test.ts src/agent/system-prompt.test.ts src/agent/index.test.ts
# 164 pass / 0 fail
```
