### PR TITLE
Track adaptive-thinking shim removal for the next pi migration

### DIFF
--- a/src/agent/adaptive-thinking-compat.ts
+++ b/src/agent/adaptive-thinking-compat.ts
@@ -1,15 +1,17 @@
 // Compatibility shim for adaptive-thinking-only Anthropic models on the
-// pinned pi stack (@mariozechner/* 0.67.3).
+// pinned pi stack (@mariozechner/* 0.73.x).
 //
 // The problem: Sonnet 5 and Fable 5 accept ONLY adaptive thinking. Manual
 // extended thinking (`thinking: {type: "enabled"}` with `budget_tokens`)
-// returns a 400. But pi-ai 0.67.3's `supportsAdaptiveThinking()` matches only
+// returns a 400. But pi-ai's `supportsAdaptiveThinking()` matches only
 // 4.6-generation ids (`opus-4-6`, `sonnet-4-6`), so for any OTHER Anthropic
 // model registered with `reasoning: true` it falls back to the budget-based
 // path — and thinking is on by default (pi-coding-agent's
 // DEFAULT_THINKING_LEVEL is "medium", and `defaultThinkingLevelForRef`
 // deliberately defers to it). Net effect without this shim: a session on
-// Sonnet 5 / Fable 5 400s on its first request.
+// Sonnet 5 / Fable 5 400s on its first request. Still true on 0.73.1: pi-ai
+// 0.73.1 does not force adaptive thinking for these ids, so bumping the
+// @mariozechner/* stack to 0.73 (PR #1123) did not obviate this shim.
 //
 // The fix: pi-ai calls `options.onPayload(params, model)` right before the
 // HTTP request and adopts a non-undefined return value as the request params
@@ -20,15 +22,21 @@
 // exactly the adaptive-only model ids. Everything else passes through
 // byte-identical.
 //
-// Not covered (deliberately): pi-ai 0.67.3 also sends the
+// Not covered (deliberately): pi-ai also sends the
 // `interleaved-thinking-2025-05-14` beta header for non-4.6 models. That
 // header is set at SDK-client construction, before `onPayload` runs, so this
 // shim can't remove it — it is redundant-but-harmless on adaptive models (the
 // API ignores it), unlike the budget `thinking` payload which hard-fails.
 //
-// DELETE THIS FILE when typeclaw migrates to @earendil-works/pi-* >= 0.80,
-// whose model records carry `compat: { forceAdaptiveThinking: true }` for
-// these ids and handle the rewrite inside the transport itself.
+// TODO(pi-migration): DELETE THIS FILE when typeclaw migrates off the
+// @mariozechner/pi-* 0.73.x line to @earendil-works/pi-* >= 0.80 (the same
+// maintainers' scope rename; @mariozechner ends at 0.73.1, @earendil-works
+// starts at 0.74.0). As of @earendil-works/pi-ai 0.80.3 the sonnet-5 / fable-5
+// model records carry `compat: { forceAdaptiveThinking: true }`, and the
+// Anthropic transport reads that flag to emit `thinking: {type: "adaptive"}`
+// itself (AnthropicMessagesCompat.forceAdaptiveThinking) — so on that stack the
+// rewrite here becomes redundant and both this file and its `onPayload` wiring
+// in `src/agent/index.ts` should be removed.
 
 import type { Api, Model } from '@mariozechner/pi-ai'
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -491,7 +491,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
 
   // Same seam, one hook later: layer the adaptive-thinking rewrite over pi's
   // onPayload so Sonnet 5 / Fable 5 never receive the budget-based `thinking`
-  // payload the pinned pi-ai 0.67.3 emits for them (a hard 400 — see
+  // payload the pinned pi-ai 0.73.x emits for them (a hard 400 — see
   // adaptive-thinking-compat.ts). Covers every provider call path through the
   // agent, including model switches mid-session.
   applyAdaptiveThinkingCompat(session.agent)

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -120,9 +120,8 @@ export const KNOWN_PROVIDERS = {
   // ChatGPT Plus/Pro subscription via the OAuth Codex backend. No API key
   // path here on purpose — the Codex backend is OAuth-only upstream.
   //
-  // pi-ai 0.73.1's `openai-codex` bucket carries gpt-5.5 (and 5.4) against
-  // chatgpt.com/backend-api. We pin pi-coding-agent ^0.67.3 today, which
-  // ships pi-ai 0.67.3 and lacks those entries — but we hand pi-ai a
+  // pi-ai's `openai-codex` bucket carries gpt-5.5 (and 5.4) against
+  // chatgpt.com/backend-api. We don't rely on that catalog: we hand pi-ai a
   // freshly-constructed `Model<>` literal via resolveModel(), bypassing its
   // built-in catalog entirely (same trick we use for kimi-k2p6-turbo). So
   // these ids work end-to-end as long as the Codex backend itself accepts
@@ -283,7 +282,7 @@ export const KNOWN_PROVIDERS = {
       //     Per-token price is unchanged, so equivalent requests cost more.
       //   - Adaptive thinking only: manual extended thinking
       //     (`thinking: {type: "enabled"}` with `budget_tokens`) returns a
-      //     400. The pinned pi-ai 0.67.3 DOES send that payload for this id
+      //     400. The pinned pi-ai 0.73.x DOES send that payload for this id
       //     (its supportsAdaptiveThinking() only matches 4.6-generation ids,
       //     and thinking defaults to "medium"), so registering this record
       //     with `reasoning: true` depends on the rewrite shim in
@@ -336,7 +335,7 @@ export const KNOWN_PROVIDERS = {
       // text vs pre-5 models, so equivalent requests cost more than the
       // per-token rates alone suggest. Adaptive thinking only, same as
       // Sonnet 5 above: `reasoning: true` here depends on the rewrite shim
-      // in src/agent/adaptive-thinking-compat.ts (pinned pi-ai 0.67.3 would
+      // in src/agent/adaptive-thinking-compat.ts (pinned pi-ai 0.73.x would
       // otherwise send budget-based `thinking`, a hard 400 on this id).
       'claude-fable-5': {
         id: 'claude-fable-5',


### PR DESCRIPTION
## Background

Follow-up to a review comment on the (merged) pi 0.73 upgrade, #1123: the reviewer asked us to leave a tracked TODO for the next pi migration so the adaptive-thinking compat shim (`src/agent/adaptive-thinking-compat.ts`, added in #1122) isn't forgotten, and confirmed that this PR's 0.73 bump did **not** obviate it.

I verified the reviewer's upstream claim against the published packages: `@earendil-works/pi-*` is the same maintainers' (Zechner / Ronacher) scope rename of `@mariozechner/pi-*` — `@mariozechner` ends at `0.73.1`, `@earendil-works` starts at `0.74.0`. As of `@earendil-works/pi-ai@0.80.3`, the `claude-sonnet-5` / `claude-fable-5` model records carry `compat: { forceAdaptiveThinking: true }` (`AnthropicMessagesCompat.forceAdaptiveThinking`, `boolean`), and the Anthropic transport reads that flag to emit `thinking: { type: "adaptive" }` itself — which makes our `onPayload` rewrite redundant on that stack.

## Summary

- Converts the shim's existing prose "DELETE THIS FILE when…" note into a **grep-able `TODO(pi-migration)`** marker with the concrete removal condition (migrate off `@mariozechner/pi-* 0.73.x` → `@earendil-works/pi-* >= 0.80`) and the exact upstream mechanism that replaces it, so the shim **and** its `onPayload` wiring in `src/agent/index.ts` get removed together during that migration.
- Refreshes now-stale pinned-version references from the pre-#1123 `0.67.3` to `0.73.x` in three places that describe the shim: the shim header, its wiring comment in `src/agent/index.ts`, and the `sonnet-5` / `fable-5` model records in `src/config/providers.ts`. Also drops a self-contradictory "we pin ^0.67.3 which lacks those entries" claim in the codex-provider comment (we bypass pi's catalog via a constructed `Model<>` literal regardless).

## What this does NOT do

- Does **not** perform the `@earendil-works` migration or remove the shim — that's the tracked follow-up. The shim is still required on the current `0.73.1` stack (pi-ai 0.73.1 does not force adaptive thinking for these ids).
- Comment/doc-only: no runtime behavior change. `adaptive-thinking-compat.test.ts` and the provider tests are unchanged and green.

## Review notes

- The load-bearing addition is the single `TODO(pi-migration)` line in `src/agent/adaptive-thinking-compat.ts` — grep for it at migration time.
- Everything else is version-string accuracy in existing comments.
