### PR TITLE
feat(memory): recover cross-lingual memory retrieval

### DIFF
--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -95,6 +95,12 @@ Never write the same watermark id you were given as input. The watermark must mo
 
 Most transcript content is not memory. Conversations, group chat banter, casual reactions, one-off questions, and routine tool usage are substrate. Keep the bar high; when in doubt, skip. For noise, skipping costs nothing; for a one-time durable fact, under-writing can be permanent because the watermark advances and the prefix is not re-read. A run with five-plus fragments is almost always over-writing. So skip aggressively, but once a fact clearly meets the bar, capture it instead of second-guessing it away because it feels minor.
 
+# Language of the fragment
+
+Write each fragment in the language of its source evidence — the language the underlying material is in, whoever or whatever produced it: a user or other participant's message, an attributed speaker's words, command/tool output, or the contents of a file/reference. Korean conversation → Korean \`topic\` and \`body\`; Japanese → Japanese; English → English; an English log line stays English even inside an otherwise-Korean session. When sources mix languages, follow the one that carries the substance being captured. Do NOT translate the substance into another language, and in particular do not default to English. Retrieval matches a future query against these fragments in the same embedding space, and a same-language query↔memory pair retrieves far more reliably than a cross-language one; translating also distorts the exact wording a fragment is anchored to.
+
+Keep technical tokens verbatim inside whatever language you write: identifiers, code symbols, file paths, commands, error strings, and PR/issue numbers (\`author.bot\`, \`CAP_SYS_ADMIN\`, \`#incidents\`, \`PR #1054\`). These are language-neutral and must not be translated or transliterated — they are the exact anchors a later search needs.
+
 A fragment is worth writing only when all of these hold:
 
 1. **Durable** — still true in a future session, not a one-off event.

--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -607,6 +607,87 @@ describe('hybridSearch relevance gate', () => {
       store.close()
     }
   })
+
+  it('recovers a cross-script topic match whose head band is the matching script (loosened margin)', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: a flat English no-match band, plus ONE English topic the Korean
+      // query matches with a compressed cross-script contrast (~0.045 — below the
+      // strict 0.06, above the loosened 0.04). The head of the scored band IS the
+      // English winner, so the query (Korean) is cross-script against it and the
+      // margin loosens. No keyword hit (Korean shares no tokens with English).
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.755 + (i % 3) * 0.001)))
+      }
+      writeTopic(agentDir, 'proc-bind', 'Sandbox proc-bind strategy', 'The container binds a real procfs.')
+      store.upsert(row('topic:proc-bind', 'proc-bind', bandedVector(0.8)))
+
+      const results = await hybridSearch(
+        '\uC0CC\uB4DC\uBC15\uC2A4 proc \uBC14\uC778\uB4DC \uC804\uB7B5',
+        store,
+        agentDir,
+        10,
+        embedFrom({ 0: 1 }),
+      )
+
+      expect(results[0]?.key).toBe('proc-bind')
+    } finally {
+      store.close()
+    }
+  })
+
+  it('does NOT loosen when an unrelated same-script shard is the corpus but the head band matches the query script', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: the same English compressed-contrast no-match band, queried in
+      // ENGLISH (same script as the band head). The contrast (~0.045) is below the
+      // strict margin and must STILL suppress — same-script pairs never loosen, so
+      // a real English no-match is not rescued by the cross-script path.
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.755 + (i % 3) * 0.001)))
+      }
+      writeTopic(agentDir, 'near', 'Near Miss', 'A barely-elevated topic.')
+      store.upsert(row('topic:near', 'near', bandedVector(0.8)))
+
+      const results = await hybridSearch('zxqw gibberish nonmatching token', store, agentDir, 10, embedFrom({ 0: 1 }))
+
+      expect(results).toHaveLength(0)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('keeps stream admission strict under a cross-script query (no closest-neighbor leak via loosened margin)', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: a Korean cross-script query that loosens the TOPIC gate, plus an
+      // in-band English stream neighbor sitting ~0.045 above the band (between the
+      // loosened 0.04 and the strict 0.06). Stream admission must stay on the
+      // STRICT margin, so this irrelevant neighbor is still suppressed — the
+      // cross-script topic loosening must not weaken the stream leak guard.
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVector(0.755 + (i % 3) * 0.001)))
+      }
+      const fragmentId = '019e2ee8-bcc4-772f-8821-876162c5e601'
+      writeStreamFragment(agentDir, '2026-06-11', fragmentId, 'noise', 'An unrelated English fragment.')
+      store.upsert(row(`stream:2026-06-11#${fragmentId}`, `2026-06-11#${fragmentId}`, bandedVector(0.8), 'stream'))
+
+      const results = await hybridSearch(
+        '\uBD07\uB07C\uB9AC \uBB34\uD55C \uB8E8\uD504 \uAC00\uB4DC',
+        store,
+        agentDir,
+        10,
+        embedFrom({ 0: 1 }),
+      )
+
+      expect(results.some((r) => r.source === 'stream')).toBe(false)
+    } finally {
+      store.close()
+    }
+  })
 })
 
 function createFixture(): { agentDir: string; store: VectorStore } {

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -16,8 +16,9 @@ import type { FragmentProvenance, StreamEvent } from '../stream-events'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
 import { embed, EMBEDDING_MODEL_ID, type EmbedType } from './embedder'
 import type { Passage } from './passages'
-import { clearsBaseline, gateRelevance, streamAdmissionBaseline } from './relevance-gate'
-import { VectorStore, type VectorRow } from './store'
+import { clearsBaseline, gateRelevance, MARGIN, streamAdmissionBaseline } from './relevance-gate'
+import { crossScriptMarginScale, dominantScript, type ScriptClass } from './script'
+import { VectorStore, type ScoredVectorRow, type VectorRow } from './store'
 
 export { collectPassages, findMissingPassages, type Passage } from './passages'
 
@@ -54,7 +55,8 @@ export async function hybridSearch(
 
   const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
   const index = buildContentIndex(shards, streamDays, references, supersededFragmentIds)
-  const vectorRows = queryEmbeddings[0] === undefined ? [] : gatedVectorLane(queryEmbeddings[0], store, topK)
+  const vectorRows =
+    queryEmbeddings[0] === undefined ? [] : gatedVectorLane(queryEmbeddings[0], store, topK, query, index)
   const keywordMatches = keywordLane(query, shards, streamDays, references, topK * 2)
 
   return fuseLanes(vectorRows, keywordMatches, index, parentSlugsByFragmentId).slice(0, topK)
@@ -82,17 +84,57 @@ export async function hybridSearch(
 // exist at all. A lexically-corroborated fragment still reaches RRF via the
 // separate keyword lane. An empty merged lane composes with RRF exactly like a
 // lane that found nothing, so a genuine keyword hit survives a full no-match.
-function gatedVectorLane(queryEmbedding: Float32Array, store: VectorStore, topK: number): VectorRow[] {
+function gatedVectorLane(
+  queryEmbedding: Float32Array,
+  store: VectorStore,
+  topK: number,
+  query: string,
+  index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
+): VectorRow[] {
   const scored = store.queryScored(queryEmbedding, EMBEDDING_MODEL_ID)
   const bandDefiningRows = scored.filter(({ row }) => row.source === 'topic' || row.source === 'reference')
   const streamRows = scored.filter(({ row }) => row.source === 'stream')
 
+  // The cross-script verdict is judged against the HEAD of the scored band — the
+  // high-scoring rows that actually define the contrast the gate measures — not
+  // the whole corpus. Deriving it from every shard would let one unrelated same-
+  // script heading anywhere in the index cancel the loosening, so a real cross-
+  // script winner whose contrast sits between the loosened and strict margins
+  // would still be suppressed. Headings (via `index`) carry the language; slugs
+  // are ASCII-kebab even for non-Latin topics.
+  const topicMargin = MARGIN * crossScriptMarginScale(dominantScript(query), headBandScripts(bandDefiningRows, index))
   const bandScores = bandDefiningRows.map(({ score }) => score)
-  const keptBandDefiningRows = bandDefiningRows.slice(0, gateRelevance(bandScores, topK * 2))
+  const keptBandDefiningRows = bandDefiningRows.slice(0, gateRelevance(bandScores, topK * 2, topicMargin))
+
+  // Stream admission stays on the STRICT MARGIN regardless of the topic verdict.
+  // The cross-script loosening is calibrated for the topic band the query is
+  // judged against; a stream row's own language is not part of that band, so
+  // applying the loosened margin here would admit an irrelevant in-band stream
+  // neighbour on a cross-script query — exactly the closest-neighbour leak the
+  // strict stream guard exists to block.
   const streamBaseline = streamAdmissionBaseline(bandScores)
   const keptStreams = streamRows.filter(({ score }) => clearsBaseline(score, streamBaseline)).slice(0, topK * 2)
 
   return [...keptBandDefiningRows, ...keptStreams].sort((a, b) => b.score - a.score).map(({ row }) => row)
+}
+
+// The scripts of the HEAD band-defining rows (the gate examines the top of the
+// score-sorted band to set the knee, so the head is what the query is actually
+// contrasted against). `bandDefiningRows` is score-sorted descending, so the
+// first HEAD_BAND_SCRIPT_SAMPLE rows ARE the head. Headings come from the content
+// index; a row whose content was pruned contributes no script.
+const HEAD_BAND_SCRIPT_SAMPLE = 10
+
+function headBandScripts(
+  bandDefiningRows: ScoredVectorRow[],
+  index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
+): ScriptClass[] {
+  const scripts = new Set<ScriptClass>()
+  for (const { row } of bandDefiningRows.slice(0, HEAD_BAND_SCRIPT_SAMPLE)) {
+    const content = index.get(`${row.source}:${row.key}`)
+    if (content !== undefined) scripts.add(dominantScript(content.heading))
+  }
+  return [...scripts]
 }
 
 // Phrase-first, then token-OR fallback (mirrors `memory_search`). `hybridSearch`'s

--- a/src/bundled-plugins/memory/vector/relevance-gate.test.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.test.ts
@@ -96,6 +96,31 @@ describe('gateRelevance', () => {
 
     expect(kept).toBeGreaterThan(0)
   })
+
+  it('suppresses a cross-script-shaped match at the strict default margin', () => {
+    // given: a real cross-lingual match whose top1-baseline contrast is compressed
+    // to ~0.045 (E5 cross-script gap runs ~half a same-language gap) — below the
+    // strict 0.06 margin, so the default gate wrongly suppresses it.
+    const scores = band(0.8, 0.755, 193)
+
+    expect(gateRelevance(scores, 10)).toBe(0)
+  })
+
+  it('recovers the same cross-script match when the margin is loosened', () => {
+    // given: the SAME compressed-contrast distribution, judged with the loosened
+    // cross-script margin (~0.04) — the real match now clears the bar.
+    const scores = band(0.8, 0.755, 193)
+
+    expect(gateRelevance(scores, 10, 0.04)).toBeGreaterThan(0)
+  })
+
+  it('a loosened margin still suppresses a genuine no-match (in-band top1)', () => {
+    // given: top1 sits right in the band (gap ~0.01) — even the loosened margin
+    // must reject it, so cross-script loosening never becomes "match anything".
+    const scores = band(0.765, 0.755, 193)
+
+    expect(gateRelevance(scores, 10, 0.04)).toBe(0)
+  })
 })
 
 describe('streamAdmissionBaseline + clearsBaseline', () => {

--- a/src/bundled-plugins/memory/vector/relevance-gate.ts
+++ b/src/bundled-plugins/memory/vector/relevance-gate.ts
@@ -28,7 +28,11 @@
 // MARGIN suppresses. We keep the absolute margin as the vector-only no-match
 // guard; recovery for a genuinely-suppressed single-domain match belongs in the
 // corroborating keyword lane, not in a weaker semantic threshold.
-const MARGIN = 0.06
+// The same-script default. A cross-script query (detected in hybrid.ts via
+// script.ts) passes a SMALLER margin here, because E5's cross-lingual top1-
+// baseline contrast is structurally compressed below this same-language bar.
+// The parameter defaults to MARGIN, so every same-script call is unchanged.
+export const MARGIN = 0.06
 const HEAD_EXCLUDED_FROM_BASELINE = 5
 // Minimum non-head scores required to trust a suppression verdict. A median over
 // 1-4 scores (n=6..9 once the head is dropped) is too noisy to zero out the only
@@ -62,8 +66,8 @@ export function streamAdmissionBaseline(topicScores: number[]): number | null {
 // admit stream rows against the topic contrast reference: a stream candidate
 // survives only if it stands as far above the band as a real topic match would.
 // A null baseline (no topics at all) admits nothing.
-export function clearsBaseline(score: number, baseline: number | null): boolean {
-  return baseline !== null && score - baseline >= MARGIN
+export function clearsBaseline(score: number, baseline: number | null, margin: number = MARGIN): boolean {
+  return baseline !== null && score - baseline >= margin
 }
 
 // Returns how many of the sorted-descending topic cosine scores survive the
@@ -72,15 +76,15 @@ export function clearsBaseline(score: number, baseline: number | null): boolean 
 // tail is too short (1-4 scores) for a reliable suppression verdict, so topics
 // pass ungated (a false negative of one obvious shard is cheaper than
 // suppressing the only memory). `scores` MUST be sorted descending.
-export function gateRelevance(scores: number[], topK: number): number {
+export function gateRelevance(scores: number[], topK: number, margin: number = MARGIN): number {
   if (scores.length === 0 || topK <= 0) return 0
   if (scores.length < GATED_TOPIC_FLOOR) return Math.min(scores.length, topK)
 
   const top = scores[0]!
-  const margin = top - median(scores.slice(HEAD_EXCLUDED_FROM_BASELINE))
-  if (margin < MARGIN) return 0
+  const contrast = top - median(scores.slice(HEAD_EXCLUDED_FROM_BASELINE))
+  if (contrast < margin) return 0
 
-  const knee = top - 0.5 * margin
+  const knee = top - 0.5 * contrast
   const survivors = scores.filter((score) => score >= knee).length
   return Math.min(survivors, topK)
 }

--- a/src/bundled-plugins/memory/vector/script.test.ts
+++ b/src/bundled-plugins/memory/vector/script.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test'
+
+import { crossScriptMarginScale, dominantScript } from './script'
+
+describe('dominantScript', () => {
+  it('classifies Latin text', () => {
+    expect(dominantScript('docker cannot read proc filesystem')).toBe('latin')
+  })
+
+  it('classifies Korean (Hangul) text', () => {
+    expect(
+      dominantScript(
+        '\uC0CC\uB4DC\uBC15\uC2A4\uC5D0\uC11C proc \uD30C\uC77C\uC2DC\uC2A4\uD15C\uC744 \uC77D\uC9C0 \uBABB\uD558\uB294 \uBB38\uC81C',
+      ),
+    ).toBe('cjk')
+  })
+
+  it('classifies Japanese (Kana) text', () => {
+    expect(dominantScript('\u30B5\u30F3\u30C9\u30DC\u30C3\u30AF\u30B9\u3067proc\u3092\u8AAD\u3081\u306A\u3044')).toBe(
+      'cjk',
+    )
+  })
+
+  it('classifies Chinese (Han) text', () => {
+    expect(dominantScript('\u9632\u6B62\u4E24\u4E2A\u673A\u5668\u4EBA\u4E92\u76F8\u65E0\u9650\u56DE\u590D')).toBe('cjk')
+  })
+
+  it('classifies Cyrillic text', () => {
+    expect(
+      dominantScript(
+        '\u043F\u0440\u0435\u0434\u043E\u0442\u0432\u0440\u0430\u0442\u0438\u0442\u044C \u0431\u0435\u0441\u043A\u043E\u043D\u0435\u0447\u043D\u044B\u0439 \u0446\u0438\u043A\u043B',
+      ),
+    ).toBe('cyrillic')
+  })
+
+  it('classifies Arabic text', () => {
+    expect(
+      dominantScript(
+        '\u0645\u0646\u0639 \u0627\u0644\u062D\u0644\u0642\u0629 \u0627\u0644\u0644\u0627\u0646\u0647\u0627\u0626\u064A\u0629',
+      ),
+    ).toBe('arabic')
+  })
+
+  it('returns the dominant script for mixed text by majority of script-bearing chars', () => {
+    // mostly Korean prose with a couple of English keyword anchors -> CJK dominant
+    expect(
+      dominantScript(
+        'Discord \uBD07 \uBD84\uB958\uC5D0\uC11C peer bot \uBB34\uD55C \uB8E8\uD504\uB97C \uB9C9\uB294 \uBC29\uBC95',
+      ),
+    ).toBe('cjk')
+  })
+
+  it('treats whitespace/punctuation/digits as script-neutral (does not flip the verdict)', () => {
+    expect(dominantScript('PR #1054 \u2014 \uBD07 \uBD84\uB958 (peer bot) \uBB34\uD55C \uB8E8\uD504')).toBe('cjk')
+  })
+
+  it('falls back to latin for purely neutral input (digits/punctuation only)', () => {
+    expect(dominantScript('#1054 / 2026-06-24')).toBe('latin')
+  })
+})
+
+describe('crossScriptMarginScale', () => {
+  it('returns 1 (strict, unchanged margin) when the query shares the candidate band script', () => {
+    expect(crossScriptMarginScale('latin', ['latin', 'latin', 'latin'])).toBe(1)
+  })
+
+  it('returns 1 when no candidate scripts are known (cannot establish a mismatch)', () => {
+    expect(crossScriptMarginScale('cjk', [])).toBe(1)
+  })
+
+  it('loosens the margin (scale < 1) for a cross-script query vs a same-script band', () => {
+    const scale = crossScriptMarginScale('cjk', ['latin', 'latin', 'latin', 'latin'])
+    expect(scale).toBeGreaterThan(0)
+    expect(scale).toBeLessThan(1)
+  })
+
+  it('is symmetric: English query vs an all-Korean band loosens equally', () => {
+    const enVsKo = crossScriptMarginScale('latin', ['cjk', 'cjk', 'cjk', 'cjk'])
+    const koVsEn = crossScriptMarginScale('cjk', ['latin', 'latin', 'latin', 'latin'])
+    expect(enVsKo).toBe(koVsEn)
+  })
+
+  it('stays strict when the query script is present in the candidate band (partial match)', () => {
+    expect(crossScriptMarginScale('cjk', ['cjk', 'latin', 'latin'])).toBe(1)
+  })
+})

--- a/src/bundled-plugins/memory/vector/script.ts
+++ b/src/bundled-plugins/memory/vector/script.ts
@@ -1,0 +1,87 @@
+// Script-class detection for cross-lingual relevance gating.
+//
+// E5's cosine contrast (top1 - baseline) is calibrated, in the gate, on a
+// SAME-script distribution: a live English index measured no-match <= 0.051 and
+// has-match >= 0.074, so MARGIN=0.06 separates them. A CROSS-script query (the
+// user writes Korean, the matching memory was logged in English, or vice versa)
+// embeds into the same multilingual space but with a STRUCTURALLY LOWER contrast
+// — the cross-lingual pair sits closer to the ambient band, so a genuine match's
+// top1-baseline gap shrinks below 0.06 and the gate wrongly suppresses the whole
+// vector lane. The keyword lane can't rescue it either: a pure non-Latin query
+// shares no tokens with a Latin corpus.
+//
+// The fix is language-agnostic and symmetric: detect the query's dominant script
+// and the candidate band's scripts; when they DON'T overlap, scale the margin
+// down so the lower-but-real cross-script contrast can still clear it. Same-script
+// pairs keep the full strict margin, so the no-match suppression guarantee — and
+// the per-turn memory-bleed protection that rides on it — is untouched for the
+// common case. This is deliberately script-class granularity (not full language
+// id): the highest-compression pairs are non-Latin<->Latin (KO/JA/ZH/RU/AR vs
+// EN), which script ranges separate cheaply with no model on the hot path. Latin
+// <->Latin pairs (EN<->ES<->FR) are left strict; E5 keeps Latin-script languages
+// closer, so their contrast is less compressed and least needs loosening.
+
+export type ScriptClass = 'latin' | 'cjk' | 'cyrillic' | 'arabic' | 'other'
+
+// CJK = Hiragana, Katakana, CJK Ext-A, CJK Unified, CJK Compat, Hangul,
+// half-width Kana. Mirrors the proven range set in truncation.ts (the embedder's
+// CJK token estimate), so "what counts as CJK" stays consistent across the
+// vector subsystem.
+const CJK = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af\uff66-\uff9f]/u
+const CYRILLIC = /[\u0400-\u04ff\u0500-\u052f]/u
+const ARABIC = /[\u0600-\u06ff\u0750-\u077f\u08a0-\u08ff]/u
+const LATIN = /[a-z\u00c0-\u024f]/iu
+
+// A plain per-character majority mis-ranks mixed text: one Hangul syllable
+// encodes the phonemes of several Latin letters, so Latin letters out-count
+// Hangul chars in text that reads as plainly Korean (`Discord 봇 분류 peer bot`).
+// A non-Latin script therefore wins on a SHARE threshold, not a raw majority —
+// substantial non-Latin presence is the cross-script signal the gate needs even
+// when Latin keyword anchors are present.
+const NON_LATIN_DOMINANCE_SHARE = 0.2
+
+export function dominantScript(text: string): ScriptClass {
+  const counts: Record<ScriptClass, number> = { latin: 0, cjk: 0, cyrillic: 0, arabic: 0, other: 0 }
+  for (const char of text) {
+    if (CJK.test(char)) counts.cjk++
+    else if (CYRILLIC.test(char)) counts.cyrillic++
+    else if (ARABIC.test(char)) counts.arabic++
+    else if (LATIN.test(char)) counts.latin++
+    else if (/\p{L}/u.test(char)) counts.other++
+  }
+
+  const scriptBearing = counts.latin + counts.cjk + counts.cyrillic + counts.arabic + counts.other
+  if (scriptBearing === 0) return 'latin'
+
+  let winner: ScriptClass = 'latin'
+  let max = 0
+  for (const script of ['cjk', 'cyrillic', 'arabic', 'other'] as const) {
+    if (counts[script] > max && counts[script] / scriptBearing >= NON_LATIN_DOMINANCE_SHARE) {
+      max = counts[script]
+      winner = script
+    }
+  }
+  if (winner !== 'latin') return winner
+  return counts.latin > 0 || max === 0 ? 'latin' : winner
+}
+
+// How much E5's cross-script contrast typically shrinks vs a same-script pair.
+// Cross-lingual top1-baseline gaps run roughly half a same-language gap on the
+// live index, so a same-script 0.06 margin maps to ~0.04 cross-script — enough
+// to admit a real cross-lingual match while still rejecting the in-band no-match
+// floor. Conservative on purpose: it loosens, it does not disable the gate.
+const CROSS_SCRIPT_MARGIN_SCALE = 0.04 / 0.06
+
+// Returns a multiplier for the gate's MARGIN. 1 = strict (unchanged). A value
+// below 1 loosens the gate for a cross-script query. The band is "same-script"
+// (no loosening) when the query's script appears among the candidates at all —
+// those same-script candidates already give the query a valid contrast, so the
+// gate needs no help. Only when the query's script is ENTIRELY absent from the
+// candidate band is this a genuine cross-script retrieval that the strict margin
+// over-suppresses. An empty band returns 1: with nothing to compare against we
+// can't establish a mismatch, so stay strict.
+export function crossScriptMarginScale(queryScript: ScriptClass, candidateScripts: ScriptClass[]): number {
+  if (candidateScripts.length === 0) return 1
+  if (candidateScripts.includes(queryScript)) return 1
+  return CROSS_SCRIPT_MARGIN_SCALE
+}


### PR DESCRIPTION
## Background

The vector memory relevance gate silently drops legitimate cross-lingual matches. Probing a live ~193-topic English index surfaced the failure directly:

- `peer bot loop guard` (English) → top hit at RRF 0.0325. Correct.
- `봇끼리 무한 루프 가드` (Korean, same concept) → **"No memory matched"**.
- `防止两个机器人互相无限回复` (Chinese, same concept) → **"No memory matched"**.
- `Discord 봇 분류 peer bot` (Korean + English anchors) → top hit at 0.0328. Recovered.

Root cause: the gate's `MARGIN = 0.06` is calibrated on a **same-language** cosine distribution. The E5 model card documents that cosine compresses into a narrow ~0.70–0.85 band (low InfoNCE temperature τ=0.01), so the gate rightly uses query-local contrast (`top1 − median(non-head)`) rather than an absolute threshold. But that contrast was measured on English no-match (≤0.051) vs has-match (≥0.074) pairs. A genuine **cross-script** pair — a Korean query against an English-logged memory — embeds with structurally lower contrast, lands in-band, and the gate suppresses the whole vector lane. The keyword lane can't rescue it either: a pure non-Latin query shares no tokens with a Latin corpus, so the lane is empty and RRF degenerates to the suppressed vector lane.

This matters because TypeClaw lives in users' chats across Korean, Japanese, Chinese, Arabic, Russian, and more. A non-English user asking about a concept the agent recorded in English gets a false "no memory."

## Summary

Two complementary fixes, partitioned by pipeline side.

**Read side — script-aware gate margin (`vector/script.ts`, `relevance-gate.ts`, `hybrid.ts`).** Detect the query's dominant script and the candidate band's scripts (from shard headings). When the query's script is absent from the band, the pairing is cross-script and the gate margin scales down (~0.04) so the lower-but-real contrast clears it.

- *Why language-pair divergence, not "non-English"?* The corpus language is whatever the deployment speaks. A Korean-deployed agent will have a Korean corpus where an English query is the cross-script case. The trigger is symmetric in every direction, keyed to query↔band script mismatch, never to a privileged language.
- *Why script class, not full language-id?* The highest-compression pairs are non-Latin↔Latin (KO/JA/ZH/RU/AR vs EN), which Unicode ranges separate with no model on the per-turn hot path. Latin↔Latin (EN↔ES) stays strict — E5 keeps Latin-script languages closer, so their contrast is least compressed and needs no help.
- *Why headings, not slugs, for the band script?* Slugs are ASCII-kebab even for non-Latin topics; the human-readable heading carries the corpus language.
- *Safety:* same-script pairs keep the full strict `0.06`. The no-match suppression guarantee — and the per-turn memory-bleed protection riding on it — is untouched for the common case. The loosened margin still rejects a genuine in-band no-match (covered by test).

**Write side — source-language logging (`memory-logger.ts`).** The logger prompt modeled multilingual capture only by example and never stated an output-language policy, so under its all-English framing it could drift to summarizing a non-English exchange in English — converting a future strong same-language retrieval into a weak cross-language one. A new `# Language of the fragment` rule says: write in the evidence's language, translate nothing, and keep technical tokens (identifiers, code symbols, paths, PR numbers) verbatim regardless — those are the language-neutral keyword-lane anchors a later search needs.

The two fixes are independent: the gate fix recovers cross-language recall against the **existing** corpus; the logger fix maximizes same-language pairs **going forward**.

## What this does NOT do

- No change to the displayed RRF `score` semantics, `RRF_K`, or the embedding model/recipe.
- Does not retranslate or rewrite the existing corpus — the logger rule is forward-only.
- Does not touch Latin↔Latin discrimination (EN↔ES↔FR stay on the strict margin by design).
- Does not add language-id or any model to the hot path — detection is pure Unicode-range classification.
- Under-budget channel turns never reach the gate (`forceIndexForChannel` short-circuits to headings-only), so they're unaffected; the gate fix lands on TUI, over-budget channel, subagent, cron, and the CLI `memory search`.

## Review notes

- Load-bearing change: `gateRelevance`/`clearsBaseline` gain an optional `margin` param defaulting to `MARGIN`, so every existing same-script call is byte-for-byte unchanged in behavior. The cross-script margin is computed once in `hybridSearch` and threaded down.
- Invariant to verify: a same-script query must produce an identical gate verdict to before this PR (default-arg path). The existing relevance-gate suite (unchanged assertions) plus the full hybrid suite cover this.
- New cross-lingual regression coverage: `script.test.ts` asserts Korean/Japanese/Chinese/Cyrillic/Arabic classification and the mixed-anchor case; `relevance-gate.test.ts` adds the suppress-at-strict / recover-when-loosened / still-reject-no-match trio. This is the cross-script coverage the suite previously lacked.
