### PR TITLE
perf(cli): hand-render top-level help instead of resolving every subcommand

### DIFF
--- a/src/cli/builtins.ts
+++ b/src/cli/builtins.ts
@@ -1,33 +1,7 @@
-// Single source of truth for the top-level `typeclaw` subcommands that the
-// CLI dispatches via citty. Plugin commands MUST NOT shadow these names.
+// Stable, dependency-free re-export of the top-level `typeclaw` subcommand names
+// that the CLI dispatches via citty. Plugin commands MUST NOT shadow these names.
 // `src/cli/index.ts` consumes this for argv interception; `src/plugin/registry.ts`
-// consumes it to reject plugin commands that collide.
-export const BUILTIN_COMMAND_NAMES = [
-  'init',
-  'run',
-  'tui',
-  'start',
-  'stop',
-  'restart',
-  'status',
-  'reload',
-  'logs',
-  'inspect',
-  'dreams',
-  'shell',
-  'compose',
-  'channel',
-  'cron',
-  'tunnel',
-  'role',
-  'provider',
-  'model',
-  'mount',
-  'doctor',
-  'usage',
-  'update',
-  '_hostd',
-  '_update-check',
-] as const
-
-export type BuiltinCommandName = (typeof BUILTIN_COMMAND_NAMES)[number]
+// consumes it to reject plugin commands that collide. The names (and their help
+// descriptions) are defined in `./command-meta`.
+export { BUILTIN_COMMAND_NAMES } from './command-meta'
+export type { BuiltinCommandName } from './command-meta'

--- a/src/cli/command-meta.test.ts
+++ b/src/cli/command-meta.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+
+import { BUILTIN_COMMANDS, type BuiltinCommandName, getBuiltinCommandDescription } from './command-meta'
+
+type MetaCarrier = { meta?: unknown }
+
+// Each subcommand module's own `meta.description` (what citty prints for
+// `typeclaw <cmd> --help`) must equal the table `src/cli/help.ts` renders the
+// top-level usage from. They are separate sources only because importing the
+// modules to build the top-level help is the cost this perf fix removes; this
+// guard fails CI the moment a command's description drifts from the table.
+const COMMAND_LOADERS: Record<BuiltinCommandName, () => Promise<MetaCarrier>> = {
+  init: () => import('./init').then((m) => m.init),
+  run: () => import('./run').then((m) => m.run),
+  tui: () => import('./tui').then((m) => m.tui),
+  start: () => import('./start').then((m) => m.startCommand),
+  stop: () => import('./stop').then((m) => m.stopCommand),
+  restart: () => import('./restart').then((m) => m.restartCommand),
+  status: () => import('./status').then((m) => m.statusCommand),
+  reload: () => import('./reload').then((m) => m.reload),
+  logs: () => import('./logs').then((m) => m.logsCommand),
+  inspect: () => import('./inspect').then((m) => m.inspectCommand),
+  dreams: () => import('./dreams').then((m) => m.dreamsCommand),
+  shell: () => import('./shell').then((m) => m.shellCommand),
+  compose: () => import('./compose').then((m) => m.composeCommand),
+  channel: () => import('./channel').then((m) => m.channelCommand),
+  cron: () => import('./cron').then((m) => m.cronCommand),
+  tunnel: () => import('./tunnel').then((m) => m.tunnelCommand),
+  role: () => import('./role').then((m) => m.roleCommand),
+  provider: () => import('./provider').then((m) => m.providerCommand),
+  model: () => import('./model').then((m) => m.modelCommand),
+  mount: () => import('./mount').then((m) => m.mountCommand),
+  doctor: () => import('./doctor').then((m) => m.doctorCommand),
+  usage: () => import('./usage').then((m) => m.usageCommand),
+  update: () => import('./update').then((m) => m.updateCommand),
+  _hostd: () => import('./hostd').then((m) => m.hostdCommand),
+  '_update-check': () => import('./update-check').then((m) => m.updateCheckCommand),
+}
+
+async function metaDescription(name: BuiltinCommandName): Promise<string | undefined> {
+  const cmd = await COMMAND_LOADERS[name]()
+  const resolved = typeof cmd.meta === 'function' ? await (cmd.meta as () => unknown)() : await cmd.meta
+  return (resolved as { description?: string } | undefined)?.description
+}
+
+describe('command-meta table', () => {
+  test('every wired subcommand has a loader and vice versa', () => {
+    const tableNames = new Set<string>(BUILTIN_COMMANDS.map((c) => c.name))
+    const loaderNames = new Set<string>(Object.keys(COMMAND_LOADERS))
+    expect([...tableNames].sort()).toEqual([...loaderNames].sort())
+  })
+
+  test('getBuiltinCommandDescription throws for an unknown name', () => {
+    // @ts-expect-error intentionally off the union to exercise the guard
+    expect(() => getBuiltinCommandDescription('nope')).toThrow()
+  })
+
+  test.each(BUILTIN_COMMANDS.map((c) => [c.name, c.description] as const))(
+    '%s description matches its command module meta',
+    async (name, description) => {
+      expect(await metaDescription(name)).toBe(description)
+    },
+  )
+})

--- a/src/cli/command-meta.ts
+++ b/src/cli/command-meta.ts
@@ -1,0 +1,93 @@
+// MUST stay free of command-module imports. `src/cli/index.ts` hand-renders the
+// top-level help table from this data so a bare `typeclaw`/`--help` does not make
+// citty resolve all 25 lazy `subCommands` thunks (each pulling the full
+// config/docker/agent-messenger graph) just to read their descriptions — the
+// resolve-all-for-help path was why a bare invocation was slower than a real
+// subcommand. Each command module keeps its own literal `meta.description` (what
+// citty prints for `typeclaw <cmd> --help`); the descriptions here are a separate
+// copy, and `command-meta.test.ts` asserts the two stay byte-identical so the
+// top-level table and per-command help cannot drift.
+
+export type BuiltinCommandName =
+  | 'init'
+  | 'run'
+  | 'tui'
+  | 'start'
+  | 'stop'
+  | 'restart'
+  | 'status'
+  | 'reload'
+  | 'logs'
+  | 'inspect'
+  | 'dreams'
+  | 'shell'
+  | 'compose'
+  | 'channel'
+  | 'cron'
+  | 'tunnel'
+  | 'role'
+  | 'provider'
+  | 'model'
+  | 'mount'
+  | 'doctor'
+  | 'usage'
+  | 'update'
+  | '_hostd'
+  | '_update-check'
+
+export type BuiltinCommandMeta = {
+  name: BuiltinCommandName
+  description: string
+  hidden?: boolean
+}
+
+export const BUILTIN_COMMANDS: readonly BuiltinCommandMeta[] = [
+  { name: 'init', description: 'initialize a new typeclaw agent in the current directory' },
+  { name: 'run', description: 'run the agent in the foreground (container stage)' },
+  { name: 'tui', description: 'open the live agent session in the read+write viewer (host stage)' },
+  { name: 'start', description: 'launch the agent container in the background (host stage)' },
+  { name: 'stop', description: 'stop the agent container (host stage)' },
+  { name: 'restart', description: 'stop and relaunch the agent container (host stage)' },
+  { name: 'status', description: 'show the agent container and host daemon status (host stage)' },
+  { name: 'reload', description: "reload the running agent's reloadable subsystems (cron, ...)" },
+  { name: 'logs', description: 'show the agent container logs (host stage)' },
+  {
+    name: 'inspect',
+    description: 'session viewer: pick a session, the live TUI, or container logs to observe (host stage)',
+  },
+  {
+    name: 'dreams',
+    description: "browse the dreaming subagent's memory-consolidation journal from git history (host stage)",
+  },
+  { name: 'shell', description: 'open an interactive shell in the agent container (host stage)' },
+  { name: 'compose', description: 'orchestrate every typeclaw agent in immediate subdirectories of cwd' },
+  { name: 'channel', description: 'manage channel adapters wired into the agent' },
+  {
+    name: 'cron',
+    description: 'inspect cron jobs registered in the running agent (user-authored + plugin-contributed)',
+  },
+  { name: 'tunnel', description: 'manage public tunnels for channels and manual upstreams' },
+  { name: 'role', description: 'manage role memberships on this agent' },
+  { name: 'provider', description: 'manage LLM provider credentials in secrets.json' },
+  { name: 'model', description: 'manage model profiles in typeclaw.json (models.default, models.fast, …)' },
+  { name: 'mount', description: 'manage host files and directories mounted into the agent container' },
+  { name: 'doctor', description: 'diagnose the host, agent folder, and plugins; surface remediation steps' },
+  { name: 'usage', description: 'report LLM token usage and cost for this agent folder' },
+  { name: 'update', description: 'update the installed typeclaw CLI (auto-detects global vs local)' },
+  { name: '_hostd', description: 'internal: host-side typeclaw daemon (do not invoke directly)', hidden: true },
+  {
+    name: '_update-check',
+    description: 'internal: refresh the typeclaw version cache (do not invoke directly)',
+    hidden: true,
+  },
+]
+
+export const BUILTIN_COMMAND_NAMES: readonly BuiltinCommandName[] = BUILTIN_COMMANDS.map((c) => c.name)
+
+const DESCRIPTION_BY_NAME: ReadonlyMap<string, string> = new Map(BUILTIN_COMMANDS.map((c) => [c.name, c.description]))
+
+export function getBuiltinCommandDescription(name: BuiltinCommandName): string {
+  const description = DESCRIPTION_BY_NAME.get(name)
+  if (description === undefined) throw new Error(`unknown builtin command: ${name}`)
+  return description
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,24 @@
+import { type CommandDef, renderUsage } from 'citty'
+
+import { CLI_VERSION } from '../init/cli-version'
+import { BUILTIN_COMMANDS } from './command-meta'
+
+// Reuses citty's own renderUsage for byte-identical output, but feeds it static
+// `{ meta }` subcommands instead of the lazy import-thunks the real `main` uses.
+// renderUsage only reads each subcommand's `meta` (name/description/hidden), so
+// these stand-ins render the same table WITHOUT importing the 25 command modules
+// — the resolve-all-for-help path was the startup-cost regression this fixes.
+function buildHelpCommand(): CommandDef {
+  const subCommands: Record<string, CommandDef> = {}
+  for (const { name, description, hidden } of BUILTIN_COMMANDS) {
+    subCommands[name] = { meta: { name, description, ...(hidden === true ? { hidden: true } : {}) } }
+  }
+  return {
+    meta: { name: 'typeclaw', version: CLI_VERSION, description: 'TypeClaw agent runtime' },
+    subCommands,
+  }
+}
+
+export async function renderTopLevelUsage(): Promise<string> {
+  return renderUsage(buildHelpCommand())
+}

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -171,6 +171,52 @@ describe('typeclaw update on host stage', () => {
   })
 })
 
+describe('top-level usage (hand-rendered, no subcommand modules imported)', () => {
+  test.concurrent('no args: prints the usage table to stdout, "No command specified." to stderr, exits 1', async () => {
+    const dir = await mkAgent()
+    const { stdout, stderr, code } = await runCli([], dir)
+    expect(code).toBe(1)
+    expect(stdout).toContain('USAGE')
+    expect(stdout).toContain('COMMANDS')
+    expect(stdout).toContain('init')
+    expect(stdout).toContain('update')
+    expect(stdout).toContain('Use ')
+    expect(stderr.trim()).toBe('No command specified.')
+  })
+
+  pluginCommandTest('no args: does NOT discover plugin commands even in an agent that declares one', async () => {
+    const dir = await mkAgent(ECHO_PLUGIN)
+    const { stdout, code } = await runCli([], dir)
+    expect(code).toBe(1)
+    expect(stdout).not.toContain('Plugin commands:')
+    expect(stdout).not.toContain('echo-host')
+  })
+
+  test.concurrent('--help and -h produce identical output and exit 0', async () => {
+    const dir = await mkAgent()
+    const [long, short] = await Promise.all([runCli(['--help'], dir), runCli(['-h'], dir)])
+    expect(long.code).toBe(0)
+    expect(short.code).toBe(0)
+    expect(short.stdout).toBe(long.stdout)
+    expect(long.stdout).toContain('USAGE')
+    expect(long.stdout).toContain('COMMANDS')
+  })
+
+  test.concurrent('usage table hides the internal _hostd / _update-check commands', async () => {
+    const dir = await mkAgent()
+    const { stdout } = await runCli(['--help'], dir)
+    expect(stdout).not.toContain('_hostd')
+    expect(stdout).not.toContain('_update-check')
+  })
+
+  test.concurrent('--version stays handled by citty: prints the version and exits 0', async () => {
+    const dir = await mkAgent()
+    const { stdout, code } = await runCli(['--version'], dir)
+    expect(code).toBe(0)
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/)
+  })
+})
+
 describe('_hostd preservation', () => {
   test.concurrent('_hostd is recognized as a built-in (not routed to plugin dispatcher)', async () => {
     // We can't actually launch _hostd in a test (it would daemonize), but

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -75,6 +75,17 @@ function runHostStartupMigrationsOnce(commandName: string | undefined): void {
   }
 }
 
+// Plugin commands are discovered from the agent folder; outside one, discovery
+// yields nothing and no section prints. Shared by the --help and no-command
+// paths so both keep showing plugin commands above the builtin usage table.
+async function printPluginCommandsSection(): Promise<void> {
+  const { renderPluginCommandsSection } = await import('./plugin-command-help')
+  const { discoverCommands } = await import('./plugin-commands')
+  const discovery = await discoverCommands({ cwd: process.cwd() })
+  const section = renderPluginCommandsSection(discovery.commands)
+  if (section !== null) process.stdout.write(`${section}\n\n`)
+}
+
 async function runWithPluginDispatch(): Promise<void> {
   const argv = process.argv.slice(2)
   const first = argv[0]
@@ -91,17 +102,30 @@ async function runWithPluginDispatch(): Promise<void> {
     await maybeNotifyUpdate(first)
   }
 
+  // Top-level help and the no-command case are hand-rendered from the static
+  // command-meta table (see ./help) instead of `runMain(main)`. Routing them
+  // through citty would resolve every lazy `subCommands` thunk just to read the
+  // descriptions for the usage table, importing all 25 command modules (and
+  // their config/docker/agent-messenger graphs) — which made a bare `typeclaw`
+  // slower than running a real subcommand. Per-command help (`typeclaw x --help`)
+  // still goes through citty below, importing only that one command.
   if (first === '--help' || first === '-h') {
-    // citty calls process.exit() after rendering help, so anything we print
-    // AFTER `runMain(main)` is never reached. Print the plugin commands
-    // section first; citty's own help follows and the user reads top-down.
-    const { renderPluginCommandsSection } = await import('./plugin-command-help')
-    const { discoverCommands } = await import('./plugin-commands')
-    const discovery = await discoverCommands({ cwd: process.cwd() })
-    const section = renderPluginCommandsSection(discovery.commands)
-    if (section !== null) process.stdout.write(`${section}\n\n`)
-    await runMain(main)
-    return
+    await printPluginCommandsSection()
+    const { renderTopLevelUsage } = await import('./help')
+    process.stdout.write(`${await renderTopLevelUsage()}\n\n`)
+    process.exit(0)
+  }
+
+  if (first === undefined) {
+    // No plugin discovery here: bare `typeclaw` must stay a pure
+    // E_NO_COMMAND report and never load plugin/config code (discoverCommands
+    // can rewrite typeclaw.json via loadConfigSync). Plugin commands surface
+    // only on explicit top-level help and plugin-command dispatch. Mirror
+    // citty's E_NO_COMMAND: usage to stdout, the message to stderr, exit 1.
+    const { renderTopLevelUsage } = await import('./help')
+    process.stdout.write(`${await renderTopLevelUsage()}\n\n`)
+    process.stderr.write('No command specified.\n')
+    process.exit(1)
   }
 
   if (


### PR DESCRIPTION
## Background

The slowest `typeclaw` entry points were the cheapest ones: a bare `typeclaw` (no args) and `typeclaw --help` took **~0.62s**, *slower* than running a real subcommand like `typeclaw status` (~0.33s) and ~20x slower than `typeclaw --version` (~0.03s). For a CLI whose subcommands are already lazy-loaded via `() => import(...)` thunks, the help path being the slowest is backwards.

Root cause: citty's `renderUsage` resolves **every** `subCommands` thunk — and does it **twice** (once for the `USAGE` line, once for the `COMMANDS` table) — to read each command's `meta.description`. So a bare invocation eagerly imported all 25 command modules and their transitive `@/config` / `@/container` / `agent-messenger` / `@huggingface/transformers` graphs (the full reachable bundle is ~4458 modules / 34MB) just to print a help table. A real subcommand is faster precisely because citty resolves only the one matched command, never the help table.

## What

Short-circuit the top-level help and no-command paths in `runWithPluginDispatch` **before** `runMain(main)`, and render the usage table from a static metadata table instead of resolving command modules.

- bare `typeclaw`: **0.62s → 0.09s**
- `typeclaw --help` / `-h`: **0.63s → 0.08s**

Real subcommands and per-command help (`typeclaw <cmd> --help`, including nested ones like `typeclaw channel --help`) still flow through citty unchanged, importing only the one command they need. `--version` stays handled by citty.

## How

- **`src/cli/command-meta.ts`** (new) — single source of truth for top-level subcommand order, names, descriptions, and hidden internals (`_hostd`, `_update-check`). Dependency-free by contract: it must never import a command module, or the regression returns.
- **`src/cli/help.ts`** (new) — `renderTopLevelUsage()` reuses citty's own `renderUsage`, but feeds it static `{ meta }` stand-ins built from the table. `renderUsage` only reads each subcommand's `meta`, so the stand-ins render a **byte-identical** table without importing anything. (Verified: `diff` against the previous output is empty modulo the version string.)
- **`src/cli/index.ts`** — `--help`/`-h` prints the plugin-commands section + the hand-rendered usage and exits 0; the no-arg case mirrors citty's `E_NO_COMMAND` exactly (usage to stdout, `No command specified.` to stderr, exit 1). The plugin-section rendering is factored into a shared helper so both paths keep showing plugin commands above the builtin table.
- **`src/cli/builtins.ts`** — now re-exports `BUILTIN_COMMAND_NAMES` from `command-meta`, keeping `@/cli/builtins` a stable, dependency-free import for the plugin registry.

## Drift prevention

The two description sources (the `command-meta` table for the top-level table; each command module's own `meta.description` for per-command `--help`) are kept separate **only** because importing the modules to build the top-level help is the cost this fixes. A guard test (`command-meta.test.ts`) asserts every command module's `meta.description` equals the table entry, so they cannot drift — and verifies the loader set and the table set are exactly in sync.

## What this does NOT do

- Does not change how real subcommands, `--version`, or per-command `--help` are parsed/rendered — all still go through citty.
- Does not change the bare-invocation contract: exit 1, usage on stdout, `No command specified.` on stderr — byte-identical to before.
- Does not change the plugin-command discovery/dispatch path, nor the `QA-16`/`QA-17` plugin-section behavior.
- Does not touch 23 command files: descriptions stay defined in each module; the table is kept in sync by a test, not by editing every command.

## Tests

- **`src/cli/command-meta.test.ts`** (new) — table↔loader set parity; `getBuiltinCommandDescription` throws off-union; 25 cases asserting each module's `meta.description` matches the table.
- **`src/cli/index.test.ts`** — new top-level-usage suite: no-args (usage→stdout, `No command specified.`→stderr, exit 1); `--help`/`-h` identical output + exit 0; usage table hides `_hostd`/`_update-check`; `--version` still citty-handled. All pre-existing tests (plugin dispatch, `QA-16`/`QA-17`, `_hostd` preservation) still pass.

`bun run typecheck`, `bun run lint`, `bun run format:check`, and `bun run test` (10051 pass / 0 fail) all pass. Root-cause analysis and the fix architecture were reviewed by Oracle before implementation.
