### PR TITLE
feat(channels): add Microsoft Teams channel adapter (chat-only)

### DIFF
--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -162,6 +162,7 @@ const PLATFORM_INFO: Record<AdapterId, PlatformInfo> = {
   },
   webex: { displayName: 'Webex', mentionMode: 'angle-id', supportsReactions: false, supportsAttachments: true },
   'webex-bot': { displayName: 'Webex', mentionMode: 'angle-id', supportsReactions: false, supportsAttachments: false },
+  teams: { displayName: 'Teams', mentionMode: 'alias', supportsReactions: false, supportsAttachments: false },
   line: { displayName: 'LINE', mentionMode: 'alias', supportsReactions: false, supportsAttachments: false },
   kakaotalk: { displayName: 'KakaoTalk', mentionMode: 'alias', supportsReactions: false, supportsAttachments: true },
 }

--- a/src/channels/adapters/teams-classify.test.ts
+++ b/src/channels/adapters/teams-classify.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { TeamsRealtimeMessage, TeamsUser } from 'agent-messenger/teams'
+
+import { channelsSchema } from '@/channels/schema'
+
+import type { TeamsChatInfo } from './teams'
+import { classifyInbound, normalizeTeamsText } from './teams-classify'
+
+const config = channelsSchema.parse({ teams: {} }).teams!
+
+const SELF: TeamsUser = { id: 'ME', displayName: 'Typeey', userPrincipalName: 'typeey@example.com' }
+
+function event(overrides: Partial<TeamsRealtimeMessage> = {}): TeamsRealtimeMessage {
+  return {
+    id: 'msg-1',
+    chatId: 'chat-1',
+    // Realtime content arrives already HTML-stripped from the SDK, so tests use
+    // plain text (no `<at>` tags) to mirror what the adapter actually receives.
+    content: 'hello typeclaw',
+    author: { id: 'user-1', displayName: 'Alice' },
+    messageType: 'RichText/Html',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function chat(overrides: Partial<TeamsChatInfo> = {}): TeamsChatInfo {
+  return { id: 'chat-1', type: 'group', ...overrides } as TeamsChatInfo
+}
+
+describe('classifyInbound', () => {
+  test('drops before self identity resolves', () => {
+    expect(classifyInbound(event(), config, null, chat())).toEqual({ kind: 'drop', reason: 'pre_connect' })
+  })
+
+  test('drops when the chat could not be resolved', () => {
+    expect(classifyInbound(event(), config, SELF, undefined)).toEqual({ kind: 'drop', reason: 'unknown_chat' })
+  })
+
+  test('drops an empty message', () => {
+    expect(classifyInbound(event({ content: '   ' }), config, SELF, chat())).toEqual({
+      kind: 'drop',
+      reason: 'empty_content',
+    })
+  })
+
+  test('routes a group message keyed as chat:<chatId> with workspace teams', () => {
+    const verdict = classifyInbound(event(), config, SELF, chat())
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.adapter).toBe('teams')
+    expect(verdict.payload.workspace).toBe('teams')
+    expect(verdict.payload.chat).toBe('chat:chat-1')
+    expect(verdict.payload.thread).toBeNull()
+    expect(verdict.payload.isDm).toBe(false)
+    expect(verdict.payload.authorId).toBe('user-1')
+    expect(verdict.payload.authorName).toBe('Alice')
+    expect(verdict.payload.text).toBe('hello typeclaw')
+  })
+
+  test('marks oneOnOne chats as DMs and never sets mentionsOthers', () => {
+    const verdict = classifyInbound(event(), config, SELF, chat({ type: 'oneOnOne' }))
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isDm).toBe(true)
+    expect(verdict.payload.mentionsOthers).toBe(false)
+  })
+
+  test('marks self chats as DMs', () => {
+    const verdict = classifyInbound(event(), config, SELF, chat({ type: 'self' }))
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isDm).toBe(true)
+  })
+
+  test('engages a group message on a plain-text alias match', () => {
+    const verdict = classifyInbound(event({ content: 'typeclaw are you there' }), config, SELF, chat(), ['typeclaw'])
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+    expect(verdict.payload.mentionsOthers).toBe(false)
+  })
+
+  test('fails a group message closed when no alias matches (solo + sticky suppressed)', () => {
+    const verdict = classifyInbound(event({ content: 'just chatting' }), config, SELF, chat(), ['typeclaw'])
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(false)
+    expect(verdict.payload.mentionsOthers).toBe(true)
+    expect(verdict.payload.suppressSticky).toBe(true)
+  })
+
+  test('an aliased group message does not suppress sticky', () => {
+    const verdict = classifyInbound(event({ content: 'typeclaw please help' }), config, SELF, chat(), ['typeclaw'])
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+    expect(verdict.payload.suppressSticky).toBe(false)
+  })
+
+  test('a DM never suppresses sticky', () => {
+    const verdict = classifyInbound(event({ content: 'no alias' }), config, SELF, chat({ type: 'oneOnOne' }))
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.suppressSticky).toBe(false)
+  })
+
+  test('routes a non-Latin (Korean) group message with a Korean alias match', () => {
+    // given a Korean-script inbound that names the bot by its Korean alias
+    const verdict = classifyInbound(event({ content: '타이피 확인 부탁해요' }), config, SELF, chat(), ['타이피'])
+    // then the alias still matches (script-agnostic) and the text is preserved
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMention).toBe(true)
+    expect(verdict.payload.mentionsOthers).toBe(false)
+    expect(verdict.payload.text).toBe('타이피 확인 부탁해요')
+  })
+
+  test('carries a zero ts when the timestamp is unparseable', () => {
+    const verdict = classifyInbound(event({ timestamp: 'not-a-date' }), config, SELF, chat())
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.ts).toBe(0)
+  })
+})
+
+describe('normalizeTeamsText', () => {
+  test('collapses whitespace and trims', () => {
+    expect(normalizeTeamsText('  hello   world \n')).toBe('hello world')
+  })
+})

--- a/src/channels/adapters/teams-classify.ts
+++ b/src/channels/adapters/teams-classify.ts
@@ -1,0 +1,79 @@
+import type { TeamsRealtimeMessage, TeamsUser } from 'agent-messenger/teams'
+
+import { matchesAnyAlias } from '@/channels/engagement'
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type { InboundMessage } from '@/channels/types'
+
+import type { TeamsChatInfo } from './teams'
+
+export type TeamsInboundEvent = TeamsRealtimeMessage
+
+export type InboundDropReason = 'self_author' | 'empty_content' | 'pre_connect' | 'unknown_chat'
+
+export type InboundClassification =
+  | { kind: 'drop'; reason: InboundDropReason }
+  | { kind: 'route'; payload: InboundMessage }
+
+// The realtime event only carries a chatId, so channel-message routing (which
+// needs a teamId + channelId) is out of scope; every routed inbound is a chat
+// message keyed as `chat:<chatId>`. `chat` is the caller's already-validated
+// TeamsChatInfo for that id (undefined ⇒ the adapter could not resolve it even
+// after a refresh, so drop as unknown_chat rather than guess isDm).
+//
+// The agent-messenger listener strips all HTML (including `<at id>` mention
+// tags) before emitting, so structured mention detection is impossible from a
+// realtime event. Engagement is therefore intentionally conservative: DMs
+// engage via the `dm` trigger; group chats engage ONLY when a configured alias
+// appears in the plain text. A group message with no alias hit is marked
+// `mentionsOthers` so the router's solo-human fallback does not make the agent
+// answer chatter it was never addressed in.
+export function classifyInbound(
+  event: TeamsInboundEvent,
+  _config: ChannelAdapterConfig,
+  self: TeamsUser | null,
+  chat: TeamsChatInfo | undefined,
+  selfAliases: readonly string[] = [],
+): InboundClassification {
+  if (self === null) return { kind: 'drop', reason: 'pre_connect' }
+  if (chat === undefined) return { kind: 'drop', reason: 'unknown_chat' }
+
+  const text = event.content.trim()
+  if (text === '') return { kind: 'drop', reason: 'empty_content' }
+
+  const isDm = chat.type === 'oneOnOne' || chat.type === 'self'
+  const isBotMention = matchesAnyAlias(text, selfAliases)
+  const ts = Date.parse(event.timestamp)
+
+  return {
+    kind: 'route',
+    payload: {
+      adapter: 'teams',
+      workspace: 'teams',
+      chat: `chat:${event.chatId}`,
+      thread: null,
+      text,
+      externalMessageId: event.id,
+      authorId: event.author.id,
+      authorName: event.author.displayName,
+      authorIsBot: false,
+      isBotMention,
+      // `sendChatMessage` has no reply/thread anchor and the realtime event
+      // exposes no parent id, so a reply can never be attributed.
+      replyToBotMessageId: null,
+      // Group messages carry no recoverable mention metadata. `mentionsOthers`
+      // suppresses the solo-human fallback, and `suppressSticky` stops a prior
+      // alias-triggered turn from keeping the agent engaged on later unaddressed
+      // messages — together they make an un-aliased group message fail closed.
+      // Neither fires in a DM, where the `dm` trigger always engages.
+      suppressSticky: !isDm && !isBotMention,
+      mentionsOthers: !isDm && !isBotMention,
+      replyToOtherMessageId: null,
+      isDm,
+      ts: Number.isFinite(ts) ? ts : 0,
+    },
+  }
+}
+
+export function normalizeTeamsText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}

--- a/src/channels/adapters/teams.test.ts
+++ b/src/channels/adapters/teams.test.ts
@@ -1,0 +1,556 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { TeamsListener, TeamsMessage, TeamsRealtimeMessage, TeamsUser } from 'agent-messenger/teams'
+
+import type { ChannelRouter } from '@/channels/router'
+import { channelsSchema } from '@/channels/schema'
+import type { InboundMessage, OutboundCallback, OutboundMessage } from '@/channels/types'
+import type { TeamsAccountRecord } from '@/secrets/schema'
+
+import {
+  createOutboundCallback,
+  createTeamsAdapter,
+  createTeamsHistoryCallback,
+  type TeamsAdapterLogger,
+  type TeamsChatInfo,
+} from './teams'
+
+const config = channelsSchema.parse({ teams: {} }).teams!
+
+const SELF: TeamsUser = { id: 'ME', displayName: 'Typeey', userPrincipalName: 'typeey@example.com' }
+
+function logger(): TeamsAdapterLogger & { lines: string[] } {
+  const lines: string[] = []
+  return {
+    lines,
+    info: (msg) => lines.push(`info:${msg}`),
+    warn: (msg) => lines.push(`warn:${msg}`),
+    error: (msg) => lines.push(`error:${msg}`),
+  }
+}
+
+function account(overrides: Partial<TeamsAccountRecord> = {}): TeamsAccountRecord {
+  return {
+    account_id: 'account-1',
+    access_token: 'access-1',
+    account_type: 'work',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function realtime(overrides: Partial<TeamsRealtimeMessage> = {}): TeamsRealtimeMessage {
+  return {
+    id: 'msg-1',
+    chatId: 'chat-1',
+    content: 'hello typeclaw',
+    author: { id: 'user-1', displayName: 'Alice' },
+    messageType: 'RichText/Html',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function teamsMessage(overrides: Partial<TeamsMessage> = {}): TeamsMessage {
+  return {
+    id: 'm',
+    channel_id: 'chat-1',
+    author: { id: 'user-1', displayName: 'Alice' },
+    content: 'hi',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function outbound(overrides: Partial<OutboundMessage> = {}): OutboundMessage {
+  return { adapter: 'teams', workspace: 'teams', chat: 'chat:chat-1', text: 'hello', ...overrides }
+}
+
+const groupChat: TeamsChatInfo = { id: 'chat-1', type: 'group' } as TeamsChatInfo
+
+class FakeListener {
+  private handlers = new Map<string, Array<(value: unknown) => void>>()
+  stopped = false
+  startImpl: () => Promise<void> = async () => {
+    // Real TeamsListener emits `connected` asynchronously after start()
+    // resolves; mirror that so the adapter's await-connected path is exercised.
+    queueMicrotask(() => this.emit('connected', { endpointId: 'ep-1' }))
+  }
+
+  on(event: string, handler: (value: unknown) => void): void {
+    this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler])
+  }
+
+  off(event: string, handler: (value: unknown) => void): void {
+    this.handlers.set(
+      event,
+      (this.handlers.get(event) ?? []).filter((h) => h !== handler),
+    )
+  }
+
+  async start(): Promise<void> {
+    await this.startImpl()
+  }
+
+  stop(): void {
+    this.stopped = true
+  }
+
+  emit(event: string, value: unknown): void {
+    for (const handler of this.handlers.get(event) ?? []) handler(value)
+  }
+}
+
+type TestRouter = ChannelRouter & {
+  routed: InboundMessage[]
+  registered: string[]
+  unregistered: string[]
+  outboundCb: OutboundCallback | null
+}
+
+function router(): TestRouter {
+  const routed: InboundMessage[] = []
+  const registered: string[] = []
+  const unregistered: string[] = []
+  const state = { outboundCb: null as OutboundCallback | null }
+  return {
+    routed,
+    registered,
+    unregistered,
+    get outboundCb() {
+      return state.outboundCb
+    },
+    route: async (msg: InboundMessage) => {
+      routed.push(msg)
+    },
+    registerOutbound: (adapter: string, cb: OutboundCallback) => {
+      registered.push(`outbound:${adapter}`)
+      state.outboundCb = cb
+    },
+    unregisterOutbound: (adapter: string) => unregistered.push(`outbound:${adapter}`),
+    registerSelfIdentity: (adapter: string) => registered.push(`self:${adapter}`),
+    unregisterSelfIdentity: (adapter: string) => unregistered.push(`self:${adapter}`),
+    registerHistory: (adapter: string) => registered.push(`history:${adapter}`),
+    unregisterHistory: (adapter: string) => unregistered.push(`history:${adapter}`),
+    getSelfAliases: () => [],
+  } as unknown as TestRouter
+}
+
+type ClientOverrides = {
+  chats?: TeamsChatInfo[]
+  sendChatMessage?: (chatId: string, content: string) => Promise<TeamsMessage>
+  getChatMessages?: (chatId: string, limit?: number) => Promise<TeamsMessage[]>
+  testAuth?: () => Promise<TeamsUser>
+}
+
+function fakeClient(overrides: ClientOverrides = {}) {
+  const sends: Array<{ chatId: string; content: string }> = []
+  const client = {
+    login: async () => {},
+    testAuth: overrides.testAuth ?? (async () => SELF),
+    listChats: async () => overrides.chats ?? [groupChat],
+    sendChatMessage:
+      overrides.sendChatMessage ??
+      (async (chatId: string, content: string) => {
+        sends.push({ chatId, content })
+        return teamsMessage({ id: 'sent', content })
+      }),
+    getChatMessages: overrides.getChatMessages ?? (async () => []),
+  }
+  return { sends, client }
+}
+
+function adapterWith(deps: {
+  r: ReturnType<typeof router>
+  listener: FakeListener
+  client: ReturnType<typeof fakeClient>['client']
+  log?: TeamsAdapterLogger
+  aliases?: readonly string[]
+  store?: { getAccount: () => Promise<TeamsAccountRecord | null> }
+  now?: () => number
+}) {
+  return createTeamsAdapter({
+    router: deps.r,
+    configRef: () => config,
+    logger: deps.log ?? logger(),
+    ...(deps.aliases ? { selfAliasesRef: () => deps.aliases! } : {}),
+    ...(deps.now ? { now: deps.now } : {}),
+    credentialsStore: deps.store ?? { getAccount: async () => account() },
+    createClient: () =>
+      deps.client as unknown as ReturnType<NonNullable<Parameters<typeof createTeamsAdapter>[0]['createClient']>>,
+    createListener: () => deps.listener as unknown as TeamsListener,
+  })
+}
+
+describe('teams outbound', () => {
+  test('sends to the decoded chat id and returns the sent message id', async () => {
+    const { sends, client } = fakeClient()
+    const cb = createOutboundCallback({ client, logger: logger() })
+
+    const result = await cb(outbound({ text: 'hi' }))
+
+    expect(result).toEqual({ ok: true, messageId: 'sent', messageIds: ['sent'] })
+    expect(sends).toEqual([{ chatId: 'chat-1', content: 'hi' }])
+  })
+
+  test('rejects a non chat: routing key', async () => {
+    const { client } = fakeClient()
+    const cb = createOutboundCallback({ client, logger: logger() })
+
+    expect(await cb(outbound({ chat: 'channel:team/ch' }))).toEqual({
+      ok: false,
+      error: 'unsupported Teams chat id: channel:team/ch',
+    })
+  })
+
+  test('rejects an empty message', async () => {
+    const { client } = fakeClient()
+    const cb = createOutboundCallback({ client, logger: logger() })
+
+    expect(await cb(outbound({ text: '' }))).toEqual({ ok: false, error: 'message has no text' })
+  })
+
+  test('surfaces a send failure as ok false', async () => {
+    const cb = createOutboundCallback({
+      client: {
+        sendChatMessage: async () => {
+          throw new Error('send boom')
+        },
+      },
+      logger: logger(),
+    })
+
+    await expect(cb(outbound({ text: 'hi' }))).resolves.toEqual({ ok: false, error: 'send boom' })
+  })
+
+  test('reserves the echo before sending and does not roll it back on success', async () => {
+    const rollbacks: number[] = []
+    let rolledBack = 0
+    const { client } = fakeClient()
+    const cb = createOutboundCallback({
+      client,
+      logger: logger(),
+      reserveEcho: (chatId, text) => {
+        rollbacks.push(1)
+        expect({ chatId, text }).toEqual({ chatId: 'chat-1', text: 'hi there' })
+        return () => {
+          rolledBack++
+        }
+      },
+    })
+
+    await cb(outbound({ text: 'hi there' }))
+
+    expect(rollbacks).toHaveLength(1)
+    expect(rolledBack).toBe(0)
+  })
+
+  test('rolls back the reserved echo when the send throws', async () => {
+    let rolledBack = 0
+    const cb = createOutboundCallback({
+      client: {
+        sendChatMessage: async () => {
+          throw new Error('send boom')
+        },
+      },
+      logger: logger(),
+      reserveEcho: () => () => {
+        rolledBack++
+      },
+    })
+
+    await cb(outbound({ text: 'hi there' }))
+
+    expect(rolledBack).toBe(1)
+  })
+})
+
+describe('teams history', () => {
+  test('maps messages to chronological history', async () => {
+    const cb = createTeamsHistoryCallback({
+      client: {
+        getChatMessages: async () => [
+          teamsMessage({ id: 'newer', content: 'reply' }),
+          teamsMessage({ id: 'older', content: 'question' }),
+        ],
+      },
+      logger: logger(),
+      selfIdRef: () => 'ME',
+    })
+
+    const res = await cb({ chat: 'chat:chat-1', thread: null, limit: 50 })
+
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('expected ok history')
+    expect(res.messages.map((m) => m.externalMessageId)).toEqual(['older', 'newer'])
+  })
+
+  test('rejects a non chat: routing key', async () => {
+    const cb = createTeamsHistoryCallback({
+      client: { getChatMessages: async () => [] },
+      logger: logger(),
+      selfIdRef: () => null,
+    })
+
+    expect(await cb({ chat: 'channel:x', thread: null, limit: 50 })).toEqual({
+      ok: false,
+      error: 'unsupported Teams chat id: channel:x',
+    })
+  })
+})
+
+describe('createTeamsAdapter', () => {
+  test('start logs in with the account token and wires router callbacks', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = adapterWith({ r, listener, client: fakeClient().client })
+
+    await adapter.start()
+
+    expect(adapter.isConnected()).toBe(true)
+    expect(r.registered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+
+    await adapter.stop()
+  })
+
+  test('missing account throws the documented error', async () => {
+    const adapter = adapterWith({
+      r: router(),
+      listener: new FakeListener(),
+      client: fakeClient().client,
+      store: { getAccount: async () => null },
+    })
+
+    await expect(adapter.start()).rejects.toThrow('no Teams account in secrets.json#channels.teams')
+  })
+
+  test('a realtime group message that matches an alias routes', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = adapterWith({ r, listener, client: fakeClient().client, aliases: ['typeclaw'] })
+
+    await adapter.start()
+    listener.emit('message', realtime())
+    await adapter.stop()
+
+    expect(r.routed).toHaveLength(1)
+    expect(r.routed[0]?.adapter).toBe('teams')
+    expect(r.routed[0]?.chat).toBe('chat:chat-1')
+    expect(r.routed[0]?.isBotMention).toBe(true)
+    expect(listener.stopped).toBe(true)
+    expect(r.unregistered).toContain('outbound:teams')
+  })
+
+  test('drops an inbound that echoes a message the agent just sent (content-only window)', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    let clock = 1_000
+    const adapter = adapterWith({ r, listener, client: fakeClient().client, now: () => clock })
+
+    await adapter.start()
+    // given the agent sends "on it" through its own registered outbound callback
+    expect(r.outboundCb).not.toBeNull()
+    await r.outboundCb!(outbound({ text: 'on it' }))
+    // when that exact text echoes back 1s later from an author we cannot prove is self
+    clock += 1_000
+    listener.emit(
+      'message',
+      realtime({ id: 'echo-1', content: 'on it', author: { id: 'user-1', displayName: 'Alice' } }),
+    )
+    await adapter.stop()
+
+    // then the recent-send fingerprint drops it inside the 5s content-only window
+    expect(r.routed).toHaveLength(0)
+  })
+
+  test('does not drop a repeat of the agent text once the content-only window has passed', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    let clock = 1_000
+    const adapter = adapterWith({ r, listener, client: fakeClient().client, now: () => clock })
+
+    await adapter.start()
+    await r.outboundCb!(outbound({ text: 'on it' }))
+    // 6s later a human genuinely typing the same short phrase is NOT an echo
+    clock += 6_000
+    listener.emit(
+      'message',
+      realtime({ id: 'human-1', content: 'on it', author: { id: 'user-1', displayName: 'Alice' } }),
+    )
+    await adapter.stop()
+
+    expect(r.routed).toHaveLength(1)
+  })
+
+  test('drops a self-name-authored echo across the full echo TTL', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    let clock = 1_000
+    const adapter = adapterWith({ r, listener, client: fakeClient().client, now: () => clock })
+
+    await adapter.start()
+    await r.outboundCb!(outbound({ text: 'status update' }))
+    // 30s later (past the content-only window) an author whose display name IS
+    // the bot's name echoes the text back → still suppressed
+    clock += 30_000
+    listener.emit(
+      'message',
+      realtime({ id: 'echo-2', content: 'status update', author: { id: 'x', displayName: 'Typeey' } }),
+    )
+    await adapter.stop()
+
+    expect(r.routed).toHaveLength(0)
+  })
+
+  test('a DM without any alias still engages', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = adapterWith({
+      r,
+      listener,
+      client: fakeClient({ chats: [{ id: 'chat-1', type: 'oneOnOne' } as TeamsChatInfo] }).client,
+    })
+
+    await adapter.start()
+    listener.emit('message', realtime({ content: 'no alias here' }))
+    await adapter.stop()
+
+    expect(r.routed).toHaveLength(1)
+    expect(r.routed[0]?.isDm).toBe(true)
+    expect(r.routed[0]?.mentionsOthers).toBe(false)
+  })
+
+  test('refreshes chats once when a realtime chatId is unknown, then routes', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    let listChatsCalls = 0
+    const client = {
+      login: async () => {},
+      testAuth: async () => SELF,
+      listChats: async () => {
+        listChatsCalls++
+        // first call (start) returns nothing; the on-miss refresh discovers the chat
+        return listChatsCalls === 1 ? [] : [{ id: 'chat-9', type: 'oneOnOne' } as TeamsChatInfo]
+      },
+      sendChatMessage: async () => teamsMessage(),
+      getChatMessages: async () => [],
+    }
+    const adapter = adapterWith({ r, listener, client: client as unknown as ReturnType<typeof fakeClient>['client'] })
+
+    await adapter.start()
+    listener.emit('message', realtime({ chatId: 'chat-9' }))
+    await adapter.stop()
+
+    expect(listChatsCalls).toBe(2)
+    expect(r.routed).toHaveLength(1)
+    expect(r.routed[0]?.chat).toBe('chat:chat-9')
+  })
+
+  test('isConnected is false after a disconnected event', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = adapterWith({ r, listener, client: fakeClient().client })
+
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
+    listener.emit('disconnected', undefined)
+    expect(adapter.isConnected()).toBe(false)
+
+    await adapter.stop()
+  })
+
+  test('rolls back every registration when the listener errors before connecting', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    listener.startImpl = async () => {
+      queueMicrotask(() => listener.emit('error', new Error('trouter down')))
+    }
+    const adapter = adapterWith({ r, listener, client: fakeClient().client })
+
+    await expect(adapter.start()).rejects.toThrow('trouter down')
+    expect(adapter.isConnected()).toBe(false)
+    expect(r.unregistered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+    expect(listener.stopped).toBe(true)
+  })
+
+  test('a listener error that arrives after start() resolves still rolls back', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    // start() resolves without connecting; the error lands on the next tick,
+    // so the adapter must be awaiting the connected/error race (not sampling a
+    // flag synchronously) to observe it.
+    listener.startImpl = async () => {
+      queueMicrotask(() => listener.emit('error', new Error('late trouter failure')))
+    }
+    const adapter = adapterWith({ r, listener, client: fakeClient().client })
+
+    await expect(adapter.start()).rejects.toThrow('late trouter failure')
+    expect(adapter.isConnected()).toBe(false)
+    expect(r.unregistered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+    expect(listener.stopped).toBe(true)
+  })
+
+  test('rolls back when listener.start() rejects synchronously without emitting error', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    // start() rejects itself and never emits a `connected`/`error` event, so
+    // the adapter must cancel the connected-wait in the rejection path (not
+    // hang for the full 20s timeout) and still roll back cleanly.
+    listener.startImpl = async () => {
+      throw new Error('start rejected')
+    }
+    const adapter = adapterWith({ r, listener, client: fakeClient().client })
+
+    await expect(adapter.start()).rejects.toThrow('start rejected')
+    expect(adapter.isConnected()).toBe(false)
+    expect(r.unregistered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+    expect(listener.stopped).toBe(true)
+  })
+
+  test('suppresses an echo delivered before the send promise resolves', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    // Hold sendChatMessage open so the echo lands while the send is in flight —
+    // the fingerprint must already be reserved (before the await), or the
+    // agent's own message routes back in.
+    const release = Promise.withResolvers<TeamsMessage>()
+    const adapter = adapterWith({
+      r,
+      listener,
+      client: fakeClient({ sendChatMessage: () => release.promise }).client,
+    })
+
+    await adapter.start()
+    const sendResult = r.outboundCb!(outbound({ text: 'working on it' }))
+    listener.emit('message', realtime({ id: 'echo-live', content: 'working on it' }))
+    release.resolve(teamsMessage({ id: 'sent' }))
+    await sendResult
+    await adapter.stop()
+
+    expect(r.routed).toHaveLength(0)
+  })
+
+  test('routes a normal message even if a concurrent send is rolled back on failure', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = adapterWith({
+      r,
+      listener,
+      client: fakeClient({
+        sendChatMessage: async () => {
+          throw new Error('send failed')
+        },
+      }).client,
+    })
+
+    await adapter.start()
+    // A failed send rolls back its reservation, so an unrelated human message
+    // with the same text is NOT wrongly suppressed.
+    await r.outboundCb!(outbound({ text: 'hello there' }))
+    listener.emit('message', realtime({ id: 'human', content: 'hello there' }))
+    await adapter.stop()
+
+    expect(r.routed).toHaveLength(1)
+  })
+})

--- a/src/channels/adapters/teams.ts
+++ b/src/channels/adapters/teams.ts
@@ -1,0 +1,422 @@
+import { TeamsClient, TeamsListener } from 'agent-messenger/teams'
+import type { TeamsListenerEventMap, TeamsMessage, TeamsUser } from 'agent-messenger/teams'
+
+import type { ChannelRouter } from '@/channels/router'
+import type { ChannelAdapterConfig } from '@/channels/schema'
+import type {
+  ChannelHistoryMessage,
+  ChannelSelfIdentityResolver,
+  FetchHistoryArgs,
+  FetchHistoryResult,
+  HistoryCallback,
+  OutboundCallback,
+  OutboundMessage,
+  SendResult,
+} from '@/channels/types'
+import type { TeamsAccountRecord } from '@/secrets/schema'
+
+import { describeError } from './describe-error'
+import { classifyInbound, normalizeTeamsText, type InboundDropReason, type TeamsInboundEvent } from './teams-classify'
+
+// `TeamsChat` is not exported from agent-messenger/teams, so derive its shape
+// from the client method that returns it — this stays in lockstep with the SDK
+// without depending on a named export the package chose to keep internal.
+export type TeamsChatInfo = Awaited<ReturnType<TeamsClient['listChats']>>[number]
+
+export type TeamsAdapterLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+const consoleLogger: TeamsAdapterLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export type TeamsClientFactory = () => TeamsClient
+export type TeamsListenerFactory = (client: TeamsClient) => TeamsListener
+
+export type TeamsCredentialStore = {
+  getAccount(id?: string): Promise<TeamsAccountRecord | null>
+}
+
+export type TeamsAdapterOptions = {
+  router: ChannelRouter
+  configRef: () => ChannelAdapterConfig
+  logger?: TeamsAdapterLogger
+  selfAliasesRef?: () => readonly string[]
+  credentialsStore?: TeamsCredentialStore
+  createClient?: TeamsClientFactory
+  createListener?: TeamsListenerFactory
+  now?: () => number
+}
+
+export type TeamsAdapter = {
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  isConnected: () => boolean
+}
+
+const CHAT_PREFIX = 'chat:'
+const TEAMS_LISTENER_START_TIMEOUT_MS = 20_000
+
+// The Teams user-account SDK has NO self-identity boundary: `testAuth()` returns
+// the literal id `'ME'`, while realtime/history authors carry the real MRI from
+// `resource.from`. So an id comparison can never recognize the agent's own
+// message echoing back over the trouter socket. Instead every successful send
+// records a (chat, normalized-text) fingerprint; an inbound that matches a
+// recent unconsumed fingerprint in the same chat is treated as the echo of our
+// own send and dropped. The author-name / `'ME'` checks are a fast path; the
+// short content-only window is the fallback for when the platform does not
+// stamp the outbound back with our display name.
+const SELF_ECHO_TTL_MS = 2 * 60_000
+const SELF_ECHO_CONTENT_ONLY_TTL_MS = 5_000
+const MAX_SENT_ECHOES = 200
+
+type SentEcho = { chatId: string; textKey: string; sentAt: number; consumed: boolean }
+
+export function createOutboundCallback(deps: {
+  client: Pick<TeamsClient, 'sendChatMessage'>
+  logger: TeamsAdapterLogger
+  // Reserve the self-echo fingerprint BEFORE the send is awaited and return a
+  // rollback. Teams delivers a send back over the listener socket, and that
+  // echo can arrive before `sendChatMessage` resolves — reserving after the
+  // await would leave a window where the agent's own message routes back in.
+  // The rollback drops the reservation if the send ultimately fails.
+  reserveEcho?: (chatId: string, text: string) => () => void
+}): OutboundCallback {
+  const { client, logger } = deps
+  return async (msg: OutboundMessage): Promise<SendResult> => {
+    if (msg.adapter !== 'teams') return { ok: false, error: `unknown adapter: ${msg.adapter}` }
+    const text = msg.text ?? ''
+    if (text === '') return { ok: false, error: 'message has no text' }
+    if (!msg.chat.startsWith(CHAT_PREFIX)) return { ok: false, error: `unsupported Teams chat id: ${msg.chat}` }
+    const chatId = msg.chat.slice(CHAT_PREFIX.length)
+
+    logger.info(`[teams] outbound chat=${chatId} text_len=${text.length}`)
+    const rollbackEcho = deps.reserveEcho?.(chatId, text)
+    try {
+      const sent = await client.sendChatMessage(chatId, text)
+      logger.info(`[teams] sent id=${sent.id} chat=${chatId}`)
+      return { ok: true, messageId: sent.id, messageIds: [sent.id] }
+    } catch (err) {
+      rollbackEcho?.()
+      const message = describeError(err)
+      logger.error(`[teams] outbound failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createTeamsHistoryCallback(deps: {
+  client: Pick<TeamsClient, 'getChatMessages'>
+  logger: TeamsAdapterLogger
+  selfIdRef: () => string | null
+}): HistoryCallback {
+  return async (args: FetchHistoryArgs): Promise<FetchHistoryResult> => {
+    if (!args.chat.startsWith(CHAT_PREFIX)) {
+      return { ok: false, error: `unsupported Teams chat id: ${args.chat}` }
+    }
+    const chatId = args.chat.slice(CHAT_PREFIX.length)
+    try {
+      const messages = await deps.client.getChatMessages(chatId, clampLimit(args.limit, 100))
+      const selfId = deps.selfIdRef()
+      return { ok: true, messages: messages.map((m) => mapTeamsHistoryMessage(m, selfId)).reverse() }
+    } catch (err) {
+      const message = describeError(err)
+      deps.logger.warn(`[teams] history fetch failed: ${message}`)
+      return { ok: false, error: message }
+    }
+  }
+}
+
+export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
+  const logger = options.logger ?? consoleLogger
+  const now = options.now ?? Date.now
+  const createClient = options.createClient ?? (() => new TeamsClient())
+  const createListener = options.createListener ?? ((client) => new TeamsListener(client))
+  const client = createClient()
+  let listener: TeamsListener | null = null
+  let self: TeamsUser | null = null
+  let chatsById = new Map<string, TeamsChatInfo>()
+  let sentEchoes: SentEcho[] = []
+  let connected = false
+  let started = false
+  let inflightInbounds = 0
+  let stopWaiters: Array<() => void> = []
+
+  const selfIdentityResolver: ChannelSelfIdentityResolver = () =>
+    self !== null ? { id: self.id, username: self.userPrincipalName ?? self.email ?? self.displayName } : null
+
+  const reserveEcho = (chatId: string, text: string): (() => void) => {
+    const echo: SentEcho = { chatId, textKey: normalizeTeamsText(text), sentAt: now(), consumed: false }
+    sentEchoes.push(echo)
+    if (sentEchoes.length > MAX_SENT_ECHOES) sentEchoes = sentEchoes.slice(-MAX_SENT_ECHOES)
+    return () => {
+      const index = sentEchoes.indexOf(echo)
+      if (index !== -1) sentEchoes.splice(index, 1)
+    }
+  }
+
+  const isSelfEcho = (event: TeamsInboundEvent): boolean => {
+    const textKey = normalizeTeamsText(event.content)
+    const authorName = event.author.displayName.trim().toLocaleLowerCase()
+    const selfName = (self?.displayName ?? '').trim().toLocaleLowerCase()
+    const nowMs = now()
+    for (const echo of sentEchoes) {
+      if (echo.consumed || echo.chatId !== event.chatId || echo.textKey !== textKey) continue
+      const age = nowMs - echo.sentAt
+      if (age > SELF_ECHO_TTL_MS) continue
+      const authorLooksSelf =
+        event.author.id === 'ME' || (selfName !== '' && authorName === selfName) || authorName === 'me'
+      if (authorLooksSelf || age <= SELF_ECHO_CONTENT_ONLY_TTL_MS) {
+        echo.consumed = true
+        return true
+      }
+    }
+    return false
+  }
+
+  const outboundCallback = createOutboundCallback({ client, logger, reserveEcho })
+  const historyCallback = createTeamsHistoryCallback({ client, logger, selfIdRef: () => self?.id ?? null })
+
+  const refreshChats = async (): Promise<void> => {
+    const chats = await client.listChats()
+    chatsById = new Map(chats.map((chat) => [chat.id, chat]))
+  }
+
+  const resolveChat = async (chatId: string): Promise<TeamsChatInfo | undefined> => {
+    const cached = chatsById.get(chatId)
+    if (cached !== undefined) return cached
+    try {
+      await refreshChats()
+    } catch (err) {
+      logger.warn(`[teams] chat refresh failed: ${describeError(err)}`)
+    }
+    return chatsById.get(chatId)
+  }
+
+  const handleMessage = async (event: TeamsInboundEvent): Promise<void> => {
+    inflightInbounds++
+    try {
+      if (isSelfEcho(event)) {
+        logger.info(`[teams] dropped id=${event.id} reason=self_echo`)
+        return
+      }
+      const chat = await resolveChat(event.chatId)
+      const verdict = classifyInbound(event, options.configRef(), self, chat, options.selfAliasesRef?.() ?? [])
+      if (verdict.kind === 'drop') {
+        logger.info(`[teams] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
+        return
+      }
+      logger.info(
+        `[teams] routed id=${event.id} chat=${event.chatId} mention=${verdict.payload.isBotMention} dm=${verdict.payload.isDm}`,
+      )
+      await options.router.route(verdict.payload)
+    } catch (err) {
+      logger.error(`[teams] handleInbound failed: ${describeError(err)}`)
+    } finally {
+      inflightInbounds--
+      if (inflightInbounds === 0 && stopWaiters.length > 0) {
+        const waiters = stopWaiters
+        stopWaiters = []
+        for (const w of waiters) w()
+      }
+    }
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (started) return
+      started = true
+      try {
+        const account = await (options.credentialsStore ?? null)?.getAccount()
+        if (account === null || account === undefined) {
+          throw new Error('no Teams account in secrets.json#channels.teams (run typeclaw init to authenticate)')
+        }
+        warnIfTokenExpiring(account, logger, now())
+        await client.login({
+          token: account.access_token,
+          ...(account.token_expires_at !== undefined ? { tokenExpiresAt: account.token_expires_at } : {}),
+          accountType: account.account_type,
+          ...(account.region !== undefined ? { region: account.region } : {}),
+        })
+        self = await client.testAuth()
+        await refreshChats()
+        logger.info(`[teams] authenticated as ${self.displayName}, ${chatsById.size} chats`)
+      } catch (err) {
+        started = false
+        self = null
+        chatsById = new Map()
+        logger.error(`[teams] login failed: ${describeError(err)}`)
+        throw err
+      }
+
+      listener = createListener(client)
+      listener.on('disconnected', () => {
+        connected = false
+        logger.warn('[teams] disconnected')
+      })
+      listener.on('error', (err: TeamsListenerEventMap['error'][0]) => {
+        logger.error(`[teams] listener error: ${describeError(err)}`)
+      })
+      listener.on('message', (event: TeamsListenerEventMap['message'][0]) => {
+        void handleMessage(event)
+      })
+
+      options.router.registerOutbound('teams', outboundCallback)
+      options.router.registerSelfIdentity('teams', selfIdentityResolver)
+      options.router.registerHistory('teams', historyCallback)
+
+      const rollbackStart = (reason: string, cause: Error): never => {
+        options.router.unregisterOutbound('teams', outboundCallback)
+        options.router.unregisterSelfIdentity('teams', selfIdentityResolver)
+        options.router.unregisterHistory('teams', historyCallback)
+        listener?.stop()
+        listener = null
+        self = null
+        chatsById = new Map()
+        sentEchoes = []
+        connected = false
+        started = false
+        logger.error(`[teams] ${reason}: ${describeError(cause)}`)
+        throw cause
+      }
+
+      // The SDK emits `connected` asynchronously, only after the trouter
+      // WebSocket registers an endpoint — it is NOT raised synchronously by
+      // `listener.start()`. So attach the connected/error race BEFORE start()
+      // and await it, rather than sampling a flag right after start() returns.
+      const connectedWait = waitForTeamsConnected(listener)
+      try {
+        await listener.start()
+        await connectedWait.promise
+        connected = true
+      } catch (err) {
+        // Tear down the connected wait first: if `listener.start()` itself
+        // rejected, `connectedWait.promise` was never awaited, so its timer and
+        // handlers would otherwise linger and reject later unhandled.
+        connectedWait.cancel()
+        rollbackStart('listener start failed', err instanceof Error ? err : new Error(describeError(err)))
+      }
+    },
+
+    async stop(): Promise<void> {
+      if (!started) return
+      started = false
+      options.router.unregisterOutbound('teams', outboundCallback)
+      options.router.unregisterSelfIdentity('teams', selfIdentityResolver)
+      options.router.unregisterHistory('teams', historyCallback)
+      listener?.stop()
+      listener = null
+      connected = false
+      if (inflightInbounds > 0) {
+        await new Promise<void>((resolve) => {
+          stopWaiters.push(resolve)
+        })
+      }
+      self = null
+      chatsById = new Map()
+      sentEchoes = []
+    },
+
+    isConnected(): boolean {
+      return started && self !== null && connected
+    },
+  }
+}
+
+// Returns the connected/error/timeout race plus a `cancel` that tears down the
+// timer and listener handlers. `cancel` is load-bearing: if `listener.start()`
+// itself rejects, the caller never awaits `promise`, so without cancellation
+// the 20s timer would linger and the promise could later reject with no handler
+// (an unhandled rejection). Cancelling resolves the promise as a no-op so it
+// stays handled.
+function waitForTeamsConnected(
+  listener: TeamsListener,
+  timeoutMs = TEAMS_LISTENER_START_TIMEOUT_MS,
+): { promise: Promise<void>; cancel: () => void } {
+  let settled = false
+  let onConnected: () => void = () => {}
+  let onError: (err: Error) => void = () => {}
+  let resolveNoop: () => void = () => {}
+  let timer: ReturnType<typeof setTimeout>
+  const cleanup = (): void => {
+    clearTimeout(timer)
+    listener.off('connected', onConnected)
+    listener.off('error', onError)
+  }
+  const promise = new Promise<void>((resolve, reject) => {
+    resolveNoop = resolve
+    const settle = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      fn()
+    }
+    onConnected = (): void => settle(resolve)
+    onError = (err: Error): void => settle(() => reject(err))
+    timer = setTimeout(
+      () => settle(() => reject(new Error(`Teams listener did not connect within ${timeoutMs}ms`))),
+      timeoutMs,
+    )
+    listener.on('connected', onConnected)
+    listener.on('error', onError)
+  })
+  const cancel = (): void => {
+    if (settled) return
+    settled = true
+    cleanup()
+    resolveNoop()
+  }
+  return { promise, cancel }
+}
+
+// `getChatMessages` already strips HTML and sets `author.id` to the real MRI
+// (never `'ME'`), so bot-authored history can only be recognized when the
+// caller happens to know that MRI — which the SDK does not surface. `selfId`
+// is therefore best-effort: it flags nothing in practice today, but leaving the
+// comparison in place means history attribution starts working for free if a
+// future SDK version exposes the real self id.
+function mapTeamsHistoryMessage(msg: TeamsMessage, selfId: string | null): ChannelHistoryMessage {
+  const ts = Date.parse(msg.timestamp)
+  return {
+    externalMessageId: msg.id,
+    authorId: msg.author.id,
+    authorName: msg.author.displayName,
+    text: msg.content,
+    ts: Number.isFinite(ts) ? ts : 0,
+    isBot: selfId !== null && msg.author.id === selfId,
+    replyToBotMessageId: null,
+  }
+}
+
+function warnIfTokenExpiring(account: TeamsAccountRecord, logger: TeamsAdapterLogger, nowMs: number): void {
+  if (account.token_expires_at === undefined) return
+  const expiresAt = Date.parse(account.token_expires_at)
+  if (!Number.isFinite(expiresAt)) return
+  if (expiresAt <= nowMs) {
+    logger.warn('[teams] access token is already expired; the adapter will fail until credentials are refreshed')
+  } else if (expiresAt - nowMs <= 10 * 60_000) {
+    logger.warn('[teams] access token expires soon; long-running sessions will stop until credentials are refreshed')
+  }
+}
+
+function clampLimit(requested: number, max: number): number {
+  if (!Number.isFinite(requested) || requested <= 0) return max
+  return Math.min(Math.floor(requested), max)
+}
+
+function dropHint(reason: InboundDropReason): string {
+  switch (reason) {
+    case 'empty_content':
+      return ' (message had no text)'
+    case 'unknown_chat':
+      return ' (chat id not found even after refresh)'
+    case 'pre_connect':
+    case 'self_author':
+      return ''
+  }
+}

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -10,6 +10,7 @@ import { SecretsLineCredentialStore } from '@/secrets/line-store'
 import type { RuntimeSecretsProvider } from '@/secrets/secrets-provider'
 import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
 import { SecretsBackend } from '@/secrets/storage'
+import { SecretsTeamsCredentialStore } from '@/secrets/teams-store'
 import { SecretsWebexCredentialStore } from '@/secrets/webex-store'
 import type { Stream } from '@/stream'
 
@@ -21,6 +22,7 @@ import { createKakaotalkAdapter, type KakaotalkAdapter } from './adapters/kakaot
 import { createLineAdapter, type LineAdapter } from './adapters/line'
 import { createSlackAdapter, type SlackAdapter } from './adapters/slack'
 import { createSlackBotAdapter, type SlackBotAdapter } from './adapters/slack-bot'
+import { createTeamsAdapter, type TeamsAdapter } from './adapters/teams'
 import { createTelegramBotAdapter, type TelegramBotAdapter } from './adapters/telegram-bot'
 import { createWebexAdapter, type WebexAdapter } from './adapters/webex'
 import { createWebexBotAdapter, type WebexBotAdapter } from './adapters/webex-bot'
@@ -90,6 +92,7 @@ export type ChannelManagerOptions = {
   createLineAdapter?: typeof createLineAdapter
   createSlackAdapter?: typeof createSlackBotAdapter
   createSlackUserAdapter?: typeof createSlackAdapter
+  createTeamsAdapter?: typeof createTeamsAdapter
   createTelegramAdapter?: typeof createTelegramBotAdapter
   createWebexAdapter?: typeof createWebexAdapter
   createWebexBotAdapter?: typeof createWebexBotAdapter
@@ -161,6 +164,7 @@ type AnyAdapter =
   | KakaotalkAdapter
   | SlackAdapter
   | SlackBotAdapter
+  | TeamsAdapter
   | TelegramBotAdapter
   | WebexAdapter
   | WebexBotAdapter
@@ -205,6 +209,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   const createLine = options.createLineAdapter ?? createLineAdapter
   const createSlackBot = options.createSlackAdapter ?? createSlackBotAdapter
   const createSlackUser = options.createSlackUserAdapter ?? createSlackAdapter
+  const createTeams = options.createTeamsAdapter ?? createTeamsAdapter
   const createTelegramAdapter = options.createTelegramAdapter ?? createTelegramBotAdapter
   const createWebex = options.createWebexAdapter ?? createWebexAdapter
   const createWebexBot = options.createWebexBotAdapter ?? createWebexBotAdapter
@@ -235,6 +240,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     if (name === 'instagram') return buildInstagramSignature(options.agentDir)
     if (name === 'kakaotalk') return buildKakaotalkSignature(options.agentDir)
     if (name === 'webex') return buildWebexSignature(options.agentDir)
+    if (name === 'teams') return buildTeamsSignature(options.agentDir)
     if (name === 'slack') return buildSlackSignature(options.agentDir)
     if (name === 'discord') return buildDiscordSignature(options.agentDir)
     if (name === 'github') return buildGithubSignature(options.agentDir)
@@ -336,6 +342,17 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       const credentialsStore = createContainerWebexCredentialStore(options.agentDir, options.secretsProvider ?? null)
       if (credentialsStore === null) return null
       return createWebex({
+        router,
+        configRef: () => options.channelsConfigRef()[name] ?? cfg,
+        logger,
+        selfAliasesRef: () => router.getSelfAliases(),
+        credentialsStore,
+      })
+    }
+    if (name === 'teams') {
+      const credentialsStore = createContainerTeamsCredentialStore(options.agentDir, options.secretsProvider ?? null)
+      if (credentialsStore === null) return null
+      return createTeams({
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,
@@ -562,6 +579,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
               name === 'line' ||
               name === 'instagram' ||
               name === 'webex' ||
+              name === 'teams' ||
               name === 'slack' ||
               name === 'discord'
                 ? 'credential rotation'
@@ -580,7 +598,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 // secrets.json#channels.<adapter>, not in env, so they go through
 // structured-block signatures instead.
 const TOKEN_ENV: Record<
-  Exclude<AdapterId, 'kakaotalk' | 'line' | 'instagram' | 'github' | 'webex' | 'slack' | 'discord'>,
+  Exclude<AdapterId, 'kakaotalk' | 'line' | 'instagram' | 'github' | 'webex' | 'teams' | 'slack' | 'discord'>,
   readonly string[]
 > = {
   'discord-bot': ['DISCORD_BOT_TOKEN'],
@@ -670,6 +688,32 @@ function buildWebexSignature(agentDir: string): { signature: string; missing: st
     return { signature: `secrets.json#channels.webex@sha256:${digest}`, missing: [] }
   } catch (err) {
     return { signature: '', missing: [`secrets.json#channels.webex (${describe(err)})`] }
+  }
+}
+
+function createContainerTeamsCredentialStore(
+  agentDir: string,
+  secretsProvider: RuntimeSecretsProvider | null,
+): SecretsTeamsCredentialStore | null {
+  if (secretsProvider === null) return null
+  return new SecretsTeamsCredentialStore({
+    mode: 'container',
+    secretsPath: join(agentDir, 'secrets.json'),
+    hostProvider: secretsProvider,
+  })
+}
+
+function buildTeamsSignature(agentDir: string): { signature: string; missing: string[] } {
+  const path = join(agentDir, 'secrets.json')
+  try {
+    const block = new SecretsBackend(path).tryReadChannelsSync()?.teams
+    if (!isTeamsCredentialBlock(block)) {
+      return { signature: '', missing: ['secrets.json#channels.teams'] }
+    }
+    const digest = createHash('sha256').update(JSON.stringify(block)).digest('hex')
+    return { signature: `secrets.json#channels.teams@sha256:${digest}`, missing: [] }
+  } catch (err) {
+    return { signature: '', missing: [`secrets.json#channels.teams (${describe(err)})`] }
   }
 }
 
@@ -823,6 +867,15 @@ function isDiscordCredentialBlock(value: unknown): value is { accounts: Record<s
 }
 
 function isWebexCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  if (!('accounts' in value)) return false
+  const accounts = value.accounts
+  return (
+    typeof accounts === 'object' && accounts !== null && !Array.isArray(accounts) && Object.keys(accounts).length > 0
+  )
+}
+
+function isTeamsCredentialBlock(value: unknown): value is { accounts: Record<string, unknown> } {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
   if (!('accounts' in value)) return false
   const accounts = value.accounts

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5558,6 +5558,7 @@ export function formatAuthorAttribution(adapter: AdapterId, authorId: string, au
     case 'telegram-bot':
     case 'webex':
     case 'webex-bot':
+    case 'teams':
     case 'instagram':
     case 'line':
     case 'kakaotalk':
@@ -5591,6 +5592,7 @@ function formatAuthorReference(adapter: AdapterId, authorId: string, authorName:
     case 'telegram-bot':
     case 'webex':
     case 'webex-bot':
+    case 'teams':
     case 'instagram':
     case 'line':
     case 'kakaotalk':

--- a/src/channels/schema.test.ts
+++ b/src/channels/schema.test.ts
@@ -147,6 +147,7 @@ describe('ADAPTER_READ_CAPABILITIES', () => {
     kakaotalk: 'kakaotalk.ts',
     slack: 'slack.ts',
     'slack-bot': 'slack-bot.ts',
+    teams: 'teams.ts',
     'telegram-bot': 'telegram-bot.ts',
     webex: 'webex.ts',
     'webex-bot': 'webex-bot.ts',

--- a/src/channels/schema.ts
+++ b/src/channels/schema.ts
@@ -9,6 +9,7 @@ export const ADAPTER_IDS = [
   'kakaotalk',
   'slack',
   'slack-bot',
+  'teams',
   'telegram-bot',
   'webex',
   'webex-bot',
@@ -35,6 +36,7 @@ export const ADAPTER_READ_CAPABILITIES: Record<AdapterId, readonly ReadCapabilit
   kakaotalk: ['history'],
   slack: ['history'],
   'slack-bot': ['history', 'message-get', 'list'],
+  teams: ['history'],
   'telegram-bot': [],
   webex: ['history'],
   'webex-bot': ['history'],
@@ -303,6 +305,13 @@ export const channelsSchema = z
     kakaotalk: adapterSchema.optional(),
     slack: adapterSchema.optional(),
     'slack-bot': adapterSchema.optional(),
+    // Teams is a personal-account channel: user-account auth (no bot token),
+    // credentials in secrets.json#channels.teams. v1 is chat-only (1:1/group/
+    // self chats) driven by agent-messenger's TeamsListener (trouter
+    // WebSocket); Teams team/channel messaging is out of scope because the
+    // realtime event carries only a chatId, no team/channel id. Plain-text
+    // sends only; standard adapterSchema (engagement + history + enabled).
+    teams: adapterSchema.optional(),
     'telegram-bot': adapterSchema.optional(),
     webex: adapterSchema.optional(),
     // Webex bots receive messages in real time over a Mercury WebSocket

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -57,11 +57,18 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'telegram-bot': 'Telegram',
   webex: 'Webex (User)',
   'webex-bot': 'Webex',
+  teams: 'Teams',
   instagram: 'Instagram',
   line: 'LINE',
   kakaotalk: 'KakaoTalk',
   github: 'GitHub',
 }
+
+// Teams has no interactive auth flow yet (device-code/AAD login isn't wired
+// into `channel add`), so it is hidden from the picker and the addable-arg
+// validation. It stays a first-class ChannelKind for list/remove/config; the
+// adapter runs from a manually-populated secrets.json#channels.teams block.
+const ADDABLE_CHANNEL_KINDS = CHANNEL_KINDS.filter((kind) => kind !== 'teams')
 
 const addSub = defineCommand({
   meta: {
@@ -71,7 +78,7 @@ const addSub = defineCommand({
   args: {
     adapter: {
       type: 'positional',
-      description: `which adapter to add (${CHANNEL_KINDS.join(' | ')}); omit to pick interactively`,
+      description: `which adapter to add (${ADDABLE_CHANNEL_KINDS.join(' | ')}); omit to pick interactively`,
       required: false,
     },
   },
@@ -654,7 +661,15 @@ async function maybePromptCredentialRefresh(
 
 function validateAdapterArg(adapter: string, configured: Set<ChannelKind>): ChannelKind {
   if (!isChannelKind(adapter)) {
-    console.error(errorLine(`Unknown adapter "${adapter}". Expected one of: ${CHANNEL_KINDS.join(', ')}.`))
+    console.error(errorLine(`Unknown adapter "${adapter}". Expected one of: ${ADDABLE_CHANNEL_KINDS.join(', ')}.`))
+    process.exit(1)
+  }
+  if (!(ADDABLE_CHANNEL_KINDS as ReadonlyArray<string>).includes(adapter)) {
+    console.error(
+      errorLine(
+        `${CHANNEL_LABELS[adapter]} ("${adapter}") has no interactive auth yet. Populate secrets.json#channels.${adapter} manually.`,
+      ),
+    )
     process.exit(1)
   }
   if (configured.has(adapter)) {
@@ -673,7 +688,7 @@ function isChannelKind(value: string): value is ChannelKind {
 }
 
 async function pickChannel(configured: Set<ChannelKind>): Promise<ChannelKind> {
-  const available = CHANNEL_KINDS.filter((kind) => !configured.has(kind))
+  const available = ADDABLE_CHANNEL_KINDS.filter((kind) => !configured.has(kind))
   if (available.length === 0) {
     console.error(errorLine('All supported channel adapters are already configured in typeclaw.json. Nothing to add.'))
     process.exit(0)
@@ -1049,6 +1064,14 @@ async function collectCredentials(
     }
     case 'webex-bot':
       return { channel, webexBotToken: await promptWebexToken() }
+    case 'teams':
+      // Unreachable in practice: `validateAdapterArg`/`pickChannel` exclude
+      // Teams from the addable set (ADDABLE_CHANNEL_KINDS). Kept as a guard so
+      // this exhaustive switch still compiles and fails loudly if that
+      // exclusion ever regresses.
+      throw new Error(
+        'Teams channel add is not yet supported interactively. Populate secrets.json#channels.teams manually.',
+      )
     case 'instagram': {
       const creds = await promptInstagramCredentials()
       const callbacks = instagramLoginCallbacks(lineSpinnerHolder ? holderSpinnerControl(lineSpinnerHolder) : undefined)

--- a/src/config/channels-mutation.ts
+++ b/src/config/channels-mutation.ts
@@ -15,6 +15,7 @@ export const CHANNEL_KINDS = [
   'telegram-bot',
   'webex',
   'webex-bot',
+  'teams',
   'instagram',
   'line',
   'kakaotalk',

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -13,6 +13,7 @@ import {
   lineChannelBlockSchema,
   mcpCredentialSchema,
   slackChannelBlockSchema,
+  teamsChannelBlockSchema,
   webexChannelBlockSchema,
 } from '@/secrets/schema'
 import { SecretsBackend } from '@/secrets/storage'
@@ -536,6 +537,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
             | { instagram: unknown }
             | { line: unknown }
             | { webex: unknown }
+            | { teams: unknown }
             | { slack: unknown }
           mcp?: never
         }
@@ -572,9 +574,11 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
               ? { key: 'discord' as const, parsed: discordChannelBlockSchema.safeParse(channelsPatch.discord) }
               : 'webex' in channelsPatch
                 ? { key: 'webex' as const, parsed: webexChannelBlockSchema.safeParse(channelsPatch.webex) }
-                : 'slack' in channelsPatch
-                  ? { key: 'slack' as const, parsed: slackChannelBlockSchema.safeParse(channelsPatch.slack) }
-                  : { key: 'kakaotalk' as const, parsed: kakaoChannelBlockSchema.safeParse(channelsPatch.kakaotalk) }
+                : 'teams' in channelsPatch
+                  ? { key: 'teams' as const, parsed: teamsChannelBlockSchema.safeParse(channelsPatch.teams) }
+                  : 'slack' in channelsPatch
+                    ? { key: 'slack' as const, parsed: slackChannelBlockSchema.safeParse(channelsPatch.slack) }
+                    : { key: 'kakaotalk' as const, parsed: kakaoChannelBlockSchema.safeParse(channelsPatch.kakaotalk) }
       if (!patch.parsed.success) {
         return { ok: false, reason: patch.parsed.error.issues.map((issue) => issue.message).join('; ') }
       }

--- a/src/hostd/protocol.ts
+++ b/src/hostd/protocol.ts
@@ -6,6 +6,7 @@ import type {
   LineChannelBlock,
   McpCredential,
   SlackChannelBlock,
+  TeamsChannelBlock,
   WebexChannelBlock,
 } from '@/secrets/schema'
 
@@ -15,6 +16,7 @@ export type SecretsPatchChannels =
   | { instagram: InstagramChannelBlock }
   | { line: LineChannelBlock }
   | { webex: WebexChannelBlock }
+  | { teams: TeamsChannelBlock }
   | { slack: SlackChannelBlock }
 
 export type SecretsPatchMcp = { server: string; credential: McpCredential }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -1149,6 +1149,7 @@ export type ChannelKind =
   | 'telegram-bot'
   | 'webex'
   | 'webex-bot'
+  | 'teams'
   | 'instagram'
   | 'line'
   | 'kakaotalk'
@@ -1166,6 +1167,7 @@ export const CHANNEL_KINDS: ReadonlyArray<ChannelKind> = [
   'telegram-bot',
   'webex',
   'webex-bot',
+  'teams',
   'instagram',
   'line',
   'kakaotalk',

--- a/src/init/run-owner-claim.ts
+++ b/src/init/run-owner-claim.ts
@@ -14,6 +14,7 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   'telegram-bot': 'Telegram',
   webex: 'Webex (User)',
   'webex-bot': 'Webex',
+  teams: 'Teams',
   instagram: 'Instagram',
   line: 'LINE',
   kakaotalk: 'KakaoTalk',

--- a/src/permissions/match-rule.ts
+++ b/src/permissions/match-rule.ts
@@ -16,7 +16,17 @@
 // error messages with typo suggestions; a single big regex would only ever
 // say "didn't match".
 
-export const PLATFORMS = ['slack', 'discord', 'telegram', 'webex', 'instagram', 'line', 'kakao', 'github'] as const
+export const PLATFORMS = [
+  'slack',
+  'discord',
+  'telegram',
+  'webex',
+  'teams',
+  'instagram',
+  'line',
+  'kakao',
+  'github',
+] as const
 export type Platform = (typeof PLATFORMS)[number]
 
 const SUBAGENT_NAME = /^[a-z][a-z0-9-]*$/

--- a/src/permissions/resolve.ts
+++ b/src/permissions/resolve.ts
@@ -13,6 +13,7 @@ const ADAPTER_TO_PLATFORM: Record<AdapterId, Platform> = {
   'telegram-bot': 'telegram',
   webex: 'webex',
   'webex-bot': 'webex',
+  teams: 'teams',
   line: 'line',
   kakaotalk: 'kakao',
 }

--- a/src/role-claim/match-rule.ts
+++ b/src/role-claim/match-rule.ts
@@ -27,7 +27,7 @@ export type PartialChannelOrigin = {
 
 const ADAPTER_TO_PLATFORM: Record<
   ChannelKey['adapter'],
-  'slack' | 'discord' | 'telegram' | 'webex' | 'kakao' | 'line' | 'github' | 'instagram'
+  'slack' | 'discord' | 'telegram' | 'webex' | 'teams' | 'kakao' | 'line' | 'github' | 'instagram'
 > = {
   slack: 'slack',
   'slack-bot': 'slack',
@@ -38,6 +38,7 @@ const ADAPTER_TO_PLATFORM: Record<
   'telegram-bot': 'telegram',
   webex: 'webex',
   'webex-bot': 'webex',
+  teams: 'teams',
   line: 'line',
   kakaotalk: 'kakao',
 }

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -182,6 +182,34 @@ export const webexChannelBlockSchema = z.object({
   accounts: z.record(z.string(), webexAccountRecordSchema),
 })
 
+const teamsAccountTypeSchema = z.union([z.literal('work'), z.literal('personal')])
+const teamsRegionSchema = z.union([z.literal('amer'), z.literal('emea'), z.literal('apac')])
+
+// Teams user-account credentials. The short-lived `access_token` expires in
+// 60-90 minutes, so a long-running adapter relies on `aad_refresh_token` (+
+// client/tenant ids from the device-code login) to silently re-mint it through
+// the agent-messenger SDK. The refresh trio is optional so an extracted-token
+// account still parses, but such an account degrades to "reauth required" once
+// the access token lapses.
+export const teamsAccountRecordSchema = z.object({
+  account_id: z.string(),
+  access_token: z.string(),
+  token_expires_at: z.string().optional(),
+  account_type: teamsAccountTypeSchema,
+  region: teamsRegionSchema.optional(),
+  user_name: z.string().optional(),
+  aad_refresh_token: z.string().optional(),
+  aad_client_id: z.string().optional(),
+  aad_tenant_id: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const teamsChannelBlockSchema = z.object({
+  currentAccount: z.string().nullable(),
+  accounts: z.record(z.string(), teamsAccountRecordSchema),
+})
+
 export const slackAccountRecordSchema = z.object({
   account_id: z.string(),
   token: z.string(),
@@ -221,6 +249,7 @@ export const channelsSchema = z
     instagram: instagramChannelBlockSchema.optional(),
     kakaotalk: kakaoChannelBlockSchema.optional(),
     webex: webexChannelBlockSchema.optional(),
+    teams: teamsChannelBlockSchema.optional(),
     slack: slackChannelBlockSchema.optional(),
   })
   .catchall(z.unknown())
@@ -257,6 +286,8 @@ export type KakaoChannelBlock = z.infer<typeof kakaoChannelBlockSchema>
 export type WebexAccountRecord = z.infer<typeof webexAccountRecordSchema>
 export type WebexChannelBlock = z.infer<typeof webexChannelBlockSchema>
 export type WebexEncryptedPassword = z.infer<typeof webexEncryptedPasswordSchema>
+export type TeamsAccountRecord = z.infer<typeof teamsAccountRecordSchema>
+export type TeamsChannelBlock = z.infer<typeof teamsChannelBlockSchema>
 export type SlackAccountRecord = z.infer<typeof slackAccountRecordSchema>
 export type SlackChannelBlock = z.infer<typeof slackChannelBlockSchema>
 export type SecretsFile = z.infer<typeof secretsFileSchema>

--- a/src/secrets/teams-store.ts
+++ b/src/secrets/teams-store.ts
@@ -1,0 +1,108 @@
+import { type TeamsAccountRecord, type TeamsChannelBlock, teamsChannelBlockSchema } from './schema'
+import type { RuntimeSecretsProvider } from './secrets-provider'
+import { SecretsBackend } from './storage'
+
+export type SetTeamsAccountInput = TeamsAccountRecord
+
+export type SecretsTeamsCredentialStoreOptions =
+  | { mode: 'host'; secretsPath: string }
+  | { mode: 'container'; secretsPath: string; hostProvider: RuntimeSecretsProvider }
+
+const EMPTY_BLOCK: TeamsChannelBlock = { currentAccount: null, accounts: {} }
+
+export class SecretsTeamsCredentialStore {
+  private readonly backend: SecretsBackend
+  private writeChain: Promise<void> = Promise.resolve()
+
+  constructor(private readonly options: SecretsTeamsCredentialStoreOptions) {
+    this.backend = new SecretsBackend(options.secretsPath)
+  }
+
+  async getAccount(id?: string): Promise<TeamsAccountRecord | null> {
+    const block = this.readBlock()
+    const accountId = id ?? block.currentAccount
+    if (!accountId) return null
+    return block.accounts[accountId] ?? null
+  }
+
+  async setAccount(account: SetTeamsAccountInput): Promise<void> {
+    await this.writeBlock((block) => {
+      const merged = mergeAccountPreservingRefreshFields(account, block.accounts[account.account_id])
+      const accounts = { ...block.accounts, [account.account_id]: merged }
+      return { ...block, currentAccount: block.currentAccount ?? account.account_id, accounts }
+    })
+  }
+
+  async removeAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => {
+      const accounts = { ...block.accounts }
+      delete accounts[id]
+      const currentAccount = block.currentAccount === id ? (Object.keys(accounts)[0] ?? null) : block.currentAccount
+      return { ...block, currentAccount, accounts }
+    })
+  }
+
+  async listAccounts(): Promise<Array<TeamsAccountRecord & { is_current: boolean }>> {
+    const block = this.readBlock()
+    return Object.values(block.accounts).map((account) => ({
+      ...account,
+      is_current: account.account_id === block.currentAccount,
+    }))
+  }
+
+  async setCurrentAccount(id: string): Promise<void> {
+    await this.writeBlock((block) => ({ ...block, currentAccount: id }))
+  }
+
+  private readBlock(): TeamsChannelBlock {
+    const channels =
+      this.options.mode === 'container' ? this.options.hostProvider.readChannels() : this.backend.readChannelsSync()
+    return parseBlock(channels?.teams)
+  }
+
+  private async writeBlock(update: (current: TeamsChannelBlock) => TeamsChannelBlock): Promise<void> {
+    return this.enqueueWrite(async () => {
+      if (this.options.mode === 'container') {
+        const next = update(this.readBlock())
+        await this.options.hostProvider.writeBackChannelBlock({ teams: next })
+        return
+      }
+
+      await this.backend.updateChannelsAsync(async (channels) => {
+        const next = { ...channels, teams: update(parseBlock(channels.teams)) }
+        return { result: undefined, next }
+      })
+    })
+  }
+
+  private enqueueWrite(op: () => Promise<void>): Promise<void> {
+    const next = this.writeChain.then(op, op)
+    this.writeChain = next.catch(() => {})
+    return next
+  }
+}
+
+function parseBlock(value: unknown): TeamsChannelBlock {
+  if (value === undefined) return EMPTY_BLOCK
+  return teamsChannelBlockSchema.parse(value)
+}
+
+// A silent-refresh write (new access token from the stored refresh token)
+// carries only the freshly minted access fields; the AAD refresh trio it was
+// minted from must survive so the NEXT refresh still has something to spend.
+function mergeAccountPreservingRefreshFields(
+  incoming: SetTeamsAccountInput,
+  priorOnDisk: TeamsChannelBlock['accounts'][string] | undefined,
+): TeamsAccountRecord {
+  const merged: TeamsAccountRecord = { ...incoming }
+  if (incoming.aad_refresh_token === undefined && priorOnDisk?.aad_refresh_token !== undefined) {
+    merged.aad_refresh_token = priorOnDisk.aad_refresh_token
+  }
+  if (incoming.aad_client_id === undefined && priorOnDisk?.aad_client_id !== undefined) {
+    merged.aad_client_id = priorOnDisk.aad_client_id
+  }
+  if (incoming.aad_tenant_id === undefined && priorOnDisk?.aad_tenant_id !== undefined) {
+    merged.aad_tenant_id = priorOnDisk.aad_tenant_id
+  }
+  return merged
+}


### PR DESCRIPTION
## Background

`agent-messenger` recently grew real Microsoft Teams support (v2.29.0: a `TeamsListener` trouter WebSocket, chat send/read, device-code auth), but TypeClaw had no Teams channel adapter — Teams was absent from `ADAPTER_IDS` and every downstream map. This adds a Teams adapter so the agent can live in Teams chats, built on the same `agent-messenger` SDK as every other non-GitHub adapter.

Teams is deliberately scoped to **chats** (1:1, group, self) for v1. The realtime event the SDK emits carries only a `chatId` — never a `teamId`/`channelId` — so Teams *team/channel* messaging cannot be routed or replied to reliably and is out of scope. The adapter mirrors the `webex` user-account adapter (user-token auth, listener + classifier, `secrets.json#channels.teams` credential store).

## Summary

The interesting decisions are all forced by the SDK's *runtime* behavior (which differs from its `.d.ts` surface — verified by reading the compiled SDK):

- **Self-echo suppression without a self id.** `TeamsClient.testAuth()` returns the literal id `"ME"`, while realtime/history authors carry real MRIs, so an id comparison can never recognize the agent's own message coming back over the socket. Instead every successful send records a `(chatId, normalized-text)` fingerprint; an inbound matching a recent fingerprint is dropped. Without this the bot replies to itself forever.
- **Alias-only group engagement, fail-closed.** The listener strips all HTML (including `<at id>` mention tags) *before* emitting, so structured `@mention` detection is impossible from a realtime event. Group chats therefore engage only on plain-text alias addressing; an un-aliased group message is marked `suppressSticky` + `mentionsOthers` so neither the sticky-credit path nor the solo-human fallback makes the agent barge in. DMs still engage via the `dm` trigger.
- **Await the async `connected` event.** `listener.start()` does not synchronously signal connection — `connected` fires later after endpoint registration — so `start()` awaits a `connected | error | timeout(20s)` race and rolls back every registration on failure.
- **Credentials** load from `secrets.json#channels.teams` via a container `SecretsTeamsCredentialStore` (same shape as webex). A startup warning fires when the access token is near/at expiry.

Why alias mention-mode (not `angle-id`)? Teams outbound is plain text and the model cannot emit the `<at id="29:…">` HTML form, so alias substring matching is the only workable addressing path — same as LINE/KakaoTalk.

## What this does NOT do

- **No Teams team/channel messaging** — chat-only. Channel routing needs a `teamId`/`channelId` the realtime event never provides.
- **No structured `@mention` detection** — the SDK strips mention HTML before the adapter sees it; group addressing is alias-only.
- **No long-lived token refresh** — the access token expires in ~60–90 min; the persisted AAD refresh trio is stored but not yet used to re-mint. Long-running sessions stop until credentials are refreshed (startup warns).
- **No interactive `channel add`** — Teams is excluded from the picker until device-code auth is wired; populate `secrets.json#channels.teams` manually for now.
- **No typing, reactions, attachments, membership resolver, or channel-name resolver** — logs/prompts show raw `chat:19:…` ids.

## Review notes

- Load-bearing invariant: **the self-echo ledger must never let the agent's own send route back as inbound.** See `isSelfEcho`/`recordSent` in `src/channels/adapters/teams.ts` and the echo tests in `teams.test.ts` (content-only 5s window vs self-name 2min window). The `escapeHtml`(send) → `stripHtml`(receive) round-trip makes the content match reliable for normal text.
- The other fail-safe is group engagement: `classifyInbound` sets `suppressSticky: !isDm && !isBotMention` so a prior alias-triggered turn cannot keep the agent engaged on later unaddressed group messages.
- `teams: ['history']` in `ADAPTER_READ_CAPABILITIES` is guarded by `schema.test.ts`, which source-greps the adapter for `registerHistory` — it registers exactly outbound/selfIdentity/history.
- Tests use SDK-shaped fixtures (already-plain content, `id: 'ME'` self) and include a non-Latin (Korean) alias case per the repo's multi-language rule.

Design and both review passes were done with the Oracle consult; all runtime blockers it found are fixed.
