### PR TITLE
docs(internals): document the capability-composition architecture

### DIFF
--- a/docs/content/docs/concepts/architecture.mdx
+++ b/docs/content/docs/concepts/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: The three stages, the host daemon, the trust boundary
+description: The three stages, the host-side control plane, the trust boundary
 icon: Layers
 ---
 
@@ -16,16 +16,16 @@ TypeClaw runs code in three stages. Each stage has a different filesystem, a dif
 
 This split is what makes deployments boring. Nothing on the host changes when an agent restarts. Nothing in the container has authority over the host. The two communicate over narrow, typed channels.
 
-## The host daemon
+## The host-side control plane
 
-There are two problems that both want a long-lived host-side process:
+There are two problems that both want something on the host side that the container can reach:
 
 - **Auto port-forward.** When a dev server inside the container binds to `127.0.0.1:5173`, the user wants `http://localhost:5173` on the host to work. Docker's `-p` mapping can't reach loopback inside a container's netns. A userland proxy can — if the upstream side runs inside the container and the downstream side runs on the host.
-- **Container self-restart.** Sometimes the agent updates itself and wants to bounce its container. The container has no Docker access; some other process on the host has to call `docker stop` / `docker start`.
+- **Container self-restart.** Sometimes the agent updates itself and wants to bounce its container. The container has no Docker access; some other process has to call `docker stop` / `docker start`.
 
-Both reduce to "a host process the container can talk to." That's `hostd`. It's a singleton per host (not per agent), spawned automatically on first `typeclaw start`, survives container restarts, and serves every agent on the box.
+Both reduce to "a control plane the container talks to over narrow, typed channels." On a machine you control, that control plane is `hostd` — a singleton per host (not per agent), spawned automatically on first `typeclaw start`, surviving container restarts, serving every agent on the box. But `hostd` is one _implementation_, not the only shape: on a managed platform (ECS, K8s) the platform is the control plane and there is no `hostd`. The container asks for a capability — restart me, forward this port, persist this secret — and a profile-selected implementation answers. See [Capabilities](/docs/internals/capabilities) for the interface model that makes the container blind to which one.
 
-The CLI never sends signals based on PID — `typeclaw stop` deregisters via the Unix socket. The pidfile is a discovery hint, never a kill target, so PID reuse is safe.
+For the default `hostd` case, the CLI never sends signals based on PID — `typeclaw stop` deregisters via the Unix socket. The pidfile is a discovery hint, never a kill target, so PID reuse is safe.
 
 ## Why this matters
 

--- a/docs/content/docs/internals/capabilities.mdx
+++ b/docs/content/docs/internals/capabilities.mdx
@@ -1,0 +1,104 @@
+---
+title: Capabilities
+description: The Controller / RuntimeSecretsProvider seams, per-stage capability bags, functional-factory DI, and the host vs managed deployment profile
+icon: Blocks
+---
+
+`src/capabilities/` and the capability interfaces it composes (`src/container/controller.ts`, `src/secrets/secrets-provider.ts`) are how TypeClaw decomposes "the host" into swappable, per-environment capabilities. A deployment is a **composition** of capability implementations, not a monolithic mode. `hostd` is one such implementation of the host-side control plane, not the architecture itself — see [Host daemon](/docs/internals/hostd).
+
+## Why it exists
+
+Historically `hostd` fused every host-side responsibility the container needs: container lifecycle, secrets write-back, restart, port-forwarding, credential renewal. That fusion assumes typeclaw is the orchestrator on a machine it controls. In a managed environment (ECS, K8s) the platform owns orchestration and there is no `hostd`.
+
+The fix is to name each responsibility as its own interface, give it per-environment implementations, and select them at boot by deployment profile. The container then calls `caps.secrets?.writeBackChannelBlock(...)` regardless of whether hostd, a mounted volume, or a platform secret store serves it (`caps.secrets` is nullable — a missing backend skips the write, it doesn't crash). That invariance is what lets the same container run with or without a host.
+
+## The two roles
+
+Two orthogonal roles, each an independent axis:
+
+- **controller** — the external actuator that acts _on_ a container: `start` / `stop` / `status` / `logs` / `shell`. `src/container/controller.ts`. The container never holds one; the host stage does.
+- **host substrate** — what the container reaches _into_ for durable state. Today that's secrets read + write-back (`RuntimeSecretsProvider`, `src/secrets/secrets-provider.ts`).
+
+These are stage-disjoint on purpose (see [Architecture](/docs/concepts/architecture)): controller lives host-stage, substrate lives container-stage.
+
+## Two composition roots, one per stage
+
+The capability bags are per-stage, never merged — the stage boundary is a real security and process line. `src/capabilities/`:
+
+```
+ControlPlaneCapabilities   (host-stage; src/capabilities/control-plane.ts)
+  controller: Controller
+
+RuntimeCapabilities        (container-stage; src/capabilities/runtime.ts)
+  secrets: RuntimeSecretsProvider | null
+```
+
+Each is built by a factory that composes implementations for a `DeploymentProfile`:
+
+```ts
+createControlPlaneCapabilities(profile) => { controller: resolveController(profile) }
+createRuntimeCapabilities(env, secretsPath) => { secrets: resolveRuntimeSecretsProvider(env, secretsPath) }
+```
+
+The bag is built at the composition root and **specific capabilities are handed down** to the modules that need them. It is not a service locator — modules receive `caps.controller`, not the whole bag.
+
+## Cross-stage capabilities: client and server halves
+
+Secrets, restart, and port-forwarding are inherently cross-stage: a container-side **client** talks to a host-side **server** over a transport. They are modeled as _two_ contracts, never one object spanning both stages. The client contract names what the runtime needs, transport- and backend-agnostic.
+
+`RuntimeSecretsProvider` is the worked example (`src/secrets/secrets-provider.ts`):
+
+- `readChannels()` — reads the mounted `secrets.json` (file-based; `null` when absent so callers degrade rather than crash).
+- `writeBackChannelBlock(block)` — persists one adapter's block. Under hostd this crosses the `secrets-patch` RPC (the container can't write the host-owned file directly); under a volume it's a direct file write.
+
+Two implementations ship today:
+
+- `createHostdSecretsProvider` — reads the mounted file, writes via hostd's `secrets-patch` RPC.
+- `createFileSecretsProvider` — both halves hit the file on disk (for a future volume-backed managed profile, or host-stage).
+
+The six channel credential stores (`src/secrets/*-store.ts`) read _and_ write through this one seam in container mode; host mode still reads `SecretsBackend` directly.
+
+## The deployment profile
+
+`DeploymentProfile` is `'host' | 'managed'` (`src/container/controller.ts`). `resolveDeploymentProfile()` is the single source of truth. There is no managed runtime yet, so it always returns `'host'`; the seam exists so that when a managed platform lands, the trigger (a platform-injected env var or config field) is wired in _one_ place.
+
+Today only the **controller axis** consumes the profile: `createControlPlaneCapabilities()` resolves it and passes it to `resolveController(profile)`. The **runtime secrets axis** does _not_ take a profile yet — `createRuntimeCapabilities(env, secretsPath)` keys off the hostd env triple via `resolveRuntimeSecretsProvider`, and the deployment profile enters there only when a managed secrets implementation lands.
+
+`resolveController(profile)` maps it to an actuator: `host` → `createLocalDockerController` (shells out to Docker), `managed` → `createNoopController` (every verb fail-loud, since the platform owns the loop).
+
+## Functional factories, not classes
+
+Every capability is an exported factory (`create*` / `resolve*`) returning an object literal that satisfies an exported `type` / `interface`. No classes for DI, no framework, no service locator — this matches the repo-wide convention (`*Deps` / `*Options` bags, `defaultDeps` constants). New capability seams follow this; don't reintroduce the class idiom.
+
+## Components
+
+`src/container/controller.ts`:
+
+- `Controller` — the lifecycle interface (`start`/`stop`/`status`/`logs`/`shell`).
+- `createLocalDockerController` — thin adapter over the existing `src/container/{start,stop,status,logs,shell}.ts` functions. No behavior change; it just names the actuation surface.
+- `createNoopController` — the managed placeholder. Lifecycle verbs return `CONTROLLER_UNSUPPORTED_REASON`; `status()` reports `missing`.
+- `DeploymentProfile`, `resolveDeploymentProfile`, `resolveController`.
+
+`src/secrets/secrets-provider.ts`:
+
+- `RuntimeSecretsProvider` — the container-stage secrets seam (read + write-back).
+- `createHostdSecretsProvider`, `createFileSecretsProvider`, `resolveRuntimeSecretsProvider`.
+
+`src/capabilities/`:
+
+- `control-plane.ts` — `ControlPlaneCapabilities` + `createControlPlaneCapabilities`.
+- `runtime.ts` — `RuntimeCapabilities` + `createRuntimeCapabilities`.
+
+## Rules of thumb
+
+- **Name contracts for the need, not the transport.** `RuntimeSecretsProvider`, not `HostProvider` — the container must not know whether hostd or a secret store serves it. The rename that fixed exactly this is why the interface reads the way it does.
+- **Never model a cross-stage capability as one object.** Split into a container-side client contract and a host/platform-side server. In managed mode the server half becomes a platform primitive and the client is reconfigured to reach it; the runtime call sites don't change.
+- **The bag is per-stage.** `ControlPlaneCapabilities` is host-stage, `RuntimeCapabilities` is container-stage. Don't merge them — that would hand container code a controller it can't use.
+- **Build the bag at the root; hand specific capabilities down.** Not a service locator. A module that needs the controller takes a `Controller`, not the whole `ControlPlaneCapabilities`.
+- **Extract a capability into an interface on-trigger, not speculatively.** The trigger is: a second implementation exists, the capability crosses a stage boundary, or the composition root needs to hide platform selection. Extracting against a single caller bakes hostd-isms into a supposedly neutral interface.
+- **`managed` stays a single value until behavior diverges.** Split to `'ecs' | 'k8s'` only when an implementation actually differs by platform.
+- **The runtime call sites are the invariant.** Across every profile composition, `caps.secrets?.writeBackChannelBlock(...)` / `caps.controller.stop(...)` never change — only the injected implementations swap. That property is what "run the container without a host" reduces to.
+
+## Not yet done
+
+The bags are defined but **not yet threaded through the composition roots** (`startAgentRuntime` in `src/run/index.ts`, `startDaemon` wiring in `src/cli/hostd.ts`) — those still hold collaborators as locals. Only two capabilities are extracted (`Controller`, `RuntimeSecretsProvider`); restart, port-forwarding, credential renewal, and ingress remain hostd-owned until their managed halves are built. There is no ECS/K8s implementation — the interfaces are prepared, file-based, ahead of the concrete platform work.

--- a/docs/content/docs/internals/hostd.mdx
+++ b/docs/content/docs/internals/hostd.mdx
@@ -4,7 +4,7 @@ description: Singleton host-stage daemon, three trust channels, the control prot
 icon: Server
 ---
 
-`src/hostd/` is a singleton host-stage daemon owning host-side capabilities the running container needs: the **supervisor** (restart), the **port broker** (delegated to `src/portbroker/`), and the **KakaoTalk renewal cron**. Singleton per host, not per agent. Only persistent host-side process; only persistent host-stage state (`~/.typeclaw/`). New host-side capabilities plug in as `src/hostd/<capability>-manager.ts` glue + a `src/<capability>/` module + an optional `DaemonOptions` callback. **Don't add new daemons.**
+`src/hostd/` is a singleton host-stage daemon: **one implementation of the host-side control plane** in the `host` deployment profile (see [Capabilities](/docs/internals/capabilities)). It provides the host-side capabilities the running container needs: the **supervisor** (restart), the **port broker** (delegated to `src/portbroker/`), and the **credential renewal crons** (KakaoTalk and Webex). Singleton per host, not per agent. Only persistent host-side process; only persistent host-stage state (`~/.typeclaw/`). A managed deployment (ECS/K8s) has no `hostd` — the platform provides these capabilities instead. New capabilities are named as interfaces and composed via `src/capabilities/`; a hostd-backed one adds `src/hostd/<capability>-manager.ts` glue + a `src/<capability>/` module + an optional `DaemonOptions` callback. **Don't add new daemons.**
 
 ## Why it exists
 
@@ -82,5 +82,5 @@ NDJSON over the Unix socket. Connection-per-request. Kinds: `register`, `deregis
 - **Wire-protocol changes to `/portbroker` require a container restart.** Bun has no hot-reload. Same as TUI protocol.
 - **CLI never SIGTERMs by PID.** `stop` deregisters via socket; pidfile is a discovery hint. Drift respawn uses `shutdown` RPC + socket-file polling. If it doesn't honor shutdown within 5s, hard failure — never escalate to signals.
 - **Daemon-source drift is detected, not assumed.** `_hostd` loads `src/` once at boot; without the version probe, every fix to daemon logic was silently a no-op until manual `pkill`. Portbroker source is part of the fingerprint.
-- **Trust boundaries scale per channel.** Unix socket → UID via 0600. HTTP → containerName + Bearer token. WS → brokerToken. New cross-container capabilities need new RPC kinds with explicit auth, not wider mounts.
+- **Trust boundaries scale per channel.** Unix socket → UID via 0600. HTTP → containerName + Bearer token. WS → brokerToken. A new capability served _by hostd_ adds a new RPC kind with explicit auth, not wider mounts — but the capability itself is defined as an interface in [Capabilities](/docs/internals/capabilities); hostd is just its `host`-profile implementation.
 - **Persistence is per-container.** One file per registration; corrupt files skip one container, not all. CLI never writes these — only hostd does, inside `runSerially(name)`.

--- a/docs/content/docs/internals/index.mdx
+++ b/docs/content/docs/internals/index.mdx
@@ -14,7 +14,8 @@ Read here before changing a subsystem. Skim here when something doesn't behave t
 - [Memory](/docs/internals/memory) — the observe/dream/apply loop, topic shards, the strength model, supersession, and the citation-superset invariant.
 - [Secrets](/docs/internals/secrets) — `.env` vs `secrets.json` policy, the `Secret` shape, bridge idempotency, KakaoTalk encryption-at-rest.
 - [Permissions](/docs/internals/permissions) — role resolution, the match-rule DSL, cron/subagent provenance, the security guard tier model.
-- [Host daemon (hostd)](/docs/internals/hostd) — singleton process, three trust channels (Unix socket / HTTP / WebSocket), the control protocol, portbroker internals.
+- [Capabilities](/docs/internals/capabilities) — the Controller and RuntimeSecretsProvider seams, per-stage capability bags, functional-factory DI, the host vs managed deployment profile.
+- [Host daemon (hostd)](/docs/internals/hostd) — one implementation of the host-side control plane: singleton process, three trust channels (Unix socket / HTTP / WebSocket), the control protocol, portbroker internals.
 - [Tunnels](/docs/internals/tunnels) — schema, providers, why cloudflared runs in-container, integration with channel adapters.
 - [Message stream](/docs/internals/message-stream) — four typed targets, subagent dispatch, the cron split, wire-protocol contracts with the TUI.
 - [Engagement](/docs/internals/engagement) — the four-way inbound decision, the `observe` context buffer, the suppressor ladder, the peer-bot loop guard.

--- a/docs/content/docs/internals/meta.json
+++ b/docs/content/docs/internals/meta.json
@@ -7,6 +7,7 @@
     "memory",
     "secrets",
     "permissions",
+    "capabilities",
     "hostd",
     "tunnels",
     "message-stream",


### PR DESCRIPTION
## What

Adds the internals doc for the capability-composition architecture shipped across #1118–#1125, and reframes the docs that the work made stale.

- **New** `docs/content/docs/internals/capabilities.mdx` — the `Controller` and `RuntimeSecretsProvider` seams, the two per-stage capability bags (`src/capabilities/`), functional-factory DI, cross-stage client/server contracts, and the host vs managed `DeploymentProfile`. Registered in the internals sidebar (after Permissions) and the index list.
- **Reframed** `internals/hostd.mdx` and `concepts/architecture.mdx` — hostd is now presented as **one implementation of the host-side control plane**, not the architecture itself. Managed platforms provide their own; the container is blind to which. Both cross-link the new Capabilities page.

## Why

We shipped a load-bearing subsystem change (how the host/container boundary is abstracted) across six merged PRs, but it lived only in `.sisyphus/plans/` (a planning artifact) plus scattered code comments. AGENTS.md's architecture table already listed `src/capabilities/` with a dangling `/docs/internals/capabilities` link — this closes it. Per AGENTS.md, `docs/internals` is edited when subsystem behavior changes.

The architecture is stable enough to document now: the interfaces are merged and settled, not in flux.

## Scope

Docs only. No code changes. Follows the internals house style (terse, file-path-heavy, one-liner open → why → components → rules of thumb; "load-bearing"/"on-trigger" idioms). The new page is honest about what's NOT done — the bags aren't threaded through the composition roots yet, only two capabilities are extracted, no ECS/K8s impl exists.

## Verification

- `bun run build` (docs) — clean (EXIT 0; MDX compiles, all internal cross-links resolve, sidebar order valid)
- docs `bun run lint` / `format` — clean
- root `bun run typecheck` / `lint` / `format:check` / `test` — clean (10341 pass, 0 fail); docs-only change, no code touched