### PR TITLE
fix(reload): wire up provider auth changes on reload

### DIFF
--- a/src/agent/auth-reloadable.test.ts
+++ b/src/agent/auth-reloadable.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { __resetConfigForTesting, reloadConfig } from '@/config/config'
+
+import { getAuthFor, resetAuthForTesting } from './auth'
+import { createProviderAuthReloadable } from './auth-reloadable'
+
+describe('createProviderAuthReloadable', () => {
+  let prevFireworks: string | undefined
+  let prevNodeEnv: string | undefined
+  let prevCwd: string
+  let cwd: string
+
+  beforeEach(async () => {
+    prevFireworks = process.env.FIREWORKS_API_KEY
+    prevNodeEnv = process.env.NODE_ENV
+    delete process.env.FIREWORKS_API_KEY
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-auth-reload-'))
+    prevCwd = process.cwd()
+    process.chdir(cwd)
+    resetAuthForTesting()
+    await writeFile(
+      join(cwd, 'typeclaw.json'),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
+    )
+    reloadConfig(cwd)
+  })
+
+  afterEach(async () => {
+    if (prevFireworks === undefined) delete process.env.FIREWORKS_API_KEY
+    else process.env.FIREWORKS_API_KEY = prevFireworks
+    if (prevNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = prevNodeEnv
+    resetAuthForTesting()
+    __resetConfigForTesting()
+    process.chdir(prevCwd)
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  test('exposes scope=providers with a description', () => {
+    const reloadable = createProviderAuthReloadable()
+    expect(reloadable.scope).toBe('providers')
+    expect(reloadable.description.length).toBeGreaterThan(0)
+  })
+
+  test('re-resolves the rotated value from secrets.json after reload', async () => {
+    // The on-disk secrets.json (bind-mounted live in the container) is the
+    // credential source under test, so bypass getAuthFor's NODE_ENV=test
+    // dummy-key branch, which only fires when no api-key env var is set.
+    delete process.env.NODE_ENV
+    await writeSecretsFireworksKey('fw_first')
+
+    const before = getAuthFor('fireworks')
+    expect(await before.authStorage.getApiKey('fireworks')).toBe('fw_first')
+
+    // given: the credential is rotated on disk (e.g. `typeclaw provider set`)
+    await writeSecretsFireworksKey('fw_rotated')
+
+    // when: the providers reloadable runs (what `typeclaw reload` triggers)
+    const result = await createProviderAuthReloadable().reload()
+
+    // then: the next resolution reads the rotated value from the file
+    expect(result.ok).toBe(true)
+    const after = getAuthFor('fireworks')
+    expect(after).not.toBe(before)
+    expect(await after.authStorage.getApiKey('fireworks')).toBe('fw_rotated')
+  })
+
+  async function writeSecretsFireworksKey(value: string): Promise<void> {
+    await writeFile(
+      join(cwd, 'secrets.json'),
+      JSON.stringify({
+        version: 2,
+        providers: { fireworks: { type: 'api_key', key: { value } } },
+        channels: {},
+      }),
+    )
+  }
+
+  test('fires onProviderAuthChanged after invalidating so live sessions can be torn down', async () => {
+    process.env.FIREWORKS_API_KEY = 'fw_test'
+    getAuthFor('fireworks')
+
+    const calls: string[] = []
+    const result = await createProviderAuthReloadable({
+      onProviderAuthChanged: () => {
+        calls.push('changed')
+      },
+    }).reload()
+
+    expect(result.ok).toBe(true)
+    expect(calls).toEqual(['changed'])
+  })
+
+  test('reports success even when no provider auth was cached yet', async () => {
+    const result = await createProviderAuthReloadable().reload()
+    expect(result.ok).toBe(true)
+  })
+})

--- a/src/agent/auth-reloadable.ts
+++ b/src/agent/auth-reloadable.ts
@@ -1,0 +1,24 @@
+import type { Reloadable, ReloadResult } from '@/reload'
+
+import { invalidateProviderAuthCache } from './auth'
+
+export type CreateProviderAuthReloadableOptions = {
+  // Fired after the auth cache is cleared. The run stage wires this to channel
+  // session teardown so live sessions — which captured an AuthStorage at
+  // creation — are recreated with freshly-resolved credentials.
+  onProviderAuthChanged?: () => void | Promise<void>
+}
+
+export function createProviderAuthReloadable({
+  onProviderAuthChanged,
+}: CreateProviderAuthReloadableOptions = {}): Reloadable {
+  return {
+    scope: 'providers',
+    description: 'secrets.json provider credentials',
+    reload: async (): Promise<ReloadResult> => {
+      invalidateProviderAuthCache()
+      await onProviderAuthChanged?.()
+      return { scope: 'providers', ok: true, summary: 'provider auth cache cleared' }
+    },
+  }
+}

--- a/src/agent/auth.ts
+++ b/src/agent/auth.ts
@@ -90,6 +90,18 @@ export function getAuth(): Auth {
   return getAuthFor(providerForModelRef(defaultRef))
 }
 
+// Clears the per-provider cache so the next getAuthFor() re-resolves from
+// secrets.json (bind-mounted live) and re-layers process.env. Wired into
+// `typeclaw reload` via the providers reloadable so a rotated secrets.json
+// key takes effect without a container restart. Resolution stays lazy, so a
+// half-written secrets.json can't turn reload into getAuthFor's process-kill;
+// the missing-credential exit only fires on next actual use. Does NOT mutate
+// live AgentSessions that already captured an AuthStorage — the run stage
+// tears those down so the next session is built with fresh auth.
+export function invalidateProviderAuthCache(): void {
+  cached.clear()
+}
+
 export function resetAuthForTesting(): void {
   cached.clear()
 }

--- a/src/cli/provider.ts
+++ b/src/cli/provider.ts
@@ -438,5 +438,12 @@ function describeSource(source: CredentialSource): string {
 
 function nextStepHints(opts: { credentialChanged: boolean }): { label: string; command: string }[] {
   if (!opts.credentialChanged) return []
-  return [{ label: 'If the agent is running:', command: 'typeclaw reload' }]
+  // secrets.json is bind-mounted live, so `typeclaw reload` clears the provider
+  // auth cache and the next call re-reads this file. Editing a key's value in
+  // .env instead still needs a restart — container env is fixed at `docker run`
+  // — so surface both paths to the user, not just reload.
+  return [
+    { label: 'Apply the secrets.json change:', command: 'typeclaw reload' },
+    { label: 'If you changed a key in .env:', command: 'typeclaw restart' },
+  ]
 }

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -286,6 +286,14 @@ describe('startAgent', () => {
     expect(running.reloadRegistry.has('cron')).toBe(true)
   })
 
+  test('registers the providers reload scope before channels so secrets.json key rotation takes effect on reload', async () => {
+    running = await startAgent({ port: 0, attachTui: false, cwd: testCwd, loadCron: noCron })
+
+    expect(running.reloadRegistry.has('providers')).toBe(true)
+    const scopes = running.reloadRegistry.list().map((r) => r.scope)
+    expect(scopes.indexOf('providers')).toBeLessThan(scopes.indexOf('channels'))
+  })
+
   test('logs and continues when cron.json fails to load', async () => {
     const loadCron: LoadCronFn = async () => ({ ok: false, reason: 'bad json' }) as LoadCronResult
     const factoryCalls: Array<{ cwd: string; file: CronFile }> = []

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -1,6 +1,7 @@
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, createSessionWithDispose } from '@/agent'
+import { createProviderAuthReloadable } from '@/agent/auth-reloadable'
 import { LiveSessionRegistry } from '@/agent/live-sessions'
 import { LiveSubagentRegistry } from '@/agent/live-subagents'
 import { requestContainerRestart } from '@/agent/restart'
@@ -738,6 +739,17 @@ async function startAgentRuntime(
       payload: { kind: 'pr.verdict-activity', ...review },
     })
   })
+
+  // Registered before channels so its cache clear lands before any channel
+  // session teardown observes it. secrets.json provider credentials are not
+  // part of the typeclaw.json config diff, so a rotated key takes effect on
+  // `typeclaw reload` only via this dedicated scope. Live sessions captured
+  // their AuthStorage at creation, so teardown recreates them with fresh auth.
+  reloadRegistry.register(
+    createProviderAuthReloadable({
+      onProviderAuthChanged: () => channelManager.router.tearDownAllLive(),
+    }),
+  )
 
   reloadRegistry.register(createChannelsReloadable({ manager: channelManager }))
 


### PR DESCRIPTION
## Problem

Provider credentials (`secrets.json#providers.<id>`) never took effect on `typeclaw reload` — they required a full container restart.

Two root causes:

1. **The auth cache is boot-only.** `getAuthFor()` in `src/agent/auth.ts` lazily builds an `AuthStorage` + `ModelRegistry` per provider into a module-level `Map` and **never invalidates it** at runtime (the only clearer was `resetAuthForTesting()`).
2. **`secrets.json` is outside the config diff.** The `config` reloadable only re-reads `typeclaw.json` and diffs against `FIELD_EFFECTS`. Provider credentials live in a separate file, so nothing in the reload path ever touched them.

The irony: `typeclaw provider add/set/remove` writes `secrets.json` and then hints `typeclaw reload` — but reload didn't actually pick the change up.

## Fix

A dedicated **`providers` reload scope**:

- `invalidateProviderAuthCache()` (new, production) clears the per-provider cache. The next `getAuthFor()` re-resolves from `secrets.json` (bind-mounted live) and re-layers `process.env`.
- `createProviderAuthReloadable()` (`scope: 'providers'`) runs that on reload, then fires an optional `onProviderAuthChanged` callback.
- Registered in `src/run/index.ts` **before** `channels`, with the callback wired to `router.tearDownAllLive()`.

### Why teardown is required

Live `AgentSession`s capture the `AuthStorage` object at creation time (`createSession` → `createAgentSession({ authStorage, modelRegistry })`). Clearing the module cache alone can't rotate an in-flight session's credentials — so the run stage tears live channel sessions down; the next inbound rebuilds them with fresh auth. New sessions (TUI, cron, post-timeout channel) pick up the new auth via the cache miss directly.

### Safety

Invalidation is **unconditional** and resolution stays **lazy**, so a half-written `secrets.json` during reload can't turn into `getAuthFor`'s `process.exit(1)` — the missing-credential exit only fires on next actual use. Registration order is load-bearing (the registry runs serially), so providers must precede channels for the cache clear to land before teardown observes it.

### Caveat (documented, not fixed — by design)

Host `.env` **value** edits still require a restart: container env is fixed at `docker run --env-file`. The provider CLI hint now states this boundary. `secrets.json` edits — the file the CLI actually writes — work on reload.

## Test plan

- `src/agent/auth-reloadable.test.ts` (new): scope/description; cache cleared so a rotated key yields a fresh `AuthStorage`; `onProviderAuthChanged` fires after invalidation; succeeds when nothing was cached.
- `src/run/index.test.ts`: asserts the `providers` scope is registered **before** `channels`.
- `bun run lint` (0 errors), `bun run format:check`, `bun run typecheck`, `bun run test` (**10142 pass, 0 fail**) all green.