### PR TITLE
feat(channels): add interactive device-code login for Teams

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -34,6 +34,7 @@ import {
   type KakaotalkAuthResult,
   type LineAuthResult,
   type SlackAuthResult,
+  type TeamsAuthResult,
   type WebexAuthResult,
 } from '@/init'
 import { runDiscordBootstrap } from '@/init/discord-auth'
@@ -41,8 +42,10 @@ import { runInstagramBootstrap, type InstagramLoginCallbacks } from '@/init/inst
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { runLineBootstrap } from '@/init/line-auth'
 import { runSlackBootstrap } from '@/init/slack-auth'
+import { runTeamsBootstrap, type TeamsDeviceCodeCallbacks } from '@/init/teams-auth'
 import { runWebexBootstrap } from '@/init/webex-auth'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
+import type { TeamsAccountType } from '@/secrets/schema'
 import { SecretsWebexCredentialStore } from '@/secrets/webex-store'
 
 import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
@@ -64,11 +67,7 @@ const CHANNEL_LABELS: Record<ChannelKind, string> = {
   github: 'GitHub',
 }
 
-// Teams has no interactive auth flow yet (device-code/AAD login isn't wired
-// into `channel add`), so it is hidden from the picker and the addable-arg
-// validation. It stays a first-class ChannelKind for list/remove/config; the
-// adapter runs from a manually-populated secrets.json#channels.teams block.
-const ADDABLE_CHANNEL_KINDS = CHANNEL_KINDS.filter((kind) => kind !== 'teams')
+const ADDABLE_CHANNEL_KINDS = CHANNEL_KINDS
 
 const addSub = defineCommand({
   meta: {
@@ -194,7 +193,7 @@ const setSub = defineCommand({
 // than a token-field rotation (`channel set`). Discord (User) belongs here — its
 // unofficial QR session expires and is refreshed by replaying the QR login, the
 // same shape as LINE's QR flow. `discord-bot` stays in SETTABLE_ADAPTERS.
-const REAUTHABLE_ADAPTERS = ['line', 'instagram', 'kakaotalk', 'webex', 'discord'] as const
+const REAUTHABLE_ADAPTERS = ['line', 'instagram', 'kakaotalk', 'webex', 'discord', 'teams'] as const
 type ReauthableAdapter = (typeof REAUTHABLE_ADAPTERS)[number]
 
 const reauthSub = defineCommand({
@@ -482,7 +481,22 @@ async function runReauth(cwd: string, adapter: ReauthableAdapter): Promise<void>
     case 'discord':
       await runDiscordReauth(cwd)
       return
+    case 'teams':
+      await runTeamsReauth(cwd)
+      return
   }
+}
+
+async function runTeamsReauth(cwd: string): Promise<void> {
+  const accountType = await promptTeamsAccountType()
+  const result = await runTeamsBootstrap({ agentDir: cwd, accountType, callbacks: teamsDeviceCodeCallbacks() })
+  if (!result.ok) {
+    console.error(errorLine(`Teams login failed: ${result.reason}`))
+    process.exit(1)
+  }
+  process.stdout.write(`${successLine('Teams credentials refreshed in secrets.json.')}\n`)
+
+  await maybePromptReauthRefresh(cwd, 'teams')
 }
 
 async function runInstagramReauth(cwd: string): Promise<void> {
@@ -1017,6 +1031,7 @@ type CollectedCredentials =
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'webex'; runWebexAuth: (options: { cwd: string }) => Promise<WebexAuthResult> }
   | { channel: 'webex-bot'; webexBotToken: string }
+  | { channel: 'teams'; runTeamsAuth: (options: { cwd: string }) => Promise<TeamsAuthResult> }
   | { channel: 'instagram'; runInstagramAuth: (options: { cwd: string }) => Promise<InstagramAuthResult> }
   | { channel: 'line'; runLineAuth: (options: { cwd: string }) => Promise<LineAuthResult> }
   | { channel: 'kakaotalk'; runKakaotalkAuth: (options: { cwd: string }) => Promise<KakaotalkAuthResult> }
@@ -1064,14 +1079,14 @@ async function collectCredentials(
     }
     case 'webex-bot':
       return { channel, webexBotToken: await promptWebexToken() }
-    case 'teams':
-      // Unreachable in practice: `validateAdapterArg`/`pickChannel` exclude
-      // Teams from the addable set (ADDABLE_CHANNEL_KINDS). Kept as a guard so
-      // this exhaustive switch still compiles and fails loudly if that
-      // exclusion ever regresses.
-      throw new Error(
-        'Teams channel add is not yet supported interactively. Populate secrets.json#channels.teams manually.',
-      )
+    case 'teams': {
+      const accountType = await promptTeamsAccountType()
+      return {
+        channel,
+        runTeamsAuth: ({ cwd: agentDir }) =>
+          runTeamsBootstrap({ agentDir, accountType, callbacks: teamsDeviceCodeCallbacks() }),
+      }
+    }
     case 'instagram': {
       const creds = await promptInstagramCredentials()
       const callbacks = instagramLoginCallbacks(lineSpinnerHolder ? holderSpinnerControl(lineSpinnerHolder) : undefined)
@@ -1545,6 +1560,47 @@ async function promptWebexToken(): Promise<string> {
   return token
 }
 
+async function promptTeamsAccountType(): Promise<TeamsAccountType> {
+  note(
+    [
+      'Teams signs in as your own Microsoft account via device-code login —',
+      'no bot registration. You get a short code to enter at',
+      'microsoft.com/devicelogin, then approve the sign-in.',
+    ].join('\n'),
+    'About to log in to Teams',
+  )
+  const accountType = await select<TeamsAccountType>({
+    message: 'Which kind of Microsoft account?',
+    options: [
+      { value: 'work', label: 'Work or school (Microsoft 365 / Azure AD)' },
+      { value: 'personal', label: 'Personal Microsoft account (outlook.com, live.com, …)' },
+    ],
+    initialValue: 'work',
+  })
+  if (isCancel(accountType)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return accountType
+}
+
+export function teamsDeviceCodeCallbacks(): TeamsDeviceCodeCallbacks {
+  return {
+    onCode: (prompt) => {
+      note(
+        [
+          `Open ${prompt.verificationUri}`,
+          `Enter code: ${prompt.userCode}`,
+          '',
+          'Then approve the sign-in in your browser. Waiting for approval…',
+        ].join('\n'),
+        'Teams device-code login',
+      )
+    },
+    onPending: () => log.info('Approved — minting the Teams token…'),
+  }
+}
+
 async function promptKakaotalkCredentials(
   opts: { defaultEmail?: string } = {},
 ): Promise<{ email: string; password: string }> {
@@ -1842,6 +1898,9 @@ function reportProgress(
       case 'webex-auth':
         s.stop(reportWebexAuth(event.result))
         break
+      case 'teams-auth':
+        s.stop(reportTeamsAuth(event.result))
+        break
       case 'discord-auth':
         s.stop(reportDiscordAuth(event.result))
         break
@@ -1866,6 +1925,7 @@ const START_MESSAGES: Record<AddChannelStepEvent['step'], string> = {
   'instagram-auth': 'Logging in to Instagram...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   'webex-auth': 'Logging in to Webex...',
+  'teams-auth': 'Logging in to Teams...',
   'discord-auth': 'Logging in to Discord...',
   'slack-auth': 'Logging in to Slack...',
   config: 'Updating typeclaw.json...',
@@ -1891,6 +1951,11 @@ function reportDiscordAuth(result: DiscordAuthResult): string {
 function reportWebexAuth(result: WebexAuthResult): string {
   if (result.ok) return 'Webex credentials saved to secrets.json.'
   return `Webex login failed: ${result.reason}`
+}
+
+function reportTeamsAuth(result: TeamsAuthResult): string {
+  if (result.ok) return 'Teams credentials saved to secrets.json.'
+  return `Teams login failed: ${result.reason}`
 }
 
 function reportLineAuth(result: LineAuthResult): string {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -67,6 +67,7 @@ import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { customModelMetaFromOption, fetchModelOptions, type ModelOption } from '@/init/models-dev'
 import { makeOAuthLoginRunner, type OAuthLoginResult } from '@/init/oauth-login'
 import { detectInitProgress } from '@/init/progress'
+import { runTeamsBootstrap } from '@/init/teams-auth'
 import {
   API_KEY_DASHBOARD_URL,
   MINIMAX_TOKEN_PLAN_DASHBOARD_URL,
@@ -74,7 +75,9 @@ import {
   type KeyValidationResult,
 } from '@/init/validate-api-key'
 import { runWebexBootstrap } from '@/init/webex-auth'
+import type { TeamsAccountType } from '@/secrets/schema'
 
+import { teamsDeviceCodeCallbacks } from './channel'
 import { fuzzyMatch } from './fuzzy-filter'
 import { buildOAuthCallbacks } from './oauth-callbacks'
 import { CANCEL_SYMBOL, promptPrivateKeyPem } from './prompt-pem'
@@ -225,6 +228,7 @@ export const init = defineCommand({
       kakaotalkPassword,
       webexEmail,
       webexPassword,
+      teamsAccountType,
       github: githubCredentials,
     } = channelSecrets
     const modelMeta = customModelMetaFromOption(model)
@@ -244,9 +248,11 @@ export const init = defineCommand({
     const reuseTelegram = reuseExistingChannel && channelChoice === 'telegram'
     const reuseKakaotalk = reuseExistingChannel && channelChoice === 'kakaotalk'
     const reuseWebex = reuseExistingChannel && channelChoice === 'webex'
+    const reuseTeams = reuseExistingChannel && channelChoice === 'teams'
     const reuseGithub = reuseExistingChannel && channelChoice === 'github'
     const wantsKakaotalk = (kakaotalkEmail !== undefined && kakaotalkPassword !== undefined) || reuseKakaotalk
     const wantsWebex = (webexEmail !== undefined && webexPassword !== undefined) || reuseWebex
+    const wantsTeams = teamsAccountType !== undefined || reuseTeams
     const wantsGithub = githubCredentials !== undefined || reuseGithub
     let hatchingOk = false
     let preflightFailure: Extract<DockerAvailability, { ok: false }> | null = null
@@ -296,6 +302,21 @@ export const init = defineCommand({
                 : {
                     runWebexAuth: ({ cwd: agentDir }) =>
                       runWebexBootstrap({ email: webexEmail!, password: webexPassword!, agentDir }),
+                  }),
+            }
+          : {}),
+        ...(wantsTeams
+          ? {
+              withTeams: true,
+              ...(reuseTeams
+                ? {}
+                : {
+                    runTeamsAuth: ({ cwd: agentDir }) =>
+                      runTeamsBootstrap({
+                        agentDir,
+                        accountType: teamsAccountType!,
+                        callbacks: teamsDeviceCodeCallbacks(),
+                      }),
                   }),
             }
           : {}),
@@ -407,7 +428,7 @@ interface WizardState {
   channelReuseExisting?: boolean
 }
 
-type ChannelChoice = 'slack' | 'discord' | 'telegram' | 'webex' | 'kakaotalk' | 'github' | 'none'
+type ChannelChoice = 'slack' | 'discord' | 'telegram' | 'webex' | 'teams' | 'kakaotalk' | 'github' | 'none'
 
 interface CollectedInputs {
   model: ModelOption
@@ -429,6 +450,7 @@ interface CollectedInputs {
     telegramBotToken?: string
     webexEmail?: string
     webexPassword?: string
+    teamsAccountType?: TeamsAccountType
     kakaotalkEmail?: string
     kakaotalkPassword?: string
     // Structured (auth union + webhook + repo allowlist) rather than flat
@@ -1141,6 +1163,8 @@ function channelDisplayName(choice: Exclude<ChannelChoice, 'none'>): string {
       return 'Telegram'
     case 'webex':
       return 'Webex (User)'
+    case 'teams':
+      return 'Teams (User)'
     case 'kakaotalk':
       return 'KakaoTalk'
     case 'github':
@@ -1483,6 +1507,7 @@ async function pickChannel(initial: ChannelChoice | undefined): Promise<StepResu
       { value: 'discord', label: 'Discord' },
       { value: 'telegram', label: 'Telegram' },
       { value: 'webex', label: 'Webex (User)' },
+      { value: 'teams', label: 'Teams (User)' },
       { value: 'kakaotalk', label: 'KakaoTalk' },
       { value: 'github', label: 'GitHub' },
       { value: 'none', label: 'Skip — no channel right now' },
@@ -1510,9 +1535,32 @@ async function runChannelFlow(
       return runTelegramFlow()
     case 'webex':
       return runWebexUserFlow()
+    case 'teams':
+      return runTeamsFlow()
     case 'github':
       return runGithubFlow(cwd)
   }
+}
+
+async function runTeamsFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
+  note(
+    [
+      'Teams signs in as your own Microsoft account via device-code login —',
+      'you get a short code to enter at microsoft.com/devicelogin, then approve.',
+      'The sign-in itself runs after scaffolding, not now.',
+    ].join('\n'),
+    'About to log in to Teams',
+  )
+  const accountType = await select<TeamsAccountType>({
+    message: 'Which kind of Microsoft account?',
+    options: [
+      { value: 'work', label: 'Work or school (Microsoft 365 / Azure AD)' },
+      { value: 'personal', label: 'Personal Microsoft account (outlook.com, live.com, …)' },
+    ],
+    initialValue: 'work',
+  })
+  if (isCancel(accountType)) return back()
+  return value({ teamsAccountType: accountType })
 }
 
 async function runDiscordFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
@@ -1903,6 +1951,9 @@ function reportProgress(
       case 'webex-auth':
         s.stop(reportWebexAuth(event.result))
         break
+      case 'teams-auth':
+        s.stop(reportTeamsAuth(event.result))
+        break
       case 'github-webhooks':
         s.stop(formatEagerGithubWebhookInstallResult(event.result))
         break
@@ -1965,6 +2016,11 @@ function reportKakaotalkAuth(result: KakaotalkAuthResult): string {
 function reportWebexAuth(result: { ok: true } | { ok: false; reason: string }): string {
   if (result.ok) return 'Webex credentials saved to secrets.json.'
   return `Webex login failed: ${result.reason}`
+}
+
+function reportTeamsAuth(result: { ok: true } | { ok: false; reason: string }): string {
+  if (result.ok) return 'Teams credentials saved to secrets.json.'
+  return `Teams login failed: ${result.reason}`
 }
 
 // Hatching launches the container and foregrounds the TUI, so it steals stdin
@@ -2050,6 +2106,7 @@ const START_MESSAGES: Record<Exclude<InitStep, 'hatching'>, string> = {
   'instagram-auth': 'Logging in to Instagram...',
   'kakaotalk-auth': 'Logging in to KakaoTalk...',
   'webex-auth': 'Logging in to Webex...',
+  'teams-auth': 'Logging in to Teams...',
   'github-webhooks': 'Installing GitHub repository webhooks...',
   install: 'Installing dependencies with bun...',
   dockerfile: 'Writing Dockerfile...',

--- a/src/init/add-channel.test.ts
+++ b/src/init/add-channel.test.ts
@@ -202,6 +202,54 @@ describe('runAddChannel', () => {
     expect(await readFile(join(root, 'secrets.json'), 'utf8')).toBe(beforeSecrets)
   })
 
+  test('adds teams as an empty block and runs auth runner before config mutation', async () => {
+    const authCalls: string[] = []
+    const events: AddChannelStepEvent[] = []
+    const result = await runAddChannel({
+      cwd: root,
+      channel: 'teams',
+      runTeamsAuth: async ({ cwd }) => {
+        authCalls.push(cwd)
+        return { ok: true }
+      },
+      onProgress: (event) => events.push(event),
+    })
+
+    expect(result).toBeUndefined()
+    expect(authCalls).toEqual([root])
+    const cfg = await readConfig()
+    expect(cfg.channels?.teams).toEqual({})
+    // Auth must run and finish BEFORE config/secrets are touched, so a declined
+    // login never leaves a half-wired channel behind.
+    expect(events.map((event) => `${event.step}:${event.phase}`)).toEqual([
+      'teams-auth:start',
+      'teams-auth:done',
+      'config:start',
+      'config:done',
+      'secrets:start',
+      'secrets:done',
+    ])
+    expect((await readSecrets()).providers?.fireworks).toEqual({ type: 'api_key', key: { value: 'fw_existing' } })
+  })
+
+  test('aborts and leaves typeclaw.json + secrets.json untouched when teams auth fails', async () => {
+    const beforeConfig = await readFile(join(root, 'typeclaw.json'), 'utf8')
+    const beforeSecrets = await readFile(join(root, 'secrets.json'), 'utf8')
+
+    await expect(
+      runAddChannel({
+        cwd: root,
+        channel: 'teams',
+        runTeamsAuth: async () => ({ ok: false, reason: 'authorization declined' }),
+      }),
+    ).rejects.toThrow(/authorization declined/)
+
+    expect(await readFile(join(root, 'typeclaw.json'), 'utf8')).toBe(beforeConfig)
+    expect(await readFile(join(root, 'secrets.json'), 'utf8')).toBe(beforeSecrets)
+    const cfg = await readConfig()
+    expect(cfg.channels?.teams).toBeUndefined()
+  })
+
   test('adds kakaotalk as an empty block (no allow field) and runs auth runner', async () => {
     const authCalls: string[] = []
     await runAddChannel({

--- a/src/init/checkpoint.ts
+++ b/src/init/checkpoint.ts
@@ -21,7 +21,7 @@ export const INIT_CHECKPOINT_PATH = join('.typeclaw', 'init-progress.json')
 
 export const WIZARD_CHECKPOINT_VERSION = 1
 
-export type WizardChannelChoice = 'slack' | 'discord' | 'telegram' | 'webex' | 'kakaotalk' | 'github' | 'none'
+export type WizardChannelChoice = 'slack' | 'discord' | 'telegram' | 'webex' | 'teams' | 'kakaotalk' | 'github' | 'none'
 
 export type AuthMethod = 'api-key' | 'oauth'
 

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1807,6 +1807,64 @@ describe('hasExistingChannelSecrets', () => {
     await seedChannels({ kakaotalk: { currentAccount: 'acc-missing', accounts: {} } })
     expect(await hasExistingChannelSecrets(root, 'kakaotalk')).toBe(false)
   })
+
+  test('returns true when teams has a full account record with the AAD refresh trio', async () => {
+    await seedChannels({
+      teams: {
+        currentAccount: 'me',
+        accounts: {
+          me: {
+            account_id: 'me',
+            access_token: 'skype-tok',
+            account_type: 'work',
+            aad_refresh_token: 'aad-refresh',
+            aad_client_id: 'client-1',
+            aad_tenant_id: 'tenant-1',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        },
+      },
+    })
+    expect(await hasExistingChannelSecrets(root, 'teams')).toBe(true)
+  })
+
+  test('returns false when teams has an access_token but no AAD refresh trio (cannot silently renew)', async () => {
+    await seedChannels({
+      teams: {
+        currentAccount: 'me',
+        accounts: {
+          me: {
+            account_id: 'me',
+            access_token: 'skype-tok',
+            account_type: 'work',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        },
+      },
+    })
+    expect(await hasExistingChannelSecrets(root, 'teams')).toBe(false)
+  })
+
+  test('returns false when teams is missing any single AAD field', async () => {
+    const base = {
+      account_id: 'me',
+      access_token: 'skype-tok',
+      account_type: 'work',
+      aad_refresh_token: 'aad-refresh',
+      aad_client_id: 'client-1',
+      aad_tenant_id: 'tenant-1',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    }
+    for (const drop of ['aad_refresh_token', 'aad_client_id', 'aad_tenant_id'] as const) {
+      const account: Record<string, unknown> = { ...base }
+      delete account[drop]
+      await seedChannels({ teams: { currentAccount: 'me', accounts: { me: account } } })
+      expect(await hasExistingChannelSecrets(root, 'teams')).toBe(false)
+    }
+  })
 })
 
 describe('channel secret reuse (init re-run preserves existing tokens)', () => {
@@ -1929,6 +1987,76 @@ describe('channel secret reuse (init re-run preserves existing tokens)', () => {
     expect(secrets.channels?.kakaotalk).toMatchObject({
       currentAccount: 'acc-1',
       accounts: { 'acc-1': { oauth_token: 'tok' } },
+    })
+  })
+
+  test('runInit with withTeams=true runs the teams auth runner and wires the adapter', async () => {
+    let ran = false
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_test_key',
+      withTeams: true,
+      runTeamsAuth: async () => {
+        ran = true
+        return { ok: true }
+      },
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
+
+    expect(ran).toBe(true)
+    const config = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      channels?: Record<string, unknown>
+    }
+    expect(config.channels?.teams).toEqual({})
+  })
+
+  test('runInit with withTeams=true and no runTeamsAuth wires teams without re-authenticating', async () => {
+    await writeFile(
+      join(root, 'secrets.json'),
+      `${JSON.stringify(
+        {
+          version: 2,
+          providers: { fireworks: { type: 'api_key', key: { value: 'fw_seed' } } },
+          channels: {
+            teams: {
+              currentAccount: 'me',
+              accounts: {
+                me: {
+                  account_id: 'me',
+                  access_token: 'tok',
+                  account_type: 'work',
+                  created_at: '2026-01-01T00:00:00Z',
+                  updated_at: '2026-01-01T00:00:00Z',
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    await runInit({
+      cwd: root,
+      apiKey: 'fw_seed',
+      withTeams: true,
+      runHatching: okHatch,
+      runBunInstall: okInstall,
+      dockerExec: okDocker,
+    })
+
+    const config = JSON.parse(await readFile(join(root, 'typeclaw.json'), 'utf8')) as {
+      channels?: Record<string, unknown>
+    }
+    expect(config.channels?.teams).toEqual({})
+
+    const secrets = await readSecrets(root)
+    expect(secrets.channels?.teams).toMatchObject({
+      currentAccount: 'me',
+      accounts: { me: { access_token: 'tok' } },
     })
   })
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -89,6 +89,7 @@ export type InitStep =
   | 'instagram-auth'
   | 'kakaotalk-auth'
   | 'webex-auth'
+  | 'teams-auth'
   | 'github-webhooks'
   | 'install'
   | 'dockerfile'
@@ -97,6 +98,7 @@ export type InitStep =
 
 export type KakaotalkAuthResult = { ok: true } | { ok: false; reason: string }
 export type WebexAuthResult = { ok: true } | { ok: false; reason: string }
+export type TeamsAuthResult = { ok: true } | { ok: false; reason: string }
 export type SlackAuthResult = { ok: true } | { ok: false; reason: string }
 export type DiscordAuthResult = { ok: true } | { ok: false; reason: string }
 export type InstagramAuthResult = { ok: true } | { ok: false; reason: string }
@@ -137,6 +139,8 @@ export type InitStepEvent =
   | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
   | { step: 'webex-auth'; phase: 'start' }
   | { step: 'webex-auth'; phase: 'done'; result: WebexAuthResult }
+  | { step: 'teams-auth'; phase: 'start' }
+  | { step: 'teams-auth'; phase: 'done'; result: TeamsAuthResult }
   | { step: 'discord-auth'; phase: 'start' }
   | { step: 'discord-auth'; phase: 'done'; result: DiscordAuthResult }
   | { step: 'instagram-auth'; phase: 'start' }
@@ -170,6 +174,7 @@ export type HatchRunner = (options: {
 
 export type KakaotalkAuthRunner = (options: { cwd: string }) => Promise<KakaotalkAuthResult>
 export type WebexAuthRunner = (options: { cwd: string }) => Promise<WebexAuthResult>
+export type TeamsAuthRunner = (options: { cwd: string }) => Promise<TeamsAuthResult>
 
 export type LineAuthResult = { ok: true } | { ok: false; reason: string }
 export type LineAuthRunner = (options: { cwd: string }) => Promise<LineAuthResult>
@@ -228,11 +233,13 @@ export type InitOptions = {
   withTelegram?: boolean
   withWebex?: boolean
   withWebexUser?: boolean
+  withTeams?: boolean
   withInstagram?: boolean
   withKakaotalk?: boolean
   withGithub?: boolean
   runKakaotalkAuth?: KakaotalkAuthRunner
   runWebexAuth?: WebexAuthRunner
+  runTeamsAuth?: TeamsAuthRunner
   runDiscordAuth?: DiscordAuthRunner
   runInstagramAuth?: InstagramAuthRunner
   // Structured GitHub credentials collected by the wizard. When omitted and
@@ -280,11 +287,13 @@ export async function runInit({
   withTelegram,
   withWebex,
   withWebexUser = false,
+  withTeams = false,
   withInstagram = false,
   withKakaotalk = false,
   withGithub = false,
   runKakaotalkAuth,
   runWebexAuth,
+  runTeamsAuth,
   runDiscordAuth,
   runInstagramAuth,
   githubCredentials,
@@ -367,6 +376,7 @@ export async function runInit({
     withTelegram: wantsTelegram,
     withWebex: wantsWebex,
     withWebexUser,
+    withTeams,
     withInstagram,
     withKakaotalk,
     platform,
@@ -409,6 +419,15 @@ export async function runInit({
     emit({ step: 'webex-auth', phase: 'done', result })
     if (!result.ok) {
       throw new Error(`Webex authentication failed: ${result.reason}`)
+    }
+  }
+
+  if (withTeams && runTeamsAuth !== undefined) {
+    emit({ step: 'teams-auth', phase: 'start' })
+    const result = await runTeamsAuth({ cwd })
+    emit({ step: 'teams-auth', phase: 'done', result })
+    if (!result.ok) {
+      throw new Error(`Teams authentication failed: ${result.reason}`)
     }
   }
 
@@ -482,6 +501,7 @@ export async function runInit({
   if (wantsTelegram) configuredChannels.push('telegram-bot')
   if (wantsWebex) configuredChannels.push('webex-bot')
   if (withWebexUser) configuredChannels.push('webex')
+  if (withTeams) configuredChannels.push('teams')
   if (withInstagram) configuredChannels.push('instagram')
   if (withKakaotalk) configuredChannels.push('kakaotalk')
   if (withGithub) configuredChannels.push('github')
@@ -653,6 +673,7 @@ export type ScaffoldOptions = {
   withTelegram?: boolean
   withWebex?: boolean
   withWebexUser?: boolean
+  withTeams?: boolean
   withInstagram?: boolean
   withKakaotalk?: boolean
   // Defaults to `process.platform`; controls the dev-mode typeclaw spec
@@ -692,6 +713,7 @@ export async function scaffold(root: string, options: ScaffoldOptions = {}): Pro
   if (options.withTelegram) channels['telegram-bot'] = {}
   if (options.withWebex) channels['webex-bot'] = {}
   if (options.withWebexUser) channels.webex = {}
+  if (options.withTeams) channels.teams = {}
   if (options.withInstagram) channels.instagram = {}
   if (options.withKakaotalk) channels.kakaotalk = {}
   if (Object.keys(channels).length > 0) config.channels = channels
@@ -1008,7 +1030,7 @@ export async function hasExistingOAuthCredentials(root: string, providerId: Know
 // kakaotalk` anyway — better to re-auth now during init.
 export async function hasExistingChannelSecrets(
   root: string,
-  channel: 'discord' | 'slack' | 'telegram' | 'webex' | 'instagram' | 'line' | 'kakaotalk' | 'github',
+  channel: 'discord' | 'slack' | 'telegram' | 'webex' | 'teams' | 'instagram' | 'line' | 'kakaotalk' | 'github',
 ): Promise<boolean> {
   const channels = new SecretsBackend(join(root, 'secrets.json')).tryReadChannelsSync()
   if (channels === null) return false
@@ -1021,6 +1043,8 @@ export async function hasExistingChannelSecrets(
       return hasSecretField(channels['telegram-bot'], 'token')
     case 'webex':
       return hasCurrentWebexAccount(channels.webex)
+    case 'teams':
+      return hasCurrentTeamsAccount(channels.teams)
     case 'github':
       // GitHub credentials alone are not enough to scaffold a working
       // channel: typeclaw.json#channels.github also needs webhookUrl and
@@ -1103,6 +1127,33 @@ function hasCurrentWebexAccount(block: unknown): boolean {
   const email = (account as { email?: unknown }).email
   const encryptedPassword = (account as { encryptedPassword?: unknown }).encryptedPassword
   return typeof token === 'string' && token.length > 0 && typeof email === 'string' && isObjectRecord(encryptedPassword)
+}
+
+// A Teams block is only reusable when the current account can survive
+// unattended: the Skype access token lapses in ~60-90min, so silent renewal
+// needs the full AAD refresh trio (refresh token + client id + tenant id). An
+// access-token-only block (e.g. a hand-pasted token) would go stale with no way
+// to re-mint, so treat it as not-configured and let the wizard re-run the
+// device-code login rather than wiring a channel that dies within the hour.
+function hasCurrentTeamsAccount(block: unknown): boolean {
+  if (!isObjectRecord(block)) return false
+  const current = (block as { currentAccount?: unknown }).currentAccount
+  if (typeof current !== 'string' || current.length === 0) return false
+  const accounts = (block as { accounts?: unknown }).accounts
+  if (!isObjectRecord(accounts)) return false
+  const account = accounts[current]
+  if (!isObjectRecord(account)) return false
+  return (
+    hasNonEmptyString(account, 'access_token') &&
+    hasNonEmptyString(account, 'aad_refresh_token') &&
+    hasNonEmptyString(account, 'aad_client_id') &&
+    hasNonEmptyString(account, 'aad_tenant_id')
+  )
+}
+
+function hasNonEmptyString(record: Record<string, unknown>, key: string): boolean {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -1196,6 +1247,8 @@ export type AddChannelStepEvent =
   | { step: 'kakaotalk-auth'; phase: 'done'; result: KakaotalkAuthResult }
   | { step: 'webex-auth'; phase: 'start' }
   | { step: 'webex-auth'; phase: 'done'; result: WebexAuthResult }
+  | { step: 'teams-auth'; phase: 'start' }
+  | { step: 'teams-auth'; phase: 'done'; result: TeamsAuthResult }
   | { step: 'discord-auth'; phase: 'start' }
   | { step: 'discord-auth'; phase: 'done'; result: DiscordAuthResult }
   | { step: 'slack-auth'; phase: 'start' }
@@ -1219,6 +1272,7 @@ export type AddChannelOptions = {
   | { channel: 'telegram-bot'; telegramBotToken: string }
   | { channel: 'webex-bot'; webexBotToken: string }
   | { channel: 'webex'; runWebexAuth: WebexAuthRunner }
+  | { channel: 'teams'; runTeamsAuth: TeamsAuthRunner }
   | { channel: 'instagram'; runInstagramAuth: InstagramAuthRunner }
   | { channel: 'line'; runLineAuth: LineAuthRunner }
   | { channel: 'kakaotalk'; runKakaotalkAuth: KakaotalkAuthRunner }
@@ -1276,6 +1330,13 @@ export async function runAddChannel(options: AddChannelOptions): Promise<void> {
     const result = await options.runWebexAuth({ cwd: options.cwd })
     emit({ step: 'webex-auth', phase: 'done', result })
     if (!result.ok) throw new Error(`Webex authentication failed: ${result.reason}`)
+  }
+
+  if (options.channel === 'teams') {
+    emit({ step: 'teams-auth', phase: 'start' })
+    const result = await options.runTeamsAuth({ cwd: options.cwd })
+    emit({ step: 'teams-auth', phase: 'done', result })
+    if (!result.ok) throw new Error(`Teams authentication failed: ${result.reason}`)
   }
 
   if (options.channel === 'discord') {
@@ -1372,6 +1433,10 @@ function channelSecretsFromOptions(options: AddChannelOptions): ChannelSecrets {
     case 'webex-bot':
       return { token: options.webexBotToken }
     case 'webex':
+      return {}
+    case 'teams':
+      // Teams auth writes its structured account block directly to
+      // secrets.json#channels.teams before config mutation.
       return {}
     case 'instagram':
       return {}

--- a/src/init/teams-auth.test.ts
+++ b/src/init/teams-auth.test.ts
@@ -1,0 +1,164 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { SecretsTeamsCredentialStore } from '@/secrets/teams-store'
+
+const realTeams = await import('agent-messenger/teams')
+mock.module('agent-messenger/teams', () => ({
+  ...realTeams,
+  loginWithDeviceCode: async () => {
+    throw new Error('test must inject loginWithDeviceCode')
+  },
+}))
+
+type TeamsAuthModule = typeof import('./teams-auth')
+type LoginWithDeviceCodeFn = NonNullable<Parameters<TeamsAuthModule['runTeamsBootstrap']>[0]['loginWithDeviceCode']>
+
+let teamsAuth: TeamsAuthModule
+
+beforeAll(async () => {
+  teamsAuth = await import('./teams-auth')
+})
+
+const tmp = async (): Promise<string> => mkdtemp(join(tmpdir(), 'typeclaw-teams-test-'))
+
+type FakeAccount = {
+  token: string
+  token_expires_at?: string
+  region?: 'amer' | 'emea' | 'apac'
+  aad_refresh_token?: string
+  aad_client_id?: string
+  aad_tenant_id?: string
+}
+
+// A stand-in for the SDK's TeamsCredentialManager: the real login writes the
+// minted token into it, so the fake login populates `accounts` the same way and
+// runTeamsBootstrap reads it back through loadConfig().
+function fakeCredManager(accounts: Record<string, FakeAccount>) {
+  return {
+    async loadConfig() {
+      return { current_account: null, accounts }
+    },
+  } as unknown as InstanceType<typeof realTeams.TeamsCredentialManager>
+}
+
+describe('runTeamsBootstrap', () => {
+  test('persists the minted Teams account to secrets.json', async () => {
+    const agentDir = await tmp()
+    try {
+      const credManager = fakeCredManager({
+        work: {
+          token: 'skype-token-abc',
+          token_expires_at: '2026-01-01T01:00:00Z',
+          region: 'amer',
+          aad_refresh_token: 'aad-refresh',
+          aad_client_id: 'client-1',
+          aad_tenant_id: 'tenant-1',
+        },
+      })
+
+      const fakeLogin: LoginWithDeviceCodeFn = async (callbacks) => {
+        expect(callbacks.accountType).toBe('work')
+        await callbacks.onCode({
+          verificationUri: 'https://microsoft.com/devicelogin',
+          verificationUriComplete: 'https://microsoft.com/devicelogin?otc=ABCD',
+          userCode: 'ABCD-EFGH',
+          expiresAt: Date.now() + 600_000,
+        })
+        return { accountType: 'work', userName: 'Agent Smith', teams: [], current: null }
+      }
+
+      const result = await teamsAuth.runTeamsBootstrap({
+        agentDir,
+        accountType: 'work',
+        callbacks: { onCode: () => {} },
+        loginWithDeviceCode: fakeLogin,
+        credManager,
+      })
+
+      expect(result).toEqual({ ok: true })
+
+      const store = new SecretsTeamsCredentialStore({ mode: 'host', secretsPath: teamsAuth.teamsSecretsPath(agentDir) })
+      const account = await store.getAccount()
+      expect(account?.account_id).toBe('Agent Smith')
+      expect(account?.access_token).toBe('skype-token-abc')
+      expect(account?.token_expires_at).toBe('2026-01-01T01:00:00Z')
+      expect(account?.account_type).toBe('work')
+      expect(account?.region).toBe('amer')
+      expect(account?.user_name).toBe('Agent Smith')
+      expect(account?.aad_refresh_token).toBe('aad-refresh')
+      expect(account?.aad_client_id).toBe('client-1')
+      expect(account?.aad_tenant_id).toBe('tenant-1')
+
+      const stored = JSON.parse(await readFile(teamsAuth.teamsSecretsPath(agentDir), 'utf8')) as {
+        channels: { teams: { currentAccount: string } }
+      }
+      expect(stored.channels.teams.currentAccount).toBe('Agent Smith')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('falls back to account type as id when the login has no user name', async () => {
+    const agentDir = await tmp()
+    try {
+      const credManager = fakeCredManager({ personal: { token: 'skype-personal' } })
+      const result = await teamsAuth.runTeamsBootstrap({
+        agentDir,
+        accountType: 'personal',
+        callbacks: { onCode: () => {} },
+        loginWithDeviceCode: async () => ({ accountType: 'personal', userName: '', teams: [], current: null }),
+        credManager,
+      })
+
+      expect(result).toEqual({ ok: true })
+      const store = new SecretsTeamsCredentialStore({ mode: 'host', secretsPath: teamsAuth.teamsSecretsPath(agentDir) })
+      expect((await store.getAccount())?.account_id).toBe('personal')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('fails when the login persists no usable token', async () => {
+    const agentDir = await tmp()
+    try {
+      const credManager = fakeCredManager({})
+      const result = await teamsAuth.runTeamsBootstrap({
+        agentDir,
+        accountType: 'work',
+        callbacks: { onCode: () => {} },
+        loginWithDeviceCode: async () => ({ accountType: 'work', userName: 'X', teams: [], current: null }),
+        credManager,
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toMatch(/did not persist a usable Teams token/)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns failure when the device-code login throws', async () => {
+    const agentDir = await tmp()
+    try {
+      const result = await teamsAuth.runTeamsBootstrap({
+        agentDir,
+        accountType: 'work',
+        callbacks: { onCode: () => {} },
+        loginWithDeviceCode: async () => {
+          throw new Error('authorization declined')
+        },
+        credManager: fakeCredManager({}),
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.reason).toBe('authorization declined')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/init/teams-auth.ts
+++ b/src/init/teams-auth.ts
@@ -1,0 +1,111 @@
+import { join } from 'node:path'
+
+import {
+  loginWithDeviceCode as upstreamLoginWithDeviceCode,
+  TeamsCredentialManager,
+  type DeviceCodePrompt,
+  type DeviceLoginResult,
+} from 'agent-messenger/teams'
+
+import type { TeamsAccountRecord, TeamsAccountType } from '@/secrets/schema'
+import { SecretsTeamsCredentialStore } from '@/secrets/teams-store'
+
+export type TeamsBootstrapStatus = { ok: true } | { ok: false; reason: string }
+
+export type LoginWithDeviceCodeFn = typeof upstreamLoginWithDeviceCode
+
+export type TeamsDeviceCodeCallbacks = {
+  onCode: (prompt: DeviceCodePrompt) => void | Promise<void>
+  onPending?: () => void
+}
+
+export type TeamsLoginInput = {
+  agentDir: string
+  accountType: TeamsAccountType
+  callbacks: TeamsDeviceCodeCallbacks
+  loginWithDeviceCode?: LoginWithDeviceCodeFn
+  // The SDK persists the minted token in its own config dir; scope it to the
+  // agent folder so the login is self-contained and read-back is deterministic
+  // instead of leaking into the operator's global agent-messenger config.
+  credManager?: TeamsCredentialManager
+}
+
+export function teamsSecretsPath(agentDir: string): string {
+  return join(agentDir, 'secrets.json')
+}
+
+export async function runTeamsBootstrap(input: TeamsLoginInput): Promise<TeamsBootstrapStatus> {
+  try {
+    const loginWithDeviceCode = input.loginWithDeviceCode ?? upstreamLoginWithDeviceCode
+    const credManager = input.credManager ?? new TeamsCredentialManager(teamsConfigDir(input.agentDir))
+
+    const result = await loginWithDeviceCode(
+      {
+        accountType: input.accountType,
+        onCode: input.callbacks.onCode,
+        ...(input.callbacks.onPending !== undefined ? { onPending: input.callbacks.onPending } : {}),
+      },
+      credManager,
+    )
+
+    const record = await buildAccountRecord(result, credManager)
+    if (record === null) {
+      return { ok: false, reason: 'device-code login did not persist a usable Teams token' }
+    }
+
+    const store = new SecretsTeamsCredentialStore({ mode: 'host', secretsPath: teamsSecretsPath(input.agentDir) })
+    await store.setAccount(record)
+    await store.setCurrentAccount(record.account_id)
+
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+// The SDK writes the minted token into its own credential manager keyed by
+// account type; read it back and translate into typeclaw's TeamsAccountRecord
+// shape for secrets.json. The AAD refresh trio is what lets the runtime adapter
+// silently re-mint the ~60-90min skype token, so it must survive the hop.
+async function buildAccountRecord(
+  result: DeviceLoginResult,
+  credManager: TeamsCredentialManager,
+): Promise<TeamsAccountRecord | null> {
+  const config = await credManager.loadConfig()
+  const account = config?.accounts[result.accountType]
+  if (account === undefined || account.token === '') return null
+
+  const now = new Date().toISOString()
+  const accountId = accountIdFor(result)
+  return {
+    account_id: accountId,
+    access_token: account.token,
+    ...(account.token_expires_at !== undefined ? { token_expires_at: account.token_expires_at } : {}),
+    account_type: result.accountType,
+    ...(account.region !== undefined ? { region: account.region } : {}),
+    ...(result.userName !== undefined ? { user_name: result.userName } : {}),
+    ...(account.aad_refresh_token !== undefined ? { aad_refresh_token: account.aad_refresh_token } : {}),
+    ...(account.aad_client_id !== undefined ? { aad_client_id: account.aad_client_id } : {}),
+    ...(account.aad_tenant_id !== undefined ? { aad_tenant_id: account.aad_tenant_id } : {}),
+    created_at: now,
+    updated_at: now,
+  }
+}
+
+// A stable per-account id for secrets.json. Teams has no cheap unique user id
+// surfaced by the device-code result, so key on the display name when present
+// and fall back to the account type, so a re-auth of the same account replaces
+// its record rather than accumulating duplicates.
+function accountIdFor(result: DeviceLoginResult): string {
+  const name = result.userName?.trim()
+  return name !== undefined && name !== '' ? name : result.accountType
+}
+
+// The SDK caches the minted token in this dir; keep it under the already
+// gitignored `.typeclaw/` local-scratch root so Teams tokens / AAD refresh
+// tokens can never be staged into git by accident.
+function teamsConfigDir(agentDir: string): string {
+  return join(agentDir, '.typeclaw', 'teams-auth')
+}
+
+export type { DeviceCodePrompt, DeviceLoginResult }

--- a/src/secrets/schema.ts
+++ b/src/secrets/schema.ts
@@ -183,6 +183,7 @@ export const webexChannelBlockSchema = z.object({
 })
 
 const teamsAccountTypeSchema = z.union([z.literal('work'), z.literal('personal')])
+export type TeamsAccountType = z.infer<typeof teamsAccountTypeSchema>
 const teamsRegionSchema = z.union([z.literal('amer'), z.literal('emea'), z.literal('apac')])
 
 // Teams user-account credentials. The short-lived `access_token` expires in


### PR DESCRIPTION
## Background

PRs #1154 and #1156 landed the Microsoft Teams channel adapter fully wired into the runtime — chat and team-channel messaging, structured mentions, self-echo suppression — but Teams could only be configured by hand-populating `secrets.json#channels.teams`. It was explicitly excluded from every interactive auth path: no `channel add teams`, no `channel reauth teams`, no init-wizard entry. This is **3 of 3** PRs closing the gaps around the Teams launch: #1159 (docs) and #1160 (CLI/operator parity) landed the surrounding pieces; this PR makes the auth flow #1159 already documents actually real.

## Summary

Adds a device-code (AAD OAuth device flow) login and wires it into every place typeclaw drives interactive channel auth:

- **`src/init/teams-auth.ts`** (new) — drives the agent-messenger SDK's device-code login, then reads the minted account back out of the SDK's own credential manager and translates it into a `TeamsAccountRecord` in `secrets.json#channels.teams`. The read-back is deliberate, not incidental: the SDK persists the token into its own credential manager, not typeclaw's secrets store, so the bootstrap has to hop between the two. The AAD refresh trio (`aad_refresh_token`/`aad_client_id`/`aad_tenant_id`) is carried across that hop unchanged — drop it and the account silently degrades to reauth-required after the ~60–90min access token expires, since the runtime adapter relies on that trio to re-mint it silently. Login is scoped to a per-agent config dir so it doesn't leak into the operator's global agent-messenger config.
- **`src/init/index.ts`** — a `teams` branch in `runAddChannel` with auth-first ordering (same as webex/discord): the device-code login runs *before* any config/secrets write, so a declined or expired login leaves the agent folder untouched, nothing half-applied. Also threads the `withTeams` scaffold flag, teams step-events, and `hasExistingChannelSecrets` support so re-running the wizard reuses an existing account instead of re-authenticating.
- **`src/cli/channel.ts`** — drops the `ADDABLE_CHANNEL_KINDS` exclusion; wires `channel add teams` (prompt work vs. personal account, display the device code + `microsoft.com/devicelogin` URL, poll for approval) and `channel reauth teams` (replay the login). Teams joins `REAUTHABLE_ADAPTERS`, not the token-rotation `set` family — it's a user-account adapter with no bot variant, so it belongs with the other account-login adapters.
- **`src/cli/init.ts`** — adds "Teams (User)" to the first-channel wizard: a picker option, a flow collecting the account type, and threading the device-code auth runner into `runInit`.

`src/secrets/schema.ts` also exports `TeamsAccountType` so callers can type the account-type choice; `src/init/checkpoint.ts` picks up the `withTeams` flag.

## Review notes

- Load-bearing: the SDK-credential-manager read-back in `teams-auth.ts`. The login itself succeeds inside the SDK regardless of whether the AAD refresh trio makes it into `secrets.json` — a regression here degrades silently (the account works for ~60–90min, then requires manual reauth) rather than failing loudly. Covered by 4 unit tests (success, id-fallback, no-token, throw).
- The other load-bearing piece is auth-first ordering in `runAddChannel`: verify the teams branch runs the login before touching `typeclaw.json`/secrets, matching the existing webex/kakaotalk pattern.
- `hasExistingChannelSecrets` reuse path: a wizard re-run against an already-authed teams account should skip login entirely rather than forcing a fresh device-code flow.

## Notes

- 3-PR split: #1159 (docs), #1160 (CLI/operator parity), this PR (interactive auth). This is the last of the three — Teams now has full parity with the other user-account adapters end to end.
- `bun run typecheck` (clean), `bun run lint` (0 errors), `bun run format:check` (clean), `bun run test` — 10606 pass, 0 fail. New tests: 4 for the bootstrap + 2 `runInit` paths (auth-runner wiring, account reuse).
