### PR TITLE
feat(channels): support Instagram 2FA and checkpoint at login

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -37,7 +37,7 @@ import {
   type WebexAuthResult,
 } from '@/init'
 import { runDiscordBootstrap } from '@/init/discord-auth'
-import { runInstagramBootstrap } from '@/init/instagram-auth'
+import { runInstagramBootstrap, type InstagramLoginCallbacks } from '@/init/instagram-auth'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { runLineBootstrap } from '@/init/line-auth'
 import { runSlackBootstrap } from '@/init/slack-auth'
@@ -469,7 +469,12 @@ async function runInstagramReauth(cwd: string): Promise<void> {
   const creds = await promptInstagramCredentials()
   const s = spinner()
   s.start('Logging in to Instagram...')
-  const result = await runInstagramBootstrap({ username: creds.username, password: creds.password, agentDir: cwd })
+  const result = await runInstagramBootstrap({
+    username: creds.username,
+    password: creds.password,
+    agentDir: cwd,
+    callbacks: instagramLoginCallbacks({ pause: () => s.stop(), resume: (message) => s.start(message) }),
+  })
   if (!result.ok) {
     s.stop(`Instagram login failed: ${result.reason}`)
     process.exit(1)
@@ -1018,10 +1023,11 @@ async function collectCredentials(
       return { channel, webexBotToken: await promptWebexToken() }
     case 'instagram': {
       const creds = await promptInstagramCredentials()
+      const callbacks = instagramLoginCallbacks(lineSpinnerHolder ? holderSpinnerControl(lineSpinnerHolder) : undefined)
       return {
         channel,
         runInstagramAuth: ({ cwd: agentDir }) =>
-          runInstagramBootstrap({ username: creds.username, password: creds.password, agentDir }),
+          runInstagramBootstrap({ username: creds.username, password: creds.password, agentDir, callbacks }),
       }
     }
     case 'line': {
@@ -1558,7 +1564,7 @@ async function promptInstagramCredentials(): Promise<{ username: string; passwor
     [
       'Instagram authentication uses a personal account.',
       'Messages will be sent and received under this account.',
-      '2FA/checkpointed accounts are not supported; use a dedicated account without those challenges.',
+      'If the account has 2FA or triggers a checkpoint, you will be prompted for the verification code here.',
     ].join('\n'),
     'About to log in to Instagram',
   )
@@ -1579,6 +1585,32 @@ async function promptInstagramCredentials(): Promise<{ username: string; passwor
     process.exit(0)
   }
   return { username, password: pwd }
+}
+
+// The login spinner ('Logging in to Instagram...') keeps animating while
+// Instagram's 2FA/checkpoint step waits on a human, and would repaint over the
+// code prompt. Pause it around the prompt so the input line stays legible, then
+// resume with a "waiting" message — same control the LINE PIN flow uses.
+function instagramLoginCallbacks(spinnerControl?: LineAuthSpinnerControl): InstagramLoginCallbacks {
+  const promptCode = async (message: string): Promise<string | null> => {
+    spinnerControl?.pause()
+    const code = await text({
+      message,
+      validate: (value) => (value && value.trim().length > 0 ? undefined : 'A verification code is required'),
+    })
+    if (isCancel(code)) return null
+    spinnerControl?.resume('Verifying the Instagram code...')
+    return code
+  }
+
+  return {
+    onTwoFactorCode: () => promptCode('Enter the Instagram 2FA code from your authenticator app or SMS'),
+    onChallengeCode: async ({ contactPoint }) => {
+      const where = contactPoint === '' ? 'your email or phone' : contactPoint
+      const code = await promptCode(`Enter the Instagram verification code sent to ${where}`)
+      return code === null ? null : { code }
+    },
+  }
 }
 
 type LinePromptResult =
@@ -1735,7 +1767,9 @@ function reportProgress(
       const s = spinner()
       s.start(START_MESSAGES[event.step])
       spinners[event.step] = s
-      if (event.step === 'line-auth' && lineSpinnerHolder) lineSpinnerHolder.current = s
+      if ((event.step === 'line-auth' || event.step === 'instagram-auth') && lineSpinnerHolder) {
+        lineSpinnerHolder.current = s
+      }
       return
     }
 
@@ -1748,6 +1782,7 @@ function reportProgress(
         s.stop(reportLineAuth(event.result))
         break
       case 'instagram-auth':
+        if (lineSpinnerHolder) lineSpinnerHolder.current = null
         s.stop(reportInstagramAuth(event.result))
         break
       case 'kakaotalk-auth':

--- a/src/init/instagram-auth.test.ts
+++ b/src/init/instagram-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -41,11 +42,48 @@ function fakeManager(accountId = 'alice'): { manager: InstagramLoginCredentialMa
   }
 }
 
+function fakeManagerWithSession(
+  sessionPath: string,
+  accountId = 'alice',
+): { manager: InstagramLoginCredentialManager; saved: InstagramAccount[] } {
+  const base = fakeManager(accountId)
+  return { ...base, manager: { ...base.manager, ensureAccountPaths: async () => ({ session_path: sessionPath }) } }
+}
+
+const noopChallengeMethods = {
+  twoFactorLogin: async () => ({ userId: '' }),
+  challengeSendCode: async () => ({ contactPoint: '', stepName: '' }),
+  challengeSubmitCode: async () => ({ userId: '' }),
+}
+
+// Mimics the SDK's checkpoint path: authenticate() persists a partial session
+// to disk (challenge_path + cookies) before returning challengeRequired, which
+// is exactly the file the bootstrap must roll back on a failed second factor.
+function checkpointWritingClient(
+  overrides: Partial<InstagramLoginClient> = {},
+  challengePath = '/challenge/xyz/',
+): InstagramLoginClient {
+  let sessionPath = ''
+  return {
+    setSessionPath: (path) => {
+      sessionPath = path
+    },
+    authenticate: async () => {
+      await writeFile(sessionPath, JSON.stringify({ challenge_path: challengePath, cookies: 'partial' }))
+      return { userId: '', challengeRequired: true, challengePath }
+    },
+    getUserId: () => null,
+    ...noopChallengeMethods,
+    ...overrides,
+  }
+}
+
 function fakeClient(result: InstagramAuthenticateResult): InstagramLoginClient {
   return {
     authenticate: async () => result,
     setSessionPath: () => {},
     getUserId: () => result.userId || null,
+    ...noopChallengeMethods,
   }
 }
 
@@ -57,6 +95,7 @@ function observingClient(result: InstagramAuthenticateResult, onAuthenticate: ()
     },
     setSessionPath: () => {},
     getUserId: () => result.userId || null,
+    ...noopChallengeMethods,
   }
 }
 
@@ -121,10 +160,10 @@ describe('runInstagramBootstrap', () => {
     await withDir(async (dir) => {
       const { manager } = fakeManager()
       const client: InstagramLoginClient = {
+        ...fakeClient({ userId: '' }),
         authenticate: async () => {
           throw new Error('login exploded')
         },
-        setSessionPath: () => {},
         getUserId: () => null,
       }
       const status = await runInstagramBootstrap({
@@ -138,7 +177,92 @@ describe('runInstagramBootstrap', () => {
     })
   })
 
-  test('fails clearly when 2FA is required', async () => {
+  test('completes 2FA by echoing the identifier and the entered code, then persists', async () => {
+    await withDir(async (dir) => {
+      const { manager, saved } = fakeManager()
+      const calls: Array<{ username: string; code: string; identifier: string }> = []
+      const client: InstagramLoginClient = {
+        ...fakeClient({ userId: '', requiresTwoFactor: true, twoFactorInfo: { two_factor_identifier: 'tfi-abc' } }),
+        twoFactorLogin: async (username, code, identifier) => {
+          calls.push({ username, code, identifier })
+          return { userId: '99999' }
+        },
+      }
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client,
+        callbacks: { onTwoFactorCode: async () => '123456' },
+      })
+      expect(status).toEqual({ ok: true })
+      expect(calls).toEqual([{ username: 'alice', code: '123456', identifier: 'tfi-abc' }])
+      expect(saved[0]).toMatchObject({ pk: '99999' })
+    })
+  })
+
+  test('completes a checkpoint challenge: sends the code, submits the entered code, persists', async () => {
+    await withDir(async (dir) => {
+      const { manager, saved } = fakeManager()
+      const sent: string[] = []
+      const submitted: Array<{ path: string; code: string }> = []
+      const client: InstagramLoginClient = {
+        ...fakeClient({ userId: '', challengeRequired: true, challengePath: '/challenge/xyz/' }),
+        challengeSendCode: async (path) => {
+          sent.push(path)
+          return { contactPoint: 'a****@example.com', stepName: 'verify_email' }
+        },
+        challengeSubmitCode: async (path, code) => {
+          submitted.push({ path, code })
+          return { userId: '77777' }
+        },
+      }
+      let promptedContact = ''
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client,
+        callbacks: {
+          onChallengeCode: async ({ contactPoint }) => {
+            promptedContact = contactPoint
+            return { code: '654321' }
+          },
+        },
+      })
+      expect(status).toEqual({ ok: true })
+      expect(sent).toEqual(['/challenge/xyz/'])
+      expect(submitted).toEqual([{ path: '/challenge/xyz/', code: '654321' }])
+      expect(promptedContact).toBe('a****@example.com')
+      expect(saved[0]).toMatchObject({ pk: '77777' })
+    })
+  })
+
+  // Per the repo multi-language rule (AGENTS.md), an interactive flow must be
+  // asserted with non-Latin input alongside the English cases.
+  test('completes 2FA for an account with a non-Latin username', async () => {
+    await withDir(async (dir) => {
+      const { manager, saved } = fakeManager('앨리스')
+      const client: InstagramLoginClient = {
+        ...fakeClient({ userId: '', requiresTwoFactor: true, twoFactorInfo: { two_factor_identifier: 'tfi-korean' } }),
+        twoFactorLogin: async () => ({ userId: '55555' }),
+      }
+      const status = await runInstagramBootstrap({
+        username: '앨리스',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client,
+        callbacks: { onTwoFactorCode: async () => '246810' },
+      })
+      expect(status).toEqual({ ok: true })
+      expect(saved[0]).toMatchObject({ username: '앨리스', pk: '55555' })
+    })
+  })
+
+  test('fails clearly when 2FA is required but no interactive prompt is available', async () => {
     await withDir(async (dir) => {
       const { manager } = fakeManager()
       const status = await runInstagramBootstrap({
@@ -146,16 +270,16 @@ describe('runInstagramBootstrap', () => {
         password: 'secret',
         agentDir: dir,
         credentialManager: manager,
-        client: fakeClient({ userId: '', requiresTwoFactor: true, twoFactorInfo: {} }),
+        client: fakeClient({ userId: '', requiresTwoFactor: true, twoFactorInfo: { two_factor_identifier: 'x' } }),
       })
       expect(status.ok).toBe(false)
       if (status.ok) throw new Error('expected failure')
-      expect(status.reason).toContain('2FA/checkpoint')
-      expect(status.reason).toContain('not yet supported')
+      expect(status.reason).toContain('2FA')
+      expect(status.reason).toContain('no interactive prompt')
     })
   })
 
-  test('fails clearly when a checkpoint challenge is required', async () => {
+  test('fails clearly when a checkpoint is required but no interactive prompt is available', async () => {
     await withDir(async (dir) => {
       const { manager } = fakeManager()
       const status = await runInstagramBootstrap({
@@ -167,8 +291,121 @@ describe('runInstagramBootstrap', () => {
       })
       expect(status.ok).toBe(false)
       if (status.ok) throw new Error('expected failure')
-      expect(status.reason).toContain('2FA/checkpoint')
-      expect(status.reason).toContain('not yet supported')
+      expect(status.reason).toContain('checkpoint')
+      expect(status.reason).toContain('no interactive prompt')
+    })
+  })
+
+  test('fails when the operator cancels the 2FA prompt', async () => {
+    await withDir(async (dir) => {
+      const { manager } = fakeManager()
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: fakeClient({ userId: '', requiresTwoFactor: true, twoFactorInfo: { two_factor_identifier: 'x' } }),
+        callbacks: { onTwoFactorCode: async () => null },
+      })
+      expect(status.ok).toBe(false)
+      if (status.ok) throw new Error('expected failure')
+      expect(status.reason).toContain('cancelled')
+    })
+  })
+
+  test('removes the partial checkpoint session when the checkpoint has no interactive prompt', async () => {
+    await withDir(async (dir) => {
+      const sessionPath = join(dir, 'session.json')
+      const { manager } = fakeManagerWithSession(sessionPath)
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: checkpointWritingClient(),
+      })
+      expect(status.ok).toBe(false)
+      expect(existsSync(sessionPath)).toBe(false)
+    })
+  })
+
+  test('removes the partial checkpoint session when the operator cancels the checkpoint prompt', async () => {
+    await withDir(async (dir) => {
+      const sessionPath = join(dir, 'session.json')
+      const { manager } = fakeManagerWithSession(sessionPath)
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: checkpointWritingClient(),
+        callbacks: { onChallengeCode: async () => null },
+      })
+      expect(status.ok).toBe(false)
+      expect(existsSync(sessionPath)).toBe(false)
+    })
+  })
+
+  test('restores a pre-existing session when a checkpoint login fails', async () => {
+    await withDir(async (dir) => {
+      const sessionPath = join(dir, 'session.json')
+      await writeFile(sessionPath, JSON.stringify({ user_id: 'existing', cookies: 'valid' }))
+      const { manager } = fakeManagerWithSession(sessionPath)
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: checkpointWritingClient(),
+        callbacks: { onChallengeCode: async () => null },
+      })
+      expect(status.ok).toBe(false)
+      const restored = JSON.parse(await readFile(sessionPath, 'utf8')) as { user_id: string }
+      expect(restored.user_id).toBe('existing')
+    })
+  })
+
+  test('removes the partial checkpoint session when challengeSubmitCode throws', async () => {
+    await withDir(async (dir) => {
+      const sessionPath = join(dir, 'session.json')
+      const { manager } = fakeManagerWithSession(sessionPath)
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: checkpointWritingClient({
+          challengeSubmitCode: async () => {
+            throw new Error('invalid verification code')
+          },
+        }),
+        callbacks: { onChallengeCode: async () => ({ code: '000000' }) },
+      })
+      expect(status).toEqual({ ok: false, reason: 'invalid verification code' })
+      expect(existsSync(sessionPath)).toBe(false)
+    })
+  })
+
+  test('restores a pre-existing session when challengeSubmitCode throws', async () => {
+    await withDir(async (dir) => {
+      const sessionPath = join(dir, 'session.json')
+      await writeFile(sessionPath, JSON.stringify({ user_id: 'existing', cookies: 'valid' }))
+      const { manager } = fakeManagerWithSession(sessionPath)
+      const status = await runInstagramBootstrap({
+        username: 'alice',
+        password: 'secret',
+        agentDir: dir,
+        credentialManager: manager,
+        client: checkpointWritingClient({
+          challengeSubmitCode: async () => {
+            throw new Error('network error')
+          },
+        }),
+        callbacks: { onChallengeCode: async () => ({ code: '000000' }) },
+      })
+      expect(status.ok).toBe(false)
+      const restored = JSON.parse(await readFile(sessionPath, 'utf8')) as { user_id: string }
+      expect(restored.user_id).toBe('existing')
     })
   })
 })

--- a/src/init/instagram-auth.ts
+++ b/src/init/instagram-auth.ts
@@ -1,3 +1,4 @@
+import { readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import {
@@ -11,10 +12,31 @@ import { SecretsInstagramCredentialStore } from '@/secrets/instagram-store'
 
 export type InstagramBootstrapStatus = { ok: true } | { ok: false; reason: string }
 
+// Instagram gates a fresh login behind one of two interactive second factors:
+// a 2FA code (authenticator app / SMS the account already has enabled) or a
+// checkpoint challenge (a suspicious-login verification code sent to email or
+// SMS). Both require a human to read a code off a device, so they only work
+// with a TTY. The callbacks return the entered code, or `null` when the user
+// aborts / no interactive prompt is available (cron/container re-auth) — in
+// which case the bootstrap fails loudly instead of hanging.
+export type InstagramLoginCallbacks = {
+  onTwoFactorCode?: (info: InstagramTwoFactorPrompt) => Promise<string | null>
+  onChallengeCode?: (info: InstagramChallengePrompt) => Promise<InstagramChallengeResponse | null>
+}
+
+export type InstagramTwoFactorPrompt = { username: string }
+
+export type InstagramChallengePrompt = { contactPoint: string; method: InstagramChallengeMethod }
+
+export type InstagramChallengeMethod = 'email' | 'sms'
+
+export type InstagramChallengeResponse = { code: string }
+
 export type InstagramLoginInput = {
   username: string
   password: string
   agentDir: string
+  callbacks?: InstagramLoginCallbacks
   client?: InstagramLoginClient
   credentialManager?: InstagramLoginCredentialManager
 }
@@ -27,8 +49,20 @@ export type InstagramAuthenticateResult = {
   challengePath?: string
 }
 
+export type InstagramTwoFactorResult = { userId: string }
+
+export type InstagramChallengeSendResult = { contactPoint: string; stepName: string }
+
+export type InstagramChallengeSubmitResult = { userId: string }
+
+// Structural subset of the upstream InstagramClient the bootstrap drives.
+// Declared here (rather than relying on the SDK class) so tests can inject a
+// fake without standing up the real HTTP client, mirroring the LINE adapter.
 export type InstagramLoginClient = {
   authenticate(username: string, password: string): Promise<InstagramAuthenticateResult>
+  twoFactorLogin(username: string, code: string, twoFactorIdentifier: string): Promise<InstagramTwoFactorResult>
+  challengeSendCode(apiPath: string, method?: InstagramChallengeMethod): Promise<InstagramChallengeSendResult>
+  challengeSubmitCode(apiPath: string, code: string): Promise<InstagramChallengeSubmitResult>
   setSessionPath(path: string): void
   getUserId(): string | null
 }
@@ -63,37 +97,23 @@ export async function runInstagramBootstrap(input: InstagramLoginInput): Promise
         const paths = await manager.ensureAccountPaths(accountId)
         const client = input.client ?? buildInstagramClient(sdkManager)
         client.setSessionPath(paths.session_path)
-        const auth = await client.authenticate(input.username, input.password)
-        if (auth.requiresTwoFactor) return unsupportedTwoFactor()
-        if (auth.challengeRequired) return unsupportedChallenge()
-        const userId = auth.userId || client.getUserId()
-        if (userId === null || userId === '') return { ok: false, reason: 'Instagram login did not authenticate' }
 
-        const now = new Date().toISOString()
-        await manager.setAccount({
-          account_id: accountId,
-          username: input.username,
-          pk: userId,
-          created_at: now,
-          updated_at: now,
-        })
-        await manager.setCurrent(accountId)
-
-        const sdkAccount = await manager.getAccount(accountId)
-        if (sdkAccount === null) {
-          return { ok: false, reason: 'Instagram login authenticated but did not persist SDK credentials' }
+        // A checkpoint login persists a partial SDK session (challenge_path +
+        // cookies) inside authenticate(), before we know whether the operator
+        // can finish it. Snapshot the file up front and restore it on any
+        // failure — whether completeLogin returns a non-ok status (fail-closed
+        // / cancelled) or throws (e.g. challengeSubmitCode rejecting a wrong
+        // code) — so a half-written session is never left behind. Rethrow so
+        // the outer catch reports the error.
+        const sessionSnapshot = await snapshotSessionFile(paths.session_path)
+        try {
+          const result = await completeLogin({ store, manager, client, accountId, input })
+          if (!result.ok) await restoreSessionFile(paths.session_path, sessionSnapshot)
+          return result
+        } catch (err) {
+          await restoreSessionFile(paths.session_path, sessionSnapshot)
+          throw err
         }
-        await store.setAccount({
-          account_id: sdkAccount.account_id,
-          username: sdkAccount.username,
-          ...(sdkAccount.full_name !== undefined ? { full_name: sdkAccount.full_name } : {}),
-          ...(sdkAccount.profile_pic_url !== undefined ? { profile_pic_url: sdkAccount.profile_pic_url } : {}),
-          ...(sdkAccount.pk !== undefined ? { pk: sdkAccount.pk } : {}),
-          created_at: sdkAccount.created_at,
-          updated_at: sdkAccount.updated_at,
-        })
-        await store.setCurrentAccount(sdkAccount.account_id)
-        return { ok: true }
       },
     )
     return result
@@ -102,23 +122,158 @@ export async function runInstagramBootstrap(input: InstagramLoginInput): Promise
   }
 }
 
+type ResolvedUserId = { ok: true; userId: string } | { ok: false; reason: string }
+
+async function completeLogin(args: {
+  store: SecretsInstagramCredentialStore
+  manager: InstagramLoginCredentialManager
+  client: InstagramLoginClient
+  accountId: string
+  input: InstagramLoginInput
+}): Promise<InstagramBootstrapStatus> {
+  const { store, manager, client, accountId, input } = args
+  const resolved = await resolveUserId(client, input)
+  if (!resolved.ok) return resolved
+  const userId = resolved.userId || client.getUserId()
+  if (userId === null || userId === '') return { ok: false, reason: 'Instagram login did not authenticate' }
+  return persistAccount({ store, manager, accountId, username: input.username, userId })
+}
+
+// Drives the authenticate → (optional 2FA / challenge) → userId path. Each
+// second factor is completed in place so a successful code entry continues to
+// the same persist step a clean login would, and an aborted / unsupported
+// prompt fails loudly rather than leaving a half-written session.
+async function resolveUserId(client: InstagramLoginClient, input: InstagramLoginInput): Promise<ResolvedUserId> {
+  const auth = await client.authenticate(input.username, input.password)
+  if (auth.requiresTwoFactor) return completeTwoFactor(client, input, auth)
+  if (auth.challengeRequired) return completeChallenge(client, input, auth)
+  return { ok: true, userId: auth.userId }
+}
+
+async function completeTwoFactor(
+  client: InstagramLoginClient,
+  input: InstagramLoginInput,
+  auth: InstagramAuthenticateResult,
+): Promise<ResolvedUserId> {
+  const identifier = readTwoFactorIdentifier(auth.twoFactorInfo)
+  if (identifier === null) {
+    return { ok: false, reason: 'Instagram requested 2FA but did not return a two-factor identifier.' }
+  }
+  const prompt = input.callbacks?.onTwoFactorCode
+  if (prompt === undefined) return twoFactorUnavailable()
+  const code = await prompt({ username: input.username })
+  if (code === null || code.trim() === '') {
+    return { ok: false, reason: 'Instagram 2FA was cancelled — no verification code was entered.' }
+  }
+  const result = await client.twoFactorLogin(input.username, code.trim(), identifier)
+  return { ok: true, userId: result.userId }
+}
+
+async function completeChallenge(
+  client: InstagramLoginClient,
+  input: InstagramLoginInput,
+  auth: InstagramAuthenticateResult,
+): Promise<ResolvedUserId> {
+  const path = auth.challengePath
+  if (path === undefined || path === '') {
+    return { ok: false, reason: 'Instagram requested a checkpoint but did not return a challenge path.' }
+  }
+  const prompt = input.callbacks?.onChallengeCode
+  if (prompt === undefined) return challengeUnavailable()
+
+  // Instagram sends the verification code to email by default; SMS is only an
+  // option when the account has a verified phone. Send-then-prompt keeps the
+  // code delivery inside the interactive window so a stale contact point can't
+  // leave the user waiting on a code that was never dispatched.
+  const method: InstagramChallengeMethod = 'email'
+  const sent = await client.challengeSendCode(path, method)
+  const response = await prompt({ contactPoint: sent.contactPoint, method })
+  if (response === null || response.code.trim() === '') {
+    return { ok: false, reason: 'Instagram checkpoint was cancelled — no verification code was entered.' }
+  }
+  const result = await client.challengeSubmitCode(path, response.code.trim())
+  return { ok: true, userId: result.userId }
+}
+
+async function persistAccount(args: {
+  store: SecretsInstagramCredentialStore
+  manager: InstagramLoginCredentialManager
+  accountId: string
+  username: string
+  userId: string
+}): Promise<InstagramBootstrapStatus> {
+  const { store, manager, accountId, username, userId } = args
+  const now = new Date().toISOString()
+  await manager.setAccount({
+    account_id: accountId,
+    username,
+    pk: userId,
+    created_at: now,
+    updated_at: now,
+  })
+  await manager.setCurrent(accountId)
+
+  const sdkAccount = await manager.getAccount(accountId)
+  if (sdkAccount === null) {
+    return { ok: false, reason: 'Instagram login authenticated but did not persist SDK credentials' }
+  }
+  await store.setAccount({
+    account_id: sdkAccount.account_id,
+    username: sdkAccount.username,
+    ...(sdkAccount.full_name !== undefined ? { full_name: sdkAccount.full_name } : {}),
+    ...(sdkAccount.profile_pic_url !== undefined ? { profile_pic_url: sdkAccount.profile_pic_url } : {}),
+    ...(sdkAccount.pk !== undefined ? { pk: sdkAccount.pk } : {}),
+    created_at: sdkAccount.created_at,
+    updated_at: sdkAccount.updated_at,
+  })
+  await store.setCurrentAccount(sdkAccount.account_id)
+  return { ok: true }
+}
+
+// The SDK returns `two_factor_info.two_factor_identifier`; it's the opaque
+// token `twoFactorLogin` must echo back. Read defensively — a shape drift
+// surfaces as a clear error instead of an SDK-internal crash.
+function readTwoFactorIdentifier(info: Record<string, unknown> | undefined): string | null {
+  const identifier = info?.['two_factor_identifier']
+  return typeof identifier === 'string' && identifier !== '' ? identifier : null
+}
+
+async function snapshotSessionFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+// Restore the pre-login state: rewrite the prior contents, or delete the file
+// when no session existed before, so a failed second factor leaves the session
+// path exactly as it was found.
+async function restoreSessionFile(path: string, snapshot: string | null): Promise<void> {
+  if (snapshot === null) {
+    await rm(path, { force: true })
+    return
+  }
+  await writeFile(path, snapshot, { mode: 0o600 })
+}
+
 function buildInstagramClient(manager: InstagramCredentialManager): InstagramLoginClient {
   return new RealInstagramClient(manager) as unknown as InstagramLoginClient
 }
 
-function unsupportedTwoFactor(): InstagramBootstrapStatus {
+function twoFactorUnavailable(): { ok: false; reason: string } {
   return {
     ok: false,
     reason:
-      'Instagram account requires 2FA/checkpoint, which is not yet supported by the typeclaw Instagram channel. Disable 2FA on a dedicated agent account, or complete the checkpoint in a browser first.',
+      'Instagram account requires a 2FA code, but no interactive prompt is available. Run `typeclaw channel add instagram` (or `typeclaw channel reauth instagram`) from a terminal to enter the code.',
   }
 }
 
-function unsupportedChallenge(): InstagramBootstrapStatus {
+function challengeUnavailable(): { ok: false; reason: string } {
   return {
     ok: false,
     reason:
-      'Instagram account requires 2FA/checkpoint, which is not yet supported by the typeclaw Instagram channel. Disable 2FA on a dedicated agent account, or complete the checkpoint in a browser first.',
+      'Instagram account requires a checkpoint verification code, but no interactive prompt is available. Run `typeclaw channel add instagram` (or `typeclaw channel reauth instagram`) from a terminal to enter the code.',
   }
 }
 

--- a/src/skills/typeclaw-channel-instagram/SKILL.md
+++ b/src/skills/typeclaw-channel-instagram/SKILL.md
@@ -27,4 +27,4 @@ Engagement: every DM message engages. Groups are alias-only because the SDK summ
 
 Realtime vs polling transport is automatic and invisible to you: TypeClaw uses the hybrid listener when available and falls back to polling on older SDKs.
 
-2FA/checkpointed Instagram accounts are unsupported for this adapter; the operator must use a dedicated account that can authenticate without those challenges.
+2FA and checkpoint-protected Instagram accounts are supported: the operator completes the verification code interactively at `typeclaw channel add instagram` (or `reauth`) time. Nothing about this is visible to you at runtime.


### PR DESCRIPTION
Follow-up to #1110, which shipped the Instagram adapter but punted on 2FA:

> **2FA** must be completed interactively at `typeclaw channel add instagram` time (no headless 2FA loop).

This adds it. The limitation was self-imposed — `runInstagramBootstrap` called `client.authenticate()` and, the moment the response came back with `requiresTwoFactor` or `challengeRequired`, bailed with a "not yet supported" error. The `agent-messenger` SDK (installed 2.28.0) already exposes the full second-factor surface:

```ts
twoFactorLogin(username, code, twoFactorIdentifier): { userId }        // authenticator / SMS
challengeSendCode(apiPath, method?: 'email' | 'sms'): { contactPoint } // checkpoint: dispatch
challengeSubmitCode(apiPath, code): { userId }                         // checkpoint: verify
```

We just weren't calling them.

## What changed

Both second-factor flows now complete interactively, modeled on the existing LINE PIN pattern:

- **`src/init/instagram-auth.ts`** — `runInstagramBootstrap` gains optional `onTwoFactorCode` / `onChallengeCode` callbacks.
  - **2FA**: extracts `two_factor_identifier` from `twoFactorInfo`, awaits the code, calls `twoFactorLogin`.
  - **Checkpoint**: `challengeSendCode` (email by default), awaits the code, `challengeSubmitCode`.
  - Both continue into the **same persist path** a clean login uses (`setAccount` → `setCurrent` → mirror into `secrets.json`), so a code entry ends with a fully-written credential, never a half-written session.
  - **Session rollback**: a checkpoint login persists a partial SDK session (`challenge_path` + cookies) inside `authenticate()`, before we know whether the operator can finish it. The bootstrap snapshots the session file up front and, on **any** failure, restores it — deleting the file when none existed, or rewriting the prior contents when rotating a valid session — so a fail-closed / cancelled second factor never leaves a half-written session behind.
- **`src/cli/channel.ts`** — the `channel add` and `channel reauth instagram` flows wire the callbacks to a `text()` prompt that **pauses/resumes the login spinner** around input (reusing `LineAuthSpinnerControl`), so the prompt renders legibly. Cancellation is checked before the spinner resumes, so aborting never flashes a "Verifying…" spinner. The add-flow spinner holder now also tracks the `instagram-auth` step. The onboarding note drops "2FA accounts unsupported" and tells operators they'll be prompted for a code.
- **`src/skills/typeclaw-channel-instagram/SKILL.md`** — the runtime skill no longer claims 2FA is unsupported; it's handled at auth time and invisible to the agent.

## Preview

**2FA account** (`typeclaw channel add instagram`) — the login spinner pauses for the code, then resumes:

```console
┌  Adding channel: Instagram
│
◇  About to log in to Instagram ────────────────────────────────╮
│                                                                │
│  Instagram authentication uses a personal account.            │
│  Messages will be sent and received under this account.       │
│  If the account has 2FA or triggers a checkpoint, you will    │
│  be prompted for the verification code here.                  │
│                                                                │
├────────────────────────────────────────────────────────────────╯
│
◇  Instagram username
│  agent.account
│
◇  Instagram password
│  ••••••••••••
│
◐  Logging in to Instagram...
│
◆  Enter the Instagram 2FA code from your authenticator app or SMS
│  123456
│
◐  Verifying the Instagram code...
│
◇  Instagram credentials saved to secrets.json.
│
└  Done.
```

**Checkpoint account** — Instagram emails/texts a code first; the prompt names the contact point returned by `challengeSendCode`:

```console
◐  Logging in to Instagram...
│
◆  Enter the Instagram verification code sent to a****@example.com
│  654321
│
◐  Verifying the Instagram code...
│
◇  Instagram credentials saved to secrets.json.
```

**Headless / no TTY** (cron or container re-auth) — no prompt is available, so it fails loudly instead of hanging:

```console
✖  Instagram login failed: Instagram account requires a 2FA code, but no interactive
   prompt is available. Run `typeclaw channel add instagram` (or `typeclaw channel
   reauth instagram`) from a terminal to enter the code.
```

## The one real constraint

This works **interactively** (host stage, a human at the terminal). It **cannot** work headless — there's no way to get a fresh 6-digit code without a human. So when the callbacks are absent (cron / container re-auth, no TTY), the bootstrap **fails loudly** with a message pointing at `typeclaw channel add/reauth instagram`, rather than hanging. Session persistence means the code is only needed once per device-trust window, not per message.

No `agent-messenger` bump, no upstream dependency — the SDK surface was already there.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings, none in touched files)
- `bun run format:check` — clean
- `bun run test` — **10286 pass, 0 fail, 1 skip** (pre-existing bwrap-on-PATH skip)

New tests in `instagram-auth.test.ts` cover: 2FA completion (identifier + code echoed correctly), checkpoint completion (send → prompt → submit), a **non-Latin username** (per the repo multi-language rule), both **headless fail-closed** paths, **operator cancellation**, and **session rollback** (no partial session left on no-callback / cancel; a pre-existing session is restored on failure).
