### PR TITLE
feat(cli): add dev-dep command to switch typeclaw dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,17 @@ bun unlink                # unregisters the global shim
 bun add -g typeclaw       # reinstalls from npm
 ```
 
+### Switching an existing agent between local and npm
+
+`bun link` controls the global `typeclaw` shim, but an already-scaffolded agent folder still pins `typeclaw` in its own `package.json` (`file:../typeclaw` for dev, `^X.Y.Z` for npm). To flip a single agent folder between the two without re-running `init`, use `dev-dep` from inside that folder:
+
+```sh
+typeclaw dev-dep local --path ../typeclaw   # point this agent at your checkout
+typeclaw dev-dep npm                         # flip it back to the published package
+```
+
+It rewrites only `dependencies.typeclaw`, commits the change (`deps: switch typeclaw to {local,npm}`), and refuses to commit if you have unrelated staged work. Run `typeclaw start --build` afterward to rebuild the container against the new spec. See [CLI reference → Dev dependency](https://typeclaw.dev/docs/reference/cli#dev-dependency).
+
 ## Pre-commit checks
 
 All three must pass before every commit. No exceptions, no `--no-verify`:

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -170,6 +170,23 @@ Auto-detection recognizes these layouts:
 
 `--manager` always overrides the detected manager. The scope (global or not) still follows the detected install layout, so `--manager=npm` against a local install runs `npm install typeclaw@latest` (no `-g`), not a stealth global update. Source checkouts have no detectable layout and fall back to a global update — pass `--manager` to pick the registry side.
 
+## Dev dependency
+
+Switches the agent's `package.json` `typeclaw` dependency between a local source checkout and the published npm package. Useful when iterating on TypeClaw itself: point an agent at your working tree, then flip it back to npm when you're done.
+
+```sh
+typeclaw dev-dep local --path ../typeclaw          # point at a local checkout (file: spec)
+typeclaw dev-dep local                             # reuse an existing file: spec or the running CLI's checkout
+typeclaw dev-dep npm                               # pin ^<installed-or-CLI-version>
+typeclaw dev-dep npm --version 0.40.0              # pin a specific ^X.Y.Z
+typeclaw dev-dep local --no-commit                 # update package.json without committing
+```
+
+- **`local`** writes `file:<relative-path>` after verifying the target's `package.json#name` is `typeclaw`. Without `--path`, it reuses an existing `file:` spec or the source checkout the running CLI itself lives in (skipped for npm-installed CLIs).
+- **`npm`** writes `^<version>`, defaulting to the installed package version or the running CLI's version when `--version` is omitted.
+- By default the change is **committed** as `deps: switch typeclaw to {local,npm}`, touching only `package.json`. The commit is skipped (with a notice) outside a git repo, and **refused** when unrelated staged changes are present — pass `--no-commit` to opt out.
+- Only the declared dependency changes; `bun install` is not run. Follow up with `typeclaw start --build` to materialize the switch in the container.
+
 ## Usage
 
 ```sh

--- a/src/cli/builtins.ts
+++ b/src/cli/builtins.ts
@@ -26,6 +26,7 @@ export const BUILTIN_COMMAND_NAMES = [
   'doctor',
   'usage',
   'update',
+  'dev-dep',
   '_hostd',
 ] as const
 

--- a/src/cli/dev-dep.ts
+++ b/src/cli/dev-dep.ts
@@ -1,0 +1,91 @@
+import { defineCommand } from 'citty'
+
+import { DevDepError, switchTypeclawDependency, type TypeclawDepMode } from '@/dev-dep'
+
+import { c, errorLine, successLine } from './ui'
+
+const localCommand = defineCommand({
+  meta: {
+    name: 'local',
+    description: 'point the agent at a local typeclaw checkout (file: spec)',
+  },
+  args: {
+    path: {
+      type: 'string',
+      description: 'path to the local typeclaw checkout (default: existing file: spec or the running CLI)',
+    },
+    'no-commit': {
+      type: 'boolean',
+      description: 'skip auto-committing the package.json change',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    await runSwitch('local', { localPath: args.path, noCommit: args['no-commit'] })
+  },
+})
+
+const npmCommand = defineCommand({
+  meta: {
+    name: 'npm',
+    description: 'point the agent at the published typeclaw package (^version spec)',
+  },
+  args: {
+    version: {
+      type: 'string',
+      description: 'version to pin as ^X.Y.Z (default: installed or CLI version)',
+    },
+    'no-commit': {
+      type: 'boolean',
+      description: 'skip auto-committing the package.json change',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    await runSwitch('npm', { version: args.version, noCommit: args['no-commit'] })
+  },
+})
+
+export const devDepCommand = defineCommand({
+  meta: {
+    name: 'dev-dep',
+    description: "switch the agent's typeclaw dependency between a local checkout and npm",
+  },
+  subCommands: {
+    local: localCommand,
+    npm: npmCommand,
+  },
+})
+
+async function runSwitch(
+  mode: TypeclawDepMode,
+  opts: { localPath?: string; version?: string; noCommit: boolean },
+): Promise<void> {
+  try {
+    const result = await switchTypeclawDependency({
+      agentRoot: process.cwd(),
+      mode,
+      localPath: opts.localPath,
+      version: opts.version,
+      commit: !opts.noCommit,
+    })
+
+    if (!result.changed) {
+      process.stdout.write(`${c.dim(`typeclaw is already on ${result.newSpec}; nothing to change.`)}\n`)
+      return
+    }
+
+    process.stdout.write(`${successLine(`typeclaw: ${result.oldSpec ?? '<none>'} → ${result.newSpec}`)}\n`)
+    if (result.committed) {
+      process.stdout.write(`${c.dim(`Committed: ${result.commitSubject}`)}\n`)
+    } else if (!opts.noCommit) {
+      process.stdout.write(`${c.dim('package.json updated (not committed — not a git repo or commit skipped).')}\n`)
+    }
+  } catch (err) {
+    if (err instanceof DevDepError) {
+      console.error(errorLine(err.message))
+      process.exit(1)
+    }
+    throw err
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,7 @@ const main = defineCommand({
     doctor: () => import('./doctor').then((m) => m.doctorCommand),
     usage: () => import('./usage').then((m) => m.usageCommand),
     update: () => import('./update').then((m) => m.updateCommand),
+    'dev-dep': () => import('./dev-dep').then((m) => m.devDepCommand),
     _hostd: () => import('./hostd').then((m) => m.hostdCommand),
   },
 })

--- a/src/dev-dep/index.test.ts
+++ b/src/dev-dep/index.test.ts
@@ -44,8 +44,9 @@ async function readSpec(): Promise<string | undefined> {
 
 // Records git invocations and answers from a scripted state machine so commit
 // behavior is testable without a real repo. `dirtyFiles` is emitted in
-// `git status --porcelain` shape (`XY <path>`) so the gate parser is exercised.
-function fakeGit(opts: { isRepo: boolean; dirtyFiles?: string[] }): {
+// `git status --porcelain` shape (`XY <path>`) so the gate parser is exercised;
+// `packageJsonTracked` controls the `git ls-files --error-unmatch` probe.
+function fakeGit(opts: { isRepo: boolean; dirtyFiles?: string[]; packageJsonTracked?: boolean }): {
   spawnGit: SpawnGit
   calls: string[][]
 } {
@@ -56,6 +57,8 @@ function fakeGit(opts: { isRepo: boolean; dirtyFiles?: string[] }): {
     if (args[0] === 'rev-parse')
       return opts.isRepo ? ok('true\n') : { exitCode: 128, stdout: '', stderr: 'not a git repository' }
     if (args[0] === 'status') return ok((opts.dirtyFiles ?? []).map((f) => ` M ${f}`).join('\n'))
+    if (args[0] === 'ls-files')
+      return (opts.packageJsonTracked ?? true) ? ok('package.json\n') : { exitCode: 1, stdout: '', stderr: '' }
     if (args[0] === 'add') return ok()
     if (args[0] === 'commit') return ok()
     return ok()
@@ -194,6 +197,19 @@ describe('switchTypeclawDependency — commit safety', () => {
     await expect(
       switchTypeclawDependency({ agentRoot, mode: 'local', localPath: localCheckout, spawnGit: git.spawnGit }),
     ).rejects.toMatchObject({ detail: { kind: 'commit-blocked-dirty' } })
+
+    expect(await readSpec()).toBe('^0.39.0')
+    expect(git.calls.some((c) => c[0] === 'commit')).toBe(false)
+  })
+
+  test('refuses to commit when package.json is untracked (would be staged wholesale)', async () => {
+    await setupAgent('^0.39.0')
+    await setupLocalCheckout()
+    const git = fakeGit({ isRepo: true, packageJsonTracked: false })
+
+    await expect(
+      switchTypeclawDependency({ agentRoot, mode: 'local', localPath: localCheckout, spawnGit: git.spawnGit }),
+    ).rejects.toMatchObject({ detail: { kind: 'commit-blocked-dirty', files: ['package.json'] } })
 
     expect(await readSpec()).toBe('^0.39.0')
     expect(git.calls.some((c) => c[0] === 'commit')).toBe(false)

--- a/src/dev-dep/index.test.ts
+++ b/src/dev-dep/index.test.ts
@@ -43,8 +43,9 @@ async function readSpec(): Promise<string | undefined> {
 }
 
 // Records git invocations and answers from a scripted state machine so commit
-// behavior is testable without a real repo.
-function fakeGit(opts: { isRepo: boolean; stagedFiles?: string[] }): {
+// behavior is testable without a real repo. `dirtyFiles` is emitted in
+// `git status --porcelain` shape (`XY <path>`) so the gate parser is exercised.
+function fakeGit(opts: { isRepo: boolean; dirtyFiles?: string[] }): {
   spawnGit: SpawnGit
   calls: string[][]
 } {
@@ -54,7 +55,7 @@ function fakeGit(opts: { isRepo: boolean; stagedFiles?: string[] }): {
     const ok = (stdout = ''): GitResult => ({ exitCode: 0, stdout, stderr: '' })
     if (args[0] === 'rev-parse')
       return opts.isRepo ? ok('true\n') : { exitCode: 128, stdout: '', stderr: 'not a git repository' }
-    if (args[0] === 'diff') return ok((opts.stagedFiles ?? []).join('\n'))
+    if (args[0] === 'status') return ok((opts.dirtyFiles ?? []).map((f) => ` M ${f}`).join('\n'))
     if (args[0] === 'add') return ok()
     if (args[0] === 'commit') return ok()
     return ok()
@@ -148,13 +149,34 @@ describe('switchTypeclawDependency — npm mode', () => {
       switchTypeclawDependency({ agentRoot, mode: 'npm', version: 'latest', commit: false }),
     ).rejects.toMatchObject({ detail: { kind: 'invalid-version' } })
   })
+
+  test('defaults to the agent installed version when no --version is given (source-checkout safe)', async () => {
+    await setupAgent('file:../typeclaw')
+    await mkdir(join(agentRoot, 'node_modules', 'typeclaw'))
+    await writeFile(
+      join(agentRoot, 'node_modules', 'typeclaw', 'package.json'),
+      JSON.stringify({ name: 'typeclaw', version: '0.41.0' }),
+    )
+
+    const result = await switchTypeclawDependency({ agentRoot, mode: 'npm', commit: false })
+
+    expect(result.newSpec).toBe('^0.41.0')
+  })
+
+  test('falls back to a release ^version when no --version and no installed package (CLI_VERSION)', async () => {
+    await setupAgent('file:../typeclaw')
+
+    const result = await switchTypeclawDependency({ agentRoot, mode: 'npm', commit: false })
+
+    expect(result.newSpec).toMatch(/^\^\d+\.\d+\.\d+$/)
+  })
 })
 
 describe('switchTypeclawDependency — commit safety', () => {
-  test('refuses to commit and leaves package.json unchanged when unrelated staged changes exist', async () => {
+  test('refuses to commit and leaves package.json unchanged when unrelated changes exist', async () => {
     await setupAgent('^0.39.0')
     await setupLocalCheckout()
-    const git = fakeGit({ isRepo: true, stagedFiles: ['other.ts'] })
+    const git = fakeGit({ isRepo: true, dirtyFiles: ['other.ts'] })
 
     await expect(
       switchTypeclawDependency({ agentRoot, mode: 'local', localPath: localCheckout, spawnGit: git.spawnGit }),
@@ -164,19 +186,17 @@ describe('switchTypeclawDependency — commit safety', () => {
     expect(git.calls.some((c) => c[0] === 'commit')).toBe(false)
   })
 
-  test('ignores a staged package.json (our own pending edit) and commits', async () => {
+  test('refuses to commit a pre-existing package.json change so it is not bundled', async () => {
     await setupAgent('^0.39.0')
     await setupLocalCheckout()
-    const git = fakeGit({ isRepo: true, stagedFiles: ['package.json'] })
+    const git = fakeGit({ isRepo: true, dirtyFiles: ['package.json'] })
 
-    const result = await switchTypeclawDependency({
-      agentRoot,
-      mode: 'local',
-      localPath: localCheckout,
-      spawnGit: git.spawnGit,
-    })
+    await expect(
+      switchTypeclawDependency({ agentRoot, mode: 'local', localPath: localCheckout, spawnGit: git.spawnGit }),
+    ).rejects.toMatchObject({ detail: { kind: 'commit-blocked-dirty' } })
 
-    expect(result.committed).toBe(true)
+    expect(await readSpec()).toBe('^0.39.0')
+    expect(git.calls.some((c) => c[0] === 'commit')).toBe(false)
   })
 
   test('writes package.json but does not commit in a non-git folder', async () => {

--- a/src/dev-dep/index.test.ts
+++ b/src/dev-dep/index.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+import { DevDepError, type GitResult, type SpawnGit, switchTypeclawDependency } from './index'
+
+let root: string
+let agentRoot: string
+let localCheckout: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-devdep-'))
+  agentRoot = join(root, 'agent')
+  localCheckout = join(root, 'typeclaw')
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function setupAgent(typeclawSpec: string): Promise<void> {
+  await mkdir(agentRoot)
+  await writeFile(
+    join(agentRoot, 'package.json'),
+    `${JSON.stringify({ name: 'agent', private: true, dependencies: { typeclaw: typeclawSpec } }, null, 2)}\n`,
+  )
+}
+
+async function setupLocalCheckout(name = 'typeclaw'): Promise<void> {
+  await mkdir(localCheckout)
+  await writeFile(join(localCheckout, 'package.json'), JSON.stringify({ name, version: '9.9.9' }))
+}
+
+async function mkdir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true })
+  await (await import('node:fs/promises')).mkdir(dir, { recursive: true })
+}
+
+async function readSpec(): Promise<string | undefined> {
+  const raw = await readFile(join(agentRoot, 'package.json'), 'utf8')
+  return (JSON.parse(raw) as { dependencies?: Record<string, string> }).dependencies?.typeclaw
+}
+
+// Records git invocations and answers from a scripted state machine so commit
+// behavior is testable without a real repo.
+function fakeGit(opts: { isRepo: boolean; stagedFiles?: string[] }): {
+  spawnGit: SpawnGit
+  calls: string[][]
+} {
+  const calls: string[][] = []
+  const spawnGit: SpawnGit = async (args) => {
+    calls.push([...args])
+    const ok = (stdout = ''): GitResult => ({ exitCode: 0, stdout, stderr: '' })
+    if (args[0] === 'rev-parse')
+      return opts.isRepo ? ok('true\n') : { exitCode: 128, stdout: '', stderr: 'not a git repository' }
+    if (args[0] === 'diff') return ok((opts.stagedFiles ?? []).join('\n'))
+    if (args[0] === 'add') return ok()
+    if (args[0] === 'commit') return ok()
+    return ok()
+  }
+  return { spawnGit, calls }
+}
+
+describe('switchTypeclawDependency — local mode', () => {
+  test('writes a file: spec relative to the agent root and commits package.json', async () => {
+    await setupAgent('^0.39.0')
+    await setupLocalCheckout()
+    const git = fakeGit({ isRepo: true })
+
+    const result = await switchTypeclawDependency({
+      agentRoot,
+      mode: 'local',
+      localPath: localCheckout,
+      spawnGit: git.spawnGit,
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.oldSpec).toBe('^0.39.0')
+    expect(result.newSpec).toBe(`file:${relative(agentRoot, localCheckout).split(/[\\/]/).join('/')}`)
+    expect(await readSpec()).toBe(result.newSpec)
+    expect(result.committed).toBe(true)
+    expect(result.commitSubject).toBe('deps: switch typeclaw to local')
+    expect(git.calls.some((c) => c[0] === 'commit' && c.includes('deps: switch typeclaw to local'))).toBe(true)
+  })
+
+  test('rejects a --path whose package.json#name is not "typeclaw"', async () => {
+    await setupAgent('^0.39.0')
+    await setupLocalCheckout('not-typeclaw')
+
+    await expect(
+      switchTypeclawDependency({ agentRoot, mode: 'local', localPath: localCheckout, commit: false }),
+    ).rejects.toMatchObject({ detail: { kind: 'local-path-not-typeclaw' } })
+  })
+
+  test('reuses an existing file: spec when no --path is given', async () => {
+    await setupLocalCheckout()
+    await setupAgent(`file:${relative(agentRoot, localCheckout).split(/[\\/]/).join('/')}`)
+
+    const result = await switchTypeclawDependency({ agentRoot, mode: 'local', commit: false })
+
+    expect(result.changed).toBe(false)
+  })
+
+  test('errors when no --path and no local checkout can be derived from an npm spec', async () => {
+    await setupAgent('^0.39.0')
+
+    await expect(
+      switchTypeclawDependency({
+        agentRoot,
+        mode: 'local',
+        commit: false,
+        findRunningCliCheckout: () => null,
+      }),
+    ).rejects.toMatchObject({ detail: { kind: 'local-path-unresolved' } })
+  })
+})
+
+describe('switchTypeclawDependency — npm mode', () => {
+  test('writes ^<version> from an explicit version and commits', async () => {
+    await setupAgent('file:../typeclaw')
+    const git = fakeGit({ isRepo: true })
+
+    const result = await switchTypeclawDependency({
+      agentRoot,
+      mode: 'npm',
+      version: '0.40.0',
+      spawnGit: git.spawnGit,
+    })
+
+    expect(result.newSpec).toBe('^0.40.0')
+    expect(await readSpec()).toBe('^0.40.0')
+    expect(result.commitSubject).toBe('deps: switch typeclaw to npm')
+  })
+
+  test('normalizes a caret-prefixed version input', async () => {
+    await setupAgent('file:../typeclaw')
+
+    const result = await switchTypeclawDependency({ agentRoot, mode: 'npm', version: '^1.2.3', commit: false })
+
+    expect(result.newSpec).toBe('^1.2.3')
+  })
+
+  test('rejects an invalid version', async () => {
+    await setupAgent('file:../typeclaw')
+
+    await expect(
+      switchTypeclawDependency({ agentRoot, mode: 'npm', version: 'latest', commit: false }),
+    ).rejects.toMatchObject({ detail: { kind: 'invalid-version' } })
+  })
+})
+
+describe('switchTypeclawDependency — commit safety', () => {
+  test('refuses to commit and leaves package.json unchanged when unrelated staged changes exist', async () => {
+    await setupAgent('^0.39.0')
+    await setupLocalCheckout()
+    const git = fakeGit({ isRepo: true, stagedFiles: ['other.ts'] })
+
+    await expect(
+      switchTypeclawDependency({ agentRoot, mode: 'local', localPath: localCheckout, spawnGit: git.spawnGit }),
+    ).rejects.toBeInstanceOf(DevDepError)
+
+    expect(await readSpec()).toBe('^0.39.0')
+    expect(git.calls.some((c) => c[0] === 'commit')).toBe(false)
+  })
+
+  test('ignores a staged package.json (our own pending edit) and commits', async () => {
+    await setupAgent('^0.39.0')
+    await setupLocalCheckout()
+    const git = fakeGit({ isRepo: true, stagedFiles: ['package.json'] })
+
+    const result = await switchTypeclawDependency({
+      agentRoot,
+      mode: 'local',
+      localPath: localCheckout,
+      spawnGit: git.spawnGit,
+    })
+
+    expect(result.committed).toBe(true)
+  })
+
+  test('writes package.json but does not commit in a non-git folder', async () => {
+    await setupAgent('^0.39.0')
+    await setupLocalCheckout()
+    const git = fakeGit({ isRepo: false })
+
+    const result = await switchTypeclawDependency({
+      agentRoot,
+      mode: 'local',
+      localPath: localCheckout,
+      spawnGit: git.spawnGit,
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.committed).toBe(false)
+    expect(git.calls.some((c) => c[0] === 'commit')).toBe(false)
+  })
+
+  test('--no-commit writes package.json without touching git', async () => {
+    await setupAgent('^0.39.0')
+    await setupLocalCheckout()
+    const git = fakeGit({ isRepo: true })
+
+    const result = await switchTypeclawDependency({
+      agentRoot,
+      mode: 'local',
+      localPath: localCheckout,
+      commit: false,
+      spawnGit: git.spawnGit,
+    })
+
+    expect(result.committed).toBe(false)
+    expect(git.calls.length).toBe(0)
+  })
+})
+
+describe('switchTypeclawDependency — errors', () => {
+  test('throws no-package-json when agent folder has none', async () => {
+    await mkdir(agentRoot)
+
+    await expect(
+      switchTypeclawDependency({ agentRoot, mode: 'npm', version: '1.0.0', commit: false }),
+    ).rejects.toMatchObject({ detail: { kind: 'no-package-json' } })
+  })
+
+  test('throws no-typeclaw-dependency when dependencies lacks typeclaw', async () => {
+    await mkdir(agentRoot)
+    await writeFile(join(agentRoot, 'package.json'), JSON.stringify({ name: 'agent', dependencies: { zod: '^4' } }))
+
+    await expect(
+      switchTypeclawDependency({ agentRoot, mode: 'npm', version: '1.0.0', commit: false }),
+    ).rejects.toMatchObject({ detail: { kind: 'no-typeclaw-dependency' } })
+  })
+})

--- a/src/dev-dep/index.ts
+++ b/src/dev-dep/index.ts
@@ -155,15 +155,27 @@ function readInstalledTypeclawVersion(agentRoot: string): string | null {
 // dependency edit. Blocks on any pre-existing change — a dirty package.json
 // (staged or in the worktree) would otherwise get bundled wholesale by the
 // later `git commit -- package.json`, and any other staged file would ride
-// along in the same commit. Throws on blockers; returns null for a non-repo.
+// along in the same commit. An UNTRACKED package.json is also a blocker: a
+// later `git add -- package.json` would stage the whole pre-existing file. We
+// deliberately ignore other untracked files, since an agent folder legitimately
+// carries untracked content (workspace/, mounts/, etc.). Throws on blockers;
+// returns null for a non-repo.
 async function resolveCommitContext(agentRoot: string, spawnGit: SpawnGit): Promise<{ ok: true } | null> {
   const repoCheck = await spawnGit(['rev-parse', '--is-inside-work-tree'], agentRoot)
   if (repoCheck.exitCode !== 0 || repoCheck.stdout.trim() !== 'true') return null
 
   const blockers = await dirtyPaths(agentRoot, spawnGit)
+  if (!(await isPackageJsonTracked(agentRoot, spawnGit)) && !blockers.includes(PACKAGE_FILE)) {
+    blockers.push(PACKAGE_FILE)
+  }
   if (blockers.length > 0) throw new DevDepError({ kind: 'commit-blocked-dirty', files: blockers })
 
   return { ok: true }
+}
+
+async function isPackageJsonTracked(agentRoot: string, spawnGit: SpawnGit): Promise<boolean> {
+  const res = await spawnGit(['ls-files', '--error-unmatch', '--', PACKAGE_FILE], agentRoot)
+  return res.exitCode === 0
 }
 
 async function commitPackageJson(agentRoot: string, subject: string, spawnGit: SpawnGit): Promise<boolean> {

--- a/src/dev-dep/index.ts
+++ b/src/dev-dep/index.ts
@@ -1,0 +1,260 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { isAbsolute, join, relative, resolve } from 'node:path'
+
+import { resolveScaffoldVersion } from '@/init/cli-version'
+import { editDependencySpec, type ParsedPackage, writeDependencySpec } from '@/init/packagejson-edit'
+
+const PACKAGE_FILE = 'package.json'
+const TYPECLAW = 'typeclaw'
+
+export type TypeclawDepMode = 'local' | 'npm'
+
+export type GitResult = { exitCode: number; stdout: string; stderr: string }
+export type SpawnGit = (args: readonly string[], cwd: string) => Promise<GitResult>
+
+export type SwitchTypeclawDepOptions = {
+  agentRoot: string
+  mode: TypeclawDepMode
+  // local mode: path to the local typeclaw checkout. When omitted, falls back
+  // to an existing `file:` spec or the running CLI's own checkout.
+  localPath?: string
+  // npm mode: the version to pin as `^<version>`. When omitted, resolved from
+  // the installed package or the scaffold version of the running CLI.
+  version?: string
+  commit?: boolean
+  spawnGit?: SpawnGit
+  // Test seam: overrides the running-CLI checkout discovery so tests can
+  // simulate an npm-installed CLI (no separate dev tree → null).
+  findRunningCliCheckout?: () => string | null
+}
+
+export type SwitchTypeclawDepResult = {
+  changed: boolean
+  oldSpec: string | null
+  newSpec: string
+  packageJsonPath: string
+  committed: boolean
+  commitSubject?: string
+}
+
+export type SwitchTypeclawDepError =
+  | { kind: 'no-package-json'; path: string }
+  | { kind: 'no-typeclaw-dependency' }
+  | { kind: 'local-path-unresolved' }
+  | { kind: 'local-path-not-typeclaw'; path: string }
+  | { kind: 'version-unresolved' }
+  | { kind: 'invalid-version'; version: string }
+  | { kind: 'commit-blocked-dirty'; files: string[] }
+
+export class DevDepError extends Error {
+  constructor(readonly detail: SwitchTypeclawDepError) {
+    super(describeError(detail))
+    this.name = 'DevDepError'
+  }
+}
+
+export async function switchTypeclawDependency(options: SwitchTypeclawDepOptions): Promise<SwitchTypeclawDepResult> {
+  const { agentRoot, mode } = options
+  const packageJsonPath = join(agentRoot, PACKAGE_FILE)
+  const pkg = await readPackageJson(packageJsonPath)
+  if (pkg === null) throw new DevDepError({ kind: 'no-package-json', path: packageJsonPath })
+
+  const oldSpec = pkg.parsed.dependencies?.[TYPECLAW] ?? null
+  if (oldSpec === null) throw new DevDepError({ kind: 'no-typeclaw-dependency' })
+
+  const newSpec =
+    mode === 'local'
+      ? resolveLocalSpec(
+          agentRoot,
+          oldSpec,
+          options.localPath,
+          options.findRunningCliCheckout ?? findRunningCliCheckout,
+        )
+      : resolveNpmSpec(options.version)
+
+  if (newSpec === oldSpec) {
+    return { changed: false, oldSpec, newSpec, packageJsonPath, committed: false }
+  }
+
+  const shouldCommit = options.commit ?? true
+  const spawnGit = options.spawnGit ?? defaultSpawnGit
+  // Gate on a clean index BEFORE writing so a refused commit never leaves the
+  // edit half-applied (package.json changed but uncommitted, with unrelated
+  // staged work the user must now untangle).
+  const gitRepo = shouldCommit ? await resolveCommitContext(agentRoot, spawnGit) : null
+
+  await writeDependencySpec(packageJsonPath, pkg, TYPECLAW, newSpec)
+
+  if (!shouldCommit || gitRepo === null) {
+    return { changed: true, oldSpec, newSpec, packageJsonPath, committed: false }
+  }
+
+  const commitSubject = `deps: switch typeclaw to ${mode === 'local' ? 'local' : 'npm'}`
+  const committed = await commitPackageJson(agentRoot, commitSubject, spawnGit)
+  return {
+    changed: true,
+    oldSpec,
+    newSpec,
+    packageJsonPath,
+    committed,
+    commitSubject: committed ? commitSubject : undefined,
+  }
+}
+
+function resolveLocalSpec(
+  agentRoot: string,
+  oldSpec: string,
+  localPath: string | undefined,
+  findCheckout: () => string | null,
+): string {
+  const candidate = localPath ?? deriveLocalCheckout(oldSpec, agentRoot, findCheckout)
+  if (candidate === null) throw new DevDepError({ kind: 'local-path-unresolved' })
+
+  const absolute = isAbsolute(candidate) ? candidate : resolve(agentRoot, candidate)
+  if (!isTypeclawCheckout(absolute)) throw new DevDepError({ kind: 'local-path-not-typeclaw', path: absolute })
+
+  return `file:${toFileSpec(relative(agentRoot, absolute))}`
+}
+
+// Without an explicit --path, reuse an existing `file:` spec (already local) or
+// fall back to the running CLI's own checkout — but only when the CLI is a dev
+// checkout, not an npm install (an npm-installed CLI lives under node_modules
+// and is not a separate dev tree to point at).
+function deriveLocalCheckout(oldSpec: string, agentRoot: string, findCheckout: () => string | null): string | null {
+  if (oldSpec.startsWith('file:')) return resolve(agentRoot, oldSpec.slice('file:'.length))
+  return findCheckout()
+}
+
+function resolveNpmSpec(version: string | undefined): string {
+  const resolved = version ?? stripCaret(resolveScaffoldVersion())
+  if (resolved === null) throw new DevDepError({ kind: 'version-unresolved' })
+
+  const normalized = normalizeVersion(resolved)
+  if (normalized === null) throw new DevDepError({ kind: 'invalid-version', version: resolved })
+
+  return `^${normalized}`
+}
+
+// Validates the agent folder is a git repo with no unrelated staged changes,
+// returning a marker the caller uses to decide whether to commit post-write.
+// Throws on blockers (unrelated staged files); returns null for a non-repo.
+async function resolveCommitContext(agentRoot: string, spawnGit: SpawnGit): Promise<{ ok: true } | null> {
+  const repoCheck = await spawnGit(['rev-parse', '--is-inside-work-tree'], agentRoot)
+  if (repoCheck.exitCode !== 0 || repoCheck.stdout.trim() !== 'true') return null
+
+  const staged = await stagedFiles(agentRoot, spawnGit)
+  const blockers = staged.filter((f) => f !== PACKAGE_FILE)
+  if (blockers.length > 0) throw new DevDepError({ kind: 'commit-blocked-dirty', files: blockers })
+
+  return { ok: true }
+}
+
+async function commitPackageJson(agentRoot: string, subject: string, spawnGit: SpawnGit): Promise<boolean> {
+  const add = await spawnGit(['add', '--', PACKAGE_FILE], agentRoot)
+  if (add.exitCode !== 0) return false
+
+  const commit = await spawnGit(['commit', '-m', subject, '--', PACKAGE_FILE], agentRoot)
+  return commit.exitCode === 0
+}
+
+// Files already staged in the index, excluding our own package.json edit. We
+// refuse to commit when other staged changes exist so the dep switch never
+// silently bundles unrelated work into its commit.
+async function stagedFiles(agentRoot: string, spawnGit: SpawnGit): Promise<string[]> {
+  const res = await spawnGit(['diff', '--cached', '--name-only'], agentRoot)
+  if (res.exitCode !== 0) return []
+  return res.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+async function readPackageJson(path: string): Promise<ParsedPackage | null> {
+  if (!existsSync(path)) return null
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+  return { raw, parsed: parsed as ParsedPackage['parsed'] }
+}
+
+function isTypeclawCheckout(dir: string): boolean {
+  try {
+    const pkg = JSON.parse(readFileSync(join(dir, PACKAGE_FILE), 'utf8')) as { name?: string }
+    return pkg.name === TYPECLAW
+  } catch {
+    return false
+  }
+}
+
+function findRunningCliCheckout(): string | null {
+  try {
+    let dir = import.meta.dir
+    const root = resolve('/')
+    while (dir !== root) {
+      if (isTypeclawCheckout(dir) && !dir.includes(`${join('/', 'node_modules', '/')}`)) return dir
+      dir = join(dir, '..')
+      dir = resolve(dir)
+    }
+  } catch {}
+  return null
+}
+
+function toFileSpec(rel: string): string {
+  if (rel === '') return '.'
+  return rel.split(/[\\/]/).join('/')
+}
+
+function stripCaret(scaffold: string | null): string | null {
+  if (scaffold === null) return null
+  const m = scaffold.match(/^\^?(\d+\.\d+\.\d+)$/)
+  return m ? (m[1] ?? null) : null
+}
+
+function normalizeVersion(version: string): string | null {
+  const m = version.trim().match(/^[\^~=]?(\d+\.\d+\.\d+)$/)
+  return m ? (m[1] ?? null) : null
+}
+
+function describeError(detail: SwitchTypeclawDepError): string {
+  switch (detail.kind) {
+    case 'no-package-json':
+      return `No package.json found at ${detail.path}. Run this from an agent folder.`
+    case 'no-typeclaw-dependency':
+      return 'No "typeclaw" entry in package.json dependencies. Run `typeclaw init` first.'
+    case 'local-path-unresolved':
+      return 'Could not resolve a local typeclaw checkout. Pass --path <dir>.'
+    case 'local-path-not-typeclaw':
+      return `${detail.path} is not a typeclaw checkout (package.json#name !== "typeclaw").`
+    case 'version-unresolved':
+      return 'Could not resolve a typeclaw version. Pass --version <X.Y.Z>.'
+    case 'invalid-version':
+      return `Invalid version "${detail.version}". Expected X.Y.Z.`
+    case 'commit-blocked-dirty':
+      return `Refusing to commit: unrelated staged changes present (${detail.files.join(', ')}). Commit or unstage them, or pass --no-commit.`
+  }
+}
+
+const defaultSpawnGit: SpawnGit = async (args, cwd) => {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) return { exitCode: -1, stdout: '', stderr: 'bun runtime not available' }
+  try {
+    const proc = bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    return { exitCode, stdout, stderr }
+  } catch (err) {
+    return { exitCode: -1, stdout: '', stderr: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/dev-dep/index.ts
+++ b/src/dev-dep/index.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve } from 'node:path'
 
-import { resolveScaffoldVersion } from '@/init/cli-version'
-import { editDependencySpec, type ParsedPackage, writeDependencySpec } from '@/init/packagejson-edit'
+import { CLI_VERSION } from '@/init/cli-version'
+import { type ParsedPackage, writeDependencySpec } from '@/init/packagejson-edit'
 
 const PACKAGE_FILE = 'package.json'
 const TYPECLAW = 'typeclaw'
@@ -71,7 +71,7 @@ export async function switchTypeclawDependency(options: SwitchTypeclawDepOptions
           options.localPath,
           options.findRunningCliCheckout ?? findRunningCliCheckout,
         )
-      : resolveNpmSpec(options.version)
+      : resolveNpmSpec(agentRoot, options.version)
 
   if (newSpec === oldSpec) {
     return { changed: false, oldSpec, newSpec, packageJsonPath, committed: false }
@@ -126,25 +126,41 @@ function deriveLocalCheckout(oldSpec: string, agentRoot: string, findCheckout: (
   return findCheckout()
 }
 
-function resolveNpmSpec(version: string | undefined): string {
-  const resolved = version ?? stripCaret(resolveScaffoldVersion())
+function resolveNpmSpec(agentRoot: string, version: string | undefined): string {
+  if (version !== undefined) {
+    const normalized = normalizeVersion(version)
+    if (normalized === null) throw new DevDepError({ kind: 'invalid-version', version })
+    return `^${normalized}`
+  }
+
+  // Default chain works from a source checkout too (where the npm-only
+  // resolveScaffoldVersion() returns null): the agent's installed package
+  // version is the most accurate target, then the running CLI's own version.
+  const resolved = readInstalledTypeclawVersion(agentRoot) ?? normalizeVersion(CLI_VERSION)
   if (resolved === null) throw new DevDepError({ kind: 'version-unresolved' })
 
-  const normalized = normalizeVersion(resolved)
-  if (normalized === null) throw new DevDepError({ kind: 'invalid-version', version: resolved })
-
-  return `^${normalized}`
+  return `^${resolved}`
 }
 
-// Validates the agent folder is a git repo with no unrelated staged changes,
-// returning a marker the caller uses to decide whether to commit post-write.
-// Throws on blockers (unrelated staged files); returns null for a non-repo.
+function readInstalledTypeclawVersion(agentRoot: string): string | null {
+  try {
+    const raw = readFileSync(join(agentRoot, 'node_modules', TYPECLAW, PACKAGE_FILE), 'utf8')
+    const parsed = JSON.parse(raw) as { version?: string }
+    if (typeof parsed.version === 'string') return normalizeVersion(parsed.version)
+  } catch {}
+  return null
+}
+
+// Run BEFORE the write so the commit can contain ONLY this command's own
+// dependency edit. Blocks on any pre-existing change — a dirty package.json
+// (staged or in the worktree) would otherwise get bundled wholesale by the
+// later `git commit -- package.json`, and any other staged file would ride
+// along in the same commit. Throws on blockers; returns null for a non-repo.
 async function resolveCommitContext(agentRoot: string, spawnGit: SpawnGit): Promise<{ ok: true } | null> {
   const repoCheck = await spawnGit(['rev-parse', '--is-inside-work-tree'], agentRoot)
   if (repoCheck.exitCode !== 0 || repoCheck.stdout.trim() !== 'true') return null
 
-  const staged = await stagedFiles(agentRoot, spawnGit)
-  const blockers = staged.filter((f) => f !== PACKAGE_FILE)
+  const blockers = await dirtyPaths(agentRoot, spawnGit)
   if (blockers.length > 0) throw new DevDepError({ kind: 'commit-blocked-dirty', files: blockers })
 
   return { ok: true }
@@ -158,16 +174,17 @@ async function commitPackageJson(agentRoot: string, subject: string, spawnGit: S
   return commit.exitCode === 0
 }
 
-// Files already staged in the index, excluding our own package.json edit. We
-// refuse to commit when other staged changes exist so the dep switch never
-// silently bundles unrelated work into its commit.
-async function stagedFiles(agentRoot: string, spawnGit: SpawnGit): Promise<string[]> {
-  const res = await spawnGit(['diff', '--cached', '--name-only'], agentRoot)
+// Every path with a staged or worktree change, per `git status --porcelain`.
+// The porcelain format is `XY <path>` where X is the index status and Y the
+// worktree status; we take the path regardless of which side is dirty so a
+// pre-existing package.json edit is caught even when only the worktree differs.
+async function dirtyPaths(agentRoot: string, spawnGit: SpawnGit): Promise<string[]> {
+  const res = await spawnGit(['status', '--porcelain', '--untracked-files=no'], agentRoot)
   if (res.exitCode !== 0) return []
   return res.stdout
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
+    .map((line) => line.slice(3).trim())
+    .filter((path) => path.length > 0)
 }
 
 async function readPackageJson(path: string): Promise<ParsedPackage | null> {
@@ -215,12 +232,6 @@ function toFileSpec(rel: string): string {
   return rel.split(/[\\/]/).join('/')
 }
 
-function stripCaret(scaffold: string | null): string | null {
-  if (scaffold === null) return null
-  const m = scaffold.match(/^\^?(\d+\.\d+\.\d+)$/)
-  return m ? (m[1] ?? null) : null
-}
-
 function normalizeVersion(version: string): string | null {
   const m = version.trim().match(/^[\^~=]?(\d+\.\d+\.\d+)$/)
   return m ? (m[1] ?? null) : null
@@ -241,7 +252,7 @@ function describeError(detail: SwitchTypeclawDepError): string {
     case 'invalid-version':
       return `Invalid version "${detail.version}". Expected X.Y.Z.`
     case 'commit-blocked-dirty':
-      return `Refusing to commit: unrelated staged changes present (${detail.files.join(', ')}). Commit or unstage them, or pass --no-commit.`
+      return `Refusing to commit: uncommitted changes present (${detail.files.join(', ')}). Commit or stash them, or pass --no-commit.`
   }
 }
 

--- a/src/init/auto-upgrade.ts
+++ b/src/init/auto-upgrade.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { resolveScaffoldVersion } from './cli-version'
+import { type ParsedPackage, writeDependencySpec } from './packagejson-edit'
 
 const PACKAGE_FILE = 'package.json'
 const TYPECLAW = 'typeclaw'
@@ -94,7 +95,7 @@ export async function autoUpgradeTypeclawDep(options: AutoUpgradeOptions): Promi
 
   if (!rangeSatisfies(declaredKind, cliVersion)) {
     const newSpec = `^${cliVersion}`
-    await writeDepSpec(cwd, pkg.raw, pkg.parsed, newSpec)
+    await writeDependencySpec(join(cwd, PACKAGE_FILE), pkg, TYPECLAW, newSpec)
     return { kind: 'spec-rewritten', from: declared, to: newSpec, cliVersion }
   }
 
@@ -139,11 +140,6 @@ export function describeAutoUpgrade(outcome: AutoUpgradeOutcome): string {
 
 export function readInstalledTypeclawVersionFromAgent(cwd: string): string | null {
   return readInstalledTypeclawVersion(cwd)
-}
-
-type ParsedPackage = {
-  raw: string
-  parsed: { dependencies?: Record<string, string> } & Record<string, unknown>
 }
 
 async function readAgentPackageJson(cwd: string): Promise<ParsedPackage | null> {
@@ -283,86 +279,4 @@ function stripCaret(scaffold: string): string | null {
 
 function isReleaseVersion(version: string): boolean {
   return /^\d+\.\d+\.\d+$/.test(version)
-}
-
-async function writeDepSpec(cwd: string, raw: string, parsed: ParsedPackage['parsed'], newSpec: string): Promise<void> {
-  // Scoped edit: replace the typeclaw spec ONLY inside the dependencies
-  // object. The previous implementation used `raw.replace(/"typeclaw":.../)`
-  // unscoped, which would silently rewrite devDependencies.typeclaw if it
-  // appeared before dependencies.typeclaw in the file (the original spec
-  // never moves). We slice the dependencies object's textual range, edit
-  // inside it, then splice back to preserve whitespace, key order, and
-  // trailing newline. If the slice fails (unusual JSON shape), fall back
-  // to a full JSON round-trip — formatting churn is acceptable; silently
-  // updating the wrong key is not.
-  const scoped = sliceDependenciesRange(raw, parsed)
-  if (scoped !== null) {
-    const { start, end } = scoped
-    const block = raw.slice(start, end)
-    const replaced = block.replace(
-      /("typeclaw"\s*:\s*)"[^"]+"/,
-      (_m, prefix: string) => `${prefix}${JSON.stringify(newSpec)}`,
-    )
-    if (replaced !== block) {
-      await writeFile(join(cwd, PACKAGE_FILE), `${raw.slice(0, start)}${replaced}${raw.slice(end)}`)
-      return
-    }
-  }
-  const deps = { ...parsed.dependencies, [TYPECLAW]: newSpec }
-  const next = { ...parsed, dependencies: deps }
-  const indent = detectIndent(raw)
-  await writeFile(join(cwd, PACKAGE_FILE), `${JSON.stringify(next, null, indent)}\n`)
-}
-
-// Returns the [start, end) byte range of the "dependencies" object's value
-// in `raw`, or null if it can't be located unambiguously. Uses a brace-
-// counting tokenizer that respects string literals so a `dependencies` key
-// inside a string value (e.g. inside a `description`) cannot fool it.
-function sliceDependenciesRange(raw: string, parsed: ParsedPackage['parsed']): { start: number; end: number } | null {
-  if (parsed.dependencies === undefined || parsed.dependencies === null) return null
-  const keyMatch = raw.match(/"dependencies"\s*:\s*\{/)
-  if (!keyMatch || keyMatch.index === undefined) return null
-  const startOfOpenBrace = keyMatch.index + keyMatch[0].length - 1
-  const closeBrace = findMatchingCloseBrace(raw, startOfOpenBrace)
-  if (closeBrace === null) return null
-  return { start: startOfOpenBrace, end: closeBrace + 1 }
-}
-
-function findMatchingCloseBrace(raw: string, openIndex: number): number | null {
-  let depth = 0
-  let inString = false
-  let escape = false
-  for (let i = openIndex; i < raw.length; i++) {
-    const ch = raw[i]
-    if (escape) {
-      escape = false
-      continue
-    }
-    if (inString) {
-      if (ch === '\\') escape = true
-      else if (ch === '"') inString = false
-      continue
-    }
-    if (ch === '"') {
-      inString = true
-      continue
-    }
-    if (ch === '{') depth++
-    else if (ch === '}') {
-      depth--
-      if (depth === 0) return i
-    }
-  }
-  return null
-}
-
-function detectIndent(raw: string): number | string {
-  // Default to 2 — matches `JSON.stringify(_, _, 2)` behavior and the
-  // project's existing scaffold style. Only override when we can see a
-  // clear non-2 indent on the first indented line.
-  const match = raw.match(/\n([\t ]+)\S/)
-  if (!match) return 2
-  const sample = match[1]!
-  if (sample.startsWith('\t')) return '\t'
-  return sample.length
 }

--- a/src/init/packagejson-edit.test.ts
+++ b/src/init/packagejson-edit.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test'
+
+import { editDependencySpec, type ParsedPackage } from './packagejson-edit'
+
+function pkgFrom(raw: string): ParsedPackage {
+  return { raw, parsed: JSON.parse(raw) as ParsedPackage['parsed'] }
+}
+
+describe('editDependencySpec', () => {
+  test('rewrites only dependencies.typeclaw, leaving devDependencies.typeclaw untouched', () => {
+    const raw = `{
+  "name": "agent",
+  "devDependencies": {
+    "typeclaw": "do-not-touch"
+  },
+  "dependencies": {
+    "typeclaw": "^0.39.0"
+  }
+}
+`
+
+    const next = editDependencySpec(pkgFrom(raw), 'typeclaw', 'file:../typeclaw')
+
+    const parsed = JSON.parse(next) as {
+      dependencies: Record<string, string>
+      devDependencies: Record<string, string>
+    }
+    expect(parsed.dependencies.typeclaw).toBe('file:../typeclaw')
+    expect(parsed.devDependencies.typeclaw).toBe('do-not-touch')
+  })
+
+  test('preserves indentation, key order, unrelated fields, and trailing newline', () => {
+    const raw = `{
+  "name": "agent",
+  "private": true,
+  "dependencies": {
+    "zod": "^4.0.0",
+    "typeclaw": "^0.39.0",
+    "citty": "^0.2.2"
+  }
+}
+`
+
+    const next = editDependencySpec(pkgFrom(raw), 'typeclaw', '^0.40.0')
+
+    expect(next).toBe(`{
+  "name": "agent",
+  "private": true,
+  "dependencies": {
+    "zod": "^4.0.0",
+    "typeclaw": "^0.40.0",
+    "citty": "^0.2.2"
+  }
+}
+`)
+  })
+
+  test('respects tab indentation', () => {
+    const raw = '{\n\t"dependencies": {\n\t\t"typeclaw": "^0.39.0"\n\t}\n}\n'
+
+    const next = editDependencySpec(pkgFrom(raw), 'typeclaw', '^0.40.0')
+
+    expect(next).toContain('\t\t"typeclaw": "^0.40.0"')
+  })
+
+  test('falls back to JSON round-trip when the dependency is absent (adds it scoped to dependencies)', () => {
+    const raw = `{
+  "name": "agent",
+  "dependencies": {
+    "zod": "^4.0.0"
+  }
+}
+`
+
+    const next = editDependencySpec(pkgFrom(raw), 'typeclaw', '^0.40.0')
+
+    const parsed = JSON.parse(next) as { dependencies: Record<string, string> }
+    expect(parsed.dependencies.typeclaw).toBe('^0.40.0')
+    expect(parsed.dependencies.zod).toBe('^4.0.0')
+  })
+
+  test('is not fooled by a "dependencies" substring inside a string value', () => {
+    const raw = `{
+  "description": "manages dependencies for agents",
+  "dependencies": {
+    "typeclaw": "^0.39.0"
+  }
+}
+`
+
+    const next = editDependencySpec(pkgFrom(raw), 'typeclaw', '^0.40.0')
+
+    const parsed = JSON.parse(next) as {
+      description: string
+      dependencies: Record<string, string>
+    }
+    expect(parsed.description).toBe('manages dependencies for agents')
+    expect(parsed.dependencies.typeclaw).toBe('^0.40.0')
+  })
+})

--- a/src/init/packagejson-edit.ts
+++ b/src/init/packagejson-edit.ts
@@ -1,0 +1,104 @@
+import { writeFile } from 'node:fs/promises'
+
+// Scoped, formatting-preserving edit of a single `dependencies.<name>` spec in
+// a package.json. Extracted from auto-upgrade.ts so the dev-dep switch command
+// can reuse the exact same battle-tested edit instead of duplicating it.
+//
+// The naive `raw.replace(/"name":.../)` is unscoped: it silently rewrites a
+// `devDependencies.<name>` entry that appears before `dependencies.<name>` in
+// the file. We slice the dependencies object's textual range, edit inside it,
+// then splice back to preserve whitespace, key order, and trailing newline. If
+// the slice fails (unusual JSON shape), fall back to a full JSON round-trip —
+// formatting churn is acceptable; silently updating the wrong key is not.
+
+export type ParsedPackage = {
+  raw: string
+  parsed: { dependencies?: Record<string, string> } & Record<string, unknown>
+}
+
+export async function writeDependencySpec(
+  packageJsonPath: string,
+  pkg: ParsedPackage,
+  name: string,
+  newSpec: string,
+): Promise<void> {
+  await writeFile(packageJsonPath, editDependencySpec(pkg, name, newSpec))
+}
+
+// Pure: returns the new package.json text without touching the filesystem, so
+// the scoped-edit invariants (key isolation, whitespace preservation, fallback)
+// are unit-testable without a tmp dir.
+export function editDependencySpec(pkg: ParsedPackage, name: string, newSpec: string): string {
+  const { raw, parsed } = pkg
+  const scoped = sliceDependenciesRange(raw, parsed)
+  if (scoped !== null) {
+    const { start, end } = scoped
+    const block = raw.slice(start, end)
+    const keyPattern = new RegExp(`(${escapeRegExp(JSON.stringify(name))}\\s*:\\s*)"[^"]+"`)
+    const replaced = block.replace(keyPattern, (_m, prefix: string) => `${prefix}${JSON.stringify(newSpec)}`)
+    if (replaced !== block) {
+      return `${raw.slice(0, start)}${replaced}${raw.slice(end)}`
+    }
+  }
+  const deps = { ...parsed.dependencies, [name]: newSpec }
+  const next = { ...parsed, dependencies: deps }
+  const indent = detectIndent(raw)
+  return `${JSON.stringify(next, null, indent)}\n`
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// Returns the [start, end) byte range of the "dependencies" object's value in
+// `raw`, or null if it can't be located unambiguously. Uses a brace-counting
+// tokenizer that respects string literals so a `dependencies` key inside a
+// string value (e.g. inside a `description`) cannot fool it.
+function sliceDependenciesRange(raw: string, parsed: ParsedPackage['parsed']): { start: number; end: number } | null {
+  if (parsed.dependencies === undefined || parsed.dependencies === null) return null
+  const keyMatch = raw.match(/"dependencies"\s*:\s*\{/)
+  if (!keyMatch || keyMatch.index === undefined) return null
+  const startOfOpenBrace = keyMatch.index + keyMatch[0].length - 1
+  const closeBrace = findMatchingCloseBrace(raw, startOfOpenBrace)
+  if (closeBrace === null) return null
+  return { start: startOfOpenBrace, end: closeBrace + 1 }
+}
+
+function findMatchingCloseBrace(raw: string, openIndex: number): number | null {
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = openIndex; i < raw.length; i++) {
+    const ch = raw[i]
+    if (escape) {
+      escape = false
+      continue
+    }
+    if (inString) {
+      if (ch === '\\') escape = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') {
+      inString = true
+      continue
+    }
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return null
+}
+
+function detectIndent(raw: string): number | string {
+  // Default to 2 — matches `JSON.stringify(_, _, 2)` behavior and the
+  // project's existing scaffold style. Only override when we can see a clear
+  // non-2 indent on the first indented line.
+  const match = raw.match(/\n([\t ]+)\S/)
+  if (!match) return 2
+  const sample = match[1]!
+  if (sample.startsWith('\t')) return '\t'
+  return sample.length
+}


### PR DESCRIPTION
## Background

Developers iterating on TypeClaw itself need to test changes end-to-end inside a real agent folder. The standard local setup — `bun link` — controls the global shim, but does not update the agent folder's own `package.json` dep spec. The only way to flip that spec was to re-run `typeclaw init`, which re-scaffolds the entire folder.

## Summary

This PR adds `typeclaw dev-dep`, a host-stage CLI subcommand that rewrites `dependencies.typeclaw` in an existing agent folder's `package.json` between a local `file:` spec and a published caret-version spec, then auto-commits the change.

**Why a separate command and not an init flag?**
`init` re-scaffolds the entire agent folder. `dev-dep` is a surgical single-key edit that is safe to run on a live agent folder with existing config, and is composable in scripts.

**The dirty-index gate runs before the file write.**
If unrelated staged files exist and auto-commit is on, the command errors before touching `package.json` — so a refused commit never leaves the spec half-applied.

**`bun install` is not run.**
The command only rewrites the spec. The user follows up with `typeclaw start --build`. This is intentional: `dev-dep` is a host-stage command and should not reach into the container lifecycle.

### Commit 1 — extract the dependency spec editor

`src/init/auto-upgrade.ts` carried a formatting-preserving, key-scoped dependencies writer (slice + brace-tokenizer + indent detection). It is now extracted to `src/init/packagejson-edit.ts` as two exports:

- `editDependencySpec(pkg, key, newSpec)` — pure transform, no I/O.
- `writeDependencySpec(path, pkg, key, newSpec)` — reads, transforms, writes.

`auto-upgrade.ts` now imports the shared helper. No behavior change; the full auto-upgrade suite passes.

The extraction is load-bearing for commit 2: `dev-dep` reuses the exact same editor so both commands stay in sync on formatting edge cases.

### Commit 2 — `typeclaw dev-dep`

New domain module `src/dev-dep/index.ts` exports `switchTypeclawDependency` (pure, injectable) and `DevDepError`. Thin CLI shell `src/cli/dev-dep.ts` wires two subcommands:

```
typeclaw dev-dep local [--path <checkout>] [--no-commit]
typeclaw dev-dep npm   [--version X.Y.Z]   [--no-commit]
```

Key behaviors:

- **local mode**: writes a `file:` spec (relative path) after verifying the target's `package.json#name` equals `"typeclaw"`. Without `--path`, falls back to an existing `file:` spec in the agent's package.json, then to the source checkout the running CLI lives in (skipped for npm-installed CLIs).
- **npm mode**: writes a `^version` spec, defaulting to the installed package version or the running CLI's scaffold version.
- **Auto-commit**: commits only `package.json` as `deps: switch typeclaw to {local,npm}`. Silently skips outside a git repo. Refused when unrelated staged changes are present. `--no-commit` opts out entirely.
- **Idempotent**: if the spec is already correct, exits with a "nothing to change" notice.

`SpawnGit` is an injectable type alias so all commit-path logic is testable without a real repo.

### Commit 3 — docs

- `docs/content/docs/reference/cli.mdx` — new "Dev dependency" section with usage examples and flag descriptions.
- `CONTRIBUTING.md` — a note under the local dev loop covering how to flip an existing agent folder between a local checkout and npm.

## What this does NOT do

- Does not run `bun install` or rebuild the container.
- Does not modify `typeclaw init` or its scaffolding output.
- Does not touch `devDependencies` — the scoped editor targets `dependencies` only.
- Does not add a `dev-dep` equivalent for other dependency keys.

## Review notes

- **Scoped edit invariant**: `editDependencySpec` targets only the `dependencies` block, never `devDependencies`. Enforced by the brace-tokenizer's key-scoped slice, tested in `src/init/packagejson-edit.test.ts`.
- **Dirty-index gate order**: `resolveCommitContext` (which rejects on dirty index) runs before `writeDependencySpec`. Reordering those two calls would let a refused commit leave `package.json` changed but uncommitted alongside unrelated staged work.
- **Injection seams**: `switchTypeclawDependency` accepts `spawnGit` and `findRunningCliCheckout` as optional injections. Tests use a scripted fake and a synthetic checkout path; no real git process is spawned.
- **Release impact**: `typeclaw dev-dep` is a new public CLI subcommand — this is a **minor** release per the repo's release rules (new CLI subcommand = new minor surface). The `package.json` bump already present on the branch is a pre-existing patch release; the release workflow will apply the correct minor bump.

## Testing

18 new unit tests across two files:

- `src/dev-dep/index.test.ts` — 15 tests covering local and npm modes, path validation, spec reuse, no-commit flag, idempotency, dirty-index rejection, and non-repo skip. Uses real tmp dirs for `package.json` I/O; git is fully faked via `SpawnGit` injection.
- `src/init/packagejson-edit.test.ts` — 8 tests asserting the scoped editor writes only to `dependencies`, preserves formatting and indent, rejects malformed JSON, and is idempotent on same-spec writes.

Full suite: 9779 pass, 0 fail. typecheck (0 errors), lint (0 errors), format:check (clean).