### PR TITLE
fix(cli): correct misleading Slack mode picker labels

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -658,8 +658,8 @@ export const WEBEX_MODES: ReadonlyArray<FamilyMode<'webex' | 'webex-bot'>> = [
 ]
 
 export const SLACK_MODES: ReadonlyArray<FamilyMode<'slack' | 'slack-bot'>> = [
-  { value: 'slack', label: 'User (QR) — receives all messages, no @mention needed (recommended)' },
-  { value: 'slack-bot', label: 'Bot (Token) — only sees @mentions and DMs' },
+  { value: 'slack', label: 'User (QR) — posts as your own Slack account (recommended)' },
+  { value: 'slack-bot', label: 'Bot (Token) — posts as a Slack app/bot user' },
 ]
 
 // Keep the displayed order (recommended/User first), dropping already-configured


### PR DESCRIPTION
## Background

The Slack User/Bot mode picker (added in #1033) described the two modes as:

```
● User (QR) — receives all messages, no @mention needed (recommended)
○ Bot (Token) — only sees @mentions and DMs
```

That framing was copied from the Webex picker, where "only sees @mentions in group spaces" is a real **Webex platform limitation** (a Webex bot genuinely doesn't receive non-mention group messages from the API). Slack has no such asymmetry: both Slack adapters (`slack` user-session and `slack-bot`) route inbound through the **same engagement layer** with the same default triggers (`['mention', 'reply', 'dm']`). So:

- "receives all messages, no @mention needed" is **not** true of the user adapter by default, and
- "only sees @mentions and DMs" is **not** a special bot limitation — it's just the shared default for both.

The labels described a distinction that doesn't exist for Slack.

## Summary

Relabel by the difference that's actually real — **identity / auth**:

```
● User (QR) — posts as your own Slack account (recommended)
○ Bot (Token) — posts as a Slack app/bot user
```

The user adapter signs in via QR as a real Slack user (messages appear under your name); the bot adapter uses an app/bot token (messages appear as the app). What each one *receives* is governed by the per-channel engagement config, not the mode — so the labels no longer imply otherwise.

## What this does NOT do

- No behavior change — labels only. Engagement/triggers are unchanged.
- Leaves the Webex labels alone; "only sees @mentions in group spaces" is accurate for Webex.

## Review notes

- Two lines in `SLACK_MODES` (`src/cli/channel.ts`). Local gate green: typecheck, lint, format:check, full test suite.
