### PR TITLE
perf(init): resolve new plugin versions concurrently

### DIFF
--- a/src/init/reconcile-plugin-deps.test.ts
+++ b/src/init/reconcile-plugin-deps.test.ts
@@ -234,6 +234,111 @@ describe('reconcilePluginDeps', () => {
     }
   })
 
+  test('resolves multiple new bare names concurrently, not serially', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      let inFlight = 0
+      let maxInFlight = 0
+      const resolveLatest = async (name: string): Promise<string> => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        inFlight -= 1
+        return `1.0.0-${name}`
+      }
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-a', 'typeclaw-plugin-b', 'typeclaw-plugin-c'],
+        resolveLatest,
+      })
+      expect(result.changed).toBe(true)
+      // given three new bare names, a serial pass would peak at 1 in flight
+      expect(maxInFlight).toBe(3)
+      const pkg = await readPkg(dir)
+      const deps = pkg.dependencies as Record<string, string>
+      expect(deps['typeclaw-plugin-a']).toBe('1.0.0-typeclaw-plugin-a')
+      expect(deps['typeclaw-plugin-b']).toBe('1.0.0-typeclaw-plugin-b')
+      expect(deps['typeclaw-plugin-c']).toBe('1.0.0-typeclaw-plugin-c')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('skipped order is deterministic regardless of which probe settles first', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      // "zed" resolves quickly, "abc" slowly: settle order is zed-then-abc, but
+      // both are not-found, so skipped must come back sorted (abc before zed).
+      const resolveLatest = async (name: string): Promise<string | null> => {
+        await new Promise((resolve) => setTimeout(resolve, name === 'abc-missing' ? 30 : 5))
+        return null
+      }
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['zed-missing', 'abc-missing'],
+        resolveLatest,
+      })
+      expect(result.changed).toBe(false)
+      expect(result.skipped).toEqual(['abc-missing', 'zed-missing'])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a later versioned entry wins over an earlier bare entry for the same name (positional last-wins)', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      // The bare entry queues a registry resolve that settles AFTER the loop;
+      // it must not clobber the explicit 1.2.3 set by the later versioned entry.
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo', 'typeclaw-plugin-foo@1.2.3'],
+        resolveLatest: async () => '9.9.9',
+      })
+      expect(result.changed).toBe(true)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('1.2.3')
+      expect((pkg.typeclaw as Record<string, unknown>).managedPlugins).toEqual({ 'typeclaw-plugin-foo': '1.2.3' })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a later bare entry wins over an earlier versioned entry for the same name (positional last-wins)', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo@1.2.3', 'typeclaw-plugin-foo'],
+        resolveLatest: async () => '9.9.9',
+      })
+      expect(result.changed).toBe(true)
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('9.9.9')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('a later versioned entry suppresses the skip of an earlier not-found bare entry', async () => {
+    const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
+    try {
+      // The earlier bare entry 404s, but the later versioned entry is the last
+      // occurrence and wins: the name must NOT appear in skipped.
+      const result = await reconcilePluginDeps({
+        cwd: dir,
+        plugins: ['typeclaw-plugin-foo', 'typeclaw-plugin-foo@1.2.3'],
+        resolveLatest: async () => null,
+      })
+      expect(result.changed).toBe(true)
+      expect(result.skipped).toEqual([])
+      const pkg = await readPkg(dir)
+      expect((pkg.dependencies as Record<string, string>)['typeclaw-plugin-foo']).toBe('1.2.3')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   test('propagates a hard resolver failure instead of skipping (network errors still block)', async () => {
     const dir = await makeAgentDir({ name: 'agent', dependencies: {} })
     try {

--- a/src/init/reconcile-plugin-deps.ts
+++ b/src/init/reconcile-plugin-deps.ts
@@ -104,34 +104,59 @@ type PackageJsonShape = {
 // re-resolve `latest` on every start and silently rewrite package.json when the
 // registry moves — bypassing the pluginAddition security gate, which only fires
 // on a guarded config write.
+//
+// Registry resolution for genuinely-new bare names runs CONCURRENTLY: each
+// `resolveLatest` spawns a `bun pm view` subprocess (a serial pass paid the
+// per-call network round-trip once per new plugin on the cold-start critical
+// path). A hard resolver failure (network/auth, NOT a 404) still rejects the
+// whole pass via Promise.all, preserving the "network errors block start"
+// contract. The `skipped` list is sorted so its order is independent of which
+// concurrent probe settled first.
+//
+// Last-entry-wins is positional, matching the prior serial loop: for a name
+// listed more than once, the LAST entry decides. An explicit/pinned version
+// applied during the loop must therefore survive even if an EARLIER bare entry
+// for the same name resolved from the registry afterward — so the post-await
+// assignment is skipped for any name whose last occurrence was not the bare one.
 async function resolveDesiredManaged(
   plugins: readonly string[],
   previousManaged: Record<string, string>,
   resolveLatest: ResolveLatestVersion,
 ): Promise<{ desired: Record<string, string>; skipped: string[] }> {
   const desired: Record<string, string> = {}
-  const skipped: string[] = []
+  const bareIsLastFor = new Set<string>()
+  const toResolve: string[] = []
   for (const entry of plugins) {
     if (isLocalEntry(entry)) continue
     const { name, versionSpec } = splitPluginEntrySpec(entry)
     if (name.length === 0) continue
     if (versionSpec !== undefined) {
       desired[name] = versionSpec
+      bareIsLastFor.delete(name)
       continue
     }
     const pinned = previousManaged[name]
     if (pinned !== undefined) {
       desired[name] = pinned
+      bareIsLastFor.delete(name)
       continue
     }
-    const resolved = await resolveLatest(name)
-    if (resolved === null) {
+    bareIsLastFor.add(name)
+    if (!toResolve.includes(name)) toResolve.push(name)
+  }
+
+  const resolved = await Promise.all(toResolve.map(async (name) => ({ name, version: await resolveLatest(name) })))
+  const skipped: string[] = []
+  for (const { name, version } of resolved) {
+    if (!bareIsLastFor.has(name)) continue
+    if (version === null) {
       skipped.push(name)
       continue
     }
-    desired[name] = resolved
+    desired[name] = version
   }
-  return { desired: sortKeys(desired), skipped }
+
+  return { desired: sortKeys(desired), skipped: skipped.sort() }
 }
 
 function isLocalEntry(entry: string): boolean {


### PR DESCRIPTION
## Background

`reconcilePluginDeps` resolved each genuinely-new bare plugin name with a serial `bun pm view` subprocess. On a multi-plugin config the cold-start critical path paid the registry round-trip once per new plugin, in sequence. With N new plugins, that is N sequential ~100–500 ms network calls before `typeclaw start` can proceed.

The root cause: `resolveDesiredManaged` awaited each `resolveLatest` call individually inside a `for` loop — no attempt to issue the probes in parallel.

## Summary

Switch `resolveDesiredManaged` to fan out all bare-name probes via `Promise.all`. Versioned entries (`pkg@1.2.3`) and already-pinned entries never hit the registry and are unchanged. Only genuinely-new bare names are affected; they now resolve in one ~round-trip of wall-clock time instead of N.

Key decisions:

- **`Promise.all`, not a concurrency-limited queue.** Registry probes are cheap on the server side and the expected count of new plugins per start is small (single digits). A simple `Promise.all` is correct and keeps the code readable.
- **Hard failures still block start.** A network or auth error (not a 404) rejects the whole `Promise.all`, same as the serial `await` did. `isPackageNotFound` still distinguishes "package not on registry" (skip) from transient failure (throw).
- **Deterministic `skipped` order.** Because concurrent probes settle in arrival order, the `skipped` list is now sorted before returning, so callers see the same order regardless of which probe happened to finish first.
- **Deduplicate before fanning out.** A name listed twice in `plugins` resolves once (`toResolve.includes(name)` guard, unchanged from the serial path).

## What this does NOT do

- Does not change behavior for versioned specs (`pkg@1.2.3`) or already-pinned entries — those paths are untouched.
- Does not add a concurrency cap. The registry is read-only and the payload is tiny; throttling adds complexity without a clear benefit at typical plugin counts.
- Does not change the `typeclaw start` boot sequence beyond the `resolveDesiredManaged` call.

## Review notes

- **Load-bearing change:** the `for` loop in `resolveDesiredManaged` that called `await resolveLatest(name)` serially is replaced by `Promise.all(toResolve.map(...))`. That is the only behavioral change in the production path (`src/init/reconcile-plugin-deps.ts`).
- **New tests** assert concurrency directly: a fake `resolveLatest` that tracks `inFlight` proves `maxInFlight === 3` when three new bare names are given (a serial pass would peak at 1). A second test asserts `skipped` comes back sorted even when the slower probe settles later. All existing reconcile-plugin-deps tests pass unchanged.
- Local gate green: typecheck (clean), lint (0 errors), format:check (clean), full test suite (9907 pass, 1 skip, 0 fail).

---

Part of a cold-start investigation; a follow-up PR parallelizes the container-boot await chain.