### PR TITLE
fix(container): fall back to Docker Desktop install paths on Windows

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -17,6 +17,7 @@ import {
   type DockerExec,
   imageTagFromCwd,
   isContainerNameConflict,
+  resolveDockerBinary,
   sanitizeDockerStderr,
   waitForRemoval,
 } from './shared'
@@ -191,6 +192,110 @@ describe('dockerCmd', () => {
 
   test('returns null when docker is not on PATH', () => {
     expect(dockerCmd(['info'], () => null)).toBeNull()
+  })
+})
+
+describe('resolveDockerBinary', () => {
+  test('returns the PATH-resolved binary when Bun.which finds it', () => {
+    const result = resolveDockerBinary({
+      which: () => '/usr/local/bin/docker',
+      platform: 'darwin',
+      exists: () => {
+        throw new Error('must not probe the filesystem when PATH resolves')
+      },
+    })
+
+    expect(result).toBe('/usr/local/bin/docker')
+  })
+
+  test('does NOT fall back to filesystem probing on POSIX when PATH misses', () => {
+    let probed = false
+    const result = resolveDockerBinary({
+      which: () => null,
+      platform: 'linux',
+      exists: () => {
+        probed = true
+        return true
+      },
+    })
+
+    expect(result).toBeNull()
+    expect(probed).toBe(false)
+  })
+
+  test('falls back to the all-users Docker Desktop install path on Windows when PATH misses', () => {
+    const expected = 'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe'
+    const result = resolveDockerBinary({
+      which: () => null,
+      platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files' },
+      exists: (path) => path === expected,
+    })
+
+    expect(result).toBe(expected)
+  })
+
+  test('falls back to the per-user Docker Desktop install path on Windows', () => {
+    const expected = 'C:\\Users\\me\\AppData\\Local\\Programs\\DockerDesktop\\resources\\bin\\docker.exe'
+    const result = resolveDockerBinary({
+      which: () => null,
+      platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files', LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local' },
+      exists: (path) => path === expected,
+    })
+
+    expect(result).toBe(expected)
+  })
+
+  test.each([
+    ['Chocolatey shim', 'C:\\ProgramData\\chocolatey\\bin\\docker.exe'],
+    ['Scoop shim', 'C:\\Users\\me\\scoop\\shims\\docker.exe'],
+    ['standalone CLI', 'C:\\Program Files\\Docker\\docker.exe'],
+    ['Rancher Desktop', 'C:\\Program Files\\Rancher Desktop\\resources\\resources\\win32\\bin\\docker.exe'],
+    ['pre-3.3.1 Docker Desktop', 'C:\\Program Files\\Docker\\Docker\\resources\\docker.exe'],
+  ])('falls back to the %s install path on Windows', (_label, expected) => {
+    const result = resolveDockerBinary({
+      which: () => null,
+      platform: 'win32',
+      env: {
+        ProgramFiles: 'C:\\Program Files',
+        ProgramData: 'C:\\ProgramData',
+        LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local',
+        USERPROFILE: 'C:\\Users\\me',
+      },
+      exists: (path) => path === expected,
+    })
+
+    expect(result).toBe(expected)
+  })
+
+  test('prefers Docker Desktop over an also-present Rancher Desktop (probe order)', () => {
+    const dockerDesktop = 'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe'
+    const rancher = 'C:\\Program Files\\Rancher Desktop\\resources\\resources\\win32\\bin\\docker.exe'
+    const result = resolveDockerBinary({
+      which: () => null,
+      platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files' },
+      exists: (path) => path === dockerDesktop || path === rancher,
+    })
+
+    expect(result).toBe(dockerDesktop)
+  })
+
+  test('returns null on Windows when docker is on neither PATH nor any known install path', () => {
+    const result = resolveDockerBinary({
+      which: () => null,
+      platform: 'win32',
+      env: {
+        ProgramFiles: 'C:\\Program Files',
+        ProgramData: 'C:\\ProgramData',
+        LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local',
+        USERPROFILE: 'C:\\Users\\me',
+      },
+      exists: () => false,
+    })
+
+    expect(result).toBeNull()
   })
 })
 

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -1,5 +1,8 @@
 import { createHash } from 'node:crypto'
-import { basename, resolve } from 'node:path'
+import { existsSync } from 'node:fs'
+import { basename, resolve, win32 } from 'node:path'
+
+import { isWindows } from '@/shared'
 
 export type DockerExecResult = { exitCode: number; stdout: string; stderr: string }
 
@@ -70,13 +73,78 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
 // "binary missing" from "daemon down".
 export const DOCKER_NOT_FOUND_STDERR = 'docker: command not found in $PATH'
 
-// Resolves the `docker` binary to an absolute path via Bun.which(), which —
-// unlike a bare `cmd: ['docker']` handed to Bun.spawn() — reliably honors
-// Windows PATHEXT and returns e.g. C:\…\docker.exe. On POSIX the resolved path
-// equals what the bare name would have found. Returns null when docker is not
-// on PATH, which callers translate into the binary-missing sentinel.
-export function resolveDockerBinary(): string | null {
-  return getBun()?.which('docker') ?? null
+export type DockerBinaryProbes = {
+  which?: (command: string) => string | null
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  exists?: (path: string) => boolean
+}
+
+// Resolves the `docker` binary to an absolute path. First via Bun.which(),
+// which — unlike a bare `cmd: ['docker']` handed to Bun.spawn() — reliably
+// honors Windows PATHEXT and returns e.g. C:\…\docker.exe. On POSIX the
+// resolved path equals what the bare name would have found.
+//
+// When Bun.which() finds nothing on Windows we fall back to Docker Desktop's
+// known install locations: its installer registers docker.exe on the SYSTEM
+// PATH, so a shell/process started before the install (or with a customized
+// PATH) inherits a stale PATH where Bun.which can't see docker even though the
+// binary exists and the engine is running — the real-world "Docker is not
+// installed" report on a machine with a working Docker. Probing these paths
+// fixes detection without a reinstall or PATH edit. The MS-Store packaged
+// build is deliberately NOT probed: its binary lives in ACL-locked
+// WindowsApps and can't be executed by a child process anyway.
+//
+// Returns null when docker is genuinely absent, which callers translate into
+// the binary-missing sentinel. Probes are injectable so tests stay
+// deterministic without depending on a real docker install or host platform.
+export function resolveDockerBinary(probes: DockerBinaryProbes = {}): string | null {
+  const which = probes.which ?? ((command: string) => getBun()?.which(command) ?? null)
+  const fromPath = which('docker')
+  if (fromPath !== null) return fromPath
+
+  const platform = probes.platform ?? process.platform
+  if (!isWindows(platform)) return null
+
+  const exists = probes.exists ?? existsSync
+  for (const candidate of windowsDockerCandidates(probes.env ?? process.env)) {
+    if (exists(candidate)) return candidate
+  }
+  return null
+}
+
+// Real, child-process-executable docker.exe locations across the common
+// Windows install methods, most-canonical first. All are confirmed real
+// binaries or executable shims (not ACL-locked WindowsApps Store stubs).
+// Probe order prefers Docker Desktop, then package-manager Docker, then the
+// standalone CLI, then the Rancher Desktop alternative runtime. An
+// arbitrary `--installation-dir` install can't be enumerated and is left to
+// Bun.which/PATH.
+function windowsDockerCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates: string[] = []
+  // win32.join (not the host-default join) so the probe builds backslash paths
+  // regardless of the host the resolver runs/tests on.
+  const add = (root: string | undefined, ...segments: string[]): void => {
+    if (root) candidates.push(win32.join(root, ...segments))
+  }
+  // ProgramW6432 covers a 32-bit Bun seeing the WOW64-redirected ProgramFiles.
+  const programFiles = env.ProgramW6432 ?? env.ProgramFiles ?? 'C:\\Program Files'
+  const programData = env.ProgramData ?? 'C:\\ProgramData'
+
+  // Docker Desktop: all-users, per-user, and the installer symlink dir.
+  add(programFiles, 'Docker', 'Docker', 'resources', 'bin', 'docker.exe')
+  add(env.LOCALAPPDATA, 'Programs', 'DockerDesktop', 'resources', 'bin', 'docker.exe')
+  add(programData, 'DockerDesktop', 'version-bin', 'docker.exe')
+  // Docker Desktop pre-3.3.1 layout (resources\docker.exe, no \bin).
+  add(programFiles, 'Docker', 'Docker', 'resources', 'docker.exe')
+  // Chocolatey and Scoop shims (executable redirectors, on PATH after install).
+  add(programData, 'chocolatey', 'bin', 'docker.exe')
+  add(env.USERPROFILE, 'scoop', 'shims', 'docker.exe')
+  // Standalone Docker CLI binary (Windows Server / manual `Expand-Archive`).
+  add(programFiles, 'Docker', 'docker.exe')
+  // Rancher Desktop's bundled Moby docker CLI (note the doubled `resources`).
+  add(programFiles, 'Rancher Desktop', 'resources', 'resources', 'win32', 'bin', 'docker.exe')
+  return candidates
 }
 
 // Builds the argv for a docker invocation with the binary resolved to an


### PR DESCRIPTION
## Background

On Windows, `typeclaw init` reported **"Docker is not installed."** on machines where Docker Desktop was present and the engine was running — but the process inherited a stale PATH. Docker Desktop's installer registers docker.exe on the SYSTEM PATH, so any shell started before the install (or with a customized PATH) can't see it via `Bun.which('docker')`. The binary exists at an absolute path and is exec'able; the lookup just fails.

This is a follow-up to #1005, which made `resolveDockerBinary()` use `Bun.which()` to fix a Windows PATHEXT spawn bug. That covers the PATH-visible case; this PR covers the stale-PATH case where `Bun.which()` misses entirely.

## Summary

When `Bun.which('docker')` returns `null` on Windows, `resolveDockerBinary()` now probes Docker Desktop's known install locations in order:

1. `%ProgramW6432%` or `%ProgramFiles%` — all-users install (the common case). `ProgramW6432` covers a 32-bit Bun on a 64-bit host where the WOW64 redirector would otherwise hide the `Program Files` path.
2. `%LOCALAPPDATA%\Programs\DockerDesktop` — per-user install.
3. `%ProgramData%\DockerDesktop\version-bin` — installer-managed symlink directory.

Paths are built with `path.win32.join` so they're correct backslash paths regardless of what OS the resolver runs or tests on. POSIX behavior is unchanged: when `Bun.which()` returns `null` on Linux/macOS, `resolveDockerBinary()` returns `null` immediately with no filesystem probing.

**Why the MS-Store packaged build is deliberately excluded:** its binary lives in an ACL-locked `WindowsApps` directory that is not executable by a child process, so probing it would produce a false positive. Returning `null` is correct there.

`resolveDockerBinary()` now accepts injectable probes (`which`, `platform`, `env`, `exists`) so the Windows fallback path is unit-testable on any host OS.

## What this does NOT do

- Does not change `checkDockerAvailable` or the binary-missing error message.
- Does not modify the spawn path — once an absolute path is returned, the existing `dockerCmd()` machinery from #1005 takes over unchanged.
- Does not probe the MS-Store `WindowsApps` location (ACL-locked, not exec'able).
- Does not change POSIX resolution behavior.

## Review notes

- **Load-bearing invariant:** `windowsDockerCandidates()` uses `path.win32.join`, not the default `path.join`. This is required when tests run on macOS/Linux — the default join would produce forward-slash paths that never match a Windows path. Any future edits to the candidate-builder must preserve the `win32` import.
- **Probe order matters.** All-users is checked first (most common). Per-user second (non-admin installs). The `version-bin` symlink dir last (installer-managed, not present in all versions).
- **Injectable probes** (`DockerBinaryProbes`) keep the Windows fallback testable without a real Windows host. The defaults — `Bun.which`, `process.platform`, `process.env`, `existsSync` — are production behavior; all four are overridden in tests.
- Five new unit tests: PATH hit (no FS probe), POSIX miss (no fallback), Windows all-users fallback, Windows per-user fallback, Windows total miss → `null`.