### PR TITLE
fix(container): resolve docker binary via Bun.which on Windows

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -13,6 +13,7 @@ import {
   containerNameFromCwd,
   DOCKER_NOT_FOUND_STDERR,
   dockerBindMount,
+  dockerCmd,
   type DockerExec,
   imageTagFromCwd,
   isContainerNameConflict,
@@ -172,6 +173,24 @@ describe('checkDockerAvailable', () => {
     await checkDockerAvailable(exec)
 
     expect(calls).toEqual([['info', '--format', '{{.ServerVersion}}']])
+  })
+})
+
+describe('dockerCmd', () => {
+  test('prepends the resolved docker binary path to the args', () => {
+    const cmd = dockerCmd(['info', '--format', '{{.ServerVersion}}'], () => '/usr/local/bin/docker')
+
+    expect(cmd).toEqual(['/usr/local/bin/docker', 'info', '--format', '{{.ServerVersion}}'])
+  })
+
+  test('resolves to the absolute .exe path on Windows rather than leaving PATHEXT to Bun.spawn', () => {
+    const cmd = dockerCmd(['info'], () => 'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe')
+
+    expect(cmd).toEqual(['C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe', 'info'])
+  })
+
+  test('returns null when docker is not on PATH', () => {
+    expect(dockerCmd(['info'], () => null)).toBeNull()
   })
 })
 

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -11,16 +11,27 @@ export type DockerExec = (
 export const defaultDockerExec: DockerExec = async (args, options) => {
   const bun = getBun()
   if (!bun) return { exitCode: -1, stdout: '', stderr: 'bun runtime not available' }
-  // Bun.spawn throws synchronously with code 'ENOENT' when docker isn't on
-  // $PATH (rather than returning a non-zero exit). Two overloads (pipe vs
-  // inherit) so each spawn call site has the literal stdout/stderr type
-  // attached — that's what lets `new Response(proc.stdout)` typecheck on
-  // the piped path. `signal` is forwarded to Bun.spawn so callers can bound
-  // long-running docker subcommands (e.g. `docker logs` on a stuck daemon).
+  // Resolve `docker` to an absolute path before spawning. Bun.spawn() resolves
+  // a bare command name through Bun.which() internally, but Windows PATH/PATHEXT
+  // resolution has a string of historical bugs (oven-sh/bun#16070, #11182,
+  // #29636) that make `cmd: ['docker', …]` throw ENOENT even when Docker
+  // Desktop is installed and docker.exe is on %PATH% — surfacing as the
+  // misleading "Docker is not installed." on a machine that has Docker.
+  // dockerCmd() goes through Bun.which(), which reliably honors PATHEXT and
+  // returns the full docker.exe path; it returns null only when docker is
+  // genuinely absent from PATH, which maps to the binary-missing sentinel.
+  const cmd = dockerCmd(args)
+  if (cmd === null) return { exitCode: -1, stdout: '', stderr: DOCKER_NOT_FOUND_STDERR }
+  // Two overloads (pipe vs inherit) so each spawn call site has the literal
+  // stdout/stderr type attached — that's what lets `new Response(proc.stdout)`
+  // typecheck on the piped path. `signal` is forwarded to Bun.spawn so callers
+  // can bound long-running docker subcommands (e.g. `docker logs` on a stuck
+  // daemon). The ENOENT catch stays as a safety net for the race where the
+  // binary disappears between resolution and spawn.
   if (options?.inheritStdio) {
     try {
       const proc = bun.spawn({
-        cmd: ['docker', ...args],
+        cmd,
         cwd: options.cwd,
         stdout: 'inherit',
         stderr: 'inherit',
@@ -36,7 +47,7 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
   }
   try {
     const proc = bun.spawn({
-      cmd: ['docker', ...args],
+      cmd,
       cwd: options?.cwd,
       stdout: 'pipe',
       stderr: 'pipe',
@@ -54,10 +65,28 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
   }
 }
 
-// Sentinel stderr from defaultDockerExec when Bun.spawn throws ENOENT.
+// Sentinel stderr from defaultDockerExec when docker can't be resolved/spawned.
 // checkDockerAvailable matches on this exact string to distinguish
 // "binary missing" from "daemon down".
 export const DOCKER_NOT_FOUND_STDERR = 'docker: command not found in $PATH'
+
+// Resolves the `docker` binary to an absolute path via Bun.which(), which —
+// unlike a bare `cmd: ['docker']` handed to Bun.spawn() — reliably honors
+// Windows PATHEXT and returns e.g. C:\…\docker.exe. On POSIX the resolved path
+// equals what the bare name would have found. Returns null when docker is not
+// on PATH, which callers translate into the binary-missing sentinel.
+export function resolveDockerBinary(): string | null {
+  return getBun()?.which('docker') ?? null
+}
+
+// Builds the argv for a docker invocation with the binary resolved to an
+// absolute path (see resolveDockerBinary). Returns null when docker is absent
+// from PATH. The resolver is injectable so callers and tests stay deterministic
+// without depending on a real docker install.
+export function dockerCmd(args: string[], resolveBinary: () => string | null = resolveDockerBinary): string[] | null {
+  const binary = resolveBinary()
+  return binary === null ? null : [binary, ...args]
+}
 
 // Collapse a multi-line `docker` CLI stderr into a single readable clause
 // suitable for inline `reason:` strings. The motivating case is `compose
@@ -299,8 +328,10 @@ function sanitizeContainerName(name: string): string {
 export async function imageExists(tag: string): Promise<boolean> {
   const bun = getBun()
   if (!bun) return false
+  const cmd = dockerCmd(['image', 'inspect', tag])
+  if (cmd === null) return false
   const proc = bun.spawn({
-    cmd: ['docker', 'image', 'inspect', tag],
+    cmd,
     stdout: 'pipe',
     stderr: 'pipe',
   })
@@ -323,8 +354,10 @@ export type ContainerState = { exists: false } | { exists: true; running: boolea
 export async function inspectContainer(name: string): Promise<ContainerState> {
   const bun = getBun()
   if (!bun) return { exists: false }
+  const cmd = dockerCmd(['inspect', '--format', '{{.State.Running}}', name])
+  if (cmd === null) return { exists: false }
   const proc = bun.spawn({
-    cmd: ['docker', 'inspect', '--format', '{{.State.Running}}', name],
+    cmd,
     stdout: 'pipe',
     stderr: 'pipe',
   })
@@ -333,6 +366,6 @@ export async function inspectContainer(name: string): Promise<ContainerState> {
   return { exists: true, running: out === 'true' }
 }
 
-export function getBun(): { spawn: typeof Bun.spawn } | undefined {
-  return (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+export function getBun(): { spawn: typeof Bun.spawn; which: typeof Bun.which } | undefined {
+  return (globalThis as { Bun?: { spawn: typeof Bun.spawn; which: typeof Bun.which } }).Bun
 }

--- a/src/container/shell.test.ts
+++ b/src/container/shell.test.ts
@@ -40,6 +40,7 @@ describe('shell', () => {
       { cwd: folder },
       {
         inspect: async () => ({ exists: false }),
+        resolveDocker: () => 'docker',
         spawn: () => ({ exited: Promise.resolve(0) }),
       },
     )
@@ -55,6 +56,7 @@ describe('shell', () => {
       { cwd: folder },
       {
         inspect: async () => ({ exists: true, running: false }),
+        resolveDocker: () => 'docker',
         spawn: () => ({ exited: Promise.resolve(0) }),
       },
     )
@@ -77,6 +79,7 @@ describe('shell', () => {
       { cwd: folder, shell: '/bin/sh' },
       {
         inspect: async () => ({ exists: true, running: true }),
+        resolveDocker: () => 'docker',
         spawn: (options) => {
           spawns.push(options)
           return { exited: Promise.resolve(7) }
@@ -94,5 +97,57 @@ describe('shell', () => {
         stderr: 'inherit',
       },
     ])
+  })
+
+  test('spawns the resolved absolute docker binary path so Windows PATHEXT resolution is not left to Bun.spawn', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const spawns: Array<{ cmd: string[] }> = []
+
+    await shell(
+      { cwd: folder, shell: '/bin/sh' },
+      {
+        inspect: async () => ({ exists: true, running: true }),
+        resolveDocker: () => 'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe',
+        spawn: (options) => {
+          spawns.push(options)
+          return { exited: Promise.resolve(0) }
+        },
+      },
+    )
+
+    expect(spawns[0]?.cmd).toEqual([
+      'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe',
+      'exec',
+      '-it',
+      'coder',
+      '/bin/sh',
+    ])
+  })
+
+  test('reports docker missing before inspecting (so it is not masked as a missing container) and without spawning', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    let inspected = false
+    let spawned = false
+
+    const result = await shell(
+      { cwd: folder },
+      {
+        resolveDocker: () => null,
+        inspect: async () => {
+          inspected = true
+          return { exists: true, running: true }
+        },
+        spawn: () => {
+          spawned = true
+          return { exited: Promise.resolve(0) }
+        },
+      },
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'Docker is not installed (docker not found on PATH).' })
+    expect(inspected).toBe(false)
+    expect(spawned).toBe(false)
   })
 })

--- a/src/container/shell.ts
+++ b/src/container/shell.ts
@@ -1,4 +1,4 @@
-import { containerNameFromCwd, getBun, inspectContainer, type ContainerState } from './shared'
+import { containerNameFromCwd, dockerCmd, getBun, inspectContainer, type ContainerState } from './shared'
 
 export type ShellPlan = {
   containerName: string
@@ -10,6 +10,7 @@ export type ShellResult = { ok: true; containerName: string; exitCode: number } 
 type ShellDeps = {
   inspect?: (name: string) => Promise<ContainerState>
   spawn?: InteractiveSpawn
+  resolveDocker?: () => string | null
 }
 
 type InteractiveSpawn = (options: {
@@ -30,6 +31,15 @@ export async function shell(
 
   const { containerName, shell: plannedShell } = planShell(cwd, { shell: shellPath })
 
+  // Resolve docker before inspecting: inspectContainer collapses a missing
+  // docker binary into { exists: false }, so deferring this check would
+  // surface the misleading "Container … not found" instead of the real
+  // "Docker is not installed" on a host without docker on PATH.
+  const cmd = dockerCmd(['exec', '-it', containerName, plannedShell], deps.resolveDocker)
+  if (cmd === null) {
+    return { ok: false, reason: 'Docker is not installed (docker not found on PATH).' }
+  }
+
   try {
     const state = await (deps.inspect ?? inspectContainer)(containerName)
     if (!state.exists) {
@@ -40,7 +50,7 @@ export async function shell(
     }
 
     const proc = spawn({
-      cmd: ['docker', 'exec', '-it', containerName, plannedShell],
+      cmd,
       cwd,
       stdin: 'inherit',
       stdout: 'inherit',


### PR DESCRIPTION
## Background

`typeclaw init` failed with **"Docker is not installed."** on Windows machines that have Docker Desktop installed and `docker.exe` on `%PATH%`. The container never started.

Root cause: `Bun.spawn({ cmd: ['docker', ...] })` throws `ENOENT` on Windows even when the binary is present, due to a string of Bun bugs in Windows `PATH`/`PATHEXT` resolution ([oven-sh/bun#16070](https://github.com/oven-sh/bun/issues/16070), [#11182](https://github.com/oven-sh/bun/issues/11182), [#29636](https://github.com/oven-sh/bun/issues/29636)). `checkDockerAvailable` classified that `ENOENT` as binary-missing, so init aborted before docker was ever invoked.

## Summary

Resolve `docker` to an absolute path via `Bun.which()` before every `Bun.spawn()`. `Bun.which()` honors `PATHEXT` and returns the full `docker.exe` path — it is the documented workaround while the upstream Bun issues are open. A `null` result from `Bun.which()` maps to the existing binary-missing sentinel, so the "Docker is not installed." error still fires for machines that genuinely lack docker.

Two new helpers in `shared.ts`:

- `resolveDockerBinary()` — wraps `getBun()?.which('docker')`, returns `string | null`.
- `dockerCmd(args, resolver?)` — builds the full argv with the resolved binary prepended; returns `null` when docker is absent. The resolver is injectable so tests stay deterministic without a real docker install.

`defaultDockerExec`, `imageExists`, and `inspectContainer` in `shared.ts`, and the interactive `docker exec` path in `shell.ts`, all call `dockerCmd()` before spawning. POSIX behavior is unchanged: the resolved path equals what the bare name would have found.

`getBun()` return type is widened to include `which` (it was already present on the real `Bun` global; the omission was a type gap, not a runtime one).

## What this does NOT do

- Does not modify `checkDockerAvailable` logic — the binary-missing and daemon-down classification remains.
- Does not add a Windows-specific code path; the fix is uniform across platforms.
- Does not pin a Bun version or add a workaround comment in CLI code — the fix is self-contained in the container helpers.

## Review notes

- **Load-bearing invariant:** `dockerCmd()` must never return a non-null result whose first element is a bare `"docker"` string on Windows; it must always be an absolute path. The ENOENT catch in `defaultDockerExec` is kept as a safety net for the race where docker is uninstalled between resolution and spawn — it is not the primary guard.
- `resolveDocker` is injected into `shell()` via its deps object (same pattern as `inspect` / `spawn`), so the docker-missing path in the shell is testable without a running container.
- Full suite: typecheck, lint (0 errors), format:check, 9750 pass / 0 fail.