### PR TITLE
fix(run): contain unhandled rejections so a flaky channel SDK can't crash the agent

### DIFF
--- a/src/run/codex-fetch-observer.test.ts
+++ b/src/run/codex-fetch-observer.test.ts
@@ -328,21 +328,46 @@ describe('installCodexFetchObserver', () => {
     expect(globalThis.fetch).toBe(before)
   })
 
-  test('double install warns and returns existing uninstall', () => {
-    const { logger, entries } = captureLogger()
-    const uninstall1 = installCodexFetchObserver({ logger })
+  test('a second install shares the wrapper and is ref-counted: a later release keeps fetch observed while another claimant remains', () => {
+    const { logger } = captureLogger()
+    const before = globalThis.fetch
+    const release1 = installCodexFetchObserver({ logger })
     const wrappedAfterFirst = globalThis.fetch
-    const uninstall2 = installCodexFetchObserver({ logger })
+    const release2 = installCodexFetchObserver({ logger })
     try {
+      // given two claimants sharing one wrapper
       expect(globalThis.fetch).toBe(wrappedAfterFirst)
-      const warns = entries.filter((e) => e.level === 'warn')
-      expect(warns.length).toBe(1)
-      expect(warns[0]!.msg).toContain('[codex-fetch]')
-      expect(warns[0]!.msg).toContain('already installed')
+
+      // when the second claimant releases (e.g. a second agent's boot-failure
+      // cleanup), the first agent's observer must survive
+      release2()
+      expect(globalThis.fetch).toBe(wrappedAfterFirst)
+
+      // then only the final release restores the original fetch
+      release1()
+      expect(globalThis.fetch).toBe(before)
     } finally {
-      uninstall1()
-      uninstall2()
+      release1()
+      release2()
     }
+  })
+
+  test('a release is idempotent and never tears down a re-acquired observer', () => {
+    const { logger } = captureLogger()
+    const before = globalThis.fetch
+    const release1 = installCodexFetchObserver({ logger })
+    release1()
+    release1() // idempotent: second call is a no-op
+    expect(globalThis.fetch).toBe(before)
+
+    // a fresh install after full release re-wraps and is independent
+    const release2 = installCodexFetchObserver({ logger })
+    expect(globalThis.fetch).not.toBe(before)
+    // the stale release1 must NOT restore over the new observer
+    release1()
+    expect(globalThis.fetch).not.toBe(before)
+    release2()
+    expect(globalThis.fetch).toBe(before)
   })
 
   test('TYPECLAW_CODEX_FETCH_OBSERVER=off disables installation', () => {

--- a/src/run/codex-fetch-observer.ts
+++ b/src/run/codex-fetch-observer.ts
@@ -87,9 +87,16 @@ const consoleLogger: CodexFetchObserverLogger = {
 
 type InstallState = {
   originalFetch: typeof fetch
-  uninstall: () => void
+  wrapped: typeof fetch
+  claimants: number
 }
 
+// Ref-counted so multiple agents in one process (compose, tests) share one
+// `globalThis.fetch` wrapper: the FIRST install wraps fetch, each later install
+// just joins, and `globalThis.fetch` is restored only when the LAST claimant
+// releases. A bare singleton would let one agent's release (e.g. a second
+// agent's boot-failure cleanup) tear down the observer out from under another
+// still-running agent.
 let installed: InstallState | null = null
 
 // Returns true when the request is for the Codex Responses endpoint and we
@@ -340,8 +347,8 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
   }
   const logger = opts.logger ?? consoleLogger
   if (installed !== null) {
-    logger.warn(`${LOG_PREFIX} install called but observer already installed; ignoring`)
-    return installed.uninstall
+    installed.claimants++
+    return makeRelease(installed.wrapped)
   }
 
   const codexHost = opts.codexHost ?? DEFAULT_CODEX_HOST
@@ -421,14 +428,23 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
 
   globalThis.fetch = wrapped
 
-  const uninstall = () => {
-    if (installed === null) return
-    if (globalThis.fetch === wrapped) {
-      globalThis.fetch = originalFetch
+  installed = { originalFetch, wrapped, claimants: 1 }
+  return makeRelease(wrapped)
+}
+
+// Each install call gets its own idempotent release. The shared
+// `globalThis.fetch` wrapper is restored only when the final claimant releases,
+// so one agent releasing never disturbs another's still-active observer.
+function makeRelease(wrapped: typeof fetch): () => void {
+  let released = false
+  return () => {
+    if (released || installed === null || installed.wrapped !== wrapped) return
+    released = true
+    installed.claimants--
+    if (installed.claimants > 0) return
+    if (globalThis.fetch === installed.wrapped) {
+      globalThis.fetch = installed.originalFetch
     }
     installed = null
   }
-
-  installed = { originalFetch, uninstall }
-  return uninstall
 }

--- a/src/run/fatal-guard.test.ts
+++ b/src/run/fatal-guard.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { classifyFatalError, installFatalGuard } from './fatal-guard'
+
+const silentLogger = { warn: () => {}, error: () => {} }
+
+let dispose: (() => void) | null = null
+
+afterEach(() => {
+  dispose?.()
+  dispose = null
+})
+
+function install(options: Parameters<typeof installFatalGuard>[0] = {}) {
+  const handle = installFatalGuard({ logger: silentLogger, ...options })
+  dispose = handle.dispose
+  return handle
+}
+
+describe('classifyFatalError', () => {
+  test('uncaughtException always restarts', () => {
+    expect(classifyFatalError('uncaughtException', new Error('boom'))).toEqual({
+      action: 'restart',
+      reason: 'uncaught exception',
+    })
+  })
+
+  test('webex KMS code is recoverable and scoped to webex', () => {
+    const err = Object.assign(new Error('KMS request timed out'), { code: 'KMS_ERROR' })
+    expect(classifyFatalError('unhandledRejection', err)).toEqual({
+      action: 'continue',
+      scope: 'webex',
+      reason: 'webex async dependency rejection',
+    })
+  })
+
+  test('webex-message-handler stack provenance is recoverable', () => {
+    const err = new Error('timed out')
+    err.stack = 'Error: timed out\n    at <anonymous> (/agent/node_modules/webex-message-handler/dist/index.mjs:783:16)'
+    expect(classifyFatalError('unhandledRejection', err)).toMatchObject({ action: 'continue', scope: 'webex' })
+  })
+
+  test('generic agent-messenger provenance degrades the channel scope', () => {
+    const err = new Error('socket hung up')
+    err.stack = 'Error\n    at (/agent/node_modules/agent-messenger/slack/index.mjs:10:1)'
+    expect(classifyFatalError('unhandledRejection', err)).toMatchObject({ action: 'continue', scope: 'channel' })
+  })
+
+  test('unknown rejection escalates to restart', () => {
+    expect(classifyFatalError('unhandledRejection', new Error('something unrelated'))).toEqual({
+      action: 'restart',
+      reason: 'unknown unhandled rejection',
+    })
+  })
+
+  test('non-Error rejection values do not throw and escalate to restart', () => {
+    expect(classifyFatalError('unhandledRejection', 'plain string reason')).toMatchObject({ action: 'restart' })
+    expect(classifyFatalError('unhandledRejection', undefined)).toMatchObject({ action: 'restart' })
+  })
+})
+
+describe('installFatalGuard', () => {
+  test('a known channel rejection degrades and does NOT request restart', () => {
+    const degraded: Array<{ scope: string; reason: string }> = []
+    let restartCalls = 0
+    const { guard } = install({
+      onDegrade: (scope, reason) => degraded.push({ scope, reason }),
+      requestRestart: async () => {
+        restartCalls++
+        return { ok: true }
+      },
+    })
+
+    guard.handle('unhandledRejection', Object.assign(new Error('kms'), { code: 'KMS_ERROR' }))
+
+    expect(degraded).toEqual([{ scope: 'webex', reason: 'webex async dependency rejection' }])
+    expect(restartCalls).toBe(0)
+  })
+
+  test('an uncaughtException requests a restart', async () => {
+    const reasons: string[] = []
+    const { guard } = install({
+      requestRestart: async (reason) => {
+        reasons.push(reason)
+        return { ok: true }
+      },
+    })
+
+    guard.handle('uncaughtException', new Error('corrupt'))
+    await Promise.resolve()
+
+    expect(reasons).toEqual(['uncaught exception'])
+  })
+
+  test('restart requests are rate-limited within the min interval', () => {
+    let clock = 0
+    let restartCalls = 0
+    const { guard } = install({
+      now: () => clock,
+      restartMinIntervalMs: 1000,
+      requestRestart: async () => {
+        restartCalls++
+        return { ok: true }
+      },
+    })
+
+    guard.handle('uncaughtException', new Error('a'))
+    clock = 500
+    guard.handle('uncaughtException', new Error('b'))
+    expect(restartCalls).toBe(1)
+
+    clock = 1500
+    guard.handle('uncaughtException', new Error('c'))
+    expect(restartCalls).toBe(2)
+  })
+
+  test('missing requestRestart continues degraded instead of throwing', () => {
+    const { guard } = install({})
+    expect(() => guard.handle('uncaughtException', new Error('no host daemon'))).not.toThrow()
+  })
+
+  test('a throwing onDegrade is contained', () => {
+    const { guard } = install({
+      onDegrade: () => {
+        throw new Error('degrade exploded')
+      },
+    })
+    expect(() =>
+      guard.handle('unhandledRejection', Object.assign(new Error('kms'), { code: 'KMS_ERROR' })),
+    ).not.toThrow()
+  })
+
+  test('a rejecting requestRestart does not surface an unhandled rejection', async () => {
+    const { guard } = install({
+      requestRestart: async () => {
+        throw new Error('hostd unreachable')
+      },
+    })
+    guard.handle('uncaughtException', new Error('boom'))
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  test('installed handlers fire on real process events and never exit', () => {
+    const seen: string[] = []
+    install({ onDegrade: (scope) => seen.push(scope), requestRestart: async () => ({ ok: true }) })
+
+    const err = Object.assign(new Error('kms'), { code: 'KMS_ERROR' })
+    process.emit('unhandledRejection', err, Promise.resolve())
+
+    expect(seen).toEqual(['webex'])
+  })
+
+  test('dispose removes the process listeners', () => {
+    const before = process.listenerCount('unhandledRejection')
+    const { dispose: disposeGuard } = install({})
+    expect(process.listenerCount('unhandledRejection')).toBe(before + 1)
+    disposeGuard()
+    dispose = null
+    expect(process.listenerCount('unhandledRejection')).toBe(before)
+  })
+})

--- a/src/run/fatal-guard.ts
+++ b/src/run/fatal-guard.ts
@@ -1,0 +1,230 @@
+// Process-level crash guard for the container stage. The incident: a Webex KMS
+// request rejected 30s AFTER `listener.on('error')` already fired, so it escaped
+// the adapter as an `unhandledRejection` — which Bun terminates the process on
+// by default, taking Slack/Discord/cron/TUI/websocket down with one flaky dep.
+//
+// The guard NEVER calls `process.exit`. Policy (see `classifyFatalError`) is
+// conservative so "never crash" does not become "pretend the process is healthy":
+// a KNOWN channel-dependency `unhandledRejection` degrades just that channel; an
+// `uncaughtException` or UNKNOWN `unhandledRejection` requests a supervised
+// container restart (corrupt state is safer replaced than swallowed) while
+// continuing best-effort until the host replaces us — it still never self-exits.
+// Restart requests are rate-limited so a per-tick fault can't hammer the daemon.
+
+export type FatalGuardKind = 'unhandledRejection' | 'uncaughtException'
+
+export type FatalGuardDecision =
+  | { action: 'continue'; reason: string; scope?: string }
+  | { action: 'restart'; reason: string; scope?: string }
+
+export type FatalGuardLogger = {
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+export type FatalGuardOptions = {
+  logger?: FatalGuardLogger
+  // Ask the host daemon to bounce this container. Returns ok=false (never
+  // throws) when no host control endpoint is configured — the guard then logs
+  // and continues degraded rather than exiting.
+  requestRestart?: (reason: string) => Promise<{ ok: boolean; reason?: string }>
+  // Called for a `continue` decision carrying a channel scope, so the channel
+  // can be visibly marked degraded (e.g. log/status) instead of silently
+  // swallowing the error.
+  onDegrade?: (scope: string, reason: string) => void
+  now?: () => number
+  // Minimum spacing between restart requests. A fault re-firing on every event
+  // loop tick must not spam the host daemon. Default 60s.
+  restartMinIntervalMs?: number
+}
+
+export type FatalGuard = {
+  // Exposed for deterministic tests: invoke the policy without emitting a real
+  // process event. Production paths go through the installed listeners.
+  handle: (kind: FatalGuardKind, error: unknown) => void
+}
+
+const DEFAULT_RESTART_MIN_INTERVAL_MS = 60_000
+
+const consoleLogger: FatalGuardLogger = {
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+// One process gets exactly one pair of OS-level listeners no matter how many
+// callers install a guard (tests, `typeclaw compose`, an embedding host). Each
+// caller's handler is refcounted into this set and receives every event; the
+// listeners are attached on the first install and detached when the last
+// disposer runs. A per-caller `process.on` would otherwise stack N copies that
+// all fire on one rejection and survive a single `dispose()`.
+type Installed = {
+  handlers: Set<(kind: FatalGuardKind, error: unknown) => void>
+  onUnhandledRejection: (reason: unknown) => void
+  onUncaughtException: (error: unknown) => void
+}
+let shared: Installed | null = null
+
+export function installFatalGuard(options: FatalGuardOptions = {}): { guard: FatalGuard; dispose: () => void } {
+  const logger = options.logger ?? consoleLogger
+  const now = options.now ?? Date.now
+  const restartMinIntervalMs = options.restartMinIntervalMs ?? DEFAULT_RESTART_MIN_INTERVAL_MS
+  let lastRestartRequestAt: number | null = null
+
+  const handle = (kind: FatalGuardKind, error: unknown): void => {
+    // The guard body must never throw — a throwing handler re-enters the very
+    // failure mode it exists to contain. Everything is wrapped, with a bare
+    // console.error as the last-resort fallback.
+    try {
+      const decision = classifyFatalError(kind, error)
+      const detail = describeError(error)
+      logger.error(
+        `[fatal-guard] ${kind}: ${decision.reason}${decision.scope !== undefined ? ` scope=${decision.scope}` : ''} action=${decision.action} :: ${detail}`,
+      )
+
+      if (decision.action === 'continue') {
+        if (decision.scope !== undefined) {
+          try {
+            options.onDegrade?.(decision.scope, decision.reason)
+          } catch (degradeErr) {
+            logger.warn(`[fatal-guard] onDegrade(${decision.scope}) threw: ${describeError(degradeErr)}`)
+          }
+        }
+        return
+      }
+
+      requestRestart(decision.reason)
+    } catch (handlerErr) {
+      try {
+        console.error(`[fatal-guard] handler failed: ${describeError(handlerErr)}`)
+      } catch {
+        // Nothing left to do; swallowing here is the whole point.
+      }
+    }
+  }
+
+  const requestRestart = (reason: string): void => {
+    if (options.requestRestart === undefined) {
+      logger.warn(`[fatal-guard] restart requested (${reason}) but no host control endpoint; continuing degraded`)
+      return
+    }
+    const at = now()
+    if (lastRestartRequestAt !== null && at - lastRestartRequestAt < restartMinIntervalMs) {
+      logger.warn(`[fatal-guard] restart requested (${reason}) but rate-limited; continuing degraded`)
+      return
+    }
+    lastRestartRequestAt = at
+    void options
+      .requestRestart(reason)
+      .then((result) => {
+        if (result.ok) {
+          logger.warn(`[fatal-guard] container restart requested: ${reason}`)
+        } else {
+          logger.warn(
+            `[fatal-guard] container restart unavailable (${result.reason ?? 'unknown'}); continuing degraded`,
+          )
+        }
+      })
+      .catch((restartErr) => {
+        logger.warn(`[fatal-guard] container restart request threw: ${describeError(restartErr)}; continuing degraded`)
+      })
+  }
+
+  if (shared === null) {
+    const onUnhandledRejection = (reason: unknown): void => {
+      for (const h of shared?.handlers ?? []) h('unhandledRejection', reason)
+    }
+    const onUncaughtException = (error: unknown): void => {
+      for (const h of shared?.handlers ?? []) h('uncaughtException', error)
+    }
+    shared = { handlers: new Set(), onUnhandledRejection, onUncaughtException }
+    process.on('unhandledRejection', onUnhandledRejection)
+    process.on('uncaughtException', onUncaughtException)
+  }
+  shared.handlers.add(handle)
+
+  let disposed = false
+  const dispose = (): void => {
+    if (disposed || shared === null) return
+    disposed = true
+    shared.handlers.delete(handle)
+    if (shared.handlers.size === 0) {
+      process.off('unhandledRejection', shared.onUnhandledRejection)
+      process.off('uncaughtException', shared.onUncaughtException)
+      shared = null
+    }
+  }
+
+  return { guard: { handle }, dispose }
+}
+
+// Conservative by design. Only errors with positive evidence that they came
+// from a known external channel dependency are recovered in place; everything
+// else escalates to a supervised restart. Broad rules ("any Error with a code",
+// "any network error") are intentionally avoided — they would mask real bugs.
+export function classifyFatalError(kind: FatalGuardKind, error: unknown): FatalGuardDecision {
+  if (kind === 'uncaughtException') {
+    // A synchronous throw that reached the top of the stack means an unknown
+    // code path is in an undefined state. Replace, don't swallow.
+    return { action: 'restart', reason: 'uncaught exception' }
+  }
+
+  const scope = recognizeExternalChannelDependency(error)
+  if (scope !== null) {
+    return { action: 'continue', scope, reason: `${scope} async dependency rejection` }
+  }
+
+  return { action: 'restart', reason: 'unknown unhandled rejection' }
+}
+
+// Returns the channel scope to degrade when the rejection carries evidence of
+// an external channel SDK, else null. Matches on structured error codes first,
+// then on stack/module provenance — protocol/diagnostic tokens emitted by the
+// libraries themselves, so English-literal matching is correct here (these are
+// not natural-language user text).
+function recognizeExternalChannelDependency(error: unknown): string | null {
+  const code = errorCode(error)
+  // Webex KMS (encryption key service) rejections: the incident's exact shape.
+  // The `WebexListener` emits an 'error' event for connection failures, but a
+  // KMS request that times out 30s later rejects a detached internal promise
+  // that never reaches that event.
+  if (code === 'KMS_ERROR') return 'webex'
+
+  const haystack = errorProvenance(error).toLowerCase()
+  if (haystack.includes('webex-message-handler') || haystack.includes('agent-messenger/webex')) return 'webex'
+
+  // Other agent-messenger channel SDKs (slack/discord/telegram/line/kakaotalk).
+  // Same containment rationale: one channel's escaped async rejection must not
+  // take the whole agent down. Generic `agent-messenger/...` provenance maps to
+  // a `channel` scope since the specific platform isn't always recoverable.
+  if (haystack.includes('agent-messenger')) return 'channel'
+
+  return null
+}
+
+function errorCode(error: unknown): string | null {
+  if (error !== null && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code: unknown }).code
+    if (typeof code === 'string') return code
+  }
+  return null
+}
+
+function errorProvenance(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.stack ?? ''}\n${error.message}`
+  }
+  if (error !== null && typeof error === 'object') {
+    const stack = 'stack' in error ? String((error as { stack: unknown }).stack ?? '') : ''
+    const message = 'message' in error ? String((error as { message: unknown }).message ?? '') : ''
+    return `${stack}\n${message}`
+  }
+  return String(error)
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    const code = errorCode(error)
+    return `${error.name}: ${error.message}${code !== null ? ` (code=${code})` : ''}`
+  }
+  return String(error)
+}

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -40,8 +40,8 @@ afterEach(async () => {
   if (savedBrokerToken === undefined) delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
   else process.env['TYPECLAW_HOSTD_BROKER_TOKEN'] = savedBrokerToken
   if (!running) return
-  running.server.stop(true)
   running.tuiPromise?.catch(() => {})
+  await running.stop()
   running = null
 })
 
@@ -66,6 +66,83 @@ describe('startAgent', () => {
     const res = await fetch(`http://localhost:${running.server.port}`)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('typeclaw agent')
+  })
+
+  test('installs a process crash guard so an escaped channel rejection does not crash', async () => {
+    running = await startAgent({ port: 0, attachTui: false, cwd: testCwd, loadCron: noCron })
+    expect(process.listenerCount('unhandledRejection')).toBeGreaterThanOrEqual(1)
+
+    // The webex KMS shape from the incident: emitting it as a real process
+    // event must be contained by the installed guard, not re-thrown.
+    const kmsError = Object.assign(new Error('KMS request timed out'), { code: 'KMS_ERROR' })
+    expect(() => process.emit('unhandledRejection', kmsError, Promise.resolve())).not.toThrow()
+
+    await running.stop()
+    running = null
+  })
+
+  test('disposes the process crash guard when boot fails after install', async () => {
+    const before = process.listenerCount('unhandledRejection')
+    // A channel manager whose start() rejects forces a boot failure AFTER the
+    // guard is installed but BEFORE startAgent returns, so the caller never gets
+    // a stop() to call — the guard must self-dispose on the throw, not leak.
+    const failingChannelManager = (opts: ChannelManagerOptions): ChannelManager => ({
+      router: createChannelRouter({ agentDir: testCwd, configForAdapter: () => undefined }),
+      start: async () => {
+        void opts
+        throw new Error('boot failure: channel manager start rejected')
+      },
+      stop: async () => {},
+      reload: async () => ({ started: [], stopped: [], restartRequired: [] }),
+      restartAdapter: async () => {},
+    })
+
+    await expect(
+      startAgent({
+        port: 0,
+        attachTui: false,
+        cwd: testCwd,
+        loadCron: noCron,
+        createChannelManager: failingChannelManager,
+      }),
+    ).rejects.toThrow('boot failure: channel manager start rejected')
+
+    expect(process.listenerCount('unhandledRejection')).toBe(before)
+    // running stays null: startAgent threw, there is nothing to tear down.
+  })
+
+  test('a second agent boot failure leaves a running agent fetch observer intact', async () => {
+    // given a running agent A whose boot installed the codex fetch observer
+    running = await startAgent({ port: 0, attachTui: false, cwd: testCwd, loadCron: noCron })
+    const observedFetch = globalThis.fetch
+    expect(typeof observedFetch).toBe('function')
+
+    // when a second agent B starts in the same process and fails after the
+    // process globals are captured
+    const failingChannelManager = (): ChannelManager => ({
+      router: createChannelRouter({ agentDir: testCwd, configForAdapter: () => undefined }),
+      start: async () => {
+        throw new Error('boot failure: second agent')
+      },
+      stop: async () => {},
+      reload: async () => ({ started: [], stopped: [], restartRequired: [] }),
+      restartAdapter: async () => {},
+    })
+    await expect(
+      startAgent({
+        port: 0,
+        attachTui: false,
+        cwd: testCwd,
+        loadCron: noCron,
+        createChannelManager: failingChannelManager,
+      }),
+    ).rejects.toThrow('boot failure: second agent')
+
+    // then B's boot-failure cleanup must NOT have torn down A's observer
+    expect(globalThis.fetch).toBe(observedFetch)
+
+    await running.stop()
+    running = null
   })
 
   test('attaches a local tui pointing at the server it just started', async () => {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -80,6 +80,7 @@ import { createTunnelManager, type TunnelManager, type TunnelManagerOptions } fr
 import { BUNDLED_PLUGINS } from './bundled-plugins'
 import { buildChannelSessionFactory } from './channel-session-factory'
 import { installCodexFetchObserver } from './codex-fetch-observer'
+import { installFatalGuard } from './fatal-guard'
 import { createPluginRuntime, type PluginRuntime, type PluginSubagentEntry } from './plugin-runtime'
 
 type BunServer = ReturnType<Server['start']>
@@ -124,19 +125,44 @@ export type StartAgentResult = {
   stop: () => void | Promise<void>
 }
 
-export async function startAgent({
-  port,
-  attachTui,
-  initialPrompt,
-  cwd = process.cwd(),
-  createTui = createTuiDefault,
-  loadCron = loadCronDefault,
-  createSchedulerFor,
-  sessionFactory = createSessionFactory({ agentDir: cwd }),
-  stream = createStream(),
-  createChannelManager: createChannelManagerFor = createChannelManager,
-  createTunnelManager: createTunnelManagerFor = createTunnelManager,
-}: StartAgentOptions): Promise<StartAgentResult> {
+// Thin wrapper that owns ONLY the boot-failure cleanup of process-global
+// installs. `installCodexFetchObserver` and `installFatalGuard` attach
+// process-wide listeners before the fallible boot work; if any boot step throws
+// before `startAgentRuntime` returns, the caller never receives a
+// `StartAgentResult` and can never call `stop()`, so those listeners would
+// strand and double-fire into the next `startAgent`. The runtime hands its
+// disposer back via `onProcessGlobalsInstalled`; on a boot throw we dispose and
+// rethrow, on success ownership transfers to the returned `stop()`. `return
+// await` is load-bearing — without it an async boot rejection would escape this
+// try. Dispose is idempotent, so the success path's `stop()` never double-fires.
+export async function startAgent(options: StartAgentOptions): Promise<StartAgentResult> {
+  const captured: { dispose: (() => void) | null } = { dispose: null }
+  try {
+    return await startAgentRuntime(options, (dispose) => {
+      captured.dispose = dispose
+    })
+  } catch (err) {
+    captured.dispose?.()
+    throw err
+  }
+}
+
+async function startAgentRuntime(
+  {
+    port,
+    attachTui,
+    initialPrompt,
+    cwd = process.cwd(),
+    createTui = createTuiDefault,
+    loadCron = loadCronDefault,
+    createSchedulerFor,
+    sessionFactory = createSessionFactory({ agentDir: cwd }),
+    stream = createStream(),
+    createChannelManager: createChannelManagerFor = createChannelManager,
+    createTunnelManager: createTunnelManagerFor = createTunnelManager,
+  }: StartAgentOptions,
+  onProcessGlobalsInstalled: (dispose: () => void) => void,
+): Promise<StartAgentResult> {
   const reloadRegistry = new ReloadRegistry()
 
   // Wrap globalThis.fetch BEFORE any plugin/session/manager construction so
@@ -156,6 +182,37 @@ export async function startAgent({
   const runtimeVersionOpt = { runtimeVersion: CLI_VERSION }
   const tuiToken = process.env.TYPECLAW_TUI_TOKEN
   const tuiTokenOpt = tuiToken !== undefined && tuiToken !== '' ? { tuiToken } : {}
+
+  // Install the crash guard FIRST, before any plugin/channel/session
+  // construction, so an `unhandledRejection` escaping a channel SDK during boot
+  // or steady-state cannot terminate the container. Restart goes through the
+  // host daemon only when there is a container to bounce; outside Docker the
+  // guard logs and continues degraded (requestContainerRestart returns ok=false
+  // when the hostd control endpoint is absent, never throws).
+  const fatalGuard = installFatalGuard({
+    ...(containerName !== undefined
+      ? {
+          requestRestart: async (reason: string) => {
+            console.warn(`[fatal-guard] requesting container restart: ${reason}`)
+            const result = await requestContainerRestart({ containerName })
+            return result.ok ? { ok: true } : { ok: false, reason: result.reason }
+          },
+        }
+      : {}),
+    onDegrade: (scope, reason) => console.warn(`[fatal-guard] ${scope} degraded: ${reason}`),
+  })
+
+  // Both process-global disposers are surrendered to the wrapper as one unit the
+  // instant they exist, so a throw anywhere below detaches them; `stop()` calls
+  // the same disposer on the success path.
+  let processGlobalsDisposed = false
+  const disposeProcessGlobals = (): void => {
+    if (processGlobalsDisposed) return
+    processGlobalsDisposed = true
+    uninstallCodexFetchObserver()
+    fatalGuard.dispose()
+  }
+  onProcessGlobalsInstalled(disposeProcessGlobals)
 
   const { config: cwdConfig, pluginConfigs: pluginConfigsByName } = loadConfigBundleSync(cwd)
   // Vector agents omit the system-prompt `# Memory` section and inject memory
@@ -875,19 +932,26 @@ export async function startAgent({
   const stop = async () => {
     if (stopped) return
     stopped = true
-    scheduler?.stop()
-    cronConsumer.stop()
-    subagentConsumer.stop()
-    server.stop(true)
-    void disposeMaterializedSkills(pluginRuntime)
-    tunnelBridge.stop()
-    subagentCompletionBridge.stop()
-    prVerdictActivityBridge.stop()
-    setReviewObserver(null)
-    await tunnelManager.stop()
-    await channelManager.stop()
-    await mcpManager?.closeAll()
-    uninstallCodexFetchObserver()
+    // The crash-guard and codex-observer disposers run in `finally` so an
+    // earlier async teardown rejection (tunnel/channel/mcp stop) cannot strand
+    // the process-global listeners they removed — a stranded fatal-guard
+    // listener would survive into the next `startAgent` and double-fire.
+    try {
+      scheduler?.stop()
+      cronConsumer.stop()
+      subagentConsumer.stop()
+      server.stop(true)
+      void disposeMaterializedSkills(pluginRuntime)
+      tunnelBridge.stop()
+      subagentCompletionBridge.stop()
+      prVerdictActivityBridge.stop()
+      setReviewObserver(null)
+      await tunnelManager.stop()
+      await channelManager.stop()
+      await mcpManager?.closeAll()
+    } finally {
+      disposeProcessGlobals()
+    }
   }
 
   if (!attachTui) {


### PR DESCRIPTION
## Background

A production container exited with code `1` and stopped serving every channel. The fatal log:

```
KmsError: KMS request <id> timed out after 30000ms
  code: "KMS_ERROR"
    at <anonymous> (/agent/node_modules/webex-message-handler/dist/index.mjs:783:16)
Bun v1.3.14 (Linux arm64)
```

Root cause — not just the symptom: the Webex KMS endpoint was returning `401 Unauthorized` (expired token), which the adapter already logs non-fatally via `WebexListener`'s `'error'` event (`[webex] listener error: ...`). But a **separate** KMS request inside the external `webex-message-handler` lib timed out 30s later and rejected a **detached internal promise** that never routed through that `'error'` event. With no `process.on('unhandledRejection')` anywhere in the container boot path, Bun's default terminated the process — so one flaky Webex dependency took Slack, Discord, cron, the TUI, and the websocket server down with it.

The container is supervised (the host daemon can `docker restart`), but it had no way to *decide* to restart vs. keep serving — it just died.

## Summary

Install a process-level crash guard in `startAgent()` (`src/run/index.ts`), before any plugin/channel/session construction so it covers the whole process lifetime. The guard **never calls `process.exit`**.

The policy is deliberately conservative — "never crash" must not become "pretend the process is healthy" (the classic Node warning that an `uncaughtException` can mean corrupt state):

- **Known external channel-dependency `unhandledRejection`** (Webex KMS `code: "KMS_ERROR"`, or any `agent-messenger` / `webex-message-handler` stack provenance) → contained; degrade **only that channel**, the rest of the agent keeps serving.
- **`uncaughtException` or an UNKNOWN `unhandledRejection`** → request a supervised container restart through the existing host daemon (`requestContainerRestart`) and keep serving best-effort until the host replaces us. Corrupt state is safer *replaced* than silently swallowed forever.
- **Outside Docker** (no hostd control endpoint) → `requestContainerRestart` returns `ok=false` (never throws), so the guard logs and continues degraded.

**Why a conservative classifier and not "swallow everything":** broad rules ("any `Error` with a `code`", "any network error") would mask real programmer bugs. Only errors with positive provenance evidence are recovered in place; everything else escalates to replacement.

**Why a refcounted singleton:** a process gets exactly one pair of OS listeners no matter how many `startAgent` calls share it (tests, `typeclaw compose`). A naive per-caller `process.on` would stack N copies that all fire once and survive a single `dispose()`.

**Why English-literal token matching** (despite the repo's multi-language rule): these are library diagnostic strings the SDK emits to itself (`KMS_ERROR`, `agent-messenger/...`), not natural-language user text — the documented protocol-token exception.

## What this does NOT do

- Does **not** patch `webex-message-handler` — it's an external npm dep resolved at runtime in `/agent/node_modules`, not vendored here. The guard contains its escapes from the outside.
- Does **not** fix the underlying Webex `401` (expired token) — that's an operator credential refresh, separate from making the agent crash-proof.
- Does **not** change the existing per-adapter containment (`listener.on('error')`, `try/catch` around `start()`/`handleMessage`). The top-level guard is the seatbelt, those remain the primary path.
- Does **not** add restart-storm risk — restart requests are rate-limited (default 60s min spacing).

## Review notes

- **Load-bearing ordering:** the guard installs *first* in `startAgent()` (before plugin/channel construction) and its disposer is wired into `stop()`. Verify both.
- **Policy invariant to verify:** the guard never calls `process.exit`; the only escalation is a rate-limited, best-effort `requestContainerRestart`. See `classifyFatalError` for the exact decision rule.
- **Classifier conservatism:** `recognizeExternalChannelDependency` matches structured `code` first, then stack/module provenance. Unknown rejections intentionally escalate to restart, not swallow.
- **Tests:** `src/run/fatal-guard.test.ts` drives the policy via synthetic `process.emit`/direct `handle` (never floating real rejections that would crash the runner); `src/run/index.test.ts` adds a wiring regression that emits the exact incident's `KMS_ERROR` shape after boot and asserts it's contained.
