### PR TITLE
perf(run): parallelize independent container-boot steps

### DIFF
--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -55,7 +55,7 @@ import {
   type Scheduler,
 } from '@/cron'
 import { CLI_VERSION } from '@/init/cli-version'
-import { createMcpManager } from '@/mcp'
+import { createMcpManager, type McpConnectResult } from '@/mcp'
 import { runStartupMigrations } from '@/migrations'
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createPluginLogger } from '@/plugin/context'
@@ -170,14 +170,19 @@ export async function startAgent({
   const githubTokenBridge = createGithubTokenBridge()
   const mcpManager =
     cwdConfig.mcpServers.length > 0 ? createMcpManager(cwdConfig.mcpServers, { env: process.env }) : null
-  if (mcpManager !== null) {
-    const results = await mcpManager.connectAll()
-    for (const result of results) {
-      if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
-    }
-  }
-  const mcpManagerOpt = mcpManager !== null ? { mcpManager } : {}
-  const pluginsLoaded = await loadPlugins({
+
+  // These three boot steps have no mutual data dependency, so they run
+  // concurrently instead of as a serial await chain on the cold-start path:
+  //   - MCP connectAll (network; each server has its own connect deadline and
+  //     degrades to {ok:false} on failure, so it never rejects boot)
+  //   - loadPlugins (module imports + I/O; left UNCAUGHT so a bundled/plugin
+  //     security failure still aborts boot, same as before)
+  //   - the vector startup unit (CPU/disk; gated on vector mode, non-fatal)
+  // The vector unit stays internally sequential (index build → embedder warm)
+  // because warmEmbedder shares the embedder module state the index build
+  // initializes.
+  const mcpConnectPromise = mcpManager === null ? Promise.resolve<McpConnectResult[]>([]) : mcpManager.connectAll()
+  const pluginsLoadedPromise = loadPlugins({
     entries: withDefaultPlugins(cwdConfig.plugins),
     agentDir: cwd,
     configsByName: pluginConfigsByName,
@@ -186,6 +191,13 @@ export async function startAgent({
     hasGithubAppTokenResolver: githubTokenBridge.hasAppTokenResolver,
     ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
   })
+  const vectorStartupPromise = suppressSystemMemory ? runVectorStartup(cwd) : Promise.resolve()
+
+  const [pluginsLoaded, mcpResults] = await Promise.all([pluginsLoadedPromise, mcpConnectPromise, vectorStartupPromise])
+  for (const result of mcpResults) {
+    if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
+  }
+  const mcpManagerOpt = mcpManager !== null ? { mcpManager } : {}
 
   reloadRegistry.register(
     createConfigReloadable({
@@ -224,19 +236,6 @@ export async function startAgent({
   // v2-only parser rejects the file and hydrate below sees no channels. Runs
   // exactly once per folder; a folder already at v2 is a no-op.
   runStartupMigrations(cwd)
-  if (suppressSystemMemory) {
-    await buildStartupVectorIndex(cwd, embed).catch((err) => {
-      console.warn(`[vector] startup index build failed: ${err instanceof Error ? err.message : String(err)}`)
-    })
-
-    // Warm the embedder now (even when the index needed no rebuild above, which
-    // skips embed() entirely) so the first channel turn's query embed doesn't
-    // pay the one-time ONNX init on its critical path. Non-fatal: a failure here
-    // degrades to the per-turn lazy load, same as before this step existed.
-    await warmEmbedder().catch((err) => {
-      console.warn(`[vector] embedder warm-up failed: ${err instanceof Error ? err.message : String(err)}`)
-    })
-  }
 
   // Channel adapters read `process.env[TOKEN_ENV]` (see channels/manager.ts).
   // Hydrate fills any unset env var from secrets.json#channels via env-wins:
@@ -901,6 +900,20 @@ export async function startAgent({
     channelManager,
     stop,
   }
+}
+
+async function runVectorStartup(cwd: string): Promise<void> {
+  await buildStartupVectorIndex(cwd, embed).catch((err) => {
+    console.warn(`[vector] startup index build failed: ${err instanceof Error ? err.message : String(err)}`)
+  })
+
+  // Warm the embedder after the index pass (even when the index needed no
+  // rebuild above, which skips embed() entirely) so the first channel turn's
+  // query embed doesn't pay the one-time ONNX init on its critical path.
+  // Non-fatal: a failure here degrades to the per-turn lazy load.
+  await warmEmbedder().catch((err) => {
+    console.warn(`[vector] embedder warm-up failed: ${err instanceof Error ? err.message : String(err)}`)
+  })
 }
 
 function buildLocalTuiUrl(port: number, token: string | null): string {


### PR DESCRIPTION
## Background

`startAgent()` awaited three boot steps as a serial chain on the container cold-start path: MCP `connectAll`, then `loadPlugins`, then the vector startup unit (index build + embedder warm). The three have no mutual data dependency. On a config with a slow or unreachable MCP server, the per-server connect deadline stalled plugin loading and the vector index build behind it — delaying when the agent's WebSocket server comes online.

This is the container-stage half of the same cold-start investigation that produced #1037, which parallelized plugin version resolution on the host-stage `start` path.

## Summary

Replace the serial await chain with `Promise.all([pluginsLoadedPromise, mcpConnectPromise, vectorStartupPromise])`, collapsing three independent waits into one.

The vector steps are extracted into a `runVectorStartup` helper that stays internally sequential (index build then embedder warm) because `warmEmbedder` shares the embedder module state that the index build initializes. The helper is still gated on `memory.vector.enabled`.

Key decisions:

- **`Promise.all` with `loadPlugins` uncaught.** `loadPlugins` is passed without a `.catch` wrapper, so a bundled-plugin or plugin-security failure still rejects the `Promise.all` and aborts boot — same behavior as the serial `await`.
- **No new MCP timeout code.** `connectAll` already degrades gracefully: each server has its own connect deadline (`DEFAULT_MCP_CONNECT_TIMEOUT_MS`, via `withConnectDeadline` in `src/mcp/client.ts`) and returns `{ok:false}` on failure, so `connectAll` never rejects boot. Per-server failure warnings still log after the join.
- **`runVectorStartup` is non-fatal by design.** Both index build and embedder warm swallow their own errors with a `console.warn`. A failure here degrades to the per-turn lazy load — same behavior as before the extraction.
- **Boot ordering invariants are unchanged.** `runStartupMigrations(cwd)` still runs before `hydrateChannelEnvFromSecrets(cwd)` (v1→v2 secrets migration before secrets read). The `reloadRegistry.register(...)` closure over `channelManager` is only invoked on reload, after boot wiring completes.

## What this does NOT do

- Does not add an `AbortController` to cancel in-flight MCP/vector ops if plugin loading fatally rejects. That is a possible future refinement; it is intentionally out of scope here.
- Does not change concurrency inside `connectAll` — each server already connects in parallel there; this PR adds no new concurrency within MCP.
- Does not touch the host-stage `start` path or `reconcilePluginDeps`.

## Review notes

- **Load-bearing change:** the three sequential `await` calls in `startAgent` become one `Promise.all`. That is the only behavioral change.
- **`McpConnectResult[]`** is now re-exported from `@/mcp` and imported here so the `Promise.resolve<McpConnectResult[]>([])` null-manager branch typechecks correctly.
- **No new tests needed.** `src/run/index.test.ts` boots `startAgent` end-to-end (integration), and `src/mcp/*` unit tests cover `connectAll` parallelism plus the per-server connect deadline. Both pass unchanged, proving no behavioral regression.
- Local gate green: typecheck (clean), lint (0 errors), format:check (clean), full test suite (9905 pass, 1 skip, 0 fail).