### PR TITLE
feat(sandbox): harden masks and privileged runtime

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -11,7 +11,13 @@ import { z } from 'zod'
 import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
 import { createPermissionService } from '@/permissions/permissions'
 import { createHookBus, defineTool, type PluginRegistry, type ToolResult } from '@/plugin'
-import { _resetBwrapAvailabilityCacheForTests, _resetRealProcProbeCacheForTests, SESSION_TMP_ROOT } from '@/sandbox'
+import {
+  _resetBwrapAvailabilityCacheForTests,
+  _resetRealProcProbeCacheForTests,
+  buildSandboxedCommand,
+  SESSION_TMP_ROOT,
+  resolvePrivilegedSandboxRuntime,
+} from '@/sandbox'
 
 import {
   __resetSharedLoopGuardForTests,
@@ -994,6 +1000,7 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
   }
 
   const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
+  const member: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'member' }
   const guest: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'guest' }
 
   test('trusted+ (tui→owner) still requires bwrap for canonical masks', async () => {
@@ -1051,6 +1058,161 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     expect(record.command).toBeUndefined()
   })
 
+  test('prepares, verifies, executes, and cleans the generated privileged runtime at the tool boundary', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-privileged-boundary-'))
+    const homeDir = path.join(agentDir, 'home')
+    let generatedSource: string | undefined
+    try {
+      await mkdir(path.join(agentDir, '.git'), { recursive: true })
+      await mkdir(homeDir)
+      await writeFile(path.join(homeDir, '.gitconfig'), '[user]\nname = Alice\nemail = user@example.com\n')
+      const record: { command?: string } = {}
+      const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
+        agentDir,
+        sessionId: 'privileged-boundary',
+        hooks: createHookBus(),
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+        bashSandboxBoundary: {
+          ensureAvailable: async () => {},
+          resolveRuntime: (options) => resolvePrivilegedSandboxRuntime({ ...options, homeDir }),
+          buildCommand(command, options) {
+            if (options === undefined) throw new Error('sandbox options were not provided')
+            for (const mount of options.mounts ?? []) {
+              if (mount.type === 'ro-bind' && mount.dest === '/tmp/.gitconfig') generatedSource = mount.source
+            }
+            expect(options.env?.set).toMatchObject({
+              GIT_CONFIG_GLOBAL: '/tmp/.gitconfig',
+              GIT_CONFIG_NOSYSTEM: '1',
+            })
+            return buildSandboxedCommand(command, options)
+          },
+        },
+      })
+
+      await wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)
+
+      expect(record.command).toContain('--bind')
+      if (generatedSource === undefined) throw new Error('generated profile did not reach sandbox command')
+      expect(await Bun.file(generatedSource).exists()).toBe(false)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('confined authenticated Git cannot load global or system config', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-git-config-isolation-'))
+    let sandboxEnv: Record<string, string> | undefined
+    try {
+      await mkdir(path.join(agentDir, '.git'), { recursive: true })
+      const wrapped = wrapBuiltinToolDefinition(fakeBash({}), {
+        agentDir,
+        sessionId: 'git-config-isolation',
+        hooks: createHookBus(),
+        getOrigin: () => member,
+        permissions: createPermissionService(),
+        bashSandboxBoundary: {
+          ensureAvailable: async () => {},
+          buildCommand(command, options) {
+            if (options === undefined) throw new Error('sandbox options were not provided')
+            sandboxEnv = options.env?.set
+            return buildSandboxedCommand(command, options)
+          },
+        },
+      })
+
+      await wrapped.execute('c', { command: 'git push origin HEAD' }, undefined, undefined, {} as never)
+
+      expect(sandboxEnv).toMatchObject({ GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_NOSYSTEM: '1' })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cleanup failure invokes tool.after once after cleanup and propagates the cleanup error', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-cleanup-boundary-'))
+    const order: string[] = []
+    const afterResults: ToolResult[] = []
+    const hooks = createHookBus()
+    hooks.registerAll('observer', agentDir, noopLogger, {
+      'tool.after': (event) => {
+        order.push('after')
+        afterResults.push(event.result)
+      },
+    })
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      order.push('execute')
+      return { content: [{ type: 'text' as const, text: 'ran' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'cleanup-boundary',
+      hooks,
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+        resolveRuntime: async () => ({ env: {}, mounts: [] }),
+        cleanupRuntime: async () => {
+          order.push('cleanup')
+          throw new Error('cleanup failed')
+        },
+      },
+    })
+
+    await expect(wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)).rejects.toThrow(
+      'cleanup failed',
+    )
+    expect(order).toEqual(['execute', 'cleanup', 'after'])
+    expect(afterResults).toHaveLength(1)
+    expect(afterResults[0]?.details).toEqual({ error: 'cleanup failed' })
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('execution error wins over cleanup error and reaches tool.after exactly once after cleanup', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-error-precedence-'))
+    const order: string[] = []
+    const afterResults: ToolResult[] = []
+    const hooks = createHookBus()
+    hooks.registerAll('observer', agentDir, noopLogger, {
+      'tool.after': (event) => {
+        order.push('after')
+        afterResults.push(event.result)
+      },
+    })
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      order.push('execute')
+      throw new Error('execution failed')
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'error-precedence',
+      hooks,
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+        resolveRuntime: async () => ({ env: {}, mounts: [] }),
+        cleanupRuntime: async () => {
+          order.push('cleanup')
+          throw new Error('cleanup failed')
+        },
+      },
+    })
+
+    await expect(wrapped.execute('c', { command: 'git status' }, undefined, undefined, {} as never)).rejects.toThrow(
+      'execution failed',
+    )
+    expect(order).toEqual(['execute', 'cleanup', 'after'])
+    expect(afterResults).toHaveLength(1)
+    expect(afterResults[0]?.details).toEqual({ error: 'execution failed' })
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
   test('without a permission service bash is never rewritten (escape hatch for unwired sessions)', async () => {
     const record: { command?: string } = {}
     const wrapped = wrapBuiltinToolDefinition(fakeBash(record), {
@@ -1082,6 +1244,65 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     await expect(wrapped.execute('c', args as never, undefined, undefined, {} as never)).rejects.toThrow()
     expect(record.command).toBeUndefined()
     expect(args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+  })
+
+  test('a secret env overlay reaches the sandbox child without entering generated bwrap text', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-secret-env-boundary-'))
+    const ghToken = 'boundary-gh-token-value'
+    const gitToken = 'boundary-git-token-value'
+    let generated: ReturnType<typeof buildSandboxedCommand> | undefined
+    try {
+      const hooks = createHookBus()
+      hooks.registerAll('env-setter', agentDir, noopLogger, {
+        'tool.before': (event) => {
+          ;(event.args as Record<string, unknown>)[TYPECLAW_INTERNAL_BASH_ENV] = {
+            GH_TOKEN: ghToken,
+            TYPECLAW_GIT_TOKEN: gitToken,
+            GH_REPO: 'acme/widgets',
+          }
+        },
+      })
+      const bash = defaultBuiltinPiToolDefinitions(agentDir).find((tool) => tool.name === 'bash')
+      if (bash === undefined) throw new Error('bash tool definition not found')
+      const wrapped = wrapBuiltinToolDefinition(bash, {
+        agentDir,
+        sessionId: 'secret-env-boundary',
+        hooks,
+        getOrigin: () => tui,
+        permissions: createPermissionService(),
+        bashSandboxBoundary: {
+          ensureAvailable: async () => {},
+          resolveRuntime: async () => ({ env: {}, mounts: [] }),
+          buildCommand(command, options) {
+            if (options === undefined) throw new Error('sandbox options were not provided')
+            expect(options.env?.inherit).toEqual(['GH_TOKEN', 'TYPECLAW_GIT_TOKEN'])
+            expect(options.env?.set).toMatchObject({ GH_REPO: 'acme/widgets' })
+            expect(options.env?.set?.GH_TOKEN).toBeUndefined()
+            expect(options.env?.set?.TYPECLAW_GIT_TOKEN).toBeUndefined()
+            generated = buildSandboxedCommand(command, options)
+            return { ...generated, commandString: command }
+          },
+        },
+      })
+
+      const result = await wrapped.execute(
+        'c',
+        { command: `printf '%s\n%s' "$GH_TOKEN" "$TYPECLAW_GIT_TOKEN"` },
+        undefined,
+        undefined,
+        {} as never,
+      )
+
+      expect(textOfFirstContent(result)).toContain(ghToken)
+      expect(textOfFirstContent(result)).toContain(gitToken)
+      expect(generated).toBeDefined()
+      expect(generated?.argv.join('\n')).not.toContain(ghToken)
+      expect(generated?.argv.join('\n')).not.toContain(gitToken)
+      expect(generated?.commandString).not.toContain(ghToken)
+      expect(generated?.commandString).not.toContain(gitToken)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
   })
 
   test('a client-supplied env overlay is stripped before hooks run (only trusted hooks may set it)', async () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -37,6 +37,7 @@ import type {
 import {
   buildSandboxedCommand,
   canWriteAgentRootInSandbox,
+  cleanupPrivilegedSandboxRuntime,
   canMountRealProc,
   commandNeedsRealProc,
   DEFAULT_SANDBOX_ENV,
@@ -44,10 +45,10 @@ import {
   ensureHiddenMaskTargets,
   ensureSessionTmpDir,
   getProcBindSafetyVerdict,
-  isPackageInstallCommand,
   mapVirtualTmpPath,
+  type PrivilegedSandboxRuntime,
   resolveHiddenPaths,
-  resolvePackageInstallZones,
+  resolvePrivilegedSandboxRuntime,
   resolveProcBindSafetyWithRetry,
   resolveProcSelfExe,
   resolveProtectedZones,
@@ -56,6 +57,8 @@ import {
   SandboxDegradedProcError,
   SandboxProcProbeUnverifiedError,
   subtractMasked,
+  verifyHiddenMaskTargets,
+  verifyPrivilegedSandboxRuntime,
 } from '@/sandbox'
 
 import { createLoopGuard, type LoopGuard, type LoopGuardDecision } from './loop-guard'
@@ -77,13 +80,17 @@ let sharedLoopGuard: LoopGuard = createLoopGuard()
 // a bash call's args to inject env vars into the spawned process WITHOUT
 // putting them in the command string (where they would leak through logs and
 // later hooks). The wrapper extracts and deletes it before the bash tool runs,
-// then threads it to the spawn (non-sandboxed) and to bwrap --setenv
-// (sandboxed). Used by github-cli-auth to inject a per-repo GH_TOKEN. The key
+// then threads it to the spawn. Sandboxed secret values stay in bwrap's parent
+// environment and are inherited by name rather than rendered into argv. Used
+// by github-cli-auth to inject a per-repo GH_TOKEN. The key
 // is stripped from client-supplied args before tool.before so only trusted
 // hooks can set it.
 export const TYPECLAW_INTERNAL_BASH_ENV = '__typeclawBashEnv'
 
 type BashEnvOverlay = Record<string, string>
+
+const SECRET_ENV_NAME_PATTERN =
+  /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASSWD|PWD|API_KEY|ACCESS_KEY(?:_ID)?|SECRET_KEY|PRIVATE_KEY|AUTH)$/
 
 const bashEnvStore = new AsyncLocalStorage<BashEnvOverlay | undefined>()
 
@@ -204,6 +211,19 @@ export type WrapToolOptions = {
   getLoopGuardTurn?: () => number | undefined
 }
 
+export type BashSandboxBoundary = {
+  ensureAvailable: () => Promise<void>
+  buildCommand: typeof buildSandboxedCommand
+  resolveRuntime?: typeof resolvePrivilegedSandboxRuntime
+  verifyRuntime?: typeof verifyPrivilegedSandboxRuntime
+  cleanupRuntime?: typeof cleanupPrivilegedSandboxRuntime
+}
+
+const DEFAULT_BASH_SANDBOX_BOUNDARY: BashSandboxBoundary = {
+  ensureAvailable: ensureBwrapAvailable,
+  buildCommand: buildSandboxedCommand,
+}
+
 export type WrapSystemToolOptions = {
   agentDir: string
   sessionId: string
@@ -221,6 +241,7 @@ export type WrapSystemToolOptions = {
   // read-only subagent keep its bash read-only no matter who spawned it. See
   // `src/agent/reviewer-bash-policy.ts`.
   bashPolicy?: SubagentBashPolicy
+  bashSandboxBoundary?: BashSandboxBoundary
 }
 
 // Zod 4 emits a top-level `"$schema": "https://json-schema.org/draft/2020-12/schema"`
@@ -444,27 +465,54 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
         if (typeof command === 'string') enforceSubagentBashPolicy(opts.bashPolicy, command)
       }
 
-      if (tool.name === 'bash' && opts.permissions !== undefined) {
-        await applyBashSandbox(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId, bashEnvOverlay)
-      }
+      const sandboxBoundary = opts.bashSandboxBoundary ?? DEFAULT_BASH_SANDBOX_BOUNDARY
+      const privilegedRuntime =
+        tool.name === 'bash' && opts.permissions !== undefined
+          ? await applyBashSandbox(
+              mutableArgs,
+              opts.permissions,
+              liveOrigin,
+              opts.agentDir,
+              opts.sessionId,
+              bashEnvOverlay,
+              sandboxBoundary,
+            )
+          : undefined
 
       const tmpRedirect =
         TMP_REDIRECT_TOOLS.has(tool.name) && opts.permissions !== undefined
           ? await applyTmpPathRedirect(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId)
           : undefined
 
-      let rawResult: ToolResult
+      let rawResult: ToolResult | undefined
+      let executionError: unknown
       try {
+        if (privilegedRuntime !== undefined) {
+          await (sandboxBoundary.verifyRuntime ?? verifyPrivilegedSandboxRuntime)(privilegedRuntime)
+        }
         rawResult = await bashEnvStore.run(bashEnvOverlay, () =>
           tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx),
         )
       } catch (error) {
-        // A throwing tool (pi's bash rejects on non-zero exit) must still run
-        // tool.after so cleanup hooks fire — e.g. the github approve guard's
-        // release, whose absence stranded a PR as "already approved" (PR #672).
-        await runToolAfterSafely(opts, tool.name, toolCallId, toErrorResult(error))
-        throw error
+        executionError = error
       }
+      let cleanupError: unknown
+      if (privilegedRuntime !== undefined) {
+        try {
+          await (sandboxBoundary.cleanupRuntime ?? cleanupPrivilegedSandboxRuntime)(privilegedRuntime)
+        } catch (error) {
+          cleanupError = error
+        }
+      }
+      const finalError = executionError ?? cleanupError
+      if (finalError !== undefined) {
+        // A throwing tool or cleanup must still run tool.after exactly once so
+        // lifecycle hooks release reservations. The execution error remains the
+        // primary failure when both phases reject.
+        await runToolAfterSafely(opts, tool.name, toolCallId, toErrorResult(finalError))
+        throw finalError
+      }
+      if (rawResult === undefined) throw new Error('tool execution returned no result')
       const result = tmpRedirect !== undefined ? restoreTmpPathInResult(rawResult, tmpRedirect) : rawResult
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
@@ -526,9 +574,10 @@ async function applyBashSandbox(
   agentDir: string,
   sessionId: string,
   envOverlay: BashEnvOverlay | undefined,
-): Promise<void> {
+  boundary: BashSandboxBoundary,
+): Promise<PrivilegedSandboxRuntime | undefined> {
   const command = mutableArgs.command
-  if (typeof command !== 'string') return
+  if (typeof command !== 'string') return undefined
 
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
 
@@ -539,7 +588,7 @@ async function applyBashSandbox(
   // targets on the real host FS first; the full {dirs, files} still feeds
   // subtractMasked below so a masked path is never re-exposed by a later RW bind.
   const maskTargets = await ensureHiddenMaskTargets({ dirs, files })
-  await ensureBwrapAvailable()
+  await boundary.ensureAvailable()
   // Per-session /tmp: bind this session's scratch dir over the default
   // --tmpfs /tmp so writes survive across the role's sandboxed bash calls AND
   // match what the write/edit wrapper redirected a /tmp path to. The bind is
@@ -581,19 +630,6 @@ async function applyBashSandbox(
     writableRoot || writable.dirs.includes(join(agentDir, '.git'))
       ? subtractMasked(await resolveProtectedZones(agentDir), { dirs, files })
       : { dirs: [], files: [] }
-  // A recognized standalone `bun add`/`bun install` needs DIRECTORY write at the
-  // root (node_modules/ + temp lockfile), which the narrow carve-out model can't
-  // grant. Widen to an RW root for that command class only, then re-hide secrets
-  // (masks) and re-RO the executable surfaces (resolvePackageInstallZones) on top
-  // — subtractMasked drops any protected path a mask already hides so the RW root
-  // never re-exposes it. The default jail's `writable`/`protected` are skipped
-  // here: writableRoot supersedes them for this command, and the same masks +
-  // package-install protected set cover the confidentiality and escalation
-  // boundaries.
-  const packageInstall = isPackageInstallCommand(command)
-    ? subtractMaskedProtected(await resolvePackageInstallZones(agentDir), { dirs, files })
-    : undefined
-
   // Only emit an in-jail symlink for a target that actually survived as a
   // writable dir: a symlink to a target that was dropped (missing, masked for
   // this role, or filtered by the writable-zone guardrails) would dangle onto an
@@ -606,9 +642,9 @@ async function applyBashSandbox(
   const symlinks = resolveSandboxSymlinks(agentDir, config.sandbox.symlinks, sandboxHome).filter((op) =>
     writableDirSet.has(op.target),
   )
-  // bwrap does --clearenv, so the overlay must be re-introduced via env.set or
-  // it would never reach the sandboxed process (the non-sandboxed spawnHook
-  // path does not run when the command is rewritten to a bwrap invocation).
+  // The spawn hook gives bwrap the command-scoped overlay as its parent env.
+  // Secret names are inherited through bwrap without putting their values in
+  // --setenv argv; only non-secret overlay/runtime values are rendered.
   const { strategy: proc, degradeReason } = await resolveProcStrategy()
   // Fail fast with an actionable error when /proc degraded to tmpfs AND the
   // command needs a real /proc: under tmpfs Bun would otherwise abort deep in its
@@ -623,29 +659,54 @@ async function applyBashSandbox(
   if (proc === 'tmpfs' && commandNeedsRealProc(command)) {
     throw degradeReason === 'unverified' ? new SandboxProcProbeUnverifiedError() : new SandboxDegradedProcError()
   }
-  const { commandString } = buildSandboxedCommand(command, {
-    mounts: [
-      { type: 'ro-bind', source: agentDir, dest: agentDir },
-      { type: 'bind', source: sessionTmp, dest: '/tmp' },
-    ],
-    ...(packageInstall !== undefined
-      ? {
-          writableRoot: { dir: packageInstall.root },
-          masks: maskTargets,
-          protected: packageInstall.protected,
-          blockedCreation: { files: packageInstall.blockedCreation },
-        }
-      : writableRoot
+  const privilegedRuntime = await (boundary.resolveRuntime ?? resolvePrivilegedSandboxRuntime)({
+    agentDir,
+    command,
+    env: sandboxEnvOverlay,
+  })
+  try {
+    await verifyHiddenMaskTargets(maskTargets)
+    const { commandString } = boundary.buildCommand(command, {
+      mounts: [
+        { type: 'ro-bind', source: agentDir, dest: agentDir },
+        { type: 'bind', source: sessionTmp, dest: '/tmp' },
+        ...(privilegedRuntime?.mounts ?? []),
+      ],
+      ...(writableRoot
         ? { writableRoot: { dir: agentDir }, masks: maskTargets, protected: protectedZones }
         : { masks: maskTargets, writable, protected: protectedZones }),
-    symlinks,
-    network: 'inherit',
-    cwd: agentDir,
-    proc,
-    procSelfExe: resolveProcSelfExe(),
-    ...(sandboxEnvOverlay !== undefined ? { env: { set: sandboxEnvOverlay } } : {}),
-  })
-  mutableArgs.command = commandString
+      symlinks,
+      network: 'inherit',
+      cwd: agentDir,
+      proc,
+      procSelfExe: resolveProcSelfExe(),
+      ...(sandboxEnvOverlay !== undefined || privilegedRuntime !== undefined
+        ? { env: buildSandboxEnvPolicy(sandboxEnvOverlay, privilegedRuntime?.env) }
+        : {}),
+    })
+    mutableArgs.command = commandString
+    return privilegedRuntime
+  } catch (error) {
+    await (boundary.cleanupRuntime ?? cleanupPrivilegedSandboxRuntime)(privilegedRuntime).catch(() => undefined)
+    throw error
+  }
+}
+
+function buildSandboxEnvPolicy(
+  overlay: BashEnvOverlay | undefined,
+  runtimeEnv: Record<string, string> | undefined,
+): { inherit?: string[]; set?: Record<string, string> } {
+  const set = { ...runtimeEnv }
+  const inherit: string[] = []
+  for (const [key, value] of Object.entries(overlay ?? {})) {
+    if (Object.hasOwn(set, key)) continue
+    if (SECRET_ENV_NAME_PATTERN.test(key)) inherit.push(key)
+    else set[key] = value
+  }
+  return {
+    ...(inherit.length > 0 ? { inherit } : {}),
+    ...(Object.keys(set).length > 0 ? { set } : {}),
+  }
 }
 
 function buildRoleScopedConfigEnv(
@@ -666,14 +727,6 @@ function buildRoleScopedConfigEnv(
     XDG_CONFIG_HOME: '/tmp/.config',
     GWS_CONFIG_HOME: '/tmp/.config/gws',
   }
-}
-
-function subtractMaskedProtected(
-  zones: { root: string; protected: { dirs: string[]; files: string[] }; blockedCreation: string[] },
-  masked: { dirs: string[]; files: string[] },
-): { root: string; protected: { dirs: string[]; files: string[] }; blockedCreation: string[] } {
-  const filtered = subtractMasked(zones.protected, masked)
-  return { root: zones.root, protected: filtered, blockedCreation: zones.blockedCreation }
 }
 
 // Picks the /proc strategy for a sandboxed bash call. The branch order is:

--- a/src/sandbox/build.test.ts
+++ b/src/sandbox/build.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
 
 import { buildSandboxedCommand } from './build'
 import { SandboxPolicyError } from './errors'
@@ -143,6 +144,47 @@ describe('buildSandboxedCommand env policy', () => {
       delete process.env.TYPECLAW_SANDBOX_SECRET
     }
   })
+
+  test('preserves an approved env name without placing its value in bwrap argv', () => {
+    const name = 'TYPECLAW_SANDBOX_INHERITED_SECRET'
+    const value = 'secret-value-that-must-not-enter-cmdline'
+    process.env[name] = value
+    try {
+      const argv = argvOf('true', { env: { inherit: [name] } })
+      expect(argv).not.toContain('--clearenv')
+      expect(argv).not.toContain(value)
+      expect(argv).not.toEqual(expect.arrayContaining(['--setenv', name, value]))
+      expect(argv).not.toEqual(expect.arrayContaining(['--unsetenv', name]))
+    } finally {
+      delete process.env[name]
+    }
+  })
+
+  test('keeps an inherited secret out of /proc cmdline while the child receives it', async () => {
+    if (process.platform !== 'linux') return
+    const name = 'TYPECLAW_SANDBOX_PROC_SECRET'
+    const value = 'proc-secret-value'
+    process.env[name] = value
+    try {
+      const argv = argvOf('true', { env: { inherit: [name] } })
+      const child = Bun.spawn(
+        [
+          process.execPath,
+          '-e',
+          `process.stdout.write(process.env.${name} ?? ''); setTimeout(() => {}, 250)`,
+          '--',
+          ...argv,
+        ],
+        { env: process.env, stdout: 'pipe', stderr: 'pipe' },
+      )
+      const cmdline = await readFile(`/proc/${child.pid}/cmdline`, 'utf8')
+      expect(cmdline).not.toContain(value)
+      expect(await new Response(child.stdout).text()).toBe(value)
+      expect(await child.exited).toBe(0)
+    } finally {
+      delete process.env[name]
+    }
+  })
 })
 
 describe('buildSandboxedCommand mounts', () => {
@@ -243,14 +285,14 @@ describe('buildSandboxedCommand writable overlays', () => {
   })
 })
 
-describe('buildSandboxedCommand writableRoot (package-install mode)', () => {
+describe('buildSandboxedCommand writableRoot (trusted-role compatibility)', () => {
   test('RW-binds the project root with --bind <root> <root>', () => {
-    const joined = argvOf('bun add foo', { writableRoot: { dir: '/agent' } }).join(' ')
+    const joined = argvOf('printf safe > ordinary.txt', { writableRoot: { dir: '/agent' } }).join(' ')
     expect(joined).toContain('--bind /agent /agent')
   })
 
   test('renders the RW root BEFORE masks so secret masks override it (no re-expose)', () => {
-    const argv = argvOf('bun add foo', {
+    const argv = argvOf('printf safe > ordinary.txt', {
       mounts: [{ type: 'ro-bind', source: '/agent', dest: '/agent' }],
       writableRoot: { dir: '/agent' },
       masks: { dirs: ['/agent/memory'], files: ['/agent/.env'] },
@@ -264,15 +306,15 @@ describe('buildSandboxedCommand writableRoot (package-install mode)', () => {
   })
 
   test('renders the RW root BEFORE protected re-binds so executable surfaces stay RO', () => {
-    const argv = argvOf('bun add foo', {
+    const argv = argvOf('printf safe > ordinary.txt', {
       writableRoot: { dir: '/agent' },
-      protected: { dirs: ['/agent/packages', '/agent/node_modules/typeclaw'], files: ['/agent/.git/config'] },
+      protected: { dirs: ['/agent/.git/hooks'], files: ['/agent/.git/config'] },
     })
     const rwRoot = argv.indexOf('--bind')
-    const packages = argv.indexOf('/agent/packages')
-    const runtime = argv.indexOf('/agent/node_modules/typeclaw')
-    expect(rwRoot).toBeLessThan(packages)
-    expect(rwRoot).toBeLessThan(runtime)
+    const hooks = argv.indexOf('/agent/.git/hooks')
+    const config = argv.indexOf('/agent/.git/config')
+    expect(rwRoot).toBeLessThan(hooks)
+    expect(rwRoot).toBeLessThan(config)
   })
 
   test('emits no RW root bind when the policy omits writableRoot', () => {
@@ -303,6 +345,23 @@ describe('buildSandboxedCommand protected re-binds', () => {
     expect(configProtect).toBeGreaterThan(writableGit)
   })
 
+  test('renders node_modules read-only after a trusted root bind while confined policy remains valid', () => {
+    const trusted = argvOf('printf safe > ordinary.txt', {
+      writableRoot: { dir: '/agent' },
+      protected: { dirs: ['/agent/node_modules'], files: [] },
+    })
+    const confined = argvOf('printf safe > workspace/output.txt', {
+      writable: { dirs: ['/agent/workspace'], files: [] },
+      protected: { dirs: ['/agent/node_modules'], files: [] },
+    })
+
+    expect(trusted.indexOf('/agent')).toBeLessThan(trusted.indexOf('/agent/node_modules'))
+    expect(trusted.join(' ')).toContain('--ro-bind /agent/node_modules /agent/node_modules')
+    expect(confined.join(' ')).toContain('--bind /agent/workspace /agent/workspace')
+    expect(confined.join(' ')).toContain('--ro-bind /agent/node_modules /agent/node_modules')
+    expect(confined.join(' ')).not.toContain('--bind /agent /agent')
+  })
+
   test('emits no protected re-binds when the policy omits them', () => {
     const joined = argvOf('true', { writable: { dirs: ['/agent/.git'] } }).join(' ')
     expect(joined).not.toContain('/agent/.git/hooks')
@@ -310,28 +369,25 @@ describe('buildSandboxedCommand protected re-binds', () => {
   })
 })
 
-describe('buildSandboxedCommand blockedCreation', () => {
-  test('binds /dev/null over each blocked path to prevent creation', () => {
-    const joined = argvOf('bun add foo', {
-      blockedCreation: { files: ['/agent/cron.json', '/agent/typeclaw.json'] },
-    }).join(' ')
-    expect(joined).toContain('--ro-bind /dev/null /agent/cron.json')
-    expect(joined).toContain('--ro-bind /dev/null /agent/typeclaw.json')
+describe('buildSandboxedCommand has no package-install path-occupancy mode', () => {
+  test('does not emit /dev/null path occupancy for a trusted ordinary write', () => {
+    const joined = argvOf('printf safe > ordinary.txt', { writableRoot: { dir: '/agent' } }).join(' ')
+    expect(joined).not.toContain('--ro-bind /dev/null')
   })
 
-  test('renders blocked binds AFTER the RW root so last-op-wins occupies the path', () => {
-    const argv = argvOf('bun add foo', {
+  test('still renders protected Git controls after the trusted RW root', () => {
+    const argv = argvOf('printf safe > ordinary.txt', {
       writableRoot: { dir: '/agent' },
-      blockedCreation: { files: ['/agent/cron.json'] },
+      protected: { dirs: ['/agent/.git/hooks'], files: ['/agent/.git/config'] },
     })
     const rwRoot = argv.indexOf('--bind')
-    const blocked = argv.indexOf('/agent/cron.json')
+    const protectedPath = argv.indexOf('/agent/.git/hooks')
     expect(rwRoot).toBeGreaterThanOrEqual(0)
-    expect(blocked).toBeGreaterThan(rwRoot)
+    expect(protectedPath).toBeGreaterThan(rwRoot)
   })
 
-  test('emits no blocked binds when the policy omits them', () => {
-    const argv = argvOf('true', { writableRoot: { dir: '/agent' } })
+  test('emits no hidden path-occupancy bind when the root is read-only', () => {
+    const argv = argvOf('true', {})
     expect(argv.join(' ')).not.toContain('/dev/null /agent')
   })
 })

--- a/src/sandbox/build.ts
+++ b/src/sandbox/build.ts
@@ -84,8 +84,21 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
     argv.push('--die-with-parent')
   }
 
-  argv.push('--clearenv')
+  const inheritedNames = new Set(policy.env?.inherit ?? [])
+  if (inheritedNames.size === 0) {
+    argv.push('--clearenv')
+  } else {
+    const retained = new Set([
+      ...inheritedNames,
+      ...Object.keys(DEFAULT_SANDBOX_ENV),
+      ...Object.keys(policy.env?.set ?? {}),
+    ])
+    for (const key of Object.keys(process.env).sort()) {
+      if (!retained.has(key)) argv.push('--unsetenv', key)
+    }
+  }
   for (const [key, value] of Object.entries(resolveEnv(policy.env))) {
+    if (inheritedNames.has(key)) continue
     argv.push('--setenv', key, value)
   }
 
@@ -171,7 +184,6 @@ function buildArgv(command: string, policy: SandboxPolicy): string[] {
   appendWritable(argv, policy)
   appendMasks(argv, policy)
   appendProtected(argv, policy)
-  appendBlockedCreation(argv, policy)
   appendSymlinks(argv, policy)
 
   if (policy.cwd !== undefined) {
@@ -215,17 +227,6 @@ function appendProtected(argv: string[], policy: SandboxPolicy): void {
   }
   for (const file of policy.protected?.files ?? []) {
     argv.push('--ro-bind', file, file)
-  }
-}
-
-// Occupies each path with an empty read-only object so a writable-root install
-// script cannot CREATE a real file there. /dev/null always exists (bwrap mounts
-// --dev), so unlike --ro-bind-data this needs no manufactured placeholder on the
-// host FS. Renders after appendProtected: both are RO carve-outs of the RW root,
-// last-op-wins.
-function appendBlockedCreation(argv: string[], policy: SandboxPolicy): void {
-  for (const file of policy.blockedCreation?.files ?? []) {
-    argv.push('--ro-bind', '/dev/null', file)
   }
 }
 

--- a/src/sandbox/errors.test.ts
+++ b/src/sandbox/errors.test.ts
@@ -14,9 +14,9 @@ describe('SandboxDegradedProcError', () => {
     expect(err.name).toBe('SandboxDegradedProcError')
   })
 
-  test('names the bun package commands and frames it as an environment limit, not a command fault', () => {
+  test('names the allowed bun package runners and frames it as an environment limit, not a command fault', () => {
     const { message } = new SandboxDegradedProcError()
-    expect(message).toContain('bun install')
+    expect(message).toContain('bun run')
     expect(message).toContain('bunx')
     expect(message).toContain('NotDir')
     expect(message.toLowerCase()).toContain('retry')
@@ -40,9 +40,9 @@ describe('SandboxProcProbeUnverifiedError', () => {
     expect(err.name).toBe('SandboxProcProbeUnverifiedError')
   })
 
-  test('names the bun package commands and frames it as transient, not a command fault', () => {
+  test('names the allowed bun package runners and frames it as transient, not a command fault', () => {
     const { message } = new SandboxProcProbeUnverifiedError()
-    expect(message).toContain('bun install')
+    expect(message).toContain('bun run')
     expect(message).toContain('bunx')
     expect(message.toLowerCase()).toContain('inconclusive')
     expect(message.toLowerCase()).toContain('temporary')

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -7,6 +7,13 @@ export class SandboxUnavailableError extends Error {
   }
 }
 
+export class SandboxMaskTargetError extends Error {
+  override readonly name = 'SandboxMaskTargetError'
+  constructor(target: string, reason: string) {
+    super(`sandbox canonical mask target is unsafe: ${target} (${reason}). Refusing to run model-driven bash.`)
+  }
+}
+
 // Raised by the optional command-filter knobs (allowPrefixes,
 // rejectShellMetacharacters). These are consumer-opt-in restrictions layered
 // ABOVE the always-on kernel containment, so a rejection here is a policy
@@ -19,17 +26,10 @@ export class SandboxPolicyError extends Error {
   }
 }
 
-export class SandboxMaskTargetError extends Error {
-  override readonly name = 'SandboxMaskTargetError'
-  constructor(target: string, reason: string) {
-    super(`sandbox mask target is unsafe (${target}): ${reason}`)
-  }
-}
-
 // Raised when the /proc strategy degraded to the empty `tmpfs` fallback AND the
-// command needs a real /proc (a bun install / bunx / bun run that reads the
+// command needs a real /proc (bunx / bun run that reads the
 // kernel-backed /proc/self/{fd,maps}). Without this pre-check Bun aborts deep in
-// its install pipeline with the opaque "NotDir" (ENOTDIR) error, which the model
+// its runner pipeline with the opaque "NotDir" (ENOTDIR) error, which the model
 // misreads as a bad package or a transient hiccup and retries forever. Surfacing
 // it here, before the command runs, turns the failure into one the operator (or
 // the model) can act on: it is an environment/runtime limitation, not the
@@ -38,8 +38,8 @@ export class SandboxDegradedProcError extends Error {
   override readonly name = 'SandboxDegradedProcError'
   constructor() {
     super(
-      'sandbox /proc is in degraded tmpfs mode, so bun package commands ' +
-        '(bun install / bun add / bunx / bun run) cannot run: Bun needs a real ' +
+      'sandbox /proc is in degraded tmpfs mode, so bun package runners ' +
+        '(bunx / bun x / bun create / bun run) cannot run: Bun needs a real ' +
         '/proc/self/fd, which this strategy cannot provide, and would otherwise ' +
         'fail with an opaque "NotDir" error. This is a container/runtime limitation ' +
         '(no usable user namespaces for the cap-free proc-bind strategy), not a ' +
@@ -66,8 +66,8 @@ export class SandboxProcProbeUnverifiedError extends Error {
     super(
       'sandbox /proc strategy could not be verified right now: the cap-free ' +
         'proc-bind safety probe stayed inconclusive (usually transient load on the ' +
-        'host while the container was starting up), so this bun package command ' +
-        '(bun install / bun add / bunx / bun run) was held back rather than run ' +
+        'host while the container was starting up), so this bun package runner ' +
+        '(bunx / bun x / bun create / bun run) was held back rather than run ' +
         'under a broken /proc. This is almost certainly temporary and NOT a problem ' +
         'with the command or the package: retry the SAME command in a few seconds — ' +
         'the next attempt re-probes and normally succeeds.',

--- a/src/sandbox/hidden-paths.test.ts
+++ b/src/sandbox/hidden-paths.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { link, lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,16 +8,32 @@ import { createPermissionService } from '@/permissions/permissions'
 import { rolesConfigSchema, type RolesConfig } from '@/permissions/schema'
 
 import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from './canonical-secrets'
-import { canWriteAgentRootInSandbox, ensureHiddenMaskTargets, resolveHiddenPaths } from './hidden-paths'
+import {
+  canWriteAgentRootInSandbox,
+  ensureHiddenMaskTargets,
+  resolveHiddenPaths,
+  verifyHiddenMaskTargets,
+} from './hidden-paths'
 
 const AGENT = '/agent'
 const hiddenDirs = (agentDir: string) => [
+  join(agentDir, 'workspace', '.config', 'gws'),
+  join(agentDir, 'workspace', '.agent-messenger'),
+  join(agentDir, '.typeclaw', 'home'),
   join(agentDir, 'workspace'),
   join(agentDir, 'memory'),
   join(agentDir, 'sessions'),
 ]
-const canonicalDirs = (agentDir: string) => CANONICAL_AGENT_SECRET_DIRS.map((dir) => join(agentDir, dir))
-const secretFiles = (agentDir: string) => CANONICAL_AGENT_SECRET_FILES.map((file) => join(agentDir, file))
+const canonicalSecretDirs = (agentDir: string) => [
+  join(agentDir, 'workspace', '.config', 'gws'),
+  join(agentDir, 'workspace', '.agent-messenger'),
+  join(agentDir, '.typeclaw', 'home'),
+]
+const secretFiles = (agentDir: string) => [
+  join(agentDir, '.env'),
+  join(agentDir, 'secrets.json'),
+  join(agentDir, 'auth.json'),
+]
 
 function parseRoles(raw: unknown): RolesConfig {
   const result = rolesConfigSchema.safeParse(raw)
@@ -31,32 +47,30 @@ function spawnedBy(role: string): SessionOrigin {
 
 const tui: SessionOrigin = { kind: 'tui', sessionId: 's' }
 
-describe('canWriteAgentRootInSandbox', () => {
-  test('preserves root writes only for owner and trusted roles', () => {
-    const svc = createPermissionService()
-    expect(canWriteAgentRootInSandbox(svc, tui)).toBe(true)
-    expect(canWriteAgentRootInSandbox(svc, spawnedBy('trusted'))).toBe(true)
-    expect(canWriteAgentRootInSandbox(svc, spawnedBy('member'))).toBe(false)
-    expect(canWriteAgentRootInSandbox(svc, spawnedBy('guest'))).toBe(false)
-  })
-})
-
 describe('resolveHiddenPaths — builtin tiers', () => {
-  test('owner (tui) always hides canonical credentials', () => {
+  test('canonical secret masks have one non-empty source of truth', () => {
+    expect(CANONICAL_AGENT_SECRET_DIRS.length).toBeGreaterThan(0)
+    expect(CANONICAL_AGENT_SECRET_FILES.length).toBeGreaterThan(0)
+    const resolved = resolveHiddenPaths(createPermissionService(), tui, AGENT)
+    expect(resolved.dirs).toEqual(CANONICAL_AGENT_SECRET_DIRS.map((entry) => join(AGENT, entry)))
+    expect(resolved.files).toEqual(CANONICAL_AGENT_SECRET_FILES.map((entry) => join(AGENT, entry)))
+  })
+
+  test('owner (tui) still masks canonical agent secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, tui, AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
-  test('trusted always hides canonical credentials', () => {
+  test('trusted sees private directories but still masks canonical agent secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('trusted'), AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
-  test('system origin hides nothing even when triggered by a guest channel turn', () => {
+  test('system-origin LLM bash still masks canonical agent secret files', () => {
     const svc = createPermissionService()
     const origin: SessionOrigin = {
       kind: 'system',
@@ -64,21 +78,21 @@ describe('resolveHiddenPaths — builtin tiers', () => {
       triggeredBy: { kind: 'channel', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: null },
     }
     const { dirs, files } = resolveHiddenPaths(svc, origin, AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('member sees private surface but hides the secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('member'), AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
   test('guest hides the private surface AND the secret files', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('guest'), AGENT)
-    expect(dirs).toEqual([...hiddenDirs(AGENT), ...canonicalDirs(AGENT)])
+    expect(dirs).toEqual(hiddenDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
@@ -89,11 +103,21 @@ describe('resolveHiddenPaths — builtin tiers', () => {
   })
 })
 
+describe('canWriteAgentRootInSandbox', () => {
+  test('preserves full agent-root writes for owner and trusted while member remains confined', () => {
+    const svc = createPermissionService()
+    expect(canWriteAgentRootInSandbox(svc, tui)).toBe(true)
+    expect(canWriteAgentRootInSandbox(svc, spawnedBy('trusted'))).toBe(true)
+    expect(canWriteAgentRootInSandbox(svc, spawnedBy('member'))).toBe(false)
+    expect(canWriteAgentRootInSandbox(svc, spawnedBy('guest'))).toBe(false)
+  })
+})
+
 describe('resolveHiddenPaths — fail-safe', () => {
   test('undefined origin is treated as guest (everything hidden)', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, undefined, AGENT)
-    expect(dirs).toEqual([...hiddenDirs(AGENT), ...canonicalDirs(AGENT)])
+    expect(dirs).toEqual(hiddenDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
@@ -108,7 +132,7 @@ describe('resolveHiddenPaths — fail-safe', () => {
       lastInboundAuthorId: 'U_STRANGER',
     }
     const { dirs, files } = resolveHiddenPaths(svc, stranger, AGENT)
-    expect(dirs).toEqual([...hiddenDirs(AGENT), ...canonicalDirs(AGENT)])
+    expect(dirs).toEqual(hiddenDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 })
@@ -118,17 +142,17 @@ describe('resolveHiddenPaths — custom roles via fs.see grants', () => {
     const roles = parseRoles({ contributor: { match: ['slack:T0 author:U_C'], permissions: ['fs.see.private'] } })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('contributor'), AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
-  test('custom role with both fs.see grants still hides canonical credentials', () => {
+  test('fs.see.secrets does not expose canonical agent secret files to LLM tools', () => {
     const roles = parseRoles({
       steward: { match: ['slack:T0 author:U_S'], permissions: ['fs.see.private', 'fs.see.secrets'] },
     })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('steward'), AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 })
@@ -140,17 +164,17 @@ describe('resolveHiddenPaths — legacy security.bypass fallback', () => {
     })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('legacymember'), AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 
-  test('a role with bypass.medium (no fs.see.*) sees both private surface and secrets', () => {
+  test('bypass.medium exposes private directories but not canonical agent secret files', () => {
     const roles = parseRoles({
       legacytrusted: { match: ['slack:T0 author:U_LT'], permissions: ['security.bypass.medium'] },
     })
     const svc = createPermissionService({ roles })
     const { dirs, files } = resolveHiddenPaths(svc, spawnedBy('legacytrusted'), AGENT)
-    expect(dirs).toEqual(canonicalDirs(AGENT))
+    expect(dirs).toEqual(canonicalSecretDirs(AGENT))
     expect(files).toEqual(secretFiles(AGENT))
   })
 })
@@ -159,7 +183,7 @@ describe('resolveHiddenPaths — agentDir relativity', () => {
   test('masks are rooted at the given agentDir, not a hardcoded /agent', () => {
     const svc = createPermissionService()
     const { dirs, files } = resolveHiddenPaths(svc, undefined, '/srv/app')
-    expect(dirs).toEqual([...hiddenDirs('/srv/app'), ...canonicalDirs('/srv/app')])
+    expect(dirs).toEqual(hiddenDirs('/srv/app'))
     expect(files).toEqual(secretFiles('/srv/app'))
   })
 })
@@ -203,7 +227,7 @@ describe('ensureHiddenMaskTargets', () => {
     expect(await Bun.file(secrets).text()).toBe('{"real":"content"}')
   })
 
-  test('fails closed when a canonical file mask target is a symlink', async () => {
+  test('fails closed when a canonical mask target is a symlink', async () => {
     const outside = join(dir, 'outside')
     await writeFile(outside, 'secret')
     const env = join(dir, '.env')
@@ -211,11 +235,54 @@ describe('ensureHiddenMaskTargets', () => {
     await expect(ensureHiddenMaskTargets({ dirs: [], files: [env] })).rejects.toThrow(/mask target/i)
   })
 
-  test('fails closed when a canonical directory mask target is a symlink', async () => {
+  test('fails closed when a credential-directory mask target is a symlink', async () => {
     const outside = join(dir, 'outside-dir')
     await mkdir(outside)
-    const credentials = join(dir, 'credentials')
-    await symlink(outside, credentials)
-    await expect(ensureHiddenMaskTargets({ dirs: [credentials], files: [] })).rejects.toThrow(/mask target/i)
+    const gws = join(dir, 'gws')
+    await symlink(outside, gws)
+    await expect(ensureHiddenMaskTargets({ dirs: [gws], files: [] })).rejects.toThrow(/mask target/i)
+  })
+
+  test('fails closed when a canonical mask target is non-regular', async () => {
+    const env = join(dir, '.env')
+    await mkdir(env)
+    await expect(ensureHiddenMaskTargets({ dirs: [], files: [env] })).rejects.toThrow(/mask target/i)
+  })
+
+  test('fails closed when a canonical mask target has another hardlink', async () => {
+    const env = join(dir, '.env')
+    await writeFile(env, 'secret')
+    await link(env, join(dir, 'env-alias'))
+    await expect(ensureHiddenMaskTargets({ dirs: [], files: [env] })).rejects.toThrow(/hardlink|mask target/i)
+  })
+
+  test('applies the same fail-closed hardlink rule to historical root auth.json', async () => {
+    const auth = join(dir, 'auth.json')
+    await writeFile(auth, 'secret')
+    await link(auth, join(dir, 'auth-alias'))
+    await expect(ensureHiddenMaskTargets({ dirs: [], files: [auth] })).rejects.toThrow(/hardlink|mask target/i)
+  })
+
+  test('revalidation catches a hardlink introduced after initial mask validation', async () => {
+    const auth = join(dir, 'auth.json')
+    await writeFile(auth, 'secret')
+    const targets = await ensureHiddenMaskTargets({ dirs: [], files: [auth] })
+    await link(auth, join(dir, 'late-alias'))
+    await expect(verifyHiddenMaskTargets(targets)).rejects.toThrow(/hardlink|mask target/i)
+  })
+
+  test('fails closed when a file under a canonical secret directory has an outside hardlink', async () => {
+    const gws = join(dir, 'workspace', '.config', 'gws')
+    await mkdir(gws, { recursive: true })
+    const credential = join(gws, 'accounts', 'credentials.json')
+    await mkdir(join(gws, 'accounts'))
+    await writeFile(credential, 'secret')
+    await link(credential, join(dir, 'public-alias'))
+    await expect(ensureHiddenMaskTargets({ dirs: [gws], files: [] })).rejects.toThrow(/hardlink|mask target/i)
+  })
+
+  test('fails closed when an absent canonical mask target cannot be materialized', async () => {
+    const env = join(dir, 'missing-parent', '.env')
+    await expect(ensureHiddenMaskTargets({ dirs: [], files: [env] })).rejects.toThrow(/mask target/i)
   })
 })

--- a/src/sandbox/hidden-paths.ts
+++ b/src/sandbox/hidden-paths.ts
@@ -1,5 +1,5 @@
-import { lstat, mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { lstat, mkdir, opendir, writeFile } from 'node:fs/promises'
+import { join, sep } from 'node:path'
 
 import type { SessionOrigin } from '@/agent/session-origin'
 import { CORE_PERMISSIONS } from '@/permissions/builtins'
@@ -14,42 +14,52 @@ export type HiddenPaths = {
 }
 
 const PRIVATE_DIRS = ['workspace', 'memory', 'sessions'] as const
-// The agent's private working surface and credential files are masked from
-// sandboxed bash unless the resolved role carries the matching fs.see.* grant.
+const MAX_CANONICAL_SECRET_SCAN_ENTRIES = 4096
+
+// The ordinary private working surface is role-scoped, but canonical credential
+// files and runtime-owned credential directories are always masked.
 // `permissions.has` resolves the role from the live origin and fails safe to
 // guest (empty permissions) for an unclear/undefined origin, so a missing
 // grant — whether from a low tier or an unresolvable author — hides the path.
 //
-// The security.bypass.* fallback keeps custom roles (which may never name the
-// fs.see.* strings) working by capability: a role trusted enough to bypass
-// medium-severity guards is treated as trusted for filesystem visibility, and
-// bypass.low maps to the private-surface tier. fs.see.* always wins when
-// present; the fallback only fires when it is absent.
+// The security.bypass.* fallback keeps custom roles (which may never name
+// fs.see.private) working by capability. fs.see.secrets remains useful for
+// runtime-owned credential injection, but it deliberately cannot make raw
+// .env, secrets.json, or historical auth.json bytes available to an LLM.
+// Privileged diagnostics must
+// use host-side commands that report presence/status without returning values.
 export function resolveHiddenPaths(
   permissions: PermissionService,
   origin: SessionOrigin | undefined,
   agentDir: string,
 ): HiddenPaths {
-  const seesPrivate =
-    permissions.has(origin, CORE_PERMISSIONS.fsSeePrivate) ||
-    permissions.has(origin, 'security.bypass.low') ||
-    permissions.has(origin, 'security.bypass.medium')
+  const seesPrivate = canSeePrivateSurface(permissions, origin)
   const dirs = [
-    ...(seesPrivate ? [] : PRIVATE_DIRS.map((d) => join(agentDir, d))),
-    ...CANONICAL_AGENT_SECRET_DIRS.map((d) => join(agentDir, d)),
+    ...CANONICAL_AGENT_SECRET_DIRS.map((dir) => join(agentDir, dir)),
+    ...(seesPrivate ? [] : PRIVATE_DIRS.map((dir) => join(agentDir, dir))),
   ]
   const files = CANONICAL_AGENT_SECRET_FILES.map((f) => join(agentDir, f))
   return { dirs, files }
 }
 
+// Before canonical secret masking became unconditional, roles carrying both
+// visibility capabilities ran bash unsandboxed and therefore had full write
+// access to the agent root. They now enter bwrap so canonical credential paths
+// can be masked, but must retain ordinary root-write capability. The policy
+// overlays the secret masks after the RW root bind, so this does not restore raw
+// credential access.
 export function canWriteAgentRootInSandbox(permissions: PermissionService, origin: SessionOrigin | undefined): boolean {
-  const seesPrivate =
+  const seesSecrets =
+    permissions.has(origin, CORE_PERMISSIONS.fsSeeSecrets) || permissions.has(origin, 'security.bypass.medium')
+  return canSeePrivateSurface(permissions, origin) && seesSecrets
+}
+
+function canSeePrivateSurface(permissions: PermissionService, origin: SessionOrigin | undefined): boolean {
+  return (
     permissions.has(origin, CORE_PERMISSIONS.fsSeePrivate) ||
     permissions.has(origin, 'security.bypass.low') ||
     permissions.has(origin, 'security.bypass.medium')
-  const seesSecrets =
-    permissions.has(origin, CORE_PERMISSIONS.fsSeeSecrets) || permissions.has(origin, 'security.bypass.medium')
-  return seesPrivate && seesSecrets
+  )
 }
 
 // SECURITY / bwrap contract: the mask ops REQUIRE a pre-existing target.
@@ -62,29 +72,78 @@ export function canWriteAgentRootInSandbox(permissions: PermissionService, origi
 // here (only sandboxed bash sees it RO), so an empty placeholder is harmless and
 // the mask binds over a real empty file, leaking nothing.
 //
-// ENSURE, not FILTER: package-install mode makes the jail root RW
+// ENSURE, not FILTER: privileged modes make the jail root RW
 // (`writableRoot: agentDir`), so dropping an absent secret would let sandboxed
-// code CREATE `.env`/`secrets.json` for real (planting) or expose one created
+// code CREATE a canonical credential path for real (planting) or expose one created
 // mid-session (TOCTOU). A guaranteed target keeps the mask always rendered over
-// it (last-op-wins), closing that hole for both jail modes. Required masks fail
-// closed: a symlink, wrong entry kind, or materialization failure aborts bash.
+// it (last-op-wins), closing that hole for every mode. Required masks are
+// fail-closed: symlinks, wrong entry kinds, hardlinked files, materialization
+// failures, or a late identity change abort bash.
 export async function ensureHiddenMaskTargets(hidden: HiddenPaths): Promise<HiddenPaths> {
-  const dirs = await Promise.all(hidden.dirs.map((target) => ensureMaskTarget(target, 'dir')))
-  const files = await Promise.all(hidden.files.map((target) => ensureMaskTarget(target, 'file')))
+  const dirs = await Promise.all(hidden.dirs.map((target) => ensureRequiredDirMaskTarget(target)))
+  const files = await Promise.all(hidden.files.map((target) => ensureRequiredFileMaskTarget(target)))
   return { dirs, files }
 }
 
-async function ensureMaskTarget(target: string, kind: 'dir' | 'file'): Promise<string> {
-  try {
-    if (kind === 'dir') await mkdir(target, { recursive: true })
-    else await ensureEmptyFile(target)
-    const stats = await lstat(target)
-    if (stats.isSymbolicLink()) throw new SandboxMaskTargetError(target, 'symlinks cannot be masked safely')
-    const validKind = kind === 'dir' ? stats.isDirectory() : stats.isFile()
-    if (!validKind) throw new SandboxMaskTargetError(target, `target is not a ${kind}`)
-    return target
-  } catch {
+export async function verifyHiddenMaskTargets(hidden: HiddenPaths): Promise<void> {
+  await Promise.all(hidden.dirs.map((target) => verifyRequiredMaskTarget(target, 'dir')))
+  await Promise.all(hidden.files.map((target) => verifyRequiredMaskTarget(target, 'file')))
+}
+
+async function ensureRequiredDirMaskTarget(target: string): Promise<string> {
+  await mkdir(target, { recursive: true }).catch(() => {})
+  await verifyRequiredMaskTarget(target, 'dir')
+  return target
+}
+
+async function ensureRequiredFileMaskTarget(target: string): Promise<string> {
+  await ensureEmptyFile(target)
+  await verifyRequiredMaskTarget(target, 'file')
+  return target
+}
+
+async function verifyRequiredMaskTarget(target: string, kind: 'dir' | 'file'): Promise<void> {
+  const stats = await lstat(target).catch(() => {
     throw new SandboxMaskTargetError(target, `could not materialize or inspect a ${kind}`)
+  })
+  if (stats.isSymbolicLink()) throw new SandboxMaskTargetError(target, 'symlinks are not maskable safely')
+  if (kind === 'dir' && !stats.isDirectory()) throw new SandboxMaskTargetError(target, 'target is not a directory')
+  if (kind === 'file' && !stats.isFile()) throw new SandboxMaskTargetError(target, 'target is not a regular file')
+  if (kind === 'file' && stats.nlink !== 1) throw new SandboxMaskTargetError(target, 'target has hardlink aliases')
+  if (kind === 'dir' && isCanonicalSecretDir(target)) await rejectHardlinksUnderCanonicalDir(target)
+}
+
+function isCanonicalSecretDir(target: string): boolean {
+  return CANONICAL_AGENT_SECRET_DIRS.some((dir) => target.endsWith(`${sep}${dir.split('/').join(sep)}`))
+}
+
+async function rejectHardlinksUnderCanonicalDir(root: string): Promise<void> {
+  const pending = [root]
+  let visited = 0
+  while (pending.length > 0) {
+    const current = pending.pop() as string
+    const dir = await opendir(current).catch(() => {
+      throw new SandboxMaskTargetError(root, 'canonical secret directory could not be scanned safely')
+    })
+    try {
+      for await (const entry of dir) {
+        visited += 1
+        if (visited > MAX_CANONICAL_SECRET_SCAN_ENTRIES) {
+          throw new SandboxMaskTargetError(root, 'canonical secret directory exceeds bounded hardlink scan')
+        }
+        const child = join(current, entry.name)
+        const stats = await lstat(child)
+        if (stats.isSymbolicLink()) continue
+        if (stats.isDirectory()) pending.push(child)
+        if (stats.isFile() && stats.nlink !== 1) {
+          throw new SandboxMaskTargetError(root, `file under canonical secret directory has hardlink aliases: ${child}`)
+        }
+      }
+    } finally {
+      try {
+        await dir.close()
+      } catch {}
+    }
   }
 }
 

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -23,23 +23,29 @@ export {
   canWriteAgentRootInSandbox,
   ensureHiddenMaskTargets,
   resolveHiddenPaths,
+  verifyHiddenMaskTargets,
   type HiddenPaths,
 } from './hidden-paths'
 export {
-  resolvePackageInstallZones,
   resolveProtectedZones,
   resolveWritableZones,
   subtractMasked,
-  type PackageInstallZones,
   type ProtectedZones,
   type WritableZones,
 } from './writable-zones'
 export { resolveSandboxSymlinks, type SandboxSymlinkSpec } from './symlinks'
-export { commandNeedsRealProc, isPackageInstallCommand } from './package-install'
+export { commandNeedsRealProc } from './package-install'
+export {
+  cleanupPrivilegedSandboxRuntime,
+  resolvePrivilegedSandboxRuntime,
+  verifyPrivilegedSandboxRuntime,
+  type PrivilegedSandboxRuntime,
+} from './privileged-runtime'
 export { ensureSessionTmpDir, isUnderTmp, mapVirtualTmpPath, SESSION_TMP_ROOT, sessionTmpDir } from './session-tmp'
 export { formatCommand, shellQuote } from './quote'
 export {
   SandboxDegradedProcError,
+  SandboxMaskTargetError,
   SandboxPolicyError,
   SandboxProcProbeUnverifiedError,
   SandboxUnavailableError,

--- a/src/sandbox/package-install.test.ts
+++ b/src/sandbox/package-install.test.ts
@@ -1,49 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { commandNeedsRealProc, isPackageInstallCommand } from './package-install'
-
-describe('isPackageInstallCommand', () => {
-  test('recognizes standalone bun add / install / i', () => {
-    expect(isPackageInstallCommand('bun add @googleworkspace/cli')).toBe(true)
-    expect(isPackageInstallCommand('bun install')).toBe(true)
-    expect(isPackageInstallCommand('bun i lodash')).toBe(true)
-    expect(isPackageInstallCommand('bun add -d typescript')).toBe(true)
-    expect(isPackageInstallCommand('  bun   add   foo  ')).toBe(true)
-  })
-
-  test('rejects non-install bun subcommands', () => {
-    expect(isPackageInstallCommand('bun run build')).toBe(false)
-    expect(isPackageInstallCommand('bun test')).toBe(false)
-    expect(isPackageInstallCommand('bunx cowsay')).toBe(false)
-    expect(isPackageInstallCommand('bun')).toBe(false)
-  })
-
-  test('rejects non-bun managers', () => {
-    expect(isPackageInstallCommand('npm install')).toBe(false)
-    expect(isPackageInstallCommand('pnpm add foo')).toBe(false)
-    expect(isPackageInstallCommand('yarn add foo')).toBe(false)
-  })
-
-  test('rejects global installs (write outside the jail; bun-hygiene blocks them)', () => {
-    expect(isPackageInstallCommand('bun add -g some-cli')).toBe(false)
-    expect(isPackageInstallCommand('bun add --global some-cli')).toBe(false)
-    expect(isPackageInstallCommand('bun install -g')).toBe(false)
-  })
-
-  // SECURITY: the broad RW root must never piggyback onto a chained second
-  // command. Any shell metacharacter falls back to the default ro-root jail.
-  test('rejects chaining, substitution, redirects, and subshells', () => {
-    expect(isPackageInstallCommand('bun add foo && rm -rf /agent/packages')).toBe(false)
-    expect(isPackageInstallCommand('bun add foo; curl evil.com')).toBe(false)
-    expect(isPackageInstallCommand('bun add foo | tee out')).toBe(false)
-    expect(isPackageInstallCommand('bun add $(echo foo)')).toBe(false)
-    expect(isPackageInstallCommand('bun add `echo foo`')).toBe(false)
-    expect(isPackageInstallCommand('bun add foo > /agent/x')).toBe(false)
-    expect(isPackageInstallCommand('(bun add foo)')).toBe(false)
-    expect(isPackageInstallCommand('bun add foo\nrm -rf x')).toBe(false)
-    expect(isPackageInstallCommand('\\bun add foo')).toBe(false)
-  })
-})
+import { commandNeedsRealProc } from './package-install'
 
 describe('commandNeedsRealProc', () => {
   test('flags package installs (add / install / i)', () => {
@@ -64,9 +21,8 @@ describe('commandNeedsRealProc', () => {
     expect(commandNeedsRealProc('bun run scripts/render.ts a b')).toBe(true)
   })
 
-  // DIAGNOSTIC, not a privilege gate: unlike isPackageInstallCommand it must still
-  // fire through shell metacharacters, since the bun invocation still runs and
-  // still needs a real /proc.
+  // This diagnostic must fire through shell metacharacters because the Bun
+  // invocation still runs and still needs a real /proc.
   test('fires even with chaining / metacharacters (the bun invocation still runs)', () => {
     expect(commandNeedsRealProc('bunx foo && echo done')).toBe(true)
     expect(commandNeedsRealProc('bun add foo; echo ok')).toBe(true)

--- a/src/sandbox/package-install.ts
+++ b/src/sandbox/package-install.ts
@@ -1,27 +1,3 @@
-// Recognizes the narrow command class that earns the package-install sandbox
-// mode (RW project root). Deliberately conservative: a single standalone local
-// `bun add` / `bun install` / `bun i` with NO shell metacharacters, chaining,
-// redirects, or substitution. Anything fancier (`bun add x && rm -rf …`,
-// `bun add x; curl …`, a subshell, a pipe) falls back to the default ro-root
-// jail so the broad RW root can never be piggybacked onto an attacker-controlled
-// second command. Global installs (`-g` / `--global`) are excluded — the
-// bun-hygiene guard already blocks them and they write outside the jail anyway.
-const SHELL_METACHARACTERS = /[;&|`$()<>\\\n\r{}!*?[\]"']/
-
-const GLOBAL_FLAG = /^(-g|--global)$/
-
-export function isPackageInstallCommand(command: string): boolean {
-  if (SHELL_METACHARACTERS.test(command)) return false
-
-  const words = command.trim().split(/\s+/)
-  if (words[0] !== 'bun') return false
-
-  const subcommand = words[1]
-  if (subcommand !== 'add' && subcommand !== 'install' && subcommand !== 'i') return false
-
-  return !words.some((word) => GLOBAL_FLAG.test(word))
-}
-
 // The bun subcommands whose work (or whose spawned child) reads the kernel-backed
 // /proc/self/{fd,maps} magic symlinks: package installs (add/install/i), the
 // package runners (x/create), and `run` (which can exec a package bin). Under the
@@ -41,11 +17,11 @@ const SHELL_COMMAND_SEPARATOR = /(?:&&|\|\||[;|&\n()])+/
 
 // Whether a command will exercise the real /proc, so a caller can turn the
 // degraded-mode `tmpfs` fallback into an actionable diagnostic instead of letting
-// Bun surface its opaque "NotDir". UNLIKE isPackageInstallCommand this is a
-// DIAGNOSTIC heuristic, not a privilege gate — it deliberately fires through shell
+// Bun surface its opaque "NotDir". This is a DIAGNOSTIC heuristic, not a
+// privilege gate — it deliberately fires through shell
 // metacharacters and chained preludes (a `cd app && bunx foo` still runs bunx) and
 // never widens the sandbox surface, so erring toward catching more only improves
-// the error message.
+// the error message. It is not an authorization boundary.
 export function commandNeedsRealProc(command: string): boolean {
   return command.split(SHELL_COMMAND_SEPARATOR).some((segment) => segmentInvokesRealProcBun(segment.trim()))
 }

--- a/src/sandbox/policy.ts
+++ b/src/sandbox/policy.ts
@@ -9,7 +9,7 @@ export type SandboxNetwork = 'none' | 'inherit'
 // 'proc-bind' (the runtime default): --ro-bind /proc /proc binds the container's
 // ALREADY-REAL procfs straight into the sandbox — no `unshare --mount-proc`, no
 // CAP_SYS_ADMIN. A JS package runner's child gets a real /proc/self/{fd,maps,exe}
-// so `bunx`/`bun add`/`bun run <pkg-bin>` stop aborting with Bun's ENOTDIR. The
+// so allowed `bunx`/`bun run <pkg-bin>` calls stop aborting with Bun's ENOTDIR. The
 // agent runtime's /proc/<agent>/environ (OPENAI_API_KEY, GH_TOKEN) is NOT
 // leaked: build.ts always emits --unshare-user, so the sandboxed bash runs as
 // mapped-root in a CHILD user namespace that is not an ancestor of the agent
@@ -37,6 +37,11 @@ export type SandboxProcStrategy = 'tmpfs' | 'none' | 'real-proc' | 'proc-bind'
 export type SandboxEnvPolicy = {
   set?: Record<string, string>
   passthrough?: string[]
+  // Preserve these names from bwrap's parent environment without rendering
+  // their values in argv. The builder switches from --clearenv to explicit
+  // --unsetenv for every other inherited name. Reserved for command-scoped
+  // secrets whose parent process is protected by the child-userns boundary.
+  inherit?: string[]
 }
 
 export type SandboxCommandFilter = {
@@ -94,34 +99,16 @@ export type SandboxSymlinkOp = {
   dest: string
 }
 
-// A single RW bind of the project root, used ONLY by the package-install path
-// (recognized standalone `bun add`/`bun install` commands). `bun add` writes
-// node_modules/ AND a temp lockfile (`bun.lock.NNN.tmp`, atomically renamed)
-// directly under the root, so a file-level RW bind of `bun.lock` alone is
-// insufficient — Bun needs DIRECTORY write to create its temp file. The default
-// ro-root + narrow carve-out model can't express that, so this widens the root
-// to RW for that command class only.
+// A single RW bind of the project root used for trusted/owner compatibility.
+// Model-driven package installs are denied before sandbox construction; this
+// preserves ordinary root writes without granting lifecycle-script persistence.
 //
 // CRITICAL ordering: unlike `writable` (rendered AFTER masks), `writableRoot`
 // renders BEFORE masks so the broad RW root does not re-expose secrets. With
 // last-op-wins the chain is: ro-bind root → writableRoot (RW root) → masks
-// (re-hide .env/secrets.json/private dirs) → protected (re-RO node_modules/typeclaw,
-// packages, .agents/skills, .git/hooks, .git/config). Everything stays hidden or
-// EROFS except the dirs a dependency install legitimately needs to write.
+// (re-hide .env/secrets.json/private dirs) → protected (.git/hooks/.git/config).
 export type SandboxWritableRootPolicy = {
   dir: string
-}
-
-// Paths whose CREATION must be blocked under a writable root, rendered as
-// `--ro-bind /dev/null <path>`. Used by the package-install path for the
-// semantically-guarded managed files (cron.json / typeclaw.json) when they are
-// ABSENT: the RW root would otherwise let a postinstall lifecycle script create
-// them, bypassing the write/edit-tool guards. Binding /dev/null occupies the
-// path with an empty read-only object (blocking creation) WITHOUT manufacturing
-// a real invalid file on the host FS. Renders after writableRoot, with the
-// protected binds, so last-op-wins keeps the path occupied.
-export type SandboxBlockedCreationPolicy = {
-  files?: string[]
 }
 
 export type SandboxPolicy = {
@@ -140,7 +127,6 @@ export type SandboxPolicy = {
   masks?: SandboxMaskPolicy
   writable?: SandboxWritablePolicy
   protected?: SandboxProtectedPolicy
-  blockedCreation?: SandboxBlockedCreationPolicy
   symlinks?: SandboxSymlinkOp[]
   network?: SandboxNetwork
   env?: SandboxEnvPolicy
@@ -158,7 +144,7 @@ export type SandboxPolicy = {
 //
 // BUN_TMPDIR / BUN_INSTALL both point under /tmp because `--clearenv` strips
 // the host's TMPDIR, and bun refuses to run without a writable scratch dir it
-// can discover: `bunx`, `bun add`, and `bun run <pkg-bin>` abort with
+// can discover: `bunx` and `bun run <pkg-bin>` abort with
 // "Unexpected accessing temporary directory. Please set $BUN_TMPDIR or
 // $BUN_INSTALL". /tmp is always writable inside the sandbox (fresh tmpfs, or
 // the per-session bind that overrides it), so both are safe targets. Without

--- a/src/sandbox/policy.ts
+++ b/src/sandbox/policy.ts
@@ -99,9 +99,9 @@ export type SandboxSymlinkOp = {
   dest: string
 }
 
-// A single RW bind of the project root used for trusted/owner compatibility.
-// Model-driven package installs are denied before sandbox construction; this
-// preserves ordinary root writes without granting lifecycle-script persistence.
+// A single RW bind that preserves ordinary agent-root writes for trusted/owner
+// callers. Masks and protected zones overlay it; writableRoot provides no
+// package-install isolation.
 //
 // CRITICAL ordering: unlike `writable` (rendered AFTER masks), `writableRoot`
 // renders BEFORE masks so the broad RW root does not re-expose secrets. With

--- a/src/sandbox/privileged-runtime.test.ts
+++ b/src/sandbox/privileged-runtime.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { buildSandboxedCommand } from './build'
+import {
+  cleanupPrivilegedSandboxRuntime,
+  resolvePrivilegedSandboxRuntime,
+  verifyPrivilegedSandboxRuntime,
+} from './privileged-runtime'
+
+describe('resolvePrivilegedSandboxRuntime', () => {
+  let root: string
+  let home: string
+  let agentDir: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'tc-privileged-runtime-'))
+    home = path.join(root, 'home')
+    agentDir = path.join(root, 'agent')
+    await mkdir(path.join(home, '.codex'), { recursive: true })
+    await mkdir(path.join(home, '.claude'), { recursive: true })
+    await mkdir(agentDir, { recursive: true })
+    await writeFile(path.join(home, '.codex', 'auth.json'), '{"token":"codex-secret"}')
+    await writeFile(path.join(home, '.codex', 'config.toml'), 'model = "test"')
+    await writeFile(path.join(home, '.claude', 'settings.json'), '{}')
+    await writeFile(path.join(home, '.claude.json'), '{}')
+    await writeFile(path.join(home, '.gitconfig'), '[user]\nname = Test\n')
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  test('ordinary privileged bash receives no credential-bearing config mounts or env', async () => {
+    const gws = path.join(agentDir, 'workspace', '.config', 'gws')
+    const messenger = path.join(agentDir, 'workspace', '.agent-messenger')
+    const runtime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: {
+        GWS_CONFIG_HOME: gws,
+        AGENT_MESSENGER_CONFIG_DIR: messenger,
+        OPENAI_API_KEY: 'must-not-pass',
+      },
+      command: 'cat /tmp/.codex/auth.json',
+    })
+
+    expect(runtime).toEqual({ env: {}, mounts: [] })
+
+    const { argv } = buildSandboxedCommand('cat /tmp/.codex/auth.json', {
+      mounts: runtime.mounts,
+      env: { set: runtime.env },
+    })
+    expect(argv).not.toContain(path.join(home, '.codex'))
+    expect(argv).toContain('--clearenv')
+  })
+
+  test('never mounts reusable Codex auth into a model-driven child', async () => {
+    const runtime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: {},
+      command: 'codex exec status',
+    })
+
+    expect(runtime).toEqual({ env: {}, mounts: [] })
+  })
+
+  test('does not broker a profile for chained or substituted CLI commands', async () => {
+    for (const command of [
+      'codex exec status && cat /tmp/.codex/auth.json',
+      'codex exec "$(cat /tmp/.codex/auth.json)"',
+    ]) {
+      expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).toEqual({
+        env: {},
+        mounts: [],
+      })
+    }
+  })
+
+  test('keeps auth diagnostics executable but supplies no credential profile', async () => {
+    for (const command of [
+      'claude setup-token',
+      'gws auth status',
+      'agent-slack auth status',
+      'agent-slack --account test auth status',
+    ]) {
+      expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).toEqual({
+        env: {},
+        mounts: [],
+      })
+    }
+  })
+
+  test('does not follow a symlinked Codex auth file because Codex profiles are never brokered', async () => {
+    await rm(path.join(home, '.codex', 'auth.json'))
+    await symlink(path.join(home, '.claude.json'), path.join(home, '.codex', 'auth.json'))
+    expect(
+      await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command: 'codex exec status' }),
+    ).toEqual({ env: {}, mounts: [] })
+  })
+
+  test('revalidation fails closed if a mounted sanitized config changes dev/inode', async () => {
+    const runtime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: {},
+      command: 'git status',
+    })
+    const generated = runtime.mounts.find((mount) => mount.type === 'ro-bind')?.source
+    if (generated === undefined) throw new Error('sanitized git config was not mounted')
+    await rm(generated)
+    await writeFile(generated, '[user]\nname = Replaced\n')
+
+    await expect(verifyPrivilegedSandboxRuntime(runtime)).rejects.toThrow(/credential profile/i)
+  })
+
+  test('never brokers GWS or agent-messenger credentials to upload-capable CLIs', async () => {
+    const gws = path.join(agentDir, 'workspace', '.config', 'gws')
+    const messenger = path.join(agentDir, 'workspace', '.agent-messenger')
+    await mkdir(gws, { recursive: true })
+    await mkdir(messenger, { recursive: true })
+    await writeFile(path.join(gws, 'credentials.json'), '{}')
+    await writeFile(path.join(gws, 'token_cache.json'), '{}')
+    await writeFile(path.join(messenger, 'slack-credentials.json'), '{}')
+
+    const gwsRuntime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: { GWS_CONFIG_HOME: gws },
+      command: 'gws drive files list',
+    })
+    expect(gwsRuntime).toEqual({ env: {}, mounts: [] })
+
+    const messengerRuntime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: { AGENT_MESSENGER_CONFIG_DIR: messenger },
+      command: 'agent-slack channel list',
+    })
+    expect(messengerRuntime).toEqual({ env: {}, mounts: [] })
+  })
+
+  test('does not expose git config to an unknown alias command', async () => {
+    expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command: 'git leak' })).toEqual({
+      env: { HOME: agentDir, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_NOSYSTEM: '1' },
+      mounts: [],
+    })
+  })
+
+  test.each(['git push origin HEAD', 'git fetch origin', 'git clone https://example.com/repo.git'])(
+    'isolates global and system config for authenticated command %s',
+    async (command) => {
+      const runtime = await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })
+      expect(runtime.env).toEqual({ HOME: agentDir, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_NOSYSTEM: '1' })
+      expect(runtime.mounts).toEqual([])
+    },
+  )
+
+  test('isolates global and system config for authenticated all-Git chains', async () => {
+    const runtime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      command: 'git clone https://example.com/repo.git && git -C repo fetch origin',
+    })
+
+    expect(runtime.env).toEqual({ HOME: agentDir, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_NOSYSTEM: '1' })
+    expect(runtime.mounts).toEqual([])
+  })
+
+  test('token-bearing quoted Git chains cannot load an executable helper from the session home', async () => {
+    const helper = path.join(root, 'credential-helper.sh')
+    const marker = path.join(root, 'helper-ran')
+    await writeFile(helper, `#!/bin/sh\ntouch '${marker}'\nprintf 'username=x\\npassword=y\\n'\n`)
+    await chmod(helper, 0o700)
+    await writeFile(path.join(home, '.gitconfig'), `[credential]\nhelper = !${helper}\n`)
+    const runtime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: { TYPECLAW_GIT_TOKEN: 'boundary-token-value' },
+      command: "'git' clone https://github.com/acme/widgets.git && 'git' -C widgets fetch origin",
+    })
+
+    expect(runtime.env).toEqual({ HOME: agentDir, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_NOSYSTEM: '1' })
+    const probe = Bun.spawn(['bash', '-c', "printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill"], {
+      env: { ...process.env, HOME: home, ...runtime.env },
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    await probe.exited
+    expect(await Bun.file(marker).exists()).toBe(false)
+  })
+
+  test('mounts only a generated git identity and drops credential helpers, headers, and includes', async () => {
+    await writeFile(
+      path.join(home, '.gitconfig'),
+      '[user]\nname = Test User\nemail = user@example.com\n[credential]\nhelper = !print-secret\n[http]\nextraHeader = Authorization: secret\n[include]\npath = /private/config\n',
+    )
+    const runtime = await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command: 'git status' })
+    const generated = runtime.mounts.find((mount) => mount.type === 'ro-bind')?.source
+    if (generated === undefined) throw new Error('sanitized git config was not mounted')
+    const rendered = await Bun.file(generated).text()
+    expect(rendered).toContain('name = Test User')
+    expect(rendered).toContain('email = user@example.com')
+    expect(rendered).not.toMatch(/credential|extraHeader|include|secret/i)
+    expect(runtime.env.GIT_CONFIG_NOSYSTEM).toBe('1')
+  })
+
+  test('removes every generated identity directory across repeated calls', async () => {
+    const generated: string[] = []
+    for (let i = 0; i < 32; i++) {
+      const runtime = await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command: 'git status' })
+      const source = runtime.mounts.find((mount) => mount.type === 'ro-bind')?.source
+      if (source === undefined) throw new Error('sanitized git config was not mounted')
+      generated.push(source)
+      await cleanupPrivilegedSandboxRuntime(runtime)
+    }
+
+    expect(await Promise.all(generated.map((source) => Bun.file(source).exists()))).toEqual(
+      Array.from({ length: generated.length }, () => false),
+    )
+  })
+})

--- a/src/sandbox/privileged-runtime.ts
+++ b/src/sandbox/privileged-runtime.ts
@@ -1,0 +1,255 @@
+import { chmod, lstat, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { SandboxPolicyError } from './errors'
+import type { SandboxMount } from './policy'
+
+const SAFE_GIT_SUBCOMMANDS = new Set([
+  'add',
+  'branch',
+  'checkout',
+  'cherry-pick',
+  'commit',
+  'diff',
+  'log',
+  'merge',
+  'rebase',
+  'remote',
+  'reset',
+  'restore',
+  'rev-parse',
+  'show',
+  'status',
+  'switch',
+  'symbolic-ref',
+  'tag',
+  'worktree',
+])
+
+const SHELL_ACTIVE = new Set(['|', ';', '&', '\n', '\r', '(', ')', '{', '}', '<', '>', '`', '$', '\\'])
+
+export type PrivilegedSandboxRuntime = {
+  env: Record<string, string>
+  mounts: SandboxMount[]
+}
+
+type StandaloneCommand = { executable: string; args: string[] }
+type MountedIdentity = { birthtimeNs: bigint; ctimeNs: bigint; dev: bigint; ino: bigint }
+const mountedIdentities = new WeakMap<PrivilegedSandboxRuntime, Map<string, MountedIdentity>>()
+const cleanupDirs = new WeakMap<PrivilegedSandboxRuntime, Set<string>>()
+
+export async function resolvePrivilegedSandboxRuntime(options: {
+  agentDir: string
+  command: string
+  env?: NodeJS.ProcessEnv
+  homeDir?: string
+}): Promise<PrivilegedSandboxRuntime> {
+  const runtime = emptyRuntime()
+  // TYPECLAW_GIT_TOKEN is set only after the auth analyzer accepts a Git command.
+  // Trust that decision rather than reparsing its command with a less capable
+  // detector (notably, the analyzer accepts quoted `git` executables).
+  if (options.env?.TYPECLAW_GIT_TOKEN !== undefined || containsGitInvocation(options.command)) {
+    runtime.env.HOME = options.agentDir
+    runtime.env.GIT_CONFIG_GLOBAL = '/dev/null'
+    runtime.env.GIT_CONFIG_NOSYSTEM = '1'
+  }
+  const parsed = parseStandaloneCommand(options.command)
+  if (parsed === null) return runtime
+
+  const homeDir = options.homeDir ?? homedir()
+  const executable = unwrapBunx(parsed)
+  if (executable === null) return runtime
+
+  // These CLIs can print or upload arbitrary files. Supplying their reusable
+  // auth profile to a model-controlled child would therefore make the CLI a
+  // confused deputy even when the outer shell is syntactically standalone.
+  if (
+    executable.executable === 'gws' ||
+    executable.executable === 'codex' ||
+    executable.executable === 'claude' ||
+    executable.executable.startsWith('agent-')
+  ) {
+    return runtime
+  }
+
+  if (executable.executable === 'git') {
+    runtime.env.GIT_CONFIG_GLOBAL = '/dev/null'
+    runtime.env.GIT_CONFIG_NOSYSTEM = '1'
+    const subcommand = gitSubcommand(executable.args)
+    if (subcommand === null) return runtime
+    rejectNamedSubcommand(subcommand, new Set(['config', 'credential', 'credential-cache', 'credential-store']))
+    if (!SAFE_GIT_SUBCOMMANDS.has(subcommand)) return runtime
+    try {
+      await addSanitizedGitIdentity(runtime, path.join(homeDir, '.gitconfig'))
+    } catch (error) {
+      await cleanupPrivilegedSandboxRuntime(runtime)
+      throw error
+    }
+  }
+
+  return runtime
+}
+
+function containsGitInvocation(command: string): boolean {
+  return /(^|[;&|]\s*)git(?:\s|$)/.test(command.trim())
+}
+
+export async function verifyPrivilegedSandboxRuntime(runtime: PrivilegedSandboxRuntime): Promise<void> {
+  const identities = mountedIdentities.get(runtime) ?? new Map()
+  for (const mount of runtime.mounts) {
+    if (mount.type !== 'ro-bind') continue
+    const safe = await lstat(mount.source, { bigint: true })
+      .then(async (stats) => {
+        if (stats.isSymbolicLink()) return false
+        const expected = identities.get(mount.source)
+        return (
+          stats.isFile() &&
+          stats.nlink === 1n &&
+          expected !== undefined &&
+          stats.dev === expected.dev &&
+          stats.ino === expected.ino &&
+          stats.ctimeNs === expected.ctimeNs &&
+          stats.birthtimeNs === expected.birthtimeNs
+        )
+      })
+      .catch(() => false)
+    if (!safe) {
+      throw new SandboxPolicyError(`credential profile changed after validation: ${mount.source}. Refusing to run.`)
+    }
+  }
+}
+
+export async function cleanupPrivilegedSandboxRuntime(runtime: PrivilegedSandboxRuntime): Promise<void> {
+  const dirs = cleanupDirs.get(runtime) ?? new Set()
+  const outcomes = await Promise.allSettled([...dirs].map((dir) => rm(dir, { recursive: true, force: true })))
+  dirs.clear()
+  const failed = outcomes.find((outcome) => outcome.status === 'rejected')
+  if (failed?.status === 'rejected') throw failed.reason
+}
+
+function emptyRuntime(): PrivilegedSandboxRuntime {
+  const runtime = { env: {}, mounts: [] }
+  mountedIdentities.set(runtime, new Map())
+  cleanupDirs.set(runtime, new Set())
+  return runtime
+}
+
+function unwrapBunx(command: StandaloneCommand): StandaloneCommand | null {
+  if (command.executable !== 'bunx') return command
+  const args = [...command.args]
+  if (args[0] === '--bun') args.shift()
+  const executable = args.shift()
+  return executable === undefined ? null : { executable, args }
+}
+
+function rejectNamedSubcommand(subcommand: string, denied: ReadonlySet<string>): void {
+  if (denied.has(subcommand)) {
+    throw new SandboxPolicyError(
+      `credential or token management command \`${subcommand}\` is unavailable to model-driven bash; use a host-side login or redacted status command instead.`,
+    )
+  }
+}
+
+function gitSubcommand(args: readonly string[]): string | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (arg === '-C') {
+      i += 1
+      continue
+    }
+    if (arg === '-c' || arg === '--config-env' || arg.startsWith('--config-env=')) return null
+    if (arg.startsWith('-')) continue
+    return arg
+  }
+  return null
+}
+
+async function addSanitizedGitIdentity(runtime: PrivilegedSandboxRuntime, source: string): Promise<void> {
+  const raw = await readFile(source, 'utf8').catch((error) => {
+    if (isNotFoundError(error)) return ''
+    throw error
+  })
+  if (raw === '') return
+  const values = parseGitUserIdentity(raw)
+  if (values.length === 0) return
+  const dir = await mkdtemp(path.join(tmpdir(), 'typeclaw-git-identity-'))
+  cleanupDirs.get(runtime)?.add(dir)
+  const generated = path.join(dir, 'config')
+  await writeFile(generated, `[user]\n${values.map(([key, value]) => `\t${key} = ${value}`).join('\n')}\n`, {
+    flag: 'wx',
+  })
+  await chmod(generated, 0o600)
+  const stats = await lstat(generated, { bigint: true })
+  mountedIdentities.get(runtime)?.set(generated, {
+    birthtimeNs: stats.birthtimeNs,
+    ctimeNs: stats.ctimeNs,
+    dev: stats.dev,
+    ino: stats.ino,
+  })
+  runtime.mounts.push({ type: 'ro-bind', source: generated, dest: '/tmp/.gitconfig' })
+  runtime.env.GIT_CONFIG_GLOBAL = '/tmp/.gitconfig'
+}
+
+function parseGitUserIdentity(raw: string): Array<['name' | 'email', string]> {
+  const values = new Map<'name' | 'email', string>()
+  let inUser = false
+  for (const line of raw.split(/\r?\n/)) {
+    const section = line.match(/^\s*\[([^\]]+)]\s*$/)
+    if (section !== null) {
+      inUser = section[1]?.trim().toLocaleLowerCase() === 'user'
+      continue
+    }
+    if (!inUser) continue
+    const entry = line.match(/^\s*(name|email)\s*=\s*(.*?)\s*$/i)
+    if (entry === null || entry[2] === undefined) continue
+    const key = entry[1]?.toLocaleLowerCase() as 'name' | 'email'
+    const value = entry[2].replaceAll('\r', '').replaceAll('\n', '').replaceAll('\0', '')
+    if (value !== '') values.set(key, value)
+  }
+  return [...values.entries()]
+}
+
+function parseStandaloneCommand(command: string): StandaloneCommand | null {
+  const words: string[] = []
+  let word = ''
+  let quote: "'" | '"' | null = null
+  let active = false
+  for (const ch of command.trim()) {
+    if (quote === "'") {
+      if (ch === "'") quote = null
+      else word += ch
+      continue
+    }
+    if (quote === '"') {
+      if (ch === '"') quote = null
+      else if (ch === '$' || ch === '`' || ch === '\\') return null
+      else word += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      active = true
+      continue
+    }
+    if (SHELL_ACTIVE.has(ch)) return null
+    if (/\s/.test(ch)) {
+      if (active) {
+        words.push(word)
+        word = ''
+        active = false
+      }
+      continue
+    }
+    word += ch
+    active = true
+  }
+  if (quote !== null) return null
+  if (active) words.push(word)
+  const executable = words.shift()
+  return executable === undefined ? null : { executable, args: words }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}

--- a/src/sandbox/writable-zones.test.ts
+++ b/src/sandbox/writable-zones.test.ts
@@ -4,12 +4,8 @@ import { lstat, mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/pro
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import {
-  resolvePackageInstallZones,
-  resolveProtectedZones,
-  resolveWritableZones,
-  subtractMasked,
-} from './writable-zones'
+import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from './canonical-secrets'
+import { resolveProtectedZones, resolveWritableZones, subtractMasked } from './writable-zones'
 
 let agentDir: string
 
@@ -201,19 +197,26 @@ describe('resolveWritableZones', () => {
       expect(dirs).not.toContain(join(agentDir, '../escape'))
     })
 
-    test.each(['.git', '.env', 'secrets.json', 'sessions', 'memory', '.typeclaw', 'node_modules'])(
-      'drops the security-sensitive root %p even when it exists',
-      async (root) => {
-        await mkdir(join(agentDir, root), { recursive: true })
+    test.each([
+      ...new Set([
+        '.git',
+        ...CANONICAL_AGENT_SECRET_FILES,
+        ...CANONICAL_AGENT_SECRET_DIRS,
+        'sessions',
+        'memory',
+        '.typeclaw',
+        'node_modules',
+      ]),
+    ])('drops the security-sensitive root %p even when it exists', async (root) => {
+      await mkdir(join(agentDir, root), { recursive: true })
 
-        const { dirs } = await resolveWritableZones(agentDir, [root])
+      const { dirs } = await resolveWritableZones(agentDir, [root])
 
-        // .git is a built-in writable zone, so it is present via WRITABLE_DIRS —
-        // but the configured path must not be what re-adds it. The other roots
-        // must be absent entirely.
-        if (root !== '.git') expect(dirs).not.toContain(join(agentDir, root))
-      },
-    )
+      // .git is a built-in writable zone, so it is present via WRITABLE_DIRS —
+      // but the configured path must not be what re-adds it. The other roots
+      // must be absent entirely.
+      if (root !== '.git') expect(dirs).not.toContain(join(agentDir, root))
+    })
 
     test('drops a configured path nested under a forbidden root', async () => {
       await mkdir(join(agentDir, 'sessions', 'sub'), { recursive: true })
@@ -250,6 +253,32 @@ describe('resolveWritableZones', () => {
 })
 
 describe('resolveProtectedZones', () => {
+  test('protects an existing node_modules directory without requiring a Git repository', async () => {
+    await mkdir(join(agentDir, 'node_modules'))
+
+    const { dirs, files } = await resolveProtectedZones(agentDir)
+
+    expect(dirs).toEqual([join(agentDir, 'node_modules')])
+    expect(files).toEqual([])
+  })
+
+  test('does not create node_modules when it is absent', async () => {
+    await resolveProtectedZones(agentDir)
+
+    expect(existsSync(join(agentDir, 'node_modules'))).toBe(false)
+  })
+
+  test('rejects a symlinked node_modules instead of leaving executable dependencies writable', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'typeclaw-node-modules-outside-'))
+    try {
+      await symlink(outside, join(agentDir, 'node_modules'))
+
+      await expect(resolveProtectedZones(agentDir)).rejects.toThrow(/symlink/i)
+    } finally {
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+
   test('re-protects .git/hooks and .git/config when present', async () => {
     await mkdir(join(agentDir, '.git', 'hooks'), { recursive: true })
     await writeFile(join(agentDir, '.git', 'config'), '[core]\n')
@@ -294,6 +323,73 @@ describe('resolveProtectedZones', () => {
     expect((await lstat(join(agentDir, 'workspace/hooks'))).isDirectory()).toBe(true)
   })
 
+  test('uses Git parsing for quoted, escaped, and commented hooksPath values', async () => {
+    await mkdir(join(agentDir, '.git'), { recursive: true })
+    await writeFile(
+      join(agentDir, '.git', 'config'),
+      '[core]\n\t# hooksPath = workspace/ignored\n\thooksPath = "workspace/hook\\\\dir"\n',
+    )
+
+    const { dirs } = await resolveProtectedZones(agentDir)
+
+    expect(dirs).toContain(join(agentDir, 'workspace/hook\\dir'))
+  })
+
+  test('protects agent-local config includes that could later redirect core.hooksPath', async () => {
+    await mkdir(join(agentDir, '.git'), { recursive: true })
+    await mkdir(join(agentDir, 'workspace'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'config'), '[include]\n\tpath = ../workspace/git.inc\n')
+    await writeFile(join(agentDir, 'workspace', 'git.inc'), '[core]\n\thooksPath = workspace/hooks\n')
+
+    const { dirs, files } = await resolveProtectedZones(agentDir)
+
+    expect(files).toContain(join(agentDir, 'workspace/git.inc'))
+    expect(dirs).toContain(join(agentDir, 'workspace/hooks'))
+  })
+
+  test('honors matching includeIf config through Git semantics', async () => {
+    await mkdir(join(agentDir, '.git', 'objects'), { recursive: true })
+    await mkdir(join(agentDir, '.git', 'refs', 'heads'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'HEAD'), 'ref: refs/heads/main\n')
+    await mkdir(join(agentDir, 'workspace'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'config'), '[includeIf "gitdir:**"]\n\tpath = ../workspace/git.inc\n')
+    await writeFile(join(agentDir, 'workspace', 'git.inc'), '[core]\n\thooksPath = workspace/conditional-hooks\n')
+
+    const { dirs, files } = await resolveProtectedZones(agentDir)
+
+    expect(files).toContain(join(agentDir, 'workspace/git.inc'))
+    expect(dirs).toContain(join(agentDir, 'workspace/conditional-hooks'))
+  })
+
+  test('protects tilde-expanded and nested agent-local includes', async () => {
+    await mkdir(join(agentDir, '.git'), { recursive: true })
+    await mkdir(join(agentDir, 'workspace'), { recursive: true })
+    await writeFile(join(agentDir, '.git', 'config'), '[include]\n\tpath = ~/workspace/first.inc\n')
+    await writeFile(join(agentDir, 'workspace', 'first.inc'), '[include]\n\tpath = nested.inc\n')
+    await writeFile(join(agentDir, 'workspace', 'nested.inc'), '[core]\n\thooksPath = workspace/nested-hooks\n')
+
+    const { dirs, files } = await resolveProtectedZones(agentDir)
+
+    expect(files).toContain(join(agentDir, 'workspace/first.inc'))
+    expect(files).toContain(join(agentDir, 'workspace/nested.inc'))
+    expect(dirs).toContain(join(agentDir, 'workspace/nested-hooks'))
+  })
+
+  test('protects Git effective hooksPath when the root overrides an included value', async () => {
+    await mkdir(join(agentDir, '.git'), { recursive: true })
+    await mkdir(join(agentDir, 'workspace'), { recursive: true })
+    await writeFile(
+      join(agentDir, '.git', 'config'),
+      '[include]\n\tpath = ../workspace/git.inc\n[core]\n\thooksPath = workspace/final-hooks\n',
+    )
+    await writeFile(join(agentDir, 'workspace', 'git.inc'), '[core]\n\thooksPath = workspace/stale-hooks\n')
+
+    const { dirs } = await resolveProtectedZones(agentDir)
+
+    expect(dirs).toContain(join(agentDir, 'workspace/final-hooks'))
+    expect(dirs).not.toContain(join(agentDir, 'workspace/stale-hooks'))
+  })
+
   test('ignores a core.hooksPath that resolves outside the agent dir', async () => {
     await mkdir(join(agentDir, '.git'), { recursive: true })
     await writeFile(join(agentDir, '.git', 'config'), '[core]\n\thooksPath = /etc\n')
@@ -317,164 +413,58 @@ describe('resolveProtectedZones', () => {
     expect(filtered.dirs).not.toContain(join(agentDir, 'workspace/hooks'))
     expect(filtered.dirs).toContain(join(agentDir, '.git/hooks'))
   })
+
+  test('resolves a worktree .git file and protects the real gitdir controls', async () => {
+    const commonDir = await mkdtemp(join(tmpdir(), 'typeclaw-common-git-'))
+    try {
+      const gitDir = join(commonDir, 'worktrees', 'agent')
+      await mkdir(gitDir, { recursive: true })
+      await writeFile(join(gitDir, 'commondir'), '../..\n')
+      await writeFile(join(agentDir, '.git'), `gitdir: ${gitDir}\n`)
+      await writeFile(join(commonDir, 'config'), '[core]\n\thooksPath = workspace/hooks\n')
+
+      const { dirs, files } = await resolveProtectedZones(agentDir)
+
+      expect(dirs).toContain(join(commonDir, 'hooks'))
+      expect(dirs).toContain(join(agentDir, 'workspace/hooks'))
+      expect(files).toContain(join(agentDir, '.git'))
+      expect(files).toContain(join(commonDir, 'config'))
+    } finally {
+      await rm(commonDir, { recursive: true, force: true })
+    }
+  })
 })
 
-describe('resolvePackageInstallZones', () => {
-  test('returns the agent root as the RW root and pre-creates node_modules', async () => {
-    const zones = await resolvePackageInstallZones(agentDir)
-
-    expect(zones.root).toBe(agentDir)
-    expect((await stat(join(agentDir, 'node_modules'))).isDirectory()).toBe(true)
+describe('resolveWritableZones package lifecycle boundary', () => {
+  test('does not create node_modules while resolving ordinary writable zones', async () => {
+    await resolveWritableZones(agentDir)
+    expect(existsSync(join(agentDir, 'node_modules'))).toBe(false)
   })
 
-  // SECURITY: the allowlist-inversion must fail closed — every root entry the
-  // unsandboxed runtime may read/execute is RO, not just a known executable set.
-  test('RO-protects runtime source trees (src/, scripts/) so lifecycle scripts cannot overwrite them', async () => {
-    await mkdir(join(agentDir, 'src'))
-    await mkdir(join(agentDir, 'scripts'))
+  test.each(['node_modules', 'node_modules/typeclaw', 'src', 'scripts', 'packages'])(
+    'does not expose executable dependency path %s as a normal writable zone',
+    async (relative) => {
+      await mkdir(join(agentDir, relative), { recursive: true })
+      const zones = await resolveWritableZones(agentDir)
+      expect(zones.dirs).not.toContain(join(agentDir, relative))
+    },
+  )
 
-    const { protected: prot } = await resolvePackageInstallZones(agentDir)
+  test.each(['bun.lock', 'cron.json', 'typeclaw.json'])(
+    'does not expose lifecycle/managed root file %s as a normal writable file',
+    async (relative) => {
+      await writeFile(join(agentDir, relative), 'x')
+      const zones = await resolveWritableZones(agentDir)
+      expect(zones.files).not.toContain(join(agentDir, relative))
+    },
+  )
 
-    expect(prot.dirs).toContain(join(agentDir, 'src'))
-    expect(prot.dirs).toContain(join(agentDir, 'scripts'))
-  })
-
-  test('RO-protects prompt-source and config root files (no bun-add write need, prompt-poison vector)', async () => {
-    for (const f of ['AGENTS.md', 'SOUL.md', 'IDENTITY.md', 'USER.md', 'cron.json', 'typeclaw.json']) {
-      await writeFile(join(agentDir, f), 'x')
-    }
-
-    const { protected: prot } = await resolvePackageInstallZones(agentDir)
-
-    for (const f of ['AGENTS.md', 'SOUL.md', 'IDENTITY.md', 'USER.md', 'cron.json', 'typeclaw.json']) {
-      expect(prot.files).toContain(join(agentDir, f))
-    }
-  })
-
-  test('RO-protects an arbitrary unanticipated root entry (covered by readdir, no hardcoded list)', async () => {
-    await mkdir(join(agentDir, 'some-new-dir'))
-    await writeFile(join(agentDir, 'evil.sh'), '#!/bin/sh')
-
-    const { protected: prot } = await resolvePackageInstallZones(agentDir)
-
-    expect(prot.dirs).toContain(join(agentDir, 'some-new-dir'))
-    expect(prot.files).toContain(join(agentDir, 'evil.sh'))
-  })
-
-  test('RO-protects the whole .git (bun add never needs git; closes hook/config escalation)', async () => {
-    await mkdir(join(agentDir, '.git'))
-
-    const { protected: prot } = await resolvePackageInstallZones(agentDir)
-
-    expect(prot.dirs).toContain(join(agentDir, '.git'))
-  })
-
-  test('RO-protects node_modules/typeclaw (the live runtime) while node_modules stays writable', async () => {
-    await mkdir(join(agentDir, 'node_modules', 'typeclaw'), { recursive: true })
-
-    const { protected: prot } = await resolvePackageInstallZones(agentDir)
-
-    expect(prot.dirs).toContain(join(agentDir, 'node_modules/typeclaw'))
-    expect(prot.dirs).not.toContain(join(agentDir, 'node_modules'))
-  })
-
-  test('keeps the writable allowlist OUT of the protected set (node_modules, package.json, bun.lock, workspace, public, mounts)', async () => {
-    for (const d of ['workspace', 'public', 'mounts']) await mkdir(join(agentDir, d))
-    for (const f of ['package.json', 'bun.lock']) await writeFile(join(agentDir, f), '{}')
-
-    const { protected: prot } = await resolvePackageInstallZones(agentDir)
-
-    for (const d of ['node_modules', 'workspace', 'public', 'mounts']) {
-      expect(prot.dirs).not.toContain(join(agentDir, d))
-    }
-    for (const f of ['package.json', 'bun.lock']) {
-      expect(prot.files).not.toContain(join(agentDir, f))
-    }
-  })
-
-  test('rejects a symlinked agent root (RW root would follow it outside the jail)', async () => {
-    const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
-    const linked = join(outside, 'link')
-    try {
-      await symlink(outside, linked)
-
-      await expect(resolvePackageInstallZones(linked)).rejects.toThrow(/symlink/i)
-    } finally {
-      await rm(outside, { recursive: true, force: true })
-    }
-  })
-
-  test('rejects a symlinked node_modules / package.json / bun.lock', async () => {
-    const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
-    try {
-      await mkdir(join(outside, 'real-nm'))
-      await symlink(join(outside, 'real-nm'), join(agentDir, 'node_modules'))
-
-      await expect(resolvePackageInstallZones(agentDir)).rejects.toThrow(/symlink/i)
-    } finally {
-      await rm(outside, { recursive: true, force: true })
-    }
-  })
-
-  test('skips a symlinked root entry rather than RO-binding it (an RO bind would follow it outside)', async () => {
-    const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
-    try {
-      await symlink(outside, join(agentDir, 'evil-link'))
-
-      const { protected: prot } = await resolvePackageInstallZones(agentDir)
-
-      expect(prot.dirs).not.toContain(join(agentDir, 'evil-link'))
-      expect(prot.files).not.toContain(join(agentDir, 'evil-link'))
-    } finally {
-      await rm(outside, { recursive: true, force: true })
-    }
-  })
-
-  // SECURITY: the RW package-install root would let a postinstall lifecycle
-  // script CREATE an absent managed file (cron.json/typeclaw.json), bypassing the
-  // write/edit-tool guards. Absent managed files must land in blockedCreation
-  // (rendered as --ro-bind /dev/null) so their path is occupied.
-  test('blocks creation of ABSENT managed files (cron.json, typeclaw.json)', async () => {
-    const { blockedCreation, protected: prot } = await resolvePackageInstallZones(agentDir)
-
-    expect(blockedCreation).toContain(join(agentDir, 'cron.json'))
-    expect(blockedCreation).toContain(join(agentDir, 'typeclaw.json'))
-    // Absent files are not (and cannot be) RO-bound — /dev/null occupies them.
-    expect(prot.files).not.toContain(join(agentDir, 'cron.json'))
-    expect(prot.files).not.toContain(join(agentDir, 'typeclaw.json'))
-  })
-
-  test('does NOT block-create a PRESENT managed file (it is RO-bound with real content instead)', async () => {
-    await writeFile(join(agentDir, 'cron.json'), '{"jobs":[]}')
-
-    const { blockedCreation, protected: prot } = await resolvePackageInstallZones(agentDir)
-
-    expect(blockedCreation).not.toContain(join(agentDir, 'cron.json'))
-    expect(prot.files).toContain(join(agentDir, 'cron.json'))
-    // typeclaw.json is still absent, so it stays blocked.
-    expect(blockedCreation).toContain(join(agentDir, 'typeclaw.json'))
-  })
-
-  test('blocks a managed file that exists only as a symlink (an RO bind would follow it out)', async () => {
-    const outside = await mkdtemp(join(tmpdir(), 'typeclaw-outside-'))
-    try {
-      await writeFile(join(outside, 'real.json'), '{}')
-      await symlink(join(outside, 'real.json'), join(agentDir, 'cron.json'))
-
-      const { blockedCreation, protected: prot } = await resolvePackageInstallZones(agentDir)
-
-      expect(blockedCreation).toContain(join(agentDir, 'cron.json'))
-      expect(prot.files).not.toContain(join(agentDir, 'cron.json'))
-    } finally {
-      await rm(outside, { recursive: true, force: true })
-    }
-  })
-
-  test('does not leave an empty placeholder on the real FS for an absent managed file', async () => {
-    await resolvePackageInstallZones(agentDir)
-
-    expect(existsSync(join(agentDir, 'cron.json'))).toBe(false)
-    expect(existsSync(join(agentDir, 'typeclaw.json'))).toBe(false)
+  test('retains ordinary non-install scratch and manifest writes', async () => {
+    for (const dir of ['workspace', 'public', 'mounts']) await mkdir(join(agentDir, dir))
+    await writeFile(join(agentDir, 'package.json'), '{}')
+    const zones = await resolveWritableZones(agentDir)
+    expect(zones.dirs).toEqual(expect.arrayContaining(['workspace', 'public', 'mounts'].map((d) => join(agentDir, d))))
+    expect(zones.files).toContain(join(agentDir, 'package.json'))
   })
 })
 

--- a/src/sandbox/writable-zones.ts
+++ b/src/sandbox/writable-zones.ts
@@ -1,5 +1,11 @@
-import { lstat, mkdir, readdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
 import path, { isAbsolute, join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from './canonical-secrets'
+
+const execFileAsync = promisify(execFile)
 
 export type WritableZones = {
   dirs: string[]
@@ -37,7 +43,7 @@ const WRITABLE_DIRS = ['workspace', 'public', 'mounts', '.git'] as const
 
 // SECURITY: configured writable paths (`sandbox.writablePaths`) may NOT resolve
 // onto these. `.git` carries the hook/config escalation surface; `.env` and
-// `secrets.json` are the credential files; `sessions`/`memory` are the agent's
+// `secrets.json`/`auth.json` are credential files; `sessions`/`memory` are the agent's
 // private surface (masked from low-trust roles by hidden-paths); `.typeclaw`
 // holds system-managed home persistence; `node_modules` is executable
 // dependency code. Granting blanket RW to any of these via config would defeat
@@ -46,16 +52,13 @@ const WRITABLE_DIRS = ['workspace', 'public', 'mounts', '.git'] as const
 // whole tree erases the read-only confinement wholesale.
 const FORBIDDEN_WRITABLE_ROOTS = [
   '.git',
-  '.env',
-  'secrets.json',
+  ...CANONICAL_AGENT_SECRET_FILES,
   'sessions',
   'memory',
   '.typeclaw',
+  ...CANONICAL_AGENT_SECRET_DIRS,
   'node_modules',
 ] as const
-
-const PROTECTED_GIT_DIRS = ['.git/hooks'] as const
-const PROTECTED_GIT_FILES = ['.git/config'] as const
 
 // Bash may EDIT these when present; creating a MISSING root file goes through
 // write/edit (bwrap cannot RW-bind a non-existent source without pre-creating it).
@@ -69,8 +72,8 @@ const PROTECTED_GIT_FILES = ['.git/config'] as const
 // this list forces every mutation of a guarded file through the one guarded path
 // (the write/edit tool), so a managed file has exactly one mutation boundary.
 // `package.json` stays writable: it is NOT a semantically-guarded managed file
-// (only cron.json/typeclaw.json are), and `bun add`/manual dep edits legitimately
-// touch it from bash.
+// (only cron.json/typeclaw.json are), and ordinary trusted/manual edits remain
+// supported.
 const WRITABLE_ROOT_FILES = ['AGENTS.md', 'IDENTITY.md', 'SOUL.md', 'USER.md', 'package.json'] as const
 
 // SECURITY: the symlink rejection is load-bearing. An RW bind follows symlinks,
@@ -153,115 +156,6 @@ function dedupe(values: string[]): string[] {
   return [...new Set(values)]
 }
 
-export type PackageInstallZones = {
-  root: string
-  protected: ProtectedZones
-  // Guarded managed files that are ABSENT at jail-build time. The RW package-
-  // install root would otherwise let a `bun install` postinstall lifecycle
-  // script CREATE them (a guard bypass — see the SECURITY note on
-  // MANAGED_ROOT_FILES). Rendered as `--ro-bind /dev/null <path>` so the path is
-  // occupied by an empty read-only object that blocks creation, without
-  // manufacturing a real (invalid) file on the host FS the way the secret-mask
-  // placeholder pattern would. Present managed files go in `protected.files`.
-  blockedCreation: string[]
-}
-
-// SECURITY: the semantically-guarded managed files. They are gated by the
-// managedConfig / cronPromotion guards (write/edit tools only), so bash must
-// never be able to write OR create them. The normal jail already excludes them
-// from WRITABLE_ROOT_FILES; the package-install RW root needs the extra step of
-// blocking their CREATION when absent (see PackageInstallZones.blockedCreation).
-const MANAGED_ROOT_FILES = ['cron.json', 'typeclaw.json'] as const
-
-// SECURITY: the package-install RW root is governed by an ALLOWLIST, not a
-// denylist. `bun add` writes exactly these and nothing else: `node_modules/`
-// (deps), `package.json` + `bun.lock` (manifest + lockfile, plus the temp
-// lockfile created in the root DIR). The scratch zones (`workspace`, `public`,
-// `mounts`) stay writable to match the normal jail. EVERY other existing root
-// entry is RO-bound, so a denylist of "executable/runtime-sensitive" paths is
-// not needed — it would be unbounded (any file the unsandboxed runtime reads or
-// execs, including `src/`/`scripts/` in dev-mode agents where typeclaw is a
-// file:/link: dep, the agent's own lifecycle scripts, and prompt-source files)
-// and fails OPEN for any root entry not yet listed. An allowlist fails CLOSED.
-const PACKAGE_INSTALL_WRITABLE_DIRS = ['node_modules', 'workspace', 'public', 'mounts'] as const
-const PACKAGE_INSTALL_WRITABLE_FILES = ['package.json', 'bun.lock'] as const
-
-// Resolves the jail layout for a recognized standalone dependency install
-// (`bun add` / `bun install`). The RW root lets bun create node_modules/ and its
-// temp lockfile (`bun.lock.NNN.tmp`, renamed) — a file-level bind of `bun.lock`
-// alone cannot, since the temp file needs DIRECTORY write. Pre-creates an empty
-// node_modules/ so the dir exists before the RW root bind. Then RO-binds every
-// EXISTING root entry not in the writable allowlist (readdir enumeration, so a
-// new file like `src/` or a planted `cron.json` is covered without a hardcoded
-// list), plus `node_modules/typeclaw` (the live/symlinked runtime, nested under
-// the writable node_modules) and the whole `.git` (a `bun add` never needs git,
-// so RO-binding it wholesale is simpler and safer than the hooks/config carve-out
-// — it closes the hook / core.hooksPath escalation by construction).
-//
-// SECURITY: rejects a symlink at agentDir, at any install-touched path
-// (node_modules, package.json, bun.lock), and at every RO-bind source — an RW
-// root or an RO bind that follows a symlink would write/read outside the jail.
-// The secret/private masks render AFTER this protected set (subtractMasked in
-// applyBashSandbox drops any protected entry a mask already hides), so .env /
-// secrets.json / memory / sessions stay hidden, not merely RO.
-export async function resolvePackageInstallZones(agentDir: string): Promise<PackageInstallZones> {
-  await assertNotSymlink(agentDir)
-  await mkdir(join(agentDir, 'node_modules'), { recursive: true })
-  for (const rel of ['node_modules', ...PACKAGE_INSTALL_WRITABLE_FILES] as const) {
-    const target = join(agentDir, rel)
-    if (await exists(target)) await assertNotSymlink(target)
-  }
-
-  const writable = new Set<string>([...PACKAGE_INSTALL_WRITABLE_DIRS, ...PACKAGE_INSTALL_WRITABLE_FILES])
-  const dirs: string[] = []
-  const files: string[] = []
-  for (const entry of await readdir(agentDir, { withFileTypes: true })) {
-    if (writable.has(entry.name)) continue
-    // A symlinked root entry is skipped, not RO-bound: an RO bind follows it to
-    // an outside target. Skipping leaves it under the RW root — but it is the
-    // agent's OWN symlink under its OWN root, contained by the agent-folder bind
-    // and the always-on kernel invariants, the same residual the default jail
-    // accepts for symlinks pointing outside /agent.
-    if (entry.isSymbolicLink()) continue
-    const target = join(agentDir, entry.name)
-    if (entry.isDirectory()) dirs.push(target)
-    else if (entry.isFile()) files.push(target)
-  }
-
-  // node_modules itself is writable (deps land there), but the runtime under it
-  // must not be — RO-bind it nested, last-op-wins over the writable node_modules.
-  const runtime = join(agentDir, 'node_modules', 'typeclaw')
-  if (await isRealEntry(runtime, 'dir')) dirs.push(runtime)
-
-  // Guarded managed files: a PRESENT real one is already RO-bound by the readdir
-  // loop above (it is not in the writable set). The gap is a managed file ABSENT
-  // at jail-build time — readdir never sees it, so nothing occupies its path and
-  // a postinstall script could CREATE it under the RW root. Block that path with
-  // `--ro-bind /dev/null`. A managed file that exists as a SYMLINK is also blocked
-  // here rather than RO-bound (the readdir loop skipped it, and an RO bind would
-  // follow it out of the jail) — occupying the path with /dev/null is safe.
-  const blockedCreation: string[] = []
-  for (const name of MANAGED_ROOT_FILES) {
-    const target = join(agentDir, name)
-    if (!(await isRealEntry(target, 'file'))) blockedCreation.push(target)
-  }
-
-  return {
-    root: agentDir,
-    protected: { dirs: dedupe(dirs), files: dedupe(files) },
-    blockedCreation: dedupe(blockedCreation),
-  }
-}
-
-async function exists(target: string): Promise<boolean> {
-  try {
-    await lstat(target)
-    return true
-  } catch {
-    return false
-  }
-}
-
 // Read-only re-protections rendered on top of the writable .git bind. Unlike
 // the writable resolvers, this MUST NOT drop absent entries: .git is writable,
 // so a path absent at jail-build time would otherwise be CREATED by sandboxed
@@ -276,20 +170,148 @@ async function exists(target: string): Promise<boolean> {
 // the .git/hooks RO-bind alone would not cover it, so that dir is protected too.
 export async function resolveProtectedZones(agentDir: string): Promise<ProtectedZones> {
   const dirs: string[] = []
-  for (const rel of PROTECTED_GIT_DIRS) {
-    dirs.push(await ensureProtectedDir(join(agentDir, rel)))
-  }
-  const files: string[] = []
-  for (const rel of PROTECTED_GIT_FILES) {
-    files.push(await ensureProtectedFile(join(agentDir, rel)))
-  }
+  const nodeModules = await resolveExistingProtectedDir(join(agentDir, 'node_modules'))
+  if (nodeModules !== undefined) dirs.push(nodeModules)
+  const layout = await resolveGitControlLayout(agentDir)
+  if (layout === undefined) return { dirs, files: [] }
 
-  const hooksPathDir = await resolveEffectiveHooksPath(agentDir)
+  dirs.push(await ensureProtectedDir(layout.defaultHooksDir))
+  const files: string[] = []
+  for (const configFile of layout.configFiles) files.push(await ensureProtectedFile(configFile))
+  if (layout.gitEntryFile !== undefined) files.push(layout.gitEntryFile)
+
+  const hooksPathDir = await resolveEffectiveHooksPath(agentDir, layout)
   if (hooksPathDir !== undefined && !dirs.includes(hooksPathDir)) {
     dirs.push(await ensureProtectedDir(hooksPathDir))
   }
 
-  return { dirs, files }
+  return { dirs: dedupe(dirs), files: dedupe(files) }
+}
+
+async function resolveExistingProtectedDir(target: string): Promise<string | undefined> {
+  const stats = await lstatOrUndefined(target)
+  if (stats === undefined) return undefined
+  if (stats.isSymbolicLink()) throw new Error(`sandbox: refusing to protect symlinked path ${target}`)
+  if (!stats.isDirectory()) throw new Error(`sandbox: protected directory is not a directory ${target}`)
+  return target
+}
+
+export async function isGitControlPath(agentDir: string, candidate: string): Promise<boolean> {
+  const absolute = resolve(agentDir, candidate)
+  const real = await realpathOrUndefined(absolute)
+  const candidates = real === undefined ? [absolute] : [absolute, real]
+  const lexicalGit = join(agentDir, '.git')
+  const lexicalGitstore = join(agentDir, '.gitstore')
+  if (candidates.some((path) => isLexicalGitControlPath(path, lexicalGit, lexicalGitstore))) {
+    return true
+  }
+
+  const layout = await resolveGitControlLayout(agentDir)
+  if (layout === undefined) return false
+  if (candidates.some((path) => layout.configFiles.includes(path))) return true
+  if (candidates.some((path) => path === layout.defaultHooksDir || isInside(layout.defaultHooksDir, path))) return true
+  const effectiveHooks = await resolveEffectiveHooksPath(agentDir, layout)
+  return (
+    effectiveHooks !== undefined && candidates.some((path) => path === effectiveHooks || isInside(effectiveHooks, path))
+  )
+}
+
+function isLexicalGitControlPath(candidate: string, dotGit: string, gitstore: string): boolean {
+  return (
+    candidate === dotGit ||
+    candidate === join(dotGit, 'config') ||
+    candidate === join(dotGit, 'hooks') ||
+    isInside(join(dotGit, 'hooks'), candidate) ||
+    candidate === join(gitstore, 'config') ||
+    candidate === join(gitstore, 'hooks') ||
+    isInside(join(gitstore, 'hooks'), candidate)
+  )
+}
+
+type GitControlLayout = {
+  gitEntryFile?: string
+  gitDir: string
+  defaultHooksDir: string
+  configFiles: string[]
+}
+
+async function resolveGitControlLayout(agentDir: string): Promise<GitControlLayout | undefined> {
+  const dotGit = join(agentDir, '.git')
+  const gitstore = join(agentDir, '.gitstore')
+  let gitDir: string
+  let gitEntryFile: string | undefined
+
+  const dotGitStats = await lstatOrUndefined(dotGit)
+  if (dotGitStats?.isDirectory()) {
+    gitDir = dotGit
+  } else if (dotGitStats?.isFile()) {
+    const pointer = await readFile(dotGit, 'utf8')
+    const match = /^gitdir:\s*(.+?)\s*$/im.exec(pointer)
+    if (match?.[1] === undefined) throw new Error(`sandbox: invalid worktree gitdir pointer ${dotGit}`)
+    gitDir = resolve(agentDir, match[1])
+    await assertRealDirectory(gitDir)
+    gitEntryFile = dotGit
+  } else {
+    const gitstoreStats = await lstatOrUndefined(gitstore)
+    if (!gitstoreStats?.isDirectory()) return undefined
+    gitDir = gitstore
+  }
+
+  const commonDir = await resolveCommonGitDir(gitDir)
+  const rootConfigFiles = [join(commonDir, 'config')]
+  const worktreeConfig = join(gitDir, 'config.worktree')
+  if (await isRealEntry(worktreeConfig, 'file')) rootConfigFiles.push(worktreeConfig)
+  const configFiles = await resolveLocalConfigFiles(agentDir, gitDir, rootConfigFiles)
+  return { gitEntryFile, gitDir, defaultHooksDir: join(commonDir, 'hooks'), configFiles }
+}
+
+async function resolveLocalConfigFiles(agentDir: string, gitDir: string, roots: readonly string[]): Promise<string[]> {
+  if (!(await isRealEntry(roots[0] as string, 'file'))) return roots.map((root) => resolve(root))
+  const result = await execLocalGitConfig(
+    agentDir,
+    gitDir,
+    roots[0] as string,
+    ['--includes', '--show-origin', '--null', '--name-only', '--list'],
+    256 * 1024,
+  )
+  const fields = result.stdout.split('\0').filter((field) => field !== '')
+  const origins: string[] = []
+  for (let index = 0; index < fields.length; index += 2) {
+    const origin = fields[index]
+    if (origin === undefined || !origin.startsWith('file:')) continue
+    const configFile = resolve(origin.slice('file:'.length))
+    if (configFile === agentDir || isInside(agentDir, configFile)) origins.push(configFile)
+  }
+  return dedupe([...roots.map((root) => resolve(root)), ...origins])
+}
+
+async function resolveCommonGitDir(gitDir: string): Promise<string> {
+  try {
+    const relative = (await readFile(join(gitDir, 'commondir'), 'utf8')).trim()
+    if (relative.length === 0) return gitDir
+    const commonDir = resolve(gitDir, relative)
+    await assertRealDirectory(commonDir)
+    return commonDir
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return gitDir
+    throw error
+  }
+}
+
+async function assertRealDirectory(target: string): Promise<void> {
+  const stats = await lstat(target)
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`sandbox: refusing non-directory git control root ${target}`)
+  }
+}
+
+async function lstatOrUndefined(target: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+  try {
+    return await lstat(target)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  }
 }
 
 // Fail closed: a symlink at a protected path would make the RO bind follow it
@@ -319,24 +341,66 @@ async function assertNotSymlink(target: string): Promise<void> {
   }
 }
 
-// Reads core.hooksPath straight from .git/config text (the file is about to be
-// RO-bound, so its content is the trusted baseline). Returns the resolved
-// absolute dir only when it lands inside agentDir — an outside path is not
-// writable by the jail and a relative path resolves against the repo root, per
-// gitconfig semantics.
-async function resolveEffectiveHooksPath(agentDir: string): Promise<string | undefined> {
-  let text: string
+// Ask Git to parse the effective value so quoting, escapes, comments, include,
+// and includeIf semantics exactly match the process that may later run hooks.
+// Global/system config and prompt-driven helpers are disabled so only the
+// repository-owned config graph can influence the result.
+async function resolveEffectiveHooksPath(agentDir: string, layout: GitControlLayout): Promise<string | undefined> {
+  let raw: string
   try {
-    text = await readFile(join(agentDir, '.git', 'config'), 'utf8')
-  } catch {
-    return undefined
+    const result = await execLocalGitConfig(
+      agentDir,
+      layout.gitDir,
+      layout.configFiles[0] as string,
+      ['--includes', '--path', '--get', 'core.hooksPath'],
+      64 * 1024,
+    )
+    raw = result.stdout.trim()
+  } catch (error) {
+    const code = (error as { code?: number | string }).code
+    if (code === 1) return undefined
+    throw error
   }
-  const match = text.match(/^\s*hooksPath\s*=\s*(.+?)\s*$/m)
-  if (match === null) return undefined
-  const raw = match[1]?.trim()
-  if (raw === undefined || raw.length === 0) return undefined
+  if (raw.length === 0) return undefined
   const resolved = isAbsolute(raw) ? resolve(raw) : resolve(agentDir, raw)
   return isInside(agentDir, resolved) ? resolved : undefined
+}
+
+function gitConfigEnv(agentDir: string, gitDir: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH ?? '/usr/bin:/bin',
+    HOME: agentDir,
+    GIT_DIR: gitDir,
+    GIT_WORK_TREE: agentDir,
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_TERMINAL_PROMPT: '0',
+  }
+}
+
+async function execLocalGitConfig(
+  agentDir: string,
+  gitDir: string,
+  rootConfig: string,
+  args: string[],
+  maxBuffer: number,
+): Promise<{ stdout: string; stderr: string }> {
+  const options = { env: gitConfigEnv(agentDir, gitDir), maxBuffer }
+  try {
+    return await execFileAsync(
+      'git',
+      [`--git-dir=${gitDir}`, `--work-tree=${agentDir}`, 'config', '--local', ...args],
+      options,
+    )
+  } catch (error) {
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    if (!stderr.includes('--local can only be used inside a git repository')) throw error
+    return execFileAsync(
+      'git',
+      [`--git-dir=${gitDir}`, `--work-tree=${agentDir}`, 'config', '--file', rootConfig, ...args],
+      options,
+    )
+  }
 }
 
 // SECURITY: a writable RW bind renders AFTER the masks and last-op-wins, so an


### PR DESCRIPTION
## Background

Extracted from #1201 to make the work reviewable. Slice 2/11.

## Summary

Hardens canonical masks, environment inheritance, writable Git controls, and privileged runtime profiles.

## Review notes

The incomplete persistent-package-install denial was removed from scope; a robust compatible solution requires a separate read-only package-runtime broker.