### PR TITLE
fix(channels): keep sticky credit live across the engage-to-send gap

### DIFF
--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -207,7 +207,7 @@ describe('decideEngagement (explicit-only inbounds)', () => {
       participants: crowded,
     })
     expect(decision).toBe('engage')
-    expect(ledger.has(KEY, 'alice', 1000)).toBe(false)
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(true)
   })
 })
 
@@ -356,10 +356,10 @@ describe('decideEngagement (alias)', () => {
     expect(decision).toBe('engage')
   })
 
-  test('alias engagement does NOT consume sticky credit when alias path fires', () => {
-    // Alias engagement runs after sticky check. If sticky credit exists
-    // and alias also matches, sticky check wins first and consumes the
-    // credit — no double-engage, no leaked credit.
+  test('sticky check wins over the alias path and refreshes the credit', () => {
+    // Sticky runs before the alias rule: when both match, sticky engages first
+    // and slides its window forward (the alias path never runs), so the credit
+    // stays live rather than being double-spent.
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 10_000)
     decideEngagement({
@@ -371,7 +371,7 @@ describe('decideEngagement (alias)', () => {
       participants: crowded,
       selfAliases: ['토토'],
     })
-    expect(ledger.has(KEY, 'alice', 1000)).toBe(false)
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(true)
   })
 })
 
@@ -395,19 +395,14 @@ describe('decideEngagement (sticky)', () => {
     expect(decision).toBe('engage')
   })
 
-  test('sticky credit is consumed (single message)', () => {
+  test('spending a live sticky credit slides its window forward', () => {
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 1000)
     decideEngagement({ message: inbound(), config: baseConfig, key: KEY, ledger, now: 100, participants: solo })
-    const second = decideEngagement({
-      message: inbound({ mentionsOthers: true }),
-      config: baseConfig,
-      key: KEY,
-      ledger,
-      now: 200,
-      participants: solo,
-    })
-    expect(second).toBe('observe')
+    // window = 5min, spent at now=100 → fresh expiry 100 + 5min, still live past
+    // the original 1000 expiry.
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(true)
+    expect(ledger.has(KEY, 'alice', 100 + 5 * 60 * 1000 + 1)).toBe(false)
   })
 
   test('expired sticky credit does not engage and is consumed', () => {
@@ -423,6 +418,31 @@ describe('decideEngagement (sticky)', () => {
     })
     expect(decision).toBe('observe')
     expect(ledger.has(KEY, 'alice', 5000)).toBe(false)
+  })
+
+  test('multi-human in-flight follow-up keeps engaging on a refreshed sticky credit', () => {
+    const ledger = new StickyLedger()
+    ledger.grant(KEY, 'alice', 1000)
+    const first = decideEngagement({
+      message: inbound({ text: 'omo 만든 분이야' }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 100,
+      participants: crowded,
+    })
+    // A same-author follow-up landing before the reply re-grants the credit
+    // (the engage→send gap) must still engage in a 2-human group, not observe.
+    const followUp = decideEngagement({
+      message: inbound({ text: 'ㅋㅋㅋㅋ' }),
+      config: baseConfig,
+      key: KEY,
+      ledger,
+      now: 200,
+      participants: crowded,
+    })
+    expect(first).toBe('engage')
+    expect(followUp).toBe('engage')
   })
 
   test('sticky off makes follow-ups observe even with prior credits', () => {
@@ -792,7 +812,7 @@ describe('decideEngagement (sticky in groups)', () => {
     expect(decision).toBe('engage')
   })
 
-  test('sticky credit force-engages a plain follow-up in a multi-human group, and is consumed', () => {
+  test('sticky credit force-engages a plain follow-up in a multi-human group and stays live', () => {
     // given a multi-human group and a held credit for alice
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 10_000)
@@ -808,18 +828,18 @@ describe('decideEngagement (sticky in groups)', () => {
     })
 
     // then we engage (selectivity is the model's job via the prompt nudge),
-    // and the one-shot credit is spent
+    // and the credit slides forward instead of being spent
     expect(decision).toBe('engage')
-    expect(ledger.has(KEY, 'alice', 1000)).toBe(false)
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(true)
   })
 
-  test('a consumed group credit does not resurrect a later follow-up', () => {
-    // given a credit consumed by the first group follow-up
+  test('a refreshed group credit keeps engaging successive plain follow-ups', () => {
+    // given a credit refreshed by the first group follow-up
     const ledger = new StickyLedger()
     ledger.grant(KEY, 'alice', 10_000)
     decideEngagement({ message: inbound(), config: baseConfig, key: KEY, ledger, now: 1000, participants: crowded })
 
-    // when alice posts again with no fresh credit and no trigger
+    // when alice posts again before any reply re-grants the credit
     const second = decideEngagement({
       message: inbound(),
       config: baseConfig,
@@ -829,8 +849,8 @@ describe('decideEngagement (sticky in groups)', () => {
       participants: crowded,
     })
 
-    // then observe — the spent one-shot credit cannot wake us a second time
-    expect(second).toBe('observe')
+    // then engage — the rolling credit keeps the active conversation alive
+    expect(second).toBe('engage')
   })
 
   test('an expired group credit is consumed but does not engage', () => {
@@ -1281,9 +1301,9 @@ describe('decideEngagement (multi-human sticky target check)', () => {
       participants: crowded,
     })
 
-    // then the preserved credit wakes us and is consumed
+    // then the preserved credit wakes us and slides forward
     expect(second).toBe('engage')
-    expect(ledger.has(KEY, 'alice', 2000)).toBe(false)
+    expect(ledger.has(KEY, 'alice', 2000)).toBe(true)
   })
 
   test('a plain multi-human follow-up from a credited author still engages (no suppressor set)', () => {
@@ -1300,7 +1320,7 @@ describe('decideEngagement (multi-human sticky target check)', () => {
       participants: crowded,
     })
     expect(decision).toBe('engage')
-    expect(ledger.has(KEY, 'alice', 1000)).toBe(false)
+    expect(ledger.has(KEY, 'alice', 1000)).toBe(true)
   })
 
   test('a credited author who names a third party BUT also aliases us engages (alias precedence)', () => {

--- a/src/channels/engagement.ts
+++ b/src/channels/engagement.ts
@@ -22,11 +22,22 @@ export class StickyLedger {
     inner.set(authorId, expiresAt)
   }
 
-  consume(key: string, authorId: string, now: number): boolean {
+  // A live credit SLIDES its window forward (`now + windowMs`) rather than
+  // clearing on first spend. The send-path only re-grants after the reply lands
+  // (router `send()`), so a same-author follow-up arriving in that gap finds no
+  // credit and observes in a multi-human group (the solo-human fallback masks it
+  // in 1-human channels). A refreshed credit keeps that follow-up engaged and
+  // still expires after a full quiet window. An expired credit is purged and
+  // returns false (the expired-credit contract). `windowMs <= 0` purges on spend.
+  consume(key: string, authorId: string, now: number, windowMs: number): boolean {
     const inner = this.byKey.get(key)
     if (!inner) return false
     const expiresAt = inner.get(authorId)
     if (expiresAt === undefined) return false
+    if (expiresAt > now && windowMs > 0) {
+      inner.set(authorId, now + windowMs)
+      return true
+    }
     inner.delete(authorId)
     if (inner.size === 0) this.byKey.delete(key)
     return expiresAt > now
@@ -141,7 +152,11 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   // STRUCTURALLY addressed elsewhere, leaving plain follow-ups engaged.
   // GitHub review-thread traffic must not spend content-blind sticky credit
   // unless the bot was explicitly addressed.
-  if (!explicitOnly && config.stickiness !== 'off' && ledger.consume(key, message.authorId, now)) {
+  if (
+    !explicitOnly &&
+    config.stickiness !== 'off' &&
+    ledger.consume(key, message.authorId, now, config.stickiness.perReply.window)
+  ) {
     return 'engage'
   }
 


### PR DESCRIPTION
## Background

In a multi-human channel, an immediate same-author follow-up after the agent engages gets observed instead of engaged, and rapid sequential messages don't each get their own reply.

Observed in production logs (2-human group):

```
04:31:55  inbound  ...218498  author=A        (M1)
04:31:56  prompting batch=1                    (M1 engages -> sticky credit consumed)
04:31:56  inbound  ...829185  author=A (same)  (M2, +0.7s)
04:31:56  observed id=...829185                 (decided in 4.5ms, NO LLM verdict)
   ...
04:32:08  send turn=1 ... terminal_after_channel_reply   (credit re-granted only HERE, too late)
```

## Summary

`StickyLedger.consume` cleared the sticky credit at engage-decision time. The credit is only re-granted in the router send-path after the reply lands. A same-author follow-up arriving in that gap finds no credit and, in a multi-human group, falls through to observe (no mention/reply/DM/alias to save it).

The solo-human fallback (`effectiveHumans <= 1`) masks this entirely in 1-human channels, which is why it only reproduces in groups.

Fix: slide a live credit's window forward on spend (`now + window`) instead of clearing it on first use, so in-flight follow-ups stay engaged for the full rolling window. An expired credit is still purged and returns false, preserving the existing expired-credit contract.

Stays within the content-blind engagement philosophy: no semantic text interpretation, just credit lifetime.

## Preview

N/A — no UI or output format change.

## What this does NOT do

- Does not change the expired-credit contract — a spent expired credit still returns false and is purged.
- Does not alter the solo-human fallback path.
- Does not add any natural-language or content-based heuristics.

## Review notes

- Load-bearing change: `StickyLedger.consume` in src/channels/engagement.ts.
  The method now slides the `expiresAt` timestamp forward on spend instead of deleting the entry. Verify the expired-credit branch still purges and returns false.
- Updated sticky tests move from the old one-shot contract to the rolling-window contract (a spent live credit now stays live and slides forward).
- Added a multi-human regression: a same-author follow-up during the engage-to-send gap keeps engaging instead of observing (covers English and Korean text per the repro).