### PR TITLE
channels: report Discord gateway disconnects

### DIFF
--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -3,14 +3,16 @@ import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type { DiscordBotClient, DiscordFile, DiscordMessage } from 'agent-messenger/discordbot'
+import type { DiscordBotClient, DiscordBotListener, DiscordFile, DiscordMessage } from 'agent-messenger/discordbot'
 import { DiscordIntent } from 'agent-messenger/discordbot'
 
+import type { ChannelRouter } from '@/channels/router'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
 import type { FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
 import type { ChannelKey } from '@/channels/types'
 
 import {
+  createDiscordBotAdapter,
   createDiscordHistoryCallback,
   createDiscordListCallback,
   createDiscordMembershipResolver,
@@ -35,6 +37,67 @@ describe('discord-bot gateway intents', () => {
 
   test('includes GuildMessages so guild channel messages are delivered', () => {
     expect(DISCORD_BOT_INTENTS & DiscordIntent.GuildMessages).toBe(DiscordIntent.GuildMessages)
+  })
+})
+
+describe('discord-bot lifecycle', () => {
+  test('reports live gateway state while retaining bot identity across reconnects', async () => {
+    const listener = new FakeDiscordBotListener()
+    const router = new FakeDiscordBotRouter()
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'token-1',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl: (async () => new Response('{}', { status: 200 })) as unknown as typeof fetch,
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+    })
+
+    expect(adapter.isConnected()).toBe(false)
+    await adapter.start()
+    expect(adapter.isConnected()).toBe(true)
+    expect(router.selfIdentity?.('@dm')).toEqual({ id: 'bot-1' })
+
+    listener.emit('disconnected', 'transport closed')
+    expect(adapter.isConnected()).toBe(false)
+    expect(router.selfIdentity?.('@dm')).toEqual({ id: 'bot-1' })
+
+    listener.emit('connected', connectedInfo())
+    expect(adapter.isConnected()).toBe(true)
+
+    listener.emit('error', new Error('temporary gateway transport error'))
+    expect(adapter.isConnected()).toBe(true)
+
+    listener.emit('error', new Error('Discord gateway closed with non-recoverable code 4004'))
+    expect(adapter.isConnected()).toBe(false)
+    expect(router.selfIdentity?.('@dm')).toEqual({ id: 'bot-1' })
+
+    listener.emit('connected', connectedInfo())
+    expect(adapter.isConnected()).toBe(true)
+
+    await adapter.stop()
+    expect(adapter.isConnected()).toBe(false)
+    expect(listener.stopped).toBe(true)
+    expect(router.unregistered).toEqual(router.registered)
+  })
+
+  test('remains disconnected when listener startup fails', async () => {
+    const listener = new FakeDiscordBotListener({ failStart: true })
+    const router = new FakeDiscordBotRouter()
+    const adapter = createDiscordBotAdapter({
+      router: router.value,
+      configRef: () => lifecycleConfig(),
+      token: 'token-1',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      fetchImpl: (async () => new Response('{}', { status: 200 })) as unknown as typeof fetch,
+      createClient: () => fakeDiscordBotClient(),
+      createListener: () => listener.value,
+    })
+
+    await expect(adapter.start()).rejects.toThrow('start failed')
+    expect(adapter.isConnected()).toBe(false)
+    expect(router.unregistered).toEqual(router.registered)
   })
 })
 
@@ -1868,3 +1931,85 @@ describe('createInteractionHandler', () => {
     expect(events.map((e) => e.kind)).toEqual(['router-call', 'ack-sent', 'channel-tag-resolved'])
   })
 })
+
+class FakeDiscordBotListener {
+  private handlers = new Map<string, Array<(arg: unknown) => void>>()
+  readonly value = this as unknown as DiscordBotListener
+  stopped = false
+
+  constructor(private readonly options: { failStart?: boolean } = {}) {}
+
+  on(event: string, listener: (arg: unknown) => void): this {
+    this.handlers.set(event, [...(this.handlers.get(event) ?? []), listener])
+    return this
+  }
+
+  async start(): Promise<void> {
+    if (this.options.failStart) throw new Error('start failed')
+    this.emit('connected', connectedInfo())
+  }
+
+  stop(): void {
+    this.stopped = true
+  }
+
+  emit(event: string, payload: unknown): void {
+    for (const handler of this.handlers.get(event) ?? []) handler(payload)
+  }
+}
+
+class FakeDiscordBotRouter {
+  readonly registered: string[] = []
+  readonly unregistered: string[] = []
+  selfIdentity: ((workspace: string) => { id: string; username?: string } | null) | null = null
+  readonly value = {
+    route: async () => {},
+    registerOutbound: () => this.registered.push('outbound'),
+    unregisterOutbound: () => this.unregistered.push('outbound'),
+    registerReaction: () => this.registered.push('reaction'),
+    unregisterReaction: () => this.unregistered.push('reaction'),
+    registerRemoveReaction: () => this.registered.push('removeReaction'),
+    unregisterRemoveReaction: () => this.unregistered.push('removeReaction'),
+    registerTyping: () => this.registered.push('typing'),
+    unregisterTyping: () => this.unregistered.push('typing'),
+    setTypingCapability: (_adapter: string, supported: boolean) =>
+      (supported ? this.registered : this.unregistered).push('typingCapability'),
+    registerChannelNameResolver: () => this.registered.push('channelNameResolver'),
+    unregisterChannelNameResolver: () => this.unregistered.push('channelNameResolver'),
+    registerSelfIdentity: (_adapter: string, cb: (workspace: string) => { id: string; username?: string } | null) => {
+      this.selfIdentity = cb
+      this.registered.push('selfIdentity')
+    },
+    unregisterSelfIdentity: () => this.unregistered.push('selfIdentity'),
+    registerHistory: () => this.registered.push('history'),
+    unregisterHistory: () => this.unregistered.push('history'),
+    registerMessageGet: () => this.registered.push('messageGet'),
+    unregisterMessageGet: () => this.unregistered.push('messageGet'),
+    registerList: () => this.registered.push('list'),
+    unregisterList: () => this.unregistered.push('list'),
+    registerEditMessage: () => this.registered.push('editMessage'),
+    unregisterEditMessage: () => this.unregistered.push('editMessage'),
+    registerFetchAttachment: () => this.registered.push('fetchAttachment'),
+    unregisterFetchAttachment: () => this.unregistered.push('fetchAttachment'),
+    registerMembership: () => this.registered.push('membership'),
+    unregisterMembership: () => this.unregistered.push('membership'),
+  } as unknown as ChannelRouter
+}
+
+function connectedInfo() {
+  return { user: { id: 'bot-1', username: 'Typeey' }, sessionId: 'session-1' }
+}
+
+function lifecycleConfig(): ChannelAdapterConfig {
+  return {
+    engagement: { trigger: ['mention'], stickiness: 'off' },
+    enabled: true,
+    history: defaultHistoryConfig(),
+  }
+}
+
+function fakeDiscordBotClient() {
+  return {
+    login: async () => fakeDiscordBotClient(),
+  } as unknown as ReturnType<NonNullable<Parameters<typeof createDiscordBotAdapter>[0]['createClient']>>
+}

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 
-import { DiscordBotClient, DiscordBotListener } from 'agent-messenger/discordbot'
+import { DiscordBotClient, DiscordBotListener, type DiscordBotListenerOptions } from 'agent-messenger/discordbot'
 import {
   DiscordIntent,
   type DiscordFile,
@@ -121,6 +121,8 @@ export type DiscordBotAdapterOptions = {
   // exact REST calls without monkey-patching globalThis.fetch. Production
   // callers leave it undefined to use the global fetch.
   fetchImpl?: typeof fetch
+  createClient?: () => DiscordBotClient
+  createListener?: (client: DiscordBotClient, options: DiscordBotListenerOptions) => DiscordBotListener
 }
 
 export type DiscordBotAdapter = {
@@ -1018,10 +1020,14 @@ export const DISCORD_SLASH_COMMAND_NAMES = SLASH_COMMAND_NAMES
 
 export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): DiscordBotAdapter {
   const logger = options.logger ?? consoleLogger
-  const client = new DiscordBotClient()
+  const createClient = options.createClient ?? (() => new DiscordBotClient())
+  const createListener =
+    options.createListener ?? ((client, listenerOptions) => new DiscordBotListener(client, listenerOptions))
+  const client = createClient()
   const fetchImpl = options.fetchImpl ?? fetch
   let listener: DiscordBotListener | null = null
   let botUserId: string | null = null
+  let connected = false
   let started = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
@@ -1178,8 +1184,9 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         throw err
       }
 
-      listener = new DiscordBotListener(client, { intents: DISCORD_BOT_INTENTS })
+      listener = createListener(client, { intents: DISCORD_BOT_INTENTS })
       listener.on('connected', (info) => {
+        connected = true
         botUserId = info.user.id
         logger.info(`[discord-bot] connected as ${info.user.username} (${info.user.id})`)
         // For bots, the gateway's user.id IS the application id — the same
@@ -1211,9 +1218,15 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         })
       })
       listener.on('disconnected', () => {
+        connected = false
         logger.warn('[discord-bot] disconnected; SDK will reconnect with backoff')
       })
       listener.on('error', (err) => {
+        // agent-messenger 2.30.0 emits only `error` (not `disconnected`)
+        // when a terminal Gateway close stops the listener. Match that
+        // distinct SDK error contract without treating transient transport
+        // errors as disconnects.
+        if (isTerminalGatewayClose(err)) connected = false
         logger.error(`[discord-bot] gateway error: ${describe(err)}`)
       })
       listener.on('message_create', (event) => {
@@ -1259,6 +1272,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         options.router.unregisterMembership('discord-bot', membershipResolver)
         listener = null
         botUserId = null
+        connected = false
         started = false
         logger.error(`[discord-bot] listener start failed: ${describe(err)}`)
         throw err
@@ -1288,12 +1302,19 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       }
       listener?.stop()
       listener = null
+      connected = false
     },
 
     isConnected(): boolean {
-      return botUserId !== null
+      return started && connected
     },
   }
+}
+
+const TERMINAL_GATEWAY_CLOSE_PATTERN = /^Discord gateway closed with non-recoverable code \d+$/
+
+function isTerminalGatewayClose(err: unknown): boolean {
+  return err instanceof Error && TERMINAL_GATEWAY_CLOSE_PATTERN.test(err.message)
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
## Summary

Fix `discord-bot` connection health reporting so TypeClaw's existing channel-manager recovery watchdog can detect and restart a Gateway listener that remains disconnected.

Closes #1195.

## Root cause

`discord-bot.isConnected()` used `botUserId !== null` as its health signal. The ID is learned from the first Gateway READY and is intentionally retained for identity-dependent routing, but it was never cleared by the listener's `disconnected` event. After one successful connection, the adapter therefore reported healthy forever—even while its Gateway listener was disconnected.

The channel manager already polls each live adapter and restarts one that remains disconnected beyond the recovery grace period. The stale Discord health signal made that existing recovery path unreachable for this adapter.

## Change

- Track current Discord Gateway connectivity separately from cached bot identity.
- Mark the adapter connected on the listener's `connected` event.
- Mark it disconnected on the listener's `disconnected` event and on agent-messenger's distinct non-recoverable Gateway-close error, plus failed start and stop.
- Keep generic/transient SDK errors from falsely clearing a live connection.
- Report `started && connected` from `isConnected()`.
- Add injectable client/listener factories, matching other channel adapters, so regression tests drive the real lifecycle handlers.
- Cover recoverable disconnect, transient error, terminal non-recoverable close, resumed/reconnected, stopped, and failed-start states while proving cached bot identity survives outages.

This intentionally does **not** change Discord message replay/backfill, `agent-messenger` reconnect behavior, or subagent concurrency. There is no fan-out cap in this change.

## Why this is safe

- No user-facing configuration or plugin surface changes.
- The SDK still gets its normal reconnect grace period; this only makes TypeClaw accurately observe whether it recovered.
- Cached `botUserId` remains available for self-classification and history while the SDK reconnects.
- A later READY or RESUMED event restores the connected signal.
- The generic manager already serializes recovery restarts and prevents duplicate restarts for one disconnected episode.

## Load-bearing invariant

Bot identity and Gateway liveness are separate state. `disconnected` must clear only the live connection flag, not `botUserId`; otherwise history/self-classification loses identity during a reconnect. The lifecycle regression test asserts both sides of that invariant and fails if the production disconnect transition is removed.

## Validation

Passed:

- `bun test --parallel ./src/channels/adapters/discord-bot.test.ts ./src/channels/manager.test.ts` — 113 passed, 0 failed
- `bun run typecheck`
- `bun run lint` — 0 errors (existing warnings only)
- `bun run format`
- `bun run format:check`
- `git diff --check`

Full suite:

- `bun run test` — 10,943 passed, 5 skipped, 6 failed
- All six failures reproduce on untouched `origin/main` in the same environment. They are existing environment-sensitive sandbox/symlink/memory tests in:
  - `src/agent/plugin-tools.test.ts`
  - `src/bundled-plugins/guard/index.test.ts`
  - `src/bundled-plugins/guard/policies/non-workspace-write.test.ts`
  - `src/bundled-plugins/memory/dreaming.test.ts`
  - `src/bundled-plugins/memory/load-shards.test.ts`
- None touch the Discord adapter or manager recovery path.
