### PR TITLE
fix(cron): isolate bad jobs so one expired job cannot brick the scheduler

### DIFF
--- a/src/cron/index.test.ts
+++ b/src/cron/index.test.ts
@@ -56,7 +56,7 @@ describe('loadCron', () => {
     expect(result.file?.jobs[1]?.id).toBe('backup')
   })
 
-  test('returns error on invalid json syntax', async () => {
+  test('returns error on invalid json syntax (file-level, unrecoverable)', async () => {
     await writeFile(join(root, 'cron.json'), '{ not valid json')
 
     const result = await loadCron(root)
@@ -65,15 +65,73 @@ describe('loadCron', () => {
     expect(result.reason).toMatch(/cron\.json/)
   })
 
-  test('returns error on schema violation', async () => {
+  test('returns error on top-level schema violation (file-level, unrecoverable)', async () => {
     await writeFile(
       join(root, 'cron.json'),
-      JSON.stringify({ jobs: [{ id: 'j', schedule: 'bogus', kind: 'prompt', prompt: 'x' }] }),
+      JSON.stringify({ jobs: [{ id: 'bad id with spaces', schedule: '* * * * *', kind: 'prompt', prompt: 'x' }] }),
     )
 
     const result = await loadCron(root)
 
     if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toMatch(/id/i)
+  })
+
+  test('default (strict load) fails the whole file on a per-job error (inspection/security safety)', async () => {
+    await writeFile(
+      join(root, 'cron.json'),
+      JSON.stringify({
+        jobs: [
+          { id: 'good', schedule: '30 23 * * *', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' },
+          { id: 'bogus-schedule', schedule: 'bogus', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' },
+        ],
+      }),
+    )
+
+    const result = await loadCron(root)
+
+    if (result.ok) throw new Error('strict load must fail the whole file on a bad job')
     expect(result.reason).toMatch(/bogus/)
+  })
+
+  test('boot mode isolates a single bad job and keeps the valid ones, surfacing a warning', async () => {
+    await writeFile(
+      join(root, 'cron.json'),
+      JSON.stringify({
+        jobs: [
+          { id: 'good', schedule: '30 23 * * *', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' },
+          { id: 'bogus-schedule', schedule: 'bogus', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' },
+        ],
+      }),
+    )
+
+    const result = await loadCron(root, { mode: 'boot' })
+
+    if (!result.ok) throw new Error(`expected boot isolation to succeed, got: ${result.reason}`)
+    expect(result.file?.jobs.map((j) => j.id)).toEqual(['good'])
+    expect(result.warnings?.some((w) => w.jobId === 'bogus-schedule' && /bogus/.test(w.reason))).toBe(true)
+  })
+
+  test('tolerates an expired "until" job on load (does not brick the file)', async () => {
+    await writeFile(
+      join(root, 'cron.json'),
+      JSON.stringify({
+        jobs: [
+          {
+            id: 'expired-ipo-monitor',
+            schedule: '*/5 * * * *',
+            until: '2020-01-01T00:00:00Z',
+            kind: 'prompt',
+            prompt: 'x',
+            scheduledByRole: 'owner',
+          },
+        ],
+      }),
+    )
+
+    const result = await loadCron(root)
+
+    if (!result.ok) throw new Error(`expected ok, got: ${result.reason}`)
+    expect(result.file?.jobs.map((j) => j.id)).toEqual(['expired-ipo-monitor'])
   })
 })

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import type { SubagentRegistry } from '@/agent/subagents'
 
-import { type CronFile, parseCronFile } from './schema'
+import { type CronFile, type CronParseWarning, type ParseCronMode, parseCronFile } from './schema'
 
 export { type CountStore, createCountStore } from './count-state'
 export { createCronReloadable } from './reloadable'
@@ -16,9 +16,11 @@ export {
   cronJobSchema,
   type CronFile,
   type CronJob,
+  type CronParseWarning,
   type ExecJob,
   type HandlerJob,
   parseCronJson,
+  type ParseCronMode,
   type ParseCronResult,
   type ParsedCronJob,
   type PromptJob,
@@ -26,10 +28,16 @@ export {
 
 const CRON_FILE = 'cron.json'
 
-export type LoadCronResult = { ok: true; file: CronFile | null } | { ok: false; reason: string }
+export type LoadCronResult =
+  | { ok: true; file: CronFile | null; warnings?: CronParseWarning[] }
+  | { ok: false; reason: string }
 
 export type LoadCronOptions = {
   subagents?: SubagentRegistry
+  // Defaults to strict `load` so inspection/security callers surface bad jobs
+  // as a whole-file error. Only the scheduler boot path passes `boot` to
+  // isolate individual bad jobs and keep the rest runnable.
+  mode?: ParseCronMode
 }
 
 export async function loadCron(agentDir: string, options: LoadCronOptions = {}): Promise<LoadCronResult> {
@@ -50,10 +58,13 @@ export async function loadCron(agentDir: string, options: LoadCronOptions = {}):
     return { ok: false, reason: `cron.json is not valid JSON: ${errorMessage(err)}` }
   }
 
-  const result = parseCronFile(parsed, options.subagents !== undefined ? { subagents: options.subagents } : {})
+  const result = parseCronFile(parsed, {
+    mode: options.mode ?? 'load',
+    ...(options.subagents !== undefined ? { subagents: options.subagents } : {}),
+  })
   if (!result.ok) return { ok: false, reason: result.reason }
 
-  return { ok: true, file: result.file }
+  return { ok: true, file: result.file, ...(result.warnings ? { warnings: result.warnings } : {}) }
 }
 
 function errorMessage(err: unknown): string {

--- a/src/cron/reloadable.test.ts
+++ b/src/cron/reloadable.test.ts
@@ -21,14 +21,17 @@ afterEach(async () => {
 
 function recordingScheduler(): Scheduler & { replacements: CronJob[][] } {
   const replacements: CronJob[][] = []
+  let live: CronJob[] = []
   return {
     replacements,
     start: () => {},
     stop: () => {},
     replaceJobs: (jobs) => {
       replacements.push([...jobs])
+      live = [...jobs]
       return { added: jobs, removed: [], updated: [], unchanged: [] } as JobDiff
     },
+    currentJobs: () => live,
   }
 }
 
@@ -39,6 +42,7 @@ function failingScheduler(error: Error): Scheduler {
     replaceJobs: () => {
       throw error
     },
+    currentJobs: () => [],
   }
 }
 
@@ -112,21 +116,26 @@ describe('createCronReloadable', () => {
     expect(result.reason).toMatch(/id/i)
   })
 
-  test('does NOT touch the scheduler when cron expression is invalid', async () => {
+  test('isolates a job with an invalid cron expression and applies the rest (per-job survivability)', async () => {
     const scheduler = recordingScheduler()
     await writeFile(
       join(agentDir, 'cron.json'),
-      JSON.stringify({ jobs: [{ id: 'j', schedule: 'not-a-cron', kind: 'prompt', prompt: 'x' }] }),
+      JSON.stringify({
+        jobs: [
+          { id: 'good', schedule: '* * * * *', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' },
+          { id: 'bad', schedule: 'not-a-cron', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' },
+        ],
+      }),
     )
 
     const reloadable = createCronReloadable({ cwd: agentDir, scheduler })
-    const result = await asFailure(reloadable.reload())
+    await asSuccess(reloadable.reload())
 
-    expect(scheduler.replacements).toEqual([])
-    expect(result.reason).toMatch(/not-a-cron/)
+    expect(scheduler.replacements).toHaveLength(1)
+    expect(scheduler.replacements[0]?.map((j) => j.id)).toEqual(['good'])
   })
 
-  test('does NOT touch the scheduler when ids are not unique', async () => {
+  test('isolates a duplicate id, keeps the first occurrence, and applies the rest', async () => {
     const scheduler = recordingScheduler()
     await writeFile(
       join(agentDir, 'cron.json'),
@@ -139,10 +148,114 @@ describe('createCronReloadable', () => {
     )
 
     const reloadable = createCronReloadable({ cwd: agentDir, scheduler })
-    const result = await asFailure(reloadable.reload())
+    await asSuccess(reloadable.reload())
+
+    expect(scheduler.replacements).toHaveLength(1)
+    expect(scheduler.replacements[0]?.map((j) => j.id)).toEqual(['dup'])
+  })
+
+  test('still fails closed on file-level errors (invalid JSON already covered; top-level schema)', async () => {
+    const scheduler = recordingScheduler()
+    await writeFile(
+      join(agentDir, 'cron.json'),
+      JSON.stringify({
+        jobs: [{ id: 'ok', schedule: '* * * * *', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }, 42],
+      }),
+    )
+
+    const reloadable = createCronReloadable({ cwd: agentDir, scheduler })
+    await asFailure(reloadable.reload())
 
     expect(scheduler.replacements).toEqual([])
-    expect(result.reason).toMatch(/duplicate/i)
+  })
+
+  test('preserves the live schedule when every user job is now invalid (no accidental wipe)', async () => {
+    const scheduler = recordingScheduler()
+    await writeFile(
+      join(agentDir, 'cron.json'),
+      JSON.stringify({
+        jobs: [{ id: 'good', schedule: '* * * * *', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }],
+      }),
+    )
+    const reloadable = createCronReloadable({ cwd: agentDir, scheduler })
+    await asSuccess(reloadable.reload())
+    expect(scheduler.replacements).toHaveLength(1)
+
+    await writeFile(
+      join(agentDir, 'cron.json'),
+      JSON.stringify({
+        jobs: [{ id: 'broken', schedule: 'not-a-cron', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }],
+      }),
+    )
+    const result = await asFailure(reloadable.reload())
+
+    expect(result.reason).toMatch(/not-a-cron/)
+    expect(scheduler.replacements).toHaveLength(1)
+  })
+
+  test('a valid empty file is an intentional deletion and applies zero jobs (not a wipe-guard)', async () => {
+    const scheduler = recordingScheduler()
+    await writeFile(
+      join(agentDir, 'cron.json'),
+      JSON.stringify({
+        jobs: [{ id: 'good', schedule: '* * * * *', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }],
+      }),
+    )
+    const reloadable = createCronReloadable({ cwd: agentDir, scheduler })
+    await asSuccess(reloadable.reload())
+
+    await writeFile(join(agentDir, 'cron.json'), JSON.stringify({ jobs: [] }))
+    await asSuccess(reloadable.reload())
+
+    expect(scheduler.replacements).toHaveLength(2)
+    expect(scheduler.replacements[1]).toEqual([])
+  })
+
+  test('all-invalid user jobs still apply when nothing was running before (no schedule to preserve)', async () => {
+    const scheduler = recordingScheduler()
+    await writeFile(
+      join(agentDir, 'cron.json'),
+      JSON.stringify({
+        jobs: [{ id: 'broken', schedule: 'not-a-cron', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }],
+      }),
+    )
+
+    const reloadable = createCronReloadable({ cwd: agentDir, scheduler })
+    await asSuccess(reloadable.reload())
+
+    expect(scheduler.replacements).toHaveLength(1)
+    expect(scheduler.replacements[0]).toEqual([])
+  })
+
+  test('the wipe-guard still applies plugin jobs are unaffected: internal jobs survive a preserved reload', async () => {
+    const scheduler = recordingScheduler()
+    const internal: CronJob = {
+      id: '__internal_test_job',
+      schedule: '0 4 * * *',
+      enabled: true,
+      kind: 'prompt',
+      prompt: '(internal)',
+      subagent: 'dreaming',
+      payload: { agentDir: '/x' },
+    }
+    await writeFile(
+      join(agentDir, 'cron.json'),
+      JSON.stringify({
+        jobs: [{ id: 'good', schedule: '* * * * *', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }],
+      }),
+    )
+    const reloadable = createCronReloadable({ cwd: agentDir, scheduler, internalJobs: () => [internal] })
+    await asSuccess(reloadable.reload())
+
+    await writeFile(
+      join(agentDir, 'cron.json'),
+      JSON.stringify({
+        jobs: [{ id: 'broken', schedule: 'not-a-cron', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }],
+      }),
+    )
+    await asFailure(reloadable.reload())
+
+    expect(scheduler.replacements).toHaveLength(1)
   })
 
   test('returns an ok=false result when scheduler.replaceJobs throws (belt-and-suspenders)', async () => {
@@ -219,6 +332,7 @@ describe('createCronReloadable', () => {
       start: () => {},
       stop: () => {},
       replaceJobs: () => diff,
+      currentJobs: () => [],
     }
     diff = {
       added: [job('a')],
@@ -246,6 +360,7 @@ describe('createCronReloadable', () => {
         updated: [],
         unchanged: [],
       }),
+      currentJobs: () => [],
     }
     await writeFile(join(agentDir, 'cron.json'), JSON.stringify({ jobs: [] }))
 

--- a/src/cron/reloadable.ts
+++ b/src/cron/reloadable.ts
@@ -36,11 +36,34 @@ async function doReload({
   getSubagents,
 }: CreateCronReloadableOptions): Promise<ReloadResult> {
   const subagents = getSubagents?.()
-  const loaded = await loadCron(cwd, subagents !== undefined ? { subagents } : {})
+  const loaded = await loadCron(cwd, { mode: 'boot', ...(subagents !== undefined ? { subagents } : {}) })
   if (!loaded.ok) {
     return { scope: 'cron', ok: false, reason: loaded.reason }
   }
+  const warnings = loaded.warnings ?? []
+  for (const warning of warnings) {
+    console.error(`[cron] skipped invalid job on reload: ${warning.reason}`)
+  }
   const userJobs = loaded.file?.jobs ?? []
+
+  // Wipe-guard: refuse a reload that would drop every user job *because they
+  // failed to parse* (not because the file was intentionally emptied) while a
+  // schedule is live, so a fat-fingered edit can't silently wipe running crons.
+  // A valid empty file has no warnings and passes through as intentional
+  // deletion. The live user-job baseline comes from the scheduler (single
+  // source of truth) minus the internal/plugin jobs, which are always present
+  // and must not count as "user jobs exist".
+  const internalIds = new Set((internalJobs?.() ?? []).map((job) => job.id))
+  const liveUserJobCount = scheduler.currentJobs().filter((job) => !internalIds.has(job.id)).length
+  if (warnings.length > 0 && userJobs.length === 0 && liveUserJobCount > 0) {
+    const reason = warnings.map((w) => w.reason).join('; ')
+    return {
+      scope: 'cron',
+      ok: false,
+      reason: `every configured user cron job is invalid; live schedule preserved: ${reason}`,
+    }
+  }
+
   const nextJobs: CronJob[] = [...userJobs, ...(internalJobs?.() ?? [])]
 
   let diff: JobDiff
@@ -51,12 +74,7 @@ async function doReload({
     return { scope: 'cron', ok: false, reason: `apply failed (schedule unchanged): ${message}` }
   }
 
-  return {
-    scope: 'cron',
-    ok: true,
-    summary: formatSummary(diff, nextJobs.length),
-    details: diff,
-  }
+  return { scope: 'cron', ok: true, summary: formatSummary(diff, nextJobs.length), details: diff }
 }
 
 function formatSummary(diff: JobDiff, total: number): string {

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -43,6 +43,7 @@ export type Scheduler = {
   start: () => void
   stop: () => void
   replaceJobs: (jobs: CronJob[]) => JobDiff
+  currentJobs: () => readonly CronJob[]
 }
 
 const realClock: SchedulerClock = {
@@ -187,6 +188,9 @@ export function createScheduler({
       for (const job of result.added) scheduleNext(job.id)
 
       return result
+    },
+    currentJobs() {
+      return [...registry.values()]
     },
   }
 }

--- a/src/cron/schema.test.ts
+++ b/src/cron/schema.test.ts
@@ -258,19 +258,46 @@ describe('parseCronFile timing boundaries (until / at / count)', () => {
     if (!result.ok) throw new Error(result.reason)
   })
 
-  test('rejects "until" in the past for an enabled job', () => {
-    const result = parseCronFile({ jobs: [job({ schedule: '0 9 * * *', until: PAST })] }, { now: NOW })
+  test('edit mode rejects "until" in the past for an enabled job', () => {
+    const result = parseCronFile({ jobs: [job({ schedule: '0 9 * * *', until: PAST })] }, { now: NOW, mode: 'edit' })
     if (result.ok) throw new Error('expected failure')
     expect(result.reason).toMatch(/past/)
   })
 
-  test('rejects "until" before the first occurrence', () => {
+  test('load mode tolerates a past "until" so an expired recurring job does not brick cron.json on reload', () => {
+    const result = parseCronFile({ jobs: [job({ schedule: '0 9 * * *', until: PAST })] }, { now: NOW, mode: 'load' })
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.file.jobs[0]?.until).toBe(PAST)
+  })
+
+  test('load is the default mode (a past "until" still parses)', () => {
+    const result = parseCronFile({ jobs: [job({ schedule: '0 9 * * *', until: PAST })] }, { now: NOW })
+    if (!result.ok) throw new Error(result.reason)
+  })
+
+  test('edit mode rejects "until" before the first occurrence', () => {
     const result = parseCronFile(
       { jobs: [job({ schedule: '0 9 1 1 *', until: '2026-06-09T00:00:00Z' })] },
-      { now: NOW },
+      { now: NOW, mode: 'edit' },
     )
     if (result.ok) throw new Error('expected failure')
     expect(result.reason).toMatch(/no occurrence/)
+  })
+
+  test('load mode tolerates "until" before the first occurrence (job is inert, scheduler retires it)', () => {
+    const result = parseCronFile(
+      { jobs: [job({ schedule: '0 9 1 1 *', until: '2026-06-09T00:00:00Z' })] },
+      { now: NOW, mode: 'load' },
+    )
+    if (!result.ok) throw new Error(result.reason)
+  })
+
+  test('edit mode still accepts a disabled past "until" (an intentional tombstone)', () => {
+    const result = parseCronFile(
+      { jobs: [job({ schedule: '0 9 * * *', until: PAST, enabled: false })] },
+      { now: NOW, mode: 'edit' },
+    )
+    if (!result.ok) throw new Error(result.reason)
   })
 
   test('rejects an "at" without an explicit zone (local-time ambiguity)', () => {
@@ -308,6 +335,99 @@ describe('parseCronFile timing boundaries (until / at / count)', () => {
   test('accepts until + count together on one recurring job', () => {
     const result = parseCronFile({ jobs: [job({ schedule: '0 9 * * *', until: FUTURE, count: 5 })] }, { now: NOW })
     if (!result.ok) throw new Error(result.reason)
+  })
+})
+
+describe('parseCronFile boot mode (per-job isolation)', () => {
+  const good = (id: string) => ({
+    id,
+    schedule: '* * * * *',
+    kind: 'prompt' as const,
+    prompt: 'x',
+    scheduledByRole: 'owner',
+  })
+
+  test('skips a job with an invalid cron expression and keeps the valid ones', () => {
+    const result = parseCronFile(
+      {
+        jobs: [
+          good('a'),
+          { id: 'bad', schedule: 'not-a-cron', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' },
+          good('b'),
+        ],
+      },
+      { mode: 'boot' },
+    )
+    if (!result.ok) throw new Error('expected boot mode to isolate, not fail the whole file')
+    expect(result.file.jobs.map((j) => j.id)).toEqual(['a', 'b'])
+    expect(result.warnings?.map((w) => w.jobId)).toContain('bad')
+    expect(result.warnings?.[0]?.reason).toMatch(/not-a-cron/)
+  })
+
+  test('skips a job missing scheduledByRole and keeps the valid ones', () => {
+    const result = parseCronFile(
+      { jobs: [good('a'), { id: 'legacy', schedule: '* * * * *', kind: 'prompt', prompt: 'x' }] },
+      { mode: 'boot' },
+    )
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.file.jobs.map((j) => j.id)).toEqual(['a'])
+    expect(result.warnings?.some((w) => w.jobId === 'legacy' && /scheduledByRole/.test(w.reason))).toBe(true)
+  })
+
+  test('keeps the first occurrence of a duplicate id and warns on the later one', () => {
+    const result = parseCronFile(
+      {
+        jobs: [
+          { id: 'dup', schedule: '* * * * *', kind: 'prompt', prompt: 'first', scheduledByRole: 'owner' },
+          { id: 'dup', schedule: '0 * * * *', kind: 'prompt', prompt: 'second', scheduledByRole: 'owner' },
+        ],
+      },
+      { mode: 'boot' },
+    )
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.file.jobs).toHaveLength(1)
+    const kept = result.file.jobs[0]
+    if (!kept || kept.kind !== 'prompt') throw new Error('expected a prompt job')
+    expect(kept.prompt).toBe('first')
+    expect(result.warnings?.some((w) => w.jobId === 'dup' && /duplicate/i.test(w.reason))).toBe(true)
+  })
+
+  test('tolerates an expired "until" job without a warning (inert, not invalid)', () => {
+    const NOW = new Date('2026-06-08T00:00:00Z').getTime()
+    const result = parseCronFile(
+      { jobs: [{ ...good('expired'), schedule: '0 9 * * *', until: '2020-01-01T00:00:00Z' }] },
+      { mode: 'boot', now: NOW },
+    )
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.file.jobs.map((j) => j.id)).toEqual(['expired'])
+    expect(result.warnings ?? []).toHaveLength(0)
+  })
+
+  test('a fully valid file in boot mode produces no warnings', () => {
+    const result = parseCronFile({ jobs: [good('a'), good('b')] }, { mode: 'boot' })
+    if (!result.ok) throw new Error(result.reason)
+    expect(result.file.jobs.map((j) => j.id)).toEqual(['a', 'b'])
+    expect(result.warnings ?? []).toHaveLength(0)
+  })
+
+  test('still hard-fails on a top-level schema violation (not a per-job error)', () => {
+    const result = parseCronFile(
+      { jobs: [{ id: 'bad id with spaces', schedule: '* * * * *', kind: 'prompt', prompt: 'x' }] },
+      { mode: 'boot' },
+    )
+    if (result.ok) throw new Error('expected top-level schema failure')
+    expect(result.reason).toMatch(/id/i)
+  })
+
+  test('load mode stays strict: one bad job fails the whole file (unchanged contract)', () => {
+    const result = parseCronFile(
+      {
+        jobs: [good('a'), { id: 'bad', schedule: 'not-a-cron', kind: 'prompt', prompt: 'x', scheduledByRole: 'owner' }],
+      },
+      { mode: 'load' },
+    )
+    if (result.ok) throw new Error('load mode must remain strict')
+    expect(result.reason).toMatch(/not-a-cron/)
   })
 })
 

--- a/src/cron/schema.ts
+++ b/src/cron/schema.ts
@@ -66,15 +66,28 @@ export type HandlerJob = z.infer<typeof baseJob> & {
 export type CronJob = ParsedCronJob | HandlerJob
 export type CronFile = z.infer<typeof cronFileSchema>
 
-export type ParseCronResult = { ok: true; file: CronFile } | { ok: false; reason: string }
+export type CronParseWarning = { jobId?: string; index: number; reason: string }
 
-// `edit` is the strict path for an agent writing/editing cron.json: a past
-// enabled `at` is rejected so a reminder scheduled in the past surfaces as an
-// error instead of silently becoming a never-firing no-op. `load` is the
-// tolerant path the scheduler uses on boot/reload: a fired or missed one-shot
-// lingers on disk with a now-past `at`, and rejecting it would brick the whole
-// file — so `load` accepts it and lets the scheduler retire it passively.
-export type ParseCronMode = 'edit' | 'load'
+export type ParseCronResult =
+  | { ok: true; file: CronFile; warnings?: CronParseWarning[] }
+  | { ok: false; reason: string }
+
+// `edit` is the strict authoring path for an agent writing/editing cron.json: a
+// past enabled `at`/`until` is rejected so a job scheduled in the past surfaces
+// as an error instead of silently becoming a never-firing no-op, and any single
+// bad job fails the whole file so the author sees it.
+//
+// `load` is the strict programmatic/security path (cron-promotion inspection,
+// reload validation): it tolerates fired past `at`/`until` tombstones but still
+// fails the whole file on any structurally bad job, so a security policy never
+// reasons over a silently-filtered subset.
+//
+// `boot` is the runtime-survivability path used only by the scheduler on
+// container boot/reload: it isolates bad individual jobs (skips them, emits a
+// warning) and keeps the valid ones, so one malformed job can never brick every
+// cron — including the plugin-registered dreaming job that isn't even in the
+// file. It shares `load`'s tolerance for expired `at`/`until`.
+export type ParseCronMode = 'edit' | 'load' | 'boot'
 
 export type ParseCronOptions = {
   // When provided, prompt jobs with a `subagent` field are validated against
@@ -113,40 +126,56 @@ export function parseCronFile(raw: unknown, options: ParseCronOptions = {}): Par
   }
 
   const file = parsed.data
+  const mode = options.mode ?? 'load'
+  const now = options.now ?? Date.now()
+
+  const validJobs: ParsedCronJob[] = []
+  const warnings: CronParseWarning[] = []
   const seen = new Set<string>()
-  for (const job of file.jobs) {
-    if (seen.has(job.id)) {
-      return { ok: false, reason: `duplicate job id: ${job.id}` }
+
+  for (const [index, job] of file.jobs.entries()) {
+    const duplicate = seen.has(job.id)
+    const reason = duplicate
+      ? `duplicate job id: ${job.id}`
+      : validateJob(job, { now, mode, subagents: options.subagents })
+
+    if (reason !== null) {
+      const scoped = duplicate ? reason : `job ${job.id}: ${reason}`
+      if (mode !== 'boot') return { ok: false, reason: scoped }
+      warnings.push({ jobId: job.id, index, reason: scoped })
+      continue
     }
+
     seen.add(job.id)
+    validJobs.push(job)
+  }
 
-    const timingError = validateTiming(job, options.now ?? Date.now(), options.mode ?? 'load')
-    if (timingError !== null) {
-      return { ok: false, reason: `job ${job.id}: ${timingError}` }
-    }
+  if (mode !== 'boot') return { ok: true, file }
+  return { ok: true, file: { ...file, jobs: validJobs }, ...(warnings.length > 0 ? { warnings } : {}) }
+}
 
-    if (job.scheduledByRole === undefined) {
-      return {
-        ok: false,
-        reason: `job ${job.id}: missing 'scheduledByRole'. Add "scheduledByRole": "owner" if you authored this entry manually.`,
-      }
-    }
+function validateJob(
+  job: ParsedCronJob,
+  { now, mode, subagents }: { now: number; mode: ParseCronMode; subagents?: SubagentRegistry },
+): string | null {
+  const timingError = validateTiming(job, now, mode)
+  if (timingError !== null) return timingError
 
-    if (job.kind === 'prompt' && job.subagent !== undefined && options.subagents !== undefined) {
-      const subagent = options.subagents[job.subagent]
-      if (!subagent) {
-        return { ok: false, reason: `job ${job.id}: unknown subagent "${job.subagent}"` }
-      }
-      try {
-        validateSubagentPayload(job.subagent, subagent, job.payload)
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        return { ok: false, reason: `job ${job.id}: ${message}` }
-      }
+  if (job.scheduledByRole === undefined) {
+    return `missing 'scheduledByRole'. Add "scheduledByRole": "owner" if you authored this entry manually.`
+  }
+
+  if (job.kind === 'prompt' && job.subagent !== undefined && subagents !== undefined) {
+    const subagent = subagents[job.subagent]
+    if (!subagent) return `unknown subagent "${job.subagent}"`
+    try {
+      validateSubagentPayload(job.subagent, subagent, job.payload)
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err)
     }
   }
 
-  return { ok: true, file }
+  return null
 }
 
 type TimingJob = {
@@ -181,7 +210,11 @@ function validateTiming(job: TimingJob, now: number = Date.now(), mode: ParseCro
   if (job.until !== undefined) {
     until = parseInstant(job.until)
     if (until === null) return `invalid "until": "${job.until}" is not an ISO datetime with an explicit zone/offset`
-    if (job.enabled && until <= now) return `"until" is in the past: "${job.until}"`
+    // Reject an expired boundary only on `edit`; `load`/`boot` tolerate an
+    // already-past `until` (the recurring counterpart of a fired one-shot `at`)
+    // so an expired job goes inert instead of bricking the whole file on reload.
+    // See ParseCronMode for the full rationale.
+    if (mode === 'edit' && job.enabled && until <= now) return `"until" is in the past: "${job.until}"`
   }
 
   let firstFire: number
@@ -199,7 +232,7 @@ function validateTiming(job: TimingJob, now: number = Date.now(), mode: ParseCro
     return `invalid schedule "${job.schedule}": ${message}`
   }
 
-  if (job.enabled && until !== null && firstFire > until) {
+  if (mode === 'edit' && job.enabled && until !== null && firstFire > until) {
     return `schedule has no occurrence at or before "until" ("${job.until}")`
   }
 

--- a/src/reload/e2e.test.ts
+++ b/src/reload/e2e.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { AgentSession } from '@/agent'
-import { createCronReloadable, createScheduler, loadCron, type Scheduler } from '@/cron'
+import { createCronReloadable, createScheduler, type CronJob, loadCron, type Scheduler } from '@/cron'
 import { ReloadRegistry } from '@/reload'
 import { createServer } from '@/server'
 
@@ -46,13 +46,16 @@ async function startTestAgent(scheduler: Scheduler): Promise<{ url: string }> {
 describe('reload end-to-end via ws', () => {
   test('edit cron.json + requestReload -> scheduler.replaceJobs receives the new jobs', async () => {
     const replacements: Array<Array<{ id: string }>> = []
+    let liveJobs: CronJob[] = []
     const scheduler: Scheduler = {
       start: () => {},
       stop: () => {},
       replaceJobs: (jobs) => {
         replacements.push(jobs.map((j) => ({ id: j.id })))
+        liveJobs = [...jobs]
         return { added: jobs, removed: [], updated: [], unchanged: [] }
       },
+      currentJobs: () => liveJobs,
     }
     await writeFile(join(agentDir, 'cron.json'), JSON.stringify({ jobs: [] }))
     const { url } = await startTestAgent(scheduler)
@@ -121,14 +124,17 @@ describe('reload end-to-end via ws', () => {
   })
 
   test('removing cron.json reloads to zero jobs', async () => {
+    let liveJobs: CronJob[] = []
     const scheduler: Scheduler & { current: { id: string }[] } = {
       current: [],
       start: () => {},
       stop: () => {},
       replaceJobs: function (jobs) {
         this.current = jobs.map((j) => ({ id: j.id }))
+        liveJobs = [...jobs]
         return { added: jobs, removed: [], updated: [], unchanged: [] }
       },
+      currentJobs: () => liveJobs,
     } as Scheduler & { current: { id: string }[] }
 
     await writeFile(
@@ -149,13 +155,16 @@ describe('reload end-to-end via ws', () => {
 
   test('multiple reloads in succession each reflect the latest cron.json', async () => {
     const seen: string[][] = []
+    let liveJobs: CronJob[] = []
     const scheduler: Scheduler = {
       start: () => {},
       stop: () => {},
       replaceJobs: (jobs) => {
         seen.push(jobs.map((j) => j.id))
+        liveJobs = [...jobs]
         return { added: jobs, removed: [], updated: [], unchanged: [] }
       },
+      currentJobs: () => liveJobs,
     }
     await writeFile(join(agentDir, 'cron.json'), JSON.stringify({ jobs: [] }))
     const { url } = await startTestAgent(scheduler)

--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -22,6 +22,7 @@ function stubScheduler(): Scheduler {
     start: () => {},
     stop: () => {},
     replaceJobs: () => ({ added: [], removed: [], updated: [], unchanged: [] }),
+    currentJobs: () => [],
   }
 }
 
@@ -260,6 +261,7 @@ describe('startAgent', () => {
         stopped = true
       },
       replaceJobs: () => ({ added: [], removed: [], updated: [], unchanged: [] }),
+      currentJobs: () => [],
     }
     const createSchedulerFor: SchedulerFactory = () => fakeScheduler
 
@@ -295,7 +297,11 @@ describe('startAgent', () => {
     expect(scopes.indexOf('providers')).toBeLessThan(scopes.indexOf('channels'))
   })
 
-  test('logs and continues when cron.json fails to load', async () => {
+  test('survives a file-level cron.json failure by still scheduling plugin jobs (dreaming stays alive)', async () => {
+    // startAgent loads the real bundled plugins, so the memory plugin's
+    // dreaming cron makes hasInternalJobs true: a broken cron.json must not
+    // take that down. The factory receives an empty user file plus the merged
+    // internal jobs.
     const loadCron: LoadCronFn = async () => ({ ok: false, reason: 'bad json' }) as LoadCronResult
     const factoryCalls: Array<{ cwd: string; file: CronFile }> = []
     const createSchedulerFor: SchedulerFactory = (opts) => {
@@ -305,8 +311,9 @@ describe('startAgent', () => {
 
     running = await startAgent({ port: 0, attachTui: false, cwd: testCwd, loadCron, createSchedulerFor })
 
-    expect(factoryCalls).toHaveLength(0)
-    expect(running.scheduler).toBeNull()
+    expect(factoryCalls).toHaveLength(1)
+    expect(factoryCalls[0]?.file.jobs).toEqual([])
+    expect(running.scheduler).not.toBeNull()
     expect(running.server.port).toBeGreaterThan(0)
   })
 
@@ -599,13 +606,16 @@ describe('startAgent bundled memory plugin (dreaming cron)', () => {
         }),
       )
       const replacements: CronJob[][] = []
+      let liveJobs: CronJob[] = []
       const fakeScheduler: Scheduler = {
         start: () => {},
         stop: () => {},
         replaceJobs: (jobs) => {
           replacements.push([...jobs])
+          liveJobs = [...jobs]
           return { added: [], removed: [], updated: [], unchanged: [] }
         },
+        currentJobs: () => liveJobs,
       }
       const createSchedulerFor: SchedulerFactory = () => fakeScheduler
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -52,6 +52,7 @@ import {
   createScheduler,
   type LoadCronResult,
   loadCron as loadCronDefault,
+  type ParseCronMode,
   type Scheduler,
 } from '@/cron'
 import { CLI_VERSION } from '@/init/cli-version'
@@ -91,7 +92,10 @@ type BunServer = ReturnType<Server['start']>
 
 export type TuiFactory = (options: TuiOptions) => { run: () => Promise<unknown> }
 
-export type LoadCronFn = (agentDir: string, options?: { subagents?: SubagentRegistry }) => Promise<LoadCronResult>
+export type LoadCronFn = (
+  agentDir: string,
+  options?: { subagents?: SubagentRegistry; mode?: ParseCronMode },
+) => Promise<LoadCronResult>
 export type SchedulerFactory = (options: {
   cwd: string
   file: CronFile
@@ -1133,7 +1137,10 @@ function reloadRolesFromDisk(cwd: string): ReturnType<typeof getConfig>['roles']
   return getConfig().roles
 }
 
-async function startScheduler({
+// Exported for the resilience regression test in `index.test.ts` (survives a
+// file-level cron.json failure by still scheduling plugin jobs). Not re-exported
+// from the package entry point, so this stays module-internal in practice.
+export async function startScheduler({
   cwd,
   loadCron,
   createSchedulerFor,
@@ -1155,17 +1162,27 @@ async function startScheduler({
   let result: LoadCronResult
   const subagents = getSubagents?.()
   try {
-    result = await loadCron(cwd, subagents !== undefined ? { subagents } : {})
+    result = await loadCron(cwd, { mode: 'boot', ...(subagents !== undefined ? { subagents } : {}) })
   } catch (err) {
-    console.error(`[cron] load failed: ${err instanceof Error ? err.message : err}`)
-    return null
+    result = { ok: false, reason: err instanceof Error ? err.message : String(err) }
   }
+
+  // A file-level cron.json failure (malformed JSON or top-level schema
+  // violation) must not take the whole scheduler down: plugin-registered jobs
+  // (e.g. memory dreaming) live outside cron.json and have to keep running.
+  // Boot with an empty user file so the factory still merges internal jobs;
+  // give up only when there is nothing to schedule at all.
   if (!result.ok) {
     console.error(`[cron] failed to load cron.json: ${result.reason}`)
-    return null
+    if (!hasInternalJobs) return null
+  } else {
+    for (const warning of result.warnings ?? []) {
+      console.error(`[cron] skipped invalid job at boot: ${warning.reason}`)
+    }
   }
-  const file: CronFile = result.file ?? { jobs: [] }
-  if (!result.file && !hasInternalJobs) return null
+
+  const file: CronFile = result.ok ? (result.file ?? { jobs: [] }) : { jobs: [] }
+  if (result.ok && !result.file && !hasInternalJobs) return null
 
   const onFire = (job: CronJob) => {
     stream.publish({ target: { kind: 'cron', jobId: job.id }, payload: job })


### PR DESCRIPTION
## Background

On a production agent, the `dreaming` memory-consolidation cron silently stopped running on 2026-06-14 and never recovered. Investigation traced it to a single expired cron job in `cron.json`:

```json
{ "id": "spcx-ipo-monitor", "schedule": "*/5 * * * *", "until": "2026-06-13T05:30:00+09:00", ... }
```

When its `until` date passed, `parseCronFile` rejected the WHOLE file (`[cron] failed to load cron.json: job spcx-ipo-monitor: "until" is in the past`). Because `startScheduler` returns null on any load failure, and plugin-registered crons (memory `dreaming`) are merged only after a successful load, the entire cron subsystem died — including dreaming, which never lives in `cron.json`. The only signal was one boot log line. The user did nothing wrong; a legitimate "retire this job after the event" usage bricked all crons.

## Summary

Two commits, two independent fixes.

**Commit 1 — `fix(cron): isolate bad jobs and tolerate expired boundaries in boot mode`**
- New `boot` `ParseCronMode`. In boot mode, `parseCronFile` isolates individual invalid jobs (skips them, collects per-job warnings) instead of failing the whole file. `edit` (authoring) and `load` (inspection/security: cron-promotion policy, `cron_list`) stay strict and reject the whole file, so no security policy or diagnostic ever reasons over a silently-filtered subset.
- An expired `until` (and an `until` before the first occurrence) is now tolerated outside `edit` mode — mirroring how a fired past `at` is already tolerated on load. Expired recurring jobs retire passively instead of bricking the file.

**Commit 2 — `fix(cron): keep plugin crons alive and guard reloads against invalid edits`**
- Boot: a file-level `cron.json` failure (malformed JSON / top-level schema) no longer kills the scheduler — plugin/internal crons (dreaming) keep running, and user jobs recover on the next reload once the file is fixed.
- Reload wipe-guard: an edit that invalidates every user job while a schedule is live is refused (live schedule preserved), distinguished from an intentional empty file by the presence of parse warnings. The live user-job baseline is read from a new `Scheduler.currentJobs()` accessor (single source of truth) minus the always-present internal jobs.

### Mode semantics

| mode | used by | on bad job | on past `at`/`until` |
| --- | --- | --- | --- |
| `edit` | authoring (user edits) | reject whole file | reject |
| `load` | inspection/security (`cron_list`, cron-promotion) — default | reject whole file | tolerate (tombstone) |
| `boot` | scheduler runtime (boot + reload) | isolate bad job, warn | tolerate |

## What this does NOT do

- Does not change `edit`-mode strictness — an interactively-authored `cron.json` with any bad job is still rejected outright, so the model gets immediate feedback while writing.
- Does not change `cron_list` / cron-promotion policy — both stay on strict `load` so a bad job is surfaced, never silently filtered from a security-relevant view.
- Does not address the memory-logger empty-spawn token cost (memory-logger keeps firing per session-idle producing `fragments_written=0` ~85-95% of the time). Tracked separately, out of scope here.

## Review notes

- Load-bearing invariant: `boot` mode must never leak into `edit` or `load` call sites — the three-way mode split (rather than an orthogonal `isolate` flag) keeps call sites self-documenting and prevents inspection/security callers from accidentally inheriting isolation.
- The reload wipe-guard is the other load-bearing piece: verify `currentJobs()` (new `Scheduler` accessor) minus internal jobs is the only source of truth for "is a schedule live", and that an all-invalid edit is distinguished from an intentional empty file via parse warnings, not job count alone.
- `startScheduler` is now exported solely for a regression test (documented in-code), following the existing `mergeSubagents` precedent.
- Full suite: 10,620 tests pass, 0 fail. `typecheck`/`lint` (0 errors)/`format:check` all clean.
- New/updated tests cover: boot-mode per-job isolation (invalid schedule, missing `scheduledByRole`, duplicate id kept-first), strict `load` still fails whole-file, expired-`until` tolerance per mode, `loadCron` strict-by-default vs boot, the reload wipe-guard (all-invalid preserves live schedule; valid empty file = intentional deletion; nothing-running-before still applies), and boot survival of a file-level failure keeping the dreaming cron alive.