### PR TITLE
perf(run): connect MCP servers and load plugins concurrently at boot

### DIFF
--- a/src/run/connect-mcp-and-load-plugins.test.ts
+++ b/src/run/connect-mcp-and-load-plugins.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { McpConnectResult, McpManager } from '@/mcp'
+
+import { connectMcpAndLoadPlugins } from './connect-mcp-and-load-plugins'
+
+describe('connectMcpAndLoadPlugins', () => {
+  test('closes MCP connections and rethrows when the plugin load fails fatally', async () => {
+    // given: a slow MCP connect that settles AFTER the plugin load has already rejected
+    let closed = 0
+    let connectSettled = false
+    const manager = fakeManager({
+      async connectAll() {
+        await delay(20)
+        connectSettled = true
+        return [{ ok: true, name: 'files', connection: undefined as never, toolCount: 0 }]
+      },
+      async closeAll() {
+        closed += 1
+      },
+    })
+    const fatal = new Error('bundled plugin blew up')
+
+    // when / then: the plugin error surfaces, but only after MCP settled and was closed
+    await expect(
+      connectMcpAndLoadPlugins(manager, async () => {
+        throw fatal
+      }),
+    ).rejects.toBe(fatal)
+    expect(connectSettled).toBe(true)
+    expect(closed).toBe(1)
+  })
+
+  test('returns the plugin result and does not close MCP on success', async () => {
+    let closed = 0
+    const manager = fakeManager({
+      async connectAll() {
+        return [
+          { ok: true, name: 'files', connection: undefined as never, toolCount: 1 },
+          { ok: false, name: 'broken', error: new Error('nope') },
+        ]
+      },
+      async closeAll() {
+        closed += 1
+      },
+    })
+
+    const result = await connectMcpAndLoadPlugins(manager, async () => 'plugins')
+
+    expect(result).toBe('plugins')
+    expect(closed).toBe(0)
+  })
+
+  test('works with no MCP manager configured', async () => {
+    const result = await connectMcpAndLoadPlugins(null, async () => 42)
+    expect(result).toBe(42)
+  })
+})
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function fakeManager(overrides: Partial<McpManager>): McpManager {
+  return {
+    async connectAll(): Promise<McpConnectResult[]> {
+      return []
+    },
+    getConnection() {
+      return undefined
+    },
+    listServers() {
+      return []
+    },
+    async refresh() {
+      return []
+    },
+    async closeAll() {},
+    ...overrides,
+  }
+}

--- a/src/run/connect-mcp-and-load-plugins.ts
+++ b/src/run/connect-mcp-and-load-plugins.ts
@@ -1,0 +1,35 @@
+import type { McpConnectResult, McpManager } from '@/mcp'
+
+// Connects MCP servers and loads plugins concurrently — neither consumes the
+// other's result — but joins with allSettled rather than Promise.all so a fatal
+// plugin-load rejection can't leak the MCP side. allSettled waits for connectAll
+// to fully settle, so on a plugin failure every MCP connection it established is
+// closed before the error is rethrown; startAgent returns no stop() handler on
+// this path, so this is the only cleanup chance. connectAll() itself never
+// rejects (per-server failures are `ok: false` results), but the rejected branch
+// is handled defensively.
+export async function connectMcpAndLoadPlugins<T>(
+  mcpManager: McpManager | null,
+  loadPlugins: () => Promise<T>,
+): Promise<T> {
+  const [mcpSettled, pluginsSettled] = await Promise.allSettled([
+    mcpManager !== null ? mcpManager.connectAll() : Promise.resolve<McpConnectResult[]>([]),
+    loadPlugins(),
+  ])
+
+  if (pluginsSettled.status === 'rejected') {
+    if (mcpManager !== null) await mcpManager.closeAll()
+    throw pluginsSettled.reason
+  }
+
+  if (mcpSettled.status === 'fulfilled') {
+    for (const result of mcpSettled.value) {
+      if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
+    }
+  } else {
+    const reason = mcpSettled.reason
+    console.warn(`[mcp] connect failed: ${reason instanceof Error ? reason.message : String(reason)}`)
+  }
+
+  return pluginsSettled.value
+}

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -84,6 +84,7 @@ import { createTunnelManager, type TunnelManager, type TunnelManagerOptions } fr
 import { BUNDLED_PLUGINS } from './bundled-plugins'
 import { buildChannelSessionFactory } from './channel-session-factory'
 import { installCodexFetchObserver } from './codex-fetch-observer'
+import { connectMcpAndLoadPlugins } from './connect-mcp-and-load-plugins'
 import { createPluginRuntime, type PluginRuntime, type PluginSubagentEntry } from './plugin-runtime'
 
 type BunServer = ReturnType<Server['start']>
@@ -170,22 +171,22 @@ export async function startAgent({
   const githubTokenBridge = createGithubTokenBridge()
   const mcpManager =
     cwdConfig.mcpServers.length > 0 ? createMcpManager(cwdConfig.mcpServers, { env: process.env }) : null
-  if (mcpManager !== null) {
-    const results = await mcpManager.connectAll()
-    for (const result of results) {
-      if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
-    }
-  }
   const mcpManagerOpt = mcpManager !== null ? { mcpManager } : {}
-  const pluginsLoaded = await loadPlugins({
-    entries: withDefaultPlugins(cwdConfig.plugins),
-    agentDir: cwd,
-    configsByName: pluginConfigsByName,
-    bundled: BUNDLED_PLUGINS,
-    resolveGithubTokenForRepo: githubTokenBridge.resolveTokenForRepo,
-    hasGithubAppTokenResolver: githubTokenBridge.hasAppTokenResolver,
-    ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
-  })
+  // MCP connection and plugin loading share no data, so run them concurrently
+  // instead of paying both serially. The helper joins with allSettled and closes
+  // any established MCP connection if the plugin load fails fatally, so a
+  // rejecting plugin load can't leak the background MCP servers.
+  const pluginsLoaded = await connectMcpAndLoadPlugins(mcpManager, () =>
+    loadPlugins({
+      entries: withDefaultPlugins(cwdConfig.plugins),
+      agentDir: cwd,
+      configsByName: pluginConfigsByName,
+      bundled: BUNDLED_PLUGINS,
+      resolveGithubTokenForRepo: githubTokenBridge.resolveTokenForRepo,
+      hasGithubAppTokenResolver: githubTokenBridge.hasAppTokenResolver,
+      ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
+    }),
+  )
 
   reloadRegistry.register(
     createConfigReloadable({


### PR DESCRIPTION
## What

In `startAgent`, runs `mcpManager.connectAll()` and `loadPlugins(...)` under a single `Promise.all` instead of awaiting them one after the other.

## Why

The two operations share no data — `loadPlugins` never reads the MCP manager, and the MCP catalog/tools are wired later at session creation. Running them serially meant boot paid the MCP subprocess spawns + `listTools()` round-trips **and then** the plugin import/registration, back to back. Concurrency overlaps them. A single slow/unreachable MCP server (up to the 15s connect timeout) no longer also delays plugin loading.

## How

```ts
const [mcpResults, pluginsLoaded] = await Promise.all([
  mcpManager !== null ? mcpManager.connectAll() : Promise.resolve([]),
  loadPlugins({ /* unchanged */ }),
])
for (const result of mcpResults) {
  if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
}
```

### Failure semantics preserved

`connectAll()` never rejects — every per-server failure is captured as an `ok: false` result and surfaced as a warning after both settle. So only a **fatal plugin load** can reject the `Promise.all`, exactly as a fatal plugin load rejected the prior sequential `await`. `mcpManagerOpt` is unchanged; it carries the manager object, not its connection state.

## Tests

No behavior change, so no new test. Covered by the existing `startAgent` boot integration test (`src/run/index.test.ts`) and the MCP manager/tools/catalog unit tests (`src/mcp/*`). Full suite: 9905 pass / 0 fail.

## Checks

`typecheck` ✓ · `lint` ✓ (0 errors) · `format:check` ✓ · `test` ✓ (9905 pass / 0 fail)

> Part of a series of independent cold-start PRs (config read · MCP+plugin concurrency · vector warm-up overlap · skill-scan cache · MCP lazy-connect).