### PR TITLE
feat(look-at): use GLM-4.6V for vision on text-only GLM Coding Plan models

### DIFF
--- a/src/agent/multimodal/look-at.test.ts
+++ b/src/agent/multimodal/look-at.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
-import { lookAtTool } from './look-at'
+import { buildGlmVisionMessages, extractGlmVisionText, lookAtTool } from './look-at'
+import { buildMultimodalLookerSystemPrompt } from './looker'
 
 type ImageParam = { url?: string; path?: string; data?: string; mimeType?: string } | Record<string, never>
 
@@ -76,5 +77,55 @@ describe('lookAtTool — image source validation (no LLM call)', () => {
       type: 'text',
       text: expect.stringContaining('mimeType must be image/*'),
     })
+  })
+})
+
+describe('extractGlmVisionText — GLM vision response parsing', () => {
+  test('extracts trimmed assistant content from a well-formed response', () => {
+    const body = { choices: [{ message: { role: 'assistant', content: '\nblue\n' } }] }
+    expect(extractGlmVisionText(body)).toBe('blue')
+  })
+
+  test('returns null when choices is empty', () => {
+    expect(extractGlmVisionText({ choices: [] })).toBeNull()
+  })
+
+  test('returns null when content is blank', () => {
+    expect(extractGlmVisionText({ choices: [{ message: { content: '   ' } }] })).toBeNull()
+  })
+
+  test('returns null for a non-object body', () => {
+    expect(extractGlmVisionText(null)).toBeNull()
+    expect(extractGlmVisionText('oops')).toBeNull()
+  })
+
+  test('returns null when the API returns an error envelope instead of choices', () => {
+    expect(extractGlmVisionText({ error: { code: '1113', message: 'Insufficient balance' } })).toBeNull()
+  })
+})
+
+describe('buildGlmVisionMessages — GLM payload preserves looker behavior', () => {
+  const image = { type: 'image' as const, data: 'aGk=', mimeType: 'image/png' }
+
+  test('prepends the looker system prompt (with a question)', () => {
+    const messages = buildGlmVisionMessages([image], 'What color is the car?')
+    expect(messages[0]).toEqual({
+      role: 'system',
+      content: buildMultimodalLookerSystemPrompt('What color is the car?'),
+    })
+    expect(messages[0]!.content).toContain('What color is the car?')
+  })
+
+  test('uses the describe-everything system prompt when no prompt is given', () => {
+    const messages = buildGlmVisionMessages([image], undefined)
+    expect(messages[0]).toEqual({ role: 'system', content: buildMultimodalLookerSystemPrompt(undefined) })
+  })
+
+  test('carries the image as a data-URI and the user text in the user turn', () => {
+    const messages = buildGlmVisionMessages([image], undefined)
+    const user = messages[1] as { role: string; content: Array<Record<string, unknown>> }
+    expect(user.role).toBe('user')
+    expect(user.content[0]).toEqual({ type: 'image_url', image_url: { url: 'data:image/png;base64,aGk=' } })
+    expect(user.content[1]).toEqual({ type: 'text', text: 'Please describe the attached image(s).' })
   })
 })

--- a/src/agent/multimodal/look-at.ts
+++ b/src/agent/multimodal/look-at.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { Type } from '@mariozechner/pi-ai'
 import type { ImageContent } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
@@ -5,6 +7,9 @@ import { defineTool } from '@mariozechner/pi-coding-agent'
 import { createSessionWithDispose, type SessionOrigin } from '@/agent'
 import type { ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
+import { getConfig, resolveModel, resolveProfile } from '@/config'
+import { providerForModelRef } from '@/config/providers'
+import { SecretsBackend } from '@/secrets'
 
 import { buildMultimodalLookerSystemPrompt, resolveImage, type ImageInput } from './looker'
 
@@ -139,6 +144,15 @@ function toImageContent(data: string, mimeType: string): ImageContent {
 }
 
 async function runLookAtImages(imageContents: ImageContent[], prompt: string | undefined) {
+  // Exception for text-only GLM Coding Plan models: the subagent below would
+  // resolve to the same image-blind model and silently fail. GLM-4.6V vision is
+  // reachable on the coding-plan endpoint with the same key (POST
+  // /api/coding/paas/v4 → 200, drawn from the plan's vision quota). Only this
+  // setup diverts; every other one keeps the subagent path.
+  if (shouldUseGlmCodingPlanVision()) {
+    return await analyzeWithGlmCodingPlanVision(imageContents, prompt)
+  }
+
   const systemPrompt = buildMultimodalLookerSystemPrompt(prompt)
   const userText =
     prompt !== undefined && prompt.trim() !== '' ? prompt.trim() : 'Please describe the attached image(s).'
@@ -186,6 +200,79 @@ async function runLookAtImages(imageContents: ImageContent[], prompt: string | u
     session.dispose()
     await dispose()
   }
+}
+
+const GLM_VISION_PROVIDER = 'zai-coding'
+const GLM_VISION_MODEL = 'glm-4.6v'
+const GLM_VISION_ENDPOINT = 'https://api.z.ai/api/coding/paas/v4/chat/completions'
+const GLM_VISION_MAX_TOKENS = 32768
+
+function shouldUseGlmCodingPlanVision(): boolean {
+  const ref = resolveProfile(getConfig().models, 'vision').ref
+  return providerForModelRef(ref) === GLM_VISION_PROVIDER && !resolveModel(ref).input.includes('image')
+}
+
+async function analyzeWithGlmCodingPlanVision(imageContents: ImageContent[], prompt: string | undefined) {
+  const details = { count: imageContents.length, prompt }
+  const apiKey = new SecretsBackend(join(process.cwd(), 'secrets.json')).tryReadProviderApiKeySync(GLM_VISION_PROVIDER)
+  if (apiKey === null) {
+    return errorResult('GLM Coding Plan vision unavailable: no zai-coding API key', details)
+  }
+
+  let response: Response
+  try {
+    response = await fetch(GLM_VISION_ENDPOINT, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: GLM_VISION_MODEL,
+        max_tokens: GLM_VISION_MAX_TOKENS,
+        messages: buildGlmVisionMessages(imageContents, prompt),
+      }),
+    })
+  } catch (error) {
+    return errorResult(`GLM vision request failed: ${error instanceof Error ? error.message : String(error)}`, details)
+  }
+
+  if (!response.ok) {
+    return errorResult(`GLM vision request failed: HTTP ${response.status}`, details)
+  }
+
+  const text = extractGlmVisionText(await response.json().catch(() => null))
+  if (text === null) {
+    return errorResult('GLM vision returned no text response', details)
+  }
+  return successResult(text, details)
+}
+
+// Mirror the subagent path's systemPromptOverride so the direct route keeps
+// the same visible-only / faithful-transcription / no-preamble behavior.
+export function buildGlmVisionMessages(imageContents: ImageContent[], prompt: string | undefined) {
+  const userText =
+    prompt !== undefined && prompt.trim() !== '' ? prompt.trim() : 'Please describe the attached image(s).'
+  return [
+    { role: 'system' as const, content: buildMultimodalLookerSystemPrompt(prompt) },
+    {
+      role: 'user' as const,
+      content: [
+        ...imageContents.map((image) => ({
+          type: 'image_url' as const,
+          image_url: { url: `data:${image.mimeType};base64,${image.data}` },
+        })),
+        { type: 'text' as const, text: userText },
+      ],
+    },
+  ]
+}
+
+export function extractGlmVisionText(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) return null
+  const choices = (body as { choices?: unknown }).choices
+  if (!Array.isArray(choices) || choices.length === 0) return null
+  const message = (choices[0] as { message?: unknown }).message
+  const text = (message as { content?: unknown } | undefined)?.content
+  if (typeof text !== 'string' || text.trim() === '') return null
+  return text.trim()
 }
 
 function toImageInput(p: ImageParam): ImageInput {


### PR DESCRIPTION
## Background

A GLM Coding Plan agent's default model is text-only — its declared input capability contains no image entry. When the look_at tool invokes the vision subagent, the `vision` profile resolves to that same text-only model, so the subagent is image-blind and silently fails. A user on the Coding Plan exclusively has effectively no working vision tool.

GLM-4.6V is available on the **same Coding Plan endpoint** with the **same API key**, covering image analysis from the plan's vision quota. This PR detects that one broken case and routes images there directly instead.

## Summary

At the top of `runLookAtImages()` — the shared helper called by both the look_at tool and its channel-attachment variant — detect exactly one condition: the resolved vision-profile model is on provider zai-coding AND lacks image input capability. When that condition is true, POST the images directly to the GLM Coding Plan vision endpoint (model glm-4.6v). Every other setup keeps the existing vision-subagent path unchanged.

**Why an exception branch and not a new subsystem:** This is a targeted gap-fill for one provider-specific limitation, not a new general pattern. No new config fields, no new agent-facing surface, no new module — just a guard that diverts one case before the subagent spawn.

**Auth and endpoint:** The existing zai-coding key from the secrets file, read via `SecretsBackend.tryReadProviderApiKeySync`. No second provider credential, no new env var, no raw process.env access. The endpoint is the same coding-plan base URL the agent already uses — not the pay-as-you-go endpoint.

**Failure handling:** Missing key, network error, non-2xx status, and unparseable response body all produce a clear look_at error result. There is no silent fallback and no retry loop.

## What this does NOT do

Does not reintroduce the reverted GLM vision plugin or MCP server wiring (reverted in #1102, #1103). That approach wired a stdio MCP process over the same HTTP endpoint; this change reaches the same coding-plan vision quota with a plain fetch and no extra infrastructure. The revert history is the reason the approach here is deliberately minimal.

Does not change behavior for any non-Coding-Plan setup. The `shouldUseGlmCodingPlanVision()` guard requires both conditions — provider zai-coding AND no image input — which together uniquely identify the broken case.

## Review notes

- **Load-bearing change:** `shouldUseGlmCodingPlanVision()` in look-at.ts.
  Verify the two-condition guard is tight enough to avoid false positives if Z.AI ever ships a text-only paygo model.
- **`extractGlmVisionText`** is exported and unit-tested directly (5 cases: well-formed response, empty choices, blank content, non-object body, error envelope).
  The parser is intentionally defensive — any shape that doesn't yield a non-blank string returns null and triggers an error result.
- **SecretsBackend path:** uses process.cwd() for the secrets file, matching how other container-stage code locates secrets.json.
- Checks: typecheck clean, lint 0 errors, format clean, full suite 10205 pass / 0 fail. Manually verified: POST to the coding endpoint with `glm-4.6v` returned HTTP 200 with a correct image description against a real Coding Plan key.