### PR TITLE
fix(channels): pin a channel session through a long-running child, not a 45m cap

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -46,7 +46,7 @@ import {
   OBSERVED_MESSAGE_MAX_CHARS,
   SESSION_GRACE_HARD_TTL_MS,
   SESSION_IDLE_MS,
-  SESSION_CHILD_PIN_MAX_MS,
+  SESSION_CHILD_STUCK_BACKSTOP_MS,
   sliceHeadTail,
   StaleLiveSessionError,
   stripThinkBlocks,
@@ -961,8 +961,8 @@ describe('ChannelRouter session lifecycle', () => {
     expect(sessions[0]!.disposed).toBe(0)
   })
 
-  test('rollover fires anyway once the running child exceeds SESSION_CHILD_PIN_MAX_MS', async () => {
-    // given: a child that started long enough ago to exceed the pin ceiling
+  test('rollover fires anyway once the running child exceeds SESSION_CHILD_STUCK_BACKSTOP_MS', async () => {
+    // given: a child that started long enough ago to exceed the stuck backstop
     const dir = await tempDir()
     const nowRef = { value: 1000 }
     const logs: string[] = []
@@ -975,21 +975,21 @@ describe('ChannelRouter session lifecycle', () => {
     await router.route(inbound({ externalMessageId: 'm1' }))
     await router.__testing!.flushDebounce(KEY)
 
-    // when: the follow-up arrives after the pin cap has elapsed
-    nowRef.value = childStartedAt + SESSION_CHILD_PIN_MAX_MS + 1
+    // when: the follow-up arrives after the stuck backstop has elapsed
+    nowRef.value = childStartedAt + SESSION_CHILD_STUCK_BACKSTOP_MS + 1
     await router.route(inbound({ externalMessageId: 'm2', text: 'are you stuck?' }))
     await router.__testing!.flushDebounce(KEY)
 
-    // then: pin is overridden, rollover proceeds with the past-cap annotation
-    expect(logs.some((l) => l.includes('stale-rollover') && l.includes('past child-pin cap'))).toBe(true)
+    // then: pin is overridden, rollover proceeds with the stuck-child annotation
+    expect(logs.some((l) => l.includes('stale-rollover') && l.includes('suspected stuck running child'))).toBe(true)
     expect(sessions).toHaveLength(2)
     expect(sessions[0]!.disposed).toBe(1)
   })
 
-  test('rollover stays pinned when the oldest child is past cap but a newer child is still within it', async () => {
-    // given: two running children — one past the cap, one fresh. The production
-    //   seam reports the NEWEST start time, so an over-cap older child must not
-    //   unpin the session while the newer child is still inside its window.
+  test('rollover stays pinned when the oldest child is past backstop but a newer child is still within it', async () => {
+    // given: two running children — one past the backstop, one fresh. The
+    //   production seam reports the NEWEST start time, so an over-backstop older
+    //   child must not unpin the session while the newer child is still in window.
     const dir = await tempDir()
     const nowRef = { value: 1000 }
     const logs: string[] = []
@@ -1009,8 +1009,8 @@ describe('ChannelRouter session lifecycle', () => {
     await router.route(inbound({ externalMessageId: 'm1' }))
     await router.__testing!.flushDebounce(KEY)
 
-    // when: the follow-up arrives after the OLDEST child has crossed the cap
-    nowRef.value = startOfTurn + SESSION_CHILD_PIN_MAX_MS + 1
+    // when: the follow-up arrives after the OLDEST child has crossed the backstop
+    nowRef.value = startOfTurn + SESSION_CHILD_STUCK_BACKSTOP_MS + 1
     await router.route(inbound({ externalMessageId: 'm2', text: 'still going?' }))
     await router.__testing!.flushDebounce(KEY)
 
@@ -9913,8 +9913,8 @@ describe('ChannelRouter cold-start prefetch', () => {
     expect(factoryCalls[0]?.existingSessionId).toBe('ses_preexisting')
   })
 
-  test('persisted stale-rollover fires once the old session child outlives the pin cap', async () => {
-    // given: same stale mapping, but the child started past SESSION_CHILD_PIN_MAX_MS ago
+  test('persisted stale-rollover fires once the old session child outlives the stuck backstop', async () => {
+    // given: same stale mapping, but the child started past SESSION_CHILD_STUCK_BACKSTOP_MS ago
     const dir = await tempDir()
     const nowRef = { value: 10_000_000 }
     const logs: string[] = []
@@ -9935,15 +9935,17 @@ describe('ChannelRouter cold-start prefetch', () => {
       logs,
       factoryCalls,
       newestRunningChildSubagentStartedAt: (sessionId) =>
-        sessionId === 'ses_preexisting' ? nowRef.value - SESSION_CHILD_PIN_MAX_MS - 1 : null,
+        sessionId === 'ses_preexisting' ? nowRef.value - SESSION_CHILD_STUCK_BACKSTOP_MS - 1 : null,
     })
 
     // when
     await router.route(inbound({ externalMessageId: 'engage', text: 'are you stuck?' }))
     await router.__testing!.flushDebounce(KEY)
 
-    // then: the past-cap override lets the persisted rollover proceed (fresh session)
-    expect(logs.some((l) => l.includes('stale-rollover (persisted') && l.includes('past child-pin cap'))).toBe(true)
+    // then: the stuck-child override lets the persisted rollover proceed (fresh session)
+    expect(
+      logs.some((l) => l.includes('stale-rollover (persisted') && l.includes('suspected stuck running child')),
+    ).toBe(true)
     expect(factoryCalls[0]?.existingSessionId).toBeUndefined()
   })
 
@@ -10220,8 +10222,62 @@ describe('ChannelRouter idle session GC', () => {
     expect(sessions[0]!.aborted).toBe(0)
   })
 
-  test('evicts a session whose background child has outlived SESSION_CHILD_PIN_MAX_MS', async () => {
-    // given: a session whose child started long enough ago to exceed the pin cap
+  test('keeps a session pinned when a background child runs past the old 45m cap (65m completion regression)', async () => {
+    // given: the reported incident — a background child running ~65 minutes, well
+    //   past the retired 45m pin cap that used to evict the parent mid-run and drop
+    //   the child's completion reminder. It must stay pinned below the 6h backstop.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const childStartedAt = 1000
+    const sixtyFiveMinutes = 65 * 60 * 1000
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_1' ? childStartedAt : null),
+    })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: GC runs 65 minutes later, long past both SESSION_IDLE_MS and the old cap
+    nowRef.value = childStartedAt + sixtyFiveMinutes
+    await router.__testing!.runIdleGc!()
+
+    // then: still pinned, so a completion landing now would have a live session
+    expect(router.liveCount()).toBe(1)
+    expect(sessions[0]!.aborted).toBe(0)
+  })
+
+  test('unpins and evicts once the child completes and the session then goes idle', async () => {
+    // given: a child that pins the session while running, then completes (the seam
+    //   reports null once no child is running — mirrors recordCompletion flipping
+    //   status off 'running')
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const childStartedAt = 1000
+    let childRunning = true
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      newestRunningChildSubagentStartedAt: (sessionId) =>
+        sessionId === 'ses_fake_1' && childRunning ? childStartedAt : null,
+    })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when: well past idle but the child still runs → pinned
+    nowRef.value = childStartedAt + SESSION_IDLE_MS + 1
+    await router.__testing!.runIdleGc!()
+    expect(router.liveCount()).toBe(1)
+
+    // and: the child completes, then another idle sweep runs
+    childRunning = false
+    await router.__testing!.runIdleGc!()
+
+    // then: no longer pinned → the idle session is evicted normally
+    expect(router.liveCount()).toBe(0)
+    expect(sessions[0]!.aborted).toBe(1)
+  })
+
+  test('evicts a session whose background child has outlived SESSION_CHILD_STUCK_BACKSTOP_MS', async () => {
+    // given: a session whose child started long enough ago to exceed the stuck backstop
     const dir = await tempDir()
     const nowRef = { value: 1000 }
     const logs: string[] = []
@@ -10234,14 +10290,14 @@ describe('ChannelRouter idle session GC', () => {
     await router.route(inbound({ text: 'hi bot' }))
     await router.__testing!.flushDebounce(KEY)
 
-    // when: GC runs after both the idle threshold AND the pin cap have elapsed
-    nowRef.value = childStartedAt + SESSION_CHILD_PIN_MAX_MS + 1
+    // when: GC runs after both the idle threshold AND the stuck backstop have elapsed
+    nowRef.value = childStartedAt + SESSION_CHILD_STUCK_BACKSTOP_MS + 1
     await router.__testing!.runIdleGc!()
 
     // then: the pin is overridden and the stuck session is evicted
     expect(router.liveCount()).toBe(0)
     expect(sessions[0]!.aborted).toBe(1)
-    expect(logs.some((l) => l.includes('idle_gc evicting') && l.includes('past child-pin cap'))).toBe(true)
+    expect(logs.some((l) => l.includes('idle_gc evicting') && l.includes('suspected stuck running child'))).toBe(true)
   })
 
   test('next inbound after eviction creates a fresh session and rehydrates the persisted sessionId', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -482,21 +482,26 @@ export const SESSION_FRESHNESS_TTL_MS = 5 * 60 * 1000
 export const SESSION_GRACE_HARD_TTL_MS = 10 * 60 * 1000
 
 /**
- * Absolute ceiling on how long a running background subagent may pin its parent
- * channel session against idle GC and stale-rollover. A still-running child defers
- * teardown because the next inbound otherwise starts a fresh session that has lost
- * track of the in-flight task and spawns a DUPLICATE child for the same work. The
- * pin is bounded so a stuck/never-completing child cannot make the session
- * immortal: past this age the session is GC'd / rolled over anyway, falling back
- * to the completion-reroute behavior. Measured from the child's start.
+ * Leak guard — NOT a freshness cap. A running background subagent pins its parent
+ * channel session against idle GC and stale-rollover for as long as the child is
+ * actually running, because the next inbound would otherwise start a fresh session
+ * that has lost track of the in-flight task and spawns a DUPLICATE child, and — the
+ * bug this backstop is sized around — a completion arriving after teardown has no
+ * live session to deliver its system-reminder to and is silently dropped.
  *
- * Set above SESSION_IDLE_MS (30m) — not equal — so a child spawned at session
- * birth still pins the session through its first idle sweep instead of the two
- * windows coinciding. Comfortably above SESSION_GRACE_HARD_TTL_MS (10m) too:
- * real research runs can exceed it (an observed run took 9m18s), so the 10m cap
- * is far too tight to bound the pin.
+ * The pin is bounded only so a genuinely stuck/wedged child cannot make the session
+ * immortal. Subagent `timeoutMs` is optional (operator declares none), so a hung
+ * child stays `status: 'running'` forever; without this ceiling its parent session
+ * would leak indefinitely. Past this age the child is treated as stuck: GC/rollover
+ * proceeds and the session falls back to completion-reroute.
+ *
+ * Sized as an ANOMALY threshold, deliberately far above any legitimate run (deep
+ * operator work is minutes-to-an-hour, not hours), so it never fires for real work.
+ * The prior 45m value was close enough to plausible deep work to turn a legitimate
+ * long run into a routine drop — the reported 65m completion loss. 6h is clearly
+ * "this child is wedged," not "this child is busy".
  */
-export const SESSION_CHILD_PIN_MAX_MS = 45 * 60 * 1000
+export const SESSION_CHILD_STUCK_BACKSTOP_MS = 6 * 60 * 60 * 1000
 
 /**
  * Cost-aware grace decision for the soft→hard TTL band. Returns true when reusing
@@ -1442,12 +1447,12 @@ export type CreateChannelRouterOptions = {
   // Returns the start time (epoch ms) of the NEWEST still-running background
   // subagent spawned from `sessionId`, or null when none is running. Lets idle
   // GC and stale-rollover pin a session whose child is still working (the next
-  // inbound would otherwise spawn a duplicate child), bounded by
-  // SESSION_CHILD_PIN_MAX_MS measured from that start. Newest — not oldest — so a
-  // long-running child that crossed the cap cannot unpin the session while a more
-  // recently spawned child is still inside its own protection window. Production
-  // wiring forwards the LiveSubagentRegistry; omitted (tests, no-subagent setups)
-  // means no pin.
+  // inbound would otherwise spawn a duplicate child, and a completion arriving
+  // after teardown is dropped), bounded only by SESSION_CHILD_STUCK_BACKSTOP_MS
+  // measured from that start. Newest — not oldest — so a long-running child that
+  // crossed the stuck backstop cannot unpin the session while a more recently
+  // spawned child is still inside its window. Production wiring forwards the
+  // LiveSubagentRegistry; omitted (tests, no-subagent setups) means no pin.
   newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
 }
 
@@ -1777,19 +1782,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   // True while a background child spawned from this session is still running AND
-  // the newest such child is within SESSION_CHILD_PIN_MAX_MS of its start. Using
-  // the newest child keeps the session pinned as long as ANY running child is
-  // still inside its protection window — an older child that already crossed the
-  // cap must not unpin the session out from under a freshly spawned one. Tearing
-  // the session down mid-child lets the next inbound spawn a duplicate child, so
-  // GC/rollover defer to this. `label` only annotates the override log.
+  // the newest such child has not outlived the stuck backstop. Using the newest
+  // child keeps the session pinned as long as ANY running child is still inside
+  // its window — an older child past the backstop must not unpin the session out
+  // from under a freshly spawned one. Tearing the session down mid-child lets the
+  // next inbound spawn a duplicate child AND drops the child's completion when it
+  // lands after teardown, so GC/rollover defer to this. Crossing the backstop is
+  // an anomaly (a wedged, timeout-less child), logged at warn. `label` only
+  // annotates the override log.
   const isPinnedByRunningChild = (sessionId: string, keyId: string, label: string): boolean => {
     const childStartedAt = newestRunningChildSubagentStartedAt(sessionId)
     if (childStartedAt === null) return false
     const pinnedForMs = now() - childStartedAt
-    if (pinnedForMs <= SESSION_CHILD_PIN_MAX_MS) return true
-    logger.info(
-      `[channels] ${keyId}: ${label} despite running child (newest pinned ${pinnedForMs}ms, past child-pin cap)`,
+    if (pinnedForMs <= SESSION_CHILD_STUCK_BACKSTOP_MS) return true
+    logger.warn(
+      `[channels] ${keyId}: ${label} despite running child (newest pinned ${pinnedForMs}ms, past stuck-child backstop; suspected stuck running child)`,
     )
     return false
   }


### PR DESCRIPTION
## Background

A user reported a background subagent whose final report never reached the Slack thread. Concrete timeline from the incident (KST):

- `17:40:15` — channel session spawns a background `operator` (`run_in_background: true`).
- `17:40:28` — parent posts an interim update via `channel_reply(continue: false)`; the turn ends `stopReason: "aborted"`.
- `18:45:18` — operator completes successfully (~**65 min**), produces its final output.
- The completion **never surfaced**. The user only got the report ~17h later, after manually asking the agent to read the session files.

The `channel_reply(continue: false)` abort is a red herring — it's signal-only and ends just the parent's post-tool turn; the child's completion path is independent and did fire. The real mechanism is session lifecycle:

A background subagent's completion is delivered by injecting a `system-reminder` into the **live** parent channel session (or a live successor for the same channel key). If neither is live, `injectSubagentCompletionReminder` returns `no-live-session` and the completion is silently dropped.

The parent was pinned against idle-GC / stale-rollover only while a running child stayed within `SESSION_CHILD_PIN_MAX_MS = 45m` of its start. A child that legitimately ran longer unpinned its parent at 45m; the thread had been idle >`SESSION_IDLE_MS` (30m) with no new inbound, so the next `runIdleGc` tick evicted it. At 65m the completion arrived to a torn-down session — and with no rollover successor (pure GC, no inbound), it was dropped.

## Summary

Retime the ceiling from a routine freshness cap into a **stuck-child leak guard**: rename `SESSION_CHILD_PIN_MAX_MS` → `SESSION_CHILD_STUCK_BACKSTOP_MS` and raise 45m → **6h**. A running child now pins its parent for the entire duration of any legitimate run.

**Why keep a bound at all (not pin-forever-while-running):** subagent `timeoutMs` is optional and the commonly-used `operator` declares none, so a genuinely wedged child stays `status: 'running'` indefinitely. Without a ceiling its parent session would leak forever. 6h is sized as an anomaly threshold — far above any legitimate run (deep operator work is minutes-to-an-hour), so it never fires for real work, but still bounds a hang.

**Why 6h and not "just raise it a bit":** 45m was close enough to plausible deep work to make the drop routine — the reported 65m loss. The value must clearly read as "this child is wedged," not "this child is busy." Crossing it now logs at `warn` (`suspected stuck running child`) instead of `info`, so a real hang is diagnosable.

The newest-child pin semantics are unchanged (an older past-backstop child can't unpin the session out from under a freshly spawned one).

## What this does NOT do

- Does **not** add durable redelivery. A completion still needs a live parent session (or a live successor for the channel key). It does not survive a legitimate session rollover that leaves no successor, or a process/container restart between spawn and completion. That's a separate follow-up (a completion outbox keyed by channel key, drained on next session spawn).
- Does **not** change `channel_reply(continue: false)` / turn-abort behavior — that was not the cause.
- Does **not** add per-subagent timeouts to `operator`/`reviewer`; stuck-child lifecycle handling is out of scope here.

## Review notes

- Load-bearing change is `isPinnedByRunningChild` (`src/channels/router.ts`): the predicate is now `pinnedForMs <= SESSION_CHILD_STUCK_BACKSTOP_MS`, and the override log is `warn` + `suspected stuck running child`.
- Invariant to verify: a running child pins the parent through the whole run (new test asserts pinned at 65m, which fails under the old 45m cap), and the parent unpins the instant the child stops running (`recordCompletion` flips status off `'running'` → the seam returns `null` → GC proceeds normally). New test covers the unpin-then-evict path.
- Existing rollover / idle-GC / persisted-stale-mapping tests were updated for the rename and the new `warn` string; their thresholds still cross the 6h backstop so their assertions hold.
- Full suite green locally (typecheck / lint 0-errors / format:check / 10709 tests pass).
