### PR TITLE
feat(cli): add `memory search` and move `dreams` under `memory`

### DIFF
--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -22,6 +22,7 @@ import { createMemoryLoggerSubagent, type MemoryLoggerPayload } from './memory-l
 import { createMemoryRetrievalSubagent, type MemoryRetrievalPayload } from './memory-retrieval'
 import { preShardBackupPath, streamFilePath, streamsDir, topicsDir } from './paths'
 import { bumpReferenceAccess } from './references/load-references'
+import { memoryCommands } from './search-command'
 import { createMemorySearchTool } from './search-tool'
 import { type InjectedMemoryState, partitionRetrievedMemoryItems } from './turn-dedup'
 import { vectorConfigSchema } from './vector/config'
@@ -276,6 +277,7 @@ async function renderVectorTurnMemory(
 export function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
   return definePlugin({
     configSchema: memoryConfigSchema,
+    commands: memoryCommands,
     plugin: async (ctx) => {
       const idleMs = ctx.config.idleMs
       const bufferBytes = ctx.config.bufferBytes

--- a/src/bundled-plugins/memory/search-command.test.ts
+++ b/src/bundled-plugins/memory/search-command.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createPluginLogger } from '@/plugin/context'
+
+import { renderShard } from './frontmatter'
+import { referenceFilePath, referencesDir, topicShardPath, topicsDir } from './paths'
+import { parseReference } from './references/frontmatter'
+import { createMemorySearchCommand, renderResults, vectorDbPath } from './search-command'
+import { DIMS, EMBEDDING_MODEL_ID } from './vector/embedder'
+import type { HybridSearchResult } from './vector/hybrid'
+import type { EmbedFn } from './vector/hybrid'
+import { VectorStore, type VectorRow } from './vector/store'
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'memory-search-command-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+})
+
+describe('renderResults', () => {
+  test('reports an empty result set against the query', () => {
+    expect(renderResults('orbit', [])).toBe('No memory matched "orbit".')
+  })
+
+  test('renders ranked hits with source, key, score, and indented excerpt', () => {
+    const results: HybridSearchResult[] = [
+      {
+        source: 'topic',
+        key: 'orbital-mechanics',
+        heading: 'Orbital Mechanics',
+        excerpt: 'Satellites orbit.',
+        rrfScore: 0.0164,
+      },
+    ]
+    const text = renderResults('orbit', results)
+    expect(text).toContain('1 result(s) for "orbit":')
+    expect(text).toContain('1. [topic] Orbital Mechanics')
+    expect(text).toContain('key: orbital-mechanics  score: 0.0164')
+    expect(text).toContain('| Satellites orbit.')
+  })
+
+  test('renders provenance when a stream hit carries who/where/when', () => {
+    const results: HybridSearchResult[] = [
+      {
+        source: 'stream',
+        key: '2026-06-24#abc',
+        heading: 'incident note',
+        excerpt: 'db down',
+        rrfScore: 0.01,
+        who: 'Jisoo',
+        when: '2026-06-24T10:00:00Z',
+        where: { adapter: 'slack', workspace: 'w', chat: 'C1', chatName: '#incidents', thread: 't' },
+      },
+    ]
+    expect(renderResults('db', results)).toContain('Jisoo in #incidents at 2026-06-24T10:00:00Z')
+  })
+})
+
+describe('memory-search container command', () => {
+  test('exits non-zero with guidance when vector is disabled', async () => {
+    await writeConfig({ memory: { vector: { enabled: false } } })
+    const { code, stderr } = await runCommand({ query: 'orbit', topK: 10, json: false })
+    expect(code).toBe(1)
+    expect(stderr).toContain('memory.vector.enabled is false')
+  })
+
+  test('exits non-zero when the vector index has not been built', async () => {
+    await writeConfig({ memory: { vector: { enabled: true } } })
+    const { code, stderr } = await runCommand({ query: 'orbit', topK: 10, json: false })
+    expect(code).toBe(1)
+    expect(stderr).toContain('vector index not built yet')
+  })
+
+  test('runs hybridSearch and prints ranked text results', async () => {
+    await writeConfig({ memory: { vector: { enabled: true } } })
+    await writeTopic('orbital-mechanics', 'Orbital Mechanics', 'Satellites remain in orbit.')
+    seedVector('topic:orbital-mechanics', 'topic', 'orbital-mechanics')
+
+    const { code, stdout } = await runCommand({ query: QUERY, topK: 10, json: false })
+    expect(code).toBe(0)
+    expect(stdout).toContain('[topic] Orbital Mechanics')
+    expect(stdout).toContain('orbital-mechanics')
+  })
+
+  test('emits raw JSON when --json is set', async () => {
+    await writeConfig({ memory: { vector: { enabled: true } } })
+    await writeTopic('orbital-mechanics', 'Orbital Mechanics', 'Satellites remain in orbit.')
+    seedVector('topic:orbital-mechanics', 'topic', 'orbital-mechanics')
+
+    const { code, stdout } = await runCommand({ query: QUERY, topK: 10, json: true })
+    expect(code).toBe(0)
+    const parsed = JSON.parse(stdout.trim()) as HybridSearchResult[]
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0]?.source).toBe('topic')
+    expect(parsed[0]?.key).toBe('orbital-mechanics')
+  })
+
+  test('advances a surfaced reference accessCount/lastAccessed so it survives time-decay', async () => {
+    await writeConfig({ memory: { vector: { enabled: true } } })
+    await writeReference('runbook', 'DB Runbook', 'Restart the primary, then failover.')
+    seedVector('reference:runbook#0', 'reference', 'runbook')
+
+    const before = await readReferenceFrontmatter('runbook')
+    const { code, stdout } = await runCommand({ query: QUERY, topK: 10, json: true })
+    expect(code).toBe(0)
+    expect((JSON.parse(stdout.trim()) as HybridSearchResult[])[0]?.source).toBe('reference')
+
+    const after = await readReferenceFrontmatter('runbook')
+    expect(after.accessCount).toBe(before.accessCount + 1)
+    expect(after.lastAccessed).not.toBe(before.lastAccessed)
+  })
+})
+
+// Absent from every slug/heading/body, so the keyword lane is inert and only the
+// vector lane can produce the hit — proving real vector search ran, not substring.
+const QUERY = 'zzqxvtrprobe'
+
+async function runCommand(args: { query: string; topK: number; json: boolean }): Promise<{
+  code: number
+  stdout: string
+  stderr: string
+}> {
+  const command = createMemorySearchCommand(queryAligned())
+  const out = collectStream()
+  const err = collectStream()
+  const code = await command.run(
+    {
+      name: 'memory',
+      version: undefined,
+      agentDir,
+      logger: createPluginLogger('memory'),
+      permissions: {} as never,
+      origin: { kind: 'tui', sessionId: 'test' },
+      signal: new AbortController().signal,
+      stdin: new ReadableStream<Uint8Array>({ start: (c) => c.close() }),
+      stdout: out.writable,
+      stderr: err.writable,
+      prompt: async () => '',
+      subagent: async () => {},
+      exec: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    },
+    args,
+  )
+  return { code, stdout: out.getOutput(), stderr: err.getOutput() }
+}
+
+async function writeConfig(value: unknown): Promise<void> {
+  await writeFile(join(agentDir, 'typeclaw.json'), JSON.stringify(value))
+}
+
+async function writeTopic(slug: string, heading: string, body: string): Promise<void> {
+  await mkdir(topicsDir(agentDir), { recursive: true })
+  await writeFile(
+    topicShardPath(agentDir, slug),
+    renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
+  )
+}
+
+function seedVector(id: string, source: VectorRow['source'], key: string): void {
+  const store = VectorStore.open(vectorDbPath(agentDir))
+  try {
+    store.upsert({
+      id,
+      source,
+      key,
+      model: EMBEDDING_MODEL_ID,
+      dims: DIMS,
+      embedding: alignedVector(),
+      contentHash: `hash:${id}`,
+    } satisfies Omit<VectorRow, 'updatedAt'>)
+  } finally {
+    store.close()
+  }
+}
+
+async function writeReference(slug: string, title: string, body: string): Promise<void> {
+  await mkdir(referencesDir(agentDir), { recursive: true })
+  await writeFile(
+    referenceFilePath(agentDir, slug),
+    `---\ntitle: ${title}\norigin: episode\ncreated: 2026-06-12T14:03:00+09:00\nlastAccessed: 2026-06-13T09:10:00+09:00\naccessCount: 3\npinned: false\ndemoted: false\ntags: []\n---\n${body}`,
+    'utf8',
+  )
+}
+
+async function readReferenceFrontmatter(slug: string) {
+  return parseReference(await Bun.file(referenceFilePath(agentDir, slug)).text()).frontmatter
+}
+
+function queryAligned(): EmbedFn {
+  return async () => [alignedVector()]
+}
+
+function alignedVector(): Float32Array {
+  const result = new Float32Array(DIMS)
+  result[0] = 1
+  return result
+}
+
+function collectStream(): { writable: WritableStream<Uint8Array>; getOutput: () => string } {
+  const chunks: Uint8Array[] = []
+  const writable = new WritableStream<Uint8Array>({
+    write(chunk) {
+      chunks.push(chunk)
+    },
+  })
+  return { writable, getOutput: () => chunks.map((c) => new TextDecoder().decode(c)).join('') }
+}

--- a/src/bundled-plugins/memory/search-command.ts
+++ b/src/bundled-plugins/memory/search-command.ts
@@ -1,0 +1,133 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { z } from 'zod'
+
+import { defineCommand, type ContainerCommand, type PluginCommand } from '@/plugin'
+
+import { bumpReferenceAccess } from './references/load-references'
+import { agentUsesVector } from './vector/config'
+import { hybridSearch, type EmbedFn, type HybridSearchResult } from './vector/hybrid'
+import { VectorStore } from './vector/store'
+
+const DEFAULT_TOP_K = 10
+const MAX_TOP_K = 50
+
+export const memorySearchArgs = z.object({
+  query: z.string(),
+  topK: z.number().int().min(1).max(MAX_TOP_K).default(DEFAULT_TOP_K),
+  json: z.boolean().default(false),
+})
+
+export type MemorySearchArgs = z.infer<typeof memorySearchArgs>
+
+// Container-only: hybridSearch needs the in-container embedding model (the host
+// has no ONNX runtime / weights). The host `typeclaw memory search` CLI proxies
+// here over the /commands websocket and streams this stdout back to the
+// operator. Vector-only by design — no keyword `memory_search` fallback: with
+// vector disabled there is no index to query, so it exits non-zero rather than
+// silently degrade to a different search the operator didn't request.
+export function createMemorySearchCommand(embedFn?: EmbedFn): ContainerCommand<MemorySearchArgs> {
+  return defineCommand({
+    surface: 'container',
+    description: 'vector-search the agent long-term memory and print ranked topic/stream/reference hits',
+    args: memorySearchArgs,
+    async run(ctx, args) {
+      if (!agentUsesVector(ctx.agentDir)) {
+        await writeLine(
+          ctx.stderr,
+          'memory.vector.enabled is false — vector search is unavailable. Enable it in typeclaw.json (memory.vector.enabled) and restart the container.',
+        )
+        return 1
+      }
+
+      const dbPath = vectorDbPath(ctx.agentDir)
+      if (!existsSync(dbPath)) {
+        await writeLine(
+          ctx.stderr,
+          'vector index not built yet (memory/.vectors/index.db is absent). Restart the container to build it, then retry.',
+        )
+        return 1
+      }
+
+      const store = VectorStore.open(dbPath)
+      let results: HybridSearchResult[]
+      try {
+        results = await hybridSearch(
+          args.query,
+          store,
+          ctx.agentDir,
+          args.topK,
+          ...(embedFn !== undefined ? ([embedFn] as const) : ([] as const)),
+        )
+      } finally {
+        store.close()
+      }
+
+      // Count a surfaced reference as an access so it survives dreaming's
+      // time-decay the same way a memory_search / per-turn-retrieval hit does
+      // (mirrors src/bundled-plugins/memory/index.ts). Awaited here — unlike the
+      // per-turn path this is a one-shot command with no latency budget to protect.
+      const referenceSlugs = results.flatMap((r) => (r.source === 'reference' ? [r.key] : []))
+      if (referenceSlugs.length > 0) {
+        await bumpReferenceAccess(ctx.agentDir, referenceSlugs, { logger: ctx.logger })
+      }
+
+      await writeLine(ctx.stdout, args.json ? JSON.stringify(results) : renderResults(args.query, results))
+      return 0
+    },
+  })
+}
+
+export const memorySearchCommand = createMemorySearchCommand()
+
+// The registry stores commands as `PluginCommand` (args: unknown) and validates
+// each call against the command's own zod `args` schema before invoking `run`
+// (see parseArgs in src/server/command-runner.ts). Widening the typed command to
+// the registry shape here is the type-level expression of that runtime contract;
+// the concrete `ContainerCommand<MemorySearchArgs>` export stays available for
+// direct, type-checked test calls.
+export const memoryCommands: Record<string, PluginCommand> = {
+  'memory-search': memorySearchCommand as ContainerCommand<unknown>,
+}
+
+export function vectorDbPath(agentDir: string): string {
+  return join(agentDir, 'memory', '.vectors', 'index.db')
+}
+
+export function renderResults(query: string, results: HybridSearchResult[]): string {
+  if (results.length === 0) {
+    return `No memory matched "${query}".`
+  }
+
+  const lines: string[] = [`${results.length} result(s) for "${query}":`, '']
+  results.forEach((result, index) => {
+    lines.push(`${index + 1}. [${result.source}] ${result.heading}`)
+    lines.push(`   key: ${result.key}  score: ${result.rrfScore.toFixed(4)}`)
+    const provenance = renderProvenance(result)
+    if (provenance !== null) lines.push(`   ${provenance}`)
+    for (const excerptLine of result.excerpt.split('\n')) {
+      lines.push(`   | ${excerptLine}`)
+    }
+    lines.push('')
+  })
+  return lines.join('\n').trimEnd()
+}
+
+function renderProvenance(result: HybridSearchResult): string | null {
+  const parts: string[] = []
+  if (result.who !== undefined) parts.push(result.who)
+  if (result.where?.chatName !== undefined) parts.push(`in ${result.where.chatName}`)
+  else if (result.where?.chat !== undefined) parts.push(`in ${result.where.chat}`)
+  if (result.when !== undefined) parts.push(`at ${result.when}`)
+  return parts.length === 0 ? null : parts.join(' ')
+}
+
+async function writeLine(stream: WritableStream<Uint8Array>, line: string): Promise<void> {
+  const writer = stream.getWriter()
+  try {
+    await writer.write(new TextEncoder().encode(`${line}\n`))
+  } finally {
+    writer.releaseLock()
+  }
+}

--- a/src/cli/command-meta.test.ts
+++ b/src/cli/command-meta.test.ts
@@ -20,7 +20,7 @@ const COMMAND_LOADERS: Record<BuiltinCommandName, () => Promise<MetaCarrier>> = 
   reload: () => import('./reload').then((m) => m.reload),
   logs: () => import('./logs').then((m) => m.logsCommand),
   inspect: () => import('./inspect').then((m) => m.inspectCommand),
-  dreams: () => import('./dreams').then((m) => m.dreamsCommand),
+  memory: () => import('./memory').then((m) => m.memoryCommand),
   shell: () => import('./shell').then((m) => m.shellCommand),
   compose: () => import('./compose').then((m) => m.composeCommand),
   channel: () => import('./channel').then((m) => m.channelCommand),

--- a/src/cli/command-meta.ts
+++ b/src/cli/command-meta.ts
@@ -19,7 +19,7 @@ export type BuiltinCommandName =
   | 'reload'
   | 'logs'
   | 'inspect'
-  | 'dreams'
+  | 'memory'
   | 'shell'
   | 'compose'
   | 'channel'
@@ -52,7 +52,7 @@ export const BUILTIN_COMMANDS: readonly BuiltinCommandMeta[] = [
   { name: 'reload', description: "reload the running agent's reloadable subsystems (cron, ...)" },
   { name: 'logs', description: 'show the agent container logs (host stage)' },
   { name: 'inspect', description: 'session viewer: a session, the live TUI, or container logs' },
-  { name: 'dreams', description: "browse the dreaming subagent's memory-consolidation journal" },
+  { name: 'memory', description: "browse and search the agent's long-term memory" },
   { name: 'shell', description: 'open an interactive shell in the agent container (host stage)' },
   { name: 'compose', description: 'orchestrate every typeclaw agent in subdirectories of cwd' },
   { name: 'channel', description: 'manage channel adapters wired into the agent' },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,7 +25,7 @@ const main = defineCommand({
     reload: () => import('./reload').then((m) => m.reload),
     logs: () => import('./logs').then((m) => m.logsCommand),
     inspect: () => import('./inspect').then((m) => m.inspectCommand),
-    dreams: () => import('./dreams').then((m) => m.dreamsCommand),
+    memory: () => import('./memory').then((m) => m.memoryCommand),
     shell: () => import('./shell').then((m) => m.shellCommand),
     compose: () => import('./compose').then((m) => m.composeCommand),
     channel: () => import('./channel').then((m) => m.channelCommand),

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,0 +1,85 @@
+import { defineCommand } from 'citty'
+
+import { proxyContainerCommand } from './container-command-client'
+import { dreamsCommand } from './dreams'
+import { requireAgentDir } from './require-agent-dir'
+import { errorLine } from './ui'
+
+const MEMORY_SEARCH_COMMAND = 'memory-search'
+
+const searchSub = defineCommand({
+  meta: {
+    name: 'search',
+    description: 'vector-search the agent long-term memory inside the running container (host stage)',
+  },
+  args: {
+    query: {
+      type: 'positional',
+      description: 'the search query',
+      required: true,
+    },
+    topK: {
+      type: 'string',
+      description: 'return at most N ranked results (default 10)',
+    },
+    json: {
+      type: 'boolean',
+      description: 'emit raw JSON results instead of formatted text',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const cwd = requireAgentDir()
+    const topK = parseTopK(args.topK)
+    if (topK === 'invalid') {
+      process.stderr.write(`${errorLine('--topK must be a positive integer')}\n`)
+      process.exit(2)
+    }
+
+    const result = await proxyContainerCommand({
+      agentDir: cwd,
+      commandName: MEMORY_SEARCH_COMMAND,
+      args: {
+        query: args.query,
+        json: args.json === true,
+        ...(topK !== undefined ? { topK } : {}),
+      },
+      stdout: nodeWritable(process.stdout),
+      stderr: nodeWritable(process.stderr),
+    })
+
+    if (!result.ok) {
+      process.stderr.write(`${errorLine(result.message)}\n`)
+      process.exit(result.exitCode)
+    }
+    process.exit(result.exitCode)
+  },
+})
+
+export const memoryCommand = defineCommand({
+  meta: {
+    name: 'memory',
+    description: "browse and search the agent's long-term memory",
+  },
+  subCommands: {
+    dreams: dreamsCommand,
+    search: searchSub,
+  },
+})
+
+function parseTopK(raw: unknown): number | undefined | 'invalid' {
+  if (typeof raw !== 'string') return undefined
+  // Whole-string match, not Number.parseInt — parseInt silently truncates
+  // "1.5" to 1 and "10abc" to 10, proxying invalid input as a valid-looking
+  // topK. The container's max-50 zod check stays as the upper-bound guard.
+  if (!/^[1-9]\d*$/.test(raw)) return 'invalid'
+  return Number(raw)
+}
+
+function nodeWritable(stream: NodeJS.WriteStream): WritableStream<Uint8Array> {
+  return new WritableStream<Uint8Array>({
+    write(chunk) {
+      stream.write(chunk)
+    },
+  })
+}


### PR DESCRIPTION
## What

Adds a `typeclaw memory` command group and a new `typeclaw memory search "query"` command, and moves the existing `typeclaw dreams` under it as `typeclaw memory dreams`.

```
typeclaw memory
├── dreams   # was `typeclaw dreams` (unchanged, re-parented)
└── search   # new: vector search over long-term memory
```

## Why

`dreams` already browses one slice of the agent's long-term memory (the dreaming-consolidation journal). Grouping memory operations under one `memory` command makes room for a sibling `search`, so an operator can query memory from the host the same way the agent does in-container.

## How

**`typeclaw memory search "query"` (host stage)**
- The search runs **inside the running container**, because hybrid (vector) search needs the in-container embedding model — the host has no ONNX runtime / weights.
- The CLI subcommand proxies the query over the existing `/commands` websocket (`proxyContainerCommand`) and streams the container's stdout straight back to the operator's terminal — "search runs on the container, result is visible from the host."
- Implemented as a container-surface plugin command (`memory-search`) registered by the bundled memory plugin; the CLI dispatches it through the same `exec_command` path used by other container commands. No new protocol.
- **Vector-only by design:** when `memory.vector.enabled` is `false` or the index has not been built, it exits non-zero with actionable guidance rather than silently degrading to keyword search.
- Flags: `--topK <n>` (default 10), `--json` (raw `HybridSearchResult[]`; otherwise a formatted text view with provenance).

**`typeclaw dreams` → `typeclaw memory dreams`**
- Pure re-parenting. `src/cli/dreams.ts` and the whole `src/dreams/` domain are unchanged.
- The `dreams` builtin is swapped for `memory` in the command tree (`src/cli/index.ts`) and the `command-meta` table; the table and its guard test (`command-meta.test.ts`, which asserts the table stays byte-identical to each command module's own `meta.description`) move together.

## Breaking change

`typeclaw dreams` no longer exists at the top level. Use `typeclaw memory dreams`.

## Tests

- New `search-command.test.ts` (7 tests): `renderResults` formatting + provenance, vector-disabled exit, missing-index exit, and a real end-to-end vector search (text + JSON) driven through the real `hybridSearch` pipeline against a seeded `VectorStore` with a synthetic embedder. The query token (`zzqxvtrprobe`) appears in no shard, so a hit proves the vector lane ran rather than substring matching.
- `command-meta.test.ts` guard updated for the `dreams` → `memory` swap.
- Full suite green locally: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, `bun run test` (10161 pass / 1 skip / 0 fail).

## Verification

```
$ typeclaw memory --help
COMMANDS
  dreams    browse the dreaming subagent's memory-consolidation journal from git history (host stage)
  search    vector-search the agent long-term memory inside the running container (host stage)

$ typeclaw memory search "vector store" --topK 5
$ typeclaw memory search "vector store" --json
$ typeclaw memory dreams
```
