### PR TITLE
feat(channels): wire non-bot Slack (user account) channel

### DIFF
--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -143,6 +143,7 @@ type PlatformInfo = {
 }
 
 const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
+  slack: { displayName: 'Slack', mentionMode: 'angle-id', supportsReactions: true, supportsAttachments: true },
   'slack-bot': { displayName: 'Slack', mentionMode: 'angle-id', supportsReactions: true, supportsAttachments: true },
   'discord-bot': {
     displayName: 'Discord',

--- a/src/channels/adapters/slack-author-resolver.ts
+++ b/src/channels/adapters/slack-author-resolver.ts
@@ -1,0 +1,54 @@
+import type { SlackClient, SlackUser } from 'agent-messenger/slack'
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000
+
+export type SlackAuthorResolverOptions = {
+  client: Pick<SlackClient, 'getUser'>
+  now?: () => number
+  ttlMs?: number
+}
+
+export type SlackAuthorResolver = {
+  resolve: (userId: string) => Promise<string>
+}
+
+type CacheEntry = { name: string; expiresAt: number }
+
+export function createSlackAuthorResolver(options: SlackAuthorResolverOptions): SlackAuthorResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const cache = new Map<string, CacheEntry>()
+  const inflight = new Map<string, Promise<string>>()
+
+  const resolve = async (userId: string): Promise<string> => {
+    const cached = cache.get(userId)
+    if (cached && cached.expiresAt > now()) return cached.name
+    const existing = inflight.get(userId)
+    if (existing) return existing
+    const promise = options.client
+      .getUser(userId)
+      .then((user) => pickDisplayName(user) ?? userId)
+      .catch(() => userId)
+      .then((name) => {
+        if (name !== userId) cache.set(userId, { name, expiresAt: now() + ttlMs })
+        return name
+      })
+      .finally(() => {
+        inflight.delete(userId)
+      })
+    inflight.set(userId, promise)
+    return promise
+  }
+
+  return { resolve }
+}
+
+// Identity fields only. `profile.status_text` is presence text ("In a meeting"),
+// not a name, so it must never stand in for the author's display name.
+function pickDisplayName(user: SlackUser): string | null {
+  const candidates = [user.real_name, user.name]
+  for (const c of candidates) {
+    if (typeof c === 'string' && c !== '') return c
+  }
+  return null
+}

--- a/src/channels/adapters/slack-channel-resolver.ts
+++ b/src/channels/adapters/slack-channel-resolver.ts
@@ -1,0 +1,49 @@
+import type { SlackClient } from 'agent-messenger/slack'
+
+import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+
+export type SlackChannelResolverOptions = {
+  client: Pick<SlackClient, 'getChannel'>
+  teamNameRef?: () => string | null
+  now?: () => number
+  ttlMs?: number
+}
+
+type CacheEntry<T> = { value: T; expiresAt: number }
+
+export function createSlackChannelResolver(options: SlackChannelResolverOptions): ChannelNameResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const chatCache = new Map<string, CacheEntry<string>>()
+
+  const fetchCached = async <T>(
+    cache: Map<string, CacheEntry<T>>,
+    key: string,
+    fetcher: () => Promise<T | null>,
+  ): Promise<T | null> => {
+    const cached = cache.get(key)
+    if (cached && cached.expiresAt > now()) return cached.value
+    const value = await fetcher()
+    if (value !== null) cache.set(key, { value, expiresAt: now() + ttlMs })
+    return value
+  }
+
+  return async (key: ChannelKey): Promise<ResolvedChannelNames> => {
+    if (key.workspace === '@dm') return {}
+    const chatName = await fetchCached(chatCache, key.chat, async () => {
+      try {
+        const channel = await options.client.getChannel(key.chat)
+        return channel.name || null
+      } catch {
+        return null
+      }
+    })
+    const workspaceName = options.teamNameRef?.() ?? null
+    const result: ResolvedChannelNames = {}
+    if (chatName !== null) result.chatName = chatName
+    if (workspaceName !== null) result.workspaceName = workspaceName
+    return result
+  }
+}

--- a/src/channels/adapters/slack-classify.test.ts
+++ b/src/channels/adapters/slack-classify.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { SlackRTMMessageEvent } from 'agent-messenger/slack'
+
+import { channelsSchema } from '@/channels/schema'
+
+import { classifyInbound } from './slack-classify'
+
+const config = channelsSchema.parse({ slack: {} }).slack!
+const context = { teamId: 'T0123456789', selfUserId: 'USELF', selfAliases: ['typeclaw'] }
+
+function event(overrides: Partial<SlackRTMMessageEvent> = {}): SlackRTMMessageEvent {
+  return {
+    type: 'message',
+    channel: 'C0123456789',
+    user: 'UUSER',
+    text: 'hello',
+    ts: '1770000000.000100',
+    ...overrides,
+  }
+}
+
+describe('classifyInbound (slack user)', () => {
+  test('drops unrouteable RTM messages', () => {
+    expect(classifyInbound(event({ user: 'USELF' }), config, context)).toEqual({ kind: 'drop', reason: 'self_author' })
+    expect(classifyInbound(event({ user: undefined }), config, context)).toEqual({ kind: 'drop', reason: 'no_user' })
+    expect(classifyInbound(event({ subtype: 'message_changed' }), config, context)).toEqual({
+      kind: 'drop',
+      reason: 'slack_system_message',
+    })
+    expect(classifyInbound(event({ text: '' }), config, context)).toEqual({ kind: 'drop', reason: 'empty_text' })
+    expect(classifyInbound(event(), config, { ...context, selfUserId: null })).toEqual({
+      kind: 'drop',
+      reason: 'pre_connect',
+    })
+  })
+
+  test('routes DMs with @dm workspace and no thread', () => {
+    const verdict = classifyInbound(event({ channel: 'D0123456789' }), config, context)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.workspace).toBe('@dm')
+    expect(verdict.payload.isDm).toBe(true)
+    expect(verdict.payload.thread).toBeNull()
+  })
+
+  test('detects self mentions, group mentions, and other mentions', () => {
+    const selfMention = classifyInbound(event({ text: 'hello <@USELF>' }), config, context)
+    const groupMention = classifyInbound(event({ text: '<!channel> deploy?' }), config, context)
+    const otherMention = classifyInbound(event({ text: 'ask <@UOTHER>' }), config, context)
+
+    expect(selfMention.kind === 'route' && selfMention.payload.isBotMention).toBe(true)
+    expect(groupMention.kind === 'route' && groupMention.payload.isBotMention).toBe(true)
+    expect(otherMention.kind === 'route' && otherMention.payload.mentionsOthers).toBe(true)
+  })
+
+  test('anchors English and Korean alias-addressed channel messages', () => {
+    const english = classifyInbound(event({ text: 'typeclaw please check this' }), config, context)
+    const korean = classifyInbound(event({ text: 'typeclaw 확인해 주세요' }), config, context)
+
+    expect(english.kind === 'route' && english.payload.thread).toBe('1770000000.000100')
+    expect(korean.kind === 'route' && korean.payload.thread).toBe('1770000000.000100')
+  })
+})

--- a/src/channels/adapters/slack-classify.ts
+++ b/src/channels/adapters/slack-classify.ts
@@ -1,0 +1,83 @@
+import type { SlackRTMMessageEvent } from 'agent-messenger/slack'
+
+import { matchesAnyAlias } from '@/channels/engagement'
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type { InboundMessage } from '@/channels/types'
+
+import { slackTsToMillis } from './slack-bot-time'
+import { encodeSlackReactionRef } from './slack-reactions'
+
+export type SlackInboundMessageEvent = SlackRTMMessageEvent
+
+export type InboundDropReason = 'self_author' | 'no_user' | 'slack_system_message' | 'empty_text' | 'pre_connect'
+
+export type InboundClassification =
+  | { kind: 'drop'; reason: InboundDropReason }
+  | { kind: 'route'; payload: InboundMessage }
+
+export type SlackInboundContext = {
+  teamId: string
+  selfUserId: string | null
+  selfAliases?: readonly string[]
+}
+
+export function classifyInbound(
+  event: SlackInboundMessageEvent,
+  _config: ChannelAdapterConfig,
+  context: SlackInboundContext,
+): InboundClassification {
+  if (context.selfUserId !== null && event.user === context.selfUserId) return { kind: 'drop', reason: 'self_author' }
+  if (event.user === undefined || event.user === '') return { kind: 'drop', reason: 'no_user' }
+  if (!isRouteableSlackMessageSubtype(event.subtype)) return { kind: 'drop', reason: 'slack_system_message' }
+  if ((event.text ?? '') === '') return { kind: 'drop', reason: 'empty_text' }
+  if (context.selfUserId === null) return { kind: 'drop', reason: 'pre_connect' }
+
+  const rawText = event.text ?? ''
+  const isDm = event.channel.startsWith('D')
+  const workspace = isDm ? '@dm' : context.teamId
+  const hasGroupMention = GROUP_MENTION_PATTERN.test(rawText)
+  const isBotMention = hasGroupMention || rawText.includes(`<@${context.selfUserId}>`)
+  const aliasMatched = !isBotMention && matchesAnyAlias(rawText, context.selfAliases ?? [])
+  const thread = event.thread_ts ?? (!isDm && (isBotMention || aliasMatched) ? event.ts : null)
+  const mentionedUserIds = extractMentionedUserIds(rawText)
+  const mentionsOthers = mentionedUserIds.length > 0 && !mentionedUserIds.includes(context.selfUserId)
+
+  return {
+    kind: 'route',
+    payload: {
+      adapter: 'slack',
+      workspace,
+      chat: event.channel,
+      thread,
+      text: rawText,
+      externalMessageId: event.ts,
+      reactionRef: encodeSlackReactionRef({ channel: event.channel, ts: event.ts }),
+      authorId: event.user,
+      authorName: event.user,
+      authorIsBot: false,
+      isBotMention,
+      // RTM user-session replies do not include parent_user_id; a pure classifier
+      // cannot prove parent authorship without an async Slack lookup.
+      replyToBotMessageId: null,
+      mentionsOthers,
+      replyToOtherMessageId: null,
+      isDm,
+      ts: slackTsToMillis(event.ts),
+    },
+  }
+}
+
+export function isRouteableSlackMessageSubtype(subtype: string | undefined): boolean {
+  return subtype === undefined || subtype === 'me_message'
+}
+
+const MENTION_PATTERN = /<@([UW][A-Z0-9]+)(?:\|[^>]*)?>/g
+const GROUP_MENTION_PATTERN = /<!(?:here|channel|everyone)(?:\|[^>]*)?>/
+
+function extractMentionedUserIds(text: string): string[] {
+  const seen = new Set<string>()
+  for (const match of text.matchAll(MENTION_PATTERN)) {
+    seen.add(match[1]!)
+  }
+  return Array.from(seen)
+}

--- a/src/channels/adapters/slack-reactions.ts
+++ b/src/channels/adapters/slack-reactions.ts
@@ -1,0 +1,126 @@
+import type { SlackClient } from 'agent-messenger/slack'
+
+import type {
+  ReactionCallback,
+  ReactionErrorCode,
+  ReactionRef,
+  ReactionResult,
+  RemoveReactionCallback,
+} from '@/channels/types'
+
+export type SlackReactionTarget = { channel: string; ts: string }
+export type SlackReactionRemovalTarget = { channel: string; ts: string; emoji: string }
+
+export function encodeSlackReactionRef(target: SlackReactionTarget): ReactionRef {
+  return { adapter: 'slack', value: JSON.stringify(target) }
+}
+
+export function decodeSlackReactionRef(ref: ReactionRef): SlackReactionTarget | null {
+  if (ref.adapter !== 'slack') return null
+  const parsed = parseRecord(ref.value)
+  if (parsed === null || parsed.op !== undefined) return null
+  const channel = typeof parsed.channel === 'string' ? parsed.channel : null
+  const ts = typeof parsed.ts === 'string' ? parsed.ts : null
+  if (channel === null || ts === null) return null
+  return { channel, ts }
+}
+
+export function encodeSlackRemovalRef(target: SlackReactionRemovalTarget): ReactionRef {
+  return { adapter: 'slack', value: JSON.stringify({ op: 'remove', ...target }) }
+}
+
+export function decodeSlackRemovalRef(ref: ReactionRef): SlackReactionRemovalTarget | null {
+  if (ref.adapter !== 'slack') return null
+  const parsed = parseRecord(ref.value)
+  if (parsed === null || parsed.op !== 'remove') return null
+  const channel = typeof parsed.channel === 'string' ? parsed.channel : null
+  const ts = typeof parsed.ts === 'string' ? parsed.ts : null
+  const emoji = typeof parsed.emoji === 'string' ? parsed.emoji : null
+  if (channel === null || ts === null || emoji === null) return null
+  return { channel, ts, emoji }
+}
+
+export function createSlackReactionCallback(deps: { client: Pick<SlackClient, 'addReaction'> }): ReactionCallback {
+  return async (req): Promise<ReactionResult> => {
+    if (req.adapter !== 'slack') return { ok: false, error: `unknown adapter: ${req.adapter}`, code: 'unsupported' }
+    const target = decodeSlackReactionRef(req.reactionRef)
+    if (target === null) return { ok: false, error: 'unparseable slack reaction ref', code: 'unsupported' }
+    const emoji = normalizeEmoji(req.emoji)
+    try {
+      await deps.client.addReaction(target.channel, target.ts, emoji)
+    } catch (err) {
+      const code = slackErrorCode(err)
+      if (code === 'already_reacted') return { ok: true, reactionRef: encodeSlackRemovalRef({ ...target, emoji }) }
+      return { ok: false, error: describe(err), code: classifySlackError(code) }
+    }
+    return { ok: true, reactionRef: encodeSlackRemovalRef({ ...target, emoji }) }
+  }
+}
+
+export function createSlackRemoveReactionCallback(deps: {
+  client: Pick<SlackClient, 'removeReaction'>
+}): RemoveReactionCallback {
+  return async (req): Promise<ReactionResult> => {
+    if (req.adapter !== 'slack') return { ok: false, error: `unknown adapter: ${req.adapter}`, code: 'unsupported' }
+    const target = decodeSlackRemovalRef(req.reactionRef)
+    if (target === null) return { ok: false, error: 'unparseable slack reaction removal ref', code: 'unsupported' }
+    try {
+      await deps.client.removeReaction(target.channel, target.ts, target.emoji)
+    } catch (err) {
+      const code = slackErrorCode(err)
+      if (code === 'no_reaction') return { ok: true }
+      return { ok: false, error: describe(err), code: classifySlackError(code) }
+    }
+    return { ok: true }
+  }
+}
+
+function normalizeEmoji(emoji: string): string {
+  return emoji.replace(/^:|:$/g, '')
+}
+
+function slackErrorCode(err: unknown): string | null {
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    const code = (err as { code: unknown }).code
+    if (typeof code === 'string') return code
+  }
+  return null
+}
+
+function classifySlackError(code: string | null): ReactionErrorCode {
+  switch (code) {
+    case 'invalid_name':
+    case 'no_item_specified':
+      return 'unsupported'
+    case 'missing_scope':
+    case 'not_in_channel':
+    case 'is_archived':
+    case 'not_authed':
+    case 'invalid_auth':
+      return 'permission-denied'
+    case 'message_not_found':
+    case 'channel_not_found':
+      return 'not-found'
+    case 'ratelimited':
+    case 'rate_limited':
+      return 'rate-limited'
+    default:
+      return 'transient'
+  }
+}
+
+function parseRecord(value: string): Record<string, unknown> | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return null
+  }
+  return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/slack.test.ts
+++ b/src/channels/adapters/slack.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { SlackListener, SlackRTMMessageEvent } from 'agent-messenger/slack'
+
+import type { ChannelRouter } from '@/channels/router'
+import { channelsSchema } from '@/channels/schema'
+import type { InboundMessage, OutboundCallback } from '@/channels/types'
+import type { SlackAccountRecord } from '@/secrets/schema'
+
+import { createSlackAdapter, type SlackAdapterLogger } from './slack'
+
+const config = channelsSchema.parse({ slack: {} }).slack!
+
+function logger(): SlackAdapterLogger & { lines: string[] } {
+  const lines: string[] = []
+  return {
+    lines,
+    info: (msg) => lines.push(`info:${msg}`),
+    warn: (msg) => lines.push(`warn:${msg}`),
+    error: (msg) => lines.push(`error:${msg}`),
+  }
+}
+
+function account(overrides: Partial<SlackAccountRecord> = {}): SlackAccountRecord {
+  return {
+    account_id: 'T0123456789',
+    token: 'xoxc-test',
+    cookie: 'xoxd-test',
+    workspace_id: 'T0123456789',
+    workspace_name: 'Acme',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+class FakeListener {
+  private handlers = new Map<string, Array<(value: unknown) => void>>()
+  stopped = false
+  failStart = false
+
+  on(event: string, handler: (value: unknown) => void): void {
+    this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler])
+  }
+
+  async start(): Promise<void> {
+    if (this.failStart) throw new Error('boom')
+    this.emit('connected', { self: { id: 'USELF' }, team: { id: 'T0123456789' } })
+  }
+
+  stop(): void {
+    this.stopped = true
+  }
+
+  emit(event: string, value: unknown): void {
+    for (const handler of this.handlers.get(event) ?? []) handler(value)
+  }
+}
+
+function router(): ChannelRouter & {
+  routed: InboundMessage[]
+  registered: string[]
+  unregistered: string[]
+  outbound?: OutboundCallback
+} {
+  const routed: InboundMessage[] = []
+  const registered: string[] = []
+  const unregistered: string[] = []
+  const r = {
+    outbound: undefined as OutboundCallback | undefined,
+    routed,
+    registered,
+    unregistered,
+    route: async (msg: InboundMessage) => {
+      routed.push(msg)
+    },
+    registerOutbound: (adapter: string, cb: OutboundCallback) => {
+      registered.push(`outbound:${adapter}`)
+      r.outbound = cb
+    },
+    unregisterOutbound: (adapter: string) => unregistered.push(`outbound:${adapter}`),
+    setTypingCapability: (adapter: string, supported: boolean) =>
+      registered.push(`typing-cap:${adapter}=${String(supported)}`),
+    registerChannelNameResolver: (adapter: string) => registered.push(`names:${adapter}`),
+    unregisterChannelNameResolver: (adapter: string) => unregistered.push(`names:${adapter}`),
+    registerSelfIdentity: (adapter: string) => registered.push(`self:${adapter}`),
+    unregisterSelfIdentity: (adapter: string) => unregistered.push(`self:${adapter}`),
+    registerHistory: (adapter: string) => registered.push(`history:${adapter}`),
+    unregisterHistory: (adapter: string) => unregistered.push(`history:${adapter}`),
+    registerFetchAttachment: (adapter: string) => registered.push(`fetch:${adapter}`),
+    unregisterFetchAttachment: (adapter: string) => unregistered.push(`fetch:${adapter}`),
+    registerMembership: (adapter: string) => registered.push(`membership:${adapter}`),
+    unregisterMembership: (adapter: string) => unregistered.push(`membership:${adapter}`),
+    registerReaction: (adapter: string) => registered.push(`reaction:${adapter}`),
+    unregisterReaction: (adapter: string) => unregistered.push(`reaction:${adapter}`),
+    registerRemoveReaction: (adapter: string) => registered.push(`remove-reaction:${adapter}`),
+    unregisterRemoveReaction: (adapter: string) => unregistered.push(`remove-reaction:${adapter}`),
+  }
+  return r as unknown as ChannelRouter & {
+    routed: InboundMessage[]
+    registered: string[]
+    unregistered: string[]
+    outbound?: OutboundCallback
+  }
+}
+
+describe('createSlackAdapter', () => {
+  test('start logs in and wires listener/router callbacks with typing disabled', async () => {
+    const calls: unknown[] = []
+    const r = router()
+    const adapter = createSlackAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        ({
+          login: async (opts: unknown) => calls.push(opts),
+          testAuth: async () => ({ user_id: 'USELF', team_id: 'T0123456789', user: 'alice', team: 'Acme' }),
+          getChannel: async () => ({ id: 'C0123456789', name: 'general' }),
+          getUser: async () => ({ id: 'UUSER', name: 'alice', real_name: 'Alice' }),
+          getMessages: async () => [],
+          listChannelMembers: async () => [],
+          sendMessage: async () => ({ ts: '1', text: 'ok', type: 'message' }),
+          uploadFile: async () => ({
+            id: 'F1',
+            name: 'a.txt',
+            title: 'a.txt',
+            mimetype: 'text/plain',
+            size: 1,
+            url_private: '',
+            created: 1,
+            user: 'USELF',
+          }),
+          downloadFile: async () => ({
+            buffer: Buffer.from('x'),
+            file: {
+              id: 'F1',
+              name: 'a.txt',
+              title: 'a.txt',
+              mimetype: 'text/plain',
+              size: 1,
+              url_private: '',
+              created: 1,
+              user: 'USELF',
+            },
+          }),
+          addReaction: async () => {},
+          removeReaction: async () => {},
+        }) as unknown as ReturnType<NonNullable<Parameters<typeof createSlackAdapter>[0]['createClient']>>,
+      createListener: () => new FakeListener() as unknown as SlackListener,
+    })
+
+    await adapter.start()
+
+    expect(calls).toEqual([{ token: 'xoxc-test', cookie: 'xoxd-test' }])
+    expect(adapter.isConnected()).toBe(true)
+    expect(r.registered).toEqual([
+      'outbound:slack',
+      'typing-cap:slack=false',
+      'names:slack',
+      'self:slack',
+      'history:slack',
+      'fetch:slack',
+      'membership:slack',
+      'reaction:slack',
+      'remove-reaction:slack',
+    ])
+  })
+
+  test('message routes through classifyInbound and stop unregisters callbacks', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createSlackAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      selfAliasesRef: () => ['typeclaw'],
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient(),
+      createListener: () => listener as unknown as SlackListener,
+    })
+
+    await adapter.start()
+    listener.emit('message', {
+      type: 'message',
+      channel: 'C0123456789',
+      user: 'UUSER',
+      text: 'typeclaw hi',
+      ts: '1770000000.000100',
+    } satisfies SlackRTMMessageEvent)
+    await adapter.stop()
+
+    expect(r.routed).toHaveLength(1)
+    expect(r.routed[0]?.adapter).toBe('slack')
+    expect(r.routed[0]?.isBotMention).toBe(false)
+    expect(listener.stopped).toBe(true)
+    expect(r.unregistered).toContain('outbound:slack')
+    expect(r.unregistered).toContain('remove-reaction:slack')
+  })
+
+  test('outbound sends messages through SlackClient.sendMessage', async () => {
+    const sent: unknown[] = []
+    const r = router()
+    const adapter = createSlackAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient({ sendMessage: async (...args: unknown[]) => void sent.push(args) }),
+      createListener: () => new FakeListener() as unknown as SlackListener,
+    })
+
+    await adapter.start()
+    const result = await r.outbound?.({
+      adapter: 'slack',
+      workspace: 'T0123456789',
+      chat: 'C0123456789',
+      text: 'hello',
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(sent).toEqual([['C0123456789', 'hello', undefined]])
+  })
+
+  test('listener start failure rolls back registrations', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    listener.failStart = true
+    const adapter = createSlackAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient(),
+      createListener: () => listener as unknown as SlackListener,
+    })
+
+    await expect(adapter.start()).rejects.toThrow('boom')
+
+    expect(adapter.isConnected()).toBe(false)
+    expect(listener.stopped).toBe(true)
+    expect(r.unregistered).toContain('outbound:slack')
+    expect(r.unregistered).toContain('remove-reaction:slack')
+  })
+})
+
+function fakeClient(
+  overrides: Record<string, unknown> = {},
+): ReturnType<NonNullable<Parameters<typeof createSlackAdapter>[0]['createClient']>> {
+  return {
+    login: async () => {},
+    testAuth: async () => ({ user_id: 'USELF', team_id: 'T0123456789', user: 'self', team: 'Acme' }),
+    getChannel: async () => ({ id: 'C0123456789', name: 'general' }),
+    getUser: async () => ({ id: 'UUSER', name: 'alice', real_name: 'Alice' }),
+    getMessages: async () => [],
+    listChannelMembers: async () => [],
+    sendMessage: async () => ({ ts: '1', text: 'ok', type: 'message' }),
+    uploadFile: async () => ({
+      id: 'F1',
+      name: 'a.txt',
+      title: 'a.txt',
+      mimetype: 'text/plain',
+      size: 1,
+      url_private: '',
+      created: 1,
+      user: 'USELF',
+    }),
+    downloadFile: async () => ({
+      buffer: Buffer.from('x'),
+      file: {
+        id: 'F1',
+        name: 'a.txt',
+        title: 'a.txt',
+        mimetype: 'text/plain',
+        size: 1,
+        url_private: '',
+        created: 1,
+        user: 'USELF',
+      },
+    }),
+    addReaction: async () => {},
+    removeReaction: async () => {},
+    ...overrides,
+  } as unknown as ReturnType<NonNullable<Parameters<typeof createSlackAdapter>[0]['createClient']>>
+}

--- a/src/channels/adapters/slack.ts
+++ b/src/channels/adapters/slack.ts
@@ -1,0 +1,416 @@
+import { basename } from 'node:path'
+
+import {
+  SlackClient,
+  SlackListener,
+  type SlackMessage,
+  type SlackRTMMessageEvent,
+  type SlackRTMReactionEvent,
+} from 'agent-messenger/slack'
+
+import {
+  MEMBERSHIP_ENUMERATION_CAP,
+  type MembershipResolver,
+  type MembershipResolverFailure,
+  type MembershipResolverResult,
+} from '@/channels/membership'
+import { deriveMembershipFromHistory } from '@/channels/membership-from-history'
+import type { ChannelRouter } from '@/channels/router'
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type {
+  ChannelHistoryMessage,
+  ChannelSelfIdentityResolver,
+  FetchAttachmentCallback,
+  FetchHistoryArgs,
+  FetchHistoryResult,
+  HistoryCallback,
+  OutboundCallback,
+  OutboundMessage,
+  ResolvedChannelNames,
+  SendResult,
+} from '@/channels/types'
+import { chunkMarkdown } from '@/markdown'
+import type { SlackAccountRecord } from '@/secrets/schema'
+
+import { createSlackAuthorResolver } from './slack-author-resolver'
+import { slackTsToMillis } from './slack-bot-time'
+import { createSlackChannelResolver } from './slack-channel-resolver'
+import { classifyInbound, type InboundDropReason } from './slack-classify'
+import { createSlackReactionCallback, createSlackRemoveReactionCallback } from './slack-reactions'
+
+export type SlackAdapterLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+const consoleLogger: SlackAdapterLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export type SlackCredentialStore = {
+  getAccount(id?: string): Promise<SlackAccountRecord | null>
+}
+
+export type SlackAdapterOptions = {
+  router: ChannelRouter
+  configRef: () => ChannelAdapterConfig
+  logger?: SlackAdapterLogger
+  selfAliasesRef?: () => readonly string[]
+  credentialsStore?: SlackCredentialStore
+  createClient?: () => SlackClient
+  createListener?: (client: SlackClient) => SlackListener
+}
+
+export type SlackAdapter = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  isConnected: () => boolean
+}
+
+export type SlackFileReader = (path: string) => Promise<Buffer>
+
+export function createSlackOutboundCallback(deps: {
+  client: Pick<SlackClient, 'sendMessage' | 'uploadFile'>
+  logger: SlackAdapterLogger
+  formatChannelTag: (chat: string) => Promise<string>
+  readFile?: SlackFileReader
+  resolvePath?: (path: string) => string
+}): OutboundCallback {
+  const readFile = deps.readFile ?? defaultReadFile
+  return async (msg: OutboundMessage): Promise<SendResult> => {
+    if (msg.adapter !== 'slack') return { ok: false, error: `unknown adapter: ${msg.adapter}` }
+    const text = msg.text ?? ''
+    const attachments = msg.attachments ?? []
+    if (text === '' && attachments.length === 0) return { ok: false, error: 'message has neither text nor attachments' }
+    const tag = await deps.formatChannelTag(msg.chat)
+    const threadTs = msg.replyTo?.externalMessageId ?? msg.thread ?? undefined
+    deps.logger.info(
+      `[slack] outbound ${tag} text_len=${text.length} attachments=${attachments.length}${threadTs !== undefined ? ` thread=${threadTs}` : ''}`,
+    )
+    try {
+      if (text !== '') {
+        for (const chunk of chunkMarkdown(text, 11_500)) await deps.client.sendMessage(msg.chat, chunk, threadTs)
+      }
+      for (const attachment of attachments) {
+        const path = deps.resolvePath ? deps.resolvePath(attachment.path) : attachment.path
+        const buffer = await readFile(path)
+        const filename = attachment.filename ?? basename(path)
+        await deps.client.uploadFile([msg.chat], buffer, filename)
+      }
+      return { ok: true }
+    } catch (err) {
+      const message = describe(err)
+      deps.logger.error(`[slack] outbound failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createSlackHistoryCallback(deps: {
+  client: Pick<SlackClient, 'getMessages'>
+  logger: SlackAdapterLogger
+}): HistoryCallback {
+  return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    try {
+      const messages = await deps.client.getMessages(args.chat, { limit: clampLimit(args.limit, 100) })
+      return { ok: true, messages: messages.map(mapSlackHistoryMessage).reverse() }
+    } catch (err) {
+      const message = describe(err)
+      deps.logger.warn(`[slack] history fetch failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createSlackMembershipResolver(deps: {
+  client: Pick<SlackClient, 'listChannelMembers'>
+  logger: SlackAdapterLogger
+  historyCallback: HistoryCallback
+  selfUserIdRef: () => string | null
+  now?: () => number
+}): MembershipResolver {
+  const now = deps.now ?? Date.now
+  return async (key): Promise<MembershipResolverResult> => {
+    if (key.adapter !== 'slack') return { kind: 'permanent' } satisfies MembershipResolverFailure
+    if (key.workspace === '@dm') return { humans: 1, bots: 1, fetchedAt: now(), truncated: false }
+    try {
+      const members = await deps.client.listChannelMembers(key.chat)
+      const capped = members.slice(0, MEMBERSHIP_ENUMERATION_CAP)
+      const selfUserId = deps.selfUserIdRef()
+      let bots = 0
+      const humanMemberIds: string[] = []
+      for (const member of capped) {
+        if (selfUserId !== null && member === selfUserId) bots++
+        else humanMemberIds.push(member)
+      }
+      const truncated = members.length >= MEMBERSHIP_ENUMERATION_CAP
+      if (truncated) return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated }
+      return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated, humanMemberIds }
+    } catch (err) {
+      deps.logger.warn(`[slack] membership channel=${key.chat} failed: ${describe(err)}; deriving from recent history`)
+      return await deriveMembershipFromHistory({
+        fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
+        now,
+      })
+    }
+  }
+}
+
+export function createSlackFetchAttachmentCallback(deps: {
+  client: Pick<SlackClient, 'downloadFile'>
+  logger: SlackAdapterLogger
+}): FetchAttachmentCallback {
+  return async ({ ref, filename }) => {
+    try {
+      const { buffer, file } = await deps.client.downloadFile(ref)
+      return {
+        ok: true,
+        buffer,
+        filename: filename ?? file.name ?? 'attachment',
+        mimetype: file.mimetype,
+        size: buffer.length,
+      }
+    } catch (err) {
+      const message = describe(err)
+      deps.logger.error(`[slack] fetchAttachment failed for ${ref}: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
+  const logger = options.logger ?? consoleLogger
+  const createClient = options.createClient ?? (() => new SlackClient())
+  const createListener = options.createListener ?? ((client) => new SlackListener(client))
+  const client = createClient()
+  let listener: SlackListener | null = null
+  let selfUserId: string | null = null
+  let selfName: string | null = null
+  let teamId = ''
+  let teamName: string | null = null
+  let connected = false
+  let started = false
+  let inflightInbounds = 0
+  let stopWaiters: Array<() => void> = []
+
+  const channelResolver = createSlackChannelResolver({ client, teamNameRef: () => teamName })
+  const authorResolver = createSlackAuthorResolver({ client })
+  const selfIdentityResolver: ChannelSelfIdentityResolver = () =>
+    selfUserId !== null ? { id: selfUserId, username: selfName ?? selfUserId } : null
+  const formatChannelTag = async (chat: string): Promise<string> => {
+    const names = await channelResolver({ adapter: 'slack', workspace: teamId, chat, thread: null }).catch(
+      (): ResolvedChannelNames => ({}),
+    )
+    const label = names.chatName ?? null
+    return label === null || label === chat ? `channel=${chat}` : `channel=${label}(${chat})`
+  }
+  const historyCallback = createSlackHistoryCallback({ client, logger })
+  const membershipResolver = createSlackMembershipResolver({
+    client,
+    logger,
+    historyCallback,
+    selfUserIdRef: () => selfUserId,
+  })
+  const outboundCallback = createSlackOutboundCallback({ client, logger, formatChannelTag })
+  const fetchAttachmentCallback = createSlackFetchAttachmentCallback({ client, logger })
+  const reactionCallback = createSlackReactionCallback({ client })
+  const removeReactionCallback = createSlackRemoveReactionCallback({ client })
+
+  const handleMessage = async (event: SlackRTMMessageEvent): Promise<void> => {
+    inflightInbounds++
+    try {
+      const tag = await formatChannelTag(event.channel)
+      logger.info(
+        `[slack] inbound id=${event.ts} author=${event.user ?? '(none)'} ${tag} text_len=${(event.text ?? '').length}`,
+      )
+      const verdict = classifyInbound(event, options.configRef(), {
+        teamId,
+        selfUserId,
+        selfAliases: options.selfAliasesRef?.() ?? [],
+      })
+      if (verdict.kind === 'drop') {
+        logger.info(`[slack] dropped id=${event.ts} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+        return
+      }
+      const payload = { ...verdict.payload, authorName: await authorResolver.resolve(verdict.payload.authorId) }
+      logger.info(`[slack] routed id=${event.ts} ${tag} mention=${payload.isBotMention}`)
+      await options.router.route(payload)
+    } catch (err) {
+      logger.error(`[slack] handleInbound failed: ${describe(err)}`)
+    } finally {
+      inflightInbounds--
+      if (inflightInbounds === 0 && stopWaiters.length > 0) {
+        const waiters = stopWaiters
+        stopWaiters = []
+        for (const w of waiters) w()
+      }
+    }
+  }
+
+  const handleReaction = (kind: 'added' | 'removed', event: SlackRTMReactionEvent): void => {
+    logger.info(`[slack] reaction_${kind} channel=${event.item.channel} ts=${event.item.ts} emoji=${event.reaction}`)
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (started) return
+      started = true
+      try {
+        const account = await (options.credentialsStore ?? null)?.getAccount()
+        if (account === null || account === undefined) {
+          throw new Error('no Slack account in secrets.json#channels.slack (run typeclaw init to authenticate)')
+        }
+        await client.login({ token: account.token, cookie: account.cookie })
+        const auth = await client.testAuth()
+        selfUserId = auth.user_id
+        selfName = auth.user ?? auth.user_id
+        teamId = auth.team_id
+        teamName = auth.team ?? account.workspace_name ?? null
+        logger.info(`[slack] authenticated as ${selfName} (${selfUserId}) team=${teamName ?? teamId}`)
+      } catch (err) {
+        started = false
+        selfUserId = null
+        teamId = ''
+        logger.error(`[slack] login failed: ${describe(err)}`)
+        throw err
+      }
+
+      listener = createListener(client)
+      let listenerConnected = false
+      let listenerStartupError: Error | null = null
+      listener.on('connected', (info) => {
+        listenerConnected = true
+        connected = true
+        selfUserId = info.self.id
+        teamId = info.team.id
+      })
+      listener.on('disconnected', () => {
+        connected = false
+        logger.warn('[slack] disconnected')
+      })
+      listener.on('error', (err) => {
+        if (!listenerConnected && listenerStartupError === null) listenerStartupError = err
+        logger.error(`[slack] listener error: ${describe(err)}`)
+      })
+      listener.on('message', (event) => void handleMessage(event))
+      listener.on('reaction_added', (event) => handleReaction('added', event))
+      listener.on('reaction_removed', (event) => handleReaction('removed', event))
+
+      options.router.registerOutbound('slack', outboundCallback)
+      options.router.setTypingCapability('slack', false)
+      options.router.registerChannelNameResolver('slack', channelResolver)
+      options.router.registerSelfIdentity('slack', selfIdentityResolver)
+      options.router.registerHistory('slack', historyCallback)
+      options.router.registerFetchAttachment('slack', fetchAttachmentCallback)
+      options.router.registerMembership('slack', membershipResolver)
+      options.router.registerReaction('slack', reactionCallback)
+      options.router.registerRemoveReaction('slack', removeReactionCallback)
+
+      const rollbackStart = (reason: string, cause: Error): never => {
+        options.router.unregisterOutbound('slack', outboundCallback)
+        options.router.setTypingCapability('slack', false)
+        options.router.unregisterChannelNameResolver('slack', channelResolver)
+        options.router.unregisterSelfIdentity('slack', selfIdentityResolver)
+        options.router.unregisterHistory('slack', historyCallback)
+        options.router.unregisterFetchAttachment('slack', fetchAttachmentCallback)
+        options.router.unregisterMembership('slack', membershipResolver)
+        options.router.unregisterReaction('slack', reactionCallback)
+        options.router.unregisterRemoveReaction('slack', removeReactionCallback)
+        listener?.stop()
+        listener = null
+        selfUserId = null
+        connected = false
+        started = false
+        logger.error(`[slack] ${reason}: ${describe(cause)}`)
+        throw cause
+      }
+
+      try {
+        await listener.start()
+      } catch (err) {
+        rollbackStart('listener start threw', err instanceof Error ? err : new Error(String(err)))
+      }
+      if (!listenerConnected) {
+        rollbackStart(
+          'listener start failed silently',
+          listenerStartupError ?? new Error('listener.start() returned without emitting connected'),
+        )
+      }
+    },
+
+    async stop(): Promise<void> {
+      if (!started) return
+      started = false
+      options.router.unregisterOutbound('slack', outboundCallback)
+      options.router.setTypingCapability('slack', false)
+      options.router.unregisterChannelNameResolver('slack', channelResolver)
+      options.router.unregisterSelfIdentity('slack', selfIdentityResolver)
+      options.router.unregisterHistory('slack', historyCallback)
+      options.router.unregisterFetchAttachment('slack', fetchAttachmentCallback)
+      options.router.unregisterMembership('slack', membershipResolver)
+      options.router.unregisterReaction('slack', reactionCallback)
+      options.router.unregisterRemoveReaction('slack', removeReactionCallback)
+      listener?.stop()
+      listener = null
+      connected = false
+      if (inflightInbounds > 0) {
+        await new Promise<void>((resolve) => {
+          stopWaiters.push(resolve)
+        })
+      }
+      selfUserId = null
+    },
+
+    isConnected(): boolean {
+      return started && selfUserId !== null && connected
+    },
+  }
+}
+
+async function defaultReadFile(path: string): Promise<Buffer> {
+  return Buffer.from(await Bun.file(path).arrayBuffer())
+}
+
+function mapSlackHistoryMessage(msg: SlackMessage): ChannelHistoryMessage {
+  const attachments = (msg.files ?? []).map((file, index) => ({
+    id: index + 1,
+    kind: 'file' as const,
+    ref: file.id,
+    filename: file.name,
+    mimetype: file.mimetype,
+  }))
+  return {
+    externalMessageId: msg.ts,
+    authorId: msg.user ?? msg.username ?? 'unknown',
+    authorName: msg.username ?? msg.user ?? 'unknown',
+    text: msg.text,
+    ts: slackTsToMillis(msg.ts),
+    isBot: false,
+    replyToBotMessageId: null,
+    ...(attachments.length > 0 ? { attachments } : {}),
+  }
+}
+
+function clampLimit(requested: number, max: number): number {
+  if (!Number.isFinite(requested) || requested <= 0) return max
+  return Math.min(Math.floor(requested), max)
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function dropHint(reason: InboundDropReason): string {
+  switch (reason) {
+    case 'empty_text':
+      return ' (message had no text)'
+    case 'pre_connect':
+    case 'self_author':
+    case 'no_user':
+    case 'slack_system_message':
+      return ''
+  }
+}

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -125,6 +125,32 @@ const writeGithubSecrets = async (dir: string): Promise<void> => {
   )
 }
 
+const writeSlackSecrets = async (dir: string): Promise<void> => {
+  await writeFile(
+    join(dir, 'secrets.json'),
+    JSON.stringify({
+      version: 2,
+      providers: {},
+      channels: {
+        slack: {
+          currentAccount: 'T0123456789',
+          accounts: {
+            T0123456789: {
+              account_id: 'T0123456789',
+              token: 'xoxc-test',
+              cookie: 'xoxd-test',
+              workspace_id: 'T0123456789',
+              workspace_name: 'Acme',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      },
+    }),
+  )
+}
+
 function recordingLogger(): {
   info: (msg: string) => void
   warn: (msg: string) => void
@@ -541,6 +567,33 @@ describe('channel manager — restartAdapter serialization', () => {
 })
 
 describe('channel manager — slack adapter lifecycle', () => {
+  test('starts slack user adapter from secrets using the createSlackUserAdapter seam', async () => {
+    cfg.slack = enabledAdapterCfg()
+    await writeSlackSecrets(agentDir)
+    const fake = makeFakeAdapter()
+    const env: NodeJS.ProcessEnv = {
+      TYPECLAW_HOSTD_URL: 'http://hostd.test',
+      TYPECLAW_HOSTD_TOKEN: 'restart-token',
+      TYPECLAW_CONTAINER_NAME: 'agent',
+    }
+    let constructed = false
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env,
+      createSlackUserAdapter: () => {
+        constructed = true
+        return fake
+      },
+    })
+
+    await mgr.start()
+
+    expect(constructed).toBe(true)
+    expect(fake.startCalls).toBe(1)
+    await mgr.stop()
+  })
+
   test('starts slack adapter when both SLACK_BOT_TOKEN and SLACK_APP_TOKEN are set', async () => {
     cfg['slack-bot'] = enabledAdapterCfg()
     const fake = makeFakeAdapter()

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -5,6 +5,7 @@ import type { PermissionService } from '@/permissions'
 import type { GithubSecretsBlock } from '@/secrets'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 import { SecretsLineCredentialStore } from '@/secrets/line-store'
+import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
 import { SecretsBackend } from '@/secrets/storage'
 import { SecretsWebexCredentialStore } from '@/secrets/webex-store'
 import type { Stream } from '@/stream'
@@ -13,6 +14,7 @@ import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/disc
 import { createGithubAdapter, type GithubAdapter } from './adapters/github'
 import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaotalk'
 import { createLineAdapter, type LineAdapter } from './adapters/line'
+import { createSlackAdapter, type SlackAdapter } from './adapters/slack'
 import { createSlackBotAdapter, type SlackBotAdapter } from './adapters/slack-bot'
 import { createTelegramBotAdapter, type TelegramBotAdapter } from './adapters/telegram-bot'
 import { createWebexAdapter, type WebexAdapter } from './adapters/webex'
@@ -73,6 +75,7 @@ export type ChannelManagerOptions = {
   createKakaotalkAdapter?: typeof createKakaotalkAdapter
   createLineAdapter?: typeof createLineAdapter
   createSlackAdapter?: typeof createSlackBotAdapter
+  createSlackUserAdapter?: typeof createSlackAdapter
   createTelegramAdapter?: typeof createTelegramBotAdapter
   createWebexAdapter?: typeof createWebexAdapter
   createWebexBotAdapter?: typeof createWebexBotAdapter
@@ -140,6 +143,7 @@ type AnyAdapter =
   | GithubAdapter
   | LineAdapter
   | KakaotalkAdapter
+  | SlackAdapter
   | SlackBotAdapter
   | TelegramBotAdapter
   | WebexAdapter
@@ -181,7 +185,8 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   const createGithub = options.createGithubAdapter ?? createGithubAdapter
   const createKakaotalk = options.createKakaotalkAdapter ?? createKakaotalkAdapter
   const createLine = options.createLineAdapter ?? createLineAdapter
-  const createSlackAdapter = options.createSlackAdapter ?? createSlackBotAdapter
+  const createSlackBot = options.createSlackAdapter ?? createSlackBotAdapter
+  const createSlackUser = options.createSlackUserAdapter ?? createSlackAdapter
   const createTelegramAdapter = options.createTelegramAdapter ?? createTelegramBotAdapter
   const createWebex = options.createWebexAdapter ?? createWebexAdapter
   const createWebexBot = options.createWebexBotAdapter ?? createWebexBotAdapter
@@ -211,6 +216,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     if (name === 'line') return buildLineSignature(options.agentDir)
     if (name === 'kakaotalk') return buildKakaotalkSignature(options.agentDir)
     if (name === 'webex') return buildWebexSignature(options.agentDir)
+    if (name === 'slack') return buildSlackSignature(options.agentDir)
     if (name === 'github') return buildGithubSignature(options.agentDir)
     const requiredEnvs = TOKEN_ENV[name]
     const parts: string[] = []
@@ -239,7 +245,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       const appToken = env.SLACK_APP_TOKEN
       if (token === undefined || token.trim() === '') return null
       if (appToken === undefined || appToken.trim() === '') return null
-      return createSlackAdapter({
+      return createSlackBot({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         token,
@@ -264,6 +270,15 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
         credentialsStore: createContainerKakaoCredentialStore(options.agentDir, env),
+      })
+    }
+    if (name === 'slack') {
+      return createSlackUser({
+        router,
+        configRef: () => options.channelsConfigRef()[name] ?? cfg,
+        logger,
+        selfAliasesRef: () => router.getSelfAliases(),
+        credentialsStore: createContainerSlackCredentialStore(options.agentDir, env),
       })
     }
     if (name === 'webex') {
@@ -482,7 +497,9 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
             stopped.push(name)
           } else if (signature !== current.credentialSignature) {
             const reason =
-              name === 'kakaotalk' || name === 'line' || name === 'webex' ? 'credential rotation' : 'token rotation'
+              name === 'kakaotalk' || name === 'line' || name === 'webex' || name === 'slack'
+                ? 'credential rotation'
+                : 'token rotation'
             restartRequired.push(`${name} (${reason})`)
           }
         }
@@ -496,11 +513,41 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 // Token-based adapters only. Personal-account credentials live in
 // secrets.json#channels.<adapter>, not in env, so they go through
 // structured-block signatures instead.
-const TOKEN_ENV: Record<Exclude<AdapterId, 'kakaotalk' | 'line' | 'github' | 'webex'>, readonly string[]> = {
+const TOKEN_ENV: Record<Exclude<AdapterId, 'kakaotalk' | 'line' | 'github' | 'webex' | 'slack'>, readonly string[]> = {
   'discord-bot': ['DISCORD_BOT_TOKEN'],
   'slack-bot': ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN'],
   'telegram-bot': ['TELEGRAM_BOT_TOKEN'],
   'webex-bot': ['WEBEX_BOT_TOKEN'],
+}
+
+function createContainerSlackCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsSlackCredentialStore {
+  const hostdUrl = env.TYPECLAW_HOSTD_URL
+  const restartToken = env.TYPECLAW_HOSTD_TOKEN
+  const containerName = env.TYPECLAW_CONTAINER_NAME
+  if (!hostdUrl || !restartToken || !containerName) {
+    throw new Error('Slack credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME')
+  }
+  return new SecretsSlackCredentialStore({
+    mode: 'container',
+    secretsPath: join(agentDir, 'secrets.json'),
+    hostdUrl,
+    restartToken,
+    containerName,
+  })
+}
+
+function buildSlackSignature(agentDir: string): { signature: string; missing: string[] } {
+  const path = join(agentDir, 'secrets.json')
+  try {
+    const block = new SecretsBackend(path).tryReadChannelsSync()?.slack
+    if (!isSlackCredentialBlock(block)) {
+      return { signature: '', missing: ['secrets.json#channels.slack'] }
+    }
+    const digest = createHash('sha256').update(JSON.stringify(block)).digest('hex')
+    return { signature: `secrets.json#channels.slack@sha256:${digest}`, missing: [] }
+  } catch (err) {
+    return { signature: '', missing: [`secrets.json#channels.slack (${describe(err)})`] }
+  }
 }
 
 function createContainerWebexCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsWebexCredentialStore {
@@ -631,6 +678,15 @@ function isKakaoCredentialBlock(value: unknown): value is { accounts: Record<str
 }
 
 function isLineCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  if (!('accounts' in value)) return false
+  const accounts = value.accounts
+  return (
+    typeof accounts === 'object' && accounts !== null && !Array.isArray(accounts) && Object.keys(accounts).length > 0
+  )
+}
+
+function isSlackCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
   if (!('accounts' in value)) return false
   const accounts = value.accounts

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4946,6 +4946,7 @@ export type { QuoteAnchorSource } from './types'
 function formatAuthorReference(adapter: AdapterId, authorId: string, authorName: string): string {
   const displayName = authorName.trim() !== '' ? authorName.trim() : authorId
   switch (adapter) {
+    case 'slack':
     case 'slack-bot':
     case 'discord-bot':
       return `<@${authorId}>`

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -5,6 +5,7 @@ export const ADAPTER_IDS = [
   'github',
   'line',
   'kakaotalk',
+  'slack',
   'slack-bot',
   'telegram-bot',
   'webex',
@@ -269,6 +270,7 @@ export const channelsSchema = z
     // token-renewal cron — it persists a long-lived auth token + certificate.
     line: adapterSchema.optional(),
     kakaotalk: adapterSchema.optional(),
+    slack: adapterSchema.optional(),
     'slack-bot': adapterSchema.optional(),
     'telegram-bot': adapterSchema.optional(),
     webex: adapterSchema.optional(),

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -29,10 +29,12 @@ import {
   type GithubTunnelProvider,
   type KakaotalkAuthResult,
   type LineAuthResult,
+  type SlackAuthResult,
   type WebexAuthResult,
 } from '@/init'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { runLineBootstrap } from '@/init/line-auth'
+import { runSlackBootstrap } from '@/init/slack-auth'
 import { runWebexBootstrap } from '@/init/webex-auth'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 import { SecretsWebexCredentialStore } from '@/secrets/webex-store'
@@ -43,6 +45,7 @@ import { c, done, errorLine, printDiscordInviteHint, printSlackAppManifestSetup,
 
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'slack-bot': 'Slack',
+  slack: 'Slack (User)',
   'discord-bot': 'Discord',
   'telegram-bot': 'Telegram',
   webex: 'Webex (User)',
@@ -853,6 +856,11 @@ async function runSetGithub(cwd: string): Promise<void> {
 
 type CollectedCredentials =
   | { channel: 'discord-bot'; discordBotToken: string }
+  | {
+      channel: 'slack'
+      slackQrDataUrl: string
+      runSlackAuth: (options: { cwd: string; qrDataUrl: string }) => Promise<SlackAuthResult>
+    }
   | { channel: 'slack-bot'; slackBotToken: string; slackAppToken: string }
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'webex'; runWebexAuth: (options: { cwd: string }) => Promise<WebexAuthResult> }
@@ -880,6 +888,14 @@ async function collectCredentials(
     case 'slack-bot': {
       const slack = await promptSlackTokens()
       return { channel, slackBotToken: slack.bot, slackAppToken: slack.app }
+    }
+    case 'slack': {
+      const qrDataUrl = await promptSlackQrDataUrl()
+      return {
+        channel,
+        slackQrDataUrl: qrDataUrl,
+        runSlackAuth: ({ cwd: agentDir, qrDataUrl }) => runSlackBootstrap({ qrDataUrl, agentDir }),
+      }
     }
     case 'telegram-bot':
       return { channel, telegramBotToken: await promptTelegramToken() }
@@ -1241,6 +1257,26 @@ async function promptSlackTokens(): Promise<{ bot: string; app: string }> {
   return { bot, app }
 }
 
+async function promptSlackQrDataUrl(): Promise<string> {
+  note(
+    [
+      'Slack user mode signs in with the QR code data URL from Slack mobile sign-in.',
+      'Messages will be sent and received as this Slack user account.',
+    ].join('\n'),
+    'About to log in to Slack',
+  )
+  const qrDataUrl = await text({
+    message: 'Slack QR data URL (data:image/png;base64,...)',
+    validate: (value) =>
+      value && value.startsWith('data:image/') ? undefined : 'QR data URL must start with "data:image/"',
+  })
+  if (isCancel(qrDataUrl)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return qrDataUrl
+}
+
 async function promptSlackBotToken(): Promise<string> {
   const botToken = await password({
     message: 'Slack bot token (xoxb-...)',
@@ -1557,6 +1593,9 @@ function reportProgress(
       case 'webex-auth':
         s.stop(reportWebexAuth(event.result))
         break
+      case 'slack-auth':
+        s.stop(reportSlackAuth(event.result))
+        break
       case 'config':
         s.stop('Updated typeclaw.json.')
         break
@@ -1574,6 +1613,7 @@ const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
   'line-auth': 'Logging in to LINE...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   'webex-auth': 'Logging in to Webex...',
+  'slack-auth': 'Logging in to Slack...',
   config: 'Updating typeclaw.json...',
   secrets: 'Saving credentials to secrets.json...',
   'github-webhooks': 'Installing GitHub repository webhooks...',
@@ -1582,6 +1622,11 @@ const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
 function reportKakaotalkAuth(result: KakaotalkAuthResult): string {
   if (result.ok) return 'KakaoTalk credentials saved to secrets.json.'
   return `KakaoTalk login failed: ${result.reason}`
+}
+
+function reportSlackAuth(result: SlackAuthResult): string {
+  if (result.ok) return 'Slack credentials saved to secrets.json.'
+  return `Slack login failed: ${result.reason}`
 }
 
 function reportWebexAuth(result: WebexAuthResult): string {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -2043,6 +2043,7 @@ const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {
   preflight: 'Checking Docker...',
   'oauth-login': 'Waiting for browser login...',
   scaffold: 'Laying the egg...',
+  'slack-auth': 'Logging in to Slack...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   'webex-auth': 'Logging in to Webex...',
   'github-webhooks': 'Installing GitHub repository webhooks...',

--- a/src/config/channels-mutation.ts
+++ b/src/config/channels-mutation.ts
@@ -9,6 +9,7 @@ const SECRETS_FILE = 'secrets.json'
 
 export const CHANNEL_KINDS = [
   'slack-bot',
+  'slack',
   'discord-bot',
   'telegram-bot',
   'webex',

--- a/src/doctor/channel-checks.test.ts
+++ b/src/doctor/channel-checks.test.ts
@@ -69,6 +69,7 @@ describe('buildChannelChecks', () => {
       'channel.discord-bot.credentials',
       'channel.telegram-bot.credentials',
       'channel.webex-bot.credentials',
+      'channel.slack.credentials',
       'channel.webex.credentials',
       'channel.line.credentials',
       'channel.kakaotalk.credentials',

--- a/src/doctor/channel-checks.ts
+++ b/src/doctor/channel-checks.ts
@@ -29,6 +29,7 @@ export function buildChannelChecks(): DoctorCheck[] {
     discordBotCredentials(),
     telegramBotCredentials(),
     webexBotCredentials(),
+    slackUserCredentials(),
     webexUserCredentials(),
     lineCredentials(),
     kakaotalkCredentials(),
@@ -44,6 +45,32 @@ function slackBotCredentials(): DoctorCheck {
     description: 'slack-bot adapter has SLACK_BOT_TOKEN and SLACK_APP_TOKEN',
     applies: (ctx) => ctx.hasAgentFolder,
     run: (ctx) => runTokenAdapterCheck(ctx, 'slack-bot', ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN']),
+  }
+}
+
+function slackUserCredentials(): DoctorCheck {
+  return {
+    name: 'channel.slack.credentials',
+    category: 'channels',
+    description: 'slack adapter has a current account with a token in secrets.json',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const channels = readDeclaredChannels(ctx)
+      if (channels === null) return configInvalidResult()
+      if (!isAdapterActive(channels, 'slack')) {
+        return { status: 'skipped', message: 'slack not configured' }
+      }
+      const block = readChannelsSecrets(ctx)?.slack
+      if (!hasCurrentAccountTokenField(block, 'token')) {
+        return {
+          status: 'warning',
+          message: 'slack has no current account token in secrets.json',
+          details: ['Adapter will start but fail authentication and stay disconnected.'],
+          fix: { description: 'Run `typeclaw channel add slack` to log in an account.' },
+        }
+      }
+      return { status: 'ok', message: 'slack has a current account token' }
+    },
   }
 }
 
@@ -90,7 +117,7 @@ function webexUserCredentials(): DoctorCheck {
         return { status: 'skipped', message: 'webex not configured' }
       }
       const block = readChannelsSecrets(ctx)?.webex
-      if (!hasCurrentAccountToken(block)) {
+      if (!hasCurrentAccountTokenField(block, 'access_token')) {
         return {
           status: 'warning',
           message: 'webex has no current account access_token in secrets.json',
@@ -353,7 +380,7 @@ function isSecretShape(value: unknown): value is { value?: string; env?: string 
   return hasValue || hasEnv
 }
 
-function hasCurrentAccountToken(block: unknown): boolean {
+function hasCurrentAccountTokenField(block: unknown, field: string): boolean {
   if (!isObjectRecord(block)) return false
   const current = (block as { currentAccount?: unknown }).currentAccount
   if (typeof current !== 'string' || current.length === 0) return false
@@ -361,7 +388,7 @@ function hasCurrentAccountToken(block: unknown): boolean {
   if (!isObjectRecord(accounts)) return false
   const account = accounts[current]
   if (!isObjectRecord(account)) return false
-  const token = (account as { access_token?: unknown }).access_token
+  const token = account[field]
   return typeof token === 'string' && token.length > 0
 }
 

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -6,7 +6,12 @@ import { join } from 'node:path'
 import type { PortForward } from '@/config'
 import { defaultDockerExec, type DockerExec } from '@/container'
 import type { PortForwardEvent } from '@/portbroker'
-import { kakaoChannelBlockSchema, lineChannelBlockSchema, webexChannelBlockSchema } from '@/secrets/schema'
+import {
+  kakaoChannelBlockSchema,
+  lineChannelBlockSchema,
+  slackChannelBlockSchema,
+  webexChannelBlockSchema,
+} from '@/secrets/schema'
 import { SecretsBackend } from '@/secrets/storage'
 import { isWindows } from '@/shared'
 
@@ -461,7 +466,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
 
   const handleSecretsPatch = async (req: {
     containerName: string
-    patch: { channels: { kakaotalk: unknown } | { line: unknown } | { webex: unknown } }
+    patch: { channels: { kakaotalk: unknown } | { line: unknown } | { webex: unknown } | { slack: unknown } }
   }): Promise<RpcResponse> =>
     runSerially(req.containerName, async () => {
       const cwd = cwds.get(req.containerName)
@@ -475,7 +480,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
           ? { key: 'line' as const, parsed: lineChannelBlockSchema.safeParse(channelsPatch.line) }
           : 'webex' in channelsPatch
             ? { key: 'webex' as const, parsed: webexChannelBlockSchema.safeParse(channelsPatch.webex) }
-            : { key: 'kakaotalk' as const, parsed: kakaoChannelBlockSchema.safeParse(channelsPatch.kakaotalk) }
+            : 'slack' in channelsPatch
+              ? { key: 'slack' as const, parsed: slackChannelBlockSchema.safeParse(channelsPatch.slack) }
+              : { key: 'kakaotalk' as const, parsed: kakaoChannelBlockSchema.safeParse(channelsPatch.kakaotalk) }
       if (!patch.parsed.success) {
         return { ok: false, reason: patch.parsed.error.issues.map((issue) => issue.message).join('; ') }
       }

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -1,5 +1,5 @@
 import type { PortForward } from '@/config'
-import type { KakaoChannelBlock, LineChannelBlock, WebexChannelBlock } from '@/secrets/schema'
+import type { KakaoChannelBlock, LineChannelBlock, SlackChannelBlock, WebexChannelBlock } from '@/secrets/schema'
 
 export type Request =
   | {
@@ -18,7 +18,13 @@ export type Request =
   | {
       kind: 'secrets-patch'
       containerName: string
-      patch: { channels: { kakaotalk: KakaoChannelBlock } | { line: LineChannelBlock } | { webex: WebexChannelBlock } }
+      patch: {
+        channels:
+          | { kakaotalk: KakaoChannelBlock }
+          | { line: LineChannelBlock }
+          | { webex: WebexChannelBlock }
+          | { slack: SlackChannelBlock }
+      }
     }
   | { kind: 'http-info' }
   | { kind: 'version' }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -84,6 +84,7 @@ export type InitStep =
   | 'preflight'
   | 'oauth-login'
   | 'scaffold'
+  | 'slack-auth'
   | 'kakaotalk-auth'
   | 'webex-auth'
   | 'github-webhooks'
@@ -94,6 +95,7 @@ export type InitStep =
 
 export type KakaotalkAuthResult = { ok: true } | { ok: false; reason: string }
 export type WebexAuthResult = { ok: true } | { ok: false; reason: string }
+export type SlackAuthResult = { ok: true } | { ok: false; reason: string }
 
 // Structured credential block for the GitHub channel adapter. Mirrors the
 // shape `runAddChannel({ channel: 'github', ... })` consumes so the wizard
@@ -1085,6 +1087,7 @@ function ignoreExists(error: NodeJS.ErrnoException): void {
 
 export type ChannelKind =
   | 'discord-bot'
+  | 'slack'
   | 'slack-bot'
   | 'telegram-bot'
   | 'webex'
@@ -1099,6 +1102,7 @@ export type ChannelKind =
 // when reading typeclaw.json.
 export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = [
   'slack-bot',
+  'slack',
   'discord-bot',
   'telegram-bot',
   'webex',
@@ -1108,7 +1112,14 @@ export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = [
   'github',
 ]
 
-export type AddChannelStep = 'line-auth' | 'kakaotalk-auth' | 'webex-auth' | 'config' | 'secrets' | 'github-webhooks'
+export type AddChannelStep =
+  | 'line-auth'
+  | 'kakaotalk-auth'
+  | 'webex-auth'
+  | 'slack-auth'
+  | 'config'
+  | 'secrets'
+  | 'github-webhooks'
 
 export type AddChannelStepEvent =
   | { step: 'config'; phase: 'start' }
@@ -1119,6 +1130,8 @@ export type AddChannelStepEvent =
   | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
   | { step: 'webex-auth'; phase: 'start' }
   | { step: 'webex-auth'; phase: 'done'; result: WebexAuthResult }
+  | { step: 'slack-auth'; phase: 'start' }
+  | { step: 'slack-auth'; phase: 'done'; result: SlackAuthResult }
   | { step: 'secrets'; phase: 'start' }
   | { step: 'secrets'; phase: 'done' }
   | { step: 'github-webhooks'; phase: 'start' }
@@ -1132,6 +1145,7 @@ export type AddChannelOptions = {
   onProgress?: (event: AddChannelStepEvent) => void
 } & (
   | { channel: 'discord-bot'; discordBotToken: string }
+  | { channel: 'slack'; slackQrDataUrl: string; runSlackAuth?: SlackAuthRunner }
   | { channel: 'slack-bot'; slackBotToken: string; slackAppToken: string }
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'webex-bot'; webexBotToken: string }
@@ -1151,6 +1165,8 @@ export type AddChannelOptions = {
       fetchImpl?: typeof fetch
     }
 )
+
+export type SlackAuthRunner = (options: { cwd: string; qrDataUrl: string }) => Promise<SlackAuthResult>
 
 export async function runAddChannel(options: AddChannelOptions): Promise<void> {
   const emit = options.onProgress ?? (() => {})
@@ -1182,6 +1198,14 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
     const result = await options.runWebexAuth({ cwd: options.cwd })
     emit({ step: 'webex-auth', phase: 'done', result })
     if (!result.ok) throw new Error(`Webex authentication failed: ${result.reason}`)
+  }
+
+  if (options.channel === 'slack') {
+    emit({ step: 'slack-auth', phase: 'start' })
+    const runner = options.runSlackAuth ?? defaultSlackAuthRunner
+    const result = await runner({ cwd: options.cwd, qrDataUrl: options.slackQrDataUrl })
+    emit({ step: 'slack-auth', phase: 'done', result })
+    if (!result.ok) throw new Error(`Slack authentication failed: ${result.reason}`)
   }
 
   emit({ step: 'config', phase: 'start' })
@@ -1254,6 +1278,8 @@ function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
       return { token: options.discordBotToken }
     case 'slack-bot':
       return { botToken: options.slackBotToken, appToken: options.slackAppToken }
+    case 'slack':
+      return {}
     case 'telegram-bot':
       return { token: options.telegramBotToken }
     case 'webex-bot':
@@ -1272,6 +1298,11 @@ function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
       // GitHub stores a structured PAT + webhook secret block directly.
       return {}
   }
+}
+
+async function defaultSlackAuthRunner(options: { cwd: string; qrDataUrl: string }): Promise<SlackAuthResult> {
+  const { runSlackBootstrap } = await import('./slack-auth')
+  return await runSlackBootstrap({ agentDir: options.cwd, qrDataUrl: options.qrDataUrl })
 }
 
 type ChannelSecrets = Record<string, string>

--- a/src/init/run-owner-claim.ts
+++ b/src/init/run-owner-claim.ts
@@ -6,6 +6,7 @@ import { runClaimSession } from '@/role-claim'
 import type { ChannelKind } from './index'
 
 const CHANNEL_LABELS: Record<ChannelKind, string> = {
+  slack: 'Slack (User)',
   'slack-bot': 'Slack',
   'discord-bot': 'Discord',
   github: 'GitHub',

--- a/src/init/slack-auth.test.ts
+++ b/src/init/slack-auth.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
+
+import { runSlackBootstrap, slackSecretsPath } from './slack-auth'
+
+const tmp = async (): Promise<string> => mkdtemp(join(tmpdir(), 'typeclaw-slack-auth-'))
+
+describe('runSlackBootstrap', () => {
+  test('logs in with QR data URL and writes slack account secrets', async () => {
+    const dir = await tmp()
+    try {
+      const result = await runSlackBootstrap({
+        agentDir: dir,
+        qrDataUrl: 'data:image/png;base64,AAAA',
+        loginWithQr: async () => ({ token: 'xoxc-test', cookie: 'xoxd-test', workspace: 'Acme' }),
+      })
+
+      expect(result).toEqual({ ok: true })
+      expect(slackSecretsPath(dir)).toBe(join(dir, 'secrets.json'))
+      const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: join(dir, 'secrets.json') })
+      const account = await store.getAccount()
+      expect(account?.token).toBe('xoxc-test')
+      expect(account?.cookie).toBe('xoxd-test')
+      expect(account?.workspace_name).toBe('Acme')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns a failure result when QR login throws', async () => {
+    const dir = await tmp()
+    try {
+      const result = await runSlackBootstrap({
+        agentDir: dir,
+        qrDataUrl: 'data:image/png;base64,AAAA',
+        loginWithQr: async () => {
+          throw new Error('invalid qr')
+        },
+      })
+
+      expect(result).toEqual({ ok: false, reason: 'invalid qr' })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/slack-auth.ts
+++ b/src/init/slack-auth.ts
@@ -1,0 +1,51 @@
+import { join } from 'node:path'
+
+import { loginWithQr as upstreamLoginWithQr, type QrSession } from 'agent-messenger/slack'
+
+import type { SlackAccountRecord } from '@/secrets/schema'
+import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
+
+export type SlackBootstrapStatus = { ok: true } | { ok: false; reason: string }
+
+export type LoginWithQrFn = typeof upstreamLoginWithQr
+
+export type SlackLoginInput = {
+  qrDataUrl: string
+  agentDir: string
+  loginWithQr?: LoginWithQrFn
+}
+
+export function slackSecretsPath(agentDir: string): string {
+  return join(agentDir, 'secrets.json')
+}
+
+export async function runSlackBootstrap(input: SlackLoginInput): Promise<SlackBootstrapStatus> {
+  try {
+    const loginWithQr = input.loginWithQr ?? upstreamLoginWithQr
+    const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: slackSecretsPath(input.agentDir) })
+    const result = await loginWithQr(input.qrDataUrl)
+    const now = new Date().toISOString()
+    const accountId = workspaceId(result)
+    const account: SlackAccountRecord = {
+      account_id: accountId,
+      token: result.token,
+      cookie: result.cookie,
+      workspace_id: accountId,
+      workspace_name: result.workspace,
+      created_at: now,
+      updated_at: now,
+    }
+    await store.setAccount(account)
+    await store.setCurrentAccount(accountId)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function workspaceId(result: QrSession): string {
+  const record = result as QrSession & { workspace_id?: unknown }
+  return typeof record.workspace_id === 'string' && record.workspace_id !== '' ? record.workspace_id : result.workspace
+}
+
+export type { QrSession }

--- a/src/permissions/resolve.ts
+++ b/src/permissions/resolve.ts
@@ -4,6 +4,7 @@ import type { AdapterId } from '@/channels/schema'
 import type { MatchRule, Platform } from './match-rule'
 
 const ADAPTER_TO_PLATFORM: Record<AdapterId, Platform> = {
+  slack: 'slack',
   'slack-bot': 'slack',
   'discord-bot': 'discord',
   github: 'github',

--- a/src/role-claim/match-rule.ts
+++ b/src/role-claim/match-rule.ts
@@ -29,6 +29,7 @@ const ADAPTER_TO_PLATFORM: Record<
   ChannelKey['adapter'],
   'slack' | 'discord' | 'telegram' | 'webex' | 'kakao' | 'line' | 'github'
 > = {
+  slack: 'slack',
   'slack-bot': 'slack',
   'discord-bot': 'discord',
   github: 'github',

--- a/src/secrets/schema.test.ts
+++ b/src/secrets/schema.test.ts
@@ -123,6 +123,41 @@ describe('parseSecretsFile (v2 envelope)', () => {
     expect(result.file.channels.kakaotalk).toEqual({ currentAccount: null, accounts: {} })
   })
 
+  test('accepts channels.slack credential block', () => {
+    const result = parseSecretsFile({
+      version: 2,
+      channels: {
+        slack: {
+          currentAccount: 'T0123456789',
+          accounts: {
+            T0123456789: {
+              account_id: 'T0123456789',
+              token: 'xoxc-test',
+              cookie: 'xoxd-test',
+              workspace_id: 'T0123456789',
+              workspace_name: 'Acme',
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.file.channels.slack?.accounts.T0123456789?.workspace_name).toBe('Acme')
+  })
+
+  test('rejects malformed channels.slack account block', () => {
+    const result = parseSecretsFile({
+      version: 2,
+      channels: { slack: { currentAccount: 'T0123456789', accounts: { T0123456789: { token: 'xoxc-test' } } } },
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
   test('accepts a kakaotalk account with renewal fields (email + encryptedPassword)', () => {
     const result = parseSecretsFile({
       version: 2,

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -144,6 +144,21 @@ export const webexChannelBlockSchema = z.object({
   accounts: z.record(z.string(), webexAccountRecordSchema),
 })
 
+export const slackAccountRecordSchema = z.object({
+  account_id: z.string(),
+  token: z.string(),
+  cookie: z.string(),
+  workspace_id: z.string(),
+  workspace_name: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const slackChannelBlockSchema = z.object({
+  currentAccount: z.string().nullable(),
+  accounts: z.record(z.string(), slackAccountRecordSchema),
+})
+
 export const kakaoPendingLoginRecordSchema = z.object({
   device_uuid: z.string(),
   device_type: z.union([z.literal('pc'), z.literal('tablet')]),
@@ -166,6 +181,7 @@ export const channelsSchema = z
     line: lineChannelBlockSchema.optional(),
     kakaotalk: kakaoChannelBlockSchema.optional(),
     webex: webexChannelBlockSchema.optional(),
+    slack: slackChannelBlockSchema.optional(),
   })
   .catchall(z.unknown())
 
@@ -194,6 +210,8 @@ export type KakaoChannelBlock = z.infer<typeof kakaoChannelBlockSchema>
 export type WebexAccountRecord = z.infer<typeof webexAccountRecordSchema>
 export type WebexChannelBlock = z.infer<typeof webexChannelBlockSchema>
 export type WebexEncryptedPassword = z.infer<typeof webexEncryptedPasswordSchema>
+export type SlackAccountRecord = z.infer<typeof slackAccountRecordSchema>
+export type SlackChannelBlock = z.infer<typeof slackChannelBlockSchema>
 export type SecretsFile = z.infer<typeof secretsFileSchema>
 
 export type ParseSecretsResult = { ok: true; file: SecretsFile } | { ok: false; reason: string }

--- a/src/secrets/slack-store.test.ts
+++ b/src/secrets/slack-store.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { SlackAccountRecord } from './schema'
+import { SecretsSlackCredentialStore } from './slack-store'
+
+const tmp = async (): Promise<string> => mkdtemp(join(tmpdir(), 'typeclaw-slack-store-'))
+
+function account(overrides: Partial<SlackAccountRecord> = {}): SlackAccountRecord {
+  return {
+    account_id: 'T0123456789',
+    token: 'xoxc-test',
+    cookie: 'xoxd-test',
+    workspace_id: 'T0123456789',
+    workspace_name: 'Acme',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('SecretsSlackCredentialStore', () => {
+  test('round-trips setAccount/getAccount on a host secrets file', async () => {
+    const dir = await tmp()
+    try {
+      const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: join(dir, 'secrets.json') })
+      await store.setAccount(account())
+
+      expect(await store.getAccount()).toEqual(account())
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('removeAccount clears the account and advances current account', async () => {
+    const dir = await tmp()
+    try {
+      const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: join(dir, 'secrets.json') })
+      await store.setAccount(account({ account_id: 'a', workspace_id: 'a' }))
+      await store.setAccount(account({ account_id: 'b', workspace_id: 'b' }))
+      await store.setCurrentAccount('a')
+
+      await store.removeAccount('a')
+
+      expect(await store.getAccount('a')).toBeNull()
+      expect((await store.getAccount())?.account_id).toBe('b')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('listAccounts marks the current account', async () => {
+    const dir = await tmp()
+    try {
+      const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: join(dir, 'secrets.json') })
+      await store.setAccount(account({ account_id: 'a', workspace_id: 'a' }))
+      await store.setAccount(account({ account_id: 'b', workspace_id: 'b' }))
+      await store.setCurrentAccount('b')
+
+      expect((await store.listAccounts()).map(({ account_id, is_current }) => ({ account_id, is_current }))).toEqual([
+        { account_id: 'a', is_current: false },
+        { account_id: 'b', is_current: true },
+      ])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/secrets/slack-store.ts
+++ b/src/secrets/slack-store.ts
@@ -1,0 +1,96 @@
+import { sendHttp } from '@/hostd/client'
+
+import { type SlackAccountRecord, type SlackChannelBlock, slackChannelBlockSchema } from './schema'
+import { SecretsBackend } from './storage'
+
+export type SetSlackAccountInput = SlackAccountRecord
+
+export type SecretsSlackCredentialStoreOptions =
+  | { mode: 'host'; secretsPath: string }
+  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+
+const EMPTY_BLOCK: SlackChannelBlock = { currentAccount: null, accounts: {} }
+
+export class SecretsSlackCredentialStore {
+  private readonly backend: SecretsBackend
+  private writeChain: Promise<void> = Promise.resolve()
+
+  constructor(private readonly options: SecretsSlackCredentialStoreOptions) {
+    this.backend = new SecretsBackend(options.secretsPath)
+  }
+
+  async getAccount(id?: string): Promise<SlackAccountRecord | null> {
+    const block = this.readBlock()
+    const accountId = id ?? block.currentAccount
+    if (!accountId) return null
+    return block.accounts[accountId] ?? null
+  }
+
+  async setAccount(account: SetSlackAccountInput): Promise<void> {
+    await this.writeBlock((block) => {
+      const accounts = { ...block.accounts, [account.account_id]: account }
+      return { ...block, currentAccount: block.currentAccount ?? account.account_id, accounts }
+    })
+  }
+
+  async removeAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => {
+      const accounts = { ...block.accounts }
+      delete accounts[id]
+      const currentAccount = block.currentAccount === id ? (Object.keys(accounts)[0] ?? null) : block.currentAccount
+      return { ...block, currentAccount, accounts }
+    })
+  }
+
+  async listAccounts(): Promise<Array<SlackAccountRecord & { is_current: boolean }>> {
+    const block = this.readBlock()
+    return Object.values(block.accounts).map((account) => ({
+      ...account,
+      is_current: account.account_id === block.currentAccount,
+    }))
+  }
+
+  async setCurrentAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => ({ ...block, currentAccount: id }))
+  }
+
+  private readBlock(): SlackChannelBlock {
+    const channels =
+      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+    return parseBlock(channels?.slack)
+  }
+
+  private async writeBlock(update: (current: SlackChannelBlock) => SlackChannelBlock): Promise<void> {
+    return this.enqueueWrite(async () => {
+      if (this.options.mode === 'container') {
+        const next = update(this.readBlock())
+        const response = await sendHttp(
+          {
+            kind: 'secrets-patch',
+            containerName: this.options.containerName,
+            patch: { channels: { slack: next } },
+          },
+          { url: this.options.hostdUrl, token: this.options.restartToken },
+        )
+        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        return
+      }
+
+      await this.backend.updateChannelsAsync(async (channels) => {
+        const next = { ...channels, slack: update(parseBlock(channels.slack)) }
+        return { result: undefined, next }
+      })
+    })
+  }
+
+  private enqueueWrite(op: () => Promise<void>): Promise<void> {
+    const next = this.writeChain.then(op, op)
+    this.writeChain = next.catch(() => {})
+    return next
+  }
+}
+
+function parseBlock(value: unknown): SlackChannelBlock {
+  if (value === undefined) return EMPTY_BLOCK
+  return slackChannelBlockSchema.parse(value)
+}


### PR DESCRIPTION
## Background

TypeClaw supports Slack today only through `slack-bot`, which needs a registered Slack App (a bot token `xoxb-` + an app-level token `xapp-` for Socket Mode). That requires workspace-admin app installation and only sees channels the bot is invited to. There was no way to run the agent **as a real Slack user account** — reading and replying under a human identity, with that user's full channel/DM visibility, without standing up an app.

This wires a new `slack` channel: a Slack **user-account** adapter authenticated by **QR login only** (no Slack App, no OAuth click-through). QR login yields an unofficial Slack web session — an `xoxc-` client token plus the `xoxd-` `d` cookie — exactly the session a desktop client holds. It's the user-session sibling of `slack-bot`, mirroring how `webex` (user) sits beside `webex-bot`.

## Summary

The transport is the already-vendored `agent-messenger/slack` SDK (the same dependency that powers every other non-GitHub channel — no new packages). `SlackClient.login({token, cookie})` drives the Web API; `SlackListener` runs Slack's RTM WebSocket with auto-reconnect for real-time receive.

Key decisions a reviewer would otherwise have to reverse-engineer:

- **Adapter id `slack` vs `slack-bot`.** Two distinct adapters, like `webex`/`webex-bot`. They don't share a token model, classifier, or transport, so they aren't merged.
- **Credentials are account-based, not env-var.** The QR session is a structured `{token, cookie, workspace}` record, so it lives in `secrets.json#channels.slack` (a `{currentAccount, accounts}` block cloned from webex/line/kakao) and flows through the hostd `secrets-patch` path in container stage — **not** `.env`/`TOKEN_ENV`. That's why `manager.buildCredentialSignature` gets a `slack` branch and `TOKEN_ENV` does not.
- **Own RTM classifier, not reuse of `slack-bot-classify`.** RTM `message` events lack the Socket-Mode fields the bot classifier relies on (`parent_user_id`, `channel_type`, `bot_id`, `files`/`attachments`). The new classifier is pure/sync: self/no-user/system-subtype/empty/pre-connect drops, DM detection by the `D`-prefixed channel id, and mention/group-mention/alias anchoring (reusing the shared multilingual `matchesAnyAlias`). Because RTM carries no parent author, `replyToBotMessageId` is conservatively `null` rather than guessed with a network round-trip in a hot path.
- **No typing indicator.** The user SDK has no typing API, so the adapter registers typing capability `false` (the one structural divergence from the webex adapter, which has both phases).

The adapter follows the webex lifecycle contract: it registers all router callbacks on `start()`, rolls back **every** registration if the listener fails to connect, and drains in-flight inbounds before tearing down on `stop()`.

## What this does NOT do

- No Slack App / OAuth `xoxp-` path — QR session only, by design.
- No slash commands or ephemeral acks (RTM user sessions don't receive slash events).
- No token/cookie auto-renewal cron. `xoxc`/`xoxd` sessions expire; on expiry the listener fails and the adapter reports disconnected, and the operator re-runs QR auth. (Unlike webex/kakao, there's no password to seal or refresh.)
- No rich blocks/formatting — plain text + file uploads, matching the SDK surface.
- Note: running as a Slack user account is against Slack's automation guidelines; this is the same posture as the existing `agent-slack` skill and is the operator's choice.

## Review notes

- **Load-bearing invariant:** the secrets block must round-trip through both host stage (`src/init/slack-auth.ts`) and container stage (`src/hostd/{protocol,daemon}.ts` `secrets-patch`). The daemon's `safeParse` dispatch and the protocol union both gained a `slack` arm — verify they stay in lockstep with the schema.
- **Exhaustiveness:** adding `'slack'` to `ADAPTER_IDS` forces every `Record<AdapterId, …>` site to add a key (router mention format, session-origin platform info, permissions platform map, role-claim platform map, init step label). These are the one-line edits in the "register slack adapter id across platform maps" and "wire slack into channel add" commits; they compile only as a set.
- **Tests** cover the classifier (including a Korean alias-addressed case per the repo's multi-language matching rule), the store round-trip, the QR bootstrap with an injected fake (no network), the adapter start/route/stop/rollback lifecycle, the manager branch, and the doctor credential check.
- Local gate green: typecheck, lint (0 errors), format:check, and the full suite (9882 pass / 0 fail), plus `debug:prompt` across all origins.
