### PR TITLE
fix(agent-browser): correct the stale "headless only" skill guidance

### DIFF
--- a/src/bundled-plugins/agent-browser/skills/agent-browser/SKILL.md
+++ b/src/bundled-plugins/agent-browser/skills/agent-browser/SKILL.md
@@ -15,10 +15,12 @@ already downloaded, so the CLI is ready to use out of the box.
 
 ## Human-in-the-loop via the dashboard
 
-You run inside a Docker container with no display, no clipboard, and no way to
-hand the keyboard over directly. The **dashboard is your only path to bring a
-human into a browser session** — it streams every session's live viewport,
-console, and command activity to a web UI the user opens on their host machine.
+You run inside a Docker container. Chrome renders to the in-container virtual X
+display (Xvfb, `DISPLAY=:99`), but there is no human-accessible display or
+clipboard and no way to hand the keyboard over directly. The **dashboard is your
+only path to bring a human into a browser session** — it streams every session's
+live viewport, console, and command activity to a web UI the user opens on their
+host machine.
 
 **Start the dashboard _before_ the step that needs a human, not after it fails.**
 The dashboard takes a moment to come up and the user needs time to open the URL.
@@ -91,13 +93,28 @@ you just want to show the user a single page or a captured state:
 Reserve the dashboard for cases that genuinely need live interaction or
 watching a multi-step flow unfold.
 
-### Headless only
+### Headed vs headless
 
-Never pass `--headed` to any `agent-browser` command — the container has no X
-server or `$DISPLAY`, and a headed launch fails with `Missing X server or
-$DISPLAY / The platform failed to initialize.` The dashboard is the substitute
-for a headed browser. Use the default headless mode for everything, including
-dogfooding and Electron flows.
+By default the container ships a virtual X server: the entrypoint spawns Xvfb
+and exports `DISPLAY=:99`, so `--headed` (or `AGENT_BROWSER_HEADED=1`) launches a
+real headed Chrome. Headless is fine for ordinary automation — dogfooding, form
+filling, Electron flows, capturing a page you can already reach.
+
+Prefer `--headed` when a site is guarded by a WAF/anti-bot layer (Akamai Bot
+Manager, Cloudflare, PerimeterX — common on large e-commerce and portal sites).
+Chrome's `--headless`/`--headless=new` modes are fingerprinted by these stacks
+via signals no UA spoof can patch, so a headless launch draws a `403 Access
+Denied` / CAPTCHA where a headed one under Xvfb passes. This is the whole reason
+the container runs Xvfb. For a hard case, combine headed mode with a persistent
+`--profile` and warm the session (land on the homepage, then navigate
+organically) so the site's trust cookie is issued before you hit the target
+page.
+
+The one exception: if the agent folder sets `docker.file.xvfb: false`, there is
+no `DISPLAY` and a headed launch fails with `Missing X server or $DISPLAY / The
+platform failed to initialize.` In that configuration, stay headless and use the
+dashboard for anything that needs a human. If a `--headed` command ever returns
+that error, the toggle is off — fall back to headless rather than retrying.
 
 ## Start here
 


### PR DESCRIPTION
## Background

The bundled `agent-browser` skill has a **Headless only** section that instructs the agent:

> Never pass `--headed` to any `agent-browser` command — the container has no X server or `$DISPLAY`, and a headed launch fails with `Missing X server or $DISPLAY`. Use the default headless mode for everything.

That is false for the container TypeClaw actually builds. `docker.file.xvfb` defaults to `true`, so `buildEntrypointShim()` (`src/init/dockerfile.ts`) spawns Xvfb and exports `DISPLAY=:99`, and there is a dedicated Layer 4.5 shim whose entire purpose is making `--headed` work correctly. The Dockerfile's own comment spells out *why* Xvfb is shipped: Chrome's `--headless`/`--headless=new` modes are fingerprinted by Akamai/Cloudflare Bot Manager "regardless of UA spoof, so real headed Chrome under a virtual framebuffer is the only path to a passing sensor score from a server-side container."

So the skill told the agent to do the one thing guaranteed to get it blocked. Observed symptom: pointed at a WAF-guarded storefront (Coupang, Akamai Bot Manager), the agent obeyed the skill, launched headless, and got `403 Access Denied` at the CDN edge (`errors.edgesuite.net`, `_abck=~-1~`) — exactly the failure mode headed-via-Xvfb exists to avoid.

The skill was the lone dissenting voice: `src/config/config.ts`, `src/init/dockerfile.ts`, and the `typeclaw-config` Dockerfile reference all describe `--headed` as the supported, intended mode for defeating headless-WAF fingerprinting.

## Summary

Rewrite the section from a blanket prohibition into accurate guidance:

- Headless stays the default for ordinary automation (dogfooding, forms, Electron, reaching pages you can already load).
- **Prefer `--headed` for WAF/anti-bot sites** (Akamai/Cloudflare/PerimeterX), optionally with a persistent `--profile` and a warmed session (homepage-first → organic navigation) so the trust cookie is issued before hitting the target page.
- The `Missing X server / $DISPLAY` error is kept, but reframed as the real trigger: the `docker.file.xvfb: false` opt-out. In that config, stay headless and use the dashboard — and if a `--headed` command ever returns that error, fall back to headless rather than retrying.

Why keep the error text rather than delete it: it's a genuine failure mode when the operator disables the xvfb toggle. The fix is to attribute it to the right cause, not to pretend headed always works.

## What this does NOT do

- No code/behavior change — this is skill-content only (the discovery stub the agent reads). The runtime, the Dockerfile shim, and the `--headed` wrapper are untouched.
- Does not add an anti-bot/stealth skill, custom Chrome flags, `--init-script` hardening, or session-warming tooling. Those are a separate, larger change; this PR only stops the skill from steering the agent into the blocked path.
- Does not change the `docker.file.xvfb` default or any config.

## Review notes

- Load-bearing change: `src/bundled-plugins/agent-browser/skills/agent-browser/SKILL.md`, the `### Headed vs headless` section (was `### Headless only`).
- Invariant to verify: the guidance matches the shipped container. Cross-check against `buildEntrypointShim()` / `start_xvfb` in `src/init/dockerfile.ts` (spawns Xvfb, exports `DISPLAY=:99`, self-heals to headless when `Xvfb` is absent) and the xvfb note in `src/config/config.ts`.
- No test asserts the old skill text, so nothing in the suite pins the wording; the `--headed` tests in `dockerfile.test.ts` validate the headed shim path and are unaffected.