### PR TITLE
feat(cli): add step-by-step Slack QR sign-in instructions

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1260,10 +1260,18 @@ async function promptSlackTokens(): Promise<{ bot: string; app: string }> {
 async function promptSlackQrDataUrl(): Promise<string> {
   note(
     [
-      'Slack user mode signs in with the QR code data URL from Slack mobile sign-in.',
-      'Messages will be sent and received as this Slack user account.',
+      'Slack user mode signs in as your own account — messages are sent and',
+      'received as this Slack user, not a bot.',
+      '',
+      'Copy the QR image data URL from the Slack desktop app:',
+      '',
+      '1. Click your name (top-left) → "Sign in on mobile".',
+      '2. Right-click the QR code → "Copy Image Address".',
+      '3. Paste it below (a long data:image/png;base64,... string).',
+      '',
+      'Generate a fresh QR each time — the sign-in link expires quickly.',
     ].join('\n'),
-    'About to log in to Slack',
+    'Sign in to Slack (user account)',
   )
   const qrDataUrl = await text({
     message: 'Slack QR data URL (data:image/png;base64,...)',


### PR DESCRIPTION
## Background

The Slack user-account channel (added in #1031) signs in with a QR image data URL. The add-channel prompt only said "Slack user mode signs in with the QR code data URL from Slack mobile sign-in" — which doesn't tell the operator *where* that data URL comes from or *how* to get it. A first-time user has no way to know they need to right-click the QR in the Slack desktop app and copy its image address.

The `agent-slack auth qr` CLI already models the right level of detail in its error hint:

```
"In Slack: your name (top-left) → \"Sign in on mobile\" → right-click the QR → Copy Image Address."
```

## Summary

Replace the vague `note` with step-by-step instructions that mirror that hint, in the same multi-line `note(...)` step-list style the other adapters already use (Telegram/@BotFather, the Slack app-level token flow, etc.):

1. Click your name (top-left) → "Sign in on mobile".
2. Right-click the QR code → "Copy Image Address".
3. Paste the `data:image/png;base64,...` string at the prompt.

Also calls out that the sign-in link expires quickly, so a stale QR must be regenerated — the most common failure mode for this flow.

## What this does NOT do

- No behavior change — the validation, the `text` prompt, and the bootstrap path are untouched. This is prompt copy only.

## Review notes

- Single change in `promptSlackQrDataUrl` (`src/cli/channel.ts`). Local gate green: typecheck, lint (0 errors), format:check, full test suite.
