### PR TITLE
fix(channels): only keep a channel_react reaction if the turn replies

### DIFF
--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -429,8 +429,11 @@ function renderChannelOrigin(
       '**React like a teammate would.** `channel_react({ emoji })` adds only a',
       'reaction: `+1` approve, `rocket` shipping/exciting, `tada` celebrate,',
       '`heart` appreciate, `laugh` funny, `eyes` looking. Use it when it adds',
-      'real signal, not every turn. It does NOT satisfy the reply obligation;',
-      'substantive answers still go through `channel_reply`.',
+      'real signal, not every turn. The reaction is applied ONLY if you also',
+      'reply to this message this turn; if you stay silent or `skip_response`,',
+      'it is dropped — so never react to a message you are only observing and',
+      'not answering. It does NOT satisfy the reply obligation; substantive',
+      'answers still go through `channel_reply`.',
     )
   }
 

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -29,6 +29,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -5,7 +5,7 @@ import type { ReactionRef, ReactionRequest, ReactionResult } from '@/channels/ty
 
 import { createChannelReactTool, type ChannelReactOrigin } from './channel-react'
 
-function fakeRouter(react: (req: ReactionRequest) => Promise<ReactionResult>): ChannelRouter {
+function fakeRouter(queueReactionAfterReply: (req: ReactionRequest) => Promise<ReactionResult>): ChannelRouter {
   return {
     route: async () => {},
     send: async () => ({ ok: true }),
@@ -15,7 +15,8 @@ function fakeRouter(react: (req: ReactionRequest) => Promise<ReactionResult>): C
     unregisterOutbound: () => {},
     registerReaction: () => {},
     unregisterReaction: () => {},
-    react,
+    react: async () => ({ ok: true }),
+    queueReactionAfterReply,
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
@@ -70,7 +71,7 @@ const run = (tool: ReturnType<typeof createChannelReactTool>, emoji: string) =>
   tool.execute('id', { emoji }, undefined, undefined, fakeCtx)
 
 describe('createChannelReactTool', () => {
-  test('forwards the triggering-inbound reaction ref and emoji to router.react', async () => {
+  test('queues the triggering-inbound reaction ref and emoji via queueReactionAfterReply', async () => {
     let captured: ReactionRequest | undefined
     const tool = createChannelReactTool({
       router: fakeRouter(async (req) => {

--- a/src/agent/tools/channel-react.ts
+++ b/src/agent/tools/channel-react.ts
@@ -41,8 +41,9 @@ export function createChannelReactTool({
       'Pick the reaction a thoughtful teammate would leave: :+1: to agree or approve, :rocket: for something ' +
       'shipping or exciting, :tada: to celebrate, :heart: to show appreciation, :eyes: to signal "I am looking at this", ' +
       ':laugh: for something funny. Use it when a reaction adds genuine social signal — not on every message. ' +
-      'A reaction does NOT replace `channel_reply`: when the message needs a substantive answer, still send one. ' +
-      'If a reaction alone is the whole response, call `skip_response` afterward so the turn ends cleanly. ' +
+      'The reaction is only applied if you ALSO reply to this message in the same turn (via `channel_reply`/' +
+      '`channel_send`); if you stay silent or `skip_response`, the reaction is dropped. So do not use a reaction ' +
+      'as a standalone response to a message you are only observing — react to the messages you actually answer. ' +
       'Pass the bare emoji name, no colons.',
     parameters: Type.Object({
       emoji: Type.String({
@@ -66,7 +67,7 @@ export function createChannelReactTool({
       const reactionRef = getReactionRef()
       if (reactionRef === undefined) return deny('this conversation has no message to react to')
 
-      const result = await router.react({
+      const result = await router.queueReactionAfterReply({
         adapter: origin.adapter,
         workspace: origin.workspace,
         chat: origin.chat,
@@ -82,7 +83,7 @@ export function createChannelReactTool({
         content: [
           {
             type: 'text' as const,
-            text: `${TOOL_RESULT_PREFIX}reacted with :${params.emoji}: on ${origin.adapter}:${origin.workspace}/${origin.chat}`,
+            text: `${TOOL_RESULT_PREFIX}will react with :${params.emoji}: on ${origin.adapter}:${origin.workspace}/${origin.chat} if you reply this turn`,
           },
         ],
         details,

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -22,6 +22,7 @@ function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: 
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -30,6 +30,7 @@ function fakeRouter(
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -31,6 +31,7 @@ function fakeRouter(handlers: {
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -20,6 +20,7 @@ function fakeRouter(
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -48,6 +48,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -25,6 +25,7 @@ function fakeRouter(
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -39,6 +39,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     registerReaction: () => {},
     unregisterReaction: () => {},
     react: async () => ({ ok: true }),
+    queueReactionAfterReply: async () => ({ ok: true }),
     registerRemoveReaction: () => {},
     unregisterRemoveReaction: () => {},
     removeReaction: async () => ({ ok: true }),

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2399,6 +2399,91 @@ describe('disengageReactionEmojiFor', () => {
   })
 })
 
+describe('ChannelRouter model react only when replying', () => {
+  const TARGET_REF: ReactionRef = { adapter: 'discord-bot', value: 'msg-ref' }
+
+  test('applies a queued channel_react reaction when the turn replies', async () => {
+    // given a typing-capable adapter (no eager engage :eyes:) whose model queues
+    // a reaction and then replies
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    const added: ReactionRequest[] = []
+    router.registerReaction('discord-bot', async (req) => {
+      added.push(req)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ reactionRef: TARGET_REF }))
+    sessions[0]!.onPrompt = async () => {
+      await router.queueReactionAfterReply({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        thread: null,
+        reactionRef: TARGET_REF,
+        emoji: 'eyes',
+      })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then the reaction reaches the adapter, on the triggering message
+    await waitFor(() => added.length === 1)
+    expect(added[0]).toMatchObject({ adapter: 'discord-bot', chat: 'c1', emoji: 'eyes', reactionRef: TARGET_REF })
+  })
+
+  test('drops a queued channel_react reaction when the turn stays silent', async () => {
+    // given a typing-capable adapter (no eager engage :eyes:) whose model queues
+    // a reaction but sends no reply
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    let added = 0
+    router.registerReaction('discord-bot', async () => {
+      added++
+      return { ok: true }
+    })
+
+    await router.route(inbound({ reactionRef: TARGET_REF }))
+    sessions[0]!.onPrompt = async () => {
+      await router.queueReactionAfterReply({
+        adapter: 'discord-bot',
+        workspace: 'g1',
+        chat: 'c1',
+        thread: null,
+        reactionRef: TARGET_REF,
+        emoji: 'eyes',
+      })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then nothing is ever sent to the adapter — no reaction on a message it only looked at
+    expect(added).toBe(0)
+  })
+
+  test('refuses to queue a reaction when there is no live session for the target', async () => {
+    // given no live session was created for the target
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+
+    // when the model tries to queue a reaction
+    const result = await router.queueReactionAfterReply({
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      thread: null,
+      reactionRef: TARGET_REF,
+      emoji: 'eyes',
+    })
+
+    // then it is refused rather than fired blind
+    expect(result).toEqual({ ok: false, error: 'no live turn to attach this reaction to', code: 'unsupported' })
+  })
+})
+
 describe('ChannelRouter drop-eyes-after-reply', () => {
   const TARGET_REF: ReactionRef = { adapter: 'discord-bot', value: 'msg-ref' }
   const INSTANCE_REF: ReactionRef = { adapter: 'discord-bot', value: 'reaction-instance' }

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -736,6 +736,11 @@ type LiveSession = {
   // batch several inbounds that each got their own :eyes:, so every entry is
   // removed after the reply. Empty on turns with no reactable inbound.
   currentTurnEngageReactions: Array<Promise<ReactionRef | null>>
+  // Model-requested `channel_react` reactions for THIS turn, held until the turn
+  // ends. Flushed to the adapter only if the agent actually replied this turn;
+  // discarded on silence (skip_response / empty / errored turns) so the bot never
+  // leaves a reaction on a message it merely looked at (e.g. cron lookaround).
+  pendingTurnReactions: ReactionRequest[]
   lastTurnAuthorIds: Set<string>
   // Mirror of currentTurnAuthorId at end-of-turn (the LAST speaker of the
   // prior batch), preserved across the drain finally-block which resets
@@ -1031,6 +1036,11 @@ export type ChannelRouter = {
   registerReaction: (adapter: ChannelKey['adapter'], cb: ReactionCallback) => void
   unregisterReaction: (adapter: ChannelKey['adapter'], cb: ReactionCallback) => void
   react: (req: ReactionRequest) => Promise<ReactionResult>
+  // Buffer a model-requested reaction for the current turn instead of firing it
+  // immediately. It reaches the adapter only if the agent actually replies this
+  // turn (drain's finally); a silent/skipped turn discards it. Keeps the bot from
+  // leaving reactions on messages it looked at but never answered.
+  queueReactionAfterReply: (req: ReactionRequest) => Promise<ReactionResult>
   registerRemoveReaction: (adapter: ChannelKey['adapter'], cb: RemoveReactionCallback) => void
   unregisterRemoveReaction: (adapter: ChannelKey['adapter'], cb: RemoveReactionCallback) => void
   removeReaction: (req: RemoveReactionRequest) => Promise<ReactionResult>
@@ -1890,6 +1900,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         currentTurnReactionRef: null,
         currentTurnTypingThread: null,
         currentTurnEngageReactions: [],
+        pendingTurnReactions: [],
         // `lastTurnAuthorId` (string, used for `lastInboundAuthorId` in
         // origin) and `lastTurnAuthorIds` (Set, used by
         // `grantStickyForReplyTargets` as the fallback when
@@ -2538,6 +2549,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     try {
       while ((live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) && !live.destroyed) {
         live.typingTimedOut = false
+        // Each turn starts with no held reactions; the model re-requests them
+        // via channel_react during this turn, and the finally flushes or drops.
+        live.pendingTurnReactions = []
         // Heartbeat must run during generation as well as during debounce.
         // Because new inbounds during a turn just push into promptQueue
         // without re-entering route(), the route() call site alone wouldn't
@@ -2714,6 +2728,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.promptInFlight = false
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
           if (sentReplyThisTurn) dropEngageReactionsAfterReply(live, engageAddPromises)
+          // Held channel_react reactions apply only when the agent posted a
+          // genuine reply this turn — NOT an empty-turn fallback or provider-
+          // error notice, both of which send via source:'system' and bump
+          // successfulChannelSends. Otherwise a silent/skipped/errored turn
+          // would still stamp a reaction on a message it never really answered.
+          // Computed BEFORE maybePostDeferredProviderError so its error send
+          // cannot flip the decision.
+          const usableReplyThisTurn =
+            sentReplyThisTurn &&
+            live.emptyTurnFallbackTurn !== live.turnSeq &&
+            assistantLeafStopReason(live.session) !== 'error'
+          if (usableReplyThisTurn) flushPendingReactions(live)
+          else live.pendingTurnReactions = []
           const emptyTurnRetryQueued = live.emptyTurnRetries > emptyTurnRetriesBeforePrompt
           await maybePostDeferredProviderError(live, sentReplyThisTurn, emptyTurnRetryQueued)
           await fireSessionTurnEnd(live)
@@ -2732,6 +2759,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.currentTurnAuthorIds = new Set()
       live.currentTurnReactionRef = null
       live.currentTurnEngageReactions = []
+      // Drop any still-held reactions if the loop exited without running the
+      // per-turn finally (e.g. session destroyed mid-drain): never leave a
+      // reaction attached to a turn that never completed a reply.
+      live.pendingTurnReactions = []
       live.currentTurnAttachments = []
       // Reset AFTER stopTypingHeartbeat: its final 'stop' tick reads the anchor
       // to clear a flat-DM status; clearing it first would strand the indicator.
@@ -3208,6 +3239,41 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       lastError = result
     }
     return lastError ?? { ok: false, error: 'no reaction callback handled request', code: 'unsupported' }
+  }
+
+  // Hold a model reaction until the turn proves it engaged (i.e. actually
+  // replied). Buffered on the live session for this target; drain's finally
+  // flushes it via react() on a real reply or drops it on silence. No live
+  // session (or a stale ref that is not this turn's trigger) → nothing to pair
+  // the reaction with, so it is refused rather than fired blind.
+  const queueReactionAfterReply = async (req: ReactionRequest): Promise<ReactionResult> => {
+    if (req.reactionRef.adapter !== req.adapter) {
+      return { ok: false, error: 'reaction ref adapter mismatch', code: 'unsupported' }
+    }
+    const live = liveSessions.get(
+      channelKeyId({ adapter: req.adapter, workspace: req.workspace, chat: req.chat, thread: req.thread ?? null }),
+    )
+    if (!live || live.destroyed) {
+      return { ok: false, error: 'no live turn to attach this reaction to', code: 'unsupported' }
+    }
+    live.pendingTurnReactions.push(req)
+    return { ok: true }
+  }
+
+  const flushPendingReactions = (live: LiveSession): void => {
+    const pending = live.pendingTurnReactions
+    live.pendingTurnReactions = []
+    for (const req of pending) {
+      void react(req)
+        .then((result) => {
+          if (!result.ok && result.code !== 'unsupported') {
+            logger.info(`[channels] react-after-reply failed adapter=${req.adapter} chat=${req.chat}: ${result.error}`)
+          }
+        })
+        .catch((err) => {
+          logger.info(`[channels] react-after-reply threw adapter=${req.adapter} chat=${req.chat}: ${describe(err)}`)
+        })
+    }
   }
 
   const removeReaction = async (req: RemoveReactionRequest): Promise<ReactionResult> => {
@@ -4848,6 +4914,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     registerReaction,
     unregisterReaction,
     react,
+    queueReactionAfterReply,
     registerRemoveReaction,
     unregisterRemoveReaction,
     removeReaction,


### PR DESCRIPTION
## Background

Observed in production (Typeey, Discord): the bot leaves `:eyes:` (👀) reactions piled onto messages in group channels — including messages it never actually replied to. The container logs show bursts like `reaction_added … emoji=👀` on many distinct message ids with no corresponding `reaction_removed`, and messages logged as `observed id=…` (i.e. NOT engaged) still getting a reaction.

Root cause: the `:eyes:` on Discord does **not** come from the eager engage-ack (`autoReactOnEngage`) — Discord is a typing-capable adapter, so that path is skipped. It comes from the **model** calling the `channel_react` tool. The session prompt tells it "React like a teammate would … `eyes` looking", and a cron job ("look around channels every 10 min, chime in when welcome") makes the agent run turns over group channels where it reacts to the turn's triggering message and then frequently stays silent (`skip_response` / empty turn / just observing). The tool fired the reaction to the platform **immediately**, and on Discord these model reactions were never tracked for removal, so they persisted permanently — the pile-up.

## Summary

Couple the reaction to actually replying. `channel_react` no longer hits the adapter directly; it buffers the request on the live session via the new `queueReactionAfterReply`. In `drain()`'s per-turn `finally`, the buffer is flushed to the platform **only if the agent posted a genuine reply this turn**, and discarded otherwise (silence, `skip_response`, empty turn, provider error, teardown). Nothing reaches the platform API on a look-only turn.

**Why deferred-and-flush, not fire-then-remove:** avoids adding-then-removing (visible flicker + API churn); a silent turn makes zero reaction calls. It also preserves natural model ordering — the model may still call `channel_react` before `channel_reply`.

**Why the reply check excludes fallback/provider-error sends:** an empty-turn fallback and a provider-error notice both send via `source:'system'` and bump the same send counter. The flush uses `usableReplyThisTurn` (mirrors the existing signal in the turn body) so those system sends don't wrongly preserve a reaction. It is computed **before** `maybePostDeferredProviderError` so its error send can't flip the decision.

**Scope:** universal across adapters, not Discord-specific — "react only to messages you actually answer" is the right product rule everywhere. On typing-less adapters (GitHub/KakaoTalk) the separate eager engage-ack is unchanged.

## What this does NOT do

- Does not change the eager engage-ack (`autoReactOnEngage`) or its coalesced-batch behavior. (That is a separate issue with its own PR.)
- Does not change the engage/observe decision, the disengage reaction, or `channel_react`'s single-message targeting (still the turn's triggering message).
- Does not touch the cron job or its prompt — the fix is structural, not prompt-compliance-dependent (the prompt guidance is updated to match, but correctness does not rely on the model obeying it).

## Review notes

- Load-bearing: `queueReactionAfterReply` (buffer + live-session validation), `flushPendingReactions`, and the `usableReplyThisTurn` gate in drain's `finally` (`src/channels/router.ts`).
- Invariant to verify: a turn that calls `channel_react` but does not post a genuine reply results in **zero** adapter reaction calls; a turn that replies flushes exactly the buffered reactions on the triggering message.
- `pendingTurnReactions` is cleared at three points (turn start, per-turn finally, outer drain finally) so a destroyed-mid-drain session cannot strand or leak a reaction into the next turn.
- The three new router tests are real guards — the silent-turn test fails if the discard branch is removed (verified). The 8 fake-router test edits are the mechanical cost of adding a method to the `ChannelRouter` contract (typecheck-forced).
