### PR TITLE
fix(channels): keep the engage :eyes: on only the last coalesced message

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2509,13 +2509,14 @@ describe('ChannelRouter drop-eyes-after-reply', () => {
     expect(removed[0]).toMatchObject({ adapter: 'discord-bot', chat: 'c1', reactionRef: INSTANCE_REF })
   })
 
-  test('removes every engage reaction when multiple inbounds coalesce into one turn', async () => {
-    // given two inbounds debounced into a single turn, each with its own :eyes:
+  test('rolls the eager eyes onto only the last inbound when several coalesce into one turn', async () => {
+    // given three inbounds debounced into a single turn, each eagerly acked
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
     const instanceFor: Record<string, ReactionRef> = {
       'msg-a': { adapter: 'discord-bot', value: 'instance-a' },
       'msg-b': { adapter: 'discord-bot', value: 'instance-b' },
+      'msg-c': { adapter: 'discord-bot', value: 'instance-c' },
     }
     const removed: RemoveReactionRequest[] = []
     router.registerReaction('discord-bot', async (req) => ({
@@ -2528,17 +2529,77 @@ describe('ChannelRouter drop-eyes-after-reply', () => {
     })
     router.registerOutbound('discord-bot', async () => ({ ok: true }))
 
-    // when both arrive before the debounce flush, then the agent replies once
+    // when all three arrive before the debounce flush, each newer one supersedes
+    // the previous ack, so the earlier eyes are removed before the turn even runs
     await router.route(inbound({ reactionRef: { adapter: 'discord-bot', value: 'msg-a' } }))
     await router.route(inbound({ reactionRef: { adapter: 'discord-bot', value: 'msg-b' } }))
+    await router.route(inbound({ reactionRef: { adapter: 'discord-bot', value: 'msg-c' } }))
+
+    // then only the last message's eyes survives into the turn; the first two are
+    // already rolled off before any reply is produced
+    await waitFor(
+      () =>
+        removed
+          .map((r) => r.reactionRef.value)
+          .sort()
+          .join(',') === 'instance-a,instance-b',
+    )
+
     sessions[0]!.onPrompt = async () => {
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply' })
     }
     await router.__testing!.flushDebounce(KEY)
 
-    // then both engage reactions are removed, not just the last inbound's
-    await waitFor(() => removed.length === 2)
-    expect(removed.map((r) => r.reactionRef.value).sort()).toEqual(['instance-a', 'instance-b'])
+    // and the surviving last-message eyes is removed after the reply lands
+    await waitFor(() => removed.length === 3)
+    expect(removed.map((r) => r.reactionRef.value).sort()).toEqual(['instance-a', 'instance-b', 'instance-c'])
+  })
+
+  test('a later reactionRef-less inbound still rolls off the previous eager eyes', async () => {
+    // given an engaging inbound that gets an eager :eyes:
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const removed: RemoveReactionRequest[] = []
+    router.registerReaction('discord-bot', async () => ({ ok: true, reactionRef: INSTANCE_REF }))
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    // when a newer engaging inbound with NO reactionRef coalesces in
+    await router.route(inbound({ reactionRef: TARGET_REF }))
+    await router.route(inbound({ externalMessageId: 'm2' }))
+
+    // then the previous eyes is stripped even though the new inbound is unreactable
+    await waitFor(() => removed.length === 1)
+    expect(removed[0]).toMatchObject({ reactionRef: INSTANCE_REF })
+
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'reply' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+  })
+
+  test('drops a still-unanswered engage reaction when the session is torn down', async () => {
+    // given an engaged inbound whose turn never replies before teardown
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    const removed: RemoveReactionRequest[] = []
+    router.registerReaction('discord-bot', async () => ({ ok: true, reactionRef: INSTANCE_REF }))
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ reactionRef: TARGET_REF }))
+
+    // when the session is destroyed before the queued turn drains
+    await router.tearDownAllLive()
+
+    // then the stranded eager :eyes: is removed rather than left on the message
+    await waitFor(() => removed.length === 1)
+    expect(removed[0]).toMatchObject({ reactionRef: INSTANCE_REF })
   })
 
   test('keeps the engage reaction when the turn sends no reply', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2727,7 +2727,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         } finally {
           live.promptInFlight = false
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
-          if (sentReplyThisTurn) dropEngageReactionsAfterReply(live, engageAddPromises)
+          if (sentReplyThisTurn) dropEngageReactions(live, engageAddPromises)
           // Held channel_react reactions apply only when the agent posted a
           // genuine reply this turn — NOT an empty-turn fallback or provider-
           // error notice, both of which send via source:'system' and bump
@@ -3159,6 +3159,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     event: InboundMessage,
     engageReaction: Promise<ReactionRef | null> | null,
   ): void => {
+    clearQueuedEngageReactions(live)
     live.promptQueue.push({
       text: event.text,
       ...(event.referenceContext !== undefined ? { referenceContext: event.referenceContext } : {}),
@@ -3329,11 +3330,23 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return addReactionRef
   }
 
-  const dropEngageReactionsAfterReply = (live: LiveSession, addPromises: Array<Promise<ReactionRef | null>>): void => {
-    for (const addPromise of addPromises) dropOneEngageReactionAfterReply(live, addPromise)
+  const dropEngageReactions = (live: LiveSession, addPromises: Array<Promise<ReactionRef | null>>): void => {
+    for (const addPromise of addPromises) dropOneEngageReaction(live, addPromise)
   }
 
-  const dropOneEngageReactionAfterReply = (live: LiveSession, addPromise: Promise<ReactionRef | null>): void => {
+  // Only the LAST engaging inbound of a coalesced batch should carry the eager
+  // :eyes:. Called from enqueue() before the new inbound is pushed to roll the
+  // ack off earlier queued-but-not-yet-drained inbounds. `delete` (not
+  // overwrite) is load-bearing: a newer engaging inbound that has no reactionRef
+  // must still strip the previous :eyes: rather than leave it stranded.
+  const clearQueuedEngageReactions = (live: LiveSession): void => {
+    const addPromises = live.promptQueue.flatMap((m) => (m.engageReaction !== undefined ? [m.engageReaction] : []))
+    if (addPromises.length === 0) return
+    for (const item of live.promptQueue) delete item.engageReaction
+    dropEngageReactions(live, addPromises)
+  }
+
+  const dropOneEngageReaction = (live: LiveSession, addPromise: Promise<ReactionRef | null>): void => {
     void addPromise
       .then((reactionRef) => {
         if (reactionRef === null) return undefined
@@ -4429,6 +4442,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const tearDownLive = async (live: LiveSession): Promise<void> => {
     live.destroyed = true
+    // A teardown before the queued/in-flight turn ever replies would otherwise
+    // strand its eager :eyes: forever (dropEngageReactions only runs after a
+    // successful send). Remove both the queued and current-turn acks here.
+    clearQueuedEngageReactions(live)
+    dropEngageReactions(live, live.currentTurnEngageReactions)
+    live.currentTurnEngageReactions = []
     if (live.debounceTimer) clearTimeout(live.debounceTimer)
     live.debounceTimer = null
     live.unsubProviderErrors?.()


### PR DESCRIPTION
## Background

The eager engagement acknowledgment — a `:eyes:` reaction dropped on the triggering message the moment the agent decides to engage — fires **per inbound** in `route()`, before any batching. It only runs on typing-less adapters (GitHub, KakaoTalk), where there is no typing indicator to signal "the bot is working".

But messages that arrive within the debounce window coalesce into a **single turn** at `drain()`, and the agent produces **one** reply for the whole batch. So a burst that all engages gets a `:eyes:` on *every* message in the batch. The concrete case is a GitHub PR review: GitHub delivers it as N+1 separate webhooks (the review body plus one per inline comment), each independently passes the engage gate, and each gets its own `:eyes:` — even though the agent reviews and answers the batch as one unit. Rapid sticky follow-ups on GitHub/KakaoTalk have the same shape.

## Summary

Keep the eager fire (it preserves fast-ack feedback during the debounce window, which matters most on these slow async channels), but make it **rolling within `promptQueue`**: `enqueue()` now strips the eager reaction off earlier queued-but-not-yet-drained inbounds before pushing the new one. At any moment only the latest engaging message in the pending batch carries `:eyes:`, so the turn's single reply lines up with a single reaction.

**Why roll in `enqueue()` and not defer to `drain()`:** deferring until the batch is known would lose the sub-second ack during the debounce window. `promptQueue` *is* the "not-yet-drained batch" boundary, so rolling within it selects the future batch's last message without new state machinery; `drain()` already treats the last queued inbound as the turn trigger.

**Why `delete` and not overwrite** the `engageReaction` promise: a newer engaging inbound that has *no* `reactionRef` (unreactable) must still strip the previous message's `:eyes:` rather than leave it stranded on a non-triggering message.

Teardown also cleans up: `dropEngageReactions` only runs after a successful send, so a session destroyed mid-turn would otherwise strand the eager ack forever. `tearDownLive()` now drops both the queued and current-turn acks.

## What this does NOT do

- Does not touch typing-capable adapters (Slack/Discord/Telegram) — they never got the eager `:eyes:` in the first place (the typing indicator is their ack).
- Does not change the model-initiated `channel_react` tool (that is a separate PR) or the disengage reaction — both were already scoped to the single triggering message.
- Does not change the engage/observe decision — only which engaged message keeps the acknowledgment.

## Review notes

- Load-bearing: `clearQueuedEngageReactions()` wired into `enqueue()` (rolling supersede) and `tearDownLive()` (stranded-ack cleanup) in `src/channels/router.ts`.
- Invariant to verify: after a coalesced batch, exactly one message retains `:eyes:` and it is the last engaging inbound; the superseded acks are removed *before* the turn produces a reply.
- The rewritten test `rolls the eager eyes onto only the last inbound…` is a real guard — it times out (fails) if the `enqueue()` supersede is removed (verified). Added coverage for the `reactionRef`-less supersede edge case and the teardown cleanup path.
