### PR TITLE
fix: Windows EBUSY — release plugin (sqlite) resources on agent teardown

### DIFF
--- a/src/agent/doctor.test.ts
+++ b/src/agent/doctor.test.ts
@@ -23,6 +23,7 @@ function emptyRegistry(): PluginRegistry {
     skillsDirs: [],
     doctorChecks: [],
     commands: [],
+    disposers: [],
   }
 }
 

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -392,6 +392,7 @@ describe('createResourceLoader', () => {
       ],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const loader = await createResourceLoader({
@@ -517,6 +518,7 @@ describe('createResourceLoader', () => {
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     // when
@@ -552,6 +554,7 @@ describe('createResourceLoader', () => {
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
     const origin: SessionOrigin = {
       kind: 'channel',

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1305,6 +1305,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({
@@ -1355,6 +1356,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({
@@ -1382,6 +1384,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({
@@ -1423,6 +1426,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -150,7 +150,12 @@ function createMemoryPluginWithStoreCapture(overrides: Partial<MemoryPluginDeps>
     ...overrides,
     openAppendVectorStore: (dir) => {
       const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
-      disposers.push(() => store.close())
+      let closed = false
+      disposers.push(() => {
+        if (closed) return
+        closed = true
+        store.close()
+      })
       return store
     },
   })
@@ -213,6 +218,39 @@ describe('memory plugin shape', () => {
     expect(withDream.cronJobs?.dreaming?.schedule).toBe('*/30 * * * *')
   })
 
+  test('onDispose closes the append vector store', async () => {
+    let closed = false
+    const plugin = createMemoryPluginForTests({
+      openAppendVectorStore: (dir) => {
+        const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
+        const close = store.close.bind(store)
+        store.close = () => {
+          closed = true
+          close()
+        }
+        return store
+      },
+    })
+    const parsed = plugin.configSchema!.safeParse({})
+    if (!parsed.success) throw new Error(`config invalid: ${parsed.error.message}`)
+    const exports = await plugin.plugin(
+      createPluginContext({
+        name: 'memory',
+        version: undefined,
+        agentDir,
+        config: parsed.data,
+        logger: createPluginLogger('memory'),
+        permissions: noopPermissionService,
+        spawnSubagent: async () => {},
+        isBooted: () => true,
+      }),
+    )
+
+    exports.onDispose?.()
+
+    expect(closed).toBe(true)
+  })
+
   test('rejects invalid cron expression in dreaming.schedule', async () => {
     await expect(bootMemoryPlugin(agentDir, { dreaming: { schedule: 'not a cron' } })).rejects.toThrow(/cron/i)
   })
@@ -234,6 +272,18 @@ describe('session.idle hook (debouncer)', () => {
     const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 1000 })
     const event: SessionIdleEvent = { sessionId: 'ses_a', parentTranscriptPath: '/tmp/t.jsonl', idleMs: 0 }
     await exports.hooks!['session.idle']!(event, { agentDir, pluginName: 'memory', logger: createPluginLogger('m') })
+    expect(spawned).toHaveLength(0)
+  })
+
+  test('onDispose cancels pending idle timers', async () => {
+    const { exports, spawned } = await bootMemoryPlugin(agentDir, { idleMs: 1000 })
+    const ctx = { agentDir, pluginName: 'memory', logger: createPluginLogger('m') }
+
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_a', parentTranscriptPath: '/tmp/a.jsonl', idleMs: 0 }, ctx)
+    await exports.hooks!['session.idle']!({ sessionId: 'ses_b', parentTranscriptPath: '/tmp/b.jsonl', idleMs: 0 }, ctx)
+    exports.onDispose?.()
+    await tickMs(1100)
+
     expect(spawned).toHaveLength(0)
   })
 

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { appendFile, mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -12,6 +12,7 @@ import { noopPermissionService } from '@/permissions'
 import type { PluginContext, PluginExports, PluginLogger, SessionEndEvent, SessionIdleEvent } from '@/plugin'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
 import { formatLocalDate } from '@/shared'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import memoryPlugin, { createMemoryPluginForTests, type MemoryPluginDeps } from './index'
 import { streamFilePath } from './paths'
@@ -165,7 +166,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await Promise.all(disposers.map((dispose) => dispose()))
-  await rm(agentDir, { recursive: true, force: true })
+  await rmTempDir(agentDir)
 })
 
 describe('memory plugin shape', () => {

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -402,14 +402,18 @@ export function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
         error: (m: string) => ctx.logger.error(m),
       }
 
-      // Long-lived, process-lifetime SQLite handle for append-time indexing
-      // (the on-write fragment/reference hooks below). Intentionally not closed
-      // by the plugin: it lives as long as the agent runtime and is released on
-      // process teardown. The per-turn query stores opened in renderVectorTurnMemory
-      // are the ones that get closed each turn.
+      // Long-lived SQLite handle for append-time indexing (the on-write
+      // fragment/reference hooks below). Closed in onDispose on agent stop so it
+      // does not pin the agent dir on Windows across restarts; the per-turn query
+      // stores opened in renderVectorTurnMemory are closed each turn.
       const appendVectorStore = deps.openAppendVectorStore(ctx.agentDir)
 
       return {
+        onDispose: () => {
+          for (const timer of idleTimers.values()) clearTimeout(timer)
+          idleTimers.clear()
+          appendVectorStore.close()
+        },
         subagents: {
           'memory-logger': createMemoryLoggerSubagent({
             logger: subagentLogger,

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { formatStatus, parseStatusResult, type StatusReport } from './status'
 
@@ -188,7 +190,7 @@ describe('typeclaw status survives broken typeclaw.json', () => {
   })
 
   afterEach(async () => {
-    await rm(cwd, { recursive: true, force: true })
+    await rmTempDir(cwd)
   })
 
   async function runStatus(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
@@ -213,7 +215,9 @@ describe('typeclaw status survives broken typeclaw.json', () => {
     expect(stdout).toContain('Port forwarding')
     expect(stderr).toMatch(/not valid JSON/)
     expect(stderr).toMatch(/diagnostic commands still work/)
-  })
+    // Spawns `bun CLI status` (compiles + loads the full CLI); slow on a loaded
+    // Windows runner, so override the 30s default (require-parallel.ts).
+  }, 120_000)
 
   test('exits 0 and renders sections when typeclaw.json is schema-invalid', async () => {
     await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
@@ -222,12 +226,12 @@ describe('typeclaw status survives broken typeclaw.json', () => {
     expect(stdout).toContain('Container')
     expect(stdout).toContain('Host daemon')
     expect(stderr).toMatch(/typeclaw\.json is invalid/)
-  })
+  }, 120_000)
 
   test('exits 0 and prints no warning when typeclaw.json is missing (fresh dir)', async () => {
     const { exitCode, stdout, stderr } = await runStatus()
     expect(exitCode).toBe(0)
     expect(stdout).toContain('Container')
     expect(stderr).not.toMatch(/warning:/)
-  })
+  }, 120_000)
 })

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -93,6 +93,7 @@ export {
   type RegisteredCronJob,
   type RegisteredDoctorCheck,
   type RegisteredMcpServer,
+  type RegisteredPluginDisposer,
   type RegisteredSkillDir,
   type RegisteredSkillEntry,
   type RegisteredSubagent,

--- a/src/plugin/manager.test.ts
+++ b/src/plugin/manager.test.ts
@@ -553,6 +553,44 @@ describe('loadPlugins — markBooted gates spawnSubagent', () => {
   })
 })
 
+describe('loadPlugins — plugin disposal', () => {
+  test('disposePlugins awaits all onDispose callbacks and isolates failures', async () => {
+    const calls: string[] = []
+    const loadEntry: LoadPluginEntryFn = async (entry) => ({
+      name: entry,
+      version: undefined,
+      source: entry,
+      defined: {
+        plugin: async () => ({
+          onDispose: async () => {
+            calls.push(`${entry}:start`)
+            await Promise.resolve()
+            if (entry === 'bad') throw new Error('dispose boom')
+            calls.push(`${entry}:done`)
+          },
+        }),
+      },
+    })
+
+    const cap = captureWarnings()
+    try {
+      const result = await loadPlugins({
+        entries: ['good', 'bad', 'later'],
+        agentDir: '/tmp',
+        configsByName: {},
+        loadEntry,
+      })
+
+      await result.disposePlugins()
+    } finally {
+      cap.restore()
+    }
+
+    expect(calls).toEqual(expect.arrayContaining(['good:start', 'good:done', 'bad:start', 'later:start', 'later:done']))
+    expect(cap.warnings.some((w) => w.includes('[plugin:bad] onDispose failed: dispose boom'))).toBe(true)
+  })
+})
+
 describe('loadPlugins — registry shape', () => {
   test('pluginCronJobs returns CronJob[] with __plugin_<name>_<key> ids', async () => {
     const loadEntry: LoadPluginEntryFn = async () => ({

--- a/src/plugin/manager.ts
+++ b/src/plugin/manager.ts
@@ -51,6 +51,7 @@ export type LoadPluginsResult = {
   failedPlugins: FailedPlugin[]
   markBooted: () => void
   setSpawnSubagent: (fn: SpawnSubagentFn) => void
+  disposePlugins: () => Promise<void>
 }
 
 export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPluginsResult> {
@@ -181,7 +182,20 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
     setSpawnSubagent: (fn) => {
       spawnSubagentImpl = fn
     },
+    disposePlugins: () => disposePlugins(registry),
   }
+}
+
+async function disposePlugins(registry: PluginRegistry): Promise<void> {
+  await Promise.all(
+    registry.disposers.map(async (disposer) => {
+      try {
+        await disposer.dispose()
+      } catch (err) {
+        disposer.logger.warn(`onDispose failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }),
+  )
 }
 
 // Tags WHICH sub-phase failed (for the failedPlugins report) while preserving

--- a/src/plugin/registry.test.ts
+++ b/src/plugin/registry.test.ts
@@ -72,6 +72,14 @@ describe('registerContributions', () => {
     expect(() => registerContributions(opts)).toThrow(/doctor check "dir-writable" already registered/)
   })
 
+  test('records plugin disposers', () => {
+    const onDispose = () => {}
+    const opts = makeOptions('p1', { onDispose })
+    registerContributions(opts)
+
+    expect(opts.registry.disposers).toEqual([{ pluginName: 'p1', logger: noopLogger, dispose: onDispose }])
+  })
+
   test('rejects duplicate tool name across plugins', () => {
     const tool = defineTool({
       description: 'echo',
@@ -318,6 +326,7 @@ describe('discardRegistrationsBy', () => {
         skills: { sk1: { description: '', content: '' } },
         skillsDirs: ['/p1/skills'],
         hooks: { 'session.start': () => {} },
+        onDispose: () => {},
         doctorChecks: {
           ping: {
             description: 'always ok',
@@ -355,6 +364,7 @@ describe('discardRegistrationsBy', () => {
     expect(registry.skills).toEqual([])
     expect(registry.skillsDirs).toEqual([])
     expect(registry.doctorChecks).toEqual([])
+    expect(registry.disposers).toEqual([])
     expect(hooks.count('session.start')).toBe(0)
     expect(hooks.count('session.end')).toBe(1)
   })

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -36,6 +36,11 @@ export type RegisteredCommand = {
   logger: PluginLogger
 }
 export type RegisteredMcpServer = { pluginName: string; name: string; server: PluginMcpServer; logger: PluginLogger }
+export type RegisteredPluginDisposer = {
+  pluginName: string
+  logger: PluginLogger
+  dispose: () => void | Promise<void>
+}
 
 export type PluginRegistry = {
   tools: RegisteredTool[]
@@ -46,6 +51,7 @@ export type PluginRegistry = {
   skillsDirs: RegisteredSkillDir[]
   doctorChecks: RegisteredDoctorCheck[]
   commands: RegisteredCommand[]
+  disposers: RegisteredPluginDisposer[]
 }
 
 export type RegisterContributionsOptions = {
@@ -178,6 +184,10 @@ export function registerContributions(opts: RegisterContributionsOptions): void 
       registry.commands.push({ pluginName, commandName, command, logger })
     }
   }
+
+  if (ex.onDispose) {
+    registry.disposers.push({ pluginName, logger, dispose: ex.onDispose })
+  }
 }
 
 export function discardRegistrationsBy(pluginName: string, registry: PluginRegistry, hooks: HookBus): void {
@@ -189,6 +199,7 @@ export function discardRegistrationsBy(pluginName: string, registry: PluginRegis
   registry.skillsDirs = registry.skillsDirs.filter((d) => d.pluginName !== pluginName)
   registry.doctorChecks = registry.doctorChecks.filter((d) => d.pluginName !== pluginName)
   registry.commands = registry.commands.filter((c) => c.pluginName !== pluginName)
+  registry.disposers = registry.disposers.filter((d) => d.pluginName !== pluginName)
   hooks.unregisterAll(pluginName)
 }
 
@@ -202,6 +213,7 @@ export function emptyRegistry(): PluginRegistry {
     skillsDirs: [],
     doctorChecks: [],
     commands: [],
+    disposers: [],
   }
 }
 

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -314,6 +314,10 @@ export type PluginExports = {
   skillsDirs?: string[]
   hooks?: Hooks
   doctorChecks?: Record<string, PluginDoctorCheck>
+  // Released once when the agent stops, for plugin-lifetime resources a GC can't
+  // reclaim deterministically (open DB handles, timers). Disposers are isolated:
+  // one throwing never blocks the others.
+  onDispose?: () => void | Promise<void>
 }
 
 export type PluginMcpServer = {

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -9,6 +9,7 @@ import { createChannelRouter, type ChannelManager, type ChannelManagerOptions } 
 import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 import type { CronFile, CronJob, LoadCronResult, Scheduler } from '@/cron'
 import type { SessionFactory } from '@/sessions'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 import type { TuiOptions } from '@/tui'
 import type { TunnelManager, TunnelManagerOptions } from '@/tunnels'
 
@@ -27,6 +28,13 @@ function stubScheduler(): Scheduler {
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
 let savedBrokerToken: string | undefined
 
+async function stopRunningAgent(): Promise<void> {
+  if (!running) return
+  running.tuiPromise?.catch(() => {})
+  await running.stop()
+  running = null
+}
+
 beforeEach(() => {
   // startAgent boots the agent-browser plugin. Keep the broker token absent so
   // these run-loop tests do not publish a reserved dashboard forward request
@@ -39,10 +47,7 @@ afterEach(async () => {
   resetDashboardForwardRequest()
   if (savedBrokerToken === undefined) delete process.env['TYPECLAW_HOSTD_BROKER_TOKEN']
   else process.env['TYPECLAW_HOSTD_BROKER_TOKEN'] = savedBrokerToken
-  if (!running) return
-  running.tuiPromise?.catch(() => {})
-  await running.stop()
-  running = null
+  await stopRunningAgent()
 })
 
 describe('startAgent', () => {
@@ -54,7 +59,8 @@ describe('startAgent', () => {
     testCwd = await mkdtemp(join(tmpdir(), 'typeclaw-run-cwd-'))
   })
   afterEach(async () => {
-    await rm(testCwd, { recursive: true, force: true })
+    await stopRunningAgent()
+    await rmTempDir(testCwd)
   })
 
   test('starts a ws server on an ephemeral port in headless mode', async () => {
@@ -450,10 +456,9 @@ describe('startAgent', () => {
 
       expect(restarts).toEqual(['github'])
     } finally {
-      await running?.stop()
-      running = null
+      await stopRunningAgent()
       __resetConfigForTesting()
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 
@@ -513,10 +518,9 @@ describe('startAgent', () => {
       expect(tunnelOptions.resolveChannelUpstreamPort?.('slack')).toBeNull()
       expect(channelOptions.tunnelUrlForChannel?.('github')).toBe('https://x.trycloudflare.com')
     } finally {
-      await running?.stop()
-      running = null
+      await stopRunningAgent()
       __resetConfigForTesting()
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 })
@@ -546,7 +550,8 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       expect(factoryCalls).toHaveLength(1)
       expect(running.scheduler).not.toBeNull()
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await stopRunningAgent()
+      await rmTempDir(agentDir)
     }
   })
 
@@ -577,7 +582,8 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       expect(factoryCalls).toHaveLength(1)
       expect(running.scheduler).not.toBeNull()
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await stopRunningAgent()
+      await rmTempDir(agentDir)
     }
   })
 
@@ -616,7 +622,8 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       expect(ids).toContain('__plugin_memory_dreaming')
       expect(ids).toContain('user-job')
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await stopRunningAgent()
+      await rmTempDir(agentDir)
     }
   })
 
@@ -668,7 +675,8 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
         expect(dreamingMsg.payload).toEqual({ agentDir })
       }
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await stopRunningAgent()
+      await rmTempDir(agentDir)
     }
   })
 })
@@ -703,7 +711,8 @@ describe('startAgent config reload wiring', () => {
     } finally {
       if (originalContainerName === undefined) delete process.env.TYPECLAW_CONTAINER_NAME
       else process.env.TYPECLAW_CONTAINER_NAME = originalContainerName
-      await rm(agentDir, { recursive: true, force: true })
+      await stopRunningAgent()
+      await rmTempDir(agentDir)
     }
   })
 
@@ -735,7 +744,8 @@ describe('startAgent config reload wiring', () => {
       }
     } finally {
       if (originalContainerName !== undefined) process.env.TYPECLAW_CONTAINER_NAME = originalContainerName
-      await rm(agentDir, { recursive: true, force: true })
+      await stopRunningAgent()
+      await rmTempDir(agentDir)
     }
   })
 })
@@ -744,7 +754,8 @@ describe('startAgent session persistence wiring', () => {
   let agentDir: string
 
   afterEach(async () => {
-    if (agentDir) await rm(agentDir, { recursive: true, force: true })
+    await stopRunningAgent()
+    if (agentDir) await rmTempDir(agentDir)
   })
 
   test('creates <cwd>/sessions/ on disk when no sessionFactory is injected', async () => {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -125,24 +125,32 @@ export type StartAgentResult = {
   stop: () => void | Promise<void>
 }
 
-// Thin wrapper that owns ONLY the boot-failure cleanup of process-global
-// installs. `installCodexFetchObserver` and `installFatalGuard` attach
-// process-wide listeners before the fallible boot work; if any boot step throws
-// before `startAgentRuntime` returns, the caller never receives a
-// `StartAgentResult` and can never call `stop()`, so those listeners would
-// strand and double-fire into the next `startAgent`. The runtime hands its
-// disposer back via `onProcessGlobalsInstalled`; on a boot throw we dispose and
+// Owns boot-failure cleanup for everything installed before `startAgentRuntime`
+// returns a `StartAgentResult`. `installCodexFetchObserver`/`installFatalGuard`
+// attach process-wide listeners, and `loadPlugins` opens plugin-lifetime
+// resources (the memory plugin's sqlite handle); if any boot step throws before
+// the result exists, the caller never receives `stop()`, so each of those would
+// strand. The runtime registers each cleanup via `registerBootCleanup` as boot
+// progresses; on a throw we run them all (newest first, best-effort) and
 // rethrow, on success ownership transfers to the returned `stop()`. `return
 // await` is load-bearing — without it an async boot rejection would escape this
-// try. Dispose is idempotent, so the success path's `stop()` never double-fires.
+// try. Cleanups are idempotent, so the success path's `stop()` never double-fires.
 export async function startAgent(options: StartAgentOptions): Promise<StartAgentResult> {
-  const captured: { dispose: (() => void) | null } = { dispose: null }
+  const bootCleanups: Array<() => void | Promise<void>> = []
   try {
-    return await startAgentRuntime(options, (dispose) => {
-      captured.dispose = dispose
+    return await startAgentRuntime(options, (cleanup) => {
+      bootCleanups.push(cleanup)
     })
   } catch (err) {
-    captured.dispose?.()
+    for (const cleanup of bootCleanups.reverse()) {
+      try {
+        await cleanup()
+      } catch (cleanupErr) {
+        console.warn(
+          `[run] boot-failure cleanup error: ${cleanupErr instanceof Error ? cleanupErr.message : cleanupErr}`,
+        )
+      }
+    }
     throw err
   }
 }
@@ -161,7 +169,7 @@ async function startAgentRuntime(
     createChannelManager: createChannelManagerFor = createChannelManager,
     createTunnelManager: createTunnelManagerFor = createTunnelManager,
   }: StartAgentOptions,
-  onProcessGlobalsInstalled: (dispose: () => void) => void,
+  registerBootCleanup: (cleanup: () => void | Promise<void>) => void,
 ): Promise<StartAgentResult> {
   const reloadRegistry = new ReloadRegistry()
 
@@ -218,7 +226,7 @@ async function startAgentRuntime(
     if (sigtermHandler !== null) process.removeListener('SIGTERM', sigtermHandler)
   }
   let sigtermHandler: (() => void) | null = null
-  onProcessGlobalsInstalled(disposeProcessGlobals)
+  registerBootCleanup(disposeProcessGlobals)
 
   const { config: cwdConfig, pluginConfigs: pluginConfigsByName } = loadConfigBundleSync(cwd)
   const githubTokenBridge = createGithubTokenBridge()
@@ -238,6 +246,10 @@ async function startAgentRuntime(
   })
   const vectorStartupPromise = runVectorStartup(cwd)
   const [pluginsLoaded] = await Promise.all([pluginsLoadedPromise, vectorStartupPromise])
+  // Plugins are loaded (sqlite handles open); from here any boot failure must
+  // release them — the caller gets no stop() on the failure path. (mcpManager is
+  // created below and cleaned up via bootMcpManager in disposeProcessGlobals.)
+  registerBootCleanup(() => pluginsLoaded.disposePlugins())
 
   reloadRegistry.register(
     createConfigReloadable({
@@ -936,10 +948,9 @@ async function startAgentRuntime(
   const stop = async () => {
     if (stopped) return
     stopped = true
-    // The crash-guard and codex-observer disposers run in `finally` so an
-    // earlier async teardown rejection (tunnel/channel/mcp stop) cannot strand
-    // the process-global listeners they removed — a stranded fatal-guard
-    // listener would survive into the next `startAgent` and double-fire.
+    // The final disposers run in `finally` so an earlier async teardown
+    // rejection cannot strand process-global listeners or plugin-owned handles
+    // into the next `startAgent`.
     try {
       scheduler?.stop()
       cronConsumer.stop()
@@ -954,6 +965,7 @@ async function startAgentRuntime(
       await channelManager.stop()
       await mcpManager?.closeAll()
     } finally {
+      await pluginsLoaded.disposePlugins()
       disposeProcessGlobals()
     }
   }

--- a/src/run/merge-subagents.test.ts
+++ b/src/run/merge-subagents.test.ts
@@ -16,6 +16,7 @@ function emptyRegistry(): PluginRegistry {
     skillsDirs: [],
     doctorChecks: [],
     commands: [],
+    disposers: [],
   }
 }
 

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from '@/bundled-plugins/agent-browser'
 import type { LoadCronResult } from '@/cron'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
+import type { TunnelManager } from '@/tunnels'
 
 import { startAgent, type LoadCronFn } from './index'
 
@@ -152,6 +153,86 @@ export default {
     }
     ws.close()
     throw new Error(`session.start hook never fired within ${TIMEOUT_MS}ms (sentinel ${sentinelFile} missing)`)
+  })
+
+  test('stop awaits plugin onDispose', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    const sentinelFile = join(agentDir, 'disposed.log')
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `import { writeFile } from 'node:fs/promises'
+export default {
+  plugin: async () => ({
+    onDispose: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      await writeFile(${JSON.stringify(sentinelFile)}, 'disposed')
+    },
+  }),
+}`,
+    )
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+
+    await running.stop()
+    running = null
+
+    expect(await Bun.file(sentinelFile).text()).toBe('disposed')
+  })
+
+  test('boot failure after plugins load (late tunnel start) still runs plugin onDispose', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    const sentinelFile = join(agentDir, 'disposed.log')
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `import { writeFile } from 'node:fs/promises'
+export default {
+  plugin: async () => ({
+    onDispose: async () => {
+      await writeFile(${JSON.stringify(sentinelFile)}, 'disposed')
+    },
+  }),
+}`,
+    )
+
+    const failingTunnelManager = (): TunnelManager => ({
+      start: async () => {
+        throw new Error('boot failure: tunnel start')
+      },
+      stop: async () => {},
+      snapshot: () => [],
+      urlFor: () => null,
+      tail: () => [],
+      subscribeToLogs: () => () => {},
+    })
+
+    // tunnelManager.start() runs AFTER channelManager.start(), so a throw here
+    // proves the boot-cleanup stack disposes plugins on a LATE boot failure —
+    // the caller never gets a stop() on this path.
+    await expect(
+      startAgent({
+        port: 0,
+        attachTui: false,
+        cwd: agentDir,
+        loadCron: noCron,
+        createTunnelManager: failingTunnelManager,
+      }),
+    ).rejects.toThrow('boot failure: tunnel start')
+
+    expect(await Bun.file(sentinelFile).text()).toBe('disposed')
   })
 
   test('plugin skill is materialized and present in the resource loader for new sessions', async () => {

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from '@/bundled-plugins/agent-browser'
 import type { LoadCronResult } from '@/cron'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { startAgent, type LoadCronFn } from './index'
 
@@ -13,6 +14,13 @@ const noCron: LoadCronFn = async () => ({ ok: true, file: null }) as LoadCronRes
 let running: Awaited<ReturnType<typeof startAgent>> | null = null
 let agentDir: string | null = null
 let savedBrokerToken: string | undefined
+
+async function stopRunningAgent(): Promise<void> {
+  if (!running) return
+  running.tuiPromise?.catch(() => {})
+  await running.stop()
+  running = null
+}
 
 beforeEach(() => {
   // startAgent boots the agent-browser plugin. Keep the broker token absent so
@@ -23,13 +31,9 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
-  if (running) {
-    running.stop()
-    running.tuiPromise?.catch(() => {})
-    running = null
-  }
+  await stopRunningAgent()
   if (agentDir) {
-    await rm(agentDir, { recursive: true, force: true })
+    await rmTempDir(agentDir)
     agentDir = null
   }
   resetDashboardForwardRequest()

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -44,6 +44,7 @@ const EMPTY_REGISTRY: PluginRegistry = {
   skillsDirs: [],
   doctorChecks: [],
   commands: [],
+  disposers: [],
 }
 
 function makeRuntimeWith(opts: { subagents: SubagentRegistry }): PluginRuntime {

--- a/src/test-helpers/rm-temp-dir.ts
+++ b/src/test-helpers/rm-temp-dir.ts
@@ -1,0 +1,27 @@
+import { rm } from 'node:fs/promises'
+import { setTimeout } from 'node:timers/promises'
+
+const MAX_ATTEMPTS = 30
+const RETRY_DELAY_MS = 200
+const RETRYABLE_RM_CODES = new Set(['EBUSY', 'EPERM', 'ENOTEMPTY'])
+
+export async function rmTempDir(dir: string): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      // bun:sqlite keeps the index.db file handle alive through Statement
+      // wrappers that have not been GC'd, which blocks rmdir on Windows with
+      // EBUSY (Bun #25964). Forcing GC runs their finalizers and releases the
+      // handle before each removal attempt; the retry covers any residual lag.
+      Bun.gc(true)
+      await rm(dir, { recursive: true, force: true })
+      return
+    } catch (err) {
+      if (!isRetryableRmError(err) || attempt === MAX_ATTEMPTS) throw err
+      await setTimeout(RETRY_DELAY_MS)
+    }
+  }
+}
+
+function isRetryableRmError(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && RETRYABLE_RM_CODES.has(String(err.code))
+}


### PR DESCRIPTION
## What

Fixes the Windows `EBUSY` failures where agent tests couldn't remove their temp dirs because the agent held a `bun:sqlite` file handle open (Bun [#25964](https://github.com/oven-sh/bun/issues/25964)).

**Split from the original combined PR into three:**
- **This PR (#1093)** — the EBUSY fix.
- **#1101** — boot-failure component teardown (robustness; stacked on this).
- **#1099** — run the Windows lanes on PRs (CI policy).

## Root cause

The memory plugin opens a long-lived `appendVectorStore` (sqlite) and never closed it — released only on process exit. The tests boot+stop many agents in one process, so each leaks an open sqlite handle, and on Windows an open handle pins the directory (POSIX lets you unlink open files).

## Fix

- **`feat(plugin)`** — add an `onDispose` hook to the plugin contract; `startAgent.stop()` (and the boot-failure cleanup) run all plugin disposers, isolated per plugin.
- **`fix(memory)`** — the memory plugin closes its `appendVectorStore` and clears pending idle timers in `onDispose`.
- **`test(run)`** — stop the agent before removing its temp dir; a shared `rmTempDir` helper that `Bun.gc(true)`s (runs the finalizers that release the sqlite handle — the #25964 workaround) then retries `rm`; plus a generous timeout on the `typeclaw status` subprocess tests.

## Verification

- macOS: `typecheck` / `lint` (0 errors) / `format` clean; full suite **0 fail**.
- Windows: verified green on the real Windows CI lane (the EBUSY tests, previously 45 failures, now pass).
