### PR TITLE
fix(channels): pin channel session while its background subagent runs

### DIFF
--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -109,6 +109,11 @@ export type ChannelManagerOptions = {
   // unregistered. See CreateChannelRouterOptions.onReload/onRestart.
   onReload?: () => Promise<string>
   onRestart?: (ctx?: RestartCommandContext) => Promise<string>
+  // Forwarded to the router so idle GC and stale-rollover can pin a channel
+  // session whose background subagent is still running (the next inbound would
+  // otherwise spawn a duplicate child). Production wiring (src/run/index.ts)
+  // supplies it from the LiveSubagentRegistry; tests omit it.
+  newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
   // Persistent messenger SDKs usually reconnect themselves, but a host sleep/offline
   // cycle can leave a socket half-dead forever. The manager watches live adapters
   // and restarts one that stays disconnected past this grace period. Test seams are
@@ -168,6 +173,9 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     ...(options.stream ? { stream: options.stream } : {}),
     ...(options.onReload ? { onReload: options.onReload } : {}),
     ...(options.onRestart ? { onRestart: options.onRestart } : {}),
+    ...(options.newestRunningChildSubagentStartedAt
+      ? { newestRunningChildSubagentStartedAt: options.newestRunningChildSubagentStartedAt }
+      : {}),
   })
   const createDiscordAdapter = options.createDiscordAdapter ?? createDiscordBotAdapter
   const createGithub = options.createGithubAdapter ?? createGithubAdapter

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -41,6 +41,7 @@ import {
   OBSERVED_MESSAGE_MAX_CHARS,
   SESSION_GRACE_HARD_TTL_MS,
   SESSION_IDLE_MS,
+  SESSION_CHILD_PIN_MAX_MS,
   sliceHeadTail,
   StaleLiveSessionError,
   stripThinkBlocks,
@@ -255,6 +256,7 @@ function makeRouter(
     onReload?: () => Promise<string>
     onRestart?: (ctx?: RestartCommandContext) => Promise<string>
     saveChannelSessions?: (agentDir: string, sessions: readonly ChannelSessionRecord[]) => Promise<void>
+    newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -270,6 +272,9 @@ function makeRouter(
     ...(options.onReload !== undefined ? { onReload: options.onReload } : {}),
     ...(options.onRestart !== undefined ? { onRestart: options.onRestart } : {}),
     ...(options.saveChannelSessions !== undefined ? { saveChannelSessions: options.saveChannelSessions } : {}),
+    ...(options.newestRunningChildSubagentStartedAt !== undefined
+      ? { newestRunningChildSubagentStartedAt: options.newestRunningChildSubagentStartedAt }
+      : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
     logger: {
@@ -852,6 +857,90 @@ describe('ChannelRouter session lifecycle', () => {
     expect(logs.some((l) => l.includes('stale-rollover'))).toBe(true)
     expect(sessions).toHaveLength(2)
     expect(sessions[0]!.disposed).toBe(1)
+  })
+
+  test('rollover does NOT fire while a background child of the session is still running', async () => {
+    // given: a session with a running background subagent that started at t=1000
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const childStartedAt = 1000
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      logs,
+      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_1' ? childStartedAt : null),
+    })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: a follow-up arrives past the freshness TTL (would normally roll over)
+    nowRef.value = 1000 + SESSION_FRESHNESS_TTL_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'still researching?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the session is pinned — no rollover, same session reused
+    expect(logs.some((l) => l.includes('stale-rollover'))).toBe(false)
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.disposed).toBe(0)
+  })
+
+  test('rollover fires anyway once the running child exceeds SESSION_CHILD_PIN_MAX_MS', async () => {
+    // given: a child that started long enough ago to exceed the pin ceiling
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const childStartedAt = 1000
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      logs,
+      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_1' ? childStartedAt : null),
+    })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: the follow-up arrives after the pin cap has elapsed
+    nowRef.value = childStartedAt + SESSION_CHILD_PIN_MAX_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'are you stuck?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: pin is overridden, rollover proceeds with the past-cap annotation
+    expect(logs.some((l) => l.includes('stale-rollover') && l.includes('past child-pin cap'))).toBe(true)
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0]!.disposed).toBe(1)
+  })
+
+  test('rollover stays pinned when the oldest child is past cap but a newer child is still within it', async () => {
+    // given: two running children — one past the cap, one fresh. The production
+    //   seam reports the NEWEST start time, so an over-cap older child must not
+    //   unpin the session while the newer child is still inside its window.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const startOfTurn = 1000
+    const runningChildStartsFor = (sessionId: string): number[] =>
+      sessionId === 'ses_fake_1'
+        ? [startOfTurn, nowRef.value - 1000] // oldest (past cap by the assertion time) + a fresh one
+        : []
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      logs,
+      newestRunningChildSubagentStartedAt: (sessionId) => {
+        const starts = runningChildStartsFor(sessionId)
+        return starts.length > 0 ? Math.max(...starts) : null
+      },
+    })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: the follow-up arrives after the OLDEST child has crossed the cap
+    nowRef.value = startOfTurn + SESSION_CHILD_PIN_MAX_MS + 1
+    await router.route(inbound({ externalMessageId: 'm2', text: 'still going?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the newer child keeps the session pinned — no rollover
+    expect(logs.some((l) => l.includes('stale-rollover'))).toBe(false)
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.disposed).toBe(0)
   })
 
   test('command path does NOT trigger rollover', async () => {
@@ -8083,6 +8172,75 @@ describe('ChannelRouter cold-start prefetch', () => {
     expect(router.liveCount()).toBe(0)
   })
 
+  test('persisted stale-rollover is deferred while the old session still has a running child', async () => {
+    // given: a stale on-disk mapping (no live session) whose old session still
+    //   has a running background child — wiping it would re-spawn that child
+    const dir = await tempDir()
+    const nowRef = { value: 1_000_000 }
+    const logs: string[] = []
+    await saveChannelSessions(dir, [
+      {
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        thread: null,
+        sessionId: 'ses_preexisting',
+        participants: [],
+        lastInboundAt: 0,
+      },
+    ])
+    const factoryCalls: SessionFactoryArgs[] = []
+    const { router } = makeRouter(dir, {
+      nowRef,
+      logs,
+      factoryCalls,
+      newestRunningChildSubagentStartedAt: (sessionId) =>
+        sessionId === 'ses_preexisting' ? nowRef.value - 1000 : null,
+    })
+
+    // when: an inbound arrives far past the freshness TTL (persisted-rollover band)
+    await router.route(inbound({ externalMessageId: 'engage', text: 'still researching?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: no persisted rollover — the same sessionId is reopened, not replaced
+    expect(logs.some((l) => l.includes('stale-rollover (persisted'))).toBe(false)
+    expect(factoryCalls[0]?.existingSessionId).toBe('ses_preexisting')
+  })
+
+  test('persisted stale-rollover fires once the old session child outlives the pin cap', async () => {
+    // given: same stale mapping, but the child started past SESSION_CHILD_PIN_MAX_MS ago
+    const dir = await tempDir()
+    const nowRef = { value: 10_000_000 }
+    const logs: string[] = []
+    await saveChannelSessions(dir, [
+      {
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        thread: null,
+        sessionId: 'ses_preexisting',
+        participants: [],
+        lastInboundAt: 0,
+      },
+    ])
+    const factoryCalls: SessionFactoryArgs[] = []
+    const { router } = makeRouter(dir, {
+      nowRef,
+      logs,
+      factoryCalls,
+      newestRunningChildSubagentStartedAt: (sessionId) =>
+        sessionId === 'ses_preexisting' ? nowRef.value - SESSION_CHILD_PIN_MAX_MS - 1 : null,
+    })
+
+    // when
+    await router.route(inbound({ externalMessageId: 'engage', text: 'are you stuck?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the past-cap override lets the persisted rollover proceed (fresh session)
+    expect(logs.some((l) => l.includes('stale-rollover (persisted') && l.includes('past child-pin cap'))).toBe(true)
+    expect(factoryCalls[0]?.existingSessionId).toBeUndefined()
+  })
+
   test('history fetch failure is non-fatal; session still processes the engaging message', async () => {
     const dir = await tempDir()
     const logs: string[] = []
@@ -8312,6 +8470,52 @@ describe('ChannelRouter idle session GC', () => {
     // cleanup so the test process can exit
     release!()
     await draining
+  })
+
+  test('does not evict a session whose background child is still running', async () => {
+    // given: an idle session that still has a running background subagent
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const childStartedAt = 1000
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_1' ? childStartedAt : null),
+    })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.liveCount()).toBe(1)
+
+    // when: time advances past the idle threshold (but within the child-pin cap)
+    nowRef.value = 1000 + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+
+    // then: the running child pins the session against eviction
+    expect(router.liveCount()).toBe(1)
+    expect(sessions[0]!.aborted).toBe(0)
+  })
+
+  test('evicts a session whose background child has outlived SESSION_CHILD_PIN_MAX_MS', async () => {
+    // given: a session whose child started long enough ago to exceed the pin cap
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const childStartedAt = 1000
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      logs,
+      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_1' ? childStartedAt : null),
+    })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: GC runs after both the idle threshold AND the pin cap have elapsed
+    nowRef.value = childStartedAt + SESSION_CHILD_PIN_MAX_MS + 1
+    await router.__testing!.runIdleGc!()
+
+    // then: the pin is overridden and the stuck session is evicted
+    expect(router.liveCount()).toBe(0)
+    expect(sessions[0]!.aborted).toBe(1)
+    expect(logs.some((l) => l.includes('idle_gc evicting') && l.includes('past child-pin cap'))).toBe(true)
   })
 
   test('next inbound after eviction creates a fresh session and rehydrates the persisted sessionId', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -381,6 +381,23 @@ export const SESSION_FRESHNESS_TTL_MS = 5 * 60 * 1000
 export const SESSION_GRACE_HARD_TTL_MS = 10 * 60 * 1000
 
 /**
+ * Absolute ceiling on how long a running background subagent may pin its parent
+ * channel session against idle GC and stale-rollover. A still-running child defers
+ * teardown because the next inbound otherwise starts a fresh session that has lost
+ * track of the in-flight task and spawns a DUPLICATE child for the same work. The
+ * pin is bounded so a stuck/never-completing child cannot make the session
+ * immortal: past this age the session is GC'd / rolled over anyway, falling back
+ * to the completion-reroute behavior. Measured from the child's start.
+ *
+ * Set above SESSION_IDLE_MS (30m) — not equal — so a child spawned at session
+ * birth still pins the session through its first idle sweep instead of the two
+ * windows coinciding. Comfortably above SESSION_GRACE_HARD_TTL_MS (10m) too:
+ * real research runs can exceed it (an observed run took 9m18s), so the 10m cap
+ * is far too tight to bound the pin.
+ */
+export const SESSION_CHILD_PIN_MAX_MS = 45 * 60 * 1000
+
+/**
  * Cost-aware grace decision for the soft→hard TTL band. Returns true when reusing
  * the (now cache-cold) live session is cheaper than a fresh cold-start.
  *
@@ -1183,6 +1200,16 @@ export type CreateChannelRouterOptions = {
   // saveChannelSessions (which swallows its own I/O errors). Tests inject a
   // throwing impl to exercise the persist-failure unwind in ensureLive.
   saveChannelSessions?: (agentDir: string, sessions: readonly ChannelSessionRecord[]) => Promise<void>
+  // Returns the start time (epoch ms) of the NEWEST still-running background
+  // subagent spawned from `sessionId`, or null when none is running. Lets idle
+  // GC and stale-rollover pin a session whose child is still working (the next
+  // inbound would otherwise spawn a duplicate child), bounded by
+  // SESSION_CHILD_PIN_MAX_MS measured from that start. Newest — not oldest — so a
+  // long-running child that crossed the cap cannot unpin the session while a more
+  // recently spawned child is still inside its own protection window. Production
+  // wiring forwards the LiveSubagentRegistry; omitted (tests, no-subagent setups)
+  // means no pin.
+  newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
 }
 
 export type RestartCommandContext = {
@@ -1239,6 +1266,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const stream = options.stream
   const onReload = options.onReload
   const onRestart = options.onRestart
+  const newestRunningChildSubagentStartedAt = options.newestRunningChildSubagentStartedAt ?? (() => null)
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
   // Restart-resume reservations, keyed by channelKeyId. Installed by
@@ -1483,11 +1511,30 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return membership
   }
 
+  // True while a background child spawned from this session is still running AND
+  // the newest such child is within SESSION_CHILD_PIN_MAX_MS of its start. Using
+  // the newest child keeps the session pinned as long as ANY running child is
+  // still inside its protection window — an older child that already crossed the
+  // cap must not unpin the session out from under a freshly spawned one. Tearing
+  // the session down mid-child lets the next inbound spawn a duplicate child, so
+  // GC/rollover defer to this. `label` only annotates the override log.
+  const isPinnedByRunningChild = (sessionId: string, keyId: string, label: string): boolean => {
+    const childStartedAt = newestRunningChildSubagentStartedAt(sessionId)
+    if (childStartedAt === null) return false
+    const pinnedForMs = now() - childStartedAt
+    if (pinnedForMs <= SESSION_CHILD_PIN_MAX_MS) return true
+    logger.info(
+      `[channels] ${keyId}: ${label} despite running child (newest pinned ${pinnedForMs}ms, past child-pin cap)`,
+    )
+    return false
+  }
+
   const shouldRolloverLive = (live: LiveSession, idleMs: number): boolean => {
     // A session mid-prompt looks idle by lastInboundAt (only bumped on engaged
     // inbounds) while session.prompt() is still in flight; rolling it over aborts
     // that work. The runIdleGc path skips draining sessions for the same reason.
     if (live.draining) return false
+    if (isPinnedByRunningChild(live.sessionId, live.keyId, 'stale-rollover')) return false
     if (idleMs <= SESSION_FRESHNESS_TTL_MS) return false
     if (idleMs > SESSION_GRACE_HARD_TTL_MS) {
       logger.info(`[channels] ${live.keyId}: stale-rollover (live: ${idleMs}ms idle, past grace cap)`)
@@ -1572,7 +1619,13 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         resumeTarget === undefined &&
         record?.sessionId !== undefined &&
         existing === undefined &&
-        now() - (record.lastInboundAt ?? 0) > SESSION_FRESHNESS_TTL_MS
+        now() - (record.lastInboundAt ?? 0) > SESSION_FRESHNESS_TTL_MS &&
+        // The live session is already gone here, but a background child it spawned
+        // may still be running under its (old) sessionId. Wiping the mapping would
+        // start a fresh session that re-spawns the same child. Keep the mapping so
+        // the reopen continues the same sessionId until the child finishes (or the
+        // pin cap elapses).
+        !isPinnedByRunningChild(record.sessionId, keyId, 'stale-rollover (persisted)')
       ) {
         const idleMs = now() - (record.lastInboundAt ?? 0)
         logger.info(`[channels] ${keyId}: stale-rollover (persisted: ${idleMs}ms idle)`)
@@ -4113,6 +4166,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       // waking the drain loop.
       if (live.pendingSystemReminders.length > 0) continue
       if (t - live.lastInboundAt <= SESSION_IDLE_MS) continue
+      if (isPinnedByRunningChild(live.sessionId, live.keyId, 'idle_gc evicting')) continue
       victims.push(live)
     }
     for (const live of victims) {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -319,6 +319,14 @@ export async function startAgent({
     claimHandler: claimController.claimHandler,
     githubTokenBridge,
     stream,
+    newestRunningChildSubagentStartedAt: (sessionId) =>
+      liveSubagentRegistry
+        .list({ parentSessionId: sessionId })
+        .reduce<number | null>(
+          (newest, child) =>
+            child.status === 'running' && (newest === null || child.startedAt > newest) ? child.startedAt : newest,
+          null,
+        ),
     onReload: async () => {
       const { results } = await reloadRegistry.reloadAll()
       return formatChannelReloadSummary(results)


### PR DESCRIPTION
## Background

A channel session could be torn down — by idle GC, live stale-rollover, or persisted stale-rollover — while a background subagent it spawned was still running. The next inbound then started a fresh session that had lost all track of the in-flight task, so the agent spawned a duplicate subagent for the same work.

Observed in production (Webex group chat): a user asked for research; the agent spawned a `researcher` background subagent; the session was rolled over on a follow-up turn (parent gone); the follow-up landed in a fresh session that re-spawned a second researcher for the identical request — a redundant multi-minute run; the original child's completion had to be "rerouted to live successor (parent gone)". Root cause: the router's teardown paths (`runIdleGc`, `shouldRolloverLive`, the persisted-mapping rollover in `ensureLive`) had no visibility into in-flight background subagents. The existing completion-reroute only preserved delivery once the child finished — it never prevented the duplicate spawn that happens before completion arrives.

## Summary

Defer session teardown across all three detach paths while the session has a running background child, via an injected predicate (`oldestRunningChildSubagentStartedAt`) wired from the existing `LiveSubagentRegistry` through the channel manager into the router.

**Why guard all three sites, not just idle GC.** The persisted stale-rollover path is the subtle one: the live session is already gone there, but the registry still holds the running child under the old `sessionId`; wiping the mapping would start a fresh session that re-spawns the child.

**Why a bounded pin (45 min) rather than an unconditional hold.** A stuck or never-completing child must not make a session immortal. Past the cap, teardown proceeds and logs the override. 45 min sits above the 30 min idle window — so a child spawned at session birth survives its first idle sweep instead of the windows coinciding — and comfortably above the 10 min grace hard cap, which a real 9m18s research run already approaches (making 10 min too tight).

**Why a predicate, not a registry dependency.** The router takes `oldestRunningChildSubagentStartedAt?: (sessionId) => number | null` rather than the concrete registry, keeping the router decoupled and the time-policy (the cap) owned by the router. Tests inject a fake.

**Why all running children, not just those flagged `background: true`.** A missing or `false` background flag should not allow the parent to tear down while a child is active.

## What this does NOT do

- Does not re-parent the running subagent to a successor session (more complex, risks corrupting ownership) — it pins the original parent instead.
- Does not change the completion-reroute fallback — that still applies once the pin cap elapses.
- Does not touch the Webex attachment-upload failure seen in the same incident; that guard lives in the upstream agent-messenger package, out of scope for this repo.

## Review notes

- **Load-bearing invariant:** `SESSION_CHILD_PIN_MAX_MS` must stay above `SESSION_IDLE_MS` (documented at the constant). Tightening it to or below the idle window reintroduces the bug for session-birth children.
- **The persisted-rollover guard** (`!isPinnedByRunningChild(record.sessionId, …)`) is the subtle one: it reads the registry under the old `sessionId` after the live session is gone.
- 6 new tests in `router.test.ts` cover all three sites and their pin-cap overrides; full suite green (9804 pass / 0 fail).