### PR TITLE
fix(secrets): align webex renewal decrypt AAD so token refresh works

### DIFF
--- a/src/hostd/webex-renewal-manager.test.ts
+++ b/src/hostd/webex-renewal-manager.test.ts
@@ -23,7 +23,7 @@ async function setupAgent(opts: {
   const ks = createKeyStore({ keysDir })
   const key = await ks.ensure(containerName)
   const encryptedPassword = opts.withEncryptedPassword
-    ? encrypt('hunter2', key, { containerName, accountId: 'u-1' })
+    ? encrypt('hunter2', key, { containerName, accountId: 'u-1', purpose: 'webex-password' })
     : undefined
   const nowIso = new Date().toISOString()
   const block: WebexChannelBlock = {

--- a/src/secrets/webex-renewal.test.ts
+++ b/src/secrets/webex-renewal.test.ts
@@ -10,6 +10,14 @@ import { type LoginWithPasswordFn, decideRenewal, RENEWAL_WINDOW_MS, renewCurren
 
 const HOUR_MS = 60 * 60 * 1000
 
+// Seal exactly like runWebexBootstrap (init/webex-auth.ts) does, so these
+// fixtures exercise the production AAD. A bare `encrypt(pw, key, {container,
+// account})` would default purpose to 'kakaotalk-password' and silently
+// re-encode the decrypt_failed bug this suite is meant to guard.
+function sealWebexPassword(plaintext: string, key: Buffer): WebexEncryptedPassword {
+  return encrypt(plaintext, key, { containerName: 'webex', accountId: 'u-1', purpose: 'webex-password' })
+}
+
 function fakeKeyStore(opts: { containerName: string; key: Buffer | null }): KeyStore {
   return {
     keyPath: (name: string) => `/fake/${name}.key`,
@@ -114,7 +122,7 @@ describe('decideRenewal', () => {
 
   test('requires reauth when the key file is missing', async () => {
     const key = generateKey()
-    const encryptedPassword = encrypt('pw', key, { containerName: 'webex', accountId: 'u-1' })
+    const encryptedPassword = sealWebexPassword('pw', key)
     const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
     const decision = await decideRenewal(block, {
       containerName: 'webex',
@@ -128,7 +136,7 @@ describe('decideRenewal', () => {
   test('requires reauth when the key does not match the ciphertext (wrong key)', async () => {
     const realKey = generateKey()
     const otherKey = generateKey()
-    const encryptedPassword = encrypt('pw', realKey, { containerName: 'webex', accountId: 'u-1' })
+    const encryptedPassword = sealWebexPassword('pw', realKey)
     const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
     const decision = await decideRenewal(block, {
       containerName: 'webex',
@@ -141,7 +149,7 @@ describe('decideRenewal', () => {
 
   test('returns should_renew with decrypted password when everything aligns', async () => {
     const key = generateKey()
-    const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+    const encryptedPassword = sealWebexPassword('hunter2', key)
     const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
     const decision = await decideRenewal(block, {
       containerName: 'webex',
@@ -158,7 +166,7 @@ describe('decideRenewal', () => {
 
   test('renews an already-expired token (negative expiresInMs is inside the window)', async () => {
     const key = generateKey()
-    const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+    const encryptedPassword = sealWebexPassword('hunter2', key)
     const block = buildBlock({ accountId: 'u-1', expiresInHours: -2, email: 'u@e.com', encryptedPassword })
     const decision = await decideRenewal(block, {
       containerName: 'webex',
@@ -222,7 +230,7 @@ describe('renewCurrentAccount', () => {
   test('writes fresh tokens through the store, preserving email + encryptedPassword', async () => {
     await withAgentDir(async (agentDir) => {
       const key = generateKey()
-      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const encryptedPassword = sealWebexPassword('hunter2', key)
       const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
       await seedSecrets(agentDir, block)
 
@@ -255,7 +263,7 @@ describe('renewCurrentAccount', () => {
   test('preserves created_at across renewals (only updated_at advances)', async () => {
     await withAgentDir(async (agentDir) => {
       const key = generateKey()
-      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const encryptedPassword = sealWebexPassword('hunter2', key)
       const originalCreatedAt = '2026-01-01T00:00:00.000Z'
       const block = buildBlock({
         accountId: 'u-1',
@@ -283,7 +291,7 @@ describe('renewCurrentAccount', () => {
   test('reports reauth_required (not transient) on an SSO/MFA WebexError', async () => {
     await withAgentDir(async (agentDir) => {
       const key = generateKey()
-      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const encryptedPassword = sealWebexPassword('hunter2', key)
       const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
       await seedSecrets(agentDir, block)
 
@@ -304,7 +312,7 @@ describe('renewCurrentAccount', () => {
   test('reports transient_failure when login throws for a non-auth reason', async () => {
     await withAgentDir(async (agentDir) => {
       const key = generateKey()
-      const encryptedPassword = encrypt('hunter2', key, { containerName: 'webex', accountId: 'u-1' })
+      const encryptedPassword = sealWebexPassword('hunter2', key)
       const block = buildBlock({ accountId: 'u-1', expiresInHours: 1, email: 'u@e.com', encryptedPassword })
       await seedSecrets(agentDir, block)
 

--- a/src/secrets/webex-renewal.ts
+++ b/src/secrets/webex-renewal.ts
@@ -83,6 +83,9 @@ export async function decideRenewal(block: WebexChannelBlock, ctx: WebexRenewalC
     plaintextPassword = decrypt(account.encryptedPassword, key, {
       containerName: ctx.containerName,
       accountId: account.account_id,
+      // Must match the AAD `runWebexBootstrap` seals with (init/webex-auth.ts);
+      // the default 'kakaotalk-password' never authenticates a webex blob.
+      purpose: 'webex-password',
     })
   } catch (err) {
     return classifyDecryptFailure(err, accountId)


### PR DESCRIPTION
## Background

Follow-up to #1076, which crash-proofed the agent against a Webex KMS `401`/`KMS_ERROR` but explicitly left the **underlying credential refresh** unfixed ("Does **not** fix the underlying Webex `401` (expired token) — that's an operator credential refresh"). This PR fixes that root cause.

Webex password-login access tokens live only ~27h, so they're meant to be auto-renewed by the host: the hostd renewal cron (`src/hostd/webex-renewal-manager.ts`) ticks hourly, and when a token is within 8h of `expires_at` it **decrypts the stored password**, re-runs `loginWithPassword`, writes fresh tokens to `secrets.json`, and restarts the container to pick them up. The container never holds the key — decryption happens host-side by design (`encryption.ts` threat model).

That renewal silently never worked. On a production agent, `~/.typeclaw/log/hostd.log` shows the cron firing every hour and failing for **16+ hours straight** the moment a token entered the 8h window:

```
[hostd] webex renewal REAUTH REQUIRED ... reason=decrypt_failed
  — Could not decrypt stored Webex password (decrypt_failed)
```

The token then expired unrenewed → KMS started returning `401` → the crash #1076 had to guard against. (The only "recovery" was an operator manually running `typeclaw channel reauth webex`, which re-seals the password and buys ~27h until the next window, where it fails again.)

**Root cause — an AES-GCM AAD mismatch.** `encryption.ts` binds every ciphertext to an AAD string `typeclaw:<purpose>:v1:<containerName>:<accountId>`, where `purpose` defaults to `'kakaotalk-password'`. The two halves of the Webex flow disagreed on `purpose`:

| Path | File | `purpose` | Effective AAD |
|---|---|---|---|
| **Encrypt** | `src/init/webex-auth.ts` | `'webex-password'` | `...:webex-password:...` |
| **Decrypt** | `src/secrets/webex-renewal.ts` | *(omitted → default)* | `...:kakaotalk-password:...` |

Different AAD → GCM authentication fails deterministically → `decrypt_failed` on **every** tick, regardless of key correctness. (Verified on the affected host: the encryption key is stable since provisioning and its fingerprint matches the freshly-sealed blob's `kid`, ruling out key rotation — the failure was purely the AAD.)

## Summary

Pass `purpose: 'webex-password'` on the decrypt side (`decideRenewal`) so it matches what `runWebexBootstrap` seals with.

**Why fix decrypt and not drop `purpose` from encrypt:** the `webex-password` vs `kakaotalk-password` AAD separation is intentional (it stops a ciphertext from one channel authenticating under another). Aligning decrypt up to the encrypt side preserves that separation and needs **no migration** — the only encrypt path already uses `'webex-password'`. KakaoTalk is unaffected: it omits `purpose` on *both* sides (`kakaotalk-auth.ts` ↔ `kakao-renewal.ts`), so it was always symmetric.

**The tests encoded the bug.** Both renewal suites sealed fixtures with a bare `encrypt(pw, key, {container, account})` — defaulting to the kakao purpose — so they passed only because encrypt and decrypt agreed on the *wrong* default. They're now routed through a `sealWebexPassword` helper (and the manager fixture gains the explicit `purpose`) so they exercise the production AAD. Reverting the one-line production fix now fails the suites (6 unit failures + the manager suite) instead of staying green.

## What this does NOT do

- Does **not** change the host-renews → container-restarts architecture, the 8h `RENEWAL_WINDOW_MS`, or the key-storage model.
- Does **not** re-seal already-stored blobs: any password sealed by `runWebexBootstrap` already used `'webex-password'`, so existing records decrypt correctly after this change — no migration, no operator action beyond the next normal tick.
- Does **not** revert or alter #1076's crash guard; that remains the seatbelt.

## Review notes

- **Load-bearing line:** the added `purpose: 'webex-password'` in `decideRenewal` (`src/secrets/webex-renewal.ts`). It must stay coupled to the seal in `init/webex-auth.ts`; a comment marks the invariant.
- **Regression proof:** revert that one line and 6 tests in `webex-renewal.test.ts` (every `should_renew`/renewal-success case) plus the `webex-renewal-manager.test.ts` success paths fail — confirming the tests are non-vacuous.
- **Pre-existing CI note:** the schema-drift guards in `scripts/generate-schema.test.ts` fail identically on clean `main` in my environment (unrelated to this 3-file change); not touched here.