### PR TITLE
fix(tool-result-cap): exempt web_fetch text from the flat 32KB cap

### DIFF
--- a/src/bundled-plugins/tool-result-cap/README.md
+++ b/src/bundled-plugins/tool-result-cap/README.md
@@ -9,7 +9,7 @@ This plugin is **auto-loaded** by every TypeClaw agent. There is no `plugins[]` 
 `pi-coding-agent`'s built-in tools occasionally return very large payloads that the model only needed once. Two empirically observed cases:
 
 1. **`read` on an image file** returns the base64-encoded image inline (e.g. `{type:"image", data:"<3.2MB of base64>"}`). The model uses it on the turn it was asked for, then sees the same 3.2MB of base64 as conversation context on every subsequent prompt — until compaction fires (which is token-driven, not byte-driven, so a single fat blob may sit in context for many turns before compaction is triggered).
-2. **`web_fetch` on a binary URL** (PNG, ZIP, etc.) receives the raw response body, treats it as text, and stores raw binary as a JSON-encoded string. Same effect: 100KB+ of mojibake sits in the transcript permanently.
+2. **`web_fetch` on a binary URL** (PNG, ZIP, etc.) receives the raw response body, treats it as text, and stores raw binary as a JSON-encoded string. Same effect: 100KB+ of mojibake sits in the transcript permanently. (Historical: this predates `web_fetch`'s own per-strategy `OUTPUT_CAPS`, which now bound its text output to ≤200KB regardless — see the `web_fetch` text exemption below.)
 
 The result is a session JSONL file that's tens of megabytes on disk but mostly one or two giant tool results, plus 3-minute first-prompt latencies after container restart because the full transcript gets re-shipped to the LLM as context.
 
@@ -46,6 +46,15 @@ The plugin registers a single `tool.after` hook. The hook receives `event.result
 The cap is per-part, not per-result, so a result with one small text part and one giant image is partly preserved (small text untouched, image elided).
 
 Placeholders carry the literal substring `tool-result-cap:` so future agents (or human operators inspecting a session) can grep for them and recognize that the original payload was intentionally elided rather than truncated by some other layer.
+
+## The `web_fetch` text exemption
+
+`web_fetch` is exempt from the **text** cap (but not the image cap), hardcoded in `cap-result.ts` via `TEXT_CAP_EXEMPT_TOOLS`. This is not user-configurable because it resolves a collision between two first-party caps:
+
+- `web_fetch` has its own per-strategy `OUTPUT_CAPS` in `src/agent/tools/webfetch/types.ts` — `readability` is capped at 200KB, `raw` at 100KB, others between 50KB and 100KB — bounded above by a 5MB transport limit. These are deliberately tuned: `readability` gets a generous budget so a full article reaches the model.
+- This plugin's flat `textMaxBytes` default (32KB) is smaller than every one of those, so without the exemption it would silently clip every `web_fetch` result to ~8K tokens, making the strategy caps meaningless. A `readability` fetch designed for 200KB would never deliver more than 32KB.
+
+The exemption is **text-only**: `web_fetch` image parts still go through `imageMaxBytes`, so the binary/base64 transcript-bloat protection (case 2 above) is preserved. The tradeoff is that this plugin no longer provides a 32KB backstop for `web_fetch` text — that responsibility now belongs entirely to `web_fetch`'s own `capOutput()`. User-configured `exemptTools` is a separate, broader knob (skips _all_ capping, image included); the `web_fetch` text exemption is narrower and always on.
 
 ## What's not capped
 

--- a/src/bundled-plugins/tool-result-cap/cap-jsonl.test.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-jsonl.test.ts
@@ -284,8 +284,8 @@ describe('capJsonlFileInPlace', () => {
         timestamp: '2026-05-12T00:00:01Z',
         message: {
           role: 'toolResult',
-          toolCallId: 'functions.web_fetch:1',
-          toolName: 'web_fetch',
+          toolCallId: 'functions.bash:1',
+          toolName: 'bash',
           content: [{ type: 'text', text: 'B'.repeat(200) }],
         },
       },
@@ -297,5 +297,30 @@ describe('capJsonlFileInPlace', () => {
     expect(stats.bytesElided).toBe(150)
     const entries = readJsonl(path) as { message?: { content: { type: string; text?: string }[] } }[]
     expect(entries[1]!.message!.content[0]?.text).toContain('tool-result-cap')
+  })
+
+  test('does not truncate web_fetch text parts at load time', () => {
+    const path = makeTmpJsonl([
+      { type: 'session', id: 's1', timestamp: '2026-05-12T00:00:00Z', cwd: '/a' },
+      {
+        type: 'message',
+        id: 'e1',
+        parentId: null,
+        timestamp: '2026-05-12T00:00:01Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'functions.web_fetch:1',
+          toolName: 'web_fetch',
+          content: [{ type: 'text', text: 'B'.repeat(200) }],
+        },
+      },
+    ])
+
+    const stats = capJsonlFileInPlace(path, baseOptions)
+
+    expect(stats.textsTruncated).toBe(0)
+    expect(stats.entriesMutated).toBe(0)
+    const entries = readJsonl(path) as { message?: { content: { type: string; text?: string }[] } }[]
+    expect(entries[1]!.message!.content[0]?.text).toBe('B'.repeat(200))
   })
 })

--- a/src/bundled-plugins/tool-result-cap/cap-result.test.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-result.test.ts
@@ -49,7 +49,7 @@ describe('capToolResult', () => {
       content: [{ type: 'text', text: 'A'.repeat(200) }],
     }
 
-    const stats = capToolResult('web_fetch', result, baseOptions)
+    const stats = capToolResult('bash', result, baseOptions)
 
     expect(stats.imagesReplaced).toBe(0)
     expect(stats.textsTruncated).toBe(1)
@@ -66,7 +66,7 @@ describe('capToolResult', () => {
       content: [{ type: 'text', text: 'A'.repeat(50) }],
     }
 
-    const stats = capToolResult('web_fetch', result, baseOptions)
+    const stats = capToolResult('bash', result, baseOptions)
 
     expect(stats.textsTruncated).toBe(0)
     expect(result.content[0]).toEqual({ type: 'text', text: 'A'.repeat(50) })
@@ -106,6 +106,42 @@ describe('capToolResult', () => {
     expect(stats.imagesReplaced).toBe(0)
     expect(stats.bytesElided).toBe(0)
     expect(result.content[0]).toEqual({ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) })
+  })
+
+  test('does not truncate web_fetch text (self-bounded by its own strategy caps)', () => {
+    const result: ToolResult = {
+      content: [{ type: 'text', text: 'A'.repeat(200) }],
+    }
+
+    const stats = capToolResult('web_fetch', result, baseOptions)
+
+    expect(stats.textsTruncated).toBe(0)
+    expect(stats.bytesElided).toBe(0)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'A'.repeat(200) })
+  })
+
+  test('still replaces oversized web_fetch image parts (binary bloat protection kept)', () => {
+    const result: ToolResult = {
+      content: [{ type: 'image', mimeType: 'image/png', data: 'A'.repeat(500) }],
+    }
+
+    const stats = capToolResult('web_fetch', result, baseOptions)
+
+    expect(stats.imagesReplaced).toBe(1)
+    expect(stats.bytesElided).toBe(500)
+    expect(result.content[0]?.type).toBe('text')
+    expect((result.content[0] as { text: string }).text).toContain('tool-result-cap')
+  })
+
+  test('still truncates oversized text from a non-exempt tool', () => {
+    const result: ToolResult = {
+      content: [{ type: 'text', text: 'A'.repeat(200) }],
+    }
+
+    const stats = capToolResult('read', result, baseOptions)
+
+    expect(stats.textsTruncated).toBe(1)
+    expect((result.content[0] as { text: string }).text).toContain('tool-result-cap')
   })
 
   test('mutates the original content array in place', () => {
@@ -151,7 +187,7 @@ describe('capToolResult', () => {
       content: [{ type: 'text', text: `[tool-result-cap: quoted prior placeholder] ${'X'.repeat(500)}` }],
     }
 
-    const stats = capToolResult('web_fetch', result, baseOptions)
+    const stats = capToolResult('bash', result, baseOptions)
 
     expect(stats.textsTruncated).toBe(1)
     const part = result.content[0] as { type: 'text'; text: string }

--- a/src/bundled-plugins/tool-result-cap/cap-result.ts
+++ b/src/bundled-plugins/tool-result-cap/cap-result.ts
@@ -14,6 +14,13 @@ export type CapStats = {
 
 const ELIDED_MARKER = '[tool-result-cap: '
 
+// `web_fetch` already bounds its own text via per-strategy OUTPUT_CAPS
+// (src/agent/tools/webfetch/types.ts: 50KB–200KB; readability gets 200KB on
+// purpose), so the flat 32KB textMaxBytes here only collides with it and clips
+// every readability fetch to ~8K tokens. Skip TEXT capping for it; image parts
+// still hit the image cap below, preserving the binary/base64 bloat protection.
+const TEXT_CAP_EXEMPT_TOOLS = new Set(['web_fetch'])
+
 // A capped text part is exactly the placeholder we generated: starts with
 // `[tool-result-cap: `, ends with `]`, and contains no inner `]`. The shape
 // check exists for idempotency so a previously-capped entry survives a second
@@ -46,6 +53,7 @@ export function capContentParts(tool: string, content: ContentPart[], options: C
       continue
     }
     if (part.type === 'text') {
+      if (TEXT_CAP_EXEMPT_TOOLS.has(tool)) continue
       const size = part.text.length
       if (size <= options.textMaxBytes) continue
       if (isElidedPlaceholderText(part.text)) continue


### PR DESCRIPTION
## Background

In production, every `web_fetch` result was being truncated to ~32KB regardless of strategy. The agent logs are full of:

```
[plugin:tool-result-cap] capped web_fetch ...: textsTruncated=1 bytesElided=19645
```

The root cause is two first-party caps colliding:

1. **`web_fetch`'s own per-strategy caps** (`src/agent/tools/webfetch/types.ts` `OUTPUT_CAPS`): `readability` 200KB, `raw` 100KB, `selector`/`grep` 100KB, `jq`/`snapshot` 50KB — all under a 5MB transport limit. These are deliberately tuned; `readability` gets a generous 200KB so a full article reaches the model.
2. **`tool-result-cap`'s flat `textMaxBytes`** default of **32KB**, applied by a `tool.after` hook to *every* tool.

32KB is smaller than every one of those per-strategy caps, so the post-hook always wins. A `readability` fetch tuned for a 200KB budget never delivered more than ~8K tokens — the strategy caps were dead weight. (Concretely: a ~52KB article logged `bytesElided=19645`, i.e. clipped down to the 32KB cap.)

## Summary

Exempt `web_fetch` from the **text** cap via a hardcoded `TEXT_CAP_EXEMPT_TOOLS` set in `cap-result.ts`. For `web_fetch`, its own `capOutput()` is the authoritative bound, so the flat cap only collides with it.

- **Why text-only, not full `exemptTools`:** the existing `exemptTools` knob skips *all* capping (image included). `web_fetch` on a binary URL can still surface base64/mojibake — exactly the transcript-bloat case this plugin was built for. So the exemption is text-only; `web_fetch` image parts still hit `imageMaxBytes`.
- **Why hardcoded, not config:** both caps are first-party and the collision is structural, not a user preference. A user shouldn't have to discover and hand-configure around two of our own subsystems disagreeing.
- **Why not just raise the global `textMaxBytes` to 200KB:** too blunt — it would weaken protection for unrelated tools (`bash`, `read`, future plugin tools) that have no self-bounding of their own.

## What this does NOT do

- Does **not** disable image capping for `web_fetch` — binary/base64 bloat protection is unchanged.
- Does **not** touch any other tool — `read`, `bash`, etc. keep the 32KB text cap.
- Does **not** change `web_fetch`'s own `OUTPUT_CAPS` or any default config value (`exemptTools` stays `[]`).

## Review notes

- Load-bearing change is the single `if (TEXT_CAP_EXEMPT_TOOLS.has(tool)) continue` in the text branch of `capContentParts` (`cap-result.ts`). The image branch above it is intentionally untouched.
- The same logic backs both the runtime `tool.after` hook and the load-time JSONL rehydrate pass (`capJsonlFileInPlace`), so the exemption is covered by new tests in both `cap-result.test.ts` and `cap-jsonl.test.ts`.
- A few existing truncation tests used `web_fetch` only incidentally as "some tool"; those are retargeted to `bash` so they still exercise the truncation mechanism. New `web_fetch`-named tests assert the actual new behavior (text passes through, image still capped).
- Invariant to verify: `web_fetch` text size is now solely owned by `src/agent/tools/webfetch/tool.ts` `capOutput()` + `OUTPUT_CAPS`. The README section "The web_fetch text exemption" documents this handoff.