### PR TITLE
fix(agent): systemic loop guard false positives on reviews

### DIFF
--- a/docs/content/docs/internals/engagement.mdx
+++ b/docs/content/docs/internals/engagement.mdx
@@ -84,7 +84,7 @@ The `contextBuffer` only flushes inside `drain()`, which only runs on an `engage
 
 ## Peer-bot loop guard
 
-Distinct from the per-session [tool loop guard](/docs/internals/message-stream) (`src/agent/loop-guard.ts`, byte-identical tool calls). The channel-level guard (`updateLoopGuard`, `router.ts`) counts **engaged peer-bot turns since the last human**:
+Distinct from the per-session [tool loop guard](/docs/internals/message-stream) (`src/agent/loop-guard.ts`, exact-call and sliding-window cycle detection). The channel-level guard (`updateLoopGuard`, `router.ts`) counts **engaged peer-bot turns since the last human**:
 
 - Any human inbound resets the counters and clears `loopGuardActive`.
 - A peer-bot engage increments `consecutiveEngagedPeerBotTurns` and pushes onto a sliding `PEER_BOT_TURNS_WINDOW_MS` (60s) window.

--- a/docs/content/docs/internals/message-stream.mdx
+++ b/docs/content/docs/internals/message-stream.mdx
@@ -19,12 +19,19 @@ Adding a fifth kind is a deliberate design choice. No generic `handler` extensio
 
 ## Subagents
 
-`src/agent/subagents.ts` defines the `Subagent` type and the `SubagentConsumer`. Two paths converge on `invokeSubagent`:
+`src/agent/subagents.ts` defines the `Subagent` type and the `SubagentConsumer`. Three paths converge on `invokeSubagent`:
 
 1. `ctx.spawnSubagent(name, payload, options)` — direct, no Stream. Plugin hooks, main-agent `spawn-subagent` tool, plugin commands.
 2. Cron with a `subagent` field → `target: { kind: 'new-session' }` → `SubagentConsumer` → `invokeSubagent`. The Stream path exists so the scheduler doesn't need to import the registry.
+3. `startSubagent` wraps `invokeSubagent` with a live handle and completion result for sync/background tool spawns. Background completions publish `subagent.completed`; failed runs can carry a captured final message as recoverable output without changing the failed lifecycle status.
 
 Production registry is built from plugin contributions. The bundled memory plugin is auto-loaded and contributes `memory-logger` + `dreaming`. Each plugin `Subagent` may declare `inFlightKey(payload)`; consumer uses `${name}:${key}` as the dedup key (both memory-logger and dreaming key by `agentDir`). `payloadSchema` is validated by the cron loader at parse time and on every `reloadAll()`.
+
+### Tool-loop termination
+
+`src/agent/loop-guard.ts` combines exact repeated-call detection with a sliding target window. Reads are classified at the awaited SDK `turn_start` boundary: calls for one canonical path emitted in the same assistant tool batch count once. Successful non-empty textual results contribute bounded observed intervals; recorded pages establish the frontier, and exact-adjacent sibling intervals extend it even when parallel calls finish out of order. Suppressed siblings do not count as independent loop observations. Recorded images, overlap, backtracking, gaps, empty results, and malformed ranges retain the coarse path signature and accumulate toward a block.
+
+A confirmed block aborts the active SDK run because returning a tool error alone lets a looping model retry indefinitely. `loop_guard:block` and `loop_guard:deferred_block` are lifecycle failures for subagents; `startSubagent` reports `ok: false` and preserves any assistant result captured before the abort only as recoverable output. Required-result repair retries never convert that forced termination back into success.
 
 ## Bundled plugins
 

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -19,6 +19,7 @@ import { createStream } from '@/stream'
 import {
   buildChannelTools,
   buildSubagentOrchestrationTools,
+  attachLoopGuardTurnTracking,
   composeSystemPrompt,
   createOverrideResourceLoader,
   createResourceLoader,
@@ -72,6 +73,35 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('attachLoopGuardTurnTracking', () => {
+  test('advances only on awaited agent turn_start events and unsubscribes cleanly', () => {
+    let listener: ((event: unknown) => void) | undefined
+    let unsubscribed = false
+    let turns = 0
+    const unsubscribe = attachLoopGuardTurnTracking(
+      {
+        subscribe: (next) => {
+          listener = next
+          return () => {
+            unsubscribed = true
+          }
+        },
+      },
+      () => {
+        turns += 1
+      },
+    )
+
+    listener?.({ type: 'message_start' })
+    listener?.({ type: 'turn_start' })
+    listener?.({ type: 'turn_start' })
+    expect(turns).toBe(2)
+
+    unsubscribe()
+    expect(unsubscribed).toBe(true)
+  })
 })
 
 describe('createResourceLoader', () => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -252,6 +252,15 @@ export async function createSession(options: CreateSessionOptions = {}): Promise
   return session
 }
 
+export function attachLoopGuardTurnTracking(
+  agent: { subscribe: (listener: (event: unknown) => void) => () => void },
+  onTurnStart: () => void,
+): () => void {
+  return agent.subscribe((event: unknown) => {
+    if ((event as { type?: string }).type === 'turn_start') onTurnStart()
+  })
+}
+
 export async function createSessionWithDispose(options: CreateSessionOptions = {}): Promise<CreateSessionResult> {
   const resolved = resolveProfile(getConfig().models, options.profile)
   // Unknown profiles silently fall back to `default`. The fallback is by design
@@ -301,6 +310,8 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   // plugin-tools.ts for why aborting (not throwing) is what stops the loop.
   const abortHolder: { abort?: (reason?: string) => void; reason?: string } = {}
   const getAbort: () => ((reason?: string) => void) | undefined = () => abortHolder.abort
+  let loopGuardTurnId = 0
+  const getLoopGuardTurn = () => loopGuardTurnId
 
   // Subagent built-in tool refs resolve to `ToolDefinition`s (see
   // plugin-tools.ts). Their NAMES narrow the session via `tools:`; their wrapped
@@ -312,8 +323,8 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   const subagentBuiltinNames = resolvedSubagentBuiltins.map((t) => t.name)
   const subagentTypeclawToolDefinitions = resolvedSubagentBuiltins.filter((t) => !isPiCodingBuiltinName(t.name))
   const pluginCustomTools = options.pluginSubagent
-    ? wrapSubagentCustomTools(options.pluginSubagent, options.plugins, getOrigin, getAbort)
-    : wrapRegistryTools(options.plugins, getOrigin, getAbort)
+    ? wrapSubagentCustomTools(options.pluginSubagent, options.plugins, getOrigin, getAbort, getLoopGuardTurn)
+    : wrapRegistryTools(options.plugins, getOrigin, getAbort, getLoopGuardTurn)
 
   // Per-run budget state for the tool-result byte ceiling. Allocated once per
   // session creation and threaded into every wrapped tool so they share the
@@ -442,10 +453,17 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
     hooks: options.plugins?.hooks ?? createHookBus(),
     getOrigin,
     getAbort,
+    getLoopGuardTurn,
     ...(options.permissions ? { permissions: options.permissions } : {}),
     ...(options.bashPolicy !== undefined ? { bashPolicy: options.bashPolicy } : {}),
   })
-  const wrappedCustomSystemTools = wrapSystemTools(customSystemTools, options.plugins, getOrigin, getAbort)
+  const wrappedCustomSystemTools = wrapSystemTools(
+    customSystemTools,
+    options.plugins,
+    getOrigin,
+    getAbort,
+    getLoopGuardTurn,
+  )
   const customToolsPreBudget = [...wrappedCustomSystemTools, ...pluginCustomTools, ...builtinPiToolOverrides]
   const customTools =
     sessionBudget && sessionBudgetState
@@ -491,6 +509,9 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   ;(session as { setAutoRetryEnabled?: (enabled: boolean) => void }).setAutoRetryEnabled?.(false)
   const getAbortReason = () => abortHolder.reason
   const sessionWithAbortReason = Object.assign(session, { getAbortReason })
+  const unsubLoopGuardTurn = attachLoopGuardTurnTracking(session.agent, () => {
+    loopGuardTurnId += 1
+  })
 
   // Layer the replay sanitizer over pi's convertToLlm so a transcript with an
   // orphaned toolResult (e.g. a torn-down restart turn) can't wedge the session
@@ -524,6 +545,7 @@ export async function createSessionWithDispose(options: CreateSessionOptions = {
   const unsubToolNudge = attachToolNotFoundNudge(session, intendedActiveToolNames)
 
   const dispose = async () => {
+    unsubLoopGuardTurn()
     unsubRestart?.()
     unsubToolNudge()
     if (materializedSkills) await materializedSkills.dispose()
@@ -863,6 +885,7 @@ function wrapRegistryTools(
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
   getAbort: () => ((reason?: string) => void) | undefined,
+  getLoopGuardTurn: () => number | undefined,
 ): ToolDefinition[] {
   if (!plugins) return []
   return plugins.registry.tools.map((t: PluginRegisteredTool) =>
@@ -875,6 +898,7 @@ function wrapRegistryTools(
       hooks: plugins.hooks,
       getOrigin,
       getAbort,
+      getLoopGuardTurn,
     }),
   )
 }
@@ -884,6 +908,7 @@ function wrapSystemTools(
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
   getAbort: () => ((reason?: string) => void) | undefined,
+  getLoopGuardTurn: () => number | undefined,
 ): ToolDefinition[] {
   if (!hasToolHooks(plugins)) return tools
   return tools.map((tool) =>
@@ -893,6 +918,7 @@ function wrapSystemTools(
       hooks: plugins.hooks,
       getOrigin,
       getAbort,
+      getLoopGuardTurn,
     }),
   )
 }
@@ -907,6 +933,7 @@ function wrapSubagentCustomTools(
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
   getAbort: () => ((reason?: string) => void) | undefined,
+  getLoopGuardTurn: () => number | undefined,
 ): ToolDefinition[] {
   if (!selection.customTools || !plugins) return []
   const logger = makePluginLogger(selection.pluginName)
@@ -920,6 +947,7 @@ function wrapSubagentCustomTools(
       hooks: plugins.hooks,
       getOrigin,
       getAbort,
+      getLoopGuardTurn,
     }),
   )
 }

--- a/src/agent/loop-guard.test.ts
+++ b/src/agent/loop-guard.test.ts
@@ -205,6 +205,199 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
     if (last.kind === 'block') expect(last.reason).toBe('windowed')
   })
 
+  test('records one same-path read observation per model turn', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+
+    const decisions = [1, 2, 3, 4, 5, 6].map((offset) =>
+      guard.check('s1', 'read', { path: '/agent/router.ts', offset, limit: 100 }, { turnId: 1 }),
+    )
+
+    expect(decisions.every((decision) => decision.kind === 'ok')).toBe(true)
+    expect(decisions.map((decision) => decision.receipt.recorded)).toEqual([true, false, false, false, false, false])
+  })
+
+  test('records one same-path read observation per model turn when pagination args are omitted', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    const decisions = Array.from({ length: 6 }, () =>
+      guard.check('s1', 'read', { path: '/agent/router.ts' }, { turnId: 1 }),
+    )
+    expect(decisions.every((decision) => decision.kind === 'ok')).toBe(true)
+    expect(decisions.map((decision) => decision.receipt.recorded)).toEqual([true, false, false, false, false, false])
+  })
+
+  test('does not count non-overlapping read pages across model turns as a cycle', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+
+    for (let turnId = 1; turnId <= 8; turnId++) {
+      const offset = 1 + (turnId - 1) * 100
+      const decision = guard.check('s1', 'read', { path: '/agent/router.ts', offset, limit: 100 }, { turnId })
+      expect(decision.kind).toBe('ok')
+      guard.noteReadResult(decision.receipt, { nonEmpty: true, outputLines: 100 })
+    }
+  })
+
+  test('merges out-of-order contiguous sibling pages across repeated fan-out turns', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+
+    for (let turnId = 1; turnId <= 6; turnId++) {
+      const firstOffset = 1 + (turnId - 1) * 600
+      const decisions = Array.from({ length: 6 }, (_, index) =>
+        guard.check(
+          's1',
+          'read',
+          { path: '/agent/router.ts', offset: firstOffset + index * 100, limit: 100 },
+          { turnId },
+        ),
+      )
+      expect(decisions.every((decision) => decision.kind === 'ok')).toBe(true)
+      for (const index of [5, 3, 1, 4, 2, 0]) {
+        guard.noteReadResult(decisions[index]!.receipt, { nonEmpty: true, outputLines: 100 })
+      }
+    }
+  })
+
+  test('uses observed output lines to advance offset-only reads', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    for (let turnId = 1; turnId <= 8; turnId++) {
+      const offset = 1 + (turnId - 1) * 100
+      const decision = guard.check('s1', 'read', { path: '/agent/router.ts', offset }, { turnId })
+      expect(decision.kind).toBe('ok')
+      guard.noteReadResult(decision.receipt, { nonEmpty: true, outputLines: 100 })
+    }
+  })
+
+  test('still blocks overlapping read pages across model turns', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    let last = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 1, limit: 100 }, { turnId: 1 })
+    guard.noteReadResult(last.receipt, { nonEmpty: true, outputLines: 100 })
+    for (let turnId = 2; turnId <= 6; turnId++) {
+      last = guard.check('s1', 'read', { path: '/agent/router.ts', offset: turnId, limit: 100 }, { turnId })
+      guard.noteReadResult(last.receipt, { nonEmpty: true, outputLines: 100 })
+    }
+
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  test('still blocks backtracking read pages across model turns', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const offsets = [1, 101, 1, 101, 1, 101, 1, 101]
+    let last = guard.check('s1', 'read', { path: '/agent/router.ts', offset: offsets[0]!, limit: 100 }, { turnId: 1 })
+    guard.noteReadResult(last.receipt, { nonEmpty: true, outputLines: 100 })
+    for (const [index, offset] of offsets.slice(1).entries()) {
+      last = guard.check('s1', 'read', { path: '/agent/router.ts', offset, limit: 100 }, { turnId: index + 2 })
+      guard.noteReadResult(last.receipt, { nonEmpty: true, outputLines: 100 })
+    }
+
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  test('overlapping suppressed same-turn reads cannot move the observed frontier', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    const first = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 1, limit: 100 }, { turnId: 1 })
+    const extending = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 51, limit: 100 }, { turnId: 1 })
+    guard.noteReadResult(first.receipt, { nonEmpty: true, outputLines: 100 })
+    guard.noteReadResult(extending.receipt, { nonEmpty: true, outputLines: 100 })
+
+    const skipped = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 151, limit: 100 }, { turnId: 2 })
+    expect(skipped.receipt.windowSignature).toBe('read#path:/agent/router.ts')
+    const next = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 101, limit: 100 }, { turnId: 3 })
+    expect(next.receipt.windowSignature).toContain('#frontier:101')
+  })
+
+  test('recorded overlapping reads cannot extend the contiguous frontier', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    const first = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 1, limit: 100 }, { turnId: 1 })
+    guard.noteReadResult(first.receipt, { nonEmpty: true, outputLines: 100 })
+    const overlap = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 51, limit: 100 }, { turnId: 2 })
+    guard.noteReadResult(overlap.receipt, { nonEmpty: true, outputLines: 100 })
+
+    const next = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 101, limit: 100 }, { turnId: 3 })
+    expect(next.receipt.windowSignature).toContain('#frontier:101')
+  })
+
+  test('does not treat skipped offsets or empty results as forward progress', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    const first = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 1, limit: 100 }, { turnId: 1 })
+    guard.noteReadResult(first.receipt, { nonEmpty: true, outputLines: 100 })
+    const skipped = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 10_000, limit: 100 }, { turnId: 2 })
+    expect(skipped.receipt.windowSignature).toBe('read#path:/agent/router.ts')
+    guard.noteReadResult(skipped.receipt, { nonEmpty: true, outputLines: 100 })
+    const expectedFrontier = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 101 }, { turnId: 3 })
+    expect(expectedFrontier.receipt.windowSignature).toContain('#frontier:101')
+  })
+
+  test('treats an observed zero-line read result as no progress', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    const first = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 1, limit: 1 }, { turnId: 1 })
+    guard.noteReadResult(first.receipt, { nonEmpty: true, outputLines: 0 })
+    const next = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 2, limit: 1 }, { turnId: 2 })
+    expect(next.receipt.windowSignature).toBe('read#path:/agent/router.ts')
+  })
+
+  test('bounds same-turn read-path deduplication state', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 4, windowSoftWarn: 3, windowHardBlock: 4 })
+    for (const path of ['a', 'b', 'c', 'd', 'e']) guard.check('s1', 'read', { path }, { turnId: 1 })
+    const revisitedEvictedPath = guard.check('s1', 'read', { path: 'a' }, { turnId: 1 })
+    expect(revisitedEvictedPath.receipt.recorded).toBe(true)
+  })
+
+  test('canonicalizes lexical read-path aliases before window accounting', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    const aliases = ['x', './x', 'a/../x', './a/../x', 'b/../x', '././x']
+    let last = guard.check('s1', 'read', { path: aliases[0] }, { turnId: 1, cwd: '/agent' })
+    for (const [index, path] of aliases.slice(1).entries()) {
+      last = guard.check('s1', 'read', { path }, { turnId: index + 2, cwd: '/agent' })
+    }
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  test('uses platform-neutral canonical keys for Windows-style read paths', () => {
+    const guard = createLoopGuard({ ...noConsecutive, windowSize: 16, windowSoftWarn: 4, windowHardBlock: 6 })
+    const first = guard.check(
+      's1',
+      'read',
+      { path: '.\\router.ts', offset: 1, limit: 100 },
+      { turnId: 1, cwd: 'C:\\agent' },
+    )
+    const alias = guard.check(
+      's1',
+      'read',
+      { path: 'C:/agent/router.ts', offset: 101, limit: 100 },
+      { turnId: 1, cwd: 'C:\\agent' },
+    )
+
+    expect(first.receipt.windowSignature).toBe('read#path:C:/agent/router.ts')
+    expect(alias.receipt.recorded).toBe(false)
+  })
+
   test('does not flag legitimate fan-out reads across distinct paths', () => {
     const guard = createLoopGuard({
       ...noConsecutive,
@@ -525,8 +718,29 @@ describe('createLoopGuard — retract', () => {
 
   test('is a no-op for an unknown session', () => {
     const guard = windowGuard()
-    const receipt = { sessionId: 'missing', tool: 'subagent_output', signature: 'x', windowSignature: 'y' }
+    const receipt = {
+      sessionId: 'missing',
+      tool: 'subagent_output',
+      signature: 'x',
+      windowSignature: 'y',
+      recorded: true,
+    }
     expect(() => guard.retract(receipt)).not.toThrow()
+  })
+
+  test('retracting a suppressed same-turn read does not remove its recorded sibling', () => {
+    const guard = windowGuard()
+    const recorded = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 1, limit: 100 }, { turnId: 1 })
+    const suppressed = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 101, limit: 100 }, { turnId: 1 })
+    expect(recorded.receipt.recorded).toBe(true)
+    expect(suppressed.receipt.recorded).toBe(false)
+
+    guard.retract(suppressed.receipt)
+    for (let turnId = 2; turnId <= 5; turnId++) {
+      guard.check('s1', 'read', { path: '/agent/router.ts', offset: turnId, limit: 100 }, { turnId })
+    }
+    const blocked = guard.check('s1', 'read', { path: '/agent/router.ts', offset: 6, limit: 100 }, { turnId: 6 })
+    expect(blocked.kind).toBe('block')
   })
 })
 
@@ -589,7 +803,13 @@ describe('createLoopGuard — noteResult / deferable', () => {
 
   test('noteResult is a no-op for an unknown session', () => {
     const guard = createLoopGuard({ softWarn: 3, hardBlock: 5 })
-    const receipt = { sessionId: 'missing', tool: 'subagent_output', signature: 'x', windowSignature: 'y' }
+    const receipt = {
+      sessionId: 'missing',
+      tool: 'subagent_output',
+      signature: 'x',
+      windowSignature: 'y',
+      recorded: true,
+    }
     expect(() => guard.noteResult(receipt, 'terminal')).not.toThrow()
   })
 })

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -1,3 +1,5 @@
+import { posix } from 'node:path'
+
 // Detects when the model is stuck looping on tool calls. Two independent
 // detectors run per call; the more severe decision wins.
 //
@@ -10,8 +12,9 @@
 //    re-reading one file with drifting offsets. Over a sliding window of the
 //    last WINDOW_SIZE calls, if one signature recurs WINDOW_SOFT_WARN times it
 //    warns and WINDOW_HARD_BLOCK times it blocks. Path-bearing tools coarsen
-//    their signature to the path alone (offsets/limits/line ranges dropped) so
-//    that paging the same file in a cycle collapses to one signature.
+//    their signature to the path alone. Read calls additionally recognize one
+//    assistant tool batch and successfully-observed forward pagination so
+//    productive inspection does not look like a reactive cycle.
 //
 // Both warn/block decisions carry the byte-identical or coarsened nudge text.
 // The wrapping in plugin-tools.ts maps a block to `errorResult` for plugin tools
@@ -71,12 +74,20 @@ export type LoopGuardReceipt = {
   tool: string
   signature: string
   windowSignature: string
+  recorded: boolean
+  readPage?: ReadPage
+}
+
+export type LoopGuardCheckContext = {
+  turnId?: number
+  cwd?: string
 }
 
 // Post-execution classification of a `subagent_output` poll, fed back via
 // `noteResult`. 'running' is a still-pending wait; 'terminal' is completed/failed
 // — a repeated terminal poll is a real loop.
 export type LoopObservedResult = 'running' | 'terminal'
+export type ReadObservedResult = { nonEmpty: boolean; outputLines?: number; textual?: boolean }
 
 export type LoopGuardDecision =
   | { kind: 'ok'; receipt: LoopGuardReceipt }
@@ -91,7 +102,7 @@ type Verdict =
   | { kind: 'block'; count: number; reason: LoopReason; message: string }
 
 export type LoopGuard = {
-  check: (sessionId: string, tool: string, args: unknown) => LoopGuardDecision
+  check: (sessionId: string, tool: string, args: unknown, context?: LoopGuardCheckContext) => LoopGuardDecision
   reset: (sessionId: string) => void
   forget: (sessionId: string) => void
   // Clears only the residue a single tool left behind in a session: its entries
@@ -104,9 +115,10 @@ export type LoopGuard = {
   forgetTool: (sessionId: string, tool: string) => void
   // Undoes the one observation a prior `check` recorded, identified by its
   // receipt. Pops that signature from the windowed history and, when the
-  // current consecutive streak is the call this receipt named (it is the most
-  // recent `check` on the session, since tool execution within a turn is
-  // sequential), rewinds the streak by one. Used post-execution for a
+  // current consecutive streak is the call this receipt named, rewinds the
+  // streak by one. Suppressed same-batch read receipts are explicit no-ops so
+  // parallel sibling completion cannot retract the recorded observation. Used
+  // post-execution for a
   // `subagent_output` poll that returned `status: 'running'` — a still-pending
   // wait, not a loop — so it never accumulates toward either detector.
   retract: (receipt: LoopGuardReceipt) => void
@@ -117,6 +129,7 @@ export type LoopGuard = {
   // mark for that signature (a task can only move running→terminal, but a
   // signature can be reused across episodes).
   noteResult: (receipt: LoopGuardReceipt, result: LoopObservedResult) => void
+  noteReadResult: (receipt: LoopGuardReceipt, result: ReadObservedResult) => void
 }
 
 type SessionState = {
@@ -134,7 +147,18 @@ type SessionState = {
   // A block on such a signature is enforced pre-execute (not deferred), so a
   // completed task is not re-polled forever just to re-learn it is done.
   termKnown: Set<string>
+  // A model turn may emit several tool calls in one assistant message. Those
+  // calls cannot react to one another's results, so same-path reads in that
+  // batch count as one loop observation rather than a reactive cycle.
+  readTurnId: number | undefined
+  readPathsThisTurn: Set<string>
+  // Observed contiguous line progress per recently-read canonical path.
+  // Suppressed siblings may wait here for earlier siblings to complete, but
+  // only exact adjacency advances the frontier.
+  readFrontiers: Map<string, ReadProgress>
 }
+
+type ReadProgress = { frontier?: number; pending: Map<number, number> }
 
 export type CreateLoopGuardOptions = {
   softWarn?: number
@@ -228,10 +252,8 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
   }
 
   return {
-    check(sessionId, tool, args) {
+    check(sessionId, tool, args, context) {
       const signature = makeCallSignature(tool, args)
-      const windowSig = makeWindowSignature(tool, args)
-      const receipt: LoopGuardReceipt = { sessionId, tool, signature, windowSignature: windowSig }
       const existing = sessions.get(sessionId)
 
       const state: SessionState = existing ?? {
@@ -241,6 +263,36 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
         window: [],
         windowWarned: new Set(),
         termKnown: new Set(),
+        readTurnId: undefined,
+        readPathsThisTurn: new Set(),
+        readFrontiers: new Map(),
+      }
+
+      const readTarget = parseReadTarget(tool, args, context?.cwd)
+      const readPage = parseReadPage(tool, args, context?.cwd)
+      if (readTarget !== undefined && context?.turnId !== undefined) {
+        if (readPathSeenThisTurn(state, readTarget.path, context.turnId, windowSize)) {
+          const receipt: LoopGuardReceipt = {
+            sessionId,
+            tool,
+            signature,
+            windowSignature: readPathSignature(readTarget.path),
+            recorded: false,
+            ...(readPage !== undefined ? { readPage } : {}),
+          }
+          touch(sessionId, state)
+          return { kind: 'ok', receipt }
+        }
+      }
+
+      const windowSig = makeWindowSignature(tool, args, state, context?.cwd)
+      const receipt: LoopGuardReceipt = {
+        sessionId,
+        tool,
+        signature,
+        windowSignature: windowSig,
+        recorded: true,
+        ...(readPage !== undefined ? { readPage } : {}),
       }
 
       if (state.signature !== signature) {
@@ -296,8 +348,14 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
       for (const sig of state.termKnown) {
         if (signatureBelongsToTool(sig, tool)) state.termKnown.delete(sig)
       }
+      if (tool === 'read') {
+        state.readTurnId = undefined
+        state.readPathsThisTurn.clear()
+        state.readFrontiers.clear()
+      }
     },
     retract(receipt) {
+      if (!receipt.recorded) return
       const state = sessions.get(receipt.sessionId)
       if (state === undefined) return
 
@@ -322,10 +380,20 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
       }
     },
     noteResult(receipt, result) {
+      if (!receipt.recorded) return
       const state = sessions.get(receipt.sessionId)
       if (state === undefined) return
       if (result === 'terminal') state.termKnown.add(receipt.signature)
       else state.termKnown.delete(receipt.signature)
+    },
+    noteReadResult(receipt, result) {
+      const page = receipt.readPage
+      if (page === undefined || !result.nonEmpty || result.textual === false) return
+      const state = sessions.get(receipt.sessionId)
+      if (state === undefined) return
+      const span = result.outputLines
+      if (span === undefined || !Number.isFinite(span) || span <= 0) return
+      updateReadFrontier(state, page.path, page.offset, page.offset + span, receipt.recorded, windowSize)
     },
   }
 }
@@ -385,7 +453,16 @@ function makeCallSignature(tool: string, args: unknown): string {
 // target path alone so re-reading one target with drifting non-path args
 // collapses to a single signature. All other tools fall back to the exact
 // signature.
-function makeWindowSignature(tool: string, args: unknown): string {
+function makeWindowSignature(tool: string, args: unknown, state: SessionState, cwd: string | undefined): string {
+  const readPage = parseReadPage(tool, args, cwd)
+  if (readPage !== undefined) {
+    const coarse = readPathSignature(readPage.path)
+    const previousFrontier = state.readFrontiers.get(readPage.path)?.frontier
+    return previousFrontier !== undefined && readPage.offset === previousFrontier
+      ? `${coarse}#frontier:${readPage.offset}`
+      : coarse
+  }
+
   const isRequiredPath = REQUIRED_PATH_TOOLS.has(tool)
   const isDefaultPath = DEFAULT_PATH_TOOLS.has(tool)
   if ((isRequiredPath || isDefaultPath) && args !== null && typeof args === 'object') {
@@ -399,6 +476,127 @@ function makeWindowSignature(tool: string, args: unknown): string {
     if (isDefaultPath) return `${tool}#path:${DEFAULT_PATH_TARGET}`
   }
   return makeCallSignature(tool, args)
+}
+
+type ReadTarget = { path: string }
+type ReadPage = ReadTarget & { offset: number; limit?: number }
+
+function parseReadTarget(tool: string, args: unknown, cwd?: string): ReadTarget | undefined {
+  if (tool !== 'read' || args === null || typeof args !== 'object') return undefined
+  const record = args as Record<string, unknown>
+  const path = PATH_ARG_KEYS.map((key) => record[key]).find(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  )
+  return path === undefined ? undefined : { path: canonicalizeReadPath(path, cwd) }
+}
+
+function parseReadPage(tool: string, args: unknown, cwd?: string): ReadPage | undefined {
+  const target = parseReadTarget(tool, args, cwd)
+  if (target === undefined || args === null || typeof args !== 'object') return undefined
+  const record = args as Record<string, unknown>
+  const { offset, limit } = record
+  if (
+    (offset !== undefined && (typeof offset !== 'number' || !Number.isFinite(offset) || offset < 1)) ||
+    (limit !== undefined && (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0))
+  ) {
+    return undefined
+  }
+  return {
+    path: target.path,
+    offset: typeof offset === 'number' ? offset : 1,
+    ...(typeof limit === 'number' ? { limit } : {}),
+  }
+}
+
+function readPathSignature(path: string): string {
+  return `read#path:${path}`
+}
+
+function readPathSeenThisTurn(state: SessionState, path: string, turnId: number, maxReadPaths: number): boolean {
+  if (state.readTurnId !== turnId) {
+    state.readTurnId = turnId
+    state.readPathsThisTurn.clear()
+  }
+  const seen = state.readPathsThisTurn.has(path)
+  if (seen) state.readPathsThisTurn.delete(path)
+  state.readPathsThisTurn.add(path)
+  while (state.readPathsThisTurn.size > maxReadPaths) {
+    const oldest = state.readPathsThisTurn.values().next().value
+    if (oldest === undefined) break
+    state.readPathsThisTurn.delete(oldest)
+  }
+  return seen
+}
+
+function updateReadFrontier(
+  state: SessionState,
+  path: string,
+  observedStart: number,
+  observedEnd: number,
+  recorded: boolean,
+  maxReadFrontiers: number,
+): void {
+  let progress = state.readFrontiers.get(path)
+  if (progress === undefined) {
+    progress = { pending: new Map() }
+  }
+  state.readFrontiers.delete(path)
+  state.readFrontiers.set(path, progress)
+
+  if (progress.frontier === undefined) {
+    if (recorded) {
+      progress.frontier = observedEnd
+      drainContiguousReadIntervals(progress)
+    } else {
+      rememberReadInterval(progress, observedStart, observedEnd, maxReadFrontiers)
+    }
+  } else if (observedStart === progress.frontier) {
+    progress.frontier = observedEnd
+    drainContiguousReadIntervals(progress)
+  } else if (!recorded && observedStart > progress.frontier) {
+    rememberReadInterval(progress, observedStart, observedEnd, maxReadFrontiers)
+  }
+
+  while (state.readFrontiers.size > maxReadFrontiers) {
+    const oldest = state.readFrontiers.keys().next().value
+    if (oldest === undefined) break
+    state.readFrontiers.delete(oldest)
+  }
+}
+
+function rememberReadInterval(progress: ReadProgress, start: number, end: number, maxIntervals: number): void {
+  const previousEnd = progress.pending.get(start)
+  progress.pending.delete(start)
+  progress.pending.set(start, previousEnd === undefined ? end : Math.max(previousEnd, end))
+  while (progress.pending.size > maxIntervals) {
+    const oldest = progress.pending.keys().next().value
+    if (oldest === undefined) break
+    progress.pending.delete(oldest)
+  }
+}
+
+function drainContiguousReadIntervals(progress: ReadProgress): void {
+  let frontier = progress.frontier
+  if (frontier === undefined) return
+  for (const start of progress.pending.keys()) {
+    if (start < frontier) progress.pending.delete(start)
+  }
+  let nextEnd = progress.pending.get(frontier)
+  while (nextEnd !== undefined) {
+    progress.pending.delete(frontier)
+    frontier = nextEnd
+    progress.frontier = frontier
+    nextEnd = progress.pending.get(frontier)
+  }
+}
+
+function canonicalizeReadPath(path: string, cwd?: string): string {
+  const normalizedPath = path.replaceAll('\\', '/')
+  if (normalizedPath.startsWith('/') || /^[A-Za-z]:\//.test(normalizedPath)) {
+    return posix.normalize(normalizedPath)
+  }
+  if (cwd === undefined) return posix.normalize(normalizedPath)
+  return posix.normalize(`${cwd.replaceAll('\\', '/')}/${normalizedPath}`)
 }
 
 // Order-independent JSON serialization so semantically-identical objects

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1735,6 +1735,264 @@ describe('loop guard integration', () => {
     expect(aborts).toBe(0)
   })
 
+  test('does not abort a same-turn fan-out of paged reads against one file', async () => {
+    let calls = 0
+    let aborts = 0
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({
+        path: Type.String(),
+        offset: Type.Optional(Type.Number()),
+        limit: Type.Optional(Type.Number()),
+      }),
+      async execute() {
+        calls += 1
+        return { content: [{ type: 'text' as const, text: 'ok' }], details: undefined }
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir: '/agent',
+      sessionId: 'read-fan-out',
+      hooks: createHookBus(),
+      getLoopGuardTurn: () => 1,
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    await Promise.all(
+      [1, 2, 3, 4, 5, 6].map((offset, index) =>
+        wrapped.execute(
+          `c${index}`,
+          { path: '/agent/router.ts', offset, limit: 100 },
+          undefined,
+          undefined,
+          {} as never,
+        ),
+      ),
+    )
+
+    expect(calls).toBe(6)
+    expect(aborts).toBe(0)
+  })
+
+  test('advances offset-only reads from observed truncation output', async () => {
+    let turnId = 0
+    let aborts = 0
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), offset: Type.Optional(Type.Number()) }),
+      async execute() {
+        return {
+          content: [{ type: 'text' as const, text: 'page' }],
+          details: { truncation: { outputLines: 100 } },
+        }
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir: '/agent',
+      sessionId: 'read-offset-only',
+      hooks: createHookBus(),
+      getLoopGuardTurn: () => turnId,
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    for (let offset = 1; offset <= 701; offset += 100) {
+      turnId += 1
+      await wrapped.execute(`c${turnId}`, { path: '/agent/router.ts', offset }, undefined, undefined, {} as never)
+    }
+    expect(aborts).toBe(0)
+  })
+
+  test('advances a short final read page only by the lines actually returned', async () => {
+    let turnId = 0
+    let aborts = 0
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), offset: Type.Number(), limit: Type.Number() }),
+      async execute(_callId, params) {
+        const lineCount = params.offset === 101 ? 50 : params.limit
+        const lines = Array.from({ length: lineCount }, (_, i) => `line ${i}`).join('\n')
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: params.offset === 1 ? `${lines}\n\n[50 more lines in file. Use offset=101 to continue.]` : lines,
+            },
+          ],
+          details: undefined,
+        }
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir: '/agent',
+      sessionId: 'read-short-page',
+      hooks: createHookBus(),
+      getLoopGuardTurn: () => turnId,
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+    const read = async (offset: number) => {
+      turnId += 1
+      return wrapped.execute(
+        `c${turnId}`,
+        { path: '/agent/router.ts', offset, limit: 100 },
+        undefined,
+        undefined,
+        {} as never,
+      )
+    }
+
+    await read(1)
+    await read(101)
+    for (const offset of [201, 202, 203, 204]) await read(offset)
+    await expect(read(205)).rejects.toThrow(/loop-guard/)
+    expect(aborts).toBe(1)
+  })
+
+  test('does not advance reads whose truncation observed zero file lines', async () => {
+    let turnId = 0
+    let aborts = 0
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), offset: Type.Number(), limit: Type.Number() }),
+      async execute() {
+        return {
+          content: [{ type: 'text' as const, text: 'line exceeds byte limit; use bash' }],
+          details: { truncation: { outputLines: 0 } },
+        }
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir: '/agent',
+      sessionId: 'read-zero-lines',
+      hooks: createHookBus(),
+      getLoopGuardTurn: () => turnId,
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    for (let offset = 1; offset <= 5; offset++) {
+      turnId += 1
+      await wrapped.execute(
+        `c${turnId}`,
+        { path: '/agent/router.ts', offset, limit: 1 },
+        undefined,
+        undefined,
+        {} as never,
+      )
+    }
+    turnId += 1
+    await expect(
+      wrapped.execute('c6', { path: '/agent/router.ts', offset: 6, limit: 1 }, undefined, undefined, {} as never),
+    ).rejects.toThrow(/loop-guard/)
+    expect(aborts).toBe(1)
+  })
+
+  test('does not infer paginated progress from image read results', async () => {
+    let turnId = 0
+    let aborts = 0
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), offset: Type.Number(), limit: Type.Number() }),
+      async execute() {
+        return {
+          content: [
+            { type: 'text' as const, text: 'Read image file [image/png]' },
+            { type: 'image' as const, data: 'AA==', mimeType: 'image/png' },
+          ],
+          details: undefined,
+        }
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir: '/agent',
+      sessionId: 'read-image',
+      hooks: createHookBus(),
+      getLoopGuardTurn: () => turnId,
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    for (let offset = 1; offset <= 5; offset++) {
+      turnId += 1
+      await wrapped.execute(
+        `c${turnId}`,
+        { path: '/agent/blob.dat', offset, limit: 1 },
+        undefined,
+        undefined,
+        {} as never,
+      )
+    }
+    turnId += 1
+    await expect(
+      wrapped.execute('c6', { path: '/agent/blob.dat', offset: 6, limit: 1 }, undefined, undefined, {} as never),
+    ).rejects.toThrow(/loop-guard/)
+    expect(aborts).toBe(1)
+  })
+
+  test('does not infer textual progress from an omitted image fallback', async () => {
+    let turnId = 0
+    let aborts = 0
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({ path: Type.String(), offset: Type.Number(), limit: Type.Number() }),
+      async execute() {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Read image file [image/png]\n[Image omitted: could not be resized below the inline image size limit.]',
+            },
+          ],
+          details: undefined,
+        }
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir: '/agent',
+      sessionId: 'read-image-fallback',
+      hooks: createHookBus(),
+      getLoopGuardTurn: () => turnId,
+      getAbort: () => () => {
+        aborts += 1
+      },
+    })
+
+    for (let offset = 1; offset <= 5; offset++) {
+      turnId += 1
+      await wrapped.execute(
+        `c${turnId}`,
+        { path: '/agent/blob.dat', offset, limit: 1 },
+        undefined,
+        undefined,
+        {} as never,
+      )
+    }
+    turnId += 1
+    await expect(
+      wrapped.execute('c6', { path: '/agent/blob.dat', offset: 6, limit: 1 }, undefined, undefined, {} as never),
+    ).rejects.toThrow(/loop-guard/)
+    expect(aborts).toBe(1)
+  })
+
   // A subagent_output poll that returns status:'running' is a still-pending
   // wait, not a loop. The wrapper retracts it from the guard so round-robin
   // fan-out polling never false-blocks (the production incident).

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -200,6 +200,7 @@ export type WrapToolOptions = {
   // time) because tools are wrapped BEFORE `createAgentSession` returns the
   // session whose `agent.abort` this points at. See `fireLoopAbort`.
   getAbort?: () => ((reason?: string) => void) | undefined
+  getLoopGuardTurn?: () => number | undefined
 }
 
 export type WrapSystemToolOptions = {
@@ -208,6 +209,7 @@ export type WrapSystemToolOptions = {
   hooks: HookBus
   getOrigin?: () => SessionOrigin | undefined
   getAbort?: () => ((reason?: string) => void) | undefined
+  getLoopGuardTurn?: () => number | undefined
   // When present, the bash builtin is rewritten through the per-tool bwrap
   // sandbox with role-derived path masks. Absent (or no masks for the role)
   // runs bash unchanged — preserving today's behavior for trusted+ and for
@@ -269,7 +271,13 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         return errorResult(`blocked: ${blockResult.reason}`)
       }
 
-      const loopGate = gateLoopGuard(opts.sessionId, opts.toolName, before.args)
+      const loopGate = gateLoopGuard(
+        opts.sessionId,
+        opts.toolName,
+        before.args,
+        opts.getLoopGuardTurn?.(),
+        opts.agentDir,
+      )
       if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort, 'loop_guard:block')
         return errorResult(loopGate.message)
@@ -332,7 +340,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       if (blockResult !== undefined) {
         throw new Error(`blocked: ${blockResult.reason}`)
       }
-      const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
+      const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs, opts.getLoopGuardTurn?.(), opts.agentDir)
       if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort, 'loop_guard:block')
         throw new Error(loopGate.message)
@@ -406,7 +414,7 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
       // loop-detection state, or pi's execute.
       const bashEnvOverlay = readBashEnvOverlay(mutableArgs)
       delete mutableArgs[TYPECLAW_INTERNAL_BASH_ENV]
-      const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs)
+      const loopGate = gateLoopGuard(opts.sessionId, tool.name, mutableArgs, opts.getLoopGuardTurn?.(), opts.agentDir)
       if (loopGate.blockNow) {
         fireLoopAbort(opts.getAbort, 'loop_guard:block')
         throw new Error(loopGate.message)
@@ -818,6 +826,44 @@ function subagentPollStatus(toolName: string, result: ToolResult): 'running' | '
   return details.status === 'running' ? 'running' : 'terminal'
 }
 
+function observedReadResult(
+  toolName: string,
+  result: ToolResult,
+): { nonEmpty: boolean; outputLines?: number; textual: boolean } | undefined {
+  if (toolName !== 'read') return undefined
+  const details = result.details as { truncation?: { outputLines?: unknown } } | undefined
+  const outputLines = details?.truncation?.outputLines
+  const hasImage = result.content.some((part) => part.type === 'image')
+  const hasText = result.content.some(
+    (part) => part.type === 'text' && typeof part.text === 'string' && part.text.trim().length > 0,
+  )
+  const imageFallback =
+    !hasImage &&
+    result.content.some(
+      (part) => part.type === 'text' && typeof part.text === 'string' && /^Read image file \[[^\]]+\]/.test(part.text),
+    )
+  const observedOutputLines =
+    typeof outputLines === 'number' && Number.isFinite(outputLines)
+      ? outputLines
+      : !hasImage && !imageFallback
+        ? countReadOutputLines(result.content)
+        : undefined
+  return {
+    nonEmpty: hasImage || hasText,
+    textual: !hasImage && !imageFallback,
+    ...(observedOutputLines !== undefined ? { outputLines: observedOutputLines } : {}),
+  }
+}
+
+function countReadOutputLines(content: ContentPart[]): number | undefined {
+  const textParts = content.filter(
+    (part): part is Extract<ContentPart, { type: 'text' }> => part.type === 'text' && typeof part.text === 'string',
+  )
+  if (textParts.length !== 1) return undefined
+  const fileText = textParts[0]!.text.replace(/\n\n\[\d+ more lines in file\. Use offset=\d+ to continue\.\]$/, '')
+  return fileText.length === 0 ? 0 : fileText.split('\n').length
+}
+
 type LoopGuardGate = {
   // True when the guard wants to block AND the block is enforced now (every tool
   // except a deferable `subagent_output` poll). The caller aborts + errors.
@@ -835,13 +881,21 @@ type LoopGuardGate = {
 // semantics. `check` runs here (recording the observation); the returned
 // `resolve` is called after execute with the tool's result, feeding the poll's
 // running/terminal status back to the guard so future blocks stop deferring.
-function gateLoopGuard(sessionId: string, toolName: string, args: unknown): LoopGuardGate {
-  const decision = sharedLoopGuard.check(sessionId, toolName, args)
+function gateLoopGuard(
+  sessionId: string,
+  toolName: string,
+  args: unknown,
+  turnId?: number,
+  cwd?: string,
+): LoopGuardGate {
+  const decision = sharedLoopGuard.check(sessionId, toolName, args, { turnId, cwd })
   const defer = shouldDeferLoopBlock(toolName, decision)
   return {
     blockNow: decision.kind === 'block' && !defer,
     message: decision.kind === 'ok' ? '' : decision.message,
     resolve(result) {
+      const readResult = observedReadResult(toolName, result)
+      if (readResult !== undefined) sharedLoopGuard.noteReadResult(decision.receipt, readResult)
       const pollStatus = subagentPollStatus(toolName, result)
       if (pollStatus !== undefined) {
         sharedLoopGuard.noteResult(decision.receipt, pollStatus)

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -1026,6 +1026,115 @@ describe('startSubagent', () => {
     }
   })
 
+  test('completion resolves ok=false when the session was aborted by the loop guard', async () => {
+    const session = {
+      prompt: async () => {},
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+      getAbortReason: () => 'loop_guard:block',
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_loop_abort',
+    })
+    const result = await completion
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('loop_guard:block')
+  })
+
+  test('loop-guard failure preserves an already-captured assistant message', async () => {
+    const listeners = new Set<(event: unknown) => void>()
+    const session = {
+      prompt: async () => {
+        for (const listener of listeners) {
+          listener({ type: 'message_end', message: { role: 'assistant', content: 'Partial but useful analysis.' } })
+        }
+      },
+      dispose: () => {},
+      subscribe: (listener: (event: unknown) => void) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+      abort: async () => {},
+      getAbortReason: () => 'loop_guard:deferred_block',
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_loop_recover',
+    })
+    const result = await completion
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.finalMessage).toBe('Partial but useful analysis.')
+  })
+
+  test('loop-guard failure captures output through the awaited agent event stream', async () => {
+    const agentListeners = new Set<(event: unknown) => void>()
+    const session = {
+      agent: {
+        subscribe: (listener: (event: unknown) => void) => {
+          agentListeners.add(listener)
+          return () => agentListeners.delete(listener)
+        },
+      },
+      prompt: async () => {
+        for (const listener of agentListeners) {
+          listener({ type: 'message_end', message: { role: 'assistant', content: 'Captured before settlement.' } })
+        }
+      },
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+      getAbortReason: () => 'loop_guard:block',
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_loop_awaited_capture',
+    })
+    const result = await completion
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.finalMessage).toBe('Captured before settlement.')
+  })
+
+  test('a non-loop abort reason keeps the existing successful completion semantics', async () => {
+    const session = {
+      prompt: async () => {},
+      dispose: () => {},
+      subscribe: () => () => {},
+      abort: async () => {},
+      getAbortReason: () => 'user_cancelled',
+    } as unknown as AgentSession
+    const registry = { greeter: { systemPrompt: 'X' } satisfies Subagent }
+
+    const { completion } = startSubagent('greeter', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_other_abort',
+    })
+
+    expect((await completion).ok).toBe(true)
+  })
+
   test('timeoutMs settles completion with ok=false when prompt wedges (parent gets woken, not stranded)', async () => {
     // given: a session whose prompt never resolves, and a subagent with a tiny timeout
     let abortCount = 0
@@ -1148,6 +1257,26 @@ describe('startSubagent', () => {
     } as unknown as AgentSession
     return { session, prompts }
   }
+
+  test('a loop-aborted researcher fails before required-block retries can mask the lifecycle error', async () => {
+    const { session, prompts } = scriptedResearcherSession([
+      [{ role: 'assistant', content: '<analysis>unfinished</analysis>' }],
+    ])
+    Object.assign(session, { getAbortReason: () => 'loop_guard:block' })
+    const registry = { researcher: { systemPrompt: 'X' } satisfies Subagent }
+
+    const { completion } = startSubagent('researcher', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'research',
+      taskId: 'bg_research_loop_abort',
+    })
+    const result = await completion
+
+    expect(result.ok).toBe(false)
+    expect(prompts).toHaveLength(1)
+  })
 
   async function runResearcher(turns: { role?: string; content: unknown }[][]) {
     const { session, prompts } = scriptedResearcherSession(turns)

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -367,6 +367,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           },
         })
         if (result.success) activeModelRef = result.refUsed
+        throwIfLoopGuardAborted(session)
       } finally {
         if (hooks && turnEvent !== undefined) {
           await hooks.runSessionTurnEnd(turnEvent)
@@ -377,10 +378,12 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           drain: backgroundDrain,
           prompt: async (text) => {
             await promptWithSameRefRetryOnly(session, `${renderTurnTimeAnchor()}\n\n${text}`)
+            throwIfLoopGuardAborted(session)
           },
           cancelled: () => aborted,
         })
       }
+      throwIfLoopGuardAborted(session)
       // Required-block guard (mirrors the channel empty-response guard): a subagent
       // that owes a result block but ended without one gets a bounded re-prompt to
       // emit it as text, then an honest fallback — never a silent stale-preamble
@@ -400,6 +403,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
             session,
             `${renderTurnTimeAnchor()}\n\n${renderRequiredBlockRetryNudge(requiredBlockTag)}`,
           )
+          throwIfLoopGuardAborted(session)
         }
         if (!aborted && !capture.hasRequiredBlock()) {
           console.warn(`[subagent] ${name} required_block_fallback tag=${requiredBlockTag}`)
@@ -446,6 +450,19 @@ export class SubagentTimeoutError extends Error {
   ) {
     super(`subagent ${subagentName} (key=${coalesceKey}) spawn timed out after ${timeoutMs}ms`)
   }
+}
+
+class SubagentLoopGuardAbortError extends Error {
+  override readonly name = 'SubagentLoopGuardAbortError'
+
+  constructor(readonly reason: string) {
+    super(`subagent aborted by loop guard (${reason})`)
+  }
+}
+
+function throwIfLoopGuardAborted(session: AgentSession): void {
+  const reason = (session as AgentSession & { getAbortReason?: () => string | undefined }).getAbortReason?.()
+  if (reason?.startsWith('loop_guard:') === true) throw new SubagentLoopGuardAbortError(reason)
 }
 
 export function isSubagentTimeoutError(err: unknown): err is SubagentTimeoutError {
@@ -544,7 +561,7 @@ export function startSubagent(name: string, options: StartSubagentOptions): Star
       if (!handleSettled) {
         rejectHandle(err instanceof Error ? err : new Error(error))
       }
-      return { ok: false as const, error }
+      return { ok: false as const, error, ...(finalMessage !== undefined ? { finalMessage } : {}) }
     })
 
   const timeoutMs = options.registry[name]?.timeoutMs
@@ -688,7 +705,7 @@ function attachFinalMessageCapture(
   let lastReview: string | null = null
   let lastRequired: string | null = null
   try {
-    session.subscribe((event: unknown) => {
+    subscribeToAwaitedAgentEvents(session, (event: unknown) => {
       const ev = event as { type?: string; message?: { role?: string; content?: unknown } }
       if (ev?.type !== 'message_end') return
       // Real assistant messages carry role 'assistant'; older test doubles omit
@@ -729,6 +746,15 @@ function attachFinalMessageCapture(
       onFinalMessage(msg)
     },
   }
+}
+
+function subscribeToAwaitedAgentEvents(session: AgentSession, listener: (event: unknown) => void): () => void {
+  const agent = (
+    session as AgentSession & {
+      agent?: { subscribe?: (listener: (event: unknown) => void) => () => void }
+    }
+  ).agent
+  return agent?.subscribe?.(listener) ?? session.subscribe(listener)
 }
 
 function extractFinalMessageText(content: unknown): string | null {

--- a/src/agent/tools/spawn-subagent.test.ts
+++ b/src/agent/tools/spawn-subagent.test.ts
@@ -313,6 +313,44 @@ describe('createSpawnSubagentTool — background mode', () => {
     expect(completion?.ok).toBe(true)
   })
 
+  test('loop-aborted background completion publishes failure with recoverable output', async () => {
+    const stream = createStream()
+    const events: unknown[] = []
+    stream.subscribe({ target: { kind: 'broadcast' } }, (msg) => {
+      events.push(msg.payload)
+    })
+    const liveRegistry = new LiveSubagentRegistry()
+    const session = emittingSession(() => ({
+      type: 'message_end',
+      message: { role: 'assistant', content: 'Partial review evidence.' },
+    }))
+    Object.assign(session, { getAbortReason: () => 'loop_guard:block' })
+    const tool = createSpawnSubagentTool({
+      registry: makeRegistry(),
+      liveRegistry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      parentSessionId: 'ses_parent',
+      getOrigin: () => ({ kind: 'tui', sessionId: 'ses_parent' }),
+      stream,
+      generateTaskId: () => 'bg_loop',
+      now: () => 1_000,
+    })
+
+    await tool.execute('call_1', { subagent_type: 'explorer', prompt: 'q' }, undefined, undefined, ctx)
+    await new Promise((resolve) => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(liveRegistry.get('bg_loop')?.status).toBe('failed')
+    const completion = events.find((event) => (event as { kind?: string }).kind === 'subagent.completed') as
+      | Record<string, unknown>
+      | undefined
+    expect(completion?.ok).toBe(false)
+    expect(completion?.error).toContain('loop_guard:block')
+    expect(completion?.hasRecoverableOutput).toBe(true)
+  })
+
   test('channel-origin background completion carries the channel key for rollover-safe routing', async () => {
     const stream = createStream()
     const events: unknown[] = []


### PR DESCRIPTION
## Background

`typeey`, TypeClaw's own PR-review subagent, twice exited a review of #1194 without returning an assessment ("the required review worker exited... without returning an assessment"). The root cause was systemic, not a one-off flake, and had two parts.

**Part 1 — false-positive block.** The tool loop guard's windowed cycle detector coarsens path-bearing tool calls to `path` alone (offsets/limits dropped) so that a model paging through one file in a reactive retry loop collapses to a single repeated signature. That coarsening is correct for a stuck model re-reading the same range, but it also collapsed a **legitimate** paginated read — the reviewer working forward through one large file across several `offset`s — into the exact same signature, several times over, and the guard blocked it as a false-positive cycle.

**Part 2 — the abort was swallowed.** When the loop guard aborts a subagent's active turn, `invokeSubagent`/`startSubagent` did not check the abort reason afterward. A background `spawn-subagent` completion for an aborted-but-otherwise-quiet run was therefore published with `ok: true` and no assessment, rather than as a failure — so the false block above became a silent, unexplained non-review instead of a visible error.

Both parts have to be fixed together: narrowing the false positive reduces how often this fires, but does not make the failure mode honest when it does.

## Summary

- **Turn-aware exact observed frontier** (`src/agent/loop-guard.ts`): `read` calls are now classified against the awaited SDK `turn_start` boundary via a new `LoopGuardCheckContext`. Calls for one canonical path emitted within the same assistant tool batch (`turnId`) count as a single observation — the calls can't react to each other's results, so they were never a reactive cycle to begin with. Separately, each path tracks a bounded, per-session **observed frontier**: a recorded read result that starts exactly at the current frontier establishes or advances it directly, and a successful, non-empty, textual result from a *suppressed* same-turn sibling is remembered as a pending interval that drains the frontier forward once it becomes exact-adjacent — including when siblings complete out of order — via the new `noteReadResult`. This collapses genuine forward pagination, including multi-page fan-out across several same-turn siblings, to one coarse signature across turns too. Suppressed same-turn siblings never count as an independent loop observation on their own; recorded images, overlap, backtracking, gaps, empty results, and malformed ranges all retain the coarse path signature and still accumulate toward a block, so a real cycle is still caught.
- **Failed subagent completion propagation** (`src/agent/subagents.ts`): `invokeSubagent` now checks `session.getAbortReason()` after every `continue()`/prompt call and throws a `SubagentLoopGuardAbortError` when the session was aborted by the loop guard, instead of silently returning success. `startSubagent`'s failure path now also carries any `finalMessage` captured before the abort as recoverable output, so a caller sees both the failure and whatever partial assessment the subagent managed to produce. `attachFinalMessageCapture` subscribes to the underlying `agent` event stream (falling back to the session) so this capture isn't dropped by the same subscription gap.
- **Short-final-page edge case**: a read that lands exactly on the tail of a file (fewer output lines than requested) still advances the frontier correctly — the frontier update uses the *observed* output-line count from the tool result (`observedReadResult`/`countReadOutputLines` in `plugin-tools.ts`), not the requested `limit`, so a short final page doesn't get miscounted as a gap and re-trigger the coarse path signature.
- **Docs** (`docs/content/docs/internals/message-stream.mdx`, `docs/content/docs/internals/engagement.mdx`): document the turn-batch + frontier read classification and the subagent-abort propagation under a new "Tool-loop termination" section, and correct a stale "byte-identical tool calls" description of the guard.

## What this does NOT do

- Does not relax the guard for a genuinely stuck read loop — backtracking, overlapping ranges, skipped offsets, and non-textual/empty results all still fall back to the coarse path signature and accumulate toward a block exactly as before.
- Does not change loop-guard behavior for any non-`read` tool, or touch the peer-bot channel-level loop guard (`router.ts`), which is a separate detector.
- Does not add retry logic for an aborted subagent — the abort is now surfaced honestly as a failure with recoverable output, not auto-retried.

## Review notes

- Load-bearing invariant: `readPathSeenThisTurn` suppresses only sibling calls within the same `turnId` for the same path, and a suppressed receipt (`recorded: false`) is an explicit no-op for `retract` and `noteResult` — a parallel sibling completing (or a poll returning `running`) can never retract the one recorded observation for that turn, or flip a signature's terminal-known state. `noteReadResult` is intentionally the exception: it still processes suppressed receipts, so a successful, non-empty, textual read from a suppressed sibling can extend the bounded per-path frontier once its start is exact-adjacent to the existing frontier, including when siblings complete out of order (held as a pending interval and drained once contiguous). Suppressed same-turn siblings therefore never add an independent loop observation — they never touch the window or consecutive counters — but their successful exact-adjacent progress is not discarded.
- Load-bearing invariant: `updateReadFrontier` only advances when `observedStart` exactly matches the existing frontier; any gap, overlap, or backtrack leaves the frontier untouched and the next check for that path falls back to the coarse path-only signature.
- Load-bearing invariant: the frontier advance amount comes from the tool result's observed line count, not the requested `limit` — verify the short-final-page test (`treats an observed zero-line read result as no progress`, plus the pagination tests in `loop-guard.test.ts`) still forces a coarse signature when a page returns less than requested.
- `SubagentLoopGuardAbortError` is checked via `reason?.startsWith('loop_guard:')`, matching both `loop_guard:block` and `loop_guard:deferred_block` — verify no other abort reason prefix collides with this.
- Root-incident writeup: https://github.com/typeclaw/typeclaw/pull/1194#issuecomment-4959648872
- Verification: `bun run typecheck`, `bun run lint` (67 pre-existing warnings, 0 errors), `bun run format:check` all clean; full suite `bun run test` — 10,977 pass, 1 skip, 0 fail; also passed the Oracle review gate.
