### PR TITLE
fix(channels): recover dropped continuation turns + casual-register acks across languages

### DIFF
--- a/src/channels/continuation-willingness.test.ts
+++ b/src/channels/continuation-willingness.test.ts
@@ -33,6 +33,19 @@ describe('detectContinuationWillingness — positive (self-directed future inten
     '검토해볼게요',
     '찾아볼게요',
     '바로 처리할게요',
+    // Casual (banmal) -ㄹ게 volitional — the same first-person promise WITHOUT the
+    // polite -요. A persona that speaks informally ("확인해볼게!") hit nothing
+    // because every KO entry was polite-form; the morpheme pass now covers both.
+    // The first entry mirrors the production ack that ended a Discord turn in silence.
+    '확인해볼게! GitHub 접근이랑 gh 인증 기준으로 둘 다 빠르게 봐볼게',
+    '확인해볼게',
+    '살펴볼게',
+    '검토해볼게',
+    '찾아볼게',
+    '계속 진행할게',
+    '바로 처리할게',
+    '업데이트할게',
+    '수정할게',
     // Action/config verb family (English) — "I'll DO X" promises beyond the
     // retrieval verbs. The cron-update production miss is the canonical case.
     "I'll update the cron timing logic.",
@@ -144,6 +157,13 @@ describe('detectContinuationWillingness — negative (final / descriptive / othe
     // other-directed requests and descriptive progressives, not self-intent.
     '바로 확인 부탁드려요.',
     '계속 확인 중입니다.',
+    // Casual (banmal) idiomatic -겠어 acks — 알겠어 = "got it", 모르겠어 = "dunno".
+    // The verb-anchored volitional regex must not read these casual forms as work
+    // promises, exactly as it excludes their polite -겠어요/-겠습니다 siblings.
+    '알겠어, 고마워!',
+    '잘 모르겠어.',
+    // Descriptive casual past — an already-done report, not a promise to act.
+    '이미 확인했어, 문제 없어.',
     '',
     '...',
   ]

--- a/src/channels/continuation-willingness.test.ts
+++ b/src/channels/continuation-willingness.test.ts
@@ -131,6 +131,80 @@ describe('detectContinuationWillingness — positive (multilingual self-directed
   }
 })
 
+describe('detectContinuationWillingness — positive (casual / informal register across languages)', () => {
+  const willing: readonly string[] = [
+    // English contractions/slang
+    'lemme dig into the logs',
+    'imma check the config',
+    'gonna check the diff now',
+    'ima look at the rest',
+    'let me go check the tests',
+    'gimme a sec',
+    // Spanish casual (déjame ver/checar, ya lo + present, checar)
+    'déjame ver los otros archivos',
+    'déjame checar eso',
+    'ya lo reviso y te digo',
+    'ahora mismo reviso los logs',
+    // French casual (check anglicism, laisse-moi voir, je m'en charge)
+    'je check ça tout de suite',
+    'laisse-moi voir le reste',
+    "je m'en charge maintenant",
+    // Italian casual (fammi vedere, vedo subito, ci guardo io)
+    'fammi vedere il resto',
+    'vedo subito i log',
+    'ci guardo io adesso',
+    // Portuguese casual (vou ver, deixa eu ver/checar, deixa comigo)
+    'vou ver isso agora',
+    'deixa eu ver os arquivos',
+    'deixa comigo, já checo',
+    // German casual (ich schau mal, ich guck nach, ich kümmere mich)
+    'ich schau mal nach',
+    'ich guck nach den logs',
+    'ich kümmere mich darum',
+    'das übernehm ich',
+    // Russian colloquial (щас/гляну + perfective)
+    'щас гляну логи',
+    'сейчас гляну остальное',
+    'дай гляну быстро',
+    'щас разберусь с этим',
+    // Chinese spoken (去/来 + verb)
+    '我去看下日志',
+    '我来处理这个',
+    '我去核实一下',
+    // Arabic colloquial (راح/رح/هـ future, خليني)
+    'راح أشوف الباقي',
+    'رح أتأكد من هالشي',
+    'خليني أشوف الكود',
+    // Hindi casual (अभी + habitual, completive ले)
+    'अभी देखता हूँ',
+    'मैं देख लेता हूँ',
+    'जरा देखता हूँ बाकी फाइलें',
+    // Turkish optative (-eyim/-ayım)
+    'şuna bakayım',
+    'bir göz atayım',
+    'şimdi bakayım hemen',
+    // Vietnamese casual/Southern (coi, thử)
+    'để tôi coi thử',
+    'coi thử cái này',
+    'tôi coi thử phần còn lại',
+    // Indonesian casual (coba/dulu/aja)
+    'coba saya cek dulu',
+    'saya liat dulu ya',
+    'saya cek sekarang',
+    // Japanese plain form (particle-anchored)
+    '確認するね',
+    '調べとくね、ちょっと待って',
+    '見てみるね',
+    'すぐ見るね',
+  ]
+
+  for (const text of willing) {
+    test(`detects: ${JSON.stringify(text)}`, () => {
+      expect(detectContinuationWillingness(text)).toBe(true)
+    })
+  }
+})
+
 describe('detectContinuationWillingness — negative (final / descriptive / other-directed)', () => {
   const notWilling: readonly string[] = [
     'Done. The diff looks good, no issues.',
@@ -201,6 +275,37 @@ describe('detectContinuationWillingness — negative (multilingual final / descr
     'どうしますか？',
     'どうします？',
     '更新します？',
+  ]
+
+  for (const text of notWilling) {
+    test(`ignores: ${JSON.stringify(text)}`, () => {
+      expect(detectContinuationWillingness(text)).toBe(false)
+    })
+  }
+})
+
+describe('detectContinuationWillingness — negative (casual-register false-positive guards)', () => {
+  // Ambiguous casual forms deliberately EXCLUDED when the casual tables were widened:
+  // bare present that reads descriptive, other-directed imperatives, and short forms
+  // that collide. Each asserts the widening did not overreach past the false-negative bias.
+  const notWilling: readonly string[] = [
+    // Bare present-as-descriptive (no temporal/volitional anchor) — omitted on purpose
+    'je regarde les résultats maintenant',
+    'guardo la TV',
+    'saya cek email tiap pagi',
+    // Present-continuous = "I'm doing it now", descriptive not future
+    'şimdi bakıyorum ekrana',
+    // Other-directed imperatives ("you look" / "let's see what happens")
+    'baksana şuna',
+    '你看看这个文件',
+    'để coi sao đã',
+    // Chinese 2-char descriptive that must not fire ("I see you're right" / receipt ack)
+    '我看你说得对',
+    '我查收了邮件',
+    // Japanese bare dictionary form (no committing particle) stays out
+    '確認する',
+    // Arabic other-directed ("do YOU want to look?")
+    'بدك أشوف هالشي',
   ]
 
   for (const text of notWilling) {

--- a/src/channels/continuation-willingness.ts
+++ b/src/channels/continuation-willingness.ts
@@ -91,6 +91,17 @@ const EN_PHRASES: readonly string[] = [
   'let me add',
   'let me create',
   'let me handle',
+  // Casual/contracted acks chat models emit. "imma"/"ima"/"gonna" are the
+  // spoken-future contractions; in an assistant reply "gonna VERB" is self-directed
+  // (a rival "you're gonna" is other-directed and never a willingness signal here).
+  'lemme dig',
+  'imma check',
+  'gonna check',
+  'gonna look',
+  'ima look',
+  'let me go check',
+  'let me peek',
+  'gimme a sec',
 ]
 
 // Korean: the -겠습니다/-겠어요 and -ㄹ게(요) verb endings are first-person
@@ -182,6 +193,21 @@ const ES_PHRASES: readonly string[] = [
   'voy a aplicar',
   'déjame actualizar',
   'déjame corregir',
+  // Casual register: "déjame ver/checar" (the colloquial twins of the déjame-forms
+  // above), and "ya lo"/"ahora mismo" + bare present, whose temporal anchor pins the
+  // present-as-future so it can't read as the descriptive "reviso [cada mañana]".
+  // "checar" is the LatAm colloquial for "revisar".
+  'déjame ver',
+  'déjame checar',
+  'ya lo reviso',
+  'lo reviso ya',
+  'ya lo checo',
+  'lo checo ya',
+  'me pongo a revisar',
+  'ahora mismo reviso',
+  'voy a darle un vistazo',
+  'reviso y te digo',
+  'lo checo enseguida',
 ]
 
 // French: "je vais" + work verb; "laisse-moi" idioms.
@@ -214,6 +240,17 @@ const FR_PHRASES: readonly string[] = [
   'je vais appliquer',
   'laisse-moi corriger',
   'laisse-moi mettre à jour',
+  // Casual: the "check" anglicism (not a native French word, so zero descriptive
+  // ambiguity), "laisse-moi voir" (colloquial twin of laisse-moi vérifier),
+  // present+"rapidement" (the adverb forces future intent), and "je m'en charge"
+  // ("I'll take charge of it"). Bare "je regarde"/"je vérifie" are deliberately
+  // omitted — present tense alone reads as descriptive "I'm looking [right now]".
+  'je check ça',
+  'laisse-moi voir',
+  'je vais checker',
+  'je regarde rapidement',
+  'je vérifie rapidement',
+  "je m'en charge",
 ]
 
 // Italian: "vado a" / "fammi" + work verb; "controllo subito" idioms.
@@ -243,6 +280,16 @@ const IT_PHRASES: readonly string[] = [
   'vado ad applicare',
   'fammi aggiornare',
   'fammi correggere',
+  // Casual: "fammi vedere" (colloquial twin of fammi controllare), present+"subito"/
+  // "adesso" (temporal anchor forces future), "vado a vedere", and "ci guardo io"
+  // (the "io" makes it emphatically self-directed). Bare "controllo"/"guardo" are
+  // omitted — present alone reads descriptive ("guardo la TV" = I'm watching TV).
+  'fammi vedere',
+  'vedo subito',
+  'vado a vedere',
+  'ci guardo io',
+  'controllo adesso',
+  'verifico adesso',
 ]
 
 // Portuguese: "vou" + work verb; "deixa eu" idioms.
@@ -273,6 +320,18 @@ const PT_PHRASES: readonly string[] = [
   'vou aplicar',
   'deixa eu atualizar',
   'deixa eu corrigir',
+  // Casual (BR-leaning): "vou ver" (the most common informal ack), "deixa eu ver/
+  // checar" and "deixa que eu vejo" (colloquial "let me"), "deixa comigo" ("leave it
+  // to me"), and "já vou ver"/"já dou uma olhada"/"...agora" (the já/agora temporal
+  // anchor forces future). "checar" is the BR colloquial for "verificar".
+  'vou ver',
+  'deixa eu ver',
+  'deixa eu checar',
+  'deixa comigo',
+  'já vou ver',
+  'verifico agora',
+  'deixa que eu vejo',
+  'já dou uma olhada',
 ]
 
 // German: "ich werde" / "lass mich" + work verb; "ich schaue gleich" idioms.
@@ -307,6 +366,22 @@ const DE_PHRASES: readonly string[] = [
   'ich werde anwenden',
   'lass mich aktualisieren',
   'lass mich korrigieren',
+  // Casual: present-as-future with the "mal"/"kurz"/"nach" particles ("ich schau
+  // mal", "ich guck nach"), the V2-inverted "schau ich mir" (word order flags 1sg),
+  // the Germanized "ich check das", and the take-responsibility forms ("ich kümmere
+  // mich", "das übernehm ich", "ich nehm das"). Bare "ich schau" is omitted — it also
+  // fits "ich schau dir zu" (I'm watching you), which is not a work promise.
+  'ich schau mal',
+  'ich guck mal',
+  'ich schau nach',
+  'ich guck nach',
+  'schau ich mir',
+  'ich kümmere mich',
+  'ich check das',
+  'das übernehm ich',
+  'ich nehm das',
+  'ich geh das checken',
+  'ich schau kurz',
 ]
 
 // Russian: first-person-future verbs (проверю/посмотрю/продолжу) — the -ю/-у
@@ -334,6 +409,24 @@ const RU_PHRASES: readonly string[] = [
   'я применю',
   'сейчас обновлю',
   'сейчас исправлю',
+  // Colloquial: "щас" is the ubiquitous informal spelling of "сейчас"; "гляну" is
+  // bare 1sg perfective of глянуть — morphologically locked to "I will" (2sg is
+  // глянешь, 3sg глянет), so it's self-directed even without a pronoun. All entries
+  // pair a 1sg-perfective verb (гляну/посмотрю/проверю/разберусь/сделаю/поправлю)
+  // with щас/сейчас/дай, none of which can read as descriptive or other-directed.
+  'гляну',
+  'щас гляну',
+  'сейчас гляну',
+  'щас посмотрю',
+  'щас проверю',
+  'дай гляну',
+  'дай посмотреть',
+  'сейчас разберусь',
+  'щас разберусь',
+  'сейчас сделаю',
+  'щас сделаю',
+  'сейчас поправлю',
+  'щас поправлю',
 ]
 
 // Chinese: 我会/我来/我再 + work verb. Full multi-character intent phrases only;
@@ -371,6 +464,17 @@ const ZH_PHRASES: readonly string[] = [
   '我马上更新',
   '让我更新',
   '让我改一下',
+  // Casual/spoken: 去+verb (我去看下/我去核实) and 来+verb (我来处理/我来瞧瞧) mark quick
+  // self-initiated action. Entries are ≥4 chars ending in a volitional suffix. The
+  // 2-char 我看/我查 are omitted (descriptive 我看你说的对 = "I see you're right"), and
+  // the 3-char reduplications 我看看/我查查 are omitted too: they fall under MIN_LENGTH
+  // as standalone acks, and embedded they risk the past-narrative 我看看了 ("I glanced").
+  '我去看下',
+  '我来处理',
+  '我搜一下',
+  '我确认下',
+  '我去核实',
+  '我来瞧瞧',
 ]
 
 // Japanese: handled by the JA_VOLITIONAL morpheme check below (-します/-いたします/
@@ -384,6 +488,24 @@ const JA_PHRASES: readonly string[] = [
   '続けます',
   '少々お待ちください',
   'ちょっと待ってください',
+  // Casual plain form (タメ口), particle-anchored. Bare dictionary forms (見る/確認する)
+  // are the SAME as descriptive present and far too ambiguous, so each entry pins a
+  // work verb to a self-commitment sentence-final particle: 〜ね (volitional), 〜わ
+  // (soft assertion), or the 〜とく/〜てくる/〜てみる auxiliaries that already imply
+  // "I'll take care of / go do / try". 〜よ is excluded (it can be merely informational).
+  '確認するね',
+  '調べるね',
+  '見てみるね',
+  '確認しとくね',
+  '調べとくね',
+  'チェックしとくね',
+  '見とくね',
+  '見てみるわ',
+  '調べてみるね',
+  '確認してみるね',
+  '見てくるね',
+  '調べてくるね',
+  'すぐ見るね',
 ]
 
 // Arabic: future particle سـ prefixed first-person verb (سأتحقق = "I will
@@ -409,12 +531,45 @@ const AR_PHRASES: readonly string[] = [
   'سأصلح',
   'سأنشئ',
   'سأضيف',
+  // Colloquial dialects: explicit future markers راح/رح (Gulf/Levantine) and هـ
+  // (Egyptian) + verb, plus خليني ("let me") and بدي ("I want to", Levantine
+  // volitional). Bare بشوف is omitted — بـ+imperfect is present-habitual in some
+  // dialects, so it can read descriptive. شيك only appears prefixed (هاشيك/راح أشيك)
+  // so it can't collide with the noun شيك ("cheque").
+  'راح أشوف',
+  'رح أشوف',
+  'هشوف',
+  'هأشوف',
+  'خليني أشوف',
+  'رح أتأكد',
+  'هاشيك',
+  'راح أشيك',
+  'رح أتحقق',
+  'بدي أشوف',
+  'هجيب المعلومة',
+  'راح أراجع',
 ]
 
 // Hindi: first-person-future is the -ūṅgā/-ūṅgī suffix, matched by
 // MORPHEME_PATTERNS below (it covers all X-करना compounds). Only the stall idiom
 // is enumerated here.
-const HI_PHRASES: readonly string[] = ['एक मिनट रुकिए']
+// Casual Hindi uses the habitual present (देखता हूँ) for immediate intent, but only
+// with an immediacy anchor (अभी "now", जरा "just") or the completive ले, which mark
+// volition; bare देखता हूँ / करता हूँ are omitted (descriptive "I'm looking / I do").
+// Both genders (-ता/-ती) are listed since the ending marks speaker gender. The formal
+// -ऊँगा future is already covered by MORPHEME_PATTERNS. एक मिनट रुकिए is the stall idiom.
+const HI_PHRASES: readonly string[] = [
+  'एक मिनट रुकिए',
+  'अभी देखता हूँ',
+  'देख लेता हूँ',
+  'मैं देख लेता हूँ',
+  'अभी चेक करता हूँ',
+  'चेक कर लेता हूँ',
+  'अभी देख लेता हूँ',
+  'जरा देखता हूँ',
+  'देख लेती हूँ',
+  'चेक कर लेती हूँ',
+]
 
 // Turkish: first-person-future "-eceğim/-acağım" is matched by MORPHEME_PATTERNS
 // below. The present-progressive ("ediyorum" = "I'm checking now"), optative
@@ -429,6 +584,16 @@ const TR_PHRASES: readonly string[] = [
   'hemen bakıyorum',
   'bir saniye',
   'bir dakika',
+  // Casual: the -eyim/-ayım optative ("let me VERB") is the safest volition anchor
+  // (bakayım/edeyim/atayım/inceleyeyim); the -ır/-ar aorist (bakarım) is only added
+  // with hemen/şimdi to force future over habitual. -yor present-continuous
+  // (bakıyorum) is NOT extended — it's descriptive "I'm looking [now]". baksana is
+  // excluded (imperative "look!", other-directed).
+  'şuna bakayım',
+  'bir inceleyeyim',
+  'bir göz atayım',
+  'şimdi bakayım',
+  'hemen bakarım',
 ]
 
 // Vietnamese: "tôi sẽ" / "để tôi" (I will / let me) + work verb.
@@ -450,6 +615,16 @@ const VI_PHRASES: readonly string[] = [
   'tôi sẽ thêm',
   'để tôi cập nhật',
   'để tôi sửa',
+  // Casual/Southern: "coi" is the Southern colloquial for "xem" (look); "thử" (try)
+  // is a strong volition marker, so coi/xem/kiểm tra + thử are safe. Bare "để coi" is
+  // omitted — it can mean "let's see [what happens]" (观望), not a work promise.
+  'coi thử',
+  'để tôi coi',
+  'xem thử',
+  'tôi coi thử',
+  'kiểm tra thử',
+  'coi một lúc',
+  'để tôi coi thử',
 ]
 
 // Indonesian: "saya akan" / "biar saya" (I will / let me) + work verb.
@@ -474,6 +649,22 @@ const ID_PHRASES: readonly string[] = [
   'saya akan tambah',
   'biar saya perbaiki',
   'biar saya perbarui',
+  // Casual/spoken: "coba" (let/try) leads a volitional; "dulu"/"aja"/"sekarang" anchor
+  // the bare present as imminent ("saya cek dulu" = "I'll check first"). "liat" is the
+  // casual "lihat". Bare "saya cek"/"saya liat" are omitted (present/past ambiguous),
+  // and the Javanese "tak" prefix is excluded (3-char substring collides with takut
+  // "afraid", menata "arrange").
+  'coba saya cek',
+  'saya cek dulu',
+  'liat dulu',
+  'saya liat dulu',
+  'coba saya liat',
+  'saya cek aja',
+  'liat dulu ya',
+  'saya cek sekarang',
+  'saya bantu cek',
+  'saya usahakan cek',
+  'liat sebentar',
 ]
 
 const ALL_PHRASES: readonly string[] = [

--- a/src/channels/continuation-willingness.ts
+++ b/src/channels/continuation-willingness.ts
@@ -93,43 +93,44 @@ const EN_PHRASES: readonly string[] = [
   'let me handle',
 ]
 
-// Korean: the -겠습니다/-겠어요 and -ㄹ게요 verb endings are first-person
+// Korean: the -겠습니다/-겠어요 and -ㄹ게(요) verb endings are first-person
 // volitional — they cannot address the listener, so they are safe self-direction
 // anchors. The -겠습니다/-겠어요 form is matched by MORPHEME_PATTERNS below (it
-// generalizes across all action verbs), so only the -게요/-게여 forms and stall
-// idioms are enumerated here. Bare adverb+noun fragments ("바로 확인", "계속 확인",
-// "곧 알려") are deliberately NOT listed: without the volitional ending they match
-// other-directed requests ("바로 확인 부탁드려요" = "please check") and descriptive
-// progressives ("계속 확인 중입니다" = "I'm still checking") — the exact false
-// positives the design forbids. Their volitional forms are caught by the morpheme
-// regex regardless.
+// generalizes across all action verbs), so only the -ㄹ게 forms and stall idioms
+// are enumerated here. Each entry is the CASUAL (banmal) -게 base; the polite -게요
+// / -게여 forms match too because the substring pass tests `includes` (볼게 ⊂
+// 볼게요). Enumerating the casual base is deliberate over a broad `[ㄹ-final]게`
+// morpheme regex: that would also fire on the adverbial -게 of adjective stems
+// (힘들게 "hard-ly", 멀게 "far-ly", 길게 "long-ly"), violating the file's
+// prefer-false-negatives bias. Bare adverb+noun fragments ("바로 확인", "계속 확인")
+// are still excluded: without the -게 volitional they match other-directed requests
+// ("바로 확인 부탁드려요" = "please check") and descriptive progressives ("계속 확인
+// 중입니다" = "I'm still checking"). The persona speaking banmal ("확인해볼게!") was
+// the production miss that closed a Discord turn in silence.
 const KO_PHRASES: readonly string[] = [
-  '확인해볼게요',
-  '확인해 볼게요',
-  '확인할게요',
-  '확인할게여',
-  '계속 진행할게요',
-  '계속할게요',
-  '바로 볼게요',
-  '살펴볼게요',
-  '볼게요',
-  '볼게여',
-  '검토할게요',
-  '검토해볼게요',
-  '조회해볼게요',
-  '찾아볼게요',
-  '알아볼게요',
-  '처리할게요',
-  '알려드릴게요',
-  // Action/config verb -게요 forms (the -겠습니다 siblings are covered by the
-  // morpheme regex; these are the casual-polite variants chat models also emit).
-  '업데이트할게요',
-  '수정할게요',
-  '설정할게요',
-  '반영할게요',
-  '적용할게요',
-  '추가할게요',
-  '생성할게요',
+  '확인해볼게',
+  '확인해 볼게',
+  '확인할게',
+  '계속 진행할게',
+  '계속할게',
+  '살펴볼게',
+  '볼게',
+  '검토할게',
+  '검토해볼게',
+  '조회해볼게',
+  '찾아볼게',
+  '알아볼게',
+  '처리할게',
+  '알려드릴게',
+  // Action/config verb -게 forms (the -겠습니다 siblings are covered by the
+  // morpheme regex; these are the casual/casual-polite variants chat models emit).
+  '업데이트할게',
+  '수정할게',
+  '설정할게',
+  '반영할게',
+  '적용할게',
+  '추가할게',
+  '생성할게',
   '잠시만요',
   '잠깐만요',
 ]

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -12851,6 +12851,163 @@ describe('ChannelRouter channel_send willingness nudge', () => {
   })
 })
 
+describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)', () => {
+  function continueReplyContext(replyText: string): AfterToolCallContext {
+    return {
+      assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
+      toolCall: {
+        type: 'toolCall',
+        id: 'tc1',
+        name: 'channel_reply',
+        arguments: { text: replyText },
+      } as AfterToolCallContext['toolCall'],
+      args: { text: replyText },
+      result: {
+        content: [{ type: 'text' as const, text: 'ignored' }],
+        details: { ok: true, continue: true },
+      } as AfterToolCallContext['result'],
+      isError: false,
+      context: { systemPrompt: '', messages: [], tools: [] },
+    }
+  }
+
+  // Reproduce the production order for a channel_reply({ continue: true }): the tool's
+  // execute() calls router.send() (which bumps successfulChannelSends) BEFORE the
+  // runtime fires afterToolCall (which stamps continueReplyTurn with that post-send
+  // count). Then install a fresh empty-stop-after-tool-work leaf — the degeneration.
+  async function continueReplyThenStrand(
+    session: FakeSession,
+    router: ChannelRouter,
+    ackText: string,
+    id: string,
+  ): Promise<void> {
+    await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: ackText })
+    await session.agent.afterToolCall!(continueReplyContext(ackText))
+    emptyStopAfterToolWork(session, id)
+  }
+
+  test('recovers a continue:true ack whose phrasing is OUTSIDE the willingness table', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'persona 파일들 좀 봐줘' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      attempt++
+      if (attempt === 1) {
+        // given: a continue:true progress ack with NO willingness phrase (casual
+        // Korean "훑어볼게" is not in the phrase table), then tool work, then a
+        // fresh empty stop — the phrase-gated path can't see this promise.
+        await continueReplyThenStrand(sessions[0]!, router, '응 persona 흔적 파일들 훑어볼게', String(attempt))
+        return
+      }
+      // then: the flag-gated recovery re-prompts, and the model delivers the answer
+      expect(text).toContain(SEND_WILLINGNESS_NUDGE)
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'persona 파일 3개 찾았어.' })
+      sessions[0]!.setAssistantText('')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent).toEqual(['응 persona 흔적 파일들 훑어볼게', 'persona 파일 3개 찾았어.'])
+    expect(
+      logs.some((m) => m.includes('send_willingness_nudge') && m.includes('cause=empty_stop_after_continue_reply')),
+    ).toBe(true)
+  })
+
+  test('posts the fallback instead of looping when the continue:true retry re-strands', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '확인해줘' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      // Every turn re-acks continue:true (distinct text to dodge the send dup-guard)
+      // and re-strands on an empty stop. Bound = MAX_WILLINGNESS_NUDGES: one nudge,
+      // then the visible fallback instead of silence.
+      await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${attempt})`, String(attempt))
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1 + MAX_WILLINGNESS_NUDGES)
+    expect(sent.filter((s) => s === EMPTY_TURN_FALLBACK_TEXT)).toHaveLength(1)
+    expect(
+      logs.some((m) => m.includes('empty_turn_fallback cause=empty_stop_after_continue_reply_nudges_exhausted')),
+    ).toBe(true)
+  })
+
+  test('does NOT recover when the continue:true ack leaf is unchanged since the send (ack-then-await-user)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ text: '확인 좀' }))
+    sessions[0]!.onPrompt = async () => {
+      // Install the leaf BEFORE the send so lastSendLeafId === the turn-end leaf:
+      // the model acked continue:true and stopped to await the user, no post-ack
+      // work — must stay on the historical no_reply path, not recover.
+      const entry: SessionEntry = {
+        type: 'message',
+        id: 'ack-leaf',
+        parentId: null,
+        timestamp: '2026-07-08T12:27:40.000Z',
+        message: { ...assistantMessage(''), content: [{ type: 'text', text: '' }], stopReason: 'stop' },
+      }
+      sessions[0]!.entriesById.set(entry.id, entry)
+      sessions[0]!.leafEntry = entry
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('바로 볼게'))
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '바로 볼게' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
+  })
+
+  test('does NOT recover when a substantive channel_send answered the user after the continue:true ack', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '레포 확인해줘' }))
+    sessions[0]!.onPrompt = async () => {
+      // given: continue:true ack (stamps continueReplyTurn with the ack's send count),
+      // tool work, then a SUBSTANTIVE channel_send final answer — which bumps
+      // successfulChannelSends past the stamped count — and finally a fresh empty stop.
+      // The user was already answered, so the trailing empty stop must NOT be nudged.
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '확인해볼게' })
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('확인해볼게'))
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'ADMIN 권한 있어, 접근 가능해.' })
+      emptyStopAfterToolWork(sessions[0]!, 'mixed')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(1)
+    expect(sent).toEqual(['확인해볼게', 'ADMIN 권한 있어, 접근 가능해.'])
+    expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
+    expect(sent.some((s) => s === EMPTY_TURN_FALLBACK_TEXT)).toBe(false)
+  })
+})
+
 describe('ChannelRouter output-token cap', () => {
   async function invokeStream(session: FakeSession, options: { maxTokens?: number } | undefined): Promise<void> {
     await session.agent.streamFn(

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -957,6 +957,18 @@ type LiveSession = {
   // turn can never trigger a nudge on a later one. `null` when no such reply
   // ended this turn.
   lastTerminalReplyAbort: { turnSeq: number; text: string } | null
+  // Stamped by `installChannelReplyTerminalHook` when a successful `channel_reply`
+  // set `continue: true` — the machine-readable "I'll keep working this turn"
+  // promise. `validateChannelTurn` reads it to recover a turn that made that promise,
+  // did more work, then ended on a fresh empty `stop` (dropped its conclusion) —
+  // independent of what natural-language phrase the ack used, so a persona speaking
+  // any language/register is covered where the willingness phrase table would miss.
+  // `turnSeq`-stamped so a stale promise can't fire on a later turn. `sendCount` is
+  // `successfulChannelSends` AT the ack (which already counts the ack itself); the
+  // recovery fires only while it still equals the live count — a later substantive
+  // send (e.g. a `channel_send` final answer) bumps the count and invalidates the
+  // promise, so an empty stop after the real answer is NOT re-nudged.
+  continueReplyTurn: { turnSeq: number; sendCount: number } | null
   // Stamped by router abort sites and read by `validateChannelTurn` for
   // reason-specific stranded-toolUse recovery logs. `turnSeq`-stamped so stale
   // abort provenance from an earlier turn can never leak into a later retry.
@@ -2114,6 +2126,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         emptyStopAfterToolWorkArmed: false,
         willingnessNudges: 0,
         lastTerminalReplyAbort: null,
+        continueReplyTurn: null,
         abortReasonThisTurn: null,
         nextPromptMaxTokens: undefined,
         skippedTurn: null,
@@ -2502,6 +2515,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const details = context.result.details as { ok?: unknown; continue?: unknown } | undefined
       const succeeded = context.toolCall.name === 'channel_reply' && !context.isError && details?.ok === true
       const keepTurnAlive = details?.continue === true
+      if (succeeded && keepTurnAlive) {
+        live.continueReplyTurn = { turnSeq: live.turnSeq, sendCount: live.successfulChannelSends }
+      }
       if (succeeded && !keepTurnAlive && agent.signal?.aborted !== true) {
         logger.info(`[channels] ${live.keyId} terminal_after_channel_reply`)
         const replyText = (context.toolCall.arguments as { text?: unknown } | undefined)?.text
@@ -2898,6 +2914,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.skipLockedSendTurn = null
         live.disengagedTurn = null
         live.emptyTurnFallbackTurn = null
+        live.continueReplyTurn = null
         live.policyDeniedToolSendsThisTurn.clear()
         resetReviewTurn(live.sessionId)
         const isRealUserTurn = batch.length > 0
@@ -4435,6 +4452,47 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     // landed — suppress it, as before.
     if (live.successfulChannelSends > successfulSendsBeforePrompt) {
       maybeNudgeContinuationWillingness(live)
+
+      // A `channel_reply({ continue: true })` progress ack landed this turn (the
+      // machine-readable "I'll keep working" promise — `continueReplyTurn` is stamped
+      // by installChannelReplyTerminalHook), the model did more work, then ended on a
+      // FRESH empty `stop` — dropping its conclusion. This is the SAME degeneration as
+      // the phrase-gated `channel_send` branch below, but keyed on the `continue: true`
+      // FLAG instead of a natural-language willingness phrase. The flag is the robust
+      // signal: it fires regardless of the ack's language or register, closing the gap
+      // where a persona speaking a phrasing outside the willingness table (e.g. casual
+      // Korean "확인해볼게") stranded the user in silence. The `attemptMadeToolCall`
+      // half ties the first trigger to real post-ack work; `willingnessNudges > 0`
+      // lets a retry that re-emitted `continue: true` and re-stranded spend the shared
+      // budget toward the visible fallback instead of bailing silent. Same
+      // MAX_WILLINGNESS_NUDGES bound, same empty-`promptQueue` gate (a coalesced live
+      // inbound supersedes this turn's silence), and same nudge/fallback path as the
+      // send-ack branch. Placed FIRST so the flag catch wins when both signals are
+      // present; the phrase branch remains the only recovery for `channel_send`, which
+      // stamps no flag. The `sendCount === successfulChannelSends` check requires the
+      // continue-reply to STILL be the latest successful send: if a later substantive
+      // send (e.g. a `channel_send` final answer) landed after the ack, the user was
+      // already answered and a trailing empty stop must NOT be re-nudged.
+      if (
+        live.promptQueue.length === 0 &&
+        live.currentTurnAuthorId !== null &&
+        live.continueReplyTurn?.turnSeq === live.turnSeq &&
+        live.continueReplyTurn.sendCount === live.successfulChannelSends &&
+        isFreshEmptyStopAfterSend(live) &&
+        (attemptMadeToolCall(live.session) || live.willingnessNudges > 0)
+      ) {
+        if (live.willingnessNudges < MAX_WILLINGNESS_NUDGES) {
+          live.willingnessNudges++
+          logger.warn(
+            `[channels] ${live.keyId} send_willingness_nudge attempt=${live.willingnessNudges}/${MAX_WILLINGNESS_NUDGES} ` +
+              `cause=empty_stop_after_continue_reply`,
+          )
+          live.pendingSystemReminders.push(SEND_WILLINGNESS_NUDGE)
+        } else {
+          await postEmptyTurnFallback('empty_stop_after_continue_reply_nudges_exhausted')
+        }
+        return
+      }
 
       // A `channel_send` ack that promised to keep working, fresh post-ack work,
       // then an EMPTY `stop` leaf: the model computed the answer in its reasoning
@@ -6474,20 +6532,29 @@ function leafIsStrandedToolUse(session: AgentSession): boolean {
   return false
 }
 
-// True when the turn-end leaf is a FRESH empty `stop` (no text, no tool call,
-// distinct from the leaf in place at the last successful send) AND the most
-// recent send to this target was a continuation-willingness ack. This is the
-// `channel_send` analogue of the `channel_reply` willingness path: the model
-// acked "I'll check…", did post-ack work, then the follow-up came back as a
-// clean empty completion that would otherwise be read as a deliberate `NO_REPLY`.
-// The fresh-leaf check (`!== lastSendLeafId`) is what separates this degeneration
-// from a legitimate ack-then-stop where the model meant to wait for the user.
-function isEmptyStopAfterWillingnessAck(live: LiveSession): boolean {
+// The turn-end leaf is a FRESH empty `stop` — an assistant message with no visible
+// text and no tool call, distinct from the leaf in place at the last successful
+// send. "Fresh" (`!== lastSendLeafId`) is what separates a post-send degeneration
+// (the model did more work, then dropped its conclusion) from a legitimate
+// ack-then-stop where the model meant to wait for the user (leaf unchanged since
+// the send). The two willingness paths below layer their own promise-signal on top
+// of this shape: `channel_reply({ continue: true })` via `continueReplyTurn`, and
+// `channel_send` acks via the willingness phrase table.
+function isFreshEmptyStopAfterSend(live: LiveSession): boolean {
   const leaf = live.session.sessionManager.getLeafEntry()
   if (!leaf || leaf.type !== 'message' || leaf.message.role !== 'assistant') return false
   if (leaf.message.stopReason !== 'stop') return false
   if (hasToolCall(leaf.message) || visibleAssistantText(leaf.message).trim() !== '') return false
-  if (leaf.id === live.lastSendLeafId) return false
+  return leaf.id !== live.lastSendLeafId
+}
+
+// The `channel_send` analogue of the `continue: true` recovery: the most recent
+// send to this target was a continuation-willingness ack (by phrase), then the
+// model produced a fresh empty stop. `channel_send` keeps the turn alive without a
+// `continue: true` flag and stamps no semantic marker, so the phrase table is the
+// only "I promised to keep working" signal available for that shape.
+function isEmptyStopAfterWillingnessAck(live: LiveSession): boolean {
+  if (!isFreshEmptyStopAfterSend(live)) return false
   const ackText = live.lastSentText.get(consecutiveSendKey(live.key.chat, live.key.thread))
   return ackText !== undefined && detectContinuationWillingness(ackText)
 }


### PR DESCRIPTION
## Background

A Discord channel agent that speaks casual Korean (banmal) went silent mid-task in two separate production sessions. The shape was identical each time:

1. The model posted a `channel_reply({ continue: true })` progress ack — "확인해볼게" / "훑어볼게" ("I'll check", "I'll look through") — which delivered fine.
2. It did real tool work (clone, read, grep — all succeeded).
3. It ended the turn on a **fresh empty `stop` leaf** (`stopReason: 'stop'`, empty text, no tool call).
4. Nothing further was posted. The user saw the ack but never the conclusion.

`validateChannelTurn` already has a recovery net for "a send landed this turn, then the model dropped its conclusion on an empty stop." Three gaps let this shape fall through it:

**Gap 1 — the recovery is phrase-gated, but `continue: true` is a machine-readable promise.** Once a send has landed, the only empty-stop recovery is `isEmptyStopAfterWillingnessAck`, which fires only if `detectContinuationWillingness(ackText)` matches. `maybeNudgeContinuationWillingness` can't help — it reads `lastTerminalReplyAbort`, which a `continue: true` reply never sets (the terminal-reply abort is suppressed by design so the turn can keep working). So recovery hinged entirely on the willingness **phrase table** matching — brittle, when the `continue: true` flag itself is the unambiguous "I'll keep working" signal.

**Gap 2 — the phrase table only knew polite Korean.** `KO_PHRASES` carried only the polite `-게요` volitional (`확인해볼게요`), so a banmal ack (`확인해볼게`, `훑어볼게`) matched nothing. Confirmed empirically: both production acks returned `false` on the old table.

**Gap 3 — the same formal-register bias existed in every other language.** An audit found casual acks a chat persona actually emits — "gonna check", "déjame ver", "щас гляну", "確認するね", "راح أشوف", "coi thử" — matched nothing across all 13 non-Korean languages. Same silent-drop risk, same root cause.

## Summary

Three commits, each independently revertable:

1. **`fix(channels): detect casual Korean -게 continuation acks`** — Replace the `KO_PHRASES` entries with their casual `-게` bases; polite `-게요`/`-게여` forms still match via the substring pass (`볼게 ⊂ 볼게요`). Enumerating the casual base is deliberate over a broad `[ㄹ-final]게` morpheme regex, which would false-positive on the adverbial `-게` of adjective stems (`힘들게`, `멀게`, `길게`).

2. **`fix(channels): recover continue:true turns that end on an empty stop`** — Add a phrase-**independent** recovery branch keyed on a new `turnSeq`-stamped `continueReplyTurn` marker (stamped at the terminal-reply hook when a successful `channel_reply` set `continue: true`). It fires on the fresh-empty-stop-after-tool-work shape regardless of the ack's language or register. The shared shape check is extracted into `isFreshEmptyStopAfterSend`; the phrase-gated path stays as the only recovery for `channel_send`, which stamps no flag. Bounded by the same `MAX_WILLINGNESS_NUDGES` budget, with the visible fallback on exhaustion instead of silence.

3. **`fix(channels): detect casual-register continuation acks across languages`** — Widen every phrase table with SAFE casual/colloquial first-person-future forms across all 14 languages: EN contractions (imma/gonna/lemme), Romance `déjame ver`/`je check`/`fammi vedere`/`vou ver`, DE `ich schau mal`, RU `щас`+perfective, ZH `去`/`来`+verb, JA plain-form particle-anchored (`〜ね`/`〜とく`/`〜てみる`), AR `راح`/`رح`/`هـ` future, HI `अभी`+habitual, TR `-eyim` optative, VI `coi`+`thử`, ID `coba`/`dulu`.

Commits 1 and 3 harden the phrase path (which still solely drives `channel_send` recovery and is the first-line signal for `channel_reply`); commit 2 makes `channel_reply` recovery robust even when the phrase path misses.

## The prefer-false-negatives bias (load-bearing)

The detector's design rule is explicit: **a miss is cheap (status quo), a false positive costs a wasted re-prompt.** Every casual addition was vetted by native-level analysis and empirically validated to keep the following **excluded** (each locked in by a negative test):

- **Bare present that reads descriptive** — `je regarde` ("I'm looking [now]"), `guardo` ("I'm watching"), `我看`, `saya cek`.
- **Present-continuous** — Turkish `bakıyorum` ("I'm looking"), which is descriptive not future.
- **Other-directed imperatives** — `baksana` ("look!"), `你看看` ("you look"), Arabic `بدك أشوف` ("do YOU want to look?").
- **Collision-prone short forms** — Chinese 2-char `我看`/`我查` (fit `我看你说得对` / `我查收了`), the 3-char reduplications `我看看`/`我查查` (sub-`MIN_LENGTH` + past-narrative risk), Javanese `tak-` prefix (collides with `takut` "afraid").
- **Japanese bare dictionary forms** — `確認する`/`見る` are identical to descriptive present; only particle-anchored forms (`〜ね`/`〜わ`/`〜とく`) are added.

## What this does NOT do

- **No change to the `channel_send` recovery path's mechanism.** It still relies on the willingness phrase table (its only "I promised to keep working" signal); commits 1 and 3 strengthen that table.
- **No new false-positive surface vs. the existing no-send guard.** The new `continue:true` branch is strictly narrower — it additionally requires an explicit `continue: true` reply that landed this turn.
- **No broad morpheme regexes for casual forms.** Rejected wherever they collide with descriptive/adverbial homographs; enumerated bases stay precision-first.
- **No change to the terminal-reply abort contract, the willingness budget, or the fallback text.**

## Review notes

- The load-bearing runtime change is the flag-gated branch in `validateChannelTurn`, placed **first** in the send-landed block so it wins when both signals are present. `continueReplyTurn` is `turnSeq`-stamped (like `skippedTurn`/`lastTerminalReplyAbort`) and reset at per-prompt turn start.
- New router coverage: (a) recovers a `continue:true` ack whose phrasing is **outside** the willingness table — the exact production shape; (b) posts the fallback instead of looping when the retry re-strands; (c) does **not** recover when the ack leaf is unchanged since the send (legitimate ack-then-await-user silence).
- New willingness coverage: one casual positive per language (14 languages) plus a dedicated negative block asserting the RISKY/excluded forms stay `false`.
- Full suite green: `10877 pass, 0 fail`; `typecheck`, `lint` (0 errors), `format:check` all clean.
