### PR TITLE
fix(inspect): label slack/discord/instagram sessions by platform name

### DIFF
--- a/src/inspect/label.test.ts
+++ b/src/inspect/label.test.ts
@@ -96,6 +96,47 @@ describe('originLabel', () => {
     ).toBe('Webex @dm/e354f6b0-2c2e-11f1-9f4f-fb975f3ebefb')
   })
 
+  test('slack user-account origin renders the Slack display name, not the raw id', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'slack',
+        workspace: 'T0123',
+        workspaceName: 'Acme',
+        chat: 'C0ABC',
+        chatName: 'general',
+        thread: null,
+      }),
+    ).toBe('Slack Acme/general')
+  })
+
+  test('discord user-account origin renders the Discord display name, not the raw id', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'discord',
+        workspace: '9999',
+        workspaceName: 'My Server',
+        chat: '8888',
+        chatName: 'dev-help',
+        thread: null,
+      }),
+    ).toBe('Discord My Server/dev-help')
+  })
+
+  test('instagram origin renders the Instagram display name, not the raw id', () => {
+    expect(
+      originLabel({
+        kind: 'channel',
+        adapter: 'instagram',
+        workspace: '@instagram-dm',
+        chat: '17841400000000000',
+        chatName: 'jane_doe',
+        thread: null,
+      }),
+    ).toBe('Instagram @instagram-dm/jane_doe')
+  })
+
   test('channel origin with unknown adapter renders adapter id verbatim', () => {
     expect(
       originLabel({

--- a/src/inspect/label.ts
+++ b/src/inspect/label.ts
@@ -3,12 +3,15 @@ import { toRef } from '@/channels/adapters/webex-id-ref'
 
 const ADAPTER_DISPLAY: Record<string, string> = {
   'slack-bot': 'Slack',
+  slack: 'Slack',
   'discord-bot': 'Discord',
+  discord: 'Discord',
   github: 'GitHub',
   'telegram-bot': 'Telegram',
   webex: 'Webex',
   'webex-bot': 'Webex',
   teams: 'Teams',
+  instagram: 'Instagram',
   line: 'LINE',
   kakaotalk: 'KakaoTalk',
 }


### PR DESCRIPTION
## Background

`ADAPTER_DISPLAY` in `src/inspect/label.ts` maps channel-adapter ids to human-readable platform names for `typeclaw inspect` session rows. It was missing three adapters — the `slack` and `discord` user-account adapters and `instagram` — so their rows fell through to the raw adapter id (e.g. `slack Acme/general` instead of `Slack Acme/general`), while every bot sibling (`slack-bot`, `discord-bot`, `webex-bot`, etc.) got a proper name. Discovered while auditing channel-adapter coverage for #1168; kept out of that docs-only PR to preserve its scope — this is the follow-up its Review notes flagged.

## Summary

Add the three missing entries using bare platform names, matching the existing convention where `webex`/`webex-bot` both map to `Webex` and `slack-bot` maps to `Slack`. No rendering-logic change — user-account rows now read identically to their bot siblings. The genuinely-unknown-adapter fallback (verbatim id) is unchanged and still covered by its existing test.

Added TDD tests (written red-first) for all three adapters. Note that `slack`/`discord` user adapters are intentionally NOT in `SLACK_CHAT_PREFIX_ADAPTERS`, so their chat names render without the leading # that `slack-bot`/`discord-bot` rows get — the tests assert that exact behavior.

## What this does NOT do

Purely a display-label fix — no change to routing, permissions, or adapter behavior. Does not touch the CLI `CHANNEL_LABELS` table (which already has all 12 adapters, and uses distinct "(User)" suffixes for a different surface).

## Review notes

The one-line-per-adapter additions to `ADAPTER_DISPLAY` are the whole change; verify the display names match the bare-platform-name convention already used for the bot adapters. Tests were written failing-first and now pass (`label.test.ts`). Full suite green (10676 pass, 0 fail); `typecheck`/`lint`/`format:check` clean.