### PR TITLE
feat(run): tear down started components on boot failure

### DIFF
--- a/src/agent/doctor.test.ts
+++ b/src/agent/doctor.test.ts
@@ -14,7 +14,16 @@ import { runPluginDoctorChecks, runPluginDoctorFix, sanitizeChangedPaths } from 
 const silentLogger: PluginLogger = { info: () => {}, warn: () => {}, error: () => {} }
 
 function emptyRegistry(): PluginRegistry {
-  return { tools: [], subagents: [], cronJobs: [], skills: [], skillsDirs: [], doctorChecks: [], commands: [] }
+  return {
+    tools: [],
+    subagents: [],
+    cronJobs: [],
+    skills: [],
+    skillsDirs: [],
+    doctorChecks: [],
+    commands: [],
+    disposers: [],
+  }
 }
 
 function registerCheck(

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -391,6 +391,7 @@ describe('createResourceLoader', () => {
       ],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const loader = await createResourceLoader({
@@ -515,6 +516,7 @@ describe('createResourceLoader', () => {
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     // when
@@ -549,6 +551,7 @@ describe('createResourceLoader', () => {
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
     const origin: SessionOrigin = {
       kind: 'channel',

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1304,6 +1304,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({
@@ -1353,6 +1354,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({
@@ -1379,6 +1381,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({
@@ -1419,6 +1422,7 @@ describe('setupSession integration: builtin pi tools route through customTools w
       skillsDirs: [],
       doctorChecks: [],
       commands: [],
+      disposers: [],
     }
 
     const session = await createSession({

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -89,6 +89,7 @@ export {
   type RegisteredCommand,
   type RegisteredCronJob,
   type RegisteredDoctorCheck,
+  type RegisteredPluginDisposer,
   type RegisteredSkillDir,
   type RegisteredSkillEntry,
   type RegisteredSubagent,

--- a/src/plugin/manager.test.ts
+++ b/src/plugin/manager.test.ts
@@ -512,6 +512,44 @@ describe('loadPlugins — markBooted gates spawnSubagent', () => {
   })
 })
 
+describe('loadPlugins — plugin disposal', () => {
+  test('disposePlugins awaits all onDispose callbacks and isolates failures', async () => {
+    const calls: string[] = []
+    const loadEntry: LoadPluginEntryFn = async (entry) => ({
+      name: entry,
+      version: undefined,
+      source: entry,
+      defined: {
+        plugin: async () => ({
+          onDispose: async () => {
+            calls.push(`${entry}:start`)
+            await Promise.resolve()
+            if (entry === 'bad') throw new Error('dispose boom')
+            calls.push(`${entry}:done`)
+          },
+        }),
+      },
+    })
+
+    const cap = captureWarnings()
+    try {
+      const result = await loadPlugins({
+        entries: ['good', 'bad', 'later'],
+        agentDir: '/tmp',
+        configsByName: {},
+        loadEntry,
+      })
+
+      await result.disposePlugins()
+    } finally {
+      cap.restore()
+    }
+
+    expect(calls).toEqual(expect.arrayContaining(['good:start', 'good:done', 'bad:start', 'later:start', 'later:done']))
+    expect(cap.warnings.some((w) => w.includes('[plugin:bad] onDispose failed: dispose boom'))).toBe(true)
+  })
+})
+
 describe('loadPlugins — registry shape', () => {
   test('pluginCronJobs returns CronJob[] with __plugin_<name>_<key> ids', async () => {
     const loadEntry: LoadPluginEntryFn = async () => ({

--- a/src/plugin/manager.ts
+++ b/src/plugin/manager.ts
@@ -51,6 +51,7 @@ export type LoadPluginsResult = {
   failedPlugins: FailedPlugin[]
   markBooted: () => void
   setSpawnSubagent: (fn: SpawnSubagentFn) => void
+  disposePlugins: () => Promise<void>
 }
 
 export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPluginsResult> {
@@ -181,7 +182,20 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadPlugins
     setSpawnSubagent: (fn) => {
       spawnSubagentImpl = fn
     },
+    disposePlugins: () => disposePlugins(registry),
   }
+}
+
+async function disposePlugins(registry: PluginRegistry): Promise<void> {
+  await Promise.all(
+    registry.disposers.map(async (disposer) => {
+      try {
+        await disposer.dispose()
+      } catch (err) {
+        disposer.logger.warn(`onDispose failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }),
+  )
 }
 
 // Tags WHICH sub-phase failed (for the failedPlugins report) while preserving

--- a/src/plugin/registry.test.ts
+++ b/src/plugin/registry.test.ts
@@ -71,6 +71,14 @@ describe('registerContributions', () => {
     expect(() => registerContributions(opts)).toThrow(/doctor check "dir-writable" already registered/)
   })
 
+  test('records plugin disposers', () => {
+    const onDispose = () => {}
+    const opts = makeOptions('p1', { onDispose })
+    registerContributions(opts)
+
+    expect(opts.registry.disposers).toEqual([{ pluginName: 'p1', logger: noopLogger, dispose: onDispose }])
+  })
+
   test('rejects duplicate tool name across plugins', () => {
     const tool = defineTool({
       description: 'echo',
@@ -262,6 +270,7 @@ describe('discardRegistrationsBy', () => {
         skills: { sk1: { description: '', content: '' } },
         skillsDirs: ['/p1/skills'],
         hooks: { 'session.start': () => {} },
+        onDispose: () => {},
         doctorChecks: {
           ping: {
             description: 'always ok',
@@ -298,6 +307,7 @@ describe('discardRegistrationsBy', () => {
     expect(registry.skills).toEqual([])
     expect(registry.skillsDirs).toEqual([])
     expect(registry.doctorChecks).toEqual([])
+    expect(registry.disposers).toEqual([])
     expect(hooks.count('session.start')).toBe(0)
     expect(hooks.count('session.end')).toBe(1)
   })

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -34,6 +34,11 @@ export type RegisteredCommand = {
   command: PluginCommand
   logger: PluginLogger
 }
+export type RegisteredPluginDisposer = {
+  pluginName: string
+  logger: PluginLogger
+  dispose: () => void | Promise<void>
+}
 
 export type PluginRegistry = {
   tools: RegisteredTool[]
@@ -43,6 +48,7 @@ export type PluginRegistry = {
   skillsDirs: RegisteredSkillDir[]
   doctorChecks: RegisteredDoctorCheck[]
   commands: RegisteredCommand[]
+  disposers: RegisteredPluginDisposer[]
 }
 
 export type RegisterContributionsOptions = {
@@ -159,6 +165,10 @@ export function registerContributions(opts: RegisterContributionsOptions): void 
       registry.commands.push({ pluginName, commandName, command, logger })
     }
   }
+
+  if (ex.onDispose) {
+    registry.disposers.push({ pluginName, logger, dispose: ex.onDispose })
+  }
 }
 
 export function discardRegistrationsBy(pluginName: string, registry: PluginRegistry, hooks: HookBus): void {
@@ -169,6 +179,7 @@ export function discardRegistrationsBy(pluginName: string, registry: PluginRegis
   registry.skillsDirs = registry.skillsDirs.filter((d) => d.pluginName !== pluginName)
   registry.doctorChecks = registry.doctorChecks.filter((d) => d.pluginName !== pluginName)
   registry.commands = registry.commands.filter((c) => c.pluginName !== pluginName)
+  registry.disposers = registry.disposers.filter((d) => d.pluginName !== pluginName)
   hooks.unregisterAll(pluginName)
 }
 
@@ -181,6 +192,7 @@ export function emptyRegistry(): PluginRegistry {
     skillsDirs: [],
     doctorChecks: [],
     commands: [],
+    disposers: [],
   }
 }
 

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -294,6 +294,10 @@ export type PluginExports = {
   skillsDirs?: string[]
   hooks?: Hooks
   doctorChecks?: Record<string, PluginDoctorCheck>
+  // Released once when the agent stops, for plugin-lifetime resources a GC can't
+  // reclaim deterministically (open DB handles, timers). Disposers are isolated:
+  // one throwing never blocks the others.
+  onDispose?: () => void | Promise<void>
 }
 
 // `typeclaw doctor` plugin extension surface. Each check is read-only by

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -125,24 +125,32 @@ export type StartAgentResult = {
   stop: () => void | Promise<void>
 }
 
-// Thin wrapper that owns ONLY the boot-failure cleanup of process-global
-// installs. `installCodexFetchObserver` and `installFatalGuard` attach
-// process-wide listeners before the fallible boot work; if any boot step throws
-// before `startAgentRuntime` returns, the caller never receives a
-// `StartAgentResult` and can never call `stop()`, so those listeners would
-// strand and double-fire into the next `startAgent`. The runtime hands its
-// disposer back via `onProcessGlobalsInstalled`; on a boot throw we dispose and
+// Owns boot-failure cleanup for everything installed before `startAgentRuntime`
+// returns a `StartAgentResult`. `installCodexFetchObserver`/`installFatalGuard`
+// attach process-wide listeners, and `loadPlugins` opens plugin-lifetime
+// resources (the memory plugin's sqlite handle); if any boot step throws before
+// the result exists, the caller never receives `stop()`, so each of those would
+// strand. The runtime registers each cleanup via `registerBootCleanup` as boot
+// progresses; on a throw we run them all (newest first, best-effort) and
 // rethrow, on success ownership transfers to the returned `stop()`. `return
 // await` is load-bearing — without it an async boot rejection would escape this
-// try. Dispose is idempotent, so the success path's `stop()` never double-fires.
+// try. Cleanups are idempotent, so the success path's `stop()` never double-fires.
 export async function startAgent(options: StartAgentOptions): Promise<StartAgentResult> {
-  const captured: { dispose: (() => void) | null } = { dispose: null }
+  const bootCleanups: Array<() => void | Promise<void>> = []
   try {
-    return await startAgentRuntime(options, (dispose) => {
-      captured.dispose = dispose
+    return await startAgentRuntime(options, (cleanup) => {
+      bootCleanups.push(cleanup)
     })
   } catch (err) {
-    captured.dispose?.()
+    for (const cleanup of bootCleanups.reverse()) {
+      try {
+        await cleanup()
+      } catch (cleanupErr) {
+        console.warn(
+          `[run] boot-failure cleanup error: ${cleanupErr instanceof Error ? cleanupErr.message : cleanupErr}`,
+        )
+      }
+    }
     throw err
   }
 }
@@ -161,7 +169,7 @@ async function startAgentRuntime(
     createChannelManager: createChannelManagerFor = createChannelManager,
     createTunnelManager: createTunnelManagerFor = createTunnelManager,
   }: StartAgentOptions,
-  onProcessGlobalsInstalled: (dispose: () => void) => void,
+  registerBootCleanup: (cleanup: () => void | Promise<void>) => void,
 ): Promise<StartAgentResult> {
   const reloadRegistry = new ReloadRegistry()
 
@@ -216,7 +224,7 @@ async function startAgentRuntime(
     if (sigtermHandler !== null) process.removeListener('SIGTERM', sigtermHandler)
   }
   let sigtermHandler: (() => void) | null = null
-  onProcessGlobalsInstalled(disposeProcessGlobals)
+  registerBootCleanup(disposeProcessGlobals)
 
   const { config: cwdConfig, pluginConfigs: pluginConfigsByName } = loadConfigBundleSync(cwd)
   const githubTokenBridge = createGithubTokenBridge()
@@ -261,6 +269,9 @@ async function startAgentRuntime(
     if (mcpManager !== null) await mcpManager.closeAll()
     throw err
   }
+  // Plugins are loaded (sqlite handles open); from here any boot failure must
+  // release them — the caller gets no stop() on the failure path.
+  registerBootCleanup(() => pluginsLoaded.disposePlugins())
 
   reloadRegistry.register(
     createConfigReloadable({
@@ -937,10 +948,9 @@ async function startAgentRuntime(
   const stop = async () => {
     if (stopped) return
     stopped = true
-    // The crash-guard and codex-observer disposers run in `finally` so an
-    // earlier async teardown rejection (tunnel/channel/mcp stop) cannot strand
-    // the process-global listeners they removed — a stranded fatal-guard
-    // listener would survive into the next `startAgent` and double-fire.
+    // The final disposers run in `finally` so an earlier async teardown
+    // rejection cannot strand process-global listeners or plugin-owned handles
+    // into the next `startAgent`.
     try {
       scheduler?.stop()
       cronConsumer.stop()
@@ -955,6 +965,7 @@ async function startAgentRuntime(
       await channelManager.stop()
       await mcpManager?.closeAll()
     } finally {
+      await pluginsLoaded.disposePlugins()
       disposeProcessGlobals()
     }
   }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -566,6 +566,7 @@ async function startAgentRuntime(
       return name
     },
   })
+  registerBootCleanup(() => subagentConsumer.stop())
   subagentConsumer.start()
 
   // Populated by startScheduler's factory (onCountStore). The consumer
@@ -704,11 +705,13 @@ async function startAgentRuntime(
   // delivers only to live subscribers (no replay), so a fire published before
   // the subscription exists would be lost. Subscribing to an empty stream is
   // harmless when there are no jobs.
+  registerBootCleanup(() => cronConsumer.stop())
   cronConsumer.start()
   const scheduler = await startScheduler({
     cwd,
     loadCron,
     createSchedulerFor: factory,
+    registerBootCleanup,
     stream,
     hasInternalJobs: internalJobs().length > 0,
     getSubagents: () => pluginRuntime.get().subagents,
@@ -724,6 +727,7 @@ async function startAgentRuntime(
   }
 
   const tunnelBridge: TunnelBridge = createTunnelBridge({ stream, channelManager })
+  registerBootCleanup(() => tunnelBridge.stop())
 
   // Bridge `subagent.completed` broadcasts into the channel router so a
   // backgrounded subagent finishing wakes up its parent channel session
@@ -734,6 +738,7 @@ async function startAgentRuntime(
     stream,
     router: channelManager.router,
   })
+  registerBootCleanup(() => subagentCompletionBridge.stop())
 
   // Fan a landed formal review verdict out to the sibling sessions reviewing the
   // same PR so they stand down from a redundant verdict (the per-thread fan-out
@@ -744,12 +749,14 @@ async function startAgentRuntime(
     stream,
     router: channelManager.router,
   })
+  registerBootCleanup(() => prVerdictActivityBridge.stop())
   setReviewObserver((review) => {
     stream.publish({
       target: { kind: 'broadcast' },
       payload: { kind: 'pr.verdict-activity', ...review },
     })
   })
+  registerBootCleanup(() => setReviewObserver(null))
 
   // Registered before channels so its cache clear lands before any channel
   // session teardown observes it. secrets.json provider credentials are not
@@ -784,6 +791,7 @@ async function startAgentRuntime(
     console.warn(`[run] channel restart-resume reserve failed: ${err instanceof Error ? err.message : err}`)
   }
 
+  registerBootCleanup(() => channelManager.stop())
   await channelManager.start()
 
   if (restartReservation !== null) {
@@ -914,7 +922,7 @@ async function startAgentRuntime(
       ...mcpManagerOpt,
     })
 
-  const server = createServer({
+  const serverFactory = createServer({
     port,
     reloadAll: () => reloadRegistry.reloadAll(),
     reloadRegistry,
@@ -935,13 +943,17 @@ async function startAgentRuntime(
     ...runtimeVersionOpt,
     ...tuiTokenOpt,
     ...containerBrokerOpt,
-  }).start()
+  })
+  let server: BunServer | null = null
+  registerBootCleanup(() => server?.stop(true))
+  server = serverFactory.start()
 
   // Tunnel manager starts AFTER the WS server is up so a slow/hanging
   // provider (PR 2's cloudflared first-URL wait) cannot block TUI, reload,
   // or channel adapter availability. External providers resolve URLs
   // synchronously; future managed providers will resolve asynchronously
   // and broadcast URL events when ready.
+  registerBootCleanup(() => tunnelManager.stop())
   await tunnelManager.start()
 
   let stopped = false
@@ -1090,6 +1102,7 @@ async function startScheduler({
   cwd,
   loadCron,
   createSchedulerFor,
+  registerBootCleanup,
   stream,
   hasInternalJobs,
   getSubagents,
@@ -1098,6 +1111,7 @@ async function startScheduler({
   cwd: string
   loadCron: LoadCronFn
   createSchedulerFor: SchedulerFactory
+  registerBootCleanup: (cleanup: () => void | Promise<void>) => void
   stream: Stream
   hasInternalJobs: boolean
   getSubagents?: () => SubagentRegistry
@@ -1122,6 +1136,7 @@ async function startScheduler({
     stream.publish({ target: { kind: 'cron', jobId: job.id }, payload: job })
   }
   const scheduler = await createSchedulerFor({ cwd, file, onFire, onCountStore })
+  registerBootCleanup(() => scheduler.stop())
   scheduler.start()
   return scheduler
 }

--- a/src/run/merge-subagents.test.ts
+++ b/src/run/merge-subagents.test.ts
@@ -15,6 +15,7 @@ function emptyRegistry(): PluginRegistry {
     skillsDirs: [],
     doctorChecks: [],
     commands: [],
+    disposers: [],
   }
 }
 

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from '@/bundled-plugins/agent-browser'
+import { createChannelRouter, type ChannelManager } from '@/channels'
 import type { LoadCronResult } from '@/cron'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 import type { TunnelManager } from '@/tunnels'
@@ -230,6 +231,82 @@ export default {
     ).rejects.toThrow('boot failure: tunnel start')
 
     expect(await Bun.file(sentinelFile).text()).toBe('disposed')
+  })
+
+  test('boot failure after a component starts runs its teardown', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
+    )
+    let channelManagerStopped = false
+    const fakeChannelManager = (): ChannelManager => ({
+      router: createChannelRouter({ agentDir: agentDir!, configForAdapter: () => undefined }),
+      start: async () => {},
+      stop: async () => {
+        channelManagerStopped = true
+      },
+      reload: async () => ({ started: [], stopped: [], restartRequired: [] }),
+      restartAdapter: async () => {},
+    })
+    const failingTunnelManager = (): TunnelManager => ({
+      start: async () => {
+        throw new Error('boot failure: tunnel start')
+      },
+      stop: async () => {},
+      snapshot: () => [],
+      urlFor: () => null,
+      tail: () => [],
+      subscribeToLogs: () => () => {},
+    })
+
+    await expect(
+      startAgent({
+        port: 0,
+        attachTui: false,
+        cwd: agentDir,
+        loadCron: noCron,
+        createChannelManager: fakeChannelManager,
+        createTunnelManager: failingTunnelManager,
+      }),
+    ).rejects.toThrow('boot failure: tunnel start')
+
+    expect(channelManagerStopped).toBe(true)
+  })
+
+  test('boot failure during channelManager.start still runs its teardown', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({ models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' } }),
+    )
+    let channelManagerStarted = false
+    let channelManagerStopped = false
+    const partiallyStartingChannelManager = (): ChannelManager => ({
+      router: createChannelRouter({ agentDir: agentDir!, configForAdapter: () => undefined }),
+      start: async () => {
+        channelManagerStarted = true
+        throw new Error('boot failure: channel manager partial start')
+      },
+      stop: async () => {
+        channelManagerStopped = true
+      },
+      reload: async () => ({ started: [], stopped: [], restartRequired: [] }),
+      restartAdapter: async () => {},
+    })
+
+    await expect(
+      startAgent({
+        port: 0,
+        attachTui: false,
+        cwd: agentDir,
+        loadCron: noCron,
+        createChannelManager: partiallyStartingChannelManager,
+      }),
+    ).rejects.toThrow('boot failure: channel manager partial start')
+
+    expect(channelManagerStarted).toBe(true)
+    expect(channelManagerStopped).toBe(true)
   })
 
   test('plugin skill is materialized and present in the resource loader for new sessions', async () => {

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from '@/bundled-plugins/agent-browser'
 import type { LoadCronResult } from '@/cron'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
+import type { TunnelManager } from '@/tunnels'
 
 import { startAgent, type LoadCronFn } from './index'
 
@@ -149,6 +150,86 @@ export default {
     }
     ws.close()
     throw new Error(`session.start hook never fired within ${TIMEOUT_MS}ms (sentinel ${sentinelFile} missing)`)
+  })
+
+  test('stop awaits plugin onDispose', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    const sentinelFile = join(agentDir, 'disposed.log')
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `import { writeFile } from 'node:fs/promises'
+export default {
+  plugin: async () => ({
+    onDispose: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      await writeFile(${JSON.stringify(sentinelFile)}, 'disposed')
+    },
+  }),
+}`,
+    )
+
+    running = await startAgent({ port: 0, attachTui: false, cwd: agentDir, loadCron: noCron })
+
+    await running.stop()
+    running = null
+
+    expect(await Bun.file(sentinelFile).text()).toBe('disposed')
+  })
+
+  test('boot failure after plugins load (late tunnel start) still runs plugin onDispose', async () => {
+    agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-plugin-e2e-'))
+    const sentinelFile = join(agentDir, 'disposed.log')
+    await writeFile(
+      join(agentDir, 'typeclaw.json'),
+      JSON.stringify({
+        models: { default: 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' },
+        plugins: ['./plugin.ts'],
+      }),
+    )
+    await writePlugin(
+      agentDir,
+      `import { writeFile } from 'node:fs/promises'
+export default {
+  plugin: async () => ({
+    onDispose: async () => {
+      await writeFile(${JSON.stringify(sentinelFile)}, 'disposed')
+    },
+  }),
+}`,
+    )
+
+    const failingTunnelManager = (): TunnelManager => ({
+      start: async () => {
+        throw new Error('boot failure: tunnel start')
+      },
+      stop: async () => {},
+      snapshot: () => [],
+      urlFor: () => null,
+      tail: () => [],
+      subscribeToLogs: () => () => {},
+    })
+
+    // tunnelManager.start() runs AFTER channelManager.start(), so a throw here
+    // proves the boot-cleanup stack disposes plugins on a LATE boot failure —
+    // the caller never gets a stop() on this path.
+    await expect(
+      startAgent({
+        port: 0,
+        attachTui: false,
+        cwd: agentDir,
+        loadCron: noCron,
+        createTunnelManager: failingTunnelManager,
+      }),
+    ).rejects.toThrow('boot failure: tunnel start')
+
+    expect(await Bun.file(sentinelFile).text()).toBe('disposed')
   })
 
   test('plugin skill is materialized and present in the resource loader for new sessions', async () => {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -43,6 +43,7 @@ const EMPTY_REGISTRY: PluginRegistry = {
   skillsDirs: [],
   doctorChecks: [],
   commands: [],
+  disposers: [],
 }
 
 function makeRuntimeWith(opts: { subagents: SubagentRegistry }): PluginRuntime {


### PR DESCRIPTION
Stacked on #1093 (base is its branch, so this diff shows only the delta; GitHub retargets to main when #1093 merges).

Extends the plugin onDispose boot-cleanup stack from #1093 to own **every started runtime component**, not just plugins. Each component's teardown is registered into the boot-cleanup stack as it starts (before its fallible `start()`, so a partial start is covered): subagent/cron consumers, scheduler, the three bridges, the review observer, channelManager, the ws server, and tunnelManager.

So if boot throws *after* a component has started (e.g. `tunnelManager.start()` after the server is up, or a partial `channelManager.start()`), that component is stopped before `startAgent()` rejects — the caller never receives `stop()` on the boot-failure path. Addresses @typeey's review on #1093.

Tests: a late-tunnel-start failure stops the started ws server's equivalent component; a throwing `channelManager.start()` still runs its teardown.

No test was failing for these (the Windows EBUSY fix in #1093 already passes); this is the robustness extension, kept separate per review.