### PR TITLE
feat(agent): default the deep profile to high thinking level

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -1594,7 +1594,11 @@ describe('subscribeRestartNotice', () => {
 describe('resolveSessionThinkingLevel', () => {
   const REF = 'openai/gpt-5.4-nano' as ModelRef
   const parseModels = (models: Record<string, unknown>): Models => configSchema.parse({ models }).models
-  const resolvedWith = (thinkingLevel?: ResolvedProfile['thinkingLevel']): Pick<ResolvedProfile, 'thinkingLevel'> => ({
+  const resolvedWith = (
+    thinkingLevel?: ResolvedProfile['thinkingLevel'],
+    profile = 'fast',
+  ): Pick<ResolvedProfile, 'thinkingLevel' | 'profile'> => ({
+    profile,
     ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
   })
 
@@ -1618,5 +1622,25 @@ describe('resolveSessionThinkingLevel', () => {
     // resolved.thinkingLevel IS the default's — exercised here directly.
     const models = parseModels({ default: { model: REF, thinkingLevel: 'xhigh' } })
     expect(resolveSessionThinkingLevel(models, resolvedWith('xhigh'), REF)).toBe('xhigh')
+  })
+
+  test('the deep profile defaults to high without its own level', () => {
+    const models = parseModels({ default: REF, deep: REF })
+    expect(resolveSessionThinkingLevel(models, resolvedWith(undefined, 'deep'), REF)).toBe('high')
+  })
+
+  test('the deep default beats a lower global default', () => {
+    const models = parseModels({ default: { model: REF, thinkingLevel: 'low' }, deep: REF })
+    expect(resolveSessionThinkingLevel(models, resolvedWith(undefined, 'deep'), REF)).toBe('high')
+  })
+
+  test('an explicit deep thinkingLevel overrides the built-in high default', () => {
+    const models = parseModels({ default: REF, deep: { model: REF, thinkingLevel: 'xhigh' } })
+    expect(resolveSessionThinkingLevel(models, resolvedWith('xhigh', 'deep'), REF)).toBe('xhigh')
+  })
+
+  test('the high default is scoped to deep — other profiles are unaffected', () => {
+    const models = parseModels({ default: REF, fast: REF })
+    expect(resolveSessionThinkingLevel(models, resolvedWith(undefined, 'fast'), REF)).toBeUndefined()
   })
 })

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -244,17 +244,26 @@ export type CreateSessionResult = {
 }
 
 // A session's reasoning effort layers like the model does: the resolved
-// profile's own `thinkingLevel` → the `default` profile's `thinkingLevel`
-// (the de-facto global default, mirroring how `models.default` is the default
-// model) → the per-provider/SDK default for the active ref. When the requested
-// profile was unknown, `resolved` is already the `default` profile, so the
-// first two terms coincide and the expression still does the right thing.
+// profile's own `thinkingLevel` → the built-in `deep` default → the `default`
+// profile's `thinkingLevel` (the de-facto global default) → the per-provider/SDK
+// default for the active ref. When the requested profile was unknown, `resolved`
+// is already the `default` profile, so those terms coincide and the expression
+// still does the right thing.
+//
+// The `deep` `high` default sits ABOVE `models.default.thinkingLevel` on purpose:
+// lowering the global default must not stop the "think hard" profile from
+// thinking hard. `high` (not `xhigh`) because `xhigh` ~doubles latency and token
+// spend for no agentic-quality gain. An explicit `models.deep.thinkingLevel`
+// still wins — it is the first term.
+const DEEP_PROFILE_DEFAULT_THINKING_LEVEL: ThinkingLevel = 'high'
+
 export function resolveSessionThinkingLevel(
   models: Models,
-  resolved: Pick<ResolvedProfile, 'thinkingLevel'>,
+  resolved: Pick<ResolvedProfile, 'thinkingLevel' | 'profile'>,
   activeRef: ModelRef,
 ): ThinkingLevel | undefined {
-  return resolved.thinkingLevel ?? models.default.thinkingLevel ?? defaultThinkingLevelForRef(activeRef)
+  const deepDefault = resolved.profile === 'deep' ? DEEP_PROFILE_DEFAULT_THINKING_LEVEL : undefined
+  return resolved.thinkingLevel ?? deepDefault ?? models.default.thinkingLevel ?? defaultThinkingLevelForRef(activeRef)
 }
 
 export async function createSession(options: CreateSessionOptions = {}): Promise<AgentSession> {


### PR DESCRIPTION
## Background

The `deep` profile had no built-in reasoning effort, so it deferred to the
`default` profile's level — or the SDK default `medium` — when no explicit
`thinkingLevel` was set on it. A profile named "deep" should think hard out
of the box, without requiring each operator to add per-agent config.

Head-to-head data on real coding tasks shows `xhigh` roughly doubles latency
(+30–40%) and token spend (~2×) vs `high` with no matching agentic-quality gain
(can even regress test-pass rates). OpenAI recommends `high` for agentic coding
and reserves `xhigh` for deep-research / long-rollout scenarios only when evals
show a clear benefit. `high` is the right default.

## Summary

`resolveSessionThinkingLevel` now applies a profile-scoped fallback: when the
active profile is `deep`, the effective thinking level is `high` unless something
higher in the chain already sets it.

**Fallback chain after this change:**

```
profile.thinkingLevel ?? deepDefault('high') ?? global.default.thinkingLevel ?? defaultThinkingLevelForRef(ref)
```

where `deepDefault` is only injected when `profile === 'deep'`. This ordering is
load-bearing: `deepDefault` sits above `global.default.thinkingLevel` so a lowered
global default cannot suppress the deep profile's intent.

**Why `resolveSessionThinkingLevel` and not `defaultThinkingLevelForRef`.**
The request is profile-scoped ("the deep profile thinks hard"), and
`resolveSessionThinkingLevel` is the only seam that knows the profile name
(`ResolvedProfile.profile`). `defaultThinkingLevelForRef` is profile-blind.

**Why `high` and not `xhigh`.** See the Background section — identical rationale.

## What this does NOT do

- Does not change any model's SDK default — `defaultThinkingLevelForRef` still
  returns `undefined` for all refs (reverted to main).
- Does not touch the adaptive attention-escalation path — a frustrated turn can
  still bump to `xhigh` for that single turn; only the deep session default changes.
- Does not affect other profiles (`default`, `fast`, `vision`) — the `high` default
  is scoped strictly to `profile === 'deep'`.
- Does not add new config surface — per-profile `thinkingLevel` already exists and
  still overrides via the first term in the chain.

## Review notes

- **Load-bearing:** the fallback ordering in `resolveSessionThinkingLevel` —
  `deepDefault` is placed before `models.default.thinkingLevel` so a lowered global
  default cannot suppress it. Verify that ordering intent in `src/agent/index.ts`.
- Four new tests cover the critical behaviors: deep defaults to high; deep beats a
  lower global default; an explicit `models.deep.thinkingLevel` overrides it; the
  high default is scoped to deep only (other profiles unaffected).