### PR TITLE
fix(agent): document adapter-unavailable code in channel_edit tool

### DIFF
--- a/src/agent/tools/channel-edit.test.ts
+++ b/src/agent/tools/channel-edit.test.ts
@@ -149,6 +149,21 @@ describe('channel_edit tool', () => {
     expect(res.details).toMatchObject({ ok: false, code: 'not-supported' })
   })
 
+  test('passes the adapter-unavailable code through so agents can retry after re-auth', async () => {
+    const tool = createChannelEditTool({
+      router: fakeRouter(async () => ({
+        ok: false,
+        error: 'message-edit-adapter-unavailable',
+        code: 'adapter-unavailable',
+      })),
+      logger: silentLogger,
+    })
+
+    const res = await run(tool, params({ adapter: 'telegram-bot' }))
+
+    expect(res.details).toMatchObject({ ok: false, code: 'adapter-unavailable' })
+  })
+
   test('strips a leaked <think> block from the replacement before calling the router', async () => {
     const captured: EditMessageRequest[] = []
     const tool = createChannelEditTool({

--- a/src/agent/tools/channel-edit.ts
+++ b/src/agent/tools/channel-edit.ts
@@ -30,11 +30,13 @@ export function createChannelEditTool({ router, logger = consoleChannelLogger }:
       'adapter/workspace/chat you sent it to, and the new `text`. Use this to fix a typo, correct a wrong answer, ' +
       'or append a result to a status message you posted earlier — not to carry on a conversation (send a new ' +
       'message for that). Editing is supported on "slack-bot", "slack", "discord-bot", "discord", "telegram-bot", ' +
-      '"webex", "webex-bot", and "teams" (chats/DMs only — Teams team-channel posts cannot be edited); other ' +
-      'adapters return ' +
+      '"webex", "webex-bot", and "teams" (chats/DMs only — Teams team-channel posts cannot be edited); an adapter ' +
+      'that does not implement editing at all returns ' +
       '{ ok: false, error, code: "not-supported" }. You can only edit messages YOU authored; editing someone ' +
       'else\'s returns code "permission-denied". On success returns { ok: true }; a missing/deleted target returns ' +
-      'code "not-found".',
+      'code "not-found". Code "adapter-unavailable" is distinct from "not-supported": the adapter DOES support ' +
+      'editing but is not currently running (e.g. it failed to start on an expired token) — re-authenticating and ' +
+      'retrying may fix it, so do not treat it as permanently unsupported.',
     parameters: Type.Object({
       adapter: Type.Union(
         ADAPTER_IDS.map((a) => Type.Literal(a)),


### PR DESCRIPTION
## Background

The `channel_edit` tool description is the model's only guidance for the tool — there's no system-prompt section for it, so whatever the schema says is what the agent knows. That description enumerated only **three** of the four `EditMessageResult` codes (`EditMessageResult`, `src/channels/types.ts:301-307`): `not-supported`, `permission-denied`, and `not-found`. It silently dropped `adapter-unavailable`.

That omission matters because `adapter-unavailable` is the one failure code with an *actionable* remedy. The router returns it (`src/channels/router.ts:3924-3931`) when the adapter **does** support editing but currently has no live callback — e.g. it failed to start on an expired token. The fix is to re-authenticate and retry. But with the code undocumented, the model has no way to distinguish this transient auth outage from a permanent `not-supported`, and would treat a recoverable failure as "editing isn't supported here" and give up.

## Summary

Extend the tool description to document `adapter-unavailable` and, crucially, contrast it with `not-supported`: the adapter DOES support editing but isn't running right now, so re-auth + retry may fix it. This mirrors the exact three-way distinction that `getMessage` already documents and that the `EditMessageResult` type comment (`src/channels/types.ts:293-300`) spells out — editing was simply inconsistent with its read-side sibling.

Also adds a passthrough test asserting the `adapter-unavailable` code reaches the tool result unchanged, paired next to the existing `not-supported` passthrough test.

## What this does NOT do

- No runtime/behavior change — the router already returned this code; only the tool's *documentation* of it was missing. Purely the LLM-facing description string plus a guard test.
- Does not touch any adapter, the router's edit path, or the `EditMessageResult` type.
- Does not add a system-prompt section for `channel_edit` (the schema remains the sole guidance surface, by design).

## Review notes

- Load-bearing change is the appended sentence in the `description` (`src/agent/tools/channel-edit.ts`), specifically the "distinct from not-supported … re-authenticating and retrying may fix it" framing — that's what steers the model to retry instead of abandoning the edit.
- The new test asserts only the `code` passes through; it deliberately doesn't assert on the human-readable error string, which stays adapter-scoped.