### PR TITLE
fix(todo): retry atomic write rename to fix Windows concurrent-write flake

### DIFF
--- a/src/agent/todo/store.test.ts
+++ b/src/agent/todo/store.test.ts
@@ -61,6 +61,13 @@ describe('todo store', () => {
     const result = await readTodos(agentDir, TUI_SCOPE)
     expect([JSON.stringify(a), JSON.stringify(b)]).toContain(JSON.stringify(result))
   })
+
+  test('many concurrent writers all resolve and the survivor is one of them', async () => {
+    const writers = Array.from({ length: 16 }, (_, i) => [{ content: `w${i}`, status: 'pending' } satisfies Todo])
+    await Promise.all(writers.map((todos) => writeTodos(agentDir, TUI_SCOPE, todos)))
+    const result = JSON.stringify(await readTodos(agentDir, TUI_SCOPE))
+    expect(writers.map((w) => JSON.stringify(w))).toContain(result)
+  })
 })
 
 describe('readTodos validation (corrupt / hand-edited files)', () => {

--- a/src/agent/todo/store.ts
+++ b/src/agent/todo/store.ts
@@ -86,7 +86,27 @@ export async function writeTodos(agentDir: string, scope: TodoScope, todos: Todo
   await mkdir(dirname(path), { recursive: true })
   const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`
   await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
-  await rename(tmp, path)
+  await renameWithRetry(tmp, path)
+}
+
+// Windows workaround: rename() onto an existing destination is not atomic and
+// fails transiently (EPERM/EACCES/EBUSY/EEXIST) when another writer or a virus
+// scanner / file indexer momentarily holds the target open — concurrent
+// writeTodos calls onto the same scope file reliably trip this. The retry keeps
+// last-writer-wins instead of rejecting a writer. POSIX rename never hits this.
+const RENAME_RETRY_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'EEXIST'])
+
+async function renameWithRetry(from: string, to: string, attempts = 10): Promise<void> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await rename(from, to)
+      return
+    } catch (err) {
+      const code = typeof err === 'object' && err !== null ? (err as { code?: unknown }).code : undefined
+      if (attempt >= attempts || typeof code !== 'string' || !RENAME_RETRY_CODES.has(code)) throw err
+      await new Promise((resolve) => setTimeout(resolve, attempt * 10))
+    }
+  }
 }
 
 export function incompleteTodos(todos: readonly Todo[]): Todo[] {


### PR DESCRIPTION
## Background

The Windows CI job (`windows tests (informational triage)`) flaked on `todo store > concurrent writes resolve to one of the writers without corruption` ([run 28004323908](https://github.com/typeclaw/typeclaw/actions/runs/28004323908/job/82882977663)).

Root cause is platform, not test: `writeTodos` persists atomically via temp-file + `rename`. On POSIX, `rename` onto an existing path is atomic and never fails. On Windows it is **not** atomic when the destination already exists — the underlying `MoveFileEx`/`ReplaceFile` fails transiently with `EPERM`/`EACCES`/`EBUSY`/`EEXIST` whenever another writer (or an AV scanner / file indexer) momentarily holds the target open. The test fires two `writeTodos` at the same scope under `Promise.all`, so the two renames race onto the same `tui.json`; on Windows one rename loses the race, rejects, and fails the whole `Promise.all`.

## Summary

Wrap the final `rename` in a bounded retry-with-backoff (`renameWithRetry`) that retries **only** the transient Windows lock codes and rethrows everything else immediately. This preserves the existing last-writer-wins contract — no lock, no lost-update detection, which the module comment already calls out as deliberately not worth it for a todo list. POSIX renames succeed on the first attempt and never enter the retry path, so behavior there is unchanged.

Why a retry and not a lock: a scope is normally owned by a single live session; concurrent writers only happen in the rare duplicate-attach case, where last-writer-wins is already the accepted semantics. A retry is the minimal change that makes that semantics hold on Windows too.

## What this does NOT do

- Does not add locking or lost-update detection — last-writer-wins is intentional.
- Does not touch the other 16 `temp + rename` call sites; only the todo store has a test that exercises true concurrent writers onto the same destination, so it's the only one that flakes. The same helper can be lifted later if another writer grows concurrent callers.

## Review notes

- Load-bearing line: `await renameWithRetry(tmp, path)` in `writeTodos`. The retry set is exactly `{EPERM, EACCES, EBUSY, EEXIST}`; any other code (e.g. `ENOENT`, `ENOSPC`) rethrows on the first failure.
- Added a 16-writer concurrency test alongside the existing 2-writer one as a cross-platform regression guard (the survivor must be one of the writers; no corruption).
- Verified locally: `bun run typecheck`, `bun run lint` (0 errors), `bun run format`, and the full `store.test.ts` suite pass.
