### PR TITLE
feat(agent): pin tool file operands

### DIFF
--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -4,7 +4,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { SessionManager } from '@mariozechner/pi-coding-agent'
+import { defineTool as definePiTool, SessionManager } from '@mariozechner/pi-coding-agent'
+import { Type } from 'typebox'
 
 import { PLANNER_SYSTEM_PROMPT } from '@/bundled-plugins/planner/planner'
 import { SCOUT_SYSTEM_PROMPT } from '@/bundled-plugins/scout/scout'
@@ -14,6 +15,7 @@ import { configSchema, type Models, resolveProfile, type ResolvedProfile, type T
 import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 import type { ModelRef } from '@/config/providers'
 import { createHookBus, type PluginRegistry } from '@/plugin'
+import { emptyRegistry } from '@/plugin/registry'
 import { createStream } from '@/stream'
 
 import {
@@ -29,6 +31,7 @@ import {
   getBundledSkillsDir,
   resolveSessionThinkingLevel,
   subscribeRestartNotice,
+  wrapSystemTools,
 } from './index'
 import { LiveSubagentRegistry } from './live-subagents'
 import { PROACTIVE_NEXT_STEP_NUDGE } from './proactive-next-step-nudge'
@@ -101,6 +104,35 @@ describe('attachLoopGuardTurnTracking', () => {
 
     unsubscribe()
     expect(unsubscribed).toBe(true)
+  })
+})
+
+describe('wrapSystemTools', () => {
+  test('hookless composition denies canonical secret operands before a custom system tool executes', async () => {
+    await writeFile(join(agentDir, '.env'), 'EXAMPLE_TOKEN=placeholder')
+    let executed = false
+    const lookAt = definePiTool({
+      name: 'look_at',
+      label: 'look_at',
+      description: '',
+      parameters: Type.Any(),
+      async execute() {
+        executed = true
+        return { content: [], details: undefined }
+      },
+    })
+    const tools = wrapSystemTools(
+      [lookAt],
+      { registry: emptyRegistry(), hooks: createHookBus(), sessionId: 'hookless', agentDir },
+      () => undefined,
+      () => undefined,
+      () => undefined,
+    )
+
+    await expect(
+      tools[0]!.execute('call', { images: [{ path: '.env' }] }, undefined, undefined, {} as never),
+    ).rejects.toThrow(/not available to LLM tools/)
+    expect(executed).toBeFalse()
   })
 })
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -912,29 +912,23 @@ function wrapRegistryTools(
   )
 }
 
-function wrapSystemTools(
+export function wrapSystemTools(
   tools: ToolDefinition[],
   plugins: PluginSessionWiring | undefined,
   getOrigin: () => SessionOrigin | undefined,
   getAbort: () => ((reason?: string) => void) | undefined,
   getLoopGuardTurn: () => number | undefined,
 ): ToolDefinition[] {
-  if (!hasToolHooks(plugins)) return tools
   return tools.map((tool) =>
     wrapSystemTool(tool, {
-      agentDir: plugins.agentDir,
-      sessionId: plugins.sessionId,
-      hooks: plugins.hooks,
+      agentDir: plugins?.agentDir ?? process.cwd(),
+      sessionId: plugins?.sessionId ?? 'system-tools',
+      hooks: plugins?.hooks ?? createHookBus(),
       getOrigin,
       getAbort,
       getLoopGuardTurn,
     }),
   )
-}
-
-function hasToolHooks(plugins: PluginSessionWiring | undefined): plugins is PluginSessionWiring {
-  if (!plugins) return false
-  return plugins.hooks.count('tool.before') > 0 || plugins.hooks.count('tool.after') > 0
 }
 
 export function wrapSubagentCustomTools(

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,27 +1,46 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import {
+  link,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  truncate,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { defineTool as definePiTool } from '@mariozechner/pi-coding-agent'
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent'
 import { Type } from 'typebox'
 import { z } from 'zod'
 
+import { createDreamingSubagent } from '@/bundled-plugins/memory/dreaming'
+import { createWriteReportTool } from '@/bundled-plugins/researcher/write-report'
 import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
 import { hooklessGitArgs } from '@/git/hookless'
 import { createPermissionService } from '@/permissions/permissions'
 import { createHookBus, defineTool, type PluginRegistry, type ToolResult } from '@/plugin'
 import {
+  buildSandboxedCommand,
+  canWriteAgentRootInSandbox,
   _resetBwrapAvailabilityCacheForTests,
   _resetRealProcProbeCacheForTests,
-  buildSandboxedCommand,
+  resolveProtectedZones,
   SESSION_TMP_ROOT,
   resolvePrivilegedSandboxRuntime,
 } from '@/sandbox'
 
+import { URL_FETCH_MAX_BYTES } from './multimodal/looker'
 import {
   __resetSharedLoopGuardForTests,
+  buildBashFilesystemPolicy,
   buildBuiltinPiToolOverrides,
   defaultBuiltinPiToolDefinitions,
   forgetSharedLoopGuardTool,
@@ -32,12 +51,21 @@ import {
   zodToToolParameters,
 } from './plugin-tools'
 import type { SessionOrigin } from './session-origin'
+import {
+  enforceAndPinToolFiles,
+  PINNED_SNAPSHOT_GLOBAL_MAX_COUNT,
+  PINNED_SNAPSHOT_MAX_WAITERS,
+  TOOL_INPUT_MAX_BYTES,
+  TOOL_INPUT_MAX_COUNT,
+  writeToolOutputNoFollow,
+} from './tool-file-safety'
 
 beforeEach(() => {
   __resetSharedLoopGuardForTests()
 })
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
+const lacksInodeAnchoring = process.platform !== 'linux'
 
 function textOfFirstContent(result: { content: { type: string; text?: string }[] }): string | undefined {
   const first = result.content[0]
@@ -319,9 +347,364 @@ describe('wrapPluginTool', () => {
     await wrapped.execute('c', {}, controller.signal, undefined, {} as never)
     expect(captured.signal).toBe(controller.signal)
   })
+
+  test('hookless plugin tools cannot open canonical credentials', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-hookless-plugin-'))
+    await writeFile(path.join(agentDir, 'secrets.json'), '{"secret":true}')
+    let called = false
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ path: z.string() }),
+      async execute() {
+        called = true
+        return { content: [] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'reader',
+      toolName: 'arbitrary_reader',
+      agentDir,
+      sessionId: 's',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    try {
+      await expect(wrapped.execute('c', { path: 'secrets.json' }, undefined, undefined, {} as never)).rejects.toThrow(
+        /ambiguous.*fileOperands\.input.*file:/i,
+      )
+      expect(called).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('plugin semantic API routes and repository slugs pass only under their narrow key grammars', async () => {
+    const seen: Array<{ path: string; repository: string; id: string }> = []
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ path: z.string(), repository: z.string(), id: z.string() }),
+      async execute(args) {
+        seen.push(args)
+        return { content: [{ type: 'text', text: args.path }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'repository',
+      toolName: 'repository_status',
+      agentDir: '/agent',
+      sessionId: 'semantic-path',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    const result = await wrapped.execute(
+      'c',
+      { path: '/v1/repos', repository: 'acme/widgets', id: 'opaque-123' },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    expect(textOfFirstContent(result)).toBe('/v1/repos')
+    expect(seen).toEqual([{ path: '/v1/repos', repository: 'acme/widgets', id: 'opaque-123' }])
+  })
+
+  test.each(['/v1/../../tmp/result.txt', '/v1/%2e%2e/tmp/result.txt', '/v1\\..\\tmp', '/v1//repos'])(
+    'rejects traversal-shaped API route %s before plugin dispatch',
+    async (route) => {
+      let called = false
+      const tool = defineTool({
+        description: '',
+        parameters: z.object({ path: z.string() }),
+        async execute() {
+          called = true
+          return { content: [] }
+        },
+      })
+      const wrapped = wrapPluginTool(tool, {
+        pluginName: 'repository',
+        toolName: 'repository_status',
+        agentDir: '/agent',
+        sessionId: `route-${route}`,
+        logger: noopLogger,
+        hooks: createHookBus(),
+      })
+
+      await expect(wrapped.execute('c', { path: route }, undefined, undefined, {} as never)).rejects.toThrow(
+        /ambiguous.*fileOperands\.input.*file:/i,
+      )
+      expect(called).toBeFalse()
+    },
+  )
+
+  test('rejects undeclared scalar array paths and non-file-key multi-component paths before plugin dispatch', async () => {
+    let called = false
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ files: z.array(z.string()), value: z.string() }),
+      async execute() {
+        called = true
+        return { content: [] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'reader',
+      toolName: 'array_reader',
+      agentDir: '/agent',
+      sessionId: 'undeclared-array',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+
+    for (const args of [
+      { files: ['workspace/missing.txt'], value: 'opaque' },
+      { files: ['opaque'], value: 'workspace/missing.txt' },
+    ]) {
+      await expect(wrapped.execute('c', args, undefined, undefined, {} as never)).rejects.toThrow(
+        /ambiguous.*fileOperands\.input.*file:/i,
+      )
+    }
+    expect(called).toBeFalse()
+  })
+
+  test('plugin-declared whole-array scalar inputs execute against immutable snapshots', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-declared-array-input-'))
+    const safe = path.join(agentDir, 'safe.txt')
+    const replacement = path.join(agentDir, 'replacement.txt')
+    await writeFile(safe, 'safe')
+    await writeFile(replacement, 'replacement')
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ files: z.array(z.string()) }),
+      fileOperands: { input: ['files'] },
+      async execute(args) {
+        await rm(safe)
+        await symlink(replacement, safe)
+        return { content: [{ type: 'text', text: await readFile(args.files[0] as string, 'utf8') }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'reader',
+      toolName: 'declared_array_reader',
+      agentDir,
+      sessionId: 'declared-array-input',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    try {
+      const result = await wrapped.execute('c', { files: ['safe.txt'] }, undefined, undefined, {} as never)
+      expect(textOfFirstContent(result)).toBe('safe')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.each([
+    ['outputPath', 'result.txt'],
+    ['filename', 'result.txt'],
+    ['value', 'result.txt'],
+    ['value', 'C:\\temp\\result.txt'],
+    ['value', '\\\\server\\share\\result.txt'],
+  ])('rejects undeclared nonexistent local operand %s=%s before dispatch', async (key, value) => {
+    let called = false
+    const tool = defineTool({
+      description: '',
+      parameters: z.record(z.string(), z.string()),
+      async execute() {
+        called = true
+        return { content: [] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'reader',
+      toolName: 'undeclared_reader',
+      agentDir: '/agent',
+      sessionId: `undeclared-${key}-${value}`,
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    await expect(wrapped.execute('c', { [key]: value }, undefined, undefined, {} as never)).rejects.toThrow(
+      /ambiguous.*fileOperands\.input.*file:/i,
+    )
+    expect(called).toBeFalse()
+  })
+
+  test('rejects a nonexistent output path before a tool can race it to a symlink', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-undeclared-output-race-'))
+    const destination = path.join(agentDir, 'result.txt')
+    let called = false
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ outputPath: z.string() }),
+      async execute() {
+        called = true
+        await symlink(path.join(agentDir, 'secrets.json'), destination)
+        return { content: [] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'writer',
+      toolName: 'undeclared_writer',
+      agentDir,
+      sessionId: 'undeclared-output-race',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    try {
+      await expect(
+        wrapped.execute('c', { outputPath: 'result.txt' }, undefined, undefined, {} as never),
+      ).rejects.toThrow(/ambiguous/i)
+      expect(called).toBeFalse()
+      expect(await Bun.file(destination).exists()).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.each(['absolute', 'relative', 'bare'])(
+    'undeclared existing %s path-like plugin operands are rejected instead of dispatched with a TOCTOU window',
+    async (kind) => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-undeclared-plugin-input-'))
+      const safe = path.join(agentDir, 'safe.txt')
+      await writeFile(safe, 'safe')
+      let called = false
+      const tool = defineTool({
+        description: '',
+        parameters: z.object({ inputPath: z.string() }),
+        async execute() {
+          called = true
+          return { content: [] }
+        },
+      })
+      const wrapped = wrapPluginTool(tool, {
+        pluginName: 'reader',
+        toolName: 'undeclared_reader',
+        agentDir,
+        sessionId: `undeclared-${kind}`,
+        logger: noopLogger,
+        hooks: createHookBus(),
+      })
+      try {
+        const inputPath = kind === 'absolute' ? safe : kind === 'relative' ? './safe.txt' : 'safe.txt'
+        await expect(wrapped.execute('c', { inputPath }, undefined, undefined, {} as never)).rejects.toThrow(
+          /ambiguous.*fileOperands\.input.*file:/i,
+        )
+        expect(called).toBeFalse()
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test('plugin-declared local input operands execute against an immutable snapshot', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-declared-plugin-input-'))
+    const safe = path.join(agentDir, 'safe.txt')
+    const replacement = path.join(agentDir, 'replacement.txt')
+    await writeFile(safe, 'safe')
+    await writeFile(replacement, 'replacement')
+    const tool = defineTool({
+      description: '',
+      parameters: z.object({ path: z.string() }),
+      fileOperands: { input: ['path'] },
+      async execute(args) {
+        await rm(safe)
+        await symlink(replacement, safe)
+        return { content: [{ type: 'text', text: await readFile(args.path, 'utf8') }] }
+      },
+    })
+    const wrapped = wrapPluginTool(tool, {
+      pluginName: 'reader',
+      toolName: 'declared_reader',
+      agentDir,
+      sessionId: 'declared-input',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    try {
+      const result = await wrapped.execute('c', { path: 'safe.txt' }, undefined, undefined, {} as never)
+      expect(textOfFirstContent(result)).toBe('safe')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('researcher write_report preserves its absent O_EXCL output through the production plugin wrapper', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-wrapped-write-report-'))
+    await mkdir(path.join(agentDir, 'workspace'))
+    const destination = path.join(agentDir, 'workspace', 'research-wrapper.md')
+    const wrapped = wrapPluginTool(createWriteReportTool(), {
+      pluginName: 'researcher',
+      toolName: 'researcher_1',
+      agentDir,
+      sessionId: `write-report-${Date.now()}`,
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    try {
+      const execution = wrapped.execute(
+        'c',
+        { path: destination, content: '# Wrapped report' },
+        undefined,
+        undefined,
+        {} as never,
+      )
+      if (lacksInodeAnchoring) {
+        await expect(execution).rejects.toThrow(/requires Linux inode anchoring/i)
+        return
+      }
+      const result = await execution
+      expect(textOfFirstContent(result)).toContain('Wrote research report')
+      expect(await readFile(destination, 'utf8')).toBe('# Wrapped report')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('memory delete_topic_shard keeps its destructive semantic path unchanged through the production wrapper', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-wrapped-delete-topic-'))
+    const topics = path.join(agentDir, 'memory', 'topics')
+    await mkdir(topics, { recursive: true })
+    await writeFile(path.join(topics, 'obsolete.md'), 'old')
+    const subagent = createDreamingSubagent()
+    const deleteTool = subagent.customTools?.[0]
+    if (deleteTool === undefined) throw new Error('dreaming delete tool was not registered')
+    const wrapped = wrapPluginTool(deleteTool, {
+      pluginName: 'memory',
+      toolName: 'dreaming_0',
+      agentDir,
+      sessionId: 'delete-topic',
+      logger: noopLogger,
+      hooks: createHookBus(),
+    })
+    try {
+      const rejected = await wrapped.execute(
+        'absolute',
+        { path: path.join(topics, 'obsolete.md') },
+        undefined,
+        undefined,
+        {} as never,
+      )
+      expect(textOfFirstContent(rejected)).toContain('invalid_path')
+      expect(await Bun.file(path.join(topics, 'obsolete.md')).exists()).toBeTrue()
+
+      const deleted = await wrapped.execute(
+        'relative',
+        { path: 'memory/topics/obsolete.md' },
+        undefined,
+        undefined,
+        {} as never,
+      )
+      expect(textOfFirstContent(deleted)).toContain('"ok":true')
+      expect(await Bun.file(path.join(topics, 'obsolete.md')).exists()).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('wrapSystemTool', () => {
+  test('local look_at snapshots share the remote-image byte ceiling', () => {
+    expect(TOOL_INPUT_MAX_BYTES.look_at).toBe(URL_FETCH_MAX_BYTES)
+  })
+
   test('tool.before mutations propagate to TypeClaw system tool execution and tool.after can rewrite the result', async () => {
     const seen: unknown[] = []
     const observed: unknown[] = []
@@ -379,45 +762,56 @@ describe('wrapSystemTool', () => {
     expect(calls).toEqual([])
   })
 
-  test('write system tool exposes and strips guard acknowledgements before execution', async () => {
-    const seen: unknown[] = []
-    const tool = definePiTool({
-      name: 'write',
-      label: 'write',
-      description: '',
-      parameters: Type.Object(
-        {
-          path: Type.String(),
-          content: Type.String(),
+  test.skipIf(lacksInodeAnchoring)(
+    'write system tool exposes and strips guard acknowledgements before execution',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-system-write-ack-'))
+      const seen: unknown[] = []
+      const tool = definePiTool({
+        name: 'write',
+        label: 'write',
+        description: '',
+        parameters: Type.Object(
+          {
+            path: Type.String(),
+            content: Type.String(),
+          },
+          { additionalProperties: false },
+        ),
+        async execute(_callId, params) {
+          seen.push({ ...params, path: 'notes.md' })
+          await writeFile(params.path, params.content)
+          return { content: [{ type: 'text', text: 'wrote' }], details: params }
         },
-        { additionalProperties: false },
-      ),
-      async execute(_callId, params) {
-        seen.push(params)
-        return { content: [{ type: 'text', text: 'wrote' }], details: params }
-      },
-    })
-    const hooks = createHookBus()
-    hooks.registerAll('p1', '/agent', noopLogger, {
-      'tool.before': (event) => {
-        expect(event.args.acknowledgeGuards).toEqual({ nonWorkspaceWrite: true })
-      },
-    })
+      })
+      const hooks = createHookBus()
+      hooks.registerAll('p1', agentDir, noopLogger, {
+        'tool.before': (event) => {
+          expect(event.args.acknowledgeGuards).toEqual({ nonWorkspaceWrite: true })
+        },
+      })
 
-    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 's', hooks })
+      const wrapped = wrapSystemTool(tool, { agentDir, sessionId: 's', hooks })
 
-    const parameters = wrapped.parameters as { properties?: Record<string, unknown> }
-    expect(parameters.properties).toHaveProperty('acknowledgeGuards')
-    await wrapped.execute(
-      'c',
-      { path: 'typeclaw.json', content: '{}', acknowledgeGuards: { nonWorkspaceWrite: true } },
-      undefined,
-      undefined,
-      {} as never,
-    )
+      const parameters = wrapped.parameters as { properties?: Record<string, unknown> }
+      expect(parameters.properties).toHaveProperty('acknowledgeGuards')
+      try {
+        const result = await wrapped.execute(
+          'c',
+          { path: 'notes.md', content: '{}', acknowledgeGuards: { nonWorkspaceWrite: true } },
+          undefined,
+          undefined,
+          {} as never,
+        )
 
-    expect(seen[0]).toEqual({ path: 'typeclaw.json', content: '{}' })
-  })
+        expect(seen[0]).toEqual({ path: 'notes.md', content: '{}' })
+        expect(result.details).toEqual({ path: 'notes.md', content: '{}' })
+        expect(await readFile(path.join(agentDir, 'notes.md'), 'utf8')).toBe('{}')
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
 
   test('write system tool runs a final guard after hook mutations', async () => {
     const calls: number[] = []
@@ -503,15 +897,1030 @@ describe('wrapSystemTool', () => {
     ).rejects.toThrow('Guard `managedConfig` blocked write')
     expect(calls).toEqual([])
   })
+
+  test('hookless system tools deny canonical secrets for read, look_at, and channel uploads', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-hookless-secret-'))
+    await writeFile(path.join(agentDir, '.env'), 'SECRET=never')
+    const cases: Array<{ name: string; args: Record<string, unknown> }> = [
+      { name: 'read', args: { path: '.env' } },
+      { name: 'look_at', args: { images: [{ path: '.env' }] } },
+      { name: 'channel_send', args: { attachments: [{ path: '.env' }] } },
+    ]
+    try {
+      for (const testCase of cases) {
+        let called = false
+        const tool = definePiTool({
+          name: testCase.name,
+          label: testCase.name,
+          description: '',
+          parameters: Type.Any(),
+          async execute() {
+            called = true
+            return { content: [], details: undefined }
+          },
+        })
+        const wrapped = wrapSystemTool(tool, { agentDir, sessionId: 's', hooks: createHookBus() })
+        await expect(wrapped.execute('c', testCase.args, undefined, undefined, {} as never)).rejects.toThrow(
+          /not available to LLM tools/,
+        )
+        expect(called).toBeFalse()
+      }
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('hookless system MCP calls reject nested file URLs before dispatch', async () => {
+    let called = false
+    const tool = definePiTool({
+      name: 'mcp_call',
+      label: 'mcp_call',
+      description: '',
+      parameters: Type.Any(),
+      async execute() {
+        called = true
+        return { content: [], details: undefined }
+      },
+    })
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 'mcp', hooks: createHookBus() })
+    await expect(
+      wrapped.execute(
+        'c',
+        { server: 'files', tool: 'read', args: { nested: { url: 'file:///agent/secrets.json' } } },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).rejects.toThrow(/not available to LLM tools/)
+    expect(called).toBeFalse()
+  })
+
+  test('ambiguous system tools execute explicit file URLs against an immutable pinned copy', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-pinned-url-'))
+    const safe = path.join(agentDir, 'safe.txt')
+    const replacement = path.join(agentDir, 'replacement.txt')
+    await writeFile(safe, 'safe')
+    await writeFile(replacement, 'replacement')
+    let startedResolve: () => void = () => {}
+    const started = new Promise<void>((resolve) => (startedResolve = resolve))
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const tool = definePiTool({
+      name: 'custom_system_reader',
+      label: 'custom_system_reader',
+      description: '',
+      parameters: Type.Any(),
+      async execute(_id, params) {
+        startedResolve()
+        await gate
+        const url = (params.args as { url: string }).url
+        return { content: [{ type: 'text' as const, text: await Bun.file(new URL(url)).text() }], details: undefined }
+      },
+    })
+    const wrapped = wrapSystemTool(tool, { agentDir, sessionId: 'mcp-pinned', hooks: createHookBus() })
+    try {
+      const resultPromise = wrapped.execute(
+        'c',
+        { server: 'files', tool: 'read', args: { url: pathToFileURL(safe).href } },
+        undefined,
+        undefined,
+        {} as never,
+      )
+      await started
+      await rm(safe)
+      await symlink(replacement, safe)
+      release()
+      expect(textOfFirstContent(await resultPromise)).toBe('safe')
+    } finally {
+      release()
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('channel attachments reject process-backed files before opening them', async () => {
+    await expect(
+      enforceAndPinToolFiles({
+        tool: 'channel_send',
+        args: { attachments: [{ path: '/proc/self/environ' }] },
+        agentDir: '/agent',
+      }),
+    ).rejects.toThrow(/virtual|process-backed|not available/i)
+  })
+
+  test('parallel read, look_at, and channel upload calls consume pinned bytes across symlink swaps', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-pinned-read-'))
+    const safe = path.join(agentDir, 'safe.txt')
+    const secret = path.join(agentDir, '.env')
+    const aliases = Array.from({ length: 8 }, (_, i) => path.join(agentDir, `alias-${i}.txt`))
+    await writeFile(safe, 'safe bytes')
+    await writeFile(secret, 'secret bytes')
+    await Promise.all(aliases.map((alias) => symlink(safe, alias)))
+
+    const releases: Array<() => void> = []
+    const started: Promise<void>[] = []
+    const names = [
+      'read',
+      'look_at',
+      'channel_send',
+      'channel_reply',
+      'read',
+      'look_at',
+      'channel_send',
+      'channel_reply',
+    ]
+
+    try {
+      const calls = aliases.map((alias, i) => {
+        const name = names[i] as string
+        const tool = definePiTool({
+          name,
+          label: name,
+          description: '',
+          parameters: Type.Any(),
+          async execute(_callId, params) {
+            let markStarted: () => void = () => {}
+            started.push(new Promise<void>((resolve) => (markStarted = resolve)))
+            let release: () => void = () => {}
+            const gate = new Promise<void>((resolve) => (release = resolve))
+            releases.push(release)
+            markStarted()
+            await gate
+            const inputPath =
+              typeof params.path === 'string'
+                ? params.path
+                : name === 'look_at'
+                  ? (params.images as Array<{ path: string }>)[0]?.path
+                  : (params.attachments as Array<{ path: string }>)[0]?.path
+            if (inputPath === undefined) throw new Error('missing pinned input')
+            return { content: [{ type: 'text' as const, text: await readFile(inputPath, 'utf8') }], details: undefined }
+          },
+        })
+        const wrapped = wrapSystemTool(tool, { agentDir, sessionId: `s-${i}`, hooks: createHookBus() })
+        const args =
+          name === 'read'
+            ? { path: alias }
+            : name === 'look_at'
+              ? { images: [{ path: alias }] }
+              : { attachments: [{ path: alias }] }
+        return wrapped.execute(String(i), args, undefined, undefined, {} as never)
+      })
+      while (started.length < calls.length) await Bun.sleep(1)
+      await Promise.all(started)
+      await Promise.all(aliases.map((alias) => rm(alias)))
+      await Promise.all(aliases.map((alias) => symlink(secret, alias)))
+      for (const release of releases) release()
+      const results = await Promise.all(calls)
+      expect(results.map((result) => textOfFirstContent(result))).toEqual(
+        Array.from({ length: calls.length }, () => 'safe bytes'),
+      )
+    } finally {
+      for (const release of releases) release()
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('absent input operands cannot appear as secret symlinks before execution', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-absent-input-'))
+    const secret = path.join(agentDir, '.env')
+    await writeFile(secret, 'secret bytes')
+    const aliases = Array.from({ length: 24 }, (_, i) => path.join(agentDir, `late-${i}.txt`))
+    let called = 0
+    const tool = definePiTool({
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({ path: Type.String() }),
+      async execute() {
+        called++
+        return { content: [], details: undefined }
+      },
+    })
+
+    try {
+      const calls = aliases.map((alias, i) => {
+        const wrapped = wrapSystemTool(tool, { agentDir, sessionId: `late-${i}`, hooks: createHookBus() })
+        return wrapped.execute(String(i), { path: alias }, undefined, undefined, {} as never).then(
+          () => false,
+          () => true,
+        )
+      })
+      await Promise.all(aliases.map((alias) => symlink(secret, alias).catch(() => {})))
+      expect(await Promise.all(calls)).toEqual(Array.from({ length: aliases.length }, () => true))
+      expect(called).toBe(0)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.skipIf(lacksInodeAnchoring)(
+    'a nonexistent write destination remains valid because it is output, not input',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-output-destination-'))
+      await mkdir(path.join(agentDir, 'workspace'))
+      const destination = path.join(agentDir, 'workspace', 'new-output.txt')
+      const tool = definePiTool({
+        name: 'write',
+        label: 'write',
+        description: '',
+        parameters: Type.Object({ path: Type.String(), content: Type.String() }),
+        async execute(_callId, params) {
+          expect(await Bun.file(destination).exists()).toBeFalse()
+          await writeFile(params.path, params.content)
+          return { content: [{ type: 'text' as const, text: 'wrote' }], details: undefined }
+        },
+      })
+      const wrapped = wrapSystemTool(tool, { agentDir, sessionId: 'output', hooks: createHookBus() })
+      try {
+        await wrapped.execute('c', { path: destination, content: 'ok' }, undefined, undefined, {} as never)
+        expect(await readFile(destination, 'utf8')).toBe('ok')
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test('missing-parent writes fail closed before creating or authorizing an unanchored path', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-missing-parent-output-'))
+    const destination = path.join(agentDir, 'workspace', 'missing', 'output.txt')
+    try {
+      await expect(
+        enforceAndPinToolFiles({ tool: 'write', args: { path: destination, content: 'x' }, agentDir }),
+      ).rejects.toThrow(/parent|anchor|Linux/i)
+      expect(await Bun.file(destination).exists()).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('an already-aborted write stops before path authorization or filesystem mutation', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-aborted-output-auth-'))
+    const destination = path.join(agentDir, '.env')
+    const controller = new AbortController()
+    controller.abort('cancel before authorization')
+    try {
+      await expect(
+        enforceAndPinToolFiles({
+          tool: 'write',
+          args: { path: destination, content: 'never' },
+          agentDir,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow(/abort|cancel/i)
+      expect(await Bun.file(destination).exists()).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects oversized read, look_at, and channel-upload inputs before tool execution', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-oversized-input-'))
+    const cases = [
+      { name: 'read', limit: TOOL_INPUT_MAX_BYTES.read, args: (file: string) => ({ path: file }) },
+      { name: 'look_at', limit: TOOL_INPUT_MAX_BYTES.look_at, args: (file: string) => ({ images: [{ path: file }] }) },
+      {
+        name: 'channel_send',
+        limit: TOOL_INPUT_MAX_BYTES.channel_upload,
+        args: (file: string) => ({ attachments: [{ path: file }] }),
+      },
+    ]
+    let called = 0
+    try {
+      for (const [index, testCase] of cases.entries()) {
+        const file = path.join(agentDir, `oversized-${index}.bin`)
+        await writeFile(file, '')
+        await truncate(file, testCase.limit + 1)
+        const tool = definePiTool({
+          name: testCase.name,
+          label: testCase.name,
+          description: '',
+          parameters: Type.Any(),
+          async execute() {
+            called++
+            return { content: [], details: undefined }
+          },
+        })
+        const wrapped = wrapSystemTool(tool, {
+          agentDir,
+          sessionId: `oversized-${index}`,
+          hooks: createHookBus(),
+        })
+        await expect(
+          wrapped.execute(String(index), testCase.args(file), undefined, undefined, {} as never),
+        ).rejects.toThrow(new RegExp(`> ${testCase.limit} byte limit`))
+      }
+      expect(called).toBe(0)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects repeated near-limit look_at and channel attachments over the aggregate byte ceiling', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-aggregate-input-'))
+    const snapshotRoot = path.join(agentDir, 'snapshots')
+    await mkdir(snapshotRoot)
+    const cases = [
+      {
+        tool: 'look_at',
+        limit: TOOL_INPUT_MAX_BYTES.look_at,
+        args: (files: string[]) => ({ images: files.map((file) => ({ path: file })) }),
+      },
+      {
+        tool: 'channel_send',
+        limit: TOOL_INPUT_MAX_BYTES.channel_upload,
+        args: (files: string[]) => ({ attachments: files.map((file) => ({ path: file })) }),
+      },
+    ]
+    try {
+      for (const [index, testCase] of cases.entries()) {
+        const files = [
+          path.join(agentDir, `near-limit-${index}-a.bin`),
+          path.join(agentDir, `near-limit-${index}-b.bin`),
+        ]
+        await Promise.all(
+          files.map(async (file) => {
+            await writeFile(file, '')
+            await truncate(file, Math.floor(testCase.limit * 0.75))
+          }),
+        )
+
+        await expect(
+          enforceAndPinToolFiles({
+            tool: testCase.tool,
+            args: testCase.args(files),
+            agentDir,
+            tempRoot: snapshotRoot,
+          }),
+        ).rejects.toThrow(/aggregate.*byte limit/i)
+        expect(await readdir(snapshotRoot)).toEqual([])
+      }
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects unbounded local-input arrays at the per-invocation count ceiling before snapshotting', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-input-count-'))
+    const snapshotRoot = path.join(agentDir, 'snapshots')
+    await mkdir(snapshotRoot)
+    const file = path.join(agentDir, 'small.bin')
+    await writeFile(file, 'x')
+    try {
+      await expect(
+        enforceAndPinToolFiles({
+          tool: 'look_at',
+          args: { images: Array.from({ length: TOOL_INPUT_MAX_COUNT.look_at + 1 }, () => ({ path: file })) },
+          agentDir,
+          tempRoot: snapshotRoot,
+        }),
+      ).rejects.toThrow(new RegExp(`count.*> ${TOOL_INPUT_MAX_COUNT.look_at}`, 'i'))
+      expect(await readdir(snapshotRoot)).toEqual([])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cleans a partial snapshot when a later attachment exceeds its byte limit', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-snapshot-cleanup-'))
+    const snapshotRoot = path.join(agentDir, 'snapshots')
+    await mkdir(snapshotRoot)
+    const small = path.join(agentDir, 'small.txt')
+    const oversized = path.join(agentDir, 'oversized.bin')
+    await writeFile(small, 'small')
+    await writeFile(oversized, '')
+    await truncate(oversized, TOOL_INPUT_MAX_BYTES.channel_upload + 1)
+    try {
+      await expect(
+        enforceAndPinToolFiles({
+          tool: 'channel_reply',
+          args: { attachments: [{ path: small }, { path: oversized }] },
+          agentDir,
+          tempRoot: snapshotRoot,
+        }),
+      ).rejects.toThrow(/tool input is too large/)
+      expect(await readdir(snapshotRoot)).toEqual([])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('removes a successful immutable snapshot when tool execution cleanup runs', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-snapshot-success-'))
+    const snapshotRoot = path.join(agentDir, 'snapshots')
+    await mkdir(snapshotRoot)
+    const input = path.join(agentDir, 'input.txt')
+    await writeFile(input, 'bounded input')
+    const args: Record<string, unknown> = { path: input }
+    try {
+      const pinned = await enforceAndPinToolFiles({ tool: 'read', args, agentDir, tempRoot: snapshotRoot })
+      expect(await readdir(snapshotRoot)).toHaveLength(1)
+      expect(await readFile(args.path as string, 'utf8')).toBe('bounded input')
+      await pinned.cleanup()
+      expect(await readdir(snapshotRoot)).toEqual([])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('direct snapshots reject a file hardlinked to .env after initial authorization but before open', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-direct-hardlink-race-'))
+    const holderFiles = Array.from({ length: PINNED_SNAPSHOT_GLOBAL_MAX_COUNT }, (_, i) =>
+      path.join(agentDir, `holder-${i}.txt`),
+    )
+    const input = path.join(agentDir, 'input.txt')
+    const env = path.join(agentDir, '.env')
+    await Promise.all(holderFiles.map(async (file) => await writeFile(file, 'x')))
+    await writeFile(input, 'safe before hardlink')
+    let holder: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+    try {
+      holder = await enforceAndPinToolFiles({
+        tool: 'channel_send',
+        args: { attachments: holderFiles.map((file) => ({ path: file })) },
+        agentDir,
+      })
+      let dispatched = false
+      const waiting = enforceAndPinToolFiles({ tool: 'read', args: { path: input }, agentDir }).then(
+        async (pinned) => {
+          dispatched = true
+          await pinned.cleanup()
+          return undefined
+        },
+        (error: unknown) => error,
+      )
+      await Bun.sleep(10)
+      await link(input, env)
+      await holder.cleanup()
+      holder = undefined
+
+      const failure = await waiting
+      expect(failure).toBeInstanceOf(Error)
+      expect((failure as Error).message).toMatch(
+        /(?:not available to LLM tools|hard links.*copy.*unique regular file)/i,
+      )
+      expect(dispatched).toBeFalse()
+    } finally {
+      await holder?.cleanup()
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.skipIf(process.platform !== 'linux')(
+    'recursive directory snapshots reject a nested file hardlinked to .env',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-tree-hardlink-'))
+      const tree = path.join(agentDir, 'safe-tree', 'nested')
+      const env = path.join(agentDir, '.env')
+      await mkdir(tree, { recursive: true })
+      await writeFile(env, 'secret')
+      await link(env, path.join(tree, 'alias.txt'))
+      try {
+        await expect(
+          enforceAndPinToolFiles({ tool: 'grep', args: { path: path.join(agentDir, 'safe-tree') }, agentDir }),
+        ).rejects.toThrow(/hardlink|hard links|aliases cannot be bounded/i)
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test('holds the process-wide pinned-count reservation through cleanup', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-global-snapshot-budget-'))
+    const files = Array.from({ length: PINNED_SNAPSHOT_GLOBAL_MAX_COUNT + 1 }, (_, i) =>
+      path.join(agentDir, `${i}.png`),
+    )
+    await Promise.all(files.map(async (file) => await writeFile(file, 'x')))
+    const make = (slice: string[]) =>
+      enforceAndPinToolFiles({
+        tool: 'look_at',
+        args: { images: slice.map((file) => ({ path: file })) },
+        agentDir,
+      })
+    let first: Awaited<ReturnType<typeof make>> | undefined
+    let second: Awaited<ReturnType<typeof make>> | undefined
+    let third: Awaited<ReturnType<typeof make>> | undefined
+    try {
+      first = await make(files.slice(0, TOOL_INPUT_MAX_COUNT.look_at))
+      second = await make(files.slice(TOOL_INPUT_MAX_COUNT.look_at, PINNED_SNAPSHOT_GLOBAL_MAX_COUNT))
+      let settled = false
+      const waiting = make([files[PINNED_SNAPSHOT_GLOBAL_MAX_COUNT] as string]).then((value) => {
+        settled = true
+        return value
+      })
+      await Bun.sleep(10)
+      expect(settled).toBeFalse()
+      await first.cleanup()
+      first = undefined
+      third = await waiting
+      expect(settled).toBeTrue()
+    } finally {
+      await first?.cleanup()
+      await second?.cleanup()
+      await third?.cleanup()
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('aborting a queued snapshot waiter removes it without consuming capacity', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-aborted-snapshot-waiter-'))
+    const files = Array.from({ length: PINNED_SNAPSHOT_GLOBAL_MAX_COUNT + 1 }, (_, i) =>
+      path.join(agentDir, `${i}.bin`),
+    )
+    await Promise.all(files.map(async (file) => await writeFile(file, 'x')))
+    let holder: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+    try {
+      holder = await enforceAndPinToolFiles({
+        tool: 'channel_send',
+        args: { attachments: files.slice(0, PINNED_SNAPSHOT_GLOBAL_MAX_COUNT).map((file) => ({ path: file })) },
+        agentDir,
+      })
+      const controller = new AbortController()
+      const waiting = enforceAndPinToolFiles({
+        tool: 'read',
+        args: { path: files[PINNED_SNAPSHOT_GLOBAL_MAX_COUNT] as string },
+        agentDir,
+        signal: controller.signal,
+      })
+      controller.abort('cancelled test waiter')
+      await expect(waiting).rejects.toThrow(/abort|cancel/i)
+      await holder.cleanup()
+      holder = undefined
+      const next = await enforceAndPinToolFiles({
+        tool: 'read',
+        args: { path: files[PINNED_SNAPSHOT_GLOBAL_MAX_COUNT] as string },
+        agentDir,
+      })
+      await next.cleanup()
+    } finally {
+      await holder?.cleanup()
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects excess queued snapshot waiters with a deterministic bound', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-bounded-snapshot-waiters-'))
+    const files = Array.from({ length: PINNED_SNAPSHOT_GLOBAL_MAX_COUNT + 1 }, (_, i) =>
+      path.join(agentDir, `${i}.bin`),
+    )
+    await Promise.all(files.map(async (file) => await writeFile(file, 'x')))
+    const controllers: AbortController[] = []
+    let holder: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+    try {
+      holder = await enforceAndPinToolFiles({
+        tool: 'channel_send',
+        args: { attachments: files.slice(0, PINNED_SNAPSHOT_GLOBAL_MAX_COUNT).map((file) => ({ path: file })) },
+        agentDir,
+      })
+      const waiters = Array.from({ length: PINNED_SNAPSHOT_MAX_WAITERS }, () => {
+        const controller = new AbortController()
+        controllers.push(controller)
+        return enforceAndPinToolFiles({
+          tool: 'read',
+          args: { path: files[PINNED_SNAPSHOT_GLOBAL_MAX_COUNT] as string },
+          agentDir,
+          signal: controller.signal,
+        })
+      })
+      await expect(
+        enforceAndPinToolFiles({
+          tool: 'read',
+          args: { path: files[PINNED_SNAPSHOT_GLOBAL_MAX_COUNT] as string },
+          agentDir,
+        }),
+      ).rejects.toThrow(/waiter|queue/i)
+      for (const controller of controllers) controller.abort()
+      await Promise.allSettled(waiters)
+    } finally {
+      await holder?.cleanup()
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('charges streamed file growth against the process-wide byte budget', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-growing-snapshot-budget-'))
+    const firstFile = path.join(agentDir, 'first.bin')
+    const growingFile = path.join(agentDir, 'growing.bin')
+    const secondFile = path.join(agentDir, 'second.bin')
+    await Promise.all([writeFile(firstFile, ''), writeFile(growingFile, ''), writeFile(secondFile, '')])
+    await Promise.all([
+      truncate(firstFile, 41 * 1024 * 1024),
+      truncate(growingFile, 60 * 1024 * 1024),
+      truncate(secondFile, 38 * 1024 * 1024),
+    ])
+    let first: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+    let second: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+    let unexpected: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+    try {
+      first = await enforceAndPinToolFiles({
+        tool: 'channel_send',
+        args: { attachments: [{ path: firstFile }] },
+        agentDir,
+      })
+      const growing = enforceAndPinToolFiles({ tool: 'read', args: { path: growingFile }, agentDir }).then((value) => {
+        unexpected = value
+        return value
+      })
+      const queuedSecond = enforceAndPinToolFiles({
+        tool: 'channel_send',
+        args: { attachments: [{ path: secondFile }] },
+        agentDir,
+      })
+      await Bun.sleep(10)
+      await truncate(growingFile, 64 * 1024 * 1024)
+      await first.cleanup()
+      first = undefined
+      second = await queuedSecond
+      await expect(growing).rejects.toThrow(/process-wide pinned byte budget|snapshot growth/i)
+    } finally {
+      await first?.cleanup()
+      await second?.cleanup()
+      await unexpected?.cleanup()
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.skipIf(process.platform !== 'linux')(
+    'grep executes against an immutable directory snapshot across a symlink swap',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-grep-snapshot-'))
+      const safeDir = path.join(agentDir, 'safe')
+      const secretDir = path.join(agentDir, 'secret')
+      const alias = path.join(agentDir, 'search')
+      await mkdir(safeDir)
+      await mkdir(secretDir)
+      await writeFile(path.join(safeDir, 'result.txt'), 'safe')
+      await writeFile(path.join(secretDir, 'result.txt'), 'secret')
+      await symlink(safeDir, alias)
+      let startedResolve: () => void = () => {}
+      const started = new Promise<void>((resolve) => (startedResolve = resolve))
+      let release: () => void = () => {}
+      const gate = new Promise<void>((resolve) => (release = resolve))
+      const tool = definePiTool({
+        name: 'grep',
+        label: 'grep',
+        description: '',
+        parameters: Type.Any(),
+        async execute(_id, params) {
+          expect((await stat(params.path as string)).mode & 0o777).toBe(0o500)
+          expect((await stat(path.join(params.path as string, 'result.txt'))).mode & 0o777).toBe(0o400)
+          startedResolve()
+          await gate
+          return {
+            content: [
+              { type: 'text' as const, text: await readFile(path.join(params.path as string, 'result.txt'), 'utf8') },
+            ],
+            details: undefined,
+          }
+        },
+      })
+      const wrapped = wrapBuiltinToolDefinition(tool, {
+        agentDir,
+        sessionId: 'grep-snapshot',
+        hooks: createHookBus(),
+      })
+      try {
+        const resultPromise = wrapped.execute('c', { path: alias }, undefined, undefined, {} as never)
+        await started
+        await rm(alias)
+        await symlink(secretDir, alias)
+        release()
+        expect(textOfFirstContent(await resultPromise)).toBe('safe')
+      } finally {
+        release()
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test.skipIf(process.platform !== 'linux')(
+    'grep, find, and ls omitted and explicit roots preserve visible discovery while excluding role-hidden descendants',
+    async () => {
+      const guestTree: SessionOrigin = {
+        kind: 'subagent',
+        subagent: 'tree-test',
+        parentSessionId: 'parent',
+        spawnedByRole: 'guest',
+      }
+      for (const rootMode of ['omitted', 'explicit'] as const) {
+        for (const name of ['grep', 'find', 'ls']) {
+          const agentDir = await mkdtemp(path.join(tmpdir(), `typeclaw-${name}-${rootMode}-hidden-`))
+          await writeFile(path.join(agentDir, 'visible.txt'), 'needle')
+          await writeFile(path.join(agentDir, '.env'), 'SECRET=never')
+          await writeFile(path.join(agentDir, 'secrets.json'), '{"secret":true}')
+          for (const hiddenDir of ['sessions', 'memory', 'workspace']) {
+            await mkdir(path.join(agentDir, hiddenDir))
+            await writeFile(path.join(agentDir, hiddenDir, 'hidden.txt'), 'needle')
+          }
+          const tool = definePiTool({
+            name,
+            label: name,
+            description: '',
+            parameters: Type.Any(),
+            async execute(_id, params) {
+              const entries = await readdir(params.path as string)
+              return {
+                content: [{ type: 'text' as const, text: entries.sort().join('\n') }],
+                details: { path: params.path },
+              }
+            },
+          })
+          const wrapped = wrapBuiltinToolDefinition(tool, {
+            agentDir,
+            sessionId: `${name}-${rootMode}-hidden`,
+            hooks: createHookBus(),
+            getOrigin: () => guestTree,
+            permissions: createPermissionService(),
+          })
+          try {
+            const result = await wrapped.execute(
+              'c',
+              rootMode === 'omitted' ? {} : { path: '.' },
+              undefined,
+              undefined,
+              {} as never,
+            )
+            expect(textOfFirstContent(result)).toBe('visible.txt')
+            expect(result.details).toEqual({ path: '.' })
+          } finally {
+            await rm(agentDir, { recursive: true, force: true })
+          }
+        }
+      }
+    },
+  )
+
+  test.skipIf(process.platform !== 'linux')(
+    'grep, find, and ls agent-root snapshots skip repository and dependency internals before traversal',
+    async () => {
+      for (const rootMode of ['omitted', 'explicit'] as const) {
+        for (const name of ['grep', 'find', 'ls']) {
+          const agentDir = await mkdtemp(path.join(tmpdir(), `typeclaw-${name}-${rootMode}-root-internals-`))
+          const outside = path.join(tmpdir(), `typeclaw-${name}-${rootMode}-outside-${Date.now()}.txt`)
+          await mkdir(path.join(agentDir, 'visible', 'nested'), { recursive: true })
+          await writeFile(path.join(agentDir, 'visible', 'nested', 'result.txt'), 'visible')
+          await writeFile(outside, 'outside')
+          for (const internal of ['.git', '.gitstore', 'node_modules']) {
+            const internalDir = path.join(agentDir, internal, 'deep')
+            await mkdir(internalDir, { recursive: true })
+            await symlink(outside, path.join(internalDir, 'must-not-open'))
+            const oversized = path.join(internalDir, 'must-not-copy.bin')
+            await writeFile(oversized, '')
+            await truncate(oversized, 65 * 1024 * 1024)
+          }
+          const tool = definePiTool({
+            name,
+            label: name,
+            description: '',
+            parameters: Type.Any(),
+            async execute(_id, params) {
+              const entries = await readdir(params.path as string)
+              const nested = await readFile(path.join(params.path as string, 'visible', 'nested', 'result.txt'), 'utf8')
+              return {
+                content: [{ type: 'text' as const, text: `${entries.sort().join('\n')}\n${nested}` }],
+                details: { path: params.path },
+              }
+            },
+          })
+          const wrapped = wrapBuiltinToolDefinition(tool, {
+            agentDir,
+            sessionId: `${name}-${rootMode}-root-internals`,
+            hooks: createHookBus(),
+          })
+          try {
+            const result = await wrapped.execute(
+              'c',
+              rootMode === 'omitted' ? {} : { path: '.' },
+              undefined,
+              undefined,
+              {} as never,
+            )
+            expect(textOfFirstContent(result)).toBe('visible\nvisible')
+            expect(result.details).toEqual({ path: '.' })
+          } finally {
+            await rm(agentDir, { recursive: true, force: true })
+            await rm(outside, { force: true })
+          }
+        }
+      }
+    },
+  )
+
+  test.skipIf(process.platform !== 'linux')(
+    'an explicitly targeted package subdirectory remains readable through a normal tree snapshot',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-explicit-package-tree-'))
+      const packageDir = path.join(agentDir, 'node_modules', 'safe-package', 'nested')
+      await mkdir(packageDir, { recursive: true })
+      await writeFile(path.join(packageDir, 'index.js'), 'safe-package')
+      const tool = definePiTool({
+        name: 'ls',
+        label: 'ls',
+        description: '',
+        parameters: Type.Any(),
+        async execute(_id, params) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: await readFile(path.join(params.path as string, 'nested', 'index.js'), 'utf8'),
+              },
+            ],
+            details: undefined,
+          }
+        },
+      })
+      const wrapped = wrapBuiltinToolDefinition(tool, {
+        agentDir,
+        sessionId: 'explicit-package-tree',
+        hooks: createHookBus(),
+      })
+      try {
+        const result = await wrapped.execute(
+          'c',
+          { path: 'node_modules/safe-package' },
+          undefined,
+          undefined,
+          {} as never,
+        )
+        expect(textOfFirstContent(result)).toBe('safe-package')
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test('grep, find, and ls normalize omitted roots before production security hooks run', async () => {
+    for (const name of ['grep', 'find', 'ls']) {
+      const seenPaths: unknown[] = []
+      const hooks = createHookBus()
+      hooks.registerAll('security', '/agent', noopLogger, {
+        'tool.before': (event) => {
+          seenPaths.push(event.args.path)
+          return { block: true, reason: 'default root inspected' }
+        },
+      })
+      const tool = definePiTool({
+        name,
+        label: name,
+        description: '',
+        parameters: Type.Any(),
+        async execute() {
+          return { content: [], details: undefined }
+        },
+      })
+      const wrapped = wrapBuiltinToolDefinition(tool, {
+        agentDir: '/agent',
+        sessionId: `${name}-default-hook`,
+        hooks,
+      })
+      await expect(wrapped.execute('c', {}, undefined, undefined, {} as never)).rejects.toThrow(
+        'blocked: default root inspected',
+      )
+      expect(seenPaths).toEqual(['.'])
+    }
+  })
+
+  test.skipIf(process.platform !== 'linux')(
+    'grep, find, and ls omitted roots execute against immutable snapshots across symlink swaps',
+    async () => {
+      for (const name of ['grep', 'find', 'ls']) {
+        const agentDir = await mkdtemp(path.join(tmpdir(), `typeclaw-${name}-omitted-swap-`))
+        const visible = path.join(agentDir, 'result.txt')
+        const secret = path.join(tmpdir(), `typeclaw-${name}-secret-${Date.now()}.txt`)
+        await writeFile(visible, 'safe')
+        await writeFile(secret, 'secret')
+        let startedResolve: () => void = () => {}
+        const started = new Promise<void>((resolve) => (startedResolve = resolve))
+        let release: () => void = () => {}
+        const gate = new Promise<void>((resolve) => (release = resolve))
+        const tool = definePiTool({
+          name,
+          label: name,
+          description: '',
+          parameters: Type.Any(),
+          async execute(_id, params) {
+            startedResolve()
+            await gate
+            return {
+              content: [
+                { type: 'text' as const, text: await readFile(path.join(params.path as string, 'result.txt'), 'utf8') },
+              ],
+              details: { path: params.path },
+            }
+          },
+        })
+        const wrapped = wrapBuiltinToolDefinition(tool, {
+          agentDir,
+          sessionId: `${name}-omitted-swap`,
+          hooks: createHookBus(),
+        })
+        try {
+          const resultPromise = wrapped.execute('c', {}, undefined, undefined, {} as never)
+          await started
+          await rm(visible)
+          await symlink(secret, visible)
+          release()
+          const result = await resultPromise
+          expect(textOfFirstContent(result)).toBe('safe')
+          expect(result.details).toEqual({ path: '.' })
+        } finally {
+          release()
+          await rm(agentDir, { recursive: true, force: true })
+          await rm(secret, { force: true })
+        }
+      }
+    },
+  )
+
+  test.skipIf(process.platform !== 'linux')(
+    'anchors a write to its opened inode across a secret symlink swap',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-output-swap-'))
+      const destination = path.join(agentDir, 'workspace', 'output.txt')
+      const secret = path.join(agentDir, '.env')
+      await mkdir(path.dirname(destination))
+      await writeFile(destination, 'old')
+      await writeFile(secret, 'SECRET=untouched')
+      const args: Record<string, unknown> = { path: destination, content: 'safe output' }
+      const pinned = await enforceAndPinToolFiles({ tool: 'write', args, agentDir })
+      try {
+        await rm(destination)
+        await symlink(secret, destination)
+        await writeFile(args.path as string, 'safe output')
+        expect(await readFile(secret, 'utf8')).toBe('SECRET=untouched')
+        expect(await readFile(args.path as string, 'utf8')).toBe('safe output')
+        await expect(pinned.cleanup()).rejects.toThrow(/changed|symbolic|ELOOP/i)
+      } finally {
+        await pinned.cleanup()
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test.skipIf(process.platform !== 'linux')(
+    'a missing output basename cannot be raced into a hardlink before the real write opens it',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-new-output-race-'))
+      const workspace = path.join(agentDir, 'workspace')
+      const destination = path.join(workspace, 'output.txt')
+      const secret = path.join(agentDir, 'protected.txt')
+      await mkdir(workspace)
+      await writeFile(secret, 'untouched')
+      const args: Record<string, unknown> = { path: destination, content: 'unsafe' }
+      const pinned = await enforceAndPinToolFiles({ tool: 'write', args, agentDir })
+      try {
+        expect(await Bun.file(destination).exists()).toBeFalse()
+        await link(secret, destination)
+        await expect(writeToolOutputNoFollow(args.path as string, 'unsafe')).rejects.toThrow()
+        expect(await readFile(secret, 'utf8')).toBe('untouched')
+        await expect(pinned.cleanup()).rejects.toThrow(/single-link|changed/i)
+      } finally {
+        await pinned.cleanup()
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
 })
 
 describe('wrapBuiltinToolDefinition (hook + guard pipeline)', () => {
+  test('hookless builtin read cannot open a canonical credential', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-hookless-builtin-'))
+    await writeFile(path.join(agentDir, '.env'), 'SECRET=never')
+    let called = false
+    const tool = {
+      name: 'grep',
+      label: 'grep',
+      description: '',
+      parameters: Type.Object({ path: Type.String() }),
+      async execute() {
+        called = true
+        return { content: [], details: undefined }
+      },
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 's',
+      hooks: createHookBus(),
+    })
+    try {
+      await expect(wrapped.execute('c', { path: '.env' }, undefined, undefined, {} as never)).rejects.toThrow(
+        /not available to LLM tools/,
+      )
+      expect(called).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
   test('tool.before and tool.after fire for built-in pi tool definitions and can rewrite the result', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-hooked-grep-'))
+    const original = path.join(agentDir, 'original')
+    const mutated = path.join(agentDir, 'mutated')
+    await writeFile(original, 'original')
+    await writeFile(mutated, 'mutated')
     const seen: unknown[] = []
     const observed: unknown[] = []
     const tool = {
-      name: 'read',
-      label: 'read',
+      name: 'grep',
+      label: 'grep',
       description: '',
       parameters: Type.Object({ path: Type.String() }),
       async execute(_callId: string, params: { path: string }) {
@@ -520,9 +1929,9 @@ describe('wrapBuiltinToolDefinition (hook + guard pipeline)', () => {
       },
     }
     const hooks = createHookBus()
-    hooks.registerAll('p1', '/agent', noopLogger, {
+    hooks.registerAll('p1', agentDir, noopLogger, {
       'tool.before': (event) => {
-        event.args.path = '/mutated'
+        event.args.path = mutated
       },
       'tool.after': (event) => {
         observed.push(event.result.details)
@@ -531,13 +1940,17 @@ describe('wrapBuiltinToolDefinition (hook + guard pipeline)', () => {
       },
     })
 
-    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir: '/agent', sessionId: 's', hooks })
+    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir, sessionId: 's', hooks })
 
-    const result = await wrapped.execute('c', { path: '/original' }, undefined, undefined, {} as never)
-    expect(textOfFirstContent(result)).toBe('rewritten read')
-    expect(result.details as Record<string, unknown>).toEqual({ rewritten: true })
-    expect(seen[0]).toEqual({ path: '/mutated' })
-    expect(observed[0]).toEqual({ path: '/mutated' })
+    try {
+      const result = await wrapped.execute('c', { path: original }, undefined, undefined, {} as never)
+      expect(textOfFirstContent(result)).toBe('rewritten read')
+      expect(result.details as Record<string, unknown>).toEqual({ rewritten: true })
+      expect((seen[0] as { path: string }).path).not.toBe(mutated)
+      expect(observed[0]).toEqual({ path: mutated })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
   })
 
   test('tool.before { block: true } rejects built-in pi-style agent tool execution through the engine error path', async () => {
@@ -568,82 +1981,103 @@ describe('wrapBuiltinToolDefinition (hook + guard pipeline)', () => {
   // pi's bash tool REJECTS on non-zero exit. Without a finally-style after-run,
   // a tool.after hook that releases a reservation (the github approve guard)
   // never fires, stranding the PR as "already approved" on retry (PR #672).
-  test('tool.after fires with an error result when a built-in agent tool throws, then rethrows', async () => {
+  test('tool.after fires with an error result when a built-in file tool throws, then rethrows', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-throwing-grep-'))
+    const input = path.join(agentDir, 'input.txt')
+    await writeFile(input, 'input')
     const afterResults: unknown[] = []
     const tool = {
-      name: 'bash',
-      label: 'bash',
+      name: 'grep',
+      label: 'grep',
       description: '',
-      parameters: Type.Object({ command: Type.String() }),
-      async execute(_callId: string, _params: { command: string }) {
+      parameters: Type.Object({ path: Type.String() }),
+      async execute(_callId: string, _params: { path: string }) {
         throw new Error('no such file or directory')
       },
     }
     const hooks = createHookBus()
-    hooks.registerAll('p1', '/agent', noopLogger, {
+    hooks.registerAll('p1', agentDir, noopLogger, {
       'tool.after': (event) => {
         afterResults.push(event.result)
       },
     })
 
-    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir: '/agent', sessionId: 's', hooks })
+    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir, sessionId: 's', hooks })
 
-    await expect(
-      wrapped.execute('c', { command: 'gh api --input /tmp/x' } as never, undefined, undefined, {} as never),
-    ).rejects.toThrow('no such file or directory')
-    expect(afterResults).toHaveLength(1)
-    const errorText = ((afterResults[0] as ToolResult).content as Array<{ type: string; text?: string }>)
-      .filter((p) => p.type === 'text')
-      .map((p) => p.text)
-      .join('\n')
-    expect(errorText).toContain('no such file or directory')
-  })
-
-  test('edit built-in agent tool exposes and strips guard acknowledgements before execution', async () => {
-    const seen: unknown[] = []
-    const tool = {
-      name: 'edit',
-      label: 'edit',
-      description: '',
-      parameters: Type.Object(
-        {
-          path: Type.String(),
-          edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
-        },
-        { additionalProperties: false },
-      ),
-      async execute(
-        _callId: string,
-        params: {
-          path: string
-          edits: { oldText: string; newText: string }[]
-          acknowledgeGuards?: { nonWorkspaceWrite?: boolean }
-        },
-      ) {
-        seen.push(params)
-        return { content: [{ type: 'text' as const, text: 'edited' }], details: params }
-      },
+    try {
+      await expect(wrapped.execute('c', { path: input } as never, undefined, undefined, {} as never)).rejects.toThrow(
+        'no such file or directory',
+      )
+      expect(afterResults).toHaveLength(1)
+      const errorText = ((afterResults[0] as ToolResult).content as Array<{ type: string; text?: string }>)
+        .filter((p) => p.type === 'text')
+        .map((p) => p.text)
+        .join('\n')
+      expect(errorText).toContain('no such file or directory')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
     }
-    const hooks = createHookBus()
-    hooks.registerAll('p1', '/agent', noopLogger, {
-      'tool.before': (event) => {
-        expect(event.args.acknowledgeGuards).toEqual({ nonWorkspaceWrite: true })
-      },
-    })
-
-    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir: '/agent', sessionId: 's', hooks })
-
-    const parameters = wrapped.parameters as { properties?: Record<string, unknown> }
-    expect(parameters.properties).toHaveProperty('acknowledgeGuards')
-    const params = {
-      path: 'notes.md',
-      edits: [{ oldText: 'x', newText: 'y' }],
-      acknowledgeGuards: { nonWorkspaceWrite: true },
-    } as unknown as Parameters<typeof wrapped.execute>[1]
-    await wrapped.execute('c', params, undefined, undefined, {} as never)
-
-    expect(seen[0]).toEqual({ path: 'notes.md', edits: [{ oldText: 'x', newText: 'y' }] })
   })
+
+  test.skipIf(lacksInodeAnchoring)(
+    'edit built-in agent tool exposes and strips guard acknowledgements before execution',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-builtin-edit-ack-'))
+      const notes = path.join(agentDir, 'notes.md')
+      await writeFile(notes, 'x')
+      const seen: unknown[] = []
+      const tool = {
+        name: 'edit',
+        label: 'edit',
+        description: '',
+        parameters: Type.Object(
+          {
+            path: Type.String(),
+            edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+          },
+          { additionalProperties: false },
+        ),
+        async execute(
+          _callId: string,
+          params: {
+            path: string
+            edits: { oldText: string; newText: string }[]
+            acknowledgeGuards?: { nonWorkspaceWrite?: boolean }
+          },
+        ) {
+          seen.push({ ...params, path: 'notes.md' })
+          const content = await readFile(params.path, 'utf8')
+          await writeFile(params.path, content.replace('x', 'y'))
+          return { content: [{ type: 'text' as const, text: 'edited' }], details: params }
+        },
+      }
+      const hooks = createHookBus()
+      hooks.registerAll('p1', agentDir, noopLogger, {
+        'tool.before': (event) => {
+          expect(event.args.acknowledgeGuards).toEqual({ nonWorkspaceWrite: true })
+        },
+      })
+
+      const wrapped = wrapBuiltinToolDefinition(tool, { agentDir, sessionId: 's', hooks })
+
+      const parameters = wrapped.parameters as { properties?: Record<string, unknown> }
+      expect(parameters.properties).toHaveProperty('acknowledgeGuards')
+      const params = {
+        path: 'notes.md',
+        edits: [{ oldText: 'x', newText: 'y' }],
+        acknowledgeGuards: { nonWorkspaceWrite: true },
+      } as unknown as Parameters<typeof wrapped.execute>[1]
+      try {
+        const result = await wrapped.execute('c', params, undefined, undefined, {} as never)
+
+        expect(seen[0]).toEqual({ path: 'notes.md', edits: [{ oldText: 'x', newText: 'y' }] })
+        expect(result.details).toEqual({ path: 'notes.md', edits: [{ oldText: 'x', newText: 'y' }] })
+        expect(await readFile(notes, 'utf8')).toBe('y')
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
 })
 
 describe('getOrigin (live origin holder)', () => {
@@ -810,43 +2244,56 @@ describe('resolveBuiltinToolRefs', () => {
 })
 
 describe('wrapBuiltinToolDefinition (pi customTools override path)', () => {
-  test('the returned ToolDefinition runs tool.before/runFinalWriteGuards before delegating to the underlying pi AgentTool', async () => {
-    let executedUnderlying = 0
-    const beforeArgs: unknown[] = []
-    const tool = {
-      name: 'edit',
-      label: 'edit',
-      description: '',
-      parameters: Type.Object({
-        path: Type.String(),
-        edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
-      }),
-      async execute(_id: string, _params: unknown) {
-        executedUnderlying++
-        return { content: [{ type: 'text' as const, text: 'underlying ran' }], details: undefined }
-      },
-    }
-    const hooks = createHookBus()
-    hooks.registerAll('p1', '/agent', noopLogger, {
-      'tool.before': (event) => {
-        beforeArgs.push({ ...event.args })
-      },
-    })
+  test.skipIf(lacksInodeAnchoring)(
+    'the returned ToolDefinition runs tool.before/runFinalWriteGuards before delegating to the underlying pi AgentTool',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-custom-edit-pipeline-'))
+      const workspace = path.join(agentDir, 'workspace')
+      const notes = path.join(workspace, 'notes.md')
+      await mkdir(workspace)
+      await writeFile(notes, 'a')
+      let executedUnderlying = 0
+      const beforeArgs: unknown[] = []
+      const tool = {
+        name: 'edit',
+        label: 'edit',
+        description: '',
+        parameters: Type.Object({
+          path: Type.String(),
+          edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })),
+        }),
+        async execute(_id: string, params: { path: string }) {
+          executedUnderlying++
+          expect(await readFile(params.path, 'utf8')).toBe('a')
+          return { content: [{ type: 'text' as const, text: 'underlying ran' }], details: undefined }
+        },
+      }
+      const hooks = createHookBus()
+      hooks.registerAll('p1', agentDir, noopLogger, {
+        'tool.before': (event) => {
+          beforeArgs.push({ ...event.args })
+        },
+      })
 
-    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir: '/agent', sessionId: 's', hooks })
+      const wrapped = wrapBuiltinToolDefinition(tool, { agentDir, sessionId: 's', hooks })
 
-    expect(wrapped.name).toBe('edit')
-    const result = await wrapped.execute(
-      'c',
-      { path: 'workspace/notes.md', edits: [{ oldText: 'a', newText: 'b' }] },
-      undefined,
-      undefined,
-      {} as never,
-    )
-    expect(textOfFirstContent(result)).toBe('underlying ran')
-    expect(executedUnderlying).toBe(1)
-    expect(beforeArgs).toEqual([{ path: 'workspace/notes.md', edits: [{ oldText: 'a', newText: 'b' }] }])
-  })
+      try {
+        expect(wrapped.name).toBe('edit')
+        const result = await wrapped.execute(
+          'c',
+          { path: 'workspace/notes.md', edits: [{ oldText: 'a', newText: 'b' }] },
+          undefined,
+          undefined,
+          {} as never,
+        )
+        expect(textOfFirstContent(result)).toBe('underlying ran')
+        expect(executedUnderlying).toBe(1)
+        expect(beforeArgs).toEqual([{ path: 'workspace/notes.md', edits: [{ oldText: 'a', newText: 'b' }] }])
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
 
   test('regression: managedConfig guard blocks an edit that would produce invalid typeclaw.json, on the customTool override path', async () => {
     // PR #283's failure mode: pi 0.67.3 ignores `tools:` for implementation
@@ -1013,7 +2460,143 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
   const member: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'member' }
   const guest: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'guest' }
 
-  test('trusted+ (tui→owner) still requires bwrap for canonical masks', async () => {
+  test('owner bash keeps the agent root writable while canonical secrets stay read-only masked and env stays cleared', () => {
+    const permissions = createPermissionService()
+    const policy = buildBashFilesystemPolicy({
+      agentDir: '/agent',
+      canWriteAgentRoot: canWriteAgentRootInSandbox(permissions, tui),
+      masks: { dirs: [], files: ['/agent/.env', '/agent/secrets.json'] },
+      writable: { dirs: ['/agent/workspace'], files: [] },
+      protected: { dirs: ['/agent/.git/hooks'], files: ['/agent/.git/config'] },
+    })
+    const { argv } = buildSandboxedCommand('printf ok > /agent/ordinary.txt', {
+      mounts: [{ type: 'ro-bind', source: '/agent', dest: '/agent' }],
+      ...policy,
+    })
+    const rendered = argv.join(' ')
+
+    expect(rendered).toContain('--ro-bind /agent /agent')
+    expect(rendered).toContain('--bind /agent /agent')
+    expect(rendered.indexOf('--bind /agent /agent')).toBeLessThan(rendered.indexOf('--ro-bind-data 3 /agent/.env'))
+    expect(rendered).toContain('--ro-bind-data 3 /agent/.env')
+    expect(rendered).toContain('--ro-bind-data 3 /agent/secrets.json')
+    expect(rendered).toContain('--ro-bind /agent/.git/hooks /agent/.git/hooks')
+    expect(rendered).toContain('--ro-bind /agent/.git/config /agent/.git/config')
+    expect(rendered.indexOf('--bind /agent /agent')).toBeLessThan(rendered.indexOf('--ro-bind /agent/.git/hooks'))
+    expect(argv).toContain('--clearenv')
+  })
+
+  test('role filesystem policies preserve ordinary trusted root writes without widening confined roles', () => {
+    const confinedPolicy = buildBashFilesystemPolicy({
+      agentDir: '/agent',
+      canWriteAgentRoot: false,
+      masks: { dirs: [], files: ['/agent/.env'] },
+      writable: { dirs: ['/agent/workspace'], files: ['/agent/package.json'] },
+      protected: {
+        dirs: ['/agent/.git/hooks', '/agent/workspace/hooks'],
+        files: ['/agent/.git/config', '/agent/workspace/git.inc'],
+      },
+    })
+    const confined = buildSandboxedCommand('printf safe > workspace/output.txt', {
+      mounts: [{ type: 'ro-bind', source: '/agent', dest: '/agent' }],
+      ...confinedPolicy,
+    }).argv.join(' ')
+
+    expect(confined).not.toContain('--bind /agent /agent')
+    expect(confined).not.toContain('--bind /agent/node_modules /agent/node_modules')
+    expect(confined).toContain('--bind /agent/workspace /agent/workspace')
+
+    const ownerPolicy = buildBashFilesystemPolicy({
+      agentDir: '/agent',
+      canWriteAgentRoot: true,
+      masks: { dirs: [], files: ['/agent/.env'] },
+      writable: { dirs: [], files: [] },
+      protected: { dirs: ['/agent/.git/hooks'], files: ['/agent/.git/config'] },
+    })
+    const owner = buildSandboxedCommand('printf safe > ordinary.txt', {
+      mounts: [{ type: 'ro-bind', source: '/agent', dest: '/agent' }],
+      ...ownerPolicy,
+    }).argv.join(' ')
+
+    expect(owner).toContain('--bind /agent /agent')
+    expect(owner.indexOf('--bind /agent /agent')).toBeLessThan(owner.indexOf('--ro-bind-data 3 /agent/.env'))
+  })
+
+  test('the entire root dependency tree renders read-only for trusted and confined role policies', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-protected-dependencies-'))
+    await mkdir(path.join(agentDir, 'node_modules'))
+    try {
+      const protectedZones = await resolveProtectedZones(agentDir)
+      const trustedPolicy = buildBashFilesystemPolicy({
+        agentDir,
+        canWriteAgentRoot: true,
+        masks: { dirs: [], files: [] },
+        writable: { dirs: [], files: [] },
+        protected: protectedZones,
+      })
+      const confinedPolicy = buildBashFilesystemPolicy({
+        agentDir,
+        canWriteAgentRoot: false,
+        masks: { dirs: [], files: [] },
+        writable: { dirs: [path.join(agentDir, 'workspace')], files: [] },
+        protected: protectedZones,
+      })
+      const trusted = buildSandboxedCommand('printf safe > ordinary.txt', trustedPolicy).argv.join(' ')
+      const confined = buildSandboxedCommand('printf safe > workspace/output.txt', confinedPolicy).argv.join(' ')
+      const protectedNodeModules = `--ro-bind ${path.join(agentDir, 'node_modules')} ${path.join(agentDir, 'node_modules')}`
+
+      expect(trusted).toContain(`--bind ${agentDir} ${agentDir}`)
+      expect(trusted).toContain(protectedNodeModules)
+      expect(trusted.indexOf(`--bind ${agentDir} ${agentDir}`)).toBeLessThan(trusted.indexOf(protectedNodeModules))
+      expect(confined).not.toContain(`--bind ${agentDir} ${agentDir}`)
+      expect(confined).toContain(protectedNodeModules)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.each(['write', 'edit'] as const)(
+    '%s cannot modify Git hook configuration even with guard acknowledgements',
+    async (toolName) => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'tc-git-control-'))
+      const calls: unknown[] = []
+      const tool = definePiTool({
+        name: toolName,
+        label: toolName,
+        description: '',
+        parameters: Type.Object({ path: Type.String() }),
+        async execute(_id, params) {
+          calls.push(params)
+          return { content: [{ type: 'text' as const, text: 'mutated' }], details: undefined }
+        },
+      })
+      const wrapped = wrapBuiltinToolDefinition(tool, {
+        agentDir,
+        sessionId: `git-control-${toolName}`,
+        hooks: createHookBus(),
+      })
+
+      try {
+        await expect(
+          wrapped.execute(
+            'c',
+            {
+              path: path.join(agentDir, '.git', 'config'),
+              acknowledgeGuards: { nonWorkspaceWrite: true, rolePromotion: true, cronPromotion: true },
+            },
+            undefined,
+            undefined,
+            {} as never,
+          ),
+        ).rejects.toThrow(/Git control path/)
+        expect(calls).toEqual([])
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test('owner bash requires canonical secret masks and fails closed without bwrap', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
       agentDir: '/agent',
@@ -1023,7 +2606,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       permissions: createPermissionService(),
     })
     await expect(
-      wrapped.execute('c', { command: 'cat /agent/.env' }, undefined, undefined, {} as never),
+      wrapped.execute('c', { command: 'cat /agent/secrets.json' }, undefined, undefined, {} as never),
     ).rejects.toThrow()
     expect(record.command).toBeUndefined()
   })
@@ -1043,7 +2626,30 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
         getOrigin: () => tui,
         permissions: createPermissionService(),
       })
+      await expect(
+        wrapped.execute('c', { command: 'echo should-not-run' }, undefined, undefined, {} as never),
+      ).rejects.toThrow(/mask target/i)
+      expect(record.command).toBeUndefined()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
 
+  test('owner bash aborts before execution when a canonical target has a hardlink alias', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'tc-unsafe-mask-hardlink-'))
+    const record: { command?: string } = {}
+    try {
+      const env = path.join(agentDir, '.env')
+      await writeFile(env, 'secret')
+      await link(env, path.join(agentDir, 'env-alias'))
+      await writeFile(path.join(agentDir, 'secrets.json'), '{}')
+      const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
+        agentDir,
+        sessionId: 's',
+        hooks: createHookBus(),
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+      })
       await expect(
         wrapped.execute('c', { command: 'echo should-not-run' }, undefined, undefined, {} as never),
       ).rejects.toThrow(/mask target/i)
@@ -1209,6 +2815,101 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     await rm(agentDir, { recursive: true, force: true })
   })
 
+  test.skipIf(lacksInodeAnchoring)(
+    'pinned output verification failure reaches tool.after exactly once before propagation',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-output-after-'))
+      const destination = path.join(agentDir, 'workspace', 'output.txt')
+      const protectedFile = path.join(agentDir, 'protected.txt')
+      const afterResults: ToolResult[] = []
+      await mkdir(path.dirname(destination))
+      await writeFile(destination, 'before')
+      await writeFile(protectedFile, 'protected')
+      const hooks = createHookBus()
+      hooks.registerAll('observer', agentDir, noopLogger, {
+        'tool.after': (event) => {
+          afterResults.push(event.result)
+        },
+      })
+      const tool = definePiTool({
+        name: 'write',
+        label: 'write',
+        description: '',
+        parameters: Type.Object({ path: Type.String(), content: Type.String() }),
+        async execute(_callId, params) {
+          await writeFile(params.path, params.content)
+          await rm(destination)
+          await symlink(protectedFile, destination)
+          return { content: [{ type: 'text' as const, text: 'wrote' }], details: undefined }
+        },
+      })
+      const wrapped = wrapBuiltinToolDefinition(tool, { agentDir, sessionId: 'output-after', hooks })
+
+      try {
+        await expect(
+          wrapped.execute('call', { path: destination, content: 'safe' }, undefined, undefined, {} as never),
+        ).rejects.toThrow(/changed|symbolic|ELOOP/i)
+        expect(afterResults).toHaveLength(1)
+        expect(afterResults[0]?.details).toEqual({ error: expect.any(String) })
+        expect(await readFile(protectedFile, 'utf8')).toBe('protected')
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test.skipIf(lacksInodeAnchoring)(
+    'plugin output verification failure reaches tool.after exactly once before propagation',
+    async () => {
+      const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-plugin-output-after-'))
+      const destination = path.join(agentDir, 'workspace', 'output.txt')
+      const protectedFile = path.join(agentDir, 'protected.txt')
+      const afterResults: ToolResult[] = []
+      await mkdir(path.dirname(destination))
+      await writeFile(destination, 'before')
+      await writeFile(protectedFile, 'protected')
+      const hooks = createHookBus()
+      hooks.registerAll('observer', agentDir, noopLogger, {
+        'tool.after': (event) => {
+          afterResults.push(event.result)
+        },
+      })
+      const tool = defineTool({
+        description: '',
+        parameters: z.object({ destination: z.string() }),
+        fileOperands: { output: ['destination'] },
+        async execute(args) {
+          await writeFile(args.destination, 'safe')
+          await rm(destination)
+          await symlink(protectedFile, destination)
+          return { content: [{ type: 'text' as const, text: 'wrote' }] }
+        },
+      })
+      const wrapped = wrapPluginTool(tool, {
+        pluginName: 'writer',
+        toolName: 'plugin_writer',
+        agentDir,
+        sessionId: 'plugin-output-after',
+        logger: noopLogger,
+        hooks,
+      })
+
+      try {
+        await expect(wrapped.execute('call', { destination }, undefined, undefined, {} as never)).rejects.toThrow(
+          /changed|symbolic|ELOOP/i,
+        )
+        expect(afterResults).toHaveLength(1)
+        expect(afterResults[0]?.details).toEqual({
+          error: true,
+          message: expect.stringMatching(/changed|symbolic|ELOOP/i),
+        })
+        expect(await readFile(protectedFile, 'utf8')).toBe('protected')
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    },
+  )
+
   test('execution error wins over cleanup error and reaches tool.after exactly once after cleanup', async () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-error-precedence-'))
     const order: string[] = []
@@ -1251,7 +2952,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     await rm(agentDir, { recursive: true, force: true })
   })
 
-  test('without a permission service bash is never rewritten (escape hatch for unwired sessions)', async () => {
+  test('without a permission service bash fails closed and never reaches the underlying tool', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
       agentDir: '/agent',
@@ -1259,11 +2960,13 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       hooks: createHookBus(),
       getOrigin: () => guest,
     })
-    await wrapped.execute('c', { command: 'echo hi' }, undefined, undefined, {} as never)
-    expect(record.command).toBe('echo hi')
+    await expect(wrapped.execute('c', { command: 'echo hi' }, undefined, undefined, {} as never)).rejects.toThrow(
+      /permission service/i,
+    )
+    expect(record.command).toBeUndefined()
   })
 
-  test('a hook-set env overlay is stripped from args before sandbox preparation', async () => {
+  test('a hook-set env overlay is stripped from args and never reaches an unwired command', async () => {
     const record: { command?: string } = {}
     const hooks = createHookBus()
     hooks.registerAll('env-setter', '/agent', noopLogger, {
@@ -1277,9 +2980,10 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       sessionId: 's',
       hooks,
       getOrigin: () => tui,
-      permissions: createPermissionService(),
     })
-    await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow()
+    await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow(
+      /permission service/i,
+    )
     expect(record.command).toBeUndefined()
     expect(args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
@@ -1361,9 +3065,10 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       sessionId: 's',
       hooks,
       getOrigin: () => tui,
-      permissions: createPermissionService(),
     })
-    await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow()
+    await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow(
+      /permission service/i,
+    )
     expect(seenInHook).toBeUndefined()
   })
 })
@@ -1400,38 +3105,38 @@ describe('wrapBuiltinToolDefinition subagent bash policy (capability fence, role
     expect(record.command).toBeUndefined()
   })
 
-  test('readonly-reviewer policy lets a read-only command reach mandatory sandbox preparation', async () => {
+  test('readonly-reviewer policy cannot bypass missing sandbox permission wiring', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
       agentDir: '/agent',
       sessionId: 's',
       hooks: createHookBus(),
       getOrigin: () => ownerTui,
-      permissions: createPermissionService(),
       bashPolicy: { kind: 'readonly-reviewer' },
     })
-    await expect(wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)).rejects.toThrow()
+    await expect(wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)).rejects.toThrow(
+      /permission service/i,
+    )
     expect(record.command).toBeUndefined()
   })
 
-  test('no bashPolicy still applies the mandatory owner sandbox', async () => {
+  test('no bashPolicy still cannot bypass missing sandbox permission wiring', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
       agentDir: '/agent',
       sessionId: 's',
       hooks: createHookBus(),
       getOrigin: () => ownerTui,
-      permissions: createPermissionService(),
     })
     await expect(
       wrapped.execute('c', { command: 'git push origin HEAD' }, undefined, undefined, {} as never),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/permission service/i)
     expect(record.command).toBeUndefined()
   })
 })
 
 describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', () => {
-  function fakeWrite(record: { path?: string }) {
+  function fakeWrite(record: { path?: string; resolvedParent?: string }) {
     return {
       name: 'write',
       label: 'write',
@@ -1439,7 +3144,9 @@ describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', (
       parameters: Type.Object({ path: Type.String(), content: Type.String() }),
       async execute(_id: string, params: { path: string; content: string }) {
         record.path = params.path
-        return { content: [{ type: 'text' as const, text: 'wrote' }], details: undefined }
+        record.resolvedParent = await realpath(path.dirname(params.path))
+        await writeFile(params.path, params.content)
+        return { content: [{ type: 'text' as const, text: 'wrote' }], details: { path: params.path } }
       },
     }
   }
@@ -1452,7 +3159,7 @@ describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', (
       parameters: Type.Object({ path: Type.String() }),
       async execute(_id: string, params: { path: string }) {
         record.path = params.path
-        return { content: [{ type: 'text' as const, text: 'read' }], details: undefined }
+        return { content: [{ type: 'text' as const, text: 'read' }], details: { path: params.path } }
       },
     }
   }
@@ -1460,75 +3167,147 @@ describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', (
   const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
   const guest: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'guest' }
 
-  test('a sandboxed role (guest) has its /tmp write redirected to the session backing dir', async () => {
-    const record: { path?: string } = {}
-    const wrapped = wrapBuiltinToolDefinition(fakeWrite(record), {
-      agentDir: '/agent',
-      sessionId: 'sid42',
-      hooks: createHookBus(),
-      getOrigin: () => guest,
-      permissions: createPermissionService(),
-    })
-    await wrapped.execute('c', { path: '/tmp/review.json', content: '{}' } as never, undefined, undefined, {} as never)
-    expect(record.path).toBe(`${SESSION_TMP_ROOT}/sid42/review.json`)
-  })
+  test.skipIf(lacksInodeAnchoring)(
+    'a sandboxed role (guest) has its /tmp write redirected to the session backing dir',
+    async () => {
+      const sessionId = 'sid42-guest-write'
+      const record: { path?: string; resolvedParent?: string } = {}
+      const wrapped = wrapBuiltinToolDefinition(fakeWrite(record), {
+        agentDir: '/agent',
+        sessionId,
+        hooks: createHookBus(),
+        getOrigin: () => guest,
+        permissions: createPermissionService(),
+      })
+      try {
+        const result = await wrapped.execute(
+          'c',
+          { path: '/tmp/review.json', content: '{}' } as never,
+          undefined,
+          undefined,
+          {} as never,
+        )
+        expect(record.path).toMatch(/^\/proc\/self\/fd\/\d+\/review\.json$/)
+        expect(record.resolvedParent).toBe(`${SESSION_TMP_ROOT}/${sessionId}`)
+        expect(result.details).toEqual({ path: '/tmp/review.json' })
+        expect(await readFile(`${SESSION_TMP_ROOT}/${sessionId}/review.json`, 'utf8')).toBe('{}')
+      } finally {
+        await rm(`${SESSION_TMP_ROOT}/${sessionId}`, { recursive: true, force: true })
+      }
+    },
+  )
 
   test('a sandboxed role (guest) reading /tmp resolves to the same session backing dir bash wrote', async () => {
-    const record: { path?: string } = {}
+    const sessionId = 'sid42-guest-read'
+    await mkdir(`${SESSION_TMP_ROOT}/${sessionId}`, { recursive: true })
+    await writeFile(`${SESSION_TMP_ROOT}/${sessionId}/review.json`, '{}')
+    const record: { path?: string; resolvedParent?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeRead(record), {
       agentDir: '/agent',
+      sessionId,
+      hooks: createHookBus(),
+      getOrigin: () => guest,
+      permissions: createPermissionService(),
+    })
+    try {
+      const result = await wrapped.execute(
+        'c',
+        { path: '/tmp/review.json' } as never,
+        undefined,
+        undefined,
+        {} as never,
+      )
+      expect(result.details).toEqual({ path: '/tmp/review.json' })
+      expect(record.path).not.toBe('/tmp/review.json')
+    } finally {
+      await rm(`${SESSION_TMP_ROOT}/${sessionId}`, { recursive: true, force: true })
+    }
+  })
+
+  test.skipIf(lacksInodeAnchoring)(
+    'an owner write uses the session /tmp backing because owner bash is also sandboxed',
+    async () => {
+      const sessionId = 'sid42-owner-write'
+      const record: { path?: string; resolvedParent?: string } = {}
+      const wrapped = wrapBuiltinToolDefinition(fakeWrite(record), {
+        agentDir: '/agent',
+        sessionId,
+        hooks: createHookBus(),
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+      })
+      try {
+        const result = await wrapped.execute(
+          'c',
+          { path: '/tmp/review.json', content: '{}' } as never,
+          undefined,
+          undefined,
+          {} as never,
+        )
+        expect(record.path).toMatch(/^\/proc\/self\/fd\/\d+\/review\.json$/)
+        expect(record.resolvedParent).toBe(`${SESSION_TMP_ROOT}/${sessionId}`)
+        expect(result.details).toEqual({ path: '/tmp/review.json' })
+        expect(await readFile(`${SESSION_TMP_ROOT}/${sessionId}/review.json`, 'utf8')).toBe('{}')
+      } finally {
+        await rm(`${SESSION_TMP_ROOT}/${sessionId}`, { recursive: true, force: true })
+      }
+    },
+  )
+
+  test('an owner read uses the session /tmp backing because owner bash is also sandboxed', async () => {
+    const sessionId = 'sid42-owner-read'
+    await mkdir(`${SESSION_TMP_ROOT}/${sessionId}`, { recursive: true })
+    await writeFile(`${SESSION_TMP_ROOT}/${sessionId}/review.json`, '{}')
+    const record: { path?: string; resolvedParent?: string } = {}
+    const wrapped = wrapBuiltinToolDefinition(fakeRead(record), {
+      agentDir: '/agent',
+      sessionId,
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+    })
+    try {
+      const result = await wrapped.execute(
+        'c',
+        { path: '/tmp/review.json' } as never,
+        undefined,
+        undefined,
+        {} as never,
+      )
+      expect(result.details).toEqual({ path: '/tmp/review.json' })
+      expect(record.path).not.toBe('/tmp/review.json')
+    } finally {
+      await rm(`${SESSION_TMP_ROOT}/${sessionId}`, { recursive: true, force: true })
+    }
+  })
+
+  test.skipIf(lacksInodeAnchoring)('a non-/tmp write is left untouched even for a sandboxed role', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-non-tmp-write-'))
+    const workspace = path.join(agentDir, 'workspace')
+    await mkdir(workspace)
+    const record: { path?: string; resolvedParent?: string } = {}
+    const wrapped = wrapBuiltinToolDefinition(fakeWrite(record), {
+      agentDir,
       sessionId: 'sid42',
       hooks: createHookBus(),
       getOrigin: () => guest,
       permissions: createPermissionService(),
     })
-    await wrapped.execute('c', { path: '/tmp/review.json' } as never, undefined, undefined, {} as never)
-    expect(record.path).toBe(`${SESSION_TMP_ROOT}/sid42/review.json`)
-  })
-
-  test('an owner write uses the session scratch backing path', async () => {
-    const record: { path?: string } = {}
-    const wrapped = wrapBuiltinToolDefinition(fakeWrite(record), {
-      agentDir: '/agent',
-      sessionId: 'sid42',
-      hooks: createHookBus(),
-      getOrigin: () => tui,
-      permissions: createPermissionService(),
-    })
-    await wrapped.execute('c', { path: '/tmp/review.json', content: '{}' } as never, undefined, undefined, {} as never)
-    expect(record.path).toBe(`${SESSION_TMP_ROOT}/sid42/review.json`)
-  })
-
-  test('an owner read uses the session scratch backing path', async () => {
-    const record: { path?: string } = {}
-    const wrapped = wrapBuiltinToolDefinition(fakeRead(record), {
-      agentDir: '/agent',
-      sessionId: 'sid42',
-      hooks: createHookBus(),
-      getOrigin: () => tui,
-      permissions: createPermissionService(),
-    })
-    await wrapped.execute('c', { path: '/tmp/review.json' } as never, undefined, undefined, {} as never)
-    expect(record.path).toBe(`${SESSION_TMP_ROOT}/sid42/review.json`)
-  })
-
-  test('a non-/tmp write is left untouched even for a sandboxed role', async () => {
-    const record: { path?: string } = {}
-    const wrapped = wrapBuiltinToolDefinition(fakeWrite(record), {
-      agentDir: '/agent',
-      sessionId: 'sid42',
-      hooks: createHookBus(),
-      getOrigin: () => guest,
-      permissions: createPermissionService(),
-    })
-    await wrapped.execute(
-      'c',
-      { path: 'workspace/out.json', content: '{}' } as never,
-      undefined,
-      undefined,
-      {} as never,
-    )
-    expect(record.path).toBe('workspace/out.json')
+    try {
+      const result = await wrapped.execute(
+        'c',
+        { path: 'workspace/out.json', content: '{}' } as never,
+        undefined,
+        undefined,
+        {} as never,
+      )
+      expect(record.path).toMatch(/^\/proc\/self\/fd\/\d+\/out\.json$/)
+      expect(record.resolvedParent).toBe(workspace)
+      expect(result.details).toEqual({ path: 'workspace/out.json' })
+      expect(await readFile(path.join(workspace, 'out.json'), 'utf8')).toBe('{}')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
   })
 
   // Mirrors pi's real write tool, which echoes the path back ("Successfully
@@ -1550,30 +3329,33 @@ describe('wrapBuiltinToolDefinition /tmp path redirect (per-session scratch)', (
     }
   }
 
-  test('a sandboxed role sees its original /tmp path in the receipt, not the backing dir', async () => {
-    const wrapped = wrapBuiltinToolDefinition(fakeWriteEchoingPath(), {
-      agentDir: '/agent',
-      sessionId: 'sid42',
-      hooks: createHookBus(),
-      getOrigin: () => guest,
-      permissions: createPermissionService(),
-    })
-    const result = await wrapped.execute(
-      'c',
-      { path: '/tmp/review.json', content: '{}' } as never,
-      undefined,
-      undefined,
-      {} as never,
-    )
-    const text = (result.content as Array<{ type: string; text?: string }>)
-      .filter((p) => p.type === 'text')
-      .map((p) => p.text)
-      .join('\n')
-    expect(text).toContain('/tmp/review.json')
-    expect(text).not.toContain(`${SESSION_TMP_ROOT}/sid42`)
-  })
+  test.skipIf(lacksInodeAnchoring)(
+    'a sandboxed role sees its original /tmp path in the receipt, not the backing dir',
+    async () => {
+      const wrapped = wrapBuiltinToolDefinition(fakeWriteEchoingPath(), {
+        agentDir: '/agent',
+        sessionId: 'sid42',
+        hooks: createHookBus(),
+        getOrigin: () => guest,
+        permissions: createPermissionService(),
+      })
+      const result = await wrapped.execute(
+        'c',
+        { path: '/tmp/review.json', content: '{}' } as never,
+        undefined,
+        undefined,
+        {} as never,
+      )
+      const text = (result.content as Array<{ type: string; text?: string }>)
+        .filter((p) => p.type === 'text')
+        .map((p) => p.text)
+        .join('\n')
+      expect(text).toContain('/tmp/review.json')
+      expect(text).not.toContain(`${SESSION_TMP_ROOT}/sid42`)
+    },
+  )
 
-  test('an unsandboxed role keeps the real /tmp path in the receipt (no rewrite)', async () => {
+  test.skipIf(lacksInodeAnchoring)('an owner still sees the virtual /tmp path in the receipt', async () => {
     const wrapped = wrapBuiltinToolDefinition(fakeWriteEchoingPath(), {
       agentDir: '/agent',
       sessionId: 'sid42',
@@ -2091,7 +3873,7 @@ describe('loop guard integration', () => {
       [1, 2, 3, 4, 5, 6].map((offset, index) =>
         wrapped.execute(
           `c${index}`,
-          { path: '/agent/router.ts', offset, limit: 100 },
+          { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset, limit: 100 },
           undefined,
           undefined,
           {} as never,
@@ -2130,7 +3912,13 @@ describe('loop guard integration', () => {
 
     for (let offset = 1; offset <= 701; offset += 100) {
       turnId += 1
-      await wrapped.execute(`c${turnId}`, { path: '/agent/router.ts', offset }, undefined, undefined, {} as never)
+      await wrapped.execute(
+        `c${turnId}`,
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset },
+        undefined,
+        undefined,
+        {} as never,
+      )
     }
     expect(aborts).toBe(0)
   })
@@ -2170,7 +3958,7 @@ describe('loop guard integration', () => {
       turnId += 1
       return wrapped.execute(
         `c${turnId}`,
-        { path: '/agent/router.ts', offset, limit: 100 },
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset, limit: 100 },
         undefined,
         undefined,
         {} as never,
@@ -2213,7 +4001,7 @@ describe('loop guard integration', () => {
       turnId += 1
       await wrapped.execute(
         `c${turnId}`,
-        { path: '/agent/router.ts', offset, limit: 1 },
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset, limit: 1 },
         undefined,
         undefined,
         {} as never,
@@ -2221,7 +4009,13 @@ describe('loop guard integration', () => {
     }
     turnId += 1
     await expect(
-      wrapped.execute('c6', { path: '/agent/router.ts', offset: 6, limit: 1 }, undefined, undefined, {} as never),
+      wrapped.execute(
+        'c6',
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset: 6, limit: 1 },
+        undefined,
+        undefined,
+        {} as never,
+      ),
     ).rejects.toThrow(/loop-guard/)
     expect(aborts).toBe(1)
   })
@@ -2258,7 +4052,7 @@ describe('loop guard integration', () => {
       turnId += 1
       await wrapped.execute(
         `c${turnId}`,
-        { path: '/agent/blob.dat', offset, limit: 1 },
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset, limit: 1 },
         undefined,
         undefined,
         {} as never,
@@ -2266,7 +4060,13 @@ describe('loop guard integration', () => {
     }
     turnId += 1
     await expect(
-      wrapped.execute('c6', { path: '/agent/blob.dat', offset: 6, limit: 1 }, undefined, undefined, {} as never),
+      wrapped.execute(
+        'c6',
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset: 6, limit: 1 },
+        undefined,
+        undefined,
+        {} as never,
+      ),
     ).rejects.toThrow(/loop-guard/)
     expect(aborts).toBe(1)
   })
@@ -2305,7 +4105,7 @@ describe('loop guard integration', () => {
       turnId += 1
       await wrapped.execute(
         `c${turnId}`,
-        { path: '/agent/blob.dat', offset, limit: 1 },
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset, limit: 1 },
         undefined,
         undefined,
         {} as never,
@@ -2313,7 +4113,13 @@ describe('loop guard integration', () => {
     }
     turnId += 1
     await expect(
-      wrapped.execute('c6', { path: '/agent/blob.dat', offset: 6, limit: 1 }, undefined, undefined, {} as never),
+      wrapped.execute(
+        'c6',
+        { path: path.join(process.cwd(), 'src/agent/plugin-tools.ts'), offset: 6, limit: 1 },
+        undefined,
+        undefined,
+        {} as never,
+      ),
     ).rejects.toThrow(/loop-guard/)
     expect(aborts).toBe(1)
   })

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1462,6 +1462,8 @@ describe('wrapSystemTool', () => {
     )
     await Promise.all(files.map(async (file) => await writeFile(file, 'x')))
     const controllers: AbortController[] = []
+    type WaiterOutcome = { error: unknown } | { pinned: Awaited<ReturnType<typeof enforceAndPinToolFiles>> }
+    let waiters: Array<Promise<WaiterOutcome>> = []
     let holder: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
     try {
       holder = await enforceAndPinToolFiles({
@@ -1469,7 +1471,7 @@ describe('wrapSystemTool', () => {
         args: { attachments: files.slice(0, PINNED_SNAPSHOT_GLOBAL_MAX_COUNT).map((file) => ({ path: file })) },
         agentDir,
       })
-      const waiters = Array.from({ length: PINNED_SNAPSHOT_MAX_WAITERS }, () => {
+      waiters = Array.from({ length: PINNED_SNAPSHOT_MAX_WAITERS + 1 }, () => {
         const controller = new AbortController()
         controllers.push(controller)
         return enforceAndPinToolFiles({
@@ -1477,18 +1479,19 @@ describe('wrapSystemTool', () => {
           args: { path: files[PINNED_SNAPSHOT_GLOBAL_MAX_COUNT] as string },
           agentDir,
           signal: controller.signal,
-        })
+        }).then<WaiterOutcome, WaiterOutcome>(
+          (pinned) => ({ pinned }),
+          (error: unknown) => ({ error }),
+        )
       })
-      await expect(
-        enforceAndPinToolFiles({
-          tool: 'read',
-          args: { path: files[PINNED_SNAPSHOT_GLOBAL_MAX_COUNT] as string },
-          agentDir,
-        }),
-      ).rejects.toThrow(/waiter|queue/i)
-      for (const controller of controllers) controller.abort()
-      await Promise.allSettled(waiters)
+      const overflow = await Promise.race(waiters)
+      if (!('error' in overflow)) throw new Error('a queued snapshot waiter acquired capacity unexpectedly')
+      expect(overflow.error).toBeInstanceOf(Error)
+      expect((overflow.error as Error).message).toMatch(/waiter|queue/i)
     } finally {
+      for (const controller of controllers) controller.abort()
+      const outcomes = await Promise.all(waiters)
+      await Promise.all(outcomes.flatMap((outcome) => ('pinned' in outcome ? [outcome.pinned.cleanup()] : [])))
       await holder?.cleanup()
       await rm(agentDir, { recursive: true, force: true })
     }

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
+import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import {
@@ -38,16 +39,16 @@ import type {
 import {
   buildSandboxedCommand,
   canWriteAgentRootInSandbox,
-  cleanupPrivilegedSandboxRuntime,
   canMountRealProc,
+  cleanupPrivilegedSandboxRuntime,
   commandNeedsRealProc,
   DEFAULT_SANDBOX_ENV,
   ensureBwrapAvailable,
   ensureHiddenMaskTargets,
   ensureSessionTmpDir,
   getProcBindSafetyVerdict,
+  isGitControlPath,
   mapVirtualTmpPath,
-  type PrivilegedSandboxRuntime,
   resolveHiddenPaths,
   resolvePrivilegedSandboxRuntime,
   resolveProcBindSafetyWithRetry,
@@ -55,6 +56,7 @@ import {
   resolveProtectedZones,
   resolveSandboxSymlinks,
   resolveWritableZones,
+  SandboxPolicyError,
   SandboxDegradedProcError,
   SandboxProcProbeUnverifiedError,
   subtractMasked,
@@ -66,6 +68,7 @@ import { createLoopGuard, type LoopGuard, type LoopGuardDecision } from './loop-
 import { checkImageReadRedirect } from './multimodal/read-redirect'
 import { enforceSubagentBashPolicy, type SubagentBashPolicy } from './reviewer-bash-policy'
 import type { SessionOrigin } from './session-origin'
+import { enforceAndPinToolFiles, writeToolOutputNoFollow } from './tool-file-safety'
 import { SUBAGENT_OUTPUT_TOOL_NAME, type SubagentOutputToolDetails } from './tools/subagent-output'
 import { webFetchTool } from './tools/webfetch'
 import { webSearchTool } from './tools/websearch'
@@ -89,6 +92,7 @@ let sharedLoopGuard: LoopGuard = createLoopGuard()
 export const TYPECLAW_INTERNAL_BASH_ENV = '__typeclawBashEnv'
 
 type BashEnvOverlay = Record<string, string>
+const SECRET_BASH_ENV_NAMES = new Set(['GH_TOKEN', 'GITHUB_TOKEN'])
 
 const SECRET_ENV_NAME_PATTERN =
   /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASSWD|PWD|API_KEY|ACCESS_KEY(?:_ID)?|SECRET_KEY|PRIVATE_KEY|AUTH)$/
@@ -107,8 +111,17 @@ function readBashEnvOverlay(args: Record<string, unknown>): BashEnvOverlay | und
 
 function bashSpawnHookWithOverlay(context: BashSpawnContext): BashSpawnContext {
   const overlay = bashEnvStore.getStore()
-  if (overlay === undefined) return context
-  return { ...context, env: { ...context.env, ...overlay } }
+  return { ...context, env: sanitizeBashSpawnEnvironment(context.env, overlay) }
+}
+
+export function sanitizeBashSpawnEnvironment(
+  inherited: NodeJS.ProcessEnv | undefined,
+  overlay: BashEnvOverlay | undefined,
+): NodeJS.ProcessEnv {
+  const env = { ...inherited }
+  for (const name of SECRET_BASH_ENV_NAMES) delete env[name]
+  if (overlay !== undefined) Object.assign(env, overlay)
+  return env
 }
 
 const ACKNOWLEDGE_GUARDS_SCHEMA = Type.Optional(
@@ -158,7 +171,14 @@ function createPiBuiltinToolDefinition(name: PiBuiltinToolName, cwd: string): To
     case 'edit':
       return piCreateEditToolDefinition(cwd)
     case 'write':
-      return piCreateWriteToolDefinition(cwd)
+      return piCreateWriteToolDefinition(cwd, {
+        operations: {
+          mkdir: async (dir) => {
+            await mkdir(dir, { recursive: true })
+          },
+          writeFile: writeToolOutputNoFollow,
+        },
+      })
     case 'grep':
       return piCreateGrepToolDefinition(cwd)
     case 'find':
@@ -234,13 +254,14 @@ export type WrapSystemToolOptions = {
   getAbort?: () => ((reason?: string) => void) | undefined
   getLoopGuardTurn?: () => number | undefined
   // When present, the bash builtin is rewritten through the per-tool bwrap
-  // sandbox with role-derived path masks. Absent (or no masks for the role)
-  // runs bash unchanged — preserving today's behavior for trusted+ and for
-  // sessions wired without a permission service (e.g. tests).
+  // sandbox. Private-directory masks remain role-derived; canonical agent
+  // secret-file masks apply to every role. Only sessions wired without a
+  // permission service fail closed before execution. Production session setup
+  // always supplies either the live service or the deny-all service.
   permissions?: PermissionService
   // Per-subagent bash capability policy, enforced as a hard pre-check BEFORE
-  // the role-derived sandbox (which returns early for trusted/owner). Lets a
-  // read-only subagent keep its bash read-only no matter who spawned it. See
+  // the role-derived sandbox. Lets a read-only subagent keep its bash read-only
+  // no matter who spawned it. See
   // `src/agent/reviewer-bash-policy.ts`.
   bashPolicy?: SubagentBashPolicy
   bashSandboxBoundary?: BashSandboxBoundary
@@ -314,13 +335,37 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         logger: opts.logger,
       }
 
-      let result: ToolResult
+      let result: ToolResult | undefined
+      let executionError: unknown
+      let cleanupError: unknown
+      const pinnedFiles = await enforceAndPinToolFiles({
+        tool: opts.toolName,
+        args: before.args,
+        agentDir: opts.agentDir,
+        genericInputs: true,
+        fileOperands: tool.fileOperands,
+        signal,
+      })
       try {
         result = await tool.execute(before.args, toolCtx)
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        return errorResult(message)
+        executionError = err
+      } finally {
+        try {
+          await pinnedFiles.cleanup()
+        } catch (error) {
+          cleanupError = error
+        }
       }
+      const finalError = executionError ?? cleanupError
+      if (finalError !== undefined) {
+        const failure = errorResult(finalError instanceof Error ? finalError.message : String(finalError))
+        await runToolAfterSafely(opts, opts.toolName, toolCallId, failure)
+        if (cleanupError !== undefined) throw finalError
+        return failure
+      }
+      if (result === undefined) throw new Error('plugin tool execution returned no result')
+      result = pinnedFiles.restoreResult(result)
 
       const resolved = loopGate.resolve(result)
       if ('deferredBlock' in resolved) {
@@ -353,6 +398,7 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
     parameters: withGuardAcknowledgements(tool.name, tool.parameters),
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const mutableArgs = params as Record<string, unknown>
+      normalizeDefaultTreeRoot(tool.name, mutableArgs)
       const liveOrigin = opts.getOrigin?.()
       const blockResult = await opts.hooks.runToolBefore({
         tool: tool.name,
@@ -383,8 +429,41 @@ export function wrapSystemTool<TParams extends TSchema, TDetails = unknown, TSta
       }
       stripGuardAcknowledgements(mutableArgs)
 
-      const result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx)
-      const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
+      const pinnedFiles = await enforceAndPinToolFiles({
+        tool: tool.name,
+        args: mutableArgs,
+        agentDir: opts.agentDir,
+        genericInputs: tool.name !== 'mcp_call',
+        ...(opts.permissions !== undefined
+          ? { hidden: resolveHiddenPaths(opts.permissions, liveOrigin, opts.agentDir) }
+          : {}),
+        signal,
+      })
+      let result: Awaited<ReturnType<typeof tool.execute>> | undefined
+      let executionError: unknown
+      let cleanupError: unknown
+      try {
+        result = await tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx)
+      } catch (error) {
+        executionError = error
+      } finally {
+        try {
+          await pinnedFiles.cleanup()
+        } catch (error) {
+          cleanupError = error
+        }
+      }
+      const finalError = executionError ?? cleanupError
+      if (finalError !== undefined) {
+        await runToolAfterSafely(opts, tool.name, toolCallId, toErrorResult(finalError))
+        throw finalError
+      }
+      if (result === undefined) throw new Error('system tool execution returned no result')
+      const restoredResult = pinnedFiles.restoreResult({
+        content: result.content as ContentPart[],
+        details: result.details,
+      })
+      const resolved = loopGate.resolve(restoredResult)
       if ('deferredBlock' in resolved) {
         fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
         throw new Error(resolved.deferredBlock)
@@ -419,6 +498,7 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
     parameters: withGuardAcknowledgements(tool.name, tool.parameters),
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const mutableArgs = params as Record<string, unknown>
+      normalizeDefaultTreeRoot(tool.name, mutableArgs)
       const liveOrigin = opts.getOrigin?.()
       // Defense-in-depth: strip any pre-existing internal env-overlay key
       // before hooks run so only trusted tool.before hooks can set it.
@@ -459,63 +539,73 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
 
       // Per-subagent capability fence: runs BEFORE the role-derived sandbox so
       // a read-only subagent's bash stays read-only even for a trusted/owner
-      // caller (for whom applyBashSandbox returns early with no masks). Throws
-      // SubagentBashPolicyError on a disallowed command, surfaced to the model
-      // as a tool error.
+      // caller whose sandbox otherwise preserves full agent-root writes. Throws
+      // SubagentBashPolicyError on a disallowed command, surfaced to the model as
+      // a tool error.
       if (tool.name === 'bash' && opts.bashPolicy !== undefined) {
         const command = mutableArgs.command
         if (typeof command === 'string') enforceSubagentBashPolicy(opts.bashPolicy, command)
       }
 
-      const sandboxBoundary = opts.bashSandboxBoundary ?? DEFAULT_BASH_SANDBOX_BOUNDARY
-      const privilegedRuntime =
-        tool.name === 'bash' && opts.permissions !== undefined
-          ? await applyBashSandbox(
-              mutableArgs,
-              opts.permissions,
-              liveOrigin,
-              opts.agentDir,
-              opts.sessionId,
-              bashEnvOverlay,
-              sandboxBoundary,
-            )
-          : undefined
-
-      const tmpRedirect =
-        TMP_REDIRECT_TOOLS.has(tool.name) && opts.permissions !== undefined
-          ? await applyTmpPathRedirect(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId)
-          : undefined
-
+      let preparedSandboxRuntime: PreparedBashSandbox | undefined
+      let pinnedFiles: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+      let tmpRedirect: TmpRedirect | undefined
       let rawResult: ToolResult | undefined
       let executionError: unknown
+      let cleanupError: unknown
+      const sandboxBoundary = opts.bashSandboxBoundary ?? DEFAULT_BASH_SANDBOX_BOUNDARY
       try {
-        if (privilegedRuntime !== undefined) {
-          await (sandboxBoundary.verifyRuntime ?? verifyPrivilegedSandboxRuntime)(privilegedRuntime)
+        if (tool.name === 'bash') {
+          if (opts.permissions === undefined) {
+            throw new SandboxPolicyError('model-driven bash has no permission service; refusing unsandboxed execution')
+          }
+          preparedSandboxRuntime = await applyBashSandbox(
+            mutableArgs,
+            opts.permissions,
+            liveOrigin,
+            opts.agentDir,
+            opts.sessionId,
+            bashEnvOverlay,
+            sandboxBoundary,
+          )
         }
+
+        tmpRedirect =
+          TMP_REDIRECT_TOOLS.has(tool.name) && opts.permissions !== undefined
+            ? await applyTmpPathRedirect(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId)
+            : undefined
+        pinnedFiles = await enforceAndPinToolFiles({
+          tool: tool.name,
+          args: mutableArgs,
+          agentDir: opts.agentDir,
+          ...(opts.permissions !== undefined
+            ? { hidden: resolveHiddenPaths(opts.permissions, liveOrigin, opts.agentDir) }
+            : {}),
+          signal,
+        })
+        await preparedSandboxRuntime?.verify()
         rawResult = await bashEnvStore.run(bashEnvOverlay, () =>
           tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx),
         )
       } catch (error) {
         executionError = error
-      }
-      let cleanupError: unknown
-      if (privilegedRuntime !== undefined) {
-        try {
-          await (sandboxBoundary.cleanupRuntime ?? cleanupPrivilegedSandboxRuntime)(privilegedRuntime)
-        } catch (error) {
-          cleanupError = error
-        }
+      } finally {
+        const cleanup = [pinnedFiles?.cleanup(), preparedSandboxRuntime?.cleanup()].filter(
+          (task): task is Promise<void> => task !== undefined,
+        )
+        const outcomes = await Promise.allSettled(cleanup)
+        const failed = outcomes.find((outcome) => outcome.status === 'rejected')
+        if (failed?.status === 'rejected') cleanupError = failed.reason
       }
       const finalError = executionError ?? cleanupError
       if (finalError !== undefined) {
-        // A throwing tool or cleanup must still run tool.after exactly once so
-        // lifecycle hooks release reservations. The execution error remains the
-        // primary failure when both phases reject.
         await runToolAfterSafely(opts, tool.name, toolCallId, toErrorResult(finalError))
         throw finalError
       }
+      if (pinnedFiles === undefined) throw new Error('tool file boundary was not initialized')
       if (rawResult === undefined) throw new Error('tool execution returned no result')
-      const result = tmpRedirect !== undefined ? restoreTmpPathInResult(rawResult, tmpRedirect) : rawResult
+      const pinnedResult = pinnedFiles.restoreResult(rawResult)
+      const result = tmpRedirect !== undefined ? restoreTmpPathInResult(pinnedResult, tmpRedirect) : pinnedResult
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
         fireLoopAbort(opts.getAbort, 'loop_guard:deferred_block')
@@ -564,9 +654,30 @@ export function buildBuiltinPiToolOverrides(opts: WrapSystemToolOptions): ToolDe
   return defaultBuiltinPiToolDefinitions(opts.agentDir).map((tool) => wrapBuiltinToolDefinition(tool, opts))
 }
 
+type BashFilesystemPolicyOptions = {
+  agentDir: string
+  canWriteAgentRoot: boolean
+  masks: { dirs: string[]; files: string[] }
+  writable: { dirs: string[]; files: string[] }
+  protected: { dirs: string[]; files: string[] }
+}
+
+type PreparedBashSandbox = {
+  verify: () => Promise<void>
+  cleanup: () => Promise<void>
+}
+
+export function buildBashFilesystemPolicy(options: BashFilesystemPolicyOptions) {
+  const { agentDir, canWriteAgentRoot, masks, writable, protected: protectedZones } = options
+  if (canWriteAgentRoot) {
+    return { writableRoot: { dir: agentDir }, masks, protected: protectedZones }
+  }
+  return { masks, writable, protected: protectedZones }
+}
+
 // Rewrites mutableArgs.command in place so the bash builtin runs inside bwrap
-// with role-derived path masks. A role that sees everything (trusted+) yields
-// no masks and runs unchanged. When masks ARE needed but bwrap is unavailable
+// with role-derived private-directory masks and unconditional canonical-secret
+// file masks. When masks are needed but bwrap is unavailable
 // we throw rather than run unsandboxed — fail closed, never leak the masked
 // surface. Runs after the tool.before guards have inspected the raw command.
 async function applyBashSandbox(
@@ -577,89 +688,32 @@ async function applyBashSandbox(
   sessionId: string,
   envOverlay: BashEnvOverlay | undefined,
   boundary: BashSandboxBoundary,
-): Promise<PrivilegedSandboxRuntime | undefined> {
+): Promise<PreparedBashSandbox> {
   const command = mutableArgs.command
-  if (typeof command !== 'string') return undefined
+  if (typeof command !== 'string') return { verify: async () => {}, cleanup: async () => {} }
 
   await assertNoCanonicalSecretsInGit(agentDir)
 
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
-
   const sandboxEnvOverlay = buildRoleScopedConfigEnv(agentDir, dirs, envOverlay)
-
-  // bwrap's --ro-bind-data/--tmpfs mask ops abort when the target does not exist
-  // on the (read-only, virtiofs/OrbStack) agent-folder bind. Materialize the mask
-  // targets on the real host FS first; the full {dirs, files} still feeds
-  // subtractMasked below so a masked path is never re-exposed by a later RW bind.
   const maskTargets = await ensureHiddenMaskTargets({ dirs, files })
   await boundary.ensureAvailable()
-  // Per-session /tmp: bind this session's scratch dir over the default
-  // --tmpfs /tmp so writes survive across the role's sandboxed bash calls AND
-  // match what the write/edit wrapper redirected a /tmp path to. The bind is
-  // emitted via policy.mounts (after the hardcoded --tmpfs /tmp), so last-op-
-  // wins makes it the live /tmp. Unsandboxed roles (empty masks, returned
-  // above) keep sharing the real container /tmp between write and bash.
   const sessionTmp = await ensureSessionTmpDir(sessionId)
-  // Write-confined jail for low-trust roles: bind the whole project read-only,
-  // hide private/secret paths, then re-expose only the free-write scratch zones
-  // (workspace + root allowlist + .git) RW. The WORKING TREE outside those zones
-  // (node_modules/, agentDir root, non-allowlisted tracked files) stays EROFS, so
-  // bash cannot sidestep the non-workspace-write guard — and `git checkout` of a
-  // protected worktree path fails at the kernel. .git is RW so members can
-  // commit; .git/hooks + .git/config (and any writable core.hooksPath target)
-  // are re-protected RO (protected, rendered after writable, ensured to exist so
-  // an absent path can't be created+executed) so a hook-plant / core.hooksPath
-  // never becomes code execution in the unsandboxed runtime git ops. Trusted/owner never reach here
-  // (their masks are empty) and keep full unsandboxed access. subtractMasked
-  // drops any writable zone masked for this role so an RW bind never re-exposes a
-  // hidden path (e.g. a guest's masked workspace/).
-  // config.sandbox.* is read from the BOOT-TIME snapshot, not getConfig():
-  // sandbox is restart-required, so the writable surface AND the in-jail symlinks
-  // must stay coherent with the boot-time bwrap/capability decisions and with the
-  // entrypoint shim's symlink creation (same contract as resolveProcStrategy's
-  // read of config.sandbox.realProc below). getSandboxWritablePathSpecs folds
-  // every sandbox.symlinks[].to into the writable set so the symlink target is
-  // writable without the operator also listing it under writablePaths.
   const writable = subtractMasked(await resolveWritableZones(agentDir, getSandboxWritablePathSpecs(config)), {
     dirs,
     files,
   })
-  // subtractMasked again on the protected set: a protected RO bind renders after
-  // the masks (last-op-wins), so an unfiltered protected path nested under a
-  // masked dir (e.g. a guest's workspace/ when core.hooksPath=workspace/hooks)
-  // would re-expose the hidden real dir. A masked path is already non-writable
-  // for this role, so it needs no protection anyway.
   const writableRoot = canWriteAgentRootInSandbox(permissions, origin)
   const protectedZones =
     writableRoot || writable.dirs.includes(join(agentDir, '.git'))
       ? subtractMasked(await resolveProtectedZones(agentDir), { dirs, files })
       : { dirs: [], files: [] }
-  // Only emit an in-jail symlink for a target that actually survived as a
-  // writable dir: a symlink to a target that was dropped (missing, masked for
-  // this role, or filtered by the writable-zone guardrails) would dangle onto an
-  // EROFS/hidden path. Resolve `from` against the SANDBOX HOME (/tmp), where the
-  // per-session tmp dir is bound — NOT the container's real /root, which the jail
-  // never sees. The entrypoint shim handles the real-/root symlink for the
-  // unsandboxed (trusted/owner) path.
   const writableDirSet = new Set(writable.dirs)
   const sandboxHome = DEFAULT_SANDBOX_ENV.HOME ?? '/tmp'
   const symlinks = resolveSandboxSymlinks(agentDir, config.sandbox.symlinks, sandboxHome).filter((op) =>
     writableDirSet.has(op.target),
   )
-  // The spawn hook gives bwrap the command-scoped overlay as its parent env.
-  // Secret names are inherited through bwrap without putting their values in
-  // --setenv argv; only non-secret overlay/runtime values are rendered.
   const { strategy: proc, degradeReason } = await resolveProcStrategy()
-  // Fail fast with an actionable error when /proc degraded to tmpfs AND the
-  // command needs a real /proc: under tmpfs Bun would otherwise abort deep in its
-  // pipeline with the opaque "NotDir", which the model retries forever. Which
-  // error depends on WHY it degraded: a 'definitive' degrade (a real leak / an
-  // incapable host) is permanent → SandboxDegradedProcError ("retrying won't
-  // help"); an 'unverified' degrade (the safety probe stayed inconclusive through
-  // its retry budget, e.g. a boot-time load spike) is transient and re-probes on
-  // the next call → SandboxProcProbeUnverifiedError ("retry the same command").
-  // Guarded on the command so non-bun bash still runs in the degraded mode (it
-  // does not touch /proc/self/{fd,maps}).
   if (proc === 'tmpfs' && commandNeedsRealProc(command)) {
     throw degradeReason === 'unverified' ? new SandboxProcProbeUnverifiedError() : new SandboxDegradedProcError()
   }
@@ -668,6 +722,8 @@ async function applyBashSandbox(
     command,
     env: sandboxEnvOverlay,
   })
+  const cleanup = async (): Promise<void> =>
+    (boundary.cleanupRuntime ?? cleanupPrivilegedSandboxRuntime)(privilegedRuntime)
   try {
     await verifyHiddenMaskTargets(maskTargets)
     const { commandString } = boundary.buildCommand(command, {
@@ -689,9 +745,12 @@ async function applyBashSandbox(
         : {}),
     })
     mutableArgs.command = commandString
-    return privilegedRuntime
+    return {
+      verify: async () => (boundary.verifyRuntime ?? verifyPrivilegedSandboxRuntime)(privilegedRuntime),
+      cleanup,
+    }
   } catch (error) {
-    await (boundary.cleanupRuntime ?? cleanupPrivilegedSandboxRuntime)(privilegedRuntime).catch(() => undefined)
+    await cleanup()
     throw error
   }
 }
@@ -721,8 +780,8 @@ function buildRoleScopedConfigEnv(
   // Low-trust roles have workspace/ masked. Do not let container-global config
   // env vars point CLIs back at that private surface: apps that honor XDG should
   // still run, but their config must land in the sandbox's per-session /tmp.
-  // Trusted/owner never get here (no hidden dirs), so their Dockerfile-level
-  // persistent GWS_CONFIG_HOME remains /agent/workspace/.config/gws.
+  // Trusted/owner have only the unconditional credential-dir masks, not the
+  // workspace root mask, so their command broker decides whether to set GWS.
   const workspaceHidden = hiddenDirs.includes(join(agentDir, 'workspace'))
   if (!workspaceHidden) return envOverlay
 
@@ -778,7 +837,7 @@ async function resolveProcStrategy(): Promise<ProcStrategyResolution> {
   )
   if (verdict === 'safe') return { strategy: 'proc-bind' }
   // Degraded last resort: no working /proc strategy. External package runners
-  // (bunx/bun add/bun run <pkg-bin>) will fail with Bun's opaque "NotDir" because
+  // (bunx/bun run <pkg-bin>) will fail with Bun's opaque "NotDir" because
   // /proc/self/{fd,maps} are absent. Only a proven 'unsafe' (a real cross-userns
   // leak) is DEFINITIVE — warn once (a real operator-facing limit). An
   // 'inconclusive' is reported as retryable upstream and NOT warned (it would cry
@@ -797,25 +856,26 @@ function warnTmpfsProcFallbackOnce(): void {
   tmpfsProcFallbackWarned = true
   console.warn(
     '[sandbox] degraded /proc mode: neither real-proc nor proc-bind is available on this host, ' +
-      'so sandboxed external package runners (bunx / bun add / bun run <pkg-bin>) will fail. ' +
+      'so sandboxed external package runners (bunx / bun run <pkg-bin>) will fail. ' +
       'This needs a runtime with working user namespaces.',
   )
 }
 
-// The builtin file tools that take a single filesystem `path` arg. For a
-// sandboxed role they all run UNSANDBOXED in the main process (only bash is
-// bwrap-wrapped), so each must apply the same /tmp -> session-dir mapping that
+// The builtin file tools that take a single filesystem `path` arg. They run in
+// the main process rather than bwrap, so each must apply the same
+// /tmp -> session-dir mapping that
 // applyBashSandbox binds for bash — otherwise a `read` of /tmp/foo hits the
 // real container /tmp while sandboxed bash wrote the session backing dir.
 const TMP_REDIRECT_TOOLS = new Set(['read', 'write', 'edit', 'grep', 'find', 'ls'])
 
-// Sandboxed roles read /tmp through bwrap's per-session bind (applyBashSandbox),
-// but the path-based file tools run unsandboxed against the real container /tmp.
+// Model-driven bash reads /tmp through bwrap's per-session bind
+// (applyBashSandbox), but the path-based file tools run in the main process
+// against the real container /tmp.
 // Without this redirect a guest/member that touches /tmp/foo through bash (bound
 // to the session dir) and through a file tool (real /tmp) would see two
 // different files. Rewriting the file tool's on-disk path to the same session
-// backing dir makes every layer resolve /tmp/foo to one file. Unsandboxed roles
-// (empty masks) are left untouched: their bash already shares the real /tmp.
+// backing dir makes every layer resolve /tmp/foo to one file. Bare harnesses
+// without the production permission wiring are left untouched.
 type TmpRedirect = { original: string; backing: string }
 
 async function applyTmpPathRedirect(
@@ -857,6 +917,12 @@ function restoreTmpPathInResult(result: ToolResult, redirect: TmpRedirect): Tool
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
+}
+
+function normalizeDefaultTreeRoot(toolName: string, args: Record<string, unknown>): void {
+  if ((toolName === 'grep' || toolName === 'find' || toolName === 'ls') && typeof args.path !== 'string') {
+    args.path = '.'
+  }
 }
 
 function appendLoopWarning(result: ToolResult, message: string): ToolResult {
@@ -1016,10 +1082,26 @@ function errorResult(message: string) {
 
 async function runFinalWriteGuards(options: { tool: string; args: Record<string, unknown>; agentDir: string }) {
   return (
+    (await checkGitControlWriteGuard(options)) ??
     (await checkManagedConfigGuard(options)) ??
     (await checkSkillAuthoringGuard(options)) ??
     checkNonWorkspaceWriteGuard(options)
   )
+}
+
+async function checkGitControlWriteGuard(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): Promise<{ block: true; reason: string } | undefined> {
+  if (options.tool !== 'write' && options.tool !== 'edit') return undefined
+  const candidate = options.args.path
+  if (typeof candidate !== 'string') return undefined
+  if (!(await isGitControlPath(options.agentDir, candidate))) return undefined
+  return {
+    block: true,
+    reason: `Git control path is runtime-protected and cannot be modified with ${options.tool}: ${candidate}`,
+  }
 }
 
 function runFinalReadGuards(options: { tool: string; args: Record<string, unknown> }) {

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -1,0 +1,978 @@
+import { constants, createWriteStream, lstatSync, type Stats } from 'node:fs'
+import { chmod, mkdir, mkdtemp, open, readdir, realpath, rm, stat, type FileHandle } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
+import type { ToolFileOperands, ToolResult } from '@/plugin'
+import { CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
+import type { HiddenPaths } from '@/sandbox/hidden-paths'
+
+type Rewrite = { original: string; pinned: string }
+type FileTarget = { get(): string; original: string; set(value: string): void; uri: boolean }
+type VerifiedInput = {
+  target: FileTarget
+  original: string
+  resolved: string
+  dev: number
+  ino: number
+  size: number
+  kind: 'file' | 'directory'
+}
+
+export const TOOL_INPUT_MAX_BYTES = {
+  // read supports offset/limit browsing, so permit large source files while
+  // bounding the immutable whole-object snapshot.
+  read: 64 * 1024 * 1024,
+  // Keep local images on the same budget as look_at's bounded URL fetch.
+  look_at: 20 * 1024 * 1024,
+  // Preserve common channel upload sizes without allowing unbounded copies.
+  channel_upload: 100 * 1024 * 1024,
+} as const
+
+export const TOOL_INPUT_MAX_COUNT = {
+  read: 1,
+  look_at: 16,
+  channel_upload: 32,
+} as const
+
+export const PINNED_SNAPSHOT_GLOBAL_MAX_BYTES = TOOL_INPUT_MAX_BYTES.channel_upload
+export const PINNED_SNAPSHOT_GLOBAL_MAX_COUNT = TOOL_INPUT_MAX_COUNT.channel_upload
+export const PINNED_SNAPSHOT_MAX_WAITERS = 32
+const TREE_SNAPSHOT_MAX_ENTRIES = 4096
+const AGENT_ROOT_SNAPSHOT_EXCLUDED_DIRS = new Set(['.git', '.gitstore', 'node_modules'])
+
+export const TOOL_INPUT_TEMP_PREFIX = 'typeclaw-tool-input-'
+
+export type PinnedToolFiles = {
+  restoreResult(result: ToolResult): ToolResult
+  cleanup(): Promise<void>
+}
+
+export async function enforceAndPinToolFiles(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+  tempRoot?: string
+  genericInputs?: boolean
+  fileOperands?: ToolFileOperands
+  hidden?: HiddenPaths
+  signal?: AbortSignal
+}): Promise<PinnedToolFiles> {
+  if (options.signal?.aborted === true) throw abortError(options.signal)
+  const maxCount = maxInputCount(options.tool)
+  const targets = fileTargets(
+    options.tool,
+    options.args,
+    maxCount,
+    options.genericInputs === true,
+    options.fileOperands,
+    options.agentDir,
+  )
+  enforceCanonicalSecretDenial(options)
+  const outputs = outputTargets(options.tool, options.args, maxCount, options.fileOperands)
+  if (outputs.length > 0) return await pinOutputTargets(options, outputs)
+  if (targets.length === 0) return noPinnedFiles()
+
+  let dir: string | undefined
+  const rewrites: Rewrite[] = []
+  const verified: VerifiedInput[] = []
+  const maxBytes = maxInputBytes(options.tool)
+  let lease: BudgetLease | undefined
+  try {
+    let declaredBytes = 0
+    for (const target of targets) {
+      const original = target.get()
+      const absolute = path.resolve(options.agentDir, original)
+      const resolved = await realpath(absolute).catch((error) => {
+        if (isNotFoundError(error)) throw new Error(`tool input did not exist while being authorized: ${original}`)
+        throw error
+      })
+      enforceCanonicalSecretDenial({ tool: options.tool, args: { path: resolved }, agentDir: options.agentDir })
+      const inspected = await stat(resolved)
+      const kind = inspected.isFile()
+        ? 'file'
+        : inspected.isDirectory() && isTreeInputTool(options.tool)
+          ? 'directory'
+          : undefined
+      if (kind === undefined) throw new Error(`tool input is not a supported regular file or directory: ${original}`)
+      if (kind === 'file') assertSingleLinkRegularFile(inspected, original)
+      if (kind === 'file' && inspected.size > maxBytes) throw inputTooLarge(original, inspected.size, maxBytes)
+      declaredBytes += kind === 'file' ? inspected.size : 0
+      if (declaredBytes > maxBytes) throw aggregateInputTooLarge(declaredBytes, maxBytes)
+      verified.push({ target, original, resolved, dev: inspected.dev, ino: inspected.ino, size: inspected.size, kind })
+    }
+
+    lease = await pinnedSnapshotBudget.acquire(declaredBytes, verified.length, options.signal)
+
+    dir = await mkdtemp(path.join(options.tempRoot ?? tmpdir(), TOOL_INPUT_TEMP_PREFIX))
+    let copiedBytes = 0
+    for (let i = 0; i < verified.length; i++) {
+      const input = verified[i] as VerifiedInput
+      const pinned = path.join(dir, String(i))
+      if (input.kind === 'file') {
+        const source = await openInput(input.resolved, input.original)
+        try {
+          const opened = await source.stat()
+          assertSingleLinkRegularFile(opened, input.original)
+          if (opened.dev !== input.dev || opened.ino !== input.ino) {
+            throw new Error(`tool input changed while waiting for snapshot capacity: ${input.original}`)
+          }
+          copiedBytes += await streamSnapshot(
+            source,
+            pinned,
+            input.original,
+            maxBytes,
+            copiedBytes,
+            lease,
+            verified.length,
+            options.signal,
+          )
+          await chmod(pinned, 0o400)
+        } finally {
+          await source.close()
+        }
+      } else {
+        copiedBytes += await snapshotDirectoryTree({
+          source: input,
+          destination: pinned,
+          agentDir: options.agentDir,
+          tool: options.tool,
+          maxBytes,
+          previouslyCopied: copiedBytes,
+          lease,
+          operandCount: verified.length,
+          hidden: options.hidden,
+          signal: options.signal,
+        })
+      }
+      const executionValue = input.target.uri ? pathToFileURL(pinned).href : pinned
+      input.target.set(executionValue)
+      rewrites.push({ original: input.target.original, pinned: executionValue })
+    }
+    if (!lease.resize(copiedBytes, verified.length)) throw processBudgetGrowthExceeded(copiedBytes)
+  } catch (error) {
+    try {
+      if (dir !== undefined) await removePinnedSnapshot(dir)
+    } finally {
+      lease?.release()
+    }
+    throw error
+  }
+
+  if (dir === undefined) return noPinnedFiles()
+
+  let cleaned = false
+
+  return {
+    restoreResult(result) {
+      let restored = result
+      for (const rewrite of rewrites) restored = replaceResultPath(restored, rewrite)
+      return restored
+    },
+    async cleanup() {
+      if (cleaned) return
+      cleaned = true
+      try {
+        await removePinnedSnapshot(dir)
+      } finally {
+        lease?.release()
+      }
+    },
+  }
+}
+
+async function removePinnedSnapshot(root: string): Promise<void> {
+  const pending = [root]
+  while (pending.length > 0) {
+    const directory = pending.pop()
+    if (directory === undefined) break
+    await chmod(directory, 0o700)
+    const entries = await readdir(directory, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isDirectory()) pending.push(path.join(directory, entry.name))
+    }
+  }
+  await rm(root, { recursive: true, force: true })
+}
+
+export function enforceCanonicalSecretDenial(options: {
+  tool: string
+  args: Record<string, unknown>
+  agentDir: string
+}): void {
+  const blocked = checkPrivateSurfaceReadGuard({ ...options, hidden: { dirs: [], files: [] } })
+  if (blocked !== undefined) throw new Error(`blocked: ${blocked.reason}`)
+}
+
+function fileTargets(
+  tool: string,
+  args: Record<string, unknown>,
+  maxCount: number,
+  genericInputs: boolean,
+  fileOperands: ToolFileOperands | undefined,
+  agentDir: string,
+): FileTarget[] {
+  if (isOutputTool(tool)) return []
+  if (tool === 'read' && typeof args.path === 'string') return [propertyTarget(args, 'path')]
+  if (isTreeInputTool(tool)) {
+    if (typeof args.path !== 'string') args.path = '.'
+    return [propertyTarget(args, 'path')]
+  }
+  const targets: FileTarget[] = []
+  const addPath = (value: unknown): void => {
+    if (!isRecord(value) || typeof value.path !== 'string') return
+    targets.push(propertyTarget(value, 'path'))
+    if (targets.length > maxCount) throw inputCountTooLarge(targets.length, maxCount)
+  }
+  if (tool === 'look_at' && Array.isArray(args.images)) {
+    for (const image of args.images) addPath(image)
+    return targets
+  }
+  if ((tool === 'channel_send' || tool === 'channel_reply') && Array.isArray(args.attachments)) {
+    for (const attachment of args.attachments) addPath(attachment)
+    return targets
+  }
+  if (tool === 'channel_fetch_attachment') return targets
+  if (genericInputs) collectGenericFileTargets(args, targets, maxCount, fileOperands, agentDir)
+  return targets
+}
+
+function propertyTarget(object: Record<string, unknown>, key: string): FileTarget {
+  const raw = object[key] as string
+  return {
+    get: () => normalizeFileReference(object[key] as string),
+    original: raw,
+    set: (value) => {
+      object[key] = value
+    },
+    uri: raw.toLocaleLowerCase().startsWith('file:'),
+  }
+}
+
+function arrayTarget(array: unknown[], index: number): FileTarget {
+  const raw = array[index] as string
+  return {
+    get: () => normalizeFileReference(array[index] as string),
+    original: raw,
+    set: (value) => {
+      array[index] = value
+    },
+    uri: raw.toLocaleLowerCase().startsWith('file:'),
+  }
+}
+
+function outputTargets(
+  tool: string,
+  args: Record<string, unknown>,
+  maxCount: number,
+  operands: ToolFileOperands | undefined,
+): FileTarget[] {
+  if (isOutputTool(tool)) return typeof args.path === 'string' ? [propertyTarget(args, 'path')] : []
+  if (operands?.output === undefined || operands.output.length === 0) return []
+  const targets: FileTarget[] = []
+  collectDeclaredOutputTargets(args, targets, maxCount, new Set(operands.output))
+  return targets
+}
+
+function collectDeclaredOutputTargets(
+  value: unknown,
+  out: FileTarget[],
+  maxCount: number,
+  declared: ReadonlySet<string>,
+  parentPath = '',
+): void {
+  if (Array.isArray(value)) {
+    const declaredOutput = declared.has(parentPath)
+    for (const [index, item] of value.entries()) {
+      if (typeof item === 'string') {
+        if (declaredOutput) {
+          out.push(arrayTarget(value, index))
+          if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
+        }
+        continue
+      }
+      collectDeclaredOutputTargets(item, out, maxCount, declared, parentPath)
+    }
+    return
+  }
+  if (!isRecord(value)) return
+  for (const [childKey, item] of Object.entries(value)) {
+    const operandPath = parentPath === '' ? childKey : `${parentPath}.${childKey}`
+    if (typeof item === 'string' && declared.has(operandPath)) {
+      out.push(propertyTarget(value, childKey))
+      if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
+      continue
+    }
+    collectDeclaredOutputTargets(item, out, maxCount, declared, operandPath)
+  }
+}
+
+function collectGenericFileTargets(
+  value: unknown,
+  out: FileTarget[],
+  maxCount: number,
+  operands: ToolFileOperands | undefined,
+  agentDir: string,
+  parentPath = '',
+): void {
+  if (Array.isArray(value)) {
+    const declaredInput = operands?.input?.includes(parentPath) === true
+    const nonInput =
+      operands?.output?.includes(parentPath) === true || operands?.destructive?.includes(parentPath) === true
+    const key = parentPath.split('.').at(-1) ?? parentPath
+    for (const [index, item] of value.entries()) {
+      if (typeof item === 'string') {
+        const fileUrl = item.toLocaleLowerCase().startsWith('file:')
+        if (!nonInput && (fileUrl || declaredInput)) {
+          out.push(arrayTarget(value, index))
+          if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
+        } else if (
+          !nonInput &&
+          !isSemanticGenericString(key, item) &&
+          isAmbiguousUndeclaredLocalOperand(item, agentDir, key)
+        ) {
+          throw new Error(
+            `ambiguous local file operand at key ${JSON.stringify(parentPath)}; the tool author must declare fileOperands.input or the caller must use a file: URI`,
+          )
+        }
+        continue
+      }
+      collectGenericFileTargets(item, out, maxCount, operands, agentDir, parentPath)
+    }
+    return
+  }
+  if (!isRecord(value)) return
+  for (const [childKey, item] of Object.entries(value)) {
+    const operandPath = parentPath === '' ? childKey : `${parentPath}.${childKey}`
+    if (typeof item === 'string') {
+      const fileUrl = item.toLocaleLowerCase().startsWith('file:')
+      const declaredInput = operands?.input?.includes(operandPath) === true
+      const nonInput =
+        operands?.output?.includes(operandPath) === true || operands?.destructive?.includes(operandPath) === true
+      if (!nonInput && (fileUrl || declaredInput)) {
+        out.push(propertyTarget(value, childKey))
+        if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
+        continue
+      }
+      if (
+        !nonInput &&
+        !isSemanticGenericString(childKey, item) &&
+        isAmbiguousUndeclaredLocalOperand(item, agentDir, childKey)
+      ) {
+        throw new Error(
+          `ambiguous local file operand at key ${JSON.stringify(operandPath)}; the tool author must declare fileOperands.input or the caller must use a file: URI`,
+        )
+      }
+    }
+    collectGenericFileTargets(item, out, maxCount, operands, agentDir, operandPath)
+  }
+}
+
+function noPinnedFiles(): PinnedToolFiles {
+  return { restoreResult: (result) => result, cleanup: async () => {} }
+}
+
+async function openInput(absolute: string, original: string): Promise<FileHandle> {
+  try {
+    return await open(absolute, constants.O_RDONLY)
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`tool input did not exist while being authorized: ${original}`)
+    }
+    throw error
+  }
+}
+
+async function pinOutputTargets(
+  options: {
+    tool: string
+    args: Record<string, unknown>
+    agentDir: string
+    signal?: AbortSignal
+  },
+  targets: FileTarget[],
+): Promise<PinnedToolFiles> {
+  const pinned: PinnedToolFiles[] = []
+  try {
+    for (const target of targets) pinned.push(await pinOutputTarget(options, target))
+  } catch (error) {
+    await Promise.allSettled([...pinned].reverse().map(async (entry) => await entry.cleanup()))
+    throw error
+  }
+  return {
+    restoreResult(result) {
+      return pinned.reduce((restored, entry) => entry.restoreResult(restored), result)
+    },
+    async cleanup() {
+      const outcomes = await Promise.allSettled([...pinned].reverse().map(async (entry) => await entry.cleanup()))
+      const failed = outcomes.find((outcome) => outcome.status === 'rejected')
+      if (failed?.status === 'rejected') throw failed.reason
+    },
+  }
+}
+
+async function pinOutputTarget(
+  options: {
+    tool: string
+    args: Record<string, unknown>
+    agentDir: string
+    signal?: AbortSignal
+  },
+  target: FileTarget,
+): Promise<PinnedToolFiles> {
+  if (options.signal?.aborted === true) throw abortError(options.signal)
+  const original = target.get()
+  const absolute = path.resolve(options.agentDir, original)
+  enforceCanonicalSecretDenial({ tool: options.tool, args: { path: absolute }, agentDir: options.agentDir })
+  if (process.platform !== 'linux') {
+    throw new Error('write/edit output authorization requires Linux inode anchoring; refusing an unanchored path')
+  }
+  const parent = path.dirname(absolute)
+  const basename = path.basename(absolute)
+  const noFollow = constants.O_NOFOLLOW ?? 0
+  const directory = await open(parent, constants.O_RDONLY | constants.O_DIRECTORY | noFollow).catch((error) => {
+    if (isNotFoundError(error))
+      throw new Error(`write/edit parent directory does not exist for anchored output: ${parent}`)
+    throw error
+  })
+  let targetHandle: FileHandle | undefined
+  let targetIdentity: { dev: number; ino: number } | undefined
+  try {
+    const fdRoot = '/proc/self/fd'
+    const resolvedParent = await realpath(`${fdRoot}/${directory.fd}`)
+    enforceCanonicalSecretDenial({
+      tool: options.tool,
+      args: { path: path.join(resolvedParent, basename) },
+      agentDir: options.agentDir,
+    })
+    const anchored = `${fdRoot}/${directory.fd}/${basename}`
+    targetHandle = await open(anchored, constants.O_RDWR | noFollow).catch((error) => {
+      if (isNotFoundError(error)) return undefined
+      throw error
+    })
+    let executionPath = anchored
+    if (targetHandle !== undefined) {
+      const inspected = await targetHandle.stat()
+      if (!inspected.isFile() || inspected.nlink !== 1) {
+        throw new Error(`write/edit output is not a single-link regular file: ${original}`)
+      }
+      targetIdentity = { dev: inspected.dev, ino: inspected.ino }
+      const resolved = await realpath(`${fdRoot}/${targetHandle.fd}`)
+      enforceCanonicalSecretDenial({ tool: options.tool, args: { path: resolved }, agentDir: options.agentDir })
+      executionPath = `${fdRoot}/${targetHandle.fd}`
+    }
+    target.set(executionPath)
+    let cleaned = false
+    return {
+      restoreResult(result) {
+        return replaceResultPath(result, { original, pinned: executionPath })
+      },
+      async cleanup() {
+        if (cleaned) return
+        cleaned = true
+        let verified: FileHandle | undefined
+        let verifyError: unknown
+        try {
+          verified = await open(anchored, constants.O_RDONLY | noFollow)
+          const inspected = await verified.stat()
+          if (!inspected.isFile() || inspected.nlink !== 1) {
+            throw new Error(`write/edit output is not a single-link regular file: ${original}`)
+          }
+          if (
+            targetIdentity !== undefined &&
+            (inspected.dev !== targetIdentity.dev || inspected.ino !== targetIdentity.ino)
+          ) {
+            throw new Error(`write/edit output destination changed during execution: ${original}`)
+          }
+          const resolved = await realpath(`${fdRoot}/${verified.fd}`)
+          enforceCanonicalSecretDenial({ tool: options.tool, args: { path: resolved }, agentDir: options.agentDir })
+        } catch (error) {
+          if (!(targetIdentity === undefined && isNotFoundError(error))) verifyError = error
+        }
+        const outcomes = await Promise.allSettled([verified?.close(), targetHandle?.close(), directory.close()])
+        const failed = outcomes.find((outcome) => outcome.status === 'rejected')
+        if (verifyError !== undefined) throw verifyError
+        if (failed?.status === 'rejected') throw failed.reason
+      },
+    }
+  } catch (error) {
+    await Promise.allSettled([targetHandle?.close(), directory.close()])
+    throw error
+  }
+}
+
+export async function writeFileAnchored(options: {
+  targetPath: string
+  data: Uint8Array
+  agentDir: string
+  tool: string
+}): Promise<void> {
+  const absolute = path.resolve(options.targetPath)
+  enforceCanonicalSecretDenial({ tool: options.tool, args: { path: absolute }, agentDir: options.agentDir })
+  if (process.platform !== 'linux') {
+    throw new Error('safe attachment writes require Linux inode anchoring; refusing an unanchored destination')
+  }
+  const parent = await createAndOpenAnchoredDirectory(path.dirname(absolute))
+  let output: FileHandle | undefined
+  let operationError: unknown
+  let cleanupError: unknown
+  try {
+    const anchored = `/proc/self/fd/${parent.fd}/${path.basename(absolute)}`
+    output = await open(anchored, constants.O_WRONLY | constants.O_CREAT | constants.O_NOFOLLOW, 0o600)
+    const opened = await output.stat()
+    if (!opened.isFile() || opened.nlink !== 1)
+      throw new Error('attachment destination is not a single-link regular file')
+    const resolved = await realpath(`/proc/self/fd/${output.fd}`)
+    enforceCanonicalSecretDenial({ tool: options.tool, args: { path: resolved }, agentDir: options.agentDir })
+    await output.truncate(0)
+    await output.writeFile(options.data)
+  } catch (error) {
+    operationError = error
+  } finally {
+    const outcomes = await Promise.allSettled([output?.close(), parent.close()])
+    const failed = outcomes.find((outcome) => outcome.status === 'rejected')
+    if (failed?.status === 'rejected') cleanupError = failed.reason
+  }
+  if (operationError !== undefined) throw operationError
+  if (cleanupError !== undefined) throw cleanupError
+}
+
+export async function writeToolOutputNoFollow(targetPath: string, content: string): Promise<void> {
+  const trustedDescriptorPath = /^\/proc\/self\/fd\/\d+$/.test(targetPath)
+  const flags = trustedDescriptorPath
+    ? constants.O_WRONLY | constants.O_TRUNC
+    : constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW
+  const output = await open(targetPath, flags, 0o666)
+  try {
+    await output.writeFile(content, 'utf8')
+  } finally {
+    await output.close()
+  }
+}
+
+async function createAndOpenAnchoredDirectory(absolute: string): Promise<FileHandle> {
+  if (!path.isAbsolute(absolute)) throw new Error(`anchored directory must be absolute: ${absolute}`)
+  const components = absolute.split(path.sep).filter(Boolean)
+  let current = await open(path.parse(absolute).root, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
+  try {
+    for (const component of components) {
+      const anchored = `/proc/self/fd/${current.fd}/${component}`
+      let next: FileHandle
+      try {
+        next = await open(anchored, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
+      } catch (error) {
+        if (!isNotFoundError(error)) throw error
+        await mkdir(anchored, { mode: 0o700 })
+        next = await open(anchored, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
+      }
+      await current.close()
+      current = next
+    }
+    return current
+  } catch (error) {
+    await current.close()
+    throw error
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
+async function streamSnapshot(
+  source: FileHandle,
+  destination: string,
+  original: string,
+  maxBytes: number,
+  previouslyCopied: number,
+  lease: BudgetLease,
+  operandCount: number,
+  signal?: AbortSignal,
+): Promise<number> {
+  let copied = 0
+  const limiter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      copied += chunk.byteLength
+      if (copied > maxBytes) {
+        callback(inputTooLarge(original, copied, maxBytes))
+        return
+      }
+      if (previouslyCopied + copied > maxBytes) {
+        callback(aggregateInputTooLarge(previouslyCopied + copied, maxBytes))
+        return
+      }
+      if (!lease.resize(previouslyCopied + copied, operandCount)) {
+        callback(processBudgetGrowthExceeded(previouslyCopied + copied))
+        return
+      }
+      callback(null, chunk)
+    },
+  })
+  await pipeline(
+    source.createReadStream({ autoClose: false, start: 0 }),
+    limiter,
+    createWriteStream(destination, {
+      flags: 'wx',
+      mode: 0o400,
+    }),
+    { signal },
+  )
+  return copied
+}
+
+async function snapshotDirectoryTree(options: {
+  source: VerifiedInput
+  destination: string
+  agentDir: string
+  tool: string
+  maxBytes: number
+  previouslyCopied: number
+  lease: BudgetLease
+  operandCount: number
+  hidden?: HiddenPaths
+  signal?: AbortSignal
+}): Promise<number> {
+  if (process.platform !== 'linux') {
+    throw new Error('directory tool inputs require Linux inode anchoring; refusing an unanchored traversal')
+  }
+  const root = await open(options.source.resolved, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
+  try {
+    const opened = await root.stat()
+    if (opened.dev !== options.source.dev || opened.ino !== options.source.ino) {
+      throw new Error(`tool input changed while waiting for snapshot capacity: ${options.source.original}`)
+    }
+    await mkdir(options.destination, { mode: 0o700 })
+    const state = { copied: 0, entries: 0 }
+    const openedRoot = await realpath(`/proc/self/fd/${root.fd}`)
+    const realAgentDir = await realpath(options.agentDir)
+    await snapshotOpenedDirectory(root, options.destination, options, state, openedRoot === realAgentDir)
+    await chmod(options.destination, 0o500)
+    return state.copied
+  } finally {
+    await root.close()
+  }
+}
+
+async function snapshotOpenedDirectory(
+  directory: FileHandle,
+  destination: string,
+  options: Parameters<typeof snapshotDirectoryTree>[0],
+  state: { copied: number; entries: number },
+  isAgentRoot: boolean,
+): Promise<void> {
+  const sourceRoot = `/proc/self/fd/${directory.fd}`
+  const sourcePath = await realpath(sourceRoot)
+  const entries = await readdir(sourceRoot, { withFileTypes: true })
+  for (const entry of entries) {
+    if (options.signal?.aborted === true) throw abortError(options.signal)
+    if (isAgentRoot && AGENT_ROOT_SNAPSHOT_EXCLUDED_DIRS.has(entry.name)) continue
+    state.entries += 1
+    if (state.entries > TREE_SNAPSHOT_MAX_ENTRIES) {
+      throw new Error(`directory snapshot exceeds entry limit (${state.entries} > ${TREE_SNAPSHOT_MAX_ENTRIES})`)
+    }
+    const anchored = `${sourceRoot}/${entry.name}`
+    const target = path.join(destination, entry.name)
+    const candidate = path.join(sourcePath, entry.name)
+    if (entry.isSymbolicLink()) {
+      if (isDeniedSnapshotPath(candidate, options)) continue
+      throw new Error(`directory snapshot refuses symbolic link: ${entry.name}`)
+    }
+    if (entry.isDirectory()) {
+      if (isDeniedSnapshotPath(candidate, options)) continue
+      const child = await open(anchored, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
+      try {
+        const resolved = await realpath(`/proc/self/fd/${child.fd}`)
+        if (isDeniedSnapshotPath(resolved, options)) continue
+        await mkdir(target, { mode: 0o700 })
+        await snapshotOpenedDirectory(child, target, options, state, false)
+        await chmod(target, 0o500)
+      } finally {
+        await child.close()
+      }
+      continue
+    }
+    if (!entry.isFile()) {
+      if (isDeniedSnapshotPath(candidate, options)) continue
+      throw new Error(`directory snapshot refuses non-regular entry: ${entry.name}`)
+    }
+    const source = await open(anchored, constants.O_RDONLY | constants.O_NOFOLLOW)
+    try {
+      const opened = await source.stat()
+      assertSingleLinkRegularFile(opened, candidate)
+      const resolved = await realpath(`/proc/self/fd/${source.fd}`)
+      if (isDeniedSnapshotPath(resolved, options)) continue
+      state.copied += await streamSnapshot(
+        source,
+        target,
+        resolved,
+        options.maxBytes,
+        options.previouslyCopied + state.copied,
+        options.lease,
+        options.operandCount,
+        options.signal,
+      )
+      await chmod(target, 0o400)
+    } finally {
+      await source.close()
+    }
+  }
+}
+
+function assertSingleLinkRegularFile(stats: Stats, original: string): void {
+  if (!stats.isFile()) throw new Error(`tool input changed to a non-regular file before snapshot: ${original}`)
+  if (stats.nlink !== 1) {
+    throw new Error(
+      `tool input has ${stats.nlink} hard links and cannot be snapshotted safely; copy it to a unique regular file before retrying: ${original}`,
+    )
+  }
+}
+
+function maxInputBytes(tool: string): number {
+  if (tool === 'look_at') return TOOL_INPUT_MAX_BYTES.look_at
+  if (tool === 'channel_send' || tool === 'channel_reply') return TOOL_INPUT_MAX_BYTES.channel_upload
+  return TOOL_INPUT_MAX_BYTES.read
+}
+
+function maxInputCount(tool: string): number {
+  if (tool === 'look_at') return TOOL_INPUT_MAX_COUNT.look_at
+  if (tool === 'channel_send' || tool === 'channel_reply') return TOOL_INPUT_MAX_COUNT.channel_upload
+  return TOOL_INPUT_MAX_COUNT.read
+}
+
+function isOutputTool(tool: string): boolean {
+  return tool === 'write' || tool === 'edit'
+}
+
+function isTreeInputTool(tool: string): boolean {
+  return tool === 'grep' || tool === 'find' || tool === 'ls'
+}
+
+function isAmbiguousUndeclaredLocalOperand(value: string, agentDir: string, key: string): boolean {
+  if (isFileShapedKey(key)) return true
+  if (value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value) || /^(?:\\\\|\/\/)[^\\/]/.test(value)) return true
+  if (value.startsWith('./') || value.startsWith('../')) return true
+  if (/[\\/]/.test(value)) return true
+  const basename = path.posix.basename(value.replaceAll('\\', '/'))
+  if (CANONICAL_AGENT_SECRET_FILES.includes(basename as (typeof CANONICAL_AGENT_SECRET_FILES)[number])) return true
+  if (/^[^./\\\s][^/\\\s]*\.[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) return true
+
+  const resolved = path.resolve(agentDir, value)
+  try {
+    lstatSync(resolved)
+    return true
+  } catch (error) {
+    return !isNotFoundError(error)
+  }
+}
+
+function isFileShapedKey(key: string): boolean {
+  const normalized = key.replaceAll(/[-_]/g, '').toLocaleLowerCase()
+  return (
+    normalized === 'path' ||
+    normalized === 'file' ||
+    normalized === 'filepath' ||
+    normalized === 'filename' ||
+    normalized.endsWith('path') ||
+    normalized.endsWith('filepath') ||
+    normalized.endsWith('filename')
+  )
+}
+
+function isSemanticGenericString(key: string, value: string): boolean {
+  if (isExplicitNonFileUrl(value)) return true
+  if (key === 'path' && isSafeApiRoute(value)) return true
+  return key === 'repository' && isSafeRepositorySlug(value)
+}
+
+function isExplicitNonFileUrl(value: string): boolean {
+  if (/^[A-Za-z]:[\\/]/.test(value)) return false
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*:/.test(value) || value.toLocaleLowerCase().startsWith('file:')) return false
+  try {
+    return new URL(value).protocol !== 'file:'
+  } catch {
+    return false
+  }
+}
+
+function isSafeApiRoute(value: string): boolean {
+  if (!/^\/v\d+\//.test(value) || value.includes('\\') || value.includes('//')) return false
+  const segments = value.split('/')
+  for (const segment of segments.slice(1)) {
+    if (segment.length === 0) return false
+    let decoded: string
+    try {
+      decoded = decodeURIComponent(segment)
+    } catch {
+      return false
+    }
+    if (decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\')) return false
+  }
+  return true
+}
+
+function isSafeRepositorySlug(value: string): boolean {
+  const match = /^([A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?)\/([A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?)$/.exec(
+    value,
+  )
+  return match !== null && match[1] !== '.' && match[1] !== '..' && match[2] !== '.' && match[2] !== '..'
+}
+
+function isDeniedSnapshotPath(
+  candidate: string,
+  options: { agentDir: string; tool: string; hidden?: HiddenPaths },
+): boolean {
+  return (
+    checkPrivateSurfaceReadGuard({
+      tool: options.tool,
+      args: { path: candidate },
+      agentDir: options.agentDir,
+      hidden: options.hidden ?? { dirs: [], files: [] },
+    }) !== undefined
+  )
+}
+
+function normalizeFileReference(value: string): string {
+  if (!value.toLocaleLowerCase().startsWith('file:')) return value
+  try {
+    return fileURLToPath(value)
+  } catch {
+    throw new Error(`invalid file URI: ${value}`)
+  }
+}
+
+function inputTooLarge(original: string, size: number, maxBytes: number): Error {
+  return new Error(`tool input is too large: ${original} (${size} bytes > ${maxBytes} byte limit)`)
+}
+
+function aggregateInputTooLarge(size: number, maxBytes: number): Error {
+  return new Error(`tool inputs exceed the aggregate byte limit (${size} bytes > ${maxBytes} byte limit)`)
+}
+
+function processBudgetGrowthExceeded(size: number): Error {
+  return new Error(`tool snapshot growth exceeds the process-wide pinned byte budget (${size} bytes requested)`)
+}
+
+function inputCountTooLarge(count: number, maxCount: number): Error {
+  return new Error(`tool input count exceeds the per-invocation limit (${count} > ${maxCount})`)
+}
+
+function replaceResultPath(result: ToolResult, rewrite: Rewrite): ToolResult {
+  const content = result.content.map((part) =>
+    part.type === 'text' ? { ...part, text: part.text.split(rewrite.pinned).join(rewrite.original) } : part,
+  )
+  const details = replaceDeep(result.details, rewrite)
+  return { content, details }
+}
+
+function replaceDeep(value: unknown, rewrite: Rewrite): unknown {
+  if (typeof value === 'string') return value.split(rewrite.pinned).join(rewrite.original)
+  if (Array.isArray(value)) return value.map((item) => replaceDeep(item, rewrite))
+  if (isRecord(value))
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, replaceDeep(item, rewrite)]))
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object'
+}
+
+type BudgetRequest = {
+  bytes: number
+  count: number
+  signal?: AbortSignal
+  resolve(lease: BudgetLease): void
+  reject(error: Error): void
+  onAbort?: () => void
+}
+
+type BudgetLease = {
+  resize(bytes: number, count: number): boolean
+  release(): void
+}
+
+class PinnedSnapshotBudget {
+  private bytes = 0
+  private count = 0
+  private readonly queue: BudgetRequest[] = []
+
+  async acquire(bytes: number, count: number, signal?: AbortSignal): Promise<BudgetLease> {
+    if (bytes > PINNED_SNAPSHOT_GLOBAL_MAX_BYTES || count > PINNED_SNAPSHOT_GLOBAL_MAX_COUNT) {
+      throw new Error('tool inputs exceed the process-wide pinned snapshot budget')
+    }
+    if (signal?.aborted === true) throw abortError(signal)
+    if (this.queue.length >= PINNED_SNAPSHOT_MAX_WAITERS) {
+      throw new Error(`pinned snapshot waiter queue is full (${PINNED_SNAPSHOT_MAX_WAITERS} waiters)`)
+    }
+    return await new Promise<BudgetLease>((resolve, reject) => {
+      const request: BudgetRequest = { bytes, count, signal, resolve, reject }
+      if (signal !== undefined) {
+        request.onAbort = () => {
+          const index = this.queue.indexOf(request)
+          if (index === -1) return
+          this.queue.splice(index, 1)
+          reject(abortError(signal))
+          this.drain()
+        }
+        signal.addEventListener('abort', request.onAbort, { once: true })
+      }
+      this.queue.push(request)
+      this.drain()
+    })
+  }
+
+  private drain(): void {
+    while (this.queue.length > 0) {
+      const next = this.queue[0] as BudgetRequest
+      if (
+        this.bytes + next.bytes > PINNED_SNAPSHOT_GLOBAL_MAX_BYTES ||
+        this.count + next.count > PINNED_SNAPSHOT_GLOBAL_MAX_COUNT
+      ) {
+        return
+      }
+      this.queue.shift()
+      if (next.onAbort !== undefined) next.signal?.removeEventListener('abort', next.onAbort)
+      this.bytes += next.bytes
+      this.count += next.count
+      let released = false
+      let leasedBytes = next.bytes
+      let leasedCount = next.count
+      next.resolve({
+        resize: (bytes, count) => {
+          if (released) return false
+          const byteDelta = bytes - leasedBytes
+          const countDelta = count - leasedCount
+          if (
+            this.bytes + byteDelta > PINNED_SNAPSHOT_GLOBAL_MAX_BYTES ||
+            this.count + countDelta > PINNED_SNAPSHOT_GLOBAL_MAX_COUNT
+          ) {
+            return false
+          }
+          this.bytes += byteDelta
+          this.count += countDelta
+          leasedBytes = bytes
+          leasedCount = count
+          this.drain()
+          return true
+        },
+        release: () => {
+          if (released) return
+          released = true
+          this.bytes -= leasedBytes
+          this.count -= leasedCount
+          this.drain()
+        },
+      })
+    }
+  }
+}
+
+const pinnedSnapshotBudget = new PinnedSnapshotBudget()
+
+function abortError(signal: AbortSignal): Error {
+  const reason = signal.reason
+  return new Error(`pinned snapshot wait aborted${reason === undefined ? '' : `: ${String(reason)}`}`)
+}

--- a/src/bundled-plugins/researcher/write-report.ts
+++ b/src/bundled-plugins/researcher/write-report.ts
@@ -9,6 +9,7 @@ import { defineTool, type Tool, type ToolContext } from '@/plugin'
 export type WriteReportArgs = { path: string; content: string }
 
 const REPORT_BASENAME_RE = /^research-[a-z0-9][a-z0-9-]*\.md$/
+const PROC_FD_PARENT_RE = /^\/proc\/self\/fd\/\d+$/
 
 // One report per session. The researcher subagent object — and therefore this
 // tool instance — is built ONCE by `createResearcherSubagent()` at plugin
@@ -64,15 +65,16 @@ Write to \`public/\` instead of \`workspace/\` when your resolved role lacks \`f
 
       const parent = path.dirname(target)
       const base = path.basename(target)
+      const lexicalParent = PROC_FD_PARENT_RE.test(parent) ? await realpath(parent) : parent
 
       if (!REPORT_BASENAME_RE.test(base)) {
         throw new Error(
           `Report filename must match research-<slug>.md (lowercase slug), got: ${base}. Path: ${target}.`,
         )
       }
-      if (parent !== workspaceDir && parent !== publicDir) {
+      if (lexicalParent !== workspaceDir && lexicalParent !== publicDir) {
         throw new Error(
-          `Report must be written directly under ${workspaceDir} or ${publicDir} (no subdirectories), got parent: ${parent}.`,
+          `Report must be written directly under ${workspaceDir} or ${publicDir} (no subdirectories), got parent: ${lexicalParent}.`,
         )
       }
 
@@ -81,7 +83,7 @@ Write to \`public/\` instead of \`workspace/\` when your resolved role lacks \`f
       // `realpath('<agent>/public')` throws ENOENT on agents that never made it,
       // which would reject every valid write to `workspace/`. The symlink-escape
       // defense is unchanged — the parent actually written to is still canonicalized.
-      const canonicalDir = parent === workspaceDir ? workspaceDir : publicDir
+      const canonicalDir = lexicalParent === workspaceDir ? workspaceDir : publicDir
       const [realParent, realCanonical] = await Promise.all([realpath(parent), realpath(canonicalDir)])
       if (realParent !== realCanonical) {
         throw new Error(`Report parent directory resolves outside the allowed report directories: ${parent}.`)

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
+import { buildMcpDispatcherToolDefinitions } from '@/agent'
+import { wrapSystemTool } from '@/agent/plugin-tools'
+import { createHookBus } from '@/plugin'
 import type { ToolContext } from '@/plugin/types'
 
 import type { McpConnection, McpToolInfo } from './client'
@@ -78,7 +85,7 @@ describe('createMcpDispatcherTools', () => {
     const [, , callTool] = createMcpDispatcherTools(manager)
 
     const result = await callTool.execute(
-      { server: 'files', tool: 'read', args: { path: 'README.md' } } satisfies McpCallArgs,
+      { server: 'files', tool: 'read', args: { id: 'readme-id' } } satisfies McpCallArgs,
       toolContext(),
     )
 
@@ -87,6 +94,265 @@ describe('createMcpDispatcherTools', () => {
       details: { server: 'files', tool: 'read', isError: false },
     })
   })
+
+  test('mcp_call blocks nested file URLs before invoking the external server', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-file-boundary-'))
+    await writeFile(path.join(agentDir, 'secrets.json'), '{"secret":true}')
+    let called = false
+    const connection = fakeConnection('files', [])
+    connection.callTool = async () => {
+      called = true
+      return { content: [{ type: 'text', text: 'leaked' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    try {
+      await expect(
+        callTool.execute(
+          {
+            server: 'files',
+            tool: 'read',
+            args: { nested: { url: pathToFileURL(path.join(agentDir, 'secrets.json')).href } },
+          } satisfies McpCallArgs,
+          toolContext(agentDir),
+        ),
+      ).rejects.toThrow(/not available to LLM tools/)
+      expect(called).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('mcp_call passes an immutable pinned copy for an authorized file URL', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-pinned-file-'))
+    const safe = path.join(agentDir, 'safe.txt')
+    const replacement = path.join(agentDir, 'replacement.txt')
+    await writeFile(safe, 'safe')
+    await writeFile(replacement, 'replacement')
+    const connection = fakeConnection('files', [])
+    connection.callTool = async (_tool, args) => {
+      await rm(safe)
+      await symlink(replacement, safe)
+      const url = (args as { nested: { url: string } }).nested.url
+      return { content: [{ type: 'text', text: await readFile(new URL(url), 'utf8') }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    try {
+      const result = await callTool.execute(
+        {
+          server: 'files',
+          tool: 'read',
+          args: { nested: { url: pathToFileURL(safe).href } },
+        } satisfies McpCallArgs,
+        toolContext(agentDir),
+      )
+      expect(result.content).toEqual([{ type: 'text', text: 'safe' }])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('mcp_call rejects an undeclared absolute path-like operand before invoking the server', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-absolute-pin-'))
+    const safe = path.join(agentDir, 'safe.txt')
+    await writeFile(safe, 'safe')
+    let called = false
+    const connection = fakeConnection('files', [])
+    connection.callTool = async () => {
+      called = true
+      return { content: [{ type: 'text', text: 'unexpected' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    try {
+      await expect(
+        callTool.execute({ server: 'files', tool: 'read', args: { inputPath: safe } }, toolContext(agentDir)),
+      ).rejects.toThrow(/ambiguous.*fileOperands\.input.*file:/i)
+      expect(called).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('mcp_call leaves narrow semantic API routes, repository slugs, and opaque ids unchanged', async () => {
+    const connection = fakeConnection('files', [])
+    let received: Record<string, unknown> | undefined
+    connection.callTool = async (_tool, args) => {
+      received = args
+      return { content: [{ type: 'text', text: 'ok' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    await callTool.execute(
+      {
+        server: 'files',
+        tool: 'repository_status',
+        args: { path: '/v1/repos', repository: 'acme/widgets', id: 'opaque-123' },
+      } satisfies McpCallArgs,
+      toolContext(),
+    )
+    expect(received).toEqual({ path: '/v1/repos', repository: 'acme/widgets', id: 'opaque-123' })
+  })
+
+  test.each(['/v1/../../tmp/result.txt', '/v1/%2e%2e/tmp/result.txt', '/v1\\..\\tmp', '/v1//repos'])(
+    'mcp_call rejects traversal-shaped API route %s before invoking the server',
+    async (route) => {
+      let called = false
+      const connection = fakeConnection('files', [])
+      connection.callTool = async () => {
+        called = true
+        return { content: [{ type: 'text', text: 'unexpected' }] }
+      }
+      const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+
+      await expect(
+        callTool.execute({ server: 'files', tool: 'request', args: { path: route } }, toolContext()),
+      ).rejects.toThrow(/ambiguous.*fileOperands\.input.*file:/i)
+      expect(called).toBeFalse()
+    },
+  )
+
+  test('mcp_call rejects undeclared scalar array paths and non-file-key multi-component paths before dispatch', async () => {
+    let called = false
+    const connection = fakeConnection('files', [])
+    connection.callTool = async () => {
+      called = true
+      return { content: [{ type: 'text', text: 'unexpected' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+
+    for (const args of [{ files: ['workspace/missing.txt'] }, { value: 'workspace/missing.txt' }]) {
+      await expect(callTool.execute({ server: 'files', tool: 'read', args }, toolContext())).rejects.toThrow(
+        /ambiguous.*fileOperands\.input.*file:/i,
+      )
+    }
+    expect(called).toBeFalse()
+  })
+
+  test('mcp_call pins an explicit file URI supplied as a scalar array element', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-array-file-'))
+    const safe = path.join(agentDir, 'safe.txt')
+    const replacement = path.join(agentDir, 'replacement.txt')
+    await writeFile(safe, 'safe')
+    await writeFile(replacement, 'replacement')
+    const connection = fakeConnection('files', [])
+    connection.callTool = async (_tool, args) => {
+      await rm(safe)
+      await symlink(replacement, safe)
+      const [url] = (args as { files: string[] }).files
+      return { content: [{ type: 'text', text: await readFile(new URL(url as string), 'utf8') }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    try {
+      const result = await callTool.execute(
+        { server: 'files', tool: 'read', args: { files: [pathToFileURL(safe).href] } },
+        toolContext(agentDir),
+      )
+      expect(result.content).toEqual([{ type: 'text', text: 'safe' }])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.each([
+    ['outputPath', 'result.txt'],
+    ['filename', 'result.txt'],
+    ['value', 'C:\\temp\\result.txt'],
+    ['value', '\\\\server\\share\\result.txt'],
+  ])('mcp_call rejects undeclared nonexistent local operand %s=%s', async (key, value) => {
+    let called = false
+    const connection = fakeConnection('files', [])
+    connection.callTool = async () => {
+      called = true
+      return { content: [{ type: 'text', text: 'unexpected' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    await expect(
+      callTool.execute({ server: 'files', tool: 'write', args: { [key]: value } }, toolContext()),
+    ).rejects.toThrow(/ambiguous.*fileOperands\.input.*file:/i)
+    expect(called).toBeFalse()
+  })
+
+  test('mcp_call rejects undeclared existing local operands with metadata guidance', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-ambiguous-local-'))
+    const local = path.join(agentDir, 'input.txt')
+    await writeFile(local, 'safe')
+    let called = false
+    const connection = fakeConnection('files', [])
+    connection.callTool = async () => {
+      called = true
+      return { content: [{ type: 'text', text: 'unexpected' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    try {
+      for (const value of [local, './input.txt', 'input.txt']) {
+        await expect(
+          callTool.execute(
+            { server: 'files', tool: 'read', args: { filename: value } } satisfies McpCallArgs,
+            toolContext(agentDir),
+          ),
+        ).rejects.toThrow(/ambiguous.*fileOperands\.input.*file:/i)
+      }
+      expect(called).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('mcp_call always denies a canonical bare display filename', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-canonical-filename-'))
+    let called = false
+    const connection = fakeConnection('files', [])
+    connection.callTool = async () => {
+      called = true
+      return { content: [{ type: 'text', text: 'unexpected' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ files: connection }))
+    try {
+      await expect(
+        callTool.execute(
+          { server: 'files', tool: 'inspect', args: { filename: 'secrets.json' } } satisfies McpCallArgs,
+          toolContext(agentDir),
+        ),
+      ).rejects.toThrow(/not available|canonical|ambiguous/i)
+      expect(called).toBeFalse()
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('production system wrapper pins a 52 MiB MCP file exactly once without self-deadlock', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-mcp-single-pin-'))
+    const input = path.join(agentDir, 'large.bin')
+    await writeFile(input, '')
+    await truncate(input, 52 * 1024 * 1024)
+    const connection = fakeConnection('files', [])
+    connection.callTool = async (_tool, args) => {
+      const url = (args as { input: { url: string } }).input.url
+      const bytes = await readFile(new URL(url))
+      return { content: [{ type: 'text', text: String(bytes.byteLength) }] }
+    }
+    const manager = fakeManager({ files: connection })
+    const definition = buildMcpDispatcherToolDefinitions(manager)[2]
+    if (definition === undefined) throw new Error('mcp_call definition missing')
+    const wrapped = wrapSystemTool(definition, {
+      agentDir,
+      sessionId: 'mcp-single-pin',
+      hooks: createHookBus(),
+    })
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort('MCP pinning timed out'), 20_000)
+    try {
+      const result = await wrapped.execute(
+        'c',
+        { server: 'files', tool: 'read_large', args: { input: { url: pathToFileURL(input).href } } },
+        controller.signal,
+        undefined,
+        {} as never,
+      )
+      expect(expectText(result.content[0])).toBe(String(52 * 1024 * 1024))
+    } finally {
+      clearTimeout(timer)
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  }, 30_000)
 
   test('mcp_call preserves text and image content together', async () => {
     const manager = fakeManager({
@@ -212,11 +478,11 @@ function fakeConnection(name: string, tools: McpToolInfo[], result?: CallToolRes
   }
 }
 
-function toolContext(): ToolContext {
+function toolContext(agentDir = '/agent'): ToolContext {
   return {
     signal: undefined,
     sessionId: 'ses_test',
-    agentDir: '/agent',
+    agentDir,
     logger: { info() {}, warn() {}, error() {} },
   }
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 
+import { enforceAndPinToolFiles } from '@/agent/tool-file-safety'
 import { defineTool } from '@/plugin/define'
 import type { ContentPart, Tool, ToolResult } from '@/plugin/types'
 
@@ -87,13 +88,25 @@ function createCallTool(manager: McpManager): Tool<McpCallArgs> {
       tool: z.string().describe('The bare tool name or namespaced server__tool id.'),
       args: z.record(z.string(), z.unknown()).optional().describe('Arguments matching the tool input schema.'),
     }),
-    async execute(args) {
+    async execute(args, ctx) {
       const resolved = resolveToolArgs(args.server, args.tool)
       const connection = await manager.ensureConnected(resolved.server)
       if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
 
-      const result = await safeCallTool(connection, resolved.tool, args.args ?? {})
-      return mapCallToolResult(resolved.server, resolved.tool, result)
+      const toolArgs = args.args ?? {}
+      const pinned = await enforceAndPinToolFiles({
+        tool: 'mcp_call',
+        args: toolArgs,
+        agentDir: ctx.agentDir,
+        genericInputs: true,
+        signal: ctx.signal,
+      })
+      try {
+        const result = await safeCallTool(connection, resolved.tool, toolArgs)
+        return pinned.restoreResult(mapCallToolResult(resolved.server, resolved.tool, result))
+      } finally {
+        await pinned.cleanup()
+      }
     },
   })
 }

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -29,6 +29,7 @@ export {
 export {
   resolveProtectedZones,
   resolveWritableZones,
+  isGitControlPath,
   subtractMasked,
   type ProtectedZones,
   type WritableZones,

--- a/src/sandbox/session-tmp.test.ts
+++ b/src/sandbox/session-tmp.test.ts
@@ -27,6 +27,11 @@ describe('session-tmp path mapping', () => {
     expect(mapVirtualTmpPath('/agent', 'sid', 'workspace/x.json')).toBeUndefined()
   })
 
+  test('does not redirect project paths when the agent fixture itself is under /tmp', () => {
+    expect(isUnderTmp('/tmp/typeclaw-agent', 'workspace/x.json')).toBe(false)
+    expect(mapVirtualTmpPath('/tmp/typeclaw-agent', 'sid', '.')).toBeUndefined()
+  })
+
   test('does not treat a /tmpfoo sibling as under /tmp', () => {
     expect(mapVirtualTmpPath('/agent', 'sid', '/tmpfoo/x')).toBeUndefined()
     expect(isUnderTmp('/agent', '/tmpfoo/x')).toBe(false)

--- a/src/sandbox/session-tmp.ts
+++ b/src/sandbox/session-tmp.ts
@@ -27,7 +27,7 @@ export async function ensureSessionTmpDir(sessionId: string): Promise<string> {
 
 export function isUnderTmp(agentDir: string, rawPath: string): boolean {
   const resolved = resolve(agentDir, rawPath)
-  return resolved === '/tmp' || isInside('/tmp', resolved)
+  return isVirtualTmpPath(agentDir, resolved)
 }
 
 // Maps a model-facing /tmp path to its per-session backing path. Returns
@@ -37,9 +37,15 @@ export function isUnderTmp(agentDir: string, rawPath: string): boolean {
 // for the sandboxed bash that reads it back.
 export function mapVirtualTmpPath(agentDir: string, sessionId: string, rawPath: string): string | undefined {
   const resolved = resolve(agentDir, rawPath)
-  if (resolved !== '/tmp' && !isInside('/tmp', resolved)) return undefined
+  if (!isVirtualTmpPath(agentDir, resolved)) return undefined
   const rel = relative('/tmp', resolved)
   return rel === '' ? sessionTmpDir(sessionId) : join(sessionTmpDir(sessionId), rel)
+}
+
+function isVirtualTmpPath(agentDir: string, resolved: string): boolean {
+  const resolvedAgentDir = resolve(agentDir)
+  if (resolved === resolvedAgentDir || isInside(resolvedAgentDir, resolved)) return false
+  return resolved === '/tmp' || isInside('/tmp', resolved)
 }
 
 function isInside(parent: string, child: string): boolean {


### PR DESCRIPTION
## Background

Extracted from #1201 to make the work reviewable. Slice 4/11.

## Summary

Pins built-in, plugin, and MCP file operands across execution and anchors output writes.

## Review notes

This is test-heavy but limited to one security boundary and its direct integration tests.