### PR TITLE
fix(channels): surface unresolved review-thread miss and disambiguate the follow-up

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -814,7 +814,7 @@ describe('channel_reply resolve_review_thread', () => {
     expect(result.details.ok).toBe(false)
   })
 
-  test('still posts when the thread is already gone (no-match is non-blocking)', async () => {
+  test('posts a no-match resolve (non-blocking) but warns the resolve did not fire', async () => {
     const calls: OutboundMessage[] = []
     const tool = createChannelReplyTool({
       router: fakeRouter(
@@ -831,6 +831,9 @@ describe('channel_reply resolve_review_thread', () => {
 
     expect(calls).toHaveLength(1)
     expect(result.details.ok).toBe(true)
+    const rendered = (result.content[0] as { text: string }).text
+    expect(rendered).toContain('3343107661')
+    expect(rendered).toContain('was not resolved')
   })
 
   test('blocks the reply on an HTTP 404 lookup (not-found is NOT no-match)', async () => {

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -210,14 +210,21 @@ export function createChannelReplyTool({
       // flag fixes). Resolve-failure blocks the reply so the agent never posts
       // a "looks resolved" ack next to a still-open thread; the router enforces
       // that only the bot's own threads can be resolved.
+      let resolveMissNotice: string | null = null
       if (params.resolve_review_thread === true) {
-        const resolveError = await resolveReviewThreadBeforeReply(router, origin)
-        if (resolveError !== null) {
-          logger.warn(formatChannelToolFailure('channel_reply', resolveError))
+        const resolve = await resolveReviewThreadBeforeReply(router, origin)
+        if (resolve.kind === 'block') {
+          logger.warn(formatChannelToolFailure('channel_reply', resolve.error))
           return {
-            content: [{ type: 'text' as const, text: `channel_reply denied: ${resolveError}` }],
-            details: { ok: false, error: resolveError },
+            content: [{ type: 'text' as const, text: `channel_reply denied: ${resolve.error}` }],
+            details: { ok: false, error: resolve.error },
           }
+        }
+        // `no-match` stays non-blocking (the thread may be genuinely gone) but
+        // the resolve did NOT run, so tell the model instead of posting a clean
+        // receipt that hides the miss. Mirrors channel_send.
+        if (resolve.kind === 'no-match') {
+          resolveMissNotice = resolveMissHint(origin.thread)
         }
       }
 
@@ -287,8 +294,9 @@ export function createChannelReplyTool({
         // intentionally weaker and is safe ONLY because denials carry no echoed
         // prose; the success result does, and the weak prefix let Kimi loop.
         const warnNote = falseReceiptNotice !== null ? fenceRuntimeNotice(falseReceiptNotice) : ''
+        const missNote = resolveMissNotice ?? ''
         return {
-          content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hint}${warnNote}` }],
+          content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hint}${warnNote}${missNote}` }],
           details,
         }
       }
@@ -324,21 +332,25 @@ function missingReviewThreadResolveChoiceError(input: {
   )
 }
 
-// Returns an error string when the resolve should block the reply, or null
-// when it's safe to proceed. Only `no-match` (the thread is already gone, so
-// there's nothing to close) joins success as non-blocking; every hard failure
-// — wrong author, permission denial, HTTP 404 on a misdirected lookup,
-// transient API error — blocks, so the agent never claims a thread is settled
-// when the resolve did not actually run.
+// `block` when the resolve should stop the reply, `no-match` when the thread is
+// gone (non-blocking — the reply posts but the caller warns), `resolved` on
+// success. Every hard failure — wrong author, permission denial, HTTP 404 on a
+// misdirected lookup, transient API error — blocks, so the agent never claims a
+// thread is settled when the resolve did not actually run.
+type ResolveOutcome = { kind: 'resolved' } | { kind: 'no-match' } | { kind: 'block'; error: string }
+
 async function resolveReviewThreadBeforeReply(
   router: ChannelRouter,
   origin: ChannelReplyOrigin,
-): Promise<string | null> {
+): Promise<ResolveOutcome> {
   if (origin.adapter !== 'github') {
-    return 'resolve_review_thread is only supported on github sessions.'
+    return { kind: 'block', error: 'resolve_review_thread is only supported on github sessions.' }
   }
   if (origin.thread === null) {
-    return 'resolve_review_thread requires replying inside a review thread (no thread on this origin).'
+    return {
+      kind: 'block',
+      error: 'resolve_review_thread requires replying inside a review thread (no thread on this origin).',
+    }
   }
   const result = await router.resolveReviewThread({
     adapter: origin.adapter,
@@ -346,9 +358,20 @@ async function resolveReviewThreadBeforeReply(
     chat: origin.chat,
     rootCommentId: origin.thread,
   })
-  if (result.ok) return null
-  if (result.code === 'no-match') return null
-  return `could not resolve review thread: ${result.error}`
+  if (result.ok) return { kind: 'resolved' }
+  if (result.code === 'no-match') return { kind: 'no-match' }
+  return { kind: 'block', error: `could not resolve review thread: ${result.error}` }
+}
+
+// The model asked to resolve but no thread was rooted at this comment. Fenced
+// as a runtime notice (not chat prose) so a persona-rich model reads it as
+// tool feedback and re-targets, rather than replying to it in-character.
+function resolveMissHint(thread: string | null): string {
+  return fenceRuntimeNotice(
+    `you set resolve_review_thread but no unresolved review thread is rooted at comment ${JSON.stringify(thread)} — ` +
+      `your reply posted, but that thread was not resolved (it may be already gone, or the thread id is stale). ` +
+      `If a thread should still close, resolve it on the correct thread.`,
+  )
 }
 
 // Tool results reach the model as USER-role messages (OpenAI / Anthropic

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -161,7 +161,7 @@ describe('channel_send resolve_review_thread', () => {
     ).toBe(false)
   })
 
-  test('treats a no-match resolve as non-blocking and still posts', async () => {
+  test('posts a no-match resolve but warns and does not record the ledger', async () => {
     let sent = 0
     const tool = createChannelSendTool({
       router: fakeRouter({
@@ -183,8 +183,17 @@ describe('channel_send resolve_review_thread', () => {
       resolve_review_thread: true,
     })
 
+    // The reply still posts (no-match is non-blocking — the thread may be gone),
+    // but the model must be told the resolve did not fire so it can re-target,
+    // and the ledger must NOT record a resolution that never happened.
     expect(sent).toBe(1)
     expect((result.details as { ok: boolean }).ok).toBe(true)
+    const rendered = (result.content[0] as { text: string }).text
+    expect(rendered).toContain('555')
+    expect(rendered).toContain('was not resolved')
+    expect(
+      hasResolvedThread({ sessionId: SESSION, workspace: 'acme/widgets', prNumber: 12, rootCommentId: '555' }),
+    ).toBe(false)
   })
 
   test('rejects resolve_review_thread without a thread', async () => {

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -230,21 +230,32 @@ export function createChannelSendTool({
       // block the acknowledgement so the bot never posts "addressed — resolving"
       // next to a still-open thread. The router enforces that only the bot's own
       // threads can be resolved.
+      let resolveMissNotice: string | null = null
       if (wantsResolve) {
-        const resolveError = await resolveReviewThreadBeforeSend(router, {
+        const resolve = await resolveReviewThreadBeforeSend(router, {
           adapter,
           workspace: params.workspace,
           chat: params.chat,
           thread: params.thread ?? null,
         })
-        if (resolveError !== null) {
-          logger.warn(formatChannelToolFailure('channel_send', resolveError))
+        if (resolve.kind === 'block') {
+          logger.warn(formatChannelToolFailure('channel_send', resolve.error))
           return {
-            content: [{ type: 'text' as const, text: `channel_send denied: ${resolveError}` }],
-            details: { ok: false, error: resolveError },
+            content: [{ type: 'text' as const, text: `channel_send denied: ${resolve.error}` }],
+            details: { ok: false, error: resolve.error },
           }
         }
-        recordResolvedThreadFromSend(sessionId, params.workspace, params.chat, params.thread ?? null)
+        // `no-match`: the thread listed cleanly but nothing is rooted at this
+        // comment (gone, or a mispaired id from the bare-id follow-up list). It
+        // stays non-blocking so a genuinely-deleted thread's ack still posts,
+        // but the resolve did NOT happen — surface it so the model re-targets,
+        // and skip the ledger so a phantom resolution can't suppress this
+        // thread on a later sweep.
+        if (resolve.kind === 'no-match') {
+          resolveMissNotice = resolveMissHint(params.thread ?? null)
+        } else {
+          recordResolvedThreadFromSend(sessionId, params.workspace, params.chat, params.thread ?? null)
+        }
       }
 
       const result = await router.send({
@@ -298,6 +309,8 @@ export function createChannelSendTool({
 
         if (falseReceiptNotice !== null) hints.push(fenceRuntimeNotice(falseReceiptNotice))
 
+        if (resolveMissNotice !== null) hints.push(resolveMissNotice)
+
         return {
           content: [{ type: 'text' as const, text: `${fenceToolResult(receipt)}${hints.join('')}` }],
           details,
@@ -331,15 +344,17 @@ function missingReviewThreadResolveChoiceError(input: {
   )
 }
 
+type ResolveOutcome = { kind: 'resolved' } | { kind: 'no-match' } | { kind: 'block'; error: string }
+
 async function resolveReviewThreadBeforeSend(
   router: ChannelRouter,
   target: { adapter: AdapterId; workspace: string; chat: string; thread: string | null },
-): Promise<string | null> {
+): Promise<ResolveOutcome> {
   if (target.adapter !== 'github') {
-    return 'resolve_review_thread is only supported on github sends.'
+    return { kind: 'block', error: 'resolve_review_thread is only supported on github sends.' }
   }
   if (target.thread === null) {
-    return 'resolve_review_thread requires a `thread` (the review thread root comment id).'
+    return { kind: 'block', error: 'resolve_review_thread requires a `thread` (the review thread root comment id).' }
   }
   const result = await router.resolveReviewThread({
     adapter: target.adapter,
@@ -347,9 +362,20 @@ async function resolveReviewThreadBeforeSend(
     chat: target.chat,
     rootCommentId: target.thread,
   })
-  if (result.ok) return null
-  if (result.code === 'no-match') return null
-  return `could not resolve review thread: ${result.error}`
+  if (result.ok) return { kind: 'resolved' }
+  if (result.code === 'no-match') return { kind: 'no-match' }
+  return { kind: 'block', error: `could not resolve review thread: ${result.error}` }
+}
+
+// The model asked to resolve but no thread was rooted at this comment. Fenced
+// as a runtime notice (not chat prose) so a persona-rich model reads it as
+// tool feedback and re-targets, rather than replying to it in-character.
+function resolveMissHint(thread: string | null): string {
+  return fenceRuntimeNotice(
+    `you set resolve_review_thread but no unresolved review thread is rooted at comment ${JSON.stringify(thread)} — ` +
+      `your reply posted, but that thread was not resolved (it may be already gone, or you passed the wrong root ` +
+      `comment id). If a different thread should close, re-call channel_send with the correct \`thread\`.`,
+  )
 }
 
 function recordResolvedThreadFromSend(sessionId: string, workspace: string, chat: string, thread: string | null): void {

--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -1568,7 +1568,16 @@ function fakeFetch(fn: (input: string, init?: RequestInit) => Response): typeof 
 }
 
 describe('createGithubWebhookHandler — pull_request.synchronize recheck', () => {
-  type ThreadNode = { id: string; isResolved: boolean; rootCommentId: number; login: string; isBot?: boolean }
+  type ThreadNode = {
+    id: string
+    isResolved: boolean
+    rootCommentId: number
+    login: string
+    isBot?: boolean
+    path?: string | null
+    line?: number | null
+    body?: string
+  }
   type SelfReviewRow = { state: string; login?: string; type?: string }
 
   function threadsResponse(threads: ThreadNode[]): Response {
@@ -1582,10 +1591,13 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
                 nodes: threads.map((t) => ({
                   id: t.id,
                   isResolved: t.isResolved,
+                  path: t.path ?? null,
+                  line: t.line ?? null,
                   comments: {
                     nodes: [
                       {
                         databaseId: t.rootCommentId,
+                        body: t.body,
                         author: { __typename: t.isBot === false ? 'User' : 'Bot', login: t.login },
                       },
                     ],
@@ -1686,7 +1698,15 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     const tasks: Array<() => Promise<void>> = []
     const handler = recheckHandler({
       fetchImpl: threadsFetch([
-        { id: 'T1', isResolved: false, rootCommentId: 100, login: 'typeclaw-bot' },
+        {
+          id: 'T1',
+          isResolved: false,
+          rootCommentId: 100,
+          login: 'typeclaw-bot',
+          path: 'src/api/auth.ts',
+          line: 42,
+          body: 'This token never expires — set a TTL.\nsecond line ignored',
+        },
         { id: 'T2', isResolved: false, rootCommentId: 200, login: 'typeclaw-bot' },
         { id: 'T_DONE', isResolved: true, rootCommentId: 300, login: 'typeclaw-bot' },
       ]),
@@ -1705,7 +1725,12 @@ describe('createGithubWebhookHandler — pull_request.synchronize recheck', () =
     expect(msg.workspace).toBe('acme/project')
     expect(msg.text).toContain('PR #7')
     expect(msg.text).toContain('deadbee')
-    expect(msg.text).toContain('100, 200')
+    // Per-thread context lets the model tell threads apart so it passes the
+    // right root comment id as `thread` (the resolve+reply pairing key).
+    expect(msg.text).toContain('thread 100 on src/api/auth.ts:42')
+    expect(msg.text).toContain('This token never expires — set a TTL.')
+    expect(msg.text).toContain('thread 200')
+    expect(msg.text).not.toContain('second line ignored')
     expect(msg.externalMessageId).toBe('pr-7-recheck-deadbeef999')
     expect(msg.text).toContain('end your turn without replying')
   })

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -10,7 +10,7 @@ import type { DeliveryDedup } from './dedup'
 import { isGithubEventAllowed } from './event-allowlist'
 import { encodeGithubReactionRef, type GithubReactionTarget } from './reactions'
 import { fetchSelfReviewBlocking } from './review-state'
-import { listUnresolvedSelfReviewThreads } from './review-thread-resolver'
+import { listUnresolvedSelfReviewThreads, type UnresolvedSelfReviewThread } from './review-thread-resolver'
 
 export type GithubInboundLogger = { info: (m: string) => void; warn: (m: string) => void; error: (m: string) => void }
 
@@ -280,15 +280,14 @@ function scheduleReviewFollowup(input: {
         else options.logger.warn(`[github] review-state recheck failed for ${target}: ${blocking.error}`)
       }
 
-      const rootCommentIds = threads.threads.map((t) => t.rootCommentId)
-      if (rootCommentIds.length === 0 && !selfBlocking) return
+      if (threads.threads.length === 0 && !selfBlocking) return
       options.route(
         withApprovalPolicy(
           buildReviewFollowupInbound({
             repository,
             pullNumber,
             headSha,
-            rootCommentIds,
+            threads: threads.threads,
             selfBlocking,
             title: readString(pr, 'title'),
           }),
@@ -307,15 +306,15 @@ function buildReviewFollowupInbound(input: {
   repository: { owner: string; name: string }
   pullNumber: number
   headSha: string
-  rootCommentIds: readonly number[]
+  threads: readonly UnresolvedSelfReviewThread[]
   selfBlocking: boolean
   title: string | null
 }): InboundMessage {
-  const { repository, pullNumber, headSha, rootCommentIds, selfBlocking, title } = input
+  const { repository, pullNumber, headSha, threads, selfBlocking, title } = input
   const titleSegment = title !== null && title.trim() !== '' ? `: "${title}"` : ''
   const text =
     `PR #${pullNumber}${titleSegment} received new commits (now at ${headSha.slice(0, 7)}). ` +
-    followupInstruction(rootCommentIds, selfBlocking)
+    followupInstruction(threads, selfBlocking)
 
   return {
     adapter: 'github',
@@ -336,14 +335,15 @@ function buildReviewFollowupInbound(input: {
   }
 }
 
-function followupInstruction(rootCommentIds: readonly number[], selfBlocking: boolean): string {
+function followupInstruction(threads: readonly UnresolvedSelfReviewThread[], selfBlocking: boolean): string {
   const threadPart =
-    rootCommentIds.length > 0
-      ? `You have ${rootCommentIds.length} unresolved review thread(s) you authored on this PR ` +
-        `(root comment id(s): ${rootCommentIds.join(', ')}). For each, check whether the new commits ` +
-        `addressed your concern. If addressed, reply on that thread via channel_send with a short ` +
-        `acknowledgement and resolve_review_thread: true (the thread id is the root comment id); ` +
-        `if not, leave it open. `
+    threads.length > 0
+      ? `You have ${threads.length} unresolved review thread(s) you authored on this PR. ` +
+        `For each, check whether the new commits addressed your concern, then act on THAT thread ` +
+        `by passing its root comment id as \`thread\` to channel_send: if addressed, reply with a short ` +
+        `acknowledgement and resolve_review_thread: true; if not, reply with resolve_review_thread: false ` +
+        `(or leave it). Use the id — not the file/line — as \`thread\`; the file/line is only to tell the ` +
+        `threads apart:\n${threads.map(renderThreadLine).join('\n')}\n`
       : ''
   // A held CHANGES_REQUESTED never clears itself: GitHub keeps the block until a
   // fresh APPROVE/COMMENT/dismiss, so a blocking follow-up must always end with a
@@ -358,6 +358,12 @@ function followupInstruction(rootCommentIds: readonly number[], selfBlocking: bo
     : ''
   const tail = selfBlocking ? '' : 'If none are addressed, end your turn without replying.'
   return `${threadPart}${blockingPart}${tail}`
+}
+
+function renderThreadLine(thread: UnresolvedSelfReviewThread): string {
+  const where = thread.path !== null ? ` on ${thread.path}${thread.line !== null ? `:${thread.line}` : ''}` : ''
+  const concern = thread.snippet !== null ? ` — "${thread.snippet}"` : ''
+  return `- thread ${thread.rootCommentId}${where}${concern}`
 }
 
 export async function verifySignature(body: string, secret: string, sigHeader: string): Promise<boolean> {

--- a/src/channels/adapters/github/review-thread-resolver.test.ts
+++ b/src/channels/adapters/github/review-thread-resolver.test.ts
@@ -10,6 +10,9 @@ type ThreadFixture = {
   rootCommentId: number
   rootAuthorLogin: string
   rootAuthorType?: 'Bot' | 'User'
+  path?: string | null
+  line?: number | null
+  rootBody?: string
 }
 
 type Page = { threads: ThreadFixture[]; hasNextPage: boolean; endCursor: string | null }
@@ -23,10 +26,13 @@ const threadsPayload = (page: Page) => ({
           nodes: page.threads.map((t) => ({
             id: t.id,
             isResolved: t.isResolved,
+            path: t.path ?? null,
+            line: t.line ?? null,
             comments: {
               nodes: [
                 {
                   databaseId: t.rootCommentId,
+                  body: t.rootBody,
                   author: { __typename: t.rootAuthorType ?? 'Bot', login: t.rootAuthorLogin },
                 },
               ],
@@ -403,7 +409,47 @@ describe('listUnresolvedSelfReviewThreads', () => {
 
     const result = await list(fetchImpl)
 
-    expect(result).toEqual({ ok: true, threads: [{ threadId: 'T_OPEN_BOT', rootCommentId: 100 }] })
+    expect(result).toEqual({
+      ok: true,
+      threads: [{ threadId: 'T_OPEN_BOT', rootCommentId: 100, path: null, line: null, snippet: null }],
+    })
+  })
+
+  it('carries per-thread context (path, line, first-line snippet) when GraphQL reports it', async () => {
+    const fetchImpl = fakeGraphql({
+      pages: [
+        {
+          threads: [
+            {
+              id: 'T_CTX',
+              isResolved: false,
+              rootCommentId: 200,
+              rootAuthorLogin: 'bot[bot]',
+              path: 'src/api/auth.ts',
+              line: 42,
+              rootBody: 'This token never expires — set a TTL.\nMore detail on the next line.',
+            },
+          ],
+          hasNextPage: false,
+          endCursor: null,
+        },
+      ],
+    })
+
+    const result = await list(fetchImpl)
+
+    expect(result).toEqual({
+      ok: true,
+      threads: [
+        {
+          threadId: 'T_CTX',
+          rootCommentId: 200,
+          path: 'src/api/auth.ts',
+          line: 42,
+          snippet: 'This token never expires — set a TTL.',
+        },
+      ],
+    })
   })
 
   it('paginates across pages and aggregates self threads', async () => {
@@ -427,8 +473,8 @@ describe('listUnresolvedSelfReviewThreads', () => {
     expect(result).toEqual({
       ok: true,
       threads: [
-        { threadId: 'T1', rootCommentId: 1 },
-        { threadId: 'T2', rootCommentId: 2 },
+        { threadId: 'T1', rootCommentId: 1, path: null, line: null, snippet: null },
+        { threadId: 'T2', rootCommentId: 2, path: null, line: null, snippet: null },
       ],
     })
   })
@@ -448,7 +494,10 @@ describe('listUnresolvedSelfReviewThreads', () => {
 
     const result = await list(fetchImpl, 'typeey[bot]')
 
-    expect(result).toEqual({ ok: true, threads: [{ threadId: 'T_APP', rootCommentId: 9 }] })
+    expect(result).toEqual({
+      ok: true,
+      threads: [{ threadId: 'T_APP', rootCommentId: 9, path: null, line: null, snippet: null }],
+    })
   })
 
   it('returns an empty list when no bot-authored unresolved threads exist', async () => {

--- a/src/channels/adapters/github/review-thread-resolver.ts
+++ b/src/channels/adapters/github/review-thread-resolver.ts
@@ -9,7 +9,7 @@ const GRAPHQL_ENDPOINT = `${GITHUB_API_BASE}/graphql`
 // carry more, so the resolver paginates until it matches the root comment id
 // or exhausts the pages — stopping early on a 404-equivalent (thread absent)
 // rather than fabricating a node id.
-const THREADS_QUERY = `query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{databaseId author{__typename login}}}}}}}}`
+const THREADS_QUERY = `query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved path line comments(first:1){nodes{databaseId body author{__typename login}}}}}}}}`
 
 const RESOLVE_MUTATION = `mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}`
 
@@ -19,6 +19,9 @@ type ReviewThreadNode = {
   rootCommentId: number | null
   rootAuthorLogin: string | null
   rootAuthorIsBot: boolean
+  path: string | null
+  line: number | null
+  rootBody: string | null
 }
 
 type ThreadLookup =
@@ -147,7 +150,25 @@ async function findThread(fetchImpl: typeof fetch, token: string, target: Resolv
   return lookup
 }
 
-export type UnresolvedSelfReviewThread = { threadId: string; rootCommentId: number }
+export type UnresolvedSelfReviewThread = {
+  threadId: string
+  rootCommentId: number
+  path: string | null
+  line: number | null
+  snippet: string | null
+}
+
+// One line of the root comment, capped, so the follow-up prompt can name each
+// thread by its concern instead of a bare id — without dumping a multi-paragraph
+// review comment into the system-facing instruction.
+const SNIPPET_MAX_CHARS = 140
+
+function firstLineSnippet(body: string | null): string | null {
+  if (body === null) return null
+  const firstLine = body.split('\n', 1)[0]?.trim() ?? ''
+  if (firstLine === '') return null
+  return firstLine.length > SNIPPET_MAX_CHARS ? `${firstLine.slice(0, SNIPPET_MAX_CHARS)}…` : firstLine
+}
 
 export type ListUnresolvedSelfReviewThreadsResult =
   | { ok: true; threads: UnresolvedSelfReviewThread[] }
@@ -174,7 +195,13 @@ export async function listUnresolvedSelfReviewThreads(deps: {
       for (const node of nodes) {
         if (node.isResolved || node.rootCommentId === null) continue
         if (!isSelfAuthor(node, deps.selfLogin)) continue
-        threads.push({ threadId: node.id, rootCommentId: node.rootCommentId })
+        threads.push({
+          threadId: node.id,
+          rootCommentId: node.rootCommentId,
+          path: node.path,
+          line: node.line,
+          snippet: firstLineSnippet(node.rootBody),
+        })
       }
       return 'continue'
     },
@@ -260,6 +287,9 @@ async function parseThreadsPage(response: Response): Promise<ThreadsPage> {
       rootCommentId: root?.databaseId ?? null,
       rootAuthorLogin: root?.author?.login ?? null,
       rootAuthorIsBot: root?.author?.__typename === 'Bot',
+      path: n.path ?? null,
+      line: n.line ?? null,
+      rootBody: root?.body ?? null,
     }
   })
   return { kind: 'ok', nodes, hasNextPage: connection.pageInfo.hasNextPage, endCursor: connection.pageInfo.endCursor }
@@ -316,7 +346,11 @@ type GraphqlThreadsResponse = {
           nodes: Array<{
             id: string
             isResolved: boolean
-            comments: { nodes: Array<{ databaseId?: number; author?: { __typename?: string; login?: string } }> }
+            path?: string | null
+            line?: number | null
+            comments: {
+              nodes: Array<{ databaseId?: number; body?: string; author?: { __typename?: string; login?: string } }>
+            }
           }>
         }
       }


### PR DESCRIPTION
## Background

Follow-up to #1155. On a GitHub PR review-thread close-out, the agent could **leave a comment on a thread while the thread stayed unresolved**, with no signal that resolution failed.

Two coupled causes, one symptom.

### Cause 1 — a `no-match` resolve was swallowed into a false receipt

`channel_send` (and `channel_reply`) resolve the thread **before** posting the ack. On a `no-match` result — the PR's threads listed cleanly but none is rooted at the supplied comment id (deleted, or a mispaired id) — the resolve helper returned "no error", so:

- the reply posted,
- the tool returned `{ ok: true }`,
- `recordResolvedThreadFromSend` was **not** called,
- and the model got **zero signal** the thread stayed open.

The most-used resolve path silently no-op'd the resolve while reporting success.

### Cause 2 — the post-push follow-up couldn't tell threads apart

On `pull_request.synchronize`, `inbound.ts` lists the bot's unresolved threads and instructs the agent to close each out via `channel_send` with the thread's **root comment id as `thread`** — the same value that is *both* the reply target and the resolve target. That instruction listed the threads as a bare `root comment id(s): 100, 200, 300`. With no context to distinguish them, the model could pass a mismatched id and resolve the wrong (or no) thread.

## What this does

Two commits, two independent fixes:

**1. `fix(channels): warn when a github resolve finds no matching thread`**
`no-match` stays non-blocking (a genuinely-deleted thread's ack should still post), but both tools now append a **fenced runtime notice** naming the root comment id that did not resolve, and skip the ledger. The model sees the miss and re-targets instead of trusting a false receipt. Mirrored across `channel_send` and `channel_reply` so their resolve semantics stay in lockstep.

**2. `fix(channels): give the review follow-up per-thread context to disambiguate`**
`listUnresolvedSelfReviewThreads` now carries each thread's `path`, `line`, and a capped first-line snippet of the root comment (extra GraphQL fields: `path line ... body`). `followupInstruction` renders one line per thread with that context and tells the model to use the **id — not the file/line — as `thread`**.

## What this does NOT do

- **Does not hard-block `no-match`.** The documented `ReviewThreadResolveResult` invariant keeps `no-match` as the one non-blocking failure (the thread may be genuinely gone); this makes the miss *loud*, not fatal. `alreadyResolved` (success) is unchanged.
- **Does not change the reply+resolve pairing.** That was already atomic (same `thread` value); this removes the ambiguity that made the model supply the wrong value, and surfaces it when it still happens.

## Review notes

- Load-bearing: the `no-match` branch in `resolveReviewThreadBeforeSend` / `resolveReviewThreadBeforeReply` now returns a `ResolveOutcome` discriminated union; the caller renders `resolveMissHint(...)` via `fenceRuntimeNotice` (the same self-reply-loop fence used by the consecutive-send / thread-mismatch hints).
- Contract change: the old `channel-send.resolve.test.ts` test *"treats a no-match resolve as non-blocking and still posts"* asserted a silent success; it now asserts the reply posts **with** a warning and **without** a ledger record. Mirror test added on `channel_reply`.
- Multi-language: the follow-up context is system-facing tool feedback (model-facing English), not NLP over human text, so the repo's multi-language rule doesn't apply — but the snippet passes through arbitrary comment text unmodified (e.g. a Korean review comment renders as-is).

## Verification

`bun run typecheck` · `bun run lint` (0 errors) · `bun run format:check` · `bun run test` → **10584 pass, 0 fail**.
