### PR TITLE
fix(channels): clear every flat-DM typing anchor so a migrated turn can't strand it

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7093,6 +7093,72 @@ describe('ChannelRouter typing indicator', () => {
     expect(router.__testing!.isTypingActive(KEY)).toBe(false)
   })
 
+  test('clears every flat-DM typingThread that got a status before the anchor migrated', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    // Record the LAST status per typingThread so a stranded "is typing..." on an
+    // anchor the turn migrated away from surfaces as a non-empty final value.
+    const lastStatus = new Map<string, string>()
+    router.registerTyping('discord-bot', async (target) => {
+      const key = target.typingThread ?? target.thread ?? 'none'
+      lastStatus.set(key, target.phase === 'stop' ? '' : 'is typing...')
+    })
+
+    // given: a flat-DM turn on ts=A held mid-prompt, so ts=A already has a live
+    // "is typing..." status while a second inbound can coalesce a new turn
+    let releasePrompt: (() => void) | undefined
+    const firstHeld = new Promise<void>((resolve) => {
+      releasePrompt = resolve
+    })
+    await router.route(inbound({ isDm: true, thread: null, typingThread: 'dm-ts-a', text: 'first' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstHeld
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+    expect(lastStatus.get('dm-ts-a')).toBe('is typing...')
+
+    // when: a second flat-DM inbound (ts=B) arrives before A's turn ends and the
+    // drain migrates the anchor to ts=B, then the turn ends
+    await router.route(
+      inbound({ isDm: true, thread: null, typingThread: 'dm-ts-b', text: 'second', externalMessageId: 'm2' }),
+    )
+    releasePrompt!()
+    await draining
+
+    // then: BOTH anchors are cleared — ts=A is not stranded on "is typing..."
+    expect(lastStatus.get('dm-ts-a')).toBe('')
+    expect(lastStatus.get('dm-ts-b')).toBe('')
+  })
+
+  test('clears each dirty flat-DM typingThread once at turn end', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    const stops: string[] = []
+    router.registerTyping('discord-bot', async (target) => {
+      if (target.phase === 'stop') stops.push(target.typingThread ?? 'none')
+    })
+
+    let releasePrompt: (() => void) | undefined
+    const firstHeld = new Promise<void>((resolve) => {
+      releasePrompt = resolve
+    })
+    await router.route(inbound({ isDm: true, thread: null, typingThread: 'dm-ts-a', text: 'first' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstHeld
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+    await router.route(
+      inbound({ isDm: true, thread: null, typingThread: 'dm-ts-b', text: 'second', externalMessageId: 'm2' }),
+    )
+    releasePrompt!()
+    await draining
+
+    // each dirty anchor is cleared exactly once — no empty-string clear storm
+    expect(stops.sort()).toEqual(['dm-ts-a', 'dm-ts-b'])
+  })
+
   test('awaits phase=stop when a turn is dropped without an outbound reply', async () => {
     const dir = await tempDir()
     const { router } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -780,6 +780,15 @@ type LiveSession = {
   // carried only to the typing path; null when the triggering inbound supplied
   // none (every non-DM inbound, and reminder-only turns).
   currentTurnTypingThread: string | null
+  // Every flat-DM typingThread anchor a 'tick' set a non-expiring status on but
+  // that has not yet been cleared. In a flat DM each inbound stamps its OWN ts
+  // as `typingThread`, so `currentTurnTypingThread` migrates from ts=A to ts=B
+  // when a second message coalesces a new turn before the first turn's stop. A
+  // single-anchor stop would then clear only B and strand A's "is typing..."
+  // forever (Slack has no auto-expiry). Recording every ticked anchor lets the
+  // stop clear ALL of them, not just the latest. An anchor is added when its
+  // 'tick' dispatches and removed when its 'stop' clear dispatches.
+  dirtyTypingThreads: Set<string>
   // One engage-:eyes:-add promise per inbound coalesced into THIS turn, each
   // resolving to its removable per-instance ref (or null). A debounced turn can
   // batch several inbounds that each got their own :eyes:, so every entry is
@@ -2025,6 +2034,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         currentTurnAuthorIds: new Set(),
         currentTurnReactionRef: null,
         currentTurnTypingThread: null,
+        dirtyTypingThreads: new Set(),
         currentTurnEngageReactions: [],
         pendingTurnReactions: [],
         silentAckTurn: null,
@@ -2285,14 +2295,24 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     await persist()
   }
 
-  const fireTyping = async (live: LiveSession, phase: 'tick' | 'stop', epoch?: number): Promise<void> => {
+  const fireTyping = async (
+    live: LiveSession,
+    phase: 'tick' | 'stop',
+    epoch?: number,
+    typingThreadOverride?: string,
+  ): Promise<void> => {
     // Drop a stale 'tick' that a since-cancelled interval still dispatched:
     // once the heartbeat stopped (or a new one started) the captured epoch no
     // longer matches, and forwarding it would re-set the indicator after the
-    // stop clear. 'stop' is never epoch-gated — it must always clear.
+    // stop clear. 'stop' is never epoch-gated — it must always clear. Marking
+    // dirty happens after this gate so a dropped tick is never recorded.
     if (phase === 'tick' && epoch !== undefined && epoch !== live.typingEpoch) return
     const callbacks = typingCallbacks.get(live.key.adapter)
     if (!callbacks || callbacks.size === 0) return
+    // A 'stop' clears an explicit anchor (fireTypingStop's per-dirty-thread
+    // clear); a 'tick' always targets the live turn anchor.
+    const typingThread = typingThreadOverride ?? live.currentTurnTypingThread
+    if (phase === 'tick' && typingThread !== null) live.dirtyTypingThreads.add(typingThread)
     // Snapshot before iterating: a callback could unregister mid-call.
     const snapshot = Array.from(callbacks)
     const target = {
@@ -2300,7 +2320,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       workspace: live.key.workspace,
       chat: live.key.chat,
       thread: live.key.thread,
-      ...(live.currentTurnTypingThread !== null ? { typingThread: live.currentTurnTypingThread } : {}),
+      ...(typingThread !== null ? { typingThread } : {}),
       phase,
     }
     await Promise.all(
@@ -2310,6 +2330,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         }),
       ),
     )
+    if (phase === 'stop' && typingThread !== null) live.dirtyTypingThreads.delete(typingThread)
+  }
+
+  // A 'stop' must clear EVERY flat-DM typingThread a tick set a status on this
+  // session — not just the current anchor — or a migrated-away anchor strands
+  // its "is typing..." (see `dirtyTypingThreads`). Clears run concurrently; each
+  // dirty thread is dispatched once and removed by fireTyping's stop path.
+  const fireTypingStop = async (live: LiveSession): Promise<void> => {
+    const dirty = new Set(live.dirtyTypingThreads)
+    if (live.currentTurnTypingThread !== null) dirty.add(live.currentTurnTypingThread)
+    if (dirty.size === 0) {
+      await fireTyping(live, 'stop')
+      return
+    }
+    await Promise.all(Array.from(dirty, (typingThread) => fireTyping(live, 'stop', undefined, typingThread)))
   }
 
   const bumpTypingActivity = (live: LiveSession): void => {
@@ -2498,7 +2533,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // clear platform-side state (e.g. Slack's 2-min server timeout) on
     // teardown. The FIFO inside the slack adapter ensures this clear lands
     // AFTER any in-flight 'tick' from the heartbeat that just stopped.
-    const stopped = fireTyping(live, 'stop').finally(() => {
+    const stopped = fireTypingStop(live).finally(() => {
       if (live.typingStopPromise === stopped) live.typingStopPromise = null
     })
     live.typingStopPromise = stopped


### PR DESCRIPTION
## Background

Follow-up to #1147. On a **flat Slack DM**, the typing indicator (Slack cycles its own loading phrases — *Reviewing findings…*, *Evaluating…*, *Putting it all together…* — via `assistant.threads.setStatus`) still stayed stranded after a turn ended, even with #1147's epoch guard in place.

Production observation (from a live agent's container logs): in one DM, two inbound messages arrived seconds apart. Per-`(chat, thread)` the final status ended non-empty for **both** message anchors:

```
thread ts=…699  ->  last status "is typing..."   (stranded)
thread ts=…740  ->  last status "is typing..."   (stranded)
```

Root cause is a **different** strand path than #1147's intra-thread interval race, so the epoch guard can't catch it. In a flat DM there is no real thread, so each inbound stamps its **own `ts`** as the `typingThread` key (`slack-bot-classify.ts`: `typingThread = isDm && thread === null ? event.ts : undefined`). The router, however, tracks only a **single** `currentTurnTypingThread` anchor. Sequence:

1. Message A (ts=A) → heartbeat sets `"is typing..."` on **ts=A**.
2. Message B (ts=B) coalesces a new turn before A's turn-end stop → the drain reassigns `currentTurnTypingThread = B`.
3. Turn ends → the single-anchor `'stop'` clears only **ts=B**. **ts=A keeps its `"is typing..."` forever** — Slack's status has no auto-expiry, so it keeps cycling loading phrases on the stranded message.

Discord/Telegram mask this because their native indicators auto-expire.

## Summary

Track **every** flat-DM anchor a `'tick'` set a status on in a per-session `dirtyTypingThreads: Set<string>`, and clear **all** of them on stop via a new `fireTypingStop` helper — instead of clearing only the live anchor.

- `fireTyping` gains an optional `typingThreadOverride` so a `'stop'` can target an old, migrated-away anchor (the target was previously always built from the live `currentTurnTypingThread`).
- A `'tick'` records its anchor as dirty; a `'stop'` clears its anchor and removes it from the set — so each dirty thread is cleared exactly once (no empty-string clear storm).

**Why the router and not the Slack adapter:** the strand is a router-level lifecycle gap (the router hands the adapter a single stale intent). Fixing it here protects every non-auto-expiring adapter — Slack today, Webex too — not just Slack.

**Why a Set and not "clear the old anchor at migration":** a migration-time clear can miss a tick whose target was built before the migration but resolves after it. Recording every non-stale tick target guarantees a later stop for each, and avoids per-anchor generation state.

**Interop with #1147:** dirty-marking happens **after** the epoch gate in `fireTyping`, so a dropped stale tick is never recorded. `'stop'` remains unconditional and un-epoch-gated.

## What this does NOT do

- No change to #1147's typing epoch, the Slack per-`(chat, thread)` FIFO tracker, the debounce/drain flow, or the after-send clear path.
- No change to when the indicator *appears* — only to guaranteeing every anchor it touched *clears*.
- Does not add auto-expiry emulation; it just makes the explicit clear cover all anchors.

## Review notes

- Load-bearing invariant: **a stop must clear every dirty anchor, not just the live one.** `fireTypingStop` unions `dirtyTypingThreads` with `currentTurnTypingThread`; if a future edit reverts `stopTypingHeartbeat` to `fireTyping(live, 'stop')`, the migrated-anchor strand returns.
- Dirty-marking is placed **after** the `epoch !== live.typingEpoch` early return in `fireTyping` — keep it there so stale ticks aren't recorded.
- Tests reproduce the exact production interleaving (two flat-DM ts in one DM, the second arriving before the first's stop). Both **fail on the pre-fix code** with ts=A stranded on `"is typing..."`; one asserts both anchors end cleared, the other asserts each dirty anchor is cleared exactly once.