### PR TITLE
fix(channels): vary attachment download dir by role visibility

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -72,7 +72,7 @@ import {
 import { attachToolNotFoundNudge } from './tool-not-found-nudge'
 import { createBudgetState, type ToolResultBudget, wrapToolDefinitionWithBudget } from './tool-result-budget'
 import { createChannelDisengageTool } from './tools/channel-disengage'
-import { createChannelFetchAttachmentTool } from './tools/channel-fetch-attachment'
+import { createChannelFetchAttachmentTool, resolveInboxBaseDir } from './tools/channel-fetch-attachment'
 import { createChannelHistoryTool } from './tools/channel-history'
 import { createChannelReactTool } from './tools/channel-react'
 import { createChannelReadTool } from './tools/channel-read'
@@ -390,7 +390,14 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
             ...(options.mcpManager ? buildMcpDispatcherToolDefinitions(options.mcpManager) : []),
             ...(options.reloadRegistry ? [createReloadTool({ registry: options.reloadRegistry })] : []),
             ...(options.stream ? [createStreamSnapshotTool({ stream: options.stream })] : []),
-            ...buildChannelTools(options.channelRouter, options.origin, sessionManager.getSessionId(), getOrigin),
+            ...buildChannelTools(
+              options.channelRouter,
+              options.origin,
+              sessionManager.getSessionId(),
+              getOrigin,
+              options.permissions,
+              options.plugins?.agentDir,
+            ),
             ...(options.containerName
               ? [
                   createRestartTool({
@@ -669,6 +676,8 @@ export function buildChannelTools(
   origin: SessionOrigin | undefined,
   sessionId?: string,
   getOrigin?: () => SessionOrigin | undefined,
+  permissions?: PermissionService,
+  agentDir?: string,
 ): ToolDefinition[] {
   if (!channelRouter) return []
   const tools: ToolDefinition[] = []
@@ -713,6 +722,9 @@ export function buildChannelTools(
       createChannelFetchAttachmentTool({
         router: channelRouter,
         origin: channelOrigin,
+        ...(permissions !== undefined && agentDir !== undefined
+          ? { resolveBaseDir: () => resolveInboxBaseDir(permissions, getOrigin?.() ?? origin, agentDir) }
+          : {}),
       }),
     )
     tools.push(createChannelLookAtTool(channelRouter, channelOrigin))

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -3,11 +3,18 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { SessionOrigin } from '@/agent/session-origin'
 import type { ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 import type { FetchAttachmentArgs, FetchAttachmentResult, InboundAttachment } from '@/channels/types'
+import { createPermissionService } from '@/permissions/permissions'
 
-import { createChannelFetchAttachmentTool } from './channel-fetch-attachment'
+import {
+  createChannelFetchAttachmentTool,
+  DEFAULT_INBOX_DIR,
+  PUBLIC_INBOX_DIR,
+  resolveInboxBaseDir,
+} from './channel-fetch-attachment'
 
 const origin = { adapter: 'slack-bot' as const, workspace: 'T0ACME', chat: 'C0CHANNEL', thread: null }
 const fakeCtx = {} as Parameters<ReturnType<typeof createChannelFetchAttachmentTool>['execute']>[4]
@@ -178,5 +185,55 @@ describe('channel_fetch_attachment', () => {
     const result = await runTool(tool, { attachment_id: 1 })
 
     expect(result.details).toEqual({ ok: false, error: 'invalid Slack file id: F-bogus' })
+  })
+
+  test('resolveBaseDir wins over inboxDir and steers the write per role', async () => {
+    const router = makeRouter({
+      attachments: [{ id: 1, kind: 'file', ref: 'F1', filename: 'shot.png' }],
+      fetch: async () => ({ ok: true, buffer: Buffer.from('x'), filename: 'shot.png', size: 1 }),
+    })
+    const tool = createChannelFetchAttachmentTool({
+      router,
+      origin,
+      inboxDir,
+      resolveBaseDir: () => join(inboxDir, 'redirected'),
+    })
+
+    const result = await runTool(tool, { attachment_id: 1 })
+
+    const expectedPath = join(inboxDir, 'redirected', 'slack-bot', 'F1', 'shot.png')
+    expect(result.details?.path).toBe(expectedPath)
+    expect(readFileSync(expectedPath, 'utf8')).toBe('x')
+  })
+})
+
+describe('resolveInboxBaseDir — per-role download location', () => {
+  const AGENT = '/agent'
+  const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
+  const spawnedBy = (role: string): SessionOrigin => ({
+    kind: 'subagent',
+    subagent: 'x',
+    parentSessionId: 'p',
+    spawnedByRole: role,
+  })
+
+  test('owner (sees workspace/) keeps the private-surface inbox', () => {
+    const svc = createPermissionService()
+    expect(resolveInboxBaseDir(svc, tui, AGENT)).toBe(DEFAULT_INBOX_DIR)
+  })
+
+  test('member (sees workspace/) keeps the private-surface inbox', () => {
+    const svc = createPermissionService()
+    expect(resolveInboxBaseDir(svc, spawnedBy('member'), AGENT)).toBe(DEFAULT_INBOX_DIR)
+  })
+
+  test('guest (hidden from workspace/) is redirected to the public inbox', () => {
+    const svc = createPermissionService()
+    expect(resolveInboxBaseDir(svc, spawnedBy('guest'), AGENT)).toBe(PUBLIC_INBOX_DIR)
+  })
+
+  test('undefined origin fails safe to the public inbox', () => {
+    const svc = createPermissionService()
+    expect(resolveInboxBaseDir(svc, undefined, AGENT)).toBe(PUBLIC_INBOX_DIR)
   })
 })

--- a/src/agent/tools/channel-fetch-attachment.ts
+++ b/src/agent/tools/channel-fetch-attachment.ts
@@ -150,6 +150,11 @@ export function createChannelFetchAttachmentTool({
 // the save location can never drift out of sync with what privateSurfaceRead
 // will let the same role read back: if workspace/inbox lands under a hidden dir
 // the file goes to the guest-visible public/ inbox instead.
+//
+// The hidden-check joins with the OS-native separator to stay byte-identical to
+// resolveHiddenPaths' own dirs, but the RETURNED path is normalized to POSIX:
+// this value names a location inside the Linux container (agentDir is /agent),
+// so a win32 CI host must not leak backslashes into it.
 export function resolveInboxBaseDir(
   permissions: PermissionService,
   origin: SessionOrigin | undefined,
@@ -158,7 +163,11 @@ export function resolveInboxBaseDir(
   const privateInbox = join(agentDir, 'workspace', 'inbox')
   const { dirs } = resolveHiddenPaths(permissions, origin, agentDir)
   const hidden = dirs.some((dir) => privateInbox === dir || privateInbox.startsWith(`${dir}${sep}`))
-  return hidden ? join(agentDir, 'public', 'inbox') : privateInbox
+  return toPosix(hidden ? join(agentDir, 'public', 'inbox') : privateInbox)
+}
+
+function toPosix(p: string): string {
+  return p.split(sep).join('/')
 }
 
 function errorResult(message: string) {

--- a/src/agent/tools/channel-fetch-attachment.ts
+++ b/src/agent/tools/channel-fetch-attachment.ts
@@ -1,11 +1,14 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import type { SessionOrigin } from '@/agent/session-origin'
 import type { ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
+import type { PermissionService } from '@/permissions'
+import { resolveHiddenPaths } from '@/sandbox'
 
 import { type ChannelToolLogger, consoleChannelLogger, formatChannelToolFailure } from './channel-log'
 
@@ -20,24 +23,37 @@ export type CreateChannelFetchAttachmentToolOptions = {
   router: ChannelRouter
   origin: ChannelFetchAttachmentOrigin
   inboxDir?: string
+  // Resolved at execute time (role is a property of the live origin, not of
+  // construction), and wins over inboxDir/DEFAULT_INBOX_DIR. Lets the save
+  // location follow the caller's role so a role hidden from workspace/ never
+  // gets a file it can write but not read back (privateSurfaceRead would block
+  // its follow-up look_at/read). See buildChannelTools for the decision.
+  resolveBaseDir?: () => string
   logger?: ChannelToolLogger
 }
 
+// workspace/ is private-surface: readable only by roles with fs.see.private.
 export const DEFAULT_INBOX_DIR = '/agent/workspace/inbox'
+// public/ is the guest-visible counterpart, so a redirected file stays readable
+// back through look_at/read by the same role that fetched it.
+export const PUBLIC_INBOX_DIR = '/agent/public/inbox'
 
 export function createChannelFetchAttachmentTool({
   router,
   origin,
   inboxDir,
+  resolveBaseDir,
   logger = consoleChannelLogger,
 }: CreateChannelFetchAttachmentToolOptions) {
-  const baseDir = inboxDir ?? DEFAULT_INBOX_DIR
+  const fallbackBaseDir = inboxDir ?? DEFAULT_INBOX_DIR
   const adapter = origin.adapter
   return defineTool({
     name: 'channel_fetch_attachment',
     label: 'Channel Fetch Attachment',
     description:
-      'Download a file attached to a channel message and save it to disk. Inbound channel ' +
+      'Download a file attached to a channel message and save it to disk. Use this only when you need the ' +
+      'file ON DISK (to edit it, re-upload it, or run a tool over it); to simply VIEW an image, use ' +
+      '`look_at_channel_attachment` instead — it returns a description without a disk write. Inbound channel ' +
       'messages with attachments show `[<Platform> attachment #N: <kind> <metadata>]` in the text. Pass `N` as ' +
       '`attachment_id`; do not invent ids that are not present in the message. The router resolves the private ' +
       'platform ref itself. Attachments on the CURRENT inbound message resolve directly; for one from an EARLIER ' +
@@ -102,6 +118,7 @@ export function createChannelFetchAttachmentTool({
 
       const safeFilename = sanitizeFilename(result.filename)
       const refSlug = sanitizeRefSlug(ref)
+      const baseDir = resolveBaseDir?.() ?? fallbackBaseDir
       const targetDir = join(baseDir, adapter, refSlug)
       const targetPath = join(targetDir, safeFilename)
       try {
@@ -126,6 +143,22 @@ export function createChannelFetchAttachmentTool({
       return { content: [{ type: 'text' as const, text }], details }
     },
   })
+}
+
+// Picks the inbox root for the caller's live role. Reuses the guard's own
+// deny-list resolution (resolveHiddenPaths) as the single source of truth, so
+// the save location can never drift out of sync with what privateSurfaceRead
+// will let the same role read back: if workspace/inbox lands under a hidden dir
+// the file goes to the guest-visible public/ inbox instead.
+export function resolveInboxBaseDir(
+  permissions: PermissionService,
+  origin: SessionOrigin | undefined,
+  agentDir: string,
+): string {
+  const privateInbox = join(agentDir, 'workspace', 'inbox')
+  const { dirs } = resolveHiddenPaths(permissions, origin, agentDir)
+  const hidden = dirs.some((dir) => privateInbox === dir || privateInbox.startsWith(`${dir}${sep}`))
+  return hidden ? join(agentDir, 'public', 'inbox') : privateInbox
 }
 
 function errorResult(message: string) {


### PR DESCRIPTION
## Background

A guest-role turn hit a dead end when trying to view a channel attachment. The observed sequence (from a production Slack session):

1. `look_at_channel_attachment` timed out (a separate vision-TTFB issue, fixed in a follow-up PR).
2. The agent fell back to `channel_fetch_attachment`, which **saved the file to `/agent/workspace/inbox/...`** and returned that path.
3. It then tried `look_at` on that path → **blocked by the `privateSurfaceRead` guard**: `resolves to /agent/workspace, which is hidden from the current role`.
4. `bash cat` on the same path → also masked by the bwrap sandbox.

Root cause: `channel_fetch_attachment` hardcoded its save path under `workspace/`, which is in the private-surface deny-list (`PRIVATE_DIRS` in `hidden-paths.ts`). For a `guest` (or any unresolved origin), `workspace/` is hidden — so the tool handed the role a file it could **write but never legally read back**. A guest-usable tool wrote exclusively to a guest-forbidden location. The guard behaved correctly; the tool/location pairing was the bug.

## Summary

Resolve the inbox root from the **caller's live role**, reusing the guard's own `resolveHiddenPaths` as the single source of truth:

- Roles that can see `workspace/` (owner/trusted/member) keep the private-surface inbox (`workspace/inbox`) — unchanged.
- Roles hidden from it (guest, unresolved origin) are redirected to the guest-visible `public/inbox`, so the `fetch → look_at/read` chain works for every role that can fetch.

**Why reuse `resolveHiddenPaths` instead of a fresh role check:** it keeps the save location from ever drifting out of sync with what `privateSurfaceRead` will permit. One deny-list, two consumers (the guard and the location picker) — no second policy to keep aligned.

The resolver runs at **execute time** (via an injected `resolveBaseDir` thunk), not at construction, because the role is a property of the live origin.

Also nudged the tool description toward `look_at_channel_attachment` for the common "just view the image" case, which round-trips vision without writing to disk at all.

## What this does NOT do

- Does not touch the `privateSurfaceRead` guard or the bwrap sandbox — the deny-list is unchanged; only where files land moves.
- Does not weaken the private surface for trusted roles — their inbox stays under `workspace/`.
- Does not address the vision-TTFB timeout that triggered the fallback in the first place — that is a separate PR.

## Review notes

- Load-bearing change: `resolveInboxBaseDir` in `channel-fetch-attachment.ts`. Invariant to verify — its hidden-dir check uses the exact `dirs` returned by `resolveHiddenPaths`, so a role that the guard would block from reading `workspace/inbox` is precisely the role that gets redirected to `public/inbox`.
- `buildChannelTools` now threads `permissions` + `agentDir` and only wires the resolver when both are present; without them the tool falls back to `DEFAULT_INBOX_DIR` (unchanged behavior for callers that don't supply them, e.g. composition tests).
- Tests cover owner/member → private inbox, guest/undefined → public inbox, and that `resolveBaseDir` overrides the static `inboxDir`.

Pre-existing unrelated test failures on this branch: 7 schema-drift/scaffold tests (`typeclaw/cron/secrets.schema.json`) fail identically on `origin/main` in this environment; this PR touches no schema files.