### PR TITLE
fix: stop silent hangs on provider stalls — guard streams + reply on failure

### DIFF
--- a/src/agent/provider-error.test.ts
+++ b/src/agent/provider-error.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, test } from 'bun:test'
 import { AgentSession as PiAgentSession, SettingsManager } from '@mariozechner/pi-coding-agent'
 
 import type { AgentSession } from './index'
-import { detectProviderError, isThrottleOrOverload, subscribeProviderErrors } from './provider-error'
+import {
+  detectHardProviderError,
+  detectProviderError,
+  isFailoverWorthy,
+  isThrottleOrOverload,
+  subscribeProviderErrors,
+} from './provider-error'
 
 describe('detectProviderError', () => {
   test('preserves the raw errorMessage on `message` for operator surfaces (logs/TUI)', () => {
@@ -135,6 +141,44 @@ describe('detectProviderError safeMessage redaction', () => {
   })
 })
 
+describe('detectHardProviderError', () => {
+  test('maps an observer stall timeout to the timeout-safe sentence (not the generic notice)', () => {
+    const raw = 'anthropic SSE body idle for 120000ms (typeclaw observer timeout)'
+    const result = detectHardProviderError(new Error(raw))
+
+    expect(result?.safeMessage).toMatch(/stopped responding|timed out/i)
+    expect(result?.safeMessage).not.toBe(
+      'The upstream LLM provider failed. Operators can check `typeclaw logs` for details.',
+    )
+    expect(result?.message).toBe(raw)
+  })
+
+  test('classifies rate-limit, billing/quota, and auth hard throws as provider failures', () => {
+    expect(detectHardProviderError(new Error('429 All tokens rate limited'))?.safeMessage).toMatch(/rate-limited/i)
+    expect(detectHardProviderError(new Error('insufficient quota'))?.safeMessage).toMatch(/billing\/quota/i)
+    expect(detectHardProviderError(new Error('401 Unauthorized'))?.safeMessage).toMatch(/unauthorized/i)
+  })
+
+  test('returns null for internal / network errors so the caller stays silent-with-log', () => {
+    expect(detectHardProviderError(new Error('network unreachable'))).toBeNull()
+    expect(detectHardProviderError(new Error('Cannot read properties of undefined'))).toBeNull()
+    expect(detectHardProviderError(new Error('ENOENT: no such file or directory'))).toBeNull()
+  })
+
+  test('accepts a non-Error throw by stringifying it', () => {
+    expect(detectHardProviderError('503 Service Unavailable')?.safeMessage).toMatch(/timed out|rate-limited|failed/i)
+    expect(detectHardProviderError('just a plain string')).toBeNull()
+  })
+
+  test('does not leak raw provider text through the safe message', () => {
+    const raw = '429 rate limited (Authorization: Bearer sk-live-LEAK)'
+    const result = detectHardProviderError(new Error(raw))
+
+    expect(result?.safeMessage).not.toContain('sk-live-LEAK')
+    expect(result?.safeMessage).not.toContain('Bearer')
+  })
+})
+
 describe('isThrottleOrOverload', () => {
   test('matches the Codex `server_is_overloaded` shape (the production incident)', () => {
     // given: the exact body Codex returns under per-account 503 throttling
@@ -207,6 +251,26 @@ describe('isThrottleOrOverload', () => {
     expect(isThrottleOrOverload('Error code: 429 - too many requests')).toBe(true)
     expect(isThrottleOrOverload('429 rate limit exceeded')).toBe(true)
     expect(isThrottleOrOverload('503 Service Unavailable')).toBe(true)
+  })
+})
+
+describe('isFailoverWorthy', () => {
+  test('an observer stall timeout IS failover-worthy (so a stall rotates to the next ref)', () => {
+    expect(isFailoverWorthy('anthropic SSE body idle for 120000ms (typeclaw observer timeout)')).toBe(true)
+    expect(
+      isFailoverWorthy('codex fetch timed out before response headers after 15000ms (typeclaw observer timeout)'),
+    ).toBe(true)
+  })
+
+  test('still fails over on throttle/overload (superset of isThrottleOrOverload)', () => {
+    expect(isFailoverWorthy('server_is_overloaded')).toBe(true)
+    expect(isFailoverWorthy('429 too many requests')).toBe(true)
+  })
+
+  test('does NOT fail over on account-wide faults (billing/quota/auth) or generic errors', () => {
+    expect(isFailoverWorthy('insufficient quota')).toBe(false)
+    expect(isFailoverWorthy('401 Unauthorized')).toBe(false)
+    expect(isFailoverWorthy('network unreachable')).toBe(false)
   })
 })
 

--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -26,6 +26,13 @@ export type DetectedProviderError = {
 
 const GENERIC_SAFE_NOTICE = 'The upstream LLM provider failed. Operators can check `typeclaw logs` for details.'
 
+// The fetch observer (`llm-fetch-observer`) aborts a stalled provider stream
+// with a message ending in this marker (TTFB / idle / overall deadline). Such a
+// stall is a hard throw, not a `stopReason: 'error'` soft error, so it never
+// reaches `detectProviderError`; the marker lets the hard-throw path recognize
+// and surface it. The literal is the system's own token — English by design.
+const OBSERVER_TIMEOUT = /\(typeclaw observer timeout\)/i
+
 // Each entry pairs a narrow matcher against the raw provider text with the
 // canonical, leak-free sentence shown in channels. Matchers are intentionally
 // specific: a miss falls through to GENERIC_SAFE_NOTICE rather than echoing raw
@@ -60,6 +67,10 @@ const SAFE_CLASSES: ReadonlyArray<{ match: RegExp; safe: string }> = [
     match: /\b(billing|quota|insufficient.*(credit|fund|balance)|payment|account is not active)\b/i,
     safe: 'The upstream LLM provider rejected the request for a billing/quota reason. Operators can check `typeclaw logs` for details.',
   },
+  {
+    match: OBSERVER_TIMEOUT,
+    safe: 'The upstream LLM provider stopped responding and the request timed out. Try again shortly.',
+  },
 ]
 
 function toSafeMessage(raw: string): string {
@@ -90,6 +101,17 @@ export function isThrottleOrOverload(raw: string): boolean {
   return THROTTLE_OR_OVERLOAD.test(raw)
 }
 
+// Failover predicate for turn-drivers' `shouldFailover`: rotate to the next model
+// ref on a transient capacity signal (throttle/overload) OR an observer stall
+// timeout. A stall — the provider accepted the stream but stopped sending bytes —
+// is as transient as an overload and another ref may well succeed, so it must
+// fail OVER before the caller surfaces a failure notice. Account-wide faults
+// (billing/quota/auth) still return false via `isThrottleOrOverload` — a
+// different ref shares the same account problem.
+export function isFailoverWorthy(raw: string): boolean {
+  return isThrottleOrOverload(raw) || OBSERVER_TIMEOUT.test(raw)
+}
+
 export function detectProviderError(message: unknown): DetectedProviderError | null {
   if (typeof message !== 'object' || message === null) return null
   const m = message as { role?: unknown; stopReason?: unknown; errorMessage?: unknown }
@@ -100,6 +122,21 @@ export function detectProviderError(message: unknown): DetectedProviderError | n
   if (m.stopReason !== 'error') return null
   const text = typeof m.errorMessage === 'string' && m.errorMessage.length > 0 ? m.errorMessage : 'LLM call failed'
   return { message: text, safeMessage: toSafeMessage(text) }
+}
+
+// Classifies a HARD-thrown error (an exception out of `session.prompt()`, after
+// model fallback is exhausted) into a user-facing notice — the throw counterpart
+// to `detectProviderError`'s soft-error path. Returns `null` for errors that are
+// NOT an operator-actionable provider failure (internal bugs, network blips),
+// so the caller stays silent-with-log rather than spamming channels. The three
+// recognized classes are: failover-worthy throttle/overload, account-wide faults
+// (billing/quota/auth) that must surface, and observer stall timeouts.
+export function detectHardProviderError(err: unknown): DetectedProviderError | null {
+  const message = err instanceof Error ? err.message : String(err)
+  const isProviderFailure =
+    isThrottleOrOverload(message) || NON_FAILOVER_FAULT.test(message) || OBSERVER_TIMEOUT.test(message)
+  if (!isProviderFailure) return null
+  return { message, safeMessage: toSafeMessage(message) }
 }
 
 export type ProviderErrorListener = (error: DetectedProviderError) => void

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -10,7 +10,7 @@ import { applyTurnThinkingLevel } from './attention-escalation'
 import { type AgentSession, createSession, type PluginSessionWiring } from './index'
 import { resolveFallbackChain } from './model-fallback'
 import { applyModelRuntimeOverrides } from './model-overrides'
-import { isThrottleOrOverload, subscribeProviderErrors } from './provider-error'
+import { isFailoverWorthy, subscribeProviderErrors } from './provider-error'
 import type { SubagentBashPolicy } from './reviewer-bash-policy'
 import type { SessionOrigin } from './session-origin'
 import {
@@ -349,7 +349,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           text: turnText,
           skipProviderErrorSubscription: true,
           detectSoftErrorFromLeaf: true,
-          shouldFailover: (err) => isThrottleOrOverload(err.message),
+          shouldFailover: (err) => isFailoverWorthy(err.message),
           setModelForRef: async (ref) => {
             await session.setModel(applyModelRuntimeOverrides(resolveModel(ref), ref))
             activeModelRef = ref

--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import type { ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
+import { isFailoverWorthy } from './provider-error'
 import { ThrottleCircuit } from './throttle-circuit'
 import { promptPersistentTurnWithFallback } from './turn-runner'
 
@@ -12,7 +13,9 @@ const REF_B = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' as ModelRef
 type FakeEvent = { type: string; message?: unknown; assistantMessageEvent?: { type: string; delta?: string } }
 
 function fakeSession(
-  behaviors: Array<'soft-throttle' | 'soft-billing' | 'text-then-throttle' | 'tool-then-throttle' | 'success'>,
+  behaviors: Array<
+    'soft-throttle' | 'soft-billing' | 'text-then-throttle' | 'tool-then-throttle' | 'hard-observer-timeout' | 'success'
+  >,
 ) {
   const events: Array<(event: FakeEvent) => void> = []
   const prompted: string[] = []
@@ -21,6 +24,9 @@ function fakeSession(
     prompt: async (text: string) => {
       prompted.push(text)
       const behavior = behaviors.shift() ?? 'success'
+      if (behavior === 'hard-observer-timeout') {
+        throw new Error('anthropic SSE body idle for 120000ms (typeclaw observer timeout)')
+      }
       if (behavior === 'text-then-throttle') {
         for (const cb of events)
           cb({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'hi' } })
@@ -67,6 +73,28 @@ describe('promptPersistentTurnWithFallback', () => {
     expect(result.refUsed).toBe(REF_B)
     expect(fake.prompted).toEqual(['hello', 'hello'])
     expect(fake.setModels).toEqual([REF_B])
+  })
+
+  test('fails over to the next ref when the first ref throws an observer stall timeout (with isFailoverWorthy)', async () => {
+    // given: ref A hard-throws an observer stall timeout before any output; ref B succeeds
+    const fake = fakeSession(['hard-observer-timeout', 'success'])
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A, REF_B],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async (ref) => {
+        fake.setModels.push(ref)
+      },
+    })
+
+    // then: the stall rotated to REF_B and succeeded — no failure surfaced to the caller
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_B)
+    expect(fake.setModels).toEqual([REF_B])
+    expect(result.attempts[0]).toMatchObject({ ref: REF_A, outcome: 'hard' })
   })
 
   test('does not advance when the throttle happens after assistant text', async () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7677,6 +7677,113 @@ describe('ChannelRouter plugin lifecycle hooks', () => {
     expect(warns.some((m) => /prompt threw/.test(m))).toBe(false)
   })
 
+  test('a hard-thrown 429 usage-limit posts exactly one redacted rate-limit notice to the channel', async () => {
+    // given: prompt() hard-throws a 429 (fallback already exhausted upstream) —
+    // the production shape where an Anthropic proxy is usage-capped.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async () => {
+          throw new Error('429 All tokens rate limited')
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_429',
+          dispose: async () => {},
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      if (msg.text !== undefined) sent.push(msg.text)
+      return { ok: true }
+    })
+
+    // when
+    await router.route(inbound({ text: 'you there?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: exactly one redacted rate-limit notice, no raw text, no "I got stuck"
+    const notices = sent.filter((t) => /rate-limited/i.test(t))
+    expect(notices).toHaveLength(1)
+    expect(notices[0]).toContain('⚠️')
+    expect(sent.some((t) => /All tokens/.test(t))).toBe(false)
+    expect(sent.some((t) => t === EMPTY_TURN_FALLBACK_TEXT)).toBe(false)
+  })
+
+  test('a hard-thrown observer stall timeout posts exactly one timeout notice', async () => {
+    // given: the fetch observer aborts a stalled stream, surfaced as a hard throw
+    const dir = await tempDir()
+    const sent: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async () => {
+          throw new Error('anthropic SSE body idle for 120000ms (typeclaw observer timeout)')
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_stall',
+          dispose: async () => {},
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      if (msg.text !== undefined) sent.push(msg.text)
+      return { ok: true }
+    })
+
+    // when
+    await router.route(inbound({ text: 'still there?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then
+    const notices = sent.filter((t) => /stopped responding|timed out/i.test(t))
+    expect(notices).toHaveLength(1)
+    expect(notices[0]).toContain('⚠️')
+    expect(sent.some((t) => /observer timeout/.test(t))).toBe(false)
+  })
+
+  test('a generic internal hard-throw logs but posts NO channel notice (silent-with-log default)', async () => {
+    // given: an internal error that is NOT an operator-actionable provider failure
+    const dir = await tempDir()
+    const sent: string[] = []
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      createSessionForChannel: async () => {
+        const fake = new FakeSession()
+        fake.prompt = async () => {
+          throw new Error('Cannot read properties of undefined')
+        }
+        return {
+          session: fake as unknown as AgentSession,
+          sessionId: 'ses_bug',
+          dispose: async () => {},
+          getTranscriptPath: () => undefined,
+        }
+      },
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      if (msg.text !== undefined) sent.push(msg.text)
+      return { ok: true }
+    })
+
+    // when
+    await router.route(inbound({ text: 'hello?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: no ⚠️ notice for an internal bug — channels are not spammed
+    expect(sent.some((t) => t.includes('⚠️'))).toBe(false)
+  })
+
   test('fires session.end on stop() before disposing each live session', async () => {
     // given
     const dir = await tempDir()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -9,7 +9,7 @@ import { applyTurnThinkingLevel, getQuestionSignal, type QuestionSignal } from '
 import { resolveFallbackChain } from '@/agent/model-fallback'
 import { applyModelRuntimeOverrides } from '@/agent/model-overrides'
 import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
-import { isThrottleOrOverload, subscribeProviderErrors } from '@/agent/provider-error'
+import { detectHardProviderError, isFailoverWorthy, subscribeProviderErrors } from '@/agent/provider-error'
 import type { RestartHandoff } from '@/agent/restart-handoff'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
@@ -2654,7 +2654,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             currentModelRef: live.activeModelRef,
             session: live.session,
             text: promptText,
-            shouldFailover: (err) => isThrottleOrOverload(err.message),
+            shouldFailover: (err) => isFailoverWorthy(err.message),
             setModelForRef: async (ref) => {
               await live.session.setModel(applyModelRuntimeOverrides(resolveModel(ref), ref))
               live.activeModelRef = ref
@@ -2694,6 +2694,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           logger.info(`[channels] ${live.keyId} prompted elapsed_ms=${now() - promptStart}`)
         } catch (err) {
           logger.error(`[channels] ${live.keyId}: prompt threw: ${describe(err)}`)
+          // Fallback is exhausted by now (promptPersistentTurnWithFallback only
+          // throws after rotating every eligible ref), so a recognizable provider
+          // failure is terminal for this turn. Stage a redacted notice for the
+          // `finally` poster — but never clobber a soft error already captured for
+          // this turnSeq by subscribeProviderErrors (first-detected wins).
+          const hardProviderError = detectHardProviderError(err)
+          if (hardProviderError !== null && live.pendingProviderError?.turnSeq !== live.turnSeq) {
+            live.pendingProviderError = { turnSeq: live.turnSeq, safeMessage: hardProviderError.safeMessage }
+          }
           live.consecutiveSends.clear()
           live.lastSentText.clear()
           live.lastSendLeafId = null

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -82,8 +82,8 @@ import { createTunnelManager, type TunnelManager, type TunnelManagerOptions } fr
 
 import { BUNDLED_PLUGINS } from './bundled-plugins'
 import { buildChannelSessionFactory } from './channel-session-factory'
-import { installCodexFetchObserver } from './codex-fetch-observer'
 import { installFatalGuard } from './fatal-guard'
+import { installLlmFetchObserver } from './llm-fetch-observer'
 import { createPluginRuntime, type PluginRuntime, type PluginSubagentEntry } from './plugin-runtime'
 
 type BunServer = ReturnType<Server['start']>
@@ -133,7 +133,7 @@ export type StartAgentResult = {
 }
 
 // Owns boot-failure cleanup for everything installed before `startAgentRuntime`
-// returns a `StartAgentResult`. `installCodexFetchObserver`/`installFatalGuard`
+// returns a `StartAgentResult`. `installLlmFetchObserver`/`installFatalGuard`
 // attach process-wide listeners, and `loadPlugins` opens plugin-lifetime
 // resources (the memory plugin's sqlite handle); if any boot step throws before
 // the result exists, the caller never receives `stop()`, so each of those would
@@ -182,12 +182,15 @@ async function startAgentRuntime(
   const reloadRegistry = new ReloadRegistry()
 
   // Wrap globalThis.fetch BEFORE any plugin/session/manager construction so
-  // every Codex Responses call from anywhere in the container is observed.
-  // Logs one `[codex-fetch]` line per matched request with phase timings;
-  // never aborts, never retries — purely passive instrumentation while we
-  // investigate the recurring multi-minute Codex stalls (see issue #394).
-  // Opt out with TYPECLAW_CODEX_FETCH_OBSERVER=off.
-  const uninstallCodexFetchObserver = installCodexFetchObserver()
+  // every LLM provider stream from anywhere in the container is guarded. Logs
+  // one `[llm-fetch]` line per matched request with phase timings and applies
+  // TTFB/idle/overall deadlines that abort a stalled stream — turning a silent
+  // infinite hang (e.g. a rate-limited proxy holding the SSE connection open
+  // with zero bytes) into a retryable error the fallback path can surface.
+  // Covers Codex, Anthropic (`/v1/messages`), and OpenAI-compatible endpoints
+  // regardless of host, since base URLs are user-configured. Opt out with
+  // TYPECLAW_LLM_FETCH_OBSERVER=off.
+  const uninstallLlmFetchObserver = installLlmFetchObserver()
 
   // The host CLI sets TYPECLAW_CONTAINER_NAME when it `docker run`s us. When
   // running outside a typeclaw container (tests, ad-hoc `bun run typeclaw run`
@@ -225,7 +228,7 @@ async function startAgentRuntime(
   const disposeProcessGlobals = (): void => {
     if (processGlobalsDisposed) return
     processGlobalsDisposed = true
-    uninstallCodexFetchObserver()
+    uninstallLlmFetchObserver()
     fatalGuard.dispose()
     // onSigterm is defined later in this scope but only ever invoked after init;
     // removing it here keeps a restarted startAgent() from stacking listeners.

--- a/src/run/llm-fetch-observer.test.ts
+++ b/src/run/llm-fetch-observer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { installCodexFetchObserver, type TimeoutScheduler } from './codex-fetch-observer'
+import { defaultLlmFetchEndpoints, installLlmFetchObserver, type TimeoutScheduler } from './llm-fetch-observer'
 
 // Programmable scheduler for tests. Tasks scheduled for time T fire when the
 // test calls `fire(T)`. Out-of-order T values (T must be monotonically
@@ -122,23 +122,28 @@ async function drainQuiet(stream: ReadableStream<Uint8Array> | null): Promise<vo
 
 const originalFetch = globalThis.fetch
 
-describe('installCodexFetchObserver', () => {
-  beforeEach(() => {
-    globalThis.fetch = originalFetch
+describe('installLlmFetchObserver', () => {
+  const clearObserverEnv = () => {
     delete process.env.TYPECLAW_CODEX_TIMEOUTS
     delete process.env.TYPECLAW_CODEX_TTFB_MS
     delete process.env.TYPECLAW_CODEX_IDLE_MS
     delete process.env.TYPECLAW_CODEX_OVERALL_MS
     delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
+    delete process.env.TYPECLAW_LLM_TIMEOUTS
+    delete process.env.TYPECLAW_LLM_TTFB_MS
+    delete process.env.TYPECLAW_LLM_IDLE_MS
+    delete process.env.TYPECLAW_LLM_OVERALL_MS
+    delete process.env.TYPECLAW_LLM_FETCH_OBSERVER
+  }
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+    clearObserverEnv()
   })
 
   afterEach(() => {
     globalThis.fetch = originalFetch
-    delete process.env.TYPECLAW_CODEX_TIMEOUTS
-    delete process.env.TYPECLAW_CODEX_TTFB_MS
-    delete process.env.TYPECLAW_CODEX_IDLE_MS
-    delete process.env.TYPECLAW_CODEX_OVERALL_MS
-    delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
+    clearObserverEnv()
   })
 
   test('passes non-Codex requests through unchanged (no wrapping)', async () => {
@@ -146,7 +151,7 @@ describe('installCodexFetchObserver', () => {
     const sentinel = Symbol('upstream')
     globalThis.fetch = (async () => sentinel as unknown as Response) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger })
+    const uninstall = installLlmFetchObserver({ logger })
     try {
       const result = await fetch('https://example.com/some/other/path')
       expect(result).toBe(sentinel as unknown as Response)
@@ -163,7 +168,7 @@ describe('installCodexFetchObserver', () => {
       throw upstreamError
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger })
+    const uninstall = installLlmFetchObserver({ logger })
     try {
       await expect(fetch('https://api.openai.com/v1/responses')).rejects.toBe(upstreamError)
       expect(entries).toEqual([])
@@ -185,7 +190,7 @@ describe('installCodexFetchObserver', () => {
       })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now })
     try {
       clock.set(0)
       const responsePromise = fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
@@ -203,9 +208,9 @@ describe('installCodexFetchObserver', () => {
       uninstall()
     }
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    const line = codexLines[0]!.msg
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    const line = observed[0]!.msg
     expect(line).toContain('status=200')
     expect(line).toContain('headers_ms=50')
     expect(line).toContain('first_byte_ms=200')
@@ -228,7 +233,7 @@ describe('installCodexFetchObserver', () => {
       })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now })
     try {
       clock.set(0)
       const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
@@ -240,10 +245,10 @@ describe('installCodexFetchObserver', () => {
       uninstall()
     }
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    expect(codexLines[0]!.msg).toContain('status=429')
-    expect(codexLines[0]!.msg).toContain('retry_after=42')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('status=429')
+    expect(observed[0]!.msg).toContain('retry_after=42')
   })
 
   test('logs stream errors with error message and partial timings', async () => {
@@ -256,7 +261,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now })
     try {
       clock.set(0)
       const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
@@ -270,9 +275,9 @@ describe('installCodexFetchObserver', () => {
       uninstall()
     }
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    const line = codexLines[0]!.msg
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    const line = observed[0]!.msg
     expect(line).toContain('status=200')
     expect(line).toContain('first_byte_ms=100')
     expect(line).toContain('error="connection reset by peer"')
@@ -286,7 +291,7 @@ describe('installCodexFetchObserver', () => {
       throw new Error('fetch failed')
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now })
     try {
       clock.set(0)
       await expect(fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })).rejects.toThrow(
@@ -296,12 +301,12 @@ describe('installCodexFetchObserver', () => {
       uninstall()
     }
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    expect(codexLines[0]!.msg).toContain('error="fetch failed"')
-    expect(codexLines[0]!.msg).toContain('headers_ms=null')
-    expect(codexLines[0]!.msg).toContain('first_byte_ms=null')
-    expect(codexLines[0]!.msg).toMatch(/total_ms=\d+/)
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('error="fetch failed"')
+    expect(observed[0]!.msg).toContain('headers_ms=null')
+    expect(observed[0]!.msg).toContain('first_byte_ms=null')
+    expect(observed[0]!.msg).toMatch(/total_ms=\d+/)
   })
 
   test('matches Codex URL by host and path, ignores other paths on same host', async () => {
@@ -309,11 +314,11 @@ describe('installCodexFetchObserver', () => {
     const sentinel = new Response(null, { status: 204 })
     globalThis.fetch = (async () => sentinel) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger })
+    const uninstall = installLlmFetchObserver({ logger })
     try {
       const result = await fetch('https://chatgpt.com/backend-api/me')
       expect(result).toBe(sentinel)
-      expect(entries.filter((e) => e.msg.startsWith('[codex-fetch]'))).toEqual([])
+      expect(entries.filter((e) => e.msg.startsWith('[llm-fetch]'))).toEqual([])
     } finally {
       uninstall()
     }
@@ -322,7 +327,7 @@ describe('installCodexFetchObserver', () => {
   test('uninstall restores original fetch', () => {
     const { logger } = captureLogger()
     const before = globalThis.fetch
-    const uninstall = installCodexFetchObserver({ logger })
+    const uninstall = installLlmFetchObserver({ logger })
     expect(globalThis.fetch).not.toBe(before)
     uninstall()
     expect(globalThis.fetch).toBe(before)
@@ -331,9 +336,9 @@ describe('installCodexFetchObserver', () => {
   test('a second install shares the wrapper and is ref-counted: a later release keeps fetch observed while another claimant remains', () => {
     const { logger } = captureLogger()
     const before = globalThis.fetch
-    const release1 = installCodexFetchObserver({ logger })
+    const release1 = installLlmFetchObserver({ logger })
     const wrappedAfterFirst = globalThis.fetch
-    const release2 = installCodexFetchObserver({ logger })
+    const release2 = installLlmFetchObserver({ logger })
     try {
       // given two claimants sharing one wrapper
       expect(globalThis.fetch).toBe(wrappedAfterFirst)
@@ -355,13 +360,13 @@ describe('installCodexFetchObserver', () => {
   test('a release is idempotent and never tears down a re-acquired observer', () => {
     const { logger } = captureLogger()
     const before = globalThis.fetch
-    const release1 = installCodexFetchObserver({ logger })
+    const release1 = installLlmFetchObserver({ logger })
     release1()
     release1() // idempotent: second call is a no-op
     expect(globalThis.fetch).toBe(before)
 
     // a fresh install after full release re-wraps and is independent
-    const release2 = installCodexFetchObserver({ logger })
+    const release2 = installLlmFetchObserver({ logger })
     expect(globalThis.fetch).not.toBe(before)
     // the stale release1 must NOT restore over the new observer
     release1()
@@ -375,17 +380,17 @@ describe('installCodexFetchObserver', () => {
     const before = globalThis.fetch
     process.env.TYPECLAW_CODEX_FETCH_OBSERVER = 'off'
     try {
-      const uninstall = installCodexFetchObserver({ logger })
+      const uninstall = installLlmFetchObserver({ logger })
       expect(globalThis.fetch).toBe(before)
       uninstall()
       expect(globalThis.fetch).toBe(before)
-      expect(entries.filter((e) => e.msg.startsWith('[codex-fetch]'))).toEqual([])
+      expect(entries.filter((e) => e.msg.startsWith('[llm-fetch]'))).toEqual([])
     } finally {
       delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
     }
   })
 
-  test('custom codexHost option matches a different host (for staging/testing)', async () => {
+  test('observes an arbitrary Anthropic proxy host by /v1/messages path suffix', async () => {
     const { logger, entries } = captureLogger()
     const clock = makeClock()
     const ctrl = makeControllableBody()
@@ -395,10 +400,10 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, codexHost: 'staging.example.com', now: clock.now })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now })
     try {
       clock.set(0)
-      const response = await fetch('https://staging.example.com/backend-api/codex/responses', { method: 'POST' })
+      const response = await fetch('https://proxy.example.com/anthropic/v1/messages', { method: 'POST' })
       const drainPromise = drainQuiet(response.body)
       clock.set(20)
       await ctrl.close()
@@ -407,7 +412,138 @@ describe('installCodexFetchObserver', () => {
       uninstall()
     }
 
-    expect(entries.filter((e) => e.msg.startsWith('[codex-fetch]')).length).toBe(1)
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('provider=anthropic')
+  })
+
+  test('matches Anthropic, OpenAI-compatible, and Codex paths; ignores GET and unrelated paths', async () => {
+    const { logger, entries } = captureLogger()
+    const sentinel = new Response(null, { status: 204 })
+    globalThis.fetch = (async () => sentinel) as unknown as typeof fetch
+
+    const matchCases: Array<{ url: string; provider: string }> = [
+      { url: 'https://api.anthropic.com/v1/messages', provider: 'anthropic' },
+      { url: 'https://proxy.internal/gateway/anthropic/v1/messages', provider: 'anthropic' },
+      { url: 'https://api.openai.com/v1/chat/completions', provider: 'openai-compatible' },
+      { url: 'https://api.fireworks.ai/inference/v1/chat/completions', provider: 'openai-compatible' },
+      { url: 'https://litellm.internal/chat/completions', provider: 'openai-compatible' },
+      { url: 'https://api.openai.com/v1/responses', provider: 'openai-compatible' },
+      { url: 'https://chatgpt.com/backend-api/codex/responses', provider: 'codex' },
+    ]
+
+    const uninstall = installLlmFetchObserver({ logger, ttfbMs: 0, idleMs: 0, overallMs: 0 })
+    try {
+      for (const { url, provider } of matchCases) {
+        entries.length = 0
+        await fetch(url, { method: 'POST' })
+        const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+        expect(observed.length, `expected ${url} to be observed`).toBe(1)
+        expect(observed[0]!.msg).toContain(`provider=${provider}`)
+      }
+
+      // given a GET to a matching path and a POST to an unrelated path
+      entries.length = 0
+      await fetch('https://api.anthropic.com/v1/messages', { method: 'GET' })
+      await fetch('https://api.anthropic.com/v1/models', { method: 'POST' })
+      expect(entries.filter((e) => e.msg.startsWith('[llm-fetch]'))).toEqual([])
+    } finally {
+      uninstall()
+    }
+  })
+
+  test('idle timeout aborts a stalled Anthropic proxy stream (the production silent-hang)', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(5)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 100 })
+    let drainErr: Error | null = null
+    try {
+      clock.set(0)
+      const response = await fetch('https://proxy.example.com/anthropic/v1/messages', { method: 'POST' })
+      const reader = response.body!.getReader()
+      const drainPromise = (async () => {
+        try {
+          while (true) {
+            const { done } = await reader.read()
+            if (done) break
+          }
+        } catch (e) {
+          drainErr = e as Error
+        }
+      })()
+      clock.set(105)
+      await scheduler.fire(105)
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    expect(drainErr).not.toBeNull()
+    expect(drainErr!.message).toContain('anthropic SSE body idle for 100ms')
+
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('provider=anthropic')
+    expect(observed[0]!.msg).toContain('cause=idle_timeout')
+  })
+
+  test('a fast 429 JSON error body passes through and logs without tripping a timeout', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    const jsonBody = new TextEncoder().encode(
+      '{"error":{"type":"rate_limit_error","message":"All tokens rate limited"}}',
+    )
+    globalThis.fetch = (async () => {
+      clock.set(8)
+      return new Response(jsonBody, { status: 429, headers: { 'retry-after': '30' } })
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, idleMs: 100, overallMs: 200 })
+    let status: number | null = null
+    let text = ''
+    try {
+      clock.set(0)
+      const response = await fetch('https://api.anthropic.com/v1/messages', { method: 'POST' })
+      status = response.status
+      clock.set(12)
+      text = await response.text()
+    } finally {
+      uninstall()
+    }
+
+    expect(status).toBe(429)
+    expect(text).toContain('All tokens rate limited')
+    expect(scheduler.pending()).toBe(0)
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('provider=anthropic')
+    expect(observed[0]!.msg).toContain('status=429')
+    expect(observed[0]!.msg).toContain('retry_after=30')
+    expect(observed[0]!.msg).toContain('cause=null')
+    expect(observed[0]!.msg).toContain('error=null')
+  })
+
+  test('TYPECLAW_CODEX_FETCH_OBSERVER=off still disables installation (legacy alias)', () => {
+    const { logger } = captureLogger()
+    const before = globalThis.fetch
+    process.env.TYPECLAW_CODEX_FETCH_OBSERVER = 'off'
+    try {
+      const uninstall = installLlmFetchObserver({ logger })
+      expect(globalThis.fetch).toBe(before)
+      uninstall()
+    } finally {
+      delete process.env.TYPECLAW_CODEX_FETCH_OBSERVER
+    }
   })
 
   test('TTFB timeout aborts pending fetch with a retryable error message', async () => {
@@ -425,7 +561,7 @@ describe('installCodexFetchObserver', () => {
       return fetchRejection as unknown as Response
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 50, idleMs: 0 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 50, idleMs: 0 })
     let caught: Error | null = null
     try {
       clock.set(0)
@@ -441,18 +577,19 @@ describe('installCodexFetchObserver', () => {
 
     expect(caught).not.toBeNull()
     expect(caught!.message).toContain('timed out')
-    expect(caught!.message).toContain('15ms'.replace('15', '50'))
+    expect(caught!.message).toContain('50ms')
     expect(underlyingSignal?.aborted).toBe(true)
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    const line = codexLines[0]!.msg
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    const line = observed[0]!.msg
+    expect(line).toContain('provider=codex')
     expect(line).toContain('status=null')
     expect(line).toContain('headers_ms=null')
     expect(line).toContain('first_byte_ms=null')
     expect(line).toContain('total_ms=50')
     expect(line).toContain('cause=ttfb_timeout')
-    expect(line).toMatch(/error="Codex fetch timed out before response headers after 50ms.*"/)
+    expect(line).toMatch(/error="codex fetch timed out before response headers after 50ms.*"/)
   })
 
   test('TTFB timer is cancelled once headers arrive (healthy fast turn)', async () => {
@@ -466,7 +603,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 1000, idleMs: 0 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 1000, idleMs: 0 })
     try {
       clock.set(0)
       const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
@@ -481,11 +618,11 @@ describe('installCodexFetchObserver', () => {
     }
 
     expect(scheduler.pending()).toBe(0)
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    expect(codexLines[0]!.msg).toContain('status=200')
-    expect(codexLines[0]!.msg).toContain('cause=null')
-    expect(codexLines[0]!.msg).toContain('error=null')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('status=200')
+    expect(observed[0]!.msg).toContain('cause=null')
+    expect(observed[0]!.msg).toContain('error=null')
   })
 
   test('TTFB composes with caller-provided AbortSignal (caller abort still wins)', async () => {
@@ -502,7 +639,7 @@ describe('installCodexFetchObserver', () => {
       }) as unknown as Response
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 60000, idleMs: 0 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 60000, idleMs: 0 })
     let caught: Error | null = null
     try {
       const pending = fetch('https://chatgpt.com/backend-api/codex/responses', {
@@ -533,7 +670,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 100 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 100 })
     let drainErr: Error | null = null
     try {
       clock.set(0)
@@ -559,9 +696,9 @@ describe('installCodexFetchObserver', () => {
     expect(drainErr).not.toBeNull()
     expect(drainErr!.message).toContain('idle for 100ms')
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    const line = codexLines[0]!.msg
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    const line = observed[0]!.msg
     expect(line).toContain('status=200')
     expect(line).toContain('cause=idle_timeout')
     expect(line).toMatch(/error=".*idle for 100ms.*"/)
@@ -578,7 +715,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 100 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 100 })
     try {
       clock.set(0)
       const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
@@ -596,11 +733,11 @@ describe('installCodexFetchObserver', () => {
       uninstall()
     }
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    expect(codexLines[0]!.msg).toContain('cause=null')
-    expect(codexLines[0]!.msg).toContain('error=null')
-    expect(codexLines[0]!.msg).toContain('body_bytes=18')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('cause=null')
+    expect(observed[0]!.msg).toContain('error=null')
+    expect(observed[0]!.msg).toContain('body_bytes=18')
   })
 
   test('Overall deadline aborts a slow-trickle stream that never trips the idle timer', async () => {
@@ -622,7 +759,7 @@ describe('installCodexFetchObserver', () => {
 
     // idleMs=100 (small) but each chunk lands inside it, so idle never trips.
     // overallMs=250 is exceeded while chunks are still trickling.
-    const uninstall = installCodexFetchObserver({
+    const uninstall = installLlmFetchObserver({
       logger,
       now: clock.now,
       scheduler,
@@ -664,9 +801,9 @@ describe('installCodexFetchObserver', () => {
     expect(drainErr).not.toBeNull()
     expect(drainErr!.message).toContain('overall deadline')
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    const line = codexLines[0]!.msg
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    const line = observed[0]!.msg
     expect(line).toContain('status=200')
     expect(line).toContain('cause=overall_timeout')
     expect(line).toMatch(/error=".*overall deadline.*"/)
@@ -687,7 +824,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({
+    const uninstall = installLlmFetchObserver({
       logger,
       now: clock.now,
       scheduler,
@@ -719,8 +856,8 @@ describe('installCodexFetchObserver', () => {
 
     expect(drainErr).not.toBeNull()
     expect(drainErr!.message).toContain('overall deadline')
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed[0]!.msg).toContain('cause=overall_timeout')
   })
 
   test('Overall deadline aborts immediately when the budget is already spent on headers', async () => {
@@ -737,7 +874,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({
+    const uninstall = installLlmFetchObserver({
       logger,
       now: clock.now,
       scheduler,
@@ -769,8 +906,8 @@ describe('installCodexFetchObserver', () => {
 
     expect(drainErr).not.toBeNull()
     expect(drainErr!.message).toContain('overall deadline')
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed[0]!.msg).toContain('cause=overall_timeout')
   })
 
   test('Idle abort listener count stays bounded across many chunks (no leak)', async () => {
@@ -807,7 +944,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 10_000 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 10_000 })
     try {
       // when: 100 chunks flow through, each one comfortably inside the idle window
       clock.set(0)
@@ -843,7 +980,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 50, idleMs: 50 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 50, idleMs: 50 })
     try {
       clock.set(0)
       const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
@@ -858,10 +995,10 @@ describe('installCodexFetchObserver', () => {
     }
 
     expect(scheduler.pending()).toBe(0)
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines.length).toBe(1)
-    expect(codexLines[0]!.msg).toContain('status=200')
-    expect(codexLines[0]!.msg).toContain('cause=null')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('status=200')
+    expect(observed[0]!.msg).toContain('cause=null')
   })
 
   test('TYPECLAW_CODEX_TTFB_MS env var overrides default', async () => {
@@ -878,7 +1015,7 @@ describe('installCodexFetchObserver', () => {
       }) as unknown as Response
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
     let caught: Error | null = null
     try {
       clock.set(0)
@@ -895,9 +1032,9 @@ describe('installCodexFetchObserver', () => {
     expect(caught).not.toBeNull()
     expect(caught!.message).toContain('250ms')
 
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines[0]!.msg).toContain('total_ms=250')
-    expect(codexLines[0]!.msg).toContain('cause=ttfb_timeout')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed[0]!.msg).toContain('total_ms=250')
+    expect(observed[0]!.msg).toContain('cause=ttfb_timeout')
   })
 
   test('Overall deadline fires even when the idle timer is disabled', async () => {
@@ -911,7 +1048,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({
+    const uninstall = installLlmFetchObserver({
       logger,
       now: clock.now,
       scheduler,
@@ -943,8 +1080,8 @@ describe('installCodexFetchObserver', () => {
 
     expect(drainErr).not.toBeNull()
     expect(drainErr!.message).toContain('overall deadline')
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed[0]!.msg).toContain('cause=overall_timeout')
   })
 
   test('overallMs=0 disables the overall deadline (stream may run unbounded)', async () => {
@@ -958,7 +1095,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({
+    const uninstall = installLlmFetchObserver({
       logger,
       now: clock.now,
       scheduler,
@@ -979,9 +1116,9 @@ describe('installCodexFetchObserver', () => {
     }
 
     expect(scheduler.pending()).toBe(0)
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines[0]!.msg).toContain('cause=null')
-    expect(codexLines[0]!.msg).toContain('error=null')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed[0]!.msg).toContain('cause=null')
+    expect(observed[0]!.msg).toContain('error=null')
   })
 
   test('TYPECLAW_CODEX_OVERALL_MS env var overrides default', async () => {
@@ -996,7 +1133,7 @@ describe('installCodexFetchObserver', () => {
       return new Response(ctrl.body, { status: 200 })
     }) as unknown as typeof fetch
 
-    const uninstall = installCodexFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 0 })
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, ttfbMs: 0, idleMs: 0 })
     let drainErr: Error | null = null
     try {
       clock.set(0)
@@ -1021,7 +1158,97 @@ describe('installCodexFetchObserver', () => {
 
     expect(drainErr).not.toBeNull()
     expect(drainErr!.message).toContain('300ms')
-    const codexLines = entries.filter((e) => e.msg.startsWith('[codex-fetch]'))
-    expect(codexLines[0]!.msg).toContain('cause=overall_timeout')
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed[0]!.msg).toContain('cause=overall_timeout')
+  })
+
+  test('an unset TYPECLAW_CODEX_*_MS leaves the codex endpoint timeouts undefined (defers to generic/default)', () => {
+    const codex = defaultLlmFetchEndpoints({}).find((e) => e.label === 'codex')
+    expect(codex).toBeDefined()
+    expect(codex!.ttfbMs).toBeUndefined()
+    expect(codex!.idleMs).toBeUndefined()
+    expect(codex!.overallMs).toBeUndefined()
+  })
+
+  test('a set TYPECLAW_CODEX_*_MS pins the codex endpoint override', () => {
+    const codex = defaultLlmFetchEndpoints({
+      TYPECLAW_CODEX_TTFB_MS: '111',
+      TYPECLAW_CODEX_IDLE_MS: '222',
+      TYPECLAW_CODEX_OVERALL_MS: '333',
+    }).find((e) => e.label === 'codex')
+    expect(codex!.ttfbMs).toBe(111)
+    expect(codex!.idleMs).toBe(222)
+    expect(codex!.overallMs).toBe(333)
+  })
+
+  test('generic TYPECLAW_LLM_TTFB_MS applies to Codex when TYPECLAW_CODEX_TTFB_MS is unset', async () => {
+    // given: only the generic var is set; the Codex-specific var is unset, so it
+    // must NOT mask the generic one (the review bug).
+    process.env.TYPECLAW_LLM_TTFB_MS = '70'
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    let underlyingSignal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      underlyingSignal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        underlyingSignal?.addEventListener('abort', () => reject(underlyingSignal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
+    let caught: Error | null = null
+    try {
+      clock.set(0)
+      const pending = fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      clock.set(70)
+      await scheduler.fire(70)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+
+    // then: the 70ms generic TTFB fired for Codex
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('70ms')
+    expect(entries.find((e) => e.msg.startsWith('[llm-fetch]'))!.msg).toContain('cause=ttfb_timeout')
+  })
+
+  test('TYPECLAW_CODEX_TTFB_MS overrides the generic TYPECLAW_LLM_TTFB_MS for Codex', async () => {
+    // given: both vars set; the Codex-specific one must win for the codex endpoint
+    process.env.TYPECLAW_LLM_TTFB_MS = '70'
+    process.env.TYPECLAW_CODEX_TTFB_MS = '40'
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    let underlyingSignal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      underlyingSignal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        underlyingSignal?.addEventListener('abort', () => reject(underlyingSignal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
+    let caught: Error | null = null
+    try {
+      clock.set(0)
+      const pending = fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+      clock.set(40)
+      await scheduler.fire(40)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+
+    // then: the 40ms Codex-specific TTFB fired, not the 70ms generic one
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('40ms')
   })
 })

--- a/src/run/llm-fetch-observer.ts
+++ b/src/run/llm-fetch-observer.ts
@@ -1,57 +1,60 @@
-export type CodexFetchObserverLogger = {
+export type LlmFetchObserverLogger = {
   info: (msg: string) => void
   warn: (msg: string) => void
 }
 
-export type CodexFetchObserverOptions = {
-  logger?: CodexFetchObserverLogger
-  codexHost?: string
+// A provider endpoint the observer should instrument. `match` is host-agnostic
+// on purpose: base URLs are user-configured (ANTHROPIC_BASE_URL, OPENAI_BASE_URL,
+// OpenRouter/LiteLLM/Fireworks/arbitrary proxies), so a host allowlist would be
+// incomplete by design and let a stalled proxy stream slip through unguarded.
+// Path-suffix matching keys off the protocol shape instead of the host.
+export type LlmFetchEndpoint = {
+  // Short identifier surfaced in logs as `provider=<label>` and in timeout
+  // error messages, so a stall is diagnosable without provider-specific text.
+  label: string
+  match: (url: URL, method: string) => boolean
+  // Per-endpoint timeout overrides. Unset falls back to the observer-level
+  // defaults. Set to 0 to disable an individual timer for this endpoint.
+  ttfbMs?: number
+  idleMs?: number
+  overallMs?: number
+}
+
+export type LlmFetchObserverOptions = {
+  logger?: LlmFetchObserverLogger
+  endpoints?: readonly LlmFetchEndpoint[]
   now?: () => number
   // Override the default pre-headers (TTFB) deadline applied to the outer
-  // fetch(). When the codex backend silently holds a request without sending
-  // response headers, this is the timer that releases the request so
-  // `pi-coding-agent`'s `_isRetryableError` can retry. Default: 15_000 ms.
+  // fetch(). When a provider silently holds a request without sending response
+  // headers, this is the timer that releases the request so `pi-coding-agent`'s
+  // `_isRetryableError` can retry. Default: 15_000 ms.
   //
-  // Healthy Codex turns return response headers within ~1s (observed
-  // production p50: ~860ms). The first SSE event (`response.created`) is
-  // emitted before any model work begins and arrives within ~50ms of
-  // headers. Pathological-but-healthy upper bounds: TLS handshake on a cold
-  // connection (~2s), prompt-prefill on a cache miss with large input
-  // (~3s), Cloudflare PoP routing slowness (~2s) — sum ~7s. 15s is ~2x
-  // that, so anything past it is almost certainly the silent-hang failure
-  // mode rather than a real request making progress. False-positive cost
-  // is one retry (~5s extra); false-negative cost is the full Bun socket
-  // deadline (~268s). Aggressive wins.
+  // Healthy turns return response headers within ~1s (observed Codex production
+  // p50: ~860ms). Pathological-but-healthy upper bounds: TLS handshake on a cold
+  // connection (~2s), prompt-prefill on a cache miss with large input (~3s),
+  // edge routing slowness (~2s) — sum ~7s. 15s is ~2x that, so anything past it
+  // is almost certainly the silent-hang failure mode rather than a real request
+  // making progress. False-positive cost is one retry (~5s extra); false-negative
+  // cost is the full Bun socket deadline (~268s). Aggressive wins.
   ttfbMs?: number
   // Override the sliding inter-chunk idle deadline applied to the SSE body
   // reader. Resets on every chunk; if no bytes arrive within this window the
-  // body stream errors. Like the overall deadline, this doubles as a recovery
-  // bound: on a silent stall the user waits this long before the retry fires,
-  // so it should not exceed the overall ceiling. Default 120_000 ms (was
-  // 300_000, which matched `openai/codex`'s Rust CLI but is 5min of dead air
-  // before recovery). 120s is loose enough for OpenAI's keepalive-less
-  // reasoning pauses (the Responses API sends no SSE heartbeats, so a quiet
-  // reasoning window is genuinely byte-silent) while bounded by the overall
-  // cap. Set to 0 to disable just this timer.
+  // body stream errors. Doubles as a recovery bound: on a silent stall the user
+  // waits this long before the retry fires, so it should not exceed the overall
+  // ceiling. Default 120_000 ms. Kept uniform across providers: even though
+  // Anthropic/OpenAI-compatible streams usually emit SSE pings, arbitrary proxies
+  // may not, and a tighter window risks aborting a valid long reasoning pause.
+  // Set to 0 to disable just this timer.
   idleMs?: number
-  // Override the absolute wall-clock ceiling on a single Codex request,
-  // measured from fetch start to body completion. Unlike `idleMs`, it does NOT
-  // reset on chunk arrival, so it catches a "slow-trickle" stream that emits
-  // bytes inside every idle window yet never reaches a terminal SSE event —
-  // the failure mode behind issue #394's multi-minute hang (one observed
-  // request occupied 901s before Bun's OS socket deadline fired). On expiry the
-  // request is aborted with a retryable error, so this also bounds how long a
-  // user waits before the retry fires — keeping it low is a UX requirement, not
-  // just a safety net. Default 300_000 ms (raised from 120_000): the 120s cap
-  // was tuned against a light-turn sample (slowest healthy ~45s, p99 ~30s) and
-  // aborted heavy reasoning turns that were still legitimately trickling bytes
-  // — PR reviews, the `dreaming` memory consolidation, and long channel threads
-  // routinely run a slow-trickle stream past 2min (observed total_ms=120009 with
-  // body_bytes>700k on otherwise-progressing turns). Those are NOT the silent
-  // hang this timer exists to catch; the sliding `idleMs` (still 120s) already
-  // bounds genuine dead air per-chunk, so the wall-clock ceiling only needs to
-  // stop a never-terminating stream. 300s caps a real hang at ~5min while giving
-  // heavy turns the headroom they need. Set to 0 to disable just this timer.
+  // Override the absolute wall-clock ceiling on a single request, measured from
+  // fetch start to body completion. Unlike `idleMs`, it does NOT reset on chunk
+  // arrival, so it catches a "slow-trickle" stream that emits bytes inside every
+  // idle window yet never reaches a terminal SSE event. On expiry the request is
+  // aborted with a retryable error, so this also bounds how long a user waits
+  // before the retry fires. Default 300_000 ms: heavy reasoning turns (PR reviews,
+  // memory consolidation, long channel threads) routinely trickle bytes past 2min
+  // on otherwise-progressing turns, so the ceiling only needs to stop a
+  // never-terminating stream. Set to 0 to disable just this timer.
   overallMs?: number
   // Schedule fn for tests. Receives (delayMs, callback) and returns a handle
   // the wrapper can pass to `clear`. Default: `setTimeout`/`clearTimeout`.
@@ -63,26 +66,69 @@ export type TimeoutScheduler = {
   clear: (handle: unknown) => void
 }
 
-const DEFAULT_CODEX_HOST = 'chatgpt.com'
-const CODEX_PATH_FRAGMENT = '/codex/responses'
-const ENV_DISABLE_OBSERVER = 'TYPECLAW_CODEX_FETCH_OBSERVER'
-const ENV_DISABLE_TIMEOUTS = 'TYPECLAW_CODEX_TIMEOUTS'
-const ENV_TTFB_MS = 'TYPECLAW_CODEX_TTFB_MS'
-const ENV_IDLE_MS = 'TYPECLAW_CODEX_IDLE_MS'
-const ENV_OVERALL_MS = 'TYPECLAW_CODEX_OVERALL_MS'
+// New neutral env vars gate the whole observer and its timeouts; the Codex names
+// stay as backwards-compatible aliases so existing deployments that opted out via
+// TYPECLAW_CODEX_FETCH_OBSERVER=off keep that behavior.
+const ENV_DISABLE_OBSERVER = 'TYPECLAW_LLM_FETCH_OBSERVER'
+const ENV_DISABLE_OBSERVER_LEGACY = 'TYPECLAW_CODEX_FETCH_OBSERVER'
+const ENV_DISABLE_TIMEOUTS = 'TYPECLAW_LLM_TIMEOUTS'
+const ENV_DISABLE_TIMEOUTS_LEGACY = 'TYPECLAW_CODEX_TIMEOUTS'
+const ENV_TTFB_MS = 'TYPECLAW_LLM_TTFB_MS'
+const ENV_IDLE_MS = 'TYPECLAW_LLM_IDLE_MS'
+const ENV_OVERALL_MS = 'TYPECLAW_LLM_OVERALL_MS'
+// Codex keeps its own tuned overrides for the codex endpoint only.
+const ENV_CODEX_TTFB_MS = 'TYPECLAW_CODEX_TTFB_MS'
+const ENV_CODEX_IDLE_MS = 'TYPECLAW_CODEX_IDLE_MS'
+const ENV_CODEX_OVERALL_MS = 'TYPECLAW_CODEX_OVERALL_MS'
 const DEFAULT_TTFB_MS = 15_000
 const DEFAULT_IDLE_MS = 120_000
 const DEFAULT_OVERALL_MS = 300_000
-const LOG_PREFIX = '[codex-fetch]'
+const LOG_PREFIX = '[llm-fetch]'
 
 const defaultScheduler: TimeoutScheduler = {
   set: (delayMs, cb) => setTimeout(cb, delayMs),
   clear: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
 }
 
-const consoleLogger: CodexFetchObserverLogger = {
+const consoleLogger: LlmFetchObserverLogger = {
   info: (m) => console.log(m),
   warn: (m) => console.warn(m),
+}
+
+// Matches a path regardless of the base-URL prefix a proxy prepends (e.g.
+// `/anthropic/v1/messages`). Trailing slash tolerated for proxies that append one.
+function pathEndsWith(pathname: string, suffix: string): boolean {
+  return pathname === suffix || pathname.endsWith(suffix) || pathname.endsWith(`${suffix}/`)
+}
+
+export function defaultLlmFetchEndpoints(env: NodeJS.ProcessEnv = process.env): readonly LlmFetchEndpoint[] {
+  return [
+    {
+      label: 'codex',
+      // Method check matches the pi-ai provider (only POST hits codex/responses);
+      // GETs to the same host (auth probes, etc.) are deliberately ignored.
+      match: (url, method) =>
+        method === 'POST' && url.hostname === 'chatgpt.com' && url.pathname.includes('/codex/responses'),
+      // Only pin a per-endpoint value when the operator explicitly set the
+      // Codex-specific var; unset falls through to the generic TYPECLAW_LLM_*
+      // (or built-in default) so it isn't masked. See readEnvMsOptional.
+      ttfbMs: readEnvMsOptional(env, ENV_CODEX_TTFB_MS),
+      idleMs: readEnvMsOptional(env, ENV_CODEX_IDLE_MS),
+      overallMs: readEnvMsOptional(env, ENV_CODEX_OVERALL_MS),
+    },
+    {
+      label: 'anthropic',
+      match: (url, method) => method === 'POST' && pathEndsWith(url.pathname, '/v1/messages'),
+    },
+    {
+      label: 'openai-compatible',
+      match: (url, method) =>
+        method === 'POST' &&
+        (pathEndsWith(url.pathname, '/v1/chat/completions') ||
+          pathEndsWith(url.pathname, '/chat/completions') ||
+          pathEndsWith(url.pathname, '/v1/responses')),
+    },
+  ]
 }
 
 type InstallState = {
@@ -99,13 +145,14 @@ type InstallState = {
 // still-running agent.
 let installed: InstallState | null = null
 
-// Returns true when the request is for the Codex Responses endpoint and we
-// should attach phase-timing instrumentation. Method check matches the
-// pi-ai provider (only POST hits codex/responses); GETs to the same host
-// (auth probes, etc.) are deliberately ignored.
-function shouldObserve(input: RequestInfo | URL, init: RequestInit | undefined, codexHost: string): boolean {
+// Returns the first endpoint whose matcher claims this request, or null. The
+// matched endpoint's per-endpoint timeout overrides win over observer defaults.
+function matchEndpoint(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  endpoints: readonly LlmFetchEndpoint[],
+): LlmFetchEndpoint | null {
   const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase()
-  if (method !== 'POST') return false
   let urlString: string
   if (typeof input === 'string') urlString = input
   else if (input instanceof URL) urlString = input.toString()
@@ -114,10 +161,12 @@ function shouldObserve(input: RequestInfo | URL, init: RequestInit | undefined, 
   try {
     parsed = new URL(urlString)
   } catch {
-    return false
+    return null
   }
-  if (parsed.hostname !== codexHost) return false
-  return parsed.pathname.includes(CODEX_PATH_FRAGMENT)
+  for (const endpoint of endpoints) {
+    if (endpoint.match(parsed, method)) return endpoint
+  }
+  return null
 }
 
 function quote(value: string | null): string {
@@ -126,6 +175,7 @@ function quote(value: string | null): string {
 }
 
 function formatLine(fields: {
+  provider: string
   status: number | null
   headersMs: number | null
   firstByteMs: number | null
@@ -138,6 +188,7 @@ function formatLine(fields: {
 }): string {
   return [
     LOG_PREFIX,
+    `provider=${fields.provider}`,
     `status=${fields.status === null ? 'null' : fields.status}`,
     `headers_ms=${fields.headersMs === null ? 'null' : fields.headersMs}`,
     `first_byte_ms=${fields.firstByteMs === null ? 'null' : fields.firstByteMs}`,
@@ -150,15 +201,32 @@ function formatLine(fields: {
   ].join(' ')
 }
 
-function readEnvMs(name: string, fallback: number): number {
-  const raw = process.env[name]
-  if (raw === undefined || raw === '') return fallback
+function readEnvMs(env: NodeJS.ProcessEnv, name: string, fallback: number): number {
+  return readEnvMsOptional(env, name) ?? fallback
+}
+
+// `undefined` when the var is unset/blank/invalid, so a per-endpoint override
+// reader can fall THROUGH to the observer defaults instead of pinning a concrete
+// value. This is what lets an unset `TYPECLAW_CODEX_*_MS` defer to the generic
+// `TYPECLAW_LLM_*_MS` (via `envDefaults`) rather than masking it with the raw
+// default — the precedence is opts > TYPECLAW_CODEX_* (when set) > TYPECLAW_LLM_*
+// > built-in default.
+function readEnvMsOptional(env: NodeJS.ProcessEnv, name: string): number | undefined {
+  const raw = env[name]
+  if (raw === undefined || raw === '') return undefined
   const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined
   return parsed
 }
 
+type ResolvedTimeouts = {
+  ttfbMs: number
+  idleMs: number
+  overallMs: number
+}
+
 type BodyTapConfig = {
+  provider: string
   idleMs: number
   overallMs: number
   scheduler: TimeoutScheduler
@@ -172,12 +240,13 @@ function attachBodyTimingTap(
   retryAfter: string | null,
   requestId: string | null,
   now: () => number,
-  logger: CodexFetchObserverLogger,
+  logger: LlmFetchObserverLogger,
   config: BodyTapConfig,
 ): Response {
   if (response.body === null) {
     logger.info(
       formatLine({
+        provider: config.provider,
         status,
         headersMs,
         firstByteMs: null,
@@ -202,6 +271,7 @@ function attachBodyTimingTap(
     settled = true
     logger.info(
       formatLine({
+        provider: config.provider,
         status,
         headersMs,
         firstByteMs,
@@ -235,7 +305,9 @@ function attachBodyTimingTap(
     if (idleHandle !== null) config.scheduler.clear(idleHandle)
     idleHandle = config.scheduler.set(config.idleMs, () => {
       cause = 'idle_timeout'
-      idleController.abort(new Error(`Codex SSE body idle for ${config.idleMs}ms (typeclaw observer timeout)`))
+      idleController.abort(
+        new Error(`${config.provider} SSE body idle for ${config.idleMs}ms (typeclaw observer timeout)`),
+      )
     })
   }
 
@@ -253,7 +325,9 @@ function attachBodyTimingTap(
     overallHandle = config.scheduler.set(remainingOverallMs, () => {
       cause = 'overall_timeout'
       idleController.abort(
-        new Error(`Codex SSE body exceeded overall deadline of ${config.overallMs}ms (typeclaw observer timeout)`),
+        new Error(
+          `${config.provider} SSE body exceeded overall deadline of ${config.overallMs}ms (typeclaw observer timeout)`,
+        ),
       )
     })
   }
@@ -341,8 +415,8 @@ function attachBodyTimingTap(
   })
 }
 
-export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}): () => void {
-  if (process.env[ENV_DISABLE_OBSERVER] === 'off') {
+export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () => void {
+  if (process.env[ENV_DISABLE_OBSERVER] === 'off' || process.env[ENV_DISABLE_OBSERVER_LEGACY] === 'off') {
     return () => {}
   }
   const logger = opts.logger ?? consoleLogger
@@ -351,33 +425,55 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
     return makeRelease(installed.wrapped)
   }
 
-  const codexHost = opts.codexHost ?? DEFAULT_CODEX_HOST
+  const endpoints = opts.endpoints ?? defaultLlmFetchEndpoints()
   const now = opts.now ?? Date.now
   const scheduler = opts.scheduler ?? defaultScheduler
-  const timeoutsEnabled = process.env[ENV_DISABLE_TIMEOUTS] !== 'off'
-  const ttfbMs = timeoutsEnabled ? (opts.ttfbMs ?? readEnvMs(ENV_TTFB_MS, DEFAULT_TTFB_MS)) : 0
-  const idleMs = timeoutsEnabled ? (opts.idleMs ?? readEnvMs(ENV_IDLE_MS, DEFAULT_IDLE_MS)) : 0
-  const overallMs = timeoutsEnabled ? (opts.overallMs ?? readEnvMs(ENV_OVERALL_MS, DEFAULT_OVERALL_MS)) : 0
+  const timeoutsEnabled =
+    process.env[ENV_DISABLE_TIMEOUTS] !== 'off' && process.env[ENV_DISABLE_TIMEOUTS_LEGACY] !== 'off'
+  const envDefaults: ResolvedTimeouts = {
+    ttfbMs: readEnvMs(process.env, ENV_TTFB_MS, DEFAULT_TTFB_MS),
+    idleMs: readEnvMs(process.env, ENV_IDLE_MS, DEFAULT_IDLE_MS),
+    overallMs: readEnvMs(process.env, ENV_OVERALL_MS, DEFAULT_OVERALL_MS),
+  }
   const originalFetch = globalThis.fetch
+
+  // Precedence per timer: explicit observer-level option wins over the endpoint's
+  // own value, which wins over the generic env/default. An explicit `opts.*` means
+  // "force this across all endpoints" (the test seam and any global override),
+  // so it must beat a per-endpoint tuned value. The master `timeoutsEnabled=off`
+  // switch forces every timer to 0 regardless.
+  const resolveTimeouts = (endpoint: LlmFetchEndpoint): ResolvedTimeouts => {
+    if (!timeoutsEnabled) return { ttfbMs: 0, idleMs: 0, overallMs: 0 }
+    return {
+      ttfbMs: opts.ttfbMs ?? endpoint.ttfbMs ?? envDefaults.ttfbMs,
+      idleMs: opts.idleMs ?? endpoint.idleMs ?? envDefaults.idleMs,
+      overallMs: opts.overallMs ?? endpoint.overallMs ?? envDefaults.overallMs,
+    }
+  }
 
   const wrappedImpl = async (
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ): Promise<Response> => {
-    if (!shouldObserve(input, init, codexHost)) {
+    const endpoint = matchEndpoint(input, init, endpoints)
+    if (endpoint === null) {
       return originalFetch(input, init)
     }
+    const timeouts = resolveTimeouts(endpoint)
+    const provider = endpoint.label
     const start = now()
 
     let ttfbCause: 'ttfb_timeout' | null = null
     let ttfbHandle: unknown = null
     let initWithSignal: RequestInit | undefined = init
-    if (ttfbMs > 0) {
+    if (timeouts.ttfbMs > 0) {
       const ttfbController = new AbortController()
-      ttfbHandle = scheduler.set(ttfbMs, () => {
+      ttfbHandle = scheduler.set(timeouts.ttfbMs, () => {
         ttfbCause = 'ttfb_timeout'
         ttfbController.abort(
-          new Error(`Codex fetch timed out before response headers after ${ttfbMs}ms (typeclaw observer timeout)`),
+          new Error(
+            `${provider} fetch timed out before response headers after ${timeouts.ttfbMs}ms (typeclaw observer timeout)`,
+          ),
         )
       })
       const signal = init?.signal ? AbortSignal.any([init.signal, ttfbController.signal]) : ttfbController.signal
@@ -391,11 +487,14 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
       if (ttfbHandle !== null) scheduler.clear(ttfbHandle)
       const isTtfbAbort = ttfbCause === 'ttfb_timeout'
       const surfacedError = isTtfbAbort
-        ? new Error(`Codex fetch timed out before response headers after ${ttfbMs}ms (typeclaw observer timeout)`)
+        ? new Error(
+            `${provider} fetch timed out before response headers after ${timeouts.ttfbMs}ms (typeclaw observer timeout)`,
+          )
         : err
       const message = surfacedError instanceof Error ? surfacedError.message : String(surfacedError)
       logger.info(
         formatLine({
+          provider,
           status: null,
           headersMs: null,
           firstByteMs: null,
@@ -414,8 +513,9 @@ export function installCodexFetchObserver(opts: CodexFetchObserverOptions = {}):
     const retryAfter = response.headers.get('retry-after')
     const requestId = response.headers.get('x-request-id')
     return attachBodyTimingTap(response, start, headersMs, response.status, retryAfter, requestId, now, logger, {
-      idleMs,
-      overallMs,
+      provider,
+      idleMs: timeouts.idleMs,
+      overallMs: timeouts.overallMs,
       scheduler,
     })
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,7 +15,7 @@ import type { LiveSubagentRegistry } from '@/agent/live-subagents'
 import { resolveFallbackChain } from '@/agent/model-fallback'
 import { applyModelRuntimeOverrides } from '@/agent/model-overrides'
 import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
-import { detectProviderError, isThrottleOrOverload } from '@/agent/provider-error'
+import { detectProviderError, isFailoverWorthy } from '@/agent/provider-error'
 import { requestContainerRestart } from '@/agent/restart'
 import { consumeRestartHandoff, type RestartHandoff } from '@/agent/restart-handoff'
 import { sessionMetaPayload } from '@/agent/session-meta'
@@ -1130,7 +1130,7 @@ async function drain(
           currentModelRef: state.activeModelRef,
           session: state.session,
           text: turnText,
-          shouldFailover: (err) => isThrottleOrOverload(err.message),
+          shouldFailover: (err) => isFailoverWorthy(err.message),
           setModelForRef: async (ref) => {
             await state.session.setModel(applyModelRuntimeOverrides(resolveModel(ref), ref))
             state.activeModelRef = ref


### PR DESCRIPTION
Two related fixes so a stalled/failed LLM provider can never leave a channel in silent limbo. Splits cleanly into two commits.

## Background (the incident)

An agent using an Anthropic model routed through a third-party proxy stopped responding. Root cause: the proxy's token pool hit a **usage cap** and returned `429 "All tokens rate limited"` with `retry-after ≈ 3h`, but on the **streaming** path it held the SSE socket open with **zero bytes**. `session.prompt()` → pi-agent-core's `for await (const event of response)` blocked **forever**: the turn never resolved, the router's `catch` never fired, and **nothing was logged or shown to the user** — the only log line was `typing indicator paused … prompt still in flight`.

---

## Commit 1 — `fix(run)`: guard all LLM provider streams against silent stalls

The fetch observer that applies **TTFB / idle / overall** deadlines and aborts a stalled stream was hard-scoped to the **Codex Responses** endpoint only. Every other provider (Anthropic + any Anthropic-compatible proxy, OpenAI-compatible gateways) had **no stall guard**.

- Rename `codex-fetch-observer` → `llm-fetch-observer`; `installLlmFetchObserver` takes an `endpoints` list of `{ label, match, ttfbMs?, idleMs?, overallMs? }`.
- **Host-independent path-suffix matching** (base URLs are user-configured): POST to `…/v1/messages` (anthropic), `…/v1/chat/completions` · `…/chat/completions` · `…/v1/responses` (openai-compatible), plus the existing codex matcher.
- On stall the request aborts → the stream **rejects** and surfaces as a retryable error the fallback path can log and rotate, instead of hanging.
- Neutral `[llm-fetch]` log prefix with `provider=<label>`; new `TYPECLAW_LLM_{FETCH_OBSERVER,TIMEOUTS,TTFB_MS,IDLE_MS,OVERALL_MS}` env vars, with `TYPECLAW_CODEX_*` kept as backwards-compatible aliases + per-endpoint Codex tuning.
- Timeout precedence: **explicit `opts` > per-endpoint > env/default**. Defaults unchanged: 15s / 120s / 300s.

## Commit 2 — `fix(channels)`: reply to the channel when a turn fails on a provider error

Even with the stall now aborting, a **hard-thrown** turn failure (provider 429/usage-limit, account-wide billing/quota/auth, or the observer stall-abort) only logged `prompt threw` and posted **nothing** to the channel. The existing deferred provider-error notice fired only for **soft** errors (`stopReason:'error'`); the throw path never populated `pendingProviderError`.

- Add `detectHardProviderError()` in `provider-error.ts` — the throw counterpart to `detectProviderError()`. Classifies throttle/overload, account-wide faults, and observer stall timeouts into a **redacted** `safeMessage`; returns `null` for internal/network errors so the router stays **silent-with-log** (no channel spam on bugs).
- Add an observer-timeout `SAFE_CLASS` → *"The upstream LLM provider stopped responding and the request timed out. Try again shortly."*
- In the router catch, populate `live.pendingProviderError` (dedup by `turnSeq`, never clobbering a soft error already captured this turn). The existing `finally → maybePostDeferredProviderError` posts the `⚠️ <safeMessage>` notice, **inheriting reply-suppression, retry carry-forward, and one-notice-per-turn** semantics. Fires only after model fallback is exhausted.
- English-only (outbound operator text, not input matching). Raw provider text is never echoed to a channel.

> Note: honoring the proxy's `retry-after` (~3h) for smarter backoff is intentionally out of scope — threading it from fetch → thrown error → fallback adds a new contract; the generic "try again shortly" is enough for this fix.

## Tests

- **Observer:** ported the full suite (renamed, green) + arbitrary-proxy `/v1/messages` idle-timeout (the exact repro), multi-provider matching, GET/unrelated rejection, fast-429 passthrough, legacy off-switch.
- **provider-error:** observer-timeout → timeout-safe message; `detectHardProviderError` non-null for rate-limit/billing/auth/observer-timeout, null for internal/network; no raw-text leak.
- **router:** hard-thrown 429 posts exactly one redacted rate-limit notice; observer stall posts one timeout notice; generic internal throw posts **no** notice (silent-with-log); existing soft-error/401/error-leaf tests still green.

## Checks

- `bun run typecheck` ✅  ·  `bun run lint` ✅ (0 errors; 67 pre-existing warnings in untouched files)  ·  `bun run format:check` ✅  ·  `bun run test` ✅ **10353 pass / 0 fail / 1 skip**