### PR TITLE
test(container): stabilize Windows-path-sensitive container test fixtures

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -454,12 +454,21 @@ describe('buildxAvailable', () => {
 })
 
 describe('dockerBindMount', () => {
+  // dockerBindMount resolve()s its src to absolute. A POSIX literal like
+  // `/srv/x` is left untouched on POSIX but rewritten to `<drive>:\srv\x` on
+  // Windows, so any assertion comparing against the literal diverges there.
+  // Build the fixture from an already-absolute, platform-native path so
+  // resolve() is a no-op and the expected string matches on every OS.
+  const absSrc = (...segments: string[]): string =>
+    isWindows() ? `C:\\${segments.join('\\')}` : `/${segments.join('/')}`
+
   test('emits a single --mount argv pair (src never collides with the dst separator)', () => {
-    // given an absolute POSIX source
-    const args = dockerBindMount({ src: '/srv/agent', dst: '/agent' })
+    // given an already-absolute, platform-native source
+    const src = absSrc('srv', 'agent')
+    const args = dockerBindMount({ src, dst: '/agent' })
 
     // then the whole spec is one argv element — no `:`-splitting like `-v`
-    expect(args).toEqual(['--mount', 'type=bind,src=/srv/agent,dst=/agent'])
+    expect(args).toEqual(['--mount', `type=bind,src=${src},dst=/agent`])
   })
 
   test('keeps a colon-bearing absolute source intact instead of splitting on it (the Windows drive-letter case)', () => {
@@ -477,10 +486,11 @@ describe('dockerBindMount', () => {
   })
 
   test('appends the readonly field only when readonly is true', () => {
-    expect(dockerBindMount({ src: '/srv/x', dst: '/opt/models', readonly: true })[1]).toBe(
-      'type=bind,src=/srv/x,dst=/opt/models,readonly',
+    const src = absSrc('srv', 'x')
+    expect(dockerBindMount({ src, dst: '/opt/models', readonly: true })[1]).toBe(
+      `type=bind,src=${src},dst=/opt/models,readonly`,
     )
-    expect(dockerBindMount({ src: '/srv/x', dst: '/agent', readonly: false })[1]).not.toContain('readonly')
+    expect(dockerBindMount({ src, dst: '/agent', readonly: false })[1]).not.toContain('readonly')
   })
 
   test('resolves a relative source to an absolute path (docker --mount rejects relative src)', () => {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -8,6 +8,7 @@ import { DEFAULT_GITHUB_EVENT_ALLOWLIST } from '@/channels/schema'
 import { startDaemon, type Daemon } from '@/hostd/daemon'
 import { buildDockerfile } from '@/init/dockerfile'
 import { buildGitignore } from '@/init/gitignore'
+import { isWindows } from '@/shared'
 
 import type { DockerExec } from './shared'
 import { commitSystemFile, planStart, refreshDockerfile, refreshGitignore, shouldMirrorDevSource, start } from './start'
@@ -319,19 +320,22 @@ describe('planStart', () => {
     }
   })
 
-  test('adds a mirror mount for the typeclaw source when dependency is a file: spec outside cwd', async () => {
-    const typeclawRepo = await mkdtemp(join(tmpdir(), 'typeclaw-repo-'))
-    try {
-      await writeDockerfile(root)
-      await writePackageJson(root, { typeclaw: `file:${typeclawRepo}` })
+  test.skipIf(isWindows())(
+    'adds a mirror mount for the typeclaw source when dependency is a file: spec outside cwd',
+    async () => {
+      const typeclawRepo = await mkdtemp(join(tmpdir(), 'typeclaw-repo-'))
+      try {
+        await writeDockerfile(root)
+        await writePackageJson(root, { typeclaw: `file:${typeclawRepo}` })
 
-      const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
+        const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
-      expect(hasBindMount(plan.runArgs, { src: typeclawRepo, dst: typeclawRepo, readonly: true })).toBe(true)
-    } finally {
-      await rm(typeclawRepo, { recursive: true, force: true })
-    }
-  })
+        expect(hasBindMount(plan.runArgs, { src: typeclawRepo, dst: typeclawRepo, readonly: true })).toBe(true)
+      } finally {
+        await rm(typeclawRepo, { recursive: true, force: true })
+      }
+    },
+  )
 
   test('skips mirror mount when typeclaw file: spec points inside the agent folder', async () => {
     await writeDockerfile(root)


### PR DESCRIPTION
## Background

Three tests in the `windows tests (informational triage)` CI job were failing deterministically on Windows. All three were test-side bugs — no production code paths were affected.

**Root cause 1 — `dockerBindMount` tests.** The tests hardcoded POSIX-absolute fixture paths (`/srv/agent`, `/srv/x`). `dockerBindMount` calls `resolve()` on its `src`, which is a no-op on POSIX but prepends the drive letter on Windows (e.g. `/srv/x` becomes `D:\srv\x`). The literal expectations therefore diverged on every Windows runner.

**Root cause 2 — `planStart` mirror-mount test.** The test asserted a bind mount that `shouldMirrorDevSource` intentionally never emits on Windows: a Windows host path with a drive letter is not a valid Linux container destination. The POSIX-only end-to-end assertion was guaranteed to fail on Windows even though the Windows contract was already covered by `shouldMirrorDevSource`'s own win32-parameterized unit tests.

## Summary

**`shared.test.ts` — `absSrc` helper.** Builds fixture paths from a platform-native absolute root (drive-letter root on Windows, `/` on POSIX) so `resolve()` is a no-op and expected strings match on every OS. Mirrors the drive-letter test already present in the file.

**`start.test.ts` — `test.skipIf(isWindows())`.** Gates the mirror-mount integration test so it only runs on POSIX. The Windows contract stays fully covered by `shouldMirrorDevSource`'s win32 unit tests; no coverage is lost.

## What this does NOT do

- Does not change any production code.
- Does not remove or weaken the Windows contract — `shouldMirrorDevSource`'s win32 unit tests remain.
- Does not fix the 7 pre-existing `*.schema.json` drift-guard failures on `main` (unrelated to this branch, reproducible on a clean checkout of the base).

## Review notes

`test.skipIf(isWindows())` is preferred over `if (isWindows()) test.skip(...)` because the former registers the test (shows as skipped in output) rather than silently eliding it.