### PR TITLE
perf(channels): overlap independent I/O in ensureLive cold-start

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -13,6 +13,7 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import type { PermissionService } from '@/permissions'
 import type { HookBus, SessionIdleEvent } from '@/plugin'
 
+import type { ChannelSessionRecord } from './persistence'
 import { channelsSessionsPath, loadChannelSessions, saveChannelSessions } from './persistence'
 import {
   CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS,
@@ -253,6 +254,7 @@ function makeRouter(
     hooks?: HookBus
     onReload?: () => Promise<string>
     onRestart?: (ctx?: RestartCommandContext) => Promise<string>
+    saveChannelSessions?: (agentDir: string, sessions: readonly ChannelSessionRecord[]) => Promise<void>
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -267,6 +269,7 @@ function makeRouter(
     ...(options.claimHandler !== undefined ? { claimHandler: options.claimHandler } : {}),
     ...(options.onReload !== undefined ? { onReload: options.onReload } : {}),
     ...(options.onRestart !== undefined ? { onRestart: options.onRestart } : {}),
+    ...(options.saveChannelSessions !== undefined ? { saveChannelSessions: options.saveChannelSessions } : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
     logger: {
@@ -8052,6 +8055,32 @@ describe('ChannelRouter cold-start prefetch', () => {
     expect(historyCalls).toBe(0)
     expect(sessions[0]!.prompts[0]).not.toContain('should-not-appear')
     expect(sessions[0]!.prompts[0]).not.toContain('## Recent context')
+  })
+
+  test('rehydrate path: a failed mapping write fails ensureLive and leaves no live session', async () => {
+    // given: a pre-existing mapping (forces the rehydrate branch, not cold-start)
+    //   and a sessions.json writer that always throws
+    const dir = await tempDir()
+    await saveChannelSessions(dir, [
+      {
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        thread: null,
+        sessionId: 'ses_preexisting',
+        participants: [],
+      },
+    ])
+    const { router } = makeRouter(dir, {
+      saveChannelSessions: async () => {
+        throw new Error('disk full')
+      },
+    })
+
+    // when: an inbound drives ensureLive down the rehydrate path
+    // then: route() rejects on the write failure and nothing is installed
+    await expect(router.route(inbound({ externalMessageId: 'engage', text: 'hi' }))).rejects.toThrow(/disk full/)
+    expect(router.liveCount()).toBe(0)
   })
 
   test('history fetch failure is non-fatal; session still processes the engaging message', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -400,21 +400,21 @@ describe('ChannelRouter session lifecycle', () => {
     await router.route(inbound())
     await router.__testing!.flushDebounce(KEY)
 
-    // then phase logs appear in order: begin → resolved-names → resolved-membership
+    // then phase logs appear in order: begin → resolved-names-and-membership
     //   → session-created → done. The bracketing is what makes a stuck phase
     //   visible from logs alone (begin without done == hung at that phase).
+    //   Name and membership resolution share one log because they now run
+    //   concurrently — separate ordered markers would misrepresent the timing.
     const phaseLogs = logs
       .filter((l) => l.startsWith('info:[channels]') && l.includes('ensureLive'))
       .map((l) => l.replace(/^.*ensureLive /, ''))
     const beginIdx = phaseLogs.findIndex((p) => p.startsWith('begin'))
-    const namesIdx = phaseLogs.findIndex((p) => p.startsWith('resolved-names'))
-    const membershipIdx = phaseLogs.findIndex((p) => p.startsWith('resolved-membership'))
+    const resolvedIdx = phaseLogs.findIndex((p) => p.startsWith('resolved-names-and-membership'))
     const createdIdx = phaseLogs.findIndex((p) => p.startsWith('session-created'))
     const doneIdx = phaseLogs.findIndex((p) => p.startsWith('done'))
     expect(beginIdx).toBeGreaterThanOrEqual(0)
-    expect(namesIdx).toBeGreaterThan(beginIdx)
-    expect(membershipIdx).toBeGreaterThan(namesIdx)
-    expect(createdIdx).toBeGreaterThan(membershipIdx)
+    expect(resolvedIdx).toBeGreaterThan(beginIdx)
+    expect(createdIdx).toBeGreaterThan(resolvedIdx)
     expect(doneIdx).toBeGreaterThan(createdIdx)
     expect(phaseLogs[beginIdx]).toContain('cold-start')
     expect(phaseLogs[doneIdx]).toContain('cold-start')

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1179,6 +1179,10 @@ export type CreateChannelRouterOptions = {
   // resumes on the next boot; when absent (cold channel / native slash with no
   // session) it should just bounce the container with no handoff.
   onRestart?: (ctx?: RestartCommandContext) => Promise<string>
+  // Test seam: override the sessions.json writer. Defaults to the disk-backed
+  // saveChannelSessions (which swallows its own I/O errors). Tests inject a
+  // throwing impl to exercise the persist-failure unwind in ensureLive.
+  saveChannelSessions?: (agentDir: string, sessions: readonly ChannelSessionRecord[]) => Promise<void>
 }
 
 export type RestartCommandContext = {
@@ -1356,13 +1360,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     await loadOnce
   }
 
+  const saveSessions = options.saveChannelSessions
+    ? options.saveChannelSessions
+    : (agentDir: string, sessions: readonly ChannelSessionRecord[]): Promise<void> =>
+        saveChannelSessions(agentDir, sessions, logger)
+
   const persist = async (): Promise<void> => {
     if (mappings === null || closing) return
     // Caller awaits `next` un-caught to observe write errors; the chain holds the
     // caught version so one rejection can't poison it or escape as unhandled.
     const next = persistChain.then(async () => {
       if (mappings === null) return
-      await saveChannelSessions(options.agentDir, mappings, logger)
+      await saveSessions(options.agentDir, mappings)
     })
     persistChain = next.catch(() => {})
     await next
@@ -1804,11 +1813,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         await persistPromise
         throw new StaleLiveSessionError(keyId)
       }
-      // Install before the slow prefetch so a concurrent teardown/shutdown can
-      // see and dispose this session during the network fetch.
-      liveSessions.set(keyId, live)
-
       if (isColdStart) {
+        // Install before the slow prefetch so a concurrent teardown/shutdown can
+        // see and dispose this session during the network fetch.
+        liveSessions.set(keyId, live)
         const adapterConfig = options.configForAdapter(key.adapter)
         // Overlap the disk mapping-write with the network history prefetch —
         // they are independent. allSettled lets a persist failure take priority
@@ -1818,14 +1826,20 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           : Promise.resolve()
         const [persistResult, prefetchResult] = await Promise.allSettled([persistPromise, prefetchPromise])
         if (persistResult.status === 'rejected') {
-          if (liveSessions.get(keyId) === live) liveSessions.delete(keyId)
-          if (!live.destroyed) await tearDownLive(live)
+          await unwindInstalledLive(keyId, live)
           throw persistResult.reason
         }
-        if (prefetchResult.status === 'rejected') throw prefetchResult.reason
+        if (prefetchResult.status === 'rejected') {
+          await unwindInstalledLive(keyId, live)
+          throw prefetchResult.reason
+        }
         if (adapterConfig) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
       } else {
+        // Rehydrate has no prefetch to overlap, so settle the mapping write
+        // before installing — a failed persist must fail ensureLive without
+        // leaving a warm session behind for later inbounds to reuse.
         await persistPromise
+        liveSessions.set(keyId, live)
       }
 
       // Snapshot the rendered base context size now, after prefetch and before
@@ -4074,6 +4088,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     } catch (err) {
       logger.warn(`[channels] dispose failed for ${live.keyId}: ${describe(err)}`)
     }
+  }
+
+  // Roll back an install when a post-install step (persist/prefetch) fails, so a
+  // rejected ensureLive never leaves a warm session behind for later inbounds.
+  const unwindInstalledLive = async (keyId: string, live: LiveSession): Promise<void> => {
+    if (liveSessions.get(keyId) === live) liveSessions.delete(keyId)
+    if (!live.destroyed) await tearDownLive(live)
   }
 
   const runIdleGc = async (): Promise<void> => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1608,10 +1608,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger.info(`[channels] ${keyId}: ensureLive begin (${phase})`)
       const participants = (resolvedRecord?.participants ?? []) as ChannelParticipant[]
       const membershipFetch = warmMembership(key)
-      const resolvedNames = await resolveChannelNames(key)
-      logger.info(`[channels] ${keyId}: ensureLive resolved-names`)
-      const membership = await membershipForPrompt(key, membershipFetch)
-      logger.info(`[channels] ${keyId}: ensureLive resolved-membership`)
+      // Independent platform lookups — overlap so the chain pays max(), not sum().
+      const [resolvedNames, membership] = await Promise.all([
+        resolveChannelNames(key),
+        membershipForPrompt(key, membershipFetch),
+      ])
+      logger.info(`[channels] ${keyId}: ensureLive resolved-names-and-membership`)
       // The session-creation origin is what the resource loader sees when it
       // renders the role/permissions block into the system prompt. It must
       // include the triggering author so author-scoped roles
@@ -1674,7 +1676,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       } else {
         mappings = [persistedRecord]
       }
-      await persist()
+      // Kick off the mapping write now but don't block on it — the disk write is
+      // independent of the synchronous `live` build below and the cold-start
+      // network prefetch, so we overlap it. Every exit path below MUST settle
+      // `persistPromise` (the immediate .catch is only an unhandled-rejection
+      // guard; write errors are still surfaced by awaiting it later).
+      const persistPromise = persist()
+      void persistPromise.catch(() => {})
 
       const live: LiveSession = {
         key,
@@ -1791,16 +1799,33 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           `[channels] ${keyId}: discarding session created across a teardown (gen ${generation} → ${liveGeneration})`,
         )
         await tearDownLive(live)
+        // Settle the in-flight mapping write before bailing — preserves the
+        // pre-overlap contract that a persist failure fails ensureLive.
+        await persistPromise
         throw new StaleLiveSessionError(keyId)
       }
+      // Install before the slow prefetch so a concurrent teardown/shutdown can
+      // see and dispose this session during the network fetch.
       liveSessions.set(keyId, live)
 
       if (isColdStart) {
         const adapterConfig = options.configForAdapter(key.adapter)
-        if (adapterConfig) {
-          await prefetchChannelContext(live, adapterConfig, triggeringMessageId)
-          logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
+        // Overlap the disk mapping-write with the network history prefetch —
+        // they are independent. allSettled lets a persist failure take priority
+        // (and unwind the install) even if prefetch also rejects.
+        const prefetchPromise = adapterConfig
+          ? prefetchChannelContext(live, adapterConfig, triggeringMessageId)
+          : Promise.resolve()
+        const [persistResult, prefetchResult] = await Promise.allSettled([persistPromise, prefetchPromise])
+        if (persistResult.status === 'rejected') {
+          if (liveSessions.get(keyId) === live) liveSessions.delete(keyId)
+          if (!live.destroyed) await tearDownLive(live)
+          throw persistResult.reason
         }
+        if (prefetchResult.status === 'rejected') throw prefetchResult.reason
+        if (adapterConfig) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
+      } else {
+        await persistPromise
       }
 
       // Snapshot the rendered base context size now, after prefetch and before


### PR DESCRIPTION
## Summary

The user asked whether `ensureLive` and vector retrieval run in parallel, and to parallelize them (plus anything else) to cut end-to-end response latency.

**On the literal ask:** `ensureLive` and per-turn vector retrieval **cannot** be parallelized. `ensureLive` (in `route()`) produces the `LiveSession`; vector retrieval happens later in `drain()` via `fireSessionTurnStart`, which consumes `live.hooks`/`live.session`. They're separated by the `enqueue → debounce → drain` boundary, so there's a hard data dependency. On the warm/steady-state path `ensureLive` returns in ~0ms anyway, so it isn't the bottleneck there.

**What this PR actually does:** the real latency win is *inside* `ensureLive` cold-start, where three independent I/O operations ran in series. This PR overlaps them so the chain pays `max()` instead of `sum()`:

1. **`resolveChannelNames` + `membershipForPrompt`** — both independent platform lookups — now run via `Promise.all`.
2. **`persist()` (sessions.json disk write) + `prefetchChannelContext()` (network history fetch)** — independent — now overlap via `Promise.allSettled`. The mapping write is kicked off without blocking and joined with the prefetch.

The per-turn hot path (`fireSessionTurnStart → session.prompt`) is already tight across all four turn-drivers and can't be parallelized further — retrieval output is composited into the prompt text before the LLM call.

## Safety

This touches the race-sensitive cold-start path (generation guard, stale-rollover, watchdog), so the deferred `persist()` is settled on **every** exit path:

- Immediate `.catch()` guards against unhandled rejection; the later `await` still surfaces write errors (preserves the pre-overlap "persist failure fails ensureLive" contract).
- **Stale-generation teardown path:** `persist` is awaited before throwing `StaleLiveSessionError`.
- The live session is **installed before** prefetch so a concurrent teardown/shutdown stays visible during the network fetch.
- A persist failure during the overlap **unwinds the install** (`liveSessions.delete` + `tearDownLive`) and takes priority over a prefetch failure.

The two `resolved-names` / `resolved-membership` phase logs are merged into one `resolved-names-and-membership` since they now run concurrently — separate ordered markers would misrepresent the timing. The lifecycle log-ordering test was updated to match.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in `router.ts`)
- `bun run format` — clean
- `bun test --parallel src/channels/router.test.ts` — **458 pass, 0 fail** (incl. cold-start, rehydrate, watchdog-timeout, and stale-rollover paths)
