### PR TITLE
fix(channels): stop only aborts an actually-running session

### DIFF
--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -2355,6 +2355,19 @@ describe('createThreadCommandHandler', () => {
     expect(replies[0]!.text).toContain('permission')
   })
 
+  test('no-live-session posts nothing (a bystander agent stays silent in a shared channel)', async () => {
+    const { handler, routerCalls, replies, logs } = setup({
+      routerImpl: async () => ({ kind: 'no-live-session' }),
+    })
+
+    const outcome = await handler(baseInput, makeReserve().reserve)
+
+    expect(outcome).toEqual({ kind: 'executed' })
+    expect(routerCalls).toHaveLength(1)
+    expect(replies).toHaveLength(0)
+    expect(logs.info.some((l) => l.includes('result=no-live-session'))).toBe(true)
+  })
+
   test('top-level !stop (no thread) targets a thread:null key', async () => {
     const { handler, routerCalls } = setup()
 

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -210,22 +210,29 @@ export function createThreadCommandHandler(
       `[slack-bot] thread-command !${command.name} invoker=${command.invokerId} team=${command.key.workspace} channel=${command.key.chat} thread=${command.key.thread ?? '(none)'}`,
     )
 
-    let reply: string
+    // null = stay silent. A shared Slack channel can host many agents; each one
+    // receives this message and runs its own executeCommand. Only the agent that
+    // actually had a running turn gets 'handled'; every bystander gets
+    // 'no-live-session'. Posting "Nothing to stop" from each bystander would spam
+    // the thread, so a no-live-session outcome posts nothing at all.
+    let reply: string | null
     try {
       const result = await deps.router.executeCommand(command.key, command.name, {
         invokerId: command.invokerId,
       })
-      reply = commandResultReply(result)
+      reply = result.kind === 'no-live-session' ? null : commandResultReply(result)
       deps.logger.info(`[slack-bot] thread-command !${command.name} result=${result.kind}`)
     } catch (err) {
       deps.logger.error(`[slack-bot] thread-command !${command.name} failed: ${describeError(err)}`)
       reply = SLACK_SLASH_REPLY_FAILED
     }
 
-    try {
-      await deps.postReply({ chat: input.channel, thread: input.threadTs, text: reply })
-    } catch (err) {
-      deps.logger.warn(`[slack-bot] thread-command reply post failed: ${describeError(err)}`)
+    if (reply !== null) {
+      try {
+        await deps.postReply({ chat: input.channel, thread: input.threadTs, text: reply })
+      } catch (err) {
+        deps.logger.warn(`[slack-bot] thread-command reply post failed: ${describeError(err)}`)
+      }
     }
     return { kind: 'executed' }
   }

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7160,10 +7160,20 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
   test('name lookup is case-insensitive (defensive — slash-command sources may send mixed case)', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
+    let releasePrompt: (() => void) | undefined
 
     await router.route(inbound({ text: 'hi' }))
-    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length === 1)
+
     const result = await router.executeCommand(KEY, 'STOP', { invokerId: 'alice' })
+    releasePrompt!()
+    await draining
 
     expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
@@ -7212,11 +7222,20 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
   test('falls back to a thread-keyed session when slash command carries thread:null (Slack)', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
+    let releasePrompt: (() => void) | undefined
 
     await router.route(inbound({ text: 'hi', thread: 'thr-1', isBotMention: true }))
-    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+    await waitFor(() => sessions[0]!.prompts.length === 1)
 
     const result = await router.executeCommand({ ...KEY, thread: null }, 'stop', { invokerId: 'alice' })
+    releasePrompt!()
+    await draining
 
     expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
@@ -7225,13 +7244,22 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
   test('exact key match wins over fallback when both apply', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)
+    let releaseTopLevel: (() => void) | undefined
 
     await router.route(inbound({ text: 'top-level' }))
-    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releaseTopLevel = resolve
+      })
+    }
+    const drainingTopLevel = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length === 1)
     await router.route(inbound({ text: 'in thread', thread: 'thr-1', isBotMention: true, externalMessageId: 'm2' }))
     await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
 
     const result = await router.executeCommand({ ...KEY, thread: null }, 'stop', { invokerId: 'alice' })
+    releaseTopLevel!()
+    await drainingTopLevel
 
     expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
@@ -7282,6 +7310,89 @@ describe('ChannelRouter.executeCommand (native slash-command surface)', () => {
 
     expect(result).toEqual({ kind: 'no-live-session' })
     expect(sessions[0]!.aborted).toBe(0)
+  })
+
+  test('thread-keyed stop does NOT fall back to a session in a different thread (multi-agent bystander bug)', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'in thread A', thread: 'thr-A', isBotMention: true, externalMessageId: 'mA' }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-A' })
+
+    const result = await router.executeCommand({ ...KEY, thread: 'thr-B' }, 'stop', { invokerId: 'alice' })
+
+    expect(result).toEqual({ kind: 'no-live-session' })
+    expect(sessions[0]!.aborted).toBe(0)
+  })
+
+  test('thread-keyed stop does NOT fall back to a channel-level (thread:null) session', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'top level' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const result = await router.executeCommand({ ...KEY, thread: 'thr-B' }, 'stop', { invokerId: 'alice' })
+
+    expect(result).toEqual({ kind: 'no-live-session' })
+    expect(sessions[0]!.aborted).toBe(0)
+  })
+
+  test('stop on an observe-only exact-thread session reports no-live-session and aborts nothing', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    // Prime a second human so the strict multi-human gate applies and an
+    // unaddressed thread message observes (creating a live session) rather than
+    // engaging — the bystander state the fix must treat as "nothing to stop".
+    await router.route(inbound({ thread: 'thr-1', isBotMention: true, authorId: 'carol', authorName: 'carol' }))
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+    const engagedSessions = sessions.length
+    await router.route(
+      inbound({ thread: 'thr-1', isBotMention: false, authorId: 'bob', authorName: 'bob', externalMessageId: 'm-obs' }),
+    )
+
+    const result = await router.executeCommand({ ...KEY, thread: 'thr-1' }, 'stop', { invokerId: 'alice' })
+
+    expect(result).toEqual({ kind: 'no-live-session' })
+    // The observe-only inbound created no new session that got aborted, and the
+    // earlier engaged session already drained (nothing in flight, empty queue).
+    for (let i = 0; i < engagedSessions; i++) expect(sessions[i]!.aborted).toBe(0)
+  })
+
+  test('stop on a draining exact-thread session aborts it', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    let releasePrompt: (() => void) | undefined
+
+    await router.route(inbound({ text: 'long task', thread: 'thr-1', isBotMention: true }))
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+    await waitFor(() => sessions[0]!.prompts.length === 1)
+
+    const result = await router.executeCommand({ ...KEY, thread: 'thr-1' }, 'stop', { invokerId: 'alice' })
+    releasePrompt!()
+    await draining
+
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
+    expect(sessions[0]!.aborted).toBe(1)
+  })
+
+  test('stop on a queued (pre-drain) exact-thread session clears the queue and aborts', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+
+    await router.route(inbound({ text: 'queued', thread: 'thr-1', isBotMention: true }))
+
+    const result = await router.executeCommand({ ...KEY, thread: 'thr-1' }, 'stop', { invokerId: 'alice' })
+    await router.__testing!.flushDebounce({ ...KEY, thread: 'thr-1' })
+
+    expect(result).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
+    expect(sessions[0]!.aborted).toBe(1)
+    expect(sessions[0]!.prompts).toEqual([])
   })
 })
 
@@ -10845,9 +10956,16 @@ describe('ChannelRouter channel.respond gate', () => {
       stranger: ['channel.respond'],
     })
     const { router, sessions } = makeRouter(dir, { permissions })
+    let releasePrompt: (() => void) | undefined
 
     await router.route(inbound({ authorId: 'alice', externalMessageId: 'm-alice' }))
-    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.onPrompt = async () => {
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve
+      })
+    }
+    const draining = router.__testing!.flushDebounce(KEY)
+    await waitFor(() => sessions[0]!.prompts.length === 1)
     expect(sessions).toHaveLength(1)
 
     const denied = await router.executeCommand(KEY, 'stop', { invokerId: 'stranger' })
@@ -10855,6 +10973,8 @@ describe('ChannelRouter channel.respond gate', () => {
     expect(sessions[0]!.aborted).toBe(0)
 
     const allowed = await router.executeCommand(KEY, 'stop', { invokerId: 'alice' })
+    releasePrompt!()
+    await draining
     expect(allowed).toEqual({ kind: 'handled', name: 'stop', reply: 'Stopped the current turn.' })
     expect(sessions[0]!.aborted).toBe(1)
   })

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2705,6 +2705,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  // ensureLive() installs a session BEFORE the engage/observe decision, so a
+  // bystander agent that only OBSERVED a thread still holds an exact-thread
+  // session with nothing running. Without this gate that agent aborts its idle
+  // session and posts "stopped" in a multi-agent channel. Mirrors exactly what
+  // stopCurrentChannelTurn cancels: in-flight drain, queued prompts, reminders.
+  const hasStoppableWork = (live: LiveSession): boolean =>
+    live.draining || live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0
+
   const maybePostDeferredProviderError = async (
     live: LiveSession,
     sentReplyThisTurn: boolean,
@@ -5130,6 +5138,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       if (resolved.kind === 'ambiguous') {
         return { kind: 'ambiguous', matchCount: resolved.count }
       }
+      // A resolved session that isn't actually running has nothing for /stop to
+      // cancel; report it as no-live-session so bystander agents stay silent.
+      if (lowered === 'stop' && !hasStoppableWork(resolved.session)) {
+        return { kind: 'no-live-session' }
+      }
       live = resolved.session
     } else if (commandInfo.wantsLiveSession) {
       // Best-effort: resolve a session if exactly one matches, but never fail
@@ -6097,10 +6110,19 @@ export type ResolveLiveSessionResult =
 // return 'ambiguous' so the caller can refuse to act rather than abort an
 // arbitrary session.
 //
-// Why the fallback: Slack slash commands carry channel_id but no thread_ts,
-// so a slash invocation from a thread-keyed live session would otherwise
-// report no-live-session. Discord doesn't hit this — Discord treats threads
-// as channels, so the exact-key path already resolves.
+// Why the fallback: Slack slash commands carry channel_id but no thread_ts
+// (`thread: null`), so a slash invocation from a thread-keyed live session
+// would otherwise report no-live-session. Discord doesn't hit this — Discord
+// treats threads as channels, so the exact-key path already resolves.
+//
+// Why the fallback is thread-null-ONLY: a `!stop` typed INSIDE a Slack thread
+// carries the real `thread_ts`, so it pinpoints one exact thread. Falling back
+// to "any session in this channel" for a thread-specific key would let the
+// command hit an UNRELATED session in a different thread (or a channel-level
+// observe-only session) — the multi-agent bug where a bystander bot that only
+// observed the thread aborts its own idle session and posts "stopped". A
+// non-null thread that misses the exact lookup therefore returns 'none', never
+// the cross-thread fallback.
 //
 // Why ambiguity-rejection: "first match wins" map-iteration semantics would
 // abort an arbitrary thread when multiple thread-keyed sessions coexist in
@@ -6113,6 +6135,8 @@ export function resolveLiveSessionForCommand(
 ): ResolveLiveSessionResult {
   const exact = liveSessions.get(channelKeyId(key))
   if (exact && !exact.destroyed) return { kind: 'found', session: exact }
+
+  if (key.thread !== null) return { kind: 'none' }
 
   const matches: LiveSession[] = []
   for (const candidate of liveSessions.values()) {


### PR DESCRIPTION
## Background

In a shared Slack channel hosting multiple agents (typeclaw runs each agent in its own container, and Slack delivers every message to every bot in the channel), a user ran `!stop` inside a thread. Only one agent was actually engaged and running in that thread — a second, unrelated agent never participated. Both agents replied "stopped."

Two independent mechanisms caused this:

1. **Thread-agnostic command fallback.** `resolveLiveSessionForCommand` (`src/channels/router.ts`) falls back to matching any live session in the same (adapter, workspace, chat) when the exact thread-keyed lookup misses. That fallback exists only to support native Slack slash commands, which cannot be invoked from inside a thread and so always carry `thread: null`. A `!stop` typed inside a thread carries the real `thread_ts` — an exact key — but the fallback ran anyway and handed the bystander agent an unrelated session (a different thread, or a channel-level session), which it then aborted.
2. **Observe-only sessions look "live."** `ensureLive` installs a live session before the engage/observe decision runs, so an agent that merely observed a thread still holds an exact-thread live session with nothing running, until idle GC reaps it. Even with fix #1, an exact-key match could resolve one of these idle sessions.

## Summary

- `resolveLiveSessionForCommand` now runs the thread-agnostic fallback only when `key.thread === null`. A non-null thread that misses the exact lookup returns `none` instead of guessing. The existing thread-null fallback behavior (and its ambiguity-rejection) is untouched, so native slash commands keep working.
- `/stop` now gates on a new `hasStoppableWork(live)` helper — `live.draining || live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0`, exactly what `stopCurrentChannelTurn` cancels. An idle/observe-only session reports `no-live-session` instead of "stopping" nothing and claiming success. The gate is scoped to `lowered === 'stop'` inside `executeCommand`, so no other command is affected.

**Why "has stoppable work" and not participation history:** an engaged agent can be running before its first send, so gating on `hasBotParticipated` would false-negative a genuinely-running turn. Draining/queued state is the actual thing `/stop` cancels, so it's the correct gate (validated with Oracle).

## What this does NOT do

- Does not change the native Slack slash-command path: its "nothing to stop" ack is ephemeral (invoker-only, `response_type: 'ephemeral'`), not channel noise, so it stays as-is.
- Does not change Discord: Discord treats threads as channels, so the exact-key path already resolves there; its interaction ack (also ephemeral) is unchanged.
- Does not touch `/reload` or `/restart`: they resolve a session best-effort via `wantsLiveSession` (not `requiresLiveSession`) only to stamp a resume handoff, so the stop-specific activeness gate does not apply to them.

## Review notes

- The `key.thread !== null` early-return in `resolveLiveSessionForCommand` is the load-bearing change. Existing tests "falls back to a thread-keyed session when slash command carries thread:null" and "returns ambiguous when multiple thread-keyed sessions match" still pass unchanged, confirming the slash-command path is preserved.
- New regression coverage: an observe-only exact-thread session no longer aborts and reports `no-live-session`; draining and queued exact-thread sessions still report `handled`; a thread-keyed `/stop` no longer falls back to a different-thread or channel-level session.
- Several existing `executeCommand` tests were updated to hold the turn in-flight (draining) when asserting `handled`, since an idle session now correctly returns `no-live-session`.

This is companion to the Slack-side fix in the second commit on this branch (`fix(channels): keep bystander agents silent on !stop in Slack threads`), which stops posting a public "Nothing to stop" reply when this resolver reports `no-live-session`.
