### PR TITLE
test: stabilize two timing/timezone-fragile tests caught by the flake guard

### DIFF
--- a/src/dreams/render.test.ts
+++ b/src/dreams/render.test.ts
@@ -32,7 +32,12 @@ describe('renderListRow', () => {
 
   it('shows an absolute date anchor alongside the relative time', () => {
     const row = renderListRow(base, { color: false })
-    expect(row).toContain('06-14')
+    // The anchor is rendered in local time, so derive the expected MM-DD from
+    // the same instant rather than hardcoding a UTC date (18:42Z rolls to the
+    // next day east of UTC+6, which is the latent flake this guards against).
+    const d = new Date(base.committedAt)
+    const pad = (n: number): string => String(n).padStart(2, '0')
+    expect(row).toContain(`${pad(d.getMonth() + 1)}-${pad(d.getDate())}`)
   })
 
   it('drops the noise-only "other" badge when a meaningful category exists', () => {

--- a/src/role-claim/client.test.ts
+++ b/src/role-claim/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 
-import type { Server } from 'bun'
+import type { Server, TCPSocketListener } from 'bun'
 
 import type { ClaimCompletedPayload, ClaimStartedPayload, ClientMessage, ServerMessage } from '@/shared'
 
@@ -8,11 +8,26 @@ import { runClaimSession } from './client'
 
 type RaceServer = Server<{ ready: boolean }>
 let server: RaceServer | null = null
+let stalledTcp: TCPSocketListener<undefined> | null = null
 
 afterEach(() => {
   server?.stop(true)
   server = null
+  stalledTcp?.stop(true)
+  stalledTcp = null
 })
+
+// Accepts the TCP connection but never speaks the WebSocket upgrade, so the
+// client's `open` event never fires and waitForOpen must hit its own budget.
+function serveStalledOpen(): number {
+  const listener = Bun.listen<undefined>({
+    hostname: '127.0.0.1',
+    port: 0,
+    socket: { open() {}, data() {}, close() {} },
+  })
+  stalledTcp = listener
+  return listener.port
+}
 
 type ServeOptions = {
   openDelayMs: number
@@ -95,8 +110,32 @@ describe('runClaimSession', () => {
     server = serveRaceProneClaim({ openDelayMs: 0, emitConnected: false })
     const port = server.port
 
-    // when: client runs with a short connect timeout
-    // then: the session rejects with a clear error rather than hanging on ttl
+    // when: client runs with a generous open budget but a short connected budget
+    // (a loaded host could otherwise blow the shared budget on the open phase and
+    // surface the wrong "timed out connecting" error)
+    // then: the session rejects specifically on the missing `connected` message
+    await expect(
+      runClaimSession({
+        url: `ws://127.0.0.1:${port}`,
+        role: 'owner',
+        ttlMs: 60_000,
+        openTimeoutMs: 5_000,
+        connectTimeoutMs: 200,
+      }),
+    ).rejects.toThrow(/timed out waiting for connected/i)
+  })
+
+  test('an omitted openTimeoutMs makes the open phase time out on the connectTimeoutMs budget', async () => {
+    // given: a peer that never completes the WS upgrade, so only the open phase
+    // can resolve the session — and it can only do so by timing out
+    const port = serveStalledOpen()
+
+    // when: openTimeoutMs is omitted and connectTimeoutMs is short
+    // then: the open phase rejects on the inherited 200ms budget. Asserting the
+    // budget in the message (not just /connecting/) is what pins the fallback:
+    // if the default regressed to DEFAULT_CONNECT_TIMEOUT_MS the open phase would
+    // wait 30s and this would fail.
+    const start = Date.now()
     await expect(
       runClaimSession({
         url: `ws://127.0.0.1:${port}`,
@@ -104,6 +143,7 @@ describe('runClaimSession', () => {
         ttlMs: 60_000,
         connectTimeoutMs: 200,
       }),
-    ).rejects.toThrow(/connected/i)
+    ).rejects.toThrow(/timed out connecting to .* after 200ms/i)
+    expect(Date.now() - start).toBeLessThan(2_000)
   })
 })

--- a/src/role-claim/client.ts
+++ b/src/role-claim/client.ts
@@ -13,6 +13,10 @@ export type ClaimSessionOptions = {
   role: string
   channel?: string
   ttlMs?: number
+  // Defaults to connectTimeoutMs. Split out so a loaded host can't let the
+  // open (transport) phase exhaust the budget meant for the connected phase
+  // and surface the wrong timeout error. See waitForOpen/waitForConnected.
+  openTimeoutMs?: number
   connectTimeoutMs?: number
   onStarted?: (payload: ClaimStartedPayload) => void
 }
@@ -28,11 +32,12 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 30_000
 export async function runClaimSession(opts: ClaimSessionOptions): Promise<ClaimSessionResult> {
   const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
   const connectTimeoutMs = opts.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
+  const openTimeoutMs = opts.openTimeoutMs ?? connectTimeoutMs
   const code = generateClaimCode()
 
   const ws = new WebSocket(opts.url)
   const displayUrl = redactUrl(opts.url)
-  await waitForOpen(ws, displayUrl, connectTimeoutMs)
+  await waitForOpen(ws, displayUrl, openTimeoutMs)
   await waitForConnected(ws, displayUrl, connectTimeoutMs)
 
   try {


### PR DESCRIPTION
Fixes two independent flaky tests. The first was the original target; the second was surfaced by this PR's own **flake guard (oversubscribed parallel)** lane, which runs the suite in a non-UTC timezone.

## Background

**1. `runClaimSession` connect-timeout test (`src/role-claim/client.ts` + test)**

The test `times out the connect handshake if connected never arrives` flakes on `main` under CI load ([CI run](https://github.com/typeclaw/typeclaw/actions/runs/28110877563)):

```
Received message: "timed out connecting to ws://127.0.0.1:40841/ after 200ms"
(fail) runClaimSession > times out the connect handshake if connected never arrives
```

`runClaimSession` ran two sequential phases — `waitForOpen` (transport handshake) and `waitForConnected` (app-level `connected` message) — against a **single shared** `connectTimeoutMs`. The test sets it to `200ms` to exercise the *connected*-phase timeout (whose message contains "connected" and matches `/connected/i`). Under event-loop starvation the WebSocket `open` event itself lands past 200ms, so `waitForOpen` times out **first** with `"timed out connecting ..."` — which lacks "connected" — failing the assertion. Reproduced locally by busy-waiting 300ms before the `open` event under a 200ms budget.

**2. `renderListRow` date-anchor test (`src/dreams/render.test.ts`)**

The flake guard surfaced `renderListRow > shows an absolute date anchor alongside the relative time`. `renderListRow` renders the anchor in **local time** (`getMonth`/`getDate`), but the test hardcoded `"06-14"` against a fixture committed at `2026-06-14T18:42:03Z`. East of UTC+6 that instant rolls to `06-15`, so the assertion fails in any non-UTC timezone. Reproduced with `TZ=Asia/Seoul` (renders `06-15`); UTC runners hid it.

## Summary

**1.** Give the open phase its own optional `openTimeoutMs`, defaulting to `connectTimeoutMs`. The test passes a generous `openTimeoutMs: 5_000` with `connectTimeoutMs: 200`, so it deterministically reaches the connected-phase timeout regardless of scheduling pressure. Chosen over widening the regex (which would let the test pass on the wrong code path). Single-timeout callers are unchanged via the fallback. Assertion tightened to `/timed out waiting for connected/i`; added a test pinning the fallback.

**2.** Derive the expected `MM-DD` from the fixture's `committedAt` instant using the same local-time logic the renderer uses — instead of a hardcoded UTC literal. The test still proves a real date anchor is shown, now timezone-independent (verified UTC, Asia/Seoul, America/Los_Angeles, Pacific/Kiritimati, Etc/GMT+12).

## What this does NOT do

- No change to default timeout values, timeout error messages, or the transport/handshake logic.
- No change to how dates render to users (`renderListRow` still shows local time) — only the test stops assuming UTC.
- Does not touch the `dreams` production formatter.

## Review notes

- `role-claim`: load-bearing line `const openTimeoutMs = opts.openTimeoutMs ?? connectTimeoutMs`. Invariant: with `openTimeoutMs` omitted, both phases share `connectTimeoutMs` exactly as before (covered by the new fallback test).
- `dreams`: the inline comment documents *why* the date is derived rather than hardcoded — please keep it so the UTC literal isn't reintroduced.
- Full suite is green under both `TZ=UTC` and `TZ=Asia/Seoul`.