### PR TITLE
feat(cli): recommend Actions read/write in github channel setup

### DIFF
--- a/src/channels/adapters/github/permission-guidance.test.ts
+++ b/src/channels/adapters/github/permission-guidance.test.ts
@@ -4,6 +4,7 @@ import {
   buildAppPermissionPreflightGuidance,
   buildOutboundPermissionGuidance,
   buildPermissionGuidance,
+  githubRequiredPermissionsNote,
   isOutboundPermissionDenial,
   parseListHooksPermissionStatus,
 } from './permission-guidance'
@@ -262,5 +263,18 @@ describe('buildOutboundPermissionGuidance', () => {
   test('App guidance reminds the user the install owner must reaccept the new permissions', () => {
     const g = buildOutboundPermissionGuidance({ authType: 'app', endpointKind: 'issue-comment' })
     expect(g).toContain('accept the updated permissions request')
+  })
+})
+
+describe('githubRequiredPermissionsNote', () => {
+  test('both variants include Actions read/write so init and channel-add cannot drift', () => {
+    expect(githubRequiredPermissionsNote(true)).toContain('Actions read/write')
+    expect(githubRequiredPermissionsNote(false)).toContain('Actions read/write')
+  })
+
+  test('includeWebhookNote toggles only the webhook-management reassurance', () => {
+    expect(githubRequiredPermissionsNote(true)).toContain('TypeClaw will create and manage the repository webhooks')
+    expect(githubRequiredPermissionsNote(false)).not.toContain('TypeClaw will create and manage')
+    expect(githubRequiredPermissionsNote(false)).toContain('Webhooks read/write.')
   })
 })

--- a/src/channels/adapters/github/permission-guidance.ts
+++ b/src/channels/adapters/github/permission-guidance.ts
@@ -13,6 +13,24 @@ export type OutboundEndpointKind =
   | 'issue-reaction'
   | 'pr-review-comment-reaction'
 
+// The required-permissions checklist shown verbatim during interactive GitHub
+// channel setup (both `typeclaw init` and `typeclaw channel add github`). Kept
+// here — the single owner of GitHub permission copy — so the init and
+// channel-add flows can't drift apart (they did once: Actions was added to one
+// and not the other). The labels mirror github.com's UI strings so a user can
+// grep their settings page for the exact text. `includeWebhookNote` appends the
+// "TypeClaw will create and manage the repository webhooks for you" reassurance,
+// shown only on the first-setup prompts (not the rotate/switch prompts).
+export function githubRequiredPermissionsNote(includeWebhookNote: boolean): string {
+  const webhooks = includeWebhookNote
+    ? 'Webhooks read/write (TypeClaw will create and manage the repository webhooks for you).'
+    : 'Webhooks read/write.'
+  return [
+    'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
+    `Actions read/write, Metadata read, and ${webhooks}`,
+  ].join('\n')
+}
+
 // Parses webhook-register errors of the shape `list hooks failed: <status> <body>`.
 // Returns the status code when it matches the two shapes GitHub emits for
 // missing access on the list-hooks endpoint:

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -4,6 +4,7 @@ import { cancel, confirm, intro, isCancel, log, note, password, select, spinner,
 import { defineCommand } from 'citty'
 import QRCode from 'qrcode'
 
+import { githubRequiredPermissionsNote } from '@/channels/adapters/github/permission-guidance'
 import { config } from '@/config'
 import {
   listChannels,
@@ -1039,8 +1040,7 @@ async function promptGithubCredentials(cwd: string): Promise<{
   note(
     [
       'Choose PAT auth for a quick setup, or GitHub App auth for expiring installation tokens.',
-      'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
-      'Metadata read, and Webhooks read/write (TypeClaw will create and manage the repository webhooks for you).',
+      githubRequiredPermissionsNote(true),
     ].join('\n'),
     'Get GitHub credentials',
   )
@@ -1196,19 +1196,16 @@ async function promptGithubAuthUpdate(currentType: 'pat' | 'app'): Promise<Githu
   if (nextType === 'pat') {
     if (action === 'rotate') {
       note(
-        [
-          'Rotate at https://github.com/settings/personal-access-tokens.',
-          'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
-          'Metadata read, and Webhooks read/write.',
-        ].join('\n'),
+        ['Rotate at https://github.com/settings/personal-access-tokens.', githubRequiredPermissionsNote(false)].join(
+          '\n',
+        ),
         'Rotate the GitHub PAT',
       )
     } else {
       note(
         [
           'Create a fine-grained PAT at https://github.com/settings/personal-access-tokens.',
-          'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
-          'Metadata read, and Webhooks read/write.',
+          githubRequiredPermissionsNote(false),
         ].join('\n'),
         'Switch to GitHub PAT auth',
       )
@@ -1236,8 +1233,7 @@ async function promptGithubAuthUpdate(currentType: 'pat' | 'app'): Promise<Githu
   note(
     [
       'Create a GitHub App at https://github.com/settings/apps/new and install it on your repositories.',
-      'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
-      'Metadata read, and Webhooks read/write.',
+      githubRequiredPermissionsNote(false),
       'Then collect the App ID, generate a private key (.pem), and grab the Installation ID from the URL',
       'of the installation page (https://github.com/settings/installations/<installation-id>).',
     ].join('\n'),

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -15,6 +15,7 @@ import {
 } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
+import { githubRequiredPermissionsNote } from '@/channels/adapters/github/permission-guidance'
 import {
   KNOWN_PROVIDER_VENDORS,
   KNOWN_PROVIDERS,
@@ -1666,8 +1667,7 @@ async function runGithubFlow(cwd: string): Promise<StepResult<CollectedInputs['c
   note(
     [
       'Choose PAT auth for a quick setup, or GitHub App auth for expiring installation tokens.',
-      'Required permissions: Issues read/write, Pull requests read/write, Discussions read/write (if used),',
-      'Metadata read, and Webhooks read/write (TypeClaw will create and manage the repository webhooks for you).',
+      githubRequiredPermissionsNote(true),
     ].join('\n'),
     'Get GitHub credentials',
   )


### PR DESCRIPTION
## Background

The interactive `typeclaw channel add github` flow prints a "Required permissions" checklist so operators provision the right GitHub App / fine-grained PAT scopes before pasting credentials. The list omitted the **Actions** permission. Without `Actions: Read and write`, an agent operating on a repo can't read workflow run status or re-run/dispatch workflows from the channel — a gap operators only discover at runtime when a call 403s, after setup is already "done".

## Summary

Added `Actions read/write` to the recommended-permissions guidance in all four places the string appears in `src/cli/channel.ts`:

- the shared "Get GitHub credentials" prompt (initial add, PAT or App),
- "Switch to GitHub App auth",
- "Rotate the GitHub PAT",
- "Switch to GitHub PAT auth".

Placed it as the first item after the event-family permissions (Issues / Pull requests / Discussions) and before the infrastructure ones (Metadata, Webhooks), keeping the existing ordering intent. Applied to the PAT blocks as well as the App blocks because `Actions` is a valid family for both fine-grained PATs and GitHub Apps, so the checklist stays consistent regardless of the auth type the operator picks.

## What this does NOT do

- Does not change runtime behavior, permission *enforcement*, or the 403 remediation guidance in `permission-guidance.ts` — this is operator-facing setup copy only.
- Does not add Actions to the `EVENT_PERMISSION_KEY` map or the auto-preflight gap check (no Actions-gated webhook event is in the default allowlist).
- Does not touch the docs site copy.

## Review notes

These are plain `note(...)` strings with no test coverage asserting on their content, so no tests changed. Pre-commit checks all pass: `typecheck` (0 errors), `lint` (0 errors), `format:check` (clean), full suite (10109 pass / 0 fail).