### PR TITLE
fix(channels): distinguish configured-but-unavailable adapters from unsupported

### DIFF
--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -36,6 +36,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -20,6 +20,7 @@ function fakeRouter(queueReactionAfterReply: (req: ReactionRequest) => Promise<R
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -29,6 +29,7 @@ function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: 
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -37,6 +37,7 @@ function fakeRouter(
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -38,6 +38,7 @@ function fakeRouter(handlers: {
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -27,6 +27,7 @@ function fakeRouter(
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -55,6 +55,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -32,6 +32,7 @@ function fakeRouter(
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -46,6 +46,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     registerTyping: () => {},
     unregisterTyping: () => {},
     setTypingCapability: () => {},
+    setAdapterConfigured: () => {},
     registerChannelNameResolver: () => {},
     unregisterChannelNameResolver: () => {},
     registerSelfIdentity: () => {},

--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -1129,3 +1129,63 @@ describe('channel manager — kakaotalk credential preflight', () => {
     await mgr.stop()
   })
 })
+
+describe('channel manager — router adapter-configured wiring', () => {
+  test('a configured adapter whose start() fails still reports history as configured-but-unavailable', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const failing = makeFakeAdapter()
+    failing.start = async () => {
+      throw new Error('401: Unauthorized')
+    }
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => failing,
+    })
+
+    await mgr.start()
+
+    const result = await mgr.router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.error).toContain('history-adapter-unavailable')
+
+    await mgr.stop()
+  })
+
+  test('an adapter absent from config reports history as plain not-supported', async () => {
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: {},
+    })
+
+    await mgr.start()
+
+    const result = await mgr.router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+    expect(result).toEqual({ ok: false, error: 'history-not-supported' })
+
+    await mgr.stop()
+  })
+
+  test('reload dropping an adapter from config reverts it to not-supported', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const fake = makeFakeAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => fake,
+    })
+
+    await mgr.start()
+    delete cfg['discord-bot']
+    await mgr.reload()
+
+    const result = await mgr.router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
+    expect(result).toEqual({ ok: false, error: 'history-not-supported' })
+
+    await mgr.stop()
+  })
+})

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -482,7 +482,13 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       // the sum of each adapter's connect latency instead of just the slowest.
       const starts = ADAPTER_IDS.flatMap((name) => {
         const adapterCfg = cfg[name]
-        return adapterCfg === undefined ? [] : [runSerially(name, () => startAdapter(name, adapterCfg))]
+        if (adapterCfg === undefined) return []
+        // Mark configured up front, regardless of start outcome: a failed start
+        // (e.g. expired token) never registers a history callback, and the router
+        // uses this flag to answer "configured but unavailable" instead of the
+        // misleading "not supported".
+        router.setAdapterConfigured(name, adapterCfg.enabled !== false)
+        return [runSerially(name, () => startAdapter(name, adapterCfg))]
       })
       // Await every launched start to settle BEFORE surfacing a failure.
       // `startAdapter` converts expected per-adapter failures to `false`, so a
@@ -528,11 +534,13 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         const desired = cfg[name]
         const current = live.get(name)
         if (desired === undefined || desired.enabled === false) {
+          router.setAdapterConfigured(name, false)
           if (current) {
             await runSerially(name, () => stopAdapter(name))
             stopped.push(name)
           }
         } else if (!current) {
+          router.setAdapterConfigured(name, true)
           const ok = await runSerially(name, () => startAdapter(name, desired))
           if (ok) started.push(name)
         } else {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8605,6 +8605,30 @@ describe('ChannelRouter history dispatch', () => {
     expect(result).toEqual({ ok: false, error: 'history-not-supported' })
   })
 
+  test('returns an adapter-unavailable error when the adapter is configured but has no callback', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.setAdapterConfigured('discord', true)
+
+    const result = await router.fetchHistory('discord', { chat: 'c1', thread: null, limit: 1 })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.error).toContain('history-adapter-unavailable')
+    expect(result.error).toContain('discord')
+  })
+
+  test('setAdapterConfigured(false) reverts to history-not-supported', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.setAdapterConfigured('discord', true)
+    router.setAdapterConfigured('discord', false)
+
+    const result = await router.fetchHistory('discord', { chat: 'c1', thread: null, limit: 1 })
+
+    expect(result).toEqual({ ok: false, error: 'history-not-supported' })
+  })
+
   test('first ok callback wins; later callbacks are not invoked', async () => {
     const dir = await tempDir()
     const { router } = makeRouter(dir)
@@ -8734,6 +8758,31 @@ describe('ChannelRouter message-get dispatch', () => {
     expect(result).toEqual({ ok: false, error: 'message-get-not-supported', code: 'not-supported' })
   })
 
+  test('returns code adapter-unavailable when a message-get-capable adapter is configured but has no callback', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.setAdapterConfigured('discord-bot', true)
+
+    const result = await router.getMessage('discord-bot', { chat: 'c1', thread: null, messageId: 'm1' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.code).toBe('adapter-unavailable')
+    expect(result.error).toContain('discord-bot')
+  })
+
+  test('keeps not-supported for a configured adapter that never implements message-get', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    // discord (personal) is configured and history-capable, but has no
+    // message-get callback by design — must stay not-supported, not unavailable.
+    router.setAdapterConfigured('discord', true)
+
+    const result = await router.getMessage('discord', { chat: 'c1', thread: null, messageId: 'm1' })
+
+    expect(result).toEqual({ ok: false, error: 'message-get-not-supported', code: 'not-supported' })
+  })
+
   test('unregisterMessageGet removes the callback so subsequent calls fall back to not-supported', async () => {
     const dir = await tempDir()
     const { router } = makeRouter(dir)
@@ -8789,6 +8838,31 @@ describe('ChannelRouter channel-list dispatch', () => {
     const { router } = makeRouter(dir)
 
     const result = await router.listChannels('slack-bot', { workspace: 'T0', limit: 50 })
+
+    expect(result).toEqual({ ok: false, error: 'list-not-supported', code: 'not-supported' })
+  })
+
+  test('returns code adapter-unavailable when a list-capable adapter is configured but has no callback', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.setAdapterConfigured('slack-bot', true)
+
+    const result = await router.listChannels('slack-bot', { workspace: 'T0', limit: 50 })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected failure')
+    expect(result.code).toBe('adapter-unavailable')
+    expect(result.error).toContain('slack-bot')
+  })
+
+  test('keeps not-supported for a configured adapter that never implements list', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    // slack (personal) is configured and history-capable but has no list
+    // callback by design — must stay not-supported, not unavailable.
+    router.setAdapterConfigured('slack', true)
+
+    const result = await router.listChannels('slack', { workspace: 'T0', limit: 50 })
 
     expect(result).toEqual({ ok: false, error: 'list-not-supported', code: 'not-supported' })
   })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -62,7 +62,13 @@ import {
   saveChannelSessions,
   type ChannelSessionRecord,
 } from './persistence'
-import { QUOTED_REPLY_EXCERPT_MAX_CHARS, type AdapterId, type ChannelAdapterConfig } from './schema'
+import {
+  ADAPTER_READ_CAPABILITIES,
+  QUOTED_REPLY_EXCERPT_MAX_CHARS,
+  type AdapterId,
+  type ChannelAdapterConfig,
+  type ReadCapability,
+} from './schema'
 import type {
   ChannelHistoryMessage,
   ChannelKey,
@@ -1097,6 +1103,17 @@ export type ChannelRouter = {
   // the wrong signal. autoReactOnEngage reads this to post :eyes: only as a
   // fallback when no visible typing exists. Unset defaults to false.
   setTypingCapability: (adapter: ChannelKey['adapter'], supported: boolean) => void
+  // Set by the manager for every adapter present in typeclaw.json#channels,
+  // independent of whether the adapter's start() succeeded (a failed login never
+  // registers callbacks). Combined with the adapter's static read-capability set
+  // (ADAPTER_READ_CAPABILITIES), fetchHistory/getMessage/listChannels tell three
+  // cases apart for a missing callback: not configured → *-not-supported;
+  // configured but the capability isn't one this adapter implements →
+  // *-not-supported; configured AND the adapter should implement it but no
+  // callback is live (e.g. auth failure at startup) → *-adapter-unavailable. So
+  // the agent only sees the actionable error when re-auth would actually help.
+  // Unset defaults to not-configured.
+  setAdapterConfigured: (adapter: ChannelKey['adapter'], configured: boolean) => void
   registerChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
   unregisterChannelNameResolver: (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver) => void
   // Self-identity is a per-adapter singleton (one bot account per adapter),
@@ -1454,6 +1471,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const removeReactionCallbacks = new Map<ChannelKey['adapter'], Set<RemoveReactionCallback>>()
   const typingCallbacks = new Map<ChannelKey['adapter'], Set<TypingCallback>>()
   const typingCapableAdapters = new Set<ChannelKey['adapter']>()
+  const configuredAdapters = new Set<ChannelKey['adapter']>()
   const channelNameResolvers = new Map<ChannelKey['adapter'], Set<ChannelNameResolver>>()
   const membershipResolvers = new Map<ChannelKey['adapter'], Set<MembershipResolver>>()
   const selfIdentityResolvers = new Map<ChannelKey['adapter'], ChannelSelfIdentityResolver>()
@@ -3502,6 +3520,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     else typingCapableAdapters.delete(adapter)
   }
 
+  const setAdapterConfigured = (adapter: ChannelKey['adapter'], configured: boolean): void => {
+    if (configured) configuredAdapters.add(adapter)
+    else configuredAdapters.delete(adapter)
+  }
+
   const registerChannelNameResolver = (adapter: ChannelKey['adapter'], resolver: ChannelNameResolver): void => {
     let set = channelNameResolvers.get(adapter)
     if (!set) {
@@ -3566,10 +3589,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     historyCallbacks.get(adapter)?.delete(cb)
   }
 
+  const isReadCapabilityUnavailable = (adapter: ChannelKey['adapter'], capability: ReadCapability): boolean =>
+    configuredAdapters.has(adapter) && ADAPTER_READ_CAPABILITIES[adapter].includes(capability)
+
+  const missingCallbackError = (adapter: ChannelKey['adapter'], capability: ReadCapability): string =>
+    isReadCapabilityUnavailable(adapter, capability)
+      ? `${capability}-adapter-unavailable: the "${adapter}" adapter is configured but not currently running (it likely failed to start, e.g. an expired token or auth error — check the container logs and re-authenticate)`
+      : `${capability}-not-supported`
+
   const fetchHistory = async (adapter: ChannelKey['adapter'], args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
     const callbacks = historyCallbacks.get(adapter)
     if (!callbacks || callbacks.size === 0) {
-      return { ok: false, error: 'history-not-supported' }
+      return { ok: false, error: missingCallbackError(adapter, 'history') }
     }
     // Snapshot before iterating, mirroring `send`: a callback that mutates
     // the set (e.g. unregisters mid-call) must not skip siblings.
@@ -3598,7 +3629,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const getMessage = async (adapter: ChannelKey['adapter'], args: GetMessageArgs): Promise<GetMessageResult> => {
     const cb = messageGetCallbacks.get(adapter)
-    if (cb === undefined) return { ok: false, error: 'message-get-not-supported', code: 'not-supported' }
+    if (cb === undefined)
+      return isReadCapabilityUnavailable(adapter, 'message-get')
+        ? { ok: false, error: missingCallbackError(adapter, 'message-get'), code: 'adapter-unavailable' }
+        : { ok: false, error: 'message-get-not-supported', code: 'not-supported' }
     try {
       return await raceWithTimeout(cb(args), fetchHistoryTimeoutMs, `[channels] ${adapter} message get`)
     } catch (err) {
@@ -3617,7 +3651,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
   const listChannels = async (adapter: ChannelKey['adapter'], args: ListChannelsArgs): Promise<ListChannelsResult> => {
     const cb = listCallbacks.get(adapter)
-    if (cb === undefined) return { ok: false, error: 'list-not-supported', code: 'not-supported' }
+    if (cb === undefined)
+      return isReadCapabilityUnavailable(adapter, 'list')
+        ? { ok: false, error: missingCallbackError(adapter, 'list'), code: 'adapter-unavailable' }
+        : { ok: false, error: 'list-not-supported', code: 'not-supported' }
     try {
       return await raceWithTimeout(cb(args), fetchHistoryTimeoutMs, `[channels] ${adapter} list channels`)
     } catch (err) {
@@ -5074,6 +5111,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     registerTyping,
     unregisterTyping,
     setTypingCapability,
+    setAdapterConfigured,
     registerChannelNameResolver,
     unregisterChannelNameResolver,
     registerSelfIdentity,

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
-import { channelsSchema, DEFAULT_GITHUB_EVENT_ALLOWLIST, STICKY_DEFAULT_WINDOW_MS } from './schema'
+import {
+  ADAPTER_IDS,
+  ADAPTER_READ_CAPABILITIES,
+  channelsSchema,
+  DEFAULT_GITHUB_EVENT_ALLOWLIST,
+  type ReadCapability,
+  STICKY_DEFAULT_WINDOW_MS,
+} from './schema'
 
 describe('channelsSchema', () => {
   test('parses an empty channels record', () => {
@@ -114,4 +123,47 @@ describe('channelsSchema', () => {
     expect(parsed.github?.eventAllowlist).toEqual([...DEFAULT_GITHUB_EVENT_ALLOWLIST])
     expect(parsed.github?.eventAllowlist).toContain('pull_request.synchronize')
   })
+})
+
+describe('ADAPTER_READ_CAPABILITIES', () => {
+  test('declares every adapter id', () => {
+    for (const id of ADAPTER_IDS) {
+      expect(ADAPTER_READ_CAPABILITIES[id]).toBeDefined()
+    }
+  })
+
+  // The read-capability table is the fence that keeps a configured-but-broken
+  // adapter reporting `*-adapter-unavailable` only for modes it actually
+  // implements. It's a hand-maintained static table (it must survive a failed
+  // start() that registers nothing), so this test statically re-derives each
+  // adapter's capabilities from the register*() calls in its source and fails
+  // if the table drifts — add/remove a callback and you must update the table.
+  const adapterSourcePath: Record<(typeof ADAPTER_IDS)[number], string> = {
+    discord: 'discord.ts',
+    'discord-bot': 'discord-bot.ts',
+    github: 'github/index.ts',
+    instagram: 'instagram.ts',
+    line: 'line.ts',
+    kakaotalk: 'kakaotalk.ts',
+    slack: 'slack.ts',
+    'slack-bot': 'slack-bot.ts',
+    'telegram-bot': 'telegram-bot.ts',
+    webex: 'webex.ts',
+    'webex-bot': 'webex-bot.ts',
+  }
+  const capabilityCall: Record<ReadCapability, RegExp> = {
+    history: /\.registerHistory\(/,
+    'message-get': /\.registerMessageGet\(/,
+    list: /\.registerList\(/,
+  }
+
+  for (const id of ADAPTER_IDS) {
+    test(`table matches the register*() calls in ${adapterSourcePath[id]}`, () => {
+      const source = readFileSync(join(import.meta.dir, 'adapters', adapterSourcePath[id]), 'utf8')
+      const derived = (Object.keys(capabilityCall) as ReadCapability[]).filter((cap) =>
+        capabilityCall[cap].test(source),
+      )
+      expect([...ADAPTER_READ_CAPABILITIES[id]].sort()).toEqual(derived.sort())
+    })
+  }
 })

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -16,6 +16,30 @@ export const ADAPTER_IDS = [
 
 export type AdapterId = (typeof ADAPTER_IDS)[number]
 
+export type ReadCapability = 'history' | 'message-get' | 'list'
+
+// Which arbitrary-read callbacks each adapter registers when it starts healthy.
+// A missing callback means "adapter-unavailable" (failed to start) ONLY for a
+// capability listed here; capabilities an adapter never implements stay
+// "not-supported" even when the adapter is configured and running. Kept as a
+// static table because the distinction must survive a failed start() (which
+// registers nothing), so it can't be derived from the live callback registry.
+// The guard test in schema.test.ts asserts this matches what each adapter's
+// start() actually registers — update both together or CI fails.
+export const ADAPTER_READ_CAPABILITIES: Record<AdapterId, readonly ReadCapability[]> = {
+  discord: ['history'],
+  'discord-bot': ['history', 'message-get', 'list'],
+  github: ['history'],
+  instagram: ['history'],
+  line: ['history'],
+  kakaotalk: ['history'],
+  slack: ['history'],
+  'slack-bot': ['history', 'message-get', 'list'],
+  'telegram-bot': [],
+  webex: ['history'],
+  'webex-bot': ['history'],
+}
+
 const engagementTriggerSchema = z.enum(['mention', 'reply', 'dm'])
 
 const stickinessSchema = z.union([

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -365,7 +365,8 @@ export type FetchHistoryResult =
 // Registered per-adapter on the ChannelRouter alongside outbound/typing
 // callbacks. Adapters that cannot fetch history (e.g. webhook-only future
 // adapters) simply do not register one; the router answers
-// 'history-not-supported' for those.
+// 'history-not-supported' for those, or 'history-adapter-unavailable' when the
+// adapter is configured but failed to start (see setAdapterConfigured).
 export type HistoryCallback = (args: FetchHistoryArgs) => Promise<FetchHistoryResult>
 
 // Fetch a single message by its platform id from an arbitrary chat. Backs the
@@ -383,9 +384,11 @@ export type GetMessageArgs = {
 export type GetMessageResult =
   | { ok: true; message: ChannelHistoryMessage }
   // `code: 'not-found'` is an expected miss (deleted/wrong id) the tool surfaces
-  // as a soft error; `code: 'not-supported'` means no adapter callback is
-  // registered, mirroring `fetchHistory`'s 'history-not-supported' contract.
-  | { ok: false; error: string; code?: 'not-found' | 'not-supported' }
+  // as a soft error; `code: 'not-supported'` means the adapter is not configured
+  // at all; `code: 'adapter-unavailable'` means it IS configured but currently
+  // has no live callback (e.g. failed to start), mirroring `fetchHistory`'s
+  // 'message-get-adapter-unavailable' string contract.
+  | { ok: false; error: string; code?: 'not-found' | 'not-supported' | 'adapter-unavailable' }
 
 export type MessageGetCallback = (args: GetMessageArgs) => Promise<GetMessageResult>
 
@@ -408,7 +411,7 @@ export type ListChannelsArgs = {
 
 export type ListChannelsResult =
   | { ok: true; entries: ChannelListEntry[]; nextCursor?: string }
-  | { ok: false; error: string; code?: 'not-supported' }
+  | { ok: false; error: string; code?: 'not-supported' | 'adapter-unavailable' }
 
 // Backs the `channel_read` tool's `mode: "list"`. Opt-in per adapter like
 // history; the router answers 'list-not-supported' when none is registered.


### PR DESCRIPTION
## Background

When the agent calls `channel_read({ adapter: "discord", mode: "history", ... })` and the router has no history callback for that adapter, `fetchHistory` returns a flat `history-not-supported` (`src/channels/router.ts`). That single error collapses two situations that are nothing alike:

1. **Genuinely unsupported** — the adapter never registers a history callback *by design* (a future webhook-only adapter). `history-not-supported` is correct here.
2. **Supported but not running** — the adapter *does* implement history but its `start()` threw before `registerHistory` ran. The canonical case: a self-token **Discord** adapter whose token expired. `client.login()` gets a `401`, `start()` rolls back and rethrows *before* `registerCallbacks()`, so the router simply has no entry — indistinguishable, from the router's seat, from case 1.

Observed in the wild: an agent with a dead Discord self-token concluded from `history-not-supported` that *"the adapter doesn't do history"* and stopped — when the real, actionable cause was *"re-authenticate the token."* Container logs told the true story (`[discord] login failed: 401: Unauthorized` → `[channels] adapter "discord" failed to start`), but none of that survived down to the tool result the model reads.

## The design

The router **cannot** infer intent from a missing map entry — it doesn't know *why* a callback is absent (never-registered-by-design vs. failed-to-start). So the fix restores the lost bit at the layer that has it: the **manager** knows which adapters are *configured* (present in `typeclaw.json#channels`), independent of whether `start()` succeeded.

- **New router capability**: `setAdapterConfigured(adapter, configured)` — a `Set<AdapterId>`, mirroring the existing `setTypingCapability` pattern exactly. Unset defaults to not-configured.
- **Manager drives it** (`src/channels/manager.ts`): marks every adapter with a config block configured *up front in `start()`*, **before and regardless of** the `startAdapter` outcome (a failed login never registers a callback — that's the whole point), and clears it on `reload()` when the adapter is dropped/disabled.
- **Three read paths react** (`fetchHistory` / `getMessage` / `listChannels`): when there's no callback,
  - configured → `*-adapter-unavailable: the "<adapter>" adapter is configured but not currently running (it likely failed to start, e.g. an expired token or auth error — check the container logs and re-authenticate)`
  - not configured → the existing `*-not-supported` (**unchanged**)

The error string is agent-facing: it names the adapter and points at logs + re-auth, so the model self-diagnoses instead of giving up.

## Why not thread the raw 401 up

The `401` happens at *startup*, minutes before the `channel_read` call, and isn't available at `fetchHistory` time. Plumbing a stale error string down would be brittle and often wrong. The right signal is a *status* (configured-but-not-live), not a *stale error* — which is exactly what a boolean `Set` conveys, and it fixes the whole class (any adapter that dies on startup), not just Discord.

## Contract changes

- `FetchHistoryResult` keeps its string-only discriminant; the new case is a `history-adapter-unavailable` **string** (no `code` field existed there — left as-is for backward-compat).
- `GetMessageResult` / `ListChannelsResult` gain `code: 'adapter-unavailable'` alongside the existing `'not-supported'`.
- Adapters that are **not configured** still get the exact old `*-not-supported` strings/codes, so every existing not-supported contract test passes untouched. Tool rendering (`channel_read`/`channel_history`) passes `result.error` through verbatim, so the richer message surfaces with no tool-layer change.

## Tests

- **router** (`router.test.ts`): configured-but-no-callback → `*-adapter-unavailable` naming the adapter, for history/message/list; `setAdapterConfigured(false)` reverts to `*-not-supported`.
- **manager** (`manager.test.ts`): a configured adapter whose `start()` throws (`401`) still reports history as `history-adapter-unavailable`; an adapter absent from config reports plain `history-not-supported`; `reload()` dropping an adapter reverts it to not-supported.
- Full suite green: `10474 pass / 0 fail`, plus `typecheck` / `lint` (0 errors) / `format:check` clean.
