### PR TITLE
feat(models): add Claude Sonnet 5 and Claude Fable 5 to the Anthropic lineup

### DIFF
--- a/src/agent/adaptive-thinking-compat.test.ts
+++ b/src/agent/adaptive-thinking-compat.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { Api, Model } from '@mariozechner/pi-ai'
+
+import {
+  applyAdaptiveThinkingCompat,
+  isAdaptiveOnlyAnthropicModel,
+  rewriteThinkingForAdaptiveOnlyModels,
+} from './adaptive-thinking-compat'
+
+function anthropicModel(id: string): Pick<Model<Api>, 'api' | 'id'> {
+  return { api: 'anthropic-messages', id }
+}
+
+// The exact params shape pi-ai 0.67.3's budget-based branch produces for a
+// reasoning Anthropic model that supportsAdaptiveThinking() does not match.
+function budgetThinkingPayload(model: string) {
+  return {
+    model,
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 32000,
+    stream: true,
+    thinking: { type: 'enabled', budget_tokens: 4096 },
+  }
+}
+
+describe('isAdaptiveOnlyAnthropicModel', () => {
+  test('matches Sonnet 5 and Fable 5, with and without date suffix', () => {
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-sonnet-5'))).toBe(true)
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-fable-5'))).toBe(true)
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-sonnet-5-20260701'))).toBe(true)
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-fable-5-20260615'))).toBe(true)
+  })
+
+  test('does not match other Anthropic models', () => {
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-sonnet-4-6'))).toBe(false)
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-opus-4-8'))).toBe(false)
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-opus-4-5'))).toBe(false)
+    expect(isAdaptiveOnlyAnthropicModel(anthropicModel('claude-haiku-4-5'))).toBe(false)
+  })
+
+  test('does not match same-named ids on a non-anthropic-messages transport', () => {
+    expect(isAdaptiveOnlyAnthropicModel({ api: 'openai-completions', id: 'claude-sonnet-5' })).toBe(false)
+  })
+})
+
+describe('rewriteThinkingForAdaptiveOnlyModels', () => {
+  test('rewrites budget thinking to adaptive for Sonnet 5 — budget_tokens never leaves', () => {
+    const result = rewriteThinkingForAdaptiveOnlyModels(
+      budgetThinkingPayload('claude-sonnet-5'),
+      anthropicModel('claude-sonnet-5'),
+    )
+    expect(result).toMatchObject({ thinking: { type: 'adaptive' } })
+    expect(JSON.stringify(result)).not.toContain('budget_tokens')
+  })
+
+  test('rewrites budget thinking to adaptive for Fable 5 — budget_tokens never leaves', () => {
+    const result = rewriteThinkingForAdaptiveOnlyModels(
+      budgetThinkingPayload('claude-fable-5'),
+      anthropicModel('claude-fable-5'),
+    )
+    expect(result).toMatchObject({ thinking: { type: 'adaptive' } })
+    expect(JSON.stringify(result)).not.toContain('budget_tokens')
+  })
+
+  test('preserves all sibling params when rewriting', () => {
+    const payload = budgetThinkingPayload('claude-sonnet-5')
+    const result = rewriteThinkingForAdaptiveOnlyModels(payload, anthropicModel('claude-sonnet-5'))
+    expect(result).toMatchObject({
+      model: 'claude-sonnet-5',
+      messages: payload.messages,
+      max_tokens: 32000,
+      stream: true,
+    })
+  })
+
+  test('does not mutate the incoming payload object', () => {
+    const payload = budgetThinkingPayload('claude-sonnet-5')
+    rewriteThinkingForAdaptiveOnlyModels(payload, anthropicModel('claude-sonnet-5'))
+    expect(payload.thinking).toEqual({ type: 'enabled', budget_tokens: 4096 })
+  })
+
+  test('returns the payload untouched (same reference) for budget-thinking models', () => {
+    const payload = budgetThinkingPayload('claude-opus-4-5')
+    expect(rewriteThinkingForAdaptiveOnlyModels(payload, anthropicModel('claude-opus-4-5'))).toBe(payload)
+  })
+
+  test('returns the payload untouched for adaptive 4.6 models pi-ai already handles', () => {
+    const payload = { model: 'claude-sonnet-4-6', thinking: { type: 'adaptive' } }
+    expect(rewriteThinkingForAdaptiveOnlyModels(payload, anthropicModel('claude-sonnet-4-6'))).toBe(payload)
+  })
+
+  test('leaves thinking: disabled untouched on target models', () => {
+    const payload = { model: 'claude-sonnet-5', thinking: { type: 'disabled' } }
+    expect(rewriteThinkingForAdaptiveOnlyModels(payload, anthropicModel('claude-sonnet-5'))).toBe(payload)
+  })
+
+  test('leaves payloads without a thinking param untouched on target models', () => {
+    const payload = { model: 'claude-fable-5', messages: [] }
+    expect(rewriteThinkingForAdaptiveOnlyModels(payload, anthropicModel('claude-fable-5'))).toBe(payload)
+  })
+
+  test('tolerates non-object payloads', () => {
+    expect(rewriteThinkingForAdaptiveOnlyModels(undefined, anthropicModel('claude-sonnet-5'))).toBeUndefined()
+    expect(rewriteThinkingForAdaptiveOnlyModels(null, anthropicModel('claude-sonnet-5'))).toBeNull()
+    expect(rewriteThinkingForAdaptiveOnlyModels('x', anthropicModel('claude-sonnet-5'))).toBe('x')
+  })
+})
+
+type FakeAgent = {
+  onPayload?: (payload: unknown, model: Model<Api>) => unknown | undefined | Promise<unknown | undefined>
+}
+
+function asModel(id: string): Model<Api> {
+  return anthropicModel(id) as Model<Api>
+}
+
+describe('applyAdaptiveThinkingCompat', () => {
+  test('rewrites when the agent has no inner onPayload', async () => {
+    const agent: FakeAgent = {}
+    applyAdaptiveThinkingCompat(agent)
+    const result = await agent.onPayload?.(budgetThinkingPayload('claude-sonnet-5'), asModel('claude-sonnet-5'))
+    expect(result).toMatchObject({ thinking: { type: 'adaptive' } })
+  })
+
+  test('runs the inner hook first and rewrites its output', async () => {
+    const seen: unknown[] = []
+    const agent: FakeAgent = {
+      onPayload: async (payload) => {
+        seen.push(payload)
+        return { ...(payload as object), tagged: true }
+      },
+    }
+    applyAdaptiveThinkingCompat(agent)
+    const original = budgetThinkingPayload('claude-sonnet-5')
+    const result = await agent.onPayload?.(original, asModel('claude-sonnet-5'))
+    expect(seen).toEqual([original])
+    expect(result).toMatchObject({ tagged: true, thinking: { type: 'adaptive' } })
+  })
+
+  test("honors pi's contract: inner undefined falls back to the original payload", async () => {
+    const agent: FakeAgent = { onPayload: async () => undefined }
+    applyAdaptiveThinkingCompat(agent)
+    const result = await agent.onPayload?.(budgetThinkingPayload('claude-fable-5'), asModel('claude-fable-5'))
+    expect(result).toMatchObject({ thinking: { type: 'adaptive' } })
+  })
+
+  test('passes non-target models through the inner hook unchanged', async () => {
+    const agent: FakeAgent = {}
+    applyAdaptiveThinkingCompat(agent)
+    const payload = budgetThinkingPayload('claude-opus-4-5')
+    const result = await agent.onPayload?.(payload, asModel('claude-opus-4-5'))
+    expect(result).toBe(payload)
+  })
+})

--- a/src/agent/adaptive-thinking-compat.ts
+++ b/src/agent/adaptive-thinking-compat.ts
@@ -1,0 +1,71 @@
+// Compatibility shim for adaptive-thinking-only Anthropic models on the
+// pinned pi stack (@mariozechner/* 0.67.3).
+//
+// The problem: Sonnet 5 and Fable 5 accept ONLY adaptive thinking. Manual
+// extended thinking (`thinking: {type: "enabled"}` with `budget_tokens`)
+// returns a 400. But pi-ai 0.67.3's `supportsAdaptiveThinking()` matches only
+// 4.6-generation ids (`opus-4-6`, `sonnet-4-6`), so for any OTHER Anthropic
+// model registered with `reasoning: true` it falls back to the budget-based
+// path — and thinking is on by default (pi-coding-agent's
+// DEFAULT_THINKING_LEVEL is "medium", and `defaultThinkingLevelForRef`
+// deliberately defers to it). Net effect without this shim: a session on
+// Sonnet 5 / Fable 5 400s on its first request.
+//
+// The fix: pi-ai calls `options.onPayload(params, model)` right before the
+// HTTP request and adopts a non-undefined return value as the request params
+// (see `streamAnthropic` in pi-ai's providers/anthropic.ts). We hook that seam
+// via `Agent.onPayload` — a public field, same seam `src/agent/index.ts`
+// already uses for `convertToLlm` (the replay sanitizer) — and rewrite
+// `thinking: {type: "enabled", ...}` to `thinking: {type: "adaptive"}` for
+// exactly the adaptive-only model ids. Everything else passes through
+// byte-identical.
+//
+// Not covered (deliberately): pi-ai 0.67.3 also sends the
+// `interleaved-thinking-2025-05-14` beta header for non-4.6 models. That
+// header is set at SDK-client construction, before `onPayload` runs, so this
+// shim can't remove it — it is redundant-but-harmless on adaptive models (the
+// API ignores it), unlike the budget `thinking` payload which hard-fails.
+//
+// DELETE THIS FILE when typeclaw migrates to @earendil-works/pi-* >= 0.80,
+// whose model records carry `compat: { forceAdaptiveThinking: true }` for
+// these ids and handle the rewrite inside the transport itself.
+
+import type { Api, Model } from '@mariozechner/pi-ai'
+
+type OnPayload = (payload: unknown, model: Model<Api>) => unknown | undefined | Promise<unknown | undefined>
+
+type OnPayloadHost = { onPayload?: OnPayload }
+
+// Mirrors pi-ai's own id matching style (`String.includes`, date-suffix
+// tolerant). Scoped to the Anthropic Messages API so a same-named id on a
+// different transport (e.g. a Bedrock alias) is never touched.
+export function isAdaptiveOnlyAnthropicModel(model: Pick<Model<Api>, 'api' | 'id'>): boolean {
+  if (model.api !== 'anthropic-messages') return false
+  return model.id.includes('sonnet-5') || model.id.includes('fable-5')
+}
+
+// Pure rewrite: budget-based `thinking` -> `{type: "adaptive"}` for
+// adaptive-only models. Returns the ORIGINAL payload object (not a clone)
+// whenever no rewrite applies, so "untouched" is reference-checkable in tests.
+export function rewriteThinkingForAdaptiveOnlyModels(payload: unknown, model: Pick<Model<Api>, 'api' | 'id'>): unknown {
+  if (!isAdaptiveOnlyAnthropicModel(model)) return payload
+  if (payload === null || typeof payload !== 'object') return payload
+  if (!('thinking' in payload)) return payload
+  const thinking = payload.thinking
+  if (thinking === null || typeof thinking !== 'object') return payload
+  if (!('type' in thinking) || thinking.type !== 'enabled') return payload
+  return { ...payload, thinking: { type: 'adaptive' } }
+}
+
+// Layers the rewrite over an agent's existing `onPayload` (pi-coding-agent
+// installs one that dispatches extension `before_provider_request` handlers).
+// Honors pi's contract that an `undefined` return means "keep the original
+// payload": the inner hook's undefined falls back to the incoming payload
+// before the rewrite runs, so the rewrite always sees the effective params.
+export function applyAdaptiveThinkingCompat(agent: OnPayloadHost): void {
+  const inner = agent.onPayload
+  agent.onPayload = async (payload, model) => {
+    const effective = inner === undefined ? payload : ((await inner(payload, model)) ?? payload)
+    return rewriteThinkingForAdaptiveOnlyModels(effective, model)
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -38,6 +38,7 @@ import { materializeSkills } from '@/plugin'
 import type { ReloadRegistry } from '@/reload'
 import type { Stream } from '@/stream'
 
+import { applyAdaptiveThinkingCompat } from './adaptive-thinking-compat'
 import { getAuthFor } from './auth'
 import { createCompactionSettingsManager } from './compaction'
 import { renderGitNudge } from './git-nudge'
@@ -490,6 +491,13 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
       return converted
     }
   }
+
+  // Same seam, one hook later: layer the adaptive-thinking rewrite over pi's
+  // onPayload so Sonnet 5 / Fable 5 never receive the budget-based `thinking`
+  // payload the pinned pi-ai 0.67.3 emits for them (a hard 400 — see
+  // adaptive-thinking-compat.ts). Covers every provider call path through the
+  // agent, including model switches mid-session.
+  applyAdaptiveThinkingCompat(session.agent)
 
   abortHolder.abort = (reason?: string) => {
     if (reason !== undefined) abortHolder.reason = reason

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1262,12 +1262,14 @@ describe('recommended models', () => {
     const sonnet = model('anthropic/claude-sonnet-4-6', { modelName: 'Claude Sonnet 4.6' })
     const opus47 = model('anthropic/claude-opus-4-7', { modelName: 'Claude Opus 4.7' })
     const opus48 = model('anthropic/claude-opus-4-8', { modelName: 'Claude Opus 4.8' })
-    const sorted = sortRecommendedFirst([haiku, sonnet, opus47, opus48])
+    const fable5 = model('anthropic/claude-fable-5', { modelName: 'Claude Fable 5' })
+    const sorted = sortRecommendedFirst([haiku, sonnet, opus47, opus48, fable5])
     expect(sorted.map((o) => o.ref)).toEqual([
       'anthropic/claude-sonnet-4-6',
       'anthropic/claude-haiku-4-5',
       'anthropic/claude-opus-4-7',
       'anthropic/claude-opus-4-8',
+      'anthropic/claude-fable-5',
     ])
   })
 

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1260,13 +1260,15 @@ describe('recommended models', () => {
   test('sortRecommendedFirst floats the recommended Anthropic model to the top', () => {
     const haiku = model('anthropic/claude-haiku-4-5', { modelName: 'Claude Haiku 4.5' })
     const sonnet = model('anthropic/claude-sonnet-4-6', { modelName: 'Claude Sonnet 4.6' })
+    const sonnet5 = model('anthropic/claude-sonnet-5', { modelName: 'Claude Sonnet 5' })
     const opus47 = model('anthropic/claude-opus-4-7', { modelName: 'Claude Opus 4.7' })
     const opus48 = model('anthropic/claude-opus-4-8', { modelName: 'Claude Opus 4.8' })
     const fable5 = model('anthropic/claude-fable-5', { modelName: 'Claude Fable 5' })
-    const sorted = sortRecommendedFirst([haiku, sonnet, opus47, opus48, fable5])
+    const sorted = sortRecommendedFirst([haiku, sonnet, sonnet5, opus47, opus48, fable5])
     expect(sorted.map((o) => o.ref)).toEqual([
       'anthropic/claude-sonnet-4-6',
       'anthropic/claude-haiku-4-5',
+      'anthropic/claude-sonnet-5',
       'anthropic/claude-opus-4-7',
       'anthropic/claude-opus-4-8',
       'anthropic/claude-fable-5',

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -403,10 +403,11 @@ describe('listKnownModelRefs', () => {
     expect(refs).toContain('moonshot-coding/kimi-for-coding')
   })
 
-  test('includes the current Anthropic GA tier (Haiku 4.5 / Sonnet 4.6 / Opus 4.7 / Opus 4.8 / Fable 5)', () => {
+  test('includes the current Anthropic GA tier (Haiku 4.5 / Sonnet 4.6 / Sonnet 5 / Opus 4.7 / Opus 4.8 / Fable 5)', () => {
     const refs = listKnownModelRefs()
     expect(refs).toContain('anthropic/claude-haiku-4-5')
     expect(refs).toContain('anthropic/claude-sonnet-4-6')
+    expect(refs).toContain('anthropic/claude-sonnet-5')
     expect(refs).toContain('anthropic/claude-opus-4-7')
     expect(refs).toContain('anthropic/claude-opus-4-8')
     expect(refs).toContain('anthropic/claude-fable-5')
@@ -446,6 +447,10 @@ describe('providerForModelRef anthropic', () => {
     expect(providerForModelRef('anthropic/claude-opus-4-8')).toBe('anthropic')
   })
 
+  test('routes claude-sonnet-5 to anthropic', () => {
+    expect(providerForModelRef('anthropic/claude-sonnet-5')).toBe('anthropic')
+  })
+
   test('routes claude-fable-5 to anthropic', () => {
     expect(providerForModelRef('anthropic/claude-fable-5')).toBe('anthropic')
   })
@@ -469,6 +474,7 @@ describe('defaultThinkingLevelForRef', () => {
 
   test('non-OpenAI providers defer to the SDK default (returns undefined)', () => {
     expect(defaultThinkingLevelForRef('anthropic/claude-opus-4-8')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('anthropic/claude-sonnet-5')).toBeUndefined()
     expect(defaultThinkingLevelForRef('anthropic/claude-fable-5')).toBeUndefined()
     expect(defaultThinkingLevelForRef('zai/glm-4.6')).toBeUndefined()
     expect(defaultThinkingLevelForRef('moonshot/kimi-k2.5')).toBeUndefined()

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -403,12 +403,18 @@ describe('listKnownModelRefs', () => {
     expect(refs).toContain('moonshot-coding/kimi-for-coding')
   })
 
-  test('includes the current Anthropic GA tier (Haiku 4.5 / Sonnet 4.6 / Opus 4.7 / Opus 4.8)', () => {
+  test('includes the current Anthropic GA tier (Haiku 4.5 / Sonnet 4.6 / Opus 4.7 / Opus 4.8 / Fable 5)', () => {
     const refs = listKnownModelRefs()
     expect(refs).toContain('anthropic/claude-haiku-4-5')
     expect(refs).toContain('anthropic/claude-sonnet-4-6')
     expect(refs).toContain('anthropic/claude-opus-4-7')
     expect(refs).toContain('anthropic/claude-opus-4-8')
+    expect(refs).toContain('anthropic/claude-fable-5')
+  })
+
+  test('does not list the limited-availability claude-mythos-5', () => {
+    const refs = listKnownModelRefs()
+    expect(refs).not.toContain('anthropic/claude-mythos-5')
   })
 
   test('includes the current xai Grok models', () => {
@@ -439,6 +445,10 @@ describe('providerForModelRef anthropic', () => {
   test('routes claude-opus-4-8 to anthropic', () => {
     expect(providerForModelRef('anthropic/claude-opus-4-8')).toBe('anthropic')
   })
+
+  test('routes claude-fable-5 to anthropic', () => {
+    expect(providerForModelRef('anthropic/claude-fable-5')).toBe('anthropic')
+  })
 })
 
 describe('isOpenAiFamilyRef', () => {
@@ -459,6 +469,7 @@ describe('defaultThinkingLevelForRef', () => {
 
   test('non-OpenAI providers defer to the SDK default (returns undefined)', () => {
     expect(defaultThinkingLevelForRef('anthropic/claude-opus-4-8')).toBeUndefined()
+    expect(defaultThinkingLevelForRef('anthropic/claude-fable-5')).toBeUndefined()
     expect(defaultThinkingLevelForRef('zai/glm-4.6')).toBeUndefined()
     expect(defaultThinkingLevelForRef('moonshot/kimi-k2.5')).toBeUndefined()
   })

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -205,14 +205,18 @@ export const KNOWN_PROVIDERS = {
   // anthropic`) before relying on the env-var path. Same rule applies to any
   // future dual-auth provider — keep the surprise in mind when expanding.
   //
-  // Model lineup is the current GA tier as of 2026-05-29: Opus 4.8 (top,
-  // released May 2026), Opus 4.7 (prior top, Apr 16 2026), Sonnet 4.6 (mid,
-  // Feb 5 2026), Haiku 4.5 (fast, Oct 1 2025). Anthropic's own model overview
-  // lists the latest Opus/Sonnet/Haiku as the current recommended set and
-  // flags earlier Opus/Sonnet variants with
+  // Model lineup is the current GA tier as of 2026-07-02: Fable 5 (top,
+  // released Jun 2026 — a tier above Opus), Opus 4.8 (May 2026), Opus 4.7
+  // (Apr 16 2026), Sonnet 4.6 (mid, Feb 5 2026), Haiku 4.5 (fast, Oct 1
+  // 2025). Anthropic's own model overview lists the
+  // latest Fable/Opus/Sonnet/Haiku as the current recommended set and flags
+  // earlier Opus/Sonnet variants with
   // "Consider migrating to current models." Opus 4 / Sonnet 4 are deprecated
   // (retirement: Jun 15 2026); the 4.5/4.6 alternates remain Active but are
-  // not the recommended path.
+  // not the recommended path. Claude Mythos 5 (Fable 5's classifier-free
+  // sibling, limited availability via Project Glasswing) is intentionally
+  // NOT listed — access is gated per-org and a registry entry would fail for
+  // everyone else.
   //
   // ID semantics differ across the lineup and matter for forward-compat:
   //   - `claude-haiku-4-5` is a 4.5-generation CONVENIENCE ALIAS that
@@ -294,6 +298,23 @@ export const KNOWN_PROVIDERS = {
         reasoning: true,
         input: ['text', 'image'],
         cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      },
+      // Fable 5 (Jun 2026) is a NEW TIER above Opus — Anthropic's most
+      // capable widely released model, aimed at long-horizon agentic work.
+      // Ships the 5-generation tokenizer: ~1.3x token counts for the same
+      // text vs pre-5 models, so equivalent requests cost more than the
+      // per-token rates alone suggest.
+      'claude-fable-5': {
+        id: 'claude-fable-5',
+        name: 'Claude Fable 5',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
         contextWindow: 1000000,
         maxTokens: 128000,
       },

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -206,9 +206,9 @@ export const KNOWN_PROVIDERS = {
   // future dual-auth provider — keep the surprise in mind when expanding.
   //
   // Model lineup is the current GA tier as of 2026-07-02: Fable 5 (top,
-  // released Jun 2026 — a tier above Opus), Opus 4.8 (May 2026), Opus 4.7
-  // (Apr 16 2026), Sonnet 4.6 (mid, Feb 5 2026), Haiku 4.5 (fast, Oct 1
-  // 2025). Anthropic's own model overview lists the
+  // released Jun 2026 — a tier above Opus), Sonnet 5 (mid, Jul 1 2026),
+  // Opus 4.8 (May 2026), Opus 4.7 (Apr 16 2026), Sonnet 4.6 (Feb 5 2026),
+  // Haiku 4.5 (fast, Oct 1 2025). Anthropic's own model overview lists the
   // latest Fable/Opus/Sonnet/Haiku as the current recommended set and flags
   // earlier Opus/Sonnet variants with
   // "Consider migrating to current models." Opus 4 / Sonnet 4 are deprecated
@@ -277,6 +277,35 @@ export const KNOWN_PROVIDERS = {
         contextWindow: 1000000,
         maxTokens: 64000,
       },
+      // Sonnet 5 (Jul 1 2026) is the drop-in successor to Sonnet 4.6 with a
+      // caveat set that affects consumers of this record:
+      //   - New tokenizer: ~30% more tokens for the same text vs Sonnet 4.6.
+      //     Per-token price is unchanged, so equivalent requests cost more.
+      //   - Adaptive thinking only: manual extended thinking
+      //     (`thinking: {type: "enabled"}` with `budget_tokens`) returns a
+      //     400. The pinned pi-ai 0.67.3 DOES send that payload for this id
+      //     (its supportsAdaptiveThinking() only matches 4.6-generation ids,
+      //     and thinking defaults to "medium"), so registering this record
+      //     with `reasoning: true` depends on the rewrite shim in
+      //     src/agent/adaptive-thinking-compat.ts. Don't wire a
+      //     thinking-budget knob to this id.
+      //   - Cost encodes the STANDARD rate (in effect Sep 1 2026+).
+      //     Introductory pricing ($2/$10, cacheRead 0.2, cacheWrite 2.5) runs
+      //     through Aug 31 2026, so `typeclaw usage` over-reports Sonnet 5
+      //     spend until then. Chosen so the record doesn't silently go stale
+      //     two months after landing.
+      'claude-sonnet-5': {
+        id: 'claude-sonnet-5',
+        name: 'Claude Sonnet 5',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      },
       'claude-opus-4-7': {
         id: 'claude-opus-4-7',
         name: 'Claude Opus 4.7',
@@ -305,7 +334,10 @@ export const KNOWN_PROVIDERS = {
       // capable widely released model, aimed at long-horizon agentic work.
       // Ships the 5-generation tokenizer: ~1.3x token counts for the same
       // text vs pre-5 models, so equivalent requests cost more than the
-      // per-token rates alone suggest.
+      // per-token rates alone suggest. Adaptive thinking only, same as
+      // Sonnet 5 above: `reasoning: true` here depends on the rewrite shim
+      // in src/agent/adaptive-thinking-compat.ts (pinned pi-ai 0.67.3 would
+      // otherwise send budget-based `thinking`, a hard 400 on this id).
       'claude-fable-5': {
         id: 'claude-fable-5',
         name: 'Claude Fable 5',


### PR DESCRIPTION
## Background

The Anthropic provider lineup in `src/config/providers.ts` topped out at `claude-opus-4-8`. Anthropic has since shipped two new GA models that were unreachable as model refs — they never appeared in `listKnownModelRefs()`, the init picker, or anywhere a user could select them:

- **Claude Fable 5** (`claude-fable-5`, Jun 2026) — a new tier **above Opus**, Anthropic's most capable widely released model, priced at $10/$50 per MTok.
- **Claude Sonnet 5** (`claude-sonnet-5`, Jul 1 2026) — the drop-in successor to Sonnet 4.6, same $3/$15 standard per-token pricing.

The lineup comment documents the refresh discipline: 4.6+-generation dateless ids are **PINNED SNAPSHOTS**, not evergreen aliases, so new families ship under new ids rather than silently advancing existing ones. This PR is exactly that edit, twice — one commit per model, each independently revertable.

## Summary

**Commit 1 — `claude-fable-5`:** `anthropic-messages` API, text+image, 1M context, 128k max output, `input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5` (5m-TTL rate), per the published pricing table. The entry comment notes the 5-generation tokenizer's ~1.3x token-count effect on real request cost. Claude Mythos 5 (Fable 5's classifier-free sibling) is intentionally **not** registered — access is gated per-org via Project Glasswing, so a registry entry would fail for everyone else; a test pins that exclusion.

**Commit 2 — `claude-sonnet-5`:** additive next to `claude-sonnet-4-6` (which stays, per the pinned-snapshot policy). 1M context (default and max), 128k max output. Two deliberate calls documented in the entry comment:

- **Cost encodes the standard rate** ($3/$15, cacheRead 0.3, cacheWrite 3.75) that takes effect Sep 1 2026, not the introductory rate ($2/$10) that expires Aug 31 2026 — so the record doesn't go stale two months after landing. `typeclaw usage` over-reports Sonnet 5 spend until then.
- **Adaptive thinking only:** manual extended thinking (`thinking: {type: "enabled"}` + `budget_tokens`) returns a 400 upstream. pi-ai's default request shape doesn't send it, so nothing to change here — the comment fences future work from wiring a thinking-budget knob to this id.

Test coverage added in the same spots that already guard the existing lineup: `listKnownModelRefs` membership, `providerForModelRef` routing, `defaultThinkingLevelForRef` classification, the `sortRecommendedFirst` ordering test, plus the new Mythos-exclusion test.

## What this does NOT do

- Does **not** remove or deprecate any existing Anthropic model — all four prior entries keep resolving.
- Does **not** change the recommended model: `RECOMMENDED_MODEL_REFS` stays at `claude-sonnet-4-6` (one recommendation per provider). Sonnet 5 and Fable 5 sort below it in the picker.
- Does **not** register `claude-mythos-5` (limited availability, see above).
- Does **not** touch the `pi-ai` / `pi-coding-agent` SDK or any provider other than `anthropic`.

## Review notes

- The load-bearing changes are the two new model blocks in `src/config/providers.ts`; pricing/context/maxTokens are copied from Anthropic's published models overview and pricing table (Fable 5: $10/$50, cacheRead $1, cacheWrite $12.50; Sonnet 5: $3/$15, cacheRead $0.30, cacheWrite $3.75; both 1M context / 128k output).
- The Sonnet 5 standard-vs-introductory pricing call is the one judgment call worth a second opinion — flipping to the intro rate is a two-line change if reviewers prefer accurate `usage` numbers through Aug 31 over post-Sep-1 durability.
- JSON schemas regenerate via `postinstall` (`bun run generate:schema`); the generated files are untracked, so nothing to review there.
- Verification: `bun run typecheck` (0 errors), `bun run lint` (0 errors), `bun run format` (clean), and the full suite passes except two pre-existing, environment-dependent failures that reproduce identically on `main`: `require-parallel preload > allows bun test --parallel` (bun 1.3.11 lacks `BUN_TEST_WORKER_ID`) and one `ChannelRouter ensureLive watchdog` timing flake under serial full-suite runs (passes standalone). Both are unrelated to this change.
