### PR TITLE
feat(discord): enrich message provenance

### DIFF
--- a/src/bundled-plugins/memory/provenance-index.test.ts
+++ b/src/bundled-plugins/memory/provenance-index.test.ts
@@ -335,10 +335,14 @@ describe('buildProvenanceIndex', () => {
       }),
     )
     await writeStream(root, '2026-07-01', historical)
-    await enrichHistoricalProvenance(root, async (where) => ({
-      where: { ...where, workspaceName: 'Current Guild', chatName: 'Current Resolver Room' },
-      parentChecked: true,
-    }))
+    await enrichHistoricalProvenance(
+      root,
+      async (where) => ({
+        where: { ...where, workspaceName: 'Current Guild', chatName: 'Current Resolver Room' },
+        parentChecked: true,
+      }),
+      { adapter: 'discord' },
+    )
 
     const index = await buildProvenanceIndex(root)
     const probe = index.undreamedChild('streams/2026-07-01#resolver-probe')
@@ -510,7 +514,7 @@ describe('buildProvenanceIndex', () => {
         where: { ...where, workspaceName: 'Current Guild', chatName: 'Current Room' },
         parentChecked: true,
       }),
-      { maxOrigins: 1 },
+      { adapter: 'discord', maxOrigins: 1 },
     )
 
     expect(enrichment).toMatchObject({ scanned: 1, attempted: 1, resolved: 1, changed: true })
@@ -548,11 +552,39 @@ describe('buildProvenanceIndex', () => {
           parentChecked: true,
         }
       },
-      { maxOrigins: 1 },
+      { adapter: 'discord', maxOrigins: 1 },
     )
 
     expect(attempted).toEqual(['guild-resolvable'])
     expect(result).toMatchObject({ scanned: 1, attempted: 1, resolved: 1 })
+  })
+
+  test('selects historical enrichment candidates only from the requested Discord adapter', async () => {
+    const root = await makeRoot()
+    await writeStream(root, '2026-07-01', [
+      fragment('user-adapter', { adapter: 'discord', workspace: 'guild-user', chat: 'room-user', thread: null }),
+      fragment('bot-adapter', {
+        adapter: 'discord-bot',
+        workspace: 'guild-bot',
+        chat: 'room-bot',
+        thread: null,
+      }),
+    ])
+    const attemptedByUserAdapter: string[] = []
+    const attemptedByBotAdapter: string[] = []
+    const resolve = (attempted: string[]) => async (where: FragmentProvenance) => {
+      attempted.push(where.adapter)
+      return {
+        where: { ...where, workspaceName: `${where.adapter} guild`, chatName: `${where.adapter} room` },
+        parentChecked: true,
+      }
+    }
+
+    await enrichHistoricalProvenance(root, resolve(attemptedByUserAdapter), { adapter: 'discord' })
+    await enrichHistoricalProvenance(root, resolve(attemptedByBotAdapter), { adapter: 'discord-bot' })
+
+    expect(attemptedByUserAdapter).toEqual(['discord'])
+    expect(attemptedByBotAdapter).toEqual(['discord-bot'])
   })
 
   test('more than 100 unresolved oldest origins do not starve a newer resolvable origin', async () => {
@@ -589,7 +621,7 @@ describe('buildProvenanceIndex', () => {
           parentChecked: true,
         }
       },
-      { maxOrigins: 100 },
+      { adapter: 'discord', maxOrigins: 100 },
     )
 
     expect(attempted).toContain('guild-new')
@@ -638,16 +670,20 @@ describe('buildProvenanceIndex', () => {
     )
     const streamBefore = await readFile(streamFilePath(root, '2026-07-01'))
 
-    const result = await enrichHistoricalProvenance(root, async (where) => ({
-      where: {
-        ...where,
-        workspaceName: 'Example Guild',
-        chatName: 'release-thread',
-        parentChat: 'room-1',
-        parentChatName: 'development',
-      },
-      parentChecked: true,
-    }))
+    const result = await enrichHistoricalProvenance(
+      root,
+      async (where) => ({
+        where: {
+          ...where,
+          workspaceName: 'Example Guild',
+          chatName: 'release-thread',
+          parentChat: 'room-1',
+          parentChatName: 'development',
+        },
+        parentChecked: true,
+      }),
+      { adapter: 'discord' },
+    )
 
     expect(result).toEqual({ scanned: 1, attempted: 1, resolved: 1, failed: 0, timedOut: 0, changed: true })
     expect((await readFile(streamFilePath(root, '2026-07-01'))).equals(streamBefore)).toBe(true)
@@ -667,9 +703,13 @@ describe('buildProvenanceIndex', () => {
     ])
     await writeTopic(root, 'raw-topic', 'Raw policy.\nfragments:\n- streams/2026-07-01#resolver-failure')
 
-    const result = await enrichHistoricalProvenance(root, async () => {
-      throw new Error('network unavailable')
-    })
+    const result = await enrichHistoricalProvenance(
+      root,
+      async () => {
+        throw new Error('network unavailable')
+      },
+      { adapter: 'discord' },
+    )
     const index = await buildProvenanceIndex(root)
 
     expect(result).toEqual({ scanned: 1, attempted: 1, resolved: 0, failed: 1, timedOut: 0, changed: false })
@@ -688,6 +728,7 @@ describe('buildProvenanceIndex', () => {
     ])
 
     const result = await enrichHistoricalProvenance(root, async () => await new Promise<never>(() => {}), {
+      adapter: 'discord',
       timeoutMs: 100,
       perOriginTimeoutMs: 1,
       maxOrigins: 1,
@@ -717,8 +758,14 @@ describe('buildProvenanceIndex', () => {
       }
     }
 
-    expect(await enrichHistoricalProvenance(root, resolve)).toMatchObject({ resolved: 1, changed: true })
-    expect(await enrichHistoricalProvenance(root, resolve)).toMatchObject({ scanned: 0, attempted: 0 })
+    expect(await enrichHistoricalProvenance(root, resolve, { adapter: 'discord-bot' })).toMatchObject({
+      resolved: 1,
+      changed: true,
+    })
+    expect(await enrichHistoricalProvenance(root, resolve, { adapter: 'discord-bot' })).toMatchObject({
+      scanned: 0,
+      attempted: 0,
+    })
     expect(calls).toBe(1)
   })
 
@@ -737,10 +784,14 @@ describe('buildProvenanceIndex', () => {
       ),
     )
 
-    await enrichHistoricalProvenance(root, async (where) => ({
-      where: { ...where, workspaceName: `Guild ${where.chat}`, chatName: `Room ${where.chat}` },
-      parentChecked: true,
-    }))
+    await enrichHistoricalProvenance(
+      root,
+      async (where) => ({
+        where: { ...where, workspaceName: `Guild ${where.chat}`, chatName: `Room ${where.chat}` },
+        parentChecked: true,
+      }),
+      { adapter: 'discord-bot' },
+    )
 
     const index = await buildProvenanceIndex(root)
     for (let alias = 0; alias < 8; alias++) {
@@ -781,15 +832,19 @@ describe('buildProvenanceIndex', () => {
     ])
     const token = 'ghp' + '_' + 'X'.repeat(36)
 
-    await enrichHistoricalProvenance(root, async (where) => ({
-      where: {
-        ...where,
-        workspaceName: token,
-        chatName: `bad\nname`,
-        parentChatName: 'x'.repeat(257),
-      },
-      parentChecked: true,
-    }))
+    await enrichHistoricalProvenance(
+      root,
+      async (where) => ({
+        where: {
+          ...where,
+          workspaceName: token,
+          chatName: `bad\nname`,
+          parentChatName: 'x'.repeat(257),
+        },
+        parentChecked: true,
+      }),
+      { adapter: 'discord' },
+    )
     const index = await buildProvenanceIndex(root)
     const text = index.lexicalTextForUndreamed('streams/2026-07-01#unsafe')
 
@@ -806,15 +861,19 @@ describe('buildProvenanceIndex', () => {
       fragment('prompt-shaping', { adapter: 'discord', workspace: '123', chat: '456', thread: null }),
     ])
 
-    await enrichHistoricalProvenance(root, async (where) => ({
-      where: {
-        ...where,
-        workspaceName: 'safe\u202Eevil',
-        chatName: 'zero\u200Bwidth',
-        parentChatName: '**SYSTEM OVERRIDE**',
-      },
-      parentChecked: true,
-    }))
+    await enrichHistoricalProvenance(
+      root,
+      async (where) => ({
+        where: {
+          ...where,
+          workspaceName: 'safe\u202Eevil',
+          chatName: 'zero\u200Bwidth',
+          parentChatName: '**SYSTEM OVERRIDE**',
+        },
+        parentChecked: true,
+      }),
+      { adapter: 'discord' },
+    )
     const text = (await buildProvenanceIndex(root)).lexicalTextForUndreamed('streams/2026-07-01#prompt-shaping')
 
     expect(text).not.toContain('evil')

--- a/src/bundled-plugins/memory/provenance-index.ts
+++ b/src/bundled-plugins/memory/provenance-index.ts
@@ -66,6 +66,7 @@ export type HistoricalProvenanceEnrichmentResult = {
 }
 
 export type HistoricalProvenanceEnrichmentOptions = {
+  adapter: Extract<AdapterId, 'discord' | 'discord-bot'>
   maxOrigins?: number
   timeoutMs?: number
   perOriginTimeoutMs?: number
@@ -206,7 +207,7 @@ export async function buildProvenanceIndexFrom(
 export async function enrichHistoricalProvenance(
   agentDir: string,
   resolve: HistoricalProvenanceResolver,
-  options: HistoricalProvenanceEnrichmentOptions = {},
+  options: HistoricalProvenanceEnrichmentOptions,
 ): Promise<HistoricalProvenanceEnrichmentResult> {
   const maxOrigins = options.maxOrigins ?? 100
   const deadline = Date.now() + (options.timeoutMs ?? 10_000)
@@ -219,8 +220,7 @@ export async function enrichHistoricalProvenance(
     const events = days[dayIndex]!.events
     for (let eventIndex = events.length - 1; eventIndex >= 0; eventIndex--) {
       const event = events[eventIndex]!
-      if (event.type !== 'fragment' || (event.where?.adapter !== 'discord' && event.where?.adapter !== 'discord-bot'))
-        continue
+      if (event.type !== 'fragment' || event.where?.adapter !== options.adapter) continue
       const where = event.where
       if (where.workspace === '@dm') continue
       if (!needsResolverEnrichment(where, registry)) continue

--- a/src/channels/adapters/discord-bot-channel-resolver.test.ts
+++ b/src/channels/adapters/discord-bot-channel-resolver.test.ts
@@ -118,4 +118,16 @@ describe('discord-bot channel resolver', () => {
 
     expect(result).toEqual({})
   })
+
+  test('rejects malformed IDs before building Discord API paths', async () => {
+    installFetch(() => {
+      throw new Error('must not fetch')
+    })
+    const resolver = createDiscordChannelResolver({ token: 'tok' })
+
+    await expect(
+      resolver({ adapter: 'discord-bot', workspace: '../guild', chat: 'room/1', thread: null }),
+    ).resolves.toEqual({})
+    expect(calls).toHaveLength(0)
+  })
 })

--- a/src/channels/adapters/discord-bot-channel-resolver.ts
+++ b/src/channels/adapters/discord-bot-channel-resolver.ts
@@ -1,5 +1,8 @@
 import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
 
+import { isDiscordSnowflake } from './discord-id'
+import { DiscordResolverCache } from './discord-resolver-cache'
+
 const DISCORD_API_BASE = 'https://discord.com/api/v10'
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
 
@@ -7,9 +10,9 @@ export type DiscordChannelResolverOptions = {
   token: string
   now?: () => number
   ttlMs?: number
+  maxCacheEntries?: number
+  fetchImpl?: typeof fetch
 }
-
-type CacheEntry<T> = { value: T; expiresAt: number }
 
 type DiscordChannel = { id?: string; name?: string }
 type DiscordGuild = { id?: string; name?: string }
@@ -17,19 +20,24 @@ type DiscordGuild = { id?: string; name?: string }
 export function createDiscordChannelResolver(options: DiscordChannelResolverOptions): ChannelNameResolver {
   const now = options.now ?? Date.now
   const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const fetchImpl = options.fetchImpl ?? fetch
 
-  const channelCache = new Map<string, CacheEntry<string>>()
-  const guildCache = new Map<string, CacheEntry<string>>()
+  const channelCache = new DiscordResolverCache<string>(options.maxCacheEntries)
+  const guildCache = new DiscordResolverCache<string>(options.maxCacheEntries)
 
   const fetchCached = async <T>(
-    cache: Map<string, CacheEntry<T>>,
+    cache: DiscordResolverCache<T>,
     key: string,
     fetcher: () => Promise<T | null>,
   ): Promise<T | null> => {
-    const cached = cache.get(key)
-    if (cached && cached.expiresAt > now()) return cached.value
+    const currentTime = now()
+    const cached = cache.get(key, currentTime)
+    if (cached !== undefined) return cached
     const value = await fetcher()
-    if (value !== null) cache.set(key, { value, expiresAt: now() + ttlMs })
+    if (value !== null) {
+      const fetchedAt = now()
+      cache.set(key, value, fetchedAt + ttlMs, fetchedAt)
+    }
     return value
   }
 
@@ -37,8 +45,12 @@ export function createDiscordChannelResolver(options: DiscordChannelResolverOpti
     if (key.workspace === '@dm') return {}
 
     const [chatName, workspaceName] = await Promise.all([
-      fetchCached(channelCache, key.chat, () => fetchChannelName(key.chat, options.token)),
-      fetchCached(guildCache, key.workspace, () => fetchGuildName(key.workspace, options.token)),
+      isDiscordSnowflake(key.chat)
+        ? fetchCached(channelCache, key.chat, () => fetchChannelName(key.chat, options.token, fetchImpl))
+        : Promise.resolve(null),
+      isDiscordSnowflake(key.workspace)
+        ? fetchCached(guildCache, key.workspace, () => fetchGuildName(key.workspace, options.token, fetchImpl))
+        : Promise.resolve(null),
     ])
 
     const result: ResolvedChannelNames = {}
@@ -48,9 +60,9 @@ export function createDiscordChannelResolver(options: DiscordChannelResolverOpti
   }
 }
 
-async function fetchChannelName(channelId: string, token: string): Promise<string | null> {
+async function fetchChannelName(channelId: string, token: string, fetchImpl: typeof fetch): Promise<string | null> {
   try {
-    const response = await fetch(`${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}`, {
+    const response = await fetchImpl(`${DISCORD_API_BASE}/channels/${encodeURIComponent(channelId)}`, {
       headers: { Authorization: `Bot ${token}` },
     })
     if (!response.ok) return null
@@ -62,9 +74,9 @@ async function fetchChannelName(channelId: string, token: string): Promise<strin
   }
 }
 
-async function fetchGuildName(guildId: string, token: string): Promise<string | null> {
+async function fetchGuildName(guildId: string, token: string, fetchImpl: typeof fetch): Promise<string | null> {
   try {
-    const response = await fetch(`${DISCORD_API_BASE}/guilds/${encodeURIComponent(guildId)}`, {
+    const response = await fetchImpl(`${DISCORD_API_BASE}/guilds/${encodeURIComponent(guildId)}`, {
       headers: { Authorization: `Bot ${token}` },
     })
     if (!response.ok) return null

--- a/src/channels/adapters/discord-bot-thread-room.test.ts
+++ b/src/channels/adapters/discord-bot-thread-room.test.ts
@@ -31,6 +31,14 @@ describe('discordThreadRoom (pure)', () => {
     expect(discordThreadRoom({ type: 0, parent_id: 'category-1' })).toBeUndefined()
   })
 
+  test('a normal channel with parent_id:null is not a thread room', () => {
+    expect(discordThreadRoom({ type: 0, parent_id: null })).toBeUndefined()
+  })
+
+  test('a thread with parent_id:null stays a bare retryable thread room', () => {
+    expect(discordThreadRoom({ type: 11, parent_id: null })).toEqual({ kind: 'thread' })
+  })
+
   test('an unknown lookup (fetch failed) fails closed to a bare thread room', () => {
     // Must NOT be treated as a confirmed non-thread channel — otherwise the
     // solo-human fallback could still engage an un-addressed fresh thread under
@@ -41,50 +49,108 @@ describe('discordThreadRoom (pure)', () => {
 
 describe('createDiscordThreadRoomResolver', () => {
   test('enriches a thread channel with room + parentChat', async () => {
-    const { fn } = fakeFetch([jsonResponse({ type: 11, parent_id: 'parent-c1' })])
+    const { fn } = fakeFetch([jsonResponse({ type: 11, parent_id: '201' })])
     const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
-    expect(await resolve('thread-t1')).toEqual({ kind: 'thread', parentChat: 'parent-c1' })
+    expect(await resolve('101')).toEqual({ kind: 'thread', parentChat: '201' })
   })
 
   test('returns undefined for a normal channel', async () => {
     const { fn } = fakeFetch([jsonResponse({ type: 0 })])
     const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
-    expect(await resolve('chan-c1')).toBeUndefined()
+    expect(await resolve('101')).toBeUndefined()
+  })
+
+  test('accepts parent_id:null on a normal channel and caches it', async () => {
+    const { fn, calls } = fakeFetch([jsonResponse({ type: 0, parent_id: null })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+
+    expect(await resolve.resolveStatus('101')).toEqual({ room: undefined, parentChecked: true })
+    expect(await resolve.resolveStatus('101')).toEqual({ room: undefined, parentChecked: true })
+    expect(calls).toHaveLength(1)
+  })
+
+  test('keeps a thread with parent_id:null retryable', async () => {
+    const { fn, calls } = fakeFetch([
+      jsonResponse({ type: 11, parent_id: null }),
+      jsonResponse({ type: 11, parent_id: null }),
+    ])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+
+    expect(await resolve.resolveStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolve.resolveStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(calls).toHaveLength(2)
   })
 
   test('caches per channel id so a busy thread issues a single fetch', async () => {
-    const { fn, calls } = fakeFetch([jsonResponse({ type: 11, parent_id: 'parent-c1' })])
+    const { fn, calls } = fakeFetch([jsonResponse({ type: 11, parent_id: '201' })])
     const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
-    await resolve('thread-t1')
-    await resolve('thread-t1')
-    await resolve('thread-t1')
+    await resolve('101')
+    await resolve('101')
+    await resolve('101')
     expect(calls).toHaveLength(1)
   })
 
   test('a failed fetch fails closed to a bare thread room (no parentChat)', async () => {
     const { fn } = fakeFetch([new Response(null, { status: 500 })])
     const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
-    expect(await resolve('thread-t1')).toEqual({ kind: 'thread' })
+    expect(await resolve('101')).toEqual({ kind: 'thread' })
   })
 
   test('a failed lookup is NOT cached so the next message retries', async () => {
     const { fn, calls } = fakeFetch([new Response(null, { status: 500 }), jsonResponse({ type: 0 })])
     const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
-    expect(await resolve('chan-c1')).toEqual({ kind: 'thread' })
-    expect(await resolve('chan-c1')).toBeUndefined()
+    expect(await resolve('101')).toEqual({ kind: 'thread' })
+    expect(await resolve('101')).toBeUndefined()
     expect(calls).toHaveLength(2)
   })
 
   test('re-fetches after the ttl expires', async () => {
     let clock = 0
     const { fn, calls } = fakeFetch([
-      jsonResponse({ type: 11, parent_id: 'p1' }),
-      jsonResponse({ type: 11, parent_id: 'p1' }),
+      jsonResponse({ type: 11, parent_id: '201' }),
+      jsonResponse({ type: 11, parent_id: '201' }),
     ])
     const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn, now: () => clock, ttlMs: 1000 })
-    await resolve('thread-t1')
+    await resolve('101')
     clock = 1001
-    await resolve('thread-t1')
+    await resolve('101')
+    expect(calls).toHaveLength(2)
+  })
+
+  test('rejects malformed IDs before building a Discord API path', async () => {
+    const { fn, calls } = fakeFetch([jsonResponse({ type: 0 })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+
+    for (const id of ['room/../1', '0', '01', '18446744073709551616']) {
+      expect(await resolve(id)).toEqual({ kind: 'thread' })
+      expect(await resolve.resolveStatus(id)).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    }
+    expect(calls).toHaveLength(0)
+  })
+
+  test('treats successful metadata with absent or non-numeric type as transient and retries', async () => {
+    const { fn, calls } = fakeFetch([
+      jsonResponse({ id: '101', name: 'missing-type' }),
+      jsonResponse({ id: '101', name: 'wrong-type', type: '0' }),
+      jsonResponse({ id: '101', name: 'general', type: 0 }),
+    ])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+
+    expect(await resolve.resolveStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolve.resolveStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolve.resolveStatus('101')).toEqual({ room: undefined, parentChecked: true })
+    expect(calls).toHaveLength(3)
+  })
+
+  test('keeps a confirmed thread with a missing parent retryable', async () => {
+    const { fn, calls } = fakeFetch([jsonResponse({ type: 11 }), jsonResponse({ type: 11, parent_id: '201' })])
+    const resolve = createDiscordThreadRoomResolver({ token: 'tok', fetchImpl: fn })
+
+    expect(await resolve.resolveStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolve.resolveStatus('101')).toEqual({
+      room: { kind: 'thread', parentChat: '201' },
+      parentChecked: true,
+    })
     expect(calls).toHaveLength(2)
   })
 })

--- a/src/channels/adapters/discord-bot-thread-room.ts
+++ b/src/channels/adapters/discord-bot-thread-room.ts
@@ -1,5 +1,8 @@
 import type { InboundMessage } from '@/channels/types'
 
+import { isDiscordSnowflake } from './discord-id'
+import { DiscordResolverCache } from './discord-resolver-cache'
+
 const DISCORD_API_BASE = 'https://discord.com/api/v10'
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
 
@@ -11,7 +14,7 @@ const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
 // carries no thread/parent signal.
 const DISCORD_THREAD_CHANNEL_TYPES: ReadonlySet<number> = new Set([10, 11, 12])
 
-export type DiscordChannelMeta = { type?: number; parent_id?: string }
+export type DiscordChannelMeta = { type?: number; parent_id?: string | null }
 
 // The lookup has THREE outcomes, and the failure case must not be conflated
 // with a confirmed non-thread channel:
@@ -25,6 +28,12 @@ export type DiscordThreadRoomResolverOptions = {
   fetchImpl?: typeof fetch
   now?: () => number
   ttlMs?: number
+  maxCacheEntries?: number
+}
+
+export type DiscordThreadRoomStatus = { room: InboundMessage['room']; parentChecked: boolean }
+export type DiscordThreadRoomResolver = ((channelId: string) => Promise<InboundMessage['room']>) & {
+  resolveStatus(channelId: string): Promise<DiscordThreadRoomStatus>
 }
 
 // Maps a lookup outcome to the room signal. A confirmed thread carries its
@@ -37,27 +46,39 @@ export type DiscordThreadRoomResolverOptions = {
 export function discordThreadRoom(meta: ChannelMetaLookup): InboundMessage['room'] {
   if (meta === 'unknown') return { kind: 'thread' }
   if (meta.type === undefined || !DISCORD_THREAD_CHANNEL_TYPES.has(meta.type)) return undefined
-  return meta.parent_id !== undefined ? { kind: 'thread', parentChat: meta.parent_id } : { kind: 'thread' }
+  return meta.parent_id != null ? { kind: 'thread', parentChat: meta.parent_id } : { kind: 'thread' }
 }
 
-export function createDiscordThreadRoomResolver(
-  options: DiscordThreadRoomResolverOptions,
-): (channelId: string) => Promise<InboundMessage['room']> {
+export function createDiscordThreadRoomResolver(options: DiscordThreadRoomResolverOptions): DiscordThreadRoomResolver {
   const fetchImpl = options.fetchImpl ?? fetch
   const now = options.now ?? Date.now
   const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
-  const cache = new Map<string, { value: DiscordChannelMeta; expiresAt: number }>()
+  const cache = new DiscordResolverCache<DiscordChannelMeta>(options.maxCacheEntries)
 
-  return async (channelId: string): Promise<InboundMessage['room']> => {
-    const cached = cache.get(channelId)
-    if (cached !== undefined && cached.expiresAt > now()) return discordThreadRoom(cached.value)
+  const resolve = (async (channelId: string): Promise<InboundMessage['room']> =>
+    (await resolve.resolveStatus(channelId)).room) as DiscordThreadRoomResolver
+
+  resolve.resolveStatus = async (channelId: string): Promise<DiscordThreadRoomStatus> => {
+    if (!isDiscordSnowflake(channelId)) return { room: { kind: 'thread' }, parentChecked: false }
+    const currentTime = now()
+    const cached = cache.get(channelId, currentTime)
+    if (cached !== undefined) {
+      return { room: discordThreadRoom(cached), parentChecked: true }
+    }
     // Only CONFIRMED metadata is cached. A failed lookup ('unknown') is not
     // cached, so the next message on this channel retries rather than pinning
     // the fail-closed state for the whole TTL.
     const meta = await fetchChannelMeta(channelId)
-    if (meta !== 'unknown') cache.set(channelId, { value: meta, expiresAt: now() + ttlMs })
-    return discordThreadRoom(meta)
+    const room = discordThreadRoom(meta)
+    const parentChecked = meta !== 'unknown' && (room?.kind !== 'thread' || room.parentChat != null)
+    if (meta !== 'unknown' && parentChecked) {
+      const fetchedAt = now()
+      cache.set(channelId, meta, fetchedAt + ttlMs, fetchedAt)
+    }
+    return { room, parentChecked }
   }
+
+  return resolve
 
   async function fetchChannelMeta(channelId: string): Promise<ChannelMetaLookup> {
     try {
@@ -65,9 +86,20 @@ export function createDiscordThreadRoomResolver(
         headers: { Authorization: `Bot ${options.token}` },
       })
       if (!response.ok) return 'unknown'
-      return (await response.json()) as DiscordChannelMeta
+      const body: unknown = await response.json()
+      if (!validChannelMetadata(body)) return 'unknown'
+      return body
     } catch {
       return 'unknown'
     }
   }
+}
+
+function validChannelMetadata(value: unknown): value is DiscordChannelMeta & { type: number } {
+  if (typeof value !== 'object' || value === null || !('type' in value)) return false
+  if (typeof value.type !== 'number' || !Number.isInteger(value.type) || value.type < 0) return false
+  if ('parent_id' in value && value.parent_id != null) {
+    if (typeof value.parent_id !== 'string' || !isDiscordSnowflake(value.parent_id)) return false
+  }
+  return true
 }

--- a/src/channels/adapters/discord-bot.test.ts
+++ b/src/channels/adapters/discord-bot.test.ts
@@ -3,12 +3,18 @@ import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type { DiscordBotClient, DiscordBotListener, DiscordFile, DiscordMessage } from 'agent-messenger/discordbot'
+import type {
+  DiscordBotClient,
+  DiscordBotListener,
+  DiscordFile,
+  DiscordGatewayMessageCreateEvent,
+  DiscordMessage,
+} from 'agent-messenger/discordbot'
 import { DiscordIntent } from 'agent-messenger/discordbot'
 
 import type { ChannelRouter } from '@/channels/router'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
-import type { FetchHistoryResult, HistoryCallback, OutboundMessage } from '@/channels/types'
+import type { FetchHistoryResult, HistoryCallback, InboundMessage, OutboundMessage } from '@/channels/types'
 import type { ChannelKey } from '@/channels/types'
 
 import {
@@ -25,6 +31,12 @@ import {
   DISCORD_SLASH_COMMAND_NAMES,
 } from './discord-bot'
 import { DISCORD_SLASH_COMMAND_TYPE_CHAT_INPUT } from './discord-bot-slash-commands'
+
+const provenanceConfig: ChannelAdapterConfig = {
+  enabled: true,
+  engagement: { trigger: ['mention', 'reply', 'dm'], stickiness: 'off' },
+  history: defaultHistoryConfig(),
+}
 
 describe('discord-bot gateway intents', () => {
   test('includes MessageContent (privileged) so inbound messages carry text', () => {
@@ -101,6 +113,149 @@ describe('discord-bot lifecycle', () => {
   })
 })
 
+describe('discord-bot provenance enrichment', () => {
+  test('startup resolves workspace and thread parent names for historical fragments', async () => {
+    const listener = fakeBotListener()
+    const logs: string[] = []
+    const resolved: unknown[] = []
+    const adapter = createDiscordBotAdapter({
+      agentDir: '/agent',
+      router: noopRouter(),
+      configRef: () => provenanceConfig,
+      token: 'test-token',
+      logger: {
+        info: (message) => logs.push(`info:${message}`),
+        warn: (message) => logs.push(`warn:${message}`),
+        error: (message) => logs.push(`error:${message}`),
+      },
+      createClient: () => ({ login: async () => {} }) as unknown as DiscordBotClient,
+      createListener: () => listener as unknown as DiscordBotListener,
+      fetchImpl: (async (input: string | URL | Request) => {
+        const url = String(input)
+        if (url.endsWith('/channels/301')) {
+          return Response.json({ id: '301', name: 'release-thread', type: 11, parent_id: '302' })
+        }
+        if (url.endsWith('/channels/302')) return Response.json({ id: '302', name: 'development', type: 0 })
+        if (url.endsWith('/guilds/201')) return Response.json({ id: '201', name: 'Example Guild' })
+        return new Response(null, { status: 404 })
+      }) as typeof fetch,
+      enrichHistoricalProvenance: async (agentDir, resolve, options) => {
+        expect(agentDir).toBe('/agent')
+        expect(options.adapter).toBe('discord-bot')
+        resolved.push(await resolve({ adapter: 'discord-bot', workspace: '201', chat: '301', thread: null }))
+        return { scanned: 1, attempted: 1, resolved: 1, failed: 0, timedOut: 0, changed: true }
+      },
+    })
+
+    await adapter.start()
+    await Bun.sleep(0)
+
+    expect(resolved).toEqual([
+      {
+        where: {
+          adapter: 'discord-bot',
+          workspace: '201',
+          workspaceName: 'Example Guild',
+          chat: '301',
+          chatName: 'release-thread',
+          thread: null,
+          parentChat: '302',
+          parentChatName: 'development',
+        },
+        parentChecked: true,
+      },
+    ])
+    expect(logs).toContain(
+      'info:[discord-bot] historical provenance enrichment scanned=1 attempted=1 resolved=1 failed=0 timed_out=0 changed=true',
+    )
+  })
+
+  test('historical enrichment failure never fails adapter startup', async () => {
+    const listener = fakeBotListener()
+    const warns: string[] = []
+    const adapter = createDiscordBotAdapter({
+      agentDir: '/agent',
+      router: noopRouter(),
+      configRef: () => provenanceConfig,
+      token: 'test-token',
+      logger: { info: () => {}, warn: (message) => warns.push(message), error: () => {} },
+      createClient: () => ({ login: async () => {} }) as unknown as DiscordBotClient,
+      createListener: () => listener as unknown as DiscordBotListener,
+      enrichHistoricalProvenance: async () => {
+        throw new Error('maintenance unavailable')
+      },
+    })
+
+    await expect(adapter.start()).resolves.toBeUndefined()
+    await Bun.sleep(0)
+    expect(warns).toContain('[discord-bot] historical provenance enrichment failed: maintenance unavailable')
+  })
+
+  test('live thread capture includes parent id and parent name before routing', async () => {
+    const listener = fakeBotListener()
+    const routed: InboundMessage[] = []
+    const adapter = createDiscordBotAdapter({
+      router: noopRouter((message) => routed.push(message)),
+      configRef: () => provenanceConfig,
+      token: 'test-token',
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      createClient: () => ({ login: async () => {} }) as unknown as DiscordBotClient,
+      createListener: () => listener as unknown as DiscordBotListener,
+      fetchImpl: (async (input: string | URL | Request) => {
+        const url = String(input)
+        if (url.endsWith('/channels/301')) {
+          return Response.json({ id: '301', name: 'release-thread', type: 11, parent_id: '302' })
+        }
+        if (url.endsWith('/channels/302')) return Response.json({ id: '302', name: 'development', type: 0 })
+        if (url.endsWith('/guilds/201')) return Response.json({ id: '201', name: 'Example Guild' })
+        return new Response(null, { status: 204 })
+      }) as typeof fetch,
+    })
+    await adapter.start()
+    listener.emit('connected', { user: { id: '999', username: 'typeclaw' } })
+    listener.emit('message_create', {
+      type: 'MESSAGE_CREATE',
+      id: '401',
+      channel_id: '301',
+      guild_id: '201',
+      author: { id: '501', username: 'alice', bot: false },
+      content: 'thread message',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    } satisfies DiscordGatewayMessageCreateEvent)
+    await adapter.stop()
+
+    expect(routed[0]?.room).toEqual({ kind: 'thread', parentChat: '302', parentChatName: 'development' })
+  })
+})
+
+function noopRouter(route?: (message: InboundMessage) => void): ChannelRouter {
+  return new Proxy(
+    {},
+    {
+      get: (_target, property) =>
+        property === 'route'
+          ? async (message: InboundMessage) => {
+              route?.(message)
+            }
+          : () => {},
+    },
+  ) as ChannelRouter
+}
+
+function fakeBotListener(): {
+  on(event: string, handler: (...args: unknown[]) => void): void
+  emit(event: string, ...args: unknown[]): void
+  start(): Promise<void>
+  stop(): void
+} {
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>()
+  return {
+    on: (event, handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
+    emit: (event, ...args) => handlers.get(event)?.forEach((handler) => handler(...args)),
+    start: async () => {},
+    stop: () => {},
+  }
+}
 describe('createTypingCallback', () => {
   let originalFetch: typeof fetch
   let calls: Array<{ url: string; init: RequestInit }>

--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -11,6 +11,10 @@ import {
 } from 'agent-messenger/discordbot'
 
 import {
+  enrichHistoricalProvenance,
+  type HistoricalProvenanceResolver,
+} from '@/bundled-plugins/memory/provenance-index'
+import {
   MEMBERSHIP_ENUMERATION_CAP,
   type MembershipResolver,
   type MembershipResolverFailure,
@@ -113,6 +117,7 @@ const consoleLogger: DiscordBotAdapterLogger = {
 }
 
 export type DiscordBotAdapterOptions = {
+  agentDir?: string
   router: ChannelRouter
   configRef: () => ChannelAdapterConfig
   token: string
@@ -123,6 +128,7 @@ export type DiscordBotAdapterOptions = {
   fetchImpl?: typeof fetch
   createClient?: () => DiscordBotClient
   createListener?: (client: DiscordBotClient, options: DiscordBotListenerOptions) => DiscordBotListener
+  enrichHistoricalProvenance?: typeof enrichHistoricalProvenance
 }
 
 export type DiscordBotAdapter = {
@@ -1032,7 +1038,7 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
 
-  const channelResolver = createDiscordChannelResolver({ token: options.token })
+  const channelResolver = createDiscordChannelResolver({ token: options.token, fetchImpl })
   const threadRoomResolver = createDiscordThreadRoomResolver({ token: options.token, fetchImpl })
 
   // Discord mentions by snowflake id (`<@id>`/`<@!id>`), so no username form.
@@ -1148,7 +1154,16 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
       // stays null), so the engagement gate cannot see "this is a thread" from
       // the payload alone. Resolve the channel's type/parent and stamp the
       // structural `room` signal for guild inbounds; DMs are never thread rooms.
-      const room = event.guild_id !== undefined ? await threadRoomResolver(event.channel_id) : undefined
+      let room = event.guild_id !== undefined ? await threadRoomResolver(event.channel_id) : undefined
+      if (room?.parentChat !== undefined && event.guild_id !== undefined) {
+        const parentNames = await channelResolver({
+          adapter: 'discord-bot',
+          workspace: event.guild_id,
+          chat: room.parentChat,
+          thread: null,
+        })
+        if (parentNames.chatName !== undefined) room = { ...room, parentChatName: parentNames.chatName }
+      }
       const basePayload =
         referenceResult.referenceContext === undefined
           ? { ...verdict.payload, text: hintedText }
@@ -1276,6 +1291,47 @@ export function createDiscordBotAdapter(options: DiscordBotAdapterOptions): Disc
         started = false
         logger.error(`[discord-bot] listener start failed: ${describe(err)}`)
         throw err
+      }
+
+      if (options.agentDir !== undefined) {
+        const runEnrichment = options.enrichHistoricalProvenance ?? enrichHistoricalProvenance
+        const resolveHistorical: HistoricalProvenanceResolver = async (where) => {
+          const key = {
+            adapter: 'discord-bot' as const,
+            workspace: where.workspace,
+            chat: where.chat,
+            thread: where.thread ?? null,
+          }
+          const [names, roomStatus] = await Promise.all([
+            channelResolver(key),
+            threadRoomResolver.resolveStatus(where.chat),
+          ])
+          const room = roomStatus.room
+          let parentChatName = room?.parentChatName
+          if (parentChatName === undefined && room?.parentChat !== undefined) {
+            const parentNames = await channelResolver({ ...key, chat: room.parentChat })
+            parentChatName = parentNames.chatName
+          }
+          return {
+            where: {
+              ...where,
+              ...names,
+              ...(room?.parentChat !== undefined ? { parentChat: room.parentChat } : {}),
+              ...(parentChatName !== undefined ? { parentChatName } : {}),
+            },
+            parentChecked: roomStatus.parentChecked,
+          }
+        }
+        void runEnrichment(options.agentDir, resolveHistorical, { adapter: 'discord-bot' }).then(
+          (result) => {
+            logger.info(
+              `[discord-bot] historical provenance enrichment scanned=${result.scanned} attempted=${result.attempted} resolved=${result.resolved} failed=${result.failed} timed_out=${result.timedOut} changed=${String(result.changed)}`,
+            )
+          },
+          (error: unknown) => {
+            logger.warn(`[discord-bot] historical provenance enrichment failed: ${describe(error)}`)
+          },
+        )
       }
     },
 

--- a/src/channels/adapters/discord-channel-resolver.test.ts
+++ b/src/channels/adapters/discord-channel-resolver.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { DiscordClient } from 'agent-messenger/discord'
+
+import { createDiscordChannelResolver } from './discord-channel-resolver'
+
+describe('discord user channel resolver', () => {
+  test('resolves and caches channel, guild, and thread-parent metadata through DiscordClient', async () => {
+    const calls: string[] = []
+    const client = {
+      getChannel: async (id: string) => {
+        calls.push(`channel:${id}`)
+        if (id === '101') return { id, name: 'topic-thread', guild_id: '201', parent_id: '301', type: 11 }
+        return { id, name: 'development', guild_id: '201', type: 0 }
+      },
+      getServer: async (id: string) => {
+        calls.push(`server:${id}`)
+        return { id, name: 'Example Guild' }
+      },
+    }
+    const resolver = createDiscordChannelResolver({ client })
+    const key = { adapter: 'discord' as const, workspace: '201', chat: '101', thread: null }
+
+    expect(await resolver(key)).toEqual({ chatName: 'topic-thread', workspaceName: 'Example Guild' })
+    expect(await resolver.resolveRoom('101')).toEqual({
+      kind: 'thread',
+      parentChat: '301',
+      parentChatName: 'development',
+    })
+    await resolver(key)
+
+    expect(calls).toEqual(['channel:101', 'server:201', 'channel:301'])
+  })
+
+  test('keeps IDs usable when server or parent resolution fails', async () => {
+    const resolver = createDiscordChannelResolver({
+      client: {
+        getChannel: async (id: string) => {
+          if (id === '101') return { id, name: 'thread', guild_id: '201', parent_id: '301', type: 11 }
+          throw new Error('parent unavailable')
+        },
+        getServer: async () => {
+          throw new Error('server unavailable')
+        },
+      },
+    })
+
+    expect(await resolver({ adapter: 'discord', workspace: '201', chat: '101', thread: null })).toEqual({
+      chatName: 'thread',
+    })
+    expect(await resolver.resolveRoom('101')).toEqual({ kind: 'thread', parentChat: '301' })
+  })
+
+  test('fails closed without caching when channel metadata lookup is transiently unavailable', async () => {
+    let attempts = 0
+    const resolver = createDiscordChannelResolver({
+      client: {
+        getChannel: async (id: string) => {
+          attempts += 1
+          if (attempts === 1) throw new Error('temporary failure')
+          return { id, name: 'general', guild_id: '201', type: 0 }
+        },
+        getServer: async (id: string) => ({ id, name: 'Example Guild' }),
+      },
+    })
+
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: undefined, parentChecked: true })
+    expect(attempts).toBe(2)
+  })
+
+  test('rejects malformed Discord IDs before calling the SDK', async () => {
+    let calls = 0
+    const resolver = createDiscordChannelResolver({
+      client: {
+        getChannel: async () => {
+          calls += 1
+          throw new Error('must not run')
+        },
+        getServer: async () => {
+          calls += 1
+          throw new Error('must not run')
+        },
+      },
+    })
+
+    for (const id of ['room/1', '0', '01', '18446744073709551616']) {
+      await resolver({ adapter: 'discord', workspace: id, chat: id, thread: null })
+      expect(await resolver.resolveRoom(id)).toEqual({ kind: 'thread' })
+    }
+    expect(calls).toBe(0)
+  })
+
+  test('treats successful channel metadata with an absent or non-numeric type as transient', async () => {
+    let attempts = 0
+    const resolver = createDiscordChannelResolver({
+      client: {
+        getChannel: (async (id: string) => {
+          attempts += 1
+          if (attempts === 1) return { id, name: 'malformed', guild_id: '201' }
+          if (attempts === 2) return { id, name: 'malformed', guild_id: '201', type: '0' }
+          return { id, name: 'general', guild_id: '201', type: 0 }
+        }) as unknown as DiscordClient['getChannel'],
+        getServer: async (id: string) => ({ id, name: 'Example Guild' }),
+      },
+    })
+
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: undefined, parentChecked: true })
+    expect(attempts).toBe(3)
+  })
+
+  test('keeps a confirmed thread with a missing parent retryable', async () => {
+    let attempts = 0
+    const resolver = createDiscordChannelResolver({
+      client: {
+        getChannel: async (id: string) => {
+          attempts += 1
+          return attempts === 1
+            ? { id, name: 'thread', guild_id: '201', type: 11 }
+            : { id, name: 'thread', guild_id: '201', type: 11, parent_id: '301' }
+        },
+        getServer: async (id: string) => ({ id, name: 'Example Guild' }),
+      },
+    })
+
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolver.resolveRoomStatus('101')).toEqual({
+      room: { kind: 'thread', parentChat: '301', parentChatName: 'thread' },
+      parentChecked: true,
+    })
+    expect(attempts).toBe(3)
+  })
+
+  test('accepts parent_id:null on a normal channel and caches the confirmed non-thread result', async () => {
+    let attempts = 0
+    const resolver = createDiscordChannelResolver({
+      client: {
+        getChannel: (async (id: string) => {
+          attempts += 1
+          return { id, name: 'general', guild_id: '201', type: 0, parent_id: null }
+        }) as unknown as DiscordClient['getChannel'],
+        getServer: async (id: string) => ({ id, name: 'Example Guild' }),
+      },
+    })
+
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: undefined, parentChecked: true })
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: undefined, parentChecked: true })
+    expect(attempts).toBe(1)
+  })
+
+  test('keeps a thread with parent_id:null retryable', async () => {
+    let attempts = 0
+    const resolver = createDiscordChannelResolver({
+      client: {
+        getChannel: (async (id: string) => {
+          attempts += 1
+          return { id, name: 'thread', guild_id: '201', type: 11, parent_id: null }
+        }) as unknown as DiscordClient['getChannel'],
+        getServer: async (id: string) => ({ id, name: 'Example Guild' }),
+      },
+    })
+
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(await resolver.resolveRoomStatus('101')).toEqual({ room: { kind: 'thread' }, parentChecked: false })
+    expect(attempts).toBe(2)
+  })
+})

--- a/src/channels/adapters/discord-channel-resolver.ts
+++ b/src/channels/adapters/discord-channel-resolver.ts
@@ -1,44 +1,112 @@
 import type { DiscordClient } from 'agent-messenger/discord'
 
-import type { ChannelKey, ChannelNameResolver, ResolvedChannelNames } from '@/channels/types'
+import type { ChannelKey, ChannelNameResolver, InboundMessage, ResolvedChannelNames } from '@/channels/types'
+
+import { isDiscordSnowflake } from './discord-id'
+import { DiscordResolverCache } from './discord-resolver-cache'
 
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+const DISCORD_THREAD_TYPES = new Set([10, 11, 12])
 
 export type DiscordChannelResolverOptions = {
-  client: Pick<DiscordClient, 'getChannel'>
+  client: Pick<DiscordClient, 'getChannel' | 'getServer'>
   now?: () => number
   ttlMs?: number
+  maxCacheEntries?: number
 }
 
-type CacheEntry<T> = { value: T; expiresAt: number }
+export type DiscordChannelResolver = ChannelNameResolver & {
+  resolveRoom(chatId: string): Promise<InboundMessage['room']>
+  resolveRoomStatus(chatId: string): Promise<{ room: InboundMessage['room']; parentChecked: boolean }>
+}
 
-export function createDiscordChannelResolver(options: DiscordChannelResolverOptions): ChannelNameResolver {
+type DiscordChannelInfo = Awaited<ReturnType<DiscordClient['getChannel']>>
+
+export function createDiscordChannelResolver(options: DiscordChannelResolverOptions): DiscordChannelResolver {
   const now = options.now ?? Date.now
   const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
-  const chatCache = new Map<string, CacheEntry<string>>()
+  const channelCache = new DiscordResolverCache<DiscordChannelInfo>(options.maxCacheEntries)
+  const guildCache = new DiscordResolverCache<string>(options.maxCacheEntries)
 
-  const fetchCached = async <T>(
-    cache: Map<string, CacheEntry<T>>,
-    key: string,
-    fetcher: () => Promise<T | null>,
-  ): Promise<T | null> => {
-    const cached = cache.get(key)
-    if (cached && cached.expiresAt > now()) return cached.value
-    const value = await fetcher()
-    if (value !== null) cache.set(key, { value, expiresAt: now() + ttlMs })
-    return value
-  }
-
-  return async (key: ChannelKey): Promise<ResolvedChannelNames> => {
-    if (key.workspace === '@dm') return {}
-    const chatName = await fetchCached(chatCache, key.chat, async () => {
+  const fetchChannel = async (channelId: string): Promise<DiscordChannelInfo | null> =>
+    await fetchCached(channelCache, channelId, async () => {
+      if (!isDiscordSnowflake(channelId)) return null
       try {
-        const channel = await options.client.getChannel(key.chat)
-        return channel.name || null
-      } catch {
+        const channel = await options.client.getChannel(channelId)
+        return validChannelMetadata(channel) ? channel : null
+      } catch (error) {
+        void error
         return null
       }
     })
-    return chatName !== null ? { chatName } : {}
+
+  const resolve = (async (key: ChannelKey): Promise<ResolvedChannelNames> => {
+    if (key.workspace === '@dm') return {}
+    const [channel, workspaceName] = await Promise.all([
+      fetchChannel(key.chat),
+      key.workspace === '' || !isDiscordSnowflake(key.workspace)
+        ? Promise.resolve(null)
+        : fetchCached(guildCache, key.workspace, async () => {
+            try {
+              const guild = await options.client.getServer(key.workspace)
+              return guild.name || null
+            } catch (error) {
+              void error
+              return null
+            }
+          }),
+    ])
+    return {
+      ...(channel?.name ? { chatName: channel.name } : {}),
+      ...(workspaceName !== null ? { workspaceName } : {}),
+    }
+  }) as DiscordChannelResolver
+
+  resolve.resolveRoomStatus = async (
+    chatId: string,
+  ): Promise<{ room: InboundMessage['room']; parentChecked: boolean }> => {
+    if (!isDiscordSnowflake(chatId)) return { room: { kind: 'thread' }, parentChecked: false }
+    const channel = await fetchChannel(chatId)
+    if (channel === null) return { room: { kind: 'thread' }, parentChecked: false }
+    if (!DISCORD_THREAD_TYPES.has(channel.type)) return { room: undefined, parentChecked: true }
+    if (channel.parent_id == null || !isDiscordSnowflake(channel.parent_id)) {
+      channelCache.delete(chatId)
+      return { room: { kind: 'thread' }, parentChecked: false }
+    }
+    const parent = await fetchChannel(channel.parent_id)
+    return {
+      room: {
+        kind: 'thread',
+        parentChat: channel.parent_id,
+        ...(parent?.name ? { parentChatName: parent.name } : {}),
+      },
+      parentChecked: true,
+    }
   }
+  resolve.resolveRoom = async (chatId: string) => (await resolve.resolveRoomStatus(chatId)).room
+
+  return resolve
+
+  async function fetchCached<T>(
+    cache: DiscordResolverCache<T>,
+    key: string,
+    fetcher: () => Promise<T | null>,
+  ): Promise<T | null> {
+    const currentTime = now()
+    const cached = cache.get(key, currentTime)
+    if (cached !== undefined) return cached
+    const value = await fetcher()
+    if (value !== null) {
+      const fetchedAt = now()
+      cache.set(key, value, fetchedAt + ttlMs, fetchedAt)
+    }
+    return value
+  }
+}
+
+function validChannelMetadata(channel: DiscordChannelInfo): boolean {
+  if (!Number.isInteger(channel.type) || channel.type < 0) return false
+  if (channel.parent_id != null && !isDiscordSnowflake(channel.parent_id)) return false
+  if (channel.guild_id !== undefined && !isDiscordSnowflake(channel.guild_id)) return false
+  return true
 }

--- a/src/channels/adapters/discord-id.ts
+++ b/src/channels/adapters/discord-id.ts
@@ -1,0 +1,4 @@
+export function isDiscordSnowflake(value: string): boolean {
+  if (!/^[1-9]\d{0,19}$/.test(value)) return false
+  return BigInt(value) <= 18_446_744_073_709_551_615n
+}

--- a/src/channels/adapters/discord-resolver-cache.test.ts
+++ b/src/channels/adapters/discord-resolver-cache.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+
+import { DiscordResolverCache } from './discord-resolver-cache'
+
+describe('DiscordResolverCache', () => {
+  test('evicts expired entries instead of retaining dead keys', () => {
+    const cache = new DiscordResolverCache<string>(2)
+    cache.set('expired', 'old', 5, 0)
+    cache.set('live', 'new', 20, 10)
+
+    expect(cache.get('expired', 10)).toBeUndefined()
+    expect(cache.get('live', 10)).toBe('new')
+  })
+
+  test('bounds cardinality and evicts the least recently used entry', () => {
+    const cache = new DiscordResolverCache<string>(2)
+    cache.set('first', 'a', 100, 0)
+    cache.set('second', 'b', 100, 0)
+    expect(cache.get('first', 1)).toBe('a')
+
+    cache.set('third', 'c', 100, 1)
+
+    expect(cache.get('second', 1)).toBeUndefined()
+    expect(cache.get('first', 1)).toBe('a')
+    expect(cache.get('third', 1)).toBe('c')
+  })
+})

--- a/src/channels/adapters/discord-resolver-cache.ts
+++ b/src/channels/adapters/discord-resolver-cache.ts
@@ -1,0 +1,41 @@
+export const DEFAULT_DISCORD_RESOLVER_CACHE_ENTRIES = 1_000
+
+type CacheEntry<T> = { value: T; expiresAt: number }
+
+export class DiscordResolverCache<T> {
+  readonly #entries = new Map<string, CacheEntry<T>>()
+  readonly #maxEntries: number
+
+  constructor(maxEntries = DEFAULT_DISCORD_RESOLVER_CACHE_ENTRIES) {
+    this.#maxEntries = Math.max(1, maxEntries)
+  }
+
+  get(key: string, now: number): T | undefined {
+    const entry = this.#entries.get(key)
+    if (entry === undefined) return undefined
+    if (entry.expiresAt <= now) {
+      this.#entries.delete(key)
+      return undefined
+    }
+    this.#entries.delete(key)
+    this.#entries.set(key, entry)
+    return entry.value
+  }
+
+  set(key: string, value: T, expiresAt: number, now: number): void {
+    for (const [candidate, entry] of this.#entries) {
+      if (entry.expiresAt <= now) this.#entries.delete(candidate)
+    }
+    this.#entries.delete(key)
+    while (this.#entries.size >= this.#maxEntries) {
+      const oldest = this.#entries.keys().next().value
+      if (oldest === undefined) break
+      this.#entries.delete(oldest)
+    }
+    this.#entries.set(key, { value, expiresAt })
+  }
+
+  delete(key: string): void {
+    this.#entries.delete(key)
+  }
+}

--- a/src/channels/adapters/discord.test.ts
+++ b/src/channels/adapters/discord.test.ts
@@ -169,6 +169,121 @@ describe('createDiscordAdapter', () => {
     expect(r.unregistered).toContain('remove-reaction:discord')
   })
 
+  test('captures Discord thread parent id and name before routing', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getChannel: async (id: string) =>
+            id === '300000000000000003'
+              ? {
+                  id,
+                  guild_id: '200000000000000002',
+                  name: 'topic-thread',
+                  type: 11,
+                  parent_id: '300000000000000099',
+                }
+              : { id, guild_id: '200000000000000002', name: 'development', type: 0 },
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+    })
+
+    await adapter.start()
+    listener.emit('message_create', {
+      type: 'MESSAGE_CREATE',
+      id: '400000000000000004',
+      channel_id: '300000000000000003',
+      guild_id: '200000000000000002',
+      author: { id: '500000000000000005', username: 'alice' },
+      content: 'thread message',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    } satisfies DiscordGatewayMessageCreateEvent)
+    await adapter.stop()
+
+    expect(r.routed[0]?.room).toEqual({
+      kind: 'thread',
+      parentChat: '300000000000000099',
+      parentChatName: 'development',
+    })
+  })
+
+  test('a known DM routes successfully without channel metadata resolution', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    let channelMetadataCalls = 0
+    const adapter = createDiscordAdapter({
+      router: r,
+      configRef: () => config,
+      logger: logger(),
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () =>
+        fakeClient({
+          getChannel: async () => {
+            channelMetadataCalls++
+            return { id: '300000000000000003', name: 'should-not-resolve', type: 0 }
+          },
+        }),
+      createListener: () => listener as unknown as DiscordListener,
+    })
+
+    await adapter.start()
+    listener.emit('message_create', {
+      type: 'MESSAGE_CREATE',
+      id: '400000000000000004',
+      channel_id: '300000000000000003',
+      author: { id: '500000000000000005', username: 'alice' },
+      content: 'private message',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    } satisfies DiscordGatewayMessageCreateEvent)
+    await adapter.stop()
+
+    expect(r.routed[0]?.workspace).toBe('@dm')
+    expect(r.routed[0]?.room).toBeUndefined()
+    expect(channelMetadataCalls).toBe(0)
+  })
+
+  test('adapter start triggers observable resolver-backed historical provenance maintenance', async () => {
+    const r = router()
+    const listener = new FakeListener()
+    const log = logger()
+    const calls: string[] = []
+    const adapter = createDiscordAdapter({
+      agentDir: '/agent',
+      router: r,
+      configRef: () => config,
+      logger: log,
+      credentialsStore: { getAccount: async () => account() },
+      createClient: () => fakeClient(),
+      createListener: () => listener as unknown as DiscordListener,
+      enrichHistoricalProvenance: async (agentDir, resolve, options) => {
+        calls.push(agentDir)
+        expect(options.adapter).toBe('discord')
+        const resolved = await resolve({
+          adapter: 'discord',
+          workspace: '200000000000000002',
+          chat: '300000000000000003',
+          thread: null,
+        })
+        expect(resolved.where.workspaceName).toBe('Example Guild')
+        expect(resolved.parentChecked).toBe(true)
+        return { scanned: 1, attempted: 1, resolved: 1, failed: 0, timedOut: 0, changed: true }
+      },
+    })
+
+    await adapter.start()
+    await Bun.sleep(0)
+
+    expect(calls).toEqual(['/agent'])
+    expect(log.lines).toContain(
+      'info:[discord] historical provenance enrichment scanned=1 attempted=1 resolved=1 failed=0 timed_out=0 changed=true',
+    )
+  })
+
   test('outbound sends messages through DiscordClient.sendMessage', async () => {
     const sent: unknown[] = []
     const r = router()
@@ -342,6 +457,7 @@ function fakeClient(
     login: async () => {},
     testAuth: async () => ({ id: '100000000000000001', username: 'self', global_name: 'Self' }),
     getChannel: async () => ({ id: '300000000000000003', guild_id: '200000000000000002', name: 'general', type: 0 }),
+    getServer: async () => ({ id: '200000000000000002', name: 'Example Guild' }),
     getUser: async () => ({ id: '500000000000000005', username: 'alice', global_name: 'Alice' }),
     getMessages: async () => [],
     sendMessage: async () => ({

--- a/src/channels/adapters/discord.ts
+++ b/src/channels/adapters/discord.ts
@@ -5,6 +5,10 @@ import {
   type DiscordMessage,
 } from 'agent-messenger/discord'
 
+import {
+  enrichHistoricalProvenance,
+  type HistoricalProvenanceResolver,
+} from '@/bundled-plugins/memory/provenance-index'
 import type { MembershipResolver, MembershipResolverResult } from '@/channels/membership'
 import { deriveMembershipFromHistory } from '@/channels/membership-from-history'
 import type { ChannelRouter } from '@/channels/router'
@@ -48,6 +52,7 @@ export type DiscordCredentialStore = {
 }
 
 export type DiscordAdapterOptions = {
+  agentDir?: string
   router: ChannelRouter
   configRef: () => ChannelAdapterConfig
   logger?: DiscordAdapterLogger
@@ -56,6 +61,7 @@ export type DiscordAdapterOptions = {
   createClient?: () => DiscordClient
   createListener?: (client: DiscordClient) => DiscordListener
   fetchImpl?: typeof fetch
+  enrichHistoricalProvenance?: typeof enrichHistoricalProvenance
 }
 
 export type DiscordAdapter = {
@@ -221,14 +227,15 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
   const handleMessage = async (event: DiscordGatewayMessageCreateEvent): Promise<void> => {
     inflightInbounds++
     try {
-      const tag = await formatChannelTag(event.channel_id)
-      logger.info(
-        `[discord] inbound id=${event.id} author=${event.author.id || '(none)'} ${tag} text_len=${event.content.length}`,
-      )
       const verdict = classifyInbound(event, options.configRef(), {
         selfUserId,
         selfAliases: options.selfAliasesRef?.() ?? [],
       })
+      const tag =
+        event.guild_id === undefined ? `channel=${event.channel_id}` : await formatChannelTag(event.channel_id)
+      logger.info(
+        `[discord] inbound id=${event.id} author=${event.author.id || '(none)'} ${tag} text_len=${event.content.length}`,
+      )
       if (verdict.kind === 'drop') {
         logger.info(`[discord] dropped id=${event.id} reason=${verdict.reason}${dropHint(verdict.reason)}`)
         return
@@ -240,9 +247,11 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
         filename: file.filename,
         mimetype: file.content_type,
       }))
+      const room = verdict.payload.isDm ? undefined : await channelResolver.resolveRoom(verdict.payload.chat)
       const payload = {
         ...verdict.payload,
         authorName: await authorResolver.resolve(verdict.payload.authorId),
+        ...(room !== undefined ? { room } : {}),
         ...(attachments.length > 0 ? { attachments } : {}),
       }
       logger.info(`[discord] routed id=${event.id} ${tag} mention=${payload.isBotMention}`)
@@ -334,6 +343,42 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): DiscordAda
         rollbackStart(
           'listener start failed silently',
           listenerStartupError ?? new Error('listener.start() returned without emitting connected'),
+        )
+      }
+
+      if (options.agentDir !== undefined) {
+        const runEnrichment = options.enrichHistoricalProvenance ?? enrichHistoricalProvenance
+        const resolveHistorical: HistoricalProvenanceResolver = async (where) => {
+          const key = {
+            adapter: 'discord' as const,
+            workspace: where.workspace,
+            chat: where.chat,
+            thread: where.thread ?? null,
+          }
+          const [names, roomStatus] = await Promise.all([
+            channelResolver(key),
+            channelResolver.resolveRoomStatus(where.chat),
+          ])
+          const room = roomStatus.room
+          return {
+            where: {
+              ...where,
+              ...names,
+              ...(room?.parentChat !== undefined ? { parentChat: room.parentChat } : {}),
+              ...(room?.parentChatName !== undefined ? { parentChatName: room.parentChatName } : {}),
+            },
+            parentChecked: roomStatus.parentChecked,
+          }
+        }
+        void runEnrichment(options.agentDir, resolveHistorical, { adapter: 'discord' }).then(
+          (result) => {
+            logger.info(
+              `[discord] historical provenance enrichment scanned=${result.scanned} attempted=${result.attempted} resolved=${result.resolved} failed=${result.failed} timed_out=${result.timedOut} changed=${String(result.changed)}`,
+            )
+          },
+          (error: unknown) => {
+            logger.warn(`[discord] historical provenance enrichment failed: ${describeError(error)}`)
+          },
         )
       }
     },

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -260,6 +260,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       const token = env.DISCORD_BOT_TOKEN
       if (token === undefined || token.trim() === '') return null
       return createDiscordBot({
+        agentDir: options.agentDir,
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         token,
@@ -331,6 +332,7 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       const credentialsStore = createContainerDiscordCredentialStore(options.agentDir, options.secretsProvider ?? null)
       if (credentialsStore === null) return null
       return createDiscordUser({
+        agentDir: options.agentDir,
         router,
         configRef: () => options.channelsConfigRef()[name] ?? cfg,
         logger,

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -7,7 +7,7 @@ import type { AfterToolCallContext, AfterToolCallResult, StreamFn } from '@mario
 import type { AssistantMessage } from '@mariozechner/pi-ai'
 import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 
-import type { AgentSession } from '@/agent'
+import type { AgentSession, SessionOriginRef } from '@/agent'
 import type { RestartHandoff } from '@/agent/restart-handoff'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { readContinuationState } from '@/agent/todo/continuation-state'
@@ -352,6 +352,7 @@ function makeRouter(
     onRetryBackoffStart?: () => void
     logs?: string[]
     origins?: SessionOrigin[]
+    originRefs?: SessionOriginRef[]
     factoryCalls?: SessionFactoryArgs[]
     transcriptPathFor?: (sessionId: string) => string | undefined
     measureTranscriptBytes?: (path: string) => number
@@ -391,12 +392,13 @@ function makeRouter(
       warn: (m) => options.logs?.push(`warn:${m}`),
       error: (m) => options.logs?.push(`error:${m}`),
     },
-    createSessionForChannel: async ({ origin, existingSessionId, existingSessionFile }) => {
+    createSessionForChannel: async ({ origin, originRef, existingSessionId, existingSessionFile }) => {
       options.factoryCalls?.push({
         ...(existingSessionId !== undefined ? { existingSessionId } : {}),
         ...(existingSessionFile !== undefined ? { existingSessionFile } : {}),
       })
       origins.push(origin)
+      options.originRefs?.push(originRef)
       const fake = new FakeSession()
       sessions.push(fake)
       const sessionId = existingSessionId ?? `ses_fake_${sessions.length}`
@@ -10562,6 +10564,35 @@ describe('ChannelRouter cold-start prefetch', () => {
     // then: membership was resolved against the PARENT channel, not the thread
     expect(resolvedChats.length).toBeGreaterThan(0)
     expect(resolvedChats.every((c) => c === 'parent-c1')).toBe(true)
+  })
+
+  test('rebuilt live channel origin retains Discord parent chat metadata and parent-scoped membership', async () => {
+    const dir = await tempDir()
+    const originRefs: SessionOriginRef[] = []
+    const { router } = makeRouter(dir, { originRefs })
+    router.registerMembership('discord-bot', async () => ({
+      humans: 4,
+      bots: 1,
+      fetchedAt: Date.now(),
+      truncated: false,
+    }))
+
+    await router.route(
+      inbound({
+        chat: 'thread-t1',
+        thread: null,
+        room: { kind: 'thread', parentChat: 'parent-c1', parentChatName: '개발실' },
+        externalMessageId: 'origin-parent',
+        text: 'hey bot',
+      }),
+    )
+    await router.__testing!.flushDebounce({ adapter: 'discord-bot', workspace: 'g1', chat: 'thread-t1', thread: null })
+
+    expect(originRefs[0]?.current).toMatchObject({
+      parentChat: 'parent-c1',
+      parentChatName: '개발실',
+      membership: { humans: 4, bots: 1, truncated: false },
+    })
   })
 
   test('a fresh Discord thread room observes an un-addressed message when membership is unknown', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -2020,6 +2020,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         chat: key.chat,
         ...(resolvedNames.chatName !== undefined ? { chatName: resolvedNames.chatName } : {}),
         thread: key.thread,
+        ...(room?.parentChat !== undefined ? { parentChat: room.parentChat } : {}),
+        ...(room?.parentChatName !== undefined ? { parentChatName: room.parentChatName } : {}),
         ...(triggeringAuthorId !== undefined ? { lastInboundAuthorId: triggeringAuthorId } : {}),
         participants,
         ...(membership !== null ? { membership } : {}),
@@ -2713,7 +2715,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   const buildLiveOrigin = (live: LiveSession): SessionOrigin => {
-    const membership = readMembership(live.key)
+    const membership = readMembership(live.key, live.room)
     const self = resolveSelfIdentity(live.key)
     return {
       kind: 'channel',
@@ -2723,6 +2725,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       chat: live.key.chat,
       ...(live.resolvedNames.chatName !== undefined ? { chatName: live.resolvedNames.chatName } : {}),
       thread: live.key.thread,
+      ...(live.room?.parentChat !== undefined ? { parentChat: live.room.parentChat } : {}),
+      ...(live.room?.parentChatName !== undefined ? { parentChatName: live.room.parentChatName } : {}),
       ...(live.currentTurnAuthorId !== null ? { lastInboundAuthorId: live.currentTurnAuthorId } : {}),
       ...(live.currentTurnReactionRef !== null ? { reactionRef: live.currentTurnReactionRef } : {}),
       participants: live.participants,


### PR DESCRIPTION
## Background

Extracted from #1200. This is slice 3/5, based on #1203's branch. Merge order: #1206 → #1203 → this PR → #1205 → #1200.

Discord stream events didn't reliably carry human-readable guild/channel/thread names or thread-parent context at capture time, so citations and provenance pointed at raw snowflake IDs with no context for lexical search (#1203's filters) or manual review.

## Summary

- Adds bounded, timeout-safe resolver utilities (`discord-resolver-cache.ts`, `discord-channel-resolver.ts`, `discord-bot-channel-resolver.ts`, `discord-bot-thread-room.ts`) backing a process-local LRU cache of guild/thread/channel-name lookups.
- Both Discord adapters run startup maintenance that resolves old ID-only coordinates into this cache. The cache is rebuilt fresh on every restart and never persisted to disk — historical stream JSONL stays append-only and untouched.
- Resolution is bounded: each enrichment pass resolves a capped batch of unique origins, newest-first, so a backlog of unresolvable old entries can't starve newer channels.
- New thread messages capture their parent channel ID/name at receipt (using #1206's `parentChat`/`parentChatName` fields) so thread provenance doesn't need a lookup at all.
- Confirmed non-thread checks are negatively cached for the process lifetime so they don't retry.
- Resolver failures and timeouts degrade to raw-ID search rather than blocking message handling.

## What this does NOT do

- Does not write anything to a provenance sidecar or mutate stored stream data — enrichment is process-local and runtime-only.
- Does not perform network resolution during search — `memory_search`/`hybridSearch` only read local memory plus the already-populated in-memory cache.
- Does not change who can recall what — this slice is name/context enrichment for existing provenance fields; scoping and filtering live in #1203.

## Review notes

- Verify the negative-cache path (confirmed non-thread) can't wedge open on a transient resolver error — it should only cache confirmed results, not timeouts/failures.
- Verify the bounded, newest-first batch resolution (see `timeoutMs` handling around startup maintenance) fails closed to raw-ID display rather than hanging or throwing on a slow/dead Discord API call.
