### PR TITLE
refactor(doc-render): write the PDF with Bun.write, not node:fs

### DIFF
--- a/src/bundled-plugins/doc-render/render.ts
+++ b/src/bundled-plugins/doc-render/render.ts
@@ -79,7 +79,7 @@ export async function loadCompilerModule(cwd: string = process.cwd()): Promise<N
 }
 
 export async function renderPdf(mainFile: string, outFile: string): Promise<number> {
-  const { existsSync, writeFileSync } = await import('node:fs')
+  const { existsSync } = await import('node:fs')
 
   const fontPaths = FONT_PATHS.filter((p) => existsSync(p))
   const mod = await loadCompilerModule()
@@ -88,7 +88,7 @@ export async function renderPdf(mainFile: string, outFile: string): Promise<numb
     ...(fontPaths.length > 0 ? { fontArgs: [{ fontPaths }] } : {}),
   })
   const pdf = compiler.pdf({ mainFilePath: mainFile })
-  writeFileSync(outFile, Buffer.from(pdf))
+  await Bun.write(outFile, pdf)
   return pdf.length
 }
 


### PR DESCRIPTION
## What

Make the `typeclaw-render-pdf` path (the `doc-render` plugin's render script) fully Bun-native by writing the compiled PDF with `Bun.write` instead of `node:fs`'s `writeFileSync`.

```diff
-  const { existsSync, writeFileSync } = await import('node:fs')
+  const { existsSync } = await import('node:fs')
   ...
-  writeFileSync(outFile, Buffer.from(pdf))
+  await Bun.write(outFile, pdf)
```

`Bun.write` accepts the `Uint8Array` the compiler returns directly, so this also drops the `Buffer.from(...)` copy. `existsSync` is kept for synchronous font-dir probing (a Node-compat API Bun supports; there's no synchronous `Bun.*` equivalent and the existing behavior — silently skipping missing dirs — is preserved).

## Why

The render script was already Bun-driven at the edges — `#!/usr/bin/env bun` shebang, the skill instructs `bun run` / `bun add`, and the compiler is dynamic-imported into the agent's own `node_modules`. The one remaining place that reached for a Node filesystem API in the hot path was the output write. This finishes the job.

## What was intentionally **not** changed

The compiler package stays `@myriaddreamin/typst-ts-node-compiler` (and the `NodeCompiler` class name). The vendor (Myriad-Dreamin/typst.ts) ships **no** Bun-specific package — only a WASM web compiler and this napi-rs `.node` compiler. The `.node` binary loads natively under Bun (Bun has N-API support), so the "Node" in the package name is the package's identity, not a runtime choice. Swapping it is impossible, not merely unnecessary.

## Verification

All from the worktree, on `bun`:

- `bun run test --parallel src/bundled-plugins/doc-render/` → **26 pass / 0 fail**
- `bun run typecheck` → clean
- `bun run lint` → 0 errors (pre-existing warnings unrelated to this change)
- `bun run format` → clean

Behavior is unchanged: same output file, same byte count returned, same error-handling paths (the `NotDir` / missing-compiler guidance still fire).
