### PR TITLE
fix(channels): record abort provenance on stranded-toolUse recovery

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -238,8 +238,9 @@ export type CreateSessionOptions = {
 }
 
 export type CreateSessionResult = {
-  session: AgentSession
+  session: AgentSession & { getAbortReason?: () => string | undefined }
   dispose: () => Promise<void>
+  getAbortReason?: () => string | undefined
 }
 
 // A session's reasoning effort layers like the model does: the resolved
@@ -309,8 +310,8 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   // Tools are wrapped BEFORE the session exists, so the loop guard reaches the
   // abort through this lazily-resolved getter. See `fireLoopAbort` in
   // plugin-tools.ts for why aborting (not throwing) is what stops the loop.
-  const abortHolder: { abort?: () => void } = {}
-  const getAbort: () => (() => void) | undefined = () => abortHolder.abort
+  const abortHolder: { abort?: (reason?: string) => void; reason?: string } = {}
+  const getAbort: () => ((reason?: string) => void) | undefined = () => abortHolder.abort
 
   // Subagent built-in tool refs are dual-routed (see BUILTIN_TOOL_DEFINITION
   // dual-map in plugin-tools.ts): pi-side coding tools go to `tools:` so they
@@ -474,6 +475,8 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     customTools,
     ...(thinkingLevel ? { thinkingLevel } : {}),
   })
+  const getAbortReason = () => abortHolder.reason
+  const sessionWithAbortReason = Object.assign(session, { getAbortReason })
 
   // Layer the replay sanitizer over pi's convertToLlm so a transcript with an
   // orphaned toolResult (e.g. a torn-down restart turn) can't wedge the session
@@ -490,7 +493,8 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     }
   }
 
-  abortHolder.abort = () => {
+  abortHolder.abort = (reason?: string) => {
+    if (reason !== undefined) abortHolder.reason = reason
     if (session.agent.signal?.aborted !== true) session.agent.abort()
   }
 
@@ -527,7 +531,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     unsubToolNudge()
     if (materializedSkills) await materializedSkills.dispose()
   }
-  return { session, dispose }
+  return { session: sessionWithAbortReason, dispose, getAbortReason }
 }
 
 // Decides whether the restart tool should write the cross-restart handoff
@@ -851,7 +855,7 @@ export function buildTodoTools(
 function wrapRegistryTools(
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
-  getAbort: () => (() => void) | undefined,
+  getAbort: () => ((reason?: string) => void) | undefined,
 ): ToolDefinition[] {
   if (!plugins) return []
   return plugins.registry.tools.map((t: PluginRegisteredTool) =>
@@ -872,7 +876,7 @@ function wrapSystemAgentTools(
   tools: AgentSessionTools | undefined,
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
-  getAbort: () => (() => void) | undefined,
+  getAbort: () => ((reason?: string) => void) | undefined,
 ): AgentSessionTools | undefined {
   if (!tools || !hasToolHooks(plugins)) return tools
   return tools.map((tool) =>
@@ -890,7 +894,7 @@ function wrapSystemTools(
   tools: ToolDefinition[],
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
-  getAbort: () => (() => void) | undefined,
+  getAbort: () => ((reason?: string) => void) | undefined,
 ): ToolDefinition[] {
   if (!hasToolHooks(plugins)) return tools
   return tools.map((tool) =>
@@ -913,7 +917,7 @@ function wrapSubagentCustomTools(
   selection: PluginSubagentSelection,
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
-  getAbort: () => (() => void) | undefined,
+  getAbort: () => ((reason?: string) => void) | undefined,
 ): ToolDefinition[] {
   if (!selection.customTools || !plugins) return []
   const logger = makePluginLogger(selection.pluginName)

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -190,7 +190,7 @@ export type WrapToolOptions = {
   // Resolves the current turn's abort handle. Resolved lazily (not at wrap
   // time) because tools are wrapped BEFORE `createAgentSession` returns the
   // session whose `agent.abort` this points at. See `fireLoopAbort`.
-  getAbort?: () => (() => void) | undefined
+  getAbort?: () => ((reason?: string) => void) | undefined
 }
 
 export type WrapSystemToolOptions = {
@@ -198,7 +198,7 @@ export type WrapSystemToolOptions = {
   sessionId: string
   hooks: HookBus
   getOrigin?: () => SessionOrigin | undefined
-  getAbort?: () => (() => void) | undefined
+  getAbort?: () => ((reason?: string) => void) | undefined
   // When present, the bash builtin is rewritten through the per-tool bwrap
   // sandbox with role-derived path masks. Absent (or no masks for the role)
   // runs bash unchanged — preserving today's behavior for trusted+ and for
@@ -262,7 +262,7 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
 
       const loopGate = gateLoopGuard(opts.sessionId, opts.toolName, before.args)
       if (loopGate.blockNow) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:block')
         return errorResult(loopGate.message)
       }
 
@@ -283,7 +283,7 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
 
       const resolved = loopGate.resolve(result)
       if ('deferredBlock' in resolved) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
         return errorResult(resolved.deferredBlock)
       }
       result = resolved.result
@@ -325,7 +325,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       }
       const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
       if (loopGate.blockNow) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:block')
         throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -345,7 +345,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx)
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
         throw new Error(resolved.deferredBlock)
       }
       const hookResult = resolved.result
@@ -385,7 +385,7 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       }
       const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
       if (loopGate.blockNow) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:block')
         throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -405,7 +405,7 @@ export function wrapSystemAgentTool<TParams extends TSchema, TDetails = unknown>
       const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate)
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
         throw new Error(resolved.deferredBlock)
       }
       const hookResult = resolved.result
@@ -460,7 +460,7 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       delete mutableArgs[TYPECLAW_INTERNAL_BASH_ENV]
       const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
       if (loopGate.blockNow) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:block')
         throw new Error(loopGate.message)
       }
       const guardResult = await runFinalWriteGuards({
@@ -511,7 +511,7 @@ export function wrapAgentToolAsCustomToolDefinition<TParams extends TSchema, TDe
       const result = tmpRedirect !== undefined ? restoreTmpPathInResult(rawResult, tmpRedirect) : rawResult
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
-        fireLoopAbort(opts.getAbort)
+        fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
         throw new Error(resolved.deferredBlock)
       }
       const hookResult = resolved.result
@@ -929,8 +929,8 @@ export function __resetSharedLoopGuardForTests(): void {
 // 'aborted'). We use the signal-only `agent.abort`, never `session.abort`,
 // which would deadlock awaiting the very run this tool call belongs to. See
 // the matching pattern in src/channels/router.ts (policy-denied send cap).
-function fireLoopAbort(getAbort: (() => (() => void) | undefined) | undefined): void {
-  getAbort?.()?.()
+function fireLoopAbort(getAbort: (() => ((reason?: string) => void) | undefined) | undefined, reason: string): void {
+  getAbort?.()?.(reason)
 }
 
 function errorResult(message: string) {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -215,6 +215,38 @@ function messageEntry(message: AssistantMessage): SessionEntry {
   }
 }
 
+function strandOnUnansweredToolUse(session: FakeSession, id: string = 'strand'): void {
+  const toolCallId = `tool-${id}`
+  const assistantEntry: SessionEntry = {
+    type: 'message',
+    id: `assistant-${id}`,
+    parentId: null,
+    timestamp: '2026-06-15T06:23:45.000Z',
+    message: {
+      ...assistantMessage(''),
+      content: [{ type: 'toolCall', id: toolCallId, name: 'stream_snapshot', arguments: { limit: 20 } }],
+      stopReason: 'toolUse',
+    },
+  }
+  const toolResultEntry: SessionEntry = {
+    type: 'message',
+    id: `tool-result-${id}`,
+    parentId: assistantEntry.id,
+    timestamp: '2026-06-15T06:23:45.500Z',
+    message: {
+      role: 'toolResult',
+      toolCallId,
+      toolName: 'stream_snapshot',
+      content: [{ type: 'text', text: 'stream events here' }],
+      isError: false,
+      timestamp: 1000,
+    },
+  }
+  session.entriesById.set(assistantEntry.id, assistantEntry)
+  session.entriesById.set(toolResultEntry.id, toolResultEntry)
+  session.leafEntry = toolResultEntry
+}
+
 const baseConfig: ChannelAdapterConfig = {
   engagement: { trigger: ['mention', 'reply', 'dm'], stickiness: { perReply: { window: 60_000 } } },
   enabled: true,
@@ -4956,6 +4988,69 @@ describe('ChannelRouter channel-turn protocol', () => {
       'cron.json은 비어 있고, 요약은 플러그인에서 와. 재시작해야 반영돼.',
     ])
     expect(logs.some((m) => m.includes('empty_turn_retry attempt=1'))).toBe(true)
+  })
+
+  test('continue-reply guard: logs policy-denied abort provenance when retrying stranded toolUse', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'check it' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      attempt++
+      if (attempt === 1) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'checking now' })
+        for (let i = 0; i < MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN; i++) {
+          await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'checking now' })
+        }
+        strandOnUnansweredToolUse(sessions[0]!, 'policy-denied')
+        return
+      }
+      expect(text).toContain(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'done' })
+      sessions[0]!.setAssistantText('done')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    const retryLog = logs.find((m) => m.includes('empty_turn_retry') && m.includes('cause=stranded_toolUse_after_send'))
+    expect(retryLog).toContain('abort_reason=policy_denied:duplicate')
+    expect(sent.map((s) => s.text)).toEqual(['checking now', 'done'])
+  })
+
+  test('continue-reply guard: logs unknown abort provenance when no internal abort fired', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'check it' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      if (attempt === 1) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'checking now' })
+        strandOnUnansweredToolUse(sessions[0]!, 'unknown-abort-reason')
+        return
+      }
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'done' })
+      sessions[0]!.setAssistantText('done')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    const retryLog = logs.find((m) => m.includes('empty_turn_retry') && m.includes('cause=stranded_toolUse_after_send'))
+    expect(retryLog).toContain('abort_reason=unknown')
+    expect(retryLog).not.toContain('policy_denied:')
+    expect(sent.map((s) => s.text)).toEqual(['checking now', 'done'])
   })
 
   test('continue-reply guard: does NOT re-prompt when the trailing toolUse carries narration and a send landed', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -554,7 +554,7 @@ export type CreateSessionForChannel = (params: {
   // `options.originRef`.
   originRef: { current: SessionOrigin | undefined }
 }) => Promise<{
-  session: AgentSession
+  session: ChannelAgentSession
   sessionId: string
   dispose: () => Promise<void>
   hooks?: HookBus
@@ -612,10 +612,12 @@ type ObservedInbound = {
 
 type TimedAttachment = { ts: number; attachment: InboundAttachment }
 
+type ChannelAgentSession = AgentSession & { getAbortReason?: () => string | undefined }
+
 type LiveSession = {
   key: ChannelKey
   keyId: string
-  session: AgentSession
+  session: ChannelAgentSession
   // The session's creation-time thinking level, captured once. A later escalated
   // turn moves `session.thinkingLevel` to `high`, so the live getter can't be the
   // reset target — this preserves the real default across the session's lifetime.
@@ -800,6 +802,10 @@ type LiveSession = {
   // turn can never trigger a nudge on a later one. `null` when no such reply
   // ended this turn.
   lastTerminalReplyAbort: { turnSeq: number; text: string } | null
+  // Stamped by router abort sites and read by `validateChannelTurn` for
+  // reason-specific stranded-toolUse recovery logs. `turnSeq`-stamped so stale
+  // abort provenance from an earlier turn can never leak into a later retry.
+  abortReasonThisTurn: { turnSeq: number; reason: string } | null
   // One-shot output-token budget for the NEXT `session.prompt()` only.
   // `installChannelOutputCap` reads and clears it per stream call, so it
   // overrides the default backstop for exactly one re-prompt. Set by the
@@ -1831,6 +1837,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         emptyTurnRetries: 0,
         willingnessNudges: 0,
         lastTerminalReplyAbort: null,
+        abortReasonThisTurn: null,
         nextPromptMaxTokens: undefined,
         skippedTurn: null,
         skipLockedSendTurn: null,
@@ -2182,6 +2189,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         logger.info(`[channels] ${live.keyId} terminal_after_channel_reply`)
         const replyText = (context.toolCall.arguments as { text?: unknown } | undefined)?.text
         live.lastTerminalReplyAbort = typeof replyText === 'string' ? { turnSeq: live.turnSeq, text: replyText } : null
+        live.abortReasonThisTurn = { turnSeq: live.turnSeq, reason: 'terminal_after_channel_reply' }
         agent.abort()
       }
       return result
@@ -2483,6 +2491,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // forever (and the raised cap stays scoped to the turn that set it).
           live.emptyTurnRetries = 0
           live.willingnessNudges = 0
+          live.abortReasonThisTurn = null
           live.nextPromptMaxTokens = undefined
         } else if (live.lastTurnAuthorId !== null) {
           live.currentTurnEngageReactions = []
@@ -3519,6 +3528,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.policyDeniedToolSendsThisTurn.set(sendKey, count)
         if (count >= MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN) {
           logger.warn(`[channels] ${live.keyId}: aborting turn — ${count} policy-denied channel sends (last: ${code})`)
+          live.abortReasonThisTurn = { turnSeq: live.turnSeq, reason: `policy_denied:${code}` }
           if (live.session.agent.signal?.aborted !== true) live.session.agent.abort()
         }
         return { ok: false, error, code }
@@ -3786,9 +3796,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         if (leafIsStrandedToolUse(live.session) && live.currentTurnAuthorId !== null) {
           if (live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
             live.emptyTurnRetries++
+            const routerAbortReason =
+              live.abortReasonThisTurn !== null && live.abortReasonThisTurn.turnSeq === live.turnSeq
+                ? live.abortReasonThisTurn.reason
+                : undefined
+            const agentAbortReason =
+              live.session.agent.signal?.aborted === true ? live.session.getAbortReason?.() : undefined
+            const abortReason = routerAbortReason ?? agentAbortReason ?? 'unknown'
             logger.warn(
               `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
-                `cause=stranded_toolUse_after_send`,
+                `cause=stranded_toolUse_after_send abort_reason=${abortReason}`,
             )
             live.pendingSystemReminders.push(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
           } else {


### PR DESCRIPTION
## Background

Production transcript analysis showed turns ending with all tool results collected but no final assistant message, roughly 20ms before the next turn, with no logged abort cause. Reconciling code and transcripts established that the strand is the structural consequence of typeclaw's intentional safety aborts severing the loop between tool-result collection and the follow-up model call.

Three abort paths can strand a turn: the loop-guard block (fires when `fireLoopAbort` decides the current iteration is unsafe to continue), the policy-denied-send cap (`MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN`), and the terminal-reply hook. When any of them calls `agent.abort()` mid-turn, the aborted follow-up stream never persists an assistant message, so the router sees a stranded toolUse and triggers the `stranded_toolUse_after_send` recovery path (merged in #1027). That recovery was blind to why the turn aborted — every strand logged the same `cause=stranded_toolUse_after_send` with no indication of which safety gate had fired.

The fix is not to re-scope or reorder the aborts, but to make each one leave labeled provenance so recovery (and operators reading logs) know the cause. This PR is that provenance layer; it pairs with #1027 as the "recover + explain" defense-in-depth.

Note on the SSE deadline hypothesis: production logs showed zero `cause=overall_timeout` or `idle_timeout` events on the stranded turns, and the longest individual SSE request ran ~45s against a 120s deadline, with turns spanning many short SSE POSTs without tripping the observer. The codex fetch observer was ruled out as a cause and is untouched here.

## Summary

Thread an optional reason string through the three abort paths and surface it to the router's recovery, logging it on the stranded-toolUse retry line as `abort_reason=<reason>`. Three layers of wiring:

**agent (`src/agent/index.ts`):** `abortHolder.abort` now accepts an optional `reason` string and stashes it in a field the session exposes via `getAbortReason()`. An unlabeled abort (called without a reason) never clobbers a previously recorded reason, so the last meaningful cause survives even if a secondary abort fires without context.

**plugin-tools (`src/agent/plugin-tools.ts`):** `fireLoopAbort` forwards a reason string to the abort; all 8 loop-guard call sites across the four wrapper types (`wrapPluginTool`, `wrapSystemTool`, `wrapSystemAgentTool`, `wrapAgentToolAsCustomToolDefinition`) are tagged `loop_guard:block` (immediate abort) or `loop_guard:deferred_block` (post-result abort). The `getAbort` callback type in the wrapper signatures is widened from `() => void` to `(reason?: string) => void`.

**router (`src/channels/router.ts`):** A turnSeq-stamped `abortReasonThisTurn` field captures the policy-denied (`policy_denied:<code>`) and terminal-reply (`terminal_after_channel_reply`) aborts at their existing abort sites. `validateChannelTurn` resolves provenance in priority order — router-stamped (turnSeq-matched) first, then agent-layer `getAbortReason()` (loop-guard), falling back to `unknown` — and appends `abort_reason=<reason>` to the existing `empty_turn_retry ... cause=stranded_toolUse_after_send` log line.

## What this does NOT do

- Does not remove, weaken, or re-scope any safety abort — the loop-guard, policy-denied cap, and terminal-reply hook fire exactly as before on the same conditions.
- Does not change the recovery nudge text (`STRANDED_TOOLUSE_CONTINUATION_NUDGE` is unchanged); a reason-specific nudge variant is a possible follow-up, deliberately out of scope.
- Does not touch the codex SSE deadline or `codex-fetch-observer.ts`; that was ruled out as the cause of the observed strands.
- Does not patch any external package; provenance lives entirely in typeclaw's own hooks and wiring.

## Review notes

- **Stale-provenance safety:** the agent-layer abort reason is only consulted when `agent.signal.aborted === true`, and `abortReasonThisTurn` is turnSeq-gated and reset to `null` at each fresh user turn alongside the other per-turn state. Provenance from an earlier turn cannot leak into a later retry.
- **8 loop-guard sites:** every wrapper variant tags its immediate-block as `loop_guard:block` and its post-result-block as `loop_guard:deferred_block`. Grepping for `fireLoopAbort` confirms all sites.
- **Two new router tests:** (1) drives `MAX_POLICY_DENIED_CHANNEL_SENDS_PER_TURN` denied sends end-to-end to trigger the real abort and stamp, strands a toolUse, asserts the retry log contains `abort_reason=policy_denied:duplicate`; (2) a strand with no internal abort asserts `abort_reason=unknown` and not `abort_reason=policy_denied:`.
- Verification: `bun run typecheck` clean, `bun run lint` 0 errors (67 pre-existing warnings unrelated to this change), `bun run format:check` clean, full `bun run test` green: 9868 pass / 0 fail / 1 skip across 500 files.