### PR TITLE
fix(slack): classify private conversations

### DIFF
--- a/src/channels/adapters/slack-bot-classify.test.ts
+++ b/src/channels/adapters/slack-bot-classify.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 
+import { decideEngagement, StickyLedger } from '@/channels/engagement'
 import { defaultHistoryConfig, type ChannelAdapterConfig } from '@/channels/schema'
+import { isDmChannelOrigin } from '@/permissions'
 
 import { classifyInbound, type SlackInboundMessageEvent } from './slack-bot-classify'
 import { encodeSlackReactionRef } from './slack-bot-reactions'
@@ -470,6 +472,30 @@ describe('slack-bot classifyInbound — route path', () => {
     expect(verdict.kind).toBe('route')
     if (verdict.kind !== 'route') throw new Error('expected route')
     expect(verdict.payload).toMatchObject({ workspace: '@dm', chat: 'D0DMID', isDm: true })
+  })
+
+  test('MPIM group DMs retain team, grant, and multi-human engagement semantics', () => {
+    const event = buildEvent({ channel_type: 'mpim', channel: 'G0MPIM', text: '여러분 안녕하세요' })
+
+    const verdict = classifyInbound(event, baseConfig, { teamId: TEAM_ID, botUserId: BOT_USER_ID })
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload).toMatchObject({ workspace: TEAM_ID, chat: 'G0MPIM', isDm: false })
+    expect(isDmChannelOrigin(verdict.payload)).toBe(false)
+    expect(
+      decideEngagement({
+        message: verdict.payload,
+        config: { trigger: ['dm'], stickiness: 'off' },
+        key: `slack-bot:${TEAM_ID}:G0MPIM:`,
+        ledger: new StickyLedger(),
+        now: 0,
+        participants: [],
+        membership: { humans: 3, bots: 1, fetchedAt: 0, truncated: false },
+        selfAliases: [],
+        botInThread: false,
+      }),
+    ).toBe('observe')
   })
 
   test('thread reply to the bot surfaces thread_ts as both thread and replyToBotMessageId', () => {

--- a/src/channels/adapters/slack-bot-slash-commands.test.ts
+++ b/src/channels/adapters/slack-bot-slash-commands.test.ts
@@ -46,12 +46,12 @@ describe('parseSlashCommand', () => {
     expect(result.command.key.chat).toBe('D-bob')
   })
 
-  test('private channel ids (G prefix) map to the team workspace (NOT @dm)', () => {
-    const result = parseSlashCommand(body({ channel_id: 'G-secret' }), known)
+  test('MPIM and private channel ids (G prefix) map to the team workspace (NOT @dm)', () => {
+    const result = parseSlashCommand(body({ channel_id: 'G0MPIM' }), known)
     expect(result.kind).toBe('parsed')
     if (result.kind !== 'parsed') return
     expect(result.command.key.workspace).toBe('T-acme')
-    expect(result.command.key.chat).toBe('G-secret')
+    expect(result.command.key.chat).toBe('G0MPIM')
   })
 
   test('lowercases the command name', () => {
@@ -133,6 +133,18 @@ describe('parseThreadCommand', () => {
     if (result.kind !== 'parsed') return
     expect(result.command.key.workspace).toBe('@dm')
     expect(result.command.key.chat).toBe('D-bob')
+  })
+
+  test('MPIM thread commands target the team-scoped group conversation', () => {
+    const result = parseThreadCommand(input({ channel: 'G0MPIM', isDm: false }), known)
+    expect(result.kind).toBe('parsed')
+    if (result.kind !== 'parsed') return
+    expect(result.command.key).toEqual({
+      adapter: 'slack-bot',
+      workspace: 'T-acme',
+      chat: 'G0MPIM',
+      thread: '1700.0001',
+    })
   })
 
   test('lowercases the command name (!STOP)', () => {

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -441,6 +441,54 @@ describe('createSlackMembershipResolver', () => {
     expect(calls).toHaveLength(0)
   })
 
+  test('MPIM classification drives real multi-human membership enumeration', async () => {
+    const verdict = classifyInbound(
+      {
+        type: 'message',
+        channel: 'G0MPIM',
+        channel_type: 'mpim',
+        user: 'U1',
+        text: '함께 확인해 주세요',
+        ts: '1700000000.000100',
+      },
+      {
+        engagement: { trigger: ['mention'], stickiness: 'off' },
+        enabled: true,
+        history: defaultHistoryConfig(),
+      },
+      { teamId: 'T1', botUserId: 'UBOT' },
+    )
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    const { fn } = fakeFetch([
+      slackResponse({ ok: true, channel: { num_members: 3 } }),
+      slackResponse({ ok: true, members: ['U1', 'U2', 'UBOT'] }),
+      slackResponse({ ok: true, members: [{ id: 'UBOT', is_bot: true }] }),
+    ])
+    const resolver = createSlackMembershipResolver({
+      token: 'tok',
+      logger: silentLogger(),
+      historyCallback: emptyHistory(),
+      fetchImpl: fn,
+      now: () => 15,
+    })
+
+    await expect(
+      resolver({
+        adapter: verdict.payload.adapter,
+        workspace: verdict.payload.workspace,
+        chat: verdict.payload.chat,
+        thread: verdict.payload.thread,
+      }),
+    ).resolves.toEqual({
+      humans: 2,
+      bots: 1,
+      fetchedAt: 15,
+      truncated: false,
+      humanMemberIds: ['U1', 'U2'],
+    })
+  })
+
   test('small channel classifies members against the bulk users.list bot set', async () => {
     const { fn, calls } = fakeFetch([
       slackResponse({ ok: true, channel: { num_members: 3 } }),

--- a/src/channels/adapters/slack-classify.test.ts
+++ b/src/channels/adapters/slack-classify.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import type { SlackRTMMessageEvent } from 'agent-messenger/slack'
 
 import { channelsSchema } from '@/channels/schema'
+import { isDmChannelOrigin } from '@/permissions'
 
 import { classifyInbound } from './slack-classify'
 
@@ -43,6 +44,29 @@ describe('classifyInbound (slack user)', () => {
     expect(verdict.payload.workspace).toBe('@dm')
     expect(verdict.payload.isDm).toBe(true)
     expect(verdict.payload.thread).toBeNull()
+  })
+
+  test('fails closed to the team workspace for a G-prefixed conversation without metadata', () => {
+    const verdict = classifyInbound(event({ channel: 'G0123456789' }), config, context)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') return
+    expect(verdict.payload.workspace).toBe('T0123456789')
+    expect(verdict.payload.chat).toBe('G0123456789')
+    expect(verdict.payload.isDm).toBe(false)
+  })
+
+  test('keeps MPIMs and private channels in the real team workspace without granting DM semantics', () => {
+    const mpim = classifyInbound(event({ channel: 'G0MPIM' }), config, { ...context, conversationType: 'mpim' })
+    const privateChannel = classifyInbound(event({ channel: 'G0PRIVATE' }), config, {
+      ...context,
+      conversationType: 'channel',
+    })
+
+    expect(mpim.kind === 'route' && mpim.payload.workspace).toBe('T0123456789')
+    expect(mpim.kind === 'route' && mpim.payload.isDm).toBe(false)
+    expect(mpim.kind === 'route' && isDmChannelOrigin(mpim.payload)).toBe(false)
+    expect(privateChannel.kind === 'route' && privateChannel.payload.workspace).toBe('T0123456789')
   })
 
   test('detects self mentions, group mentions, and other mentions', () => {

--- a/src/channels/adapters/slack-classify.ts
+++ b/src/channels/adapters/slack-classify.ts
@@ -7,7 +7,12 @@ import type { InboundMessage } from '@/channels/types'
 import { slackTsToMillis } from './slack-bot-time'
 import { encodeSlackReactionRef } from './slack-reactions'
 
-export type SlackInboundMessageEvent = SlackRTMMessageEvent
+export type SlackInboundMessageEvent = SlackRTMMessageEvent & {
+  channel_type?: string
+  is_mpim?: boolean
+}
+
+export type SlackConversationType = 'im' | 'mpim' | 'channel'
 
 export type InboundDropReason = 'self_author' | 'no_user' | 'slack_system_message' | 'empty_text' | 'pre_connect'
 
@@ -19,6 +24,7 @@ export type SlackInboundContext = {
   teamId: string
   selfUserId: string | null
   selfAliases?: readonly string[]
+  conversationType?: SlackConversationType
 }
 
 export function classifyInbound(
@@ -33,7 +39,8 @@ export function classifyInbound(
   if (context.selfUserId === null) return { kind: 'drop', reason: 'pre_connect' }
 
   const rawText = event.text ?? ''
-  const isDm = event.channel.startsWith('D')
+  const conversationType = classifyConversation(event, context.conversationType)
+  const isDm = conversationType === 'im'
   const workspace = isDm ? '@dm' : context.teamId
   const hasGroupMention = GROUP_MENTION_PATTERN.test(rawText)
   const isBotMention = hasGroupMention || rawText.includes(`<@${context.selfUserId}>`)
@@ -66,6 +73,18 @@ export function classifyInbound(
       ts: slackTsToMillis(event.ts),
     },
   }
+}
+
+function classifyConversation(
+  event: SlackInboundMessageEvent,
+  resolvedType: SlackConversationType | undefined,
+): SlackConversationType {
+  if (event.channel_type === 'im' || event.channel_type === 'mpim' || event.channel_type === 'channel') {
+    return event.channel_type
+  }
+  if (event.is_mpim === true) return 'mpim'
+  if (resolvedType !== undefined) return resolvedType
+  return event.channel.startsWith('D') ? 'im' : 'channel'
 }
 
 export function isRouteableSlackMessageSubtype(subtype: string | undefined): boolean {

--- a/src/channels/adapters/slack.test.ts
+++ b/src/channels/adapters/slack.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { SlackListener, SlackRTMMessageEvent } from 'agent-messenger/slack'
 
+import type { MembershipResolver } from '@/channels/membership'
 import type { ChannelRouter } from '@/channels/router'
 import { channelsSchema } from '@/channels/schema'
 import type { InboundMessage, OutboundCallback } from '@/channels/types'
@@ -72,12 +73,14 @@ function router(): ChannelRouter & {
   registered: string[]
   unregistered: string[]
   outbound?: OutboundCallback
+  membership?: MembershipResolver
 } {
   const routed: InboundMessage[] = []
   const registered: string[] = []
   const unregistered: string[] = []
   const r = {
     outbound: undefined as OutboundCallback | undefined,
+    membership: undefined as MembershipResolver | undefined,
     routed,
     registered,
     unregistered,
@@ -99,7 +102,10 @@ function router(): ChannelRouter & {
     unregisterHistory: (adapter: string) => unregistered.push(`history:${adapter}`),
     registerFetchAttachment: (adapter: string) => registered.push(`fetch:${adapter}`),
     unregisterFetchAttachment: (adapter: string) => unregistered.push(`fetch:${adapter}`),
-    registerMembership: (adapter: string) => registered.push(`membership:${adapter}`),
+    registerMembership: (adapter: string, resolver: MembershipResolver) => {
+      registered.push(`membership:${adapter}`)
+      r.membership = resolver
+    },
     unregisterMembership: (adapter: string) => unregistered.push(`membership:${adapter}`),
     registerReaction: (adapter: string) => registered.push(`reaction:${adapter}`),
     unregisterReaction: (adapter: string) => unregistered.push(`reaction:${adapter}`),
@@ -113,6 +119,7 @@ function router(): ChannelRouter & {
     registered: string[]
     unregistered: string[]
     outbound?: OutboundCallback
+    membership?: MembershipResolver
   }
 }
 
@@ -210,6 +217,52 @@ describe('createSlackAdapter', () => {
     expect(listener.stopped).toBe(true)
     expect(r.unregistered).toContain('outbound:slack')
     expect(r.unregistered).toContain('remove-reaction:slack')
+  })
+
+  test('G-prefixed conversations use Slack metadata to distinguish MPIMs from private channels', async () => {
+    for (const [channel, isMpim, expectedWorkspace] of [
+      ['G0MPIM', true, 'T0123456789'],
+      ['G0PRIVATE', false, 'T0123456789'],
+    ] as const) {
+      const r = router()
+      const listener = new FakeListener()
+      const adapter = createSlackAdapter({
+        router: r,
+        configRef: () => config,
+        logger: logger(),
+        credentialsStore: { getAccount: async () => account() },
+        createClient: () =>
+          fakeClient({
+            listDMs: async () => [{ id: channel, user: 'UUSER', is_mpim: isMpim }],
+            listChannelMembers: async () => ['UUSER', 'UOTHER', 'USELF'],
+          }),
+        createListener: () => listener as unknown as SlackListener,
+      })
+
+      await adapter.start()
+      listener.emit('message', {
+        type: 'message',
+        channel,
+        user: 'UUSER',
+        text: 'private conversation',
+        ts: '1770000000.000100',
+      } satisfies SlackRTMMessageEvent)
+      const membership = isMpim
+        ? await r.membership?.({ adapter: 'slack', workspace: 'T0123456789', chat: channel, thread: null })
+        : undefined
+      await adapter.stop()
+
+      expect(r.routed[0]?.workspace).toBe(expectedWorkspace)
+      if (isMpim) {
+        expect(membership).toEqual({
+          humans: 2,
+          bots: 1,
+          fetchedAt: expect.any(Number),
+          truncated: false,
+          humanMemberIds: ['UUSER', 'UOTHER'],
+        })
+      }
+    }
   })
 
   test('outbound sends messages through SlackClient.sendMessage', async () => {

--- a/src/channels/adapters/slack.ts
+++ b/src/channels/adapters/slack.ts
@@ -36,7 +36,7 @@ import { describeError } from './describe-error'
 import { createSlackAuthorResolver } from './slack-author-resolver'
 import { slackTsToMillis } from './slack-bot-time'
 import { createSlackChannelResolver } from './slack-channel-resolver'
-import { classifyInbound, type InboundDropReason } from './slack-classify'
+import { classifyInbound, type InboundDropReason, type SlackConversationType } from './slack-classify'
 import { createSlackUserEditMessageCallback } from './slack-edit'
 import { createSlackReactionCallback, createSlackRemoveReactionCallback } from './slack-reactions'
 
@@ -201,6 +201,7 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
   let started = false
   let inflightInbounds = 0
   let stopWaiters: Array<() => void> = []
+  const conversationTypes = new Map<string, SlackConversationType>()
 
   const channelResolver = createSlackChannelResolver({ client, teamNameRef: () => teamName })
   const authorResolver = createSlackAuthorResolver({ client })
@@ -226,6 +227,27 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
   const removeReactionCallback = createSlackRemoveReactionCallback({ client })
   const editMessageCallback = createSlackUserEditMessageCallback({ client })
 
+  const resolveConversationType = async (event: SlackRTMMessageEvent): Promise<SlackConversationType | undefined> => {
+    if (!event.channel.startsWith('G')) return undefined
+    const cached = conversationTypes.get(event.channel)
+    if (cached !== undefined) return cached
+    return await client.listDMs().then(
+      (conversations) => {
+        const type: SlackConversationType = conversations.some(
+          (conversation) => conversation.id === event.channel && conversation.is_mpim,
+        )
+          ? 'mpim'
+          : 'channel'
+        conversationTypes.set(event.channel, type)
+        return type
+      },
+      (error: unknown) => {
+        logger.warn(`[slack] conversation metadata failed channel=${event.channel}: ${describeError(error)}`)
+        return 'channel'
+      },
+    )
+  }
+
   const handleMessage = async (event: SlackRTMMessageEvent): Promise<void> => {
     inflightInbounds++
     try {
@@ -237,6 +259,7 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
         teamId,
         selfUserId,
         selfAliases: options.selfAliasesRef?.() ?? [],
+        conversationType: await resolveConversationType(event),
       })
       if (verdict.kind === 'drop') {
         logger.info(`[slack] dropped id=${event.ts} reason=${verdict.reason}${dropHint(verdict.reason)}`)


### PR DESCRIPTION
## Background

Extracted from #1200. This is slice 4/5, based on #1202's branch. Merge order: #1206 → #1203 → #1202 → this PR → #1200.

Slack conversation classification relied on the channel-ID prefix (`D…` = DM, everything else = team channel), which can't distinguish an MPIM (multi-person group DM, `G`-prefixed) from a regular private channel — both share the same prefix. That meant MPIM conversations couldn't get correct multi-human membership counts, so mention-trigger engagement and other membership-aware behavior didn't work right for group DMs, and the workspace/chat coordinates captured for provenance (consumed by #1202/#1203) weren't reliably accurate for them either.

## Summary

- `classifyInbound` (both the user-token `slack.ts` adapter and `slack-bot.ts`) now accepts explicit conversation-type metadata (`channel_type`, `is_mpim`) instead of relying only on the channel-ID prefix, correctly distinguishing `im` (true 1:1 DM), `mpim` (group DM), and `channel` (private channel).
- MPIM conversations classify into the team workspace with `isDm: false` and now get real multi-human membership resolution, so mention-trigger engagement and membership-based semantics work correctly for group DMs.
- The user-token adapter resolves conversation type via `client.listDMs()` metadata, caches it per channel, and falls back to `channel` (team workspace) if the lookup fails.
- A `G`-prefixed conversation with no resolvable metadata fails closed to the team workspace rather than guessing DM.

## What this does NOT do

- Does not add or change any authorization/isolation boundary — this is conversation-type classification for provenance and engagement accuracy, not an access-control mechanism.
- Does not directly change memory recall scope — it improves the accuracy of the workspace/chat coordinates that #1202's provenance enrichment and #1203's optional filters consume.

## Review notes

- Verify the fail-closed fallback in `resolveConversationType` (catch path returning `'channel'`) can't misclassify an MPIM as a plain DM elsewhere (e.g. `isDmChannelOrigin`).
- Membership resolver registration/invocation for MPIM needs to fire correctly on both adapters — see the new `MPIM classification drives real multi-human membership enumeration` (bot) and `G-prefixed conversations use Slack metadata to distinguish MPIMs from private channels` (user-token) tests.
