### PR TITLE
fix: deflake embedder test fakes, xAI provider re-registration, and hostd boot-restore tests

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-batch.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-batch.test.ts
@@ -1,34 +1,44 @@
-import { beforeAll, describe, expect, mock, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 
-import { __setModelCacheCheckForTests, DIMS } from './embedder'
+import { EMBEDDING_DIMS } from '@/models/embedding-model'
 
 // Records the size of every onnxruntime forward pass so the test can prove the
 // embed is chunked (bounding peak memory) rather than run as one giant batch.
 const batchSizes: number[] = []
 
-mock.module('@huggingface/transformers', () => ({
-  env: {},
-  pipeline: async () => {
+type EmbedderModule = typeof import('./embedder')
+type TransformersImporter = NonNullable<Parameters<EmbedderModule['__setTransformersImporterForTests']>[0]>
+type TransformersModule = Awaited<ReturnType<TransformersImporter>>
+
+async function freshEmbedderModule(): Promise<EmbedderModule> {
+  const mod = await import(`./embedder?batch=${crypto.randomUUID()}`)
+  mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  const pipeline = (async () => {
     return (texts: string[]) => {
       const count = Array.isArray(texts) ? texts.length : 1
       batchSizes.push(count)
       // Stamp each row's first lane with a running global index so the caller
       // can assert order is preserved across chunk boundaries.
-      const data = new Float32Array(count * DIMS)
+      const data = new Float32Array(count * EMBEDDING_DIMS)
       const base = batchSizes.slice(0, -1).reduce((sum, n) => sum + n, 0)
-      for (let i = 0; i < count; i++) data[i * DIMS] = base + i
+      for (let i = 0; i < count; i++) data[i * EMBEDDING_DIMS] = base + i
       return { data }
     }
-  },
-}))
+  }) as TransformersModule['pipeline']
+  mod.__setTransformersImporterForTests(async () => ({
+    env: {} as never,
+    pipeline,
+  }))
+  return mod
+}
 
 describe('embedder batching', () => {
-  beforeAll(() => {
-    __setModelCacheCheckForTests(() => Promise.resolve())
+  beforeEach(() => {
+    batchSizes.length = 0
   })
 
   test('splits a large input set into bounded forward passes and preserves order', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
     const inputs = Array.from({ length: 150 }, (_, i) => `passage ${i}`)
 
     const out = await embed(inputs, 'passage')

--- a/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-lazy-load.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, mock, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
 
 // Regression guard for the container-boot crash: `@huggingface/transformers`
 // eagerly `import sharp`s at module-evaluation time, and the memory plugin
@@ -6,39 +6,72 @@ import { beforeAll, describe, expect, mock, test } from 'bun:test'
 // `vector.enabled` defaulting to false. If embedder.ts ever goes back to a
 // top-level `import { env, pipeline } from '@huggingface/transformers'`, the
 // transformers module would evaluate the moment embedder.ts is imported —
-// dragging sharp onto every boot and crashing the container. This test proves
+// dragging sharp onto every boot and crashing the container. These tests prove
 // the import is deferred to first embed.
 let transformersEvaluated = false
 let lastPipelineOptions: Record<string, unknown> | undefined
 
-mock.module('@huggingface/transformers', () => {
-  transformersEvaluated = true
-  return {
-    env: {},
-    pipeline: async (_task: string, _model: string, options?: Record<string, unknown>) => {
+type EmbedderModule = typeof import('./embedder')
+type TransformersImporter = NonNullable<Parameters<EmbedderModule['__setTransformersImporterForTests']>[0]>
+type TransformersModule = Awaited<ReturnType<TransformersImporter>>
+
+function fakeTransformersModule(): TransformersImporter {
+  return async () => {
+    transformersEvaluated = true
+    const pipeline = (async (_task: string, _model?: string, options?: Record<string, unknown>) => {
       lastPipelineOptions = options
       const extractor = () => ({ data: new Float32Array(768) })
       return extractor
-    },
+    }) as TransformersModule['pipeline']
+    return {
+      env: {} as never,
+      pipeline,
+    }
   }
-})
+}
+
+async function freshEmbedderModule(): Promise<EmbedderModule> {
+  const mod = await import(`./embedder?lazy=${crypto.randomUUID()}`)
+  mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  mod.__setTransformersImporterForTests(fakeTransformersModule())
+  return mod
+}
 
 describe('embedder lazy transformers load', () => {
-  // Importing the module to set the seam does NOT evaluate transformers (that is
-  // exactly what the first test asserts) — the cache check is a separate concern
-  // with its own coverage, so a no-op keeps these tests off a real model cache.
-  beforeAll(async () => {
-    const mod = await import('./embedder')
-    mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  beforeEach(() => {
+    transformersEvaluated = false
+    lastPipelineOptions = undefined
   })
 
-  test('importing the embedder module does NOT evaluate @huggingface/transformers', async () => {
-    await import('./embedder')
-    expect(transformersEvaluated).toBe(false)
+  test('importing the embedder module does NOT evaluate @huggingface/transformers', () => {
+    // The flag-based seam below only fires for the FAKE importer, which is
+    // installed after embedder.ts is already imported — so it cannot observe a
+    // top-level static import that evaluates the REAL module during embedder.ts
+    // module evaluation. This guard runs in a child bun process that mocks the
+    // specifier and fails if the mock factory is invoked while importing
+    // embedder.ts, catching exactly that regression without leaking Bun's
+    // process-global mock.module into the sibling tests.
+    const embedderUrl = `${new URL('./embedder.ts', import.meta.url).href}?lazy=${crypto.randomUUID()}`
+    const script = `
+      import { mock } from 'bun:test'
+      let transformersRequested = false
+      mock.module('@huggingface/transformers', () => {
+        transformersRequested = true
+        return { env: {}, pipeline: async () => { throw new Error('pipeline must not run during module eval') } }
+      })
+      await import(${JSON.stringify(embedderUrl)})
+      if (transformersRequested) {
+        console.error('@huggingface/transformers was requested while evaluating embedder.ts')
+        process.exit(1)
+      }
+    `
+    const result = Bun.spawnSync({ cmd: [process.execPath, '--eval', script], stdout: 'pipe', stderr: 'pipe' })
+    const output = new TextDecoder().decode(result.stderr) || new TextDecoder().decode(result.stdout)
+    expect(result.exitCode, output).toBe(0)
   })
 
   test('@huggingface/transformers is evaluated only when an embedding is actually requested', async () => {
-    const { getEmbedder } = await import('./embedder')
+    const { getEmbedder } = await freshEmbedderModule()
     expect(transformersEvaluated).toBe(false)
 
     await getEmbedder()
@@ -46,7 +79,7 @@ describe('embedder lazy transformers load', () => {
   })
 
   test('loads the q8 variant locally (dtype pinned, local_files_only preserved)', async () => {
-    const { getEmbedder } = await import('./embedder')
+    const { getEmbedder } = await freshEmbedderModule()
 
     await getEmbedder()
 

--- a/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-truncation.test.ts
@@ -1,30 +1,44 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { __setModelCacheCheckForTests, DIMS } from './embedder'
+import { EMBEDDING_DIMS } from '@/models/embedding-model'
+
 import { estimateTokens, TEXT_TOKEN_BUDGET } from './truncation'
-
-__setModelCacheCheckForTests(() => Promise.resolve())
 
 let lastExtractorInput: string[] | undefined
 let lastExtractorOptions: Record<string, unknown> | undefined
 
-mock.module('@huggingface/transformers', () => ({
-  env: {},
-  pipeline: async () => {
+type EmbedderModule = typeof import('./embedder')
+type TransformersImporter = NonNullable<Parameters<EmbedderModule['__setTransformersImporterForTests']>[0]>
+type TransformersModule = Awaited<ReturnType<TransformersImporter>>
+
+async function freshEmbedderModule(): Promise<EmbedderModule> {
+  const mod = await import(`./embedder?truncation=${crypto.randomUUID()}`)
+  mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  const pipeline = (async () => {
     return (texts: string[], options?: Record<string, unknown>) => {
       lastExtractorInput = texts
       lastExtractorOptions = options
       const count = Array.isArray(texts) ? texts.length : 1
-      return { data: new Float32Array(count * DIMS) }
+      return { data: new Float32Array(count * EMBEDDING_DIMS) }
     }
-  },
-}))
+  }) as TransformersModule['pipeline']
+  mod.__setTransformersImporterForTests(async () => ({
+    env: {} as never,
+    pipeline,
+  }))
+  return mod
+}
 
 const overBudgetText = 'word '.repeat(TEXT_TOKEN_BUDGET * 4)
 
 describe('embedder bounding', () => {
+  beforeEach(() => {
+    lastExtractorInput = undefined
+    lastExtractorOptions = undefined
+  })
+
   test('extracts with mean pooling and normalized embeddings', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(['short passage'], 'passage')
 
@@ -33,7 +47,7 @@ describe('embedder bounding', () => {
   })
 
   test('bounds an over-budget passage to the token budget before the extractor sees it', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed([overBudgetText], 'passage')
 
@@ -44,7 +58,7 @@ describe('embedder bounding', () => {
   })
 
   test('passes an in-budget passage through unchanged', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(['a short belief sentence'], 'passage')
 
@@ -52,7 +66,7 @@ describe('embedder bounding', () => {
   })
 
   test('bounds an over-budget query too (no silent loss on the retrieval side)', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed([overBudgetText], 'query')
 
@@ -66,6 +80,8 @@ describe('embedder bounding observability', () => {
   const originalWarn = console.warn
 
   beforeEach(() => {
+    lastExtractorInput = undefined
+    lastExtractorOptions = undefined
     warnings = []
     console.warn = (message?: unknown) => {
       warnings.push(String(message))
@@ -77,7 +93,7 @@ describe('embedder bounding observability', () => {
   })
 
   test('warns content-free with the type and count when an input is bounded', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(['in budget', overBudgetText], 'query')
 
@@ -90,7 +106,7 @@ describe('embedder bounding observability', () => {
   })
 
   test('does not warn about bounding when every input is within budget', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(['short a', 'short b'], 'passage')
 
@@ -105,6 +121,8 @@ describe('embedder batch-size observability', () => {
   const originalInfo = console.info
 
   beforeEach(() => {
+    lastExtractorInput = undefined
+    lastExtractorOptions = undefined
     warnings = []
     notices = []
     console.warn = (message?: unknown) => {
@@ -121,7 +139,7 @@ describe('embedder batch-size observability', () => {
   })
 
   test('logs the total embed size and chunk width at info for a small build', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(['short a', 'short b'], 'passage')
 
@@ -131,7 +149,7 @@ describe('embedder batch-size observability', () => {
   })
 
   test('notes a large build is slow but does not warn — chunking removed the OOM risk', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(
       Array.from({ length: 256 }, (_, i) => `passage ${i}`),
@@ -160,7 +178,7 @@ describe('embedder progress observability', () => {
   })
 
   test('reports per-chunk progress for a large build, ending at 100%', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(
       Array.from({ length: 256 }, (_, i) => `passage ${i}`),
@@ -175,7 +193,7 @@ describe('embedder progress observability', () => {
   })
 
   test('does not report per-chunk progress for a small build', async () => {
-    const { embed } = await import('./embedder')
+    const { embed } = await freshEmbedderModule()
 
     await embed(['short a', 'short b'], 'passage')
 

--- a/src/bundled-plugins/memory/vector/embedder-warm.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-warm.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 
 // A controllable transformers fake whose pipeline load can be made to fail on
 // demand, so we can prove getEmbedder/warmEmbedder recover from a transient
@@ -9,14 +9,20 @@ import { describe, expect, mock, test } from 'bun:test'
 let pipelineCalls = 0
 let failNextPipeline = false
 
-mock.module('@huggingface/transformers', () => ({
-  env: {},
-  pipeline: async () => {
-    pipelineCalls += 1
-    if (failNextPipeline) throw new Error('local_files_only: model weights missing')
-    return () => ({ data: new Float32Array(768) })
-  },
-}))
+type EmbedderModule = typeof import('./embedder')
+type TransformersImporter = NonNullable<Parameters<EmbedderModule['__setTransformersImporterForTests']>[0]>
+type TransformersModule = Awaited<ReturnType<TransformersImporter>>
+
+function fakeTransformersModule(): TransformersImporter {
+  return async () => ({
+    env: {} as never,
+    pipeline: (async () => {
+      pipelineCalls += 1
+      if (failNextPipeline) throw new Error('local_files_only: model weights missing')
+      return () => ({ data: new Float32Array(768) })
+    }) as TransformersModule['pipeline'],
+  })
+}
 
 describe('embedder warm-up and retry-safe memoization', () => {
   test('warmEmbedder loads the embedder so a later call reuses the singleton', async () => {
@@ -85,5 +91,6 @@ describe('embedder warm-up and retry-safe memoization', () => {
 async function freshEmbedderModule(): Promise<typeof import('./embedder')> {
   const mod = await import(`./embedder?warm=${crypto.randomUUID()}`)
   mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  mod.__setTransformersImporterForTests(fakeTransformersModule())
   return mod
 }

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -703,6 +703,11 @@ describe('startDaemon', () => {
 
     daemon = await startDaemon({ exec: fakeExec(new Set(['coder'])), gcIntervalMs: 1_000_000, restart })
 
+    // status awaits restore; gate on it before asserting list, which is part of
+    // the non-blocking readiness surface and otherwise races the async restore.
+    const restored = await send({ kind: 'status', containerName: 'coder' })
+    expect(restored.ok).toBe(true)
+
     const list = await send({ kind: 'list' })
     expect(list.ok).toBe(true)
     if (!list.ok) return
@@ -723,7 +728,7 @@ describe('startDaemon', () => {
     expect(restartCalls).toEqual([{ containerName: 'coder', cwd: '/agent/coder' }])
   })
 
-  test('boot-time restore tolerates corrupted registration files', async () => {
+  test('boot-time restore tolerates corrupted registration files (asserted after restore completes)', async () => {
     const alive = new Set(['good'])
     daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000 })
     await send({ kind: 'register', containerName: 'good', cwd: '/agent/good' })
@@ -733,6 +738,14 @@ describe('startDaemon', () => {
     await writeFile(join(registrationsDir(), 'mismatch.json'), JSON.stringify({ containerName: 'other', cwd: '/x' }))
 
     daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000 })
+
+    // `list` is part of the non-blocking readiness surface and does NOT wait for
+    // restore, so the first list after boot can race the async restore and read a
+    // half-built registry. Gate on a restore-aware RPC (status awaits restore)
+    // before asserting authoritative registry state — otherwise this asserts
+    // scheduler timing, not corrupted-file tolerance.
+    const status = await send({ kind: 'status', containerName: 'good' })
+    expect(status.ok).toBe(true)
 
     const list = await send({ kind: 'list' })
     expect(list.ok).toBe(true)
@@ -766,7 +779,9 @@ describe('startDaemon', () => {
     startCalls.length = 0
     daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, portbroker })
 
-    expect(startCalls).toHaveLength(1)
+    // Restore applies registrations (and fires portbroker.start) asynchronously;
+    // wait for the broker-start callback rather than racing it right after boot.
+    await waitFor(() => startCalls.length === 1)
     expect(startCalls[0]?.containerName).toBe('with-broker')
     expect(startCalls[0]?.cwd).toBe('/agent/with-broker')
     expect(startCalls[0]?.wsHostPort).toBe(54321)
@@ -805,8 +820,11 @@ describe('startDaemon', () => {
     startCalls.length = 0
     daemon = await startDaemon({ exec: fakeExec(new Set()), gcIntervalMs: 1_000_000, portbroker })
 
+    // Restore runs async; unlinking the gone container's file is its last step,
+    // so waiting on the unlink is the deterministic restore-complete signal here.
+    // A bare existsSync / list right after startDaemon races restore (the CI flake).
+    await waitFor(() => !existsSync(filePath))
     expect(startCalls).toHaveLength(0)
-    expect(existsSync(filePath)).toBe(false)
 
     const list = await send({ kind: 'list' })
     expect(list.ok).toBe(true)
@@ -843,7 +861,9 @@ describe('startDaemon', () => {
     startCalls.length = 0
     daemon = await startDaemon({ exec: flakyExec, gcIntervalMs: 1_000_000, portbroker })
 
-    expect(startCalls).toHaveLength(1)
+    // Restore is async; wait for the broker-start callback (its observable effect)
+    // instead of asserting right after boot, which races the restore.
+    await waitFor(() => startCalls.length === 1)
     expect(existsSync(registrationFilePath('flaky'))).toBe(true)
   })
 

--- a/src/secrets/oauth-xai.test.ts
+++ b/src/secrets/oauth-xai.test.ts
@@ -29,6 +29,20 @@ describe('registerXaiOAuthProvider', () => {
     expect(provider?.name).toBe('xAI (Grok)')
     expect(provider?.usesCallbackServer).toBe(true)
   })
+
+  test('re-registers after the registry is cleared while the module-level flag stays true', () => {
+    // given: a first registration sets the module-level `registered` flag true
+    registerXaiOAuthProvider()
+    // when: the registry is cleared out from under us (the `registered` flag is
+    // unaffected — it's module-level state pi-ai's registry can't reach), then
+    // registerXaiOAuthProvider() is called again
+    unregisterOAuthProvider(XAI_OAUTH_PROVIDER_ID)
+    expect(getOAuthProvider(XAI_OAUTH_PROVIDER_ID)).toBeUndefined()
+    registerXaiOAuthProvider()
+    // then: the cleared provider is restored rather than skipped by the flag —
+    // this guards the `&& getOAuthProvider(...)` half of the idempotency check
+    expect(getOAuthProvider(XAI_OAUTH_PROVIDER_ID)?.id).toBe('xai')
+  })
 })
 
 describe('xaiOAuthProvider.getApiKey', () => {

--- a/src/secrets/oauth-xai.ts
+++ b/src/secrets/oauth-xai.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http'
 
-import { registerOAuthProvider } from '@mariozechner/pi-ai/oauth'
+import { getOAuthProvider, registerOAuthProvider } from '@mariozechner/pi-ai/oauth'
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from '@mariozechner/pi-ai/oauth'
 
 // xAI (Grok) OAuth 2.0. xAI runs a standard OIDC authorization server at
@@ -336,7 +336,7 @@ let registered = false
 // so the provider is always present before `AuthStorage.login()` /
 // `getApiKey()` look it up via `getOAuthProvider('xai')`.
 export function registerXaiOAuthProvider(): void {
-  if (registered) return
+  if (registered && getOAuthProvider(XAI_OAUTH_PROVIDER_ID)) return
   registerOAuthProvider(xaiOAuthProvider)
   registered = true
 }


### PR DESCRIPTION
## Background

Three independent flakiness sources were found while working on the hephaestus fix suite.

**Embedder tests:** All four embedder test files called `mock.module` from bun:test at the top level.
`mock.module` installs a **process-global** override, so whichever file ran first won and the rest silently received a stale or wrong fake.
Running with --parallel or reordering tests produced different results — the classic shared-global-mutable-module-registry flaw.

**xAI OAuth re-registration:** `registerXaiOAuthProvider` guarded re-registration with a module-level registered flag.
If the global OAuth provider registry was externally cleared after the flag was set to true, a second call early-exited on the flag,
leaving the xai provider absent from the registry.
Any subsequent getApiKey() or AuthStorage.login() call for xAI then threw a "provider not found" error.

**hostd boot-restore race:** Boot-time registration restore runs **asynchronously** (concurrent with the socket listener).
Several daemon tests asserted registry state (`list`) or restore side effects (portbroker start, leftover-file unlink)
immediately after a restart `startDaemon`, racing that restore. `list` is deliberately part of the **non-blocking readiness
surface** (it backs `isDaemonReachable`) and does not wait for restore, so the first `list` after boot could read a half-built
registry. This surfaced as the intermittent CI failure in `boot-time restore tolerates corrupted registration files` — it passed
in isolation but failed under full-suite parallel load.

## Summary

**Embedder isolation:** Replace the top-level mock.module call with the `__setTransformersImporterForTests` seam
already threaded through `embedder.ts`.
Each test file now calls `freshEmbedderModule()`, which imports the embedder with a unique query-string cache-buster
so Bun allocates a fresh module instance per suite — no shared global state.
The mock import is removed from all four files.

The embedder-warm.test.ts file already had the freshEmbedderModule helper but was missing the
`__setTransformersImporterForTests` call, so warm-up tests were accidentally relying on whatever transformer
fake happened to win globally. Adding the call closes that gap.

The lazy-load regression guard (`importing the embedder module does NOT evaluate @huggingface/transformers`) is
strengthened: the previous in-process flag could only observe the *fake* importer (installed after import) and so could
never detect a top-level static import that evaluates the real module during module eval. It now runs a **subprocess
sentinel** — a child bun process that mocks `@huggingface/transformers` and fails if the mock factory is invoked while
importing `embedder.ts` — catching exactly that regression without leaking the process-global mock into sibling tests.

**xAI guard:** Tighten the early-exit condition to `if (registered && getOAuthProvider(XAI_OAUTH_PROVIDER_ID))`.
This makes the flag a cache hint rather than a hard gate — if the registry was cleared, `getOAuthProvider` returns falsy
and registerOAuthProvider runs again.
The flag still short-circuits the common path (provider present in both flag and registry), so normal boot pays no extra overhead.
A register → clear-registry → register-again regression test now locks this in.

**hostd guard:** Gate each authoritative assertion on a restore-aware signal instead of timing — `status` (which awaits
restore) before `list`, and `waitFor` on the restore's observable effect (broker-start callback, leftover-file unlink) for
the rest. Production `daemon.ts` is unchanged: `list`'s non-blocking readiness contract is correct, and gating it would
deadlock `isDaemonReachable`. Only the tests' assumption that the first post-boot `list` is authoritative was wrong.

## What this does NOT do

- Does not change any embedder behavior or the transformer loading contract — only the test seam is touched.
- Does not change the xAI provider definition or OAuth flow — only the registration guard logic.
- Does not change daemon behavior — `list` stays a non-blocking readiness probe; only the test synchronization was fixed.
- Does not introduce new test infrastructure; the transformer importer seam and freshEmbedderModule pattern
  already existed in embedder-warm.test.ts.

## Review notes

- **Load-bearing seam:** `__setTransformersImporterForTests` in embedder.ts — confirm all four test files call it
  (via freshEmbedderModule) before any embed / getEmbedder invocation.
- **Cache-buster pattern:** each freshEmbedderModule import uses a unique query string to get a distinct module namespace
  in Bun's cache. This pattern already existed in embedder-warm.test.ts and is now applied consistently.
- **Subprocess sentinel:** the lazy-load guard spawns a child bun process (`process.execPath --eval`) so its
  `mock.module` cannot pollute the sibling injectable-seam tests. Verified it fails on a reintroduced top-level runtime
  import and passes on the current lazy import.
- **xAI guard:** `getOAuthProvider` is the only addition in oauth-xai.ts. It hits the same in-memory map that
  registerOAuthProvider writes to, so there is no I/O cost.
- **hostd race:** `list` is intentionally NOT gated on restore (readiness surface); the fix is in the tests, which now
  gate on `status`/`waitFor` before asserting restored state. Each affected test verified deterministic across repeated runs.
- **Verification:** run `bun test --parallel --rerun-each 5` on the four embedder files and the secrets suite,
  the hostd daemon suite, plus `bun run typecheck`, lint, format:check, and the full test suite (5x) — all clean.
