### PR TITLE
fix(channels): stop leaving a stale :eyes: on unaddressed silent turns

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -2833,6 +2833,150 @@ describe('ChannelRouter silent-ack :eyes: on deliberate silence', () => {
     await waitFor(() => events.length === 3)
     expect(events).toEqual(['add-eyes', 'remove-eyes', 'add-eyes'])
   })
+
+  test('an ambient (unaddressed) NO_REPLY leaves NO :eyes:', async () => {
+    // given a message NOT addressed to the bot (no mention, no DM, no reply-to-bot)
+    // — human-to-human chatter the bot only observed — that the model NO_REPLYs
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    let called = false
+    router.registerReaction('discord-bot', async () => {
+      called = true
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ reactionRef: REACTION_REF, isBotMention: false }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then no silent-ack :eyes: is planted — the bot stays invisible in chatter
+    expect(called).toBe(false)
+  })
+
+  test('an ambient (unaddressed) skip_response leaves NO :eyes:', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    let called = false
+    router.registerReaction('discord-bot', async () => {
+      called = true
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ reactionRef: REACTION_REF, isBotMention: false }))
+    sessions[0]!.onPrompt = () => {
+      router.markTurnSkipped({ parentSessionId: 'ses_fake_1', reason: 'not addressed to me' })
+      sessions[0]!.setAssistantText('Just observing.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(called).toBe(false)
+  })
+
+  test('a DM NO_REPLY still leaves an :eyes: (explicitly addressed)', async () => {
+    const dir = await tempDir()
+    const { router, sessions, captured } = await (async () => {
+      const { router, sessions } = makeRouter(dir)
+      router.setTypingCapability('discord-bot', true)
+      const captured: ReactionRequest[] = []
+      router.registerReaction('discord-bot', async (req) => {
+        captured.push(req)
+        return { ok: true }
+      })
+      router.registerOutbound('discord-bot', async () => ({ ok: true }))
+      await router.route(inbound({ reactionRef: REACTION_REF, isBotMention: false, isDm: true }))
+      return { router, sessions, captured }
+    })()
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => captured.length > 0)
+    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+  })
+
+  test('a reply-to-bot NO_REPLY still leaves an :eyes: (explicitly addressed)', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    const captured: ReactionRequest[] = []
+    router.registerReaction('discord-bot', async (req) => {
+      captured.push(req)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    await router.route(inbound({ reactionRef: REACTION_REF, isBotMention: false, replyToBotMessageId: 'bot-msg-1' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    await waitFor(() => captured.length > 0)
+    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: REACTION_REF })
+  })
+
+  const ADDRESSED_REF: ReactionRef = { adapter: 'discord-bot', value: 'addressed-msg' }
+  const AMBIENT_REF: ReactionRef = { adapter: 'discord-bot', value: 'ambient-msg' }
+
+  test('addressed then ambient coalesced: the final ambient message leaves NO :eyes:', async () => {
+    // given an addressed message and a later ambient one coalescing into ONE turn
+    // (single-author harness engages both via the solo-human fallback, so both
+    // land in the batch). Eligibility must follow batch[last] — the ambient tail —
+    // NOT "any addressed message in the batch".
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    let called = false
+    router.registerReaction('discord-bot', async () => {
+      called = true
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    // when both arrive before the debounce flush, so they coalesce
+    await router.route(inbound({ reactionRef: ADDRESSED_REF, isBotMention: true }))
+    await router.route(inbound({ reactionRef: AMBIENT_REF, isBotMention: false, externalMessageId: 'm2' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then the trailing ambient message drives the (in)eligibility: no ack
+    expect(called).toBe(false)
+  })
+
+  test('ambient then addressed coalesced: the :eyes: lands on the final addressed message', async () => {
+    // given an ambient message and a later addressed one coalescing into ONE turn.
+    // batch[last] is the addressed tail, so the ack must fire AND target its ref.
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.setTypingCapability('discord-bot', true)
+    const captured: ReactionRequest[] = []
+    router.registerReaction('discord-bot', async (req) => {
+      captured.push(req)
+      return { ok: true }
+    })
+    router.registerOutbound('discord-bot', async () => ({ ok: true }))
+
+    // when both arrive before the debounce flush, so they coalesce
+    await router.route(inbound({ reactionRef: AMBIENT_REF, isBotMention: false }))
+    await router.route(inbound({ reactionRef: ADDRESSED_REF, isBotMention: true, externalMessageId: 'm2' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then the ack fires on the final addressed message's ref, not the ambient one
+    await waitFor(() => captured.length > 0)
+    expect(captured[0]).toMatchObject({ emoji: 'eyes', reactionRef: ADDRESSED_REF })
+  })
 })
 
 describe('ChannelRouter retires the persistent silent-ack :eyes: on a later reply', () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -785,6 +785,19 @@ type LiveSession = {
   // origin so `channel_react` reacts to the triggering message, not whichever
   // inbound happens to be latest in the queue. Null on reminder-only turns.
   currentTurnReactionRef: ReactionRef | null
+  // True when the inbound that triggered THIS turn (the message
+  // `currentTurnReactionRef` points at — last item of the drained batch) was
+  // EXPLICITLY addressed to the bot: a DM, an @-mention/alias (`isBotMention`
+  // folds plain-name matching in at the adapter classify layer), or a reply to
+  // the bot's own message. Gates the PERSISTENT silent-ack :eyes: (see
+  // `armSilentTurnAck`): a deliberate silence on a message aimed AT us earns a
+  // courteous "seen, nothing to add" 👀, but staying quiet during ambient
+  // human-to-human chatter (sticky observation, solo-human fallback) must leave
+  // NO mark — otherwise a busy room accumulates stale 👀 on messages the bot
+  // was never part of. Computed from the SAME message the reaction targets so
+  // eligibility and target can never disagree. Reset with `currentTurnReactionRef`
+  // in the drain finally; preserved across reminder-only iterations exactly like it.
+  currentTurnExplicitlyAddressed: boolean
   // Typing-status anchor of the inbound that triggered THIS turn (last item in
   // the drained batch, mirroring `currentTurnReactionRef`). Adapter-opaque ts
   // carried only to the typing path; null when the triggering inbound supplied
@@ -2093,6 +2106,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         currentTurnAuthorId: null,
         currentTurnAuthorIds: new Set(),
         currentTurnReactionRef: null,
+        currentTurnExplicitlyAddressed: false,
         currentTurnTypingThread: null,
         dirtyTypingThreads: new Set(),
         currentTurnEngageReactions: [],
@@ -2838,6 +2852,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.currentTurnAuthorId = batch[batch.length - 1]!.authorId
           live.currentTurnAuthorIds = new Set(batch.map((m) => m.authorId))
           live.currentTurnReactionRef = batch[batch.length - 1]!.reactionRef ?? null
+          const trigger = batch[batch.length - 1]!
+          live.currentTurnExplicitlyAddressed =
+            trigger.isDm || trigger.isBotMention || trigger.replyToBotMessageId !== null
           live.currentTurnTypingThread = batch[batch.length - 1]!.typingThread ?? null
           live.currentTurnEngageReactions = batch.flatMap((m) =>
             m.engageReaction !== undefined ? [m.engageReaction] : [],
@@ -3054,6 +3071,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.currentTurnAuthorId = null
       live.currentTurnAuthorIds = new Set()
       live.currentTurnReactionRef = null
+      live.currentTurnExplicitlyAddressed = false
       live.currentTurnEngageReactions = []
       // Drop any still-held reactions if the loop exited without running the
       // per-turn finally (e.g. session destroyed mid-drain): never leave a
@@ -5502,6 +5520,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const armSilentTurnAck = (live: LiveSession, reason: SilentAckReason): void => {
+    // A GitHub review IS its own emoji-shaped output, so it always earns the
+    // 👀; every other deliberate silence earns one ONLY when the triggering
+    // message was addressed to the bot. Staying quiet in ambient chatter leaves
+    // no mark, so a busy room never accumulates stale 👀 on messages the bot
+    // was never part of.
+    const eligible =
+      reason === 'github_review_output' ? live.key.adapter === 'github' : live.currentTurnExplicitlyAddressed
+    if (!eligible) return
     live.silentAckTurn = { turnSeq: live.turnSeq, reason }
   }
 


### PR DESCRIPTION
## Background

Typeey was setting an :eyes: (👀) reaction on messages it decided **not** to reply to and never removing them — in a busy Discord channel of human-to-human chatter, nearly every message the bot merely observed accumulated a permanent 👀 it was never part of.

That 👀 is the **persistent silent-ack** (`reactOnSilentAck` in `src/channels/router.ts`), armed by `armSilentTurnAck` on every deliberate silence: `no_reply`, `skip_response`, `skip_response_text_leak`, and `github_review_output`. It's meant as a courteous "seen, intentionally not replying" mark, and it's only retired later by `dropSilentAckReactions` — **which fires only when the bot posts a genuine reply in that same channel session.** In an ambient room the bot rarely (or never) replies, so the marks never come off.

The transient engage-👀 (`autoReactOnEngage`) was *not* the culprit here: it's gated to typing-less adapters (github, kakaotalk) and always removed at turn end. Discord is typing-capable, so on Discord the *only* 👀 is the persistent silent-ack — which fired regardless of whether the message was aimed at the bot.

## Summary

Gate the persistent silent-ack on **explicit address**.

- New turn-scoped `currentTurnExplicitlyAddressed`, computed from the **same** triggering message `currentTurnReactionRef` points at (last item of the drained batch), so eligibility and the reaction target can never disagree. It's reset alongside `currentTurnReactionRef` in the drain `finally`, and preserved across reminder-only iterations exactly like it.
- `armSilentTurnAck` now plants the mark only when the trigger was a **DM**, an **@-mention/alias** (`isBotMention` already folds plain-name matching in at the adapter classify layer), or a **reply to the bot**. The `github_review_output` case stays **unconditional** (gated on `adapter === 'github'`) — there the emoji *is* the output.

**Why gate in `armSilentTurnAck` and not per-call-site or inside `reactOnSilentAck`?** Centralizing eligibility keeps all four silent outcomes on one policy instead of drifting independently, and an ineligible turn never starts a reaction-add — so there's no half-applied reaction and no new cleanup race. The existing promise-ordering guards in `reactOnSilentAck`/`dropSilentAckReactions` are untouched.

**Why not `multiHumanGroup`?** Too coarse — a direct @-mention inside a busy room still deserves the ack. Typing-capability is also the wrong discriminator (it describes adapter UX, not whether the user addressed the bot). The inbound already carries the authoritative structural signals.

## What this does NOT do

- Does **not** retroactively remove 👀 already posted to Discord before this change — it only prevents new ones.
- Does **not** change the transient engage-👀 path, the disengage (🤐) reaction, or the GitHub review-output ack.
- Does **not** touch sticky-engagement or the engage/observe decision itself — sticky observation and solo-human fallback are (correctly) treated as *not* explicitly addressed.

## Review notes

- Load-bearing invariant: `currentTurnExplicitlyAddressed` **must** be derived from `batch[batch.length - 1]` (same message as `currentTurnReactionRef`). Checking "any addressed message in the batch" while reacting to the last (ambient) one would recreate the clutter.
- Eligibility lives in `armSilentTurnAck`; the reaction mechanism (`reactOnSilentAck`) and cleanup ordering are unchanged.
- Tests: ambient (unaddressed) `NO_REPLY` / `skip_response` now leave **no** :eyes:; DM and reply-to-bot silences still leave one. Existing silent-ack assertions are unchanged because the test harness defaults `isBotMention: true`.