### PR TITLE
docs(agent-browser): offer a public tunnel URL on dashboard handoff

### DIFF
--- a/src/bundled-plugins/agent-browser/skills/agent-browser/SKILL.md
+++ b/src/bundled-plugins/agent-browser/skills/agent-browser/SKILL.md
@@ -44,8 +44,32 @@ The dashboard takes a moment to come up and the user needs time to open the URL.
 3. Tell the user: **"Open `http://localhost:<port>` in your browser."** Over
    Tailscale or LAN, the same port works on the host's external address:
    `http://<host>:<port>`.
-4. Wait for the user to confirm they're ready before proceeding.
-5. When the user is done, they hand control back implicitly — just resume your
+4. **Also offer a public tunnel URL — assume the user is non-technical.** Most
+   users won't know what "the dashboard" is, won't be on the host machine, and
+   won't be on the same LAN/Tailscale, so `localhost:<port>` is useless to them.
+   Whenever you hand off the dashboard, in the same message tell them you can
+   also expose it as a public link they can open from any device. In plain
+   words — never make them reason about "cloudflared" or "tunnels":
+
+   > I've started the live browser view. If `http://localhost:<port>` doesn't
+   > open on your device, I can also give you a public web link that works from
+   > anywhere — want me to set that up?
+
+   If they say yes, expose the dashboard over a Cloudflare Quick tunnel (no
+   signup, URL looks like `https://<random>.trycloudflare.com`) and hand them
+   that URL instead. Point the tunnel at the dashboard's **in-container** service
+   — not the host-forward port from `/tmp/typeclaw-agent-browser-proxy-port`.
+   That hint file is the host-visible mapping for `localhost`/Tailscale/LAN
+   handoff; it can fall back to a different host port, and a tunnel upstream must
+   be the in-container port the dashboard actually listens on. Let
+   `typeclaw-tunnels` own the upstream choice: the mechanics —
+   `docker.file.cloudflared`, `typeclaw tunnel add`, picking the right
+   `upstreamPort`, restart-required, root-cause diagnosis — live there; load it
+   before touching `typeclaw.json`. Surface the public URL to the user as a
+   normal link; never make them think about cloudflared, ports, or config.
+
+5. Wait for the user to confirm they're ready before proceeding.
+6. When the user is done, they hand control back implicitly — just resume your
    normal `agent-browser` commands. Session state is shared with the dashboard.
 
 The dashboard is served directly by `agent-browser` on one origin; TypeClaw only


### PR DESCRIPTION
## Background

The agent-browser dashboard handoff step only told the agent to share `http://localhost:<port>` (plus a Tailscale/LAN variant). For a non-technical user who is not on the host machine and not on the same network, that address is unreachable — the human-in-the-loop handoff silently fails for exactly the people who most need the live browser view.

## Summary

Extend the "How to hand off" steps in the agent-browser skill to also offer a Cloudflare Quick tunnel public URL in the same handoff message. The phrasing is intentionally plain: the user is asked whether they want "a public web link that works from anywhere" — they never see "cloudflared", "tunnel", port numbers, or config. If they say yes, the agent exposes the dashboard via a Quick tunnel and hands them the public URL. The tunnel mechanics are delegated to the typeclaw-tunnels skill so there is no duplication.

The existing localhost and Tailscale/LAN step is preserved unchanged. New step 4 inserts the tunnel offer; previous steps 4 and 5 are renumbered to 5 and 6.

## Preview

Before: agent shared only `http://localhost:<port>` (and LAN equivalent) and waited for confirmation.

After: agent shares the localhost link AND offers to produce a public link in the same message, with a sample phrase included in the skill to keep the wording consistent across sessions.

## What this does NOT do

- Does not change any runtime code paths — this is a prompt/docs change only.
- Does not make the tunnel mandatory or default; it is opt-in via the user's reply.
- Does not duplicate tunnel setup mechanics from the typeclaw-tunnels skill.
- Does not affect any tool, config field, or plugin contract.

## Review notes

The only file touched is `src/bundled-plugins/agent-browser/skills/agent-browser/SKILL.md`. The load-bearing addition is the new step 4 block and its sample blockquote. Verify the step numbering is consistent (steps 5 and 6 are the renumbered successors of the old 4 and 5).

Checks: typecheck clean, lint 0 errors (66 pre-existing warnings unrelated to this change), format check clean, 10210 tests pass / 0 fail.