### PR TITLE
feat(agent): retry same model before failover

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -481,6 +481,14 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     customTools,
     ...(thinkingLevel ? { thinkingLevel } : {}),
   })
+  // typeclaw owns retry/fallback in its turn drivers, so the SDK's own
+  // same-model auto-retry must be OFF. Leaving it on races typeclaw's
+  // soft-error capture: the SDK can silently recover a `stopReason:'error'` turn
+  // while typeclaw has already latched the failure, reporting a recovered turn as
+  // failed (and burning an unnecessary failover). Disabling it makes a soft error
+  // a deterministic, typeclaw-owned signal. Compaction/context-overflow recovery
+  // is independent (gated on compaction settings), so this does not disable those.
+  ;(session as { setAutoRetryEnabled?: (enabled: boolean) => void }).setAutoRetryEnabled?.(false)
   const getAbortReason = () => abortHolder.reason
   const sessionWithAbortReason = Object.assign(session, { getAbortReason })
 

--- a/src/agent/model-fallback.test.ts
+++ b/src/agent/model-fallback.test.ts
@@ -333,3 +333,98 @@ describe('promptWithFallback shouldFailover gate', () => {
     expect(created).toHaveLength(2)
   })
 })
+
+// A createSessionForRef factory that plays a scripted behavior per invocation,
+// so we can assert same-ref retry: e.g. first attempt fails transiently, the
+// recreated session for the SAME ref succeeds.
+function scriptedFactory(script: Array<'success' | 'throw' | 'soft-error'>, errorMessage: string) {
+  const created: SessionFake[] = []
+  let call = 0
+  const createSessionForRef = async (ref: KnownModelRef) => {
+    const behavior = script[Math.min(call, script.length - 1)]!
+    call++
+    const { session, fake } = fakeSession({ ref, behavior, errorMessage })
+    created.push(fake)
+    return { session, dispose: async () => void (fake.disposed = true) }
+  }
+  return { createSessionForRef, created }
+}
+
+describe('promptWithFallback same-ref retry', () => {
+  test('a transient failure on a single ref is retried on a fresh session and recovers', async () => {
+    // given: the ONLY ref fails transiently, then its recreated session succeeds
+    const { createSessionForRef, created } = scriptedFactory(['throw', 'success'], 'socket hang up')
+
+    const result = await promptWithFallback({ refs: [REF_A], text: 'hi', createSessionForRef })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_A)
+    // one attempt recorded (the recovering one); two sessions created (retry recreated it)
+    expect(result.attempts).toEqual([{ ref: REF_A, outcome: 'success' }])
+    expect(created).toHaveLength(2)
+    expect(created[0]!.disposed).toBe(true)
+  })
+
+  test('a persistent transient failure on a single ref exhausts the retry then surfaces', async () => {
+    const { createSessionForRef, created } = scriptedFactory(['throw', 'throw', 'throw'], 'socket hang up')
+
+    const result = await promptWithFallback({ refs: [REF_A], text: 'hi', createSessionForRef })
+
+    expect(result.success).toBe(false)
+    expect(result.lastError?.message).toBe('socket hang up')
+    // 1 initial + RETRIES_PER_REF(1) same-ref retry = 2 sessions
+    expect(created).toHaveLength(2)
+  })
+
+  test('a NON-retryable failure (auth) is not same-ref retried — it fails over instead', async () => {
+    const created: SessionFake[] = []
+    let call = 0
+    const result = await promptWithFallback({
+      refs: [REF_A, REF_B],
+      text: 'hi',
+      createSessionForRef: async (ref) => {
+        call++
+        const { session, fake } = fakeSession({
+          ref,
+          behavior: ref === REF_A ? 'soft-error' : 'success',
+          errorMessage: '401 unauthorized',
+        })
+        created.push(fake)
+        return { session, dispose: async () => void (fake.disposed = true) }
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_B)
+    // REF_A tried once (no same-ref retry for auth), then REF_B — exactly 2 sessions
+    expect(created).toHaveLength(2)
+    expect(call).toBe(2)
+  })
+
+  test('a throttle/overload failure is not same-ref retried — it fails over immediately', async () => {
+    const { createSessionForRef, created } = (() => {
+      const c: SessionFake[] = []
+      let call = 0
+      return {
+        created: c,
+        createSessionForRef: async (ref: KnownModelRef) => {
+          call++
+          const { session, fake } = fakeSession({
+            ref,
+            behavior: ref === REF_A ? 'soft-error' : 'success',
+            errorMessage: 'server_is_overloaded',
+          })
+          c.push(fake)
+          return { session, dispose: async () => void (fake.disposed = true) }
+        },
+      }
+    })()
+
+    const result = await promptWithFallback({ refs: [REF_A, REF_B], text: 'hi', createSessionForRef })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_B)
+    // no wasted same-ref retry on REF_A: 1 (REF_A) + 1 (REF_B) = 2
+    expect(created).toHaveLength(2)
+  })
+})

--- a/src/agent/model-fallback.ts
+++ b/src/agent/model-fallback.ts
@@ -3,7 +3,8 @@ import type { Models } from '@/config/config'
 import type { KnownModelRef, ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
-import { subscribeProviderErrors } from './provider-error'
+import { isRetryableSameRef, subscribeProviderErrors } from './provider-error'
+import { RETRIES_PER_REF, sleepBackoff } from './retry-same-ref'
 import { renderTurnTimeAnchor } from './system-prompt'
 
 // Result of a single fallback-aware prompt run.
@@ -87,53 +88,71 @@ export async function promptWithFallback<TRef extends FallbackModelRef>(opts: {
   for (let i = 0; i < opts.refs.length; i++) {
     const ref = opts.refs[i]!
     const isLast = i === opts.refs.length - 1
+    // Try this ref, replaying the SAME ref on a transient failure before we give
+    // up on it. Cron sessions are cheap and fresh-per-attempt, so a same-ref
+    // retry just recreates the session — no state surgery needed.
+    const outcome = await attemptRefWithRetry(ref, opts)
+    if (outcome.kind === 'success') {
+      attempts.push({ ref, outcome: 'success' })
+      return { success: true, refUsed: ref, attempts, session: outcome.session, dispose: outcome.dispose }
+    }
+    attempts.push({ ref, outcome: outcome.kind, errorMessage: outcome.error.message })
+    lastError = outcome.error
+    const stop = isLast || !failoverGate(outcome.error)
+    if (!stop) opts.onAttemptFailed?.({ ref, outcome: outcome.kind, errorMessage: outcome.error.message })
+    // The failed ref's session is spent either way — dispose it. On stop we still
+    // hand the caller the (now-disposed) session for its final surface, with a
+    // no-op dispose so a double-dispose can't happen.
+    await outcome.dispose()
+    if (stop) {
+      return { success: false, refUsed: ref, attempts, session: outcome.session, dispose: async () => {}, lastError }
+    }
+  }
+  throw new Error('promptWithFallback: unreachable — loop terminated without returning')
+}
+
+type RefAttemptOutcome =
+  | { kind: 'success'; session: AgentSession; dispose: () => Promise<void> }
+  | { kind: 'hard' | 'soft'; error: Error; session: AgentSession; dispose: () => Promise<void> }
+
+// One ref, with same-ref retry. Each attempt gets a fresh session (cron's
+// pattern); a retryable failure disposes it and recreates the same ref up to
+// RETRIES_PER_REF times before returning failure to the chain. The returned
+// session/dispose is always from the LAST attempt so the caller can surface or
+// keep it exactly as before.
+async function attemptRefWithRetry<TRef extends FallbackModelRef>(
+  ref: TRef,
+  opts: {
+    text: string
+    createSessionForRef: (ref: TRef) => Promise<{ session: AgentSession; dispose: () => Promise<void> }>
+  },
+): Promise<RefAttemptOutcome> {
+  for (let attempt = 0; ; attempt++) {
     const { session, dispose } = await opts.createSessionForRef(ref)
-    // Capture the first soft error per attempt. The `subscribeProviderErrors`
-    // listener fires synchronously off the `message_end` event, which lands
-    // BEFORE `session.prompt()` resolves — so by the time `await` returns,
-    // `softError` is populated if a soft error occurred.
+    // Capture the first soft error per attempt. The listener fires synchronously
+    // off `message_end`, which lands BEFORE `session.prompt()` resolves, so by
+    // the time `await` returns `softError` is populated if one occurred.
     let softError: Error | undefined
     const unsub = subscribeProviderErrors(session, (err) => {
       if (!softError) softError = new Error(err.message)
     })
+    let outcome: RefAttemptOutcome
     try {
-      try {
-        await session.prompt(`${renderTurnTimeAnchor()}\n\n${opts.text}`)
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-        const attempt: FallbackAttempt<TRef> = { ref, outcome: 'hard', errorMessage: error.message }
-        attempts.push(attempt)
-        lastError = error
-        const stop = isLast || !failoverGate(error)
-        if (!stop) opts.onAttemptFailed?.(attempt)
-        unsub()
-        await dispose()
-        if (stop) {
-          return { success: false, refUsed: ref, attempts, session, dispose: async () => {}, lastError }
-        }
-        continue
-      }
-      if (softError !== undefined) {
-        const attempt: FallbackAttempt<TRef> = { ref, outcome: 'soft', errorMessage: softError.message }
-        attempts.push(attempt)
-        lastError = softError
-        const stop = isLast || !failoverGate(softError)
-        if (!stop) opts.onAttemptFailed?.(attempt)
-        unsub()
-        await dispose()
-        if (stop) {
-          return { success: false, refUsed: ref, attempts, session, dispose: async () => {}, lastError }
-        }
-        continue
-      }
-      attempts.push({ ref, outcome: 'success' })
-      unsub()
-      return { success: true, refUsed: ref, attempts, session, dispose }
+      await session.prompt(`${renderTurnTimeAnchor()}\n\n${opts.text}`)
+      outcome =
+        softError === undefined
+          ? { kind: 'success', session, dispose }
+          : { kind: 'soft', error: softError, session, dispose }
     } catch (err) {
+      outcome = { kind: 'hard', error: err instanceof Error ? err : new Error(String(err)), session, dispose }
+    } finally {
       unsub()
-      await dispose()
-      throw err
     }
+    if (outcome.kind === 'success') return outcome
+    const canRetry = attempt < RETRIES_PER_REF && isRetryableSameRef(outcome.error.message)
+    if (!canRetry) return outcome
+    // Retryable and budget remains: drop this session and replay the same ref.
+    await dispose()
+    await sleepBackoff(attempt)
   }
-  throw new Error('promptWithFallback: unreachable — loop terminated without returning')
 }

--- a/src/agent/multimodal/look-at.ts
+++ b/src/agent/multimodal/look-at.ts
@@ -12,6 +12,7 @@ import { providerForModelRef } from '@/config/providers'
 import { LLM_FETCH_OBSERVER_TIMEOUTS, type LlmFetchObservedRequestInit } from '@/run/llm-fetch-observer'
 import { SecretsBackend } from '@/secrets'
 
+import { promptWithSameRefRetryOnly } from '../retry-same-ref'
 import { buildMultimodalLookerSystemPrompt, resolveImage, type ImageInput } from './looker'
 
 type ImageParam = { url: string } | { path: string } | { data: string; mimeType: string }
@@ -188,7 +189,7 @@ async function runLookAtImages(imageContents: ImageContent[], prompt: string | u
   })
 
   try {
-    await session.prompt(userText, { images: imageContents })
+    await promptWithSameRefRetryOnly(session, userText, { images: imageContents })
     const text = extractLastAssistantText(session.messages)
     if (text === null) {
       return errorResult('multimodal-looker returned no text response', {

--- a/src/agent/provider-error.test.ts
+++ b/src/agent/provider-error.test.ts
@@ -7,6 +7,7 @@ import {
   detectHardProviderError,
   detectProviderError,
   isFailoverWorthy,
+  isRetryableSameRef,
   isThrottleOrOverload,
   subscribeProviderErrors,
 } from './provider-error'
@@ -324,6 +325,35 @@ describe('isFailoverWorthy', () => {
     const result = detectHardProviderError(new Error('session expired: api key expired'))
     expect(result?.safeMessage).toMatch(/unauthorized|API key/i)
     expect(result?.safeMessage).not.toMatch(/session\/transport failure|dropped/i)
+  })
+})
+
+describe('isRetryableSameRef', () => {
+  test('retries transport/session, observer-stall, and network/5xx blips (same-model replay)', () => {
+    expect(isRetryableSameRef('provider_transport_failure')).toBe(true)
+    expect(isRetryableSameRef('Your ChatGPT session expired before this request finished.')).toBe(true)
+    expect(isRetryableSameRef('anthropic SSE body idle for 120000ms (typeclaw observer timeout)')).toBe(true)
+    expect(isRetryableSameRef('socket hang up')).toBe(true)
+    expect(isRetryableSameRef('ECONNRESET')).toBe(true)
+    expect(isRetryableSameRef('fetch failed')).toBe(true)
+    expect(isRetryableSameRef('500 Internal Server Error')).toBe(true)
+  })
+
+  test('does NOT same-ref retry throttle/overload — those fail OVER to another ref', () => {
+    expect(isRetryableSameRef('server_is_overloaded')).toBe(false)
+    expect(isRetryableSameRef('429 too many requests')).toBe(false)
+    expect(isRetryableSameRef('503 Service Unavailable')).toBe(false)
+  })
+
+  test('does NOT same-ref retry account-wide faults (auth/billing/quota) — those surface', () => {
+    expect(isRetryableSameRef('401 Unauthorized')).toBe(false)
+    expect(isRetryableSameRef('insufficient quota')).toBe(false)
+    expect(isRetryableSameRef('session expired: api key expired')).toBe(false)
+  })
+
+  test('does NOT same-ref retry context-overflow or generic errors (compaction / surface own it)', () => {
+    expect(isRetryableSameRef('context length exceeded')).toBe(false)
+    expect(isRetryableSameRef('malformed response')).toBe(false)
   })
 })
 

--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -137,6 +137,31 @@ export function isFailoverWorthy(raw: string): boolean {
   return isThrottleOrOverload(raw) || OBSERVER_TIMEOUT.test(raw) || TRANSPORT_FAILURE.test(raw)
 }
 
+// Transient network / upstream 5xx signals that a same-model replay may clear.
+// Distinct from THROTTLE_OR_OVERLOAD (429/503/overload) on purpose: an overload
+// means the model is out of capacity NOW, so the right move is to fail OVER to a
+// different ref, not hammer the same one — whereas a socket hang-up or a 500 is a
+// one-off blip a replay against the SAME ref often fixes. `\b` anchors the 5xx
+// codes so they don't match digit runs in prose. Provider protocol tokens —
+// English by design (the system-token exception to the multi-language rule).
+const NETWORK_OR_5XX =
+  /econnreset|econnrefused|etimedout|enetunreach|socket hang up|network.?error|connection.?(?:error|refused|reset|lost)|fetch failed|other side closed|reset before headers|http2 request did not get a response|\b(?:500|502|504)\b/i
+
+// Retry predicate for typeclaw-owned SAME-REF retry: replay the SAME model ref
+// before advancing the chain. Deliberately NARROWER than `isFailoverWorthy` —
+// only transient failures a same-model replay can plausibly clear: transport/
+// session drops, observer stalls, and network/5xx blips. It intentionally EXCLUDES
+// throttle/overload (429/503) — those mean "this ref is out of capacity now", so
+// they should fail OVER to another ref rather than burn same-ref retries — and
+// account-wide faults (auth/billing/quota/cyber_policy), which must surface. It
+// does NOT match context-overflow: that stays on the SDK compaction path and must
+// never be treated as a retryable provider failure.
+export function isRetryableSameRef(raw: string): boolean {
+  if (NON_FAILOVER_FAULT.test(raw)) return false
+  if (isThrottleOrOverload(raw)) return false
+  return TRANSPORT_FAILURE.test(raw) || OBSERVER_TIMEOUT.test(raw) || NETWORK_OR_5XX.test(raw)
+}
+
 export function detectProviderError(message: unknown): DetectedProviderError | null {
   if (typeof message !== 'object' || message === null) return null
   const m = message as { role?: unknown; stopReason?: unknown; errorMessage?: unknown }

--- a/src/agent/retry-same-ref.test.ts
+++ b/src/agent/retry-same-ref.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { AgentSession } from './index'
+import {
+  promptWithSameRefRetryOnly,
+  retryBackoffMs,
+  retryTurnOnPersistentSession,
+  RETRIES_PER_REF,
+} from './retry-same-ref'
+
+describe('retryBackoffMs', () => {
+  test('is full-jitter: random in [0, min(cap, base·2^attempt))', () => {
+    // given random()=1 (upper bound), attempt 0 -> ceiling = base(1000)
+    expect(retryBackoffMs(0, () => 0.999999)).toBe(999)
+    // attempt 1 -> ceiling = min(5000, 2000) = 2000
+    expect(retryBackoffMs(1, () => 0.5)).toBe(1000)
+    // attempt grows past the cap -> clamped to MAX_DELAY_MS (5000)
+    expect(retryBackoffMs(10, () => 0.999999)).toBe(4999)
+  })
+
+  test('random()=0 yields no delay (immediate retry allowed)', () => {
+    expect(retryBackoffMs(3, () => 0)).toBe(0)
+  })
+})
+
+type FakeAgent = {
+  state: { messages: Array<{ role: string; stopReason?: string }> }
+  continue: () => Promise<void>
+  continued: number
+}
+
+function sessionWith(messages: Array<{ role: string; stopReason?: string }>, continueImpl?: () => Promise<void>) {
+  const agent: FakeAgent = {
+    state: { messages },
+    continued: 0,
+    continue: async () => {
+      agent.continued++
+      await continueImpl?.()
+    },
+  }
+  return { session: { agent } as unknown as AgentSession, agent }
+}
+
+describe('retryTurnOnPersistentSession', () => {
+  test('pops the trailing assistant error leaf, then continues (no user-message re-append)', async () => {
+    const messages = [{ role: 'user' }, { role: 'assistant', stopReason: 'error' }]
+    const { session, agent } = sessionWith(messages)
+
+    const ok = await retryTurnOnPersistentSession(session, { attempt: 0, random: () => 0 })
+
+    expect(ok).toBe(true)
+    expect(agent.continued).toBe(1)
+    // the failed assistant leaf is gone; the user message is untouched (not duplicated)
+    expect(agent.state.messages).toEqual([{ role: 'user' }])
+  })
+
+  test('retries a trailing USER leaf WITHOUT popping — the pre-stream incident shape', async () => {
+    // given: the provider died before writing any assistant message, so the turn
+    // is still just the user message (no assistant error leaf to pop)
+    const messages = [{ role: 'user' }]
+    const { session, agent } = sessionWith(messages)
+
+    const ok = await retryTurnOnPersistentSession(session, { attempt: 0, random: () => 0 })
+
+    expect(ok).toBe(true)
+    expect(agent.continued).toBe(1)
+    expect(agent.state.messages).toEqual([{ role: 'user' }]) // untouched, not re-appended
+  })
+
+  test('fails closed when the trailing message is neither user nor assistant', async () => {
+    const { session, agent } = sessionWith([{ role: 'user' }, { role: 'toolResult' }])
+
+    const ok = await retryTurnOnPersistentSession(session, { attempt: 0, random: () => 0 })
+
+    expect(ok).toBe(false)
+    expect(agent.continued).toBe(0)
+  })
+
+  test('fails closed when the session exposes no agent.continue', async () => {
+    const session = {
+      agent: { state: { messages: [{ role: 'assistant', stopReason: 'error' }] } },
+    } as unknown as AgentSession
+    expect(await retryTurnOnPersistentSession(session, { attempt: 0, random: () => 0 })).toBe(false)
+  })
+
+  test('fails closed on an empty transcript', async () => {
+    const { session } = sessionWith([])
+    expect(await retryTurnOnPersistentSession(session, { attempt: 0, random: () => 0 })).toBe(false)
+  })
+
+  test('propagates a throw from continue() so the caller can surface it', async () => {
+    const { session } = sessionWith([{ role: 'user' }, { role: 'assistant', stopReason: 'error' }], async () => {
+      throw new Error('socket hang up')
+    })
+    await expect(retryTurnOnPersistentSession(session, { attempt: 0, random: () => 0 })).rejects.toThrow(
+      'socket hang up',
+    )
+  })
+})
+
+describe('RETRIES_PER_REF', () => {
+  test('defaults to a single conservative same-ref replay', () => {
+    expect(RETRIES_PER_REF).toBe(1)
+  })
+})
+
+type PromptScript = Array<'soft-transient' | 'hard-transient' | 'hard-auth' | 'success'>
+
+function promptFake(script: PromptScript) {
+  const listeners = new Set<(event: { type: string; message?: unknown }) => void>()
+  const messages: Array<{ role: string; stopReason?: string }> = []
+  let idx = 0
+  const step = (viaContinue: boolean) => {
+    const behavior = script[Math.min(idx, script.length - 1)]!
+    idx++
+    if (!viaContinue) messages.push({ role: 'user' })
+    if (behavior === 'hard-auth') throw new Error('401 unauthorized')
+    if (behavior === 'hard-transient') {
+      messages.push({ role: 'assistant', stopReason: 'error' })
+      throw new Error('socket hang up')
+    }
+    if (behavior === 'soft-transient') {
+      messages.push({ role: 'assistant', stopReason: 'error' })
+      for (const cb of listeners)
+        cb({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: 'ECONNRESET' } })
+      return
+    }
+    messages.push({ role: 'assistant', stopReason: 'stop' })
+  }
+  const session = {
+    subscribe: (cb: (event: { type: string; message?: unknown }) => void) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+    prompt: async () => step(false),
+    agent: {
+      state: {
+        get messages() {
+          return messages
+        },
+        set messages(v: Array<{ role: string; stopReason?: string }>) {
+          messages.length = 0
+          messages.push(...v)
+        },
+      },
+      continue: async () => step(true),
+    },
+  } as unknown as AgentSession
+  return { session, userMessages: () => messages.filter((m) => m.role === 'user').length, attempts: () => idx }
+}
+
+describe('promptWithSameRefRetryOnly', () => {
+  test('recovers a transient soft error via continue without duplicating the user message', async () => {
+    const fake = promptFake(['soft-transient', 'success'])
+    await promptWithSameRefRetryOnly(fake.session, 'hi')
+    expect(fake.attempts()).toBe(2)
+    expect(fake.userMessages()).toBe(1)
+  })
+
+  test('recovers a transient hard throw via continue', async () => {
+    const fake = promptFake(['hard-transient', 'success'])
+    await promptWithSameRefRetryOnly(fake.session, 'hi')
+    expect(fake.attempts()).toBe(2)
+    expect(fake.userMessages()).toBe(1)
+  })
+
+  test('propagates a non-retryable hard throw (bare-prompt semantics preserved)', async () => {
+    const fake = promptFake(['hard-auth'])
+    await expect(promptWithSameRefRetryOnly(fake.session, 'hi')).rejects.toThrow('401 unauthorized')
+    expect(fake.attempts()).toBe(1)
+  })
+
+  test('does not retry when the first attempt succeeds', async () => {
+    const fake = promptFake(['success'])
+    await promptWithSameRefRetryOnly(fake.session, 'hi')
+    expect(fake.attempts()).toBe(1)
+  })
+
+  test('surfaces the original hard error when the retry recipe cannot apply (no phantom success)', async () => {
+    // given: a RETRYABLE hard throw, but the transcript leaf is an unsafe shape
+    // (tool-result) so retryTurnOnPersistentSession fails closed and never replays
+    const messages = [{ role: 'user' }, { role: 'toolResult' }]
+    let promptCalls = 0
+    let continueCalls = 0
+    const session = {
+      subscribe: () => () => {},
+      prompt: async () => {
+        promptCalls++
+        throw new Error('socket hang up')
+      },
+      agent: {
+        state: {
+          get messages() {
+            return messages
+          },
+          set messages(v: Array<{ role: string }>) {
+            messages.length = 0
+            messages.push(...v)
+          },
+        },
+        continue: async () => {
+          continueCalls++
+        },
+      },
+    } as unknown as AgentSession
+
+    // then: the original hard error propagates — it is NOT swallowed as success
+    await expect(promptWithSameRefRetryOnly(session, 'hi')).rejects.toThrow('socket hang up')
+    expect(promptCalls).toBe(1)
+    expect(continueCalls).toBe(0) // unsafe leaf → continue() never runs
+  })
+})

--- a/src/agent/retry-same-ref.ts
+++ b/src/agent/retry-same-ref.ts
@@ -1,0 +1,139 @@
+import type { AgentSession } from './index'
+import { isRetryableSameRef, subscribeProviderErrors } from './provider-error'
+
+// Same-ref retry policy. Conservative on purpose: the pi-ai provider layer ALSO
+// retries transport/5xx blips underneath us (WebSocket→SSE fallback + its own
+// SSE retry loop), and each typeclaw attempt is bounded by the observer timeouts
+// (TTFB 15s / idle 120s / overall 300s). Stacking a large per-ref retry count on
+// top of that turns one outage into minutes of dead air, so we replay the same
+// ref just ONCE by default and rely on cross-ref fallback for anything the single
+// replay can't clear.
+export const RETRIES_PER_REF = 1
+const BASE_DELAY_MS = 1_000
+const MAX_DELAY_MS = 5_000
+
+// Full-jitter exponential backoff: random in [0, min(cap, base·2^attempt)].
+// Jitter decorrelates concurrent turns (multiple channels/subagents recovering
+// from the same upstream blip) so they don't retry in lockstep and re-collide.
+export function retryBackoffMs(attempt: number, random: () => number = Math.random): number {
+  const ceiling = Math.min(MAX_DELAY_MS, BASE_DELAY_MS * 2 ** attempt)
+  return Math.floor(random() * ceiling)
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+}
+
+// For callers that recreate the session themselves (cron) and only need the delay.
+export function sleepBackoff(attempt: number, signal?: AbortSignal, random?: () => number): Promise<void> {
+  return sleep(retryBackoffMs(attempt, random), signal)
+}
+
+type ContinuableAgent = {
+  state?: { messages?: unknown }
+  continue?: () => Promise<void>
+}
+
+// Replay the CURRENT turn on a persistent session WITHOUT re-appending the user
+// message. Mirrors the SDK's own auto-retry shape, resuming via `agent.continue()`
+// (which replays from the trailing user/tool-result message). Re-calling
+// `session.prompt(text)` instead would duplicate the user message and corrupt
+// history, so we never do that.
+//
+// Two resolved shapes are retryable, matching `continue()`'s contract that the
+// last message be user/tool-result:
+//   - trailing ASSISTANT error leaf → pop it, then continue (soft error, or a
+//     hard throw AFTER a partial assistant message was written)
+//   - trailing USER message → the provider died BEFORE writing any assistant
+//     message (the reported incident: transport/session failure before stream
+//     start). Nothing to pop — continue() replays the user turn as-is.
+// Any other trailing shape (tool-result mid-execution, custom, empty transcript,
+// no `agent.continue`) fails CLOSED — the caller falls back / surfaces instead.
+export async function retryTurnOnPersistentSession(
+  session: AgentSession,
+  opts: { attempt: number; signal?: AbortSignal; random?: () => number } = { attempt: 0 },
+): Promise<boolean> {
+  const agent = (session as { agent?: ContinuableAgent }).agent
+  if (!agent || typeof agent.continue !== 'function') return false
+  const messages = agent.state?.messages
+  if (!Array.isArray(messages) || messages.length === 0) return false
+  const leafRole = (messages[messages.length - 1] as { role?: unknown }).role
+  if (leafRole !== 'assistant' && leafRole !== 'user') return false
+
+  await sleep(retryBackoffMs(opts.attempt, opts.random), opts.signal)
+  if (opts.signal?.aborted) return false
+
+  // Drop only a trailing assistant error leaf; a trailing user message is already
+  // the shape continue() wants, so leave it untouched (and never re-appended).
+  if (leafRole === 'assistant') {
+    ;(agent.state as { messages: unknown }).messages = messages.slice(0, -1)
+  }
+  await agent.continue()
+  return true
+}
+
+// Same-ref retry for DIRECT `session.prompt()` call sites that bypass the model
+// fallback helpers (non-stream TUI, slash commands, subagent drain/required-block
+// nudges, multimodal look-at). These lost the SDK's built-in retry when it was
+// disabled globally to kill the soft-error race; this restores equivalent
+// same-model resilience WITHOUT cross-ref fallback (there's no chain here) and
+// WITHOUT the race (typeclaw owns the soft-error signal). On a non-retryable
+// failure it does exactly what a bare prompt() did: the throw propagates, or the
+// soft error stays on the leaf for the caller to read.
+export async function promptWithSameRefRetryOnly(
+  session: AgentSession,
+  text: string,
+  promptOpts?: Parameters<AgentSession['prompt']>[1],
+): Promise<void> {
+  let softError: Error | undefined
+  // Feature-detect subscribe: some lightweight call sites / test fakes pass a
+  // session without an event stream. Without it we simply can't observe soft
+  // errors — the wrapper then only retries hard throws, still safe.
+  const canSubscribe = typeof (session as { subscribe?: unknown }).subscribe === 'function'
+  const unsub = canSubscribe
+    ? subscribeProviderErrors(session, (err) => {
+        if (!softError) softError = new Error(err.message)
+      })
+    : () => {}
+  try {
+    // Carry the last attempt's failure so a retry that CAN'T run (unsafe
+    // transcript shape → retryTurnOnPersistentSession returns false) still
+    // surfaces the original failure instead of resolving as a phantom success.
+    let priorHardError: Error | undefined
+    for (let attempt = 0; ; attempt++) {
+      softError = undefined
+      let hardError: Error | undefined
+      try {
+        if (attempt === 0) {
+          await session.prompt(text, promptOpts)
+        } else if (!(await retryTurnOnPersistentSession(session, { attempt: attempt - 1 }))) {
+          // Continue-recipe not applicable: replay never happened, so the prior
+          // failure stands — re-throw a hard error, or return to leave a soft
+          // error on the leaf (bare-prompt() semantics).
+          if (priorHardError !== undefined) throw priorHardError
+          return
+        }
+      } catch (err) {
+        hardError = err instanceof Error ? err : new Error(String(err))
+      }
+      const error = hardError ?? softError
+      if (error === undefined) return
+      if (attempt >= RETRIES_PER_REF || !isRetryableSameRef(error.message)) {
+        // Out of budget or not retryable: preserve bare-prompt() semantics — a
+        // hard error throws; a soft error stays on the leaf for the caller.
+        if (hardError !== undefined) throw hardError
+        return
+      }
+      priorHardError = hardError
+    }
+  } finally {
+    unsub()
+  }
+}

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -11,6 +11,7 @@ import { type AgentSession, createSession, type PluginSessionWiring } from './in
 import { resolveFallbackChain } from './model-fallback'
 import { applyModelRuntimeOverrides } from './model-overrides'
 import { isFailoverWorthy, subscribeProviderErrors } from './provider-error'
+import { promptWithSameRefRetryOnly } from './retry-same-ref'
 import type { SubagentBashPolicy } from './reviewer-bash-policy'
 import type { SessionOrigin } from './session-origin'
 import {
@@ -375,7 +376,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
         await runSubagentDrain(drainWatch, {
           drain: backgroundDrain,
           prompt: async (text) => {
-            await session.prompt(`${renderTurnTimeAnchor()}\n\n${text}`)
+            await promptWithSameRefRetryOnly(session, `${renderTurnTimeAnchor()}\n\n${text}`)
           },
           cancelled: () => aborted,
         })
@@ -395,7 +396,10 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           console.warn(
             `[subagent] ${name} required_block_retry attempt=${attempt}/${MAX_REQUIRED_BLOCK_RETRIES} tag=${requiredBlockTag}`,
           )
-          await session.prompt(`${renderTurnTimeAnchor()}\n\n${renderRequiredBlockRetryNudge(requiredBlockTag)}`)
+          await promptWithSameRefRetryOnly(
+            session,
+            `${renderTurnTimeAnchor()}\n\n${renderRequiredBlockRetryNudge(requiredBlockTag)}`,
+          )
         }
         if (!aborted && !capture.hasRequiredBlock()) {
           console.warn(`[subagent] ${name} required_block_fallback tag=${requiredBlockTag}`)

--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -314,3 +314,137 @@ describe('promptPersistentTurnWithFallback', () => {
     expect(turn2.setModels).toEqual([REF_A])
   })
 })
+
+// A persistent-session fake that supports same-ref retry via agent.continue().
+// `prompt` runs the first behavior; `continue` runs subsequent ones WITHOUT
+// re-appending a user message — mirroring the real SDK recipe we depend on.
+// `userMessages` lets tests assert the user message is never duplicated.
+type RetryBehavior = 'throw-transient' | 'throw-before-assistant' | 'soft-transient' | 'success'
+
+function retryableFakeSession(behaviors: RetryBehavior[]) {
+  const listeners: Array<(event: FakeEvent) => void> = []
+  const messages: Array<{ role: string; stopReason?: string }> = []
+  let idx = 0
+  const run = (viaContinue: boolean) => {
+    const behavior = behaviors[Math.min(idx, behaviors.length - 1)]!
+    idx++
+    if (!viaContinue) messages.push({ role: 'user' })
+    if (behavior === 'throw-before-assistant') {
+      // provider dies before writing any assistant message: trailing leaf stays 'user'
+      throw new Error('provider_transport_failure')
+    }
+    if (behavior === 'throw-transient') {
+      messages.push({ role: 'assistant', stopReason: 'error' })
+      throw new Error('socket hang up')
+    }
+    if (behavior === 'soft-transient') {
+      messages.push({ role: 'assistant', stopReason: 'error' })
+      for (const cb of listeners)
+        cb({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: 'ECONNRESET' } })
+      return
+    }
+    messages.push({ role: 'assistant', stopReason: 'stop' })
+  }
+  const session = {
+    prompt: async () => run(false),
+    subscribe: (cb: (event: FakeEvent) => void) => {
+      listeners.push(cb)
+      return () => {
+        const i = listeners.indexOf(cb)
+        if (i >= 0) listeners.splice(i, 1)
+      }
+    },
+    setModel: async () => {},
+    agent: {
+      state: {
+        get messages() {
+          return messages
+        },
+        set messages(v: Array<{ role: string; stopReason?: string }>) {
+          messages.length = 0
+          messages.push(...v)
+        },
+      },
+      continue: async () => run(true),
+    },
+  } as unknown as AgentSession
+  return { session, userMessages: () => messages.filter((m) => m.role === 'user').length, attempts: () => idx }
+}
+
+describe('promptPersistentTurnWithFallback same-ref retry', () => {
+  test('a transient soft error recovers via agent.continue without duplicating the user message', async () => {
+    const fake = retryableFakeSession(['soft-transient', 'success'])
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_A)
+    expect(fake.attempts()).toBe(2) // one prompt + one continue-retry
+    expect(fake.userMessages()).toBe(1) // continue() did NOT re-append the user message
+  })
+
+  test('a transient hard throw recovers via agent.continue on the same ref', async () => {
+    const fake = retryableFakeSession(['throw-transient', 'success'])
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+    })
+
+    expect(result.success).toBe(true)
+    expect(fake.userMessages()).toBe(1)
+  })
+
+  test('recovers a transport failure that died BEFORE the assistant stream started (the reported incident)', async () => {
+    // given: first attempt throws provider_transport_failure with only a user leaf
+    // in state (no assistant message written); the same-ref continue() then succeeds
+    const fake = retryableFakeSession(['throw-before-assistant', 'success'])
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(REF_A)
+    expect(fake.attempts()).toBe(2) // prompt threw pre-stream, continue() recovered
+    expect(fake.userMessages()).toBe(1) // no duplicate user message
+  })
+
+  test('a single turn does not self-trip the throttle circuit across same-ref retries', async () => {
+    // given: the ref keeps failing transiently for the whole retry budget
+    const circuit = new ThrottleCircuit()
+    const fake = retryableFakeSession(['soft-transient', 'soft-transient', 'soft-transient'])
+    await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      profile: 'default',
+      session: fake.session,
+      text: 'hello',
+      circuit,
+      // ECONNRESET is retryable-same-ref but NOT failover-worthy, so shouldFailover
+      // is false — no throttle should be recorded at all here.
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+    })
+
+    // one throttle record would need THRESHOLD(2) to open; a single turn must not
+    // reach it — the circuit stays closed for REF_A.
+    expect(circuit.isOpen({ profile: 'default', ref: REF_A })).toBe(false)
+  })
+})

--- a/src/agent/turn-runner.ts
+++ b/src/agent/turn-runner.ts
@@ -1,7 +1,8 @@
 import type { ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
-import { detectProviderError, subscribeProviderErrors } from './provider-error'
+import { detectProviderError, isRetryableSameRef, subscribeProviderErrors } from './provider-error'
+import { RETRIES_PER_REF, retryTurnOnPersistentSession } from './retry-same-ref'
 import { modelThrottleCircuit, type ThrottleCircuit } from './throttle-circuit'
 
 export type PersistentTurnAttempt = {
@@ -73,50 +74,78 @@ export async function promptPersistentTurnWithFallback(opts: {
           if (softError === undefined) softError = new Error(err.message)
         })
     try {
-      try {
-        await opts.session.prompt(opts.text)
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err))
-        const attempt: PersistentTurnAttempt = { ref, outcome: 'hard', errorMessage: error.message }
-        attempts.push(attempt)
-        lastError = error
-        if (opts.shouldFailover(error)) circuit.recordThrottle({ profile: opts.profile, ref })
-        if (isLast || !canAdvance(error, activity, opts.shouldFailover)) throw error
-        opts.onAttemptFailed?.(attempt)
-        continue
-      }
-      if (softError !== undefined) {
-        const attempt: PersistentTurnAttempt = { ref, outcome: 'soft', errorMessage: softError.message }
-        attempts.push(attempt)
-        lastError = softError
-        if (opts.shouldFailover(softError)) circuit.recordThrottle({ profile: opts.profile, ref })
-        if (isLast || !canAdvance(softError, activity, opts.shouldFailover)) {
-          return { success: false, refUsed: ref, attempts, lastError }
+      // Same-ref retry loop: replay this ref on a transient failure before
+      // advancing the chain. `retry === 0` is the first, prompt()-driven attempt;
+      // later iterations resume via agent.continue() (no user-message re-append).
+      let outcome: AttemptOutcome | undefined
+      for (let retry = 0; ; retry++) {
+        softError = undefined
+        let outcomeThisAttempt: AttemptOutcome | undefined
+        try {
+          if (retry === 0) {
+            await opts.session.prompt(opts.text)
+          } else {
+            const retried = await retryTurnOnPersistentSession(opts.session, { attempt: retry - 1 })
+            // The safe continue-recipe couldn't apply: keep the PREVIOUS failure
+            // outcome (never cleared) and let it drive the advance/return below.
+            if (!retried) break
+          }
+          outcomeThisAttempt = classifySoftOutcome(softError, opts)
+        } catch (err) {
+          outcomeThisAttempt = { kind: 'hard', error: err instanceof Error ? err : new Error(String(err)) }
         }
-        opts.onAttemptFailed?.(attempt)
-        continue
+        outcome = outcomeThisAttempt
+        if (outcome === undefined) break
+        // Only keep retrying while the failure is same-ref retryable, the turn
+        // stayed idempotent (no output/tool-exec yet), and budget remains.
+        const mayRetry =
+          retry < RETRIES_PER_REF &&
+          isRetryableSameRef(outcome.error.message) &&
+          !activity.producedAssistantOutput &&
+          !activity.startedToolExecution
+        if (!mayRetry) break
       }
-      const leafSoftError = opts.detectSoftErrorFromLeaf ? detectLeafSoftError(opts.session) : undefined
-      if (leafSoftError !== undefined) {
-        const attempt: PersistentTurnAttempt = { ref, outcome: 'soft', errorMessage: leafSoftError.message }
-        attempts.push(attempt)
-        lastError = leafSoftError
-        if (opts.shouldFailover(leafSoftError)) circuit.recordThrottle({ profile: opts.profile, ref })
-        if (isLast || !canAdvance(leafSoftError, activity, opts.shouldFailover)) {
-          return { success: false, refUsed: ref, attempts, lastError }
-        }
-        opts.onAttemptFailed?.(attempt)
-        continue
+
+      if (outcome === undefined) {
+        attempts.push({ ref, outcome: 'success' })
+        circuit.recordSuccess({ profile: opts.profile, ref })
+        return { success: true, refUsed: ref, attempts }
       }
-      attempts.push({ ref, outcome: 'success' })
-      circuit.recordSuccess({ profile: opts.profile, ref })
-      return { success: true, refUsed: ref, attempts }
+
+      // Ref abandoned after exhausting same-ref retries. Record throttle ONCE
+      // here (not per internal retry) so a single turn can't self-trip the
+      // circuit breaker.
+      const attempt: PersistentTurnAttempt = { ref, outcome: outcome.kind, errorMessage: outcome.error.message }
+      attempts.push(attempt)
+      lastError = outcome.error
+      if (opts.shouldFailover(outcome.error)) circuit.recordThrottle({ profile: opts.profile, ref })
+      if (isLast || !canAdvance(outcome.error, activity, opts.shouldFailover)) {
+        if (outcome.kind === 'hard') throw outcome.error
+        return { success: false, refUsed: ref, attempts, lastError }
+      }
+      opts.onAttemptFailed?.(attempt)
+      continue
     } finally {
       unsubProvider()
       unsubActivity()
     }
   }
   return { success: false, refUsed: opts.refs[opts.refs.length - 1]!, attempts, lastError }
+}
+
+type AttemptOutcome = { kind: 'hard' | 'soft'; error: Error }
+
+// Classify a completed (non-throwing) attempt: a captured soft error, else a
+// leaf soft error (subagent path), else success (undefined). Mirrors the two
+// soft-error sources the loop handled inline before the retry refactor.
+function classifySoftOutcome(
+  softError: Error | undefined,
+  opts: { session: AgentSession; detectSoftErrorFromLeaf?: boolean },
+): AttemptOutcome | undefined {
+  if (softError !== undefined) return { kind: 'soft', error: softError }
+  const leafSoftError = opts.detectSoftErrorFromLeaf ? detectLeafSoftError(opts.session) : undefined
+  if (leafSoftError !== undefined) return { kind: 'soft', error: leafSoftError }
+  return undefined
 }
 
 function canAdvance(error: Error, activity: AttemptActivity, shouldFailover: (err: Error) => boolean): boolean {

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -8,6 +8,7 @@ import {
   type SessionOrigin,
 } from '@/agent'
 import { applyTurnThinkingLevel } from '@/agent/attention-escalation'
+import { promptWithSameRefRetryOnly } from '@/agent/retry-same-ref'
 import type { ChannelRouter } from '@/channels/router'
 import type { McpManager } from '@/mcp'
 import type { PermissionService } from '@/permissions'
@@ -427,7 +428,7 @@ export async function runPromptForCommand(args: {
         : `${renderTurnTimeAnchor()}\n\n${args.text}`
     applyTurnThinkingLevel(session, args.text, session.thinkingLevel)
     try {
-      await session.prompt(turnText)
+      await promptWithSameRefRetryOnly(session, turnText)
     } finally {
       await snapshot.hooks.runSessionTurnEnd(turnEvent)
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,6 +18,7 @@ import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
 import { detectProviderError, isFailoverWorthy } from '@/agent/provider-error'
 import { requestContainerRestart } from '@/agent/restart'
 import { consumeRestartHandoff, type RestartHandoff } from '@/agent/restart-handoff'
+import { promptWithSameRefRetryOnly } from '@/agent/retry-same-ref'
 import { sessionMetaPayload } from '@/agent/session-meta'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { parseSubagentCompletedPayload, renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
@@ -816,7 +817,7 @@ export function createServer({
                   ? `${renderTurnTimeAnchor()}\n\n${msg.text}\n\n${retrievalContext.results}`
                   : `${renderTurnTimeAnchor()}\n\n${msg.text}`
               applyTurnThinkingLevel(state.session, msg.text, state.turnThinkingDefault, state.lastQuestionSignal)
-              await state.session.prompt(turnText)
+              await promptWithSameRefRetryOnly(state.session, turnText)
               // A usable turn seeds the next turn's escalation; a failed leaf must
               // CLEAR the prior signal (not just skip), else an older question
               // leaks across the failed turn and wrongly escalates the next one.


### PR DESCRIPTION
## Background

A cron turn (`daily-stats-report`) ran but posted nothing to Slack: the turn died on a provider transport failure — the configured Codex/ChatGPT WebSocket session expired before the model stream even started (`provider_transport_failure`, "Expected 101 status code"). #1187 made transport failures eligible for model FALLBACK, but fallback only helps a profile with multiple model refs configured — and almost every user runs a single ref. A single-ref turn had nowhere to fall over to; what it actually needed was to retry the same model first.

Digging into the SDK (`@mariozechner/pi-coding-agent`) turned up same-model auto-retry that already existed (on by default, 3x) — with two gaps that explain why it didn't help here:

1. It only fires on soft errors (assistant `stopReason: 'error'`), never on a hard throw — and the reported incident (transport failure before the stream starts) is a hard throw, so nothing retried it.
2. A race: the SDK's auto-retry runs on the same session where typeclaw captures soft errors. typeclaw latches the failure the instant it fires; the SDK may then silently recover on its own retry, but typeclaw never un-latches, so a recovered turn is still reported FAILED (and on a multi-ref profile, burns an unnecessary failover). typeclaw only side-stepped this for throttle/overload via `abortRetry`, leaving transport/5xx/network soft errors racy.

## Summary

Own retry end-to-end in typeclaw's turn drivers instead of leaning on the SDK's auto-retry, establishing a clear hierarchy: retry the same model ref on a transient failure, then fall over to the next ref, then surface.

- **Disable the SDK's built-in auto-retry** at the single session-creation choke point. Verified from SDK source that compaction and context-overflow recovery are independent of retry (gated on compaction settings) and that `waitForRetry()` returns immediately when retry is disabled, so `prompt()` never hangs. This turns a soft error into a deterministic, typeclaw-owned signal and removes the race entirely.
- **New `isRetryableSameRef` predicate**, deliberately narrower than `isFailoverWorthy`: it matches transport/session drops, observer stalls, and network/5xx blips only. Throttle/overload (429/503) is excluded — that means the ref is out of capacity *now*, so it should fail OVER rather than burn a same-ref retry. Auth/billing/quota stay excluded too (must surface), and context-overflow is untouched (compaction owns it).
- **Idempotent same-ref replay.** A retry resumes via the SDK's `agent.continue()` after dropping any trailing assistant error leaf, so the user message is never duplicated. A turn that died before writing an assistant message at all (the reported incident — a trailing user leaf) is replayed as-is; anything else fails closed. Why `continue()` and not re-calling `prompt(text)`: re-prompting would duplicate the user message and corrupt history. This mirrors the shape of the SDK's own auto-retry.
- **Conservative budget:** `RETRIES_PER_REF=1` with full-jitter backoff. The pi-ai provider layer already retries transport/5xx blips underneath us, and each attempt is bounded by the existing observer timeouts (TTFB 15s / idle 120s / overall 300s) — a larger retry count would turn one outage into minutes of dead air.
- **Guards:** retries never fire once assistant output or a tool call has started (idempotency), and throttle is recorded once per abandoned ref rather than per internal retry, so a single turn can't self-trip the circuit breaker.
- **Wired into both turn drivers:** the cron helper (fresh session per attempt — dispose + recreate) and the persistent helper (channels/TUI/subagents — `continue()`-based, reusing one live session). Direct `session.prompt()` call sites with no fallback chain (non-stream TUI, slash commands, subagent drain + required-block nudges, multimodal look-at) go through a new `promptWithSameRefRetryOnly` wrapper so they keep the same-model resilience the SDK auto-retry used to give them, without the race.

## What this does NOT do

- Does not add cross-ref fallback to the direct-prompt paths — they have no chain, only same-model retry.
- Does not expose retry policy as config. `RETRIES_PER_REF` and the backoff are module constants for now, deliberately not surfaced as per-error-class or per-ref knobs yet.
- Does not change the fallback classification landed in #1187 — transport failures were already made failover-worthy there; this PR only adds the retry step in front of it.
- Does not retry auth/billing/quota/context-overflow/throttle on the same ref, by design (see `isRetryableSameRef`).
- Does not add cron failure alerting or auto-retry scheduling — a separate concern raised in the incident thread.

## Review notes

- Load-bearing invariants to verify:
  1. Same-ref replay never duplicates the user message — `retryTurnOnPersistentSession` pops only a trailing assistant leaf, replays a trailing user leaf as-is, and fails closed on anything else.
  2. Disabling the SDK auto-retry does not break compaction/context-overflow recovery (independent gate) and does not hang `prompt()`.
  3. Throttle is recorded once per abandoned ref, not per internal retry — no circuit self-trip.
  4. `isRetryableSameRef` excludes throttle, auth/billing, and context-overflow.
- The reported-incident shape (transport failure before the assistant stream starts, i.e. a trailing user leaf) has a dedicated case in `turn-runner.test.ts`.
- The design went through two internal review passes: two self-caught control-flow bugs (a dispose regression in the cron path, a false-success on a failed continue-recipe in the persistent path) and two review-caught issues (the incident's user-leaf retry case, a regression on the direct-prompt paths) were all fixed with accompanying tests.
