### PR TITLE
fix(channels): recover empty stop after tool work instead of going silent

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -21,6 +21,7 @@ import {
   createChannelRouter,
   disengageReactionEmojiFor,
   DUPLICATE_SEND_ERROR,
+  EMPTY_STOP_AFTER_TOOL_WORK_NUDGE,
   EMPTY_TURN_FALLBACK_TEXT,
   EMPTY_TURN_RETRY_NUDGE,
   extractPlainTextChannelToolCallText,
@@ -245,6 +246,60 @@ function strandOnUnansweredToolUse(session: FakeSession, id: string = 'strand'):
   session.entriesById.set(assistantEntry.id, assistantEntry)
   session.entriesById.set(toolResultEntry.id, toolResultEntry)
   session.leafEntry = toolResultEntry
+}
+
+// A bare-empty `stop` leaf whose parentId chain runs back through a web_search
+// tool call to a bounding user entry — the production shape recoverableAssistantText
+// recovers as { text: '', source: 'leaf' } while attemptMadeToolCall still finds
+// the tool work. Pass userId null to drop the bounding user entry and exercise the
+// walk terminating on depth/root instead of a turn boundary.
+function emptyStopAfterToolWork(session: FakeSession, id: string = 'tw', userId: string | null = `user-${id}`): void {
+  const toolCallId = `tool-${id}`
+  if (userId !== null) {
+    session.entriesById.set(userId, {
+      type: 'message',
+      id: userId,
+      parentId: null,
+      timestamp: '2026-06-15T06:23:44.000Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'q' }], timestamp: 1000 },
+    } as unknown as SessionEntry)
+  }
+  const toolCallEntry: SessionEntry = {
+    type: 'message',
+    id: `assistant-toolcall-${id}`,
+    parentId: userId,
+    timestamp: '2026-06-15T06:23:45.000Z',
+    message: {
+      ...assistantMessage(''),
+      content: [{ type: 'toolCall', id: toolCallId, name: 'web_search', arguments: { query: 'x' } }],
+      stopReason: 'toolUse',
+    },
+  }
+  const toolResultEntry: SessionEntry = {
+    type: 'message',
+    id: `tool-result-${id}`,
+    parentId: toolCallEntry.id,
+    timestamp: '2026-06-15T06:23:45.500Z',
+    message: {
+      role: 'toolResult',
+      toolCallId,
+      toolName: 'web_search',
+      content: [{ type: 'text', text: 'junk results' }],
+      isError: false,
+      timestamp: 1000,
+    },
+  }
+  const emptyStopEntry: SessionEntry = {
+    type: 'message',
+    id: `assistant-empty-stop-${id}`,
+    parentId: toolResultEntry.id,
+    timestamp: '2026-06-15T06:23:46.000Z',
+    message: assistantMessage(''),
+  }
+  session.entriesById.set(toolCallEntry.id, toolCallEntry)
+  session.entriesById.set(toolResultEntry.id, toolResultEntry)
+  session.entriesById.set(emptyStopEntry.id, emptyStopEntry)
+  session.leafEntry = emptyStopEntry
 }
 
 const baseConfig: ChannelAdapterConfig = {
@@ -2734,6 +2789,171 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     // then: the arm self-cleared — no retry, historical no_reply
     expect(logs.some((m) => m.includes('cold_start_solo_bare_empty'))).toBe(false)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+  })
+
+  test('empty-stop-after-tool-work: a bare-empty stop following tool work retries, then the model answers', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // given: a mention (so cold-start is NOT armed) on a group channel
+    await router.route(inbound({ isBotMention: true, text: '부평역에서 포스트타워 마포까지 몇분 걸려?' }))
+    let calls = 0
+    sessions[0]!.onPrompt = () => {
+      calls++
+      // when: the model searches then whiffs an empty completion, then answers on retry
+      if (calls === 1) emptyStopAfterToolWork(sessions[0]!)
+      else sessions[0]!.setAssistantText('1호선 타고 가다 공덕에서 환승, 약 60분이야.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: it retried with the tool-work nudge instead of dropping silently
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sessions[0]!.prompts[1]).toContain(EMPTY_STOP_AFTER_TOOL_WORK_NUDGE)
+    expect(logs.some((m) => m.includes('empty_turn_retry') && m.includes('cause=empty_stop_after_tool_work'))).toBe(
+      true,
+    )
+    expect(sent.map((s) => s.text)).toEqual(['1호선 타고 가다 공덕에서 환승, 약 60분이야.'])
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(false)
+  })
+
+  test('empty-stop-after-tool-work: a bare-empty stop with NO tool work this attempt stays silent', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // given: a mention, model emits a bare-empty stop with no tool call this attempt
+    await router.route(inbound({ isBotMention: true, text: 'hey bot' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('')
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the tool-work threshold is unmet — historical silent no_reply holds
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(logs.some((m) => m.includes('empty_stop_after_tool_work'))).toBe(false)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(sent).toHaveLength(0)
+  })
+
+  test('empty-stop-after-tool-work: an explicit NO_REPLY after tool work stays silent (bare-empty required)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: true, text: 'check this' }))
+    // given: the model did tool work but then DELIBERATELY declined with a NO_REPLY token
+    sessions[0]!.onPrompt = () => {
+      emptyStopAfterToolWork(sessions[0]!)
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: non-empty NO_REPLY is a deliberate decline — not retried
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(logs.some((m) => m.includes('empty_stop_after_tool_work'))).toBe(false)
+    expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+    expect(sent).toHaveLength(0)
+  })
+
+  test('empty-stop-after-tool-work: a persistent bare-empty stop exhausts to the visible fallback', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: true, text: 'check this' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(
+      logs.filter((m) => m.includes('empty_turn_retry') && m.includes('cause=empty_stop_after_tool_work')).length,
+    ).toBe(MAX_EMPTY_TURN_RETRIES)
+    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=empty_stop_after_tool_work_retries_exhausted'))).toBe(
+      true,
+    )
+  })
+
+  test('empty-stop-after-tool-work: once armed, a bare-empty retry that obeys the no-re-run nudge keeps spending budget to fallback', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: true, text: 'check this' }))
+    let calls = 0
+    sessions[0]!.onPrompt = () => {
+      calls++
+      // given: attempt 1 does tool work then whiffs (arms the cause); the retry nudge
+      // says "do not re-run tools", so later attempts whiff bare-empty with no new tools
+      if (calls === 1) emptyStopAfterToolWork(sessions[0]!)
+      else sessions[0]!.setAssistantText('')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the armed cause persists — bare-empty retries keep consuming the budget
+    // and the user gets the visible fallback instead of silent dead air
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_EMPTY_TURN_RETRIES)
+    expect(
+      logs.filter((m) => m.includes('empty_turn_retry') && m.includes('cause=empty_stop_after_tool_work')).length,
+    ).toBe(MAX_EMPTY_TURN_RETRIES)
+    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause=empty_stop_after_tool_work_retries_exhausted'))).toBe(
+      true,
+    )
+  })
+
+  test('empty-stop-after-tool-work: an armed turn still honors an explicit NO_REPLY escape', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ isBotMention: true, text: 'check this' }))
+    let calls = 0
+    sessions[0]!.onPrompt = () => {
+      calls++
+      // given: attempt 1 arms the cause; attempt 2 deliberately declines with NO_REPLY
+      if (calls === 1) emptyStopAfterToolWork(sessions[0]!)
+      else sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the non-empty NO_REPLY escapes the armed retry loop — silence, no fallback
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(
+      logs.filter((m) => m.includes('empty_turn_retry') && m.includes('cause=empty_stop_after_tool_work')).length,
+    ).toBe(1)
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
     expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
   })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2,7 +2,7 @@ import { statSync } from 'node:fs'
 import { basename } from 'node:path'
 
 import type { AssistantMessage } from '@mariozechner/pi-ai'
-import { SessionManager } from '@mariozechner/pi-coding-agent'
+import { type SessionEntry, SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, renderTurnRoleAnchor, renderTurnTimeAnchor, type AgentSession } from '@/agent'
 import { applyTurnThinkingLevel, getQuestionSignal, type QuestionSignal } from '@/agent/attention-escalation'
@@ -312,6 +312,32 @@ export const COLD_START_REPLY_NUDGE = [
   'Answer the last user message now via your channel reply tool. If you truly',
   'have nothing to add, call `skip_response({ reason })` (preferred) or end with',
   'exactly `NO_REPLY` so the silence is recorded — do not just end empty.',
+  '',
+  '---',
+].join('\n')
+// Reminder-only nudge for the empty-stop-after-tool-work retry. Distinct from
+// both EMPTY_TURN_RETRY_NUDGE (which misdiagnoses a clean `stop` as output-budget
+// exhaustion and, per its own docstring, makes the model RE-RUN its tools and
+// strand again) and STRANDED_TOOLUSE_CONTINUATION_NUDGE (which assumes a `continue:
+// true` status reply already landed). Here NO send landed, the model gathered real
+// tool results, then the final completion came back as a bare empty `stop` — the
+// Fireworks/gpt empty-completion degeneration. The recovery is to READ the results
+// already in this branch, summarize, and reply — NOT to re-investigate. The
+// trailing NO_REPLY escape is what makes the rare research-then-decline false
+// positive self-correct on the first retry instead of forcing the fallback.
+export const EMPTY_STOP_AFTER_TOOL_WORK_NUDGE = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'Your previous turn gathered information with your tools, then ended without',
+  'sending any reply — the final completion came back empty. This is an automated',
+  'signal from the channel router, not a message from anyone in the chat. **Do not',
+  'acknowledge or reply to this notice itself.**',
+  '',
+  'Do NOT re-run your tools. The results you already gathered are still in this',
+  'conversation above — read them, summarize what you found, and send your reply',
+  'now via your channel reply tool. Only call more tools if a specific fact is',
+  'genuinely still missing. If you truly have nothing to say, reply with `NO_REPLY`.',
   '',
   '---',
 ].join('\n')
@@ -791,6 +817,14 @@ type LiveSession = {
   // increments it before injecting EMPTY_TURN_RETRY_NUDGE and reads it to decide
   // retry-vs-fallback. See the candidate===null branch.
   emptyTurnRetries: number
+  // Latches once a bare-empty `stop` has been classified as empty-stop-after-tool-work
+  // this logical turn. The recovery nudge tells the model NOT to re-run its tools, so
+  // a compliant retry is expected to land another bare-empty `stop` with NO new tool
+  // call — `attemptMadeToolCall` would then be false and the turn would silently bail
+  // with budget unspent. Once armed, the cause persists for the turn so later bare-empty
+  // stops keep spending the shared retry budget toward the visible fallback. Reset
+  // alongside `emptyTurnRetries` on a real user batch only (anti-reloop discipline).
+  emptyStopAfterToolWorkArmed: boolean
   // Count of continuation nudges spent on the CURRENT logical turn, bounded by
   // MAX_WILLINGNESS_NUDGES. Reset alongside `emptyTurnRetries` only when a real
   // user batch starts (batch.length > 0), NOT on the reminder-only iteration the
@@ -1849,6 +1883,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
         emptyTurnRetries: 0,
+        emptyStopAfterToolWorkArmed: false,
         willingnessNudges: 0,
         lastTerminalReplyAbort: null,
         abortReasonThisTurn: null,
@@ -2504,6 +2539,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // iterations the retry itself queues do not refill the budget and loop
           // forever (and the raised cap stays scoped to the turn that set it).
           live.emptyTurnRetries = 0
+          live.emptyStopAfterToolWorkArmed = false
           live.willingnessNudges = 0
           live.abortReasonThisTurn = null
           live.nextPromptMaxTokens = undefined
@@ -3983,6 +4019,42 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           return
         }
         await postEmptyTurnFallback('cold_start_solo_bare_empty_retries_exhausted')
+        return
+      }
+      // Deliberately AFTER the cold-start guard (that path has its own nudge). A
+      // bare-empty stop that followed real tool work — but landed no send — is the
+      // no-send sibling of the willingness-ack / stranded-toolUse degenerations
+      // above: the model gathered results then emitted an empty completion instead
+      // of the answer. Retry telling it to summarize what it already has; on
+      // exhaustion post the visible fallback rather than stranding the asker on
+      // silence. The cause LATCHES for the logical turn (`emptyStopAfterToolWorkArmed`):
+      // the nudge tells the model not to re-run tools, so a compliant retry lands
+      // another bare-empty stop with NO new tool call — requiring fresh tool work on
+      // every attempt would silently drop exactly that shape with budget unspent.
+      // Once armed, subsequent bare-empty stops keep spending the shared retry budget
+      // toward the fallback. An explicit non-empty NO_REPLY still escapes to silence
+      // (its `trim()` is non-empty, so the first condition fails and it falls through
+      // to no_reply below); a bare-empty stop with no tool work AND never-armed stays
+      // silent too.
+      if (
+        assistantText.trim() === '' &&
+        source === 'leaf' &&
+        (live.emptyStopAfterToolWorkArmed || attemptMadeToolCall(live.session)) &&
+        live.currentTurnAuthorId !== null &&
+        live.successfulChannelSends === successfulSendsBeforePrompt &&
+        live.promptQueue.length === 0
+      ) {
+        live.emptyStopAfterToolWorkArmed = true
+        if (live.emptyTurnRetries < MAX_EMPTY_TURN_RETRIES) {
+          live.emptyTurnRetries++
+          logger.warn(
+            `[channels] ${live.keyId} empty_turn_retry attempt=${live.emptyTurnRetries}/${MAX_EMPTY_TURN_RETRIES} ` +
+              `cause=empty_stop_after_tool_work`,
+          )
+          live.pendingSystemReminders.push(EMPTY_STOP_AFTER_TOOL_WORK_NUDGE)
+          return
+        }
+        await postEmptyTurnFallback('empty_stop_after_tool_work_retries_exhausted')
         return
       }
       const leakedReasoning = !isNoReplySignal(assistantText)
@@ -5569,6 +5641,30 @@ function visibleAssistantText(message: AssistantMessage): string {
 
 function hasToolCall(message: AssistantMessage): boolean {
   return message.content.some((block) => block.type === 'toolCall')
+}
+
+// True when any assistant message in the CURRENT prompt-attempt carries a
+// toolCall block. "This attempt" is bounded by walking the parentId chain back
+// to the first user message — which INCLUDES an injected retry nudge, since
+// that lands as a user-side entry — so each retry is scored on its own tool
+// work, not the original turn's. validateChannelTurn uses this to tell a
+// bare-empty `stop` that followed real tool work (Fireworks/gpt empty-completion
+// degeneration → retry) apart from a bare-empty `stop` that produced nothing
+// from nothing (deliberate silence → honor it). The `source === 'leaf'` +
+// `stopReason: 'stop'` invariant at the call site guarantees any tool called
+// this attempt already returned a toolResult; otherwise the leaf would be
+// `toolUse`, not `stop`. Depth-bounded like the other branch walks so a
+// malformed session can't loop.
+function attemptMadeToolCall(session: AgentSession): boolean {
+  let cursor: SessionEntry | undefined = session.sessionManager.getLeafEntry()
+  for (let depth = 0; depth < 32 && cursor; depth++) {
+    if (cursor.type === 'message') {
+      if (cursor.message.role === 'user') return false
+      if (cursor.message.role === 'assistant' && hasToolCall(cursor.message)) return true
+    }
+    cursor = cursor.parentId ? session.sessionManager.getEntry(cursor.parentId) : undefined
+  }
+  return false
 }
 
 // Lenient on purpose: distilled / smaller models routinely drift off the


### PR DESCRIPTION
## Background

A channel turn where the model did tool work (e.g. `web_search`), then emitted a final assistant message with empty text and `stopReason: stop`, was silently discarded. The user sent a direct question in a group channel; the agent ran its research tools, then went quiet — dead air where an answer was expected.

The path through the router:

1. `recoverableAssistantText` returns `{ text: '', source: 'leaf' }` (not `null`) because the leaf block exists; it just has no text.
2. The `candidate === null` retry branch is skipped.
3. `endsWithNoReplySignal('')` returns `true` — an empty string is treated as a NO_REPLY signal.
4. All four existing empty-turn recovery guards miss this case (see Summary).
5. The turn falls through to a silent `no_reply`.

The question was a Korean-language message asking about research the agent had just looked up. It received no response.

## Summary

**Why the four existing guards all miss this case.**

- `isEmptyStopAfterWillingnessAck` — only fires when a send already landed this turn (it guards a stale willingness state after a visible reply). No send landed here.
- `leafIsStrandedToolUse` — only fires when a send already landed this turn for the same reason.
- `candidate === null` retry — the candidate is non-null (`{ text: '', source: 'leaf' }`), so this branch never enters.
- Cold-start-solo guard — only arms on the very first one-on-one turn; this was a group channel mid-conversation.

**The fix.**

A new guard is inserted in the `endsWithNoReplySignal` block, after the cold-start-solo guard and before the terminal `no_reply`. It fires when the current prompt-attempt made at least one tool call — the evidence that the model intended to gather and return information, not stay silent. On each retry the router posts `EMPTY_STOP_AFTER_TOOL_WORK_NUDGE`, which instructs the model to summarize the results it already gathered rather than re-run its tools. On exhaustion the visible fallback is posted so the user gets a response.

**`attemptMadeToolCall`** walks the `parentId` chain back to the first user message of the current attempt (which includes the injected retry nudge as a new user message, so each retry is scored on its own tool work independently). Tool-call detection uses the existing `AssistantMessage.toolCalls` array; no new I/O.

**Why a separate nudge constant and not `EMPTY_TURN_RETRY_NUDGE`.** `EMPTY_TURN_RETRY_NUDGE` was designed for the budget-exhaustion / no-tool-use path; reusing it here would tell the model to re-investigate (re-run tools) when it already ran them, and would misdiagnose a clean stop as budget exhaustion. The new `EMPTY_STOP_AFTER_TOOL_WORK_NUDGE` explicitly says "you've gathered results — please summarize them." The trailing `NO_REPLY` escape is preserved so a genuine research-then-decline can self-correct on the first retry rather than being forced to reply.

**The tool-work requirement is the decision threshold.** A bare-empty stop with no tool work stays silent (group-chat default, already handled by other paths). Tool work is the observable evidence that overrides that default.

Design was reviewed by Oracle before implementation.

## What this does NOT do

- Does not change how `recoverableAssistantText` classifies empty leaves — the source of truth stays `{ text: '', source: 'leaf' }`.
- Does not affect turns where the model returned non-empty text after tool work (already handled correctly).
- Does not affect the `candidate === null` retry path or the willingness-ack / stranded-toolUse degeneration paths.
- Does not change behavior for bare-empty stops with no preceding tool work (still silent — the group-chat default is intentional).
- Does not add new config surface; the guard is always-on within the `endsWithNoReplySignal` block.

## Review notes

- **Load-bearing location:** the new guard sits *after* the cold-start-solo guard and *before* the terminal `no_reply` in the `endsWithNoReplySignal` block. Order matters — cold-start-solo must remain the earlier check.
- **`attemptMadeToolCall`** uses `parentId` chain traversal capped at the first user message of the current attempt. Verify it does not walk past a retry boundary into a prior attempt's tool calls.
- **Log causes to look for:** `empty_stop_after_tool_work` (guard fires, retry posted) and `empty_stop_after_tool_work_retries_exhausted` (fallback posted). Absence of these in logs for an affected turn means the guard condition was not satisfied.
- **5 new tests** in `router.test.ts` cover: guard fires after one tool call; guard fires after multiple tool calls; guard does NOT fire on a bare-empty stop with no tool work; retries are capped at `MAX_EMPTY_STOP_RETRIES`; exhaustion posts the visible fallback. All 5 were verified via mutation (removing the guard causes each to fail). Full suite: 9973 pass / 0 fail. Typecheck, lint, and format:check all clean.