### PR TITLE
refactor(cli): route lifecycle consumers through the Controller seam

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -12,7 +12,7 @@ import {
   type ChannelListEntry,
   type GithubConfigCleanup,
 } from '@/config/channels-mutation'
-import { start, status, stop } from '@/container'
+import { LocalDockerController } from '@/container'
 import {
   CHANNEL_KINDS,
   appendOrReplaceEnvKey,
@@ -580,7 +580,8 @@ async function maybePromptCredentialRefresh(
   label: string,
   verbPast: 're-authenticated' | 'credentials updated',
 ): Promise<void> {
-  const current = await status({ cwd }).catch(() => null)
+  const controller = new LocalDockerController()
+  const current = await controller.status({ cwd }).catch(() => null)
   if (current === null || current.kind !== 'running') {
     done({
       title: c.green(`${label} ${verbPast}.`),
@@ -608,12 +609,12 @@ async function maybePromptCredentialRefresh(
     return
   }
 
-  const stopped = await stop({ cwd })
+  const stopped = await controller.stop({ cwd })
   if (!stopped.ok) {
     console.error(errorLine(`Restart failed during stop: ${stopped.reason}`))
     process.exit(1)
   }
-  const started = await start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
+  const started = await controller.start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
   if (!started.ok) {
     console.error(errorLine(`Restart failed during start: ${started.reason}`))
     process.exit(1)
@@ -1858,7 +1859,8 @@ async function maybePromptRestart(
   verb: 'added' | 'removed' = 'added',
 ): Promise<void> {
   const label = CHANNEL_LABELS[channel]
-  const current = await status({ cwd }).catch(() => null)
+  const controller = new LocalDockerController()
+  const current = await controller.status({ cwd }).catch(() => null)
   if (current === null || current.kind !== 'running') {
     done({
       title: c.green(`${label} channel ${verb}.`),
@@ -1885,12 +1887,12 @@ async function maybePromptRestart(
     return
   }
 
-  const stopped = await stop({ cwd })
+  const stopped = await controller.stop({ cwd })
   if (!stopped.ok) {
     console.error(errorLine(`Restart failed during stop: ${stopped.reason}`))
     process.exit(1)
   }
-  const started = await start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
+  const started = await controller.start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
   if (!started.ok) {
     console.error(errorLine(`Restart failed during start: ${started.reason}`))
     process.exit(1)

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty'
 
 import { loadConfigSync, validateConfig, type Config, type ValidateConfigResult } from '@/config'
-import { start, stop, type StartOptions, type StartResult, type StopResult } from '@/container'
+import { LocalDockerController, type StartOptions, type StartResult, type StopResult } from '@/container'
 import { createCurrentHostDaemonHolder } from '@/hostd/current-host-daemon'
 import { startDaemon, type DaemonLogEvent, type RestartPreflight } from '@/hostd/daemon'
 import { createKakaoRenewalManager } from '@/hostd/kakao-renewal-manager'
@@ -92,11 +92,12 @@ export type HostdRestartDeps = {
   start: (opts: StartOptions) => Promise<StartResult>
 }
 
+const controller = new LocalDockerController()
 const defaultRestartDeps: HostdRestartDeps = {
   validateConfig,
-  stop,
+  stop: (opts) => controller.stop(opts),
   loadConfigSync,
-  start,
+  start: (opts) => controller.start(opts),
 }
 
 export function buildHostdRestart(

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { logs, parseTailValue } from '@/container'
+import { LocalDockerController, parseTailValue } from '@/container'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { runInspectViewer } from './inspect'
@@ -64,7 +64,7 @@ export const logsCommand = defineCommand({
       console.log(c.dim('Showing container logs.'))
     }
 
-    const result = await logs({ cwd, follow: args.follow, tail })
+    const result = await new LocalDockerController().logs({ cwd, follow: args.follow, tail })
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -2,7 +2,7 @@ import { confirm, isCancel } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { config, validateConfig } from '@/config'
-import { start, stop } from '@/container'
+import { LocalDockerController } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
@@ -70,9 +70,11 @@ export const restartCommand = defineCommand({
       process.exit(1)
     }
 
+    const controller = new LocalDockerController()
+
     const stopSpin = spinner()
     stopSpin.start('Stopping container...')
-    const stopped = await stop({ cwd })
+    const stopped = await controller.stop({ cwd })
     if (!stopped.ok) {
       stopSpin.error(stopped.reason)
       process.exit(1)
@@ -81,7 +83,7 @@ export const restartCommand = defineCommand({
 
     const startSpin = spinner()
     startSpin.start('Starting container...')
-    const started = await start({
+    const started = await controller.start({
       cwd,
       preferredHostPort: Number(args.port),
       forceBuild: args.build,

--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { shell } from '@/container'
+import { LocalDockerController } from '@/container'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { requireAgentDir } from './require-agent-dir'
@@ -29,7 +29,7 @@ export const shellCommand = defineCommand({
 
     console.log(c.cyan(`Attaching ${args.shell} inside the container...`))
 
-    const result = await shell({ cwd, shell: args.shell })
+    const result = await new LocalDockerController().shell({ cwd, shell: args.shell })
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -2,7 +2,7 @@ import { confirm, isCancel } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { config, validateConfig } from '@/config'
-import { start } from '@/container'
+import { LocalDockerController } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
@@ -72,7 +72,7 @@ export const startCommand = defineCommand({
 
     const s = spinner()
     s.start('Starting container...')
-    const result = await start({
+    const result = await new LocalDockerController().start({
       cwd,
       preferredHostPort: Number(args.port),
       forceBuild: args.build,

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -2,7 +2,7 @@ import { styleText } from 'node:util'
 
 import { defineCommand } from 'citty'
 
-import { status as containerStatus, type ContainerStatus, type DockerExec } from '@/container'
+import { type ContainerStatus, type DockerExec, LocalDockerController } from '@/container'
 import { isDaemonReachable, send } from '@/hostd'
 import type { StatusResult } from '@/hostd'
 import { findAgentDir } from '@/init'
@@ -52,7 +52,7 @@ export async function runStatus(deps: RunStatusDeps = {}): Promise<void> {
     return
   }
 
-  const container = await containerStatus({ cwd, exec: deps.exec })
+  const container = await new LocalDockerController().status({ cwd, exec: deps.exec })
   const hostd = await (deps.fetchHostd ?? fetchHostdStatus)(container.containerName)
 
   const useColor = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { stop } from '@/container'
+import { LocalDockerController } from '@/container'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { requireAgentDir } from './require-agent-dir'
@@ -22,7 +22,7 @@ export const stopCommand = defineCommand({
 
     const s = spinner()
     s.start('Stopping container...')
-    const result = await stop({ cwd })
+    const result = await new LocalDockerController().stop({ cwd })
 
     if (!result.ok) {
       s.error(result.reason)

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -1,5 +1,5 @@
 import { validateConfig } from '@/config'
-import { start, stop } from '@/container'
+import { LocalDockerController } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 import type { AgentResult, StartSuccess } from './start'
@@ -57,10 +57,11 @@ async function runOne(
   const validated = validateConfig(cwd)
   if (!validated.ok) return { name, ok: false, reason: validated.reason }
   try {
-    const stopped = await stop({ cwd })
+    const controller = new LocalDockerController()
+    const stopped = await controller.stop({ cwd })
     if (!stopped.ok) return { name, ok: false, reason: stopped.reason }
     onStopped()
-    const started = await start({ cwd, preferredHostPort, forceBuild, cliEntry })
+    const started = await controller.start({ cwd, preferredHostPort, forceBuild, cliEntry })
     if (!started.ok) return { name, ok: false, reason: started.reason }
     return { name, ok: true, data: { stop: stopped, start: started }, warnings: validated.warnings }
   } catch (error) {

--- a/src/compose/start.ts
+++ b/src/compose/start.ts
@@ -1,5 +1,5 @@
 import { validateConfig } from '@/config'
-import { start, type StartResult } from '@/container'
+import { LocalDockerController, type StartResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 
@@ -55,7 +55,7 @@ async function runOne(
   const validated = validateConfig(cwd)
   if (!validated.ok) return { name, ok: false, reason: validated.reason }
   try {
-    const data = await start({ cwd, preferredHostPort, forceBuild, cliEntry })
+    const data = await new LocalDockerController().start({ cwd, preferredHostPort, forceBuild, cliEntry })
     if (!data.ok) return { name, ok: false, reason: data.reason }
     return { name, ok: true, data, warnings: validated.warnings }
   } catch (error) {

--- a/src/compose/stop.ts
+++ b/src/compose/stop.ts
@@ -1,4 +1,4 @@
-import { stop, type StopResult } from '@/container'
+import { LocalDockerController, type StopResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 import type { AgentResult } from './start'
@@ -34,7 +34,7 @@ export async function composeStop({ rootCwd, onProgress }: ComposeStopOptions): 
 
 async function runOne(name: string, cwd: string): Promise<AgentResult<StopSuccess>> {
   try {
-    const data = await stop({ cwd })
+    const data = await new LocalDockerController().stop({ cwd })
     if (!data.ok) return { name, ok: false, reason: data.reason }
     return { name, ok: true, data }
   } catch (error) {

--- a/src/inspect/logs-item.ts
+++ b/src/inspect/logs-item.ts
@@ -1,4 +1,4 @@
-import { logs } from '@/container'
+import { LocalDockerController } from '@/container'
 
 export type StreamLogsOptions = {
   cwd: string
@@ -28,7 +28,7 @@ export async function streamLogs(opts: StreamLogsOptions): Promise<StreamLogsRes
   const out = lineSink(opts.stdout)
   const err = lineSink(opts.stderr)
 
-  const result = await logs({
+  const result = await new LocalDockerController().logs({
     cwd: opts.cwd,
     follow: true,
     out,


### PR DESCRIPTION
## What

Routes the container-lifecycle consumers through `LocalDockerController` instead of calling the concrete `start`/`stop`/`status`/`logs`/`shell` functions directly.

Consumers rewired:
- **CLI commands** — `start`, `stop`, `restart`, `shell`, `logs`, `status`
- **hostd** — `defaultRestartDeps` (the daemon's self-restart path) now sources `start`/`stop` from a `LocalDockerController`

## Why

The `Controller` seam (added in the prior slice, #1119) named the lifecycle-actuator role and shipped `LocalDockerController` + `NoopController` — but **nothing consumed the interface**. Every CLI command still imported and called the free functions, so `LocalDockerController` was dead code and the abstraction was ornamental.

This PR makes the seam **load-bearing**: consumers now depend on the `Controller` interface, not the concrete functions. That's the step that lets a future profile-aware resolver swap `LocalDockerController` (host) for `NoopController` (managed) at a single point per consumer — without which the managed profile can't be wired at all.

## Scope

Deliberately minimal. Each consumer constructs `new LocalDockerController()` inline and calls the interface method. This does **not** introduce profile resolution (`host` vs `managed`) — that knob doesn't exist yet and inventing it here would be scope creep. The `new LocalDockerController()` call site is the future swap point for a `resolveController()` factory.

`parseTailValue` (a pure helper, not a lifecycle verb) stays a direct import in `logs.ts`. hostd's injectable `HostdRestartDeps` seam is untouched — its tests keep passing with their own stubs.

## Behavior change

None. `LocalDockerController` forwards to the same functions with the same options. `status` keeps its injectable `exec` seam via `StatusOptions`.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (66 pre-existing warnings, unrelated)
- `bun run format:check` — clean
- `bun run test` — 10308 pass, 0 fail