### PR TITLE
fix(github): stop duplicate PR review verdicts (cooldown + sibling-session liveness)

### DIFF
--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -59,6 +59,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     executeCommand: async () => ({ kind: 'no-live-session' }),
     getSelfAliases: () => [],
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -40,6 +40,7 @@ function fakeRouter(react: (req: ReactionRequest) => Promise<ReactionResult>): C
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     resumeRestartHandoff: async () => {},
   } as unknown as ChannelRouter

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -55,6 +55,7 @@ function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: 
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -63,6 +63,7 @@ function fakeRouter(
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -64,6 +64,7 @@ function fakeRouter(handlers: {
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -53,6 +53,7 @@ function fakeRouter(
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -81,6 +81,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -58,6 +58,7 @@ function fakeRouter(
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: (args) => {
       opts.markCalls?.push({ parentSessionId: args.parentSessionId, reason: args.reason })
       return opts.markResult ?? { kind: 'recorded', keyId: 'discord-bot:g1:c1' }

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.test.ts
@@ -220,7 +220,7 @@ describe('review verdict idempotency guard', () => {
   // done) but GitHub's reviews read still lags, reporting NONE — the exact gap that
   // landed two APPROVEs on PR #691. The resolver returns NONE so these exercise the
   // raw-NONE path the shield is allowed to override.
-  const LAG_WINDOW_MS = 120_000
+  const LAG_WINDOW_MS = 5 * 60_000
   function makeShaGuard(headSha: string | null, now?: () => number) {
     return createApproveIdempotencyGuard({
       resolveEffectiveApproval: async () => ({ ok: true, effective: 'NONE' }),
@@ -348,7 +348,7 @@ describe('review verdict idempotency guard', () => {
     }
   })
 
-  test('a legitimate re-APPROVE just past the 2-minute window is allowed', async () => {
+  test('a legitimate re-APPROVE just past the 5-minute window is allowed', async () => {
     let clock = 1_000
     const g = makeShaGuard('sha-abc', () => clock)
     await g.guard({ callId: 'a1', workspace: WS, prNumber: 42, verdict: 'APPROVE' })
@@ -356,6 +356,69 @@ describe('review verdict idempotency guard', () => {
     clock += LAG_WINDOW_MS + 1
     const after = await g.guard({ callId: 'a2', workspace: WS, prNumber: 42, verdict: 'APPROVE' })
     expect(after).toBeNull()
+  })
+
+  // The cooldown extension (PR #1042 incident): thread fan-out spread three
+  // same-commit APPROVEs over ~2 minutes, each AFTER GitHub had indexed the
+  // prior ones — so the standing-verdict read no longer returned a bare NONE for
+  // the lag shield to override, yet the redundant verdict still landed. The
+  // cooldown now fires on any same-verdict + same-head land within the window,
+  // regardless of what GitHub's effective read reports, and the window is 5 min.
+  test('blocks a same-commit same-verdict re-APPROVE within the cooldown even when GitHub already reports the standing APPROVED', async () => {
+    // given: an APPROVE landed at sha-abc and GitHub has since indexed it
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective: 'APPROVED' }),
+      resolveHeadSha: async () => 'sha-abc',
+    })
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 50, verdict: 'APPROVE' })
+    await g.release({ callId: 'a1', succeeded: true })
+    // when: a fan-out sibling fires the same verdict on the same head minutes later
+    const dup = await g.guard({ callId: 'a2', workspace: WS, prNumber: 50, verdict: 'APPROVE' })
+    // then: the cooldown blocks the redundant duplicate (Layer 2 already blocks
+    // this standing case too, but the cooldown must independently hold)
+    expect(dup?.block).toBe(true)
+  })
+
+  test('the cooldown window is 5 minutes: a same-commit re-APPROVE blocks at 4m59s and passes at 5m01s', async () => {
+    let clock = 1_000
+    const g = makeShaGuard('sha-abc', () => clock)
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 51, verdict: 'APPROVE' })
+    await g.release({ callId: 'a1', succeeded: true })
+    // just inside the 5-minute window — still blocked
+    clock += 5 * 60_000 - 1_000
+    const inside = await g.guard({ callId: 'a2', workspace: WS, prNumber: 51, verdict: 'APPROVE' })
+    expect(inside?.block).toBe(true)
+    // just outside the 5-minute window — genuine re-review allowed
+    clock += 2_000
+    const outside = await g.guard({ callId: 'a3', workspace: WS, prNumber: 51, verdict: 'APPROVE' })
+    expect(outside).toBeNull()
+  })
+
+  test('cooldown does not block a genuine DISMISSED-then-reapprove on the same commit (35287f99 invariant holds)', async () => {
+    // given: an APPROVE landed at sha-abc
+    let effective: EffectiveVerdict = 'NONE'
+    const g = createApproveIdempotencyGuard({
+      resolveEffectiveApproval: async () => ({ ok: true, effective }),
+      resolveHeadSha: async () => 'sha-abc',
+    })
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 52, verdict: 'APPROVE' })
+    await g.release({ callId: 'a1', succeeded: true })
+    // when: the approval is genuinely dismissed and a fresh re-APPROVE fires on
+    // the SAME commit inside the cooldown window
+    effective = 'DISMISSED'
+    const reapprove = await g.guard({ callId: 'a2', workspace: WS, prNumber: 52, verdict: 'APPROVE' })
+    // then: a real dismissal is a legitimate reason to re-approve — the cooldown
+    // must not strand it (DISMISSED is decisive, not a redundant duplicate)
+    expect(reapprove).toBeNull()
+  })
+
+  test('cooldown allows a flipped verdict on the same commit even within the window', async () => {
+    const g = makeShaGuard('sha-abc')
+    await g.guard({ callId: 'a1', workspace: WS, prNumber: 53, verdict: 'APPROVE' })
+    await g.release({ callId: 'a1', succeeded: true })
+    // a REQUEST_CHANGES after an APPROVE is a real supersession, never a duplicate
+    const flip = await g.guard({ callId: 'a2', workspace: WS, prNumber: 53, verdict: 'REQUEST_CHANGES' })
+    expect(flip).toBeNull()
   })
 
   test('noteLandedReview arms the shield with no prior reservation (backstop path)', async () => {

--- a/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
+++ b/src/bundled-plugins/github-cli-auth/approve-idempotency.ts
@@ -70,25 +70,35 @@ function duplicatesStanding(verdict: ReviewVerdict, effective: EffectiveVerdict)
   return verdict === 'APPROVE' ? effective === 'APPROVED' : effective === 'CHANGES_REQUESTED'
 }
 
+// Whether the duplicate-review cooldown may fire for this GitHub state. Only the
+// AMBIGUOUS states qualify: a bare NONE (read lag) or the SAME standing verdict
+// (post-indexing fan-out). A DISMISSED or the opposite decisive verdict is a real
+// supersession that legitimizes a fresh same-verdict review, so the cooldown is
+// skipped — preserving the 35287f99 invariant against stranding a re-verdict.
+function cooldownApplies(verdict: ReviewVerdict, effective: EffectiveVerdict): boolean {
+  return effective === 'NONE' || duplicatesStanding(verdict, effective)
+}
+
 // How long a reservation may sit before it is treated as abandoned. A normal
 // `gh` review submit completes in seconds; this only guards against a tool.after
 // that never fires (crash mid-command), so it must outlast a slow command yet
 // never strand a PR for long.
 const LEASE_TTL_MS = 5 * 60_000
 
-// How long a just-landed verdict is trusted to explain a GitHub `NONE` as
-// read-after-write lag rather than a genuine absence. GitHub's `/pulls/<n>/reviews`
-// list lags a write by up to ~10s, so a second engagement turn firing in that
-// window reads NONE and would land a duplicate. Observed duplicates were ~10-18s
-// apart originally; a later fan-out incident spread FOUR sequential APPROVEs over
-// ~15s (one channel session per inline review thread), each ~3-7s after the last —
-// well inside the read lag yet beyond a single turn. 120s gives margin for that
-// thread fan-out plus slow API indexing without turning the shield into a human-
-// facing rate limit (a legitimate re-verdict after a new push carries a new head
-// SHA and bypasses this entirely; staying under ~5min avoids blocking genuine
-// re-reviews). This window only shadows a raw NONE on the SAME verdict (+ same or
-// uncertain head) — a DISMISSED/CHANGES_REQUESTED/flipped-verdict all bypass it.
-const RECENT_LANDED_TTL_MS = 120_000
+// How long a just-landed verdict suppresses a redundant same-verdict re-submit on
+// the same head — a duplicate-review cooldown. It started as a narrow lag shield
+// for GitHub's ~10-18s read-after-write lag (the original ~10-18s-apart duplicates
+// on PR #691), but the PR #1042 thread fan-out spread same-commit APPROVEs over ~2
+// minutes — each one AFTER GitHub had already indexed the prior, so the
+// standing-verdict read no longer returned a bare NONE for a lag-only shield to
+// catch, yet the redundant verdict still landed. So the window now also fires when
+// GitHub reports the standing verdict, and is widened to 5 minutes to cover slow
+// sequential fan-out. It only ever shadows the SAME verdict on the SAME (or
+// uncertain) head: a DISMISSED, the opposite decisive verdict, a flipped verdict,
+// and a new-push head all bypass it, so a genuine re-review is never stranded. 5min
+// stays well under the lease TTL and short enough that a deliberate human-driven
+// re-approval of the identical commit is the only thing it can delay.
+const RECENT_LANDED_TTL_MS = 5 * 60_000
 
 type Reservation = {
   key: string
@@ -204,11 +214,23 @@ export function createApproveIdempotencyGuard(deps: {
         return { block: true, reason: duplicateReason(args.verdict) }
       }
 
-      // Layer 3: only a raw NONE from a successful read is ambiguous — it can mean
-      // "no review" or "our just-landed review not yet indexed". A recent same
-      // verdict on the same head resolves it to lag and blocks the duplicate. Any
-      // non-NONE state already decided above, so this never overrides a supersession.
-      if (remote.ok && remote.effective === 'NONE' && recentlyLandedSame(key, args.verdict, headSha, now)) {
+      // Layer 3 — duplicate-review cooldown. A recently-landed SAME verdict on the
+      // SAME (or uncertain) head blocks a redundant re-submit for the window. It
+      // fires on a bare NONE (read-after-write lag, the original shield) AND on the
+      // now-indexed SAME standing verdict (the PR #1042 fan-out, where siblings fired
+      // minutes apart after indexing) — `duplicatesStanding` above already returned
+      // here for that case, so reaching this line on a same-standing-verdict means
+      // only that the lease-released duplicate is being re-tried; either way the
+      // cooldown holds. It must NOT fire on a DISMISSED or the opposite decisive
+      // verdict: those are genuine supersessions, so the cooldown is gated to the
+      // ambiguous states (NONE, or the same standing verdict) and skipped for any
+      // decisive state that contradicts a redundant re-submit. A read error skips it
+      // (fails open) so a transient failure cannot strand a re-verdict.
+      if (
+        remote.ok &&
+        cooldownApplies(args.verdict, remote.effective) &&
+        recentlyLandedSame(key, args.verdict, headSha, now)
+      ) {
         releaseReservation(args.callId, reservation)
         return { block: true, reason: duplicateReason(args.verdict) }
       }

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -72,6 +72,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
+    injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/channels/github-review-turn-ledger.test.ts
+++ b/src/channels/github-review-turn-ledger.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 
 import {
+  __resetReviewObserverForTest,
   hasResolvedThread,
   hasReview,
   recordResolvedThread,
   recordReview,
   resetReviewTurn,
+  setReviewObserver,
 } from './github-review-turn-ledger'
 
 const S1 = 'ses_one'
@@ -15,6 +17,7 @@ const WS = 'acme/widgets'
 afterEach(() => {
   resetReviewTurn(S1)
   resetReviewTurn(S2)
+  __resetReviewObserverForTest()
 })
 
 describe('review ledger', () => {
@@ -44,6 +47,39 @@ describe('review ledger', () => {
     resetReviewTurn(S1)
     expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(false)
     expect(hasReview({ sessionId: S2, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(true)
+  })
+})
+
+describe('review observer', () => {
+  test('fires the observer with the landed verdict on recordReview', () => {
+    const seen: unknown[] = []
+    setReviewObserver((args) => seen.push(args))
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(seen).toEqual([{ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' }])
+  })
+
+  test('a thrown observer never breaks the ledger record', () => {
+    setReviewObserver(() => {
+      throw new Error('boom')
+    })
+    expect(() => recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).not.toThrow()
+    // the record still landed despite the observer throwing
+    expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(true)
+  })
+
+  test('__resetReviewObserverForTest detaches the observer', () => {
+    const seen: unknown[] = []
+    setReviewObserver((args) => seen.push(args))
+    __resetReviewObserverForTest()
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(seen).toEqual([])
+  })
+
+  test('recordResolvedThread does not fire the verdict observer', () => {
+    const seen: unknown[] = []
+    setReviewObserver((args) => seen.push(args))
+    recordResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '555' })
+    expect(seen).toEqual([])
   })
 })
 

--- a/src/channels/github-review-turn-ledger.ts
+++ b/src/channels/github-review-turn-ledger.ts
@@ -8,11 +8,34 @@
 
 export type ReviewVerdict = 'APPROVE' | 'REQUEST_CHANGES'
 
+export type ReviewObserver = (args: {
+  sessionId: string
+  workspace: string
+  prNumber: number
+  verdict: ReviewVerdict
+}) => void
+
 type PrKey = string
 type ThreadKey = string
 
 const reviewsByPr = new Map<PrKey, Set<ReviewVerdict>>()
 const resolvedThreads = new Set<ThreadKey>()
+
+// A single process-wide observer notified AFTER a verdict is recorded, so the
+// run-side wiring can fan a landed verdict out over the broadcast bus to sibling
+// PR sessions (see github-verdict-activity.ts) WITHOUT giving the github-cli-auth
+// plugin stream access. Registered once at boot from run/index.ts. The ledger
+// stays the single seam where "a formal verdict happened" is known across the
+// plugin/channels boundary, which is why it owns this hook.
+let reviewObserver: ReviewObserver | null = null
+
+export function setReviewObserver(observer: ReviewObserver | null): void {
+  reviewObserver = observer
+}
+
+export function __resetReviewObserverForTest(): void {
+  reviewObserver = null
+}
 
 function prKey(sessionId: string, workspace: string, prNumber: number): PrKey {
   return `${sessionId}::${workspace}::${prNumber}`
@@ -41,6 +64,15 @@ export function recordReview(args: {
   const set = reviewsByPr.get(key) ?? new Set<ReviewVerdict>()
   set.add(args.verdict)
   reviewsByPr.set(key, set)
+  // Notify AFTER the record lands and never let an observer failure corrupt the
+  // ledger write — the false-receipt guard depends on this record being durable.
+  if (reviewObserver !== null) {
+    try {
+      reviewObserver(args)
+    } catch {
+      // swallow: a broken broadcast must not break verdict bookkeeping
+    }
+  }
 }
 
 export function hasReview(args: {

--- a/src/channels/github-verdict-activity.test.ts
+++ b/src/channels/github-verdict-activity.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parsePrVerdictActivityPayload, renderPrVerdictStandDownReminder } from './github-verdict-activity'
+
+describe('parsePrVerdictActivityPayload', () => {
+  test('parses a well-formed landed payload', () => {
+    const parsed = parsePrVerdictActivityPayload({
+      kind: 'pr.verdict-activity',
+      workspace: 'acme/widgets',
+      prNumber: 42,
+      verdict: 'APPROVE',
+      sessionId: 'ses_abc',
+    })
+    expect(parsed).toEqual({ workspace: 'acme/widgets', prNumber: 42, verdict: 'APPROVE', sessionId: 'ses_abc' })
+  })
+
+  test('rejects a payload whose kind is not pr.verdict-activity', () => {
+    expect(parsePrVerdictActivityPayload({ kind: 'subagent.completed', workspace: 'a/b', prNumber: 1 })).toBeNull()
+  })
+
+  test('rejects a non-object payload', () => {
+    expect(parsePrVerdictActivityPayload(null)).toBeNull()
+    expect(parsePrVerdictActivityPayload('pr.verdict-activity')).toBeNull()
+  })
+
+  test('rejects a payload missing the routing key (workspace / prNumber)', () => {
+    expect(
+      parsePrVerdictActivityPayload({ kind: 'pr.verdict-activity', verdict: 'APPROVE', sessionId: 'ses_abc' }),
+    ).toBeNull()
+    expect(
+      parsePrVerdictActivityPayload({
+        kind: 'pr.verdict-activity',
+        workspace: 'acme/widgets',
+        verdict: 'APPROVE',
+        sessionId: 'ses_abc',
+      }),
+    ).toBeNull()
+  })
+
+  test('rejects a non-verdict review state (only APPROVE / REQUEST_CHANGES carry duplicate risk)', () => {
+    expect(
+      parsePrVerdictActivityPayload({
+        kind: 'pr.verdict-activity',
+        workspace: 'acme/widgets',
+        prNumber: 42,
+        verdict: 'COMMENT',
+        sessionId: 'ses_abc',
+      }),
+    ).toBeNull()
+  })
+
+  test('rejects a non-integer prNumber', () => {
+    expect(
+      parsePrVerdictActivityPayload({
+        kind: 'pr.verdict-activity',
+        workspace: 'acme/widgets',
+        prNumber: 4.2,
+        verdict: 'APPROVE',
+        sessionId: 'ses_abc',
+      }),
+    ).toBeNull()
+  })
+
+  test('parses a REQUEST_CHANGES verdict', () => {
+    const parsed = parsePrVerdictActivityPayload({
+      kind: 'pr.verdict-activity',
+      workspace: 'acme/widgets',
+      prNumber: 7,
+      verdict: 'REQUEST_CHANGES',
+      sessionId: 'ses_xyz',
+    })
+    expect(parsed?.verdict).toBe('REQUEST_CHANGES')
+  })
+})
+
+describe('renderPrVerdictStandDownReminder', () => {
+  test('names the verdict and PR, and scopes the stand-down to redundant verdicts only', () => {
+    const text = renderPrVerdictStandDownReminder({ prNumber: 42, verdict: 'APPROVE' })
+    expect(text).toContain('<system-reminder>')
+    expect(text).toContain('#42')
+    expect(text).toContain('APPROVE')
+    // verdict-only carve-out: thread replies are still allowed
+    expect(text.toLowerCase()).toContain('inline')
+    // soft wording: a genuine new-evidence verdict is not suppressed
+    expect(text.toLowerCase()).toContain('unless new information')
+  })
+
+  test('renders the REQUEST_CHANGES wording', () => {
+    const text = renderPrVerdictStandDownReminder({ prNumber: 7, verdict: 'REQUEST_CHANGES' })
+    expect(text).toContain('REQUEST_CHANGES')
+    expect(text).toContain('#7')
+  })
+})

--- a/src/channels/github-verdict-activity.ts
+++ b/src/channels/github-verdict-activity.ts
@@ -1,0 +1,60 @@
+import type { ReviewVerdict } from './github-review-turn-ledger'
+
+// A formal review verdict (APPROVE / REQUEST_CHANGES) that LANDED on a PR, fanned
+// out over the broadcast bus so the OTHER live sessions reviewing the same PR
+// stand down from posting their own redundant verdict. The duplicate-review
+// incident was driven by per-thread session fan-out: N sessions for one PR each
+// independently submitted a verdict, blind to the others. The hard idempotency
+// lease + cooldown catch overlapping/near-simultaneous submits; this advisory
+// signal covers the SEQUENTIAL case — a sibling that wakes after another already
+// landed the verdict and would otherwise re-derive and re-submit it.
+//
+// Routing is by { workspace, prNumber } only (the PR is the unit), with sessionId
+// carried so the publisher excludes itself. No channel key — the publish seam is
+// the turn-ledger's recordReview(), which has no channel coordinate, and Oracle's
+// review favored not expanding plugin coupling just to mirror subagent.completed.
+
+export type PrVerdictActivityPayload = {
+  workspace: string
+  prNumber: number
+  verdict: ReviewVerdict
+  sessionId: string
+}
+
+export function parsePrVerdictActivityPayload(payload: unknown): PrVerdictActivityPayload | null {
+  if (payload === null || typeof payload !== 'object') return null
+  const p = payload as {
+    kind?: unknown
+    workspace?: unknown
+    prNumber?: unknown
+    verdict?: unknown
+    sessionId?: unknown
+  }
+  if (p.kind !== 'pr.verdict-activity') return null
+  if (typeof p.workspace !== 'string' || p.workspace === '') return null
+  if (typeof p.prNumber !== 'number' || !Number.isInteger(p.prNumber)) return null
+  if (typeof p.sessionId !== 'string' || p.sessionId === '') return null
+  const verdict = parseVerdict(p.verdict)
+  if (verdict === null) return null
+  return { workspace: p.workspace, prNumber: p.prNumber, verdict, sessionId: p.sessionId }
+}
+
+function parseVerdict(value: unknown): ReviewVerdict | null {
+  return value === 'APPROVE' || value === 'REQUEST_CHANGES' ? value : null
+}
+
+// Advisory and deliberately soft (per the design review): it must not suppress a
+// genuine flipped verdict or a re-review after new commits/evidence, so it forbids
+// only a REDUNDANT same-intent verdict and explicitly preserves inline-thread
+// replies. The hard guards remain the correctness boundary; this only trims wasted
+// sibling work before they fire.
+export function renderPrVerdictStandDownReminder(args: { prNumber: number; verdict: ReviewVerdict }): string {
+  return (
+    `<system-reminder>\n` +
+    `Another session in this agent has already posted a formal ${args.verdict} review for PR #${args.prNumber}. ` +
+    `Do not submit your own ${args.verdict} (or any redundant verdict) for this PR this turn unless new ` +
+    `information genuinely invalidates that result (e.g. new commits, or a different verdict warranted by ` +
+    `fresh evidence). You may still reply to inline review comments / threads as normal.\n` +
+    `</system-reminder>`
+  )
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -16,6 +16,12 @@ export {
 } from './router'
 export { createChannelsReloadable } from './reloadable'
 export {
+  createPrVerdictActivityBridge,
+  type PrVerdictActivityBridge,
+  type PrVerdictActivityBridgeOptions,
+} from './pr-verdict-activity-bridge'
+export { setReviewObserver } from './github-review-turn-ledger'
+export {
   createSubagentCompletionBridge,
   type SubagentCompletionBridge,
   type SubagentCompletionBridgeOptions,

--- a/src/channels/pr-verdict-activity-bridge.test.ts
+++ b/src/channels/pr-verdict-activity-bridge.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createStream } from '@/stream'
+
+import { createPrVerdictActivityBridge } from './pr-verdict-activity-bridge'
+import type { ChannelRouter } from './router'
+
+type Injection = Parameters<ChannelRouter['injectPrVerdictActivity']>[0]
+
+function fakeRouter(): {
+  router: Pick<ChannelRouter, 'injectPrVerdictActivity'>
+  calls: Injection[]
+} {
+  const calls: Injection[] = []
+  return {
+    router: {
+      injectPrVerdictActivity: (args) => {
+        calls.push(args)
+        return { kind: 'delivered', count: 1 }
+      },
+    },
+    calls,
+  }
+}
+
+describe('createPrVerdictActivityBridge', () => {
+  test('pr.verdict-activity broadcast → injectPrVerdictActivity call with same fields', () => {
+    const stream = createStream()
+    const { router, calls } = fakeRouter()
+    createPrVerdictActivityBridge({ stream, router })
+
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'pr.verdict-activity',
+        workspace: 'typeclaw/typeclaw',
+        prNumber: 1042,
+        verdict: 'APPROVE',
+        sessionId: 'ses_pub',
+      },
+    })
+
+    expect(calls).toEqual([
+      { workspace: 'typeclaw/typeclaw', prNumber: 1042, verdict: 'APPROVE', sessionId: 'ses_pub' },
+    ])
+  })
+
+  test('ignores unrelated broadcast payloads', () => {
+    const stream = createStream()
+    const { router, calls } = fakeRouter()
+    createPrVerdictActivityBridge({ stream, router })
+
+    stream.publish({ target: { kind: 'broadcast' }, payload: { kind: 'subagent.completed', parentSessionId: 'x' } })
+    stream.publish({ target: { kind: 'broadcast' }, payload: { kind: 'tunnel-url-changed' } })
+    stream.publish({ target: { kind: 'broadcast' }, payload: { kind: 'pr.verdict-activity', workspace: 'a/b' } })
+
+    expect(calls).toHaveLength(0)
+  })
+
+  test('stop() unsubscribes so later broadcasts are not routed', () => {
+    const stream = createStream()
+    const { router, calls } = fakeRouter()
+    const bridge = createPrVerdictActivityBridge({ stream, router })
+    bridge.stop()
+
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'pr.verdict-activity',
+        workspace: 'typeclaw/typeclaw',
+        prNumber: 1042,
+        verdict: 'REQUEST_CHANGES',
+        sessionId: 'ses_pub',
+      },
+    })
+
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/src/channels/pr-verdict-activity-bridge.ts
+++ b/src/channels/pr-verdict-activity-bridge.ts
@@ -1,0 +1,43 @@
+import type { Stream } from '@/stream'
+
+import { parsePrVerdictActivityPayload } from './github-verdict-activity'
+import type { ChannelRouter } from './router'
+
+export type PrVerdictActivityBridgeLogger = {
+  info: (msg: string) => void
+}
+
+export type PrVerdictActivityBridgeOptions = {
+  stream: Stream
+  router: Pick<ChannelRouter, 'injectPrVerdictActivity'>
+  logger?: PrVerdictActivityBridgeLogger
+}
+
+export type PrVerdictActivityBridge = {
+  stop: () => void
+}
+
+const consoleLogger: PrVerdictActivityBridgeLogger = {
+  info: (msg) => console.log(msg),
+}
+
+// Bridges `pr.verdict-activity` broadcasts on the in-process Stream into a router
+// call so the OTHER live sessions reviewing the same PR get a stand-down reminder
+// once one of them lands a formal verdict. Mirrors the subagent-completion bridge:
+// one broadcast subscriber, self-filtering payload parse, single router call. The
+// verdict reaches the bus via the turn-ledger review observer (src/run/index.ts),
+// because plugins have no direct stream access.
+export function createPrVerdictActivityBridge(options: PrVerdictActivityBridgeOptions): PrVerdictActivityBridge {
+  const logger = options.logger ?? consoleLogger
+  const unsubscribe = options.stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
+    const parsed = parsePrVerdictActivityPayload(msg.payload)
+    if (parsed === null) return
+    const result = options.router.injectPrVerdictActivity(parsed)
+    if (result.count > 0) {
+      logger.info(
+        `[channels] pr-verdict stand-down fanned out to ${result.count} sibling session(s) for ${parsed.workspace}#${parsed.prNumber} verdict=${parsed.verdict}`,
+      )
+    }
+  })
+  return { stop: unsubscribe }
+}

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -11222,3 +11222,101 @@ describe('resumeRestartHandoff', () => {
     expect(originDuringWake.lastInboundAuthorId).toBe('U_OWNER')
   })
 })
+
+describe('injectPrVerdictActivity (PR-keyed verdict liveness)', () => {
+  const WS = 'typeclaw/typeclaw'
+
+  function ghInbound(thread: string | null, over: Partial<InboundMessage> = {}): InboundMessage {
+    return inbound({
+      adapter: 'github',
+      workspace: WS,
+      chat: 'pr:1042',
+      thread,
+      authorId: '931655',
+      authorName: 'devxoul',
+      text: '@typeey please review',
+      isBotMention: true,
+      ...over,
+    })
+  }
+
+  async function spawnTwoSiblingSessions(dir: string) {
+    const { router, sessions } = makeRouter(dir)
+    await router.route(ghInbound(null))
+    await router.__testing!.flushDebounce({ adapter: 'github', workspace: WS, chat: 'pr:1042', thread: null })
+    await router.route(ghInbound('3458942280', { externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce({ adapter: 'github', workspace: WS, chat: 'pr:1042', thread: '3458942280' })
+    return { router, sessions }
+  }
+
+  test('sequential fan-out: a landed verdict stands down the OTHER live pr session, not the publisher', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = await spawnTwoSiblingSessions(dir)
+    expect(sessions).toHaveLength(2)
+    const publisherPrompts = sessions[0]!.prompts.length
+    const siblingPrompts = sessions[1]!.prompts.length
+
+    // when: session 1 (ses_fake_1, thread:null) lands an APPROVE
+    const result = router.injectPrVerdictActivity({
+      workspace: WS,
+      prNumber: 1042,
+      verdict: 'APPROVE',
+      sessionId: 'ses_fake_1',
+    })
+
+    // then: exactly the sibling is nudged; the publisher is excluded
+    expect(result).toEqual({ kind: 'delivered', count: 1 })
+    await waitFor(() => sessions[1]!.prompts.length > siblingPrompts)
+    const reminder = sessions[1]!.prompts.at(-1) ?? ''
+    expect(reminder).toContain('<system-reminder>')
+    expect(reminder).toContain('APPROVE')
+    expect(reminder).toContain('#1042')
+    expect(sessions[0]!.prompts.length).toBe(publisherPrompts)
+  })
+
+  test('publisher-exclusion: a single solo session landing a verdict nudges nobody', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(ghInbound(null))
+    await router.__testing!.flushDebounce({ adapter: 'github', workspace: WS, chat: 'pr:1042', thread: null })
+
+    const result = router.injectPrVerdictActivity({
+      workspace: WS,
+      prNumber: 1042,
+      verdict: 'APPROVE',
+      sessionId: 'ses_fake_1',
+    })
+    expect(result).toEqual({ kind: 'delivered', count: 0 })
+    expect(sessions[0]!.prompts.length).toBe(1)
+  })
+
+  test('scoped by PR: a verdict on a different PR does not touch this PR session', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = await spawnTwoSiblingSessions(dir)
+    const before = sessions.map((s) => s.prompts.length)
+
+    const result = router.injectPrVerdictActivity({
+      workspace: WS,
+      prNumber: 999,
+      verdict: 'APPROVE',
+      sessionId: 'ses_other',
+    })
+    expect(result).toEqual({ kind: 'delivered', count: 0 })
+    expect(sessions.map((s) => s.prompts.length)).toEqual(before)
+  })
+
+  test('scoped by workspace: a same-PR-number verdict in a different repo is ignored', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = await spawnTwoSiblingSessions(dir)
+    const before = sessions.map((s) => s.prompts.length)
+
+    const result = router.injectPrVerdictActivity({
+      workspace: 'other/repo',
+      prNumber: 1042,
+      verdict: 'APPROVE',
+      sessionId: 'ses_other',
+    })
+    expect(result).toEqual({ kind: 'delivered', count: 0 })
+    expect(sessions.map((s) => s.prompts.length)).toEqual(before)
+  })
+})

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -39,6 +39,7 @@ import {
 import { checkFalseReceipt } from './github-false-receipt'
 import { evaluateRereviewGuard } from './github-rereview-guard'
 import { resetReviewTurn } from './github-review-turn-ledger'
+import { renderPrVerdictStandDownReminder } from './github-verdict-activity'
 import {
   MEMBERSHIP_COLD_FETCH_TIMEOUT_MS,
   type MembershipCount,
@@ -1067,6 +1068,19 @@ export type ChannelRouter = {
     error?: string
     channelKey?: { adapter: string; workspace: string; chat: string; thread: string | null }
   }) => { kind: 'delivered'; keyId: string } | { kind: 'no-live-session' }
+  // Fan a LANDED formal review verdict out to the OTHER live sessions reviewing
+  // the same PR so they stand down from posting a redundant verdict. Targets every
+  // live github session whose chat is `pr:<prNumber>` in `workspace`, EXCLUDING the
+  // publisher (`sessionId`). Routes by (workspace, prNumber) across all threads —
+  // the duplicate-review fan-out is exactly the per-thread sibling sessions. The
+  // injected reminder is advisory (verdict-only stand-down); the hard idempotency
+  // guards remain the correctness boundary. Returns how many siblings were nudged.
+  injectPrVerdictActivity: (args: {
+    workspace: string
+    prNumber: number
+    verdict: 'APPROVE' | 'REQUEST_CHANGES'
+    sessionId: string
+  }) => { kind: 'delivered'; count: number }
   // Record that the agent invoked `skip_response` during the current turn
   // for the channel session identified by `parentSessionId`. The reason is
   // logged at INFO level inside `validateChannelTurn` (single log line per
@@ -4534,6 +4548,30 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return { kind: 'no-live-session' }
   }
 
+  const injectPrVerdictActivity = (args: {
+    workspace: string
+    prNumber: number
+    verdict: 'APPROVE' | 'REQUEST_CHANGES'
+    sessionId: string
+  }): { kind: 'delivered'; count: number } => {
+    const chat = `pr:${args.prNumber}`
+    let count = 0
+    for (const live of liveSessions.values()) {
+      if (live.destroyed) continue
+      if (live.key.adapter !== 'github') continue
+      if (live.key.workspace !== args.workspace || live.key.chat !== chat) continue
+      // Self-exclude: the session that just landed the verdict must not be told to
+      // stand down from its own legitimate review.
+      if (live.sessionId === args.sessionId) continue
+      const text = renderPrVerdictStandDownReminder({ prNumber: args.prNumber, verdict: args.verdict })
+      live.pendingSystemReminders.push(text)
+      logger.info(`[channels] ${live.keyId}: pr-verdict stand-down queued pr=${chat} verdict=${args.verdict}`)
+      if (!live.draining) void drain(live)
+      count++
+    }
+    return { kind: 'delivered', count }
+  }
+
   const markTurnSkipped = (args: {
     parentSessionId: string
     reason: string
@@ -4641,6 +4679,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     executeCommand,
     getSelfAliases: computeSelfAliases,
     injectSubagentCompletionReminder,
+    injectPrVerdictActivity,
     markTurnSkipped,
     clearSticky,
     reserveRestartHandoff,

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -28,8 +28,11 @@ import {
   createChannelManager,
   createChannelsReloadable,
   createGithubTokenBridge,
+  createPrVerdictActivityBridge,
   createSubagentCompletionBridge,
+  setReviewObserver,
   type ChannelManager,
+  type PrVerdictActivityBridge,
   type SubagentCompletionBridge,
 } from '@/channels'
 import { createTunnelBridge, type TunnelBridge } from '@/channels/tunnel-bridge'
@@ -667,6 +670,22 @@ export async function startAgent({
     router: channelManager.router,
   })
 
+  // Fan a landed formal review verdict out to the sibling sessions reviewing the
+  // same PR so they stand down from a redundant verdict (the per-thread fan-out
+  // duplicate-review fix). The github-cli-auth plugin records the verdict in the
+  // turn-ledger but has no stream access, so the ledger's review observer is the
+  // seam: it publishes onto the broadcast bus here, and the bridge routes it.
+  const prVerdictActivityBridge: PrVerdictActivityBridge = createPrVerdictActivityBridge({
+    stream,
+    router: channelManager.router,
+  })
+  setReviewObserver((review) => {
+    stream.publish({
+      target: { kind: 'broadcast' },
+      payload: { kind: 'pr.verdict-activity', ...review },
+    })
+  })
+
   reloadRegistry.register(createChannelsReloadable({ manager: channelManager }))
 
   // Two-phase channel restart-resume around adapter startup, to close the race
@@ -863,6 +882,8 @@ export async function startAgent({
     void disposeMaterializedSkills(pluginRuntime)
     tunnelBridge.stop()
     subagentCompletionBridge.stop()
+    prVerdictActivityBridge.stop()
+    setReviewObserver(null)
     await tunnelManager.stop()
     await channelManager.stop()
     await mcpManager?.closeAll()


### PR DESCRIPTION
## Background

The GitHub reviewer bot posts **redundant duplicate review verdicts** on the same PR. On [#1042](https://github.com/typeclaw/typeclaw/pull/1042) it posted three separate `APPROVED` reviews on the same commit within ~2 minutes.

**Root cause — per-thread session fan-out.** Inline review-comment events are keyed into *separate* agent sessions: `inbound.ts` produces `chat: 'pr:<N>'` but `thread: String(rootCommentId)`, while the main PR session uses `thread: null`. Sessions are keyed `(adapter, workspace, chat, thread)`, and the router's in-flight coalescing only dedups within the *same* key — so N thread-sessions for one PR run concurrently, each blind to the others, and each independently submits a verdict.

The existing `approve-idempotency` guard (in-flight lease + GitHub effective-state read + read-lag shield) is the hard correctness boundary at submit time, but nothing made the sibling sessions *aware* of each other.

## What this does

Two layered fixes:

### 1. `fix(github)`: extend the duplicate-review cooldown to 5min and fire on a standing verdict

The lag shield only blocked a same-verdict re-submit when GitHub still reported a bare `NONE` (read-after-write lag). On #1042 the three APPROVEs were spread over ~2 minutes — each *after* GitHub had indexed the prior one, so the standing-verdict read no longer returned `NONE` and the duplicate landed. This widens the window 120s→5min and lets the cooldown fire on the same *standing* verdict, gated by `cooldownApplies()` so a `DISMISSED` or opposite decisive verdict still passes (the 35287f99 supersession invariant).

### 2. `feat(channels)`: stand down sibling PR sessions on a landed verdict

An **advisory liveness signal** over the existing broadcast bus (mirroring the `subagent.completed` bridge):

- When a formal verdict **lands**, the turn-ledger's `recordReview()` notifies a process-wide **review observer**. The `github-cli-auth` plugin has no stream access, so the ledger is the cross-boundary seam.
- `run/index.ts` wires that observer to publish a `pr.verdict-activity` broadcast and runs a bridge that routes it to `router.injectPrVerdictActivity`.
- The router injects a `<system-reminder>` into every live `pr:<N>` session in the same repo **except the publisher** (self-exclusion), telling it to stand down from a **redundant** verdict — while still allowing inline-thread replies, and **not** suppressing a genuine flipped/new-evidence verdict.

**Landed-only, advisory by design.** Per design review: the hard guards already cover the overlap window; `landed` is exactly the signal a later *sequential* sibling needs. This is a coordination layer that *reduces* duplicate attempts — the idempotency lease + cooldown remain the correctness boundary.

## What this does NOT do

Does **not** change the session-keying contract (coalescing per-thread sessions onto one PR session). That's the deeper root cause, but it's a high-blast-radius change touching thread semantics across all channel adapters — out of scope here, deliberately.

## Tests

- `approve-idempotency.test.ts`: 5-min boundary, standing-verdict cooldown, and DISMISSED/flipped-verdict supersession (no regression).
- `github-verdict-activity.test.ts`: payload parsing + soft stand-down wording.
- `github-review-turn-ledger.test.ts`: observer fires/resets; a thrown observer never corrupts the ledger.
- `router.test.ts`: sequential fan-out stands down the sibling not the publisher; publisher-exclusion; PR/workspace scoping.
- `pr-verdict-activity-bridge.test.ts`: broadcast→router routing, payload self-filtering, `stop()` unsubscribe.

`bun run lint` (0 errors) · `format:check` · `typecheck` · `test` — **9961 pass / 0 fail**.
