### PR TITLE
fix(channels): stop Webex self-echo and fail fast on cold-start history

### DIFF
--- a/src/channels/adapters/webex-bot-classify.test.ts
+++ b/src/channels/adapters/webex-bot-classify.test.ts
@@ -35,6 +35,30 @@ describe('classifyInbound', () => {
     })
   })
 
+  test('drops self-authored messages by email when personRef desyncs from the bot ref', () => {
+    expect(
+      classifyInbound(
+        message({ personRef: 'uuid-from-mercury', personEmail: 'typeey@typeclaw.dev' }),
+        config,
+        'legacy-email-ref',
+        [],
+        'typeey@typeclaw.dev',
+      ),
+    ).toEqual({ kind: 'drop', reason: 'self_author' })
+  })
+
+  test('self-email match is case-insensitive', () => {
+    expect(
+      classifyInbound(
+        message({ personRef: 'uuid-from-mercury', personEmail: 'TypeEy@TypeClaw.DEV' }),
+        config,
+        'legacy-email-ref',
+        [],
+        'typeey@typeclaw.dev',
+      ),
+    ).toEqual({ kind: 'drop', reason: 'self_author' })
+  })
+
   test('drops empty messages without files', () => {
     expect(classifyInbound(message({ text: '' }), config, 'bot-1')).toEqual({ kind: 'drop', reason: 'empty_content' })
   })

--- a/src/channels/adapters/webex-bot-classify.ts
+++ b/src/channels/adapters/webex-bot-classify.ts
@@ -12,13 +12,18 @@ export type InboundClassification =
   | { kind: 'drop'; reason: InboundDropReason }
   | { kind: 'route'; payload: InboundMessage }
 
+// `botPersonEmail` is a second self-identity anchor alongside `botPersonRef`:
+// legacy Hydra accounts can decode the bot identity to an email on one side and a
+// UUID on the other, so a ref-only check leaks the agent's own reply back as a
+// new inbound. Matching personEmail closes that echo loop. See webex-classify.ts.
 export function classifyInbound(
   event: WebexInboundMessage,
   _config: ChannelAdapterConfig,
   botPersonRef: string | null,
   selfAliases: readonly string[] = [],
+  botPersonEmail: string | null = null,
 ): InboundClassification {
-  if (botPersonRef !== null && event.personRef === botPersonRef) {
+  if (isSelfAuthor(event, botPersonRef, botPersonEmail)) {
     return { kind: 'drop', reason: 'self_author' }
   }
 
@@ -64,6 +69,14 @@ export function classifyInbound(
       ts: Number.isFinite(ts) ? ts : 0,
     },
   }
+}
+
+function isSelfAuthor(event: WebexInboundMessage, botPersonRef: string | null, botPersonEmail: string | null): boolean {
+  if (botPersonRef !== null && event.personRef === botPersonRef) return true
+  if (botPersonEmail !== null && event.personEmail !== '') {
+    return event.personEmail.toLowerCase() === botPersonEmail.toLowerCase()
+  }
+  return false
 }
 
 type SplitInbound = { text: string; attachments: InboundAttachment[] }

--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -249,6 +249,19 @@ describe('webex history and membership', () => {
     await expect(cb({ chat: 'room-1', thread: null, limit: 10 })).resolves.toEqual({ ok: false, error: 'down' })
   })
 
+  test('fails fast when listMessages hangs past the cold-start timeout', async () => {
+    const cb = createWebexHistoryCallback({
+      client: { listMessages: () => new Promise<ReturnType<typeof webexMessage>[]>(() => {}) },
+      logger: logger(),
+      botPersonIdRef: () => 'bot-1',
+      timeoutMs: 20,
+    })
+    const start = Date.now()
+    const res = await cb({ chat: 'room-1', thread: null, limit: 10 })
+    expect(res.ok).toBe(false)
+    expect(Date.now() - start).toBeLessThan(500)
+  })
+
   test('resolves direct and group membership, falling back to history on failure', async () => {
     const history = createWebexHistoryCallback({
       client: {

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -297,6 +297,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
         options.configRef(),
         botSnapshot?.ref ?? null,
         options.selfAliasesRef?.() ?? [],
+        botSnapshot?.emails[0] ?? null,
       )
       if (verdict.kind === 'drop') {
         logger.info(`[webex-bot] dropped id=${event.ref} reason=${verdict.reason}${dropHint(verdict.reason)}`)

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -136,14 +136,24 @@ async function defaultReadFile(path: string): Promise<WebexOutboundFile> {
   return { content: Bun.file(path), filename: path.split('/').pop() ?? 'attachment' }
 }
 
+// See webex.ts: the bot client has no AbortSignal either, so a hung listMessages
+// is bounded by a tighter internal deadline than the router's 5s history ceiling.
+const WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS = 2500
+
 export function createWebexHistoryCallback(deps: {
   client: Pick<WebexBotClient, 'listMessages'>
   logger: WebexBotAdapterLogger
   botPersonIdRef: () => string | null
+  timeoutMs?: number
 }): HistoryCallback {
+  const timeoutMs = deps.timeoutMs ?? WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS
   return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
     try {
-      const messages = await deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) })
+      const messages = await raceWithTimeout(
+        deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) }),
+        timeoutMs,
+        '[webex-bot] history fetch',
+      )
       return { ok: true, messages: messages.map((m) => mapWebexHistoryMessage(m, deps.botPersonIdRef())).reverse() }
     } catch (err) {
       const message = describe(err)
@@ -450,6 +460,18 @@ function clampLimit(requested: number, max: number): number {
 
 function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  try {
+    return await Promise.race([work, timeout])
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+  }
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/adapters/webex-classify.test.ts
+++ b/src/channels/adapters/webex-classify.test.ts
@@ -35,6 +35,45 @@ describe('classifyInbound for Webex user channel', () => {
     })
   })
 
+  test('drops self-authored messages by email when personRef desyncs from the bot ref', () => {
+    // Legacy Hydra accounts can surface the bot identity as an email while the
+    // Mercury event carries a UUID personRef (or vice versa), so a ref-only
+    // self-check leaks the agent's own message back as a new inbound. Matching
+    // personEmail against the bot's email closes that echo loop.
+    expect(
+      classifyInbound(
+        message({ personRef: 'uuid-from-mercury', personEmail: 'typeey@typeclaw.dev' }),
+        config,
+        'legacy-email-ref',
+        [],
+        'typeey@typeclaw.dev',
+      ),
+    ).toEqual({ kind: 'drop', reason: 'self_author' })
+  })
+
+  test('self-email match is case-insensitive', () => {
+    expect(
+      classifyInbound(
+        message({ personRef: 'uuid-from-mercury', personEmail: 'TypeEy@TypeClaw.DEV' }),
+        config,
+        'legacy-email-ref',
+        [],
+        'typeey@typeclaw.dev',
+      ),
+    ).toEqual({ kind: 'drop', reason: 'self_author' })
+  })
+
+  test('does not drop a human whose email differs from the bot email', () => {
+    const verdict = classifyInbound(
+      message({ personRef: 'human-ref', personEmail: 'human@example.com', text: 'typeclaw hi' }),
+      config,
+      'self-1',
+      ['typeclaw'],
+      'typeey@typeclaw.dev',
+    )
+    expect(verdict.kind).toBe('route')
+  })
+
   test('drops empty messages without files', () => {
     expect(classifyInbound(message({ text: '' }), config, 'self-1')).toEqual({ kind: 'drop', reason: 'empty_content' })
   })

--- a/src/channels/adapters/webex-classify.ts
+++ b/src/channels/adapters/webex-classify.ts
@@ -16,13 +16,20 @@ export type InboundClassification =
 // `botPersonRef` is the bot's decoded UUID ref (from WebexPerson.ref), matched
 // against the event's *Ref fields so identity comparison happens entirely in
 // ref-space — the same currency typeclaw now stores as ChannelKey/authorId.
+//
+// `botPersonEmail` is a second self-identity anchor: legacy Hydra accounts can
+// surface the bot's ref as an email on one side (`/people/me`) and a UUID on the
+// other (Mercury event), so a ref-only check leaks the agent's own reply back as
+// a new inbound and burns a full prompt cycle. Matching personEmail closes that
+// echo loop regardless of which side decoded to which form.
 export function classifyInbound(
   event: WebexInboundMessage,
   _config: ChannelAdapterConfig,
   botPersonRef: string | null,
   selfAliases: readonly string[] = [],
+  botPersonEmail: string | null = null,
 ): InboundClassification {
-  if (botPersonRef !== null && event.personRef === botPersonRef) {
+  if (isSelfAuthor(event, botPersonRef, botPersonEmail)) {
     return { kind: 'drop', reason: 'self_author' }
   }
 
@@ -70,6 +77,14 @@ export function classifyInbound(
       ts: Number.isFinite(ts) ? ts : 0,
     },
   }
+}
+
+function isSelfAuthor(event: WebexInboundMessage, botPersonRef: string | null, botPersonEmail: string | null): boolean {
+  if (botPersonRef !== null && event.personRef === botPersonRef) return true
+  if (botPersonEmail !== null && event.personEmail !== '') {
+    return event.personEmail.toLowerCase() === botPersonEmail.toLowerCase()
+  }
+  return false
 }
 
 type SplitInbound = { text: string; attachments: InboundAttachment[] }

--- a/src/channels/adapters/webex.test.ts
+++ b/src/channels/adapters/webex.test.ts
@@ -325,4 +325,18 @@ describe('createWebexHistoryCallback reply attribution', () => {
     const history = await historyOf([child], 'bot-1')
     expect(history.find((m) => m.externalMessageId === 'child-1')?.replyToBotMessageId).toBeNull()
   })
+
+  test('fails fast when listMessages hangs past the cold-start timeout', async () => {
+    const cb = createWebexHistoryCallback({
+      client: { listMessages: () => new Promise<WebexMessage[]>(() => {}) },
+      logger: logger(),
+      botPersonIdRef: () => 'bot-1',
+      timeoutMs: 20,
+    })
+    const start = Date.now()
+    const res = await cb({ chat: 'room-1', thread: null, limit: 50 })
+    const elapsed = Date.now() - start
+    expect(res.ok).toBe(false)
+    expect(elapsed).toBeLessThan(500)
+  })
 })

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -305,6 +305,7 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
         options.configRef(),
         botSnapshot?.ref ?? null,
         options.selfAliasesRef?.() ?? [],
+        botSnapshot?.emails[0] ?? null,
       )
       if (verdict.kind === 'drop') {
         logger.info(`[webex] dropped id=${event.ref} reason=${verdict.reason}${dropHint(verdict.reason)}`)

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -141,14 +141,27 @@ async function defaultReadFile(path: string): Promise<WebexOutboundFile> {
   return { content: Bun.file(path), filename: path.split('/').pop() ?? 'attachment' }
 }
 
+// The Webex REST/internal client offers no AbortSignal, so a hung `listMessages`
+// would otherwise block cold-start prefetch for the router's full 5s history
+// ceiling before degrading. Racing it against a tighter internal deadline lets
+// prefetch fall back to membership-derivation (or skip) seconds sooner, mirroring
+// the cold-fetch fail-fast posture the membership resolver already uses.
+const WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS = 2500
+
 export function createWebexHistoryCallback(deps: {
   client: Pick<WebexClient, 'listMessages'>
   logger: WebexAdapterLogger
   botPersonIdRef: () => string | null
+  timeoutMs?: number
 }): HistoryCallback {
+  const timeoutMs = deps.timeoutMs ?? WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS
   return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
     try {
-      const messages = await deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) })
+      const messages = await raceWithTimeout(
+        deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) }),
+        timeoutMs,
+        '[webex] history fetch',
+      )
       const authorById = new Map(messages.map((m) => [m.ref, m.personRef]))
       const botPersonId = deps.botPersonIdRef()
       return { ok: true, messages: messages.map((m) => mapWebexHistoryMessage(m, botPersonId, authorById)).reverse() }
@@ -481,6 +494,18 @@ function clampLimit(requested: number, max: number): number {
 
 function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
+}
+
+async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  try {
+    return await Promise.race([work, timeout])
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+  }
 }
 
 function dropHint(reason: InboundDropReason): string {


### PR DESCRIPTION
## Background

Webex felt noticeably slower to respond than other channels. Live container-log investigation found two Webex-specific costs on top of channel-agnostic model inference:

1. **Self-echo — a wasted prompt cycle per reply.** The agent's own outbound came back as a new inbound (`[webex] inbound … author=<bot>`), routed as a mention, and ran a full second prompt turn before being discarded as `skipped_by_tool` (~10s wasted). Despite the SDK listener using `ignoreSelfMessages: true`, zero `self_author` drops were logged. Root cause: `classifyInbound` compares only the decoded UUID `personRef`, but legacy "Hydra" Webex accounts can decode the bot identity to an email on one side (`/people/me`, the bot's stored identity) and a UUID on the other (the Mercury `message_created` event), or vice-versa. When the two forms disagree the ref-only equality misses, the SDK's own UUID-based `botPersonId` filter can miss for the same reason, and the echo leaks.

2. **Cold-start history hang — up to 5s of dead air.** First message to an idle room calls `listMessages`, which hung and was only bounded by the router's 5s `fetchHistoryTimeoutMs` before degrading to `history-not-supported`. `listMessages` exposes no AbortSignal.

## Summary

- **Self-echo:** harden `classifyInbound` in both `webex` and `webex-bot` adapters to also drop when `personEmail` matches the bot's email (case-insensitive), in addition to the existing `personRef` check. Thread the bot email (`botPerson.emails[0]`) through from each adapter. Email is a second identity anchor that survives the legacy ref/UUID desync. Keep (not replace) the ref check; do not rely on the SDK's `ignoreSelfMessages` as the sole guard.

- **Cold-start history:** race `listMessages` against a tighter internal deadline (2500ms) in each Webex history callback. On timeout it returns `ok: false` so prefetch falls back to membership-derivation or skips seconds sooner — mirroring the membership resolver's cold-fetch posture. A manual race (not abort) because the client has no AbortSignal.

## What this does NOT do

- No typing indicator: Cisco Webex's Messaging API and Mercury protocol expose no typing-indicator endpoint for bots, and the agent-messenger SDK has no typing method (confirmed against Cisco docs/community and the SDK source). This PR intentionally omits it.
- Does not touch the channel-agnostic debounce window or model inference time (the dominant latency), and changes no config surface.

## Review notes

- Load-bearing change: `isSelfAuthor` in `webex-classify.ts` and `webex-bot-classify.ts`. Invariants verified by tests: a human whose email differs from the bot's still routes; a self-message whose `personRef` desyncs but `personEmail` matches the bot drops.
- The 2500ms history deadline is intentionally below the router's 5s ceiling; it only speeds the failure path and does not affect the healthy path (a fast `listMessages` returns immediately).
- Tests cover both behaviors including non-Latin (Korean) inbound in the existing suite. Full suite green (9629 pass / 0 fail).