### PR TITLE
feat(channels): add Instagram channel adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Channels — one agent, many inboxes
 
-- 📨 **Supported channels** — Slack, Discord, Telegram, Webex, LINE, KakaoTalk, GitHub, and a websocket TUI, driven by the same agent
+- 📨 **Supported channels** — Slack, Discord, Telegram, Webex, Instagram, LINE, KakaoTalk, GitHub, and a websocket TUI, driven by the same agent
 - 🔎 **Cross-channel reading** — beyond the conversation it's in, it can read another channel's history, pull a single message by id, or list a workspace's channels on demand, so "check what's going on in #general" or "what do you make of this message?" just works
 - ✅ **Pull-request review** — treats a GitHub PR as a conversation, reviewing as a participant, with guards against claiming a verdict it didn't actually post and against leaving a PR stranded
 
@@ -126,7 +126,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the recommended local dev loop (`bu
 
 ## Acknowledgments
 
-- **Multi-channel** is powered by [agent-messenger](https://github.com/agent-messenger/agent-messenger) — every non-GitHub adapter (`slack-bot`, `discord-bot`, `telegram-bot`, `webex-bot`, `line`, `kakaotalk`) is built on its SDK. Thanks to the maintainers for the credential extraction, listener protocols, and platform coverage that made multi-channel a feature instead of a year-long project.
+- **Multi-channel** is powered by [agent-messenger](https://github.com/agent-messenger/agent-messenger) — every non-GitHub adapter (`slack-bot`, `discord-bot`, `telegram-bot`, `webex-bot`, `instagram`, `line`, `kakaotalk`) is built on its SDK. Thanks to the maintainers for the credential extraction, listener protocols, and platform coverage that made multi-channel a feature instead of a year-long project.
 - **Subagent architecture** is inspired by [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) by [@code-yeongyu](https://github.com/code-yeongyu). Thanks for the shape that made this clean.
 - **Question-mark attention escalation** ("Jeff Bezos detection") was suggested by [@kdhfred](https://github.com/kdhfred). Thanks for the idea that turned a wall of `?` into a real signal.
 

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -153,6 +153,7 @@ const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
     supportsAttachments: true,
   },
   github: { displayName: 'GitHub', mentionMode: 'at-username', supportsReactions: true, supportsAttachments: false },
+  instagram: { displayName: 'Instagram', mentionMode: 'alias', supportsReactions: false, supportsAttachments: false },
   'telegram-bot': {
     displayName: 'Telegram',
     mentionMode: 'at-username',

--- a/src/channels/adapters/instagram-channel-resolver.test.ts
+++ b/src/channels/adapters/instagram-channel-resolver.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { InstagramChatSummary } from 'agent-messenger/instagram'
+
+import { createInstagramChannelResolver } from './instagram-channel-resolver'
+
+function chat(overrides: Partial<InstagramChatSummary>): InstagramChatSummary {
+  return {
+    id: 'T1',
+    name: 'Alice',
+    type: 'private',
+    is_group: false,
+    participant_count: 2,
+    unread_count: 0,
+    ...overrides,
+  }
+}
+
+describe('createInstagramChannelResolver', () => {
+  test('buckets DMs and groups', async () => {
+    const resolver = createInstagramChannelResolver({
+      client: { listChats: async () => [chat({ id: 'D1' }), chat({ id: 'G1', type: 'group', is_group: true })] },
+    })
+    await resolver.refresh()
+    expect(resolver.lookupChat('D1')).toEqual({ workspace: '@instagram-dm', isDm: true })
+    expect(resolver.lookupChat('G1')).toEqual({ workspace: '@instagram-group', isDm: false })
+  })
+
+  test('provisional ingest defaults to group', () => {
+    const resolver = createInstagramChannelResolver({ client: { listChats: async () => [] } })
+    resolver.ingestProvisional('T_new')
+    expect(resolver.lookupChat('T_new')).toEqual({ workspace: '@instagram-group', isDm: false })
+  })
+
+  test('refreshes stale cache on resolve', async () => {
+    let now = 0
+    let calls = 0
+    const resolver = createInstagramChannelResolver({
+      now: () => now,
+      ttlMs: 10,
+      client: {
+        listChats: async () => {
+          calls++
+          return [chat({ id: 'D1', name: `Alice ${calls}` })]
+        },
+      },
+    })
+    await resolver.refresh()
+    now = 11
+    expect(
+      await resolver.resolve({ adapter: 'instagram', workspace: '@instagram-dm', chat: 'D1', thread: null }),
+    ).toEqual({
+      chatName: 'Alice 2',
+    })
+  })
+})

--- a/src/channels/adapters/instagram-channel-resolver.ts
+++ b/src/channels/adapters/instagram-channel-resolver.ts
@@ -1,0 +1,113 @@
+import type { InstagramChatSummary } from 'agent-messenger/instagram'
+
+import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000
+const CHAT_FETCH_LIMIT = 500
+
+export type InstagramWorkspace = '@instagram-dm' | '@instagram-group'
+
+export function instagramWorkspaceForChat(chat: Pick<InstagramChatSummary, 'type' | 'is_group'>): InstagramWorkspace {
+  return chat.type === 'private' && !chat.is_group ? '@instagram-dm' : '@instagram-group'
+}
+
+export type InstagramChatLookupValue = {
+  workspace: InstagramWorkspace
+  isDm: boolean
+}
+
+export type InstagramChannelResolver = {
+  resolve: ChannelNameResolver
+  lookupChat: (chatId: string) => InstagramChatLookupValue | null
+  refresh: () => Promise<void>
+  // Inbound events can arrive before listChats() surfaces the thread. Default
+  // provisional entries to the stricter group bucket until a real refresh can
+  // prove the chat is a DM.
+  ingestProvisional: (chatId: string) => void
+}
+
+export type InstagramChannelResolverOptions = {
+  client: { listChats(limit?: number): Promise<InstagramChatSummary[]> }
+  now?: () => number
+  ttlMs?: number
+  logger?: { warn: (msg: string) => void }
+}
+
+type Entry = {
+  workspace: InstagramWorkspace
+  isDm: boolean
+  chatName: string | null
+  expiresAt: number
+}
+
+export function createInstagramChannelResolver(options: InstagramChannelResolverOptions): InstagramChannelResolver {
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const cache = new Map<string, Entry>()
+  let inflight: Promise<void> | null = null
+
+  const refresh = async (): Promise<void> => {
+    if (inflight !== null) {
+      await inflight
+      return
+    }
+    const promise = loadAll().finally(() => {
+      inflight = null
+    })
+    inflight = promise
+    await promise
+  }
+
+  const loadAll = async (): Promise<void> => {
+    try {
+      const chats = await options.client.listChats(CHAT_FETCH_LIMIT)
+      const expiresAt = now() + ttlMs
+      for (const chat of chats) ingest(chat, expiresAt)
+    } catch (err) {
+      options.logger?.warn(`[instagram] channel resolver refresh failed: ${describe(err)}`)
+    }
+  }
+
+  const ingest = (chat: InstagramChatSummary, expiresAt: number): void => {
+    const workspace = instagramWorkspaceForChat(chat)
+    cache.set(chat.id, {
+      workspace,
+      isDm: workspace === '@instagram-dm',
+      chatName: chat.name === '' ? null : chat.name,
+      expiresAt,
+    })
+  }
+
+  const resolve: ChannelNameResolver = async (key: ChannelKey): Promise<ResolvedChannelNames> => {
+    const entry = cache.get(key.chat)
+    if (entry === undefined || entry.expiresAt <= now()) await refresh()
+    const fresh = cache.get(key.chat)
+    if (fresh === undefined) return {}
+    const result: ResolvedChannelNames = {}
+    if (fresh.chatName !== null && fresh.chatName !== '') result.chatName = fresh.chatName
+    return result
+  }
+
+  const lookupChat = (chatId: string): InstagramChatLookupValue | null => {
+    const entry = cache.get(chatId)
+    if (entry === undefined || entry.expiresAt <= now()) return null
+    return { workspace: entry.workspace, isDm: entry.isDm }
+  }
+
+  const ingestProvisional = (chatId: string): void => {
+    const existing = cache.get(chatId)
+    if (existing !== undefined && existing.expiresAt > now()) return
+    cache.set(chatId, {
+      workspace: '@instagram-group',
+      isDm: false,
+      chatName: null,
+      expiresAt: now() + ttlMs,
+    })
+  }
+
+  return { resolve, lookupChat, refresh, ingestProvisional }
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/instagram-classify.test.ts
+++ b/src/channels/adapters/instagram-classify.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { InstagramMessageSummary } from 'agent-messenger/instagram'
+
+import type { ChannelAdapterConfig } from '@/channels/schema'
+
+import { classifyInbound, type InstagramChatLookup } from './instagram-classify'
+
+const CONFIG = {} as ChannelAdapterConfig
+
+function message(overrides: Partial<InstagramMessageSummary> = {}): InstagramMessageSummary {
+  return {
+    id: 'M1',
+    thread_id: 'T1',
+    from: 'U_other',
+    from_name: 'Alice',
+    timestamp: '2025-01-02T03:04:05.000Z',
+    is_outgoing: false,
+    type: 'text',
+    text: 'hello',
+    ...overrides,
+  }
+}
+
+const dmLookup: InstagramChatLookup = (id) => (id === 'T1' ? { workspace: '@instagram-dm', isDm: true } : null)
+const groupLookup: InstagramChatLookup = (id) => (id === 'T1' ? { workspace: '@instagram-group', isDm: false } : null)
+
+describe('classifyInbound', () => {
+  test('drops before self id is known', () => {
+    expect(classifyInbound(message(), CONFIG, { selfUserId: null, lookupChat: dmLookup })).toEqual({
+      kind: 'drop',
+      reason: 'pre_connect',
+    })
+  })
+
+  test('drops outgoing and self-authored messages', () => {
+    expect(
+      classifyInbound(message({ is_outgoing: true }), CONFIG, { selfUserId: 'U_self', lookupChat: dmLookup }),
+    ).toEqual({
+      kind: 'drop',
+      reason: 'self_author',
+    })
+    expect(
+      classifyInbound(message({ from: 'U_self' }), CONFIG, { selfUserId: 'U_self', lookupChat: dmLookup }),
+    ).toEqual({
+      kind: 'drop',
+      reason: 'self_author',
+    })
+  })
+
+  test('drops empty text with no media and unknown chats', () => {
+    expect(
+      classifyInbound(message({ text: undefined }), CONFIG, { selfUserId: 'U_self', lookupChat: dmLookup }),
+    ).toEqual({
+      kind: 'drop',
+      reason: 'empty_text',
+    })
+    expect(
+      classifyInbound(message({ thread_id: 'missing' }), CONFIG, { selfUserId: 'U_self', lookupChat: dmLookup }),
+    ).toEqual({
+      kind: 'drop',
+      reason: 'unknown_chat',
+    })
+  })
+
+  test('routes media-only messages with a plain-text placeholder', () => {
+    const verdict = classifyInbound(
+      message({ text: undefined, type: 'reel_share', media_url: 'https://example.test/reel' }),
+      CONFIG,
+      {
+        selfUserId: 'U_self',
+        lookupChat: dmLookup,
+      },
+    )
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.text).toBe('[Instagram reel_share]')
+  })
+
+  test('routes DMs and parses timestamps', () => {
+    const verdict = classifyInbound(message(), CONFIG, { selfUserId: 'U_self', lookupChat: dmLookup })
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.adapter).toBe('instagram')
+    expect(verdict.payload.workspace).toBe('@instagram-dm')
+    expect(verdict.payload.isDm).toBe(true)
+    expect(verdict.payload.isBotMention).toBe(false)
+    expect(verdict.payload.ts).toBe(Date.parse('2025-01-02T03:04:05.000Z'))
+  })
+
+  test('marks English and Korean alias hits in groups', () => {
+    const english = classifyInbound(message({ text: 'hey claude' }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: groupLookup,
+      selfAliases: ['claude'],
+    })
+    if (english.kind !== 'route') throw new Error('expected route')
+    expect(english.payload.isBotMention).toBe(true)
+
+    const korean = classifyInbound(message({ text: '확인 부탁해요' }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: groupLookup,
+      selfAliases: ['확인'],
+    })
+    if (korean.kind !== 'route') throw new Error('expected route')
+    expect(korean.payload.isBotMention).toBe(true)
+  })
+
+  test('degrades malformed timestamps to 0', () => {
+    const verdict = classifyInbound(message({ timestamp: 'bad' }), CONFIG, {
+      selfUserId: 'U_self',
+      lookupChat: dmLookup,
+    })
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.ts).toBe(0)
+  })
+})

--- a/src/channels/adapters/instagram-classify.ts
+++ b/src/channels/adapters/instagram-classify.ts
@@ -1,0 +1,69 @@
+import type { InstagramMessageSummary } from 'agent-messenger/instagram'
+
+import { matchesAnyAlias } from '@/channels/engagement'
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type { InboundMessage } from '@/channels/types'
+
+import type { InstagramChatLookupValue } from './instagram-channel-resolver'
+
+export type InboundDropReason = 'self_author' | 'empty_text' | 'unknown_chat' | 'pre_connect'
+
+export type InboundClassification =
+  | { kind: 'drop'; reason: InboundDropReason }
+  | { kind: 'route'; payload: InboundMessage }
+
+export type InstagramChatLookup = (chatId: string) => InstagramChatLookupValue | null
+
+export type InstagramInboundContext = {
+  selfUserId: string | null
+  lookupChat: InstagramChatLookup
+  selfAliases?: readonly string[]
+}
+
+export function classifyInbound(
+  message: InstagramMessageSummary,
+  _config: ChannelAdapterConfig,
+  context: InstagramInboundContext,
+): InboundClassification {
+  if (context.selfUserId === null) return { kind: 'drop', reason: 'pre_connect' }
+  if (message.is_outgoing || message.from === context.selfUserId) return { kind: 'drop', reason: 'self_author' }
+
+  const rawText = message.text ?? ''
+  if (rawText === '' && message.media_url === undefined) return { kind: 'drop', reason: 'empty_text' }
+  const text = rawText === '' ? instagramMediaPlaceholder(message.type) : rawText
+
+  const chatInfo = context.lookupChat(message.thread_id)
+  if (chatInfo === null) return { kind: 'drop', reason: 'unknown_chat' }
+
+  // Instagram summaries expose no native @-mention metadata. Group engagement
+  // is therefore plain-text alias matching only; DMs engage every message.
+  const aliasMatched = matchesAnyAlias(text, context.selfAliases ?? [])
+  const parsed = Date.parse(message.timestamp)
+
+  return {
+    kind: 'route',
+    payload: {
+      adapter: 'instagram',
+      workspace: chatInfo.workspace,
+      chat: message.thread_id,
+      thread: null,
+      text,
+      externalMessageId: message.id,
+      authorId: message.from,
+      authorName: message.from_name ?? message.from,
+      authorIsBot: false,
+      isBotMention: aliasMatched,
+      replyToBotMessageId: null,
+      mentionsOthers: false,
+      replyToOtherMessageId: null,
+      isDm: chatInfo.isDm,
+      ts: Number.isNaN(parsed) ? 0 : parsed,
+    },
+  }
+}
+
+function instagramMediaPlaceholder(type: string): string {
+  const normalized = type.trim()
+  if (normalized === '' || normalized === 'text') return '[Instagram media]'
+  return `[Instagram ${normalized}]`
+}

--- a/src/channels/adapters/instagram-format.ts
+++ b/src/channels/adapters/instagram-format.ts
@@ -1,0 +1,8 @@
+import { toKakaoPlainText } from './kakaotalk-format'
+
+// Instagram DMs render plain text like KakaoTalk and LINE: markdown markers are
+// visible to recipients, so reuse the existing plain-text stripper until the SDK
+// exposes a platform-specific rich-text surface.
+export function toInstagramPlainText(input: string): string {
+  return toKakaoPlainText(input)
+}

--- a/src/channels/adapters/instagram.test.ts
+++ b/src/channels/adapters/instagram.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { InstagramChatSummary, InstagramMessageSummary } from 'agent-messenger/instagram'
+
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type { InboundMessage, OutboundMessage } from '@/channels/types'
+
+import {
+  createInstagramAdapter,
+  createInstagramHistoryCallback,
+  createOutboundCallback,
+  resolveInstagramListenerCtor,
+  type ConnectedPayload,
+  type InstagramClientShape,
+  type InstagramListenerShape,
+} from './instagram'
+
+const SILENT = { info: () => {}, warn: () => {}, error: () => {} }
+
+class FakeListener implements InstagramListenerShape {
+  connected?: (payload: ConnectedPayload) => void
+  message?: (message: InstagramMessageSummary) => void
+  error?: (error: Error) => void
+  disconnected?: () => void
+  started = false
+  stopped = false
+  start = async (): Promise<void> => {
+    this.started = true
+  }
+  stop = (): void => {
+    this.stopped = true
+  }
+  on(event: 'connected', handler: (payload: ConnectedPayload) => void): this
+  on(event: 'message', handler: (message: InstagramMessageSummary) => void): this
+  on(event: 'error', handler: (error: Error) => void): this
+  on(event: 'disconnected', handler: () => void): this
+  on(event: string, handler: unknown): this {
+    if (event === 'connected') this.connected = handler as (payload: ConnectedPayload) => void
+    if (event === 'message') this.message = handler as (message: InstagramMessageSummary) => void
+    if (event === 'error') this.error = handler as (error: Error) => void
+    if (event === 'disconnected') this.disconnected = handler as () => void
+    return this
+  }
+  off(): this {
+    return this
+  }
+}
+
+function chat(overrides: Partial<InstagramChatSummary> = {}): InstagramChatSummary {
+  return {
+    id: 'T1',
+    name: 'Alice',
+    type: 'private',
+    is_group: false,
+    participant_count: 2,
+    unread_count: 0,
+    ...overrides,
+  }
+}
+
+function msg(overrides: Partial<InstagramMessageSummary> = {}): InstagramMessageSummary {
+  return {
+    id: 'M1',
+    thread_id: 'T1',
+    from: 'U_other',
+    from_name: 'Alice',
+    timestamp: '2025-01-02T00:00:00.000Z',
+    is_outgoing: false,
+    type: 'text',
+    text: 'hello bot',
+    ...overrides,
+  }
+}
+
+type FakeInstagramClient = InstagramClientShape & {
+  loginCalls: Array<{ credentials: { username: string; password: string } | undefined; accountId: string | undefined }>
+}
+
+function fakeClient(overrides: Partial<InstagramClientShape> = {}): FakeInstagramClient {
+  const loginCalls: Array<{
+    credentials: { username: string; password: string } | undefined
+    accountId: string | undefined
+  }> = []
+  const base: FakeInstagramClient = {
+    loginCalls,
+    login: async function (this: FakeInstagramClient, credentials, accountId): Promise<FakeInstagramClient> {
+      loginCalls.push({ credentials, accountId })
+      return this
+    },
+    getProfile: async () => ({ user_id: 'U_self', username: 'bot', full_name: null, profile_pic_url: null }),
+    listChats: async () => [chat()],
+    getMessages: async () => [],
+    sendMessage: async (threadId, text) =>
+      msg({ id: 'M_sent', thread_id: threadId, from: 'U_self', text, is_outgoing: true }),
+    getUserId: () => 'U_self',
+  }
+  return Object.assign(base, overrides)
+}
+
+describe('resolveInstagramListenerCtor', () => {
+  test('resolves the installed 2.27.1 module to polling', () => {
+    expect(resolveInstagramListenerCtor().transport).toBe('polling')
+  })
+})
+
+describe('createOutboundCallback', () => {
+  const tag = async (): Promise<string> => 'tag'
+
+  test('sends markdown-stripped plain text and maps id', async () => {
+    const sent: Array<{ chat: string; text: string }> = []
+    const cb = createOutboundCallback({
+      client: {
+        sendMessage: async (chat, text) => {
+          sent.push({ chat, text })
+          return msg({ id: 'M', thread_id: chat, text })
+        },
+      },
+      logger: SILENT,
+      formatChannelTag: tag,
+    })
+    const res = await cb({
+      adapter: 'instagram',
+      workspace: '@instagram-dm',
+      chat: 'T1',
+      text: '**hi**',
+    } as OutboundMessage)
+    expect(res).toEqual({ ok: true, messageId: 'M', messageIds: ['M'] })
+    expect(sent).toEqual([{ chat: 'T1', text: 'hi' }])
+  })
+
+  test('rejects attachments, empty text, and wrong adapter', async () => {
+    const cb = createOutboundCallback({
+      client: { sendMessage: async () => msg() },
+      logger: SILENT,
+      formatChannelTag: tag,
+    })
+    expect(
+      (
+        await cb({
+          adapter: 'instagram',
+          workspace: '@instagram-dm',
+          chat: 'T1',
+          text: 'hi',
+          attachments: [{ path: '/tmp/x.png' }],
+        } as OutboundMessage)
+      ).ok,
+    ).toBe(false)
+    expect(
+      (await cb({ adapter: 'instagram', workspace: '@instagram-dm', chat: 'T1', text: '' } as OutboundMessage)).ok,
+    ).toBe(false)
+    expect((await cb({ adapter: 'line', workspace: '@line-dm', chat: 'T1', text: 'hi' } as OutboundMessage)).ok).toBe(
+      false,
+    )
+  })
+})
+
+describe('createInstagramHistoryCallback', () => {
+  test('maps messages', async () => {
+    const cb = createInstagramHistoryCallback({
+      client: {
+        getMessages: async () => [msg({ from: 'U_self', is_outgoing: true }), msg({ id: 'M2', from_name: undefined })],
+      },
+      logger: SILENT,
+      selfUserIdRef: () => 'U_self',
+    })
+    const res = await cb({ chat: 'T1', thread: null, limit: 50 })
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.messages[0]!.isBot).toBe(true)
+    expect(res.messages[1]!.authorName).toBe('U_other')
+  })
+})
+
+describe('createInstagramAdapter lifecycle', () => {
+  test('supports polling listener, registers callbacks, and routes inbound', async () => {
+    const listener = new FakeListener()
+    const routed: InboundMessage[] = []
+    const router = makeRouterStub((m) => routed.push(m))
+    const adapter = createInstagramAdapter({
+      router,
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient(),
+      listenerCtorResolver: () => ({
+        ctor: class {
+          constructor() {
+            return listener
+          }
+        } as never,
+        transport: 'polling',
+      }),
+      credentialsStore: {
+        getAccount: async () => ({ account_id: 'U_self', username: 'bot', created_at: '', updated_at: '' }),
+      },
+    })
+    await adapter.start()
+    listener.connected?.({ userId: 'U_self' })
+    expect(adapter.isConnected()).toBe(true)
+    expect(router.registered.outbound).toBe(true)
+    listener.message?.(msg())
+    await waitFor(() => routed.length > 0)
+    expect(routed[0]!.workspace).toBe('@instagram-dm')
+    await adapter.stop()
+    expect(router.registered.outbound).toBe(false)
+  })
+
+  test('supports hybrid listener connected payload with transport', async () => {
+    const listener = new FakeListener()
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client: fakeClient(),
+      listenerCtorResolver: () => ({
+        ctor: class {
+          constructor() {
+            return listener
+          }
+        } as never,
+        transport: 'hybrid',
+      }),
+      credentialsStore: {
+        getAccount: async () => ({ account_id: 'U_self', username: 'bot', created_at: '', updated_at: '' }),
+      },
+    })
+    await adapter.start()
+    expect(() => listener.connected?.({ userId: 'U_self', transport: 'realtime' })).not.toThrow()
+    expect(adapter.isConnected()).toBe(true)
+    await adapter.stop()
+  })
+
+  test('starts with stored-session login using the metadata account id', async () => {
+    const client = fakeClient()
+    const adapter = createInstagramAdapter({
+      router: makeRouterStub(() => {}),
+      configRef: () => ({}) as ChannelAdapterConfig,
+      logger: SILENT,
+      client,
+      listenerCtorResolver: () => ({
+        ctor: class {
+          constructor() {
+            return new FakeListener()
+          }
+        } as never,
+        transport: 'polling',
+      }),
+      credentialsStore: {
+        getAccount: async () => ({ account_id: 'ig-account' }),
+      },
+    })
+
+    await adapter.start()
+
+    expect(client.loginCalls).toEqual([{ credentials: undefined, accountId: 'ig-account' }])
+    await adapter.stop()
+  })
+})
+
+function makeRouterStub(onRoute: (m: InboundMessage) => void) {
+  const registered = { outbound: false, history: false, nameResolver: false }
+  return {
+    registered,
+    route: async (m: InboundMessage) => onRoute(m),
+    registerOutbound: () => {
+      registered.outbound = true
+    },
+    unregisterOutbound: () => {
+      registered.outbound = false
+    },
+    registerHistory: () => {
+      registered.history = true
+    },
+    unregisterHistory: () => {
+      registered.history = false
+    },
+    registerChannelNameResolver: () => {
+      registered.nameResolver = true
+    },
+    unregisterChannelNameResolver: () => {
+      registered.nameResolver = false
+    },
+  } as unknown as Parameters<typeof createInstagramAdapter>[0]['router'] & { registered: typeof registered }
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now()
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timeout')
+    await new Promise((r) => setTimeout(r, 5))
+  }
+}

--- a/src/channels/adapters/instagram.ts
+++ b/src/channels/adapters/instagram.ts
@@ -1,0 +1,346 @@
+import * as instagramModule from 'agent-messenger/instagram'
+import {
+  InstagramClient as RealInstagramClient,
+  InstagramCredentialManager,
+  InstagramListener as RealInstagramListener,
+} from 'agent-messenger/instagram'
+import type { InstagramChatSummary, InstagramMessageSummary } from 'agent-messenger/instagram'
+
+import type { ChannelRouter } from '@/channels/router'
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type {
+  ChannelHistoryMessage,
+  FetchHistoryArgs,
+  FetchHistoryResult,
+  HistoryCallback,
+  OutboundCallback,
+  OutboundMessage,
+  ResolvedChannelNames,
+  SendResult,
+} from '@/channels/types'
+
+import { describeError } from './describe-error'
+import { createInstagramChannelResolver } from './instagram-channel-resolver'
+import { classifyInbound } from './instagram-classify'
+import { toInstagramPlainText } from './instagram-format'
+
+export interface InstagramClientShape {
+  login(credentials?: { username: string; password: string }, accountId?: string): Promise<this>
+  getProfile(): Promise<{ user_id: string; username: string; full_name: string | null; profile_pic_url: string | null }>
+  listChats(limit?: number): Promise<InstagramChatSummary[]>
+  getMessages(threadId: string, limit?: number): Promise<InstagramMessageSummary[]>
+  sendMessage(threadId: string, text: string): Promise<InstagramMessageSummary>
+  getUserId(): string | null
+  fetchIrisBootstrap?: () => Promise<unknown>
+  getSessionState?: () => unknown
+}
+
+export type ConnectedPayload = { userId: string; transport?: 'realtime' | 'polling' }
+
+export interface InstagramListenerShape {
+  start(): Promise<void> | void
+  stop(): void
+  on(event: 'connected', handler: (payload: ConnectedPayload) => void): this
+  on(event: 'message', handler: (message: InstagramMessageSummary) => void): this
+  on(event: 'error', handler: (error: Error) => void): this
+  on(event: 'disconnected', handler: () => void): this
+  off(event: 'connected', handler: (payload: ConnectedPayload) => void): this
+  off(event: 'message', handler: (message: InstagramMessageSummary) => void): this
+  off(event: 'error', handler: (error: Error) => void): this
+  off(event: 'disconnected', handler: () => void): this
+}
+
+const InstagramClient = RealInstagramClient as unknown as new (
+  credManager?: InstagramCredentialManager,
+) => InstagramClientShape
+
+export type InstagramListenerCtor = new (
+  client: InstagramClientShape,
+  options?: {
+    pollInterval?: number
+    realtimeRetryBaseMs?: number
+    realtimeRetryMaxMs?: number
+    disableRealtime?: boolean
+    connackTimeoutMs?: number
+  },
+) => InstagramListenerShape
+
+export function resolveInstagramListenerCtor(): { ctor: InstagramListenerCtor; transport: 'hybrid' | 'polling' } {
+  const maybeHybrid = (instagramModule as Record<string, unknown>).InstagramHybridListener
+  if (typeof maybeHybrid === 'function')
+    return { ctor: maybeHybrid as unknown as InstagramListenerCtor, transport: 'hybrid' }
+  return { ctor: RealInstagramListener as unknown as InstagramListenerCtor, transport: 'polling' }
+}
+
+export type InstagramCredentialStore = {
+  getAccount(id?: string): Promise<{ account_id: string } | null>
+}
+
+export type InstagramAdapterLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+const consoleLogger: InstagramAdapterLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export type InstagramAdapterOptions = {
+  router: ChannelRouter
+  configRef: () => ChannelAdapterConfig
+  logger?: InstagramAdapterLogger
+  selfAliasesRef?: () => readonly string[]
+  credentialsStore?: InstagramCredentialStore
+  client?: InstagramClientShape
+  clientFactory?: (credManager?: InstagramCredentialManager) => InstagramClientShape
+  listenerCtorResolver?: () => { ctor: InstagramListenerCtor; transport: 'hybrid' | 'polling' }
+  now?: () => number
+}
+
+export type InstagramAdapter = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  isConnected: () => boolean
+}
+
+export const INSTAGRAM_HISTORY_LIMIT_MAX = 200
+
+export function createOutboundCallback(deps: {
+  client: Pick<InstagramClientShape, 'sendMessage'>
+  logger: InstagramAdapterLogger
+  formatChannelTag: (workspace: string, chat: string) => Promise<string>
+}): OutboundCallback {
+  const { client, logger, formatChannelTag } = deps
+  return async (msg: OutboundMessage): Promise<SendResult> => {
+    if (msg.adapter !== 'instagram') return { ok: false, error: `unknown adapter: ${msg.adapter}` }
+    if (msg.attachments !== undefined && msg.attachments.length > 0) {
+      return { ok: false, error: 'instagram adapter does not support outbound attachments' }
+    }
+    const text = toInstagramPlainText(msg.text ?? '')
+    if (text === '') return { ok: false, error: 'message has no text' }
+    const tag = await formatChannelTag(msg.workspace, msg.chat)
+    logger.info(`[instagram] outbound ${tag} text_len=${text.length}`)
+    try {
+      const result = await client.sendMessage(msg.chat, text)
+      logger.info(`[instagram] sent message_id=${result.id} ${tag}`)
+      return { ok: true, messageId: result.id, messageIds: [result.id] }
+    } catch (err) {
+      const message = describeError(err)
+      logger.error(`[instagram] sendMessage failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createInstagramHistoryCallback(deps: {
+  client: Pick<InstagramClientShape, 'getMessages'>
+  logger: InstagramAdapterLogger
+  selfUserIdRef: () => string | null
+}): HistoryCallback {
+  const { client, logger, selfUserIdRef } = deps
+  return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    const limit = clampLimit(args.limit, INSTAGRAM_HISTORY_LIMIT_MAX)
+    try {
+      const messages = await client.getMessages(args.chat, limit)
+      const selfId = selfUserIdRef()
+      const mapped: ChannelHistoryMessage[] = messages.map((m) => {
+        const parsed = Date.parse(m.timestamp)
+        return {
+          externalMessageId: m.id,
+          authorId: m.from,
+          authorName: m.from_name ?? m.from,
+          text: m.text ?? '',
+          ts: Number.isNaN(parsed) ? 0 : parsed,
+          isBot: selfId !== null && (m.from === selfId || m.is_outgoing),
+          replyToBotMessageId: null,
+        }
+      })
+      return { ok: true, messages: mapped }
+    } catch (err) {
+      const message = describeError(err)
+      logger.warn(`[instagram] history fetch failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createInstagramAdapter(options: InstagramAdapterOptions): InstagramAdapter {
+  const logger = options.logger ?? consoleLogger
+  const buildClient = options.clientFactory ?? ((cm?: InstagramCredentialManager) => new InstagramClient(cm))
+  const client = options.client ?? buildClient(new InstagramCredentialManager())
+  let listener: InstagramListenerShape | null = null
+  let selfUserId: string | null = null
+  let connected = false
+  let started = false
+  let inflightInbounds = 0
+  let stopWaiters: Array<() => void> = []
+
+  const channelResolver = createInstagramChannelResolver({ client, logger })
+
+  const formatChannelTag = async (workspace: string, chat: string): Promise<string> => {
+    const names = await channelResolver
+      .resolve({ adapter: 'instagram', workspace, chat, thread: null })
+      .catch(() => ({}) as ResolvedChannelNames)
+    return `bucket=${workspace} chat=${formatLabel(names.chatName, chat)}`
+  }
+
+  const historyCallback = createInstagramHistoryCallback({ client, logger, selfUserIdRef: () => selfUserId })
+  const outboundCallback = createOutboundCallback({ client, logger, formatChannelTag })
+
+  const processInbound = async (message: InstagramMessageSummary): Promise<void> => {
+    inflightInbounds++
+    try {
+      if (channelResolver.lookupChat(message.thread_id) === null) {
+        await channelResolver.refresh()
+        if (channelResolver.lookupChat(message.thread_id) === null) {
+          channelResolver.ingestProvisional(message.thread_id)
+          logger.warn(
+            `[instagram] provisional chat=${message.thread_id} message_id=${message.id} bucket=@instagram-group reason=not_in_listChats`,
+          )
+        }
+      }
+
+      const bucket = channelResolver.lookupChat(message.thread_id)?.workspace ?? '@instagram-group'
+      const inboundTag = await formatChannelTag(bucket, message.thread_id)
+      logger.info(
+        `[instagram] inbound message_id=${message.id} author=${message.from} ${inboundTag} type=${message.type} text_len=${(message.text ?? '').length}`,
+      )
+
+      const verdict = classifyInbound(message, options.configRef(), {
+        selfUserId,
+        lookupChat: (id) => channelResolver.lookupChat(id),
+        ...(options.selfAliasesRef ? { selfAliases: options.selfAliasesRef() } : {}),
+      })
+      if (verdict.kind === 'drop') {
+        logger.info(`[instagram] dropped message_id=${message.id} reason=${verdict.reason}`)
+        return
+      }
+
+      logger.info(
+        `[instagram] routed message_id=${message.id} ${inboundTag} mention=${verdict.payload.isBotMention} dm=${verdict.payload.isDm}`,
+      )
+      await options.router.route(verdict.payload)
+    } catch (err) {
+      logger.error(`[instagram] handleInbound failed: ${describeError(err)}`)
+    } finally {
+      inflightInbounds--
+      if (inflightInbounds === 0 && stopWaiters.length > 0) {
+        const waiters = stopWaiters
+        stopWaiters = []
+        for (const w of waiters) w()
+      }
+    }
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (started) return
+      started = true
+
+      try {
+        const credentialStore = options.credentialsStore ?? null
+        if (credentialStore !== null) {
+          const account = await credentialStore.getAccount()
+          if (account === null) {
+            throw new Error(
+              'no Instagram account in secrets.json#channels.instagram (run typeclaw channel add instagram)',
+            )
+          }
+          await client.login(undefined, account.account_id)
+        } else {
+          await client.login()
+        }
+      } catch (err) {
+        started = false
+        logger.error(`[instagram] login failed: ${describeError(err)}`)
+        throw err
+      }
+
+      try {
+        const profile = await client.getProfile()
+        selfUserId = profile.user_id
+        logger.info(`[instagram] authenticated as ${profile.username} (${profile.user_id})`)
+      } catch (err) {
+        started = false
+        logger.error(`[instagram] getProfile failed: ${describeError(err)}`)
+        throw err
+      }
+
+      try {
+        await channelResolver.refresh()
+      } catch (err) {
+        logger.warn(`[instagram] initial chat list fetch failed: ${describeError(err)}`)
+      }
+
+      const resolved = (options.listenerCtorResolver ?? resolveInstagramListenerCtor)()
+      listener = new resolved.ctor(client, { pollInterval: 5_000 })
+      logger.info(`[instagram] listener transport=${resolved.transport}`)
+      listener.on('connected', ({ userId, transport = 'polling' }) => {
+        connected = true
+        logger.info(`[instagram] connected (user_id=${userId}, transport=${transport})`)
+      })
+      listener.on('disconnected', () => {
+        connected = false
+        logger.warn('[instagram] disconnected; SDK will reconnect with backoff')
+      })
+      listener.on('error', (err) => {
+        logger.error(`[instagram] listener error: ${describeError(err)}`)
+      })
+      listener.on('message', (message) => {
+        void processInbound(message)
+      })
+
+      try {
+        await listener.start()
+      } catch (err) {
+        try {
+          listener.stop()
+        } catch {
+          // best-effort cleanup; the start failure is what we surface
+        }
+        listener = null
+        started = false
+        logger.error(`[instagram] listener start failed: ${describeError(err)}`)
+        throw err
+      }
+
+      options.router.registerOutbound('instagram', outboundCallback)
+      options.router.registerChannelNameResolver('instagram', channelResolver.resolve)
+      options.router.registerHistory('instagram', historyCallback)
+    },
+
+    async stop(): Promise<void> {
+      if (!started) return
+      started = false
+      options.router.unregisterOutbound('instagram', outboundCallback)
+      options.router.unregisterChannelNameResolver('instagram', channelResolver.resolve)
+      options.router.unregisterHistory('instagram', historyCallback)
+      if (inflightInbounds > 0) {
+        await new Promise<void>((resolve) => {
+          stopWaiters.push(resolve)
+        })
+      }
+      listener?.stop()
+      listener = null
+      selfUserId = null
+      connected = false
+    },
+
+    isConnected(): boolean {
+      return connected && selfUserId !== null
+    },
+  }
+}
+
+function clampLimit(requested: number, max: number): number {
+  if (!Number.isFinite(requested) || requested <= 0) return max
+  return Math.min(Math.floor(requested), max)
+}
+
+function formatLabel(name: string | undefined, id: string): string {
+  if (name === undefined || name === '' || name === id) return id
+  return `${name}(${id})`
+}

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import type { PermissionService } from '@/permissions'
 import type { GithubSecretsBlock } from '@/secrets'
 import { SecretsDiscordCredentialStore } from '@/secrets/discord-store'
+import { SecretsInstagramCredentialStore } from '@/secrets/instagram-store'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 import { SecretsLineCredentialStore } from '@/secrets/line-store'
 import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
@@ -14,6 +15,7 @@ import type { Stream } from '@/stream'
 import { createDiscordAdapter, type DiscordAdapter } from './adapters/discord'
 import { createDiscordBotAdapter, type DiscordBotAdapter } from './adapters/discord-bot'
 import { createGithubAdapter, type GithubAdapter } from './adapters/github'
+import { createInstagramAdapter, type InstagramAdapter } from './adapters/instagram'
 import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaotalk'
 import { createLineAdapter, type LineAdapter } from './adapters/line'
 import { createSlackAdapter, type SlackAdapter } from './adapters/slack'
@@ -75,6 +77,7 @@ export type ChannelManagerOptions = {
   createDiscordAdapter?: typeof createDiscordBotAdapter
   createDiscordUserAdapter?: typeof createDiscordAdapter
   createGithubAdapter?: typeof createGithubAdapter
+  createInstagramAdapter?: typeof createInstagramAdapter
   createKakaotalkAdapter?: typeof createKakaotalkAdapter
   createLineAdapter?: typeof createLineAdapter
   createSlackAdapter?: typeof createSlackBotAdapter
@@ -145,6 +148,7 @@ type AnyAdapter =
   | DiscordAdapter
   | DiscordBotAdapter
   | GithubAdapter
+  | InstagramAdapter
   | LineAdapter
   | KakaotalkAdapter
   | SlackAdapter
@@ -188,6 +192,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   const createDiscordBot = options.createDiscordAdapter ?? createDiscordBotAdapter
   const createDiscordUser = options.createDiscordUserAdapter ?? createDiscordAdapter
   const createGithub = options.createGithubAdapter ?? createGithubAdapter
+  const createInstagram = options.createInstagramAdapter ?? createInstagramAdapter
   const createKakaotalk = options.createKakaotalkAdapter ?? createKakaotalkAdapter
   const createLine = options.createLineAdapter ?? createLineAdapter
   const createSlackBot = options.createSlackAdapter ?? createSlackBotAdapter
@@ -219,6 +224,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 
   const buildCredentialSignature = (name: AdapterId): { signature: string; missing: string[] } => {
     if (name === 'line') return buildLineSignature(options.agentDir)
+    if (name === 'instagram') return buildInstagramSignature(options.agentDir)
     if (name === 'kakaotalk') return buildKakaotalkSignature(options.agentDir)
     if (name === 'webex') return buildWebexSignature(options.agentDir)
     if (name === 'slack') return buildSlackSignature(options.agentDir)
@@ -264,6 +270,17 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       const credentialsStore = createContainerLineCredentialStore(options.agentDir, env)
       if (credentialsStore === null) return null
       return createLine({
+        router,
+        configRef: () => options.channelsConfigRef()[name] ?? cfg,
+        logger,
+        selfAliasesRef: () => router.getSelfAliases(),
+        credentialsStore,
+      })
+    }
+    if (name === 'instagram') {
+      const credentialsStore = createContainerInstagramCredentialStore(options.agentDir, env)
+      if (credentialsStore === null) return null
+      return createInstagram({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
@@ -522,7 +539,12 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
             stopped.push(name)
           } else if (signature !== current.credentialSignature) {
             const reason =
-              name === 'kakaotalk' || name === 'line' || name === 'webex' || name === 'slack' || name === 'discord'
+              name === 'kakaotalk' ||
+              name === 'line' ||
+              name === 'instagram' ||
+              name === 'webex' ||
+              name === 'slack' ||
+              name === 'discord'
                 ? 'credential rotation'
                 : 'token rotation'
             restartRequired.push(`${name} (${reason})`)
@@ -539,7 +561,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 // secrets.json#channels.<adapter>, not in env, so they go through
 // structured-block signatures instead.
 const TOKEN_ENV: Record<
-  Exclude<AdapterId, 'kakaotalk' | 'line' | 'github' | 'webex' | 'slack' | 'discord'>,
+  Exclude<AdapterId, 'kakaotalk' | 'line' | 'instagram' | 'github' | 'webex' | 'slack' | 'discord'>,
   readonly string[]
 > = {
   'discord-bot': ['DISCORD_BOT_TOKEN'],
@@ -700,6 +722,33 @@ function buildLineSignature(agentDir: string): { signature: string; missing: str
   }
 }
 
+function createContainerInstagramCredentialStore(
+  agentDir: string,
+  env: NodeJS.ProcessEnv,
+): SecretsInstagramCredentialStore | null {
+  const creds = resolveHostdContainerCredentials(env)
+  if (creds === null) return null
+  return new SecretsInstagramCredentialStore({
+    mode: 'container',
+    secretsPath: join(agentDir, 'secrets.json'),
+    ...creds,
+  })
+}
+
+function buildInstagramSignature(agentDir: string): { signature: string; missing: string[] } {
+  const path = join(agentDir, 'secrets.json')
+  try {
+    const block = new SecretsBackend(path).tryReadChannelsSync()?.instagram
+    if (!isInstagramCredentialBlock(block)) {
+      return { signature: '', missing: ['secrets.json#channels.instagram'] }
+    }
+    const digest = createHash('sha256').update(JSON.stringify(block)).digest('hex')
+    return { signature: `secrets.json#channels.instagram@sha256:${digest}`, missing: [] }
+  } catch (err) {
+    return { signature: '', missing: [`secrets.json#channels.instagram (${describe(err)})`] }
+  }
+}
+
 function buildGithubSignature(agentDir: string): { signature: string; missing: string[] } {
   const block = readGithubSecrets(agentDir)
   if (block === null) return { signature: '', missing: ['secrets.json#channels.github'] }
@@ -736,6 +785,15 @@ function isKakaoCredentialBlock(value: unknown): value is { accounts: Record<str
 }
 
 function isLineCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  if (!('accounts' in value)) return false
+  const accounts = value.accounts
+  return (
+    typeof accounts === 'object' && accounts !== null && !Array.isArray(accounts) && Object.keys(accounts).length > 0
+  )
+}
+
+function isInstagramCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
   if (!('accounts' in value)) return false
   const accounts = value.accounts

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5220,6 +5220,7 @@ export function formatAuthorAttribution(adapter: AdapterId, authorId: string, au
     case 'telegram-bot':
     case 'webex':
     case 'webex-bot':
+    case 'instagram':
     case 'line':
     case 'kakaotalk':
       return hasDisplayName ? `${displayName} <${id}>` : id
@@ -5252,6 +5253,7 @@ function formatAuthorReference(adapter: AdapterId, authorId: string, authorName:
     case 'telegram-bot':
     case 'webex':
     case 'webex-bot':
+    case 'instagram':
     case 'line':
     case 'kakaotalk':
       return displayName

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -4,6 +4,7 @@ export const ADAPTER_IDS = [
   'discord',
   'discord-bot',
   'github',
+  'instagram',
   'line',
   'kakaotalk',
   'slack',
@@ -266,6 +267,10 @@ export const channelsSchema = z
     discord: adapterSchema.optional(),
     'discord-bot': adapterSchema.optional(),
     github: githubChannelSchema.optional(),
+    // Instagram is a personal-account channel: plain-text sends only,
+    // alias-only engagement in groups, and DM/group buckets backed by
+    // secrets.json#channels.instagram credentials rather than env vars.
+    instagram: adapterSchema.optional(),
     // LINE is a personal-account channel like KakaoTalk: plain-text only,
     // alias-only engagement (no native @-mention), credentials in
     // secrets.json#channels.line (not env). Unlike KakaoTalk it has no

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -30,12 +30,14 @@ import {
   type DiscordAuthResult,
   type GithubCredentialPatch,
   type GithubTunnelProvider,
+  type InstagramAuthResult,
   type KakaotalkAuthResult,
   type LineAuthResult,
   type SlackAuthResult,
   type WebexAuthResult,
 } from '@/init'
 import { runDiscordBootstrap } from '@/init/discord-auth'
+import { runInstagramBootstrap } from '@/init/instagram-auth'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { runLineBootstrap } from '@/init/line-auth'
 import { runSlackBootstrap } from '@/init/slack-auth'
@@ -55,6 +57,7 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'telegram-bot': 'Telegram',
   webex: 'Webex (User)',
   'webex-bot': 'Webex',
+  instagram: 'Instagram',
   line: 'LINE',
   kakaotalk: 'KakaoTalk',
   github: 'GitHub',
@@ -160,6 +163,15 @@ const setSub = defineCommand({
       process.exit(1)
     }
 
+    if (args.adapter === 'instagram') {
+      console.error(
+        errorLine(
+          'Instagram uses a username/password auth flow. Use `typeclaw channel reauth instagram` to rotate its credentials.',
+        ),
+      )
+      process.exit(1)
+    }
+
     const adapter =
       args.adapter === undefined
         ? await pickSettableAdapter(configured)
@@ -171,7 +183,7 @@ const setSub = defineCommand({
   },
 })
 
-const REAUTHABLE_ADAPTERS = ['line', 'kakaotalk', 'webex'] as const
+const REAUTHABLE_ADAPTERS = ['line', 'instagram', 'kakaotalk', 'webex'] as const
 type ReauthableAdapter = (typeof REAUTHABLE_ADAPTERS)[number]
 
 const reauthSub = defineCommand({
@@ -441,6 +453,9 @@ async function runReauth(cwd: string, adapter: ReauthableAdapter): Promise<void>
     case 'line':
       await runLineReauth(cwd)
       return
+    case 'instagram':
+      await runInstagramReauth(cwd)
+      return
     case 'kakaotalk':
       await runKakaotalkReauth(cwd)
       return
@@ -448,6 +463,20 @@ async function runReauth(cwd: string, adapter: ReauthableAdapter): Promise<void>
       await runWebexReauth(cwd)
       return
   }
+}
+
+async function runInstagramReauth(cwd: string): Promise<void> {
+  const creds = await promptInstagramCredentials()
+  const s = spinner()
+  s.start('Logging in to Instagram...')
+  const result = await runInstagramBootstrap({ username: creds.username, password: creds.password, agentDir: cwd })
+  if (!result.ok) {
+    s.stop(`Instagram login failed: ${result.reason}`)
+    process.exit(1)
+  }
+  s.stop('Instagram credentials refreshed in secrets.json.')
+
+  await maybePromptReauthRefresh(cwd, 'instagram')
 }
 
 async function runLineReauth(cwd: string): Promise<void> {
@@ -940,6 +969,7 @@ type CollectedCredentials =
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'webex'; runWebexAuth: (options: { cwd: string }) => Promise<WebexAuthResult> }
   | { channel: 'webex-bot'; webexBotToken: string }
+  | { channel: 'instagram'; runInstagramAuth: (options: { cwd: string }) => Promise<InstagramAuthResult> }
   | { channel: 'line'; runLineAuth: (options: { cwd: string }) => Promise<LineAuthResult> }
   | { channel: 'kakaotalk'; runKakaotalkAuth: (options: { cwd: string }) => Promise<KakaotalkAuthResult> }
   | {
@@ -986,6 +1016,14 @@ async function collectCredentials(
     }
     case 'webex-bot':
       return { channel, webexBotToken: await promptWebexToken() }
+    case 'instagram': {
+      const creds = await promptInstagramCredentials()
+      return {
+        channel,
+        runInstagramAuth: ({ cwd: agentDir }) =>
+          runInstagramBootstrap({ username: creds.username, password: creds.password, agentDir }),
+      }
+    }
     case 'line': {
       const login = await promptLineLogin(lineSpinnerHolder ? holderSpinnerControl(lineSpinnerHolder) : undefined)
       return {
@@ -1515,6 +1553,34 @@ async function promptWebexCredentials(
   return { email, password: pwd }
 }
 
+async function promptInstagramCredentials(): Promise<{ username: string; password: string }> {
+  note(
+    [
+      'Instagram authentication uses a personal account.',
+      'Messages will be sent and received under this account.',
+      '2FA/checkpointed accounts are not supported; use a dedicated account without those challenges.',
+    ].join('\n'),
+    'About to log in to Instagram',
+  )
+  const username = await text({
+    message: 'Instagram username',
+    validate: (value) => (value && value.length > 0 ? undefined : 'Username is required'),
+  })
+  if (isCancel(username)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  const pwd = await password({
+    message: 'Instagram password',
+    validate: (value) => (value && value.length > 0 ? undefined : 'Password is required'),
+  })
+  if (isCancel(pwd)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return { username, password: pwd }
+}
+
 type LinePromptResult =
   | { method: 'qr'; callbacks: { onQRUrl: (url: string) => Promise<void>; onPincode: (pin: string) => void } }
   | {
@@ -1681,6 +1747,9 @@ function reportProgress(
         if (lineSpinnerHolder) lineSpinnerHolder.current = null
         s.stop(reportLineAuth(event.result))
         break
+      case 'instagram-auth':
+        s.stop(reportInstagramAuth(event.result))
+        break
       case 'kakaotalk-auth':
         s.stop(reportKakaotalkAuth(event.result))
         break
@@ -1708,6 +1777,7 @@ function reportProgress(
 
 const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
   'line-auth': 'Logging in to LINE...',
+  'instagram-auth': 'Logging in to Instagram...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   'webex-auth': 'Logging in to Webex...',
   'discord-auth': 'Logging in to Discord...',
@@ -1740,6 +1810,11 @@ function reportWebexAuth(result: WebexAuthResult): string {
 function reportLineAuth(result: LineAuthResult): string {
   if (result.ok) return 'LINE credentials saved to secrets.json.'
   return `LINE login failed: ${result.reason}`
+}
+
+function reportInstagramAuth(result: InstagramAuthResult): string {
+  if (result.ok) return 'Instagram credentials saved to secrets.json.'
+  return `Instagram login failed: ${result.reason}`
 }
 
 async function maybePromptRestart(

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -2047,6 +2047,7 @@ const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {
   scaffold: 'Laying the egg...',
   'slack-auth': 'Logging in to Slack...',
   'discord-auth': 'Logging in to Discord...',
+  'instagram-auth': 'Logging in to Instagram...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   'webex-auth': 'Logging in to Webex...',
   'github-webhooks': 'Installing GitHub repository webhooks...',

--- a/src/config/channels-mutation.ts
+++ b/src/config/channels-mutation.ts
@@ -15,6 +15,7 @@ export const CHANNEL_KINDS = [
   'telegram-bot',
   'webex',
   'webex-bot',
+  'instagram',
   'line',
   'kakaotalk',
   'github',
@@ -189,7 +190,7 @@ function buildDetail(kind: ChannelKind, channelConfig: unknown, secretsBlock: un
     const repos = isObjectRecord(channelConfig) && Array.isArray(channelConfig.repos) ? channelConfig.repos.length : 0
     return { detail: `${repos} repo${repos === 1 ? '' : 's'}` }
   }
-  if (kind === 'line' || kind === 'kakaotalk' || kind === 'webex' || kind === 'discord') {
+  if (kind === 'line' || kind === 'instagram' || kind === 'kakaotalk' || kind === 'webex' || kind === 'discord') {
     if (!isObjectRecord(secretsBlock)) return {}
     const accounts = isObjectRecord(secretsBlock.accounts) ? Object.keys(secretsBlock.accounts).length : 0
     const current = typeof secretsBlock.currentAccount === 'string' ? secretsBlock.currentAccount : undefined

--- a/src/doctor/channel-checks.test.ts
+++ b/src/doctor/channel-checks.test.ts
@@ -72,6 +72,7 @@ describe('buildChannelChecks', () => {
       'channel.discord.credentials',
       'channel.slack.credentials',
       'channel.webex.credentials',
+      'channel.instagram.credentials',
       'channel.line.credentials',
       'channel.kakaotalk.credentials',
       'channel.github.credentials',

--- a/src/doctor/channel-checks.ts
+++ b/src/doctor/channel-checks.ts
@@ -32,6 +32,7 @@ export function buildChannelChecks(): DoctorCheck[] {
     discordUserCredentials(),
     slackUserCredentials(),
     webexUserCredentials(),
+    instagramCredentials(),
     lineCredentials(),
     kakaotalkCredentials(),
     githubCredentials(),
@@ -153,6 +154,33 @@ function webexUserCredentials(): DoctorCheck {
         }
       }
       return { status: 'ok', message: 'webex has a current account access_token' }
+    },
+  }
+}
+
+function instagramCredentials(): DoctorCheck {
+  return {
+    name: 'channel.instagram.credentials',
+    category: 'channels',
+    description: 'instagram adapter has at least one account in secrets.json',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const channels = readDeclaredChannels(ctx)
+      if (channels === null) return configInvalidResult()
+      if (!isAdapterActive(channels, 'instagram')) {
+        return { status: 'skipped', message: 'instagram not configured' }
+      }
+      const block = readChannelsSecrets(ctx)?.instagram
+      const accountCount = block?.accounts ? Object.keys(block.accounts).length : 0
+      if (accountCount === 0) {
+        return {
+          status: 'warning',
+          message: 'instagram has no accounts in secrets.json',
+          details: ['Adapter will start but fail authentication and stay disconnected.'],
+          fix: { description: 'Run `typeclaw channel add instagram` to log in an account.' },
+        }
+      }
+      return { status: 'ok', message: `instagram has ${accountCount} account(s)` }
     },
   }
 }

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -8,6 +8,7 @@ import { defaultDockerExec, type DockerExec, type HostDaemonRegisterPayload } fr
 import type { PortForwardEvent } from '@/portbroker'
 import {
   discordChannelBlockSchema,
+  instagramChannelBlockSchema,
   kakaoChannelBlockSchema,
   lineChannelBlockSchema,
   slackChannelBlockSchema,
@@ -530,6 +531,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       channels:
         | { kakaotalk: unknown }
         | { discord: unknown }
+        | { instagram: unknown }
         | { line: unknown }
         | { webex: unknown }
         | { slack: unknown }
@@ -545,13 +547,15 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       const patch =
         'line' in channelsPatch
           ? { key: 'line' as const, parsed: lineChannelBlockSchema.safeParse(channelsPatch.line) }
-          : 'discord' in channelsPatch
-            ? { key: 'discord' as const, parsed: discordChannelBlockSchema.safeParse(channelsPatch.discord) }
-            : 'webex' in channelsPatch
-              ? { key: 'webex' as const, parsed: webexChannelBlockSchema.safeParse(channelsPatch.webex) }
-              : 'slack' in channelsPatch
-                ? { key: 'slack' as const, parsed: slackChannelBlockSchema.safeParse(channelsPatch.slack) }
-                : { key: 'kakaotalk' as const, parsed: kakaoChannelBlockSchema.safeParse(channelsPatch.kakaotalk) }
+          : 'instagram' in channelsPatch
+            ? { key: 'instagram' as const, parsed: instagramChannelBlockSchema.safeParse(channelsPatch.instagram) }
+            : 'discord' in channelsPatch
+              ? { key: 'discord' as const, parsed: discordChannelBlockSchema.safeParse(channelsPatch.discord) }
+              : 'webex' in channelsPatch
+                ? { key: 'webex' as const, parsed: webexChannelBlockSchema.safeParse(channelsPatch.webex) }
+                : 'slack' in channelsPatch
+                  ? { key: 'slack' as const, parsed: slackChannelBlockSchema.safeParse(channelsPatch.slack) }
+                  : { key: 'kakaotalk' as const, parsed: kakaoChannelBlockSchema.safeParse(channelsPatch.kakaotalk) }
       if (!patch.parsed.success) {
         return { ok: false, reason: patch.parsed.error.issues.map((issue) => issue.message).join('; ') }
       }

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -1,6 +1,7 @@
 import type { PortForward } from '@/config'
 import type {
   DiscordChannelBlock,
+  InstagramChannelBlock,
   KakaoChannelBlock,
   LineChannelBlock,
   SlackChannelBlock,
@@ -28,6 +29,7 @@ export type Request =
         channels:
           | { kakaotalk: KakaoChannelBlock }
           | { discord: DiscordChannelBlock }
+          | { instagram: InstagramChannelBlock }
           | { line: LineChannelBlock }
           | { webex: WebexChannelBlock }
           | { slack: SlackChannelBlock }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -86,6 +86,7 @@ export type InitStep =
   | 'scaffold'
   | 'slack-auth'
   | 'discord-auth'
+  | 'instagram-auth'
   | 'kakaotalk-auth'
   | 'webex-auth'
   | 'github-webhooks'
@@ -98,6 +99,7 @@ export type KakaotalkAuthResult = { ok: true } | { ok: false; reason: string }
 export type WebexAuthResult = { ok: true } | { ok: false; reason: string }
 export type SlackAuthResult = { ok: true } | { ok: false; reason: string }
 export type DiscordAuthResult = { ok: true } | { ok: false; reason: string }
+export type InstagramAuthResult = { ok: true } | { ok: false; reason: string }
 
 // Structured credential block for the GitHub channel adapter. Mirrors the
 // shape `runAddChannel({ channel: 'github', ... })` consumes so the wizard
@@ -137,6 +139,8 @@ export type InitStepEvent =
   | { step: 'webex-auth'; phase: 'done'; result: WebexAuthResult }
   | { step: 'discord-auth'; phase: 'start' }
   | { step: 'discord-auth'; phase: 'done'; result: DiscordAuthResult }
+  | { step: 'instagram-auth'; phase: 'start' }
+  | { step: 'instagram-auth'; phase: 'done'; result: InstagramAuthResult }
   | { step: 'github-webhooks'; phase: 'start' }
   | { step: 'github-webhooks'; phase: 'done'; result: EagerGithubWebhookInstallResult }
   | { step: 'install'; phase: 'start' }
@@ -169,6 +173,7 @@ export type WebexAuthRunner = (options: { cwd: string }) => Promise<WebexAuthRes
 
 export type LineAuthResult = { ok: true } | { ok: false; reason: string }
 export type LineAuthRunner = (options: { cwd: string }) => Promise<LineAuthResult>
+export type InstagramAuthRunner = (options: { cwd: string }) => Promise<InstagramAuthResult>
 
 // Discriminated by `kind` so the type system enforces "you can't pass an
 // API key to an OAuth provider, and you can't pass an OAuth runner to an
@@ -223,11 +228,13 @@ export type InitOptions = {
   withTelegram?: boolean
   withWebex?: boolean
   withWebexUser?: boolean
+  withInstagram?: boolean
   withKakaotalk?: boolean
   withGithub?: boolean
   runKakaotalkAuth?: KakaotalkAuthRunner
   runWebexAuth?: WebexAuthRunner
   runDiscordAuth?: DiscordAuthRunner
+  runInstagramAuth?: InstagramAuthRunner
   // Structured GitHub credentials collected by the wizard. When omitted and
   // `withGithub` is true, the existing secrets.json#channels.github block is
   // reused as-is (the wizard's "reuse existing credentials" path).
@@ -273,11 +280,13 @@ export async function runInit({
   withTelegram,
   withWebex,
   withWebexUser = false,
+  withInstagram = false,
   withKakaotalk = false,
   withGithub = false,
   runKakaotalkAuth,
   runWebexAuth,
   runDiscordAuth,
+  runInstagramAuth,
   githubCredentials,
   githubFetchImpl,
   onProgress,
@@ -358,6 +367,7 @@ export async function runInit({
     withTelegram: wantsTelegram,
     withWebex: wantsWebex,
     withWebexUser,
+    withInstagram,
     withKakaotalk,
     platform,
   })
@@ -412,6 +422,15 @@ export async function runInit({
     }
   }
 
+  if (withInstagram && runInstagramAuth !== undefined) {
+    emit({ step: 'instagram-auth', phase: 'start' })
+    const result = await runInstagramAuth({ cwd })
+    emit({ step: 'instagram-auth', phase: 'done', result })
+    if (!result.ok) {
+      throw new Error(`Instagram authentication failed: ${result.reason}`)
+    }
+  }
+
   // Write the structured github channel block alongside scaffold's bot-token
   // blocks. We do NOT delegate to runAddChannel because that's the `channel
   // add` semantics — strict no-overwrite, throws when secrets.json#channels
@@ -463,6 +482,7 @@ export async function runInit({
   if (wantsTelegram) configuredChannels.push('telegram-bot')
   if (wantsWebex) configuredChannels.push('webex-bot')
   if (withWebexUser) configuredChannels.push('webex')
+  if (withInstagram) configuredChannels.push('instagram')
   if (withKakaotalk) configuredChannels.push('kakaotalk')
   if (withGithub) configuredChannels.push('github')
 
@@ -633,6 +653,7 @@ export type ScaffoldOptions = {
   withTelegram?: boolean
   withWebex?: boolean
   withWebexUser?: boolean
+  withInstagram?: boolean
   withKakaotalk?: boolean
   // Defaults to `process.platform`; controls the dev-mode typeclaw spec
   // (`link:` on Windows, `file:` on POSIX). Tests inject it.
@@ -671,6 +692,7 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   if (options.withTelegram) channels['telegram-bot'] = {}
   if (options.withWebex) channels['webex-bot'] = {}
   if (options.withWebexUser) channels.webex = {}
+  if (options.withInstagram) channels.instagram = {}
   if (options.withKakaotalk) channels.kakaotalk = {}
   if (Object.keys(channels).length > 0) config.channels = channels
   // No default `member` match is seeded. A fresh chat agent starts with every
@@ -986,7 +1008,7 @@ export async function hasExistingOAuthCredentials(root: string, providerId: Know
 // kakaotalk` anyway — better to re-auth now during init.
 export async function hasExistingChannelSecrets(
   root: string,
-  channel: 'discord' | 'slack' | 'telegram' | 'webex' | 'line' | 'kakaotalk' | 'github',
+  channel: 'discord' | 'slack' | 'telegram' | 'webex' | 'instagram' | 'line' | 'kakaotalk' | 'github',
 ): Promise<boolean> {
   const channels = new SecretsBackend(join(root, 'secrets.json')).tryReadChannelsSync()
   if (channels === null) return false
@@ -1008,6 +1030,18 @@ export async function hasExistingChannelSecrets(
       // surfaced as a hard error inside `runAddChannel` to prevent silent
       // overwrites.
       return false
+    case 'instagram': {
+      const block = channels.instagram
+      if (!isObjectRecord(block)) return false
+      const current = (block as { currentAccount?: unknown }).currentAccount
+      if (typeof current !== 'string' || current.length === 0) return false
+      const accounts = (block as { accounts?: unknown }).accounts
+      if (!isObjectRecord(accounts)) return false
+      const account = accounts[current]
+      if (!isObjectRecord(account)) return false
+      const username = (account as { username?: unknown }).username
+      return typeof username === 'string' && username.length > 0
+    }
     case 'line': {
       // A usable LINE block needs a current account whose record carries an
       // auth_token. Unlike KakaoTalk there are no renewal fields (email +
@@ -1115,6 +1149,7 @@ export type ChannelKind =
   | 'telegram-bot'
   | 'webex'
   | 'webex-bot'
+  | 'instagram'
   | 'line'
   | 'kakaotalk'
   | 'github'
@@ -1131,6 +1166,7 @@ export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = [
   'telegram-bot',
   'webex',
   'webex-bot',
+  'instagram',
   'line',
   'kakaotalk',
   'github',
@@ -1138,6 +1174,7 @@ export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = [
 
 export type AddChannelStep =
   | 'line-auth'
+  | 'instagram-auth'
   | 'kakaotalk-auth'
   | 'webex-auth'
   | 'discord-auth'
@@ -1151,6 +1188,8 @@ export type AddChannelStepEvent =
   | { step: 'config'; phase: 'done' }
   | { step: 'line-auth'; phase: 'start' }
   | { step: 'line-auth'; phase: 'done'; result: LineAuthResult }
+  | { step: 'instagram-auth'; phase: 'start' }
+  | { step: 'instagram-auth'; phase: 'done'; result: InstagramAuthResult }
   | { step: 'kakaotalk-auth'; phase: 'start' }
   | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
   | { step: 'webex-auth'; phase: 'start' }
@@ -1178,6 +1217,7 @@ export type AddChannelOptions = {
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'webex-bot'; webexBotToken: string }
   | { channel: 'webex'; runWebexAuth: WebexAuthRunner }
+  | { channel: 'instagram'; runInstagramAuth: InstagramAuthRunner }
   | { channel: 'line'; runLineAuth: LineAuthRunner }
   | { channel: 'kakaotalk'; runKakaotalkAuth: KakaotalkAuthRunner }
   | {
@@ -1213,6 +1253,13 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
     const result = await options.runLineAuth({ cwd: options.cwd })
     emit({ step: 'line-auth', phase: 'done', result })
     if (!result.ok) throw new Error(`LINE authentication failed: ${result.reason}`)
+  }
+
+  if (options.channel === 'instagram') {
+    emit({ step: 'instagram-auth', phase: 'start' })
+    const result = await options.runInstagramAuth({ cwd: options.cwd })
+    emit({ step: 'instagram-auth', phase: 'done', result })
+    if (!result.ok) throw new Error(`Instagram authentication failed: ${result.reason}`)
   }
 
   if (options.channel === 'kakaotalk') {
@@ -1323,6 +1370,8 @@ function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
     case 'webex-bot':
       return { token: options.webexBotToken }
     case 'webex':
+      return {}
+    case 'instagram':
       return {}
     case 'line':
       // LINE auth writes its structured account block directly to

--- a/src/init/instagram-auth.test.ts
+++ b/src/init/instagram-auth.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { InstagramAccount } from 'agent-messenger/instagram'
+
+import {
+  instagramConfigDir,
+  runInstagramBootstrap,
+  type InstagramAuthenticateResult,
+  type InstagramLoginClient,
+  type InstagramLoginCredentialManager,
+} from './instagram-auth'
+
+async function withDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'typeclaw-instagram-auth-'))
+  try {
+    return await fn(root)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+function fakeManager(accountId = 'alice'): { manager: InstagramLoginCredentialManager; saved: InstagramAccount[] } {
+  const saved: InstagramAccount[] = []
+  let current: string | null = null
+  return {
+    saved,
+    manager: {
+      ensureAccountPaths: async (id) => ({ session_path: `/tmp/${id}/session.json` }),
+      getAccount: async (id) => saved.find((account) => account.account_id === (id ?? current)) ?? null,
+      setAccount: async (account) => {
+        saved.push(account)
+      },
+      setCurrent: async (id) => {
+        current = id
+        return id === accountId
+      },
+    },
+  }
+}
+
+function fakeClient(result: InstagramAuthenticateResult): InstagramLoginClient {
+  return {
+    authenticate: async () => result,
+    setSessionPath: () => {},
+    getUserId: () => result.userId || null,
+  }
+}
+
+function observingClient(result: InstagramAuthenticateResult, onAuthenticate: () => void): InstagramLoginClient {
+  return {
+    authenticate: async () => {
+      onAuthenticate()
+      return result
+    },
+    setSessionPath: () => {},
+    getUserId: () => result.userId || null,
+  }
+}
+
+describe('runInstagramBootstrap', () => {
+  test('points the SDK storage at the agent workspace during login, then restores the env', async () => {
+    await withDir(async (dir) => {
+      const savedEnv = process.env.AGENT_MESSENGER_CONFIG_DIR
+      delete process.env.AGENT_MESSENGER_CONFIG_DIR
+      try {
+        const { manager } = fakeManager()
+        let duringLogin: string | undefined
+        await runInstagramBootstrap({
+          username: 'alice',
+          password: 'secret',
+          agentDir: dir,
+          credentialManager: manager,
+          client: observingClient({ userId: '12345' }, () => {
+            duringLogin = process.env.AGENT_MESSENGER_CONFIG_DIR
+          }),
+        })
+        expect(duringLogin ?? '').toBe(instagramConfigDir(dir))
+        expect(process.env.AGENT_MESSENGER_CONFIG_DIR).toBeUndefined()
+      } finally {
+        if (savedEnv === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+        else process.env.AGENT_MESSENGER_CONFIG_DIR = savedEnv
+      }
+    })
+  })
+
+  test('mirrors SDK account metadata into secrets after clean authentication', async () => {
+    await withDir(async (dir) => {
+      const { manager, saved } = fakeManager()
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: fakeClient({ userId: '12345' }),
+      })
+      expect(status).toEqual({ ok: true })
+      expect(saved).toHaveLength(1)
+      expect(saved[0]).toMatchObject({ account_id: 'alice', username: 'alice', pk: '12345' })
+
+      const raw = JSON.parse(await readFile(join(dir, 'secrets.json'), 'utf8')) as {
+        channels: {
+          instagram: {
+            currentAccount: string
+            accounts: Record<string, { account_id: string; username: string; pk?: string }>
+          }
+        }
+      }
+      expect(raw.channels.instagram.currentAccount).toBe('alice')
+      expect(raw.channels.instagram.accounts.alice).toMatchObject({
+        account_id: 'alice',
+        username: 'alice',
+        pk: '12345',
+      })
+    })
+  })
+
+  test('reports login failures', async () => {
+    await withDir(async (dir) => {
+      const { manager } = fakeManager()
+      const client: InstagramLoginClient = {
+        authenticate: async () => {
+          throw new Error('login exploded')
+        },
+        setSessionPath: () => {},
+        getUserId: () => null,
+      }
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client,
+      })
+      expect(status).toEqual({ ok: false, reason: 'login exploded' })
+    })
+  })
+
+  test('fails clearly when 2FA is required', async () => {
+    await withDir(async (dir) => {
+      const { manager } = fakeManager()
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: fakeClient({ userId: '', requiresTwoFactor: true, twoFactorInfo: {} }),
+      })
+      expect(status.ok).toBe(false)
+      if (status.ok) throw new Error('expected failure')
+      expect(status.reason).toContain('2FA/checkpoint')
+      expect(status.reason).toContain('not yet supported')
+    })
+  })
+
+  test('fails clearly when a checkpoint challenge is required', async () => {
+    await withDir(async (dir) => {
+      const { manager } = fakeManager()
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: fakeClient({ userId: '', challengeRequired: true, challengePath: '/challenge/' }),
+      })
+      expect(status.ok).toBe(false)
+      if (status.ok) throw new Error('expected failure')
+      expect(status.reason).toContain('2FA/checkpoint')
+      expect(status.reason).toContain('not yet supported')
+    })
+  })
+})

--- a/src/init/instagram-auth.ts
+++ b/src/init/instagram-auth.ts
@@ -1,0 +1,134 @@
+import { join } from 'node:path'
+
+import {
+  createAccountId,
+  InstagramClient as RealInstagramClient,
+  InstagramCredentialManager,
+  type InstagramAccount,
+} from 'agent-messenger/instagram'
+
+import { SecretsInstagramCredentialStore } from '@/secrets/instagram-store'
+
+export type InstagramBootstrapStatus = { ok: true } | { ok: false; reason: string }
+
+export type InstagramLoginInput = {
+  username: string
+  password: string
+  agentDir: string
+  client?: InstagramLoginClient
+  credentialManager?: InstagramLoginCredentialManager
+}
+
+export type InstagramAuthenticateResult = {
+  userId: string
+  requiresTwoFactor?: boolean
+  twoFactorInfo?: Record<string, unknown>
+  challengeRequired?: boolean
+  challengePath?: string
+}
+
+export type InstagramLoginClient = {
+  authenticate(username: string, password: string): Promise<InstagramAuthenticateResult>
+  setSessionPath(path: string): void
+  getUserId(): string | null
+}
+
+export type InstagramLoginCredentialManager = {
+  ensureAccountPaths(accountId: string): Promise<{ session_path: string }>
+  getAccount(accountId?: string): Promise<InstagramAccount | null>
+  setAccount(account: InstagramAccount): Promise<void>
+  setCurrent(accountId: string): Promise<boolean>
+}
+
+export function instagramSecretsPath(agentDir: string): string {
+  return join(agentDir, 'secrets.json')
+}
+
+export function instagramConfigDir(agentDir: string): string {
+  return join(agentDir, 'workspace', '.agent-messenger')
+}
+
+export async function runInstagramBootstrap(input: InstagramLoginInput): Promise<InstagramBootstrapStatus> {
+  try {
+    const store = new SecretsInstagramCredentialStore({
+      mode: 'host',
+      secretsPath: instagramSecretsPath(input.agentDir),
+    })
+    const result = await withInstagramConfigDir(
+      instagramConfigDir(input.agentDir),
+      async (): Promise<InstagramBootstrapStatus> => {
+        const sdkManager = new InstagramCredentialManager()
+        const manager = input.credentialManager ?? sdkManager
+        const accountId = createAccountId(input.username)
+        const paths = await manager.ensureAccountPaths(accountId)
+        const client = input.client ?? buildInstagramClient(sdkManager)
+        client.setSessionPath(paths.session_path)
+        const auth = await client.authenticate(input.username, input.password)
+        if (auth.requiresTwoFactor) return unsupportedTwoFactor()
+        if (auth.challengeRequired) return unsupportedChallenge()
+        const userId = auth.userId || client.getUserId()
+        if (userId === null || userId === '') return { ok: false, reason: 'Instagram login did not authenticate' }
+
+        const now = new Date().toISOString()
+        await manager.setAccount({
+          account_id: accountId,
+          username: input.username,
+          pk: userId,
+          created_at: now,
+          updated_at: now,
+        })
+        await manager.setCurrent(accountId)
+
+        const sdkAccount = await manager.getAccount(accountId)
+        if (sdkAccount === null) {
+          return { ok: false, reason: 'Instagram login authenticated but did not persist SDK credentials' }
+        }
+        await store.setAccount({
+          account_id: sdkAccount.account_id,
+          username: sdkAccount.username,
+          ...(sdkAccount.full_name !== undefined ? { full_name: sdkAccount.full_name } : {}),
+          ...(sdkAccount.profile_pic_url !== undefined ? { profile_pic_url: sdkAccount.profile_pic_url } : {}),
+          ...(sdkAccount.pk !== undefined ? { pk: sdkAccount.pk } : {}),
+          created_at: sdkAccount.created_at,
+          updated_at: sdkAccount.updated_at,
+        })
+        await store.setCurrentAccount(sdkAccount.account_id)
+        return { ok: true }
+      },
+    )
+    return result
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function buildInstagramClient(manager: InstagramCredentialManager): InstagramLoginClient {
+  return new RealInstagramClient(manager) as unknown as InstagramLoginClient
+}
+
+function unsupportedTwoFactor(): InstagramBootstrapStatus {
+  return {
+    ok: false,
+    reason:
+      'Instagram account requires 2FA/checkpoint, which is not yet supported by the typeclaw Instagram channel. Disable 2FA on a dedicated agent account, or complete the checkpoint in a browser first.',
+  }
+}
+
+function unsupportedChallenge(): InstagramBootstrapStatus {
+  return {
+    ok: false,
+    reason:
+      'Instagram account requires 2FA/checkpoint, which is not yet supported by the typeclaw Instagram channel. Disable 2FA on a dedicated agent account, or complete the checkpoint in a browser first.',
+  }
+}
+
+async function withInstagramConfigDir<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.AGENT_MESSENGER_CONFIG_DIR
+  process.env.AGENT_MESSENGER_CONFIG_DIR = dir
+  try {
+    return await fn()
+  } finally {
+    if (previous === undefined) delete process.env.AGENT_MESSENGER_CONFIG_DIR
+    else process.env.AGENT_MESSENGER_CONFIG_DIR = previous
+  }
+}

--- a/src/init/run-owner-claim.ts
+++ b/src/init/run-owner-claim.ts
@@ -14,6 +14,7 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'telegram-bot': 'Telegram',
   webex: 'Webex (User)',
   'webex-bot': 'Webex',
+  instagram: 'Instagram',
   line: 'LINE',
   kakaotalk: 'KakaoTalk',
 }

--- a/src/permissions/match-rule.ts
+++ b/src/permissions/match-rule.ts
@@ -16,7 +16,7 @@
 // error messages with typo suggestions; a single big regex would only ever
 // say "didn't match".
 
-export const PLATFORMS = ['slack', 'discord', 'telegram', 'webex', 'line', 'kakao', 'github'] as const
+export const PLATFORMS = ['slack', 'discord', 'telegram', 'webex', 'instagram', 'line', 'kakao', 'github'] as const
 export type Platform = (typeof PLATFORMS)[number]
 
 const SUBAGENT_NAME = /^[a-z][a-z0-9-]*$/

--- a/src/permissions/resolve.ts
+++ b/src/permissions/resolve.ts
@@ -9,6 +9,7 @@ const ADAPTER_TO_PLATFORM: Record<AdapterId, Platform> = {
   discord: 'discord',
   'discord-bot': 'discord',
   github: 'github',
+  instagram: 'instagram',
   'telegram-bot': 'telegram',
   webex: 'webex',
   'webex-bot': 'webex',

--- a/src/role-claim/match-rule.ts
+++ b/src/role-claim/match-rule.ts
@@ -27,13 +27,14 @@ export type PartialChannelOrigin = {
 
 const ADAPTER_TO_PLATFORM: Record<
   ChannelKey['adapter'],
-  'slack' | 'discord' | 'telegram' | 'webex' | 'kakao' | 'line' | 'github'
+  'slack' | 'discord' | 'telegram' | 'webex' | 'kakao' | 'line' | 'github' | 'instagram'
 > = {
   slack: 'slack',
   'slack-bot': 'slack',
   discord: 'discord',
   'discord-bot': 'discord',
   github: 'github',
+  instagram: 'instagram',
   'telegram-bot': 'telegram',
   webex: 'webex',
   'webex-bot': 'webex',

--- a/src/secrets/instagram-store.test.ts
+++ b/src/secrets/instagram-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { SecretsInstagramCredentialStore } from './instagram-store'
+import type { InstagramAccountRecord } from './schema'
+
+async function withStore<T>(
+  fn: (store: SecretsInstagramCredentialStore, secretsPath: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'typeclaw-instagram-store-'))
+  try {
+    const secretsPath = join(root, 'secrets.json')
+    return await fn(new SecretsInstagramCredentialStore({ mode: 'host', secretsPath }), secretsPath)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+function account(id: string, overrides: Partial<InstagramAccountRecord> = {}): InstagramAccountRecord {
+  return {
+    account_id: id,
+    username: `user-${id}`,
+    pk: `pk-${id}`,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('SecretsInstagramCredentialStore host mode', () => {
+  test('round-trips setAccount through secrets.json#channels.instagram', async () => {
+    await withStore(async (store, secretsPath) => {
+      await store.setAccount(account('ig-1'))
+      expect(await store.getAccount()).toEqual(account('ig-1'))
+      const raw = JSON.parse(await readFile(secretsPath, 'utf8')) as { channels: Record<string, unknown> }
+      expect(raw.channels.instagram).toEqual({ currentAccount: 'ig-1', accounts: { 'ig-1': account('ig-1') } })
+    })
+  })
+
+  test('supports list, current-account switching, and remove', async () => {
+    await withStore(async (store) => {
+      await store.setAccount(account('ig-1'))
+      await store.setAccount(account('ig-2'))
+      await store.setCurrentAccount('ig-2')
+      expect(await store.getAccount()).toEqual(account('ig-2'))
+      expect(await store.listAccounts()).toEqual([
+        { ...account('ig-1'), is_current: false },
+        { ...account('ig-2'), is_current: true },
+      ])
+      await store.removeAccount('ig-1')
+      expect(await store.getAccount('ig-1')).toBeNull()
+    })
+  })
+})

--- a/src/secrets/instagram-store.ts
+++ b/src/secrets/instagram-store.ts
@@ -1,0 +1,112 @@
+import { sendHttp } from '@/hostd/client'
+
+import { type InstagramAccountRecord, type InstagramChannelBlock, instagramChannelBlockSchema } from './schema'
+import { SecretsBackend } from './storage'
+
+export type SecretsInstagramCredentialStoreOptions =
+  | { mode: 'host'; secretsPath: string }
+  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+
+const EMPTY_BLOCK: InstagramChannelBlock = { currentAccount: null, accounts: {} }
+
+export class SecretsInstagramCredentialStore {
+  private readonly backend: SecretsBackend
+  private writeChain: Promise<void> = Promise.resolve()
+
+  constructor(private readonly options: SecretsInstagramCredentialStoreOptions) {
+    this.backend = new SecretsBackend(options.secretsPath)
+  }
+
+  async load(): Promise<InstagramConfig> {
+    return toInstagramConfig(this.readBlock())
+  }
+
+  async save(config: InstagramConfig): Promise<void> {
+    await this.writeBlock(() => fromInstagramConfig(config))
+  }
+
+  async getAccount(id?: string): Promise<InstagramAccountRecord | null> {
+    const config = await this.load()
+    if (id) return config.accounts[id] ?? null
+    if (!config.current) return null
+    return config.accounts[config.current] ?? null
+  }
+
+  async setAccount(account: InstagramAccountRecord): Promise<void> {
+    await this.writeBlock((block) => {
+      const accounts = { ...block.accounts, [account.account_id]: account }
+      return { ...block, currentAccount: block.currentAccount ?? account.account_id, accounts }
+    })
+  }
+
+  async removeAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => {
+      const accounts = { ...block.accounts }
+      delete accounts[id]
+      const currentAccount = block.currentAccount === id ? (Object.keys(accounts)[0] ?? null) : block.currentAccount
+      return { ...block, currentAccount, accounts }
+    })
+  }
+
+  async listAccounts(): Promise<Array<InstagramAccountRecord & { is_current: boolean }>> {
+    const config = await this.load()
+    return Object.values(config.accounts).map((account) => ({
+      ...account,
+      is_current: account.account_id === config.current,
+    }))
+  }
+
+  async setCurrentAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => ({ ...block, currentAccount: id }))
+  }
+
+  private readBlock(): InstagramChannelBlock {
+    const channels =
+      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+    return parseBlock(channels?.instagram)
+  }
+
+  private async writeBlock(update: (current: InstagramChannelBlock) => InstagramChannelBlock): Promise<void> {
+    return this.enqueueWrite(async () => {
+      if (this.options.mode === 'container') {
+        const next = update(this.readBlock())
+        const response = await sendHttp(
+          {
+            kind: 'secrets-patch',
+            containerName: this.options.containerName,
+            patch: { channels: { instagram: next } },
+          },
+          { url: this.options.hostdUrl, token: this.options.restartToken },
+        )
+        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        return
+      }
+
+      await this.backend.updateChannelsAsync(async (channels) => {
+        const next = { ...channels, instagram: update(parseBlock(channels.instagram)) }
+        return { result: undefined, next }
+      })
+    })
+  }
+
+  private enqueueWrite(op: () => Promise<void>): Promise<void> {
+    const next = this.writeChain.then(op, op)
+    this.writeChain = next.catch(() => {})
+    return next
+  }
+}
+
+function parseBlock(value: unknown): InstagramChannelBlock {
+  if (value === undefined) return EMPTY_BLOCK
+  return instagramChannelBlockSchema.parse(value)
+}
+
+export type InstagramConfig = { current: string | null; accounts: Record<string, InstagramAccountRecord> }
+
+function toInstagramConfig(block: InstagramChannelBlock): InstagramConfig {
+  return { current: block.currentAccount, accounts: block.accounts }
+}
+
+function fromInstagramConfig(config: InstagramConfig): InstagramChannelBlock {
+  return { currentAccount: config.current, accounts: config.accounts }
+}

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -90,6 +90,21 @@ export const lineChannelBlockSchema = z.object({
   accounts: z.record(z.string(), lineAccountRecordSchema),
 })
 
+export const instagramAccountRecordSchema = z.object({
+  account_id: z.string(),
+  username: z.string(),
+  full_name: z.string().optional(),
+  profile_pic_url: z.string().optional(),
+  pk: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const instagramChannelBlockSchema = z.object({
+  currentAccount: z.string().nullable(),
+  accounts: z.record(z.string(), instagramAccountRecordSchema),
+})
+
 // Encrypted password envelope produced by src/secrets/encryption.ts. Optional
 // in the schema because legacy v2 accounts (pre-renewal feature) don't have
 // one; the renewal cron treats a missing envelope as "reauth required" and
@@ -193,6 +208,7 @@ export const channelsSchema = z
     github: githubChannelSchema.optional(),
     'telegram-bot': telegramBotChannelSchema.optional(),
     line: lineChannelBlockSchema.optional(),
+    instagram: instagramChannelBlockSchema.optional(),
     kakaotalk: kakaoChannelBlockSchema.optional(),
     webex: webexChannelBlockSchema.optional(),
     slack: slackChannelBlockSchema.optional(),
@@ -220,6 +236,8 @@ export type DiscordAccountRecord = z.infer<typeof discordAccountRecordSchema>
 export type DiscordChannelBlock = z.infer<typeof discordChannelBlockSchema>
 export type LineAccountRecord = z.infer<typeof lineAccountRecordSchema>
 export type LineChannelBlock = z.infer<typeof lineChannelBlockSchema>
+export type InstagramAccountRecord = z.infer<typeof instagramAccountRecordSchema>
+export type InstagramChannelBlock = z.infer<typeof instagramChannelBlockSchema>
 export type KakaoAccountRecord = z.infer<typeof kakaoAccountRecordSchema>
 export type PendingLoginRecord = z.infer<typeof kakaoPendingLoginRecordSchema>
 export type KakaoChannelBlock = z.infer<typeof kakaoChannelBlockSchema>

--- a/src/skills/typeclaw-channel-instagram/SKILL.md
+++ b/src/skills/typeclaw-channel-instagram/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: typeclaw-channel-instagram
+description: Use this skill BEFORE every `channel_reply` or `channel_send` call whose adapter is `instagram`. Instagram DMs render messages as plain text — no markdown, no surfaced @-mention syntax, no threads, and no outbound attachments or stickers. Read this skill before composing anything on Instagram.
+---
+
+# typeclaw-channel-instagram
+
+You are speaking through the `instagram` channel adapter as a personal Instagram account.
+
+Write plain text. The adapter strips common markdown as a safety net, but Instagram DMs do not provide rich text in this adapter.
+
+Do not rely on:
+
+- Markdown formatting, tables, or code fences.
+- `@mention` syntax surfaced to the adapter. Address people by name in text.
+- Threads or replies-with-quote. Every send is a top-level message.
+- Outbound attachments, media, or stickers. The adapter sends text only via `sendMessage`.
+
+Inbound media may be observed as metadata, but bytes are not fetchable through this adapter. Do not invent attachment ids.
+
+Workspaces:
+
+- `@instagram-dm` — a 1:1 direct message.
+- `@instagram-group` — a group thread.
+
+Engagement: every DM message engages. Groups are alias-only because the SDK summary does not surface native @-mention metadata.
+
+Realtime vs polling transport is automatic and invisible to you: TypeClaw uses the hybrid listener when available and falls back to polling on older SDKs.
+
+2FA/checkpointed Instagram accounts are unsupported for this adapter; the operator must use a dedicated account that can authenticate without those challenges.


### PR DESCRIPTION
## Summary

Adds **Instagram DM** as a first-class TypeClaw channel, built on `agent-messenger`'s Instagram SDK. It's a personal-account adapter modeled on the LINE adapter: the agent messages **as a real Instagram account** (not a bot), plain-text only, alias-only engagement in groups, every message in a DM. Credentials live in `secrets.json#channels.instagram`.

This brings the supported-channel set to: Slack, Discord, Telegram, Webex, LINE, KakaoTalk, GitHub, **Instagram**.

## Realtime via upstream PR #271 (the interesting part)

[agent-messenger#271](https://github.com/agent-messenger/agent-messenger/pull/271) adds Instagram realtime messaging over MQTT (`InstagramHybridListener`, which tries a realtime socket and falls back to polling). That PR is **merged upstream but not yet released to npm** — the installed `agent-messenger@2.27.1` ships only the polling `InstagramListener`.

This adapter is written **as if #271 were already released**, while still compiling and running against the polling-only build we actually have today:

- The adapter declares **local structural interfaces** for the client/listener (the same pattern `line.ts` already uses for SDK surface it can't statically rely on), with the #271-only client methods (`fetchIrisBootstrap`, `getSessionState`) typed **optional**.
- The **only** reference to the unreleased `InstagramHybridListener` is a single runtime namespace probe:
  ```ts
  const maybeHybrid = (instagramModule as Record<string, unknown>).InstagramHybridListener
  if (typeof maybeHybrid === 'function') return { ctor: maybeHybrid, transport: 'hybrid' }
  return { ctor: RealInstagramListener, transport: 'polling' } // 2.27.1 today
  ```
  No static import of the unreleased symbol, so typecheck stays green on 2.27.1.
- The `connected` event payload is typed as a **superset** (`transport?: 'realtime' | 'polling'`), so the same handler accepts both the polling `{ userId }` and the hybrid `{ userId, transport }` shapes.

**Net effect:** realtime activates automatically the moment `agent-messenger` 2.28 lands and the export appears — **zero code change required**. Until then it transparently runs on polling. The `agent-messenger` dependency is intentionally **not** bumped or pinned to a git ref, to preserve install reproducibility.

> This approach was reviewed and approved by Oracle (read-only architecture consult). Verified: `resolveInstagramListenerCtor()` currently resolves to `transport: 'polling'` against installed 2.27.1 (asserted in a test).

## What's included

- **Adapter** (`src/channels/adapters/instagram*.ts`): main adapter (lifecycle, router registration, inflight draining, rollback-on-start-failure), inbound classifier, channel-name resolver (`@instagram-dm` / `@instagram-group` buckets), plain-text formatter (reuses the KakaoTalk markdown stripper).
- **Secrets** (`src/secrets/`): `instagram` credential schema + `SecretsInstagramCredentialStore` (host/container modes, container writes via the hostd `secrets-patch` channel).
- **Wiring**: registered through the closed `AdapterId` union — `channels/schema`, `channels/manager` (build + credential-signature + container store), `hostd` protocol+daemon, `permissions`/`role-claim` platform maps, `session-origin` platform info, `doctor` check, `config/channels-mutation`, and the `init` + `cli channel add/reauth/list` onboarding flows.
- **Skill**: `typeclaw-channel-instagram` — tells the agent Instagram is plain-text, no @-mention syntax, no threads, no outbound attachments; documents the DM/group buckets and that realtime-vs-polling is automatic.

## Engagement / multilingual

Group engagement is alias-only (Instagram surfaces no native @-mention in the message summary), matched via the existing script-agnostic `matchesAnyAlias`. Per the repo's multi-language rule, the classifier tests assert both an English **and** a Korean (`확인`) alias hit.

## Limitations

- **Text only.** Outbound attachments/stickers are rejected loudly; inbound media isn't fetchable through this adapter (matches the SDK surface).
- **2FA** must be completed interactively at `typeclaw channel add instagram` time (no headless 2FA loop).

## Verification

All run in a clean worktree on `agent-messenger@2.27.1`:

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings, none in new files)
- `bun run format:check` — clean
- `bun run test` — **10264 pass, 0 fail, 1 skip** (the skip is a pre-existing bwrap-on-PATH env test)

New tests cover both listener transports (polling + a faked hybrid), the real-module probe resolving to polling on 2.27.1, outbound/history/lifecycle, multilingual classification, the credential store round-trip, and the auth bootstrap (success, login failure, persisted-but-unverified).

## Note on the diff size

18 of the changed files are one- or two-line additions forced by `AdapterId` being a closed union — every exhaustive `Record<AdapterId, …>` / `switch` must handle `'instagram'` or typecheck fails. The substantive logic is the new `src/channels/adapters/instagram*` + `src/secrets/instagram-store` + `src/init/instagram-auth` files.