### PR TITLE
fix(agent): fail over to next model ref on provider transport failure

### DIFF
--- a/src/agent/provider-error.test.ts
+++ b/src/agent/provider-error.test.ts
@@ -121,6 +121,19 @@ describe('detectProviderError safeMessage redaction', () => {
     )
   })
 
+  test('maps a transport/session failure to a transport-safe sentence without echoing the wss URL', () => {
+    const raw =
+      "WebSocket connection to 'wss://chatgpt.com/backend-api/codex/responses' failed: Expected 101 status code"
+    const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })
+
+    expect(result?.safeMessage).toMatch(/session\/transport failure|dropped/i)
+    expect(result?.safeMessage).not.toContain('wss://')
+    expect(result?.safeMessage).not.toContain('chatgpt.com')
+    expect(result?.safeMessage).not.toBe(
+      'The upstream LLM provider failed. Operators can check `typeclaw logs` for details.',
+    )
+  })
+
   test('collapses unknown / malformed-response failures to a generic notice (no raw leak)', () => {
     const raw = 'malformed response: {"id":"resp_abc","debug":"Bearer sk-live-LEAK","body":"<html>500</html>"}'
     const result = detectProviderError({ role: 'assistant', stopReason: 'error', errorMessage: raw })
@@ -157,6 +170,16 @@ describe('detectHardProviderError', () => {
     expect(detectHardProviderError(new Error('429 All tokens rate limited'))?.safeMessage).toMatch(/rate-limited/i)
     expect(detectHardProviderError(new Error('insufficient quota'))?.safeMessage).toMatch(/billing\/quota/i)
     expect(detectHardProviderError(new Error('401 Unauthorized'))?.safeMessage).toMatch(/unauthorized/i)
+  })
+
+  test('maps a transport/session hard throw to the transport-safe sentence (the cron-report incident)', () => {
+    const raw =
+      "WebSocket connection to 'wss://chatgpt.com/backend-api/codex/responses' failed: Expected 101 status code (provider_transport_failure). Your ChatGPT session expired before this request finished."
+    const result = detectHardProviderError(new Error(raw))
+
+    expect(result?.safeMessage).toMatch(/session\/transport failure|dropped/i)
+    expect(result?.safeMessage).not.toContain('chatgpt.com')
+    expect(result?.message).toBe(raw)
   })
 
   test('returns null for internal / network errors so the caller stays silent-with-log', () => {
@@ -271,6 +294,36 @@ describe('isFailoverWorthy', () => {
     expect(isFailoverWorthy('insufficient quota')).toBe(false)
     expect(isFailoverWorthy('401 Unauthorized')).toBe(false)
     expect(isFailoverWorthy('network unreachable')).toBe(false)
+  })
+
+  test('a provider transport / expired-session failure IS failover-worthy (the cron-report incident)', () => {
+    expect(isFailoverWorthy('provider_transport_failure')).toBe(true)
+    expect(
+      isFailoverWorthy(
+        "WebSocket connection to 'wss://chatgpt.com/backend-api/codex/responses' failed: Expected 101 status code",
+      ),
+    ).toBe(true)
+    expect(isFailoverWorthy('Your ChatGPT session expired before this request finished.')).toBe(true)
+  })
+
+  test('a transport failure carrying an auth reason still surfaces (auth exclusion wins)', () => {
+    expect(isFailoverWorthy('session expired: 401 unauthorized, invalid api key')).toBe(false)
+  })
+
+  test('a `session expired` message carrying an api-key fault does NOT fail over (shared AUTH_FAULT source)', () => {
+    // The transport matcher matches "session expired", but an expired/invalid/missing
+    // API key is an account-wide auth fault — a different ref shares it, so it must
+    // surface, not rotate. Regression: NON_FAILOVER_FAULT once omitted the
+    // `api key ... expired` shape the safe-message auth class matched.
+    expect(isFailoverWorthy('session expired: api key expired')).toBe(false)
+    expect(isFailoverWorthy('session expired - api key invalid')).toBe(false)
+    expect(isFailoverWorthy('session expired, api key missing')).toBe(false)
+  })
+
+  test('the api-key-fault-carrying transport error redacts to the auth safe sentence, not the transport one', () => {
+    const result = detectHardProviderError(new Error('session expired: api key expired'))
+    expect(result?.safeMessage).toMatch(/unauthorized|API key/i)
+    expect(result?.safeMessage).not.toMatch(/session\/transport failure|dropped/i)
   })
 })
 

--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -33,19 +33,36 @@ const GENERIC_SAFE_NOTICE = 'The upstream LLM provider failed. Operators can che
 // and surface it. The literal is the system's own token — English by design.
 const OBSERVER_TIMEOUT = /\(typeclaw observer timeout\)/i
 
+// Transport-layer failure: the request died at the connection/session before a
+// usable response — an expired live session, a WebSocket upgrade that never
+// reached `101 Switching Protocols`, or a dropped transport. Unlike an
+// account-wide auth/billing fault, this is transient AND ref-specific: a
+// different ref opens its own session, so failing OVER can succeed. Observed from
+// Codex/ChatGPT (`provider_transport_failure`, expired ChatGPT session, a
+// `wss://…/codex/responses` non-101 upgrade). Provider protocol tokens — English
+// by design (the system-token exception to the multi-language rule).
+const TRANSPORT_FAILURE =
+  /provider[_ -]?transport[_ -]?failure|(?:websocket|ws) connection.*failed|expected 101|session expired/i
+
+// Auth failure: the provider rejected our credentials (bad/expired/missing API
+// key, 401, failed authentication). Account-wide — a different ref shares the
+// same credential problem — so this is BOTH a redacted safe-message class (a
+// 401 body can carry a Bearer token) AND a NON_FAILOVER_FAULT reason. Shared as
+// one constant so the two uses can never drift: previously the safe-message copy
+// matched `api key ... expired` but the failover copy didn't, letting
+// `session expired: api key expired` wrongly fail over past the auth guard.
+const AUTH_FAULT =
+  /\b(401|unauthori[sz]ed|invalid[_ -]?api[_ -]?key|api key.*(?:invalid|expired|missing)|authentication failed|invalid bearer)\b/i
+
 // Each entry pairs a narrow matcher against the raw provider text with the
 // canonical, leak-free sentence shown in channels. Matchers are intentionally
 // specific: a miss falls through to GENERIC_SAFE_NOTICE rather than echoing raw
 // text, so adding a new class is opt-in and never widens what we expose.
 const SAFE_CLASSES: ReadonlyArray<{ match: RegExp; safe: string }> = [
   {
-    // Auth failure: the provider rejected our credentials (bad/expired/missing
-    // API key). Matched first because a 401 body can also mention "account",
-    // which would otherwise fall into the billing class below. The safe text
-    // names the operator action (check the API key) without echoing the raw
-    // error, whose body can carry a Bearer token.
-    match:
-      /\b(401|unauthori[sz]ed|invalid[_ -]?api[_ -]?key|api key.*(?:invalid|expired|missing)|authentication failed|invalid bearer)\b/i,
+    // Matched first because a 401 body can also mention "account", which would
+    // otherwise fall into the billing class below.
+    match: AUTH_FAULT,
     safe: 'The upstream LLM provider rejected the request as unauthorized. Operators should check the provider API key configuration and `typeclaw logs`.',
   },
   {
@@ -71,6 +88,10 @@ const SAFE_CLASSES: ReadonlyArray<{ match: RegExp; safe: string }> = [
     match: OBSERVER_TIMEOUT,
     safe: 'The upstream LLM provider stopped responding and the request timed out. Try again shortly.',
   },
+  {
+    match: TRANSPORT_FAILURE,
+    safe: 'The connection to the upstream LLM provider dropped (session/transport failure). Try again shortly.',
+  },
 ]
 
 function toSafeMessage(raw: string): string {
@@ -92,9 +113,12 @@ const THROTTLE_OR_OVERLOAD =
 // help (same account) and would mask a config error the operator must fix. This
 // is checked BEFORE the throttle match because providers often pair a `429`
 // status with a quota/billing/auth reason (e.g. `429 insufficient quota`) — the
-// status code alone must not force a pointless failover.
-const NON_FAILOVER_FAULT =
-  /\bcyber_policy\b|insufficient.*(?:quota|credit|fund|balance)|\bquota\b|billing|payment|account is not active|unauthori[sz]ed|invalid[_ -]?api[_ -]?key|authentication failed|invalid bearer/i
+// status code alone must not force a pointless failover. The auth arm reuses the
+// shared `AUTH_FAULT` source so it stays in lockstep with the safe-message class.
+const NON_FAILOVER_FAULT = new RegExp(
+  `\\bcyber_policy\\b|insufficient.*(?:quota|credit|fund|balance)|\\bquota\\b|billing|payment|account is not active|${AUTH_FAULT.source}`,
+  'i',
+)
 
 export function isThrottleOrOverload(raw: string): boolean {
   if (NON_FAILOVER_FAULT.test(raw)) return false
@@ -102,14 +126,15 @@ export function isThrottleOrOverload(raw: string): boolean {
 }
 
 // Failover predicate for turn-drivers' `shouldFailover`: rotate to the next model
-// ref on a transient capacity signal (throttle/overload) OR an observer stall
-// timeout. A stall — the provider accepted the stream but stopped sending bytes —
-// is as transient as an overload and another ref may well succeed, so it must
-// fail OVER before the caller surfaces a failure notice. Account-wide faults
-// (billing/quota/auth) still return false via `isThrottleOrOverload` — a
-// different ref shares the same account problem.
+// ref on a transient capacity signal (throttle/overload), an observer stall
+// timeout, or a transport/session failure. A stall or a dropped session is as
+// transient as an overload and another ref (its own session/transport) may well
+// succeed, so it must fail OVER before the caller surfaces a failure notice.
+// Account-wide faults (billing/quota/auth) are excluded up front — a different
+// ref shares the same account problem, so switching can't help.
 export function isFailoverWorthy(raw: string): boolean {
-  return isThrottleOrOverload(raw) || OBSERVER_TIMEOUT.test(raw)
+  if (NON_FAILOVER_FAULT.test(raw)) return false
+  return isThrottleOrOverload(raw) || OBSERVER_TIMEOUT.test(raw) || TRANSPORT_FAILURE.test(raw)
 }
 
 export function detectProviderError(message: unknown): DetectedProviderError | null {
@@ -134,7 +159,10 @@ export function detectProviderError(message: unknown): DetectedProviderError | n
 export function detectHardProviderError(err: unknown): DetectedProviderError | null {
   const message = err instanceof Error ? err.message : String(err)
   const isProviderFailure =
-    isThrottleOrOverload(message) || NON_FAILOVER_FAULT.test(message) || OBSERVER_TIMEOUT.test(message)
+    isThrottleOrOverload(message) ||
+    NON_FAILOVER_FAULT.test(message) ||
+    OBSERVER_TIMEOUT.test(message) ||
+    TRANSPORT_FAILURE.test(message)
   if (!isProviderFailure) return null
   return { message, safeMessage: toSafeMessage(message) }
 }


### PR DESCRIPTION
## Background

A cron turn (`daily-stats-report`) ran at its scheduled time but posted nothing to Slack. The session log showed the turn ending with `stopReason: error` — a `provider_transport_failure` from the configured Codex/ChatGPT session: `WebSocket connection to 'wss://chatgpt.com/backend-api/codex/responses' failed: Expected 101 status code`, with the underlying cause "Your ChatGPT session expired before this request finished." The model response stream died before it started, so zero tool calls ran (no bash, no write, no channel_send) — this rules out a stats-API bug or a Slack-timestamp issue; the failure was in the model session/transport itself.

TypeClaw already has a model fallback chain: turn-drivers (channels, TUI, subagents) rotate to the next model ref via a `shouldFailover` gate backed by `isFailoverWorthy()` in `src/agent/provider-error.ts`. But that gate only recognized throttle/overload signals (429/503/"overloaded"/rate-limit) and observer-stall timeouts. A transport/session failure — a dropped session, a WebSocket upgrade that never reaches HTTP 101, an expired live session — wasn't classified as failover-worthy, so instead of rotating to the next ref the turn just surfaced the failure. (Cron's own driver already fails over on any error when the profile has more than one ref, but the shared classification gap is what blocked failover for the gated drivers, and is the correct place to fix it centrally.)

## Summary

- Add a `TRANSPORT_FAILURE` matcher covering `provider_transport_failure`, `(websocket|ws) connection ... failed`, `expected 101`, and `session expired`.
- Fold it into `isFailoverWorthy()` — a transport/session failure now rotates to the next ref exactly like an observer stall, because both are transient AND ref-specific: a different ref opens its own session/transport.
- Fold it into `detectHardProviderError()` too, since this incident arrives as a thrown error rather than a soft `stopReason`.
- Add a safe, leak-free sentence to the channel redaction map so a raw `wss://` URL never reaches a channel.
- Add an up-front `NON_FAILOVER_FAULT` guard in `isFailoverWorthy()`: account-wide auth/billing/quota faults still surface rather than fail over, since a different ref shares the same account problem. This matters here because a transport error can also carry an auth reason (e.g. "session expired: 401 unauthorized") — that case must still surface, not pointlessly rotate.

## What this does NOT do

- Does not add same-ref retry or session-token refresh — a transport failure still fails over to the *next* ref rather than retrying the same one.
- Does not add cron failure alerting or auto-retry (a separate follow-up) — out of scope here.
- Does not change config schema. Fallback still requires a multi-ref model profile (e.g. `models.default: ["openai-codex/gpt-5.5", "anthropic/claude-sonnet-5"]`); this PR only ensures a transport failure actually triggers the existing fallback.
- Does not add fallback to the TUI/command-runner bare `session.prompt()` paths.

## Review notes

- The load-bearing change is `isFailoverWorthy()` in `src/agent/provider-error.ts`. Invariant to verify: transport/session failures fail over, but account-wide auth/billing/quota faults still surface (the `NON_FAILOVER_FAULT` up-front guard).
- `provider-error.test.ts` covers the incident's exact error strings, the auth-exclusion case, and channel redaction (no `wss://` URL leak).