### PR TITLE
fix(hostd): register restarted child in-process so the hostd env triple survives renewal restarts

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -130,6 +130,46 @@ describe('buildHostdRestart', () => {
     expect(result).toBeNull()
   })
 
+  test('forwards the daemon-supplied currentHostDaemon into start()', async () => {
+    const starts: StartOptions[] = []
+    const register = async (): Promise<{ ok: true }> => ({ ok: true })
+    const restart = buildHostdRestart('/repo/src/cli/index.ts', {
+      validateConfig: () => ({ ok: true }),
+      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
+      loadConfigSync: () => configSchema.parse({ port: 61234 }),
+      start: async (opts) => {
+        starts.push(opts)
+        return startOk(opts)
+      },
+    })
+
+    const result = await restart({
+      containerName: 'agent',
+      cwd: '/agent-dir',
+      currentHostDaemon: { httpPort: 8974, register },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(starts[0]?.currentHostDaemon).toEqual({ httpPort: 8974, register })
+  })
+
+  test('omits currentHostDaemon when the daemon does not supply one', async () => {
+    const starts: StartOptions[] = []
+    const restart = buildHostdRestart('/repo/src/cli/index.ts', {
+      validateConfig: () => ({ ok: true }),
+      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
+      loadConfigSync: () => configSchema.parse({ port: 61234 }),
+      start: async (opts) => {
+        starts.push(opts)
+        return startOk(opts)
+      },
+    })
+
+    await restart({ containerName: 'agent', cwd: '/agent-dir' })
+
+    expect(starts[0]).not.toHaveProperty('currentHostDaemon')
+  })
+
   test('omitted build defaults to forceBuild:false', async () => {
     const starts: StartOptions[] = []
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty'
 
 import { loadConfigSync, validateConfig, type Config, type ValidateConfigResult } from '@/config'
 import { start, stop, type StartOptions, type StartResult, type StopResult } from '@/container'
+import { createCurrentHostDaemonHolder } from '@/hostd/current-host-daemon'
 import { startDaemon, type DaemonLogEvent, type RestartPreflight } from '@/hostd/daemon'
 import { createKakaoRenewalManager } from '@/hostd/kakao-renewal-manager'
 import { createPortbrokerManager } from '@/hostd/portbroker-manager'
@@ -26,6 +27,10 @@ export const hostdCommand = defineCommand({
     })
 
     const hostdRestart = buildHostdRestart(cliEntry, defaultRestartDeps, version)
+    // Renewal restarts call hostdRestart directly (not via the restart RPC), so
+    // they must thread currentHostDaemon themselves to get the in-process
+    // registration path. The daemon populates this holder once booted.
+    const currentHostDaemonHolder = createCurrentHostDaemonHolder()
     const kakaoRenewal = createKakaoRenewalManager({
       onLog: (event) => writeLogLine(formatLog(event)),
       onRenewalOk: async ({ containerName, cwd }) => {
@@ -33,7 +38,8 @@ export const hostdCommand = defineCommand({
         // up the renewed tokens from secrets.json. Without this, the cron
         // would write fresh tokens but the running adapter would keep using
         // the old token in its closure and still 401 at the ~7-day wall.
-        const result = await hostdRestart({ containerName, cwd })
+        const currentHostDaemon = await currentHostDaemonHolder.ready()
+        const result = await hostdRestart({ containerName, cwd, currentHostDaemon })
         if (!result.ok) throw new Error(result.reason)
       },
       shouldRenew: ({ cwd }) => kakaoChannelConfigured(cwd),
@@ -45,7 +51,8 @@ export const hostdCommand = defineCommand({
         // secrets.json. Without this, the cron writes a fresh token but the
         // running adapter keeps the old token in its getToken closure and still
         // 401s on every outbound REST call + KMS key fetch.
-        const result = await hostdRestart({ containerName, cwd })
+        const currentHostDaemon = await currentHostDaemonHolder.ready()
+        const result = await hostdRestart({ containerName, cwd, currentHostDaemon })
         if (!result.ok) throw new Error(result.reason)
       },
       shouldRenew: ({ cwd }) => webexChannelConfigured(cwd),
@@ -58,6 +65,7 @@ export const hostdCommand = defineCommand({
       portbroker,
       kakaoRenewal,
       webexRenewal,
+      currentHostDaemonHolder,
       restartPreflight: buildHostdRestartPreflight(cliEntry, version, defaultPreflightDeps),
       restart: hostdRestart,
     })
@@ -96,7 +104,7 @@ export function buildHostdRestart(
   deps: HostdRestartDeps = defaultRestartDeps,
   daemonVersion?: string,
 ): SupervisorRestart {
-  return async ({ containerName, cwd, build = false }) => {
+  return async ({ containerName, cwd, build = false, currentHostDaemon }) => {
     const drift = await detectSourceDrift(cliEntry, daemonVersion)
     if (drift) return { ok: false, reason: drift }
 
@@ -114,6 +122,7 @@ export function buildHostdRestart(
       forceBuild: build,
       cliEntry,
       reuseCurrentHostDaemon: true,
+      ...(currentHostDaemon ? { currentHostDaemon } : {}),
     })
     if (!startResult.ok) return { ok: false, reason: `start failed: ${startResult.reason}` }
     return { ok: true }

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -26,6 +26,8 @@ export {
   refreshDockerfile,
   refreshGitignore,
   start,
+  type CurrentHostDaemon,
+  type HostDaemonRegisterPayload,
   type HostDaemonStatus,
   type PlanStartOptions,
   type StartOptions,

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -20,6 +20,7 @@ import {
   shouldMirrorDevSource,
   shouldMountWindowsDevSource,
   start,
+  type HostDaemonRegisterPayload,
 } from './start'
 
 type ParsedBindMount = { src: string; dst: string; readonly: boolean }
@@ -2639,6 +2640,106 @@ describe('start (composition)', () => {
       else process.env.TYPECLAW_HOME = previousHome
       await rm(home, { recursive: true, force: true })
     }
+  })
+
+  test('currentHostDaemon registers in-process and injects the hostd env triple without any socket RPC', async () => {
+    // given: a daemon-owned restart supplies its own httpPort + in-process registrar
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+    const { exec } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    const registered: HostDaemonRegisterPayload[] = []
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      cliEntry: '/nonexistent/cli.ts',
+      reuseCurrentHostDaemon: true,
+      currentHostDaemon: {
+        httpPort: 49999,
+        register: async (payload) => {
+          registered.push(payload)
+          return { ok: true }
+        },
+      },
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.hostd.state).toBe('registered')
+    // then: the container is registered in-process (not over a socket)
+    expect(registered).toHaveLength(1)
+    expect(registered[0]).toMatchObject({ containerName: basename(root), cwd: root, wsHostPort: 8973 })
+    // then: the env triple points at the daemon's own http port
+    expect(result.plan.runArgs).toContain('TYPECLAW_HOSTD_URL=http://host.docker.internal:49999')
+    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_TOKEN=${registered[0]!.restartToken}`)
+    expect(result.plan.runArgs).toContain(`TYPECLAW_HOSTD_BROKER_TOKEN=${registered[0]!.brokerToken}`)
+  })
+
+  test('currentHostDaemon register failure still boots the container (degraded, never dead)', async () => {
+    // given: in-process registration fails — the daemon-owned restart must not strand the agent
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      cliEntry: '/nonexistent/cli.ts',
+      reuseCurrentHostDaemon: true,
+      currentHostDaemon: {
+        httpPort: 49999,
+        register: async () => ({ ok: false, reason: 'daemon stopping' }),
+      },
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    // then: the container still launches, but without the hostd env triple
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'daemon stopping' })
+    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
+    expect(result.plan.runArgs.find((a) => a.startsWith('TYPECLAW_HOSTD_URL='))).toBeUndefined()
+  })
+
+  test('a throwing in-process registrar degrades to a booting container, never aborts the restart', async () => {
+    // given: the in-process registrar rejects (e.g. a throw from the shared registration path)
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    await writeTypeclawConfig(root)
+    const { exec, calls } = fakeDockerExec({ imageExists: true, container: { exists: false } })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      cliEntry: '/nonexistent/cli.ts',
+      reuseCurrentHostDaemon: true,
+      currentHostDaemon: {
+        httpPort: 49999,
+        register: async () => {
+          throw new Error('registry write failed')
+        },
+      },
+      ensureDeps: noEnsureDeps,
+      ...bypassVerify,
+    })
+
+    // then: the throw is normalized to a degraded boot, not an aborted start
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.hostd).toEqual({ state: 'unavailable', reason: 'registry write failed' })
+    expect(calls.find((c) => c.args[0] === 'run')).toBeDefined()
+    expect(result.plan.runArgs.find((a) => a.startsWith('TYPECLAW_HOSTD_URL='))).toBeUndefined()
   })
 
   test('forceBuild=false skips build entirely when image already exists', async () => {

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { isAbsolute, join, relative, resolve } from 'node:path'
 
 import { agentUsesVector } from '@/bundled-plugins/memory/vector/config'
-import { expandMountPath, loadConfigSync, withDefaultPlugins, type Config } from '@/config'
+import { expandMountPath, loadConfigSync, withDefaultPlugins, type Config, type PortForward } from '@/config'
 import { commitGitignoreWithUntracks, untrackTrulyIgnoredFiles } from '@/git/reconcile-ignored'
 import { commitSystemFile as commitSystemFileShared } from '@/git/system-commit'
 import { send as sendToDaemon } from '@/hostd/client'
@@ -94,6 +94,27 @@ export type HostDaemonControl = {
   brokerToken: string
 }
 
+// Mirrors the `register` RPC's fields minus `kind`; shared by socket and
+// in-process registration so both paths record the same registry entry.
+export type HostDaemonRegisterPayload = {
+  containerName: string
+  cwd: string
+  restartToken: string
+  wsHostPort: number
+  portForward: PortForward
+  brokerToken: string
+}
+
+// Injected only on the daemon-owned restart path (reuseCurrentHostDaemon).
+// The daemon registers the container in-process and reports its own HTTP port,
+// so the restart skips the `http-info`/`register` self-RPCs — those round-trips
+// can time out under IPC congestion and silently drop the TYPECLAW_HOSTD_* env
+// triple, booting a container whose hostd-bridged adapters can't construct.
+export type CurrentHostDaemon = {
+  httpPort: number
+  register: (payload: HostDaemonRegisterPayload) => Promise<{ ok: true } | { ok: false; reason: string }>
+}
+
 export type StartOptions = {
   cwd: string
   preferredHostPort: number
@@ -106,6 +127,10 @@ export type StartOptions = {
   // Hostd's supervisor restart callback already runs inside the daemon process.
   // Reusing that daemon avoids a self-shutdown when disk source has drifted.
   reuseCurrentHostDaemon?: boolean
+  // Set by hostd's supervisor restart wrapper. When present, registration goes
+  // through the daemon in-process (no socket round-trips), so the env triple is
+  // injected from known-good values even under IPC congestion. See type docs.
+  currentHostDaemon?: CurrentHostDaemon
   ensureDeps?: (cwd: string, opts?: { force?: boolean }) => Promise<EnsureDepsResult>
   // Test seam for the typeclaw-version auto-upgrade. Production callers omit
   // this and get the real autoUpgradeTypeclawDep (which reads the CLI's own
@@ -183,6 +208,7 @@ export async function start({
   allocatePort = findFreePort,
   cliEntry,
   reuseCurrentHostDaemon = false,
+  currentHostDaemon,
   ensureDeps = (dir, opts) => ensureDepsInstalled({ cwd: dir, ...opts }),
   autoUpgrade = (dir) => autoUpgradeTypeclawDep({ cwd: dir, localSpec: resolveTypeclawSpec(dir) }),
   forceBunUpdate = runBunUpdate,
@@ -424,7 +450,7 @@ export async function start({
     // Register AFTER port allocation so the daemon's portbroker has the right
     // wsHostPort. Re-register on TOCTOU retry below if the port changes.
     let hostd: PreparedHostDaemonStatus = cliEntry
-      ? await registerWithDaemon({ cwd, containerName, cliEntry, hostPort, reuseCurrentHostDaemon })
+      ? await registerWithDaemon({ cwd, containerName, cliEntry, hostPort, reuseCurrentHostDaemon, currentHostDaemon })
       : { state: 'disabled' as const }
     let hostdControl = hostd.state === 'registered' ? hostd.control : undefined
 
@@ -503,7 +529,14 @@ export async function start({
       }
       hostPort = await allocatePort(0)
       if (cliEntry) {
-        hostd = await registerWithDaemon({ cwd, containerName, cliEntry, hostPort, reuseCurrentHostDaemon })
+        hostd = await registerWithDaemon({
+          cwd,
+          containerName,
+          cliEntry,
+          hostPort,
+          reuseCurrentHostDaemon,
+          currentHostDaemon,
+        })
         hostdControl = hostd.state === 'registered' ? hostd.control : undefined
       }
       plan = await planStart({
@@ -1158,27 +1191,47 @@ async function registerWithDaemon({
   cliEntry,
   hostPort,
   reuseCurrentHostDaemon,
+  currentHostDaemon,
 }: {
   cwd: string
   containerName: string
   cliEntry: string
   hostPort: number
   reuseCurrentHostDaemon: boolean
+  currentHostDaemon: CurrentHostDaemon | undefined
 }): Promise<PreparedHostDaemonStatus> {
-  const prepared = reuseCurrentHostDaemon ? await useCurrentHostDaemon() : await ensureDaemonWithBridgeRetry(cliEntry)
-  if (!prepared.ok) return { state: 'unavailable', reason: prepared.reason }
   const token = randomBytes(32).toString('base64url')
   const brokerToken = randomBytes(32).toString('base64url')
   const cfg = await loadTypeclawConfig(cwd)
-  const reply = await sendToDaemon({
-    kind: 'register',
+  const payload: HostDaemonRegisterPayload = {
     containerName,
     cwd,
     restartToken: token,
     wsHostPort: hostPort,
     portForward: cfg.portForward,
     brokerToken,
-  })
+  }
+
+  if (currentHostDaemon) {
+    // A thrown/rejected registrar must degrade to a still-booting container,
+    // not abort start() — the daemon-owned restart already stopped the old
+    // container, so ok:false here would leave the agent dead.
+    let reply: { ok: true } | { ok: false; reason: string }
+    try {
+      reply = await currentHostDaemon.register(payload)
+    } catch (error) {
+      return { state: 'unavailable', reason: error instanceof Error ? error.message : String(error) }
+    }
+    if (!reply.ok) return { state: 'unavailable', reason: reply.reason }
+    return {
+      state: 'registered',
+      control: { url: `http://${CONTAINER_HOSTD_HOST}:${currentHostDaemon.httpPort}`, token, brokerToken },
+    }
+  }
+
+  const prepared = reuseCurrentHostDaemon ? await useCurrentHostDaemon() : await ensureDaemonWithBridgeRetry(cliEntry)
+  if (!prepared.ok) return { state: 'unavailable', reason: prepared.reason }
+  const reply = await sendToDaemon({ kind: 'register', ...payload })
   if (!reply.ok) return { state: 'unavailable', reason: reply.reason }
   return {
     state: 'registered',

--- a/src/hostd/current-host-daemon.test.ts
+++ b/src/hostd/current-host-daemon.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { CurrentHostDaemon } from '@/container'
+
+import { createCurrentHostDaemonHolder } from './current-host-daemon'
+
+describe('createCurrentHostDaemonHolder', () => {
+  test('ready() resolves with the value once set, even when awaited before set', async () => {
+    // given: a caller awaits ready() before the daemon has booted
+    const holder = createCurrentHostDaemonHolder()
+    const value: CurrentHostDaemon = { httpPort: 8974, register: async () => ({ ok: true }) }
+    const pending = holder.ready()
+
+    // when: the daemon populates the holder after boot
+    holder.set(value)
+
+    // then: the earlier awaiter receives the populated value
+    expect(await pending).toBe(value)
+  })
+
+  test('ready() resolves immediately when set has already happened', async () => {
+    const holder = createCurrentHostDaemonHolder()
+    const value: CurrentHostDaemon = { httpPort: 49999, register: async () => ({ ok: true }) }
+    holder.set(value)
+
+    expect(await holder.ready()).toBe(value)
+  })
+})

--- a/src/hostd/current-host-daemon.ts
+++ b/src/hostd/current-host-daemon.ts
@@ -1,0 +1,21 @@
+import type { CurrentHostDaemon } from '@/container'
+
+// Shared between the daemon (which alone knows its HTTP port + in-process
+// registrar, both available only after boot) and the renewal callbacks in
+// cli/hostd.ts (constructed before the daemon). `ready()` lets a caller that
+// fires before boot await population instead of racing to a null read.
+export type CurrentHostDaemonHolder = {
+  set: (value: CurrentHostDaemon) => void
+  ready: () => Promise<CurrentHostDaemon>
+}
+
+export function createCurrentHostDaemonHolder(): CurrentHostDaemonHolder {
+  let resolveReady: (value: CurrentHostDaemon) => void
+  const readyPromise = new Promise<CurrentHostDaemon>((resolve) => {
+    resolveReady = resolve
+  })
+  return {
+    set: (value) => resolveReady(value),
+    ready: () => readyPromise,
+  }
+}

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -10,6 +10,7 @@ import { isWindows } from '@/shared'
 import { expectStable, waitFor } from '@/test-helpers/wait-for'
 
 import { isDaemonReachable, send, sendHttp } from './client'
+import { createCurrentHostDaemonHolder } from './current-host-daemon'
 import { startDaemon, type Daemon, type PortbrokerCallbacks, type PortbrokerStartInput } from './daemon'
 import type { KakaoRenewalCallbacks, KakaoRenewalStartInput } from './kakao-renewal-manager'
 import { registrationFilePath, registrationsDir, socketPath } from './paths'
@@ -268,6 +269,52 @@ describe('startDaemon', () => {
 
     await waitFor(() => restartCalls.length > 0)
     expect(restartCalls).toEqual([{ containerName: 'coder', cwd: '/agent/coder', build: false }])
+  })
+
+  test('restart RPC supplies the supervisor with an in-process currentHostDaemon (no socket self-RPC)', async () => {
+    const restartCalls: Array<{ containerName: string; currentHostDaemon?: { httpPort: number } }> = []
+    daemon = await startDaemon({
+      exec: fakeExec(new Set(['coder'])),
+      gcIntervalMs: 1_000_000,
+      restart: async ({ containerName, currentHostDaemon }) => {
+        restartCalls.push({
+          containerName,
+          ...(currentHostDaemon ? { currentHostDaemon: { httpPort: currentHostDaemon.httpPort } } : {}),
+        })
+        return { ok: true }
+      },
+    })
+
+    await send({ kind: 'register', containerName: 'coder', cwd: '/agent/coder' })
+    const ack = await send({ kind: 'restart', containerName: 'coder' })
+    expect(ack.ok).toBe(true)
+
+    await waitFor(() => restartCalls.length > 0)
+    // then: the daemon injected its own http port so start() skips the http-info RPC
+    expect(restartCalls[0]?.currentHostDaemon?.httpPort).toBeGreaterThan(0)
+  })
+
+  test('populates the currentHostDaemon holder with an in-process registrar once booted', async () => {
+    const holder = createCurrentHostDaemonHolder()
+    daemon = await startDaemon({
+      exec: fakeExec(),
+      gcIntervalMs: 1_000_000,
+      currentHostDaemonHolder: holder,
+    })
+
+    // then: the holder is populated and its registrar records a registration in-process
+    const current = await holder.ready()
+    expect(current.httpPort).toBeGreaterThan(0)
+    const reply = await current.register({
+      containerName: 'coder',
+      cwd: '/agent/coder',
+      restartToken: 'tok',
+      wsHostPort: 8973,
+      portForward: { allow: [] },
+      brokerToken: 'broker',
+    })
+    expect(reply).toEqual({ ok: true })
+    expect(daemon.registered()).toContain('coder')
   })
 
   test('restart RPC forwards build:true to the supervisor', async () => {

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -4,7 +4,7 @@ import { createServer, type Server, type Socket as NetSocket } from 'node:net'
 import { join } from 'node:path'
 
 import type { PortForward } from '@/config'
-import { defaultDockerExec, type DockerExec } from '@/container'
+import { defaultDockerExec, type DockerExec, type HostDaemonRegisterPayload } from '@/container'
 import type { PortForwardEvent } from '@/portbroker'
 import {
   discordChannelBlockSchema,
@@ -17,6 +17,7 @@ import { SecretsBackend } from '@/secrets/storage'
 import { isWindows } from '@/shared'
 
 import { isDaemonReachable } from './client'
+import type { CurrentHostDaemonHolder } from './current-host-daemon'
 import type { KakaoRenewalCallbacks, KakaoRenewalLogEvent } from './kakao-renewal-manager'
 import { ensureDirs, registrationFilePath, registrationsDir, socketPath } from './paths'
 import type {
@@ -71,6 +72,10 @@ export type DaemonOptions = {
   // ticks hourly because Webex password tokens live ~27h (see
   // webex-renewal-manager.ts). Omit when the agent has no webex channel.
   webexRenewal?: WebexRenewalCallbacks
+  // Populated once the daemon is booted so direct callers of the restart
+  // (the renewal callbacks in cli/hostd.ts) get the in-process registration
+  // path instead of the socket self-RPC. Omit in tests that don't exercise it.
+  currentHostDaemonHolder?: CurrentHostDaemonHolder
 }
 
 export type RestartPreflight = (input: {
@@ -400,7 +405,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     }
   }
 
-  const handleRegister = async (req: RegisterPayload): Promise<RpcResponse> => {
+  const registerContainer = async (req: RegisterPayload): Promise<RpcResponse> => {
     if (stopped) return { ok: false, reason: 'daemon stopping' }
     return runSerially(req.containerName, async () => {
       if (stopped) return { ok: false, reason: 'daemon stopping' }
@@ -416,6 +421,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       return { ok: true }
     })
   }
+
+  const handleRegister = async (req: RegisterPayload): Promise<RpcResponse> => registerContainer(req)
 
   const handleDeregister = async (req: { containerName: string }): Promise<RpcResponse> =>
     runSerially(req.containerName, async () => {
@@ -449,6 +456,17 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     return { ok: true, result }
   }
 
+  // Lets the supervisor's restart re-register the child in-process instead of
+  // over the socket. Awaits restore for the same no-mutation-before-restore
+  // invariant the socket dispatcher enforces before handleRegister.
+  const registerCurrentChild = async (
+    payload: HostDaemonRegisterPayload,
+  ): Promise<{ ok: true } | { ok: false; reason: string }> => {
+    await awaitRestored()
+    const reply = await registerContainer(payload)
+    return reply.ok ? { ok: true } : { ok: false, reason: reply.reason }
+  }
+
   // Auth: only restart containers that registered with this daemon. The
   // socket is 0o600 + UID-bound, but inside a container any process that
   // reaches the mounted socket could otherwise restart any peer container on
@@ -465,7 +483,12 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       ? await opts.restartPreflight({ containerName: req.containerName, cwd, build: req.build })
       : null
     if (preflight) return preflight
-    const ack = supervisor.scheduleRestart({ containerName: req.containerName, cwd, build: req.build })
+    const ack = supervisor.scheduleRestart({
+      containerName: req.containerName,
+      cwd,
+      build: req.build,
+      currentHostDaemon: { httpPort, register: registerCurrentChild },
+    })
     if (!ack.ok) return ack
     const result: RestartResult = { containerName: req.containerName, scheduled: true }
     return { ok: true, result }
@@ -699,6 +722,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   }
   httpPort = httpServer.port ?? 0
   log({ kind: 'daemon-http-listening', host: httpHostname, port: httpPort })
+  opts.currentHostDaemonHolder?.set({ httpPort, register: registerCurrentChild })
 
   const sockets = new Set<NetSocket>()
   const listener = createServer((socket) => {

--- a/src/hostd/supervisor.ts
+++ b/src/hostd/supervisor.ts
@@ -1,3 +1,5 @@
+import type { CurrentHostDaemon } from '@/container'
+
 import type { Response } from './protocol'
 
 export type SupervisorRestart = (input: {
@@ -8,6 +10,9 @@ export type SupervisorRestart = (input: {
   // image even if it already exists. Default false matches the host-side
   // `typeclaw restart` (no `--build` flag) behavior.
   build?: boolean
+  // Injected by the daemon so the restart registers the container in-process
+  // instead of over the socket — see CurrentHostDaemon docs in src/container.
+  currentHostDaemon?: CurrentHostDaemon
 }) => Promise<{ ok: true } | { ok: false; reason: string }>
 
 export type SupervisorOptions = {
@@ -20,7 +25,12 @@ export type SupervisorLogEvent =
   | { kind: 'restart-failed'; containerName: string; reason: string }
 
 export type Supervisor = {
-  scheduleRestart: (input: { containerName: string; cwd: string; build?: boolean }) => Response
+  scheduleRestart: (input: {
+    containerName: string
+    cwd: string
+    build?: boolean
+    currentHostDaemon?: CurrentHostDaemon
+  }) => Response
 }
 
 export type SupervisorBuildOptions = {
@@ -36,7 +46,7 @@ export type SupervisorBuildOptions = {
 // surfaced via the log channel; there is no connected client to receive them.
 export function buildSupervisor({ restart, onLog, isStopped }: SupervisorBuildOptions): Supervisor {
   return {
-    scheduleRestart: ({ containerName, cwd, build = false }): Response => {
+    scheduleRestart: ({ containerName, cwd, build = false, currentHostDaemon }): Response => {
       if (isStopped()) return { ok: false, reason: 'daemon stopping' }
       onLog({ kind: 'restart-scheduled', containerName, build })
       void runRestart()
@@ -44,7 +54,12 @@ export function buildSupervisor({ restart, onLog, isStopped }: SupervisorBuildOp
 
       async function runRestart(): Promise<void> {
         try {
-          const result = await restart({ containerName, cwd, build })
+          const result = await restart({
+            containerName,
+            cwd,
+            build,
+            ...(currentHostDaemon ? { currentHostDaemon } : {}),
+          })
           if (result.ok) onLog({ kind: 'restart-completed', containerName })
           else onLog({ kind: 'restart-failed', containerName, reason: result.reason })
         } catch (error) {


### PR DESCRIPTION
## Background

Channel adapters for line/kakaotalk/webex call `resolveHostdContainerCredentials(env)` at boot, which returns null and skips the adapter when any of the three hostd env vars (`TYPECLAW_HOSTD_URL`, `TYPECLAW_HOSTD_TOKEN`, `TYPECLAW_HOSTD_BROKER_TOKEN`) is missing. Those vars are injected by the env-injection block in `start()`, which is gated `if (hostdControl)`. On the reuse path, `hostdControl` was set by `registerWithDaemon`, which re-discovered the running daemon by sending an `http-info` RPC over the unix control socket.

The silent failure path: webex/kakao token renewal mints a fresh token then restarts the container so the in-memory client picks it up. The supervisor's stop → start sequence fires `registerWithDaemon`'s self-RPC again. Under IPC congestion — observed: duplicate renewal ticks firing in the same ~2ms window during the restart — that single `http-info` round-trip could time out. `registerWithDaemon` returned `state: 'unavailable'`, `hostdControl` became undefined, and the env-injection block silently skipped all three vars from `docker run`. The container booted (docker run succeeded, restart reported success), but every hostd-bridged adapter was dead with "adapter could not be constructed; skipping" — no surfaced error, no recovery.

Production observation: an affected agent had only `TYPECLAW_CONTAINER_NAME` set in its environment, missing the other two hostd vars; every sibling agent on the same host had all three. Secrets were fully present throughout; this was purely the missing hostd env triple.

The same restart path is taken by the agent's self-restart tool and `typeclaw restart`, not just token renewal — all route through hostd's supervisor restart.

## Summary

The daemon is restarting its own child, so it already knows its HTTP control port. There is no need to rediscover itself over a socket RPC that can time out.

This PR threads a `currentHostDaemon` value (its `httpPort` + an in-process registrar callback) from the daemon through the supervisor's restart wrapper and `buildHostdRestart` into `start()`. When present, `registerWithDaemon` skips both the `http-info` and `register` self-RPCs and builds the env triple from known-good in-process values.

The in-process registrar reuses the same registry code path as the socket `register` handler — extracted to `registerContainer`, not duplicated — and awaits boot-restore first, preserving the existing "no registry mutation before boot-restore completes" invariant.

**Why in-process and not "retry the http-info RPC then fail closed":** a hard constraint is that a renewal restart must never leave a previously-healthy agent dead. The supervisor does stop() then start(), so returning `ok: false` would strand the agent with nothing running. So the design (a) removes the race at its source for the common case, and (b) preserves crash-safety: if in-process registration still fails, the container boots degraded (without the triple) rather than failing the start. The non-reuse path (genuine first start / host CLI start that may need to spawn hostd) is unchanged.

## What this does NOT do

- Does not change the non-daemon-owned start path — `cliEntry && !reuseCurrentHostDaemon` keeps today's spawn/ensure behavior.
- Does not add a new fail-closed gate; that was explicitly rejected because it would crash a healthy agent on a renewal restart.
- Does not touch the unrelated GitHub-App-not-installed reconcile errors that may appear in the same logs.
- Does not change the secrets/encryption path; secrets were never the problem.

## Review notes

- **In-process registrar must await `awaitRestored()` before mutating the registry** — same invariant the socket dispatcher enforces before `handleRegister`. Verify this ordering in the registrar callback.
- **`registerContainer` is the extracted shared path.** `handleRegister` now delegates to it, so socket and in-process registration record identical registry entries. Any future change to what a registry entry contains needs to update only `registerContainer`.
- **Crash-safety invariant:** on the reuse path, registration failure degrades (boots without env triple) and never returns `ok: false`. This is what prevents a renewal restart from stranding a healthy agent.
- **`reuseCurrentHostDaemon: true` appears only in `buildHostdRestart`**, so the "daemon owns this restart" signal is reliable — there is no other caller that sets it.
- 4 new tests cover: in-process registration injects the env triple at the daemon's own http port with no socket RPC; in-process register failure still boots the container (degraded, never dead); `buildHostdRestart` forwards `currentHostDaemon` into `start()`; and omits it when absent.