### PR TITLE
test: deflake the post-merge windows-test lane (hostd boot-restore + container dispatch)

### DIFF
--- a/src/cli/plugin-commands-dispatch.ts
+++ b/src/cli/plugin-commands-dispatch.ts
@@ -1,4 +1,4 @@
-import { proxyContainerCommand } from './container-command-client'
+import { proxyContainerCommand, type ContainerProxyOptions } from './container-command-client'
 import { parseArgs, runHostCommand } from './host-command-runner'
 import { renderCommandHelp } from './plugin-command-help'
 import { discoverCommands } from './plugin-commands'
@@ -16,6 +16,11 @@ export type DispatchOptions = {
   stdout?: WritableStream<Uint8Array>
   stderr?: WritableStream<Uint8Array>
   signal?: AbortSignal
+  // Test seam: override container-URL resolution so unit tests exercise the
+  // container dispatch path without spawning a real `docker inspect` (slow and
+  // flaky on Windows CI). Unset in production: proxyContainerCommand falls back
+  // to the live docker probe.
+  resolveContainerUrl?: ContainerProxyOptions['resolveUrl']
 }
 
 export async function dispatchPluginCommand(opts: DispatchOptions): Promise<PluginCommandDispatchOutcome> {
@@ -62,6 +67,7 @@ export async function dispatchPluginCommand(opts: DispatchOptions): Promise<Plug
       stdout,
       stderr,
       abortSignal: signal,
+      resolveUrl: opts.resolveContainerUrl,
     })
     if (!containerResult.ok) {
       return { kind: 'error', exitCode: containerResult.exitCode, message: containerResult.message }

--- a/src/cli/plugin-commands.test.ts
+++ b/src/cli/plugin-commands.test.ts
@@ -270,6 +270,14 @@ describe('dispatchPluginCommand', () => {
       stdin,
       stdout,
       stderr,
+      // Stub URL resolution instead of probing real Docker: the live `docker
+      // inspect` is slow and times out on Windows CI. The not-running hint
+      // itself is covered in require-running.test.ts and
+      // container-command-client.test.ts; here we only assert dispatch routes a
+      // container command through the proxy and propagates its error.
+      resolveContainerUrl: async () => ({
+        error: 'Container container-only is not running. Run `typeclaw start` first.',
+      }),
     })
     expect(outcome.kind).toBe('error')
     if (outcome.kind === 'error') {

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -997,6 +997,9 @@ describe('startDaemon', () => {
     starts.length = 0
     daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, kakaoRenewal })
 
+    // Boot-time restore fires kakaoRenewal.start asynchronously; wait for the
+    // start callback rather than racing it right after boot (the Windows CI flake).
+    await waitFor(() => starts.length === 1)
     expect(starts).toEqual([{ containerName: 'persistent-kakao', cwd: '/agent/pk' }])
   })
 
@@ -1069,6 +1072,9 @@ describe('startDaemon', () => {
     starts.length = 0
     daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 1_000_000, webexRenewal })
 
+    // Boot-time restore fires webexRenewal.start asynchronously; wait for the
+    // start callback rather than racing it right after boot (the Windows CI flake).
+    await waitFor(() => starts.length === 1)
     expect(starts).toEqual([{ containerName: 'persistent-webex', cwd: '/agent/pw' }])
   })
 


### PR DESCRIPTION
## Summary

The post-merge `windows tests (informational triage)` lane went red on the `0.39.4`
run with two **flaky** failures (both had passed on the previous five `main` pushes).
This PR deflakes both at the test layer. Production runtime is unchanged.

## Root cause

**1. `startDaemon > boot-time restore invokes webexRenewal.start ...` (`src/hostd/daemon.test.ts`)**

Boot-time restore fires the renewal `.start` callback **asynchronously** (it probes
each persisted container via `exec` before applying the registration). The webex and
kakao renewal tests asserted `starts` **synchronously**, immediately after the restart
`startDaemon` — racing the restore. On the slower Windows runner the assertion ran
before the callback, so `starts` was still `[]`:

```
- [ { "containerName": "persistent-webex", "cwd": "/agent/pw" } ]
+ []
      at src/hostd/daemon.test.ts:1072
```

The portbroker boot-restore tests in the same file were already gated with `waitFor`
in #1058 (`41257b11`), but the kakao/webex renewal twins were missed. The webex twin
lost the race on `0.39.4`; kakao shares the identical race and only happened to win it.

**2. `dispatchPluginCommand > container command without a running container errors with start-it hint` (`src/cli/plugin-commands.test.ts`)**

This test drove the real `resolveUrlFromDocker` → `docker inspect` probe. That spawn is
slow on the Windows runner (~7.5s in the last green run) and **timed out at the 30s
deadline** under parallel load.

## Fixes

- **Gate both renewal boot-restore assertions** on the restore's observable effect with
  `await waitFor(() => starts.length === 1)`, matching the portbroker tests already in
  the file.
- **Add an inert `resolveContainerUrl` test seam** to `DispatchOptions` (mirroring
  `proxyContainerCommand`'s existing `resolveUrl`/`websocketFactory` override hooks) and
  stub it in the test so it no longer spawns Docker. The not-running hint itself stays
  covered by `require-running.test.ts` and `container-command-client.test.ts`; this test
  now asserts only the dispatch routing + error propagation it uniquely owns. In
  production the option is left unset and still probes Docker.

## Verification

- `bun run typecheck` · `bun run lint` (0 errors) · `bun run format:check` — clean
- `bun run test` — **10095 pass, 1 skip, 0 fail**
- The container-dispatch test now runs in **0.60ms** (was ~7.5s) — the real `docker inspect` is gone.

## Risk

Test-only behavior change. `src/hostd/daemon.ts` is untouched; the only `src/` change is
the optional, production-inert `resolveContainerUrl` seam.
