### PR TITLE
fix(slack): wait for connected event and surface real listener errors

### DIFF
--- a/src/channels/adapters/describe-error.test.ts
+++ b/src/channels/adapters/describe-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+
+import { describeError } from '@/channels/adapters/describe-error'
+
+describe('describeError', () => {
+  test('returns the message of a plain Error', () => {
+    expect(describeError(new Error('boom'))).toBe('boom')
+  })
+
+  test('recovers the reason from an ErrorEvent-shaped object instead of [object ErrorEvent]', () => {
+    // given: a browser/ws ErrorEvent is not an Error and stringifies uselessly
+    const errorEvent = { type: 'error', message: 'Unexpected server response: 401' }
+    expect(String(errorEvent)).toBe('[object Object]')
+
+    expect(describeError(errorEvent)).toBe('Unexpected server response: 401')
+  })
+
+  test('digs into a nested .error when .message is absent', () => {
+    const event = { type: 'error', error: new Error('ECONNREFUSED') }
+    expect(describeError(event)).toBe('ECONNREFUSED')
+  })
+
+  test('joins AggregateError inner messages', () => {
+    const agg = new AggregateError([new Error('a'), new Error('b')], 'all failed')
+    expect(describeError(agg)).toBe('all failed: a; b')
+  })
+
+  test('unwraps an empty-message Error via its cause', () => {
+    const err = new Error('')
+    err.cause = new Error('root cause')
+    expect(describeError(err)).toBe('root cause')
+  })
+
+  test('falls back to String() for primitives', () => {
+    expect(describeError('plain string')).toBe('plain string')
+    expect(describeError(42)).toBe('42')
+  })
+
+  test('does not loop on a self-referential object', () => {
+    const circular: { error?: unknown; message?: unknown } = {}
+    circular.error = circular
+    expect(describeError(circular)).toBe(String(circular))
+  })
+})

--- a/src/channels/adapters/describe-error.ts
+++ b/src/channels/adapters/describe-error.ts
@@ -1,0 +1,40 @@
+// A WebSocket 'error' fires with an `ErrorEvent`, NOT an `Error`, so
+// `String(err)` yields the useless `[object ErrorEvent]`. Dig the real reason
+// out of `.message`/nested `.error` (same trap as `describeWsErrorEvent` in
+// `src/cli/tunnel.ts`), unwrapping `AggregateError` and `.cause` chains.
+
+const MAX_DEPTH = 4
+
+export function describeError(err: unknown): string {
+  const message = extract(err, 0)
+  return message ?? String(err)
+}
+
+function extract(err: unknown, depth: number): string | null {
+  if (depth > MAX_DEPTH) return null
+
+  if (err instanceof Error) {
+    if (err instanceof AggregateError && err.errors.length > 0) {
+      const inner = err.errors.map((e) => extract(e, depth + 1) ?? String(e)).join('; ')
+      if (err.message !== '') return `${err.message}: ${inner}`
+      return inner
+    }
+    if (err.message !== '') return err.message
+    if (err.cause !== undefined) return extract(err.cause, depth + 1)
+    return err.name
+  }
+
+  if (typeof err === 'string') return err === '' ? null : err
+
+  if (typeof err === 'object' && err !== null) {
+    const { message, error } = err as { message?: unknown; error?: unknown }
+    if (typeof message === 'string' && message !== '') return message
+    if (error !== undefined && error !== err) {
+      const nested = extract(error, depth + 1)
+      if (nested !== null) return nested
+    }
+    return null
+  }
+
+  return null
+}

--- a/src/channels/adapters/discord.ts
+++ b/src/channels/adapters/discord.ts
@@ -24,6 +24,7 @@ import type {
 import { chunkMarkdown } from '@/markdown'
 import type { DiscordAccountRecord } from '@/secrets/schema'
 
+import { describeError } from './describe-error'
 import { createDiscordAuthorResolver } from './discord-author-resolver'
 import { createDiscordChannelResolver } from './discord-channel-resolver'
 import { classifyInbound, type InboundDropReason } from './discord-classify'
@@ -84,7 +85,7 @@ export function createDiscordOutboundCallback(deps: {
       }
       return { ok: true }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.error(`[discord] outbound failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -100,7 +101,7 @@ export function createDiscordHistoryCallback(deps: {
       const messages = await deps.client.getMessages(args.chat, clampLimit(args.limit, 100))
       return { ok: true, messages: messages.map(mapDiscordHistoryMessage).reverse() }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.warn(`[discord] history fetch failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -159,7 +160,7 @@ export function createDiscordFetchAttachmentCallback(deps: {
         size: buffer.length,
       }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.error(`[discord] fetchAttachment failed for ${url.toString()}: ${message}`)
       return { ok: false, error: message }
     }
@@ -232,7 +233,7 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
       logger.info(`[discord] routed id=${event.id} ${tag} mention=${payload.isBotMention}`)
       await options.router.route(payload)
     } catch (err) {
-      logger.error(`[discord] handleInbound failed: ${describe(err)}`)
+      logger.error(`[discord] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -262,7 +263,7 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
         started = false
         selfUserId = null
         token = null
-        logger.error(`[discord] login failed: ${describe(err)}`)
+        logger.error(`[discord] login failed: ${describeError(err)}`)
         throw err
       }
 
@@ -281,7 +282,7 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
       })
       listener.on('error', (err) => {
         if (!listenerConnected && listenerStartupError === null) listenerStartupError = err
-        logger.error(`[discord] listener error: ${describe(err)}`)
+        logger.error(`[discord] listener error: ${describeError(err)}`)
       })
       listener.on('message_create', (event) => void handleMessage(event))
       listener.on('message_reaction_add', (event) =>
@@ -305,14 +306,14 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
         token = null
         connected = false
         started = false
-        logger.error(`[discord] ${reason}: ${describe(cause)}`)
+        logger.error(`[discord] ${reason}: ${describeError(cause)}`)
         throw cause
       }
 
       try {
         await listener.start()
       } catch (err) {
-        rollbackStart('listener start threw', err instanceof Error ? err : new Error(String(err)))
+        rollbackStart('listener start threw', err instanceof Error ? err : new Error(describeError(err)))
       }
       if (!listenerConnected) {
         rollbackStart(
@@ -398,10 +399,6 @@ const DISCORD_ATTACHMENT_HOSTS = new Set(['cdn.discordapp.com', 'media.discordap
 function clampLimit(requested: number, max: number): number {
   if (!Number.isFinite(requested) || requested <= 0) return max
   return Math.min(Math.floor(requested), max)
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -32,6 +32,7 @@ import type {
   InboundAttachment,
 } from '@/channels/types'
 
+import { describeError } from './describe-error'
 import {
   emoticonEventToMessageEvent,
   splitEmoticonInbound,
@@ -215,7 +216,7 @@ export function createOutboundCallback(deps: {
           }),
         )
       } catch (err) {
-        const message = describe(err)
+        const message = describeError(err)
         logger.error(`[kakaotalk] readFile failed: ${message}`)
         return { ok: false, error: `readFile failed: ${message}` }
       }
@@ -228,7 +229,7 @@ export function createOutboundCallback(deps: {
         logIds.push(result.log_id)
         logger.info(`[kakaotalk] uploaded log_id=${result.log_id} attachments=${items.length} ${tag}`)
       } catch (err) {
-        const message = describe(err)
+        const message = describeError(err)
         logger.error(`[kakaotalk] sendAttachment failed: ${message}`)
         return { ok: false, error: message }
       }
@@ -262,7 +263,7 @@ export function createOutboundCallback(deps: {
         logIds.push(result.log_id)
         logger.info(`[kakaotalk] sent log_id=${result.log_id} ${tag}`)
       } catch (err) {
-        const message = describe(err)
+        const message = describeError(err)
         logger.error(`[kakaotalk] sendMessage failed: ${message}`)
         return { ok: false, error: message }
       }
@@ -295,7 +296,7 @@ async function resolveKakaoReplyTarget(
     }
     return { log_id: target.log_id, author_id: target.author_id, message: target.message, type: target.type }
   } catch (err) {
-    logger.warn(`[kakaotalk] reply target lookup failed: ${describe(err)}`)
+    logger.warn(`[kakaotalk] reply target lookup failed: ${describeError(err)}`)
     return undefined
   }
 }
@@ -334,7 +335,7 @@ export function createKakaoHistoryCallback(deps: {
       )
       return { ok: true, messages: mapped }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.warn(`[kakaotalk] history fetch failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -483,7 +484,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
       )
       await options.router.route(enriched)
     } catch (err) {
-      logger.error(`[kakaotalk] handleInbound failed: ${describe(err)}`)
+      logger.error(`[kakaotalk] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -527,7 +528,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         }
       } catch (err) {
         started = false
-        logger.error(`[kakaotalk] login failed: ${describe(err)}`)
+        logger.error(`[kakaotalk] login failed: ${describeError(err)}`)
         throw err
       }
 
@@ -546,14 +547,14 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
           logger.error(`[kakaotalk] ${message}`)
           throw new Error(message)
         }
-        logger.error(`[kakaotalk] getProfile failed: ${describe(err)}`)
+        logger.error(`[kakaotalk] getProfile failed: ${describeError(err)}`)
         throw err
       }
 
       try {
         await channelResolver.refresh()
       } catch (err) {
-        logger.warn(`[kakaotalk] initial chat list fetch failed: ${describe(err)}`)
+        logger.warn(`[kakaotalk] initial chat list fetch failed: ${describeError(err)}`)
       }
 
       listener = options.listenerFactory ? options.listenerFactory(client) : new KakaoTalkListener(client)
@@ -585,7 +586,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         logger.warn('[kakaotalk] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
-        logger.error(`[kakaotalk] listener error: ${describe(err)}`)
+        logger.error(`[kakaotalk] listener error: ${describeError(err)}`)
         if (!isKickoutError(err)) return
         // KICKOUT closes the SDK session and skips scheduleReconnect, so
         // without intervention the adapter goes silent. We must either
@@ -624,7 +625,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
           if (recoveryEpisode !== episode) return
           activeListener.start().catch((retryErr) => {
             logger.error(
-              `[kakaotalk] KICKOUT auto-recovery failed: ${describe(retryErr)}. Run \`typeclaw restart\` to retry.`,
+              `[kakaotalk] KICKOUT auto-recovery failed: ${describeError(retryErr)}. Run \`typeclaw restart\` to retry.`,
             )
           })
         }, delayMs)
@@ -658,7 +659,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         }
         listener = null
         started = false
-        logger.error(`[kakaotalk] listener start failed: ${describe(err)}`)
+        logger.error(`[kakaotalk] listener start failed: ${describeError(err)}`)
         throw err
       }
 
@@ -707,10 +708,6 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
   }
 }
 
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
-}
-
 function markReadIfSupported(deps: {
   client: Pick<KakaoTalkClient, 'markRead'>
   event: KakaoTalkPushMessageEvent
@@ -738,7 +735,7 @@ function markReadIfSupported(deps: {
       }
     },
     (err) => {
-      logger.warn(`[kakaotalk] mark-read failed: ${describe(err)} chat=${event.chat_id} log=${event.log_id}`)
+      logger.warn(`[kakaotalk] mark-read failed: ${describeError(err)} chat=${event.chat_id} log=${event.log_id}`)
     },
   )
 }

--- a/src/channels/adapters/line.ts
+++ b/src/channels/adapters/line.ts
@@ -25,6 +25,7 @@ import type {
   SendResult,
 } from '@/channels/types'
 
+import { describeError } from './describe-error'
 import { splitInboundLine } from './line-attachment'
 import { createLineChannelResolver } from './line-channel-resolver'
 import { classifyInbound } from './line-classify'
@@ -128,7 +129,7 @@ export function createOutboundCallback(deps: {
       logger.info(`[line] sent message_id=${result.message_id} ${tag}`)
       return { ok: true, messageId: result.message_id, messageIds: [result.message_id] }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.error(`[line] sendMessage failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -160,7 +161,7 @@ export function createLineHistoryCallback(deps: {
       })
       return { ok: true, messages: mapped }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.warn(`[line] history fetch failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -231,7 +232,7 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
       lastPersistedToken = authToken
       logger.info('[line] persisted refreshed auth token to secrets')
     } catch (err) {
-      logger.warn(`[line] failed to persist refreshed auth token: ${describe(err)}`)
+      logger.warn(`[line] failed to persist refreshed auth token: ${describeError(err)}`)
     }
   }
 
@@ -241,7 +242,7 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
       const token = await client.ensureFreshAuthToken({ skewMs: LINE_TOKEN_REFRESH_SKEW_MS })
       if (token) await persistAuthToken(token)
     } catch (err) {
-      logger.warn(`[line] token refresh failed: ${describe(err)}`)
+      logger.warn(`[line] token refresh failed: ${describeError(err)}`)
     }
   }
 
@@ -301,7 +302,7 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
       )
       await options.router.route(verdict.payload)
     } catch (err) {
-      logger.error(`[line] handleInbound failed: ${describe(err)}`)
+      logger.error(`[line] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -335,7 +336,7 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
         }
       } catch (err) {
         started = false
-        logger.error(`[line] login failed: ${describe(err)}`)
+        logger.error(`[line] login failed: ${describeError(err)}`)
         throw err
       }
 
@@ -348,14 +349,14 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
         logger.info(`[line] authenticated as ${profile.display_name || profile.mid} (${profile.mid})`)
       } catch (err) {
         started = false
-        logger.error(`[line] getProfile failed: ${describe(err)}`)
+        logger.error(`[line] getProfile failed: ${describeError(err)}`)
         throw err
       }
 
       try {
         await channelResolver.refresh()
       } catch (err) {
-        logger.warn(`[line] initial chat list fetch failed: ${describe(err)}`)
+        logger.warn(`[line] initial chat list fetch failed: ${describeError(err)}`)
       }
 
       listener = options.listenerFactory ? options.listenerFactory(client) : new LineListener(client)
@@ -368,7 +369,7 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
         logger.warn('[line] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
-        logger.error(`[line] listener error: ${describe(err)}`)
+        logger.error(`[line] listener error: ${describeError(err)}`)
       })
       listener.on('message', (event) => {
         void processInbound(event)
@@ -384,7 +385,7 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
         }
         listener = null
         started = false
-        logger.error(`[line] listener start failed: ${describe(err)}`)
+        logger.error(`[line] listener start failed: ${describeError(err)}`)
         throw err
       }
 
@@ -431,8 +432,4 @@ export function createLineAdapter(options: LineAdapterOptions): LineAdapter {
 function formatLabel(name: string | undefined, id: string): string {
   if (name === undefined || name === '' || name === id) return id
   return `${name}(${id})`
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -32,6 +32,7 @@ import type {
 } from '@/channels/types'
 import { chunkMarkdown } from '@/markdown'
 
+import { describeError } from './describe-error'
 import { addSlackMentionHints } from './mention-hints'
 import { createSlackAuthorResolver, type SlackAuthorResolver } from './slack-bot-author-resolver'
 import { createSlackChannelResolver } from './slack-bot-channel-resolver'
@@ -110,7 +111,7 @@ export function createSlashCommandHandler(
       try {
         ack(buildSlashAckPayload(SLACK_SLASH_REPLY_FAILED))
       } catch (err) {
-        deps.logger.warn(`[slack-bot] slash command ack (drop path) failed: ${describe(err)}`)
+        deps.logger.warn(`[slack-bot] slash command ack (drop path) failed: ${describeError(err)}`)
       }
       return
     }
@@ -128,11 +129,11 @@ export function createSlashCommandHandler(
         invokerId: command.invokerId,
       })
     } catch (err) {
-      deps.logger.error(`[slack-bot] slash command handler failed: ${describe(err)}`)
+      deps.logger.error(`[slack-bot] slash command handler failed: ${describeError(err)}`)
       try {
         ack(buildSlashAckPayload(SLACK_SLASH_REPLY_FAILED))
       } catch (ackErr) {
-        deps.logger.warn(`[slack-bot] slash command error-ack failed: ${describe(ackErr)}`)
+        deps.logger.warn(`[slack-bot] slash command error-ack failed: ${describeError(ackErr)}`)
       }
       return
     }
@@ -146,7 +147,7 @@ export function createSlashCommandHandler(
     try {
       ack(buildSlashAckPayload(replyContent))
     } catch (err) {
-      deps.logger.warn(`[slack-bot] slash command ack failed: ${describe(err)}`)
+      deps.logger.warn(`[slack-bot] slash command ack failed: ${describeError(err)}`)
     }
 
     // Decorative post-ack logging: resolve channel names now that the 3s
@@ -156,7 +157,7 @@ export function createSlashCommandHandler(
       deps.logger.info(`[slack-bot] slash /${command.name} result=${result.kind} ${inboundTag}`)
     } catch (err) {
       deps.logger.info(
-        `[slack-bot] slash /${command.name} result=${result.kind} (channel-tag resolution failed: ${describe(err)})`,
+        `[slack-bot] slash /${command.name} result=${result.kind} (channel-tag resolution failed: ${describeError(err)})`,
       )
     }
   }
@@ -210,14 +211,14 @@ export function createThreadCommandHandler(
       reply = commandResultReply(result)
       deps.logger.info(`[slack-bot] thread-command !${command.name} result=${result.kind}`)
     } catch (err) {
-      deps.logger.error(`[slack-bot] thread-command !${command.name} failed: ${describe(err)}`)
+      deps.logger.error(`[slack-bot] thread-command !${command.name} failed: ${describeError(err)}`)
       reply = SLACK_SLASH_REPLY_FAILED
     }
 
     try {
       await deps.postReply({ chat: input.channel, thread: input.threadTs, text: reply })
     } catch (err) {
-      deps.logger.warn(`[slack-bot] thread-command reply post failed: ${describe(err)}`)
+      deps.logger.warn(`[slack-bot] thread-command reply post failed: ${describeError(err)}`)
     }
     return { kind: 'executed' }
   }
@@ -329,7 +330,7 @@ export function createSlackTypingTracker(deps: {
       })
       .catch((err: unknown) => {
         logger.warn(
-          `[slack-bot] typing call=${callId} chat=${chat} thread=${threadTs} status="${status}" failed: ${describe(err)}`,
+          `[slack-bot] typing call=${callId} chat=${chat} thread=${threadTs} status="${status}" failed: ${describeError(err)}`,
         )
       })
     queues.set(key, next)
@@ -575,7 +576,7 @@ async function slackApi<T>(
     })
     raw = (await response.json()) as { ok?: boolean; error?: string }
   } catch (err) {
-    return { ok: false, reason: describe(err), failure: { kind: 'transient' } }
+    return { ok: false, reason: describeError(err), failure: { kind: 'transient' } }
   }
   if (raw.ok !== true) {
     const reason = raw.error ?? 'unknown slack error'
@@ -1162,7 +1163,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       )
       await options.router.route(enriched)
     } catch (err) {
-      logger.error(`[slack-bot] handleInbound failed: ${describe(err)}`)
+      logger.error(`[slack-bot] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -1181,7 +1182,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         await client.login({ token: options.token })
       } catch (err) {
         started = false
-        logger.error(`[slack-bot] login failed: ${describe(err)}`)
+        logger.error(`[slack-bot] login failed: ${describeError(err)}`)
         throw err
       }
 
@@ -1196,7 +1197,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         logger.info(`[slack-bot] authenticated as ${auth.user ?? auth.user_id} in team ${auth.team ?? auth.team_id}`)
       } catch (err) {
         started = false
-        logger.error(`[slack-bot] auth.test failed: ${describe(err)}`)
+        logger.error(`[slack-bot] auth.test failed: ${describeError(err)}`)
         throw err
       }
 
@@ -1208,7 +1209,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         logger.warn('[slack-bot] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
-        logger.error(`[slack-bot] socket-mode error: ${describe(err)}`)
+        logger.error(`[slack-bot] socket-mode error: ${describeError(err)}`)
       })
       listener.on('message', ({ ack, event }) => {
         // Ack first so Slack stops retrying; failure to ack causes duplicate
@@ -1280,7 +1281,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
         botUserId = null
         teamId = null
         started = false
-        logger.error(`[slack-bot] listener start failed: ${describe(err)}`)
+        logger.error(`[slack-bot] listener start failed: ${describeError(err)}`)
         throw err
       }
     },
@@ -1313,10 +1314,6 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
       return botUserId !== null && teamId !== null
     },
   }
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/adapters/slack.test.ts
+++ b/src/channels/adapters/slack.test.ts
@@ -34,10 +34,14 @@ function account(overrides: Partial<SlackAccountRecord> = {}): SlackAccountRecor
   }
 }
 
+type ConnectMode = 'sync' | 'async' | 'never'
+
 class FakeListener {
   private handlers = new Map<string, Array<(value: unknown) => void>>()
   stopped = false
   failStart = false
+  connectMode: ConnectMode = 'sync'
+  emitErrorOnStart: unknown = null
 
   on(event: string, handler: (value: unknown) => void): void {
     this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler])
@@ -45,6 +49,12 @@ class FakeListener {
 
   async start(): Promise<void> {
     if (this.failStart) throw new Error('boom')
+    if (this.emitErrorOnStart !== null) queueMicrotask(() => this.emit('error', this.emitErrorOnStart))
+    if (this.connectMode === 'sync') this.emitConnected()
+    else if (this.connectMode === 'async') queueMicrotask(() => this.emitConnected())
+  }
+
+  emitConnected(): void {
     this.emit('connected', { self: { id: 'USELF' }, team: { id: 'T0123456789' } })
   }
 
@@ -242,6 +252,49 @@ describe('createSlackAdapter', () => {
     expect(listener.stopped).toBe(true)
     expect(r.unregistered).toContain('outbound:slack')
     expect(r.unregistered).toContain('remove-reaction:slack')
+  })
+
+  test('start resolves when connected is emitted asynchronously after start()', async () => {
+    // given: the real SlackListener emits 'connected' on the later `hello` frame,
+    // not synchronously inside start()
+    const r = router()
+    const listener = new FakeListener()
+    listener.connectMode = 'async'
+    const adapter = createSlackAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient(),
+      createListener: () => listener as unknown as SlackListener,
+    })
+
+    await adapter.start()
+
+    expect(adapter.isConnected()).toBe(true)
+  })
+
+  test('an error before connected rolls back with the real reason, not [object ErrorEvent]', async () => {
+    const r = router()
+    const log = logger()
+    const listener = new FakeListener()
+    listener.connectMode = 'never'
+    listener.emitErrorOnStart = { type: 'error', message: 'invalid_auth' }
+    const adapter = createSlackAdapter({
+      router: r,
+      configRef: () => config,
+      logger: log,
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient(),
+      createListener: () => listener as unknown as SlackListener,
+    })
+
+    await expect(adapter.start()).rejects.toThrow('invalid_auth')
+    expect(adapter.isConnected()).toBe(false)
+    expect(listener.stopped).toBe(true)
+    expect(r.unregistered).toContain('outbound:slack')
+    expect(log.lines).toContain('error:[slack] listener error: invalid_auth')
+    expect(log.lines.some((line) => line.includes('[object'))).toBe(false)
   })
 })
 

--- a/src/channels/adapters/slack.ts
+++ b/src/channels/adapters/slack.ts
@@ -32,6 +32,7 @@ import type {
 import { chunkMarkdown } from '@/markdown'
 import type { SlackAccountRecord } from '@/secrets/schema'
 
+import { describeError } from './describe-error'
 import { createSlackAuthorResolver } from './slack-author-resolver'
 import { slackTsToMillis } from './slack-bot-time'
 import { createSlackChannelResolver } from './slack-channel-resolver'
@@ -49,6 +50,8 @@ const consoleLogger: SlackAdapterLogger = {
   warn: (m) => console.warn(m),
   error: (m) => console.error(m),
 }
+
+const LISTENER_CONNECT_TIMEOUT_MS = 15_000
 
 export type SlackCredentialStore = {
   getAccount(id?: string): Promise<SlackAccountRecord | null>
@@ -102,7 +105,7 @@ export function createSlackOutboundCallback(deps: {
       }
       return { ok: true }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.error(`[slack] outbound failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -118,7 +121,7 @@ export function createSlackHistoryCallback(deps: {
       const messages = await deps.client.getMessages(args.chat, { limit: clampLimit(args.limit, 100) })
       return { ok: true, messages: messages.map(mapSlackHistoryMessage).reverse() }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.warn(`[slack] history fetch failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -150,7 +153,9 @@ export function createSlackMembershipResolver(deps: {
       if (truncated) return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated }
       return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated, humanMemberIds }
     } catch (err) {
-      deps.logger.warn(`[slack] membership channel=${key.chat} failed: ${describe(err)}; deriving from recent history`)
+      deps.logger.warn(
+        `[slack] membership channel=${key.chat} failed: ${describeError(err)}; deriving from recent history`,
+      )
       return await deriveMembershipFromHistory({
         fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit }),
         now,
@@ -174,7 +179,7 @@ export function createSlackFetchAttachmentCallback(deps: {
         size: buffer.length,
       }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.error(`[slack] fetchAttachment failed for ${ref}: ${message}`)
       return { ok: false, error: message }
     }
@@ -239,7 +244,7 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
       logger.info(`[slack] routed id=${event.ts} ${tag} mention=${payload.isBotMention}`)
       await options.router.route(payload)
     } catch (err) {
-      logger.error(`[slack] handleInbound failed: ${describe(err)}`)
+      logger.error(`[slack] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -274,26 +279,52 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
         started = false
         selfUserId = null
         teamId = ''
-        logger.error(`[slack] login failed: ${describe(err)}`)
+        logger.error(`[slack] login failed: ${describeError(err)}`)
         throw err
       }
 
       listener = createListener(client)
       let listenerConnected = false
       let listenerStartupError: Error | null = null
+
+      // SlackListener.start() resolves as soon as the WebSocket is opened, but
+      // 'connected' is only emitted later when Slack sends the `hello` frame. A
+      // synchronous post-start check therefore always fails the race. Gate
+      // startup on a deferred settled by the 'connected'/'error' handlers below.
+      let settleStartup: (() => void) | null = null
+      let failStartup: ((err: Error) => void) | null = null
+      const startupTimer = setTimeout(() => {
+        failStartup?.(new Error(`listener did not connect within ${LISTENER_CONNECT_TIMEOUT_MS}ms`))
+      }, LISTENER_CONNECT_TIMEOUT_MS)
+      const connectedPromise = new Promise<void>((resolve, reject) => {
+        settleStartup = () => {
+          clearTimeout(startupTimer)
+          resolve()
+        }
+        failStartup = (err) => {
+          clearTimeout(startupTimer)
+          reject(err)
+        }
+      })
+
       listener.on('connected', (info) => {
         listenerConnected = true
         connected = true
         selfUserId = info.self.id
         teamId = info.team.id
+        settleStartup?.()
       })
       listener.on('disconnected', () => {
         connected = false
         logger.warn('[slack] disconnected')
       })
       listener.on('error', (err) => {
-        if (!listenerConnected && listenerStartupError === null) listenerStartupError = err
-        logger.error(`[slack] listener error: ${describe(err)}`)
+        const error = err instanceof Error ? err : new Error(describeError(err))
+        if (!listenerConnected && listenerStartupError === null) {
+          listenerStartupError = error
+          failStartup?.(error)
+        }
+        logger.error(`[slack] listener error: ${describeError(err)}`)
       })
       listener.on('message', (event) => void handleMessage(event))
       listener.on('reaction_added', (event) => handleReaction('added', event))
@@ -319,25 +350,22 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
         options.router.unregisterMembership('slack', membershipResolver)
         options.router.unregisterReaction('slack', reactionCallback)
         options.router.unregisterRemoveReaction('slack', removeReactionCallback)
+        clearTimeout(startupTimer)
         listener?.stop()
         listener = null
         selfUserId = null
         connected = false
         started = false
-        logger.error(`[slack] ${reason}: ${describe(cause)}`)
+        logger.error(`[slack] ${reason}: ${describeError(cause)}`)
         throw cause
       }
 
       try {
-        await listener.start()
+        await Promise.all([listener.start(), connectedPromise])
       } catch (err) {
-        rollbackStart('listener start threw', err instanceof Error ? err : new Error(String(err)))
-      }
-      if (!listenerConnected) {
-        rollbackStart(
-          'listener start failed silently',
-          listenerStartupError ?? new Error('listener.start() returned without emitting connected'),
-        )
+        const cause = err instanceof Error ? err : new Error(describeError(err))
+        const reason = listenerStartupError !== null ? 'listener start failed' : 'listener start threw'
+        rollbackStart(reason, cause)
       }
     },
 
@@ -397,10 +425,6 @@ function mapSlackHistoryMessage(msg: SlackMessage): ChannelHistoryMessage {
 function clampLimit(requested: number, max: number): number {
   if (!Number.isFinite(requested) || requested <= 0) return max
   return Math.min(Math.floor(requested), max)
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/adapters/telegram-bot-lifecycle.test.ts
+++ b/src/channels/adapters/telegram-bot-lifecycle.test.ts
@@ -47,7 +47,8 @@ class FakeListener {
   started = false
   stopped = 0
   startCalls = 0
-  startBehavior: 'emit-connected' | 'silent-fail' | 'throw' | 'wait-for-connected-call' = 'emit-connected'
+  startBehavior: 'emit-connected' | 'silent-fail' | 'error-event' | 'throw' | 'wait-for-connected-call' =
+    'emit-connected'
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private handlers = new Map<ListenerEvent, Array<(...args: any[]) => void>>()
 
@@ -71,6 +72,11 @@ class FakeListener {
     }
     if (this.startBehavior === 'silent-fail') {
       this.emit('error', new Error('deleteWebhook failed'))
+      return
+    }
+    if (this.startBehavior === 'error-event') {
+      // A WebSocket 'error' fires with an ErrorEvent-shaped value, not an Error
+      this.emit('error', { type: 'error', message: 'invalid_auth' } as unknown as Error)
       return
     }
     // 'wait-for-connected-call' — caller will trigger the event manually
@@ -171,6 +177,33 @@ describe('createTelegramBotAdapter — startup correctness', () => {
     expect(sendResult.ok).toBe(false)
     if (sendResult.ok) throw new Error('expected error')
     expect(sendResult.error).toContain('no adapter registered')
+  })
+
+  test('surfaces the real reason from an ErrorEvent-shaped listener failure, not [object ErrorEvent]', async () => {
+    const fakeClient = new FakeClient()
+    const fakeListener = new FakeListener()
+    fakeListener.startBehavior = 'error-event'
+    const logger = silentLogger()
+
+    const adapter = createTelegramBotAdapter({
+      router: makeRouter(),
+      configRef: () => adapterCfg,
+      token: 'tok',
+      logger,
+      createClient: () => fakeClient as unknown as TelegramBotClient,
+      createListener: () => fakeListener as unknown as TelegramBotListener,
+    })
+
+    let thrown: unknown = null
+    try {
+      await adapter.start()
+    } catch (err) {
+      thrown = err
+    }
+
+    expect((thrown as Error).message).toContain('invalid_auth')
+    expect(logger.errors.some((line) => line.includes('invalid_auth'))).toBe(true)
+    expect(logger.errors.some((line) => line.includes('[object'))).toBe(false)
   })
 
   test('throws and unregisters when listener.start() rejects synchronously', async () => {

--- a/src/channels/adapters/telegram-bot.ts
+++ b/src/channels/adapters/telegram-bot.ts
@@ -16,6 +16,7 @@ import type {
   TypingTarget,
 } from '@/channels/types'
 
+import { describeError } from './describe-error'
 import { classifyInbound, type InboundDropReason, TELEGRAM_WORKSPACE } from './telegram-bot-classify'
 import { toTelegramMarkdownV2 } from './telegram-bot-format'
 
@@ -105,7 +106,7 @@ export function createTypingCallback(deps: {
         logger.warn(`[telegram-bot] typing ${tag} status=${response.status}`)
       }
     } catch (err) {
-      logger.warn(`[telegram-bot] typing ${tag} failed: ${describe(err)}`)
+      logger.warn(`[telegram-bot] typing ${tag} failed: ${describeError(err)}`)
     }
   }
 }
@@ -187,7 +188,7 @@ export function createTelegramMembershipResolver(deps: {
         truncated: true,
       }
     } catch (err) {
-      deps.logger.warn(`[telegram-bot] membership chat=${key.chat} failed: ${describe(err)}`)
+      deps.logger.warn(`[telegram-bot] membership chat=${key.chat} failed: ${describeError(err)}`)
       return { kind: 'transient' } satisfies MembershipResolverFailure
     }
   }
@@ -240,7 +241,7 @@ export function createOutboundCallback(deps: {
           )
         }
       } catch (err) {
-        const message = describe(err)
+        const message = describeError(err)
         logger.error(`[telegram-bot] sendDocument failed for ${path}: ${message}`)
         return { ok: false, error: `sendDocument failed: ${message}` }
       }
@@ -263,7 +264,7 @@ export function createOutboundCallback(deps: {
       const id = String(sent.message_id)
       return { ok: true, messageId: id, messageIds: [id] }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.error(`[telegram-bot] sendMessage failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -319,7 +320,7 @@ export function createFetchAttachmentCallback(deps: {
     try {
       metaResponse = await fetchImpl(`${TELEGRAM_API_BASE}/bot${token}/getFile?file_id=${encodeURIComponent(ref)}`)
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.error(`[telegram-bot] getFile failed for ${ref}: ${message}`)
       return { ok: false, error: `getFile failed: ${message}` }
     }
@@ -333,7 +334,7 @@ export function createFetchAttachmentCallback(deps: {
     try {
       meta = (await metaResponse.json()) as TelegramFileResponse
     } catch (err) {
-      return { ok: false, error: `getFile parse failed: ${describe(err)}` }
+      return { ok: false, error: `getFile parse failed: ${describeError(err)}` }
     }
     if (!meta.ok || meta.result === undefined || meta.result.file_path === undefined) {
       const message = meta.description ?? 'getFile returned no file_path'
@@ -345,7 +346,7 @@ export function createFetchAttachmentCallback(deps: {
     try {
       response = await fetchImpl(downloadUrl)
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.error(`[telegram-bot] download failed for ${ref}: ${message}`)
       return { ok: false, error: message }
     }
@@ -449,7 +450,7 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
       )
       await options.router.route(verdict.payload)
     } catch (err) {
-      logger.error(`[telegram-bot] handleInbound failed: ${describe(err)}`)
+      logger.error(`[telegram-bot] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -468,7 +469,7 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
         await client.login({ token: options.token })
       } catch (err) {
         started = false
-        logger.error(`[telegram-bot] login failed: ${describe(err)}`)
+        logger.error(`[telegram-bot] login failed: ${describeError(err)}`)
         throw err
       }
 
@@ -486,7 +487,7 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
       } catch (err) {
         started = false
         botUser = null
-        logger.error(`[telegram-bot] getMe failed (likely invalid token): ${describe(err)}`)
+        logger.error(`[telegram-bot] getMe failed (likely invalid token): ${describeError(err)}`)
         throw err
       }
 
@@ -515,11 +516,11 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
         logger.warn('[telegram-bot] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
-        const error = err instanceof Error ? err : new Error(String(err))
+        const error = err instanceof Error ? err : new Error(describeError(err))
         if (!listenerConnected && listenerStartupError === null) {
           listenerStartupError = error
         }
-        logger.error(`[telegram-bot] listener error: ${describe(error)}`)
+        logger.error(`[telegram-bot] listener error: ${describeError(err)}`)
       })
       listener.on('message', (event) => {
         void handleMessage(event)
@@ -548,14 +549,14 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
         listener = null
         botUser = null
         started = false
-        logger.error(`[telegram-bot] ${reason}: ${describe(cause)}`)
+        logger.error(`[telegram-bot] ${reason}: ${describeError(cause)}`)
         throw cause
       }
 
       try {
         await listener.start()
       } catch (err) {
-        rollbackStart('listener start threw', err instanceof Error ? err : new Error(String(err)))
+        rollbackStart('listener start threw', err instanceof Error ? err : new Error(describeError(err)))
       }
       if (!listenerConnected) {
         const cause = listenerStartupError ?? new Error('listener.start() returned without emitting connected')
@@ -597,10 +598,6 @@ export function createTelegramBotAdapter(options: TelegramBotAdapterOptions): Te
       return botUser !== null
     },
   }
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -29,6 +29,7 @@ import type {
   SendResult,
 } from '@/channels/types'
 
+import { describeError } from './describe-error'
 import { createWebexChannelNameResolver } from './webex-bot-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-bot-classify'
 import { enrichWebexMessageReference } from './webex-bot-reference'
@@ -129,7 +130,7 @@ export function createOutboundCallback(deps: {
       logger.info(`[webex-bot] sent id=${sent.ref} ${tag}`)
       return { ok: true, messageId: sent.ref, messageIds: [sent.ref] }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.error(`[webex-bot] outbound failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -168,7 +169,7 @@ export function createWebexHistoryCallback(deps: {
       }
       return toHistory(outcome.value)
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       if (args.prefetch === true && isWebexRateLimitError(err)) {
         deps.logger.info(`[webex-bot] history prefetch skipped: rate limited (${message})`)
         return { ok: false, error: message, skipReason: 'rate-limited' }
@@ -215,7 +216,9 @@ export function createWebexMembershipResolver(deps: {
       }
       return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated, humanMemberIds }
     } catch (err) {
-      deps.logger.warn(`[webex-bot] membership room=${key.chat} failed: ${describe(err)}; deriving from recent history`)
+      deps.logger.warn(
+        `[webex-bot] membership room=${key.chat} failed: ${describeError(err)}; deriving from recent history`,
+      )
       return await deriveMembershipFromHistory({
         fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit, prefetch: true }),
         now,
@@ -267,7 +270,7 @@ export function createFetchAttachmentCallback(deps: {
         size: buffer.length,
       }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.error(`[webex-bot] fetchAttachment failed for ${url.toString()}: ${message}`)
       return { ok: false, error: message }
     }
@@ -340,7 +343,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
       )
       await options.router.route(payload)
     } catch (err) {
-      logger.error(`[webex-bot] handleInbound failed: ${describe(err)}`)
+      logger.error(`[webex-bot] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -362,7 +365,7 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
       } catch (err) {
         started = false
         botPerson = null
-        logger.error(`[webex-bot] login failed: ${describe(err)}`)
+        logger.error(`[webex-bot] login failed: ${describeError(err)}`)
         throw err
       }
 
@@ -378,9 +381,9 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
         logger.warn(`[webex-bot] disconnected: ${reason}`)
       })
       listener.on('error', (err) => {
-        const error = err instanceof Error ? err : new Error(String(err))
+        const error = err instanceof Error ? err : new Error(describeError(err))
         if (!listenerConnected && listenerStartupError === null) listenerStartupError = error
-        logger.error(`[webex-bot] listener error: ${describe(error)}`)
+        logger.error(`[webex-bot] listener error: ${describeError(err)}`)
       })
       listener.on('message_created', (event: WebexBotListenerEventMap['message_created'][0]) => {
         void handleMessage(event)
@@ -405,14 +408,14 @@ export function createWebexBotAdapter(options: WebexBotAdapterOptions): WebexBot
         botPerson = null
         connected = false
         started = false
-        logger.error(`[webex-bot] ${reason}: ${describe(cause)}`)
+        logger.error(`[webex-bot] ${reason}: ${describeError(cause)}`)
         throw cause
       }
 
       try {
         await listener.start()
       } catch (err) {
-        rollbackStart('listener start threw', err instanceof Error ? err : new Error(String(err)))
+        rollbackStart('listener start threw', err instanceof Error ? err : new Error(describeError(err)))
       }
       if (!listenerConnected) {
         rollbackStart(
@@ -472,10 +475,6 @@ function isAllowedWebexFileHost(hostname: string): boolean {
 function clampLimit(requested: number, max: number): number {
   if (!Number.isFinite(requested) || requested <= 0) return max
   return Math.min(Math.floor(requested), max)
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -34,6 +34,7 @@ import type {
 } from '@/channels/types'
 import type { WebexAccountRecord } from '@/secrets/schema'
 
+import { describeError } from './describe-error'
 import { createWebexChannelNameResolver } from './webex-channel-resolver'
 import { classifyInbound, type InboundDropReason, type WebexInboundMessage } from './webex-classify'
 import { resolveWebexBodyText } from './webex-format'
@@ -136,7 +137,7 @@ export function createOutboundCallback(deps: {
       logger.info(`[webex] sent id=${sent.ref} ${tag}`)
       return { ok: true, messageId: sent.ref, messageIds: [sent.ref] }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       logger.error(`[webex] outbound failed: ${message}`)
       return { ok: false, error: message }
     }
@@ -178,7 +179,7 @@ export function createTypingCallback(deps: {
       .then(() => client.setTyping(target.chat, typing))
       .catch(async (err: unknown) => {
         const tag = formatChannelTag ? await formatChannelTag(target.chat) : `room=${target.chat}`
-        logger.warn(`[webex] typing ${tag} phase=${target.phase} failed: ${describe(err)}`)
+        logger.warn(`[webex] typing ${tag} phase=${target.phase} failed: ${describeError(err)}`)
       })
     queues.set(target.chat, next)
     void next.finally(() => {
@@ -217,7 +218,7 @@ export function createWebexHistoryCallback(deps: {
       }
       return toHistory(outcome.value)
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       if (args.prefetch === true && isWebexRateLimitError(err)) {
         deps.logger.info(`[webex] history prefetch skipped: rate limited (${message})`)
         return { ok: false, error: message, skipReason: 'rate-limited' }
@@ -264,7 +265,9 @@ export function createWebexMembershipResolver(deps: {
       }
       return { humans: humanMemberIds.length, bots, fetchedAt: now(), truncated, humanMemberIds }
     } catch (err) {
-      deps.logger.warn(`[webex] membership room=${key.chat} failed: ${describe(err)}; deriving from recent history`)
+      deps.logger.warn(
+        `[webex] membership room=${key.chat} failed: ${describeError(err)}; deriving from recent history`,
+      )
       return await deriveMembershipFromHistory({
         fetchHistory: (limit) => deps.historyCallback({ chat: key.chat, thread: key.thread, limit, prefetch: true }),
         now,
@@ -318,7 +321,7 @@ export function createFetchAttachmentCallback(deps: {
         size: buffer.length,
       }
     } catch (err) {
-      const message = describe(err)
+      const message = describeError(err)
       deps.logger.error(`[webex] fetchAttachment failed for ${url.toString()}: ${message}`)
       return { ok: false, error: message }
     }
@@ -391,7 +394,7 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
       )
       await options.router.route(payload)
     } catch (err) {
-      logger.error(`[webex] handleInbound failed: ${describe(err)}`)
+      logger.error(`[webex] handleInbound failed: ${describeError(err)}`)
     } finally {
       inflightInbounds--
       if (inflightInbounds === 0 && stopWaiters.length > 0) {
@@ -419,7 +422,7 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
         started = false
         currentToken = null
         botPerson = null
-        logger.error(`[webex] login failed: ${describe(err)}`)
+        logger.error(`[webex] login failed: ${describeError(err)}`)
         throw err
       }
 
@@ -438,9 +441,9 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
         logger.warn(`[webex] disconnected: ${reason}`)
       })
       listener.on('error', (err: unknown) => {
-        const error = err instanceof Error ? err : new Error(String(err))
+        const error = err instanceof Error ? err : new Error(describeError(err))
         if (!listenerConnected && listenerStartupError === null) listenerStartupError = error
-        logger.error(`[webex] listener error: ${describe(error)}`)
+        logger.error(`[webex] listener error: ${describeError(err)}`)
       })
       listener.on('message_created', (event: WebexListenerEventMap['message_created'][0]) => {
         void handleMessage(event)
@@ -470,14 +473,14 @@ export function createWebexAdapter(options: WebexAdapterOptions): WebexAdapter {
         currentToken = null
         connected = false
         started = false
-        logger.error(`[webex] ${reason}: ${describe(cause)}`)
+        logger.error(`[webex] ${reason}: ${describeError(cause)}`)
         throw cause
       }
 
       try {
         await listener.start()
       } catch (err) {
-        rollbackStart('listener start threw', err instanceof Error ? err : new Error(String(err)))
+        rollbackStart('listener start threw', err instanceof Error ? err : new Error(describeError(err)))
       }
       if (!listenerConnected) {
         rollbackStart(
@@ -552,10 +555,6 @@ function isAllowedWebexFileHost(hostname: string): boolean {
 function clampLimit(requested: number, max: number): number {
   if (!Number.isFinite(requested) || requested <= 0) return max
   return Math.min(Math.floor(requested), max)
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }
 
 function dropHint(reason: InboundDropReason): string {

--- a/src/container/port.test.ts
+++ b/src/container/port.test.ts
@@ -204,12 +204,14 @@ describe('resolveHostPort', () => {
     const folder = join(root, 'coder')
     await mkdir(folder)
 
-    // when
-    const port = await resolveHostPort({ cwd: folder, exec, retryMs: 200, intervalMs: 5 })
+    // when: a generous retry budget and zero interval keep success tied to the
+    // deterministic 3-probe sequence, not to wall-clock timing (which drifts
+    // under CPU oversubscription and made this test flaky)
+    const port = await resolveHostPort({ cwd: folder, exec, retryMs: 60_000, intervalMs: 0 })
 
     // then
     expect(port).toBe(42424)
-    expect(calls.length).toBeGreaterThanOrEqual(3)
+    expect(calls.length).toBe(3)
   })
 
   test('uses the container name derived from the agent folder basename', async () => {


### PR DESCRIPTION
## Background

On startup the Slack channel adapter logged:

```
[slack] listener start failed silently: listener.start() returned without emitting connected
[channels] adapter "slack" failed to start: listener.start() returned without emitting connected
[slack] listener error: [object ErrorEvent]
```

Two independent root causes hide behind those three lines:

1. **A connect race that fails even with valid credentials.** The adapter called `await listener.start()` and then *synchronously* checked `listenerConnected`. But `agent-messenger`'s `SlackListener.start()` resolves as soon as the WebSocket is opened — it does **not** wait for the connection to be live. `'connected'` is emitted later, from `handleEvent`, only once Slack sends the `hello` frame over the socket. So `start()` always returns before `'connected'` can fire, and the synchronous check always trips. Discord/Webex don't hit this because their listeners internally `await` a readiness promise before `start()` resolves — Slack's contract is asymmetric. The unit test masked it: the `FakeListener` emitted `'connected'` *synchronously inside* `start()`, which real Slack never does.

2. **The real failure reason was unreadable.** A WebSocket `'error'` fires with an `ErrorEvent`, which is **not** an `Error`. The duplicated `describe()` helper (`err instanceof Error ? err.message : String(err)`) fell through to `String(errorEvent)` → `[object ErrorEvent]`, so whatever actually broke the connection (auth, network, RTM rejection) was swallowed.

## Summary

- **Gate Slack startup on the `connected` event.** Before calling `start()`, set up a deferred that the existing `'connected'`/`'error'` handlers settle, then `await Promise.all([listener.start(), connectedPromise])` with a 15s timeout. Startup now succeeds only once the `hello` frame actually arrives, and a pre-connect `error` (or timeout) rolls back with the real reason. **Why `Promise.all` and not `Promise.race`:** `race` would proceed the moment `start()` resolves — i.e. before `hello` — reintroducing the bug; `all` requires both that `start()` didn't throw *and* that `connected` fired.
- **Extract a shared `describeError()`** that digs the reason out of `ErrorEvent`-shaped objects (`.message`, then nested `.error`) and unwraps `AggregateError`/`.cause`, mirroring the existing `describeWsErrorEvent` in `src/cli/tunnel.ts`. It replaces the byte-identical local `describe()` duplicated across the listener adapters, so `[object ErrorEvent]` can't recur on any channel.

Only the Slack adapter's connect-wait logic changed. The other adapters' listeners already await readiness internally, so they get the logging fix only.

## What this does NOT do

- Does not change Discord/Webex/Telegram/LINE/KakaoTalk startup/connect semantics — only their listener-error log formatting.
- Does not touch the ~22 non-listener `describe()` duplicates (github, cron, persistence, etc.), which only ever see real `Error`s.
- Does not diagnose any specific environment-level Slack failure (expired token, blocked network). It makes that failure *legible* — the next start will log the real reason instead of `[object ErrorEvent]`.

## Review notes

- Load-bearing change: `src/channels/adapters/slack.ts` start flow. The invariant to verify is that the deferred is settled by the **permanent** `'connected'`/`'error'` handlers (not throwaway `once()` listeners), so the reconnect lifecycle keeps working, and the startup timer is cleared on success, on error, and in `rollbackStart`.
- New tests in `slack.test.ts` cover both the **async**-`connected` path (the real-world case the old test never exercised) and an **error-before-connected** rollback asserting the log reads `invalid_auth`, not `[object ErrorEvent]`.
- `describe-error.test.ts` pins the `ErrorEvent`/`AggregateError`/`.cause`/circular-object behavior.
