### PR TITLE
feat(channels): close teams CLI and operator parity gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,40 @@ The workflow is the only supported release path. The GHCR-first-then-npm orderin
 
 "channel" — or `channel_*` tool/code references — means **`src/channels/`**, this repo's channels subsystem (router, manager, persistence, Slack/Discord adapters). NOT Channel Talk, NOT abstract Slack channels, NOT the agent-messenger `agent-channeltalk*` skills. Only branch out when the user explicitly names a different platform.
 
+## Adding a channel adapter
+
+A new adapter is **not done when the adapter file compiles and the runtime routes it.** An adapter is a public surface with many enumeration sites, and the easy-to-miss ones are the CLI/init/docs touch-points — a half-wired adapter runs but is invisible to `channel add`, `channel list`, `doctor`, `inspect`, and every reader of the docs. When you add (or audit) an adapter, walk this checklist and name each site explicitly; skipping one is the single most common channel bug. The Teams adapter's initial landing is the worked cautionary example: the runtime was fully wired but `buildDetail`, `inspect/label.ts`, `doctor/channel-checks.ts`, the `channel add`/`reauth` flows, the init wizard, and **all docs** were missing.
+
+**Runtime + type system (the adapter won't route without these):**
+
+- `src/channels/schema.ts` — add the id to `ADAPTER_IDS`, a slot to `channelsSchema`, and an entry to `ADAPTER_READ_CAPABILITIES` (there's a guard test in `schema.test.ts` mapping id → adapter file).
+- `src/channels/manager.ts` — `buildAdapter` branch + credential-store wiring + credential-signature hashing for reload detection.
+- `src/channels/adapters/<name>.ts` (+ `-classify`, `-key`, etc.) — the adapter itself and its router-callback registrations. Register **every** capability the platform supports (outbound, history, message-get, list, membership, reactions, typing, fetch-attachment, channel-name resolver) — a missing registration is a silent capability gap, not a compile error.
+- `src/secrets/schema.ts` + `src/secrets/<name>-store.ts` — credential record + block schema and its store (host + container modes).
+- `src/config/channels-mutation.ts` — `CHANNEL_KINDS`.
+- `src/permissions/match-rule.ts`, `src/permissions/resolve.ts`, `src/role-claim/match-rule.ts`, `src/agent/session-origin.ts` — platform mapping for permissions, roles, provenance, prompt rendering.
+- `src/hostd/daemon.ts` + `src/hostd/protocol.ts` — if the adapter needs host-side credential write-back (token refresh).
+
+**CLI + init surface (the adapter is invisible without these):**
+
+- `src/cli/channel.ts` — `CHANNEL_LABELS`; then depending on auth model: `ADDABLE_CHANNEL_KINDS` + `collectCredentials` (for `channel add`), `SETTABLE_ADAPTERS` (token rotation via `channel set`), `REAUTHABLE_ADAPTERS` + `runReauth` (account-login replay), and any family picker (Slack/Discord/Webex-style bot-vs-user modes).
+- `src/init/<name>-auth.ts` — the interactive bootstrap (device-code / QR / password), mirroring `slack-auth.ts` / `webex-auth.ts` / `discord-auth.ts`.
+- `src/init/index.ts` — `runAddChannel` (`AddChannelOptions` union, `AddChannelStepEvent`, the auth-first ordering, `channelSecretsFromOptions`), plus the init-wizard path: `with<Name>` scaffold flag, `pickChannel`/`runChannelFlow`/`channelDisplayName`, and `configuredChannels`.
+- `src/config/channels-mutation.ts` `buildDetail` — the `channel list` DETAIL column (account count / repo count). Multi-account adapters share the `currentAccount`/`accounts` branch.
+- `src/inspect/label.ts` `ADAPTER_DISPLAY` — the human-readable name in `inspect`.
+- `src/doctor/channel-checks.ts` — a `buildChannelChecks()` entry verifying credentials resolve host-side (and update the `channel-checks.test.ts` names assertion).
+- `src/channels/router.ts` `NATIVE_REPLY_EVERY_SHAPE_ADAPTERS` — only if the platform's reply model needs it.
+
+**Docs (ships in the same PR as the code that motivates it):**
+
+- `docs/content/docs/reference/<name>.mdx` — reference page (model it on the closest existing adapter: bot-token → `slack-bot.mdx`; user-account → `webex.mdx`).
+- `docs/content/docs/reference/meta.json` — sidebar nav entry.
+- `docs/content/docs/reference/channel-adapters.mdx` — the master adapter table row, the `channels.<adapter>` shape example, the per-adapter quirks row, and the `set`/`reauth` CLI-verb split.
+- `docs/content/docs/guides/add-a-channel.mdx` — the CLI line under "Other platforms", an `<Accordion>` for the sign-in specifics, and the reauth list.
+- `README.md` — the "Supported channels" bullet.
+
+Multi-language rules (below) apply to any inbound classification / alias matching the adapter adds.
+
 ## Multi-language
 
 TypeClaw is a **multi-language project**: the agent lives in users' chats and reads messages in Korean, Japanese, Chinese, Arabic, Russian, every Latin-script language, and more — not just English. Any code that does **natural-language pattern matching over user/agent text** MUST work across languages, not just hardcoded English words or ASCII-only regex. This applies whenever you add or audit keyword detection, mention/alias matching, intent or engagement heuristics, suppressors, trigger-word lists, or verdict/sentiment classifiers.

--- a/src/config/channels-mutation.test.ts
+++ b/src/config/channels-mutation.test.ts
@@ -94,6 +94,29 @@ describe('channels mutation', () => {
       expect(list).toHaveLength(1)
       expect(list[0]?.detail).toBe('1 repo')
     })
+
+    test('includes an account-count detail for teams', async () => {
+      await writeConfig({ channels: { teams: {} } })
+      await writeSecrets({
+        teams: {
+          currentAccount: 'me',
+          accounts: {
+            me: {
+              account_id: 'me',
+              access_token: 't',
+              account_type: 'work',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z',
+            },
+          },
+        },
+      })
+
+      const list = listChannels(cwd)
+
+      expect(list).toHaveLength(1)
+      expect(list[0]?.detail).toBe('1 account (active: me)')
+    })
   })
 
   describe('removeChannel', () => {

--- a/src/config/channels-mutation.ts
+++ b/src/config/channels-mutation.ts
@@ -191,7 +191,14 @@ function buildDetail(kind: ChannelKind, channelConfig: unknown, secretsBlock: un
     const repos = isObjectRecord(channelConfig) && Array.isArray(channelConfig.repos) ? channelConfig.repos.length : 0
     return { detail: `${repos} repo${repos === 1 ? '' : 's'}` }
   }
-  if (kind === 'line' || kind === 'instagram' || kind === 'kakaotalk' || kind === 'webex' || kind === 'discord') {
+  if (
+    kind === 'line' ||
+    kind === 'instagram' ||
+    kind === 'kakaotalk' ||
+    kind === 'webex' ||
+    kind === 'discord' ||
+    kind === 'teams'
+  ) {
     if (!isObjectRecord(secretsBlock)) return {}
     const accounts = isObjectRecord(secretsBlock.accounts) ? Object.keys(secretsBlock.accounts).length : 0
     const current = typeof secretsBlock.currentAccount === 'string' ? secretsBlock.currentAccount : undefined

--- a/src/doctor/channel-checks.test.ts
+++ b/src/doctor/channel-checks.test.ts
@@ -72,6 +72,7 @@ describe('buildChannelChecks', () => {
       'channel.discord.credentials',
       'channel.slack.credentials',
       'channel.webex.credentials',
+      'channel.teams.credentials',
       'channel.instagram.credentials',
       'channel.line.credentials',
       'channel.kakaotalk.credentials',
@@ -285,6 +286,43 @@ describe('buildChannelChecks', () => {
       const result = await runCheck('channel.kakaotalk.credentials', ctxFor(cwd))
       expect(result.status).toBe('ok')
       expect(result.message).toContain('1 account')
+    })
+  })
+
+  describe('teams', () => {
+    test('skips when not configured', async () => {
+      const cwd = makeTmpAgentDir({})
+      const result = await runCheck('channel.teams.credentials', ctxFor(cwd))
+      expect(result.status).toBe('skipped')
+    })
+
+    test('warns when configured but current account has no access_token', async () => {
+      const cwd = makeTmpAgentDir({ teams: {} })
+      const result = await runCheck('channel.teams.credentials', ctxFor(cwd))
+      expect(result.status).toBe('warning')
+      expect(result.message).toMatch(/no current account access_token/)
+      expect(result.fix?.description).toContain('secrets.json#channels.teams')
+    })
+
+    test('passes when the current account has an access_token', async () => {
+      const cwd = makeTmpAgentDir({ teams: {} })
+      writeChannelsSecrets(cwd, {
+        teams: {
+          currentAccount: 'a',
+          accounts: {
+            a: {
+              account_id: 'a',
+              access_token: 't',
+              account_type: 'work',
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z',
+            },
+          },
+        },
+      })
+      const result = await runCheck('channel.teams.credentials', ctxFor(cwd))
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('access_token')
     })
   })
 

--- a/src/doctor/channel-checks.ts
+++ b/src/doctor/channel-checks.ts
@@ -32,6 +32,7 @@ export function buildChannelChecks(): DoctorCheck[] {
     discordUserCredentials(),
     slackUserCredentials(),
     webexUserCredentials(),
+    teamsCredentials(),
     instagramCredentials(),
     lineCredentials(),
     kakaotalkCredentials(),
@@ -154,6 +155,32 @@ function webexUserCredentials(): DoctorCheck {
         }
       }
       return { status: 'ok', message: 'webex has a current account access_token' }
+    },
+  }
+}
+
+function teamsCredentials(): DoctorCheck {
+  return {
+    name: 'channel.teams.credentials',
+    category: 'channels',
+    description: 'teams adapter has a current account with an access token in secrets.json',
+    applies: (ctx) => ctx.hasAgentFolder,
+    async run(ctx) {
+      const channels = readDeclaredChannels(ctx)
+      if (channels === null) return configInvalidResult()
+      if (!isAdapterActive(channels, 'teams')) {
+        return { status: 'skipped', message: 'teams not configured' }
+      }
+      const block = readChannelsSecrets(ctx)?.teams
+      if (!hasCurrentAccountTokenField(block, 'access_token')) {
+        return {
+          status: 'warning',
+          message: 'teams has no current account access_token in secrets.json',
+          details: ['Adapter will start but fail authentication and stay disconnected.'],
+          fix: { description: 'Populate secrets.json#channels.teams manually with an access token to authenticate.' },
+        }
+      }
+      return { status: 'ok', message: 'teams has a current account access_token' }
     },
   }
 }

--- a/src/inspect/label.ts
+++ b/src/inspect/label.ts
@@ -8,6 +8,7 @@ const ADAPTER_DISPLAY: Record<string, string> = {
   'telegram-bot': 'Telegram',
   webex: 'Webex',
   'webex-bot': 'Webex',
+  teams: 'Teams',
   line: 'LINE',
   kakaotalk: 'KakaoTalk',
 }


### PR DESCRIPTION
## Background

The Teams adapter (#1154, #1156) landed fully wired into the runtime but invisible to several operator-facing surfaces — the exact class of gap `AGENTS.md`'s new channel-adapter checklist (this PR) now enumerates. This is PR 2 of a 3-PR cleanup: docs land in `feat/teams-docs` (PR 1), the interactive `channel add teams` auth flow lands separately in `feat/teams-interactive-auth` (PR 3). This PR is the small, self-contained CLI/operator-parity fixes with no new auth flow.

## Summary

- **`typeclaw channel list` showed no DETAIL for teams.** `buildDetail` in `src/config/channels-mutation.ts` skipped the `teams` kind. Teams uses the same `currentAccount`/`accounts` secrets-block shape as the other user-account adapters (webex, discord, line, kakaotalk, instagram), so it's folded into that branch to show account count and the active account.
- **`typeclaw doctor` had no teams credential check.** Every other adapter has a host-stage check verifying credentials resolve before `typeclaw start`; teams had none. `teamsCredentials()` in `src/doctor/channel-checks.ts` mirrors the `webexUserCredentials` check — skips when teams isn't configured, warns when the current account has no `access_token`.
- **`typeclaw inspect` fell back to the raw adapter id for teams sessions.** `ADAPTER_DISPLAY` in `src/inspect/label.ts` had no `teams` entry.
- **`AGENTS.md` gains a channel-adapter checklist.** Enumerates every wiring site (runtime, secrets, permissions, CLI, init, `buildDetail`, inspect label, doctor, docs) an adapter needs, naming Teams's initial landing as the worked cautionary example.

## Notes

- Split across 3 PRs by design — see Background. This one is intentionally the smallest and safest: no new auth surface, just filling in existing per-adapter branches.
- The `AGENTS.md` checklist is the durable fix; it's meant to keep the next adapter from repeating this exact class of gap.
- Verification: `bun run typecheck` (clean), `bun run lint` (0 errors), `bun run format:check` (clean), `bun run test` — 10604 pass, 0 fail. New tests cover the teams channel-list detail and the teams doctor check (skip/warn/ok paths), plus the doctor check-registry names assertion is updated.
