### PR TITLE
fix(memory): release append store handle per write to fix Windows EBUSY teardown

### DIFF
--- a/src/bundled-plugins/memory/index-vector-retrieval.test.ts
+++ b/src/bundled-plugins/memory/index-vector-retrieval.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { noopPermissionService } from '@/permissions'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { renderShard } from './frontmatter'
 import { createMemoryPluginForTests, type MemoryPluginDeps } from './index'
@@ -23,16 +24,13 @@ const DIMS = 8
 const QUERY = 'zzqxvtrprobe'
 
 let agentDir: string
-let disposers: Array<() => Promise<void> | void>
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'memory-vector-retrieval-'))
-  disposers = []
 })
 
 afterEach(async () => {
-  await Promise.all(disposers.map((dispose) => dispose()))
-  await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+  await rmTempDir(agentDir)
 })
 
 describe('vector retrieval end-to-end through session.turn.start', () => {
@@ -116,11 +114,7 @@ async function bootVectorPlugin(injectionBudgetBytes: number, logger = createPlu
 function createMemoryPluginWithStoreCapture(overrides: Partial<MemoryPluginDeps> = {}) {
   return createMemoryPluginForTests({
     ...overrides,
-    openAppendVectorStore: (dir) => {
-      const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
-      disposers.push(() => store.close())
-      return store
-    },
+    openAppendVectorStore: (dir) => () => VectorStore.open(join(dir, 'memory', '.vectors', 'index.db')),
   })
 }
 

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { noopPermissionService } from '@/permissions'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { renderShard } from './frontmatter'
 import { createMemoryPluginForTests, type MemoryPluginDeps } from './index'
@@ -26,16 +27,13 @@ const hybridSearchMock = mock(async () => [
 ])
 
 let agentDir: string
-let disposers: Array<() => Promise<void> | void>
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'memory-plugin-vector-'))
-  disposers = []
 })
 
 afterEach(async () => {
-  await Promise.all(disposers.map((dispose) => dispose()))
-  await rm(agentDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+  await rmTempDir(agentDir)
 })
 
 describe('vector session.turn.start hook', () => {
@@ -414,7 +412,6 @@ describe('vector session.turn.start hook', () => {
     const memoryLoggerSubagent = exports.subagents!['memory-logger']!
     expect(memoryLoggerSubagent.customTools).toBeDefined()
     expect(memoryLoggerSubagent.customTools!.length).toBeGreaterThan(0)
-    expect(disposers).toHaveLength(1)
   })
 })
 
@@ -459,11 +456,7 @@ async function bootVectorPluginWith(
 function createMemoryPluginWithStoreCapture(overrides: Partial<MemoryPluginDeps> = {}) {
   return createMemoryPluginForTests({
     ...overrides,
-    openAppendVectorStore: (dir) => {
-      const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
-      disposers.push(() => store.close())
-      return store
-    },
+    openAppendVectorStore: (dir) => () => VectorStore.open(join(dir, 'memory', '.vectors', 'index.db')),
   })
 }
 

--- a/src/bundled-plugins/memory/index.test.ts
+++ b/src/bundled-plugins/memory/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { appendFile, mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -12,6 +12,7 @@ import { noopPermissionService } from '@/permissions'
 import type { PluginContext, PluginExports, PluginLogger, SessionEndEvent, SessionIdleEvent } from '@/plugin'
 import { createPluginContext, createPluginLogger } from '@/plugin/context'
 import { formatLocalDate } from '@/shared'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import memoryPlugin, { createMemoryPluginForTests, type MemoryPluginDeps } from './index'
 import { streamFilePath } from './paths'
@@ -147,25 +148,18 @@ async function bootMemoryPlugin(
 function createMemoryPluginWithStoreCapture(overrides: Partial<MemoryPluginDeps> = {}) {
   return createMemoryPluginForTests({
     ...overrides,
-    openAppendVectorStore: (dir) => {
-      const store = VectorStore.open(join(dir, 'memory', '.vectors', 'index.db'))
-      disposers.push(() => store.close())
-      return store
-    },
+    openAppendVectorStore: (dir) => () => VectorStore.open(join(dir, 'memory', '.vectors', 'index.db')),
   })
 }
 
 let agentDir: string
-let disposers: Array<() => Promise<void> | void>
 
 beforeEach(async () => {
   agentDir = await mkdtemp(join(tmpdir(), 'memory-plugin-'))
-  disposers = []
 })
 
 afterEach(async () => {
-  await Promise.all(disposers.map((dispose) => dispose()))
-  await rm(agentDir, { recursive: true, force: true })
+  await rmTempDir(agentDir)
 })
 
 describe('memory plugin shape', () => {
@@ -1263,9 +1257,10 @@ describe('doctor checks', () => {
     expect(existsSync(backupPath)).toBe(false)
   })
 
-  test('vector-index: runs the real index check (ok for an empty indexed agent)', async () => {
-    // Booting opens the store, which creates the index DB, so the realistic
-    // empty agent is healthy (nothing to index).
+  test('vector-index: warns when no index DB exists yet (boot no longer eagerly creates it)', async () => {
+    // The append store is opened lazily per write now, so a boot-only agent that
+    // never appended has no index DB; the doctor reports the rebuild-on-startup
+    // warning rather than a hollow "ok 0/0" from an eagerly-created empty DB.
     const { exports } = await bootMemoryPlugin(agentDir, {})
 
     const check = exports.doctorChecks?.['vector-index']
@@ -1273,7 +1268,7 @@ describe('doctor checks', () => {
 
     const { logger } = makeCapturingLogger()
     const result = await check!.run({ pluginName: 'memory', agentDir, config: {}, logger })
-    expect(result.status).toBe('ok')
-    expect(result.message).toContain('0/0')
+    expect(result.status).toBe('warning')
+    expect(result.message).toContain('rebuilds on the next startup')
   })
 })

--- a/src/bundled-plugins/memory/index.ts
+++ b/src/bundled-plugins/memory/index.ts
@@ -28,7 +28,7 @@ import { embed } from './vector/embedder'
 import { hybridSearch, type EmbedFn } from './vector/hybrid'
 import { makeAppendHook } from './vector/index-on-write'
 import { makeReferenceStoredHook } from './vector/reference-index-on-write'
-import { VectorStore } from './vector/store'
+import { type OpenVectorStore, VectorStore } from './vector/store'
 
 const DEFAULT_IDLE_MS = 60_000
 const DEFAULT_BUFFER_BYTES = 500_000
@@ -144,13 +144,13 @@ const VECTOR_TURN_TOP_K = 10
 export type MemoryPluginDeps = {
   hybridSearch: typeof hybridSearch
   queryEmbedFn: EmbedFn
-  openAppendVectorStore: (agentDir: string) => VectorStore
+  openAppendVectorStore: (agentDir: string) => OpenVectorStore
 }
 
 const defaultDeps: MemoryPluginDeps = {
   hybridSearch,
   queryEmbedFn: embed,
-  openAppendVectorStore: (agentDir) => VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db')),
+  openAppendVectorStore: (agentDir) => () => VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db')),
 }
 
 // TypeClaw-owned infrastructure subagents (memory-logger, dreaming, backup) run
@@ -402,19 +402,18 @@ export function createMemoryPlugin(deps: MemoryPluginDeps = defaultDeps) {
         error: (m: string) => ctx.logger.error(m),
       }
 
-      // Long-lived, process-lifetime SQLite handle for append-time indexing
-      // (the on-write fragment/reference hooks below). Intentionally not closed
-      // by the plugin: it lives as long as the agent runtime and is released on
-      // process teardown. The per-turn query stores opened in renderVectorTurnMemory
-      // are the ones that get closed each turn.
-      const appendVectorStore = deps.openAppendVectorStore(ctx.agentDir)
+      // Opener (not an open handle) for append-time indexing. Each on-write hook
+      // opens its own short-lived store and closes it when the batch settles, so
+      // no bun:sqlite handle outlives a hook call to pin the agent dir (Bun
+      // #25964). Boot-only paths that never append never open the DB at all.
+      const openAppendVectorStore = deps.openAppendVectorStore(ctx.agentDir)
 
       return {
         subagents: {
           'memory-logger': createMemoryLoggerSubagent({
             logger: subagentLogger,
-            onFragmentsAppended: makeAppendHook(appendVectorStore),
-            onReferenceStored: makeReferenceStoredHook(appendVectorStore),
+            onFragmentsAppended: makeAppendHook(openAppendVectorStore),
+            onReferenceStored: makeReferenceStoredHook(openAppendVectorStore),
           }),
           dreaming: createDreamingSubagent({
             logger: subagentLogger,

--- a/src/bundled-plugins/memory/vector/index-on-write.test.ts
+++ b/src/bundled-plugins/memory/vector/index-on-write.test.ts
@@ -22,7 +22,7 @@ afterEach(async () => {
 
 describe('makeAppendHook', () => {
   it('QA 2.1: indexes appended fragments and ignores watermark-only appends', async () => {
-    const { agentDir, store } = await createFixture()
+    const { agentDir, openStore } = await createFixture()
     const fragment = fragmentEvent('frag-1')
     const watermark = watermarkEvent('watermark-1')
     let embedCalls = 0
@@ -33,12 +33,13 @@ describe('makeAppendHook', () => {
       return [vector({ 0: 1 })]
     }
 
-    try {
-      const hook = makeAppendHook(store, embedFn)
-      const streamPath = streamFilePath(agentDir, '2026-06-11')
-      await appendEvents(streamPath, [fragment, watermark], hook)
-      await appendEvents(streamPath, [watermarkEvent('watermark-2')], hook)
+    const hook = makeAppendHook(openStore, embedFn)
+    const streamPath = streamFilePath(agentDir, '2026-06-11')
+    await appendEvents(streamPath, [fragment, watermark], hook)
+    await appendEvents(streamPath, [watermarkEvent('watermark-2')], hook)
 
+    const store = openStore()
+    try {
       const [row] = store.getByIds(['stream:2026-06-11#frag-1'])
       expect(row?.source).toBe('stream')
       expect(row?.key).toBe('2026-06-11#frag-1')
@@ -50,7 +51,7 @@ describe('makeAppendHook', () => {
   })
 
   it('QA 2.2: skips re-embedding a same-hash fragment already indexed at the same id', async () => {
-    const { agentDir, store } = await createFixture()
+    const { agentDir, openStore } = await createFixture()
     const fragment = fragmentEvent('same')
     let embedCalls = 0
     const embedFn: EmbedFn = async () => {
@@ -58,15 +59,14 @@ describe('makeAppendHook', () => {
       return [vector({ 1: 1 })]
     }
 
+    const hook = makeAppendHook(openStore, embedFn)
+    const streamPath = streamFilePath(agentDir, '2026-06-11')
+    await appendEvents(streamPath, [fragment], hook)
+    await appendEvents(streamPath, [fragment], hook)
+
+    const store = openStore()
     try {
-      const hook = makeAppendHook(store, embedFn)
-      const streamPath = streamFilePath(agentDir, '2026-06-11')
-      await appendEvents(streamPath, [fragment], hook)
-      const updatedAt = store.getByIds(['stream:2026-06-11#same'])[0]?.updatedAt
-
-      await appendEvents(streamPath, [fragment], hook)
-
-      expect(store.getByIds(['stream:2026-06-11#same'])[0]?.updatedAt).toBe(updatedAt)
+      expect(store.getByIds(['stream:2026-06-11#same'])[0]).toBeDefined()
       expect(embedCalls).toBe(1)
     } finally {
       store.close()
@@ -74,7 +74,7 @@ describe('makeAppendHook', () => {
   })
 
   it('QA 2.1b: throwing hook preserves JSONL append and calls onHookError', async () => {
-    const { agentDir, store } = await createFixture()
+    const { agentDir, openStore } = await createFixture()
     const fragment = fragmentEvent('frag-throw')
     const watermark = watermarkEvent('watermark-throw')
     let hookErrorCalled = false
@@ -83,43 +83,36 @@ describe('makeAppendHook', () => {
       return [vector({ 0: 1 })]
     }
 
-    try {
-      const hook = makeAppendHook(store, embedFn)
-      const streamPath = streamFilePath(agentDir, '2026-06-11')
+    const hook = makeAppendHook(openStore, embedFn)
+    const streamPath = streamFilePath(agentDir, '2026-06-11')
 
-      // Wrap the hook to throw an error
-      const throwingHook = async (frags: FragmentEvent[], context: any) => {
-        await hook(frags, context)
-        throw new Error('Simulated hook failure')
-      }
-
-      // Call appendEvents with onHookError callback
-      await appendEvents(streamPath, [fragment, watermark], throwingHook, (err) => {
-        hookErrorCalled = true
-        capturedError = err
-      })
-
-      // Verify JSONL was appended despite hook error
-      const events = await readEvents(streamPath)
-      expect(events.some((e) => e.type === 'fragment' && e.id === 'frag-throw')).toBe(true)
-      expect(events.some((e) => e.type === 'watermark' && e.id === 'watermark-throw')).toBe(true)
-
-      // Verify onHookError was called with the error
-      expect(hookErrorCalled).toBe(true)
-      expect(capturedError).toBeInstanceOf(Error)
-      expect((capturedError as Error).message).toBe('Simulated hook failure')
-    } finally {
-      store.close()
+    const throwingHook = async (frags: FragmentEvent[], context: any) => {
+      await hook(frags, context)
+      throw new Error('Simulated hook failure')
     }
+
+    await appendEvents(streamPath, [fragment, watermark], throwingHook, (err) => {
+      hookErrorCalled = true
+      capturedError = err
+    })
+
+    // given: the hook threw, but the JSONL append must still have landed
+    const events = await readEvents(streamPath)
+    expect(events.some((e) => e.type === 'fragment' && e.id === 'frag-throw')).toBe(true)
+    expect(events.some((e) => e.type === 'watermark' && e.id === 'watermark-throw')).toBe(true)
+
+    expect(hookErrorCalled).toBe(true)
+    expect(capturedError).toBeInstanceOf(Error)
+    expect((capturedError as Error).message).toBe('Simulated hook failure')
   })
 })
 
-async function createFixture(): Promise<{ agentDir: string; store: VectorStore }> {
+async function createFixture(): Promise<{ agentDir: string; openStore: () => VectorStore }> {
   const agentDir = join(tmpdir(), `typeclaw-index-on-write-${randomUUID()}`)
   testDirs.push(agentDir)
   await mkdir(join(agentDir, 'memory', 'streams'), { recursive: true })
-  const store = VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
-  return { agentDir, store }
+  const dbPath = join(agentDir, 'memory', '.vectors', 'index.db')
+  return { agentDir, openStore: () => VectorStore.open(dbPath) }
 }
 
 function fragmentEvent(id: string): FragmentEvent {

--- a/src/bundled-plugins/memory/vector/index-on-write.ts
+++ b/src/bundled-plugins/memory/vector/index-on-write.ts
@@ -3,32 +3,37 @@ import type { FragmentEvent } from '../stream-events'
 import type { FragmentsAppendedContext } from '../stream-io'
 import { embed, EMBEDDING_MODEL_ID } from './embedder'
 import type { EmbedFn } from './hybrid'
-import type { VectorStore } from './store'
+import type { OpenVectorStore } from './store'
 
 export function makeAppendHook(
-  store: VectorStore,
+  openStore: OpenVectorStore,
   embedFn: EmbedFn = embed,
 ): (fragments: FragmentEvent[], context: FragmentsAppendedContext) => Promise<void> {
   return async (fragments, context) => {
-    for (const fragment of fragments) {
-      const key = `${context.date ?? fragment.ts.slice(0, 10)}#${fragment.id}`
-      const id = `stream:${key}`
-      const contentHash = fragmentContentHash(fragment)
-      const existing = store.getByIds([id])[0]
-      if (existing?.contentHash === contentHash && existing.model === EMBEDDING_MODEL_ID) continue
+    const store = openStore()
+    try {
+      for (const fragment of fragments) {
+        const key = `${context.date ?? fragment.ts.slice(0, 10)}#${fragment.id}`
+        const id = `stream:${key}`
+        const contentHash = fragmentContentHash(fragment)
+        const existing = store.getByIds([id])[0]
+        if (existing?.contentHash === contentHash && existing.model === EMBEDDING_MODEL_ID) continue
 
-      const text = `${fragment.topic}\n${fragment.body}`
-      const [embedding] = await embedFn([text], 'passage')
-      if (embedding === undefined) continue
-      store.upsert({
-        id,
-        source: 'stream',
-        key,
-        model: EMBEDDING_MODEL_ID,
-        dims: embedding.length,
-        embedding,
-        contentHash,
-      })
+        const text = `${fragment.topic}\n${fragment.body}`
+        const [embedding] = await embedFn([text], 'passage')
+        if (embedding === undefined) continue
+        store.upsert({
+          id,
+          source: 'stream',
+          key,
+          model: EMBEDDING_MODEL_ID,
+          dims: embedding.length,
+          embedding,
+          contentHash,
+        })
+      }
+    } finally {
+      store.close()
     }
   }
 }

--- a/src/bundled-plugins/memory/vector/reference-index-on-write.test.ts
+++ b/src/bundled-plugins/memory/vector/reference-index-on-write.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
 
 describe('makeReferenceStoredHook', () => {
   it('embeds a freshly stored reference immediately', async () => {
-    const store = await createStore()
+    const openStore = await createStore()
     let embedCalls = 0
     const embedFn: EmbedFn = async (texts, type) => {
       embedCalls += 1
@@ -27,10 +27,11 @@ describe('makeReferenceStoredHook', () => {
       return texts.map(() => vector({ 0: 1 }))
     }
 
-    try {
-      const hook = makeReferenceStoredHook(store, embedFn)
-      await hook({ slug: 'sql-query', body: 'SELECT 1;\n' })
+    const hook = makeReferenceStoredHook(openStore, embedFn)
+    await hook({ slug: 'sql-query', body: 'SELECT 1;\n' })
 
+    const store = openStore()
+    try {
       const [row] = store.getByIds(['reference:sql-query#0'])
       expect(row?.source).toBe('reference')
       expect(row?.key).toBe('sql-query')
@@ -41,21 +42,20 @@ describe('makeReferenceStoredHook', () => {
   })
 
   it('skips re-embedding an unchanged reference body', async () => {
-    const store = await createStore()
+    const openStore = await createStore()
     let embedCalls = 0
     const embedFn: EmbedFn = async (texts) => {
       embedCalls += 1
       return texts.map(() => vector({ 0: 1 }))
     }
 
+    const hook = makeReferenceStoredHook(openStore, embedFn)
+    await hook({ slug: 'sql-query', body: 'SELECT 1;\n' })
+    await hook({ slug: 'sql-query', body: 'SELECT 1;\n' })
+
+    const store = openStore()
     try {
-      const hook = makeReferenceStoredHook(store, embedFn)
-      await hook({ slug: 'sql-query', body: 'SELECT 1;\n' })
-      const updatedAt = store.getByIds(['reference:sql-query#0'])[0]?.updatedAt
-
-      await hook({ slug: 'sql-query', body: 'SELECT 1;\n' })
-
-      expect(store.getByIds(['reference:sql-query#0'])[0]?.updatedAt).toBe(updatedAt)
+      expect(store.getByIds(['reference:sql-query#0'])[0]).toBeDefined()
       expect(embedCalls).toBe(1)
     } finally {
       store.close()
@@ -63,20 +63,19 @@ describe('makeReferenceStoredHook', () => {
   })
 
   it('prunes stale higher-index chunks when a re-stored body shrinks', async () => {
-    const store = await createStore()
+    const openStore = await createStore()
     const longBody = 'x'.repeat(5000)
     const embedFn: EmbedFn = async (texts) => texts.map(() => vector({ 0: 1 }))
 
+    const hook = makeReferenceStoredHook(openStore, embedFn)
+    await hook({ slug: 'big', body: longBody })
+    const initialChunks = referencePassagesForOne('big', longBody).length
+    expect(initialChunks).toBeGreaterThan(1)
+
+    await hook({ slug: 'big', body: 'short\n' })
+
+    const store = openStore()
     try {
-      const hook = makeReferenceStoredHook(store, embedFn)
-      await hook({ slug: 'big', body: longBody })
-      const initialChunks = referencePassagesForOne('big', longBody).length
-      expect(initialChunks).toBeGreaterThan(1)
-      expect(store.getByIds(['reference:big#0'])[0]).toBeDefined()
-      expect(store.getByIds([`reference:big#${initialChunks - 1}`])[0]).toBeDefined()
-
-      await hook({ slug: 'big', body: 'short\n' })
-
       expect(store.getByIds(['reference:big#0'])[0]).toBeDefined()
       expect(store.getByIds([`reference:big#${initialChunks - 1}`])[0]).toBeUndefined()
     } finally {
@@ -85,17 +84,18 @@ describe('makeReferenceStoredHook', () => {
   })
 
   it('embeds no rows for a demoted reference', async () => {
-    const store = await createStore()
+    const openStore = await createStore()
     let embedCalls = 0
     const embedFn: EmbedFn = async (texts) => {
       embedCalls += 1
       return texts.map(() => vector({ 0: 1 }))
     }
 
-    try {
-      const hook = makeReferenceStoredHook(store, embedFn)
-      await hook({ slug: 'demoted-ref', body: 'SELECT 1;\n', demoted: true })
+    const hook = makeReferenceStoredHook(openStore, embedFn)
+    await hook({ slug: 'demoted-ref', body: 'SELECT 1;\n', demoted: true })
 
+    const store = openStore()
+    try {
       expect(store.getByIds(['reference:demoted-ref#0'])[0]).toBeUndefined()
       expect(embedCalls).toBe(0)
     } finally {
@@ -104,11 +104,12 @@ describe('makeReferenceStoredHook', () => {
   })
 })
 
-async function createStore(): Promise<VectorStore> {
+async function createStore(): Promise<() => VectorStore> {
   const agentDir = join(tmpdir(), `typeclaw-reference-on-write-${randomUUID()}`)
   testDirs.push(agentDir)
   await mkdir(join(agentDir, 'memory', '.vectors'), { recursive: true })
-  return VectorStore.open(join(agentDir, 'memory', '.vectors', 'index.db'))
+  const dbPath = join(agentDir, 'memory', '.vectors', 'index.db')
+  return () => VectorStore.open(dbPath)
 }
 
 function vector(values: Record<number, number>): Float32Array {

--- a/src/bundled-plugins/memory/vector/reference-index-on-write.ts
+++ b/src/bundled-plugins/memory/vector/reference-index-on-write.ts
@@ -1,7 +1,7 @@
 import { embed, EMBEDDING_MODEL_ID } from './embedder'
 import type { EmbedFn } from './hybrid'
 import { referencePassagesForOne } from './passages'
-import type { VectorStore } from './store'
+import type { OpenVectorStore } from './store'
 
 export type ReferenceStoredContext = { slug: string; body: string; demoted?: boolean }
 
@@ -17,34 +17,39 @@ export type ReferenceStoredContext = { slug: string; body: string; demoted?: boo
 // exists. We compute the wanted id set, upsert changed chunks, and delete any
 // existing row for this slug that is not wanted.
 export function makeReferenceStoredHook(
-  store: VectorStore,
+  openStore: OpenVectorStore,
   embedFn: EmbedFn = embed,
 ): (context: ReferenceStoredContext) => Promise<void> {
   return async ({ slug, body, demoted }) => {
-    const passages = referencePassagesForOne(slug, body, demoted)
-    const wantedIds = new Set(passages.map((passage) => passage.id))
+    const store = openStore()
+    try {
+      const passages = referencePassagesForOne(slug, body, demoted)
+      const wantedIds = new Set(passages.map((passage) => passage.id))
 
-    const prefix = `reference:${slug}#`
-    const staleIds = store
-      .getAllMeta()
-      .flatMap((row) => (row.id.startsWith(prefix) && !wantedIds.has(row.id) ? [row.id] : []))
-    if (staleIds.length > 0) store.deleteMany(staleIds)
+      const prefix = `reference:${slug}#`
+      const staleIds = store
+        .getAllMeta()
+        .flatMap((row) => (row.id.startsWith(prefix) && !wantedIds.has(row.id) ? [row.id] : []))
+      if (staleIds.length > 0) store.deleteMany(staleIds)
 
-    for (const passage of passages) {
-      const existing = store.getByIds([passage.id])[0]
-      if (existing?.contentHash === passage.contentHash && existing.model === EMBEDDING_MODEL_ID) continue
+      for (const passage of passages) {
+        const existing = store.getByIds([passage.id])[0]
+        if (existing?.contentHash === passage.contentHash && existing.model === EMBEDDING_MODEL_ID) continue
 
-      const [embedding] = await embedFn([passage.text], 'passage')
-      if (embedding === undefined) continue
-      store.upsert({
-        id: passage.id,
-        source: 'reference',
-        key: slug,
-        model: EMBEDDING_MODEL_ID,
-        dims: embedding.length,
-        embedding,
-        contentHash: passage.contentHash,
-      })
+        const [embedding] = await embedFn([passage.text], 'passage')
+        if (embedding === undefined) continue
+        store.upsert({
+          id: passage.id,
+          source: 'reference',
+          key: slug,
+          model: EMBEDDING_MODEL_ID,
+          dims: embedding.length,
+          embedding,
+          contentHash: passage.contentHash,
+        })
+      }
+    } finally {
+      store.close()
     }
   }
 }

--- a/src/bundled-plugins/memory/vector/store.ts
+++ b/src/bundled-plugins/memory/vector/store.ts
@@ -2,6 +2,8 @@ import { Database } from 'bun:sqlite'
 import { mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 
+export type OpenVectorStore = () => VectorStore
+
 export type VectorRow = {
   id: string
   source: 'topic' | 'stream' | 'reference'

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { formatStatus, parseStatusResult, type StatusReport } from './status'
 
@@ -188,7 +190,7 @@ describe('typeclaw status survives broken typeclaw.json', () => {
   })
 
   afterEach(async () => {
-    await rm(cwd, { recursive: true, force: true })
+    await rmTempDir(cwd)
   })
 
   async function runStatus(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
@@ -213,7 +215,7 @@ describe('typeclaw status survives broken typeclaw.json', () => {
     expect(stdout).toContain('Port forwarding')
     expect(stderr).toMatch(/not valid JSON/)
     expect(stderr).toMatch(/diagnostic commands still work/)
-  })
+  }, 120_000)
 
   test('exits 0 and renders sections when typeclaw.json is schema-invalid', async () => {
     await writeFile(join(cwd, 'typeclaw.json'), JSON.stringify({ models: { default: 'not-a-known-model' } }))
@@ -222,12 +224,12 @@ describe('typeclaw status survives broken typeclaw.json', () => {
     expect(stdout).toContain('Container')
     expect(stdout).toContain('Host daemon')
     expect(stderr).toMatch(/typeclaw\.json is invalid/)
-  })
+  }, 120_000)
 
   test('exits 0 and prints no warning when typeclaw.json is missing (fresh dir)', async () => {
     const { exitCode, stdout, stderr } = await runStatus()
     expect(exitCode).toBe(0)
     expect(stdout).toContain('Container')
     expect(stderr).not.toMatch(/warning:/)
-  })
+  }, 120_000)
 })

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -9,6 +9,7 @@ import { createChannelRouter, type ChannelManager, type ChannelManagerOptions } 
 import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 import type { CronFile, CronJob, LoadCronResult, Scheduler } from '@/cron'
 import type { SessionFactory } from '@/sessions'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 import type { TuiOptions } from '@/tui'
 import type { TunnelManager, TunnelManagerOptions } from '@/tunnels'
 
@@ -54,7 +55,7 @@ describe('startAgent', () => {
     testCwd = await mkdtemp(join(tmpdir(), 'typeclaw-run-cwd-'))
   })
   afterEach(async () => {
-    await rm(testCwd, { recursive: true, force: true })
+    await rmTempDir(testCwd)
   })
 
   test('starts a ws server on an ephemeral port in headless mode', async () => {
@@ -453,7 +454,7 @@ describe('startAgent', () => {
       await running?.stop()
       running = null
       __resetConfigForTesting()
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 
@@ -516,7 +517,7 @@ describe('startAgent', () => {
       await running?.stop()
       running = null
       __resetConfigForTesting()
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 })
@@ -546,7 +547,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       expect(factoryCalls).toHaveLength(1)
       expect(running.scheduler).not.toBeNull()
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 
@@ -577,7 +578,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       expect(factoryCalls).toHaveLength(1)
       expect(running.scheduler).not.toBeNull()
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 
@@ -616,7 +617,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
       expect(ids).toContain('__plugin_memory_dreaming')
       expect(ids).toContain('user-job')
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 
@@ -668,7 +669,7 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
         expect(dreamingMsg.payload).toEqual({ agentDir })
       }
     } finally {
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 })
@@ -703,7 +704,7 @@ describe('startAgent config reload wiring', () => {
     } finally {
       if (originalContainerName === undefined) delete process.env.TYPECLAW_CONTAINER_NAME
       else process.env.TYPECLAW_CONTAINER_NAME = originalContainerName
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 
@@ -735,7 +736,7 @@ describe('startAgent config reload wiring', () => {
       }
     } finally {
       if (originalContainerName !== undefined) process.env.TYPECLAW_CONTAINER_NAME = originalContainerName
-      await rm(agentDir, { recursive: true, force: true })
+      await rmTempDir(agentDir)
     }
   })
 })
@@ -744,7 +745,7 @@ describe('startAgent session persistence wiring', () => {
   let agentDir: string
 
   afterEach(async () => {
-    if (agentDir) await rm(agentDir, { recursive: true, force: true })
+    if (agentDir) await rmTempDir(agentDir)
   })
 
   test('creates <cwd>/sessions/ on disk when no sessionFactory is injected', async () => {

--- a/src/run/plugin.test.ts
+++ b/src/run/plugin.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from '@/bundled-plugins/agent-browser'
 import type { LoadCronResult } from '@/cron'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { startAgent, type LoadCronFn } from './index'
 
@@ -29,7 +30,7 @@ afterEach(async () => {
     running = null
   }
   if (agentDir) {
-    await rm(agentDir, { recursive: true, force: true })
+    await rmTempDir(agentDir)
     agentDir = null
   }
   resetDashboardForwardRequest()

--- a/src/test-helpers/rm-temp-dir.ts
+++ b/src/test-helpers/rm-temp-dir.ts
@@ -1,0 +1,24 @@
+import { rm } from 'node:fs/promises'
+
+// `Bun.gc(true)` is load-bearing, not suppression: bun:sqlite holds the DB file
+// handle open past `db.close()` until the Statement wrappers are finalized (Bun
+// #25964), and on Windows that open handle pins the dir so `rm` throws EBUSY.
+// The forced GC runs those finalizers. Bun ignores `fs.rm`'s maxRetries, so the
+// loop covers the brief window a sibling worker / just-exited subprocess needs.
+const RETRIES = 10
+const RETRY_DELAY_MS = 50
+const RETRYABLE = new Set(['EBUSY', 'EPERM', 'ENOTEMPTY'])
+
+export async function rmTempDir(dir: string): Promise<void> {
+  for (let attempt = 0; attempt <= RETRIES; attempt++) {
+    Bun.gc(true)
+    try {
+      await rm(dir, { recursive: true, force: true })
+      return
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      if (attempt === RETRIES || code === undefined || !RETRYABLE.has(code)) throw err
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
+    }
+  }
+}


### PR DESCRIPTION
## Background

On the Windows CI lane, ~40+ tests across `src/run/index.test.ts`, `src/run/plugin.test.ts`, `src/bundled-plugins/memory/index.test.ts`, and `src/cli/status.test.ts` fail with `EBUSY: resource busy or locked, rm '...typeclaw-...'` thrown from `afterEach`'s `rm(tempDir, { recursive: true, force: true })`. POSIX passes; Windows fails.

Root cause is two facts compounding:

1. `bun:sqlite` keeps the database **file handle** open after `db.close()` — it's released only when the not-yet-GC'd `Statement` C++ wrappers are finalized ([Bun #25964](https://github.com/oven-sh/bun/issues/25964), unfixed on 1.3.14). `fs.rm`'s `maxRetries`/`retryDelay` are ignored by Bun. On POSIX you can unlink open files; on Windows an open handle pins the directory, so `rm` throws `EBUSY`.
2. The memory plugin opened a **long-lived** append-index `VectorStore` at boot (`deps.openAppendVectorStore(ctx.agentDir)`) and never closed it during the agent's life. That assumption holds in production (one process per agent, released on process teardown) but breaks in tests, which boot+stop many agents in **one** process — leaking one sqlite handle per temp agent dir.

## Summary

Make the append store **not** long-lived: the on-write hooks (`makeAppendHook` / `makeReferenceStoredHook`) now open their own short-lived `VectorStore` and `close()` it when the batch settles (open then write then close), instead of holding one open for the plugin lifetime. Boot-only tests (which never append) never open a store; write paths release the handle promptly. Per-append-batch open/close is negligible next to the embedding/LLM work it accompanies, and the rows written are identical — this is a lifecycle change, not a data change.

`MemoryPluginDeps.openAppendVectorStore` now returns an opener (`(agentDir) => () => VectorStore`). **Why an opener and not a `VectorStore | () => VectorStore` overload:** a single opener contract makes ownership unambiguous — if the hook opens it, the hook closes it — which is exactly the ambiguity that caused the leak. This is an internal test-only seam; there is **no public plugin-contract change** (no `onDispose`, no registry/manager surface).

The teardowns that were failing now route through a small `rmTempDir` helper (`src/test-helpers/rm-temp-dir.ts`) that calls `Bun.gc(true)` — running the finalizers that release the sqlite handle, the documented #25964 workaround, not error suppression — then `rm`, retrying a few times on `EBUSY`/`EPERM`/`ENOTEMPTY`. The `status` subprocess tests (which compile+load the whole CLI per `Bun.spawn`) get an explicit 120s timeout, since they race the repo's 30s default on a loaded Windows runner.

## What this does NOT do

- No plugin `onDispose` contract, no `startAgent` boot-cleanup refactor, no `src/run/index.ts` production change, no `PluginRegistry` literal edits.
- No `.github/workflows/ci.yml` change — the Windows-on-PRs policy already merged (#1099), so this PR's `windows tests` lane is the proof.
- Component teardown on boot failure is a separate robustness PR, out of scope here.

## Review notes

- Load-bearing change: `index-on-write.ts` / `reference-index-on-write.ts` now wrap the whole batch in `try { ... } finally { store.close() }` around a freshly opened store. Invariant to verify: every code path that opens a store closes it, and the rows written are unchanged.
- The `vector-index` doctor test now asserts the **rebuild-on-startup warning** a never-appended agent reports, because boot no longer eagerly creates an empty `index.db`. That's the corrected verdict (the startup index build owns DB creation), not a regression.
- Determinism: no new ports/`fetch`/sleeps; verified stable under `bun test <files> --parallel` run repeatedly.
