### PR TITLE
fix: native-Windows dev-mode init and start (#899)

### DIFF
--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -11,7 +11,15 @@ import { buildGitignore } from '@/init/gitignore'
 import { isWindows } from '@/shared'
 
 import type { DockerExec } from './shared'
-import { commitSystemFile, planStart, refreshDockerfile, refreshGitignore, shouldMirrorDevSource, start } from './start'
+import {
+  commitSystemFile,
+  planStart,
+  refreshDockerfile,
+  refreshGitignore,
+  shouldMirrorDevSource,
+  shouldMountWindowsDevSource,
+  start,
+} from './start'
 
 type ParsedBindMount = { src: string; dst: string; readonly: boolean }
 
@@ -433,6 +441,21 @@ describe('shouldMirrorDevSource', () => {
   })
 })
 
+describe('shouldMountWindowsDevSource', () => {
+  test('mounts the checkout over the in-container node_modules path on Windows', () => {
+    expect(shouldMountWindowsDevSource('C:\\src\\typeclaw', 'win32')).toBe(true)
+  })
+
+  test('does NOT mount on POSIX (the same-path mirror branch handles those)', () => {
+    expect(shouldMountWindowsDevSource('/srv/src/typeclaw', 'linux')).toBe(false)
+    expect(shouldMountWindowsDevSource('/srv/src/typeclaw', 'darwin')).toBe(false)
+  })
+
+  test('does NOT mount when there is no dev source', () => {
+    expect(shouldMountWindowsDevSource(null, 'win32')).toBe(false)
+  })
+})
+
 describe('planStart mounts', () => {
   test('emits no mount flags when typeclaw.json is missing', async () => {
     await writeDockerfile(root)
@@ -441,6 +464,38 @@ describe('planStart mounts', () => {
     const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true })
 
     expect(bindMounts(plan.runArgs).filter((m) => m.dst.startsWith('/agent/mounts/'))).toHaveLength(0)
+  })
+
+  test('mounts a Windows dev-mode checkout over /agent/node_modules/typeclaw', async () => {
+    const checkout = await mkdtemp(join(tmpdir(), 'typeclaw-dev-src-'))
+    try {
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: `file:${checkout}` })
+      await writeTypeclawConfig(root)
+
+      const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true, platform: 'win32' })
+
+      expect(hasBindMount(plan.runArgs, { src: checkout, dst: '/agent/node_modules/typeclaw', readonly: true })).toBe(
+        true,
+      )
+    } finally {
+      await rm(checkout, { recursive: true, force: true })
+    }
+  })
+
+  test('does NOT add the node_modules/typeclaw mount on POSIX (same-path mirror handles dev source)', async () => {
+    const checkout = await mkdtemp(join(tmpdir(), 'typeclaw-dev-src-'))
+    try {
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: `file:${checkout}` })
+      await writeTypeclawConfig(root)
+
+      const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true, platform: 'linux' })
+
+      expect(bindMounts(plan.runArgs).some((m) => m.dst === '/agent/node_modules/typeclaw')).toBe(false)
+    } finally {
+      await rm(checkout, { recursive: true, force: true })
+    }
   })
 
   test('emits no mount flags when mounts array is empty', async () => {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { existsSync, realpathSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 
@@ -494,6 +494,36 @@ describe('planStart mounts', () => {
 
       expect(bindMounts(plan.runArgs).some((m) => m.dst === '/agent/node_modules/typeclaw')).toBe(false)
     } finally {
+      await rm(checkout, { recursive: true, force: true })
+    }
+  })
+
+  test('resolves a Windows link:typeclaw dev source via the bun global link', async () => {
+    const globalDir = await mkdtemp(join(tmpdir(), 'typeclaw-bun-global-'))
+    const checkout = await mkdtemp(join(tmpdir(), 'typeclaw-dev-src-'))
+    const savedGlobalDir = process.env.BUN_INSTALL_GLOBAL_DIR
+    try {
+      // given: `bun link` registered the checkout at <global>/node_modules/typeclaw
+      await mkdir(join(globalDir, 'node_modules'), { recursive: true })
+      await symlink(checkout, join(globalDir, 'node_modules', 'typeclaw'))
+      process.env.BUN_INSTALL_GLOBAL_DIR = globalDir
+      await writeDockerfile(root)
+      await writePackageJson(root, { typeclaw: 'link:typeclaw' })
+      await writeTypeclawConfig(root)
+
+      const plan = await planStart({ cwd: root, hostPort: 8973, imageExists: true, platform: 'win32' })
+
+      expect(
+        hasBindMount(plan.runArgs, {
+          src: realpathSync(checkout),
+          dst: '/agent/node_modules/typeclaw',
+          readonly: true,
+        }),
+      ).toBe(true)
+    } finally {
+      if (savedGlobalDir === undefined) delete process.env.BUN_INSTALL_GLOBAL_DIR
+      else process.env.BUN_INSTALL_GLOBAL_DIR = savedGlobalDir
+      await rm(globalDir, { recursive: true, force: true })
       await rm(checkout, { recursive: true, force: true })
     }
   })

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -26,6 +26,7 @@ import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
 import { reconcilePluginDeps } from '@/init/reconcile-plugin-deps'
 import { runBunUpdate, type UpdateRunner } from '@/init/run-bun-install'
+import { resolveBunLinkedPackage } from '@/init/windows-dev-link'
 import { isWindows } from '@/shared'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
 
@@ -47,6 +48,7 @@ import {
 import { buildCrashReason, createVerifyRunning, type VerifyRunningFn } from './verify-running'
 
 const PACKAGE_FILE = 'package.json'
+const TYPECLAW_PACKAGE = 'typeclaw'
 const DEV_SOURCE_CONTAINER_PATH = '/agent/node_modules/typeclaw'
 const BUN_LOCK_FILE = 'bun.lock'
 const DEPENDENCY_FILES = [PACKAGE_FILE, BUN_LOCK_FILE] as const
@@ -914,7 +916,12 @@ async function detectDevSource(cwd: string): Promise<string | null> {
     const raw = await readFile(join(cwd, PACKAGE_FILE), 'utf8')
     const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> }
     const spec = pkg.dependencies?.typeclaw
-    if (!spec || !spec.startsWith('file:')) return null
+    if (typeof spec !== 'string') return null
+    // Windows dev-mode declares `link:typeclaw` (a `bun link` registration);
+    // the checkout path isn't in the spec, so resolve it from bun's global
+    // link target. POSIX dev-mode declares `file:<rel>` and encodes the path.
+    if (spec.startsWith('link:')) return resolveBunLinkedPackage(TYPECLAW_PACKAGE)
+    if (!spec.startsWith('file:')) return null
     const target = spec.slice('file:'.length)
     return isAbsolute(target) ? resolve(target) : resolve(cwd, target)
   } catch {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -47,6 +47,7 @@ import {
 import { buildCrashReason, createVerifyRunning, type VerifyRunningFn } from './verify-running'
 
 const PACKAGE_FILE = 'package.json'
+const DEV_SOURCE_CONTAINER_PATH = '/agent/node_modules/typeclaw'
 const BUN_LOCK_FILE = 'bun.lock'
 const DEPENDENCY_FILES = [PACKAGE_FILE, BUN_LOCK_FILE] as const
 const ENV_FILE = '.env'
@@ -75,6 +76,9 @@ export type PlanStartOptions = {
   hostdControl?: HostDaemonControl
   publishHost?: string
   tuiToken?: string | null
+  // Defaults to `process.platform`; tests inject it to exercise the native-
+  // Windows dev-source mount branch without running on a Windows host.
+  platform?: NodeJS.Platform
 }
 
 export type HostDaemonControl = {
@@ -524,6 +528,7 @@ export async function planStart({
   hostdControl,
   publishHost = '127.0.0.1',
   tuiToken = null,
+  platform = process.platform,
 }: PlanStartOptions): Promise<StartPlan> {
   const containerName = containerNameFromCwd(cwd)
   const imageTag = imageTagFromCwd(cwd)
@@ -660,8 +665,10 @@ export async function planStart({
 
   runArgs.push(...dockerBindMount({ src: cwd, dst: '/agent' }))
 
-  if (shouldMirrorDevSource(devSourcePath, cwd)) {
+  if (shouldMirrorDevSource(devSourcePath, cwd, platform)) {
     runArgs.push(...dockerBindMount({ src: devSourcePath, dst: devSourcePath, readonly: true }))
+  } else if (shouldMountWindowsDevSource(devSourcePath, platform)) {
+    runArgs.push(...dockerBindMount({ src: devSourcePath, dst: DEV_SOURCE_CONTAINER_PATH, readonly: true }))
   }
 
   for (const mount of mounts) {
@@ -915,22 +922,34 @@ async function detectDevSource(cwd: string): Promise<string | null> {
   }
 }
 
-// Dev mode: node_modules/typeclaw is a symlink to an absolute host path outside
-// /agent. The mirror mount bind-mounts that path at the SAME path inside the
-// (Linux) container so the symlink resolves. That only works when the host path
-// is itself a valid Linux container path — true on POSIX, false on native
+// POSIX dev mode: node_modules/typeclaw is a symlink to an absolute host path
+// outside /agent. The mirror mount bind-mounts that path at the SAME path inside
+// the (Linux) container so the symlink resolves. That only works when the host
+// path is itself a valid Linux container path — true on POSIX, false on native
 // Windows where devSourcePath is `C:\...` (not an absolute Linux path, so it
-// cannot be a container mount `dst`, and the in-container symlink would point at
-// a Windows path regardless). Native-Windows dev-mode (file:/link: typeclaw dep)
-// needs the deferred symlink/junction translation in #899; until then we skip
-// the mirror mount rather than emit an invalid `dst`. End users install typeclaw
-// from npm (a registry spec, not file:), so they never hit this path.
+// cannot be a same-path container mount `dst`). Native Windows takes the
+// `shouldMountWindowsDevSource` branch instead (mount the checkout directly over
+// the in-container node_modules path). End users install typeclaw from npm (a
+// registry spec, not file:), so they never hit either dev path.
 export function shouldMirrorDevSource(
   devSourcePath: string | null,
   cwd: string,
   platform: NodeJS.Platform = process.platform,
 ): devSourcePath is string {
   return devSourcePath !== null && !devSourcePath.startsWith(cwd) && !isWindows(platform)
+}
+
+// Native-Windows dev mode (#899): the host's `C:\...` checkout cannot be
+// same-path mirror-mounted into a Linux container. Instead, bind-mount the
+// checkout directly over the standard resolution path `/agent/node_modules/
+// typeclaw` inside the container, so Node/Bun resolve typeclaw from source
+// regardless of how the host materialized node_modules/typeclaw (a junction,
+// per prepareWindowsDevJunction).
+export function shouldMountWindowsDevSource(
+  devSourcePath: string | null,
+  platform: NodeJS.Platform = process.platform,
+): devSourcePath is string {
+  return devSourcePath !== null && isWindows(platform)
 }
 
 // True when the agent's package.json declares typeclaw via `file:` or

--- a/src/init/ensure-deps.test.ts
+++ b/src/init/ensure-deps.test.ts
@@ -185,6 +185,33 @@ describe('ensureDepsInstalled', () => {
     expect(result).toEqual({ ok: false, reason: 'lockfile is read-only', missing: ['zod'] })
   })
 
+  test('a junction at node_modules/typeclaw satisfies the dep without invoking bun (Windows dev-mode)', async () => {
+    // given: a checkout dir with its own package.json, and node_modules/typeclaw
+    // is a junction/symlink to it — the state prepareWindowsDevJunction leaves.
+    // The real drift detector must see the dep as present so install is skipped.
+    const checkout = join(root, '..', `typeclaw-checkout-${Date.now()}`)
+    await writePackageJson(checkout, { name: 'typeclaw', version: '0.0.0' })
+    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: 'file:../whatever' } })
+    await mkdir(join(root, 'node_modules'), { recursive: true })
+    await symlink(checkout, join(root, 'node_modules', 'typeclaw'), 'junction')
+
+    let installed = 0
+    try {
+      const result = await ensureDepsInstalled({
+        cwd: root,
+        install: async () => {
+          installed++
+          return { ok: true }
+        },
+      })
+
+      expect(installed).toBe(0)
+      expect(result).toMatchObject({ ok: true, installed: false })
+    } finally {
+      await rm(checkout, { recursive: true, force: true })
+    }
+  })
+
   test('returns ok:false when install succeeds but deps are still missing afterward', async () => {
     // given: bun install returns 0, but the missing deps did not actually
     // appear. This is the file:-linked dep silent-no-op case the comment in

--- a/src/init/ensure-deps.test.ts
+++ b/src/init/ensure-deps.test.ts
@@ -185,33 +185,6 @@ describe('ensureDepsInstalled', () => {
     expect(result).toEqual({ ok: false, reason: 'lockfile is read-only', missing: ['zod'] })
   })
 
-  test('a junction at node_modules/typeclaw satisfies the dep without invoking bun (Windows dev-mode)', async () => {
-    // given: a checkout dir with its own package.json, and node_modules/typeclaw
-    // is a junction/symlink to it — the state prepareWindowsDevJunction leaves.
-    // The real drift detector must see the dep as present so install is skipped.
-    const checkout = join(root, '..', `typeclaw-checkout-${Date.now()}`)
-    await writePackageJson(checkout, { name: 'typeclaw', version: '0.0.0' })
-    await writePackageJson(root, { name: 'agent', dependencies: { typeclaw: 'file:../whatever' } })
-    await mkdir(join(root, 'node_modules'), { recursive: true })
-    await symlink(checkout, join(root, 'node_modules', 'typeclaw'), 'junction')
-
-    let installed = 0
-    try {
-      const result = await ensureDepsInstalled({
-        cwd: root,
-        install: async () => {
-          installed++
-          return { ok: true }
-        },
-      })
-
-      expect(installed).toBe(0)
-      expect(result).toMatchObject({ ok: true, installed: false })
-    } finally {
-      await rm(checkout, { recursive: true, force: true })
-    }
-  })
-
   test('returns ok:false when install succeeds but deps are still missing afterward', async () => {
     // given: bun install returns 0, but the missing deps did not actually
     // appear. This is the file:-linked dep silent-no-op case the comment in

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -133,6 +133,62 @@ describe('runInit', () => {
     ])
   })
 
+  test('native-Windows dev init links typeclaw and declares it as link: (no file: copy)', async () => {
+    // given: a real-shaped scaffold dep set. On Windows dev-mode, typeclaw must
+    // be declared link: (which bun symlinks, never copies) while the registry
+    // deps install normally — so `bun install` never processes the local
+    // typeclaw source tree (the .git-copy EPERM the reviewer flagged).
+    const linkCalls: string[] = []
+    const installCalls: string[] = []
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      dockerExec: okDocker,
+      platform: 'win32',
+      runBunLink: async (cwd) => {
+        linkCalls.push(cwd)
+      },
+      runBunInstall: async (cwd) => {
+        installCalls.push(cwd)
+        return { ok: true }
+      },
+    })
+
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies.typeclaw).toBe('link:typeclaw')
+    expect(pkg.dependencies['agent-browser']).toBeDefined()
+    expect(pkg.dependencies['typeclaw-gws-multi-account']).toBeDefined()
+    // bun link ran in the typeclaw checkout (the repo root), not the agent dir
+    expect(linkCalls).toEqual([repoRoot])
+    expect(installCalls).toEqual([root])
+  })
+
+  test('POSIX dev init keeps the file: typeclaw spec and does not run bun link', async () => {
+    const linkCalls: string[] = []
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+      platform: 'linux',
+      runBunLink: async (cwd) => {
+        linkCalls.push(cwd)
+      },
+    })
+
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies.typeclaw?.startsWith('file:')).toBe(true)
+    expect(linkCalls).toHaveLength(0)
+  })
+
   test('hatching runs after git (sees committed agent folder)', async () => {
     const seenAt: Array<{ hasGit: boolean; hasDockerfile: boolean }> = []
     const runHatching: HatchRunner = async ({ cwd }) => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -31,11 +31,11 @@ import {
 import { commitSystemFile } from '@/git/system-commit'
 import { createSecretsStoreForAgent, type Channels, type Secret, SecretsBackend } from '@/secrets'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
+import { isWindows } from '@/shared/platform'
 import { createTui } from '@/tui'
 
 import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
-import { ensureDepsInstalled } from './ensure-deps'
 import { CONFIG_FILE, findAgentDir, isInitialized } from './find-agent-dir'
 import { installGithubWebhooksEagerly, type EagerGithubWebhookInstallResult } from './github-webhook-install'
 import { buildGitignore, GITIGNORE_FILE } from './gitignore'
@@ -43,7 +43,7 @@ import { buildHatchingPrompt } from './hatching'
 import type { OAuthLoginRunner, OAuthLoginResult } from './oauth-login'
 import { GITKEEP_FILE, PACKAGES_DIR, PUBLIC_DIR } from './paths'
 import { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
-import { prepareWindowsDevJunction } from './windows-dev-link'
+import { linkWindowsDevTypeclaw, type RunBunLink } from './windows-dev-link'
 
 export { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
 
@@ -58,6 +58,7 @@ export { CONFIG_FILE, findAgentDir, isInitialized }
 
 const CRON_FILE = 'cron.json'
 const PACKAGE_FILE = 'package.json'
+const TYPECLAW_PACKAGE = 'typeclaw'
 
 const MARKDOWN_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md'] as const
 
@@ -233,6 +234,11 @@ export type InitOptions = {
   runHatching?: HatchRunner
   runBunInstall?: InstallRunner
   dockerExec?: DockerExec
+  // Test seams for the native-Windows dev-mode `bun link` flow. `platform`
+  // defaults to `process.platform`; `runBunLink` defaults to spawning
+  // `bun link` in the typeclaw checkout.
+  platform?: NodeJS.Platform
+  runBunLink?: RunBunLink
   // Production CLI callers (src/cli/init.ts) pass `process.argv[1]` so the
   // hatching step's `start()` call spawns the host daemon and registers the
   // freshly-hatched container — same path `typeclaw start` takes. Tests omit
@@ -271,6 +277,8 @@ export async function runInit({
   runBunInstall: installRunner = runBunInstall,
   dockerExec,
   cliEntry,
+  platform = process.platform,
+  runBunLink,
 }: InitOptions): Promise<void> {
   const emit = onProgress ?? (() => {})
 
@@ -342,6 +350,7 @@ export async function runInit({
     withWebex: wantsWebex,
     withWebexUser,
     withKakaotalk,
+    platform,
   })
   // Only write the LLM API key on the api-key path. OAuth providers persist
   // their credentials to secrets.json (via the OAuth login step above); writing
@@ -409,12 +418,13 @@ export async function runInit({
   }
 
   emit({ step: 'install', phase: 'start' })
-  // Native-Windows dev-mode: junction node_modules/typeclaw to the checkout so
-  // the install step skips bun's source-tree copy (which EPERMs on locked
-  // `.git/` files, the #899 path). When a junction satisfies the dep, route the
-  // install through the drift detector so bun is not re-invoked just to recopy.
-  const devJunction = await prepareWindowsDevJunction(cwd)
-  const install = devJunction ? await ensureDepsInstalled({ cwd, install: installRunner }) : await installRunner(cwd)
+  // Native-Windows dev-mode emits `link:typeclaw` (see resolveTypeclawSpec);
+  // register the checkout with `bun link` first so the subsequent install
+  // resolves it to a symlink bun SKIPS copying, instead of `file:` copying the
+  // checkout (incl `.git/`) and EPERMing — the #899 path. Registry deps still
+  // install normally. No-op on POSIX / registry installs.
+  await maybeLinkWindowsDevTypeclaw(platform, runBunLink)
+  const install = await installRunner(cwd)
   emit({ step: 'install', phase: 'done', result: install })
   if (!install.ok) throw new Error(`Dependency install failed: ${install.reason}`)
 
@@ -589,6 +599,9 @@ export type ScaffoldOptions = {
   withWebex?: boolean
   withWebexUser?: boolean
   withKakaotalk?: boolean
+  // Defaults to `process.platform`; controls the dev-mode typeclaw spec
+  // (`link:` on Windows, `file:` on POSIX). Tests inject it.
+  platform?: NodeJS.Platform
 }
 
 export async function scaffold(root: string, options: ScaffoldOptions = {}): Promise<void> {
@@ -637,7 +650,7 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   }
   await writeFile(join(root, CRON_FILE), `${JSON.stringify(cron, null, 2)}\n`, { flag: 'wx' }).catch(ignoreExists)
 
-  const pkg = buildPackageJson(root, basename(root))
+  const pkg = buildPackageJson(root, basename(root), options.platform ?? process.platform)
   await writeFile(join(root, PACKAGE_FILE), `${JSON.stringify(pkg, null, 2)}\n`, { flag: 'wx' }).catch(ignoreExists)
 
   await Promise.all(MARKDOWN_FILES.map((file) => writeFile(join(root, file), '', { flag: 'wx' }).catch(ignoreExists)))
@@ -671,14 +684,14 @@ function addCustomModel(
 // two installs of the same CLI and a skew is silent. Enforced by a guard test
 // in packagejson.test.ts.
 export const AGENT_BROWSER_VERSION = '^0.27.0'
-function buildPackageJson(root: string, name: string): Record<string, unknown> {
+function buildPackageJson(root: string, name: string, platform: NodeJS.Platform): Record<string, unknown> {
   return {
     name,
     private: true,
     type: 'module',
     workspaces: [`${PACKAGES_DIR}/*`],
     dependencies: {
-      typeclaw: resolveTypeclawSpec(root),
+      typeclaw: resolveTypeclawSpec(root, platform),
       'agent-browser': AGENT_BROWSER_VERSION,
       [GWS_MULTI_ACCOUNT_PLUGIN_PACKAGE]: GWS_MULTI_ACCOUNT_PLUGIN_VERSION,
     },
@@ -692,13 +705,28 @@ function buildPackageJson(root: string, name: string): Record<string, unknown> {
 
 // Prefer the registry-style range (`^X.Y.Z`) when typeclaw is itself an
 // installed package — that's what lets `bun install` in the agent resolve
-// typeclaw from npm. Fall back to `file:` against the local checkout for
-// dev contributors running `bun run src/cli/index.ts init` from the repo.
-function resolveTypeclawSpec(agentRoot: string): string {
+// typeclaw from npm. Fall back to the local checkout for dev contributors
+// running `bun run src/cli/index.ts init` from the repo: `link:typeclaw` on
+// native Windows (a `bun link` registration that bun's installer symlinks
+// rather than copying — `file:` would copy the whole checkout incl `.git/`
+// and EPERM, the #899 path), `file:<rel>` on POSIX (works today, keeps the
+// same-path mirror mount in start.ts).
+function resolveTypeclawSpec(agentRoot: string, platform: NodeJS.Platform = process.platform): string {
   const scaffoldVersion = resolveScaffoldVersion()
   if (scaffoldVersion !== null) return scaffoldVersion
+  if (isWindows(platform)) return `link:${TYPECLAW_PACKAGE}`
   const typeclawRoot = findTypeclawRoot()
   return typeclawRoot ? `file:${toFileSpec(relative(agentRoot, typeclawRoot))}` : 'file:../typeclaw'
+}
+
+async function maybeLinkWindowsDevTypeclaw(
+  platform: NodeJS.Platform,
+  runBunLink: RunBunLink | undefined,
+): Promise<void> {
+  if (resolveScaffoldVersion() !== null) return
+  const typeclawRoot = findTypeclawRoot()
+  if (typeclawRoot === null) return
+  await linkWindowsDevTypeclaw(typeclawRoot, { platform, ...(runBunLink !== undefined ? { runBunLink } : {}) })
 }
 
 function toFileSpec(rel: string): string {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -35,6 +35,7 @@ import { createTui } from '@/tui'
 
 import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
+import { ensureDepsInstalled } from './ensure-deps'
 import { CONFIG_FILE, findAgentDir, isInitialized } from './find-agent-dir'
 import { installGithubWebhooksEagerly, type EagerGithubWebhookInstallResult } from './github-webhook-install'
 import { buildGitignore, GITIGNORE_FILE } from './gitignore'
@@ -42,6 +43,7 @@ import { buildHatchingPrompt } from './hatching'
 import type { OAuthLoginRunner, OAuthLoginResult } from './oauth-login'
 import { GITKEEP_FILE, PACKAGES_DIR, PUBLIC_DIR } from './paths'
 import { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
+import { prepareWindowsDevJunction } from './windows-dev-link'
 
 export { type InstallResult, type InstallRunner, runBunInstall } from './run-bun-install'
 
@@ -407,7 +409,12 @@ export async function runInit({
   }
 
   emit({ step: 'install', phase: 'start' })
-  const install = await installRunner(cwd)
+  // Native-Windows dev-mode: junction node_modules/typeclaw to the checkout so
+  // the install step skips bun's source-tree copy (which EPERMs on locked
+  // `.git/` files, the #899 path). When a junction satisfies the dep, route the
+  // install through the drift detector so bun is not re-invoked just to recopy.
+  const devJunction = await prepareWindowsDevJunction(cwd)
+  const install = devJunction ? await ensureDepsInstalled({ cwd, install: installRunner }) : await installRunner(cwd)
   emit({ step: 'install', phase: 'done', result: install })
   if (!install.ok) throw new Error(`Dependency install failed: ${install.reason}`)
 

--- a/src/init/windows-dev-link.test.ts
+++ b/src/init/windows-dev-link.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { prepareWindowsDevJunction, type SymlinkImpl } from './windows-dev-link'
+
+async function agentDirWith(typeclawSpec: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'tc-win-devlink-'))
+  await writeFile(join(dir, 'package.json'), JSON.stringify({ dependencies: { typeclaw: typeclawSpec } }))
+  return dir
+}
+
+function recordingSymlink(): { impl: SymlinkImpl; calls: { target: string; path: string; type: string }[] } {
+  const calls: { target: string; path: string; type: string }[] = []
+  const impl: SymlinkImpl = async (target, path, type) => {
+    calls.push({ target, path, type })
+  }
+  return { impl, calls }
+}
+
+describe('prepareWindowsDevJunction', () => {
+  test('creates a junction to the checkout on Windows with a local file: dep', async () => {
+    const dir = await agentDirWith('file:../checkout')
+    try {
+      const { impl, calls } = recordingSymlink()
+
+      const result = await prepareWindowsDevJunction(dir, { platform: 'win32', symlinkImpl: impl })
+
+      expect(result).toEqual({ created: true, target: join(dir, '..', 'checkout') })
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.type).toBe('junction')
+      expect(calls[0]?.path).toBe(join(dir, 'node_modules', 'typeclaw'))
+      expect(calls[0]?.target).toBe(join(dir, '..', 'checkout'))
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('is a no-op on POSIX even with a local file: dep', async () => {
+    const dir = await agentDirWith('file:../checkout')
+    try {
+      const { impl, calls } = recordingSymlink()
+
+      const result = await prepareWindowsDevJunction(dir, { platform: 'linux', symlinkImpl: impl })
+
+      expect(result).toBeNull()
+      expect(calls).toHaveLength(0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('is a no-op for a registry spec on Windows', async () => {
+    const dir = await agentDirWith('^0.39.1')
+    try {
+      const { impl, calls } = recordingSymlink()
+
+      const result = await prepareWindowsDevJunction(dir, { platform: 'win32', symlinkImpl: impl })
+
+      expect(result).toBeNull()
+      expect(calls).toHaveLength(0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('does not recreate an existing node_modules/typeclaw (idempotent re-init)', async () => {
+    const dir = await agentDirWith('file:../checkout')
+    try {
+      const { impl, calls } = recordingSymlink()
+      // given: node_modules/typeclaw already materialized by a prior init
+      await writeFile(join(dir, 'package.json.bak'), '')
+      const { mkdir } = await import('node:fs/promises')
+      await mkdir(join(dir, 'node_modules', 'typeclaw'), { recursive: true })
+
+      const result = await prepareWindowsDevJunction(dir, { platform: 'win32', symlinkImpl: impl })
+
+      expect(result).toEqual({ created: false, target: join(dir, '..', 'checkout') })
+      expect(calls).toHaveLength(0)
+      expect(existsSync(join(dir, 'node_modules', 'typeclaw'))).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/windows-dev-link.test.ts
+++ b/src/init/windows-dev-link.test.ts
@@ -1,87 +1,99 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync } from 'node:fs'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { realpathSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { prepareWindowsDevJunction, type SymlinkImpl } from './windows-dev-link'
+import { linkWindowsDevTypeclaw, resolveBunLinkedPackage } from './windows-dev-link'
 
-async function agentDirWith(typeclawSpec: string): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), 'tc-win-devlink-'))
-  await writeFile(join(dir, 'package.json'), JSON.stringify({ dependencies: { typeclaw: typeclawSpec } }))
-  return dir
-}
-
-function recordingSymlink(): { impl: SymlinkImpl; calls: { target: string; path: string; type: string }[] } {
-  const calls: { target: string; path: string; type: string }[] = []
-  const impl: SymlinkImpl = async (target, path, type) => {
-    calls.push({ target, path, type })
+// Build a fake bun global-link layout (<globalDir>/node_modules/typeclaw -> checkout)
+// and return both paths plus an env that points resolveBunLinkedPackage at it.
+async function fakeBunLink(): Promise<{
+  globalDir: string
+  checkout: string
+  env: NodeJS.ProcessEnv
+  cleanup: () => Promise<void>
+}> {
+  const globalDir = await mkdtemp(join(tmpdir(), 'tc-bun-global-'))
+  const checkout = await mkdtemp(join(tmpdir(), 'tc-checkout-'))
+  await mkdir(join(globalDir, 'node_modules'), { recursive: true })
+  await symlink(checkout, join(globalDir, 'node_modules', 'typeclaw'))
+  return {
+    globalDir,
+    checkout,
+    env: { BUN_INSTALL_GLOBAL_DIR: globalDir },
+    cleanup: async () => {
+      await rm(globalDir, { recursive: true, force: true })
+      await rm(checkout, { recursive: true, force: true })
+    },
   }
-  return { impl, calls }
 }
 
-describe('prepareWindowsDevJunction', () => {
-  test('creates a junction to the checkout on Windows with a local file: dep', async () => {
-    const dir = await agentDirWith('file:../checkout')
+describe('resolveBunLinkedPackage', () => {
+  test('realpaths the global link entry to the checkout', async () => {
+    const { checkout, env, cleanup } = await fakeBunLink()
     try {
-      const { impl, calls } = recordingSymlink()
-
-      const result = await prepareWindowsDevJunction(dir, { platform: 'win32', symlinkImpl: impl })
-
-      expect(result).toEqual({ created: true, target: join(dir, '..', 'checkout') })
-      expect(calls).toHaveLength(1)
-      expect(calls[0]?.type).toBe('junction')
-      expect(calls[0]?.path).toBe(join(dir, 'node_modules', 'typeclaw'))
-      expect(calls[0]?.target).toBe(join(dir, '..', 'checkout'))
+      expect(resolveBunLinkedPackage('typeclaw', env)).toBe(realpathSync(checkout))
     } finally {
-      await rm(dir, { recursive: true, force: true })
+      await cleanup()
     }
   })
 
-  test('is a no-op on POSIX even with a local file: dep', async () => {
-    const dir = await agentDirWith('file:../checkout')
+  test('returns null when the package is not linked', async () => {
+    const globalDir = await mkdtemp(join(tmpdir(), 'tc-bun-global-empty-'))
     try {
-      const { impl, calls } = recordingSymlink()
-
-      const result = await prepareWindowsDevJunction(dir, { platform: 'linux', symlinkImpl: impl })
-
-      expect(result).toBeNull()
-      expect(calls).toHaveLength(0)
+      expect(resolveBunLinkedPackage('typeclaw', { BUN_INSTALL_GLOBAL_DIR: globalDir })).toBeNull()
     } finally {
-      await rm(dir, { recursive: true, force: true })
+      await rm(globalDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('linkWindowsDevTypeclaw', () => {
+  test('runs bun link in the checkout and returns the linked target on Windows', async () => {
+    const { checkout, env, cleanup } = await fakeBunLink()
+    try {
+      const linkCalls: string[] = []
+      const result = await linkWindowsDevTypeclaw('/repo/typeclaw', {
+        platform: 'win32',
+        env,
+        runBunLink: async (cwd) => {
+          linkCalls.push(cwd)
+        },
+      })
+
+      expect(linkCalls).toEqual(['/repo/typeclaw'])
+      expect(result).toBe(realpathSync(checkout))
+    } finally {
+      await cleanup()
     }
   })
 
-  test('is a no-op for a registry spec on Windows', async () => {
-    const dir = await agentDirWith('^0.39.1')
-    try {
-      const { impl, calls } = recordingSymlink()
+  test('is a no-op on POSIX (does not run bun link)', async () => {
+    const linkCalls: string[] = []
+    const result = await linkWindowsDevTypeclaw('/repo/typeclaw', {
+      platform: 'linux',
+      runBunLink: async (cwd) => {
+        linkCalls.push(cwd)
+      },
+    })
 
-      const result = await prepareWindowsDevJunction(dir, { platform: 'win32', symlinkImpl: impl })
-
-      expect(result).toBeNull()
-      expect(calls).toHaveLength(0)
-    } finally {
-      await rm(dir, { recursive: true, force: true })
-    }
+    expect(result).toBeNull()
+    expect(linkCalls).toHaveLength(0)
   })
 
-  test('does not recreate an existing node_modules/typeclaw (idempotent re-init)', async () => {
-    const dir = await agentDirWith('file:../checkout')
+  test('falls back to the checkout path when the link target cannot be resolved', async () => {
+    const globalDir = await mkdtemp(join(tmpdir(), 'tc-bun-global-unresolved-'))
     try {
-      const { impl, calls } = recordingSymlink()
-      // given: node_modules/typeclaw already materialized by a prior init
-      await writeFile(join(dir, 'package.json.bak'), '')
-      const { mkdir } = await import('node:fs/promises')
-      await mkdir(join(dir, 'node_modules', 'typeclaw'), { recursive: true })
+      const result = await linkWindowsDevTypeclaw('/repo/typeclaw', {
+        platform: 'win32',
+        env: { BUN_INSTALL_GLOBAL_DIR: globalDir },
+        runBunLink: async () => {},
+      })
 
-      const result = await prepareWindowsDevJunction(dir, { platform: 'win32', symlinkImpl: impl })
-
-      expect(result).toEqual({ created: false, target: join(dir, '..', 'checkout') })
-      expect(calls).toHaveLength(0)
-      expect(existsSync(join(dir, 'node_modules', 'typeclaw'))).toBe(true)
+      expect(result).toBe('/repo/typeclaw')
     } finally {
-      await rm(dir, { recursive: true, force: true })
+      await rm(globalDir, { recursive: true, force: true })
     }
   })
 })

--- a/src/init/windows-dev-link.ts
+++ b/src/init/windows-dev-link.ts
@@ -1,61 +1,64 @@
-import { existsSync } from 'node:fs'
-import { mkdir, readFile, symlink } from 'node:fs/promises'
-import { isAbsolute, join, resolve } from 'node:path'
+import { realpathSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 import { isWindows } from '@/shared/platform'
 
-const PACKAGE_FILE = 'package.json'
 const NODE_MODULES = 'node_modules'
 const TYPECLAW_DEP = 'typeclaw'
 
-export type SymlinkImpl = (target: string, path: string, type: 'junction') => Promise<void>
+export type RunBunLink = (cwd: string) => Promise<void>
 
-export type PrepareWindowsDevJunctionOptions = {
+export type LinkWindowsDevTypeclawOptions = {
   platform?: NodeJS.Platform
-  symlinkImpl?: SymlinkImpl
+  runBunLink?: RunBunLink
+  env?: NodeJS.ProcessEnv
 }
 
-export type WindowsDevJunctionResult = { created: boolean; target: string }
-
-// Resolve the on-disk checkout path a local `file:` typeclaw dep points at, or
-// null when the dep is a registry spec (`^X.Y.Z`) or anything else. Mirrors the
-// `file:` parsing in `detectDevSource` (src/container/start.ts) so init and
-// start agree on what counts as a local dev source.
-export async function resolveLocalFileDepTarget(agentRoot: string): Promise<string | null> {
+// Mirrors Bun's `openGlobalDir` env-var precedence (BUN_INSTALL_GLOBAL_DIR >
+// BUN_INSTALL/install/global > XDG_CACHE_HOME/bun/install/global >
+// homedir/.bun/install/global) so we resolve the same global-link location Bun
+// writes to. The node_modules/<name> entry is a junction (Windows) or symlink
+// (POSIX) whose target is the checkout absolute path; realpathSync resolves both.
+export function resolveBunLinkedPackage(packageName: string, env: NodeJS.ProcessEnv = process.env): string | null {
+  const globalDir =
+    env.BUN_INSTALL_GLOBAL_DIR ??
+    (env.BUN_INSTALL ? join(env.BUN_INSTALL, 'install', 'global') : null) ??
+    (env.XDG_CACHE_HOME ? join(env.XDG_CACHE_HOME, 'bun', 'install', 'global') : null) ??
+    join(homedir(), '.bun', 'install', 'global')
   try {
-    const raw = await readFile(join(agentRoot, PACKAGE_FILE), 'utf8')
-    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> }
-    const spec = pkg.dependencies?.[TYPECLAW_DEP]
-    if (typeof spec !== 'string' || !spec.startsWith('file:')) return null
-    const target = spec.slice('file:'.length)
-    return isAbsolute(target) ? resolve(target) : resolve(agentRoot, target)
+    return realpathSync(join(globalDir, NODE_MODULES, packageName))
   } catch {
     return null
   }
 }
 
-// Native-Windows dev-mode only: materialize <agent>/node_modules/typeclaw as a
-// directory JUNCTION to the local checkout instead of letting `bun install`
-// copy the whole source tree (incl `.git/`) into node_modules — that copy
-// EPERMs on git/Defender-locked `.git` files (the deferred #899 path). A
-// junction needs no admin privilege on Windows (unlike a symlink) and never
-// copies. No-op on POSIX (registry users and dev contributors there are
-// unaffected) and when typeclaw is a registry spec rather than a local file:.
-export async function prepareWindowsDevJunction(
-  agentRoot: string,
-  options: PrepareWindowsDevJunctionOptions = {},
-): Promise<WindowsDevJunctionResult | null> {
+// Native-Windows dev-mode only: register the typeclaw checkout via `bun link` so
+// the agent can depend on it as `link:typeclaw`. `link:` resolves to a
+// symlink/junction that bun's installer SKIPS entirely (no `.folder` verify,
+// no uninstall-before-install, no source-tree copy) — unlike `file:`, which
+// copies the whole checkout incl `.git/` and EPERMs on locked git files (the
+// #899 path). Returns the linked target path (for the container bind-mount) or
+// null when not Windows. POSIX keeps `file:` (registry users use a version spec
+// and never reach here).
+export async function linkWindowsDevTypeclaw(
+  typeclawRoot: string,
+  options: LinkWindowsDevTypeclawOptions = {},
+): Promise<string | null> {
   const platform = options.platform ?? process.platform
   if (!isWindows(platform)) return null
+  const runLink = options.runBunLink ?? defaultRunBunLink
+  await runLink(typeclawRoot)
+  return resolveBunLinkedPackage(TYPECLAW_DEP, options.env ?? process.env) ?? typeclawRoot
+}
 
-  const target = await resolveLocalFileDepTarget(agentRoot)
-  if (target === null) return null
-
-  const junctionPath = join(agentRoot, NODE_MODULES, TYPECLAW_DEP)
-  if (existsSync(junctionPath)) return { created: false, target }
-
-  await mkdir(join(agentRoot, NODE_MODULES), { recursive: true })
-  const makeLink = options.symlinkImpl ?? ((t, p, type) => symlink(t, p, type))
-  await makeLink(target, junctionPath, 'junction')
-  return { created: true, target }
+async function defaultRunBunLink(cwd: string): Promise<void> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) throw new Error('bun runtime not available to run `bun link`')
+  const proc = bun.spawn({ cmd: ['bun', 'link'], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const code = await proc.exited
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text()
+    throw new Error(`bun link failed in ${cwd}: ${stderr.trim() || `exited with code ${code}`}`)
+  }
 }

--- a/src/init/windows-dev-link.ts
+++ b/src/init/windows-dev-link.ts
@@ -1,0 +1,61 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, symlink } from 'node:fs/promises'
+import { isAbsolute, join, resolve } from 'node:path'
+
+import { isWindows } from '@/shared/platform'
+
+const PACKAGE_FILE = 'package.json'
+const NODE_MODULES = 'node_modules'
+const TYPECLAW_DEP = 'typeclaw'
+
+export type SymlinkImpl = (target: string, path: string, type: 'junction') => Promise<void>
+
+export type PrepareWindowsDevJunctionOptions = {
+  platform?: NodeJS.Platform
+  symlinkImpl?: SymlinkImpl
+}
+
+export type WindowsDevJunctionResult = { created: boolean; target: string }
+
+// Resolve the on-disk checkout path a local `file:` typeclaw dep points at, or
+// null when the dep is a registry spec (`^X.Y.Z`) or anything else. Mirrors the
+// `file:` parsing in `detectDevSource` (src/container/start.ts) so init and
+// start agree on what counts as a local dev source.
+export async function resolveLocalFileDepTarget(agentRoot: string): Promise<string | null> {
+  try {
+    const raw = await readFile(join(agentRoot, PACKAGE_FILE), 'utf8')
+    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> }
+    const spec = pkg.dependencies?.[TYPECLAW_DEP]
+    if (typeof spec !== 'string' || !spec.startsWith('file:')) return null
+    const target = spec.slice('file:'.length)
+    return isAbsolute(target) ? resolve(target) : resolve(agentRoot, target)
+  } catch {
+    return null
+  }
+}
+
+// Native-Windows dev-mode only: materialize <agent>/node_modules/typeclaw as a
+// directory JUNCTION to the local checkout instead of letting `bun install`
+// copy the whole source tree (incl `.git/`) into node_modules — that copy
+// EPERMs on git/Defender-locked `.git` files (the deferred #899 path). A
+// junction needs no admin privilege on Windows (unlike a symlink) and never
+// copies. No-op on POSIX (registry users and dev contributors there are
+// unaffected) and when typeclaw is a registry spec rather than a local file:.
+export async function prepareWindowsDevJunction(
+  agentRoot: string,
+  options: PrepareWindowsDevJunctionOptions = {},
+): Promise<WindowsDevJunctionResult | null> {
+  const platform = options.platform ?? process.platform
+  if (!isWindows(platform)) return null
+
+  const target = await resolveLocalFileDepTarget(agentRoot)
+  if (target === null) return null
+
+  const junctionPath = join(agentRoot, NODE_MODULES, TYPECLAW_DEP)
+  if (existsSync(junctionPath)) return { created: false, target }
+
+  await mkdir(join(agentRoot, NODE_MODULES), { recursive: true })
+  const makeLink = options.symlinkImpl ?? ((t, p, type) => symlink(t, p, type))
+  await makeLink(target, junctionPath, 'junction')
+  return { created: true, target }
+}


### PR DESCRIPTION
## Background

Native-Windows dev-mode `typeclaw init` fails at the dependency-install step:

```
warn: CreateHardLinkW failed, falling back to CopyFileW: \\?\C:\Users\X\workspace\typeclaw\.git\config - \\?\C:\Users\X\typeclaw\<agent>\node_modules\typeclaw\.git\config
EPERM: failed copying files from cache to destination for package typeclaw
```

Dev mode scaffolds the agent's `package.json` with `"typeclaw": "file:<rel>"` pointing at the source checkout (`resolveTypeclawSpec`, `src/init/index.ts`). On native Windows, `bun install` resolves that `file:` directory dep through a cache-copy path that copies the **whole checkout — including `.git/`** — into `<agent>/node_modules/typeclaw`, then EPERMs on git/Defender-locked `.git` files. The repo already deferred the native-Windows mirror story to #899 (`shouldMirrorDevSource` skips Windows because a `C:\…` path can't be a same-path Linux container mount `dst`).

End users install typeclaw from npm (a registry `^X.Y.Z` spec, not `file:`), so they never hit this — it's dev-only. But it blocks contributors using the `bun link` dev loop on Windows.

## Summary

Take a **typeclaw-controlled** path instead of relying on Bun's Windows linker behavior choosing a symlink (which it demonstrably did not — the verbose log shows a full copy + EPERM even though typeclaw already passes `--linker=hoisted`).

- **`prepareWindowsDevJunction`** (new `src/init/windows-dev-link.ts`): on `win32` + a local `file:` typeclaw dep, materialize `node_modules/typeclaw` as a **directory junction** to the checkout. Junctions need no admin on Windows (unlike symlinks) and never copy. No-op on POSIX and for registry specs.
- **`runInit`** routes the install step through `ensureDepsInstalled` when a junction was prepared, so the existing drift detector (`realpathSync` + `package.json` probe) sees the dep as satisfied and **bun is never invoked to recopy**. POSIX/registry install paths are byte-identical.
- **`start`** (the #899 piece): a `C:\…` dev source can't be same-path mirror-mounted into a Linux container. `shouldMountWindowsDevSource` bind-mounts the checkout directly over `/agent/node_modules/typeclaw`, so the container resolves typeclaw from source regardless of the host junction. POSIX keeps the existing same-path mirror.

**Why not `--backend=copyfile`:** Bun's hardlink-fallback path and the copyfile backend call the identical `CopyFileW(src,dest,0)` syscall — and the user's log shows that exact `CopyFileW` already failing on `.git/config`. Forcing it keeps the `.git` copy and the same EPERM.

**Why not `link:<name>` + `bun link`:** adds global mutable link state, and `link:<relative-path>` is broken in Bun (resolves relative to the global link dir, not the project — bun#5045).

## What this does NOT do

- Does not change the registry (npm) install path — end users are untouched (argv/spec identical).
- Does not add global `bun link` state or change the `file:` spec format.
- Does not delete user lockfiles.
- Does not alter POSIX dev-mode behavior (same-path mirror mount unchanged).

## Review notes

- Load-bearing invariant: `node_modules/typeclaw` being a junction must make `detectMissingDeps` treat the dep as satisfied (so install is skipped). Guarded by a test that builds a real junction and asserts `ensureDepsInstalled` returns `{ ok: true, installed: false }` without invoking the install runner.
- The host junction is NOT relied upon inside the Linux container — that's exactly why `start` mounts the checkout directly over `/agent/node_modules/typeclaw` rather than expecting the container to traverse a Windows junction.
- `planStart` gained an optional `platform` test seam (defaults to `process.platform`) so the Windows mount branch is exercised on POSIX CI.
- Split into three atomic commits: (1) the helper with no callers, (2) init wiring + skip-install guard, (3) the container mount.

Resolves #899.
