### PR TITLE
fix(channels): serialize webex history prefetch to stop 429 stampede

### DIFF
--- a/src/channels/adapters/webex-bot.test.ts
+++ b/src/channels/adapters/webex-bot.test.ts
@@ -16,6 +16,7 @@ import {
   type WebexBotAdapterLogger,
 } from './webex-bot'
 import type { WebexInboundMessage } from './webex-bot-classify'
+import { createWebexPrefetchLimiter } from './webex-prefetch-limiter'
 
 const config = channelsSchema.parse({ 'webex-bot': {} })['webex-bot']!
 
@@ -250,17 +251,132 @@ describe('webex history and membership', () => {
     await expect(cb({ chat: 'room-1', thread: null, limit: 10 })).resolves.toEqual({ ok: false, error: 'down' })
   })
 
-  test('fails fast when listMessages hangs past the cold-start timeout', async () => {
+  test('logs prefetch rate-limit skips at info with skipReason, not warn', async () => {
+    const log = logger()
     const cb = createWebexHistoryCallback({
-      client: { listMessages: () => new Promise<ReturnType<typeof webexMessage>[]>(() => {}) },
-      logger: logger(),
-      botPersonIdRef: () => 'bot-1',
-      timeoutMs: 20,
+      client: {
+        listMessages: async () => Promise.reject(Object.assign(new Error('Rate limited'), { code: 'rate_limited' })),
+      },
+      logger: log,
+      botPersonIdRef: () => null,
     })
-    const start = Date.now()
+
+    const res = await cb({ chat: 'room-1', thread: null, limit: 10, prefetch: true })
+
+    expect(res).toEqual({ ok: false, error: 'Rate limited', skipReason: 'rate-limited' })
+    expect(log.lines.some((l) => l.startsWith('info:') && l.includes('rate limited'))).toBe(true)
+    expect(log.lines.some((l) => l.startsWith('warn:'))).toBe(false)
+  })
+
+  test('warns (no skipReason) on a 429 from an explicit non-prefetch read', async () => {
+    const log = logger()
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async () => Promise.reject(Object.assign(new Error('Rate limited'), { code: 'rate_limited' })),
+      },
+      logger: log,
+      botPersonIdRef: () => null,
+    })
+
     const res = await cb({ chat: 'room-1', thread: null, limit: 10 })
+
     expect(res.ok).toBe(false)
-    expect(Date.now() - start).toBeLessThan(500)
+    if (res.ok) throw new Error('expected failure')
+    expect(res.skipReason).toBeUndefined()
+    expect(log.lines.some((l) => l.startsWith('warn:'))).toBe(true)
+  })
+
+  test('skips a same-room prefetch without calling listMessages when the limiter cannot admit', async () => {
+    let calls = 0
+    const blockUntil = Promise.withResolvers<void>()
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 20 })
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async () => {
+          calls++
+          await blockUntil.promise
+          return []
+        },
+      },
+      logger: logger(),
+      botPersonIdRef: () => null,
+      limiter,
+    })
+
+    const held = cb({ chat: 'room-1', thread: null, limit: 10, prefetch: true })
+    const skipped = await cb({ chat: 'room-1', thread: null, limit: 10, prefetch: true })
+
+    expect(skipped).toEqual({
+      ok: false,
+      error: 'prefetch skipped: rate-limit backpressure',
+      skipReason: 'rate-limited',
+    })
+    expect(calls).toBe(1)
+    blockUntil.resolve()
+    await held
+    expect(calls).toBe(1)
+  })
+
+  test('an explicit (non-prefetch) read bypasses the limiter even under backpressure', async () => {
+    let prefetchCalls = 0
+    let explicitCalls = 0
+    const blockPrefetch = Promise.withResolvers<void>()
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 20 })
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async (_chat, opts) => {
+          // Distinguish callers by limit (not call order) so the test is immune
+          // to the limiter deferring its work by a microtask.
+          if ((opts?.max ?? 0) === 99) {
+            prefetchCalls++
+            await blockPrefetch.promise
+          } else {
+            explicitCalls++
+          }
+          return []
+        },
+      },
+      logger: logger(),
+      botPersonIdRef: () => null,
+      limiter,
+    })
+
+    const heldPrefetch = cb({ chat: 'room-1', thread: null, limit: 99, prefetch: true })
+    const explicit = await cb({ chat: 'room-1', thread: null, limit: 10 })
+
+    expect(explicit.ok).toBe(true)
+    expect(explicitCalls).toBe(1)
+    blockPrefetch.resolve()
+    await heldPrefetch
+    expect(prefetchCalls).toBe(1)
+  })
+
+  test('does not throttle prefetches for different rooms', async () => {
+    let calls = 0
+    const blockUntil = Promise.withResolvers<void>()
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 20 })
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async () => {
+          calls++
+          await blockUntil.promise
+          return []
+        },
+      },
+      logger: logger(),
+      botPersonIdRef: () => null,
+      limiter,
+    })
+
+    const held = cb({ chat: 'room-1', thread: null, limit: 10, prefetch: true })
+    const other = cb({ chat: 'room-2', thread: null, limit: 10, prefetch: true })
+
+    blockUntil.resolve()
+    const [a, b] = await Promise.all([held, other])
+
+    expect(a.ok).toBe(true)
+    expect(b.ok).toBe(true)
+    expect(calls).toBe(2)
   })
 
   test('resolves direct and group membership, falling back to history on failure', async () => {

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -33,6 +33,7 @@ import { createWebexChannelNameResolver } from './webex-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-bot-classify'
 import { enrichWebexMessageReference } from './webex-bot-reference'
 import { resolveWebexBodyText } from './webex-format'
+import { createWebexPrefetchLimiter, isWebexRateLimitError, type WebexPrefetchLimiter } from './webex-prefetch-limiter'
 
 export type WebexBotAdapterLogger = {
   info: (msg: string) => void
@@ -139,27 +140,39 @@ async function defaultReadFile(path: string): Promise<WebexOutboundFile> {
   return { content: Bun.file(path), filename: path.split('/').pop() ?? 'attachment' }
 }
 
-// See webex.ts: the bot client has no AbortSignal either, so a hung listMessages
-// is bounded by a tighter internal deadline than the router's 5s history ceiling.
-const WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS = 2500
-
 export function createWebexHistoryCallback(deps: {
   client: Pick<WebexBotClient, 'listMessages'>
   logger: WebexBotAdapterLogger
   botPersonIdRef: () => string | null
-  timeoutMs?: number
+  limiter?: WebexPrefetchLimiter
 }): HistoryCallback {
-  const timeoutMs = deps.timeoutMs ?? WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS
+  const limiter = deps.limiter ?? createWebexPrefetchLimiter()
+  const listMessages = (args: FetchHistoryArgs) =>
+    deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) })
+  const toHistory = (messages: WebexMessage[]): FetchHistoryResult => ({
+    ok: true,
+    messages: messages.map((m) => mapWebexHistoryMessage(m, deps.botPersonIdRef())).reverse(),
+  })
   return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
     try {
-      const messages = await raceWithTimeout(
-        deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) }),
-        timeoutMs,
-        '[webex-bot] history fetch',
-      )
-      return { ok: true, messages: messages.map((m) => mapWebexHistoryMessage(m, deps.botPersonIdRef())).reverse() }
+      // Only best-effort reads (cold-start prefetch, membership fallback) submit
+      // to the per-room limiter. Explicit channel_history reads bypass it so a
+      // user-initiated look-back is never declined by prefetch backpressure.
+      if (args.prefetch !== true) {
+        return toHistory(await listMessages(args))
+      }
+      const outcome = await limiter.run(args.chat, () => listMessages(args))
+      if (!outcome.admitted) {
+        deps.logger.info('[webex-bot] history prefetch skipped: rate-limit backpressure')
+        return { ok: false, error: 'prefetch skipped: rate-limit backpressure', skipReason: 'rate-limited' }
+      }
+      return toHistory(outcome.value)
     } catch (err) {
       const message = describe(err)
+      if (args.prefetch === true && isWebexRateLimitError(err)) {
+        deps.logger.info(`[webex-bot] history prefetch skipped: rate limited (${message})`)
+        return { ok: false, error: message, skipReason: 'rate-limited' }
+      }
       deps.logger.warn(`[webex-bot] history fetch failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -204,7 +217,7 @@ export function createWebexMembershipResolver(deps: {
     } catch (err) {
       deps.logger.warn(`[webex-bot] membership room=${key.chat} failed: ${describe(err)}; deriving from recent history`)
       return await deriveMembershipFromHistory({
-        fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
+        fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit, prefetch: true }),
         now,
       })
     }
@@ -463,18 +476,6 @@ function clampLimit(requested: number, max: number): number {
 
 function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
-}
-
-async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | null = null
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
-  })
-  try {
-    return await Promise.race([work, timeout])
-  } finally {
-    if (timer !== null) clearTimeout(timer)
-  }
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/adapters/webex-prefetch-limiter.test.ts
+++ b/src/channels/adapters/webex-prefetch-limiter.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createWebexPrefetchLimiter, isWebexRateLimitError } from './webex-prefetch-limiter'
+
+const ROOM = 'room-1'
+const OTHER = 'room-2'
+
+describe('createWebexPrefetchLimiter', () => {
+  test('serializes same-room work at concurrency 1', async () => {
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1 })
+    let active = 0
+    let maxActive = 0
+    const job = () =>
+      limiter.run(ROOM, async () => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await new Promise((r) => setTimeout(r, 10))
+        active--
+        return 'done'
+      })
+
+    await Promise.all([job(), job(), job()])
+
+    expect(maxActive).toBe(1)
+  })
+
+  test('runs up to `concurrency` same-room jobs at once', async () => {
+    const limiter = createWebexPrefetchLimiter({ concurrency: 2, admitTimeoutMs: 1000 })
+    let active = 0
+    let maxActive = 0
+    const job = () =>
+      limiter.run(ROOM, async () => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await new Promise((r) => setTimeout(r, 10))
+        active--
+      })
+
+    await Promise.all([job(), job(), job(), job()])
+
+    expect(maxActive).toBe(2)
+  })
+
+  test('different rooms never contend — each gets its own permit pool', async () => {
+    // given: concurrency 1 per room, but two DIFFERENT rooms each holding a slot
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 15 })
+    let concurrent = 0
+    let maxConcurrent = 0
+    const job = (room: string) =>
+      limiter.run(room, async () => {
+        concurrent++
+        maxConcurrent = Math.max(maxConcurrent, concurrent)
+        await new Promise((r) => setTimeout(r, 20))
+        concurrent--
+        return room
+      })
+
+    // then: both run in parallel despite concurrency 1, because keys differ
+    const [a, b] = await Promise.all([job(ROOM), job(OTHER)])
+
+    expect(maxConcurrent).toBe(2)
+    expect([a, b]).toEqual([
+      { admitted: true, value: ROOM },
+      { admitted: true, value: OTHER },
+    ])
+  })
+
+  test('skips (admitted=false) without running work when no same-room slot frees in time', async () => {
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 15 })
+    const block = Promise.withResolvers<void>()
+    let secondRan = false
+
+    const held = limiter.run(ROOM, async () => {
+      await block.promise
+    })
+    const skipped = await limiter.run(ROOM, async () => {
+      secondRan = true
+    })
+
+    expect(skipped).toEqual({ admitted: false })
+    expect(secondRan).toBe(false)
+    block.resolve()
+    await held
+  })
+
+  test('admits a queued same-room waiter once a slot frees within the budget', async () => {
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 1000 })
+    const block = Promise.withResolvers<void>()
+
+    const held = limiter.run(ROOM, async () => {
+      await block.promise
+      return 'first'
+    })
+    const queued = limiter.run(ROOM, async () => 'second')
+
+    block.resolve()
+    await held
+
+    await expect(queued).resolves.toEqual({ admitted: true, value: 'second' })
+  })
+
+  test('a timed-out grant releases its slot instead of leaking it', async () => {
+    // given: one slot held long enough that the queued waiter times out, but the
+    // holder releases AFTER that timeout — exercising the late-grant release path.
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 15 })
+    const block = Promise.withResolvers<void>()
+
+    const held = limiter.run(ROOM, async () => {
+      await block.promise
+    })
+    const skipped = await limiter.run(ROOM, async () => 'never')
+    expect(skipped).toEqual({ admitted: false })
+
+    block.resolve()
+    await held
+
+    // then: the slot is free again — a fresh job admits and runs.
+    await expect(limiter.run(ROOM, async () => 'ok')).resolves.toEqual({ admitted: true, value: 'ok' })
+  })
+
+  test('releases the slot even when work throws', async () => {
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 1000 })
+
+    await expect(limiter.run(ROOM, async () => Promise.reject(new Error('boom')))).rejects.toThrow('boom')
+    await expect(limiter.run(ROOM, async () => 'ok')).resolves.toEqual({ admitted: true, value: 'ok' })
+  })
+})
+
+describe('isWebexRateLimitError', () => {
+  test('matches the SDK rate-limit codes', () => {
+    expect(isWebexRateLimitError(Object.assign(new Error('Rate limited'), { code: 'rate_limited' }))).toBe(true)
+    expect(isWebexRateLimitError(Object.assign(new Error('HTTP 429'), { code: 'http_429' }))).toBe(true)
+  })
+
+  test('does not match other failures', () => {
+    expect(isWebexRateLimitError(Object.assign(new Error('boom'), { code: 'http_500' }))).toBe(false)
+    expect(isWebexRateLimitError(new Error('network down'))).toBe(false)
+    expect(isWebexRateLimitError(null)).toBe(false)
+    expect(isWebexRateLimitError('429')).toBe(false)
+  })
+})

--- a/src/channels/adapters/webex-prefetch-limiter.ts
+++ b/src/channels/adapters/webex-prefetch-limiter.ts
@@ -1,0 +1,120 @@
+// Webex's internal conversation API rate-limits reads PER ROOM, not per account:
+// hammering one room's history returns HTTP 429 (x-ratelimit-limit ~3, Retry-After
+// up to ~25s) while a different room served by the same token stays unaffected
+// (verified empirically — saturating room A produced zero 429s on room B). The
+// upstream agent-messenger SDK retries 429s, but its bucket tracker is reactive
+// (it learns the limit only after a 429 lands) and its 3-retry budget cannot
+// outlast a 25s window, so same-room pile-up — cold-start prefetch plus the
+// membership resolver's deriveMembershipFromHistory fallback, both reading the
+// same room — overflows the bucket and fails the prefetch.
+//
+// History prefetch is a context improvement, not liveness — the router skips it
+// and the agent can call channel_history on demand later. So the fix is keyed by
+// room: bound concurrent reads PER ROOM (independent rooms never wait on each
+// other) and keep cold-start non-blocking with bounded admission ("admit fast or
+// skip"), because starting then abandoning a listMessages we cannot cancel (the
+// SDK exposes no AbortSignal) would only burn more quota on an orphaned fetch.
+
+export type WebexPrefetchLimiter = {
+  // Runs `work` under the permit pool for `key` (the room id). If no slot frees
+  // within `admitTimeoutMs`, resolves to `{ admitted: false }` WITHOUT starting
+  // `work` — the caller then skips the prefetch. On admission, runs `work` and
+  // returns its result. Distinct keys never contend.
+  run<T>(key: string, work: () => Promise<T>): Promise<{ admitted: true; value: T } | { admitted: false }>
+}
+
+export type WebexPrefetchLimiterOptions = {
+  // Max concurrent reads PER ROOM. Defaults to 2: Webex's per-room cap is ~3, so
+  // 2 leaves headroom for the SDK's own retry traffic while still letting a
+  // prefetch and a membership-fallback read of the same room overlap.
+  concurrency?: number
+  // How long a queued caller waits for a slot before giving up and skipping.
+  // Defaults to 2500ms, matching the prior cold-fetch fail-fast posture so a
+  // backlog never stalls cold-start past the router's history ceiling.
+  admitTimeoutMs?: number
+}
+
+const DEFAULT_CONCURRENCY = 2
+const DEFAULT_ADMIT_TIMEOUT_MS = 2500
+
+export function createWebexPrefetchLimiter(options: WebexPrefetchLimiterOptions = {}): WebexPrefetchLimiter {
+  const concurrency = Math.max(1, Math.floor(options.concurrency ?? DEFAULT_CONCURRENCY))
+  const admitTimeoutMs = options.admitTimeoutMs ?? DEFAULT_ADMIT_TIMEOUT_MS
+
+  type Pool = { active: number; waiters: Array<() => void> }
+  const pools = new Map<string, Pool>()
+
+  const poolFor = (key: string): Pool => {
+    let pool = pools.get(key)
+    if (pool === undefined) {
+      pool = { active: 0, waiters: [] }
+      pools.set(key, pool)
+    }
+    return pool
+  }
+
+  const release = (key: string): void => {
+    const pool = pools.get(key)
+    if (pool === undefined) return
+    pool.active--
+    const next = pool.waiters.shift()
+    if (next) next()
+    // Drop idle pools so a long-lived limiter does not accumulate one entry per
+    // room ever seen.
+    else if (pool.active === 0 && pool.waiters.length === 0) pools.delete(key)
+  }
+
+  const acquire = (key: string): Promise<boolean> => {
+    const pool = poolFor(key)
+    if (pool.active < concurrency) {
+      pool.active++
+      return Promise.resolve(true)
+    }
+    return new Promise<boolean>((resolve) => {
+      let settled = false
+      const timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        const idx = pool.waiters.indexOf(grant)
+        if (idx >= 0) pool.waiters.splice(idx, 1)
+        resolve(false)
+      }, admitTimeoutMs)
+      const grant = (): void => {
+        if (settled) {
+          // Admitted after we already gave up: hand the freed slot to the next
+          // waiter so a timed-out grant never leaks a permanently-held slot.
+          release(key)
+          return
+        }
+        settled = true
+        clearTimeout(timer)
+        pool.active++
+        resolve(true)
+      }
+      pool.waiters.push(grant)
+    })
+  }
+
+  return {
+    async run<T>(key: string, work: () => Promise<T>): Promise<{ admitted: true; value: T } | { admitted: false }> {
+      const admitted = await acquire(key)
+      if (!admitted) return { admitted: false }
+      try {
+        return { admitted: true, value: await work() }
+      } finally {
+        release(key)
+      }
+    },
+  }
+}
+
+// The SDK throws WebexError with code 'rate_limited' once 429 retries are
+// exhausted, and 'http_429' for a raw 429 that bypassed the retry path. Both mean
+// the same thing to us: an expected, transient, non-fatal rate-limit skip — not an
+// auth/network failure worth a warn. Matching on the SDK's code field (rather than
+// the human message) keeps this stable across SDK message-wording changes.
+export function isWebexRateLimitError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const code = (err as { code?: unknown }).code
+  return code === 'rate_limited' || code === 'http_429'
+}

--- a/src/channels/adapters/webex.test.ts
+++ b/src/channels/adapters/webex.test.ts
@@ -15,6 +15,7 @@ import {
   type WebexAdapterLogger,
 } from './webex'
 import type { WebexInboundMessage } from './webex-classify'
+import { createWebexPrefetchLimiter } from './webex-prefetch-limiter'
 
 const config = channelsSchema.parse({ webex: {} }).webex!
 
@@ -461,18 +462,146 @@ describe('createWebexHistoryCallback reply attribution', () => {
     expect(history.find((m) => m.externalMessageId === 'child-1')?.replyToBotMessageId).toBeNull()
   })
 
-  test('fails fast when listMessages hangs past the cold-start timeout', async () => {
+  test('logs prefetch rate-limit skips at info with skipReason, not warn', async () => {
+    const log = logger()
     const cb = createWebexHistoryCallback({
-      client: { listMessages: () => new Promise<WebexMessage[]>(() => {}) },
+      client: {
+        listMessages: async () => Promise.reject(Object.assign(new Error('HTTP 429'), { code: 'http_429' })),
+      },
+      logger: log,
+      botPersonIdRef: () => 'bot-1',
+    })
+
+    const res = await cb({ chat: 'room-1', thread: null, limit: 50, prefetch: true })
+
+    expect(res).toEqual({ ok: false, error: 'HTTP 429', skipReason: 'rate-limited' })
+    expect(log.lines.some((l) => l.startsWith('info:') && l.includes('rate limited'))).toBe(true)
+    expect(log.lines.some((l) => l.startsWith('warn:'))).toBe(false)
+  })
+
+  test('warns (no skipReason) on a 429 from an explicit non-prefetch read', async () => {
+    const log = logger()
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async () => Promise.reject(Object.assign(new Error('HTTP 429'), { code: 'http_429' })),
+      },
+      logger: log,
+      botPersonIdRef: () => 'bot-1',
+    })
+
+    const res = await cb({ chat: 'room-1', thread: null, limit: 50 })
+
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('expected failure')
+    expect(res.skipReason).toBeUndefined()
+    expect(log.lines.some((l) => l.startsWith('warn:'))).toBe(true)
+  })
+
+  test('still logs non-rate-limit failures at warn', async () => {
+    const log = logger()
+    const cb = createWebexHistoryCallback({
+      client: { listMessages: async () => Promise.reject(new Error('boom')) },
+      logger: log,
+      botPersonIdRef: () => 'bot-1',
+    })
+
+    const res = await cb({ chat: 'room-1', thread: null, limit: 50, prefetch: true })
+
+    expect(res.ok).toBe(false)
+    expect(log.lines.some((l) => l.startsWith('warn:') && l.includes('boom'))).toBe(true)
+  })
+
+  test('skips a same-room prefetch without calling listMessages when the limiter cannot admit', async () => {
+    let calls = 0
+    const blockUntil = Promise.withResolvers<void>()
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 20 })
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async () => {
+          calls++
+          await blockUntil.promise
+          return [] as WebexMessage[]
+        },
+      },
       logger: logger(),
       botPersonIdRef: () => 'bot-1',
-      timeoutMs: 20,
+      limiter,
     })
-    const start = Date.now()
-    const res = await cb({ chat: 'room-1', thread: null, limit: 50 })
-    const elapsed = Date.now() - start
-    expect(res.ok).toBe(false)
-    expect(elapsed).toBeLessThan(500)
+
+    const held = cb({ chat: 'room-1', thread: null, limit: 50, prefetch: true })
+    const skipped = await cb({ chat: 'room-1', thread: null, limit: 50, prefetch: true })
+
+    expect(skipped).toEqual({
+      ok: false,
+      error: 'prefetch skipped: rate-limit backpressure',
+      skipReason: 'rate-limited',
+    })
+    expect(calls).toBe(1)
+    blockUntil.resolve()
+    await held
+    expect(calls).toBe(1)
+  })
+
+  test('an explicit (non-prefetch) read bypasses the limiter even under backpressure', async () => {
+    let prefetchCalls = 0
+    let explicitCalls = 0
+    const blockPrefetch = Promise.withResolvers<void>()
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 20 })
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async (_chat, opts) => {
+          // The prefetch caller over-requests by one; use the limit to tell the
+          // two callers apart so blocking is independent of scheduling order.
+          if ((opts?.max ?? 0) === 99) {
+            prefetchCalls++
+            await blockPrefetch.promise
+          } else {
+            explicitCalls++
+          }
+          return [] as WebexMessage[]
+        },
+      },
+      logger: logger(),
+      botPersonIdRef: () => 'bot-1',
+      limiter,
+    })
+
+    const heldPrefetch = cb({ chat: 'room-1', thread: null, limit: 99, prefetch: true })
+    const explicit = await cb({ chat: 'room-1', thread: null, limit: 50 })
+
+    expect(explicit.ok).toBe(true)
+    expect(explicitCalls).toBe(1)
+    blockPrefetch.resolve()
+    await heldPrefetch
+    expect(prefetchCalls).toBe(1)
+  })
+
+  test('does not throttle prefetches for different rooms', async () => {
+    let calls = 0
+    const blockUntil = Promise.withResolvers<void>()
+    const limiter = createWebexPrefetchLimiter({ concurrency: 1, admitTimeoutMs: 20 })
+    const cb = createWebexHistoryCallback({
+      client: {
+        listMessages: async () => {
+          calls++
+          await blockUntil.promise
+          return [] as WebexMessage[]
+        },
+      },
+      logger: logger(),
+      botPersonIdRef: () => 'bot-1',
+      limiter,
+    })
+
+    const held = cb({ chat: 'room-1', thread: null, limit: 50, prefetch: true })
+    const other = cb({ chat: 'room-2', thread: null, limit: 50, prefetch: true })
+
+    blockUntil.resolve()
+    const [a, b] = await Promise.all([held, other])
+
+    expect(a.ok).toBe(true)
+    expect(b.ok).toBe(true)
+    expect(calls).toBe(2)
   })
 })
 

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -37,6 +37,7 @@ import type { WebexAccountRecord } from '@/secrets/schema'
 import { createWebexChannelNameResolver } from './webex-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-classify'
 import { resolveWebexBodyText } from './webex-format'
+import { createWebexPrefetchLimiter, isWebexRateLimitError, type WebexPrefetchLimiter } from './webex-prefetch-limiter'
 import { enrichWebexMessageReference } from './webex-reference'
 
 export type WebexAdapterLogger = {
@@ -187,32 +188,40 @@ export function createTypingCallback(deps: {
   }
 }
 
-// The Webex REST/internal client offers no AbortSignal, so a hung `listMessages`
-// would otherwise block cold-start prefetch for the router's full 5s history
-// ceiling before degrading. Racing it against a tighter internal deadline lets
-// prefetch fall back to membership-derivation (or skip) seconds sooner, mirroring
-// the cold-fetch fail-fast posture the membership resolver already uses.
-const WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS = 2500
-
 export function createWebexHistoryCallback(deps: {
   client: Pick<WebexClient, 'listMessages'>
   logger: WebexAdapterLogger
   botPersonIdRef: () => string | null
-  timeoutMs?: number
+  limiter?: WebexPrefetchLimiter
 }): HistoryCallback {
-  const timeoutMs = deps.timeoutMs ?? WEBEX_HISTORY_COLD_FETCH_TIMEOUT_MS
+  const limiter = deps.limiter ?? createWebexPrefetchLimiter()
+  const listMessages = (args: FetchHistoryArgs) =>
+    deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) })
+  const toHistory = (messages: WebexMessage[]): FetchHistoryResult => {
+    const authorById = new Map(messages.map((m) => [m.ref, m.personRef]))
+    const botPersonId = deps.botPersonIdRef()
+    return { ok: true, messages: messages.map((m) => mapWebexHistoryMessage(m, botPersonId, authorById)).reverse() }
+  }
   return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
     try {
-      const messages = await raceWithTimeout(
-        deps.client.listMessages(args.chat, { max: clampLimit(args.limit, 100) }),
-        timeoutMs,
-        '[webex] history fetch',
-      )
-      const authorById = new Map(messages.map((m) => [m.ref, m.personRef]))
-      const botPersonId = deps.botPersonIdRef()
-      return { ok: true, messages: messages.map((m) => mapWebexHistoryMessage(m, botPersonId, authorById)).reverse() }
+      // Only best-effort reads (cold-start prefetch, membership fallback) submit
+      // to the per-room limiter. Explicit channel_history reads bypass it so a
+      // user-initiated look-back is never declined by prefetch backpressure.
+      if (args.prefetch !== true) {
+        return toHistory(await listMessages(args))
+      }
+      const outcome = await limiter.run(args.chat, () => listMessages(args))
+      if (!outcome.admitted) {
+        deps.logger.info('[webex] history prefetch skipped: rate-limit backpressure')
+        return { ok: false, error: 'prefetch skipped: rate-limit backpressure', skipReason: 'rate-limited' }
+      }
+      return toHistory(outcome.value)
     } catch (err) {
       const message = describe(err)
+      if (args.prefetch === true && isWebexRateLimitError(err)) {
+        deps.logger.info(`[webex] history prefetch skipped: rate limited (${message})`)
+        return { ok: false, error: message, skipReason: 'rate-limited' }
+      }
       deps.logger.warn(`[webex] history fetch failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -257,7 +266,7 @@ export function createWebexMembershipResolver(deps: {
     } catch (err) {
       deps.logger.warn(`[webex] membership room=${key.chat} failed: ${describe(err)}; deriving from recent history`)
       return await deriveMembershipFromHistory({
-        fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
+        fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit, prefetch: true }),
         now,
       })
     }
@@ -547,18 +556,6 @@ function clampLimit(requested: number, max: number): number {
 
 function describe(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
-}
-
-async function raceWithTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | null = null
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
-  })
-  try {
-    return await Promise.race([work, timeout])
-  } finally {
-    if (timer !== null) clearTimeout(timer)
-  }
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8368,6 +8368,26 @@ describe('ChannelRouter cold-start prefetch', () => {
     ).toBe(true)
   })
 
+  test('prefetch skip carrying skipReason rate-limited logs at info, not warn', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerHistory('discord-bot', async () => ({
+      ok: false,
+      error: 'prefetch skipped: rate-limit backpressure',
+      skipReason: 'rate-limited',
+    }))
+
+    await router.route(inbound({ externalMessageId: 'engage', text: 'still works' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(
+      logs.some((l) => l.startsWith('info:') && l.includes('prefetch skipped') && l.includes('rate limited')),
+    ).toBe(true)
+    expect(logs.some((l) => l.startsWith('warn:') && l.includes('prefetch skipped'))).toBe(false)
+  })
+
   test('no history adapter registered → prefetch quietly skipped, no error', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
@@ -8507,7 +8527,7 @@ describe('ChannelRouter cold-start prefetch', () => {
     await router.route(inbound({ thread: 't-A', externalMessageId: 'engage', text: 'hi' }))
     await router.__testing!.flushDebounce(THREAD_KEY)
 
-    expect(captured).toEqual([{ chat: 'c1', thread: 't-A', limit: 8 }])
+    expect(captured).toEqual([{ chat: 'c1', thread: 't-A', limit: 8, prefetch: true }])
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1999,10 +1999,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       chat: live.key.chat,
       thread: live.key.thread,
       limit: requested,
+      prefetch: true,
     })
 
     if (!result.ok) {
-      logger.warn(`[channels] ${live.keyId}: prefetch skipped (history fetch failed: ${result.error})`)
+      // An adapter that declined a best-effort read to avoid hammering a
+      // rate-limited resource is expected optional-context loss, not a failure —
+      // log it at info so it does not masquerade as an auth/network warning.
+      if (result.skipReason === 'rate-limited') {
+        logger.info(`[channels] ${live.keyId}: prefetch skipped (rate limited: ${result.error})`)
+      } else {
+        logger.warn(`[channels] ${live.keyId}: prefetch skipped (history fetch failed: ${result.error})`)
+      }
       return
     }
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -339,11 +339,18 @@ export type FetchHistoryArgs = {
   thread: string | null
   limit: number
   cursor?: string
+  // Set by best-effort callers (cold-start prefetch, membership fallback) to opt
+  // into adapter-side rate-limit backpressure. Explicit reads (channel_history)
+  // leave it unset so they always attempt the fetch under the router's timeout.
+  prefetch?: boolean
 }
 
 export type FetchHistoryResult =
   | { ok: true; messages: ChannelHistoryMessage[]; nextCursor?: string }
-  | { ok: false; error: string }
+  // `skipReason: 'rate-limited'` marks an expected, optional-context skip (the
+  // adapter declined a best-effort read to avoid hammering a rate-limited
+  // resource) so callers can log it at info instead of warn.
+  | { ok: false; error: string; skipReason?: 'rate-limited' }
 
 // Registered per-adapter on the ChannelRouter alongside outbound/typing
 // callbacks. Adapters that cannot fetch history (e.g. webhook-only future


### PR DESCRIPTION
## Background

A Webex session surfaced `[webex] history fetch failed: HTTP 429` and the agent
reported it couldn't read recent messages. The symptom is rate limiting on
cold-start history prefetch.

Reproduced against a live Webex account through the same SDK the adapter uses.
The rate limit is **per room, not per account** (verified directly):

- Saturating room A with 20 concurrent reads produced 17× 429 (`x-ratelimit-limit:
  3`, `Retry-After` up to **25s**), while room B — same token, hit at the same
  moment — returned **3/3 OK, zero 429**. Only room A's id appeared in the 429s.
- That endpoint returns no `x-ratelimit-remaining`/`reset`, so the upstream
  `agent-messenger` SDK's proactive tracker is blind there — it only learns it's
  limited *after* a 429 lands. Its 3-retry budget can't outlast a 25s window.
- So the failure is **same-room** read pile-up overflowing that room's small
  bucket: cold-start prefetch plus the membership resolver's
  `deriveMembershipFromHistory` fallback, both reading the same room, plus the
  SDK's own retry traffic.

## Summary

Add a **per-room** prefetch concurrency limiter (keyed by room id) and adopt it in
both the `webex` and `webex-bot` history callbacks.

Key decisions:

- **Key by room, not adapter/account.** The rate limit is per-room, so independent
  rooms must never wait on each other — a global limiter would needlessly serialize
  unrelated rooms on restart. Default concurrency **2** (under Webex's ~3 cap, with
  headroom for SDK retry traffic).
- **Limit concurrency, don't add retries.** The SDK already retries 429s; a second
  retry layer would only lengthen cold-start and pile more onto a saturated bucket.
- **Admit-or-skip, not start-then-abandon.** The old per-call `raceWithTimeout` was
  illusory cancellation: `listMessages` exposes no `AbortSignal`, so the race only
  abandoned the *result* while the fetch kept running and burning quota. The limiter
  refuses to *start* a read it can't admit within a bounded budget, keeping
  cold-start non-blocking without leaking in-flight requests.
- **429 skips log at `info`, not `warn`.** Prefetch is optional context, not
  liveness — the router already continues on skip and the agent can pull history via
  `channel_history`. Real auth/network failures still `warn`. Classification matches
  the SDK's `code` field (`rate_limited`/`http_429`), not the human message.

## What this does NOT do

- Does **not** touch on-demand `channel_history` — only cold-start prefetch is
  limited. (Extend the limiter to cover it if on-demand reads start hitting 429.)
- Does **not** change the upstream `agent-messenger` SDK retry behavior.
- Does **not** address the separate **credential-refresh rename race** observed
  during the burst (`ENOENT … webex-credentials.json.tmp`) — concurrent token
  refreshes racing on a shared temp path. Flagged for a separate fix.

## Review notes

- Load-bearing file: `webex-prefetch-limiter.ts`. Two invariants to verify:
  1. **Distinct keys never contend** — the per-room permit pool (covered by
     "different rooms never contend" tests in all three test files).
  2. **A timed-out grant releases its slot** (`grant()` when `settled`) — without
     it, a waiter that times out and is later granted would leak a permit and wedge
     that room's pool at zero free slots. Covered by the "timed-out grant releases
     its slot" test.
- Idle per-room pools are evicted on release so a long-lived limiter doesn't
  accumulate one entry per room ever seen.
- The two pre-existing `scaffold`/`*.schema.json`/`startDaemon` test failures on CI
  are unrelated to this change (they also fail on the base commit with no Webex
  changes).
