### PR TITLE
feat(mcp): OAuth for HTTP MCP servers

### DIFF
--- a/src/cli/command-meta.test.ts
+++ b/src/cli/command-meta.test.ts
@@ -28,6 +28,7 @@ const COMMAND_LOADERS: Record<BuiltinCommandName, () => Promise<MetaCarrier>> = 
   tunnel: () => import('./tunnel').then((m) => m.tunnelCommand),
   role: () => import('./role').then((m) => m.roleCommand),
   provider: () => import('./provider').then((m) => m.providerCommand),
+  mcp: () => import('./mcp').then((m) => m.mcpCommand),
   model: () => import('./model').then((m) => m.modelCommand),
   mount: () => import('./mount').then((m) => m.mountCommand),
   doctor: () => import('./doctor').then((m) => m.doctorCommand),

--- a/src/cli/command-meta.ts
+++ b/src/cli/command-meta.ts
@@ -27,6 +27,7 @@ export type BuiltinCommandName =
   | 'tunnel'
   | 'role'
   | 'provider'
+  | 'mcp'
   | 'model'
   | 'mount'
   | 'doctor'
@@ -60,6 +61,7 @@ export const BUILTIN_COMMANDS: readonly BuiltinCommandMeta[] = [
   { name: 'tunnel', description: 'manage public tunnels for channels and manual upstreams' },
   { name: 'role', description: 'manage role memberships on this agent' },
   { name: 'provider', description: 'manage LLM provider credentials in secrets.json' },
+  { name: 'mcp', description: 'manage MCP server OAuth credentials' },
   { name: 'model', description: 'manage model profiles in typeclaw.json (models.default, ...)' },
   { name: 'mount', description: 'manage host files and directories mounted into the agent container' },
   { name: 'doctor', description: 'diagnose host, agent folder, and plugins; suggest fixes' },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,6 +33,7 @@ const main = defineCommand({
     tunnel: () => import('./tunnel').then((m) => m.tunnelCommand),
     role: () => import('./role').then((m) => m.roleCommand),
     provider: () => import('./provider').then((m) => m.providerCommand),
+    mcp: () => import('./mcp').then((m) => m.mcpCommand),
     model: () => import('./model').then((m) => m.modelCommand),
     mount: () => import('./mount').then((m) => m.mountCommand),
     doctor: () => import('./doctor').then((m) => m.doctorCommand),

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -1,0 +1,233 @@
+import { spawn } from 'node:child_process'
+import { join } from 'node:path'
+
+import { isCancel, log, note, text } from '@clack/prompts'
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { defineCommand } from 'citty'
+
+import { loadConfigSync } from '@/config'
+import { findAgentDir, isInitialized } from '@/init'
+import { createFileMcpOAuthStore, TypeClawMcpOAuthProvider, listMcpCredentials } from '@/mcp'
+import { SecretsBackend } from '@/secrets'
+
+import { c, done, errorLine } from './ui'
+
+const DEFAULT_CALLBACK_PORT = 1456
+
+const authSub = defineCommand({
+  meta: {
+    name: 'auth',
+    description: 'authenticate an HTTP MCP server with OAuth',
+  },
+  args: {
+    server: { type: 'positional', description: 'MCP server name from typeclaw.json', required: true },
+  },
+  async run({ args }) {
+    const cwd = ensureAgentDir()
+    const result = await runMcpAuthFlow(cwd, args.server)
+    if (!result.ok) {
+      console.error(errorLine(result.reason))
+      process.exit(1)
+    }
+  },
+})
+
+const listSub = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'show configured MCP servers and OAuth credential state',
+  },
+  run() {
+    const cwd = ensureAgentDir()
+    const config = loadConfigSync(cwd)
+    const credentials = listMcpCredentials(join(cwd, 'secrets.json'))
+    if (config.mcpServers.length === 0) {
+      console.log(c.dim('No MCP servers configured in typeclaw.json.'))
+      return
+    }
+    const nameWidth = Math.max(4, ...config.mcpServers.map((server) => server.name.length))
+    const typeWidth = 5
+    console.log(c.dim(`${'NAME'.padEnd(nameWidth)}  ${'TYPE'.padEnd(typeWidth)}  OAUTH`))
+    for (const server of config.mcpServers) {
+      const type = server.url === undefined ? 'stdio' : 'http'
+      const oauth = credentials[server.name] === undefined ? 'not configured' : 'configured'
+      console.log(`${server.name.padEnd(nameWidth)}  ${type.padEnd(typeWidth)}  ${oauth}`)
+    }
+  },
+})
+
+const logoutSub = defineCommand({
+  meta: {
+    name: 'logout',
+    description: 'remove OAuth credentials for an MCP server',
+  },
+  args: {
+    server: { type: 'positional', description: 'MCP server name from typeclaw.json', required: true },
+  },
+  run({ args }) {
+    const cwd = ensureAgentDir()
+    const removed = new SecretsBackend(join(cwd, 'secrets.json')).removeMcpCredentialSync(args.server)
+    if (!removed) log.info(`No OAuth credentials found for MCP server "${args.server}".`)
+    done({
+      title: c.green(`Removed OAuth credentials for MCP server "${args.server}".`),
+      hints: [{ label: 'Apply the secrets.json change:', command: 'typeclaw reload' }],
+    })
+  },
+})
+
+export const mcpCommand = defineCommand({
+  meta: {
+    name: 'mcp',
+    description: 'manage MCP server OAuth credentials',
+  },
+  subCommands: {
+    auth: authSub,
+    list: listSub,
+    logout: logoutSub,
+  },
+})
+
+export type McpAuthFlowResult = { ok: true } | { ok: false; reason: string }
+
+export async function runMcpAuthFlow(cwd: string, serverName: string): Promise<McpAuthFlowResult> {
+  const config = loadConfigSync(cwd)
+  const server = config.mcpServers.find((candidate) => candidate.name === serverName)
+  if (server === undefined) return { ok: false, reason: `MCP server "${serverName}" is not configured.` }
+  if (server.url === undefined)
+    return { ok: false, reason: `MCP server "${serverName}" is stdio-only; OAuth is HTTP-only.` }
+
+  const redirectUrl = `http://localhost:${DEFAULT_CALLBACK_PORT}/callback`
+  let authorizationUrl: URL | undefined
+  const provider = new TypeClawMcpOAuthProvider(serverName, createFileMcpOAuthStore(join(cwd, 'secrets.json')), {
+    mode: 'host',
+    redirectUrl,
+    clientName: 'typeclaw',
+    onRedirect: (url) => {
+      authorizationUrl = url
+    },
+  })
+  const callback = createCallbackServer(DEFAULT_CALLBACK_PORT)
+  try {
+    const transport = new StreamableHTTPClientTransport(new URL(server.url), { authProvider: provider })
+    const client = new Client({ name: 'typeclaw', version: '0.17.0' }, { capabilities: {} })
+    try {
+      await client.connect(transport)
+      await client.close()
+      done({ title: c.green(`MCP server "${serverName}" is already authenticated.`), hints: [] })
+      return { ok: true }
+    } catch (cause) {
+      await client.close().catch(() => undefined)
+      if (!(cause instanceof UnauthorizedError)) throw cause
+    }
+    if (authorizationUrl === undefined)
+      return { ok: false, reason: 'OAuth server did not provide an authorization URL.' }
+    renderAuthorizationUrl(serverName, authorizationUrl)
+    openBrowserBestEffort(authorizationUrl)
+    const expectedState = await provider.state()
+    const codeResult = await Promise.race([callback.code, promptForCodeOrUrl()])
+    if (expectedState !== undefined && codeResult.state !== undefined && codeResult.state !== expectedState) {
+      return { ok: false, reason: 'OAuth callback state did not match the authorization request.' }
+    }
+    await transport.finishAuth(codeResult.code)
+    await verifyMcpAuth(server.url, provider)
+    done({
+      title: c.green(`Authenticated MCP server "${serverName}".`),
+      hints: [{ label: 'Apply the secrets.json change:', command: 'typeclaw reload' }],
+    })
+    return { ok: true }
+  } catch (cause) {
+    return { ok: false, reason: cause instanceof Error ? cause.message : String(cause) }
+  } finally {
+    callback.stop()
+  }
+}
+
+function ensureAgentDir(): string {
+  const cwd = findAgentDir(process.cwd()) ?? process.cwd()
+  if (!isInitialized(cwd)) {
+    console.error(errorLine('TypeClaw config file not found. Run `typeclaw init` first, or cd into an agent folder.'))
+    process.exit(1)
+  }
+  return cwd
+}
+
+function createCallbackServer(port: number): { code: Promise<{ code: string; state?: string }>; stop(): void } {
+  let resolveCode!: (value: { code: string; state?: string }) => void
+  const code = new Promise<{ code: string; state?: string }>((resolve) => {
+    resolveCode = resolve
+  })
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port,
+    fetch(req) {
+      const url = new URL(req.url)
+      if (url.pathname !== '/callback') return new Response('Not found', { status: 404 })
+      const parsed = parseCodeInput(url)
+      if (parsed === null) return new Response('Missing OAuth code', { status: 400 })
+      resolveCode(parsed)
+      return new Response('TypeClaw MCP OAuth complete. You can close this tab.')
+    },
+  })
+  return { code, stop: () => server.stop(true) }
+}
+
+function renderAuthorizationUrl(serverName: string, url: URL): void {
+  note(
+    [
+      `Open this URL in your browser to authenticate MCP server "${serverName}".`,
+      '',
+      'If the browser cannot reach localhost after sign-in, copy the full redirect URL or code and paste it below.',
+    ].join('\n'),
+    'MCP OAuth',
+  )
+  console.log(url.toString())
+  console.log('')
+}
+
+function openBrowserBestEffort(url: URL): void {
+  const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open'
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url.toString()] : [url.toString()]
+  const child = spawn(command, args, { stdio: 'ignore', detached: true })
+  child.on('error', () => undefined)
+  child.unref()
+}
+
+async function promptForCodeOrUrl(): Promise<{ code: string; state?: string }> {
+  const value = await text({
+    message: 'After signing in, paste the code or full redirect URL:',
+    placeholder: 'code, or http://localhost:1456/callback?code=...&state=...',
+  })
+  if (isCancel(value)) throw new Error('OAuth login cancelled by user')
+  const parsed = parseCodeInput(value)
+  if (parsed === null) throw new Error('OAuth callback did not include a code')
+  return parsed
+}
+
+function parseCodeInput(input: string | URL): { code: string; state?: string } | null {
+  if (input instanceof URL) {
+    const code = input.searchParams.get('code')
+    if (code === null || code.trim() === '') return null
+    const state = input.searchParams.get('state') ?? undefined
+    return { code, ...(state === undefined ? {} : { state }) }
+  }
+  const trimmed = input.trim()
+  if (trimmed === '') return null
+  try {
+    return parseCodeInput(new URL(trimmed))
+  } catch {
+    return { code: trimmed }
+  }
+}
+
+async function verifyMcpAuth(url: string, authProvider: TypeClawMcpOAuthProvider): Promise<void> {
+  const client = new Client({ name: 'typeclaw', version: '0.17.0' }, { capabilities: {} })
+  try {
+    const transport = new StreamableHTTPClientTransport(new URL(url), { authProvider })
+    await client.connect(transport)
+    await client.listTools()
+  } finally {
+    await client.close().catch(() => undefined)
+  }
+}

--- a/src/hostd/daemon.test.ts
+++ b/src/hostd/daemon.test.ts
@@ -569,6 +569,83 @@ describe('startDaemon', () => {
     }
   })
 
+  test('HTTP secrets-patch writes MCP credentials while preserving channels and sibling servers', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-daemon-agent-'))
+    try {
+      await writeFile(
+        join(agentDir, 'secrets.json'),
+        JSON.stringify({
+          version: 2,
+          providers: {},
+          channels: { 'discord-bot': { token: { value: 'keep' } } },
+          mcp: { existing: { client: { client_id: 'existing-client' } } },
+        }),
+      )
+      daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
+      const info = await send({ kind: 'http-info' })
+      expect(info.ok).toBe(true)
+      if (!info.ok) return
+      const url = `http://127.0.0.1:${(info.result as HttpInfoResult).port}`
+      await send({ kind: 'register', containerName: 'coder', cwd: agentDir, restartToken: 'secret' })
+
+      const ack = await sendHttp(
+        {
+          kind: 'secrets-patch',
+          containerName: 'coder',
+          patch: {
+            mcp: {
+              server: 'linear',
+              credential: {
+                client: { client_id: 'test-client' },
+                tokens: { access_token: 'access-test', refresh_token: 'refresh-test' },
+              },
+            },
+          },
+        },
+        { url, token: 'secret' },
+      )
+
+      expect(ack.ok).toBe(true)
+      const raw = JSON.parse(await readFile(join(agentDir, 'secrets.json'), 'utf8')) as {
+        channels: Record<string, unknown>
+        mcp: Record<string, unknown>
+      }
+      expect(raw.channels['discord-bot']).toEqual({ token: { value: 'keep' } })
+      expect(raw.mcp.existing).toEqual({ client: { client_id: 'existing-client' } })
+      expect(raw.mcp.linear).toEqual({
+        client: { client_id: 'test-client' },
+        tokens: { access_token: 'access-test', refresh_token: 'refresh-test' },
+      })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('HTTP secrets-patch rejects malformed MCP credential payloads', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-daemon-agent-'))
+    try {
+      daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000 })
+      const info = await send({ kind: 'http-info' })
+      expect(info.ok).toBe(true)
+      if (!info.ok) return
+      const url = `http://127.0.0.1:${(info.result as HttpInfoResult).port}`
+      await send({ kind: 'register', containerName: 'coder', cwd: agentDir, restartToken: 'secret' })
+
+      const ack = await sendHttp(
+        {
+          kind: 'secrets-patch',
+          containerName: 'coder',
+          patch: { mcp: { server: 'linear', credential: 'not-an-object' as unknown as Record<string, unknown> } },
+        },
+        { url, token: 'secret' },
+      )
+
+      expect(ack.ok).toBe(false)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
   test('HTTP restart rejects oversized unauthenticated requests before parsing JSON', async () => {
     daemon = await startDaemon({ exec: fakeExec(), gcIntervalMs: 1_000_000, restart: async () => ({ ok: true }) })
     const info = await send({ kind: 'http-info' })

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -11,6 +11,7 @@ import {
   instagramChannelBlockSchema,
   kakaoChannelBlockSchema,
   lineChannelBlockSchema,
+  mcpCredentialSchema,
   slackChannelBlockSchema,
   webexChannelBlockSchema,
 } from '@/secrets/schema'
@@ -527,19 +528,37 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
 
   const handleSecretsPatch = async (req: {
     containerName: string
-    patch: {
-      channels:
-        | { kakaotalk: unknown }
-        | { discord: unknown }
-        | { instagram: unknown }
-        | { line: unknown }
-        | { webex: unknown }
-        | { slack: unknown }
-    }
+    patch:
+      | {
+          channels:
+            | { kakaotalk: unknown }
+            | { discord: unknown }
+            | { instagram: unknown }
+            | { line: unknown }
+            | { webex: unknown }
+            | { slack: unknown }
+          mcp?: never
+        }
+      | { mcp: { server: unknown; credential: unknown }; channels?: never }
   }): Promise<RpcResponse> =>
     runSerially(req.containerName, async () => {
       const cwd = cwds.get(req.containerName)
       if (!cwd) return { ok: false, reason: `not registered: ${req.containerName}` }
+      if (req.patch.mcp !== undefined) {
+        const server = req.patch.mcp.server
+        if (typeof server !== 'string' || server.length === 0) return { ok: false, reason: 'mcp.server is required' }
+        const parsed = mcpCredentialSchema.safeParse(req.patch.mcp.credential)
+        if (!parsed.success) {
+          return { ok: false, reason: parsed.error.issues.map((issue) => issue.message).join('; ') }
+        }
+        const backend = new SecretsBackend(join(cwd, 'secrets.json'))
+        await backend.updateMcpAsync(async (mcp) => ({
+          result: undefined,
+          next: { ...mcp, [server]: parsed.data },
+        }))
+        const result: SecretsPatchResult = { containerName: req.containerName, patched: true }
+        return { ok: true, result }
+      }
       const channelsPatch = req.patch?.channels
       // Exactly one personal-account channel block per patch. KakaoTalk, LINE,
       // and Webex write their structured account block through this RPC; the

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -4,9 +4,20 @@ import type {
   InstagramChannelBlock,
   KakaoChannelBlock,
   LineChannelBlock,
+  McpCredential,
   SlackChannelBlock,
   WebexChannelBlock,
 } from '@/secrets/schema'
+
+export type SecretsPatchChannels =
+  | { kakaotalk: KakaoChannelBlock }
+  | { discord: DiscordChannelBlock }
+  | { instagram: InstagramChannelBlock }
+  | { line: LineChannelBlock }
+  | { webex: WebexChannelBlock }
+  | { slack: SlackChannelBlock }
+
+export type SecretsPatchMcp = { server: string; credential: McpCredential }
 
 export type Request =
   | {
@@ -25,15 +36,7 @@ export type Request =
   | {
       kind: 'secrets-patch'
       containerName: string
-      patch: {
-        channels:
-          | { kakaotalk: KakaoChannelBlock }
-          | { discord: DiscordChannelBlock }
-          | { instagram: InstagramChannelBlock }
-          | { line: LineChannelBlock }
-          | { webex: WebexChannelBlock }
-          | { slack: SlackChannelBlock }
-      }
+      patch: { channels: SecretsPatchChannels; mcp?: never } | { mcp: SecretsPatchMcp; channels?: never }
     }
   | { kind: 'http-info' }
   | { kind: 'version' }

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 import type { McpServer } from '@/config/config'
 
-import { connectMcpServer, createMcpConnection, resolveServerEnv, type McpSdkClient } from './client'
+import { connectMcpServer, createMcpConnection, createTransport, resolveServerEnv, type McpSdkClient } from './client'
 
 describe('resolveServerEnv', () => {
   test('uses target env key before explicit secret env before secret value', () => {
@@ -159,6 +160,20 @@ describe('connectMcpServer', () => {
   })
 })
 
+describe('createTransport', () => {
+  test('attaches an auth provider only for HTTP servers when one is provided', () => {
+    const authProvider = fakeAuthProvider()
+
+    const withAuth = createTransport(httpServer(), {}, authProvider)
+    const bare = createTransport(httpServer(), {})
+    const stdio = createTransport(server(), {}, authProvider)
+
+    expect(objectGraphContains(withAuth, authProvider)).toBe(true)
+    expect(objectGraphContains(bare, authProvider)).toBe(false)
+    expect(objectGraphContains(stdio, authProvider)).toBe(false)
+  })
+})
+
 function server(timeoutMs?: number): McpServer {
   return {
     name: 'server',
@@ -168,6 +183,54 @@ function server(timeoutMs?: number): McpServer {
     env: {},
     ...(timeoutMs === undefined ? {} : { timeoutMs }),
   }
+}
+
+function httpServer(): McpServer {
+  return {
+    name: 'server',
+    enabled: true,
+    url: 'https://mcp.example.com/mcp',
+    args: [],
+    env: {},
+  }
+}
+
+function fakeAuthProvider(): OAuthClientProvider {
+  return {
+    redirectUrl: 'http://localhost:1456/callback',
+    clientMetadata: {
+      client_name: 'typeclaw',
+      redirect_uris: ['http://localhost:1456/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    },
+    clientInformation() {
+      return undefined
+    },
+    tokens() {
+      return undefined
+    },
+    async saveTokens(_tokens) {},
+    async redirectToAuthorization(_url) {},
+    async saveCodeVerifier(_verifier) {},
+    codeVerifier() {
+      return 'verifier-test'
+    },
+  }
+}
+
+function objectGraphContains(root: unknown, needle: unknown): boolean {
+  const seen = new Set<unknown>()
+  const stack: unknown[] = [root]
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (current === needle) return true
+    if (typeof current !== 'object' || current === null || seen.has(current)) continue
+    seen.add(current)
+    stack.push(...Object.values(current as Record<string, unknown>))
+  }
+  return false
 }
 
 function fakeTransport(): Transport {

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,3 +1,4 @@
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -55,12 +56,13 @@ export async function connectMcpServer(
     connectTimeoutMs?: number
     client?: McpConnectClient
     transport?: Transport
+    authProvider?: OAuthClientProvider
   },
 ): Promise<McpConnection> {
   const requestTimeout = server.timeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS
   const connectTimeout = opts.connectTimeoutMs ?? DEFAULT_MCP_CONNECT_TIMEOUT_MS
   const client = opts.client ?? new Client({ name: 'typeclaw', version: '0.17.0' }, { capabilities: {} })
-  const transport = opts.transport ?? createTransport(server, opts.env)
+  const transport = opts.transport ?? createTransport(server, opts.env, opts.authProvider)
 
   try {
     await withConnectDeadline(connectTimeout, opts.signal, (signal) =>
@@ -141,10 +143,18 @@ export function createMcpConnection(
   }
 }
 
-function createTransport(server: McpServer, env: NodeJS.ProcessEnv): Transport {
-  return server.command
-    ? new StdioClientTransport({ command: server.command, args: server.args, env: resolveServerEnv(server, env) })
-    : new StreamableHTTPClientTransport(new URL(requiredUrl(server)))
+export function createTransport(
+  server: McpServer,
+  env: NodeJS.ProcessEnv,
+  authProvider?: OAuthClientProvider,
+): Transport {
+  if (server.command) {
+    return new StdioClientTransport({ command: server.command, args: server.args, env: resolveServerEnv(server, env) })
+  }
+  const url = new URL(requiredUrl(server))
+  return authProvider === undefined
+    ? new StreamableHTTPClientTransport(url)
+    : new StreamableHTTPClientTransport(url, { authProvider })
 }
 
 async function withConnectDeadline<T>(

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,6 +1,7 @@
 export {
   connectMcpServer,
   createMcpConnection,
+  createTransport,
   resolveServerEnv,
   type McpConnection,
   type McpSdkClient,
@@ -14,6 +15,17 @@ export {
   type McpConnectResult,
   type McpManager,
 } from './manager'
+export {
+  createFileMcpOAuthStore,
+  createHostdMcpOAuthStore,
+  listMcpCredentials,
+  resolveContainerMcpOAuthStore,
+  TypeClawMcpOAuthProvider,
+  type HostdMcpOAuthStoreOptions,
+  type McpOAuthInvalidateScope,
+  type McpOAuthStore,
+  type TypeClawMcpOAuthProviderOptions,
+} from './oauth'
 export { renderMcpCatalog, type McpCatalogServer } from './catalog'
 export {
   createMcpDispatcherTools,

--- a/src/mcp/manager.test.ts
+++ b/src/mcp/manager.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+
 import type { McpServer } from '@/config/config'
 
 import type { McpConnection, McpToolInfo } from './client'
@@ -101,6 +103,23 @@ describe('createMcpManager', () => {
     await manager.connectAll({ signal: abort.signal })
 
     expect(signals).toEqual([abort.signal, abort.signal])
+  })
+
+  test('threads auth providers from the factory to HTTP connector calls', async () => {
+    const authProvider = fakeAuthProvider()
+    const authProviders: Array<OAuthClientProvider | undefined> = []
+    const manager = createMcpManager([httpServer('remote'), server('local')], {
+      env: {},
+      authProvider: (mcpServer) => (mcpServer.url === undefined ? undefined : authProvider),
+      async connect(mcpServer, opts) {
+        authProviders.push(opts.authProvider)
+        return fakeConnection(mcpServer.name, [], [])
+      },
+    })
+
+    await manager.connectAll()
+
+    expect(authProviders).toEqual([authProvider, undefined])
   })
 
   test('fails a duplicate server name fast instead of shadowing the first connection', async () => {
@@ -415,6 +434,35 @@ function paginatedListConnection(name: string, pages: number, pageDelayMs: numbe
 
 function server(name: string, enabled = true): McpServer {
   return { name, enabled, command: 'server-command', args: [], env: {} }
+}
+
+function httpServer(name: string): McpServer {
+  return { name, enabled: true, url: 'https://mcp.example.com/mcp', args: [], env: {} }
+}
+
+function fakeAuthProvider(): OAuthClientProvider {
+  return {
+    redirectUrl: 'http://localhost:1456/callback',
+    clientMetadata: {
+      client_name: 'typeclaw',
+      redirect_uris: ['http://localhost:1456/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    },
+    clientInformation() {
+      return undefined
+    },
+    tokens() {
+      return undefined
+    },
+    async saveTokens(_tokens) {},
+    async redirectToAuthorization(_url) {},
+    async saveCodeVerifier(_verifier) {},
+    codeVerifier() {
+      return 'verifier-test'
+    },
+  }
 }
 
 function fakeConnection(name: string, tools: McpToolInfo[], closed: string[]): McpConnection {

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -1,3 +1,5 @@
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+
 import type { McpServer } from '@/config/config'
 
 import { connectMcpServer, type McpConnection } from './client'
@@ -22,12 +24,14 @@ export type McpManager = {
 
 export type ConnectMcpServerFn = (
   server: McpServer,
-  opts: { env: NodeJS.ProcessEnv; signal?: AbortSignal },
+  opts: { env: NodeJS.ProcessEnv; signal?: AbortSignal; authProvider?: OAuthClientProvider },
 ) => Promise<McpConnection>
+
+export type McpAuthProviderFactory = (server: McpServer) => OAuthClientProvider | undefined
 
 export function createMcpManager(
   servers: McpServer[],
-  opts: { env: NodeJS.ProcessEnv; connect?: ConnectMcpServerFn },
+  opts: { env: NodeJS.ProcessEnv; connect?: ConnectMcpServerFn; authProvider?: McpAuthProviderFactory },
 ): McpManager {
   const activeServers = servers.filter((server) => server.enabled)
   const connect = opts.connect ?? connectMcpServer
@@ -62,7 +66,7 @@ export function createMcpManager(
     const pending = inflight.get(server.name)
     if (pending !== undefined) return pending
 
-    const attempt = connectOne(server, opts.env, connect, signal).then(async (result) => {
+    const attempt = connectOne(server, opts.env, connect, signal, opts.authProvider?.(server)).then(async (result) => {
       inflight.delete(server.name)
       if (result.ok) {
         if (closed) {
@@ -207,10 +211,11 @@ async function connectOne(
   env: NodeJS.ProcessEnv,
   connect: ConnectMcpServerFn,
   signal: AbortSignal | undefined,
+  authProvider: OAuthClientProvider | undefined,
 ): Promise<McpConnectResult> {
   let connection: McpConnection | undefined
   try {
-    connection = await connect(server, { env, signal })
+    connection = await connect(server, { env, signal, authProvider })
     const tools = await connection.listTools()
     return { ok: true, name: server.name, connection, toolCount: tools.length }
   } catch (cause) {

--- a/src/mcp/oauth.test.ts
+++ b/src/mcp/oauth.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth.js'
+import type { OAuthClientInformationMixed, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js'
+
+import { createFileMcpOAuthStore, TypeClawMcpOAuthProvider } from './oauth'
+
+describe('TypeClawMcpOAuthProvider', () => {
+  let dir: string
+  let secretsPath: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'typeclaw-mcp-oauth-'))
+    secretsPath = join(dir, 'secrets.json')
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  test('saves and reloads client, tokens, and discovery through the store', async () => {
+    const store = createFileMcpOAuthStore(secretsPath)
+    const provider = new TypeClawMcpOAuthProvider('linear', store, {
+      mode: 'host',
+      redirectUrl: 'http://localhost:1456/callback',
+      clientName: 'typeclaw',
+      scope: 'read write',
+    })
+    const client: OAuthClientInformationMixed = { client_id: 'test-client' }
+    const tokens: OAuthTokens = {
+      access_token: 'access-test',
+      refresh_token: 'refresh-test',
+      token_type: 'Bearer',
+    }
+    const rotated: OAuthTokens = {
+      access_token: 'access-rotated',
+      refresh_token: 'refresh-rotated',
+      token_type: 'Bearer',
+    }
+    const discovery = { authorizationServerUrl: 'https://mcp.example.com' } as OAuthDiscoveryState
+
+    await provider.saveClientInformation(client)
+    await provider.saveTokens(tokens)
+    await provider.saveDiscoveryState(discovery)
+    await provider.saveTokens(rotated)
+
+    const reloaded = new TypeClawMcpOAuthProvider('linear', createFileMcpOAuthStore(secretsPath), {
+      mode: 'host',
+      redirectUrl: 'http://localhost:1456/callback',
+      clientName: 'typeclaw',
+    })
+    expect(await reloaded.clientInformation()).toEqual(client)
+    expect(await reloaded.tokens()).toEqual(rotated)
+    expect(await reloaded.discoveryState()).toEqual(discovery)
+    const raw = JSON.parse(await readFile(secretsPath, 'utf8')) as { mcp: Record<string, { tokens?: unknown }> }
+    expect(raw.mcp.linear?.tokens).toEqual(rotated)
+  })
+
+  test('keeps PKCE verifier and state ephemeral instead of writing them to secrets.json', async () => {
+    const provider = new TypeClawMcpOAuthProvider('linear', createFileMcpOAuthStore(secretsPath), {
+      mode: 'host',
+      redirectUrl: 'http://localhost:1456/callback',
+      clientName: 'typeclaw',
+    })
+
+    await provider.saveClientInformation({ client_id: 'test-client' })
+    await provider.saveCodeVerifier('verifier-test')
+    const state = await provider.state()
+
+    expect(await provider.codeVerifier()).toBe('verifier-test')
+    expect(state).toBeDefined()
+    const raw = JSON.parse(await readFile(secretsPath, 'utf8')) as { mcp: Record<string, unknown> }
+    expect(JSON.stringify(raw)).not.toContain('verifier-test')
+    expect(JSON.stringify(raw)).not.toContain(state)
+  })
+
+  test('throws an actionable host command instead of opening a browser in container mode', async () => {
+    const provider = new TypeClawMcpOAuthProvider('linear', createFileMcpOAuthStore(secretsPath), {
+      mode: 'container',
+      redirectUrl: 'http://localhost:1456/callback',
+      clientName: 'typeclaw',
+    })
+
+    await expect(provider.redirectToAuthorization(new URL('https://mcp.example.com/oauth'))).rejects.toThrow(
+      'MCP server "linear" needs OAuth. Run on the host: typeclaw mcp auth linear',
+    )
+  })
+
+  test('exposes public-client metadata for SDK dynamic client registration', () => {
+    const provider = new TypeClawMcpOAuthProvider('linear', createFileMcpOAuthStore(secretsPath), {
+      mode: 'host',
+      redirectUrl: 'http://localhost:1456/callback',
+      clientName: 'typeclaw',
+      scope: 'read write',
+    })
+
+    expect(provider.clientMetadata).toEqual({
+      client_name: 'typeclaw',
+      redirect_uris: ['http://localhost:1456/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: 'read write',
+    })
+  })
+})

--- a/src/mcp/oauth.ts
+++ b/src/mcp/oauth.ts
@@ -1,0 +1,212 @@
+import { randomUUID } from 'node:crypto'
+
+import type { OAuthClientProvider, OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth.js'
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js'
+
+import { sendHttp } from '@/hostd/client'
+import type { Request } from '@/hostd/protocol'
+import type { McpCredential, McpSlice } from '@/secrets/schema'
+import { SecretsBackend } from '@/secrets/storage'
+
+export type McpOAuthInvalidateScope = Parameters<NonNullable<OAuthClientProvider['invalidateCredentials']>>[0]
+
+export interface McpOAuthStore {
+  get(server: string): McpCredential | undefined | Promise<McpCredential | undefined>
+  saveClient(server: string, client: OAuthClientInformationMixed): Promise<void>
+  saveTokens(server: string, tokens: OAuthTokens): Promise<void>
+  saveDiscovery(server: string, state: OAuthDiscoveryState): Promise<void>
+  invalidate(server: string, scope: McpOAuthInvalidateScope): Promise<void>
+}
+
+export type TypeClawMcpOAuthProviderOptions = {
+  mode: 'host' | 'container'
+  redirectUrl: string
+  clientName: string
+  scope?: string
+  onRedirect?: (url: URL) => void
+}
+
+export class TypeClawMcpOAuthProvider implements OAuthClientProvider {
+  private verifier: string | undefined
+  private oauthState: string | undefined
+
+  constructor(
+    private readonly serverName: string,
+    private readonly store: McpOAuthStore,
+    private readonly opts: TypeClawMcpOAuthProviderOptions,
+  ) {}
+
+  get redirectUrl(): string {
+    return this.opts.redirectUrl
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      client_name: this.opts.clientName,
+      redirect_uris: [this.opts.redirectUrl],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      ...(this.opts.scope === undefined ? {} : { scope: this.opts.scope }),
+    }
+  }
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    return (await this.store.get(this.serverName))?.client as OAuthClientInformationMixed | undefined
+  }
+
+  async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+    await this.store.saveClient(this.serverName, info)
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    return (await this.store.get(this.serverName))?.tokens as OAuthTokens | undefined
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await this.store.saveTokens(this.serverName, tokens)
+  }
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    return (await this.store.get(this.serverName))?.discovery as OAuthDiscoveryState | undefined
+  }
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    await this.store.saveDiscovery(this.serverName, state)
+  }
+
+  async saveCodeVerifier(verifier: string): Promise<void> {
+    this.verifier = verifier
+  }
+
+  async codeVerifier(): Promise<string> {
+    if (this.verifier === undefined) throw new Error(`MCP server "${this.serverName}" OAuth verifier is missing`)
+    return this.verifier
+  }
+
+  async state(): Promise<string> {
+    this.oauthState ??= randomUUID()
+    return this.oauthState
+  }
+
+  async redirectToAuthorization(url: URL): Promise<void> {
+    if (this.opts.mode === 'container') {
+      throw new Error(
+        `MCP server "${this.serverName}" needs OAuth. Run on the host: typeclaw mcp auth ${this.serverName}`,
+      )
+    }
+    this.opts.onRedirect?.(url)
+  }
+
+  async invalidateCredentials(scope: McpOAuthInvalidateScope): Promise<void> {
+    await this.store.invalidate(this.serverName, scope)
+  }
+}
+
+export function createFileMcpOAuthStore(secretsPath: string): McpOAuthStore {
+  const backend = new SecretsBackend(secretsPath)
+  return {
+    get(server) {
+      return backend.readMcpCredentialSync(server)
+    },
+    async saveClient(server, client) {
+      await patchMcp(backend, server, { client })
+    },
+    async saveTokens(server, tokens) {
+      await patchMcp(backend, server, { tokens })
+    },
+    async saveDiscovery(server, discovery) {
+      await patchMcp(backend, server, { discovery })
+    },
+    async invalidate(server, scope) {
+      await invalidateMcp(backend, server, scope)
+    },
+  }
+}
+
+export type HostdMcpOAuthStoreOptions = {
+  hostdUrl: string
+  restartToken: string
+  containerName: string
+  secretsPath: string
+}
+
+export function createHostdMcpOAuthStore(options: HostdMcpOAuthStoreOptions): McpOAuthStore {
+  const backend = new SecretsBackend(options.secretsPath)
+  const write = async (server: string, credential: McpCredential): Promise<void> => {
+    const request: Extract<Request, { kind: 'secrets-patch' }> = {
+      kind: 'secrets-patch',
+      containerName: options.containerName,
+      patch: { mcp: { server, credential } },
+    }
+    const response = await sendHttp(request, { url: options.hostdUrl, token: options.restartToken })
+    if (!response.ok) throw new Error(`secrets-patch failed: ${response.reason}`)
+  }
+  const patch = async (server: string, fieldPatch: McpCredential): Promise<void> => {
+    await write(server, { ...backend.readMcpCredentialSync(server), ...fieldPatch })
+  }
+  return {
+    get(server) {
+      return backend.readMcpCredentialSync(server)
+    },
+    async saveClient(server, client) {
+      await patch(server, { client })
+    },
+    async saveTokens(server, tokens) {
+      await patch(server, { tokens })
+    },
+    async saveDiscovery(server, discovery) {
+      await patch(server, { discovery })
+    },
+    async invalidate(server, scope) {
+      const credential = invalidateCredential(backend.readMcpCredentialSync(server), scope)
+      if (credential === undefined) return
+      await write(server, credential)
+    },
+  }
+}
+
+async function patchMcp(backend: SecretsBackend, server: string, fieldPatch: McpCredential): Promise<void> {
+  await backend.updateMcpAsync(async (mcp) => ({
+    result: undefined,
+    next: { ...mcp, [server]: { ...mcp[server], ...fieldPatch } },
+  }))
+}
+
+async function invalidateMcp(backend: SecretsBackend, server: string, scope: McpOAuthInvalidateScope): Promise<void> {
+  await backend.updateMcpAsync(async (mcp) => {
+    const credential = invalidateCredential(mcp[server], scope)
+    if (credential === undefined) return { result: undefined }
+    return { result: undefined, next: { ...mcp, [server]: credential } }
+  })
+}
+
+function invalidateCredential(
+  credential: McpCredential | undefined,
+  scope: McpOAuthInvalidateScope,
+): McpCredential | undefined {
+  if (credential === undefined) return undefined
+  const next: McpCredential = { ...credential }
+  if (scope === 'tokens' || scope === 'all') delete next.tokens
+  if (scope === 'client' || scope === 'all') delete next.client
+  if (scope === 'all') delete next.discovery
+  return next
+}
+
+export function resolveContainerMcpOAuthStore(env: NodeJS.ProcessEnv, secretsPath: string): McpOAuthStore {
+  const hostdUrl = env.TYPECLAW_HOSTD_URL
+  const restartToken = env.TYPECLAW_HOSTD_TOKEN
+  const containerName = env.TYPECLAW_CONTAINER_NAME
+  if (hostdUrl && restartToken && containerName) {
+    return createHostdMcpOAuthStore({ hostdUrl, restartToken, containerName, secretsPath })
+  }
+  return createFileMcpOAuthStore(secretsPath)
+}
+
+export function listMcpCredentials(secretsPath: string): McpSlice {
+  return new SecretsBackend(secretsPath).tryReadMcpSync()
+}

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -54,7 +54,7 @@ import {
   type Scheduler,
 } from '@/cron'
 import { CLI_VERSION } from '@/init/cli-version'
-import { createMcpManager } from '@/mcp'
+import { createMcpManager, resolveContainerMcpOAuthStore, TypeClawMcpOAuthProvider } from '@/mcp'
 import { runStartupMigrations } from '@/migrations'
 import { loadPlugins, type LoadPluginsResult, pluginCronJobs, type PluginRegistry, summarizeLoaded } from '@/plugin'
 import { createPluginLogger } from '@/plugin/context'
@@ -239,8 +239,21 @@ async function startAgentRuntime(
 
   const { config: cwdConfig, pluginConfigs: pluginConfigsByName } = loadConfigBundleSync(cwd)
   const githubTokenBridge = createGithubTokenBridge()
+  const mcpOAuthStore = resolveContainerMcpOAuthStore(process.env, join(cwd, 'secrets.json'))
   const mcpManager =
-    cwdConfig.mcpServers.length > 0 ? createMcpManager(cwdConfig.mcpServers, { env: process.env }) : null
+    cwdConfig.mcpServers.length > 0
+      ? createMcpManager(cwdConfig.mcpServers, {
+          env: process.env,
+          authProvider: (server) =>
+            server.url === undefined
+              ? undefined
+              : new TypeClawMcpOAuthProvider(server.name, mcpOAuthStore, {
+                  mode: 'container',
+                  redirectUrl: 'http://localhost:1456/callback',
+                  clientName: 'typeclaw',
+                }),
+        })
+      : null
   const mcpManagerOpt = mcpManager !== null ? { mcpManager } : {}
 
   // Warm up MCP connections in the BACKGROUND so boot doesn't block on each

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -1,4 +1,4 @@
-export { type Channels, type GithubSecretsBlock } from './schema'
+export { type Channels, type GithubSecretsBlock, type McpCredential, type McpSlice } from './schema'
 
 export { createSecretsStoreForAgent, SecretsBackend } from './storage'
 

--- a/src/secrets/kakao-store.container-mode.test.ts
+++ b/src/secrets/kakao-store.container-mode.test.ts
@@ -50,7 +50,9 @@ function startFakeHostd(
       patches.push(rpc)
       if (rpc.kind !== 'secrets-patch') return json({ ok: false, reason: 'unsupported' }, 403)
       if (rpc.containerName !== containerName) return json({ ok: false, reason: 'not registered' }, 403)
-      if (!('kakaotalk' in rpc.patch.channels)) return json({ ok: false, reason: 'expected kakaotalk patch' }, 403)
+      if (rpc.patch.channels === undefined || !('kakaotalk' in rpc.patch.channels)) {
+        return json({ ok: false, reason: 'expected kakaotalk patch' }, 403)
+      }
       const block = kakaoChannelBlockSchema.parse(rpc.patch.channels.kakaotalk)
       await new SecretsBackend(secretsPath).updateChannelsAsync(async (channels) => ({
         result: undefined,

--- a/src/secrets/line-store.test.ts
+++ b/src/secrets/line-store.test.ts
@@ -102,7 +102,7 @@ describe('SecretsLineCredentialStore container mode', () => {
           const rpc = (await req.json()) as Request
           patches.push(rpc)
           if (rpc.kind !== 'secrets-patch') return Response.json({ ok: false, reason: 'unsupported' }, { status: 403 })
-          if (!('line' in rpc.patch.channels)) {
+          if (rpc.patch.channels === undefined || !('line' in rpc.patch.channels)) {
             return Response.json({ ok: false, reason: 'expected line patch' }, { status: 403 })
           }
           const lineBlock = rpc.patch.channels.line

--- a/src/secrets/schema.test.ts
+++ b/src/secrets/schema.test.ts
@@ -41,6 +41,32 @@ describe('parseSecretsFile (v2 envelope)', () => {
     if (!result.ok) return
     expect(result.file.providers).toEqual({})
     expect(result.file.channels).toEqual({})
+    expect(result.file.mcp).toEqual({})
+  })
+
+  test('accepts and preserves MCP OAuth credentials while keeping mcp optional', () => {
+    const result = parseSecretsFile({
+      version: 2,
+      providers: {},
+      channels: {},
+      mcp: {
+        linear: {
+          client: { client_id: 'test-client' },
+          tokens: { access_token: 'access-test', refresh_token: 'refresh-test' },
+          discovery: { authorizationServerUrl: 'https://mcp.example.com' },
+          futureField: { nested: true },
+        },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.file.mcp.linear).toEqual({
+      client: { client_id: 'test-client' },
+      tokens: { access_token: 'access-test', refresh_token: 'refresh-test' },
+      discovery: { authorizationServerUrl: 'https://mcp.example.com' },
+      futureField: { nested: true },
+    })
   })
 
   test('accepts per-adapter channel fields with mixed Secret shapes', () => {

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -22,6 +22,16 @@ export const providerCredentialSchema = z.discriminatedUnion('type', [apiKeyProv
 
 export const providersSchema = z.record(z.string(), providerCredentialSchema)
 
+export const mcpCredentialSchema = z
+  .object({
+    client: z.unknown().optional(),
+    tokens: z.unknown().optional(),
+    discovery: z.unknown().optional(),
+  })
+  .catchall(z.unknown())
+
+export const mcpSliceSchema = z.record(z.string(), mcpCredentialSchema)
+
 // Per-adapter channel slots use named fields (`botToken`, `appToken`, `token`)
 // instead of env-var-name keys. The Secret union per field carries the env-var
 // override. Unknown adapter ids pass through via catchall so a future
@@ -224,10 +234,13 @@ export const secretsFileSchema = z.object({
   version: z.literal(SECRETS_FILE_VERSION),
   providers: providersSchema.default({}),
   channels: channelsSchema.default({}),
+  mcp: mcpSliceSchema.default({}),
 })
 
 export type ProviderCredential = z.infer<typeof providerCredentialSchema>
 export type Providers = z.infer<typeof providersSchema>
+export type McpCredential = z.infer<typeof mcpCredentialSchema>
+export type McpSlice = z.infer<typeof mcpSliceSchema>
 export type Channels = z.infer<typeof channelsSchema>
 export type GithubPatAuthBlock = z.infer<typeof githubPatAuthSchema>
 export type GithubAppAuthBlock = z.infer<typeof githubAppAuthSchema>

--- a/src/secrets/secrets-provider.ts
+++ b/src/secrets/secrets-provider.ts
@@ -1,5 +1,5 @@
 import { sendHttp } from '@/hostd/client'
-import type { Request } from '@/hostd/protocol'
+import type { SecretsPatchChannels } from '@/hostd/protocol'
 
 import type { Channels } from './schema'
 import { SecretsBackend } from './storage'
@@ -8,7 +8,7 @@ import { SecretsBackend } from './storage'
 // Identical to the `secrets-patch` RPC's `patch.channels` union so the hostd
 // implementation forwards it verbatim — the on-the-wire contract is unchanged
 // by this abstraction.
-export type ChannelBlockPatch = Extract<Request, { kind: 'secrets-patch' }>['patch']['channels']
+export type ChannelBlockPatch = SecretsPatchChannels
 
 // The container-stage secrets seam. Named for what the runtime NEEDS, not the
 // transport that serves it. Two halves:

--- a/src/secrets/storage.test.ts
+++ b/src/secrets/storage.test.ts
@@ -42,6 +42,7 @@ describe('SecretsBackend', () => {
     expect(parsed['version']).toBe(2)
     expect(parsed['providers']).toEqual({ openai: { type: 'api_key', key: { value: 'sk-test' } } })
     expect(parsed['channels']).toEqual({})
+    expect(parsed['mcp']).toEqual({})
     expect(parsed['$schema']).toBe('./node_modules/typeclaw/secrets.schema.json')
   })
 
@@ -103,6 +104,7 @@ describe('SecretsBackend', () => {
     expect(result.file.version).toBe(2)
     expect(result.file.providers).toEqual({})
     expect(result.file.channels).toEqual({})
+    expect(result.file.mcp).toEqual({})
   })
 
   test('surfaces a parse error via drainErrors when the file is unparseable', async () => {
@@ -146,6 +148,66 @@ describe('SecretsBackend', () => {
     expect(obj['providers']).toBeDefined()
     expect(obj['channels']).toBeDefined()
     expect(obj['openai']).toBeUndefined()
+  })
+
+  describe('mcp credentials', () => {
+    async function readEnvelope(): Promise<{
+      providers: Record<string, unknown>
+      channels: Record<string, unknown>
+      mcp: Record<string, unknown>
+    }> {
+      return JSON.parse(await readFile(secretsPath, 'utf8')) as {
+        providers: Record<string, unknown>
+        channels: Record<string, unknown>
+        mcp: Record<string, unknown>
+      }
+    }
+
+    test('read/write/update/remove preserves sibling MCP servers and other slices', async () => {
+      await writeFile(
+        secretsPath,
+        JSON.stringify({
+          version: 2,
+          providers: { openai: { type: 'api_key', key: { value: 'sk-existing' } } },
+          channels: { 'discord-bot': { token: { value: 'discord-test' } } },
+          mcp: { existing: { client: { client_id: 'existing-client' } } },
+        }),
+      )
+      const backend = new SecretsBackend(secretsPath)
+
+      backend.writeMcpCredentialSync('linear', {
+        client: { client_id: 'test-client' },
+        tokens: { access_token: 'access-test', refresh_token: 'refresh-test' },
+      })
+      await backend.updateMcpAsync(async (mcp) => ({
+        result: undefined,
+        next: {
+          ...mcp,
+          linear: {
+            ...mcp.linear,
+            tokens: { access_token: 'access-rotated', refresh_token: 'refresh-rotated' },
+          },
+        },
+      }))
+
+      expect(backend.tryReadMcpSync().existing).toEqual({ client: { client_id: 'existing-client' } })
+      expect(backend.readMcpCredentialSync('linear')).toEqual({
+        client: { client_id: 'test-client' },
+        tokens: { access_token: 'access-rotated', refresh_token: 'refresh-rotated' },
+      })
+      const envelope = await readEnvelope()
+      expect(envelope.providers.openai).toEqual({ type: 'api_key', key: { value: 'sk-existing' } })
+      expect(envelope.channels['discord-bot']).toEqual({ token: { value: 'discord-test' } })
+      expect(envelope.mcp.existing).toEqual({ client: { client_id: 'existing-client' } })
+      expect(envelope.mcp.linear).toEqual({
+        client: { client_id: 'test-client' },
+        tokens: { access_token: 'access-rotated', refresh_token: 'refresh-rotated' },
+      })
+
+      expect(backend.removeMcpCredentialSync('linear')).toBe(true)
+      expect(backend.removeMcpCredentialSync('missing')).toBe(false)
+      expect(backend.tryReadMcpSync()).toEqual({ existing: { client: { client_id: 'existing-client' } } })
+    })
   })
 })
 

--- a/src/secrets/storage.ts
+++ b/src/secrets/storage.ts
@@ -13,6 +13,8 @@ import { registerXaiOAuthProvider } from './oauth-xai'
 import { resolveSecret, type Secret } from './resolve'
 import {
   type Channels,
+  type McpCredential,
+  type McpSlice,
   type ProviderCredential,
   type Providers,
   type SecretsFile,
@@ -186,6 +188,111 @@ export class SecretsBackend implements AuthStorageBackend {
     try {
       release = this.acquireSyncLockWithRetry()
       return { ...this.readEnvelope().providers }
+    } finally {
+      release?.()
+    }
+  }
+
+  tryReadMcpSync(): McpSlice {
+    if (!existsSync(this.secretsPath)) return {}
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      return { ...this.readEnvelope().mcp }
+    } finally {
+      release?.()
+    }
+  }
+
+  readMcpCredentialSync(serverName: string): McpCredential | undefined {
+    if (!existsSync(this.secretsPath)) return undefined
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      return this.readEnvelope().mcp[serverName]
+    } finally {
+      release?.()
+    }
+  }
+
+  writeMcpCredentialSync(serverName: string, credential: McpCredential): void {
+    this.ensureParentDir()
+    this.ensureFileExists()
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      const envelope = this.readEnvelope()
+      const next: SecretsFile = {
+        ...envelope,
+        $schema: envelope.$schema ?? SCHEMA_REL,
+        version: SECRETS_FILE_VERSION,
+        mcp: { ...envelope.mcp, [serverName]: credential },
+      }
+      this.writeEnvelopeAtomic(next)
+    } finally {
+      release?.()
+    }
+  }
+
+  async updateMcpAsync<T>(fn: (current: McpSlice) => Promise<{ result: T; next?: McpSlice }>): Promise<T> {
+    this.ensureParentDir()
+    this.ensureFileExists()
+    let release: (() => Promise<void>) | undefined
+    let lockCompromised = false
+    let lockCompromisedError: Error | undefined
+    const throwIfCompromised = (): void => {
+      if (lockCompromised) {
+        throw lockCompromisedError ?? new Error('Secrets store lock was compromised')
+      }
+    }
+    try {
+      release = await lockfile.lock(this.secretsPath, {
+        ...ASYNC_LOCK_OPTIONS,
+        onCompromised: (err: Error) => {
+          lockCompromised = true
+          lockCompromisedError = err
+        },
+      })
+      throwIfCompromised()
+      const envelope = this.readEnvelope()
+      const { result, next } = await fn(envelope.mcp)
+      throwIfCompromised()
+      if (next !== undefined) {
+        const merged: SecretsFile = {
+          ...envelope,
+          $schema: envelope.$schema ?? SCHEMA_REL,
+          version: SECRETS_FILE_VERSION,
+          mcp: next,
+        }
+        this.writeEnvelopeAtomic(merged)
+      }
+      throwIfCompromised()
+      return result
+    } finally {
+      if (release) {
+        try {
+          await release()
+        } catch {}
+      }
+    }
+  }
+
+  removeMcpCredentialSync(serverName: string): boolean {
+    if (!existsSync(this.secretsPath)) return false
+    let release: (() => void) | undefined
+    try {
+      release = this.acquireSyncLockWithRetry()
+      const envelope = this.readEnvelope()
+      if (!(serverName in envelope.mcp)) return false
+      const { [serverName]: _removed, ...rest } = envelope.mcp
+      const next: SecretsFile = {
+        ...envelope,
+        $schema: envelope.$schema ?? SCHEMA_REL,
+        version: SECRETS_FILE_VERSION,
+        mcp: rest,
+      }
+      this.writeEnvelopeAtomic(next)
+      return true
     } finally {
       release?.()
     }
@@ -407,7 +514,7 @@ export function createSecretsStoreForAgent(secretsPath: string): AuthStorage {
 }
 
 function newEmptyEnvelope(): SecretsFile {
-  return { $schema: SCHEMA_REL, version: SECRETS_FILE_VERSION, providers: {}, channels: {} }
+  return { $schema: SCHEMA_REL, version: SECRETS_FILE_VERSION, providers: {}, channels: {}, mcp: {} }
 }
 
 function stringifyEnvelope(envelope: SecretsFile): string {


### PR DESCRIPTION
## Background

HTTP MCP servers that require OAuth (e.g. Linear's `https://mcp.linear.app/mcp`) could not be authenticated in typeclaw. Two mechanisms combined to block it:

1. The agent runs inside a Docker container with no browser, so the OAuth authorization-code redirect flow had nowhere to land.
2. `createTransport` built `StreamableHTTPClientTransport` with a bare URL and no auth, so any 401-guarded MCP server simply failed to connect.

There was also no `typeclaw mcp auth` command and no guidance, which is the friction that motivated this.

The design is grounded in the MCP spec and verified against a live server, not guessed:

- MCP's spec auth is **OAuth 2.1** (Authorization Code + PKCE, browser redirect); discovery via RFC 9728 Protected Resource Metadata → RFC 8414 Authorization Server Metadata; client registration via RFC 7591 **Dynamic Client Registration**. The spec defines **no** device-code grant.
- Confirmed live against Linear: `401` + `WWW-Authenticate: Bearer resource_metadata=...`, working DCR (`POST /register` returns a public client with `token_endpoint_auth_method: "none"`), scopes `read`/`write`.
- The `@modelcontextprotocol/sdk` (v1.29.0, already a dependency) performs discovery, DCR, PKCE, and token refresh automatically once given an `OAuthClientProvider` via `StreamableHTTPClientTransport(url, { authProvider })`.

## Summary

The approach mirrors typeclaw's existing ChatGPT/Codex OAuth architecture: the browser flow runs at **host stage** (where the browser is), tokens land in `secrets.json`, and the container merely consumes and refreshes them.

- **New `typeclaw mcp auth <server>` host command** drives the flow (localhost callback raced with a manual paste fallback, as the provider OAuth flow already does). Why host-stage and not in-container: the container has no browser and no reachable redirect target across Docker/remote setups.
- **New `mcp` slice in the `secrets.json` v2 envelope** stores, per server, the DCR client info + tokens + discovery state as opaque passthrough (like oauth provider credentials). Additive and backward compatible — envelopes without `mcp` still parse (`.default({})`).
- **`TypeClawMcpOAuthProvider`** implements the SDK's `OAuthClientProvider` over two store backends — file-backed (host CLI) and hostd-backed (container) — mirroring the existing `RuntimeSecretsProvider` file-vs-hostd split. The PKCE `code_verifier` and `state` are kept in-memory only, never written to disk.
- **Refresh reconciliation:** the hostd `secrets-patch` RPC gains a tightly-scoped `mcp` variant so the container persists refreshed (rotated) tokens immediately. Why not in-memory-only refresh: `refresh_token` rotation would invalidate the stored token on the next boot. Why not a container-local overlay file: it creates a second credential authority needing newer-wins reconciliation — extending the already-locked hostd write path keeps `secrets.json` canonical and is simpler.
- **No `auth: 'oauth'` config field** is added to `mcpServers`. OAuth is inferred from a persisted `mcp.<server>` credential plus the server's 401 challenge, avoiding an expansion of the restart-required config schema.
- **Backward compatible with the static-bearer path:** when no OAuth credential exists, `createTransport` keeps its bare-URL behavior, so servers that accept a token via the `env` field keep working. stdio servers are untouched.

## Preview

End-to-end, using Linear as the example. First, add the server to `typeclaw.json`:

```json
{
  "mcpServers": [
    { "name": "linear", "url": "https://mcp.linear.app/mcp" }
  ]
}
```

Authenticate from the **host** (where the browser is). The SDK handles discovery, dynamic client registration, and PKCE; the command opens the browser and runs a localhost callback, with a paste fallback for SSH/remote:

```console
$ typeclaw mcp auth linear

┌  MCP OAuth
│
│  Open this URL in your browser to authenticate MCP server "linear".
│
│  If the browser cannot reach localhost after sign-in, copy the full
│  redirect URL or code and paste it below.
│
https://mcp.linear.app/authorize?response_type=code&client_id=...&code_challenge=...

│  After signing in, paste the code or full redirect URL:
│  (or just wait — the localhost callback completes automatically)
│
◇  Authenticated MCP server "linear".
│
└  Apply the secrets.json change:  typeclaw reload
```

Inspect which servers have OAuth wired up:

```console
$ typeclaw mcp list
NAME    TYPE   OAUTH
linear  http   configured
```

Revoke locally when you're done:

```console
$ typeclaw mcp logout linear
◇  Removed OAuth credentials for MCP server "linear".
└  Apply the secrets.json change:  typeclaw reload
```

The container consumes the stored token on the next connect and refreshes it in place; a container that hits a 401 with no stored credential prints the exact command to run: `MCP server "linear" needs OAuth. Run on the host: typeclaw mcp auth linear`.

## What this does NOT do

- No device-code flow (the MCP spec defines none).
- No OAuth for stdio MCP servers (they take credentials from env, per the spec).
- No `auth` marker in `typeclaw.json`'s `mcpServers`.
- Does not auto-run OAuth from inside the container; container stage surfaces an actionable "run `typeclaw mcp auth <server>` on the host" error instead.
- No dedicated docs page (possible follow-up).

## Review notes

- **`src/hostd/daemon.ts` `handleSecretsPatch`** — the new `mcp` branch validates the credential with `mcpCredentialSchema.safeParse` and merges via `updateMcpAsync`, preserving sibling MCP servers and the existing `channels` patch path. This is the only container→`secrets.json` write path for mcp; confirm it stays tightly scoped.
- **`src/mcp/oauth.ts` `TypeClawMcpOAuthProvider`** — verify the PKCE verifier/state are never persisted (a test asserts the serialized `secrets.json` contains neither), and that container-mode `redirectToAuthorization` throws the actionable host-command error.
- **Refresh-token rotation** is covered in `src/mcp/oauth.test.ts` and `src/secrets/storage.test.ts` (save a new `refresh_token`, assert it lands on disk) — the whole reason for the hostd-persist design.
- **`token_endpoint_auth_method: 'none'`** is pinned in the client metadata so DCR yields a public client (Linear also offers confidential clients requiring a secret; we must not get one).
