### PR TITLE
feat(security): define canonical secret denial

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -8,6 +8,7 @@ import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
 import { Type } from 'typebox'
 import { z } from 'zod'
 
+import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
 import { createPermissionService } from '@/permissions/permissions'
 import { createHookBus, defineTool, type PluginRegistry, type ToolResult } from '@/plugin'
 import { _resetBwrapAvailabilityCacheForTests, _resetRealProcProbeCacheForTests, SESSION_TMP_ROOT } from '@/sandbox'
@@ -84,6 +85,42 @@ describe('zodToToolParameters', () => {
 })
 
 describe('wrapPluginTool', () => {
+  test('blocks a declared filename operand that targets a canonical secret', async () => {
+    const calls: string[] = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ filename: z.string() }),
+      fileOperands: { input: ['filename'] },
+      async execute(args) {
+        calls.push(args.filename)
+        return { content: [] }
+      },
+    })
+    const hooks = createHookBus()
+    hooks.registerAll('security', '/agent', noopLogger, {
+      'tool.before': (event) =>
+        checkPrivateSurfaceReadGuard({
+          tool: event.tool,
+          args: event.args,
+          agentDir: '/agent',
+          hidden: { dirs: [], files: [] },
+        }),
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'reader',
+      toolName: 'plugin_reader',
+      agentDir: '/agent',
+      sessionId: 's',
+      logger: noopLogger,
+      hooks,
+    })
+
+    const result = await wrapped.execute('c', { filename: '/agent/.env' }, undefined, undefined, {} as never)
+
+    expect(calls).toEqual([])
+    expect(result).toMatchObject({ isError: true })
+  })
+
   test('passes parsed args to plugin execute and exposes ToolContext', async () => {
     const seen: { args: unknown; ctx: { sessionId: string; agentDir: string } }[] = []
     const tool = defineTool({

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -959,7 +959,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
   const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
   const guest: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'guest' }
 
-  test('trusted+ (tui→owner) has no masks, so bash runs unchanged even without bwrap', async () => {
+  test('trusted+ (tui→owner) still requires bwrap for canonical masks', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
       agentDir: '/agent',
@@ -968,8 +968,35 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       getOrigin: () => tui,
       permissions: createPermissionService(),
     })
-    await wrapped.execute('c', { command: 'echo hi' }, undefined, undefined, {} as never)
-    expect(record.command).toBe('echo hi')
+    await expect(
+      wrapped.execute('c', { command: 'cat /agent/.env' }, undefined, undefined, {} as never),
+    ).rejects.toThrow()
+    expect(record.command).toBeUndefined()
+  })
+
+  test('owner bash aborts before execution when a canonical target is symlinked', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'tc-unsafe-mask-symlink-'))
+    const record: { command?: string } = {}
+    try {
+      const outside = path.join(agentDir, 'outside')
+      await writeFile(outside, 'secret')
+      await symlink(outside, path.join(agentDir, '.env'))
+      await writeFile(path.join(agentDir, 'secrets.json'), '{}')
+      const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
+        agentDir,
+        sessionId: 's',
+        hooks: createHookBus(),
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+      })
+
+      await expect(
+        wrapped.execute('c', { command: 'echo should-not-run' }, undefined, undefined, {} as never),
+      ).rejects.toThrow(/mask target/i)
+      expect(record.command).toBeUndefined()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
   })
 
   test('guest needs masks; with bwrap unavailable the call fails closed and the underlying bash never runs', async () => {
@@ -999,7 +1026,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     expect(record.command).toBe('echo hi')
   })
 
-  test('a hook-set env overlay is stripped from args and never reaches the command (non-sandboxed)', async () => {
+  test('a hook-set env overlay is stripped from args before sandbox preparation', async () => {
     const record: { command?: string } = {}
     const hooks = createHookBus()
     hooks.registerAll('env-setter', '/agent', noopLogger, {
@@ -1015,8 +1042,8 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       getOrigin: () => tui,
       permissions: createPermissionService(),
     })
-    await wrapped.execute('c', args as never, undefined, undefined, {} as never)
-    expect(record.command).toBe('gh pr view -R acme/widgets')
+    await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow()
+    expect(record.command).toBeUndefined()
     expect(args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
@@ -1040,7 +1067,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       getOrigin: () => tui,
       permissions: createPermissionService(),
     })
-    await wrapped.execute('c', args as never, undefined, undefined, {} as never)
+    await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow()
     expect(seenInHook).toBeUndefined()
   })
 })
@@ -1077,7 +1104,7 @@ describe('wrapBuiltinToolDefinition subagent bash policy (capability fence, role
     expect(record.command).toBeUndefined()
   })
 
-  test('readonly-reviewer policy lets a read-only command through (and the role sandbox still leaves an owner command unchanged)', async () => {
+  test('readonly-reviewer policy lets a read-only command reach mandatory sandbox preparation', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
       agentDir: '/agent',
@@ -1087,11 +1114,11 @@ describe('wrapBuiltinToolDefinition subagent bash policy (capability fence, role
       permissions: createPermissionService(),
       bashPolicy: { kind: 'readonly-reviewer' },
     })
-    await wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)
-    expect(record.command).toBe('git status')
+    await expect(wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)).rejects.toThrow()
+    expect(record.command).toBeUndefined()
   })
 
-  test('no bashPolicy leaves bash unrestricted (default subagents keep today behavior)', async () => {
+  test('no bashPolicy still applies the mandatory owner sandbox', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
       agentDir: '/agent',
@@ -1100,8 +1127,10 @@ describe('wrapBuiltinToolDefinition subagent bash policy (capability fence, role
       getOrigin: () => ownerTui,
       permissions: createPermissionService(),
     })
-    await wrapped.execute('c', { command: 'git push origin HEAD' }, undefined, undefined, {} as never)
-    expect(record.command).toBe('git push origin HEAD')
+    await expect(
+      wrapped.execute('c', { command: 'git push origin HEAD' }, undefined, undefined, {} as never),
+    ).rejects.toThrow()
+    expect(record.command).toBeUndefined()
   })
 })
 
@@ -1161,7 +1190,7 @@ describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', (
     expect(record.path).toBe(`${SESSION_TMP_ROOT}/sid42/review.json`)
   })
 
-  test('an unsandboxed role (tui→owner) writes the real /tmp path untouched', async () => {
+  test('an owner write uses the session scratch backing path', async () => {
     const record: { path?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeWrite(record), {
       agentDir: '/agent',
@@ -1171,10 +1200,10 @@ describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', (
       permissions: createPermissionService(),
     })
     await wrapped.execute('c', { path: '/tmp/review.json', content: '{}' } as never, undefined, undefined, {} as never)
-    expect(record.path).toBe('/tmp/review.json')
+    expect(record.path).toBe(`${SESSION_TMP_ROOT}/sid42/review.json`)
   })
 
-  test('an unsandboxed role (tui→owner) reads the real /tmp path untouched', async () => {
+  test('an owner read uses the session scratch backing path', async () => {
     const record: { path?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeRead(record), {
       agentDir: '/agent',
@@ -1184,7 +1213,7 @@ describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', (
       permissions: createPermissionService(),
     })
     await wrapped.execute('c', { path: '/tmp/review.json' } as never, undefined, undefined, {} as never)
-    expect(record.path).toBe('/tmp/review.json')
+    expect(record.path).toBe(`${SESSION_TMP_ROOT}/sid42/review.json`)
   })
 
   test('a non-/tmp write is left untouched even for a sandboxed role', async () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -36,6 +36,7 @@ import type {
 } from '@/plugin'
 import {
   buildSandboxedCommand,
+  canWriteAgentRootInSandbox,
   canMountRealProc,
   commandNeedsRealProc,
   DEFAULT_SANDBOX_ENV,
@@ -530,16 +531,15 @@ async function applyBashSandbox(
   if (typeof command !== 'string') return
 
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
-  if (dirs.length === 0 && files.length === 0) return
 
   const sandboxEnvOverlay = buildRoleScopedConfigEnv(agentDir, dirs, envOverlay)
 
-  await ensureBwrapAvailable()
   // bwrap's --ro-bind-data/--tmpfs mask ops abort when the target does not exist
   // on the (read-only, virtiofs/OrbStack) agent-folder bind. Materialize the mask
   // targets on the real host FS first; the full {dirs, files} still feeds
   // subtractMasked below so a masked path is never re-exposed by a later RW bind.
   const maskTargets = await ensureHiddenMaskTargets({ dirs, files })
+  await ensureBwrapAvailable()
   // Per-session /tmp: bind this session's scratch dir over the default
   // --tmpfs /tmp so writes survive across the role's sandboxed bash calls AND
   // match what the write/edit wrapper redirected a /tmp path to. The bind is
@@ -576,9 +576,11 @@ async function applyBashSandbox(
   // masked dir (e.g. a guest's workspace/ when core.hooksPath=workspace/hooks)
   // would re-expose the hidden real dir. A masked path is already non-writable
   // for this role, so it needs no protection anyway.
-  const protectedZones = writable.dirs.includes(join(agentDir, '.git'))
-    ? subtractMasked(await resolveProtectedZones(agentDir), { dirs, files })
-    : { dirs: [], files: [] }
+  const writableRoot = canWriteAgentRootInSandbox(permissions, origin)
+  const protectedZones =
+    writableRoot || writable.dirs.includes(join(agentDir, '.git'))
+      ? subtractMasked(await resolveProtectedZones(agentDir), { dirs, files })
+      : { dirs: [], files: [] }
   // A recognized standalone `bun add`/`bun install` needs DIRECTORY write at the
   // root (node_modules/ + temp lockfile), which the narrow carve-out model can't
   // grant. Widen to an RW root for that command class only, then re-hide secrets
@@ -633,7 +635,9 @@ async function applyBashSandbox(
           protected: packageInstall.protected,
           blockedCreation: { files: packageInstall.blockedCreation },
         }
-      : { masks: maskTargets, writable, protected: protectedZones }),
+      : writableRoot
+        ? { writableRoot: { dir: agentDir }, masks: maskTargets, protected: protectedZones }
+        : { masks: maskTargets, writable, protected: protectedZones }),
     symlinks,
     network: 'inherit',
     cwd: agentDir,

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -14,10 +14,10 @@ import githubCliAuthPlugin from './index'
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
 
-// resolveHiddenPaths checks fs.see.private + fs.see.secrets; granting both
-// yields empty masks => runsUnsandboxed() true, matching owner/trusted. The
-// default noopPermissionService grants nothing => sandboxed (member/guest).
-const unsandboxedPermissions: PermissionService = {
+// fs.see.secrets authorizes runtime-owned PAT injection for owner/trusted even
+// though canonical credential files remain masked. The default permission
+// service grants nothing, matching member/guest credential withholding.
+const credentialEntitledPermissions: PermissionService = {
   ...noopPermissionService,
   has: (_origin, permission) => permission === 'fs.see.private' || permission === 'fs.see.secrets',
 }
@@ -209,7 +209,7 @@ describe('github-cli-auth plugin', () => {
     expect(resolverCalled).toBe(false)
   })
 
-  test('classic PAT (unsandboxed): injects the PAT for a repo-targeting gh, does not mint', async () => {
+  test('classic PAT (credential-entitled): injects the PAT for a repo-targeting gh, does not mint', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
     let resolverCalled = false
     const hook = await hookFor(
@@ -218,7 +218,7 @@ describe('github-cli-auth plugin', () => {
         return { kind: 'token', token: 'ghs_minted' }
       },
       true,
-      { permissions: unsandboxedPermissions },
+      { permissions: credentialEntitledPermissions },
     )
     const event = bashEvent('gh pr view -R acme/widgets')
 
@@ -226,15 +226,14 @@ describe('github-cli-auth plugin', () => {
 
     expect(result).toBeUndefined()
     expect(event.args.command).toBe('gh pr view -R acme/widgets')
-    // Unsandboxed: the PAT already rides inherited env; we re-assert it in the
-    // overlay (no minting) so behavior is explicit and matches the git path.
+    // Runtime-owned injection keeps the PAT out of the command and raw files.
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghp_classic' })
     expect(resolverCalled).toBe(false)
   })
 
-  test('classic PAT (unsandboxed): non-repo-targeting gh passes through (nothing to inject)', async () => {
+  test('classic PAT (credential-entitled): non-repo-targeting gh passes through', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
-    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: unsandboxedPermissions })
+    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: credentialEntitledPermissions })
     const event = bashEvent('gh pr view 12')
 
     const result = await hook(event, hookCtx)
@@ -244,7 +243,7 @@ describe('github-cli-auth plugin', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
-  test('fine-grained PAT (unsandboxed): leaves command as-is, injects the PAT, does not mint', async () => {
+  test('fine-grained PAT (credential-entitled): leaves command as-is, injects the PAT, does not mint', async () => {
     process.env.GH_TOKEN = 'github_pat_xyz'
     let resolverCalled = false
     const hook = await hookFor(
@@ -253,7 +252,7 @@ describe('github-cli-auth plugin', () => {
         return { kind: 'token', token: 'ghs_minted' }
       },
       true,
-      { permissions: unsandboxedPermissions },
+      { permissions: credentialEntitledPermissions },
     )
     const event = bashEvent('gh pr view -R acme/widgets')
 
@@ -277,7 +276,7 @@ describe('github-cli-auth plugin', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toEqual({ GH_TOKEN: 'ghs_minted' })
   })
 
-  test('classic PAT (unsandboxed): strips a redundant -R on gh api, injects the PAT, no mint', async () => {
+  test('classic PAT (credential-entitled): strips a redundant -R on gh api, injects the PAT, no mint', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
     let resolverCalled = false
     const hook = await hookFor(
@@ -286,7 +285,7 @@ describe('github-cli-auth plugin', () => {
         return { kind: 'token', token: 'ghs_minted' }
       },
       true,
-      { permissions: unsandboxedPermissions },
+      { permissions: credentialEntitledPermissions },
     )
     const event = bashEvent('gh api repos/acme/widgets/issues -R acme/widgets')
 
@@ -298,7 +297,7 @@ describe('github-cli-auth plugin', () => {
     expect(resolverCalled).toBe(false)
   })
 
-  test('fine-grained PAT (unsandboxed): strips a redundant -R on gh api, injects the PAT, no mint', async () => {
+  test('fine-grained PAT (credential-entitled): strips a redundant -R on gh api, injects the PAT, no mint', async () => {
     process.env.GH_TOKEN = 'github_pat_xyz'
     let resolverCalled = false
     const hook = await hookFor(
@@ -307,7 +306,7 @@ describe('github-cli-auth plugin', () => {
         return { kind: 'token', token: 'ghs_minted' }
       },
       true,
-      { permissions: unsandboxedPermissions },
+      { permissions: credentialEntitledPermissions },
     )
     const event = bashEvent('gh api repos/acme/widgets/issues --repo=acme/widgets')
 
@@ -640,7 +639,7 @@ describe('github-cli-auth plugin — git path', () => {
     expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
   })
 
-  test('classic PAT (unsandboxed): injects GIT_ASKPASS with the PAT, does not mint', async () => {
+  test('classic PAT (credential-entitled): injects GIT_ASKPASS with the PAT, does not mint', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
     let resolverCalled = false
     const hook = await hookFor(
@@ -649,7 +648,7 @@ describe('github-cli-auth plugin — git path', () => {
         return { kind: 'token', token: 'ghs_minted' }
       },
       true,
-      { permissions: unsandboxedPermissions },
+      { permissions: credentialEntitledPermissions },
     )
     const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
@@ -663,7 +662,7 @@ describe('github-cli-auth plugin — git path', () => {
     expect(resolverCalled).toBe(false)
   })
 
-  test('fine-grained PAT (unsandboxed): injects GIT_ASKPASS with the PAT, does not mint', async () => {
+  test('fine-grained PAT (credential-entitled): injects GIT_ASKPASS with the PAT, does not mint', async () => {
     process.env.GH_TOKEN = 'github_pat_xyz'
     let resolverCalled = false
     const hook = await hookFor(
@@ -672,7 +671,7 @@ describe('github-cli-auth plugin — git path', () => {
         return { kind: 'token', token: 'ghs_minted' }
       },
       true,
-      { permissions: unsandboxedPermissions },
+      { permissions: credentialEntitledPermissions },
     )
     const event = bashEvent('git clone https://github.com/acme/widgets.git')
 

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -1,7 +1,7 @@
 import { TYPECLAW_INTERNAL_BASH_ENV } from '@/agent/plugin-tools'
 import type { SessionOrigin } from '@/agent/session-origin'
+import { CORE_PERMISSIONS } from '@/permissions/builtins'
 import { definePlugin } from '@/plugin'
-import { resolveHiddenPaths } from '@/sandbox'
 
 import { createApproveIdempotencyGuard } from './approve-idempotency'
 import { createGithubEffectiveApprovalResolver, createGithubHeadShaResolver } from './effective-approval'
@@ -17,16 +17,13 @@ export default definePlugin({
     const resolveTokenForRepo = ctx.github.resolveTokenForRepo
     const hasAppTokenResolver = ctx.github.hasAppTokenResolver
 
-    // A .env PAT is broad and long-lived, so it may only reach bash that runs
-    // WITHOUT bwrap's --clearenv — otherwise a low-trust, stranger-drivable
-    // sandbox could exfiltrate it. We gate on the SAME signal applyBashSandbox
-    // uses (resolveHiddenPaths empty => unsandboxed) rather than a role name, so
-    // the credential policy can never diverge from the actual sandbox decision
-    // and custom roles follow their real fs.see.secrets / security.bypass grant.
-    const runsUnsandboxed = (origin: SessionOrigin | undefined): boolean => {
-      const { dirs, files } = resolveHiddenPaths(ctx.permissions, origin, ctx.agentDir)
-      return dirs.length === 0 && files.length === 0
-    }
+    // Canonical credentials remain masked for every role, including owner and
+    // trusted. Privileged roles may still use a PAT through this runtime-owned
+    // command overlay, gated by the existing credential capability rather than
+    // by whether the sandbox happens to render path masks.
+    const canUsePat = (origin: SessionOrigin | undefined): boolean =>
+      ctx.permissions.has(origin, CORE_PERMISSIONS.fsSeeSecrets) ||
+      ctx.permissions.has(origin, 'security.bypass.medium')
 
     // The PAT is in the container env but stripped by --clearenv for this role,
     // and a PAT is not re-mintable per repo, so there is no token to inject. Tell
@@ -199,7 +196,7 @@ export default definePlugin({
         // overlay so behavior is explicit and matches the git path; otherwise we
         // pass through. The App-oriented missing-repo / multi-owner BLOCK does
         // NOT apply — a PAT needs no per-repo mint — so we never surface it here.
-        if (runsUnsandboxed(event.origin)) {
+        if (canUsePat(event.origin)) {
           if (decision.kind === 'inject') {
             event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
               GH_TOKEN: process.env.GH_TOKEN as string,
@@ -266,7 +263,7 @@ export default definePlugin({
       // withheld (env cleared): mint an App token instead if available, else
       // block with guidance rather than letting git fail silently. App auth must
       // still mint for sandboxed roles even when a PAT is present.
-      const useEnvPat = isPat && runsUnsandboxed(event.origin)
+      const useEnvPat = isPat && canUsePat(event.origin)
       // Sandboxed PAT: the env is cleared, so the PAT can't reach git. Mint an
       // App token instead when a minter is live (a PAT must NOT suppress it);
       // otherwise block with guidance below rather than fail silently.

--- a/src/bundled-plugins/researcher/write-report.ts
+++ b/src/bundled-plugins/researcher/write-report.ts
@@ -51,6 +51,7 @@ Write to \`public/\` instead of \`workspace/\` when your resolved role lacks \`f
         .describe('Absolute path: <agent>/workspace/research-<slug>.md or <agent>/public/research-<slug>.md'),
       content: z.string().describe('The full markdown report body.'),
     }),
+    fileOperands: { output: ['path'] },
     async execute(args: WriteReportArgs, ctx: ToolContext) {
       if (writtenBySession.has(ctx.sessionId)) {
         throw new Error('A report has already been written for this session. You may write exactly one report.')

--- a/src/bundled-plugins/security/index.test.ts
+++ b/src/bundled-plugins/security/index.test.ts
@@ -304,6 +304,56 @@ describe('security plugin wiring', () => {
     expect(result).toBeUndefined()
   })
 
+  test('permissions: owner cannot bypass canonical agent secret files, even with an acknowledgement', async () => {
+    const hook = await toolBeforeHookWith(prodPermissionService())
+    const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
+
+    for (const event of [
+      toolEvent('read', { path: '.env', acknowledgeGuards: { secretExfilRead: true } }),
+      toolEvent('grep', { pattern: 'token', path: '/agent/secrets.json' }),
+      toolEvent('find', { path: '.', pattern: 'secrets.json' }),
+      toolEvent('ls', { path: '/agent/.env' }),
+    ]) {
+      const result = await hook({ ...event, origin: tui }, hookContext('/agent'))
+      expect(result?.block).toBe(true)
+      expect(result?.reason).toContain('privateSurfaceRead')
+    }
+  })
+
+  test('permissions: owner keeps existing bypass semantics for unrelated credential-like files', async () => {
+    const hook = await toolBeforeHookWith(prodPermissionService())
+    const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
+
+    expect(
+      await hook({ ...toolEvent('read', { path: 'config/.env.local' }), origin: tui }, hookContext('/agent')),
+    ).toBeUndefined()
+    expect(
+      await hook({ ...toolEvent('read', { path: 'fixtures/credentials.json' }), origin: tui }, hookContext('/agent')),
+    ).toBeUndefined()
+  })
+
+  test('permissions: trusted cannot bypass canonical files but still bypasses unrelated credential-like files', async () => {
+    const permissions = prodPermissionService({
+      trusted: { match: [{ kind: 'channel', platform: 'slack', workspace: 'T0', author: 'U_TRUSTED' }] },
+    })
+    const hook = await toolBeforeHookWith(permissions)
+    const origin: SessionOrigin = {
+      kind: 'channel',
+      adapter: 'slack-bot',
+      workspace: 'T0',
+      chat: 'C0',
+      thread: null,
+      lastInboundAuthorId: 'U_TRUSTED',
+    }
+
+    const canonical = await hook({ ...toolEvent('read', { path: 'secrets.json' }), origin }, hookContext('/agent'))
+    expect(canonical?.block).toBe(true)
+    expect(canonical?.reason).toContain('privateSurfaceRead')
+    expect(
+      await hook({ ...toolEvent('read', { path: 'fixtures/credentials.json' }), origin }, hookContext('/agent')),
+    ).toBeUndefined()
+  })
+
   test('permissions: TUI owner BYPASSES `git push` (medium tier; owner carries bypass.medium by default under the role-tower model)', async () => {
     const svc = prodPermissionService()
     const hook = await toolBeforeHookWith(svc)
@@ -519,7 +569,9 @@ describe('security plugin wiring', () => {
     const tui: SessionOrigin = { kind: 'tui', sessionId: 's_owner_lm' }
 
     expect(await hook({ ...toolEvent('bash', { command: 'env' }), origin: tui }, hookContext('/agent'))).toBeUndefined()
-    expect(await hook({ ...toolEvent('read', { path: '.env' }), origin: tui }, hookContext('/agent'))).toBeUndefined()
+    expect(
+      await hook({ ...toolEvent('read', { path: 'config/.env.local' }), origin: tui }, hookContext('/agent')),
+    ).toBeUndefined()
     expect(
       await hook(
         { ...toolEvent('web_fetch', { url: 'http://169.254.169.254/latest/meta-data/' }), origin: tui },

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -201,10 +201,9 @@ export default definePlugin({
                 SECURITY_PERMISSIONS.bypassSecretExfilRead,
                 GUARD_SECRET_EXFIL_READ_SEVERITY,
               ),
-          // Role-derived, not severity-bypassed: resolveHiddenPaths already
-          // returns an empty deny-list for roles that may see the surface, so
-          // there is no canBypass wrapper. Mirrors the bash sandbox masks onto
-          // the non-bash read/grep/find/ls/edit/write builtins.
+          // Not severity-bypassed: private directories remain role-derived,
+          // while canonical credential-store denial is unconditional. Mirrors
+          // the bash masks onto every non-bash path-bearing tool.
           checkPrivateSurfaceReadGuard({
             tool: event.tool,
             args: event.args,

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
+import { linkSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
 import { realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { homedir } from 'node:os'
 import path from 'node:path'
 
 import type { HiddenPaths } from '@/sandbox'
@@ -11,9 +12,9 @@ import { checkPrivateSurfaceReadGuard } from './private-surface-read'
 const AGENT = '/agent'
 const guestHidden: HiddenPaths = {
   dirs: ['/agent/workspace', '/agent/memory', '/agent/sessions'],
-  files: ['/agent/.env', '/agent/secrets.json'],
+  files: ['/agent/.env', '/agent/secrets.json', '/agent/auth.json'],
 }
-const emptyHidden: HiddenPaths = { dirs: [], files: [] }
+const privilegedHidden: HiddenPaths = { dirs: [], files: [] }
 
 function check(tool: string, args: Record<string, unknown>, hidden: HiddenPaths = guestHidden) {
   return checkPrivateSurfaceReadGuard({ tool, args, agentDir: AGENT, hidden })
@@ -88,18 +89,71 @@ describe('private-surface-read guard — free-text field scoping (no false posit
     expect(check('some_new_plugin_tool', { nested: { target: 'workspace/y' } })?.block).toBe(true)
   })
 
-  test('does not block an attachment display filename that equals a hidden-dir name', () => {
-    expect(
-      check('channel_send', {
-        text: 'see attached',
-        attachments: [{ path: 'public/report.pdf', filename: 'memory' }],
-      }),
-    ).toBeUndefined()
-    expect(check('channel_reply', { attachments: [{ path: 'public/x.md', filename: 'sessions' }] })).toBeUndefined()
-    expect(check('channel_fetch_attachment', { attachment_id: 1, filename: 'workspace' })).toBeUndefined()
+  test('scans filename/filepath keys, file URIs, and nested shapes without scanning prose', () => {
+    expect(check('mcp_reader', { input: { filename: 'file:///agent/memory/x.md' } })?.block).toBe(true)
+    expect(check('plugin_reader', { payload: [{ filePath: '/agent/sessions/x.jsonl' }] })?.block).toBe(true)
+    expect(check('plugin_reader', { description: 'file:///agent/memory/x.md is an example' })?.block).toBe(true)
   })
 
-  test('STILL blocks a hidden attachments[].path even when filename is exempt', () => {
+  test('file URIs override free-text exemptions, including nested MCP url arguments', () => {
+    expect(
+      check('mcp_call', {
+        server: 'files',
+        tool: 'read',
+        args: { nested: { url: 'file:///agent/secrets.json' } },
+      })?.block,
+    ).toBe(true)
+    expect(check('plugin_tool', { prompt: 'file:///agent/.env' })?.block).toBe(true)
+  })
+
+  test('unconditionally blocks virtual and process-backed filesystems and effective aliases', () => {
+    for (const candidate of ['/proc/self/environ', '/sys/kernel/notes', '/dev/fd/0', '/run/secrets/token']) {
+      expect(check('channel_send', { attachments: [{ path: candidate }] }, privilegedHidden)?.block).toBe(true)
+    }
+  })
+
+  test('recognizes synthetic POSIX, file URI, Windows-drive, and UNC private paths without host path semantics', () => {
+    const windowsHidden: HiddenPaths = {
+      dirs: ['C:\\agent\\memory', '\\\\server\\agent\\sessions'],
+      files: ['C:\\agent\\secrets.json'],
+    }
+    expect(check('read', { path: '/agent/memory/x.md' })?.block).toBe(true)
+    expect(check('read', { path: 'file:///agent/secrets.json' })?.block).toBe(true)
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'read',
+        args: { path: 'C:\\agent\\secrets.json' },
+        agentDir: 'C:\\agent',
+        hidden: windowsHidden,
+      })?.block,
+    ).toBe(true)
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'read',
+        args: { path: '\\\\server\\agent\\sessions\\turn.jsonl' },
+        agentDir: '\\\\server\\agent',
+        hidden: windowsHidden,
+      })?.block,
+    ).toBe(true)
+  })
+
+  test('reports synthetic /proc denial before host filesystem lookup', () => {
+    const result = check('channel_send', { attachments: [{ path: '/proc/self/environ' }] }, privilegedHidden)
+    expect(result?.reason).toMatch(/virtual|process-backed/i)
+  })
+
+  test('treats display filenames as metadata rather than file operands', () => {
+    expect(check('channel_send', { attachments: [{ path: 'public/x', filename: 'secrets.json' }] })).toBeUndefined()
+    expect(check('channel_reply', { attachments: [{ path: 'public/x', filename: '.env' }] })).toBeUndefined()
+    expect(check('channel_fetch_attachment', { attachment_id: 1, filename: 'auth.json' })).toBeUndefined()
+    expect(check('channel_reply', { attachments: [{ path: 'public/x.md', filename: 'report.pdf' }] })).toBeUndefined()
+  })
+
+  test('treats filename as a path for tools where it is not declared display metadata', () => {
+    expect(check('plugin_reader', { filename: '/agent/.env' })?.block).toBe(true)
+  })
+
+  test('still blocks a hidden attachments[].path when the filename itself is public', () => {
     expect(
       check('channel_send', {
         attachments: [{ path: 'memory/leak.md', filename: 'report.pdf' }],
@@ -173,16 +227,36 @@ describe('private-surface-read guard — traversal + scope', () => {
     expect(check('write', { path: 'secrets.json' })?.block).toBe(true)
     expect(check('look_at', { images: [{ path: '/agent/secrets.json' }] })?.block).toBe(true)
     expect(check('channel_send', { attachments: [{ path: '/agent/.env' }] })?.block).toBe(true)
+    expect(check('read', { path: '/agent/auth.json' })?.block).toBe(true)
   })
 
   test('a secret file matches exactly, not by prefix (.env does not block .envrc-style siblings)', () => {
     expect(check('read', { path: '/agent/.environment' })).toBeUndefined()
     expect(check('read', { path: '/agent/secrets.json.bak' })).toBeUndefined()
+    expect(check('read', { path: '/agent/auth.json.bak' })).toBeUndefined()
   })
 
-  test('empty deny-list (trusted+) is a no-op for every tool', () => {
-    expect(check('read', { path: 'workspace/notes.md' }, emptyHidden)).toBeUndefined()
-    expect(check('look_at', { images: [{ path: 'workspace/x' }] }, emptyHidden)).toBeUndefined()
+  test('privileged roles may read private directories but never canonical agent secret files', () => {
+    expect(check('read', { path: 'workspace/notes.md' }, privilegedHidden)).toBeUndefined()
+    expect(check('look_at', { images: [{ path: 'workspace/x' }] }, privilegedHidden)).toBeUndefined()
+    expect(check('read', { path: '.env' }, privilegedHidden)?.block).toBe(true)
+    expect(check('grep', { pattern: 'token', path: '/agent/secrets.json' }, privilegedHidden)?.block).toBe(true)
+    expect(check('find', { path: '.', pattern: 'secrets.json' }, privilegedHidden)?.block).toBe(true)
+    expect(check('ls', { path: '/agent/.env' }, privilegedHidden)?.block).toBe(true)
+    expect(check('read', { path: '/agent/auth.json' }, privilegedHidden)?.block).toBe(true)
+    expect(
+      check('read', { path: '/agent/workspace/.agent-messenger/slack-credentials.json' }, privilegedHidden)?.block,
+    ).toBe(true)
+    expect(check('read', { path: '/agent/workspace/.config/gws/credentials.json' }, privilegedHidden)?.block).toBe(true)
+    expect(check('read', { path: '/agent/.typeclaw/home/.codex/auth.json' }, privilegedHidden)?.block).toBe(true)
+  })
+
+  test('canonical HOME credential profiles are denied to privileged non-bash tools', () => {
+    expect(check('read', { path: path.join(homedir(), '.gitconfig') }, privilegedHidden)?.block).toBe(true)
+    expect(check('read', { path: path.join(homedir(), '.codex', 'auth.json') }, privilegedHidden)?.block).toBe(true)
+    expect(check('read', { path: path.join(homedir(), '.claude', '.credentials.json') }, privilegedHidden)?.block).toBe(
+      true,
+    )
   })
 
   test('bash is never blocked here (its access is contained by the bwrap sandbox)', () => {
@@ -208,7 +282,7 @@ describe('private-surface-read guard — symlink bypass defense', () => {
       agentDir,
       hidden: {
         dirs: ['workspace', 'memory', 'sessions'].map((d) => path.join(agentDir, d)),
-        files: ['.env', 'secrets.json'].map((f) => path.join(agentDir, f)),
+        files: ['.env', 'secrets.json', 'auth.json'].map((f) => path.join(agentDir, f)),
       },
     }
   }
@@ -217,6 +291,67 @@ describe('private-surface-read guard — symlink bypass defense', () => {
     const { agentDir, hidden } = makeAgentWithSymlinks()
     const result = checkPrivateSurfaceReadGuard({ tool: 'read', args: { path: 'public/env-link' }, agentDir, hidden })
     expect(result?.block).toBe(true)
+  })
+
+  test('blocks a privileged non-bash read through a symlink to a canonical secret file', () => {
+    const { agentDir } = makeAgentWithSymlinks()
+    const result = checkPrivateSurfaceReadGuard({
+      tool: 'read',
+      args: { path: 'public/env-link' },
+      agentDir,
+      hidden: privilegedHidden,
+    })
+    expect(result?.block).toBe(true)
+  })
+
+  test('blocks a privileged non-bash read through a hardlink alias to a canonical secret file', () => {
+    const { agentDir } = makeAgentWithSymlinks()
+    const alias = path.join(agentDir, 'public', 'env-hardlink')
+    linkSync(path.join(agentDir, '.env'), alias)
+    const result = checkPrivateSurfaceReadGuard({
+      tool: 'read',
+      args: { path: alias },
+      agentDir,
+      hidden: privilegedHidden,
+    })
+    expect(result?.block).toBe(true)
+  })
+
+  test('blocks a privileged hardlink alias to historical root auth.json', () => {
+    const { agentDir } = makeAgentWithSymlinks()
+    writeFileSync(path.join(agentDir, 'auth.json'), 'legacy-secret')
+    const alias = path.join(agentDir, 'public', 'auth-hardlink')
+    linkSync(path.join(agentDir, 'auth.json'), alias)
+    const result = checkPrivateSurfaceReadGuard({
+      tool: 'read',
+      args: { path: alias },
+      agentDir,
+      hidden: privilegedHidden,
+    })
+    expect(result?.block).toBe(true)
+  })
+
+  test('blocks a hardlink alias of a file below a denied directory', () => {
+    const { agentDir } = makeAgentWithSymlinks()
+    const source = path.join(agentDir, 'workspace', '.agent-messenger', 'nested-token')
+    mkdirSync(path.dirname(source), { recursive: true })
+    writeFileSync(source, 'secret')
+    const alias = path.join(agentDir, 'public', 'nested-hardlink')
+    linkSync(source, alias)
+    expect(
+      checkPrivateSurfaceReadGuard({ tool: 'read', args: { path: alias }, agentDir, hidden: privilegedHidden })?.block,
+    ).toBe(true)
+  })
+
+  test('allows unrelated public hardlinks', () => {
+    const { agentDir } = makeAgentWithSymlinks()
+    const source = path.join(agentDir, 'public', 'report-a.md')
+    const alias = path.join(agentDir, 'public', 'report-b.md')
+    writeFileSync(source, 'public')
+    linkSync(source, alias)
+    expect(
+      checkPrivateSurfaceReadGuard({ tool: 'read', args: { path: alias }, agentDir, hidden: privilegedHidden }),
+    ).toBeUndefined()
   })
 
   test('blocks a non-bash read THROUGH a public/ symlink pointing at a hidden DIR', () => {
@@ -240,6 +375,19 @@ describe('private-surface-read guard — symlink bypass defense', () => {
       hidden,
     })
     expect(result?.block).toBe(true)
+  })
+
+  test.skipIf(process.platform !== 'linux')('blocks an effective public symlink alias into procfs', () => {
+    const { agentDir } = makeAgentWithSymlinks()
+    symlinkSync('/proc', path.join(agentDir, 'public', 'proc-link'))
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'read',
+        args: { path: 'public/proc-link/self/environ' },
+        agentDir,
+        hidden: privilegedHidden,
+      })?.block,
+    ).toBe(true)
   })
 
   test('still ALLOWS a genuine non-symlink file inside public/', () => {

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -1,7 +1,15 @@
-import { realpathSync } from 'node:fs'
+import { readdirSync, realpathSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-import type { HiddenPaths } from '@/sandbox'
+import {
+  CANONICAL_AGENT_SECRET_DIRS,
+  CANONICAL_AGENT_SECRET_FILES,
+  CANONICAL_HOME_SECRET_DIRS,
+  CANONICAL_HOME_SECRET_FILES,
+  type HiddenPaths,
+} from '@/sandbox'
 
 import type { SecurityBlock } from '../policy'
 
@@ -13,9 +21,11 @@ export const GUARD_PRIVATE_SURFACE_READ = 'privateSurfaceRead'
 // the day it ships without a whitelist edit. web_search/web_fetch take URLs, not
 // local paths, and the path-plausibility filter keeps their args from matching.
 const UNSCANNED_TOOLS = new Set(['bash'])
+const VIRTUAL_FILESYSTEM_ROOTS = ['/proc', '/sys', '/dev', '/run'] as const
 
 // The bash sandbox hides the role's private surface — the working DIRECTORIES
-// (workspace/, memory/, sessions/) and the secret FILES (.env, secrets.json) —
+// (workspace/, memory/, sessions/), unconditional credential directories, and
+// secret FILES (.env, secrets.json, auth.json) —
 // via bwrap masks, but every non-bash tool runs in the main process, outside
 // any sandbox. find_entry, look_at, and the channel attachment tools all read
 // files by a caller-supplied path, so without a guard a restricted role could
@@ -26,11 +36,11 @@ const UNSCANNED_TOOLS = new Set(['bash'])
 // It covers the full deny-list rather than delegating secret files to the
 // secretExfilRead guard: that guard only inspects read/grep/find/ls (not
 // edit/write/look_at/channel_send) and is acknowledgement-bypassable, so
-// delegating would leave .env/secrets.json reachable through the uncovered
+// delegating would leave canonical credential files reachable through uncovered
 // tools — exactly the gap the bash masks close. secretExfilRead remains as
 // independent defense in depth for the four tools it does cover.
 //
-// Posture is FAIL-CLOSED for restricted roles: it does not whitelist a known
+// Posture is FAIL-CLOSED: it does not whitelist a known
 // set of tools (that fails open the moment a new reader is added). It scans
 // every arg of every non-bash tool — recursively, since paths hide in nested
 // shapes like look_at's images[].path and channel_send's attachments[].path —
@@ -44,8 +54,23 @@ export function checkPrivateSurfaceReadGuard(options: {
 }): SecurityBlock | undefined {
   const { tool, args, agentDir, hidden } = options
   if (UNSCANNED_TOOLS.has(tool)) return undefined
-  const deniedDirs = hidden.dirs
-  const deniedFiles = hidden.files
+  const deniedDirs = [
+    ...new Set([
+      ...hidden.dirs,
+      ...CANONICAL_AGENT_SECRET_DIRS.map((dir) => path.join(agentDir, dir)),
+      ...CANONICAL_HOME_SECRET_DIRS.map((dir) => path.join(homedir(), dir)),
+    ]),
+  ]
+  // Keep these runtime-owned credential stores independent of role-derived
+  // visibility so a privileged role or partially-wired caller cannot turn raw
+  // credentials into model context.
+  const deniedFiles = [
+    ...new Set([
+      ...hidden.files,
+      ...CANONICAL_AGENT_SECRET_FILES.map((file) => path.join(agentDir, file)),
+      ...CANONICAL_HOME_SECRET_FILES.map((file) => path.join(homedir(), file)),
+    ]),
+  ]
   if (deniedDirs.length === 0 && deniedFiles.length === 0) return undefined
 
   for (const candidate of collectPathCandidates(args, tool)) {
@@ -54,8 +79,8 @@ export function checkPrivateSurfaceReadGuard(options: {
       return {
         block: true,
         reason: [
-          `Guard \`${GUARD_PRIVATE_SURFACE_READ}\` blocked ${tool}: argument \`${candidate}\` resolves to ${hit}, which is hidden from the current role.`,
-          'The bash sandbox masks the same path; reaching it through another tool is the same disclosure.',
+          `Guard \`${GUARD_PRIVATE_SURFACE_READ}\` blocked ${tool}: argument \`${candidate}\` resolves to ${hit}, which is not available to LLM tools.`,
+          'The bash sandbox masks the same path. Privileged roles cannot bypass canonical agent credential files; use host-side redacted diagnostics such as `typeclaw doctor`, `typeclaw provider list`, or `typeclaw channel list` instead.',
         ].join(' '),
       }
     }
@@ -95,12 +120,11 @@ const NON_PATH_KEYS = new Set([
   'newText',
   // memory append tool: fragment topic is free text.
   'topic',
-  // channel_send/channel_reply attachments[].filename and
-  // channel_fetch_attachment.filename: display-only metadata (defaults to the
-  // basename of the real `path`), never the file location the guard cares
-  // about — `attachments[].path` carries that and is NOT exempted.
-  'filename',
 ])
+
+const PATH_KEYS = /(?:^|[_-])(path|filepath|file)$/i
+const CAMEL_PATH_KEYS = /(?:Path|Filepath|File)$/
+const MAX_HARDLINK_IDENTITY_ENTRIES = 4_096
 
 // Keys that are free text in SPECIFIC tools but path-bearing in others, so a
 // global denylist would either over-block or open a bypass. Scoped per tool:
@@ -117,10 +141,16 @@ const NON_PATH_KEYS = new Set([
 // (or grep gaining a new key) scans everything.
 const FREE_TEXT_KEYS_BY_TOOL: Record<string, ReadonlySet<string>> = {
   grep: new Set(['pattern']),
+  // These channel tools use filename only as attachment display metadata. The
+  // corresponding attachments[].path is scanned independently where present.
+  channel_send: new Set(['filename']),
+  channel_reply: new Set(['filename']),
+  channel_fetch_attachment: new Set(['filename']),
 }
 
 // Recursively collects strings that could be paths, skipping values under a
-// universally-free-text key or a tool-scoped free-text key. matchHidden then
+// universally-free-text key or a tool-scoped free-text key. Explicit path-like
+// keys still win, and file:// values are normalized before matching. matchHidden then
 // realpath-resolves each candidate and fires only on one landing inside a
 // hidden directory. Fail-closed by design: a bare path-bearing value equal to a
 // hidden dir name (e.g. `path: "memory"`) is still blocked. `underExempt`
@@ -133,21 +163,23 @@ function collectPathCandidates(value: unknown, tool: string): string[] {
   return out
 }
 
-function walk(value: unknown, out: string[], tool: string, underExempt: boolean): void {
+function walk(value: unknown, out: string[], tool: string, underExempt: boolean, key?: string): void {
   if (typeof value === 'string') {
-    if (underExempt) return
-    out.push(value)
+    const isFileUrl = value.toLocaleLowerCase().startsWith('file:')
+    if (underExempt && !isPathKey(key) && !isFileUrl) return
+    const normalized = normalizeCandidate(value)
+    if (normalized !== undefined) out.push(normalized)
     return
   }
   if (Array.isArray(value)) {
-    for (const item of value) walk(item, out, tool, underExempt)
+    for (const item of value) walk(item, out, tool, underExempt, key)
     return
   }
   if (value !== null && typeof value === 'object') {
     const toolFreeText = FREE_TEXT_KEYS_BY_TOOL[tool]
     for (const [key, item] of Object.entries(value)) {
       const keyIsExempt = NON_PATH_KEYS.has(key) || (toolFreeText?.has(key) ?? false)
-      walk(item, out, tool, underExempt || keyIsExempt)
+      walk(item, out, tool, underExempt || keyIsExempt, key)
     }
   }
 }
@@ -172,9 +204,14 @@ function matchHidden(
   deniedDirs: string[],
   deniedFiles: string[],
 ): string | undefined {
-  const resolved = realpathRealIntendedPath(path.resolve(agentDir, candidate))
+  const lexicalHit = matchLexicallyDenied(candidate, agentDir, deniedDirs, deniedFiles)
+  if (lexicalHit !== undefined) return lexicalHit
+  const lexical = path.resolve(agentDir, candidate)
+  const resolved = realpathRealIntendedPath(lexical)
+  const virtualRoot = virtualFilesystemRoot(lexical) ?? virtualFilesystemRoot(resolved)
+  if (virtualRoot !== undefined) return `${virtualRoot}, a virtual or process-backed filesystem`
   for (const file of deniedFiles) {
-    if (resolved === realpathRealIntendedPath(file)) return file
+    if (resolved === realpathRealIntendedPath(file) || hasSameFileIdentity(resolved, file)) return file
   }
   for (const dir of deniedDirs) {
     const realDir = realpathRealIntendedPath(dir)
@@ -183,7 +220,121 @@ function matchHidden(
     // "\"-joined paths a win32 test runner produces.
     if (resolved === realDir || resolved.startsWith(`${realDir}${path.sep}`)) return dir
   }
+  if (hasMultipleLinks(resolved)) {
+    const alias = findDeniedHardlinkAlias(resolved, deniedDirs)
+    if (alias !== undefined) return alias
+  }
   return undefined
+}
+
+function matchLexicallyDenied(
+  candidate: string,
+  agentDir: string,
+  deniedDirs: readonly string[],
+  deniedFiles: readonly string[],
+): string | undefined {
+  const absolute = portableAbsolute(agentDir, candidate)
+  const virtualRoot = virtualFilesystemRoot(absolute)
+  if (virtualRoot !== undefined) return `${virtualRoot}, a virtual or process-backed filesystem`
+  for (const file of deniedFiles) {
+    if (portableEqual(absolute, portableAbsolute(agentDir, file))) return file
+  }
+  for (const dir of deniedDirs) {
+    const root = portableAbsolute(agentDir, dir)
+    if (portableEqual(absolute, root) || portableInside(root, absolute)) return dir
+  }
+  return undefined
+}
+
+function portableAbsolute(agentDir: string, candidate: string): string {
+  const normalized = candidate.replaceAll('\\', '/')
+  if (/^[A-Za-z]:\//.test(normalized) || normalized.startsWith('//')) return path.posix.normalize(normalized)
+  if (normalized.startsWith('/')) return path.posix.normalize(normalized)
+  return path.posix.resolve(agentDir.replaceAll('\\', '/'), normalized)
+}
+
+function portableEqual(left: string, right: string): boolean {
+  const windows =
+    /^[A-Za-z]:\//.test(left) || left.startsWith('//') || /^[A-Za-z]:\//.test(right) || right.startsWith('//')
+  return windows ? left.toLocaleLowerCase() === right.toLocaleLowerCase() : left === right
+}
+
+function portableInside(parent: string, child: string): boolean {
+  const normalizedParent = parent.endsWith('/') ? parent : `${parent}/`
+  return portableEqual(child.slice(0, normalizedParent.length), normalizedParent)
+}
+
+function virtualFilesystemRoot(candidate: string): string | undefined {
+  const normalized = candidate.replaceAll('\\', '/')
+  for (const root of VIRTUAL_FILESYSTEM_ROOTS) {
+    if (normalized === root || normalized.startsWith(`${root}/`)) return root
+  }
+  return undefined
+}
+
+function hasMultipleLinks(candidate: string): boolean {
+  try {
+    const stats = statSync(candidate)
+    return stats.isFile() && stats.nlink > 1
+  } catch {
+    return false
+  }
+}
+
+function findDeniedHardlinkAlias(candidate: string, deniedDirs: readonly string[]): string | undefined {
+  let remaining = MAX_HARDLINK_IDENTITY_ENTRIES
+  for (const deniedDir of deniedDirs) {
+    const pending = [realpathRealIntendedPath(deniedDir)]
+    while (pending.length > 0) {
+      const current = pending.pop()
+      if (current === undefined) break
+      let entries
+      try {
+        entries = readdirSync(current, { withFileTypes: true })
+      } catch {
+        continue
+      }
+      for (const entry of entries) {
+        const entryPath = path.join(current, entry.name)
+        if (entry.isDirectory()) pending.push(entryPath)
+        else if (entry.isFile()) {
+          if (remaining-- <= 0) return undefined
+          if (hasSameFileIdentity(candidate, entryPath)) return deniedDir
+        }
+      }
+    }
+  }
+  return undefined
+}
+
+function isPathKey(key: string | undefined): boolean {
+  return key !== undefined && (PATH_KEYS.test(key) || CAMEL_PATH_KEYS.test(key))
+}
+
+function normalizeCandidate(value: string): string | undefined {
+  if (!value.toLocaleLowerCase().startsWith('file:')) return value
+  try {
+    const url = new URL(value)
+    const pathname = decodeURIComponent(url.pathname)
+    if (url.hostname !== '') return `//${url.hostname}${pathname}`
+    if (/^\/[A-Za-z]:\//.test(pathname)) return pathname.slice(1)
+    // Keep synthetic POSIX container paths platform-independent. fileURLToPath
+    // would reinterpret file:///agent/... through the Windows host grammar.
+    if (pathname.startsWith('/agent/') || pathname === '/agent') return pathname
+    return fileURLToPath(value)
+  } catch {
+    return value
+  }
+}
+
+function hasSameFileIdentity(candidate: string, deniedFile: string): boolean {
+  try {
+    const candidateStats = statSync(candidate)
+    const deniedStats = statSync(deniedFile)
+    return candidateStats.dev === deniedStats.dev && candidateStats.ino === deniedStats.ino
+  } catch {
+    return false
+  }
 }
 
 // Resolves symlinks on the longest existing prefix of an absolute path, then

--- a/src/bundled-plugins/security/policies/secret-exfil-read.test.ts
+++ b/src/bundled-plugins/security/policies/secret-exfil-read.test.ts
@@ -9,6 +9,11 @@ describe('secret-exfil-read guard', () => {
     expect(checkSecretExfilReadGuard({ tool: 'read', args: { path: '/agent/.env' } })?.block).toBe(true)
   })
 
+  test('treats secrets.json as a sensitive basename', () => {
+    expect(checkSecretExfilReadGuard({ tool: 'read', args: { path: 'secrets.json' } })?.block).toBe(true)
+    expect(checkSecretExfilReadGuard({ tool: 'find', args: { path: '.', pattern: 'secrets.json' } })?.block).toBe(true)
+  })
+
   test('blocks read of .env.production / .env.local', () => {
     expect(checkSecretExfilReadGuard({ tool: 'read', args: { path: '.env.production' } })?.block).toBe(true)
     expect(checkSecretExfilReadGuard({ tool: 'read', args: { path: 'config/.env.local' } })?.block).toBe(true)

--- a/src/bundled-plugins/security/policies/secret-exfil-read.ts
+++ b/src/bundled-plugins/security/policies/secret-exfil-read.ts
@@ -22,6 +22,7 @@ const SENSITIVE_BASENAMES = new Set([
   'service-account.json',
   'gha-creds.json',
   'token.json',
+  'secrets.json',
 ])
 
 const SENSITIVE_BASENAME_PATTERNS: ReadonlyArray<RegExp> = [

--- a/src/permissions/builtins.ts
+++ b/src/permissions/builtins.ts
@@ -32,7 +32,9 @@ export const CORE_PERMISSIONS = {
   // Phrased as capabilities to SEE, not to hide, so the role tower stays
   // monotonic (a higher tier sees a strict superset of a lower tier).
   // resolveHiddenPaths masks whatever the resolved role lacks: fsSeePrivate
-  // gates workspace/+memory/+sessions/, fsSeeSecrets gates .env+secrets.json.
+  // gates workspace/+memory/+sessions/. fsSeeSecrets authorizes runtime-owned
+  // credential use, never raw LLM tool access to canonical credential stores;
+  // canonical files are unconditionally masked for every role.
   // The fail-safe floor is the undefined origin (see has() in
   // permissions.ts), not the guest role, which is now grantable.
   fsSeePrivate: 'fs.see.private',

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -60,6 +60,7 @@ export type {
   ToolBeforeEvent,
   ToolBeforeResult,
   ToolContext,
+  ToolFileOperands,
   ToolLogger,
   ToolResult,
 } from './types'

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -25,9 +25,16 @@ export type ToolContext = {
   logger: ToolLogger
 }
 
+export type ToolFileOperands = {
+  input?: readonly string[]
+  output?: readonly string[]
+  destructive?: readonly string[]
+}
+
 export type Tool<P = unknown> = {
   description: string
   parameters: z.ZodType<P>
+  fileOperands?: ToolFileOperands
   execute: (args: P, ctx: ToolContext) => Promise<ToolResult>
 }
 

--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -220,19 +220,21 @@ describe('buildSandboxedCommand writable overlays', () => {
     expect(joined).toContain('--bind /agent/AGENTS.md /agent/AGENTS.md')
   })
 
-  test('renders writable overlays AFTER the ro-bind root and after masks so they win', () => {
+  test('renders writable overlays after the root but before nested masks', () => {
     const argv = argvOf('true', {
       mounts: [{ type: 'ro-bind', source: '/agent', dest: '/agent' }],
-      masks: { dirs: ['/agent/memory'], files: ['/agent/.env'] },
+      masks: { dirs: ['/agent/workspace/.agent-messenger'], files: ['/agent/workspace/.env'] },
       writable: { dirs: ['/agent/workspace'], files: ['/agent/AGENTS.md'] },
     })
     const roRootDest = argv.indexOf('/agent')
-    const memoryMask = argv.indexOf('/agent/memory')
+    const messengerMask = argv.indexOf('/agent/workspace/.agent-messenger')
+    const envMask = argv.indexOf('/agent/workspace/.env')
     const writableDir = argv.indexOf('/agent/workspace')
     const writableFile = argv.indexOf('/agent/AGENTS.md')
     expect(roRootDest).toBeLessThan(writableDir)
-    expect(memoryMask).toBeLessThan(writableDir)
-    expect(memoryMask).toBeLessThan(writableFile)
+    expect(writableDir).toBeLessThan(messengerMask)
+    expect(writableDir).toBeLessThan(envMask)
+    expect(writableFile).toBeLessThan(messengerMask)
   })
 
   test('emits no writable binds when the policy omits them', () => {

--- a/src/sandbox/build.ts
+++ b/src/sandbox/build.ts
@@ -168,8 +168,8 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
   }
 
   appendWritableRoot(argv, policy)
-  appendMasks(argv, policy)
   appendWritable(argv, policy)
+  appendMasks(argv, policy)
   appendProtected(argv, policy)
   appendBlockedCreation(argv, policy)
   appendSymlinks(argv, policy)

--- a/src/sandbox/canonical-secrets.ts
+++ b/src/sandbox/canonical-secrets.ts
@@ -1,0 +1,18 @@
+export const CANONICAL_AGENT_SECRET_DIRS = [
+  'workspace/.config/gws',
+  'workspace/.agent-messenger',
+  '.typeclaw/home',
+] as const
+
+export const CANONICAL_AGENT_SECRET_FILES = ['.env', 'secrets.json', 'auth.json'] as const
+
+export const CANONICAL_HOME_SECRET_DIRS = [
+  '.ssh',
+  '.config/gh',
+  '.config/gws',
+  '.agent-messenger',
+  '.codex',
+  '.claude',
+] as const
+
+export const CANONICAL_HOME_SECRET_FILES = ['.gitconfig', '.claude.json', '.netrc'] as const

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -19,6 +19,13 @@ export class SandboxPolicyError extends Error {
   }
 }
 
+export class SandboxMaskTargetError extends Error {
+  override readonly name = 'SandboxMaskTargetError'
+  constructor(target: string, reason: string) {
+    super(`sandbox mask target is unsafe (${target}): ${reason}`)
+  }
+}
+
 // Raised when the /proc strategy degraded to the empty `tmpfs` fallback AND the
 // command needs a real /proc (a bun install / bunx / bun run that reads the
 // kernel-backed /proc/self/{fd,maps}). Without this pre-check Bun aborts deep in

--- a/src/sandbox/hidden-paths.test.ts
+++ b/src/sandbox/hidden-paths.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { lstat, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,7 +7,8 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import { createPermissionService } from '@/permissions/permissions'
 import { rolesConfigSchema, type RolesConfig } from '@/permissions/schema'
 
-import { ensureHiddenMaskTargets, resolveHiddenPaths } from './hidden-paths'
+import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from './canonical-secrets'
+import { canWriteAgentRootInSandbox, ensureHiddenMaskTargets, resolveHiddenPaths } from './hidden-paths'
 
 const AGENT = '/agent'
 const hiddenDirs = (agentDir: string) => [
@@ -15,7 +16,8 @@ const hiddenDirs = (agentDir: string) => [
   join(agentDir, 'memory'),
   join(agentDir, 'sessions'),
 ]
-const secretFiles = (agentDir: string) => [join(agentDir, '.env'), join(agentDir, 'secrets.json')]
+const canonicalDirs = (agentDir: string) => CANONICAL_AGENT_SECRET_DIRS.map((dir) => join(agentDir, dir))
+const secretFiles = (agentDir: string) => CANONICAL_AGENT_SECRET_FILES.map((file) => join(agentDir, file))
 
 function parseRoles(raw: unknown): RolesConfig {
   const result = rolesConfigSchema.safeParse(raw)
@@ -29,19 +31,29 @@ function spawnedBy(role: string): SessionOrigin {
 
 const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
 
+describe('canWriteAgentRootInSandbox', () => {
+  test('preserves root writes only for owner and trusted roles', () => {
+    const svc = createPermissionService()
+    expect(canWriteAgentRootInSandbox(svc, tui)).toBe(true)
+    expect(canWriteAgentRootInSandbox(svc, spawnedBy('trusted'))).toBe(true)
+    expect(canWriteAgentRootInSandbox(svc, spawnedBy('member'))).toBe(false)
+    expect(canWriteAgentRootInSandbox(svc, spawnedBy('guest'))).toBe(false)
+  })
+})
+
 describe('resolveHiddenPaths — builtin tiers', () => {
-  test('owner (tui) hides nothing', () => {
+  test('owner (tui) always hides canonical credentials', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, tui, AGENT)
-    expect(dirs).toEqual([])
-    expect(files).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
-  test('trusted hides nothing (sees private surface and secrets)', () => {
+  test('trusted always hides canonical credentials', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('trusted'), AGENT)
-    expect(dirs).toEqual([])
-    expect(files).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('system origin hides nothing even when triggered by a guest channel turn', () => {
@@ -52,21 +64,21 @@ describe('resolveHiddenPaths — builtin tiers', () => {
       triggeredBy: { kind: 'channel', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
     }
     const { dirs, files } = resolveHiddenPaths(svc, origin, AGENT)
-    expect(dirs).toEqual([])
-    expect(files).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('member sees private surface but hides the secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('member'), AGENT)
-    expect(dirs).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('guest hides the private surface AND the secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('guest'), AGENT)
-    expect(dirs).toEqual(hiddenDirs(AGENT))
+    expect(dirs).toEqual([...hiddenDirs(AGENT), ...canonicalDirs(AGENT)])
     expect(files).toEqual(secretFiles(AGENT))
   })
 
@@ -81,7 +93,7 @@ describe('resolveHiddenPaths — fail-safe', () => {
   test('undefined origin is treated as guest (everything hidden)', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, undefined, AGENT)
-    expect(dirs).toEqual(hiddenDirs(AGENT))
+    expect(dirs).toEqual([...hiddenDirs(AGENT), ...canonicalDirs(AGENT)])
     expect(files).toEqual(secretFiles(AGENT))
   })
 
@@ -96,7 +108,7 @@ describe('resolveHiddenPaths — fail-safe', () => {
       lastInboundAuthorId: 'U_STRANGER',
     }
     const { dirs, files } = resolveHiddenPaths(svc, stranger, AGENT)
-    expect(dirs).toEqual(hiddenDirs(AGENT))
+    expect(dirs).toEqual([...hiddenDirs(AGENT), ...canonicalDirs(AGENT)])
     expect(files).toEqual(secretFiles(AGENT))
   })
 })
@@ -106,18 +118,18 @@ describe('resolveHiddenPaths — custom roles via fs.see grants', () => {
     const roles = parseRoles({ contributor: { match: ['slack:T0 author:U_C'], permissions: ['fs.see.private'] } })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('contributor'), AGENT)
-    expect(dirs).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
-  test('custom role with both fs.see grants hides nothing', () => {
+  test('custom role with both fs.see grants still hides canonical credentials', () => {
     const roles = parseRoles({
       steward: { match: ['slack:T0 author:U_S'], permissions: ['fs.see.private', 'fs.see.secrets'] },
     })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('steward'), AGENT)
-    expect(dirs).toEqual([])
-    expect(files).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 })
 
@@ -128,7 +140,7 @@ describe('resolveHiddenPaths — legacy security.bypass fallback', () => {
     })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('legacymember'), AGENT)
-    expect(dirs).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
@@ -138,8 +150,8 @@ describe('resolveHiddenPaths — legacy security.bypass fallback', () => {
     })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('legacytrusted'), AGENT)
-    expect(dirs).toEqual([])
-    expect(files).toEqual([])
+    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(files).toEqual(secretFiles(AGENT))
   })
 })
 
@@ -147,7 +159,7 @@ describe('resolveHiddenPaths — agentDir relativity', () => {
   test('masks are rooted at the given agentDir, not a hardcoded /agent', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, undefined, '/srv/app')
-    expect(dirs).toEqual(hiddenDirs('/srv/app'))
+    expect(dirs).toEqual([...hiddenDirs('/srv/app'), ...canonicalDirs('/srv/app')])
     expect(files).toEqual(secretFiles('/srv/app'))
   })
 })
@@ -191,27 +203,19 @@ describe('ensureHiddenMaskTargets', () => {
     expect(await Bun.file(secrets).text()).toBe('{"real":"content"}')
   })
 
-  test('drops a symlinked mask target — a bind would follow it outside the jail', async () => {
-    // given: a symlink squatting the .env mask target
+  test('fails closed when a canonical file mask target is a symlink', async () => {
     const outside = join(dir, 'outside')
     await writeFile(outside, 'secret')
     const env = join(dir, '.env')
     await symlink(outside, env)
-    // when
-    const result = await ensureHiddenMaskTargets({ dirs: [], files: [env] })
-    // then: the symlink is refused, so it never becomes a --ro-bind-data target
-    expect(result.files).toEqual([])
+    await expect(ensureHiddenMaskTargets({ dirs: [], files: [env] })).rejects.toThrow(/mask target/i)
   })
 
-  test('degrades per target: one unmaterializable entry drops out, the rest survive', async () => {
-    // given: .env is a symlink (dropped), secrets.json is absent (created)
-    const badEnv = join(dir, '.env')
-    await symlink(join(dir, 'nowhere'), badEnv)
-    const secrets = join(dir, 'secrets.json')
-    // when
-    const result = await ensureHiddenMaskTargets({ dirs: [], files: [badEnv, secrets] })
-    // then
-    expect(result.files).toEqual([secrets])
-    expect(await isRegularFile(secrets)).toBe(true)
+  test('fails closed when a canonical directory mask target is a symlink', async () => {
+    const outside = join(dir, 'outside-dir')
+    await mkdir(outside)
+    const credentials = join(dir, 'credentials')
+    await symlink(outside, credentials)
+    await expect(ensureHiddenMaskTargets({ dirs: [credentials], files: [] })).rejects.toThrow(/mask target/i)
   })
 })

--- a/src/sandbox/hidden-paths.ts
+++ b/src/sandbox/hidden-paths.ts
@@ -5,14 +5,15 @@ import type { SessionOrigin } from '@/agent/session-origin'
 import { CORE_PERMISSIONS } from '@/permissions/builtins'
 import type { PermissionService } from '@/permissions/permissions'
 
+import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from './canonical-secrets'
+import { SandboxMaskTargetError } from './errors'
+
 export type HiddenPaths = {
   dirs: string[]
   files: string[]
 }
 
 const PRIVATE_DIRS = ['workspace', 'memory', 'sessions'] as const
-const SECRET_FILES = ['.env', 'secrets.json'] as const
-
 // The agent's private working surface and credential files are masked from
 // sandboxed bash unless the resolved role carries the matching fs.see.* grant.
 // `permissions.has` resolves the role from the live origin and fails safe to
@@ -33,12 +34,22 @@ export function resolveHiddenPaths(
     permissions.has(origin, CORE_PERMISSIONS.fsSeePrivate) ||
     permissions.has(origin, 'security.bypass.low') ||
     permissions.has(origin, 'security.bypass.medium')
+  const dirs = [
+    ...(seesPrivate ? [] : PRIVATE_DIRS.map((d) => join(agentDir, d))),
+    ...CANONICAL_AGENT_SECRET_DIRS.map((d) => join(agentDir, d)),
+  ]
+  const files = CANONICAL_AGENT_SECRET_FILES.map((f) => join(agentDir, f))
+  return { dirs, files }
+}
+
+export function canWriteAgentRootInSandbox(permissions: PermissionService, origin: SessionOrigin | undefined): boolean {
+  const seesPrivate =
+    permissions.has(origin, CORE_PERMISSIONS.fsSeePrivate) ||
+    permissions.has(origin, 'security.bypass.low') ||
+    permissions.has(origin, 'security.bypass.medium')
   const seesSecrets =
     permissions.has(origin, CORE_PERMISSIONS.fsSeeSecrets) || permissions.has(origin, 'security.bypass.medium')
-
-  const dirs = seesPrivate ? [] : PRIVATE_DIRS.map((d) => join(agentDir, d))
-  const files = seesSecrets ? [] : SECRET_FILES.map((f) => join(agentDir, f))
-  return { dirs, files }
+  return seesPrivate && seesSecrets
 }
 
 // SECURITY / bwrap contract: the mask ops REQUIRE a pre-existing target.
@@ -55,27 +66,25 @@ export function resolveHiddenPaths(
 // (`writableRoot: agentDir`), so dropping an absent secret would let sandboxed
 // code CREATE `.env`/`secrets.json` for real (planting) or expose one created
 // mid-session (TOCTOU). A guaranteed target keeps the mask always rendered over
-// it (last-op-wins), closing that hole for both jail modes. A symlink squatting
-// a target is refused and dropped (a bind would follow it out), and each target
-// is best-effort so one bad entry degrades that mask, never aborts sandboxing.
+// it (last-op-wins), closing that hole for both jail modes. Required masks fail
+// closed: a symlink, wrong entry kind, or materialization failure aborts bash.
 export async function ensureHiddenMaskTargets(hidden: HiddenPaths): Promise<HiddenPaths> {
-  const dirs = await ensureMaskTargets(hidden.dirs, 'dir')
-  const files = await ensureMaskTargets(hidden.files, 'file')
+  const dirs = await Promise.all(hidden.dirs.map((target) => ensureMaskTarget(target, 'dir')))
+  const files = await Promise.all(hidden.files.map((target) => ensureMaskTarget(target, 'file')))
   return { dirs, files }
 }
 
-async function ensureMaskTargets(targets: string[], kind: 'dir' | 'file'): Promise<string[]> {
-  const results = await Promise.all(targets.map((target) => ensureMaskTarget(target, kind)))
-  return targets.filter((_, i) => results[i])
-}
-
-async function ensureMaskTarget(target: string, kind: 'dir' | 'file'): Promise<boolean> {
+async function ensureMaskTarget(target: string, kind: 'dir' | 'file'): Promise<string> {
   try {
     if (kind === 'dir') await mkdir(target, { recursive: true })
     else await ensureEmptyFile(target)
-    return await isRealEntry(target, kind)
+    const stats = await lstat(target)
+    if (stats.isSymbolicLink()) throw new SandboxMaskTargetError(target, 'symlinks cannot be masked safely')
+    const validKind = kind === 'dir' ? stats.isDirectory() : stats.isFile()
+    if (!validKind) throw new SandboxMaskTargetError(target, `target is not a ${kind}`)
+    return target
   } catch {
-    return false
+    throw new SandboxMaskTargetError(target, `could not materialize or inspect a ${kind}`)
   }
 }
 
@@ -86,15 +95,5 @@ async function ensureEmptyFile(target: string): Promise<void> {
     // Already exists or lost a creation race; isRealEntry re-validates the kind
     // and rejects a symlink, so an existing regular file passes and anything
     // else is dropped from the mask.
-  }
-}
-
-async function isRealEntry(target: string, kind: 'dir' | 'file'): Promise<boolean> {
-  try {
-    const stats = await lstat(target)
-    if (stats.isSymbolicLink()) return false
-    return kind === 'dir' ? stats.isDirectory() : stats.isFile()
-  } catch {
-    return false
   }
 }

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,5 +1,11 @@
 export { buildSandboxedCommand, type SandboxedCommand } from './build'
 export {
+  CANONICAL_AGENT_SECRET_DIRS,
+  CANONICAL_AGENT_SECRET_FILES,
+  CANONICAL_HOME_SECRET_DIRS,
+  CANONICAL_HOME_SECRET_FILES,
+} from './canonical-secrets'
+export {
   buildProcBindProbeScript,
   canBindProcSafely,
   canMountRealProc,
@@ -13,7 +19,12 @@ export {
   _resetProcBindProbeCacheForTests,
   _resetRealProcProbeCacheForTests,
 } from './availability'
-export { ensureHiddenMaskTargets, resolveHiddenPaths, type HiddenPaths } from './hidden-paths'
+export {
+  canWriteAgentRootInSandbox,
+  ensureHiddenMaskTargets,
+  resolveHiddenPaths,
+  type HiddenPaths,
+} from './hidden-paths'
 export {
   resolvePackageInstallZones,
   resolveProtectedZones,


### PR DESCRIPTION
## Background

Extracted from #1201 to make the work reviewable. Slice 1/11.

## Summary

Declares tool file operands, defines canonical secret paths, and enforces unconditional private-surface denial.

## Review notes

Foundation slice; no package-install policy is included.