### PR TITLE
fix(channels): stop the bot engaging un-addressed messages in fresh threads

### DIFF
--- a/src/channels/adapters/discord-bot-thread-room.test.ts
+++ b/src/channels/adapters/discord-bot-thread-room.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createDiscordThreadRoomResolver, discordThreadRoom } from './discord-bot-thread-room'
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function fakeFetch(responses: Response[]): { fn: typeof fetch; calls: string[] } {
+  const calls: string[] = []
+  const fn = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    calls.push(url)
+    return responses.shift() ?? new Response(null, { status: 500 })
+  }) as unknown as typeof fetch
+  return { fn, calls }
+}
+
+describe('discordThreadRoom (pure)', () => {
+  test('public/private/announcement thread types map to a thread room', () => {
+    for (const type of [10, 11, 12]) {
+      expect(discordThreadRoom({ type, parent_id: 'parent-c1' })).toEqual({ kind: 'thread', parentChat: 'parent-c1' })
+    }
+  })
+
+  test('a thread without a parent_id still marks a thread room (fail-closed)', () => {
+    expect(discordThreadRoom({ type: 11 })).toEqual({ kind: 'thread' })
+  })
+
+  test('a normal text channel is not a thread room', () => {
+    expect(discordThreadRoom({ type: 0, parent_id: 'category-1' })).toBeUndefined()
+  })
+
+  test('an unknown lookup (fetch failed) fails closed to a bare thread room', () => {
+    // Must NOT be treated as a confirmed non-thread channel — otherwise the
+    // solo-human fallback could still engage an un-addressed fresh thread under
+    // a transient Discord API failure (the original bug shape).
+    expect(discordThreadRoom('unknown')).toEqual({ kind: 'thread' })
+  })
+})
+
+describe('createDiscordThreadRoomResolver', () => {
+  test('enriches a thread channel with room + parentChat', async () => {
+    const { fn } = fakeFetch([jsonResponse({ type: 11, parent_id: 'parent-c1' })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+    expect(await resolve('thread-t1')).toEqual({ kind: 'thread', parentChat: 'parent-c1' })
+  })
+
+  test('returns undefined for a normal channel', async () => {
+    const { fn } = fakeFetch([jsonResponse({ type: 0 })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+    expect(await resolve('chan-c1')).toBeUndefined()
+  })
+
+  test('caches per channel id so a busy thread issues a single fetch', async () => {
+    const { fn, calls } = fakeFetch([jsonResponse({ type: 11, parent_id: 'parent-c1' })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+    await resolve('thread-t1')
+    await resolve('thread-t1')
+    await resolve('thread-t1')
+    expect(calls).toHaveLength(1)
+  })
+
+  test('a failed fetch fails closed to a bare thread room (no parentChat)', async () => {
+    const { fn } = fakeFetch([new Response(null, { status: 500 })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+    expect(await resolve('thread-t1')).toEqual({ kind: 'thread' })
+  })
+
+  test('a failed lookup is NOT cached so the next message retries', async () => {
+    const { fn, calls } = fakeFetch([new Response(null, { status: 500 }), jsonResponse({ type: 0 })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+    expect(await resolve('chan-c1')).toEqual({ kind: 'thread' })
+    expect(await resolve('chan-c1')).toBeUndefined()
+    expect(calls).toHaveLength(2)
+  })
+
+  test('re-fetches after the ttl expires', async () => {
+    let clock = 0
+    const { fn, calls } = fakeFetch([
+      jsonResponse({ type: 11, parent_id: 'p1' }),
+      jsonResponse({ type: 11, parent_id: 'p1' }),
+    ])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn, now: () => clock, ttlMs: 1000 })
+    await resolve('thread-t1')
+    clock = 1001
+    await resolve('thread-t1')
+    expect(calls).toHaveLength(2)
+  })
+})

--- a/src/channels/adapters/discord-bot-thread-room.ts
+++ b/src/channels/adapters/discord-bot-thread-room.ts
@@ -1,0 +1,73 @@
+import type { InboundMessage } from '@/channels/types'
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10'
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+
+// Discord channel `type` values that are threads (public, private, announcement
+// threads). A Discord thread is its OWN channel — a thread message arrives with
+// `chat = <thread-channel-id>` and `thread = null`, unlike Slack where the
+// thread ts rides `thread`. So the only way to know an inbound is in a thread
+// room is to look up the channel's type; the gateway MESSAGE_CREATE event
+// carries no thread/parent signal.
+const DISCORD_THREAD_CHANNEL_TYPES: ReadonlySet<number> = new Set([10, 11, 12])
+
+export type DiscordChannelMeta = { type?: number; parent_id?: string }
+
+// The lookup has THREE outcomes, and the failure case must not be conflated
+// with a confirmed non-thread channel:
+//   - a channel object → we know the type (thread or not)
+//   - 'unknown' → the fetch failed (network / non-OK / rate limit); we cannot
+//     tell, so downstream must fail closed rather than assume "normal channel".
+type ChannelMetaLookup = DiscordChannelMeta | 'unknown'
+
+export type DiscordThreadRoomResolverOptions = {
+  token: string
+  fetchImpl?: typeof fetch
+  now?: () => number
+  ttlMs?: number
+}
+
+// Maps a lookup outcome to the room signal. A confirmed thread carries its
+// parent for membership scoping; a confirmed non-thread returns undefined (the
+// solo fallback may apply). An 'unknown' fetch failure returns a bare thread
+// room WITHOUT parentChat: it fails the engagement gate closed (so the bot
+// won't butt into a possibly-thread it can't classify) while still resolving
+// membership against the thread's own channel — the same conservative posture
+// as a private thread whose parent we can't read.
+export function discordThreadRoom(meta: ChannelMetaLookup): InboundMessage['room'] {
+  if (meta === 'unknown') return { kind: 'thread' }
+  if (meta.type === undefined || !DISCORD_THREAD_CHANNEL_TYPES.has(meta.type)) return undefined
+  return meta.parent_id !== undefined ? { kind: 'thread', parentChat: meta.parent_id } : { kind: 'thread' }
+}
+
+export function createDiscordThreadRoomResolver(
+  options: DiscordThreadRoomResolverOptions,
+): (channelId: string) => Promise<InboundMessage['room']> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const now = options.now ?? Date.now
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const cache = new Map<string, { value: DiscordChannelMeta; expiresAt: number }>()
+
+  return async (channelId: string): Promise<InboundMessage['room']> => {
+    const cached = cache.get(channelId)
+    if (cached !== undefined && cached.expiresAt > now()) return discordThreadRoom(cached.value)
+    // Only CONFIRMED metadata is cached. A failed lookup ('unknown') is not
+    // cached, so the next message on this channel retries rather than pinning
+    // the fail-closed state for the whole TTL.
+    const meta = await fetchChannelMeta(channelId)
+    if (meta !== 'unknown') cache.set(channelId, { value: meta, expiresAt: now() + ttlMs })
+    return discordThreadRoom(meta)
+  }
+
+  async function fetchChannelMeta(channelId: string): Promise<ChannelMetaLookup> {
+    try {
+      const response = await fetchImpl(`${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}`, {
+        headers: { Authorization: `Bot ${options.token}` },
+      })
+      if (!response.ok) return 'unknown'
+      return (await response.json()) as DiscordChannelMeta
+    } catch {
+      return 'unknown'
+    }
+  }
+}

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -55,6 +55,7 @@ import {
   registerCommands,
   type DiscordCommandDeclaration,
 } from './discord-bot-slash-commands'
+import { createDiscordThreadRoomResolver } from './discord-bot-thread-room'
 import { addDiscordMentionHints, type DiscordMentionUser } from './mention-hints'
 
 // One declared slash command per logical agent gesture. /stop maps to the
@@ -954,6 +955,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
   let stopWaiters: Array<() => void> = []
 
   const channelResolver = createDiscordChannelResolver({ token: options.token })
+  const threadRoomResolver = createDiscordThreadRoomResolver({ token: options.token, fetchImpl })
 
   // Discord mentions by snowflake id (`<@id>`/`<@!id>`), so no username form.
   const selfIdentityResolver: ChannelSelfIdentityResolver = () => (botUserId !== null ? { id: botUserId } : null)
@@ -1061,10 +1063,16 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
           }
         },
       })
-      const payload =
+      // Discord threads are their own channels (`chat = thread id`, `thread`
+      // stays null), so the engagement gate cannot see "this is a thread" from
+      // the payload alone. Resolve the channel's type/parent and stamp the
+      // structural `room` signal for guild inbounds; DMs are never thread rooms.
+      const room = event.guild_id !== undefined ? await threadRoomResolver(event.channel_id) : undefined
+      const basePayload =
         referenceResult.referenceContext === undefined
           ? { ...verdict.payload, text: hintedText }
           : { ...verdict.payload, text: hintedText, referenceContext: referenceResult.referenceContext }
+      const payload = room !== undefined ? { ...basePayload, room } : basePayload
 
       const routedTag = await formatChannelTag(payload.workspace, payload.chat)
       logger.info(

--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -275,6 +275,7 @@ describe('slack-bot classifyInbound — route path', () => {
       workspace: TEAM_ID,
       chat: 'C0CHANNEL',
       thread: '1700000000.000100',
+      room: { kind: 'thread' },
       text: `hi <@${BOT_USER_ID}>`,
       externalMessageId: '1700000000.000100',
       reactionRef: encodeSlackReactionRef({ channel: 'C0CHANNEL', ts: '1700000000.000100' }),
@@ -299,6 +300,25 @@ describe('slack-bot classifyInbound — route path', () => {
     if (verdict.kind !== 'route') throw new Error('expected route')
     expect(verdict.payload.isBotMention).toBe(false)
     expect(verdict.payload.thread).toBeNull()
+  })
+
+  test('a flat channel message carries no room signal', () => {
+    const event = buildEvent({ text: 'good morning team' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.room).toBeUndefined()
+  })
+
+  test('a thread reply is stamped with a thread room signal', () => {
+    const event = buildEvent({ text: 'a reply in the thread', thread_ts: '1700000000.000100' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.thread).toBe('1700000000.000100')
+    expect(verdict.payload.room).toEqual({ kind: 'thread' })
   })
 
   test('routes /me messages that mention the bot because they are user-authored messages', () => {

--- a/src/channels/adapters/slack-bot-classify.ts
+++ b/src/channels/adapters/slack-bot-classify.ts
@@ -143,6 +143,7 @@ export function classifyInbound(
       workspace,
       chat: event.channel,
       thread,
+      ...(thread !== null ? { room: { kind: 'thread' as const } } : {}),
       ...(typingThread !== undefined ? { typingThread } : {}),
       text,
       ...(attachments.length > 0 ? { attachments } : {}),

--- a/src/channels/adapters/slack-classify.ts
+++ b/src/channels/adapters/slack-classify.ts
@@ -49,6 +49,7 @@ export function classifyInbound(
       workspace,
       chat: event.channel,
       thread,
+      ...(thread !== null ? { room: { kind: 'thread' as const } } : {}),
       text: rawText,
       externalMessageId: event.ts,
       reactionRef: encodeSlackReactionRef({ channel: event.channel, ts: event.ts }),

--- a/src/channels/engagement.test.ts
+++ b/src/channels/engagement.test.ts
@@ -783,6 +783,287 @@ describe('decideEngagement (solo-human fallback)', () => {
   })
 })
 
+describe('decideEngagement (thread solo-fallback fail-closed gate)', () => {
+  const THREAD_KEY = 'slack-bot:g1:c1:t-root'
+
+  function threadInbound(over: Partial<InboundMessage> = {}): InboundMessage {
+    return inbound({ adapter: 'slack-bot', thread: 't-root', ...over })
+  }
+
+  test('observes an un-addressed thread message when membership is unknown (null)', () => {
+    // given a freshly-opened thread in a busy channel: only the opener has
+    // spoken (persistedHumans === 1) and the thread-scoped membership fetch has
+    // not resolved yet
+    const ledger = new StickyLedger()
+
+    // when a bare human message arrives with no membership evidence
+    const decision = decideEngagement({
+      message: threadInbound(),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 0,
+      participants: [participant('alice')],
+      membership: null,
+    })
+
+    // then it fails closed rather than treating the fresh thread as solo
+    expect(decision).toBe('observe')
+  })
+
+  test('observes an un-addressed thread message when membership is truncated', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: threadInbound(),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 10_000,
+      participants: [participant('alice')],
+      membership: { humans: 1, bots: 0, fetchedAt: 10_000, truncated: true },
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('observes an un-addressed thread message when membership is stale', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: threadInbound(),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 120_000,
+      participants: [participant('alice')],
+      membership: { humans: 1, bots: 0, fetchedAt: 0, truncated: false },
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('reproduces the reported incident: bare compare link plus a request in a fresh thread stays silent', () => {
+    // given the exact production shape: a mention-less, alias-less, reply-less
+    // link + a Japanese "please" opening a thread in a busy multi-human channel
+    const ledger = new StickyLedger()
+
+    // when it lands with no fresh-complete membership proof
+    const decision = decideEngagement({
+      message: threadInbound({
+        text: 'https://github.com/org/repo/compare\n\nお願いします',
+        authorId: 'user-a',
+        authorName: 'user-a',
+      }),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 0,
+      participants: [participant('user-a')],
+      membership: null,
+    })
+
+    // then the bot observes instead of engaging on a message not aimed at it
+    expect(decision).toBe('observe')
+  })
+
+  test('engages a thread only when a fresh complete membership read proves a solo room', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: threadInbound(),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 20_000,
+      participants: [participant('alice')],
+      membership: { humans: 1, bots: 0, fetchedAt: 20_000, truncated: false, humanMemberIds: ['alice'] },
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('observes a thread when fresh complete membership shows two humans', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: threadInbound(),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 20_000,
+      participants: [participant('alice')],
+      membership: { humans: 2, bots: 0, fetchedAt: 20_000, truncated: false },
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('an explicit mention still engages in a thread despite unknown membership', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: threadInbound({ isBotMention: true }),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 0,
+      participants: [participant('alice')],
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('a plain-text alias (Korean) still engages in a thread despite unknown membership', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: threadInbound({ text: '비서 이거 확인해줄 수 있어?', authorId: 'user-a', authorName: 'user-a' }),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 0,
+      participants: [participant('user-a')],
+      selfAliases: ['비서', 'assistant'],
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('a sticky follow-up still engages in a thread despite unknown membership', () => {
+    const ledger = new StickyLedger()
+    ledger.grant(THREAD_KEY, 'alice', 10_000)
+    const decision = decideEngagement({
+      message: threadInbound(),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 1000,
+      participants: [participant('alice')],
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('a DM with a typing-surface thread id still engages (DMs are exempt)', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ adapter: 'slack-bot', isDm: true, thread: 'dm-typing-ts' }),
+      config: baseConfig,
+      key: 'slack-bot:@dm:d1:dm-typing-ts',
+      ledger,
+      now: 0,
+      participants: [participant('alice')],
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('non-thread solo channels keep the legacy answer-everything fallback', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: inbound({ adapter: 'slack-bot', thread: null }),
+      config: baseConfig,
+      key: 'slack-bot:g1:c1:',
+      ledger,
+      now: 0,
+      participants: [participant('alice')],
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('a thread the bot already participates in still engages despite unknown membership', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: threadInbound({ authorId: 'user-a', authorName: 'user-a', text: 'follow-up question' }),
+      config: baseConfig,
+      key: THREAD_KEY,
+      ledger,
+      now: 0,
+      participants: [participant('user-a')],
+      botInThread: true,
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  // Discord models a thread as its own channel: `thread` is null and the thread
+  // id rides `chat`, so the gate must key on the structural `room` signal, not
+  // `thread !== null`. Without this the Discord half of the incident bypasses
+  // the gate entirely.
+  function discordThreadInbound(over: Partial<InboundMessage> = {}): InboundMessage {
+    return inbound({
+      adapter: 'discord-bot',
+      chat: 'thread-t1',
+      thread: null,
+      room: { kind: 'thread', parentChat: 'parent-c1' },
+      ...over,
+    })
+  }
+
+  test('observes an un-addressed Discord thread message (thread=null, room set) when membership is unknown', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: discordThreadInbound(),
+      config: baseConfig,
+      key: 'discord-bot:g1:thread-t1:',
+      ledger,
+      now: 0,
+      participants: [participant('alice')],
+      membership: null,
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('observes an un-addressed Discord thread message when membership is truncated (history-derived)', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: discordThreadInbound(),
+      config: baseConfig,
+      key: 'discord-bot:g1:thread-t1:',
+      ledger,
+      now: 10_000,
+      participants: [participant('alice')],
+      membership: { humans: 1, bots: 0, fetchedAt: 10_000, truncated: true },
+    })
+    expect(decision).toBe('observe')
+  })
+
+  test('engages a Discord thread only when a fresh complete membership read proves a solo room', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: discordThreadInbound(),
+      config: baseConfig,
+      key: 'discord-bot:g1:thread-t1:',
+      ledger,
+      now: 20_000,
+      participants: [participant('alice')],
+      membership: { humans: 1, bots: 0, fetchedAt: 20_000, truncated: false, humanMemberIds: ['alice'] },
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('an explicit mention still engages in a Discord thread despite unknown membership', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: discordThreadInbound({ isBotMention: true }),
+      config: baseConfig,
+      key: 'discord-bot:g1:thread-t1:',
+      ledger,
+      now: 0,
+      participants: [participant('alice')],
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+
+  test('a Discord thread the bot already participates in still engages despite unknown membership', () => {
+    const ledger = new StickyLedger()
+    const decision = decideEngagement({
+      message: discordThreadInbound({ authorId: 'user-a', authorName: 'user-a' }),
+      config: baseConfig,
+      key: 'discord-bot:g1:thread-t1:',
+      ledger,
+      now: 0,
+      participants: [participant('user-a')],
+      botInThread: true,
+      membership: null,
+    })
+    expect(decision).toBe('engage')
+  })
+})
+
 describe('decideEngagement (sticky in groups)', () => {
   test('sticky credit force-engages in a DM', () => {
     const ledger = new StickyLedger()

--- a/src/channels/engagement.ts
+++ b/src/channels/engagement.ts
@@ -216,9 +216,42 @@ export function decideEngagement(input: EngagementInput): EngagementDecision {
   // fallback fix.
   if (targetsSomeoneElse(message, participants, botInThread)) return 'observe'
 
+  // Thread solo-fallback fail-closed gate. A thread is a SEPARATE live session
+  // from its parent channel (the participant/membership key carries the thread
+  // suffix — see `channelKeyId`), so a freshly-opened thread starts with one
+  // known speaker and a cold membership cache. That collapses `effectiveHumans`
+  // to ≤1 and would trip the solo-human fallback below, making the bot butt
+  // into a thread it was never part of in a busy multi-human channel. Membership
+  // is a room property, not a thread property, so a thread may ride the fallback
+  // ONLY on a fresh, complete membership read that itself proves ≤1 human; null
+  // / truncated / stale reads fail closed to `observe`. Exemptions: DMs (solo by
+  // construction) and threads the bot ALREADY participates in (`botInThread` —
+  // an established conversation, not an un-addressed intrusion; this is the same
+  // escape hatch the `replyToOtherMessageId` suppressor uses). Non-thread solo
+  // channels keep the legacy answer-everything fallback untouched.
+  //
+  // `isThreadRoom` reads the structural `room` signal FIRST so this fires for
+  // Discord threads too (their `thread` is null — the thread id lives in
+  // `chat`), falling back to `thread !== null` for Slack-shaped inbounds.
+  if (isThreadRoom(message) && !botInThread && !isFreshCompleteSoloRoom(input.membership, now)) {
+    return 'observe'
+  }
+
   if (effectiveHumans <= 1 && !message.authorIsBot) return 'engage'
 
   return 'observe'
+}
+
+function isThreadRoom(message: InboundMessage): boolean {
+  if (message.isDm) return false
+  return message.room?.kind === 'thread' || message.thread !== null
+}
+
+function isFreshCompleteSoloRoom(membership: MembershipCount | null, now: number): boolean {
+  if (membership === null) return false
+  if (membership.truncated) return false
+  if (now - membership.fetchedAt >= MEMBERSHIP_FRESHNESS_MS) return false
+  return membership.humans <= 1
 }
 
 // Structural "this message is addressed to someone other than us" test. Pure

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8658,6 +8658,109 @@ describe('ChannelRouter cold-start prefetch', () => {
     expect(prompt).toContain('channel-msg-2')
   })
 
+  test('a fresh thread resolves membership under the parent-channel key (thread=null)', async () => {
+    // given: a busy channel (5 humans) and a resolver that records the keys it
+    // was queried with
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const resolvedThreads: (string | null)[] = []
+    router.registerMembership('discord-bot', async (key) => {
+      resolvedThreads.push(key.thread)
+      return { humans: 5, bots: 0, fetchedAt: Date.now(), truncated: false }
+    })
+
+    // when: a brand-new thread cold-starts
+    await router.route(inbound({ thread: 't-A', externalMessageId: 'engage1', text: 'hey bot' }))
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A' })
+
+    // then: every membership query used the parent-channel key, never the thread
+    expect(resolvedThreads.length).toBeGreaterThan(0)
+    expect(resolvedThreads.every((t) => t === null)).toBe(true)
+  })
+
+  test('a fresh thread in a busy channel observes an un-addressed message (solo-fallback fail-closed)', async () => {
+    // given: a channel whose parent membership reports 5 humans
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerMembership('discord-bot', async () => ({
+      humans: 5,
+      bots: 0,
+      fetchedAt: Date.now(),
+      truncated: false,
+    }))
+
+    // when: a fresh thread opens with a plain, un-addressed message (no
+    // mention/reply/alias) — the exact reported-incident shape
+    await router.route(
+      inbound({
+        thread: 't-A',
+        externalMessageId: 'thread-opener',
+        text: 'https://github.com/org/repo/compare',
+        isBotMention: false,
+        replyToBotMessageId: null,
+        replyToOtherMessageId: null,
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: 't-A' })
+
+    // then: the bot stays silent instead of butting in
+    expect(sessions[0]?.prompts ?? []).toHaveLength(0)
+  })
+
+  test('a Discord-shaped thread room (chat=thread-id, thread=null) resolves membership under the parent chat', async () => {
+    // given: a Discord thread inbound — its own channel id in `chat`, `thread`
+    // null, and a `room.parentChat` pointing at the parent channel
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const resolvedChats: string[] = []
+    router.registerMembership('discord-bot', async (key) => {
+      resolvedChats.push(key.chat)
+      return { humans: 5, bots: 0, fetchedAt: Date.now(), truncated: false }
+    })
+
+    // when: the message lands in the thread channel
+    await router.route(
+      inbound({
+        chat: 'thread-t1',
+        thread: null,
+        room: { kind: 'thread', parentChat: 'parent-c1' },
+        externalMessageId: 'engage1',
+        text: 'hey bot',
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'thread-t1', thread: null })
+
+    // then: membership was resolved against the PARENT channel, not the thread
+    expect(resolvedChats.length).toBeGreaterThan(0)
+    expect(resolvedChats.every((c) => c === 'parent-c1')).toBe(true)
+  })
+
+  test('a fresh Discord thread room observes an un-addressed message when membership is unknown', async () => {
+    // given: a resolver that fails (transient) so membership stays null, the
+    // cold-fetch-timeout shape that made the Discord half of the bug fire
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerMembership('discord-bot', async () => ({ kind: 'transient' }))
+
+    // when: a plain un-addressed message opens a Discord thread
+    await router.route(
+      inbound({
+        chat: 'thread-t1',
+        thread: null,
+        room: { kind: 'thread', parentChat: 'parent-c1' },
+        externalMessageId: 'thread-opener',
+        text: 'https://github.com/org/repo/compare',
+        isBotMention: false,
+        replyToBotMessageId: null,
+        replyToOtherMessageId: null,
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'thread-t1', thread: null })
+
+    // then: the bot stays silent (fail-closed) instead of butting in
+    expect(sessions[0]?.prompts ?? []).toHaveLength(0)
+  })
+
   test('reopened session (existing sessionId persisted) skips prefetch', async () => {
     const dir = await tempDir()
     // given: a pre-existing channel→session mapping on disk

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -656,6 +656,11 @@ type ChannelAgentSession = AgentSession & { getAbortReason?: () => string | unde
 type LiveSession = {
   key: ChannelKey
   keyId: string
+  // Structural room shape from the inbound (thread + optional parent channel).
+  // Kept on the session so membership scoping can reach the parent channel for
+  // platforms (Discord) where the thread is its own channel and the key alone
+  // cannot express "this is a thread in channel X". Updated per inbound in route().
+  room: InboundMessage['room']
   session: ChannelAgentSession
   activeModelRef: ReturnType<typeof resolveFallbackChain>[number]
   // The session's creation-time thinking level, captured once. A later escalated
@@ -1561,16 +1566,37 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return merged
   }
 
-  const readMembership = (key: ChannelKey): MembershipCount | null => {
-    if (key.workspace === '@dm') return dmMembership(now())
-    return membershipCaches.get(key.adapter)?.get(key) ?? null
+  // Membership is a ROOM property, not a thread property: every human in the
+  // parent channel can see and join a thread, so a thread has the same
+  // effective human count as its parent channel. The engagement key carries the
+  // thread suffix (`channelKeyId`) to give each thread its own live session and
+  // sticky ledger, but scoping membership by that same key would give a fresh
+  // thread a cold, thread-local count (≤1) and misfire the solo-human fallback.
+  // Resolve/cache/invalidate membership under the PARENT-channel key so a thread
+  // reuses the channel's warm count. Two platform shapes:
+  //   - Slack: the thread ts rides `key.thread`, so stripping it to null reaches
+  //     the parent channel (`key.chat` is already the parent).
+  //   - Discord: the thread is its OWN channel (`key.chat` = thread id,
+  //     `key.thread` = null), so we must repoint `chat` to `room.parentChat`.
+  // DMs keep their own key — a DM's `@dm` workspace short-circuits before this.
+  const membershipScopeKey = (key: ChannelKey, room?: InboundMessage['room']): ChannelKey => {
+    if (key.workspace === '@dm') return key
+    if (room?.parentChat !== undefined) return { ...key, chat: room.parentChat, thread: null }
+    return key.thread === null ? key : { ...key, thread: null }
   }
 
-  const warmMembership = (key: ChannelKey): Promise<MembershipCount | null> | null => {
+  const readMembership = (key: ChannelKey, room?: InboundMessage['room']): MembershipCount | null => {
+    if (key.workspace === '@dm') return dmMembership(now())
+    const scoped = membershipScopeKey(key, room)
+    return membershipCaches.get(scoped.adapter)?.get(scoped) ?? null
+  }
+
+  const warmMembership = (key: ChannelKey, room?: InboundMessage['room']): Promise<MembershipCount | null> | null => {
     if (key.workspace === '@dm') return Promise.resolve(dmMembership(now()))
-    const cache = membershipCaches.get(key.adapter)
+    const scoped = membershipScopeKey(key, room)
+    const cache = membershipCaches.get(scoped.adapter)
     if (cache === undefined) return null
-    return cache.warmUp(key)
+    return cache.warmUp(scoped)
   }
 
   const resolveThroughRegisteredMembership = async (key: ChannelKey): Promise<MembershipResolverResult> => {
@@ -1599,22 +1625,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const membershipForEngagement = async (live: LiveSession): Promise<MembershipCount | null> => {
     if (live.key.workspace === '@dm') return dmMembership(now())
-    const cache = membershipCaches.get(live.key.adapter)
+    const scoped = membershipScopeKey(live.key, live.room)
+    const cache = membershipCaches.get(scoped.adapter)
     if (cache === undefined) return null
 
-    const cached = cache.read(live.key)
+    const cached = cache.read(scoped)
     if (cached.kind === 'hit') return cached.membership
     if (cached.kind === 'stale') {
-      void cache.warmUp(live.key).catch((err) => {
+      void cache.warmUp(scoped).catch((err) => {
         logger.warn(`[channels] membership refresh failed for ${live.keyId}: ${describe(err)}`)
       })
       return cached.membership
     }
 
-    const fetchPromise = live.membershipFetch ?? warmMembership(live.key)
+    const fetchPromise = live.membershipFetch ?? warmMembership(live.key, live.room)
     live.membershipFetch = fetchPromise
     if (fetchPromise === null) return null
-    const membership = await withMembershipTimeout(fetchPromise, live.key, logger)
+    const membership = await withMembershipTimeout(fetchPromise, scoped, logger)
     if (live.membershipFetch === fetchPromise) live.membershipFetch = null
     return membership
   }
@@ -1674,6 +1701,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // is persisted only through the normal success path below — no pre-mutation
     // — so a reopen failure leaves the durable mapping untouched.
     resumeTarget?: { sessionId: string; sessionFile: string },
+    // Inbound room shape, passed so the COLD-START membership warm below is
+    // parent-scoped from the first fetch (Discord threads resolve `chat` to the
+    // thread id, so an unscoped warm would prime the cache against the thread).
+    room?: InboundMessage['room'],
   ): Promise<LiveSession> => {
     const keyId = channelKeyId(key)
     const existing = liveSessions.get(keyId)
@@ -1777,7 +1808,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const phase = resolvedRecord?.sessionId === undefined ? 'cold-start' : 'rehydrate'
       logger.info(`[channels] ${keyId}: ensureLive begin (${phase})`)
       const participants = (resolvedRecord?.participants ?? []) as ChannelParticipant[]
-      const membershipFetch = warmMembership(key)
+      const membershipFetch = warmMembership(key, room)
       // Independent platform lookups — overlap so the chain pays max(), not sum().
       const [resolvedNames, membership] = await Promise.all([
         resolveChannelNames(key),
@@ -1857,6 +1888,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const live: LiveSession = {
         key,
         keyId,
+        room,
         session: created.session,
         activeModelRef: resolveFallbackChain(getConfig().models, undefined)[0]!,
         turnThinkingDefault: created.session.thinkingLevel,
@@ -2941,7 +2973,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const reservation = restartReservations.get(channelKeyId(key))
     if (reservation !== undefined) reservation.sawInbound = true
 
-    const live = await ensureLive(key, event.externalMessageId, event.authorId)
+    const live = await ensureLive(key, event.externalMessageId, event.authorId, undefined, event.room)
+    live.room = event.room
 
     const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
     live.participants = updateParticipants(
@@ -2960,10 +2993,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // *next* turn sees fresh data, but the current turn still gets a
     // fast answer (cache miss → cold fetch with timeout, or stale-ok).
     if (isNewAuthor && live.key.workspace !== '@dm') {
-      const cache = membershipCaches.get(live.key.adapter)
+      const scoped = membershipScopeKey(live.key, live.room)
+      const cache = membershipCaches.get(scoped.adapter)
       if (cache !== undefined) {
-        cache.invalidate(live.key)
-        void cache.warmUp(live.key).catch((err) => {
+        cache.invalidate(scoped)
+        void cache.warmUp(scoped).catch((err) => {
           logger.warn(`[channels] membership warmup after new author failed for ${live.keyId}: ${describe(err)}`)
         })
       }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -51,6 +51,16 @@ export type InboundMessage = {
   workspace: string
   chat: string
   thread: string | null
+  // Structural "this message lives in a thread room" signal, kept SEPARATE
+  // from `thread`. `thread` is a reply-routing field whose meaning differs per
+  // platform: Slack puts the thread ts here (so `thread !== null` ⇒ thread
+  // room), but Discord models a thread as its own channel — the thread's id is
+  // in `chat` and `thread` stays null. The engagement gate and membership
+  // scoping need "is this a thread room?" independent of routing, so adapters
+  // set this explicitly. `parentChat` carries the parent channel id when the
+  // adapter knows it, so membership can be scoped to the room (channel), not
+  // the thread. Absent ⇒ not a thread room (or the adapter cannot tell).
+  room?: { kind: 'thread'; parentChat?: string }
   text: string
   // Prompt-only context for replied-to / quoted / linked messages. Kept out
   // of `text` so the engagement gate sees only the human-authored body.


### PR DESCRIPTION
## Summary

A Slack/Discord bot was engaging with messages that were **not addressed to it** — no `@mention`, no alias, no reply — when they were posted inside a **freshly-opened thread** of a busy multi-human channel. The same message in the channel body is correctly observed (silent). This is the opposite of the "quiet in group chats" contract.

## Root cause

A thread is a **separate live session** from its parent channel: `channelKeyId` embeds the thread suffix, so each thread gets its own participant list and its own membership cache entry, both starting near-empty. When a fresh thread opens:

- `live.participants` holds only the thread opener → `persistedHumans` = 1.
- Membership is resolved/cached under the **thread key**, so it's a cold miss; the cold fetch can time out (→ `null`), or a channel over the 50-member enumeration cap falls back to **thread-scoped history** (→ `humans: 1, truncated: true`).

Either way `effectiveHumans` collapses to ≤1, tripping the **solo-human fallback** (`effectiveHumans <= 1 → engage`) that exists for 1-human DM-like channels. The bot then answers un-addressed messages it would correctly ignore in the channel body.

## Fix (two layers, defense-in-depth)

**1. Router — parent-channel membership scoping** (`src/channels/router.ts`)
New `membershipScopeKey()` strips the thread for non-DM sessions. Membership is a *room* property, not a thread property — every human in the channel can see and join the thread — so `readMembership`, `warmMembership`, `membershipForEngagement`, and the new-author invalidate/warm path now resolve, cache, and invalidate membership under the parent-channel key (`thread=null`). A thread reuses the channel's warm human count instead of a cold, thread-local one.

**2. Engagement — fail-closed thread gate** (`src/channels/engagement.ts`)
Even with parent scoping, membership can still come back `null`/`truncated`/`stale` (cold-fetch timeout, history fallback). A non-DM thread may now ride the solo-human fallback **only** on a *fresh, complete* membership read proving ≤1 human; absence of evidence fails closed to `observe`. Exemptions preserved:
- **DMs** — solo by construction (their `thread` only drives the typing surface).
- **`botInThread`** — threads the bot already participates in are an established conversation, not an un-addressed intrusion (same escape hatch the `replyToOtherMessageId` suppressor uses).

Non-thread solo channels keep the legacy answer-everything fallback untouched.

## Tests

- `engagement.test.ts` — new `thread solo-fallback fail-closed gate` block: incident shape (bare compare link + Japanese "please"), `null`/`truncated`/`stale` → observe, fresh-complete-1 → engage, fresh-2 → observe, mention/alias/sticky still engage, DM exempt, `botInThread` exempt, legacy solo channel unchanged. Includes **Korean and Japanese** input per the repo's multilingual matching convention.
- `router.test.ts` — a fresh thread resolves membership under the parent key (`thread=null`), and a fresh thread in a busy channel observes an un-addressed message.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅ (0 errors)
- `bun run format:check` ✅
- `bun run test` ✅ — **10396 pass / 0 fail**

## Notes

- No behavior change for DMs, solo channels, or threads the bot already participates in.
- Scoped strictly to `src/channels/`; no schema, config, or public-surface changes.
