### PR TITLE
feat(hostd): renew Webex password tokens before they expire

### DIFF
--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -7,6 +7,7 @@ import { createKakaoRenewalManager } from '@/hostd/kakao-renewal-manager'
 import { createPortbrokerManager } from '@/hostd/portbroker-manager'
 import type { SupervisorLogEvent, SupervisorRestart } from '@/hostd/supervisor'
 import { computeSourceVersion, resolveSrcRoot, UNVERSIONED_SENTINEL } from '@/hostd/version'
+import { createWebexRenewalManager } from '@/hostd/webex-renewal-manager'
 import { validateRestartDeps, type RestartDepsPreflightResult } from '@/init/restart-deps-preflight'
 
 export const hostdCommand = defineCommand({
@@ -37,6 +38,18 @@ export const hostdCommand = defineCommand({
       },
       shouldRenew: ({ cwd }) => kakaoChannelConfigured(cwd),
     })
+    const webexRenewal = createWebexRenewalManager({
+      onLog: (event) => writeLogLine(formatLog(event)),
+      onRenewalOk: async ({ containerName, cwd }) => {
+        // Restart so the in-memory WebexClient picks up the renewed token from
+        // secrets.json. Without this, the cron writes a fresh token but the
+        // running adapter keeps the old token in its getToken closure and still
+        // 401s on every outbound REST call + KMS key fetch.
+        const result = await hostdRestart({ containerName, cwd })
+        if (!result.ok) throw new Error(result.reason)
+      },
+      shouldRenew: ({ cwd }) => webexChannelConfigured(cwd),
+    })
 
     const daemon = await startDaemon({
       onLog: (e) => writeLogLine(formatLog(e)),
@@ -44,6 +57,7 @@ export const hostdCommand = defineCommand({
       onShutdown: () => process.exit(0),
       portbroker,
       kakaoRenewal,
+      webexRenewal,
       restartPreflight: buildHostdRestartPreflight(cliEntry, version, defaultPreflightDeps),
       restart: hostdRestart,
     })
@@ -53,6 +67,7 @@ export const hostdCommand = defineCommand({
         .stop()
         .then(() => portbroker.drain())
         .then(() => kakaoRenewal.drain())
+        .then(() => webexRenewal.drain())
         .then(() => process.exit(0))
     }
     process.on('SIGTERM', shutdown)
@@ -201,6 +216,22 @@ function formatLog(event: DaemonLogEvent | SupervisorLogEvent): string {
       return `[hostd] kakao renewal scheduled container restart for ${event.containerName} account=${event.accountId}`
     case 'kakao-renewal-restart-failed':
       return `[hostd] kakao renewal container restart FAILED for ${event.containerName} account=${event.accountId}: ${event.reason}`
+    case 'webex-renewal-tick-start':
+      return `[hostd] webex renewal tick started for ${event.containerName}`
+    case 'webex-renewal-tick-skipped':
+      return `[hostd] webex renewal skipped for ${event.containerName}: ${event.reason}${event.expiresInMs !== undefined ? ` (expires in ${Math.round(event.expiresInMs / 1000 / 60 / 60)}h)` : ''}`
+    case 'webex-renewal-tick-ok':
+      return `[hostd] webex renewal OK for ${event.containerName} account=${event.accountId} (new token expires ${new Date(event.nextExpiresAt).toISOString()})`
+    case 'webex-renewal-tick-reauth-required':
+      return `[hostd] webex renewal REAUTH REQUIRED for ${event.containerName} account=${event.accountId} reason=${event.reason} — ${event.message}`
+    case 'webex-renewal-tick-transient-failure':
+      return `[hostd] webex renewal transient failure for ${event.containerName} account=${event.accountId}: ${event.reason}`
+    case 'webex-renewal-tick-error':
+      return `[hostd] webex renewal ERROR for ${event.containerName}: ${event.error}`
+    case 'webex-renewal-restart-scheduled':
+      return `[hostd] webex renewal scheduled container restart for ${event.containerName} account=${event.accountId}`
+    case 'webex-renewal-restart-failed':
+      return `[hostd] webex renewal container restart FAILED for ${event.containerName} account=${event.accountId}: ${event.reason}`
   }
 }
 
@@ -214,6 +245,15 @@ function kakaoChannelConfigured(cwd: string): boolean {
   try {
     const cfg = loadConfigSync(cwd)
     return cfg.channels?.kakaotalk !== undefined
+  } catch {
+    return false
+  }
+}
+
+function webexChannelConfigured(cwd: string): boolean {
+  try {
+    const cfg = loadConfigSync(cwd)
+    return cfg.channels?.webex !== undefined
   } catch {
     return false
   }

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -14,6 +14,7 @@ import { startDaemon, type Daemon, type PortbrokerCallbacks, type PortbrokerStar
 import type { KakaoRenewalCallbacks, KakaoRenewalStartInput } from './kakao-renewal-manager'
 import { registrationFilePath, registrationsDir, socketPath } from './paths'
 import type { HttpInfoResult, ListResult, VersionResult } from './protocol'
+import type { WebexRenewalCallbacks, WebexRenewalStartInput } from './webex-renewal-manager'
 
 let home: string
 let prev: string | undefined
@@ -908,6 +909,78 @@ describe('startDaemon', () => {
     daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, kakaoRenewal })
 
     expect(starts).toEqual([{ containerName: 'persistent-kakao', cwd: '/agent/pk' }])
+  })
+
+  test('register invokes webexRenewal.start with the registered container and cwd', async () => {
+    const starts: WebexRenewalStartInput[] = []
+    const webexRenewal: WebexRenewalCallbacks = {
+      start: (input) => {
+        starts.push(input)
+      },
+      stop: async () => {},
+      drain: async () => {},
+    }
+    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, webexRenewal })
+
+    await send({ kind: 'register', containerName: 'webex-agent', cwd: '/agent/webex' })
+
+    expect(starts).toEqual([{ containerName: 'webex-agent', cwd: '/agent/webex' }])
+  })
+
+  test('deregister awaits webexRenewal.stop for that container', async () => {
+    const stopCalls: string[] = []
+    const webexRenewal: WebexRenewalCallbacks = {
+      start: () => {},
+      stop: async (name) => {
+        stopCalls.push(name)
+      },
+      drain: async () => {},
+    }
+    daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, webexRenewal })
+
+    await send({ kind: 'register', containerName: 'webex-agent', cwd: '/agent/webex' })
+    await send({ kind: 'deregister', containerName: 'webex-agent' })
+
+    expect(stopCalls).toEqual(['webex-agent'])
+  })
+
+  test('daemon.stop() drains webexRenewal across all registered containers', async () => {
+    const stopCalls: string[] = []
+    const webexRenewal: WebexRenewalCallbacks = {
+      start: () => {},
+      stop: async (name) => {
+        stopCalls.push(name)
+      },
+      drain: async () => {},
+    }
+    const d = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, webexRenewal })
+
+    await send({ kind: 'register', containerName: 'a', cwd: '/agent/a' })
+    await send({ kind: 'register', containerName: 'b', cwd: '/agent/b' })
+    await d.stop()
+
+    expect(stopCalls.sort()).toEqual(['a', 'b'])
+  })
+
+  test('boot-time restore invokes webexRenewal.start for persisted registrations whose container is still alive', async () => {
+    const starts: WebexRenewalStartInput[] = []
+    const webexRenewal: WebexRenewalCallbacks = {
+      start: (input) => {
+        starts.push(input)
+      },
+      stop: async () => {},
+      drain: async () => {},
+    }
+    const alive = new Set(['persistent-webex'])
+
+    const d1 = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, webexRenewal })
+    await send({ kind: 'register', containerName: 'persistent-webex', cwd: '/agent/pw', restartToken: 't' })
+    await d1.stop()
+
+    starts.length = 0
+    daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, webexRenewal })
+
+    expect(starts).toEqual([{ containerName: 'persistent-webex', cwd: '/agent/pw' }])
   })
 
   test('HTTP control falls back to an ephemeral port when the preferred port is busy', async () => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -27,6 +27,7 @@ import type {
 import { buildSupervisor, type SupervisorLogEvent, type SupervisorRestart } from './supervisor'
 import type { TailscaleServeEvent } from './tailscale'
 import { UNVERSIONED_SENTINEL } from './version'
+import type { WebexRenewalCallbacks, WebexRenewalLogEvent } from './webex-renewal-manager'
 
 export type DaemonOptions = {
   exec?: DockerExec
@@ -60,6 +61,10 @@ export type DaemonOptions = {
   // deregister. Omit to disable in tests / when the agent has no kakaotalk
   // channel configured.
   kakaoRenewal?: KakaoRenewalCallbacks
+  // Webex credential renewal capability. Same lifecycle as kakaoRenewal but
+  // ticks hourly because Webex password tokens live ~27h (see
+  // webex-renewal-manager.ts). Omit when the agent has no webex channel.
+  webexRenewal?: WebexRenewalCallbacks
 }
 
 export type RestartPreflight = (input: {
@@ -102,6 +107,7 @@ export type DaemonLogEvent =
   | { kind: 'port-forward-event'; event: PortForwardEvent }
   | { kind: 'tailscale-serve-event'; event: TailscaleServeEvent }
   | KakaoRenewalLogEvent
+  | WebexRenewalLogEvent
 
 export type Daemon = {
   registered: () => string[]
@@ -341,6 +347,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       gcMisses.delete(containerName)
       if (opts.portbroker) await opts.portbroker.stop(containerName, 'fatal-auth').catch(() => {})
       if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(containerName).catch(() => {})
+      if (opts.webexRenewal) await opts.webexRenewal.stop(containerName).catch(() => {})
       await removeRegistrationFile(containerName)
       log({ kind: 'registration-skipped', containerName, reason: `fatal broker auth: ${reason}` })
     })
@@ -376,6 +383,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     if (opts.kakaoRenewal) {
       opts.kakaoRenewal.start({ containerName: payload.containerName, cwd: payload.cwd })
     }
+    if (opts.webexRenewal) {
+      opts.webexRenewal.start({ containerName: payload.containerName, cwd: payload.cwd })
+    }
   }
 
   const handleRegister = async (req: RegisterPayload): Promise<RpcResponse> => {
@@ -403,6 +413,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       gcMisses.delete(req.containerName)
       if (opts.portbroker) await opts.portbroker.stop(req.containerName, 'deregistered').catch(() => {})
       if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(req.containerName).catch(() => {})
+      if (opts.webexRenewal) await opts.webexRenewal.stop(req.containerName).catch(() => {})
       await removeRegistrationFile(req.containerName)
       if (hadCwd) log({ kind: 'deregister', containerName: req.containerName, reason: 'requested' })
       return { ok: true }
@@ -684,6 +695,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         restartTokens.delete(name)
         if (opts.portbroker) await opts.portbroker.stop(name, 'deregistered').catch(() => {})
         if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(name).catch(() => {})
+        if (opts.webexRenewal) await opts.webexRenewal.stop(name).catch(() => {})
         await removeRegistrationFile(name)
         if (hadCwd) log({ kind: 'deregister', containerName: name, reason: 'gone' })
         return { ok: true }
@@ -712,6 +724,10 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       if (opts.kakaoRenewal) {
         const names = Array.from(cwds.keys())
         await Promise.allSettled(names.map((n) => opts.kakaoRenewal!.stop(n)))
+      }
+      if (opts.webexRenewal) {
+        const names = Array.from(cwds.keys())
+        await Promise.allSettled(names.map((n) => opts.webexRenewal!.stop(n)))
       }
       cwds.clear()
       restartTokens.clear()

--- a/src/hostd/webex-renewal-manager.test.ts
+++ b/src/hostd/webex-renewal-manager.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { encrypt } from '@/secrets/encryption'
+import { createKeyStore } from '@/secrets/keys'
+import type { WebexChannelBlock } from '@/secrets/schema'
+import type { LoginWithPasswordFn } from '@/secrets/webex-renewal'
+import { expectStable, waitFor } from '@/test-helpers/wait-for'
+
+import { createWebexRenewalManager, type WebexRenewalLogEvent } from './webex-renewal-manager'
+
+const HOUR_MS = 60 * 60 * 1000
+
+async function setupAgent(opts: {
+  agentDir: string
+  expiresInHours: number
+  withEncryptedPassword: boolean
+}): Promise<{ containerName: string; cwd: string; keysDir: string }> {
+  const containerName = 'webex'
+  const keysDir = join(opts.agentDir, 'keys')
+  const ks = createKeyStore({ keysDir })
+  const key = await ks.ensure(containerName)
+  const encryptedPassword = opts.withEncryptedPassword
+    ? encrypt('hunter2', key, { containerName, accountId: 'u-1' })
+    : undefined
+  const nowIso = new Date().toISOString()
+  const block: WebexChannelBlock = {
+    currentAccount: 'u-1',
+    accounts: {
+      'u-1': {
+        account_id: 'u-1',
+        access_token: 'old-access',
+        refresh_token: 'old-refresh',
+        expires_at: Date.now() + opts.expiresInHours * HOUR_MS,
+        device_url: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/device-1',
+        user_id: 'u-1',
+        created_at: nowIso,
+        updated_at: nowIso,
+        email: 'u@e.com',
+        ...(encryptedPassword !== undefined ? { encryptedPassword } : {}),
+      },
+    },
+  }
+  const envelope = { version: 2, providers: {}, channels: { webex: block } }
+  await writeFile(join(opts.agentDir, 'secrets.json'), JSON.stringify(envelope))
+  return { containerName, cwd: opts.agentDir, keysDir }
+}
+
+async function withAgentDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  return fn(await mkdtemp(join(tmpdir(), 'typeclaw-webex-renewal-mgr-')))
+}
+
+function freshLogin(): LoginWithPasswordFn {
+  return async () => ({
+    accessToken: 'fresh-access',
+    refreshToken: 'fresh-refresh',
+    expiresAt: Date.now() + 27 * HOUR_MS,
+    deviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/device-1',
+    userId: 'u-1',
+  })
+}
+
+describe('createWebexRenewalManager', () => {
+  test('runs the first tick immediately on start and renews an expiring token', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      const events: WebexRenewalLogEvent[] = []
+      let loginCalls = 0
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async (...args) => {
+          loginCalls++
+          return freshLogin()(...args)
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onLog: (e) => events.push(e),
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await manager.drain()
+
+      expect(loginCalls).toBe(1)
+      expect(events.some((e) => e.kind === 'webex-renewal-tick-ok')).toBe(true)
+    })
+  })
+
+  test('emits tick-skipped (fresh_enough) when the token is far from expiry', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 20, withEncryptedPassword: true })
+      const events: WebexRenewalLogEvent[] = []
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          throw new Error('must not be called for a fresh account')
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onLog: (e) => events.push(e),
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await manager.drain()
+
+      expect(events.some((e) => e.kind === 'webex-renewal-tick-skipped')).toBe(true)
+    })
+  })
+
+  test('emits tick-reauth-required when the key file is missing', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      await writeFile(join(setup.keysDir, `${setup.containerName}.key`), Buffer.alloc(0))
+      const events: WebexRenewalLogEvent[] = []
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          throw new Error('must not be called when key file is unusable')
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onLog: (e) => events.push(e),
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await manager.drain()
+
+      expect(events.some((e) => e.kind === 'webex-renewal-tick-reauth-required')).toBe(true)
+    })
+  })
+
+  test('stop() cancels the scheduled timer', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      let scheduleStopCalled = 0
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: freshLogin(),
+        schedule: (_fn, _ms) => ({
+          stop: () => {
+            scheduleStopCalled++
+          },
+        }),
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await manager.stop(setup.containerName)
+
+      expect(scheduleStopCalled).toBe(1)
+      await manager.drain()
+    })
+  })
+
+  test('start() called twice for the same container replaces the timer', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      let scheduleStopCalled = 0
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: freshLogin(),
+        schedule: (_fn, _ms) => ({
+          stop: () => {
+            scheduleStopCalled++
+          },
+        }),
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => scheduleStopCalled >= 1)
+
+      expect(scheduleStopCalled).toBe(1)
+      await manager.drain()
+    })
+  })
+
+  test('drain() stops all timers', async () => {
+    await withAgentDir(async (dir) => {
+      const a = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      let scheduleStopCalled = 0
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: a.keysDir }),
+        loginWithPassword: freshLogin(),
+        schedule: (_fn, _ms) => ({
+          stop: () => {
+            scheduleStopCalled++
+          },
+        }),
+      })
+
+      manager.start({ containerName: 'agent-a', cwd: a.cwd })
+      manager.start({ containerName: 'agent-b', cwd: a.cwd })
+      await manager.drain()
+
+      expect(scheduleStopCalled).toBe(2)
+    })
+  })
+
+  test('invokes onRenewalOk after a successful renewal, so the host can restart the container', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      const restartCalls: Array<{ containerName: string; cwd: string; accountId: string }> = []
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: freshLogin(),
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onRenewalOk: async (input) => {
+          restartCalls.push(input)
+        },
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => restartCalls.length > 0)
+      await manager.drain()
+
+      expect(restartCalls).toEqual([{ containerName: setup.containerName, cwd: setup.cwd, accountId: 'u-1' }])
+    })
+  })
+
+  test('does NOT invoke onRenewalOk when the renewal skips', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 20, withEncryptedPassword: true })
+      let restartCalls = 0
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          throw new Error('loginWithPassword should not run for a fresh account')
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onRenewalOk: async () => {
+          restartCalls++
+        },
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await manager.drain()
+
+      expect(restartCalls).toBe(0)
+    })
+  })
+
+  test('logs webex-renewal-restart-failed when onRenewalOk throws', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      const events: WebexRenewalLogEvent[] = []
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: freshLogin(),
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onRenewalOk: async () => {
+          throw new Error('docker stop refused')
+        },
+        onLog: (e) => events.push(e),
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => events.some((e) => e.kind === 'webex-renewal-restart-failed'))
+      await manager.drain()
+
+      expect(events.some((e) => e.kind === 'webex-renewal-tick-ok')).toBe(true)
+      expect(events.some((e) => e.kind === 'webex-renewal-restart-failed')).toBe(true)
+    })
+  })
+
+  test('shouldRenew=false suppresses the cron entirely (no tick, no timer, no log spam)', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      const events: WebexRenewalLogEvent[] = []
+      let scheduleCalls = 0
+      let loginCalls = 0
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          loginCalls++
+          throw new Error('loginWithPassword should not run for a non-webex agent')
+        },
+        schedule: (_fn, _ms) => {
+          scheduleCalls++
+          return { stop: () => {} }
+        },
+        onLog: (e) => events.push(e),
+        shouldRenew: () => false,
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await expectStable(() => loginCalls > 0 || scheduleCalls > 0 || events.length > 0, {
+        durationMs: 25,
+        description: 'suppressed cron activity',
+      })
+
+      expect(scheduleCalls).toBe(0)
+      expect(loginCalls).toBe(0)
+      expect(events).toHaveLength(0)
+
+      await manager.drain()
+    })
+  })
+
+  test('drain() awaits in-flight renewal work so the daemon does not exit mid-login', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      let loginStarted = false
+      let loginFinished = false
+      let releaseLogin: (() => void) | null = null
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          loginStarted = true
+          await new Promise<void>((r) => {
+            releaseLogin = r
+          })
+          loginFinished = true
+          return freshLogin()('u@e.com', 'hunter2')
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => loginStarted)
+      expect(loginFinished).toBe(false)
+
+      const drainPromise = manager.drain()
+      const racer = Promise.race([drainPromise, new Promise((r) => setTimeout(() => r('timeout'), 50))])
+      expect(await racer).toBe('timeout')
+      expect(loginFinished).toBe(false)
+
+      releaseLogin!()
+      await drainPromise
+      expect(loginFinished).toBe(true)
+    })
+  })
+
+  test('does NOT invoke onRenewalOk when stop() removed the container during an in-flight renewal', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      let loginStarted = false
+      let releaseLogin: (() => void) | null = null
+      const restartCalls: string[] = []
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          loginStarted = true
+          await new Promise<void>((r) => {
+            releaseLogin = r
+          })
+          return freshLogin()('u@e.com', 'hunter2')
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onRenewalOk: async ({ containerName }) => {
+          restartCalls.push(containerName)
+        },
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => loginStarted)
+
+      const stopPromise = manager.stop(setup.containerName)
+      releaseLogin!()
+      await stopPromise
+
+      expect(restartCalls).toEqual([])
+    })
+  })
+
+  test('does NOT restart the old cwd when the container re-registers with a new cwd mid-tick', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      let loginStarted = false
+      let releaseLogin: (() => void) | null = null
+      const restartCwds: string[] = []
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          loginStarted = true
+          await new Promise<void>((r) => {
+            releaseLogin = r
+          })
+          return freshLogin()('u@e.com', 'hunter2')
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onRenewalOk: async ({ cwd }) => {
+          restartCwds.push(cwd)
+        },
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => loginStarted)
+
+      // Re-register the same container with a different cwd while the first
+      // tick is parked in login.
+      manager.start({ containerName: setup.containerName, cwd: '/agent/relocated' })
+      releaseLogin!()
+      await manager.drain()
+
+      expect(restartCwds).not.toContain(setup.cwd)
+    })
+  })
+
+  test('re-registering to a shouldRenew=false cwd clears the old timer and does not restart the old cwd', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, expiresInHours: 1, withEncryptedPassword: true })
+      let loginStarted = false
+      let releaseLogin: (() => void) | null = null
+      const restartCwds: string[] = []
+      const scheduleStops = new Map<number, number>()
+      let scheduleSeq = 0
+
+      const manager = createWebexRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        loginWithPassword: async () => {
+          loginStarted = true
+          await new Promise<void>((r) => {
+            releaseLogin = r
+          })
+          return freshLogin()('u@e.com', 'hunter2')
+        },
+        schedule: (_fn, _ms) => {
+          const id = scheduleSeq++
+          scheduleStops.set(id, 0)
+          return {
+            stop: () => {
+              scheduleStops.set(id, (scheduleStops.get(id) ?? 0) + 1)
+            },
+          }
+        },
+        onRenewalOk: async ({ cwd }) => {
+          restartCwds.push(cwd)
+        },
+        shouldRenew: ({ cwd }) => cwd === setup.cwd,
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => loginStarted)
+
+      manager.start({ containerName: setup.containerName, cwd: '/agent/no-webex' })
+      releaseLogin!()
+      await manager.drain()
+
+      expect(restartCwds).not.toContain(setup.cwd)
+      // The first registration's timer was stopped by the ineligible re-register.
+      expect(scheduleStops.get(0)).toBe(1)
+      // No second timer was scheduled for the ineligible cwd.
+      expect(scheduleSeq).toBe(1)
+    })
+  })
+})

--- a/src/hostd/webex-renewal-manager.ts
+++ b/src/hostd/webex-renewal-manager.ts
@@ -1,0 +1,216 @@
+import { createKeyStore, type KeyStore } from '@/secrets/keys'
+import { renewCurrentAccount, type LoginWithPasswordFn } from '@/secrets/webex-renewal'
+
+import { keysDir } from './paths'
+
+// Webex password-login tokens live ~27h and renewal triggers within 8h of
+// expiry (see RENEWAL_WINDOW_MS). A 24h tick like KakaoTalk's would let a token
+// cross into the 8h window and expire before the next tick, so Webex ticks
+// hourly: short enough to always catch the window, cheap because a fresh token
+// short-circuits to a no-op skip.
+const DEFAULT_TICK_INTERVAL_MS = 60 * 60 * 1000
+
+export type WebexRenewalCallbacks = {
+  start: (input: WebexRenewalStartInput) => void
+  stop: (containerName: string) => Promise<void>
+  drain: () => Promise<void>
+}
+
+export type WebexRenewalStartInput = {
+  containerName: string
+  cwd: string
+}
+
+export type WebexRenewalLogEvent =
+  | { kind: 'webex-renewal-tick-start'; containerName: string }
+  | { kind: 'webex-renewal-tick-skipped'; containerName: string; reason: string; expiresInMs?: number }
+  | { kind: 'webex-renewal-tick-ok'; containerName: string; accountId: string; nextExpiresAt: number }
+  | {
+      kind: 'webex-renewal-tick-reauth-required'
+      containerName: string
+      accountId: string
+      reason: string
+      message: string
+    }
+  | { kind: 'webex-renewal-tick-transient-failure'; containerName: string; accountId: string; reason: string }
+  | { kind: 'webex-renewal-tick-error'; containerName: string; error: string }
+  | { kind: 'webex-renewal-restart-scheduled'; containerName: string; accountId: string }
+  | { kind: 'webex-renewal-restart-failed'; containerName: string; accountId: string; reason: string }
+
+export type WebexRenewalManagerOptions = {
+  onLog?: (event: WebexRenewalLogEvent) => void
+  tickIntervalMs?: number
+  keyStoreFactory?: () => KeyStore
+  loginWithPassword?: LoginWithPasswordFn
+  schedule?: (fn: () => void, intervalMs: number) => { stop: () => void }
+  // Invoked after a successful renewal so the host can restart the container
+  // and the in-memory adapter picks up the fresh token. Without this, the cron
+  // writes a new token to secrets.json but the live WebexClient keeps the old
+  // token in its `getToken` closure (src/channels/adapters/webex.ts) and still
+  // hits 401 on every outbound REST call and KMS key fetch.
+  onRenewalOk?: (input: { containerName: string; cwd: string; accountId: string }) => Promise<void>
+  // Only start the renewal cron for containers whose typeclaw.json actually has
+  // a channels.webex block, so non-webex agents don't emit hourly no_account
+  // skip logs.
+  shouldRenew?: (input: WebexRenewalStartInput) => boolean
+}
+
+export function createWebexRenewalManager(opts: WebexRenewalManagerOptions = {}): WebexRenewalCallbacks {
+  const intervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS
+  const keyStore = (opts.keyStoreFactory ?? (() => createKeyStore({ keysDir: keysDir() })))()
+  const log = opts.onLog ?? (() => {})
+  const schedule =
+    opts.schedule ??
+    ((fn: () => void, ms: number) => {
+      const handle = setInterval(fn, ms)
+      return { stop: () => clearInterval(handle) }
+    })
+
+  const timers = new Map<string, { stop: () => void }>()
+  const latestInput = new Map<string, WebexRenewalStartInput>()
+  const inFlight = new Map<string, Promise<void>>()
+  const pendingRerun = new Set<string>()
+
+  const runTick = async (input: WebexRenewalStartInput): Promise<void> => {
+    log({ kind: 'webex-renewal-tick-start', containerName: input.containerName })
+    try {
+      const result = await renewCurrentAccount({
+        containerName: input.containerName,
+        agentDir: input.cwd,
+        keyStore,
+        ...(opts.loginWithPassword ? { loginWithPassword: opts.loginWithPassword } : {}),
+      })
+      if (result.kind === 'skipped') {
+        log({
+          kind: 'webex-renewal-tick-skipped',
+          containerName: input.containerName,
+          reason: result.reason,
+          ...(result.expiresInMs !== undefined ? { expiresInMs: result.expiresInMs } : {}),
+        })
+      } else if (result.kind === 'ok') {
+        log({
+          kind: 'webex-renewal-tick-ok',
+          containerName: input.containerName,
+          accountId: result.account_id,
+          nextExpiresAt: result.nextExpiresAt,
+        })
+        // A tick that started before stop()/drain() (deregister, shutdown) or
+        // before a re-register with a different cwd can finish the slow login
+        // here. Restarting a container that is no longer the current
+        // registration would resurrect a just-deregistered agent or fight a
+        // shutdown, so skip onRenewalOk unless this container+cwd is still the
+        // live registration.
+        const current = latestInput.get(input.containerName)
+        if (opts.onRenewalOk && current?.cwd === input.cwd) {
+          log({
+            kind: 'webex-renewal-restart-scheduled',
+            containerName: input.containerName,
+            accountId: result.account_id,
+          })
+          try {
+            await opts.onRenewalOk({
+              containerName: input.containerName,
+              cwd: input.cwd,
+              accountId: result.account_id,
+            })
+          } catch (err) {
+            log({
+              kind: 'webex-renewal-restart-failed',
+              containerName: input.containerName,
+              accountId: result.account_id,
+              reason: err instanceof Error ? err.message : String(err),
+            })
+          }
+        }
+      } else if (result.kind === 'reauth_required') {
+        log({
+          kind: 'webex-renewal-tick-reauth-required',
+          containerName: input.containerName,
+          accountId: result.account_id,
+          reason: result.reason,
+          message: result.message,
+        })
+      } else {
+        log({
+          kind: 'webex-renewal-tick-transient-failure',
+          containerName: input.containerName,
+          accountId: result.account_id,
+          reason: result.reason,
+        })
+      }
+    } catch (err) {
+      log({
+        kind: 'webex-renewal-tick-error',
+        containerName: input.containerName,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const scheduleTick = (containerName: string): Promise<void> => {
+    const existing = inFlight.get(containerName)
+    if (existing) {
+      pendingRerun.add(containerName)
+      return existing
+    }
+    const promise = (async () => {
+      while (true) {
+        const input = latestInput.get(containerName)
+        if (!input) return
+        await runTick(input)
+        if (!pendingRerun.has(containerName)) return
+        pendingRerun.delete(containerName)
+      }
+    })().finally(() => {
+      inFlight.delete(containerName)
+      pendingRerun.delete(containerName)
+    })
+    inFlight.set(containerName, promise)
+    return promise
+  }
+
+  return {
+    start(input: WebexRenewalStartInput): void {
+      // Tear down any prior registration for this container BEFORE the
+      // shouldRenew gate. The daemon calls start() on every registration, so a
+      // container that had Webex can re-register to a non-Webex cwd; if we
+      // returned early without clearing, the old timer would keep ticking and a
+      // post-login restart guard would still match the stale cwd. Clearing
+      // latestInput also makes an in-flight tick's onRenewalOk re-check fail.
+      const existing = timers.get(input.containerName)
+      if (existing) {
+        existing.stop()
+        timers.delete(input.containerName)
+      }
+      latestInput.delete(input.containerName)
+
+      if (opts.shouldRenew && !opts.shouldRenew(input)) return
+
+      latestInput.set(input.containerName, input)
+      const handle = schedule(() => {
+        void scheduleTick(input.containerName)
+      }, intervalMs)
+      timers.set(input.containerName, handle)
+      void scheduleTick(input.containerName)
+    },
+
+    async stop(containerName: string): Promise<void> {
+      const handle = timers.get(containerName)
+      if (handle) {
+        timers.delete(containerName)
+        handle.stop()
+      }
+      latestInput.delete(containerName)
+      const promise = inFlight.get(containerName)
+      if (promise) await promise.catch(() => {})
+    },
+
+    async drain(): Promise<void> {
+      for (const [, handle] of timers) handle.stop()
+      timers.clear()
+      latestInput.clear()
+      const promises = Array.from(inFlight.values())
+      await Promise.allSettled(promises)
+    },
+  }
+}

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -193,6 +193,7 @@ export type PendingLoginRecord = z.infer<typeof kakaoPendingLoginRecordSchema>
 export type KakaoChannelBlock = z.infer<typeof kakaoChannelBlockSchema>
 export type WebexAccountRecord = z.infer<typeof webexAccountRecordSchema>
 export type WebexChannelBlock = z.infer<typeof webexChannelBlockSchema>
+export type WebexEncryptedPassword = z.infer<typeof webexEncryptedPasswordSchema>
 export type SecretsFile = z.infer<typeof secretsFileSchema>
 
 export type ParseSecretsResult = { ok: true; file: SecretsFile } | { ok: false; reason: string }

--- a/src/secrets/webex-renewal.test.ts
+++ b/src/secrets/webex-renewal.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { encrypt, generateKey } from './encryption'
+import { KeyStoreError, type KeyStore } from './keys'
+import { type WebexEncryptedPassword, type WebexChannelBlock } from './schema'
+import { type LoginWithPasswordFn, decideRenewal, RENEWAL_WINDOW_MS, renewCurrentAccount } from './webex-renewal'
+
+const HOUR_MS = 60 * 60 * 1000
+
+function fakeKeyStore(opts: { containerName: string; key: Buffer | null }): KeyStore {
+  return {
+    keyPath: (name: string) => `/fake/${name}.key`,
+    exists: (name: string) => opts.key !== null && name === opts.containerName,
+    async read(name: string) {
+      if (opts.key === null || name !== opts.containerName) {
+        throw new KeyStoreError(`key file missing: ${name}`, 'missing')
+      }
+      return opts.key
+    },
+    async ensure(name: string) {
+      if (opts.key === null || name !== opts.containerName) {
+        throw new KeyStoreError(`key file missing: ${name}`, 'missing')
+      }
+      return opts.key
+    },
+    fingerprint: () => 'sha256:test',
+  }
+}
+
+function buildBlock(opts: {
+  accountId: string
+  expiresInHours: number
+  email?: string
+  encryptedPassword?: WebexEncryptedPassword
+  createdAt?: string
+}): WebexChannelBlock {
+  const nowIso = new Date().toISOString()
+  return {
+    currentAccount: opts.accountId,
+    accounts: {
+      [opts.accountId]: {
+        account_id: opts.accountId,
+        access_token: 'stale-access',
+        refresh_token: 'stale-refresh',
+        expires_at: Date.now() + opts.expiresInHours * HOUR_MS,
+        device_url: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/device-1',
+        user_id: opts.accountId,
+        created_at: opts.createdAt ?? nowIso,
+        updated_at: nowIso,
+        ...(opts.email !== undefined ? { email: opts.email } : {}),
+        ...(opts.encryptedPassword !== undefined ? { encryptedPassword: opts.encryptedPassword } : {}),
+      },
+    },
+  }
+}
+
+function freshLoginResult(): Awaited<ReturnType<LoginWithPasswordFn>> {
+  return {
+    accessToken: 'fresh-access',
+    refreshToken: 'fresh-refresh',
+    expiresAt: Date.now() + 27 * HOUR_MS,
+    deviceUrl: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/device-1',
+    userId: 'u-1',
+  }
+}
+
+describe('decideRenewal', () => {
+  test('skips when there is no current account', async () => {
+    const block: WebexChannelBlock = { currentAccount: null, accounts: {} }
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+    })
+    expect(decision.kind).toBe('skip')
+    if (decision.kind === 'skip') expect(decision.reason).toBe('no_account')
+  })
+
+  test('skips when the token expires comfortably beyond the renewal window', async () => {
+    const block = buildBlock({ accountId: 'u-1', expiresInHours: 20 })
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+    })
+    expect(decision.kind).toBe('skip')
+    if (decision.kind === 'skip') expect(decision.reason).toBe('fresh_enough')
+  })
+
+  test('requires reauth when email is absent within the renewal window', async () => {
+    const block = buildBlock({ accountId: 'u-1', expiresInHours: 1 })
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+    })
+    expect(decision.kind).toBe('reauth_required')
+    if (decision.kind === 'reauth_required') expect(decision.reason).toBe('no_email')
+  })
+
+  test('requires reauth when encryptedPassword is absent', async () => {
+    const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com' })
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+    })
+    expect(decision.kind).toBe('reauth_required')
+    if (decision.kind === 'reauth_required') expect(decision.reason).toBe('no_password')
+  })
+
+  test('requires reauth when the key file is missing', async () => {
+    const key = generateKey()
+    const encryptedPassword = encrypt('pw', key, { containerName: 'webex', accountId: 'u-1' })
+    const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+    })
+    expect(decision.kind).toBe('reauth_required')
+    if (decision.kind === 'reauth_required') expect(decision.reason).toBe('key_missing')
+  })
+
+  test('requires reauth when the key does not match the ciphertext (wrong key)', async () => {
+    const realKey = generateKey()
+    const otherKey = generateKey()
+    const encryptedPassword = encrypt('pw', realKey, { containerName: 'webex', accountId: 'u-1' })
+    const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key: otherKey }),
+    })
+    expect(decision.kind).toBe('reauth_required')
+    if (decision.kind === 'reauth_required') expect(decision.reason).toBe('decrypt_failed')
+  })
+
+  test('returns should_renew with decrypted password when everything aligns', async () => {
+    const key = generateKey()
+    const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+    const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key }),
+    })
+    expect(decision.kind).toBe('should_renew')
+    if (decision.kind === 'should_renew') {
+      expect(decision.account.account_id).toBe('u-1')
+      expect(decision.account.email).toBe('u@e.com')
+      expect(decision.password).toBe('hunter2')
+    }
+  })
+
+  test('renews an already-expired token (negative expiresInMs is inside the window)', async () => {
+    const key = generateKey()
+    const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+    const block = buildBlock({ accountId: 'u-1', expiresInHours: -2, email: 'u@e.com', encryptedPassword })
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key }),
+    })
+    expect(decision.kind).toBe('should_renew')
+  })
+
+  test('respects the RENEWAL_WINDOW_MS boundary exactly', async () => {
+    const block: WebexChannelBlock = {
+      currentAccount: 'u-1',
+      accounts: {
+        'u-1': {
+          account_id: 'u-1',
+          access_token: 'a',
+          refresh_token: 'r',
+          expires_at: Date.now() + RENEWAL_WINDOW_MS - 1000,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      },
+    }
+    const decision = await decideRenewal(block, {
+      containerName: 'webex',
+      agentDir: '/tmp/x',
+      keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+    })
+    // Inside the window and lacks email → reauth_required (NOT skip)
+    expect(decision.kind).toBe('reauth_required')
+  })
+})
+
+describe('renewCurrentAccount', () => {
+  async function withAgentDir<T>(fn: (agentDir: string) => Promise<T>): Promise<T> {
+    return fn(await mkdtemp(join(tmpdir(), 'typeclaw-webex-renewal-')))
+  }
+
+  async function seedSecrets(agentDir: string, block: WebexChannelBlock): Promise<void> {
+    const envelope = { version: 2, providers: {}, channels: { webex: block } }
+    await writeFile(join(agentDir, 'secrets.json'), JSON.stringify(envelope))
+  }
+
+  test('skips when current account is fresh', async () => {
+    await withAgentDir(async (agentDir) => {
+      const block = buildBlock({ accountId: 'u-1', expiresInHours: 20 })
+      await seedSecrets(agentDir, block)
+
+      const result = await renewCurrentAccount({
+        containerName: 'webex',
+        agentDir,
+        keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+        loginWithPassword: async () => {
+          throw new Error('loginWithPassword must not be called for a fresh account')
+        },
+      })
+      expect(result.kind).toBe('skipped')
+    })
+  })
+
+  test('writes fresh tokens through the store, preserving email + encryptedPassword', async () => {
+    await withAgentDir(async (agentDir) => {
+      const key = generateKey()
+      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
+      await seedSecrets(agentDir, block)
+
+      const calls: Array<{ email: string; password: string }> = []
+      const fakeLogin: LoginWithPasswordFn = async (email, password) => {
+        calls.push({ email, password })
+        return freshLoginResult()
+      }
+
+      const result = await renewCurrentAccount({
+        containerName: 'webex',
+        agentDir,
+        keyStore: fakeKeyStore({ containerName: 'webex', key }),
+        loginWithPassword: fakeLogin,
+      })
+
+      expect(result.kind).toBe('ok')
+      expect(calls).toEqual([{ email: 'u@e.com', password: 'hunter2' }])
+
+      const raw = JSON.parse(await readFile(join(agentDir, 'secrets.json'), 'utf8'))
+      const persisted = raw.channels.webex.accounts['u-1']
+      expect(persisted.access_token).toBe('fresh-access')
+      expect(persisted.refresh_token).toBe('fresh-refresh')
+      expect(persisted.email).toBe('u@e.com')
+      expect(persisted.encryptedPassword?.kid).toBe(encryptedPassword.kid)
+      expect(persisted.expires_at).toBeGreaterThan(block.accounts['u-1']!.expires_at)
+    })
+  })
+
+  test('preserves created_at across renewals (only updated_at advances)', async () => {
+    await withAgentDir(async (agentDir) => {
+      const key = generateKey()
+      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const originalCreatedAt = '2026-01-01T00:00:00.000Z'
+      const block = buildBlock({
+        accountId: 'u-1',
+        expiresInHours: 1,
+        email: 'u@e.com',
+        encryptedPassword,
+        createdAt: originalCreatedAt,
+      })
+      await seedSecrets(agentDir, block)
+
+      const result = await renewCurrentAccount({
+        containerName: 'webex',
+        agentDir,
+        keyStore: fakeKeyStore({ containerName: 'webex', key }),
+        loginWithPassword: async () => freshLoginResult(),
+      })
+
+      expect(result.kind).toBe('ok')
+      const raw = JSON.parse(await readFile(join(agentDir, 'secrets.json'), 'utf8'))
+      const persisted = raw.channels.webex.accounts['u-1']
+      expect(persisted.created_at).toBe(originalCreatedAt)
+    })
+  })
+
+  test('reports reauth_required (not transient) on an SSO/MFA WebexError', async () => {
+    await withAgentDir(async (agentDir) => {
+      const key = generateKey()
+      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
+      await seedSecrets(agentDir, block)
+
+      const result = await renewCurrentAccount({
+        containerName: 'webex',
+        agentDir,
+        keyStore: fakeKeyStore({ containerName: 'webex', key }),
+        loginWithPassword: async () => {
+          throw Object.assign(new Error('Account requires MFA'), { code: 'mfa_required' })
+        },
+      })
+
+      expect(result.kind).toBe('reauth_required')
+      if (result.kind === 'reauth_required') expect(result.reason).toBe('mfa_required')
+    })
+  })
+
+  test('reports transient_failure when login throws for a non-auth reason', async () => {
+    await withAgentDir(async (agentDir) => {
+      const key = generateKey()
+      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
+      await seedSecrets(agentDir, block)
+
+      const result = await renewCurrentAccount({
+        containerName: 'webex',
+        agentDir,
+        keyStore: fakeKeyStore({ containerName: 'webex', key }),
+        loginWithPassword: async () => {
+          throw new Error('HTTP 503 from idbroker')
+        },
+      })
+
+      expect(result.kind).toBe('transient_failure')
+    })
+  })
+
+  test('returns reauth_required when email is missing, without calling loginWithPassword', async () => {
+    await withAgentDir(async (agentDir) => {
+      const block = buildBlock({ accountId: 'u-1', expiresInHours: 1 })
+      await seedSecrets(agentDir, block)
+
+      const result = await renewCurrentAccount({
+        containerName: 'webex',
+        agentDir,
+        keyStore: fakeKeyStore({ containerName: 'webex', key: null }),
+        loginWithPassword: async () => {
+          throw new Error('loginWithPassword must not be called when reauth is required')
+        },
+      })
+
+      expect(result.kind).toBe('reauth_required')
+    })
+  })
+})

--- a/src/secrets/webex-renewal.ts
+++ b/src/secrets/webex-renewal.ts
@@ -1,0 +1,215 @@
+import { join } from 'node:path'
+
+import { loginWithPassword as upstreamLoginWithPassword } from 'agent-messenger/webex'
+
+import { decrypt, EncryptionError } from './encryption'
+import { type KeyStore, KeyStoreError } from './keys'
+import { type WebexChannelBlock } from './schema'
+import { SecretsBackend } from './storage'
+import { SecretsWebexCredentialStore } from './webex-store'
+
+// Webex password-login access tokens live ~27h. The daily renewal tick fires
+// every 24h, so a token must be refreshed while it still has more than one
+// tick-interval of life left — otherwise it expires in the gap between two
+// ticks and every REST call (send, history, KMS key fetch) 401s while the
+// Mercury listener stays connected on its already-authenticated socket. We
+// renew when the token is within 8h of `expires_at`: that clears a full 24h
+// tick plus headroom for host sleep / daemon respawn, and a fresh token
+// minted on each tick keeps the window comfortably ahead of expiry.
+export const RENEWAL_WINDOW_MS = 8 * 60 * 60 * 1000
+
+export type WebexRenewalDecision =
+  | { kind: 'skip'; reason: 'no_account' | 'fresh_enough'; expiresInMs?: number }
+  | {
+      kind: 'reauth_required'
+      reason: 'no_password' | 'no_email' | 'key_missing' | 'decrypt_failed'
+      message: string
+    }
+  | { kind: 'should_renew'; account: WebexAccountSnapshot; password: string }
+
+export type WebexAccountSnapshot = {
+  account_id: string
+  email: string
+  created_at: string
+  updated_at: string
+}
+
+export type WebexRenewalAttempt =
+  | { kind: 'ok'; account_id: string; previousExpiresAt: number; nextExpiresAt: number }
+  | { kind: 'reauth_required'; account_id: string; reason: string; message: string }
+  | { kind: 'transient_failure'; account_id: string; reason: string }
+
+export type LoginWithPasswordFn = typeof upstreamLoginWithPassword
+
+export type WebexRenewalContext = {
+  containerName: string
+  agentDir: string
+  keyStore: KeyStore
+  now?: () => number
+  loginWithPassword?: LoginWithPasswordFn
+  idbrokerHost?: string
+}
+
+export async function decideRenewal(block: WebexChannelBlock, ctx: WebexRenewalContext): Promise<WebexRenewalDecision> {
+  const accountId = block.currentAccount
+  if (!accountId) return { kind: 'skip', reason: 'no_account' }
+  const account = block.accounts[accountId]
+  if (!account) return { kind: 'skip', reason: 'no_account' }
+
+  const now = (ctx.now ?? Date.now)()
+  const expiresInMs = account.expires_at - now
+  if (Number.isFinite(expiresInMs) && expiresInMs > RENEWAL_WINDOW_MS) {
+    return { kind: 'skip', reason: 'fresh_enough', expiresInMs }
+  }
+
+  if (!account.email) {
+    return {
+      kind: 'reauth_required',
+      reason: 'no_email',
+      message: `Webex account ${accountId} has no stored email — run \`typeclaw channel reauth webex\`.`,
+    }
+  }
+  if (!account.encryptedPassword) {
+    return {
+      kind: 'reauth_required',
+      reason: 'no_password',
+      message: `Webex account ${accountId} has no stored password — run \`typeclaw channel reauth webex\`.`,
+    }
+  }
+
+  let plaintextPassword: string
+  try {
+    const key = await ctx.keyStore.read(ctx.containerName)
+    plaintextPassword = decrypt(account.encryptedPassword, key, {
+      containerName: ctx.containerName,
+      accountId: account.account_id,
+    })
+  } catch (err) {
+    return classifyDecryptFailure(err, accountId)
+  }
+
+  return {
+    kind: 'should_renew',
+    account: {
+      account_id: account.account_id,
+      email: account.email,
+      created_at: account.created_at,
+      updated_at: account.updated_at,
+    },
+    password: plaintextPassword,
+  }
+}
+
+export async function renewCurrentAccount(
+  ctx: WebexRenewalContext,
+): Promise<WebexRenewalAttempt | { kind: 'skipped'; reason: string; expiresInMs?: number }> {
+  const secretsPath = join(ctx.agentDir, 'secrets.json')
+  const backend = new SecretsBackend(secretsPath)
+  const block = backend.readChannelsSync()?.webex
+  const parsed = parseBlockOrEmpty(block)
+  const decision = await decideRenewal(parsed, ctx)
+
+  if (decision.kind === 'skip') {
+    return {
+      kind: 'skipped',
+      reason: decision.reason,
+      ...(decision.expiresInMs !== undefined ? { expiresInMs: decision.expiresInMs } : {}),
+    }
+  }
+  if (decision.kind === 'reauth_required') {
+    return {
+      kind: 'reauth_required',
+      account_id: parsed.currentAccount ?? '',
+      reason: decision.reason,
+      message: decision.message,
+    }
+  }
+
+  const loginWithPassword = ctx.loginWithPassword ?? upstreamLoginWithPassword
+  const loginOptions = ctx.idbrokerHost !== undefined ? { idbrokerHost: ctx.idbrokerHost } : undefined
+
+  let result: Awaited<ReturnType<LoginWithPasswordFn>>
+  try {
+    result = await loginWithPassword(decision.account.email, decision.password, loginOptions)
+  } catch (err) {
+    return classifyLoginFailure(err, decision.account.account_id)
+  }
+
+  // The renewed login resolves to the same Webex user, so reuse the stored
+  // account_id rather than `result.userId`: the store keys accounts by id and a
+  // drifted id would orphan the record (and its encryptedPassword) instead of
+  // updating it. `setAccount` merges and preserves email/encryptedPassword.
+  const store = new SecretsWebexCredentialStore({ mode: 'host', secretsPath })
+  const nowIso = new Date().toISOString()
+  const previousExpiresAt = parsed.accounts[decision.account.account_id]?.expires_at ?? 0
+  await store.setAccount({
+    account_id: decision.account.account_id,
+    access_token: result.accessToken,
+    refresh_token: result.refreshToken,
+    expires_at: result.expiresAt,
+    device_url: result.deviceUrl,
+    user_id: result.userId,
+    created_at: decision.account.created_at,
+    updated_at: nowIso,
+    email: decision.account.email,
+  })
+
+  return {
+    kind: 'ok',
+    account_id: decision.account.account_id,
+    previousExpiresAt,
+    nextExpiresAt: result.expiresAt,
+  }
+}
+
+function parseBlockOrEmpty(value: unknown): WebexChannelBlock {
+  if (value === undefined) return { currentAccount: null, accounts: {} }
+  return value as WebexChannelBlock
+}
+
+function classifyLoginFailure(err: unknown, accountId: string): WebexRenewalAttempt {
+  const message = err instanceof Error ? err.message : String(err)
+  // agent-messenger's loginWithPassword throws WebexError with a `code` for
+  // unrecoverable auth states (SSO/IdP or MFA accounts that headless password
+  // login can't satisfy). Those need human reauth; everything else (network,
+  // 5xx, transient idbroker hiccup) is retried on the next tick.
+  const code = (err as { code?: unknown })?.code
+  if (code === 'sso_required' || code === 'mfa_required') {
+    return {
+      kind: 'reauth_required',
+      account_id: accountId,
+      reason: String(code),
+      message: `${message} — run \`typeclaw channel reauth webex\`.`,
+    }
+  }
+  return { kind: 'transient_failure', account_id: accountId, reason: message }
+}
+
+function classifyDecryptFailure(err: unknown, accountId: string): WebexRenewalDecision {
+  if (err instanceof KeyStoreError) {
+    if (err.code === 'missing') {
+      return {
+        kind: 'reauth_required',
+        reason: 'key_missing',
+        message: `Encryption key missing for Webex account ${accountId} — run \`typeclaw channel reauth webex\` to mint a fresh one.`,
+      }
+    }
+    return {
+      kind: 'reauth_required',
+      reason: 'key_missing',
+      message: `Encryption key for Webex account ${accountId} is unusable (${err.code}: ${err.message}). Move it aside and run \`typeclaw channel reauth webex\` to mint a fresh one.`,
+    }
+  }
+  if (err instanceof EncryptionError) {
+    return {
+      kind: 'reauth_required',
+      reason: 'decrypt_failed',
+      message: `Could not decrypt stored Webex password (${err.code}) — run \`typeclaw channel reauth webex\`.`,
+    }
+  }
+  return {
+    kind: 'reauth_required',
+    reason: 'decrypt_failed',
+    message: `Could not decrypt stored Webex password (${err instanceof Error ? err.message : String(err)}).`,
+  }
+}


### PR DESCRIPTION
## Background

A live agent stopped replying in Webex while still receiving messages. Root cause: Webex password-login access tokens live ~27h and were never renewed. The adapter (`src/channels/adapters/webex.ts`) logs in once at start with the stored access_token and keeps it in a `getToken` closure for the process lifetime. When the token expires, the Mercury WebSocket listener stays connected (it authenticated at boot) so inbound messages keep flowing — making the channel look healthy — but every outbound REST call uses the expired bearer token, so `channel_reply → client.sendMessage` returns HTTP 401. History fetch, membership resolution, and the KMS encryption-key fetch also 401.

Production logs: last successful send 10:04Z, token exp 11:38Z, first `channel_reply failed: ... HTTP 401` at 11:52Z (right after an idle-GC eviction forced a cold REST path). The only recovery today is a container restart (which forces a fresh `loginWithPassword`). The account record already stores `encryptedPassword` + `refresh_token` and the webex store already preserves them via `getAccountWithRenewalFields`/`mergeAccountPreservingRenewalFields` — the renewal consumer was just never built. KakaoTalk solved the same problem with a hostd renewal cron; this mirrors that design for Webex.

## Summary

Three stacked commits, one per layer:

1. `feat(secrets)` — `webex-renewal.ts`: decrypt the stored password with the host keystore, call agent-messenger `loginWithPassword`, persist the fresh token via the webex store; renews within 8h of `expires_at`.
2. `feat(hostd)` — `webex-renewal-manager.ts`: per-container tick with single-flight dedup and drain-awaits-in-flight, mirroring `kakao-renewal-manager.ts`. Ticks hourly rather than daily because Webex tokens live ~27h, so a 24h tick could let a token cross into the 8h renewal window and expire before the next tick.
3. `feat(hostd)` — wires `webexRenewal` into the daemon lifecycle (register / boot-restore / deregister / fatal-auth / shutdown) and `cli/hostd`.

**Key decisions (why X not Y):**

- **Why a host-side cron, not in agent-messenger or the adapter?** Renewal needs the host keystore to decrypt the password — by design that key is unreachable from inside the container. After minting a token, the live `WebexClient` still holds the stale token in its closure, so a container restart (`onRenewalOk`) is required, and only hostd can do that. agent-messenger correctly owns only the stateless `loginWithPassword` primitive, which already exists.
- **Why an hourly tick (vs KakaoTalk's 24h)?** Webex tokens live ~27h; a 24h tick could let a token cross into the 8h renewal window and expire before the next tick. Hourly is cheap because a fresh token short-circuits to a no-op skip.
- **Why renew on `expires_at` proximity, not `updated_at` age?** Webex stores a real expiry timestamp; KakaoTalk only had an age heuristic.

## What this does NOT do

- Does not touch agent-messenger — `loginWithPassword` already ships there (verified in the installed SDK).
- Does not add adapter-level 401-retry. The host renewal cron is the durable fix (needs the keystore + restart); an in-adapter `refresh_token` retry would be a nice complementary resilience layer but is out of scope.
- Does not change the Webex channel/credential schema beyond exporting an existing type (`WebexEncryptedPassword`).
- Does not handle SSO/MFA accounts — surfaced as `reauth_required` (a human must re-auth).

## Review notes

- **Load-bearing:** `onRenewalOk` must restart the container — without it the cron writes a fresh token to `secrets.json` but the running adapter keeps the stale one (the exact production bug). Covered by `webex-renewal-manager.test.ts`.
- **Keep coherent:** `RENEWAL_WINDOW_MS` (8h) vs the 1h tick vs the ~27h token life — documented inline.
- Daemon wiring matches the KakaoTalk cron 1:1, with parallel daemon tests added.
- All checks green locally: typecheck, lint (0 errors), format:check, full suite (9652 pass / 0 fail).