### PR TITLE
feat(container): add deployment-profile resolver for the Controller seam

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -12,7 +12,7 @@ import {
   type ChannelListEntry,
   type GithubConfigCleanup,
 } from '@/config/channels-mutation'
-import { LocalDockerController } from '@/container'
+import { resolveController } from '@/container'
 import {
   CHANNEL_KINDS,
   appendOrReplaceEnvKey,
@@ -580,7 +580,7 @@ async function maybePromptCredentialRefresh(
   label: string,
   verbPast: 're-authenticated' | 'credentials updated',
 ): Promise<void> {
-  const controller = new LocalDockerController()
+  const controller = resolveController()
   const current = await controller.status({ cwd }).catch(() => null)
   if (current === null || current.kind !== 'running') {
     done({
@@ -1859,7 +1859,7 @@ async function maybePromptRestart(
   verb: 'added' | 'removed' = 'added',
 ): Promise<void> {
   const label = CHANNEL_LABELS[channel]
-  const controller = new LocalDockerController()
+  const controller = resolveController()
   const current = await controller.status({ cwd }).catch(() => null)
   if (current === null || current.kind !== 'running') {
     done({

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty'
 
 import { loadConfigSync, validateConfig, type Config, type ValidateConfigResult } from '@/config'
-import { LocalDockerController, type StartOptions, type StartResult, type StopResult } from '@/container'
+import { resolveController, type StartOptions, type StartResult, type StopResult } from '@/container'
 import { createCurrentHostDaemonHolder } from '@/hostd/current-host-daemon'
 import { startDaemon, type DaemonLogEvent, type RestartPreflight } from '@/hostd/daemon'
 import { createKakaoRenewalManager } from '@/hostd/kakao-renewal-manager'
@@ -92,7 +92,7 @@ export type HostdRestartDeps = {
   start: (opts: StartOptions) => Promise<StartResult>
 }
 
-const controller = new LocalDockerController()
+const controller = resolveController()
 const defaultRestartDeps: HostdRestartDeps = {
   validateConfig,
   stop: (opts) => controller.stop(opts),

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { LocalDockerController, parseTailValue } from '@/container'
+import { parseTailValue, resolveController } from '@/container'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { runInspectViewer } from './inspect'
@@ -64,7 +64,7 @@ export const logsCommand = defineCommand({
       console.log(c.dim('Showing container logs.'))
     }
 
-    const result = await new LocalDockerController().logs({ cwd, follow: args.follow, tail })
+    const result = await resolveController().logs({ cwd, follow: args.follow, tail })
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -2,7 +2,7 @@ import { confirm, isCancel } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { config, validateConfig } from '@/config'
-import { LocalDockerController } from '@/container'
+import { resolveController } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
@@ -70,7 +70,7 @@ export const restartCommand = defineCommand({
       process.exit(1)
     }
 
-    const controller = new LocalDockerController()
+    const controller = resolveController()
 
     const stopSpin = spinner()
     stopSpin.start('Stopping container...')

--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { LocalDockerController } from '@/container'
+import { resolveController } from '@/container'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { requireAgentDir } from './require-agent-dir'
@@ -29,7 +29,7 @@ export const shellCommand = defineCommand({
 
     console.log(c.cyan(`Attaching ${args.shell} inside the container...`))
 
-    const result = await new LocalDockerController().shell({ cwd, shell: args.shell })
+    const result = await resolveController().shell({ cwd, shell: args.shell })
     if (!result.ok) {
       console.error(errorLine(result.reason))
       process.exit(1)

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -2,7 +2,7 @@ import { confirm, isCancel } from '@clack/prompts'
 import { defineCommand } from 'citty'
 
 import { config, validateConfig } from '@/config'
-import { LocalDockerController } from '@/container'
+import { resolveController } from '@/container'
 import { findAgentDir, isInitialized } from '@/init'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
@@ -72,7 +72,7 @@ export const startCommand = defineCommand({
 
     const s = spinner()
     s.start('Starting container...')
-    const result = await new LocalDockerController().start({
+    const result = await resolveController().start({
       cwd,
       preferredHostPort: Number(args.port),
       forceBuild: args.build,

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -2,7 +2,7 @@ import { styleText } from 'node:util'
 
 import { defineCommand } from 'citty'
 
-import { type ContainerStatus, type DockerExec, LocalDockerController } from '@/container'
+import { type ContainerStatus, type DockerExec, resolveController } from '@/container'
 import { isDaemonReachable, send } from '@/hostd'
 import type { StatusResult } from '@/hostd'
 import { findAgentDir } from '@/init'
@@ -52,7 +52,7 @@ export async function runStatus(deps: RunStatusDeps = {}): Promise<void> {
     return
   }
 
-  const container = await new LocalDockerController().status({ cwd, exec: deps.exec })
+  const container = await resolveController().status({ cwd, exec: deps.exec })
   const hostd = await (deps.fetchHostd ?? fetchHostdStatus)(container.containerName)
 
   const useColor = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { LocalDockerController } from '@/container'
+import { resolveController } from '@/container'
 
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
 import { requireAgentDir } from './require-agent-dir'
@@ -22,7 +22,7 @@ export const stopCommand = defineCommand({
 
     const s = spinner()
     s.start('Stopping container...')
-    const result = await new LocalDockerController().stop({ cwd })
+    const result = await resolveController().stop({ cwd })
 
     if (!result.ok) {
       s.error(result.reason)

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -1,5 +1,5 @@
 import { validateConfig } from '@/config'
-import { LocalDockerController } from '@/container'
+import { resolveController } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 import type { AgentResult, StartSuccess } from './start'
@@ -57,7 +57,7 @@ async function runOne(
   const validated = validateConfig(cwd)
   if (!validated.ok) return { name, ok: false, reason: validated.reason }
   try {
-    const controller = new LocalDockerController()
+    const controller = resolveController()
     const stopped = await controller.stop({ cwd })
     if (!stopped.ok) return { name, ok: false, reason: stopped.reason }
     onStopped()

--- a/src/compose/start.ts
+++ b/src/compose/start.ts
@@ -1,5 +1,5 @@
 import { validateConfig } from '@/config'
-import { LocalDockerController, type StartResult } from '@/container'
+import { resolveController, type StartResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 
@@ -55,7 +55,7 @@ async function runOne(
   const validated = validateConfig(cwd)
   if (!validated.ok) return { name, ok: false, reason: validated.reason }
   try {
-    const data = await new LocalDockerController().start({ cwd, preferredHostPort, forceBuild, cliEntry })
+    const data = await resolveController().start({ cwd, preferredHostPort, forceBuild, cliEntry })
     if (!data.ok) return { name, ok: false, reason: data.reason }
     return { name, ok: true, data, warnings: validated.warnings }
   } catch (error) {

--- a/src/compose/stop.ts
+++ b/src/compose/stop.ts
@@ -1,4 +1,4 @@
-import { LocalDockerController, type StopResult } from '@/container'
+import { resolveController, type StopResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 import type { AgentResult } from './start'
@@ -34,7 +34,7 @@ export async function composeStop({ rootCwd, onProgress }: ComposeStopOptions): 
 
 async function runOne(name: string, cwd: string): Promise<AgentResult<StopSuccess>> {
   try {
-    const data = await new LocalDockerController().stop({ cwd })
+    const data = await resolveController().stop({ cwd })
     if (!data.ok) return { name, ok: false, reason: data.reason }
     return { name, ok: true, data }
   } catch (error) {

--- a/src/container/controller.test.ts
+++ b/src/container/controller.test.ts
@@ -3,7 +3,13 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { CONTROLLER_UNSUPPORTED_REASON, LocalDockerController, NoopController } from './controller'
+import {
+  CONTROLLER_UNSUPPORTED_REASON,
+  LocalDockerController,
+  NoopController,
+  resolveController,
+  resolveDeploymentProfile,
+} from './controller'
 import { containerNameFromCwd, type DockerExec, type DockerExecResult, imageTagFromCwd } from './shared'
 
 function fakeExec(handler: (args: string[]) => DockerExecResult): DockerExec {
@@ -92,5 +98,25 @@ describe('NoopController', () => {
     expect(result.kind).toBe('missing')
     expect(result.containerName).toBe(containerNameFromCwd(cwd))
     expect(result.imageTag).toBe(imageTagFromCwd(cwd))
+  })
+})
+
+describe('resolveController', () => {
+  test('host profile resolves to LocalDockerController', () => {
+    expect(resolveController('host')).toBeInstanceOf(LocalDockerController)
+  })
+
+  test('managed profile resolves to NoopController', () => {
+    expect(resolveController('managed')).toBeInstanceOf(NoopController)
+  })
+
+  test('defaults to the host controller (no managed runtime yet)', () => {
+    expect(resolveController()).toBeInstanceOf(LocalDockerController)
+  })
+})
+
+describe('resolveDeploymentProfile', () => {
+  test('resolves to host (the only reachable profile today)', () => {
+    expect(resolveDeploymentProfile()).toBe('host')
   })
 })

--- a/src/container/controller.ts
+++ b/src/container/controller.ts
@@ -78,3 +78,40 @@ export class NoopController implements Controller {
 function unsupported(verb: string, cwd: string): string {
   return `${verb} unsupported for ${cwd}: ${CONTROLLER_UNSUPPORTED_REASON}`
 }
+
+// Which side owns the container control loop. `host` = typeclaw orchestrates
+// via local Docker (the only reachable value today). `managed` = an external
+// platform (ECS/K8s/…) owns it. The distinction is a deployer concern, not an
+// agent-runtime one; see docs/internals for the host/controller split.
+export type DeploymentProfile = 'host' | 'managed'
+
+// Single source of truth for the deployment profile. There is no `managed`
+// runtime yet, so this always resolves to `host`. When a managed platform
+// lands, the trigger (a platform-injected env var, or a config field) is wired
+// HERE — one place, not per call site.
+export function resolveDeploymentProfile(): DeploymentProfile {
+  return 'host'
+}
+
+// The controller-axis resolver: maps the deployment profile to its actuator.
+// Callers construct their Controller through this instead of `new
+// LocalDockerController()` directly. `profile` is injectable for tests;
+// production omits it and gets `resolveDeploymentProfile()`.
+//
+// SCOPE (do not overclaim): this centralizes only the *direct controller
+// construction* — the lifecycle CALLS that previously did `new
+// LocalDockerController()`. It is NOT yet the single deployment boundary. Two
+// host-Docker escape hatches still sit outside it, to be routed when the
+// managed controller is actually built:
+//   1. Docker preflight (`preflightDocker()`) runs BEFORE the resolver in
+//      start/stop/logs/shell/restart and compose, so a managed profile would
+//      exit on the host-only check before reaching a managed controller.
+//      Fix: resolve profile first, move availability checks inside the host
+//      controller path.
+//   2. Fleet/status/init paths still use host primitives directly
+//      (`resolveDockerBinary` in compose/logs, `inspectContainer` in
+//      compose/status, `start`/`stop` deps in init) — probes not on the
+//      Controller surface. Route or narrow when managed lands.
+export function resolveController(profile: DeploymentProfile = resolveDeploymentProfile()): Controller {
+  return profile === 'managed' ? new NoopController() : new LocalDockerController()
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -1,4 +1,12 @@
-export { CONTROLLER_UNSUPPORTED_REASON, type Controller, LocalDockerController, NoopController } from './controller'
+export {
+  CONTROLLER_UNSUPPORTED_REASON,
+  type Controller,
+  type DeploymentProfile,
+  LocalDockerController,
+  NoopController,
+  resolveController,
+  resolveDeploymentProfile,
+} from './controller'
 export {
   classifyConfiguredRuntime,
   detectInstalledDockerApps,

--- a/src/inspect/logs-item.ts
+++ b/src/inspect/logs-item.ts
@@ -1,4 +1,4 @@
-import { LocalDockerController } from '@/container'
+import { resolveController } from '@/container'
 
 export type StreamLogsOptions = {
   cwd: string
@@ -28,7 +28,7 @@ export async function streamLogs(opts: StreamLogsOptions): Promise<StreamLogsRes
   const out = lineSink(opts.stdout)
   const err = lineSink(opts.stderr)
 
-  const result = await new LocalDockerController().logs({
+  const result = await resolveController().logs({
     cwd: opts.cwd,
     follow: true,
     out,


### PR DESCRIPTION
## What

Introduces `resolveController()` — a profile-aware factory that maps the deployment profile to its actuator — and routes the direct controller constructions through it instead of `new LocalDockerController()`.

- `DeploymentProfile` = `'host' | 'managed'`
- `resolveDeploymentProfile()` — the single source of truth (always `'host'` today)
- `resolveController(profile?)` — `host` → `LocalDockerController`, `managed` → `NoopController`

## Why

The prior slices added the `Controller` interface + `LocalDockerController`/`NoopController` and routed the direct lifecycle constructions through `LocalDockerController`. But **nothing selected the implementation** — `NoopController` was unreachable dead code. This PR closes that: the direct constructions now go through `resolveController()`, so host/managed selection for *those call sites* lives at one place.

## Scope (narrowed — see the resolver docstring)

This centralizes only the **direct controller construction** — the ~13 call sites that previously did `new LocalDockerController()`. It is **not yet the single deployment boundary**, and the code says so explicitly. Two host-Docker escape hatches remain, deliberately out of scope for this "add the resolver" slice and tracked for the follow-up capability-composition work:

1. **Docker preflight runs before the resolver** in start/stop/logs/shell/restart and compose — a managed profile would exit on the host-only `preflightDocker()` check before reaching a managed controller. Fix: resolve profile first, move availability checks inside the host controller path.
2. **Fleet/status/init paths still use host primitives directly** (`resolveDockerBinary` in `compose/logs.ts`, `inspectContainer` in `compose/status.ts`, `start`/`stop` deps in `init/index.ts`) — probes not on the `Controller` surface. Route or narrow when managed lands.

The `resolveController` docstring carries this scope note in-code so it can't drift back into an overclaim.

## Behavior change

None. `resolveController()` returns the host controller everywhere, forwarding to the same functions as before. The only remaining `new LocalDockerController()` in production is *inside* `resolveController` itself.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — 10312 pass, 0 fail (4 resolver tests: host→Local, managed→Noop, default→host, profile→host)