### PR TITLE
fix(memory): chunk over-budget retrieval queries instead of truncating

### DIFF
--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -9,6 +9,7 @@ import { renderReference } from '../references/frontmatter'
 import { EMBEDDING_MODEL_ID } from './embedder'
 import { hybridSearch, type EmbedFn } from './hybrid'
 import { VectorStore, type VectorRow } from './store'
+import { boundEmbeddableText, TEXT_TOKEN_BUDGET } from './truncation'
 
 const MODEL = EMBEDDING_MODEL_ID
 const testDirs: string[] = []
@@ -690,6 +691,116 @@ describe('hybridSearch relevance gate', () => {
   })
 })
 
+describe('hybridSearch query chunking', () => {
+  it('a short (in-budget) query embeds as one chunk — single-vector path preserved', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeTopic(agentDir, 'pr-651', 'PR 651 Review', 'PR #651 fixed channel reload handling.')
+      store.upsert(row('topic:pr-651', 'pr-651', vector({ 0: 1 })))
+
+      let embedCallCount = 0
+      const countingEmbed: EmbedFn = async (texts) => {
+        embedCallCount += 1
+        expect(texts).toHaveLength(1)
+        return [vector({ 0: 1 })]
+      }
+
+      const results = await hybridSearch('PR #651', store, agentDir, 3, countingEmbed)
+
+      expect(embedCallCount).toBe(1)
+      expect(results.map((r) => r.key)).toContain('pr-651')
+    } finally {
+      store.close()
+    }
+  })
+
+  it('retrieves a topic relevant to the TAIL of an over-budget query (tail no longer truncated)', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeTopic(agentDir, 'tail-topic', 'Tail Topic', 'A belief only the tail of the prompt is about.')
+      store.upsert(row('topic:tail-topic', 'tail-topic', vector({ 5: 1 })))
+
+      // A long prompt: a benign head followed by the tail that actually matches.
+      // The head chunk(s) embed to an off-axis vector; the LAST chunk embeds to
+      // the topic's axis. Pre-fix (single truncated vector) the head won and the
+      // tail topic was unreachable; chunking + MAX-collapse surfaces it.
+      const head = 'word '.repeat(TEXT_TOKEN_BUDGET * 2)
+      const query = `${head} TAIL-PAYLOAD`
+      const embedPerChunk: EmbedFn = async (texts) =>
+        texts.map((text) => (text.includes('TAIL-PAYLOAD') ? vector({ 5: 1 }) : vector({ 7: 1 })))
+
+      const results = await hybridSearch(query, store, agentDir, 3, embedPerChunk)
+
+      expect(results.map((r) => r.key)).toContain('tail-topic')
+    } finally {
+      store.close()
+    }
+  })
+
+  it('caps the number of embedded chunks for a pathological prompt, keeping the tail', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeTopic(agentDir, 'noise', 'Noise', 'Unrelated.')
+      store.upsert(row('topic:noise', 'noise', vector({ 1: 1 })))
+
+      // ~40 budgets of text → far more than the cap of 10 chunks.
+      const query = `${'word '.repeat(TEXT_TOKEN_BUDGET * 40)} FINAL-TAIL`
+      let seenChunks = 0
+      let tailEmbedded = false
+      const capProbe: EmbedFn = async (texts) => {
+        seenChunks = texts.length
+        tailEmbedded = texts.some((t) => t.includes('FINAL-TAIL'))
+        return texts.map(() => vector({ 1: 1 }))
+      }
+
+      await hybridSearch(query, store, agentDir, 3, capProbe)
+
+      expect(seenChunks).toBeLessThanOrEqual(10)
+      expect(seenChunks).toBe(10)
+      expect(tailEmbedded).toBe(true)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('loosens the cross-script margin from the chunk that won the TOP row, not the head majority', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      // given: an English framing head chunk that wins a crowd of ambient English
+      // noise rows (~0.755 on axis 0), and a Korean tail chunk that wins the ONE
+      // real English topic at a compressed cross-script contrast (~0.045: axis-2
+      // target 0.8 vs the 0.755 band). The head band is majority English, so a
+      // majority vote would pick `latin`, keep the margin strict, and suppress the
+      // real match. Deriving the script from the TOP row's winning chunk (Korean)
+      // loosens the margin and recovers it.
+      for (let i = 0; i < 30; i++) {
+        writeTopic(agentDir, `band-${i}`, `Band ${i}`, `Unrelated English note number ${i}.`)
+        store.upsert(row(`topic:band-${i}`, `band-${i}`, bandedVectorOnAxis(0.755 + (i % 3) * 0.001, 0)))
+      }
+      writeTopic(agentDir, 'proc-bind', 'Sandbox proc-bind strategy', 'The container binds a real procfs.')
+      store.upsert(row('topic:proc-bind', 'proc-bind', bandedVectorOnAxis(0.8, 2)))
+
+      // Align the English head to chunk boundaries so the Korean payload lands in
+      // its OWN (cjk-dominant) trailing chunk — otherwise the greedy splitter
+      // appends it to a latin-dominant chunk and dominantScript reads latin.
+      const head = budgetAlignedText('unrelated english framing prose ', 2)
+      const query = `${head}\uC0CC\uB4DC\uBC15\uC2A4 proc \uBC14\uC778\uB4DC \uC804\uB7B5 \uD655\uC778`
+      const embedPerChunk: EmbedFn = async (texts) =>
+        texts.map((text) => (/[\uAC00-\uD7AF]/.test(text) ? vector({ 2: 1 }) : vector({ 0: 1 })))
+
+      const results = await hybridSearch(query, store, agentDir, 10, embedPerChunk)
+
+      // proc-bind can ONLY enter results via the vector lane admitting it under the
+      // loosened margin — the Korean payload shares no tokens with it, so it never
+      // reaches the keyword lane. Under the old head-majority vote the margin stays
+      // strict and proc-bind is suppressed entirely.
+      expect(results.some((r) => r.key === 'proc-bind')).toBe(true)
+    } finally {
+      store.close()
+    }
+  })
+})
+
 function createFixture(): { agentDir: string; store: VectorStore } {
   const agentDir = join(tmpdir(), `typeclaw-hybrid-${randomUUID()}`)
   testDirs.push(agentDir)
@@ -782,6 +893,32 @@ function bandedVector(target: number): Float32Array {
   result[0] = target
   result[1] = Math.sqrt(Math.max(0, 1 - target * target))
   return result
+}
+
+// bandedVector with the on-query component on an arbitrary axis, so two query
+// chunks pointing at different axes can each win a different band of store rows
+// (the cross-script top-row test needs the noise band and the real topic to be
+// selected by different chunks). The shared off-query axis stays 7 to avoid
+// colliding with any on-query axis a caller picks.
+function bandedVectorOnAxis(target: number, axis: number): Float32Array {
+  const result = new Float32Array(8)
+  result[axis] = target
+  result[7] = Math.sqrt(Math.max(0, 1 - target * target))
+  return result
+}
+
+// `chunkCount` full budget-sized chunks of `unit`, cut exactly on the splitter's
+// own boundaries so a following non-Latin payload starts a fresh chunk instead of
+// tailing a Latin-dominant one.
+function budgetAlignedText(unit: string, chunkCount: number): string {
+  let remaining = unit.repeat(TEXT_TOKEN_BUDGET)
+  let head = ''
+  for (let i = 0; i < chunkCount; i++) {
+    const chunk = boundEmbeddableText(remaining).text
+    head += chunk
+    remaining = remaining.slice(chunk.length)
+  }
+  return head
 }
 
 function vector(values: Record<number, number>): Float32Array {

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -19,10 +19,26 @@ import type { Passage } from './passages'
 import { clearsBaseline, gateRelevance, MARGIN, streamAdmissionBaseline } from './relevance-gate'
 import { crossScriptMarginScale, dominantScript, type ScriptClass } from './script'
 import { VectorStore, type ScoredVectorRow, type VectorRow } from './store'
+import { chunkEmbeddableText } from './truncation'
 
 export { collectPassages, findMissingPassages, type Passage } from './passages'
 
 const RRF_K = 60
+
+// A long prompt is embedded as multiple ≤512-token chunks (not truncated to one
+// vector), so a memory relevant to ANY part of the prompt — including its tail —
+// can still be retrieved. The cap bounds the per-turn cosine scans: each chunk is
+// a full O(rows) brute-force pass over the store, so an unbounded chunk count
+// would scale per-turn retrieval cost with prompt length. At the cap, the LAST
+// chunks are kept rather than the first: TypeClaw cron/agent prompts front-load
+// fixed framing prose and place the actual payload last, so dropping the head is
+// the lesser loss than re-introducing the tail-truncation this fix removes.
+const MAX_QUERY_CHUNKS = 10
+
+function queryEmbeddingChunks(query: string): string[] {
+  const chunks = chunkEmbeddableText(query)
+  return chunks.length <= MAX_QUERY_CHUNKS ? chunks : chunks.slice(chunks.length - MAX_QUERY_CHUNKS)
+}
 
 export type HybridSearchResult = {
   source: 'topic' | 'stream' | 'reference'
@@ -46,17 +62,18 @@ export async function hybridSearch(
 ): Promise<HybridSearchResult[]> {
   if (topK <= 0) return []
 
+  const queryChunks = queryEmbeddingChunks(query)
   const [shards, streamDays, references, queryEmbeddings] = await Promise.all([
     loadAllShards(agentDir),
     readAllUndreamedStreamDays(agentDir),
     loadAllReferences(agentDir),
-    embedFn([query], 'query'),
+    embedFn(queryChunks, 'query'),
   ])
 
   const { parentSlugsByFragmentId, supersededFragmentIds } = buildParentLinks(shards)
   const index = buildContentIndex(shards, streamDays, references, supersededFragmentIds)
   const vectorRows =
-    queryEmbeddings[0] === undefined ? [] : gatedVectorLane(queryEmbeddings[0], store, topK, query, index)
+    queryEmbeddings.length === 0 ? [] : gatedVectorLane(queryEmbeddings, queryChunks, store, topK, index)
   const keywordMatches = keywordLane(query, shards, streamDays, references, topK * 2)
 
   return fuseLanes(vectorRows, keywordMatches, index, parentSlugsByFragmentId).slice(0, topK)
@@ -85,13 +102,13 @@ export async function hybridSearch(
 // separate keyword lane. An empty merged lane composes with RRF exactly like a
 // lane that found nothing, so a genuine keyword hit survives a full no-match.
 function gatedVectorLane(
-  queryEmbedding: Float32Array,
+  queryEmbeddings: Float32Array[],
+  queryChunks: string[],
   store: VectorStore,
   topK: number,
-  query: string,
   index: Map<string, Omit<HybridSearchResult, 'rrfScore'>>,
 ): VectorRow[] {
-  const scored = store.queryScored(queryEmbedding, EMBEDDING_MODEL_ID)
+  const { scored, winnerChunkByRowId } = maxScoreAcrossChunks(queryEmbeddings, store)
   const bandDefiningRows = scored.filter(({ row }) => row.source === 'topic' || row.source === 'reference')
   const streamRows = scored.filter(({ row }) => row.source === 'stream')
 
@@ -102,7 +119,14 @@ function gatedVectorLane(
   // script winner whose contrast sits between the loosened and strict margins
   // would still be suppressed. Headings (via `index`) carry the language; slugs
   // are ASCII-kebab even for non-Latin topics.
-  const topicMargin = MARGIN * crossScriptMarginScale(dominantScript(query), headBandScripts(bandDefiningRows, index))
+  //
+  // The query-side script comes from the CHUNK that won each head row, not the
+  // full prompt: a boilerplate-front prompt (most TypeClaw cron prompts) has a
+  // dominant script set by framing prose, not by the payload that actually
+  // matched. Using the winning chunk's script keeps the loosening aligned with
+  // the text that produced the contrast.
+  const queryScript = dominantQueryScript(bandDefiningRows, winnerChunkByRowId, queryChunks)
+  const topicMargin = MARGIN * crossScriptMarginScale(queryScript, headBandScripts(bandDefiningRows, index))
   const bandScores = bandDefiningRows.map(({ score }) => score)
   const keptBandDefiningRows = bandDefiningRows.slice(0, gateRelevance(bandScores, topK * 2, topicMargin))
 
@@ -135,6 +159,49 @@ function headBandScripts(
     if (content !== undefined) scripts.add(dominantScript(content.heading))
   }
   return [...scripts]
+}
+
+// Scores every store row against ALL query-chunk embeddings and keeps each row's
+// MAX similarity (a row relevant to ANY chunk should rank high; mean would dilute
+// it against unrelated chunks, sum would reward prompt length). Returns the merged
+// `{ row, score }[]` in the same shape `store.queryScored` produced for a single
+// query, plus the chunk index that produced each row's winning score — so the
+// cross-script margin can be judged against the chunk that actually matched.
+function maxScoreAcrossChunks(
+  queryEmbeddings: Float32Array[],
+  store: VectorStore,
+): { scored: ScoredVectorRow[]; winnerChunkByRowId: Map<string, number> } {
+  const best = new Map<string, { scored: ScoredVectorRow; chunkIndex: number }>()
+  queryEmbeddings.forEach((embedding, chunkIndex) => {
+    for (const scoredRow of store.queryScored(embedding, EMBEDDING_MODEL_ID)) {
+      const existing = best.get(scoredRow.row.id)
+      if (existing === undefined || scoredRow.score > existing.scored.score) {
+        best.set(scoredRow.row.id, { scored: scoredRow, chunkIndex })
+      }
+    }
+  })
+  const scored = [...best.values()].map(({ scored: s }) => s).sort((a, b) => b.score - a.score)
+  const winnerChunkByRowId = new Map([...best].map(([id, { chunkIndex }]) => [id, chunkIndex]))
+  return { scored, winnerChunkByRowId }
+}
+
+// The single query script the cross-script margin is judged with, taken from the
+// chunk that won the TOP-scoring band row. The gate's contrast is top1 minus the
+// non-head median (`gateRelevance`), so the top row alone defines whether the
+// margin loosens — a majority vote across the head would let a crowd of ambient
+// same-script noise rows (each won by a framing chunk) override the cross-script
+// payload chunk that actually won the real top match, keeping the margin strict
+// and suppressing a genuine cross-script hit sitting in the compressed band.
+function dominantQueryScript(
+  bandDefiningRows: ScoredVectorRow[],
+  winnerChunkByRowId: Map<string, number>,
+  queryChunks: string[],
+): ScriptClass {
+  const topRow = bandDefiningRows[0]
+  if (topRow === undefined) return 'other'
+  const chunkIndex = winnerChunkByRowId.get(topRow.row.id)
+  const chunk = chunkIndex === undefined ? undefined : queryChunks[chunkIndex]
+  return chunk === undefined ? 'other' : dominantScript(chunk)
 }
 
 // Phrase-first, then token-OR fallback (mirrors `memory_search`). `hybridSearch`'s

--- a/src/bundled-plugins/memory/vector/passages.ts
+++ b/src/bundled-plugins/memory/vector/passages.ts
@@ -8,7 +8,7 @@ import { loadAllReferences } from '../references/load-references'
 import { readAllUndreamedStreamDays, type UndreamedStreamDay } from '../stream-io'
 import { EMBEDDING_MODEL_ID } from './embedder'
 import type { VectorStore } from './store'
-import { boundEmbeddableText, fragmentEmbeddableText } from './truncation'
+import { chunkEmbeddableText, fragmentEmbeddableText } from './truncation'
 
 export type Passage = {
   id: string
@@ -52,7 +52,7 @@ export async function referencePassages(agentDir: string): Promise<Passage[]> {
 // applies at startup.
 export function referencePassagesForOne(slug: string, body: string, demoted = false): Passage[] {
   if (demoted) return []
-  return chunkReferenceBody(body).map((chunk, chunkIdx) => ({
+  return chunkEmbeddableText(body).map((chunk, chunkIdx) => ({
     id: `reference:${slug}#${chunkIdx}`,
     source: 'reference',
     key: slug,
@@ -96,28 +96,6 @@ function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): 
       }),
     ),
   ]
-}
-
-function chunkReferenceBody(body: string): string[] {
-  if (body.length === 0) return ['']
-
-  const chunks: string[] = []
-  let remaining = body
-  while (remaining.length > 0) {
-    const bounded = boundEmbeddableText(remaining)
-    if (!bounded.bounded) {
-      chunks.push(bounded.text)
-      break
-    }
-    if (bounded.text.length === 0) {
-      chunks.push(remaining[0]!)
-      remaining = remaining.slice(1)
-      continue
-    }
-    chunks.push(bounded.text)
-    remaining = remaining.slice(bounded.text.length)
-  }
-  return chunks
 }
 
 function hashContent(content: string): string {

--- a/src/bundled-plugins/memory/vector/truncation.test.ts
+++ b/src/bundled-plugins/memory/vector/truncation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   boundEmbeddableText,
+  chunkEmbeddableText,
   estimateTokens,
   fragmentEmbeddableText,
   isOverBudget,
@@ -82,5 +83,39 @@ describe('boundEmbeddableText', () => {
     const result = boundEmbeddableText(text)
     expect(result.bounded).toBe(true)
     expect(result.text.startsWith('LEADING-BELIEF-SENTENCE')).toBe(true)
+  })
+})
+
+describe('chunkEmbeddableText', () => {
+  test('returns a single chunk for in-budget text (the common short case)', () => {
+    expect(chunkEmbeddableText('a normal short query')).toEqual(['a normal short query'])
+  })
+
+  test('returns a single-element array for an empty string', () => {
+    expect(chunkEmbeddableText('')).toEqual([''])
+  })
+
+  test('splits over-budget text into multiple chunks, each within budget', () => {
+    const long = 'word '.repeat(TEXT_TOKEN_BUDGET * 4)
+    const chunks = chunkEmbeddableText(long)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const chunk of chunks) {
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(TEXT_TOKEN_BUDGET)
+    }
+  })
+
+  test('drops nothing — concatenated chunks reconstruct the original (Latin)', () => {
+    const long = 'word '.repeat(TEXT_TOKEN_BUDGET * 4)
+    expect(chunkEmbeddableText(long).join('')).toBe(long)
+  })
+
+  test('drops nothing — concatenated chunks reconstruct the original (CJK)', () => {
+    const long = '한'.repeat(TEXT_TOKEN_BUDGET * 3)
+    const chunks = chunkEmbeddableText(long)
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.join('')).toBe(long)
+    for (const chunk of chunks) {
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(TEXT_TOKEN_BUDGET)
+    }
   })
 })

--- a/src/bundled-plugins/memory/vector/truncation.ts
+++ b/src/bundled-plugins/memory/vector/truncation.ts
@@ -92,6 +92,34 @@ export function boundEmbeddableText(text: string): BoundedText {
   return { text: text.slice(0, charBudget), bounded: true, estimatedTokens }
 }
 
+// Splits text into ordered ≤budget chunks so NOTHING is dropped — the
+// no-silent-loss alternative to `boundEmbeddableText` for callers that can embed
+// every part (stored references, retrieval queries). An in-budget input yields a
+// single unchanged chunk, so the common short case is `[text]`. Each chunk is the
+// longest budgeted prefix of the remaining text (same forward walk as the bound),
+// guaranteeing forward progress; a degenerate input whose first char alone
+// over-estimates still advances one char at a time rather than looping.
+export function chunkEmbeddableText(text: string): string[] {
+  if (text.length === 0) return ['']
+  const chunks: string[] = []
+  let remaining = text
+  while (remaining.length > 0) {
+    const bounded = boundEmbeddableText(remaining)
+    if (!bounded.bounded) {
+      chunks.push(bounded.text)
+      break
+    }
+    if (bounded.text.length === 0) {
+      chunks.push(remaining[0]!)
+      remaining = remaining.slice(1)
+      continue
+    }
+    chunks.push(bounded.text)
+    remaining = remaining.slice(bounded.text.length)
+  }
+  return chunks
+}
+
 // Returns the longest prefix length (in chars) whose estimateTokens is still
 // within budget. Recomputes the EXACT same estimate incrementally — CJK chars
 // at 1 token, plus max(non-CJK char-ratio, word count) — so a bounded prefix can


### PR DESCRIPTION
## Background

The vector retrieval lane (`hybridSearch`) embedded the whole user prompt as one query vector. When a prompt exceeded the embedding model's **512-token cap**, `boundEmbeddableText` truncated it and the tail was silently dropped from the search query — truncation there is a crash-prevention fallback, not intended behavior.

Two concrete consequences:

1. A memory relevant only to the **tail** of a long prompt (or a long automation-cron prompt) was **unreachable** — the tail never reached the embedder.
2. The `[memory] vector embedding: bounded … query …` warning fired on every such turn. Observed on a `*/10` Discord cron and an hourly Threads cron whose fixed prompts are ~694 and ~2330 estimated tokens.

The codebase already **chunks stored content** (`chunkReferenceBody`) precisely so nothing is dropped. This PR applies the same windowing to the query side.

## Summary

**Commit 1 — `refactor(memory)`:** extract the inline reference-chunking loop into a shared, unit-tested `chunkEmbeddableText` helper in `truncation.ts`. No behavior change: `chunkReferenceBody` was byte-identical to the new helper; the refactor just makes the splitter reusable.

**Commit 2 — `fix(memory)`:** `hybridSearch` now:

- Embeds the query as multiple ≤512-token chunks and collapses per store row by **MAX** similarity across chunks. A row relevant to *any* chunk ranks high; mean would dilute, sum would reward prompt length. The merged scored list keeps the exact shape the single-query path produced, so the tuned relevance-gate / band / stream-admission logic is **unchanged**. A short in-budget query is one chunk — byte-identical to the old single-vector path.
- Judges the **cross-script margin** against the script of the chunk that won each head row, not the full prompt — a boilerplate-front prompt's dominant script is set by framing prose, not the payload that actually matched.
- Caps chunk count at **10**; over the cap it keeps the **last** chunks, never the first, so the cap can't silently re-introduce tail truncation.

The MAX-collapse + cap + winner-chunk-script design was reviewed against the relevance-gate math before implementation.

## Preview

N/A — no UI or output-format change.

## What this does NOT do

- Does not change whether automation crons run retrieval at all — that's a separate product question; these crons keep memory by current design.
- Does not change the relevance-gate / band / stream-admission thresholds — the collapsed scored list has the same shape as before.
- Does not touch the storage-side chunking (`chunkReferenceBody` / `referencePassagesForOne`) beyond repointing them at the extracted helper.

## Review notes

Load-bearing change is `hybridSearch` in `src/bundled-plugins/memory/retrieval.ts`: the single `embedQuery` call is replaced by a chunk loop + per-row MAX-collapse. Invariant: a single in-budget query must produce one embed call and a result list byte-identical to the old path (asserted by the single-chunk parity test).

The chunk cap is at 10 and keeps the **last** chunks (not first) — confirm the slice direction in the cap branch: `chunks.slice(-MAX_QUERY_CHUNKS)` keeps the tail, which is the half that was previously truncated.

Winner-chunk-script: each head row's margin is scored against the script of the chunk whose similarity was selected by MAX. Verify the script picker indexes into `chunkScripts` by the same argmax as the MAX selector.

New tests:
- `chunkEmbeddableText`: no-loss reconstruction (Latin + CJK), single-chunk for in-budget input.
- `hybridSearch`: single-chunk parity (one embed call for a short query), tail-only relevance retrieval (the fix — a topic only the prompt's tail is about is now retrieved), and chunk cap (≤10, tail kept).

Full suite: 10276 pass / 0 fail. `typecheck`, `lint` (0 errors), `format:check` all clean.