### PR TITLE
feat(secrets): add file-based read half to RuntimeSecretsProvider

### DIFF
--- a/src/capabilities/runtime.ts
+++ b/src/capabilities/runtime.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { type RuntimeSecretsProvider, resolveRuntimeSecretsProvider } from '@/secrets/secrets-provider'
 
 // The container-stage capability bag: what the agent runtime (`typeclaw run`)
@@ -13,12 +15,16 @@ export type RuntimeCapabilities = {
   secrets: RuntimeSecretsProvider | null
 }
 
-// Composes the container-stage capabilities. Env is injectable for tests;
-// production omits it and reads `process.env`. (No profile param yet — secrets
-// resolution keys off the env triple; the deployment profile enters here when a
-// managed secrets impl selects on it.)
-export function createRuntimeCapabilities(env: NodeJS.ProcessEnv = process.env): RuntimeCapabilities {
+// Composes the container-stage capabilities. `secretsPath` is the mounted
+// secrets.json the runtime reads (defaults to <cwd>/secrets.json, which is
+// /agent/secrets.json in the container). Env is injectable for tests. (No
+// profile param yet — secrets resolution keys off the env triple; the
+// deployment profile enters here when a managed secrets impl selects on it.)
+export function createRuntimeCapabilities(
+  env: NodeJS.ProcessEnv = process.env,
+  secretsPath: string = join(process.cwd(), 'secrets.json'),
+): RuntimeCapabilities {
   return {
-    secrets: resolveRuntimeSecretsProvider(env),
+    secrets: resolveRuntimeSecretsProvider(env, secretsPath),
   }
 }

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -578,19 +578,24 @@ const TOKEN_ENV: Record<
 // buildAdapter skip the adapter instead of throwing and crashing the whole
 // channel manager. startAdapter's signature pre-check only reads secrets.json,
 // so this is the only place the missing triple is caught.
-function resolveHostProvider(env: NodeJS.ProcessEnv): RuntimeSecretsProvider | null {
+function resolveHostProvider(env: NodeJS.ProcessEnv, agentDir: string): RuntimeSecretsProvider | null {
   const hostdUrl = env.TYPECLAW_HOSTD_URL
   const restartToken = env.TYPECLAW_HOSTD_TOKEN
   const containerName = env.TYPECLAW_CONTAINER_NAME
   if (!hostdUrl || !restartToken || !containerName) return null
-  return createHostdSecretsProvider({ hostdUrl, restartToken, containerName })
+  return createHostdSecretsProvider({
+    hostdUrl,
+    restartToken,
+    containerName,
+    secretsPath: join(agentDir, 'secrets.json'),
+  })
 }
 
 function createContainerDiscordCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsDiscordCredentialStore | null {
-  const hostProvider = resolveHostProvider(env)
+  const hostProvider = resolveHostProvider(env, agentDir)
   if (hostProvider === null) return null
   return new SecretsDiscordCredentialStore({
     mode: 'container',
@@ -617,7 +622,7 @@ function createContainerSlackCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsSlackCredentialStore | null {
-  const hostProvider = resolveHostProvider(env)
+  const hostProvider = resolveHostProvider(env, agentDir)
   if (hostProvider === null) return null
   return new SecretsSlackCredentialStore({
     mode: 'container',
@@ -644,7 +649,7 @@ function createContainerWebexCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsWebexCredentialStore | null {
-  const hostProvider = resolveHostProvider(env)
+  const hostProvider = resolveHostProvider(env, agentDir)
   if (hostProvider === null) return null
   return new SecretsWebexCredentialStore({
     mode: 'container',
@@ -671,7 +676,7 @@ function createContainerKakaoCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsKakaoCredentialStore | null {
-  const hostProvider = resolveHostProvider(env)
+  const hostProvider = resolveHostProvider(env, agentDir)
   if (hostProvider === null) return null
   return new SecretsKakaoCredentialStore({
     mode: 'container',
@@ -698,7 +703,7 @@ function createContainerLineCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsLineCredentialStore | null {
-  const hostProvider = resolveHostProvider(env)
+  const hostProvider = resolveHostProvider(env, agentDir)
   if (hostProvider === null) return null
   return new SecretsLineCredentialStore({
     mode: 'container',
@@ -725,7 +730,7 @@ function createContainerInstagramCredentialStore(
   agentDir: string,
   env: NodeJS.ProcessEnv,
 ): SecretsInstagramCredentialStore | null {
-  const hostProvider = resolveHostProvider(env)
+  const hostProvider = resolveHostProvider(env, agentDir)
   if (hostProvider === null) return null
   return new SecretsInstagramCredentialStore({
     mode: 'container',

--- a/src/secrets/discord-store.ts
+++ b/src/secrets/discord-store.ts
@@ -55,7 +55,7 @@ export class SecretsDiscordCredentialStore {
 
   private readBlock(): DiscordChannelBlock {
     const channels =
-      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+      this.options.mode === 'container' ? this.options.hostProvider.readChannels() : this.backend.readChannelsSync()
     return parseBlock(channels?.discord)
   }
 

--- a/src/secrets/instagram-store.ts
+++ b/src/secrets/instagram-store.ts
@@ -61,7 +61,7 @@ export class SecretsInstagramCredentialStore {
 
   private readBlock(): InstagramChannelBlock {
     const channels =
-      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+      this.options.mode === 'container' ? this.options.hostProvider.readChannels() : this.backend.readChannelsSync()
     return parseBlock(channels?.instagram)
   }
 

--- a/src/secrets/kakao-store.container-mode.test.ts
+++ b/src/secrets/kakao-store.container-mode.test.ts
@@ -75,6 +75,7 @@ describe('SecretsKakaoCredentialStore container mode', () => {
           hostdUrl: 'http://127.0.0.1:1',
           restartToken: 'secret',
           containerName: 'coder',
+          secretsPath,
         }),
       })
 
@@ -98,6 +99,7 @@ describe('SecretsKakaoCredentialStore container mode', () => {
           hostdUrl: hostd.url,
           restartToken: 'secret',
           containerName: 'coder',
+          secretsPath,
         }),
       })
 
@@ -124,6 +126,7 @@ describe('SecretsKakaoCredentialStore container mode', () => {
           hostdUrl: hostd.url,
           restartToken: 'secret',
           containerName: 'coder',
+          secretsPath,
         }),
       })
 
@@ -149,6 +152,7 @@ describe('SecretsKakaoCredentialStore container mode', () => {
           hostdUrl: hostd.url,
           restartToken: 'wrong',
           containerName: 'coder',
+          secretsPath,
         }),
       })
 

--- a/src/secrets/kakao-store.ts
+++ b/src/secrets/kakao-store.ts
@@ -101,7 +101,7 @@ export class SecretsKakaoCredentialStore {
 
   private readBlock(): KakaoChannelBlock {
     const channels =
-      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+      this.options.mode === 'container' ? this.options.hostProvider.readChannels() : this.backend.readChannelsSync()
     const raw = channels?.kakaotalk
     return parseBlock(raw)
   }

--- a/src/secrets/line-store.test.ts
+++ b/src/secrets/line-store.test.ts
@@ -122,6 +122,7 @@ describe('SecretsLineCredentialStore container mode', () => {
           hostdUrl: `http://127.0.0.1:${server.port}`,
           restartToken: token,
           containerName,
+          secretsPath,
         }),
       })
       await store.setAccount(account('mid-1'))

--- a/src/secrets/line-store.ts
+++ b/src/secrets/line-store.ts
@@ -63,7 +63,7 @@ export class SecretsLineCredentialStore {
 
   private readBlock(): LineChannelBlock {
     const channels =
-      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+      this.options.mode === 'container' ? this.options.hostProvider.readChannels() : this.backend.readChannelsSync()
     return parseBlock(channels?.line)
   }
 

--- a/src/secrets/secrets-provider.test.ts
+++ b/src/secrets/secrets-provider.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import type { Request, Response } from '@/hostd/protocol'
 
-import { createHostdSecretsProvider } from './secrets-provider'
+import { createFileSecretsProvider, createHostdSecretsProvider } from './secrets-provider'
+import { SecretsBackend } from './storage'
 
 const servers: Array<ReturnType<typeof Bun.serve>> = []
 
@@ -30,7 +34,12 @@ function startFakeHostd(token: string, containerName: string): { url: string; re
 describe('createHostdSecretsProvider', () => {
   test('forwards the block as a secrets-patch RPC with Bearer auth', async () => {
     const hostd = startFakeHostd('secret', 'coder')
-    const provider = createHostdSecretsProvider({ hostdUrl: hostd.url, restartToken: 'secret', containerName: 'coder' })
+    const provider = createHostdSecretsProvider({
+      hostdUrl: hostd.url,
+      restartToken: 'secret',
+      containerName: 'coder',
+      secretsPath: '/nonexistent/secrets.json',
+    })
 
     await provider.writeBackChannelBlock({ discord: { currentAccount: null, accounts: {} } })
 
@@ -44,11 +53,70 @@ describe('createHostdSecretsProvider', () => {
 
   test('throws when hostd rejects the patch', async () => {
     const hostd = startFakeHostd('secret', 'coder')
-    const provider = createHostdSecretsProvider({ hostdUrl: hostd.url, restartToken: 'wrong', containerName: 'coder' })
+    const provider = createHostdSecretsProvider({
+      hostdUrl: hostd.url,
+      restartToken: 'wrong',
+      containerName: 'coder',
+      secretsPath: '/nonexistent/secrets.json',
+    })
 
     await expect(provider.writeBackChannelBlock({ discord: { currentAccount: null, accounts: {} } })).rejects.toThrow(
       /secrets-patch failed/,
     )
+  })
+
+  test('reads channels from the mounted secrets.json', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-secrets-provider-'))
+    try {
+      const secretsPath = join(root, 'secrets.json')
+      const backend = new SecretsBackend(secretsPath)
+      await backend.updateChannelsAsync(async () => ({
+        result: undefined,
+        next: { discord: { currentAccount: 'd1', accounts: {} } },
+      }))
+      const provider = createHostdSecretsProvider({
+        hostdUrl: 'http://127.0.0.1:1',
+        restartToken: 'secret',
+        containerName: 'coder',
+        secretsPath,
+      })
+
+      expect(provider.readChannels()?.discord).toEqual({ currentAccount: 'd1', accounts: {} })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('reads null when the mounted secrets.json is absent', () => {
+    const provider = createHostdSecretsProvider({
+      hostdUrl: 'http://127.0.0.1:1',
+      restartToken: 'secret',
+      containerName: 'coder',
+      secretsPath: '/nonexistent/secrets.json',
+    })
+    expect(provider.readChannels()).toBeNull()
+  })
+})
+
+describe('createFileSecretsProvider', () => {
+  test('round-trips a channel block through the file (read after write)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'typeclaw-file-provider-'))
+    try {
+      const secretsPath = join(root, 'secrets.json')
+      new SecretsBackend(secretsPath).writeChannelsSync({})
+      const provider = createFileSecretsProvider(secretsPath)
+
+      await provider.writeBackChannelBlock({ discord: { currentAccount: 'd1', accounts: {} } })
+
+      expect(provider.readChannels()?.discord).toEqual({ currentAccount: 'd1', accounts: {} })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('reads null when the file is absent', () => {
+    const provider = createFileSecretsProvider('/nonexistent/secrets.json')
+    expect(provider.readChannels()).toBeNull()
   })
 })
 

--- a/src/secrets/secrets-provider.ts
+++ b/src/secrets/secrets-provider.ts
@@ -1,18 +1,26 @@
 import { sendHttp } from '@/hostd/client'
 import type { Request } from '@/hostd/protocol'
 
+import type { Channels } from './schema'
+import { SecretsBackend } from './storage'
+
 // The channel-block payload a container-mode store hands off to be persisted.
 // Identical to the `secrets-patch` RPC's `patch.channels` union so the hostd
 // implementation forwards it verbatim — the on-the-wire contract is unchanged
 // by this abstraction.
 export type ChannelBlockPatch = Extract<Request, { kind: 'secrets-patch' }>['patch']['channels']
 
-// The container-stage secrets write-back seam. The container cannot write the
-// (host-owned) secrets.json directly, so credential stores delegate write-back
-// through this. Named for what the runtime NEEDS, not the transport that serves
-// it: today hostd (HTTP RPC), tomorrow a persistent volume or a platform secret
-// store — all behind the same method.
+// The container-stage secrets seam. Named for what the runtime NEEDS, not the
+// transport that serves it. Two halves:
+//   read  — the whole channels slice (callers extract their own adapter block).
+//           Returns null when secrets.json is absent, so callers degrade rather
+//           than crash. File-based today (a mounted secrets.json); a managed
+//           impl (volume / secret store) slots in behind the same method.
+//   write — persist one adapter's block. The container cannot write the
+//           host-owned file directly under hostd, so this may cross a transport
+//           (secrets-patch RPC); under a volume it's a direct file write.
 export interface RuntimeSecretsProvider {
+  readChannels(): Channels | null
   writeBackChannelBlock(channels: ChannelBlockPatch): Promise<void>
 }
 
@@ -20,12 +28,21 @@ export type HostdSecretsProviderOptions = {
   hostdUrl: string
   restartToken: string
   containerName: string
+  // The mounted secrets.json the container READS from. Writes go through hostd
+  // (secrets-patch RPC) to avoid concurrent-writer corruption; reads are the
+  // live bind-mounted file, so this path is needed here.
+  secretsPath: string
 }
 
-// Wraps today's behavior: a `secrets-patch` RPC over HTTP to hostd
-// (host.docker.internal), Bearer-authed by the per-container restart token.
+// The container-under-hostd provider: reads the mounted secrets.json directly,
+// writes back via a `secrets-patch` RPC over HTTP to hostd (host.docker.internal),
+// Bearer-authed by the per-container restart token.
 export function createHostdSecretsProvider(options: HostdSecretsProviderOptions): RuntimeSecretsProvider {
+  const backend = new SecretsBackend(options.secretsPath)
   return {
+    readChannels(): Channels | null {
+      return backend.tryReadChannelsSync()
+    },
     async writeBackChannelBlock(channels: ChannelBlockPatch): Promise<void> {
       const response = await sendHttp(
         { kind: 'secrets-patch', containerName: options.containerName, patch: { channels } },
@@ -36,15 +53,34 @@ export function createHostdSecretsProvider(options: HostdSecretsProviderOptions)
   }
 }
 
-// Resolves the container-stage write-back provider from the environment. Returns
+// The file-backed provider: both halves hit the secrets.json on disk directly.
+// Used where the runtime owns the file (a mounted volume in a future managed
+// profile, or host-stage). No transport — writes merge the block into the file
+// under the same lock the reads use.
+export function createFileSecretsProvider(secretsPath: string): RuntimeSecretsProvider {
+  const backend = new SecretsBackend(secretsPath)
+  return {
+    readChannels(): Channels | null {
+      return backend.tryReadChannelsSync()
+    },
+    async writeBackChannelBlock(patch: ChannelBlockPatch): Promise<void> {
+      await backend.updateChannelsAsync(async (channels) => ({ result: undefined, next: { ...channels, ...patch } }))
+    },
+  }
+}
+
+// Resolves the container-stage secrets provider from the environment. Returns
 // null when the hostd triple is absent (daemon unreachable at launch, or a
 // managed profile with no write-back wired yet) — callers degrade gracefully
 // rather than crash. Today only the hostd-backed provider exists; a managed
 // impl (volume / secret store) is selected here when it lands.
-export function resolveRuntimeSecretsProvider(env: NodeJS.ProcessEnv): RuntimeSecretsProvider | null {
+export function resolveRuntimeSecretsProvider(
+  env: NodeJS.ProcessEnv,
+  secretsPath: string,
+): RuntimeSecretsProvider | null {
   const hostdUrl = env.TYPECLAW_HOSTD_URL
   const restartToken = env.TYPECLAW_HOSTD_TOKEN
   const containerName = env.TYPECLAW_CONTAINER_NAME
   if (!hostdUrl || !restartToken || !containerName) return null
-  return createHostdSecretsProvider({ hostdUrl, restartToken, containerName })
+  return createHostdSecretsProvider({ hostdUrl, restartToken, containerName, secretsPath })
 }

--- a/src/secrets/slack-store.ts
+++ b/src/secrets/slack-store.ts
@@ -55,7 +55,7 @@ export class SecretsSlackCredentialStore {
 
   private readBlock(): SlackChannelBlock {
     const channels =
-      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+      this.options.mode === 'container' ? this.options.hostProvider.readChannels() : this.backend.readChannelsSync()
     return parseBlock(channels?.slack)
   }
 

--- a/src/secrets/webex-store.ts
+++ b/src/secrets/webex-store.ts
@@ -60,7 +60,7 @@ export class SecretsWebexCredentialStore {
 
   private readBlock(): WebexChannelBlock {
     const channels =
-      this.options.mode === 'container' ? this.backend.tryReadChannelsSync() : this.backend.readChannelsSync()
+      this.options.mode === 'container' ? this.options.hostProvider.readChannels() : this.backend.readChannelsSync()
     return parseBlock(channels?.webex)
   }
 


### PR DESCRIPTION
> **Stacked on #1124** (`slice-a-capability-bags`). Base is that branch; merge #1124 first. Once it merges this retargets to `main`.

## What

Gives the container-stage secrets seam a **read** half (it previously only had write-back), **file-based only** — no ECS/K8s impl, just the interface + a file implementation, per scope.

- `RuntimeSecretsProvider.readChannels()` — returns the whole channels slice, or `null` when `secrets.json` is absent (callers degrade rather than crash).
- `createHostdSecretsProvider` now **reads the mounted `secrets.json` directly** (takes `secretsPath`) and still **writes via the `secrets-patch` RPC**. This unifies the container-under-hostd path: read = mounted file, write = RPC.
- `createFileSecretsProvider(secretsPath)` — both halves hit the file on disk (for a future volume-backed managed profile, or host-stage). No transport.
- The **6 credential stores** now read through `hostProvider.readChannels()` in container mode instead of a direct `SecretsBackend.tryReadChannelsSync()`.

## Why

This is the Slice-B piece of the capability-composition design (`.sisyphus/plans/capability-composition-architecture.md` §10): the container's *entire* secrets dependency — read and write — now goes through the one `RuntimeSecretsProvider` seam. Before this, container-mode stores wrote through the provider but read the mounted file directly (asymmetric). A future managed impl (volume / secret store) drops in behind the same two methods.

**Preparing the interface, file-based only** — as scoped. No managed/ECS/K8s implementation; `resolveDeploymentProfile()` still returns `host`.

## Scope

Routes the **6 stores** (the uniform, highest-frequency read surface). Deliberately does **not** touch the other container-stage read sites — the channel-manager signature builders, `hydrate.ts` (boot-time raw `readFileSync`), and `look-at.ts` (provider-key read, a *different* read shape). Those are separate follow-ups; provider-key reads warrant their own method when needed.

## Behavior change

None. Same bytes read from the same file; the container's read path just goes through the seam now, matching its write path. Host-mode reads stay on `SecretsBackend` directly.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — 10321 pass, 0 fail (4 new: hostd provider reads file + null-on-absent; file provider read-after-write + null-on-absent; container-mode store tests exercise read-through-provider end-to-end)