### PR TITLE
ci: cache bun install + cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,23 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel superseded runs, but only for PRs. A force-push or quick follow-up
+# commit on a PR otherwise leaves the obsolete run grinding through a full
+# install + typecheck + lint + test for no reason, hogging runner minutes and
+# the concurrency queue.
+#
+# Pushes to `main` must NEVER be superseded: each post-merge run gates
+# `windows-test` and reflects the actual shipped state of main, so every
+# back-to-back merge has to run to completion. `cancel-in-progress: false`
+# alone is NOT enough — GitHub allows only one running + one PENDING run per
+# group, and a newly-queued run cancels the existing pending one regardless of
+# that flag. So the group must be UNIQUE per push run: `github.run_id` gives
+# each push its own group (nothing to collide with), while PRs keep a shared
+# per-PR group so a new commit supersedes the previous run for that same PR.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-run-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: typecheck / lint / format / test
@@ -28,6 +45,25 @@ jobs:
           # token contention; a pinned version skips that lookup and goes
           # straight to the release download URL.
           bun-version: 1.3.14
+
+      - name: Cache Bun install cache
+        # setup-bun caches only the Bun BINARY, not downloaded packages, so a
+        # cold runner re-fetches all 674 deps (~821MB) every run — the dominant
+        # cost that grew as the dependency tree did. Cache Bun's global tarball
+        # store (~/.bun/install/cache), NOT node_modules: bun hardlinks packages
+        # from that store into node_modules, so a restored node_modules would be
+        # dangling hardlinks, and platform-specific native builds (sharp,
+        # onnxruntime, @huggingface/transformers) must be linked per-runner from
+        # the tarball anyway. Key on the lockfile hash; restore-keys lets a
+        # changed lockfile reuse the prior cache for everything that didn't move.
+        # A cache hit also sidesteps the flaky api.github.com tarball fetch that
+        # the retry loop below exists for — fewer cold fetches, fewer 504s.
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.14-
 
       - name: Install dependencies
         # GitHub tarball deps (e.g. libsignal-node, pinned via @whiskeysockets/baileys)
@@ -81,8 +117,14 @@ jobs:
     # Windows runner lacks and require a separate triage (#899) first.
     # continue-on-error keeps it informational until the Windows toolchain is
     # proven stable, then it graduates to a required check.
+    # Gated to push (post-merge on main), matching windows-test: while the lane
+    # is advisory (continue-on-error), running a Windows runner on every PR
+    # spends 2x-cost minutes for a check nobody blocks on. Post-merge coverage
+    # still catches Windows toolchain regressions before a release. Drop this
+    # `if` and graduate to a required PR check once the Windows lane is stable.
     name: windows static checks (typecheck / lint / format)
     runs-on: windows-latest
+    if: github.event_name == 'push'
     continue-on-error: true
     env:
       FIREWORKS_API_KEY: dummy
@@ -94,6 +136,17 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
+
+      - name: Cache Bun install cache
+        # Same rationale as the `ci` job's cache step. The ${{ runner.os }} key
+        # prefix keeps this Windows cache separate from the Linux one — the
+        # tarball store layout differs per OS and must never cross-contaminate.
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.14-
 
       - name: Install dependencies
         # GitHub tarball deps (e.g. libsignal-node, pinned via @whiskeysockets/baileys)
@@ -146,6 +199,17 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
+
+      - name: Cache Bun install cache
+        # Same rationale as the `ci` job's cache step. The ${{ runner.os }} key
+        # prefix keeps this Windows cache separate from the Linux one — the
+        # tarball store layout differs per OS and must never cross-contaminate.
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.14-
 
       - name: Install dependencies
         # GitHub tarball deps (e.g. libsignal-node, pinned via @whiskeysockets/baileys)


### PR DESCRIPTION
## Background

CI wall time has crept up as the dependency tree grew. The `ci` job (and both Windows lanes) run a cold `bun install` on every run with **no dependency caching anywhere** — not in `actions/cache`, and `oven-sh/setup-bun` caches only the Bun *binary*, never the packages. The tree is now 674 packages / ~821MB `node_modules`, including heavy native deps (`@huggingface/transformers`, `onnxruntime`, `sharp`, `jsdom`). So every run re-downloads the full set from scratch, and that download time grows with the dependency list — the "slower and slower" symptom.

Two secondary sources of waste compound it: superseded PR pushes keep running to completion (no `concurrency` block), and the advisory `windows-static` lane burns 2x-cost Windows-runner minutes on *every* PR for a check that's `continue-on-error` and blocks nothing.

## Summary

Three changes, all confined to `.github/workflows/ci.yml`:

1. **Cache Bun's global tarball store** (`~/.bun/install/cache`) keyed on `hashFiles('bun.lock')`, in all three install jobs.
   - **Why the global store and not `node_modules`:** bun hardlinks packages from that store into `node_modules`, so a restored `node_modules` would be dangling hardlinks pointing at a store that isn't there; and platform-specific native builds must be linked per-runner from the tarball regardless. Caching the store is the correct, officially-recommended layer.
   - **Bonus:** a cache hit avoids the flaky `api.github.com` tarball fetch the existing retry loop was added for — fewer cold fetches means fewer 504s. The retry loop stays (cache miss on a lockfile change still hits that path).
   - Keys are `${{ runner.os }}`-scoped so the Windows and Linux caches never cross-contaminate.

2. **`concurrency` group that cancels superseded runs — PRs only.** `cancel-in-progress` is gated to `pull_request` events, so pushes to `main` are never cancelled (the post-merge run gates `windows-test` and reflects the actual shipped state of main).

3. **Gate `windows-static` to `push`**, matching the existing `windows-test` lane, so it stops spending Windows minutes on every PR. Post-merge coverage still catches Windows toolchain regressions before a release.

## What this does NOT do

- Does **not** touch `release.yml` or `base-image.yml`.
- Does **not** remove the `bun install` retry loop (still needed on cache miss).
- Does **not** split typecheck/lint/format into parallel jobs — with an 821MB tree, each parallel job would re-pay install/restore overhead and likely *increase* total runner minutes for a small wall-clock gain.
- Does **not** change the pinned Bun version, test flags, or any job's actual checks.

## Review notes

- Load-bearing line: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — verify `main` pushes are intentionally exempt.
- The cache `key`/`restore-keys` use a literal `1.3.14` matching the pinned `bun-version`; if that pin moves, the key prefix should move with it (called out in the inline comment).
- Cache path `~/.bun/install/cache` is correct on both ubuntu and windows runners.
- Verified locally on the branch: `bun run typecheck` (exit 0), `bun run lint` (0 errors), `bun run format:check` (clean), `bun test --parallel` (9866 pass / 0 fail).