### PR TITLE
test(test-helpers): deflake waitFor fast-path via invocation count

### DIFF
--- a/src/test-helpers/wait-for.test.ts
+++ b/src/test-helpers/wait-for.test.ts
@@ -4,10 +4,21 @@ import { expectStable, waitFor } from './wait-for'
 
 describe('waitFor', () => {
   test('resolves immediately when predicate is already truthy (fast path, no timer tick)', async () => {
-    const start = Date.now()
-    const result = await waitFor(() => 'ready')
+    // Assert the fast-path BEHAVIOR (return on the first predicate call, no
+    // polling loop) instead of a wall-clock bound. History: the timing
+    // assertion was 5ms (74be577-era), widened to 50ms (86abb5f) after CI
+    // flakes, then STILL flaked at 108ms under 18-worker `bun test --parallel`
+    // contention — a saturated scheduler stretches even one `await` microtask
+    // past any fixed budget. Counting invocations is scheduler-independent:
+    // the loop pays one `setTimeout` per extra call, so "called once" IS
+    // "no timer tick".
+    let calls = 0
+    const result = await waitFor(() => {
+      calls++
+      return 'ready'
+    })
     expect(result).toBe('ready')
-    expect(Date.now() - start).toBeLessThan(50)
+    expect(calls).toBe(1)
   })
 
   test('resolves with the truthy value when predicate flips during polling', async () => {


### PR DESCRIPTION
## Background

`waitFor > resolves immediately when predicate is already truthy (fast path, no timer tick)` fails intermittently in CI. The most recent failure:

```
(fail) waitFor > resolves immediately when predicate is already truthy (fast path, no timer tick) [108.65ms]
```

The assertion bounded **wall-clock** time — `expect(Date.now() - start).toBeLessThan(50)`. That's fundamentally fragile under the repo's `bun test --parallel` runner (18 workers): when the scheduler is saturated, even the single `await predicate()` microtask on the fast path can be delayed past any fixed budget. The observed 108ms run had zero timer ticks — it was purely scheduler latency, not a real regression.

This has already been "fixed" twice by tuning the number — 5ms originally, widened to 50ms in `86abb5f`. It kept coming back because the approach is wrong: no wall-clock constant survives an arbitrarily contended scheduler.

## Summary

Assert the **behavior** the test name promises instead of a timing bound: when the predicate is already truthy, `waitFor` returns on the first call without entering the polling loop. The test now counts predicate invocations and asserts `calls === 1`.

**Why invocation count and not a wider timeout:** the count is scheduler-independent. `waitFor`'s loop pays exactly one `setTimeout(intervalMs)` per extra predicate call, so "called exactly once" is a precise, deterministic proxy for "no timer tick" — the very thing the test name claims. A wider timeout would only push the flake further out, not remove it.

This mirrors the earlier `expectStable` deflake in the same file, which likewise dropped its wall-clock dependency in favor of a scheduler-independent signal.

## What this does NOT do

- Does not touch `src/test-helpers/wait-for.ts` — the fast-path implementation is correct; only the test's assertion strategy changes.
- Does not alter the other `waitFor` / `expectStable` tests.
- Does not change the `DEFAULT_TIMEOUT_MS` / `DEFAULT_INTERVAL_MS` constants.

## Review notes

- Load-bearing line: `expect(calls).toBe(1)` replaces `expect(Date.now() - start).toBeLessThan(50)`. Invariant to verify: the fast path (`if (initial) return`) returns before the `while` loop, so the predicate is invoked exactly once and no `setTimeout` fires.
- The retained comment documents the flake history so a future contributor doesn't revert to a wall-clock bound a third time.
- Verified locally: full suite `10945 pass, 0 fail`; the target test passed 5/5 consecutive `--parallel` runs.