### PR TITLE
feat(channels): surface webex upload refs on send results

### DIFF
--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -99,7 +99,7 @@ describe('webex outbound', () => {
 
     const result = await cb(outbound({ text: 'caption', thread: 'root-1', attachments: [{ path: '/tmp/a.txt' }] }))
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, messageId: 'up-1', messageIds: ['up-1'] })
     expect(sends).toEqual([])
     expect(uploads).toEqual([{ roomId: 'room-1', filename: 'a.txt', text: 'caption', parentId: 'root-1' }])
   })
@@ -113,10 +113,11 @@ describe('webex outbound', () => {
       readFile: async (path) => ({ content: new Blob(['data']), filename: path.split('/').pop() ?? 'x' }),
     })
 
-    await cb(
+    const result = await cb(
       outbound({ text: 'caption', thread: 'root-1', attachments: [{ path: '/tmp/a.txt' }, { path: '/tmp/b.txt' }] }),
     )
 
+    expect(result).toEqual({ ok: true, messageId: 'up-1', messageIds: ['up-1', 'up-2'] })
     expect(uploads).toEqual([
       { roomId: 'room-1', filename: 'a.txt', text: 'caption', parentId: 'root-1' },
       { roomId: 'room-1', filename: 'b.txt', text: undefined, parentId: 'root-1' },
@@ -134,7 +135,7 @@ describe('webex outbound', () => {
 
     const result = await cb(outbound({ text: '', attachments: [{ path: '/tmp/a.txt' }] }))
 
-    expect(result).toEqual({ ok: true })
+    expect(result).toEqual({ ok: true, messageId: 'up-1', messageIds: ['up-1'] })
     expect(uploads).toEqual([{ roomId: 'room-1', filename: 'a.txt', text: undefined, parentId: undefined }])
   })
 

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -107,6 +107,7 @@ export function createOutboundCallback(deps: {
 
     try {
       if (attachments.length > 0) {
+        const uploadedRefs: string[] = []
         for (const [index, attachment] of attachments.entries()) {
           const path = resolvePath ? resolvePath(attachment.path) : attachment.path
           const file = await readFile(path)
@@ -116,9 +117,11 @@ export function createOutboundCallback(deps: {
             ...(carriesText ? { text } : {}),
             ...(parentId !== undefined ? { parentId } : {}),
           })
+          uploadedRefs.push(sent.ref)
           logger.info(`[webex-bot] uploaded id=${sent.ref} filename=${file.filename} ${tag}`)
         }
-        return { ok: true }
+        // First upload carries the text and is the thread parent, so it is the reply anchor.
+        return { ok: true, messageId: uploadedRefs[0], messageIds: uploadedRefs }
       }
 
       const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)

--- a/src/channels/adapters/webex.test.ts
+++ b/src/channels/adapters/webex.test.ts
@@ -4,10 +4,16 @@ import type { WebexListener, WebexMessage } from 'agent-messenger/webex'
 
 import type { ChannelRouter } from '@/channels/router'
 import { channelsSchema } from '@/channels/schema'
-import type { InboundMessage } from '@/channels/types'
+import type { InboundMessage, OutboundMessage } from '@/channels/types'
 import type { WebexAccountRecord } from '@/secrets/schema'
 
-import { createTypingCallback, createWebexAdapter, createWebexHistoryCallback, type WebexAdapterLogger } from './webex'
+import {
+  createOutboundCallback,
+  createTypingCallback,
+  createWebexAdapter,
+  createWebexHistoryCallback,
+  type WebexAdapterLogger,
+} from './webex'
 import type { WebexInboundMessage } from './webex-classify'
 
 const config = channelsSchema.parse({ webex: {} }).webex!
@@ -105,6 +111,129 @@ function router(): ChannelRouter & { routed: InboundMessage[]; registered: strin
     unregisterMembership: (adapter: string) => unregistered.push(`membership:${adapter}`),
   } as unknown as ChannelRouter & { routed: InboundMessage[]; registered: string[]; unregistered: string[] }
 }
+
+function outbound(overrides: Partial<OutboundMessage> = {}): OutboundMessage {
+  return { adapter: 'webex', workspace: 'room-1', chat: 'room-1', text: 'hello', ...overrides }
+}
+
+function webexMessage(overrides: Partial<WebexMessage> = {}): WebexMessage {
+  return {
+    id: 'm',
+    ref: 'm',
+    roomId: 'room-1',
+    roomRef: 'room-1',
+    roomType: 'group',
+    text: 'hi',
+    personId: 'p',
+    personRef: 'p',
+    personEmail: 'p@example.com',
+    created: '2026-01-01T00:00:00.000Z',
+    files: [],
+    ...overrides,
+  }
+}
+
+describe('webex outbound', () => {
+  function outboundClient() {
+    const sends: Array<{ roomId: string; text: string; parentId?: string }> = []
+    const uploads: Array<{ roomId: string; filename: string; text?: string; parentId?: string }> = []
+    return {
+      sends,
+      uploads,
+      client: {
+        sendMessage: async (roomId: string, text: string, options?: { parentId?: string }) => {
+          sends.push({ roomId, text, parentId: options?.parentId })
+          return webexMessage({ ref: 'sent', text })
+        },
+        uploadFile: async (
+          roomId: string,
+          file: { content: Blob; filename: string },
+          options?: { text?: string; parentId?: string },
+        ) => {
+          uploads.push({ roomId, filename: file.filename, text: options?.text, parentId: options?.parentId })
+          return webexMessage({ ref: `up-${uploads.length}` })
+        },
+      },
+    }
+  }
+
+  test('returns the sent message ref as messageId for a plain-text send', async () => {
+    const { client } = outboundClient()
+    const cb = createOutboundCallback({ client, logger: logger(), formatChannelTag: async () => 'room=room-1' })
+
+    const result = await cb(outbound({ text: 'hi' }))
+
+    expect(result).toEqual({ ok: true, messageId: 'sent', messageIds: ['sent'] })
+  })
+
+  test('surfaces the upload ref as the anchor for a text+file send', async () => {
+    const { sends, uploads, client } = outboundClient()
+    const cb = createOutboundCallback({
+      client,
+      logger: logger(),
+      formatChannelTag: async () => 'room=room-1',
+      readFile: async (path) => ({ content: new Blob(['data']), filename: path.split('/').pop() ?? 'x' }),
+    })
+
+    const result = await cb(outbound({ text: 'caption', thread: 'root-1', attachments: [{ path: '/tmp/a.txt' }] }))
+
+    expect(result).toEqual({ ok: true, messageId: 'up-1', messageIds: ['up-1'] })
+    expect(sends).toEqual([])
+    expect(uploads).toEqual([{ roomId: 'room-1', filename: 'a.txt', text: 'caption', parentId: 'root-1' }])
+  })
+
+  test('lists every upload ref in send order for a multi-file send', async () => {
+    const { uploads, client } = outboundClient()
+    const cb = createOutboundCallback({
+      client,
+      logger: logger(),
+      formatChannelTag: async () => 'room=room-1',
+      readFile: async (path) => ({ content: new Blob(['data']), filename: path.split('/').pop() ?? 'x' }),
+    })
+
+    const result = await cb(
+      outbound({ text: 'caption', thread: 'root-1', attachments: [{ path: '/tmp/a.txt' }, { path: '/tmp/b.txt' }] }),
+    )
+
+    expect(result).toEqual({ ok: true, messageId: 'up-1', messageIds: ['up-1', 'up-2'] })
+    expect(uploads).toEqual([
+      { roomId: 'room-1', filename: 'a.txt', text: 'caption', parentId: 'root-1' },
+      { roomId: 'room-1', filename: 'b.txt', text: undefined, parentId: 'root-1' },
+    ])
+  })
+
+  test('surfaces the upload ref for an attachment-only send', async () => {
+    const { uploads, client } = outboundClient()
+    const cb = createOutboundCallback({
+      client,
+      logger: logger(),
+      formatChannelTag: async () => 'room=room-1',
+      readFile: async (path) => ({ content: new Blob(['data']), filename: path.split('/').pop() ?? 'x' }),
+    })
+
+    const result = await cb(outbound({ text: '', attachments: [{ path: '/tmp/a.txt' }] }))
+
+    expect(result).toEqual({ ok: true, messageId: 'up-1', messageIds: ['up-1'] })
+    expect(uploads).toEqual([{ roomId: 'room-1', filename: 'a.txt', text: undefined, parentId: undefined }])
+  })
+
+  test('returns ok false when an upload fails', async () => {
+    const cb = createOutboundCallback({
+      client: {
+        sendMessage: async () => webexMessage({ ref: 'unused' }),
+        uploadFile: async () => Promise.reject(new Error('upload boom')),
+      },
+      logger: logger(),
+      formatChannelTag: async () => 'room=room-1',
+      readFile: async () => ({ content: new Blob(['data']), filename: 'a.txt' }),
+    })
+
+    await expect(cb(outbound({ text: '', attachments: [{ path: '/tmp/a.txt' }] }))).resolves.toEqual({
+      ok: false,
+      error: 'upload boom',
+    })
+  })
+})
 
 describe('createWebexAdapter', () => {
   test('start logs in with account token and wires listener/router callbacks', async () => {

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -114,6 +114,7 @@ export function createOutboundCallback(deps: {
 
     try {
       if (attachments.length > 0) {
+        const uploadedRefs: string[] = []
         for (const [index, attachment] of attachments.entries()) {
           const path = resolvePath ? resolvePath(attachment.path) : attachment.path
           const file = await readFile(path)
@@ -123,9 +124,11 @@ export function createOutboundCallback(deps: {
             ...(carriesText ? { text } : {}),
             ...(parentId !== undefined ? { parentId } : {}),
           })
+          uploadedRefs.push(sent.ref)
           logger.info(`[webex] uploaded id=${sent.ref} filename=${file.filename} ${tag}`)
         }
-        return { ok: true }
+        // First upload carries the text and is the thread parent, so it is the reply anchor.
+        return { ok: true, messageId: uploadedRefs[0], messageIds: uploadedRefs }
       }
 
       const sent = await client.sendMessage(msg.chat, text, parentId !== undefined ? { parentId } : undefined)


### PR DESCRIPTION
## Background

Follow-up to #1044, which surfaced the posted message id on `SendResult` across adapters. That PR merged with one unresolved change-request: the **Webex attachment-send paths still returned a bare `{ ok: true }`**, dropping every `uploadFile` message ref.

`uploadFile` hands back a threadable message ref (unlike Discord/Telegram bare uploads, where attachments land with no reply anchor), and both adapters already captured it as `const sent = await client.uploadFile(...)` and logged `sent.ref` — it was just being thrown away after the loop. That left an agent unable to thread a follow-up onto an attachment-only, text+file, or multi-file send.

## Summary

Both `src/channels/adapters/webex.ts` and `src/channels/adapters/webex-bot.ts` now accumulate each upload's `sent.ref` in send order and return `{ ok: true, messageId: uploadedRefs[0], messageIds: uploadedRefs }`, mirroring the existing text-send path.

The first upload carries the text and is the thread parent, so it is the reply anchor (`messageId`) — consistent with the adapter-specific reply-anchor semantics documented on `SendResult` in `src/channels/types.ts`. `messageIds` lists every upload in send order.

## Tests

- **webex.ts** had no direct outbound unit tests, so this adds a `describe('webex outbound')` block covering: text-only (baseline `messageId`), text+file, multi-file, attachment-only, and upload-failure.
- **webex-bot.ts** upload assertions updated: text+file and attachment-only now assert `{ ok: true, messageId: 'up-1', messageIds: ['up-1'] }`, and the multi-file test now asserts the result shape `messageIds: ['up-1', 'up-2']` (previously only checked the upload calls).

## Verification

```
bun run typecheck   # clean
bun run lint        # 0 errors (pre-existing warnings only)
bun run format      # clean
bun test --parallel src/channels/adapters/webex.test.ts src/channels/adapters/webex-bot.test.ts   # 42 pass
```
