### PR TITLE
fix(multimodal): give GLM vision a 45s TTFB so it stops flaking at 15s

### DIFF
--- a/src/agent/multimodal/look-at.test.ts
+++ b/src/agent/multimodal/look-at.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
-import { buildGlmVisionMessages, extractGlmVisionText, lookAtTool } from './look-at'
+import {
+  buildGlmVisionMessages,
+  extractGlmVisionText,
+  GLM_VISION_TTFB_MS,
+  lookAtTool,
+  resolveGlmVisionTtfbMs,
+} from './look-at'
 import { buildMultimodalLookerSystemPrompt } from './looker'
 
 type ImageParam = { url?: string; path?: string; data?: string; mimeType?: string } | Record<string, never>
@@ -127,5 +133,22 @@ describe('buildGlmVisionMessages — GLM payload preserves looker behavior', () 
     expect(user.role).toBe('user')
     expect(user.content[0]).toEqual({ type: 'image_url', image_url: { url: 'data:image/png;base64,aGk=' } })
     expect(user.content[1]).toEqual({ type: 'text', text: 'Please describe the attached image(s).' })
+  })
+})
+
+describe('resolveGlmVisionTtfbMs — vision TTFB budget', () => {
+  test('defaults to 45s when the env var is unset', () => {
+    expect(resolveGlmVisionTtfbMs({})).toBe(GLM_VISION_TTFB_MS)
+    expect(GLM_VISION_TTFB_MS).toBe(45_000)
+  })
+
+  test('a valid TYPECLAW_GLM_VISION_TTFB_MS overrides the default', () => {
+    expect(resolveGlmVisionTtfbMs({ TYPECLAW_GLM_VISION_TTFB_MS: '60000' })).toBe(60_000)
+  })
+
+  test('an invalid or empty env value falls back to the default', () => {
+    expect(resolveGlmVisionTtfbMs({ TYPECLAW_GLM_VISION_TTFB_MS: '' })).toBe(GLM_VISION_TTFB_MS)
+    expect(resolveGlmVisionTtfbMs({ TYPECLAW_GLM_VISION_TTFB_MS: 'abc' })).toBe(GLM_VISION_TTFB_MS)
+    expect(resolveGlmVisionTtfbMs({ TYPECLAW_GLM_VISION_TTFB_MS: '-5' })).toBe(GLM_VISION_TTFB_MS)
   })
 })

--- a/src/agent/multimodal/look-at.ts
+++ b/src/agent/multimodal/look-at.ts
@@ -9,6 +9,7 @@ import type { ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
 import { providerForModelRef } from '@/config/providers'
+import { LLM_FETCH_OBSERVER_TIMEOUTS, type LlmFetchObservedRequestInit } from '@/run/llm-fetch-observer'
 import { SecretsBackend } from '@/secrets'
 
 import { buildMultimodalLookerSystemPrompt, resolveImage, type ImageInput } from './looker'
@@ -207,6 +208,21 @@ const GLM_VISION_MODEL = 'glm-4.6v'
 const GLM_VISION_ENDPOINT = 'https://api.z.ai/api/coding/paas/v4/chat/completions'
 const GLM_VISION_MAX_TOKENS = 32768
 
+// Vision requests carry a base64 image body the server must decode before it can
+// send response headers, so the observer's 15s default TTFB (tuned for ~1s text
+// completions) is too tight and flakes on cold connections. 45s is 3x the
+// observed-under-load window; env-overridable for operators who need more.
+export const GLM_VISION_TTFB_MS = 45_000
+const ENV_GLM_VISION_TTFB_MS = 'TYPECLAW_GLM_VISION_TTFB_MS'
+
+export function resolveGlmVisionTtfbMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[ENV_GLM_VISION_TTFB_MS]
+  if (raw === undefined || raw === '') return GLM_VISION_TTFB_MS
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return GLM_VISION_TTFB_MS
+  return parsed
+}
+
 function shouldUseGlmCodingPlanVision(): boolean {
   const ref = resolveProfile(getConfig().models, 'vision').ref
   return providerForModelRef(ref) === GLM_VISION_PROVIDER && !resolveModel(ref).input.includes('image')
@@ -219,17 +235,19 @@ async function analyzeWithGlmCodingPlanVision(imageContents: ImageContent[], pro
     return errorResult('GLM Coding Plan vision unavailable: no zai-coding API key', details)
   }
 
+  const requestInit: LlmFetchObservedRequestInit = {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: GLM_VISION_MODEL,
+      max_tokens: GLM_VISION_MAX_TOKENS,
+      messages: buildGlmVisionMessages(imageContents, prompt),
+    }),
+    [LLM_FETCH_OBSERVER_TIMEOUTS]: { ttfbMs: resolveGlmVisionTtfbMs() },
+  }
   let response: Response
   try {
-    response = await fetch(GLM_VISION_ENDPOINT, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: GLM_VISION_MODEL,
-        max_tokens: GLM_VISION_MAX_TOKENS,
-        messages: buildGlmVisionMessages(imageContents, prompt),
-      }),
-    })
+    response = await fetch(GLM_VISION_ENDPOINT, requestInit)
   } catch (error) {
     return errorResult(`GLM vision request failed: ${error instanceof Error ? error.message : String(error)}`, details)
   }

--- a/src/run/llm-fetch-observer.test.ts
+++ b/src/run/llm-fetch-observer.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { defaultLlmFetchEndpoints, installLlmFetchObserver, type TimeoutScheduler } from './llm-fetch-observer'
+import {
+  defaultLlmFetchEndpoints,
+  installLlmFetchObserver,
+  LLM_FETCH_OBSERVER_TIMEOUTS,
+  type LlmFetchObservedRequestInit,
+  type TimeoutScheduler,
+} from './llm-fetch-observer'
 
 // Programmable scheduler for tests. Tasks scheduled for time T fire when the
 // test calls `fire(T)`. Out-of-order T values (T must be monotonically
@@ -1250,5 +1256,112 @@ describe('installLlmFetchObserver', () => {
     // then: the 40ms Codex-specific TTFB fired, not the 70ms generic one
     expect(caught).not.toBeNull()
     expect(caught!.message).toContain('40ms')
+  })
+
+  test('a per-request TTFB override beats the endpoint default on the SAME url', async () => {
+    // given: generic default TTFB is 50ms, but this ONE request carries a 500ms
+    // per-request override (the GLM-vision path on a URL it shares with GLM text)
+    process.env.TYPECLAW_LLM_TTFB_MS = '50'
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    let underlyingSignal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      underlyingSignal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        underlyingSignal?.addEventListener('abort', () => reject(underlyingSignal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
+    let firedAt50 = false
+    let caught: Error | null = null
+    const init: LlmFetchObservedRequestInit = { method: 'POST', [LLM_FETCH_OBSERVER_TIMEOUTS]: { ttfbMs: 500 } }
+    try {
+      clock.set(0)
+      const pending = fetch('https://api.z.ai/api/coding/paas/v4/chat/completions', init)
+      // the endpoint default would have fired here; the override must suppress it
+      clock.set(50)
+      await scheduler.fire(50)
+      firedAt50 = underlyingSignal?.aborted ?? false
+      clock.set(500)
+      await scheduler.fire(500)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+
+    expect(firedAt50).toBe(false)
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('500ms')
+  })
+
+  test('an identical url WITHOUT the override still uses the endpoint default (GLM text stays aggressive)', async () => {
+    // given: same z.ai coding URL as vision, but no per-request override
+    process.env.TYPECLAW_LLM_TTFB_MS = '50'
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+
+    let underlyingSignal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      underlyingSignal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        underlyingSignal?.addEventListener('abort', () => reject(underlyingSignal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
+    let caught: Error | null = null
+    try {
+      clock.set(0)
+      const pending = fetch('https://api.z.ai/api/coding/paas/v4/chat/completions', { method: 'POST' })
+      clock.set(50)
+      await scheduler.fire(50)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+
+    // then: the 50ms default fired — the override mechanism did not loosen text
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('50ms')
+  })
+
+  test('a per-request override still gets the body-timing tap + log on a healthy response', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const ctrl = makeControllableBody()
+
+    globalThis.fetch = (async () => {
+      clock.set(10)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now, scheduler, idleMs: 0 })
+    const init: LlmFetchObservedRequestInit = { method: 'POST', [LLM_FETCH_OBSERVER_TIMEOUTS]: { ttfbMs: 500 } }
+    try {
+      clock.set(0)
+      const response = await fetch('https://api.z.ai/api/coding/paas/v4/chat/completions', init)
+      const drainPromise = drainQuiet(response.body)
+      clock.set(50)
+      await ctrl.push(new TextEncoder().encode('ok'))
+      clock.set(100)
+      await ctrl.close()
+      await drainPromise
+    } finally {
+      uninstall()
+    }
+
+    const observed = entries.filter((e) => e.msg.startsWith('[llm-fetch]'))
+    expect(observed.length).toBe(1)
+    expect(observed[0]!.msg).toContain('status=200')
+    expect(observed[0]!.msg).toContain('provider=openai-compatible')
   })
 })

--- a/src/run/llm-fetch-observer.ts
+++ b/src/run/llm-fetch-observer.ts
@@ -3,6 +3,24 @@ export type LlmFetchObserverLogger = {
   warn: (msg: string) => void
 }
 
+// Per-request timeout override, attached to a RequestInit under a Symbol key so
+// it travels with a single fetch() without leaking a wire header to the provider
+// and without widening the endpoint matcher. Used where one call on a SHARED
+// endpoint URL needs a different deadline than its siblings — e.g. GLM vision and
+// GLM text hit the identical /chat/completions URL, so a URL/header match cannot
+// tell them apart, but the vision caller owns its fetch and can tag it directly.
+export const LLM_FETCH_OBSERVER_TIMEOUTS = Symbol.for('typeclaw.llmFetchObserverTimeouts')
+
+export type LlmFetchObserverTimeoutOverrides = {
+  ttfbMs?: number
+  idleMs?: number
+  overallMs?: number
+}
+
+export type LlmFetchObservedRequestInit = RequestInit & {
+  [LLM_FETCH_OBSERVER_TIMEOUTS]?: LlmFetchObserverTimeoutOverrides
+}
+
 // A provider endpoint the observer should instrument. `match` is host-agnostic
 // on purpose: base URLs are user-configured (ANTHROPIC_BASE_URL, OPENAI_BASE_URL,
 // OpenRouter/LiteLLM/Fireworks/arbitrary proxies), so a host allowlist would be
@@ -442,12 +460,15 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
   // "force this across all endpoints" (the test seam and any global override),
   // so it must beat a per-endpoint tuned value. The master `timeoutsEnabled=off`
   // switch forces every timer to 0 regardless.
-  const resolveTimeouts = (endpoint: LlmFetchEndpoint): ResolvedTimeouts => {
+  const resolveTimeouts = (
+    endpoint: LlmFetchEndpoint,
+    perRequest: LlmFetchObserverTimeoutOverrides | undefined,
+  ): ResolvedTimeouts => {
     if (!timeoutsEnabled) return { ttfbMs: 0, idleMs: 0, overallMs: 0 }
     return {
-      ttfbMs: opts.ttfbMs ?? endpoint.ttfbMs ?? envDefaults.ttfbMs,
-      idleMs: opts.idleMs ?? endpoint.idleMs ?? envDefaults.idleMs,
-      overallMs: opts.overallMs ?? endpoint.overallMs ?? envDefaults.overallMs,
+      ttfbMs: opts.ttfbMs ?? perRequest?.ttfbMs ?? endpoint.ttfbMs ?? envDefaults.ttfbMs,
+      idleMs: opts.idleMs ?? perRequest?.idleMs ?? endpoint.idleMs ?? envDefaults.idleMs,
+      overallMs: opts.overallMs ?? perRequest?.overallMs ?? endpoint.overallMs ?? envDefaults.overallMs,
     }
   }
 
@@ -459,7 +480,8 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
     if (endpoint === null) {
       return originalFetch(input, init)
     }
-    const timeouts = resolveTimeouts(endpoint)
+    const perRequest = (init as LlmFetchObservedRequestInit | undefined)?.[LLM_FETCH_OBSERVER_TIMEOUTS]
+    const timeouts = resolveTimeouts(endpoint, perRequest)
     const provider = endpoint.label
     const start = now()
 


### PR DESCRIPTION
## Background

A production `look_at_channel_attachment` call failed with:

```
GLM vision request failed: openai-compatible fetch timed out before response headers after 15000ms (typeclaw observer timeout)
```

…and then **succeeded on retry seconds later**. Root cause: the GLM Coding Plan vision call (`analyzeWithGlmCodingPlanVision` in `look-at.ts`) posts to `https://api.z.ai/api/coding/paas/v4/chat/completions` — the **same URL GLM text/coding models use**. The `llm-fetch-observer` matches endpoints by `(url, method)` and applies its default 15s TTFB (time-to-first-byte) deadline, a budget deliberately tuned for ~1s text completions (see the observer's own comment: healthy text TTFB ~1s, 15s ≈ 2× the pathological ceiling).

Vision requests carry a base64 image body the server must decode before it can emit response headers, so on a cold connection they trip the 15s deadline and abort. The observer classifies it as failover-worthy, the retry warms the connection, and it works — a flaky, user-visible failure that isn't a real capability limit.

## Summary

Two commits:

1. **`feat(run)`** — add a per-request TTFB override to the observer, carried on `RequestInit` under an internal `Symbol` key (`LLM_FETCH_OBSERVER_TIMEOUTS`). It sits above the endpoint/env defaults in `resolveTimeouts` precedence but below the observer-level `opts` (so a global force still wins).

2. **`fix(multimodal)`** — tag the GLM vision fetch with a **45s** TTFB (3× the observed-under-load window), overridable via `TYPECLAW_GLM_VISION_TTFB_MS`.

**Why a `Symbol` on the request and not a URL/header match** (the load-bearing decision, confirmed with Oracle): GLM vision and GLM text hit the **identical URL**, so a URL match can't distinguish them and would loosen the aggressive 15s guard for the main agent's primary text model. A marker *header* would leak to the provider and needs stripping. Widening the endpoint matcher to inspect headers widens the contract across all three endpoints. The `Symbol` travels with the one request that needs it, is invisible on the wire, and leaves the matcher, body-timing tap, idle/overall timers, and logging completely untouched.

## What this does NOT do

- Does not change the generic default TTFB (15s) or any endpoint's TTFB — only the single tagged vision request is affected.
- Does not loosen GLM **text** on the shared URL — verified by a test asserting an identical URL *without* the override still fires at the default deadline.
- Does not touch idle/overall body timers or the observer's logging for the vision request.

## Review notes

- Precedence in `resolveTimeouts`: `opts.ttfbMs ?? perRequest?.ttfbMs ?? endpoint.ttfbMs ?? envDefaults.ttfbMs`. The per-request override is deliberately below `opts` (the global test/force seam) and above per-endpoint/env, so an operator-wide `TYPECLAW_LLM_TTFB_MS` is still overridden by the vision-specific budget, which is the intent.
- Tests cover: per-request override beats the default on the shared URL; the same URL without the override stays at the default (text unaffected); the body-timing tap + log still fire when an override is present; and the `resolveGlmVisionTtfbMs` default (45s) + env override + invalid-value fallback.

Pre-existing unrelated test failures on this branch: the same 7 schema-drift/scaffold tests (`typeclaw/cron/secrets.schema.json`) fail identically on `origin/main` in this environment; this PR touches no schema files.