### PR TITLE
fix(init): raise cold-boot readiness timeout so first hatch survives slow Windows boot

### DIFF
--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -18,6 +18,7 @@ import {
   hasExistingChannelSecrets,
   hasExistingOAuthCredentials,
   type HatchingResult,
+  hatchingReadinessTimeoutMs,
   type HatchRunner,
   initGitRepo,
   type InitStepEvent,
@@ -103,6 +104,21 @@ async function readSecrets(root: string): Promise<{
     channels?: Record<string, Record<string, unknown>>
   }
 }
+
+describe('hatchingReadinessTimeoutMs', () => {
+  test('gives Windows a larger cold-boot budget than other platforms', () => {
+    const windows = hatchingReadinessTimeoutMs('win32')
+    const linux = hatchingReadinessTimeoutMs('linux')
+    const mac = hatchingReadinessTimeoutMs('darwin')
+    expect(windows).toBeGreaterThan(linux)
+    expect(linux).toBe(mac)
+  })
+
+  test('budgets are generous enough to outlast a slow first boot (>= 60s, Windows >= 120s)', () => {
+    expect(hatchingReadinessTimeoutMs('linux')).toBeGreaterThanOrEqual(60_000)
+    expect(hatchingReadinessTimeoutMs('win32')).toBeGreaterThanOrEqual(120_000)
+  })
+})
 
 describe('runInit', () => {
   test('runs scaffold, install, dockerfile, git, and hatching steps in order', async () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -498,7 +498,7 @@ export async function defaultRunHatching({
     // the preferred port, otherwise we'd connect to the wrong service.
     const hostPort = launch.hostPort
 
-    await waitForAgentFn(`http://127.0.0.1:${hostPort}`, { timeoutMs: 30_000 })
+    await waitForAgentFn(`http://127.0.0.1:${hostPort}`, { timeoutMs: hatchingReadinessTimeoutMs() })
 
     if (configuredChannels !== undefined && configuredChannels.length > 0) {
       const url = buildTuiUrl(hostPort, launch.tuiToken)
@@ -542,6 +542,20 @@ function buildTuiUrl(hostPort: number, token: string | null): string {
   const url = new URL(`ws://127.0.0.1:${hostPort}`)
   if (token !== null) url.searchParams.set('token', token)
   return url.toString()
+}
+
+// Cold-boot readiness budget for the first `typeclaw init`. The image was just
+// unpacked and the agent folder (incl. a large node_modules) is bind-mounted
+// into the container, so the very first server boot is markedly slower than
+// subsequent `typeclaw start`s — plugin loading reads hundreds of files off a
+// cold mount before Bun.serve() binds the port. On Windows Docker Desktop that
+// mount crosses into the WSL2 VM and is slower still; during the warmup window
+// Docker Desktop's port proxy may accept then immediately reset connections
+// ("socket connection was closed unexpectedly"), which is why a too-short budget
+// fails the first run even though an immediate retry (warm caches) succeeds.
+// Give Windows a generous budget; keep other platforms tighter.
+export function hatchingReadinessTimeoutMs(platform: NodeJS.Platform = process.platform): number {
+  return isWindows(platform) ? 120_000 : 60_000
 }
 
 // Probe the server's plain HTTP fallback (non-upgrade requests get a 200 with


### PR DESCRIPTION
## Problem

After the build and container-startup fixes land, `typeclaw init` on Windows Docker Desktop now reaches the readiness probe but fails with:

```
✖ Hatching failed: timed out waiting for agent at http://127.0.0.1:8973/:
The socket connection was closed unexpectedly.
```

`init` polled the agent's HTTP readiness endpoint for only **30s** after `docker run`. On the **first** hatch, the image was just unpacked and the agent folder (with a large `node_modules`) is bind-mounted into the container, so the initial server boot — plugin loading reads hundreds of files off a cold mount before `Bun.serve()` binds the port — is markedly slower than a warm `typeclaw start`. On Windows Docker Desktop that mount crosses into the WSL2 VM and is slower still, and during the warmup window Docker Desktop's port proxy accepts then immediately resets connections, which surfaces as the "socket connection was closed unexpectedly" fetch error.

**Key evidence this is a timing issue, not a crash:** an immediate `typeclaw start` retry succeeds (warm caches). A real boot crash would fail the retry identically. Port mapping and server bind were already verified correct (`-p 0.0.0.0:<port>:8973` ↔ `Bun.serve` on `0.0.0.0:8973`).

## Fix

Replace the hardcoded `30_000` ms with a platform-aware `hatchingReadinessTimeoutMs()`:

- **Windows:** 120s (pays the WSL2 bind-mount + port-proxy warmup cost on first boot)
- **Other platforms:** 60s

The asymmetry is deliberate: Windows needs the headroom; other platforms shouldn't wait twice as long on a genuinely dead server. The poll still hits the plain-HTTP fallback (no WebSocket, so no LLM session is burned just to check readiness).

A unit test asserts Windows gets a strictly larger budget than Linux/macOS and that both budgets clear the slow-first-boot floor (>= 60s, Windows >= 120s).

## Scope

Third in the Windows `typeclaw init` series; independent of:
- #1011 — docker credential-helper **build** failure
- #1015 — container **startup** (`Cannot run /agent/typeclaw.json`)

This one fixes the **readiness wait** after the container is up. All three are needed for a clean first `typeclaw init` on Windows.

All checks pass locally: `typecheck`, `lint` (0 errors), `format:check`, full `test` (9789 pass / 0 fail).