### PR TITLE
feat(channels): bound attachment downloads

### DIFF
--- a/src/channels/adapters/discord-bot.ts
+++ b/src/channels/adapters/discord-bot.ts
@@ -15,6 +15,11 @@ import {
   type HistoricalProvenanceResolver,
 } from '@/bundled-plugins/memory/provenance-index'
 import {
+  DEFAULT_ATTACHMENT_MAX_BYTES,
+  readAttachmentErrorSnippet,
+  readAttachmentResponse,
+} from '@/channels/fetch-attachment'
+import {
   MEMBERSHIP_ENUMERATION_CAP,
   type MembershipResolver,
   type MembershipResolverFailure,
@@ -901,7 +906,7 @@ export function createFetchAttachmentCallback(deps: {
 }): FetchAttachmentCallback {
   const { token, logger } = deps
   const fetchImpl = deps.fetchImpl ?? fetch
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     let url: URL
     try {
       url = new URL(ref)
@@ -914,13 +919,12 @@ export function createFetchAttachmentCallback(deps: {
     try {
       const res = await fetchImpl(url.toString(), { headers: { Authorization: `Bot ${token}` } })
       if (!res.ok) {
-        const body = await res.text().catch(() => '')
+        const body = await readAttachmentErrorSnippet(res)
         const message = `discord cdn fetch ${res.status} ${res.statusText}${body ? `: ${body.slice(0, 200)}` : ''}`
         logger.error(`[discord-bot] fetchAttachment failed for ${url.toString()}: ${message}`)
         return { ok: false, error: message }
       }
-      const arrayBuffer = await res.arrayBuffer()
-      const buffer = Buffer.from(arrayBuffer)
+      const buffer = await readAttachmentResponse(res, maxBytes)
       const inferredFilename = filename ?? url.pathname.split('/').pop() ?? 'attachment'
       const contentType = res.headers.get('content-type') ?? undefined
       logger.info(

--- a/src/channels/adapters/discord.ts
+++ b/src/channels/adapters/discord.ts
@@ -9,6 +9,11 @@ import {
   enrichHistoricalProvenance,
   type HistoricalProvenanceResolver,
 } from '@/bundled-plugins/memory/provenance-index'
+import {
+  DEFAULT_ATTACHMENT_MAX_BYTES,
+  readAttachmentErrorSnippet,
+  readAttachmentResponse,
+} from '@/channels/fetch-attachment'
 import type { MembershipResolver, MembershipResolverResult } from '@/channels/membership'
 import { deriveMembershipFromHistory } from '@/channels/membership-from-history'
 import type { ChannelRouter } from '@/channels/router'
@@ -149,7 +154,7 @@ export function createDiscordFetchAttachmentCallback(deps: {
   logger: DiscordAdapterLogger
 }): FetchAttachmentCallback {
   const fetchFn = deps.fetchImpl ?? fetch
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     let url: URL
     try {
       url = new URL(ref)
@@ -164,12 +169,12 @@ export function createDiscordFetchAttachmentCallback(deps: {
       const headers = token !== null ? { Authorization: token } : undefined
       const res = await fetchFn(url.toString(), headers !== undefined ? { headers } : undefined)
       if (!res.ok) {
-        const body = await res.text().catch(() => '')
+        const body = await readAttachmentErrorSnippet(res)
         const message = `discord cdn fetch ${res.status} ${res.statusText}${body ? `: ${body.slice(0, 200)}` : ''}`
         deps.logger.error(`[discord] fetchAttachment failed for ${url.toString()}: ${message}`)
         return { ok: false, error: message }
       }
-      const buffer = Buffer.from(await res.arrayBuffer())
+      const buffer = await readAttachmentResponse(res, maxBytes)
       const inferredFilename = filename ?? url.pathname.split('/').pop() ?? 'attachment'
       const contentType = res.headers.get('content-type') ?? undefined
       return {

--- a/src/channels/adapters/kakaotalk-fetch-attachment.ts
+++ b/src/channels/adapters/kakaotalk-fetch-attachment.ts
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_ATTACHMENT_MAX_BYTES,
+  readAttachmentErrorSnippet,
+  readAttachmentResponse,
+} from '@/channels/fetch-attachment'
 import type { FetchAttachmentCallback } from '@/channels/types'
 
 import type { KakaotalkAdapterLogger } from './kakaotalk'
@@ -21,7 +26,7 @@ export function createFetchAttachmentCallback(deps: {
 }): FetchAttachmentCallback {
   const { logger } = deps
   const fetchImpl = deps.fetchImpl ?? fetch
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     let url: URL
     try {
       url = new URL(ref)
@@ -37,7 +42,7 @@ export function createFetchAttachmentCallback(deps: {
     try {
       const res = await fetchImpl(url.toString())
       if (!res.ok) {
-        const body = await res.text().catch(() => '')
+        const body = await readAttachmentErrorSnippet(res)
         // 403 from kakaocdn almost always means the pre-signed URL expired
         // (the `expires=` query param has a fixed TTL — empirically ~3
         // days from the push event). Surfacing that distinction lets the
@@ -49,8 +54,7 @@ export function createFetchAttachmentCallback(deps: {
         logger.error(`[kakaotalk] fetchAttachment failed for ${url.toString()}: ${message}`)
         return { ok: false, error: message }
       }
-      const arrayBuffer = await res.arrayBuffer()
-      const buffer = Buffer.from(arrayBuffer)
+      const buffer = await readAttachmentResponse(res, maxBytes)
       const inferredFilename = filename ?? deriveFilename(url) ?? 'attachment'
       const contentType = res.headers.get('content-type') ?? undefined
       logger.info(

--- a/src/channels/adapters/slack-attachment-download.ts
+++ b/src/channels/adapters/slack-attachment-download.ts
@@ -1,0 +1,71 @@
+import {
+  discardAttachmentResponse,
+  readAttachmentErrorSnippet,
+  readAttachmentResponse,
+} from '@/channels/fetch-attachment'
+
+const MAX_SLACK_REDIRECTS = 5
+const SLACK_DOWNLOAD_HOSTS = ['slack.com', 'slack-edge.com', 'slack-files.com'] as const
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+export type SlackDownloadMetadata = {
+  name?: string
+  mimetype?: string
+  size?: number
+  url_private?: string
+  url_private_download?: string
+}
+
+export type SlackAttachmentFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+export async function downloadSlackAttachment(options: {
+  metadata: SlackDownloadMetadata
+  token: string
+  cookie?: string
+  maxBytes: number
+  fetchImpl?: SlackAttachmentFetch
+}): Promise<{ buffer: Buffer; url: URL }> {
+  const rawUrl = options.metadata.url_private_download ?? options.metadata.url_private
+  if (rawUrl === undefined || rawUrl === '') throw new Error('Slack file metadata has no private download URL')
+  const fetchImpl = options.fetchImpl ?? fetch
+  let url = parseTrustedSlackUrl(rawUrl)
+
+  for (let redirects = 0; ; redirects++) {
+    const response = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+        ...(options.cookie === undefined ? {} : { Cookie: `d=${options.cookie}` }),
+      },
+      redirect: 'manual',
+    })
+    if (REDIRECT_STATUSES.has(response.status)) {
+      await discardAttachmentResponse(response)
+      if (redirects >= MAX_SLACK_REDIRECTS) throw new Error('Slack attachment redirect limit exceeded')
+      const location = response.headers.get('location')
+      if (location === null) throw new Error('Slack attachment redirect omitted Location')
+      url = parseTrustedSlackUrl(new URL(location, url).toString())
+      continue
+    }
+    if (!response.ok) {
+      const snippet = await readAttachmentErrorSnippet(response)
+      throw new Error(`Slack attachment download failed (${response.status})${snippet === '' ? '' : `: ${snippet}`}`)
+    }
+    const contentType = response.headers.get('content-type')?.toLocaleLowerCase() ?? ''
+    if (contentType.includes('text/html') || contentType.includes('application/xhtml+xml')) {
+      await discardAttachmentResponse(response)
+      throw new Error('Slack attachment download returned an HTML login response')
+    }
+    return { buffer: await readAttachmentResponse(response, options.maxBytes), url }
+  }
+}
+
+function parseTrustedSlackUrl(raw: string): URL {
+  const url = new URL(raw)
+  if (
+    url.protocol !== 'https:' ||
+    !SLACK_DOWNLOAD_HOSTS.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`))
+  ) {
+    throw new Error(`refusing untrusted Slack attachment URL host: ${url.hostname}`)
+  }
+  return url
+}

--- a/src/channels/adapters/slack-bot-fetch-attachment.test.ts
+++ b/src/channels/adapters/slack-bot-fetch-attachment.test.ts
@@ -19,20 +19,10 @@ describe('slack-bot createFetchAttachmentCallback', () => {
     const logger = silentLogger()
     const cb = createFetchAttachmentCallback({
       client: {
-        downloadFile: async (fileId) => ({
-          buffer: Buffer.from(`bytes-for-${fileId}`),
-          file: {
-            id: fileId,
-            name: 'diagram.png',
-            title: 'diagram',
-            mimetype: 'image/png',
-            size: 17,
-            url_private: 'https://files.slack.com/.../diagram.png',
-            created: 1700000000,
-            user: 'UALICE',
-          },
-        }),
+        getFileInfo: async (fileId) => slackFile(fileId, 17),
       },
+      token: 'xoxb-secret',
+      fetchImpl: async () => new Response('bytes-for-F12345', { headers: { 'content-type': 'image/png' } }),
       logger,
     })
 
@@ -43,7 +33,7 @@ describe('slack-bot createFetchAttachmentCallback', () => {
       buffer: Buffer.from('bytes-for-F12345'),
       filename: 'diagram.png',
       mimetype: 'image/png',
-      size: 17,
+      size: 16,
     })
     expect(logger.errors).toEqual([])
   })
@@ -51,20 +41,10 @@ describe('slack-bot createFetchAttachmentCallback', () => {
   test('respects an explicit filename override (lets the agent rename inflight)', async () => {
     const cb = createFetchAttachmentCallback({
       client: {
-        downloadFile: async () => ({
-          buffer: Buffer.from('x'),
-          file: {
-            id: 'F1',
-            name: 'upstream.png',
-            title: 'u',
-            mimetype: 'image/png',
-            size: 1,
-            url_private: 'https://files.slack.com/.../upstream.png',
-            created: 1700000000,
-            user: 'UALICE',
-          },
-        }),
+        getFileInfo: async () => slackFile('F1', 1, 'upstream.png'),
       },
+      token: 'xoxb-secret',
+      fetchImpl: async () => new Response('x', { headers: { 'content-type': 'image/png' } }),
       logger: silentLogger(),
     })
 
@@ -79,10 +59,12 @@ describe('slack-bot createFetchAttachmentCallback', () => {
     let downloadCalled = false
     const cb = createFetchAttachmentCallback({
       client: {
-        downloadFile: async () => {
-          downloadCalled = true
-          throw new Error('should not be called')
-        },
+        getFileInfo: async () => slackFile('F1', 1),
+      },
+      token: 'xoxb-secret',
+      fetchImpl: async () => {
+        downloadCalled = true
+        throw new Error('should not be called')
       },
       logger: silentLogger(),
     })
@@ -99,10 +81,11 @@ describe('slack-bot createFetchAttachmentCallback', () => {
     const logger = silentLogger()
     const cb = createFetchAttachmentCallback({
       client: {
-        downloadFile: async () => {
+        getFileInfo: async () => {
           throw new Error('files.info: file_not_found')
         },
       },
+      token: 'xoxb-secret',
       logger,
     })
 
@@ -111,4 +94,82 @@ describe('slack-bot createFetchAttachmentCallback', () => {
     expect(result).toEqual({ ok: false, error: 'files.info: file_not_found' })
     expect(logger.errors[0]).toContain('downloadFile failed for F404')
   })
+
+  test('cancels an over-limit stream and returns a structured size error', async () => {
+    let cancelled = false
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(8))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+    const cb = createFetchAttachmentCallback({
+      client: { getFileInfo: async () => slackFile('F1', 4) },
+      token: 'xoxb-secret',
+      fetchImpl: async () => new Response(body),
+      logger: silentLogger(),
+    })
+
+    const result = await cb({ ref: 'F1', maxBytes: 4 })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('attachment is too large')
+    expect(cancelled).toBe(true)
+  })
+
+  test('retains bearer auth across trusted Slack redirects', async () => {
+    const seen: Array<{ url: string; auth: string | null }> = []
+    const cb = createFetchAttachmentCallback({
+      client: { getFileInfo: async () => slackFile('F1', 2) },
+      token: 'xoxb-secret',
+      fetchImpl: async (input, init) => {
+        const url = String(input)
+        seen.push({ url, auth: new Headers(init?.headers).get('authorization') })
+        return seen.length === 1
+          ? new Response(null, { status: 302, headers: { location: 'https://cdn.slack-edge.com/file' } })
+          : new Response('ok', { headers: { 'content-type': 'application/octet-stream' } })
+      },
+      logger: silentLogger(),
+    })
+
+    expect((await cb({ ref: 'F1' })).ok).toBe(true)
+    expect(seen).toEqual([
+      { url: 'https://files.slack.com/files/diagram.png', auth: 'Bearer xoxb-secret' },
+      { url: 'https://cdn.slack-edge.com/file', auth: 'Bearer xoxb-secret' },
+    ])
+  })
+
+  test('refuses an untrusted redirect without sending credentials to it', async () => {
+    const seen: string[] = []
+    const cb = createFetchAttachmentCallback({
+      client: { getFileInfo: async () => slackFile('F1', 2) },
+      token: 'xoxb-secret',
+      fetchImpl: async (input) => {
+        seen.push(String(input))
+        return new Response(null, { status: 302, headers: { location: 'https://evil.example/file' } })
+      },
+      logger: silentLogger(),
+    })
+
+    const result = await cb({ ref: 'F1' })
+
+    expect(result.ok).toBe(false)
+    expect(seen).toEqual(['https://files.slack.com/files/diagram.png'])
+  })
 })
+
+function slackFile(id: string, size: number, name = 'diagram.png') {
+  return {
+    id,
+    name,
+    title: 'file',
+    mimetype: 'image/png',
+    size,
+    url_private: `https://files.slack.com/files/${name}`,
+    created: 1700000000,
+    user: 'U123',
+  }
+}

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -5,6 +5,7 @@ import {
   type SlackSocketModeSlashCommandArgs,
 } from 'agent-messenger/slackbot'
 
+import { DEFAULT_ATTACHMENT_MAX_BYTES, enforceAttachmentMetadataSize } from '@/channels/fetch-attachment'
 import {
   MEMBERSHIP_CACHE_TRANSIENT_TTL_MS,
   MEMBERSHIP_CACHE_TTL_MS,
@@ -41,6 +42,7 @@ import { chunkMarkdown } from '@/markdown'
 
 import { describeError } from './describe-error'
 import { addSlackMentionHints } from './mention-hints'
+import { downloadSlackAttachment, type SlackAttachmentFetch } from './slack-attachment-download'
 import { createSlackAuthorResolver, type SlackAuthorResolver } from './slack-bot-author-resolver'
 import { createSlackChannelResolver } from './slack-bot-channel-resolver'
 import {
@@ -1049,24 +1051,33 @@ export function createOutboundCallback(deps: {
 // (legacy persisted state may still carry the old prompt-visible `id=` shape,
 // which channel_fetch_attachment strips before reaching this callback).
 export function createFetchAttachmentCallback(deps: {
-  client: Pick<SlackBotClient, 'downloadFile'>
+  client: Pick<SlackBotClient, 'getFileInfo'>
+  token: string
+  fetchImpl?: SlackAttachmentFetch
   logger: SlackBotAdapterLogger
 }): FetchAttachmentCallback {
   const { client, logger } = deps
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     const fileId = ref.trim()
     if (!/^F[A-Z0-9]+$/.test(fileId)) {
       return { ok: false, error: `invalid Slack file id: ${ref}` }
     }
     try {
-      const { buffer, file } = await client.downloadFile(fileId)
-      logger.info(`[slack-bot] downloaded id=${file.id} name=${file.name} size=${file.size}`)
+      const metadata = await client.getFileInfo(fileId)
+      enforceAttachmentMetadataSize(metadata.size, maxBytes)
+      const { buffer } = await downloadSlackAttachment({
+        metadata,
+        token: deps.token,
+        maxBytes,
+        fetchImpl: deps.fetchImpl,
+      })
+      logger.info(`[slack-bot] downloaded id=${fileId} name=${metadata.name} size=${buffer.length}`)
       return {
         ok: true,
         buffer,
-        filename: filename ?? file.name,
-        mimetype: file.mimetype,
-        size: file.size,
+        filename: filename ?? metadata.name,
+        mimetype: metadata.mimetype,
+        size: buffer.length,
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -1184,7 +1195,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
     typingTracker,
   })
 
-  const fetchAttachmentCallback = createFetchAttachmentCallback({ client, logger })
+  const fetchAttachmentCallback = createFetchAttachmentCallback({ client, logger, token: options.token })
 
   const reactionCallback = createSlackReactionCallback({ client })
   const removeReactionCallback = createSlackRemoveReactionCallback({ client })

--- a/src/channels/adapters/slack-fetch-attachment.test.ts
+++ b/src/channels/adapters/slack-fetch-attachment.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createSlackFetchAttachmentCallback, type SlackAdapterLogger } from './slack'
+
+const logger: SlackAdapterLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+function metadata(size: number) {
+  return {
+    id: 'F1',
+    name: 'report.bin',
+    title: 'report',
+    mimetype: 'application/octet-stream',
+    size,
+    url_private: 'https://files.slack.com/files/report.bin',
+    created: 1,
+    user: 'U1',
+  }
+}
+
+describe('slack user attachment downloads', () => {
+  test('cancels an over-limit response body', async () => {
+    let cancelled = false
+    const callback = createSlackFetchAttachmentCallback({
+      client: { getFileInfo: async () => metadata(4) },
+      tokenRef: () => 'xoxc-secret',
+      logger,
+      fetchImpl: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array(8))
+            },
+            cancel() {
+              cancelled = true
+            },
+          }),
+        ),
+    })
+
+    const result = await callback({ ref: 'F1', maxBytes: 4 })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('attachment is too large')
+    expect(cancelled).toBe(true)
+  })
+
+  test('retains user bearer and session-cookie auth across trusted redirects', async () => {
+    const seen: Array<{ url: string; auth: string | null; cookie: string | null }> = []
+    const callback = createSlackFetchAttachmentCallback({
+      client: { getFileInfo: async () => metadata(2) },
+      tokenRef: () => 'xoxc-secret',
+      cookieRef: () => 'session-cookie',
+      logger,
+      fetchImpl: async (input, init) => {
+        const headers = new Headers(init?.headers)
+        seen.push({
+          url: String(input),
+          auth: headers.get('authorization'),
+          cookie: headers.get('cookie'),
+        })
+        return seen.length === 1
+          ? new Response(null, { status: 302, headers: { location: 'https://cdn.slack-files.com/report.bin' } })
+          : new Response('ok')
+      },
+    })
+
+    expect((await callback({ ref: 'F1' })).ok).toBe(true)
+    expect(seen.map((entry) => entry.auth)).toEqual(['Bearer xoxc-secret', 'Bearer xoxc-secret'])
+    expect(seen.map((entry) => entry.cookie)).toEqual(['d=session-cookie', 'd=session-cookie'])
+  })
+
+  test('keeps bearer-only downloads cookie-free', async () => {
+    let cookie: string | null = 'unobserved'
+    const callback = createSlackFetchAttachmentCallback({
+      client: { getFileInfo: async () => metadata(2) },
+      tokenRef: () => 'xoxb-secret',
+      logger,
+      fetchImpl: async (_input, init) => {
+        cookie = new Headers(init?.headers).get('cookie')
+        return new Response('ok')
+      },
+    })
+
+    expect((await callback({ ref: 'F1' })).ok).toBe(true)
+    expect(cookie).toBeNull()
+  })
+
+  test('refuses untrusted redirects before any credential-bearing follow-up', async () => {
+    const seen: string[] = []
+    const callback = createSlackFetchAttachmentCallback({
+      client: { getFileInfo: async () => metadata(2) },
+      tokenRef: () => 'xoxc-secret',
+      logger,
+      fetchImpl: async (input) => {
+        seen.push(String(input))
+        return new Response(null, { status: 302, headers: { location: 'https://evil.example/report.bin' } })
+      },
+    })
+
+    expect((await callback({ ref: 'F1' })).ok).toBe(false)
+    expect(seen).toEqual(['https://files.slack.com/files/report.bin'])
+  })
+})

--- a/src/channels/adapters/slack.ts
+++ b/src/channels/adapters/slack.ts
@@ -8,6 +8,7 @@ import {
   type SlackRTMReactionEvent,
 } from 'agent-messenger/slack'
 
+import { DEFAULT_ATTACHMENT_MAX_BYTES, enforceAttachmentMetadataSize } from '@/channels/fetch-attachment'
 import {
   MEMBERSHIP_ENUMERATION_CAP,
   type MembershipResolver,
@@ -33,6 +34,7 @@ import { chunkMarkdown } from '@/markdown'
 import type { SlackAccountRecord } from '@/secrets/schema'
 
 import { describeError } from './describe-error'
+import { downloadSlackAttachment, type SlackAttachmentFetch } from './slack-attachment-download'
 import { createSlackAuthorResolver } from './slack-author-resolver'
 import { slackTsToMillis } from './slack-bot-time'
 import { createSlackChannelResolver } from './slack-channel-resolver'
@@ -166,17 +168,31 @@ export function createSlackMembershipResolver(deps: {
 }
 
 export function createSlackFetchAttachmentCallback(deps: {
-  client: Pick<SlackClient, 'downloadFile'>
+  client: Pick<SlackClient, 'getFileInfo'>
+  tokenRef: () => string | null
+  cookieRef?: () => string | null
+  fetchImpl?: SlackAttachmentFetch
   logger: SlackAdapterLogger
 }): FetchAttachmentCallback {
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     try {
-      const { buffer, file } = await deps.client.downloadFile(ref)
+      const metadata = await deps.client.getFileInfo(ref)
+      enforceAttachmentMetadataSize(metadata.size, maxBytes)
+      const token = deps.tokenRef()
+      if (token === null) throw new Error('Slack attachment credential is unavailable')
+      const cookie = deps.cookieRef?.() ?? undefined
+      const { buffer } = await downloadSlackAttachment({
+        metadata,
+        token,
+        ...(cookie === undefined ? {} : { cookie }),
+        maxBytes,
+        fetchImpl: deps.fetchImpl,
+      })
       return {
         ok: true,
         buffer,
-        filename: filename ?? file.name ?? 'attachment',
-        mimetype: file.mimetype,
+        filename: filename ?? metadata.name ?? 'attachment',
+        mimetype: metadata.mimetype,
         size: buffer.length,
       }
     } catch (err) {
@@ -197,6 +213,8 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
   let selfName: string | null = null
   let teamId = ''
   let teamName: string | null = null
+  let accountToken: string | null = null
+  let accountCookie: string | null = null
   let connected = false
   let started = false
   let inflightInbounds = 0
@@ -222,7 +240,12 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
     selfUserIdRef: () => selfUserId,
   })
   const outboundCallback = createSlackOutboundCallback({ client, logger, formatChannelTag })
-  const fetchAttachmentCallback = createSlackFetchAttachmentCallback({ client, logger })
+  const fetchAttachmentCallback = createSlackFetchAttachmentCallback({
+    client,
+    logger,
+    tokenRef: () => accountToken,
+    cookieRef: () => accountCookie,
+  })
   const reactionCallback = createSlackReactionCallback({ client })
   const removeReactionCallback = createSlackRemoveReactionCallback({ client })
   const editMessageCallback = createSlackUserEditMessageCallback({ client })
@@ -294,6 +317,8 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
           throw new Error('no Slack account in secrets.json#channels.slack (run typeclaw init to authenticate)')
         }
         await client.login({ token: account.token, cookie: account.cookie })
+        accountToken = account.token
+        accountCookie = account.cookie
         const auth = await client.testAuth()
         selfUserId = auth.user_id
         selfName = auth.user ?? auth.user_id
@@ -303,6 +328,8 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
       } catch (err) {
         started = false
         selfUserId = null
+        accountToken = null
+        accountCookie = null
         teamId = ''
         logger.error(`[slack] login failed: ${describeError(err)}`)
         throw err
@@ -381,6 +408,7 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
         listener?.stop()
         listener = null
         selfUserId = null
+        accountToken = null
         connected = false
         started = false
         logger.error(`[slack] ${reason}: ${describeError(cause)}`)
@@ -399,6 +427,7 @@ export function createSlackAdapter(options: SlackAdapterOptions): SlackAdapter {
     async stop(): Promise<void> {
       if (!started) return
       started = false
+      accountToken = null
       options.router.unregisterOutbound('slack', outboundCallback)
       options.router.setTypingCapability('slack', false)
       options.router.unregisterChannelNameResolver('slack', channelResolver)

--- a/src/channels/adapters/telegram-bot-fetch-attachment.test.ts
+++ b/src/channels/adapters/telegram-bot-fetch-attachment.test.ts
@@ -177,4 +177,34 @@ describe('telegram-bot createFetchAttachmentCallback', () => {
     if (!result.ok) throw new Error('expected ok')
     expect(result.filename).toBe('renamed.jpg')
   })
+
+  test('resolves over-limit reads as structured errors and cancels the body', async () => {
+    let cancelled = false
+    const cb = createFetchAttachmentCallback({
+      token: 'T',
+      logger: silentLogger(),
+      fetchImpl: fakeFetch((url) => {
+        if (url.includes('/getFile')) {
+          return new Response(JSON.stringify({ ok: true, result: { file_path: 'documents/large.bin' } }))
+        }
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array(8))
+            },
+            cancel() {
+              cancelled = true
+            },
+          }),
+        )
+      }),
+    })
+
+    const result = await cb({ ref: 'AgAD', maxBytes: 4 })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected error')
+    expect(result.error).toContain('attachment is too large')
+    expect(cancelled).toBe(true)
+  })
 })

--- a/src/channels/adapters/telegram-bot.ts
+++ b/src/channels/adapters/telegram-bot.ts
@@ -1,6 +1,12 @@
 import { TelegramBotClient, TelegramBotListener } from 'agent-messenger/telegrambot'
 import type { TelegramBotUser, TelegramMessage } from 'agent-messenger/telegrambot'
 
+import { readResponseBodyBounded } from '@/agent/network/response-body'
+import {
+  DEFAULT_ATTACHMENT_MAX_BYTES,
+  readAttachmentErrorSnippet,
+  readAttachmentResponse,
+} from '@/channels/fetch-attachment'
 import type { MembershipResolver, MembershipResolverFailure, MembershipResolverResult } from '@/channels/membership'
 import type { ChannelRouter } from '@/channels/router'
 import type { ChannelAdapterConfig } from '@/channels/schema'
@@ -313,7 +319,7 @@ export function createFetchAttachmentCallback(deps: {
 }): FetchAttachmentCallback {
   const { token, logger } = deps
   const fetchImpl = deps.fetchImpl ?? fetch
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     if (ref === '' || ref.includes('://')) {
       return { ok: false, error: `invalid Telegram file_id: ${ref}` }
     }
@@ -333,7 +339,8 @@ export function createFetchAttachmentCallback(deps: {
     }
     let meta: TelegramFileResponse
     try {
-      meta = (await metaResponse.json()) as TelegramFileResponse
+      const bytes = await readResponseBodyBounded(metaResponse, 64 * 1024)
+      meta = JSON.parse(bytes.toString('utf8')) as TelegramFileResponse
     } catch (err) {
       return { ok: false, error: `getFile parse failed: ${describeError(err)}` }
     }
@@ -352,13 +359,19 @@ export function createFetchAttachmentCallback(deps: {
       return { ok: false, error: message }
     }
     if (!response.ok) {
-      const body = await response.text().catch(() => '')
+      const body = await readAttachmentErrorSnippet(response)
       const message = `download ${response.status} ${response.statusText}${body !== '' ? `: ${body.slice(0, 200)}` : ''}`
       logger.error(`[telegram-bot] download failed for ${ref}: ${message}`)
       return { ok: false, error: message }
     }
-    const arrayBuffer = await response.arrayBuffer()
-    const buffer = Buffer.from(arrayBuffer)
+    let buffer: Buffer
+    try {
+      buffer = await readAttachmentResponse(response, maxBytes)
+    } catch (err) {
+      const message = describeError(err)
+      logger.error(`[telegram-bot] download failed for ${ref}: ${message}`)
+      return { ok: false, error: message }
+    }
     const inferredFilename = filename ?? filePath.split('/').pop() ?? 'attachment'
     const contentType = response.headers.get('content-type') ?? undefined
     logger.info(

--- a/src/channels/adapters/webex-bot.ts
+++ b/src/channels/adapters/webex-bot.ts
@@ -8,6 +8,11 @@ import type {
 } from 'agent-messenger/webexbot'
 
 import {
+  DEFAULT_ATTACHMENT_MAX_BYTES,
+  readAttachmentErrorSnippet,
+  readAttachmentResponse,
+} from '@/channels/fetch-attachment'
+import {
   MEMBERSHIP_ENUMERATION_CAP,
   type MembershipResolver,
   type MembershipResolverFailure,
@@ -236,7 +241,7 @@ export function createFetchAttachmentCallback(deps: {
   fetchImpl?: typeof fetch
 }): FetchAttachmentCallback {
   const fetchImpl = deps.fetchImpl ?? fetch
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     let url: URL
     try {
       url = new URL(ref)
@@ -255,12 +260,12 @@ export function createFetchAttachmentCallback(deps: {
     try {
       const res = await fetchImpl(url.toString(), { headers: { Authorization: `Bearer ${deps.token}` } })
       if (!res.ok) {
-        const body = await res.text().catch(() => '')
+        const body = await readAttachmentErrorSnippet(res)
         const message = `webex file fetch ${res.status} ${res.statusText}${body ? `: ${body.slice(0, 200)}` : ''}`
         deps.logger.error(`[webex-bot] fetchAttachment failed for ${url.toString()}: ${message}`)
         return { ok: false, error: message }
       }
-      const buffer = Buffer.from(await res.arrayBuffer())
+      const buffer = await readAttachmentResponse(res, maxBytes)
       const inferredFilename = filename ?? url.pathname.split('/').pop() ?? 'attachment'
       const contentType = res.headers.get('content-type') ?? undefined
       return {

--- a/src/channels/adapters/webex.ts
+++ b/src/channels/adapters/webex.ts
@@ -10,6 +10,11 @@ import type {
 } from 'agent-messenger/webex'
 
 import {
+  DEFAULT_ATTACHMENT_MAX_BYTES,
+  readAttachmentErrorSnippet,
+  readAttachmentResponse,
+} from '@/channels/fetch-attachment'
+import {
   MEMBERSHIP_ENUMERATION_CAP,
   type MembershipResolver,
   type MembershipResolverFailure,
@@ -285,7 +290,7 @@ export function createFetchAttachmentCallback(deps: {
   fetchImpl?: typeof fetch
 }): FetchAttachmentCallback {
   const fetchImpl = deps.fetchImpl ?? fetch
-  return async ({ ref, filename }) => {
+  return async ({ ref, filename, maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES }) => {
     const token = deps.tokenRef()
     if (token === null) return { ok: false, error: 'webex account token is not available' }
     let url: URL
@@ -306,12 +311,12 @@ export function createFetchAttachmentCallback(deps: {
     try {
       const res = await fetchImpl(url.toString(), { headers: { Authorization: `Bearer ${token}` } })
       if (!res.ok) {
-        const body = await res.text().catch(() => '')
+        const body = await readAttachmentErrorSnippet(res)
         const message = `webex file fetch ${res.status} ${res.statusText}${body ? `: ${body.slice(0, 200)}` : ''}`
         deps.logger.error(`[webex] fetchAttachment failed for ${url.toString()}: ${message}`)
         return { ok: false, error: message }
       }
-      const buffer = Buffer.from(await res.arrayBuffer())
+      const buffer = await readAttachmentResponse(res, maxBytes)
       const inferredFilename = filename ?? url.pathname.split('/').pop() ?? 'attachment'
       const contentType = res.headers.get('content-type') ?? undefined
       return {

--- a/src/channels/fetch-attachment.test.ts
+++ b/src/channels/fetch-attachment.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { readAttachmentResponse } from './fetch-attachment'
+
+describe('bounded attachment response reader', () => {
+  test('fails before reading a declared oversized body and cancels it', async () => {
+    let pulled = false
+    let cancelled = false
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulled = true
+        controller.enqueue(new Uint8Array([1]))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+    const response = new Response(body, { headers: { 'content-length': '11' } })
+    await expect(readAttachmentResponse(response, 10)).rejects.toThrow(/too large/)
+    expect(pulled).toBeFalse()
+    expect(cancelled).toBeTrue()
+  })
+
+  test('stops and cancels a streaming body as soon as the cap is crossed', async () => {
+    let cancelled = false
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(6))
+        controller.enqueue(new Uint8Array(6))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+    await expect(readAttachmentResponse(new Response(body), 10)).rejects.toThrow(/too large/)
+    expect(cancelled).toBeTrue()
+  })
+})
+
+describe('FetchAttachmentCallback adapter contract guard', () => {
+  test('every registered download-capable adapter wires the shared byte limit into bounded handling', async () => {
+    const implementations = [
+      ['discord.ts', 'readAttachmentResponse'],
+      ['discord-bot.ts', 'readAttachmentResponse'],
+      ['telegram-bot.ts', 'readAttachmentResponse'],
+      ['webex.ts', 'readAttachmentResponse'],
+      ['webex-bot.ts', 'readAttachmentResponse'],
+      ['kakaotalk-fetch-attachment.ts', 'readAttachmentResponse'],
+      ['slack.ts', 'enforceAttachmentMetadataSize'],
+      ['slack-bot.ts', 'enforceAttachmentMetadataSize'],
+    ] as const
+    for (const [filename, enforcement] of implementations) {
+      const source = await readFile(path.join(import.meta.dir, 'adapters', filename), 'utf8')
+      expect(source).toContain('maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES')
+      expect(source).toContain(enforcement)
+    }
+  })
+})

--- a/src/channels/fetch-attachment.ts
+++ b/src/channels/fetch-attachment.ts
@@ -1,0 +1,43 @@
+import { readResponseBodyBounded } from '@/agent/network/response-body'
+
+export const DEFAULT_ATTACHMENT_MAX_BYTES = 100 * 1024 * 1024
+
+export async function readAttachmentResponse(response: Response, maxBytes: number): Promise<Buffer> {
+  try {
+    return await readResponseBodyBounded(response, maxBytes)
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('response is too large')) {
+      throw new Error(error.message.replace('response is too large', 'attachment is too large'))
+    }
+    throw error
+  }
+}
+
+export async function discardAttachmentResponse(response: Response): Promise<void> {
+  await response.body?.cancel().catch(() => undefined)
+}
+
+export async function readAttachmentErrorSnippet(response: Response): Promise<string> {
+  try {
+    const buffer = await readAttachmentResponse(response, 1024)
+    return buffer.toString('utf8').slice(0, 200)
+  } catch {
+    await discardAttachmentResponse(response)
+    return ''
+  }
+}
+
+export function enforceAttachmentMetadataSize(size: number | undefined, maxBytes: number): void {
+  if (size === undefined || !Number.isSafeInteger(size) || size < 0) {
+    throw new Error('attachment size is unknown; refusing an unbounded SDK download')
+  }
+  if (size > maxBytes) throw attachmentTooLarge(size, maxBytes)
+}
+
+export function enforceAttachmentBufferSize(buffer: Buffer, maxBytes: number): void {
+  if (buffer.byteLength > maxBytes) throw attachmentTooLarge(buffer.byteLength, maxBytes)
+}
+
+function attachmentTooLarge(size: number, maxBytes: number): Error {
+  return new Error(`attachment is too large (${size} bytes > ${maxBytes} byte limit)`)
+}


### PR DESCRIPTION
## Background

Extracted from #1201 to make the work reviewable. Slice 6/11.

## Summary

Extends attachment contracts and applies bounded streaming across Discord, KakaoTalk, Slack, Telegram, and Webex.

## Review notes

Adapter changes follow one shared bounded-download contract.