### PR TITLE
fix(init): use --backend=copyfile for bun install on Windows

### DIFF
--- a/src/init/run-bun-install.test.ts
+++ b/src/init/run-bun-install.test.ts
@@ -5,6 +5,17 @@ import { join } from 'node:path'
 
 import { runBunInstall, runBunUpdate } from './run-bun-install'
 
+// Capture the argv a runner hands to `spawn` while still returning a real,
+// fast-exiting process so `runTimedBunProcess` can await `exited`/`stderr`.
+function capturingSpawn(): { spawn: typeof Bun.spawn; cmds: string[][] } {
+  const cmds: string[][] = []
+  const spawn: typeof Bun.spawn = (options) => {
+    cmds.push([...((options as { cmd: string[] }).cmd ?? [])])
+    return Bun.spawn({ cmd: ['bun', '-e', ''], stdout: 'pipe', stderr: 'pipe' })
+  }
+  return { spawn, cmds }
+}
+
 describe('runBunInstall', () => {
   test('times out a hung install process', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'tc-bun-install-timeout-'))
@@ -19,6 +30,30 @@ describe('runBunInstall', () => {
     } finally {
       await rm(cwd, { recursive: true, force: true })
     }
+  })
+
+  test('adds --backend=copyfile on Windows', async () => {
+    const { spawn, cmds } = capturingSpawn()
+
+    await runBunInstall('/agent', { spawn, platform: 'win32' })
+
+    expect(cmds[0]).toEqual(['bun', 'install', '--linker=hoisted', '--backend=copyfile'])
+  })
+
+  test('keeps the default backend on POSIX', async () => {
+    const { spawn, cmds } = capturingSpawn()
+
+    await runBunInstall('/agent', { spawn, platform: 'linux' })
+
+    expect(cmds[0]).toEqual(['bun', 'install', '--linker=hoisted'])
+  })
+
+  test('orders --backend=copyfile before --force on Windows', async () => {
+    const { spawn, cmds } = capturingSpawn()
+
+    await runBunInstall('/agent', { spawn, platform: 'win32', force: true })
+
+    expect(cmds[0]).toEqual(['bun', 'install', '--linker=hoisted', '--backend=copyfile', '--force'])
   })
 })
 

--- a/src/init/run-bun-install.ts
+++ b/src/init/run-bun-install.ts
@@ -1,3 +1,5 @@
+import { isWindows } from '../shared/platform'
+
 export type InstallResult = { ok: true } | { ok: false; reason: string }
 
 const INSTALL_TIMEOUT_MS = 300_000
@@ -11,6 +13,24 @@ export type InstallRunnerOptions = {
   force?: boolean
   timeoutMs?: number
   spawn?: typeof Bun.spawn
+  // Defaults to `process.platform`; tests inject it to assert the backend
+  // argv without mutating the read-only `process.platform`.
+  platform?: NodeJS.Platform
+}
+
+// On Windows, Bun's default install backend is `hardlink` (CreateHardLinkW).
+// When the hardlink fails — cross-context copies, locked files, antivirus
+// (Defender) real-time scanning of the cache or destination — Bun's per-file
+// path falls back to CopyFileW, but if that ALSO fails it aborts the whole
+// install: the outer hardlink→copyfile fallback in Bun is `#[cfg(not(windows))]`,
+// so Windows has no recovery and surfaces "EPERM: failed copying files from
+// cache to destination". This bites the `bun link` dev workflow hardest, where
+// a `file:` typeclaw dep copies the whole source tree (including `.git/`) into
+// <agent>/node_modules. `--backend=copyfile` skips CreateHardLinkW entirely and
+// uses CopyFileW directly, which sidesteps the hardlink-permission failure.
+// POSIX keeps Bun's default (hardlink on Linux, clonefile on macOS).
+function bunInstallBackendArgs(platform?: NodeJS.Platform): string[] {
+  return isWindows(platform ?? process.platform) ? ['--backend=copyfile'] : []
 }
 
 // Signature for the function `runInit` uses to materialize the agent folder's
@@ -38,8 +58,11 @@ export async function runBunInstall(cwd: string, opts?: InstallRunnerOptions): P
     // deps re-copy their current on-disk source into node_modules. Bun's
     // file-dep cache is keyed on name+version, so without --force, edits to
     // a `file:..` typeclaw never reach the container after the first install.
+    const backend = bunInstallBackendArgs(opts?.platform)
     return await runTimedBunProcess({
-      cmd: opts?.force ? ['bun', 'install', '--linker=hoisted', '--force'] : ['bun', 'install', '--linker=hoisted'],
+      cmd: opts?.force
+        ? ['bun', 'install', '--linker=hoisted', ...backend, '--force']
+        : ['bun', 'install', '--linker=hoisted', ...backend],
       cwd,
       timeoutMs: opts?.timeoutMs ?? INSTALL_TIMEOUT_MS,
       spawn: opts?.spawn ?? bun.spawn,
@@ -57,7 +80,7 @@ export async function runBunInstall(cwd: string, opts?: InstallRunnerOptions): P
 // install` would no-op when the existing lockfile entry already satisfies
 // an in-range spec — which is the exact regression auto-upgrade exists to
 // prevent).
-export type UpdateRunnerOptions = Pick<InstallRunnerOptions, 'timeoutMs' | 'spawn'>
+export type UpdateRunnerOptions = Pick<InstallRunnerOptions, 'timeoutMs' | 'spawn' | 'platform'>
 
 export type UpdateRunner = (cwd: string, pkg: string, opts?: UpdateRunnerOptions) => Promise<InstallResult>
 
@@ -73,7 +96,7 @@ export async function runBunUpdate(cwd: string, pkg: string, opts?: UpdateRunner
     // `--linker=hoisted` for the same Bun 1.3.x deadlock reason as
     // runBunInstall above.
     return await runTimedBunProcess({
-      cmd: ['bun', 'update', pkg, '--latest', '--linker=hoisted'],
+      cmd: ['bun', 'update', pkg, '--latest', '--linker=hoisted', ...bunInstallBackendArgs(opts?.platform)],
       cwd,
       timeoutMs: opts?.timeoutMs ?? INSTALL_TIMEOUT_MS,
       spawn: opts?.spawn ?? bun.spawn,


### PR DESCRIPTION
## Background

`typeclaw init` fails on native Windows during the dependency install step with:

```
EPERM: failed copying files from cache to destination for package typeclaw
```

Verbose `bun install` output pins the mechanism:

```
warn: CreateHardLinkW failed, falling back to CopyFileW:
  \\?\C:\Users\<user>\workspace\typeclaw\.git\config
  - \\?\C:\Users\<user>\typeclaw\<agent>\node_modules\typeclaw\.git\config
EPERM: failed copying files from cache to destination for package typeclaw
```

Root cause is in Bun, not typeclaw. Bun's default install backend on Windows is `hardlink` (`CreateHardLinkW`). When a hardlink fails — locked files, antivirus/Defender real-time scanning of the cache or destination, cross-context copies — Bun's per-file path falls back to `CopyFileW`; but when that *also* fails it aborts the whole install. Bun's outer hardlink→copyfile fallback is gated behind `#[cfg(not(windows))]`, so Windows has no recovery path and surfaces the EPERM.

This hits the `bun link` dev workflow hardest: in that mode the agent's `package.json` declares a `file:` typeclaw dep, so Bun copies the entire source tree — including `.git/` — into `<agent>/node_modules/typeclaw`, and the `.git` internals are exactly what Defender tends to lock. End users installing from npm (`^X.Y.Z` registry spec) hit it less often but the same hardlink-permission failure mode applies to any package.

## Summary

Pass `--backend=copyfile` to `bun install` / `bun update` on Windows so Bun skips `CreateHardLinkW` and copies directly via `CopyFileW`, sidestepping the hardlink-permission failure that has no fallback on Windows.

- **Why `copyfile` and not "run as admin" / antivirus exclusions:** those are per-machine manual workarounds that mask the issue; selecting a backend that doesn't depend on hardlinks fixes it for every Windows user with no setup.
- **Why gate on platform:** POSIX keeps Bun's faster defaults (hardlink on Linux, clonefile on macOS) — there's no reason to slow those down.
- The backend selection lives in one helper (`bunInstallBackendArgs`) threaded through both `runBunInstall` and `runBunUpdate`, with a `platform` test seam mirroring the existing `isWindows(platform)` convention in `src/shared/platform.ts`.

This continues the recent Windows-init fix series (`resolve docker via Bun.which`, `fall back to Docker Desktop install paths`).

## What this does NOT do

- Does not change install behavior on Linux or macOS — argv is byte-identical there.
- Does not add retry-on-EPERM, cache clearing (`bun pm cache rm`), or `BUN_INSTALL_CACHE_DIR` redirection. Those are complementary mitigations but out of scope; `--backend=copyfile` addresses the specific hardlink-fallback gap.
- Does not address the deferred native-Windows dev-mode symlink/junction work tracked in #899; it only makes the install copy succeed.

## Review notes

- Load-bearing change: `bunInstallBackendArgs(platform)` returns `['--backend=copyfile']` only on `win32`, `[]` elsewhere. Verify argv ordering — on Windows with `force`, the backend flag must precede `--force` (asserted in the new tests).
- The new test helper `capturingSpawn()` records the argv handed to `spawn` but still returns a real fast-exiting Bun process, so the production `runTimedBunProcess` can `await proc.exited` / read `proc.stderr` without hanging.
