### PR TITLE
feat(hostd): auto-refresh Teams tokens before they expire

### DIFF
--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -7,6 +7,7 @@ import { startDaemon, type DaemonLogEvent, type RestartPreflight } from '@/hostd
 import { createKakaoRenewalManager } from '@/hostd/kakao-renewal-manager'
 import { createPortbrokerManager } from '@/hostd/portbroker-manager'
 import type { SupervisorLogEvent, SupervisorRestart } from '@/hostd/supervisor'
+import { createTeamsRenewalManager } from '@/hostd/teams-renewal-manager'
 import { computeSourceVersion, resolveSrcRoot, UNVERSIONED_SENTINEL } from '@/hostd/version'
 import { createWebexRenewalManager } from '@/hostd/webex-renewal-manager'
 import { validateRestartDeps, type RestartDepsPreflightResult } from '@/init/restart-deps-preflight'
@@ -57,6 +58,19 @@ export const hostdCommand = defineCommand({
       },
       shouldRenew: ({ cwd }) => webexChannelConfigured(cwd),
     })
+    const teamsRenewal = createTeamsRenewalManager({
+      onLog: (event) => writeLogLine(formatLog(event)),
+      onRenewalOk: async ({ containerName, cwd }) => {
+        // Restart so the in-memory TeamsClient picks up the renewed token from
+        // secrets.json. Without this, the cron writes a fresh token but the
+        // running adapter keeps the old token in its login closure and still
+        // cannot obtain an id_token for the realtime listener.
+        const currentHostDaemon = await currentHostDaemonHolder.ready()
+        const result = await hostdRestart({ containerName, cwd, currentHostDaemon })
+        if (!result.ok) throw new Error(result.reason)
+      },
+      shouldRenew: ({ cwd }) => teamsChannelConfigured(cwd),
+    })
 
     const daemon = await startDaemon({
       onLog: (e) => writeLogLine(formatLog(e)),
@@ -65,6 +79,7 @@ export const hostdCommand = defineCommand({
       portbroker,
       kakaoRenewal,
       webexRenewal,
+      teamsRenewal,
       currentHostDaemonHolder,
       restartPreflight: buildHostdRestartPreflight(cliEntry, version, defaultPreflightDeps),
       restart: hostdRestart,
@@ -76,6 +91,7 @@ export const hostdCommand = defineCommand({
         .then(() => portbroker.drain())
         .then(() => kakaoRenewal.drain())
         .then(() => webexRenewal.drain())
+        .then(() => teamsRenewal.drain())
         .then(() => process.exit(0))
     }
     process.on('SIGTERM', shutdown)
@@ -242,6 +258,22 @@ function formatLog(event: DaemonLogEvent | SupervisorLogEvent): string {
       return `[hostd] webex renewal scheduled container restart for ${event.containerName} account=${event.accountId}`
     case 'webex-renewal-restart-failed':
       return `[hostd] webex renewal container restart FAILED for ${event.containerName} account=${event.accountId}: ${event.reason}`
+    case 'teams-renewal-tick-start':
+      return `[hostd] teams renewal tick started for ${event.containerName}`
+    case 'teams-renewal-tick-skipped':
+      return `[hostd] teams renewal skipped for ${event.containerName}: ${event.reason}${event.expiresInMs !== undefined ? ` (expires in ${Math.round(event.expiresInMs / 1000 / 60)}m)` : ''}`
+    case 'teams-renewal-tick-ok':
+      return `[hostd] teams renewal OK for ${event.containerName} account=${event.accountId} (new token expires ${new Date(event.nextExpiresAt).toISOString()})`
+    case 'teams-renewal-tick-reauth-required':
+      return `[hostd] teams renewal REAUTH REQUIRED for ${event.containerName} account=${event.accountId} reason=${event.reason} — ${event.message}`
+    case 'teams-renewal-tick-transient-failure':
+      return `[hostd] teams renewal transient failure for ${event.containerName} account=${event.accountId}: ${event.reason}`
+    case 'teams-renewal-tick-error':
+      return `[hostd] teams renewal ERROR for ${event.containerName}: ${event.error}`
+    case 'teams-renewal-restart-scheduled':
+      return `[hostd] teams renewal scheduled container restart for ${event.containerName} account=${event.accountId}`
+    case 'teams-renewal-restart-failed':
+      return `[hostd] teams renewal container restart FAILED for ${event.containerName} account=${event.accountId}: ${event.reason}`
   }
 }
 
@@ -264,6 +296,15 @@ function webexChannelConfigured(cwd: string): boolean {
   try {
     const cfg = loadConfigSync(cwd)
     return cfg.channels?.webex !== undefined
+  } catch {
+    return false
+  }
+}
+
+function teamsChannelConfigured(cwd: string): boolean {
+  try {
+    const cfg = loadConfigSync(cwd)
+    return cfg.channels?.teams !== undefined
   } catch {
     return false
   }

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -36,6 +36,7 @@ import type {
 } from './protocol'
 import { buildSupervisor, type SupervisorLogEvent, type SupervisorRestart } from './supervisor'
 import type { TailscaleServeEvent } from './tailscale'
+import type { TeamsRenewalCallbacks, TeamsRenewalLogEvent } from './teams-renewal-manager'
 import { UNVERSIONED_SENTINEL } from './version'
 import type { WebexRenewalCallbacks, WebexRenewalLogEvent } from './webex-renewal-manager'
 
@@ -79,6 +80,10 @@ export type DaemonOptions = {
   // ticks hourly because Webex password tokens live ~27h (see
   // webex-renewal-manager.ts). Omit when the agent has no webex channel.
   webexRenewal?: WebexRenewalCallbacks
+  // Teams credential renewal capability. Same lifecycle as webexRenewal but
+  // ticks every 5 minutes because Teams skype tokens live only 60-90 min (see
+  // teams-renewal-manager.ts). Omit when the agent has no teams channel.
+  teamsRenewal?: TeamsRenewalCallbacks
   // Populated once the daemon is booted so direct callers of the restart
   // (the renewal callbacks in cli/hostd.ts) get the in-process registration
   // path instead of the socket self-RPC. Omit in tests that don't exercise it.
@@ -126,6 +131,7 @@ export type DaemonLogEvent =
   | { kind: 'tailscale-serve-event'; event: TailscaleServeEvent }
   | KakaoRenewalLogEvent
   | WebexRenewalLogEvent
+  | TeamsRenewalLogEvent
 
 export type Daemon = {
   registered: () => string[]
@@ -397,6 +403,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         await withCleanupTimeout(opts.portbroker.stop(containerName, 'fatal-auth'), cleanupStepTimeoutMs)
       if (opts.kakaoRenewal) await withCleanupTimeout(opts.kakaoRenewal.stop(containerName), cleanupStepTimeoutMs)
       if (opts.webexRenewal) await withCleanupTimeout(opts.webexRenewal.stop(containerName), cleanupStepTimeoutMs)
+      if (opts.teamsRenewal) await withCleanupTimeout(opts.teamsRenewal.stop(containerName), cleanupStepTimeoutMs)
       await removeRegistrationFile(containerName)
       log({ kind: 'registration-skipped', containerName, reason: `fatal broker auth: ${reason}` })
     })
@@ -435,6 +442,9 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
     if (opts.webexRenewal) {
       opts.webexRenewal.start({ containerName: payload.containerName, cwd: payload.cwd })
     }
+    if (opts.teamsRenewal) {
+      opts.teamsRenewal.start({ containerName: payload.containerName, cwd: payload.cwd })
+    }
   }
 
   const registerContainer = async (req: RegisterPayload): Promise<RpcResponse> => {
@@ -466,6 +476,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         await withCleanupTimeout(opts.portbroker.stop(req.containerName, 'deregistered'), cleanupStepTimeoutMs)
       if (opts.kakaoRenewal) await withCleanupTimeout(opts.kakaoRenewal.stop(req.containerName), cleanupStepTimeoutMs)
       if (opts.webexRenewal) await withCleanupTimeout(opts.webexRenewal.stop(req.containerName), cleanupStepTimeoutMs)
+      if (opts.teamsRenewal) await withCleanupTimeout(opts.teamsRenewal.stop(req.containerName), cleanupStepTimeoutMs)
       await removeRegistrationFile(req.containerName)
       if (hadCwd) log({ kind: 'deregister', containerName: req.containerName, reason: 'requested' })
       return { ok: true }
@@ -819,6 +830,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
         if (opts.portbroker) await withCleanupTimeout(opts.portbroker.stop(name, 'deregistered'), cleanupStepTimeoutMs)
         if (opts.kakaoRenewal) await withCleanupTimeout(opts.kakaoRenewal.stop(name), cleanupStepTimeoutMs)
         if (opts.webexRenewal) await withCleanupTimeout(opts.webexRenewal.stop(name), cleanupStepTimeoutMs)
+        if (opts.teamsRenewal) await withCleanupTimeout(opts.teamsRenewal.stop(name), cleanupStepTimeoutMs)
         await removeRegistrationFile(name)
         if (hadCwd) log({ kind: 'deregister', containerName: name, reason: 'gone' })
         return { ok: true }
@@ -861,6 +873,10 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       if (opts.webexRenewal) {
         const names = Array.from(cwds.keys())
         await withCleanupTimeout(Promise.allSettled(names.map((n) => opts.webexRenewal!.stop(n))), cleanupStepTimeoutMs)
+      }
+      if (opts.teamsRenewal) {
+        const names = Array.from(cwds.keys())
+        await withCleanupTimeout(Promise.allSettled(names.map((n) => opts.teamsRenewal!.stop(n))), cleanupStepTimeoutMs)
       }
       cwds.clear()
       restartTokens.clear()

--- a/src/hostd/teams-renewal-manager.test.ts
+++ b/src/hostd/teams-renewal-manager.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { renewCurrentAccount } from '@/secrets/teams-renewal'
+import { expectStable, waitFor } from '@/test-helpers/wait-for'
+
+import { createTeamsRenewalManager, type TeamsRenewalLogEvent } from './teams-renewal-manager'
+
+type RenewFn = typeof renewCurrentAccount
+type RenewResult = Awaited<ReturnType<RenewFn>>
+
+function renewReturning(result: RenewResult): RenewFn {
+  return (async () => result) as RenewFn
+}
+
+const OK: RenewResult = { kind: 'ok', account_id: 'acc-1', previousExpiresAt: 1, nextExpiresAt: 2 }
+const SKIPPED: RenewResult = { kind: 'skipped', reason: 'fresh_enough', expiresInMs: 999 }
+const REAUTH: RenewResult = { kind: 'reauth_required', account_id: 'acc-1', reason: 'no_refresh_token', message: 'x' }
+const TRANSIENT: RenewResult = { kind: 'transient_failure', account_id: 'acc-1', reason: 'silent_refresh_failed' }
+
+describe('createTeamsRenewalManager', () => {
+  test('runs the first tick immediately and emits tick-ok on a successful renewal', async () => {
+    const events: TeamsRenewalLogEvent[] = []
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(OK),
+      schedule: () => ({ stop: () => {} }),
+      onLog: (e) => events.push(e),
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await manager.drain()
+
+    expect(events.some((e) => e.kind === 'teams-renewal-tick-ok')).toBe(true)
+  })
+
+  test('emits tick-skipped when the token is fresh', async () => {
+    const events: TeamsRenewalLogEvent[] = []
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(SKIPPED),
+      schedule: () => ({ stop: () => {} }),
+      onLog: (e) => events.push(e),
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await manager.drain()
+
+    expect(events.some((e) => e.kind === 'teams-renewal-tick-skipped')).toBe(true)
+  })
+
+  test('emits tick-reauth-required when the account has no refresh token', async () => {
+    const events: TeamsRenewalLogEvent[] = []
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(REAUTH),
+      schedule: () => ({ stop: () => {} }),
+      onLog: (e) => events.push(e),
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await manager.drain()
+
+    expect(events.some((e) => e.kind === 'teams-renewal-tick-reauth-required')).toBe(true)
+  })
+
+  test('emits tick-transient-failure and does NOT restart on a transient failure', async () => {
+    const events: TeamsRenewalLogEvent[] = []
+    let restarts = 0
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(TRANSIENT),
+      schedule: () => ({ stop: () => {} }),
+      onLog: (e) => events.push(e),
+      onRenewalOk: async () => {
+        restarts++
+      },
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await manager.drain()
+
+    expect(events.some((e) => e.kind === 'teams-renewal-tick-transient-failure')).toBe(true)
+    expect(restarts).toBe(0)
+  })
+
+  test('invokes onRenewalOk after a successful renewal so the host can restart the container', async () => {
+    const restarts: Array<{ containerName: string; cwd: string; accountId: string }> = []
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(OK),
+      schedule: () => ({ stop: () => {} }),
+      onRenewalOk: async (input) => {
+        restarts.push(input)
+      },
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await waitFor(() => restarts.length > 0)
+    await manager.drain()
+
+    expect(restarts).toEqual([{ containerName: 'teams', cwd: '/agent', accountId: 'acc-1' }])
+  })
+
+  test('does NOT invoke onRenewalOk when the renewal skips', async () => {
+    let restarts = 0
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(SKIPPED),
+      schedule: () => ({ stop: () => {} }),
+      onRenewalOk: async () => {
+        restarts++
+      },
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await manager.drain()
+
+    expect(restarts).toBe(0)
+  })
+
+  test('logs teams-renewal-restart-failed when onRenewalOk throws', async () => {
+    const events: TeamsRenewalLogEvent[] = []
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(OK),
+      schedule: () => ({ stop: () => {} }),
+      onRenewalOk: async () => {
+        throw new Error('docker stop refused')
+      },
+      onLog: (e) => events.push(e),
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await waitFor(() => events.some((e) => e.kind === 'teams-renewal-restart-failed'))
+    await manager.drain()
+
+    expect(events.some((e) => e.kind === 'teams-renewal-tick-ok')).toBe(true)
+    expect(events.some((e) => e.kind === 'teams-renewal-restart-failed')).toBe(true)
+  })
+
+  test('shouldRenew=false suppresses the cron entirely (no tick, no timer, no log spam)', async () => {
+    const events: TeamsRenewalLogEvent[] = []
+    let scheduleCalls = 0
+    let renewCalls = 0
+    const manager = createTeamsRenewalManager({
+      renew: (async () => {
+        renewCalls++
+        return OK
+      }) as RenewFn,
+      schedule: () => {
+        scheduleCalls++
+        return { stop: () => {} }
+      },
+      onLog: (e) => events.push(e),
+      shouldRenew: () => false,
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await expectStable(() => renewCalls > 0 || scheduleCalls > 0 || events.length > 0, {
+      durationMs: 25,
+      description: 'suppressed cron activity',
+    })
+
+    expect(scheduleCalls).toBe(0)
+    expect(renewCalls).toBe(0)
+    expect(events).toHaveLength(0)
+
+    await manager.drain()
+  })
+
+  test('stop() cancels the scheduled timer', async () => {
+    let scheduleStopCalled = 0
+    const manager = createTeamsRenewalManager({
+      renew: renewReturning(OK),
+      schedule: () => ({
+        stop: () => {
+          scheduleStopCalled++
+        },
+      }),
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await manager.stop('teams')
+
+    expect(scheduleStopCalled).toBe(1)
+    await manager.drain()
+  })
+
+  test('drain() awaits in-flight renewal work so the daemon does not exit mid-refresh', async () => {
+    let renewStarted = false
+    let renewFinished = false
+    let release: (() => void) | null = null
+    const manager = createTeamsRenewalManager({
+      renew: (async () => {
+        renewStarted = true
+        await new Promise<void>((r) => {
+          release = r
+        })
+        renewFinished = true
+        return OK
+      }) as RenewFn,
+      schedule: () => ({ stop: () => {} }),
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await waitFor(() => renewStarted)
+    expect(renewFinished).toBe(false)
+
+    const drainPromise = manager.drain()
+    const racer = Promise.race([drainPromise, new Promise((r) => setTimeout(() => r('timeout'), 50))])
+    expect(await racer).toBe('timeout')
+
+    release!()
+    await drainPromise
+    expect(renewFinished).toBe(true)
+  })
+
+  test('does NOT restart the old cwd when the container re-registers with a new cwd mid-tick', async () => {
+    let firstRenewStarted = false
+    let release: (() => void) | null = null
+    let renewCalls = 0
+    const restartCwds: string[] = []
+    const manager = createTeamsRenewalManager({
+      renew: (async () => {
+        // Only the first tick parks; the re-run after re-register resolves
+        // immediately so the pending-rerun loop can finish.
+        if (renewCalls++ === 0) {
+          firstRenewStarted = true
+          await new Promise<void>((r) => {
+            release = r
+          })
+        }
+        return OK
+      }) as RenewFn,
+      schedule: () => ({ stop: () => {} }),
+      onRenewalOk: async ({ cwd }) => {
+        restartCwds.push(cwd)
+      },
+    })
+
+    manager.start({ containerName: 'teams', cwd: '/agent' })
+    await waitFor(() => firstRenewStarted)
+
+    manager.start({ containerName: 'teams', cwd: '/agent/relocated' })
+    release!()
+    await manager.drain()
+
+    expect(restartCwds).not.toContain('/agent')
+  })
+})

--- a/src/hostd/teams-renewal-manager.ts
+++ b/src/hostd/teams-renewal-manager.ts
@@ -1,0 +1,212 @@
+import { renewCurrentAccount } from '@/secrets/teams-renewal'
+
+// Teams skype tokens live only 60-90 minutes (far shorter than Webex's ~27h),
+// so the tick is minutes not hours: 5 minutes gives ~3 refresh attempts inside
+// the 15-minute renewal window before a token would lapse, while a fresh token
+// short-circuits to a cheap no-op skip.
+const DEFAULT_TICK_INTERVAL_MS = 5 * 60 * 1000
+
+export type TeamsRenewalCallbacks = {
+  start: (input: TeamsRenewalStartInput) => void
+  stop: (containerName: string) => Promise<void>
+  drain: () => Promise<void>
+}
+
+export type TeamsRenewalStartInput = {
+  containerName: string
+  cwd: string
+}
+
+export type TeamsRenewalLogEvent =
+  | { kind: 'teams-renewal-tick-start'; containerName: string }
+  | { kind: 'teams-renewal-tick-skipped'; containerName: string; reason: string; expiresInMs?: number }
+  | { kind: 'teams-renewal-tick-ok'; containerName: string; accountId: string; nextExpiresAt: number }
+  | {
+      kind: 'teams-renewal-tick-reauth-required'
+      containerName: string
+      accountId: string
+      reason: string
+      message: string
+    }
+  | { kind: 'teams-renewal-tick-transient-failure'; containerName: string; accountId: string; reason: string }
+  | { kind: 'teams-renewal-tick-error'; containerName: string; error: string }
+  | { kind: 'teams-renewal-restart-scheduled'; containerName: string; accountId: string }
+  | { kind: 'teams-renewal-restart-failed'; containerName: string; accountId: string; reason: string }
+
+export type TeamsRenewalManagerOptions = {
+  onLog?: (event: TeamsRenewalLogEvent) => void
+  tickIntervalMs?: number
+  renew?: typeof renewCurrentAccount
+  schedule?: (fn: () => void, intervalMs: number) => { stop: () => void }
+  // Invoked after a successful renewal so the host can restart the container and
+  // the in-memory TeamsClient picks up the fresh token. Without this, the cron
+  // writes a new token to secrets.json but the live client keeps the old token
+  // in its login closure (src/channels/adapters/teams.ts) and still fails to
+  // obtain an id_token for the realtime listener.
+  onRenewalOk?: (input: { containerName: string; cwd: string; accountId: string }) => Promise<void>
+  // Only start the renewal cron for containers whose typeclaw.json actually has
+  // a channels.teams block, so non-teams agents don't emit no_account skip logs.
+  shouldRenew?: (input: TeamsRenewalStartInput) => boolean
+}
+
+export function createTeamsRenewalManager(opts: TeamsRenewalManagerOptions = {}): TeamsRenewalCallbacks {
+  const intervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS
+  const renew = opts.renew ?? renewCurrentAccount
+  const log = opts.onLog ?? (() => {})
+  const schedule =
+    opts.schedule ??
+    ((fn: () => void, ms: number) => {
+      const handle = setInterval(fn, ms)
+      return { stop: () => clearInterval(handle) }
+    })
+
+  const timers = new Map<string, { stop: () => void }>()
+  const latestInput = new Map<string, TeamsRenewalStartInput>()
+  const inFlight = new Map<string, Promise<void>>()
+  const pendingRerun = new Set<string>()
+
+  const runTick = async (input: TeamsRenewalStartInput): Promise<void> => {
+    log({ kind: 'teams-renewal-tick-start', containerName: input.containerName })
+    try {
+      const result = await renew({ agentDir: input.cwd })
+      if (result.kind === 'skipped') {
+        log({
+          kind: 'teams-renewal-tick-skipped',
+          containerName: input.containerName,
+          reason: result.reason,
+          ...(result.expiresInMs !== undefined ? { expiresInMs: result.expiresInMs } : {}),
+        })
+      } else if (result.kind === 'ok') {
+        log({
+          kind: 'teams-renewal-tick-ok',
+          containerName: input.containerName,
+          accountId: result.account_id,
+          nextExpiresAt: result.nextExpiresAt,
+        })
+        // A tick that started before stop()/drain() or before a re-register with
+        // a different cwd can finish here. Restarting a container that is no
+        // longer the current registration would resurrect a just-deregistered
+        // agent or fight a shutdown, so skip onRenewalOk unless this
+        // container+cwd is still the live registration.
+        const current = latestInput.get(input.containerName)
+        if (opts.onRenewalOk && current?.cwd === input.cwd) {
+          log({
+            kind: 'teams-renewal-restart-scheduled',
+            containerName: input.containerName,
+            accountId: result.account_id,
+          })
+          try {
+            await opts.onRenewalOk({
+              containerName: input.containerName,
+              cwd: input.cwd,
+              accountId: result.account_id,
+            })
+          } catch (err) {
+            log({
+              kind: 'teams-renewal-restart-failed',
+              containerName: input.containerName,
+              accountId: result.account_id,
+              reason: err instanceof Error ? err.message : String(err),
+            })
+          }
+        }
+      } else if (result.kind === 'reauth_required') {
+        log({
+          kind: 'teams-renewal-tick-reauth-required',
+          containerName: input.containerName,
+          accountId: result.account_id,
+          reason: result.reason,
+          message: result.message,
+        })
+      } else {
+        log({
+          kind: 'teams-renewal-tick-transient-failure',
+          containerName: input.containerName,
+          accountId: result.account_id,
+          reason: result.reason,
+        })
+      }
+    } catch (err) {
+      log({
+        kind: 'teams-renewal-tick-error',
+        containerName: input.containerName,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const scheduleTick = (containerName: string): Promise<void> => {
+    const existing = inFlight.get(containerName)
+    if (existing) {
+      pendingRerun.add(containerName)
+      return existing
+    }
+    const promise = (async () => {
+      while (true) {
+        const input = latestInput.get(containerName)
+        if (!input) return
+        await runTick(input)
+        if (!pendingRerun.has(containerName)) return
+        pendingRerun.delete(containerName)
+      }
+    })().finally(() => {
+      inFlight.delete(containerName)
+      pendingRerun.delete(containerName)
+    })
+    inFlight.set(containerName, promise)
+    return promise
+  }
+
+  return {
+    start(input: TeamsRenewalStartInput): void {
+      // Tear down any prior registration BEFORE the shouldRenew gate: the daemon
+      // calls start() on every registration, so a container that had Teams can
+      // re-register to a non-Teams cwd; returning early without clearing would
+      // leave the old timer ticking and let a post-login restart guard match the
+      // stale cwd. Clearing latestInput also fails an in-flight tick's
+      // onRenewalOk re-check.
+      const existing = timers.get(input.containerName)
+      if (existing) {
+        existing.stop()
+        timers.delete(input.containerName)
+      }
+      latestInput.delete(input.containerName)
+
+      if (opts.shouldRenew && !opts.shouldRenew(input)) return
+
+      latestInput.set(input.containerName, input)
+      const handle = schedule(() => {
+        void scheduleTick(input.containerName)
+      }, intervalMs)
+      timers.set(input.containerName, handle)
+      void scheduleTick(input.containerName)
+    },
+
+    // Must NOT await the in-flight tick: a successful tick runs onRenewalOk →
+    // hostdRestart → container stop() → deregister RPC → teamsRenewal.stop(), so
+    // awaiting inFlight here waits on the very tick parked waiting for this
+    // restart — a self-deadlock. Clearing latestInput (not the await) is what
+    // fails the tick's onRenewalOk guard; drain() still awaits.
+    stop(containerName: string): Promise<void> {
+      const handle = timers.get(containerName)
+      if (handle) {
+        timers.delete(containerName)
+        handle.stop()
+      }
+      latestInput.delete(containerName)
+      return Promise.resolve()
+    },
+
+    async drain(): Promise<void> {
+      for (const [, handle] of timers) handle.stop()
+      timers.clear()
+      // Clear latestInput AFTER awaiting in-flight: the onRenewalOk guard reads
+      // latestInput, so clearing first would suppress the restart of a tick that
+      // is mid-refresh when drain() runs. drain() is shutdown — it waits for
+      // that work to finish rather than dropping it.
+      const promises = Array.from(inFlight.values())
+      await Promise.allSettled(promises)
+      latestInput.clear()
+    },
+  }
+}

--- a/src/secrets/teams-renewal.test.ts
+++ b/src/secrets/teams-renewal.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { TeamsChannelBlock } from './schema'
+import { decideRenewal, type RefreshDeviceCodeAccountFn, renewCurrentAccount, RENEWAL_WINDOW_MS } from './teams-renewal'
+
+const MIN_MS = 60 * 1000
+const NOW = Date.parse('2026-07-08T00:00:00.000Z')
+
+function block(overrides: Partial<TeamsChannelBlock['accounts'][string]> = {}): TeamsChannelBlock {
+  return {
+    currentAccount: 'acc-1',
+    accounts: {
+      'acc-1': {
+        account_id: 'acc-1',
+        access_token: 'old-token',
+        token_expires_at: new Date(NOW + 5 * MIN_MS).toISOString(),
+        account_type: 'work',
+        aad_refresh_token: 'old-refresh',
+        aad_client_id: 'client-1',
+        aad_tenant_id: 'tenant-1',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        ...overrides,
+      },
+    },
+  }
+}
+
+async function withAgentDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  return fn(await mkdtemp(join(tmpdir(), 'typeclaw-teams-renewal-')))
+}
+
+async function writeSecrets(dir: string, teams: TeamsChannelBlock): Promise<void> {
+  await writeFile(join(dir, 'secrets.json'), JSON.stringify({ version: 2, providers: {}, channels: { teams } }))
+}
+
+async function readTeamsBlock(dir: string): Promise<TeamsChannelBlock> {
+  const raw = JSON.parse(await readFile(join(dir, 'secrets.json'), 'utf8'))
+  return raw.channels.teams
+}
+
+// A fake SDK refresh that mirrors the real one's contract: it mutates the given
+// credManager by writing back a freshly minted account, then returns true.
+function fakeRefresh(next: {
+  token: string
+  tokenExpiresAt: string
+  refreshToken?: string
+}): RefreshDeviceCodeAccountFn {
+  return (async (accountType, credManager) => {
+    if (!credManager) return false
+    const prior = await credManager.getCurrentAccount()
+    if (!prior?.aad_refresh_token) return false
+    await credManager.setDeviceCodeAccount({
+      accountType,
+      token: next.token,
+      tokenExpiresAt: next.tokenExpiresAt,
+      aadRefreshToken: next.refreshToken ?? prior.aad_refresh_token,
+      aadClientId: prior.aad_client_id,
+      aadTenantId: prior.aad_tenant_id,
+      teams: {},
+      currentTeam: null,
+      authMethod: 'device-code',
+      makeCurrent: true,
+    })
+    return true
+  }) as RefreshDeviceCodeAccountFn
+}
+
+describe('decideRenewal', () => {
+  test('skips when no current account', () => {
+    expect(decideRenewal({ currentAccount: null, accounts: {} }, NOW)).toEqual({ kind: 'skip', reason: 'no_account' })
+  })
+
+  test('skips when the token is comfortably fresh', () => {
+    const b = block({ token_expires_at: new Date(NOW + RENEWAL_WINDOW_MS + 60 * MIN_MS).toISOString() })
+    const decision = decideRenewal(b, NOW)
+    expect(decision.kind).toBe('skip')
+    if (decision.kind === 'skip') expect(decision.reason).toBe('fresh_enough')
+  })
+
+  test('renews when the token is inside the renewal window', () => {
+    const decision = decideRenewal(block(), NOW)
+    expect(decision.kind).toBe('should_renew')
+  })
+
+  test('reauth_required when inside the window but no refresh token', () => {
+    const decision = decideRenewal(block({ aad_refresh_token: undefined }), NOW)
+    expect(decision).toMatchObject({ kind: 'reauth_required', reason: 'no_refresh_token' })
+  })
+
+  test('attempts renewal when expiry is missing but refresh material exists', () => {
+    const decision = decideRenewal(block({ token_expires_at: undefined }), NOW)
+    expect(decision.kind).toBe('should_renew')
+  })
+
+  test('attempts renewal when expiry is unparseable but refresh material exists', () => {
+    const decision = decideRenewal(block({ token_expires_at: 'not-a-date' }), NOW)
+    expect(decision.kind).toBe('should_renew')
+  })
+})
+
+describe('renewCurrentAccount', () => {
+  test('refreshes an expiring token and writes the new token back to secrets.json', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block())
+      const nextExpiry = new Date(NOW + 80 * MIN_MS).toISOString()
+
+      const result = await renewCurrentAccount({
+        agentDir: dir,
+        now: () => NOW,
+        refreshDeviceCodeAccount: fakeRefresh({
+          token: 'new-token',
+          tokenExpiresAt: nextExpiry,
+          refreshToken: 'rotated-refresh',
+        }),
+      })
+
+      expect(result.kind).toBe('ok')
+      const persisted = await readTeamsBlock(dir)
+      expect(persisted.accounts['acc-1']?.access_token).toBe('new-token')
+      expect(persisted.accounts['acc-1']?.token_expires_at).toBe(nextExpiry)
+      expect(persisted.accounts['acc-1']?.aad_refresh_token).toBe('rotated-refresh')
+    })
+  })
+
+  test('preserves the AAD client/tenant ids across a refresh', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block())
+
+      await renewCurrentAccount({
+        agentDir: dir,
+        now: () => NOW,
+        refreshDeviceCodeAccount: fakeRefresh({
+          token: 'new-token',
+          tokenExpiresAt: new Date(NOW + 80 * MIN_MS).toISOString(),
+        }),
+      })
+
+      const persisted = await readTeamsBlock(dir)
+      expect(persisted.accounts['acc-1']?.aad_client_id).toBe('client-1')
+      expect(persisted.accounts['acc-1']?.aad_tenant_id).toBe('tenant-1')
+    })
+  })
+
+  test('skips a fresh token without calling the SDK', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block({ token_expires_at: new Date(NOW + 60 * MIN_MS).toISOString() }))
+      let called = false
+
+      const result = await renewCurrentAccount({
+        agentDir: dir,
+        now: () => NOW,
+        refreshDeviceCodeAccount: (async () => {
+          called = true
+          return true
+        }) as RefreshDeviceCodeAccountFn,
+      })
+
+      expect(result).toMatchObject({ kind: 'skipped', reason: 'fresh_enough' })
+      expect(called).toBe(false)
+    })
+  })
+
+  test('reports reauth_required when there is no refresh token', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block({ aad_refresh_token: undefined }))
+
+      const result = await renewCurrentAccount({ agentDir: dir, now: () => NOW })
+
+      expect(result).toMatchObject({ kind: 'reauth_required', reason: 'no_refresh_token', account_id: 'acc-1' })
+    })
+  })
+
+  test('classifies an SDK false (refresh material present) as transient_failure and leaves the token untouched', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block())
+
+      const result = await renewCurrentAccount({
+        agentDir: dir,
+        now: () => NOW,
+        refreshDeviceCodeAccount: (async () => false) as RefreshDeviceCodeAccountFn,
+      })
+
+      expect(result).toMatchObject({ kind: 'transient_failure', account_id: 'acc-1' })
+      const persisted = await readTeamsBlock(dir)
+      expect(persisted.accounts['acc-1']?.access_token).toBe('old-token')
+    })
+  })
+
+  test('treats a malformed success (true but no readable account) as transient_failure', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block())
+
+      const result = await renewCurrentAccount({
+        agentDir: dir,
+        now: () => NOW,
+        // Returns true but wipes the store so the readback yields no account —
+        // a malformed success the bridge must not persist as a real token.
+        refreshDeviceCodeAccount: (async (_accountType, credManager) => {
+          await credManager?.clearCredentials()
+          return true
+        }) as RefreshDeviceCodeAccountFn,
+      })
+
+      expect(result).toMatchObject({ kind: 'transient_failure', account_id: 'acc-1' })
+      const persisted = await readTeamsBlock(dir)
+      expect(persisted.accounts['acc-1']?.access_token).toBe('old-token')
+    })
+  })
+})

--- a/src/secrets/teams-renewal.test.ts
+++ b/src/secrets/teams-renewal.test.ts
@@ -174,7 +174,7 @@ describe('renewCurrentAccount', () => {
     })
   })
 
-  test('classifies an SDK false (refresh material present) as transient_failure and leaves the token untouched', async () => {
+  test('classifies a bare SDK false (no error detail) as transient_failure and leaves the token untouched', async () => {
     await withAgentDir(async (dir) => {
       await writeSecrets(dir, block())
 
@@ -187,6 +187,42 @@ describe('renewCurrentAccount', () => {
       expect(result).toMatchObject({ kind: 'transient_failure', account_id: 'acc-1' })
       const persisted = await readTeamsBlock(dir)
       expect(persisted.accounts['acc-1']?.access_token).toBe('old-token')
+    })
+  })
+
+  test('classifies a permanent AAD failure (invalid_grant via the debug callback) as reauth_required', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block())
+
+      const result = await renewCurrentAccount({
+        agentDir: dir,
+        now: () => NOW,
+        // Mirror the SDK: report the AAD error through the debug callback, then
+        // return false — a revoked refresh token needs a human, not a retry.
+        refreshDeviceCodeAccount: (async (_type, _mgr, debug) => {
+          debug?.('Silent refresh failed: AADSTS700082: The refresh token has expired due to inactivity.')
+          return false
+        }) as RefreshDeviceCodeAccountFn,
+      })
+
+      expect(result).toMatchObject({ kind: 'reauth_required', account_id: 'acc-1', reason: 'refresh_token_rejected' })
+    })
+  })
+
+  test('keeps a transient AAD failure (5xx via the debug callback) as transient_failure', async () => {
+    await withAgentDir(async (dir) => {
+      await writeSecrets(dir, block())
+
+      const result = await renewCurrentAccount({
+        agentDir: dir,
+        now: () => NOW,
+        refreshDeviceCodeAccount: (async (_type, _mgr, debug) => {
+          debug?.('Silent refresh failed: HTTP 503')
+          return false
+        }) as RefreshDeviceCodeAccountFn,
+      })
+
+      expect(result.kind).toBe('transient_failure')
     })
   })
 

--- a/src/secrets/teams-renewal.ts
+++ b/src/secrets/teams-renewal.ts
@@ -91,15 +91,29 @@ export async function renewCurrentAccount(
   }
 
   const refreshFn = ctx.refreshDeviceCodeAccount ?? refreshDeviceCodeAccount
-  const refreshed = await enqueueRefresh(() => runBridgedRefresh(decision.account, refreshFn))
-  if (refreshed === null) {
-    // The SDK swallows the underlying error and only returns a boolean, so a
-    // false here could be a dead refresh token OR a transient AAD/network blip.
-    // The permanent case (no refresh token) is already caught in decideRenewal,
-    // so classify a failure past that gate as transient and retry next tick
-    // rather than permanently disabling the account.
-    return { kind: 'transient_failure', account_id: decision.account.account_id, reason: 'silent_refresh_failed' }
+  const outcome = await enqueueRefresh(() => runBridgedRefresh(decision.account, refreshFn))
+  if (outcome.kind === 'failed') {
+    // The SDK only returns a boolean, but its debug callback first reports the
+    // underlying AAD error. A revoked/expired refresh token (invalid_grant,
+    // interaction_required, the AADSTS7xxxx expiry/revocation family) can never
+    // recover without a human, so surface it as reauth_required rather than
+    // retrying it forever; a network/5xx blip stays transient and retries next
+    // tick.
+    if (isPermanentAadFailure(outcome.detail)) {
+      return {
+        kind: 'reauth_required',
+        account_id: decision.account.account_id,
+        reason: 'refresh_token_rejected',
+        message: `Teams silent refresh was rejected (${outcome.detail ?? 'invalid_grant'}) — run \`typeclaw channel reauth teams\`.`,
+      }
+    }
+    return {
+      kind: 'transient_failure',
+      account_id: decision.account.account_id,
+      reason: outcome.detail ?? 'silent_refresh_failed',
+    }
   }
+  const refreshed = outcome.fields
 
   const store = new SecretsTeamsCredentialStore({ mode: 'host', secretsPath })
   const previousExpiresAt = Date.parse(decision.account.token_expires_at ?? '')
@@ -125,17 +139,21 @@ export async function renewCurrentAccount(
 
 type RefreshedFields = Pick<TeamsAccountRecord, 'access_token' | 'token_expires_at' | 'aad_refresh_token' | 'region'>
 
+type BridgedRefreshResult = { kind: 'ok'; fields: RefreshedFields } | { kind: 'failed'; detail?: string }
+
 // The only public Teams refresh entry point writes through the SDK's own
 // file-backed TeamsCredentialManager, so bridge it: seed a throwaway manager in
 // a temp dir from our stored record, let the SDK exchange the AAD refresh token
 // for a fresh skype token, then read the refreshed account back out and hand
-// only the TypeClaw-owned fields to the caller. Returns null when the SDK could
-// not produce a usable token.
+// only the TypeClaw-owned fields to the caller. On failure the SDK just returns
+// false, but its debug callback reports the underlying AAD error first, so
+// capture that into `detail` for the caller's permanent-vs-transient split.
 async function runBridgedRefresh(
   account: TeamsAccountRecord,
   refreshFn: RefreshDeviceCodeAccountFn,
-): Promise<RefreshedFields | null> {
+): Promise<BridgedRefreshResult> {
   const dir = await mkdtemp(join(tmpdir(), 'typeclaw-teams-refresh-'))
+  let lastDebug: string | undefined
   try {
     const manager = new TeamsCredentialManager(dir)
     await manager.setDeviceCodeAccount({
@@ -153,25 +171,50 @@ async function runBridgedRefresh(
       makeCurrent: true,
     })
 
-    const ok = await refreshFn(account.account_type, manager)
-    if (!ok) return null
+    const ok = await refreshFn(account.account_type, manager, (message) => {
+      lastDebug = message
+    })
+    if (!ok) return { kind: 'failed', ...(lastDebug !== undefined ? { detail: lastDebug } : {}) }
 
     const refreshed = await manager.getCurrentAccount()
     // A true return with a null/tokenless readback is a malformed success — the
-    // caller treats null as a transient failure rather than persisting garbage.
-    if (!refreshed || !refreshed.token) return null
+    // caller treats a failure as transient rather than persisting garbage.
+    if (!refreshed || !refreshed.token) return { kind: 'failed' }
 
     return {
-      access_token: refreshed.token,
-      ...(refreshed.token_expires_at !== undefined ? { token_expires_at: refreshed.token_expires_at } : {}),
-      ...(refreshed.aad_refresh_token !== undefined ? { aad_refresh_token: refreshed.aad_refresh_token } : {}),
-      ...(refreshed.region !== undefined ? { region: refreshed.region } : {}),
+      kind: 'ok',
+      fields: {
+        access_token: refreshed.token,
+        ...(refreshed.token_expires_at !== undefined ? { token_expires_at: refreshed.token_expires_at } : {}),
+        ...(refreshed.aad_refresh_token !== undefined ? { aad_refresh_token: refreshed.aad_refresh_token } : {}),
+        ...(refreshed.region !== undefined ? { region: refreshed.region } : {}),
+      },
     }
-  } catch {
-    return null
+  } catch (err) {
+    return { kind: 'failed', detail: err instanceof Error ? err.message : lastDebug }
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
+}
+
+// AAD returns these for a refresh token that a human must re-mint: an explicit
+// invalid_grant / interaction_required, or the AADSTS token expiry/revocation
+// family (700082 expired, 70008 expired, 50173 changed-password, 700084/50076
+// re-auth). Anything else (network, 5xx, throttling) is transient. Matched
+// case-insensitively as a substring because the detail is a free-form
+// error_description line, not a stable code field.
+function isPermanentAadFailure(detail: string | undefined): boolean {
+  if (detail === undefined) return false
+  const haystack = detail.toLowerCase()
+  return [
+    'invalid_grant',
+    'interaction_required',
+    'aadsts700082',
+    'aadsts70008',
+    'aadsts50173',
+    'aadsts700084',
+    'aadsts50076',
+  ].some((needle) => haystack.includes(needle))
 }
 
 function enqueueRefresh<T>(op: () => Promise<T>): Promise<T> {

--- a/src/secrets/teams-renewal.ts
+++ b/src/secrets/teams-renewal.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { refreshDeviceCodeAccount, TeamsCredentialManager } from 'agent-messenger/teams'
+
+import { type TeamsAccountRecord, type TeamsChannelBlock, teamsChannelBlockSchema } from './schema'
+import { SecretsBackend } from './storage'
+import { SecretsTeamsCredentialStore } from './teams-store'
+
+// Teams user-account skype tokens live only 60-90 minutes, so a long-running
+// adapter must silently re-mint them from the stored AAD refresh trio. The
+// host tick fires every 5 minutes and renews once the token is within 15
+// minutes of `token_expires_at`: that clears a full tick-interval with headroom
+// for host sleep / daemon respawn, and gives ~3 attempts before a token would
+// otherwise lapse mid-session.
+export const RENEWAL_WINDOW_MS = 15 * 60 * 1000
+
+// `TeamsCredentialManager.accountOverride` is static process state and the SDK
+// refresh reads/writes a file store, so only one Teams refresh may run in a
+// hostd process at a time. Serialize every SDK call through this chain.
+let refreshChain: Promise<unknown> = Promise.resolve()
+
+export type TeamsRenewalDecision =
+  | { kind: 'skip'; reason: 'no_account' | 'fresh_enough'; expiresInMs?: number }
+  | { kind: 'reauth_required'; reason: 'no_refresh_token'; message: string }
+  | { kind: 'should_renew'; account: TeamsAccountRecord }
+
+export type TeamsRenewalAttempt =
+  | { kind: 'ok'; account_id: string; previousExpiresAt: number; nextExpiresAt: number }
+  | { kind: 'reauth_required'; account_id: string; reason: string; message: string }
+  | { kind: 'transient_failure'; account_id: string; reason: string }
+
+export type RefreshDeviceCodeAccountFn = typeof refreshDeviceCodeAccount
+
+export type TeamsRenewalContext = {
+  agentDir: string
+  now?: () => number
+  refreshDeviceCodeAccount?: RefreshDeviceCodeAccountFn
+}
+
+export function decideRenewal(block: TeamsChannelBlock, now: number): TeamsRenewalDecision {
+  const accountId = block.currentAccount
+  if (!accountId) return { kind: 'skip', reason: 'no_account' }
+  const account = block.accounts[accountId]
+  if (!account) return { kind: 'skip', reason: 'no_account' }
+
+  // A present-and-parseable expiry more than a window away is the only reason
+  // to skip. A missing or unparseable expiry falls through to renew (better to
+  // spend a refresh than leave an extracted/legacy record stuck until manual
+  // reauth) — but only if there's refresh material to spend.
+  const expiresAt = account.token_expires_at !== undefined ? Date.parse(account.token_expires_at) : Number.NaN
+  if (Number.isFinite(expiresAt)) {
+    const expiresInMs = expiresAt - now
+    if (expiresInMs > RENEWAL_WINDOW_MS) return { kind: 'skip', reason: 'fresh_enough', expiresInMs }
+  }
+
+  if (!account.aad_refresh_token) {
+    return {
+      kind: 'reauth_required',
+      reason: 'no_refresh_token',
+      message: `Teams account ${accountId} has no AAD refresh token — run \`typeclaw channel reauth teams\`.`,
+    }
+  }
+
+  return { kind: 'should_renew', account }
+}
+
+export async function renewCurrentAccount(
+  ctx: TeamsRenewalContext,
+): Promise<TeamsRenewalAttempt | { kind: 'skipped'; reason: string; expiresInMs?: number }> {
+  const secretsPath = join(ctx.agentDir, 'secrets.json')
+  const backend = new SecretsBackend(secretsPath)
+  const block = parseBlockOrEmpty(backend.readChannelsSync()?.teams)
+  const decision = decideRenewal(block, (ctx.now ?? Date.now)())
+
+  if (decision.kind === 'skip') {
+    return {
+      kind: 'skipped',
+      reason: decision.reason,
+      ...(decision.expiresInMs !== undefined ? { expiresInMs: decision.expiresInMs } : {}),
+    }
+  }
+  if (decision.kind === 'reauth_required') {
+    return {
+      kind: 'reauth_required',
+      account_id: block.currentAccount ?? '',
+      reason: decision.reason,
+      message: decision.message,
+    }
+  }
+
+  const refreshFn = ctx.refreshDeviceCodeAccount ?? refreshDeviceCodeAccount
+  const refreshed = await enqueueRefresh(() => runBridgedRefresh(decision.account, refreshFn))
+  if (refreshed === null) {
+    // The SDK swallows the underlying error and only returns a boolean, so a
+    // false here could be a dead refresh token OR a transient AAD/network blip.
+    // The permanent case (no refresh token) is already caught in decideRenewal,
+    // so classify a failure past that gate as transient and retry next tick
+    // rather than permanently disabling the account.
+    return { kind: 'transient_failure', account_id: decision.account.account_id, reason: 'silent_refresh_failed' }
+  }
+
+  const store = new SecretsTeamsCredentialStore({ mode: 'host', secretsPath })
+  const previousExpiresAt = Date.parse(decision.account.token_expires_at ?? '')
+  const nextExpiresAt = Date.parse(refreshed.token_expires_at ?? '')
+  // setAccount's mergeAccountPreservingRefreshFields backfills any AAD field the
+  // readback omitted, so we always keep a spendable refresh trio.
+  await store.setAccount({
+    ...decision.account,
+    access_token: refreshed.access_token,
+    ...(refreshed.token_expires_at !== undefined ? { token_expires_at: refreshed.token_expires_at } : {}),
+    ...(refreshed.aad_refresh_token !== undefined ? { aad_refresh_token: refreshed.aad_refresh_token } : {}),
+    ...(refreshed.region !== undefined ? { region: refreshed.region } : {}),
+    updated_at: new Date().toISOString(),
+  })
+
+  return {
+    kind: 'ok',
+    account_id: decision.account.account_id,
+    previousExpiresAt: Number.isFinite(previousExpiresAt) ? previousExpiresAt : 0,
+    nextExpiresAt: Number.isFinite(nextExpiresAt) ? nextExpiresAt : 0,
+  }
+}
+
+type RefreshedFields = Pick<TeamsAccountRecord, 'access_token' | 'token_expires_at' | 'aad_refresh_token' | 'region'>
+
+// The only public Teams refresh entry point writes through the SDK's own
+// file-backed TeamsCredentialManager, so bridge it: seed a throwaway manager in
+// a temp dir from our stored record, let the SDK exchange the AAD refresh token
+// for a fresh skype token, then read the refreshed account back out and hand
+// only the TypeClaw-owned fields to the caller. Returns null when the SDK could
+// not produce a usable token.
+async function runBridgedRefresh(
+  account: TeamsAccountRecord,
+  refreshFn: RefreshDeviceCodeAccountFn,
+): Promise<RefreshedFields | null> {
+  const dir = await mkdtemp(join(tmpdir(), 'typeclaw-teams-refresh-'))
+  try {
+    const manager = new TeamsCredentialManager(dir)
+    await manager.setDeviceCodeAccount({
+      accountType: account.account_type,
+      token: account.access_token,
+      tokenExpiresAt: account.token_expires_at ?? '',
+      ...(account.aad_refresh_token !== undefined ? { aadRefreshToken: account.aad_refresh_token } : {}),
+      ...(account.aad_client_id !== undefined ? { aadClientId: account.aad_client_id } : {}),
+      ...(account.aad_tenant_id !== undefined ? { aadTenantId: account.aad_tenant_id } : {}),
+      ...(account.region !== undefined ? { region: account.region } : {}),
+      ...(account.user_name !== undefined ? { userName: account.user_name } : {}),
+      teams: {},
+      currentTeam: null,
+      authMethod: 'device-code',
+      makeCurrent: true,
+    })
+
+    const ok = await refreshFn(account.account_type, manager)
+    if (!ok) return null
+
+    const refreshed = await manager.getCurrentAccount()
+    // A true return with a null/tokenless readback is a malformed success — the
+    // caller treats null as a transient failure rather than persisting garbage.
+    if (!refreshed || !refreshed.token) return null
+
+    return {
+      access_token: refreshed.token,
+      ...(refreshed.token_expires_at !== undefined ? { token_expires_at: refreshed.token_expires_at } : {}),
+      ...(refreshed.aad_refresh_token !== undefined ? { aad_refresh_token: refreshed.aad_refresh_token } : {}),
+      ...(refreshed.region !== undefined ? { region: refreshed.region } : {}),
+    }
+  } catch {
+    return null
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+function enqueueRefresh<T>(op: () => Promise<T>): Promise<T> {
+  const next = refreshChain.then(op, op)
+  refreshChain = next.catch(() => {})
+  return next
+}
+
+function parseBlockOrEmpty(value: unknown): TeamsChannelBlock {
+  if (value === undefined) return { currentAccount: null, accounts: {} }
+  return teamsChannelBlockSchema.parse(value)
+}


### PR DESCRIPTION
## Background

A running Teams agent goes dead roughly once an hour with:

```
[teams] listener error: Could not obtain Teams id_token for real-time auth.
[teams] listener start failed: Could not obtain Teams id_token for real-time auth.
[channels] adapter "teams" failed to start: Could not obtain Teams id_token ...
```

Root cause: Teams user-account skype tokens live only **60–90 minutes**. Login and `testAuth()` succeed, but the realtime listener needs a separately-derived `id_token` that the SDK re-extracts on every connect — and once the stored access token lapses, that derivation fails, the listener errors, and the reconnect-hardened adapter (PR #1164) correctly fails closed. Unlike Slack/Discord (long-lived bot tokens), Teams has no way to stay alive unattended without re-minting the token. The account record already carries the AAD refresh trio (`aad_refresh_token` / `aad_client_id` / `aad_tenant_id`) captured at device-code login, but nothing spent it.

## Summary

Add a host-side renewal cron for Teams, modeled directly on the existing Webex renewal (`src/secrets/webex-renewal.ts` + `src/hostd/webex-renewal-manager.ts`). A per-container tick re-mints the token from the stored refresh trio and writes it back to `secrets.json`, then restarts the container so the in-memory `TeamsClient` reloads a coherent token.

Key decisions:

- **Why a temp-dir bridge, not a direct refresh call.** `agent-messenger/teams` only exports `refreshDeviceCodeAccount`, which writes through the SDK's *own* file-backed `TeamsCredentialManager` (the lower-level `exchangeForSkypeScope`/`mintSkypeToken` primitives are not exported). So each tick seeds a throwaway temp-dir manager from our stored record, lets the SDK do the AAD refresh_token grant, reads the refreshed account back, and persists only the fields TypeClaw owns. The store's existing `mergeAccountPreservingRefreshFields` keeps the AAD trio across the write.
- **Why a hostd-wide refresh mutex.** `TeamsCredentialManager.accountOverride` is static process state, so concurrent work/personal or multi-agent refreshes could race even with per-container temp dirs. Every SDK refresh is serialized through a module-level chain.
- **Outcome classification around a lossy SDK boolean.** `refreshDeviceCodeAccount` collapses "no refresh token" and "transient network/AAD failure" into a single `false`. The permanent case is caught *before* the SDK call (`reauth_required` when the refresh token is absent); a `false` past that gate is treated as `transient_failure` and retried next tick, so a blip never permanently disables an account and a dead token never gets hammered as if fresh.
- **Why 5-minute tick / 15-minute window.** Teams tokens are minutes-scale (Webex's are ~27h), so the tick is minutes not hours — ~3 attempts inside the window before a token would lapse. Missing/unparseable expiry with refresh material present attempts a refresh rather than skipping, so extracted/legacy records aren't stuck until manual reauth.

## What this does NOT do

- No container-side (mid-session) refresh — host cron + restart only, matching Webex. The restart is the coherence boundary; adding an in-adapter timer is deferred.
- Does not change the Teams adapter, its inbound path, or the SDK.
- Does not add password/secret storage — Teams renews from the AAD refresh token, so there is nothing to encrypt at rest (unlike Webex's stored password).
- Does not touch the Webex/Kakao renewal managers.

## Review notes

- Load-bearing: the temp-dir bridge and the static-state serialization in `src/secrets/teams-renewal.ts`, and the `onRenewalOk` → restart coupling in `src/hostd/teams-renewal-manager.ts` (a renewed token in `secrets.json` is useless until the container restarts and the client re-logs-in).
- Invariants covered by tests: refresh-trio preservation across a write, malformed-success (SDK true but no readable account) → `transient_failure` not a persisted garbage token, restart fires only on a token-changing `ok`, and the drain / re-register concurrency guards ported from Webex.
- The daemon wiring threads `teamsRenewal` through the same 8 lifecycle points as `webexRenewal`; the CLI gates it on a configured `channels.teams` block so non-Teams agents emit no renewal logs.
- Split into 3 commits by layer (secrets core → hostd manager → daemon/CLI wiring), each independently reviewable.
- `bun run lint` reports 67 pre-existing warnings repo-wide (0 errors); none in the changed files.