### PR TITLE
fix(sandbox): stop bash-writing the guarded managed files

### DIFF
--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -619,7 +619,12 @@ async function applyBashSandbox(
       { type: 'bind', source: sessionTmp, dest: '/tmp' },
     ],
     ...(packageInstall !== undefined
-      ? { writableRoot: { dir: packageInstall.root }, masks: maskTargets, protected: packageInstall.protected }
+      ? {
+          writableRoot: { dir: packageInstall.root },
+          masks: maskTargets,
+          protected: packageInstall.protected,
+          blockedCreation: { files: packageInstall.blockedCreation },
+        }
       : { masks: maskTargets, writable, protected: protectedZones }),
     symlinks,
     network: 'inherit',
@@ -652,11 +657,11 @@ function buildRoleScopedConfigEnv(
 }
 
 function subtractMaskedProtected(
-  zones: { root: string; protected: { dirs: string[]; files: string[] } },
+  zones: { root: string; protected: { dirs: string[]; files: string[] }; blockedCreation: string[] },
   masked: { dirs: string[]; files: string[] },
-): { root: string; protected: { dirs: string[]; files: string[] } } {
+): { root: string; protected: { dirs: string[]; files: string[] }; blockedCreation: string[] } {
   const filtered = subtractMasked(zones.protected, masked)
-  return { root: zones.root, protected: filtered }
+  return { root: zones.root, protected: filtered, blockedCreation: zones.blockedCreation }
 }
 
 // Picks the /proc strategy for a sandboxed bash call. The branch order is:

--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -308,6 +308,32 @@ describe('buildSandboxedCommand protected re-binds', () => {
   })
 })
 
+describe('buildSandboxedCommand blockedCreation', () => {
+  test('binds /dev/null over each blocked path to prevent creation', () => {
+    const joined = argvOf('bun add foo', {
+      blockedCreation: { files: ['/agent/cron.json', '/agent/typeclaw.json'] },
+    }).join(' ')
+    expect(joined).toContain('--ro-bind /dev/null /agent/cron.json')
+    expect(joined).toContain('--ro-bind /dev/null /agent/typeclaw.json')
+  })
+
+  test('renders blocked binds AFTER the RW root so last-op-wins occupies the path', () => {
+    const argv = argvOf('bun add foo', {
+      writableRoot: { dir: '/agent' },
+      blockedCreation: { files: ['/agent/cron.json'] },
+    })
+    const rwRoot = argv.indexOf('--bind')
+    const blocked = argv.indexOf('/agent/cron.json')
+    expect(rwRoot).toBeGreaterThanOrEqual(0)
+    expect(blocked).toBeGreaterThan(rwRoot)
+  })
+
+  test('emits no blocked binds when the policy omits them', () => {
+    const argv = argvOf('true', { writableRoot: { dir: '/agent' } })
+    expect(argv.join(' ')).not.toContain('/dev/null /agent')
+  })
+})
+
 describe('buildSandboxedCommand symlinks', () => {
   test('emits --dir <parent> then --symlink <target> <dest> for each op', () => {
     const joined = argvOf('true', {

--- a/src/sandbox/build.ts
+++ b/src/sandbox/build.ts
@@ -171,6 +171,7 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
   appendMasks(argv, policy)
   appendWritable(argv, policy)
   appendProtected(argv, policy)
+  appendBlockedCreation(argv, policy)
   appendSymlinks(argv, policy)
 
   if (policy.cwd !== undefined) {
@@ -214,6 +215,17 @@ function appendProtected(argv: string[], policy: SandboxPolicy): void {
   }
   for (const file of policy.protected?.files ?? []) {
     argv.push('--ro-bind', file, file)
+  }
+}
+
+// Occupies each path with an empty read-only object so a writable-root install
+// script cannot CREATE a real file there. /dev/null always exists (bwrap mounts
+// --dev), so unlike --ro-bind-data this needs no manufactured placeholder on the
+// host FS. Renders after appendProtected: both are RO carve-outs of the RW root,
+// last-op-wins.
+function appendBlockedCreation(argv: string[], policy: SandboxPolicy): void {
+  for (const file of policy.blockedCreation?.files ?? []) {
+    argv.push('--ro-bind', '/dev/null', file)
   }
 }
 

--- a/src/sandbox/policy.ts
+++ b/src/sandbox/policy.ts
@@ -112,6 +112,18 @@ export type SandboxWritableRootPolicy = {
   dir: string
 }
 
+// Paths whose CREATION must be blocked under a writable root, rendered as
+// `--ro-bind /dev/null <path>`. Used by the package-install path for the
+// semantically-guarded managed files (cron.json / typeclaw.json) when they are
+// ABSENT: the RW root would otherwise let a postinstall lifecycle script create
+// them, bypassing the write/edit-tool guards. Binding /dev/null occupies the
+// path with an empty read-only object (blocking creation) WITHOUT manufacturing
+// a real invalid file on the host FS. Renders after writableRoot, with the
+// protected binds, so last-op-wins keeps the path occupied.
+export type SandboxBlockedCreationPolicy = {
+  files?: string[]
+}
+
 export type SandboxPolicy = {
   bwrapPath?: string
   cwd?: string
@@ -128,6 +140,7 @@ export type SandboxPolicy = {
   masks?: SandboxMaskPolicy
   writable?: SandboxWritablePolicy
   protected?: SandboxProtectedPolicy
+  blockedCreation?: SandboxBlockedCreationPolicy
   symlinks?: SandboxSymlinkOp[]
   network?: SandboxNetwork
   env?: SandboxEnvPolicy

--- a/src/sandbox/writable-zones.test.ts
+++ b/src/sandbox/writable-zones.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { lstat, mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -42,11 +43,23 @@ describe('resolveWritableZones', () => {
 
   test('includes only the allowed root files that exist', async () => {
     await writeFile(join(agentDir, 'AGENTS.md'), '# agents')
+    await writeFile(join(agentDir, 'IDENTITY.md'), '# identity')
+
+    const { files } = await resolveWritableZones(agentDir)
+
+    expect(files).toEqual([join(agentDir, 'AGENTS.md'), join(agentDir, 'IDENTITY.md')])
+  })
+
+  test('excludes the semantically-guarded managed files (cron.json, typeclaw.json)', async () => {
+    await writeFile(join(agentDir, 'AGENTS.md'), '# agents')
+    await writeFile(join(agentDir, 'cron.json'), '{"jobs":[]}')
     await writeFile(join(agentDir, 'typeclaw.json'), '{}')
 
     const { files } = await resolveWritableZones(agentDir)
 
-    expect(files).toEqual([join(agentDir, 'AGENTS.md'), join(agentDir, 'typeclaw.json')])
+    expect(files).not.toContain(join(agentDir, 'cron.json'))
+    expect(files).not.toContain(join(agentDir, 'typeclaw.json'))
+    expect(files).toContain(join(agentDir, 'AGENTS.md'))
   })
 
   test('rejects a zone dir that is a symlink (RW bind would follow it outside)', async () => {
@@ -65,13 +78,13 @@ describe('resolveWritableZones', () => {
   test('rejects a root file that is a symlink', async () => {
     const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
     try {
-      const target = join(outside, 'real.json')
-      await writeFile(target, '{}')
-      await symlink(target, join(agentDir, 'typeclaw.json'))
+      const target = join(outside, 'real.md')
+      await writeFile(target, '# real')
+      await symlink(target, join(agentDir, 'AGENTS.md'))
 
       const { files } = await resolveWritableZones(agentDir)
 
-      expect(files).not.toContain(join(agentDir, 'typeclaw.json'))
+      expect(files).not.toContain(join(agentDir, 'AGENTS.md'))
     } finally {
       await rm(outside, { recursive: true, force: true })
     }
@@ -415,6 +428,53 @@ describe('resolvePackageInstallZones', () => {
     } finally {
       await rm(outside, { recursive: true, force: true })
     }
+  })
+
+  // SECURITY: the RW package-install root would let a postinstall lifecycle
+  // script CREATE an absent managed file (cron.json/typeclaw.json), bypassing the
+  // write/edit-tool guards. Absent managed files must land in blockedCreation
+  // (rendered as --ro-bind /dev/null) so their path is occupied.
+  test('blocks creation of ABSENT managed files (cron.json, typeclaw.json)', async () => {
+    const { blockedCreation, protected: prot } = await resolvePackageInstallZones(agentDir)
+
+    expect(blockedCreation).toContain(join(agentDir, 'cron.json'))
+    expect(blockedCreation).toContain(join(agentDir, 'typeclaw.json'))
+    // Absent files are not (and cannot be) RO-bound — /dev/null occupies them.
+    expect(prot.files).not.toContain(join(agentDir, 'cron.json'))
+    expect(prot.files).not.toContain(join(agentDir, 'typeclaw.json'))
+  })
+
+  test('does NOT block-create a PRESENT managed file (it is RO-bound with real content instead)', async () => {
+    await writeFile(join(agentDir, 'cron.json'), '{"jobs":[]}')
+
+    const { blockedCreation, protected: prot } = await resolvePackageInstallZones(agentDir)
+
+    expect(blockedCreation).not.toContain(join(agentDir, 'cron.json'))
+    expect(prot.files).toContain(join(agentDir, 'cron.json'))
+    // typeclaw.json is still absent, so it stays blocked.
+    expect(blockedCreation).toContain(join(agentDir, 'typeclaw.json'))
+  })
+
+  test('blocks a managed file that exists only as a symlink (an RO bind would follow it out)', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
+    try {
+      await writeFile(join(outside, 'real.json'), '{}')
+      await symlink(join(outside, 'real.json'), join(agentDir, 'cron.json'))
+
+      const { blockedCreation, protected: prot } = await resolvePackageInstallZones(agentDir)
+
+      expect(blockedCreation).toContain(join(agentDir, 'cron.json'))
+      expect(prot.files).not.toContain(join(agentDir, 'cron.json'))
+    } finally {
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+
+  test('does not leave an empty placeholder on the real FS for an absent managed file', async () => {
+    await resolvePackageInstallZones(agentDir)
+
+    expect(existsSync(join(agentDir, 'cron.json'))).toBe(false)
+    expect(existsSync(join(agentDir, 'typeclaw.json'))).toBe(false)
   })
 })
 

--- a/src/sandbox/writable-zones.ts
+++ b/src/sandbox/writable-zones.ts
@@ -59,15 +59,19 @@ const PROTECTED_GIT_FILES = ['.git/config'] as const
 
 // Bash may EDIT these when present; creating a MISSING root file goes through
 // write/edit (bwrap cannot RW-bind a non-existent source without pre-creating it).
-const WRITABLE_ROOT_FILES = [
-  'AGENTS.md',
-  'IDENTITY.md',
-  'SOUL.md',
-  'USER.md',
-  'cron.json',
-  'package.json',
-  'typeclaw.json',
-] as const
+//
+// SECURITY: the semantically-guarded managed files (`cron.json`, `typeclaw.json`)
+// are deliberately EXCLUDED. Those two are the only files gated by the
+// managedConfig / cronPromotion guards, which fire on the `write`/`edit` tools
+// only. Granting bash a blanket RW bind to them opened a bypass: an agent
+// blocked from writing cron.json through the guarded tools could just
+// `echo … > cron.json` from bash and defeat the guard entirely. Keeping them off
+// this list forces every mutation of a guarded file through the one guarded path
+// (the write/edit tool), so a managed file has exactly one mutation boundary.
+// `package.json` stays writable: it is NOT a semantically-guarded managed file
+// (only cron.json/typeclaw.json are), and `bun add`/manual dep edits legitimately
+// touch it from bash.
+const WRITABLE_ROOT_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md', 'package.json'] as const
 
 // SECURITY: the symlink rejection is load-bearing. An RW bind follows symlinks,
 // so a `workspace -> /etc` symlink at a zone root would grant write access to an
@@ -152,7 +156,22 @@ function dedupe(values: string[]): string[] {
 export type PackageInstallZones = {
   root: string
   protected: ProtectedZones
+  // Guarded managed files that are ABSENT at jail-build time. The RW package-
+  // install root would otherwise let a `bun install` postinstall lifecycle
+  // script CREATE them (a guard bypass — see the SECURITY note on
+  // MANAGED_ROOT_FILES). Rendered as `--ro-bind /dev/null <path>` so the path is
+  // occupied by an empty read-only object that blocks creation, without
+  // manufacturing a real (invalid) file on the host FS the way the secret-mask
+  // placeholder pattern would. Present managed files go in `protected.files`.
+  blockedCreation: string[]
 }
+
+// SECURITY: the semantically-guarded managed files. They are gated by the
+// managedConfig / cronPromotion guards (write/edit tools only), so bash must
+// never be able to write OR create them. The normal jail already excludes them
+// from WRITABLE_ROOT_FILES; the package-install RW root needs the extra step of
+// blocking their CREATION when absent (see PackageInstallZones.blockedCreation).
+const MANAGED_ROOT_FILES = ['cron.json', 'typeclaw.json'] as const
 
 // SECURITY: the package-install RW root is governed by an ALLOWLIST, not a
 // denylist. `bun add` writes exactly these and nothing else: `node_modules/`
@@ -214,7 +233,24 @@ export async function resolvePackageInstallZones(agentDir: string): Promise<Pack
   const runtime = join(agentDir, 'node_modules', 'typeclaw')
   if (await isRealEntry(runtime, 'dir')) dirs.push(runtime)
 
-  return { root: agentDir, protected: { dirs: dedupe(dirs), files: dedupe(files) } }
+  // Guarded managed files: a PRESENT real one is already RO-bound by the readdir
+  // loop above (it is not in the writable set). The gap is a managed file ABSENT
+  // at jail-build time — readdir never sees it, so nothing occupies its path and
+  // a postinstall script could CREATE it under the RW root. Block that path with
+  // `--ro-bind /dev/null`. A managed file that exists as a SYMLINK is also blocked
+  // here rather than RO-bound (the readdir loop skipped it, and an RO bind would
+  // follow it out of the jail) — occupying the path with /dev/null is safe.
+  const blockedCreation: string[] = []
+  for (const name of MANAGED_ROOT_FILES) {
+    const target = join(agentDir, name)
+    if (!(await isRealEntry(target, 'file'))) blockedCreation.push(target)
+  }
+
+  return {
+    root: agentDir,
+    protected: { dirs: dedupe(dirs), files: dedupe(files) },
+    blockedCreation: dedupe(blockedCreation),
+  }
 }
 
 async function exists(target: string): Promise<boolean> {


### PR DESCRIPTION
## Problem

`cron.json` and `typeclaw.json` are the only two files protected by the `managedConfig` and `cronPromotion` guards — but those guards fire on the **`write`/`edit` tools only**. Both files were also listed in `WRITABLE_ROOT_FILES`, so the bash sandbox gave them a blanket RW bind.

Result: an agent blocked from writing `cron.json` through the guarded tools could just `echo … > cron.json` (or run inline python) from **bash** and defeat every cron guard. In the incident, that is exactly what happened — the agent, trapped by the whole-file edit-mode rejection, escaped to bash and wrote the file directly, bypassing `managedConfig` and `cronPromotion`.

Guarding one door while the other is wide open is not defense-in-depth; it is a bypass.

## Fix

Remove `cron.json` and `typeclaw.json` from `WRITABLE_ROOT_FILES`. A semantically-guarded managed file now has **exactly one mutation path** — the guarded `write`/`edit` tool.

- `package.json` stays writable: it is **not** a guarded managed file (only `cron.json`/`typeclaw.json` are), and `bun add` / manual dep edits legitimately touch it from bash.
- The remaining free-write root files (`AGENTS.md`, `IDENTITY.md`, `SOUL.md`, `USER.md`) are unguarded prose and stay writable.

## Tests

- Updated the "allowed root files" and symlink-rejection tests to use non-guarded files.
- New regression test: `cron.json` and `typeclaw.json` are **excluded** from the bash-writable root files while `AGENTS.md` remains included.

## Checks

`bun run typecheck` · `bun run lint` (0 errors) · `bun run format:check` · `bun run test` (10695 pass, 0 fail) — all green. Full `src/sandbox` suite (209 pass) verified.

## Scope

**3 of 4** independent fixes for the cron-setup failure cascade. Closes the guard bypass (Bug C). Siblings: #1174 (reload silence), #1175 (managed-config edit-mode over-rejection). One more follows (guest cron authoring + stale-job self-heal).