### PR TITLE
feat(run): gracefully resume todos after restart-induced abort

### DIFF
--- a/src/agent/todo/continuation-policy.test.ts
+++ b/src/agent/todo/continuation-policy.test.ts
@@ -89,6 +89,7 @@ describe('parseContinuationState (fail-closed validation)', () => {
       lastTurnOutcome: { turnId: 't', stopReason: 'stop', endedAt: 9 },
       suppressNextIdleNudgeReason: 'restart-kick',
       autoResumeBlockedUntilRealUserTurn: true,
+      restartAbortPending: false,
     }
     expect(parseContinuationState(state)).toEqual(state)
   })

--- a/src/agent/todo/continuation-policy.ts
+++ b/src/agent/todo/continuation-policy.ts
@@ -65,6 +65,12 @@ export type ContinuationState = {
   // explicit user abort; cleared only by the next real user turn. While set,
   // no auto-continuation fires regardless of episode budget.
   autoResumeBlockedUntilRealUserTurn: boolean
+  // One-shot marker the graceful-restart shutdown sets per scope before it
+  // aborts an in-flight turn. It tells onTurnOutcome that the imminent 'aborted'
+  // outcome is a restart lifecycle transition, not a user stop, so the durable
+  // D1 block above must NOT arm. Consumed on the next turn outcome so it never
+  // masks a later genuine user abort.
+  restartAbortPending: boolean
 }
 
 export function emptyContinuationState(): ContinuationState {
@@ -73,6 +79,7 @@ export function emptyContinuationState(): ContinuationState {
     lastTurnOutcome: null,
     suppressNextIdleNudgeReason: null,
     autoResumeBlockedUntilRealUserTurn: false,
+    restartAbortPending: false,
   }
 }
 
@@ -94,6 +101,7 @@ export function parseContinuationState(value: unknown): ContinuationState {
     lastTurnOutcome: parseOutcome(v.lastTurnOutcome),
     suppressNextIdleNudgeReason: v.suppressNextIdleNudgeReason === 'restart-kick' ? 'restart-kick' : null,
     autoResumeBlockedUntilRealUserTurn: v.autoResumeBlockedUntilRealUserTurn === true,
+    restartAbortPending: v.restartAbortPending === true,
   }
 }
 

--- a/src/agent/todo/continuation-state.test.ts
+++ b/src/agent/todo/continuation-state.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   armRestartKickSuppression,
   consumeRestartKickSuppression,
+  markRestartAbortPending,
   onTurnOutcome,
   onTurnStart,
   readContinuationState,
@@ -52,6 +53,7 @@ describe('continuation-state persistence', () => {
       lastTurnOutcome: { turnId: 't', stopReason: 'stop', endedAt: 1 },
       suppressNextIdleNudgeReason: null,
       autoResumeBlockedUntilRealUserTurn: false,
+      restartAbortPending: false,
     }
     await writeContinuationState(agentDir, SCOPE, state)
     expect(await readContinuationState(agentDir, SCOPE)).toEqual(state)
@@ -86,16 +88,34 @@ describe('onTurnStart', () => {
       lastTurnOutcome: null,
       suppressNextIdleNudgeReason: 'restart-kick',
       autoResumeBlockedUntilRealUserTurn: true,
+      restartAbortPending: true,
     }
     const next = onTurnStart(state, true)
     expect(next.episode).toBeNull()
     expect(next.suppressNextIdleNudgeReason).toBeNull()
     expect(next.autoResumeBlockedUntilRealUserTurn).toBe(false)
+    expect(next.restartAbortPending).toBe(false)
   })
 
   test('an injected (non-user) turn does NOT reset the episode budget', () => {
     const state: ContinuationState = { ...emptyContinuationState(), episode: EPISODE }
     expect(onTurnStart(state, false)).toBe(state)
+  })
+
+  // Regression: a restart marker orphaned by a hard process exit (no aborted
+  // outcome ever recorded — e.g. the singleton TUI scope marked with no live
+  // turn) must NOT survive into the next user turn and downgrade a genuine user
+  // abort. The real user turn clears the stale marker, so the user's later
+  // abort still arms D1.
+  test('a stale restart marker does not suppress D1 for a later genuine user abort', () => {
+    // given a marker left on disk by a restart, with no outcome recorded
+    const stale: ContinuationState = { ...emptyContinuationState(), restartAbortPending: true }
+    // when the user prompts again (real user turn) and then aborts that turn
+    const afterUserPrompt = onTurnStart(stale, true)
+    expect(afterUserPrompt.restartAbortPending).toBe(false)
+    const afterUserAbort = onTurnOutcome(afterUserPrompt, { turnId: 'u1', stopReason: 'aborted', endedAt: 1 })
+    // then D1 arms — the stale marker did not classify it as restart-induced
+    expect(afterUserAbort.autoResumeBlockedUntilRealUserTurn).toBe(true)
   })
 })
 
@@ -114,6 +134,35 @@ describe('onTurnOutcome', () => {
   test('a normal stop does not arm the suppressor', () => {
     const outcome: TurnOutcome = { turnId: 't', stopReason: 'stop', endedAt: 9 }
     expect(onTurnOutcome(emptyContinuationState(), outcome).autoResumeBlockedUntilRealUserTurn).toBe(false)
+  })
+
+  test('a restart-induced abort does NOT arm the suppressor and consumes the marker', () => {
+    const outcome: TurnOutcome = { turnId: 't', stopReason: 'aborted', endedAt: 9 }
+    const marked = markRestartAbortPending(emptyContinuationState())
+    const next = onTurnOutcome(marked, outcome)
+    expect(next.autoResumeBlockedUntilRealUserTurn).toBe(false)
+    expect(next.restartAbortPending).toBe(false)
+  })
+
+  test('the marker is one-shot: a later genuine abort still arms the suppressor', () => {
+    const firstAbort = onTurnOutcome(markRestartAbortPending(emptyContinuationState()), {
+      turnId: 't1',
+      stopReason: 'aborted',
+      endedAt: 1,
+    })
+    const secondAbort = onTurnOutcome(firstAbort, { turnId: 't2', stopReason: 'aborted', endedAt: 2 })
+    expect(secondAbort.autoResumeBlockedUntilRealUserTurn).toBe(true)
+  })
+})
+
+describe('markRestartAbortPending', () => {
+  test('sets the one-shot marker', () => {
+    expect(markRestartAbortPending(emptyContinuationState()).restartAbortPending).toBe(true)
+  })
+
+  test('is idempotent', () => {
+    const once = markRestartAbortPending(emptyContinuationState())
+    expect(markRestartAbortPending(once)).toBe(once)
   })
 })
 

--- a/src/agent/todo/continuation-state.ts
+++ b/src/agent/todo/continuation-state.ts
@@ -50,10 +50,18 @@ export async function writeContinuationState(
   await rename(tmp, path)
 }
 
-// A real user turn ends any active continuation episode and clears both
-// suppressors. This is the ONLY thing that resets the episode budget — the
-// runtime's own injected continuation prompts must not. Callers pass `false`
-// for injected prompts so the episode budget keeps counting down.
+// A real user turn ends any active continuation episode and clears every
+// suppressor, including the one-shot restart-abort marker. This is the ONLY
+// thing that resets the episode budget — the runtime's own injected
+// continuation prompts must not. Callers pass `false` for injected prompts so
+// the episode budget keeps counting down.
+//
+// Clearing restartAbortPending here is load-bearing for policy D1: the host
+// SIGTERM path can leave a marker on disk that was never consumed (the process
+// exited before any aborted outcome was recorded, or the singleton TUI scope
+// was marked with no live turn). A real user turn is the staleness boundary —
+// once the user prompts again, any leftover marker is stale, so a LATER user
+// abort in that turn must still arm D1 rather than consume the dead marker.
 export function onTurnStart(state: ContinuationState, isRealUserTurn: boolean): ContinuationState {
   if (!isRealUserTurn) return state
   return {
@@ -61,20 +69,46 @@ export function onTurnStart(state: ContinuationState, isRealUserTurn: boolean): 
     episode: null,
     autoResumeBlockedUntilRealUserTurn: false,
     suppressNextIdleNudgeReason: null,
+    restartAbortPending: false,
   }
 }
 
 // Record the most recently completed turn's outcome. Explicit user abort also
 // arms the durable suppressor so no auto-continuation fires until a real user
-// turn clears it (policy D1).
+// turn clears it (policy D1). A restart-induced abort is the one exception: the
+// graceful-shutdown path sets restartAbortPending before aborting, so the
+// imminent 'aborted' outcome does NOT arm the block. The marker is one-shot —
+// consumed here regardless — so a later genuine user abort still arms D1.
 export function onTurnOutcome(state: ContinuationState, outcome: TurnOutcome): ContinuationState {
-  const next: ContinuationState = { ...state, lastTurnOutcome: outcome }
-  if (outcome.stopReason === 'aborted') next.autoResumeBlockedUntilRealUserTurn = true
+  const next: ContinuationState = { ...state, lastTurnOutcome: outcome, restartAbortPending: false }
+  if (outcome.stopReason === 'aborted' && !state.restartAbortPending) {
+    next.autoResumeBlockedUntilRealUserTurn = true
+  }
   return next
+}
+
+// Set the one-shot restart-abort marker so the next 'aborted' outcome is read
+// as a restart lifecycle transition, not a user stop. Gated by the caller to
+// the graceful-restart shutdown path only. Consumed by onTurnOutcome OR cleared
+// by the next real user turn (onTurnStart), whichever comes first — so a marker
+// orphaned by a hard process exit can never outlive the next user prompt.
+export function markRestartAbortPending(state: ContinuationState): ContinuationState {
+  if (state.restartAbortPending) return state
+  return { ...state, restartAbortPending: true }
 }
 
 export function armRestartKickSuppression(state: ContinuationState): ContinuationState {
   return { ...state, suppressNextIdleNudgeReason: 'restart-kick' }
+}
+
+// The ONE sanctioned bypass of policy D1's "only a real user turn clears the
+// abort block": a restart aborts the in-flight turn (arming the block via
+// onTurnOutcome), but that is a lifecycle transition, not a user stop. Callers
+// MUST gate this on the consumed restart handoff so an ordinary user abort
+// still leaves the block in place.
+export function clearAbortSuppression(state: ContinuationState): ContinuationState {
+  if (!state.autoResumeBlockedUntilRealUserTurn) return state
+  return { ...state, autoResumeBlockedUntilRealUserTurn: false }
 }
 
 export function consumeRestartKickSuppression(state: ContinuationState): ContinuationState {

--- a/src/agent/todo/continuation-wiring.test.ts
+++ b/src/agent/todo/continuation-wiring.test.ts
@@ -9,6 +9,7 @@ import { readContinuationState } from './continuation-state'
 import {
   armRestartKickForOrigin,
   classifyStopReason,
+  clearAbortSuppressionForOrigin,
   clearTodosForOrigin,
   extractStopReason,
   recordTurnOutcome,
@@ -75,6 +76,61 @@ describe('recordTurnOutcome / recordTurnStart', () => {
     await recordTurnOutcome({ agentDir, origin, turnId: 't', stopReason: 'stop' })
     await recordTurnStart({ agentDir, origin, isRealUserTurn: true })
     // nothing thrown, nothing written
+    expect(true).toBe(true)
+  })
+})
+
+describe('clearAbortSuppressionForOrigin', () => {
+  test('clears the abort suppressor a restart-induced abort armed', async () => {
+    // given a turn aborted (as a restart would) which armed the durable block
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'aborted' })
+    expect((await readContinuationState(agentDir, SCOPE)).autoResumeBlockedUntilRealUserTurn).toBe(true)
+    // when the restart resume path clears it
+    await clearAbortSuppressionForOrigin(agentDir, TUI)
+    // then auto-continuation is unblocked without needing a real user turn
+    expect((await readContinuationState(agentDir, SCOPE)).autoResumeBlockedUntilRealUserTurn).toBe(false)
+  })
+
+  test('lets work auto-continue once the restart-kick turn laundered the aborted outcome', async () => {
+    // given a turn the restart aborted, leaving incomplete work
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'aborted' })
+
+    // when the resume path clears the durable block and arms the one-shot kick
+    await clearAbortSuppressionForOrigin(agentDir, TUI)
+    await armRestartKickForOrigin(agentDir, TUI)
+
+    // and the synthetic "I'm back" kick runs as a non-user turn, then goes idle
+    await recordTurnStart({ agentDir, origin: TUI, isRealUserTurn: false })
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 'kick', stopReason: 'stop' })
+    let count = 0
+    const firstIdle = await runIdleContinuation({ agentDir, origin: TUI, deliver: () => count++ })
+
+    // then the kick's own idle is suppressed, but the next idle continues —
+    // proving the kick laundered lastTurnOutcome from 'aborted' to 'stop'
+    expect(firstIdle).toBe(false)
+    const secondIdle = await runIdleContinuation({ agentDir, origin: TUI, deliver: () => count++ })
+    expect(secondIdle).toBe(true)
+    expect(count).toBe(1)
+  })
+
+  test('still blocks when the restart-kick turn itself aborts', async () => {
+    await writeTodos(agentDir, SCOPE, [{ content: 'task', status: 'pending' }])
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 't1', stopReason: 'aborted' })
+    await clearAbortSuppressionForOrigin(agentDir, TUI)
+    await armRestartKickForOrigin(agentDir, TUI)
+    await recordTurnStart({ agentDir, origin: TUI, isRealUserTurn: false })
+    await recordTurnOutcome({ agentDir, origin: TUI, turnId: 'kick', stopReason: 'aborted' })
+    await runIdleContinuation({ agentDir, origin: TUI, deliver: () => undefined })
+    let delivered = false
+    const ok = await runIdleContinuation({ agentDir, origin: TUI, deliver: () => (delivered = true) })
+    expect(ok).toBe(false)
+    expect(delivered).toBe(false)
+  })
+
+  test('scopeless origins are a no-op', async () => {
+    const origin: SessionOrigin = { kind: 'subagent', subagent: 's', parentSessionId: 'p' }
+    await clearAbortSuppressionForOrigin(agentDir, origin)
     expect(true).toBe(true)
   })
 })

--- a/src/agent/todo/continuation-wiring.ts
+++ b/src/agent/todo/continuation-wiring.ts
@@ -4,6 +4,8 @@ import { maybeInjectContinuation } from './continuation'
 import { type TurnOutcome } from './continuation-policy'
 import {
   armRestartKickSuppression,
+  clearAbortSuppression,
+  markRestartAbortPending,
   onTurnOutcome,
   onTurnStart,
   readContinuationState,
@@ -88,6 +90,30 @@ export async function armRestartKickForOrigin(agentDir: string, origin: SessionO
   if (scope === null) return
   const state = await readContinuationState(agentDir, scope)
   await writeContinuationState(agentDir, scope, armRestartKickSuppression(state))
+}
+
+// Mark an origin's scope so the imminent restart-induced abort does not arm the
+// durable user-abort block. Called by the graceful-restart shutdown BEFORE it
+// aborts the in-flight turn, so onTurnOutcome reads the marker when it records
+// the 'aborted' outcome. No-op for scopeless origins.
+export async function markRestartAbortPendingForOrigin(agentDir: string, origin: SessionOrigin): Promise<void> {
+  const scope = resolveTodoScope(origin)
+  if (scope === null) return
+  const state = await readContinuationState(agentDir, scope)
+  const next = markRestartAbortPending(state)
+  if (next !== state) await writeContinuationState(agentDir, scope, next)
+}
+
+// Clear the durable user-abort suppressor for an origin's scope on a restart
+// resume, so a turn aborted by the restart itself does not permanently block
+// auto-continuation. Gated by the caller to the restart-handoff path only.
+// No-op for scopeless origins.
+export async function clearAbortSuppressionForOrigin(agentDir: string, origin: SessionOrigin): Promise<void> {
+  const scope = resolveTodoScope(origin)
+  if (scope === null) return
+  const state = await readContinuationState(agentDir, scope)
+  const next = clearAbortSuppression(state)
+  if (next !== state) await writeContinuationState(agentDir, scope, next)
 }
 
 // Empty the todo list for an origin's scope. No-op for scopeless origins.

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -66,6 +66,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     resumeRestartHandoff: async () => {},
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
   }
 }

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -37,6 +37,7 @@ function fakeRouter(react: (req: ReactionRequest) => Promise<ReactionResult>): C
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -52,6 +52,7 @@ function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: 
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -60,6 +60,7 @@ function fakeRouter(
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -61,6 +61,7 @@ function fakeRouter(handlers: {
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -50,6 +50,7 @@ function fakeRouter(
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -78,6 +78,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -55,6 +55,7 @@ function fakeRouter(
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -69,6 +69,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     getSelfAliases: () => [],
     stop: async () => {},
     tearDownAllLive: async () => {},
+    markRestartAbortForAllLive: async () => {},
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -10,6 +10,8 @@ import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 import type { AgentSession } from '@/agent'
 import type { RestartHandoff } from '@/agent/restart-handoff'
 import type { SessionOrigin } from '@/agent/session-origin'
+import { readContinuationState } from '@/agent/todo/continuation-state'
+import { resolveTodoScope } from '@/agent/todo/scope'
 import type { PermissionService } from '@/permissions'
 import type { HookBus, SessionIdleEvent } from '@/plugin'
 
@@ -11473,6 +11475,40 @@ describe('resumeRestartHandoff', () => {
     expect(originDuringWake?.kind).toBe('channel')
     if (originDuringWake?.kind !== 'channel') throw new Error('unreachable')
     expect(originDuringWake.lastInboundAuthorId).toBe('U_OWNER')
+  })
+})
+
+describe('markRestartAbortForAllLive (graceful host restart)', () => {
+  test('aborts every live session and marks its scope so resume auto-continues', async () => {
+    // given a live channel session with an in-flight-capable turn
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(1)
+
+    // when the graceful-restart shutdown marks + aborts all live sessions
+    await router.markRestartAbortForAllLive()
+
+    // then the turn was aborted and the scope carries the one-shot marker, so
+    // the next 'aborted' outcome will NOT arm the durable user-abort block
+    expect(sessions[0]!.aborted).toBeGreaterThan(0)
+    const scope = resolveTodoScope({
+      kind: 'channel',
+      adapter: KEY.adapter,
+      workspace: KEY.workspace,
+      chat: KEY.chat,
+      thread: KEY.thread,
+      participants: [],
+    })!
+    expect((await readContinuationState(dir, scope)).restartAbortPending).toBe(true)
+  })
+
+  test('is a no-op with no live sessions', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    await router.markRestartAbortForAllLive()
+    expect(true).toBe(true)
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -15,7 +15,9 @@ import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
 import {
   armRestartKickForOrigin,
+  clearAbortSuppressionForOrigin,
   extractTurnUsage,
+  markRestartAbortPendingForOrigin,
   recordTurnOutcome,
   recordTurnStart,
   runIdleContinuation,
@@ -1168,6 +1170,9 @@ export type ChannelRouter = {
   resumeRestartHandoff: (handoff: RestartHandoff) => Promise<void>
   stop: () => Promise<void>
   tearDownAllLive: () => Promise<void>
+  // Graceful-restart shutdown: mark + abort every live channel session so each
+  // scope's incomplete todos auto-continue on the next boot. See the impl.
+  markRestartAbortForAllLive: () => Promise<void>
   liveCount: () => number
   __testing?: {
     flushDebounce: (key: ChannelKey) => Promise<void>
@@ -4393,6 +4398,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     closing = false
   }
 
+  // Graceful-restart shutdown: mark every live channel session's todo scope so
+  // the turn the restart is about to abort does not arm the durable user-abort
+  // block, then abort the in-flight turns. On the next boot each scope's resume
+  // continues its incomplete todos instead of waiting for a human. Best-effort
+  // and bounded by the caller's shutdown deadline.
+  const markRestartAbortForAllLive = async (): Promise<void> => {
+    for (const live of Array.from(liveSessions.values())) {
+      const origin = buildLiveOrigin(live)
+      await markRestartAbortPendingForOrigin(options.agentDir, origin).catch((err) =>
+        logger.error(`[channels] graceful-restart mark abort failed: ${describe(err)}`),
+      )
+      await live.session
+        .abort()
+        .catch((err) => logger.error(`[channels] graceful-restart abort failed: ${describe(err)}`))
+    }
+  }
+
   // Boot-time resume for a restart that originated from a channel session, in
   // two phases to close the race with adapters that begin receiving inbounds.
   //
@@ -4493,6 +4515,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
         await armRestartKickForOrigin(options.agentDir, buildLiveOrigin(live)).catch((err) =>
           logger.error(`[channels] ${keyId}: restart-resume arm restart-kick failed: ${describe(err)}`),
+        )
+        // A restart-aborted turn arms the durable user-abort block; this resume
+        // IS the restart, so clear it or the resumed session never auto-resumes
+        // its incomplete todos. Gated to this restart-handoff path.
+        await clearAbortSuppressionForOrigin(options.agentDir, buildLiveOrigin(live)).catch((err) =>
+          logger.error(`[channels] ${keyId}: restart-resume clear abort suppression failed: ${describe(err)}`),
         )
 
         live.pendingSystemReminders.push(RESTART_RESUME_WAKE_REMINDER)
@@ -4792,6 +4820,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     resumeRestartHandoff,
     stop,
     tearDownAllLive,
+    markRestartAbortForAllLive,
     liveCount: () => liveSessions.size,
     __testing: {
       flushDebounce: async (key: ChannelKey) => {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -19,7 +19,7 @@ import {
   type SubagentRegistry,
   type SubagentShared,
 } from '@/agent/subagents'
-import { clearTodosForOrigin } from '@/agent/todo/continuation-wiring'
+import { clearTodosForOrigin, markRestartAbortPendingForOrigin } from '@/agent/todo/continuation-wiring'
 import { vectorEnabledFromMemoryConfig } from '@/bundled-plugins/memory/vector/config'
 import { embed, warmEmbedder } from '@/bundled-plugins/memory/vector/embedder'
 import { buildStartupVectorIndex } from '@/bundled-plugins/memory/vector/startup'
@@ -211,7 +211,11 @@ async function startAgentRuntime(
     processGlobalsDisposed = true
     uninstallCodexFetchObserver()
     fatalGuard.dispose()
+    // onSigterm is defined later in this scope but only ever invoked after init;
+    // removing it here keeps a restarted startAgent() from stacking listeners.
+    if (sigtermHandler !== null) process.removeListener('SIGTERM', sigtermHandler)
   }
+  let sigtermHandler: (() => void) | null = null
   onProcessGlobalsInstalled(disposeProcessGlobals)
 
   const { config: cwdConfig, pluginConfigs: pluginConfigsByName } = loadConfigBundleSync(cwd)
@@ -953,6 +957,34 @@ async function startAgentRuntime(
       disposeProcessGlobals()
     }
   }
+
+  // Graceful shutdown on host-initiated restart (`typeclaw restart` → docker
+  // stop → SIGTERM, ~10s before SIGKILL). Mark every live session's todo scope
+  // so the turn this restart aborts does not arm the durable user-abort block —
+  // each scope's incomplete todos then auto-continue after the new container
+  // boots. Then run best-effort teardown. A hard deadline force-exits well
+  // inside Docker's grace window so a hung turn can't get the process SIGKILL'd
+  // mid-flush. Only meaningful inside a container; outside Docker SIGTERM is an
+  // ordinary stop with nothing to resume.
+  const SHUTDOWN_DEADLINE_MS = 8_000
+  let shuttingDown = false
+  const onSigterm = (): void => {
+    if (shuttingDown) return
+    shuttingDown = true
+    const forceExit = setTimeout(() => process.exit(0), SHUTDOWN_DEADLINE_MS)
+    forceExit.unref()
+    void (async () => {
+      if (containerName !== undefined) {
+        await markRestartAbortPendingForOrigin(cwd, { kind: 'tui', sessionId: 'tui' }).catch(() => undefined)
+        await channelManager.router.markRestartAbortForAllLive().catch(() => undefined)
+      }
+      await stop().catch(() => undefined)
+      clearTimeout(forceExit)
+      process.exit(0)
+    })()
+  }
+  sigtermHandler = onSigterm
+  process.on('SIGTERM', onSigterm)
 
   if (!attachTui) {
     return {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,7 @@ import type { CreateSessionForSubagent } from '@/agent/subagents'
 import { TODO_CONTINUATION_SOURCE } from '@/agent/todo/continuation'
 import {
   armRestartKickForOrigin,
+  clearAbortSuppressionForOrigin,
   extractTurnUsage,
   recordTurnOutcome,
   recordTurnStart,
@@ -619,6 +620,13 @@ export function createServer({
               if (agentDir !== undefined) {
                 await armRestartKickForOrigin(agentDir, origin).catch((err) =>
                   logger.error(`[server] ${sessionFileId}: arm restart-kick suppression failed: ${describeErr(err)}`),
+                )
+                // The restart may have aborted an in-flight turn, arming the
+                // durable user-abort block. This resume IS the restart, so
+                // clear it — otherwise the resumed session never auto-continues
+                // its incomplete todos. Gated to this restart-handoff path.
+                await clearAbortSuppressionForOrigin(agentDir, origin).catch((err) =>
+                  logger.error(`[server] ${sessionFileId}: clear abort suppression failed: ${describeErr(err)}`),
                 )
               }
               stream.publish({


### PR DESCRIPTION
## Background

TypeClaw persists todo lists to disk and auto-continues incomplete work on idle. A safety guard — policy D1 (`autoResumeBlockedUntilRealUserTurn` in `src/agent/todo/continuation-policy.ts`) — arms a durable block on any `'aborted'` turn outcome, halting all todo auto-continuation until a real human turn clears it. This is correct for a genuine user stop.

A container restart also aborts the in-flight turn, producing the same `'aborted'` outcome. Before this PR, a resumed session would sit on its incomplete todos forever, waiting for a human who might never type — silently losing work-in-progress context.

There were two restart paths, and neither handled this:

1. **Agent-initiated `restart` tool** — writes a restart handoff and resumes the originating session on next boot. Policy D1 armed and blocked.
2. **Host-initiated `typeclaw restart`** — `docker stop` sends SIGTERM (~10s grace, then SIGKILL). The container had no SIGTERM handler at all, so turns were hard-killed with zero resume context.

## Summary

Distinguish a restart-induced abort from a genuine user stop without eroding policy D1 for real user aborts. Two complementary mechanisms, each gated to its own caller:

**Abort-time marker (host SIGTERM path).** A new in-container SIGTERM handler (`src/run/index.ts`) sets a one-shot `restartAbortPending` marker per live session's todo scope before aborting the turn. `onTurnOutcome` reads the imminent `'aborted'` as a lifecycle transition and skips arming the block. The marker is consumed on that same outcome, so a later genuine user abort still arms D1. A hard 8s force-exit timer keeps a hung turn from eating Docker's 10s grace window.

**Resume-time clear (agent `restart` tool path).** The TUI websocket open handler (`src/server/index.ts`) and the channel router's reserve/resume path (`src/channels/router.ts`), right next to the existing restart-kick arming, now clear the durable block. The synthetic restart-kick turn launders the aborted `lastTurnOutcome` to `'stop'`, so the next idle continues normally.

**Why a marker and not rewriting the outcome:** `lastTurnOutcome` stays truthful — `'aborted'` is still recorded. Only the block's arming is gated. Rewriting or suppressing the outcome at source was rejected because it races the async `message_end` → `recordTurnOutcome` write and weakens the semantic meaning of `'aborted'`.

**Why a per-scope marker and not a multi-session handoff file:** the existing restart handoff is single-consumer-per-kind; host SIGTERM aborts all live sessions simultaneously. The marker lives in the same per-scope durable continuation-state that already owns the abort block, so each TUI/channel scope is handled independently.

## What this does NOT do

- Does not add explicit turn-aborting plumbing for the host path beyond `markRestartAbortForAllLive` in the channel router and the TUI singleton scope marker — process exit stops the turns; the marker is what guarantees resume continues.
- Does not refactor `LiveSessionRegistry` into a universal session registry.
- Does not reset the episode continuation budget (max auto-turns/tokens) on restart.
- Does not change protocol or control tokens.

## Review notes

- **Load-bearing invariant — policy D1 must still arm for a genuine user abort.** The marker is one-shot (consumed in `onTurnOutcome`). Verified by the test "the marker is one-shot: a later genuine abort still arms the suppressor" in `src/agent/todo/continuation-state.test.ts`.
- **Ordering matters — the marker is set BEFORE abort.** `onTurnOutcome` must observe it; see the SIGTERM handler in `src/run/index.ts` and `markRestartAbortForAllLive` in `src/channels/router.ts`.
- **The restart-kick launders `lastTurnOutcome`.** Verified by "lets work auto-continue once the restart-kick turn laundered the aborted outcome" and "still blocks when the restart-kick turn itself aborts" in `continuation-wiring.test.ts`.
- The 9 channel-tool test doubles in `src/channels/router.test.ts` gain one-line stubs for the new interface member so the suite keeps type-checking; no behavioral change.