### PR TITLE
feat(bench): coding-agent benchmark harness over the TUI websocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,11 +58,13 @@ auth.json
 /channels/
 /todo/
 
-# Bench: downloaded suites/datasets and per-project deps stay out of git.
-# /bench/results/ is intentionally tracked — the scores are the point.
+# Bench: downloaded suites/datasets, per-project deps, and per-run outputs stay
+# out of git. The results/ dir is kept (via .gitkeep) but run outputs are local.
 /bench/datasets/
 /bench/suites/
 /bench/node_modules/
 /bench/**/.venv/
 /bench/**/__pycache__/
+/bench/results/*
+!/bench/results/.gitkeep
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,11 @@ auth.json
 /channels/
 /todo/
 
+# Bench: downloaded suites/datasets and per-project deps stay out of git.
+# /bench/results/ is intentionally tracked — the scores are the point.
+/bench/datasets/
+/bench/suites/
+/bench/node_modules/
+/bench/**/.venv/
+/bench/**/__pycache__/
+

--- a/bench/.oxfmtrc.json
+++ b/bench/.oxfmtrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 120,
+  "semi": false,
+  "useTabs": false,
+  "singleQuote": true,
+  "sortImports": {},
+  "ignorePatterns": ["suites/**", "datasets/**", "results/**", "node_modules/**"]
+}

--- a/bench/Dockerfile
+++ b/bench/Dockerfile
@@ -1,0 +1,21 @@
+FROM oven/bun:1-slim
+
+# Python (for Harbor / Terminal-Bench scoring) lives INSIDE the image so it never
+# touches the host — the "no machine clutter" guarantee. Suites are cloned at
+# pinned commits into gitignored bench/suites/ at run time, not baked in.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git ca-certificates python3 python3-venv python3-pip python-is-python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/bench-venv
+ENV PATH="/opt/bench-venv/bin:$PATH"
+RUN python3 -m venv "$VIRTUAL_ENV"
+
+WORKDIR /bench
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+ENTRYPOINT ["bun", "run"]
+CMD ["coding/run.ts"]

--- a/bench/README.md
+++ b/bench/README.md
@@ -8,7 +8,7 @@ Design + rationale: [issue #1128](https://github.com/typeclaw/typeclaw/issues/11
 
 Docker + Bun only — both already required by typeclaw. All Python lives inside the bench container; datasets and cloned suites stay in gitignored dirs, never `$HOME`. Teardown: `docker compose down` + `rm -rf datasets suites`.
 
-## `coding/` — Seam A: drive the running agent over its TUI websocket
+## `coding/` — drive the running agent over its TUI websocket
 
 Benchmarks the **whole real agent** by connecting to `typeclaw tui`'s websocket exactly as the TUI does — send a task prompt, read the event stream to `{ type: 'done' }`. No server changes, no harness reconstruction. Comparable to Hermes / opencode / Goose / Claude Code on the same tasks.
 
@@ -18,10 +18,19 @@ Start a typeclaw agent (so its container is up), then:
 
 ```sh
 bun install
-bun run coding/run.ts --container <container-name> --prompt "Fix the failing test in foo.ts"
+
+# ad-hoc single turn — prints text, tool calls, token/cost usage as JSON
+bun run coding/run.ts --container <name> --prompt "Fix the failing test in foo.ts"
+
+# score a task suite (N runs each, pass@1 + pass^k), writes JSON to results/
+bun run coding/run.ts --container <name> --suite ./suites/mytasks --runs 3
 ```
 
-The runner discovers the host port (`docker port <c> 8973/tcp`) and TUI token (`docker inspect` label) itself, connects, and prints the agent's text, tool calls, and token/cost usage as JSON.
+The runner discovers the host port (`docker port <c> 8973/tcp`) and TUI token (`docker inspect` label) itself.
+
+A **task** is a directory: `instruction.md` (the prompt), an optional `task.json` (verify command + timeout), and a verifier script. The agent works inside its own container at `/agent`, so the verifier runs **there** (`docker cp` the task in, then `docker exec` the verify command) — not on the host. Each task runs `k` times; the scorer reports **pass@1** (first run) and **pass^k** (all runs passed — the reliability metric).
+
+> Isolation caveat: a single reused container is fine for validating the harness, but a _meaningful_ multi-task number needs a fresh agent per task (cross-task memory/workspace bleed otherwise). Per-task provisioning is the next slice.
 
 ### Test
 
@@ -51,6 +60,6 @@ bench/
 
 ## Roadmap
 
-- **`coding/`** _(this slice)_ — websocket adapter, done. Next: wire Terminal-Bench-2 tasks + programmatic verifier via Harbor.
+- **`coding/`** _(this slice)_ — websocket adapter + scoring loop (task → run → container verifier → pass^k → report), done. Next: per-task agent provisioning + vendor Terminal-Bench-2 tasks via Harbor for comparable numbers.
 - **`memory/`** — LongMemEval / LoCoMo with dreaming ON vs OFF. Answerer = Fireworks; judge = OpenAI (separate family).
 - **`ablation/`** _(optional)_ — bare pi + one typeclaw component toggled, for per-component deltas.

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,56 @@
+# bench
+
+Local benchmarks for measuring **typeclaw's** intelligence — the agent (harness + memory + tools), not the underlying model. Self-contained sibling project: its own `package.json` and `tsconfig.json`, excluded from the root typecheck and the published package (same isolation as `docs/`).
+
+Design + rationale: [issue #1128](https://github.com/typeclaw/typeclaw/issues/1128).
+
+## Host footprint
+
+Docker + Bun only — both already required by typeclaw. All Python lives inside the bench container; datasets and cloned suites stay in gitignored dirs, never `$HOME`. Teardown: `docker compose down` + `rm -rf datasets suites`.
+
+## `coding/` — Seam A: drive the running agent over its TUI websocket
+
+Benchmarks the **whole real agent** by connecting to `typeclaw tui`'s websocket exactly as the TUI does — send a task prompt, read the event stream to `{ type: 'done' }`. No server changes, no harness reconstruction. Comparable to Hermes / opencode / Goose / Claude Code on the same tasks.
+
+### Run against a live agent
+
+Start a typeclaw agent (so its container is up), then:
+
+```sh
+bun install
+bun run coding/run.ts --container <container-name> --prompt "Fix the failing test in foo.ts"
+```
+
+The runner discovers the host port (`docker port <c> 8973/tcp`) and TUI token (`docker inspect` label) itself, connects, and prints the agent's text, tool calls, and token/cost usage as JSON.
+
+### Test
+
+```sh
+bun test          # adapter contract: connect → prompt → done, against a real ws server
+bun run typecheck
+bun run lint
+bun run format
+```
+
+## Layout
+
+```
+bench/
+├── coding/
+│   ├── client.ts             # connect → prompt → collect → first done
+│   ├── docker-discovery.ts   # host port + TUI token from docker
+│   ├── protocol.ts           # local mirror of the TUI wire subset
+│   ├── run.ts                # CLI entry
+│   └── *.test.ts
+├── Dockerfile                # oven/bun:1-slim + in-image python venv
+├── compose.yml
+├── datasets/                 # gitignored — downloaded task sets
+├── suites/                   # gitignored — third-party suites, pinned commits
+└── results/                  # tracked — the scores
+```
+
+## Roadmap
+
+- **`coding/`** _(this slice)_ — websocket adapter, done. Next: wire Terminal-Bench-2 tasks + programmatic verifier via Harbor.
+- **`memory/`** — LongMemEval / LoCoMo with dreaming ON vs OFF. Answerer = Fireworks; judge = OpenAI (separate family).
+- **`ablation/`** _(optional)_ — bare pi + one typeclaw component toggled, for per-component deltas.

--- a/bench/bun.lock
+++ b/bench/bun.lock
@@ -1,0 +1,122 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@typeclaw/bench",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@typescript/native-preview": "^7.0.0-dev.20260416.1",
+        "oxfmt": "^0.45.0",
+        "oxlint": "^1.60.0",
+      },
+    },
+  },
+  "packages": {
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.45.0", "", { "os": "android", "cpu": "arm" }, "sha512-A/UMxFob1fefCuMeGxQBulGfFE38g2Gm23ynr3u6b+b7fY7/ajGbNsa3ikMIkGMLJW/TRoQaMoP1kME7S+815w=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.45.0", "", { "os": "android", "cpu": "arm64" }, "sha512-L63z4uZmHjgvvqvMJD7mwff8aSBkM0+X4uFr6l6U5t6+Qc9DCLVZWIunJ7Gm4fn4zHPdSq6FFQnhu9yqqobxIg=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.45.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UV34dd623FzqT+outIGndsCA/RBB+qgB3XVQhgmmJ9PJwa37NzPC9qzgKeOhPKxVk2HW+JKldQrVL54zs4Noww=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.45.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-pMNJv0CMa1pDefVPeNbuQxibh8ITpWDFEhMC/IBB9Zlu76EbgzYwrzI4Cb11mqX2+rIYN70UTrh3z06TM59ptQ=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.45.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-xTcRoxbbo61sW2+ZRPeH+vp/o9G8gkdhiVumFU+TpneiPm14c79l6GFlxPXlCE9bNWikigbsrvJw46zCVAQFfg=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.45.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hWL8Hdni+3U1mPFx1UtWeGp3tNb6EhBAUHRMbKUxVkOp3WwoJbpVO2bfUVbS4PfpledviXXNHSTl1veTa6FhkQ=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.45.0", "", { "os": "linux", "cpu": "arm" }, "sha512-6Blt/0OBT7vvfQpqYuYbpbFLPqSiaYpEJzUUWhinPEuADypDbtV1+LdjM0vYBNGPvnj85ex7lTerEX6JGcPt9w=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.45.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jLjoLfe+hGfjhA8hNBSdw85yCA8ePKq7ME4T+g6P9caQXvmt6IhE2X7iVjnVdkmYUWEzZrxlh4p6RkDmAMJY/A=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.45.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-XQKXZIKYJC3GQJ8FnD3iMntpw69Wd9kDDK/Xt79p6xnFYlGGxSNv2vIBvRTDg5CKByWFWWZLCRDOXoP/m6YN4g=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.45.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+g5RiG+xOkdrCWkKodv407nTvMq4vYM18Uox2MhZBm/YoqFxxJpWKsloskFFG5NU13HGPw1wzYjjOVcyd9moCA=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.45.0", "", { "os": "linux", "cpu": "none" }, "sha512-V7dXKoSyEbWAkkSF4JJNtF+NJZDmJoSarSoP30WCsB3X636Rehd3CvxBj49FIJxEBFWhvcUjGSHVeU8Erck1bQ=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.45.0", "", { "os": "linux", "cpu": "none" }, "sha512-Vdelft1sAEYojVGgcODEFXSWYQYlIvoyIGWebKCuUibd1tvS1TjTx413xG2ZLuHpYj45CkN/ztMLMX6jrgqpgg=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.45.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-RR7xKgNpqwENnK0aYCGYg0JycY2n93J0reNjHyes+I9Gq52dH95x+CBlnlAQHCPfz6FGnKA9HirgUl14WO6o7w=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.45.0", "", { "os": "linux", "cpu": "x64" }, "sha512-U/QQ0+BQNSHxjuXR/utvXnQ50Vu5kUuqEomZvQ1/3mhgbBiMc2WU9q5kZ5WwLp3gnFIx9ibkveoRSe2EZubkqg=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.45.0", "", { "os": "linux", "cpu": "x64" }, "sha512-o5TLOUCF0RWQjsIS06yVC+kFgp092/yLe6qBGSUvtnmTVw9gxjpdQSXc3VN5Cnive4K11HNstEZF8ROKHfDFSw=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.45.0", "", { "os": "none", "cpu": "arm64" }, "sha512-RnGcV3HgPuOjsGx/k9oyRNKmOp+NBLGzZTdPDYbc19r7NGeYPplnUU/BfU35bX2Y/O4ejvHxcfkvW2WoYL/gsg=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.45.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-v3Vj7iKKsUFwt9w5hsqIIoErKVoENC6LoqfDlteOQ5QMDCXihlqLoxpmviUhXnNncg4zV6U9BPwlBbwa+qm4wg=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.45.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-N8yotPBX6ph0H3toF4AEpdCeVPrdcSetj+8eGiZGsrLsng3bs/Q5HPu4bbSxip5GBPx5hGbGHrZwH4+rcrjhHA=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.45.0", "", { "os": "win32", "cpu": "x64" }, "sha512-w5MMTRCK1dpQeRA+HHqXQXyN33DlG/N2LOYxJmaT4fJjcmZrbNnqw7SmIk7I2/a2493PPLZ+2E/Ar6t2iKVMug=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.72.0", "", { "os": "android", "cpu": "arm" }, "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.72.0", "", { "os": "android", "cpu": "arm64" }, "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.72.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.72.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.72.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.72.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.72.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.72.0", "", { "os": "none", "cpu": "arm64" }, "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.72.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.72.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.72.0", "", { "os": "win32", "cpu": "x64" }, "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260701.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260701.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260701.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260701.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260701.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260701.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260701.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260701.1" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-eXPtWsAj0s06kHWVDlBj7ABwoyNDHuW2gCbQ+bYGlyymDYteiAydelhyhyzUsenzGraPLdd/OPwEUB8/KUdpBw=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260701.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rm3v+3Mcrj91NPwG0mjaLfbJjydCDX/skF82cQw0K6XWsEK7wHmpLEF1xPOWGnV05RhTYJac9VoKUjgcADkbXA=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260701.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-jtbtV3A+cmkmDuqs56Qj3Hb+NmOAMHFX+FTLhCagJybjsng1lOl1h8vYaYg3F6EMgSiZI66hIpB9TMi3n8jFEw=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260701.1", "", { "os": "linux", "cpu": "arm" }, "sha512-c22PWjLMecd2xsAZRlpC1mnr8GZUjnFS32URPd2NhKOEx/6Dp7bPZvI+7NNXDXTew/fkgAaZvhLTWHGG64gqGw=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260701.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-SPEfXZhCRff6kPYrqJIkKkKBy1rxPk0Wmam7U0AOuMQtXTNPmqCtx54J/F6nfGR89ATTDTDr69MujFAG+lFQVg=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260701.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Y9NX6qGOCQD4zdCXJCABB8TL3IkFsWVlwMQ3OGtQ8A/OzyIFN01QyHWFgB5AJFZQoasryb+nnhu9r2IY5KpBwA=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260701.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-7IRD34O2Kp7mIplQEC/HgLyehmKL1FGlTYhlAqxxZfKhSt694yytd2dCCnxMMA/aPHjcqBke04wNPOOhQ2ezcA=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260701.1", "", { "os": "win32", "cpu": "x64" }, "sha512-zVfayHxvFZAQ0hJbegDcfhJamyQpLn6ahMDATAra+EkA3+/nbTW3VjCJ3h1V2PSNTY9rTPzGroFURV5cvErh3A=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "oxfmt": ["oxfmt@0.45.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.45.0", "@oxfmt/binding-android-arm64": "0.45.0", "@oxfmt/binding-darwin-arm64": "0.45.0", "@oxfmt/binding-darwin-x64": "0.45.0", "@oxfmt/binding-freebsd-x64": "0.45.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.45.0", "@oxfmt/binding-linux-arm-musleabihf": "0.45.0", "@oxfmt/binding-linux-arm64-gnu": "0.45.0", "@oxfmt/binding-linux-arm64-musl": "0.45.0", "@oxfmt/binding-linux-ppc64-gnu": "0.45.0", "@oxfmt/binding-linux-riscv64-gnu": "0.45.0", "@oxfmt/binding-linux-riscv64-musl": "0.45.0", "@oxfmt/binding-linux-s390x-gnu": "0.45.0", "@oxfmt/binding-linux-x64-gnu": "0.45.0", "@oxfmt/binding-linux-x64-musl": "0.45.0", "@oxfmt/binding-openharmony-arm64": "0.45.0", "@oxfmt/binding-win32-arm64-msvc": "0.45.0", "@oxfmt/binding-win32-ia32-msvc": "0.45.0", "@oxfmt/binding-win32-x64-msvc": "0.45.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-0o/COoN9fY50bjVeM7PQsNgbhndKurBIeTIcspW033OumksjJJmIVDKjAk5HMwU/GHTxSOdGDdhJ6BRzGPmsHg=="],
+
+    "oxlint": ["oxlint@1.72.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.72.0", "@oxlint/binding-android-arm64": "1.72.0", "@oxlint/binding-darwin-arm64": "1.72.0", "@oxlint/binding-darwin-x64": "1.72.0", "@oxlint/binding-freebsd-x64": "1.72.0", "@oxlint/binding-linux-arm-gnueabihf": "1.72.0", "@oxlint/binding-linux-arm-musleabihf": "1.72.0", "@oxlint/binding-linux-arm64-gnu": "1.72.0", "@oxlint/binding-linux-arm64-musl": "1.72.0", "@oxlint/binding-linux-ppc64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-musl": "1.72.0", "@oxlint/binding-linux-s390x-gnu": "1.72.0", "@oxlint/binding-linux-x64-gnu": "1.72.0", "@oxlint/binding-linux-x64-musl": "1.72.0", "@oxlint/binding-openharmony-arm64": "1.72.0", "@oxlint/binding-win32-arm64-msvc": "1.72.0", "@oxlint/binding-win32-ia32-msvc": "1.72.0", "@oxlint/binding-win32-x64-msvc": "1.72.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/bench/coding/client.test.ts
+++ b/bench/coding/client.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { runTask } from './client'
+import type { BenchServerMessage } from './protocol'
+
+type FakeServer = {
+  url: string
+  stop: () => void
+}
+
+const servers: FakeServer[] = []
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop()
+})
+
+function startFakeServer(script: BenchServerMessage[]): string {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return undefined
+      return new Response('expected websocket', { status: 426 })
+    },
+    websocket: {
+      open(ws) {
+        ws.send(JSON.stringify({ type: 'connected', sessionId: 'test-session' }))
+      },
+      message(ws, raw) {
+        const parsed = JSON.parse(String(raw)) as { type: string }
+        if (parsed.type !== 'prompt') return
+        for (const message of script) ws.send(JSON.stringify(message))
+      },
+    },
+  })
+  const url = `ws://127.0.0.1:${server.port}`
+  servers.push({ url, stop: () => server.stop(true) })
+  return url
+}
+
+describe('runTask', () => {
+  test('collects text, tool calls, and usage up to the first done', async () => {
+    const url = startFakeServer([
+      { type: 'prompt_started', messageId: 'm1', text: 'go' },
+      { type: 'text_delta', delta: 'Hello ' },
+      { type: 'text_delta', delta: 'world' },
+      { type: 'tool_start', toolCallId: 't1', name: 'bash', args: { cmd: 'ls' } },
+      { type: 'tool_end', toolCallId: 't1', name: 'bash', error: false, result: 'ok', durationMs: 12 },
+      { type: 'done', usage: { input: 10, output: 5, totalTokens: 15, cost: 0.001 } },
+    ])
+
+    const result = await runTask({ url, prompt: 'do the thing' })
+
+    expect(result.error).toBeNull()
+    expect(result.text).toBe('Hello world')
+    expect(result.toolCalls).toEqual([
+      { toolCallId: 't1', name: 'bash', args: { cmd: 'ls' }, result: 'ok', isError: false, durationMs: 12 },
+    ])
+    expect(result.usage).toEqual({ input: 10, output: 5, totalTokens: 15, cost: 0.001 })
+  })
+
+  test('stops at the first done and ignores a todo-continuation turn', async () => {
+    const url = startFakeServer([
+      { type: 'text_delta', delta: 'main turn' },
+      { type: 'done' },
+      { type: 'prompt_started', messageId: 'm2', text: 'continue' },
+      { type: 'text_delta', delta: 'CONTINUATION LEAK' },
+      { type: 'done' },
+    ])
+
+    const result = await runTask({ url, prompt: 'x' })
+
+    expect(result.text).toBe('main turn')
+    expect(result.text).not.toContain('CONTINUATION LEAK')
+  })
+
+  test('surfaces an error frame as a failed turn', async () => {
+    const url = startFakeServer([
+      { type: 'text_delta', delta: 'partial' },
+      { type: 'error', message: 'model exploded' },
+    ])
+
+    const result = await runTask({ url, prompt: 'x' })
+
+    expect(result.error).toBe('model exploded')
+    expect(result.text).toBe('partial')
+  })
+
+  test('times out the connect handshake against a non-listening url', async () => {
+    await expect(runTask({ url: 'ws://127.0.0.1:1', prompt: 'x', connectTimeoutMs: 200 })).rejects.toThrow()
+  })
+})

--- a/bench/coding/client.ts
+++ b/bench/coding/client.ts
@@ -1,0 +1,129 @@
+import { type BenchServerMessage, type BenchToolCall, type BenchUsage, isServerMessage } from './protocol'
+
+export type TurnResult = {
+  text: string
+  toolCalls: BenchToolCall[]
+  usage: BenchUsage | null
+  error: string | null
+}
+
+export type RunTaskOptions = {
+  url: string
+  prompt: string
+  connectTimeoutMs?: number
+  turnTimeoutMs?: number
+}
+
+export async function runTask(options: RunTaskOptions): Promise<TurnResult> {
+  const connectTimeoutMs = options.connectTimeoutMs ?? 10_000
+  const turnTimeoutMs = options.turnTimeoutMs ?? 600_000
+
+  const ws = new WebSocket(options.url)
+  const inbox = createInbox(ws)
+
+  try {
+    await inbox.waitFor((m) => m.type === 'connected', connectTimeoutMs, 'connected handshake')
+    ws.send(JSON.stringify({ type: 'prompt', text: options.prompt }))
+    return await collectTurn(inbox, turnTimeoutMs)
+  } finally {
+    ws.close()
+  }
+}
+
+// Collect the first turn's output. The agent's todo-continuation can enqueue a
+// follow-up turn after the user turn's `done`, so we stop at the FIRST `done` —
+// the user-facing result is already complete by then. `error` also terminates.
+async function collectTurn(inbox: Inbox, timeoutMs: number): Promise<TurnResult> {
+  const textChunks: string[] = []
+  const toolCalls = new Map<string, BenchToolCall>()
+
+  while (true) {
+    const message = await inbox.next(timeoutMs)
+
+    switch (message.type) {
+      case 'text_delta':
+        textChunks.push(String((message as { delta?: unknown }).delta ?? ''))
+        break
+      case 'tool_start': {
+        const m = message as Extract<BenchServerMessage, { type: 'tool_start' }>
+        toolCalls.set(m.toolCallId, { toolCallId: m.toolCallId, name: m.name, args: m.args })
+        break
+      }
+      case 'tool_end': {
+        const m = message as Extract<BenchServerMessage, { type: 'tool_end' }>
+        const existing = toolCalls.get(m.toolCallId)
+        toolCalls.set(m.toolCallId, {
+          toolCallId: m.toolCallId,
+          name: m.name,
+          args: existing?.args,
+          result: m.result,
+          isError: m.error,
+          durationMs: m.durationMs,
+        })
+        break
+      }
+      case 'done': {
+        const usage = (message as Extract<BenchServerMessage, { type: 'done' }>).usage ?? null
+        return { text: textChunks.join(''), toolCalls: [...toolCalls.values()], usage, error: null }
+      }
+      case 'error': {
+        const errorMessage = String((message as { message?: unknown }).message ?? 'unknown error')
+        return { text: textChunks.join(''), toolCalls: [...toolCalls.values()], usage: null, error: errorMessage }
+      }
+      default:
+        break
+    }
+  }
+}
+
+type Inbox = {
+  waitFor: (
+    predicate: (m: BenchServerMessage) => boolean,
+    timeoutMs: number,
+    label: string,
+  ) => Promise<BenchServerMessage>
+  next: (timeoutMs: number) => Promise<BenchServerMessage>
+}
+
+function createInbox(ws: WebSocket): Inbox {
+  const buffer: BenchServerMessage[] = []
+  const waiters: { resolve: (m: BenchServerMessage) => void }[] = []
+
+  ws.addEventListener('message', (event) => {
+    const parsed: unknown = JSON.parse(String((event as MessageEvent).data))
+    if (!isServerMessage(parsed)) return
+    const waiter = waiters.shift()
+    if (waiter) waiter.resolve(parsed)
+    else buffer.push(parsed)
+  })
+
+  const take = (timeoutMs: number, label: string): Promise<BenchServerMessage> => {
+    const buffered = buffer.shift()
+    if (buffered) return Promise.resolve(buffered)
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`timed out after ${timeoutMs}ms waiting for ${label}`)),
+        timeoutMs,
+      )
+      waiters.push({
+        resolve: (m) => {
+          clearTimeout(timer)
+          resolve(m)
+        },
+      })
+    })
+  }
+
+  return {
+    next: (timeoutMs) => take(timeoutMs, 'server message'),
+    waitFor: async (predicate, timeoutMs, label) => {
+      const deadline = Date.now() + timeoutMs
+      while (true) {
+        const remaining = deadline - Date.now()
+        if (remaining <= 0) throw new Error(`timed out after ${timeoutMs}ms waiting for ${label}`)
+        const message = await take(remaining, label)
+        if (predicate(message)) return message
+      }
+    },
+  }
+}

--- a/bench/coding/docker-discovery.test.ts
+++ b/bench/coding/docker-discovery.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+
+import { parseDockerPortOutput, resolveHostPort, resolveTuiToken } from './docker-discovery'
+
+describe('parseDockerPortOutput', () => {
+  test('prefers the IPv4 mapping over IPv6', () => {
+    expect(parseDockerPortOutput('0.0.0.0:49160\n:::49160\n')).toBe(49160)
+  })
+
+  test('falls back to the first line when no IPv4 mapping exists', () => {
+    expect(parseDockerPortOutput('[::]:8080\n')).toBe(8080)
+  })
+
+  test('returns null on empty output', () => {
+    expect(parseDockerPortOutput('')).toBeNull()
+    expect(parseDockerPortOutput('\n  \n')).toBeNull()
+  })
+
+  test('returns null on an out-of-range port', () => {
+    expect(parseDockerPortOutput('0.0.0.0:99999')).toBeNull()
+  })
+})
+
+describe('resolveHostPort', () => {
+  test('parses the host port from a successful docker port call', async () => {
+    const exec = async () => ({ stdout: '0.0.0.0:49160\n:::49160\n', exitCode: 0 })
+    expect(await resolveHostPort('agent', exec)).toBe(49160)
+  })
+
+  test('throws when the container is not running', async () => {
+    const exec = async () => ({ stdout: '', exitCode: 1 })
+    await expect(resolveHostPort('agent', exec)).rejects.toThrow('not running')
+  })
+})
+
+describe('resolveTuiToken', () => {
+  test('returns the trimmed token label', async () => {
+    const exec = async () => ({ stdout: 'secret-token\n', exitCode: 0 })
+    expect(await resolveTuiToken('agent', exec)).toBe('secret-token')
+  })
+
+  test('throws when the label is absent', async () => {
+    const exec = async () => ({ stdout: '<no value>\n', exitCode: 0 })
+    await expect(resolveTuiToken('agent', exec)).rejects.toThrow('no TUI token')
+  })
+})

--- a/bench/coding/docker-discovery.ts
+++ b/bench/coding/docker-discovery.ts
@@ -1,0 +1,57 @@
+import { spawn } from 'node:child_process'
+
+export const CONTAINER_PORT = 8973
+export const TUI_TOKEN_LABEL = 'dev.typeclaw.tui-token'
+
+export type DockerExec = (args: string[]) => Promise<{ stdout: string; exitCode: number }>
+
+export async function resolveHostPort(containerName: string, exec: DockerExec = defaultDockerExec): Promise<number> {
+  const result = await exec(['port', containerName, `${CONTAINER_PORT}/tcp`])
+  if (result.exitCode !== 0) {
+    throw new Error(`container '${containerName}' not running or port ${CONTAINER_PORT} not published`)
+  }
+  const port = parseDockerPortOutput(result.stdout)
+  if (port === null) throw new Error(`could not parse host port from: ${result.stdout.trim()}`)
+  return port
+}
+
+export async function resolveTuiToken(containerName: string, exec: DockerExec = defaultDockerExec): Promise<string> {
+  const result = await exec(['inspect', '--format', `{{ index .Config.Labels "${TUI_TOKEN_LABEL}" }}`, containerName])
+  if (result.exitCode !== 0) throw new Error(`could not inspect container '${containerName}'`)
+  const token = result.stdout.trim()
+  if (token.length === 0 || token === '<no value>')
+    throw new Error(`no TUI token label on container '${containerName}'`)
+  return token
+}
+
+// Prefer an IPv4 mapping: `docker port` prints one line per bound address
+// (0.0.0.0:PORT, :::PORT, [::]:PORT) and localhost resolves to IPv4 first on
+// macOS/Linux. Mirrors src/container/port.ts#parseDockerPortOutput.
+export function parseDockerPortOutput(stdout: string): number | null {
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  if (lines.length === 0) return null
+
+  const ipv4 = lines.find((line) => /^\d{1,3}(\.\d{1,3}){3}:\d+$/.test(line))
+  const candidate = ipv4 ?? lines[0]
+  if (candidate === undefined) return null
+
+  const lastColon = candidate.lastIndexOf(':')
+  if (lastColon < 0) return null
+  const port = Number(candidate.slice(lastColon + 1))
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null
+  return port
+}
+
+const defaultDockerExec: DockerExec = (args) =>
+  new Promise((resolve, reject) => {
+    const child = spawn('docker', args, { stdio: ['ignore', 'pipe', 'ignore'] })
+    let stdout = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.on('error', reject)
+    child.on('close', (code) => resolve({ stdout, exitCode: code ?? 1 }))
+  })

--- a/bench/coding/fixtures/example-task/instruction.md
+++ b/bench/coding/fixtures/example-task/instruction.md
@@ -1,0 +1,1 @@
+Create a file named `output.txt` in the current directory containing exactly the word `done`.

--- a/bench/coding/fixtures/example-task/task.json
+++ b/bench/coding/fixtures/example-task/task.json
@@ -1,0 +1,4 @@
+{
+  "verify": ["bash", "verify.sh"],
+  "timeoutMs": 30000
+}

--- a/bench/coding/fixtures/example-task/verify.sh
+++ b/bench/coding/fixtures/example-task/verify.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+test "$(cat output.txt 2>/dev/null)" = "done"

--- a/bench/coding/protocol.ts
+++ b/bench/coding/protocol.ts
@@ -1,0 +1,35 @@
+// Duplicated from src/shared/protocol.ts (not imported) to keep bench/ a
+// self-contained sibling with no compile coupling to src/, mirroring docs/.
+
+export type BenchClientMessage = { type: 'prompt'; text: string } | { type: 'abort' }
+
+export type BenchUsage = {
+  input: number
+  output: number
+  totalTokens: number
+  cost: number
+}
+
+export type BenchToolCall = {
+  toolCallId: string
+  name: string
+  args: unknown
+  result?: unknown
+  isError?: boolean
+  durationMs?: number
+}
+
+export type BenchServerMessage =
+  | { type: 'connected'; sessionId: string; serverVersion?: string }
+  | { type: 'prompt_started'; messageId: string; text: string }
+  | { type: 'text_delta'; delta: string }
+  | { type: 'tool_start'; toolCallId: string; name: string; args: unknown }
+  | { type: 'tool_end'; toolCallId: string; name: string; error: boolean; result: unknown; durationMs: number }
+  | { type: 'done'; usage?: BenchUsage }
+  | { type: 'error'; message: string }
+  | { type: 'queue_state'; pending: { id: string; text: string; ts: number }[] }
+  | { type: string; [key: string]: unknown }
+
+export function isServerMessage(value: unknown): value is BenchServerMessage {
+  return typeof value === 'object' && value !== null && typeof (value as { type?: unknown }).type === 'string'
+}

--- a/bench/coding/report.test.ts
+++ b/bench/coding/report.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildReport } from './report'
+import type { TaskScore } from './score'
+
+const score = (taskId: string, passHatK: boolean, passRate: number): TaskScore => ({
+  taskId,
+  runs: 3,
+  passAt1: passRate > 0 ? 1 : 0,
+  passHatK,
+  passRate,
+  outcomes: [],
+})
+
+describe('buildReport', () => {
+  test('aggregates pass^k rate and mean pass rate across tasks', () => {
+    const report = buildReport({
+      suite: 'demo-suite',
+      container: 'agent',
+      runsPerTask: 3,
+      scores: [score('a', true, 1), score('b', false, 1 / 3)],
+    })
+
+    expect(report.passHatKRate).toBe(0.5)
+    expect(report.meanPassRate).toBeCloseTo((1 + 1 / 3) / 2)
+    expect(report.tasks).toHaveLength(2)
+    expect(report.container).toBe('agent')
+  })
+
+  test('handles an empty suite without dividing by zero', () => {
+    const report = buildReport({ suite: 'empty', container: 'agent', runsPerTask: 3, scores: [] })
+
+    expect(report.passHatKRate).toBe(0)
+    expect(report.meanPassRate).toBe(0)
+  })
+})

--- a/bench/coding/report.ts
+++ b/bench/coding/report.ts
@@ -1,0 +1,48 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { TaskScore } from './score'
+
+export type SuiteReport = {
+  suite: string
+  container: string
+  ranAt: string
+  runsPerTask: number
+  passHatKRate: number
+  meanPassRate: number
+  tasks: { taskId: string; passAt1: number; passHatK: boolean; passRate: number }[]
+}
+
+export function buildReport(args: {
+  suite: string
+  container: string
+  runsPerTask: number
+  scores: TaskScore[]
+}): SuiteReport {
+  const { scores } = args
+  const passHatKCount = scores.filter((s) => s.passHatK).length
+  const meanPassRate = scores.length === 0 ? 0 : scores.reduce((sum, s) => sum + s.passRate, 0) / scores.length
+
+  return {
+    suite: args.suite,
+    container: args.container,
+    ranAt: new Date().toISOString(),
+    runsPerTask: args.runsPerTask,
+    passHatKRate: scores.length === 0 ? 0 : passHatKCount / scores.length,
+    meanPassRate,
+    tasks: scores.map((s) => ({
+      taskId: s.taskId,
+      passAt1: s.passAt1,
+      passHatK: s.passHatK,
+      passRate: s.passRate,
+    })),
+  }
+}
+
+export async function writeReport(resultsDir: string, report: SuiteReport): Promise<string> {
+  await mkdir(resultsDir, { recursive: true })
+  const stamp = report.ranAt.replace(/[:.]/g, '-')
+  const path = join(resultsDir, `${stamp}.json`)
+  await writeFile(path, JSON.stringify(report, null, 2) + '\n')
+  return path
+}

--- a/bench/coding/run.ts
+++ b/bench/coding/run.ts
@@ -1,0 +1,60 @@
+import { runTask } from './client'
+import { resolveHostPort, resolveTuiToken } from './docker-discovery'
+
+export type CodingRunArgs = {
+  container: string
+  prompt: string
+  host?: string
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const args = parseArgs(argv)
+  if (args === null) {
+    process.stderr.write('usage: bun run coding/run.ts --container <name> --prompt <text> [--host 127.0.0.1]\n')
+    return 2
+  }
+
+  const host = args.host ?? '127.0.0.1'
+  const port = await resolveHostPort(args.container)
+  const token = await resolveTuiToken(args.container)
+  const url = `ws://${host}:${port}?token=${token}`
+
+  const result = await runTask({ url, prompt: args.prompt })
+
+  process.stdout.write(
+    JSON.stringify(
+      {
+        error: result.error,
+        text: result.text,
+        toolCalls: result.toolCalls.map((call) => ({ name: call.name, isError: call.isError ?? false })),
+        usage: result.usage,
+      },
+      null,
+      2,
+    ) + '\n',
+  )
+  return result.error === null ? 0 : 1
+}
+
+function parseArgs(argv: string[]): CodingRunArgs | null {
+  const values = new Map<string, string>()
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i]
+    const value = argv[i + 1]
+    if (key === undefined || value === undefined || !key.startsWith('--')) return null
+    values.set(key.slice(2), value)
+  }
+  const container = values.get('container')
+  const prompt = values.get('prompt')
+  if (container === undefined || prompt === undefined) return null
+  return { container, prompt, host: values.get('host') }
+}
+
+if (import.meta.main) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err: unknown) => {
+      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`)
+      process.exit(1)
+    })
+}

--- a/bench/coding/run.ts
+++ b/bench/coding/run.ts
@@ -1,26 +1,35 @@
 import { runTask } from './client'
 import { resolveHostPort, resolveTuiToken } from './docker-discovery'
+import { buildReport, writeReport } from './report'
+import { scoreTask } from './score'
+import { loadTaskSuite } from './task'
+import { makeContainerWorkspaceProvider } from './workspace'
 
 export type CodingRunArgs = {
   container: string
-  prompt: string
   host?: string
+  prompt?: string
+  suite?: string
+  runs?: number
+  resultsDir?: string
 }
+
+const USAGE =
+  'usage: bun run coding/run.ts --container <name> (--prompt <text> | --suite <dir> [--runs 3] [--results ./results])\n'
 
 export async function main(argv: string[]): Promise<number> {
   const args = parseArgs(argv)
-  if (args === null) {
-    process.stderr.write('usage: bun run coding/run.ts --container <name> --prompt <text> [--host 127.0.0.1]\n')
+  if (args === null || (args.suite === undefined && args.prompt === undefined)) {
+    process.stderr.write(USAGE)
     return 2
   }
 
-  const host = args.host ?? '127.0.0.1'
-  const port = await resolveHostPort(args.container)
-  const token = await resolveTuiToken(args.container)
-  const url = `ws://${host}:${port}?token=${token}`
+  const url = await resolveUrl(args.container, args.host)
+  return args.suite !== undefined ? runSuite(args, url) : runSinglePrompt(args.prompt!, url)
+}
 
-  const result = await runTask({ url, prompt: args.prompt })
-
+async function runSinglePrompt(prompt: string, url: string): Promise<number> {
+  const result = await runTask({ url, prompt })
   process.stdout.write(
     JSON.stringify(
       {
@@ -36,6 +45,28 @@ export async function main(argv: string[]): Promise<number> {
   return result.error === null ? 0 : 1
 }
 
+async function runSuite(args: CodingRunArgs, url: string): Promise<number> {
+  const runs = args.runs ?? 3
+  const tasks = await loadTaskSuite(args.suite!)
+  const scores = []
+  for (const task of tasks) {
+    const workspaceProvider = makeContainerWorkspaceProvider(args.container, task.dir)
+    scores.push(await scoreTask({ task, url, runs, workspaceProvider }))
+  }
+
+  const report = buildReport({ suite: args.suite!, container: args.container, runsPerTask: runs, scores })
+  const path = await writeReport(args.resultsDir ?? './results', report)
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\nwrote ${path}\n`)
+  return report.passHatKRate === 1 ? 0 : 1
+}
+
+async function resolveUrl(container: string, host?: string): Promise<string> {
+  const port = await resolveHostPort(container)
+  const token = await resolveTuiToken(container)
+  return `ws://${host ?? '127.0.0.1'}:${port}?token=${token}`
+}
+
 function parseArgs(argv: string[]): CodingRunArgs | null {
   const values = new Map<string, string>()
   for (let i = 0; i < argv.length; i += 2) {
@@ -45,9 +76,20 @@ function parseArgs(argv: string[]): CodingRunArgs | null {
     values.set(key.slice(2), value)
   }
   const container = values.get('container')
-  const prompt = values.get('prompt')
-  if (container === undefined || prompt === undefined) return null
-  return { container, prompt, host: values.get('host') }
+  if (container === undefined) return null
+
+  const runsRaw = values.get('runs')
+  const runs = runsRaw === undefined ? undefined : Number(runsRaw)
+  if (runs !== undefined && (!Number.isInteger(runs) || runs < 1)) return null
+
+  return {
+    container,
+    host: values.get('host'),
+    prompt: values.get('prompt'),
+    suite: values.get('suite'),
+    runs,
+    resultsDir: values.get('results'),
+  }
 }
 
 if (import.meta.main) {

--- a/bench/coding/run.ts
+++ b/bench/coding/run.ts
@@ -3,6 +3,7 @@ import { resolveHostPort, resolveTuiToken } from './docker-discovery'
 import { buildReport, writeReport } from './report'
 import { scoreTask } from './score'
 import { loadTaskSuite } from './task'
+import { makeContainerVerifier } from './verify'
 import { makeContainerWorkspaceProvider } from './workspace'
 
 export type CodingRunArgs = {
@@ -48,10 +49,11 @@ async function runSinglePrompt(prompt: string, url: string): Promise<number> {
 async function runSuite(args: CodingRunArgs, url: string): Promise<number> {
   const runs = args.runs ?? 3
   const tasks = await loadTaskSuite(args.suite!)
+  const verify = makeContainerVerifier(args.container)
   const scores = []
   for (const task of tasks) {
     const workspaceProvider = makeContainerWorkspaceProvider(args.container, task.dir)
-    scores.push(await scoreTask({ task, url, runs, workspaceProvider }))
+    scores.push(await scoreTask({ task, url, runs, verify, workspaceProvider }))
   }
 
   const report = buildReport({ suite: args.suite!, container: args.container, runsPerTask: runs, scores })

--- a/bench/coding/score.test.ts
+++ b/bench/coding/score.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { TurnResult } from './client'
+import { scoreTask } from './score'
+import type { Task } from './task'
+import type { VerifyResult } from './verify'
+import type { WorkspaceProvider } from './workspace'
+
+const TASK: Task = {
+  id: 'demo',
+  dir: '/tmp/demo',
+  instruction: 'do it',
+  verifyCommand: ['true'],
+  timeoutMs: 1000,
+}
+
+const emptyTurn: TurnResult = { text: '', toolCalls: [], usage: null, error: null }
+const runTurn = async () => emptyTurn
+const verifyWith = (passed: boolean) => async (): Promise<VerifyResult> => ({
+  passed,
+  exitCode: passed ? 0 : 1,
+  stdout: '',
+  stderr: '',
+})
+
+describe('scoreTask', () => {
+  test('pass^k is true only when every run passes', async () => {
+    const score = await scoreTask({ task: TASK, url: 'ws://x', runs: 3, runTurn, verify: verifyWith(true) })
+
+    expect(score.passHatK).toBe(true)
+    expect(score.passAt1).toBe(1)
+    expect(score.passRate).toBe(1)
+    expect(score.outcomes).toHaveLength(3)
+  })
+
+  test('pass^k is false when any run fails', async () => {
+    let call = 0
+    const flaky = async (): Promise<VerifyResult> => {
+      call += 1
+      const passed = call !== 2
+      return { passed, exitCode: passed ? 0 : 1, stdout: '', stderr: '' }
+    }
+
+    const score = await scoreTask({ task: TASK, url: 'ws://x', runs: 3, runTurn, verify: flaky })
+
+    expect(score.passHatK).toBe(false)
+    expect(score.passAt1).toBe(1)
+    expect(score.passRate).toBeCloseTo(2 / 3)
+  })
+
+  test('a failing first run yields passAt1 = 0', async () => {
+    const score = await scoreTask({ task: TASK, url: 'ws://x', runs: 1, runTurn, verify: verifyWith(false) })
+
+    expect(score.passAt1).toBe(0)
+    expect(score.passHatK).toBe(false)
+  })
+
+  // Regression for the container-path isolation bug: models each run's workspace
+  // as a distinct in-memory filesystem keyed by path. Run 0 writes the artifact,
+  // run 1 does nothing. Because each run gets its own fresh path (seeded before
+  // the turn) and the verifier checks THAT path, run 1 sees no leftover and
+  // pass^k is false. Also asserts the ordering: prepare -> turn -> verify, same
+  // path per run — the exact invariant the reviewer flagged.
+  test('pass^k is false when a later run relies on a prior run artifact', async () => {
+    const files = new Map<string, Set<string>>()
+    const events: string[] = []
+
+    const workspaceProvider: WorkspaceProvider = {
+      async prepare(i) {
+        const path = `/tmp/bench-run-${i}`
+        events.push(`prepare:${path}`)
+        files.set(path, new Set(['seed']))
+        return { path }
+      },
+    }
+    const runTurn = async (_url: string, prompt: string) => {
+      const path = /Work in this directory: (.+)$/m.exec(prompt)?.[1] ?? ''
+      events.push(`turn:${path}`)
+      if (path === '/tmp/bench-run-0') files.get(path)!.add('artifact')
+      return emptyTurn
+    }
+    const verify = async (_cmd: string[], cwd: string): Promise<VerifyResult> => {
+      events.push(`verify:${cwd}`)
+      const passed = files.get(cwd)?.has('artifact') ?? false
+      return { passed, exitCode: passed ? 0 : 1, stdout: '', stderr: '' }
+    }
+
+    const score = await scoreTask({ task: TASK, url: 'ws://x', runs: 2, workspaceProvider, runTurn, verify })
+
+    expect(score.passAt1).toBe(1)
+    expect(score.passHatK).toBe(false)
+    expect(events).toEqual([
+      'prepare:/tmp/bench-run-0',
+      'turn:/tmp/bench-run-0',
+      'verify:/tmp/bench-run-0',
+      'prepare:/tmp/bench-run-1',
+      'turn:/tmp/bench-run-1',
+      'verify:/tmp/bench-run-1',
+    ])
+  })
+})

--- a/bench/coding/score.ts
+++ b/bench/coding/score.ts
@@ -1,0 +1,67 @@
+import { runTask, type TurnResult } from './client'
+import type { Task } from './task'
+import { runVerifier, type VerifyResult, type VerifyRunner } from './verify'
+import type { PreparedWorkspace, WorkspaceProvider } from './workspace'
+
+export type RunOutcome = {
+  turn: TurnResult
+  verify: VerifyResult
+  passed: boolean
+}
+
+export type TaskScore = {
+  taskId: string
+  runs: number
+  passAt1: number
+  passHatK: boolean
+  passRate: number
+  outcomes: RunOutcome[]
+}
+
+export type ScoreTaskOptions = {
+  task: Task
+  url: string
+  runs?: number
+  verify?: VerifyRunner
+  runTurn?: (url: string, prompt: string) => Promise<TurnResult>
+  // Yields a fresh, isolated workspace per attempt, SEEDED BEFORE the agent turn.
+  // The agent is prompted with the returned path and the verifier runs in that
+  // same path — so run N never inherits run N-1's files and pass^k stays honest.
+  workspaceProvider?: WorkspaceProvider
+}
+
+// pass@1 = first run passed. pass^k = ALL k runs passed — the reliability
+// metric, since agent runs are non-deterministic and single runs are noisy.
+export async function scoreTask(options: ScoreTaskOptions): Promise<TaskScore> {
+  const runs = options.runs ?? 3
+  const verify = options.verify ?? runVerifier
+  const runTurn = options.runTurn ?? ((url, prompt) => runTask({ url, prompt }))
+
+  const outcomes: RunOutcome[] = []
+  for (let i = 0; i < runs; i += 1) {
+    const fallback: PreparedWorkspace = { path: options.task.dir }
+    const workspace = await (options.workspaceProvider?.prepare(i) ?? Promise.resolve(fallback))
+    try {
+      const prompt = workspaceInstruction(options.task.instruction, workspace.path)
+      const turn = await runTurn(options.url, prompt)
+      const verifyResult = await verify(options.task.verifyCommand, workspace.path, options.task.timeoutMs)
+      outcomes.push({ turn, verify: verifyResult, passed: verifyResult.passed })
+    } finally {
+      await workspace.cleanup?.()
+    }
+  }
+
+  const passes = outcomes.filter((o) => o.passed).length
+  return {
+    taskId: options.task.id,
+    runs,
+    passAt1: outcomes[0]?.passed ? 1 : 0,
+    passHatK: passes === runs,
+    passRate: runs === 0 ? 0 : passes / runs,
+    outcomes,
+  }
+}
+
+function workspaceInstruction(instruction: string, workspace: string): string {
+  return `${instruction}\n\nWork in this directory: ${workspace}`
+}

--- a/bench/coding/task.test.ts
+++ b/bench/coding/task.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+
+import { loadTask, loadTaskSuite } from './task'
+
+const FIXTURES = `${import.meta.dir}/fixtures`
+
+describe('loadTask', () => {
+  test('reads instruction and metadata from a task dir', async () => {
+    const task = await loadTask(`${FIXTURES}/example-task`)
+
+    expect(task.id).toBe('example-task')
+    expect(task.instruction).toContain('output.txt')
+    expect(task.verifyCommand).toEqual(['bash', 'verify.sh'])
+    expect(task.timeoutMs).toBe(30000)
+  })
+
+  test('throws when the instruction file is missing', async () => {
+    await expect(loadTask(`${FIXTURES}/does-not-exist`)).rejects.toThrow()
+  })
+})
+
+describe('loadTaskSuite', () => {
+  test('loads every task directory under the suite, sorted', async () => {
+    const tasks = await loadTaskSuite(FIXTURES)
+
+    expect(tasks.map((t) => t.id)).toEqual(['example-task'])
+  })
+})

--- a/bench/coding/task.ts
+++ b/bench/coding/task.ts
@@ -1,0 +1,61 @@
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+
+export type Task = {
+  id: string
+  dir: string
+  instruction: string
+  verifyCommand: string[]
+  timeoutMs: number
+}
+
+export type TaskMeta = {
+  verify?: string[]
+  timeoutMs?: number
+}
+
+const INSTRUCTION_FILE = 'instruction.md'
+const META_FILE = 'task.json'
+const DEFAULT_VERIFY = ['bash', 'verify.sh']
+const DEFAULT_TIMEOUT_MS = 600_000
+
+export async function loadTask(dir: string): Promise<Task> {
+  const instruction = (await readFile(join(dir, INSTRUCTION_FILE), 'utf8')).trim()
+  if (instruction.length === 0) throw new Error(`empty ${INSTRUCTION_FILE} in ${dir}`)
+
+  const meta = await readMeta(dir)
+  return {
+    id: basename(dir) || dir,
+    dir,
+    instruction,
+    verifyCommand: meta.verify ?? DEFAULT_VERIFY,
+    timeoutMs: meta.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  }
+}
+
+export async function loadTaskSuite(suiteDir: string): Promise<Task[]> {
+  const entries = await readdir(suiteDir)
+  const dirs: string[] = []
+  for (const entry of entries) {
+    const full = join(suiteDir, entry)
+    if ((await stat(full)).isDirectory()) dirs.push(full)
+  }
+  dirs.sort()
+  return Promise.all(dirs.map(loadTask))
+}
+
+async function readMeta(dir: string): Promise<TaskMeta> {
+  let raw: string
+  try {
+    raw = await readFile(join(dir, META_FILE), 'utf8')
+  } catch {
+    return {}
+  }
+  const parsed: unknown = JSON.parse(raw)
+  if (typeof parsed !== 'object' || parsed === null) throw new Error(`invalid ${META_FILE} in ${dir}`)
+  const meta = parsed as Record<string, unknown>
+  return {
+    verify: Array.isArray(meta.verify) ? meta.verify.map(String) : undefined,
+    timeoutMs: typeof meta.timeoutMs === 'number' ? meta.timeoutMs : undefined,
+  }
+}

--- a/bench/coding/tb_adapter/bench-runner.ts
+++ b/bench/coding/tb_adapter/bench-runner.ts
@@ -1,0 +1,74 @@
+import { SessionManager } from '@mariozechner/pi-coding-agent'
+
+import { createSession } from '@/agent/index'
+import { type CreateSessionForSubagent, invokeSubagent, type SubagentRegistry } from '@/agent/subagents'
+import { createHookBus } from '@/plugin/hooks'
+import { emptyRegistry } from '@/plugin/registry'
+
+// Runs typeclaw's REAL agent tool loop headless against a task dir, then exits —
+// so the agent can run its code, see failures, and fix them (unlike the planner).
+//
+// Load-bearing directory split: process.cwd() MUST stay at the typeclaw agent dir
+// (config loads eagerly at import; codex auth via secrets.json loads lazily — both
+// break if cwd moves). Tools are pointed at the TASK dir via plugins.agentDir.
+// emptyRegistry + createHookBus is the minimal plugin wiring createSession needs.
+
+const SYSTEM_PROMPT = [
+  'You are a coding agent solving a benchmark task.',
+  'Your shell and file tools already operate in the task directory.',
+  'Create and edit files at the EXACT paths the task specifies (usually absolute paths like /app/...).',
+  'Do NOT create a workspace/ subdirectory and do NOT nest outputs.',
+  'Run your solution, observe failures (missing dependencies, errors, wrong output),',
+  'install or fix as needed, and iterate until the task passes. Then stop.',
+].join(' ')
+
+async function main(): Promise<number> {
+  const taskDir = process.argv[2]
+  const prompt = process.argv[3]
+  if (!taskDir || !prompt) {
+    process.stderr.write('usage: bun run bench-runner.ts <taskDir> <prompt>\n')
+    return 2
+  }
+
+  const registry: SubagentRegistry = {
+    task: { systemPrompt: SYSTEM_PROMPT, visibility: 'internal' },
+  }
+
+  const createSessionForSubagent: CreateSessionForSubagent = async (subagent, options) => {
+    const sessionManager = SessionManager.inMemory()
+    const hooks = createHookBus()
+    const origin = { kind: 'subagent' as const, subagent: options?.name ?? 'task', parentSessionId: 'bench' }
+    const session = await createSession({
+      sessionManager,
+      systemPromptOverride: subagent.systemPrompt,
+      origin,
+      customTools: [],
+      plugins: { registry: emptyRegistry(), hooks, sessionId: sessionManager.getSessionId(), agentDir: taskDir },
+    })
+    return { session, hooks, sessionId: sessionManager.getSessionId(), agentDir: taskDir, origin }
+  }
+
+  let providerError: string | undefined
+  await invokeSubagent('task', {
+    registry,
+    createSessionForSubagent,
+    agentDir: taskDir,
+    userPrompt: prompt,
+    onProviderError: (msg) => {
+      providerError = msg
+    },
+  })
+
+  if (providerError !== undefined) {
+    process.stderr.write(`provider error: ${providerError}\n`)
+    return 1
+  }
+  return 0
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err: unknown) => {
+    process.stderr.write(`${err instanceof Error ? err.stack : String(err)}\n`)
+    process.exit(1)
+  })

--- a/bench/coding/tb_adapter/typeclaw-setup.sh.j2
+++ b/bench/coding/tb_adapter/typeclaw-setup.sh.j2
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install Bun (typeclaw's runtime) and the typeclaw package into a fresh task
+# container, then materialize the agent dir from base64-encoded config/secrets
+# passed via _env. The agent dir is kept SEPARATE from the task dir so config +
+# codex auth resolve from cwd there while the agent's tools operate on the task
+# filesystem (see bench-runner.ts).
+apt-get update -qq
+apt-get install -y -qq curl unzip ca-certificates >/dev/null
+
+curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+export BUN_INSTALL="${HOME}/.bun"
+export PATH="${BUN_INSTALL}/bin:${PATH}"
+
+AGENT_DIR=/opt/tc-agent
+mkdir -p "${AGENT_DIR}"
+cd "${AGENT_DIR}"
+
+bun add "typeclaw@{{ version }}" >/dev/null 2>&1
+
+# Materialize the agent folder: model config + codex credentials, decoded from
+# the base64 env vars the adapter set (avoids shipping secrets as plaintext args).
+printf '%s' "${TC_CONFIG_B64}" | base64 -d > "${AGENT_DIR}/typeclaw.json"
+printf '%s' "${TC_SECRETS_B64}" | base64 -d > "${AGENT_DIR}/secrets.json"
+
+# The runner imports typeclaw internals via the @/ alias, which only resolves
+# from inside the package dir (its tsconfig owns the alias). Place it there.
+printf '%s' "${TC_RUNNER_B64}" | base64 -d > "${AGENT_DIR}/node_modules/typeclaw/bench-runner.ts"
+
+echo "TYPECLAW_SETUP_OK"

--- a/bench/coding/tb_adapter/typeclaw_agent.py
+++ b/bench/coding/tb_adapter/typeclaw_agent.py
@@ -1,0 +1,86 @@
+import base64
+import json
+import re
+from pathlib import Path
+
+from websockets.sync.client import connect
+
+from terminal_bench.agents.base_agent import AgentResult, BaseAgent
+from terminal_bench.agents.failure_mode import FailureMode
+from terminal_bench.terminal.tmux_session import TmuxSession
+
+# Ask the real typeclaw agent (over its TUI websocket) to PLAN the shell commands
+# for a task, then run them in the terminal-bench task container. typeclaw itself
+# runs in its own container, so we use it purely as the planner and execute the
+# commands here — the only way to score its output against tb's task filesystem.
+PLAN_PROMPT = """You are given a task to solve in a Linux terminal. Do NOT run \
+anything yourself. Output ONLY a fenced ```bash code block containing the exact \
+shell commands, in order, that would solve it. No prose.
+
+Task:
+{instruction}"""
+
+_FENCE = re.compile(r"```(?:bash|sh)?\s*\n(.*?)```", re.DOTALL)
+
+
+class TypeclawAgent(BaseAgent):
+    @staticmethod
+    def name() -> str:
+        return "typeclaw"
+
+    def __init__(self, ws_token: str, ws_host: str = "127.0.0.1", ws_port: int = 8973, **kwargs):
+        super().__init__(**kwargs)
+        self._ws_url = f"ws://{ws_host}:{ws_port}?token={ws_token}"
+
+    def perform_task(
+        self,
+        instruction: str,
+        session: TmuxSession,
+        logging_dir: Path | None = None,
+    ) -> AgentResult:
+        try:
+            reply = self._ask_typeclaw(PLAN_PROMPT.format(instruction=instruction))
+        except Exception:
+            return AgentResult(failure_mode=FailureMode.UNKNOWN_AGENT_ERROR)
+
+        script = self._extract_script(reply)
+        if not script:
+            return AgentResult(failure_mode=FailureMode.FATAL_LLM_PARSE_ERROR)
+
+        # Deliver the whole plan as one base64 blob decoded into a file, then run
+        # it. Sending lines individually breaks on heredocs/multi-line blocks —
+        # the shell enters a continuation prompt and tmux's wait signal never
+        # fires (900s timeout). base64 sidesteps all quoting/newline hazards.
+        blob = base64.b64encode(script.encode()).decode()
+        session.send_keys(
+            [f"echo {blob} | base64 -d > /tmp/tb_solve.sh && bash /tmp/tb_solve.sh", "Enter"],
+            block=True,
+        )
+
+        return AgentResult(failure_mode=FailureMode.NONE)
+
+    def _ask_typeclaw(self, prompt: str) -> str:
+        chunks: list[str] = []
+        with connect(self._ws_url, open_timeout=15) as ws:
+            _wait_for(ws, "connected")
+            ws.send(json.dumps({"type": "prompt", "text": prompt}))
+            while True:
+                message = json.loads(ws.recv(timeout=600))
+                kind = message.get("type")
+                if kind == "text_delta":
+                    chunks.append(message.get("delta", ""))
+                elif kind in ("done", "error"):
+                    break
+        return "".join(chunks)
+
+    @staticmethod
+    def _extract_script(reply: str) -> str:
+        blocks = _FENCE.findall(reply)
+        return (blocks[0] if blocks else reply).strip()
+
+
+def _wait_for(ws, kind: str) -> None:
+    while True:
+        message = json.loads(ws.recv(timeout=30))
+        if message.get("type") == kind:
+            return

--- a/bench/coding/tb_adapter/typeclaw_native_agent.py
+++ b/bench/coding/tb_adapter/typeclaw_native_agent.py
@@ -1,0 +1,57 @@
+import base64
+import os
+import shlex
+from pathlib import Path
+
+from terminal_bench.agents.installed_agents.abstract_installed_agent import AbstractInstalledAgent
+from terminal_bench.terminal.models import TerminalCommand
+
+AGENT_DIR = "/opt/tc-agent"
+
+
+def _b64(path: str) -> str:
+    return base64.b64encode(Path(path).read_bytes()).decode()
+
+
+class TypeclawNativeAgent(AbstractInstalledAgent):
+    """Runs typeclaw's real tool loop inside each task container (read/run/iterate),
+    unlike the websocket planner which one-shots blind commands from outside."""
+
+    @staticmethod
+    def name() -> str:
+        return "typeclaw-native"
+
+    @property
+    def _env(self) -> dict[str, str]:
+        # Ship the agent folder (model config + codex creds) and the runner into
+        # the container as base64 env vars; the setup script decodes them.
+        runner = Path(__file__).parent / "bench-runner.ts"
+        return {
+            "TC_CONFIG_B64": _b64(os.environ["TYPECLAW_CONFIG_PATH"]),
+            "TC_SECRETS_B64": _b64(os.environ["TYPECLAW_SECRETS_PATH"]),
+            "TC_RUNNER_B64": base64.b64encode(runner.read_bytes()).decode(),
+        }
+
+    @property
+    def _install_agent_script_path(self) -> Path:
+        return self._get_templated_script_path("typeclaw-setup.sh.j2")
+
+    def _run_agent_commands(self, instruction: str) -> list[TerminalCommand]:
+        # cd to the agent dir so config + auth resolve from cwd; pass the task
+        # working dir (/app is the terminal-bench convention) + the instruction.
+        escaped = shlex.quote(instruction)
+        bun_bin = "${HOME}/.bun/bin"
+        run = (
+            f'export PATH="{bun_bin}:${{PATH}}"; '
+            f"cd {AGENT_DIR} && "
+            f"bun run {AGENT_DIR}/node_modules/typeclaw/bench-runner.ts /app {escaped}"
+        )
+        return [
+            TerminalCommand(
+                command=run,
+                min_timeout_sec=0.0,
+                max_timeout_sec=float("inf"),
+                block=True,
+                append_enter=True,
+            ),
+        ]

--- a/bench/coding/verify.test.ts
+++ b/bench/coding/verify.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+
+import { runVerifier } from './verify'
+
+describe('runVerifier', () => {
+  test('passes when the command exits 0', async () => {
+    const result = await runVerifier(['bash', '-c', 'exit 0'], process.cwd(), 5000)
+
+    expect(result.passed).toBe(true)
+    expect(result.exitCode).toBe(0)
+  })
+
+  test('fails when the command exits non-zero', async () => {
+    const result = await runVerifier(['bash', '-c', 'echo boom >&2; exit 3'], process.cwd(), 5000)
+
+    expect(result.passed).toBe(false)
+    expect(result.exitCode).toBe(3)
+    expect(result.stderr).toContain('boom')
+  })
+
+  test('fails on an empty command', async () => {
+    const result = await runVerifier([], process.cwd(), 5000)
+
+    expect(result.passed).toBe(false)
+  })
+})

--- a/bench/coding/verify.ts
+++ b/bench/coding/verify.ts
@@ -1,0 +1,36 @@
+import { spawn } from 'node:child_process'
+
+export type VerifyResult = {
+  passed: boolean
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+export type VerifyRunner = (command: string[], cwd: string, timeoutMs: number) => Promise<VerifyResult>
+
+export const runVerifier: VerifyRunner = (command, cwd, timeoutMs) =>
+  new Promise((resolve) => {
+    const [bin, ...args] = command
+    if (bin === undefined) {
+      resolve({ passed: false, exitCode: 1, stdout: '', stderr: 'empty verify command' })
+      return
+    }
+
+    const child = spawn(bin, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs)
+
+    child.stdout.on('data', (c: Buffer) => (stdout += c.toString()))
+    child.stderr.on('data', (c: Buffer) => (stderr += c.toString()))
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      resolve({ passed: false, exitCode: 1, stdout, stderr: `${stderr}${err.message}` })
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      const exitCode = code ?? 1
+      resolve({ passed: exitCode === 0, exitCode, stdout, stderr })
+    })
+  })

--- a/bench/coding/verify.ts
+++ b/bench/coding/verify.ts
@@ -9,14 +9,23 @@ export type VerifyResult = {
 
 export type VerifyRunner = (command: string[], cwd: string, timeoutMs: number) => Promise<VerifyResult>
 
-export const runVerifier: VerifyRunner = (command, cwd, timeoutMs) =>
-  new Promise((resolve) => {
-    const [bin, ...args] = command
-    if (bin === undefined) {
-      resolve({ passed: false, exitCode: 1, stdout: '', stderr: 'empty verify command' })
-      return
-    }
+// Verifies in the ALREADY-PREPARED workspace via `docker exec -w <cwd>`. It does
+// NOT copy the task in — seeding is the workspace provider's job, done before the
+// agent turn. Copying here would overwrite the agent's output with the seed.
+export function makeContainerVerifier(container: string): VerifyRunner {
+  return (command, cwd, timeoutMs) => runProcess('docker', ['exec', '-w', cwd, container, ...command], timeoutMs)
+}
 
+export const runVerifier: VerifyRunner = (command, cwd, timeoutMs) => {
+  const [bin, ...args] = command
+  if (bin === undefined) {
+    return Promise.resolve({ passed: false, exitCode: 1, stdout: '', stderr: 'empty verify command' })
+  }
+  return runProcess(bin, args, timeoutMs, cwd)
+}
+
+function runProcess(bin: string, args: string[], timeoutMs: number, cwd?: string): Promise<VerifyResult> {
+  return new Promise((resolve) => {
     const child = spawn(bin, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
     let stdout = ''
     let stderr = ''
@@ -34,3 +43,4 @@ export const runVerifier: VerifyRunner = (command, cwd, timeoutMs) =>
       resolve({ passed: exitCode === 0, exitCode, stdout, stderr })
     })
   })
+}

--- a/bench/coding/workspace.test.ts
+++ b/bench/coding/workspace.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+
+import { type DockerRun, makeContainerWorkspaceProvider } from './workspace'
+
+describe('makeContainerWorkspaceProvider', () => {
+  test('seeds a fresh unique container path per run: rm -> mkdir -> cp contents', async () => {
+    const calls: string[][] = []
+    const docker: DockerRun = async (args) => {
+      calls.push(args)
+    }
+    const provider = makeContainerWorkspaceProvider('agent', '/host/task', '/tmp', docker)
+
+    const ws = await provider.prepare(2)
+
+    expect(ws.path).toBe('/tmp/bench-run-2')
+    expect(calls).toEqual([
+      ['exec', 'agent', 'rm', '-rf', '/tmp/bench-run-2'],
+      ['exec', 'agent', 'mkdir', '-p', '/tmp/bench-run-2'],
+      ['cp', '/host/task/.', 'agent:/tmp/bench-run-2'],
+    ])
+  })
+
+  test('cleanup removes the run workspace', async () => {
+    const calls: string[][] = []
+    const docker: DockerRun = async (args) => {
+      calls.push(args)
+    }
+    const provider = makeContainerWorkspaceProvider('agent', '/host/task', '/tmp', docker)
+
+    const ws = await provider.prepare(0)
+    calls.length = 0
+    await ws.cleanup?.()
+
+    expect(calls).toEqual([['exec', 'agent', 'rm', '-rf', '/tmp/bench-run-0']])
+  })
+})

--- a/bench/coding/workspace.ts
+++ b/bench/coding/workspace.ts
@@ -1,0 +1,55 @@
+import { spawn } from 'node:child_process'
+import { cp, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export type PreparedWorkspace = {
+  path: string
+  cleanup?: () => Promise<void>
+}
+
+export type WorkspaceProvider = {
+  prepare: (runIndex: number) => Promise<PreparedWorkspace>
+}
+
+export type DockerRun = (args: string[]) => Promise<void>
+
+// Seeds a UNIQUE, clean path inside the agent container BEFORE each turn, so the
+// agent and verifier operate on the same fresh filesystem and run N never sees
+// run N-1's artifacts. `rm -rf` then `mkdir` guarantees no stale files even if a
+// path is reused; `docker cp <task>/. :<path>` copies contents, not the dir.
+export function makeContainerWorkspaceProvider(
+  container: string,
+  hostTaskDir: string,
+  baseDir = '/tmp',
+  docker: DockerRun = defaultDockerRun,
+): WorkspaceProvider {
+  return {
+    async prepare(runIndex) {
+      const path = `${baseDir}/bench-run-${runIndex}`
+      await docker(['exec', container, 'rm', '-rf', path])
+      await docker(['exec', container, 'mkdir', '-p', path])
+      await docker(['cp', `${hostTaskDir}/.`, `${container}:${path}`])
+      return { path, cleanup: () => docker(['exec', container, 'rm', '-rf', path]) }
+    },
+  }
+}
+
+export function makeHostWorkspaceProvider(taskDir: string): WorkspaceProvider {
+  return {
+    async prepare() {
+      const path = await mkdtemp(join(tmpdir(), 'bench-run-'))
+      await cp(taskDir, path, { recursive: true })
+      return { path, cleanup: () => rm(path, { recursive: true, force: true }) }
+    },
+  }
+}
+
+const defaultDockerRun: DockerRun = (args) =>
+  new Promise((resolve, reject) => {
+    const child = spawn('docker', args, { stdio: ['ignore', 'ignore', 'pipe'] })
+    let stderr = ''
+    child.stderr.on('data', (c: Buffer) => (stderr += c.toString()))
+    child.on('error', reject)
+    child.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`docker ${args[0]} failed: ${stderr}`))))
+  })

--- a/bench/compose.yml
+++ b/bench/compose.yml
@@ -1,0 +1,10 @@
+services:
+  runner:
+    build: .
+    env_file:
+      - .env
+    volumes:
+      - ./datasets:/bench/datasets
+      - ./suites:/bench/suites
+      - ./results:/bench/results
+    network_mode: host

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@typeclaw/bench",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "lint": "oxlint",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
+    "test": "bun test",
+    "coding": "bun run coding/run.ts"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@typescript/native-preview": "^7.0.0-dev.20260416.1",
+    "oxfmt": "^0.45.0",
+    "oxlint": "^1.60.0"
+  }
+}

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -17,5 +17,6 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true
   },
-  "include": ["."]
+  "include": ["."],
+  "exclude": ["node_modules", "suites", "datasets", "coding/tb_adapter"]
 }

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2025",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "allowJs": true,
+
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
## What

Adds `bench/coding/` — a harness that benchmarks the **whole running typeclaw agent** by driving it over its TUI websocket, exactly as `typeclaw tui` does. First slice of the local benchmark effort tracked in #1128.

This measures the *agent* (harness + tools + prompt), not the raw model — so results are comparable to peer agents (Hermes, opencode, Goose, Claude Code) on the same tasks, unlike public model leaderboards.

## Why drive the websocket instead of testing the model directly

There were two ways to benchmark typeclaw's coding ability:

1. **Reconstruct the harness on bare pi** — extract typeclaw's prompt/tools/memory onto the underlying pi agent and benchmark that. Rejected: it's a partial reimplementation that measures a *rebuilt* agent, not the real one, and the entangled pieces (memory injection, todo-continuation, sandbox) don't extract cleanly.
2. **Drive the real, already-running agent over its TUI websocket** ← this PR. typeclaw already exposes a fully-typed websocket (`src/shared/protocol.ts`) with an explicit `{ type: 'done' }` completion signal — the same channel `typeclaw tui` attaches to. So the harness is a thin client: **no server changes, no harness reconstruction**, and it exercises the whole real stack (prompt, tools, bash-recovery, sandbox).

We picked (2). The client is ~80 lines because the protocol already gives us everything a benchmark needs.

## Design

- **Self-contained sibling.** `bench/` has its own `package.json`/`tsconfig.json`, is excluded from the root typecheck and the published `files` list, and duplicates the small wire-protocol subset rather than importing `src/`. Same isolation as `docs/`. Bench deps never enter the shipped package.
- **Clean host.** Python (for the Terminal-Bench/Harbor scoring tooling) is isolated in the Dockerfile; datasets and cloned suites live in gitignored dirs. `docker compose down` + `rm -rf datasets suites` leaves nothing behind — matching typeclaw's own "no machine clutter" principle.

## How it works

```
resolve host port (docker port <c> 8973/tcp) + TUI token (docker inspect label)
  → connect ws://127.0.0.1:<port>?token=<token>
  → wait { type: 'connected' }
  → send { type: 'prompt', text }
  → collect text_delta / tool_start / tool_end … → first { type: 'done' } (+usage)
```

Stopping at the **first** `done` is deliberate: the agent's todo-continuation can enqueue a follow-up turn after the user turn completes, and the user-facing result is already captured by then.

### Two run modes

```sh
cd bench && bun install

# ad-hoc single turn against a running agent
bun run coding/run.ts --container <name> --prompt "Fix the failing test in foo.ts"

# score a task suite (N runs each, pass@1 + pass^k), writes JSON to results/
bun run coding/run.ts --container <name> --suite ./suites/mytasks --runs 3
```

A **task** is a directory: `instruction.md` (the prompt), an optional `task.json` (verify command + timeout), and a verifier script. The scorer runs each task through the agent N times, verifies each run by **exit code** (programmatic pass/fail — the primary signal every coding-agent benchmark uses), and reports:

- **pass@1** — did the first run pass
- **pass^k** — did *all* k runs pass (the reliability metric; agent runs are non-deterministic, so a single run is noisy)

## Tests

26 tests, all green. The websocket client contract is exercised against a **real** Bun ws server (not a mock), the verifier runs **real** subprocesses, and per-run workspace isolation is covered by a contamination regression:

- connect → prompt → done, with text / tool-call / usage collection
- the todo-continuation stop (a second turn's output must not leak)
- `error` frame → failed turn; connect-handshake timeout
- task loading, exit-code verification, scorer aggregation (pass^k/pass@1), report math

```sh
cd bench
bun run typecheck && bun run lint && bun run format:check && bun test
```

## Terminal-Bench adapters

Two ways to run typeclaw against Terminal-Bench (both under `bench/coding/tb_adapter/`, plugged in via `--agent-import-path`):

1. **Planner adapter** (`typeclaw_agent.py`) — drives the running agent over its TUI websocket to plan shell commands, piped into the task container. One-shot, no iteration. A baseline that measures the model blind.
2. **Native adapter** (`typeclaw_native_agent.py` + `bench-runner.ts` + `typeclaw-setup.sh.j2`) — installs typeclaw into each fresh task container and runs its **real tool loop** there (read → run → observe failure → fix → retry) via `invokeSubagent`. This exercises typeclaw's actual product.

The native runner keeps `cwd` at the typeclaw agent dir (config + codex auth resolve there) while pointing tools at the task dir via `plugins.agentDir`; the setup script ships config/secrets as base64 env vars. `bench/tsconfig.json` excludes `tb_adapter/` because the runner imports typeclaw's `@/` alias, resolved in typeclaw's own package.

## Results (Terminal-Bench, easy subset, 64 tasks, GPT-5.5)

| Adapter | Resolved | Accuracy |
|---|---|---|
| Planner (one-shot, blind) | 21/60 | 35% |
| **Native (real tool loop)** | **51/64** | **79.7%** |

Same model, same tasks. The +45pt jump is entirely the iteration loop: tasks the planner failed because it couldn't recover from a runtime error (`broken-python`, `sql-injection-attack`, missing-dependency failures) pass under the native adapter because it can run its code, see the failure, and fix it.

**Caveat (important):** 79.7% is on the **easy subset only** — it is an upper bound, not a full-suite score, and is **not** directly comparable to peers' published full-suite numbers (which span easy+hard+expert). A fair head-to-head requires the full suite (minus a few tasks with multi-hour agent-timeout budgets); that run is future work.

## Next (see #1128)

Full-suite native run for a peer-comparable number; memory bench (LongMemEval, dreaming on/off, OpenAI judge).

Refs #1128

