### PR TITLE
fix(channels): detach the eager engage-ack reaction when a turn doesn't reply

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2602,7 +2602,8 @@ describe('ChannelRouter drop-eyes-after-reply', () => {
     expect(removed[0]).toMatchObject({ reactionRef: INSTANCE_REF })
   })
 
-  test('keeps the engage reaction when the turn sends no reply', async () => {
+  test('detaches the engage reaction when the turn observes after engaging (no reply)', async () => {
+    // given an engaging inbound that gets the eager :eyes: ack
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
     const removed: RemoveReactionRequest[] = []
@@ -2612,13 +2613,17 @@ describe('ChannelRouter drop-eyes-after-reply', () => {
       return { ok: true }
     })
 
+    // when the turn ends up observing (NO_REPLY) instead of replying
     await router.route(inbound({ reactionRef: TARGET_REF }))
     sessions[0]!.onPrompt = () => {
       sessions[0]!.setAssistantText('NO_REPLY')
     }
     await router.__testing!.flushDebounce(KEY)
 
-    expect(removed).toHaveLength(0)
+    // then the eager :eyes: is detached rather than left stranded on a message
+    // the agent never answered
+    await waitFor(() => removed.length === 1)
+    expect(removed[0]).toMatchObject({ adapter: 'discord-bot', chat: 'c1', reactionRef: INSTANCE_REF })
   })
 
   test('orders removal after the in-flight add resolves', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2759,7 +2759,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         } finally {
           live.promptInFlight = false
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
-          if (sentReplyThisTurn) dropEngageReactions(live, engageAddPromises)
+          // The eager :eyes: ack is a "looking at this" signal, not a "replied"
+          // one, so it comes off at turn end no matter the outcome — a reply, but
+          // also silence, skip_response, an empty turn, or a provider error
+          // (observe-after-engage). Leaving it only on the reply path stranded the
+          // ack permanently on messages the agent looked at but never answered.
+          dropEngageReactions(live, engageAddPromises)
           // Held channel_react reactions apply only when the agent posted a
           // genuine reply this turn — NOT an empty-turn fallback or provider-
           // error notice, both of which send via source:'system' and bump


### PR DESCRIPTION
## Background

Follow-up to #1139, which fixed the *model-driven* `channel_react` reaction leaking on look-only turns. This PR handles the other reaction lifecycle: the *eager* engage-ack.

`autoReactOnEngage` drops a `:eyes:` on the triggering message the instant the router decides to ENGAGE — but only on typing-less adapters (GitHub, KakaoTalk); typing-capable adapters (Slack/Discord/Telegram) skip it because their typing indicator already says "the bot is working". Until now, this eager `:eyes:` was removed only when the turn actually posted a reply (`if (sentReplyThisTurn) dropEngageReactions(...)` in drain()'s per-turn `finally`). A turn that engaged and then observed instead — NO_REPLY, `skip_response`, an empty turn, or a provider error — left the `:eyes:` stranded permanently on a message the agent looked at but never answered.

## Summary

Drop the `sentReplyThisTurn` gate and call `dropEngageReactions(live, engageAddPromises)` unconditionally in drain()'s per-turn `finally` (`src/channels/router.ts`). The `:eyes:` is a "looking at this" ack, not a "replied" one, so it comes off at turn end no matter the outcome. The reply path already removed it; this just extends the same removal to every non-reply outcome.

`sentReplyThisTurn` itself is untouched — it's still computed and still gates `usableReplyThisTurn` and the separate `channel_react` hold-for-reply flush from #1139.

Together with #1139 this closes both reaction leak paths: #1139 holds the model's `channel_react` and only flushes it on a genuine reply; this PR drops the eager engage-ack on any turn end. No reaction should now outlive a turn the agent didn't actually answer.

## What this does NOT do

- Does not change `autoReactOnEngage`'s typing-capability gate — Slack/Discord/Telegram still skip the eager `:eyes:` entirely.
- Does not change the engage/observe decision (`decideEngagement` in `engagement.ts`).
- Does not change the coalesced-batch roll-off — only the last inbound of a debounced batch keeps the ack; earlier ones are still rolled off in `enqueue()` via `clearQueuedEngageReactions`.
- Does not change teardown cleanup — `tearDownLive` still drops a still-held ack on session destroy.
- Does not touch the disengage reaction (`zipper_mouth_face`) or #1139's `channel_react` hold-for-reply gate.

## Review notes

- Load-bearing line: `if (sentReplyThisTurn) dropEngageReactions(...)` → unconditional `dropEngageReactions(...)` in drain()'s per-turn `finally`.
- Invariant to verify: after any turn that engaged (added the eager `:eyes:`), the ack is removed by turn end — whether the turn replied or observed. Only typing-less adapters (GitHub, KakaoTalk) ever add it in the first place.
- `dropEngageReactions` is a no-op on empty arrays and null refs, so reminder-only turns and typing-capable adapters (whose engage promises resolve to null) are unaffected.
- The rewritten test in `src/channels/router.test.ts` (`ChannelRouter drop-eyes-after-reply` block) inverts the prior `'keeps the engage reaction when the turn sends no reply'` — which asserted the old buggy behavior (`removed` empty) — into `'detaches the engage reaction when the turn observes after engaging (no reply)'`, asserting the ack IS removed. Verified it fails against pre-fix code and passes after. All other drop-eyes tests (reply removal, coalesced roll-off, reactionRef-less roll-off, teardown, ordering, unsupported/not-found handling) are unchanged and pass. Full suite: 10449 pass / 0 fail; typecheck, lint, and format:check all clean.