### PR TITLE
fix(channels): mint teams realtime id_token in-container, degrade to REST-only

### DIFF
--- a/docs/content/docs/reference/teams.mdx
+++ b/docs/content/docs/reference/teams.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'fumadocs-ui/components/callout'
 
 Part of the [channel adapters](/docs/reference/channel-adapters) family.
 
-Transport: **trouter WebSocket** over a user-token session (no public URL required). Setup walkthrough: [Add a channel](/docs/guides/add-a-channel).
+Transport: **trouter WebSocket** for realtime inbound (no public URL required), with a **REST-only fallback** when realtime can't authenticate. Setup walkthrough: [Add a channel](/docs/guides/add-a-channel).
 
 This is the **user-account** Microsoft Teams adapter (`teams`). It signs in as your own Teams user, so it hears every chat and team channel the account belongs to — no bot registration exists for Teams in agent-messenger, so this is the only variant.
 
@@ -93,14 +93,23 @@ The `channel set` / `channel add` / `channel reauth` CLI verbs do not support Te
 
 Access tokens live 60–90 minutes. The adapter does **not** refresh them automatically today: on start it warns when the token is expired or expiring soon, and a long-running session stops delivering once the token lapses. To recover, extract a fresh token (e.g. with the [`agent-teams`](https://agent-messenger.dev/docs/cli/teams) CLI) and replace `access_token` (and `token_expires_at`) in `secrets.json#channels.teams` by hand, then restart the agent.
 
-The record also holds an AAD refresh trio (`aad_refresh_token`, `aad_client_id`, `aad_tenant_id`) reserved for a future unattended-refresh path, but the runtime adapter does not consume it yet — until then, renewal is manual.
+The record also holds an AAD refresh trio (`aad_refresh_token`, `aad_client_id`, `aad_tenant_id`). The runtime adapter uses it to mint the realtime **id_token** in-container (see [Realtime](#realtime-inbound) below); the short-lived `access_token` (skypetoken) itself is still refreshed manually today.
+
+## Realtime inbound
+
+Realtime inbound rides Teams' internal **trouter WebSocket**. Authenticating that socket needs a second credential — an AAD Bearer "id_token" for the Teams/Skype spaces resource — separate from the `access_token` skypetoken. The upstream `agent-messenger` SDK obtains that id_token by scraping the Teams desktop app's cookie database (or a local browser profile), which is impossible in TypeClaw's headless container.
+
+Instead, TypeClaw mints the id_token in-container from the stored `aad_refresh_token` via a standard AAD `refresh_token` grant — no desktop app or browser required. This needs the AAD refresh trio to be present on the account record (device-code logins capture it; legacy extracted-token accounts may not).
+
+When the id_token can't be minted (no `aad_refresh_token`, an expired/revoked refresh token, or a trouter outage), the adapter **degrades to REST-only** rather than failing: outbound sends, history reads, and self-identity keep working, but the agent is no longer woken by inbound Teams messages until realtime recovers on the next start. A single warning is logged; there is no reconnect log-loop.
 
 ## Quirks
 
 - **User-account, not a bot**: hears every chat and team-channel message the account can see, not just @mentions — engagement is governed by your `engagement.trigger` and match rules, not by a bot-mention model.
 - **Chats and channels both**: unlike most user adapters, Teams covers both 1:1/group chats and full team channels; channel messages carry `teamId`/`channelId` and parsed @mentions.
 - **Self-echo suppression**: the Teams user SDK has no self-identity boundary — `testAuth` returns the literal id `'ME'`, not a real MRI. Every successful send records a `(chat, normalized-text)` fingerprint, and a matching inbound arriving within a short window is dropped as the echo of our own send rather than routed as a new message.
-- **Short-lived tokens, manual refresh today**: `access_token` expires in 60–90 minutes; the adapter warns on expiry but does not yet auto-refresh, so a long-running session needs the token replaced by hand in `secrets.json#channels.teams`. The AAD refresh trio is captured for a future unattended-refresh path.
+- **Realtime id_token is minted, not scraped**: the trouter socket needs an AAD Bearer id_token that the `agent-messenger` SDK would normally scrape from the Teams desktop app or a browser profile — neither of which exists in the container. TypeClaw mints it from the stored `aad_refresh_token` instead, and falls back to REST-only (send/read, no proactive inbound) when it can't. See [Realtime](#realtime-inbound).
+- **Short-lived tokens, manual refresh today**: `access_token` expires in 60–90 minutes; the adapter warns on expiry but does not yet auto-refresh the skypetoken, so a long-running session needs the token replaced by hand in `secrets.json#channels.teams`. (The AAD refresh trio IS consumed for the realtime id_token above.)
 - **Work vs personal accounts**: `account_type` distinguishes work/school tenants from personal Microsoft accounts; `region` records which AAD region issued the token.
 
 ## Config

--- a/src/channels/adapters/teams-id-token.test.ts
+++ b/src/channels/adapters/teams-id-token.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { TeamsAccountRecord } from '@/secrets/schema'
+
+import { ContainerTeamsClient, mintTeamsIdToken } from './teams-id-token'
+
+function account(overrides: Partial<TeamsAccountRecord> = {}): TeamsAccountRecord {
+  return {
+    account_id: 'account-1',
+    access_token: 'skype-1',
+    account_type: 'work',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+type Captured = { url: string; body: URLSearchParams }
+
+function capturingFetch(response: Response): { fetch: typeof fetch; calls: Captured[] } {
+  const calls: Captured[] = []
+  const fetchImpl = (async (url: string, init: RequestInit) => {
+    calls.push({ url, body: init.body as URLSearchParams })
+    return response
+  }) as unknown as typeof fetch
+  return { fetch: fetchImpl, calls }
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+describe('mintTeamsIdToken', () => {
+  test('returns null when the account has no aad_refresh_token', async () => {
+    const result = await mintTeamsIdToken(account({ aad_refresh_token: undefined }))
+    expect(result).toBeNull()
+  })
+
+  test('mints a work bearer via the tenant-scoped refresh_token grant', async () => {
+    const { fetch, calls } = capturingFetch(jsonResponse({ access_token: 'minted-work-bearer' }))
+
+    const result = await mintTeamsIdToken(
+      account({ aad_refresh_token: 'rt-work', aad_client_id: 'client-w', aad_tenant_id: 'tenant-guid' }),
+      { fetch },
+    )
+
+    expect(result).toBe('minted-work-bearer')
+    expect(calls).toHaveLength(1)
+    // given a work account with a resolved tenant, the grant targets that tenant's authority
+    expect(calls[0]?.url).toBe('https://login.microsoftonline.com/tenant-guid/oauth2/v2.0/token')
+    expect(calls[0]?.body.get('grant_type')).toBe('refresh_token')
+    expect(calls[0]?.body.get('refresh_token')).toBe('rt-work')
+    expect(calls[0]?.body.get('client_id')).toBe('client-w')
+    expect(calls[0]?.body.get('scope')).toBe('https://api.spaces.skype.com/.default openid profile offline_access')
+  })
+
+  test('falls back to the organizations authority when no tenant is stored', async () => {
+    const { fetch, calls } = capturingFetch(jsonResponse({ access_token: 'x' }))
+
+    await mintTeamsIdToken(account({ aad_refresh_token: 'rt', account_type: 'work', aad_tenant_id: undefined }), {
+      fetch,
+    })
+
+    expect(calls[0]?.url).toBe('https://login.microsoftonline.com/organizations/oauth2/v2.0/token')
+  })
+
+  test('mints a personal bearer against the consumer tenant with the MSA scope', async () => {
+    const { fetch, calls } = capturingFetch(jsonResponse({ access_token: 'minted-personal' }))
+
+    const result = await mintTeamsIdToken(account({ account_type: 'personal', aad_refresh_token: 'rt-personal' }), {
+      fetch,
+    })
+
+    expect(result).toBe('minted-personal')
+    expect(calls[0]?.url).toBe(
+      'https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/oauth2/v2.0/token',
+    )
+    expect(calls[0]?.body.get('scope')).toBe('service::api.fl.spaces.skype.com::MBI_SSL openid profile offline_access')
+  })
+
+  test('returns null on an AAD error response so the caller degrades', async () => {
+    const { fetch } = capturingFetch(jsonResponse({ error: 'invalid_grant' }, 400))
+    const result = await mintTeamsIdToken(account({ aad_refresh_token: 'stale' }), { fetch })
+    expect(result).toBeNull()
+  })
+
+  test('returns null on a transport failure rather than throwing', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const result = await mintTeamsIdToken(account({ aad_refresh_token: 'rt' }), { fetch: fetchImpl })
+    expect(result).toBeNull()
+  })
+
+  test('returns null when the grant omits an access_token', async () => {
+    const { fetch } = capturingFetch(jsonResponse({ token_type: 'Bearer' }))
+    const result = await mintTeamsIdToken(account({ aad_refresh_token: 'rt' }), { fetch })
+    expect(result).toBeNull()
+  })
+})
+
+describe('ContainerTeamsClient', () => {
+  test('getIdToken mints from the currently-loaded account via the injected minter', async () => {
+    const acct = account({ aad_refresh_token: 'rt' })
+    const seen: TeamsAccountRecord[] = []
+    const client = new ContainerTeamsClient(
+      () => acct,
+      async (a) => {
+        seen.push(a)
+        return 'minted-id-token'
+      },
+    )
+
+    expect(await client.getIdToken()).toBe('minted-id-token')
+    expect(seen).toEqual([acct])
+  })
+
+  test('getIdToken returns null before an account is loaded', async () => {
+    let loaded: TeamsAccountRecord | null = null
+    const client = new ContainerTeamsClient(
+      () => loaded,
+      async () => 'should-not-be-called',
+    )
+
+    expect(await client.getIdToken()).toBeNull()
+    loaded = account({ aad_refresh_token: 'rt' })
+    expect(await client.getIdToken()).toBe('should-not-be-called')
+  })
+})

--- a/src/channels/adapters/teams-id-token.ts
+++ b/src/channels/adapters/teams-id-token.ts
@@ -1,0 +1,112 @@
+import { TeamsClient } from 'agent-messenger/teams'
+
+import type { TeamsAccountRecord } from '@/secrets/schema'
+
+// The Teams realtime trouter WebSocket authenticates every connect (and every
+// reconnect) with an `Authorization: Bearer <idToken>` header. The upstream
+// agent-messenger SDK only knows how to obtain that token by scraping the
+// `authtoken` cookie out of the Teams desktop app's on-disk SQLite database (or
+// a local Chromium profile) — see agent-messenger/.../teams/token-extractor.ts.
+// TypeClaw runs headless in a container where neither exists, so the scrape
+// always returns null and the SDK throws `no_id_token` on start and in a
+// reconnect loop.
+//
+// The token the trouter wants is an ordinary AAD OAuth bearer for the Teams /
+// Skype "spaces" resource — the SAME resource family that our stored
+// `aad_refresh_token` was minted against by the device-code login
+// (agent-messenger/.../teams/device-login.ts stores `skypeScoped.refreshToken`).
+// So instead of scraping, we mint the bearer in-container with a standard AAD
+// `refresh_token` grant, exactly as the SDK's own `exchangeForSkypeScope` does.
+// Those helpers are not exported from `agent-messenger/teams`, so the minimal
+// grant is reproduced here; the scope/authority constants are mirrored from the
+// SDK's `app-config.ts` and traced back to it in the comments below.
+
+// From agent-messenger/.../teams/app-config.ts:
+//   DEVICE_CODE_SCOPE_SKYPE      (personal / MSA)
+//   WORK_DEVICE_CODE_SCOPE_SKYPE (work / AAD)
+const SKYPE_SCOPE_PERSONAL = 'service::api.fl.spaces.skype.com::MBI_SSL openid profile offline_access'
+const SKYPE_SCOPE_WORK = 'https://api.spaces.skype.com/.default openid profile offline_access'
+
+// From agent-messenger/.../teams/app-config.ts: CONSUMER_TENANT_ID / WORK_TENANT_ID
+const CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad'
+const WORK_TENANT_AUTHORITY = 'organizations'
+
+// From agent-messenger/.../teams/app-config.ts: TEAMS_WEB_CLIENT_ID / TEAMS_DESKTOP_CLIENT_ID.
+// Only used when the stored account never captured its own aad_client_id.
+const TEAMS_WEB_CLIENT_ID = '5e3ce6c0-2b1f-4285-8d4b-75ee78787346'
+const TEAMS_DESKTOP_CLIENT_ID = '1fec8e78-bce4-4aaf-ab1b-5451cc387264'
+
+export type FetchLike = (url: string, init: RequestInit) => Promise<Response>
+
+export type MintTeamsIdTokenDeps = {
+  fetch?: FetchLike
+}
+
+// Returns a freshly minted skype/spaces-scoped AAD access token to use as the
+// trouter bearer, or null when the account lacks the AAD refresh trio needed to
+// mint one (a legacy extracted-token account) — the caller degrades to REST-only
+// in that case. Throws only on an unexpected transport failure; an AAD error
+// response resolves to null so the caller degrades rather than crash-loops.
+export async function mintTeamsIdToken(
+  account: TeamsAccountRecord,
+  deps: MintTeamsIdTokenDeps = {},
+): Promise<string | null> {
+  const refreshToken = account.aad_refresh_token
+  if (refreshToken === undefined || refreshToken === '') return null
+
+  const doFetch = deps.fetch ?? ((url, init) => fetch(url, init))
+  const clientId = account.aad_client_id ?? defaultClientId(account.account_type)
+  const scope = account.account_type === 'personal' ? SKYPE_SCOPE_PERSONAL : SKYPE_SCOPE_WORK
+
+  let response: Response
+  try {
+    response = await doFetch(tokenUrl(account), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        scope,
+      }),
+    })
+  } catch {
+    return null
+  }
+
+  if (!response.ok) return null
+  const body = (await response.json().catch(() => ({}))) as { access_token?: unknown }
+  return typeof body.access_token === 'string' && body.access_token !== '' ? body.access_token : null
+}
+
+export type TeamsIdTokenMinter = (account: TeamsAccountRecord) => Promise<string | null>
+
+// A TeamsClient whose realtime `getIdToken()` mints the trouter bearer from the
+// account's AAD refresh token instead of scraping a desktop/browser cookie.
+// `TeamsListener` re-calls this on every (re)connect, so it re-mints each time —
+// matching the SDK's own "re-extract on every attempt" contract. Returning null
+// (legacy account without the AAD trio, or an expired refresh token) makes the
+// SDK throw `no_id_token`, which the adapter catches to degrade to REST-only.
+export class ContainerTeamsClient extends TeamsClient {
+  constructor(
+    private readonly idTokenAccount: () => TeamsAccountRecord | null,
+    private readonly mint: TeamsIdTokenMinter = mintTeamsIdToken,
+  ) {
+    super()
+  }
+
+  override async getIdToken(): Promise<string | null> {
+    const account = this.idTokenAccount()
+    return account === null ? null : this.mint(account)
+  }
+}
+
+function tokenUrl(account: TeamsAccountRecord): string {
+  const tenant =
+    account.account_type === 'personal' ? CONSUMER_TENANT_ID : (account.aad_tenant_id ?? WORK_TENANT_AUTHORITY)
+  return `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`
+}
+
+function defaultClientId(accountType: TeamsAccountRecord['account_type']): string {
+  return accountType === 'work' ? TEAMS_DESKTOP_CLIENT_ID : TEAMS_WEB_CLIENT_ID
+}

--- a/src/channels/adapters/teams.test.ts
+++ b/src/channels/adapters/teams.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
+import { TeamsError } from 'agent-messenger/teams'
 import type { TeamsListener, TeamsMessage, TeamsRealtimeMessage, TeamsUser } from 'agent-messenger/teams'
 
 import type { ChannelRouter } from '@/channels/router'
@@ -493,49 +494,81 @@ describe('createTeamsAdapter', () => {
     expect(r.routed[0]?.chat).toBe('chat:chat-9')
   })
 
-  test('isConnected is false after a disconnected event', async () => {
+  test('stays usable (REST) even after a realtime disconnected event', async () => {
     const r = router()
     const listener = new FakeListener()
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
     await adapter.start()
     expect(adapter.isConnected()).toBe(true)
+    // a realtime drop does not make the adapter unusable — send/read still work,
+    // so isConnected() stays true and the manager does not churn-restart it
     listener.emit('disconnected', undefined)
-    expect(adapter.isConnected()).toBe(false)
-
-    await adapter.stop()
-  })
-
-  test('isConnected recovers when the SDK re-emits connected after a reconnect', async () => {
-    const r = router()
-    const listener = new FakeListener()
-    const adapter = adapterWith({ r, listener, client: fakeClient().client })
-
-    await adapter.start()
-    // given a transient drop the SDK reports as disconnected
-    listener.emit('disconnected', undefined)
-    expect(adapter.isConnected()).toBe(false)
-    // when the SDK auto-reconnects and re-registers its endpoint
-    listener.emit('connected', { endpointId: 'ep-2' })
-    // then the adapter reports live again without a manager restart
     expect(adapter.isConnected()).toBe(true)
 
     await adapter.stop()
   })
 
-  test('a stale listener event after stop cannot flip connected state', async () => {
+  test('degrades to REST-only when the id_token becomes unmintable after a successful connect', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const log = logger()
+    const adapter = adapterWith({ r, listener, client: fakeClient().client, log })
+
+    // given the listener connected fine at start
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
+    const errorsBefore = log.lines.filter((l) => l.startsWith('error:')).length
+
+    // when a later reconnect can no longer mint the id_token (expired refresh
+    // token, outage): the SDK re-emits the same no_id_token error on every retry
+    listener.emit('error', new TeamsError('no id_token', 'no_id_token'))
+    listener.emit('error', new TeamsError('no id_token', 'no_id_token'))
+
+    // then the listener is torn down (stopping the SDK's unbounded reconnect
+    // loop) and no error lines are logged — it degrades to REST-only instead
+    expect(listener.stopped).toBe(true)
+    expect(log.lines.filter((l) => l.startsWith('error:')).length).toBe(errorsBefore)
+    expect(log.lines.some((l) => l.includes('continuing REST-only'))).toBe(true)
+    // REST send/read remain usable, callbacks stay registered
+    expect(adapter.isConnected()).toBe(true)
+    expect(r.unregistered).toEqual([])
+
+    await adapter.stop()
+  })
+
+  test('keeps the listener alive on a transient error so the SDK can reconnect', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const log = logger()
+    const adapter = adapterWith({ r, listener, client: fakeClient().client, log })
+
+    await adapter.start()
+    // a transient socket error is NOT the unrecoverable id_token failure, so the
+    // adapter leaves the listener running for the SDK's own reconnect to recover
+    listener.emit('error', new Error('websocket hiccup'))
+
+    expect(listener.stopped).toBe(false)
+    expect(log.lines.some((l) => l.startsWith('error:') && l.includes('websocket hiccup'))).toBe(true)
+
+    await adapter.stop()
+  })
+
+  test('is not usable after stop', async () => {
     const r = router()
     const listener = new FakeListener()
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
     await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
     await adapter.stop()
-    // a late event from the stopped listener must not resurrect connected state
+    expect(adapter.isConnected()).toBe(false)
+    // a late event from the stopped listener must not resurrect usable state
     listener.emit('connected', { endpointId: 'ep-stale' })
     expect(adapter.isConnected()).toBe(false)
   })
 
-  test('rolls back every registration when the listener errors before connecting', async () => {
+  test('degrades to REST-only when the listener errors before connecting', async () => {
     const r = router()
     const listener = new FakeListener()
     listener.startImpl = async () => {
@@ -543,44 +576,54 @@ describe('createTeamsAdapter', () => {
     }
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
-    await expect(adapter.start()).rejects.toThrow('trouter down')
-    expect(adapter.isConnected()).toBe(false)
-    expect(r.unregistered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+    // start() resolves (does not throw): REST send/read remain usable
+    await adapter.start()
+    // isConnected() reflects REST usability, so the manager won't churn-restart it
+    expect(adapter.isConnected()).toBe(true)
+    // the REST callbacks stay registered — only the listener is torn down
+    expect(r.registered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+    expect(r.unregistered).toEqual([])
     expect(listener.stopped).toBe(true)
+
+    await adapter.stop()
   })
 
-  test('a listener error that arrives after start() resolves still rolls back', async () => {
+  test('degrades to REST-only when a listener error arrives after start() resolves', async () => {
     const r = router()
     const listener = new FakeListener()
     // start() resolves without connecting; the error lands on the next tick,
     // so the adapter must be awaiting the connected/error race (not sampling a
-    // flag synchronously) to observe it.
+    // flag synchronously) to observe it before degrading.
     listener.startImpl = async () => {
       queueMicrotask(() => listener.emit('error', new Error('late trouter failure')))
     }
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
-    await expect(adapter.start()).rejects.toThrow('late trouter failure')
-    expect(adapter.isConnected()).toBe(false)
-    expect(r.unregistered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
+    expect(r.unregistered).toEqual([])
     expect(listener.stopped).toBe(true)
+
+    await adapter.stop()
   })
 
-  test('rolls back when listener.start() rejects synchronously without emitting error', async () => {
+  test('degrades to REST-only when listener.start() rejects synchronously', async () => {
     const r = router()
     const listener = new FakeListener()
     // start() rejects itself and never emits a `connected`/`error` event, so
     // the adapter must cancel the connected-wait in the rejection path (not
-    // hang for the full 20s timeout) and still roll back cleanly.
+    // hang for the full 20s timeout) and still degrade cleanly.
     listener.startImpl = async () => {
       throw new Error('start rejected')
     }
     const adapter = adapterWith({ r, listener, client: fakeClient().client })
 
-    await expect(adapter.start()).rejects.toThrow('start rejected')
-    expect(adapter.isConnected()).toBe(false)
-    expect(r.unregistered).toEqual(['outbound:teams', 'self:teams', 'history:teams'])
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
+    expect(r.unregistered).toEqual([])
     expect(listener.stopped).toBe(true)
+
+    await adapter.stop()
   })
 
   test('suppresses an echo delivered before the send promise resolves', async () => {

--- a/src/channels/adapters/teams.ts
+++ b/src/channels/adapters/teams.ts
@@ -1,4 +1,4 @@
-import { TeamsClient, TeamsListener } from 'agent-messenger/teams'
+import { TeamsClient, TeamsError, TeamsListener } from 'agent-messenger/teams'
 import type { TeamsListenerEventMap, TeamsMessage, TeamsUser } from 'agent-messenger/teams'
 
 import type { ChannelRouter } from '@/channels/router'
@@ -23,6 +23,7 @@ import {
   type InboundDropReason,
   type TeamsInboundEvent,
 } from './teams-classify'
+import { ContainerTeamsClient } from './teams-id-token'
 import { decodeTeamsConversationKey } from './teams-key'
 
 // `TeamsChat` is not exported from agent-messenger/teams, so derive its shape
@@ -148,7 +149,8 @@ export function createTeamsHistoryCallback(deps: {
 export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
   const logger = options.logger ?? consoleLogger
   const now = options.now ?? Date.now
-  const createClient = options.createClient ?? (() => new TeamsClient())
+  let loadedAccount: TeamsAccountRecord | null = null
+  const createClient = options.createClient ?? (() => new ContainerTeamsClient(() => loadedAccount))
   const createListener = options.createListener ?? ((client) => new TeamsListener(client))
   const client = createClient()
   let listener: TeamsListener | null = null
@@ -156,7 +158,6 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
   let chatsById = new Map<string, TeamsChatInfo>()
   let channelTeamMap = new Map<string, string>()
   let sentEchoes: SentEcho[] = []
-  let connected = false
   let started = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
@@ -280,6 +281,7 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
           ...(account.region !== undefined ? { region: account.region } : {}),
         })
         self = await client.testAuth()
+        loadedAccount = account
         await refreshChats()
         // Best-effort channelId->teamId map: the SDK already resolves teamId on
         // channel events, so this only backs the defensive fallback in
@@ -293,58 +295,66 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
       } catch (err) {
         started = false
         self = null
+        loadedAccount = null
         chatsById = new Map()
         channelTeamMap = new Map()
         logger.error(`[teams] login failed: ${describeError(err)}`)
         throw err
       }
 
+      // REST auth succeeded, so send/history/self-identity work regardless of
+      // whether the realtime listener can connect. Register them now and NEVER
+      // unregister them on a listener failure — realtime is a best-effort
+      // add-on, not a precondition for the adapter being usable.
+      options.router.registerOutbound('teams', outboundCallback)
+      options.router.registerSelfIdentity('teams', selfIdentityResolver)
+      options.router.registerHistory('teams', historyCallback)
+
       listener = createListener(client)
-      // The SDK auto-reconnects on any WebSocket drop and re-emits `connected`
-      // each reconnect. This permanent handler is what tracks liveness across
-      // reconnects: the one-shot startup wait below only sees the FIRST
-      // `connected`, so without this the flag would stay stuck false after the
-      // first reconnect and the manager's recovery loop would needlessly
-      // restart the adapter. The identity guard stops a late event from a
-      // stopped/rolled-back listener from mutating a fresh adapter's state.
       const activeListener = listener
       const isActive = (): boolean => listener === activeListener && started
+
+      // The realtime trouter listener needs an id_token the container mints from
+      // the account's AAD refresh token. When that is unavailable (legacy
+      // extracted-token account, expired refresh token, or a genuine trouter
+      // outage) the SDK rejects — and, crucially, on a still-running listener it
+      // schedules an UNBOUNDED reconnect that re-fails and re-emits `error`
+      // forever. Rather than fail the whole adapter (or let it log-loop), tear
+      // the listener down and keep running REST-only: send/read still work, we
+      // just don't get proactively woken by inbound Teams messages.
+      const degradeToRestOnly = (cause: Error): void => {
+        if (listener !== activeListener) return
+        listener?.stop()
+        listener = null
+        logger.warn(
+          `[teams] realtime listener unavailable, continuing REST-only (send/read work, no proactive inbound): ${describeError(cause)}`,
+        )
+      }
+
       listener.on('connected', () => {
         if (!isActive()) return
-        connected = true
         logger.info('[teams] connected')
       })
       listener.on('disconnected', () => {
         if (!isActive()) return
-        connected = false
         logger.warn('[teams] disconnected')
       })
+      // A post-connect `error` for the unrecoverable id_token failure would
+      // otherwise loop forever through the SDK's reconnect (each retry re-mints
+      // nothing and re-emits `error`). Degrade to REST-only on that specific
+      // cause so the loop stops; transient socket errors keep just logging and
+      // let the SDK's own reconnect recover them.
       listener.on('error', (err: TeamsListenerEventMap['error'][0]) => {
+        if (!isActive()) return
+        if (isUnrecoverableRealtimeAuthError(err)) {
+          degradeToRestOnly(err)
+          return
+        }
         logger.error(`[teams] listener error: ${describeError(err)}`)
       })
       listener.on('message', (event: TeamsListenerEventMap['message'][0]) => {
         void handleMessage(event)
       })
-
-      options.router.registerOutbound('teams', outboundCallback)
-      options.router.registerSelfIdentity('teams', selfIdentityResolver)
-      options.router.registerHistory('teams', historyCallback)
-
-      const rollbackStart = (reason: string, cause: Error): never => {
-        options.router.unregisterOutbound('teams', outboundCallback)
-        options.router.unregisterSelfIdentity('teams', selfIdentityResolver)
-        options.router.unregisterHistory('teams', historyCallback)
-        listener?.stop()
-        listener = null
-        self = null
-        chatsById = new Map()
-        channelTeamMap = new Map()
-        sentEchoes = []
-        connected = false
-        started = false
-        logger.error(`[teams] ${reason}: ${describeError(cause)}`)
-        throw cause
-      }
 
       // The SDK emits `connected` asynchronously, only after the trouter
       // WebSocket registers an endpoint — it is NOT raised synchronously by
@@ -354,13 +364,13 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
       try {
         await listener.start()
         await connectedWait.promise
-        connected = true
+        logger.info('[teams] realtime listener connected')
       } catch (err) {
         // Tear down the connected wait first: if `listener.start()` itself
         // rejected, `connectedWait.promise` was never awaited, so its timer and
         // handlers would otherwise linger and reject later unhandled.
         connectedWait.cancel()
-        rollbackStart('listener start failed', err instanceof Error ? err : new Error(describeError(err)))
+        degradeToRestOnly(err instanceof Error ? err : new Error(describeError(err)))
       }
     },
 
@@ -372,7 +382,6 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
       options.router.unregisterHistory('teams', historyCallback)
       listener?.stop()
       listener = null
-      connected = false
       if (inflightInbounds > 0) {
         await new Promise<void>((resolve) => {
           stopWaiters.push(resolve)
@@ -384,8 +393,13 @@ export function createTeamsAdapter(options: TeamsAdapterOptions): TeamsAdapter {
       sentEchoes = []
     },
 
+    // REST auth being live is what makes the adapter usable (send/read); the
+    // realtime listener is a best-effort add-on. Returning true here even in
+    // REST-only mode is deliberate: the channel manager restarts any adapter
+    // whose isConnected() is false, which would pointlessly churn a healthy
+    // REST-only Teams adapter that can never get a realtime listener.
     isConnected(): boolean {
-      return started && self !== null && connected
+      return started && self !== null
     },
   }
 }
@@ -464,6 +478,16 @@ function warnIfTokenExpiring(account: TeamsAccountRecord, logger: TeamsAdapterLo
   } else if (expiresAt - nowMs <= 10 * 60_000) {
     logger.warn('[teams] access token expires soon; long-running sessions will stop until credentials are refreshed')
   }
+}
+
+// The SDK throws a `TeamsError` with code `no_id_token` when it cannot obtain
+// the trouter id_token. In the container that never self-heals (the token is
+// minted from the AAD refresh token, so if minting fails once it keeps failing
+// every reconnect), so treat it as the signal to stop the doomed reconnect loop
+// and degrade. Transient socket errors carry other codes / plain Errors and are
+// left for the SDK's own reconnect to recover.
+function isUnrecoverableRealtimeAuthError(err: unknown): boolean {
+  return err instanceof TeamsError && err.code === 'no_id_token'
 }
 
 // The echo the socket delivers back for our own send carries the conversation


### PR DESCRIPTION
## Problem

A running container spams these on start and in a reconnect loop:

```
[teams] listener error: Could not obtain Teams id_token for real-time auth. Ensure the Teams desktop app is logged in, then re-run "auth extract".
[teams] listener start failed: Could not obtain Teams id_token for real-time auth...
[channels] adapter "teams" failed to start: Could not obtain Teams id_token for real-time auth...
```

The error comes from the upstream `agent-messenger` SDK. Its `TeamsListener` authenticates the realtime trouter WebSocket with an AAD Bearer **id_token**, and the only way it knows to obtain one (`TeamsClient.getIdToken()` → `TeamsTokenExtractor.extractIdToken()`) is to **scrape the `authtoken` cookie from the Teams desktop app's on-disk SQLite DB or a local Chromium profile**. TypeClaw runs headless in a Docker container where neither exists, so the scrape always returns `null`, the SDK throws `no_id_token`, and — because the failure also fires on every SDK reconnect — the logs loop. Worse, the adapter treated this as fatal: it rolled back **all** router registrations and rethrew, so even working REST send/read was torn down.

## Fix

Two parts:

**1. Mint the id_token in-container instead of scraping it.** The token the trouter wants is an ordinary AAD OAuth bearer for the Teams/Skype *spaces* resource — the same resource family the stored `aad_refresh_token` was minted against by the device-code login (`device-login.ts` stores `skypeScoped.refreshToken`). So `mintTeamsIdToken()` does a standard AAD `refresh_token` grant for that scope (mirroring the SDK's own `exchangeForSkypeScope`, which isn't exported), and `ContainerTeamsClient` overrides `getIdToken()` to use it. No desktop app, no browser — works in the container.

**2. Fail closed to REST-only.** When the id_token can't be minted (account without the AAD refresh trio, expired/revoked refresh token, or a genuine trouter outage), the adapter no longer dies. It registers outbound/history/self-identity as soon as REST auth succeeds and **keeps them regardless of the listener**; on listener failure it tears the listener down and logs a single warning. `isConnected()` now reflects REST usability (`started && self`), not realtime liveness, so the channel manager's recovery loop doesn't churn-restart a healthy REST-only adapter.

Net: realtime inbound now works in-container when the AAD refresh trio is present; otherwise the agent still sends/reads Teams on demand with no crash-loop.

## A note on confidence

Per Oracle review, the minted-token approach is *probably viable but wants runtime verification against a real tenant* — I could not test against a live Teams tenant. The design is deliberately fail-closed: if the minted bearer is ever rejected by the trouter, the adapter degrades to REST-only exactly as it does today when no token can be minted. So the worst case is "realtime doesn't wake the agent" (send/read still work), never a crash-loop or a dead adapter. Work-vs-personal acceptance is the main unknown to validate.

## Changes

- `src/channels/adapters/teams-id-token.ts` (new) + tests — `mintTeamsIdToken()` and `ContainerTeamsClient`.
- `src/channels/adapters/teams.ts` + tests — wire the minting client; make listener failure degrade to REST-only; `isConnected()` = REST usability.
- `docs/content/docs/reference/teams.mdx` — new **Realtime** section, corrected transport line and quirks.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (pre-existing warnings only)
- `bun run format:check` — clean
- `bun run test` — 10646 pass, 0 fail (7 new id-token unit tests; adapter suite updated so listener-failure paths assert REST-only degradation instead of teardown; inbound/echo tests unchanged and still green, proving realtime still works when the listener connects)

## Related

Companion docs rule shipped separately in #1165 (AGENTS.md: never depend on desktop/browser credential extraction in-container).