### PR TITLE
fix(run): raise codex overall-timeout ceiling to 300s

### DIFF
--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -42,11 +42,16 @@ export type CodexFetchObserverOptions = {
   // request occupied 901s before Bun's OS socket deadline fired). On expiry the
   // request is aborted with a retryable error, so this also bounds how long a
   // user waits before the retry fires — keeping it low is a UX requirement, not
-  // just a safety net. Default 120_000 ms: across 96 observed requests the
-  // slowest *healthy* (completed) one was 45s and p99 was ~30s, with a clean
-  // gap up to the 901s hang — so 120s is ~2.7x the healthy max (ample headroom
-  // for PoP/TLS outliers) while capping a real hang at ~2min instead of ~15min.
-  // Set to 0 to disable just this timer.
+  // just a safety net. Default 300_000 ms (raised from 120_000): the 120s cap
+  // was tuned against a light-turn sample (slowest healthy ~45s, p99 ~30s) and
+  // aborted heavy reasoning turns that were still legitimately trickling bytes
+  // — PR reviews, the `dreaming` memory consolidation, and long channel threads
+  // routinely run a slow-trickle stream past 2min (observed total_ms=120009 with
+  // body_bytes>700k on otherwise-progressing turns). Those are NOT the silent
+  // hang this timer exists to catch; the sliding `idleMs` (still 120s) already
+  // bounds genuine dead air per-chunk, so the wall-clock ceiling only needs to
+  // stop a never-terminating stream. 300s caps a real hang at ~5min while giving
+  // heavy turns the headroom they need. Set to 0 to disable just this timer.
   overallMs?: number
   // Schedule fn for tests. Receives (delayMs, callback) and returns a handle
   // the wrapper can pass to `clear`. Default: `setTimeout`/`clearTimeout`.
@@ -67,7 +72,7 @@ const ENV_IDLE_MS = 'TYPECLAW_CODEX_IDLE_MS'
 const ENV_OVERALL_MS = 'TYPECLAW_CODEX_OVERALL_MS'
 const DEFAULT_TTFB_MS = 15_000
 const DEFAULT_IDLE_MS = 120_000
-const DEFAULT_OVERALL_MS = 120_000
+const DEFAULT_OVERALL_MS = 300_000
 const LOG_PREFIX = '[codex-fetch]'
 
 const defaultScheduler: TimeoutScheduler = {


### PR DESCRIPTION
## Background

A typeclaw agent running on `openai-codex/gpt-5.5` was producing user-visible turn failures. Across one 6-hour window on a production agent, **547** Codex requests yielded **6** aborts with `cause=overall_timeout` (e.g. `total_ms=120009` with `body_bytes>700k`), on top of the upstream `server_is_overloaded` events.

Root cause: the absolute wall-clock ceiling in `codex-fetch-observer.ts` (`DEFAULT_OVERALL_MS = 120_000`) was tuned against a light-turn sample (slowest *healthy* turn ~45s, p99 ~30s). Heavy reasoning turns — PR reviews, the `dreaming` memory consolidation, and long channel threads — legitimately stream bytes for longer than 2 minutes. The ceiling does not reset on chunk arrival, so it aborted these *progressing* streams even though they were not the silent-hang failure mode the timer exists to catch.

## Summary

Raise `DEFAULT_OVERALL_MS` to `300_000`.

Why the overall timer and not `idleMs`: `idleMs` (the sliding per-chunk deadline, left at 120s) already bounds genuine dead air between SSE chunks. The overall ceiling's only job is to stop a stream that trickles bytes forever without reaching a terminal event. 300s caps a real hang at ~5min while giving heavy turns the headroom they need.

Why not larger / disable: the timer also bounds how long a user waits before the retry fires, so it stays as low as the heavy-turn workload allows.

## What this does NOT do

- Does not touch `ttfbMs` (15s, pre-headers/"first response" timer) or `idleMs` (120s, per-chunk).
- Does not address `server_is_overloaded` — that is upstream Codex capacity, separate from this wall-clock ceiling.
- No new config surface; the existing `TYPECLAW_CODEX_OVERALL_MS` env override is unchanged.

## Review notes

Load-bearing change is the single constant `DEFAULT_OVERALL_MS`. Invariant to keep: `idleMs <= overallMs` (120s ≤ 300s holds). No test pins the default value (env-override and explicit-`overallMs` tests use their own values), so all 25 observer tests pass unchanged.
