### PR TITLE
feat(container): add Controller seam for the lifecycle-actuator role

### DIFF
--- a/src/container/controller.test.ts
+++ b/src/container/controller.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { CONTROLLER_UNSUPPORTED_REASON, LocalDockerController, NoopController } from './controller'
+import { containerNameFromCwd, type DockerExec, type DockerExecResult, imageTagFromCwd } from './shared'
+
+function fakeExec(handler: (args: string[]) => DockerExecResult): DockerExec {
+  return async (args) => handler(args)
+}
+
+describe('LocalDockerController', () => {
+  test('status delegates to the docker inspect path via the injected exec', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-controller-'))
+    try {
+      const exec = fakeExec((args) => {
+        if (args[0] === 'inspect') return { exitCode: 1, stdout: '', stderr: 'no such container' }
+        return { exitCode: 0, stdout: '', stderr: '' }
+      })
+
+      const result = await new LocalDockerController().status({ cwd: root, exec })
+
+      expect(result.kind).toBe('missing')
+      expect(result.containerName).toBe(containerNameFromCwd(root))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('stop delegates to the docker stop/rm path via the injected exec', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-controller-'))
+    try {
+      const calls: string[][] = []
+      const exec = fakeExec((args) => {
+        calls.push(args)
+        // First inspect: container is a stopped corpse. The post-rm
+        // waitForRemoval poll then sees it gone so stop() returns promptly.
+        if (args[0] === 'inspect') {
+          const seenInspects = calls.filter((c) => c[0] === 'inspect').length
+          return seenInspects === 1
+            ? { exitCode: 0, stdout: 'false\n', stderr: '' }
+            : { exitCode: 1, stdout: '', stderr: 'no such container' }
+        }
+        return { exitCode: 0, stdout: '', stderr: '' }
+      })
+
+      const result = await new LocalDockerController().stop({ cwd: root, exec })
+
+      expect(result.ok).toBe(true)
+      expect(calls.some((c) => c[0] === 'rm')).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('NoopController', () => {
+  const cwd = '/agent'
+
+  test('start fails loud with the unsupported reason', async () => {
+    const result = await new NoopController().start({ cwd, preferredHostPort: 8973 })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain(CONTROLLER_UNSUPPORTED_REASON)
+    expect(result.reason).toContain('start')
+  })
+
+  test('stop fails loud with the unsupported reason', async () => {
+    const result = await new NoopController().stop({ cwd })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain(CONTROLLER_UNSUPPORTED_REASON)
+  })
+
+  test('logs fails loud with the unsupported reason', async () => {
+    const result = await new NoopController().logs({ cwd, follow: false })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain(CONTROLLER_UNSUPPORTED_REASON)
+  })
+
+  test('shell fails loud with the unsupported reason', async () => {
+    const result = await new NoopController().shell({ cwd })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toContain(CONTROLLER_UNSUPPORTED_REASON)
+  })
+
+  test('status reports missing since typeclaw does not orchestrate the container', async () => {
+    const result = await new NoopController().status({ cwd })
+    expect(result.kind).toBe('missing')
+    expect(result.containerName).toBe(containerNameFromCwd(cwd))
+    expect(result.imageTag).toBe(imageTagFromCwd(cwd))
+  })
+})

--- a/src/container/controller.ts
+++ b/src/container/controller.ts
@@ -1,0 +1,80 @@
+import { logs, type LogsOptions, type LogsResult } from './logs'
+import { containerNameFromCwd, imageTagFromCwd } from './shared'
+import { shell, type ShellResult } from './shell'
+import { start, type StartOptions, type StartResult } from './start'
+import { status, type ContainerStatus, type StatusOptions } from './status'
+import { stop, type StopOptions, type StopResult } from './stop'
+
+// The controller role: the external actuator that acts ON a container's
+// lifecycle (start/stop/status/logs/shell). Distinct from the host role
+// (HostProvider), which the container reaches INTO for durable state.
+//
+// In the `host` profile typeclaw owns this loop (LocalDockerController shells
+// out to Docker). In a `managed` profile a platform (ECS/K8s/…) owns it, so
+// typeclaw carries no controller — NoopController makes that absence explicit
+// and fail-loud instead of silently shelling out to a Docker that isn't there.
+export interface Controller {
+  start(options: StartOptions): Promise<StartResult>
+  stop(options: StopOptions): Promise<StopResult>
+  status(options: StatusOptions): Promise<ContainerStatus>
+  logs(options: LogsOptions): Promise<LogsResult>
+  shell(options: { cwd: string; shell?: string }): Promise<ShellResult>
+}
+
+// Thin adapter over the existing lifecycle functions — no behavior change, it
+// just names the actuation surface as an interface so a managed profile can
+// substitute NoopController.
+export class LocalDockerController implements Controller {
+  start(options: StartOptions): Promise<StartResult> {
+    return start(options)
+  }
+
+  stop(options: StopOptions): Promise<StopResult> {
+    return stop(options)
+  }
+
+  status(options: StatusOptions): Promise<ContainerStatus> {
+    return status(options)
+  }
+
+  logs(options: LogsOptions): Promise<LogsResult> {
+    return logs(options)
+  }
+
+  shell(options: { cwd: string; shell?: string }): Promise<ShellResult> {
+    return shell(options)
+  }
+}
+
+export const CONTROLLER_UNSUPPORTED_REASON =
+  'container lifecycle is managed by the platform; typeclaw has no controller in this profile'
+
+// The `managed`-profile controller: the platform owns start/stop/restart, so
+// every lifecycle verb is a fail-loud no-op rather than a Docker shell-out.
+// status() reports `missing` because typeclaw cannot introspect a container it
+// does not orchestrate.
+export class NoopController implements Controller {
+  async start({ cwd }: StartOptions): Promise<StartResult> {
+    return { ok: false, reason: unsupported('start', cwd) }
+  }
+
+  async stop({ cwd }: StopOptions): Promise<StopResult> {
+    return { ok: false, reason: unsupported('stop', cwd) }
+  }
+
+  async status({ cwd }: StatusOptions): Promise<ContainerStatus> {
+    return { kind: 'missing', containerName: containerNameFromCwd(cwd), imageTag: imageTagFromCwd(cwd) }
+  }
+
+  async logs({ cwd }: LogsOptions): Promise<LogsResult> {
+    return { ok: false, reason: unsupported('logs', cwd) }
+  }
+
+  async shell({ cwd }: { cwd: string; shell?: string }): Promise<ShellResult> {
+    return { ok: false, reason: unsupported('shell', cwd) }
+  }
+}
+
+function unsupported(verb: string, cwd: string): string {
+  return `${verb} unsupported for ${cwd}: ${CONTROLLER_UNSUPPORTED_REASON}`
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,3 +1,4 @@
+export { CONTROLLER_UNSUPPORTED_REASON, type Controller, LocalDockerController, NoopController } from './controller'
 export {
   classifyConfiguredRuntime,
   detectInstalledDockerApps,


### PR DESCRIPTION
> **Stacked on #1118** (`slice-a-host-provider`). Review/merge that first; this PR's base is `slice-a-host-provider`, so its diff shows only the Controller change.

## What

Names the **controller role** — the external actuator that acts *on* a container's lifecycle (`start`/`stop`/`status`/`logs`/`shell`) — as a `Controller` interface, with two implementations:

- **`LocalDockerController`** — a thin adapter over the existing lifecycle functions. No behavior change.
- **`NoopController`** — the `managed`-profile implementation: the platform owns the control loop, so every lifecycle verb fails loud with `CONTROLLER_UNSUPPORTED_REASON`, and `status()` reports `missing` rather than silently shelling out to a Docker that isn't there.

This is **Slice A (part 2)** of the deployment host/controller split. Together with the `HostProvider` seam (#1118), it completes the two orthogonal seams the design calls for: **host** (substrate the container reaches *into*) and **controller** (actuator that acts *on* the container). `hostd` is the fusion of both; these seams let a `managed` platform own the controller while the host role is provided by platform primitives.

## Why

The lifecycle functions in `src/container/` (`start`/`stop`/`status`/`logs`/`shell`) are today invoked directly and always shell out to Docker via `defaultDockerExec`. Naming them as a `Controller` interface makes the actuator axis explicit and lets a managed profile substitute `NoopController` — making "the platform owns the control loop" a fail-loud, tested contract instead of an env-var accident.

## Scope discipline

This is deliberately a **thin** extraction, not a rewrite. `LocalDockerController` delegates to the existing functions unchanged; the 22 CLI consumers are **not** rewired in this PR (they keep calling the functions directly). Consumers migrate to the interface incrementally in later work. That keeps this diff small and the behavior provably identical.

## Behavior change

None. `LocalDockerController` forwards to the same functions with the same options. `NoopController` is new code only reachable in a `managed` profile that does not exist yet.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings, unrelated)
- `bun run format:check` — clean
- `bun run test` — 10308 pass, 0 fail (7 new controller tests: delegation for `LocalDockerController`, fail-loud + `missing`-status for `NoopController`)