### PR TITLE
feat(channels): surface posted message id on send results

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -119,6 +119,24 @@ describe('createChannelReplyTool', () => {
     expect(result.details).toEqual({ ok: true })
   })
 
+  test('surfaces messageId and messageIds from the router result in details', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true, messageId: 'ts1', messageIds: ['ts1', 'ts2'] })),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'hi' })
+    expect(result.details).toEqual({ ok: true, messageId: 'ts1', messageIds: ['ts1', 'ts2'] })
+  })
+
+  test('combines continue with messageId when a mid-turn ack carries an id', async () => {
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async () => ({ ok: true, messageId: 'ts9', messageIds: ['ts9'] })),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, { text: 'working on it', continue: true })
+    expect(result.details).toEqual({ ok: true, continue: true, messageId: 'ts9', messageIds: ['ts9'] })
+  })
+
   test('passes thread=null verbatim when origin is a channel-root session', async () => {
     const captured: { thread: string | null | undefined } = { thread: undefined }
     const tool = createChannelReplyTool({

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -53,7 +53,11 @@ export function createChannelReplyTool({
       'Reply in the current conversation. This is your default way to respond to a channel session — ' +
       'addressing fields (adapter, workspace, chat, thread) are filled in from the session origin, so ' +
       'you only supply the text. To post somewhere else (different chat, break out of the current ' +
-      'thread, etc.), use `channel_send` instead.',
+      'thread, etc.), use `channel_send` instead. ' +
+      'On success the result carries `messageId` (the posted message id) and `messageIds` (every id when ' +
+      'the text was split into multiple posts) when the platform reports them; pass `messageId` as a ' +
+      '`channel_send` `thread` to post follow-ups into the same thread. Some adapters do not report an id, ' +
+      'in which case both are absent.',
     parameters: Type.Object({
       text: Type.Optional(
         Type.String({
@@ -216,10 +220,19 @@ export function createChannelReplyTool({
       // `continue` is read by the router's terminal hook (installChannelReplyTerminalHook),
       // not by this tool — it suppresses the post-reply abort so a multi-step turn
       // keeps going. Success-only: a denied reply never ran, so there is no turn to keep.
-      const details: { ok: boolean; error?: string; continue?: boolean } = result.ok
-        ? keepTurnAlive
-          ? { ok: true, continue: true }
-          : { ok: true }
+      const details: {
+        ok: boolean
+        error?: string
+        continue?: boolean
+        messageId?: string
+        messageIds?: readonly string[]
+      } = result.ok
+        ? {
+            ok: true,
+            ...(keepTurnAlive ? { continue: true } : {}),
+            ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
+            ...(result.messageIds !== undefined ? { messageIds: result.messageIds } : {}),
+          }
         : { ok: false, error: result.error }
       // Echo the delivered text back to the model. The adapter classifier
       // drops self-authored messages on the inbound path (`self_author`),

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -94,6 +94,14 @@ describe('createChannelSendTool', () => {
     expect(result.details).toEqual({ ok: true })
   })
 
+  test('surfaces messageId and messageIds from the router result in details', async () => {
+    const tool = createChannelSendTool({
+      router: fakeRouter(async () => ({ ok: true, messageId: '1700.0001', messageIds: ['1700.0001', '1700.0002'] })),
+    })
+    const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: 'hi' })
+    expect(result.details).toEqual({ ok: true, messageId: '1700.0001', messageIds: ['1700.0001', '1700.0002'] })
+  })
+
   test('forwards an optional thread when provided', async () => {
     const captured: { thread: string | null | undefined } = { thread: undefined }
     const tool = createChannelSendTool({

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -52,7 +52,12 @@ export function createChannelSendTool({
       'For Discord guild channels, workspace is the guild id; for Slack team channels, workspace is ' +
       'the team id (e.g. "T0ACME"). For DMs on either platform, workspace is the literal "@dm". ' +
       'On failure (no adapter registered, or the adapter-level send failed), the call returns ' +
-      '{ ok: false, error }. There is no auto-reply: the only way for an agent to post is via this tool.',
+      '{ ok: false, error }. On success it returns { ok: true } and, when the platform reports it, ' +
+      '`messageId` (the posted message id, e.g. a Slack thread ts or Discord/Telegram message id) plus ' +
+      '`messageIds` (every id in send order when the post was split into multiple messages; `messageId` is ' +
+      'the reply anchor — usually the first message). Pass `messageId` back as `thread` on a later send to ' +
+      'post follow-ups into the same thread. Some adapters do not report an id, in which case both are absent. ' +
+      'There is no auto-reply: the only way for an agent to post is via this tool.',
     parameters: Type.Object({
       adapter: Type.Union(
         ADAPTER_IDS.map((a) => Type.Literal(a)),
@@ -236,7 +241,13 @@ export function createChannelSendTool({
           ),
         )
       }
-      const details: { ok: boolean; error?: string } = result.ok ? { ok: true } : { ok: false, error: result.error }
+      const details: { ok: boolean; error?: string; messageId?: string; messageIds?: readonly string[] } = result.ok
+        ? {
+            ok: true,
+            ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
+            ...(result.messageIds !== undefined ? { messageIds: result.messageIds } : {}),
+          }
+        : { ok: false, error: result.error }
       // Success wraps the echoed sent text in the strong SYSTEM MESSAGE fence;
       // denials keep the lighter prefix. See channel-reply.ts for the full
       // rationale (PR #481 self-reply loop).

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -1249,7 +1249,7 @@ describe('discord-bot createOutboundCallback', () => {
     // when
     const result = await cb(makeMsg({ text: 'hello' }))
     // then
-    expect(result.ok).toBe(true)
+    expect(result).toEqual({ ok: true, messageId: 'm1', messageIds: ['m1'] })
     expect(uploads).toHaveLength(0)
     expect(sends).toEqual([{ chat: 'c1', content: 'hello', options: undefined }])
   })

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -696,7 +696,7 @@ export function createOutboundCallback(deps: {
         Object.keys(sendOptions).length > 0 ? sendOptions : undefined,
       )
       logger.info(`[discord-bot] sent id=${sent.id} ${tag}`)
-      return { ok: true }
+      return { ok: true, messageId: sent.id, messageIds: [sent.id] }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       logger.error(`[discord-bot] sendMessage failed: ${message}`)

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -173,7 +173,7 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       fakeCtx,
     )
 
-    expect(result.details).toEqual({ ok: true })
+    expect(result.details).toEqual({ ok: true, messageId: '999', messageIds: ['999'] })
     expect(calls).toHaveLength(1)
     expect(calls[0]).toEqual({
       url: 'https://api.github.com/repos/acme/project/pulls/7/comments/555/replies',

--- a/src/channels/adapters/github/outbound.test.ts
+++ b/src/channels/adapters/github/outbound.test.ts
@@ -33,7 +33,7 @@ describe('createGithubOutboundCallback', () => {
       text: 'hello',
     })
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, messageId: '1', messageIds: ['1'] })
   })
 
   it('posts PR review thread replies through the pull comment replies endpoint', async () => {
@@ -54,7 +54,61 @@ describe('createGithubOutboundCallback', () => {
       text: 'reply',
     })
 
+    expect(result).toEqual({ ok: true, messageId: '2', messageIds: ['2'] })
+  })
+
+  it('omits messageId when the REST response body has no id', async () => {
+    const cb = createGithubOutboundCallback({
+      token: async () => 'tok',
+      authType: 'app',
+      logger,
+      fetchImpl: fakeFetch({
+        'POST https://api.github.com/repos/acme/project/issues/42/comments': { status: 201, body: {} },
+      }),
+    })
+
+    const result = await cb({
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'issue:42',
+      thread: null,
+      text: 'hello',
+    })
+
     expect(result).toEqual({ ok: true })
+  })
+
+  it('surfaces a discussion comment databaseId (numeric) as messageId, matching the inbound shape', async () => {
+    const graphqlFetch = Object.assign(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const body = String(init?.body ?? '')
+        if (body.includes('addDiscussionComment')) {
+          return new Response(JSON.stringify({ data: { addDiscussionComment: { comment: { databaseId: 987654 } } } }), {
+            status: 200,
+          })
+        }
+        return new Response(JSON.stringify({ data: { repository: { discussion: { id: 'D_kwDO123' } } } }), {
+          status: 200,
+        })
+      },
+      { preconnect: () => {} },
+    ) as typeof fetch
+    const cb = createGithubOutboundCallback({
+      token: async () => 'tok',
+      authType: 'app',
+      logger,
+      fetchImpl: graphqlFetch,
+    })
+
+    const result = await cb({
+      adapter: 'github',
+      workspace: 'acme/project',
+      chat: 'discussion:5',
+      thread: null,
+      text: 'hello',
+    })
+
+    expect(result).toEqual({ ok: true, messageId: '987654', messageIds: ['987654'] })
   })
 
   it('rejects attachments', async () => {

--- a/src/channels/adapters/github/outbound.ts
+++ b/src/channels/adapters/github/outbound.ts
@@ -69,7 +69,10 @@ async function postDiscussionComment(options: {
 }): Promise<SendResult> {
   const discussionId = await fetchDiscussionId(options)
   if (!discussionId.ok) return discussionId
-  const mutation = `mutation($discussionId:ID!,$body:String!){addDiscussionComment(input:{discussionId:$discussionId,body:$body}){comment{id}}}`
+  // databaseId (numeric REST id), NOT the GraphQL node id: the discussion_comment
+  // inbound classifier stamps externalMessageId from the webhook's numeric
+  // comment.id, so the outbound messageId must use the same shape to round-trip.
+  const mutation = `mutation($discussionId:ID!,$body:String!){addDiscussionComment(input:{discussionId:$discussionId,body:$body}){comment{databaseId}}}`
   return await postGraphql(
     options.fetchImpl,
     await options.token(),
@@ -80,6 +83,10 @@ async function postDiscussionComment(options: {
     },
     { authType: options.authType, endpointKind: 'discussion-comment' },
   )
+}
+
+function withMessageId(id: string | undefined): SendResult {
+  return id !== undefined ? { ok: true, messageId: id, messageIds: [id] } : { ok: true }
 }
 
 async function fetchDiscussionId(options: {
@@ -113,8 +120,16 @@ async function postGraphql(
   variables: Record<string, unknown>,
   guidance: { authType: GithubAuthType; endpointKind: OutboundEndpointKind },
 ): Promise<SendResult> {
-  const result = await graphql(fetchImpl, token, query, variables, guidance)
-  return result.ok ? { ok: true } : { ok: false, error: result.error }
+  const result = await graphql<{ addDiscussionComment?: { comment?: { databaseId?: number } | null } | null }>(
+    fetchImpl,
+    token,
+    query,
+    variables,
+    guidance,
+  )
+  if (!result.ok) return { ok: false, error: result.error }
+  const id = result.data.addDiscussionComment?.comment?.databaseId
+  return withMessageId(typeof id === 'number' ? String(id) : undefined)
 }
 
 async function graphql<T>(
@@ -162,7 +177,11 @@ async function postJson(
       headers: githubJsonHeaders(token),
       body: JSON.stringify(payload),
     })
-    if (response.ok) return { ok: true }
+    if (response.ok) {
+      const created = (await response.json().catch(() => null)) as { id?: number | string } | null
+      const id = created?.id
+      return withMessageId(id !== undefined ? String(id) : undefined)
+    }
     const text = await response.text().catch(() => '')
     const baseError = `GitHub API ${response.status}${text !== '' ? `: ${text}` : ''}`
     const decorated = isOutboundPermissionDenial(response.status, text)

--- a/src/channels/adapters/kakaotalk.test.ts
+++ b/src/channels/adapters/kakaotalk.test.ts
@@ -336,7 +336,7 @@ describe('createKakaotalkAdapter — outbound', () => {
       chat: '111',
       text: 'hello',
     })
-    expect(result.ok).toBe(true)
+    expect(result).toEqual({ ok: true, messageId: 'L1', messageIds: ['L1'] })
     expect(client.sendMessageCalls).toEqual([{ chatId: '111', text: 'hello' }])
 
     await adapter.stop()

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -200,6 +200,7 @@ export function createOutboundCallback(deps: {
     const tag = await formatChannelTag(msg.workspace, msg.chat)
     logger.info(`[kakaotalk] outbound ${tag} text_len=${text.length} attachments=${attachments.length}`)
 
+    const logIds: string[] = []
     // KakaoTalk has no shared text-with-file send (Slack's initial_comment) — files first, then text.
     if (attachments.length > 0) {
       let items: AttachmentInput[]
@@ -224,6 +225,7 @@ export function createOutboundCallback(deps: {
           logger.error(`[kakaotalk] sendAttachment status_code=${result.status_code} ${tag}`)
           return { ok: false, error: `kakaotalk attachment send failed with status ${result.status_code}` }
         }
+        logIds.push(result.log_id)
         logger.info(`[kakaotalk] uploaded log_id=${result.log_id} attachments=${items.length} ${tag}`)
       } catch (err) {
         const message = describe(err)
@@ -257,6 +259,7 @@ export function createOutboundCallback(deps: {
           logger.error(`[kakaotalk] sendMessage status_code=${result.status_code} ${tag}`)
           return { ok: false, error: `kakaotalk send failed with status ${result.status_code}` }
         }
+        logIds.push(result.log_id)
         logger.info(`[kakaotalk] sent log_id=${result.log_id} ${tag}`)
       } catch (err) {
         const message = describe(err)
@@ -265,7 +268,11 @@ export function createOutboundCallback(deps: {
       }
     }
 
-    return { ok: true }
+    // The text send is the message an agent replies to, so when both an
+    // attachment and text went out the text log_id (last in `logIds`) is the
+    // anchor; attachment-only sends fall back to the attachment log_id.
+    const anchor = logIds.length > 0 ? logIds[logIds.length - 1] : undefined
+    return { ok: true, messageId: anchor, messageIds: logIds }
   }
 }
 

--- a/src/channels/adapters/line.test.ts
+++ b/src/channels/adapters/line.test.ts
@@ -81,7 +81,7 @@ describe('createOutboundCallback', () => {
       formatChannelTag: tag,
     })
     const res = await cb({ adapter: 'line', workspace: '@line-dm', chat: 'C1', text: '**hi**' } as OutboundMessage)
-    expect(res).toEqual({ ok: true })
+    expect(res).toEqual({ ok: true, messageId: 'M', messageIds: ['M'] })
     expect(sent).toEqual([{ chat: 'C1', text: 'hi' }])
   })
 

--- a/src/channels/adapters/line.ts
+++ b/src/channels/adapters/line.ts
@@ -126,12 +126,12 @@ export function createOutboundCallback(deps: {
         return { ok: false, error: 'line send failed' }
       }
       logger.info(`[line] sent message_id=${result.message_id} ${tag}`)
+      return { ok: true, messageId: result.message_id, messageIds: [result.message_id] }
     } catch (err) {
       const message = describe(err)
       logger.error(`[line] sendMessage failed: ${message}`)
       return { ok: false, error: message }
     }
-    return { ok: true }
   }
 }
 

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -1476,7 +1476,7 @@ describe('slack-bot createOutboundCallback', () => {
     // when
     const result = await cb(makeMsg({ text: 'hello' }))
     // then
-    expect(result.ok).toBe(true)
+    expect(result).toEqual({ ok: true, messageId: 'ts1', messageIds: ['ts1'] })
     expect(uploads).toHaveLength(0)
     expect(posts).toEqual([
       {
@@ -1552,6 +1552,9 @@ describe('slack-bot createOutboundCallback', () => {
       expect(Array.isArray(blocks)).toBe(true)
       expect(blocks?.length).toBe(1)
     }
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.messageId).toBe('ts1')
+    expect(result.messageIds).toEqual(posts.map((_, i) => `ts${i + 1}`))
   })
 
   test('oversize text in an existing thread keeps every chunk on that thread', async () => {

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -845,12 +845,14 @@ export function createOutboundCallback(deps: {
       const chunks = chunkMarkdown(text, SLACK_MARKDOWN_BLOCK_LIMIT)
       const explicitThread = msg.thread !== undefined && msg.thread !== null ? msg.thread : null
       let threadTs: string | null = explicitThread
+      const sentTs: string[] = []
       try {
         for (let i = 0; i < chunks.length; i++) {
           const chunk = chunks[i]!
           const options: { thread_ts?: string; blocks?: unknown[] } = { blocks: [buildMarkdownBlock(chunk)] }
           if (threadTs !== null) options.thread_ts = threadTs
           const sent = await client.postMessage(msg.chat, chunk, options)
+          sentTs.push(sent.ts)
           logger.info(
             `[slack-bot] sent ts=${sent.ts} ${tag} chunk=${i + 1}/${chunks.length} blocks=markdown len=${chunk.length}`,
           )
@@ -860,7 +862,7 @@ export function createOutboundCallback(deps: {
           if (threadTs === null && chunks.length > 1) threadTs = sent.ts
         }
         if (typingTracker) await typingTracker.clearAfterSend(msg.chat, msg.typingThread ?? msg.thread)
-        return { ok: true }
+        return { ok: true, messageId: sentTs[0], messageIds: sentTs }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         logger.error(`[slack-bot] postMessage failed: ${message}`)

--- a/src/channels/adapters/telegram-bot-outbound.test.ts
+++ b/src/channels/adapters/telegram-bot-outbound.test.ts
@@ -112,6 +112,20 @@ describe('telegram-bot createOutboundCallback', () => {
     expect(fake.sendMessageCalls[0]?.options).toEqual({ parse_mode: 'MarkdownV2' })
   })
 
+  test('surfaces the posted message_id (stringified) so the agent can thread follow-ups', async () => {
+    const fake = fakeClient()
+    fake.setSendMessageBehavior(async () => fakeMessage({ message_id: 4242 }))
+    const cb = createOutboundCallback({
+      client: fake.client,
+      logger: silentLogger(),
+      formatChannelTag: async () => 'chat=-100123',
+    })
+
+    const result = await cb(buildOutbound({ text: 'hi' }))
+
+    expect(result).toEqual({ ok: true, messageId: '4242', messageIds: ['4242'] })
+  })
+
   test('renders agent Markdown (**bold**, *italic*, `code`) into MarkdownV2 entities', async () => {
     const fake = fakeClient()
     const cb = createOutboundCallback({

--- a/src/channels/adapters/telegram-bot.ts
+++ b/src/channels/adapters/telegram-bot.ts
@@ -260,7 +260,8 @@ export function createOutboundCallback(deps: {
       if (replyToId !== undefined) sendOptions.reply_to_message_id = replyToId
       const sent = await client.sendMessage(msg.chat, rendered, sendOptions)
       logger.info(`[telegram-bot] sent message_id=${sent.message_id} ${tag}`)
-      return { ok: true }
+      const id = String(sent.message_id)
+      return { ok: true, messageId: id, messageIds: [id] }
     } catch (err) {
       const message = describe(err)
       logger.error(`[telegram-bot] sendMessage failed: ${message}`)

--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -64,7 +64,7 @@ describe('webex outbound', () => {
     // given: Korean body to keep the path script-agnostic
     const result = await cb(outbound({ text: '**안녕하세요**' }))
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, messageId: 'sent', messageIds: ['sent'] })
     // markdown is omitted so Webex's E2E path does not render verbatim HTML
     expect(sends).toEqual([{ roomId: 'room-1', text: '**안녕하세요**', markdown: undefined, parentId: undefined }])
     expect(uploads).toEqual([])

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -123,7 +123,7 @@ export function createOutboundCallback(deps: {
 
       const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)
       logger.info(`[webex-bot] sent id=${sent.ref} ${tag}`)
-      return { ok: true }
+      return { ok: true, messageId: sent.ref, messageIds: [sent.ref] }
     } catch (err) {
       const message = describe(err)
       logger.error(`[webex-bot] outbound failed: ${message}`)

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -130,7 +130,7 @@ export function createOutboundCallback(deps: {
 
       const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)
       logger.info(`[webex] sent id=${sent.ref} ${tag}`)
-      return { ok: true }
+      return { ok: true, messageId: sent.ref, messageIds: [sent.ref] }
     } catch (err) {
       const message = describe(err)
       logger.error(`[webex] outbound failed: ${message}`)

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5283,6 +5283,28 @@ describe('ChannelRouter duplicate-send guard', () => {
     expect(second).toEqual({ ok: true })
   })
 
+  test('passes the adapter messageId/messageIds through to the send result', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true, messageId: 'm1', messageIds: ['m1', 'm2'] }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const result = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hello' })
+    expect(result).toEqual({ ok: true, messageId: 'm1', messageIds: ['m1', 'm2'] })
+  })
+
+  test('omits messageId when the adapter does not report one', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound())
+    await router.__testing!.flushDebounce(KEY)
+
+    const result = await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'hello' })
+    expect(result).toEqual({ ok: true })
+  })
+
   test('failed delivery does not reserve a dup slot — retry with same text succeeds', async () => {
     const dir = await tempDir()
     let attempts = 0

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -3577,11 +3577,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const snapshot = Array.from(callbacks)
     let lastError: string | undefined
     let delivered = false
+    let messageId: string | undefined
+    let messageIds: readonly string[] | undefined
     try {
       for (const cb of snapshot) {
         const result = await cb(msg)
         if (result.ok) {
           delivered = true
+          messageId = result.messageId
+          messageIds = result.messageIds
           break
         }
         lastError = result.error
@@ -3662,7 +3666,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger[level](`[channels] ${live.keyId} send ${fields}${warn}`)
     }
 
-    return { ok: true }
+    return {
+      ok: true,
+      ...(messageId !== undefined ? { messageId } : {}),
+      ...(messageIds !== undefined ? { messageIds } : {}),
+    }
   }
 
   // The turn ended via the terminal-reply abort. If that reply promised to keep

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -242,7 +242,23 @@ export type SendErrorCode =
   | 'callback-rejected'
   | 'skip-locked'
 
-export type SendResult = { ok: true } | { ok: false; error: string; code?: SendErrorCode }
+// `messageId` is the platform-native id of the posted message (Slack `ts`,
+// Discord snowflake, Telegram `message_id`, Webex/GitHub comment id, KakaoTalk
+// `log_id`, LINE `message_id`). It is the SAME id shape an inbound carries as
+// `externalMessageId`, so an agent can feed it straight back into a follow-up
+// `thread` / `replyTo` to keep posting into one conversation. For a send the
+// adapter splits into multiple posts (long text chunked, or attachments +
+// text), `messageId` is the post a reply should anchor to — usually the FIRST
+// post, but adapter-specific: KakaoTalk uploads files BEFORE the text, so the
+// text post (the message a human replies to) is the anchor even though it is
+// last. `messageIds` always lists every post in send order, so a caller that
+// needs a specific post (rather than the reply anchor) can index it directly.
+// Optional throughout: an adapter whose SDK does not hand back an id (legacy
+// slack/discord user-account adapters) omits both, and callers must treat a
+// missing id as "not available", never as an error.
+export type SendResult =
+  | { ok: true; messageId?: string; messageIds?: readonly string[] }
+  | { ok: false; error: string; code?: SendErrorCode }
 
 export type OutboundCallback = (msg: OutboundMessage) => Promise<SendResult>
 


### PR DESCRIPTION
## Background

`channel_send` / `channel_reply` told the agent *that* a message was posted but never *which* message. On success the tools returned a bare `{ ok: true }`, and `router.send` discarded whatever id the adapter had in hand. That leaves an agent unable to post several messages into one conversation thread (the motivating case: a few follow-up messages under a single Slack thread) — it has no anchor to thread the next send onto.

Every primary adapter already had the platform id as a local variable (and was logging it), so the data was there — it was just being thrown away at the `router.send` boundary, which builds its own result rather than passing the callback's through.

## Summary

`SendResult.ok` gains two optional fields:

- `messageId` — the posted message / thread anchor.
- `messageIds` — every post in order, for sends an adapter splits (long text chunked into multiple posts).

The id is the **same shape an inbound carries as `externalMessageId`**, so it round-trips straight back as a `thread` / `replyTo` with no translation. `router.send` now threads the first successful callback's ids through to its return.

Adapters populate it from values they already captured: slack-bot \`ts\` (first chunk is the anchor, all chunks in \`messageIds\`), discord-bot message id, telegram-bot \`message_id\` (stringified to match the inbound shape), webex/webex-bot ref, line \`message_id\`, kakaotalk \`log_id\` (the text send is the reply target). GitHub is the one adapter that needed extra work — it now parses the REST comment id and the GraphQL discussion-comment id it already queried but discarded.

**Why optional, not required:** legacy slack/discord user-account adapters void-iterate their SDK sends and never capture a return; Slack/Discord attachment uploads produce a file id, not a threadable message id. Those omit both fields, and callers treat a missing id as "not available", never as an error — so no adapter is forced to fabricate an id it doesn't have.

**Why \`messageId\` is the *first* chunk:** for chunked sends it's the thread parent (slack-bot already anchors follow-up chunks to it), which is what an agent needs to keep posting into one thread. KakaoTalk is the deliberate exception — it sends attachments before text, so the text post (last id) is the reply target; that's commented at the call site.

## What this does NOT do

- Does not add a new \`thread\`/\`reply\` parameter or change how sends are addressed — agents already pass \`thread\`; this just gives them the value to pass.
- Does not surface attachment/file ids (Slack file id, Discord upload id) — those aren't threadable message anchors.
- Does not touch the legacy slack/discord user-account adapters' SDK call sites (they don't capture a return); they simply omit the id.

## Review notes

- Load-bearing change: \`src/channels/router.ts\` — \`router.send\` now captures \`messageId\`/\`messageIds\` from the first \`result.ok\` callback and returns them; previously it rebuilt \`{ ok: true }\`. Verify the invariant that an adapter returning a bare \`{ ok: true }\` still yields a bare \`{ ok: true }\` (covered by a router test).
- The contract is documented on the \`SendResult\` type in \`src/channels/types.ts\`.
- Round-trip safety: telegram (\`String(message_id)\`) and github (\`String(id)\`) are stringified to match the exact \`externalMessageId\` format the inbound classifiers produce, so an id fed back as \`thread\` resolves.
- Tests assert the new shape per adapter, the router pass-through and omit cases, and the end-to-end flow through \`channel_reply\` (github line-comment integration test).