### PR TITLE
fix(cli): arm readline keypress decoding so clack pickers navigate over SSH

### DIFF
--- a/src/cli/ui.test.ts
+++ b/src/cli/ui.test.ts
@@ -446,64 +446,72 @@ describe('spinner', () => {
 describe('prepareStdinForClack', () => {
   type FakeStdin = {
     isTTY: boolean
-    setRawMode?: (value: boolean) => void
-    rawModeCalls: boolean[]
     resumed: number
     resume: () => void
   }
 
-  function fakeStdin(opts: { isTTY: boolean; hasSetRawMode?: boolean; rawModeThrows?: boolean }): FakeStdin {
-    const s: FakeStdin = {
+  function fakeStdin(opts: { isTTY: boolean }): FakeStdin {
+    return {
       isTTY: opts.isTTY,
-      rawModeCalls: [],
       resumed: 0,
       resume() {
         this.resumed += 1
       },
     }
-    if (opts.hasSetRawMode !== false) {
-      s.setRawMode = (value: boolean): void => {
-        s.rawModeCalls.push(value)
-        if (opts.rawModeThrows === true) throw new Error('terminal torn down')
-      }
-    }
-    return s
   }
 
-  test('resumes stdin so a clack picker receives bytes over an SSH pseudo-TTY', () => {
-    // given: a TTY that has never been resumed (the first-picker state over SSH)
+  test('arms readline keypress decoding on stdin so arrow bytes become keypress events', () => {
+    // given: a TTY whose readline keypress decoder is not yet armed (SSH first-picker)
     const stdin = fakeStdin({ isTTY: true })
+    const armed: unknown[] = []
     // when: handing stdin to clack
-    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
-    // then: the stream is resumed so clack's keypress listener gets input
-    expect(stdin.resumed).toBeGreaterThanOrEqual(1)
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream, {
+      emitKeypressEvents: (stream) => armed.push(stream),
+    })
+    // then: the keypress decoder is installed on that exact stream
+    expect(armed).toEqual([stdin])
   })
 
-  test('kicks stdin back to flowing with a raw-mode toggle, ending non-raw', () => {
-    // A pi-tui ProcessTerminal.stop() leaves stdin paused; on->off raw toggle
-    // re-flows it under Bun/SSH, and the final non-raw state is what clack owns.
+  test('pre-arms with clack 1.2.0 escapeCodeTimeout (50ms) so bare Esc stays fast', () => {
+    // readline binds escapeCodeTimeout once, when the decoder is first installed,
+    // and no-ops on clack's later createInterface — so the pre-arm MUST carry
+    // clack's 50ms or a bare Esc falls back to readline's 500ms default.
     const stdin = fakeStdin({ isTTY: true })
-    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
-    expect(stdin.rawModeCalls).toEqual([true, false])
+    let ifaceArg: { escapeCodeTimeout?: number } | undefined
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream, {
+      emitKeypressEvents: (_stream, iface) => {
+        ifaceArg = iface
+      },
+    })
+    expect(ifaceArg?.escapeCodeTimeout).toBe(50)
+  })
+
+  test('arms keypress decoding BEFORE resuming so no keystroke is missed', () => {
+    const order: string[] = []
+    const stdin = {
+      isTTY: true,
+      resume: () => order.push('resume'),
+    }
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream, {
+      emitKeypressEvents: () => order.push('emitKeypressEvents'),
+    })
+    expect(order).toEqual(['emitKeypressEvents', 'resume'])
+  })
+
+  test('resumes stdin so the flowing stream feeds clack the decoded keypresses', () => {
+    const stdin = fakeStdin({ isTTY: true })
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream, { emitKeypressEvents: () => {} })
+    expect(stdin.resumed).toBeGreaterThanOrEqual(1)
   })
 
   test('is a no-op on a non-TTY stdin (piped/redirected input)', () => {
     const stdin = fakeStdin({ isTTY: false })
-    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)
+    const armed: unknown[] = []
+    prepareStdinForClack(stdin as unknown as NodeJS.ReadStream, {
+      emitKeypressEvents: (stream) => armed.push(stream),
+    })
     expect(stdin.resumed).toBe(0)
-    expect(stdin.rawModeCalls).toEqual([])
-  })
-
-  test('still resumes when setRawMode throws (terminal already torn down)', () => {
-    const stdin = fakeStdin({ isTTY: true, rawModeThrows: true })
-    expect(() => prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)).not.toThrow()
-    expect(stdin.resumed).toBeGreaterThanOrEqual(1)
-  })
-
-  test('resumes even when setRawMode is unavailable on the stream', () => {
-    const stdin = fakeStdin({ isTTY: true, hasSetRawMode: false })
-    expect(() => prepareStdinForClack(stdin as unknown as NodeJS.ReadStream)).not.toThrow()
-    expect(stdin.resumed).toBeGreaterThanOrEqual(1)
+    expect(armed).toEqual([])
   })
 })
 

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -1,3 +1,4 @@
+import { emitKeypressEvents as nodeEmitKeypressEvents } from 'node:readline'
 import { styleText } from 'node:util'
 
 import { cancel, intro, isCancel, log, note, outro, spinner as clackSpinner } from '@clack/prompts'
@@ -8,29 +9,38 @@ import { COMPACT_WORDMARK, WORDMARK_LINES, WORDMARK_WIDTH } from '@/shared/wordm
 
 export { cancel, intro, isCancel, log, note, outro }
 
-type ClackInput = Pick<NodeJS.ReadStream, 'isTTY' | 'setRawMode' | 'resume'>
+type ClackInput = Pick<NodeJS.ReadStream, 'isTTY' | 'resume'>
 
-// Hand stdin to a clack picker in a state it can own. Over an SSH pseudo-TTY,
-// Bun's readline keypress wiring only transitions stdin into flowing raw mode
-// reliably once the stream has already been resumed; on a never-resumed stdin
-// the picker renders but arrow keys echo as raw `^[[B` and never advance it.
-// Local terminals dodge this because stdin was already flowing. Worse, after a
-// pi-tui viewer (ProcessTerminal.stop() calls process.stdin.pause()), a plain
-// resume() does NOT re-flow stdin under Bun, so the next picker is dead over
-// SSH. Toggling raw mode on->off forces the TTY read back into flowing mode;
-// the trailing resume() + non-raw state is the baseline clack expects.
-// Never pause() here — a paused process.stdin does not reliably re-flow.
-export function prepareStdinForClack(input: ClackInput = process.stdin): void {
+type KeypressInterface = { escapeCodeTimeout?: number }
+
+type PrepareStdinDeps = {
+  emitKeypressEvents?: (stream: NodeJS.ReadableStream, iface: KeypressInterface) => void
+}
+
+// @clack/core@1.2.0 builds its readline interface with escapeCodeTimeout: 50 so
+// a bare Esc (the cancel key) resolves fast. readline's keypress decoder binds
+// that timeout ONCE, when emitKeypressEvents first installs it on the stream, and
+// is a no-op on every later call — so pre-arming here without it would lock in
+// readline's 500ms default and clack's own 50ms could never take effect.
+const CLACK_ESCAPE_CODE_TIMEOUT_MS = 50
+
+// Arm readline's keypress decoder on stdin before a clack picker reads it. Over
+// an SSH pseudo-TTY, arrow keys arrive as raw `\x1b[A`/`\x1b[B` bytes and only
+// become the `{ name: 'up' }` keypress events clack navigates on once that
+// decoder is installed on THIS stream. After a prior raw-mode 'data' consumer or
+// a pi-tui detach (ProcessTerminal.stop() pauses stdin), Bun does NOT re-arm the
+// decoder when clack later calls createInterface({ terminal: true }), so the
+// picker renders but arrows echo as `^[[A` and never advance. We pass clack's
+// own escapeCodeTimeout so the pre-arm matches what clack would have set; raw
+// mode is left to clack. Never pause() — a paused process.stdin does not
+// reliably re-flow under Bun.
+export function prepareStdinForClack(input: ClackInput = process.stdin, deps: PrepareStdinDeps = {}): void {
   if (!input.isTTY) return
-  input.resume()
-  if (typeof input.setRawMode === 'function') {
-    try {
-      input.setRawMode(true)
-      input.setRawMode(false)
-    } catch {
-      /* terminal already torn down */
-    }
-  }
+  const emitKeypressEvents =
+    deps.emitKeypressEvents ??
+    ((stream: NodeJS.ReadableStream, iface: KeypressInterface) =>
+      nodeEmitKeypressEvents(stream, iface as unknown as Parameters<typeof nodeEmitKeypressEvents>[1]))
+  emitKeypressEvents(input as unknown as NodeJS.ReadableStream, { escapeCodeTimeout: CLACK_ESCAPE_CODE_TIMEOUT_MS })
   input.resume()
 }
 

--- a/src/inspect/index.ts
+++ b/src/inspect/index.ts
@@ -85,9 +85,8 @@ export type ResolveInspectResult = { ok: true; target: InspectTarget } | { ok: f
 
 // Picker phase, split out from the streaming phase so the tail scope is created
 // AFTER the picker, never before. A raw-mode 'data' listener active during the
-// Clack picker (which forces cooked mode via prepareStdinForClack) fights Clack
-// for stdin and leaves the later stream in cooked mode — that was the recurring
-// "esc does nothing" regression.
+// Clack picker fights Clack for stdin and leaves the later stream in cooked mode
+// — that was the recurring "esc does nothing" regression.
 export async function resolveInspectTarget(opts: Omit<RunInspectOptions, 'signal'>): Promise<ResolveInspectResult> {
   const filterResult = parseFilter(opts.filter)
   if (!filterResult.ok) return { ok: false, exitCode: 2, reason: filterResult.reason }


### PR DESCRIPTION
## Background

Over an SSH pseudo-TTY, the `inspect` picker ("Pick what to view") rendered fine but **arrow keys did nothing useful — they echoed as literal `^[[A` / `^[[B` into the prompt instead of moving the selection.** Local terminals were unaffected, so the bug only showed up over SSH.

Root cause: clack's `SelectPrompt` navigates on readline `keypress` events (`{ name: 'up' }`), not on raw bytes. Arrow keys arrive from the pty as raw escape sequences (`\x1b[A`/`\x1b[B`); those only get decoded into keypress events once readline's keypress decoder is *armed on that stream*. After a prior raw-mode `'data'` consumer (the inspect tail viewer) or a pi-tui detach — which calls `process.stdin.pause()` — **Bun does not re-arm the decoder** when clack later calls `createInterface({ terminal: true })`. So the bytes were delivered raw and echoed rather than parsed.

The previous workaround in `prepareStdinForClack` toggled `setRawMode(true) → setRawMode(false)`. That changed terminal mode but never installed the keypress decoder, which is why it never actually fixed SSH.

## Summary

`prepareStdinForClack` now arms the decoder explicitly:

- Call `readline.emitKeypressEvents(stdin)` — the correct primitive that turns `\x1b[A` bytes into `{ name: 'up' }` keypress events. It's idempotent, so clack attaching its own keypress listener afterward reuses the already-armed stream.
- Keep `stdin.resume()` so the stream is flowing.
- **Drop the `setRawMode` toggle.** Raw-mode lifecycle is left entirely to clack, which already owns it (and its cleanup) — avoiding a two-owner cleanup race.

**Why here and not in `refreshableSelect`:** `prepareStdinForClack` is the single boundary between TypeClaw's custom raw-stdin handling (tail viewer / pi-tui) and clack's prompt handling, and every picker call site already routes through it. Fixing it once covers `inspect` and `dreams` pickers alike.

A `PrepareStdinDeps` injection seam (`emitKeypressEvents`) lets the unit tests prove the decoder is armed — and armed *before* `resume()` — without a real pty.

## What this does NOT do

- Does not touch the live pi-tui TUI input path (`src/tui/`) — that uses its own `@mariozechner/pi-tui` `matchesKey()` decoder, not clack/readline.
- Does not change the tail viewer's escape-sequence state machine (`inspect-controller.ts`).
- Does not change raw-mode ownership inside clack.

## Review notes

- Load-bearing line: `emitKeypressEvents(input)` before `input.resume()` in `src/cli/ui.ts`. Ordering is asserted by the "arms keypress decoding BEFORE resuming" test.
- The stale comment in `src/inspect/index.ts` was corrected — `prepareStdinForClack` no longer "forces cooked mode."
- Verified locally: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full suite pass. (One Xvfb entrypoint-shim test is flaky on a 5s timeout and passes on isolated re-run — unrelated to this change.)
