### PR TITLE
feat(config): add thinkingLevel field to typeclaw.json

### DIFF
--- a/docs/content/docs/reference/typeclaw-json.mdx
+++ b/docs/content/docs/reference/typeclaw-json.mdx
@@ -8,22 +8,23 @@ JSON Schema–validated. `typeclaw init` scaffolds a `$schema` pointer at `./nod
 
 ## Top-level fields
 
-| Field                   | Type                             | Reload                                       | Concept                                                                                |
-| ----------------------- | -------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `models`                | `Record<string, ref \| ref[]>`   | live                                         | model profile → ref or fallback chain                                                  |
-| `port`                  | `number`                         | restart-required                             | preferred host port; CLI falls back to ephemeral on conflict                           |
-| `mounts`                | `Mount[]`                        | restart-required                             | host files or directories exposed inside the container                                 |
-| `plugins`               | `string[]`                       | restart-required                             | plugin module specifiers                                                               |
-| `alias`                 | `string[]`                       | live                                         | additional names the agent answers to in channels                                      |
-| `channels`              | `Record<adapter, AdapterConfig>` | live                                         | per-adapter config                                                                     |
-| `portForward`           | `{ allow, deny? }`               | restart-required                             | auto port-forward allow/deny lists; default `{ allow: '*' }`                           |
-| `network`               | `NetworkPolicy`                  | restart-required                             | egress filtering                                                                       |
-| `sandbox`               | `SandboxPolicy`                  | restart-required                             | per-tool bwrap sandbox options                                                         |
-| `tunnels`               | `Tunnel[]`                       | restart-required                             | public URLs (see [/concepts/architecture](/docs/concepts/architecture))                |
-| `roles`                 | `Record<name, Role>`             | `match` live, `permissions` restart-required | permission roles (see [/concepts/permissions-model](/docs/concepts/permissions-model)) |
-| `docker.file`           | `DockerFileOptions`              | rebuild via `start`                          | Dockerfile feature toggles + append lines                                              |
-| `docker.runArgs.append` | `string[]`                       | rebuild via `start`                          | extra `docker run` flags                                                               |
-| `git.ignore.append`     | `string[]`                       | rebuild via `start`                          | extra `.gitignore` lines                                                               |
+| Field                   | Type                                                           | Reload                                       | Concept                                                                                |
+| ----------------------- | -------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `models`                | `Record<string, ref \| ref[]>`                                 | live                                         | model profile → ref or fallback chain                                                  |
+| `thinkingLevel`         | `'off' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'xhigh'` | live                                         | reasoning effort for new sessions; defers to the SDK default when unset                |
+| `port`                  | `number`                                                       | restart-required                             | preferred host port; CLI falls back to ephemeral on conflict                           |
+| `mounts`                | `Mount[]`                                                      | restart-required                             | host files or directories exposed inside the container                                 |
+| `plugins`               | `string[]`                                                     | restart-required                             | plugin module specifiers                                                               |
+| `alias`                 | `string[]`                                                     | live                                         | additional names the agent answers to in channels                                      |
+| `channels`              | `Record<adapter, AdapterConfig>`                               | live                                         | per-adapter config                                                                     |
+| `portForward`           | `{ allow, deny? }`                                             | restart-required                             | auto port-forward allow/deny lists; default `{ allow: '*' }`                           |
+| `network`               | `NetworkPolicy`                                                | restart-required                             | egress filtering                                                                       |
+| `sandbox`               | `SandboxPolicy`                                                | restart-required                             | per-tool bwrap sandbox options                                                         |
+| `tunnels`               | `Tunnel[]`                                                     | restart-required                             | public URLs (see [/concepts/architecture](/docs/concepts/architecture))                |
+| `roles`                 | `Record<name, Role>`                                           | `match` live, `permissions` restart-required | permission roles (see [/concepts/permissions-model](/docs/concepts/permissions-model)) |
+| `docker.file`           | `DockerFileOptions`                                            | rebuild via `start`                          | Dockerfile feature toggles + append lines                                              |
+| `docker.runArgs.append` | `string[]`                                                     | rebuild via `start`                          | extra `docker run` flags                                                               |
+| `git.ignore.append`     | `string[]`                                                     | rebuild via `start`                          | extra `.gitignore` lines                                                               |
 
 Plugin-owned config blocks live at the top level under their plugin name and are validated by the plugin's own `configSchema`.
 
@@ -42,7 +43,15 @@ Plugin-owned config blocks live at the top level under their plugin name and are
 
 `default` is required. Other profile names are conventional but not enforced. Each value is either a single `<provider>/<model>` ref or a non-empty array forming a fallback chain: on failure, the runtime disposes the failed session and replays the prompt against the next ref.
 
-Provider-family defaults override the SDK's reasoning level at session creation: OpenAI-family refs (`openai/*`, `openai-codex/*`) pin `thinkingLevel: 'low'` because GPT-5.x at the SDK default of `medium` pads reasoning tokens on routine tool-driven turns with no observable quality delta. Anthropic, GLM, and Kimi refs keep the SDK default.
+## `thinkingLevel`
+
+```json
+{
+  "thinkingLevel": "high"
+}
+```
+
+Sets the reasoning effort applied to new sessions, from `off` through `xhigh`. When unset, the runtime defers to pi-coding-agent's SDK default (`medium`) — no provider family is pinned. The value is clamped to each model's capabilities at session creation (e.g. `xhigh` is OpenAI-family-only and clamps down to `high` elsewhere). Live-reloadable: a change lands on the next session without a container restart. An attention-escalation cue in a turn (frustration or an explicit "do it properly" / "ultrathink") still bumps that single turn to maximum effort regardless of this setting.
 
 ## `network`
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -439,7 +439,9 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
       : customToolsPreBudget
 
   const model = applyModelRuntimeOverrides(resolveModel(activeRef), activeRef)
-  const thinkingLevel = defaultThinkingLevelForRef(activeRef)
+  // User config wins over the per-provider default. Read live so a reloaded
+  // `thinkingLevel` lands on the next session without a container restart.
+  const thinkingLevel = getConfig().thinkingLevel ?? defaultThinkingLevelForRef(activeRef)
   const { session } = await createAgentSession({
     model,
     sessionManager,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -14,6 +14,7 @@ import {
   configSchema,
   extractPluginConfigs,
   expandMountPath,
+  FIELD_EFFECTS,
   getSandboxWritablePathSpecs,
   loadConfigSync,
   loadConfigSyncOrDefaults,
@@ -129,6 +130,28 @@ describe('configSchema models field', () => {
       models: { default: ['openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'] },
     })
     expect(parsed.models.default).toEqual(modelRefList('openai/gpt-5.4-nano', 'openai/gpt-5.4-mini'))
+  })
+})
+
+describe('configSchema thinkingLevel field', () => {
+  test('is undefined when omitted (defers to the per-provider/SDK default)', () => {
+    const parsed = configSchema.parse({ models: { default: VALID_MODEL } })
+    expect(parsed.thinkingLevel).toBeUndefined()
+  })
+
+  test('accepts every supported level', () => {
+    for (const level of ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const) {
+      const parsed = configSchema.parse({ models: { default: VALID_MODEL }, thinkingLevel: level })
+      expect(parsed.thinkingLevel).toBe(level)
+    }
+  })
+
+  test('rejects an unknown level', () => {
+    expect(() => configSchema.parse({ models: { default: VALID_MODEL }, thinkingLevel: 'turbo' })).toThrow()
+  })
+
+  test('is classified applied (live-reloadable, no restart)', () => {
+    expect(FIELD_EFFECTS.thinkingLevel).toBe('applied')
   })
 })
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -661,6 +661,12 @@ export const modelsSchema = z
 // consumer the `T | undefined` assertion noise.
 export type Models = Record<string, ModelRef[]> & { default: ModelRef[] }
 
+// Mirrors pi-coding-agent's `ThinkingLevel`. Kept as a local enum (rather than
+// importing the SDK type) so the schema owns the canonical value list and zod
+// can validate `typeclaw.json` without a runtime SDK dependency.
+export const thinkingLevelSchema = z.enum(['off', 'minimal', 'low', 'medium', 'high', 'xhigh'])
+export type ThinkingLevel = z.infer<typeof thinkingLevelSchema>
+
 export const configSchema = z
   .object({
     $schema: z.string().optional(),
@@ -672,6 +678,7 @@ export const configSchema = z
     // not the user-facing input shape.
     models: modelsSchema.default(() => ({ default: [asModelRef(DEFAULT_MODEL_REF)] })) as unknown as z.ZodType<Models>,
     customModels: customModelsSchema,
+    thinkingLevel: thinkingLevelSchema.optional(),
     // Defaults to `[]` so the field can be omitted from `typeclaw.json` (no
     // host paths exposed) without failing the whole config load. `typeclaw
     // init` omits this field so users don't see noise for the empty case.
@@ -880,6 +887,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   $schema: 'ignored',
   models: 'applied',
   customModels: 'applied',
+  thinkingLevel: 'applied',
   port: 'restart-required',
   mounts: 'restart-required',
   mcpServers: 'restart-required',
@@ -976,6 +984,7 @@ export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
     'port',
     'models',
     'customModels',
+    'thinkingLevel',
     'mounts',
     'plugins',
     'alias',

--- a/src/config/reloadable.test.ts
+++ b/src/config/reloadable.test.ts
@@ -319,4 +319,7 @@ function shouldRecurse(path: string): boolean {
   return path === 'docker' || path === 'git' || path === 'permissions'
 }
 
-const KNOWN_OPTIONAL_PATHS = new Set<string>(['roles.match', 'roles.permissions'])
+// `thinkingLevel` is an optional top-level field: absent from a bare-`{}` parse
+// (so it never shows up in the enumerated default-config paths) but classified
+// in FIELD_EFFECTS, exactly like the roles virtual paths.
+const KNOWN_OPTIONAL_PATHS = new Set<string>(['roles.match', 'roles.permissions', 'thinkingLevel'])


### PR DESCRIPTION
## Background

Reasoning effort (thinking level) was entirely implicit: a per-provider hardcoded default with no user control. Operators who want a specific model to reason harder or cheaper had no knob. This PR adds a user-configurable `thinkingLevel` field to `typeclaw.json`.

## Summary

New optional top-level `thinkingLevel` field: `off | minimal | low | medium | high | xhigh`. It overrides the per-provider default at session creation; when unset, the runtime defers to the SDK default (`medium`).

Key decisions worth calling out:

- **Why `getConfig()` and not the boot snapshot.** The field is read live so a reloaded value lands on the next session without a container restart — hence classified `applied` in `FIELD_EFFECTS`, per the config two-access-pattern rule.
- **Why a locally-defined zod enum.** The config module owns the canonical value list and validates `typeclaw.json` without a runtime SDK dependency. Importing the SDK's `ThinkingLevel` type would couple the config layer to the agent runtime.
- **`extractPluginConfigs` known-set.** Added `thinkingLevel` so it isn't misread as plugin config during config parsing.
- **Reloadable coverage guard.** Allowlisted as an optional field — optional fields don't appear in a bare-`{}` parse, the same treatment as the `roles.*` virtual paths.

Docs updated: the `thinkingLevel` field is documented in `typeclaw-json.mdx`; the now-removed OpenAI-family `low`-pin note (from the now-merged PR #986) is no longer referenced.

## What this does NOT do

- Does not add a CLI prompt or `typeclaw model add/set` integration — that is the next PR in the stack.
- Does not make the field per-profile. It is a single top-level setting; the per-turn attention-escalation bump still overrides it for escalated turns.

## Review notes

PR 3 of a 4-PR stack. Originally stacked on PR #986 (drop OpenAI `low` default), which has since merged to `main` — so the base is now `main` and the diff shows exactly this commit. No rebase needed.

Load-bearing changes to verify:
- `FIELD_EFFECTS` entry classifies `thinkingLevel` as `applied` (not `restart-required`).
- `extractPluginConfigs` known-set includes `thinkingLevel`.
- `reloadable.test.ts` allowlist entry uses the optional-field exception, consistent with `roles.*`.
- `src/agent/index.ts` reads the field via `getConfig()`, not the boot snapshot.

Follow-up: PR 4 adds the `typeclaw model add/set` prompt and the `typeclaw-config` skill docs.