### PR TITLE
perf(config): read typeclaw.json once at boot

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -16,6 +16,7 @@ import {
   expandMountPath,
   FIELD_EFFECTS,
   getSandboxWritablePathSpecs,
+  loadConfigBundleSync,
   loadConfigSync,
   loadConfigSyncOrDefaults,
   loadPluginConfigsSync,
@@ -1172,6 +1173,53 @@ describe('migrateLegacyConfigShape', () => {
     } finally {
       await rm(cwd, { recursive: true, force: true })
     }
+  })
+
+  describe('loadConfigBundleSync', () => {
+    test('returns the same config and plugin configs as the two standalone loaders', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-bundle-'))
+      try {
+        await writeFile(
+          join(cwd, 'typeclaw.json'),
+          JSON.stringify({
+            models: { default: VALID_MODEL },
+            port: 9100,
+            'standup-log': { channel: 'C123' },
+            memory: { vector: { enabled: true } },
+          }),
+        )
+
+        const bundle = loadConfigBundleSync(cwd)
+
+        expect(bundle.config).toEqual(loadConfigSync(cwd))
+        expect(bundle.pluginConfigs).toEqual(loadPluginConfigsSync(cwd))
+        expect(bundle.pluginConfigs['standup-log']).toEqual({ channel: 'C123' })
+        expect(bundle.pluginConfigs.memory).toEqual({ vector: { enabled: true } })
+      } finally {
+        await rm(cwd, { recursive: true, force: true })
+      }
+    })
+
+    test('returns schema defaults and empty plugin configs when the file is absent', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-bundle-missing-'))
+      try {
+        const bundle = loadConfigBundleSync(cwd)
+        expect(bundle.config).toEqual(configSchema.parse({}))
+        expect(bundle.pluginConfigs).toEqual({})
+      } finally {
+        await rm(cwd, { recursive: true, force: true })
+      }
+    })
+
+    test('throws on invalid JSON (matching loadConfigSync)', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-bundle-badjson-'))
+      try {
+        await writeFile(join(cwd, 'typeclaw.json'), '{ not valid json')
+        expect(() => loadConfigBundleSync(cwd)).toThrow('not valid JSON')
+      } finally {
+        await rm(cwd, { recursive: true, force: true })
+      }
+    })
   })
 
   test('validateConfig also performs the on-disk rewrite', async () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1129,6 +1129,38 @@ export function loadConfigSync(cwd: string): Config {
   return result.data
 }
 
+// Single-read variant of loadConfigSync + loadPluginConfigsSync for the boot
+// path, which otherwise reads + parses + migrates typeclaw.json twice. Throws on
+// invalid JSON / failed schema parse and returns defaults + `{}` on a missing
+// file, matching loadConfigSync.
+export function loadConfigBundleSync(cwd: string): { config: Config; pluginConfigs: Record<string, unknown> } {
+  let raw: string
+  try {
+    raw = readFileSync(join(cwd, CONFIG_FILE), 'utf8')
+  } catch {
+    return { config: configSchema.parse({}), pluginConfigs: {} }
+  }
+
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(`${CONFIG_FILE} is not valid JSON: ${detail}`)
+  }
+
+  const migrated = migrateLegacyConfigShape(json)
+  if (migrated.changed) {
+    persistMigratedConfig(cwd, migrated.json, migrated.applied)
+  }
+
+  const result = configSchema.safeParse(migrated.json)
+  if (!result.success) {
+    throw new Error(`${CONFIG_FILE} is invalid: ${formatZodError(result.error)}`)
+  }
+  return { config: result.data, pluginConfigs: extractPluginConfigs(migrated.json) }
+}
+
 // Strips a `channels.github.eventAllowlist` that deep-equals a value `channel
 // add` / `init` previously seeded verbatim, so the config re-tracks the shipped
 // default. Called from every entry point that reads `typeclaw.json` so the rest

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,6 +15,7 @@ export {
   GWS_MULTI_ACCOUNT_PLUGIN_PACKAGE,
   GWS_MULTI_ACCOUNT_PLUGIN_VERSION,
   thinkingLevelSchema,
+  loadConfigBundleSync,
   loadConfigSync,
   loadConfigSyncOrDefaults,
   loadPluginConfigsSync,

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -33,14 +33,7 @@ import {
   type SubagentCompletionBridge,
 } from '@/channels'
 import { createTunnelBridge, type TunnelBridge } from '@/channels/tunnel-bridge'
-import {
-  createConfigReloadable,
-  getConfig,
-  loadConfigSync,
-  loadPluginConfigsSync,
-  reloadConfig,
-  withDefaultPlugins,
-} from '@/config'
+import { createConfigReloadable, getConfig, loadConfigBundleSync, reloadConfig, withDefaultPlugins } from '@/config'
 import {
   type CountStore,
   type CronConsumer,
@@ -161,12 +154,11 @@ export async function startAgent({
   const tuiToken = process.env.TYPECLAW_TUI_TOKEN
   const tuiTokenOpt = tuiToken !== undefined && tuiToken !== '' ? { tuiToken } : {}
 
-  const pluginConfigsByName = loadPluginConfigsSync(cwd)
+  const { config: cwdConfig, pluginConfigs: pluginConfigsByName } = loadConfigBundleSync(cwd)
   // Vector agents omit the system-prompt `# Memory` section and inject memory
   // per-turn instead. Derived once here: `memory.vector.enabled` is
   // restart-required, so a single boot read is coherent for the process.
   const suppressSystemMemory = vectorEnabledFromMemoryConfig(pluginConfigsByName.memory)
-  const cwdConfig = loadConfigSync(cwd)
   const githubTokenBridge = createGithubTokenBridge()
   const mcpManager =
     cwdConfig.mcpServers.length > 0 ? createMcpManager(cwdConfig.mcpServers, { env: process.env }) : null


### PR DESCRIPTION
## Background

On every cold start, boot read and parsed `typeclaw.json` **twice** — once through `loadPluginConfigsSync` and once through `loadConfigSync` — each repeating `readFileSync` + `JSON.parse` + `migrateLegacyConfigShape`. This is the cheapest of the cold-start wins from the boot-latency investigation: one file read instead of two, with no behavior change.

## Summary

Adds `loadConfigBundleSync(cwd)` and uses it in `startAgent`, replacing the back-to-back `loadPluginConfigsSync(cwd)` + `loadConfigSync(cwd)` calls.

`loadConfigBundleSync` does the read/parse/migrate once and returns both halves from the same migrated JSON:

```ts
const { config: cwdConfig, pluginConfigs: pluginConfigsByName } = loadConfigBundleSync(cwd)
```

- Behavior matches `loadConfigSync`: **throws** on invalid JSON or a failed schema parse, and returns schema defaults + an empty plugin map when the file is absent.
- The standalone `loadConfigSync` / `loadPluginConfigsSync` stay unchanged for host-side callers that need only one half.

## Preview

N/A — no user-visible output change.

## What this does NOT do

- Does not remove or change the standalone `loadConfigSync` / `loadPluginConfigsSync` helpers; host-side callers remain unaffected.
- Does not change any config schema, migration logic, or behavior — purely a read-deduplication.

## Review notes

- Load-bearing change: `src/run/index.ts` — `startAgent` now calls `loadConfigBundleSync` instead of the two-call sequence.
- `loadConfigBundleSync` is tested in `src/config/config.test.ts`: returns the same `config` / `pluginConfigs` as the two standalone loaders (incl. plugin blocks `standup-log`, `memory`), returns schema defaults + `{}` when absent, and throws on invalid JSON matching `loadConfigSync`.
- `typecheck` ✓ · `lint` ✓ (0 errors) · `format:check` ✓ · `test` ✓ (9908 pass / 0 fail)

> Part of a series of independent cold-start PRs (config read · MCP+plugin concurrency · vector warm-up overlap · skill-scan cache · MCP lazy-connect).