### PR TITLE
fix(subagent): raise deep-profile reviewer/planner spawn timeout to 30m

### DIFF
--- a/src/bundled-plugins/planner/planner.test.ts
+++ b/src/bundled-plugins/planner/planner.test.ts
@@ -282,7 +282,7 @@ describe('planner subagent declaration', () => {
   test('spawn timeout is generous enough for a deep-model plan but not unbounded', () => {
     const sub = createPlannerSubagent()
     const timeout = sub.timeoutMs ?? 0
-    expect(timeout).toBeGreaterThanOrEqual(60_000)
+    expect(timeout).toBeGreaterThanOrEqual(1_800_000)
     expect(timeout).toBeLessThanOrEqual(1_800_000)
   })
 

--- a/src/bundled-plugins/planner/planner.ts
+++ b/src/bundled-plugins/planner/planner.ts
@@ -38,8 +38,10 @@ export const PLANNER_SKILLS: readonly LoadableSkill[] = [PROJECT_PLAN_SKILL, GEN
 // request fails loudly. Sized for a thorough `deep`-model plan (research lookups
 // + a careful decomposition), well above the typical sub-minute plan. This is
 // liveness for the parent, not hard cancellation. See src/agent/subagents.ts
-// `timeoutMs`.
-export const PLANNER_SPAWN_TIMEOUT_MS = 600_000
+// `timeoutMs`. 30m matches the reviewer and researcher — every deep-profile
+// subagent shares the same nested-fan-out budget so a real pass is not killed
+// mid-synthesis.
+export const PLANNER_SPAWN_TIMEOUT_MS = 1_800_000
 
 // The default write zone for the plan file when the caller does not specify
 // `outputPath`. MUST be a universally-writable location, because a subagent

--- a/src/bundled-plugins/reviewer/reviewer.test.ts
+++ b/src/bundled-plugins/reviewer/reviewer.test.ts
@@ -239,10 +239,10 @@ describe('reviewer subagent declaration', () => {
     expect(sub.timeoutMs).toBeGreaterThan(0)
   })
 
-  test('spawn timeout is generous enough for a deep-model review but not unbounded', () => {
+  test('spawn timeout is generous enough for a deep-model review of a large PR but not unbounded', () => {
     const sub = createReviewerSubagent()
     const timeout = sub.timeoutMs ?? 0
-    expect(timeout).toBeGreaterThanOrEqual(60_000)
+    expect(timeout).toBeGreaterThanOrEqual(1_800_000)
     expect(timeout).toBeLessThanOrEqual(1_800_000)
   })
 

--- a/src/bundled-plugins/reviewer/reviewer.ts
+++ b/src/bundled-plugins/reviewer/reviewer.ts
@@ -51,7 +51,15 @@ export const REVIEWER_SKILLS: readonly LoadableSkill[] = [
 // liveness for the parent, not hard cancellation: pi's `session.prompt` takes no
 // AbortSignal, so the LLM stream may run until the OS reaps it. See
 // src/agent/subagents.ts `timeoutMs`.
-export const REVIEWER_SPAWN_TIMEOUT_MS = 600_000
+//
+// 30m, not the prior 10m: the `deep` profile trades speed for quality, and a
+// real review of a large PR (many changed files + nested scout fan-out + a few
+// web lookups + careful synthesis) routinely exceeds 10m. A 10m ceiling killed
+// both the first and retry reviews of a 27-file PR mid-analysis, leaving the PR
+// with no posted verdict — the exact "stranded review" failure the guards exist
+// to prevent. Matches RESEARCHER_SPAWN_TIMEOUT_MS, the other deep-profile
+// subagent that hit the same nested-fan-out wall.
+export const REVIEWER_SPAWN_TIMEOUT_MS = 1_800_000
 
 // The reviewer's read-only contract is enforced in depth: this system prompt
 // states it, the global bash guards (`secret-exfil-bash`, `git-exfil`) catch


### PR DESCRIPTION
## Background

A GitHub PR review went out with no verdict because the `reviewer` subagent timed out — twice. The reviewer runs on the `deep` model profile but kept the original 10m (`600_000`ms) spawn ceiling. On a large PR (27 changed files spanning docs, `src/mcp/`, `src/plugin/`, `src/run/`), the deep pass fanned out into nested `scout` subagents plus ~24 reads and ~10 greps, then ran out of budget:

- first reviewer: `reviewer failed after 600104ms: spawn timed out after 600000ms` → `ok=false`
- retry reviewer: identical 600s timeout → `ok=false`

The PR ended up `REVIEW_REQUIRED` with nothing posted — the "stranded review" failure the spawn timeout is supposed to *surface loudly*, not *cause*. The ceiling is liveness for the parent (so a wedged `session.prompt` doesn't hang forever), but 10m was simply too tight for a real deep-profile pass.

This is the same wall the `researcher` subagent already hit and was bumped for: its `RESEARCHER_SPAWN_TIMEOUT_MS` was raised from 10m → 30m for exactly this reason (nested scout warmup + multi-source gathering + synthesis routinely exceed 10m). The reviewer and planner are the remaining deep-profile subagents still on the old 10m ceiling.

## Summary

Raise the spawn timeout to 30m (`1_800_000`ms) for the two deep-profile subagents still on the old ceiling:

- `REVIEWER_SPAWN_TIMEOUT_MS`: `600_000` → `1_800_000`
- `PLANNER_SPAWN_TIMEOUT_MS`: `600_000` → `1_800_000`

**Why 30m and not a smaller bump:** it matches `RESEARCHER_SPAWN_TIMEOUT_MS`, so all three deep-profile subagents now share one nested-fan-out budget instead of drifting apart. **Why still bounded (not removed):** the ceiling exists for parent liveness — a stalled subagent must still fail loudly via `SubagentTimeoutError` rather than hang forever; this is liveness, not hard cancellation (`session.prompt` takes no `AbortSignal`).

The timeout tests previously asserted only a loose range (`>= 60_000 && <= 1_800_000`), which a 10m value satisfied too — so they didn't actually guard the value. They now assert the 30m floor (`>= 1_800_000`), verified by a revert-check: dropping the constant back to `600_000` makes the test fail.

## What this does NOT do

- Does not change the `fast`-profile subagents (`explorer`, `scout`) or the configurable `operator`.
- Does not add real cancellation — a half-open LLM stream still runs until the OS reaps it; only the parent's await settles and the coalescing key is released.
- Does not touch the retry/fan-out logic or reduce how much work a deep review does.

## Review notes

- Load-bearing change: the two constants in `src/bundled-plugins/{reviewer,planner}/*.ts`.
- Invariant to verify: both stay `<= 1_800_000` (the upper-bound assertion is unchanged), so the ceiling is raised but not unbounded.
- Rationale comments mirror the existing `researcher` constant comment so future readers know why 30m was chosen over 10m.
