### PR TITLE
fix(sandbox): ensure mask targets exist so bwrap can bind them

### DIFF
--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -40,6 +40,7 @@ import {
   commandNeedsRealProc,
   DEFAULT_SANDBOX_ENV,
   ensureBwrapAvailable,
+  ensureHiddenMaskTargets,
   ensureSessionTmpDir,
   getProcBindSafetyVerdict,
   isPackageInstallCommand,
@@ -526,6 +527,11 @@ async function applyBashSandbox(
   const sandboxEnvOverlay = buildRoleScopedConfigEnv(agentDir, dirs, envOverlay)
 
   await ensureBwrapAvailable()
+  // bwrap's --ro-bind-data/--tmpfs mask ops abort when the target does not exist
+  // on the (read-only, virtiofs/OrbStack) agent-folder bind. Materialize the mask
+  // targets on the real host FS first; the full {dirs, files} still feeds
+  // subtractMasked below so a masked path is never re-exposed by a later RW bind.
+  const maskTargets = await ensureHiddenMaskTargets({ dirs, files })
   // Per-session /tmp: bind this session's scratch dir over the default
   // --tmpfs /tmp so writes survive across the role's sandboxed bash calls AND
   // match what the write/edit wrapper redirected a /tmp path to. The bind is
@@ -613,8 +619,8 @@ async function applyBashSandbox(
       { type: 'bind', source: sessionTmp, dest: '/tmp' },
     ],
     ...(packageInstall !== undefined
-      ? { writableRoot: { dir: packageInstall.root }, masks: { dirs, files }, protected: packageInstall.protected }
-      : { masks: { dirs, files }, writable, protected: protectedZones }),
+      ? { writableRoot: { dir: packageInstall.root }, masks: maskTargets, protected: packageInstall.protected }
+      : { masks: maskTargets, writable, protected: protectedZones }),
     symlinks,
     network: 'inherit',
     cwd: agentDir,

--- a/src/sandbox/hidden-paths.test.ts
+++ b/src/sandbox/hidden-paths.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { lstat, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { SessionOrigin } from '@/agent/session-origin'
 import { createPermissionService } from '@/permissions/permissions'
 import { rolesConfigSchema, type RolesConfig } from '@/permissions/schema'
 
-import { resolveHiddenPaths } from './hidden-paths'
+import { ensureHiddenMaskTargets, resolveHiddenPaths } from './hidden-paths'
 
 const AGENT = '/agent'
 const hiddenDirs = (agentDir: string) => [
@@ -147,5 +149,69 @@ describe('resolveHiddenPaths — agentDir relativity', () => {
     const { dirs, files } = resolveHiddenPaths(svc, undefined, '/srv/app')
     expect(dirs).toEqual(hiddenDirs('/srv/app'))
     expect(files).toEqual(secretFiles('/srv/app'))
+  })
+})
+
+describe('ensureHiddenMaskTargets', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'tc-mask-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const isRegularFile = async (target: string) => (await lstat(target)).isFile()
+  const isDir = async (target: string) => (await lstat(target)).isDirectory()
+
+  test('materializes an absent secret file so the mask has a real target to bind over', async () => {
+    // given: an agent folder whose .env legitimately does not exist (keys in secrets.json)
+    const env = join(dir, '.env')
+    // when
+    const result = await ensureHiddenMaskTargets({ dirs: [], files: [env] })
+    // then: the placeholder exists and the mask keeps it
+    expect(await isRegularFile(env)).toBe(true)
+    expect(result.files).toEqual([env])
+  })
+
+  test('materializes an absent private dir so a --tmpfs mask has a real mount point', async () => {
+    const workspace = join(dir, 'workspace')
+    const result = await ensureHiddenMaskTargets({ dirs: [workspace], files: [] })
+    expect(await isDir(workspace)).toBe(true)
+    expect(result.dirs).toEqual([workspace])
+  })
+
+  test('leaves an existing secret file untouched and keeps it in the mask', async () => {
+    const secrets = join(dir, 'secrets.json')
+    await writeFile(secrets, '{"real":"content"}')
+    const result = await ensureHiddenMaskTargets({ dirs: [], files: [secrets] })
+    expect(result.files).toEqual([secrets])
+    expect(await Bun.file(secrets).text()).toBe('{"real":"content"}')
+  })
+
+  test('drops a symlinked mask target — a bind would follow it outside the jail', async () => {
+    // given: a symlink squatting the .env mask target
+    const outside = join(dir, 'outside')
+    await writeFile(outside, 'secret')
+    const env = join(dir, '.env')
+    await symlink(outside, env)
+    // when
+    const result = await ensureHiddenMaskTargets({ dirs: [], files: [env] })
+    // then: the symlink is refused, so it never becomes a --ro-bind-data target
+    expect(result.files).toEqual([])
+  })
+
+  test('degrades per target: one unmaterializable entry drops out, the rest survive', async () => {
+    // given: .env is a symlink (dropped), secrets.json is absent (created)
+    const badEnv = join(dir, '.env')
+    await symlink(join(dir, 'nowhere'), badEnv)
+    const secrets = join(dir, 'secrets.json')
+    // when
+    const result = await ensureHiddenMaskTargets({ dirs: [], files: [badEnv, secrets] })
+    // then
+    expect(result.files).toEqual([secrets])
+    expect(await isRegularFile(secrets)).toBe(true)
   })
 })

--- a/src/sandbox/hidden-paths.ts
+++ b/src/sandbox/hidden-paths.ts
@@ -1,3 +1,4 @@
+import { lstat, mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { SessionOrigin } from '@/agent/session-origin'
@@ -38,4 +39,62 @@ export function resolveHiddenPaths(
   const dirs = seesPrivate ? [] : PRIVATE_DIRS.map((d) => join(agentDir, d))
   const files = seesSecrets ? [] : SECRET_FILES.map((f) => join(agentDir, f))
   return { dirs, files }
+}
+
+// SECURITY / bwrap contract: the mask ops REQUIRE a pre-existing target.
+// `--ro-bind-data` (secret files) and `--tmpfs` (private dirs) create their
+// mount point under the agent-folder bind, which fails "Read-only file system"
+// on a virtiofs/OrbStack bind (bwrap cannot create it from its child user
+// namespace). An agent whose folder legitimately lacks `.env` (keys live in
+// secrets.json) would otherwise have EVERY sandboxed bash call abort at setup.
+// Ensure each target on the REAL host FS first — the runtime owns agentDir RW
+// here (only sandboxed bash sees it RO), so an empty placeholder is harmless and
+// the mask binds over a real empty file, leaking nothing.
+//
+// ENSURE, not FILTER: package-install mode makes the jail root RW
+// (`writableRoot: agentDir`), so dropping an absent secret would let sandboxed
+// code CREATE `.env`/`secrets.json` for real (planting) or expose one created
+// mid-session (TOCTOU). A guaranteed target keeps the mask always rendered over
+// it (last-op-wins), closing that hole for both jail modes. A symlink squatting
+// a target is refused and dropped (a bind would follow it out), and each target
+// is best-effort so one bad entry degrades that mask, never aborts sandboxing.
+export async function ensureHiddenMaskTargets(hidden: HiddenPaths): Promise<HiddenPaths> {
+  const dirs = await ensureMaskTargets(hidden.dirs, 'dir')
+  const files = await ensureMaskTargets(hidden.files, 'file')
+  return { dirs, files }
+}
+
+async function ensureMaskTargets(targets: string[], kind: 'dir' | 'file'): Promise<string[]> {
+  const results = await Promise.all(targets.map((target) => ensureMaskTarget(target, kind)))
+  return targets.filter((_, i) => results[i])
+}
+
+async function ensureMaskTarget(target: string, kind: 'dir' | 'file'): Promise<boolean> {
+  try {
+    if (kind === 'dir') await mkdir(target, { recursive: true })
+    else await ensureEmptyFile(target)
+    return await isRealEntry(target, kind)
+  } catch {
+    return false
+  }
+}
+
+async function ensureEmptyFile(target: string): Promise<void> {
+  try {
+    await writeFile(target, '', { flag: 'wx' })
+  } catch {
+    // Already exists or lost a creation race; isRealEntry re-validates the kind
+    // and rejects a symlink, so an existing regular file passes and anything
+    // else is dropped from the mask.
+  }
+}
+
+async function isRealEntry(target: string, kind: 'dir' | 'file'): Promise<boolean> {
+  try {
+    const stats = await lstat(target)
+    if (stats.isSymbolicLink()) return false
+    return kind === 'dir' ? stats.isDirectory() : stats.isFile()
+  } catch {
+    return false
+  }
 }

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -13,7 +13,7 @@ export {
   _resetProcBindProbeCacheForTests,
   _resetRealProcProbeCacheForTests,
 } from './availability'
-export { resolveHiddenPaths, type HiddenPaths } from './hidden-paths'
+export { ensureHiddenMaskTargets, resolveHiddenPaths, type HiddenPaths } from './hidden-paths'
 export {
   resolvePackageInstallZones,
   resolveProtectedZones,


### PR DESCRIPTION
## Background

Every sandboxed bash call from a low-trust role (member/guest) was aborting at bwrap setup with:

```
bwrap: Can't create file at /agent/.env: Read-only file system
```

Even `echo hello` failed — the error fires before the real command runs. Observed in production on an OrbStack host: the agent reported that *all* shell commands were broken and (wrongly) blamed it on a transient container issue that a restart would fix. A restart does not fix it.

**Root cause.** The secret/private mask is emitted unconditionally. For each hidden path `applyBashSandbox` produces `--ro-bind-data <fd> <agentDir>/.env` (secret files) and `--tmpfs <agentDir>/<dir>` (private dirs). Both bwrap ops must **create their mount point** when the target is absent. On the OrbStack/virtiofs agent-folder bind, bwrap — running in its child user namespace — cannot create a file/dir on that backing, so it aborts with `Read-only file system`.

The trigger is a **missing `.env`**: some agents get their provider keys from `secrets.json` and legitimately have no `.env` file. `secrets.json` (which exists) masks fine; `.env` (absent) bricks the whole sandbox. Verified at the kernel level inside the affected container: masking an absent file fails, masking an existing file succeeds, `touch .env` then masking succeeds, and `--tmpfs` over an absent dir fails the same way.

## Summary

Materialize each mask target on the **real host filesystem** in `applyBashSandbox` (new `ensureHiddenMaskTargets`) before building the bwrap command. The runtime process owns `agentDir` RW at that point — only the *sandboxed* bash sees it read-only — so creating an empty placeholder file / empty dir is cheap and harmless. The mask then binds over a real empty file/dir and leaks nothing.

**Why ensure, not filter.** The obvious alternative — drop absent secrets from the mask — is unsafe in package-install mode, where the jail root is RW (`writableRoot: agentDir`). A dropped mask would let sandboxed code *create* `.env`/`secrets.json` for real (file planting), or expose one created mid-session (TOCTOU). Guaranteeing the target exists keeps the `--ro-bind-data` mask always rendered over it (last-op-wins), closing that hole for **both** jail modes with one mechanism. This also matches the existing idiom in `writable-zones.ts` (`ensureProtectedFile`/`ensureProtectedDir`), whose comment already documents the same "bwrap cannot bind a non-existent source" constraint.

**Ordering invariant preserved.** The full (unfiltered) `{ dirs, files }` still feeds `subtractMasked` for the writable/protected sets, so a masked path is never re-exposed by a later RW bind. Only the *materialized* subset is passed as the `masks` policy — the parameter that generates the failing bwrap op.

A symlink squatting a mask target is refused and dropped (a bind would follow it out of the jail), and each target is best-effort: one bad entry degrades that single mask rather than aborting sandboxing.

## What this does NOT do

- Does not change the mask *policy* — which paths are hidden per role (`resolveHiddenPaths`) is unchanged; trusted/owner still get no masks.
- Does not touch `buildSandboxedCommand`, which stays pure (no host I/O by design); all filesystem work lives in the I/O-aware caller.
- Does not add `.env` creation to `init` or any host flow — the placeholder is created lazily, only when a sandboxed role actually runs bash.

## Review notes

- Load-bearing change: `applyBashSandbox` now passes `maskTargets` (materialized subset) to `masks`, while `subtractMasked` keeps consuming the full `{ dirs, files }`. Verify that split is intact — collapsing them would re-open the re-exposure hole.
- `ensureHiddenMaskTargets` rejects symlinks via `lstat` before including a target; the empty `catch` in `ensureEmptyFile` is intentional (create-race tolerance) and re-validated by `isRealEntry`.
- New tests cover: absent secret file materialized, absent private dir materialized, existing file left untouched, symlink dropped, and per-target degradation. All 10387 tests pass locally (typecheck + lint + format clean).