### PR TITLE
fix(channels): require resolve_review_thread choice on github sends

### DIFF
--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -238,10 +238,15 @@ describe('channel_send resolve_review_thread', () => {
     expect((result.details as { error: string }).error).toContain('only supported on github')
   })
 
-  test('does not resolve when the flag is unset', async () => {
+  test('denies a thread text send that omits the resolve choice, resolving nothing', async () => {
     let resolved = 0
+    let sent = 0
     const tool = createChannelSendTool({
       router: fakeRouter({
+        onSend: () => {
+          sent++
+          return { ok: true }
+        },
         onResolve: () => {
           resolved++
           return { ok: true }
@@ -259,6 +264,39 @@ describe('channel_send resolve_review_thread', () => {
     })
 
     expect(resolved).toBe(0)
+    expect(sent).toBe(0)
+    expect((result.details as { ok: boolean }).ok).toBe(false)
+    expect((result.details as { error: string }).error).toContain('resolve_review_thread')
+  })
+
+  test('does not resolve when the flag is an explicit false (thread kept open)', async () => {
+    let resolved = 0
+    let sent = 0
+    const tool = createChannelSendTool({
+      router: fakeRouter({
+        onSend: () => {
+          sent++
+          return { ok: true }
+        },
+        onResolve: () => {
+          resolved++
+          return { ok: true }
+        },
+      }),
+      sessionId: SESSION,
+    })
+
+    const result = await run(tool, {
+      adapter: 'github',
+      workspace: 'acme/widgets',
+      chat: 'pr:12',
+      thread: '555',
+      text: 'just a comment, keeping open',
+      resolve_review_thread: false,
+    })
+
+    expect(resolved).toBe(0)
+    expect(sent).toBe(1)
     expect((result.details as { ok: boolean }).ok).toBe(true)
   })
 })

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -680,4 +680,164 @@ describe('createChannelSendTool', () => {
       expect(text).toContain('Send-cap reached')
     })
   })
+
+  describe('channel_send resolve_review_thread required-choice enforcement', () => {
+    test('denies a github PR review-thread text send that omits the resolve choice', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'github',
+        workspace: 'acme/widgets',
+        chat: 'pr:585',
+        thread: 'RC_kwABC',
+        text: 'okay I checked, it is addressed.',
+      })
+
+      expect(calls).toHaveLength(0)
+      expect(result.details).toMatchObject({ ok: false })
+      expect((result.details as { error: string }).error).toContain('resolve_review_thread')
+      const rendered = (result.content[0] as { text: string }).text
+      expect(rendered).toContain('channel_send denied')
+      expect(rendered).not.toContain('posted to')
+    })
+
+    test('denies a non-English (Korean) close-out send that omits the resolve choice', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'github',
+        workspace: 'acme/widgets',
+        chat: 'pr:585',
+        thread: 'RC_kwABC',
+        text: '확인했고 반영됐어요.',
+      })
+
+      expect(calls).toHaveLength(0)
+      expect((result.details as { error: string }).error).toContain('resolve_review_thread')
+    })
+
+    test('proceeds when the resolve choice is an explicit false (thread kept open)', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'github',
+        workspace: 'acme/widgets',
+        chat: 'pr:585',
+        thread: 'RC_kwABC',
+        text: 'Still looking into this one.',
+        resolve_review_thread: false,
+      })
+
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+
+    test('exempts an attachments-only github review-thread send (no text to acknowledge)', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'github',
+        workspace: 'acme/widgets',
+        chat: 'pr:585',
+        thread: 'RC_kwABC',
+        attachments: [{ path: '/agent/diff.png' }],
+      })
+
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+
+    test('does not require the choice on a github PR send outside a review thread (no thread)', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'github',
+        workspace: 'acme/widgets',
+        chat: 'pr:585',
+        text: 'General note on the PR.',
+      })
+
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+
+    test('does not require the choice on a non-github thread send', async () => {
+      const calls: OutboundMessage[] = []
+      const tool = createChannelSendTool({
+        router: fakeRouter(async (msg) => {
+          calls.push(msg)
+          return { ok: true }
+        }),
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'slack-bot',
+        workspace: 'T0',
+        chat: 'C0',
+        thread: '1700.0001',
+        text: 'done',
+      })
+
+      expect(calls).toHaveLength(1)
+      expect(result.details).toEqual({ ok: true })
+    })
+
+    test('an explicit true still drives the resolve-before-post path', async () => {
+      const order: string[] = []
+      const tool = createChannelSendTool({
+        router: {
+          ...fakeRouter(async () => {
+            order.push('send')
+            return { ok: true }
+          }),
+          resolveReviewThread: async (req) => {
+            order.push(`resolve:${req.rootCommentId}`)
+            return { ok: true }
+          },
+        },
+      })
+
+      const result = await runTool(tool, {
+        adapter: 'github',
+        workspace: 'acme/widgets',
+        chat: 'pr:585',
+        thread: 'RC_kwABC',
+        text: 'Verified — fix looks solid.',
+        resolve_review_thread: true,
+      })
+
+      expect(result.details).toEqual({ ok: true })
+      expect(order).toEqual(['resolve:RC_kwABC', 'send'])
+    })
+  })
 })

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -116,7 +116,8 @@ export function createChannelSendTool({
             'GitHub review threads ONLY — ignored on every other adapter and on a github send that has no `thread`. ' +
             'Set `true` to close out a review thread you authored once you have confirmed the new commits address your concern: pass the thread\'s root comment id as `thread`, an acknowledgement (e.g. "addressed in <sha> — resolving") as `text`, and this flag. ' +
             'This is the post-push close-out path: a `pull_request.synchronize` recheck lists your unresolved threads, and you call this once per addressed thread. ' +
-            "Safe by default — the runtime resolves BEFORE posting and ONLY if the thread's root comment is yours, refusing (and blocking the send) on a human reviewer's thread. Leave it unset to keep the thread open (not addressed, partial fix, disagreement).",
+            "Safe by default — the runtime resolves BEFORE posting and ONLY if the thread's root comment is yours, refusing (and blocking the send) on a human reviewer's thread. " +
+            'REQUIRED on a github PR review-thread send that has both a `thread` and `text`: pass `false` to post your reply while keeping the thread open (not addressed, partial fix, disagreement) — omitting it there is denied. Outside that scope (no `thread`, no `text`, or a non-github adapter) it may be left unset.',
         }),
       ),
     }),
@@ -159,6 +160,28 @@ export function createChannelSendTool({
         return {
           content: [{ type: 'text' as const, text: `channel_send denied: ${kimiLeakError}` }],
           details: { ok: false, error: kimiLeakError },
+        }
+      }
+
+      // Required-choice guard (mirrors channel_reply): a github PR review-thread
+      // send with text must make an explicit resolve_review_thread choice. The
+      // `pull_request.synchronize` recheck routes the post-push close-out HERE
+      // via channel_send, and the model kept acknowledging "addressed" without
+      // the flag, stranding the thread — channel_reply forced the choice but
+      // channel_send did not, so the most-used resolve path was the least
+      // guarded. A send is always terminal, so there is no continue exemption.
+      const missingResolveChoice = missingReviewThreadResolveChoiceError({
+        adapter,
+        chat: params.chat,
+        thread: params.thread ?? null,
+        text: bodyText,
+        resolveReviewThread: params.resolve_review_thread,
+      })
+      if (missingResolveChoice) {
+        logger.warn(formatChannelToolFailure('channel_send', missingResolveChoice))
+        return {
+          content: [{ type: 'text' as const, text: `channel_send denied: ${missingResolveChoice}` }],
+          details: { ok: false, error: missingResolveChoice },
         }
       }
 
@@ -286,6 +309,26 @@ export function createChannelSendTool({
       }
     },
   })
+}
+
+function missingReviewThreadResolveChoiceError(input: {
+  adapter: AdapterId
+  chat: string
+  thread: string | null
+  text: string | undefined
+  resolveReviewThread: boolean | undefined
+}): string {
+  const isGithubPrReviewThread = input.adapter === 'github' && /^pr:\d+$/.test(input.chat) && input.thread !== null
+  const hasText = input.text !== undefined && input.text.trim() !== ''
+  if (!isGithubPrReviewThread || !hasText || input.resolveReviewThread !== undefined) {
+    return ''
+  }
+  return (
+    'This is a github PR review-thread send with text, so `resolve_review_thread` is required: ' +
+    'set it to `true` when the concern is fixed and this bot-authored thread should be closed (the runtime ' +
+    'resolves before posting and only on your own thread), or `false` to leave it open. You omitted it; ' +
+    're-call channel_send with an explicit boolean.'
+  )
 }
 
 async function resolveReviewThreadBeforeSend(


### PR DESCRIPTION
## Background

On GitHub PRs, the agent reliably acknowledges that a review comment was addressed ("okay I checked, it's addressed") but leaves the thread **open**, leaving a wall of unresolved threads on the PR.

Root cause: there are two write paths for a review-thread close-out, and only one was guarded.

- `channel_reply` has a **required-choice guard** (`missingReviewThreadResolveChoiceError`): a terminal github review-thread text reply that omits `resolve_review_thread` is denied, forcing the model to pass an explicit `true`/`false`.
- `channel_send` had the false-receipt and re-review guards but **no required-choice guard** — `resolve_review_thread` was optional.

The problem is that the post-push recovery path routes through the *unguarded* tool: on `pull_request.synchronize`, `inbound.ts` lists the bot's unresolved threads and instructs the agent to reply "via `channel_send` with `resolve_review_thread: true`". When the model sends an ack without the flag, the false-receipt classifier scores a casual "it's addressed" as `warn` (not `block-resolve`), so the send posts with a soft notice and the thread stays open. The most-used resolve path was the least guarded.

## Summary

Mirror the `channel_reply` required-choice guard onto `channel_send`. A github PR review-thread send (`adapter === 'github'`, `chat` matches `^pr:\d+$`, `thread !== null`) that carries text must pass an explicit `resolve_review_thread` boolean; omitting it is denied and the model re-calls.

Key decisions:
- **Guard runs before** the false-receipt / re-review / resolve logic, so a missing choice never posts a message or mutates a thread.
- **No `continue` exemption** (unlike `channel_reply`): a `channel_send` is always terminal — it already passes `isContinue: false` to the existing guards — so there is no mid-turn status case to exempt.
- **Scope matches `channel_reply` exactly** (`^pr:\d+$` + `thread !== null`), so top-level PR comments (no thread) and non-github sends are untouched — the flag is a no-op there.

This is fix #1 of the diagnosis; it does not change any claim-classification semantics.

## What this does NOT do

- Does not auto-resolve threads. It forces an explicit choice; the model still decides `true` vs `false`. Auto-resolving on close-out-shaped text risks closing threads intended to stay open (partial fix, disagreement).
- Does not touch the `warn`→`block` escalation in `github-false-receipt.ts` (proposed fix #2, deferred).
- Does not affect top-level PR comments or non-github adapters.

## Review notes

- Load-bearing change: `missingReviewThreadResolveChoiceError` in `src/agent/tools/channel-send.ts` and its call site placed **before** `checkFalseReceipt`.
- Invariant to verify: a github `pr:N` send with a `thread` and text but no `resolve_review_thread` is denied with `ok: false`, and neither `router.send` nor `router.resolveReviewThread` is invoked.
- One existing test in `channel-send.resolve.test.ts` ("does not resolve when the flag is unset") asserted the old behavior (unset flag on a thread text send silently succeeds). That contract is now invalid — updated to assert the send is denied, plus a new test for the explicit-`false` "keep open" path.
- Per the repo multi-language rule, added a Korean close-out case ("확인했고 반영됐어요.") asserting the guard fires regardless of language — it keys on text presence, not phrase matching.