### PR TITLE
fix(channels): register a KakaoTalk membership resolver

### DIFF
--- a/src/channels/adapters/kakaotalk-membership.test.ts
+++ b/src/channels/adapters/kakaotalk-membership.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { KakaoMember } from 'agent-messenger/kakaotalk'
+
+import type { ChannelKey } from '@/channels/types'
+
+import { createKakaoMembershipResolver } from './kakaotalk-membership'
+
+const member = (user_id: string): KakaoMember => ({
+  user_id,
+  nickname: `name-${user_id}`,
+  profile_image_url: null,
+  full_profile_image_url: null,
+  original_profile_image_url: null,
+  status_message: null,
+  country_iso: null,
+  user_type: 100,
+  open_token: null,
+  open_profile_link_id: null,
+  open_permission: null,
+})
+
+const groupKey: ChannelKey = { adapter: 'kakaotalk', workspace: '@kakao-group', chat: 'chat-1', thread: null }
+
+const logger = () => ({ warn: () => {} })
+
+describe('createKakaoMembershipResolver', () => {
+  test('counts every roster member except the agent as a human', async () => {
+    // given: a group of the agent (self) plus three humans
+    const resolver = createKakaoMembershipResolver({
+      client: { getMembers: async () => [member('self'), member('m1'), member('m2'), member('m3')] },
+      selfUserIdRef: () => 'self',
+      logger: logger(),
+      now: () => 123,
+    })
+
+    // when
+    const result = await resolver(groupKey)
+
+    // then: self is excluded; the group reports >1 human so engagement stays strict
+    expect(result).toEqual({
+      humans: 3,
+      bots: 1,
+      fetchedAt: 123,
+      truncated: false,
+      humanMemberIds: ['m1', 'm2', 'm3'],
+    })
+  })
+
+  test('a real group never collapses to the solo-human fallback (regression)', async () => {
+    // given: the incident shape — a multi-member group where only one human
+    // has posted; the roster must still report >1 human
+    const resolver = createKakaoMembershipResolver({
+      client: { getMembers: async () => [member('self'), member('mom'), member('son')] },
+      selfUserIdRef: () => 'self',
+      logger: logger(),
+      now: () => 0,
+    })
+
+    const result = await resolver(groupKey)
+
+    expect(result).not.toHaveProperty('kind')
+    if ('humans' in result) expect(result.humans).toBeGreaterThan(1)
+  })
+
+  test('dedupes members listed by both GETMEM and CHATONROOM', async () => {
+    const resolver = createKakaoMembershipResolver({
+      client: { getMembers: async () => [member('self'), member('m1'), member('m1'), member('m2')] },
+      selfUserIdRef: () => 'self',
+      logger: logger(),
+      now: () => 5,
+    })
+
+    const result = await resolver(groupKey)
+
+    expect(result).toEqual({
+      humans: 2,
+      bots: 1,
+      fetchedAt: 5,
+      truncated: false,
+      humanMemberIds: ['m1', 'm2'],
+    })
+  })
+
+  test('reports a 1:1 chat as exactly one human (self excluded)', async () => {
+    const resolver = createKakaoMembershipResolver({
+      client: { getMembers: async () => [member('self'), member('peer')] },
+      selfUserIdRef: () => 'self',
+      logger: logger(),
+      now: () => 1,
+    })
+
+    expect(await resolver(groupKey)).toEqual({
+      humans: 1,
+      bots: 1,
+      fetchedAt: 1,
+      truncated: false,
+      humanMemberIds: ['peer'],
+    })
+  })
+
+  test('fails transient before login resolves a self id', async () => {
+    let called = false
+    const resolver = createKakaoMembershipResolver({
+      client: {
+        getMembers: async () => {
+          called = true
+          return []
+        },
+      },
+      selfUserIdRef: () => null,
+      logger: logger(),
+    })
+
+    expect(await resolver(groupKey)).toEqual({ kind: 'transient' })
+    expect(called).toBe(false)
+  })
+
+  test('fails transient when the roster fetch throws', async () => {
+    const resolver = createKakaoMembershipResolver({
+      client: {
+        getMembers: async () => {
+          throw new Error('GETMEM failed')
+        },
+      },
+      selfUserIdRef: () => 'self',
+      logger: logger(),
+    })
+
+    expect(await resolver(groupKey)).toEqual({ kind: 'transient' })
+  })
+
+  test('rejects a non-kakaotalk key as a permanent failure', async () => {
+    const resolver = createKakaoMembershipResolver({
+      client: { getMembers: async () => [] },
+      selfUserIdRef: () => 'self',
+      logger: logger(),
+    })
+
+    expect(await resolver({ adapter: 'discord-bot', workspace: 'w', chat: 'c', thread: null })).toEqual({
+      kind: 'permanent',
+    })
+  })
+})

--- a/src/channels/adapters/kakaotalk-membership.ts
+++ b/src/channels/adapters/kakaotalk-membership.ts
@@ -1,0 +1,67 @@
+import type {
+  MembershipCount,
+  MembershipResolver,
+  MembershipResolverFailure,
+  MembershipResolverResult,
+} from '../membership'
+import type { KakaoTalkClient } from './kakaotalk'
+
+export type KakaoMembershipResolverOptions = {
+  client: Pick<KakaoTalkClient, 'getMembers'>
+  // The logged-in agent's own KakaoTalk user_id. Returned by `getMembers`
+  // alongside every human in the room, so it must be excluded from the
+  // human count — otherwise a 1:1 chat (agent + one human) reports two
+  // humans and a real group is off by one. Null before login completes,
+  // in which case we cannot prove self-exclusion and fail closed.
+  selfUserIdRef: () => string | null
+  logger: { warn: (msg: string) => void }
+  now?: () => number
+}
+
+// Without a registered resolver the router's `resolveEffectiveHumans` falls
+// back to `persistedHumans` — only humans who already posted in the live
+// session. On a cold-started group that is just the sender, tripping the
+// engagement layer's solo-human "answer everything" fallback so the agent
+// replies to messages aimed at others. Every other adapter registers a
+// resolver; KakaoTalk was the lone gap. `getMembers` returns the COMPLETE
+// active roster (agent-messenger merges the GETMEM subset with the CHATONROOM
+// full list), so unlike Telegram's opaque count we report it as non-truncated.
+// Room rosters list only human accounts plus the agent's own; hence
+// `humans = roster excluding self` and `bots: 1` (the agent) — `bots: 0` would
+// defeat the engagement layer's peer-bot loop suppression.
+export function createKakaoMembershipResolver(options: KakaoMembershipResolverOptions): MembershipResolver {
+  const now = options.now ?? Date.now
+  return async (key): Promise<MembershipResolverResult> => {
+    if (key.adapter !== 'kakaotalk') return { kind: 'permanent' } satisfies MembershipResolverFailure
+    const selfUserId = options.selfUserIdRef()
+    if (selfUserId === null) {
+      // Pre-login: we cannot exclude ourselves from the roster, so any count
+      // would over-report humans by one. Fail transient so the router keeps
+      // its `persistedHumans` fallback and retries once we have identity.
+      return { kind: 'transient' } satisfies MembershipResolverFailure
+    }
+    try {
+      const members = await options.client.getMembers(key.chat)
+      // Dedupe by user_id — a merged GETMEM+CHATONROOM roster can list the
+      // same member twice when both sources carry them.
+      const memberIds = new Set<string>()
+      for (const m of members) memberIds.add(m.user_id)
+      memberIds.delete(selfUserId)
+      const humanMemberIds = [...memberIds]
+      return {
+        humans: humanMemberIds.length,
+        bots: 1,
+        fetchedAt: now(),
+        truncated: false,
+        humanMemberIds,
+      } satisfies MembershipCount
+    } catch (err) {
+      options.logger.warn(`[kakaotalk] membership chat=${key.chat} failed: ${describe(err)}`)
+      return { kind: 'transient' } satisfies MembershipResolverFailure
+    }
+  }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -823,6 +823,12 @@ describe('createKakaotalkAdapter — author name resolution', () => {
     const client = new FakeClient()
     const listener = new FakeListener()
     const router = createChannelRouter({ agentDir, configForAdapter: () => adapterCfg() })
+    // Intercept route so the engagement turn (and its membership GETMEM read)
+    // never runs — this isolates the author-resolution path under test.
+    const routed: { authorName: string }[] = []
+    router.route = async (event) => {
+      routed.push({ authorName: event.authorName })
+    }
     const adapter = createKakaotalkAdapter({
       router,
       configRef: () => adapterCfg(),
@@ -846,6 +852,7 @@ describe('createKakaotalkAdapter — author name resolution', () => {
     })
     await new Promise((r) => setTimeout(r, 10))
 
+    expect(routed).toEqual([{ authorName: 'Alice' }])
     expect(client.getMembersCalls).toHaveLength(0)
 
     await adapter.stop()
@@ -917,7 +924,10 @@ describe('createKakaotalkAdapter — author name resolution', () => {
     })
     await new Promise((r) => setTimeout(r, 10))
 
-    expect(client.getMembersCalls).toEqual(['111'])
+    // Author resolution falls back to GETMEM for chat 111 (the membership
+    // resolver also reads the roster on engagement, so assert containment
+    // rather than an exact call list).
+    expect(client.getMembersCalls).toContain('111')
 
     await adapter.stop()
     await router.stop()

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -43,6 +43,7 @@ import { createKakaoChannelResolver, type KakaoChannelResolver } from './kakaota
 import { classifyInbound, type InboundDropReason } from './kakaotalk-classify'
 import { createFetchAttachmentCallback } from './kakaotalk-fetch-attachment'
 import { toKakaoPlainText } from './kakaotalk-format'
+import { createKakaoMembershipResolver } from './kakaotalk-membership'
 
 // Structural duck-type of the upstream KakaoTalkClient class. The upstream
 // type is a class with private fields, and TypeScript treats those
@@ -368,6 +369,11 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
 
   const channelResolver = createKakaoChannelResolver({ client, logger })
   const authorResolver = createKakaoAuthorResolver({ client, logger })
+  const membershipResolver = createKakaoMembershipResolver({
+    client,
+    selfUserIdRef: () => selfUserId,
+    logger,
+  })
 
   const formatChannelTag = async (workspace: string, chat: string): Promise<string> => {
     const names = await channelResolver
@@ -658,6 +664,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       options.router.registerChannelNameResolver('kakaotalk', channelResolver.resolve)
       options.router.registerHistory('kakaotalk', historyCallback)
       options.router.registerFetchAttachment('kakaotalk', fetchAttachmentCallback)
+      options.router.registerMembership('kakaotalk', membershipResolver)
     },
 
     async stop(): Promise<void> {
@@ -667,6 +674,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       options.router.unregisterChannelNameResolver('kakaotalk', channelResolver.resolve)
       options.router.unregisterHistory('kakaotalk', historyCallback)
       options.router.unregisterFetchAttachment('kakaotalk', fetchAttachmentCallback)
+      options.router.unregisterMembership('kakaotalk', membershipResolver)
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)


### PR DESCRIPTION
## Background

A KakaoTalk-connected agent replied in a group chat to a message that was **not addressed to it** — no alias, no mention. The agent's own alias never matched (the inbound logged `mention=false dm=false`), yet it engaged and answered a message one human sent to *another* human in the room.

Root cause: **KakaoTalk is the only channel adapter that never registers a membership resolver.** Every other adapter (`discord-bot`, `slack-bot`, `telegram-bot`, `webex`, `github`) calls `router.registerMembership(...)`; KakaoTalk did not. Without a resolver, the router's `resolveEffectiveHumans` falls back to `persistedHumans` — only the humans who have actually *posted* in the current live session.

The failing chat was a freshly cold-started ("provisional", `not_in_getchats`) group. At decision time only one human had spoken, so `persistedHumans = 1`. That tripped the engagement layer's solo-human "answer everything" fallback:

```ts
// engagement.ts
if (effectiveHumans <= 1 && !message.authorIsBot) return 'engage'
```

So a real multi-member group was misclassified as a 1-on-1, and the agent answered a message meant for someone else. It only reverted to strict mention-only once a second human happened to post.

## Summary

Register a `kakaotalk` membership resolver that reads the room roster and reports an accurate human count, so `effectiveHumans` reflects the real group size instead of "humans seen so far".

- **Reuse `getMembers`.** The KakaoTalk client already exposes it (used today only for author-name resolution), and agent-messenger now merges the GETMEM subset with the CHATONROOM full roster — so the list is the complete active membership.
- **`truncated: false`, with `humanMemberIds`.** Unlike Telegram (an opaque `getChatMemberCount` that must be reported approximate), KakaoTalk enumerates every member, so the count is authoritative.
- **Self-exclusion.** The agent's own account appears in the roster alongside humans, so it's removed from the human count; `bots: 1` represents the agent itself. Reporting `bots: 0` would falsely signal "alone with humans" and defeat peer-bot loop suppression.
- **Fail closed before identity / on error.** Pre-login (no self id yet) and roster-fetch failures return a `transient` failure, so the router keeps its persisted-speakers fallback and retries later — never over-counts by including self.

## What this does NOT do

- Does **not** change the solo-human fallback itself — that behavior is correct for genuine 1-on-1 chats; the bug was a wrong member count feeding it.
- Does **not** touch any other adapter or the engagement algorithm.
- Does **not** add `humanMemberIds`-based completeness consumers; it just populates the field the same way the enumerating adapters do.

## Review notes

- Load-bearing change: `src/channels/adapters/kakaotalk.ts` now constructs `membershipResolver` and registers/unregisters it alongside the other router callbacks (registration after `listener.start()`, unregistration first in `stop()` — same ordering invariant as the existing callbacks).
- Invariant to verify: a multi-member group must report `humans > 1` even when only one member has posted (covered by the "real group never collapses to the solo-human fallback (regression)" test).
- Two existing `kakaotalk.test.ts` GETMEM-call assertions were relaxed/retargeted because the resolver now legitimately calls `getMembers` during the engagement turn — they assert author-resolution *behavior* (resolved name) rather than an exact `getMembers` call list. The "without firing GETMEM" case now intercepts `router.route` to isolate the author-resolution path from the engagement read.
- Related upstream: agent-messenger#209 ("Fix partial KakaoTalk member lists") is what makes `getMembers` return the complete roster this resolver depends on; it is already shipped in the pinned `agent-messenger` version.
