### PR TITLE
feat(cli): group Slack add behind a User/Bot mode pick

### DIFF
--- a/src/cli/channel.test.ts
+++ b/src/cli/channel.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 import { Writable } from 'node:stream'
 
-import { holderSpinnerControl, printLinePincode, printLineQrUrl, type LineAuthSpinnerHolder } from './channel'
+import {
+  familyModeOptions,
+  holderSpinnerControl,
+  printLinePincode,
+  printLineQrUrl,
+  SLACK_MODES,
+  WEBEX_MODES,
+  type LineAuthSpinnerHolder,
+} from './channel'
 
 function captureStream(): { stream: Writable; written: () => string } {
   const chunks: string[] = []
@@ -41,6 +49,42 @@ describe('printLinePincode', () => {
     // then
     expect(written()).toContain('12345678')
     expect(written()).not.toContain('│')
+  })
+})
+
+describe('familyModeOptions', () => {
+  test('preselects the recommended User mode for Slack when both modes are available', () => {
+    // given both Slack modes are addable (CHANNEL_KINDS lists slack-bot before slack)
+    const available = ['slack-bot', 'slack'] as const
+
+    // when
+    const options = familyModeOptions(SLACK_MODES, available)
+
+    // then the recommended User (QR) option is first, so options[0] is the default
+    expect(options.map((o) => o.value)).toEqual(['slack', 'slack-bot'])
+    expect(options[0]?.value).toBe('slack')
+  })
+
+  test('preselects the recommended User mode for Webex when both modes are available', () => {
+    // given
+    const available = ['webex', 'webex-bot'] as const
+
+    // when
+    const options = familyModeOptions(WEBEX_MODES, available)
+
+    // then
+    expect(options[0]?.value).toBe('webex')
+  })
+
+  test('keeps only the still-available mode when one is already configured', () => {
+    // given only the bot mode is left to add
+    const available = ['slack-bot'] as const
+
+    // when
+    const options = familyModeOptions(SLACK_MODES, available)
+
+    // then
+    expect(options.map((o) => o.value)).toEqual(['slack-bot'])
   })
 })
 

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -615,16 +615,18 @@ async function pickChannel(configured: Set<ChannelKind>): Promise<ChannelKind> {
     process.exit(0)
   }
 
-  type PickerValue = Exclude<ChannelKind, 'webex' | 'webex-bot'> | 'webex-family'
-  const webexModes = available.filter((kind): kind is 'webex' | 'webex-bot' => kind === 'webex' || kind === 'webex-bot')
+  type FamilyValue = 'webex-family' | 'slack-family'
+  type FlatKind = Exclude<ChannelKind, 'webex' | 'webex-bot' | 'slack' | 'slack-bot'>
+  type PickerValue = FlatKind | FamilyValue
   const options: Array<{ value: PickerValue; label: string }> = []
   for (const kind of available) {
-    if (kind === 'webex' || kind === 'webex-bot') {
-      if (!options.some((option) => option.value === 'webex-family'))
-        options.push({ value: 'webex-family', label: 'Webex' })
+    const family = FAMILY_OF[kind]
+    if (family !== undefined) {
+      if (!options.some((option) => option.value === family.value))
+        options.push({ value: family.value, label: family.label })
       continue
     }
-    options.push({ value: kind, label: CHANNEL_LABELS[kind] })
+    options.push({ value: kind as FlatKind, label: CHANNEL_LABELS[kind] })
   }
 
   const selected = await select<PickerValue>({
@@ -636,20 +638,62 @@ async function pickChannel(configured: Set<ChannelKind>): Promise<ChannelKind> {
     cancel('Aborted.')
     process.exit(0)
   }
-  if (selected !== 'webex-family') return selected
-  if (webexModes.length === 1) return webexModes[0]!
-  const allWebexOptions: Array<{ value: 'webex' | 'webex-bot'; label: string }> = [
-    {
-      value: 'webex',
-      label: 'User (ID/PW) — receives all messages, no @mention needed (recommended)',
-    },
-    { value: 'webex-bot', label: 'Bot (Token) — only sees @mentions in group spaces' },
-  ]
-  const webexOptions = allWebexOptions.filter((option) => webexModes.includes(option.value))
+  if (selected === 'webex-family') return pickWebexMode(available)
+  if (selected === 'slack-family') return pickSlackMode(available)
+  return selected
+}
+
+const FAMILY_OF: Partial<Record<ChannelKind, { value: 'webex-family' | 'slack-family'; label: string }>> = {
+  webex: { value: 'webex-family', label: 'Webex' },
+  'webex-bot': { value: 'webex-family', label: 'Webex' },
+  slack: { value: 'slack-family', label: 'Slack' },
+  'slack-bot': { value: 'slack-family', label: 'Slack' },
+}
+
+type FamilyMode<K extends ChannelKind> = { value: K; label: string }
+
+export const WEBEX_MODES: ReadonlyArray<FamilyMode<'webex' | 'webex-bot'>> = [
+  { value: 'webex', label: 'User (ID/PW) — receives all messages, no @mention needed (recommended)' },
+  { value: 'webex-bot', label: 'Bot (Token) — only sees @mentions in group spaces' },
+]
+
+export const SLACK_MODES: ReadonlyArray<FamilyMode<'slack' | 'slack-bot'>> = [
+  { value: 'slack', label: 'User (QR) — receives all messages, no @mention needed (recommended)' },
+  { value: 'slack-bot', label: 'Bot (Token) — only sees @mentions and DMs' },
+]
+
+// Keep the displayed order (recommended/User first), dropping already-configured
+// modes. The caller defaults the selection to options[0], so this order — NOT
+// CHANNEL_KINDS order — decides which mode is preselected.
+export function familyModeOptions<K extends ChannelKind>(
+  modes: ReadonlyArray<FamilyMode<K>>,
+  available: ReadonlyArray<ChannelKind>,
+): Array<FamilyMode<K>> {
+  return modes.filter((mode) => available.includes(mode.value))
+}
+
+async function pickWebexMode(available: ReadonlyArray<ChannelKind>): Promise<'webex' | 'webex-bot'> {
+  const options = familyModeOptions(WEBEX_MODES, available)
+  if (options.length === 1) return options[0]!.value
   const mode = await select<'webex' | 'webex-bot'>({
     message: 'Which Webex mode?',
-    options: webexOptions,
-    initialValue: webexModes[0],
+    options: options.map((o) => ({ value: o.value, label: o.label })),
+    initialValue: options[0]?.value,
+  })
+  if (isCancel(mode)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return mode
+}
+
+async function pickSlackMode(available: ReadonlyArray<ChannelKind>): Promise<'slack' | 'slack-bot'> {
+  const options = familyModeOptions(SLACK_MODES, available)
+  if (options.length === 1) return options[0]!.value
+  const mode = await select<'slack' | 'slack-bot'>({
+    message: 'Which Slack mode?',
+    options: options.map((o) => ({ value: o.value, label: o.label })),
+    initialValue: options[0]?.value,
   })
   if (isCancel(mode)) {
     cancel('Aborted.')


### PR DESCRIPTION
## Background

Now that Slack has both a bot adapter (`slack-bot`) and a user adapter (`slack`, #1031), the `channel add` picker lists them as two flat, confusingly-labeled siblings:

```
● Slack
○ Slack (User)
○ Telegram
...
```

A user scanning the list can't tell that "Slack" and "Slack (User)" are two modes of the same platform — it reads like two unrelated channels. Webex already solved this: it shows a single "Webex" entry and then asks "Which Webex mode?" (User vs Bot). Slack should match.

## Summary

Generalize `pickChannel` so Slack collapses into one **Slack** entry, exactly like the existing `webex-family` grouping. Picking it asks a follow-up:

```
Which Slack mode?
● User (QR) — receives all messages, no @mention needed (recommended)
○ Bot (Token) — only sees @mentions and DMs
```

Implementation mirrors the proven webex pattern rather than inventing a new one:

- A `FAMILY_OF` map folds `slack`/`slack-bot` (and `webex`/`webex-bot`) into a single family option in the top-level list.
- Two concrete sub-pick helpers (`pickSlackMode`, `pickWebexMode`) each use a concrete union type for `select<…>` — deliberately **not** a generic helper, because clack's `Option<K>` doesn't hold up under a generic `K` (the generic version fails to typecheck). Concrete unions match the existing webex code and keep the types sound.
- If only one mode of a family is still un-configured, the sub-pick is skipped and that mode is returned directly — same short-circuit webex already had.

`CHANNEL_LABELS` is unchanged: the per-adapter labels (`slack` → "Slack (User)", `slack-bot` → "Slack") still drive the non-picker displays ("Adding channel: …", remove/reauth lines), consistent with how webex labels work.

## What this does NOT do

- No change to credential collection, the adapters, or any non-picker flow. Purely how the interactive `channel add` menu is structured.
- Doesn't touch the positional `channel add <adapter>` path — passing `slack` or `slack-bot` explicitly still works unchanged.

## Review notes

- Single change in `src/cli/channel.ts` (`pickChannel` + two helpers). The `kind as FlatKind` cast is safe because every family member is handled and `continue`d before that line. Local gate green: typecheck, lint (0 errors), format:check, full test suite.
