### PR TITLE
fix(hostd): stop a renewal-triggered restart from wedging the daemon

### DIFF
--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -158,6 +158,48 @@ describe('startDaemon', () => {
     expect((await send({ kind: 'deregister', containerName: 'never' })).ok).toBe(true)
   })
 
+  test('a hung portbroker.stop does not wedge the container serial chain forever', async () => {
+    // portbroker.stop never resolves — the renewal-restart wedge failure mode.
+    // The cleanup timeout must let deregister settle so a later register for the
+    // SAME container (which serializes behind it) still succeeds.
+    const portbroker: PortbrokerCallbacks = {
+      start: async () => {},
+      stop: () => new Promise<void>(() => {}),
+      forwardedPorts: () => [],
+    }
+    daemon = await startDaemon({
+      exec: fakeExec(),
+      gcIntervalMs: 1_000_000,
+      portbroker,
+      cleanupStepTimeoutMs: 20,
+    })
+    await send({
+      kind: 'register',
+      containerName: 'coder',
+      cwd: '/x',
+      wsHostPort: 1,
+      portForward: { allow: '*' },
+      brokerToken: 'tok',
+    })
+
+    expect((await send({ kind: 'deregister', containerName: 'coder' })).ok).toBe(true)
+
+    const reReg = await send({
+      kind: 'register',
+      containerName: 'coder',
+      cwd: '/x2',
+      wsHostPort: 1,
+      portForward: { allow: '*' },
+      brokerToken: 'tok',
+    })
+    expect(reReg.ok).toBe(true)
+
+    const list = await send({ kind: 'list' })
+    expect(list.ok).toBe(true)
+    if (!list.ok) return
+    expect((list.result as ListResult).registrations).toEqual([{ containerName: 'coder', cwd: '/x2' }])
+  })
+
   test('GC removes registrations whose containers vanished', async () => {
     const alive = new Set(['coder'])
     daemon = await startDaemon({ exec: fakeExec(alive), gcIntervalMs: 30, gcMissesToDeregister: 1 })
@@ -991,7 +1033,7 @@ describe('startDaemon', () => {
     expect(starts).toEqual([{ containerName: 'kakao-agent', cwd: '/agent/kakao' }])
   })
 
-  test('deregister awaits kakaoRenewal.stop for that container', async () => {
+  test('deregister calls kakaoRenewal.stop for that container', async () => {
     const stopCalls: string[] = []
     const kakaoRenewal: KakaoRenewalCallbacks = {
       start: () => {},
@@ -1066,7 +1108,7 @@ describe('startDaemon', () => {
     expect(starts).toEqual([{ containerName: 'webex-agent', cwd: '/agent/webex' }])
   })
 
-  test('deregister awaits webexRenewal.stop for that container', async () => {
+  test('deregister calls webexRenewal.stop for that container', async () => {
     const stopCalls: string[] = []
     const webexRenewal: WebexRenewalCallbacks = {
       start: () => {},

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -41,6 +41,10 @@ export type DaemonOptions = {
   onLog?: (event: DaemonLogEvent | SupervisorLogEvent) => void
   gcIntervalMs?: number
   gcMissesToDeregister?: number
+  // Per-step bound on teardown calls (portbroker/renewal stop) run inside the
+  // per-container serial chain. Defaults to CLEANUP_STEP_TIMEOUT_MS; tests
+  // override it to a few ms to assert the chain never wedges on a hung step.
+  cleanupStepTimeoutMs?: number
   socket?: string
   // When provided, the daemon honors `restart` RPCs by invoking this with the
   // (containerName, cwd) it captured at register time. Omit to disable the
@@ -129,6 +133,14 @@ const DEFAULT_GC_INTERVAL_MS = 30_000
 const DEFAULT_GC_MISSES_TO_DEREGISTER = 3
 const MAX_REQUEST_BUFFER_BYTES = 64 * 1024
 const MAX_HTTP_REQUEST_BYTES = 64 * 1024
+
+// Upper bound on any single teardown step (portbroker/renewal stop) run inside
+// the per-container runSerially chain. A teardown dependency must never own a
+// container's serial queue forever — that wedges every later register/deregister
+// for that container (the renewal-restart wedge). Larger than tailscale's 30s
+// per-call budget so a slow-but-progressing serve-off isn't cut off, yet finite
+// so a genuine hang releases the queue instead of poisoning it.
+const CLEANUP_STEP_TIMEOUT_MS = 60_000
 
 // Preferred port for the HTTP control surface. Adjacent to CONTAINER_PORT
 // (8973) for mnemonics. Stability matters: containers cache the URL in
@@ -223,6 +235,21 @@ function stringifyError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+// Races a teardown step against a wall clock so a hung dependency can't hold the
+// per-container serial chain open forever. Resolves (never rejects) on timeout
+// so the surrounding runSerially op always settles and releases the queue.
+async function withCleanupTimeout(work: Promise<unknown>, timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs)
+  })
+  try {
+    await Promise.race([work.catch(() => {}), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
 function errorCode(error: Error): unknown {
   const direct = error as Error & { code?: unknown; cause?: unknown }
   if (direct.code !== undefined) return direct.code
@@ -282,6 +309,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
   const exec = opts.exec ?? defaultDockerExec
   const gcIntervalMs = opts.gcIntervalMs ?? DEFAULT_GC_INTERVAL_MS
   const gcMissesToDeregister = opts.gcMissesToDeregister ?? DEFAULT_GC_MISSES_TO_DEREGISTER
+  const cleanupStepTimeoutMs = opts.cleanupStepTimeoutMs ?? CLEANUP_STEP_TIMEOUT_MS
   const version = opts.version ?? UNVERSIONED_SENTINEL
   const cwds = new Map<string, string>()
   const restartTokens = new Map<string, string>()
@@ -362,9 +390,10 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       cwds.delete(containerName)
       restartTokens.delete(containerName)
       gcMisses.delete(containerName)
-      if (opts.portbroker) await opts.portbroker.stop(containerName, 'fatal-auth').catch(() => {})
-      if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(containerName).catch(() => {})
-      if (opts.webexRenewal) await opts.webexRenewal.stop(containerName).catch(() => {})
+      if (opts.portbroker)
+        await withCleanupTimeout(opts.portbroker.stop(containerName, 'fatal-auth'), cleanupStepTimeoutMs)
+      if (opts.kakaoRenewal) await withCleanupTimeout(opts.kakaoRenewal.stop(containerName), cleanupStepTimeoutMs)
+      if (opts.webexRenewal) await withCleanupTimeout(opts.webexRenewal.stop(containerName), cleanupStepTimeoutMs)
       await removeRegistrationFile(containerName)
       log({ kind: 'registration-skipped', containerName, reason: `fatal broker auth: ${reason}` })
     })
@@ -430,9 +459,10 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       restartTokens.delete(req.containerName)
       brokerTokens.delete(req.containerName)
       gcMisses.delete(req.containerName)
-      if (opts.portbroker) await opts.portbroker.stop(req.containerName, 'deregistered').catch(() => {})
-      if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(req.containerName).catch(() => {})
-      if (opts.webexRenewal) await opts.webexRenewal.stop(req.containerName).catch(() => {})
+      if (opts.portbroker)
+        await withCleanupTimeout(opts.portbroker.stop(req.containerName, 'deregistered'), cleanupStepTimeoutMs)
+      if (opts.kakaoRenewal) await withCleanupTimeout(opts.kakaoRenewal.stop(req.containerName), cleanupStepTimeoutMs)
+      if (opts.webexRenewal) await withCleanupTimeout(opts.webexRenewal.stop(req.containerName), cleanupStepTimeoutMs)
       await removeRegistrationFile(req.containerName)
       if (hadCwd) log({ kind: 'deregister', containerName: req.containerName, reason: 'requested' })
       return { ok: true }
@@ -759,9 +789,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       void runSerially(name, async () => {
         const hadCwd = cwds.delete(name)
         restartTokens.delete(name)
-        if (opts.portbroker) await opts.portbroker.stop(name, 'deregistered').catch(() => {})
-        if (opts.kakaoRenewal) await opts.kakaoRenewal.stop(name).catch(() => {})
-        if (opts.webexRenewal) await opts.webexRenewal.stop(name).catch(() => {})
+        if (opts.portbroker) await withCleanupTimeout(opts.portbroker.stop(name, 'deregistered'), cleanupStepTimeoutMs)
+        if (opts.kakaoRenewal) await withCleanupTimeout(opts.kakaoRenewal.stop(name), cleanupStepTimeoutMs)
+        if (opts.webexRenewal) await withCleanupTimeout(opts.webexRenewal.stop(name), cleanupStepTimeoutMs)
         await removeRegistrationFile(name)
         if (hadCwd) log({ kind: 'deregister', containerName: name, reason: 'gone' })
         return { ok: true }
@@ -787,17 +817,23 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       // after the teardown loop below already ran, leaking it. Let restore
       // settle (it never rejects past the detached catch) before tearing down.
       await (restoreComplete ?? Promise.resolve()).catch(() => {})
+      // Bound shutdown teardown too: a wedged broker/renewal stop must not
+      // block daemon.stop() forever, which would also stall the version-drift
+      // respawn flow that waits for this to return before unlinking the socket.
       if (opts.portbroker) {
         const names = Array.from(cwds.keys())
-        await Promise.allSettled(names.map((n) => opts.portbroker!.stop(n, 'broker-stopped')))
+        await withCleanupTimeout(
+          Promise.allSettled(names.map((n) => opts.portbroker!.stop(n, 'broker-stopped'))),
+          cleanupStepTimeoutMs,
+        )
       }
       if (opts.kakaoRenewal) {
         const names = Array.from(cwds.keys())
-        await Promise.allSettled(names.map((n) => opts.kakaoRenewal!.stop(n)))
+        await withCleanupTimeout(Promise.allSettled(names.map((n) => opts.kakaoRenewal!.stop(n))), cleanupStepTimeoutMs)
       }
       if (opts.webexRenewal) {
         const names = Array.from(cwds.keys())
-        await Promise.allSettled(names.map((n) => opts.webexRenewal!.stop(n)))
+        await withCleanupTimeout(Promise.allSettled(names.map((n) => opts.webexRenewal!.stop(n))), cleanupStepTimeoutMs)
       }
       cwds.clear()
       restartTokens.clear()

--- a/src/hostd/kakao-renewal-manager.test.ts
+++ b/src/hostd/kakao-renewal-manager.test.ts
@@ -400,7 +400,7 @@ describe('createKakaoRenewalManager', () => {
     })
   })
 
-  test('stop(containerName) awaits the in-flight tick for that container', async () => {
+  test('stop(containerName) returns without awaiting the in-flight tick (no self-deadlock)', async () => {
     await withAgentDir(async (dir) => {
       const setup = await setupAgent({ agentDir: dir, ageDays: 6, withEncryptedPassword: true })
       let attemptStarted = false
@@ -430,12 +430,117 @@ describe('createKakaoRenewalManager', () => {
       manager.start({ containerName: setup.containerName, cwd: setup.cwd })
       await waitFor(() => attemptStarted)
 
+      // stop() must resolve while the tick is still parked in login. Awaiting
+      // the tick here is the self-deadlock that wedged hostd: deregister calls
+      // stop() on the very tick that is mid-restart waiting for deregister.
       const stopPromise = manager.stop(setup.containerName)
-      const racer = Promise.race([stopPromise, new Promise((r) => setTimeout(() => r('timeout'), 50))])
-      expect(await racer).toBe('timeout')
+      const racer = Promise.race([
+        stopPromise.then(() => 'stopped'),
+        new Promise((r) => setTimeout(() => r('timeout'), 50)),
+      ])
+      expect(await racer).toBe('stopped')
 
       releaseAttempt!()
-      await stopPromise
+      await manager.drain()
+    })
+  })
+
+  test('does NOT invoke onRenewalOk when stop() removed the container during an in-flight renewal', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, ageDays: 6, withEncryptedPassword: true })
+      let attemptStarted = false
+      let releaseAttempt: (() => void) | null = null
+      const restartCalls: string[] = []
+
+      const manager = createKakaoRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        attemptLogin: async (_email, _password, deviceUuid, deviceType) => {
+          attemptStarted = true
+          await new Promise<void>((r) => {
+            releaseAttempt = r
+          })
+          return {
+            authenticated: true,
+            credentials: {
+              access_token: 'fresh',
+              refresh_token: 'fresh-refresh',
+              user_id: 'u-1',
+              device_uuid: deviceUuid,
+              device_type: deviceType,
+            },
+          }
+        },
+        schedule: (_fn, _ms) => ({ stop: () => {} }),
+        onRenewalOk: async ({ containerName }) => {
+          restartCalls.push(containerName)
+        },
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => attemptStarted)
+
+      await manager.stop(setup.containerName)
+      releaseAttempt!()
+      await manager.drain()
+
+      expect(restartCalls).toEqual([])
+    })
+  })
+
+  test('re-registering to a shouldRenew=false cwd clears the old timer and does not restart the old cwd', async () => {
+    await withAgentDir(async (dir) => {
+      const setup = await setupAgent({ agentDir: dir, ageDays: 6, withEncryptedPassword: true })
+      let attemptStarted = false
+      let releaseAttempt: (() => void) | null = null
+      const restartCwds: string[] = []
+      const scheduleStops = new Map<number, number>()
+      let scheduleSeq = 0
+
+      const manager = createKakaoRenewalManager({
+        keyStoreFactory: () => createKeyStore({ keysDir: setup.keysDir }),
+        attemptLogin: async (_email, _password, deviceUuid, deviceType) => {
+          attemptStarted = true
+          await new Promise<void>((r) => {
+            releaseAttempt = r
+          })
+          return {
+            authenticated: true,
+            credentials: {
+              access_token: 'fresh',
+              refresh_token: 'fresh-refresh',
+              user_id: 'u-1',
+              device_uuid: deviceUuid,
+              device_type: deviceType,
+            },
+          }
+        },
+        schedule: (_fn, _ms) => {
+          const id = scheduleSeq++
+          scheduleStops.set(id, 0)
+          return {
+            stop: () => {
+              scheduleStops.set(id, (scheduleStops.get(id) ?? 0) + 1)
+            },
+          }
+        },
+        onRenewalOk: async ({ cwd }) => {
+          restartCwds.push(cwd)
+        },
+        shouldRenew: ({ cwd }) => cwd === setup.cwd,
+      })
+
+      manager.start({ containerName: setup.containerName, cwd: setup.cwd })
+      await waitFor(() => attemptStarted)
+
+      manager.start({ containerName: setup.containerName, cwd: '/agent/no-kakao' })
+      releaseAttempt!()
+      await manager.drain()
+
+      expect(restartCwds).not.toContain(setup.cwd)
+      // The first registration's timer was stopped by the ineligible re-register.
+      expect(scheduleStops.get(0)).toBe(1)
+      // No second timer was scheduled for the ineligible cwd.
+      expect(scheduleSeq).toBe(1)
     })
   })
 })

--- a/src/hostd/kakao-renewal-manager.ts
+++ b/src/hostd/kakao-renewal-manager.ts
@@ -104,7 +104,14 @@ export function createKakaoRenewalManager(opts: KakaoRenewalManagerOptions = {})
           accountId: result.account_id,
           previousUpdatedAt: result.previousUpdatedAt,
         })
-        if (opts.onRenewalOk) {
+        // A tick that started before stop()/drain() (deregister, shutdown) or
+        // before a re-register with a different cwd can finish the slow login
+        // here. Restarting a container that is no longer the current
+        // registration would resurrect a just-deregistered agent or fight a
+        // shutdown, so skip onRenewalOk unless this container+cwd is still the
+        // live registration. Matches webex-renewal-manager's guard.
+        const current = latestInput.get(input.containerName)
+        if (opts.onRenewalOk && current?.cwd === input.cwd) {
           log({
             kind: 'kakao-renewal-restart-scheduled',
             containerName: input.containerName,
@@ -187,9 +194,21 @@ export function createKakaoRenewalManager(opts: KakaoRenewalManagerOptions = {})
 
   return {
     start(input: KakaoRenewalStartInput): void {
-      if (opts.shouldRenew && !opts.shouldRenew(input)) return
+      // Tear down any prior registration for this container BEFORE the
+      // shouldRenew gate. The daemon calls start() on every registration, so a
+      // container that had Kakao can re-register to a non-Kakao cwd; if we
+      // returned early without clearing, the old timer would keep ticking and a
+      // post-login restart guard would still match the stale cwd. Clearing
+      // latestInput also makes an in-flight tick's onRenewalOk re-check fail.
       const existing = timers.get(input.containerName)
-      if (existing) existing.stop()
+      if (existing) {
+        existing.stop()
+        timers.delete(input.containerName)
+      }
+      latestInput.delete(input.containerName)
+
+      if (opts.shouldRenew && !opts.shouldRenew(input)) return
+
       latestInput.set(input.containerName, input)
       const handle = schedule(() => {
         void scheduleTick(input.containerName)
@@ -198,26 +217,32 @@ export function createKakaoRenewalManager(opts: KakaoRenewalManagerOptions = {})
       void scheduleTick(input.containerName)
     },
 
-    async stop(containerName: string): Promise<void> {
+    // Must NOT await the in-flight tick: a successful tick runs onRenewalOk →
+    // hostdRestart → container stop() → deregister RPC → handleDeregister →
+    // kakaoRenewal.stop(), so awaiting inFlight here waits on the very tick that
+    // is parked waiting for this restart — a self-deadlock that wedges the
+    // daemon's per-container serial chain forever. Clearing latestInput (not the
+    // await) is what fails the tick's onRenewalOk guard; drain() still awaits.
+    stop(containerName: string): Promise<void> {
       const handle = timers.get(containerName)
       if (handle) {
         timers.delete(containerName)
         handle.stop()
       }
       latestInput.delete(containerName)
-      // Await any in-flight tick before resolving so the caller can rely on
-      // "stop returned → no work outstanding". Daemon shutdown depends on
-      // this; without it, a mid-tick `attemptLogin` HTTPS call is abandoned.
-      const promise = inFlight.get(containerName)
-      if (promise) await promise.catch(() => {})
+      return Promise.resolve()
     },
 
     async drain(): Promise<void> {
       for (const [, handle] of timers) handle.stop()
       timers.clear()
-      latestInput.clear()
+      // Clear latestInput AFTER awaiting in-flight: the onRenewalOk guard reads
+      // latestInput, so clearing first would suppress the restart of a tick that
+      // is mid-login when drain() runs. drain() is shutdown — it waits for that
+      // work to finish rather than dropping it.
       const promises = Array.from(inFlight.values())
       await Promise.allSettled(promises)
+      latestInput.clear()
     },
   }
 }

--- a/src/hostd/tailscale.test.ts
+++ b/src/hostd/tailscale.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   createTailscaleServeManager,
+  runTailscale,
   tailscaleCandidates,
   type TailscaleExec,
   type TailscaleServeEvent,
@@ -139,5 +140,25 @@ describe('tailscaleCandidates', () => {
 
   test('Linux uses PATH only', () => {
     expect(tailscaleCandidates('linux')).toEqual(['tailscale'])
+  })
+})
+
+describe('runTailscale subprocess timeout', () => {
+  test('kills a hung CLI call and returns exit 124 instead of blocking forever', async () => {
+    const start = Date.now()
+    const result = await runTailscale('sh', ['-c', 'sleep 30'], 50)
+    const elapsed = Date.now() - start
+
+    expect(result.exitCode).toBe(124)
+    expect(result.stderr).toContain('timed out after 50ms')
+    expect(elapsed).toBeLessThan(5_000)
+  })
+
+  test('returns stdout/stderr for a CLI call that exits before the timeout', async () => {
+    const result = await runTailscale('sh', ['-c', 'echo hi; echo oops 1>&2; exit 3'], 5_000)
+
+    expect(result.exitCode).toBe(3)
+    expect(result.stdout.trim()).toBe('hi')
+    expect(result.stderr.trim()).toBe('oops')
   })
 })

--- a/src/hostd/tailscale.ts
+++ b/src/hostd/tailscale.ts
@@ -36,6 +36,17 @@ type TailscaleStatus = {
 const MACOS_APP_CLI = '/Applications/Tailscale.app/Contents/MacOS/Tailscale'
 const WINDOWS_CLI = 'C:\\Program Files\\Tailscale\\tailscale.exe'
 
+// Per-CLI-call wall clock. The tailscaled "serve config" is a global resource
+// guarded by an etag; concurrent agent restarts racing `serve`/`serve off`
+// surface "Another client is changing the serve config" and the losing CLI can
+// block on the lock indefinitely. An unbounded `await proc.exited` then poisons
+// stopAll() → portbroker.stop() → the daemon's per-container serial chain (the
+// renewal-restart wedge). 30s is far longer than a healthy serve call yet bounds
+// the hang. Kept below the daemon teardown budget so a timed-out call surfaces
+// as a normal tailscale-serve-failed before the teardown wrapper trips.
+const TAILSCALE_CLI_TIMEOUT_MS = 30_000
+const TAILSCALE_TIMEOUT_EXIT_CODE = 124
+
 export function createTailscaleServeManager(opts: TailscaleServeManagerOptions): TailscaleServeManager {
   const exec = opts.exec ?? defaultTailscaleExec
   const log = opts.onLog ?? (() => {})
@@ -153,7 +164,11 @@ export const defaultTailscaleExec: TailscaleExec = async (args) => {
   return { exitCode: 127, stdout: '', stderr: lastError }
 }
 
-async function runTailscale(bin: string, args: string[]): Promise<TailscaleExecResult> {
+export async function runTailscale(
+  bin: string,
+  args: string[],
+  timeoutMs: number = TAILSCALE_CLI_TIMEOUT_MS,
+): Promise<TailscaleExecResult> {
   const bun = getBun()
   if (!bun) return { exitCode: 127, stdout: '', stderr: 'bun runtime not available' }
   try {
@@ -163,10 +178,31 @@ async function runTailscale(bin: string, args: string[]): Promise<TailscaleExecR
       stderr: 'pipe',
       env: bin === MACOS_APP_CLI ? { ...process.env, TAILSCALE_BE_CLI: '1' } : process.env,
     })
-    const exitCode = await proc.exited
-    const stdout = await new Response(proc.stdout).text()
-    const stderr = await new Response(proc.stderr).text()
-    return { exitCode, stdout, stderr }
+    // Drain both pipes concurrently with the exit wait. Reading them only after
+    // `proc.exited` can deadlock: a child that fills its stdout/stderr pipe
+    // buffer blocks on write while we block on exit, so neither side advances.
+    const stdoutPromise = new Response(proc.stdout).text().catch(() => '')
+    const stderrPromise = new Response(proc.stderr).text().catch(() => '')
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timedOut = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), timeoutMs)
+    })
+    const outcome = await Promise.race([proc.exited.then(() => 'exited' as const), timedOut])
+    if (timer) clearTimeout(timer)
+
+    if (outcome === 'timeout') {
+      try {
+        proc.kill()
+      } catch {}
+      return {
+        exitCode: TAILSCALE_TIMEOUT_EXIT_CODE,
+        stdout: '',
+        stderr: `tailscale ${args.join(' ')} timed out after ${timeoutMs}ms`,
+      }
+    }
+
+    return { exitCode: await proc.exited, stdout: await stdoutPromise, stderr: await stderrPromise }
   } catch (error) {
     const code = typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : ''
     const exitCode = code === 'ENOENT' ? 127 : 1

--- a/src/hostd/webex-renewal-manager.ts
+++ b/src/hostd/webex-renewal-manager.ts
@@ -194,23 +194,32 @@ export function createWebexRenewalManager(opts: WebexRenewalManagerOptions = {})
       void scheduleTick(input.containerName)
     },
 
-    async stop(containerName: string): Promise<void> {
+    // Must NOT await the in-flight tick: a successful tick runs onRenewalOk →
+    // hostdRestart → container stop() → deregister RPC → handleDeregister →
+    // webexRenewal.stop(), so awaiting inFlight here waits on the very tick that
+    // is parked waiting for this restart — a self-deadlock that wedges the
+    // daemon's per-container serial chain forever. Clearing latestInput (not the
+    // await) is what fails the tick's onRenewalOk guard; drain() still awaits.
+    stop(containerName: string): Promise<void> {
       const handle = timers.get(containerName)
       if (handle) {
         timers.delete(containerName)
         handle.stop()
       }
       latestInput.delete(containerName)
-      const promise = inFlight.get(containerName)
-      if (promise) await promise.catch(() => {})
+      return Promise.resolve()
     },
 
     async drain(): Promise<void> {
       for (const [, handle] of timers) handle.stop()
       timers.clear()
-      latestInput.clear()
+      // Clear latestInput AFTER awaiting in-flight: the onRenewalOk guard reads
+      // latestInput, so clearing first would suppress the restart of a tick that
+      // is mid-login when drain() runs. drain() is shutdown — it waits for that
+      // work to finish rather than dropping it.
       const promises = Array.from(inFlight.values())
       await Promise.allSettled(promises)
+      latestInput.clear()
     },
   }
 }


### PR DESCRIPTION
## Background

An agent went down and never came back. `hostd` stayed alive but stopped doing anything **for that one agent** — its container ran but was never re-registered, so port-forwarding and inbound channels were dead. Every other agent on the host kept working. Recovery required killing and respawning `hostd`.

## Summary

A successful **token renewal restart** deadlocks the daemon's per-container serial queue.

`hostd` runs hourly webex / daily kakao token renewals. On success it restarts the container so the in-memory adapter picks up the fresh token:

```
renewal tick (held in `inFlight`)
  └─ onRenewalOk → hostdRestart → container stop()
       └─ deregister RPC → daemon handleDeregister  (runs inside runSerially(name))
            └─ await renewal.stop(name)
                 └─ await inFlight.get(name)   ← the SAME tick that is calling this
                    ✗ self-deadlock
```

`stop()` awaited the in-flight tick, but `stop()` is invoked **from** that tick (via `onRenewalOk → restart → deregister`). The deregister runs inside `runSerially(name)` — a per-container promise chain — so once it hangs, **every later register/deregister for that container queues behind it forever**. Other agents are unaffected because the chain is keyed per container.

A second, independent way to hang the same chain: `runTailscale` awaited `proc.exited` with **no timeout**. Under a `tailscale serve` etag race ("Another client is changing the serve config" — triggered by two agents restarting at once), the losing `serve off` can block on the tailscaled lock indefinitely, poisoning `stopAll() → portbroker.stop() → runSerially`.

## Preview

N/A — no visual output.

## What this does NOT do

- Does not change the happy-path renewal flow: containers that renew and restart without a concurrent deregister are unaffected.
- Does not add hard cancellation to `session.prompt` or `runSerially` themselves — only the teardown steps inside those queues are bounded.
- Does not touch the retry or fan-out logic for the renewal tick itself.

## Review notes

The fix is three commits, each closing a distinct hang path:

1. **`break renewal-manager stop() self-deadlock`** — `stop()` cancels the timer and clears `latestInput` **without** awaiting the in-flight tick. Clearing `latestInput` is what already fails the tick's `onRenewalOk` guard, so a deregistered agent is never resurrected. `drain()` (shutdown) still awaits in-flight work and now clears `latestInput` *after* the await so a mid-login tick still completes. Kakao gains the live-registration guard it was missing (webex already had it).

2. **`bound the tailscale CLI subprocess with a timeout`** — each `tailscale` call is bounded to 30s (kill + exit 124 on timeout), surfacing as a normal `tailscale-serve-failed` event instead of handling. stdout/stderr are drained concurrently with the exit wait to avoid a pipe-buffer deadlock.

3. **`bound teardown so a hung step can't wedge the serial chain`** — defense in depth: every teardown step run inside `runSerially` (deregister, fatal-auth cleanup, GC) and the shutdown teardown is wrapped in a 60s timeout that resolves (never rejects), so no single hung dependency can ever own a container's serial queue.

**Why three layers:** the self-deadlock (1) is the precise cause of this incident. The tailscale timeout (2) closes the other observed hang. The daemon bound (3) is structural — even an unknown future teardown hang can no longer wedge a container's lifecycle.

**Tests:** renewal-manager stop() returns without awaiting the in-flight tick (no self-deadlock); kakao guard parity; drain() still completes a mid-login restart; hung tailscale CLI is killed and returns exit 124; daemon regression proving a never-resolving portbroker.stop no longer blocks re-registration of the same container.

All checks green: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, `bun run test` (10209 pass / 0 fail).