### PR TITLE
fix(container): exec typeclaw CLI by path so Windows-installed agents start

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -23,6 +23,7 @@ import {
   NETWORK_BLOCK_IPV4_NETS,
   NETWORK_BLOCK_IPV6_NETS,
   TRANSFORMERS_VERSION,
+  TYPECLAW_CLI_ENTRY,
   TYPECLAW_ENTRYPOINT_PATH,
 } from './dockerfile'
 
@@ -1409,8 +1410,9 @@ describe('network egress entrypoint shim', () => {
     const shim = buildEntrypointShim()
     expect(shim).toContain('"${TYPECLAW_NETWORK_BLOCK_INTERNAL:-0}" != "1"')
     expect(shim).toMatch(
-      /!= "1" \];? then\s+link_persistent_home_files\s+link_configured_symlinks\s+start_xvfb\s+exec bun run typeclaw "\$@"/,
+      /!= "1" \];? then\s+link_persistent_home_files\s+link_configured_symlinks\s+start_xvfb\s+exec bun run \/agent\/node_modules\/typeclaw\/src\/cli\/index\.ts "\$@"/,
     )
+    expect(shim).toContain(`exec bun run ${TYPECLAW_CLI_ENTRY} "$@"`)
   })
 
   test('shim self-heals on Xvfb presence: spawns Xvfb directly (not xvfb-run, which hangs as PID 1) and exports DISPLAY', () => {
@@ -1500,7 +1502,7 @@ describe('network egress entrypoint shim', () => {
   test('drops NET_ADMIN from bounding+inheritable+ambient sets before exec-ing (matches setpriv(1) warning)', () => {
     const shim = buildEntrypointShim()
     expect(shim).toContain(
-      'exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- bun run typeclaw "$@"',
+      `exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- bun run ${TYPECLAW_CLI_ENTRY} "$@"`,
     )
   })
 
@@ -1512,7 +1514,7 @@ describe('network egress entrypoint shim', () => {
     expect(offBranchEnd).toBeGreaterThan(-1)
     const offBranch = shim.slice(0, offBranchEnd)
     const offStartXvfbIdx = offBranch.lastIndexOf('start_xvfb\n')
-    const offExecIdx = offBranch.search(/exec bun run typeclaw "\$@"/)
+    const offExecIdx = offBranch.indexOf(`exec bun run ${TYPECLAW_CLI_ENTRY} "$@"`)
     expect(offStartXvfbIdx).toBeGreaterThan(-1)
     expect(offExecIdx).toBeGreaterThan(offStartXvfbIdx)
 
@@ -1561,8 +1563,8 @@ describe('network egress entrypoint shim', () => {
     expect(offBranchEnd).toBeGreaterThan(-1)
     const offBranch = shim.slice(0, offBranchEnd)
     expect(offBranch).not.toContain('iptables -A OUTPUT')
-    expect(offBranch).toMatch(/exec bun run typeclaw "\$@"/)
-    expect(offBranch).not.toMatch(/exec setpriv [^\n]*-- bun run typeclaw/)
+    expect(offBranch).toContain(`exec bun run ${TYPECLAW_CLI_ENTRY} "$@"`)
+    expect(offBranch).not.toMatch(/exec setpriv [^\n]*-- bun run/)
   })
 
   test('per-agent Dockerfile wires ENTRYPOINT to the shim path, not directly to bun run', () => {
@@ -1714,7 +1716,7 @@ describe('network egress entrypoint shim', () => {
     expect(offBranchEnd).toBeGreaterThan(-1)
     const offBranch = shim.slice(0, offBranchEnd)
     const offLinkIdx = offBranch.lastIndexOf('link_persistent_home_files\n')
-    const offExecIdx = offBranch.search(/exec bun run typeclaw "\$@"/)
+    const offExecIdx = offBranch.indexOf(`exec bun run ${TYPECLAW_CLI_ENTRY} "$@"`)
     expect(offLinkIdx).toBeGreaterThan(-1)
     expect(offExecIdx).toBeGreaterThan(offLinkIdx)
 
@@ -1784,7 +1786,7 @@ exec "$@"
     )
 
     // Fake `bun` that records its argv and the value of $DISPLAY, then
-    // exits 0. Stands in for the real \`bun run typeclaw "$@"\` exec at
+    // exits 0. Stands in for the real \`bun run <cli-entry> "$@"\` exec at
     // the end of the shim.
     await writeShellScript(
       join(bindir, 'bun'),
@@ -1937,7 +1939,7 @@ exec "$@"
     await mkdir(bin, { recursive: true })
     await symlinkHostBinaries(bin, ['mkdir', 'ln', 'readlink'])
     // Fake `bun`: pass `-e <script>` through to the real bun (link_configured_symlinks
-    // needs a real JSON parser + fs), but turn the final `bun run typeclaw` exec
+    // needs a real JSON parser + fs), but turn the final `bun run <cli-entry>` exec
     // into a no-op so the shim ends cleanly without launching the agent.
     await writeShellScript(join(bin, 'bun'), `#!/bin/sh\nif [ "$1" = "-e" ]; then exec ${realBun} "$@"; fi\nexit 0\n`)
     await writeShellScript(

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -125,6 +125,18 @@ export const CLOUDFLARED_RELEASE_URL_BASE = 'https://github.com/cloudflare/cloud
 
 export const TYPECLAW_ENTRYPOINT_PATH = '/usr/local/bin/typeclaw-entrypoint'
 
+// The installed TypeClaw CLI entry, executed directly by the container
+// entrypoint. `package.json#bin.typeclaw` points at `src/cli/index.ts` and the
+// package ships `src`, so this path exists for both the registry install and a
+// `file:`/linked dev install (where node_modules/typeclaw is the repo). Running
+// it directly bypasses `bun run typeclaw`'s script/`.bin` resolution — which
+// breaks when the agent folder was installed on a Windows host: the hoisted
+// linker writes Windows-native `.bin/typeclaw` shims that aren't valid Linux
+// executables once the folder is bind-mounted into the container, so
+// `bun run typeclaw` finds no usable bin, falls back to treating `typeclaw` as
+// a path, and resolves `/agent/typeclaw.json` (`Cannot run json files`).
+export const TYPECLAW_CLI_ENTRY = '/agent/node_modules/typeclaw/src/cli/index.ts'
+
 // IPv4 networks the container is forbidden to egress to when
 // `network.blockInternal` is true. Loopback (127/8) is NOT here — loopback
 // traffic uses the `lo` interface, which the shim's first ACCEPT rule
@@ -157,9 +169,10 @@ export const NETWORK_BLOCK_IPV6_NETS = ['fc00::/7', 'fe80::/10', 'ff00::/8', '::
 // modes, picked at boot time from `$TYPECLAW_NETWORK_BLOCK_INTERNAL`:
 //
 //   off (env unset or != "1"): no rules installed, no setpriv. Just exec
-//   `bun run typeclaw "$@"`. Identical observable behavior to a container
-//   without this feature. This is the opt-out path for users who set
-//   `network.blockInternal: false` in their `typeclaw.json`.
+//   the TypeClaw CLI entry directly (see TYPECLAW_CLI_ENTRY). Identical
+//   observable behavior to a container without this feature. This is the
+//   opt-out path for users who set `network.blockInternal: false` in their
+//   `typeclaw.json`.
 //
 //   on (default, env = "1" via `network.blockInternal: true`): walks IPv4 +
 //   IPv6 block lists and installs
@@ -515,7 +528,7 @@ if [ "\${TYPECLAW_NETWORK_BLOCK_INTERNAL:-0}" != "1" ]; then
   link_persistent_home_files
   link_configured_symlinks
   start_xvfb
-  exec bun run typeclaw "$@"
+  exec bun run ${TYPECLAW_CLI_ENTRY} "$@"
 fi
 
 iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
@@ -562,7 +575,7 @@ ${ipv6Rules.join('\n')}
 link_persistent_home_files
 link_configured_symlinks
 start_xvfb
-exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- bun run typeclaw "$@"
+exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- bun run ${TYPECLAW_CLI_ENTRY} "$@"
 `
 }
 


### PR DESCRIPTION
## Background

After a successful docker build, the container starts and exits immediately:

```
✖ Hatching failed: Container <name> stopped running immediately after start (state: exited). Last logs:
error: Cannot run "/agent/typeclaw.json"
note: Bun cannot run json files directly
```

The container entrypoint ran `bun run typeclaw "$@"` with `CMD ["run"]`. `bun run typeclaw` resolves via the bin shim at `node_modules/.bin/typeclaw`. When the agent folder is installed on a **Windows host**, bun's hoisted linker writes **Windows-native `.bin/typeclaw` shims** that aren't valid Linux executables once the folder is bind-mounted into the Linux container. `bun run typeclaw` finds no usable bin, falls back to treating `typeclaw` as a path, auto-appends an extension, and resolves `/agent/typeclaw.json` — which Bun refuses to run.

Reproduces with **both** the npm and dev (`file:`/linked) typeclaw dependency, since the broken shim is created by the host-side install regardless of source.

## Summary

Exec the installed CLI entry file **directly**, bypassing bin/script resolution entirely:

```sh
bun run /agent/node_modules/typeclaw/src/cli/index.ts "$@"
```

`package.json#bin.typeclaw` points at `src/cli/index.ts` and the package ships `src`, so the path exists for **both** registry and dev/linked installs (where `node_modules/typeclaw` is the repo). The host-OS shim format no longer matters — there's no `.bin` lookup.

This matches how the codebase already execs its own container code by absolute `/agent/node_modules/typeclaw/...` path (the agent-browser and doc-render shims). A new `TYPECLAW_CLI_ENTRY` constant holds the path; both the `network.blockInternal=false` and `blockInternal=true` (`setpriv`) entrypoint branches are updated; tests assert the new invocation on both branches.

## Preview

N/A — no visual output.

## What this does NOT do

- Does not change anything in the **build** path — that is covered by #1011 (docker credential-helper fix). This PR fixes **container startup**; both are needed for `typeclaw init` to work on Windows.
- Does not modify how typeclaw resolves its version or config at runtime.
- Does not affect Linux or macOS hosts where `.bin/typeclaw` is a valid shell script.

## Review notes

Load-bearing change: `TYPECLAW_CLI_ENTRY` in `src/init/dockerfile.ts` and its use in both entrypoint branches. The invariant: the path must exist in both the npm-installed package (which ships `src/`) and the dev-linked repo. Entrypoint-shim tests in `src/init/dockerfile.test.ts` assert the exact invocation on both branches so a regression in either path is caught.

All checks pass locally: `typecheck`, `lint` (0 errors), `format:check`, full `test` (9773 pass / 0 fail).