### PR TITLE
fix(cli): support channel reauth for discord and fix misleading set/reauth errors

### DIFF
--- a/docs/content/docs/guides/add-a-channel.mdx
+++ b/docs/content/docs/guides/add-a-channel.mdx
@@ -218,7 +218,7 @@ LINE logs in as a real user account by QR or email/PIN and stores the resulting 
 
 <Accordion title="KakaoTalk — credentials that renew themselves">
 
-KakaoTalk is the only adapter whose login expires (about every 7 days). TypeClaw renews it for you automatically using the email and password you provide — stored encrypted, with the key kept outside the agent folder. See [Secrets policy](/docs/concepts/secrets-policy) for the threat model.
+KakaoTalk is the only adapter TypeClaw re-authenticates for you _automatically_. Its login expires (about every 7 days) and is renewed using the email and password you provide — stored encrypted, with the key kept outside the agent folder. See [Secrets policy](/docs/concepts/secrets-policy) for the threat model. Other account-login adapters (LINE, Discord user, Instagram, Webex user) can also expire, but you refresh those yourself with `typeclaw channel reauth <adapter>`.
 
 </Accordion>
 
@@ -229,9 +229,11 @@ KakaoTalk is the only adapter whose login expires (about every 7 days). TypeClaw
 If a token leaks or expires, swap it without re-adding the channel:
 
 ```sh
-typeclaw channel set slack-bot      # most adapters
-typeclaw channel reauth kakaotalk   # KakaoTalk needs an interactive re-login
+typeclaw channel set slack-bot      # token-based adapters — swap the saved token
+typeclaw channel reauth discord     # account-login adapters — replay the interactive login
 ```
+
+`channel set` covers the token-based adapters (`slack-bot`, `discord-bot`, `telegram-bot`, `webex-bot`, `github`); `channel reauth` covers the account-login ones (`line`, `instagram`, `kakaotalk`, `webex`, `discord`). See the [channel-adapters capability table](/docs/reference/channel-adapters#cli-verbs) for the full split.
 
 <Accordions>
 

--- a/docs/content/docs/reference/channel-adapters.mdx
+++ b/docs/content/docs/reference/channel-adapters.mdx
@@ -71,9 +71,9 @@ typeclaw channel reauth <adapter>   # replay the interactive login
 | Verb     | Supported adapters                                                | Notes                                                            |
 | -------- | ----------------------------------------------------------------- | ---------------------------------------------------------------- |
 | `set`    | `slack-bot`, `discord-bot`, `telegram-bot`, `webex-bot`, `github` | token-based adapters — swaps the saved token(s)                  |
-| `reauth` | `line`, `instagram`, `kakaotalk`, `webex`                         | account-login adapters — replays the full interactive login flow |
+| `reauth` | `line`, `instagram`, `kakaotalk`, `webex`, `discord`              | account-login adapters — replays the full interactive login flow |
 
-`slack` and `discord` (user-account) have no dedicated `set`/`reauth` command today. To re-authenticate, remove the adapter's `channels.<adapter>` block from **both** `secrets.json` and `typeclaw.json`, then run `channel add` again — `channel add` refuses an adapter that is still configured in `typeclaw.json`.
+`slack` (user-account) has no dedicated `set`/`reauth` command today. To re-authenticate, remove its `channels.slack` block from **both** `secrets.json` and `typeclaw.json`, then run `channel add slack` again — `channel add` refuses an adapter that is still configured in `typeclaw.json`. (`discord` user-account is reauthable: run `channel reauth discord` to replay the QR login in place.)
 
 ## Routing model
 

--- a/docs/content/docs/reference/discord.mdx
+++ b/docs/content/docs/reference/discord.mdx
@@ -59,7 +59,7 @@ Each record under `accounts.<accountId>`:
 | `created_at` | Record creation timestamp                |
 | `updated_at` | Last-update timestamp                    |
 
-CLI: `typeclaw channel add discord` (interactive QR login). The `discord` adapter is not part of `channel set` or `channel reauth` today, so there is no dedicated re-auth command — see the [re-auth quirk](#quirks) below if the session expires.
+CLI: `typeclaw channel add discord` (interactive QR login). When the unofficial session expires, run `typeclaw channel reauth discord` to replay the QR login and refresh the token in `secrets.json` — see the [re-auth quirk](#quirks) below.
 
 ## Capabilities
 
@@ -92,7 +92,7 @@ In role match rules, DMs are addressed by the canonical `dm` **bucket** scope, n
 - **No typing indicator**: the adapter declares no typing capability, so delayed replies are anchored with a quoted-reply prefix instead of a live typing dot (see [Channel adapters](/docs/reference/channel-adapters)).
 - **No slash commands**: `/help`, `/stop`, `/reload`, `/restart` exist only on the [`discord-bot`](/docs/reference/discord-bot) adapter.
 - **Attachments post first, then text**: a failed upload won't leave a text-only message already posted.
-- **Re-auth has no dedicated CLI command**: the session can expire, but `discord` is excluded from both `channel set` and `channel reauth`, and `channel add discord` refuses an already-configured adapter. To re-authenticate today, remove the `channels.discord` block from `secrets.json` (and the `discord` entry from `typeclaw.json` if present), then run `typeclaw channel add discord` again to scan a fresh QR code.
+- **Re-auth replays the QR login**: the unofficial session can expire. Run `typeclaw channel reauth discord` to scan a fresh QR code and rotate the token in place — no need to remove and re-add the channel. (Credential rotation goes through `channel reauth`, not `channel set`, because there is no token field to paste; `channel set discord` redirects you to `reauth`.)
 
 ## Config
 

--- a/src/cli/channel.test.ts
+++ b/src/cli/channel.test.ts
@@ -7,6 +7,8 @@ import {
   holderSpinnerControl,
   printLinePincode,
   printLineQrUrl,
+  reauthAdapterRejectionMessage,
+  setAdapterRejectionMessage,
   SLACK_MODES,
   WEBEX_MODES,
   type LineAuthSpinnerHolder,
@@ -136,5 +138,67 @@ describe('holderSpinnerControl', () => {
       control.pause()
       control.resume('anything')
     }).not.toThrow()
+  })
+})
+
+describe('setAdapterRejectionMessage', () => {
+  test('redirects reauthable adapters to `channel reauth` instead of dead-ending', () => {
+    // given a user-mode adapter that rotates via full re-auth (the reported Discord bug)
+    // when
+    const message = setAdapterRejectionMessage('discord')
+
+    // then it points at the command that actually works, not a contradictory one
+    expect(message).toBe(
+      'Adapter "discord" does not support `channel set`. Use `typeclaw channel reauth discord` instead.',
+    )
+  })
+
+  test('sends other reauthable adapters (line) to `channel reauth` too', () => {
+    // when
+    const message = setAdapterRejectionMessage('line')
+
+    // then
+    expect(message).toContain('typeclaw channel reauth line')
+  })
+
+  test('gives a remove+add recipe for a known kind that is neither settable nor reauthable', () => {
+    // given slack user-mode has no in-place rotation path
+    // when
+    const message = setAdapterRejectionMessage('slack')
+
+    // then it does not falsely suggest reauth
+    expect(message).toContain('typeclaw channel remove slack && typeclaw channel add slack')
+    expect(message).not.toContain('reauth')
+  })
+
+  test('reports unknown adapters with the settable allow-list', () => {
+    // when
+    const message = setAdapterRejectionMessage('bogus')
+
+    // then
+    expect(message).toContain('Unknown adapter "bogus"')
+  })
+})
+
+describe('reauthAdapterRejectionMessage', () => {
+  test('redirects settable adapters to `channel set` instead of dead-ending', () => {
+    // given discord-bot rotates via a token field, not re-auth (mirror of the reported bug)
+    // when
+    const message = reauthAdapterRejectionMessage('discord-bot')
+
+    // then it points at the command that actually works
+    expect(message).toBe(
+      'Adapter "discord-bot" does not support reauth. Use `typeclaw channel set discord-bot` to rotate its credentials.',
+    )
+  })
+
+  test('lists the supported adapters (now including discord) for a neither-settable-nor-reauthable kind', () => {
+    // given slack user-mode is neither settable nor reauthable
+    // when
+    const message = reauthAdapterRejectionMessage('slack')
+
+    // then discord user-mode is advertised as reauth-capable
+    expect(message).toContain('does not support reauth. Supported:')
+    expect(message).toContain('discord')
   })
 })

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -183,7 +183,11 @@ const setSub = defineCommand({
   },
 })
 
-const REAUTHABLE_ADAPTERS = ['line', 'instagram', 'kakaotalk', 'webex'] as const
+// Adapters that re-authenticate through a full interactive login replay rather
+// than a token-field rotation (`channel set`). Discord (User) belongs here — its
+// unofficial QR session expires and is refreshed by replaying the QR login, the
+// same shape as LINE's QR flow. `discord-bot` stays in SETTABLE_ADAPTERS.
+const REAUTHABLE_ADAPTERS = ['line', 'instagram', 'kakaotalk', 'webex', 'discord'] as const
 type ReauthableAdapter = (typeof REAUTHABLE_ADAPTERS)[number]
 
 const reauthSub = defineCommand({
@@ -405,9 +409,7 @@ async function resolveReauthableAdapter(
 ): Promise<ReauthableAdapter> {
   if (requested !== undefined) {
     if (!isReauthableAdapter(requested)) {
-      console.error(
-        errorLine(`Adapter "${requested}" does not support reauth. Supported: ${REAUTHABLE_ADAPTERS.join(', ')}.`),
-      )
+      console.error(errorLine(reauthAdapterRejectionMessage(requested)))
       process.exit(1)
     }
     if (!configured.has(requested)) {
@@ -448,6 +450,14 @@ function isReauthableAdapter(value: string): value is ReauthableAdapter {
   return (REAUTHABLE_ADAPTERS as ReadonlyArray<string>).includes(value)
 }
 
+// Returns the string (rather than exiting inline) so the routing stays testable.
+export function reauthAdapterRejectionMessage(adapter: string): string {
+  if (isSettableAdapter(adapter)) {
+    return `Adapter "${adapter}" does not support reauth. Use \`typeclaw channel set ${adapter}\` to rotate its credentials.`
+  }
+  return `Adapter "${adapter}" does not support reauth. Supported: ${REAUTHABLE_ADAPTERS.join(', ')}.`
+}
+
 async function runReauth(cwd: string, adapter: ReauthableAdapter): Promise<void> {
   switch (adapter) {
     case 'line':
@@ -461,6 +471,9 @@ async function runReauth(cwd: string, adapter: ReauthableAdapter): Promise<void>
       return
     case 'webex':
       await runWebexReauth(cwd)
+      return
+    case 'discord':
+      await runDiscordReauth(cwd)
       return
   }
 }
@@ -538,6 +551,17 @@ async function runWebexReauth(cwd: string): Promise<void> {
   s.stop('Webex credentials refreshed in secrets.json.')
 
   await maybePromptReauthRefresh(cwd, 'webex')
+}
+
+async function runDiscordReauth(cwd: string): Promise<void> {
+  const result = await runDiscordBootstrap({ agentDir: cwd, onQrUrl: renderDiscordQrToTerminal })
+  if (!result.ok) {
+    console.error(errorLine(`Discord login failed: ${result.reason}`))
+    process.exit(1)
+  }
+  process.stdout.write(`${successLine('Discord credentials refreshed in secrets.json.')}\n`)
+
+  await maybePromptReauthRefresh(cwd, 'discord')
 }
 
 async function readExistingKakaotalkEmail(cwd: string): Promise<string | undefined> {
@@ -771,17 +795,20 @@ function isSettableAdapter(value: string): value is SettableAdapter {
   return (SETTABLE_ADAPTERS as ReadonlyArray<string>).includes(value)
 }
 
+// Returns the string (rather than exiting inline) so the routing stays testable.
+export function setAdapterRejectionMessage(adapter: string): string {
+  if (isReauthableAdapter(adapter)) {
+    return `Adapter "${adapter}" does not support \`channel set\`. Use \`typeclaw channel reauth ${adapter}\` instead.`
+  }
+  if (isChannelKind(adapter)) {
+    return `Adapter "${adapter}" does not support \`channel set\`. Rotate its credentials by removing and re-adding it: \`typeclaw channel remove ${adapter} && typeclaw channel add ${adapter}\`.`
+  }
+  return `Unknown adapter "${adapter}". Expected one of: ${SETTABLE_ADAPTERS.join(', ')}.`
+}
+
 function validateSetAdapterArg(adapter: string, configured: Set<ChannelKind>): SettableAdapter {
   if (!isSettableAdapter(adapter)) {
-    if (isChannelKind(adapter)) {
-      console.error(
-        errorLine(
-          `Adapter "${adapter}" does not support \`channel set\`. Use \`typeclaw channel reauth ${adapter}\` instead.`,
-        ),
-      )
-    } else {
-      console.error(errorLine(`Unknown adapter "${adapter}". Expected one of: ${SETTABLE_ADAPTERS.join(', ')}.`))
-    }
+    console.error(errorLine(setAdapterRejectionMessage(adapter)))
     process.exit(1)
   }
   if (!configured.has(adapter)) {


### PR DESCRIPTION
## Background

Rotating Discord (User) credentials from the CLI dead-ends in a contradictory loop:

```console
$ typeclaw channel set discord
✖ Adapter "discord" does not support `channel set`. Use `typeclaw channel reauth discord` instead.

$ typeclaw channel reauth discord
✖ Adapter "discord" does not support reauth. Supported: line, instagram, kakaotalk, webex.
```

`channel set` sends you to `channel reauth`, and `channel reauth` says Discord isn't supported. The user is stuck with no working command.

Root cause (`src/cli/channel.ts`): `discord` (user mode) was in **neither** capability list. `discord-bot` (bot mode) is in `SETTABLE_ADAPTERS`, but the QR-based `discord` user adapter was in `SETTABLE_ADAPTERS` **and** `REAUTHABLE_ADAPTERS` — nowhere. So:

- `channel set discord` → `validateSetAdapterArg` → not settable, but a known `ChannelKind` → the generic branch blindly suggested `reauth` for **any** non-settable kind, regardless of whether it was actually reauthable.
- `channel reauth discord` → `resolveReauthableAdapter` → not reauthable → "Supported: line, instagram, kakaotalk, webex."

Discord user mode already has a QR bootstrap (`runDiscordBootstrap` in `src/init/discord-auth.ts`) used by `channel add discord`; its unofficial session token expires like LINE's, so it belongs with the account-login (reauth) adapters — there just was no `runDiscordReauth` wired up.

## Summary

Both fixes the user asked for:

1. **Add real `channel reauth discord` support.** `discord` joins `REAUTHABLE_ADAPTERS`; `runDiscordReauth` replays the QR login via the existing `runDiscordBootstrap` and prompts for a restart, the same shape as `runLineReauth`. The `reauth` command's help text auto-derives from the list, so it now advertises `discord` too.

2. **Fix the misleading cross-hints (both directions).** The set↔reauth redirect is now accurate instead of a blanket "use reauth":
   - a **reauthable** kind (`discord`, `line`, …) under `channel set` → redirected to `channel reauth` (correct).
   - a **settable-but-not-reauthable** kind (`discord-bot`) under `channel reauth` → redirected to `channel set` (previously dumped the raw "Supported:" list).
   - a kind supporting **neither** (`slack` user) → gets a `remove && add` recipe instead of a bogus reauth suggestion that would itself dead-end.

The message selection is extracted into two pure functions (`setAdapterRejectionMessage` / `reauthAdapterRejectionMessage`) so the routing is unit-testable without stubbing `process.exit`; the validators just print the returned string and exit.

After:

```console
$ typeclaw channel set discord
✖ Adapter "discord" does not support `channel set`. Use `typeclaw channel reauth discord` instead.

$ typeclaw channel reauth discord
◇  Re-authenticating channel: Discord (User)
   … QR login … Discord credentials refreshed in secrets.json.
```

## What this does NOT do

- Does **not** change `discord-bot` (it stays in `SETTABLE_ADAPTERS`; `channel set discord-bot` is unchanged).
- Does **not** add a `channel set discord` path — Discord user has no token field to paste, so rotation goes through `reauth` (QR), exactly like LINE.
- Does **not** touch the existing kakaotalk/line/instagram early-exit guards in `setSub`, the QR rendering, or the restart-prompt flow.
- Does **not** change `slack` user mode's capabilities — it remains neither settable nor reauthable (its message is just no longer misleading).

## Review notes

- Load-bearing: `discord` added to `REAUTHABLE_ADAPTERS` and the `case 'discord'` arm in `runReauth` (`src/cli/channel.ts`). `resolveReauthableAdapter`'s existing `configured.has(...)` guard still fires "run `channel add discord` first" when Discord isn't configured.
- `reauthAdapterRejectionMessage` references `isSettableAdapter`, which is declared later in the file — fine via function hoisting, consistent with the existing forward references in this module.
- Tests (`src/cli/channel.test.ts`): the two new pure functions are asserted directly — `set discord`→reauth, `set line`→reauth, `set slack`→remove+add (and explicitly `not.toContain('reauth')`), `set bogus`→unknown; `reauth discord-bot`→set, `reauth slack`→supported-list-now-includes-discord. These reproduce the reported dead-end and lock the fix.
- Full suite: **10471 pass / 0 fail**; typecheck, lint, and format:check all clean.
