### PR TITLE
feat(agent): cap per-engine search concurrency to dodge rate-limit CAPTCHAs

### DIFF
--- a/src/agent/tools/ddg.test.ts
+++ b/src/agent/tools/ddg.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { isWindows } from '@/shared'
 
-import { _setCurlBinaryForTest, fetchDdgHtml, parseDdgHtml } from './ddg'
+import {
+  _setCurlBinaryForTest,
+  _setSearchRetryForTest,
+  DDG_CONCURRENCY,
+  ddgSearch,
+  fetchDdgHtml,
+  parseDdgHtml,
+} from './ddg'
 
 const onWindows = isWindows()
 
@@ -229,5 +236,141 @@ printf '%s' "$RENDERED"
 
     // then
     await expect(promise).rejects.toThrow()
+  })
+})
+
+// Use double-quoted class attrs so the bodies embed cleanly inside the shell
+// fake's single-quoted printf (the lite SERP markup uses single quotes, but the
+// parser accepts either quote style).
+const RESULT_SERP = `<tr><td><a href="https://ok.example/" class="result-link">OK</a></td></tr>`
+const CAPTCHA_SERP = `<form id="challenge-form">Please verify you are a human</form>`
+
+// Emits a per-call body chosen by a counter file, plus the per-request random
+// sentinel round-tripped from `-w` (the primitive rejects output without it).
+function fakeCurlSwitching(scratchDir: string, captchaBody: string, okBody: string): string {
+  const counter = join(scratchDir, 'count')
+  return `
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then j=$((i + 1)); eval "WTPL=\\"\\\${$j}\\""; break; fi
+  i=$((i + 1))
+done
+N=$(cat ${counter} 2>/dev/null || echo 0)
+echo $((N + 1)) > ${counter}
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/200/' -e 's|%{url_effective}|https://lite.duckduckgo.com/lite/|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/0/')
+if [ "$N" -lt 1 ]; then printf '%s' '${captchaBody}'; else printf '%s' '${okBody}'; fi
+printf '%s' "$RENDERED"
+`
+}
+
+describe.skipIf(onWindows)('ddgSearch (retry + concurrency)', () => {
+  let scratchDir: string
+
+  beforeEach(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), 'ddg-search-test-'))
+    _setSearchRetryForTest({ attempts: 3, sleep: async () => {} })
+  })
+
+  afterEach(() => {
+    _setCurlBinaryForTest(null)
+    _setSearchRetryForTest(null)
+    rmSync(scratchDir, { recursive: true, force: true })
+  })
+
+  function installFakeBinary(script: string): void {
+    const path = join(scratchDir, 'fake-curl')
+    writeFileSync(path, `#!/bin/sh\n${script}\n`, 'utf8')
+    chmodSync(path, 0o755)
+    _setCurlBinaryForTest(path)
+  }
+
+  test('retries past a transient CAPTCHA and returns results', async () => {
+    // given: first response is a CAPTCHA, the next is a real SERP
+    installFakeBinary(fakeCurlSwitching(scratchDir, CAPTCHA_SERP, RESULT_SERP))
+
+    // when
+    const results = await ddgSearch('q', 10)
+
+    // then
+    expect(results).toHaveLength(1)
+    expect(results[0]?.url).toBe('https://ok.example/')
+  })
+
+  test('caps concurrent ddgSearch calls at DDG_CONCURRENCY across the process', async () => {
+    // given: a fake binary that records overlap by tracking live invocations
+    const liveFile = join(scratchDir, 'live')
+    const peakFile = join(scratchDir, 'peak')
+    installFakeBinary(`
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then j=$((i + 1)); eval "WTPL=\\"\\\${$j}\\""; break; fi
+  i=$((i + 1))
+done
+LIVE=$(cat ${liveFile} 2>/dev/null || echo 0); LIVE=$((LIVE + 1)); echo $LIVE > ${liveFile}
+PEAK=$(cat ${peakFile} 2>/dev/null || echo 0); if [ "$LIVE" -gt "$PEAK" ]; then echo $LIVE > ${peakFile}; fi
+sleep 0.3
+LIVE=$(cat ${liveFile}); echo $((LIVE - 1)) > ${liveFile}
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/200/' -e 's|%{url_effective}|https://lite.duckduckgo.com/lite/|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/0/')
+printf '%s' '${RESULT_SERP}'
+printf '%s' "$RENDERED"
+`)
+
+    // when: fire 5 searches at once through the shared process-wide limiter
+    await Promise.all(Array.from({ length: 5 }, () => ddgSearch('q', 10)))
+
+    // then: never more than DDG_CONCURRENCY ran the curl spawn simultaneously
+    const peak = Number((await Bun.file(peakFile).text()).trim())
+    expect(peak).toBeLessThanOrEqual(DDG_CONCURRENCY)
+    expect(peak).toBeGreaterThan(0)
+  })
+
+  test('a queued ddgSearch aborted before a slot frees rejects without spawning curl', async () => {
+    // given: a fake binary that records each spawn as its own marker file (so
+    // counting is free of the read-modify-write race a shared counter has) and
+    // blocks on a release file so the DDG_CONCURRENCY admitted calls hold slots
+    const spawnDir = join(scratchDir, 'spawns')
+    const releaseFile = join(scratchDir, 'release')
+    installFakeBinary(`
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then j=$((i + 1)); eval "WTPL=\\"\\\${$j}\\""; break; fi
+  i=$((i + 1))
+done
+mkdir -p ${spawnDir}
+: > ${spawnDir}/spawn.$$
+while [ ! -f ${releaseFile} ]; do sleep 0.02; done
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/200/' -e 's|%{url_effective}|https://lite.duckduckgo.com/lite/|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/0/')
+printf '%s' '${RESULT_SERP}'
+printf '%s' "$RENDERED"
+`)
+
+    const countSpawns = async (): Promise<number> => {
+      if (!existsSync(spawnDir)) return 0
+      const glob = new Bun.Glob('spawn.*')
+      let n = 0
+      for await (const _ of glob.scan({ cwd: spawnDir })) n++
+      return n
+    }
+
+    // when: saturate every slot, then queue one more with a signal and abort it
+    const saturating = Array.from({ length: DDG_CONCURRENCY }, () => ddgSearch('q', 10))
+    while ((await countSpawns()) < DDG_CONCURRENCY) {
+      await Bun.sleep(10)
+    }
+    const controller = new AbortController()
+    const queued = ddgSearch('q', 10, controller.signal)
+    await Bun.sleep(20)
+    controller.abort()
+
+    // then: the queued call rejected and never spawned curl (count stayed at DDG_CONCURRENCY)
+    await expect(queued).rejects.toThrow()
+    expect(await countSpawns()).toBe(DDG_CONCURRENCY)
+
+    // cleanup: release the held slots so the saturating calls finish
+    writeFileSync(releaseFile, 'go', 'utf8')
+    await Promise.all(saturating)
   })
 })

--- a/src/agent/tools/ddg.ts
+++ b/src/agent/tools/ddg.ts
@@ -13,10 +13,25 @@
 // for the full rationale and AGENTS.md §"Web search" for the original story.
 
 import { curlImpersonate } from './curl-impersonate'
+import { createKeyedSemaphore } from './keyed-semaphore'
+import { type SearchRetryOptions, withSearchRetry } from './search-retry'
 
 export { _setCurlBinaryForTest } from './curl-impersonate'
 
 const DDG_LITE_URL = 'https://lite.duckduckgo.com/lite/'
+
+// Empirically derived: a clean source IP serves DDG-lite at concurrency ~4 but
+// trips a sticky multi-minute CAPTCHA at 5-6 (see keyed-semaphore.ts header).
+// The whole agent egresses from one IP and the scout subagent fans out parallel
+// searches, so 2 sits well under the observed ceiling with headroom for the
+// concurrent membership-style overlap — matching the webex-prefetch-limiter
+// default for the same reason.
+export const DDG_CONCURRENCY = 2
+
+// Process-wide, so the cap spans every session/subagent/cron in this agent.
+const searchLimiter = createKeyedSemaphore({ concurrency: DDG_CONCURRENCY })
+
+const DDG_KEY = 'ddg'
 
 export type DdgResult = {
   title: string
@@ -24,12 +39,32 @@ export type DdgResult = {
   snippet: string
 }
 
+type RetryOverride = Pick<SearchRetryOptions, 'attempts' | 'baseDelayMs' | 'maxDelayMs' | 'sleep'>
+let retryOverride: RetryOverride = {}
+
+// Test-only seam: lets *.test.ts collapse the generous production backoff to
+// zero-delay single-shot retries so CAPTCHA tests don't burn real seconds.
+// Production never calls this — the empty default above is what production sees.
+export function _setSearchRetryForTest(override: RetryOverride | null): void {
+  retryOverride = override ?? {}
+}
+
 export async function ddgSearch(query: string, limit: number, signal?: AbortSignal): Promise<DdgResult[]> {
-  const html = await fetchDdgHtml(query, signal)
-  if (isCaptcha(html)) {
-    throw new DdgCaptchaError()
-  }
-  return parseDdgHtml(html).slice(0, limit)
+  return searchLimiter.run(
+    DDG_KEY,
+    () =>
+      withSearchRetry(
+        async () => {
+          const html = await fetchDdgHtml(query, signal)
+          if (isCaptcha(html)) {
+            throw new DdgCaptchaError()
+          }
+          return parseDdgHtml(html).slice(0, limit)
+        },
+        { ...retryOverride, shouldRetry: (error) => error instanceof DdgCaptchaError, signal },
+      ),
+    signal,
+  )
 }
 
 export class DdgCaptchaError extends Error {

--- a/src/agent/tools/keyed-semaphore.test.ts
+++ b/src/agent/tools/keyed-semaphore.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createKeyedSemaphore, SemaphoreAbortedError } from './keyed-semaphore'
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+describe('createKeyedSemaphore', () => {
+  test('caps concurrent runs per key at the configured limit', async () => {
+    // given
+    const sem = createKeyedSemaphore({ concurrency: 2 })
+    let active = 0
+    let peak = 0
+    const gate = deferred()
+
+    const work = async () => {
+      active++
+      peak = Math.max(peak, active)
+      await gate.promise
+      active--
+    }
+
+    // when: launch 4 against the same key, then release
+    const runs = [sem.run('k', work), sem.run('k', work), sem.run('k', work), sem.run('k', work)]
+    await Promise.resolve()
+    await Promise.resolve()
+    gate.resolve()
+    await Promise.all(runs)
+
+    // then
+    expect(peak).toBe(2)
+  })
+
+  test('queued work waits and runs after a slot frees (never skipped)', async () => {
+    // given
+    const sem = createKeyedSemaphore({ concurrency: 1 })
+    const order: string[] = []
+    const first = deferred()
+
+    // when
+    const a = sem.run('k', async () => {
+      order.push('a-start')
+      await first.promise
+      order.push('a-end')
+    })
+    const b = sem.run('k', async () => {
+      order.push('b-start')
+    })
+
+    await Promise.resolve()
+    expect(order).toEqual(['a-start'])
+    first.resolve()
+    await Promise.all([a, b])
+
+    // then: b ran only after a released, and was not dropped
+    expect(order).toEqual(['a-start', 'a-end', 'b-start'])
+  })
+
+  test('distinct keys never contend', async () => {
+    // given
+    const sem = createKeyedSemaphore({ concurrency: 1 })
+    let active = 0
+    let peak = 0
+    const gate = deferred()
+    const work = async () => {
+      active++
+      peak = Math.max(peak, active)
+      await gate.promise
+      active--
+    }
+
+    // when: two different keys run together
+    const runs = [sem.run('a', work), sem.run('b', work)]
+    await Promise.resolve()
+    gate.resolve()
+    await Promise.all(runs)
+
+    // then
+    expect(peak).toBe(2)
+  })
+
+  test('releases the slot even when work throws', async () => {
+    // given
+    const sem = createKeyedSemaphore({ concurrency: 1 })
+
+    // when
+    await expect(sem.run('k', async () => Promise.reject(new Error('boom')))).rejects.toThrow('boom')
+    const after = await sem.run('k', async () => 'ok')
+
+    // then: the rejected run did not leak the slot
+    expect(after).toBe('ok')
+  })
+
+  test('rejects immediately without running work when the signal is already aborted', async () => {
+    // given
+    const sem = createKeyedSemaphore({ concurrency: 1 })
+    let ran = false
+    const controller = new AbortController()
+    controller.abort()
+
+    // when / then
+    await expect(
+      sem.run(
+        'k',
+        async () => {
+          ran = true
+          return 'ok'
+        },
+        controller.signal,
+      ),
+    ).rejects.toBeInstanceOf(SemaphoreAbortedError)
+    expect(ran).toBe(false)
+  })
+
+  test('a queued call that aborts before admission rejects without running work', async () => {
+    // given: the only slot is held open
+    const sem = createKeyedSemaphore({ concurrency: 1 })
+    const hold = deferred()
+    const occupier = sem.run('k', async () => {
+      await hold.promise
+    })
+
+    // when: a second call queues, then aborts before the slot frees
+    let queuedRan = false
+    const controller = new AbortController()
+    const queued = sem.run(
+      'k',
+      async () => {
+        queuedRan = true
+      },
+      controller.signal,
+    )
+    await Promise.resolve()
+    controller.abort()
+
+    // then: the queued call rejected and never ran
+    await expect(queued).rejects.toBeInstanceOf(SemaphoreAbortedError)
+    expect(queuedRan).toBe(false)
+
+    // and: the freed slot is still usable by a fresh caller after the occupier releases
+    hold.resolve()
+    await occupier
+    const after = await sem.run('k', async () => 'ok')
+    expect(after).toBe('ok')
+  })
+
+  test('an aborted queued waiter does not consume the slot handed to it', async () => {
+    // given: concurrency 1, slot held, two queued waiters (one will abort)
+    const sem = createKeyedSemaphore({ concurrency: 1 })
+    const hold = deferred()
+    const occupier = sem.run('k', async () => {
+      await hold.promise
+    })
+
+    const controller = new AbortController()
+    const abortedQueued = sem.run('k', async () => 'should-not-run', controller.signal)
+    const secondGate = deferred()
+    let secondRan = false
+    const secondQueued = sem.run('k', async () => {
+      secondRan = true
+      await secondGate.promise
+    })
+
+    // when: first queued aborts, then the occupier releases its slot
+    await Promise.resolve()
+    controller.abort()
+    await expect(abortedQueued).rejects.toBeInstanceOf(SemaphoreAbortedError)
+    hold.resolve()
+    await occupier
+    await Promise.resolve()
+
+    // then: the slot was handed to the live waiter, not lost to the aborted one
+    expect(secondRan).toBe(true)
+    secondGate.resolve()
+    await secondQueued
+  })
+})

--- a/src/agent/tools/keyed-semaphore.ts
+++ b/src/agent/tools/keyed-semaphore.ts
@@ -1,0 +1,114 @@
+// A process-wide keyed concurrency limiter: at most `concurrency` calls run
+// at once PER KEY, and work queued behind a full key WAITS for a slot rather
+// than being skipped. Distinct keys never contend.
+//
+// This is the queue-and-wait sibling of src/channels/adapters/webex-prefetch-
+// limiter.ts. That limiter uses admit-or-skip because its work (history
+// prefetch) is an optional context improvement — dropping it is fine. Here the
+// work is a search the model explicitly asked for, so dropping it is NOT fine;
+// callers must block until a slot frees.
+//
+// Why this exists: one typeclaw agent is one process, and all sessions
+// (TUI, channel, cron, subagent) share that process. A search engine like
+// DuckDuckGo rate-limits by source IP, and the whole agent egresses from one
+// IP, so parallel searches across sessions/subagents stack onto the same
+// per-engine budget. An empirical probe of lite.duckduckgo.com showed a clean
+// IP serves ~4 concurrent requests but trips a sticky multi-minute CAPTCHA at
+// 5-6 — and once tripped, even serial requests stay boxed. Capping concurrency
+// PER ENGINE keeps the burst under that ceiling so the box is never tripped.
+
+export type KeyedSemaphore = {
+  // Runs `work` once a slot for `key` is free, waiting if necessary. The slot
+  // is released when `work` settles (resolve or reject). Distinct keys run
+  // fully independently. If `signal` aborts while the call is still queued (or
+  // is already aborted on entry), the call rejects with SemaphoreAbortedError
+  // WITHOUT ever running `work` or holding a slot.
+  run<T>(key: string, work: () => Promise<T>, signal?: AbortSignal): Promise<T>
+}
+
+export type KeyedSemaphoreOptions = {
+  // Max concurrent runs PER KEY. Defaults to 1.
+  concurrency?: number
+}
+
+export class SemaphoreAbortedError extends Error {
+  constructor() {
+    super('Semaphore acquisition aborted before admission.')
+    this.name = 'SemaphoreAbortedError'
+  }
+}
+
+export function createKeyedSemaphore(options: KeyedSemaphoreOptions = {}): KeyedSemaphore {
+  const concurrency = Math.max(1, Math.floor(options.concurrency ?? 1))
+
+  type Waiter = () => void
+  type Pool = { active: number; waiters: Waiter[] }
+  const pools = new Map<string, Pool>()
+
+  const poolFor = (key: string): Pool => {
+    let pool = pools.get(key)
+    if (pool === undefined) {
+      pool = { active: 0, waiters: [] }
+      pools.set(key, pool)
+    }
+    return pool
+  }
+
+  const release = (key: string): void => {
+    const pool = pools.get(key)
+    if (pool === undefined) return
+    pool.active--
+    const next = pool.waiters.shift()
+    if (next) {
+      pool.active++
+      next()
+      // Drop idle pools so a long-lived semaphore does not accumulate one entry
+      // per key ever seen.
+    } else if (pool.active === 0 && pool.waiters.length === 0) {
+      pools.delete(key)
+    }
+  }
+
+  const acquire = (key: string, signal?: AbortSignal): Promise<void> => {
+    if (signal?.aborted) return Promise.reject(new SemaphoreAbortedError())
+    const pool = poolFor(key)
+    if (pool.active < concurrency) {
+      pool.active++
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve, reject) => {
+      let settled = false
+      const grant: Waiter = () => {
+        if (settled) {
+          // Granted after we already aborted: hand the freed slot to the next
+          // waiter so an aborted grant never leaks a permanently-held slot.
+          release(key)
+          return
+        }
+        settled = true
+        signal?.removeEventListener('abort', onAbort)
+        resolve()
+      }
+      const onAbort = (): void => {
+        if (settled) return
+        settled = true
+        const idx = pool.waiters.indexOf(grant)
+        if (idx >= 0) pool.waiters.splice(idx, 1)
+        reject(new SemaphoreAbortedError())
+      }
+      pool.waiters.push(grant)
+      signal?.addEventListener('abort', onAbort, { once: true })
+    })
+  }
+
+  return {
+    async run<T>(key: string, work: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+      await acquire(key, signal)
+      try {
+        return await work()
+      } finally {
+        release(key)
+      }
+    },
+  }
+}

--- a/src/agent/tools/search-retry.test.ts
+++ b/src/agent/tools/search-retry.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+
+import { backoffDelayMs, SearchRetryAbortedError, withSearchRetry } from './search-retry'
+
+const noSleep = async () => {}
+
+describe('withSearchRetry', () => {
+  test('returns immediately on first success without retrying', async () => {
+    // given
+    let calls = 0
+    const work = async () => {
+      calls++
+      return 'ok'
+    }
+
+    // when
+    const result = await withSearchRetry(work, { shouldRetry: () => true, sleep: noSleep })
+
+    // then
+    expect(result).toBe('ok')
+    expect(calls).toBe(1)
+  })
+
+  test('retries a retryable error then succeeds', async () => {
+    // given
+    let calls = 0
+    const work = async () => {
+      calls++
+      if (calls < 3) throw new Error('captcha')
+      return 'ok'
+    }
+
+    // when
+    const result = await withSearchRetry(work, { attempts: 3, shouldRetry: () => true, sleep: noSleep })
+
+    // then
+    expect(result).toBe('ok')
+    expect(calls).toBe(3)
+  })
+
+  test('stops immediately on a non-retryable error', async () => {
+    // given
+    let calls = 0
+    const work = async () => {
+      calls++
+      throw new Error('parse failure')
+    }
+
+    // when / then
+    await expect(withSearchRetry(work, { attempts: 5, shouldRetry: () => false, sleep: noSleep })).rejects.toThrow(
+      'parse failure',
+    )
+    expect(calls).toBe(1)
+  })
+
+  test('throws the last error after exhausting all attempts', async () => {
+    // given
+    let calls = 0
+    const work = async () => {
+      calls++
+      throw new Error(`attempt ${calls}`)
+    }
+
+    // when / then
+    await expect(withSearchRetry(work, { attempts: 3, shouldRetry: () => true, sleep: noSleep })).rejects.toThrow(
+      'attempt 3',
+    )
+    expect(calls).toBe(3)
+  })
+
+  test('aborts before running when the signal is already aborted', async () => {
+    // given
+    let calls = 0
+    const controller = new AbortController()
+    controller.abort()
+
+    // when / then
+    await expect(
+      withSearchRetry(
+        async () => {
+          calls++
+          return 'ok'
+        },
+        { shouldRetry: () => true, sleep: noSleep, signal: controller.signal },
+      ),
+    ).rejects.toBeInstanceOf(SearchRetryAbortedError)
+    expect(calls).toBe(0)
+  })
+})
+
+describe('backoffDelayMs', () => {
+  test('grows the cap exponentially but never exceeds maxDelayMs', () => {
+    // given full jitter returns a value within [0, capped]
+    const base = 2_000
+    const max = 15_000
+
+    // when / then
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const capped = Math.min(max, base * 2 ** attempt)
+      const delay = backoffDelayMs(attempt, base, max)
+      expect(delay).toBeGreaterThanOrEqual(0)
+      expect(delay).toBeLessThanOrEqual(capped)
+      expect(delay).toBeLessThanOrEqual(max)
+    }
+  })
+})

--- a/src/agent/tools/search-retry.ts
+++ b/src/agent/tools/search-retry.ts
@@ -1,0 +1,82 @@
+// Retry-with-backoff for search-engine calls that hit a transient rate-limit
+// or CAPTCHA wall.
+//
+// Empirically, lite.duckduckgo.com does NOT recover in milliseconds once it
+// starts gating: a tripped source IP stays boxed for minutes, and the gate
+// surfaces as a CAPTCHA page (parsed as DdgCaptchaError) rather than a clean
+// 429. So the backoff here is deliberately generous (seconds, growing) — a
+// tight millisecond retry would just burn the remaining budget and confirm the
+// box. The concurrency cap (keyed-semaphore.ts) is the real preventer; this is
+// the second line of defense for a request that still raced into a gate.
+//
+// `shouldRetry` decides which errors are worth retrying — only transient
+// rate-limit/CAPTCHA signals, never a parse error or a hard network failure.
+
+export type SearchRetryOptions = {
+  attempts?: number
+  baseDelayMs?: number
+  maxDelayMs?: number
+  shouldRetry: (error: unknown) => boolean
+  signal?: AbortSignal
+  // Injectable sleep so tests can run without real timers.
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>
+}
+
+export const DEFAULT_SEARCH_RETRY_ATTEMPTS = 3
+export const DEFAULT_SEARCH_RETRY_BASE_DELAY_MS = 2_000
+export const DEFAULT_SEARCH_RETRY_MAX_DELAY_MS = 15_000
+
+export async function withSearchRetry<T>(work: () => Promise<T>, options: SearchRetryOptions): Promise<T> {
+  const attempts = Math.max(1, Math.floor(options.attempts ?? DEFAULT_SEARCH_RETRY_ATTEMPTS))
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_SEARCH_RETRY_BASE_DELAY_MS
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_SEARCH_RETRY_MAX_DELAY_MS
+  const sleep = options.sleep ?? defaultSleep
+
+  let lastError: unknown
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (options.signal?.aborted) throw new SearchRetryAbortedError()
+    try {
+      return await work()
+    } catch (error) {
+      lastError = error
+      const isLastAttempt = attempt === attempts - 1
+      if (isLastAttempt || !options.shouldRetry(error)) throw error
+      await sleep(backoffDelayMs(attempt, baseDelayMs, maxDelayMs), options.signal)
+    }
+  }
+  throw lastError
+}
+
+export class SearchRetryAbortedError extends Error {
+  constructor() {
+    super('Search retry aborted.')
+    this.name = 'SearchRetryAbortedError'
+  }
+}
+
+// Exponential backoff with full jitter (AWS "Exponential Backoff And Jitter").
+// Full jitter — random in [0, capped] — decorrelates concurrent retriers so a
+// burst that all tripped the gate together does not re-collide on the same
+// wake-up, which would just re-trip the box.
+export function backoffDelayMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const capped = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt)
+  return Math.floor(Math.random() * capped)
+}
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new SearchRetryAbortedError())
+      return
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(new SearchRetryAbortedError())
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}

--- a/src/agent/tools/websearch.test.ts
+++ b/src/agent/tools/websearch.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { isWindows } from '@/shared'
 
-import { _setCurlBinaryForTest } from './ddg'
+import { _setCurlBinaryForTest, _setSearchRetryForTest } from './ddg'
 import { webSearchTool } from './websearch'
 
 const onWindows = isWindows()
@@ -48,10 +48,14 @@ describe.skipIf(onWindows)('websearch tool: web (DuckDuckGo)', () => {
 
   beforeEach(() => {
     scratchDir = mkdtempSync(join(tmpdir(), 'websearch-test-'))
+    // Collapse the production CAPTCHA backoff so the retry path doesn't burn
+    // real seconds: one attempt, zero-delay sleep.
+    _setSearchRetryForTest({ attempts: 1, sleep: async () => {} })
   })
 
   afterEach(() => {
     _setCurlBinaryForTest(null)
+    _setSearchRetryForTest(null)
     rmSync(scratchDir, { recursive: true, force: true })
   })
 


### PR DESCRIPTION
## Why

`web_search` (DuckDuckGo) was the one outbound path with **no** rate-limit protection. Unlike LLM inference — which already has a circuit breaker (`modelThrottleCircuit`) plus model failover — a DDG search that hit a CAPTCHA was surfaced straight to the model with zero retry and zero concurrency cap.

This matters because **one typeclaw agent = one process = one egress IP**. All sessions (TUI, channel, cron) and every `scout` subagent share that IP, and DDG rate-limits by source IP. The `scout` subagent in particular fans out parallel searches, so bursts stack onto a single per-engine budget.

## Empirical basis for the concurrency value

I probed `lite.duckduckgo.com/lite/` directly at varying concurrency from a clean IP:

| Concurrency | Result |
|---|---|
| 1–4 | 100% success (HTTP 200, results parsed) |
| 5–6 | **CAPTCHA on every request** (HTTP 202 challenge page) |

Two further findings shaped the design:
- **The penalty is sticky.** Once tripped by a burst, the IP stayed boxed for *minutes* — even serial requests kept returning CAPTCHA after 90s of cooldown.
- **The probe used plain curl**, which is a *weaker* fingerprint than production's `curl_chrome136` TLS impersonation. So the real ceiling is **≥** what I measured; the observed safe ceiling (4) is a conservative floor.

**Decision: cap DDG at `2`.** It sits well under the ~4 floor with headroom for the multi-session reality (shared IP + parallel subagents), and matches the existing `webex-prefetch-limiter` default of 2, chosen for the same per-IP-budget reason. The stickiness is *why* the retry backoff is deliberately generous rather than millisecond-tight.

## What changed

Two small, reusable primitives + the wiring:

1. **`KeyedSemaphore`** (`keyed-semaphore.ts`) — process-wide concurrency limiter keyed by an arbitrary string. The **queue-and-wait** sibling of `webex-prefetch-limiter.ts` (which uses admit-or-skip because its work is optional; a model-requested search is not optional, so it queues instead of dropping).
2. **`withSearchRetry`** (`search-retry.ts`) — retry-with-**full-jitter** exponential backoff. Full jitter decorrelates a burst of retriers that all tripped the gate together so they don't re-collide on the same wake-up. `shouldRetry` gates which errors retry (only transient CAPTCHA, never parse/network failures).
3. **`ddgSearch`** now runs inside a process-wide semaphore (`DDG_CONCURRENCY = 2`) and retries a transient `DdgCaptchaError` with backoff.

The cap is the **preventer**; the retry is the **second line** for a request that still raced into a gate.

## Scope notes

- Per **search engine**, not per arbitrary domain — DDG is its own bucket (`'ddg'`). Wikipedia (effectively unlimited) is untouched. Future engines get their own key.
- LLM-inference concurrency is intentionally **out of scope** — it already has circuit-breaker + failover.

## Testing

- New unit tests for both primitives (concurrency cap, queue-not-skip, distinct keys, slot release on throw; retry success/exhaustion/non-retryable/abort; jitter bounds).
- New `ddgSearch` integration tests: retry-past-CAPTCHA, and a process-wide concurrency cap assertion (peak in-flight ≤ `DDG_CONCURRENCY`).
- A test-only seam (`_setSearchRetryForTest`, mirroring the existing `_setCurlBinaryForTest`) collapses the production backoff so CAPTCHA tests don't burn real seconds.
- `bun run typecheck` / `lint` (0 errors) / `format:check` / full `bun run test` (**10107 pass, 0 fail**) all green.
