### PR TITLE
feat(channels): require an explicit resolve choice on github review-thread replies

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -851,7 +851,7 @@ describe('channel_reply resolve_review_thread', () => {
     expect(result.details.ok).toBe(false)
   })
 
-  test('does not attempt resolution when the flag is omitted', async () => {
+  test('does not attempt resolution on an explicit false (thread stays open)', async () => {
     let resolveCalled = false
     const tool = createChannelReplyTool({
       router: fakeRouter(async () => ({ ok: true }), {
@@ -863,9 +863,135 @@ describe('channel_reply resolve_review_thread', () => {
       origin: githubThreadOrigin,
     })
 
-    await runTool(tool, { text: 'plain reply' })
+    await runTool(tool, { text: 'plain reply', resolve_review_thread: false })
 
     expect(resolveCalled).toBe(false)
+  })
+})
+
+describe('channel_reply resolve_review_thread required-choice enforcement', () => {
+  test('denies a terminal github review-thread text reply that omits the resolve choice', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: githubThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: 'Thanks for the context — makes sense.' })
+
+    expect(calls).toHaveLength(0)
+    expect(result.details).toMatchObject({ ok: false })
+    expect((result.details as { error: string }).error).toContain('resolve_review_thread')
+    const rendered = (result.content[0] as { text: string }).text
+    expect(rendered).toContain('channel_reply denied')
+    expect(rendered).not.toContain('posted to')
+  })
+
+  test('proceeds when the resolve choice is an explicit false (thread kept open)', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: githubThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: 'Still looking into this one.', resolve_review_thread: false })
+
+    expect(calls).toHaveLength(1)
+    expect(result.details).toEqual({ ok: true })
+  })
+
+  test('exempts a mid-turn status reply (continue:true) from the required choice', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: githubThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: 'On it — checking the diff now.', continue: true })
+
+    expect(calls).toHaveLength(1)
+    expect(result.details).toEqual({ ok: true, continue: true })
+  })
+
+  test('exempts an attachments-only github review-thread reply (no text to acknowledge)', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: githubThreadOrigin,
+    })
+
+    const result = await runTool(tool, { attachments: [{ path: '/agent/diff.png' }] })
+
+    expect(calls).toHaveLength(1)
+    expect(result.details).toEqual({ ok: true })
+  })
+
+  test('does not require the choice on a github PR reply outside a review thread (thread === null)', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: { adapter: 'github', workspace: 'acme/widgets', chat: 'pr:585', thread: null },
+    })
+
+    const result = await runTool(tool, { text: 'General note on the PR.' })
+
+    expect(calls).toHaveLength(1)
+    expect(result.details).toEqual({ ok: true })
+  })
+
+  test('does not require the choice on a non-github review-thread reply', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: slackThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: 'done' })
+
+    expect(calls).toHaveLength(1)
+    expect(result.details).toEqual({ ok: true })
+  })
+
+  test('an explicit true still drives the existing resolve-before-post path', async () => {
+    const order: string[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(
+        async () => {
+          order.push('send')
+          return { ok: true }
+        },
+        {
+          resolveReviewThread: async (req) => {
+            order.push(`resolve:${req.rootCommentId}`)
+            return { ok: true }
+          },
+        },
+      ),
+      origin: githubThreadOrigin,
+    })
+
+    const result = await runTool(tool, { text: 'Verified — fix looks solid.', resolve_review_thread: true })
+
+    expect(order).toEqual(['resolve:3343107661', 'send'])
+    expect(result.details).toEqual({ ok: true })
   })
 })
 
@@ -948,7 +1074,10 @@ describe('channel_reply re-review stranding guard', () => {
       origin: githubThreadOrigin,
     })
 
-    const result = await runTool(tool, { text: 'Thanks for the context — makes sense.' })
+    const result = await runTool(tool, {
+      text: 'Thanks for the context — makes sense.',
+      resolve_review_thread: false,
+    })
 
     expect(result.details.ok).toBe(true)
     expect(queried).toBe(false)

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -92,9 +92,9 @@ export function createChannelReplyTool({
       resolve_review_thread: Type.Optional(
         Type.Boolean({
           description:
-            'GitHub review threads ONLY — ignored on Slack, Discord, Telegram, KakaoTalk, and any non-github session, and ignored on a github reply that is not inside a `thread`. On those, leave this unset and ignore the rest of this description. ' +
-            'On a github reply inside a review thread you authored: when your `text` acknowledges the concern is fixed/verified/addressed (e.g. "verified at <sha>", "thanks, that resolves it"), treat setting this `true` as the expected close-out — do it in the SAME call. This is a strong instruction, not a schema requirement: the field stays optional and nothing rejects an acknowledgement that omits it, but a bare ack without it leaves the thread open, because a successful reply ends the turn and the resolve cannot run in a later one. So this flag is the only way the close-out actually happens. ' +
-            "It is safe to set by default: the runtime resolves BEFORE posting and ONLY if the thread's root comment is yours — it refuses (and blocks the reply) on a human reviewer's thread, so you never close someone else's open question. You need not pre-check authorship; just set it on your acknowledgement and let the runtime enforce ownership. Leave it unset when you intend to keep the thread open (partial fix, disagreement, mid-discussion).",
+            'GitHub PR review threads ONLY. On a TERMINAL (`continue:false`) github PR review-thread reply that carries `text`, this is REQUIRED: you must set it to `true` or `false` and omitting it is rejected — you will be told to re-call with an explicit choice. (It stays a normal optional field everywhere else: ignored on Slack/Discord/Telegram/KakaoTalk and any non-github session, on github replies outside a review thread, on attachments-only replies, and on mid-turn `continue:true` status updates — leave it unset there.) ' +
+            'Set `true` when your `text` acknowledges the concern is fixed/verified/addressed (e.g. "verified at <sha>", "thanks, that resolves it"): the runtime resolves the thread BEFORE posting, so the close-out actually happens in this same turn — a successful reply ends the turn, so a resolve deferred to "later" never runs. ' +
+            "Set `false` when the thread should stay open (partial fix, disagreement, mid-discussion). It is safe to set `true` by default: the runtime resolves ONLY if the thread's root comment is yours — it refuses (and blocks the reply) on a human reviewer's thread, so you never close someone else's open question. You need not pre-check authorship; let the runtime enforce ownership.",
         }),
       ),
     }),
@@ -137,6 +137,27 @@ export function createChannelReplyTool({
         return {
           content: [{ type: 'text' as const, text: `channel_reply denied: ${kimiLeakError}` }],
           details: { ok: false, error: kimiLeakError },
+        }
+      }
+
+      // Required-choice guard: a terminal github review-thread text reply must
+      // make an explicit resolve_review_thread choice. The model kept silently
+      // omitting the flag after acknowledging a fix, leaving the thread open;
+      // forcing the choice (the discipline `continue` already enforces) closes
+      // the loop where prose instructions did not. The field stays optional in
+      // the schema precisely so omission is still detectable here (vs explicit
+      // false). Runs before the resolve/guards so a missing choice never acts.
+      const missingResolveChoice = missingReviewThreadResolveChoiceError({
+        origin,
+        text,
+        isContinue: keepTurnAlive,
+        resolveReviewThread: params.resolve_review_thread,
+      })
+      if (missingResolveChoice) {
+        logger.warn(formatChannelToolFailure('channel_reply', missingResolveChoice))
+        return {
+          content: [{ type: 'text' as const, text: `channel_reply denied: ${missingResolveChoice}` }],
+          details: { ok: false, error: missingResolveChoice },
         }
       }
 
@@ -277,6 +298,30 @@ export function createChannelReplyTool({
       }
     },
   })
+}
+
+// Returns the denial string when a terminal github PR review-thread text reply
+// omits an explicit resolve_review_thread choice, or '' when no choice is owed.
+// Scoped by `^pr:\d+$` (not just thread !== null) so a future threaded github
+// context can't be forced into a resolve choice that means nothing there.
+function missingReviewThreadResolveChoiceError(input: {
+  origin: ChannelReplyOrigin
+  text: string | undefined
+  isContinue: boolean
+  resolveReviewThread: boolean | undefined
+}): string {
+  const isGithubPrReviewThread =
+    input.origin.adapter === 'github' && /^pr:\d+$/.test(input.origin.chat) && input.origin.thread !== null
+  const hasText = input.text !== undefined && input.text.trim() !== ''
+  if (!isGithubPrReviewThread || !hasText || input.isContinue || input.resolveReviewThread !== undefined) {
+    return ''
+  }
+  return (
+    'This is a terminal github PR review-thread reply with text, so `resolve_review_thread` is required: ' +
+    'set it to `true` when the concern is fixed and this bot-authored thread should be closed (the runtime ' +
+    'resolves before posting and only on your own thread), or `false` to leave it open. You omitted it; ' +
+    're-call channel_reply with an explicit boolean.'
+  )
 }
 
 // Returns an error string when the resolve should block the reply, or null

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -168,7 +168,7 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
 
     const result = await tool.execute(
       'id',
-      { text: 'sure, here is the rationale', continue: false },
+      { text: 'sure, here is the rationale', continue: false, resolve_review_thread: false },
       undefined,
       undefined,
       fakeCtx,
@@ -212,7 +212,13 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       origin: { adapter: 'github', workspace: inbound.workspace, chat: inbound.chat, thread: inbound.thread },
       logger: silent,
     })
-    await tool.execute('id', { text: 'got it', continue: false }, undefined, undefined, fakeCtx)
+    await tool.execute(
+      'id',
+      { text: 'got it', continue: false, resolve_review_thread: false },
+      undefined,
+      undefined,
+      fakeCtx,
+    )
 
     expect(calls[0]?.url).toBe('https://api.github.com/repos/acme/project/pulls/7/comments/555/replies')
   })
@@ -244,7 +250,13 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
       origin: { adapter: 'github', workspace: inbound.workspace, chat: inbound.chat, thread: inbound.thread },
       logger: silent,
     })
-    await tool.execute('id', { text: 'reply', continue: false }, undefined, undefined, fakeCtx)
+    await tool.execute(
+      'id',
+      { text: 'reply', continue: false, resolve_review_thread: false },
+      undefined,
+      undefined,
+      fakeCtx,
+    )
 
     expect(calls[0]?.url).toContain('/pulls/7/comments/200/replies')
     expect(calls[0]?.url).not.toContain('/issues/7/comments')


### PR DESCRIPTION
## Background

`resolve_review_thread` was optional on terminal (`continue:false`) GitHub PR review-thread replies that carry text. The model routinely omitted it after acknowledging a fix, leaving threads open — the behavioral gap we tried to close with increasingly long natural-language prompt instructions the model kept ignoring.

The structural problem: the schema had no enforcement at the tool boundary, so "omitted" and "explicit false" (keep thread open intentionally) were indistinguishable. Prose instructions in the system prompt are overridden by the path of least resistance; a hard rejection at `execute()` is not.

## Summary

A runtime guard now rejects terminal github review-thread replies that carry text but omit `resolve_review_thread`. The error message instructs the model to re-call with an explicit boolean — the same required-choice discipline `continue` already enforces.

**Why a runtime guard and not a static TypeBox `Required`?** A TypeBox object can't conditionally require a field per-channel. More importantly, the distinction between "omitted" (rejected) and "explicit false" (keep thread open intentionally) would collapse if the field were statically required — the schema would force a value and we'd lose the ability to detect absence. So the field stays `Type.Optional` and the guard enforces the choice in `execute()`.

Enforcement scope: adapter `github`, chat matching `^pr:\d+$`, thread not null, text present. The `^pr:\d+$` scope rather than just `thread !== null` future-proofs against other GitHub threaded contexts. Exemptions: mid-turn `continue:true` status acks (no resolve decision yet), and attachments-only replies. Ordering: the guard runs before the false-receipt / re-review / resolve-before-post steps so a missing choice never partially acts.

The tool description is rewritten to state the conditional requirement bluntly rather than relying on prose that wasn't working.

## Preview

N/A — no UI or output format change.

## What this does NOT do

- Does not change behavior for non-github adapters, non-PR chats, or threadless replies.
- Does not auto-resolve or auto-keep-open threads — the model must still make the choice; the guard only ensures it does.
- Does not touch the schema type: `resolve_review_thread` remains `Type.Optional` so TypeScript callers that pass an explicit value are unaffected.

## Review notes

- Load-bearing change: `missingReviewThreadResolveChoiceError` guard in `src/agent/tools/channel-reply.ts`. Verify it runs **before** the false-receipt / re-review / resolve-before-post block — ordering matters so a missing choice can't partially side-effect.
- The new `'channel_reply resolve_review_thread required-choice enforcement'` describe block in `channel-reply.test.ts` covers six cases: omitted → denied, explicit false → proceeds, `continue:true` → exempt, attachments-only → exempt, non-thread / non-github → exempt, explicit true → hits the existing resolve-before-post path.
- Pre-existing tests in `channel-reply.test.ts` and `line-comment-thread.test.ts` that used terminal github-thread replies were updated to pass `resolve_review_thread: false` — their behavior (outbound routing, no-attempt-on-omission) is unchanged; they now just satisfy the new guard.
- `bun run typecheck` / `bun run lint` (0 errors, only pre-existing warnings elsewhere) / `bun run format` all pass. Full `src/agent/tools` + `src/channels` suites green (2620 tests, 0 fail).