### PR TITLE
fix(run): join session rehydrate path with node:path for Windows

### DIFF
--- a/src/run/channel-session-factory.ts
+++ b/src/run/channel-session-factory.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession as defaultCreateSession } from '@/agent'
@@ -192,7 +194,7 @@ function tryReopenOrCreate(
     )
     return SessionManager.create(cwd, sessionDir)
   }
-  const path = `${sessionDir}/${existingSessionFile}`
+  const path = join(sessionDir, existingSessionFile)
   if (capOptions !== null) {
     try {
       const stats = capJsonlFileInPlace(path, capOptions)


### PR DESCRIPTION
## Background

`tryReopenOrCreate` in `src/run/channel-session-factory.ts` built the path to an existing session's JSONL file with a hardcoded forward slash:

```ts
const path = `${sessionDir}/${existingSessionFile}`
```

On a native-Windows host (`#899`, the experimental Windows lane) `sessionDir` comes back with `\` separators from `path.join`, so concatenating a `/` produces a mixed-separator path. It happens to resolve today because this code path runs container-side (`/agent/sessions/...`), but it's the one spot in this file that bypasses `node:path` and is a latent break the moment it executes on a Windows host (e.g. host-side rehydrate-cap validation).

Spotted during a Windows-compatibility review of an unrelated memory PR. Splitting it out here so the fix lands as its own atomic, revertible change rather than riding along in a feature PR.

## Summary

Use `join(sessionDir, existingSessionFile)` and import `join` from `node:path`, matching the convention every other path construction in this file (and the repo) already follows. `existingSessionFile` is already validated as a bare basename by `isValidSessionFileBasename` just above, so `join` only normalizes the separator — no behavior change on POSIX (`join('a','b') === 'a/b'`), correct separator on Windows.

## What this does NOT do

- No behavioral change on Linux/macOS — purely a separator-normalization fix.
- Does not touch the basename validation or the path-traversal guard above it.
- Does not attempt to make the broader Windows lane green (`#899`); this is one isolated spot.

## Review notes

- The reopen/cap path is covered by `src/run/channel-session-factory.test.ts` ("caps oversized tool results in the JSONL before pi-coding-agent opens it" and the path-traversal fallback test) — all green with this change.
