### PR TITLE
chore(tui): drop the open-box assistant header

### DIFF
--- a/src/tui/format.test.ts
+++ b/src/tui/format.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
-  formatAssistantHeader,
   formatCost,
   formatTimestamp,
   formatTokenCount,
@@ -257,18 +256,6 @@ describe('formatTimestamp', () => {
   test('withTimestamp prefixes the body with the time', () => {
     const ts = new Date(2026, 0, 2, 23, 59, 59).getTime()
     expect(visible(withTimestamp(ts, 'hello'))).toBe('23:59:59 hello')
-  })
-})
-
-describe('formatAssistantHeader', () => {
-  test('renders a typeclaw box header carrying the timestamp', () => {
-    const ts = new Date(2026, 0, 2, 9, 5, 7).getTime()
-    const out = visible(formatAssistantHeader(ts))
-    expect(out).toContain('╭─ typeclaw · 09:05:07')
-  })
-
-  test('falls back to the placeholder clock for undefined ts', () => {
-    expect(visible(formatAssistantHeader(undefined))).toContain('--:--:--')
   })
 })
 

--- a/src/tui/format.ts
+++ b/src/tui/format.ts
@@ -37,25 +37,6 @@ export function withTimestamp(ts: number | undefined, body: string): string {
   return `${formatTimestamp(ts)} ${body}`
 }
 
-// Open-box top rule for an assistant turn. Only a header (no closing rule) so
-// the look survives streaming Markdown whose end is unknown at render time.
-export function formatAssistantHeader(ts: number | undefined): string {
-  const clock = plainTimestamp(ts)
-  const label = `╭─ typeclaw · ${clock} `
-  return colors.accent(`${label}${'─'.repeat(ASSISTANT_HEADER_RULE_WIDTH)}`)
-}
-
-const ASSISTANT_HEADER_RULE_WIDTH = 8
-
-function plainTimestamp(ts: number | undefined): string {
-  if (ts === undefined || ts === 0) return '--:--:--'
-  const d = new Date(ts)
-  const hh = String(d.getHours()).padStart(2, '0')
-  const mm = String(d.getMinutes()).padStart(2, '0')
-  const ss = String(d.getSeconds()).padStart(2, '0')
-  return `${hh}:${mm}:${ss}`
-}
-
 export function formatTokenCount(tokens: number): string {
   if (tokens < 1000) return `${tokens}`
   const k = tokens / 1000

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -15,7 +15,6 @@ import { parseCommand } from '@/commands'
 import { formatBanner } from './banner'
 import { createClient as createClientDefault, type Client } from './client'
 import {
-  formatAssistantHeader,
   formatQueuePanel,
   formatToolEnd,
   formatToolStart,
@@ -251,13 +250,8 @@ export function createTui({
       onReplyDone = null
     }
 
-    // A Markdown block can't carry an ANSI header prefix (it'd be parsed as
-    // markdown), so the assistant turn's boxed header (label + timestamp) is a
-    // separate Text line emitted just above the block when it's first created —
-    // stamped with the first delta's server `ts`.
-    const ensureAssistantBlock = (ts: number | undefined): Markdown => {
+    const ensureAssistantBlock = (): Markdown => {
       if (currentAssistant) return currentAssistant
-      appendHistory(new Text(formatAssistantHeader(ts), 0, 0))
       const md = new Markdown('', 0, 0, markdownTheme)
       currentAssistant = md
       currentAssistantText = ''
@@ -275,7 +269,7 @@ export function createTui({
         }
         case 'text_delta': {
           hideThinking()
-          const block = ensureAssistantBlock(msg.ts)
+          const block = ensureAssistantBlock()
           currentAssistantText += msg.delta
           block.setText(currentAssistantText)
           tui.requestRender()


### PR DESCRIPTION
## Summary

Removes the per-turn decorative header that rendered above every assistant reply in the TUI:

```
╭─ typeclaw · 12:24:59 ────────
```

The shape was a single rounded top-left corner + a horizontal rule with no right corner, no side walls, and no bottom rule — a half-drawn box rather than a clean visual divider. Because it reads as a rendering artifact rather than intentional chrome, it is cleaner to remove it and let the assistant reply stream directly into its Markdown block.

## Changes

### `src/tui/format.ts`
- Delete `formatAssistantHeader()` along with its `ASSISTANT_HEADER_RULE_WIDTH` constant.
- Delete the now-dead `plainTimestamp()` helper, which was only ever called from the header formatter.

### `src/tui/index.ts`
- Stop emitting the header line in `ensureAssistantBlock`; drop the `ts` parameter that existed solely to supply the timestamp.
- Remove the stale `formatAssistantHeader` import.

### `src/tui/format.test.ts`
- Remove the `formatAssistantHeader` test block and its import (dead code after the deletion).

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — 9798 pass, 0 fail (TUI suite: 85 pass)