### PR TITLE
refactor(secrets): extract HostProvider seam for container-mode write-back

### DIFF
--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import type { PermissionService } from '@/permissions'
 import type { GithubSecretsBlock } from '@/secrets'
 import { SecretsDiscordCredentialStore } from '@/secrets/discord-store'
+import { type HostProvider, HostdHostProvider } from '@/secrets/host-provider'
 import { SecretsInstagramCredentialStore } from '@/secrets/instagram-store'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 import { SecretsLineCredentialStore } from '@/secrets/line-store'
@@ -577,26 +578,24 @@ const TOKEN_ENV: Record<
 // buildAdapter skip the adapter instead of throwing and crashing the whole
 // channel manager. startAdapter's signature pre-check only reads secrets.json,
 // so this is the only place the missing triple is caught.
-type HostdContainerCredentials = { hostdUrl: string; restartToken: string; containerName: string }
-
-function resolveHostdContainerCredentials(env: NodeJS.ProcessEnv): HostdContainerCredentials | null {
+function resolveHostProvider(env: NodeJS.ProcessEnv): HostProvider | null {
   const hostdUrl = env.TYPECLAW_HOSTD_URL
   const restartToken = env.TYPECLAW_HOSTD_TOKEN
   const containerName = env.TYPECLAW_CONTAINER_NAME
   if (!hostdUrl || !restartToken || !containerName) return null
-  return { hostdUrl, restartToken, containerName }
+  return new HostdHostProvider({ hostdUrl, restartToken, containerName })
 }
 
 function createContainerDiscordCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsDiscordCredentialStore | null {
-  const creds = resolveHostdContainerCredentials(env)
-  if (creds === null) return null
+  const hostProvider = resolveHostProvider(env)
+  if (hostProvider === null) return null
   return new SecretsDiscordCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    ...creds,
+    hostProvider,
   })
 }
 
@@ -618,12 +617,12 @@ function createContainerSlackCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsSlackCredentialStore | null {
-  const creds = resolveHostdContainerCredentials(env)
-  if (creds === null) return null
+  const hostProvider = resolveHostProvider(env)
+  if (hostProvider === null) return null
   return new SecretsSlackCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    ...creds,
+    hostProvider,
   })
 }
 
@@ -645,12 +644,12 @@ function createContainerWebexCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsWebexCredentialStore | null {
-  const creds = resolveHostdContainerCredentials(env)
-  if (creds === null) return null
+  const hostProvider = resolveHostProvider(env)
+  if (hostProvider === null) return null
   return new SecretsWebexCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    ...creds,
+    hostProvider,
   })
 }
 
@@ -672,12 +671,12 @@ function createContainerKakaoCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsKakaoCredentialStore | null {
-  const creds = resolveHostdContainerCredentials(env)
-  if (creds === null) return null
+  const hostProvider = resolveHostProvider(env)
+  if (hostProvider === null) return null
   return new SecretsKakaoCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    ...creds,
+    hostProvider,
   })
 }
 
@@ -699,12 +698,12 @@ function createContainerLineCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsLineCredentialStore | null {
-  const creds = resolveHostdContainerCredentials(env)
-  if (creds === null) return null
+  const hostProvider = resolveHostProvider(env)
+  if (hostProvider === null) return null
   return new SecretsLineCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    ...creds,
+    hostProvider,
   })
 }
 
@@ -726,12 +725,12 @@ function createContainerInstagramCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsInstagramCredentialStore | null {
-  const creds = resolveHostdContainerCredentials(env)
-  if (creds === null) return null
+  const hostProvider = resolveHostProvider(env)
+  if (hostProvider === null) return null
   return new SecretsInstagramCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    ...creds,
+    hostProvider,
   })
 }
 

--- a/src/secrets/discord-store.ts
+++ b/src/secrets/discord-store.ts
@@ -1,5 +1,4 @@
-import { sendHttp } from '@/hostd/client'
-
+import type { HostProvider } from './host-provider'
 import { type DiscordAccountRecord, type DiscordChannelBlock, discordChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
@@ -7,7 +6,7 @@ export type SetDiscordAccountInput = DiscordAccountRecord
 
 export type SecretsDiscordCredentialStoreOptions =
   | { mode: 'host'; secretsPath: string }
-  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+  | { mode: 'container'; secretsPath: string; hostProvider: HostProvider }
 
 const EMPTY_BLOCK: DiscordChannelBlock = { currentAccount: null, accounts: {} }
 
@@ -64,15 +63,7 @@ export class SecretsDiscordCredentialStore {
     return this.enqueueWrite(async () => {
       if (this.options.mode === 'container') {
         const next = update(this.readBlock())
-        const response = await sendHttp(
-          {
-            kind: 'secrets-patch',
-            containerName: this.options.containerName,
-            patch: { channels: { discord: next } },
-          },
-          { url: this.options.hostdUrl, token: this.options.restartToken },
-        )
-        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        await this.options.hostProvider.writeBackChannelBlock({ discord: next })
         return
       }
 

--- a/src/secrets/host-provider.test.ts
+++ b/src/secrets/host-provider.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import type { Request, Response } from '@/hostd/protocol'
+
+import { HostdHostProvider } from './host-provider'
+
+const servers: Array<ReturnType<typeof Bun.serve>> = []
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true)
+})
+
+function startFakeHostd(token: string, containerName: string): { url: string; requests: Request[] } {
+  const requests: Request[] = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      if (req.headers.get('authorization') !== `Bearer ${token}`) {
+        return json({ ok: false, reason: 'invalid restart token' }, 403)
+      }
+      const rpc = (await req.json()) as Request
+      requests.push(rpc)
+      return json({ ok: true, result: { containerName, patched: true } })
+    },
+  })
+  servers.push(server)
+  return { url: `http://127.0.0.1:${server.port}`, requests }
+}
+
+describe('HostdHostProvider', () => {
+  test('forwards the block as a secrets-patch RPC with Bearer auth', async () => {
+    const hostd = startFakeHostd('secret', 'coder')
+    const provider = new HostdHostProvider({ hostdUrl: hostd.url, restartToken: 'secret', containerName: 'coder' })
+
+    await provider.writeBackChannelBlock({ discord: { currentAccount: null, accounts: {} } })
+
+    expect(hostd.requests).toHaveLength(1)
+    const rpc = hostd.requests[0]
+    expect(rpc?.kind).toBe('secrets-patch')
+    if (rpc?.kind !== 'secrets-patch') throw new Error('expected secrets-patch')
+    expect(rpc.containerName).toBe('coder')
+    expect(rpc.patch.channels).toEqual({ discord: { currentAccount: null, accounts: {} } })
+  })
+
+  test('throws when hostd rejects the patch', async () => {
+    const hostd = startFakeHostd('secret', 'coder')
+    const provider = new HostdHostProvider({ hostdUrl: hostd.url, restartToken: 'wrong', containerName: 'coder' })
+
+    await expect(provider.writeBackChannelBlock({ discord: { currentAccount: null, accounts: {} } })).rejects.toThrow(
+      /secrets-patch failed/,
+    )
+  })
+})
+
+function json(response: Response, status = 200): globalThis.Response {
+  return new Response(JSON.stringify(response), { status, headers: { 'content-type': 'application/json' } })
+}

--- a/src/secrets/host-provider.ts
+++ b/src/secrets/host-provider.ts
@@ -1,0 +1,37 @@
+import { sendHttp } from '@/hostd/client'
+import type { Request } from '@/hostd/protocol'
+
+// The channel-block payload a container-mode store hands the host to persist.
+// Identical to the `secrets-patch` RPC's `patch.channels` union so the hostd
+// implementation forwards it verbatim — the on-the-wire contract is unchanged
+// by this abstraction.
+export type ChannelBlockPatch = Extract<Request, { kind: 'secrets-patch' }>['patch']['channels']
+
+// The host role's substrate-write seam: the container cannot write the
+// (host-owned) secrets.json directly, so credential stores in container mode
+// delegate write-back through a HostProvider. Today the only implementation
+// routes through hostd; a future managed-platform implementation writes to a
+// persistent volume or a platform secret store behind the same interface.
+export interface HostProvider {
+  writeBackChannelBlock(channels: ChannelBlockPatch): Promise<void>
+}
+
+export type HostdHostProviderOptions = {
+  hostdUrl: string
+  restartToken: string
+  containerName: string
+}
+
+// Wraps today's behavior: a `secrets-patch` RPC over HTTP to hostd
+// (host.docker.internal), Bearer-authed by the per-container restart token.
+export class HostdHostProvider implements HostProvider {
+  constructor(private readonly options: HostdHostProviderOptions) {}
+
+  async writeBackChannelBlock(channels: ChannelBlockPatch): Promise<void> {
+    const response = await sendHttp(
+      { kind: 'secrets-patch', containerName: this.options.containerName, patch: { channels } },
+      { url: this.options.hostdUrl, token: this.options.restartToken },
+    )
+    if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+  }
+}

--- a/src/secrets/instagram-store.ts
+++ b/src/secrets/instagram-store.ts
@@ -1,11 +1,10 @@
-import { sendHttp } from '@/hostd/client'
-
+import type { HostProvider } from './host-provider'
 import { type InstagramAccountRecord, type InstagramChannelBlock, instagramChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
 export type SecretsInstagramCredentialStoreOptions =
   | { mode: 'host'; secretsPath: string }
-  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+  | { mode: 'container'; secretsPath: string; hostProvider: HostProvider }
 
 const EMPTY_BLOCK: InstagramChannelBlock = { currentAccount: null, accounts: {} }
 
@@ -70,15 +69,7 @@ export class SecretsInstagramCredentialStore {
     return this.enqueueWrite(async () => {
       if (this.options.mode === 'container') {
         const next = update(this.readBlock())
-        const response = await sendHttp(
-          {
-            kind: 'secrets-patch',
-            containerName: this.options.containerName,
-            patch: { channels: { instagram: next } },
-          },
-          { url: this.options.hostdUrl, token: this.options.restartToken },
-        )
-        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        await this.options.hostProvider.writeBackChannelBlock({ instagram: next })
         return
       }
 

--- a/src/secrets/kakao-store.container-mode.test.ts
+++ b/src/secrets/kakao-store.container-mode.test.ts
@@ -8,6 +8,7 @@ import type { KakaoAccountCredentials } from 'agent-messenger/kakaotalk'
 
 import type { Request, Response } from '@/hostd/protocol'
 
+import { HostdHostProvider } from './host-provider'
 import { SecretsKakaoCredentialStore } from './kakao-store'
 import { kakaoChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
@@ -70,9 +71,11 @@ describe('SecretsKakaoCredentialStore container mode', () => {
       const store = new SecretsKakaoCredentialStore({
         mode: 'container',
         secretsPath,
-        hostdUrl: 'http://127.0.0.1:1',
-        restartToken: 'secret',
-        containerName: 'coder',
+        hostProvider: new HostdHostProvider({
+          hostdUrl: 'http://127.0.0.1:1',
+          restartToken: 'secret',
+          containerName: 'coder',
+        }),
       })
 
       expect(await store.load()).toEqual({ current_account: null, accounts: {} })
@@ -91,9 +94,7 @@ describe('SecretsKakaoCredentialStore container mode', () => {
       const store = new SecretsKakaoCredentialStore({
         mode: 'container',
         secretsPath,
-        hostdUrl: hostd.url,
-        restartToken: 'secret',
-        containerName: 'coder',
+        hostProvider: new HostdHostProvider({ hostdUrl: hostd.url, restartToken: 'secret', containerName: 'coder' }),
       })
 
       await store.setAccount(account('user-1'))
@@ -115,9 +116,7 @@ describe('SecretsKakaoCredentialStore container mode', () => {
       const store = new SecretsKakaoCredentialStore({
         mode: 'container',
         secretsPath,
-        hostdUrl: hostd.url,
-        restartToken: 'secret',
-        containerName: 'coder',
+        hostProvider: new HostdHostProvider({ hostdUrl: hostd.url, restartToken: 'secret', containerName: 'coder' }),
       })
 
       await Promise.all([store.setAccount(account('user-1')), store.setAccount(account('user-2'))])
@@ -138,9 +137,7 @@ describe('SecretsKakaoCredentialStore container mode', () => {
       const store = new SecretsKakaoCredentialStore({
         mode: 'container',
         secretsPath,
-        hostdUrl: hostd.url,
-        restartToken: 'wrong',
-        containerName: 'coder',
+        hostProvider: new HostdHostProvider({ hostdUrl: hostd.url, restartToken: 'wrong', containerName: 'coder' }),
       })
 
       await expect(store.setAccount(account('user-1'))).rejects.toThrow(/secrets-patch failed/)

--- a/src/secrets/kakao-store.ts
+++ b/src/secrets/kakao-store.ts
@@ -1,8 +1,7 @@
 import type { KakaoAccountCredentials, KakaoConfig } from 'agent-messenger/kakaotalk'
 import type { PendingLoginState } from 'agent-messenger/kakaotalk'
 
-import { sendHttp } from '@/hostd/client'
-
+import type { HostProvider } from './host-provider'
 import { type KakaoChannelBlock, type KakaoEncryptedPassword, kakaoChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
@@ -18,7 +17,7 @@ export type SetKakaoAccountInput = KakaoAccountCredentials & {
 
 export type SecretsKakaoCredentialStoreOptions =
   | { mode: 'host'; secretsPath: string }
-  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+  | { mode: 'container'; secretsPath: string; hostProvider: HostProvider }
 
 const EMPTY_BLOCK: KakaoChannelBlock = { currentAccount: null, accounts: {} }
 
@@ -111,15 +110,7 @@ export class SecretsKakaoCredentialStore {
     return this.enqueueWrite(async () => {
       if (this.options.mode === 'container') {
         const next = update(this.readBlock())
-        const response = await sendHttp(
-          {
-            kind: 'secrets-patch',
-            containerName: this.options.containerName,
-            patch: { channels: { kakaotalk: next } },
-          },
-          { url: this.options.hostdUrl, token: this.options.restartToken },
-        )
-        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        await this.options.hostProvider.writeBackChannelBlock({ kakaotalk: next })
         return
       }
 

--- a/src/secrets/line-store.test.ts
+++ b/src/secrets/line-store.test.ts
@@ -7,6 +7,7 @@ import type { LineAccountCredentials } from 'agent-messenger/line'
 
 import type { Request } from '@/hostd/protocol'
 
+import { HostdHostProvider } from './host-provider'
 import { SecretsLineCredentialStore } from './line-store'
 import { SecretsBackend } from './storage'
 
@@ -117,9 +118,11 @@ describe('SecretsLineCredentialStore container mode', () => {
       const store = new SecretsLineCredentialStore({
         mode: 'container',
         secretsPath,
-        hostdUrl: `http://127.0.0.1:${server.port}`,
-        restartToken: token,
-        containerName,
+        hostProvider: new HostdHostProvider({
+          hostdUrl: `http://127.0.0.1:${server.port}`,
+          restartToken: token,
+          containerName,
+        }),
       })
       await store.setAccount(account('mid-1'))
 

--- a/src/secrets/line-store.ts
+++ b/src/secrets/line-store.ts
@@ -1,13 +1,12 @@
 import type { LineAccountCredentials, LineConfig } from 'agent-messenger/line'
 
-import { sendHttp } from '@/hostd/client'
-
+import type { HostProvider } from './host-provider'
 import { type LineChannelBlock, lineChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
 export type SecretsLineCredentialStoreOptions =
   | { mode: 'host'; secretsPath: string }
-  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+  | { mode: 'container'; secretsPath: string; hostProvider: HostProvider }
 
 const EMPTY_BLOCK: LineChannelBlock = { currentAccount: null, accounts: {} }
 
@@ -72,15 +71,7 @@ export class SecretsLineCredentialStore {
     return this.enqueueWrite(async () => {
       if (this.options.mode === 'container') {
         const next = update(this.readBlock())
-        const response = await sendHttp(
-          {
-            kind: 'secrets-patch',
-            containerName: this.options.containerName,
-            patch: { channels: { line: next } },
-          },
-          { url: this.options.hostdUrl, token: this.options.restartToken },
-        )
-        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        await this.options.hostProvider.writeBackChannelBlock({ line: next })
         return
       }
 

--- a/src/secrets/slack-store.ts
+++ b/src/secrets/slack-store.ts
@@ -1,5 +1,4 @@
-import { sendHttp } from '@/hostd/client'
-
+import type { HostProvider } from './host-provider'
 import { type SlackAccountRecord, type SlackChannelBlock, slackChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
@@ -7,7 +6,7 @@ export type SetSlackAccountInput = SlackAccountRecord
 
 export type SecretsSlackCredentialStoreOptions =
   | { mode: 'host'; secretsPath: string }
-  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+  | { mode: 'container'; secretsPath: string; hostProvider: HostProvider }
 
 const EMPTY_BLOCK: SlackChannelBlock = { currentAccount: null, accounts: {} }
 
@@ -64,15 +63,7 @@ export class SecretsSlackCredentialStore {
     return this.enqueueWrite(async () => {
       if (this.options.mode === 'container') {
         const next = update(this.readBlock())
-        const response = await sendHttp(
-          {
-            kind: 'secrets-patch',
-            containerName: this.options.containerName,
-            patch: { channels: { slack: next } },
-          },
-          { url: this.options.hostdUrl, token: this.options.restartToken },
-        )
-        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        await this.options.hostProvider.writeBackChannelBlock({ slack: next })
         return
       }
 

--- a/src/secrets/webex-store.ts
+++ b/src/secrets/webex-store.ts
@@ -1,5 +1,4 @@
-import { sendHttp } from '@/hostd/client'
-
+import type { HostProvider } from './host-provider'
 import { type WebexAccountRecord, type WebexChannelBlock, webexChannelBlockSchema } from './schema'
 import { SecretsBackend } from './storage'
 
@@ -7,7 +6,7 @@ export type SetWebexAccountInput = WebexAccountRecord
 
 export type SecretsWebexCredentialStoreOptions =
   | { mode: 'host'; secretsPath: string }
-  | { mode: 'container'; secretsPath: string; hostdUrl: string; restartToken: string; containerName: string }
+  | { mode: 'container'; secretsPath: string; hostProvider: HostProvider }
 
 const EMPTY_BLOCK: WebexChannelBlock = { currentAccount: null, accounts: {} }
 
@@ -69,15 +68,7 @@ export class SecretsWebexCredentialStore {
     return this.enqueueWrite(async () => {
       if (this.options.mode === 'container') {
         const next = update(this.readBlock())
-        const response = await sendHttp(
-          {
-            kind: 'secrets-patch',
-            containerName: this.options.containerName,
-            patch: { channels: { webex: next } },
-          },
-          { url: this.options.hostdUrl, token: this.options.restartToken },
-        )
-        if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+        await this.options.hostProvider.writeBackChannelBlock({ webex: next })
         return
       }
 


### PR DESCRIPTION
## What

Extracts a `HostProvider` interface as the **substrate-write seam** for container-mode credential write-back, and routes the six personal-account credential stores through it.

This is **Slice A (part 1)** of the deployment host/controller split: it makes the container→host write-back path injectable without changing any behavior. A follow-up PR extracts the `Controller` seam.

## Why

The six personal-account stores (`kakaotalk`, `discord`, `slack`, `webex`, `line`, `instagram`) each hard-imported `sendHttp` and hand-rolled an identical container-mode path: build a `secrets-patch` RPC, POST it to hostd, throw on failure. That welds the stores directly to the hostd transport.

The `HostProvider` seam decouples "the container needs to persist a credential block" (the **host role**) from "how that persistence reaches durable storage" (hostd today; a persistent volume or platform secret store on a managed platform tomorrow). This is the one genuinely host-role concern that survives when a container platform owns orchestration.

## How

- **New:** `src/secrets/host-provider.ts` — `HostProvider` interface (`writeBackChannelBlock`) + `HostdHostProvider` wrapping today's `secrets-patch` RPC over HTTP (Bearer-authed by the per-container restart token). The block payload type is derived from the `secrets-patch` RPC union, so the wire contract is provably unchanged.
- **Stores:** container-mode option variant swaps `{ hostdUrl, restartToken, containerName }` → `{ hostProvider }`; `writeBlock` delegates to `hostProvider.writeBackChannelBlock(...)`.
- **Channel manager:** `resolveHostProvider` replaces `resolveHostdContainerCredentials` — reads the same env triple, returns a `HostdHostProvider` (or `null` when the daemon wasn't reachable at launch; gating unchanged).

## Behavior change

None. `HostdHostProvider` issues the identical `secrets-patch` RPC. The existing container-mode tests (`kakao-store.container-mode.test.ts`, `line-store.test.ts`) still drive it end-to-end through a fake hostd server; a new `host-provider.test.ts` pins the provider directly.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings, unrelated)
- `bun run format:check` — clean
- `bun run test` — 10301 pass, 0 fail