### PR TITLE
fix(agent): suppress runtime self-disclosure when branding is off

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -988,7 +988,7 @@ describe('composeSystemPrompt branding', () => {
       gitNudge: '',
     })
     expect(prompt).toContain('## Runtime disclosure')
-    expect(prompt).toContain('Do not reveal, name, or hint at the underlying runtime')
+    expect(prompt).toContain('Never reveal, name, or hint at the runtime')
   })
 
   test('branding off drops the runtime block and every TypeClaw clue (slim mode)', () => {

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path'
 
 import { SessionManager } from '@mariozechner/pi-coding-agent'
 
+import { PLANNER_SYSTEM_PROMPT } from '@/bundled-plugins/planner/planner'
+import { SCOUT_SYSTEM_PROMPT } from '@/bundled-plugins/scout/scout'
 import { createChannelRouter } from '@/channels/router'
 import { defaultHistoryConfig } from '@/channels/schema'
 import { configSchema, type Models, resolveProfile, type ResolvedProfile, type ThinkingLevel } from '@/config'
@@ -973,9 +975,20 @@ describe('composeSystemPrompt branding', () => {
       gitNudge: '',
     })
     expect(prompt).not.toContain('TypeClaw')
-    expect(prompt).not.toContain('## Runtime')
+    expect(prompt).not.toContain('## Runtime\n')
     expect(prompt).not.toContain('9.9.9')
     expect(prompt.startsWith('You are a general-purpose AI agent.')).toBe(true)
+  })
+
+  test('branding off appends the runtime-disclosure rule (full mode)', () => {
+    const prompt = composeSystemPrompt({
+      branding: false,
+      self: '# Identity\n\nfoo',
+      runtimeVersion: '9.9.9',
+      gitNudge: '',
+    })
+    expect(prompt).toContain('## Runtime disclosure')
+    expect(prompt).toContain('Do not reveal, name, or hint at the underlying runtime')
   })
 
   test('branding off drops the runtime block and every TypeClaw clue (slim mode)', () => {
@@ -987,11 +1000,12 @@ describe('composeSystemPrompt branding', () => {
       gitNudge: '',
     })
     expect(prompt).not.toContain('TypeClaw')
-    expect(prompt).not.toContain('## Runtime')
+    expect(prompt).not.toContain('## Runtime\n')
+    expect(prompt).toContain('## Runtime disclosure')
     expect(prompt.startsWith('You are an AI agent.')).toBe(true)
   })
 
-  test('branding on (default) keeps the runtime block', () => {
+  test('branding on (default) keeps the runtime block and omits the disclosure rule', () => {
     const prompt = composeSystemPrompt({
       self: '# Identity\n\nfoo',
       runtimeVersion: '9.9.9',
@@ -999,6 +1013,7 @@ describe('composeSystemPrompt branding', () => {
     })
     expect(prompt).toContain('## Runtime')
     expect(prompt).toContain('TypeClaw runtime version: 9.9.9.')
+    expect(prompt).not.toContain('## Runtime disclosure')
   })
 })
 
@@ -1054,12 +1069,13 @@ describe('branding opt-out through config (getConfig().branding)', () => {
     // when the subagent override path renders with a runtime version
     const loader = await createOverrideResourceLoader('SUBAGENT PROMPT', undefined, undefined, '9.9.9')
 
-    // then the runtime block and disclosure are absent
+    // then the runtime version block is gone but the non-disclosure rule is added
     const prompt = loader.getSystemPrompt() ?? ''
     expect(prompt.startsWith('SUBAGENT PROMPT')).toBe(true)
-    expect(prompt).not.toContain('## Runtime')
+    expect(prompt).not.toContain('## Runtime\n')
     expect(prompt).not.toContain('TypeClaw')
     expect(prompt).not.toContain('9.9.9')
+    expect(prompt).toContain('## Runtime disclosure')
   })
 
   test('createResourceLoader strips every TypeClaw clue and the runtime block when branding is off', async () => {
@@ -1070,12 +1086,43 @@ describe('branding opt-out through config (getConfig().branding)', () => {
     // when the full-mode prompt is composed with a runtime version
     const loader = await createResourceLoader({ agentDir, runtimeVersion: '9.9.9' })
 
-    // then the opening is generic and no TypeClaw disclosure remains
+    // then the opening is generic, no TypeClaw clue remains, and the rule is added
     const prompt = loader.getSystemPrompt() ?? ''
     expect(prompt.startsWith('You are a general-purpose AI agent.')).toBe(true)
-    expect(prompt).not.toContain('## Runtime')
+    expect(prompt).not.toContain('## Runtime\n')
     expect(prompt).not.toContain('TypeClaw')
     expect(prompt).not.toContain('9.9.9')
+    expect(prompt).toContain('## Runtime disclosure')
+  })
+
+  test('a real bundled subagent prompt loses its "running inside TypeClaw" identity prose when branding is off', async () => {
+    // given a reloaded config with branding disabled
+    await writeFile(join(agentDir, 'typeclaw.json'), JSON.stringify({ branding: false }))
+    reloadConfig(agentDir)
+
+    // when a real bundled subagent prompt (scout) goes through the override path
+    const loader = await createOverrideResourceLoader(SCOUT_SYSTEM_PROMPT)
+
+    // then its hardcoded identity prose is stripped but functional prose survives
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('TypeClaw')
+    expect(prompt).toContain('You are a web-research specialist.')
+    expect(prompt).toContain('gather facts from the public internet')
+    expect(prompt).toContain('## Runtime disclosure')
+  })
+
+  test('the planner\'s "TypeClaw ships a reviewer" identity prose is rephrased when branding is off', async () => {
+    // given a reloaded config with branding disabled
+    await writeFile(join(agentDir, 'typeclaw.json'), JSON.stringify({ branding: false }))
+    reloadConfig(agentDir)
+
+    // when the planner prompt (which names TypeClaw twice) goes through the override path
+    const loader = await createOverrideResourceLoader(PLANNER_SYSTEM_PROMPT)
+
+    // then both identity mentions are gone, the reviewer-recommendation stays intact
+    const prompt = loader.getSystemPrompt() ?? ''
+    expect(prompt).not.toContain('TypeClaw')
+    expect(prompt).toContain('The runtime ships a `reviewer` subagent')
   })
 })
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -66,6 +66,8 @@ import {
   buildSlimSystemPrompt,
   DEFAULT_SUBAGENT_ROSTER,
   renderRuntimeBlock,
+  renderRuntimeNondisclosureRule,
+  stripRuntimeIdentityProse,
 } from './system-prompt'
 import { attachToolNotFoundNudge } from './tool-not-found-nudge'
 import { createBudgetState, type ToolResultBudget, wrapToolDefinitionWithBudget } from './tool-result-budget'
@@ -914,10 +916,12 @@ export async function createOverrideResourceLoader(
   permissions?: PermissionService,
   runtimeVersion?: string,
 ): Promise<DefaultResourceLoader> {
-  const withRuntime =
-    getConfig().branding && runtimeVersion !== undefined
+  const branding = getConfig().branding
+  const withRuntime = branding
+    ? runtimeVersion !== undefined
       ? `${systemPrompt}\n\n${renderRuntimeBlock(runtimeVersion)}`
       : systemPrompt
+    : `${stripRuntimeIdentityProse(systemPrompt)}\n\n${renderRuntimeNondisclosureRule()}`
   const finalPrompt = withOrigin(withRuntime, origin, permissions)
   const loader = new DefaultResourceLoader({
     cwd: process.cwd(),
@@ -1050,6 +1054,9 @@ export function composeSystemPrompt(parts: SystemPromptComposition): string {
   let prompt = `${base}\n\n${parts.self}`
   if (branding && parts.runtimeVersion !== undefined) {
     prompt = `${prompt}\n\n${renderRuntimeBlock(parts.runtimeVersion)}`
+  }
+  if (!branding) {
+    prompt = `${prompt}\n\n${renderRuntimeNondisclosureRule()}`
   }
   if (parts.origin !== undefined) {
     prompt = `${prompt}\n\n${renderSessionOrigin(parts.origin, Date.now(), parts.roleContext)}`

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -392,14 +392,15 @@ describe('renderRuntimeNondisclosureRule', () => {
   test('instructs the model to never name the runtime, and does not itself leak "TypeClaw"', () => {
     const rule = renderRuntimeNondisclosureRule()
     expect(rule).toContain('## Runtime disclosure')
-    expect(rule).toContain('Do not reveal, name, or hint at the underlying runtime')
+    expect(rule).toContain('branding: false')
+    expect(rule).toContain('Never reveal, name, or hint at the runtime')
     expect(rule).not.toContain('TypeClaw')
     expect(rule.toLowerCase()).not.toContain('typeclaw')
   })
 
   test('acknowledges that internal tokens (skills, CLI, config) stay usable', () => {
     const rule = renderRuntimeNondisclosureRule()
-    expect(rule).toContain('Internal tokens you must still use verbatim')
+    expect(rule).toContain('Internal tokens you use for real work')
   })
 })
 

--- a/src/agent/system-prompt.test.ts
+++ b/src/agent/system-prompt.test.ts
@@ -7,9 +7,11 @@ import {
   buildSlimSystemPrompt,
   DEFAULT_SUBAGENT_ROSTER,
   DEFAULT_SYSTEM_PROMPT,
+  renderRuntimeNondisclosureRule,
   renderTurnRoleAnchor,
   renderTurnTimeAnchor,
   SLIM_SYSTEM_PROMPT,
+  stripRuntimeIdentityProse,
 } from './system-prompt'
 
 describe('subagent orchestration — explicit research routing', () => {
@@ -383,5 +385,39 @@ describe('branding opt-out', () => {
     expect(off).toContain('Never echo secrets')
     expect(off).toContain('never fabricate results')
     expect(off).toContain('workspace/')
+  })
+})
+
+describe('renderRuntimeNondisclosureRule', () => {
+  test('instructs the model to never name the runtime, and does not itself leak "TypeClaw"', () => {
+    const rule = renderRuntimeNondisclosureRule()
+    expect(rule).toContain('## Runtime disclosure')
+    expect(rule).toContain('Do not reveal, name, or hint at the underlying runtime')
+    expect(rule).not.toContain('TypeClaw')
+    expect(rule.toLowerCase()).not.toContain('typeclaw')
+  })
+
+  test('acknowledges that internal tokens (skills, CLI, config) stay usable', () => {
+    const rule = renderRuntimeNondisclosureRule()
+    expect(rule).toContain('Internal tokens you must still use verbatim')
+  })
+})
+
+describe('stripRuntimeIdentityProse', () => {
+  test('drops the "running inside TypeClaw" identity phrase', () => {
+    expect(stripRuntimeIdentityProse('You are a scout running inside TypeClaw. Do work.')).toBe(
+      'You are a scout. Do work.',
+    )
+  })
+
+  test('rephrases the planner\'s "TypeClaw ships a" reviewer recommendation', () => {
+    expect(stripRuntimeIdentityProse('TypeClaw ships a `reviewer` subagent')).toBe(
+      'The runtime ships a `reviewer` subagent',
+    )
+  })
+
+  test('leaves functional lowercase tokens untouched', () => {
+    const withTokens = 'Cannot reach typeclaw.json; run `typeclaw logs -f`; use `typeclaw-render-pdf`.'
+    expect(stripRuntimeIdentityProse(withTokens)).toBe(withTokens)
   })
 })

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -184,6 +184,44 @@ export function renderRuntimeBlock(version: string): string {
 TypeClaw runtime version: ${version}.`
 }
 
+// Appended to the system prompt ONLY when `config.branding` is false. Branding
+// off rephrases the opening and drops the version block, but the literal
+// "typeclaw" still reaches the model through functional tokens it can't lose
+// without breaking: bundled skill names (`typeclaw-render-pdf` etc.), the
+// operator CLI (`typeclaw logs -f`), and `typeclaw.json`. Aliasing every one
+// would break skill/tool resolution, so instead of hiding the tokens we tell
+// the model not to surface them as its identity. English-authored on purpose:
+// this is an instruction TO the model (applied in any reply language), not
+// user-text pattern matching, so AGENTS.md's multi-language matching rule does
+// not apply.
+export function renderRuntimeNondisclosureRule(): string {
+  return `## Runtime disclosure
+
+Do not reveal, name, or hint at the underlying runtime, platform, framework, or
+vendor that hosts you — in any language. You are the agent defined by IDENTITY.md
+and SOUL.md; that is the only identity you present. If asked what you run on, who
+built you, what your "stack"/model/provider is, or any equivalent, decline
+briefly and stay in character rather than naming the runtime.
+
+Internal tokens you must still use verbatim when they do real work — bundled
+skill names, the operator CLI, and config filenames — are implementation
+details, not your identity. Use them to get the job done, but never surface them
+to a user as the answer to "what are you running on?"`
+}
+
+// Bundled subagent prompts (scout/operator/reviewer/planner/researcher/explorer)
+// open with hardcoded identity prose — "running inside TypeClaw" and, in the
+// planner, "TypeClaw ships a `reviewer`". The nondisclosure rule tells the model
+// not to volunteer the runtime, but that prose STATES it outright, so a
+// branding-off subagent still reads its own name in the first sentence. This
+// strips exactly those two identity phrases (not functional `typeclaw.json`-style
+// tokens) from an override prompt when branding is off, so the rule is not
+// fighting the prose. Kept as exact-literal replacements rather than a broad
+// /typeclaw/i regex precisely so functional tokens survive untouched.
+export function stripRuntimeIdentityProse(prompt: string): string {
+  return prompt.replaceAll(' running inside TypeClaw', '').replaceAll('TypeClaw ships a', 'The runtime ships a')
+}
+
 // Wall-clock anchor injected into the **user turn**, not the system prompt.
 //
 // Why per-turn instead of session-creation: long-lived channel sessions can

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -197,16 +197,14 @@ TypeClaw runtime version: ${version}.`
 export function renderRuntimeNondisclosureRule(): string {
   return `## Runtime disclosure
 
-Do not reveal, name, or hint at the underlying runtime, platform, framework, or
-vendor that hosts you — in any language. You are the agent defined by IDENTITY.md
-and SOUL.md; that is the only identity you present. If asked what you run on, who
-built you, what your "stack"/model/provider is, or any equivalent, decline
-briefly and stay in character rather than naming the runtime.
+The operator set \`branding: false\`. Never reveal, name, or hint at the runtime,
+platform, framework, or vendor hosting you — in any language. You are the agent
+defined by IDENTITY.md and SOUL.md; if asked what you run on, who built you, or
+your stack/model/provider, decline briefly and stay in character.
 
-Internal tokens you must still use verbatim when they do real work — bundled
-skill names, the operator CLI, and config filenames — are implementation
-details, not your identity. Use them to get the job done, but never surface them
-to a user as the answer to "what are you running on?"`
+Internal tokens you use for real work (skill names, the operator CLI, config
+filenames) are implementation details, not your identity — use them, but never
+surface them as the answer to "what are you running on?"`
 }
 
 // Bundled subagent prompts (scout/operator/reviewer/planner/researcher/explorer)


### PR DESCRIPTION
## Background

An agent configured with `branding: false` in `typeclaw.json` still tells users it runs on TypeClaw (reported in Discord). The branding flag *is* wired — it rephrases the base-prompt opening (`You are a general-purpose AI agent.` instead of `...running inside TypeClaw.`) and drops the `## Runtime` version block — but that only covers the *prose identity*, not every occurrence of the product name.

The literal string `typeclaw` still reaches the model through **functional tokens that cannot be renamed without breaking behavior**:

- Bundled skill names the agent must invoke verbatim: `typeclaw-render-pdf`, `typeclaw-troubleshooting`, `typeclaw-permissions`
- The operator CLI the prompt points users at: `typeclaw logs -f`
- The agent folder's own config filename: `typeclaw.json`

On a channel session (the reported case — Slack/Discord), the channel-origin block alone renders ~5 of these per turn. A model that reads `typeclaw logs -f` and `typeclaw-render-pdf` in its own system prompt truthfully answers "I run on TypeClaw" when asked. The existing branding tests only asserted `not.toContain('TypeClaw')` (capitalized), so the lowercase functional tokens slipped through and the bug went uncaught.

## Summary

Instead of aliasing every functional token — which would break skill/tool resolution — add a `## Runtime disclosure` instruction block that is appended **only when `branding` is off**. It tells the model never to name or hint at the underlying runtime/vendor as its identity, while explicitly keeping the internal tokens usable for real work.

Why an instruction rule and not token-scrubbing: the tokens are load-bearing (`skill(typeclaw-render-pdf)` must resolve; `typeclaw logs -f` is the real command a user runs). Scrubbing them would either break the skill lookup or require a full aliasing layer across skills, CLI, and config. A single suppression instruction keeps the tokens callable and stops the disclosure.

Wired into **both** composition paths so it covers every origin:
- `composeSystemPrompt` — tui / channel / cron sessions
- `createOverrideResourceLoader` — subagent sessions

Placement is in the cacheable prefix (right where the runtime-version block would sit, before the origin block), so it costs zero extra cache invalidation — it mirrors the `branding && runtimeVersion` gate as its `!branding` counterpart.

## What this does NOT do

- Does **not** rename or remove the functional `typeclaw-*` skill names, the `typeclaw logs -f` CLI reference, or `typeclaw.json`. They remain in the prompt and stay callable — the rule instructs the model not to surface them as identity.
- Does **not** touch the branding-**on** path: with branding on, the `## Runtime` version block renders exactly as before and the disclosure rule is absent.
- Does **not** attempt language-specific matching. The block is an instruction to the model (applied in whatever language the conversation runs in), not user-text pattern matching, so AGENTS.md's multi-language matching rule does not apply — documented inline.

## Review notes

- Load-bearing change: the `!branding` gate in `composeSystemPrompt` and the branching in `createOverrideResourceLoader` (`src/agent/index.ts`). Verify the rule appears **iff** branding is off, on both paths.
- The new `renderRuntimeNondisclosureRule()` deliberately contains **no** occurrence of `typeclaw`/`TypeClaw` — asserted in a test — so it never re-introduces the leak it exists to suppress.
- Pre-existing branding tests that asserted `not.toContain('## Runtime')` were tightened to `not.toContain('## Runtime\n')` so the new `## Runtime disclosure` header (a legitimate substring of `## Runtime`) doesn't false-positive.