### PR TITLE
fix(deps): make typeclaw installable on Windows without C++ build tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,17 @@ bun run format
 
 No exceptions. No `--no-verify`. No partial fixes.
 
+## Dependencies
+
+**Never demote a real runtime dependency to `devDependencies` to dodge an install failure.** Consumers do not receive a package's `devDependencies`, so this silently removes the feature for _every_ published install (`bun add -g typeclaw`) — on macOS/Linux too, not just the platform you were trying to unblock. It looks like it "fixes" the install only because the broken dependency is no longer there; it is a UX regression, not a fix. `agent-messenger` is a runtime dependency and stays in `dependencies`.
+
+When a transitive **native** module (e.g. `agent-messenger` → `better-sqlite3`) fails to build on a host without a C++ toolchain (Windows without VS Build Tools), `bun add -g typeclaw` aborts the whole install — bun aborts on any failed lifecycle script. The fix is to make that native module **not need a host compiler at all**, at its source — not to hide its parent:
+
+- The clean fix is **upstream**: the owning package should not force a from-source native build on consumers. Prefer a dependency that ships **ABI-stable (N-API) prebuilds** for all target platforms (like `classic-level`, which never recompiles on a new Node), or read SQLite via the runtime built-ins (`bun:sqlite` / `node:sqlite`) instead of a node-gyp module like `better-sqlite3`. `better-sqlite3` ships no in-package prebuilds and is keyed to the exact Node ABI, so a brand-new Node or bun finds no prebuilt and compiles from source — the actual failure.
+- `optionalDependencies` is NOT a real fix: it only lets the install _skip_ a failed build, leaving the feature dead with no recovery path for anyone who needs it. And it does not even apply to a _required_ child of an _optional_ parent — bun still runs and aborts on `better-sqlite3`'s build script under an optional `agent-messenger`. Only the failing package being _itself_ optional is non-fatal.
+- `overrides`, `resolutions`, `trustedDependencies`, `patchedDependencies`, and `bunfig.toml install.ignoreScripts` are all **root-project-only** — they are ignored when typeclaw is installed as someone else's dependency, so typeclaw cannot use them to neutralize a transitive native build for its own consumers.
+- Container-only native deps may additionally be seeded into the image in `src/init/dockerfile.ts` (the `WORKDIR /` "survives-the-/agent-bind-mount" pattern), but that addresses the container, not the host install.
+
 ## Debugging the system prompt
 
 `bun run debug:prompt` dumps the rendered system prompt for each session-origin kind (`tui`, `cron`, `channel`, `subagent`) with placeholder values, plus a per-section token/char/byte breakdown.


### PR DESCRIPTION
## Status: blocked on an agent-messenger release (draft)

The actual fix belongs in **agent-messenger**, not here. This PR now carries only the AGENTS.md rule that records the lesson; it will bump the `agent-messenger` version once the upstream fix ships, at which point it leaves draft.

## Background

`bun add -g typeclaw` (the documented install command) aborts on Windows without the Visual Studio "Desktop development with C++" workload:

```
⚙️ better-sqlite3 [2/2]
gyp ERR! find VS  You need to install the latest version of Visual Studio ...
error: install script from "better-sqlite3" exited with 1
```

Root cause: `agent-messenger` (a runtime dependency) pulls in the native module `better-sqlite3`. It ships **no in-package prebuilds** and is keyed to the exact Node ABI, so a brand-new Node (24) or bun finds no matching prebuilt, falls back to a `node-gyp` source build, and — with no C++ toolchain — fails. bun aborts the whole install on any failed lifecycle script, so typeclaw is uninstallable on a stock Windows host. (typeclaw's own SQLite use is `bun:sqlite`; it never calls the agent-messenger paths that need `better-sqlite3`.)

## Why the first attempt was wrong

The initial version moved `agent-messenger` to `devDependencies` so consumers wouldn't pull `better-sqlite3`. Reviewer @typeey correctly flagged this:
- **Regression** — consumers never receive a package's `devDependencies`, so this silently removed host Webex/KakaoTalk/LINE auth for *every* published install (macOS/Linux too), not just Windows.
- **Hard crash** — host-reachable modules still statically imported `agent-messenger` (e.g. `webex-id-ref.ts` via the permissions/plugin-discovery chain), so `typeclaw --help` would crash with "Cannot find package 'agent-messenger'".

Both have been reverted; `agent-messenger` stays a normal `dependency`.

## The correct fix (upstream, tracked separately)

Make the dependency not require a host compiler **at its source**: in agent-messenger, drop `better-sqlite3` (node-gyp) in favor of the runtime built-in SQLite (`bun:sqlite` / `node:sqlite`) for its read-only cookie/token reads. That removes the only force-compiling native dep; `classic-level` and `koffi` already ship ABI-stable (N-API) prebuilds and install without a toolchain. typeclaw then bumps `agent-messenger` to that release — fixing the Windows install with `agent-messenger` remaining a normal dependency and host auth working on all platforms.

Why not solve it in typeclaw alone: `optionalDependencies` only lets the install *skip* a failed build (feature dead, no recovery) and doesn't even apply to a required child of an optional parent; `overrides` / `resolutions` / `trustedDependencies` / `patchedDependencies` / `bunfig.toml ignoreScripts` are all root-project-only and ignored for consumers of typeclaw.

## This PR

- Adds a `## Dependencies` rule to `AGENTS.md` documenting the anti-pattern (never demote a runtime dep to `devDependencies` to dodge a native build), the correct fix, and why the root-only levers don't help.

## Follow-up

- [ ] agent-messenger: drop `better-sqlite3` → built-in `bun:sqlite`/`node:sqlite`; release.
- [ ] Bump `agent-messenger` here to that release; mark ready.