### PR TITLE
fix(channels): classify peer bots and replies on the discord user adapter

### DIFF
--- a/src/channels/adapters/discord-classify.test.ts
+++ b/src/channels/adapters/discord-classify.test.ts
@@ -1,15 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
-import type { DiscordGatewayMessageCreateEvent } from 'agent-messenger/discord'
-
 import { channelsSchema } from '@/channels/schema'
 
-import { classifyInbound } from './discord-classify'
+import { classifyInbound, type RawDiscordMessageCreateEvent } from './discord-classify'
 
 const config = channelsSchema.parse({ discord: {} }).discord!
 const context = { selfUserId: '100000000000000001', selfAliases: ['typeclaw', '타입클로'] }
 
-function event(overrides: Partial<DiscordGatewayMessageCreateEvent> = {}): DiscordGatewayMessageCreateEvent {
+function event(overrides: Partial<RawDiscordMessageCreateEvent> = {}): RawDiscordMessageCreateEvent {
   return {
     type: 'MESSAGE_CREATE',
     id: '400000000000000004',
@@ -74,5 +72,46 @@ describe('classifyInbound (discord user)', () => {
     expect(english.kind === 'route' && english.payload.isBotMention).toBe(true)
     expect(korean.kind === 'route' && korean.payload.isBotMention).toBe(true)
     expect(korean.kind === 'route' && korean.payload.thread).toBeNull()
+  })
+
+  test('flags peer-bot authors and leaves human authors unflagged', () => {
+    const peerBot = classifyInbound(
+      event({ author: { id: '700000000000000007', username: 'peerbot', bot: true } }),
+      config,
+      context,
+    )
+    const human = classifyInbound(event(), config, context)
+
+    expect(peerBot.kind === 'route' && peerBot.payload.authorIsBot).toBe(true)
+    expect(human.kind === 'route' && human.payload.authorIsBot).toBe(false)
+  })
+
+  test('resolves replies to self via the auto-mention array', () => {
+    const replyToSelf = classifyInbound(
+      event({
+        message_reference: { message_id: '800000000000000008' },
+        mentions: [{ id: '100000000000000001', username: 'self' }],
+        content: '확인했어요?',
+      }),
+      config,
+      context,
+    )
+
+    expect(replyToSelf.kind === 'route' && replyToSelf.payload.replyToBotMessageId).toBe('800000000000000008')
+    expect(replyToSelf.kind === 'route' && replyToSelf.payload.replyToOtherMessageId).toBeNull()
+  })
+
+  test('marks replies to other authors as targeting someone else', () => {
+    const replyToOther = classifyInbound(
+      event({
+        message_reference: { message_id: '800000000000000008' },
+        mentions: [{ id: '600000000000000006', username: 'bob' }],
+      }),
+      config,
+      context,
+    )
+
+    expect(replyToOther.kind === 'route' && replyToOther.payload.replyToBotMessageId).toBeNull()
+    expect(replyToOther.kind === 'route' && replyToOther.payload.replyToOtherMessageId).toBe('800000000000000008')
   })
 })

--- a/src/channels/adapters/discord-classify.ts
+++ b/src/channels/adapters/discord-classify.ts
@@ -8,6 +8,15 @@ import { encodeDiscordReactionRef } from './discord-reactions'
 
 export type DiscordInboundMessageEvent = DiscordGatewayMessageCreateEvent
 
+// WORKAROUND: the USER-token SDK type omits `author.bot` and
+// `message_reference`, but the listener spreads the raw Discord payload
+// (`{ ...d }`), so both fields exist at runtime. Narrow locally instead of
+// augmenting the SDK type globally — do not "simplify" this away.
+export type RawDiscordMessageCreateEvent = DiscordGatewayMessageCreateEvent & {
+  author: { bot?: boolean }
+  message_reference?: { message_id?: string; channel_id?: string; guild_id?: string }
+}
+
 export type InboundDropReason = 'self_author' | 'no_user' | 'empty_content' | 'pre_connect'
 
 export type InboundClassification =
@@ -42,6 +51,12 @@ export function classifyInbound(
   const mentionedUsers = event.mentions ?? []
   const mentionsOthers = mentionedUsers.length > 0 && !mentionedUsers.some((user) => user.id === context.selfUserId)
 
+  const raw = event as RawDiscordMessageCreateEvent
+  const replyToParentId = raw.message_reference?.message_id
+  const replyToBotMessageId =
+    replyToParentId !== undefined && isReplyToSelf(raw, context.selfUserId) ? replyToParentId : null
+  const replyToOtherMessageId = replyToParentId !== undefined && replyToBotMessageId === null ? replyToParentId : null
+
   return {
     kind: 'route',
     payload: {
@@ -55,15 +70,24 @@ export function classifyInbound(
       reactionRef: encodeDiscordReactionRef({ channel: event.channel_id, message: event.id }),
       authorId: event.author.id,
       authorName: event.author.username,
-      authorIsBot: false,
+      authorIsBot: raw.author.bot === true,
       isBotMention: isBotMention || aliasMatched,
-      replyToBotMessageId: null,
+      replyToBotMessageId,
       mentionsOthers,
-      replyToOtherMessageId: null,
+      replyToOtherMessageId,
       isDm,
       ts: parseDiscordTimestamp(event.timestamp),
     },
   }
+}
+
+// `message_reference` carries only the parent id, not its author, so we infer
+// "this reply targets us" from the auto-mention Discord injects into the
+// reply's `mentions` array (same trick as the bot adapter). Named "...Self"
+// because the user-token identity is a Discord user; the payload field stays
+// `replyToBotMessageId` to match the InboundMessage contract.
+function isReplyToSelf(event: RawDiscordMessageCreateEvent, selfUserId: string): boolean {
+  return (event.mentions ?? []).some((m) => m.id === selfUserId)
 }
 
 const GROUP_MENTION_PATTERN = /@(?:everyone|here)/

--- a/src/channels/adapters/discord.ts
+++ b/src/channels/adapters/discord.ts
@@ -368,14 +368,22 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
   }
 }
 
+// WORKAROUND: the SDK's `DiscordMessage` type omits `author.bot`, but the REST
+// API returns it and the client passes the body through unchanged, so it's
+// present at runtime. `=== true` fails closed to human if absent. This flag
+// feeds history-derived membership (deriveMembershipFromHistory), which
+// otherwise miscounts peer bots as humans and inflates effectiveHumans.
+type RawDiscordMessage = DiscordMessage & { author: { bot?: boolean } }
+
 function mapDiscordHistoryMessage(msg: DiscordMessage): ChannelHistoryMessage {
+  const raw = msg as RawDiscordMessage
   return {
     externalMessageId: msg.id,
     authorId: msg.author.id,
     authorName: msg.author.username,
     text: msg.content,
     ts: parseDiscordTimestamp(msg.timestamp),
-    isBot: false,
+    isBot: raw.author.bot === true,
     replyToBotMessageId: null,
   }
 }


### PR DESCRIPTION
## Background

On a user-token (`discord`, non-bot) channel, the agent stayed silent in a guild channel even though messages were arriving. Production logs from the affected agent showed the inbound was **routed and observed, never engaged**:

```
[discord] inbound id=… author=<peer-bot-id> channel=… text_len=52
[discord] routed  id=… channel=… mention=false
[channels] discord:…:…: observed id=…        ← stayed silent
```

Root cause is two hardcoded fields in the user-token adapter:

1. In `discord-classify.ts`, `authorIsBot` was hardcoded to `false`. The user-token gateway gives no `author.bot`, so a peer Discord app was counted as a **second human**. With `effectiveHumans > 1`, the solo-human engagement fallback (`effectiveHumans <= 1 && !authorIsBot`) never fired, and with no @mention/alias/sticky the message was observed.
2. The same classifier (and the history mapper) hardcoded `replyToBotMessageId` to `null`, so the `reply` trigger was **permanently dead** for the user adapter — replying to the agent's message could never engage it.

The bot adapter (`discord-bot`) already classifies both correctly; only the user-token path was missing them.

## Summary

`author.bot` and `message_reference` are absent from agent-messenger's user-token SDK types, but the listener emits `{ ...d, type: t }` spreading the raw Discord `MESSAGE_CREATE` payload, so both fields exist at runtime. The REST history body carries `author.bot` the same way. Rather than a global module augmentation of an upstream type (fragile, detaches the "why" from the consumer), I read them through a **local narrowing type** confined to the adapter, documented inline as a workaround so it isn't "simplified" away.

Reply targeting mirrors the bot adapter exactly: Discord doesn't echo the parent author on `message_reference`, so "reply to us" is inferred from the auto-mention it injects into the reply's `mentions` array.

**Why fix the history mapper too:** `resolveEffectiveHumans` max-folds history-derived membership with the live participant count. A peer bot miscounted as human in history would re-inflate `effectiveHumans` past the live fix, so the `isBot` correction in `mapDiscordHistoryMessage` is load-bearing, not cosmetic. Checking `=== true` fails closed to human if the field is ever absent — no regression.

## What this does NOT do

- Does **not** make the agent reply to a peer bot's unsolicited plain messages. Peer bots remain excluded from the solo-human fallback by design (the documented bot-to-bot loop guard) — they engage only via mention/reply/alias/sticky. The fix restores replies to the **human** (count no longer inflated) and to a peer bot **when it replies to or @mentions the agent**.
- Does not add the `THREAD_CREATED` system-message drop the bot adapter has — unrelated to this bug and out of scope.
- Does not resolve `replyToBotMessageId` for history messages (no self-identity context at the history layer; only `isBot` is needed there for membership counting).

## Review notes

- Load-bearing change: `authorIsBot` flows through `updateParticipants` (the only writer of `ChannelParticipant.isBot`) into `countEffectiveHumans` — verify that path is unbroken.
- The peer-bot flag is **sticky** (`participants.ts`) and self-healing: pre-existing sessions correct on the peer's next live message; no migration.
- Tests cover bot vs human classification and reply-to-self / reply-to-other, with a Korean-content reply case to keep reply classification content-agnostic per the repo's multi-language testing rule.