### PR TITLE
fix(channels): settle persist chain in flushDebounce to kill flaky test

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -372,23 +372,13 @@ async function waitFor(predicate: () => boolean): Promise<void> {
   throw new Error('condition not met')
 }
 
-async function waitForPersistedLastInboundAt(agentDir: string, expected: number): Promise<void> {
-  // Wall-clock-bounded poll, not iteration-bounded. The original 20-iteration
-  // × 1ms-sleep budget (~20ms total) was tight enough to lose the race
-  // against tmpdir fs persistence under `bun test --parallel` contention.
-  // The persistence chain is route -> flushDebounce -> writeFile(atomic
-  // temp + rename); each fs op can stall hundreds of ms when libuv's
-  // threadpool is saturated across 18 workers. 2s is the same shape every
-  // other waitFor helper in the repo uses (see scripts/require-parallel.ts
-  // for the global-timeout rationale).
-  const deadline = performance.now() + 2_000
-  while (performance.now() < deadline) {
-    const loaded = await loadChannelSessions(agentDir)
-    if (loaded[0]?.lastInboundAt === expected) return
-    await new Promise((resolve) => setTimeout(resolve, 5))
-  }
+async function expectPersistedLastInboundAt(agentDir: string, expected: number): Promise<void> {
+  // No poll: callers always flushDebounce() first, which now awaits the persist
+  // chain, so the lastInboundAt write has already landed on disk. Polling here
+  // was the source of the Windows-CI flake — a tight wall-clock budget racing
+  // tmpdir fs latency.
   const loaded = await loadChannelSessions(agentDir)
-  throw new Error(`lastInboundAt persisted as ${String(loaded[0]?.lastInboundAt)}, expected ${expected}`)
+  expect(loaded[0]?.lastInboundAt).toBe(expected)
 }
 
 const KEY: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null }
@@ -619,7 +609,7 @@ describe('ChannelRouter session lifecycle', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(sessions).toHaveLength(1)
-    await waitForPersistedLastInboundAt(dir, 1000 + SESSION_FRESHNESS_TTL_MS)
+    await expectPersistedLastInboundAt(dir, 1000 + SESSION_FRESHNESS_TTL_MS)
     const loaded = await loadChannelSessions(dir)
     expect(loaded[0]?.sessionId).toBe('ses_fake_1')
     expect(loaded[0]?.lastInboundAt).toBe(1000 + SESSION_FRESHNESS_TTL_MS)
@@ -754,12 +744,12 @@ describe('ChannelRouter session lifecycle', () => {
 
     await router.route(inbound({ externalMessageId: 'm1' }))
     await router.__testing!.flushDebounce(KEY)
-    await waitForPersistedLastInboundAt(dir, 1000)
+    await expectPersistedLastInboundAt(dir, 1000)
 
     nowRef.value = 2000
     await router.route(inbound({ externalMessageId: 'm2', text: 'second' }))
     await router.__testing!.flushDebounce(KEY)
-    await waitForPersistedLastInboundAt(dir, 2000)
+    await expectPersistedLastInboundAt(dir, 2000)
   })
 
   test('stop() flushes the fire-and-forget persist before returning', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4658,6 +4658,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         }
         live.firstUnprocessedAt = 0
         await drain(live)
+        // Settle the fire-and-forget `void persist()` from scheduleDebouncedDrain
+        // (the lastInboundAt write). Draining alone doesn't await that promise, so
+        // a test reading sessions.json right after would race the disk write — the
+        // flake that forced wall-clock polling on slow (Windows CI) filesystems.
+        await persistChain
       },
       fireTypingHeartbeat: async (key: ChannelKey, phase: 'tick' | 'stop' = 'tick') => {
         const live = liveSessions.get(channelKeyId(key))


### PR DESCRIPTION
## Background

The `lastInboundAt persisted to sessions.json after every engaged inbound` test in `src/channels/router.test.ts` was intermittently failing on the Windows CI job with:

```
waitForPersistedLastInboundAt -> "lastInboundAt persisted as ..., expected 2000"
```

Failing run: https://github.com/typeclaw/typeclaw/actions/runs/28019631542/job/82932421098

Root cause: `scheduleDebouncedDrain` persists the `lastInboundAt` mapping update via a fire-and-forget `void persist()`. The `flushDebounce` test helper (in the `__testing` export block) cleared the debounce timer and awaited `drain(live)`, but never awaited that persist promise — leaving the write in flight when the test read `sessions.json`. On Linux the tmpdir write landed fast enough to pass; on Windows CI the filesystem latency was enough to lose the race.

## Summary

`flushDebounce` now awaits `persistChain` after draining. `persistChain` is the same serialized-write chain that `stop()` and `tearDownAllLive()` already drain, so the write is guaranteed on disk when `flushDebounce` returns — no wall-clock dependency.

With the write deterministic, the poll-based test helper `waitForPersistedLastInboundAt` (timeout loop + `readFileSync`) is replaced by `expectPersistedLastInboundAt`: a direct read + `expect(...).toBe(expected)`. All three call sites updated.

Key decision: `persistChain` was already the right serialization primitive — `stop()` depends on it for exactly this guarantee. Reusing it in `flushDebounce` closes the gap without introducing a second drain mechanism.

## Preview

N/A — no user-visible output change.

## What this does NOT do

- Does not change how `scheduleDebouncedDrain` or `persist()` work in production — the fire-and-forget pattern stays; only the test helper gains the await.
- Does not add any new timeout or retry logic.

## Review notes

- **Load-bearing change:** `flushDebounce` in `src/channels/router.ts` gains `await persistChain` after `await drain(live)`. One line.
- **Test simplification:** `waitForPersistedLastInboundAt` (poll loop, ~15 lines) → `expectPersistedLastInboundAt` (direct assert, ~4 lines). The rename signals that the synchronization guarantee moved out of the helper and into `flushDebounce`.
- Local gate green: `typecheck` (clean), `lint` (0 errors), `format:check` (clean), full test suite (9921 pass, 1 skip, 0 fail). The previously-flaky test ran 5× in a row under `--parallel`: pass every time.