### PR TITLE
feat(cli): non-blocking update-available notice

### DIFF
--- a/docs/content/docs/reference/env-vars.mdx
+++ b/docs/content/docs/reference/env-vars.mdx
@@ -6,11 +6,12 @@ icon: Variable
 
 ## Host stage
 
-| Variable             | Read by    | Default       | Effect                                                        |
-| -------------------- | ---------- | ------------- | ------------------------------------------------------------- |
-| `TYPECLAW_HOME`      | hostd, CLI | `~/.typeclaw` | Override the host daemon state directory; primarily for tests |
-| `TYPECLAW_LOG_LEVEL` | CLI        | `info`        | `debug` / `info` / `warn` / `error`                           |
-| `TYPECLAW_DEBUG`     | CLI        | unset         | Anything truthy enables verbose tracing                       |
+| Variable                   | Read by    | Default       | Effect                                                                                                            |
+| -------------------------- | ---------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `TYPECLAW_HOME`            | hostd, CLI | `~/.typeclaw` | Override the host daemon state directory; primarily for tests                                                     |
+| `TYPECLAW_LOG_LEVEL`       | CLI        | `info`        | `debug` / `info` / `warn` / `error`                                                                               |
+| `TYPECLAW_DEBUG`           | CLI        | unset         | Anything truthy enables verbose tracing                                                                           |
+| `TYPECLAW_NO_UPDATE_CHECK` | CLI        | unset         | Anything truthy disables the background "newer typeclaw available" check (also honors `NO_UPDATE_NOTIFIER`, `CI`) |
 
 ## Container stage (set by `typeclaw start`)
 

--- a/docs/content/docs/reference/typeclaw-json.mdx
+++ b/docs/content/docs/reference/typeclaw-json.mdx
@@ -8,24 +8,27 @@ JSON Schema–validated. `typeclaw init` scaffolds a `$schema` pointer at `./nod
 
 ## Top-level fields
 
-| Field                   | Type                                            | Reload                                       | Concept                                                                                |
-| ----------------------- | ----------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `models`                | `Record<string, ref \| ref[] \| ProfileObject>` | live                                         | model profile → ref, fallback chain, or object with a per-profile `thinkingLevel`      |
-| `port`                  | `number`                                        | restart-required                             | preferred host port; CLI falls back to ephemeral on conflict                           |
-| `mounts`                | `Mount[]`                                       | restart-required                             | host files or directories exposed inside the container                                 |
-| `plugins`               | `string[]`                                      | restart-required                             | plugin module specifiers                                                               |
-| `alias`                 | `string[]`                                      | live                                         | additional names the agent answers to in channels                                      |
-| `channels`              | `Record<adapter, AdapterConfig>`                | live                                         | per-adapter config                                                                     |
-| `portForward`           | `{ allow, deny? }`                              | restart-required                             | auto port-forward allow/deny lists; default `{ allow: '*' }`                           |
-| `network`               | `NetworkPolicy`                                 | restart-required                             | egress filtering                                                                       |
-| `sandbox`               | `SandboxPolicy`                                 | restart-required                             | per-tool bwrap sandbox options                                                         |
-| `tunnels`               | `Tunnel[]`                                      | restart-required                             | public URLs (see [/concepts/architecture](/docs/concepts/architecture))                |
-| `roles`                 | `Record<name, Role>`                            | `match` live, `permissions` restart-required | permission roles (see [/concepts/permissions-model](/docs/concepts/permissions-model)) |
-| `docker.file`           | `DockerFileOptions`                             | rebuild via `start`                          | Dockerfile feature toggles + append lines                                              |
-| `docker.runArgs.append` | `string[]`                                      | rebuild via `start`                          | extra `docker run` flags                                                               |
-| `git.ignore.append`     | `string[]`                                      | rebuild via `start`                          | extra `.gitignore` lines                                                               |
+| Field                   | Type                                            | Reload                                       | Concept                                                                                  |
+| ----------------------- | ----------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `models`                | `Record<string, ref \| ref[] \| ProfileObject>` | live                                         | model profile → ref, fallback chain, or object with a per-profile `thinkingLevel`        |
+| `port`                  | `number`                                        | restart-required                             | preferred host port; CLI falls back to ephemeral on conflict                             |
+| `mounts`                | `Mount[]`                                       | restart-required                             | host files or directories exposed inside the container                                   |
+| `plugins`               | `string[]`                                      | restart-required                             | plugin module specifiers                                                                 |
+| `alias`                 | `string[]`                                      | live                                         | additional names the agent answers to in channels                                        |
+| `channels`              | `Record<adapter, AdapterConfig>`                | live                                         | per-adapter config                                                                       |
+| `portForward`           | `{ allow, deny? }`                              | restart-required                             | auto port-forward allow/deny lists; default `{ allow: '*' }`                             |
+| `network`               | `NetworkPolicy`                                 | restart-required                             | egress filtering                                                                         |
+| `sandbox`               | `SandboxPolicy`                                 | restart-required                             | per-tool bwrap sandbox options                                                           |
+| `tunnels`               | `Tunnel[]`                                      | restart-required                             | public URLs (see [/concepts/architecture](/docs/concepts/architecture))                  |
+| `roles`                 | `Record<name, Role>`                            | `match` live, `permissions` restart-required | permission roles (see [/concepts/permissions-model](/docs/concepts/permissions-model))   |
+| `docker.file`           | `DockerFileOptions`                             | rebuild via `start`                          | Dockerfile feature toggles + append lines                                                |
+| `docker.runArgs.append` | `string[]`                                      | rebuild via `start`                          | extra `docker run` flags                                                                 |
+| `git.ignore.append`     | `string[]`                                      | rebuild via `start`                          | extra `.gitignore` lines                                                                 |
+| `updateCheck`           | `{ enabled }`                                   | host-only                                    | toggle the once-a-day "newer typeclaw available" CLI notice; default `{ enabled: true }` |
 
 Plugin-owned config blocks live at the top level under their plugin name and are validated by the plugin's own `configSchema`.
+
+The `updateCheck` notice is host-stage only — the container never reads it. Every CLI command does a cheap disk read of a cached "latest" version under `~/.typeclaw/` and prints a single line to stderr when a newer release exists; a detached, throttled (once per 24h) background process refreshes that cache off the hot path. The check never blocks or fails a command. Disable it persistently with `"updateCheck": { "enabled": false }`, or per-invocation with the `TYPECLAW_NO_UPDATE_CHECK` / `NO_UPDATE_NOTIFIER` / `CI` env vars.
 
 ## `models`
 

--- a/src/cli/builtins.ts
+++ b/src/cli/builtins.ts
@@ -27,6 +27,7 @@ export const BUILTIN_COMMAND_NAMES = [
   'usage',
   'update',
   '_hostd',
+  '_update-check',
 ] as const
 
 export type BuiltinCommandName = (typeof BUILTIN_COMMAND_NAMES)[number]

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,6 +39,7 @@ const main = defineCommand({
     usage: () => import('./usage').then((m) => m.usageCommand),
     update: () => import('./update').then((m) => m.updateCommand),
     _hostd: () => import('./hostd').then((m) => m.hostdCommand),
+    '_update-check': () => import('./update-check').then((m) => m.updateCheckCommand),
   },
 })
 
@@ -79,6 +80,16 @@ async function runWithPluginDispatch(): Promise<void> {
   const first = argv[0]
 
   runHostStartupMigrationsOnce(first)
+
+  // Disk-only read + detached background refresh; fail-open and never blocks the
+  // command. The suppression check is dependency-free and runs FIRST so a bare
+  // flag or plugin command never imports update-notify (which eagerly loads
+  // @/config). See src/cli/update-suppression.ts and src/cli/update-notify.ts.
+  const { shouldConsiderUpdateNotice } = await import('./update-suppression')
+  if (shouldConsiderUpdateNotice(first)) {
+    const { maybeNotifyUpdate } = await import('./update-notify')
+    await maybeNotifyUpdate(first)
+  }
 
   if (first === '--help' || first === '-h') {
     // citty calls process.exit() after rendering help, so anything we print

--- a/src/cli/update-check.ts
+++ b/src/cli/update-check.ts
@@ -1,0 +1,14 @@
+import { defineCommand } from 'citty'
+
+import { runBackgroundCheck } from '@/update/check'
+
+export const updateCheckCommand = defineCommand({
+  meta: {
+    name: '_update-check',
+    description: 'internal: refresh the typeclaw version cache (do not invoke directly)',
+    hidden: true,
+  },
+  async run() {
+    await runBackgroundCheck()
+  },
+})

--- a/src/cli/update-notify.test.ts
+++ b/src/cli/update-notify.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { decideUpdateAction } from './update-notify'
+import { shouldConsiderUpdateNotice } from './update-suppression'
+
+beforeEach(() => {
+  process.env.NO_COLOR = '1'
+})
+afterEach(() => {
+  delete process.env.NO_COLOR
+})
+
+describe('decideUpdateAction', () => {
+  const NOW = 1_000_000_000_000
+  const DAY = 24 * 60 * 60 * 1000
+  // Stale attempt marker so the default scenario asks for a refresh.
+  const newerStaleCache = { latest: '99.0.0', checkedAt: NOW - 2 * DAY, lastAttemptAt: NOW - 2 * DAY }
+  const enabled = {
+    current: '0.39.2',
+    isInstalled: true,
+    configEnabled: true,
+    env: {} as Record<string, string | undefined>,
+    cache: newerStaleCache,
+    now: NOW,
+  }
+
+  test('enabled + newer + stale cache: notice rendered and refresh requested', () => {
+    const action = decideUpdateAction(enabled)
+    expect(action.notice).toContain('99.0.0')
+    expect(action.refresh).toBe(true)
+  })
+
+  test('config disabled suppresses BOTH notice and refresh (review #1)', () => {
+    const action = decideUpdateAction({ ...enabled, configEnabled: false })
+    expect(action.notice).toBeNull()
+    expect(action.refresh).toBe(false)
+  })
+
+  test('env opt-out suppresses BOTH notice and refresh, even with a newer cache', () => {
+    const action = decideUpdateAction({ ...enabled, env: { TYPECLAW_NO_UPDATE_CHECK: '1' } })
+    expect(action.notice).toBeNull()
+    expect(action.refresh).toBe(false)
+  })
+
+  test('dev checkout suppresses BOTH notice and refresh', () => {
+    const action = decideUpdateAction({ ...enabled, isInstalled: false })
+    expect(action.notice).toBeNull()
+    expect(action.refresh).toBe(false)
+  })
+
+  test('enabled but no cache: no notice, refresh requested (nothing fresh to throttle on)', () => {
+    const action = decideUpdateAction({ ...enabled, cache: null })
+    expect(action.notice).toBeNull()
+    expect(action.refresh).toBe(true)
+  })
+
+  test('a fresh success cache still renders the notice but suppresses the refresh (review)', () => {
+    const action = decideUpdateAction({
+      ...enabled,
+      cache: { latest: '99.0.0', checkedAt: NOW - 1000, lastAttemptAt: NOW - 1000 },
+    })
+    expect(action.notice).toContain('99.0.0')
+    expect(action.refresh).toBe(false)
+  })
+
+  test('a fresh failure-only cache suppresses the refresh (no respawn-on-every-call, review)', () => {
+    const action = decideUpdateAction({ ...enabled, cache: { lastAttemptAt: NOW - 1000 } })
+    expect(action.notice).toBeNull()
+    expect(action.refresh).toBe(false)
+  })
+})
+
+describe('shouldConsiderUpdateNotice', () => {
+  test('considers real host builtin commands', () => {
+    expect(shouldConsiderUpdateNotice('start')).toBe(true)
+    expect(shouldConsiderUpdateNotice('tui')).toBe(true)
+    expect(shouldConsiderUpdateNotice('logs')).toBe(true)
+    expect(shouldConsiderUpdateNotice('status')).toBe(true)
+  })
+
+  test('suppresses the container stage and self-update', () => {
+    expect(shouldConsiderUpdateNotice('run')).toBe(false)
+    expect(shouldConsiderUpdateNotice('update')).toBe(false)
+  })
+
+  test('suppresses hidden internals', () => {
+    expect(shouldConsiderUpdateNotice('_hostd')).toBe(false)
+    expect(shouldConsiderUpdateNotice('_update-check')).toBe(false)
+  })
+
+  test('suppresses bare flags and empty invocations', () => {
+    expect(shouldConsiderUpdateNotice('--help')).toBe(false)
+    expect(shouldConsiderUpdateNotice('-v')).toBe(false)
+    expect(shouldConsiderUpdateNotice(undefined)).toBe(false)
+  })
+
+  test('suppresses unknown (plugin) commands', () => {
+    expect(shouldConsiderUpdateNotice('some-plugin-command')).toBe(false)
+  })
+})
+
+// End-to-end CLI behavior: the notice gate is observable only as stderr output,
+// so these run the real binary with a planted newer-version cache and assert the
+// disabled paths stay silent. This is the regression guard for review #1 — the
+// skip decision must gate the rendered notice, not just the background refresh.
+// (The positive "enabled => notice" case can't run from a source checkout: the
+// dev-checkout skip suppresses it by design; renderUpdateNotice covers that
+// path directly above.)
+describe('maybeNotifyUpdate (end-to-end notice gating)', () => {
+  const CLI_ENTRY = join(import.meta.dir, 'index.ts')
+
+  async function runStatus(home: string, env: Record<string, string>): Promise<string> {
+    const proc = Bun.spawn({
+      cmd: [process.execPath, CLI_ENTRY, 'status'],
+      env: { ...process.env, TYPECLAW_HOME: home, NO_COLOR: '1', ...env },
+      stdout: 'ignore',
+      stderr: 'pipe',
+    })
+    const stderr = await new Response(proc.stderr).text()
+    await proc.exited
+    return stderr
+  }
+
+  async function withSeededCache(fn: (home: string) => Promise<void>): Promise<void> {
+    const home = await mkdtemp(join(tmpdir(), 'typeclaw-notify-'))
+    try {
+      await writeFile(
+        join(home, 'version-cache.json'),
+        JSON.stringify({ latest: '99.0.0', checkedAt: Date.now(), lastAttemptAt: Date.now() }),
+      )
+      await fn(home)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }
+
+  test('prints nothing when TYPECLAW_NO_UPDATE_CHECK is set, even with a newer cache', async () => {
+    await withSeededCache(async (home) => {
+      const stderr = await runStatus(home, { TYPECLAW_NO_UPDATE_CHECK: '1' })
+      expect(stderr).not.toContain('Update available')
+    })
+  })
+
+  test('prints nothing in CI mode, even with a newer cache', async () => {
+    await withSeededCache(async (home) => {
+      const stderr = await runStatus(home, { CI: 'true' })
+      expect(stderr).not.toContain('Update available')
+    })
+  })
+})
+
+// Structural guard for the review fix: the env/dev/non-release skip must be able
+// to run before @/config is loaded, which is only true if this module never
+// statically imports config. A behavioral e2e can't isolate this (every real
+// builtin pulls @/config transitively), so we assert the source structure
+// directly — a regression that re-adds the eager import fails here.
+describe('update-notify module does not eagerly load @/config', () => {
+  test('no top-level @/config import', async () => {
+    const source = await readFile(join(import.meta.dir, 'update-notify.ts'), 'utf8')
+    const topLevelConfigImport = /^import\s[^\n]*from\s+['"]@\/config['"]/m
+    expect(topLevelConfigImport.test(source)).toBe(false)
+  })
+})

--- a/src/cli/update-notify.ts
+++ b/src/cli/update-notify.ts
@@ -1,0 +1,91 @@
+import { CLI_VERSION, isInstalledCli } from '@/init/cli-version'
+import {
+  isCacheFresh,
+  readVersionCache,
+  renderUpdateNotice,
+  resolveSkipReason,
+  type VersionCache,
+} from '@/update/check'
+
+import { shouldConsiderUpdateNotice, UPDATE_CHECK_COMMAND } from './update-suppression'
+
+export { shouldConsiderUpdateNotice }
+
+export type UpdateAction = { notice: string | null; refresh: boolean }
+
+// Pure decision, kept config-free (takes `configEnabled` as a param) so it is
+// unit-testable without spawning or loading config. Two invariants the reviews
+// pinned: a skipped check suppresses BOTH the notice and the refresh; and a
+// FRESH cache (success or failure-only) suppresses the refresh so the parent
+// stops forking a check child on every invocation while the throttle holds.
+export function decideUpdateAction(opts: {
+  current: string
+  isInstalled: boolean
+  configEnabled: boolean
+  env: Record<string, string | undefined>
+  cache: VersionCache | null
+  now: number
+}): UpdateAction {
+  const skip = resolveSkipReason({
+    current: opts.current,
+    isInstalled: opts.isInstalled,
+    configEnabled: opts.configEnabled,
+    env: opts.env,
+  })
+  if (skip !== null) return { notice: null, refresh: false }
+  return {
+    notice: renderUpdateNotice({ current: opts.current, cache: opts.cache }),
+    refresh: !isCacheFresh(opts.cache, opts.now),
+  }
+}
+
+// The host-stage entry hook. Fail-open: a thrown error here must never disrupt
+// the command the user actually ran, so the whole body is best-effort. Order is
+// load-bearing: the dependency-free skip (env / dev / non-release) runs BEFORE
+// @/config is ever imported, so a suppressed command (CI / opt-out) never pays
+// the eager config load that would emit malformed-typeclaw.json warnings.
+export async function maybeNotifyUpdate(commandName: string | undefined): Promise<void> {
+  try {
+    if (!shouldConsiderUpdateNotice(commandName)) return
+
+    const { resolveDependencyFreeSkip } = await import('@/update/check')
+    if (resolveDependencyFreeSkip({ current: CLI_VERSION, isInstalled: isInstalledCli(), env: process.env }) !== null) {
+      return
+    }
+
+    const { config } = await import('@/config')
+    const cache = await readVersionCache()
+    const action = decideUpdateAction({
+      current: CLI_VERSION,
+      isInstalled: isInstalledCli(),
+      configEnabled: config.updateCheck.enabled,
+      env: process.env,
+      cache,
+      now: Date.now(),
+    })
+
+    if (action.notice !== null) process.stderr.write(`${action.notice}\n`)
+    if (action.refresh) spawnBackgroundRefresh()
+  } catch {}
+}
+
+// Detached `typeclaw _update-check` child: fully unref'd so the parent process
+// exits immediately regardless of the network call's fate (the user's hard rule
+// — the command is 10000x more important than the check). stdio is ignored so
+// the child can't write into the parent's terminal.
+function spawnBackgroundRefresh(): void {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (!bun) return
+  const cliEntry = process.argv[1]
+  if (cliEntry === undefined) return
+  try {
+    const proc = bun.spawn({
+      cmd: [process.execPath, cliEntry, UPDATE_CHECK_COMMAND],
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+      env: { ...process.env },
+    })
+    proc.unref()
+  } catch {}
+}

--- a/src/cli/update-suppression.ts
+++ b/src/cli/update-suppression.ts
@@ -1,0 +1,19 @@
+import { BUILTIN_COMMAND_NAMES } from './builtins'
+
+export const UPDATE_CHECK_COMMAND = '_update-check'
+
+// Commands for which an update nudge would be noise or out of place: the
+// container stage (`run`), the hidden internals, and `update` itself (the user
+// is already updating). Bare flags are filtered separately by the `-` prefix.
+const SUPPRESSED_COMMANDS = new Set(['run', 'update', '_hostd', UPDATE_CHECK_COMMAND])
+
+// Dependency-free on purpose: index.ts calls this BEFORE importing the rest of
+// the update-notify path so a suppressed command (bare flag, plugin command,
+// `run`) never pays the eager `@/config` load that module triggers. Keep this
+// file's imports limited to the builtin-name list.
+export function shouldConsiderUpdateNotice(commandName: string | undefined): boolean {
+  if (commandName === undefined) return false
+  if (commandName.startsWith('-')) return false
+  if (SUPPRESSED_COMMANDS.has(commandName)) return false
+  return BUILTIN_COMMAND_NAMES.includes(commandName as (typeof BUILTIN_COMMAND_NAMES)[number])
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -495,6 +495,22 @@ export const composeSchema = z
 
 export type ComposeConfig = z.infer<typeof composeSchema>
 
+// Host-stage update-checker knob. `enabled: false` turns off the once-a-day
+// "a newer typeclaw is on npm" notice the host CLI prints before a command
+// runs. The container never reads this — the check is a pure host-stage
+// affordance that compares the installed CLI version against the npm registry
+// off the hot path (a detached, throttled background refresh writes a cache
+// under ~/.typeclaw/; every CLI invocation only does a disk read). Env
+// overrides (TYPECLAW_NO_UPDATE_CHECK, NO_UPDATE_NOTIFIER, CI) also disable it
+// without touching config, so this field is the persistent opt-out.
+export const updateCheckSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+  })
+  .default({ enabled: true })
+
+export type UpdateCheckConfig = z.infer<typeof updateCheckSchema>
+
 // Reverse-proxy tunnels expose a container-private port to the public internet
 // via a managed subprocess (cloudflared) or a user-supplied external URL.
 // See AGENTS.md `## Tunnels`. Keeping the enum scoped to what's implemented
@@ -735,6 +751,7 @@ export const configSchema = z
     // here, so a freshly-hatched bot already has its identity wired up.
     alias: z.array(z.string().trim().min(1)).default([]),
     compose: composeSchema,
+    updateCheck: updateCheckSchema,
     channels: channelsSchema,
     portForward: portForwardSchema,
     network: networkSchema,
@@ -951,6 +968,7 @@ export const FIELD_EFFECTS: Record<string, FieldEffect> = {
   plugins: 'restart-required',
   alias: 'applied',
   compose: 'ignored',
+  updateCheck: 'ignored',
   channels: 'applied',
   portForward: 'restart-required',
   network: 'restart-required',
@@ -1045,6 +1063,7 @@ export function extractPluginConfigs(raw: unknown): Record<string, unknown> {
     'plugins',
     'alias',
     'compose',
+    'updateCheck',
     'channels',
     'portForward',
     'network',

--- a/src/hostd/index.ts
+++ b/src/hostd/index.ts
@@ -1,6 +1,16 @@
 export { isDaemonReachable, send } from './client'
 export { startDaemon, type Daemon, type DaemonLogEvent, type DaemonOptions } from './daemon'
-export { ensureDirs, homeRoot, lockfilePath, logDir, logfilePath, pidfilePath, runDir, socketPath } from './paths'
+export {
+  ensureDirs,
+  homeRoot,
+  lockfilePath,
+  logDir,
+  logfilePath,
+  pidfilePath,
+  runDir,
+  socketPath,
+  versionCachePath,
+} from './paths'
 export type {
   ListResult,
   Request,

--- a/src/hostd/paths.ts
+++ b/src/hostd/paths.ts
@@ -75,6 +75,10 @@ export function modelsDir(): string {
   return join(homeRoot(), 'models')
 }
 
+export function versionCachePath(): string {
+  return join(homeRoot(), 'version-cache.json')
+}
+
 // Throws on any name that could traverse out of registrationsDir() or
 // confuse the filesystem. Caller's responsibility to handle the error;
 // don't catch-and-ignore — an invalid name is a protocol violation.

--- a/src/init/cli-version.ts
+++ b/src/init/cli-version.ts
@@ -23,7 +23,7 @@ export const CLI_VERSION = cliPkg.version
 
 const NODE_MODULES_SEGMENT = `${join('/', 'node_modules', '/')}`
 
-function isInstalledCli(): boolean {
+export function isInstalledCli(): boolean {
   return CLI_PACKAGE_JSON_PATH.includes(NODE_MODULES_SEGMENT)
 }
 

--- a/src/update/check.test.ts
+++ b/src/update/check.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  compareReleaseVersions,
+  isCacheFresh,
+  isReleaseVersion,
+  parseVersionCache,
+  readVersionCache,
+  renderUpdateNotice,
+  resolveSkipReason,
+  runBackgroundCheck,
+} from './check'
+
+// NO_COLOR strips ANSI from the `c.*` helpers so the rendered notice is a plain
+// assertable string across CI and local terminals.
+beforeEach(() => {
+  process.env.NO_COLOR = '1'
+})
+afterEach(() => {
+  delete process.env.NO_COLOR
+})
+
+describe('isReleaseVersion', () => {
+  test('accepts X.Y.Z', () => {
+    expect(isReleaseVersion('0.39.2')).toBe(true)
+    expect(isReleaseVersion('1.0.0')).toBe(true)
+  })
+
+  test('rejects pre-release, ranges, and dist-tags', () => {
+    expect(isReleaseVersion('0.39.2-beta.1')).toBe(false)
+    expect(isReleaseVersion('^0.39.2')).toBe(false)
+    expect(isReleaseVersion('latest')).toBe(false)
+    expect(isReleaseVersion('0.39')).toBe(false)
+  })
+})
+
+describe('compareReleaseVersions', () => {
+  test('orders by major, minor, patch', () => {
+    expect(compareReleaseVersions('1.0.0', '0.39.2')).toBeGreaterThan(0)
+    expect(compareReleaseVersions('0.40.0', '0.39.9')).toBeGreaterThan(0)
+    expect(compareReleaseVersions('0.39.3', '0.39.2')).toBeGreaterThan(0)
+    expect(compareReleaseVersions('0.39.2', '0.39.2')).toBe(0)
+    expect(compareReleaseVersions('0.39.2', '0.40.0')).toBeLessThan(0)
+  })
+
+  test('compares numerically, not lexically', () => {
+    expect(compareReleaseVersions('0.39.10', '0.39.9')).toBeGreaterThan(0)
+    expect(compareReleaseVersions('0.100.0', '0.99.0')).toBeGreaterThan(0)
+  })
+})
+
+describe('renderUpdateNotice', () => {
+  test('renders a one-line notice when latest is newer', () => {
+    const notice = renderUpdateNotice({
+      current: '0.39.2',
+      cache: { latest: '0.40.0', checkedAt: 0, lastAttemptAt: 0 },
+    })
+    expect(notice).toContain('0.39.2')
+    expect(notice).toContain('0.40.0')
+    expect(notice).toContain('typeclaw update')
+    expect(notice).not.toContain('\n')
+  })
+
+  test('returns null when up to date or ahead', () => {
+    expect(
+      renderUpdateNotice({ current: '0.40.0', cache: { latest: '0.40.0', checkedAt: 0, lastAttemptAt: 0 } }),
+    ).toBeNull()
+    expect(
+      renderUpdateNotice({ current: '0.41.0', cache: { latest: '0.40.0', checkedAt: 0, lastAttemptAt: 0 } }),
+    ).toBeNull()
+  })
+
+  test('returns null when there is no cache', () => {
+    expect(renderUpdateNotice({ current: '0.39.2', cache: null })).toBeNull()
+  })
+
+  test('returns null when the cache has only a failed attempt (no latest)', () => {
+    expect(renderUpdateNotice({ current: '0.39.2', cache: { lastAttemptAt: 123 } })).toBeNull()
+  })
+
+  test('returns null when either version is not a release', () => {
+    expect(
+      renderUpdateNotice({ current: '0.0.0-dev', cache: { latest: '0.40.0', checkedAt: 0, lastAttemptAt: 0 } }),
+    ).toBeNull()
+    expect(
+      renderUpdateNotice({ current: '0.39.2', cache: { latest: 'latest', checkedAt: 0, lastAttemptAt: 0 } }),
+    ).toBeNull()
+  })
+})
+
+describe('resolveSkipReason', () => {
+  const base = {
+    current: '0.39.2',
+    isInstalled: true,
+    configEnabled: true,
+    env: {} as Record<string, string | undefined>,
+  }
+
+  test('returns null when everything is go', () => {
+    expect(resolveSkipReason(base)).toBeNull()
+  })
+
+  test('skips on env opt-outs', () => {
+    expect(resolveSkipReason({ ...base, env: { TYPECLAW_NO_UPDATE_CHECK: '1' } })).toBe('disabled-env')
+    expect(resolveSkipReason({ ...base, env: { NO_UPDATE_NOTIFIER: 'true' } })).toBe('disabled-env')
+    expect(resolveSkipReason({ ...base, env: { CI: 'true' } })).toBe('disabled-env')
+  })
+
+  test('treats falsy env strings as not-set', () => {
+    expect(resolveSkipReason({ ...base, env: { CI: '' } })).toBeNull()
+    expect(resolveSkipReason({ ...base, env: { CI: '0' } })).toBeNull()
+    expect(resolveSkipReason({ ...base, env: { TYPECLAW_NO_UPDATE_CHECK: 'false' } })).toBeNull()
+  })
+
+  test('skips when config disabled', () => {
+    expect(resolveSkipReason({ ...base, configEnabled: false })).toBe('disabled-config')
+  })
+
+  test('skips on dev checkout', () => {
+    expect(resolveSkipReason({ ...base, isInstalled: false })).toBe('dev-checkout')
+  })
+
+  test('skips when current version is not a release', () => {
+    expect(resolveSkipReason({ ...base, current: '0.0.0-dev' })).toBe('not-release')
+  })
+
+  test('env opt-out wins over config and dev checks', () => {
+    expect(resolveSkipReason({ ...base, configEnabled: false, isInstalled: false, env: { CI: '1' } })).toBe(
+      'disabled-env',
+    )
+  })
+})
+
+describe('isCacheFresh', () => {
+  const now = 1_000_000_000_000
+  const ttl = 24 * 60 * 60 * 1000
+
+  test('fresh within the TTL, keyed on lastAttemptAt', () => {
+    expect(isCacheFresh({ latest: '0.40.0', checkedAt: now, lastAttemptAt: now - 1000 }, now)).toBe(true)
+    expect(isCacheFresh({ lastAttemptAt: now }, now)).toBe(true)
+  })
+
+  test('a recent FAILED attempt (no latest) still throttles', () => {
+    expect(isCacheFresh({ lastAttemptAt: now - 1000 }, now)).toBe(true)
+  })
+
+  test('stale at or past the TTL', () => {
+    expect(isCacheFresh({ lastAttemptAt: now - ttl }, now)).toBe(false)
+    expect(isCacheFresh({ lastAttemptAt: now - ttl - 1 }, now)).toBe(false)
+  })
+
+  test('an old attempt is stale even when latest was fetched recently (the field that matters is lastAttemptAt)', () => {
+    expect(isCacheFresh({ latest: '0.40.0', checkedAt: now, lastAttemptAt: now - ttl - 1 }, now)).toBe(false)
+  })
+
+  test('null cache is never fresh', () => {
+    expect(isCacheFresh(null, now)).toBe(false)
+  })
+
+  test('a future timestamp (clock skew) is treated as stale', () => {
+    expect(isCacheFresh({ lastAttemptAt: now + 1000 }, now)).toBe(false)
+  })
+})
+
+describe('parseVersionCache', () => {
+  test('parses a full cache with all three fields', () => {
+    expect(parseVersionCache('{"latest":"0.40.0","checkedAt":123,"lastAttemptAt":456}')).toEqual({
+      latest: '0.40.0',
+      checkedAt: 123,
+      lastAttemptAt: 456,
+    })
+  })
+
+  test('parses a failure-only cache (lastAttemptAt, no latest)', () => {
+    expect(parseVersionCache('{"lastAttemptAt":456}')).toEqual({ lastAttemptAt: 456 })
+  })
+
+  test('back-compat: a pre-throttle cache maps checkedAt into lastAttemptAt', () => {
+    expect(parseVersionCache('{"latest":"0.40.0","checkedAt":123}')).toEqual({
+      latest: '0.40.0',
+      checkedAt: 123,
+      lastAttemptAt: 123,
+    })
+  })
+
+  test('returns null on garbage or wrong shape', () => {
+    expect(parseVersionCache('not json')).toBeNull()
+    expect(parseVersionCache('null')).toBeNull()
+    expect(parseVersionCache('{"latest":"0.40.0"}')).toBeNull()
+    expect(parseVersionCache('{"checkedAt":123}')).toBeNull()
+    expect(parseVersionCache('{"latest":1,"checkedAt":123}')).toBeNull()
+    expect(parseVersionCache('[]')).toBeNull()
+  })
+})
+
+describe('runBackgroundCheck', () => {
+  let home: string
+  let prevHome: string | undefined
+  const realFetch = globalThis.fetch
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'typeclaw-update-check-'))
+    prevHome = process.env.TYPECLAW_HOME
+    process.env.TYPECLAW_HOME = home
+  })
+
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.TYPECLAW_HOME
+    else process.env.TYPECLAW_HOME = prevHome
+    globalThis.fetch = realFetch
+    await rm(home, { recursive: true, force: true })
+  })
+
+  function stubFetch(impl: () => Promise<Response> | Response): () => number {
+    let calls = 0
+    globalThis.fetch = (() => {
+      calls++
+      return impl()
+    }) as unknown as typeof fetch
+    return () => calls
+  }
+
+  test('a successful fetch writes latest + both timestamps', async () => {
+    stubFetch(() => new Response(JSON.stringify({ version: '0.40.0' }), { status: 200 }))
+    await runBackgroundCheck(1000)
+    expect(await readVersionCache()).toEqual({ latest: '0.40.0', checkedAt: 1000, lastAttemptAt: 1000 })
+  })
+
+  test('a failed fetch stamps lastAttemptAt so the throttle holds (review #3)', async () => {
+    stubFetch(() => new Response('nope', { status: 503 }))
+    await runBackgroundCheck(2000)
+    expect(await readVersionCache()).toEqual({ lastAttemptAt: 2000 })
+  })
+
+  test('a failed fetch preserves a previously-cached latest for rendering', async () => {
+    stubFetch(() => new Response(JSON.stringify({ version: '0.40.0' }), { status: 200 }))
+    await runBackgroundCheck(1000)
+
+    // A day later, npm is down: latest must survive, lastAttemptAt advances.
+    stubFetch(() => new Response('down', { status: 500 }))
+    await runBackgroundCheck(1000 + 25 * 60 * 60 * 1000)
+    expect(await readVersionCache()).toEqual({
+      latest: '0.40.0',
+      checkedAt: 1000,
+      lastAttemptAt: 1000 + 25 * 60 * 60 * 1000,
+    })
+  })
+
+  test('a fresh attempt (success or failure) short-circuits without fetching', async () => {
+    const calls = stubFetch(() => new Response('down', { status: 500 }))
+    await runBackgroundCheck(2000) // first run: one fetch, stamps lastAttemptAt=2000
+    await runBackgroundCheck(3000) // within TTL of 2000: must NOT fetch again
+    expect(calls()).toBe(1)
+  })
+})

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -1,0 +1,192 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+
+import { c } from '@/cli/ui'
+import { UPDATE_CHECK_COMMAND } from '@/cli/update-suppression'
+import { homeRoot, versionCachePath } from '@/hostd/paths'
+
+export { UPDATE_CHECK_COMMAND }
+const NPM_LATEST_URL = 'https://registry.npmjs.org/typeclaw/latest'
+const RELEASE_VERSION = /^(\d+)\.(\d+)\.(\d+)$/
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const FETCH_TIMEOUT_MS = 5_000
+
+export type VersionCache = {
+  latest?: string
+  checkedAt?: number
+  // The throttle marker, distinct from `checkedAt` (last success) on purpose: it
+  // advances on every refresh RUN, success or failure, so an npm outage can't
+  // make each CLI invocation respawn a check child until the fetch finally wins.
+  lastAttemptAt: number
+}
+
+// Returns true only for an `X.Y.Z` release version (no pre-release / build
+// metadata) — the only shape we can confidently compare and turn into a `Run:
+// typeclaw update` nudge. Anything else (dist-tags, ranges, a dev `0.0.0`) is
+// treated as "not comparable" upstream.
+export function isReleaseVersion(version: string): boolean {
+  return RELEASE_VERSION.test(version)
+}
+
+// Positive when `a` is newer than `b`, negative when older, 0 when equal.
+// Hand-rolled rather than adding the `semver` package for a three-integer
+// compare — mirrors src/init/auto-upgrade.ts. Inputs must pass isReleaseVersion.
+export function compareReleaseVersions(a: string, b: string): number {
+  const av = a.match(RELEASE_VERSION)
+  const bv = b.match(RELEASE_VERSION)
+  if (av === null || bv === null) return 0
+  for (let i = 1; i <= 3; i++) {
+    const diff = Number(av[i]) - Number(bv[i])
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+// The disk-only hot path: parse a cached "latest" version and decide whether to
+// render a one-line update notice. Pure — no I/O — so the per-invocation cost is
+// just the caller's single cache read. Returns null when there's nothing to say
+// (no cache, unparseable, not a release, or already up to date).
+export function renderUpdateNotice(opts: { current: string; cache: VersionCache | null }): string | null {
+  const { current, cache } = opts
+  if (cache?.latest === undefined) return null
+  if (!isReleaseVersion(current) || !isReleaseVersion(cache.latest)) return null
+  if (compareReleaseVersions(cache.latest, current) <= 0) return null
+  return `${c.dim('⚡ Update available:')} ${current} ${c.dim('→')} ${c.green(cache.latest)}  ${c.dim('Run:')} ${c.cyan('typeclaw update')}`
+}
+
+export type SkipReason = 'disabled-env' | 'disabled-config' | 'dev-checkout' | 'not-release'
+export type DependencyFreeSkipReason = Exclude<SkipReason, 'disabled-config'>
+
+// The skip reasons that need NO config: env opt-out, dev checkout, non-release
+// version. Split out so the caller can run these BEFORE importing @/config —
+// a suppressed command (CI / TYPECLAW_NO_UPDATE_CHECK) must not pay the eager
+// config load, which would emit malformed-typeclaw.json warnings (review).
+export function resolveDependencyFreeSkip(opts: {
+  current: string
+  isInstalled: boolean
+  env: Record<string, string | undefined>
+}): DependencyFreeSkipReason | null {
+  if (isEnvOptOut(opts.env)) return 'disabled-env'
+  if (!opts.isInstalled) return 'dev-checkout'
+  if (!isReleaseVersion(opts.current)) return 'not-release'
+  return null
+}
+
+// Full skip matrix including the config opt-out. The config check is folded in
+// last so callers that have already cleared the dependency-free reasons only
+// reach it after deciding a config read is warranted.
+export function resolveSkipReason(opts: {
+  current: string
+  isInstalled: boolean
+  configEnabled: boolean
+  env: Record<string, string | undefined>
+}): SkipReason | null {
+  const envSkip = isEnvOptOut(opts.env) ? ('disabled-env' as const) : null
+  if (envSkip !== null) return envSkip
+  if (!opts.configEnabled) return 'disabled-config'
+  if (!opts.isInstalled) return 'dev-checkout'
+  if (!isReleaseVersion(opts.current)) return 'not-release'
+  return null
+}
+
+function isEnvOptOut(env: Record<string, string | undefined>): boolean {
+  if (truthy(env.TYPECLAW_NO_UPDATE_CHECK)) return true
+  if (truthy(env.NO_UPDATE_NOTIFIER)) return true
+  if (truthy(env.CI)) return true
+  return false
+}
+
+function truthy(value: string | undefined): boolean {
+  return value !== undefined && value !== '' && value !== '0' && value.toLowerCase() !== 'false'
+}
+
+// True when the last refresh ATTEMPT is within the TTL — so a failed fetch
+// throttles re-checks just as a success does. Keyed on `lastAttemptAt`, not
+// `checkedAt`, so npm being down doesn't reopen the per-invocation respawn.
+// `now` is injectable for tests.
+export function isCacheFresh(cache: VersionCache | null, now: number): boolean {
+  if (cache === null) return false
+  const age = now - cache.lastAttemptAt
+  return age >= 0 && age < CACHE_TTL_MS
+}
+
+export async function readVersionCache(): Promise<VersionCache | null> {
+  let raw: string
+  try {
+    raw = await readFile(versionCachePath(), 'utf8')
+  } catch {
+    return null
+  }
+  return parseVersionCache(raw)
+}
+
+export function parseVersionCache(raw: string): VersionCache | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const { latest, checkedAt, lastAttemptAt } = parsed as Record<string, unknown>
+  const hasLatest = typeof latest === 'string' && typeof checkedAt === 'number'
+  // Back-compat: a pre-throttle cache has only latest+checkedAt; treat its
+  // checkedAt as the attempt marker so an upgrade doesn't reset the throttle.
+  const attempt = typeof lastAttemptAt === 'number' ? lastAttemptAt : hasLatest ? (checkedAt as number) : undefined
+  if (attempt === undefined) return null
+  const result: VersionCache = { lastAttemptAt: attempt }
+  if (hasLatest) {
+    result.latest = latest as string
+    result.checkedAt = checkedAt as number
+  }
+  return result
+}
+
+async function writeVersionCache(cache: VersionCache): Promise<void> {
+  await mkdir(homeRoot(), { recursive: true }).catch(() => {})
+  const final = versionCachePath()
+  const tmp = `${final}.${process.pid}.tmp`
+  await writeFile(tmp, JSON.stringify(cache), { mode: 0o600 })
+  await rename(tmp, final)
+}
+
+// Hits the npm registry for the published `latest` version. Returns null on any
+// failure (network, non-200, malformed body, non-release version) — the caller
+// never surfaces the error; a failed check is a silent no-op by design.
+export async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    let body: unknown
+    try {
+      const res = await fetch(NPM_LATEST_URL, { signal: controller.signal })
+      if (!res.ok) return null
+      body = await res.json()
+    } finally {
+      clearTimeout(timer)
+    }
+    const version = (body as { version?: unknown })?.version
+    if (typeof version !== 'string' || !isReleaseVersion(version)) return null
+    return version
+  } catch {
+    return null
+  }
+}
+
+// The body of the hidden `typeclaw _update-check` command: refresh the cache
+// when stale, otherwise no-op. Wrapped so any throw is swallowed — this runs in
+// a detached child whose only job is to leave a fresh cache behind, and it must
+// never crash loudly into the log.
+export async function runBackgroundCheck(now: number = Date.now()): Promise<void> {
+  try {
+    const existing = await readVersionCache()
+    if (isCacheFresh(existing, now)) return
+    const latest = await fetchLatestVersion()
+    if (latest === null) {
+      // Failure path: still stamp the attempt so the 24h throttle holds, while
+      // preserving any previously-fetched latest version for the notice.
+      await writeVersionCache({ ...existing, lastAttemptAt: now })
+      return
+    }
+    await writeVersionCache({ latest, checkedAt: now, lastAttemptAt: now })
+  } catch {}
+}


### PR DESCRIPTION
## Background

A globally-installed `typeclaw` CLI has no way to tell the user a newer release is on npm — they only find out when something breaks or they happen to re-run `bun add -g`. We want a passive "you're behind" nudge, but the operator CLI (`start`, `tui`, `logs`, `status`, …) is latency-sensitive and is the launcher for everything else. A version check that adds even a few hundred ms of network latency — or, worse, fails a command when npm is unreachable — would be a net negative. The hard requirement: **the check must never block, slow, or fail the command it rides alongside.**

## Summary

Every host CLI command now does a single **disk read** of a cached "latest" version under `~/.typeclaw/version-cache.json` and prints at most one stderr line when the installed version is behind. The network call is fully decoupled: a **detached, `unref`'d** `typeclaw _update-check` child refreshes that cache off the hot path, throttled to once per 24h, swallowing every error.

Key decisions:

- **Disk-read on the hot path, network in a detached child — not an inline `fetch().catch()`.** An inline fire-and-forget fetch keeps the event loop alive until the request settles, delaying process exit on fast commands like `stop`. A `proc.unref()`'d child (the same pattern as `hostd/spawn.ts`) lets the parent exit immediately regardless of the fetch's fate.
- **npm registry, not GHCR.** `registry.npmjs.org/typeclaw/latest` is one fast unauthenticated JSON request and is the canonical publish surface per the release flow; GHCR would need a token dance.
- **Notice to stderr, one dim line.** Never touches stdout, so `typeclaw usage | jq` and friends stay clean. Suppressed on the container stage (`run`), hidden internals, `update` itself, bare flags, and unknown plugin commands.
- **Hand-rolled three-integer version compare**, mirroring `src/init/auto-upgrade.ts`, to avoid adding the `semver` dependency for an `X.Y.Z` comparison.
- **`updateCheck` is host-stage only.** The container never reads it, so it's classified `ignored` in `FIELD_EFFECTS` (same rationale as `compose`).

## Preview

A real run with a planted cache (newer version) — notice prints to stderr, then the command's own output follows:

```
⚡ Update available: 0.39.2 → 99.0.0  Run: typeclaw update
Container  my-agent
  cwd     /path/to/agent
  image   typeclaw-my-agent
  state   missing
```

A bare flag (`--version`) prints no notice; a cold cache prints nothing and the command returns in ~40ms.

## What this does NOT do

- Does not auto-update anything — it only nudges; the user still runs `typeclaw update`.
- Does not run inside the container or affect agent runtime behavior.
- Does not block, retry, or surface errors — a failed check is a silent no-op.
- Does not check on dev checkouts, pre-release versions, or when opted out.

## Review notes

- **Load-bearing invariant:** the non-blocking guarantee. The hot path (`maybeNotifyUpdate` → `readVersionCache` → `renderUpdateNotice`) is pure + a single disk read; the only spawn is detached and `unref`'d. The whole entry hook is wrapped fail-open so a throw can never disrupt the user's command.
- **Opt-out:** persistent via `"updateCheck": { "enabled": false }`; per-invocation via `TYPECLAW_NO_UPDATE_CHECK` / `NO_UPDATE_NOTIFIER` / `CI`. The skip matrix is unit-tested in `src/update/check.test.ts` (`resolveSkipReason`).
- Pure logic (version compare, notice render, cache parse, freshness, skip reasons) is fully unit-tested without spawning or network; `shouldConsiderUpdateNotice` covers the command-suppression matrix.
- `FIELD_EFFECTS` coverage guard in `src/config/reloadable.test.ts` confirms the new `updateCheck` field is classified.