### PR TITLE
feat(glm-vision): first-party GLM Coding Plan vision plugin

### DIFF
--- a/docs/content/docs/reference/bundled-plugins.mdx
+++ b/docs/content/docs/reference/bundled-plugins.mdx
@@ -4,7 +4,7 @@ description: Plugins shipped with TypeClaw; auto-loaded, not listed in plugins[]
 icon: Package
 ---
 
-Nine plugins ship with TypeClaw and load automatically. You don't list them in `plugins[]`; they're always on. Their config blocks live at the top level of `typeclaw.json`, namespaced by plugin name.
+Bundled plugins ship with TypeClaw and load automatically. You don't list them in `plugins[]`; they're always on. Their config blocks live at the top level of `typeclaw.json`, namespaced by plugin name.
 
 | Plugin            | Config key      | Contributions                                                                                                                                                    |
 | ----------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -14,6 +14,7 @@ Nine plugins ship with TypeClaw and load automatically. You don't list them in `
 | `memory`          | `memory`        | three subagents (`memory-logger`, `dreaming`, daily-stream rotator); writes daily memory streams and consolidates them into `MEMORY.md` and muscle-memory skills |
 | `backup`          | `backup`        | auto-commits `sessions/` and `memory/` on idle; LLM-generated commit subjects                                                                                    |
 | `agent-browser`   | `agentBrowser`  | headed Chrome under Xvfb for bot-resistant browsing; dashboard host-forward                                                                                      |
+| `glm-vision`      | `glm-vision`    | exposes the Z.AI vision MCP server for GLM Coding Plan agents when `ZAI_CODING_API_KEY` is present                                                               |
 | `explorer`        | none            | workspace exploration tools — file tree, glob, grep tuned for agent ergonomics                                                                                   |
 | `scout`           | none            | web-research subagent that scrapes and summarizes                                                                                                                |
 | `operator`        | none            | exposes the `operator` subagent — a focused worker that can write files and edit the workspace                                                                   |
@@ -54,6 +55,19 @@ Both fields restart-required. The `dreaming.schedule` is a standard 5-field cron
 ```
 
 `maxChars` is the threshold above which tool results are truncated (default 50 KB). Truncated output is replaced with a tail summary plus the path to the full result on disk. Restart-required.
+
+## `glm-vision`
+
+```json
+{
+  "glm-vision": {
+    "enabled": true,
+    "version": "0.1.4"
+  }
+}
+```
+
+`glm-vision` only activates for GLM Coding Plan agents (`defaultProviderId: "zai-coding"`). When `ZAI_CODING_API_KEY` is configured, it registers the `glm-vision` MCP server via `bunx @z_ai/mcp-server` and provides skill guidance for image, video, OCR, UI-to-code, diagram, and chart analysis. Without the key, it contributes the skill and a doctor warning but no MCP server. Set `enabled: false` to disable it entirely. Restart-required.
 
 ## Plugin permissions
 

--- a/src/bundled-plugins/glm-vision/index.test.ts
+++ b/src/bundled-plugins/glm-vision/index.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test'
+
+import { noopPermissionService } from '@/permissions'
+import type { PluginContext, PluginDoctorContext, PluginModels } from '@/plugin'
+import { stubPluginModels } from '@/plugin/test-support'
+
+import glmVisionPlugin from './index'
+
+const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+describe('glm vision plugin wiring', () => {
+  test('returns no exports when provider is not zai-coding', async () => {
+    // given: a non-GLM Coding Plan provider
+    const ctx = pluginContext({ defaultProviderId: 'fireworks', hasSecret: true })
+
+    // when: the plugin factory runs
+    const exports = await glmVisionPlugin.plugin(ctx)
+
+    // then: no MCP, skill, or doctor surface is contributed
+    expect(exports).toEqual({})
+  })
+
+  test('returns doctor check and skill but no MCP server when coding key is absent', async () => {
+    // given: a GLM Coding Plan agent without the coding key
+    const ctx = pluginContext({ defaultProviderId: 'zai-coding', hasSecret: false })
+
+    // when: the plugin factory runs
+    const exports = await glmVisionPlugin.plugin(ctx)
+
+    // then: guidance is available, but the MCP server is not activated
+    expect(exports.skillsDirs).toHaveLength(1)
+    expect(exports.doctorChecks?.['coding-key']).toBeDefined()
+    expect(exports.mcpServers).toBeUndefined()
+    await withZaiCodingKey(undefined, async () => {
+      const result = await exports.doctorChecks?.['coding-key']?.run(doctorContext())
+      expect(result?.status).toBe('warning')
+    })
+  })
+
+  test('exports pinned stdio MCP server when coding key is present', async () => {
+    // given: a GLM Coding Plan agent with the coding key
+    const ctx = pluginContext({ defaultProviderId: 'zai-coding', hasSecret: true })
+
+    // when: the plugin factory runs
+    const exports = await glmVisionPlugin.plugin(ctx)
+
+    // then: the Z.AI MCP server is wired with Secret object env entries
+    const server = exports.mcpServers?.['glm-vision']
+    expect(server?.transport.type).toBe('stdio')
+    if (server?.transport.type !== 'stdio') throw new Error('glm-vision MCP server did not use stdio')
+    expect(server.transport.command).toBe('bunx')
+    expect(server.transport.args).toContain('@z_ai/mcp-server@0.1.4')
+    expect(server.transport.env?.Z_AI_API_KEY).toEqual({ env: 'ZAI_CODING_API_KEY' })
+    expect(server.transport.env?.Z_AI_MODE).toEqual({ value: 'ZAI' })
+    await withZaiCodingKey('present', async () => {
+      const result = await exports.doctorChecks?.['coding-key']?.run(doctorContext())
+      expect(result?.status).toBe('ok')
+    })
+  })
+
+  test('activates when a non-default profile uses zai-coding', async () => {
+    // given: default runs a non-GLM provider but the deep profile uses the Coding Plan
+    const ctx = pluginContext({
+      models: stubPluginModels({
+        defaultProviderId: 'openai',
+        profiles: [{ profile: 'deep', providerId: 'zai-coding' }],
+      }),
+      hasSecret: true,
+    })
+
+    // when: the plugin factory runs
+    const exports = await glmVisionPlugin.plugin(ctx)
+
+    // then: the vision MCP is contributed because some profile uses zai-coding
+    expect(exports.mcpServers?.['glm-vision']).toBeDefined()
+  })
+
+  test('returns no exports when disabled', async () => {
+    // given: a disabled plugin config
+    const ctx = pluginContext({
+      defaultProviderId: 'zai-coding',
+      hasSecret: true,
+      config: { enabled: false, version: '0.1.4' },
+    })
+
+    // when: the plugin factory runs
+    const exports = await glmVisionPlugin.plugin(ctx)
+
+    // then: nothing is contributed
+    expect(exports).toEqual({})
+  })
+})
+
+function pluginContext(options: {
+  defaultProviderId?: string
+  models?: PluginModels
+  hasSecret: boolean
+  config?: { enabled: boolean; version: string }
+}): PluginContext<{ enabled: boolean; version: string }> {
+  return {
+    name: 'glm-vision',
+    version: undefined,
+    agentDir: '/agent',
+    config: options.config ?? { enabled: true, version: '0.1.4' },
+    models: options.models ?? stubPluginModels({ defaultProviderId: options.defaultProviderId ?? 'fireworks' }),
+    hasSecret: (envName) => envName === 'ZAI_CODING_API_KEY' && options.hasSecret,
+    logger: noopLogger,
+    permissions: noopPermissionService,
+    github: {
+      resolveTokenForRepo: async () => ({ kind: 'unavailable', reason: 'test' }),
+      hasAppTokenResolver: () => false,
+    },
+    spawnSubagent: async () => {},
+  }
+}
+
+function doctorContext(): PluginDoctorContext {
+  return { pluginName: 'glm-vision', agentDir: '/agent', config: {}, logger: noopLogger }
+}
+
+async function withZaiCodingKey(value: string | undefined, fn: () => Promise<void>): Promise<void> {
+  const previous = process.env.ZAI_CODING_API_KEY
+  try {
+    if (value === undefined) delete process.env.ZAI_CODING_API_KEY
+    else process.env.ZAI_CODING_API_KEY = value
+    await fn()
+  } finally {
+    if (previous === undefined) delete process.env.ZAI_CODING_API_KEY
+    else process.env.ZAI_CODING_API_KEY = previous
+  }
+}

--- a/src/bundled-plugins/glm-vision/index.ts
+++ b/src/bundled-plugins/glm-vision/index.ts
@@ -1,0 +1,63 @@
+import { join } from 'node:path'
+
+import { z } from 'zod'
+
+import { definePlugin } from '@/plugin'
+
+const glmVisionConfigSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    version: z.string().default('0.1.4'),
+  })
+  .default({ enabled: true, version: '0.1.4' })
+
+export default definePlugin({
+  configSchema: glmVisionConfigSchema,
+  permissions: ['mcp'],
+  plugin: async (ctx) => {
+    if (!ctx.config.enabled) return {}
+    if (!ctx.models.usesProvider('zai-coding')) return {}
+
+    const hasKey = ctx.hasSecret('ZAI_CODING_API_KEY')
+    const doctorChecks = {
+      'coding-key': {
+        description: 'GLM vision (Z.AI) coding-plan key is configured',
+        run: async () => {
+          // Presence-only; never read or log the secret value.
+          const keyPresent =
+            typeof process.env.ZAI_CODING_API_KEY === 'string' && process.env.ZAI_CODING_API_KEY.length > 0
+          if (keyPresent) {
+            return { status: 'ok' as const, message: 'ZAI_CODING_API_KEY present; GLM vision MCP active' }
+          }
+          return {
+            status: 'warning' as const,
+            message: 'Set ZAI_CODING_API_KEY to enable GLM vision (bunx @z_ai/mcp-server)',
+          }
+        },
+      },
+    }
+
+    const baseExports = {
+      skillsDirs: [join(import.meta.dir, 'skills')],
+      doctorChecks,
+    }
+
+    if (!hasKey) return baseExports
+
+    return {
+      ...baseExports,
+      mcpServers: {
+        'glm-vision': {
+          description:
+            'GLM-4.6V vision via the GLM Coding Plan: image/video analysis, OCR, UI-to-code, diagram and chart reading.',
+          transport: {
+            type: 'stdio' as const,
+            command: 'bunx',
+            args: [`@z_ai/mcp-server@${ctx.config.version}`],
+            env: { Z_AI_API_KEY: { env: 'ZAI_CODING_API_KEY' }, Z_AI_MODE: { value: 'ZAI' } },
+          },
+        },
+      },
+    }
+  },
+})

--- a/src/bundled-plugins/glm-vision/skills/glm-vision/SKILL.md
+++ b/src/bundled-plugins/glm-vision/skills/glm-vision/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: glm-vision
+description: 'Use GLM Coding Plan vision tools for image, video, screenshot, OCR, UI-to-code, diagram, chart, and UI diff analysis. Load when asked to inspect visual media while running a GLM Coding Plan agent.'
+---
+
+# GLM vision
+
+This agent's base GLM model is text-only: it cannot see images or videos directly.
+For visual inputs, call the `glm-vision__*` MCP tools with `mcp_call`.
+
+Use local file paths or URLs as inputs. If the user pasted or attached media, place
+it on disk first, then pass that path.
+
+Common tools:
+
+- `glm-vision__analyze_image` — general image understanding.
+- `glm-vision__extract_text_from_screenshot` — OCR from screenshots/images.
+- `glm-vision__ui_to_artifact` — convert UI screenshots into code/artifacts.
+- `glm-vision__diagnose_error_screenshot` — inspect error screenshots.
+- `glm-vision__understand_technical_diagram` — explain diagrams and architecture.
+- `glm-vision__analyze_data_visualization` — read charts and plots.
+- `glm-vision__ui_diff_check` — compare UI screenshots.
+- `glm-vision__analyze_video` — analyze video files or URLs.
+
+These calls draw from the GLM Coding Plan vision quota.

--- a/src/run/bundled-plugins.test.ts
+++ b/src/run/bundled-plugins.test.ts
@@ -25,6 +25,7 @@ describe('BUNDLED_PLUGINS', () => {
       'backup',
       'agent-browser',
       'doc-render',
+      'glm-vision',
       'explorer',
       'scout',
       'reviewer',

--- a/src/run/bundled-plugins.ts
+++ b/src/run/bundled-plugins.ts
@@ -4,6 +4,7 @@ import bunHygienePlugin from '@/bundled-plugins/bun-hygiene'
 import docRenderPlugin from '@/bundled-plugins/doc-render'
 import explorerPlugin from '@/bundled-plugins/explorer'
 import githubCliAuthPlugin from '@/bundled-plugins/github-cli-auth'
+import glmVisionPlugin from '@/bundled-plugins/glm-vision'
 import guardPlugin from '@/bundled-plugins/guard'
 import memoryPlugin from '@/bundled-plugins/memory'
 import operatorPlugin from '@/bundled-plugins/operator'
@@ -60,6 +61,7 @@ export const BUNDLED_PLUGINS: ResolvedPlugin[] = [
   { name: 'backup', version: undefined, source: '<bundled>', defined: backupPlugin },
   { name: 'agent-browser', version: undefined, source: '<bundled>', defined: agentBrowserPlugin },
   { name: 'doc-render', version: undefined, source: '<bundled>', defined: docRenderPlugin },
+  { name: 'glm-vision', version: undefined, source: '<bundled>', defined: glmVisionPlugin },
   { name: 'explorer', version: undefined, source: '<bundled>', defined: explorerPlugin },
   { name: 'scout', version: undefined, source: '<bundled>', defined: scoutPlugin },
   { name: 'reviewer', version: undefined, source: '<bundled>', defined: reviewerPlugin },


### PR DESCRIPTION
## What

Adds a first-party **bundled plugin** that gives GLM Coding Plan agents working vision by wiring Z.AI's `@z_ai/mcp-server` (GLM-4.6V) as an MCP server — built on the plugin↔MCP surface from #1095.

> **Stacked on #1095** (`feat/plugin-mcp-surface`). Review/merge that first.

## Why

Every GLM model is text-only (`input: ['text']`), so the native `look_at`/vision path has no model to route to on a coding-plan-only setup. The Z.AI vision MCP exposes GLM-4.6V through the **coding-plan vision quota** — no second provider needed. (Bun-compat verified: `bunx @z_ai/mcp-server` runs the full MCP stdio handshake on the container's Bun; no Node required.)

## Behavior (conditional activation — in the plugin factory)

| default provider | `ZAI_CODING_API_KEY` | plugin contributes |
|---|---|---|
| not `zai-coding` | — | **nothing** |
| `zai-coding` | absent | skill + doctor check (warning), **no** MCP server |
| `zai-coding` | present | skill + doctor check (ok) + the `glm-vision` MCP server |

- MCP server: `bunx @z_ai/mcp-server@<version>`, env `Z_AI_API_KEY ← ZAI_CODING_API_KEY`, `Z_AI_MODE = ZAI`. Tools surface as `glm-vision__image_analysis`, `glm-vision__analyze_video`, `glm-vision__extract_text_from_screenshot`, etc.
- **Skill** clarifies the agent's GLM model is image-blind and to call `glm-vision__*` via `mcp_call` with file paths/URLs — resolving the "two vision paths" ambiguity vs native `look_at`.
- **Doctor check** reports coding-plan key presence (presence-only; never reads the value).
- **Config**: `glm-vision.enabled` (default true), `glm-vision.version` (default `0.1.4`). Declares the `'mcp'` permission.

## Tests

Factory gating across all four branches (wrong provider / key absent / key present / disabled) + doctor-check statuses; integration confirms it loads in `BUNDLED_PLUGINS` and contributes 0 servers when the default provider isn't `zai-coding`.

## Checks

`bun run typecheck` ✓ · `bun run lint` (0 errors) ✓ · `bun run format` ✓ · `bun run test` (10201 pass / 0 fail) ✓