### PR TITLE
fix(agent): nudge the bot to resolve review threads in the same reply

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -205,6 +205,33 @@ describe('renderSessionOrigin', () => {
     expect(out).toMatch(/skip_response/)
   })
 
+  test('github review-thread origin tells the bot to resolve the thread in the same reply', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'pr:7',
+      thread: '12345',
+    })
+    // guards the real failure: agent addresses review-comment feedback and ends
+    // the turn without resolving, leaving threads open forever
+    expect(out).toMatch(/resolve_review_thread: true/)
+    expect(out).toMatch(/same call/i)
+    expect(out).toMatch(/leaves the thread open|open forever/i)
+  })
+
+  test('github top-level (no-thread) origin omits the resolve-thread instruction', () => {
+    const out = renderSessionOrigin({
+      kind: 'channel',
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'pr:7',
+      thread: null,
+    })
+    // a top-level PR/issue comment has no thread to resolve; the flag is a no-op
+    expect(out).not.toContain('resolve_review_thread')
+  })
+
   test('discord channel origin tells the bot to emit bare pipe tables, not fenced ones', () => {
     const out = renderSessionOrigin({
       kind: 'channel',

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -370,6 +370,27 @@ function renderChannelOrigin(
       'One verdict, one surface. After submitting the review, use',
       '`skip_response({ reason: "verdict posted as review" })`.',
     )
+
+    // Models reliably address review-comment feedback and then end the turn
+    // WITHOUT resolving the thread — leaving a wall of "open" threads on the PR.
+    // The `resolve_review_thread` flag lives only in the tool description, which
+    // the model reads at call time and routinely skips. The resolve cannot run
+    // in a later turn (a successful reply ends the turn), so a bare ack strands
+    // the thread permanently. Gate on `thread`: a top-level PR/issue comment has
+    // no thread to resolve, and the flag is a no-op there.
+    if (origin.thread !== null) {
+      lines.push(
+        '',
+        '**This is an inline review thread. When your reply acknowledges the',
+        'concern is fixed/addressed, set `resolve_review_thread: true` on that',
+        '`channel_reply` — in the SAME call.** A bare acknowledgement leaves the',
+        'thread open forever: the resolve only runs as part of this reply, never',
+        'in a later turn. It is safe to set by default — the runtime resolves',
+        "only threads you authored and refuses on a human reviewer's thread.",
+        'Leave it unset only when you mean to keep the thread open (partial fix,',
+        'disagreement, mid-discussion).',
+      )
+    }
   }
 
   // Discord renders no GFM tables — a raw `| a | b |` block shows as literal


### PR DESCRIPTION
## Problem

The agent reliably **addresses** GitHub review-comment feedback and then ends the turn **without resolving the review thread**, leaving a wall of "open" threads on the PR even after the concerns are fixed.

### Root cause

The `resolve_review_thread: true` flag is the only way a thread actually closes (the resolve runs as part of the reply — a successful reply ends the turn, so it can't run in a later turn). But the instruction to set it lived **only** in the `channel_reply` tool-parameter description, which the model reads at call time and routinely skips. There was **no instruction in the system prompt itself**:

- `session-origin.ts` (the always-present github prompt) covered verdicts, "On it" acks, and duplicate posting — but said nothing about resolving threads.
- The only proactive resolve nudge (`followupInstruction` in `inbound.ts`) fires only on the `pull_request.synchronize` push-recheck path — not on direct replies to review comments.

## Fix

Inject an explicit instruction into the **github session-origin system prompt** whenever the turn is inside an inline review thread (`origin.thread !== null`), telling the bot to set `resolve_review_thread: true` on the same `channel_reply`. This is the highest-leverage spot: it's always present (no lazy skill load required) and covers both the direct review-comment-reply path and the push-recheck path, since both carry `thread`.

The instruction is **gated on `thread`**: a top-level PR/issue comment has no thread to resolve, and the flag is a no-op there, so the nudge is omitted.

## Why not also patch the inbound text?

The direct review-comment-reply inbound already carries `thread: <rootCommentId>`, so the system-prompt instruction covers it without mutating the user-visible comment text (which would pollute the public-comment context the model reads). One injection point, no double-nudging.

## Tests

- New: instruction **present** when `thread` is set, asserting `resolve_review_thread: true` / "same call" / "open".
- New: instruction **absent** for top-level (no-thread) origins.
- Existing `session-origin` suite (83 tests) and the `dump-system-prompt` cache-suffix guard test pass unchanged.

`bun run typecheck`, `bun run lint` (0 errors), `bun run format` all clean.