### PR TITLE
feat(channels): drop an :eyes: reaction when a turn deliberately stays silent

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2400,6 +2400,172 @@ describe('disengageReactionEmojiFor', () => {
   })
 })
 
+describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
+  const REACTION_REF: ReactionRef = { adapter: 'discord-bot', value: 'msg-ref' }
+
+  // discord-bot is typing-capable, so route() adds no eager engage :eyes: — every
+  // captured reaction is the silent-ack, keeping these assertions unambiguous.
+  const setupSilentTurn = async (
+    dir: string,
+  ): Promise<{
+    router: ReturnType<typeof makeRouter>['router']
+    sessions: ReturnType<typeof makeRouter>['sessions']
+    captured: ReactionRequest[]
+  }> => {
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    const captured: ReactionRequest[] = []
+    router.registerReaction('discord-bot', async (req) => {
+      captured.push(req)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    await router.route(inbound({ reactionRef: REACTION_REF }))
+    return { router, sessions, captured }
+  }
+
+  test('skip_response leaves an :eyes: on the triggering message', async () => {
+    const dir = await tempDir()
+    const { router, sessions, captured } = await setupSilentTurn(dir)
+    sessions[0]!.onPrompt = () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'nothing to add' })
+      sessions[0]!.setAssistantText('Nothing actionable here.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => captured.length > 0)
+    expect(captured[0]).toMatchObject({ adapter: 'discord-bot', chat: 'c1', emoji: 'eyes', reactionRef: REACTION_REF })
+  })
+
+  test('an explicit NO_REPLY leaves an :eyes: on the triggering message', async () => {
+    const dir = await tempDir()
+    const { router, sessions, captured } = await setupSilentTurn(dir)
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => captured.length > 0)
+    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+  })
+
+  test('(NO_REPLY) with parens leaves an :eyes:', async () => {
+    const dir = await tempDir()
+    const { router, sessions, captured } = await setupSilentTurn(dir)
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('(NO_REPLY)')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => captured.length > 0)
+    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+  })
+
+  test('a plain-text skip_response(...) leak leaves an :eyes: (deliberate silence)', async () => {
+    const dir = await tempDir()
+    const { router, sessions, captured } = await setupSilentTurn(dir)
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('skip_response({ reason: "not addressed to me" })')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => captured.length > 0)
+    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+  })
+
+  test('does not react when the silent turn carries no triggering reactionRef', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    let called = false
+    router.registerReaction('discord-bot', async () => {
+      called = true
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound())
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(called).toBe(false)
+  })
+
+  test('a real reply leaves NO silent-ack :eyes:', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    const captured: ReactionRequest[] = []
+    router.registerReaction('discord-bot', async (req) => {
+      captured.push(req)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ reactionRef: REACTION_REF }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null, text: 'here you go' })
+      sessions[0]!.setAssistantText('here you go')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(captured.some((r) => r.emoji === 'eyes')).toBe(false)
+  })
+
+  test('a model malfunction (upstream empty sentinel) leaves NO silent-ack :eyes:', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    let called = false
+    router.registerReaction('discord-bot', async () => {
+      called = true
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ reactionRef: REACTION_REF }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText("(Empty response: finish_reason 'stop_reason' with no content)")
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(called).toBe(false)
+  })
+
+  test('on a typing-less adapter, the silent-ack :eyes: is added AFTER the transient engage :eyes: is removed', async () => {
+    // given a typing-less adapter (engage :eyes: IS added on route, then removed
+    // at turn end) whose engage add resolves to a removable instance ref. Both
+    // the engage add and the silent-ack add target the SAME triggering message /
+    // emoji, so the guard is the ORDER: the final event must be the silent-ack
+    // add, never a removal. Pre-fix (fire-and-forget drop) the order raced to
+    // add,add,remove — the trailing remove would strip the ack on toggle adapters.
+    const dir = await tempDir()
+    const engageInstanceRef: ReactionRef = { adapter: 'discord-bot', value: 'engage-instance' }
+    const events: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerReaction('discord-bot', async (req) => {
+      events.push(`add-${req.emoji}`)
+      return { ok: true, reactionRef: engageInstanceRef }
+    })
+    router.registerRemoveReaction('discord-bot', async () => {
+      events.push('remove-eyes')
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ reactionRef: REACTION_REF }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => events.length === 3)
+    expect(events).toEqual(['add-eyes', 'remove-eyes', 'add-eyes'])
+  })
+})
+
 describe('ChannelRouter model react only when replying', () => {
   const TARGET_REF: ReactionRef = { adapter: 'discord-bot', value: 'msg-ref' }
 
@@ -2437,13 +2603,14 @@ describe('ChannelRouter model react only when replying', () => {
 
   test('drops a queued channel_react reaction when the turn stays silent', async () => {
     // given a typing-capable adapter (no eager engage :eyes:) whose model queues
-    // a reaction but sends no reply
+    // a reaction but sends no reply. The queued reaction uses a DISTINCT emoji so
+    // it is separable from the silent-ack :eyes: a NO_REPLY turn now leaves.
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
     router.setTypingCapability('discord-bot', true)
-    let added = 0
-    router.registerReaction('discord-bot', async () => {
-      added++
+    const emojis: string[] = []
+    router.registerReaction('discord-bot', async (req) => {
+      emojis.push(req.emoji)
       return { ok: true }
     })
 
@@ -2455,14 +2622,15 @@ describe('ChannelRouter model react only when replying', () => {
         chat: 'c1',
         thread: null,
         reactionRef: TARGET_REF,
-        emoji: 'eyes',
+        emoji: 'thumbsup',
       })
       sessions[0]!.setAssistantText('NO_REPLY')
     }
     await router.__testing!.flushDebounce(KEY)
 
-    // then nothing is ever sent to the adapter — no reaction on a message it only looked at
-    expect(added).toBe(0)
+    // then the held channel_react reaction is never flushed — no reaction on a
+    // message it merely looked at
+    expect(emojis).not.toContain('thumbsup')
   })
 
   test('refuses to queue a reaction when there is no live session for the target', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -179,6 +179,8 @@ export function disengageReactionEmojiFor(adapter: AdapterId): string {
   return DISENGAGE_REACTION_EMOJI_OVERRIDES[adapter] ?? DISENGAGE_REACTION_EMOJI
 }
 
+type SilentAckReason = 'skip_response' | 'no_reply' | 'skip_response_text_leak'
+
 // Wake nudge pushed into a resumed channel session at boot so drain() has a
 // non-empty batch and fires a turn. The substantive instruction the model acts
 // on is the `typeclaw.restart-self` entry already in the reopened JSONL (pi
@@ -782,6 +784,17 @@ type LiveSession = {
   // discarded on silence (skip_response / empty / errored turns) so the bot never
   // leaves a reaction on a message it merely looked at (e.g. cron lookaround).
   pendingTurnReactions: ReactionRequest[]
+  // Armed by `validateChannelTurn` on a DELIBERATE silent turn (skip_response or
+  // an explicit NO_REPLY), stamped with `turnSeq` so a stale flag from a crashed
+  // turn cannot leak into the next one. Read in drain's per-turn finally — AFTER
+  // the transient engage :eyes: is dropped — to leave a PERSISTENT :eyes: on the
+  // triggering message: "I saw this and intentionally chose not to reply." Null
+  // on every non-deliberate outcome (a real reply, a model malfunction, a
+  // plumbing leak, a retry, a synthetic turn). Firing after the engage-drop is
+  // load-bearing: adapters that collapse a same-actor same-emoji reaction into
+  // one toggle would otherwise have the engage-drop remove the only visible
+  // :eyes:. See `reactOnSilentAck`.
+  silentAckTurn: { turnSeq: number; reason: SilentAckReason } | null
   lastTurnAuthorIds: Set<string>
   // Mirror of currentTurnAuthorId at end-of-turn (the LAST speaker of the
   // prior batch), preserved across the drain finally-block which resets
@@ -1977,6 +1990,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         currentTurnTypingThread: null,
         currentTurnEngageReactions: [],
         pendingTurnReactions: [],
+        silentAckTurn: null,
         // `lastTurnAuthorId` (string, used for `lastInboundAuthorId` in
         // origin) and `lastTurnAuthorIds` (Set, used by
         // `grantStickyForReplyTargets` as the fallback when
@@ -2830,7 +2844,19 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // also silence, skip_response, an empty turn, or a provider error
           // (observe-after-engage). Leaving it only on the reply path stranded the
           // ack permanently on messages the agent looked at but never answered.
-          dropEngageReactions(live, engageAddPromises)
+          const dropDone = dropEngageReactions(live, engageAddPromises)
+          // A DELIBERATE silent turn (skip_response / NO_REPLY) leaves a
+          // PERSISTENT :eyes: acking "seen, intentionally not replying". On a
+          // typing-less adapter it reuses the same message/emoji/actor as the
+          // transient engage :eyes:, and adapters that collapse that into one
+          // toggle would let a still-in-flight engage removal strip the ack — so
+          // the silent path AWAITS every engage removal reaching the adapter
+          // before adding the persistent one. Only silent turns pay that wait:
+          // normal/reply turns keep the engage drop fire-and-forget (`void`), so
+          // turn-end never blocks on the reaction API off the silent path.
+          if (live.silentAckTurn?.turnSeq === live.turnSeq) await dropDone
+          else void dropDone
+          reactOnSilentAck(live)
           // Held channel_react reactions apply only when the agent posted a
           // genuine reply this turn — NOT an empty-turn fallback or provider-
           // error notice, both of which send via source:'system' and bump
@@ -3438,8 +3464,12 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return addReactionRef
   }
 
-  const dropEngageReactions = (live: LiveSession, addPromises: Array<Promise<ReactionRef | null>>): void => {
-    for (const addPromise of addPromises) dropOneEngageReaction(live, addPromise)
+  // Returns a promise that settles only once every engage removal has REACHED
+  // the adapter, not merely been scheduled. The silent-ack path awaits this so
+  // its persistent :eyes: is added strictly AFTER the transient one is removed
+  // (see reactOnSilentAck). Fire-and-forget callers just `void` the result.
+  const dropEngageReactions = (live: LiveSession, addPromises: Array<Promise<ReactionRef | null>>): Promise<void> => {
+    return Promise.all(addPromises.map((addPromise) => dropOneEngageReaction(live, addPromise))).then(() => undefined)
   }
 
   // Only the LAST engaging inbound of a coalesced batch should carry the eager
@@ -3451,11 +3481,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const addPromises = live.promptQueue.flatMap((m) => (m.engageReaction !== undefined ? [m.engageReaction] : []))
     if (addPromises.length === 0) return
     for (const item of live.promptQueue) delete item.engageReaction
-    dropEngageReactions(live, addPromises)
+    void dropEngageReactions(live, addPromises)
   }
 
-  const dropOneEngageReaction = (live: LiveSession, addPromise: Promise<ReactionRef | null>): void => {
-    void addPromise
+  const dropOneEngageReaction = (live: LiveSession, addPromise: Promise<ReactionRef | null>): Promise<void> => {
+    return addPromise
       .then((reactionRef) => {
         if (reactionRef === null) return undefined
         return removeReaction({
@@ -4052,6 +4082,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const { reason } = live.skippedTurn
       live.skippedTurn = null
       logger.info(`[channels] ${live.keyId} skipped_by_tool reason=${JSON.stringify(reason)}`)
+      armSilentTurnAck(live, 'skip_response')
       return
     }
     if (live.skippedTurn !== null && live.skippedTurn.turnSeq === live.turnSeq) {
@@ -4371,6 +4402,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
       const leakedReasoning = !isNoReplySignal(assistantText)
       logger.info(`[channels] ${live.keyId} no_reply${leakedReasoning ? ' (with_leaked_reasoning)' : ''}`)
+      armSilentTurnAck(live, 'no_reply')
       return
     }
 
@@ -4400,6 +4432,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger.warn(
         `[channels] ${live.keyId}: suppressed plain_text_tool_call_leak (silent) text_len=${assistantText.length}`,
       )
+      armSilentTurnAck(live, 'skip_response_text_leak')
       return
     }
     if (plainTextToolCallKind === 'suppress-warn') {
@@ -5053,6 +5086,38 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       .catch((err) => {
         logger.info(
           `[channels] disengage-react threw adapter=${live.key.adapter} chat=${live.key.chat}: ${describe(err)}`,
+        )
+      })
+  }
+
+  const armSilentTurnAck = (live: LiveSession, reason: SilentAckReason): void => {
+    live.silentAckTurn = { turnSeq: live.turnSeq, reason }
+  }
+
+  const reactOnSilentAck = (live: LiveSession): void => {
+    if (live.silentAckTurn?.turnSeq !== live.turnSeq) return
+    const { reason } = live.silentAckTurn
+    live.silentAckTurn = null
+    const reactionRef = live.currentTurnReactionRef
+    if (reactionRef === null) return
+    void react({
+      adapter: live.key.adapter,
+      workspace: live.key.workspace,
+      chat: live.key.chat,
+      thread: live.key.thread,
+      reactionRef,
+      emoji: ENGAGE_REACTION_EMOJI,
+    })
+      .then((result) => {
+        if (!result.ok && result.code !== 'unsupported') {
+          logger.info(
+            `[channels] silent-ack-react failed reason=${reason} adapter=${live.key.adapter} chat=${live.key.chat}: ${result.error}`,
+          )
+        }
+      })
+      .catch((err) => {
+        logger.info(
+          `[channels] silent-ack-react threw reason=${reason} adapter=${live.key.adapter} chat=${live.key.chat}: ${describe(err)}`,
         )
       })
   }


### PR DESCRIPTION
## Background

When the agent decides not to reply — via the `skip_response` tool or an explicit `NO_REPLY` — it left **nothing** on the triggering message. From a human's side, "the agent saw this and intentionally chose not to reply" is indistinguishable from "the agent never saw it / silently dropped it." In a busy group chat that ambiguity erodes trust: people re-ping, or assume the bot is broken.

This adds a persistent `:eyes:` reaction on the triggering message whenever a turn deliberately stays silent — a lightweight "seen, intentionally not replying" ack, mirroring how humans react rather than reply.

## Summary

The reaction is armed **only on deliberate silence**:

- the `skip_response` tool path,
- the explicit `NO_REPLY` text sentinel path,
- a plain-text `skip_response(...)` leak (`suppress-silent`), which is semantically a serialized skip.

Model malfunctions and plumbing leaks — the upstream-empty-response sentinel, the Kimi tool-call leak, and `suppress-warn` tool-call leaks — deliberately **do not** arm it. The `:eyes:` should always signal *intent*, never a glitch.

**Why fire it from drain's per-turn `finally` and not inline in `validateChannelTurn`?** The eager engage-`:eyes:` (added on typing-less adapters when the agent decides to engage) is removed at turn end via `dropEngageReactions`. Some adapters collapse a same-actor same-emoji reaction into a single toggle, so if the persistent ack were added *before* the engage-drop, that drop would strip the only visible `:eyes:`. `validateChannelTurn` therefore only **arms** a turn-seq-stamped marker (`silentAckTurn`); the actual `react()` fires in the `finally` **after** `dropEngageReactions`. The ordering is load-bearing and commented as such.

The marker is stamped with `turnSeq` (same pattern as `skippedTurn` / `emptyTurnFallbackTurn`) so a stale flag from a turn that crashed before validation can't leak into the next turn. `react()` is fire-and-forget and never throws, matching the existing `reactOnDisengage` helper.

Reuses the existing `ENGAGE_REACTION_EMOJI = 'eyes'` constant. Not config-gated — consistent with the always-on engage/disengage reactions; can be revisited if real users report reaction noise.

## What this does NOT do

- Does not react on model malfunctions or plumbing leaks (upstream-empty sentinel, Kimi leak, `suppress-warn`) — those aren't deliberate silence.
- Does not react on turns that actually reply, retry, error, or on the contested-skip recovery path.
- Does not react on synthetic/reminder turns with no reactable trigger (`currentTurnReactionRef === null`).
- Does not add a config field or change any existing reaction behavior (engage/disengage/`channel_react` are untouched).

## Review notes

- Load-bearing ordering: `reactOnSilentAck(live)` MUST stay **after** `dropEngageReactions(...)` in drain's per-turn `finally` (`src/channels/router.ts`). Reordering silently breaks the ack on toggle-collapsing adapters.
- Arming sites: three deliberate-silence `return` points in `validateChannelTurn` (`skip_response`, terminal `no_reply`, `suppress-silent`).
- Tests use `discord-bot` (typing-capable → no eager engage-`:eyes:`) so each captured reaction is unambiguously the silent-ack. Coverage: all three arming paths fire, no-trigger-ref no-ops, a real reply does NOT ack, and a model-malfunction path does NOT ack.