### PR TITLE
fix(channels): suppress plain-text tool-call leaks by default and self-correct

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -50,6 +50,7 @@ import {
   sliceHeadTail,
   StaleLiveSessionError,
   stripThinkBlocks,
+  TOOL_CALL_LEAK_NUDGE,
   TURN_CAP_ERROR,
   WILLINGNESS_NUDGE,
   type ChannelRouter,
@@ -4003,8 +4004,10 @@ describe('ChannelRouter channel-turn protocol', () => {
     }
     await router.__testing!.flushDebounce(KEY)
 
+    // A reply leak with no salvageable text still owes the user a message, so it
+    // takes the suppress-AND-warn path (nudge to retry), not a silent drop.
     expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('suppressed unextractable_plain_text_channel_tool_call'))).toBe(true)
+    expect(logs.some((m) => m.includes('plain_text_tool_call_leak (nudge'))).toBe(true)
   })
 
   test('suppresses leaked plain-text skip_response(...) serialization instead of posting it to the channel', async () => {
@@ -4024,8 +4027,80 @@ describe('ChannelRouter channel-turn protocol', () => {
     await router.__testing!.flushDebounce(KEY)
 
     expect(sent).toHaveLength(0)
-    expect(logs.some((m) => m.includes('suppressed plain_text_channel_skip_response'))).toBe(true)
+    expect(logs.some((m) => m.includes('suppressed plain_text_tool_call_leak (silent)'))).toBe(true)
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+  })
+
+  test('suppresses a quote-free skip_response() leak SILENTLY (no self-correction nudge)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('skip_response()')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed plain_text_tool_call_leak (silent)'))).toBe(true)
+    // skip already delivered the model's intent (silence) — no nudge, no retry.
+    expect(logs.some((m) => m.includes('plain_text_tool_call_leak (nudge'))).toBe(false)
+  })
+
+  test('suppresses a narrated channel_disengage() leak AND nudges the model to redo the turn', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'stop replying' }))
+    // Leak once, then on the nudged retry send a clean reply — proves the
+    // self-correction loop lets the model recover in the same logical turn.
+    let attempt = 0
+    sessions[0]!.onPrompt = () => {
+      attempt++
+      if (attempt === 1) {
+        sessions[0]!.setAssistantText('channel_disengage()')
+      } else {
+        sessions[0]!.setAssistantText('ok, backing off')
+      }
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(logs.some((m) => m.includes('plain_text_tool_call_leak (nudge attempt=1/1)'))).toBe(true)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('ok, backing off')
+  })
+
+  test('a persistently-leaking whole-message tool call stays silent after the retry budget (no livelock)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'stop replying' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('channel_disengage()')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('plain_text_tool_call_leak (nudge attempt=1/1)'))).toBe(true)
+    expect(logs.some((m) => m.includes('plain_text_tool_call_leak (retries exhausted, silent)'))).toBe(true)
   })
 
   test('still recovers prose that mentions skip_response in a non-call shape', async () => {
@@ -4071,15 +4146,55 @@ describe('ChannelRouter channel-turn protocol', () => {
   })
 
   describe('getPlainTextChannelToolCallKind', () => {
-    test('classifies anchored reply/send/skip serializations', () => {
+    test('recovers reply/send serializations (their args hold a user message)', () => {
       expect(getPlainTextChannelToolCallKind('channel_reply({"text":"hi"})')).toBe('reply')
       expect(getPlainTextChannelToolCallKind('channel_send({"chat":"c","text":"hi"})')).toBe('send')
-      expect(getPlainTextChannelToolCallKind('skip_response({ reason: "no content" })')).toBe('skip')
     })
 
-    test('returns null for prose that merely mentions a tool name', () => {
+    test('recovers a TRUNCATED reply/send serialization (unbalanced, still a leak)', () => {
+      expect(getPlainTextChannelToolCallKind('channel_reply({"text":"hi there')).toBe('reply')
+    })
+
+    test('delivers prose that STARTS with a reply/send call but continues as explanation', () => {
+      // Reply/send recovery is gated on the SAME whole-message boundary as
+      // suppression — a prefix match would recover `hi` and drop the rest.
+      expect(getPlainTextChannelToolCallKind('channel_reply({"text":"hi"}) is the serialized form')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('channel_send({"text":"x"}) — that is how you send')).toBeNull()
+    })
+
+    test('suppresses skip_response leaks SILENTLY (the model already got its silence)', () => {
+      expect(getPlainTextChannelToolCallKind('skip_response({ reason: "no content" })')).toBe('suppress-silent')
+      expect(getPlainTextChannelToolCallKind('skip_response()')).toBe('suppress-silent')
+      expect(getPlainTextChannelToolCallKind('skip_response({})')).toBe('suppress-silent')
+      expect(getPlainTextChannelToolCallKind('skip_response({ reason: not addressed to me })')).toBe('suppress-silent')
+    })
+
+    test('suppresses every OTHER whole-message tool call with a WARN (model owes a real turn)', () => {
+      // Default is suppress-warn for any leaked call that is the whole message —
+      // channel tools AND generic tools alike, no allowlist. The warn drives the
+      // self-correction retry.
+      expect(getPlainTextChannelToolCallKind('channel_disengage()')).toBe('suppress-warn')
+      expect(getPlainTextChannelToolCallKind('channel_react({ emoji: "eyes" })')).toBe('suppress-warn')
+      expect(getPlainTextChannelToolCallKind('channel_history({ limit: 20 })')).toBe('suppress-warn')
+      expect(getPlainTextChannelToolCallKind('channel_read({ message_id: "123" })')).toBe('suppress-warn')
+      expect(getPlainTextChannelToolCallKind('channel_fetch_attachment({ id: "a1" })')).toBe('suppress-warn')
+      expect(getPlainTextChannelToolCallKind('look_at_channel_attachment({ id: "a1" })')).toBe('suppress-warn')
+      // generic tools too — a whole-message `bash(...)` / `read(...)` is a leak
+      expect(getPlainTextChannelToolCallKind('bash("ls -la")')).toBe('suppress-warn')
+      expect(getPlainTextChannelToolCallKind('read({ path: "x" })')).toBe('suppress-warn')
+      expect(getPlainTextChannelToolCallKind('restart()')).toBe('suppress-warn')
+    })
+
+    test('delivers prose that merely mentions or explains a tool (whole message is NOT a call)', () => {
+      // The whole-message boundary is what protects real replies: a message with
+      // any text after the closing paren, or no call shape at all, is prose.
       expect(getPlainTextChannelToolCallKind('Use the channel_reply tool to send "text".')).toBeNull()
       expect(getPlainTextChannelToolCallKind('channel_reply does this')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('skip_response tool when there is nothing to add')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('channel_react whenever a message deserves an emoji')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('read({ path: "x" }) loads a file for you')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('You can use bash("ls") to list files')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('channel_disengagement is the noun')).toBeNull()
     })
   })
 
@@ -4481,6 +4596,50 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     // then: turn C did not escalate (no xhigh) — B overwrote A's question signal.
     expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
+  })
+
+  test('cross-turn escalation: a tool-leak-retried question turn seeds the next turn (retry accounting)', async () => {
+    // given: turn A is a QUESTION that leaks a tool call, then replies on the
+    // nudged self-correction retry; turn B is a question. The tool-leak retry
+    // keeps the logical turn in flight, so A must commit its question signal AT
+    // the successful retry — then B escalates. Before including toolLeakRetries
+    // in retryQueuedThisTurn, A's signal was cleared after the first suppressed
+    // attempt, and B would NOT escalate.
+    const dir = await tempDir()
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    // turn A — a question that leaks channel_disengage(), then replies on retry
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    let aAttempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      aAttempt++
+      if (aAttempt === 1) {
+        sessions[0]!.setAssistantText('channel_disengage()')
+        return
+      }
+      expect(text).toContain(TOOL_CALL_LEAK_NUDGE)
+      sessions[0]!.setAssistantText('A')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'because of X' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn B — a real question; predecessor A was a question with a usable reply
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('B')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'so what exactly should i change to fix it?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn B escalated (xhigh) — A's question signal survived the leak retry.
+    expect(sessions[0]!.thinkingLevels).toContain('xhigh')
   })
 
   test('cross-turn escalation: a provider-error question turn does not seed the next turn', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -251,6 +251,35 @@ export const CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS = 16384
 // thrashed the send path, so a re-prompt would just re-thrash; they skip
 // straight to the fallback. See validateChannelTurn's candidate===null branch.
 export const MAX_EMPTY_TURN_RETRIES = 2
+
+// Separate, tiny budget for the tool-call-leak self-correction retry. Kept
+// apart from MAX_EMPTY_TURN_RETRIES so a persistently-leaking model cannot
+// consume the empty-turn budget (or vice versa) and so it can't livelock: one
+// nudged retry, then on a second leak we suppress and stay silent. A leaked
+// call is a clean protocol miss, not budget exhaustion — one reminder is
+// usually enough, and silence is safer than an unbounded re-prompt loop.
+export const MAX_TOOL_LEAK_RETRIES = 1
+// Reminder-only nudge injected before a tool-call-leak retry. The model wrote a
+// tool call as its visible message text instead of actually calling the tool,
+// so we suppressed the plumbing and ask it to redo the turn properly. Same
+// SYSTEM MESSAGE framing as the other reminder-only nudges.
+export const TOOL_CALL_LEAK_NUDGE = [
+  '---',
+  '**[SYSTEM MESSAGE — not from a human]**',
+  '',
+  'Your previous turn wrote a tool call (e.g. `channel_reply(...)`,',
+  '`channel_react(...)`, `skip_response(...)`) as plain message TEXT instead of',
+  'actually invoking the tool. That text was suppressed — it was NOT sent to the',
+  'channel — because raw tool-call syntax must never be posted as a message. This',
+  'is an automated signal from the channel router, not a message from anyone in',
+  'the chat. **Do not acknowledge or reply to this notice itself.**',
+  '',
+  'Redo the turn correctly: to reply, call your channel reply tool; to react or',
+  'disengage, call that tool; to stay silent, call `skip_response({ reason })`.',
+  'Emit a real tool call — do not type its syntax as your answer.',
+  '',
+  '---',
+].join('\n')
 // Reminder-only nudge injected before an empty-turn retry. Uses the repo's
 // SYSTEM MESSAGE framing (see composeTurnPrompt) so persona-rich models do not
 // reply to the notice itself. Names the actual failure (the prior turn ran out
@@ -840,6 +869,11 @@ type LiveSession = {
   // increments it before injecting EMPTY_TURN_RETRY_NUDGE and reads it to decide
   // retry-vs-fallback. See the candidate===null branch.
   emptyTurnRetries: number
+  // Count of tool-call-leak self-correction re-prompts spent this logical turn,
+  // bounded by MAX_TOOL_LEAK_RETRIES. Separate from emptyTurnRetries so the two
+  // failure modes can't drain each other's budget. Reset with the rest on a
+  // fresh user batch.
+  toolLeakRetries: number
   // Latches once a bare-empty `stop` has been classified as empty-stop-after-tool-work
   // this logical turn. The recovery nudge tells the model NOT to re-run its tools, so
   // a compliant retry is expected to land another bare-empty `stop` with NO new tool
@@ -1956,6 +1990,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         inFlightToolSends: new Map(),
         policyDeniedToolSendsThisTurn: new Map(),
         emptyTurnRetries: 0,
+        toolLeakRetries: 0,
         emptyStopAfterToolWorkArmed: false,
         willingnessNudges: 0,
         lastTerminalReplyAbort: null,
@@ -2623,6 +2658,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // iterations the retry itself queues do not refill the budget and loop
           // forever (and the raised cap stays scoped to the turn that set it).
           live.emptyTurnRetries = 0
+          live.toolLeakRetries = 0
           live.emptyStopAfterToolWorkArmed = false
           live.willingnessNudges = 0
           live.abortReasonThisTurn = null
@@ -2672,6 +2708,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const promptStart = now()
         const successfulSendsBeforePrompt = live.successfulChannelSends
         const emptyTurnRetriesBeforePrompt = live.emptyTurnRetries
+        const toolLeakRetriesBeforePrompt = live.toolLeakRetries
         const engageAddPromises = live.currentTurnEngageReactions
         live.turnSeq++
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
@@ -2721,14 +2758,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // usable assistant reply (real model prose the user saw) seeds the next
           // turn's escalation. Every other terminal outcome CLEARS lastQuestionSignal
           // so an older question can't leak across the failed/silent turn:
-          //   - retry queued (`length`/`aborted`, budget left): turn still in
-          //     flight → leave both for the reminder-only iteration that ends it.
+          //   - retry queued (`length`/`aborted`, budget left, OR a tool-call
+          //     leak nudged a self-correction retry): turn still in flight →
+          //     leave both for the reminder-only iteration that ends it.
           //   - usable reply → commit the pending signal.
           //   - provider error / empty-turn fallback / NO_REPLY / skip (no usable
           //     reply) → clear BOTH (pending and lastQuestionSignal).
           // A fallback sends via source:'system', which also bumps
-          // successfulChannelSends, so it must be excluded explicitly.
-          const retryQueuedThisTurn = live.emptyTurnRetries > emptyTurnRetriesBeforePrompt
+          // successfulChannelSends, so it must be excluded explicitly. Both retry
+          // budgets keep the logical turn open, so both must count here — a
+          // tool-leak retry that later replies must commit the signal AT the
+          // successful retry, not clear it after the first suppressed attempt.
+          const retryQueuedThisTurn =
+            live.emptyTurnRetries > emptyTurnRetriesBeforePrompt || live.toolLeakRetries > toolLeakRetriesBeforePrompt
           const providerErrorThisTurn = assistantLeafStopReason(live.session) === 'error'
           const fallbackPostedThisTurn = live.emptyTurnFallbackTurn === live.turnSeq
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
@@ -2778,8 +2820,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             assistantLeafStopReason(live.session) !== 'error'
           if (usableReplyThisTurn) flushPendingReactions(live)
           else live.pendingTurnReactions = []
-          const emptyTurnRetryQueued = live.emptyTurnRetries > emptyTurnRetriesBeforePrompt
-          await maybePostDeferredProviderError(live, sentReplyThisTurn, emptyTurnRetryQueued)
+          // Either retry budget keeps the turn in flight, so a deferred provider
+          // error must wait for the reminder-only iteration that actually ends it.
+          const retryQueuedThisTurn =
+            live.emptyTurnRetries > emptyTurnRetriesBeforePrompt || live.toolLeakRetries > toolLeakRetriesBeforePrompt
+          await maybePostDeferredProviderError(live, sentReplyThisTurn, retryQueuedThisTurn)
           await fireSessionTurnEnd(live)
         }
         await fireSessionIdle(live)
@@ -4008,6 +4053,27 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
     }
 
+    // Suppress a leaked tool call (never post the plumbing) and, while budget
+    // remains, push a self-correction reminder so the same logical turn
+    // re-prompts and the model can redo it with a real tool call. On exhaustion
+    // we stay silent — a persistently-leaking model must not livelock, and
+    // silence is safer than posting a fallback the user didn't ask for.
+    const suppressToolLeakAndNudge = (live: LiveSession, leakedText: string): void => {
+      if (live.toolLeakRetries < MAX_TOOL_LEAK_RETRIES) {
+        live.toolLeakRetries++
+        logger.warn(
+          `[channels] ${live.keyId}: suppressed plain_text_tool_call_leak (nudge ` +
+            `attempt=${live.toolLeakRetries}/${MAX_TOOL_LEAK_RETRIES}) text_len=${leakedText.length}`,
+        )
+        live.pendingSystemReminders.push(TOOL_CALL_LEAK_NUDGE)
+        return
+      }
+      logger.warn(
+        `[channels] ${live.keyId}: suppressed plain_text_tool_call_leak (retries exhausted, silent) ` +
+          `text_len=${leakedText.length}`,
+      )
+    }
+
     // A send landed this turn, but the model may have posted a `continue: true`
     // progress reply, kept working, then ENDED with its final answer as plain
     // prose — never calling a channel tool again. The terminal-reply abort fires
@@ -4296,28 +4362,33 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
-    // Plain-text tool-call leak: the model serialized a channel tool call as
-    // ordinary prose instead of producing a real tool call (a Kimi-on-Fireworks
-    // failure mode — see `isLikelyPlainTextChannelToolCall`). We can't post the
-    // raw `channel_reply({...})` serialization to the channel, but for
-    // reply/send the model's *intent* is unambiguous: deliver the `text` arg.
-    // Extract it and recover the actual message. `skip_response` is the
-    // opposite — a genuine decline — so it stays suppressed.
+    // Plain-text tool-call leak: the model serialized a tool call as ordinary
+    // message text instead of producing a real tool call. Default is SUPPRESS —
+    // that raw plumbing must never reach the channel. The two exceptions are
+    // `channel_reply` / `channel_send`, whose leaked form carries a salvageable
+    // user message: extract the `text` arg and recover the actual reply.
+    // `suppress-silent` (skip_response) drops without a nudge because the model
+    // already got the silence it asked for; `suppress-warn` (every other leaked
+    // call) drops AND re-prompts the model to redo the turn with a real tool
+    // call, bounded by MAX_TOOL_LEAK_RETRIES so it can't livelock.
     const plainTextToolCallKind = getPlainTextChannelToolCallKind(assistantText)
-    if (plainTextToolCallKind === 'skip') {
+    if (plainTextToolCallKind === 'suppress-silent') {
       logger.warn(
-        `[channels] ${live.keyId}: suppressed plain_text_channel_skip_response text_len=${assistantText.length}`,
+        `[channels] ${live.keyId}: suppressed plain_text_tool_call_leak (silent) text_len=${assistantText.length}`,
       )
+      return
+    }
+    if (plainTextToolCallKind === 'suppress-warn') {
+      suppressToolLeakAndNudge(live, assistantText)
       return
     }
     if (plainTextToolCallKind !== null) {
       const extracted = extractPlainTextChannelToolCallText(assistantText)
-      // Unextractable (no `text` arg, empty value, or fully-truncated): fall
-      // back to the historical safe behavior — drop it rather than leak plumbing.
+      // A reply/send leak with no recoverable `text` (missing arg, empty value,
+      // or fully-truncated) still owes the user a real message — treat it as a
+      // warn-worthy leak, not a silent drop, so the model retries properly.
       if (extracted === null) {
-        logger.warn(
-          `[channels] ${live.keyId}: suppressed unextractable_plain_text_channel_tool_call text_len=${assistantText.length}`,
-        )
+        suppressToolLeakAndNudge(live, assistantText)
         return
       }
       // The extracted value is still untrusted model output: if it is itself a
@@ -6115,42 +6186,97 @@ export function isLikelyKimiChannelToolLeak(text: string): boolean {
 // posts its own "I'm staying silent" plumbing to the channel, the exact
 // opposite of the intended no-op. It is never a legitimate user-facing reply.
 //
-// Structural-only detection (NOT a substring search): the trimmed text must
-// *start* with `channel_reply(`, `channel_send(`, or `skip_response(`, and
-// that opening paren must enclose at least one quote — `"` or `'` (the
-// serialized argument). The single-quote arm matters because the extractor
-// recovers single-quoted values too; if the classifier only matched `"`, a
-// single-quoted leak like `channel_reply({text: 'hi'})` would bypass the
-// extractor and post raw plumbing. This deliberately matches the leak shape
-// while letting prose that merely
-// *mentions* a tool name (e.g. "I would normally call channel_reply here
-// but...") reach the user — that false-positive class is already locked in by
-// the `still recovers prose that mentions channel_reply` test.
+// Detection is a SINGLE whole-message boundary for every tool, then a per-name
+// disposition. reply/send RECOVER (their leaked form holds a salvageable user
+// message the extractor re-posts); everything else SUPPRESSES.
 //
-// The trailing close paren is NOT required: the model sometimes truncates
-// mid-serialization, and a half-leaked `channel_reply({"text":"..."` is
-// just as user-hostile as the full shape.
-const PLAIN_TEXT_CHANNEL_TOOL_CALL_RE = /^(channel_reply|channel_send|skip_response)\s*\(\s*[^)]*["']/
+// SUPPRESS is the default and is detected by SHAPE, not a curated name list — a
+// `toolname(...)` that is the model's ENTIRE turn output is always a protocol
+// malfunction (the model narrated a call instead of emitting it), and that raw
+// plumbing must never reach the channel. No allowlist to keep in sync as tools
+// are added.
+//
+// The false-positive boundary is "the WHOLE trimmed message is a single call
+// expression" — NOT "starts with a call". A developer-facing reply like
+// `read({ ... }) lets you load a file` has text after the closing paren, so it
+// is prose and reaches the user. Only a message that is *nothing but* the call
+// (`skip_response({ ... })`, `channel_react({ emoji: "eyes" })`, bare
+// `channel_disengage()`) is a leak. This is what lets the rule cover every tool
+// — including future ones and generic tools like `bash(...)` — without risking
+// legitimate replies, because a real reply is never *only* a bare tool call.
+//
+// `isWholeMessageToolCall` (below) is the bracket-aware parser; it returns the
+// called tool's name so the caller can apply the one intrinsic distinction that
+// survives: `skip_response` suppresses SILENTLY (the model wanted silence, and
+// suppression already delivered it — warning would be noise), while every other
+// suppressed leak pushes a self-correction reminder so the model retries with a
+// real tool call or a real reply.
+const SKIP_RESPONSE_TOOL_NAME = 'skip_response'
 
-export type PlainTextChannelToolCallKind = 'reply' | 'send' | 'skip'
+export type PlainTextChannelToolCallKind = 'reply' | 'send' | 'suppress-silent' | 'suppress-warn'
 
 export function getPlainTextChannelToolCallKind(text: string): PlainTextChannelToolCallKind | null {
-  const match = PLAIN_TEXT_CHANNEL_TOOL_CALL_RE.exec(text.trim())
-  if (match === null) return null
-  switch (match[1]) {
-    case 'channel_reply':
-      return 'reply'
-    case 'channel_send':
-      return 'send'
-    case 'skip_response':
-      return 'skip'
-    default:
-      return null
-  }
+  // Everything routes through the SAME whole-message boundary, including
+  // reply/send recovery — a prefix match there would false-positive prose like
+  // `channel_reply({"text":"hi"}) is the serialized form`, recovering `hi` and
+  // dropping the explanation. `isWholeMessageToolCall` returns the tool name
+  // only when the entire trimmed message is the call (or a truncated one), so a
+  // reply/send leak still recovers while a mention-with-trailing-prose falls
+  // through to the user.
+  const toolName = isWholeMessageToolCall(text)
+  if (toolName === null) return null
+  if (toolName === 'channel_reply') return 'reply'
+  if (toolName === 'channel_send') return 'send'
+  // `skip_response` already got what it wanted once suppressed (silence), so
+  // warning would be noise. Every other leaked call dropped a real action or
+  // reply, so nudge the model to redo it properly.
+  return toolName === SKIP_RESPONSE_TOOL_NAME ? 'suppress-silent' : 'suppress-warn'
 }
 
 export function isLikelyPlainTextChannelToolCall(text: string): boolean {
   return getPlainTextChannelToolCallKind(text) !== null
+}
+
+// Bracket-aware parser: returns the called tool's name when the ENTIRE trimmed
+// text is a single call expression `identifier(...)` — empty args `()` or a
+// single object-literal `({ ... })` — with nothing but optional whitespace and
+// a trailing `;` after the closing paren. Returns null for anything else, which
+// is what keeps prose safe: `read({...}) loads a file` has trailing text, and
+// `bash` alone (no parens) is a bare word, so neither is a call. A naive
+// `^ident\(.*\)$` regex can't tell the closing paren of the arg object from a
+// paren inside a quoted string, so this walks the string honoring quotes and
+// brace/bracket/paren depth.
+export function isWholeMessageToolCall(text: string): string | null {
+  const trimmed = text.trim()
+  const nameMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*\(/.exec(trimmed)
+  if (nameMatch === null) return null
+  const name = nameMatch[1]!
+
+  let i = nameMatch[0].length - 1
+  let depth = 0
+  for (; i < trimmed.length; i++) {
+    const ch = trimmed[i]!
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipStringLiteral(trimmed, i, ch)
+      continue
+    }
+    if (ch === '(' || ch === '{' || ch === '[') {
+      depth++
+      continue
+    }
+    if (ch === ')' || ch === '}' || ch === ']') {
+      depth--
+      if (depth === 0) break
+      continue
+    }
+  }
+
+  // Unbalanced (truncated mid-serialization) — still a leaked call, not prose.
+  if (depth !== 0) return name
+
+  const rest = trimmed.slice(i + 1).trim()
+  if (rest === '' || rest === ';') return name
+  return null
 }
 
 // Tolerant single-purpose scanner that pulls the `text` argument out of a


### PR DESCRIPTION
## Background

When the agent ends a channel turn with plain assistant **text** instead of calling a tool, the recovery path in `src/channels/router.ts` posts that text to the channel. A degraded model sometimes narrates a tool call *as* its output — the bot literally publishing `skip_response({ reason: "...staying quiet." })` or `channel_react({ emoji: "eyes" })` into the chat, the exact opposite of the intended action. (Observed in the wild: a community agent posting its own "staying quiet" plumbing into Discord.)

The original guard caught only a hand-maintained allowlist of tool names. Two problems, surfaced in review:

1. **The allowlist rots.** A new no-text channel tool (say a future `channel_pin`) leaks until someone remembers to add it to a regex in `router.ts` — knowledge kept far from the tool definition.
2. **Suppress alone is half a fix.** We dropped the leak but never *told the model it malfunctioned*, so it re-leaks on the next similar turn. The self-correction machinery (`pendingSystemReminders` + the drain loop that re-prompts the same logical turn) already existed — the leak branch just didn't use it.

## The design (inverted)

**Default = SUPPRESS. Detect by SHAPE, not a name list.**

`isWholeMessageToolCall` bracket-parses the assistant text and fires only when the **entire trimmed message** is a single `identifier(...)` call — empty `()` or one object-literal `({...})` arg, optional trailing `;`, nothing after the closing paren. The parser is quote/brace/bracket-depth aware, so a `)` inside a string doesn't fool it and a truncated `skip_response({ reason: "…` still counts.

The whole-message boundary is the key: it's what makes "suppress *every* tool by default, generic ones included" safe. A real reply is never *only* a bare tool call, and:
- `read({ path }) loads a file for you` → has trailing prose → **delivered**
- `You can use bash("ls") to list files` → doesn't start with a call → **delivered**
- `channel_react whenever a message deserves an emoji` → no call shape → **delivered**
- `bash("ls -la")` as the *whole* message → **suppressed** (a real leak, whatever the tool)

No allowlist. Future tools are covered automatically.

**RECOVER = the two-name exception.** `channel_reply` / `channel_send` leaks carry a salvageable user message, so their `text` arg is extracted and posted, exactly as before. A reply/send leak with no recoverable text falls through to the warn path (the user is still owed a message).

**SELF-CORRECT.** A suppressed leak now pushes a `TOOL_CALL_LEAK_NUDGE` system reminder and re-prompts the same logical turn, so the model redoes it with a real tool call. Bounded by a **separate** `MAX_TOOL_LEAK_RETRIES = 1` (not the empty-turn budget) so a persistently-leaking model stays silent instead of livelocking. The one intrinsic carve-out: **`skip_response` suppresses silently, no nudge** — the model's goal (silence) was already achieved by suppression, so warning would be noise.

## Why not a `deliversText` flag on the tool (raised in review)

A tool definition's concern is the contract the model reads (what/when/how to call it). "Should a leak be suppressed or recovered" is the *guard's* policy, not a property of the tool — stamping `deliversText` on every tool smears guard concerns across the tool files. So the policy lives entirely in the guard, and the guard derives it structurally (whole-message call → suppress) rather than from tool-declared metadata. The only two-name list left is the *recover* exception, which is inherently stable (a new *messaging* tool is a big, deliberate event, not a quiet side-effect tool).

## Behavior changes vs. the previous guard

- Generic tools (`bash`, `read`, `ls`, `restart`, …) narrated as a whole-message call are now **suppressed** (previously delivered). Safe because of the whole-message boundary; mid-prose mentions still deliver.
- A **bare tool name with no parens** (`skip_response` as a lone word) is no longer suppressed — without a name list it's indistinguishable from prose, and every real-world/reported leak carries parens. Accepted tradeoff.
- Leaks now trigger a bounded **self-correction retry**; on exhaustion the turn stays silent (never posts a fallback).

## Tests

- `getPlainTextChannelToolCallKind`: reply/send → recover; `skip_response(...)` → `suppress-silent`; every other whole-message call (channel *and* generic) → `suppress-warn`; prose/mentions/trailing-text → delivered (null).
- `isWholeMessageToolCall` boundary verified: quotes-with-parens, nested braces, truncation, trailing-prose rejection, bare-word rejection, `channel_read` not shadowed by `channel_react`.
- Router integration: `skip_response()` suppressed silently (no nudge); `channel_disengage()` suppressed + nudged, and a clean reply on the nudged retry lands in the same turn; a persistent leaker exhausts the 1-retry budget and stays silent (no livelock); `channel_reply` recovery intact.
- Full suite: **10462 pass / 0 fail**; typecheck, lint, format:check all clean.

## Follow-up (not in this PR)

The `channel_reply`/`channel_send` recover set and the `skip_response` silent-carve-out are still two tiny name references in the guard. They're stable, but if the router ever gains access to the live tool registry, a completeness assertion ("every channel tool is classified") would make even those self-enforcing. Noted, not built here.