### PR TITLE
fix(guard): validate cron edits against the baseline, not whole-file strict

### DIFF
--- a/src/bundled-plugins/guard/policies/managed-config.test.ts
+++ b/src/bundled-plugins/guard/policies/managed-config.test.ts
@@ -299,6 +299,104 @@ describe('managedConfig guard — cron.json', () => {
   })
 })
 
+// Delta-timing regression: a stale enabled job (expired `until` from the past)
+// used to fail the whole file in strict edit mode, so it held the file hostage —
+// the agent could not remove it, add a valid job, or touch any sibling. The
+// guard now strict-checks timing only on newly-authored jobs, tolerating a stale
+// boundary that is carried over unchanged.
+describe('managedConfig guard — cron.json stale-job delta validation', () => {
+  const staleJob = {
+    id: 'expired',
+    schedule: '0 9 * * *',
+    until: '2020-01-01T00:00:00Z',
+    kind: 'prompt',
+    prompt: 'x',
+    scheduledByRole: 'owner',
+  }
+  const freshJob = {
+    id: 'fresh',
+    schedule: '0 10 * * *',
+    kind: 'prompt',
+    prompt: 'y',
+    scheduledByRole: 'owner',
+  }
+
+  async function withExisting(jobs: unknown[]): Promise<string> {
+    const agentDir = await makeAgentDir()
+    await writeFile(path.join(agentDir, 'cron.json'), JSON.stringify({ jobs }, null, 2))
+    return agentDir
+  }
+
+  test('allows removing a stale pre-existing job', async () => {
+    const agentDir = await withExisting([staleJob, freshJob])
+    const result = await checkManagedConfigGuard({
+      tool: 'write',
+      args: { path: 'cron.json', content: JSON.stringify({ jobs: [freshJob] }) },
+      agentDir,
+    })
+    expect(result).toBeUndefined()
+  })
+
+  test('allows editing an unrelated job while a stale job persists unchanged', async () => {
+    const agentDir = await withExisting([staleJob, freshJob])
+    const editedFresh = { ...freshJob, schedule: '0 11 * * *' }
+    const result = await checkManagedConfigGuard({
+      tool: 'write',
+      args: { path: 'cron.json', content: JSON.stringify({ jobs: [staleJob, editedFresh] }) },
+      agentDir,
+    })
+    expect(result).toBeUndefined()
+  })
+
+  test('still blocks adding a NEW job with a past until', async () => {
+    const agentDir = await withExisting([freshJob])
+    const newStale = { ...staleJob, id: 'new-expired' }
+    const result = await checkManagedConfigGuard({
+      tool: 'write',
+      args: { path: 'cron.json', content: JSON.stringify({ jobs: [freshJob, newStale] }) },
+      agentDir,
+    })
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('past')
+  })
+
+  test('still blocks re-timing an existing job into the past', async () => {
+    const agentDir = await withExisting([freshJob])
+    const reTimed = { ...freshJob, until: '2020-01-01T00:00:00Z' }
+    const result = await checkManagedConfigGuard({
+      tool: 'write',
+      args: { path: 'cron.json', content: JSON.stringify({ jobs: [reTimed] }) },
+      agentDir,
+    })
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('past')
+  })
+
+  test('still blocks re-enabling a stale disabled job (enabled flip re-arms the check)', async () => {
+    const disabledStale = { ...staleJob, enabled: false }
+    const agentDir = await withExisting([disabledStale])
+    const reEnabled = { ...staleJob, enabled: true }
+    const result = await checkManagedConfigGuard({
+      tool: 'write',
+      args: { path: 'cron.json', content: JSON.stringify({ jobs: [reEnabled] }) },
+      agentDir,
+    })
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('past')
+  })
+
+  test('on first-init (no existing file) a past job is still blocked', async () => {
+    const agentDir = await makeAgentDir()
+    const result = await checkManagedConfigGuard({
+      tool: 'write',
+      args: { path: 'cron.json', content: JSON.stringify({ jobs: [staleJob] }) },
+      agentDir,
+    })
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toContain('past')
+  })
+})
+
 describe('managedConfig guard — scope', () => {
   test('ignores tools other than write/edit', async () => {
     const agentDir = await makeAgentDir()

--- a/src/bundled-plugins/guard/policies/managed-config.ts
+++ b/src/bundled-plugins/guard/policies/managed-config.ts
@@ -2,7 +2,7 @@ import { readFile, realpath } from 'node:fs/promises'
 import path from 'node:path'
 
 import { parseConfigJson } from '@/config'
-import { parseCronJson } from '@/cron'
+import { validateCronEdit } from '@/cron'
 
 import type { GuardBlock } from '../policy'
 
@@ -30,7 +30,8 @@ export async function checkManagedConfigGuard(options: {
   const contentResult = await intendedContent(tool, args, targetPath)
   if ('block' in contentResult) return contentResult
 
-  const validation = validateManagedContent(managed.file, contentResult.content)
+  const existing = await readExisting(targetPath)
+  const validation = validateManagedContent(managed.file, contentResult.content, existing)
   if (validation.ok) return undefined
 
   return {
@@ -66,13 +67,28 @@ async function resolveManagedTarget(agentDir: string, targetPath: string): Promi
   return undefined
 }
 
-function validateManagedContent(file: ManagedFile, content: string): { ok: true } | { ok: false; reason: string } {
+function validateManagedContent(
+  file: ManagedFile,
+  content: string,
+  existing: string | undefined,
+): { ok: true } | { ok: false; reason: string } {
   if (file === 'typeclaw.json') {
     const result = parseConfigJson(content, { migrate: false })
     return result.ok ? { ok: true } : { ok: false, reason: result.reason }
   }
-  const result = parseCronJson(content, { mode: 'edit' })
+  // Delta validation: a stale `at`/`until` on a job carried over unchanged from
+  // the existing file must not block the edit (esp. an edit that removes it),
+  // but a newly-added or re-timed past job is still rejected. See validateCronEdit.
+  const result = validateCronEdit(content, existing)
   return result.ok ? { ok: true } : { ok: false, reason: result.reason }
+}
+
+async function readExisting(targetPath: string): Promise<string | undefined> {
+  try {
+    return await readFile(targetPath, 'utf8')
+  } catch {
+    return undefined
+  }
 }
 
 async function intendedContent(

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -24,6 +24,7 @@ export {
   type ParseCronResult,
   type ParsedCronJob,
   type PromptJob,
+  validateCronEdit,
 } from './schema'
 
 const CRON_FILE = 'cron.json'

--- a/src/cron/schema.test.ts
+++ b/src/cron/schema.test.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import type { Subagent, SubagentRegistry } from '@/agent/subagents'
 
-import { cronFileSchema, parseCronFile } from './schema'
+import { cronFileSchema, parseCronFile, validateCronEdit } from './schema'
 
 describe('cronFileSchema', () => {
   test('accepts an empty jobs list', () => {
@@ -534,5 +534,70 @@ describe('parseCronFile with subagents registry', () => {
       ],
     })
     expect(result.ok).toBe(true)
+  })
+})
+
+describe('validateCronEdit (authoring-delta timing)', () => {
+  const NOW = new Date('2026-06-08T00:00:00Z').getTime()
+  const PAST = '2020-01-01T00:00:00Z'
+
+  const jobJson = (extra: Record<string, unknown>): Record<string, unknown> => ({
+    id: 'j',
+    kind: 'prompt',
+    prompt: 'x',
+    scheduledByRole: 'owner',
+    ...extra,
+  })
+  const file = (...jobs: Record<string, unknown>[]): string => JSON.stringify({ jobs })
+
+  test('tolerates a stale until carried over unchanged from the baseline', () => {
+    const stale = jobJson({ id: 'expired', schedule: '0 9 * * *', until: PAST })
+    const existing = file(stale)
+    const result = validateCronEdit(existing, existing, { now: NOW })
+    expect(result.ok).toBe(true)
+  })
+
+  test('allows removing a stale job (proposed omits it)', () => {
+    const stale = jobJson({ id: 'expired', schedule: '0 9 * * *', until: PAST })
+    const fresh = jobJson({ id: 'fresh', schedule: '0 10 * * *' })
+    const result = validateCronEdit(file(fresh), file(stale, fresh), { now: NOW })
+    expect(result.ok).toBe(true)
+  })
+
+  test('blocks a newly-added job with a past until', () => {
+    const fresh = jobJson({ id: 'fresh', schedule: '0 10 * * *' })
+    const newStale = jobJson({ id: 'new-expired', schedule: '0 9 * * *', until: PAST })
+    const result = validateCronEdit(file(fresh, newStale), file(fresh), { now: NOW })
+    if (result.ok) throw new Error('expected block')
+    expect(result.reason).toContain('past')
+  })
+
+  test('blocks re-timing an existing job into the past', () => {
+    const fresh = jobJson({ id: 'j', schedule: '0 10 * * *' })
+    const reTimed = jobJson({ id: 'j', schedule: '0 10 * * *', until: PAST })
+    const result = validateCronEdit(file(reTimed), file(fresh), { now: NOW })
+    if (result.ok) throw new Error('expected block')
+    expect(result.reason).toContain('past')
+  })
+
+  test('treats every job as new when no baseline is provided (fail closed)', () => {
+    const stale = jobJson({ schedule: '0 9 * * *', until: PAST })
+    const result = validateCronEdit(file(stale), undefined, { now: NOW })
+    if (result.ok) throw new Error('expected block')
+    expect(result.reason).toContain('past')
+  })
+
+  test('treats every job as new when the baseline is unparseable (fail closed)', () => {
+    const stale = jobJson({ schedule: '0 9 * * *', until: PAST })
+    const result = validateCronEdit(file(stale), 'not json', { now: NOW })
+    if (result.ok) throw new Error('expected block')
+    expect(result.reason).toContain('past')
+  })
+
+  test('still reports structural errors in the proposed content', () => {
+    const bad = jobJson({ schedule: 'bogus' })
+    const result = validateCronEdit(file(bad), undefined, { now: NOW })
+    if (result.ok) throw new Error('expected block')
+    expect(result.reason).toContain('bogus')
   })
 })

--- a/src/cron/schema.ts
+++ b/src/cron/schema.ts
@@ -119,6 +119,81 @@ export function parseCronJson(raw: string, options: ParseCronJsonOptions = {}): 
   })
 }
 
+// Authoring-delta validation for a cron.json edit. Strict `edit` mode fails the
+// whole file on any enabled job with a past `at`/`until`, which lets a single
+// stale pre-existing job (an expired `until` from weeks ago) brick EVERY edit —
+// including the edit that would remove it, or an edit to a completely unrelated
+// job. That is the trap: expired history holds the file hostage.
+//
+// This validator parses the proposed content in tolerant `load` mode (so it
+// still catches structural errors and duplicate ids), then applies the strict
+// `edit` timing check ONLY to jobs whose timing is newly-authored — a job that
+// is new, or whose timing fields changed versus the on-disk baseline. A job
+// carried over unchanged keeps its stale boundary tolerated, so removing it or
+// editing a sibling is never blocked. Adding a new past job, or re-timing an
+// existing one into the past, is still rejected exactly as before.
+//
+// `existingRaw` is the current on-disk cron.json (undefined on first-init). If
+// it is missing or unparseable the baseline is empty, so every proposed job is
+// treated as new and strict-checked — the safe direction (fail closed).
+export function validateCronEdit(
+  proposedRaw: string,
+  existingRaw: string | undefined,
+  options: ParseCronOptions = {},
+): ParseCronResult {
+  const now = options.now ?? Date.now()
+  const proposed = parseCronJson(proposedRaw, { ...options, mode: 'load' })
+  if (!proposed.ok) return proposed
+
+  const baselineTiming = existingRaw !== undefined ? timingSignaturesByJobId(existingRaw) : new Map<string, string>()
+
+  for (const job of proposed.file.jobs) {
+    const prior = baselineTiming.get(job.id)
+    const timingUnchanged = prior !== undefined && prior === timingSignature(job)
+    if (timingUnchanged) continue
+    const timingError = validateTiming(job, now, 'edit')
+    if (timingError !== null) return { ok: false, reason: `job ${job.id}: ${timingError}` }
+  }
+
+  return proposed
+}
+
+// The timing fields whose change re-arms the strict past-boundary check. A job
+// is exempt from the stale-boundary rejection only when ALL of these match the
+// baseline; touching any of them (including flipping `enabled` back on) counts
+// as re-authoring the schedule and is strict-checked afresh.
+function timingSignature(job: {
+  schedule?: string | undefined
+  at?: string | undefined
+  until?: string | undefined
+  count?: number | undefined
+  timezone?: string | undefined
+  enabled: boolean
+}): string {
+  return JSON.stringify([
+    job.schedule ?? null,
+    job.at ?? null,
+    job.until ?? null,
+    job.count ?? null,
+    job.timezone ?? null,
+    job.enabled,
+  ])
+}
+
+function timingSignaturesByJobId(raw: string): Map<string, string> {
+  const signatures = new Map<string, string>()
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch {
+    return signatures
+  }
+  const parsed = cronFileSchema.safeParse(json)
+  if (!parsed.success) return signatures
+  for (const job of parsed.data.jobs) signatures.set(job.id, timingSignature(job))
+  return signatures
+}
+
 export function parseCronFile(raw: unknown, options: ParseCronOptions = {}): ParseCronResult {
   const parsed = cronFileSchema.safeParse(raw)
   if (!parsed.success) {


### PR DESCRIPTION
## Problem

A guest agent tried to add a cron job but could not write `cron.json` **at all** — every `write` and `edit` was rejected. Root cause: `cron.json` already held a job with an expired `until` (`"until": "2020-01-01"`). The `managedConfig` guard validates the **entire** intended file in strict `edit` mode (`parseCronJson(content, { mode: 'edit' })`), and strict mode rejects any enabled job with a past `at`/`until`, failing the **whole file**.

So one stale historical job held the file hostage: the agent could not add a job, edit an unrelated sibling, or even **remove the offending job** — every path re-validated the whole file and tripped on the same expired boundary. In the incident this forced the agent to escape to raw `bash` to edit the file, bypassing all guards.

## Fix

New cron-domain function `validateCronEdit(proposed, existing)`:

- Parses the proposed content in tolerant `load` mode — still catches structural errors and duplicate ids.
- Applies the strict `edit` past-boundary check **only to newly-authored jobs**: a job that is new, or whose timing fields (`schedule`/`at`/`until`/`count`/`timezone`/`enabled`) differ from the on-disk baseline.
- A job carried over **unchanged** keeps its stale boundary tolerated.
- Missing/unparseable baseline → every job treated as new and strict-checked (**fail closed**).

The `managedConfig` guard routes cron validation through it, passing the existing on-disk file as the baseline. `typeclaw.json` validation is unchanged.

**Invariant preserved:** removing a stale job ✅ · editing an unrelated sibling ✅ · adding a new past job ❌ · re-timing an existing job into the past ❌ · re-enabling a stale disabled job ❌ · first-init past job ❌.

## Tests

- `validateCronEdit` unit tests (schema.test.ts): tolerate unchanged stale; allow removal; block new-past, re-timed-past, no-baseline, unparseable-baseline; still surface structural errors.
- `managedConfig` guard tests: removal + unrelated-sibling edit allowed; new-past, re-timed, re-enabled, first-init still blocked.

## Checks

`bun run typecheck` · `bun run lint` (0 errors) · `bun run format:check` · `bun run test` (10707 pass, 0 fail) — all green.

## Scope

**2 of 4** independent fixes for the cron-setup failure cascade. Addresses the authoring-side file lock (Bug A). Sibling PR #1174 fixes the reload silence; two more follow (bash guard bypass; guest cron authoring + stale-job self-heal).