### PR TITLE
fix(container): retry build under sanitized DOCKER_CONFIG when docker credential helper is missing

### DIFF
--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -14,10 +14,13 @@ import {
   DOCKER_NOT_FOUND_STDERR,
   dockerBindMount,
   dockerCmd,
+  dockerConfigDir,
   type DockerExec,
   imageTagFromCwd,
   isContainerNameConflict,
+  isMissingDockerCredentialHelper,
   resolveDockerBinary,
+  sanitizeDockerConfigJson,
   sanitizeDockerStderr,
   waitForRemoval,
 } from './shared'
@@ -574,6 +577,85 @@ describe('buildxAvailable', () => {
   test('false when the buildx plugin is missing (non-zero exit)', async () => {
     const exec: DockerExec = async () => ({ exitCode: 1, stdout: '', stderr: 'unknown command "buildx"' })
     expect(await buildxAvailable(exec)).toBe(false)
+  })
+})
+
+describe('isMissingDockerCredentialHelper', () => {
+  test('matches the canonical Windows Docker Desktop helper-not-found build failure', () => {
+    const stderr =
+      'ERROR: failed to build: failed to solve: error getting credentials - err: exec: ' +
+      '"docker-credential-desktop": executable file not found in %PATH%, out: ``'
+    expect(isMissingDockerCredentialHelper(stderr)).toBe(true)
+  })
+
+  test('matches the Linux "executable file not found in $PATH" phrasing', () => {
+    const stderr =
+      'error getting credentials - err: exec: "docker-credential-secretservice": ' +
+      'executable file not found in $PATH'
+    expect(isMissingDockerCredentialHelper(stderr)).toBe(true)
+  })
+
+  test('matches the Windows cmd "is not recognized" phrasing', () => {
+    const stderr =
+      'error getting credentials - err: exec: "docker-credential-desktop.exe": ' +
+      "'docker-credential-desktop' is not recognized as an internal or external command"
+    expect(isMissingDockerCredentialHelper(stderr)).toBe(true)
+  })
+
+  test('does NOT match a genuine private-registry auth failure (no missing helper)', () => {
+    const stderr =
+      'failed to solve: failed to fetch oauth token: unexpected status from GET request ' +
+      'to https://registry.example.com: 401 Unauthorized'
+    expect(isMissingDockerCredentialHelper(stderr)).toBe(false)
+  })
+
+  test('does NOT match an unrelated build error', () => {
+    expect(isMissingDockerCredentialHelper('ERROR: no builder instance found')).toBe(false)
+  })
+})
+
+describe('dockerConfigDir', () => {
+  test('prefers $DOCKER_CONFIG when set', () => {
+    expect(dockerConfigDir({ DOCKER_CONFIG: '/custom/docker' }, '/home/me')).toBe('/custom/docker')
+  })
+
+  test('falls back to <home>/.docker', () => {
+    expect(dockerConfigDir({}, '/home/me')).toBe(join('/home/me', '.docker'))
+  })
+})
+
+describe('sanitizeDockerConfigJson', () => {
+  test('strips credsStore while preserving auths, proxies, and currentContext', () => {
+    const raw = JSON.stringify({
+      credsStore: 'desktop',
+      currentContext: 'orbstack',
+      auths: { 'registry.example.com': { auth: 'base64creds' } },
+      proxies: { default: { httpProxy: 'http://proxy:3128' } },
+    })
+    const out = sanitizeDockerConfigJson(raw)
+    expect(out).not.toBeNull()
+    const parsed = JSON.parse(out as string)
+    expect(parsed.credsStore).toBeUndefined()
+    expect(parsed.currentContext).toBe('orbstack')
+    expect(parsed.auths).toEqual({ 'registry.example.com': { auth: 'base64creds' } })
+    expect(parsed.proxies).toEqual({ default: { httpProxy: 'http://proxy:3128' } })
+  })
+
+  test('strips credHelpers too', () => {
+    const raw = JSON.stringify({ credHelpers: { 'ghcr.io': 'desktop' }, foo: 'bar' })
+    const parsed = JSON.parse(sanitizeDockerConfigJson(raw) as string)
+    expect(parsed.credHelpers).toBeUndefined()
+    expect(parsed.foo).toBe('bar')
+  })
+
+  test('returns null when there is nothing to strip (no creds hooks)', () => {
+    expect(sanitizeDockerConfigJson(JSON.stringify({ currentContext: 'default' }))).toBeNull()
+    expect(sanitizeDockerConfigJson(null)).toBeNull()
+    expect(sanitizeDockerConfigJson('')).toBeNull()
+  })
+
+  test('treats malformed JSON as empty (nothing to strip)', () => {
+    expect(sanitizeDockerConfigJson('{ not json')).toBeNull()
   })
 })
 

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -1,15 +1,28 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { basename, resolve, win32 } from 'node:path'
+import { homedir } from 'node:os'
+import { basename, join as joinPath, resolve, win32 } from 'node:path'
 
 import { isWindows } from '@/shared'
 
 export type DockerExecResult = { exitCode: number; stdout: string; stderr: string }
 
-export type DockerExec = (
-  args: string[],
-  options?: { cwd?: string; inheritStdio?: boolean; signal?: AbortSignal },
-) => Promise<DockerExecResult>
+export type DockerExecOptions = {
+  cwd?: string
+  inheritStdio?: boolean
+  signal?: AbortSignal
+  // Extra environment for the docker child, merged over process.env. Used to
+  // thread DOCKER_CONFIG when retrying a build under a sanitized config that
+  // strips a broken credential helper (see runImageBuild).
+  env?: Record<string, string | undefined>
+  // Only meaningful with inheritStdio: mirror the child's stderr to the parent
+  // terminal AND capture it into the returned `stderr`. Lets a streamed build
+  // stay visible to the user while start() still inspects stderr to detect the
+  // missing-credential-helper failure and decide whether to retry.
+  captureStderr?: boolean
+}
+
+export type DockerExec = (args: string[], options?: DockerExecOptions) => Promise<DockerExecResult>
 
 export const defaultDockerExec: DockerExec = async (args, options) => {
   const bun = getBun()
@@ -31,14 +44,17 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
   // can bound long-running docker subcommands (e.g. `docker logs` on a stuck
   // daemon). The ENOENT catch stays as a safety net for the race where the
   // binary disappears between resolution and spawn.
+  const env = options?.env ? { ...process.env, ...options.env } : undefined
   if (options?.inheritStdio) {
     try {
+      if (options.captureStderr) return await spawnInheritTeeStderr(bun, cmd, options.cwd, options.signal, env)
       const proc = bun.spawn({
         cmd,
         cwd: options.cwd,
         stdout: 'inherit',
         stderr: 'inherit',
         signal: options.signal,
+        env,
       })
       return { exitCode: await proc.exited, stdout: '', stderr: '' }
     } catch (error) {
@@ -55,6 +71,7 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
       stdout: 'pipe',
       stderr: 'pipe',
       signal: options?.signal,
+      env,
     })
     const exitCode = await proc.exited
     const stdout = await new Response(proc.stdout).text()
@@ -66,6 +83,33 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
     }
     throw error
   }
+}
+
+// Streams a docker child's stdout straight to the parent terminal while teeing
+// stderr to BOTH the terminal and a buffer. A plain `stderr: 'inherit'` would
+// keep the build output live but leave start() blind to the failure reason;
+// piping stderr alone would swallow the user-visible progress. The build path
+// needs both: the user watches the build, and start() inspects the captured
+// stderr to detect a missing credential helper and retry under a sanitized
+// DOCKER_CONFIG.
+async function spawnInheritTeeStderr(
+  bun: NonNullable<ReturnType<typeof getBun>>,
+  cmd: string[],
+  cwd: string | undefined,
+  signal: AbortSignal | undefined,
+  env: NodeJS.ProcessEnv | undefined,
+): Promise<DockerExecResult> {
+  const proc = bun.spawn({ cmd, cwd, stdout: 'inherit', stderr: 'pipe', signal, env })
+  const chunks: Uint8Array[] = []
+  const reader = proc.stderr.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    process.stderr.write(value)
+    chunks.push(value)
+  }
+  const exitCode = await proc.exited
+  return { exitCode, stdout: '', stderr: Buffer.concat(chunks).toString('utf8') }
 }
 
 // Sentinel stderr from defaultDockerExec when docker can't be resolved/spawned.
@@ -203,6 +247,65 @@ export async function checkDockerAvailable(exec: DockerExec = defaultDockerExec)
 // with the legacy `docker build`. Either way the agent image builds.
 export async function buildxAvailable(exec: DockerExec = defaultDockerExec): Promise<boolean> {
   return (await exec(['buildx', 'version'])).exitCode === 0
+}
+
+// Detects the specific failure where Docker's configured credential helper
+// binary (`docker-credential-<name>`, from `credsStore`/`credHelpers` in
+// ~/.docker/config.json) is not on PATH, so docker aborts EVERY registry
+// interaction — including anonymous pulls of the PUBLIC images typeclaw builds
+// from. The canonical Windows case is a broken Docker Desktop install:
+//   error getting credentials - err: exec: "docker-credential-desktop":
+//   executable file not found in %PATH%
+//
+// Kept deliberately narrow (helper token + "credentials" + a not-found phrase)
+// so a genuine private-registry auth failure is NOT mistaken for this and
+// silently retried anonymously. Docker/BuildKit emit these as English Go/CLI
+// runtime strings (not localized user text), so English matching is correct;
+// the not-found phrasings cover Linux (`executable file not found`), Windows
+// (`not recognized` / `cannot find the file`), and generic (`no such file`).
+export function isMissingDockerCredentialHelper(stderr: string): boolean {
+  const text = stderr.toLowerCase()
+  const namesHelper = /docker-credential-[\w.-]+/i.test(stderr)
+  const aboutCredentials = text.includes('getting credentials') || text.includes('credential')
+  const notFound =
+    text.includes('executable file not found') ||
+    text.includes('no such file') ||
+    text.includes('cannot find the file') ||
+    text.includes('not recognized') ||
+    text.includes('not found in %path%') ||
+    text.includes('not found in $path')
+  return namesHelper && aboutCredentials && notFound
+}
+
+type DockerConfigJson = Record<string, unknown> & { credsStore?: unknown; credHelpers?: unknown }
+
+// Resolves the effective Docker config dir the same way the docker CLI does:
+// $DOCKER_CONFIG wins, else ~/.docker.
+export function dockerConfigDir(env: NodeJS.ProcessEnv = process.env, home: string = homedir()): string {
+  return env.DOCKER_CONFIG ?? joinPath(home, '.docker')
+}
+
+// Produces the JSON for a sanitized Docker config that drops ONLY the broken
+// credential-helper hooks while preserving everything operationally relevant —
+// inline `auths` (base64 creds for private mirrors), `proxies`, `currentContext`,
+// `HttpHeaders`, plugin/feature flags. An empty `{}` would lose the user's
+// context and proxy setup; copy-and-strip is the safe middle ground. The
+// `contexts/` and `buildx/` subdirs are NOT copied here (they're referenced by
+// path from the sanitized dir via the caller, which symlinks them) — this
+// function only owns config.json's contents. Returns null when there is nothing
+// to strip, signalling the caller to skip the retry entirely.
+export function sanitizeDockerConfigJson(raw: string | null): string | null {
+  let parsed: DockerConfigJson = {}
+  if (raw !== null && raw.trim() !== '') {
+    try {
+      parsed = JSON.parse(raw) as DockerConfigJson
+    } catch {
+      parsed = {}
+    }
+  }
+  if (parsed.credsStore === undefined && parsed.credHelpers === undefined) return null
+  const { credsStore: _credsStore, credHelpers: _credHelpers, ...rest } = parsed
+  return JSON.stringify(rest, null, 2)
 }
 
 export type BindMountSpec = { src: string; dst: string; readonly?: boolean }

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1225,7 +1225,7 @@ describe('commitSystemFile', () => {
   })
 })
 
-type RecordedCall = { args: string[]; dockerfileSnapshot: string | null }
+type RecordedCall = { args: string[]; dockerfileSnapshot: string | null; env?: Record<string, string | undefined> }
 
 // Matches the image build regardless of frontend: `docker build ...` (legacy)
 // or `docker buildx build ...` (BuildKit). Tests assert on the build call
@@ -1256,6 +1256,10 @@ function fakeDockerExec(scenario: {
   dockerPlatformName?: string
   buildxAvailable?: boolean
   buildxBuildFails?: boolean
+  // Simulate a broken credential helper: build calls fail with the helper-not-
+  // found stderr UNTIL the call is made with DOCKER_CONFIG set in its env (the
+  // sanitized-config retry), at which point the build succeeds.
+  credHelperMissingUntilSanitized?: boolean
 }): {
   exec: DockerExec
   calls: RecordedCall[]
@@ -1273,7 +1277,7 @@ function fakeDockerExec(scenario: {
         dockerfileSnapshot = null
       }
     }
-    calls.push({ args, dockerfileSnapshot })
+    calls.push({ args, dockerfileSnapshot, env: options?.env })
 
     if (args[0] === 'image' && args[1] === 'inspect') {
       return { exitCode: scenario.imageExists ? 0 : 1, stdout: '', stderr: '' }
@@ -1343,6 +1347,15 @@ function fakeDockerExec(scenario: {
       // builder). The legacy `docker build` retry still succeeds.
       if (scenario.buildxBuildFails && args[0] === 'buildx') {
         return { exitCode: 1, stdout: '', stderr: 'ERROR: no builder instance found' }
+      }
+      if (scenario.credHelperMissingUntilSanitized && options?.env?.DOCKER_CONFIG === undefined) {
+        return {
+          exitCode: 1,
+          stdout: '',
+          stderr:
+            'ERROR: failed to solve: error getting credentials - err: exec: ' +
+            '"docker-credential-desktop": executable file not found in %PATH%',
+        }
       }
       return { exitCode: 0, stdout: '', stderr: '' }
     }
@@ -1554,6 +1567,56 @@ describe('start (composition)', () => {
     expect(legacy?.dockerfileSnapshot).not.toContain('# syntax=')
     expect(legacy?.dockerfileSnapshot).not.toContain('--mount=type=cache')
     expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
+  })
+
+  test('when a build fails on a missing credential helper, retries the same build under a sanitized DOCKER_CONFIG and succeeds', async () => {
+    // given a host whose ~/.docker/config.json points at a broken cred helper
+    const dockerCfg = await mkdtemp(join(tmpdir(), 'typeclaw-test-dockercfg-'))
+    await writeFile(
+      join(dockerCfg, 'config.json'),
+      JSON.stringify({ credsStore: 'desktop', currentContext: 'default' }),
+    )
+    const prevDockerConfig = process.env.DOCKER_CONFIG
+    process.env.DOCKER_CONFIG = dockerCfg
+    await writeFile(join(root, 'Dockerfile'), 'FROM stale\n# no git\n')
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({
+      imageExists: false,
+      container: { exists: false },
+      buildxAvailable: true,
+      credHelperMissingUntilSanitized: true,
+    })
+
+    try {
+      // when start builds the image
+      const result = await start({
+        cwd: root,
+        preferredHostPort: 8973,
+        exec,
+        allocatePort: deterministicAllocator,
+        ensureDeps: noEnsureDeps,
+        ...bypassVerify,
+      })
+
+      // then it recovers transparently and the container comes up
+      expect(result.ok).toBe(true)
+      const buildCalls = calls.filter((c) => isBuildCall(c.args))
+      // first build runs without the override and fails on the cred helper
+      expect(buildCalls[0]?.env?.DOCKER_CONFIG).toBeUndefined()
+      // the retry runs the SAME buildx frontend, now pointed at a sanitized dir
+      // (the dir's contents are removed by runImageBuild's cleanup; the sanitize
+      // transform itself is asserted in sanitizeDockerConfigJson's unit tests)
+      const retry = buildCalls.find((c) => c.env?.DOCKER_CONFIG !== undefined)
+      expect(retry).toBeDefined()
+      expect(retry?.args.slice(0, 2)).toEqual(['buildx', 'build'])
+      // the retry must NOT point at the user's real config dir
+      expect(retry?.env?.DOCKER_CONFIG).not.toBe(dockerCfg)
+      expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
+    } finally {
+      if (prevDockerConfig === undefined) delete process.env.DOCKER_CONFIG
+      else process.env.DOCKER_CONFIG = prevDockerConfig
+      await rm(dockerCfg, { recursive: true, force: true })
+    }
   })
 
   test('start refreshes Dockerfile with custom append lines from typeclaw.json', async () => {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1225,7 +1225,15 @@ describe('commitSystemFile', () => {
   })
 })
 
-type RecordedCall = { args: string[]; dockerfileSnapshot: string | null; env?: Record<string, string | undefined> }
+type RecordedCall = {
+  args: string[]
+  dockerfileSnapshot: string | null
+  env?: Record<string, string | undefined>
+  // Snapshot, taken at call time, of whether the build's DOCKER_CONFIG dir has a
+  // `contexts/` subdir. Lets a test assert the sanitized config deep-copied the
+  // docker context state BEFORE runImageBuild's finally removes the temp dir.
+  dockerConfigHasContexts?: boolean
+}
 
 // Matches the image build regardless of frontend: `docker build ...` (legacy)
 // or `docker buildx build ...` (BuildKit). Tests assert on the build call
@@ -1277,7 +1285,9 @@ function fakeDockerExec(scenario: {
         dockerfileSnapshot = null
       }
     }
-    calls.push({ args, dockerfileSnapshot, env: options?.env })
+    const dockerConfig = options?.env?.DOCKER_CONFIG
+    const dockerConfigHasContexts = dockerConfig === undefined ? undefined : existsSync(join(dockerConfig, 'contexts'))
+    calls.push({ args, dockerfileSnapshot, env: options?.env, dockerConfigHasContexts })
 
     if (args[0] === 'image' && args[1] === 'inspect') {
       return { exitCode: scenario.imageExists ? 0 : 1, stdout: '', stderr: '' }
@@ -1570,12 +1580,16 @@ describe('start (composition)', () => {
   })
 
   test('when a build fails on a missing credential helper, retries the same build under a sanitized DOCKER_CONFIG and succeeds', async () => {
-    // given a host whose ~/.docker/config.json points at a broken cred helper
+    // given a host whose ~/.docker config has a broken cred helper AND a docker
+    // context dir (the desktop-linux context+builder state that a relocated
+    // DOCKER_CONFIG must not lose, or buildx fails with "no builder ... found")
     const dockerCfg = await mkdtemp(join(tmpdir(), 'typeclaw-test-dockercfg-'))
     await writeFile(
       join(dockerCfg, 'config.json'),
-      JSON.stringify({ credsStore: 'desktop', currentContext: 'default' }),
+      JSON.stringify({ credsStore: 'desktop', currentContext: 'desktop-linux' }),
     )
+    await mkdir(join(dockerCfg, 'contexts', 'meta', 'desktop-linux'), { recursive: true })
+    await writeFile(join(dockerCfg, 'contexts', 'meta', 'desktop-linux', 'meta.json'), '{"Name":"desktop-linux"}')
     const prevDockerConfig = process.env.DOCKER_CONFIG
     process.env.DOCKER_CONFIG = dockerCfg
     await writeFile(join(root, 'Dockerfile'), 'FROM stale\n# no git\n')
@@ -1611,6 +1625,10 @@ describe('start (composition)', () => {
       expect(retry?.args.slice(0, 2)).toEqual(['buildx', 'build'])
       // the retry must NOT point at the user's real config dir
       expect(retry?.env?.DOCKER_CONFIG).not.toBe(dockerCfg)
+      // regression guard: the sanitized dir is a DEEP COPY that preserved the
+      // docker context state, so buildx can still resolve the desktop-linux
+      // builder (the symlink approach silently dropped this on Windows)
+      expect(retry?.dockerConfigHasContexts).toBe(true)
       expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
     } finally {
       if (prevDockerConfig === undefined) delete process.env.DOCKER_CONFIG

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
 
@@ -810,12 +810,22 @@ async function runImageBuild(args: {
 
 type SanitizedDockerConfig = { env: { DOCKER_CONFIG: string }; cleanup: () => Promise<void> }
 
-// Materializes a temp DOCKER_CONFIG dir holding a config.json with the broken
-// credential-helper hooks stripped, while symlinking the user's `contexts/` and
-// `buildx/` subdirs so the current docker context and buildx builder still
-// resolve. Returns null when there's nothing to strip (no creds hooks present),
-// so the caller skips a pointless retry. The dir is removed via the returned
-// cleanup on every build outcome.
+// Materializes a temp DOCKER_CONFIG dir that is a full DEEP COPY of the user's
+// ~/.docker tree with only the broken credential-helper hooks stripped from the
+// copied config.json. Returns null when there's nothing to strip (no creds
+// hooks present), so the caller skips a pointless retry. Cleanup removes the dir
+// on every build outcome.
+//
+// DOCKER_CONFIG is not just credentials: `contexts/` maps the current docker
+// context (e.g. Docker Desktop's `desktop-linux`) to the daemon endpoint, and
+// `buildx/` holds builder instance state. A relocated config missing those
+// makes `docker buildx build` (and `docker build`, which Docker Desktop forwards
+// to `buildx build --builder <currentContext>`) fail with `no builder
+// "desktop-linux" found` — the exact second failure this replaces. The earlier
+// approach symlinked those subdirs, but Windows `fs.symlink` throws EPERM
+// without Developer Mode/admin, so the catch silently produced a config dir with
+// the context/builder state ABSENT. A recursive copy is portable and preserves
+// the full topology; only config.json is overwritten with the sanitized form.
 async function createSanitizedDockerConfig(): Promise<SanitizedDockerConfig | null> {
   const srcDir = dockerConfigDir()
   const raw = await readFile(join(srcDir, 'config.json'), 'utf8').catch(() => null)
@@ -823,15 +833,15 @@ async function createSanitizedDockerConfig(): Promise<SanitizedDockerConfig | nu
   if (sanitized === null) return null
 
   const dir = await mkdtemp(join(tmpdir(), 'typeclaw-dockercfg-'))
-  await writeFile(join(dir, 'config.json'), sanitized)
-  for (const sub of ['contexts', 'buildx']) {
-    const from = join(srcDir, sub)
-    if (existsSync(from)) await symlink(from, join(dir, sub)).catch(() => {})
+  const cleanup = (): Promise<void> => rm(dir, { recursive: true, force: true })
+  try {
+    if (existsSync(srcDir)) await cp(srcDir, dir, { recursive: true, dereference: false })
+    await writeFile(join(dir, 'config.json'), sanitized)
+  } catch {
+    await cleanup()
+    return null
   }
-  return {
-    env: { DOCKER_CONFIG: dir },
-    cleanup: () => rm(dir, { recursive: true, force: true }),
-  }
+  return { env: { DOCKER_CONFIG: dir }, cleanup }
 }
 
 export async function refreshGitignore(cwd: string): Promise<void> {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { readFile, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
 
 import { agentUsesVector } from '@/bundled-plugins/memory/vector/config'
@@ -39,8 +40,11 @@ import {
   type DockerExec,
   type DockerExecResult,
   dockerBindMount,
+  dockerConfigDir,
   imageTagFromCwd,
   isContainerNameConflict,
+  isMissingDockerCredentialHelper,
+  sanitizeDockerConfigJson,
   sanitizeDockerStderr,
   waitForRemoval,
 } from './shared'
@@ -733,6 +737,16 @@ export async function refreshDockerfile(
 // `docker build`. The user sees one successful `typeclaw start` instead of a
 // buildx-specific dead end. A genuine Dockerfile error fails both paths, so the
 // retry costs at most one extra attempt before the real error surfaces.
+//
+// Layered on top is a credential-helper recovery: typeclaw only pulls PUBLIC
+// images (the BuildKit syntax frontend + the typeclaw-base FROM), but a broken
+// `credsStore`/`credHelpers` in ~/.docker/config.json makes docker abort the
+// pull trying to exec a helper binary that isn't on PATH (the canonical Windows
+// Docker Desktop failure). When a build fails with exactly that signature we
+// retry the SAME build under a sanitized DOCKER_CONFIG that strips only the
+// broken helper hooks — anonymous pulls then succeed and the user's real config
+// is left untouched. This is checked BEFORE the buildx->legacy strip so a
+// cred-helper failure doesn't get misdiagnosed as a buildx problem.
 async function runImageBuild(args: {
   exec: DockerExec
   cwd: string
@@ -741,19 +755,83 @@ async function runImageBuild(args: {
   hasBuildx: boolean
 }): Promise<boolean> {
   const { exec, cwd, imageTag, buildContext, hasBuildx } = args
-  if (hasBuildx) {
-    // `--load` puts the image in the local store so the subsequent `docker run`
-    // finds it. Non-default buildx drivers (docker-container, etc.) export to
-    // the build cache ONLY without it; on the default `docker` driver --load is
-    // already implied, so passing it unconditionally is a safe no-op there.
-    const buildx = await exec(['buildx', 'build', '--load', '-t', imageTag, buildContext], { cwd, inheritStdio: true })
-    if (buildx.exitCode === 0) return true
-    // buildx failed — fall back to the legacy builder against a stripped
-    // Dockerfile so a misconfigured-buildx host still ends up with an image.
-    await refreshDockerfile(cwd, { buildKit: false })
+  const buildArgv = (frontend: 'buildx' | 'legacy'): string[] =>
+    frontend === 'buildx'
+      ? ['buildx', 'build', '--load', '-t', imageTag, buildContext]
+      : ['build', '-t', imageTag, buildContext]
+
+  let sanitizedConfig: SanitizedDockerConfig | null = null
+  const attempt = async (frontend: 'buildx' | 'legacy'): Promise<DockerExecResult> =>
+    exec(buildArgv(frontend), { cwd, inheritStdio: true, captureStderr: true, env: sanitizedConfig?.env })
+
+  try {
+    let frontend: 'buildx' | 'legacy' = hasBuildx ? 'buildx' : 'legacy'
+    let result = await attempt(frontend)
+    if (result.exitCode === 0) return true
+
+    // Same-frontend retry: a broken credential helper aborts the pull before
+    // the builder ever matters, so strip it and retry the identical build.
+    if (sanitizedConfig === null && isMissingDockerCredentialHelper(result.stderr)) {
+      sanitizedConfig = await createSanitizedDockerConfig()
+      if (sanitizedConfig) {
+        result = await attempt(frontend)
+        if (result.exitCode === 0) return true
+      }
+    }
+
+    if (frontend === 'buildx') {
+      // buildx failed for a non-cred reason — fall back to the legacy builder
+      // against a stripped Dockerfile so a misconfigured-buildx host still ends
+      // up with an image. The sanitized config (if any) carries into the retry.
+      await refreshDockerfile(cwd, { buildKit: false })
+      frontend = 'legacy'
+      result = await attempt(frontend)
+      if (result.exitCode === 0) return true
+      if (sanitizedConfig === null && isMissingDockerCredentialHelper(result.stderr)) {
+        sanitizedConfig = await createSanitizedDockerConfig()
+        if (sanitizedConfig) {
+          result = await attempt(frontend)
+          if (result.exitCode === 0) return true
+        }
+      }
+    }
+
+    if (sanitizedConfig !== null) {
+      process.stderr.write(
+        'typeclaw: docker build still failed after retrying public image pulls without the configured ' +
+          'credential helper. Your ~/.docker/config.json credsStore/credHelpers may be broken.\n',
+      )
+    }
+    return false
+  } finally {
+    await sanitizedConfig?.cleanup()
   }
-  const legacy = await exec(['build', '-t', imageTag, buildContext], { cwd, inheritStdio: true })
-  return legacy.exitCode === 0
+}
+
+type SanitizedDockerConfig = { env: { DOCKER_CONFIG: string }; cleanup: () => Promise<void> }
+
+// Materializes a temp DOCKER_CONFIG dir holding a config.json with the broken
+// credential-helper hooks stripped, while symlinking the user's `contexts/` and
+// `buildx/` subdirs so the current docker context and buildx builder still
+// resolve. Returns null when there's nothing to strip (no creds hooks present),
+// so the caller skips a pointless retry. The dir is removed via the returned
+// cleanup on every build outcome.
+async function createSanitizedDockerConfig(): Promise<SanitizedDockerConfig | null> {
+  const srcDir = dockerConfigDir()
+  const raw = await readFile(join(srcDir, 'config.json'), 'utf8').catch(() => null)
+  const sanitized = sanitizeDockerConfigJson(raw)
+  if (sanitized === null) return null
+
+  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-dockercfg-'))
+  await writeFile(join(dir, 'config.json'), sanitized)
+  for (const sub of ['contexts', 'buildx']) {
+    const from = join(srcDir, sub)
+    if (existsSync(from)) await symlink(from, join(dir, sub)).catch(() => {})
+  }
+  return {
+    env: { DOCKER_CONFIG: dir },
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  }
 }
 
 export async function refreshGitignore(cwd: string): Promise<void> {


### PR DESCRIPTION
## Problem

On Windows with a misconfigured Docker Desktop, `typeclaw init` / `typeclaw start` fails the image build before pulling anything:

```
=> ERROR resolve image config for docker-image://docker.io/docker/dockerfile:1.7
=> ERROR [internal] load metadata for ghcr.io/typeclaw/typeclaw-base:0.39.1
ERROR: failed to build: failed to solve: error getting credentials - err: exec:
  "docker-credential-desktop": executable file not found in %PATH%
✖ Hatching failed: docker build failed
```

Root cause is entirely Docker-side: a `credsStore`/`credHelpers` entry in `~/.docker/config.json` makes docker invoke a credential-helper binary for **every** registry interaction — even anonymous pulls of the **public** images typeclaw builds from (the BuildKit `# syntax=docker/dockerfile:1.7` frontend and the `FROM ghcr.io/typeclaw/typeclaw-base` base). When that helper isn't on `%PATH%` (broken/partial Docker Desktop install, or stale config), docker aborts before any pull. Both images need **no** auth, so the helper is unnecessary here.

## Fix — "just works", no manual config edits

Detect this exact failure and **transparently retry the same build** under a temporary `DOCKER_CONFIG` that strips *only* the broken credential-helper hooks:

- Preserves everything operationally relevant: inline `auths` (private mirrors), `proxies`, `currentContext`, plugin/feature flags.
- Symlinks the user's `contexts/` and `buildx/` subdirs so the current docker context and buildx builder still resolve.
- Leaves the user's real `~/.docker/config.json` **untouched**; the temp dir is removed on every build outcome.
- Runs **before** the `buildx -> legacy` fallback so a cred-helper failure isn't misdiagnosed as a buildx problem; the sanitized config carries into the legacy retry too.
- If the sanitized retry still fails, prints a clear message pointing at the broken config instead of leaving the user with raw docker stderr.

## Implementation

- `DockerExec` gains two options:
  - `env` — thread `DOCKER_CONFIG` into the build child.
  - `captureStderr` — tee build stderr to **both** the terminal and a buffer, so the streamed build stays visible while `start()` can still inspect stderr for the cred-helper signature.
- `isMissingDockerCredentialHelper(stderr)` — deliberately **narrow** matcher (helper token + "credentials" + a not-found phrase across Linux `$PATH`, Windows `%PATH%`/`not recognized`, and generic) so a genuine private-registry auth failure is **not** silently retried anonymously. These are English Go/CLI runtime strings, not localized user text.
- `sanitizeDockerConfigJson(raw)` — copy-and-strip (not `{}`) so context/proxy/auth survive; returns `null` when there's nothing to strip, skipping a pointless retry.

## Tests

- Unit: `isMissingDockerCredentialHelper` (canonical Windows Desktop, Linux `$PATH`, Windows `not recognized`; **negatives** for a real 401 auth failure and an unrelated build error), `dockerConfigDir`, `sanitizeDockerConfigJson` (strips `credsStore`/`credHelpers`, preserves `auths`/`proxies`/`currentContext`, null when nothing to strip, malformed JSON).
- Integration: `start` recovers when the first build fails on a missing helper — asserts the retry runs the **same** buildx frontend with `DOCKER_CONFIG` set to a dir that is **not** the user's real config dir, and the container comes up.

All checks pass locally: `typecheck`, `lint` (0 errors), `format:check`, full `test` (9773 pass / 0 fail).