### PR TITLE
feat: friendly guidance when Docker is not running

### DIFF
--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -17,8 +17,22 @@ import { formatJson, formatReport } from '@/doctor'
 
 import { formatComposeStatus } from './compose-status'
 import { formatComposeUsage, formatComposeUsageJson } from './compose-usage'
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { c, errorLine, spinner } from './ui'
 import { parseSince, parseUntil } from './usage-args'
+
+// Compose fans a docker command out across every agent folder. A down daemon
+// would otherwise surface as N identical raw-stderr rows (one per agent) instead
+// of one actionable message, so gate the whole fleet operation on a single
+// preflight up front. usage reads only local session files and never touches
+// docker, so it is intentionally not gated.
+async function requireDockerOrExit(): Promise<void> {
+  const preflight = await preflightDocker()
+  if (!preflight.ok) {
+    printDockerGuidance(preflight)
+    process.exit(1)
+  }
+}
 
 const startSub = defineCommand({
   meta: { name: 'start', description: 'start every agent in immediate subdirectories of cwd' },
@@ -35,6 +49,7 @@ const startSub = defineCommand({
     },
   },
   async run({ args }) {
+    await requireDockerOrExit()
     const board = makeBoard('Starting agents')
     const s = spinner()
     const { agents, results } = await composeStart({
@@ -63,6 +78,7 @@ const startSub = defineCommand({
 const stopSub = defineCommand({
   meta: { name: 'stop', description: 'stop every agent in immediate subdirectories of cwd' },
   async run() {
+    await requireDockerOrExit()
     const board = makeBoard('Stopping agents')
     const s = spinner()
     const { agents, results } = await composeStop({
@@ -100,6 +116,7 @@ const restartSub = defineCommand({
     },
   },
   async run({ args }) {
+    await requireDockerOrExit()
     const board = makeBoard('Restarting agents')
     const s = spinner()
     const { agents, results } = await composeRestart({
@@ -130,6 +147,7 @@ const restartSub = defineCommand({
 const statusSub = defineCommand({
   meta: { name: 'status', description: 'show status of every agent in immediate subdirectories of cwd' },
   async run() {
+    await requireDockerOrExit()
     const result = await composeStatus(process.cwd())
     const useColor = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined
     process.stdout.write(`${formatComposeStatus(result, { useColor })}\n`)
@@ -161,6 +179,8 @@ const logsSub = defineCommand({
       }
       tail = parsed.value
     }
+
+    await requireDockerOrExit()
 
     const controller = new AbortController()
     const onSig = (): void => controller.abort()

--- a/src/cli/docker-preflight.test.ts
+++ b/src/cli/docker-preflight.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { DockerExec } from '@/container'
+
+import { preflightDocker } from './docker-preflight'
+
+function execReturning(exitCode: number, stderr = ''): DockerExec {
+  return async () => ({ exitCode, stdout: exitCode === 0 ? '27.0.0' : '', stderr })
+}
+
+describe('preflightDocker', () => {
+  test('ok when docker info succeeds', async () => {
+    const result = await preflightDocker(execReturning(0))
+    expect(result.ok).toBe(true)
+  })
+
+  test('daemon-down yields a non-ok result with summary and guidance', async () => {
+    const stderr =
+      'failed to connect to the docker API at unix:///home/user/.docker/run/docker.sock; check if the daemon is running'
+    const result = await preflightDocker(execReturning(1, stderr))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.summary.length).toBeGreaterThan(0)
+    expect(result.guidance.length).toBeGreaterThan(0)
+  })
+
+  test('binary-missing yields install guidance', async () => {
+    const result = await preflightDocker(execReturning(-1, 'docker: command not found in $PATH'))
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.summary).toBe('Docker is not installed.')
+    expect(result.guidance.join('\n')).toContain('https://orbstack.dev')
+  })
+})

--- a/src/cli/docker-preflight.ts
+++ b/src/cli/docker-preflight.ts
@@ -1,0 +1,42 @@
+import {
+  checkDockerAvailable,
+  detectInstalledDockerApps,
+  pickRuntimeToNudge,
+  renderDockerUnavailableGuidance,
+  type DockerExec,
+} from '@/container'
+
+import { c, errorLine } from './ui'
+
+export type DockerPreflightResult = { ok: true } | { ok: false; summary: string; guidance: string[] }
+
+// Single host-side gate every Docker-dependent CLI command calls before it
+// spawns docker. Without it the raw daemon-down stderr (an unactionable socket
+// path) leaks straight to the user. This probes once via checkDockerAvailable,
+// then hands the friendly, runtime-specific guidance back to the caller so each
+// command renders it in its own style (spinner vs console) — no process.exit
+// here, that belongs to the command.
+export async function preflightDocker(exec?: DockerExec): Promise<DockerPreflightResult> {
+  const availability = exec ? await checkDockerAvailable(exec) : await checkDockerAvailable()
+  if (availability.ok) return { ok: true }
+
+  const detail = availability.reason === 'daemon-down' ? availability.detail : undefined
+  const installed = detectInstalledDockerApps()
+  const nudge = pickRuntimeToNudge(process.env, detail, installed)
+  const { summary, lines } = renderDockerUnavailableGuidance(availability, {
+    platform: process.platform,
+    nudge,
+    installed,
+  })
+  return { ok: false, summary, guidance: lines }
+}
+
+// Prints the friendly guidance to stderr in the standard CLI error style
+// (red ✖ summary, then dimmed guidance lines). Shared by every command's
+// non-spinner failure path so the look is identical everywhere.
+export function printDockerGuidance(failure: Extract<DockerPreflightResult, { ok: false }>): void {
+  console.error(errorLine(failure.summary))
+  for (const line of failure.guidance) {
+    console.error(line === '' ? '' : c.dim(line))
+  }
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -30,7 +30,13 @@ import {
   type KnownProviderId,
   type KnownProviderVendorId,
 } from '@/config/providers'
-import { checkDockerAvailable, type DockerAvailability } from '@/container'
+import {
+  checkDockerAvailable,
+  detectInstalledDockerApps,
+  pickRuntimeToNudge,
+  renderDockerUnavailableGuidance,
+  type DockerAvailability,
+} from '@/container'
 import {
   appendOrReplaceEnvKey,
   findAgentDir,
@@ -1928,31 +1934,27 @@ function reportProgress(
   }
 }
 
+function renderPreflightFailure(result: Extract<DockerAvailability, { ok: false }>): {
+  summary: string
+  lines: string[]
+} {
+  const detail = result.reason === 'daemon-down' ? result.detail : undefined
+  const installed = detectInstalledDockerApps()
+  const nudge = pickRuntimeToNudge(process.env, detail, installed)
+  return renderDockerUnavailableGuidance(result, {
+    platform: process.platform,
+    nudge,
+    installed,
+    retryHint: 'Then re-run `typeclaw init`.',
+  })
+}
+
 function preflightFailureSummary(result: Extract<DockerAvailability, { ok: false }>): string {
-  if (result.reason === 'binary-missing') return 'Docker is not installed.'
-  return 'Docker is installed but the daemon is not reachable.'
+  return renderPreflightFailure(result).summary
 }
 
 function preflightFailureGuidance(result: Extract<DockerAvailability, { ok: false }>): string[] {
-  if (result.reason === 'binary-missing') {
-    return [
-      'TypeClaw runs every agent inside its own Docker container, so Docker is required.',
-      '',
-      'Install one of:',
-      '  • Docker Desktop — https://docs.docker.com/get-docker/',
-      '  • OrbStack (macOS, lighter) — https://orbstack.dev',
-      '',
-      'Then re-run `typeclaw init`.',
-    ]
-  }
-  return [
-    'The docker CLI is on $PATH, but the daemon refused the connection:',
-    '',
-    `  ${result.detail}`,
-    '',
-    'Start Docker Desktop / OrbStack (or `sudo systemctl start docker` on Linux),',
-    'then re-run `typeclaw init`.',
-  ]
+  return renderPreflightFailure(result).lines
 }
 
 function reportKakaotalkAuth(result: KakaotalkAuthResult): string {

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty'
 
 import { logs, parseTailValue } from '@/container'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { runInspectViewer } from './inspect'
 import { requireAgentDir } from './require-agent-dir'
 import { c, errorLine } from './ui'
@@ -49,6 +50,12 @@ export const logsCommand = defineCommand({
     if (args.list) {
       const exitCode = await runInspectViewer({ cwd, sessionArg: 'logs' })
       process.exit(exitCode)
+    }
+
+    const preflight = await preflightDocker()
+    if (!preflight.ok) {
+      printDockerGuidance(preflight)
+      process.exit(1)
     }
 
     if (args.follow) {

--- a/src/cli/reload.ts
+++ b/src/cli/reload.ts
@@ -4,6 +4,7 @@ import { requireContainerRunning, resolveHostPort, resolveTuiToken } from '@/con
 import { findAgentDir } from '@/init'
 import { requestReloadWithFallback, type ReloadResult } from '@/reload'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { c, errorLine, spinner } from './ui'
 
 export const reload = defineCommand({
@@ -84,6 +85,11 @@ export function printReloadRecoveryHint(recoveredHostError: string | undefined):
 
 async function defaultTarget(): Promise<{ url: string; cwd: string; token: string | null }> {
   const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  const preflight = await preflightDocker()
+  if (!preflight.ok) {
+    printDockerGuidance(preflight)
+    process.exit(1)
+  }
   const precheck = await requireContainerRunning({ cwd })
   if (!precheck.ok) {
     console.error(errorLine(precheck.reason))

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -5,6 +5,7 @@ import { config, validateConfig } from '@/config'
 import { start, stop } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { guardIncompleteInit } from './incomplete-init'
 import { c, errorLine, renderStartSuccess, reportConfigWarnings, spinner } from './ui'
 
@@ -62,6 +63,12 @@ export const restartCommand = defineCommand({
       process.exit(1)
     }
     reportConfigWarnings(validated.warnings)
+
+    const preflight = await preflightDocker()
+    if (!preflight.ok) {
+      printDockerGuidance(preflight)
+      process.exit(1)
+    }
 
     const stopSpin = spinner()
     stopSpin.start('Stopping container...')

--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty'
 
 import { shell } from '@/container'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { requireAgentDir } from './require-agent-dir'
 import { c, errorLine } from './ui'
 
@@ -19,6 +20,12 @@ export const shellCommand = defineCommand({
   },
   async run({ args }) {
     const cwd = requireAgentDir()
+
+    const preflight = await preflightDocker()
+    if (!preflight.ok) {
+      printDockerGuidance(preflight)
+      process.exit(1)
+    }
 
     console.log(c.cyan(`Attaching ${args.shell} inside the container...`))
 

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -5,6 +5,7 @@ import { config, validateConfig } from '@/config'
 import { start } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { guardIncompleteInit } from './incomplete-init'
 import { errorLine, renderStartSuccess, reportConfigWarnings, spinner } from './ui'
 
@@ -62,6 +63,12 @@ export const startCommand = defineCommand({
       process.exit(1)
     }
     reportConfigWarnings(validated.warnings)
+
+    const preflight = await preflightDocker()
+    if (!preflight.ok) {
+      printDockerGuidance(preflight)
+      process.exit(1)
+    }
 
     const s = spinner()
     s.start('Starting container...')

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -7,6 +7,8 @@ import { isDaemonReachable, send } from '@/hostd'
 import type { StatusResult } from '@/hostd'
 import { findAgentDir } from '@/init'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
+
 export type HostdStatus =
   | { kind: 'unreachable' }
   | { kind: 'not-registered'; reason: string }
@@ -25,6 +27,13 @@ export const statusCommand = defineCommand({
   },
   async run() {
     const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+
+    const preflight = await preflightDocker()
+    if (!preflight.ok) {
+      printDockerGuidance(preflight)
+      process.exit(1)
+    }
+
     const container = await containerStatus({ cwd })
     const hostd = await fetchHostdStatus(container.containerName)
 

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty'
 
 import { stop } from '@/container'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { requireAgentDir } from './require-agent-dir'
 import { c, spinner } from './ui'
 
@@ -12,6 +13,12 @@ export const stopCommand = defineCommand({
   },
   async run() {
     const cwd = requireAgentDir()
+
+    const preflight = await preflightDocker()
+    if (!preflight.ok) {
+      printDockerGuidance(preflight)
+      process.exit(1)
+    }
 
     const s = spinner()
     s.start('Stopping container...')

--- a/src/cli/tui.ts
+++ b/src/cli/tui.ts
@@ -5,6 +5,7 @@ import { CLI_VERSION } from '@/init/cli-version'
 import { runTuiViewer } from '@/inspect'
 import { formatVersionMismatchWarning } from '@/tui'
 
+import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { runInspectViewer } from './inspect'
 import { requireAgentDir } from './require-agent-dir'
 import { errorLine } from './ui'
@@ -75,6 +76,11 @@ export const tui = defineCommand({
 })
 
 async function defaultUrl(cwd: string): Promise<string> {
+  const preflight = await preflightDocker()
+  if (!preflight.ok) {
+    printDockerGuidance(preflight)
+    process.exit(1)
+  }
   const precheck = await requireContainerRunning({ cwd })
   if (!precheck.ok) throw new Error(precheck.reason)
   const port = await resolveHostPort({ cwd })

--- a/src/container/docker-app.test.ts
+++ b/src/container/docker-app.test.ts
@@ -39,6 +39,23 @@ describe('classifyConfiguredRuntime', () => {
     expect(classifyConfiguredRuntime({}, 'unix:///var/run/docker.sock')).toBeNull()
     expect(classifyConfiguredRuntime({}, undefined)).toBeNull()
   })
+
+  test('classifies Docker Desktop from the Windows named pipe', () => {
+    expect(classifyConfiguredRuntime({ DOCKER_HOST: 'npipe:////./pipe/dockerDesktopLinuxEngine' }, undefined)).toBe(
+      'docker-desktop',
+    )
+  })
+
+  test('classifies Podman from the Windows machine pipe', () => {
+    expect(classifyConfiguredRuntime({ DOCKER_HOST: 'npipe:////./pipe/podman-machine-default' }, undefined)).toBe(
+      'podman',
+    )
+  })
+
+  test('returns null for the generic Windows docker_engine pipe (no runtime marker)', () => {
+    const detail = 'open //./pipe/docker_engine: The system cannot find the file specified.'
+    expect(classifyConfiguredRuntime({ DOCKER_HOST: 'npipe:////./pipe/docker_engine' }, detail)).toBeNull()
+  })
 })
 
 describe('detectInstalledDockerApps', () => {
@@ -60,7 +77,7 @@ describe('detectInstalledDockerApps', () => {
     expect(found).toEqual(['docker-desktop', 'orbstack'])
   })
 
-  test('finds colima and podman on PATH regardless of platform', () => {
+  test('finds colima and podman on PATH on linux', () => {
     const found = detectInstalledDockerApps({
       platform: 'linux',
       exists: () => false,
@@ -69,11 +86,41 @@ describe('detectInstalledDockerApps', () => {
     expect(found).toEqual(['colima', 'podman'])
   })
 
-  test('does not probe app bundles off macOS', () => {
+  test('does not probe macOS app bundles off macOS', () => {
+    const found = detectInstalledDockerApps({
+      platform: 'linux',
+      exists: (p) => p.startsWith('/Applications/'),
+      which: () => null,
+    })
+    expect(found).toEqual([])
+  })
+
+  test('finds Docker Desktop on Windows via Program Files', () => {
     const found = detectInstalledDockerApps({
       platform: 'win32',
-      exists: () => true,
+      env: { ProgramFiles: 'C:\\Program Files' },
+      exists: (p) => p === 'C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe',
       which: () => null,
+    })
+    expect(found).toEqual(['docker-desktop'])
+  })
+
+  test('finds Podman on Windows via per-user install', () => {
+    const found = detectInstalledDockerApps({
+      platform: 'win32',
+      env: { LOCALAPPDATA: 'C:\\Users\\example\\AppData\\Local' },
+      exists: (p) => p === 'C:\\Users\\example\\AppData\\Local\\Programs\\Podman\\podman.exe',
+      which: () => null,
+    })
+    expect(found).toEqual(['podman'])
+  })
+
+  test('does not suggest Colima or OrbStack on Windows', () => {
+    const found = detectInstalledDockerApps({
+      platform: 'win32',
+      env: {},
+      exists: () => false,
+      which: (cmd) => (cmd === 'colima' ? 'C:\\colima.exe' : null),
     })
     expect(found).toEqual([])
   })
@@ -126,6 +173,15 @@ describe('renderDockerUnavailableGuidance', () => {
     )
     expect(result.summary).toBe('Docker is not running. Docker Desktop is installed but not started.')
     expect(result.lines.join('\n')).toContain('open -a Docker')
+  })
+
+  test('daemon-down with docker-desktop nudge on Windows points at the Start menu', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: 'npipe:////./pipe/docker_engine' },
+      { platform: 'win32', nudge: 'docker-desktop', installed: ['docker-desktop'] },
+    )
+    expect(result.summary).toBe('Docker is not running. Docker Desktop is installed but not started.')
+    expect(result.lines.join('\n')).toContain('Start menu')
   })
 
   test('daemon-down with colima nudge', () => {

--- a/src/container/docker-app.test.ts
+++ b/src/container/docker-app.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  classifyConfiguredRuntime,
+  detectInstalledDockerApps,
+  pickRuntimeToNudge,
+  renderDockerUnavailableGuidance,
+} from './docker-app'
+
+describe('classifyConfiguredRuntime', () => {
+  test('reads orbstack from the daemon-down socket path', () => {
+    const detail =
+      'failed to connect to the docker API at unix:///home/user/.orbstack/run/docker.sock; check if the daemon is running'
+    expect(classifyConfiguredRuntime({}, detail)).toBe('orbstack')
+  })
+
+  test('DOCKER_HOST wins over the stderr detail', () => {
+    const env = { DOCKER_HOST: 'unix:///home/user/.colima/default/docker.sock' }
+    const detail = 'unix:///var/run/orbstack.sock'
+    expect(classifyConfiguredRuntime(env, detail)).toBe('colima')
+  })
+
+  test('falls back to the detail when DOCKER_HOST names no known runtime', () => {
+    const env = { DOCKER_HOST: 'unix:///var/run/docker.sock' }
+    const detail = 'unix:///home/user/.orbstack/run/docker.sock'
+    expect(classifyConfiguredRuntime(env, detail)).toBe('orbstack')
+  })
+
+  test('classifies docker desktop from its desktop-linux socket', () => {
+    expect(classifyConfiguredRuntime({}, 'unix:///home/user/.docker/desktop-linux/docker.sock')).toBe('docker-desktop')
+  })
+
+  test('classifies colima and podman', () => {
+    expect(classifyConfiguredRuntime({}, 'unix:///home/user/.colima/default/docker.sock')).toBe('colima')
+    expect(classifyConfiguredRuntime({}, 'unix:///run/user/1000/podman/podman.sock')).toBe('podman')
+  })
+
+  test('returns null when no marker is present', () => {
+    expect(classifyConfiguredRuntime({}, 'unix:///var/run/docker.sock')).toBeNull()
+    expect(classifyConfiguredRuntime({}, undefined)).toBeNull()
+  })
+})
+
+describe('detectInstalledDockerApps', () => {
+  test('finds macOS app bundles', () => {
+    const found = detectInstalledDockerApps({
+      platform: 'darwin',
+      exists: (p) => p === '/Applications/OrbStack.app',
+      which: () => null,
+    })
+    expect(found).toEqual(['orbstack'])
+  })
+
+  test('finds both Docker Desktop and OrbStack bundles', () => {
+    const found = detectInstalledDockerApps({
+      platform: 'darwin',
+      exists: () => true,
+      which: () => null,
+    })
+    expect(found).toEqual(['docker-desktop', 'orbstack'])
+  })
+
+  test('finds colima and podman on PATH regardless of platform', () => {
+    const found = detectInstalledDockerApps({
+      platform: 'linux',
+      exists: () => false,
+      which: (cmd) => (cmd === 'colima' || cmd === 'podman' ? `/usr/bin/${cmd}` : null),
+    })
+    expect(found).toEqual(['colima', 'podman'])
+  })
+
+  test('does not probe app bundles off macOS', () => {
+    const found = detectInstalledDockerApps({
+      platform: 'win32',
+      exists: () => true,
+      which: () => null,
+    })
+    expect(found).toEqual([])
+  })
+})
+
+describe('pickRuntimeToNudge', () => {
+  test('configured socket hint beats installed apps', () => {
+    const nudge = pickRuntimeToNudge({}, 'unix:///home/user/.orbstack/run/docker.sock', ['docker-desktop'])
+    expect(nudge).toBe('orbstack')
+  })
+
+  test('falls back to the single installed app', () => {
+    expect(pickRuntimeToNudge({}, undefined, ['colima'])).toBe('colima')
+  })
+
+  test('returns null when multiple apps installed and no socket hint', () => {
+    expect(pickRuntimeToNudge({}, undefined, ['docker-desktop', 'orbstack'])).toBeNull()
+  })
+
+  test('returns null when nothing detected', () => {
+    expect(pickRuntimeToNudge({}, undefined, [])).toBeNull()
+  })
+})
+
+describe('renderDockerUnavailableGuidance', () => {
+  test('binary-missing renders install links', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'binary-missing', detail: 'docker: command not found in $PATH' },
+      { platform: 'darwin', nudge: null, installed: [] },
+    )
+    expect(result.summary).toBe('Docker is not installed.')
+    expect(result.lines.join('\n')).toContain('https://orbstack.dev')
+    expect(result.lines.join('\n')).toContain('https://docs.docker.com/get-docker/')
+  })
+
+  test('daemon-down with orbstack nudge names the app and gives start steps', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: 'unix:///home/user/.orbstack/run/docker.sock' },
+      { platform: 'darwin', nudge: 'orbstack', installed: ['orbstack'] },
+    )
+    expect(result.summary).toBe('Docker is not running. OrbStack is installed but not started.')
+    expect(result.lines.join('\n')).toContain('Open OrbStack')
+    expect(result.lines.join('\n')).toContain('orb start')
+  })
+
+  test('daemon-down with docker-desktop nudge on macOS', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: '' },
+      { platform: 'darwin', nudge: 'docker-desktop', installed: ['docker-desktop'] },
+    )
+    expect(result.summary).toBe('Docker is not running. Docker Desktop is installed but not started.')
+    expect(result.lines.join('\n')).toContain('open -a Docker')
+  })
+
+  test('daemon-down with colima nudge', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: '' },
+      { platform: 'darwin', nudge: 'colima', installed: ['colima'] },
+    )
+    expect(result.lines.join('\n')).toContain('colima start')
+  })
+
+  test('daemon-down with multiple apps and no hint lists them generically', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: '' },
+      { platform: 'darwin', nudge: null, installed: ['docker-desktop', 'orbstack'] },
+    )
+    expect(result.summary).toBe('Docker is not running.')
+    expect(result.lines.join('\n')).toContain('Docker Desktop, OrbStack')
+  })
+
+  test('daemon-down on linux with no app falls back to systemctl', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: '' },
+      { platform: 'linux', nudge: null, installed: [] },
+    )
+    expect(result.lines.join('\n')).toContain('sudo systemctl start docker')
+  })
+
+  test('retryHint is appended when provided', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: '' },
+      { platform: 'darwin', nudge: 'orbstack', installed: ['orbstack'], retryHint: 'Then re-run `typeclaw init`.' },
+    )
+    expect(result.lines[result.lines.length - 1]).toBe('Then re-run `typeclaw init`.')
+  })
+})

--- a/src/container/docker-app.ts
+++ b/src/container/docker-app.ts
@@ -1,0 +1,213 @@
+import { existsSync } from 'node:fs'
+
+import { getBun } from './shared'
+import type { DockerAvailability } from './shared'
+
+// Detection + friendly guidance for "Docker is not reachable".
+//
+// `checkDockerAvailable` (in ./shared) already tells us WHETHER docker works and
+// discriminates `binary-missing` (no `docker` on PATH) from `daemon-down` (CLI
+// present, daemon refused the connection — the common "Docker Desktop / OrbStack
+// installed but not started" case on macOS). What it does NOT do is tell the
+// user WHICH runtime to nudge. This module fills that gap: it classifies the
+// likely runtime and renders a short, copy-pasteable instruction instead of
+// leaking the raw daemon error (which on OrbStack embeds a per-user socket path
+// under the user's home dir — noise the user can't act on).
+//
+// Classification priority (most → least authoritative):
+//   1. The configured socket: `DOCKER_HOST` or the socket path inside the raw
+//      daemon-down `detail`. An `orbstack` / `docker-desktop` / `colima` /
+//      `podman` marker in that path is a high-confidence signal of the runtime
+//      the CLI is actually configured to talk to — sharper than guessing from
+//      what's installed on disk.
+//   2. Installed-app probes (filesystem / PATH). A fallback used only when the
+//      socket gives no hint.
+//   3. Platform default (generic "start your Docker daemon").
+
+export type DockerApp = 'docker-desktop' | 'orbstack' | 'colima' | 'podman'
+
+export type DockerAppProbes = {
+  platform?: NodeJS.Platform
+  exists?: (path: string) => boolean
+  which?: (command: string) => string | null
+  env?: NodeJS.ProcessEnv
+}
+
+const APP_LABELS: Record<DockerApp, string> = {
+  'docker-desktop': 'Docker Desktop',
+  orbstack: 'OrbStack',
+  colima: 'Colima',
+  podman: 'Podman',
+}
+
+export function dockerAppLabel(app: DockerApp): string {
+  return APP_LABELS[app]
+}
+
+function defaultWhich(command: string): string | null {
+  return getBun()?.which(command) ?? null
+}
+
+function resolveProbes(probes: DockerAppProbes): Required<DockerAppProbes> {
+  return {
+    platform: probes.platform ?? process.platform,
+    exists: probes.exists ?? existsSync,
+    which: probes.which ?? defaultWhich,
+    env: probes.env ?? process.env,
+  }
+}
+
+// Reads the socket the docker CLI is configured to use and classifies the
+// runtime from its path. `DOCKER_HOST` wins (it overrides the default socket);
+// otherwise we fall back to the socket path docker printed inside its own
+// connection-refused error. Both are matched case-insensitively on the vendor's
+// own directory/socket naming, which is ASCII by the tools' own conventions —
+// these are protocol/path tokens, not human language, so English matching is
+// correct here.
+export function classifyConfiguredRuntime(env: NodeJS.ProcessEnv, detail: string | undefined): DockerApp | null {
+  // DOCKER_HOST is the runtime the CLI is actually configured to talk to, so it
+  // must win outright: classify it alone first and only consult the daemon error
+  // detail when DOCKER_HOST names no recognized runtime. Folding both into one
+  // haystack would let a stale marker in the error text override an explicit
+  // DOCKER_HOST (e.g. DOCKER_HOST=…/.colima/… but the error mentions orbstack).
+  return classifyRuntimeMarker(env.DOCKER_HOST) ?? classifyRuntimeMarker(detail)
+}
+
+function classifyRuntimeMarker(text: string | undefined): DockerApp | null {
+  if (!text) return null
+  const lower = text.toLowerCase()
+  if (lower.includes('orbstack')) return 'orbstack'
+  if (lower.includes('colima')) return 'colima'
+  if (lower.includes('podman')) return 'podman'
+  // Docker Desktop's user socket lives under `~/.docker/<context>/docker.sock`;
+  // the only stable runtime marker in that path is the `desktop`/`desktop-linux`
+  // context dir. Checked last so a colima/orbstack context that also sits under
+  // `~/.docker` is classified by its own sharper marker first.
+  if (lower.includes('desktop')) return 'docker-desktop'
+  return null
+}
+
+// Probes which Docker runtimes are installed on disk / PATH, most-canonical
+// first. macOS app bundles for the GUI runtimes; PATH binaries for the CLI-first
+// runtimes (Colima/Podman). The list is deliberately conservative — a false
+// "installed" only downgrades the message from runtime-specific to generic, it
+// never blocks anything.
+export function detectInstalledDockerApps(probes: DockerAppProbes = {}): DockerApp[] {
+  const { platform, exists, which } = resolveProbes(probes)
+  const found: DockerApp[] = []
+
+  if (platform === 'darwin') {
+    if (exists('/Applications/Docker.app')) found.push('docker-desktop')
+    if (exists('/Applications/OrbStack.app')) found.push('orbstack')
+  }
+
+  if (which('colima') !== null) found.push('colima')
+  if (which('podman') !== null) found.push('podman')
+
+  return found
+}
+
+// The runtime we should nudge the user to start: configured-socket hint first,
+// then the single installed app (if unambiguous), else null (caller emits the
+// generic message). When multiple apps are installed and the socket gives no
+// hint we deliberately return null rather than guess wrong — the
+// "don't claim OrbStack just because the bundle exists" guardrail.
+export function pickRuntimeToNudge(
+  env: NodeJS.ProcessEnv,
+  detail: string | undefined,
+  installed: DockerApp[],
+): DockerApp | null {
+  const configured = classifyConfiguredRuntime(env, detail)
+  if (configured !== null) return configured
+  if (installed.length === 1) return installed[0] ?? null
+  return null
+}
+
+function startInstructions(app: DockerApp, platform: NodeJS.Platform): string[] {
+  switch (app) {
+    case 'orbstack':
+      return platform === 'darwin'
+        ? ['Open OrbStack (from Applications or Spotlight), then retry.', 'Or from a terminal: `orb start`']
+        : ['Start OrbStack, then retry. (`orb start`)']
+    case 'docker-desktop':
+      if (platform === 'darwin') {
+        return [
+          'Open Docker Desktop (from Applications or Spotlight), then retry.',
+          'Or from a terminal: `open -a Docker`',
+        ]
+      }
+      if (platform === 'win32') {
+        return ['Start Docker Desktop from the Start menu, then retry.']
+      }
+      return ['Start Docker Desktop, then retry.']
+    case 'colima':
+      return ['Start Colima, then retry: `colima start`']
+    case 'podman':
+      return ['Start the Podman machine, then retry: `podman machine start`']
+  }
+}
+
+// Generic "start your daemon" guidance when we can't name the runtime. On Linux
+// the daemon is usually systemd-managed; elsewhere it's a GUI app.
+function genericStartInstructions(platform: NodeJS.Platform): string[] {
+  if (platform === 'linux') {
+    return ['Start the Docker daemon, then retry.', 'On most distros: `sudo systemctl start docker`']
+  }
+  if (platform === 'darwin') {
+    return ['Start your Docker runtime (Docker Desktop or OrbStack), then retry.']
+  }
+  return ['Start your Docker runtime, then retry.']
+}
+
+const INSTALL_LINES = [
+  'TypeClaw runs every agent inside its own Docker container, so Docker is required.',
+  '',
+  'Install one of:',
+  '  • Docker Desktop — https://docs.docker.com/get-docker/',
+  '  • OrbStack (macOS, lighter) — https://orbstack.dev',
+]
+
+// Builds the friendly, multi-line guidance shown when Docker is unavailable.
+// Pure (no I/O): callers pass the availability result plus pre-probed detection
+// facts so this stays trivially testable and reusable by both the CLI preflight
+// and `typeclaw init`. `retryHint` lets each caller append its own next step
+// (e.g. "re-run `typeclaw init`" vs "retry `typeclaw start`").
+export function renderDockerUnavailableGuidance(
+  availability: Extract<DockerAvailability, { ok: false }>,
+  options: {
+    platform: NodeJS.Platform
+    nudge: DockerApp | null
+    installed: DockerApp[]
+    retryHint?: string
+  },
+): { summary: string; lines: string[] } {
+  const { platform, nudge, installed, retryHint } = options
+
+  if (availability.reason === 'binary-missing') {
+    const lines = [...INSTALL_LINES]
+    if (retryHint) {
+      lines.push('', retryHint)
+    }
+    return { summary: 'Docker is not installed.', lines }
+  }
+
+  // daemon-down
+  const lines: string[] = []
+  let summary: string
+  if (nudge !== null) {
+    summary = `Docker is not running. ${dockerAppLabel(nudge)} is installed but not started.`
+    lines.push(...startInstructions(nudge, platform))
+  } else if (installed.length > 1) {
+    const names = installed.map(dockerAppLabel).join(', ')
+    summary = 'Docker is not running.'
+    lines.push(`Detected: ${names}. Start whichever one you use, then retry.`)
+  } else {
+    summary = 'Docker is installed but the daemon is not reachable.'
+    lines.push(...genericStartInstructions(platform))
+  }
+
+  if (retryHint) {
+    lines.push('', retryHint)
+  }
+  return { summary, lines }
+}

--- a/src/container/docker-app.ts
+++ b/src/container/docker-app.ts
@@ -93,7 +93,7 @@ function classifyRuntimeMarker(text: string | undefined): DockerApp | null {
 // "installed" only downgrades the message from runtime-specific to generic, it
 // never blocks anything.
 export function detectInstalledDockerApps(probes: DockerAppProbes = {}): DockerApp[] {
-  const { platform, exists, which } = resolveProbes(probes)
+  const { platform, exists, which, env } = resolveProbes(probes)
   const found: DockerApp[] = []
 
   if (platform === 'darwin') {
@@ -101,10 +101,50 @@ export function detectInstalledDockerApps(probes: DockerAppProbes = {}): DockerA
     if (exists('/Applications/OrbStack.app')) found.push('orbstack')
   }
 
-  if (which('colima') !== null) found.push('colima')
-  if (which('podman') !== null) found.push('podman')
+  if (platform === 'win32') {
+    if (windowsDockerDesktopInstalled(env, exists)) found.push('docker-desktop')
+    if (windowsPodmanInstalled(env, exists)) found.push('podman')
+  }
+
+  // Colima and OrbStack are macOS/Linux only, so probing them on win32 would be
+  // dead weight; Podman ships a `podman.exe` that also lands on PATH, caught by
+  // the install-path probe above. Off Windows, the PATH binaries are the
+  // canonical signal for the CLI-first runtimes.
+  if (platform !== 'win32') {
+    if (which('colima') !== null) found.push('colima')
+    if (which('podman') !== null) found.push('podman')
+  }
 
   return found
+}
+
+// Docker Desktop's GUI launcher (`Docker Desktop.exe`) across the MSI, 32-bit,
+// and per-user install layouts confirmed by the Docker Desktop installer and
+// PowerShell's own probing scripts. Probing the exe (not just `docker` on PATH)
+// is what lets us say "Docker Desktop is installed but not started" when the
+// daemon is down — a stale PATH can hide the CLI even when Desktop is present.
+function windowsDockerDesktopInstalled(env: NodeJS.ProcessEnv, exists: (path: string) => boolean): boolean {
+  const programFiles = env.ProgramW6432 ?? env.ProgramFiles ?? 'C:\\Program Files'
+  const programFilesX86 = env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)'
+  const candidates = [
+    `${programFiles}\\Docker\\Docker\\Docker Desktop.exe`,
+    `${programFilesX86}\\Docker\\Docker\\Docker Desktop.exe`,
+  ]
+  if (env.LOCALAPPDATA) {
+    candidates.push(`${env.LOCALAPPDATA}\\Programs\\Docker\\Docker\\Docker Desktop.exe`)
+  }
+  return candidates.some(exists)
+}
+
+// Podman's Windows install layouts: per-machine (current + legacy RedHat path)
+// and per-user, from the official podman win-installer test script.
+function windowsPodmanInstalled(env: NodeJS.ProcessEnv, exists: (path: string) => boolean): boolean {
+  const programFiles = env.ProgramW6432 ?? env.ProgramFiles ?? 'C:\\Program Files'
+  const candidates = [`${programFiles}\\Podman\\podman.exe`, `${programFiles}\\RedHat\\Podman\\podman.exe`]
+  if (env.LOCALAPPDATA) {
+    candidates.push(`${env.LOCALAPPDATA}\\Programs\\Podman\\podman.exe`)
+  }
+  return candidates.some(exists)
 }
 
 // The runtime we should nudge the user to start: configured-socket hint first,

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,3 +1,12 @@
+export {
+  classifyConfiguredRuntime,
+  detectInstalledDockerApps,
+  dockerAppLabel,
+  pickRuntimeToNudge,
+  renderDockerUnavailableGuidance,
+  type DockerApp,
+  type DockerAppProbes,
+} from './docker-app'
 export { buildDockerLogsCmd, logs, parseTailValue, planLogs, type LogsPlan, type LogsResult } from './logs'
 export { CONTAINER_PORT, TUI_TOKEN_LABEL, findFreePort, resolveHostPort, resolveTuiToken } from './port'
 export {


### PR DESCRIPTION
## Problem

When Docker isn't running, every host command that touches docker leaked the **raw daemon error** straight to the user — an unactionable wall of socket-path text:

```
▲  docker inspect failed (failed to connect to the docker API at
unix:///<home>/.orbstack/run/docker.sock; check if the path is correct
and if the daemon is running: dial unix /<home>/.orbstack/run/docker.sock:
connect: no such file or directory) and docker rm -f could not recover:
failed to connect to the docker API at unix:///<home>/.orbstack/run/docker.sock; ...
```

`typeclaw init` already had a friendly preflight, but `start`, `stop`, `restart`, `tui`, `logs`, `status`, `shell`, and `reload` did not — they spawned docker directly and surfaced whatever stderr came back.

## What this does

Detects **which Docker runtime** the CLI is configured for and tells the user exactly what to start; if no docker binary is found at all, it guides installation.

Detection priority (most → least authoritative):
1. **Configured socket** — `DOCKER_HOST` or the failed socket path in the daemon error (`.orbstack` → OrbStack, `colima` → Colima, etc.). Sharper than guessing from disk.
2. **Installed-app probes** — `/Applications/*.app` (macOS) and `colima`/`podman` on `$PATH`.
3. **Platform default** — generic "start your Docker daemon" (with `systemctl` on Linux).

Ambiguous multi-app installs deliberately fall back to a generic message instead of guessing wrong.

## Before → After examples

**Before** (all commands, daemon down):

```
✖ docker inspect failed (failed to connect to the docker API at
  unix:///<home>/.orbstack/run/docker.sock; ... connect: no such file
  or directory) and docker rm -f could not recover: ...
```

**After:**

_OrbStack configured but not running (macOS):_
```
✖ Docker is not running. OrbStack is installed but not started.
Open OrbStack (from Applications or Spotlight), then retry.
Or from a terminal: `orb start`
```

_Docker Desktop:_
```
✖ Docker is not running. Docker Desktop is installed but not started.
Open Docker Desktop (from Applications or Spotlight), then retry.
Or from a terminal: `open -a Docker`
```

_Colima:_
```
✖ Docker is not running. Colima is installed but not started.
Start Colima, then retry: `colima start`
```

_Multiple installed, can't disambiguate:_
```
✖ Docker is not running.
Detected: Docker Desktop, OrbStack. Start whichever one you use, then retry.
```

_Linux, none detected:_
```
✖ Docker is installed but the daemon is not reachable.
Start the Docker daemon, then retry.
On most distros: `sudo systemctl start docker`
```

_No docker binary at all:_
```
✖ Docker is not installed.
TypeClaw runs every agent inside its own Docker container, so Docker is required.

Install one of:
  • Docker Desktop — https://docs.docker.com/get-docker/
  • OrbStack (macOS, lighter) — https://orbstack.dev
```

## Design

- **`src/container/docker-app.ts`** — pure detection + classification + guidance renderer, injectable probes (mirrors the `src/shared/wsl.ts` pattern). No I/O in the render path.
- **`src/cli/docker-preflight.ts`** — non-exiting `preflightDocker()` gate + shared `printDockerGuidance()` sink. Each command renders in its own style (spinner vs console) and owns its own `process.exit`; the domain layer never exits.
- **`init`** refactored to reuse the same renderer, so there's one Docker-UX path, not two.

`tui`/`reload` resolve their default target via `requireContainerRunning`, which inspects through docker and would otherwise mislabel a down daemon as "container not found"; `status` would render a misleading "missing" container. All three now preflight.

## Tests

- `src/container/docker-app.test.ts` — socket-hint classification (OrbStack / Docker Desktop / Colima / Podman), `DOCKER_HOST` precedence, fs/PATH probe fallbacks, multi-app ambiguity, Linux systemd fallback, binary-missing install links, `retryHint` append.
- `src/cli/docker-preflight.test.ts` — ok passthrough, daemon-down, binary-missing, via an injected `DockerExec`.

Full suite: **10160 pass / 0 fail**. `typecheck`, `lint` (0 errors), `format:check` all clean.

## Commits

1. `feat(container): add Docker runtime detection and guidance renderer`
2. `feat(cli): add non-exiting Docker preflight gate`
3. `refactor(cli): reuse shared Docker guidance renderer in init`
4. `feat(cli): preflight Docker in start, stop, and restart`
5. `feat(cli): preflight Docker in shell, logs, tui, reload, and status`
