### PR TITLE
feat(reviewer): review the PR title and body as a record, not just context

### DIFF
--- a/src/bundled-plugins/reviewer/reviewer.test.ts
+++ b/src/bundled-plugins/reviewer/reviewer.test.ts
@@ -291,6 +291,28 @@ describe('reviewer skill content', () => {
     expect(lower).toContain('already-acknowledged gaps')
   })
 
+  test('code-review skill reviews the PR title/body as a first-class artifact, not just context (drift guard)', () => {
+    // The core behavior of this skill's PR-record dimension: the title/body is a
+    // review target in its own right (a record of the why), and the reviewer must
+    // catch a diff change whose rationale is silently dropped. Without these, the
+    // section can be neutralized back to "body is only input to verify code against".
+    const lower = CODE_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('review the pr title and body as an artifact')
+    expect(lower).toContain('a pr is a record')
+    expect(lower).toContain('rationale for every meaningful change')
+    expect(lower).toContain('meaning-unit separation')
+  })
+
+  test('code-review skill reconciles restating-vs-reviewing the description as echo-vs-evaluate (drift guard)', () => {
+    // The load-bearing reconciliation: the new PR-body review must not collide with
+    // the pre-existing "restating the change description = noise" rule. The distinction
+    // is echo (noise) vs. evaluate (in scope). Without this the two sections read as a
+    // direct contradiction and the new dimension gets suppressed as restatement.
+    const lower = CODE_REVIEW_SKILL.content.toLowerCase()
+    expect(lower).toContain('echo vs. evaluate')
+    expect(lower).toContain('do not confuse restating the description with reviewing it')
+  })
+
   test('code-review skill demands blast-radius + pinned evidence on findings (drift guard)', () => {
     // A line anchor says where; these say how far it reaches and where the evidence lives.
     const lower = CODE_REVIEW_SKILL.content.toLowerCase()

--- a/src/bundled-plugins/reviewer/skills/code-review.ts
+++ b/src/bundled-plugins/reviewer/skills/code-review.ts
@@ -3,7 +3,7 @@ import type { LoadableSkill } from '@/plugin'
 export const CODE_REVIEW_SKILL_NAME = 'code-review'
 
 export const CODE_REVIEW_SKILL_DESCRIPTION =
-  'Review code: a pull request, a commit, a single file, or a module. Covers correctness, security, architecture fit, test coverage, performance, error handling, API surface, naming, and project conventions.'
+  'Review code: a pull request, a commit, a single file, or a module. Covers correctness, security, architecture fit, test coverage, performance, error handling, API surface, naming, project conventions, and the PR title/body itself as a record — whether it captures the why behind each change for future readers.'
 
 export const CODE_REVIEW_SKILL_CONTENT = `# code-review
 
@@ -55,6 +55,26 @@ A finding without context is noise. Before forming findings:
 3. **Read the project's conventions.** \`AGENTS.md\`, \`CONTRIBUTING.md\`, \`CLAUDE.md\`, \`README.md\`, the test layout, the linter config. Deviation from established convention is a finding worth raising; following convention is not worth praising.
 4. **Read the tests.** Existing tests show what the project considers important to verify. New tests show what the author considers important to lock in. The gap between them is often where the bugs hide.
 
+## Review the PR title and body as an artifact, not just as context
+
+Steps above use the PR title and body as *input* — the author's stated intent, which you check the code against. But the description is also a **deliverable in its own right, and it is part of your review scope.** Most harnesses only diff code and never review the prose; you are the one pass that can, so treat the title and body as a first-class review target alongside the diff.
+
+Why this matters — the frame that decides your findings here:
+
+- **A PR is a record, not a showcase.** Its dominant purpose is not to display the code or even to solicit code review — it is to **record the translation from the business need into the code change**: *why* this change became necessary, what business or product context forced it, what decision was made and what was rejected. The code shows *what* changed; the body is the only place *why* survives. When the why is absent, it is gone the moment the author forgets it.
+- **The audience is the reviewer and future-self, who do NOT share the author's context.** The current reviewer, a teammate six months from now, or the author themselves later, all read this record under real cognitive load, missing the context that was obvious the day it was written. A good body exists to *lower that load*. Judge the body by whether a reader without the author's head can reconstruct why each change was made.
+- **The concrete failure is a change whose context is silently dropped.** A large task drags in incidental side changes; the low-importance ones lose their rationale first, and later someone does redundant or wrong work because the record never explained the earlier decision (e.g. a field added in one PR with no note that it duplicates an existing one, so a later PR "fixes" a problem that was actually intentional). This is the highest-value thing to catch: a change in the diff that the body leaves **unexplained or unconnected to its reason**.
+
+What to look for in the title and body:
+
+1. **Rationale for every meaningful change, not just the headline one.** The primary change is usually explained. The finding is the *secondary* change — a schema tweak, a config flip, a "while I was here" refactor, a new field — that appears in the diff with no corresponding why in the body. Anchor the finding to the diff hunk whose rationale is missing, and name what a future reader would fail to reconstruct.
+2. **Title accuracy and scope match.** Does the title name what the change actually does? Does the body's described scope match the diff — nothing significant in the diff that the body never mentions, and nothing promised in the body that the diff never delivers? A title that says A while the diff also does B is a scope/record defect: the B change is now unfindable by anyone searching the history for it.
+3. **Meaning-unit separation.** When the diff bundles several unrelated logical changes under one description, the context for each is harder to recover and the record is degraded even if every line is correct. Flag it as a record problem — the fix may be to split the PR, or at minimum to give each logical unit its own explained section in the body — not as a code defect.
+4. **Decision and trade-off capture.** For a change that chose one approach over an obvious alternative, or that is a deliberate one-way door (schema, public API, migration), does the body record the decision and why? A silent irreversible decision is a record gap worth raising even when the code is correct.
+5. **Linked context integrity.** Referenced issues/tickets/prior PRs actually correspond to this change; a load-bearing claim in the body ("as decided in #123") points where it says it does. A dangling or wrong reference breaks the record's chain.
+
+Keep the anti-noise line from below firmly in view: **do not confuse restating the description with reviewing it.** Summarizing what the PR does back to the author is noise (see "What NOT to find"). The review work here is the *gap* — a change with no recorded reason, a title that misleads, a bundled scope that buries context, a decision left unexplained. Anchor these to the specific diff hunk or the quoted body passage; use \`location="general"\` only for a whole-description defect (e.g. an empty body on a non-trivial change) and say why in the \`<issue>\`. Calibrate severity to consequence, not to prose taste: an unexplained behavior-changing hunk or a title that hides a real change is a \`concern\` (a \`blocker\` when the missing context is what stops a future reader from avoiding a concrete mistake); a thin-but-adequate body is at most a \`nit\`. A body's writing quality is not the target — its function as a record is.
+
 ## What to look for
 
 Prioritize in this order:
@@ -77,7 +97,7 @@ Prioritize in this order:
 - **Settled convention objections.** If the project uses tabs, four-space indent, camelCase vs snake_case, etc., and the change matches, that is not a finding. Only the deviation is.
 - **Generic best-practice essays.** "Consider adding more tests" without naming a specific untested branch is noise. "Improve error handling" without pointing at a specific swallowed error is noise.
 - **Restating the code.** "This function reads the file and returns its contents" is not a finding.
-- **Restating the change description.** Summarizing what the PR does back to its author — "this PR adds caching to the user lookup" — is not a review. They wrote the description; they know.
+- **Restating the change description.** Summarizing what the PR does back to its author — "this PR adds caching to the user lookup" — is not a review. They wrote the description; they know. (This forbids *echoing* the body, not *reviewing* it: judging whether the body records the why, matches the diff, and separates its meaning units is in scope — see "Review the PR title and body as an artifact". The line is echo vs. evaluate.)
 - **Already-acknowledged gaps.** A weakness the author already flagged with a \`TODO\`/\`FIXME\` in the diff, or named in the PR body as out of scope, is not a finding — they're already aware. Only raise it if you have new information: the gap is worse than they think, or it's a blocker they've mislabeled as deferrable. Say which.
 
 ## Severity hints specific to code


### PR DESCRIPTION
## Background

The bundled `reviewer` subagent's `code-review` skill already fetches the PR title and body (`gh pr view --json title,body,...`), but only ever uses them **one way**: as the author's stated intent, which the reviewer checks the *code* against ("the author told you what they intended — verify the code matches"). The description itself was never a review target — no pass ever asked whether the body does its own job.

That job is not cosmetic. A PR is fundamentally a **record**: its dominant purpose is to capture the translation from a business need into a code change — *why* this change became necessary, what was decided, what was rejected. The diff shows *what* changed; the body is the only place *why* survives once the author forgets it. Its real audience is the reviewer today and the teammate (or the author) six months from now, who all read it missing the context that was obvious the day it was written.

The concrete, recurring failure this leaves unguarded: a large task drags in an incidental side change, the low-importance change loses its rationale first, and later someone does redundant or wrong work because the record never explained the earlier decision — e.g. a field added in one PR with no note that it duplicates an existing one, so a later PR "fixes" a problem that was actually intentional. Our harness diffs code and never reviews prose, so the reviewer is the *only* pass positioned to catch this — and it wasn't looking.

## Summary

Bring the PR title and body into the `code-review` skill's scope as a **first-class artifact**, reviewed alongside the diff.

A new section — "Review the PR title and body as an artifact, not just as context" — frames the check around the PR-as-record view and gives the reviewer five concrete things to look for:

1. **Rationale for every meaningful change** — the finding is the *secondary* change (schema tweak, config flip, "while I was here" refactor) that appears in the diff with no corresponding *why* in the body.
2. **Title accuracy and scope match** — the title/body describes what the diff actually does; nothing significant in the diff goes unmentioned, nothing promised goes undelivered.
3. **Meaning-unit separation** — unrelated logical changes bundled under one description degrade the record even when every line is correct.
4. **Decision and trade-off capture** — a chosen-over-alternative or one-way-door decision (schema, public API, migration) is recorded.
5. **Linked-context integrity** — referenced issues/PRs actually correspond to this change.

**Why reconcile the anti-noise rule (the one non-additive edit):** the skill's "What NOT to find" list forbids "Restating the change description," and the reviewer's `<summary>` contract says the same. Left as-is, the new section would read as a direct contradiction. The fix draws the line as **echo vs. evaluate**: *echoing* the body back to its author is still noise; *evaluating* whether the body records the why, matches the diff, and separates its meaning units is the new in-scope work. Severity is calibrated to consequence, not prose taste — an unexplained behavior-changing hunk is a `concern`/`blocker`, a thin-but-adequate body is at most a `nit`.

The Korean anchors (`기록물`, `의미 단위 구분`) sit as parentheticals beside the English framing — consistent with the repo's multi-language ethos and the vocabulary the concept originates from — not as the sole phrasing.

## What this does NOT do

- **No runtime, tool, or contract change.** Prose-only edit to `CODE_REVIEW_SKILL_CONTENT` plus its one-line description. No new tool, no schema change, no change to the universal `<review>` output shape or verdict vocabulary.
- **Does not turn the reviewer into a prose editor.** A body's *writing quality* is explicitly not the target — only its function as a record.
- **Does not touch the peer skills** (`plan-review`, `doc-review`, etc.), the reviewer system prompt, or `REVIEWER_SKILLS` registration.

## Review notes

- The load-bearing edit is the **echo-vs-evaluate reconciliation** at the "Restating the change description" bullet — verify the new section and that bullet read as coherent, not contradictory.
- Additive to the skill content, so the `reviewer.test.ts` drift-guards (which assert on `CODE_REVIEW_SKILL.content` substrings) still hold. Full suite green: `10800 pass, 0 fail`; `typecheck`, `lint` (0 errors), `format:check` all clean.
