### PR TITLE
fix(channels): retire the persistent silent-ack :eyes: on a later reply

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2566,6 +2566,178 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
   })
 })
 
+describe('ChannelRouter retires the persistent silent-ack :eyes: on a later reply', () => {
+  const REF_A: ReactionRef = { adapter: 'discord-bot', value: 'msg-a' }
+  const REF_B: ReactionRef = { adapter: 'discord-bot', value: 'msg-b' }
+  const SILENT_ACK_INSTANCE: ReactionRef = { adapter: 'discord-bot', value: 'silent-ack-instance' }
+
+  // discord-bot is typing-capable, so route() adds no eager engage :eyes: — every
+  // add is the silent-ack, and the add resolves to a removable instance ref so a
+  // later reply can retire it. Removals are captured to assert cleanup.
+  const setup = (
+    dir: string,
+  ): {
+    router: ReturnType<typeof makeRouter>['router']
+    sessions: ReturnType<typeof makeRouter>['sessions']
+    added: ReactionRequest[]
+    removed: ReactionRef[]
+  } => {
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    const added: ReactionRequest[] = []
+    const removed: ReactionRef[] = []
+    router.registerReaction('discord-bot', async (req) => {
+      added.push(req)
+      return { ok: true, reactionRef: SILENT_ACK_INSTANCE }
+    })
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+    return { router, sessions, added, removed }
+  }
+
+  test('a silent turn plants an :eyes: that a later reply removes', async () => {
+    const dir = await tempDir()
+    const { router, sessions, added, removed } = setup(dir)
+
+    // given a first turn that deliberately stays silent
+    await router.route(inbound({ reactionRef: REF_A }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => added.some((r) => r.emoji === 'eyes'))
+
+    // when a later turn in the same conversation replies for real
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+      sessions[0]!.setAssistantText('here you go')
+    }
+    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then the stale silent-ack :eyes: is retired
+    await waitFor(() => removed.length > 0)
+    expect(removed).toContainEqual(SILENT_ACK_INSTANCE)
+  })
+
+  test('a reply retires ALL outstanding silent-ack :eyes: in the conversation', async () => {
+    const dir = await tempDir()
+    const { router, sessions, added, removed } = setup(dir)
+
+    // given two separate silent turns, each planting its own :eyes:
+    await router.route(inbound({ reactionRef: REF_A }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 1)
+
+    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 2)
+
+    // when a third turn finally replies
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'done' })
+      sessions[0]!.setAssistantText('done')
+    }
+    await router.route(inbound({ externalMessageId: 'm3', reactionRef: REF_A }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then both silent-ack markers are removed, not just the latest
+    await waitFor(() => removed.length === 2)
+    expect(removed).toEqual([SILENT_ACK_INSTANCE, SILENT_ACK_INSTANCE])
+  })
+
+  test('a later silent turn does NOT remove the earlier silent-ack :eyes:', async () => {
+    const dir = await tempDir()
+    const { router, sessions, added, removed } = setup(dir)
+
+    await router.route(inbound({ reactionRef: REF_A }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 1)
+
+    // when a second turn is ALSO silent
+    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => added.filter((r) => r.emoji === 'eyes').length === 2)
+
+    // then nothing is removed — silence never contradicts a prior "seen" ack
+    expect(removed).toHaveLength(0)
+  })
+
+  test('a Korean silent turn then a reply retires the :eyes: (language-agnostic)', async () => {
+    const dir = await tempDir()
+    const { router, sessions, added, removed } = setup(dir)
+
+    // given a Korean inbound the agent silently acks
+    await router.route(inbound({ text: '확인만 해주세요', reactionRef: REF_A }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => added.some((r) => r.emoji === 'eyes'))
+
+    // when a later Korean turn replies
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '네, 처리했어요' })
+      sessions[0]!.setAssistantText('네, 처리했어요')
+    }
+    await router.route(inbound({ externalMessageId: 'm2', text: '고마워요', reactionRef: REF_B }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then the marker is retired regardless of message language
+    await waitFor(() => removed.length > 0)
+    expect(removed).toContainEqual(SILENT_ACK_INSTANCE)
+  })
+
+  test('a reply removes the :eyes: even when the silent-ack add resolves AFTER cleanup starts', async () => {
+    // Regression for the race: reactOnSilentAck stores the add PROMISE (not its
+    // resolved ref), so a reply that runs cleanup before a slow add resolves
+    // still awaits it and removes the mark. Here the add is held open until the
+    // reply turn has already drained, forcing cleanup to see an unresolved entry.
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    const removed: ReactionRef[] = []
+    let releaseSilentAckAdd: (() => void) | null = null
+    const silentAckAddGate = new Promise<void>((resolve) => {
+      releaseSilentAckAdd = resolve
+    })
+    let addCount = 0
+    router.registerReaction('discord-bot', async () => {
+      addCount++
+      await silentAckAddGate
+      return { ok: true, reactionRef: SILENT_ACK_INSTANCE }
+    })
+    router.registerRemoveReaction('discord-bot', async (req) => {
+      removed.push(req.reactionRef)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    // given a silent turn whose :eyes: add is still in flight (gated)
+    await router.route(inbound({ reactionRef: REF_A }))
+    sessions[0]!.onPrompt = () => sessions[0]!.setAssistantText('NO_REPLY')
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => addCount === 1)
+
+    // when a later turn replies while the add is STILL unresolved
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'done' })
+      sessions[0]!.setAssistantText('done')
+    }
+    await router.route(inbound({ externalMessageId: 'm2', reactionRef: REF_B }))
+    await router.__testing!.flushDebounce(KEY)
+    // let the gated add resolve only now — after cleanup has already begun
+    releaseSilentAckAdd!()
+
+    // then cleanup still awaits the add and retires the mark (no strand)
+    await waitFor(() => removed.length > 0)
+    expect(removed).toContainEqual(SILENT_ACK_INSTANCE)
+  })
+})
+
 describe('ChannelRouter model react only when replying', () => {
   const TARGET_REF: ReactionRef = { adapter: 'discord-bot', value: 'msg-ref' }
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -801,6 +801,24 @@ type LiveSession = {
   // one toggle would otherwise have the engage-drop remove the only visible
   // :eyes:. See `reactOnSilentAck`.
   silentAckTurn: { turnSeq: number; reason: SilentAckReason } | null
+  // One silent-ack-:eyes:-add promise per PERSISTENT ack `reactOnSilentAck` has
+  // planted on a trigger message, each resolving to its removable ref (or null).
+  // Mirrors `currentTurnEngageReactions`: the PROMISE is pushed synchronously at
+  // arm time, so a later replied-turn cleanup that snapshots this array always
+  // sees every in-flight add and awaits it before removing — storing only the
+  // resolved ref raced (cleanup could snapshot an empty array, then a slow add
+  // append its ref afterward, stranding the :eyes:). Cross-turn state on purpose:
+  // a silent turn means "seen, not replying FOR NOW", and once the same sticky
+  // conversation gets a genuine reply those marks read as stale/contradictory —
+  // so they are retired on the next replied turn (see dropSilentAckReactions).
+  // Conversation-scoped, NOT per-trigger-message: coalescing means the silent
+  // turn's trigger (message N) and the eventual reply's trigger (message N+1)
+  // routinely differ, so exact-message scoping would strand the mark. NOT reset
+  // in drain's outer per-turn finally. On teardown the entries are dropped
+  // WITHOUT removing the reactions: a session that ends without ever replying
+  // legitimately keeps its "seen, not replying" ack, unlike the transient
+  // engage :eyes: which teardown must strip.
+  activeSilentAckReactions: Array<Promise<ReactionRef | null>>
   lastTurnAuthorIds: Set<string>
   // Mirror of currentTurnAuthorId at end-of-turn (the LAST speaker of the
   // prior batch), preserved across the drain finally-block which resets
@@ -2028,6 +2046,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         currentTurnEngageReactions: [],
         pendingTurnReactions: [],
         silentAckTurn: null,
+        activeSilentAckReactions: [],
         // `lastTurnAuthorId` (string, used for `lastInboundAuthorId` in
         // origin) and `lastTurnAuthorIds` (Set, used by
         // `grantStickyForReplyTargets` as the fallback when
@@ -2910,8 +2929,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             sentReplyThisTurn &&
             live.emptyTurnFallbackTurn !== live.turnSeq &&
             assistantLeafStopReason(live.session) !== 'error'
-          if (usableReplyThisTurn) flushPendingReactions(live)
-          else live.pendingTurnReactions = []
+          if (usableReplyThisTurn) {
+            flushPendingReactions(live)
+            void dropSilentAckReactions(live)
+          } else live.pendingTurnReactions = []
           // Either retry budget keeps the turn in flight, so a deferred provider
           // error must wait for the reminder-only iteration that actually ends it.
           const retryQueuedThisTurn =
@@ -5203,7 +5224,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.silentAckTurn = null
     const reactionRef = live.currentTurnReactionRef
     if (reactionRef === null) return
-    void react({
+    const addResult = react({
       adapter: live.key.adapter,
       workspace: live.key.workspace,
       chat: live.key.chat,
@@ -5211,6 +5232,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       reactionRef,
       emoji: ENGAGE_REACTION_EMOJI,
     })
+    void addResult
       .then((result) => {
         if (!result.ok && result.code !== 'unsupported') {
           logger.info(
@@ -5223,6 +5245,49 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           `[channels] silent-ack-react threw reason=${reason} adapter=${live.key.adapter} chat=${live.key.chat}: ${describe(err)}`,
         )
       })
+    // Register the add promise (not its resolved ref) SYNCHRONOUSLY, so a later
+    // replied-turn cleanup can never race ahead of a still-in-flight add.
+    live.activeSilentAckReactions.push(addResult.then((r) => (r.ok ? (r.reactionRef ?? null) : null)).catch(() => null))
+  }
+
+  // Retire every persistent silent-ack :eyes: outstanding in this live session
+  // once the agent posts a genuine reply — the "seen, not replying" mark is now
+  // contradicted. Snapshot-and-clear the promise array BEFORE awaiting, so a
+  // concurrent later silent turn appending a fresh add is never swept by this
+  // in-flight cleanup. Each entry is AWAITED to its resolved ref before removal,
+  // so an add still in flight when the reply lands is still retired. Failures are
+  // logged, never retried: stale emoji cleanup must never block routing.
+  const dropSilentAckReactions = (live: LiveSession): Promise<void> => {
+    const addPromises = live.activeSilentAckReactions
+    if (addPromises.length === 0) return Promise.resolve()
+    live.activeSilentAckReactions = []
+    return Promise.all(
+      addPromises.map((addPromise) =>
+        addPromise
+          .then((reactionRef) => {
+            if (reactionRef === null) return undefined
+            return removeReaction({
+              adapter: live.key.adapter,
+              workspace: live.key.workspace,
+              chat: live.key.chat,
+              thread: live.key.thread,
+              reactionRef,
+            })
+          })
+          .then((result) => {
+            if (result && !result.ok && result.code !== 'unsupported' && result.code !== 'not-found') {
+              logger.info(
+                `[channels] silent-ack-unreact failed adapter=${live.key.adapter} chat=${live.key.chat}: ${result.error}`,
+              )
+            }
+          })
+          .catch((err) => {
+            logger.info(
+              `[channels] silent-ack-unreact threw adapter=${live.key.adapter} chat=${live.key.chat}: ${describe(err)}`,
+            )
+          }),
+      ),
+    ).then(() => undefined)
   }
 
   return {


### PR DESCRIPTION
## Background

Reported via a Slack thread: in an ongoing sticky conversation, the agent left a persistent 👀 (`:eyes:`) reaction stranded on a user message it had actually replied to in text later. User complaint: "the emoji (reaction) is not dropped."

Root cause: the router plants a PERSISTENT `:eyes:` on the triggering message whenever a turn is deliberately silent (`skip_response`, an explicit `NO_REPLY` sentinel, a plain-text `skip_response` leak, or a `github_review_output`) — added in c8e607d4 to mean "seen, intentionally not replying." There was no removal path: once planted, it stayed forever. In a sticky conversation the agent frequently goes silent on an intermediate message (thinking, coalescing, deferring) and then replies for real on a later turn, leaving a stale "not replying" marker on a message it did engage with. On the typing-less user-token `slack` adapter every engaging inbound is eligible for that ack, so markers piled up across a thread the agent was actively answering.

## Summary

Add a cross-turn removal path that retires stale silent-ack `:eyes:` once the agent posts a genuine reply, while leaving a genuinely-declined message's ack untouched.

- New `LiveSession` field `activeSilentAckReactions: ReactionRef[]` holds the removal refs of silent-ack `:eyes:` planted across turns.
- `reactOnSilentAck` now stashes the removal ref returned by the add instead of discarding it.
- New helper `dropSilentAckReactions` retires every outstanding silent-ack `:eyes:` once the agent posts a genuine reply — wired into drain's per-turn `finally` on the `usableReplyThisTurn` path only (never fires on an empty-turn fallback or a provider-error notice).
- Removal is **conversation-scoped, not per-trigger-message**: coalescing routinely splits the silent turn's trigger (message N) from the eventual reply's trigger (message N+1), so exact-message scoping would strand the marker.
- `dropSilentAckReactions` snapshots-and-clears the array before awaiting removals, so a concurrent later silent turn's fresh ref is never swept by an in-flight cleanup. Failures are logged, never retried — stale emoji cleanup must never block routing.
- The refs are intentionally NOT reset in the per-turn `finally`, and NOT stripped on teardown: a session that ends without ever replying legitimately keeps its "seen, not replying" ack, unlike the transient engage `:eyes:` which teardown must strip.

## What this does NOT do

- Does not change the persistent silent-ack `:eyes:` on a genuinely-declined message — that marker staying put is the intended behavior. Only the *stale* case, where the same live conversation later gets a real reply, is cleaned up.
- Does not touch the transient engage-reaction lifecycle or its teardown handling.
- Does not retry failed removals — a failed unreact is logged and left, never re-attempted.

## Review notes

- Load-bearing: the `usableReplyThisTurn`-only gating on `dropSilentAckReactions` (an empty-turn fallback or provider-error notice must NOT retire the ack), and the snapshot-and-clear ordering that protects a concurrent later silent turn's fresh ref.
- New tests in `src/channels/router.test.ts` ("ChannelRouter retires the persistent silent-ack :eyes: on a later reply"): a silent turn's `:eyes:` gets removed by a later reply; a reply retires ALL outstanding silent-ack `:eyes:` in the conversation, not just the latest trigger; a later silent turn does NOT remove an earlier silent-ack `:eyes:` (silence never contradicts a prior "seen" ack); and a Korean silent-then-reply pair retires the `:eyes:` the same way (language-agnostic, per repo policy).
- `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full `bun run test` suite (10680 pass, 0 fail) all pass.
