### PR TITLE
feat(agent): escalate thinking on question-mark patterns ("Jeff Bezos detection")

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the recommended local dev loop (`bu
 
 - **Multi-channel** is powered by [agent-messenger](https://github.com/agent-messenger/agent-messenger) — every non-GitHub adapter (`slack-bot`, `discord-bot`, `telegram-bot`, `webex-bot`, `line`, `kakaotalk`) is built on its SDK. Thanks to the maintainers for the credential extraction, listener protocols, and platform coverage that made multi-channel a feature instead of a year-long project.
 - **Subagent architecture** is inspired by [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) by [@code-yeongyu](https://github.com/code-yeongyu). Thanks for the shape that made this clean.
+- **Question-mark attention escalation** ("Jeff Bezos detection") was suggested by [@kdhfred](https://github.com/kdhfred). Thanks for the idea that turned a wall of `?` into a real signal.
 
 ## License
 

--- a/src/agent/attention-escalation.test.ts
+++ b/src/agent/attention-escalation.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from 'bun:test'
 
 import type { ThinkingLevel } from '@mariozechner/pi-agent-core'
 
-import { applyTurnThinkingLevel, detectAttentionEscalation, resolveTurnThinkingLevel } from './attention-escalation'
+import {
+  applyTurnThinkingLevel,
+  detectAttentionEscalation,
+  getQuestionSignal,
+  resolveTurnThinkingLevel,
+} from './attention-escalation'
 
 describe('detectAttentionEscalation — positive (explicit effort)', () => {
   const escalating: readonly string[] = [
@@ -107,6 +112,139 @@ describe('detectAttentionEscalation — negative', () => {
       expect(detectAttentionEscalation(text)).toBe(false)
     })
   }
+})
+
+describe('detectAttentionEscalation — question-only message (mode 1)', () => {
+  const escalating: readonly string[] = ['?', '???', '？？', '？？？', '؟؟؟', '？ ？ ？', '?\n?', '`?`', '? ? ?']
+
+  for (const text of escalating) {
+    test(`detects: ${JSON.stringify(text)}`, () => {
+      expect(detectAttentionEscalation(text)).toBe(true)
+    })
+  }
+
+  const notQuestionOnly: readonly string[] = ['?!', 'what?', 'hmm ...', '!', '. ?']
+
+  for (const text of notQuestionOnly) {
+    test(`ignores: ${JSON.stringify(text)}`, () => {
+      expect(detectAttentionEscalation(text)).toBe(false)
+    })
+  }
+})
+
+describe('detectAttentionEscalation — many questions in one turn (mode 2)', () => {
+  const escalating: readonly string[] = [
+    'are you sure? do you mean this? what about that? how does it work?',
+    '왜 이렇게 했어? 어떻게 고쳐? 이게 맞아?',
+    // zh: "Is this right? Why like this? How to change?"
+    '\u8fd9\u662f\u5bf9\u7684\u5417? \u4e3a\u4ec0\u4e48\u8fd9\u6837? \u600e\u4e48\u6539?',
+    'これで合ってる？ なぜこうした？ どう直す？',
+  ]
+
+  for (const text of escalating) {
+    test(`detects: ${JSON.stringify(text)}`, () => {
+      expect(detectAttentionEscalation(text)).toBe(true)
+    })
+  }
+
+  const notEscalating: readonly string[] = [
+    'is this right?',
+    'is this right? yes it is. moving on now.',
+    'do you think we should refactor this whole module today?',
+  ]
+
+  for (const text of notEscalating) {
+    test(`ignores: ${JSON.stringify(text)}`, () => {
+      expect(detectAttentionEscalation(text)).toBe(false)
+    })
+  }
+})
+
+describe('detectAttentionEscalation — sequential question turns (mode 3)', () => {
+  test('two question-dominant turns in a row escalate', () => {
+    const prior = getQuestionSignal('why did the container crash on startup?')
+    expect(detectAttentionEscalation('how do i actually fix this properly now?', prior)).toBe(true)
+  })
+
+  test('works across scripts (Korean prior + current)', () => {
+    const prior = getQuestionSignal('이 컨테이너는 왜 자꾸 죽는 거야?')
+    expect(detectAttentionEscalation('그럼 어떻게 고쳐야 하는 거야?', prior)).toBe(true)
+  })
+
+  test('no prior signal does not escalate a lone question', () => {
+    expect(detectAttentionEscalation('how do i fix this thing?', null)).toBe(false)
+    expect(detectAttentionEscalation('how do i fix this thing?', undefined)).toBe(false)
+  })
+
+  test('short trailing-? chit-chat on both turns does not escalate', () => {
+    const prior = getQuestionSignal('this?')
+    expect(detectAttentionEscalation('now this?', prior)).toBe(false)
+  })
+
+  test('statement-heavy current turn does not escalate even after a question', () => {
+    const prior = getQuestionSignal('why did the container crash on startup?')
+    expect(detectAttentionEscalation('ok thanks, that makes sense. i will try it now.', prior)).toBe(false)
+  })
+})
+
+describe('getQuestionSignal', () => {
+  test('captures trailing question, count, dominance, and content size', () => {
+    const signal = getQuestionSignal('why did the container crash on startup?')
+    expect(signal.endedWithQuestion).toBe(true)
+    expect(signal.questionSentenceCount).toBe(1)
+    expect(signal.dominant).toBe(true)
+    expect(signal.alnumCount).toBeGreaterThanOrEqual(12)
+  })
+
+  test('statement-dominant turn is not dominant', () => {
+    const signal = getQuestionSignal('here is the plan. step one is done. is that ok?')
+    expect(signal.endedWithQuestion).toBe(true)
+    expect(signal.dominant).toBe(false)
+  })
+
+  test('empty text yields a zero signal', () => {
+    expect(getQuestionSignal('')).toEqual({
+      endedWithQuestion: false,
+      questionSentenceCount: 0,
+      dominant: false,
+      alnumCount: 0,
+    })
+  })
+
+  test('Armenian in-word question mark counts as a question ending', () => {
+    // ՞ (U+055E) sits inside the word `Ի՞նչ`; the sentence ends with `։` (U+0589).
+    const signal = getQuestionSignal('Ի՞նչ եք անում։')
+    expect(signal.questionSentenceCount).toBe(1)
+    expect(signal.endedWithQuestion).toBe(true)
+    expect(signal.dominant).toBe(true)
+    expect(signal.alnumCount).toBeGreaterThan(0)
+  })
+
+  test('Greek ano teleia is a semicolon, not a question mark', () => {
+    // `·` (U+00B7) splits clauses but is the Greek semicolon — not interrogative.
+    const signal = getQuestionSignal('Πρώτο μέρος· δεύτερο μέρος· τρίτο μέρος·')
+    expect(signal.questionSentenceCount).toBe(0)
+    expect(signal.endedWithQuestion).toBe(false)
+  })
+
+  test('Greek question mark (ASCII semicolon) is interrogative', () => {
+    const signal = getQuestionSignal('Τι κάνεις;')
+    expect(signal.questionSentenceCount).toBe(1)
+    expect(signal.endedWithQuestion).toBe(true)
+  })
+})
+
+describe('detectAttentionEscalation — Greek ano teleia is not a question (mode 2)', () => {
+  test('three ano-teleia clauses do not escalate', () => {
+    expect(detectAttentionEscalation('Πρώτο μέρος· δεύτερο μέρος· τρίτο μέρος·')).toBe(false)
+  })
+})
+
+describe('detectAttentionEscalation — Armenian sequential question turns (mode 3)', () => {
+  test('two Armenian question turns in a row escalate', () => {
+    const prior = getQuestionSignal('Ինչու՞ է այս կոնտեյները անընդհատ կանգ առնում։')
+    expect(detectAttentionEscalation('Իսկ ինչպե՞ս եմ ես սա շտկում հիմա։', prior)).toBe(true)
+  })
 })
 
 describe('resolveTurnThinkingLevel', () => {

--- a/src/agent/attention-escalation.ts
+++ b/src/agent/attention-escalation.ts
@@ -554,10 +554,158 @@ const MORPHEME_PATTERNS: readonly RegExp[] = []
 
 const MIN_LENGTH = 2
 
-export function detectAttentionEscalation(text: string): boolean {
-  if (text.length < MIN_LENGTH) return false
+// "Jeff Bezos detection": a message that is dense with question marks is a
+// human pressing for a real answer (Bezos was famous for replying to internal
+// mail with a single "?"). We treat three question-shaped patterns as the same
+// budget hint the phrase tables emit — care, not a command. Idea from
+// GitHub @kdhfred.
+//
+// Question punctuation is multilingual: ASCII `?`, fullwidth `？` (U+FF1F),
+// Arabic `؟` (U+061F), and Armenian `՞` (U+055E). The Greek question mark is the
+// ASCII `;`, and `·` (U+00B7) is the Greek ano teleia — both are ambiguous with
+// ordinary punctuation in Latin text, so they only count as question marks when
+// the same message actually contains Greek letters.
+const QUESTION_PUNCT_RE = /[?？\u061F\u055E]/u
+// The Greek question mark is the ASCII semicolon `;` (and its canonical
+// equivalent U+037E). The ano teleia `·` (U+00B7) is the Greek SEMICOLON, not a
+// question mark, so it splits sentences but must never count as a question.
+const GREEK_QUESTION_PUNCT_RE = /[;\u037E]/u
+const GREEK_LETTER_RE = /\p{Script=Greek}/u
+// Armenian writes its question mark `՞` (U+055E) INSIDE the questioned word
+// (e.g. `Ի՞նչ եք անում։`), not as a terminal mark — so it must not split a
+// sentence. We detect it on the chunk body instead, and let the Armenian full
+// stop `։` (U+0589, distinct from ASCII `:`) terminate the sentence.
+const ARMENIAN_INLINE_QUESTION_RE = /\u055E/u
+// `\b` is ASCII-only and meaningless for CJK/Arabic/Hindi, so we count Unicode
+// letters and numbers directly instead of tokenizing on word boundaries.
+const ALNUM_RE = /[\p{L}\p{N}]/gu
+// Terminal punctuation that ends a sentence-like chunk, across scripts.
+const TERMINATOR_SPLIT_RE = /([.!?？\u061F;·。！？\u0589]+)/u
+
+function hasGreek(text: string): boolean {
+  return GREEK_LETTER_RE.test(text)
+}
+
+function isQuestionRun(run: string, greek: boolean): boolean {
+  if (QUESTION_PUNCT_RE.test(run)) return true
+  return greek && GREEK_QUESTION_PUNCT_RE.test(run)
+}
+
+function isQuestionSentence(body: string, terminator: string, greek: boolean): boolean {
+  return isQuestionRun(terminator, greek) || ARMENIAN_INLINE_QUESTION_RE.test(body)
+}
+
+function isQuestionOrSpace(char: string, greek: boolean): boolean {
+  if (/\s/u.test(char)) return true
+  if (QUESTION_PUNCT_RE.test(char)) return true
+  return greek && GREEK_QUESTION_PUNCT_RE.test(char)
+}
+
+function countAlnum(text: string): number {
+  const matches = text.match(ALNUM_RE)
+  return matches === null ? 0 : matches.length
+}
+
+// Mode 1: the whole message is nothing but question marks (and whitespace) —
+// `?`, `???`, `？？`, `؟؟؟`. A trailing `?` on a real sentence, or `?!`, must NOT
+// match here; those are handled (if at all) by the other modes.
+function isQuestionOnlyMessage(normalized: string): boolean {
+  if (normalized.length === 0) return false
+  const greek = hasGreek(normalized)
+  let sawQuestion = false
+  for (const char of normalized) {
+    if (QUESTION_PUNCT_RE.test(char) || (greek && GREEK_QUESTION_PUNCT_RE.test(char))) {
+      sawQuestion = true
+      continue
+    }
+    if (!isQuestionOrSpace(char, greek)) return false
+  }
+  return sawQuestion
+}
+
+type Sentence = { text: string; isQuestion: boolean }
+
+function splitSentences(normalized: string): Sentence[] {
+  const greek = hasGreek(normalized)
+  const parts = normalized.split(TERMINATOR_SPLIT_RE)
+  const sentences: Sentence[] = []
+  for (let i = 0; i < parts.length; i += 2) {
+    const body = parts[i] ?? ''
+    const terminator = parts[i + 1] ?? ''
+    const trimmed = body.trim()
+    if (trimmed.length === 0 && terminator.length === 0) continue
+    if (trimmed.length === 0) continue
+    sentences.push({ text: trimmed, isQuestion: isQuestionSentence(trimmed, terminator, greek) })
+  }
+  return sentences
+}
+
+// Mode 2: a single turn packed with separate questions — "are you …? do you …?
+// what …? how …?". Require 3+ genuine question sentences, each with enough
+// content (>= 3 letters/numbers) so a bare "? ? ?" stays a mode-1 case only.
+const MODE2_MIN_QUESTIONS = 3
+const SENTENCE_MIN_ALNUM = 3
+
+function countContentfulQuestions(sentences: readonly Sentence[]): number {
+  let count = 0
+  for (const sentence of sentences) {
+    if (sentence.isQuestion && countAlnum(sentence.text) >= SENTENCE_MIN_ALNUM) count++
+  }
+  return count
+}
+
+export type QuestionSignal = {
+  endedWithQuestion: boolean
+  questionSentenceCount: number
+  // True when the turn is mostly questions (>= 60% of its sentences), so a
+  // single trailing "?" on an otherwise statement-heavy message is not "dominant".
+  dominant: boolean
+  alnumCount: number
+}
+
+export function getQuestionSignal(text: string): QuestionSignal {
   const normalized = normalize(text)
+  if (normalized.length === 0) {
+    return { endedWithQuestion: false, questionSentenceCount: 0, dominant: false, alnumCount: 0 }
+  }
+  const sentences = splitSentences(normalized)
+  const questionSentenceCount = sentences.reduce((acc, s) => acc + (s.isQuestion ? 1 : 0), 0)
+  const sentenceCount = Math.max(sentences.length, 1)
+  return {
+    endedWithQuestion: sentences.at(-1)?.isQuestion ?? false,
+    questionSentenceCount,
+    dominant: questionSentenceCount >= 1 && questionSentenceCount >= Math.ceil(sentenceCount * 0.6),
+    alnumCount: countAlnum(normalized),
+  }
+}
+
+// Mode 3: the user is interrogating across turns — a question-dominant turn
+// following another question-dominant turn (prev "why …?", current "how …?").
+// A single trailing "?" on consecutive turns is far too common in normal chat,
+// so both turns must be dominant, both must end on a question mark, and both
+// must carry real content (>= 12 letters/numbers) to clear the noise floor.
+const MODE3_MIN_ALNUM = 12
+
+function isSequentialQuestionEscalation(current: QuestionSignal, prior: QuestionSignal | null | undefined): boolean {
+  return Boolean(
+    prior?.dominant &&
+    current.dominant &&
+    prior.endedWithQuestion &&
+    current.endedWithQuestion &&
+    prior.alnumCount >= MODE3_MIN_ALNUM &&
+    current.alnumCount >= MODE3_MIN_ALNUM,
+  )
+}
+
+export function detectAttentionEscalation(text: string, prior?: QuestionSignal | null): boolean {
+  const normalized = normalize(text)
+  // Mode 1 deliberately bypasses MIN_LENGTH: a lone "?" is shorter than the
+  // phrase-table floor but is itself the signal.
+  if (isQuestionOnlyMessage(normalized)) return true
   if (normalized.length < MIN_LENGTH) return false
+  const sentences = splitSentences(normalized)
+  if (countContentfulQuestions(sentences) >= MODE2_MIN_QUESTIONS) return true
+  if (isSequentialQuestionEscalation(getQuestionSignal(text), prior)) return true
   if (ALL_PHRASES.some((phrase) => normalized.includes(phrase))) return true
   return MORPHEME_PATTERNS.some((pattern) => pattern.test(normalized))
 }
@@ -570,8 +718,9 @@ const ESCALATED_LEVEL: ThinkingLevel = 'xhigh'
 export function resolveTurnThinkingLevel(
   text: string,
   sessionDefault: ThinkingLevel | undefined,
+  prior?: QuestionSignal | null,
 ): ThinkingLevel | undefined {
-  return detectAttentionEscalation(text) ? ESCALATED_LEVEL : sessionDefault
+  return detectAttentionEscalation(text, prior) ? ESCALATED_LEVEL : sessionDefault
 }
 
 type ThinkingLevelSettable = {
@@ -585,7 +734,8 @@ export function applyTurnThinkingLevel(
   session: ThinkingLevelSettable,
   text: string,
   sessionDefault: ThinkingLevel | undefined,
+  prior?: QuestionSignal | null,
 ): void {
-  const resolved = resolveTurnThinkingLevel(text, sessionDefault)
+  const resolved = resolveTurnThinkingLevel(text, sessionDefault, prior)
   if (resolved !== undefined) session.setThinkingLevel(resolved)
 }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -67,6 +67,10 @@ class FakeSession {
   public prompts: string[] = []
   public aborted = 0
   public disposed = 0
+  public thinkingLevels: string[] = []
+  setThinkingLevel = (level: string): void => {
+    this.thinkingLevels.push(level)
+  }
   public leafEntry: SessionEntry | undefined
   // Additional entries indexed by id for `getEntry` lookups. Walked by
   // `recoverableAssistantText` when the leaf is a toolResult and we need to
@@ -3936,6 +3940,210 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent.some((s) => s.text === EMPTY_TURN_FALLBACK_TEXT)).toBe(false)
     expect(logs.some((m) => m.includes('empty_turn_retry attempt=1'))).toBe(true)
     expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+  })
+
+  test('cross-turn escalation: a length-retried non-question turn overwrites the prior question signal', async () => {
+    // given: turn A is a question (seeds the prior signal); turn B is a
+    // NON-question that length-truncates then recovers on retry; turn C is a
+    // question. The completed logical turn B must commit its own (non-question)
+    // signal, so C sees a non-question predecessor and must NOT mode-3 escalate.
+    // Before the pending-commit fix, B's truncated attempt never committed and
+    // A's question signal leaked across B, wrongly escalating C.
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn A — a real question, completes cleanly
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('A')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'because of X' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // turn B — a non-question that truncates (length) then replies on retry
+    let bAttempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      bAttempt++
+      if (bAttempt === 1) {
+        sessions[0]!.setAssistantMidTurn('thought-loop output that must not be posted', 'length')
+        return
+      }
+      expect(text).toContain(EMPTY_TURN_RETRY_NUDGE)
+      sessions[0]!.setAssistantText('B')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'please apply that fix to the staging cluster now.' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn C — a real question; predecessor is B (non-question) → no escalation
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('C')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'sure' })
+    }
+    await router.route(inbound({ text: 'and how do i roll it back if it breaks again?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn C did not escalate (no xhigh) — B overwrote A's question signal.
+    expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
+  })
+
+  test('cross-turn escalation: a provider-error question turn does not seed the next turn', async () => {
+    // given: turn A is a question whose leaf is a provider `error` (diverted to
+    // the error notice, no retry queued); turn B is a question. The failed turn A
+    // must not commit its question signal, so B has no question predecessor and
+    // must NOT mode-3 escalate.
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn A — a question that ends on a provider error
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantMessage({
+        role: 'assistant',
+        content: [],
+        stopReason: 'error',
+        errorMessage: 'transient upstream blip',
+      } as unknown as Parameters<FakeSession['setAssistantMessage']>[0])
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn B — a question; predecessor A failed, so no escalation
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('B')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'and how do i actually fix it properly now?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn B did not escalate — A's failed question signal was dropped.
+    expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
+  })
+
+  test('cross-turn escalation: a retry-exhausted fallback question turn does not seed the next turn', async () => {
+    // given: turn A is a question that length-truncates on every attempt until
+    // retries are exhausted and the fallback is posted (no usable reply); turn B
+    // is a question. The fallback turn must not commit A's question signal, so B
+    // has no question predecessor and must NOT mode-3 escalate.
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn A — a question that always truncates → retries exhausted → fallback
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantMidTurn('never-ending loop output', 'length')
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn B — a question; predecessor A only produced a fallback → no escalation
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('B')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'and how do i actually fix it properly now?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn B did not escalate — A's fallback turn never seeded the signal.
+    expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
+  })
+
+  test('cross-turn escalation: a NO_REPLY question turn does not seed the next turn', async () => {
+    // given: turn A is a question the agent deliberately stays silent on
+    // (NO_REPLY — a completed but non-usable turn); turn B is a question. A
+    // silent turn produced no usable reply, so it must not seed escalation.
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn A — a question the agent answers with NO_REPLY (no send)
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn B — a question; predecessor A was silent → no escalation
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('B')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'and how do i actually fix it properly now?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn B did not escalate — a NO_REPLY turn does not seed the signal.
+    expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
+  })
+
+  test('cross-turn escalation: a failed middle turn clears a previously seeded question signal', async () => {
+    // given: clean question A seeds the prior signal; failed question B (provider
+    // error) sits between; question C follows. C must NOT escalate from A — the
+    // failed turn B must CLEAR the prior signal, not merely skip committing, so a
+    // stale question cannot leak across the failed logical turn.
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn A — a question, clean reply (seeds the signal)
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('A')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'because of X' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // turn B — a question that fails with a provider error (clears the signal)
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantMessage({
+        role: 'assistant',
+        content: [],
+        stopReason: 'error',
+        errorMessage: 'transient upstream blip',
+      } as unknown as Parameters<FakeSession['setAssistantMessage']>[0])
+    }
+    await router.route(inbound({ text: 'is the rollback even possible right now?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn C — a question; A's signal was cleared by B, so no escalation
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('C')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'sure' })
+    }
+    await router.route(inbound({ text: 'and how do i actually fix it properly now?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn C did not escalate — B cleared A's signal (no stale leak).
+    expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
   })
 
   test('empty-turn guard: pure reasoning-loop posts the fallback after retries are exhausted', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5,7 +5,7 @@ import type { AssistantMessage } from '@mariozechner/pi-ai'
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSession } from '@/agent'
-import { applyTurnThinkingLevel } from '@/agent/attention-escalation'
+import { applyTurnThinkingLevel, getQuestionSignal, type QuestionSignal } from '@/agent/attention-escalation'
 import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
 import { subscribeProviderErrors } from '@/agent/provider-error'
 import type { RestartHandoff } from '@/agent/restart-handoff'
@@ -578,6 +578,16 @@ type LiveSession = {
   // turn moves `session.thinkingLevel` to `high`, so the live getter can't be the
   // reset target — this preserves the real default across the session's lifetime.
   turnThinkingDefault: AgentSession['thinkingLevel']
+  // Last COMPLETED real user turn's question shape, for cross-turn "Jeff Bezos"
+  // escalation. Read by the next turn; committed from pendingUserTurnSignal only
+  // when a logical turn finishes (no empty-turn retry queued).
+  lastQuestionSignal: QuestionSignal | null
+  // A real user turn's question shape captured at turn start but not yet
+  // committed: a `length`/`aborted` truncation spans the original batch plus
+  // reminder-only retry iterations, so the signal commits to lastQuestionSignal
+  // only when that whole logical turn completes (success or fallback), never
+  // from the truncated attempt and never leaving stale state across the turn.
+  pendingUserTurnSignal: { signal: QuestionSignal } | null
   sessionId: string
   dispose: () => Promise<void>
   hooks: HookBus | undefined
@@ -788,6 +798,12 @@ type LiveSession = {
   // shape as the skip lock. `null` when no disengage has been recorded.
   // Compared by `turnSeq` so a stale value can't leak across turns.
   disengagedTurn: number | null
+  // Stamped with the current `turnSeq` when validateChannelTurn posts the
+  // empty-turn fallback (retry exhaustion). Read by the cross-turn signal commit
+  // so a fallback turn — which produced no usable assistant reply — does not seed
+  // question escalation. Compared by `turnSeq` so a stale value can't leak across
+  // turns.
+  emptyTurnFallbackTurn: number | null
   // Captured by drain() at batch dequeue; read+cleared by send() on the
   // first tool-source send of the turn. The anchor decision (delay
   // threshold + intervening-observed check) is evaluated at SEND time
@@ -1665,6 +1681,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         keyId,
         session: created.session,
         turnThinkingDefault: created.session.thinkingLevel,
+        lastQuestionSignal: null,
+        pendingUserTurnSignal: null,
         sessionId: created.sessionId,
         dispose: created.dispose,
         hooks: created.hooks,
@@ -1722,6 +1740,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         skippedTurn: null,
         skipLockedSendTurn: null,
         disengagedTurn: null,
+        emptyTurnFallbackTurn: null,
         pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
@@ -2398,24 +2417,57 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
         live.skipLockedSendTurn = null
         live.disengagedTurn = null
+        live.emptyTurnFallbackTurn = null
         live.policyDeniedToolSendsThisTurn.clear()
         resetReviewTurn(live.sessionId)
         const isRealUserTurn = batch.length > 0
         const retrievalQuery = composeRetrievalQuery(batch)
+        // A fresh real-user batch opens a new logical turn. Capture its question
+        // shape as PENDING (committed only once the turn completes below). The
+        // drain is serial and retries are reminder-only, so a prior pending must
+        // already be resolved; a leftover here means a logical turn never
+        // completed — fail closed by discarding it rather than misattributing.
+        if (isRealUserTurn) {
+          live.pendingUserTurnSignal = { signal: getQuestionSignal(retrievalQuery) }
+        }
         const retrievalContext = await fireSessionTurnStart(live, retrievalQuery)
         const promptText = retrievalContext.results.length > 0 ? `${text}\n\n${retrievalContext.results}` : text
-        applyTurnThinkingLevel(live.session, retrievalQuery, live.turnThinkingDefault)
+        applyTurnThinkingLevel(live.session, retrievalQuery, live.turnThinkingDefault, live.lastQuestionSignal)
         live.promptInFlight = true
         try {
           await live.session.prompt(promptText)
           await validateChannelTurn(live, successfulSendsBeforePrompt)
           live.consecutiveAborts = 0
+          // Resolve the pending logical-turn signal on a binary rule: ONLY a
+          // usable assistant reply (real model prose the user saw) seeds the next
+          // turn's escalation. Every other terminal outcome CLEARS lastQuestionSignal
+          // so an older question can't leak across the failed/silent turn:
+          //   - retry queued (`length`/`aborted`, budget left): turn still in
+          //     flight → leave both for the reminder-only iteration that ends it.
+          //   - usable reply → commit the pending signal.
+          //   - provider error / empty-turn fallback / NO_REPLY / skip (no usable
+          //     reply) → clear BOTH (pending and lastQuestionSignal).
+          // A fallback sends via source:'system', which also bumps
+          // successfulChannelSends, so it must be excluded explicitly.
+          const retryQueuedThisTurn = live.emptyTurnRetries > emptyTurnRetriesBeforePrompt
+          const providerErrorThisTurn = assistantLeafStopReason(live.session) === 'error'
+          const fallbackPostedThisTurn = live.emptyTurnFallbackTurn === live.turnSeq
+          const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
+          const usableReplyThisTurn = sentReplyThisTurn && !fallbackPostedThisTurn && !providerErrorThisTurn
+          if (live.pendingUserTurnSignal !== null && !retryQueuedThisTurn) {
+            live.lastQuestionSignal = usableReplyThisTurn ? live.pendingUserTurnSignal.signal : null
+            live.pendingUserTurnSignal = null
+          }
           logger.info(`[channels] ${live.keyId} prompted elapsed_ms=${now() - promptStart}`)
         } catch (err) {
           logger.error(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
           live.consecutiveSends.clear()
           live.lastSentText.clear()
           live.lastSendLeafId = null
+          // A thrown prompt is a non-usable terminal outcome: drop pending AND
+          // clear the prior signal so an older question can't leak across it.
+          live.pendingUserTurnSignal = null
+          live.lastQuestionSignal = null
         } finally {
           live.promptInFlight = false
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
@@ -3533,6 +3585,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
     const postEmptyTurnFallback = async (cause: string): Promise<void> => {
       logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)
+      live.emptyTurnFallbackTurn = live.turnSeq
       const result = await send(
         {
           adapter: live.key.adapter,

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -114,6 +114,9 @@ function createFakeSession(): AgentSession & {
       pendingPromptResolve = null
       pendingPromptReject = null
     },
+    sessionManager: {
+      getLeafEntry: () => undefined,
+    },
     abortCalls: 0,
     disposeCalls: 0,
     promptCalls: [] as string[],
@@ -513,6 +516,44 @@ describe('createServer abort handling (no stream — fallback path)', () => {
     await waitFor((m) => m.type === 'done')
 
     expect(thinkingCalls).toEqual(['xhigh', 'low'])
+    ws.close()
+  })
+
+  test('an aborted question turn does not seed cross-turn escalation', async () => {
+    // given: turn 1 is a question that aborts; turn 2 is also a question. Mode-3
+    // escalation must NOT fire on turn 2, because the aborted turn never produced
+    // a usable assistant turn and must not poison the prior-signal state.
+    const session = createFakeSession()
+    const thinkingCalls: string[] = []
+    let currentLevel: string | undefined
+    let leafStop: string | undefined
+    Object.defineProperty(session, 'thinkingLevel', { get: () => currentLevel, configurable: true })
+    ;(session as unknown as { setThinkingLevel: (l: string) => void }).setThinkingLevel = (level) => {
+      thinkingCalls.push(level)
+      currentLevel = level
+    }
+    ;(session.sessionManager as unknown as { getLeafEntry: () => unknown }).getLeafEntry = () =>
+      leafStop === undefined ? undefined : { type: 'message', message: { role: 'assistant', stopReason: leafStop } }
+
+    const { url } = await startWithSession(session)
+    const { ws, waitFor } = await connect(url)
+    await waitFor((m) => m.type === 'connected')
+
+    leafStop = 'aborted'
+    ws.send(JSON.stringify({ type: 'prompt', text: 'why did the container crash on startup?' }))
+    await waitForState(() => session.promptCalls.length === 1)
+    session.resolvePrompt()
+    await waitFor((m) => m.type === 'done')
+
+    leafStop = 'stop'
+    ws.send(JSON.stringify({ type: 'prompt', text: 'how do i actually fix this properly now?' }))
+    await waitForState(() => session.promptCalls.length === 2)
+    session.resolvePrompt()
+    await waitFor((m) => m.type === 'done')
+
+    // then: neither turn escalates — turn 1's question signal was never stored,
+    // so turn 2's lone question has no question-dominant predecessor.
+    expect(thinkingCalls).toEqual([])
     ws.close()
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,7 +8,7 @@ import {
   type CreateSessionOptions,
   type CreateSessionResult,
 } from '@/agent'
-import { applyTurnThinkingLevel } from '@/agent/attention-escalation'
+import { applyTurnThinkingLevel, getQuestionSignal, type QuestionSignal } from '@/agent/attention-escalation'
 import { runPluginDoctorChecks, runPluginDoctorFix } from '@/agent/doctor'
 import type { LiveSessionRegistry } from '@/agent/live-sessions'
 import type { LiveSubagentRegistry } from '@/agent/live-subagents'
@@ -165,6 +165,14 @@ type TunnelLogsWs = ServerWebSocket<TunnelLogsWsData>
 type InspectWs = ServerWebSocket<InspectWsData>
 type AnyOwnerWs = Ws | CommandWs
 
+// A turn whose assistant leaf aborted or errored never produced a usable turn,
+// so its question shape must not seed the next turn's cross-turn escalation.
+function tuiTurnLeafFailed(session: AgentSession): boolean {
+  const leaf = session.sessionManager?.getLeafEntry()
+  if (!leaf || leaf.type !== 'message' || leaf.message.role !== 'assistant') return false
+  return leaf.message.stopReason === 'aborted' || leaf.message.stopReason === 'error'
+}
+
 type QueuedPrompt = {
   streamMessageId: StreamMessageId
   text: string
@@ -180,6 +188,9 @@ type SessionState = {
   // loop, no-stream fallback) can use the live getter as the reset target — both
   // read this captured default instead.
   turnThinkingDefault: AgentSession['thinkingLevel']
+  // Prior real user turn's question shape, for cross-turn "Jeff Bezos" escalation.
+  // Null until the first user turn; carried turn-to-turn within this session only.
+  lastQuestionSignal: QuestionSignal | null
   sessionFileId: string
   origin: SessionOrigin
   sessionManager: { getSessionFile: () => string | undefined } | undefined
@@ -525,6 +536,7 @@ export function createServer({
             const state: SessionState = {
               session,
               turnThinkingDefault: session.thinkingLevel,
+              lastQuestionSignal: null,
               sessionFileId,
               origin,
               sessionManager,
@@ -789,8 +801,12 @@ export function createServer({
                 retrievalContext.results.length > 0
                   ? `${renderTurnTimeAnchor()}\n\n${msg.text}\n\n${retrievalContext.results}`
                   : `${renderTurnTimeAnchor()}\n\n${msg.text}`
-              applyTurnThinkingLevel(state.session, msg.text, state.turnThinkingDefault)
+              applyTurnThinkingLevel(state.session, msg.text, state.turnThinkingDefault, state.lastQuestionSignal)
               await state.session.prompt(turnText)
+              // A usable turn seeds the next turn's escalation; a failed leaf must
+              // CLEAR the prior signal (not just skip), else an older question
+              // leaks across the failed turn and wrongly escalates the next one.
+              state.lastQuestionSignal = tuiTurnLeafFailed(state.session) ? null : getQuestionSignal(msg.text)
               send(ws, doneMessage(state))
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err)
@@ -1094,8 +1110,14 @@ async function drain(
           retrievalContext.results.length > 0
             ? `${renderTurnTimeAnchor()}\n\n${item.text}\n\n${retrievalContext.results}`
             : `${renderTurnTimeAnchor()}\n\n${item.text}`
-        applyTurnThinkingLevel(state.session, item.text, state.turnThinkingDefault)
+        applyTurnThinkingLevel(state.session, item.text, state.turnThinkingDefault, state.lastQuestionSignal)
         await state.session.prompt(turnText)
+        // Only real user turns move the signal: a usable turn seeds it, a failed
+        // leaf CLEARS it (else an older question leaks across the failed turn).
+        // Todo-continuation turns are not user turns, so they leave it untouched.
+        if (item.source !== TODO_CONTINUATION_SOURCE) {
+          state.lastQuestionSignal = tuiTurnLeafFailed(state.session) ? null : getQuestionSignal(item.text)
+        }
         send(ws, doneMessage(state))
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Background

We already escalate a turn's thinking level to `xhigh` when the user's message hits the keyword phrase tables (explicit "think harder", frustration/profanity across 15 languages). But there's a whole class of "I'm pressing you for a real answer" signal those tables miss: question marks. Jeff Bezos is famous for forwarding a problem with nothing but a `?` and expecting a serious response. A wall of `?`, a barrage of questions in one breath, or a back-and-forth of pointed questions are all the same human hint — *think harder about this* — and we were treating them as ordinary turns.

This fills that gap by teaching `attention-escalation` to read question shape, not just keywords.

## Summary

Three new detection modes, all feeding the **same** `xhigh` bump the phrase tables already emit (this is a budget hint, not a new control surface):

1. **Question-only message** — `?`, `???`, `？？`, `؟؟؟`. Deliberately bypasses the `MIN_LENGTH` floor, because a lone `?` *is* the signal.
2. **Many questions in one turn** — 3+ contentful question sentences ("are you …? do you …? what …? how …?"). Each question must carry ≥3 letters/numbers so a bare `? ? ?` stays a mode-1 case and doesn't double-count.
3. **Sequential question turns** — a question-dominant turn following another question-dominant turn (prev "why …?", current "how …?").

**Why mode 3 is gated hard:** a single trailing `?` on two consecutive turns is *extremely* common in normal chat ("does this look right?" → "ok now this?"). To keep signal high, mode 3 fires only when **both** turns are question-dominant (≥60% of sentences are questions), **both** end on a question mark, and **both** carry ≥12 letters/numbers of real content. This filters the chit-chat case while still catching genuine interrogation.

**Why multilingual, and how:** TypeClaw reads every script, so question detection covers ASCII `?`, fullwidth `？`, Arabic `؟`, and Armenian `՞`. The Greek question mark is an ASCII `; ` (and `·` is the ano teleia) — both ambiguous in Latin text — so they only count as questions when the message actually contains Greek letters. Content is counted with `\p{L}\p{N}` rather than `\b`, since `\b` is ASCII-only and meaningless for CJK/Arabic/Hindi (per the repo's multi-language rules).

**Why a compact signal, not raw text:** mode 3 needs prior-turn context. `getQuestionSignal` returns a small `QuestionSignal` (4 fields) that the TUI and channel turn drivers stash per-session as `lastQuestionSignal` and pass back into `applyTurnThinkingLevel`. Storing the shape instead of the raw user text avoids holding onto message content across turns.

## What this does NOT do

- Does not add a new thinking level — reuses the existing `xhigh` clamp (downgrades to `high` on non-OpenAI models, unchanged).
- Does not change cron / subagent / command-runner behavior — they pass no prior signal and are unaffected by mode 3.
- Does not persist `lastQuestionSignal` across restarts — it's in-memory, session-scoped, and only updated on **real** user turns (never todo-continuation or observe-only channel turns), so synthetic text can't poison the cross-turn signal.
- Does not touch the keyword phrase tables.

## Review notes

- Load-bearing logic is `detectAttentionEscalation` / `getQuestionSignal` in `src/agent/attention-escalation.ts`. The `prior` param is threaded but optional, so the 3 stateless call sites are unchanged.
- The two stateful call sites are the TUI drain (`src/server/index.ts`, both the stream-drain and no-stream-fallback paths) and the channel drain (`src/channels/router.ts`). Verify the invariant: `lastQuestionSignal` is read *before* the prompt and written *after*, and only on real user turns.
- Tests cover all three modes with non-Latin input (Korean, CJK, Japanese) per the repo's multilingual test requirement, plus the negative cases (single `?`, statement-heavy turns, short chit-chat).

## Acknowledgments

Idea from [@kdhfred](https://github.com/kdhfred) — thanks for the nudge that turned a wall of `?` into a real signal.