### PR TITLE
feat(channels): surface display name with stable id in transcript author lines

### DIFF
--- a/src/channels/router.quote-anchor.test.ts
+++ b/src/channels/router.quote-anchor.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   captureQuoteCandidate,
   decideQuoteAnchor,
+  formatAuthorAttribution,
   prependQuoteAnchor,
   renderQuoteAnchor,
   resolveReplyRenderMode,
@@ -24,6 +25,30 @@ const humanInbound = {
   receivedAt: 1000,
   externalMessageId: 'M_ALICE',
 }
+
+describe('formatAuthorAttribution', () => {
+  test('Slack transcript attribution includes display name and stable mention id', () => {
+    expect(formatAuthorAttribution('slack-bot', 'U_ALICE', 'Alice')).toBe('Alice <@U_ALICE>')
+  })
+
+  test('Discord transcript attribution includes display name and stable mention id', () => {
+    expect(formatAuthorAttribution('discord-bot', '123456789', 'Bob')).toBe('Bob <@123456789>')
+  })
+
+  test('KakaoTalk transcript attribution includes Korean display name and numeric id', () => {
+    expect(formatAuthorAttribution('kakaotalk', '999000111', '민준')).toBe('민준 <999000111>')
+  })
+
+  test('GitHub transcript attribution uses a natural handle without duplicating login-only names', () => {
+    expect(formatAuthorAttribution('github', 'octocat', 'octocat')).toBe('@octocat')
+    expect(formatAuthorAttribution('github', 'octocat', 'Mona Lisa')).toBe('Mona Lisa (@octocat)')
+  })
+
+  test('empty display names fall back to the stable identifier only', () => {
+    expect(formatAuthorAttribution('slack-bot', 'U_ALICE', '  ')).toBe('<@U_ALICE>')
+    expect(formatAuthorAttribution('kakaotalk', '999000111', '')).toBe('999000111')
+  })
+})
 
 describe('renderQuoteAnchor', () => {
   test('Slack: emits a real `<@authorId>` mention so the quote anchors against the platform-native mention', () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1194,7 +1194,7 @@ describe('ChannelRouter engagement and prompt composition', () => {
     await router.route(inbound({ text: 'what time is it?' }))
     await router.__testing!.flushDebounce(KEY)
     expect(sessions[0]!.prompts).toHaveLength(1)
-    expect(sessions[0]!.prompts[0]).toContain('<@alice> (alice): what time is it?')
+    expect(sessions[0]!.prompts[0]).toContain('alice <@alice>: what time is it?')
   })
 
   test('prompt line is prefixed with the platform-side ISO 8601 timestamp from event.ts', async () => {
@@ -1202,7 +1202,7 @@ describe('ChannelRouter engagement and prompt composition', () => {
     const { router, sessions } = makeRouter(dir)
     await router.route(inbound({ text: 'hello there', ts: FIXED_INBOUND_TS }))
     await router.__testing!.flushDebounce(KEY)
-    expect(sessions[0]!.prompts[0]).toContain(`[${FIXED_INBOUND_ISO}] <@alice> (alice): hello there`)
+    expect(sessions[0]!.prompts[0]).toContain(`[${FIXED_INBOUND_ISO}] alice <@alice>: hello there`)
   })
 
   test('prompt line omits the timestamp prefix when ts is unknown (0)', async () => {
@@ -1211,7 +1211,7 @@ describe('ChannelRouter engagement and prompt composition', () => {
     await router.route(inbound({ text: 'hello there', ts: 0 }))
     await router.__testing!.flushDebounce(KEY)
     const line = sessions[0]!.prompts[0]!
-    expect(line).toContain('<@alice> (alice): hello there')
+    expect(line).toContain('alice <@alice>: hello there')
     expect(line).not.toMatch(/\[\d{4}-\d{2}-\d{2}T/)
   })
 
@@ -1232,7 +1232,7 @@ describe('ChannelRouter engagement and prompt composition', () => {
     )
     await router.__testing!.flushDebounce(key)
 
-    expect(sessions[0]!.prompts[0]).toContain('@octocat (octocat): @typeey can you review this PR')
+    expect(sessions[0]!.prompts[0]).toContain('@octocat: @typeey can you review this PR')
     expect(sessions[0]!.prompts[0]).not.toContain('<@12345>')
   })
 
@@ -1277,9 +1277,9 @@ describe('ChannelRouter engagement and prompt composition', () => {
     await router.__testing!.flushDebounce(KEY)
     const prompt = sessions[0]!.prompts[0]!
     expect(prompt).toContain('Recent context (not addressed to you, for awareness only)')
-    expect(prompt).toContain('<@bob> (bob): unrelated')
+    expect(prompt).toContain('bob <@bob>: unrelated')
     expect(prompt).toContain('Current message')
-    expect(prompt).toContain('<@alice> (alice): hey bot')
+    expect(prompt).toContain('alice <@alice>: hey bot')
     expect(prompt.indexOf('unrelated')).toBeLessThan(prompt.indexOf('hey bot'))
   })
 
@@ -1402,7 +1402,7 @@ describe('ChannelRouter engagement and prompt composition', () => {
     const prompt = sessions[0]!.prompts[0]!
     expect(prompt).not.toContain('Recent context')
     expect(prompt).toContain('## Current message (addressed to you)')
-    expect(prompt).toContain('<@alice> (alice): hey bot')
+    expect(prompt).toContain('alice <@alice>: hey bot')
   })
 
   test('engaged turn carries the history-interpretation note above the current-message header', async () => {
@@ -1472,7 +1472,7 @@ describe('ChannelRouter engagement and prompt composition', () => {
     await router.route(inbound({ isBotMention: false, text: 'hello there' }))
     await router.__testing!.flushDebounce(KEY)
     expect(sessions[0]!.prompts).toHaveLength(1)
-    expect(sessions[0]!.prompts[0]).toContain('<@alice> (alice): hello there')
+    expect(sessions[0]!.prompts[0]).toContain('alice <@alice>: hello there')
   })
 
   test('solo-human fallback turns off once a second human posts', async () => {
@@ -8079,7 +8079,7 @@ describe('ChannelRouter peer-bot loop guard', () => {
     await router.__testing!.flushDebounce(KEY)
 
     // then
-    expect(sessions[0]!.prompts[0]).toContain('<@peer1> (PeerBot) [bot]: hi from a bot')
+    expect(sessions[0]!.prompts[0]).toContain('PeerBot <@peer1> [bot]: hi from a bot')
   })
 
   test('human author lines are NOT tagged with [bot]', async () => {
@@ -8092,7 +8092,7 @@ describe('ChannelRouter peer-bot loop guard', () => {
     await router.__testing!.flushDebounce(KEY)
 
     // then
-    expect(sessions[0]!.prompts[0]).toContain('<@alice> (alice): hi from alice')
+    expect(sessions[0]!.prompts[0]).toContain('alice <@alice>: hi from alice')
     expect(sessions[0]!.prompts[0]).not.toContain('[bot]')
   })
 
@@ -8117,7 +8117,7 @@ describe('ChannelRouter peer-bot loop guard', () => {
     await router.__testing!.flushDebounce(KEY)
 
     // then
-    expect(sessions[0]!.prompts[0]).toContain('<@peer1> (PeerBot) [bot]: ')
+    expect(sessions[0]!.prompts[0]).toContain('PeerBot <@peer1> [bot]: ')
   })
 })
 
@@ -10005,7 +10005,7 @@ describe('ChannelRouter injectSubagentCompletionReminder', () => {
     expect(prompt).toContain(`> <@bob>: ${'x'.repeat(QUOTED_REPLY_EXCERPT_MAX_CHARS - 1)}…`)
     expect(prompt).not.toContain('tail')
     expect(prompt).toContain('> <@carol>: linked context')
-    expect(prompt.indexOf('> <@bob>:')).toBeLessThan(prompt.indexOf(`<@alice> (alice): actual reply`))
+    expect(prompt.indexOf('> <@bob>:')).toBeLessThan(prompt.indexOf(`alice <@alice>: actual reply`))
   })
 
   test('share-only Slack referenceContext renders even when raw text is empty', async () => {
@@ -10033,8 +10033,8 @@ describe('ChannelRouter injectSubagentCompletionReminder', () => {
 
     const prompt = sessions[0]!.prompts[0] ?? ''
     expect(prompt).toContain('> <@UBOB>: shared message body')
-    expect(prompt).toContain('<@alice> (alice): ')
-    expect(prompt.indexOf('> <@UBOB>: shared message body')).toBeLessThan(prompt.indexOf('<@alice> (alice): '))
+    expect(prompt).toContain('alice <@alice>: ')
+    expect(prompt.indexOf('> <@UBOB>: shared message body')).toBeLessThan(prompt.indexOf('alice <@alice>: '))
   })
 
   test("reminder lookup skips destroyed sessions (channels GC'd while subagent was running drops the reminder)", async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5091,7 +5091,7 @@ function formatAuthorLine(
 ): string {
   const tag = authorIsBot ? ' [bot]' : ''
   const stamp = ts > 0 ? `[${new Date(ts).toISOString()}] ` : ''
-  return `${stamp}${formatAuthorReference(adapter, authorId, authorName)} (${authorName})${tag}: ${capObservedText(text, maxChars)}`
+  return `${stamp}${formatAuthorAttribution(adapter, authorId, authorName)}${tag}: ${capObservedText(text, maxChars)}`
 }
 
 // Cap by whole code points so truncation never splits a surrogate pair (emoji,
@@ -5133,6 +5133,36 @@ function formatInboundPromptLines(
 }
 
 export type { QuoteAnchorSource } from './types'
+
+export function formatAuthorAttribution(adapter: AdapterId, authorId: string, authorName: string): string {
+  const displayName = authorName.trim()
+  const hasDisplayName = displayName !== ''
+  const id = authorId.trim()
+  if (id === '') return hasDisplayName ? displayName : authorId
+
+  switch (adapter) {
+    case 'slack':
+    case 'slack-bot':
+    case 'discord':
+    case 'discord-bot': {
+      const mention = `<@${id}>`
+      return hasDisplayName ? `${displayName} ${mention}` : mention
+    }
+    case 'github': {
+      const login = /^\d+$/.test(id) && hasDisplayName ? displayName : id
+      const handle = login.startsWith('@') ? login : `@${login}`
+      if (!hasDisplayName) return handle
+      const normalizedDisplayName = displayName.startsWith('@') ? displayName : `@${displayName}`
+      return normalizedDisplayName === handle ? handle : `${displayName} (${handle})`
+    }
+    case 'telegram-bot':
+    case 'webex':
+    case 'webex-bot':
+    case 'line':
+    case 'kakaotalk':
+      return hasDisplayName ? `${displayName} <${id}>` : id
+  }
+}
 
 // Picks the right author syntax for the platform so prompts and rendered
 // quote anchors use the same form the user would type in that channel.


### PR DESCRIPTION
## Background

The per-line transcript the agent reads attributes each message with a single author token, and that token is **inconsistent across adapters**. Slack/Discord render `<@id> (name)`; KakaoTalk/Telegram/Webex/LINE render the **display name alone, with no stable identifier**.

On the name-only adapters this is the root of a real recall failure. A KakaoTalk participant's display name is volatile (a nickname that can change, and on KakaoTalk is the *only* identity field the inbound carries). When the transcript surfaces only that nickname with no `authorId` beside it, neither the agent nor the `memory-logger` (which reads the same transcript text and stamps the `who` provenance field) can anchor a person to a stable key. Concretely: a participant addressed in-chat by one nickname but stored under a different display name can never be resolved, because the stable id that would link them is never visible in the text the model reasons over.

## Summary

Add a transcript-only `formatAuthorAttribution(adapter, authorId, authorName)` that renders a uniform **`Name <id>`** pair on every channel, and switch `formatAuthorLine` to use it:

| Adapter | Rendered |
|---|---|
| Slack / Discord | `Alice <@U_ALICE>` |
| KakaoTalk / Telegram / Webex / LINE | `민준 <999000111>` |
| GitHub (name == login) | `@octocat` |
| GitHub (name != login) | `Mona Lisa (@octocat)` |
| empty display name | identifier alone (`<@U_ALICE>` / `999000111`) |

**Why a separate helper and not a change to `formatAuthorReference`:** `formatAuthorReference` is also the mention token used by `renderQuoteAnchor` to build the user-facing `> <@id>: …` blockquotes posted **back** to Slack/Discord, where `<@id>` must stay a real, ping-capable mention. Rewriting it to carry the name would corrupt those mentions (PR #374 intent). So the mention path is left byte-identical and only the agent-facing transcript path changes. The previous `${ref} (${name})` shape would also double-print the name once the ref carried it; the new helper produces exactly one `Name <id>`.

## What this does NOT do

- Does **not** change `formatAuthorReference` / `renderQuoteAnchor` — outbound user-facing mentions are unchanged (asserted by the quote-anchor tests).
- Does **not** change `renderParticipantAddressing` (the system-prompt participant block). Its leading token is a copy-pasteable addressing/mention contract (issues #188/#374); reordering it to `Name <id>` would break Discord/Slack mention emission. Left intentionally as-is.
- Does **not** touch memory, retrieval, config, or add any config field. This is purely the transcript author-rendering surface.

## Review notes

- Load-bearing change: `formatAuthorLine` now calls the new `formatAuthorAttribution` instead of `formatAuthorReference(...) + (name)`. The invariant to verify is that **the quote-anchor / mention output is unchanged** — covered by `router.quote-anchor.test.ts` (the `> <@bob>:` / `> <@UBOB>:` assertions).
- New unit tests cover Slack, Discord, KakaoTalk (CJK — `민준 <999000111>`), GitHub login-vs-name, and empty-name fallback. Multilingual coverage is required for this repo; the CJK case is the relevant one here (identity rendering, not NL matching — no `\b` involved).
- This is the first, lowest-risk slice of a larger people-memory effort; the alias-resolution and person-record work that builds on having a stable id in the transcript is deferred to follow-ups.