### PR TITLE
fix(channels): summarize instead of re-investigate on stranded-toolUse retry

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -35,6 +35,7 @@ import {
   SEND_RATE_WARN_THRESHOLD,
   SEND_RATE_WINDOW_MS,
   SEND_WILLINGNESS_NUDGE,
+  STRANDED_TOOLUSE_CONTINUATION_NUDGE,
   isGraceWorthReusing,
   SESSION_GC_INTERVAL_MS,
   SESSION_FRESHNESS_TTL_MS,
@@ -4931,10 +4932,12 @@ describe('ChannelRouter channel-turn protocol', () => {
         strandOnUnansweredToolUse()
         return
       }
-      // The retry nudge re-prompts the same logical turn; now the model
-      // finishes its investigation and posts the conclusion it promised, then
-      // ends cleanly (the leaf is the reply, not another stranded toolUse).
-      expect(text).toContain(EMPTY_TURN_RETRY_NUDGE)
+      // The retry re-prompts the same logical turn with the CONTINUATION nudge
+      // (summarize what you already gathered), NOT the budget-exhaustion nudge
+      // (which would invite a fresh investigation). The model then posts the
+      // conclusion it promised and ends cleanly (the leaf is the reply).
+      expect(text).toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
+      expect(text).not.toContain(EMPTY_TURN_RETRY_NUDGE)
       await router.send({
         adapter: 'discord-bot',
         workspace: 'g1',

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -261,6 +261,31 @@ export const EMPTY_TURN_RETRY_NUDGE = [
   '',
   '---',
 ].join('\n')
+// Reminder-only nudge for the stranded-toolUse-after-send retry. Distinct from
+// EMPTY_TURN_RETRY_NUDGE: that one diagnoses output-budget exhaustion and tells
+// the model to "answer directly", which makes a stranded investigation RE-RUN
+// its tools and strand again. Here the model already sent a `continue: true`
+// status ack and did real tool work; the turn just ended on an unanswered
+// toolUse before final prose. The prior toolUse/toolResult entries are still in
+// this session's branch on the re-prompt, so the recovery is to STOP, read what
+// it already gathered, and reply — not to start the investigation over.
+export const STRANDED_TOOLUSE_CONTINUATION_NUDGE = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'Your previous turn sent a brief status reply, did some tool work, then ended',
+  'before sending the answer it promised. This is an automated signal from the',
+  'channel router, not a message from anyone in the chat. **Do not acknowledge or',
+  'reply to this notice itself.**',
+  '',
+  'Do NOT start the investigation over. The tool results you already gathered are',
+  'still in this conversation above — read them, summarize what you found, and',
+  'send your reply now via your channel reply tool. Only call more tools if a',
+  'specific fact is genuinely still missing. If you truly have nothing to say,',
+  'reply with `NO_REPLY`.',
+  '',
+  '---',
+].join('\n')
 // Posted to the channel (via the `source:'system'` one-shot bypass) when an
 // empty turn cannot be recovered AND retries are exhausted (or are skipped
 // because the turn thrashed the send path). Replaces the historical silent
@@ -3748,9 +3773,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // unanswered `toolUse` (the post-tool follow-up never produced an
         // assistant message — aborted loop / cancelled stream). The promised
         // work never finished, so the user is left with a bare "checking now…"
-        // and nothing after it. Re-prompt the same logical turn so the model
-        // completes its investigation and actually replies, instead of ending
-        // in silence. On retry-exhaustion post the fallback rather than
+        // and nothing after it. Re-prompt the same logical turn with the
+        // continuation nudge so the model SUMMARIZES the tool results it already
+        // gathered (still in this branch) and replies, instead of re-running the
+        // investigation under EMPTY_TURN_RETRY_NUDGE's "answer directly" framing
+        // and stranding again. On retry-exhaustion post the fallback rather than
         // returning silently — a retry turn that re-sends a status and re-strands
         // on the same no-prose shape must not deadair the user. Any postable
         // pre-tool/mid-turn prose is suppressed here as before (it was narration
@@ -3763,7 +3790,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
               `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
                 `cause=stranded_toolUse_after_send`,
             )
-            live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
+            live.pendingSystemReminders.push(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
           } else {
             await postEmptyTurnFallback('stranded_toolUse_retries_exhausted')
           }


### PR DESCRIPTION
## Background

In the channel router, a turn that sends a `continue: true` status ack (e.g.
"I'll check now"), does tool-heavy work, then ends on an unanswered `toolUse`
before producing final prose hits the `stranded_toolUse_after_send` branch.
The recovery re-prompted the same session branch with `EMPTY_TURN_RETRY_NUDGE`.
That nudge diagnoses output-budget exhaustion and tells the model to "answer
directly" — the right framing for a length-truncated turn but exactly the wrong
framing for a stranded investigation: the model has no signal that its tool
results are still intact in the branch, so it starts the investigation over,
re-runs its tools, and strands again on the next turn end. The user sees
repeated brief status messages and then silence: dead air on every retry until
exhaustion fires `postEmptyTurnFallback`.

A production Discord channel agent hit this loop when asked to debug a flapping
status monitor. It sent a brief status reply, ran a multi-tool self-investigation,
and stranded. Each retry re-diagnosed the situation as a fresh question, re-ran
the same tools, and stranded again. The user sent multiple follow-up pings with
no substantive reply. Verified against production logs: zero `cause=overall_timeout`
or `idle_timeout` events on the stranded turns (ruling out the SSE observer
deadline as a cause — see **What this does NOT do**); the longest individual SSE
request was ~45s against a 120s deadline, and turns routinely ran 2–8 min of wall
time spanning many short SSE POSTs without tripping the observer.

## Summary

Add a new exported constant `STRANDED_TOOLUSE_CONTINUATION_NUDGE` and push it
in the `stranded_toolUse_after_send` recovery path instead of
`EMPTY_TURN_RETRY_NUDGE`.

The new nudge tells the model: the prior tool results are still in this
session's branch above — stop, read them, summarize, and reply via the reply
tool. It explicitly says "do NOT start the investigation over" and acknowledges
the `continue: true` turn shape, so the model has a correct mental model of its
own state before it produces text. If a specific fact is genuinely still
missing it may call one more tool; if it truly has nothing to say it may emit
`NO_REPLY`.

Key decisions:

- **Separate constant, not a parameter on the existing nudge.** The two recovery
  scenarios (budget-exhausted length truncation vs. stranded-after-send toolUse)
  have opposite model-state implications. A conditional string inside
  `EMPTY_TURN_RETRY_NUDGE` would make both harder to reason about and test.
- **Reasoning-loop and length-truncation paths unchanged.** Those branches still
  push `EMPTY_TURN_RETRY_NUDGE` — the "answer directly without more tools"
  framing is correct there because the model either never sent a status or was
  cut off mid-output, not stranded after real tool work.
- **Control flow is identical.** Same branch guard
  (`leafIsStrandedToolUse && currentTurnAuthorId !== null`), same
  `MAX_EMPTY_TURN_RETRIES` counter, same `pendingSystemReminders` injection
  mechanism, same exhaustion path to `postEmptyTurnFallback`. Only the reminder
  text the model sees on retry differs.
- **Token budget not raised for this branch.** The raised
  `CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS` budget applies to the
  `length`-leaf path only. A concise "here's what I found" summary fits the
  normal `CHANNEL_MAX_OUTPUT_TOKENS` cap; raising the budget here would encourage
  verbose re-investigation instead of a focused summary.

## What this does NOT do

- Does not change the retry counter, exhaustion threshold, or fallback post
  behavior — the maximum number of attempts and the dead-air fallback are
  identical to before.
- Does not change `EMPTY_TURN_RETRY_NUDGE` — reasoning-loop and
  length-truncation recovery remain on the existing prompt.
- Does not raise `CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS` for the stranded
  branch; that budget increase applies to the length-truncation path only.
- Does not address the SSE observer deadline (`DEFAULT_OVERALL_MS` in the codex
  fetch observer). Production-log analysis showed zero timeout events on the
  affected turns; raising the deadline would not prevent stranded-toolUse
  recurrences.

## Review notes

- **Load-bearing change:** `live.pendingSystemReminders.push(STRANDED_TOOLUSE_CONTINUATION_NUDGE)`
  in the `stranded_toolUse_after_send` branch of `router.ts`. Verify the guard
  condition above it (`leafIsStrandedToolUse && currentTurnAuthorId !== null`)
  is unchanged.
- **Scope guard on the test:** the stranded-toolUse continue-reply test now
  asserts `.toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)` AND
  `.not.toContain(EMPTY_TURN_RETRY_NUDGE)`. The reasoning-loop and length tests
  still assert `EMPTY_TURN_RETRY_NUDGE`, proving the two paths are mutually
  exclusive.
- **Token budget invariant:** the new nudge does not touch
  `CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS`; the budget is deliberately
  left at the normal cap for this branch. A reviewer who wonders "should we
  also raise the budget here?" — the answer is no; a concise summary is the
  intended output, not an extended re-investigation.
- Verification: `bun run typecheck` clean, `bun run lint` 0 errors (67
  pre-existing warnings unrelated to this change), `bun run format:check`
  clean, full `bun run test` green: 9865 pass / 0 fail / 1 skip across 500
  files.