### PR TITLE
fix(channels): drop stale typing ticks so a silent turn clears the indicator

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6954,6 +6954,53 @@ describe('ChannelRouter typing indicator', () => {
     await draining
   })
 
+  test('a stale-epoch tick is dropped so it cannot reach the adapter after a stop', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    // Model the Slack adapter: a 'tick' would set "is typing...", a 'stop' the
+    // empty-string clear. Recording the resolved status lets us assert the last
+    // value on the wire rather than an internal phase order.
+    const wire: string[] = []
+    router.registerTyping('discord-bot', async (target) => {
+      wire.push(target.phase === 'stop' ? '' : 'is typing...')
+    })
+
+    // given: an engaged turn with a live heartbeat at a known epoch
+    await router.route(inbound({ text: 'hi bot' }))
+    const staleEpoch = router.__testing!.typingEpoch(KEY)!
+    expect(wire).toEqual(['is typing...'])
+
+    // when: the turn ends (stop bumps the epoch and clears) and only THEN a
+    // due-but-not-yet-run interval tick from the old generation fires
+    await router.__testing!.stopTyping(KEY)
+    await router.__testing!.fireTypingTick(KEY, staleEpoch)
+
+    // then: the stale tick was dropped; the last status on the wire is the clear
+    expect(wire).toEqual(['is typing...', ''])
+    expect(wire.at(-1)).toBe('')
+  })
+
+  test('a NO_REPLY turn on a channel thread leaves the typing indicator cleared', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const wire: string[] = []
+    router.registerTyping('discord-bot', async (target) => {
+      wire.push(target.phase === 'stop' ? '' : 'is typing...')
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    // given: a mention-engaged turn on a real channel thread that decides to
+    // stay silent — no channel send happens, so the only clear is the turn-end
+    // stop (the flat-DM/after-send clear paths never run)
+    await router.route(inbound({ thread: 'thread-9', text: 'hey bot' }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thread-9' })
+
+    // then: the turn ended with the indicator cleared, not stranded on "is typing..."
+    expect(wire.at(-1)).toBe('')
+    expect(router.__testing!.isTypingActive({ ...KEY, thread: 'thread-9' })).toBe(false)
+  })
+
   test('phase=stop carries the same chat/thread coordinates as ticks', async () => {
     const dir = await tempDir()
     const { router } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -740,6 +740,13 @@ type LiveSession = {
   typingStartedAt: number
   typingTimedOut: boolean
   typingStopPromise: Promise<void> | null
+  // Monotonic heartbeat generation. Captured when a heartbeat starts and
+  // bumped when it stops. `clearInterval` cannot cancel a timer callback that
+  // already came due, so a stale 'tick' can still run AFTER stopTypingHeartbeat
+  // enqueued its clear — on Slack that re-sets "is typing..." after the empty-
+  // string clear and strands the indicator (Slack's status has no auto-expiry).
+  // A 'tick' fired with a stale epoch is dropped before it reaches the adapter.
+  typingEpoch: number
   // True only while `live.session.prompt()` is actively running. Gates the
   // deferred typing revival: a revival queued behind an in-flight cap-trip
   // 'stop' must NOT re-arm the heartbeat once the prompt has finished, or it
@@ -1243,6 +1250,8 @@ export type ChannelRouter = {
     flushDebounce: (key: ChannelKey) => Promise<void>
     fireTypingHeartbeat: (key: ChannelKey, phase?: 'tick' | 'stop') => Promise<void>
     fireTypingInterval: (key: ChannelKey) => Promise<void>
+    fireTypingTick: (key: ChannelKey, epoch: number) => Promise<void>
+    typingEpoch: (key: ChannelKey) => number | undefined
     isTypingActive: (key: ChannelKey) => boolean
     stopTyping: (key: ChannelKey) => Promise<void>
     runIdleGc: () => Promise<void>
@@ -1957,6 +1966,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         typingStartedAt: 0,
         typingTimedOut: false,
         typingStopPromise: null,
+        typingEpoch: 0,
         promptInFlight: false,
         lastInboundAt: now(),
         baseContextBytes: 0,
@@ -2223,7 +2233,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     await persist()
   }
 
-  const fireTyping = async (live: LiveSession, phase: 'tick' | 'stop'): Promise<void> => {
+  const fireTyping = async (live: LiveSession, phase: 'tick' | 'stop', epoch?: number): Promise<void> => {
+    // Drop a stale 'tick' that a since-cancelled interval still dispatched:
+    // once the heartbeat stopped (or a new one started) the captured epoch no
+    // longer matches, and forwarding it would re-set the indicator after the
+    // stop clear. 'stop' is never epoch-gated — it must always clear.
+    if (phase === 'tick' && epoch !== undefined && epoch !== live.typingEpoch) return
     const callbacks = typingCallbacks.get(live.key.adapter)
     if (!callbacks || callbacks.size === 0) return
     // Snapshot before iterating: a callback could unregister mid-call.
@@ -2389,11 +2404,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       bumpTypingActivity(live)
       return
     }
+    const epoch = ++live.typingEpoch
     live.typingStartedAt = now()
     // Fire immediately so the indicator appears on the very first inbound,
     // not 8 seconds later.
-    void fireTyping(live, 'tick')
+    void fireTyping(live, 'tick', epoch)
     live.typingTimer = setInterval(() => {
+      // A due callback can run one last time after stopTypingHeartbeat's
+      // clearInterval; the epoch mismatch makes fireTyping drop the tick so it
+      // can't re-set the indicator after the stop clear.
+      if (epoch !== live.typingEpoch) return
       if (live.destroyed) {
         void stopTypingHeartbeat(live)
         return
@@ -2406,11 +2426,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         void stopTypingHeartbeat(live)
         return
       }
-      void fireTyping(live, 'tick')
+      void fireTyping(live, 'tick', epoch)
     }, TYPING_HEARTBEAT_MS)
   }
 
   const stopTypingHeartbeat = async (live: LiveSession): Promise<void> => {
+    // Bump first, before any early return: a stop must invalidate the current
+    // generation so a due-but-not-yet-run interval tick is dropped by
+    // fireTyping's epoch guard even if the timer was already cleared.
+    live.typingEpoch++
     if (!live.typingTimer) {
       await live.typingStopPromise
       return
@@ -5127,6 +5151,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         }
         await fireTyping(live, 'tick')
       },
+      fireTypingTick: async (key: ChannelKey, epoch: number) => {
+        const live = liveSessions.get(channelKeyId(key))
+        if (!live) return
+        await fireTyping(live, 'tick', epoch)
+      },
+      typingEpoch: (key: ChannelKey) => liveSessions.get(channelKeyId(key))?.typingEpoch,
       isTypingActive: (key: ChannelKey) => {
         const live = liveSessions.get(channelKeyId(key))
         return live?.typingTimer !== null && live?.typingTimer !== undefined


### PR DESCRIPTION
## Background

In a Slack group chat, the "typing" indicator (Slack renders it as **Evaluating…**, set via `assistant.threads.setStatus`) stayed visible **after** the agent finished a turn and decided **not** to reply — the screenshot showed two consecutive bot turns both stuck typing on casual chatter the bot chose to observe silently.

Root cause is a turn-lifecycle race in the router heartbeat, not the Slack adapter. The heartbeat's `setInterval` callback fires `fireTyping(live, 'tick')` **fire-and-forget** (`void`), and `clearInterval` does **not** cancel a callback that already came due. So on a no-send turn (NO_REPLY / a leaked `skip_response`), a stale tick can still run **after** `stopTypingHeartbeat` has enqueued its empty-string clear. Slack's per-`(chat, thread)` FIFO then records:

```
""              // turn-end stop clear
"is typing..."  // stale tick, lands after the clear
```

Slack's assistant status has **no auto-expiry**, so the indicator is stranded. Discord/Telegram masked the same defect because their native indicators auto-expire and self-heal on the next tick.

## Summary

Add a monotonic per-session **typing epoch**:

- `startTypingHeartbeat` captures the epoch; the interval closure carries it.
- `stopTypingHeartbeat` bumps the epoch **before** enqueuing the clear (before any early return, so a stop always invalidates the current generation even when the timer was already null).
- `fireTyping` drops any `'tick'` whose captured epoch no longer matches the live one. `'stop'` is **never** epoch-gated — it must always clear.

**Why at the router level and not in the Slack tracker:** the FIFO is correct — it faithfully serializes what it's told. The bug is that the router hands it a stale *intent*. Fixing it here covers every current and future adapter and also prevents a stale tick from bleeding into a newly-started heartbeat (which a bare `if (!live.typingTimer)` guard would miss). "Last-intent-wins" in the Slack adapter alone would hide the same lifecycle bug behind one platform.

## What this does NOT do

- No change to the Slack per-`(chat, thread)` FIFO tracker, the debounce/drain flow, or the empty-turn / tool-leak self-correct retry logic.
- Does not touch the DM `typingThread` anchoring or the after-send clear path — those were already correct; this closes the no-send / stale-tick gap they didn't cover.
- Not a behavioral change to when the indicator *appears*, only to guaranteeing it *clears*.

## Review notes

- Load-bearing invariant: **`'stop'` is unconditional; only `'tick'` is epoch-gated.** If a future edit gates `'stop'` on the epoch, the indicator will strand again.
- The `live.typingEpoch++` in `stopTypingHeartbeat` must stay **before** the `if (!live.typingTimer)` early return.
- Tests: the race test (`a stale-epoch tick is dropped…`) reproduces the exact production strand — it **fails on the pre-fix code** with `["is typing...", "", "is typing..."]` and passes after. A second test asserts the end-to-end shape: a NO_REPLY turn on a real **channel thread** (not just a DM) ends with the indicator cleared.