### PR TITLE
feat(channels): auto-refresh LINE access tokens before they expire

### DIFF
--- a/src/channels/adapters/line-token.test.ts
+++ b/src/channels/adapters/line-token.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test'
+
+import { decodeJwtExpMs, isTokenNearExpiry, LINE_TOKEN_REFRESH_SKEW_MS, nextRefreshDelayMs } from './line-token'
+
+function jwt(payload: Record<string, unknown>): string {
+  const b64 = (obj: Record<string, unknown>): string => Buffer.from(JSON.stringify(obj)).toString('base64url')
+  return `${b64({ typ: 'JWT', alg: 'HS256' })}.${b64(payload)}.sig`
+}
+
+describe('decodeJwtExpMs', () => {
+  test('returns exp in milliseconds', () => {
+    expect(decodeJwtExpMs(jwt({ exp: 1_781_785_105 }))).toBe(1_781_785_105_000)
+  })
+
+  test('returns null for a non-JWT string', () => {
+    expect(decodeJwtExpMs('not-a-jwt')).toBeNull()
+  })
+
+  test('returns null when exp is missing or non-numeric', () => {
+    expect(decodeJwtExpMs(jwt({ aud: 'LINE' }))).toBeNull()
+    expect(decodeJwtExpMs(jwt({ exp: 'soon' }))).toBeNull()
+  })
+
+  test('returns null for malformed base64 payload', () => {
+    expect(decodeJwtExpMs('a.@@@.c')).toBeNull()
+  })
+})
+
+describe('isTokenNearExpiry', () => {
+  const exp = 1_781_785_105_000
+
+  test('false when well outside the skew window', () => {
+    expect(isTokenNearExpiry(jwt({ exp: exp / 1000 }), exp - 2 * LINE_TOKEN_REFRESH_SKEW_MS)).toBe(false)
+  })
+
+  test('true once inside the skew window', () => {
+    expect(isTokenNearExpiry(jwt({ exp: exp / 1000 }), exp - LINE_TOKEN_REFRESH_SKEW_MS + 1)).toBe(true)
+  })
+
+  test('true for an already-expired token', () => {
+    expect(isTokenNearExpiry(jwt({ exp: exp / 1000 }), exp + 1)).toBe(true)
+  })
+
+  test('treats an undecodable token as needing refresh', () => {
+    expect(isTokenNearExpiry('garbage', Date.now())).toBe(true)
+  })
+})
+
+describe('nextRefreshDelayMs', () => {
+  const exp = 1_781_785_105_000
+
+  test('schedules toward the refresh window, capped at the daily re-check', () => {
+    // Window opens in 4 days, but the timer wakes at most daily to re-evaluate
+    // (it reschedules each tick), so the delay clamps to the 24h maximum.
+    const now = exp - 5 * LINE_TOKEN_REFRESH_SKEW_MS
+    expect(nextRefreshDelayMs(jwt({ exp: exp / 1000 }), now)).toBe(24 * 60 * 60 * 1000)
+  })
+
+  test('schedules to the exact window start when it is under the daily cap', () => {
+    const now = exp - LINE_TOKEN_REFRESH_SKEW_MS - 60 * 60 * 1000
+    expect(nextRefreshDelayMs(jwt({ exp: exp / 1000 }), now)).toBe(60 * 60 * 1000)
+  })
+
+  test('clamps to a minimum delay when already inside the window', () => {
+    expect(nextRefreshDelayMs(jwt({ exp: exp / 1000 }), exp)).toBe(60_000)
+  })
+
+  test('clamps to a maximum delay for a far-future expiry', () => {
+    const now = exp - 400 * 24 * 60 * 60 * 1000
+    expect(nextRefreshDelayMs(jwt({ exp: exp / 1000 }), now)).toBe(24 * 60 * 60 * 1000)
+  })
+
+  test('falls back to the minimum delay for an undecodable token', () => {
+    expect(nextRefreshDelayMs('garbage', Date.now())).toBe(60_000)
+  })
+})

--- a/src/channels/adapters/line-token.ts
+++ b/src/channels/adapters/line-token.ts
@@ -1,0 +1,55 @@
+// LINE access tokens (`auth_token`) are JWTs with a ~7-day lifetime. The adapter
+// schedules a proactive refresh ahead of expiry rather than waiting for the SDK's
+// reactive MUST_REFRESH_V3_TOKEN path, which only fires on a live request and
+// surfaces a cryptic failure when the token is already fully expired at startup.
+
+// Refresh once the token is within this window of its expiry. The LINE refresh
+// token lives ~365 days and rotates on use, so refreshing early is cheap and
+// leaves margin for missed timers (container asleep, listener reconnecting).
+export const LINE_TOKEN_REFRESH_SKEW_MS = 24 * 60 * 60 * 1000
+
+// Clamp the scheduled timer so a malformed or far-future `exp` can't push the
+// next refresh check beyond a day, and a near/past expiry retries promptly
+// rather than busy-looping.
+const MIN_REFRESH_DELAY_MS = 60 * 1000
+const MAX_REFRESH_DELAY_MS = 24 * 60 * 60 * 1000
+
+export function decodeJwtExpMs(token: string): number | null {
+  const parts = token.split('.')
+  if (parts.length < 2) return null
+  const payload = parts[1]
+  if (payload === undefined || payload === '') return null
+  try {
+    const json = Buffer.from(base64UrlToBase64(payload), 'base64').toString('utf-8')
+    const parsed: unknown = JSON.parse(json)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const exp = (parsed as { exp?: unknown }).exp
+    if (typeof exp !== 'number' || !Number.isFinite(exp)) return null
+    return exp * 1000
+  } catch {
+    return null
+  }
+}
+
+export function isTokenNearExpiry(token: string, now: number, skewMs = LINE_TOKEN_REFRESH_SKEW_MS): boolean {
+  const expMs = decodeJwtExpMs(token)
+  // A token we can't decode is treated as needing refresh: better to attempt a
+  // (cheap, idempotent) refresh than to sit on an opaque, possibly-dead token.
+  if (expMs === null) return true
+  return now >= expMs - skewMs
+}
+
+export function nextRefreshDelayMs(token: string, now: number, skewMs = LINE_TOKEN_REFRESH_SKEW_MS): number {
+  const expMs = decodeJwtExpMs(token)
+  if (expMs === null) return MIN_REFRESH_DELAY_MS
+  const target = expMs - skewMs
+  const delay = target - now
+  if (delay <= 0) return MIN_REFRESH_DELAY_MS
+  return Math.min(Math.max(delay, MIN_REFRESH_DELAY_MS), MAX_REFRESH_DELAY_MS)
+}
+
+function base64UrlToBase64(input: string): string {
+  const replaced = input.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = replaced.length % 4
+  return pad === 0 ? replaced : replaced + '='.repeat(4 - pad)
+}

--- a/src/channels/adapters/line.test.ts
+++ b/src/channels/adapters/line.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { LineChat, LineListenerEventMap, LineMessage, LineProfile, LineSendResult } from 'agent-messenger/line'
+import type {
+  LineAccountCredentials,
+  LineChat,
+  LineListenerEventMap,
+  LineMessage,
+  LineProfile,
+  LineSendResult,
+} from 'agent-messenger/line'
 
 import type { ChannelAdapterConfig } from '@/channels/schema'
 import type { InboundMessage, OutboundMessage } from '@/channels/types'
@@ -259,6 +266,184 @@ describe('createLineAdapter lifecycle', () => {
       credentialsStore: { load: async () => ({ current_account: null, accounts: {} }), getAccount: async () => null },
     })
     await expect(adapter.start()).rejects.toThrow(/no LINE account/)
+  })
+})
+
+describe('createLineAdapter token refresh', () => {
+  function expiringToken(expSecondsFromNow: number, nowMs: number): string {
+    const b64 = (obj: Record<string, unknown>): string => Buffer.from(JSON.stringify(obj)).toString('base64url')
+    const exp = Math.floor(nowMs / 1000) + expSecondsFromNow
+    return `${b64({ alg: 'HS256' })}.${b64({ exp })}.sig`
+  }
+
+  function storeWithAccount(authToken: string) {
+    const saved: LineAccountCredentials[] = []
+    const account: LineAccountCredentials = {
+      account_id: 'U_self',
+      auth_token: authToken,
+      device: 'DESKTOPMAC',
+      created_at: '',
+      updated_at: '',
+    }
+    return {
+      saved,
+      store: {
+        load: async () => ({ current_account: 'U_self', accounts: { U_self: account } }),
+        getAccount: async () => account,
+        setAccount: async (next: LineAccountCredentials) => {
+          saved.push(next)
+        },
+      },
+    }
+  }
+
+  test('refreshes a near-expiry token at startup and persists the new token', async () => {
+    const nowMs = 1_781_000_000_000
+    const { saved, store } = storeWithAccount(expiringToken(60, nowMs))
+    const client = fakeClient({
+      ensureFreshAuthToken: async () => 'fresh-token',
+    })
+
+    const adapter = createLineAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client,
+      listenerFactory: () => new FakeListener(),
+      credentialsStore: store,
+      now: () => nowMs,
+    })
+
+    await adapter.start()
+
+    expect(saved).toHaveLength(1)
+    expect(saved[0]!.auth_token).toBe('fresh-token')
+    expect(saved[0]!.account_id).toBe('U_self')
+    await adapter.stop()
+  })
+
+  test('persists a token delivered via the onTokenUpdate event', async () => {
+    const nowMs = 1_781_000_000_000
+    const { saved, store } = storeWithAccount(expiringToken(60 * 60 * 24 * 30, nowMs))
+    let tokenListener: ((t: string) => void) | undefined
+    const client = fakeClient({
+      onTokenUpdate: (listener) => {
+        tokenListener = listener
+      },
+    })
+
+    const adapter = createLineAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client,
+      listenerFactory: () => new FakeListener(),
+      credentialsStore: store,
+      now: () => nowMs,
+    })
+
+    await adapter.start()
+    expect(tokenListener).toBeDefined()
+    tokenListener!('rotated-token')
+    await waitFor(() => saved.length > 0)
+
+    expect(saved.at(-1)!.auth_token).toBe('rotated-token')
+    await adapter.stop()
+  })
+
+  test('retries persistence with the same token after a failed write', async () => {
+    const nowMs = 1_781_000_000_000
+    const account: LineAccountCredentials = {
+      account_id: 'U_self',
+      auth_token: expiringToken(60 * 60 * 24 * 30, nowMs),
+      device: 'DESKTOPMAC',
+      created_at: '',
+      updated_at: '',
+    }
+    const saved: LineAccountCredentials[] = []
+    let failNext = true
+    const store = {
+      load: async () => ({ current_account: 'U_self', accounts: { U_self: account } }),
+      getAccount: async () => account,
+      setAccount: async (next: LineAccountCredentials) => {
+        if (failNext) {
+          failNext = false
+          throw new Error('secrets-patch failed: hostd unreachable')
+        }
+        saved.push(next)
+      },
+    }
+    let tokenListener: ((t: string) => void) | undefined
+    const client = fakeClient({
+      onTokenUpdate: (listener) => {
+        tokenListener = listener
+      },
+    })
+
+    const adapter = createLineAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client,
+      listenerFactory: () => new FakeListener(),
+      credentialsStore: store,
+      now: () => nowMs,
+    })
+
+    await adapter.start()
+
+    tokenListener!('rotated-token')
+    await waitFor(() => failNext === false)
+    expect(saved).toHaveLength(0)
+
+    tokenListener!('rotated-token')
+    await waitFor(() => saved.length > 0)
+    expect(saved.at(-1)!.auth_token).toBe('rotated-token')
+    await adapter.stop()
+  })
+
+  test('a refresh failure at startup is non-fatal', async () => {
+    const nowMs = 1_781_000_000_000
+    const { saved, store } = storeWithAccount(expiringToken(60, nowMs))
+    const client = fakeClient({
+      ensureFreshAuthToken: async () => {
+        throw new Error('refresh endpoint 500')
+      },
+    })
+
+    const adapter = createLineAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client,
+      listenerFactory: () => new FakeListener(),
+      credentialsStore: store,
+      now: () => nowMs,
+    })
+
+    await expect(adapter.start()).resolves.toBeUndefined()
+    expect(saved).toHaveLength(0)
+    await adapter.stop()
+  })
+
+  test('a client without the refresh surface starts cleanly (SDK version skew)', async () => {
+    const nowMs = 1_781_000_000_000
+    const { saved, store } = storeWithAccount(expiringToken(60, nowMs))
+    const client = fakeClient()
+
+    const adapter = createLineAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client,
+      listenerFactory: () => new FakeListener(),
+      credentialsStore: store,
+      now: () => nowMs,
+    })
+
+    await expect(adapter.start()).resolves.toBeUndefined()
+    expect(saved).toHaveLength(0)
+    await adapter.stop()
   })
 })
 

--- a/src/channels/adapters/line.ts
+++ b/src/channels/adapters/line.ts
@@ -29,6 +29,7 @@ import { splitInboundLine } from './line-attachment'
 import { createLineChannelResolver } from './line-channel-resolver'
 import { classifyInbound } from './line-classify'
 import { toLinePlainText } from './line-format'
+import { LINE_TOKEN_REFRESH_SKEW_MS, nextRefreshDelayMs } from './line-token'
 
 // Structural duck-type of the upstream LineClient class. Declaring this as an
 // interface (rather than reusing the nominal class type) lets test fakes
@@ -41,6 +42,11 @@ export interface LineClient {
   getMessages(chatId: string, options?: { count?: number }): Promise<LineMessage[]>
   sendMessage(chatId: string, text: string): Promise<LineSendResult>
   close(): void
+  // Optional on the structural type: older SDK builds predate the refresh
+  // surface, so the adapter feature-detects both before using them and a
+  // missing method degrades to "no proactive refresh" rather than a crash.
+  ensureFreshAuthToken?: (options?: { skewMs?: number }) => Promise<string | null>
+  onTokenUpdate?: (listener: (authToken: string) => void) => void
 }
 
 export interface LineListener {
@@ -53,6 +59,7 @@ export interface LineListener {
 export type LineCredentialStore = {
   load(): Promise<LineConfig>
   getAccount(id?: string): Promise<LineAccountCredentials | null>
+  setAccount?(account: LineAccountCredentials): Promise<void>
 }
 
 const LineClient = RealLineClient as unknown as new (credManager?: LineCredentialManager) => LineClient
@@ -79,6 +86,7 @@ export type LineAdapterOptions = {
   client?: LineClient
   clientFactory?: (credManager?: LineCredentialManager) => LineClient
   listenerFactory?: (client: LineClient) => LineListener
+  now?: () => number
 }
 
 export type LineAdapter = {
@@ -181,6 +189,14 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
   let started = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null
+  // currentAuthToken tracks the freshest known token for refresh SCHEDULING;
+  // lastPersistedToken is the dedupe marker and only advances after a write to
+  // secrets actually succeeds, so a failed persist can be retried with the same
+  // token instead of being silently swallowed by the dedupe early-return.
+  let currentAuthToken: string | null = null
+  let lastPersistedToken: string | null = null
+  const now = options.now ?? Date.now
 
   const channelResolver = createLineChannelResolver({ client, logger })
 
@@ -198,6 +214,51 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
   })
 
   const outboundCallback = createOutboundCallback({ client, logger, formatChannelTag })
+
+  // The SDK's AuthService updates the LIVE client's token in-place and emits this
+  // event; we mirror it into secrets.json so the next container start boots from a
+  // fresh token instead of a dead one. The refresh token (which rotates on use)
+  // stays the SDK FileStorage's responsibility and is never copied here.
+  const persistAuthToken = async (authToken: string): Promise<void> => {
+    currentAuthToken = authToken
+    if (authToken === lastPersistedToken) return
+    const store = options.credentialsStore
+    if (!store?.setAccount) return
+    try {
+      const account = await store.getAccount()
+      if (account === null) return
+      await store.setAccount({ ...account, auth_token: authToken, updated_at: new Date(now()).toISOString() })
+      lastPersistedToken = authToken
+      logger.info('[line] persisted refreshed auth token to secrets')
+    } catch (err) {
+      logger.warn(`[line] failed to persist refreshed auth token: ${describe(err)}`)
+    }
+  }
+
+  const refreshNow = async (): Promise<void> => {
+    if (!client.ensureFreshAuthToken) return
+    try {
+      const token = await client.ensureFreshAuthToken({ skewMs: LINE_TOKEN_REFRESH_SKEW_MS })
+      if (token) await persistAuthToken(token)
+    } catch (err) {
+      logger.warn(`[line] token refresh failed: ${describe(err)}`)
+    }
+  }
+
+  const scheduleRefresh = (): void => {
+    if (refreshTimer !== null) clearTimeout(refreshTimer)
+    if (!client.ensureFreshAuthToken) return
+    const token = currentAuthToken
+    const delay = token ? nextRefreshDelayMs(token, now()) : LINE_TOKEN_REFRESH_SKEW_MS
+    refreshTimer = setTimeout(() => {
+      void (async () => {
+        if (!started) return
+        await refreshNow()
+        if (started) scheduleRefresh()
+      })()
+    }, delay)
+    refreshTimer.unref?.()
+  }
 
   const processInbound = async (event: LinePushMessageEvent): Promise<void> => {
     inflightInbounds++
@@ -255,6 +316,10 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
     async start(): Promise<void> {
       if (started) return
       started = true
+      client.onTokenUpdate?.((authToken) => {
+        void persistAuthToken(authToken)
+      })
+
       try {
         const credentialStore = options.credentialsStore ?? null
         if (credentialStore !== null) {
@@ -262,6 +327,8 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
           if (account === null) {
             throw new Error('no LINE account in secrets.json#channels.line (run typeclaw init to authenticate)')
           }
+          currentAuthToken = account.auth_token
+          lastPersistedToken = account.auth_token
           await client.login(account)
         } else {
           await client.login()
@@ -271,6 +338,9 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
         logger.error(`[line] login failed: ${describe(err)}`)
         throw err
       }
+
+      await refreshNow()
+      scheduleRefresh()
 
       try {
         const profile = await client.getProfile()
@@ -329,6 +399,10 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
     async stop(): Promise<void> {
       if (!started) return
       started = false
+      if (refreshTimer !== null) {
+        clearTimeout(refreshTimer)
+        refreshTimer = null
+      }
       options.router.unregisterOutbound('line', outboundCallback)
       options.router.unregisterChannelNameResolver('line', channelResolver.resolve)
       options.router.unregisterHistory('line', historyCallback)


### PR DESCRIPTION
## Background

A live agent stopped responding on LINE after a container restart, with the cryptic startup error `adapter "line" failed to start: undefined is not an object (evaluating 'res.data.e.code')`. Root cause was twofold:

1. **Token expiry, never renewed.** The LINE adapter (`src/channels/adapters/line.ts`) logs in once at start with the stored `auth_token` — a ~7-day JWT — and keeps it for the process lifetime. There was no renewal path at all. Once the JWT expired, every `start()` failed and the channel stayed down until a manual QR/email re-auth.

2. **The SDK's refresh is reactive-only.** agent-messenger's vendored linejs has refresh machinery (`AuthService.tryRefreshToken()` driven off `update:authtoken`), but it only fires when a *live request* gets a `MUST_REFRESH_V3_TOKEN` response. The wrapper's `login()` starts from the stale JWT, so a fully-expired token at boot fails server-side before the refresh path can ever run. (The opaque `TypeError` is a separate SDK null-guard bug, handled upstream.)

The account already has everything renewal needs: the LINE refresh token lives in the SDK's per-account `FileStorage` (bind-mounted, survives restarts, reachable in-container), is valid ~365 days, and rotates on use. So unlike Webex/KakaoTalk — which need the host keystore to decrypt a stored password and therefore renew host-side (#1001) — LINE can refresh **in-container without a restart**: the SDK mutates the live client's token in place and emits an event. This PR builds the consumer that was missing.

## Summary

Drive refresh proactively from the adapter, in three small pieces:

- **`line-token.ts`** — decode the `auth_token` JWT `exp` and compute when it enters a 24h refresh skew window, clamped to a daily re-check. Pure, unit-tested.
- **Adapter wiring** — at startup and on a self-rescheduling timer, call the SDK's `ensureFreshAuthToken()`; also subscribe to `onTokenUpdate` for tokens the SDK rotates on its own (e.g. reactive `MUST_REFRESH`). Every refreshed access token is mirrored back into `secrets.json` so the next restart boots from a live token.

**Why X not Y:**

- **Why in-container, not a hostd cron like Webex/Kakao?** Those are host-side *only* because renewal needs the keystore to decrypt a password, and the live client holds a stale token in a closure → must restart. Neither applies to LINE: no password/keystore (refresh token is plaintext in a host-and-container-readable file), and the SDK updates the live client in place, so no restart is needed. A host cron would add restart churn and a host/container double-refresh race against a *rotating* token.
- **Why are `ensureFreshAuthToken`/`onTokenUpdate` optional on the client type?** Same structural duck-typing the file already uses for `LineClient`. An SDK build that predates the refresh surface degrades to "no proactive refresh" instead of crashing — no hard version pin.
- **Why never copy the refresh token into `secrets.json`?** It rotates on use; a stale copy is worse than none. The SDK `FileStorage` stays the single source of truth for refresh state; `secrets.json` only holds the current *access* token snapshot needed to bootstrap.

## What this does NOT do

- Does not touch agent-messenger. It depends on the SDK exposing `ensureFreshAuthToken()` + `onTokenUpdate` and fixing the expired-token `login()` fallback / `res.data.e.code` null-guard — those land in a separate upstream PR. This adapter feature-detects both and is a safe no-op until they ship.
- Does not add a hostd LINE renewal cron (see Summary for why).
- Does not change the LINE channel/credential schema.
- Does not handle a fully-expired *refresh* token (~365d) — that still requires interactive QR/email re-auth, a LINE platform constraint.

## Review notes

- **Load-bearing invariant:** the rotating refresh token is never written to `secrets.json` (`persistAuthToken` only ever sets `auth_token`). Violating this strands a dead token across restarts.
- **Non-fatal by design:** all refresh failures are caught and logged; a refresh error can never take the channel down at start. Covered by the "refresh failure at startup is non-fatal" and "SDK version skew" tests.
- **Timer:** `unref()`'d and self-reschedules off the freshest token's `exp`; cleared in `stop()`. The daily max-delay clamp means the timer re-evaluates at most once a day rather than sleeping for the full multi-day gap.
- Tests: `line-token.test.ts` (decode/window/clamp edge cases) and four new adapter cases (startup refresh persists; `onTokenUpdate` persists; failure non-fatal; missing-surface no-op). Full suite green locally: typecheck, lint (0 errors), format:check, 9639 pass / 0 fail.
