### PR TITLE
fix(cli): recommend Slack Bot mode, not the unofficial QR user session

### DIFF
--- a/src/cli/channel.test.ts
+++ b/src/cli/channel.test.ts
@@ -53,16 +53,17 @@ describe('printLinePincode', () => {
 })
 
 describe('familyModeOptions', () => {
-  test('preselects the recommended User mode for Slack when both modes are available', () => {
+  test('preselects the recommended Bot mode for Slack when both modes are available', () => {
     // given both Slack modes are addable (CHANNEL_KINDS lists slack-bot before slack)
     const available = ['slack-bot', 'slack'] as const
 
     // when
     const options = familyModeOptions(SLACK_MODES, available)
 
-    // then the recommended User (QR) option is first, so options[0] is the default
-    expect(options.map((o) => o.value)).toEqual(['slack', 'slack-bot'])
-    expect(options[0]?.value).toBe('slack')
+    // then the recommended Bot (official) option is first, so options[0] is the default —
+    // the QR user session is unofficial, so it must not be the default
+    expect(options.map((o) => o.value)).toEqual(['slack-bot', 'slack'])
+    expect(options[0]?.value).toBe('slack-bot')
   })
 
   test('preselects the recommended User mode for Webex when both modes are available', () => {

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -658,8 +658,8 @@ export const WEBEX_MODES: ReadonlyArray<FamilyMode<'webex' | 'webex-bot'>> = [
 ]
 
 export const SLACK_MODES: ReadonlyArray<FamilyMode<'slack' | 'slack-bot'>> = [
-  { value: 'slack', label: 'User (QR) — posts as your own Slack account (recommended)' },
-  { value: 'slack-bot', label: 'Bot (Token) — posts as a Slack app/bot user' },
+  { value: 'slack-bot', label: 'Bot (Token) — posts as a Slack app/bot user (recommended)' },
+  { value: 'slack', label: 'User (QR) — posts as your own Slack account; unofficial session, may need re-auth' },
 ]
 
 // Keep the displayed order (recommended/User first), dropping already-configured


### PR DESCRIPTION
## Background

The Slack mode picker marked **User (QR)** as `(recommended)`:

```
● User (QR) — posts as your own Slack account (recommended)
○ Bot (Token) — posts as a Slack app/bot user
```

That recommendation was carried over from the Webex picker, where the user (ID/PW) login is the supported, durable path and the bot has a real platform limitation. For Slack the situation is **inverted**:

- **User (QR)** is an *unofficial* `xoxc` token + `xoxd` cookie self-bot session. It's against Slack's automation guidelines, the session expires, and there is no renewal — recovery means manually re-running QR sign-in. (This is documented in the user adapter's own PR, #1031.)
- **Bot (Token)** is the *official* Slack-app path: a proper `xoxb` bot token + `xapp` Socket Mode token, durable and sanctioned.

Recommending the unofficial, fragile mode over the official one was wrong.

## Summary

- Move `(recommended)` from the User option to the **Bot** option.
- Make Bot the first/default-selected mode (the `familyModeOptions` default follows display order).
- Flag the User mode honestly: "unofficial session, may need re-auth".

```
● Bot (Token) — posts as a Slack app/bot user (recommended)
○ User (QR) — posts as your own Slack account; unofficial session, may need re-auth
```

The QR/user mode still works and is still offered — it's just no longer presented as the default-recommended choice.

## What this does NOT do

- Doesn't remove the QR/user mode; users who want it can still pick it.
- Doesn't touch Webex (its "User (recommended)" is correct for that platform).
- Labels + default selection + the matching picker test only — no adapter behavior change.

## Review notes

- `SLACK_MODES` reordered in `src/cli/channel.ts`; the `familyModeOptions` test updated to assert the default is now `slack-bot` (the recommended/official mode), explicitly documenting that the unofficial QR session must not be the default. Local gate green: typecheck, lint, format:check, full test suite (the one transient sandbox-proc test flake re-ran clean).
