### PR TITLE
fix(channels): defer teardown of an in-flight session on reload

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -936,6 +936,153 @@ describe('ChannelRouter session lifecycle', () => {
     expect(sessions[0]!.disposed).toBe(1)
   })
 
+  // Regression for the reload-silence incident: a reload (roles/provider swap)
+  // ran tearDownAllLive() while the reload's own turn was mid-flight, aborting
+  // the in-flight prompt so the closing reply was never sent — the user saw
+  // silence. tearDownAllLive must defer teardown of a draining session until
+  // the turn drains, then recreate it.
+  test('tearDownAllLive() defers an in-flight session: no abort, reply lands, torn down after drain', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    // Fire drain without awaiting so the held onPrompt leaves the turn mid-flight
+    // (live.draining=true, blocked at session.prompt()).
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+
+    // A reload tears down all live sessions while this turn is in flight.
+    await router.tearDownAllLive()
+
+    // The in-flight session is NOT aborted or disposed yet — it stays live so
+    // its reply can land, and no duplicate is spawned.
+    expect(sessions[0]!.aborted).toBe(0)
+    expect(sessions[0]!.disposed).toBe(0)
+    expect(router.liveCount()).toBe(1)
+
+    // Once the held turn drains, the deferred teardown fires: the session is
+    // disposed and recreated on the next inbound. The abort() that runs here is
+    // benign — it lands AFTER the turn already finished (aborted stayed 0 for
+    // the whole in-flight window above, which is the property that matters).
+    releaseFirstPrompt()
+    await drainPromise
+    await waitFor(() => sessions[0]!.disposed === 1)
+    expect(router.liveCount()).toBe(0)
+
+    // A fresh inbound after the deferred teardown creates a new live session.
+    await router.route(inbound({ externalMessageId: 'm2' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(sessions).toHaveLength(2)
+    expect(router.liveCount()).toBe(1)
+  })
+
+  // Reviewer regression (#1174): a message that arrives AFTER a reload marks the
+  // draining session for teardown but BEFORE the held prompt finishes must not be
+  // processed by the stale session — the reload's whole point is to recreate with
+  // fresh state. The stale session finishes only its in-flight prompt; the queued
+  // post-reload message is handed to the freshly-recreated successor.
+  test('tearDownAllLive() does not let the stale session process a post-reload inbound', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+
+    // Reload marks the draining session for teardown.
+    await router.tearDownAllLive()
+
+    // A second message arrives while the first prompt is still held.
+    await router.route(inbound({ externalMessageId: 'm2', text: 'after reload' }))
+
+    // The stale session must NOT pick up the post-reload message: it still has
+    // exactly its one in-flight prompt, and it was never aborted mid-turn.
+    expect(sessions[0]!.prompts.length).toBe(1)
+    expect(sessions[0]!.aborted).toBe(0)
+
+    // Release the held prompt: the stale session tears down (finishing only the
+    // in-flight prompt), and a fresh successor is created that processes the
+    // post-reload message exactly once.
+    releaseFirstPrompt()
+    await drainPromise
+    await waitFor(() => sessions.length === 2)
+    await waitFor(() => sessions[1]!.prompts.length > 0)
+    expect(sessions[0]!.prompts.length).toBe(1)
+    expect(sessions[1]!.prompts.some((p) => p.includes('after reload'))).toBe(true)
+    expect(router.liveCount()).toBe(1)
+  })
+
+  // Reviewer follow-up (#1174): observe-only messages (buffered to contextBuffer
+  // with no queued prompt) that arrive during the held prompt must be carried to
+  // the successor, not dropped — and must NOT themselves trigger a turn on the
+  // successor. They surface as "Recent context" on the next real inbound.
+  test('tearDownAllLive() carries observe-only context to the successor without triggering a turn', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    // Prime a second human so the strict engagement gate applies and an
+    // unaddressed message observes instead of engaging.
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    let releaseFirstPrompt: () => void = () => {}
+    const firstPromptHeld = new Promise<void>((resolve) => {
+      releaseFirstPrompt = resolve
+    })
+    await router.route(inbound({ externalMessageId: 'm-hold', text: 'address me' }))
+    sessions[0]!.onPrompt = async () => {
+      await firstPromptHeld
+    }
+    const drainPromise = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+
+    await router.tearDownAllLive()
+
+    // An observe-only message arrives during the held prompt.
+    await router.route(inbound({ isBotMention: false, externalMessageId: 'm-observed', text: 'ambient chatter' }))
+
+    releaseFirstPrompt()
+    await drainPromise
+
+    // A fresh successor exists, but the observe-only message did NOT trigger a
+    // turn on it (no prompt yet — observed context waits for a real inbound).
+    await waitFor(() => sessions.length === 2)
+    expect(sessions[1]!.prompts).toHaveLength(0)
+
+    // A subsequent addressed inbound surfaces the carried context as "Recent
+    // context", proving the observe-only message was not dropped.
+    await router.route(inbound({ externalMessageId: 'm-next', text: 'now answer' }))
+    await router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[1]!.prompts.length > 0)
+    expect(sessions[1]!.prompts.some((p) => p.includes('ambient chatter'))).toBe(true)
+  })
+
+  // An idle session (no turn in flight) must still tear down immediately on a
+  // reload — the deferral is scoped strictly to draining sessions.
+  test('tearDownAllLive() tears down an idle session immediately', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ externalMessageId: 'm1' }))
+    await router.__testing!.flushDebounce(KEY)
+    expect(router.liveCount()).toBe(1)
+
+    await router.tearDownAllLive()
+
+    expect(sessions[0]!.disposed).toBe(1)
+    expect(router.liveCount()).toBe(0)
+  })
+
   test('rollover does NOT fire while a background child of the session is still running', async () => {
     // given: a session with a running background subagent that started at t=1000
     const dir = await tempDir()

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1058,6 +1058,13 @@ type LiveSession = {
   // crashed prior turn can't leak into the next.
   pendingProviderError: { turnSeq: number; safeMessage: string } | null
   destroyed: boolean
+  // Set by tearDownAllLive when a reload/roles/auth swap wants to recreate this
+  // session but a turn is mid-flight. Aborting now would strand the in-flight
+  // reply (the reload's own turn goes silent). Instead the session stays live
+  // and finishes its current reply with pre-reload state; the drain loop's
+  // finally tears it down once the turn drains, so the next inbound rehydrates
+  // with fresh role/auth/prompt state. Idle sessions are torn down immediately.
+  pendingTeardown: boolean
   unsubProviderErrors: (() => void) | null
   unsubTypingActivity: (() => void) | null
   unsubTodoOutcome: (() => void) | null
@@ -2101,6 +2108,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         membershipFetch,
         pendingProviderError: null,
         destroyed: false,
+        pendingTeardown: false,
         unsubProviderErrors: null,
         unsubTypingActivity: null,
         unsubTodoOutcome: null,
@@ -2744,7 +2752,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live.draining || live.destroyed) return
     live.draining = true
     try {
-      while ((live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) && !live.destroyed) {
+      // `!live.pendingTeardown`: once a reload marks this draining session for
+      // teardown, finish ONLY the in-flight prompt (its batch was already
+      // spliced out of promptQueue at the top of the current iteration) and
+      // stop — do NOT splice a fresh batch of post-reload inbounds onto the
+      // stale, about-to-be-recreated session. Those queued inbounds are handed
+      // to the fresh successor in the teardown block below.
+      while (
+        (live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) &&
+        !live.destroyed &&
+        !live.pendingTeardown
+      ) {
         live.typingTimedOut = false
         // Each turn starts with no held reactions; the model re-requests them
         // via channel_react during this turn, and the finally flushes or drops.
@@ -2999,6 +3017,60 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       await stopTypingHeartbeat(live)
       live.currentTurnTypingThread = null
     }
+    // A reload deferred this session's teardown so its in-flight reply could
+    // land; now that the turn drained (and the loop stopped BEFORE draining any
+    // post-reload inbound), complete the recreate so the fresh session picks up
+    // the swapped role/auth/prompt state. Guarded on !destroyed so a concurrent
+    // stop()/idle-gc that already tore it down wins the race without a double
+    // teardown.
+    if (live.pendingTeardown && !live.destroyed) {
+      live.pendingTeardown = false
+      // Snapshot the post-reload inbounds that arrived during the held prompt
+      // BEFORE tearDownLive (its clearQueuedEngageReactions must not drop the
+      // engage acks we are handing to the successor). Clear the source arrays so
+      // the dying session owns nothing we are moving forward.
+      const carriedInbounds = live.promptQueue.splice(0, live.promptQueue.length)
+      const carriedObserved = live.contextBuffer.splice(0, live.contextBuffer.length)
+      const carriedReminders = live.pendingSystemReminders.splice(0, live.pendingSystemReminders.length)
+      liveSessions.delete(live.keyId)
+      await tearDownLive(live)
+      await handOffToSuccessor(live.key, carriedInbounds, carriedObserved, carriedReminders)
+    }
+  }
+
+  // Rebuild a live session for a channel key after a reload tore its predecessor
+  // down mid-drain, and replay the post-reload work that predecessor never got
+  // to process. The carried inbounds already have their engagement decided (they
+  // were enqueued while draining), so they are transplanted straight onto the
+  // fresh session's queues rather than re-routed through route() — re-routing
+  // would re-run the claim/command/permission gates and re-derive engagement
+  // from a lossy QueuedInbound projection. Best-effort: a recreate failure logs
+  // and drops the batch rather than throwing out of the predecessor's drain.
+  const handOffToSuccessor = async (
+    key: ChannelKey,
+    inbounds: QueuedInbound[],
+    observed: ObservedInbound[],
+    reminders: string[],
+  ): Promise<void> => {
+    // Observed context alone is carried too: observe() can buffer post-reload
+    // messages onto contextBuffer with no queued prompt, and dropping them would
+    // lose the successor's "recent context". Only skip when nothing at all was
+    // carried.
+    if (inbounds.length === 0 && reminders.length === 0 && observed.length === 0) return
+    let successor: LiveSession
+    try {
+      successor = await ensureLive(key)
+    } catch (err) {
+      logger.warn(`[channels] ${channelKeyId(key)}: successor recreate after reload failed: ${describe(err)}`)
+      return
+    }
+    if (successor.destroyed) return
+    successor.promptQueue.push(...inbounds)
+    successor.contextBuffer.push(...observed)
+    successor.pendingSystemReminders.push(...reminders)
+    // Observed-only context is NOT a turn trigger — it waits on contextBuffer for
+    // a real inbound. Drain only when there is actual work (a prompt or reminder).
+    if ((inbounds.length > 0 || reminders.length > 0) && !successor.draining) void drain(successor)
   }
 
   const scheduleDebouncedDrain = (live: LiveSession): void => {
@@ -4839,11 +4911,26 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const tearDownAllLive = async (): Promise<void> => {
     liveGeneration++
     const all = Array.from(liveSessions.values())
+    // A session mid-turn is deferred, not aborted: tearing it down here calls
+    // session.abort(), which kills the in-flight reply — including the very turn
+    // that triggered this reload, leaving the user in silence. Such a session
+    // stays in liveSessions (so a concurrent inbound coalesces into the running
+    // turn instead of spawning a duplicate) and is torn down by the drain
+    // finally once its turn drains. Idle sessions tear down immediately below.
+    const deferred: LiveSession[] = []
+    const immediate: LiveSession[] = []
+    for (const live of all) {
+      if (live.draining && !live.destroyed) {
+        live.pendingTeardown = true
+        deferred.push(live)
+      } else immediate.push(live)
+    }
     liveSessions.clear()
+    for (const live of deferred) liveSessions.set(live.keyId, live)
     // Seal only around the flush — unlike stop() the router keeps serving after a
     // roles reload, so re-enable persist() once pending writes have drained.
     closing = true
-    for (const live of all) {
+    for (const live of immediate) {
       await tearDownLive(live)
     }
     await persistChain


### PR DESCRIPTION
## Problem

An agent went **silent** mid-conversation after a `reload`. It handled the chat, then called a bare `reload()` while composing its closing reply — and never sent it.

Root cause: `reload` (via `reloadAll`) runs the `providers` reloadable, which **unconditionally** calls `onProviderAuthChanged → router.tearDownAllLive()`. The `config` reloadable does the same on a `roles.match` change. `tearDownAllLive()` iterates **every** live channel session and calls `session.abort()` (`router.ts`) — including the session whose turn *triggered* the reload. `abort()` kills the in-flight LLM stream, so the closing reply is dropped and the user sees silence.

`tearDownAllLive()` exists only to recreate live sessions so their **frozen system-prompt role block** re-renders. The actual reload effect — swapping the live config pointer, rebuilding the permission table, invalidating the auth cache — happens *before* teardown and takes effect immediately and globally. So teardown is safe to defer for a session that is mid-turn.

## Fix

`tearDownAllLive()` now splits live sessions:

- **Idle** sessions tear down immediately (unchanged).
- A session **mid-turn** (`live.draining`) is flagged `pendingTeardown` and **kept in `liveSessions`** (so a concurrent inbound coalesces into the running turn instead of spawning a duplicate). The drain loop's `finally` tears it down once the turn drains — the reply lands first, then the session recreates on the next inbound with fresh role/auth/prompt state.

No reload delay: the data swap is untouched and still global/immediate. Only the recreation of the one in-flight session waits a single turn.

## Tests

- `tearDownAllLive()` defers an in-flight session: it is **not aborted** mid-turn, its reply lands, and it tears down after the turn drains; a fresh inbound then creates a new session.
- `tearDownAllLive()` tears down an **idle** session immediately (deferral is scoped strictly to draining sessions).
- Existing `tearDownAllLive() during an in-flight creation` race test still passes.

## Checks

`bun run typecheck` · `bun run lint` (0 errors) · `bun run format:check` · `bun run test` (10696 pass, 0 fail) — all green.

## Scope

This is **1 of 4** independent fixes for a cron-setup failure cascade. This PR addresses the actual silence (highest leverage). Siblings (managed-config edit-mode over-rejection, bash guard bypass, guest cron authoring + stale-job self-heal) follow as separate PRs.