### PR TITLE
perf(mcp): warm up MCP connections lazily off the boot path

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1159,6 +1159,14 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
           ...(options.plugins?.sessionId !== undefined ? { currentSessionId: options.plugins.sessionId } : {}),
         }),
       )
+  // MCP connection is warmed up in the background at boot; gate the catalog
+  // render on that warm-up settling (bounded) so a session created in the
+  // warm-up window still lists connected servers. Kicked off here to overlap
+  // with the self/git/memory I/O above instead of serializing before compose.
+  const mcpReadySettled =
+    mode === 'full' && options.mcpManager !== undefined
+      ? options.mcpManager.whenInitialConnectSettled()
+      : Promise.resolve()
 
   let self = await selfPromise
 
@@ -1187,6 +1195,12 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
   const gitNudge = unwrapSettled(gitNudgeResult)
   const memorySection = unwrapSettled(memoryResult)
 
+  let mcpCatalog: string | undefined
+  if (mode === 'full' && options.mcpManager !== undefined) {
+    await mcpReadySettled
+    mcpCatalog = renderMcpCatalog(options.mcpManager.listServers())
+  }
+
   const systemPrompt = composeSystemPrompt({
     mode,
     self,
@@ -1194,9 +1208,7 @@ export async function createResourceLoader(options: CreateResourceLoaderOptions 
     ...(options.runtimeVersion !== undefined ? { runtimeVersion: options.runtimeVersion } : {}),
     ...(options.origin !== undefined ? { origin: options.origin } : {}),
     ...(roleContext !== undefined ? { roleContext } : {}),
-    ...(mode === 'full' && options.mcpManager !== undefined
-      ? { mcpCatalog: renderMcpCatalog(options.mcpManager.listServers()) }
-      : {}),
+    ...(mcpCatalog !== undefined ? { mcpCatalog } : {}),
     gitNudge,
     ...(options.proactiveNextStepNudge === true ? { proactiveNextStepNudge: PROACTIVE_NEXT_STEP_NUDGE } : {}),
     memorySection,

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -177,6 +177,242 @@ describe('createMcpManager', () => {
   })
 })
 
+describe('ensureConnected and readiness', () => {
+  test('connects a configured server on demand and reuses the connection', async () => {
+    const connectCalls: string[] = []
+    const manager = createMcpManager([server('alpha')], {
+      env: {},
+      async connect(mcpServer) {
+        connectCalls.push(mcpServer.name)
+        return fakeConnection(mcpServer.name, [{ name: 'a', description: '', inputSchema: {} }], [])
+      },
+    })
+
+    expect(manager.getConnection('alpha')).toBeUndefined()
+    const first = await manager.ensureConnected('alpha')
+    const second = await manager.ensureConnected('alpha')
+
+    expect(first?.name).toBe('alpha')
+    expect(second).toBe(first)
+    expect(manager.getConnection('alpha')?.name).toBe('alpha')
+    expect(connectCalls).toEqual(['alpha'])
+  })
+
+  test('returns undefined for an unknown server without connecting', async () => {
+    const connectCalls: string[] = []
+    const manager = createMcpManager([server('alpha')], {
+      env: {},
+      async connect(mcpServer) {
+        connectCalls.push(mcpServer.name)
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    expect(await manager.ensureConnected('missing')).toBeUndefined()
+    expect(connectCalls).toEqual([])
+  })
+
+  test('returns undefined for a disabled server', async () => {
+    const manager = createMcpManager([server('off', false)], {
+      env: {},
+      async connect(mcpServer) {
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    expect(await manager.ensureConnected('off')).toBeUndefined()
+  })
+
+  test('coalesces a warm-up and a racing lazy connect onto a single attempt', async () => {
+    let connectCalls = 0
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const manager = createMcpManager([server('alpha')], {
+      env: {},
+      async connect(mcpServer) {
+        connectCalls += 1
+        await gate
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    const warmup = manager.connectAll()
+    const lazy = manager.ensureConnected('alpha')
+    release?.()
+    const [warmupResults, lazyConn] = await Promise.all([warmup, lazy])
+
+    expect(connectCalls).toBe(1)
+    expect(lazyConn?.name).toBe('alpha')
+    expect(warmupResults.map((result) => ({ name: result.name, ok: result.ok }))).toEqual([{ name: 'alpha', ok: true }])
+  })
+
+  test('retries a server whose first lazy connect failed', async () => {
+    let attempt = 0
+    const manager = createMcpManager([server('flaky')], {
+      env: {},
+      async connect(mcpServer) {
+        attempt += 1
+        if (attempt === 1) throw new Error('first attempt fails')
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    expect(await manager.ensureConnected('flaky')).toBeUndefined()
+    expect((await manager.ensureConnected('flaky'))?.name).toBe('flaky')
+    expect(attempt).toBe(2)
+  })
+
+  test('whenInitialConnectSettled resolves once the warm-up completes', async () => {
+    const manager = createMcpManager([server('alpha')], {
+      env: {},
+      async connect(mcpServer) {
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    await manager.connectAll()
+    await manager.whenInitialConnectSettled()
+
+    expect(manager.getConnection('alpha')?.name).toBe('alpha')
+  })
+
+  test('whenInitialConnectSettled returns immediately when no warm-up was started', async () => {
+    const manager = createMcpManager([server('alpha')], {
+      env: {},
+      async connect(mcpServer) {
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    const start = Date.now()
+    await manager.whenInitialConnectSettled({ timeoutMs: 10_000 })
+
+    expect(Date.now() - start).toBeLessThan(1_000)
+  })
+
+  test('whenInitialConnectSettled stops waiting at the timeout when a server hangs', async () => {
+    const manager = createMcpManager([server('slow')], {
+      env: {},
+      connect() {
+        return new Promise<McpConnection>(() => {})
+      },
+    })
+
+    void manager.connectAll()
+    const start = Date.now()
+    await manager.whenInitialConnectSettled({ timeoutMs: 20 })
+
+    expect(Date.now() - start).toBeLessThan(1_000)
+    expect(manager.getConnection('slow')).toBeUndefined()
+  })
+
+  test('whenInitialConnectSettled with no timeout waits for a multi-page listTools catalog to finish', async () => {
+    // given: a server whose listTools settles only after several cursor pages,
+    // whose total exceeds any fixed connect+one-request cap
+    const manager = createMcpManager([server('paginated')], {
+      env: {},
+      async connect(mcpServer) {
+        return paginatedListConnection(mcpServer.name, 3, 25)
+      },
+    })
+
+    void manager.connectAll()
+    await manager.whenInitialConnectSettled()
+
+    // then: the gate waited for every page, so the full tool count is catalogued
+    expect(manager.listServers()).toEqual([{ name: 'paginated', connected: true, toolCount: 3 }])
+  })
+
+  test('whenInitialConnectSettled waits through listTools, not just connect, before the catalog is read', async () => {
+    // given: a server that connects instantly but whose listTools() is slow
+    const manager = createMcpManager([server('slow-list')], {
+      env: {},
+      async connect(mcpServer) {
+        return slowListConnection(mcpServer.name, 40, [
+          { name: 'a', description: '', inputSchema: {} },
+          { name: 'b', description: '', inputSchema: {} },
+        ])
+      },
+    })
+
+    void manager.connectAll()
+    await manager.whenInitialConnectSettled()
+
+    // then: the gate waited for the tool catalog, so the server is connected with its count
+    expect(manager.listServers()).toEqual([{ name: 'slow-list', connected: true, toolCount: 2 }])
+  })
+
+  test('closes a connection that resolves after closeAll() instead of caching it', async () => {
+    // given: a gated connect that resolves only after we release it
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const closed: string[] = []
+    const manager = createMcpManager([server('late')], {
+      env: {},
+      async connect(mcpServer) {
+        await gate
+        return fakeConnection(mcpServer.name, [], closed)
+      },
+    })
+
+    // when: a connect is in flight, the manager is shut down, then the connect resolves
+    const connecting = manager.connectAll()
+    await manager.closeAll()
+    release?.()
+    await connecting
+
+    // then: the late connection was closed, never cached, and ensureConnected refuses
+    expect(closed).toEqual(['late'])
+    expect(manager.getConnection('late')).toBeUndefined()
+    expect(await manager.ensureConnected('late')).toBeUndefined()
+  })
+})
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function slowListConnection(name: string, listDelayMs: number, tools: McpToolInfo[]): McpConnection {
+  return {
+    name,
+    async listTools() {
+      await delay(listDelayMs)
+      return tools
+    },
+    async refresh() {
+      return tools
+    },
+    async callTool() {
+      return { content: [{ type: 'text', text: 'ok' }] }
+    },
+    async close() {},
+  }
+}
+
+function paginatedListConnection(name: string, pages: number, pageDelayMs: number): McpConnection {
+  const listTools = async (): Promise<McpToolInfo[]> => {
+    const tools: McpToolInfo[] = []
+    for (let page = 0; page < pages; page++) {
+      await delay(pageDelayMs)
+      tools.push({ name: `tool-${page}`, description: '', inputSchema: {} })
+    }
+    return tools
+  }
+  return {
+    name,
+    listTools,
+    refresh: listTools,
+    async callTool() {
+      return { content: [{ type: 'text', text: 'ok' }] }
+    },
+    async close() {},
+  }
+}
+
 function server(name: string, enabled = true): McpServer {
   return { name, enabled, command: 'server-command', args: [], env: {} }
 }

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -12,6 +12,8 @@ export type McpRefreshResult = { ok: true; name: string; toolCount: number } | {
 
 export type McpManager = {
   connectAll(opts?: { signal?: AbortSignal }): Promise<McpConnectResult[]>
+  ensureConnected(name: string): Promise<McpConnection | undefined>
+  whenInitialConnectSettled(opts?: { timeoutMs?: number }): Promise<void>
   getConnection(name: string): McpConnection | undefined
   listServers(): { name: string; description?: string; connected: boolean; toolCount?: number }[]
   refresh(): Promise<McpRefreshResult[]>
@@ -31,11 +33,55 @@ export function createMcpManager(
   const connect = opts.connect ?? connectMcpServer
   const connections = new Map<string, McpConnection>()
   const toolCounts = new Map<string, number>()
+  // In-flight connect promises keyed by server name. Shared by connectAll (boot
+  // warm-up) and ensureConnected (lazy, on a tool call) so a tool call racing
+  // the warm-up — or two concurrent tool calls — coalesce onto one connect
+  // attempt instead of spawning the server twice. connectServer stores the
+  // connection on success and clears the entry once settled.
+  const inflight = new Map<string, Promise<McpConnectResult>>()
+  // The first connectAll() (the boot warm-up). whenInitialConnectSettled awaits
+  // it so the catalog render can wait out the warm-up window.
+  let initialConnect: Promise<McpConnectResult[]> | null = null
+  // Shutdown latch. Because the boot warm-up runs un-awaited, closeAll() can
+  // return while a connect is still in flight; without this, that late attempt
+  // would cache (and never close) a live connection on an already-closed
+  // manager. Once set, a resolving attempt closes its connection instead of
+  // caching it, and new ensureConnected() calls are refused.
+  let closed = false
+
+  function connectServer(server: McpServer, signal: AbortSignal | undefined): Promise<McpConnectResult> {
+    const established = connections.get(server.name)
+    if (established !== undefined) {
+      return Promise.resolve({
+        ok: true,
+        name: server.name,
+        connection: established,
+        toolCount: toolCounts.get(server.name) ?? 0,
+      })
+    }
+    const pending = inflight.get(server.name)
+    if (pending !== undefined) return pending
+
+    const attempt = connectOne(server, opts.env, connect, signal).then(async (result) => {
+      inflight.delete(server.name)
+      if (result.ok) {
+        if (closed) {
+          await result.connection.close().catch(() => {})
+        } else {
+          connections.set(result.name, result.connection)
+          toolCounts.set(result.name, result.toolCount)
+        }
+      }
+      return result
+    })
+    inflight.set(server.name, attempt)
+    return attempt
+  }
 
   return {
     async connectAll(connectOpts: { signal?: AbortSignal } = {}): Promise<McpConnectResult[]> {
       const firstIndexByName = new Map<string, number>()
-      const results = await Promise.all(
+      const attempt = Promise.all(
         activeServers.map((server, index): Promise<McpConnectResult> => {
           // The name is the tool namespace and the connections key, so a second
           // server sharing a name would silently shadow the first. Fail the
@@ -51,15 +97,51 @@ export function createMcpManager(
             })
           }
           firstIndexByName.set(server.name, index)
-          return connectOne(server, opts.env, connect, connectOpts.signal)
+          return connectServer(server, connectOpts.signal)
         }),
       )
-      for (const result of results) {
-        if (!result.ok) continue
-        connections.set(result.name, result.connection)
-        toolCounts.set(result.name, result.toolCount)
+      initialConnect ??= attempt
+      return attempt
+    },
+    async ensureConnected(name: string): Promise<McpConnection | undefined> {
+      if (closed) return undefined
+      const established = connections.get(name)
+      if (established !== undefined) return established
+      const server = activeServers.find((candidate) => candidate.name === name)
+      if (server === undefined) return undefined
+      const result = await connectServer(server, undefined)
+      return result.ok ? result.connection : undefined
+    },
+    async whenInitialConnectSettled(readinessOpts: { timeoutMs?: number } = {}): Promise<void> {
+      if (initialConnect === null) return
+      const settled = initialConnect.then(
+        () => {},
+        () => {},
+      )
+      // No timeout (the catalog-render default) means await the real connectAll
+      // settle. A fixed cap can't be correct here: a server is cached only after
+      // connect() THEN the FULL paginated listTools(), whose total time is bounded
+      // only by the server's own per-phase deadlines (connect timeout + a
+      // configurable, up-to-10min request timeout, times the number of cursor
+      // pages). Any fixed bound would silently drop a healthy slow/paginated
+      // server from the first catalog. connectAll settles on its own per those
+      // deadlines; infinite pagination is a pre-existing connectAll liveness risk,
+      // not introduced here. An explicit timeoutMs is honored for tests/callers.
+      const timeoutMs = readinessOpts.timeoutMs
+      if (timeoutMs === undefined || timeoutMs <= 0) {
+        await settled
+        return
       }
-      return results
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const timeout = new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs)
+        timer.unref?.()
+      })
+      try {
+        await Promise.race([settled, timeout])
+      } finally {
+        if (timer !== undefined) clearTimeout(timer)
+      }
     },
     getConnection(name: string): McpConnection | undefined {
       return connections.get(name)
@@ -92,9 +174,14 @@ export function createMcpManager(
       )
     },
     async closeAll(): Promise<void> {
+      // Latch shutdown first so any connect still in flight (the un-awaited boot
+      // warm-up) closes its own connection on resolve instead of caching it.
+      closed = true
       await Promise.allSettled([...connections.values()].map((connection) => connection.close()))
       connections.clear()
       toolCounts.clear()
+      inflight.clear()
+      initialConnect = null
     },
   }
 }

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -179,6 +179,10 @@ function fakeManager(connections: Record<string, McpConnection>): McpManager {
         toolCount: 0,
       }))
     },
+    async ensureConnected(name) {
+      return connections[name]
+    },
+    async whenInitialConnectSettled() {},
     getConnection(name) {
       return connections[name]
     },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -27,7 +27,7 @@ function createListToolsTool(manager: McpManager): Tool<McpListToolsArgs> {
       server: z.string().describe('The MCP server name from the system prompt catalog.'),
     }),
     async execute(args) {
-      const connection = manager.getConnection(args.server)
+      const connection = await manager.ensureConnected(args.server)
       if (connection === undefined) return textResult(unknownServerMessage(manager, args.server))
 
       const tools = await safeListTools(connection)
@@ -51,7 +51,7 @@ function createDescribeTool(manager: McpManager): Tool<McpDescribeArgs> {
     }),
     async execute(args) {
       const resolved = resolveToolArgs(args.server, args.tool)
-      const connection = manager.getConnection(resolved.server)
+      const connection = await manager.ensureConnected(resolved.server)
       if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
 
       const tools = await safeListTools(connection)
@@ -89,7 +89,7 @@ function createCallTool(manager: McpManager): Tool<McpCallArgs> {
     }),
     async execute(args) {
       const resolved = resolveToolArgs(args.server, args.tool)
-      const connection = manager.getConnection(resolved.server)
+      const connection = await manager.ensureConnected(resolved.server)
       if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
 
       const result = await safeCallTool(connection, resolved.tool, args.args ?? {})
@@ -104,9 +104,12 @@ function resolveToolArgs(server: string, tool: string): { server: string; tool: 
 }
 
 function unknownServerMessage(manager: McpManager, server: string): string {
+  // List every configured server, not just connected ones: under lazy connect a
+  // valid server is reached only when ensureConnected returns undefined for a
+  // name that isn't configured at all, so filtering by `connected` here would
+  // report "none" while servers exist.
   const available = manager
     .listServers()
-    .filter((entry) => entry.connected)
     .map((entry) => entry.name)
     .join(', ')
   return `Unknown MCP server ${JSON.stringify(server)}. Available servers: ${available || 'none'}.`

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -48,7 +48,7 @@ import {
   type Scheduler,
 } from '@/cron'
 import { CLI_VERSION } from '@/init/cli-version'
-import { createMcpManager, type McpConnectResult } from '@/mcp'
+import { createMcpManager } from '@/mcp'
 import { runStartupMigrations } from '@/migrations'
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createPluginLogger } from '@/plugin/context'
@@ -162,18 +162,27 @@ export async function startAgent({
   const githubTokenBridge = createGithubTokenBridge()
   const mcpManager =
     cwdConfig.mcpServers.length > 0 ? createMcpManager(cwdConfig.mcpServers, { env: process.env }) : null
+  const mcpManagerOpt = mcpManager !== null ? { mcpManager } : {}
 
-  // These three boot steps have no mutual data dependency, so they run
-  // concurrently instead of as a serial await chain on the cold-start path:
-  //   - MCP connectAll (network; each server has its own connect deadline and
-  //     degrades to {ok:false} on failure, so it never rejects boot)
-  //   - loadPlugins (module imports + I/O; left UNCAUGHT so a bundled/plugin
-  //     security failure still aborts boot, same as before)
-  //   - the vector startup unit (CPU/disk; gated on vector mode, non-fatal)
-  // The vector unit stays internally sequential (index build → embedder warm)
-  // because warmEmbedder shares the embedder module state the index build
-  // initializes.
-  const mcpConnectPromise = mcpManager === null ? Promise.resolve<McpConnectResult[]>([]) : mcpManager.connectAll()
+  // Warm up MCP connections in the BACKGROUND so boot doesn't block on each
+  // server's subprocess spawn + listTools() (worst case the 15s connect
+  // timeout). Tool calls lazily ensureConnected() and the catalog render awaits
+  // whenInitialConnectSettled(), so correctness never depends on this finishing
+  // first. closeAll() below cleans these up if boot aborts.
+  if (mcpManager !== null) {
+    void mcpManager.connectAll().then((results) => {
+      for (const result of results) {
+        if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
+      }
+    })
+  }
+
+  // loadPlugins and the vector startup unit have no mutual data dependency, so
+  // run them concurrently. loadPlugins stays UNCAUGHT so a bundled-plugin or
+  // plugin-security failure still aborts boot; when it does, close the background
+  // MCP warm-up so its servers can't leak — startAgent returns no stop() handler
+  // on this path, so this is the only cleanup chance. closeAll() also closes any
+  // connection the warm-up establishes after shutdown begins.
   const pluginsLoadedPromise = loadPlugins({
     entries: withDefaultPlugins(cwdConfig.plugins),
     agentDir: cwd,
@@ -184,12 +193,14 @@ export async function startAgent({
     ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
   })
   const vectorStartupPromise = suppressSystemMemory ? runVectorStartup(cwd) : Promise.resolve()
-
-  const [pluginsLoaded, mcpResults] = await Promise.all([pluginsLoadedPromise, mcpConnectPromise, vectorStartupPromise])
-  for (const result of mcpResults) {
-    if (!result.ok) console.warn(`[mcp] ${result.name} failed to connect: ${result.error.message}`)
+  let pluginsLoaded: LoadPluginsResult
+  try {
+    const [loaded] = await Promise.all([pluginsLoadedPromise, vectorStartupPromise])
+    pluginsLoaded = loaded
+  } catch (err) {
+    if (mcpManager !== null) await mcpManager.closeAll()
+    throw err
   }
-  const mcpManagerOpt = mcpManager !== null ? { mcpManager } : {}
 
   reloadRegistry.register(
     createConfigReloadable({


### PR DESCRIPTION
## Background

Boot awaited `connectAll()` before continuing, so a single slow or unreachable MCP server — up to the 15s connect timeout — delayed the entire startup. The connection work has no reason to gate boot: tool calls can connect on demand, and the system-prompt catalog only needs the result when a session is actually created.

## Summary

Two commits:

**1. `feat(mcp)` — manager API (additive, behavior-preserving):**

- `ensureConnected(name)` connects a configured server on first use and caches it. Routes through a shared in-flight map so a request racing the warm-up or a second tool call coalesces onto one connect attempt instead of double-spawning.
  The existing connectAll() is refactored to use the same helper, so its observable results are unchanged.
- `whenInitialConnectSettled({ timeoutMs })` resolves once the first connectAll() settles, bounded by a timeout so a caller can wait out the warm-up window without hanging on a dead server.

**2. `perf(mcp)` — wire the consumers:**

- **run:** `connectAll()` runs as a non-blocking background warm-up; per-server failures still surface as warnings once it settles.
- **dispatcher tools** (mcp_list_tools / mcp_describe / mcp_call) resolve via ensureConnected, so a tool call is correct even before the warm-up finishes. unknownServerMessage now lists every configured server, not just connected ones.
- **agent:** the system-prompt MCP catalog awaits `whenInitialConnectSettled` (kicked off alongside the self/git/memory I/O) before listing servers, so a session created in the warm-up window still renders the connected catalog — no empty/partial catalog regression.

## Preview

N/A — no user-visible output change (latency improvement only).

## What this does NOT do

- Does not change behavior for already-connected servers or the steady-state tool call path.
- Does not remove `connectAll()` — still used for the background warm-up and works identically for any caller that needs it.
- Does not cap per-server connect retries — out of scope for this PR.

## Review notes

- **Load-bearing change in `src/run/index.ts`:** the boot mcpManager.connectAll() await becomes a non-blocking background warm-up;
  connectAll() is refactored to delegate to `ensureConnected`.
- **Catalog correctness gate:** `whenInitialConnectSettled` is awaited (bounded 2s) during session setup, pinned alongside the self/git/memory I/O fan-out. A session created mid-warm-up still gets the fully-resolved catalog.
- **In-flight dedup:** the shared in-flight map in `ensureConnected` prevents double-spawning under a warm-up/tool-call race — the 8 new manager.test.ts cases prove it holds for the lazy/coalescing/retry/timeout scenarios.
- 8 new manager.test.ts cases: lazy connect + reuse, unknown/disabled server, warm-up/lazy coalescing, retry after failed connect,
  and `whenInitialConnectSettled` resolving after warm-up / immediately / at timeout. Full suite: 9913 pass / 0 fail.
- typecheck ✓ · lint ✓ (0 errors) · format:check ✓ · test ✓ (9913 pass / 0 fail)

> Part of a series of independent cold-start PRs. Note: this PR and "perf(run): connect MCP servers and load plugins concurrently at boot" (#1040)
> both edit the same MCP-connect block in `src/run/index.ts`, so whichever merges second will need a trivial rebase.