### PR TITLE
fix(hostd): stop the first-boot daemon race from crashing channels

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -594,6 +594,34 @@ describe('channel manager — slack adapter lifecycle', () => {
     await mgr.stop()
   })
 
+  test('skips slack user adapter (does not throw) when hostd env vars are missing', async () => {
+    // given: secrets present but no TYPECLAW_HOSTD_* (lost first-boot daemon race)
+    cfg.slack = enabledAdapterCfg()
+    await writeSlackSecrets(agentDir)
+    const fake = makeFakeAdapter()
+    const logger = recordingLogger()
+    let constructed = false
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+      logger,
+      createSlackUserAdapter: () => {
+        constructed = true
+        return fake
+      },
+    })
+
+    // when: start runs with the hostd-backed adapter unsatisfiable
+    // then: the whole manager must not crash — the adapter is skipped, not thrown
+    await mgr.start()
+
+    expect(constructed).toBe(false)
+    expect(fake.startCalls).toBe(0)
+    expect(logger.messages.some((m) => m.includes('could not be constructed'))).toBe(true)
+    await mgr.stop()
+  })
+
   test('starts slack adapter when both SLACK_BOT_TOKEN and SLACK_APP_TOKEN are set', async () => {
     cfg['slack-bot'] = enabledAdapterCfg()
     const fake = makeFakeAdapter()

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -261,48 +261,58 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'line') {
+      const credentialsStore = createContainerLineCredentialStore(options.agentDir, env)
+      if (credentialsStore === null) return null
       return createLine({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
-        credentialsStore: createContainerLineCredentialStore(options.agentDir, env),
+        credentialsStore,
       })
     }
     if (name === 'kakaotalk') {
+      const credentialsStore = createContainerKakaoCredentialStore(options.agentDir, env)
+      if (credentialsStore === null) return null
       return createKakaotalk({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
-        credentialsStore: createContainerKakaoCredentialStore(options.agentDir, env),
+        credentialsStore,
       })
     }
     if (name === 'slack') {
+      const credentialsStore = createContainerSlackCredentialStore(options.agentDir, env)
+      if (credentialsStore === null) return null
       return createSlackUser({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
-        credentialsStore: createContainerSlackCredentialStore(options.agentDir, env),
+        credentialsStore,
       })
     }
     if (name === 'discord') {
+      const credentialsStore = createContainerDiscordCredentialStore(options.agentDir, env)
+      if (credentialsStore === null) return null
       return createDiscordUser({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
-        credentialsStore: createContainerDiscordCredentialStore(options.agentDir, env),
+        credentialsStore,
       })
     }
     if (name === 'webex') {
+      const credentialsStore = createContainerWebexCredentialStore(options.agentDir, env)
+      if (credentialsStore === null) return null
       return createWebex({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
         selfAliasesRef: () => router.getSelfAliases(),
-        credentialsStore: createContainerWebexCredentialStore(options.agentDir, env),
+        credentialsStore,
       })
     }
     if (name === 'github') {
@@ -538,22 +548,33 @@ const TOKEN_ENV: Record<
   'webex-bot': ['WEBEX_BOT_TOKEN'],
 }
 
-function createContainerDiscordCredentialStore(
-  agentDir: string,
-  env: NodeJS.ProcessEnv,
-): SecretsDiscordCredentialStore {
+// Personal-account adapters (line/kakaotalk/slack/discord/webex) need the hostd
+// triple the host CLI injects at `docker run` time, gated on a successful daemon
+// registration (src/container/start.ts). If the daemon wasn't reachable at
+// launch (e.g. a lost first-boot spawn race) the triple is absent; null lets
+// buildAdapter skip the adapter instead of throwing and crashing the whole
+// channel manager. startAdapter's signature pre-check only reads secrets.json,
+// so this is the only place the missing triple is caught.
+type HostdContainerCredentials = { hostdUrl: string; restartToken: string; containerName: string }
+
+function resolveHostdContainerCredentials(env: NodeJS.ProcessEnv): HostdContainerCredentials | null {
   const hostdUrl = env.TYPECLAW_HOSTD_URL
   const restartToken = env.TYPECLAW_HOSTD_TOKEN
   const containerName = env.TYPECLAW_CONTAINER_NAME
-  if (!hostdUrl || !restartToken || !containerName) {
-    throw new Error('Discord credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME')
-  }
+  if (!hostdUrl || !restartToken || !containerName) return null
+  return { hostdUrl, restartToken, containerName }
+}
+
+function createContainerDiscordCredentialStore(
+  agentDir: string,
+  env: NodeJS.ProcessEnv,
+): SecretsDiscordCredentialStore | null {
+  const creds = resolveHostdContainerCredentials(env)
+  if (creds === null) return null
   return new SecretsDiscordCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostdUrl,
-    restartToken,
-    containerName,
+    ...creds,
   })
 }
 
@@ -571,19 +592,16 @@ function buildDiscordSignature(agentDir: string): { signature: string; missing: 
   }
 }
 
-function createContainerSlackCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsSlackCredentialStore {
-  const hostdUrl = env.TYPECLAW_HOSTD_URL
-  const restartToken = env.TYPECLAW_HOSTD_TOKEN
-  const containerName = env.TYPECLAW_CONTAINER_NAME
-  if (!hostdUrl || !restartToken || !containerName) {
-    throw new Error('Slack credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME')
-  }
+function createContainerSlackCredentialStore(
+  agentDir: string,
+  env: NodeJS.ProcessEnv,
+): SecretsSlackCredentialStore | null {
+  const creds = resolveHostdContainerCredentials(env)
+  if (creds === null) return null
   return new SecretsSlackCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostdUrl,
-    restartToken,
-    containerName,
+    ...creds,
   })
 }
 
@@ -601,19 +619,16 @@ function buildSlackSignature(agentDir: string): { signature: string; missing: st
   }
 }
 
-function createContainerWebexCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsWebexCredentialStore {
-  const hostdUrl = env.TYPECLAW_HOSTD_URL
-  const restartToken = env.TYPECLAW_HOSTD_TOKEN
-  const containerName = env.TYPECLAW_CONTAINER_NAME
-  if (!hostdUrl || !restartToken || !containerName) {
-    throw new Error('Webex credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME')
-  }
+function createContainerWebexCredentialStore(
+  agentDir: string,
+  env: NodeJS.ProcessEnv,
+): SecretsWebexCredentialStore | null {
+  const creds = resolveHostdContainerCredentials(env)
+  if (creds === null) return null
   return new SecretsWebexCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostdUrl,
-    restartToken,
-    containerName,
+    ...creds,
   })
 }
 
@@ -631,21 +646,16 @@ function buildWebexSignature(agentDir: string): { signature: string; missing: st
   }
 }
 
-function createContainerKakaoCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsKakaoCredentialStore {
-  const hostdUrl = env.TYPECLAW_HOSTD_URL
-  const restartToken = env.TYPECLAW_HOSTD_TOKEN
-  const containerName = env.TYPECLAW_CONTAINER_NAME
-  if (!hostdUrl || !restartToken || !containerName) {
-    throw new Error(
-      'KakaoTalk credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME',
-    )
-  }
+function createContainerKakaoCredentialStore(
+  agentDir: string,
+  env: NodeJS.ProcessEnv,
+): SecretsKakaoCredentialStore | null {
+  const creds = resolveHostdContainerCredentials(env)
+  if (creds === null) return null
   return new SecretsKakaoCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostdUrl,
-    restartToken,
-    containerName,
+    ...creds,
   })
 }
 
@@ -663,19 +673,16 @@ function buildKakaotalkSignature(agentDir: string): { signature: string; missing
   }
 }
 
-function createContainerLineCredentialStore(agentDir: string, env: NodeJS.ProcessEnv): SecretsLineCredentialStore {
-  const hostdUrl = env.TYPECLAW_HOSTD_URL
-  const restartToken = env.TYPECLAW_HOSTD_TOKEN
-  const containerName = env.TYPECLAW_CONTAINER_NAME
-  if (!hostdUrl || !restartToken || !containerName) {
-    throw new Error('LINE credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME')
-  }
+function createContainerLineCredentialStore(
+  agentDir: string,
+  env: NodeJS.ProcessEnv,
+): SecretsLineCredentialStore | null {
+  const creds = resolveHostdContainerCredentials(env)
+  if (creds === null) return null
   return new SecretsLineCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostdUrl,
-    restartToken,
-    containerName,
+    ...creds,
   })
 }
 

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -12,7 +12,7 @@ import { send as sendToDaemon } from '@/hostd/client'
 import { ensureModels } from '@/hostd/models'
 import { homeRoot } from '@/hostd/paths'
 import type { HttpInfoResult } from '@/hostd/protocol'
-import { ensureDaemon } from '@/hostd/spawn'
+import { ensureDaemon, type EnsureDaemonResult } from '@/hostd/spawn'
 import {
   autoUpgradeTypeclawDep,
   type AutoUpgradeOutcome,
@@ -1165,7 +1165,7 @@ async function registerWithDaemon({
   hostPort: number
   reuseCurrentHostDaemon: boolean
 }): Promise<PreparedHostDaemonStatus> {
-  const prepared = reuseCurrentHostDaemon ? await useCurrentHostDaemon() : await ensureDaemon({ cliEntry })
+  const prepared = reuseCurrentHostDaemon ? await useCurrentHostDaemon() : await ensureDaemonWithBridgeRetry(cliEntry)
   if (!prepared.ok) return { state: 'unavailable', reason: prepared.reason }
   const token = randomBytes(32).toString('base64url')
   const brokerToken = randomBytes(32).toString('base64url')
@@ -1184,6 +1184,26 @@ async function registerWithDaemon({
     state: 'registered',
     control: { url: `http://${CONTAINER_HOSTD_HOST}:${prepared.httpPort}`, token, brokerToken },
   }
+}
+
+// ensureDaemon spawns the daemon detached and polls for readiness, but a cold
+// daemon can take longer than that internal window to bind its socket. Rather
+// than treat the first not-ready-yet as a hard failure (which would drop the
+// hostd env vars and crash hostd-backed channel adapters on boot), re-probe a
+// few times: the still-booting daemon becomes reachable and ensureDaemon
+// fast-paths through its top-of-function isDaemonReachable() check WITHOUT
+// re-spawning. Bridges the first-boot spawn race; a genuinely dead daemon still
+// surfaces as unavailable after the budget.
+const HOSTD_BRIDGE_RETRIES = 3
+const HOSTD_BRIDGE_RETRY_DELAY_MS = 2_000
+
+async function ensureDaemonWithBridgeRetry(cliEntry: string): Promise<EnsureDaemonResult> {
+  let last = await ensureDaemon({ cliEntry })
+  for (let attempt = 0; !last.ok && attempt < HOSTD_BRIDGE_RETRIES; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, HOSTD_BRIDGE_RETRY_DELAY_MS))
+    last = await ensureDaemon({ cliEntry })
+  }
+  return last
 }
 
 async function useCurrentHostDaemon(): Promise<{ ok: true; httpPort: number } | { ok: false; reason: string }> {

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -78,6 +78,14 @@ async function daemonEndpointGone(): Promise<boolean> {
   return !existsSync(socketPath())
 }
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 describe('startDaemon', () => {
   test('register tracks a container cwd; list reflects the registration', async () => {
     daemon = await startDaemon({ exec: fakeExec(new Set(['coder'])), gcIntervalMs: 1_000_000 })
@@ -837,6 +845,67 @@ describe('startDaemon', () => {
 
     expect(startCalls).toHaveLength(1)
     expect(existsSync(registrationFilePath('flaky'))).toBe(true)
+  })
+
+  test('daemon is reachable before a slow boot-time restore completes', async () => {
+    // given: a persisted registration whose restore probe (docker ps) blocks
+    const d1 = await startDaemon({ exec: fakeExec(new Set(['slow'])), gcIntervalMs: 1_000_000 })
+    await send({ kind: 'register', containerName: 'slow', cwd: '/agent/slow', restartToken: 't' })
+    await d1.stop()
+
+    const release = deferred()
+    const slowExec: DockerExec = async (args) => {
+      if (args[0] === 'ps') {
+        await release.promise
+        return { exitCode: 0, stdout: 'slow\n', stderr: '' }
+      }
+      return { exitCode: 1, stdout: '', stderr: 'unknown command' }
+    }
+
+    daemon = await startDaemon({ exec: slowExec, gcIntervalMs: 1_000_000 })
+
+    // when: restore is still blocked on the docker probe
+    // then: the readiness surface (http-info / list) answers without waiting
+    const info = await send({ kind: 'http-info' }, { timeoutMs: 1_000 })
+    expect(info.ok).toBe(true)
+    const list = await send({ kind: 'list' }, { timeoutMs: 1_000 })
+    expect(list.ok).toBe(true)
+
+    release.resolve()
+  })
+
+  test('register RPC waits for boot-time restore to complete before mutating the registry', async () => {
+    const d1 = await startDaemon({ exec: fakeExec(new Set(['slow'])), gcIntervalMs: 1_000_000 })
+    await send({ kind: 'register', containerName: 'slow', cwd: '/agent/slow', restartToken: 't' })
+    await d1.stop()
+
+    const release = deferred()
+    let probeStarted = false
+    const slowExec: DockerExec = async (args) => {
+      if (args[0] === 'ps') {
+        probeStarted = true
+        await release.promise
+        return { exitCode: 0, stdout: 'slow\n', stderr: '' }
+      }
+      return { exitCode: 1, stdout: '', stderr: 'unknown command' }
+    }
+
+    daemon = await startDaemon({ exec: slowExec, gcIntervalMs: 1_000_000 })
+    await waitFor(() => probeStarted)
+
+    // given: restore is mid-probe; when a register lands, it must not resolve yet
+    let resolved = false
+    const registerPromise = send({ kind: 'register', containerName: 'new', cwd: '/agent/new' }).then((r) => {
+      resolved = true
+      return r
+    })
+    await expectStable(() => resolved, { durationMs: 50, description: 'register gated on restore' })
+    expect(resolved).toBe(false)
+
+    // then: once restore unblocks, the gated register completes
+    release.resolve()
+    const ack = await registerPromise
+    expect(ack.ok).toBe(true)
   })
 
   test('register invokes kakaoRenewal.start with the registered container and cwd', async () => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -285,6 +285,12 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   const gcMisses = new Map<string, number>()
   let stopped = false
   let httpPort = 0
+  // Boot-time restore runs concurrently with the listeners (see the kickoff
+  // below). Declared here so the IPC dispatcher and HTTP handler — both defined
+  // before restore starts — can gate on it; until it's assigned, no registry
+  // RPC has been accepted yet, so resolving immediately is safe.
+  let restoreComplete: Promise<void> | null = null
+  const awaitRestored = (): Promise<void> => restoreComplete ?? Promise.resolve()
 
   const supervisor = opts.restart
     ? buildSupervisor({
@@ -538,16 +544,21 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   const dispatch = async (req: Request): Promise<RpcResponse> => {
     switch (req.kind) {
       case 'register':
+        await awaitRestored()
         return handleRegister(req)
       case 'deregister':
+        await awaitRestored()
         return handleDeregister(req)
       case 'list':
         return handleList()
       case 'status':
+        await awaitRestored()
         return handleStatus(req)
       case 'restart':
+        await awaitRestored()
         return handleRestart(req)
       case 'secrets-patch':
+        await awaitRestored()
         return handleSecretsPatch(req)
       case 'http-info':
         return handleHttpInfo()
@@ -614,11 +625,51 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     if (rpc.kind !== 'restart' && rpc.kind !== 'secrets-patch') {
       return json({ ok: false, reason: 'http transport only supports restart and secrets-patch' }, 403)
     }
+    // restartTokens is populated by boot-time restore; authorizing before it
+    // completes would reject a valid token as "invalid restart token".
+    await awaitRestored()
     if (restartTokens.get(rpc.containerName) !== token) {
       return json({ ok: false, reason: 'invalid restart token' }, 403)
     }
     return json(rpc.kind === 'restart' ? await handleRestart(rpc) : await handleSecretsPatch(rpc))
   }
+
+  // GC tick distinguishes "container confirmed gone" from "docker call failed":
+  // a `docker ps` blip should not deregister a live container registration, so
+  // we require gcMissesToDeregister consecutive confirmed absences. Boot-time
+  // restore reuses the same probe but with a stricter policy — see
+  // restorePersistedRegistrations.
+  const probeContainerAlive = async (name: string): Promise<'alive' | 'gone' | 'unknown'> => {
+    try {
+      const result = await exec(['ps', '-a', '--filter', `name=^${name}$`, '--format', '{{.Names}}'])
+      if (result.exitCode !== 0) return 'unknown'
+      const names = result.stdout
+        .trim()
+        .split('\n')
+        .filter((s) => s.length > 0)
+      return names.includes(name) ? 'alive' : 'gone'
+    } catch {
+      return 'unknown'
+    }
+  }
+
+  // Boot-time restore replays every persisted registration into the in-memory
+  // maps and revives portbroker. It runs N docker-ps probes, so on a cold
+  // daemon it can take seconds — longer than the CLI's spawn-readiness window.
+  // We therefore start it WITHOUT blocking the listeners: the sockets accept
+  // connections immediately (so `isDaemonReachable` succeeds fast and the CLI
+  // injects the hostd env vars), but every handler that reads or mutates the
+  // restored registry awaits `awaitRestored` first. That preserves the original
+  // invariant — no RPC observes a half-restored registry — without coupling
+  // readiness to docker latency. Kicked off BEFORE the HTTP/IPC listeners so no
+  // request can slip past the gate in an unrestored window. A bad file (parse
+  // error, schema mismatch) is logged-and-skipped; one corrupt registration
+  // must not gate recovery.
+  restoreComplete = restorePersistedRegistrations(applyRegistration, log, probeContainerAlive, removeRegistrationFile)
+  // Swallow the rejection on a detached handle so a restore failure never
+  // becomes an unhandledRejection before the first gated handler awaits it.
+  // Handlers await `restoreComplete` directly so they still fail closed.
+  restoreComplete.catch(() => {})
 
   const httpHostname = opts.httpHost ?? '0.0.0.0'
   // Try the stable port first so containers' cached TYPECLAW_HOSTD_URL stays
@@ -648,32 +699,6 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
   httpPort = httpServer.port ?? 0
   log({ kind: 'daemon-http-listening', host: httpHostname, port: httpPort })
-
-  // GC tick distinguishes "container confirmed gone" from "docker call failed":
-  // a `docker ps` blip should not deregister a live container registration, so
-  // we require gcMissesToDeregister consecutive confirmed absences. Boot-time
-  // restore reuses the same probe but with a stricter policy — see
-  // restorePersistedRegistrations.
-  const probeContainerAlive = async (name: string): Promise<'alive' | 'gone' | 'unknown'> => {
-    try {
-      const result = await exec(['ps', '-a', '--filter', `name=^${name}$`, '--format', '{{.Names}}'])
-      if (result.exitCode !== 0) return 'unknown'
-      const names = result.stdout
-        .trim()
-        .split('\n')
-        .filter((s) => s.length > 0)
-      return names.includes(name) ? 'alive' : 'gone'
-    } catch {
-      return 'unknown'
-    }
-  }
-
-  // Boot-time restore: replay every persisted registration into the in-memory
-  // maps and revive portbroker for it. Runs before the IPC listener so the socket
-  // is never accepting RPCs against a half-restored registry. A bad file
-  // (parse error, schema mismatch) is logged-and-skipped — one corrupt
-  // registration must not gate every other container's recovery.
-  await restorePersistedRegistrations(applyRegistration, log, probeContainerAlive, removeRegistrationFile)
 
   const sockets = new Set<NetSocket>()
   const listener = createServer((socket) => {
@@ -734,6 +759,10 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       clearInterval(gcTimer)
       await closeSocketServer(listener, sockets)
       httpServer.stop(true)
+      // A stop racing an in-flight boot restore could let a portbroker start
+      // after the teardown loop below already ran, leaking it. Let restore
+      // settle (it never rejects past the detached catch) before tearing down.
+      await (restoreComplete ?? Promise.resolve()).catch(() => {})
       if (opts.portbroker) {
         const names = Array.from(cwds.keys())
         await Promise.allSettled(names.map((n) => opts.portbroker!.stop(n, 'broker-stopped')))

--- a/src/hostd/spawn.test.ts
+++ b/src/hostd/spawn.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { existsSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { existsSync, readFileSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { isWindows } from '@/shared'
 
 import { isDaemonReachable } from './client'
 import { startDaemon, type Daemon } from './daemon'
-import { socketPath } from './paths'
+import { pidfilePath, socketPath } from './paths'
 import { ensureDaemon } from './spawn'
 
 let home: string
@@ -97,10 +97,43 @@ describe('ensureDaemon', () => {
     })
 
     // Production path requires a real CLI entry; the test invokes with a
-    // dummy path, so spawn fails. The test asserts the failure mode is the
-    // spawn failure (not the drift path).
+    // dummy path, so the spawned child exits immediately. The test asserts the
+    // failure mode is the spawn failure (not the drift path), and that an
+    // EXITED child is reaped — its pidfile must not linger.
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason.toLowerCase()).not.toContain('drift')
+    expect(result.reason.toLowerCase()).toContain('exited')
+    expect(existsSync(pidfilePath())).toBe(false)
+  })
+
+  test('adopts a live-but-unreachable child instead of spawning a second daemon', async () => {
+    // given: a previous spawn left a live child that never bound the socket —
+    // simulated by a harmless long-lived process recorded in the pidfile
+    if (isWindows()) return
+    await expectDaemonEndpointGone()
+    const child = Bun.spawn({
+      cmd: [process.execPath, '-e', 'setTimeout(() => {}, 60_000)'],
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    child.unref()
+    try {
+      await mkdir(dirname(pidfilePath()), { recursive: true })
+      await writeFile(pidfilePath(), `${child.pid}\n`)
+
+      // when: ensureDaemon runs while that child is alive but unreachable
+      const result = await ensureDaemon({ cliEntry: '/nonexistent/cli.ts', spawnTimeoutMs: 150 })
+
+      // then: it adopts and polls the existing child (times out), never spawning
+      // a second daemon — the pidfile still points at OUR child, untouched
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toContain('did not become reachable yet')
+      expect(readFileSync(pidfilePath(), 'utf8').trim()).toBe(String(child.pid))
+    } finally {
+      child.kill('SIGKILL')
+    }
   })
 })

--- a/src/hostd/spawn.ts
+++ b/src/hostd/spawn.ts
@@ -111,10 +111,46 @@ async function ensureDaemonWithRetry(opts: EnsureDaemonOptions, retriesLeft: num
       if (httpPort === null) return { ok: false, reason: 'daemon did not report an HTTP control port' }
       return { ok: true, pid: await readPidQuiet(), spawned: false, httpPort }
     }
+    // A prior spawn attempt can leave a live-but-not-yet-listening child (its
+    // readiness poll timed out without killing it — see spawnDaemonDetached).
+    // Spawning a second daemon would race two processes for the same socket, so
+    // adopt the existing child and poll IT for readiness instead of re-spawning.
+    const existingPid = await livePidfileChild()
+    if (existingPid !== null) {
+      const ready = await pollForReadiness(opts.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS)
+      if (ready === null) return { ok: false, reason: 'daemon spawned but did not become reachable yet' }
+      return { ok: true, pid: existingPid, spawned: false, httpPort: ready }
+    }
     return await spawnDaemonDetached(opts)
   } finally {
     await releaseLock(lock.token)
   }
+}
+
+// Reads the pidfile and returns its pid only if that process is still alive
+// (signal 0 = existence check, no signal delivered). Returns null when the
+// pidfile is absent/garbage or the process has exited — i.e. nothing to adopt.
+async function livePidfileChild(): Promise<number | null> {
+  const pid = await readPidQuiet()
+  if (pid <= 0) return null
+  try {
+    process.kill(pid, 0)
+    return pid
+  } catch {
+    return null
+  }
+}
+
+async function pollForReadiness(timeoutMs: number): Promise<number | null> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await isDaemonReachable()) {
+      const httpPort = await readHttpPort()
+      if (httpPort !== null) return httpPort
+    }
+    await sleep(POLL_INTERVAL_MS)
+  }
+  return null
 }
 
 async function spawnDaemonDetached(opts: EnsureDaemonOptions): Promise<SpawnAttemptResult> {
@@ -154,26 +190,24 @@ async function spawnDaemonDetached(opts: EnsureDaemonOptions): Promise<SpawnAtte
     return { ok: false, reason: `failed to write daemon pidfile: ${stringify(error)}` }
   }
 
-  const deadline = Date.now() + (opts.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS)
-  while (Date.now() < deadline) {
-    if (await isDaemonReachable()) {
-      const httpPort = await readHttpPort()
-      if (httpPort !== null) return { ok: true, pid: proc.pid, spawned: true, httpPort }
-    }
-    await sleep(POLL_INTERVAL_MS)
-  }
+  const httpPort = await pollForReadiness(opts.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS)
+  if (httpPort !== null) return { ok: true, pid: proc.pid, spawned: true, httpPort }
 
-  // Daemon failed to come up. Reap the orphan and clean the pidfile so the
-  // next ensureDaemon() doesn't observe a dangling pidfile pointing at our
-  // dead child.
-  try {
-    proc.kill('SIGTERM')
-  } catch {}
-  try {
-    const raw = await readFile(pidfilePath(), 'utf8').catch(() => '')
-    if (raw.trim() === String(proc.pid)) await unlink(pidfilePath())
-  } catch {}
-  return { ok: false, reason: 'daemon spawned but did not become reachable' }
+  // Timed out waiting for readiness. A still-running child is "slow-booting",
+  // not "wedged" — killing it would throw away a daemon that's about to come up
+  // and force every caller into a respawn loop. Only reap a child that already
+  // EXITED (proc.exitCode !== null): that's a genuine failure with a dangling
+  // pidfile to clean. A live-but-not-ready child is left running so the caller
+  // can re-probe it (see registerWithDaemon's retry) — the next ensureDaemon()
+  // fast-paths through isDaemonReachable() once its socket binds.
+  if (proc.exitCode !== null) {
+    try {
+      const raw = await readFile(pidfilePath(), 'utf8').catch(() => '')
+      if (raw.trim() === String(proc.pid)) await unlink(pidfilePath())
+    } catch {}
+    return { ok: false, reason: 'daemon exited before becoming reachable' }
+  }
+  return { ok: false, reason: 'daemon spawned but did not become reachable yet' }
 }
 
 type LockToken = { path: string }


### PR DESCRIPTION
## Background

A cold `typeclaw start` would crash all channels on boot with:

```
error: LINE credentials require TYPECLAW_HOSTD_URL, TYPECLAW_HOSTD_TOKEN, and TYPECLAW_CONTAINER_NAME
  at createContainerLineCredentialStore (src/channels/manager.ts)
  at buildAdapter (src/channels/manager.ts)
```

…and a second `typeclaw start` (restart) made it disappear. LINE was just the messenger — the same crash applies to any hostd-backed adapter (`line`/`kakaotalk`/`slack`/`discord`/`webex`).

**Root cause** is a first-boot race in the host daemon, not in channels:

1. The host CLI spawns hostd **detached**, then polls for readiness for only 5s (`spawnDaemonDetached`, `DEFAULT_SPAWN_TIMEOUT_MS`).
2. hostd's boot ran `restorePersistedRegistrations` — an `N × docker ps` reconcile — **before** opening its IPC socket (`isDaemonReachable` is gated on that socket). On cold/slow Docker (or many persisted registrations) the reconcile exceeds 5s.
3. The readiness poll then **SIGTERM'd the still-booting child** and returned `unavailable`, so `registerWithDaemon` failed and the `TYPECLAW_HOSTD_URL`/`TYPECLAW_HOSTD_TOKEN` env vars were **never injected** at `docker run` time (`TYPECLAW_CONTAINER_NAME` is injected unconditionally — hence the partial-triple error).
4. Inside the container, the credential-store factory **threw** inside `buildAdapter`; that throw propagated through `start()`'s `Promise.allSettled` and took down the whole channel manager.

The restart "fix" was just the daemon having finished booting by the second attempt.

## Summary

Two separable changes (one commit each):

**1. `fix(hostd)` — the race (cause).** Open hostd's IPC/HTTP listeners **before** the restore reconcile, and gate only the registry-reading/mutating handlers (`register`, `deregister`, `status`, `restart`, `secrets-patch`, over both IPC and HTTP) on a `restoreComplete` promise. `list`/`http-info` stay **ungated** so readiness probes answer immediately — this decouples "daemon reachable" from docker latency while preserving the original invariant that no RPC observes a half-restored registry. Why not just bump the 5s timeout: it only narrows the window, it doesn't fix the semantic bug that reachability was bound to docker reconcile time. Complemented by: `spawn` only reaps the child on a readiness timeout if it already **exited** (a live child is slow-booting, not wedged); and `start` adds a bounded retry around `ensureDaemon` to bridge a still-booting daemon (it fast-paths through `isDaemonReachable()` without re-spawning).

**2. `fix(channels)` — the blast radius (defense-in-depth).** The five container credential stores now return `null` (adapter skipped + logged) instead of throwing when the hostd triple is absent, so any *future* lost race degrades to "that adapter didn't start" rather than crashing every channel. This is intentionally orthogonal to the race fix.

## What this does NOT do

- Does not change the 5s spawn-readiness window or the `host.docker.internal` plumbing.
- Does not change the credential-rotation / `restartToken` model — only when the hostd triple is read and what happens when it's missing.
- Does not touch the GitHub adapter (it doesn't use the hostd credential store).
- `restoreComplete` is not surfaced in config or telemetry; it's an internal boot gate.

## Review notes

- **Load-bearing ordering** is in `startDaemon` (`src/hostd/daemon.ts`): `probeContainerAlive` → restore kickoff (assigns `restoreComplete`) → `Bun.serve` → `listenOnSocket`. The kickoff is deliberately **before** the listeners so no request can slip past the gate in an unrestored window; `restoreComplete` is hoisted as `let … | null` with an `awaitRestored` fallback to avoid a TDZ if an HTTP request lands the instant the server binds.
- **Invariant to verify:** every handler that reads or mutates the registry/token maps awaits `awaitRestored()`; `list`/`http-info`/`version`/`shutdown` must NOT (readiness + control plane). The HTTP `restart`/`secrets-patch` auth check is gated too — otherwise a valid `restartToken` would be rejected mid-restore.
- `stop()` now awaits restore settling before the portbroker teardown loop, so a stop racing restore can't leak a broker.
- Tests: `daemon.test.ts` proves readiness answers before a blocked restore and that `register` waits for it; `spawn.test.ts` asserts an exited child is reaped (pidfile gone); `manager.test.ts` proves a missing hostd triple skips the adapter instead of throwing.
