### PR TITLE
refactor(channels): resolve the secrets provider once at the composition root

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { AgentSession } from '@/agent'
+import { createFileSecretsProvider } from '@/secrets/secrets-provider'
 
 import { createChannelManager } from './manager'
 import { defaultHistoryConfig, type ChannelAdapterConfig, type ChannelsConfig } from './schema'
@@ -581,6 +582,7 @@ describe('channel manager — slack adapter lifecycle', () => {
       agentDir,
       channelsConfigRef: () => cfg,
       env,
+      secretsProvider: createFileSecretsProvider(join(agentDir, 'secrets.json')),
       createSlackUserAdapter: () => {
         constructed = true
         return fake
@@ -1017,6 +1019,7 @@ describe('channel manager — kakaotalk credential preflight', () => {
       agentDir,
       channelsConfigRef: () => cfg,
       env: kakaoEnv,
+      secretsProvider: createFileSecretsProvider(join(agentDir, 'secrets.json')),
       createKakaotalkAdapter: () => fake,
     })
 
@@ -1069,6 +1072,7 @@ describe('channel manager — kakaotalk credential preflight', () => {
       agentDir,
       channelsConfigRef: () => cfg,
       env: kakaoEnv,
+      secretsProvider: createFileSecretsProvider(join(agentDir, 'secrets.json')),
       createKakaotalkAdapter: () => fake,
     })
 
@@ -1090,6 +1094,7 @@ describe('channel manager — kakaotalk credential preflight', () => {
       agentDir,
       channelsConfigRef: () => cfg,
       env: kakaoEnv,
+      secretsProvider: createFileSecretsProvider(join(agentDir, 'secrets.json')),
       createKakaotalkAdapter: () => fake,
     })
 
@@ -1111,6 +1116,7 @@ describe('channel manager — kakaotalk credential preflight', () => {
       agentDir,
       channelsConfigRef: () => cfg,
       env: kakaoEnv,
+      secretsProvider: createFileSecretsProvider(join(agentDir, 'secrets.json')),
       createKakaotalkAdapter: () => fake,
     })
 

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -7,7 +7,7 @@ import { SecretsDiscordCredentialStore } from '@/secrets/discord-store'
 import { SecretsInstagramCredentialStore } from '@/secrets/instagram-store'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
 import { SecretsLineCredentialStore } from '@/secrets/line-store'
-import { createHostdSecretsProvider, type RuntimeSecretsProvider } from '@/secrets/secrets-provider'
+import type { RuntimeSecretsProvider } from '@/secrets/secrets-provider'
 import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
 import { SecretsBackend } from '@/secrets/storage'
 import { SecretsWebexCredentialStore } from '@/secrets/webex-store'
@@ -67,6 +67,13 @@ export type ChannelManagerOptions = {
   aliasesRef?: () => readonly string[]
   logger?: ChannelManagerLogger
   env?: NodeJS.ProcessEnv
+  // The container-stage secrets provider for personal-account adapters
+  // (line/kakaotalk/slack/discord/webex/instagram write-back + read). Resolved
+  // ONCE at the composition root (createRuntimeCapabilities in src/run/index.ts)
+  // and threaded in here — the manager never resolves it from env itself. Null
+  // (or omitted) skips those adapters; see the note above the
+  // createContainer*CredentialStore factories.
+  secretsProvider?: RuntimeSecretsProvider | null
   // Production wiring passes a factory that builds sessions with the full
   // runtime plumbing (channelRouter, stream, plugins, reloadRegistry). When
   // omitted, the router falls back to a hollow factory that creates sessions
@@ -268,7 +275,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'line') {
-      const credentialsStore = createContainerLineCredentialStore(options.agentDir, env)
+      const credentialsStore = createContainerLineCredentialStore(options.agentDir, options.secretsProvider ?? null)
       if (credentialsStore === null) return null
       return createLine({
         router,
@@ -279,7 +286,10 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'instagram') {
-      const credentialsStore = createContainerInstagramCredentialStore(options.agentDir, env)
+      const credentialsStore = createContainerInstagramCredentialStore(
+        options.agentDir,
+        options.secretsProvider ?? null,
+      )
       if (credentialsStore === null) return null
       return createInstagram({
         router,
@@ -290,7 +300,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'kakaotalk') {
-      const credentialsStore = createContainerKakaoCredentialStore(options.agentDir, env)
+      const credentialsStore = createContainerKakaoCredentialStore(options.agentDir, options.secretsProvider ?? null)
       if (credentialsStore === null) return null
       return createKakaotalk({
         router,
@@ -301,7 +311,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'slack') {
-      const credentialsStore = createContainerSlackCredentialStore(options.agentDir, env)
+      const credentialsStore = createContainerSlackCredentialStore(options.agentDir, options.secretsProvider ?? null)
       if (credentialsStore === null) return null
       return createSlackUser({
         router,
@@ -312,7 +322,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'discord') {
-      const credentialsStore = createContainerDiscordCredentialStore(options.agentDir, env)
+      const credentialsStore = createContainerDiscordCredentialStore(options.agentDir, options.secretsProvider ?? null)
       if (credentialsStore === null) return null
       return createDiscordUser({
         router,
@@ -323,7 +333,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       })
     }
     if (name === 'webex') {
-      const credentialsStore = createContainerWebexCredentialStore(options.agentDir, env)
+      const credentialsStore = createContainerWebexCredentialStore(options.agentDir, options.secretsProvider ?? null)
       if (credentialsStore === null) return null
       return createWebex({
         router,
@@ -571,36 +581,21 @@ const TOKEN_ENV: Record<
   'webex-bot': ['WEBEX_BOT_TOKEN'],
 }
 
-// Personal-account adapters (line/kakaotalk/slack/discord/webex) need the hostd
-// triple the host CLI injects at `docker run` time, gated on a successful daemon
-// registration (src/container/start.ts). If the daemon wasn't reachable at
-// launch (e.g. a lost first-boot spawn race) the triple is absent; null lets
-// buildAdapter skip the adapter instead of throwing and crashing the whole
-// channel manager. startAdapter's signature pre-check only reads secrets.json,
-// so this is the only place the missing triple is caught.
-function resolveHostProvider(env: NodeJS.ProcessEnv, agentDir: string): RuntimeSecretsProvider | null {
-  const hostdUrl = env.TYPECLAW_HOSTD_URL
-  const restartToken = env.TYPECLAW_HOSTD_TOKEN
-  const containerName = env.TYPECLAW_CONTAINER_NAME
-  if (!hostdUrl || !restartToken || !containerName) return null
-  return createHostdSecretsProvider({
-    hostdUrl,
-    restartToken,
-    containerName,
-    secretsPath: join(agentDir, 'secrets.json'),
-  })
-}
-
+// Personal-account adapters (line/kakaotalk/slack/discord/webex) need a
+// container-stage secrets provider. It's resolved ONCE at the composition root
+// (createRuntimeCapabilities in src/run/index.ts) and threaded in via
+// `secretsProvider`; a null value (hostd triple absent — e.g. a lost first-boot
+// spawn race, or a managed profile with no write-back wired) lets buildAdapter
+// skip the adapter instead of crashing the whole channel manager.
 function createContainerDiscordCredentialStore(
   agentDir: string,
-  env: NodeJS.ProcessEnv,
+  secretsProvider: RuntimeSecretsProvider | null,
 ): SecretsDiscordCredentialStore | null {
-  const hostProvider = resolveHostProvider(env, agentDir)
-  if (hostProvider === null) return null
+  if (secretsProvider === null) return null
   return new SecretsDiscordCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostProvider,
+    hostProvider: secretsProvider,
   })
 }
 
@@ -620,14 +615,13 @@ function buildDiscordSignature(agentDir: string): { signature: string; missing: 
 
 function createContainerSlackCredentialStore(
   agentDir: string,
-  env: NodeJS.ProcessEnv,
+  secretsProvider: RuntimeSecretsProvider | null,
 ): SecretsSlackCredentialStore | null {
-  const hostProvider = resolveHostProvider(env, agentDir)
-  if (hostProvider === null) return null
+  if (secretsProvider === null) return null
   return new SecretsSlackCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostProvider,
+    hostProvider: secretsProvider,
   })
 }
 
@@ -647,14 +641,13 @@ function buildSlackSignature(agentDir: string): { signature: string; missing: st
 
 function createContainerWebexCredentialStore(
   agentDir: string,
-  env: NodeJS.ProcessEnv,
+  secretsProvider: RuntimeSecretsProvider | null,
 ): SecretsWebexCredentialStore | null {
-  const hostProvider = resolveHostProvider(env, agentDir)
-  if (hostProvider === null) return null
+  if (secretsProvider === null) return null
   return new SecretsWebexCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostProvider,
+    hostProvider: secretsProvider,
   })
 }
 
@@ -674,14 +667,13 @@ function buildWebexSignature(agentDir: string): { signature: string; missing: st
 
 function createContainerKakaoCredentialStore(
   agentDir: string,
-  env: NodeJS.ProcessEnv,
+  secretsProvider: RuntimeSecretsProvider | null,
 ): SecretsKakaoCredentialStore | null {
-  const hostProvider = resolveHostProvider(env, agentDir)
-  if (hostProvider === null) return null
+  if (secretsProvider === null) return null
   return new SecretsKakaoCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostProvider,
+    hostProvider: secretsProvider,
   })
 }
 
@@ -701,14 +693,13 @@ function buildKakaotalkSignature(agentDir: string): { signature: string; missing
 
 function createContainerLineCredentialStore(
   agentDir: string,
-  env: NodeJS.ProcessEnv,
+  secretsProvider: RuntimeSecretsProvider | null,
 ): SecretsLineCredentialStore | null {
-  const hostProvider = resolveHostProvider(env, agentDir)
-  if (hostProvider === null) return null
+  if (secretsProvider === null) return null
   return new SecretsLineCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostProvider,
+    hostProvider: secretsProvider,
   })
 }
 
@@ -728,14 +719,13 @@ function buildLineSignature(agentDir: string): { signature: string; missing: str
 
 function createContainerInstagramCredentialStore(
   agentDir: string,
-  env: NodeJS.ProcessEnv,
+  secretsProvider: RuntimeSecretsProvider | null,
 ): SecretsInstagramCredentialStore | null {
-  const hostProvider = resolveHostProvider(env, agentDir)
-  if (hostProvider === null) return null
+  if (secretsProvider === null) return null
   return new SecretsInstagramCredentialStore({
     mode: 'container',
     secretsPath: join(agentDir, 'secrets.json'),
-    hostProvider,
+    hostProvider: secretsProvider,
   })
 }
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
 import { createSession, createSessionWithDispose } from '@/agent'
@@ -24,6 +26,7 @@ import { clearTodosForOrigin, markRestartAbortPendingForOrigin } from '@/agent/t
 import { embed, warmEmbedder } from '@/bundled-plugins/memory/vector/embedder'
 import { buildStartupVectorIndex } from '@/bundled-plugins/memory/vector/startup'
 import { resolveCapOptionsFromConfig } from '@/bundled-plugins/tool-result-cap'
+import { createRuntimeCapabilities, type RuntimeCapabilities } from '@/capabilities'
 import {
   createChannelManager,
   createChannelsReloadable,
@@ -109,6 +112,10 @@ export type StartAgentOptions = {
   stream?: Stream
   createChannelManager?: ChannelManagerFactory
   createTunnelManager?: TunnelManagerFactory
+  // The container-stage capability bag. Defaults to createRuntimeCapabilities()
+  // over the real env + <cwd>/secrets.json. Injectable so tests can supply a
+  // fake secrets provider without touching process.env.
+  caps?: RuntimeCapabilities
 }
 
 export type StartAgentResult = {
@@ -168,6 +175,7 @@ async function startAgentRuntime(
     stream = createStream(),
     createChannelManager: createChannelManagerFor = createChannelManager,
     createTunnelManager: createTunnelManagerFor = createTunnelManager,
+    caps = createRuntimeCapabilities(process.env, join(cwd, 'secrets.json')),
   }: StartAgentOptions,
   registerBootCleanup: (cleanup: () => void | Promise<void>) => void,
 ): Promise<StartAgentResult> {
@@ -365,6 +373,7 @@ async function startAgentRuntime(
 
   const channelManager = createChannelManagerFor({
     agentDir: cwd,
+    secretsProvider: caps.secrets,
     channelsConfigRef: () => getConfig().channels,
     aliasesRef: () => getConfig().alias,
     tunnelUrlForChannel: (name) => resolveTunnelUrlForChannel(name, tunnelManager),


### PR DESCRIPTION
## What

Consolidates the container-stage `RuntimeSecretsProvider` from **six construction sites to one**. The channel manager built a provider once per personal-account adapter (discord/slack/webex/kakaotalk/line/instagram) — each reading the same `TYPECLAW_HOSTD_*` env triple via a private `resolveHostProvider()`. Now the provider is resolved once at the composition root and threaded in.

- `startAgentRuntime` (`src/run/index.ts`) assembles `RuntimeCapabilities` via `createRuntimeCapabilities(env, <cwd>/secrets.json)` and passes `caps.secrets` into the channel manager as `secretsProvider`. Injectable via `StartAgentOptions.caps` for tests.
- `ChannelManagerOptions` gains `secretsProvider?: RuntimeSecretsProvider | null`; the six `createContainer*CredentialStore` factories take the pre-resolved provider.
- `resolveHostProvider` is deleted. **The manager no longer reads `TYPECLAW_HOSTD_*` itself.**

## Why

This is the one piece of "thread the capability bags through the roots" that actually earns its keep (per an Oracle architecture review): the secrets provider had real duplication — six sites, identical inputs, a hidden `process.env` dependency. Consolidating removes drift and makes the wiring testable via injection.

**Deliberately NOT included** (Oracle flagged as premature ceremony / speculative until a managed profile exists):
- Collapsing the 14 per-command `resolveController()` calls — each CLI command is already its own process-level composition root; per-command resolution is correct.
- The preflight-before-resolveController reordering and the compose/init controller bypasses — these only matter once a managed profile is executable.

## Behavior change

None. `caps.secrets` resolves to exactly what the six `resolveHostProvider` calls produced (same env triple → same `HostdSecretsProvider`, or `null`). Null still skips the adapter — graceful degradation preserved. Host-mode reads and the token-based adapters (which read `env` directly, not the provider) are untouched.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — 10341 pass, 0 fail (manager container-mode tests updated to pass an explicit file-based `secretsProvider`; skip-tests unchanged)
- Confirmed: `grep TYPECLAW_HOSTD src/channels/manager.ts` → none; `resolveHostProvider` → gone.