### PR TITLE
feat(git): harden system-owned repository operations

### DIFF
--- a/src/agent/git-nudge.ts
+++ b/src/agent/git-nudge.ts
@@ -1,3 +1,4 @@
+import { hooklessGitArgs } from '@/git/hookless'
 import { resolveAgentGit } from '@/git/resolve-agent-git'
 
 const MAX_LISTED_PATHS = 10
@@ -71,7 +72,7 @@ const defaultDeps: GitNudgeDeps = {
     if (!bun) return null
     try {
       const proc = bun.spawn({
-        cmd: ['git', ...gitArgs, 'status', '--porcelain=v1'],
+        cmd: ['git', ...hooklessGitArgs([...gitArgs, 'status', '--porcelain=v1'])],
         cwd: agentDir,
         stdout: 'pipe',
         stderr: 'pipe',

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -9,6 +9,7 @@ import { Type } from 'typebox'
 import { z } from 'zod'
 
 import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
+import { hooklessGitArgs } from '@/git/hookless'
 import { createPermissionService } from '@/permissions/permissions'
 import { createHookBus, defineTool, type PluginRegistry, type ToolResult } from '@/plugin'
 import {
@@ -999,6 +1000,15 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     }
   }
 
+  async function runFixtureGit(agentDir: string, ...args: string[]): Promise<void> {
+    const proc = Bun.spawn(['git', ...hooklessGitArgs(['-C', agentDir, ...args])], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const stderr = await new Response(proc.stderr).text()
+    if ((await proc.exited) !== 0) throw new Error(`git fixture failed: ${stderr}`)
+  }
+
   const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
   const member: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'member' }
   const guest: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'guest' }
@@ -1063,7 +1073,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     const homeDir = path.join(agentDir, 'home')
     let generatedSource: string | undefined
     try {
-      await mkdir(path.join(agentDir, '.git'), { recursive: true })
+      await runFixtureGit(agentDir, 'init')
       await mkdir(homeDir)
       await writeFile(path.join(homeDir, '.gitconfig'), '[user]\nname = Alice\nemail = user@example.com\n')
       const record: { command?: string } = {}
@@ -1104,7 +1114,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-git-config-isolation-'))
     let sandboxEnv: Record<string, string> | undefined
     try {
-      await mkdir(path.join(agentDir, '.git'), { recursive: true })
+      await runFixtureGit(agentDir, 'init')
       const wrapped = wrapBuiltinToolDefinition(fakeBash({}), {
         agentDir,
         sessionId: 'git-config-isolation',
@@ -1124,6 +1134,34 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       await wrapped.execute('c', { command: 'git push origin HEAD' }, undefined, undefined, {} as never)
 
       expect(sandboxEnv).toMatchObject({ GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_NOSYSTEM: '1' })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('blocks model-facing bash before execution when canonical secret history exists', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-contaminated-boundary-'))
+    const record: { command?: string } = {}
+    try {
+      await runFixtureGit(agentDir, 'init')
+      await runFixtureGit(agentDir, 'config', 'user.name', 'Test User')
+      await runFixtureGit(agentDir, 'config', 'user.email', 'test@example.com')
+      await writeFile(path.join(agentDir, '.env'), 'EXAMPLE_TOKEN=placeholder')
+      await runFixtureGit(agentDir, 'add', '.env')
+      await runFixtureGit(agentDir, 'commit', '-m', 'add fixture')
+      const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
+        agentDir,
+        sessionId: 'contaminated-boundary',
+        hooks: createHookBus(),
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+        bashSandboxBoundary: { ensureAvailable: async () => {}, buildCommand: buildSandboxedCommand },
+      })
+
+      await expect(wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)).rejects.toThrow(
+        /contaminated|canonical|secret/i,
+      )
+      expect(record.command).toBeUndefined()
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -23,6 +23,7 @@ import {
   checkSkillAuthoringGuard,
 } from '@/bundled-plugins/guard/policy'
 import { config, getSandboxWritablePathSpecs } from '@/config/config'
+import { assertNoCanonicalSecretsInGit } from '@/git/secret-history'
 import type { PermissionService } from '@/permissions/permissions'
 import type {
   BuiltinToolRef,
@@ -578,6 +579,8 @@ async function applyBashSandbox(
 ): Promise<PrivilegedSandboxRuntime | undefined> {
   const command = mutableArgs.command
   if (typeof command !== 'string') return undefined
+
+  await assertNoCanonicalSecretsInGit(agentDir)
 
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
 

--- a/src/bundled-plugins/backup/index.ts
+++ b/src/bundled-plugins/backup/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { hooklessGitArgs } from '@/git/hookless'
 import { withGitLock } from '@/git/mutex'
 import { resolveAgentGit } from '@/git/resolve-agent-git'
 import { definePlugin, type PluginContext, type SpawnSubagentOptions, type Subagent } from '@/plugin'
@@ -265,7 +266,7 @@ export async function resolveOriginPushUrl(cwd: string): Promise<string | null> 
   if (!repo) return null
   try {
     const proc = bun.spawn({
-      cmd: ['git', '-C', cwd, ...repo.gitArgs, 'remote', 'get-url', '--push', 'origin'],
+      cmd: ['git', ...hooklessGitArgs(['-C', cwd, ...repo.gitArgs, 'remote', 'get-url', '--push', 'origin'])],
       stdout: 'pipe',
       stderr: 'ignore',
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_OPTIONAL_LOCKS: '0' },

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,6 +8,7 @@ import {
   type GitSpawn,
   type GitSpawnResult,
   parsePorcelain,
+  makeDefaultGitSpawn,
   runBackup,
   withIndexLockRetry,
 } from './runner'
@@ -49,6 +50,53 @@ const baseDeps = (spawn: GitSpawn, message = 'chore: test'): BackupRunnerDeps =>
 })
 
 describe('runBackup', () => {
+  test('default runner commits without executing a planted hook', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'autobackup-hookless-'))
+    try {
+      const git = async (args: string[]): Promise<void> => {
+        const proc = Bun.spawn({
+          cmd: ['git', ...args],
+          cwd,
+          env: {
+            ...process.env,
+            GIT_AUTHOR_NAME: 'Test',
+            GIT_AUTHOR_EMAIL: 'test@example.com',
+            GIT_COMMITTER_NAME: 'Test',
+            GIT_COMMITTER_EMAIL: 'test@example.com',
+          },
+          stdout: 'pipe',
+          stderr: 'pipe',
+        })
+        expect(await proc.exited).toBe(0)
+      }
+      await git(['init', '-q', '-b', 'main'])
+      await writeFile(join(cwd, 'notes.md'), 'initial\n')
+      await git(['add', 'notes.md'])
+      await git(['commit', '-qm', 'initial'])
+      const marker = join(cwd, 'hook-ran')
+      const hook = join(cwd, '.git', 'hooks', 'pre-commit')
+      await writeFile(hook, `#!/bin/sh\nprintf '%s' "$TYPECLAW_HOOK_SECRET" > "${marker}"\n`)
+      await chmod(hook, 0o755)
+      await writeFile(join(cwd, 'notes.md'), 'changed\n')
+
+      const previous = process.env.TYPECLAW_HOOK_SECRET
+      process.env.TYPECLAW_HOOK_SECRET = 'must-not-leak'
+      try {
+        const result = await runBackup(
+          { cwd, pushToOrigin: false },
+          { gitSpawn: makeDefaultGitSpawn(), pickCommitMessage: async () => 'backup without hooks' },
+        )
+        expect(result).toEqual({ ok: true, kind: 'committed' })
+      } finally {
+        if (previous === undefined) delete process.env.TYPECLAW_HOOK_SECRET
+        else process.env.TYPECLAW_HOOK_SECRET = previous
+      }
+      expect(await Bun.file(marker).exists()).toBe(false)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
   test('returns no-repo when .git is missing', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'autobackup-norepo-'))
     const { spawn, calls } = makeSpawn(() => okResult())

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { hooklessGitArgs } from '@/git/hookless'
 import { type AgentGit, resolveAgentGit } from '@/git/resolve-agent-git'
 
 export const COMMIT_TIMEOUT_MS = 30_000
@@ -328,7 +329,7 @@ export function makeDefaultGitSpawn(): GitSpawn {
       // GIT_TERMINAL_PROMPT wins; NONINTERACTIVE_ENV's pager/GCM settings still
       // apply to every call. Local commands pass no `env` and stay token-free.
       const proc = bun.spawn({
-        cmd: ['git', ...args],
+        cmd: ['git', ...hooklessGitArgs(args)],
         cwd,
         stdout: 'pipe',
         stderr: 'pipe',

--- a/src/bundled-plugins/guard/policies/uncommitted-changes.ts
+++ b/src/bundled-plugins/guard/policies/uncommitted-changes.ts
@@ -1,3 +1,4 @@
+import { hooklessGitArgs } from '@/git/hookless'
 import { resolveAgentGit } from '@/git/resolve-agent-git'
 import type { ContentPart, ToolResult } from '@/plugin'
 
@@ -63,7 +64,7 @@ const defaultDeps: UncommittedChangesDeps = {
     if (!bun) return null
     try {
       const proc = bun.spawn({
-        cmd: ['git', ...gitArgs, 'status', '--porcelain=v1'],
+        cmd: ['git', ...hooklessGitArgs([...gitArgs, 'status', '--porcelain=v1'])],
         cwd: agentDir,
         stdout: 'pipe',
         stderr: 'pipe',

--- a/src/bundled-plugins/memory/dreaming.test.ts
+++ b/src/bundled-plugins/memory/dreaming.test.ts
@@ -1430,6 +1430,20 @@ async function skipWorktreeFiles(cwd: string): Promise<string[]> {
 }
 
 describe('commitMemorySnapshot', () => {
+  test('commits a snapshot without executing a planted hook', async () => {
+    await initRepo(agentDir)
+    await writeFile(streamFile('2026-04-27'), 'fragment\n')
+    const marker = join(agentDir, 'hook-ran')
+    const hook = join(agentDir, '.git', 'hooks', 'pre-commit')
+    await writeFile(hook, `#!/bin/sh\nprintf hook > "${marker}"\n`)
+    await chmod(hook, 0o755)
+
+    await commitMemorySnapshot(agentDir)
+
+    expect(await Bun.file(marker).exists()).toBe(false)
+    expect((await runGit(agentDir, ['log', '-1', '--format=%s'])).stdout).toStartWith('dream:')
+  })
+
   test('is a no-op when the directory is not a git repo', async () => {
     await writeFile(streamFile('2026-04-27'), 'fragment\n')
     await commitMemorySnapshot(agentDir)

--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -5,6 +5,7 @@ import { basename, join } from 'node:path'
 
 import { z } from 'zod'
 
+import { hooklessGitArgs } from '@/git/hookless'
 import { withGitLock } from '@/git/mutex'
 import { type AgentGit, resolveAgentGit } from '@/git/resolve-agent-git'
 import { defineTool, lsTool, readTool, type Subagent, writeTool } from '@/plugin'
@@ -773,7 +774,7 @@ async function commitMemorySnapshotUnlocked(cwd: string): Promise<void> {
   }
 
   const add = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'add', '-f', '--', ...presentPaths],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'add', '-f', '--', ...presentPaths])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -788,7 +789,10 @@ async function commitMemorySnapshotUnlocked(cwd: string): Promise<void> {
   // fails outright when `bar/` matches no tracked file, even if `foo` is
   // staged.
   const stagedNames = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'diff', '--cached', '--name-only', '-z', '--', ...SNAPSHOT_PATHS],
+    cmd: [
+      'git',
+      ...hooklessGitArgs([...repo.gitArgs, 'diff', '--cached', '--name-only', '-z', '--', ...SNAPSHOT_PATHS]),
+    ],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -807,7 +811,7 @@ async function commitMemorySnapshotUnlocked(cwd: string): Promise<void> {
   const message = await buildCommitMessage(bun, cwd, staged, undefined, repo.gitArgs)
 
   const commit = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...staged],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...staged])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -864,7 +868,7 @@ async function buildDreamSummary(
   // numstat: `<added>\t<deleted>\t<path>` per line. Use NUL-terminated so paths
   // with whitespace round-trip; -z switches the record separator to NUL.
   const numstat = bun.spawn({
-    cmd: ['git', ...gitArgs, 'diff', '--cached', '--numstat', '-z', '--', ...staged],
+    cmd: ['git', ...hooklessGitArgs([...gitArgs, 'diff', '--cached', '--numstat', '-z', '--', ...staged])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -921,7 +925,7 @@ async function listNewlyAddedSkills(
   gitArgs: readonly string[] = [],
 ): Promise<string[]> {
   const proc = bun.spawn({
-    cmd: ['git', ...gitArgs, 'diff', '--cached', '--name-status', '-z', '--', ...staged],
+    cmd: ['git', ...hooklessGitArgs([...gitArgs, 'diff', '--cached', '--name-status', '-z', '--', ...staged])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -949,7 +953,7 @@ async function listTrackedSnapshotFiles(
   repo: AgentGit,
 ): Promise<string[]> {
   const ls = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'ls-files', '-z', '--', ...SNAPSHOT_PATHS],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'ls-files', '-z', '--', ...SNAPSHOT_PATHS])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -963,7 +967,7 @@ async function clearSkipWorktree(bun: { spawn: typeof Bun.spawn }, cwd: string, 
   const files = await listTrackedSnapshotFiles(bun, cwd, repo)
   if (files.length === 0) return
   const proc = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'update-index', '--no-skip-worktree', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'update-index', '--no-skip-worktree', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -975,7 +979,7 @@ async function applySkipWorktree(bun: { spawn: typeof Bun.spawn }, cwd: string, 
   const files = await listTrackedSnapshotFiles(bun, cwd, repo)
   if (files.length === 0) return
   const proc = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'update-index', '--skip-worktree', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'update-index', '--skip-worktree', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -1324,6 +1328,7 @@ function escapeTableCell(value: string): string {
 const dreamingDeleteTopicShardTool = defineTool({
   description: deleteTopicShardTool.description,
   parameters: deleteTopicShardTool.inputSchema,
+  fileOperands: { destructive: ['path'] },
   async execute(args, ctx) {
     const result = await deleteTopicShardTool.run(args, { agentDir: ctx.agentDir })
     return { content: [{ type: 'text', text: JSON.stringify(result) }] }

--- a/src/doctor/commit.test.ts
+++ b/src/doctor/commit.test.ts
@@ -1,11 +1,52 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { commitAutoFixes, type SpawnGit } from './commit'
 
 describe('commitAutoFixes', () => {
+  test('commits fixes without executing a planted hook', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-doctor-hookless-'))
+    try {
+      const run = async (args: string[]): Promise<void> => {
+        const proc = Bun.spawn({
+          cmd: ['git', ...args],
+          cwd,
+          env: {
+            ...process.env,
+            GIT_AUTHOR_NAME: 'Test',
+            GIT_AUTHOR_EMAIL: 'test@example.com',
+            GIT_COMMITTER_NAME: 'Test',
+            GIT_COMMITTER_EMAIL: 'test@example.com',
+          },
+          stdout: 'pipe',
+          stderr: 'pipe',
+        })
+        expect(await proc.exited).toBe(0)
+      }
+      await run(['init', '-q', '-b', 'main'])
+      await writeFile(join(cwd, 'config.json'), '{}\n')
+      await run(['add', 'config.json'])
+      await run(['commit', '-qm', 'initial'])
+      await writeFile(join(cwd, 'config.json'), '{"fixed":true}\n')
+      const marker = join(cwd, 'hook-ran')
+      const hook = join(cwd, '.git', 'hooks', 'pre-commit')
+      await writeFile(hook, `#!/bin/sh\nprintf hook > "${marker}"\n`)
+      await chmod(hook, 0o755)
+
+      const result = await commitAutoFixes({
+        cwd,
+        attempts: [{ ok: true, source: 'static', name: 'config', summary: 'fixed', changedPaths: ['config.json'] }],
+      })
+
+      expect(result.kind).toBe('committed')
+      expect(await Bun.file(marker).exists()).toBe(false)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
   test('threads gitstore args into doctor auto-fix git calls', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-doctor-commit-'))
     try {

--- a/src/doctor/commit.ts
+++ b/src/doctor/commit.ts
@@ -1,3 +1,4 @@
+import { hooklessGitArgs } from '@/git/hookless'
 import { resolveAgentGit } from '@/git/resolve-agent-git'
 
 import type { CommitOutcome, FixAttempt } from './types'
@@ -97,7 +98,7 @@ const defaultSpawnGit: SpawnGit = async (args, cwd) => {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return { exitCode: -1, stdout: '', stderr: 'bun runtime not available' }
   try {
-    const proc = bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+    const proc = bun.spawn({ cmd: ['git', ...hooklessGitArgs(args)], cwd, stdout: 'pipe', stderr: 'pipe' })
     const exitCode = await proc.exited
     const stdout = await new Response(proc.stdout).text()
     const stderr = await new Response(proc.stderr).text()

--- a/src/dreams/git.ts
+++ b/src/dreams/git.ts
@@ -1,3 +1,4 @@
+import { hooklessGitArgs } from '@/git/hookless'
 import { resolveAgentGit } from '@/git/resolve-agent-git'
 
 export type GitResult = { exitCode: number; stdout: string; stderr: string }
@@ -87,7 +88,7 @@ const defaultSpawnGit: SpawnGit = async (args, cwd) => {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return { exitCode: -1, stdout: '', stderr: 'bun runtime not available' }
   try {
-    const proc = bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+    const proc = bun.spawn({ cmd: ['git', ...hooklessGitArgs(args)], cwd, stdout: 'pipe', stderr: 'pipe' })
     const exitCode = await proc.exited
     const stdout = await new Response(proc.stdout).text()
     const stderr = await new Response(proc.stderr).text()

--- a/src/git/hookless.ts
+++ b/src/git/hookless.ts
@@ -1,0 +1,5 @@
+const HOOKLESS_GIT_CONFIG = ['-c', 'core.hooksPath=/dev/null'] as const
+
+export function hooklessGitArgs(args: readonly string[]): string[] {
+  return [...HOOKLESS_GIT_CONFIG, ...args]
+}

--- a/src/git/no-bare-git-spawn.test.ts
+++ b/src/git/no-bare-git-spawn.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-const COMMITTER_FILES = [
+import * as ts from '@typescript/typescript6'
+
+import { hooklessGitArgs } from './hookless'
+
+const RUNTIME_GIT_FILES = [
   'src/bundled-plugins/backup/runner.ts',
   'src/bundled-plugins/backup/index.ts',
   'src/bundled-plugins/memory/dreaming.ts',
@@ -10,15 +14,112 @@ const COMMITTER_FILES = [
   'src/git/reconcile-ignored.ts',
   'src/doctor/commit.ts',
   'src/agent/git-nudge.ts',
+  'src/git/secret-history.ts',
   'src/bundled-plugins/guard/policies/uncommitted-changes.ts',
   'src/dreams/git.ts',
+  'src/init/index.ts',
 ] as const
 
-describe('committer git layout resolution', () => {
+const RUNTIME_COMMIT_PATHS = [
+  'src/git/system-commit.ts',
+  'src/bundled-plugins/backup/runner.ts',
+  'src/bundled-plugins/memory/dreaming.ts',
+  'src/doctor/commit.ts',
+  'src/init/index.ts',
+] as const
+
+describe('runtime git invocation guard', () => {
   test('retrofitted committers import resolveAgentGit', async () => {
-    for (const file of COMMITTER_FILES) {
+    for (const file of RUNTIME_GIT_FILES.filter((file) => file !== 'src/init/index.ts')) {
       const source = await readFile(join(process.cwd(), file), 'utf8')
       expect(source, file).toContain('resolveAgentGit')
     }
   })
+
+  test('every runtime-owned direct git spawn disables hooks through the shared helper', async () => {
+    for (const file of RUNTIME_GIT_FILES) {
+      const source = await readFile(join(process.cwd(), file), 'utf8')
+      expect(findBareGitSpawns(source, file), file).toEqual([])
+    }
+  })
+
+  test('detects direct-array and multiline object spawn forms without hooklessGitArgs', () => {
+    expect(findBareGitSpawns("Bun.spawn(['git', 'status'])", 'direct.ts')).toHaveLength(1)
+    expect(
+      findBareGitSpawns(`bun.spawn({\n  cmd: [\n    'git',\n    'commit',\n  ],\n})`, 'multiline.ts'),
+    ).toHaveLength(1)
+    expect(findBareGitSpawns("Bun.spawn(['git', ...hooklessGitArgs(['status'])])", 'safe.ts')).toEqual([])
+  })
+
+  test('enumerates every TypeClaw-owned commit path under the hookless invariant', async () => {
+    for (const file of RUNTIME_COMMIT_PATHS) {
+      const source = await readFile(join(process.cwd(), file), 'utf8')
+      expect(source, file).toContain("'commit'")
+      expect(source, file).toContain('hooklessGitArgs')
+    }
+  })
+
+  test('places the hook override before repository-layout and subcommand args', () => {
+    expect(hooklessGitArgs(['--git-dir', '/repo/gitdir', '--work-tree', '/repo/worktree', 'commit'])).toEqual([
+      '-c',
+      'core.hooksPath=/dev/null',
+      '--git-dir',
+      '/repo/gitdir',
+      '--work-tree',
+      '/repo/worktree',
+      'commit',
+    ])
+  })
 })
+
+function findBareGitSpawns(source: string, fileName: string): number[] {
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  const lines: number[] = []
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && isBunSpawn(node.expression)) {
+      const command = commandArray(node.arguments[0])
+      if (command !== undefined && isGitArray(command) && !usesHooklessGitArgs(command)) {
+        lines.push(sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return lines
+}
+
+function isBunSpawn(expression: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.name.text === 'spawn' &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text.toLocaleLowerCase() === 'bun'
+  )
+}
+
+function commandArray(argument: ts.Expression | undefined): ts.ArrayLiteralExpression | undefined {
+  if (argument === undefined) return undefined
+  if (ts.isArrayLiteralExpression(argument)) return argument
+  if (!ts.isObjectLiteralExpression(argument)) return undefined
+  for (const property of argument.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    const name = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : undefined
+    if (name === 'cmd' && ts.isArrayLiteralExpression(property.initializer)) return property.initializer
+  }
+  return undefined
+}
+
+function isGitArray(command: ts.ArrayLiteralExpression): boolean {
+  const first = command.elements[0]
+  return first !== undefined && ts.isStringLiteral(first) && first.text === 'git'
+}
+
+function usesHooklessGitArgs(command: ts.ArrayLiteralExpression): boolean {
+  return command.elements.some(
+    (element) =>
+      ts.isSpreadElement(element) &&
+      ts.isCallExpression(element.expression) &&
+      ts.isIdentifier(element.expression.expression) &&
+      element.expression.expression.text === 'hooklessGitArgs',
+  )
+}

--- a/src/git/reconcile-ignored.ts
+++ b/src/git/reconcile-ignored.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import { SYSTEM_MANAGED_ROOTS, TRULY_IGNORED_PATTERNS } from '@/init/gitignore'
 
+import { hooklessGitArgs } from './hookless'
 import { type AgentGit, resolveAgentGit } from './resolve-agent-git'
 
 export type UntrackResult = { untracked: string[] }
@@ -170,7 +171,7 @@ async function listTrackedIgnored(
   excludeFile: string,
 ): Promise<string[]> {
   const proc = bun.spawn({
-    cmd: ['git', ...gitArgs, 'ls-files', '-z', '-c', '-i', '--exclude-from', excludeFile],
+    cmd: ['git', ...hooklessGitArgs([...gitArgs, 'ls-files', '-z', '-c', '-i', '--exclude-from', excludeFile])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -182,7 +183,7 @@ async function listTrackedIgnored(
 
 async function gitRmCached(bun: BunLike, cwd: string, gitArgs: readonly string[], files: string[]): Promise<string[]> {
   const proc = bun.spawn({
-    cmd: ['git', ...gitArgs, 'rm', '--cached', '-q', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...gitArgs, 'rm', '--cached', '-q', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -200,7 +201,13 @@ async function run(
   args: readonly string[],
   env?: GitEnv,
 ): Promise<boolean> {
-  const proc = bun.spawn({ cmd: ['git', ...gitArgs, ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+  const proc = bun.spawn({
+    cmd: ['git', ...hooklessGitArgs([...gitArgs, ...args])],
+    cwd,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
   return (await proc.exited) === 0
 }
 
@@ -211,7 +218,13 @@ async function capture(
   args: readonly string[],
   env?: GitEnv,
 ): Promise<string> {
-  const proc = bun.spawn({ cmd: ['git', ...gitArgs, ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+  const proc = bun.spawn({
+    cmd: ['git', ...hooklessGitArgs([...gitArgs, ...args])],
+    cwd,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
   if ((await proc.exited) !== 0) return ''
   return await new Response(proc.stdout).text()
 }
@@ -226,7 +239,7 @@ async function forceRemove(
   env: GitEnv,
 ): Promise<boolean> {
   const proc = bun.spawn({
-    cmd: ['git', ...gitArgs, 'update-index', '-z', '--force-remove', '--stdin'],
+    cmd: ['git', ...hooklessGitArgs([...gitArgs, 'update-index', '-z', '--force-remove', '--stdin'])],
     cwd,
     env,
     stdin: new TextEncoder().encode(files.join('\0')),

--- a/src/git/secret-history.test.ts
+++ b/src/git/secret-history.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import {
+  GitSecretHistoryError,
+  assertNoCanonicalSecretsInGit,
+  resetGitSecretHistoryCacheForTests,
+  scanCanonicalSecretsInGit,
+} from './secret-history'
+
+let roots: string[] = []
+
+beforeEach(() => resetGitSecretHistoryCacheForTests())
+afterEach(async () => {
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })))
+  roots = []
+})
+
+describe('canonical Git secret history guard', () => {
+  test('leaves a clean repository unaffected', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+  })
+
+  test('detects canonical files in the current index without reading their contents', async () => {
+    const repo = await makeRepo()
+    await writeFile(join(repo, 'secrets.json'), '{"token":"example-placeholder"}')
+    await git(repo, 'add', 'secrets.json')
+
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: false, paths: ['secrets.json'] })
+  })
+
+  test('rescans a previously clean repository and catches a newly dangling staged blob', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+
+    await writeFile(join(repo, 'secrets.json'), '{"credential":"placeholder"}')
+    await git(repo, 'add', 'secrets.json')
+    await git(repo, 'reset', '--', 'secrets.json')
+    await rm(join(repo, 'secrets.json'))
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(/unreachable|dangling/i)
+  })
+
+  test('rejects replacement refs even when a replacement commit hides a canonical secret path', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const cleanCommit = await gitOutput(repo, 'rev-parse', 'HEAD')
+    await commitFile(repo, '.env', 'EXAMPLE_TOKEN=placeholder')
+    const secretCommit = await gitOutput(repo, 'rev-parse', 'HEAD')
+    await git(repo, 'replace', secretCommit, cleanCommit)
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(/replacement ref|rotate.*purge/i)
+  })
+
+  test('rejects an unreachable blob left by staging and resetting a canonical secret', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await writeFile(join(repo, 'auth.json'), '{"credential":"placeholder"}')
+    await git(repo, 'add', 'auth.json')
+    await git(repo, 'reset', '--', 'auth.json')
+    await rm(join(repo, 'auth.json'))
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(/unreachable|dangling.*rotate.*gc/i)
+  })
+
+  test('detects a removed canonical file that remains reachable from history', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, '.env', 'EXAMPLE_TOKEN=placeholder')
+    await rm(join(repo, '.env'))
+    await git(repo, 'add', '.env')
+    await git(repo, 'commit', '-m', 'remove example credential')
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
+  })
+
+  test('decodes Git C-quoted historical paths before canonical matching', async () => {
+    const repo = await makeRepo()
+    const unusual = 'workspace/.agent-messenger/비밀.json'
+    await commitFile(repo, unusual, '{"credential":"placeholder"}')
+    await rm(join(repo, unusual))
+    await git(repo, 'add', unusual)
+    await git(repo, 'commit', '-m', 'remove unusual credential path')
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(/workspace\/\.agent-messenger/i)
+  })
+
+  test('detects a canonical credential commit reachable only through a reflog as unreachable object contamination', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await commitFile(repo, 'workspace/.agent-messenger/session.json', '{"credential":"placeholder"}')
+    await git(repo, 'reset', '--hard', 'HEAD^')
+
+    const result = await scanCanonicalSecretsInGit(repo)
+    expect(result).toEqual({ ok: false, paths: ['dangling or unreachable Git objects'] })
+  })
+
+  test('handles linked worktrees whose .git entry is a file', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'auth.json', '{"credential":"placeholder"}')
+    const worktree = `${repo}-worktree`
+    roots.push(worktree)
+    await git(repo, 'worktree', 'add', worktree)
+
+    await expect(assertNoCanonicalSecretsInGit(worktree)).rejects.toThrow(/rotate.*purge.*reflog.*garbage collection/i)
+  })
+
+  test('allows a clean linked worktree whose .git entry is a file', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const worktree = `${repo}-clean-worktree`
+    roots.push(worktree)
+    await git(repo, 'worktree', 'add', worktree)
+
+    await expect(assertNoCanonicalSecretsInGit(worktree)).resolves.toBeUndefined()
+  })
+
+  test('caches contamination fail-closed for the process lifetime', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, '.env', 'EXAMPLE_TOKEN=placeholder')
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow()
+    await git(repo, 'rm', '.env')
+    await git(repo, 'commit', '-m', 'remove example credential')
+    await git(repo, 'reflog', 'expire', '--expire=now', '--all')
+    await git(repo, 'gc', '--prune=now')
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
+  })
+})
+
+async function makeRepo(): Promise<string> {
+  const repo = await mkdtemp(join(tmpdir(), 'typeclaw-git-secret-history-'))
+  roots.push(repo)
+  await git(repo, 'init')
+  await git(repo, 'config', 'user.name', 'Test User')
+  await git(repo, 'config', 'user.email', 'test@example.com')
+  return repo
+}
+
+async function commitFile(repo: string, relative: string, content: string): Promise<void> {
+  const target = join(repo, relative)
+  await mkdir(dirname(target), { recursive: true })
+  await writeFile(target, content)
+  await git(repo, 'add', relative)
+  await git(repo, 'commit', '-m', `add ${relative}`)
+}
+
+async function git(repo: string, ...args: string[]): Promise<void> {
+  await gitOutput(repo, ...args)
+}
+
+async function gitOutput(repo: string, ...args: string[]): Promise<string> {
+  const proc = Bun.spawn(['git', '-c', 'core.hooksPath=/dev/null', '-C', repo, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  const exitCode = await proc.exited
+  if (exitCode !== 0) throw new Error(`git ${args[0] ?? ''} failed: ${stderr}`)
+  return stdout.trim()
+}

--- a/src/git/secret-history.ts
+++ b/src/git/secret-history.ts
@@ -1,0 +1,148 @@
+import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
+
+import { hooklessGitArgs } from './hookless'
+import { resolveAgentGit } from './resolve-agent-git'
+
+type ScanResult = { ok: true } | { ok: false; paths: string[] }
+
+const contaminatedCache = new Map<string, string[]>()
+
+export class GitSecretHistoryError extends Error {
+  constructor(paths: readonly string[]) {
+    super(
+      [
+        `Model-driven Git/bash is disabled because Git metadata is contaminated or can conceal objects: ${paths.join(', ')}.`,
+        'Assume credentials in the repository were exposed and rotate them first. Purge canonical secret paths and every refs/replace entry, expire all reflogs, and run Git garbage collection to remove unreachable objects before retrying.',
+        'Suggested operator sequence: rewrite/purge the affected history and replacement refs, run `git reflog expire --expire=now --all`, then `git gc --prune=now`, and restart TypeClaw before retrying.',
+        'TypeClaw inspects path names and object reachability without reading blob contents. Any dangling or unreachable object blocks model-driven Git because its former path cannot be attributed safely.',
+      ].join(' '),
+    )
+    this.name = 'GitSecretHistoryError'
+  }
+}
+
+export async function assertNoCanonicalSecretsInGit(agentDir: string): Promise<void> {
+  const contaminated = contaminatedCache.get(agentDir)
+  if (contaminated !== undefined) throw new GitSecretHistoryError(contaminated)
+
+  const scan = await scanCanonicalSecretsInGit(agentDir)
+  if (!scan.ok) {
+    contaminatedCache.set(agentDir, scan.paths)
+    throw new GitSecretHistoryError(scan.paths)
+  }
+}
+
+export async function scanCanonicalSecretsInGit(agentDir: string): Promise<ScanResult> {
+  const layout = resolveAgentGit(agentDir)
+  if (layout === null) return { ok: true }
+  const gitArgs = layout.gitArgs
+  const inside = await runGit(agentDir, gitArgs, ['rev-parse', '--is-inside-work-tree'])
+  if (inside.trim() !== 'true') throw new GitSecretHistoryError(['Git metadata did not resolve to a work tree'])
+
+  const replacements = await runGit(agentDir, gitArgs, ['for-each-ref', '--format=%(refname)', 'refs/replace'])
+  if (replacements.trim() !== '') return { ok: false, paths: ['replacement refs exist under refs/replace'] }
+
+  const unreachable = await runGit(agentDir, gitArgs, ['fsck', '--unreachable', '--no-reflogs', '--no-progress'])
+  if (unreachable.trim() !== '') return { ok: false, paths: ['dangling or unreachable Git objects'] }
+
+  const index = await runGit(agentDir, gitArgs, ['ls-files', '--cached', '-z'])
+  const indexPaths = splitNul(index)
+  const directMatches = matchingCanonicalPaths(indexPaths)
+
+  const objects = await runGit(agentDir, gitArgs, ['rev-list', '--objects', '--all', '--reflog'])
+  const historicalPaths: string[] = []
+  for (const line of objects.split('\n')) {
+    const separator = line.indexOf(' ')
+    if (separator >= 0) historicalPaths.push(decodeGitPath(line.slice(separator + 1)))
+  }
+  const matches = [...new Set([...directMatches, ...matchingCanonicalPaths(historicalPaths)])].sort()
+  if (matches.length > 0) return { ok: false, paths: matches }
+
+  return { ok: true }
+}
+
+function decodeGitPath(raw: string): string {
+  if (!raw.startsWith('"') || !raw.endsWith('"')) return raw
+  const bytes: number[] = []
+  const encoder = new TextEncoder()
+  const escaped = raw.slice(1, -1)
+  for (let index = 0; index < escaped.length; index += 1) {
+    const character = escaped[index] as string
+    if (character !== '\\') {
+      bytes.push(...encoder.encode(character))
+      continue
+    }
+    const next = escaped[++index]
+    if (next === undefined) return raw
+    const simple: Record<string, number> = {
+      a: 7,
+      b: 8,
+      t: 9,
+      n: 10,
+      v: 11,
+      f: 12,
+      r: 13,
+      '"': 34,
+      '\\': 92,
+    }
+    const simpleByte = simple[next]
+    if (simpleByte !== undefined) {
+      bytes.push(simpleByte)
+      continue
+    }
+    if (/[0-7]/.test(next)) {
+      let octal = next
+      while (octal.length < 3 && index + 1 < escaped.length && /[0-7]/.test(escaped[index + 1] as string)) {
+        octal += escaped[++index]
+      }
+      bytes.push(Number.parseInt(octal, 8))
+      continue
+    }
+    bytes.push(...encoder.encode(next))
+  }
+  return new TextDecoder().decode(Uint8Array.from(bytes))
+}
+
+export function resetGitSecretHistoryCacheForTests(): void {
+  contaminatedCache.clear()
+}
+
+function matchingCanonicalPaths(paths: readonly string[]): string[] {
+  return paths.filter((raw) => {
+    const path = raw.replaceAll('\\', '/').replace(/^\.\//, '')
+    if (CANONICAL_AGENT_SECRET_FILES.some((secret) => path === secret)) return true
+    return CANONICAL_AGENT_SECRET_DIRS.some((dir) => path.startsWith(`${dir}/`))
+  })
+}
+
+function splitNul(value: string): string[] {
+  return value.split('\0').filter((entry) => entry !== '')
+}
+
+async function runGit(agentDir: string, gitArgs: readonly string[], args: readonly string[]): Promise<string> {
+  const proc = Bun.spawn(['git', ...hooklessGitArgs(['-C', agentDir, ...gitArgs, ...args])], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
+      HOME: process.env.HOME ?? '/tmp',
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_PAGER: 'cat',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_SYSTEM: '/dev/null',
+      GIT_NO_REPLACE_OBJECTS: '1',
+    },
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (exitCode === 0) return stdout
+  throw new GitSecretHistoryError([`Git metadata scan failed (${args[0] ?? 'unknown'}): ${redactGitError(stderr)}`])
+}
+
+function redactGitError(stderr: string): string {
+  const firstLine = stderr.split(/\r?\n/, 1)[0]?.trim()
+  return firstLine === undefined || firstLine === '' ? 'unknown Git error' : firstLine.slice(0, 200)
+}

--- a/src/git/system-commit.test.ts
+++ b/src/git/system-commit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
-import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -29,6 +29,35 @@ async function gitInit(cwd: string): Promise<void> {
 }
 
 describe('commitSystemFile (async)', () => {
+  test('does not execute a planted hook or expose runtime env to it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sys-commit-hookless-'))
+    try {
+      await gitInit(dir)
+      await writeFile(join(dir, 'typeclaw.json'), '{"a":1}\n')
+      await runGit(dir, ['add', 'typeclaw.json'])
+      await runGit(dir, ['commit', '-m', 'initial'])
+      await writeFile(join(dir, 'typeclaw.json'), '{"a":2}\n')
+      await mkdir(join(dir, '.git', 'hooks'), { recursive: true })
+      const marker = join(dir, 'hook-ran')
+      const hook = join(dir, '.git', 'hooks', 'pre-commit')
+      await writeFile(hook, `#!/bin/sh\nprintf '%s' "$TYPECLAW_HOOK_SECRET" > "${marker}"\n`)
+      await chmod(hook, 0o755)
+      const previous = process.env.TYPECLAW_HOOK_SECRET
+      process.env.TYPECLAW_HOOK_SECRET = 'must-not-leak'
+      try {
+        await commitSystemFile(dir, 'typeclaw.json', 'hookless update')
+      } finally {
+        if (previous === undefined) delete process.env.TYPECLAW_HOOK_SECRET
+        else process.env.TYPECLAW_HOOK_SECRET = previous
+      }
+
+      expect(await runGit(dir, ['log', '-1', '--format=%s'])).toBe('hookless update')
+      expect(existsSync(marker)).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   test('commits a dirty tracked file', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'sys-commit-async-'))
     try {

--- a/src/git/system-commit.ts
+++ b/src/git/system-commit.ts
@@ -1,3 +1,4 @@
+import { hooklessGitArgs } from './hookless'
 import { resolveAgentGit } from './resolve-agent-git'
 
 // Commits TypeClaw-owned tracked files (.gitignore, package.json,
@@ -27,7 +28,7 @@ export async function commitSystemFile(cwd: string, file: string | readonly stri
   if (!repo) return
 
   const status = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'status', '--porcelain', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'status', '--porcelain', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -36,11 +37,16 @@ export async function commitSystemFile(cwd: string, file: string | readonly stri
   const dirty = (await new Response(status.stdout).text()).trim().length > 0
   if (!dirty) return
 
-  const add = bun.spawn({ cmd: ['git', ...repo.gitArgs, 'add', '--', ...files], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const add = bun.spawn({
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'add', '--', ...files])],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
   if ((await add.exited) !== 0) return
 
   const commit = bun.spawn({
-    cmd: ['git', ...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -73,7 +79,7 @@ export function commitSystemFileSync(cwd: string, file: string | readonly string
   if (!repo) return
 
   const status = bun.spawnSync({
-    cmd: ['git', ...repo.gitArgs, 'status', '--porcelain', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'status', '--porcelain', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -82,7 +88,7 @@ export function commitSystemFileSync(cwd: string, file: string | readonly string
   if (new TextDecoder().decode(status.stdout).trim().length === 0) return
 
   const add = bun.spawnSync({
-    cmd: ['git', ...repo.gitArgs, 'add', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'add', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -90,7 +96,7 @@ export function commitSystemFileSync(cwd: string, file: string | readonly string
   if (add.exitCode !== 0) return
 
   bun.spawnSync({
-    cmd: ['git', ...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...files],
+    cmd: ['git', ...hooklessGitArgs([...repo.gitArgs, 'commit', '-m', message, '--only', '--', ...files])],
     cwd,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, statSync } from 'node:fs'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, isAbsolute, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -1188,6 +1188,20 @@ describe('scaffold', () => {
 })
 
 describe('initGitRepo', () => {
+  test('initial commit does not execute a hook already present in an empty repo', async () => {
+    await scaffold(root)
+    await runGit(root, ['init', '-b', 'main'])
+    const marker = join(root, 'hook-ran')
+    const hook = join(root, '.git', 'hooks', 'pre-commit')
+    await writeFile(hook, `#!/bin/sh\nprintf hook > "${marker}"\n`)
+    await chmod(hook, 0o755)
+
+    const result = await initGitRepo(root)
+
+    expect(result).toEqual({ ok: true, skipped: false })
+    expect(existsSync(marker)).toBe(false)
+  })
+
   test('initializes a git repo with an initial commit on main', async () => {
     await scaffold(root)
 

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -27,6 +27,7 @@ import {
   type StartResult,
   stop,
 } from '@/container'
+import { hooklessGitArgs } from '@/git/hookless'
 import { commitSystemFile } from '@/git/system-commit'
 import { createSecretsStoreForAgent, type Channels, type Secret, SecretsBackend } from '@/secrets'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
@@ -653,7 +654,12 @@ export async function isHatched(dir: string): Promise<boolean> {
   const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return false
   try {
-    const proc = bun.spawn({ cmd: ['git', 'log', '--format=%s'], cwd: dir, stdout: 'pipe', stderr: 'pipe' })
+    const proc = bun.spawn({
+      cmd: ['git', ...hooklessGitArgs(['log', '--format=%s'])],
+      cwd: dir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
     if ((await proc.exited) !== 0) return false
     const subjects = (await new Response(proc.stdout).text()).split('\n')
     return subjects.includes(HATCHED_COMMIT_SUBJECT)
@@ -858,7 +864,7 @@ export async function initGitRepo(cwd: string): Promise<GitInitResult> {
   try {
     if (hasGit) {
       const head = bun.spawn({
-        cmd: ['git', 'rev-parse', '--verify', 'HEAD'],
+        cmd: ['git', ...hooklessGitArgs(['rev-parse', '--verify', 'HEAD'])],
         cwd,
         env,
         stdout: 'pipe',
@@ -866,21 +872,27 @@ export async function initGitRepo(cwd: string): Promise<GitInitResult> {
       })
       if ((await head.exited) === 0) return { ok: true, skipped: true }
     } else {
-      const init = bun.spawn({ cmd: ['git', 'init', '-b', 'main'], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+      const init = bun.spawn({
+        cmd: ['git', ...hooklessGitArgs(['init', '-b', 'main'])],
+        cwd,
+        env,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
       if ((await init.exited) !== 0) {
         const stderr = await new Response(init.stderr).text()
         return { ok: false, reason: `git init failed: ${stderr.trim() || 'no stderr'}` }
       }
     }
 
-    const add = bun.spawn({ cmd: ['git', 'add', '.'], cwd, env, stdout: 'pipe', stderr: 'pipe' })
+    const add = bun.spawn({ cmd: ['git', ...hooklessGitArgs(['add', '.'])], cwd, env, stdout: 'pipe', stderr: 'pipe' })
     if ((await add.exited) !== 0) {
       const stderr = await new Response(add.stderr).text()
       return { ok: false, reason: `git add failed: ${stderr.trim() || 'no stderr'}` }
     }
 
     const commit = bun.spawn({
-      cmd: ['git', 'commit', '-m', 'Initial commit 🥚'],
+      cmd: ['git', ...hooklessGitArgs(['commit', '-m', 'Initial commit 🥚'])],
       cwd,
       env,
       stdout: 'pipe',


### PR DESCRIPTION
## Background

Extracted from #1201 to make the work reviewable. Slice 3/11.

## Summary

Rejects contaminated secret history and disables hooks for TypeClaw-owned Git operations.

## Review notes

The repeated caller updates all apply the same hookless argument boundary.