### PR TITLE
fix(channels): retry provider failures after progress replies

### DIFF
--- a/src/agent/provider-error.test.ts
+++ b/src/agent/provider-error.test.ts
@@ -297,6 +297,11 @@ describe('isFailoverWorthy', () => {
     expect(isFailoverWorthy('network unreachable')).toBe(false)
   })
 
+  test('does NOT fail over context overflow even when transport text is also present', () => {
+    expect(isFailoverWorthy('context length exceeded')).toBe(false)
+    expect(isFailoverWorthy('WebSocket closed 1000: context length exceeded')).toBe(false)
+  })
+
   test('a provider transport / expired-session failure IS failover-worthy (the cron-report incident)', () => {
     expect(isFailoverWorthy('provider_transport_failure')).toBe(true)
     expect(
@@ -337,6 +342,8 @@ describe('isRetryableSameRef', () => {
     expect(isRetryableSameRef('ECONNRESET')).toBe(true)
     expect(isRetryableSameRef('fetch failed')).toBe(true)
     expect(isRetryableSameRef('500 Internal Server Error')).toBe(true)
+    expect(isRetryableSameRef('WebSocket closed 1000')).toBe(true)
+    expect(isRetryableSameRef('websocket connection was closed normally')).toBe(true)
   })
 
   test('does NOT same-ref retry throttle/overload — those fail OVER to another ref', () => {
@@ -349,10 +356,18 @@ describe('isRetryableSameRef', () => {
     expect(isRetryableSameRef('401 Unauthorized')).toBe(false)
     expect(isRetryableSameRef('insufficient quota')).toBe(false)
     expect(isRetryableSameRef('session expired: api key expired')).toBe(false)
+    expect(isRetryableSameRef('WebSocket closed 1000: 401 Unauthorized')).toBe(false)
+    expect(isRetryableSameRef('WebSocket closed 1000: 403 Forbidden')).toBe(false)
+    expect(isRetryableSameRef('WebSocket closed 1000: access denied')).toBe(false)
+    expect(isRetryableSameRef('WebSocket closed 1000: access token expired')).toBe(false)
+    expect(isRetryableSameRef('WebSocket closed 1000: session token has expired')).toBe(false)
+    expect(isRetryableSameRef('WebSocket closed 1000: authentication_error')).toBe(false)
+    expect(isRetryableSameRef('websocket connection closed: billing quota exhausted')).toBe(false)
   })
 
   test('does NOT same-ref retry context-overflow or generic errors (compaction / surface own it)', () => {
     expect(isRetryableSameRef('context length exceeded')).toBe(false)
+    expect(isRetryableSameRef('WebSocket closed 1000: context length exceeded')).toBe(false)
     expect(isRetryableSameRef('malformed response')).toBe(false)
   })
 })

--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -42,17 +42,17 @@ const OBSERVER_TIMEOUT = /\(typeclaw observer timeout\)/i
 // `wss://…/codex/responses` non-101 upgrade). Provider protocol tokens — English
 // by design (the system-token exception to the multi-language rule).
 const TRANSPORT_FAILURE =
-  /provider[_ -]?transport[_ -]?failure|(?:websocket|ws) connection.*failed|expected 101|session expired/i
+  /provider[_ -]?transport[_ -]?failure|(?:websocket|ws)(?: connection)?(?:(?: was| is)? closed|.*failed)|expected 101|session expired/i
 
 // Auth failure: the provider rejected our credentials (bad/expired/missing API
-// key, 401, failed authentication). Account-wide — a different ref shares the
+// key or token, 401/403, failed authentication). Account-wide — a different ref shares the
 // same credential problem — so this is BOTH a redacted safe-message class (a
 // 401 body can carry a Bearer token) AND a NON_FAILOVER_FAULT reason. Shared as
 // one constant so the two uses can never drift: previously the safe-message copy
 // matched `api key ... expired` but the failover copy didn't, letting
 // `session expired: api key expired` wrongly fail over past the auth guard.
 const AUTH_FAULT =
-  /\b(401|unauthori[sz]ed|invalid[_ -]?api[_ -]?key|api key.*(?:invalid|expired|missing)|authentication failed|invalid bearer)\b/i
+  /\b(401|403|unauthori[sz]ed|forbidden|access denied|invalid[_ -]?api[_ -]?key|api key.*(?:invalid|expired|missing)|(?:access|session)[_ -]?token(?:(?:[_ -]+)(?:has|is))?[_ -]+expired|authentication(?: failed|[_ -]?error)|invalid bearer)\b/i
 
 // Each entry pairs a narrow matcher against the raw provider text with the
 // canonical, leak-free sentence shown in channels. Matchers are intentionally
@@ -120,6 +120,11 @@ const NON_FAILOVER_FAULT = new RegExp(
   'i',
 )
 
+// Context-window exhaustion belongs to the SDK compaction/error path, never
+// transport recovery. Keep this to provider protocol forms rather than matching
+// natural-language user text.
+const CONTEXT_OVERFLOW = /\bcontext[_ -]?length[_ -]?exceeded\b/i
+
 export function isThrottleOrOverload(raw: string): boolean {
   if (NON_FAILOVER_FAULT.test(raw)) return false
   return THROTTLE_OR_OVERLOAD.test(raw)
@@ -133,6 +138,7 @@ export function isThrottleOrOverload(raw: string): boolean {
 // Account-wide faults (billing/quota/auth) are excluded up front — a different
 // ref shares the same account problem, so switching can't help.
 export function isFailoverWorthy(raw: string): boolean {
+  if (CONTEXT_OVERFLOW.test(raw)) return false
   if (NON_FAILOVER_FAULT.test(raw)) return false
   return isThrottleOrOverload(raw) || OBSERVER_TIMEOUT.test(raw) || TRANSPORT_FAILURE.test(raw)
 }
@@ -157,6 +163,7 @@ const NETWORK_OR_5XX =
 // does NOT match context-overflow: that stays on the SDK compaction path and must
 // never be treated as a retryable provider failure.
 export function isRetryableSameRef(raw: string): boolean {
+  if (CONTEXT_OVERFLOW.test(raw)) return false
   if (NON_FAILOVER_FAULT.test(raw)) return false
   if (isThrottleOrOverload(raw)) return false
   return TRANSPORT_FAILURE.test(raw) || OBSERVER_TIMEOUT.test(raw) || NETWORK_OR_5XX.test(raw)

--- a/src/agent/retry-same-ref.test.ts
+++ b/src/agent/retry-same-ref.test.ts
@@ -4,6 +4,7 @@ import type { AgentSession } from './index'
 import {
   promptWithSameRefRetryOnly,
   retryBackoffMs,
+  retryTurnAfterCompletedToolResult,
   retryTurnOnPersistentSession,
   RETRIES_PER_REF,
 } from './retry-same-ref'
@@ -29,13 +30,16 @@ type FakeAgent = {
   continued: number
 }
 
-function sessionWith(messages: Array<{ role: string; stopReason?: string }>, continueImpl?: () => Promise<void>) {
+function sessionWith(
+  messages: Array<{ role: string; stopReason?: string }>,
+  continueImpl?: (agent: FakeAgent) => Promise<void>,
+) {
   const agent: FakeAgent = {
     state: { messages },
     continued: 0,
     continue: async () => {
       agent.continued++
-      await continueImpl?.()
+      await continueImpl?.(agent)
     },
   }
   return { session: { agent } as unknown as AgentSession, agent }
@@ -95,6 +99,130 @@ describe('retryTurnOnPersistentSession', () => {
     await expect(retryTurnOnPersistentSession(session, { attempt: 0, random: () => 0 })).rejects.toThrow(
       'socket hang up',
     )
+  })
+})
+
+describe('retryTurnAfterCompletedToolResult', () => {
+  test('removes only an error assistant after a completed tool result, then continues', async () => {
+    const messages = [
+      { role: 'user' },
+      { role: 'assistant', stopReason: 'toolUse' },
+      { role: 'toolResult' },
+      { role: 'assistant', stopReason: 'error' },
+    ]
+    const { session, agent } = sessionWith(messages)
+
+    const ok = await retryTurnAfterCompletedToolResult(session, {
+      attempt: 0,
+      random: () => 0,
+      authorize: () => true,
+    })
+
+    expect(ok).toBe(true)
+    expect(agent.continued).toBe(1)
+    expect(agent.state.messages).toEqual(messages.slice(0, -1))
+  })
+
+  test('signals backoff after tail eligibility and before jitter/authorization', async () => {
+    const order: string[] = []
+    const { session } = sessionWith([{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }], async () => {
+      order.push('continue')
+    })
+
+    expect(
+      await retryTurnAfterCompletedToolResult(session, {
+        attempt: 0,
+        onBackoffStart: () => order.push('backoff-start'),
+        random: () => {
+          order.push('random')
+          return 0
+        },
+        authorize: () => {
+          order.push('authorize')
+          return true
+        },
+      }),
+    ).toBe(true)
+    expect(order).toEqual(['backoff-start', 'random', 'authorize', 'continue'])
+  })
+
+  test('fails closed without mutation for unsafe transcript tails', async () => {
+    const unsafeTails = [
+      [{ role: 'toolResult' }],
+      [{ role: 'user' }, { role: 'assistant', stopReason: 'error' }],
+      [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'stop' }],
+      [{ role: 'user' }, { role: 'toolResult' }],
+    ]
+
+    for (const messages of unsafeTails) {
+      const original = messages.map((message) => ({ ...message }))
+      const { session, agent } = sessionWith(messages)
+      expect(
+        await retryTurnAfterCompletedToolResult(session, {
+          attempt: 0,
+          random: () => 0,
+          authorize: () => true,
+        }),
+      ).toBe(false)
+      expect(agent.continued).toBe(0)
+      expect(agent.state.messages).toEqual(original)
+    }
+  })
+
+  test('reauthorizes after backoff and fails closed when authorization was revoked', async () => {
+    const messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
+    const { session, agent } = sessionWith(messages)
+    let authorized = true
+
+    const retry = retryTurnAfterCompletedToolResult(session, {
+      attempt: 0,
+      random: () => 0.001,
+      authorize: () => authorized,
+    })
+    authorized = false
+
+    expect(await retry).toBe(false)
+    expect(agent.continued).toBe(0)
+    expect(agent.state.messages).toBe(messages)
+  })
+
+  test('restores the removed error leaf when continue throws without transcript progress', async () => {
+    const messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
+    const { session, agent } = sessionWith(messages, async () => {
+      throw new Error('socket hang up')
+    })
+
+    await expect(
+      retryTurnAfterCompletedToolResult(session, {
+        attempt: 0,
+        random: () => 0,
+        authorize: () => true,
+      }),
+    ).rejects.toThrow('socket hang up')
+
+    expect(agent.continued).toBe(1)
+    expect(agent.state.messages).toBe(messages)
+  })
+
+  test('preserves newer transcript progress when continue appends state before throwing', async () => {
+    const messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
+    const progress = { role: 'assistant', stopReason: 'error' }
+    const { session, agent } = sessionWith(messages, async (currentAgent) => {
+      currentAgent.state.messages = [...currentAgent.state.messages, progress]
+      throw new Error('socket hang up after progress')
+    })
+
+    await expect(
+      retryTurnAfterCompletedToolResult(session, {
+        attempt: 0,
+        random: () => 0,
+        authorize: () => true,
+      }),
+    ).rejects.toThrow('socket hang up after progress')
+
+    expect(agent.continued).toBe(1)
+    expect(agent.state.messages).toEqual([{ role: 'toolResult' }, progress])
+    expect(agent.state.messages).not.toBe(messages)
   })
 })
 

--- a/src/agent/retry-same-ref.ts
+++ b/src/agent/retry-same-ref.ts
@@ -79,6 +79,72 @@ export async function retryTurnOnPersistentSession(
   return true
 }
 
+// Resume only the post-tool provider-failure shape. Unlike the generic helper,
+// this deliberately refuses a trailing user leaf or an assistant error whose
+// predecessor is anything other than the completed tool result. Callers use it
+// after externally visible tool activity, where replaying the original turn
+// could duplicate side effects.
+export async function retryTurnAfterCompletedToolResult(
+  session: AgentSession,
+  opts: {
+    attempt: number
+    signal?: AbortSignal
+    random?: () => number
+    authorize: () => boolean
+    onBackoffStart?: () => void
+  },
+): Promise<boolean> {
+  const agent = (session as { agent?: ContinuableAgent }).agent
+  if (!agent || typeof agent.continue !== 'function') return false
+  if (!hasCompletedToolResultErrorTail(agent.state?.messages)) return false
+
+  opts.onBackoffStart?.()
+  await sleep(retryBackoffMs(opts.attempt, opts.random), opts.signal)
+  if (opts.signal?.aborted) return false
+
+  // Re-read after the backoff: another actor may have advanced the transcript
+  // while we slept. Mutation is safe only while the exact tail still holds.
+  const messages = agent.state?.messages
+  if (!hasCompletedToolResultErrorTail(messages)) return false
+  if (opts.authorize() !== true) return false
+
+  const originalMessages = messages
+  const prefix = messages.slice(0, -1)
+  ;(agent.state as { messages: unknown }).messages = prefix
+  try {
+    await agent.continue()
+  } catch (err) {
+    if (hasSameEntries(agent.state?.messages, prefix)) {
+      ;(agent.state as { messages: unknown }).messages = originalMessages
+    }
+    throw err
+  }
+  return true
+}
+
+function hasCompletedToolResultErrorTail(messages: unknown): messages is unknown[] {
+  if (!Array.isArray(messages) || messages.length < 2) return false
+  const predecessor = messages[messages.length - 2]
+  const leaf = messages[messages.length - 1]
+  return (
+    typeof predecessor === 'object' &&
+    predecessor !== null &&
+    (predecessor as { role?: unknown }).role === 'toolResult' &&
+    typeof leaf === 'object' &&
+    leaf !== null &&
+    (leaf as { role?: unknown }).role === 'assistant' &&
+    (leaf as { stopReason?: unknown }).stopReason === 'error'
+  )
+}
+
+function hasSameEntries(messages: unknown, expected: unknown[]): boolean {
+  return (
+    Array.isArray(messages) &&
+    messages.length === expected.length &&
+    messages.every((entry, i) => entry === expected[i])
+  )
+}
+
 // Same-ref retry for DIRECT `session.prompt()` call sites that bypass the model
 // fallback helpers (non-stream TUI, slash commands, subagent drain/required-block
 // nudges, multimodal look-at). These lost the SDK's built-in retry when it was

--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -372,6 +372,237 @@ function retryableFakeSession(behaviors: RetryBehavior[]) {
 }
 
 describe('promptPersistentTurnWithFallback same-ref retry', () => {
+  test('an authorized retry resumes from a completed tool result despite tool activity', async () => {
+    const listeners = new Set<(event: FakeEvent) => void>()
+    const messages: Array<{ role: string; stopReason?: string }> = []
+    let promptCalls = 0
+    let continueCalls = 0
+    const session = {
+      prompt: async () => {
+        promptCalls++
+        messages.push(
+          { role: 'user' },
+          { role: 'assistant', stopReason: 'toolUse' },
+          { role: 'toolResult' },
+          { role: 'assistant', stopReason: 'error' },
+        )
+        for (const cb of listeners) cb({ type: 'tool_execution_start' })
+        for (const cb of listeners) cb({ type: 'tool_execution_end' })
+        for (const cb of listeners) {
+          cb({
+            type: 'message_end',
+            message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+          })
+        }
+      },
+      subscribe: (cb: (event: FakeEvent) => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+      agent: {
+        state: { messages },
+        continue: async () => {
+          continueCalls++
+          messages.push({ role: 'assistant', stopReason: 'stop' })
+        },
+      },
+    } as unknown as AgentSession
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      authorizeRetryAfterCompletedToolResult: () => true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(promptCalls).toBe(1)
+    expect(continueCalls).toBe(1)
+    expect(messages.filter((message) => message.role === 'user')).toHaveLength(1)
+  })
+
+  test('authorization alone cannot retry an unsafe transcript tail', async () => {
+    const listeners = new Set<(event: FakeEvent) => void>()
+    const messages = [{ role: 'user' }, { role: 'assistant', stopReason: 'error' }]
+    const originalMessages = messages.map((message) => ({ ...message }))
+    let continueCalls = 0
+    const session = {
+      prompt: async () => {
+        for (const cb of listeners) cb({ type: 'tool_execution_start' })
+        for (const cb of listeners) {
+          cb({
+            type: 'message_end',
+            message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+          })
+        }
+      },
+      subscribe: (cb: (event: FakeEvent) => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+      agent: {
+        state: { messages },
+        continue: async () => {
+          continueCalls++
+        },
+      },
+    } as unknown as AgentSession
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      authorizeRetryAfterCompletedToolResult: () => true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.lastError?.message).toBe('WebSocket closed 1000')
+    expect(continueCalls).toBe(0)
+    expect(messages).toEqual(originalMessages)
+  })
+
+  test('passes authorization through for late revalidation before transcript mutation', async () => {
+    const listeners = new Set<(event: FakeEvent) => void>()
+    const messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
+    const originalMessages = messages.map((message) => ({ ...message }))
+    let authorizationChecks = 0
+    let continueCalls = 0
+    const session = {
+      prompt: async () => {
+        for (const cb of listeners) cb({ type: 'tool_execution_start' })
+        for (const cb of listeners) {
+          cb({
+            type: 'message_end',
+            message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+          })
+        }
+      },
+      subscribe: (cb: (event: FakeEvent) => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+      agent: {
+        state: { messages },
+        continue: async () => {
+          continueCalls++
+        },
+      },
+    } as unknown as AgentSession
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      authorizeRetryAfterCompletedToolResult: () => {
+        authorizationChecks++
+        return authorizationChecks === 1
+      },
+    })
+
+    expect(result.success).toBe(false)
+    expect(authorizationChecks).toBe(2)
+    expect(continueCalls).toBe(0)
+    expect(messages).toEqual(originalMessages)
+  })
+
+  test('authorization and a safe transcript cannot retry a non-retryable provider error', async () => {
+    const listeners = new Set<(event: FakeEvent) => void>()
+    const messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
+    const originalMessages = messages.map((message) => ({ ...message }))
+    let continueCalls = 0
+    const session = {
+      prompt: async () => {
+        for (const cb of listeners) cb({ type: 'tool_execution_start' })
+        for (const cb of listeners) {
+          cb({
+            type: 'message_end',
+            message: { role: 'assistant', stopReason: 'error', errorMessage: '401 Unauthorized' },
+          })
+        }
+      },
+      subscribe: (cb: (event: FakeEvent) => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+      agent: {
+        state: { messages },
+        continue: async () => {
+          continueCalls++
+        },
+      },
+    } as unknown as AgentSession
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      authorizeRetryAfterCompletedToolResult: () => true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.lastError?.message).toBe('401 Unauthorized')
+    expect(continueCalls).toBe(0)
+    expect(messages).toEqual(originalMessages)
+  })
+
+  test('does not relax tool-activity retry gating without caller authorization', async () => {
+    const listeners = new Set<(event: FakeEvent) => void>()
+    const messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
+    let continueCalls = 0
+    const session = {
+      prompt: async () => {
+        for (const cb of listeners) cb({ type: 'tool_execution_start' })
+        for (const cb of listeners) {
+          cb({
+            type: 'message_end',
+            message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+          })
+        }
+      },
+      subscribe: (cb: (event: FakeEvent) => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+      agent: {
+        state: { messages },
+        continue: async () => {
+          continueCalls++
+        },
+      },
+    } as unknown as AgentSession
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A, REF_B],
+      currentModelRef: REF_A,
+      session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.refUsed).toBe(REF_A)
+    expect(continueCalls).toBe(0)
+    expect(messages).toHaveLength(2)
+  })
+
   test('a transient soft error recovers via agent.continue without duplicating the user message', async () => {
     const fake = retryableFakeSession(['soft-transient', 'success'])
     const result = await promptPersistentTurnWithFallback({

--- a/src/agent/turn-runner.ts
+++ b/src/agent/turn-runner.ts
@@ -2,7 +2,7 @@ import type { ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
 import { detectProviderError, isRetryableSameRef, subscribeProviderErrors } from './provider-error'
-import { RETRIES_PER_REF, retryTurnOnPersistentSession } from './retry-same-ref'
+import { RETRIES_PER_REF, retryTurnAfterCompletedToolResult, retryTurnOnPersistentSession } from './retry-same-ref'
 import { modelThrottleCircuit, type ThrottleCircuit } from './throttle-circuit'
 
 export type PersistentTurnAttempt = {
@@ -34,6 +34,9 @@ export async function promptPersistentTurnWithFallback(opts: {
   circuit?: ThrottleCircuit
   skipProviderErrorSubscription?: boolean
   detectSoftErrorFromLeaf?: boolean
+  authorizeRetryAfterCompletedToolResult?: () => boolean
+  retryRandom?: () => number
+  onRetryBackoffStart?: () => void
   beforeAttempt?: (ref: ModelRef) => void
   onAttemptFailed?: (attempt: PersistentTurnAttempt) => void
 }): Promise<PersistentTurnResult> {
@@ -78,6 +81,7 @@ export async function promptPersistentTurnWithFallback(opts: {
       // advancing the chain. `retry === 0` is the first, prompt()-driven attempt;
       // later iterations resume via agent.continue() (no user-message re-append).
       let outcome: AttemptOutcome | undefined
+      let retryAfterCompletedToolResult = false
       for (let retry = 0; ; retry++) {
         softError = undefined
         let outcomeThisAttempt: AttemptOutcome | undefined
@@ -85,7 +89,14 @@ export async function promptPersistentTurnWithFallback(opts: {
           if (retry === 0) {
             await opts.session.prompt(opts.text)
           } else {
-            const retried = await retryTurnOnPersistentSession(opts.session, { attempt: retry - 1 })
+            const retried = retryAfterCompletedToolResult
+              ? await retryTurnAfterCompletedToolResult(opts.session, {
+                  attempt: retry - 1,
+                  authorize: () => opts.authorizeRetryAfterCompletedToolResult?.() === true,
+                  ...(opts.retryRandom !== undefined ? { random: opts.retryRandom } : {}),
+                  ...(opts.onRetryBackoffStart !== undefined ? { onBackoffStart: opts.onRetryBackoffStart } : {}),
+                })
+              : await retryTurnOnPersistentSession(opts.session, { attempt: retry - 1 })
             // The safe continue-recipe couldn't apply: keep the PREVIOUS failure
             // outcome (never cleared) and let it drive the advance/return below.
             if (!retried) break
@@ -96,13 +107,16 @@ export async function promptPersistentTurnWithFallback(opts: {
         }
         outcome = outcomeThisAttempt
         if (outcome === undefined) break
-        // Only keep retrying while the failure is same-ref retryable, the turn
-        // stayed idempotent (no output/tool-exec yet), and budget remains.
-        const mayRetry =
-          retry < RETRIES_PER_REF &&
-          isRetryableSameRef(outcome.error.message) &&
-          !activity.producedAssistantOutput &&
-          !activity.startedToolExecution
+        // Retry within budget only when the failure is same-ref retryable and
+        // either no visible/tool activity occurred, or the caller explicitly
+        // authorizes the strict post-tool-result resume recipe.
+        const retryableWithinBudget = retry < RETRIES_PER_REF && isRetryableSameRef(outcome.error.message)
+        const mayRetryWithoutActivity = !activity.producedAssistantOutput && !activity.startedToolExecution
+        retryAfterCompletedToolResult =
+          retryableWithinBudget &&
+          activity.startedToolExecution &&
+          opts.authorizeRetryAfterCompletedToolResult?.() === true
+        const mayRetry = retryableWithinBudget && (mayRetryWithoutActivity || retryAfterCompletedToolResult)
         if (!mayRetry) break
       }
 

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -13323,6 +13323,59 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     ).toBe(true)
   })
 
+  test('surfaces a provider error after a continue:true progress reply', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(2)
+    expect(sent[0]).toBe('찾아볼게.')
+    expect(sent[1]).toMatch(/upstream LLM provider failed/i)
+    expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
+  })
+
+  test('suppresses a provider error after a final reply follows the continue:true progress reply', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '지난 기록은 이 내용이야.' })
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toEqual(['찾아볼게.', '지난 기록은 이 내용이야.'])
+  })
+
   test('does NOT recover when the continue:true ack leaf is unchanged since the send (ack-then-await-user)', async () => {
     const dir = await tempDir()
     const logs: string[] = []

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -88,6 +88,8 @@ class FakeSession {
   // find the assistant message that called the tool.
   public entriesById = new Map<string, SessionEntry>()
   public onPrompt: ((text: string) => void | Promise<void>) | undefined
+  public onContinue: (() => void | Promise<void>) | undefined
+  public continued = 0
 
   // Mirrors the real `AgentSession.agent` surface the router touches:
   // `agent.abort()` flips `agent.signal.aborted`. The router uses this as the
@@ -98,6 +100,8 @@ class FakeSession {
   public agent: {
     controller: AbortController
     readonly signal: AbortSignal
+    state: { messages: Array<{ role: string; stopReason?: string }> }
+    continue(): Promise<void>
     abort(): void
     afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>
     streamFn: StreamFn
@@ -111,6 +115,11 @@ class FakeSession {
       controller: new AbortController(),
       get signal(): AbortSignal {
         return this.controller.signal
+      },
+      state: { messages: [] },
+      continue: async (): Promise<void> => {
+        this.continued++
+        await this.onContinue?.()
       },
       abort(): void {
         this.controller.abort()
@@ -339,6 +348,8 @@ function makeRouter(
     config?: ChannelAdapterConfig
     sessions?: FakeSession[]
     nowRef?: { value: number }
+    retryRandom?: () => number
+    onRetryBackoffStart?: () => void
     logs?: string[]
     origins?: SessionOrigin[]
     factoryCalls?: SessionFactoryArgs[]
@@ -363,6 +374,8 @@ function makeRouter(
     configForAdapter: () => options.config ?? baseConfig,
     ...(options.configuredAliases !== undefined ? { configuredAliases: options.configuredAliases } : {}),
     ...(options.ensureLiveTimeoutMs !== undefined ? { ensureLiveTimeoutMs: options.ensureLiveTimeoutMs } : {}),
+    ...(options.retryRandom !== undefined ? { retryRandom: options.retryRandom } : {}),
+    ...(options.onRetryBackoffStart !== undefined ? { onRetryBackoffStart: options.onRetryBackoffStart } : {}),
     ...(options.measureTranscriptBytes !== undefined ? { measureTranscriptBytes: options.measureTranscriptBytes } : {}),
     ...(options.claimHandler !== undefined ? { claimHandler: options.claimHandler } : {}),
     ...(options.onReload !== undefined ? { onReload: options.onReload } : {}),
@@ -13323,7 +13336,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     ).toBe(true)
   })
 
-  test('surfaces a provider error after a continue:true progress reply', async () => {
+  test('retries once after a continue:true progress reply and suppresses the warning when the final reply succeeds', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
@@ -13337,18 +13350,174 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     sessions[0]!.onPrompt = async () => {
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
       await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.agent.state.messages = [
+        { role: 'user' },
+        { role: 'assistant', stopReason: 'toolUse' },
+        { role: 'toolResult' },
+        { role: 'assistant', stopReason: 'error' },
+      ]
       sessions[0]!.emit({
         type: 'message_end',
         message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
       })
       sessions[0]!.setAssistantMidTurn('', 'error')
     }
+    sessions[0]!.onContinue = async () => {
+      sessions[0]!.agent.state.messages.push({ role: 'assistant', stopReason: 'stop' })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '지난 기록은 이 내용이야.' })
+      sessions[0]!.setAssistantText('')
+    }
     await router.__testing!.flushDebounce(KEY)
 
-    expect(sent).toHaveLength(2)
-    expect(sent[0]).toBe('찾아볼게.')
-    expect(sent[1]).toMatch(/upstream LLM provider failed/i)
+    expect(sessions[0]!.continued).toBe(1)
+    expect(sent).toEqual(['찾아볼게.', '지난 기록은 이 내용이야.'])
+    expect(sent.some((text) => /upstream LLM provider/i.test(text))).toBe(false)
     expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
+  })
+
+  test('/stop during post-tool retry backoff invalidates the continue:true authorization', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    let signalBackoffStart: () => void = () => {}
+    const backoffStarted = new Promise<void>((resolve) => {
+      signalBackoffStart = resolve
+    })
+    const { router, sessions } = makeRouter(dir, {
+      retryRandom: () => 0.999,
+      onRetryBackoffStart: signalBackoffStart,
+    })
+    router.registerOutbound('discord-bot', async (msg) => {
+      const text = msg.text ?? ''
+      if (text === 'Stopped the current turn.') return { ok: false, error: 'stop acknowledgment unavailable' }
+      sent.push(text)
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.agent.state.messages = [
+        { role: 'user' },
+        { role: 'assistant', stopReason: 'toolUse' },
+        { role: 'toolResult' },
+        { role: 'assistant', stopReason: 'error' },
+      ]
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    sessions[0]!.onContinue = async () => {
+      sessions[0]!.agent.state.messages.push({ role: 'assistant', stopReason: 'stop' })
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '지난 기록은 이 내용이야.' })
+      sessions[0]!.setAssistantText('')
+    }
+
+    const draining = router.__testing!.flushDebounce(KEY)
+    await backoffStarted
+
+    await router.route(inbound({ text: '/stop', externalMessageId: 'm-stop-retry-backoff' }))
+    await draining
+
+    expect(sessions[0]!.aborted).toBe(1)
+    expect(sessions[0]!.continued).toBe(0)
+    expect(sent.filter((text) => text === '찾아볼게.')).toHaveLength(1)
+    expect(sent).not.toContain('지난 기록은 이 내용이야.')
+  })
+
+  test('surfaces one redacted warning after the authorized retry fails again', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.agent.state.messages = [
+        { role: 'user' },
+        { role: 'assistant', stopReason: 'toolUse' },
+        { role: 'toolResult' },
+        { role: 'assistant', stopReason: 'error' },
+      ]
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000 raw-detail' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    sessions[0]!.onContinue = () => {
+      sessions[0]!.agent.state.messages.push({ role: 'assistant', stopReason: 'error' })
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000 second-raw-detail' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.continued).toBe(1)
+    expect(sent[0]).toBe('찾아볼게.')
+    expect(sent.filter((text) => text.startsWith('⚠️'))).toHaveLength(1)
+    expect(sent[1]).toMatch(/connection to the upstream LLM provider dropped/i)
+    expect(sent[1]).not.toContain('raw-detail')
+    expect(sent[1]).not.toContain('second-raw-detail')
+  })
+
+  test('keeps the deferred warning latched when recovery queues an empty-continuation nudge', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    let promptAttempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      promptAttempt++
+      if (promptAttempt === 1) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+        await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+        sessions[0]!.emit({ type: 'tool_execution_start' })
+        sessions[0]!.agent.state.messages = [
+          { role: 'user' },
+          { role: 'assistant', stopReason: 'toolUse' },
+          { role: 'toolResult' },
+          { role: 'assistant', stopReason: 'error' },
+        ]
+        sessions[0]!.emit({
+          type: 'message_end',
+          message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },
+        })
+        sessions[0]!.setAssistantMidTurn('', 'error')
+        return
+      }
+
+      expect(text).toContain(SEND_WILLINGNESS_NUDGE)
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '지난 기록은 이 내용이야.' })
+      sessions[0]!.setAssistantText('')
+    }
+    sessions[0]!.onContinue = () => {
+      sessions[0]!.agent.state.messages.push({ role: 'assistant', stopReason: 'stop' })
+      emptyStopAfterToolWork(sessions[0]!, 'provider-recovery-empty')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.continued).toBe(1)
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent).toEqual(['찾아볼게.', '지난 기록은 이 내용이야.'])
+    expect(sent.some((text) => text.startsWith('⚠️'))).toBe(false)
   })
 
   test('suppresses a provider error after a final reply follows the continue:true progress reply', async () => {
@@ -13365,6 +13534,8 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
       await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
       await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '지난 기록은 이 내용이야.' })
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.agent.state.messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
       sessions[0]!.emit({
         type: 'message_end',
         message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000' },

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2759,9 +2759,18 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const hasStoppableWork = (live: LiveSession): boolean =>
     live.draining || live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0
 
+  const hasPendingContinueReply = (live: LiveSession): boolean => {
+    const progressReply = live.continueReplyTurn
+    return (
+      progressReply !== null &&
+      progressReply.turnSeq === live.turnSeq &&
+      progressReply.sendCount === live.successfulChannelSends
+    )
+  }
+
   const maybePostDeferredProviderError = async (
     live: LiveSession,
-    sentReplyThisTurn: boolean,
+    completedReplyThisTurn: boolean,
     retryQueued: boolean,
   ): Promise<void> => {
     const pending = live.pendingProviderError
@@ -2771,7 +2780,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
     // The turn recovered and replied — the provider blip was transient, so a
     // failure notice would be a false alarm stranded above the real reply.
-    if (sentReplyThisTurn) {
+    if (completedReplyThisTurn) {
       live.pendingProviderError = null
       return
     }
@@ -3055,7 +3064,11 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // error must wait for the reminder-only iteration that actually ends it.
           const retryQueuedThisTurn =
             live.emptyTurnRetries > emptyTurnRetriesBeforePrompt || live.toolLeakRetries > toolLeakRetriesBeforePrompt
-          await maybePostDeferredProviderError(live, sentReplyThisTurn, retryQueuedThisTurn)
+          await maybePostDeferredProviderError(
+            live,
+            sentReplyThisTurn && !hasPendingContinueReply(live),
+            retryQueuedThisTurn,
+          )
           await fireSessionTurnEnd(live)
         }
         await fireSessionIdle(live)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1431,6 +1431,10 @@ export type CreateChannelRouterOptions = {
   logger?: RouterLogger
   // Test seam: clock for sticky/debounce/participants. Defaults to Date.now.
   now?: () => number
+  // Test seams for synchronizing strict post-tool retry backoff without global
+  // random/timer mutation. Production defaults remain Math.random and no hook.
+  retryRandom?: () => number
+  onRetryBackoffStart?: () => void
   // Test seam: measure a transcript file's byte size for the soft-TTL grace
   // decision. Defaults to a stat()-based reader returning 0 for a missing or
   // unreadable file (grace then fails closed to roll-over-at-soft-TTL).
@@ -2742,6 +2746,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     live.firstUnprocessedAt = 0
     live.promptQueue.length = 0
     live.pendingSystemReminders.length = 0
+    live.continueReplyTurn = null
     await stopTypingHeartbeat(live)
     try {
       await live.session.abort()
@@ -2934,6 +2939,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         const successfulSendsBeforePrompt = live.successfulChannelSends
         const emptyTurnRetriesBeforePrompt = live.emptyTurnRetries
         const toolLeakRetriesBeforePrompt = live.toolLeakRetries
+        const willingnessNudgesBeforePrompt = live.willingnessNudges
         const engageAddPromises = live.currentTurnEngageReactions
         live.turnSeq++
         live.successfulSendsAtTurnStart = successfulSendsBeforePrompt
@@ -2964,6 +2970,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             session: live.session,
             text: promptText,
             shouldFailover: (err) => isFailoverWorthy(err.message),
+            authorizeRetryAfterCompletedToolResult: () => hasPendingContinueReply(live),
+            ...(options.retryRandom !== undefined ? { retryRandom: options.retryRandom } : {}),
+            ...(options.onRetryBackoffStart !== undefined ? { onRetryBackoffStart: options.onRetryBackoffStart } : {}),
             setModelForRef: async (ref) => {
               await live.session.setModel(applyModelRuntimeOverrides(resolveModel(ref), ref))
               live.activeModelRef = ref
@@ -2996,7 +3005,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // tool-leak retry that later replies must commit the signal AT the
           // successful retry, not clear it after the first suppressed attempt.
           const retryQueuedThisTurn =
-            live.emptyTurnRetries > emptyTurnRetriesBeforePrompt || live.toolLeakRetries > toolLeakRetriesBeforePrompt
+            live.emptyTurnRetries > emptyTurnRetriesBeforePrompt ||
+            live.toolLeakRetries > toolLeakRetriesBeforePrompt ||
+            live.willingnessNudges > willingnessNudgesBeforePrompt
           const providerErrorThisTurn = assistantLeafStopReason(live.session) === 'error'
           const fallbackPostedThisTurn = live.emptyTurnFallbackTurn === live.turnSeq
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
@@ -3063,7 +3074,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // Either retry budget keeps the turn in flight, so a deferred provider
           // error must wait for the reminder-only iteration that actually ends it.
           const retryQueuedThisTurn =
-            live.emptyTurnRetries > emptyTurnRetriesBeforePrompt || live.toolLeakRetries > toolLeakRetriesBeforePrompt
+            live.emptyTurnRetries > emptyTurnRetriesBeforePrompt ||
+            live.toolLeakRetries > toolLeakRetriesBeforePrompt ||
+            live.willingnessNudges > willingnessNudgesBeforePrompt
           await maybePostDeferredProviderError(
             live,
             sentReplyThisTurn && !hasPendingContinueReply(live),


### PR DESCRIPTION
## Background

The original version of this PR only fixed a narrow surfacing bug: a `continue:true` progress reply (a "still working on it" ack) followed by a provider error, with nothing else sent, previously cleared the pending provider error silently — `sentReplyThisTurn` didn't distinguish a progress ack from a real reply, so the failure never reached the user.

That fix exposed a more consequential gap underneath: the failure is very often *retryable* — a WebSocket connection closing (the `WebSocket closed 1000` incident class) mid-turn — and could simply be retried on the same model ref instead of surfaced as an error at all. Retrying blindly is unsafe once tool execution has already produced side effects, because a naive same-ref retry replays the whole turn from the user message and would re-run the tool. This PR adds a strict, narrowly-scoped retry for exactly that post-tool-result shape, and reserves the warning for genuine exhaustion.

## Summary

- **Broaden retryable-transport classification** (`src/agent/provider-error.ts`): `TRANSPORT_FAILURE` now matches WebSocket closures generically, not just connection-failed/non-101-upgrade forms. `AUTH_FAULT` now also matches `403`/forbidden/access-denied and access/session-token-expired forms. A new context-overflow matcher is carved out of both `isFailoverWorthy` and `isRetryableSameRef`. This preserves the strict safety boundary: account-wide faults (auth/billing/quota) and context overflow must never be retried or failed over — only the transport blip is.
- **New `retryTurnAfterCompletedToolResult`** (`src/agent/retry-same-ref.ts`): resumes a turn only when the message tail is exactly toolResult followed by an assistant error leaf — never a trailing user leaf, never any other shape. On match it removes only the trailing error leaf (keeping the completed tool result) and calls `agent.continue()`, so the already-executed tool call and any already-sent progress reply are never replayed. If `continue()` throws having made no progress, the trimmed leaf is restored rather than leaving the session on a truncated transcript.
- **Explicit authorization, rechecked after backoff** (`src/agent/turn-runner.ts`, `src/channels/router.ts`): the router authorizes the retry only while the progress reply's stamped `turnSeq`/`sendCount` still match the live session — i.e. nothing further has been sent since the progress ack. The retry helper checks this authorization again after its backoff sleep, not just before, since another actor could have advanced the transcript while it slept. Once tool execution has started, the turn also stops failing over to a different model ref — only this exact-tail retry applies, and only once per ref.
- **Suppression follows the outcome, not just the attempt**: a successful retry suppresses the deferred provider-error warning entirely. Exhaustion (retry unauthorized, tail doesn't match, or the retried `continue()` fails again) still emits exactly one redacted warning. The router's retry-in-flight bookkeeping now also accounts for willingness-nudge retries alongside the existing empty-turn/tool-leak counters, so a turn extended by a willingness nudge correctly keeps carrying the pending warning through to the iteration that actually ends the turn, instead of clearing or double-posting it early.

## What this does NOT do

- Does not retry account-wide faults (auth/billing/quota) or context-window overflow under any circumstance — those still surface immediately via the existing hard-error path.
- Does not attempt more than one same-ref retry for the post-tool-result shape, and does not fail over to a different model ref once tool execution has started in the turn.
- Does not touch the engage/silent-ack reaction logic, the `channel_send`/`channel_reply` boundaries, or any adapter code — confined to `src/agent/provider-error.ts`, `src/agent/retry-same-ref.ts`, `src/agent/turn-runner.ts`, and `src/channels/router.ts`.
- No public surface change: no new CLI flag, config field, or plugin contract, and no docs update — internal reliability fix only.

## Review notes

- Load-bearing invariant: the tail-match helper accepts ONLY toolResult followed by an assistant error leaf — any other tail (including a trailing user message) must fail closed so no other retry shape gets silently absorbed by this path.
- Load-bearing invariant: the pending-progress-reply authorization check is rechecked after the backoff sleep, not only before — verify a send that lands during the sleep correctly revokes authorization.
- Rollback safety: the trimmed error leaf is restored on a failed `continue()` only when the transcript is provably unchanged from the trimmed prefix, so a genuinely-in-progress retry attempt is never overwritten.
- Verification: `bun run typecheck`, `bun run lint` (0 errors), `bun run format` all clean; full suite 10,966 pass, 1 skip, 0 fail; this PR also went through the 5-gate review process (goal/constraint, code quality, security, hands-on QA, context mining), all passing.