### PR TITLE
fix(init): derive sharp arch from uname -m so containers without buildx load sharp

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1004,9 +1004,17 @@ describe('transformers native-deps layer (sharp + onnxruntime linux binaries)', 
     expect(out).toContain('"@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4"')
   })
 
-  test('layer resolves SHARP_ARCH from $TARGETARCH (arm64 -> arm64, else x64) with an amd64 fallback so a bare `docker build` without buildx stays deterministic', () => {
-    const out = buildDockerfile()
-    expect(out).toContain('SHARP_ARCH="$(if [ "${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)"')
+  test('layer resolves SHARP_ARCH from the real install arch via `uname -m` (aarch64/arm64 -> arm64, x86_64/amd64 -> x64), failing closed on unknown machines — NOT from the build arg `$TARGETARCH`, whose `:-amd64` default silently seeded x64 sharp packages on arm64 hosts built without buildx and crashed `typeclaw --help` with "Could not load the sharp module using the linux-arm64 runtime"', () => {
+    for (const out of [
+      buildDockerfile(),
+      buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' }),
+      buildBaseDockerfile(),
+    ]) {
+      expect(out).toContain(
+        'SHARP_ARCH="$(case "$(uname -m)" in aarch64|arm64) echo arm64 ;; x86_64|amd64) echo x64 ;; *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;; esac)"',
+      )
+      expect(out).not.toContain('${TARGETARCH:-amd64}')
+    }
   })
 
   test('versioned (base-image) form installs the same native-deps set — drift guard so GHCR-base agents whose base image predates this fix still get linux sharp binaries seeded by the per-agent layer', () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -627,9 +627,18 @@ export const TRANSFORMERS_VERSION = '4.2.0'
 // resolves. A future transformers bump that moves sharp must bump
 // TRANSFORMERS_VERSION, `sharp@`, `@img/sharp-linux-*`, and
 // `@img/sharp-libvips-linux-*` together — mismatched sharp/libvips platform
-// packages are a known failure mode. `$TARGETARCH` is `arm64` or `amd64`; an
-// empty value (bare `docker build` without buildx) falls back to x64 for
-// determinism.
+// packages are a known failure mode.
+//
+// ARCH DETECTION — uname -m, not $TARGETARCH. Deriving the arch from the build
+// arg as `${TARGETARCH:-amd64}` was a footgun: a bare `docker build` without
+// BuildKit/buildx leaves TARGETARCH unset, so the default installed x64 packages
+// even on arm64 hosts. The arm64 platform packages then exist in NEITHER
+// /agent/node_modules/@img NOR /node_modules/@img, so sharp exhausts every
+// candidate and aborts with a clean MODULE_NOT_FOUND ("Could not load the sharp
+// module using the linux-arm64 runtime") the moment any code touches it (e.g.
+// `typeclaw --help`). `uname -m` is the arch that actually runs this `bun add`
+// (and the arch the native code must later load on), correct in every build path
+// including emulated cross-builds. Unknown machines fail the build loudly.
 const LAYER_TRANSFORMERS_INSTALL = `# Layer 7: install @huggingface/transformers with its linux-native binaries.
 # Installs the linux onnxruntime-node addon AND sharp's linux platform packages
 # (@img/sharp-linux-*) into the image's /node_modules so they survive the
@@ -637,7 +646,7 @@ const LAYER_TRANSFORMERS_INSTALL = `# Layer 7: install @huggingface/transformers
 # /agent/node_modules/sharp. The transformers version is pinned EXACT (this
 # bun add has no lockfile) — see src/init/dockerfile.ts for the rationale.
 WORKDIR /
-RUN SHARP_ARCH="$(if [ "\${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)" \\
+RUN SHARP_ARCH="$(case "$(uname -m)" in aarch64|arm64) echo arm64 ;; x86_64|amd64) echo x64 ;; *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;; esac)" \\
  && bun add \\
       @huggingface/transformers@${TRANSFORMERS_VERSION} \\
       sharp@0.34.5 \\


### PR DESCRIPTION
## Background

`typeclaw <anything>` crashes inside the container the moment any code path touches `sharp`:

```
error: Could not load the "sharp" module using the linux-arm64 runtime
  at /agent/node_modules/sharp/lib/sharp.js:120:13
  at /agent/node_modules/sharp/lib/constructor.js:8:7
  at /agent/node_modules/sharp/lib/index.js:6:7
```

`sharp` is not a direct dependency — it is transitive via `@huggingface/transformers@4.2.0` (vector-memory embeddings), which eagerly imports it at module-evaluation time. The container never has the host's macOS sharp binaries (the host `node_modules` is bind-mounted over `/agent`), so Layer 7 of the generated Dockerfile installs the linux platform packages (`@img/sharp-linux-*`) into the image's `/node_modules` — outside the bind mount — where Node/Bun resolution from `/agent/node_modules/sharp` ascends and finds them.

**Root cause:** Layer 7 picked the arch from `SHARP_ARCH="$(if [ "${TARGETARCH:-amd64}" = "arm64" ]; then echo arm64; else echo x64; fi)"`. `TARGETARCH` is a BuildKit/buildx build arg. A bare `docker build` **without** buildx leaves it unset, so the `:-amd64` default installed `@img/sharp-linux-x64` **even on an arm64 host**. On a `linux-arm64` runtime the arm64 package is then absent from *both* `/agent/node_modules/@img` and `/node_modules/@img`, sharp exhausts all four candidate paths, and aborts with a clean `MODULE_NOT_FOUND` — exactly the error above (note: no `ERR_DLOPEN_FAILED`, which would indicate a present-but-broken binary).

## Summary

Derive the arch from `uname -m` at install time instead of trusting the build arg:

```dockerfile
RUN SHARP_ARCH="$(case "$(uname -m)" in aarch64|arm64) echo arm64 ;; x86_64|amd64) echo x64 ;; *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;; esac)" \
 && bun add @huggingface/transformers@4.2.0 sharp@0.34.5 "@img/sharp-linux-${SHARP_ARCH}@0.34.5" "@img/sharp-libvips-linux-${SHARP_ARCH}@1.2.4"
```

**Why `uname -m` and not `$TARGETARCH`:** `uname -m` reports the architecture that actually runs this `bun add` — which is the arch the native binary must later load on. It is correct in every build path (buildx, bare `docker build`, and emulated cross-builds, where it reports the emulated target arch). `$TARGETARCH` is only populated by BuildKit and silently defaults wrong otherwise.

**Why fail-closed on unknown arch:** a loud build failure beats shipping an image that only crashes at runtime inside `typeclaw --help`.

The change lives in the single `LAYER_TRANSFORMERS_INSTALL` constant, so all three Dockerfile emitters (inline/dev, versioned/GHCR-base, and `buildBaseDockerfile`) are fixed at once.

## What this does NOT do

- Does not change `sharp`/`@huggingface/transformers`/libvips version pins.
- Does not switch to `@img/sharp-linuxmusl-*` — the base is `oven/bun:1-slim` (Debian/glibc), so glibc packages are correct.
- Does not touch the lazy-load seam in the vector embedder or `--help` plugin discovery (orthogonal defense-in-depth, out of scope).

## Review notes

- Load-bearing line: the `SHARP_ARCH` derivation in `LAYER_TRANSFORMERS_INSTALL` (`src/init/dockerfile.ts`). `$(uname -m)` is intentionally unescaped so it executes at Docker build time rather than being interpolated by the JS template literal.
- Verified in the actual container shell (`/bin/sh` → `dash`): `aarch64 → arm64` resolves `/node_modules/@img/sharp-linux-arm64`, and a stubbed unknown arch prints `unsupported arch: …` and exits 1 (so `bun add` never runs). `sh -n` confirms the snippet's syntax.
- Regression guard updated in `dockerfile.test.ts`: asserts the `uname -m` mapping is present and `${TARGETARCH:-amd64}` is absent across all three emitters.
