### PR TITLE
fix(cli): stop update-notify e2e from spawning the Docker-bound status command

### DIFF
--- a/src/cli/update-notify.test.ts
+++ b/src/cli/update-notify.test.ts
@@ -79,6 +79,9 @@ describe('shouldConsiderUpdateNotice', () => {
     expect(shouldConsiderUpdateNotice('tui')).toBe(true)
     expect(shouldConsiderUpdateNotice('logs')).toBe(true)
     expect(shouldConsiderUpdateNotice('status')).toBe(true)
+    // The e2e gate below spawns `usage`; assert it actually flows through the
+    // gate so that vehicle stays a valid regression target.
+    expect(shouldConsiderUpdateNotice('usage')).toBe(true)
   })
 
   test('suppresses the container stage and self-update', () => {
@@ -109,18 +112,25 @@ describe('shouldConsiderUpdateNotice', () => {
 // (The positive "enabled => notice" case can't run from a source checkout: the
 // dev-checkout skip suppresses it by design; renderUpdateNotice covers that
 // path directly above.)
+//
+// The vehicle is `usage`, not `status`: `usage` is a gate-considered builtin
+// whose run path only scans <agentDir>/sessions, so it never touches Docker or
+// the host daemon. `status` probes `docker info` with no timeout, which
+// cold-starts Docker Desktop (~70s) on Windows CI and blew this test's 30s
+// budget — a flaky failure unrelated to the gate under test.
 describe('maybeNotifyUpdate (end-to-end notice gating)', () => {
   const CLI_ENTRY = join(import.meta.dir, 'index.ts')
 
-  async function runStatus(home: string, env: Record<string, string>): Promise<string> {
+  async function runNoticeGateBuiltin(home: string, env: Record<string, string>): Promise<string> {
     const proc = Bun.spawn({
-      cmd: [process.execPath, CLI_ENTRY, 'status'],
+      cmd: [process.execPath, CLI_ENTRY, 'usage', '--cwd', home, '--json'],
       env: { ...process.env, TYPECLAW_HOME: home, NO_COLOR: '1', ...env },
       stdout: 'ignore',
       stderr: 'pipe',
     })
     const stderr = await new Response(proc.stderr).text()
-    await proc.exited
+    const exitCode = await proc.exited
+    if (exitCode !== 0) throw new Error(`usage command failed with ${exitCode}: ${stderr}`)
     return stderr
   }
 
@@ -139,14 +149,14 @@ describe('maybeNotifyUpdate (end-to-end notice gating)', () => {
 
   test('prints nothing when TYPECLAW_NO_UPDATE_CHECK is set, even with a newer cache', async () => {
     await withSeededCache(async (home) => {
-      const stderr = await runStatus(home, { TYPECLAW_NO_UPDATE_CHECK: '1' })
+      const stderr = await runNoticeGateBuiltin(home, { TYPECLAW_NO_UPDATE_CHECK: '1' })
       expect(stderr).not.toContain('Update available')
     })
   })
 
   test('prints nothing in CI mode, even with a newer cache', async () => {
     await withSeededCache(async (home) => {
-      const stderr = await runStatus(home, { CI: 'true' })
+      const stderr = await runNoticeGateBuiltin(home, { CI: 'true' })
       expect(stderr).not.toContain('Update available')
     })
   })


### PR DESCRIPTION
## Problem

Two end-to-end tests in `src/cli/update-notify.test.ts` (`maybeNotifyUpdate (end-to-end notice gating)`) flake on Windows CI, timing out after 30000ms (`killed 1 dangling process`):

- `prints nothing when TYPECLAW_NO_UPDATE_CHECK is set, even with a newer cache`
- `prints nothing in CI mode, even with a newer cache`

Example failure: [run 28456964874](https://github.com/typeclaw/typeclaw/actions/runs/28456964874/job/84334289330?pr=1111)

## Root cause

Both tests spawn the real `typeclaw status` binary as a subprocess and read its stderr. The `status` run path calls `preflightDocker()` -> `checkDockerAvailable()`, which probes `docker info --format {{.ServerVersion}}` with **no timeout**. On Windows CI, Docker Desktop is not running and cold-starts (the existing comment in `status.ts` notes ~70s), so the subprocess hangs past the 30s test budget.

`runStatus()` has an injectable `RunStatusDeps` seam to avoid real Docker in unit tests, but these tests spawn the real binary precisely to exercise the gate end-to-end, so they can't inject. The hang is incidental to Docker and unrelated to the update-notice gate under test.

## Fix

Switch the e2e vehicle from `status` to `usage --cwd <home> --json`:

- `usage` is a gate-considered builtin (`shouldConsiderUpdateNotice('usage') === true`), so it still flows through `maybeNotifyUpdate` exactly like `status` did.
- Its run path only scans the agent folder's `sessions/` dir; it imports neither `@/container` nor `@/hostd`, so it never touches Docker or the host daemon.
- An exit-code guard in the helper surfaces a broken vehicle instead of silently passing.
- A unit assertion pins `usage` as gate-considered so the vehicle stays valid.

The gate under test (notice suppression under `TYPECLAW_NO_UPDATE_CHECK` / `CI`) is unchanged. **Test-only change, no product behavior change.**

## Verification

Locally the two e2e tests now run in ~277ms each (was 30000ms+ timeout). Full suite green:

- `bun run typecheck` - clean
- `bun run lint` - 0 errors (66 pre-existing warnings, unrelated)
- `bun run format:check` - clean
- `bun run test` - 10268 pass, 0 fail, 1 skip