### PR TITLE
fix(channels): keep teams adapter live across SDK reconnects

### DIFF
--- a/src/channels/adapters/teams.test.ts
+++ b/src/channels/adapters/teams.test.ts
@@ -506,6 +506,35 @@ describe('createTeamsAdapter', () => {
     await adapter.stop()
   })
 
+  test('isConnected recovers when the SDK re-emits connected after a reconnect', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = adapterWith({ r, listener, client: fakeClient().client })
+
+    await adapter.start()
+    // given a transient drop the SDK reports as disconnected
+    listener.emit('disconnected', undefined)
+    expect(adapter.isConnected()).toBe(false)
+    // when the SDK auto-reconnects and re-registers its endpoint
+    listener.emit('connected', { endpointId: 'ep-2' })
+    // then the adapter reports live again without a manager restart
+    expect(adapter.isConnected()).toBe(true)
+
+    await adapter.stop()
+  })
+
+  test('a stale listener event after stop cannot flip connected state', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = adapterWith({ r, listener, client: fakeClient().client })
+
+    await adapter.start()
+    await adapter.stop()
+    // a late event from the stopped listener must not resurrect connected state
+    listener.emit('connected', { endpointId: 'ep-stale' })
+    expect(adapter.isConnected()).toBe(false)
+  })
+
   test('rolls back every registration when the listener errors before connecting', async () => {
     const r = router()
     const listener = new FakeListener()

--- a/src/channels/adapters/teams.ts
+++ b/src/channels/adapters/teams.ts
@@ -300,7 +300,22 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
       }
 
       listener = createListener(client)
+      // The SDK auto-reconnects on any WebSocket drop and re-emits `connected`
+      // each reconnect. This permanent handler is what tracks liveness across
+      // reconnects: the one-shot startup wait below only sees the FIRST
+      // `connected`, so without this the flag would stay stuck false after the
+      // first reconnect and the manager's recovery loop would needlessly
+      // restart the adapter. The identity guard stops a late event from a
+      // stopped/rolled-back listener from mutating a fresh adapter's state.
+      const activeListener = listener
+      const isActive = (): boolean => listener === activeListener && started
+      listener.on('connected', () => {
+        if (!isActive()) return
+        connected = true
+        logger.info('[teams] connected')
+      })
       listener.on('disconnected', () => {
+        if (!isActive()) return
         connected = false
         logger.warn('[teams] disconnected')
       })


### PR DESCRIPTION
## Background

The Teams channel adapter stops being treated as live after its first WebSocket reconnect, which triggers needless full adapter restarts and drops inbound messages during each teardown window.

Root-cause mechanism: the `agent-messenger` `TeamsListener` auto-reconnects on any WebSocket drop and re-emits `connected` every time it re-registers its trouter endpoint (an unregistered endpoint receives no messages, so this event is the real liveness signal). The typeclaw adapter, however, only observed `connected` through the **one-shot** startup wait `waitForTeamsConnected`, which removes its own `connected`/`error` handlers after the first fire. It wired a **permanent** handler for `disconnected` (sets `connected = false`) but none for `connected`. So the sequence is:

1. transient drop → `disconnected` → `connected = false`
2. SDK auto-reconnects within seconds and re-emits `connected` → **adapter ignores it**; the flag stays stuck `false`
3. `isConnected()` (`started && self !== null && connected`) wrongly reports dead
4. the channel manager's recovery loop waits out the 90s disconnected-grace and **force-restarts** the adapter (`stop()` → `start()`), dropping the `message` handler mid-flight and re-running the 20s connect gate

Teams user tokens expire in 60–90 min, so drops/reconnects are frequent and this restart churn is effectively chronic — matching the report that the adapter "doesn't listen to inbound messages properly."

## Summary

Add a **permanent** `connected` handler (mirroring the existing `disconnected` one) so the `connected` flag tracks every reconnect, not just the first. The startup one-shot wait is retained unchanged — it still gives `start()` the "endpoint is registered and ready" guarantee before resolving.

Both permanent handlers are **identity-guarded** against the active listener (`listener === activeListener && started`). Why: the rollback and manager-restart paths null out `listener` and set `started = false`; without the guard, a late `connected`/`disconnected` event from a stopped or rolled-back listener could mutate the state of a fresh adapter instance. The guard makes stale events no-ops.

Regression test asserts the full cycle: `connected` after start → `disconnected` (`isConnected() === false`) → `connected` again (`isConnected() === true`). It fails red against the unfixed adapter. A second test asserts a stale event after `stop()` cannot flip state back to connected.

## What this does NOT do

- Does not change the inbound routing path, classification, or self-echo suppression (all correct as-is).
- Does not touch the manager recovery loop — the outer restart is still a valid last-resort for genuinely prolonged failure; this just stops it firing on healthy reconnects.
- Does not change the `agent-messenger` SDK (the SDK's reconnect behavior is correct; the bug was entirely on typeclaw's wrapper side).
- No change to the 20s startup connect timeout or the rollback semantics.

## Review notes

- Load-bearing change: the new permanent `listener.on('connected', ...)` in `createTeamsAdapter`'s `start()`, plus the `isActive()` identity guard now applied to both `connected` and `disconnected`.
- Invariant to verify: after `stop()` or a failed/rolled-back `start()`, no residual listener event can set `connected = true` on a new instance (covered by the "stale listener event after stop" test).
- Unrelated: `bun run lint` reports 67 pre-existing warnings across the repo (0 errors); none are in the changed files.