### PR TITLE
fix(channels): strip trailing tool-call leaks from outbound messages

### DIFF
--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -149,6 +149,24 @@ describe('createChannelReplyTool', () => {
     expect(result.details).toEqual({ ok: true, messageId: 'ts1', messageIds: ['ts1', 'ts2'] })
   })
 
+  test('strips a trailing tool-call leak from text, sending only the prose', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelReplyTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+      origin: slackThreadOrigin,
+    })
+    const result = await runTool(tool, {
+      text: 'hmm, not really sure about that one\n\nskip_response({ reason: "no new info" })',
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.text).toBe('hmm, not really sure about that one')
+    expect(calls[0]!.text).not.toContain('skip_response')
+    expect(result.details).toMatchObject({ ok: true })
+  })
+
   test('combines continue with messageId when a mid-turn ack carries an id', async () => {
     const tool = createChannelReplyTool({
       router: fakeRouter(async () => ({ ok: true, messageId: 'ts9', messageIds: ['ts9'] })),

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -7,6 +7,7 @@ import {
   containsKimiToolDelimiter,
   isNoReplySignal,
   isUpstreamEmptyResponseSentinel,
+  stripTrailingLeakedToolCall,
   type ChannelRouter,
 } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
@@ -100,7 +101,7 @@ export function createChannelReplyTool({
     }),
 
     async execute(_toolCallId, params) {
-      const text = params.text
+      let text = params.text
       const attachments = params.attachments
       const keepTurnAlive = params.continue === true
       if ((text === undefined || text === '') && (attachments === undefined || attachments.length === 0)) {
@@ -137,6 +138,19 @@ export function createChannelReplyTool({
         return {
           content: [{ type: 'text' as const, text: `channel_reply denied: ${kimiLeakError}` }],
           details: { ok: false, error: kimiLeakError },
+        }
+      }
+
+      // Prose-then-trailing-call leak (mirrors router.ts + channel-send.ts):
+      // strip a serialized trailing tool call while keeping the real reply
+      // prose, rather than denying and stranding the user's answer.
+      if (text !== undefined) {
+        const trailingLeak = stripTrailingLeakedToolCall(text)
+        if (trailingLeak !== null && trailingLeak.text !== '') {
+          logger.warn(
+            formatChannelToolFailure('channel_reply', `stripped trailing_tool_call_leak tool=${trailingLeak.toolName}`),
+          )
+          text = trailingLeak.text
         }
       }
 

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -108,6 +108,26 @@ describe('createChannelSendTool', () => {
     expect(result.details).toEqual({ ok: true })
   })
 
+  test('strips a trailing tool-call leak from text, sending only the prose', async () => {
+    const calls: OutboundMessage[] = []
+    const tool = createChannelSendTool({
+      router: fakeRouter(async (msg) => {
+        calls.push(msg)
+        return { ok: true }
+      }),
+    })
+    const result = await runTool(tool, {
+      adapter: 'discord-bot',
+      workspace: 'g1',
+      chat: 'c1',
+      text: 'hmm, not really sure about that one\n\nskip_response({ reason: "no new info" })',
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.text).toBe('hmm, not really sure about that one')
+    expect(calls[0]!.text).not.toContain('skip_response')
+    expect(result.details).toMatchObject({ ok: true })
+  })
+
   test('surfaces messageId and messageIds from the router result in details', async () => {
     const tool = createChannelSendTool({
       router: fakeRouter(async () => ({ ok: true, messageId: '1700.0001', messageIds: ['1700.0001', '1700.0002'] })),

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -8,6 +8,7 @@ import {
   containsKimiToolDelimiter,
   isNoReplySignal,
   isUpstreamEmptyResponseSentinel,
+  stripTrailingLeakedToolCall,
   type ChannelRouter,
 } from '@/channels/router'
 import { ADAPTER_IDS, type AdapterId } from '@/channels/schema'
@@ -124,7 +125,7 @@ export function createChannelSendTool({
 
     async execute(_toolCallId, params) {
       const adapter = params.adapter as AdapterId
-      const bodyText = params.text
+      let bodyText = params.text
       const attachments = params.attachments
       if ((bodyText === undefined || bodyText === '') && (attachments === undefined || attachments.length === 0)) {
         logger.warn(formatChannelToolFailure('channel_send', 'missing text and attachments'))
@@ -160,6 +161,21 @@ export function createChannelSendTool({
         return {
           content: [{ type: 'text' as const, text: `channel_send denied: ${kimiLeakError}` }],
           details: { ok: false, error: kimiLeakError },
+        }
+      }
+
+      // Prose-then-trailing-call leak (mirrors router.ts validateChannelTurn):
+      // the model put a real reply plus a serialized trailing tool call in the
+      // `text` arg. Strip the plumbing and keep the prose rather than denying,
+      // so the legitimate reply still reaches the channel. Whole-message calls
+      // (no prose prefix) are untouched here and left to the router's recovery.
+      if (bodyText !== undefined) {
+        const trailingLeak = stripTrailingLeakedToolCall(bodyText)
+        if (trailingLeak !== null && trailingLeak.text !== '') {
+          logger.warn(
+            formatChannelToolFailure('channel_send', `stripped trailing_tool_call_leak tool=${trailingLeak.toolName}`),
+          )
+          bodyText = trailingLeak.text
         }
       }
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -29,6 +29,7 @@ import {
   EMPTY_TURN_RETRY_NUDGE,
   extractPlainTextChannelToolCallText,
   getPlainTextChannelToolCallKind,
+  stripTrailingLeakedToolCall,
   HISTORY_ATTACHMENT_LIMIT,
   MAX_CHANNEL_SENDS_PER_TURN,
   MAX_EMPTY_TURN_RETRIES,
@@ -4865,6 +4866,30 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
+  test('posts only the prose when a real reply is followed by a trailing skip_response leak', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: "you're not really an AI, right?" }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText(
+        'hmm, not really sure about that one\n\nskip_response({ reason: "Natural conversation end, no new info to add" })',
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('hmm, not really sure about that one')
+    expect(sent[0]!.text).not.toContain('skip_response')
+    expect(logs.some((m) => m.includes('stripped trailing_tool_call_leak tool=skip_response'))).toBe(true)
+  })
+
   test('suppresses a quote-free skip_response() leak SILENTLY (no self-correction nudge)', async () => {
     const dir = await tempDir()
     const logs: string[] = []
@@ -5029,6 +5054,211 @@ describe('ChannelRouter channel-turn protocol', () => {
       expect(getPlainTextChannelToolCallKind('read({ path: "x" }) loads a file for you')).toBeNull()
       expect(getPlainTextChannelToolCallKind('You can use bash("ls") to list files')).toBeNull()
       expect(getPlainTextChannelToolCallKind('channel_disengagement is the noun')).toBeNull()
+    })
+  })
+
+  describe('stripTrailingLeakedToolCall', () => {
+    test('strips a real reply followed by a trailing skip_response leak, keeping only the prose', () => {
+      const leak =
+        'hmm, not really sure about that one\n\nskip_response({ reason: "Natural conversation end, no new info to add" })'
+      const res = stripTrailingLeakedToolCall(leak)
+      expect(res?.text).toBe('hmm, not really sure about that one')
+      expect(res?.toolName).toBe('skip_response')
+    })
+
+    test('is language-agnostic: strips after Japanese and Arabic prefixes too', () => {
+      expect(stripTrailingLeakedToolCall('なるほど、それは分かりません\n\nskip_response({ reason: "x" })')?.text).toBe(
+        'なるほど、それは分かりません',
+      )
+      expect(stripTrailingLeakedToolCall('لا أعرف ذلك حقًا\n\nskip_response()')?.text).toBe('لا أعرف ذلك حقًا')
+    })
+
+    test('normalizes CRLF and strips the trailing call', () => {
+      expect(stripTrailingLeakedToolCall('hello there\r\n\r\nskip_response()')?.text).toBe('hello there')
+    })
+
+    test('strips a trailing channel_reply/send leak without recovering its text arg', () => {
+      const res = stripTrailingLeakedToolCall('here you go\n\nchannel_reply({"text":"hi"})')
+      expect(res?.text).toBe('here you go')
+      expect(res?.toolName).toBe('channel_reply')
+    })
+
+    test('strips a truncated (unbalanced) trailing call — partial plumbing must not ship', () => {
+      expect(stripTrailingLeakedToolCall('answer text\n\nskip_response({ reason: "hi')?.text).toBe('answer text')
+    })
+
+    test('strips multiple contiguous trailing call blocks, keeping the prose', () => {
+      const res = stripTrailingLeakedToolCall('my answer\n\nchannel_react({ emoji: "eyes" })\n\nskip_response()')
+      expect(res?.text).toBe('my answer')
+      // The OUTERMOST (last) leaked call is reported as the tool name.
+      expect(res?.toolName).toBe('skip_response')
+    })
+
+    test('strips a leak that follows a CLOSED fenced code block', () => {
+      expect(stripTrailingLeakedToolCall('```\ncode\n```\n\nsome answer\n\nskip_response()')?.text).toBe(
+        '```\ncode\n```\n\nsome answer',
+      )
+    })
+
+    test('leaves an inline tool mention untouched (not a whole-message trailing call)', () => {
+      expect(stripTrailingLeakedToolCall('Use skip_response() when you want silence.')).toBeNull()
+      expect(stripTrailingLeakedToolCall('read({ path: "x" }) loads a file.')).toBeNull()
+    })
+
+    test('leaves a call that is followed by more prose untouched', () => {
+      expect(stripTrailingLeakedToolCall('prose\n\nskip_response()\n\nmore explanation here.')).toBeNull()
+    })
+
+    test('requires a BLANK line: an adjacent final call line is left untouched', () => {
+      expect(stripTrailingLeakedToolCall('Explanation:\nskip_response()')).toBeNull()
+    })
+
+    test('leaves a call INSIDE an open fenced code block untouched (legitimate teaching)', () => {
+      expect(stripTrailingLeakedToolCall('example:\n\n```\nskip_response()\n```')).toBeNull()
+    })
+
+    test('leaves a call inside a tilde-fenced code block untouched', () => {
+      expect(stripTrailingLeakedToolCall('example:\n\n~~~\nskip_response()\n~~~')).toBeNull()
+    })
+
+    // Each pseudo-closer fixture ends with a blank-line-separated bare
+    // `skip_response()` immediately after the pseudo-closer and omits any later
+    // real fence, so the trailing candidate IS a whole-message call and the ONLY
+    // thing keeping it unstripped is `startsInsideFencedCodeBlock` treating the
+    // fence as still-open. Reverting the scanner fix therefore fails these.
+    test('a SHORTER fence run does not close a longer opener — the call stays fenced', () => {
+      // CommonMark: a closer must be at least as long as the opener, so the ```
+      // line inside the ```` block is content and the fence stays open.
+      expect(stripTrailingLeakedToolCall('example:\n\n````\ncode\n```\n\nskip_response()')).toBeNull()
+    })
+
+    test('a fence run with trailing non-whitespace does not close — the call stays fenced', () => {
+      // CommonMark: a closer carries only whitespace after the run; ``` js is an
+      // info string, so it never closes and the fence stays open.
+      expect(stripTrailingLeakedToolCall('```\ncode\n``` js\n\nskip_response()')).toBeNull()
+    })
+
+    test('a 4-space-indented fence run does not close — the call stays fenced', () => {
+      // CommonMark: a closing fence has at most 3 leading spaces; 4+ is an
+      // indented-code line, not a closer, so the fence stays open.
+      expect(stripTrailingLeakedToolCall('example:\n\n```\ncode\n    ```\n\nskip_response()')).toBeNull()
+    })
+
+    test('a backtick-fence opener whose info string contains a backtick opens nothing — later call is stripped', () => {
+      // CommonMark forbids a backtick in a backtick-fence info string, so this
+      // line is not a valid opener and the later call is NOT protected.
+      expect(stripTrailingLeakedToolCall('answer\n\n``` docs `x`\n\nskip_response()')?.text).toBe(
+        'answer\n\n``` docs `x`',
+      )
+    })
+
+    test('a same-length closing fence DOES close, so a later real leak is stripped', () => {
+      // Guards the fix against over-correcting: once the fence is properly closed
+      // by an equal-length run, a genuine trailing leak after it is still caught.
+      expect(stripTrailingLeakedToolCall('````\ncode\n````\n\nreal answer\n\nskip_response()')?.text).toBe(
+        '````\ncode\n````\n\nreal answer',
+      )
+    })
+
+    test('a mismatched-character fence run does not close — the call stays fenced', () => {
+      // CommonMark: a closer must use the SAME fence character. A ~~~ line inside
+      // a ``` block (and the reverse) is content, so the fence stays open.
+      expect(stripTrailingLeakedToolCall('```\ncode\n~~~\n\nskip_response()')).toBeNull()
+      expect(stripTrailingLeakedToolCall('~~~\ncode\n```\n\nskip_response()')).toBeNull()
+    })
+
+    test('a fence opened inside a list item stays open while the candidate stays indented', () => {
+      // CommonMark parses `- ``` ` as a list item introducing a fenced block; the
+      // trailing call is still indented into the item, so it stays fenced.
+      expect(stripTrailingLeakedToolCall('example:\n\n- ```\n  code\n\n  skip_response()')).toBeNull()
+      expect(stripTrailingLeakedToolCall('example:\n\n1. ```\n   code\n\n   skip_response()')).toBeNull()
+    })
+
+    test('abandons a list fence when the trailing candidate is dedented out of the item — call stripped', () => {
+      // The bare (column-0) trailing call is indented before the item's content
+      // column, so it has LEFT the list item and the fence no longer protects it.
+      expect(stripTrailingLeakedToolCall('example:\n\n- ```\n  code\n\nskip_response()')?.text).toBe(
+        'example:\n\n- ```\n  code',
+      )
+    })
+
+    test('abandons a blockquote fence when the trailing candidate is unquoted — call stripped', () => {
+      // The bare (unquoted) trailing call has LEFT the blockquote that owns the
+      // fence, so the fence no longer protects it and the call is a real leak.
+      expect(stripTrailingLeakedToolCall('> ```\n> code\n\nskip_response()')?.text).toBe('> ```\n> code')
+    })
+
+    test('a QUOTED trailing candidate is filtered before the fence check (not a whole-message call)', () => {
+      // A `> skip_response()` candidate is not a bare tool call (leading `>`), so
+      // isWholeMessageToolCall rejects it and the message is left untouched — the
+      // fence path is never reached.
+      expect(stripTrailingLeakedToolCall('> ```\n> code\n\n> skip_response()')).toBeNull()
+    })
+
+    test('a CLOSED blockquote fence lets a later real leak be stripped', () => {
+      // Counterpart to the open-blockquote case: once the `> ``` ` fence is closed
+      // (also blockquoted), a genuine trailing leak after it is still caught.
+      expect(stripTrailingLeakedToolCall('> ```\n> code\n> ```\n\nanswer\n\nskip_response()')?.text).toBe(
+        '> ```\n> code\n> ```\n\nanswer',
+      )
+    })
+
+    test('abandons an open blockquote fence after an unquoted non-blank line — later leak is stripped', () => {
+      // The blockquote fence is never explicitly closed, but leaving the blockquote
+      // (an unquoted non-blank line `answer`) ends the container that owns it, so
+      // the fence is abandoned and the trailing call is a real leak.
+      expect(stripTrailingLeakedToolCall('> ```\n> code\n\nanswer\n\nskip_response()')?.text).toBe(
+        '> ```\n> code\n\nanswer',
+      )
+    })
+
+    test('abandons an open list fence after dedenting out of the item — later leak is stripped', () => {
+      // The `- ``` ` fence opens inside a list item; a later non-blank line indented
+      // before the item's content column (`answer` at column 0) leaves the item, so
+      // the fence is abandoned and the trailing call is stripped.
+      expect(stripTrailingLeakedToolCall('example:\n\n- ```\n  code\n\nanswer\n\nskip_response()')?.text).toBe(
+        'example:\n\n- ```\n  code\n\nanswer',
+      )
+    })
+
+    test('a list-marker-prefixed fence never CLOSES an open fence — a later real leak is stripped', () => {
+      // Inside an already-open top-level fence, a `- ``` ` line is content, not a
+      // closer, so the block the reviewer flagged cannot be abused to swallow a
+      // genuine trailing leak. The equal-length top-level closer still closes it.
+      expect(stripTrailingLeakedToolCall('```\n- ```\n```\n\nreal answer\n\nskip_response()')?.text).toBe(
+        '```\n- ```\n```\n\nreal answer',
+      )
+    })
+
+    test('abandons a blockquote+list stacked fence when the candidate leaves the blockquote — call stripped', () => {
+      // A `> - ``` ` fence requires BOTH a blockquote and the list indent. The
+      // candidate `  skip_response()` still meets the list column (2) but is
+      // unquoted — it has left the blockquote — so the fence is abandoned and the
+      // call is a real leak, not fenced content.
+      expect(stripTrailingLeakedToolCall('> - ```\n>   code\n\n  skip_response()')?.text).toBe('> - ```\n>   code')
+    })
+
+    test('abandons a CONTINUATION-line list fence when the candidate is dedented — call stripped', () => {
+      // The fence opens on the list item's continuation line (`  ``` `, not a
+      // `- ``` ` marker line), so it inherits the item's content column (2). The
+      // column-0 candidate has dedented out of the item, so the call is stripped.
+      expect(stripTrailingLeakedToolCall('- item text\n  ```\n  code\n\nskip_response()')?.text).toBe(
+        '- item text\n  ```\n  code',
+      )
+    })
+
+    test('a CONTINUATION-line list fence protects a candidate that stays in the item', () => {
+      // Same continuation-line fence, but the candidate stays indented into the
+      // item (column 2), so it remains fenced content and is not stripped.
+      expect(stripTrailingLeakedToolCall('- item text\n  ```\n  code\n\n  skip_response()')).toBeNull()
+    })
+
+    test('returns null for a whole-message call (no prose prefix) — that is the other parser’s job', () => {
+      expect(stripTrailingLeakedToolCall('skip_response({ reason: "x" })')).toBeNull()
+    })
+
+    test('returns null for ordinary prose with no trailing call', () => {
+      expect(stripTrailingLeakedToolCall('just a normal reply, nothing leaked here')).toBeNull()
     })
   })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4758,6 +4758,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return
     }
 
+    // Prose-then-trailing-call leak: the model wrote a real reply and then
+    // serialized a tool decision as a trailing block (the Discord skip_response
+    // incident). Strip the plumbing and keep the prose BEFORE the whole-message
+    // classification below, so a message that was ONLY the call still reaches the
+    // existing name-dependent suppress/recover path, while a message with real
+    // prose keeps that prose. Prefix-first: no arg-recovery, no nudge, no ack.
+    const trailingLeak = stripTrailingLeakedToolCall(assistantText)
+    if (trailingLeak !== null && trailingLeak.text !== '') {
+      logger.warn(
+        `[channels] ${live.keyId}: stripped trailing_tool_call_leak tool=${trailingLeak.toolName} ` +
+          `text_len=${trailingLeak.text.length}`,
+      )
+      assistantText = trailingLeak.text
+    }
+
     if (isUpstreamEmptyResponseSentinel(assistantText)) {
       logger.warn(
         `[channels] ${live.keyId}: suppressed upstream_empty_response_sentinel text_len=${assistantText.length}`,
@@ -6864,6 +6879,233 @@ export function isWholeMessageToolCall(text: string): string | null {
   const rest = trimmed.slice(i + 1).trim()
   if (rest === '' || rest === ';') return name
   return null
+}
+
+export type TrailingToolCallLeak = { text: string; toolName: string; leakedCall: string }
+
+// Catches the sibling leak that `isWholeMessageToolCall` cannot: the model wrote
+// a REAL reply, then serialized a tool decision as a trailing block instead of
+// emitting a real tool call. The production incident (Discord) was Korean prose,
+// a blank line, then `skip_response({ reason: "..." })` — the whole-message
+// parser saw prose before the call, returned null, and the plumbing shipped
+// verbatim, confirming to probing users that it's a bot and exposing an internal
+// tool name.
+//
+// The whole-message contract of `isWholeMessageToolCall` is deliberately NOT
+// broadened: it stays "the entire message is a call" so a name-dependent
+// disposition (reply/send recover, skip silent, else nudge) still applies to a
+// message that is nothing but a call. This is the STRICTLY narrower sibling —
+// "prose, THEN a trailing standalone call block" — with a prefix-first
+// disposition: the prose is a legitimate reply the user must see, so we post it
+// and drop only the trailing plumbing, regardless of which tool leaked. No
+// arg-recovery, no nudge, no silent-turn ack — the prose already satisfied the
+// turn.
+//
+// The false-positive surface is contained by three STRUCTURAL (language-agnostic,
+// per the repo's multi-language rule) signals, none of which interpret prose:
+//   1. a BLANK line must separate prefix from the trailing block — an adjacent
+//      final line (`Explanation:\nskip_response()`) is left untouched, since a
+//      model teaching a tool inline never blank-line-separates the example;
+//   2. the trailing block must independently satisfy `isWholeMessageToolCall`
+//      (bracket-aware, quote-honoring) — a bare `channel_react whenever…` word or
+//      `read({...}) loads a file` mid-sentence is not a whole call;
+//   3. the block must NOT begin inside a Markdown fenced code block — a fenced
+//      ``` example ending in a call is legitimate teaching output.
+// The prefix must stay non-empty after trimming, else this is the whole-message
+// case and belongs to the existing parser.
+//
+// Multiple contiguous trailing call blocks are stripped iteratively (each must
+// independently pass the predicate); the loop stops at the first non-call block.
+export function stripTrailingLeakedToolCall(text: string): TrailingToolCallLeak | null {
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  let body = normalized
+  let outerToolName: string | null = null
+  let outerLeakedCall = ''
+
+  for (;;) {
+    // Locate the final blank-line-separated block: <prefix>\n[ \t]*\n<candidate>,
+    // where <candidate> is the trailing run with no interior blank line.
+    const match = /\n[ \t]*\n([^\n]*(?:\n(?![ \t]*\n)[^\n]*)*)[ \t\n]*$/.exec(body)
+    if (match === null) break
+    const rawCandidate = match[1]!
+    const candidate = rawCandidate.trim()
+    if (candidate === '') break
+    const prefix = body.slice(0, match.index)
+    if (prefix.trim() === '') break
+
+    // Classify BEFORE the fence check: a whole-message tool call can never itself
+    // be a fence marker, which is what lets the fence scanner treat the
+    // candidate's first line purely as a container-continuation signal.
+    const toolName = isWholeMessageToolCall(candidate)
+    if (toolName === null) break
+
+    // The candidate's own first line decides whether it still continues an open
+    // list/blockquote container: an unquoted or dedented candidate has LEFT the
+    // container, so a container-owned fence no longer protects it.
+    const candidateFirstLine = rawCandidate.split('\n', 1)[0]!
+    if (startsInsideFencedCodeBlock(prefix, candidateFirstLine)) break
+
+    if (outerToolName === null) {
+      outerToolName = toolName
+      outerLeakedCall = candidate
+    }
+    body = prefix
+  }
+
+  if (outerToolName === null) return null
+  return { text: body.trimEnd(), toolName: outerToolName, leakedCall: outerLeakedCall }
+}
+
+// A fence carries the container requirements it was opened under. Both are
+// independent: a `> - ``` ` opener requires BOTH a blockquote (`requiresQuote`)
+// and the list content column, so leaving EITHER container abandons the fence.
+// This captures at most one blockquote requirement + one post-blockquote list
+// column — a bounded stack, not an arbitrary container parser.
+type FenceOwner = { requiresQuote: boolean; listContentColumn: number | null }
+type OpenFence = { char: '`' | '~'; len: number; owner: FenceOwner }
+
+// Best-effort fenced-code detection for the trailing-tool-call safety guard.
+// Returns true when the candidate (whose first raw line is `candidateFirstLine`)
+// sits inside a still-open Markdown fence — meaning the trailing call is fenced
+// example content and must NOT be stripped.
+//
+// Top-level and blockquote-prefixed fences use normal opener/closer bookkeeping;
+// list-marker-prefixed fences are recognized as OPENERS only. An open
+// blockquote-owned fence is abandoned by an unquoted non-blank line, and an open
+// list-owned fence by a non-blank line indented before the marker's recorded
+// content column (see `abandonIfLeftContainer`). The candidate's OWN first line is
+// run through the same abandon check last: an unquoted/dedented candidate has left
+// its container, so a container-owned fence no longer protects it and the call is
+// stripped. Blank lines never abandon; top-level fences are never abandoned, so a
+// column-zero candidate under an ordinary open top-level fence stays protected.
+//
+// This deliberately approximates container continuity: a fence tracks at most one
+// blockquote requirement plus one post-blockquote list content column (so a
+// `> - ``` ` fence requires BOTH), while paragraph lazy continuation, exact
+// CommonMark list padding, DEEPER nested stacks (list-in-list, quote-in-list-in-
+// quote), and container re-entry are out of scope. The safety bias is toward "in a
+// fence" (a missed close leaves a legitimate example unstripped, safer than
+// stripping it), bounded by the container-exit rules so a real leak that has left
+// its container is still caught.
+function startsInsideFencedCodeBlock(prefix: string, candidateFirstLine: string): boolean {
+  let open: OpenFence | null = null
+  // The list item currently in effect (measured post-blockquote-strip), so a
+  // fence that opens on a list item's CONTINUATION line — `- item`\n`  ``` `,
+  // not the `- ``` ` marker line — inherits the item's content column and is
+  // abandoned when a later line dedents out of it. Tracks its own quote
+  // requirement so an unquoted line can't inherit a list started inside `> …`.
+  let activeListItem: { contentColumn: number; requiresQuote: boolean } | null = null
+
+  for (const rawLine of prefix.split('\n')) {
+    open = abandonIfLeftContainer(open, rawLine)
+    const { line, quoted } = stripBlockquoteMarkers(rawLine)
+
+    // Maintain the active list item only outside a fence (fenced content must not
+    // create list state): a marker line replaces it; a non-blank line that leaves
+    // its quote context or dedents before its content column expires it; blank
+    // lines preserve it.
+    if (open === null) {
+      const listItem = /^( {0,3})((?:[-+*]|\d{1,9}[.)])[ \t]+)/.exec(line)
+      if (listItem !== null) {
+        activeListItem = { contentColumn: columnWidth(listItem[1]! + listItem[2]!), requiresQuote: quoted }
+      } else if (
+        line.trim() !== '' &&
+        activeListItem !== null &&
+        (activeListItem.requiresQuote !== quoted || leadingIndentColumns(line) < activeListItem.contentColumn)
+      ) {
+        activeListItem = null
+      }
+    }
+
+    const plainFence = /^( {0,3})(`{3,}|~{3,})([^\n]*)$/.exec(line)
+    if (plainFence !== null) {
+      const indent = plainFence[1]!
+      const run = plainFence[2]!
+      const char = run[0] as '`' | '~'
+      const rest = plainFence[3]!
+      if (open === null) {
+        if (char === '`' && rest.includes('`')) continue
+        // A plain opener indented into the active list item inherits its content
+        // column (continuation-line fence); a genuinely top-level opener keeps null.
+        const listContentColumn =
+          activeListItem !== null &&
+          activeListItem.requiresQuote === quoted &&
+          columnWidth(indent) >= activeListItem.contentColumn
+            ? activeListItem.contentColumn
+            : null
+        open = { char, len: run.length, owner: { requiresQuote: quoted, listContentColumn } }
+      } else if (char === open.char && run.length >= open.len && rest.trim() === '') {
+        open = null
+      }
+      continue
+    }
+
+    // A list-marker-prefixed fence only ever OPENS; inside an open fence it is
+    // fenced content, not a closer. It records BOTH requirements it was opened
+    // under: the blockquote (`> - ``` `) and the list content column — the full
+    // width of the marker prefix (`- `, `1. `, nested chains, post-quote-strip),
+    // tabs expanded — so a later line that leaves EITHER has left the item.
+    if (open !== null) continue
+    const listFence = /^((?: {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+)+) {0,3}(`{3,}|~{3,})([^\n]*)$/.exec(line)
+    if (listFence === null) continue
+    const markerPrefix = listFence[1]!
+    const run = listFence[2]!
+    const char = run[0] as '`' | '~'
+    const rest = listFence[3]!
+    if (char === '`' && rest.includes('`')) continue
+    open = { char, len: run.length, owner: { requiresQuote: quoted, listContentColumn: columnWidth(markerPrefix) } }
+  }
+  // The candidate's own first line is the final container-continuation signal: an
+  // unquoted (blockquote) or dedented (list) candidate has left the container, so
+  // a container-owned fence no longer protects it. The candidate is never itself a
+  // fence marker (it already passed isWholeMessageToolCall), so only the abandon
+  // check applies here — no fence open/close bookkeeping.
+  return abandonIfLeftContainer(open, candidateFirstLine) !== null
+}
+
+// Returns the fence with its owning container(s) still intact, or null when the
+// given raw line has LEFT any required container: a fence that requires a
+// blockquote is abandoned by an unquoted non-blank line, and a fence with a list
+// content column is abandoned by a non-blank line indented before it. The two
+// requirements are independent (OR), so a `> - ``` ` fence is abandoned by leaving
+// EITHER the blockquote or the list. A fence with no requirements (top-level) and
+// blank lines never abandon.
+function abandonIfLeftContainer(open: OpenFence | null, rawLine: string): OpenFence | null {
+  if (open === null) return null
+  const { line, quoted } = stripBlockquoteMarkers(rawLine)
+  if (line.trim() === '') return open
+  if (open.owner.requiresQuote && !quoted) return null
+  if (open.owner.listContentColumn !== null && leadingIndentColumns(line) < open.owner.listContentColumn) return null
+  return open
+}
+
+// Removes one or more leading blockquote markers so a `> ```` fence participates
+// in bookkeeping as if unquoted, and reports whether the line was quoted so the
+// caller can detect the blockquote-exit that abandons a blockquote-owned fence.
+function stripBlockquoteMarkers(line: string): { line: string; quoted: boolean } {
+  const match = /^(?: {0,3}>[ \t]?)+(.*)$/.exec(line)
+  return match === null ? { line, quoted: false } : { line: match[1]!, quoted: true }
+}
+
+// Leading-indent width in columns (whitespace only, stopping at the first
+// non-space), expanding tabs to the next 4-column stop. Used to compare a later
+// line's indentation against a list item's content column.
+function leadingIndentColumns(line: string): number {
+  let column = 0
+  for (const char of line) {
+    if (char === ' ') column += 1
+    else if (char === '\t') column += 4 - (column % 4)
+    else break
+  }
+  return column
+}
+
+// Full display width of a string in columns, expanding tabs to the next 4-column
+// stop. Used to measure a list marker prefix so the content column lands after it.
+function columnWidth(s: string): number {
+  let column = 0
+  for (const char of s) column += char === '\t' ? 4 - (column % 4) : 1
+  return column
 }
 
 // Tolerant single-purpose scanner that pulls the `text` argument out of a


### PR DESCRIPTION
## Background

A model occasionally writes a legitimate reply and then, on a trailing line after a blank-line separator, serializes a tool decision as plain text instead of emitting a real tool call — e.g. a call like `skip_response({ reason: "..." })` appended after otherwise-normal reply prose. The existing whole-message guard (`isWholeMessageToolCall` in `src/channels/router.ts`) only fires when the ENTIRE trimmed outbound message is a single `toolname(...)` call, so this "prose, then trailing plumbing" shape slipped through untouched and shipped raw tool-call syntax verbatim to the channel. That both exposes an internal tool name and, in bot-probing contexts, confirms the sender is automated.

## Summary

Add `stripTrailingLeakedToolCall(text)` — a strictly narrower sibling of `isWholeMessageToolCall` that detects "prose, then a trailing standalone call block" using only structural, language-agnostic signals (required per the repo's multi-language rule, since the agent replies in many languages):

1. a blank-line separator between the prose and the trailing block,
2. the trailing block independently satisfying the existing bracket-aware `isWholeMessageToolCall`,
3. the trailing block not starting inside a Markdown fenced code block (` ``` ` or `~~~`).

Disposition is prefix-first: keep the prose, drop only the trailing plumbing, regardless of which tool leaked. No argument recovery, no self-correction nudge, no silent-turn acknowledgment — the prose already satisfies the turn. The whole-message contract of `isWholeMessageToolCall` is deliberately left untouched, so a message that is nothing but a call still hits its existing name-dependent suppress/recover path.

Wired into `validateChannelTurn` before the whole-message classification, and mirrored at the `channel_send` / `channel_reply` tool boundaries (`src/agent/tools/`) so a leak carried through an explicit tool call is sanitized at the boundary too, not only on the router's recovery path. Multiple contiguous trailing call blocks are stripped iteratively, and a truncated (unbalanced) trailing call is also stripped so partial plumbing can't ship.

## What this does NOT do

- Does not touch the whole-message contract of `isWholeMessageToolCall` — a message that is nothing but a call is untouched by this change and still routes through its existing name-dependent path.
- No argument recovery, no self-correction nudge, no silent-turn acknowledgment on strip — just prefix-keep, plumbing-drop.
- The `channel_send`/`channel_reply` boundaries strip rather than deny (unlike the adjacent `NO_REPLY` / upstream-empty-sentinel / Kimi-delimiter guards beside them), so a legitimate reply is never stranded.

## Review notes

- Load-bearing invariants to verify: the blank-line requirement, the fenced-code exemption, and that the whole-message path is unaffected.
- 14 unit tests for `stripTrailingLeakedToolCall`: the core prose+trailing-call strip, non-Latin-script prefixes (Japanese, Arabic, Korean) proving language-agnosticism, CRLF normalization, fenced-code exemption (both backtick and tilde fences), an inline tool mention left untouched, a call-followed-by-more-prose left untouched, the required blank-line boundary, multiple contiguous trailing blocks, a truncated call, and the whole-message no-op.
- 1 router behavior test (prose + trailing call → only the prose is posted) and 2 tool-boundary tests (`channel_send` + `channel_reply` strip and send only the prose).
- Full suite green: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and `bun run test` (10928 pass, 0 fail).
- Known limitation, stated honestly: an unfenced deliberate example that ends with a blank line followed by a bare `toolname()` on its own line is structurally indistinguishable from the leak. The fenced-code exemption plus the blank-line requirement shrink this to a corner case, but no deterministic multilingual text heuristic can eliminate it entirely.