### PR TITLE
fix(windows): handle native-Windows link: specs in dev-mode mount + devMode detection

### DIFF
--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -13,6 +13,7 @@ import { isWindows } from '@/shared'
 import type { DockerExec } from './shared'
 import {
   commitSystemFile,
+  isPathInsideOrEqual,
   planStart,
   refreshDockerfile,
   refreshGitignore,
@@ -448,17 +449,33 @@ describe('shouldMirrorDevSource', () => {
 })
 
 describe('shouldMountWindowsDevSource', () => {
-  test('mounts the checkout over the in-container node_modules path on Windows', () => {
-    expect(shouldMountWindowsDevSource('C:\\src\\typeclaw', 'win32')).toBe(true)
+  test('mounts an out-of-cwd checkout (e.g. a bun-linked link: source) over the in-container node_modules path on Windows', () => {
+    expect(shouldMountWindowsDevSource('/src/typeclaw', '/agents/coder', 'win32')).toBe(true)
   })
 
   test('does NOT mount on POSIX (the same-path mirror branch handles those)', () => {
-    expect(shouldMountWindowsDevSource('/srv/src/typeclaw', 'linux')).toBe(false)
-    expect(shouldMountWindowsDevSource('/srv/src/typeclaw', 'darwin')).toBe(false)
+    expect(shouldMountWindowsDevSource('/srv/src/typeclaw', '/srv/agents/coder', 'linux')).toBe(false)
+    expect(shouldMountWindowsDevSource('/srv/src/typeclaw', '/srv/agents/coder', 'darwin')).toBe(false)
   })
 
   test('does NOT mount when there is no dev source', () => {
-    expect(shouldMountWindowsDevSource(null, 'win32')).toBe(false)
+    expect(shouldMountWindowsDevSource(null, '/agents/coder', 'win32')).toBe(false)
+  })
+
+  test('does NOT mount when the dev source lives inside the agent folder (already exposed via /agent)', () => {
+    expect(shouldMountWindowsDevSource('/agents/coder/vendor/typeclaw', '/agents/coder', 'win32')).toBe(false)
+  })
+})
+
+describe('isPathInsideOrEqual', () => {
+  test('treats the parent itself and descendants as inside', () => {
+    expect(isPathInsideOrEqual('/srv/agent', '/srv/agent')).toBe(true)
+    expect(isPathInsideOrEqual('/srv/agent/vendor/typeclaw', '/srv/agent')).toBe(true)
+  })
+
+  test('treats siblings and prefix-collision neighbors as outside', () => {
+    expect(isPathInsideOrEqual('/srv/src/typeclaw', '/srv/agent')).toBe(false)
+    expect(isPathInsideOrEqual('/srv/agentX', '/srv/agent')).toBe(false)
   })
 })
 
@@ -1055,6 +1072,34 @@ describe('refreshDockerfile', () => {
       await refreshDockerfile(dir)
 
       // then: no GHCR pin (dev version doesn't exist on GHCR yet) — inline heavy stack on oven/bun
+      const written = await readFile(join(dir, 'Dockerfile'), 'utf8')
+      expect(written).not.toContain('ghcr.io/typeclaw/typeclaw-base')
+      expect(written).toContain('FROM oven/bun:1-slim')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('inlines (no GHCR pin) for a link: dev install even when node_modules has a release-shaped version', async () => {
+    // given: a native-Windows link: dev agent where ensureDeps already populated
+    // node_modules/typeclaw with a release-shaped but unpublished version — the
+    // case that would otherwise be rewritten to FROM ...:99.99.99 on start
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-refresh-winlink-'))
+    try {
+      await writeFile(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: 'test', dependencies: { typeclaw: 'link:typeclaw' } }),
+      )
+      await mkdir(join(dir, 'node_modules', 'typeclaw'), { recursive: true })
+      await writeFile(
+        join(dir, 'node_modules', 'typeclaw', 'package.json'),
+        JSON.stringify({ name: 'typeclaw', version: '99.99.99' }),
+      )
+
+      // when: refreshDockerfile runs (the path start() takes after ensureDeps)
+      await refreshDockerfile(dir)
+
+      // then: the local-spec gate inlines the heavy stack instead of pinning a nonexistent GHCR tag
       const written = await readFile(join(dir, 'Dockerfile'), 'utf8')
       expect(written).not.toContain('ghcr.io/typeclaw/typeclaw-base')
       expect(written).toContain('FROM oven/bun:1-slim')

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { isAbsolute, join, resolve } from 'node:path'
+import { isAbsolute, join, relative, resolve } from 'node:path'
 
 import { agentUsesVector } from '@/bundled-plugins/memory/vector/config'
 import { expandMountPath, loadConfigSync, withDefaultPlugins, type Config } from '@/config'
@@ -716,7 +716,7 @@ export async function planStart({
 
   if (shouldMirrorDevSource(devSourcePath, cwd, platform)) {
     runArgs.push(...dockerBindMount({ src: devSourcePath, dst: devSourcePath, readonly: true }))
-  } else if (shouldMountWindowsDevSource(devSourcePath, platform)) {
+  } else if (shouldMountWindowsDevSource(devSourcePath, cwd, platform)) {
     runArgs.push(...dockerBindMount({ src: devSourcePath, dst: DEV_SOURCE_CONTAINER_PATH, readonly: true }))
   }
 
@@ -767,8 +767,16 @@ export async function refreshDockerfile(
   opts: { buildKit?: boolean } = {},
 ): Promise<{ changed: boolean; warnings: string[] }> {
   const cfg = await loadTypeclawConfig(cwd)
+  // A local-spec (`file:`/`link:`) dev install must inline the heavy stack: its
+  // unreleased version has no published `typeclaw-base` tag, and
+  // resolveBaseImageVersion prefers node_modules/typeclaw/package.json#version —
+  // which `ensureDeps` has already materialized by the time start() calls this —
+  // so without the gate a release-shaped dev version pins a nonexistent
+  // `FROM ghcr.io/...:<version>`. `null` selects the inline `oven/bun:1-slim`
+  // path. Mirrors the same gate in writeDockerAssets (src/init/index.ts).
+  const devMode = await hasLocallyLinkedTypeclawDep(cwd)
   const next = buildDockerfile(cfg.docker.file, {
-    baseImageVersion: resolveBaseImageVersion(cwd),
+    baseImageVersion: devMode ? null : resolveBaseImageVersion(cwd),
     cjkFontsAuto: hostLocaleIsCjk(),
     buildKit: opts.buildKit,
   })
@@ -1060,6 +1068,18 @@ async function detectDevSource(cwd: string): Promise<string | null> {
   }
 }
 
+// True when `child` is `parent` itself or nested beneath it. Lexical, not
+// realpath-aware — callers pass already-resolved absolute paths. Preferred over
+// `child.startsWith(parent)`, which mis-fires on sibling-prefix collisions
+// (`C:\foo` vs `C:\foobar`), trailing-separator skew, and would treat
+// `/srv/agentX` as inside `/srv/agent`. A dev source already inside the agent
+// folder is reachable through the `/agent` bind mount, so neither dev-source
+// branch should add a second mount for it.
+export function isPathInsideOrEqual(child: string, parent: string): boolean {
+  const rel = relative(parent, child)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
 // POSIX dev mode: node_modules/typeclaw is a symlink to an absolute host path
 // outside /agent. The mirror mount bind-mounts that path at the SAME path inside
 // the (Linux) container so the symlink resolves. That only works when the host
@@ -1074,7 +1094,7 @@ export function shouldMirrorDevSource(
   cwd: string,
   platform: NodeJS.Platform = process.platform,
 ): devSourcePath is string {
-  return devSourcePath !== null && !devSourcePath.startsWith(cwd) && !isWindows(platform)
+  return devSourcePath !== null && !isPathInsideOrEqual(devSourcePath, cwd) && !isWindows(platform)
 }
 
 // Native-Windows dev mode (#899): the host's `C:\...` checkout cannot be
@@ -1082,12 +1102,16 @@ export function shouldMirrorDevSource(
 // checkout directly over the standard resolution path `/agent/node_modules/
 // typeclaw` inside the container, so Node/Bun resolve typeclaw from source
 // regardless of how the host materialized node_modules/typeclaw (a junction,
-// per prepareWindowsDevJunction).
+// per prepareWindowsDevJunction). Like the POSIX branch, skip when the dev
+// source lives inside the agent folder: a `file:./vendor/typeclaw` checkout is
+// already exposed via the `/agent` mount, so a second mount is wrong. A
+// bun-linked (`link:`) checkout legitimately lives outside cwd and still mounts.
 export function shouldMountWindowsDevSource(
   devSourcePath: string | null,
+  cwd: string,
   platform: NodeJS.Platform = process.platform,
 ): devSourcePath is string {
-  return devSourcePath !== null && isWindows(platform)
+  return devSourcePath !== null && !isPathInsideOrEqual(devSourcePath, cwd) && isWindows(platform)
 }
 
 // True when the agent's package.json declares typeclaw via `file:` or

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -337,6 +337,10 @@ describe('runInit', () => {
     await runInit({
       cwd: root,
       apiKey: 'fw_test_key',
+      // Pin POSIX: the dev-checkout spec is `file:` on POSIX, `link:` on
+      // Windows (resolveTypeclawSpec). This case asserts the `file:` contract;
+      // the Windows `link:` contract is covered by a sibling test below.
+      platform: 'linux',
       runHatching: okHatch,
       runBunInstall: okInstall,
       dockerExec: okDocker,
@@ -984,7 +988,7 @@ describe('scaffold', () => {
   })
 
   test('writes a private package.json named after the folder with typeclaw as a file: dependency', async () => {
-    await scaffold(root)
+    await scaffold(root, { platform: 'linux' })
 
     const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as Record<string, unknown>
     expect(pkg.name).toBe(basename(root))
@@ -993,6 +997,15 @@ describe('scaffold', () => {
     const deps = pkg.dependencies as Record<string, string>
     expect(deps.typeclaw).toMatch(/^file:/)
     expect(pkg.scripts).toBeUndefined()
+  })
+
+  test('writes typeclaw as a link: dependency on native Windows (#899)', async () => {
+    await scaffold(root, { platform: 'win32' })
+
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies.typeclaw).toBe('link:typeclaw')
   })
 
   test('package.json declares packages/* as a bun workspace root', async () => {
@@ -1024,7 +1037,7 @@ describe('scaffold', () => {
   })
 
   test('package.json typeclaw file: dependency points at the typeclaw repo', async () => {
-    await scaffold(root)
+    await scaffold(root, { platform: 'linux' })
 
     const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
       dependencies: Record<string, string>
@@ -1422,11 +1435,41 @@ describe('writeDockerAssets', () => {
   })
 
   test('returns devMode true when typeclaw dep is a file: spec', async () => {
-    await scaffold(root)
+    await scaffold(root, { platform: 'linux' })
 
     const result = await writeDockerAssets(root)
 
     expect(result).toEqual({ ok: true, devMode: true })
+  })
+
+  test('returns devMode true when typeclaw dep is a link: spec (native-Windows dev)', async () => {
+    await scaffold(root, { platform: 'win32' })
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies.typeclaw).toBe('link:typeclaw')
+
+    const result = await writeDockerAssets(root)
+
+    expect(result).toEqual({ ok: true, devMode: true })
+  })
+
+  test('inlines the heavy stack (no ghcr base pin) for a link: dev install whose node_modules version looks release-shaped', async () => {
+    await scaffold(root, { platform: 'win32' })
+    // resolveBaseImageVersion prefers node_modules/typeclaw/package.json#version;
+    // a release-SHAPED but unpublished dev version must NOT become a base-image
+    // pin, since that GHCR tag does not exist.
+    await mkdir(join(root, 'node_modules', 'typeclaw'), { recursive: true })
+    await writeFile(
+      join(root, 'node_modules', 'typeclaw', 'package.json'),
+      `${JSON.stringify({ name: 'typeclaw', version: '99.99.99' }, null, 2)}\n`,
+    )
+
+    const result = await writeDockerAssets(root)
+
+    expect(result).toEqual({ ok: true, devMode: true })
+    const dockerfile = await readFile(join(root, 'Dockerfile'), 'utf8')
+    expect(dockerfile).not.toContain('ghcr.io/typeclaw/typeclaw-base')
   })
 
   test('returns devMode false when typeclaw dep is a version range', async () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -728,13 +728,21 @@ export async function writeDockerAssets(root: string): Promise<DockerAssetsResul
   try {
     const pkg = await readPackageJson(root)
     const typeclawSpec = pkg.dependencies?.typeclaw ?? ''
-    const devMode = typeclawSpec.startsWith('file:')
+    // Both `file:` (POSIX dev) and `link:` (native-Windows dev, see
+    // resolveTypeclawSpec) are locally-linked checkouts that must inline the
+    // heavy stack on the slim base, since the matching GHCR base tag for an
+    // unreleased dev build does not exist. Mirrors hasLocallyLinkedTypeclawDep.
+    const devMode = typeclawSpec.startsWith('file:') || typeclawSpec.startsWith('link:')
 
     const typeclawConfig = await readTypeclawConfig(root)
     await writeFile(
       join(root, DOCKERFILE),
       buildDockerfile(typeclawConfig.docker.file, {
-        baseImageVersion: resolveBaseImageVersion(root),
+        // A local-spec dev install must inline the heavy stack: its unreleased
+        // version has no published `typeclaw-base` tag, so resolving a base
+        // image version would pin a nonexistent `FROM ghcr.io/...:<version>`.
+        // `null` selects the inline `oven/bun:1-slim` path in buildDockerfile.
+        baseImageVersion: devMode ? null : resolveBaseImageVersion(root),
         cjkFontsAuto: hostLocaleIsCjk(),
       }),
       { flag: 'wx' },


### PR DESCRIPTION
## Summary

The `windows-test` CI lane (informational triage, `continue-on-error`) reported **5 deterministic failures** on native Windows. They were not environment flakiness — every failure traced to POSIX-only assumptions about how the agent's `typeclaw` dependency is specified: `file:<rel>` on POSIX vs `link:typeclaw` on native Windows (`resolveTypeclawSpec`, #899).

This splits into **2 genuine product bugs** and **3 test-portability bugs**.

## Product bugs fixed

**1. `shouldMountWindowsDevSource` mounted an already-mounted source**

The Windows dev-source branch added a read-only bind mount for *any* non-null dev source — including a `file:./vendor/typeclaw` checkout living **inside** the agent folder, which is already exposed through the `/agent` bind mount. The POSIX branch (`shouldMirrorDevSource`) already guarded this with an inside-cwd check; the Windows branch did not.

Fix: extract a robust `isPathInsideOrEqual(child, parent)` helper (built on `path.relative`, immune to the `startsWith` prefix-collision trap — `C:\foo` vs `C:\foobar` — and trailing-separator skew) and apply it to **both** branches. A bun-linked (`link:`) checkout outside cwd still mounts, as intended.

**2. `writeDockerAssets` devMode ignored `link:`**

`devMode` was derived from `spec.startsWith('file:')` only, so a native-Windows dev install (`link:` spec) was wrongly treated as a release build — which would pin a nonexistent `ghcr.io/typeclaw/typeclaw-base:X.Y.Z` tag for an unreleased dev build. Now recognizes `link:` too, matching the existing `hasLocallyLinkedTypeclawDep` precedent in `start.ts`.

## Test bugs fixed

`scaffold` / `runInit` / `writeDockerAssets` tests asserted the POSIX `file:` contract while running under `process.platform`, so they failed on the Windows runner. Pinned `platform: 'linux'` on those cases (they are explicitly about POSIX output), and added explicit **Windows contract tests**:

- `scaffold` writes `link:typeclaw` on `win32`
- `writeDockerAssets` reports `devMode: true` for a `link:` spec
- `shouldMountWindowsDevSource` skips the mount when the source is inside cwd, and mounts when it is outside
- `isPathInsideOrEqual` unit coverage (parent/descendant inside; sibling + prefix-collision outside)

## Verification

| Check | Result |
|---|---|
| `bun run typecheck` | pass |
| `bun run lint` | 0 errors (67 pre-existing warnings, unrelated) |
| `bun run format:check` | pass |
| `bun test --parallel` | **9805 pass, 0 fail, 1 skip** (Linux-only bwrap skip) |

The 5 previously-failing tests now pass, and the new contract/regression tests lock the per-OS behavior so the POSIX/Windows split can't silently regress.