### PR TITLE
feat(web_fetch): auto-warm Akamai Bot Manager 403s

### DIFF
--- a/src/agent/tools/curl-impersonate.test.ts
+++ b/src/agent/tools/curl-impersonate.test.ts
@@ -21,7 +21,13 @@ const onWindows = isWindows()
 // fake binary reads it out of argv (the value following '-w') and renders
 // a fake metadata block back. See fetch.test.ts for the rationale on the
 // argv positional-access pattern.
-const FAKE_BINARY_BODY = (body: string, status = 200, finalUrl = 'https://example.com', contentType = 'text/html') => `
+const FAKE_BINARY_BODY = (
+  body: string,
+  status = 200,
+  finalUrl = 'https://example.com',
+  contentType = 'text/html',
+  headerJson = '{}',
+) => `
 ARGV_FILE="$SCRATCH_ARGV"
 printf '%s\\n' "$@" > "$ARGV_FILE"
 WTPL=""
@@ -34,9 +40,9 @@ for arg in "$@"; do
   fi
   i=$((i + 1))
 done
-RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/${status}/' -e 's|%{url_effective}|${finalUrl}|' -e 's|%{content_type}|${contentType}|' -e 's/%{size_download}/${body.length}/')
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/${status}/' -e 's|%{url_effective}|${finalUrl}|' -e 's|%{content_type}|${contentType}|' -e 's/%{size_download}/${body.length}/' -e 's|%{header_json}|@@HJ@@|')
 printf '%s' '${body}'
-printf '%s' "$RENDERED"
+printf '%s' "$RENDERED" | sed "s|@@HJ@@|$(printf '%s' '${headerJson.replace(/'/g, `'\\''`).replace(/\|/g, '\\\\|')}')|"
 `
 
 // POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
@@ -213,6 +219,48 @@ describe.skipIf(onWindows)('curlImpersonate', () => {
     const idx = a.indexOf('--max-filesize')
     expect(idx).toBeGreaterThanOrEqual(0)
     expect(a[idx + 1]).toBe('5000000')
+  })
+
+  test('passes -b and -c with the same jar path when cookieJarPath is set', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
+
+    await curlImpersonate({ url: 'https://example.com', cookieJarPath: '/tmp/jar.txt' })
+
+    const a = await argv()
+    const readIdx = a.indexOf('-b')
+    const writeIdx = a.indexOf('-c')
+    expect(readIdx).toBeGreaterThanOrEqual(0)
+    expect(a[readIdx + 1]).toBe('/tmp/jar.txt')
+    expect(writeIdx).toBeGreaterThanOrEqual(0)
+    expect(a[writeIdx + 1]).toBe('/tmp/jar.txt')
+  })
+
+  test('omits cookie-jar flags when cookieJarPath is not set', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('ok'))
+
+    await curlImpersonate({ url: 'https://example.com' })
+
+    const a = await argv()
+    expect(a).not.toContain('-b')
+    expect(a).not.toContain('-c')
+  })
+
+  test('parses Set-Cookie names from header_json', async () => {
+    const headerJson = '{"set-cookie":["_abck=xyz; Path=/","bm_sz=abc; Path=/"],"content-type":["text/html"]}'
+    installFakeBinary(FAKE_BINARY_BODY('blocked', 403, 'https://example.com', 'text/html', headerJson))
+
+    const result = await curlImpersonate({ url: 'https://example.com' })
+
+    expect(result.httpStatus).toBe(403)
+    expect(result.setCookieNames).toEqual(['_abck', 'bm_sz'])
+  })
+
+  test('returns empty setCookieNames when the server sets no cookies', async () => {
+    installFakeBinary(FAKE_BINARY_BODY('ok', 200, 'https://example.com', 'text/html', '{"content-type":["text/html"]}'))
+
+    const result = await curlImpersonate({ url: 'https://example.com' })
+
+    expect(result.setCookieNames).toEqual([])
   })
 
   test('aborts when the AbortSignal fires', async () => {

--- a/src/agent/tools/curl-impersonate.ts
+++ b/src/agent/tools/curl-impersonate.ts
@@ -47,6 +47,11 @@ export type CurlImpersonateRequest = {
   // bail early instead of streaming gigabytes.
   maxBytes?: number
   timeoutSeconds?: number
+  // Read/write cookies to this jar (curl `-b`+`-c`, same path). Enables a
+  // two-request sequence sharing one jar. Cookie plumbing does NOT alter the
+  // TLS/HTTP-2/header-order impersonation, so it is exempt from the no-`-H`
+  // doctrine above.
+  cookieJarPath?: string
   signal?: AbortSignal
 }
 
@@ -56,6 +61,10 @@ export type CurlImpersonateResponse = {
   httpStatus: number
   contentType: string
   bytesIn: number
+  // Cookie names the server set via Set-Cookie on this response (from curl
+  // %{header_json}); lets the policy layer detect a bot-manager 403 without
+  // parsing the jar file format.
+  setCookieNames: string[]
 }
 
 // Specific curl exit codes we map to typed errors. The full list is in
@@ -113,7 +122,10 @@ export async function curlImpersonate(req: CurlImpersonateRequest): Promise<Curl
   // response and replay it; last-match alone fails if the attacker can
   // append text after curl's write-out (they can't, but defense in depth).
   const sentinel = generateSentinel()
-  const writeOutTemplate = `${sentinel}%{http_code}\n%{url_effective}\n%{content_type}\n%{size_download}\n`
+  // %{header_json} is the LAST field so the existing status/url/type/size
+  // positions stay byte-compatible with the old parser. It is a single-line
+  // JSON object of response headers; we read only Set-Cookie names from it.
+  const writeOutTemplate = `${sentinel}%{http_code}\n%{url_effective}\n%{content_type}\n%{size_download}\n%{header_json}\n`
 
   const cmd: string[] = [
     curlBinary,
@@ -154,6 +166,10 @@ export async function curlImpersonate(req: CurlImpersonateRequest): Promise<Curl
 
   if (req.maxBytes !== undefined) {
     cmd.push('--max-filesize', String(req.maxBytes))
+  }
+
+  if (req.cookieJarPath !== undefined) {
+    cmd.push('-b', req.cookieJarPath, '-c', req.cookieJarPath)
   }
 
   if (req.formFields) {
@@ -248,6 +264,7 @@ function parseCurlOutput(buf: ArrayBuffer, sentinel: string, stderr: string): Cu
   const finalUrl = (meta[1] ?? '').trim()
   const contentType = (meta[2] ?? '').trim().toLowerCase()
   const declaredBytes = Number(meta[3]?.trim() ?? '0') || bodyBytes.byteLength
+  const setCookieNames = parseSetCookieNames(meta[4] ?? '')
 
   const body = new TextDecoder('utf-8', { fatal: false }).decode(bodyBytes)
 
@@ -257,7 +274,29 @@ function parseCurlOutput(buf: ArrayBuffer, sentinel: string, stderr: string): Cu
     httpStatus,
     contentType,
     bytesIn: declaredBytes,
+    setCookieNames,
   }
+}
+
+function parseSetCookieNames(headerJson: string): string[] {
+  const trimmed = headerJson.trim()
+  if (!trimmed) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return []
+  }
+  if (typeof parsed !== 'object' || parsed === null) return []
+  const setCookie = (parsed as Record<string, unknown>)['set-cookie']
+  const values = Array.isArray(setCookie) ? setCookie : setCookie === undefined ? [] : [setCookie]
+  const names: string[] = []
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const name = value.split('=', 1)[0]?.trim()
+    if (name) names.push(name)
+  }
+  return names
 }
 
 function lastIndexOfBytes(haystack: Uint8Array, needle: Uint8Array): number {

--- a/src/agent/tools/webfetch/fetch.test.ts
+++ b/src/agent/tools/webfetch/fetch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -257,5 +257,150 @@ describe.skipIf(onWindows)('fetchWithLimits — curl-impersonate path', () => {
     // then: globalThis.fetch was the actual transport
     expect(result.body).toBe('fallback body')
     expect(fetchCalls).toHaveLength(1)
+  })
+})
+
+// A fake curl that renders a single response including %{header_json}, so the
+// primitive can parse Set-Cookie names. headerJson is baked in via a @@HJ@@
+// placeholder to dodge sed metacharacter issues (see curl-impersonate.test.ts).
+function fakeCurlWithHeaders(body: string, status: number, headerJson: string): string {
+  return `
+ARGV_FILE="\${SCRATCH_ARGV:-/tmp/argv.txt}"
+printf '%s\\n' "$@" > "$ARGV_FILE"
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then
+    j=$((i + 1))
+    eval "WTPL=\\"\\\${$j}\\""
+    break
+  fi
+  i=$((i + 1))
+done
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/${status}/' -e 's|%{url_effective}|https://example.com|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/${body.length}/' -e 's|%{header_json}|@@HJ@@|')
+printf '%s' '${body}'
+printf '%s' "$RENDERED" | sed "s|@@HJ@@|$(printf '%s' '${headerJson.replace(/'/g, `'\\''`).replace(/\|/g, '\\\\|')}')|"
+`
+}
+
+// POSIX-only fake shell binary. Windows cannot spawn it (#899).
+describe.skipIf(onWindows)('fetchWithLimits — antibot cookie warmup', () => {
+  let scratchDir: string
+  let curlPath: string
+  let countPath: string
+
+  beforeEach(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), 'webfetch-warmup-test-'))
+    curlPath = join(scratchDir, 'fake-curl')
+    countPath = join(scratchDir, 'count')
+    _setForceFallbackForTest(false)
+  })
+
+  afterEach(() => {
+    rmSync(scratchDir, { recursive: true, force: true })
+  })
+
+  function install(script: string): void {
+    writeFileSync(
+      curlPath,
+      `#!/bin/sh\nSCRATCH_ARGV="${join(scratchDir, 'argv.txt')}"\nif [ "$1" = "--version" ]; then exit 0; fi\n${script}\n`,
+      'utf8',
+    )
+    chmodSync(curlPath, 0o755)
+    _setCurlBinaryForTest(curlPath)
+    _resetAvailabilityCacheForTest()
+  }
+
+  // A two-call fake: first invocation emits `first`, second emits `second`.
+  // State is a counter file so the two curlImpersonate() spawns diverge.
+  function installTwoCall(first: string, second: string): void {
+    const dispatch = `
+if [ "$1" = "--version" ]; then exit 0; fi
+COUNT_FILE="${countPath}"
+N=$(cat "$COUNT_FILE" 2>/dev/null || printf '0')
+printf '%s' "$((N + 1))" > "$COUNT_FILE"
+if [ "$N" = "0" ]; then
+${first}
+else
+${second}
+fi
+`
+    writeFileSync(curlPath, `#!/bin/sh\nSCRATCH_ARGV="${join(scratchDir, 'argv.txt')}"\n${dispatch}\n`, 'utf8')
+    chmodSync(curlPath, 0o755)
+    _setCurlBinaryForTest(curlPath)
+    _resetAvailabilityCacheForTest()
+  }
+
+  test('plain 200: no warmup attempted flag surfaced as triggered', async () => {
+    install(fakeCurlWithHeaders('<html>ok</html>', 200, '{"content-type":["text/html"]}'))
+
+    const result = await fetchWithLimits('https://example.com', 30)
+
+    expect(result.httpStatus).toBe(200)
+    expect(result.antibotWarmup?.triggered).toBe(false)
+  })
+
+  test('403 with bot-manager Set-Cookie: replays once and returns the 200', async () => {
+    const first = fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz; Path=/","bm_sz=abc"]}')
+    const second = fakeCurlWithHeaders('<html>product</html>', 200, '{"content-type":["text/html"]}')
+    installTwoCall(first, second)
+
+    const result = await fetchWithLimits('https://example.com', 30)
+
+    expect(result.httpStatus).toBe(200)
+    expect(result.body).toBe('<html>product</html>')
+    expect(result.antibotWarmup?.triggered).toBe(true)
+    expect(result.antibotWarmup?.initialStatus).toBe(403)
+    expect(result.antibotWarmup?.initialSetCookieNames).toEqual(['_abck', 'bm_sz'])
+    expect(result.antibotWarmup?.replayStatus).toBe(200)
+  })
+
+  test('403 WITHOUT a bot-manager cookie: no replay, throws HTTP 403', async () => {
+    install(fakeCurlWithHeaders('nope', 403, '{"set-cookie":["session=abc"]}'))
+
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
+  })
+
+  test('401 with a bot cookie present: no replay (only 403 triggers), throws HTTP 401', async () => {
+    install(fakeCurlWithHeaders('unauth', 401, '{"set-cookie":["_abck=xyz"]}'))
+
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 401/)
+  })
+
+  test('403 with only a normal app cookie: no replay, throws HTTP 403', async () => {
+    install(fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["JSESSIONID=abc; Path=/"]}'))
+
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
+  })
+
+  test('403 with bot cookie, replay still 403: throws final HTTP 403', async () => {
+    const first = fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz"]}')
+    const second = fakeCurlWithHeaders('blocked again', 403, '{"set-cookie":["_abck=xyz2"]}')
+    installTwoCall(first, second)
+
+    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
+  })
+
+  test('antibotWarmup="off": a bot-manager 403 is NOT replayed, throws HTTP 403', async () => {
+    const first = fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz"]}')
+    const second = fakeCurlWithHeaders('<html>product</html>', 200, '{"content-type":["text/html"]}')
+    installTwoCall(first, second)
+
+    await expect(fetchWithLimits('https://example.com', 30, undefined, 'off')).rejects.toThrow(/HTTP 403/)
+  })
+
+  test('replay is charged the remaining budget, not a fresh timeout', async () => {
+    // given: the first request eats the whole 1s budget before returning a
+    // bot-manager 403, so no time is left to replay.
+    const first = `sleep 1.2\n${fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz"]}')}`
+    const second = fakeCurlWithHeaders('<html>product</html>', 200, '{"content-type":["text/html"]}')
+    installTwoCall(first, second)
+
+    // when / then: it surfaces the initial 403 rather than spending a second
+    // full budget on the replay.
+    await expect(fetchWithLimits('https://example.com', 1)).rejects.toThrow(/HTTP 403/)
+
+    // and: the replay never ran (counter advanced only for the first call).
+    expect(readFileSync(countPath, 'utf8')).toBe('1')
   })
 })

--- a/src/agent/tools/webfetch/fetch.ts
+++ b/src/agent/tools/webfetch/fetch.ts
@@ -21,14 +21,29 @@
 // translates non-2xx into a tool-level error message that's useful to the
 // model.
 
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import {
   CurlImpersonateError,
   curlImpersonate,
+  type CurlImpersonateResponse,
   isCurlExitFilesizeExceeded,
   isCurlExitTimeout,
   isCurlImpersonateAvailable,
 } from '../curl-impersonate'
 import { MAX_RESPONSE_BYTES } from './types'
+
+export type AntibotWarmup = 'auto' | 'off'
+
+export type AntibotWarmupInfo = {
+  attempted: boolean
+  triggered: boolean
+  initialStatus?: number
+  initialSetCookieNames?: string[]
+  replayStatus?: number
+}
 
 export type FetchResult = {
   body: string
@@ -36,6 +51,19 @@ export type FetchResult = {
   finalUrl: string
   httpStatus: number
   bytesIn: number
+  antibotWarmup?: AntibotWarmupInfo
+}
+
+// Cookie names Akamai Bot Manager sets in the Set-Cookie of its 403 challenge.
+// A 403 carrying one of these is a state-bootstrap handshake (absorb cookies,
+// replay once), NOT an authorization failure — that distinction is what makes
+// the auto-retry safe. Scoped to Akamai on purpose: Cloudflare/DataDome use
+// different challenge semantics (JS/redirects/CAPTCHA) that a blind replay
+// would not satisfy.
+const AKAMAI_BOTMANAGER_COOKIE = /^(_abck|bm_sz|bm_s|bm_ss|bm_so|ak_bmsc)$/i
+
+function isAntibotWarmup403(response: CurlImpersonateResponse): boolean {
+  return response.httpStatus === 403 && response.setCookieNames.some((name) => AKAMAI_BOTMANAGER_COOKIE.test(name))
 }
 
 export class WebFetchError extends Error {
@@ -76,10 +104,11 @@ export async function fetchWithLimits(
   url: string,
   timeoutSeconds: number,
   parentSignal?: AbortSignal,
+  antibotWarmup: AntibotWarmup = 'auto',
 ): Promise<FetchResult> {
   const useImpersonate = !forceFallbackForTest && (await isCurlImpersonateAvailable())
   if (useImpersonate) {
-    return fetchWithCurlImpersonate(url, timeoutSeconds, parentSignal)
+    return fetchWithCurlImpersonate(url, timeoutSeconds, antibotWarmup, parentSignal)
   }
   return fetchWithBunFetch(url, timeoutSeconds, parentSignal)
 }
@@ -87,15 +116,66 @@ export async function fetchWithLimits(
 async function fetchWithCurlImpersonate(
   url: string,
   timeoutSeconds: number,
+  antibotWarmup: AntibotWarmup,
   parentSignal?: AbortSignal,
 ): Promise<FetchResult> {
-  let response
+  if (antibotWarmup === 'off') {
+    const response = await runCurl(url, timeoutSeconds, undefined, parentSignal)
+    return toFetchResult(url, response)
+  }
+
+  // Warmup needs a jar shared across both requests: request 1 (`-c`) captures
+  // the bot-manager cookies the 403 sets; request 2 (`-b`) replays them.
+  const jarDir = await mkdtemp(join(tmpdir(), 'typeclaw-webfetch-jar-'))
+  const jarPath = join(jarDir, 'cookies.txt')
+  const startedAt = Date.now()
   try {
-    response = await curlImpersonate({
+    const first = await runCurl(url, timeoutSeconds, jarPath, parentSignal)
+    if (!isAntibotWarmup403(first)) {
+      return toFetchResult(url, first, { attempted: true, triggered: false })
+    }
+
+    // `timeoutSeconds` is the budget for the WHOLE web_fetch call, not per
+    // attempt: charge the replay only the time the first request left, so a
+    // warmed fetch can't run for ~2x the requested timeout. If the first
+    // request already spent the budget, surface its 403 instead of forcing a
+    // zero-time replay that would just time out.
+    const remaining = timeoutSeconds - (Date.now() - startedAt) / 1000
+    if (remaining < 1) {
+      return toFetchResult(url, first, {
+        attempted: true,
+        triggered: false,
+        initialStatus: first.httpStatus,
+        initialSetCookieNames: first.setCookieNames,
+      })
+    }
+
+    const replay = await runCurl(url, Math.floor(remaining), jarPath, parentSignal)
+    return toFetchResult(url, replay, {
+      attempted: true,
+      triggered: true,
+      initialStatus: first.httpStatus,
+      initialSetCookieNames: first.setCookieNames,
+      replayStatus: replay.httpStatus,
+    })
+  } finally {
+    await rm(jarDir, { recursive: true, force: true })
+  }
+}
+
+async function runCurl(
+  url: string,
+  timeoutSeconds: number,
+  cookieJarPath: string | undefined,
+  parentSignal?: AbortSignal,
+): Promise<CurlImpersonateResponse> {
+  try {
+    return await curlImpersonate({
       url,
       method: 'GET',
       timeoutSeconds,
       maxBytes: MAX_RESPONSE_BYTES,
+      cookieJarPath,
       signal: parentSignal,
     })
   } catch (error) {
@@ -114,7 +194,9 @@ async function fetchWithCurlImpersonate(
     const message = error instanceof Error ? error.message : String(error)
     throw new WebFetchError(`Fetch failed: ${message}`)
   }
+}
 
+function toFetchResult(url: string, response: CurlImpersonateResponse, antibotWarmup?: AntibotWarmupInfo): FetchResult {
   if (response.httpStatus < 200 || response.httpStatus >= 300) {
     throw new WebFetchError(`Fetch failed: HTTP ${response.httpStatus}`)
   }
@@ -132,6 +214,7 @@ async function fetchWithCurlImpersonate(
     finalUrl: response.finalUrl || url,
     httpStatus: response.httpStatus,
     bytesIn: bodyByteLength,
+    ...(antibotWarmup ? { antibotWarmup } : {}),
   }
 }
 

--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -27,8 +27,11 @@ export const webFetchTool = defineTool({
     'If `spawn_subagent` is available to you, PREFER delegating to the `scout` subagent by default: spawn it whenever you expect more than one fetch, an "across multiple sources" task, or any search-then-fetch loop. Scout runs the noisy fetching in its own context window and returns a distilled, citation-backed answer, keeping bulky page bodies out of yours. Only call this tool directly for a single known URL whose content you will cite immediately — or whenever you cannot spawn subagents (e.g. you are yourself a subagent), in which case fetch here. ' +
     'Outbound requests impersonate Chrome 136 at the TLS, HTTP/2, and header layers ' +
     '(via curl-impersonate), which helps with TLS/header fingerprint gates on sites behind Cloudflare/Akamai. ' +
-    'It does NOT solve JavaScript challenges, behavioural fingerprinting (mouse/scroll/timing), interactive CAPTCHAs, ' +
-    'or IP-reputation blocks — a 403 from those layers is expected and unrecoverable from this tool. ' +
+    'For Akamai Bot Manager specifically, it auto-warms the session: a first-request 403 that sets bot-manager ' +
+    'cookies (_abck/bm_sz/…) is absorbed and replayed once, which returns 200 on many Akamai-fronted sites ' +
+    '(disable with `antibotWarmup: "off"`). It still does NOT solve JavaScript challenges, behavioural ' +
+    'fingerprinting (mouse/scroll/timing), interactive CAPTCHAs, or IP-reputation blocks — a 403 from those ' +
+    'layers is expected and unrecoverable from this tool. ' +
     'Strategy guide:\n' +
     '- "readability": extract article content as markdown (blogs, docs, news). Default for HTML.\n' +
     '- "jq": query JSON APIs (npm registry, GitHub API). Pass `query` (e.g. ".items[].name").\n' +
@@ -62,6 +65,15 @@ export const webFetchTool = defineTool({
         maximum: MAX_TIMEOUT_SECONDS,
       }),
     ),
+    antibotWarmup: Type.Optional(
+      Type.Union([Type.Literal('auto'), Type.Literal('off')], {
+        description:
+          'Akamai Bot Manager warmup. "auto" (default): if the first request is a 403 that sets bot-manager cookies ' +
+          '(_abck/bm_sz/…), absorb them and replay once — many Akamai-fronted sites (e.g. Coupang) only serve content ' +
+          'on the second, cookie-bearing request. "off": disable the replay; a bot-manager 403 then surfaces as the ' +
+          'normal HTTP 403 error (use to confirm the block without the warmup).',
+      }),
+    ),
   }),
 
   async execute(_toolCallId, params, signal) {
@@ -80,7 +92,7 @@ export const webFetchTool = defineTool({
 
     let response
     try {
-      response = await fetchWithLimits(normalizedUrl, timeout, signal)
+      response = await fetchWithLimits(normalizedUrl, timeout, signal, params.antibotWarmup ?? 'auto')
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       return errorResult(normalizedUrl, message, { startedAt, finalUrl: normalizedUrl })
@@ -141,6 +153,16 @@ export const webFetchTool = defineTool({
       bytesOut: byteLength(capped.text),
       truncated: capped.truncated,
       durationMs: Date.now() - startedAt,
+      ...(response.antibotWarmup?.triggered
+        ? {
+            antibotWarmup: {
+              triggered: true,
+              initialStatus: response.antibotWarmup.initialStatus,
+              initialSetCookieNames: response.antibotWarmup.initialSetCookieNames,
+              replayStatus: response.antibotWarmup.replayStatus,
+            },
+          }
+        : {}),
     }
 
     return {
@@ -153,6 +175,7 @@ export const webFetchTool = defineTool({
 type WebFetchParams = {
   url: string
   strategy?: CompactionStrategy
+  antibotWarmup?: 'auto' | 'off'
   query?: string
   selector?: string
   pattern?: string

--- a/src/agent/tools/webfetch/types.ts
+++ b/src/agent/tools/webfetch/types.ts
@@ -1,5 +1,12 @@
 export type CompactionStrategy = 'readability' | 'jq' | 'selector' | 'grep' | 'snapshot' | 'raw'
 
+export type AntibotWarmupDetails = {
+  triggered: boolean
+  initialStatus?: number
+  initialSetCookieNames?: string[]
+  replayStatus?: number
+}
+
 export type WebFetchDetails = {
   url: string
   finalUrl: string
@@ -11,6 +18,7 @@ export type WebFetchDetails = {
   bytesOut: number
   truncated: boolean
   durationMs: number
+  antibotWarmup?: AntibotWarmupDetails
   error?: boolean
   message?: string
 }


### PR DESCRIPTION
## Background

Akamai Bot Manager fronts a large share of big consumer sites (Coupang was the case that surfaced this; airline/retail/ticketing portals behave the same). Its edge does something specific and counter-intuitive: the **first** request returns `403 Access Denied` (server `AkamaiGHost`), but that 403's `Set-Cookie` **hands back the bot-manager cookies** (`_abck`, `bm_sz`, `bm_s`, `bm_ss`, `bm_so`, `ak_bmsc`). Replaying the *same* request once, carrying those cookies, over a client with a genuine Chrome TLS/HTTP-2/header-order fingerprint, returns `200`. It's a state-bootstrap handshake, not an authorization failure.

This was verified end-to-end against Coupang: on a clean residential IP, real desktop Chrome loads the page (200) while a one-shot fetch gets the edge 403 — the difference is the client fingerprint *and* the two-step cookie handshake. `web_fetch` already ships the right client (`curl_chrome136`), but it did a one-shot GET and treated the 403 as a hard error, so it never completed the handshake and could never reach the content. A JA3-only client fails where full HTTP/2-SETTINGS + header-order impersonation succeeds, which is why `curl_chrome136` (not Bun's fetch) is the transport that makes this work.

This is deliberately a **generic** capability, not a Coupang feature — any Akamai-Bot-Manager-fronted origin gets the same treatment.

## Summary

Three layers, split across two commits:

- **Primitive (`curl-impersonate.ts`)** gains an optional `cookieJarPath` (passes `-b`+`-c` with one path so two requests can share a jar) and returns `setCookieNames` per response (parsed from curl `%{header_json}`, appended as the last `-w` field so the existing status/url/type/size positions stay byte-compatible). Cookie plumbing does not alter the TLS/H2/header impersonation, so it's exempt from the primitive's no-`-H` doctrine.
- **Policy (`fetch.ts`)** owns the temp-jar lifecycle and the warmup: on a `403` whose `Set-Cookie` carries a known bot-manager cookie, absorb into a temp jar and replay **once**.
- **Tool (`tool.ts`)** exposes an `antibotWarmup: "auto" | "off"` param (default `"auto"`) and threads observable metadata.

**Why default-on.** A bot-manager 403 is a handshake every transparent fetch should complete, so the useful default is to complete it. The risk with "silently retry a 403" is masking a real authorization failure — so the trigger is narrow: it requires `status === 403` **and** a bot-manager cookie name in `Set-Cookie`. A bare 403, a 401 (even with a bot cookie present), or an app-only cookie (`JSESSIONID`, `session`) is left untouched and still throws. `antibotWarmup: "off"` returns the raw first response for debugging/audits.

**Why Akamai-only.** The cookie-name predicate is Akamai Bot Manager's. Cloudflare (`__cf_bm`) and DataDome use different challenge semantics (JS/redirects/CAPTCHA) that a blind single replay would not satisfy, so generalizing now would create false confidence. The regex is the single place to extend later if the same 403-replay behavior is measured for another vendor.

**Why one replay.** Empirically one warmup is enough. Starting at N>1 adds ambiguity and looks like brute-force probing; if a `403 → set A → 403 → set B → 200` chain is ever observed, the bound is the only thing to raise.

## What this does NOT do

- Does not touch the Bun.fetch fallback path (warmup only applies to the curl-impersonate transport, which is the only one that gets past the fingerprint gate anyway).
- Does not add per-site logic, a Coupang skill, or any hardcoded hostnames — the trigger is purely the response shape.
- Does not solve JavaScript challenges, behavioural fingerprinting, interactive CAPTCHAs, or IP-reputation blocks — those 403s set no bot-manager cookie, so they don't trigger a replay and remain hard errors.
- Does not extend to Cloudflare/DataDome.
- Does not change the container timezone (a separate, unrelated Akamai signal for the *browser* path); out of scope here.

## Review notes

- Load-bearing predicate: `isAntibotWarmup403()` in `fetch.ts` — `status === 403 && setCookieNames matches /^(_abck|bm_sz|bm_s|bm_ss|bm_so|ak_bmsc)$/i`. This is the guard that keeps real authz 403s from being retried; scrutinize it.
- Parser invariant: in `curl-impersonate.ts`, `%{header_json}` MUST remain the last `-w` field — the positional parser depends on it. There's a comment marking this.
- Metadata is only attached when the warmup actually triggered, to keep tool output lean; a normal 200 carries no `antibotWarmup` block.
- Test matrix (`fetch.test.ts`, 7 cases) covers: plain 200 (no trigger), 403+bot-cookie→replay→200, 403 without bot-cookie (no retry), 401 with a bot cookie (no retry — only 403 triggers), 403 with app-only cookie (no retry), 403→replay-still-403 (final throw), and `"off"` (no retry). The two-call divergence uses a counter-file fake curl; the `--version` availability probe is short-circuited before the counter so the first real request sees call 0.
- No secrets/local paths in the diff; temp jars use `os.tmpdir()` and are `rm`'d in `finally`.