### PR TITLE
fix(kakaotalk): engage on reply-to-bot when src_userId is a JSON string

### DIFF
--- a/src/channels/adapters/kakaotalk-classify.test.ts
+++ b/src/channels/adapters/kakaotalk-classify.test.ts
@@ -191,6 +191,75 @@ describe('classifyInbound', () => {
     expect(verdict.payload.replyToOtherMessageId).toBeNull()
   })
 
+  test('engages reply-to-bot when LOCO sends src_userId as a string (production shape)', () => {
+    const verdict = classifyInbound(
+      event({
+        message: 'yes, please',
+        message_type: 26,
+        attachment: {
+          attach_only: false,
+          src_logId: 'BOT-L1',
+          src_userId: '999',
+          src_message: 'Do you want me to summarize this?',
+          src_type: 1,
+        },
+      }),
+      dmConfig(),
+      { selfUserId: '999', lookupChat: dmLookup },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.replyToBotMessageId).toBe('BOT-L1')
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
+  })
+
+  test('compares large string ids without precision loss', () => {
+    const bigId = '9007199254740993123'
+    const verdict = classifyInbound(
+      event({
+        message: 'thanks',
+        message_type: 26,
+        attachment: {
+          attach_only: false,
+          src_logId: 'BOT-L9',
+          src_userId: bigId,
+          src_message: 'sure',
+          src_type: 1,
+        },
+      }),
+      dmConfig(),
+      { selfUserId: bigId, lookupChat: dmLookup },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.replyToBotMessageId).toBe('BOT-L9')
+  })
+
+  test('ignores a non-numeric src_userId rather than crediting the bot', () => {
+    const verdict = classifyInbound(
+      event({
+        message: 'hm',
+        message_type: 26,
+        attachment: {
+          attach_only: false,
+          src_logId: 'L-X',
+          src_userId: 'not-a-number',
+          src_message: 'context',
+          src_type: 1,
+        },
+      }),
+      dmConfig(),
+      { selfUserId: '999', lookupChat: dmLookup },
+    )
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.replyToBotMessageId).toBeNull()
+    expect(verdict.payload.replyToOtherMessageId).toBeNull()
+  })
+
   test('keeps raw text and sets referenceContext for replies to another user', () => {
     const verdict = classifyInbound(
       event({

--- a/src/channels/adapters/kakaotalk-classify.ts
+++ b/src/channels/adapters/kakaotalk-classify.ts
@@ -109,11 +109,10 @@ function parseReplyContext(event: KakaoTalkPushMessageEvent, selfUserId: string)
   if (event.message_type !== KAKAO_MESSAGE_TYPE.REPLY) return null
   if (event.attachment === null) return null
 
-  const logId = stringField(event.attachment, 'src_logId')
-  const sourceUserId = numericField(event.attachment, 'src_userId')
-  if (logId === null || sourceUserId === null) return null
+  const logId = scalarIdField(event.attachment, 'src_logId')
+  const sourceAuthorId = decimalIdField(event.attachment, 'src_userId')
+  if (logId === null || sourceAuthorId === null) return null
 
-  const sourceAuthorId = String(sourceUserId)
   const quotedText = stringField(event.attachment, 'src_message')
   return {
     logId,
@@ -150,7 +149,33 @@ function stringField(record: Record<string, unknown>, key: string): string | nul
   return typeof value === 'string' && value.length > 0 ? value : null
 }
 
-function numericField(record: Record<string, unknown>, key: string): number | null {
+// LOCO reply attachments are unvalidated `JSON.parse` output: `src_userId` arrives
+// as a string in production despite the SDK annotating it `number`, so a number-only
+// reader dropped every reply-to-bot. `src_userId` gates the bot-vs-other identity
+// check, so require digits and keep it as an opaque string — never `Number()` a
+// 64-bit id (lossy past 2^53).
+function decimalIdField(record: Record<string, unknown>, key: string): string | null {
   const value = record[key]
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return /^\d+$/.test(trimmed) ? trimmed : null
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value >= 0 ? String(value) : null
+  }
+  return null
+}
+
+// `src_logId` is an opaque message reference we only echo back, never compare for
+// identity, so accept any non-empty scalar (string or integer) without digit-gating.
+function scalarIdField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value >= 0 ? String(value) : null
+  }
+  return null
 }

--- a/src/channels/adapters/kakaotalk.ts
+++ b/src/channels/adapters/kakaotalk.ts
@@ -480,7 +480,7 @@ export function createKakaotalkAdapter(options: KakaotalkAdapterOptions): Kakaot
         authorName: resolvedName ?? verdict.payload.authorId,
       }
       logger.info(
-        `[kakaotalk] routed log_id=${event.log_id} ${inboundTag} mention=${enriched.isBotMention} dm=${enriched.isDm}`,
+        `[kakaotalk] routed log_id=${event.log_id} ${inboundTag} mention=${enriched.isBotMention} reply=${enriched.replyToBotMessageId !== null} dm=${enriched.isDm}`,
       )
       await options.router.route(enriched)
     } catch (err) {


### PR DESCRIPTION
## Background

A user directly replied to the bot's own message in a KakaoTalk group chat and the agent stayed silent — it `observed` the message instead of engaging. Production logs for the incident:

```
[kakaotalk] inbound log_id=… author=… bucket=@kakao-group chat=… type=26 text_len=11
[kakaotalk] routed  log_id=… bucket=@kakao-group chat=… mention=false dm=false
[channels] kakaotalk:@kakao-group:…: observed id=…
```

`type=26` is `KAKAO_MESSAGE_TYPE.REPLY`, so this *was* a native reply. The bot had posted in that same chat earlier, so a genuine reply-to-bot should have hit the `reply` engage trigger (`engagement.ts`: `config.trigger.includes('reply') && message.replyToBotMessageId !== null`). It never has — there is no record of a `type=26` reply ever engaging this agent.

Root cause: KakaoTalk LOCO reply attachments reach us as raw, unvalidated `JSON.parse` output (agent-messenger passes the blob straight through). The SDK type annotates `attachment.src_userId` as `number`, but in production the LOCO server serializes it as a **string**. The classifier read it with a number-only helper (`typeof value === 'number' ? … : null`), so `src_userId` came back `null`, `parseReplyContext` bailed out, `replyToBotMessageId` stayed `null`, and the reply fell through to `observe`. The existing unit tests passed only because their fixtures hand-craft `src_userId` as a JS number — the exact shape production never sends.

## Summary

Stop treating KakaoTalk reply ids as numbers. `src_userId` is now read as an opaque decimal string accepting both the JSON-number and numeric-string shapes, and compared against `selfUserId` purely as strings.

- **Why string comparison, not numeric** — LOCO user/log ids are 64-bit; routing them through `Number()` is lossy past 2^53. `selfUserId` already arrives as a string from `getProfile()`, so a string compare is both correct and precision-safe.
- **Why two helpers** — `src_userId` gates the bot-vs-other identity decision, so it's digit-validated. `src_logId` is only echoed back (never compared), so it accepts any non-empty scalar; tightening it to digits would risk dropping valid replies if the id format ever varies.
- Added the missing `reply=` field to the KakaoTalk `routed` log line. Every other adapter (slack/discord/telegram/webex) already logs it; KakaoTalk's omission is precisely why this bug was invisible in the logs for so long.

## What this does NOT do

- Does not change the engagement decision logic itself (`engagement.ts` is untouched) — the `reply` trigger was always correct; it just never received a non-null `replyToBotMessageId`.
- Does not add runtime schema validation/coercion to the agent-messenger attachment payload; the fix is scoped to the fields the classifier actually reads.
- Does not touch other adapters.

## Review notes

- Load-bearing change: `decimalIdField` / `scalarIdField` in `src/channels/adapters/kakaotalk-classify.ts`, and the string-only comparison in `parseReplyContext`.
- Invariant to verify: a reply whose `src_userId` equals the bot's own id (whether sent as `999` or `"999"`) must set `replyToBotMessageId`; a non-numeric `src_userId` must be ignored rather than mis-credited to the bot. Regression tests cover the production string shape, a >2^53 id, and the non-numeric reject case.