### PR TITLE
fix(channels): guard loud markdown-emphasized NO_REPLY variants

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -573,6 +573,23 @@ describe('createChannelReplyTool', () => {
       expect(result.details).toMatchObject({ ok: false })
       expect((result.details as { error: string }).error).toContain('silent-turn signal')
     })
+
+    for (const loud of ['**NO_REPLY**', '`NO_REPLY`', '*NO_REPLY*']) {
+      test(`blocks the loud ${loud} form (mirrors router lenience)`, async () => {
+        const calls: OutboundMessage[] = []
+        const tool = createChannelReplyTool({
+          router: fakeRouter(async (msg) => {
+            calls.push(msg)
+            return { ok: true }
+          }),
+          origin: slackThreadOrigin,
+        })
+        const result = await runTool(tool, { text: loud })
+        expect(calls).toHaveLength(0)
+        expect(result.details).toMatchObject({ ok: false })
+        expect((result.details as { error: string }).error).toContain('silent-turn signal')
+      })
+    }
   })
 
   describe('upstream empty-response sentinel guard', () => {

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -526,6 +526,22 @@ describe('createChannelSendTool', () => {
       expect(result.details).toMatchObject({ ok: false })
       expect((result.details as { error: string }).error).toContain('silent-turn signal')
     })
+
+    for (const loud of ['**NO_REPLY**', '`NO_REPLY`', '*NO_REPLY*']) {
+      test(`blocks the loud ${loud} form (mirrors router lenience)`, async () => {
+        const calls: OutboundMessage[] = []
+        const tool = createChannelSendTool({
+          router: fakeRouter(async (msg) => {
+            calls.push(msg)
+            return { ok: true }
+          }),
+        })
+        const result = await runTool(tool, { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', text: loud })
+        expect(calls).toHaveLength(0)
+        expect(result.details).toMatchObject({ ok: false })
+        expect((result.details as { error: string }).error).toContain('silent-turn signal')
+      })
+    }
   })
 
   describe('upstream empty-response sentinel guard', () => {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3388,6 +3388,112 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(sent[0]!.text).toContain('NO_REPLY_MODE')
   })
 
+  test('still recovers prose ending in an identifier like FOO_NO_REPLY (underscore is not a token boundary)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'which flag?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('The flag is FOO_NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('FOO_NO_REPLY')
+  })
+
+  // Drift mode: models shout the silent-turn token in markdown emphasis
+  // (**NO_REPLY**, `NO_REPLY`, *NO_REPLY*) instead of the bare documented form.
+  for (const loud of ['**NO_REPLY**', '`NO_REPLY`', '*NO_REPLY*', '***NO_REPLY***', '__NO_REPLY__']) {
+    test(`allows loud ${loud} as a silent-turn signal`, async () => {
+      const dir = await tempDir()
+      const logs: string[] = []
+      const sent: Array<{ text: string }> = []
+      const { router, sessions } = makeRouter(dir, { logs })
+      router.registerOutbound('discord-bot', async (msg) => {
+        sent.push({ text: msg.text ?? '' })
+        return { ok: true }
+      })
+
+      await router.route(inbound({ text: 'just FYI' }))
+      sessions[0]!.onPrompt = () => {
+        sessions[0]!.setAssistantText(loud)
+      }
+      await router.__testing!.flushDebounce(KEY)
+
+      expect(sent).toHaveLength(0)
+      expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
+      expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
+    })
+  }
+
+  test('suppresses recovery when assistant ends with loud **NO_REPLY** after prose', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Nothing to add here. **NO_REPLY**')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('no_reply (with_leaked_reasoning)'))).toBe(true)
+  })
+
+  test('suppresses recovery when assistant ends with loud `NO_REPLY` (inline code) after prose', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'just FYI' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('Nothing actionable here. `NO_REPLY`')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('no_reply (with_leaked_reasoning)'))).toBe(true)
+  })
+
+  test('still recovers prose where an emphasized **NO_REPLY** appears mid-sentence (not at end)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'what does NO_REPLY do?' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('The **NO_REPLY** token is how the agent stays quiet — end your turn with it.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toContain('stays quiet')
+    expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(true)
+  })
+
   test('skip_response: markTurnSkipped + skip-only turn produces no channel send, logs reason, no recovery', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -6162,15 +6162,27 @@ function attemptMadeToolCall(session: AgentSession): boolean {
   return false
 }
 
+// Peels a single symmetric markdown-emphasis wrapper off a token: bold/italic
+// asterisks (`*`, `**`, `***`), underscores (`_`, `__`), or inline-code
+// backticks. Only strips when the SAME run brackets both ends, so `**NO_REPLY**`
+// → `NO_REPLY` while an asymmetric `*NO_REPLY` or a non-wrapping `NO_REPLY_MODE`
+// is returned unchanged. Not recursive — one layer is enough for the observed
+// `**...**` / `` `...` `` "loud" drift; anything more nested is not a real form.
+function stripEmphasisWrapper(token: string): string {
+  const match = /^([*_`]{1,3})([^*_`].*?[^*_`]|[^*_`])\1$/.exec(token)
+  return match ? match[2]! : token
+}
+
 // Lenient on purpose: distilled / smaller models routinely drift off the
 // documented `NO_REPLY` form. We additionally accept `(NO_REPLY)` (Claude-style
-// hedging) and empty visible text (e.g. Kimi-distilled models that emit only a
-// thinking block and end the turn) — without the empty case we'd recover an
-// empty string into the chat. The prompt contract still teaches the strict
+// hedging), markdown-emphasized "loud" forms (`**NO_REPLY**`, `` `NO_REPLY` ``,
+// `*NO_REPLY*`), and empty visible text (e.g. Kimi-distilled models that emit
+// only a thinking block and end the turn) — without the empty case we'd recover
+// an empty string into the chat. The prompt contract still teaches the strict
 // literal; this just widens what we accept. Shared with channel_send /
 // channel_reply so all three call sites stay in lockstep.
 export function isNoReplySignal(text: string): boolean {
-  const trimmed = text.trim()
+  const trimmed = stripEmphasisWrapper(text.trim())
   if (trimmed === '') return true
   if (trimmed === 'NO_REPLY') return true
   if (trimmed === '(NO_REPLY)') return true
@@ -6199,21 +6211,31 @@ export function isNoReplySignal(text: string): boolean {
 //   "... end with NO_REPLY."          (+ sentence punctuation)
 //   "... end with NO_REPLY.NO_REPLY"  (model-doubled terminator, glued)
 //   "... and stop. (NO_REPLY)"        (parenthesized at end)
+//   "... nothing to add. **NO_REPLY**"(markdown-emphasized "loud" form)
+//   "... nothing here. `NO_REPLY`"    (inline-code "loud" form)
 // Does not match (returns false):
 //   "NO_REPLY means do nothing"       (token at start, prose after)
 //   "the env var is NO_REPLY_MODE"    (substring, not whole token)
+//   "the flag is FOO_NO_REPLY"        (identifier — `_` is not a token boundary)
+//   "the **NO_REPLY** token is how..."(emphasized but mid-sentence, prose after)
 //   "no reply needed"                 (case-sensitive on purpose)
 export function endsWithNoReplySignal(text: string): boolean {
   if (isNoReplySignal(text)) return true
   const trimmed = text.trim()
   if (trimmed === '') return false
-  // Strip trailing sentence punctuation / closing brackets / whitespace, then
-  // check the last whitespace-or-punctuation-separated token. The leading
-  // boundary in the regex (`[\s.!?([]`) treats `.NO_REPLY` as a separate
-  // token from the preceding sentence, which covers the model-doubled
-  // `...NO_REPLY.NO_REPLY` shape.
+  // Isolate the final token, then defer to isNoReplySignal (which strips a
+  // symmetric emphasis wrapper). Boundaries are whitespace / sentence
+  // punctuation / opening bracket only — `.NO_REPLY` splits off the preceding
+  // sentence (covering the model-doubled `...NO_REPLY.NO_REPLY` shape), while
+  // `_` is deliberately NOT a boundary so an identifier like `FOO_NO_REPLY`
+  // stays one token and reads as prose, not a signal.
   const tail = trimmed.replace(/[.!?)\]\s]+$/, '')
-  return /(?:^|[\s.!?([])\(?NO_REPLY\)?$/.test(tail)
+  const lastToken = tail.split(/[\s.!?([]/).pop() ?? ''
+  // An empty final token means the text ended on an opening bracket (e.g. a
+  // leaked `skip_response()` call), not a signal — don't hand it to
+  // isNoReplySignal, whose empty-string case reads as deliberate silence.
+  if (lastToken === '') return false
+  return isNoReplySignal(lastToken)
 }
 
 // Detects the upstream "empty response" debug sentinel: when the LLM ends a


### PR DESCRIPTION
## Background

The channel runtime has a `NO_REPLY` protocol: to stay silent for a turn, the agent ends its turn with the bare token `NO_REPLY` (or `(NO_REPLY)`, or an empty visible response). Two guards enforce this:

- `isNoReplySignal` — the strict misuse guard, shared by the router recovery path **and** the `channel_send` / `channel_reply` tool boundaries. It blocks a model from posting the silent-turn token as a message body.
- `endsWithNoReplySignal` — the looser recovery matcher, used only by `validateChannelTurn`, that catches leaked-reasoning turns which end in the token (so the whole reasoning paragraph isn't posted to the channel).

Both matched the token as a strict literal. In practice, models routinely **shout** the token in markdown emphasis instead of emitting the bare form — `**NO_REPLY**`, `` `NO_REPLY` ``, `*NO_REPLY*`, `***NO_REPLY***`, `__NO_REPLY__`. A newly observed instance of this drift (Discord report) ended a turn with an emphasized token; because neither guard saw through the wrapper, the emphasized token — and in the trailing-prose case, the entire leaked-reasoning paragraph — leaked into the channel, exactly the outcome the guards exist to prevent.

## Summary

Peel a single **symmetric** markdown-emphasis wrapper off the token before the literal comparison, and extend the recovery matcher's trailing-token boundary to treat `*`, `` ` ``, and `_` as separators.

- `stripEmphasisWrapper` strips one layer of `*`/`**`/`***`, `_`/`__`, or `` ` `` **only when the same run brackets both ends**. This is what keeps `NO_REPLY_MODE` and `set NO_REPLY=true` from being misread — they have no symmetric wrapper around the *whole* token.
- Widening `isNoReplySignal` (not just the recovery matcher) is deliberate: an emphasized token as an entire message body is still misuse, so all three call sites — router recovery, `channel_send`, `channel_reply` — stay in lockstep, which is the existing contract for this helper.
- **Why symmetric-only and non-recursive**: one layer covers every observed "loud" form; matching asymmetric or deeply-nested markdown would start swallowing legitimate prose. The stripping is targeted, not a blanket trailing-character strip.

## What this does NOT do

- Does not change the prompt contract — the model is still taught the bare `NO_REPLY` literal; this only widens what the guards *accept*.
- Does not make matching case-insensitive — `no_reply` / `No_Reply` still pass through as normal prose (unchanged).
- Does not suppress emphasized mentions that appear **mid-sentence** — `The **NO_REPLY** token is how the agent stays quiet.` still recovers and posts, because the token isn't the trailing token. Substrings like `NO_REPLY_MODE` still recover too.
- Does not touch the upstream-empty-response or Kimi-tool-leak guards.

## Review notes

- Load-bearing invariant: the negative cases must keep recovering. Verify `endsWithNoReplySignal` still returns `false` for `NO_REPLY_MODE`, `set \`NO_REPLY=true\``, mid-sentence `**NO_REPLY**`, and `no reply needed` — covered by existing + new router tests.
- The regex in `stripEmphasisWrapper` (`/^([*_\`]{1,3})([^*_\`].*?[^*_\`]|[^*_\`])\1$/`) uses a backreference to require the same delimiter run on both ends; the inner alternation handles the single-char body case so `*a*` still strips.
- Tests added at all three layers: router silent-turn + trailing-prose suppression (`router.test.ts`), and tool-boundary blocking (`channel-send.test.ts`, `channel-reply.test.ts`). Full suite green (10516 pass).
