### PR TITLE
fix(github-cli-auth): release the review-verdict lease on a tool.before block

### DIFF
--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -8,6 +8,7 @@ import type { GithubTokenResolveResult } from '@/channels/github-token-bridge'
 import { noopPermissionService, type PermissionService } from '@/permissions'
 import type { PluginContext, PluginLogger, ToolBeforeEvent } from '@/plugin'
 
+import { __resetReviewVerdictGuardForTest } from './approve-idempotency'
 import { resetGitAskPassHelperForTests } from './git-askpass'
 import githubCliAuthPlugin from './index'
 
@@ -734,5 +735,91 @@ describe('github-cli-auth plugin — git path', () => {
 
     expect(result).toBeUndefined()
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+  })
+})
+
+describe('github-cli-auth plugin — review verdict lease is released on a tool.before block', () => {
+  const originalFetch = globalThis.fetch
+
+  // The plugin builds its effective-approval + head-SHA resolvers around the real
+  // global fetch, so the unit test stubs globalThis.fetch rather than making live
+  // GitHub calls. The stub resolves a CONCRETE head.sha for acme/widgets#5 and an
+  // empty reviews list (=> NONE, so the guard allows). A real head.sha is what
+  // makes these tests lock the succeeded:false invariant: with it, release() arms
+  // the same-head duplicate-review cooldown ONLY when succeeded is true — so a
+  // regression flipping blockAfterLease() to succeeded:true would arm the cooldown
+  // and block the second submission, failing the test. A null head (the live-call
+  // degraded path) would skip the cooldown either way and hide that regression.
+  function stubGithubFetch(): void {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const body = url.includes('/user')
+        ? { login: 'review-bot' }
+        : url.includes('/pulls/5/reviews')
+          ? []
+          : url.includes('/pulls/5')
+            ? { head: { sha: 'sha-5' } }
+            : null
+      const status = body === null ? 404 : 200
+      return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+    }) as typeof fetch
+  }
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    __resetReviewVerdictGuardForTest()
+  })
+
+  function reviewBashEvent(command: string, callId: string): ToolBeforeEvent {
+    return { tool: 'bash', sessionId: 's', callId, args: { command } }
+  }
+
+  // A review-submission command whose VERDICT is detected (so guard() claims the
+  // in-flight lease) but whose SHAPE is blocked by analyzeGhCommand (the `cd … &&`
+  // composition) — the production path that stranded PR #1112's approve. The lease
+  // must be released so the next session can submit, not told "the in-flight one
+  // will post" when the blocked one never will.
+  const STRANDING_REVIEW = 'cd /agent && gh api -X POST repos/acme/widgets/pulls/5/reviews -f event=APPROVE'
+  const CLEAN_REVIEW = 'gh api -X POST repos/acme/widgets/pulls/5/reviews -f event=APPROVE'
+
+  test('a shape-blocked review submission releases the lease (succeeded:false) so a later session can still submit', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    stubGithubFetch()
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    // given: a first session's review submit is detected (lease claimed) then
+    // blocked by the composition shape guard
+    const firstBlocked = await hook(reviewBashEvent(STRANDING_REVIEW, 'call-1'), hookCtx)
+    expect(firstBlocked).toMatchObject({ block: true })
+
+    // when: a second session submits a clean review for the SAME PR on the SAME head
+    const event = reviewBashEvent(CLEAN_REVIEW, 'call-2')
+    const second = await hook(event, hookCtx)
+
+    // then: it is NOT blocked — neither by the released in-flight lease nor by a
+    // duplicate-review cooldown. With a real head.sha resolved, a regression that
+    // released the blocked submission as succeeded:true would arm the same-head
+    // cooldown and block this submission, so this assertion locks succeeded:false.
+    expect(second).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
+  })
+
+  test('an ALLOWED in-flight submission still blocks a concurrent duplicate (the fix does not weaken the guard)', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    stubGithubFetch()
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+
+    // given: a clean review submit that is ALLOWED (lease claimed, command would
+    // run and tool.after would release) — here tool.after never fires in the test,
+    // so the lease stays held, exactly as a real in-flight submission would
+    const firstAllowed = await hook(reviewBashEvent(CLEAN_REVIEW, 'call-1'), hookCtx)
+    expect(firstAllowed).toBeUndefined()
+
+    // when: a second session submits for the same PR while the first is in flight
+    const second = await hook(reviewBashEvent(CLEAN_REVIEW, 'call-2'), hookCtx)
+
+    // then: the legitimate concurrent-duplicate guard still fires (only a BLOCKED
+    // first submission releases early)
+    expect(second).toMatchObject({ block: true })
   })
 })

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -109,6 +109,18 @@ export default definePlugin({
     }): Promise<HookResult | 'fall-through'> => {
       const { event, command } = params
       const review = await noteReviewCommand({ callId: event.callId, command })
+      // guard() holds the lease expecting tool.after to release it, but a
+      // tool.before block (from ANY guard below) means the command never runs, so
+      // tool.after never fires and the lease strands for its full TTL — telling
+      // every other session "the in-flight one will post" when it never will (the
+      // lost-verdict strand: a review trips the shape guard, the lease strands, the
+      // PR ends unreviewed). blockAfterLease() releases on such a block. guard()'s
+      // OWN terminal block self-releases and returns directly, bypassing this path.
+      let leaseClaimed = false
+      const blockAfterLease = async (block: HookResult & { block: true }): Promise<HookResult> => {
+        if (leaseClaimed) await verdictGuard.release({ callId: event.callId, succeeded: false })
+        return block
+      }
       if (review.detected !== null) {
         const block = await verdictGuard.guard({
           callId: event.callId,
@@ -117,8 +129,9 @@ export default definePlugin({
           verdict: review.detected.verdict,
         })
         if (block !== null) return block
+        leaseClaimed = true
       }
-      if (review.dump !== null) return review.dump
+      if (review.dump !== null) return blockAfterLease(review.dump)
 
       // Analyze first WITHOUT the fallback: an explicit `-R`/path repo must win,
       // and we only pay for fallback resolution (a git subprocess) when the
@@ -152,7 +165,7 @@ export default definePlugin({
         GITHUB_TOKEN: process.env.GITHUB_TOKEN,
       })
       if (userEndpointTokens.some((token) => shouldMintAppToken(token, hasAppTokenResolver()))) {
-        return { block: true, reason: appUserEndpointReason }
+        return blockAfterLease({ block: true, reason: appUserEndpointReason })
       }
 
       if (decision.kind === 'pass-through') return 'fall-through'
@@ -200,16 +213,22 @@ export default definePlugin({
         // bug returns); otherwise block with guidance rather than failing mute.
         if (!shouldMintAppToken(undefined, hasAppTokenResolver())) {
           if (decision.kind === 'block') {
-            return { block: true, reason: decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo) }
+            return blockAfterLease({
+              block: true,
+              reason: decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo),
+            })
           }
           warnSandboxedPatWithheldOnce()
-          return { block: true, reason: sandboxedPatWithheldReason }
+          return blockAfterLease({ block: true, reason: sandboxedPatWithheldReason })
         }
         mintForSandboxedPat = true
       }
 
       if (decision.kind === 'block') {
-        return { block: true, reason: decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo) }
+        return blockAfterLease({
+          block: true,
+          reason: decision.reason + buildGhBlockGuidance(decision.code, fallbackRepo),
+        })
       }
 
       // No App auth (no App-class GH_TOKEN and no live minter): leave whatever
@@ -218,7 +237,7 @@ export default definePlugin({
       if (!mintForSandboxedPat && !shouldMintAppToken(process.env.GH_TOKEN, hasAppTokenResolver())) return
 
       const result = await resolveTokenForRepo(decision.repoSlug)
-      if (result.kind === 'unavailable') return { block: true, reason: result.reason }
+      if (result.kind === 'unavailable') return blockAfterLease({ block: true, reason: result.reason })
       // Inject via the internal env overlay (delivered to the spawn / bwrap
       // --setenv by the bash wrapper) so the token never enters the command
       // string, where it could leak through logs or later hooks. When the repo


### PR DESCRIPTION
## Background

In production, a reviewer subagent computed an `approve` verdict for PR #1112 but the PR ended with zero reviews. Tracing container logs and the session transcript back to source revealed the following mechanism.

The github-cli-auth plugin makes formal PR review submission idempotent via a process-wide in-flight verdict lease (`approve-idempotency.ts`). The lease is CLAIMED in `verdictGuard.guard()` during `tool.before` and RELEASED in `verdictGuard.release()` during `tool.after`. While the lease is held, every other session's verdict for the same PR is blocked: "Another session is already submitting a formal review verdict... the in-flight one will post."

The bug: `handleGhCommand` (the `tool.before` handler) calls `guard()` first, then continues through several other guards — the gh-command shape guard (`analyzeGhCommand`), the `/user` endpoint guard, the sandboxed-PAT guard, the token-unavailable path, and the review-dump guard. If ANY of those returns a block, the bash command never executes, `tool.after` never fires, and `release()` is never called. The lease strands for its full 5-minute TTL (`LEASE_TTL_MS`). Every concurrent or retry session is told "the in-flight one will post" — but the in-flight one was blocked and will never post. The computed APPROVE or REQUEST_CHANGES is silently discarded and the PR is left unreviewed.

On PR #1112 specifically: the reviewer returned `approve`, the submit command tripped the gh-command shape guard (a compound `cd ... && gh api ...` composition), the lease stranded, and reviews remained empty.

## Summary

Route every downstream `tool.before` block in `handleGhCommand` through a new local helper `blockAfterLease()`. When `guard()` had claimed the lease this call, `blockAfterLease()` calls `verdictGuard.release({ callId, succeeded: false })` before returning the block.

Key design decisions:

- **`succeeded: false` is correct here.** A `tool.before` block is strictly pre-execution: the command never ran, no verdict was posted to the remote, so no read-after-write lag shield needs to be armed.
- **`guard()`'s own terminal block bypasses this path intentionally.** When `guard()` itself blocks (remote-already-approved / concurrent-duplicate), it already self-releases its lease and returns directly. Those returns do not go through `blockAfterLease()`.
- **The legitimate concurrent-duplicate guard is NOT weakened.** An allowed in-flight submission still holds the lease until `tool.after`. Only a BLOCKED first submission releases early — the TOCTOU window the lease protects against does not exist when the command was never executed.
- **The lease invariant is preserved.** The invariant is "do not release after a remote read while another session could race and duplicate a posted review." A pre-execution block has no remote write, so releasing there is safe.

## Preview

Not applicable (no UI or output format change).

## What this does NOT do

- Does not change any verdict guard logic — `guard()`'s concurrent-duplicate detection is untouched.
- Does not alter the `tool.after` / `release()` path for commands that do execute.
- Does not change `LEASE_TTL_MS` or any lease bookkeeping beyond the early-release on a blocked call.
- Does not address other potential causes of a stranded lease (e.g., an unhandled exception mid-execution — a separate, pre-existing concern).

## Review notes

Load-bearing change: the new `blockAfterLease()` helper in `src/bundled-plugins/github-cli-auth/index.ts` and its call sites across the five downstream block paths. Invariant to verify: every code path in `handleGhCommand` that (a) runs after `guard()` claims the lease and (b) returns a block must go through `blockAfterLease()`. `guard()`'s own terminal block is the one intentional exception — it already self-releases.

Regression tests added in `src/bundled-plugins/github-cli-auth/index.test.ts`:

1. A shape-blocked review submission (compound `cd /agent && gh api -X POST repos/acme/widgets/pulls/5/reviews -f event=APPROVE` command) releases the lease, so a later clean submission for the same PR is not blocked.
2. An allowed in-flight review submission still blocks a concurrent duplicate — confirming the fix does not weaken the legitimate guard.

TDD-verified: neutering the release call makes test 1 fail (stranded lease blocks the second submission) while test 2 continues to pass.

Checks: `bun run typecheck` clean, `bun run lint` 0 errors (pre-existing warnings only, none in changed files), `bun run format:check` clean, `bun run test` 10270 pass / 0 fail.