### PR TITLE
feat(init): auto-reconcile agent typeclaw dep to the running CLI

### DIFF
--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -154,6 +154,12 @@ const deterministicAllocator = async (preferred: number): Promise<number> => (pr
 // tests and would slow each one by ~hundreds of ms.
 const noEnsureDeps = async (): Promise<{ ok: true; installed: false }> => ({ ok: true, installed: false })
 
+// The real autoUpgrade detector sees the test runner itself as a LOCAL typeclaw
+// checkout and would relink each agent's package.json — disruptive to tests that
+// aren't about auto-reconcile. Inject this no-op so they stay deterministic
+// regardless of how the suite was launched; reconcile tests inject their own.
+const noAutoUpgrade = async () => ({ kind: 'up-to-date', installedVersion: '0.1.0' }) as const
+
 // Bypasses the post-`docker run` verification window so happy-path tests don't
 // pay the production 1.5s wait. Verification has its own dedicated test file
 // (verify-running.test.ts); start.test.ts only proves start() routes a
@@ -1486,6 +1492,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1507,6 +1514,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1531,6 +1539,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1554,6 +1563,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1576,6 +1586,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1597,6 +1608,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1621,6 +1633,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1649,6 +1662,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1735,6 +1749,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1760,6 +1775,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1787,6 +1803,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1817,6 +1834,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1848,6 +1866,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1876,6 +1895,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -1910,6 +1930,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
     expect(first.ok).toBe(true)
@@ -1922,6 +1943,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
     expect(second.ok).toBe(true)
@@ -1966,6 +1988,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2013,6 +2036,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2047,6 +2071,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2353,6 +2378,7 @@ describe('start (composition)', () => {
         ensureCalls.push(opts)
         return { ok: true, installed: false }
       },
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2382,6 +2408,7 @@ describe('start (composition)', () => {
         ensureCalls.push(opts)
         return { ok: true, installed: false }
       },
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2437,6 +2464,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2467,6 +2495,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2489,6 +2518,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2516,6 +2546,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2577,6 +2608,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2598,6 +2630,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2624,6 +2657,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2651,6 +2685,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2690,6 +2725,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2713,6 +2749,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2738,6 +2775,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2776,6 +2814,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2822,6 +2861,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2850,6 +2890,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2925,6 +2966,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -2990,6 +3032,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3057,6 +3100,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3138,6 +3182,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3198,6 +3243,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3250,6 +3296,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3286,6 +3333,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3317,6 +3365,7 @@ describe('start (composition)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3342,6 +3391,7 @@ describe('start (port allocation)', () => {
       exec,
       allocatePort,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3367,6 +3417,7 @@ describe('start (port allocation)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3412,6 +3463,7 @@ describe('start (port allocation)', () => {
       exec,
       allocatePort,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3445,6 +3497,7 @@ describe('start (port allocation)', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 
@@ -3763,6 +3816,7 @@ describe('start autoUpgrade integration', () => {
       exec,
       allocatePort: deterministicAllocator,
       ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
       ...bypassVerify,
     })
 

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -4001,17 +4001,53 @@ describe('start autoUpgrade integration', () => {
       runBunLink: async () => {
         order.push('bun-link')
       },
-      ensureDeps: async () => {
-        order.push('ensureDeps')
+      ensureDeps: async (_dir, opts) => {
+        order.push(`ensureDeps:force=${opts?.force === true}`)
         return { ok: true, installed: true }
       },
       ...bypassVerify,
     })
 
     expect(result.ok).toBe(true)
-    // The point: bun link runs before ensureDeps even with no reconcile
-    // transition, so the link: spec is registered before install.
-    expect(order).toEqual(['bun-link', 'ensureDeps'])
+    // The point: bun link runs before ensureDeps, AND ensureDeps is forced so a
+    // stale node_modules/typeclaw can't make the relink skip the install.
+    expect(order).toEqual(['bun-link', 'ensureDeps:force=true'])
+  })
+
+  test('win32 interrupted relink with a stale node_modules/typeclaw forces ensureDeps on the retry', async () => {
+    // First start: reconcile rewrites ^0.1.0 → link:typeclaw, then bun link
+    // throws (interrupted). Second start: spec is already link: so reconcile is
+    // skipped-dev-mode, but bun link must re-run AND ensureDeps must be forced
+    // to overwrite the stale npm node_modules/typeclaw with the linked checkout.
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: 'link:typeclaw' })
+    await mkdir(join(root, 'node_modules', 'typeclaw'), { recursive: true })
+    await writeFile(
+      join(root, 'node_modules', 'typeclaw', 'package.json'),
+      JSON.stringify({ name: 'typeclaw', version: '0.1.0' }),
+    )
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const order: string[] = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      platform: 'win32',
+      exec,
+      allocatePort: deterministicAllocator,
+      autoUpgrade: async () => ({ kind: 'skipped-dev-mode' }),
+      runBunLink: async () => {
+        order.push('bun-link')
+      },
+      ensureDeps: async (_dir, opts) => {
+        order.push(`ensureDeps:force=${opts?.force === true}`)
+        return { ok: true, installed: true }
+      },
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(order).toEqual(['bun-link', 'ensureDeps:force=true'])
   })
 
   test('link:typeclaw agent does NOT run bun link off-Windows', async () => {

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -3918,4 +3918,90 @@ describe('start autoUpgrade integration', () => {
     expect(subjects).toContain('Update dependencies')
     expect(subjects.filter((s) => s.startsWith('Upgrade typeclaw'))).toEqual([])
   })
+
+  test('relinked-to-local (file:) forces ensureDeps and never calls forceBunUpdate', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const updateCalls: Array<{ cwd: string; pkg: string }> = []
+    const ensureCalls: Array<{ force?: boolean } | undefined> = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      autoUpgrade: async () => ({ kind: 'relinked-to-local', from: '^0.1.0', to: 'file:../typeclaw' }),
+      forceBunUpdate: async (cwd, pkg) => {
+        updateCalls.push({ cwd, pkg })
+        return { ok: true }
+      },
+      ensureDeps: async (_dir, opts) => {
+        ensureCalls.push(opts)
+        return { ok: true, installed: true }
+      },
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(updateCalls).toEqual([])
+    expect(ensureCalls).toEqual([{ force: true }])
+  })
+
+  test('relinked-to-local (link:) on win32 runs bun link BEFORE the forced install, no forceBunUpdate', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const order: string[] = []
+    const updateCalls: string[] = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      platform: 'win32',
+      exec,
+      allocatePort: deterministicAllocator,
+      autoUpgrade: async () => ({ kind: 'relinked-to-local', from: '^0.1.0', to: 'link:typeclaw' }),
+      runBunLink: async () => {
+        order.push('bun-link')
+      },
+      forceBunUpdate: async () => {
+        updateCalls.push('update')
+        return { ok: true }
+      },
+      ensureDeps: async (_dir, opts) => {
+        order.push(`ensureDeps:force=${opts?.force === true}`)
+        return { ok: true, installed: true }
+      },
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(updateCalls).toEqual([])
+    expect(order).toEqual(['bun-link', 'ensureDeps:force=true'])
+  })
+
+  test('relinked-to-local (link:) does NOT run bun link off-Windows', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    let linkCalled = false
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      platform: 'linux',
+      exec,
+      allocatePort: deterministicAllocator,
+      autoUpgrade: async () => ({ kind: 'relinked-to-local', from: '^0.1.0', to: 'link:typeclaw' }),
+      runBunLink: async () => {
+        linkCalled = true
+      },
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(linkCalled).toBe(false)
+  })
 })

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -3948,9 +3948,9 @@ describe('start autoUpgrade integration', () => {
     expect(ensureCalls).toEqual([{ force: true }])
   })
 
-  test('relinked-to-local (link:) on win32 runs bun link BEFORE the forced install, no forceBunUpdate', async () => {
+  test('win32 link:typeclaw agent runs bun link BEFORE the forced install, no forceBunUpdate', async () => {
     await writeDockerfile(root)
-    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writePackageJson(root, { typeclaw: 'link:typeclaw' })
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     const order: string[] = []
@@ -3981,9 +3981,42 @@ describe('start autoUpgrade integration', () => {
     expect(order).toEqual(['bun-link', 'ensureDeps:force=true'])
   })
 
-  test('relinked-to-local (link:) does NOT run bun link off-Windows', async () => {
+  test('win32 self-heals an interrupted relink: link: spec already on disk still runs bun link before install', async () => {
+    // A prior start wrote `link:typeclaw` but its bun link failed, so reconcile
+    // now sees a local spec and returns skipped-dev-mode (no transition). The
+    // guard must STILL register the link before install, keyed on the on-disk
+    // spec rather than the outcome.
     await writeDockerfile(root)
-    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writePackageJson(root, { typeclaw: 'link:typeclaw' })
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const order: string[] = []
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      platform: 'win32',
+      exec,
+      allocatePort: deterministicAllocator,
+      autoUpgrade: async () => ({ kind: 'skipped-dev-mode' }),
+      runBunLink: async () => {
+        order.push('bun-link')
+      },
+      ensureDeps: async () => {
+        order.push('ensureDeps')
+        return { ok: true, installed: true }
+      },
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    // The point: bun link runs before ensureDeps even with no reconcile
+    // transition, so the link: spec is registered before install.
+    expect(order).toEqual(['bun-link', 'ensureDeps'])
+  })
+
+  test('link:typeclaw agent does NOT run bun link off-Windows', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: 'link:typeclaw' })
     const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
 
     let linkCalled = false
@@ -3993,7 +4026,7 @@ describe('start autoUpgrade integration', () => {
       platform: 'linux',
       exec,
       allocatePort: deterministicAllocator,
-      autoUpgrade: async () => ({ kind: 'relinked-to-local', from: '^0.1.0', to: 'link:typeclaw' }),
+      autoUpgrade: async () => ({ kind: 'skipped-dev-mode' }),
       runBunLink: async () => {
         linkCalled = true
       },

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -254,11 +254,16 @@ export async function start({
     // image to a fresh container build.
     const upgrade = await autoUpgrade(cwd)
     const upgradeCommitMessage = commitMessageForAutoUpgrade(upgrade)
-    // A relink to `link:typeclaw` (native-Windows dev) needs the checkout
-    // registered with `bun link` BEFORE the forced install, exactly as init's
-    // maybeLinkWindowsDevTypeclaw does — otherwise ensureDeps can't resolve the
-    // link: spec. No-op off Windows (linkWindowsDevTypeclaw returns null).
-    if (upgrade.kind === 'relinked-to-local' && upgrade.to.startsWith('link:')) {
+    // Any agent on a `link:typeclaw` spec (native-Windows dev) needs the
+    // checkout registered with `bun link` BEFORE ensureDeps, exactly as init's
+    // maybeLinkWindowsDevTypeclaw does — otherwise bun can't resolve the link:
+    // spec. We gate on the EFFECTIVE on-disk spec, not the transition outcome:
+    // a prior start that wrote `link:` but failed/interrupted before
+    // registering would otherwise leave the next start (which sees the spec
+    // already local → skipped-dev-mode) reaching ensureDeps unregistered.
+    // `bun link` is idempotent, so re-running it on every link: start is safe
+    // and self-heals that gap. No-op off Windows (linkWindowsDevTypeclaw → null).
+    if ((await readTypeclawDepSpec(cwd))?.startsWith('link:') === true) {
       const checkout = typeclawCheckoutRoot()
       if (checkout !== null) {
         await linkWindowsDevTypeclaw(checkout, { platform, ...(runBunLink !== undefined ? { runBunLink } : {}) })
@@ -1082,14 +1087,18 @@ export function shouldMountWindowsDevSource(
 // users (`^X.Y.Z`, `~X.Y.Z`, exact pins) pay nothing because their
 // install path is already cache-correct.
 async function hasLocallyLinkedTypeclawDep(cwd: string): Promise<boolean> {
+  const spec = await readTypeclawDepSpec(cwd)
+  return spec !== null && (spec.startsWith('file:') || spec.startsWith('link:'))
+}
+
+async function readTypeclawDepSpec(cwd: string): Promise<string | null> {
   try {
     const raw = await readFile(join(cwd, PACKAGE_FILE), 'utf8')
     const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> }
     const spec = pkg.dependencies?.typeclaw
-    if (typeof spec !== 'string') return false
-    return spec.startsWith('file:') || spec.startsWith('link:')
+    return typeof spec === 'string' ? spec : null
   } catch {
-    return false
+    return null
   }
 }
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -18,9 +18,10 @@ import {
   type AutoUpgradeOutcome,
   expectedInstalledAfterUpgrade,
   outcomeForcesInstall,
+  outcomeRequiresForceInstall,
   readInstalledTypeclawVersionFromAgent,
 } from '@/init/auto-upgrade'
-import { resolveBaseImageVersion } from '@/init/cli-version'
+import { resolveBaseImageVersion, resolveTypeclawSpec } from '@/init/cli-version'
 import { buildDockerfile, classifyDockerfileAppend, DOCKERFILE } from '@/init/dockerfile'
 import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
@@ -176,7 +177,7 @@ export async function start({
   cliEntry,
   reuseCurrentHostDaemon = false,
   ensureDeps = (dir, opts) => ensureDepsInstalled({ cwd: dir, ...opts }),
-  autoUpgrade = (dir) => autoUpgradeTypeclawDep({ cwd: dir }),
+  autoUpgrade = (dir) => autoUpgradeTypeclawDep({ cwd: dir, localSpec: resolveTypeclawSpec(dir) }),
   forceBunUpdate = runBunUpdate,
   readInstalledVersion = readInstalledTypeclawVersionFromAgent,
   verifyRunning = createVerifyRunning({ exec }),
@@ -294,7 +295,10 @@ export async function start({
     // version bump (dir already present) or a removal (stale dir left behind)
     // would otherwise leave bun.lock/node_modules out of sync with the
     // reconciled package.json.
-    const forceDepsReinstall = (forceBuild && (await hasLocallyLinkedTypeclawDep(cwd))) || pluginReconcile.changed
+    const forceDepsReinstall =
+      (forceBuild && (await hasLocallyLinkedTypeclawDep(cwd))) ||
+      pluginReconcile.changed ||
+      outcomeRequiresForceInstall(upgrade)
     const deps = await ensureDeps(cwd, { force: forceDepsReinstall })
     if (!deps.ok) {
       return { ok: false, reason: `dependency install failed: ${deps.reason}` }
@@ -511,6 +515,7 @@ export async function start({
 function commitMessageForAutoUpgrade(outcome: AutoUpgradeOutcome): string | null {
   if (outcome.kind === 'spec-rewritten') return `Upgrade typeclaw to ${outcome.to}`
   if (outcome.kind === 'reinstall-needed') return `Upgrade typeclaw to ${outcome.to}`
+  if (outcome.kind === 'relinked-to-local') return `Link typeclaw to local checkout (${outcome.to})`
   return null
 }
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -263,10 +263,21 @@ export async function start({
     // already local → skipped-dev-mode) reaching ensureDeps unregistered.
     // `bun link` is idempotent, so re-running it on every link: start is safe
     // and self-heals that gap. No-op off Windows (linkWindowsDevTypeclaw → null).
+    // True when this is a native-Windows agent on a `link:typeclaw` spec, after
+    // (re)registering its checkout. Forces ensureDeps below: ensureDeps' drift
+    // detector only looks for MISSING dep names, so a stale npm-installed
+    // node_modules/typeclaw left by an interrupted relink would make it skip the
+    // install and leave the agent on the old runtime. Forcing materializes the
+    // link. Off Windows / non-link specs this stays false.
+    let registeredWindowsLink = false
     if ((await readTypeclawDepSpec(cwd))?.startsWith('link:') === true) {
       const checkout = typeclawCheckoutRoot()
       if (checkout !== null) {
-        await linkWindowsDevTypeclaw(checkout, { platform, ...(runBunLink !== undefined ? { runBunLink } : {}) })
+        const linked = await linkWindowsDevTypeclaw(checkout, {
+          platform,
+          ...(runBunLink !== undefined ? { runBunLink } : {}),
+        })
+        registeredWindowsLink = linked !== null
       }
     }
     if (outcomeForcesInstall(upgrade)) {
@@ -322,7 +333,8 @@ export async function start({
     const forceDepsReinstall =
       (forceBuild && (await hasLocallyLinkedTypeclawDep(cwd))) ||
       pluginReconcile.changed ||
-      outcomeRequiresForceInstall(upgrade)
+      outcomeRequiresForceInstall(upgrade) ||
+      registeredWindowsLink
     const deps = await ensureDeps(cwd, { force: forceDepsReinstall })
     if (!deps.ok) {
       return { ok: false, reason: `dependency install failed: ${deps.reason}` }

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -21,14 +21,14 @@ import {
   outcomeRequiresForceInstall,
   readInstalledTypeclawVersionFromAgent,
 } from '@/init/auto-upgrade'
-import { resolveBaseImageVersion, resolveTypeclawSpec } from '@/init/cli-version'
+import { resolveBaseImageVersion, resolveTypeclawSpec, typeclawCheckoutRoot } from '@/init/cli-version'
 import { buildDockerfile, classifyDockerfileAppend, DOCKERFILE } from '@/init/dockerfile'
 import { ensureDepsInstalled, type EnsureDepsResult } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import { refreshPackageJson } from '@/init/packagejson'
 import { reconcilePluginDeps } from '@/init/reconcile-plugin-deps'
 import { runBunUpdate, type UpdateRunner } from '@/init/run-bun-install'
-import { resolveBunLinkedPackage } from '@/init/windows-dev-link'
+import { linkWindowsDevTypeclaw, resolveBunLinkedPackage, type RunBunLink } from '@/init/windows-dev-link'
 import { isWindows } from '@/shared'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
 
@@ -134,6 +134,13 @@ export type StartOptions = {
   // function to override the wait window or to bypass verification entirely
   // (e.g. a no-op `async () => ({ ok: true })` for unit tests that don't care).
   verifyRunning?: VerifyRunningFn
+  // Test seam for the native-Windows dev-link step run before ensureDeps when a
+  // local-checkout reconcile emits `link:typeclaw`. Defaults to `bun link` in
+  // the checkout. Mirrors init's `runBunLink` seam.
+  runBunLink?: RunBunLink
+  // Defaults to `process.platform`; tests inject it to exercise the
+  // native-Windows dev-link reconcile path off a non-Windows runner.
+  platform?: NodeJS.Platform
 }
 
 export type HostDaemonStatus =
@@ -181,6 +188,8 @@ export async function start({
   forceBunUpdate = runBunUpdate,
   readInstalledVersion = readInstalledTypeclawVersionFromAgent,
   verifyRunning = createVerifyRunning({ exec }),
+  runBunLink,
+  platform = process.platform,
 }: StartOptions): Promise<StartResult> {
   try {
     const containerName = containerNameFromCwd(cwd)
@@ -245,6 +254,16 @@ export async function start({
     // image to a fresh container build.
     const upgrade = await autoUpgrade(cwd)
     const upgradeCommitMessage = commitMessageForAutoUpgrade(upgrade)
+    // A relink to `link:typeclaw` (native-Windows dev) needs the checkout
+    // registered with `bun link` BEFORE the forced install, exactly as init's
+    // maybeLinkWindowsDevTypeclaw does — otherwise ensureDeps can't resolve the
+    // link: spec. No-op off Windows (linkWindowsDevTypeclaw returns null).
+    if (upgrade.kind === 'relinked-to-local' && upgrade.to.startsWith('link:')) {
+      const checkout = typeclawCheckoutRoot()
+      if (checkout !== null) {
+        await linkWindowsDevTypeclaw(checkout, { platform, ...(runBunLink !== undefined ? { runBunLink } : {}) })
+      }
+    }
     if (outcomeForcesInstall(upgrade)) {
       const forced = await forceBunUpdate(cwd, 'typeclaw')
       if (!forced.ok) {
@@ -402,6 +421,7 @@ export async function start({
       hostdControl,
       publishHost,
       tuiToken,
+      platform,
     })
 
     let built = false
@@ -477,6 +497,7 @@ export async function start({
         hostdControl,
         publishHost,
         tuiToken,
+        platform,
       })
       run = await execRunWithConflictRetry(exec, plan.runArgs, cwd, containerName)
     }

--- a/src/init/auto-upgrade.test.ts
+++ b/src/init/auto-upgrade.test.ts
@@ -91,10 +91,10 @@ describe('autoUpgradeTypeclawDep — skipped outcomes', () => {
     expect(outcome).toEqual({ kind: 'skipped-no-dep' })
   })
 
-  test('returns skipped-non-release-spec for file: / link: / dist-tag / range / glob / github: specs', async () => {
+  test('returns skipped-non-release-spec for dist-tag / range / glob / github: specs', async () => {
+    // file:/link: are intentionally excluded — under an npm CLI they relink to
+    // npm (covered in the reconcile suite), so they are NOT skipped specs.
     for (const spec of [
-      'file:../typeclaw',
-      'link:../typeclaw',
       'latest',
       'workspace:*',
       'npm:typeclaw@0.1.0',
@@ -109,6 +109,51 @@ describe('autoUpgradeTypeclawDep — skipped outcomes', () => {
 
       expect(outcome).toEqual({ kind: 'skipped-non-release-spec', declared: spec })
     }
+  })
+})
+
+describe('autoUpgradeTypeclawDep — local/npm reconcile', () => {
+  test('npm CLI + file: spec → relinks to ^version (spec-rewritten)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: 'file:../typeclaw' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.4.0' })
+
+    expect(outcome).toMatchObject({ kind: 'spec-rewritten', from: 'file:../typeclaw', to: '^0.4.0' })
+    expect((await readPackageJson()).dependencies).toEqual({ typeclaw: '^0.4.0' })
+  })
+
+  test('npm CLI + link: spec → relinks to ^version (spec-rewritten)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: 'link:typeclaw' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: '^0.4.0' })
+
+    expect(outcome).toMatchObject({ kind: 'spec-rewritten', to: '^0.4.0' })
+  })
+
+  test('local CLI + npm range → relinks to the local spec (relinked-to-local)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '^0.1.0' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: null, localSpec: 'file:../typeclaw' })
+
+    expect(outcome).toMatchObject({ kind: 'relinked-to-local', from: '^0.1.0', to: 'file:../typeclaw' })
+    expect((await readPackageJson()).dependencies).toEqual({ typeclaw: 'file:../typeclaw' })
+  })
+
+  test('local CLI + spec already matching the local spec → no-op (skipped-dev-mode)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: 'file:../typeclaw' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: null, localSpec: 'file:../typeclaw' })
+
+    expect(outcome).toEqual({ kind: 'skipped-dev-mode' })
+  })
+
+  test('local CLI + exact pin → left untouched (skipped-dev-mode)', async () => {
+    await writePackageJson({ dependencies: { typeclaw: '0.1.5' } })
+
+    const outcome = await autoUpgradeTypeclawDep({ cwd: root, scaffoldVersion: null, localSpec: 'file:../typeclaw' })
+
+    expect(outcome).toEqual({ kind: 'skipped-dev-mode' })
+    expect((await readPackageJson()).dependencies).toEqual({ typeclaw: '0.1.5' })
   })
 })
 

--- a/src/init/auto-upgrade.ts
+++ b/src/init/auto-upgrade.ts
@@ -30,21 +30,21 @@ export type AutoUpgradeOutcome =
   | { kind: 'exact-pin-respected'; declared: string; cliVersion: string }
   | { kind: 'spec-rewritten'; from: string; to: string; cliVersion: string }
   | { kind: 'reinstall-needed'; from: string; to: string }
+  | { kind: 'relinked-to-local'; from: string; to: string }
 
 export type AutoUpgradeOptions = {
   cwd: string
   // Test seam: lets tests simulate dev-mode (null) and arbitrary release
   // versions without depending on the test runner's actual CLI version.
   scaffoldVersion?: string | null
+  // Test seam: the local spec to relink to in dev-mode, so tests don't depend
+  // on the test runner's actual checkout path.
+  localSpec?: string
 }
 
 export async function autoUpgradeTypeclawDep(options: AutoUpgradeOptions): Promise<AutoUpgradeOutcome> {
   const { cwd } = options
   const scaffold = options.scaffoldVersion !== undefined ? options.scaffoldVersion : resolveScaffoldVersion()
-  if (scaffold === null) return { kind: 'skipped-dev-mode' }
-
-  const cliVersion = stripCaret(scaffold)
-  if (cliVersion === null) return { kind: 'skipped-dev-mode' }
 
   const pkg = await readAgentPackageJson(cwd)
   if (pkg === null) return { kind: 'skipped-no-dep' }
@@ -52,8 +52,32 @@ export async function autoUpgradeTypeclawDep(options: AutoUpgradeOptions): Promi
   const declared = pkg.parsed.dependencies?.[TYPECLAW]
   if (typeof declared !== 'string') return { kind: 'skipped-no-dep' }
 
+  // The CLI runs from a source checkout (scaffold === null): the agent should
+  // track that checkout, not a published version. Relink any registry-range
+  // spec to the local spec (`file:`/`link:`); leave an exact pin (explicit user
+  // override) and an already-local spec alone.
+  if (scaffold === null) {
+    const localSpec = options.localSpec ?? null
+    if (localSpec === null || declared.startsWith('file:') || declared.startsWith('link:')) {
+      return { kind: 'skipped-dev-mode' }
+    }
+    if (classifyDepSpec(declared).kind === 'exact') return { kind: 'skipped-dev-mode' }
+    await writeDepSpec(cwd, pkg.raw, pkg.parsed, localSpec)
+    return { kind: 'relinked-to-local', from: declared, to: localSpec }
+  }
+
+  const cliVersion = stripCaret(scaffold)
+  if (cliVersion === null) return { kind: 'skipped-dev-mode' }
+
   const declaredKind = classifyDepSpec(declared)
   if (declaredKind.kind === 'non-release') {
+    // An installed CLI against a local (`file:`/`link:`) spec: the agent was on
+    // a dev checkout but is now run by an npm CLI — restore the registry range.
+    if (declared.startsWith('file:') || declared.startsWith('link:')) {
+      const newSpec = `^${cliVersion}`
+      await writeDepSpec(cwd, pkg.raw, pkg.parsed, newSpec)
+      return { kind: 'spec-rewritten', from: declared, to: newSpec, cliVersion }
+    }
     return { kind: 'skipped-non-release-spec', declared }
   }
 
@@ -113,6 +137,14 @@ export function outcomeForcesInstall(outcome: AutoUpgradeOutcome): boolean {
   return outcome.kind === 'spec-rewritten' || outcome.kind === 'reinstall-needed'
 }
 
+// A relink to a local `file:`/`link:` spec installs via a forced `bun install`
+// (file deps don't "update"), NOT the `bun update --latest` path above — and it
+// skips version verification, since a local install's version is whatever the
+// checkout declares. start.ts ORs this into its ensureDeps force flag.
+export function outcomeRequiresForceInstall(outcome: AutoUpgradeOutcome): boolean {
+  return outcome.kind === 'relinked-to-local'
+}
+
 // The version we expect to find in node_modules/typeclaw after the
 // auto-upgrade-triggered install completes. Callers use this to verify
 // the install actually moved the on-disk version (not just resolved the
@@ -130,6 +162,8 @@ export function describeAutoUpgrade(outcome: AutoUpgradeOutcome): string {
       return `Upgrading agent typeclaw ${outcome.from} → ${outcome.to} to match CLI`
     case 'reinstall-needed':
       return `Upgrading agent typeclaw ${outcome.from} → ${outcome.to} to match CLI`
+    case 'relinked-to-local':
+      return `Linking agent typeclaw to local checkout (${outcome.to})`
     case 'exact-pin-respected':
       return `Agent typeclaw is exact-pinned to ${outcome.declared}; CLI is ${outcome.cliVersion}. Not upgrading (remove the exact pin to allow auto-upgrade).`
     default:

--- a/src/init/cli-version.ts
+++ b/src/init/cli-version.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join, relative } from 'node:path'
+
+import { isWindows } from '@/shared/platform'
 
 // Single source of truth for "what version of typeclaw is this agent on,
 // and where does that mean we should pin the base image / write the dep
@@ -32,6 +34,33 @@ function isInstalledCli(): boolean {
 export function resolveScaffoldVersion(): string | null {
   if (!isInstalledCli()) return null
   return `^${CLI_VERSION}`
+}
+
+const TYPECLAW_PACKAGE = 'typeclaw'
+
+// The local typeclaw source checkout this CLI runs from (the dir holding the
+// CLI's own package.json), or null when the CLI is an installed package.
+export function typeclawCheckoutRoot(): string | null {
+  return isInstalledCli() ? null : dirname(CLI_PACKAGE_JSON_PATH)
+}
+
+// The `dependencies.typeclaw` spec a fresh/reconciled agent should declare to
+// track the running CLI: `^X.Y.Z` when the CLI is an installed package, else the
+// local checkout — `link:typeclaw` on native Windows (a `bun link` registration
+// bun symlinks instead of copying; `file:` would copy the whole checkout incl
+// `.git/` and EPERM, the #899 path) and `file:<rel>` on POSIX.
+export function resolveTypeclawSpec(agentRoot: string, platform: NodeJS.Platform = process.platform): string {
+  const scaffoldVersion = resolveScaffoldVersion()
+  if (scaffoldVersion !== null) return scaffoldVersion
+  if (isWindows(platform)) return `link:${TYPECLAW_PACKAGE}`
+  const checkout = typeclawCheckoutRoot()
+  return checkout ? `file:${toFileSpec(relative(agentRoot, checkout))}` : 'file:../typeclaw'
+}
+
+function toFileSpec(rel: string): string {
+  if (rel === '') return '.'
+  // bun/npm accept POSIX-style paths in file: specifiers; normalize separators.
+  return rel.split(/[\\/]/).join('/')
 }
 
 // The version of typeclaw the AGENT will actually run inside the container.

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -1,7 +1,6 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { basename, dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { basename, join, resolve } from 'node:path'
 
 import {
   config,
@@ -34,7 +33,7 @@ import { hostLocaleIsCjk } from '@/shared/host-locale'
 import { isWindows } from '@/shared/platform'
 import { createTui } from '@/tui'
 
-import { resolveBaseImageVersion, resolveScaffoldVersion } from './cli-version'
+import { resolveBaseImageVersion, resolveTypeclawSpec, typeclawCheckoutRoot } from './cli-version'
 import { buildDockerfile, DOCKERFILE } from './dockerfile'
 import { CONFIG_FILE, findAgentDir, isInitialized } from './find-agent-dir'
 import { installGithubWebhooksEagerly, type EagerGithubWebhookInstallResult } from './github-webhook-install'
@@ -58,7 +57,6 @@ export { CONFIG_FILE, findAgentDir, isInitialized }
 
 const CRON_FILE = 'cron.json'
 const PACKAGE_FILE = 'package.json'
-const TYPECLAW_PACKAGE = 'typeclaw'
 
 const MARKDOWN_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md'] as const
 
@@ -717,52 +715,13 @@ function buildPackageJson(root: string, name: string, platform: NodeJS.Platform)
   }
 }
 
-// Prefer the registry-style range (`^X.Y.Z`) when typeclaw is itself an
-// installed package — that's what lets `bun install` in the agent resolve
-// typeclaw from npm. Fall back to the local checkout for dev contributors
-// running `bun run src/cli/index.ts init` from the repo: `link:typeclaw` on
-// native Windows (a `bun link` registration that bun's installer symlinks
-// rather than copying — `file:` would copy the whole checkout incl `.git/`
-// and EPERM, the #899 path), `file:<rel>` on POSIX (works today, keeps the
-// same-path mirror mount in start.ts).
-function resolveTypeclawSpec(agentRoot: string, platform: NodeJS.Platform = process.platform): string {
-  const scaffoldVersion = resolveScaffoldVersion()
-  if (scaffoldVersion !== null) return scaffoldVersion
-  if (isWindows(platform)) return `link:${TYPECLAW_PACKAGE}`
-  const typeclawRoot = findTypeclawRoot()
-  return typeclawRoot ? `file:${toFileSpec(relative(agentRoot, typeclawRoot))}` : 'file:../typeclaw'
-}
-
 async function maybeLinkWindowsDevTypeclaw(
   platform: NodeJS.Platform,
   runBunLink: RunBunLink | undefined,
 ): Promise<void> {
-  if (resolveScaffoldVersion() !== null) return
-  const typeclawRoot = findTypeclawRoot()
+  const typeclawRoot = typeclawCheckoutRoot()
   if (typeclawRoot === null) return
   await linkWindowsDevTypeclaw(typeclawRoot, { platform, ...(runBunLink !== undefined ? { runBunLink } : {}) })
-}
-
-function toFileSpec(rel: string): string {
-  if (rel === '') return '.'
-  // bun/npm accept POSIX-style paths in file: specifiers; normalize separators.
-  return rel.split(/[\\/]/).join('/')
-}
-
-function findTypeclawRoot(): string | null {
-  try {
-    let dir = dirname(fileURLToPath(import.meta.url))
-    const root = resolve('/')
-    while (dir !== root) {
-      const pkgPath = join(dir, 'package.json')
-      if (existsSync(pkgPath)) {
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: string }
-        if (pkg.name === 'typeclaw') return dir
-      }
-      dir = dirname(dir)
-    }
-  } catch {}
-  return null
 }
 
 export async function writeDockerAssets(root: string): Promise<DockerAssetsResult> {


### PR DESCRIPTION
## Background

Switching between npm-installed and local-checkout typeclaw left the agent's `dependencies.typeclaw` inconsistent with the running CLI. The only fix was to manually edit `package.json` or re-run `init`. This folds the reconcile into the existing start-time auto-upgrade path (`autoUpgradeTypeclawDep`) that already runs on every `init`/`start`/`restart`, rather than adding a new command (the approach in the now-closed #1013, abandoned for being too large a surface addition).

## Summary

`autoUpgradeTypeclawDep` now handles four cases:

| Running CLI | Agent spec | Outcome |
|---|---|---|
| npm-installed | local (file:/link:) | Rewrite to `^<cliVersion>` — `spec-rewritten`, existing bun update + version-verify path |
| local-checkout | npm range | Rewrite to local spec — `relinked-to-local`, forced bun install; skips npm-version verify |
| Either | Exact pin (=x.y.z) | No-op — treated as explicit user override |
| Either | Already-correct spec | No-op — no rewrite, no install |

The local spec is computed by the existing `resolveTypeclawSpec` (produces `^version` for npm, `link:typeclaw` on native-Windows dev, `file:<rel>` on POSIX dev). The first commit moves it from `src/init/index.ts` to `src/init/cli-version.ts` so `start.ts` can import it without cycling through the heavy init barrel.

A new `outcomeRequiresForceInstall` flag threads the `relinked-to-local` outcome through `start.ts` to take the existing `forceDepsReinstall` path (`ensureDeps` with `force: true`) instead of `bun update`.

## What this does NOT do

- Does not add a CLI command, flag, config field, or plugin contract surface — patch-level release impact.
- Does not touch exact-pinned specs or already-correct specs.
- Does not change POSIX or Windows dev behavior on paths that were already consistent.
- Supersedes #1013 (the standalone `typeclaw dev-dep` command approach), now closed.

## Review notes

Two commits; review in order:

1. `refactor(init): move resolveTypeclawSpec into cli-version` — pure relocation, no behavior change. Verifiable by comparing the function body before and after.
2. `feat(init): auto-reconcile the agent typeclaw dep to the running CLI` — the load-bearing change. Key invariant: `relinked-to-local` must NOT take the bun update + npm-version-verify path (fails for `file:` installs — no registry version exists). The `outcomeRequiresForceInstall` flag is the gate. Tests in `auto-upgrade.test.ts` cover the full npm↔local matrix and no-op cases; `start.test.ts` covers install-strategy routing.

All checks pass: `typecheck`, `lint` (0 errors), `format`, full test suite (9794 pass, 0 fail). 6 files changed, +182/−56.