### PR TITLE
feat(agent): add intent-recognition steering to base prompt

### DIFF
--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -81,6 +81,112 @@ describe('agent folder vs project repo', () => {
   })
 })
 
+describe('understanding the request — intent-recognition steer', () => {
+  // Fixes TASK RECOGNITION, upstream of the "choose a reasonable default"
+  // ambiguity rule (which only fires AFTER the task is recognized) and the
+  // "finish the job" rule (which only helps ONCE the job is known). The failure
+  // mode: the agent executes the literal SURFACE form of a message instead of
+  // the practical task behind it — answering "yes I can" to a polite imperative,
+  // or a bare status answer when the user obviously wants the fix next.
+  test('the default prompt tells the agent to infer the practical task behind the wording, not the literal speech act', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toContain('## Understanding the request')
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Understanding the request')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 1000)
+    expect(section).toMatch(
+      /practical task|what the user (actually )?(needs|wants)|real(?: underlying)? (need|intent)/i,
+    )
+    expect(section).toMatch(/literal|surface|wording/i)
+  })
+
+  // The polite-imperative trap, stated language-agnostically: "can you X?" /
+  // "could you X" / "X would be nice" are requests to DO X, not yes/no
+  // questions — and this holds across languages (this is a multilingual chat
+  // agent). Soften this and the "yes I can" regression reopens.
+  test('the default prompt calls out the polite-imperative trap language-agnostically', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Understanding the request')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 1200)
+    expect(section).toMatch(/can you|could you|would be (nice|good|great)|capability|polite/i)
+    // Language-agnostic framing — must not be scoped to English phrasing only.
+    expect(section).toMatch(/any language|across languages|regardless of (the )?language|whatever the language/i)
+  })
+
+  // Anti-over-clarification guardrail: intent inference must REDUCE questions,
+  // not add them. A chat agent that interrogates "what did you really mean?" on
+  // every turn is a UX regression. The carve-out: act on the safe conventional
+  // reading; ask only when interpretations materially diverge. This is the
+  // CANONICAL home for the clarifying-question rule — `## How to behave` no
+  // longer duplicates it (the dedupe guard below pins that).
+  test('the default prompt frames intent inference as reducing questions, not adding a clarification ritual', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Understanding the request')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 1200)
+    expect(section).toMatch(
+      /fewer\b[\s*]*(clarifying )?questions|not.*more questions|reduce.*question|don't (over-?ask|interrogate)|without.*(asking|clarif)/i,
+    )
+    expect(section).toMatch(/reasonable|conventional|safe|likely/i)
+    expect(section).toMatch(/materially change scope|scope, permissions, cost/i)
+  })
+
+  // The action-bias steer ("start in the same turn, don't answer with only a
+  // plan") was merged INTO this section from the former standalone
+  // `## Execution bias` header. Guards both that the steer survived the merge
+  // and that it stays salient as the section's opening line (not buried).
+  test('the action-bias steer is folded into the section and is no longer a separate `## Execution bias` header', () => {
+    expect(DEFAULT_SYSTEM_PROMPT).not.toContain('## Execution bias')
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Understanding the request')
+    const opening = DEFAULT_SYSTEM_PROMPT.slice(start, start + 220)
+    expect(opening).toMatch(/start work in the same turn|same turn/i)
+    expect(opening).toMatch(/only a plan|not narration/i)
+  })
+
+  // Dedupe guard: the clarifying-question / reasonable-default rule lives ONLY
+  // in `## Understanding the request` now. `## How to behave` must not carry a
+  // second copy (the redundancy this consolidation removed).
+  test('the clarifying-question rule is not duplicated in `## How to behave`', () => {
+    const behaveStart = DEFAULT_SYSTEM_PROMPT.indexOf('## How to behave')
+    expect(behaveStart).toBeGreaterThan(-1)
+    const behave = DEFAULT_SYSTEM_PROMPT.slice(behaveStart, behaveStart + 700)
+    expect(behave).not.toMatch(/clarifying question/i)
+    expect(behave).not.toMatch(/choose a reasonable default/i)
+  })
+
+  // Scope guard: the helpful next step lives WITHIN the apparent request — the
+  // steer must not license inventing a larger project off a small ask.
+  test('the default prompt bounds the inferred next step to the apparent request (no scope inflation)', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Understanding the request')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 1400)
+    expect(section).toMatch(
+      /don't (invent|expand|inflate)|not a (larger|bigger) project|within (the )?(apparent|requested) (scope|request)|stay within scope/i,
+    )
+  })
+
+  // Delegation-on-recognition steer (PR #993): recognizing the task includes
+  // recognizing WHO should do it. Heavy/side-effectful execution work belongs
+  // to a subagent (`operator`) so the main conversation stays fast on the
+  // lighter default model, rather than the orchestrator grinding through it
+  // inline. The section names operator and points at the delegation mechanics
+  // rather than restating Mode B/C.
+  test('the default prompt encourages routing heavy execution work to a subagent once the task is recognized', () => {
+    const start = DEFAULT_SYSTEM_PROMPT.indexOf('## Understanding the request')
+    const section = DEFAULT_SYSTEM_PROMPT.slice(start, start + 1600)
+    expect(section).toMatch(/delegat|hand (it )?off|spawn|subagent/i)
+    expect(section).toContain('operator')
+    expect(section).toMatch(
+      /responsive|stay (fast|light)|conversation (fast|responsive|light)|keep.*(fast|responsive)/i,
+    )
+  })
+
+  // Cache-suffix contract: like the other steering blocks, this lives in the
+  // least-volatile base prefix, ahead of the per-agent identity block, so it
+  // never invalidates cached bytes when IDENTITY.md / SOUL.md change. It leads
+  // the execution-discipline run: recognize the task BEFORE finishing it.
+  test('the understanding-the-request steer sits in the base prefix, ahead of finishing-the-job and the identity block', () => {
+    const intentIdx = DEFAULT_SYSTEM_PROMPT.indexOf('## Understanding the request')
+    expect(intentIdx).toBeGreaterThan(-1)
+    expect(intentIdx).toBeLessThan(DEFAULT_SYSTEM_PROMPT.indexOf('## Finishing the job'))
+    expect(intentIdx).toBeLessThan(DEFAULT_SYSTEM_PROMPT.indexOf('You are not pi, not Claude, not ChatGPT.'))
+  })
+})
+
 describe('finishing the job — completion + anti-fabrication steer', () => {
   // Ported from hermes-agent's TASK_COMPLETION_GUIDANCE: deliverable is a
   // working artifact backed by real tool output, and the agent must never

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -48,9 +48,13 @@ If it describes how you sound, use SOUL.md; how you work, AGENTS.md. **Edit disc
 - **\`typeclaw.json\`** — runtime config. Read when needed.
 - **\`secrets.json\`** — canonical gitignored secrets store. \`.env\` is legacy/env override. Never echo, log, or commit either file's values; hand-edit only when explicitly rotating credentials.
 
-## Execution bias
+## Understanding the request
 
-Start work in the same turn when the next action is clear; do not answer with only a plan. For multi-step work, give one short progress update, not narration.
+When the next action is clear, start work in the same turn — don't answer with only a plan, and for multi-step work give one short progress update, not narration.
+
+Read for the practical task behind the wording, not the literal speech act: a status question ("is the build red?") usually wants the answer **and** the obvious next step it implies, and a capability or permission phrasing ("can you add a retry?", "a dark mode would be nice") is almost always a request to **do** the thing, not a yes/no about whether you're able to — this holds in any language, so treat the polite form as the imperative it is. Reading intent well means **fewer** clarifying questions, not more: act on the safe, conventional reading and stay within the apparent request rather than inventing a larger project; ask only when the plausible interpretations would materially change scope, permissions, cost, or risk.
+
+Recognizing the task also means recognizing **who** should do it. When the real work is heavy, side-effectful, long-running, or multi-step — installs, builds, \`docker\`, long test runs, refactors, a bug that resisted a quick fix — prefer to delegate it to a subagent (usually \`operator\`) instead of grinding through it inline; this keeps the conversation responsive and lets you raise the model tier for genuinely hard work. Keep quick, single-shot answers inline. See \`## Subagent orchestration\` for the mechanics.
 
 ## Finishing the job
 
@@ -106,7 +110,6 @@ Commits to your agent folder (your own state):
 - Match the user's register. If SOUL.md specifies a voice, use it; otherwise be concise and direct.
 - Read files/memory before guessing. Follow AGENTS.md under your IDENTITY.md role; suggest AGENTS.md additions for repeatable gaps.
 - Answer questions, do work, and avoid over-explaining unless asked.
-- Ask one clarifying question only when ambiguity would materially change the work; otherwise choose a reasonable default.
 - Never suppress errors to make things "work", and never fabricate results. Report failures clearly.
 
 ## Subagent orchestration


### PR DESCRIPTION
## Why

The base prompt steers **execution discipline** (start in the same turn; deliver a real artifact, never fabricate) but had no upstream steer for **task recognition** — reading the *practical task behind the user's wording* rather than its literal speech act. Two recurring failures followed:

- Answering "yes I can" to a polite imperative ("can you add a retry?", "a dark mode would be nice") instead of just doing it.
- A bare yes/no to a status question ("is the build red?") when the user obviously wants the implied next step (the cause and likely fix).

This is upstream of the existing "choose a reasonable default" rule (which only fires **after** the task is recognized) and "finish the job" (which only helps **once** the job is known). It fixes recognition itself.

Follow-up to #989 (universal completion/anti-fabrication steering) and aligned with #993 (per-spawn model-profile override): both want a lighter, faster default conversation with heavy reasoning delegated — this adds the *recognize-who-should-execute* half of that at the call site.

## What

A new `## Understanding the request` section in `buildDefaultSystemPrompt` (`src/agent/system-prompt.ts`), covering three things:

- **Read the practical task, not the literal speech act.** Treat polite capability/permission phrasing as the imperative it is — **in any language** (TypeClaw is a multilingual chat agent, so this is stated language-agnostically, not as an English phrase list).
- **Intent inference must REDUCE clarifying questions, not add them.** Act on the safe, conventional reading and stay within the apparent request (don't invent a larger project); ask only when interpretations would materially change scope, permissions, cost, or risk.
- **Recognizing the task includes recognizing _who_ should do it.** Delegate heavy / side-effectful / long-running / multi-step work to a subagent (usually `operator`) to keep the conversation responsive and allow a higher model tier for hard work. Mechanics stay in `## Subagent orchestration` — this is a one-line pointer, not a restatement of Mode B/C.

## Consolidation (keeps length flat)

To avoid growing the prompt, this also tightens the surrounding area:

- **Merged** the former standalone `## Execution bias` header into this section as its opening action-bias line (kept first, so the "don't answer with only a plan" steer stays salient).
- **Removed** the duplicate clarifying-question rule from `## How to behave` — `## Understanding the request` is now its single canonical home.

## Cache-suffix contract

The section lives in the **least-volatile base prefix**, ahead of the per-agent identity block (`IDENTITY.md`/`SOUL.md`), so after the first turn it costs **zero extra cached bytes** via prefix caching and doesn't perturb the least-volatile-first ordering the `dump-system-prompt` section-order + token-budget guards enforce. The slim cron/subagent prompt is unchanged.

## Tests (TDD, failing-first)

Added to `src/agent/system-prompt.test.ts`:

- practical-task-not-literal-speech-act, language-agnostic polite-imperative trap, anti-over-clarification (fewer questions), scope bound (no project inflation), delegation steer (names `operator`, points to orchestration).
- structural guards: the `## Execution bias` merge (no separate header; action-bias survives as the opening line) and the `## How to behave` dedupe (clarifying-question rule not duplicated).
- base-prefix placement (ahead of `## Finishing the job` and the identity block).

```
bun run typecheck      # clean
bun run lint           # 0 errors (pre-existing warnings only)
bun run format:check   # clean
bun test --parallel src/agent/system-prompt.test.ts scripts/dump-system-prompt.test.ts src/agent/index.test.ts
# 172 pass / 0 fail
```

Note: the full `bun run test` shows 7 failures in `typeclaw.schema.json` / `cron.schema.json` / `secrets.schema.json` / scaffold drift guards. These are **pre-existing on the base** (verified identical count with this branch's two files reverted) and unrelated to this prompt-only change.