### PR TITLE
test(backup): make idle-debounce tests deterministic with fake timers

### DIFF
--- a/src/bundled-plugins/backup/index.test.ts
+++ b/src/bundled-plugins/backup/index.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import * as FakeTimers from '@sinonjs/fake-timers'
 
 import { noopPermissionService } from '@/permissions'
 import type { PluginContext, PluginExports } from '@/plugin'
@@ -64,6 +66,31 @@ const tinyConfig = {
   networkTimeoutMs: 1000,
 }
 
+// Fake setTimeout/clearTimeout so the session.idle debounce (which schedules its
+// fire via the global setTimeout in index.ts) advances on virtual time instead of
+// the wall clock — the wall-clock version flaked on Windows CI where coarse timer
+// granularity let the debounce window fire more than once. Same seam the sibling
+// memory plugin's index.test.ts uses.
+let clock: FakeTimers.Clock | null = null
+
+beforeEach(() => {
+  clock = FakeTimers.install({ toFake: ['setTimeout', 'clearTimeout'] })
+})
+
+afterEach(() => {
+  clock?.uninstall()
+  clock = null
+})
+
+async function advance(ms: number): Promise<void> {
+  if (!clock) throw new Error('clock not installed; beforeEach did not run')
+  await clock.tickAsync(ms)
+  // Drain trailing microtasks the fire path awaits (fireIfQuiet's spawnSubagent
+  // and the pendingFire queueMicrotask re-entry) so a post-advance assertion
+  // observes the settled spawnCalls, not an in-flight chain.
+  for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r))
+}
+
 describe('backup plugin', () => {
   test('exposes the three subagents (runner, message, diagnose)', async () => {
     const { ctx } = makeCtx({ config: tinyConfig })
@@ -98,7 +125,7 @@ describe('backup plugin', () => {
     const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
     const { idle } = await loadHooks(ctx)
     await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-    await sleep(80)
+    await advance(80)
     expect(spawnCalls.map((c) => c.name)).toEqual(['backup'])
     expect(spawnCalls[0]?.payload).toEqual({ agentDir: '/agent', pushToOrigin: false })
   })
@@ -109,7 +136,7 @@ describe('backup plugin', () => {
 
     await turnStart({ sessionId: 's1', agentDir: '/agent', userPrompt: 'hi' }, hookCtx())
     await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-    await sleep(80)
+    await advance(80)
     expect(spawnCalls).toEqual([])
   })
 
@@ -119,12 +146,12 @@ describe('backup plugin', () => {
 
     await turnStart({ sessionId: 's1', agentDir: '/agent', userPrompt: 'hi' }, hookCtx())
     await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-    await sleep(40)
+    await advance(40)
     expect(spawnCalls).toEqual([])
 
     await turnEnd({ sessionId: 's1', agentDir: '/agent' }, hookCtx())
     await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-    await sleep(80)
+    await advance(80)
     expect(spawnCalls.map((c) => c.name)).toEqual(['backup'])
   })
 
@@ -142,7 +169,7 @@ describe('backup plugin', () => {
       hookCtx(),
     )
     await idle({ sessionId: 's1', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-    await sleep(80)
+    await advance(80)
     expect(spawnCalls.map((c) => c.name)).toEqual(['backup'])
   })
 
@@ -150,11 +177,13 @@ describe('backup plugin', () => {
     const { ctx, spawnCalls } = makeCtx({ config: tinyConfig })
     const { idle } = await loadHooks(ctx)
 
+    // Each idle resets the 25ms debounce; the 5ms gaps stay inside the window so
+    // the timer never fires mid-loop, then one advance past the window fires once.
     for (let i = 0; i < 5; i++) {
       await idle({ sessionId: 's', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-      await sleep(5)
+      await advance(5)
     }
-    await sleep(80)
+    await advance(80)
     expect(spawnCalls.length).toBe(1)
   })
 
@@ -162,7 +191,7 @@ describe('backup plugin', () => {
     const { ctx, spawnCalls } = makeCtx({ config: { ...tinyConfig, enabled: false } })
     const { idle } = await loadHooks(ctx)
     await idle({ sessionId: 's', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-    await sleep(80)
+    await advance(80)
     expect(spawnCalls).toEqual([])
   })
 
@@ -173,7 +202,7 @@ describe('backup plugin', () => {
     await turnStart({ sessionId: 's1', agentDir: '/agent', userPrompt: 'hi' }, hookCtx())
     await sessionEnd({ sessionId: 's1' }, hookCtx())
     await idle({ sessionId: 's2', parentTranscriptPath: undefined, idleMs: 0 }, hookCtx())
-    await sleep(80)
+    await advance(80)
     expect(spawnCalls.length).toBe(1)
   })
 
@@ -184,8 +213,6 @@ describe('backup plugin', () => {
     expect(DIAGNOSE_FAILURE_SYSTEM_PROMPT).toMatch(/only the one push retry|only.*one.*retry/i)
   })
 })
-
-const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
 function hookCtx() {
   return {


### PR DESCRIPTION
## Background

`backup plugin > debounce: rapid idle events coalesce into a single fire` (`src/bundled-plugins/backup/index.test.ts`) was flaky on Windows CI. The test fires 5 `session.idle` events with a real `sleep(5)` between each, then `sleep(80)`, and asserts `spawnCalls.length === 1` — i.e. that the debounce coalesces the burst into exactly one backup fire.

The root cause is that the plugin's `session.idle` debounce schedules its fire via the global `setTimeout` (`src/bundled-plugins/backup/index.ts`), and the test drove it on the wall clock. Windows runners have ~15.6ms timer granularity plus scheduling jitter, so the 25ms debounce window occasionally elapsed *mid-burst* and fired more than once, tripping the `=== 1` assertion. Two sibling tests (`disabled plugin never spawns the runner`, `session.end clears any in-flight active turn`) shared the same wall-clock `sleep(80)` pattern and the same latent flakiness.

## Summary

Drive the debounce on **virtual time** instead of the wall clock, using `@sinonjs/fake-timers` — the exact seam the sibling `memory` plugin's `index.test.ts` already uses, so this stays consistent within the directory rather than introducing a new mechanism.

- `beforeEach`/`afterEach` install/uninstall a fake clock over `setTimeout`/`clearTimeout` only (the two timers the plugin touches). `Date` is intentionally left real — these tests never read `Date.now()`, so faking it would be dead surface.
- An `advance(ms)` helper replaces `sleep(ms)`: it `tickAsync(ms)` the fake clock, then drains the fire path's trailing microtasks (`fireIfQuiet` → `spawnSubagent`, plus the `pendingFire` `queueMicrotask` re-entry) with a short `setImmediate` spin so a post-advance assertion sees settled `spawnCalls`.

**Why fake timers in the test and not a clock-injection seam in the plugin:** the plugin already calls the *global* `setTimeout`/`clearTimeout`, which sinon replaces wholesale. No constructor-injected clock was needed, so the plugin source is byte-for-byte unchanged — the fix is confined to the test.

The coalesce assertion is preserved verbatim (`spawnCalls.length === 1`); the 25ms-window / 5ms-gap relationship that makes the burst coalesce is now deterministic rather than timing-dependent.

## What this does NOT do

- Does not touch `src/bundled-plugins/backup/index.ts` or any production code — test-only.
- Does not weaken any assertion. It does not add a clock/scheduler injection seam to the plugin, because faking the global timers made one unnecessary.
- Does not change the debounce behavior, `idleMs` semantics, or config.

## Review notes

- Load-bearing change: `advance()` (`tickAsync` + microtask drain) is what makes the async fire chain settle under virtual time. If a future test adds a fire path with a deeper await chain, it may need more drain cycles.
- Verified the tests still *guard* the behavior, not just pass: temporarily dropping the `cancelTimer()` call in the plugin's `session.idle` hook (so each idle schedules an independent timer) turns the coalesce test red, then reverting restores green. So the deterministic version still catches a real double-fire regression.
- Determinism confirmed across repeated runs; full `bun run test` (10473 pass, 0 fail) plus `typecheck`/`lint`/`format:check` all green.