### PR TITLE
fix(agent): pin scout/explorer to their fast profile

### DIFF
--- a/src/agent/attention-escalation.test.ts
+++ b/src/agent/attention-escalation.test.ts
@@ -260,6 +260,15 @@ describe('resolveTurnThinkingLevel', () => {
   test('normal text with no session default stays undefined', () => {
     expect(resolveTurnThinkingLevel('add a comment', undefined)).toBeUndefined()
   })
+
+  test('allowEscalation:false pins to the session default even on escalation text', () => {
+    expect(resolveTurnThinkingLevel('wtf', 'low', null, { allowEscalation: false })).toBe('low')
+    expect(resolveTurnThinkingLevel('제대로 해', 'low', null, { allowEscalation: false })).toBe('low')
+  })
+
+  test('allowEscalation:false with no session default stays undefined', () => {
+    expect(resolveTurnThinkingLevel('wtf', undefined, null, { allowEscalation: false })).toBeUndefined()
+  })
 })
 
 describe('applyTurnThinkingLevel', () => {
@@ -296,5 +305,11 @@ describe('applyTurnThinkingLevel', () => {
     applyTurnThinkingLevel(session, '뭐하는 거야', 'low')
     applyTurnThinkingLevel(session, 'thanks, looks good', 'low')
     expect(session.calls).toEqual(['xhigh', 'low'])
+  })
+
+  test('allowEscalation:false keeps an escalation turn at the session default', () => {
+    const session = fakeSession()
+    applyTurnThinkingLevel(session, 'ultrathink please', 'low', null, { allowEscalation: false })
+    expect(session.calls).toEqual(['low'])
   })
 })

--- a/src/agent/attention-escalation.ts
+++ b/src/agent/attention-escalation.ts
@@ -715,11 +715,20 @@ export function detectAttentionEscalation(text: string, prior?: QuestionSignal |
 // unconditionally and gives OpenAI models maximum effort on escalation turns.
 const ESCALATED_LEVEL: ThinkingLevel = 'xhigh'
 
+// `allowEscalation: false` pins the turn to `sessionDefault`. Subagent turns set
+// it because their "user prompt" is composed by another agent, not a human — so
+// the question-mark/frustration heuristics would misread a multi-question brief
+// and silently bump a `fast`/`low` worker to `xhigh`. Default `true` keeps the
+// human-facing sessions (TUI, channels, cron) escalating as before.
+export type TurnThinkingOptions = { allowEscalation?: boolean }
+
 export function resolveTurnThinkingLevel(
   text: string,
   sessionDefault: ThinkingLevel | undefined,
   prior?: QuestionSignal | null,
+  options?: TurnThinkingOptions,
 ): ThinkingLevel | undefined {
+  if (options?.allowEscalation === false) return sessionDefault
   return detectAttentionEscalation(text, prior) ? ESCALATED_LEVEL : sessionDefault
 }
 
@@ -735,7 +744,8 @@ export function applyTurnThinkingLevel(
   text: string,
   sessionDefault: ThinkingLevel | undefined,
   prior?: QuestionSignal | null,
+  options?: TurnThinkingOptions,
 ): void {
-  const resolved = resolveTurnThinkingLevel(text, sessionDefault, prior)
+  const resolved = resolveTurnThinkingLevel(text, sessionDefault, prior, options)
   if (resolved !== undefined) session.setThinkingLevel(resolved)
 }

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -190,6 +190,36 @@ describe('invokeSubagent', () => {
     expect(captured[0]!.profileOverride).toBeUndefined()
   })
 
+  test('a payload whose schema strips `profile` leaves profileOverride undefined (fast-tier pin survives a parent override)', async () => {
+    // given: a worker whose schema drops `profile`, exactly like scout/explorer
+    const captured: { profileOverride?: string }[] = []
+    const registry = {
+      worker: {
+        systemPrompt: 'X',
+        profile: 'fast',
+        payloadSchema: z
+          .object({ prompt: z.string().optional() })
+          .passthrough()
+          .transform(({ profile: _profile, ...rest }) => rest),
+      } satisfies Subagent,
+    }
+
+    // when
+    await invokeSubagent('worker', {
+      registry,
+      createSessionForSubagent: async (_subagent, options) => {
+        captured.push({ profileOverride: options?.profileOverride })
+        return fakeSession().session
+      },
+      agentDir: '/agent',
+      userPrompt: 'do the thing',
+      payload: { prompt: 'do the thing', profile: 'deep' },
+    })
+
+    // then
+    expect(captured[0]!.profileOverride).toBeUndefined()
+  })
+
   test('handler receives validated payload and runs runSession when called', async () => {
     // given
     const { session, calls } = fakeSession()

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -338,7 +338,9 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           retrievalContext.results.length > 0
             ? `${renderTurnTimeAnchor()}\n\n${userPromptForTurn}\n\n${retrievalContext.results}`
             : `${renderTurnTimeAnchor()}\n\n${userPromptForTurn}`
-        applyTurnThinkingLevel(session, userPromptForTurn, session.thinkingLevel)
+        applyTurnThinkingLevel(session, userPromptForTurn, session.thinkingLevel, undefined, {
+          allowEscalation: false,
+        })
         const result = await promptPersistentTurnWithFallback({
           refs: resolveFallbackChain(getConfig().models, resolveSubagentProfile(subagent, sessionOptions)),
           currentModelRef: activeModelRef,
@@ -353,7 +355,9 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
             activeModelRef = ref
           },
           beforeAttempt: () => {
-            applyTurnThinkingLevel(session, userPromptForTurn, session.thinkingLevel)
+            applyTurnThinkingLevel(session, userPromptForTurn, session.thinkingLevel, undefined, {
+              allowEscalation: false,
+            })
           },
           onAttemptFailed: (attempt) => {
             console.warn(

--- a/src/bundled-plugins/explorer/explorer.test.ts
+++ b/src/bundled-plugins/explorer/explorer.test.ts
@@ -132,5 +132,12 @@ describe('explorerPayloadSchema', () => {
   test('passes through unknown fields (forward-compat with future spawn-tool params)', () => {
     const result = explorerPayloadSchema.safeParse({ requestId: 'bg_t1', futureField: 42 })
     expect(result.success).toBe(true)
+    expect((result.data as Record<string, unknown>).futureField).toBe(42)
+  })
+
+  test('drops a parent-supplied profile so explorer cannot be bumped off its fast tier', () => {
+    const result = explorerPayloadSchema.safeParse({ requestId: 'bg_t1', prompt: 'x', profile: 'deep' })
+    expect(result.success).toBe(true)
+    expect(result.data).not.toHaveProperty('profile')
   })
 })

--- a/src/bundled-plugins/explorer/explorer.ts
+++ b/src/bundled-plugins/explorer/explorer.ts
@@ -77,6 +77,10 @@ End every response with this exact structure:
 - If the question requires EXTERNAL/web information (docs, library reference, web search, fetching a URL), say so explicitly and tell the caller to spawn \`scout\` instead. Do not try to answer external questions from memory.
 - If you cannot find what was asked, say so explicitly with what you DID find and what surfaces you searched.`
 
+// `profile` is dropped, not passed through: explorer is a fast-tier specialist, so
+// a parent must not bump it off `fast` via a per-spawn `profile` override (which the
+// `spawn_subagent` tool injects into the payload and `profileFromPayload` would
+// otherwise honor). Other fields still pass through untouched.
 export const explorerPayloadSchema = z
   .object({
     requestId: z.string().optional(),
@@ -84,6 +88,7 @@ export const explorerPayloadSchema = z
     description: z.string().optional(),
   })
   .passthrough()
+  .transform(({ profile: _profile, ...rest }) => rest)
 
 export type ExplorerPayload = z.infer<typeof explorerPayloadSchema>
 

--- a/src/bundled-plugins/scout/scout.test.ts
+++ b/src/bundled-plugins/scout/scout.test.ts
@@ -145,5 +145,12 @@ describe('scoutPayloadSchema', () => {
   test('passes through unknown fields (forward-compat with future spawn-tool params)', () => {
     const result = scoutPayloadSchema.safeParse({ requestId: 'bg_t1', futureField: 42 })
     expect(result.success).toBe(true)
+    expect((result.data as Record<string, unknown>).futureField).toBe(42)
+  })
+
+  test('drops a parent-supplied profile so scout cannot be bumped off its fast tier', () => {
+    const result = scoutPayloadSchema.safeParse({ requestId: 'bg_t1', prompt: 'x', profile: 'deep' })
+    expect(result.success).toBe(true)
+    expect(result.data).not.toHaveProperty('profile')
   })
 })

--- a/src/bundled-plugins/scout/scout.ts
+++ b/src/bundled-plugins/scout/scout.ts
@@ -68,6 +68,10 @@ End every response with this exact structure:
 - If the question requires LOCAL information (codebase, files in /agent/, git history, memory), say so explicitly and tell the caller to spawn \`explorer\` instead.
 - If you cannot find what was asked, say so explicitly with what queries you tried and what you DID find.`
 
+// `profile` is dropped, not passed through: scout is a fast-tier specialist, so a
+// parent must not bump it off `fast` via a per-spawn `profile` override (which the
+// `spawn_subagent` tool injects into the payload and `profileFromPayload` would
+// otherwise honor). Other fields still pass through untouched.
 export const scoutPayloadSchema = z
   .object({
     requestId: z.string().optional(),
@@ -75,6 +79,7 @@ export const scoutPayloadSchema = z
     description: z.string().optional(),
   })
   .passthrough()
+  .transform(({ profile: _profile, ...rest }) => rest)
 
 export type ScoutPayload = z.infer<typeof scoutPayloadSchema>
 


### PR DESCRIPTION
## Background

In production, scout runs were observed executing at `xhigh` instead of `low` — taking 600s+ per spawn instead of seconds. Both scout and explorer declare `profile: 'fast'` (→ reasoning effort `low` via `PROFILE_THINKING_LEVEL_DEFAULTS`). Two independent leaks let parent agents silently override that.

**Leak 1 — attention-escalation (primary cause of xhigh).**

Every subagent turn called `applyTurnThinkingLevel` inside `invokeSubagent` — twice: once before the turn and once in the `beforeAttempt` retry callback. That function runs `detectAttentionEscalation`, the "question-mark / frustration / Bezos detection" heuristic designed for TUI/channel sessions where a human typing `???` should get stronger reasoning. A subagent's prompt is composed by the *parent*, not a human. A multi-question research brief (exactly what a researcher hands a scout) trips the heuristic and silently bumps the child to `xhigh`. Category error.

Concrete evidence: in one real run, a researcher's scout ×2 ran at `xhigh` (641s + 460s) while another researcher's scout ×6 ran at `low` (49–135s each) — the only difference was the parent-composed prompt text.

**Leak 2 — profile-override passthrough (defense-in-depth; explains the `high` case).**

`spawn_subagent` injects an optional `profile` into the payload. Both scout and explorer used `.passthrough()` on their payload schemas, so `profileFromPayload` read the injected field and `resolveSubagentProfile` preferred it over the declared `fast`. A parent passing `profile: 'deep'` could bump scout/explorer to `high`.

## Summary

**Fix 1 — `src/agent/attention-escalation.ts` + `src/agent/subagents.ts`**

Add `allowEscalation?: boolean` to `TurnThinkingOptions`. `resolveTurnThinkingLevel` / `applyTurnThinkingLevel` skip the escalation path when `allowEscalation: false`. Default is `true` — all human-facing call sites (TUI, channel, cron) are unchanged. `invokeSubagent` now passes `{ allowEscalation: false }` at both call sites, so every subagent turn uses exactly its session default. This applies to all subagents (researcher, operator, reviewer) — their prompts are machine-composed; if stronger reasoning is needed it should come from the declared profile, not question-mark heuristics.

**Fix 2 — `src/bundled-plugins/scout/scout.ts` + `explorer.ts`**

After `.passthrough()` each schema now chains `.transform(({ profile: _p, ...rest }) => rest)`, dropping a parent-supplied `profile` before `profileFromPayload` can read it. Other passthrough fields are untouched. Subagents whose schema genuinely admits `profile` (e.g. operator) keep the generic per-spawn override.

## What this does NOT do

- Does not touch human-facing (TUI / channel / cron) escalation behavior — those sessions still escalate to `xhigh` on frustration signals.
- Does not remove `allowEscalation` from the public interface of `resolveTurnThinkingLevel` — callers that want escalation (the default) need no changes.
- Does not restrict the `spawn_subagent` `profile` param globally — it still works for subagents that admit it.

## Review notes

- **Load-bearing:** `allowEscalation: false` in the two `invokeSubagent` call sites in `src/agent/subagents.ts` (before the turn + `beforeAttempt` retry). Both must carry the flag — missing either leaves the retry path open to escalation.
- **Schema transform order:** the transform must appear after `.passthrough()`, not before — otherwise `profile` is stripped before passthrough recognizes it.
- Verified: `bun run lint` (0 errors), `bun run format:check` (clean), `bun run typecheck` (clean), `bun run test` (10101 pass, 1 skip, 0 fail).