### PR TITLE
fix(channels): suppress the empty-turn fallback after a github review lands

### DIFF
--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -68,6 +68,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     getSelfAliases: () => [],
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-react.test.ts
+++ b/src/agent/tools/channel-react.test.ts
@@ -50,6 +50,7 @@ function fakeRouter(queueReactionAfterReply: (req: ReactionRequest) => Promise<R
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     resumeRestartHandoff: async () => {},
   } as unknown as ChannelRouter

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -65,6 +65,7 @@ function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: 
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -73,6 +73,7 @@ function fakeRouter(
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -74,6 +74,7 @@ function fakeRouter(handlers: {
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -63,6 +63,7 @@ function fakeRouter(
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -91,6 +91,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -68,6 +68,7 @@ function fakeRouter(
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: (args) => {
       opts.markCalls?.push({ parentSessionId: args.parentSessionId, reason: args.reason })
       return opts.markResult ?? { kind: 'recorded', keyId: 'discord-bot:g1:c1' }

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { detectReviewSubmission, detectReviewSubmissionAttempt } from './gh-review-detect'
+import { detectReviewOutput, detectReviewSubmission, detectReviewSubmissionAttempt } from './gh-review-detect'
 
 describe('detectReviewSubmission — REST --input', () => {
   test('APPROVE in the input file is detected', () => {
@@ -189,5 +189,43 @@ describe('detectReviewSubmissionAttempt — submission intent, verdict aside', (
 
   test('a non-reviews POST is NOT an attempt', () => {
     expect(detectReviewSubmissionAttempt('gh api -X POST /repos/acme/widgets/issues/12/comments -f body=hi')).toBeNull()
+  })
+})
+
+describe('detectReviewOutput — includes COMMENT', () => {
+  test('a COMMENT review via input file is detected as output', () => {
+    const result = detectReviewOutput({
+      command: 'gh api -X POST /repos/acme/widgets/pulls/7/reviews --input /tmp/r.json',
+      inputFileContents: '{"event":"COMMENT","body":"a few notes"}',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 7, state: 'COMMENT', source: 'api' })
+  })
+
+  test('a COMMENT review via -f event=COMMENT is detected as output', () => {
+    const result = detectReviewOutput({
+      command: 'gh api /repos/acme/widgets/pulls/3/reviews -f event=COMMENT -f body=notes',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 3, state: 'COMMENT', source: 'api' })
+  })
+
+  test('gh pr review --comment is detected as output', () => {
+    const result = detectReviewOutput({
+      command: 'gh pr review 42 --comment --body "some notes" -R acme/widgets',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 42, state: 'COMMENT', source: 'pr-review' })
+  })
+
+  test('a decisive verdict is still surfaced as output', () => {
+    const result = detectReviewOutput({
+      command: 'gh api /repos/acme/widgets/pulls/3/reviews -f event=APPROVE',
+    })
+    expect(result).toEqual({ workspace: 'acme/widgets', prNumber: 3, state: 'APPROVE', source: 'api' })
+  })
+
+  test('a bare create-review with no event (PENDING draft) is not output', () => {
+    const result = detectReviewOutput({
+      command: 'gh api -X POST /repos/acme/widgets/pulls/7/reviews -f body=draft',
+    })
+    expect(result).toBeNull()
   })
 })

--- a/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
+++ b/src/bundled-plugins/github-cli-auth/gh-review-detect.ts
@@ -1,4 +1,4 @@
-import type { ReviewVerdict } from '@/channels/github-review-turn-ledger'
+import type { ReviewOutputState, ReviewVerdict } from '@/channels/github-review-turn-ledger'
 
 // Extracts the formal-review verdict a successful `gh` command landed, so the
 // false-receipt ledger can credit it. Covers the three vectors the agent uses to
@@ -46,6 +46,106 @@ export function detectReviewSubmission(input: GhReviewDetectInput): DetectedRevi
     const detected = detectInGhSegment(segment, fileContents)
     if (detected !== null) return detected
   }
+  return null
+}
+
+// A landed review of ANY state — the two decisive verdicts PLUS a COMMENT. Feeds
+// the router's empty-turn guard (a COMMENT is real user-facing output, so an empty
+// completion afterward must not fire the "I got stuck" fallback). Deliberately
+// SEPARATE from detectReviewSubmission, which stays verdict-only for the
+// false-receipt ledger: a COMMENT carries no verdict-claim risk and must never be
+// credited there. A bare create-review with no event (a PENDING draft, not a
+// submitted review) returns null — only a submitted state counts as output.
+export type DetectedReviewOutput = {
+  workspace: string
+  prNumber: number
+  state: ReviewOutputState
+  source: 'api' | 'pr-review'
+}
+
+export function detectReviewOutput(input: GhReviewDetectInput): DetectedReviewOutput | null {
+  const fileContents = input.inputFileContents ?? null
+  for (const args of ghSegments(input.command)) {
+    const sub = args[1]
+    if (sub === 'api') {
+      const out = detectApiReviewOutput(args, fileContents)
+      if (out !== null) return out
+    } else if (sub === 'pr' && args[2] === 'review') {
+      const out = detectPrReviewOutput(args)
+      if (out !== null) return out
+    }
+  }
+  return null
+}
+
+function detectApiReviewOutput(args: readonly string[], fileContents: string | null): DetectedReviewOutput | null {
+  const endpoint = args.find((a) => REVIEWS_ENDPOINT.test(a))
+  if (endpoint === undefined) return null
+  const m = REVIEWS_ENDPOINT.exec(endpoint)
+  if (m === null) return null
+  const prNumber = Number(m[3])
+  if (!Number.isSafeInteger(prNumber)) return null
+  const state = reviewStateFromInlineFields(args) ?? reviewStateFromFile(fileContents)
+  if (state === null) return null
+  return { workspace: `${m[1]}/${m[2]}`, prNumber, state, source: 'api' }
+}
+
+function detectPrReviewOutput(args: readonly string[]): DetectedReviewOutput | null {
+  const state: ReviewOutputState | null = args.includes('--approve')
+    ? 'APPROVE'
+    : args.includes('--request-changes')
+      ? 'REQUEST_CHANGES'
+      : args.includes('--comment') || args.includes('-c')
+        ? 'COMMENT'
+        : null
+  if (state === null) return null
+  const workspace = repoFromFlag(args)
+  const prNumber = prNumberArg(args)
+  if (workspace === null || prNumber === null) return null
+  return { workspace, prNumber, state, source: 'pr-review' }
+}
+
+function reviewStateFromInlineFields(args: readonly string[]): ReviewOutputState | null {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === undefined) continue
+    if (a === '-f' || a === '-F' || a === '--field' || a === '--raw-field') {
+      const v = parseEventState(args[i + 1])
+      if (v !== null) return v
+    }
+    if (a.startsWith('-f=') || a.startsWith('-F=') || a.startsWith('--field=') || a.startsWith('--raw-field=')) {
+      const v = parseEventState(a.slice(a.indexOf('=') + 1))
+      if (v !== null) return v
+    }
+  }
+  return null
+}
+
+function parseEventState(token: string | undefined): ReviewOutputState | null {
+  if (token === undefined) return null
+  const eq = token.indexOf('=')
+  if (eq === -1) return null
+  if (token.slice(0, eq).trim().toLowerCase() !== 'event') return null
+  return normalizeReviewState(token.slice(eq + 1))
+}
+
+function reviewStateFromFile(contents: string | null): ReviewOutputState | null {
+  if (contents === null || contents === '') return null
+  try {
+    const parsed = JSON.parse(contents) as unknown
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const event = (parsed as Record<string, unknown>).event
+    return typeof event === 'string' ? normalizeReviewState(event) : null
+  } catch {
+    return null
+  }
+}
+
+function normalizeReviewState(value: string): ReviewOutputState | null {
+  const v = value.trim().toUpperCase()
+  if (v === 'APPROVE') return 'APPROVE'
+  if (v === 'REQUEST_CHANGES') return 'REQUEST_CHANGES'
+  if (v === 'COMMENT') return 'COMMENT'
   return null
 }
 

--- a/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.test.ts
@@ -3,7 +3,13 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { hasReview, resetReviewTurn } from '@/channels/github-review-turn-ledger'
+import {
+  __resetReviewObserverForTest,
+  hasReview,
+  resetReviewTurn,
+  type ReviewOutputState,
+  setReviewOutputObserver,
+} from '@/channels/github-review-turn-ledger'
 import type { ToolResult } from '@/plugin'
 
 import { __resetReviewVerdictGuardForTest, createApproveIdempotencyGuard } from './approve-idempotency'
@@ -15,6 +21,7 @@ const WS = 'acme/widgets'
 afterEach(() => {
   resetReviewTurn(SESSION)
   __resetReviewVerdictGuardForTest()
+  __resetReviewObserverForTest()
 })
 
 function textResult(text: string): ToolResult {
@@ -234,6 +241,60 @@ describe('review recorder', () => {
       // GitHub's reviews read still lags (NONE)
       const dup = await guard.guard({ callId: 'i2', workspace: WS, prNumber: 90, verdict: 'APPROVE' })
       expect(dup?.block).toBe(true)
+    })
+  })
+
+  describe('COMMENT review output', () => {
+    function captureOutput(): ReviewOutputState[] {
+      const states: ReviewOutputState[] = []
+      setReviewOutputObserver((args) => states.push(args.state))
+      return states
+    }
+
+    test('credits review output (not the verdict ledger) for a successful COMMENT', async () => {
+      const states = captureOutput()
+      await noteReviewCommand({
+        callId: 'cm1',
+        command: `gh api -X POST /repos/${WS}/pulls/91/reviews -f event=COMMENT -f body=notes`,
+      })
+      const out = `{"state":"COMMENTED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/91"}`
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'cm1', result: textResult(out) })
+
+      // the output observer sees the COMMENT, but it never enters the verdict ledger
+      expect(states).toEqual(['COMMENT'])
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 91, verdict: 'APPROVE' })).toBe(false)
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 91, verdict: 'REQUEST_CHANGES' })).toBe(false)
+    })
+
+    test('a POST COMMENT does not leave a stale submission-attempt entry behind', async () => {
+      captureOutput()
+      // given: a COMMENT POST that succeeds — this is also a POST to the reviews
+      // endpoint, so the OLD code armed the backstop attempt AND returned early,
+      // never clearing it
+      await noteReviewCommand({
+        callId: 'cm2',
+        command: `gh api -X POST /repos/${WS}/pulls/92/reviews -f event=COMMENT -f body=notes`,
+      })
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'cm2', result: textResult('{"state":"COMMENTED"}') })
+
+      // when: a later commit reuses the same callId with a decisive-verdict response,
+      // a stale attempt would let the backstop credit a verdict that no command posted
+      const landed = `{"state":"APPROVED","pull_request_url":"https://api.github.com/repos/${WS}/pulls/92"}`
+      const result = commitReviewIfSucceeded({ sessionId: SESSION, callId: 'cm2', result: textResult(landed) })
+
+      // then: no stale attempt remained, so nothing is credited
+      expect(result.committed).toBe(false)
+      expect(hasReview({ sessionId: SESSION, workspace: WS, prNumber: 92, verdict: 'APPROVE' })).toBe(false)
+    })
+
+    test('does NOT credit output when the COMMENT command failed (fail closed)', async () => {
+      const states = captureOutput()
+      await noteReviewCommand({
+        callId: 'cm3',
+        command: `gh api -X POST /repos/${WS}/pulls/93/reviews -f event=COMMENT -f body=notes`,
+      })
+      commitReviewIfSucceeded({ sessionId: SESSION, callId: 'cm3', result: textResult(FAILURE_OUTPUT) })
+      expect(states).toEqual([])
     })
   })
 })

--- a/src/bundled-plugins/github-cli-auth/review-recorder.ts
+++ b/src/bundled-plugins/github-cli-auth/review-recorder.ts
@@ -1,12 +1,14 @@
 import { readFile } from 'node:fs/promises'
 
-import { recordReview } from '@/channels/github-review-turn-ledger'
+import { recordReview, recordReviewOutput } from '@/channels/github-review-turn-ledger'
 import type { ContentPart, ToolResult } from '@/plugin'
 
 import {
+  detectReviewOutput,
   detectReviewSubmission,
   detectReviewSubmissionAttempt,
   type DetectedReview,
+  type DetectedReviewOutput,
   type ReviewSubmissionAttempt,
 } from './gh-review-detect'
 import { detectReviewDump, type ReviewDumpDecision } from './gh-review-inline-detect'
@@ -29,6 +31,10 @@ import { detectReviewDump, type ReviewDumpDecision } from './gh-review-inline-de
 
 const pending = new Map<string, DetectedReview>()
 const submissionAttempts = new Map<string, ReviewSubmissionAttempt>()
+// COMMENT-only submissions, stashed apart from `pending`: a decisive verdict is
+// credited to the false-receipt ledger via recordReview (which also fans to the
+// output observer), so only non-verdict COMMENTs need their own output credit.
+const pendingCommentOutput = new Map<string, DetectedReviewOutput>()
 
 const MAX_INPUT_BYTES = 1_000_000
 
@@ -45,8 +51,19 @@ export async function noteReviewCommand(args: { callId: string; command: string 
   // missed shape): only such a command may later arm the backstop, so a reviews
   // READ — which is not an attempt — can never be miscredited as a landed review.
   else {
-    const attempt = detectReviewSubmissionAttempt(args.command)
-    if (attempt !== null) submissionAttempts.set(args.callId, attempt)
+    // A COMMENT review carries no verdict, so it dodges `pending` above — stash it
+    // here so a successful COMMENT still credits review OUTPUT (not the verdict
+    // ledger) and suppresses the router's empty-turn fallback. It is stashed
+    // INSTEAD of a submission attempt: the backstop only ever credits a decisive
+    // verdict, so arming it for a COMMENT would just leave a stale attempt entry
+    // that `commitReviewIfSucceeded`'s COMMENT branch returns before clearing.
+    const output = detectReviewOutput({ command: args.command, inputFileContents })
+    if (output !== null && output.state === 'COMMENT') {
+      pendingCommentOutput.set(args.callId, output)
+    } else {
+      const attempt = detectReviewSubmissionAttempt(args.command)
+      if (attempt !== null) submissionAttempts.set(args.callId, attempt)
+    }
   }
   return { dump: detectReviewDump({ command: args.command, inputFileContents }), detected }
 }
@@ -77,6 +94,22 @@ export function commitReviewIfSucceeded(args: {
       verdict: detected.verdict,
     })
     return { committed: true, landedFromResult: null }
+  }
+
+  // A COMMENT review credits review OUTPUT only (never the verdict ledger). Same
+  // fail-closed success bias as verdicts: an ambiguous result stays uncredited.
+  const comment = pendingCommentOutput.get(args.callId)
+  if (comment !== undefined) {
+    pendingCommentOutput.delete(args.callId)
+    if (commentReviewSucceeded(text)) {
+      recordReviewOutput({
+        sessionId: args.sessionId,
+        workspace: comment.workspace,
+        prNumber: comment.prNumber,
+        state: 'COMMENT',
+      })
+    }
+    return { committed: false, landedFromResult: null }
   }
 
   // The backstop runs ONLY for a command that tool.before saw as a real
@@ -177,7 +210,15 @@ const API_SUCCESS_MARKERS = [
   '"state": "APPROVED"',
 ]
 const PR_REVIEW_SUCCESS_MARKERS = ['Approved pull request', 'Requested changes to pull request']
+// COMMENT vectors: REST echoes `"state":"COMMENTED"`; the `gh pr review --comment`
+// porcelain prints "Reviewed pull request …". Covers both spacings of the JSON.
+const COMMENT_SUCCESS_MARKERS = ['"state":"COMMENTED"', '"state": "COMMENTED"', 'Reviewed pull request']
 const FAILURE_MARKERS = ['gh: ', 'HTTP 4', 'HTTP 5', 'Bad credentials', 'Not Found', 'Validation Failed']
+
+function commentReviewSucceeded(text: string): boolean {
+  if (FAILURE_MARKERS.some((m) => text.includes(m))) return false
+  return COMMENT_SUCCESS_MARKERS.some((m) => text.includes(m))
+}
 
 // Require a success marker AND no failure marker, so a partial/garbled capture
 // fails closed (uncredited).

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -82,6 +82,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),
     injectPrVerdictActivity: () => ({ kind: 'delivered', count: 0 }),
+    noteGithubReviewOutput: () => ({ kind: 'no-live-session' }),
     markTurnSkipped: () => ({ kind: 'no-live-session' }),
     clearSticky: () => ({ keyId: '', cleared: 0 }),
     reserveRestartHandoff: () => null,

--- a/src/channels/github-review-turn-ledger.test.ts
+++ b/src/channels/github-review-turn-ledger.test.ts
@@ -6,8 +6,10 @@ import {
   hasReview,
   recordResolvedThread,
   recordReview,
+  recordReviewOutput,
   resetReviewTurn,
   setReviewObserver,
+  setReviewOutputObserver,
 } from './github-review-turn-ledger'
 
 const S1 = 'ses_one'
@@ -79,6 +81,46 @@ describe('review observer', () => {
     const seen: unknown[] = []
     setReviewObserver((args) => seen.push(args))
     recordResolvedThread({ sessionId: S1, workspace: WS, prNumber: 12, rootCommentId: '555' })
+    expect(seen).toEqual([])
+  })
+})
+
+describe('review-output observer', () => {
+  test('a recorded verdict also fires the output observer with the same state', () => {
+    const seen: unknown[] = []
+    setReviewOutputObserver((args) => seen.push(args))
+    recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })
+    expect(seen).toEqual([{ sessionId: S1, workspace: WS, prNumber: 12, state: 'APPROVE' }])
+  })
+
+  test('recordReviewOutput COMMENT fires the output observer but not the verdict ledger', () => {
+    const output: unknown[] = []
+    const verdicts: unknown[] = []
+    setReviewOutputObserver((args) => output.push(args))
+    setReviewObserver((args) => verdicts.push(args))
+
+    recordReviewOutput({ sessionId: S1, workspace: WS, prNumber: 12, state: 'COMMENT' })
+
+    // given a COMMENT: the router-facing output signal fires
+    expect(output).toEqual([{ sessionId: S1, workspace: WS, prNumber: 12, state: 'COMMENT' }])
+    // but the false-receipt ledger is untouched — a COMMENT must never satisfy hasReview
+    expect(verdicts).toEqual([])
+    expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(false)
+  })
+
+  test('a thrown output observer never breaks the ledger record', () => {
+    setReviewOutputObserver(() => {
+      throw new Error('boom')
+    })
+    expect(() => recordReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).not.toThrow()
+    expect(hasReview({ sessionId: S1, workspace: WS, prNumber: 12, verdict: 'APPROVE' })).toBe(true)
+  })
+
+  test('__resetReviewObserverForTest detaches the output observer', () => {
+    const seen: unknown[] = []
+    setReviewOutputObserver((args) => seen.push(args))
+    __resetReviewObserverForTest()
+    recordReviewOutput({ sessionId: S1, workspace: WS, prNumber: 12, state: 'COMMENT' })
     expect(seen).toEqual([])
   })
 })

--- a/src/channels/github-review-turn-ledger.ts
+++ b/src/channels/github-review-turn-ledger.ts
@@ -15,6 +15,21 @@ export type ReviewObserver = (args: {
   verdict: ReviewVerdict
 }) => void
 
+// A formal review LANDED this turn, of ANY state — the two decisive verdicts PLUS
+// a non-decisive COMMENT. This signal ONLY tells the channel router "the agent
+// already delivered output via the GitHub review API this turn" so an empty
+// completion afterward doesn't fire the empty-turn fallback. It is deliberately
+// NOT stored in the false-receipt ledger (`reviewsByPr`): a COMMENT carries no
+// verdict-claim risk and must never satisfy `hasReview()`.
+export type ReviewOutputState = ReviewVerdict | 'COMMENT'
+
+export type ReviewOutputObserver = (args: {
+  sessionId: string
+  workspace: string
+  prNumber: number
+  state: ReviewOutputState
+}) => void
+
 type PrKey = string
 type ThreadKey = string
 
@@ -28,13 +43,19 @@ const resolvedThreads = new Set<ThreadKey>()
 // stays the single seam where "a formal verdict happened" is known across the
 // plugin/channels boundary, which is why it owns this hook.
 let reviewObserver: ReviewObserver | null = null
+let reviewOutputObserver: ReviewOutputObserver | null = null
 
 export function setReviewObserver(observer: ReviewObserver | null): void {
   reviewObserver = observer
 }
 
+export function setReviewOutputObserver(observer: ReviewOutputObserver | null): void {
+  reviewOutputObserver = observer
+}
+
 export function __resetReviewObserverForTest(): void {
   reviewObserver = null
+  reviewOutputObserver = null
 }
 
 function prKey(sessionId: string, workspace: string, prNumber: number): PrKey {
@@ -72,6 +93,28 @@ export function recordReview(args: {
     } catch {
       // swallow: a broken broadcast must not break verdict bookkeeping
     }
+  }
+  // A decisive verdict IS review output too — fan it to the output observer so the
+  // router's empty-turn guard sees it without a second detection path.
+  recordReviewOutput({
+    sessionId: args.sessionId,
+    workspace: args.workspace,
+    prNumber: args.prNumber,
+    state: args.verdict,
+  })
+}
+
+export function recordReviewOutput(args: {
+  sessionId: string
+  workspace: string
+  prNumber: number
+  state: ReviewOutputState
+}): void {
+  if (reviewOutputObserver === null) return
+  try {
+    reviewOutputObserver(args)
+  } catch {
+    // swallow: a broken router notification must not break review bookkeeping
   }
 }
 

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -20,7 +20,7 @@ export {
   type PrVerdictActivityBridge,
   type PrVerdictActivityBridgeOptions,
 } from './pr-verdict-activity-bridge'
-export { setReviewObserver } from './github-review-turn-ledger'
+export { setReviewObserver, setReviewOutputObserver, type ReviewOutputState } from './github-review-turn-ledger'
 export {
   createSubagentCompletionBridge,
   type SubagentCompletionBridge,

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -3280,6 +3280,126 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('no_reply'))).toBe(true)
   })
 
+  test('github review output: an APPROVE landed this turn suppresses the empty-turn fallback (no dead-air apology)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    const githubKey: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    router.registerOutbound('github', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', text: '@bot review' }))
+    let calls = 0
+    sessions[0]!.onPrompt = () => {
+      calls++
+      // given: the agent lands a formal APPROVE via the GitHub API (never a channel
+      // send), then whiffs empty completions on every attempt — the prod failure shape
+      if (calls === 1) {
+        router.noteGithubReviewOutput({
+          sessionId: 'ses_fake_1',
+          workspace: 'acme/repo',
+          prNumber: 672,
+          state: 'APPROVE',
+        })
+      }
+      emptyStopAfterToolWork(sessions[0]!)
+    }
+    await router.__testing!.flushDebounce(githubKey)
+
+    // then: the review IS the turn's output — no retries, no visible "I got stuck"
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_retry'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_suppressed cause=github_review_output_this_turn'))).toBe(true)
+  })
+
+  test('github review output: a COMMENT landed this turn also suppresses the empty-turn fallback', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    const githubKey: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    router.registerOutbound('github', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', text: '@bot review' }))
+    sessions[0]!.onPrompt = () => {
+      router.noteGithubReviewOutput({
+        sessionId: 'ses_fake_1',
+        workspace: 'acme/repo',
+        prNumber: 672,
+        state: 'COMMENT',
+      })
+      emptyStopAfterToolWork(sessions[0]!)
+    }
+    await router.__testing!.flushDebounce(githubKey)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+    expect(logs.some((m) => m.includes('empty_turn_suppressed cause=github_review_output_this_turn'))).toBe(true)
+  })
+
+  test('github review output: the review flag survives retries — landed in attempt 1, empty stops later still suppress', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    const githubKey: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    router.registerOutbound('github', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', text: '@bot review' }))
+    let calls = 0
+    sessions[0]!.onPrompt = () => {
+      calls++
+      // given: the verdict lands only on attempt 1; per the prod timeline the review
+      // is in an EARLIER iteration than the empty completions that follow
+      if (calls === 1) {
+        router.noteGithubReviewOutput({
+          sessionId: 'ses_fake_1',
+          workspace: 'acme/repo',
+          prNumber: 672,
+          state: 'APPROVE',
+        })
+      }
+      emptyStopAfterToolWork(sessions[0]!)
+    }
+    await router.__testing!.flushDebounce(githubKey)
+
+    // then: a single prompt, suppressed immediately — the flag isn't wiped by the
+    // per-iteration resetReviewTurn, so no retry loop and no fallback ever fire
+    expect(calls).toBe(1)
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('empty_turn_fallback'))).toBe(false)
+  })
+
+  test('github review output: an unrelated empty turn (no review landed) still posts the fallback', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    const githubKey: ChannelKey = { adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', thread: null }
+    router.registerOutbound('github', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ adapter: 'github', workspace: 'acme/repo', chat: 'pr:672', text: '@bot review' }))
+    sessions[0]!.onPrompt = () => emptyStopAfterToolWork(sessions[0]!)
+    await router.__testing!.flushDebounce(githubKey)
+
+    // then: with no review this turn the guard doesn't fire — the visible fallback stands
+    expect(sent.map((s) => s.text)).toEqual([EMPTY_TURN_FALLBACK_TEXT])
+    expect(logs.some((m) => m.includes('empty_turn_suppressed'))).toBe(false)
+  })
+
   test('suppresses recovery when assistant ends with NO_REPLY after leaked reasoning', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -44,7 +44,7 @@ import {
 } from './engagement'
 import { checkFalseReceipt } from './github-false-receipt'
 import { evaluateRereviewGuard } from './github-rereview-guard'
-import { resetReviewTurn } from './github-review-turn-ledger'
+import { resetReviewTurn, type ReviewOutputState } from './github-review-turn-ledger'
 import { renderPrVerdictStandDownReminder } from './github-verdict-activity'
 import {
   MEMBERSHIP_COLD_FETCH_TIMEOUT_MS,
@@ -185,7 +185,7 @@ export function disengageReactionEmojiFor(adapter: AdapterId): string {
   return DISENGAGE_REACTION_EMOJI_OVERRIDES[adapter] ?? DISENGAGE_REACTION_EMOJI
 }
 
-type SilentAckReason = 'skip_response' | 'no_reply' | 'skip_response_text_leak'
+type SilentAckReason = 'skip_response' | 'no_reply' | 'skip_response_text_leak' | 'github_review_output'
 
 // Wake nudge pushed into a resumed channel session at boot so drain() has a
 // non-empty batch and fires a turn. The substantive instruction the model acts
@@ -970,6 +970,19 @@ type LiveSession = {
   // question escalation. Compared by `turnSeq` so a stale value can't leak across
   // turns.
   emptyTurnFallbackTurn: number | null
+  // Stamped with `turnSeq` when a formal GitHub review (APPROVE / REQUEST_CHANGES /
+  // COMMENT) lands during this LOGICAL turn, via noteGithubReviewOutput off the
+  // review-output observer. On a github PR channel the agent's real deliverable is
+  // the review — posted through the GitHub API by the bash tool, NOT through
+  // channel_reply/channel_send — so it never bumps `successfulChannelSends`. An
+  // empty completion afterward would otherwise look like a dead turn and fire the
+  // "I got stuck" empty-turn fallback (a real verdict, then a contradictory fallback
+  // seconds later). validateChannelTurn reads this to treat such an empty stop as a
+  // legitimate silent completion. Reset ONLY on a real user batch (with the retry
+  // budgets) so it survives reminder-only retry iterations — the review lands in an
+  // EARLIER iteration than the fallback; resetting per-iteration (beside
+  // resetReviewTurn) would recreate the bug.
+  githubReviewOutputTurn: number | null
   // Captured by drain() at batch dequeue; read+cleared by send() on the
   // first tool-source send of the turn. The anchor decision (delay
   // threshold + intervening-observed check) is evaluated at SEND time
@@ -1224,6 +1237,12 @@ export type ChannelRouter = {
     verdict: 'APPROVE' | 'REQUEST_CHANGES'
     sessionId: string
   }) => { kind: 'delivered'; count: number }
+  noteGithubReviewOutput: (args: {
+    sessionId: string
+    workspace: string
+    prNumber: number
+    state: ReviewOutputState
+  }) => { kind: 'stamped' | 'no-live-session' }
   // Record that the agent invoked `skip_response` during the current turn
   // for the channel session identified by `parentSessionId`. The reason is
   // logged at INFO level inside `validateChannelTurn` (single log line per
@@ -2042,6 +2061,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         skipLockedSendTurn: null,
         disengagedTurn: null,
         emptyTurnFallbackTurn: null,
+        githubReviewOutputTurn: null,
         pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
@@ -2719,6 +2739,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.willingnessNudges = 0
           live.abortReasonThisTurn = null
           live.nextPromptMaxTokens = undefined
+          // Cleared with the retry budgets (NOT beside resetReviewTurn below) so a
+          // review landed earlier in this logical turn keeps suppressing the
+          // empty-turn fallback across the reminder-only retry iterations.
+          live.githubReviewOutputTurn = null
         } else if (live.lastTurnAuthorId !== null) {
           live.currentTurnEngageReactions = []
           // Reminder-only turn (batch.length === 0, reminders.length > 0):
@@ -4145,6 +4169,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       }
     }
 
+    // A formal GitHub review already landed this logical turn (APPROVE /
+    // REQUEST_CHANGES / COMMENT, stamped via noteGithubReviewOutput). That review IS
+    // the turn's user-facing output — it just went through the GitHub review API, not
+    // channel_reply/channel_send, so `successfulChannelSends` never moved. An empty
+    // completion afterward is the agent legitimately having nothing more to say, NOT
+    // a dead turn: skip the empty-turn retries AND the "I got stuck" fallback and
+    // treat it as silent completion. Gated on no channel send this turn so a turn
+    // that ALSO replied in-channel still runs the normal reply-recovery below.
+    if (
+      live.githubReviewOutputTurn === live.turnSeq &&
+      live.successfulChannelSends === successfulSendsBeforePrompt &&
+      live.currentTurnAuthorId !== null
+    ) {
+      logger.info(`[channels] ${live.keyId} empty_turn_suppressed cause=github_review_output_this_turn`)
+      armSilentTurnAck(live, 'github_review_output')
+      return
+    }
+
     // Suppress a leaked tool call (never post the plumbing) and, while budget
     // remains, push a self-correction reminder so the same logical turn
     // re-prompts and the model can redo it with a real tool call. On exhaustion
@@ -5060,6 +5102,30 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return { kind: 'delivered', count }
   }
 
+  // Stamp the review-output flag on the session that just landed a formal GitHub
+  // review this turn. Matched by sessionId (the recorder records the exact
+  // event.sessionId), and confirmed to be the right github PR live session so a
+  // stray/mismatched signal can't suppress an unrelated turn's fallback. See
+  // `githubReviewOutputTurn`.
+  const noteGithubReviewOutput = (args: {
+    sessionId: string
+    workspace: string
+    prNumber: number
+    state: ReviewOutputState
+  }): { kind: 'stamped' | 'no-live-session' } => {
+    const chat = `pr:${args.prNumber}`
+    for (const live of liveSessions.values()) {
+      if (live.destroyed) continue
+      if (live.sessionId !== args.sessionId) continue
+      if (live.key.adapter !== 'github') continue
+      if (live.key.workspace !== args.workspace || live.key.chat !== chat) continue
+      live.githubReviewOutputTurn = live.turnSeq
+      logger.info(`[channels] ${live.keyId}: github_review_output state=${args.state} turn=${live.turnSeq}`)
+      return { kind: 'stamped' }
+    }
+    return { kind: 'no-live-session' }
+  }
+
   const markTurnSkipped = (args: {
     parentSessionId: string
     reason: string
@@ -5208,6 +5274,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     getSelfAliases: computeSelfAliases,
     injectSubagentCompletionReminder,
     injectPrVerdictActivity,
+    noteGithubReviewOutput,
     markTurnSkipped,
     clearSticky,
     reserveRestartHandoff,

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -34,6 +34,7 @@ import {
   createPrVerdictActivityBridge,
   createSubagentCompletionBridge,
   setReviewObserver,
+  setReviewOutputObserver,
   type ChannelManager,
   type PrVerdictActivityBridge,
   type SubagentCompletionBridge,
@@ -782,6 +783,15 @@ async function startAgentRuntime(
     })
   })
   registerBootCleanup(() => setReviewObserver(null))
+
+  // A landed review of ANY state (incl. COMMENT) marks the recording session so its
+  // empty-turn fallback is suppressed: the review IS the turn's output, but it goes
+  // through the GitHub API, not the channel send path. In-process router call — no
+  // stream fan-out, since this is the recording session's own bookkeeping.
+  setReviewOutputObserver((output) => {
+    channelManager.router.noteGithubReviewOutput(output)
+  })
+  registerBootCleanup(() => setReviewOutputObserver(null))
 
   // Registered before channels so its cache clear lands before any channel
   // session teardown observes it. secrets.json provider credentials are not


### PR DESCRIPTION
## Background

A github PR review turn posted the visible empty-turn fallback — `⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?` — as a PR comment **seconds after the agent had already posted a real, correct review**, contradicting itself to the user.

Production timeline for one occurrence (`github:<repo>:pr:NNNN`):

| time (UTC) | event |
| --- | --- |
| 08:06:56 | agent submits a real **APPROVED** review |
| 08:07:38 | `empty_turn_retry attempt=2/2 cause=empty_stop_after_tool_work` |
| 08:08:03 | agent submits a real **COMMENTED** review |
| **08:08:13** | `empty_turn_fallback cause=empty_stop_after_tool_work_retries_exhausted` → posts "I got stuck…" |

Root cause: on a github PR channel the agent's real deliverable is a formal review submitted through the GitHub review API (`gh pr review` / `gh api .../reviews`), posted by the **bash tool** — not through `channel_reply` / `channel_send`. So it never increments `successfulChannelSends`, the counter the empty-turn detector keys on. A turn whose only output was a review then ends on an empty completion, which the detector reads as a dead turn: it burns the empty-turn retries and posts the fallback. The review *was* the turn's output; the detector just couldn't see it.

## Summary

Track "a formal github review landed this **logical** turn" on the router and skip both the empty-turn retries and the fallback when it did.

- **ledger** — a new review-**output** signal (`setReviewOutputObserver` / `recordReviewOutput`) carrying `APPROVE | REQUEST_CHANGES | COMMENT`. Kept **separate** from the false-receipt verdict ledger (`reviewsByPr` / `hasReview`): a COMMENT carries no verdict-claim risk and must never satisfy `hasReview`. A recorded verdict also fans to the output observer, so one detection path feeds both.
- **detect** — `detectReviewOutput` additionally recognizes COMMENT reviews across all three vectors (input file, `-f event=COMMENT`, `gh pr review --comment`). `detectReviewSubmission` stays verdict-only for the false-receipt path.
- **recorder** — credits a successful COMMENT via `recordReviewOutput` (output only, never the verdict ledger), with the same fail-closed success bias as verdicts.
- **router** — `LiveSession.githubReviewOutputTurn` is stamped (`turnSeq`) via `noteGithubReviewOutput`. **Why reset only on a real user batch and not beside the per-iteration `resetReviewTurn`:** the review lands in an *earlier* prompt iteration than the fallback would fire, so a per-iteration reset would wipe the flag before the fallback check and the bug would survive. `validateChannelTurn` treats an empty stop as legitimate silence when the flag matches this turn and no channel send landed.
- **run** — wires `setReviewOutputObserver` to `router.noteGithubReviewOutput` (in-process, no broadcast — this is the recording session's own bookkeeping, unlike the sibling verdict-standdown fan-out).

**Why not just count github sends toward `successfulChannelSends`:** the counter has other semantics (rate limiting, dedupe, quote anchoring). Overloading it with API-side review submissions would ripple into those. A dedicated per-logical-turn flag is narrower and self-documenting.

## What this does NOT do

- Does **not** change the false-receipt verdict ledger — a COMMENT still never satisfies `hasReview`, and verdict claims are gated exactly as before.
- Does **not** touch the other empty-turn shapes (length exhaustion, stranded toolUse, cold-start solo) beyond the shared suppression point — a turn with no review still gets its retries and fallback.
- Does **not** address the sibling risks surfaced during investigation (cross-channel `channel_send` crediting the target session's counter, thread-resolution not counting as a send). Those are separate, lower-severity, and out of scope here.

## Review notes

- Load-bearing invariant: `githubReviewOutputTurn` **must** reset with the retry budgets (real-user-batch branch in `drain()`), not beside `resetReviewTurn`. There's a test that lands the review in attempt 1 and asserts the flag survives to suppress later empty stops.
- The guard is gated on `successfulChannelSends === successfulSendsBeforePrompt`, so a turn that *also* replied in-channel still runs the normal reply-recovery path.
- New tests: ledger output-observer split (COMMENT fires output but not the verdict ledger), COMMENT detection across all three vectors, and the router guard (APPROVE suppresses, COMMENT suppresses, flag survives retries, unrelated empty turn still posts the fallback).
- Pre-existing, unrelated: `*.schema.json` drift-guard and scaffold schema-validation tests fail on a clean `main` in this checkout too; untouched by this PR.
