### PR TITLE
feat(network): add SSRF-safe bounded transport

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "jsdom": "^29.0.2",
         "proper-lockfile": "^4.1.2",
         "qrcode": "^1.5.4",
+        "tough-cookie": "^6.0.2",
         "turndown": "^7.2.4",
         "zod": "^4.3.6",
       },
@@ -1236,7 +1237,7 @@
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
-    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -1353,6 +1354,8 @@
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "jsdom/parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jsdom": "^29.0.2",
     "proper-lockfile": "^4.1.2",
     "qrcode": "^1.5.4",
+    "tough-cookie": "^6.0.2",
     "turndown": "^7.2.4",
     "zod": "^4.3.6"
   },

--- a/src/agent/multimodal/index.ts
+++ b/src/agent/multimodal/index.ts
@@ -1,4 +1,4 @@
-export { createChannelLookAtTool, lookAtTool } from './look-at'
+export { createChannelLookAtTool, createLookAtTool, lookAtTool } from './look-at'
 export {
   buildMultimodalLookerSystemPrompt,
   imageInputSchema,

--- a/src/agent/multimodal/look-at.test.ts
+++ b/src/agent/multimodal/look-at.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from 'bun:test'
+import type { LookupAddress } from 'node:dns'
+import { mkdtemp, rm, truncate } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
 import {
   buildGlmVisionMessages,
@@ -7,7 +11,13 @@ import {
   lookAtTool,
   resolveGlmVisionTtfbMs,
 } from './look-at'
-import { buildMultimodalLookerSystemPrompt } from './looker'
+import {
+  buildMultimodalLookerSystemPrompt,
+  type LookAtHttpResponse,
+  type LookAtNetworkDependencies,
+  type LookAtRequestOptions,
+} from './looker'
+import { LOOK_AT_MAX_BYTES, LOOK_AT_MAX_CONCURRENCY, LOOK_AT_MAX_IMAGES, resolveImagesBounded } from './looker'
 
 type ImageParam = { url?: string; path?: string; data?: string; mimeType?: string } | Record<string, never>
 
@@ -85,6 +95,414 @@ describe('lookAtTool — image source validation (no LLM call)', () => {
     })
   })
 })
+
+describe('resolveImagesBounded — aggregate resource boundary', () => {
+  test('rejects image arrays above the global count limit before resolving any source', async () => {
+    await expect(
+      resolveImagesBounded(
+        Array.from({ length: LOOK_AT_MAX_IMAGES + 1 }, () => ({
+          kind: 'url' as const,
+          url: 'https://example.com/image.png',
+        })),
+      ),
+    ).rejects.toThrow(/image count exceeds limit/)
+  })
+
+  test('bounds decoded base64 size before constructing a decoded Buffer', async () => {
+    const encoded = 'A'.repeat(Math.ceil((LOOK_AT_MAX_BYTES + 1) / 3) * 4)
+    await expect(resolveImagesBounded([{ kind: 'base64', data: encoded, mimeType: 'image/png' }])).rejects.toThrow(
+      /base64 image too large/,
+    )
+  })
+
+  test('enforces one aggregate byte budget across mixed local and base64 sources', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'typeclaw-look-at-mixed-'))
+    const file = path.join(root, 'image.png')
+    await Bun.write(file, '')
+    await truncate(file, Math.floor(LOOK_AT_MAX_BYTES * 0.6))
+    const encoded = 'A'.repeat(Math.ceil((LOOK_AT_MAX_BYTES * 0.6) / 3) * 4)
+    try {
+      await expect(
+        resolveImagesBounded([
+          { kind: 'file', path: file },
+          { kind: 'base64', data: encoded, mimeType: 'image/png' },
+        ]),
+      ).rejects.toThrow(/aggregate byte limit/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('limits concurrent URL downloads', async () => {
+    let active = 0
+    let peak = 0
+    const network = networkFixture({
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        active += 1
+        peak = Math.max(peak, active)
+        await Bun.sleep(5)
+        active -= 1
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    await resolveImagesBounded(
+      Array.from({ length: LOOK_AT_MAX_IMAGES }, (_, i) => ({
+        kind: 'url' as const,
+        url: `https://example.com/${i}.png`,
+      })),
+      undefined,
+      network,
+    )
+    expect(peak).toBeLessThanOrEqual(LOOK_AT_MAX_CONCURRENCY)
+  })
+
+  test('aborts and settles sibling workers before propagating the first failure', async () => {
+    let aborted = 0
+    let active = 0
+    const network = networkFixture({
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        if (options.path === '/fail.png') throw new Error('first failure')
+        active++
+        await new Promise<void>((_resolve, reject) => {
+          const onAbort = () => {
+            aborted++
+            active--
+            reject(new Error('sibling aborted'))
+          }
+          if (options.signal.aborted) onAbort()
+          else options.signal.addEventListener('abort', onAbort, { once: true })
+        })
+        throw new Error('unreachable')
+      },
+    })
+
+    await expect(
+      resolveImagesBounded(
+        [
+          { kind: 'url', url: 'https://example.com/slow-1.png' },
+          { kind: 'url', url: 'https://example.com/slow-2.png' },
+          { kind: 'url', url: 'https://example.com/fail.png' },
+        ],
+        undefined,
+        network,
+      ),
+    ).rejects.toThrow('first failure')
+    expect(aborted).toBe(2)
+    expect(active).toBe(0)
+  })
+
+  test('rejects direct internal and non-HTTP URL sources before opening a request', async () => {
+    let calls = 0
+    const network = networkFixture({
+      request: async () => {
+        calls += 1
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    for (const url of ['http://169.254.169.254/latest/meta-data', 'http://127.0.0.1/a.png', 'file:///etc/passwd']) {
+      await expect(resolveImagesBounded([{ kind: 'url', url }], undefined, network)).rejects.toThrow(
+        /public|SSRF|HTTP/i,
+      )
+    }
+    expect(calls).toBe(0)
+  })
+
+  test('validates every redirect target and refuses a public-to-private hostname before requesting it', async () => {
+    const requested: string[] = []
+    const network = networkFixture({
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        requested.push(`${options.protocol}//${options.hostname}${options.path}`)
+        return imageResponse({ statusCode: 302, headers: { location: 'http://127.0.0.1/private.png' } })
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://example.com/image.png' }], undefined, network),
+    ).rejects.toThrow(/public|SSRF|redirect/i)
+    expect(requested).toEqual(['https://example.com/image.png'])
+  })
+
+  test('preserves normal public HTTP image fetching', async () => {
+    const network = networkFixture({
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        return imageResponse({ chunks: [new Uint8Array([1, 2, 3])] })
+      },
+    })
+    const [image] = await resolveImagesBounded(
+      [{ kind: 'url', url: 'https://example.com/image.png' }],
+      undefined,
+      network,
+    )
+    expect(image).toEqual({ data: 'AQID', mimeType: 'image/png' })
+  })
+
+  test.each([
+    ['loopback', [{ address: '127.0.0.1', family: 4 as const }]],
+    ['RFC1918', [{ address: '10.2.3.4', family: 4 as const }]],
+    ['IPv4 link-local', [{ address: '169.254.20.1', family: 4 as const }]],
+    ['IPv6 link-local', [{ address: 'fe90::1', family: 6 as const }]],
+    ['IPv4-mapped IPv6', [{ address: '::ffff:127.0.0.1', family: 6 as const }]],
+    [
+      'mixed public/private',
+      [
+        { address: '93.184.216.34', family: 4 as const },
+        { address: '192.168.1.5', family: 4 as const },
+      ],
+    ],
+  ])('rejects %s answers in the socket lookup used by the request', async (_label, addresses) => {
+    let requests = 0
+    const network = networkFixture({
+      resolveAddresses: async () => addresses,
+      request: async (options) => {
+        requests += 1
+        await resolveSocketAddress(options)
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://images.example/photo.png' }], undefined, network),
+    ).rejects.toThrow(/DNS|non-public|SSRF|address/i)
+    expect(requests).toBe(1)
+  })
+
+  test('pins the actual socket lookup to one validated answer without a second resolution', async () => {
+    let resolutions = 0
+    let connectedAddress = ''
+    const network = networkFixture({
+      resolveAddresses: async () => {
+        resolutions += 1
+        return resolutions === 1 ? [{ address: '93.184.216.34', family: 4 }] : [{ address: '127.0.0.1', family: 4 }]
+      },
+      request: async (options) => {
+        connectedAddress = (await resolveSocketAddress(options)).address
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    await resolveImagesBounded([{ kind: 'url', url: 'https://images.example/photo.png' }], undefined, network)
+    expect(connectedAddress).toBe('93.184.216.34')
+    expect(resolutions).toBe(1)
+  })
+
+  test('preserves the original HTTPS hostname for Host, SNI, and certificate validation', async () => {
+    let observed: LookAtRequestOptions | undefined
+    const network = networkFixture({
+      request: async (options) => {
+        observed = options
+        await resolveSocketAddress(options)
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    await resolveImagesBounded([{ kind: 'url', url: 'https://images.example:8443/photo.png?q=1' }], undefined, network)
+    expect(observed?.hostname).toBe('images.example')
+    expect(observed?.servername).toBe('images.example')
+    expect(observed?.headers.Host).toBe('images.example:8443')
+    expect(observed?.path).toBe('/photo.png?q=1')
+  })
+
+  test('performs a fresh validated socket lookup for every manual redirect hop', async () => {
+    const resolvedHosts: string[] = []
+    const requestedHosts: string[] = []
+    const network = networkFixture({
+      resolveAddresses: async (hostname) => {
+        resolvedHosts.push(hostname)
+        return hostname === 'cdn.example'
+          ? [{ address: '93.184.216.34', family: 4 }]
+          : [{ address: '127.0.0.1', family: 4 }]
+      },
+      request: async (options) => {
+        requestedHosts.push(options.hostname)
+        await resolveSocketAddress(options)
+        if (options.hostname === 'cdn.example') {
+          return imageResponse({ statusCode: 302, headers: { location: 'https://rebound.example/private.png' } })
+        }
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://cdn.example/photo.png' }], undefined, network),
+    ).rejects.toThrow(/DNS|non-public|SSRF|address/i)
+    expect(requestedHosts).toEqual(['cdn.example', 'rebound.example'])
+    expect(resolvedHosts).toEqual(['cdn.example', 'rebound.example'])
+  })
+
+  test('surfaces DNS lookup failures and never falls back to an unpinned request', async () => {
+    const network = networkFixture({
+      resolveAddresses: async () => {
+        throw new Error('dns unavailable')
+      },
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://images.example/photo.png' }], undefined, network),
+    ).rejects.toThrow(/dns unavailable/)
+  })
+
+  test('propagates caller aborts into the socket request', async () => {
+    const controller = new AbortController()
+    controller.abort('cancel image request')
+    const network = networkFixture({
+      request: async (options) => {
+        if (options.signal.aborted) throw new Error(String(options.signal.reason))
+        return imageResponse({ chunks: [new Uint8Array([1])] })
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://images.example/photo.png' }], controller.signal, network),
+    ).rejects.toThrow(/cancel image request/)
+  })
+
+  test('retains image content-type and streaming byte limits on the pinned transport', async () => {
+    const nonImage = networkFixture({
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        return imageResponse({ headers: { 'content-type': 'text/html' }, chunks: [new Uint8Array([1])] })
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://images.example/not-image' }], undefined, nonImage),
+    ).rejects.toThrow(/did not return an image content-type/)
+
+    const oversized = networkFixture({
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        return imageResponse({ chunks: [new Uint8Array(LOOK_AT_MAX_BYTES + 1)] })
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://images.example/huge.png' }], undefined, oversized),
+    ).rejects.toThrow(/response exceeded.*cap/)
+  })
+
+  test('cancels every final response on consumed and rejected paths', async () => {
+    const cases = [
+      imageResponse({ statusCode: 404 }),
+      imageResponse({ headers: { 'content-type': 'text/html' } }),
+      imageResponse({ headers: { 'content-length': String(LOOK_AT_MAX_BYTES + 1) } }),
+      imageResponse({ chunks: [new Uint8Array(LOOK_AT_MAX_BYTES + 1)] }),
+      imageResponse({ chunks: [new Uint8Array([1])], iterationError: new Error('body failed') }),
+      imageResponse({ chunks: [new Uint8Array([1])] }),
+    ]
+    for (const candidate of cases) {
+      const network = networkFixture({
+        request: async (options) => {
+          await resolveSocketAddress(options)
+          return candidate
+        },
+      })
+      await resolveImagesBounded([{ kind: 'url', url: 'https://images.example/photo.png' }], undefined, network).catch(
+        () => undefined,
+      )
+      expect(candidate.cancelled()).toBeTrue()
+    }
+  })
+
+  test('cancels the response when the aggregate budget rejects a URL chunk', async () => {
+    const candidate = imageResponse({ chunks: [new Uint8Array(Math.ceil(LOOK_AT_MAX_BYTES * 0.6))] })
+    const network = networkFixture({ request: async (options) => (await resolveSocketAddress(options), candidate) })
+    const encoded = 'A'.repeat(Math.ceil((LOOK_AT_MAX_BYTES * 0.6) / 3) * 4)
+    await expect(
+      resolveImagesBounded(
+        [
+          { kind: 'base64', data: encoded, mimeType: 'image/png' },
+          { kind: 'url', url: 'https://images.example/photo.png' },
+        ],
+        undefined,
+        network,
+      ),
+    ).rejects.toThrow(/aggregate byte limit/)
+    expect(candidate.cancelled()).toBeTrue()
+  })
+
+  test('cancels the final response when the caller aborts during body iteration', async () => {
+    const controller = new AbortController()
+    let cancelled = false
+    const network = networkFixture({
+      request: async (options) => {
+        await resolveSocketAddress(options)
+        return {
+          statusCode: 200,
+          headers: { 'content-type': 'image/png' },
+          body: {
+            async *[Symbol.asyncIterator]() {
+              controller.abort('stop')
+              if (options.signal.aborted) throw new Error(String(options.signal.reason))
+              yield new Uint8Array([1])
+            },
+          },
+          cancel: () => {
+            cancelled = true
+          },
+        }
+      },
+    })
+    await expect(
+      resolveImagesBounded([{ kind: 'url', url: 'https://images.example/photo.png' }], controller.signal, network),
+    ).rejects.toThrow(/stop/)
+    expect(cancelled).toBeTrue()
+  })
+})
+
+function networkFixture(overrides: Partial<LookAtNetworkDependencies> = {}): LookAtNetworkDependencies {
+  return {
+    resolveAddresses: async () => [{ address: '93.184.216.34', family: 4 }],
+    request: async (options) => {
+      await resolveSocketAddress(options)
+      return imageResponse({ chunks: [new Uint8Array([1])] })
+    },
+    ...overrides,
+  }
+}
+
+function imageResponse(options: {
+  statusCode?: number
+  headers?: Record<string, string>
+  chunks?: Uint8Array[]
+  iterationError?: Error
+}): LookAtHttpResponse & { cancelled(): boolean } {
+  const chunks = options.chunks ?? []
+  let wasCancelled = false
+  return {
+    statusCode: options.statusCode ?? 200,
+    headers: { 'content-type': 'image/png', ...options.headers },
+    body: {
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of chunks) yield chunk
+        if (options.iterationError !== undefined) throw options.iterationError
+      },
+    },
+    cancel() {
+      wasCancelled = true
+    },
+    cancelled: () => wasCancelled,
+  }
+}
+
+async function resolveSocketAddress(options: LookAtRequestOptions): Promise<{ address: string; family: number }> {
+  return await new Promise((resolve, reject) => {
+    options.lookup(options.hostname, {}, (error, address, family) => {
+      if (error !== null) {
+        reject(error)
+        return
+      }
+      if (Array.isArray(address)) {
+        const first = address[0] as LookupAddress | undefined
+        if (first === undefined) {
+          reject(new Error('lookup returned no address'))
+          return
+        }
+        resolve({ address: first.address, family: first.family })
+        return
+      }
+      resolve({ address, family: family ?? 0 })
+    })
+  })
+}
 
 describe('extractGlmVisionText — GLM vision response parsing', () => {
   test('extracts trimmed assistant content from a well-formed response', () => {

--- a/src/agent/multimodal/look-at.ts
+++ b/src/agent/multimodal/look-at.ts
@@ -5,15 +5,23 @@ import type { ImageContent } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
 import { createSessionWithDispose, type SessionOrigin } from '@/agent'
+import { readResponseBodyBounded } from '@/agent/network/response-body'
 import type { ChannelRouter } from '@/channels/router'
 import type { AdapterId } from '@/channels/schema'
 import { getConfig, resolveModel, resolveProfile } from '@/config'
 import { providerForModelRef } from '@/config/providers'
+import type { PermissionService } from '@/permissions'
 import { LLM_FETCH_OBSERVER_TIMEOUTS, type LlmFetchObservedRequestInit } from '@/run/llm-fetch-observer'
 import { SecretsBackend } from '@/secrets'
 
 import { promptWithSameRefRetryOnly } from '../retry-same-ref'
-import { buildMultimodalLookerSystemPrompt, resolveImage, type ImageInput } from './looker'
+import {
+  buildMultimodalLookerSystemPrompt,
+  LOOK_AT_MAX_BYTES,
+  LOOK_AT_MAX_IMAGES,
+  resolveImagesBounded,
+  type ImageInput,
+} from './looker'
 
 type ImageParam = { url: string } | { path: string } | { data: string; mimeType: string }
 
@@ -46,52 +54,62 @@ export type ChannelLookAtOrigin = {
 // Output is the subagent's text response. The subagent itself decides whether
 // to answer the user's question (when `prompt` is supplied) or describe the
 // image (when `prompt` is omitted) via its dynamic system prompt.
-export const lookAtTool = defineTool({
-  name: 'look_at',
-  label: 'Look at images',
-  description:
-    'Route image(s) through a vision-capable subagent and get a text result. ' +
-    'Use this when you need to see an image: a screenshot the user shared, a diagram in a doc, a photo, a chart, etc. ' +
-    'Each image is specified by ONE of `url` (https://...), `path` (absolute filesystem path), or `data`+`mimeType` (base64). ' +
-    'The optional `prompt` is a question to ask about the image(s); without it, the subagent returns a faithful description. ' +
-    'The image bytes never enter your context — only the resulting text comes back.',
-  parameters: Type.Object({
-    images: Type.Array(
-      Type.Object({
-        url: Type.Optional(Type.String({ description: 'https:// URL to fetch the image from.' })),
-        path: Type.Optional(Type.String({ description: 'Absolute filesystem path (inside /agent or a mounted dir).' })),
-        data: Type.Optional(Type.String({ description: 'Base64-encoded image bytes (pair with mimeType).' })),
-        mimeType: Type.Optional(Type.String({ description: 'MIME type when using `data` (e.g. "image/png").' })),
-      }),
-      { minItems: 1, description: 'One or more images to look at.' },
-    ),
-    prompt: Type.Optional(
-      Type.String({
-        description:
-          'Optional question to ask about the image(s). When omitted, the subagent returns a faithful description.',
-      }),
-    ),
-  }),
+export function createLookAtTool(permissions?: PermissionService) {
+  return defineTool({
+    name: 'look_at',
+    label: 'Look at images',
+    description:
+      'Route image(s) through a vision-capable subagent and get a text result. ' +
+      'Use this when you need to see an image: a screenshot the user shared, a diagram in a doc, a photo, a chart, etc. ' +
+      'Each image is specified by ONE of `url` (https://...), `path` (absolute filesystem path), or `data`+`mimeType` (base64). ' +
+      'The optional `prompt` is a question to ask about the image(s); without it, the subagent returns a faithful description. ' +
+      'The image bytes never enter your context — only the resulting text comes back.',
+    parameters: Type.Object({
+      images: Type.Array(
+        Type.Object({
+          url: Type.Optional(Type.String({ description: 'https:// URL to fetch the image from.' })),
+          path: Type.Optional(
+            Type.String({ description: 'Absolute filesystem path (inside /agent or a mounted dir).' }),
+          ),
+          data: Type.Optional(Type.String({ description: 'Base64-encoded image bytes (pair with mimeType).' })),
+          mimeType: Type.Optional(Type.String({ description: 'MIME type when using `data` (e.g. "image/png").' })),
+        }),
+        { minItems: 1, maxItems: LOOK_AT_MAX_IMAGES, description: 'One or more images to look at.' },
+      ),
+      prompt: Type.Optional(
+        Type.String({
+          description:
+            'Optional question to ask about the image(s). When omitted, the subagent returns a faithful description.',
+        }),
+      ),
+    }),
 
-  async execute(_toolCallId, params, signal) {
-    const args = params as LookAtArgs
-    try {
-      const imageInputs = args.images.map(toImageInput)
-      const resolved = await Promise.all(imageInputs.map((i) => resolveImage(i, signal)))
-      const imageContents: ImageContent[] = resolved.map((r) => toImageContent(r.data, r.mimeType))
-      return await runLookAtImages(imageContents, args.prompt)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      return errorResult(message, { count: args.images.length, prompt: args.prompt })
-    }
-  },
-})
+    async execute(_toolCallId, params, signal) {
+      const args = params as LookAtArgs
+      try {
+        const imageInputs = args.images.map(toImageInput)
+        const resolved = await resolveImagesBounded(imageInputs, signal)
+        const imageContents: ImageContent[] = resolved.map((r) => toImageContent(r.data, r.mimeType))
+        return await runLookAtImages(imageContents, args.prompt, permissions)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        return errorResult(message, { count: args.images.length, prompt: args.prompt })
+      }
+    },
+  })
+}
+
+export const lookAtTool = createLookAtTool()
 
 // Channel attachments intentionally use a separate tool instead of adding
 // channel-only dependencies to the global look_at implementation. This keeps
 // non-channel sessions' image source validation unchanged while channel
 // sessions get router-validated attachment_id lookup.
-export function createChannelLookAtTool(router: ChannelRouter, origin: ChannelLookAtOrigin) {
+export function createChannelLookAtTool(
+  router: ChannelRouter,
+  origin: ChannelLookAtOrigin,
+  permissions?: PermissionService,
+) {
   return defineTool({
     name: 'look_at_channel_attachment',
     label: 'Look at channel attachment',
@@ -130,12 +148,14 @@ export function createChannelLookAtTool(router: ChannelRouter, origin: ChannelLo
       }
       const result = await router.fetchAttachment(origin.adapter, {
         ref: found.ref,
+        maxBytes: LOOK_AT_MAX_BYTES,
         ...(found.filename !== undefined ? { filename: found.filename } : {}),
       })
       if (!result.ok) return errorResult(result.error, { count: 0, prompt: params.prompt })
       return await runLookAtImages(
         [toImageContent(result.buffer.toString('base64'), result.mimetype ?? 'image/jpeg')],
         params.prompt,
+        permissions,
       )
     },
   })
@@ -145,7 +165,11 @@ function toImageContent(data: string, mimeType: string): ImageContent {
   return { type: 'image', data, mimeType }
 }
 
-async function runLookAtImages(imageContents: ImageContent[], prompt: string | undefined) {
+async function runLookAtImages(
+  imageContents: ImageContent[],
+  prompt: string | undefined,
+  permissions?: PermissionService,
+) {
   // Exception for text-only GLM Coding Plan models: the subagent below would
   // resolve to the same image-blind model and silently fail. GLM-4.6V vision is
   // reachable on the coding-plan endpoint with the same key (POST
@@ -176,6 +200,7 @@ async function runLookAtImages(imageContents: ImageContent[], prompt: string | u
   const { session, dispose } = await createSessionWithDispose({
     systemPromptOverride: systemPrompt,
     origin,
+    ...(permissions !== undefined ? { permissions } : {}),
     profile: 'vision',
     // Both knobs are required to fully disarm the subagent's tool surface:
     // `customTools: []` blocks typeclaw's system tools (web_search/web_fetch/
@@ -208,6 +233,7 @@ const GLM_VISION_PROVIDER = 'zai-coding'
 const GLM_VISION_MODEL = 'glm-4.6v'
 const GLM_VISION_ENDPOINT = 'https://api.z.ai/api/coding/paas/v4/chat/completions'
 const GLM_VISION_MAX_TOKENS = 32768
+export const GLM_VISION_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 
 // Vision requests carry a base64 image body the server must decode before it can
 // send response headers, so the observer's 15s default TTFB (tuned for ~1s text
@@ -254,10 +280,18 @@ async function analyzeWithGlmCodingPlanVision(imageContents: ImageContent[], pro
   }
 
   if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined)
     return errorResult(`GLM vision request failed: HTTP ${response.status}`, details)
   }
 
-  const text = extractGlmVisionText(await response.json().catch(() => null))
+  let body: unknown
+  try {
+    const bytes = await readResponseBodyBounded(response, GLM_VISION_MAX_RESPONSE_BYTES)
+    body = JSON.parse(bytes.toString('utf8'))
+  } catch (error) {
+    return errorResult(`GLM vision response failed: ${error instanceof Error ? error.message : String(error)}`, details)
+  }
+  const text = extractGlmVisionText(body)
   if (text === null) {
     return errorResult('GLM vision returned no text response', details)
   }

--- a/src/agent/multimodal/looker.ts
+++ b/src/agent/multimodal/looker.ts
@@ -1,7 +1,18 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { open } from 'node:fs/promises'
 import { extname, isAbsolute } from 'node:path'
 
 import { z } from 'zod'
+
+import {
+  createPublicSocketLookup,
+  defaultPublicHttpDependencies,
+  headerValue,
+  requestPublicHttpUrl,
+  type PublicHttpAddress,
+  type PublicHttpDependencies,
+  type PublicHttpRequestOptions,
+  type PublicHttpResponse,
+} from '@/agent/network/safe-http'
 
 const SUPPORTED_MIME_TYPES = {
   '.png': 'image/png',
@@ -18,6 +29,10 @@ const SUPPORTED_MIME_TYPES = {
 // 30 s is generous for a single HTTP image fetch over a slow link.
 export const URL_FETCH_TIMEOUT_MS = 30_000
 export const URL_FETCH_MAX_BYTES = 20 * 1024 * 1024
+export const LOOK_AT_MAX_IMAGES = 16
+export const LOOK_AT_MAX_BYTES = URL_FETCH_MAX_BYTES
+export const LOOK_AT_MAX_CONCURRENCY = 4
+export const LOOK_AT_MAX_REDIRECTS = 5
 
 type Mime = (typeof SUPPORTED_MIME_TYPES)[keyof typeof SUPPORTED_MIME_TYPES]
 
@@ -71,6 +86,57 @@ export type ResolvedImage = {
   mimeType: string
 }
 
+export type LookAtAddress = PublicHttpAddress
+export type LookAtRequestOptions = PublicHttpRequestOptions
+export type LookAtHttpResponse = PublicHttpResponse
+export type LookAtNetworkDependencies = PublicHttpDependencies
+
+type ImageByteBudget = {
+  consume(bytes: number): void
+}
+
+export async function resolveImagesBounded(
+  inputs: ImageInput[],
+  signal?: AbortSignal,
+  network: LookAtNetworkDependencies = defaultLookAtNetwork,
+): Promise<ResolvedImage[]> {
+  if (inputs.length > LOOK_AT_MAX_IMAGES) {
+    throw new Error(`look_at: image count exceeds limit (${inputs.length} > ${LOOK_AT_MAX_IMAGES})`)
+  }
+  let consumed = 0
+  const budget: ImageByteBudget = {
+    consume(bytes) {
+      consumed += bytes
+      if (consumed > LOOK_AT_MAX_BYTES) {
+        throw new Error(`look_at: images exceed aggregate byte limit (${consumed} > ${LOOK_AT_MAX_BYTES})`)
+      }
+    },
+  }
+  const results = Array.from<ResolvedImage>({ length: inputs.length })
+  const siblingController = new AbortController()
+  const workerSignal =
+    signal === undefined ? siblingController.signal : AbortSignal.any([signal, siblingController.signal])
+  let next = 0
+  let firstError: unknown
+  let failed = false
+  const worker = async (): Promise<void> => {
+    try {
+      while (next < inputs.length) {
+        const index = next++
+        results[index] = await resolveImage(inputs[index] as ImageInput, workerSignal, budget, network)
+      }
+    } catch (error) {
+      if (!failed) firstError = error
+      failed = true
+      siblingController.abort(error)
+      throw error
+    }
+  }
+  await Promise.allSettled(Array.from({ length: Math.min(inputs.length, LOOK_AT_MAX_CONCURRENCY) }, worker))
+  if (failed) throw firstError
+  return results
+}
+
 // Materializes an ImageInput into the base64-encoded form pi-ai expects.
 // - `url`: passthrough; pi-ai's image content does not accept URLs, so we fetch
 //   the bytes and base64-encode here (lazy; only when the tool is invoked).
@@ -78,19 +144,26 @@ export type ResolvedImage = {
 //   resolvable against the caller's cwd (callers should normalize ahead of
 //   time; this function rejects relative paths to avoid ambiguity).
 // - `base64`: passthrough.
-export async function resolveImage(input: ImageInput, signal?: AbortSignal): Promise<ResolvedImage> {
+export async function resolveImage(
+  input: ImageInput,
+  signal?: AbortSignal,
+  aggregateBudget?: ImageByteBudget,
+  network: LookAtNetworkDependencies = defaultLookAtNetwork,
+): Promise<ResolvedImage> {
   if (input.kind === 'base64') {
     if (!input.mimeType.startsWith('image/')) {
       throw new Error(`look_at: base64 mimeType must be image/* (got "${input.mimeType}")`)
     }
+    const decodedBytes = decodedBase64Size(input.data)
+    if (decodedBytes > URL_FETCH_MAX_BYTES) {
+      throw new Error(`look_at: base64 image too large (${decodedBytes} bytes > ${URL_FETCH_MAX_BYTES} cap)`)
+    }
+    aggregateBudget?.consume(decodedBytes)
     return { data: input.data, mimeType: input.mimeType }
   }
   if (input.kind === 'file') {
     if (!isAbsolute(input.path)) {
       throw new Error(`look_at: file path must be absolute (got "${input.path}")`)
-    }
-    if (!existsSync(input.path)) {
-      throw new Error(`look_at: file not found at ${input.path}`)
     }
     const ext = extname(input.path).toLowerCase() as keyof typeof SUPPORTED_MIME_TYPES
     const mimeType = (SUPPORTED_MIME_TYPES[ext] ?? null) as Mime | null
@@ -99,47 +172,86 @@ export async function resolveImage(input: ImageInput, signal?: AbortSignal): Pro
         `look_at: unsupported image extension "${ext}" for ${input.path} (supported: ${Object.keys(SUPPORTED_MIME_TYPES).join(', ')})`,
       )
     }
-    const bytes = readFileSync(input.path)
-    return { data: bytes.toString('base64'), mimeType }
+    const handle = await open(input.path, 'r').catch(() => {
+      throw new Error(`look_at: file not found at ${input.path}`)
+    })
+    try {
+      const size = (await handle.stat()).size
+      if (size > URL_FETCH_MAX_BYTES) {
+        throw new Error(`look_at: file too large (${size} bytes > ${URL_FETCH_MAX_BYTES} cap)`)
+      }
+      aggregateBudget?.consume(size)
+      const bytes = Buffer.alloc(size + 1)
+      let offset = 0
+      while (offset < bytes.byteLength) {
+        const { bytesRead } = await handle.read(bytes, offset, bytes.byteLength - offset, null)
+        if (bytesRead === 0) break
+        offset += bytesRead
+      }
+      const finalSize = (await handle.stat()).size
+      if (offset !== size || finalSize !== size) {
+        throw new Error(`look_at: file changed while being read: ${input.path}`)
+      }
+      return { data: bytes.subarray(0, offset).toString('base64'), mimeType }
+    } finally {
+      await handle.close()
+    }
   }
   // URL branch: independent timeout + size cap on top of any caller-provided
   // signal. The two abort signals are merged so the tool's overall abort wins
   // over our timeout AND vice versa.
   const timeoutSignal = AbortSignal.timeout(URL_FETCH_TIMEOUT_MS)
   const mergedSignal = signal !== undefined ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
-  const res = await fetch(input.url, { signal: mergedSignal })
-  if (!res.ok) {
-    throw new Error(`look_at: failed to fetch ${input.url}: HTTP ${res.status}`)
-  }
-  const mimeType = res.headers.get('content-type')?.split(';')[0]?.trim() ?? 'application/octet-stream'
-  if (!mimeType.startsWith('image/')) {
-    throw new Error(`look_at: ${input.url} did not return an image content-type (got "${mimeType}")`)
-  }
-  // Streaming size check: arrayBuffer() would read the whole body before we
-  // could enforce a cap. Read chunk-by-chunk and abort once we cross the
-  // limit. Content-Length is checked first when present, but absent or lying
-  // headers fall through to the streaming check.
-  const declared = Number(res.headers.get('content-length') ?? '')
-  if (Number.isFinite(declared) && declared > URL_FETCH_MAX_BYTES) {
-    throw new Error(`look_at: ${input.url} response too large (${declared} bytes > ${URL_FETCH_MAX_BYTES} cap)`)
-  }
-  const reader = res.body?.getReader()
-  if (reader === undefined) {
-    throw new Error(`look_at: ${input.url} returned an empty body`)
-  }
-  const chunks: Uint8Array[] = []
-  let total = 0
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (value === undefined) continue
-    total += value.byteLength
-    if (total > URL_FETCH_MAX_BYTES) {
-      await reader.cancel()
-      throw new Error(`look_at: ${input.url} response exceeded ${URL_FETCH_MAX_BYTES}-byte cap`)
+  const { response: res, finalUrl } = await requestPublicHttpUrl(input.url, {
+    signal: mergedSignal,
+    headers: { Accept: 'image/*' },
+    maxRedirects: LOOK_AT_MAX_REDIRECTS,
+    dependencies: network,
+  })
+  try {
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw new Error(`look_at: failed to fetch ${finalUrl}: HTTP ${res.statusCode}`)
     }
-    chunks.push(value)
+    const mimeType = headerValue(res.headers, 'content-type')?.split(';')[0]?.trim() ?? 'application/octet-stream'
+    if (!mimeType.startsWith('image/')) {
+      throw new Error(`look_at: ${input.url} did not return an image content-type (got "${mimeType}")`)
+    }
+    // Streaming size check: arrayBuffer() would read the whole body before we
+    // could enforce a cap. Read chunk-by-chunk and abort once we cross the
+    // limit. Content-Length is checked first when present, but absent or lying
+    // headers fall through to the streaming check.
+    const declared = Number(headerValue(res.headers, 'content-length') ?? '')
+    if (Number.isFinite(declared) && declared > URL_FETCH_MAX_BYTES) {
+      throw new Error(`look_at: ${input.url} response too large (${declared} bytes > ${URL_FETCH_MAX_BYTES} cap)`)
+    }
+    const chunks: Uint8Array[] = []
+    let total = 0
+    for await (const value of res.body) {
+      total += value.byteLength
+      if (total > URL_FETCH_MAX_BYTES) {
+        throw new Error(`look_at: ${input.url} response exceeded ${URL_FETCH_MAX_BYTES}-byte cap`)
+      }
+      aggregateBudget?.consume(value.byteLength)
+      chunks.push(value)
+    }
+    const buf = Buffer.concat(chunks)
+    return { data: buf.toString('base64'), mimeType }
+  } finally {
+    res.cancel()
   }
-  const buf = Buffer.concat(chunks)
-  return { data: buf.toString('base64'), mimeType }
+}
+
+const defaultLookAtNetwork = defaultPublicHttpDependencies
+
+export { createPublicSocketLookup }
+
+function decodedBase64Size(data: string): number {
+  if (data.length > Math.ceil(URL_FETCH_MAX_BYTES / 3) * 4) {
+    throw new Error(`look_at: base64 image too large (encoded length exceeds ${URL_FETCH_MAX_BYTES}-byte cap)`)
+  }
+  if (data.length % 4 !== 0 || !/^[A-Za-z\d+/]*={0,2}$/.test(data)) {
+    throw new Error('look_at: invalid base64 image data')
+  }
+  const padding = data.endsWith('==') ? 2 : data.endsWith('=') ? 1 : 0
+  return (data.length / 4) * 3 - padding
 }

--- a/src/agent/network/response-body.ts
+++ b/src/agent/network/response-body.ts
@@ -1,0 +1,26 @@
+export async function readResponseBodyBounded(response: Response, maxBytes: number): Promise<Buffer> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) throw new Error(`invalid response byte limit: ${maxBytes}`)
+  if (response.body === null) return Buffer.alloc(0)
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    const declared = Number(response.headers.get('content-length') ?? '')
+    if (Number.isFinite(declared) && declared > maxBytes) throw responseTooLarge(declared, maxBytes)
+    while (true) {
+      const next = await reader.read()
+      if (next.done) break
+      total += next.value.byteLength
+      if (total > maxBytes) throw responseTooLarge(total, maxBytes)
+      chunks.push(next.value)
+    }
+    return Buffer.concat(chunks)
+  } finally {
+    await reader.cancel().catch(() => undefined)
+    reader.releaseLock()
+  }
+}
+
+function responseTooLarge(size: number, maxBytes: number): Error {
+  return new Error(`response is too large (${size} bytes > ${maxBytes} byte limit)`)
+}

--- a/src/agent/network/safe-http.ts
+++ b/src/agent/network/safe-http.ts
@@ -1,0 +1,198 @@
+import { lookup as dnsLookup } from 'node:dns/promises'
+import { request as httpRequest, type IncomingHttpHeaders } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import { isIP, type LookupFunction } from 'node:net'
+
+import { classifyIpAddress, classifyUrl } from '@/bundled-plugins/security/policies/ssrf'
+
+export type PublicHttpAddress = { address: string; family: 4 | 6 }
+
+export type PublicHttpRequestOptions = {
+  protocol: 'http:' | 'https:'
+  hostname: string
+  port?: number
+  path: string
+  method: 'GET'
+  headers: Record<string, string>
+  servername?: string
+  signal: AbortSignal
+  lookup: LookupFunction
+  autoSelectFamily: false
+}
+
+export type PublicHttpResponse = {
+  statusCode: number
+  headers: IncomingHttpHeaders
+  body: AsyncIterable<Uint8Array>
+  cancel(): void
+}
+
+export type PublicHttpDependencies = {
+  resolveAddresses(hostname: string): Promise<readonly PublicHttpAddress[]>
+  request(options: PublicHttpRequestOptions): Promise<PublicHttpResponse>
+}
+
+export type PublicHttpResult = { response: PublicHttpResponse; finalUrl: string }
+
+export const DEFAULT_PUBLIC_HTTP_MAX_REDIRECTS = 5
+
+export async function requestPublicHttpUrl(
+  rawUrl: string,
+  options: {
+    signal: AbortSignal
+    headers?: Record<string, string>
+    headersForUrl?: (url: string) => Record<string, string>
+    onResponse?: (response: PublicHttpResponse, url: string) => void
+    maxRedirects?: number
+    dependencies?: PublicHttpDependencies
+  },
+): Promise<PublicHttpResult> {
+  const dependencies = options.dependencies ?? defaultPublicHttpDependencies
+  const maxRedirects = options.maxRedirects ?? DEFAULT_PUBLIC_HTTP_MAX_REDIRECTS
+  let current = requirePublicHttpUrl(rawUrl)
+  const initialOrigin = new URL(current).origin
+  for (let redirects = 0; redirects <= maxRedirects; redirects++) {
+    const parsed = new URL(current)
+    const hostname = unbracketHostname(parsed.hostname)
+    const response = await dependencies.request({
+      protocol: parsed.protocol as 'http:' | 'https:',
+      hostname,
+      ...(parsed.port === '' ? {} : { port: Number(parsed.port) }),
+      path: `${parsed.pathname}${parsed.search}`,
+      method: 'GET',
+      headers: {
+        ...headersForHop(options.headers ?? {}, initialOrigin, parsed.origin),
+        ...options.headersForUrl?.(current),
+        Host: parsed.host,
+      },
+      ...(parsed.protocol === 'https:' ? { servername: hostname } : {}),
+      signal: options.signal,
+      lookup: createPublicSocketLookup(dependencies.resolveAddresses),
+      autoSelectFamily: false,
+    })
+    options.onResponse?.(response, current)
+    if (!isRedirectStatus(response.statusCode)) return { response, finalUrl: current }
+    try {
+      const location = headerValue(response.headers, 'location')
+      if (location === null) throw new Error(`redirect from ${current} omitted the Location header`)
+      if (redirects === maxRedirects) throw new Error(`redirect limit exceeded (${maxRedirects})`)
+      current = requirePublicHttpUrl(new URL(location, current).toString())
+    } finally {
+      response.cancel()
+    }
+  }
+  throw new Error('redirect limit exceeded')
+}
+
+function headersForHop(
+  headers: Record<string, string>,
+  initialOrigin: string,
+  currentOrigin: string,
+): Record<string, string> {
+  if (initialOrigin === currentOrigin) return headers
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !/^(authorization|cookie|proxy-authorization)$/i.test(name)),
+  )
+}
+
+export function createPublicSocketLookup(resolveAddresses: PublicHttpDependencies['resolveAddresses']): LookupFunction {
+  return (hostname, options, callback) => {
+    void resolveAddresses(hostname).then(
+      (addresses) => {
+        if (addresses.length === 0) {
+          callback(new Error(`DNS lookup returned no addresses for ${hostname}`), '', 0)
+          return
+        }
+        for (const candidate of addresses) {
+          const actualFamily = isIP(candidate.address)
+          if (actualFamily !== candidate.family || (actualFamily !== 4 && actualFamily !== 6)) {
+            callback(new Error(`DNS lookup returned an invalid address for ${hostname}`), '', 0)
+            return
+          }
+          const classification = classifyIpAddress(candidate.address)
+          if (classification.blocked) {
+            callback(
+              new Error(
+                `DNS lookup rejected non-public address for ${hostname}: ${classification.reason ?? candidate.address}`,
+              ),
+              '',
+              0,
+            )
+            return
+          }
+        }
+        const requestedFamily = options.family === 4 || options.family === 6 ? options.family : undefined
+        const chosen = addresses.find(
+          (candidate) => requestedFamily === undefined || candidate.family === requestedFamily,
+        )
+        if (chosen === undefined) {
+          callback(new Error(`DNS lookup returned no IPv${requestedFamily} address for ${hostname}`), '', 0)
+          return
+        }
+        if (options.all === true) callback(null, [chosen])
+        else callback(null, chosen.address, chosen.family)
+      },
+      (error: unknown) => callback(error instanceof Error ? error : new Error(String(error)), '', 0),
+    )
+  }
+}
+
+export function headerValue(headers: IncomingHttpHeaders, name: string): string | null {
+  const value = headers[name]
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export const defaultPublicHttpDependencies: PublicHttpDependencies = {
+  async resolveAddresses(hostname) {
+    const addresses = await dnsLookup(hostname, { all: true, verbatim: true })
+    return addresses.map((candidate) => {
+      if (candidate.family !== 4 && candidate.family !== 6) {
+        throw new Error(`DNS lookup returned unsupported family ${candidate.family} for ${hostname}`)
+      }
+      return { address: candidate.address, family: candidate.family }
+    })
+  },
+  async request(options) {
+    return await new Promise((resolve, reject) => {
+      const request = options.protocol === 'https:' ? httpsRequest : httpRequest
+      const outgoing = request(options, (response) => {
+        resolve({
+          statusCode: response.statusCode ?? 0,
+          headers: response.headers,
+          body: response,
+          cancel: () => response.destroy(),
+        })
+      })
+      outgoing.once('error', reject)
+      outgoing.end()
+    })
+  },
+}
+
+function requirePublicHttpUrl(rawUrl: string): string {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new Error(`URL must be a valid public HTTP(S) URL: ${rawUrl}`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`URL must use public HTTP(S), not ${parsed.protocol}`)
+  }
+  const classification = classifyUrl(parsed.toString())
+  if (classification.blocked) {
+    throw new Error(
+      `SSRF policy rejected non-public URL (${classification.category ?? 'internal'}): ${classification.reason ?? rawUrl}`,
+    )
+  }
+  return parsed.toString()
+}
+
+function unbracketHostname(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308
+}

--- a/src/agent/tools/webfetch/fetch.test.ts
+++ b/src/agent/tools/webfetch/fetch.test.ts
@@ -1,406 +1,232 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { describe, expect, test } from 'bun:test'
+import type { LookupAddress } from 'node:dns'
 
-import { isWindows } from '@/shared'
+import type { PublicHttpRequestOptions, PublicHttpResponse } from '@/agent/network/safe-http'
 
-import { _resetAvailabilityCacheForTest, _setCurlBinaryForTest } from '../curl-impersonate'
-import { _setForceFallbackForTest, fetchWithLimits, normalizeUrl, parseMimeType, WebFetchError } from './fetch'
-
-const onWindows = isWindows()
-
-type FetchInput = Parameters<typeof fetch>[0]
-type FetchArgs = { url: string; init: RequestInit | undefined }
-
-let fetchCalls: FetchArgs[]
-let fetchResponse: (args: FetchArgs) => Response | Promise<Response>
-const originalFetch = globalThis.fetch
-
-// Fake-curl shell-script template. We read the -w arg value (the curl
-// write-out template containing the per-request random sentinel) directly
-// out of argv by index — `printf '%s\\n' "$@"` collapses multi-line argv
-// values into adjacent lines, but Bun spawns each argv element as a
-// separate process argument, so positional `$N` accessors preserve the
-// raw value verbatim. We find the position of '-w' via a small loop and
-// emit `$N+1` as the template. Then substitute curl's %{...} codes for
-// our static body. Same pattern as curl-impersonate.test.ts.
-const FAKE_CURL = (body: string, status: number, finalUrl: string, contentType: string) => `
-ARGV_FILE="\${SCRATCH_ARGV:-/tmp/argv.txt}"
-printf '%s\\n' "$@" > "$ARGV_FILE"
-WTPL=""
-i=1
-for arg in "$@"; do
-  if [ "$arg" = "-w" ]; then
-    j=$((i + 1))
-    eval "WTPL=\\"\\\${$j}\\""
-    break
-  fi
-  i=$((i + 1))
-done
-# WTPL is e.g. "\\n--TYPECLAW-CURL-META-<hex>--\\n%{http_code}\\n..."
-# Replace curl's %{...} codes by hand.
-RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/${status}/' -e 's|%{url_effective}|${finalUrl}|' -e 's|%{content_type}|${contentType}|' -e 's/%{size_download}/${body.length}/')
-printf '%s' '${body}'
-printf '%s' "$RENDERED"
-`
-
-beforeEach(() => {
-  fetchCalls = []
-  globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
-    const url = typeof input === 'string' ? input : input.toString()
-    const args = { url, init }
-    fetchCalls.push(args)
-    return fetchResponse(args)
-  }) as typeof fetch
-  // Default mode: force the Bun.fetch fallback so existing assertions on
-  // mocked `globalThis.fetch` keep working. The impersonate-path tests
-  // below opt into the curl path explicitly.
-  _setForceFallbackForTest(true)
-  _resetAvailabilityCacheForTest()
-})
-
-afterEach(() => {
-  globalThis.fetch = originalFetch
-  _setForceFallbackForTest(false)
-  _setCurlBinaryForTest(null)
-  _resetAvailabilityCacheForTest()
-})
+import { fetchWithLimits, normalizeUrl, parseMimeType, type WebFetchNetworkDependencies, WebFetchError } from './fetch'
+import { MAX_RESPONSE_BYTES } from './types'
 
 describe('normalizeUrl', () => {
-  test('passes http and https through unchanged', () => {
-    expect(normalizeUrl('http://example.com')).toBe('http://example.com')
-    expect(normalizeUrl('https://example.com/path')).toBe('https://example.com/path')
-  })
-
-  test('prepends https:// to bare hostnames', () => {
-    expect(normalizeUrl('example.com')).toBe('https://example.com')
-    expect(normalizeUrl('example.com/foo?bar=1')).toBe('https://example.com/foo?bar=1')
-  })
-
-  test('rejects non-http(s) schemes', () => {
-    expect(() => normalizeUrl('ftp://example.com')).toThrow(WebFetchError)
+  test('normalizes HTTP(S) and rejects other schemes', () => {
+    expect(normalizeUrl('example.com/a')).toBe('https://example.com/a')
+    expect(normalizeUrl(' http://example.com ')).toBe('http://example.com')
     expect(() => normalizeUrl('file:///etc/passwd')).toThrow(WebFetchError)
-    expect(() => normalizeUrl('javascript:alert(1)')).toThrow(WebFetchError)
-  })
-
-  test('trims whitespace', () => {
-    expect(normalizeUrl('   https://example.com   ')).toBe('https://example.com')
   })
 })
 
 describe('parseMimeType', () => {
-  test('extracts mime type from content-type header', () => {
-    expect(parseMimeType('text/html; charset=utf-8')).toBe('text/html')
-    expect(parseMimeType('application/json')).toBe('application/json')
-    expect(parseMimeType('TEXT/PLAIN; charset=us-ascii')).toBe('text/plain')
-    expect(parseMimeType('')).toBe('')
+  test('normalizes the media type', () => {
+    expect(parseMimeType('TEXT/PLAIN; charset=utf-8')).toBe('text/plain')
   })
 })
 
-describe('fetchWithLimits — Bun.fetch fallback path', () => {
-  test('returns body, content-type, status, and final URL on success', async () => {
-    fetchResponse = () => new Response('hello', { status: 200, headers: { 'content-type': 'text/plain' } })
-
-    const result = await fetchWithLimits('https://example.com', 30)
-
+describe('fetchWithLimits safe transport', () => {
+  test('pins the socket lookup and preserves Host and SNI', async () => {
+    let observed: PublicHttpRequestOptions | undefined
+    const network = fixture({
+      request: async (options) => {
+        observed = options
+        expect(await socketAddress(options)).toEqual({ address: '93.184.216.34', family: 4 })
+        return response({ chunks: [new TextEncoder().encode('hello')], headers: { 'content-type': 'text/plain' } })
+      },
+    })
+    const result = await fetchWithLimits('https://example.com:8443/a', 30, undefined, 'off', network)
     expect(result.body).toBe('hello')
-    expect(result.contentType).toBe('text/plain')
-    expect(result.httpStatus).toBe(200)
-    expect(result.bytesIn).toBe(5)
+    expect(observed?.headers.Host).toBe('example.com:8443')
+    expect(observed?.servername).toBe('example.com')
   })
 
-  test('throws WebFetchError on non-2xx status', async () => {
-    fetchResponse = () => new Response('not found', { status: 404, statusText: 'Not Found' })
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 404/)
-  })
-
-  test('rejects responses larger than MAX_RESPONSE_BYTES via content-length header', async () => {
-    fetchResponse = () => new Response('x', { status: 200, headers: { 'content-length': String(10 * 1024 * 1024) } })
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Response too large/)
-  })
-
-  test('rejects responses larger than MAX_RESPONSE_BYTES via actual byte size', async () => {
-    const big = new Uint8Array(6 * 1024 * 1024)
-    fetchResponse = () => new Response(big, { status: 200 })
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Response too large/)
-  })
-
-  test('reports timeout with seconds in the error message', async () => {
-    fetchResponse = (args) =>
-      new Promise((_resolve, reject) => {
-        args.init?.signal?.addEventListener('abort', () => {
-          reject(new DOMException('aborted', 'AbortError'))
-        })
-      })
-
-    await expect(fetchWithLimits('https://example.com', 0.05)).rejects.toThrow(/timed out after 0\.05s/)
-  })
-
-  test('wraps unexpected fetch errors as WebFetchError', async () => {
-    fetchResponse = () => {
-      throw new Error('ECONNREFUSED')
-    }
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Fetch failed: ECONNREFUSED/)
-  })
-
-  test('sends typeclaw User-Agent on the fallback path', async () => {
-    fetchResponse = () => new Response('ok', { status: 200 })
-
-    await fetchWithLimits('https://example.com', 30)
-
-    const headers = fetchCalls[0]?.init?.headers as Record<string, string> | undefined
-    expect(headers?.['User-Agent']).toContain('typeclaw')
-  })
-})
-
-// POSIX-only fake shell binary without .exe/.cmd; Windows cannot spawn it (#899).
-describe.skipIf(onWindows)('fetchWithLimits — curl-impersonate path', () => {
-  let scratchDir: string
-
-  beforeEach(() => {
-    scratchDir = mkdtempSync(join(tmpdir(), 'webfetch-curl-test-'))
-    // Opt back into the real availability check (one of the tests below
-    // installs a fake binary; another asserts the fallback fires when no
-    // binary exists).
-    _setForceFallbackForTest(false)
-  })
-
-  afterEach(() => {
-    rmSync(scratchDir, { recursive: true, force: true })
-  })
-
-  function installFakeBinary(script: string): void {
-    const path = join(scratchDir, 'fake-curl')
-    const argvPath = join(scratchDir, 'argv.txt')
-    // Short-circuit --version (the availability probe) to exit 0 regardless
-    // of what the script body does on real invocations. Otherwise tests
-    // that simulate an error exit (e.g. exit 56) would also fail the
-    // availability check, silently falling through to the Bun.fetch path.
-    writeFileSync(
-      path,
-      `#!/bin/sh\nSCRATCH_ARGV="${argvPath}"\nif [ "$1" = "--version" ]; then exit 0; fi\n${script}\n`,
-      'utf8',
+  test.each([
+    ['loopback', [{ address: '127.0.0.1', family: 4 as const }]],
+    ['private', [{ address: '10.0.0.1', family: 4 as const }]],
+    ['benchmarking', [{ address: '198.18.24.9', family: 4 as const }]],
+    [
+      'mixed',
+      [
+        { address: '93.184.216.34', family: 4 as const },
+        { address: '192.168.1.2', family: 4 as const },
+      ],
+    ],
+  ])('rejects %s DNS answers used by the actual request lookup', async (_label, addresses) => {
+    const network = fixture({
+      resolveAddresses: async () => addresses,
+      request: async (options) => {
+        await socketAddress(options)
+        return response({})
+      },
+    })
+    await expect(fetchWithLimits('https://example.com', 30, undefined, 'off', network)).rejects.toThrow(
+      /non-public|DNS/,
     )
-    chmodSync(path, 0o755)
-    _setCurlBinaryForTest(path)
-    _resetAvailabilityCacheForTest()
-  }
-
-  test('uses curl-impersonate when the binary is available', async () => {
-    // given: fake binary that round-trips the per-request sentinel
-    installFakeBinary(FAKE_CURL('<html>ok</html>', 200, 'https://example.com/final', 'text/html; charset=utf-8'))
-
-    // when
-    const result = await fetchWithLimits('https://example.com', 30)
-
-    // then: the result came from curl, NOT from globalThis.fetch
-    expect(result.body).toBe('<html>ok</html>')
-    expect(result.contentType).toBe('text/html; charset=utf-8')
-    expect(result.httpStatus).toBe(200)
-    expect(result.finalUrl).toBe('https://example.com/final')
-    expect(fetchCalls).toHaveLength(0)
   })
 
-  test('translates curl non-2xx response into WebFetchError matching the fallback contract', async () => {
-    // given: fake binary that emits a 403-shaped response (Akamai-style block)
-    installFakeBinary(FAKE_CURL('<html>blocked</html>', 403, 'https://example.com', 'text/html'))
-
-    // when / then
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(WebFetchError)
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
+  test('validates and pins every redirect hop', async () => {
+    const hosts: string[] = []
+    const network = fixture({
+      resolveAddresses: async (hostname) =>
+        hostname === 'public.example'
+          ? [{ address: '93.184.216.34', family: 4 }]
+          : [{ address: '127.0.0.1', family: 4 }],
+      request: async (options) => {
+        hosts.push(options.hostname)
+        await socketAddress(options)
+        return response({ statusCode: 302, headers: { location: 'https://rebound.example/private' } })
+      },
+    })
+    await expect(fetchWithLimits('https://public.example', 30, undefined, 'off', network)).rejects.toThrow(/non-public/)
+    expect(hosts).toEqual(['public.example', 'rebound.example'])
   })
 
-  test('translates curl exit 28 (timeout) into a timeout-specific WebFetchError', async () => {
-    // given: fake binary that exits with code 28 (Operation timeout)
-    installFakeBinary('echo "Operation timed out after 30000 milliseconds" >&2; exit 28')
+  test('rejects a redirect to a literal 198.19.x benchmarking address before requesting it', async () => {
+    const hosts: string[] = []
+    const network = fixture({
+      request: async (options) => {
+        hosts.push(options.hostname)
+        await socketAddress(options)
+        return response({ statusCode: 302, headers: { location: 'http://198.19.7.8/private' } })
+      },
+    })
 
-    // when / then
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/timed out after 30s/)
+    await expect(fetchWithLimits('https://public.example', 30, undefined, 'off', network)).rejects.toThrow(
+      /SSRF|non-public|198\.19/,
+    )
+    expect(hosts).toEqual(['public.example'])
   })
 
-  test('translates curl exit 63 (content-length filesize overflow) into a too-large WebFetchError', async () => {
-    installFakeBinary('echo "Maximum file size exceeded" >&2; exit 63')
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Response too large/)
+  test('cancels non-2xx, declared-oversize, streaming-oversize, iteration-error, and successful responses', async () => {
+    for (const candidate of [
+      response({ statusCode: 404 }),
+      response({ headers: { 'content-length': String(MAX_RESPONSE_BYTES + 1) } }),
+      response({ chunks: [new Uint8Array(MAX_RESPONSE_BYTES + 1)] }),
+      response({ iterationError: new Error('body broke') }),
+      response({ chunks: [new Uint8Array([1])] }),
+    ]) {
+      const network = fixture({ request: async (options) => (await socketAddress(options), candidate) })
+      await fetchWithLimits('https://example.com', 30, undefined, 'off', network).catch(() => undefined)
+      expect(candidate.cancelled()).toBeTrue()
+    }
   })
 
-  test('translates curl exit 56 + filesize stderr into a too-large WebFetchError', async () => {
-    // given: fake emits the transfer-time variant Oracle verified empirically
-    installFakeBinary('echo "Exceeded the maximum allowed file size (1) with 1 bytes" >&2; exit 56')
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Response too large/)
+  test('safely replays Akamai cookie warmup through the same pinned transport', async () => {
+    const seenCookies: Array<string | undefined> = []
+    let calls = 0
+    const network = fixture({
+      request: async (options) => {
+        await socketAddress(options)
+        seenCookies.push(options.headers.Cookie)
+        calls++
+        return calls === 1
+          ? response({ statusCode: 403, headers: { 'set-cookie': ['_abck=one; Path=/', 'bm_sz=two'] } })
+          : response({ chunks: [new TextEncoder().encode('ok')] })
+      },
+    })
+    const result = await fetchWithLimits('https://example.com', 30, undefined, 'auto', network)
+    expect(result.body).toBe('ok')
+    expect(result.antibotWarmup?.triggered).toBeTrue()
+    expect(seenCookies).toEqual([undefined, '_abck=one; bm_sz=two'])
   })
 
-  test('does NOT misclassify generic exit 56 (recv failure) as filesize exceeded', async () => {
-    installFakeBinary('echo "Recv failure: Connection reset by peer" >&2; exit 56')
+  test('scopes warmup cookies to each URL across redirects', async () => {
+    const seen: Array<{ host: string; path: string; cookie?: string }> = []
+    let calls = 0
+    const network = fixture({
+      request: async (options) => {
+        await socketAddress(options)
+        seen.push({
+          host: options.hostname,
+          path: options.path,
+          ...(options.headers.Cookie === undefined ? {} : { cookie: options.headers.Cookie }),
+        })
+        calls++
+        if (options.hostname === 'app.example') {
+          return response({
+            statusCode: 302,
+            headers: {
+              location: 'https://cdn.app.example/challenge',
+              'set-cookie': ['_abck=one; Domain=.app.example; Path=/challenge; Secure'],
+            },
+          })
+        }
+        return calls === 2 ? response({ statusCode: 403 }) : response({ chunks: [new TextEncoder().encode('ok')] })
+      },
+    })
 
-    // when / then: it's a generic Fetch failed:, not "Response too large"
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/Fetch failed.*exited 56/)
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.not.toThrow(/Response too large/)
+    const result = await fetchWithLimits('https://app.example/', 30, undefined, 'auto', network)
+
+    expect(result.body).toBe('ok')
+    expect(result.antibotWarmup?.triggered).toBeTrue()
+    expect(seen).toEqual([
+      { host: 'app.example', path: '/' },
+      { host: 'cdn.app.example', path: '/challenge', cookie: '_abck=one' },
+      { host: 'app.example', path: '/' },
+      { host: 'cdn.app.example', path: '/challenge', cookie: '_abck=one' },
+    ])
   })
 
-  test('falls back to Bun.fetch when curl-impersonate is not installed', async () => {
-    // given: point the curl resolver at a path that doesn't exist, and have
-    // globalThis.fetch ready to serve a known body
-    _setCurlBinaryForTest('/nonexistent/curl_chrome136')
-    _resetAvailabilityCacheForTest()
-    fetchResponse = () => new Response('fallback body', { status: 200, headers: { 'content-type': 'text/plain' } })
+  test.each([
+    ['foreign domain', '_abck=one; Domain=other.example; Path=/'],
+    ['different path', '_abck=one; Path=/challenge'],
+    ['secure over HTTP', '_abck=one; Path=/; Secure'],
+    ['expired', '_abck=one; Path=/; Max-Age=0'],
+  ])('does not replay a %s warmup cookie', async (_label, setCookie) => {
+    let calls = 0
+    const network = fixture({
+      request: async (options) => {
+        await socketAddress(options)
+        calls++
+        return response({ statusCode: 403, headers: { 'set-cookie': [setCookie] } })
+      },
+    })
 
-    // when
-    const result = await fetchWithLimits('https://example.com', 30)
-
-    // then: globalThis.fetch was the actual transport
-    expect(result.body).toBe('fallback body')
-    expect(fetchCalls).toHaveLength(1)
+    await expect(fetchWithLimits('http://app.example/product', 30, undefined, 'auto', network)).rejects.toThrow(
+      /HTTP 403/,
+    )
+    expect(calls).toBe(1)
   })
 })
 
-// A fake curl that renders a single response including %{header_json}, so the
-// primitive can parse Set-Cookie names. headerJson is baked in via a @@HJ@@
-// placeholder to dodge sed metacharacter issues (see curl-impersonate.test.ts).
-function fakeCurlWithHeaders(body: string, status: number, headerJson: string): string {
-  return `
-ARGV_FILE="\${SCRATCH_ARGV:-/tmp/argv.txt}"
-printf '%s\\n' "$@" > "$ARGV_FILE"
-WTPL=""
-i=1
-for arg in "$@"; do
-  if [ "$arg" = "-w" ]; then
-    j=$((i + 1))
-    eval "WTPL=\\"\\\${$j}\\""
-    break
-  fi
-  i=$((i + 1))
-done
-RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/${status}/' -e 's|%{url_effective}|https://example.com|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/${body.length}/' -e 's|%{header_json}|@@HJ@@|')
-printf '%s' '${body}'
-printf '%s' "$RENDERED" | sed "s|@@HJ@@|$(printf '%s' '${headerJson.replace(/'/g, `'\\''`).replace(/\|/g, '\\\\|')}')|"
-`
+function fixture(overrides: Partial<WebFetchNetworkDependencies> = {}): WebFetchNetworkDependencies {
+  return {
+    resolveAddresses: async () => [{ address: '93.184.216.34', family: 4 }],
+    request: async (options) => (await socketAddress(options), response({ chunks: [new Uint8Array([1])] })),
+    ...overrides,
+  }
 }
 
-// POSIX-only fake shell binary. Windows cannot spawn it (#899).
-describe.skipIf(onWindows)('fetchWithLimits — antibot cookie warmup', () => {
-  let scratchDir: string
-  let curlPath: string
-  let countPath: string
-
-  beforeEach(() => {
-    scratchDir = mkdtempSync(join(tmpdir(), 'webfetch-warmup-test-'))
-    curlPath = join(scratchDir, 'fake-curl')
-    countPath = join(scratchDir, 'count')
-    _setForceFallbackForTest(false)
-  })
-
-  afterEach(() => {
-    rmSync(scratchDir, { recursive: true, force: true })
-  })
-
-  function install(script: string): void {
-    writeFileSync(
-      curlPath,
-      `#!/bin/sh\nSCRATCH_ARGV="${join(scratchDir, 'argv.txt')}"\nif [ "$1" = "--version" ]; then exit 0; fi\n${script}\n`,
-      'utf8',
-    )
-    chmodSync(curlPath, 0o755)
-    _setCurlBinaryForTest(curlPath)
-    _resetAvailabilityCacheForTest()
+function response(options: {
+  statusCode?: number
+  headers?: PublicHttpResponse['headers']
+  chunks?: Uint8Array[]
+  iterationError?: Error
+}): PublicHttpResponse & { cancelled(): boolean } {
+  let wasCancelled = false
+  return {
+    statusCode: options.statusCode ?? 200,
+    headers: options.headers ?? {},
+    body: {
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of options.chunks ?? []) yield chunk
+        if (options.iterationError !== undefined) throw options.iterationError
+      },
+    },
+    cancel: () => {
+      wasCancelled = true
+    },
+    cancelled: () => wasCancelled,
   }
+}
 
-  // A two-call fake: first invocation emits `first`, second emits `second`.
-  // State is a counter file so the two curlImpersonate() spawns diverge.
-  function installTwoCall(first: string, second: string): void {
-    const dispatch = `
-if [ "$1" = "--version" ]; then exit 0; fi
-COUNT_FILE="${countPath}"
-N=$(cat "$COUNT_FILE" 2>/dev/null || printf '0')
-printf '%s' "$((N + 1))" > "$COUNT_FILE"
-if [ "$N" = "0" ]; then
-${first}
-else
-${second}
-fi
-`
-    writeFileSync(curlPath, `#!/bin/sh\nSCRATCH_ARGV="${join(scratchDir, 'argv.txt')}"\n${dispatch}\n`, 'utf8')
-    chmodSync(curlPath, 0o755)
-    _setCurlBinaryForTest(curlPath)
-    _resetAvailabilityCacheForTest()
-  }
-
-  test('plain 200: no warmup attempted flag surfaced as triggered', async () => {
-    install(fakeCurlWithHeaders('<html>ok</html>', 200, '{"content-type":["text/html"]}'))
-
-    const result = await fetchWithLimits('https://example.com', 30)
-
-    expect(result.httpStatus).toBe(200)
-    expect(result.antibotWarmup?.triggered).toBe(false)
+async function socketAddress(options: PublicHttpRequestOptions): Promise<{ address: string; family: number }> {
+  return await new Promise((resolve, reject) => {
+    options.lookup(options.hostname, {}, (error, address, family) => {
+      if (error !== null) return reject(error)
+      if (Array.isArray(address)) {
+        const first = address[0] as LookupAddress | undefined
+        if (first === undefined) return reject(new Error('no address'))
+        resolve(first)
+        return
+      }
+      resolve({ address, family: family ?? 0 })
+    })
   })
-
-  test('403 with bot-manager Set-Cookie: replays once and returns the 200', async () => {
-    const first = fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz; Path=/","bm_sz=abc"]}')
-    const second = fakeCurlWithHeaders('<html>product</html>', 200, '{"content-type":["text/html"]}')
-    installTwoCall(first, second)
-
-    const result = await fetchWithLimits('https://example.com', 30)
-
-    expect(result.httpStatus).toBe(200)
-    expect(result.body).toBe('<html>product</html>')
-    expect(result.antibotWarmup?.triggered).toBe(true)
-    expect(result.antibotWarmup?.initialStatus).toBe(403)
-    expect(result.antibotWarmup?.initialSetCookieNames).toEqual(['_abck', 'bm_sz'])
-    expect(result.antibotWarmup?.replayStatus).toBe(200)
-  })
-
-  test('403 WITHOUT a bot-manager cookie: no replay, throws HTTP 403', async () => {
-    install(fakeCurlWithHeaders('nope', 403, '{"set-cookie":["session=abc"]}'))
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
-  })
-
-  test('401 with a bot cookie present: no replay (only 403 triggers), throws HTTP 401', async () => {
-    install(fakeCurlWithHeaders('unauth', 401, '{"set-cookie":["_abck=xyz"]}'))
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 401/)
-  })
-
-  test('403 with only a normal app cookie: no replay, throws HTTP 403', async () => {
-    install(fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["JSESSIONID=abc; Path=/"]}'))
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
-  })
-
-  test('403 with bot cookie, replay still 403: throws final HTTP 403', async () => {
-    const first = fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz"]}')
-    const second = fakeCurlWithHeaders('blocked again', 403, '{"set-cookie":["_abck=xyz2"]}')
-    installTwoCall(first, second)
-
-    await expect(fetchWithLimits('https://example.com', 30)).rejects.toThrow(/HTTP 403/)
-  })
-
-  test('antibotWarmup="off": a bot-manager 403 is NOT replayed, throws HTTP 403', async () => {
-    const first = fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz"]}')
-    const second = fakeCurlWithHeaders('<html>product</html>', 200, '{"content-type":["text/html"]}')
-    installTwoCall(first, second)
-
-    await expect(fetchWithLimits('https://example.com', 30, undefined, 'off')).rejects.toThrow(/HTTP 403/)
-  })
-
-  test('replay is charged the remaining budget, not a fresh timeout', async () => {
-    // given: the first request eats the whole 1s budget before returning a
-    // bot-manager 403, so no time is left to replay.
-    const first = `sleep 1.2\n${fakeCurlWithHeaders('blocked', 403, '{"set-cookie":["_abck=xyz"]}')}`
-    const second = fakeCurlWithHeaders('<html>product</html>', 200, '{"content-type":["text/html"]}')
-    installTwoCall(first, second)
-
-    // when / then: it surfaces the initial 403 rather than spending a second
-    // full budget on the replay.
-    await expect(fetchWithLimits('https://example.com', 1)).rejects.toThrow(/HTTP 403/)
-
-    // and: the replay never ran (counter advanced only for the first call).
-    expect(readFileSync(countPath, 'utf8')).toBe('1')
-  })
-})
+}

--- a/src/agent/tools/webfetch/fetch.ts
+++ b/src/agent/tools/webfetch/fetch.ts
@@ -1,38 +1,13 @@
-// WebFetch's HTTP transport.
-//
-// Production path (container, curl-impersonate available): we shell out to
-// `curl_chrome136` so outbound requests carry Chrome 136's TLS handshake
-// (JA3/JA4), HTTP/2 SETTINGS frame, and full header set. This is what gets
-// us past the modern bot-detection stacks on Cloudflare/Akamai-protected
-// sites (Reuters, MarketWatch, etc.) when the agent is running from the
-// user's home network — the IP is already residential, so impersonating
-// the browser is the only remaining missing piece. See AGENTS.md §"Web
-// search" and src/agent/tools/curl-impersonate.ts for the full story.
-//
-// Test/dev fallback (curl_chrome136 not on PATH): we transparently fall
-// back to Bun's native `fetch()` with a static User-Agent. This keeps unit
-// tests on developer macOS machines working without forcing every contributor
-// to install curl-impersonate locally. Production runs always have the binary
-// because the typeclaw Dockerfile pins it.
-//
-// Best-effort doctrine: this transport does NOT guarantee the fetch succeeds.
-// Bot-detected sites can still serve 403/CAPTCHA pages. We surface what we
-// got (status, body, final URL) and let the caller decide. The web_fetch tool
-// translates non-2xx into a tool-level error message that's useful to the
-// model.
-
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { CookieJar } from 'tough-cookie'
 
 import {
-  CurlImpersonateError,
-  curlImpersonate,
-  type CurlImpersonateResponse,
-  isCurlExitFilesizeExceeded,
-  isCurlExitTimeout,
-  isCurlImpersonateAvailable,
-} from '../curl-impersonate'
+  defaultPublicHttpDependencies,
+  headerValue,
+  requestPublicHttpUrl,
+  type PublicHttpDependencies,
+  type PublicHttpResponse,
+} from '@/agent/network/safe-http'
+
 import { MAX_RESPONSE_BYTES } from './types'
 
 export type AntibotWarmup = 'auto' | 'off'
@@ -54,17 +29,9 @@ export type FetchResult = {
   antibotWarmup?: AntibotWarmupInfo
 }
 
-// Cookie names Akamai Bot Manager sets in the Set-Cookie of its 403 challenge.
-// A 403 carrying one of these is a state-bootstrap handshake (absorb cookies,
-// replay once), NOT an authorization failure — that distinction is what makes
-// the auto-retry safe. Scoped to Akamai on purpose: Cloudflare/DataDome use
-// different challenge semantics (JS/redirects/CAPTCHA) that a blind replay
-// would not satisfy.
-const AKAMAI_BOTMANAGER_COOKIE = /^(_abck|bm_sz|bm_s|bm_ss|bm_so|ak_bmsc)$/i
+export type WebFetchNetworkDependencies = PublicHttpDependencies
 
-function isAntibotWarmup403(response: CurlImpersonateResponse): boolean {
-  return response.httpStatus === 403 && response.setCookieNames.some((name) => AKAMAI_BOTMANAGER_COOKIE.test(name))
-}
+const AKAMAI_BOTMANAGER_COOKIE = /^(_abck|bm_sz|bm_s|bm_ss|bm_so|ak_bmsc)$/i
 
 export class WebFetchError extends Error {
   constructor(message: string) {
@@ -73,7 +40,7 @@ export class WebFetchError extends Error {
   }
 }
 
-const FALLBACK_HEADERS: Record<string, string> = {
+const REQUEST_HEADERS: Record<string, string> = {
   'User-Agent': 'typeclaw/0 (+https://github.com/code-yeongyu/typeclaw)',
   Accept: 'text/html,application/xhtml+xml,application/json;q=0.9,text/plain;q=0.8,*/*;q=0.1',
   'Accept-Language': 'en-US,en;q=0.9',
@@ -90,10 +57,6 @@ export function normalizeUrl(input: string): string {
   return `https://${trimmed}`
 }
 
-// Test-only seam: forces fetchWithLimits to use the native-fetch fallback
-// even when curl-impersonate is detected. Used by fetch.test.ts to keep its
-// existing mocked-fetch contract working without the test having to install
-// a fake curl binary. Production code never calls this.
 let forceFallbackForTest = false
 
 export function _setForceFallbackForTest(value: boolean): void {
@@ -105,175 +68,172 @@ export async function fetchWithLimits(
   timeoutSeconds: number,
   parentSignal?: AbortSignal,
   antibotWarmup: AntibotWarmup = 'auto',
-): Promise<FetchResult> {
-  const useImpersonate = !forceFallbackForTest && (await isCurlImpersonateAvailable())
-  if (useImpersonate) {
-    return fetchWithCurlImpersonate(url, timeoutSeconds, antibotWarmup, parentSignal)
-  }
-  return fetchWithBunFetch(url, timeoutSeconds, parentSignal)
-}
-
-async function fetchWithCurlImpersonate(
-  url: string,
-  timeoutSeconds: number,
-  antibotWarmup: AntibotWarmup,
-  parentSignal?: AbortSignal,
-): Promise<FetchResult> {
-  if (antibotWarmup === 'off') {
-    const response = await runCurl(url, timeoutSeconds, undefined, parentSignal)
-    return toFetchResult(url, response)
-  }
-
-  // Warmup needs a jar shared across both requests: request 1 (`-c`) captures
-  // the bot-manager cookies the 403 sets; request 2 (`-b`) replays them.
-  const jarDir = await mkdtemp(join(tmpdir(), 'typeclaw-webfetch-jar-'))
-  const jarPath = join(jarDir, 'cookies.txt')
-  const startedAt = Date.now()
-  try {
-    const first = await runCurl(url, timeoutSeconds, jarPath, parentSignal)
-    if (!isAntibotWarmup403(first)) {
-      return toFetchResult(url, first, { attempted: true, triggered: false })
-    }
-
-    // `timeoutSeconds` is the budget for the WHOLE web_fetch call, not per
-    // attempt: charge the replay only the time the first request left, so a
-    // warmed fetch can't run for ~2x the requested timeout. If the first
-    // request already spent the budget, surface its 403 instead of forcing a
-    // zero-time replay that would just time out.
-    const remaining = timeoutSeconds - (Date.now() - startedAt) / 1000
-    if (remaining < 1) {
-      return toFetchResult(url, first, {
-        attempted: true,
-        triggered: false,
-        initialStatus: first.httpStatus,
-        initialSetCookieNames: first.setCookieNames,
-      })
-    }
-
-    const replay = await runCurl(url, Math.floor(remaining), jarPath, parentSignal)
-    return toFetchResult(url, replay, {
-      attempted: true,
-      triggered: true,
-      initialStatus: first.httpStatus,
-      initialSetCookieNames: first.setCookieNames,
-      replayStatus: replay.httpStatus,
-    })
-  } finally {
-    await rm(jarDir, { recursive: true, force: true })
-  }
-}
-
-async function runCurl(
-  url: string,
-  timeoutSeconds: number,
-  cookieJarPath: string | undefined,
-  parentSignal?: AbortSignal,
-): Promise<CurlImpersonateResponse> {
-  try {
-    return await curlImpersonate({
-      url,
-      method: 'GET',
-      timeoutSeconds,
-      maxBytes: MAX_RESPONSE_BYTES,
-      cookieJarPath,
-      signal: parentSignal,
-    })
-  } catch (error) {
-    if (parentSignal?.aborted) {
-      throw new WebFetchError('Request aborted')
-    }
-    if (error instanceof CurlImpersonateError) {
-      if (isCurlExitTimeout(error)) {
-        throw new WebFetchError(`Request timed out after ${timeoutSeconds}s`)
-      }
-      if (isCurlExitFilesizeExceeded(error)) {
-        throw new WebFetchError(`Response too large (exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`)
-      }
-      throw new WebFetchError(`Fetch failed: ${error.message}`)
-    }
-    const message = error instanceof Error ? error.message : String(error)
-    throw new WebFetchError(`Fetch failed: ${message}`)
-  }
-}
-
-function toFetchResult(url: string, response: CurlImpersonateResponse, antibotWarmup?: AntibotWarmupInfo): FetchResult {
-  if (response.httpStatus < 200 || response.httpStatus >= 300) {
-    throw new WebFetchError(`Fetch failed: HTTP ${response.httpStatus}`)
-  }
-
-  const bodyByteLength = new TextEncoder().encode(response.body).byteLength
-  if (bodyByteLength > MAX_RESPONSE_BYTES) {
-    throw new WebFetchError(
-      `Response too large (${formatBytes(bodyByteLength)} exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`,
-    )
-  }
-
-  return {
-    body: response.body,
-    contentType: response.contentType,
-    finalUrl: response.finalUrl || url,
-    httpStatus: response.httpStatus,
-    bytesIn: bodyByteLength,
-    ...(antibotWarmup ? { antibotWarmup } : {}),
-  }
-}
-
-async function fetchWithBunFetch(
-  url: string,
-  timeoutSeconds: number,
-  parentSignal?: AbortSignal,
+  network: WebFetchNetworkDependencies = forceFallbackForTest ? testFetchDependencies : defaultPublicHttpDependencies,
 ): Promise<FetchResult> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(new Error('timeout')), timeoutSeconds * 1000)
   const onAbort = () => controller.abort(parentSignal?.reason)
   parentSignal?.addEventListener('abort', onAbort, { once: true })
-
+  const startedAt = Date.now()
   try {
-    const response = await fetch(url, { headers: FALLBACK_HEADERS, signal: controller.signal, redirect: 'follow' })
-    if (!response.ok) {
-      throw new WebFetchError(`Fetch failed: HTTP ${response.status} ${response.statusText}`)
+    const cookieJar = new WarmupCookieJar()
+    const visitedUrls = new Set<string>()
+    const first = await fetchOnce(url, controller.signal, network, REQUEST_HEADERS, cookieJar, visitedUrls)
+    const cookieNames = cookieJar.names()
+    const warmup =
+      antibotWarmup === 'auto' &&
+      first.statusCode === 403 &&
+      [...visitedUrls].some((visitedUrl) => cookieJar.hasMatching(visitedUrl, AKAMAI_BOTMANAGER_COOKIE))
+    if (!warmup) {
+      return toFetchResult(first, { attempted: antibotWarmup === 'auto', triggered: false })
     }
 
-    const contentLengthHeader = response.headers.get('content-length')
-    if (contentLengthHeader) {
-      const declared = Number(contentLengthHeader)
-      if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
-        throw new WebFetchError(
-          `Response too large (${formatBytes(declared)} exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`,
-        )
-      }
+    const remainingMs = timeoutSeconds * 1000 - (Date.now() - startedAt)
+    if (remainingMs < 1_000) {
+      return toFetchResult(first, {
+        attempted: true,
+        triggered: false,
+        initialStatus: first.statusCode,
+        initialSetCookieNames: cookieNames,
+      })
     }
-
-    const buffer = await response.arrayBuffer()
-    if (buffer.byteLength > MAX_RESPONSE_BYTES) {
-      throw new WebFetchError(
-        `Response too large (${formatBytes(buffer.byteLength)} exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`,
-      )
-    }
-
-    const body = new TextDecoder('utf-8', { fatal: false }).decode(buffer)
-    return {
-      body,
-      contentType: response.headers.get('content-type') ?? '',
-      finalUrl: response.url || url,
-      httpStatus: response.status,
-      bytesIn: buffer.byteLength,
-    }
+    const replay = await fetchOnce(url, controller.signal, network, REQUEST_HEADERS, cookieJar)
+    return toFetchResult(replay, {
+      attempted: true,
+      triggered: true,
+      initialStatus: first.statusCode,
+      initialSetCookieNames: cookieNames,
+      replayStatus: replay.statusCode,
+    })
   } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof Error &&
-      controller.signal.reason.message === 'timeout'
-    ) {
-      throw new WebFetchError(`Request timed out after ${timeoutSeconds}s`)
+    if (controller.signal.aborted) {
+      if (controller.signal.reason instanceof Error && controller.signal.reason.message === 'timeout') {
+        throw new WebFetchError(`Request timed out after ${timeoutSeconds}s`)
+      }
+      throw new WebFetchError('Request aborted')
     }
     if (error instanceof WebFetchError) throw error
-    const message = error instanceof Error ? error.message : String(error)
-    throw new WebFetchError(`Fetch failed: ${message}`)
+    throw new WebFetchError(`Fetch failed: ${error instanceof Error ? error.message : String(error)}`)
   } finally {
     clearTimeout(timeout)
     parentSignal?.removeEventListener('abort', onAbort)
   }
+}
+
+const testFetchDependencies: WebFetchNetworkDependencies = {
+  resolveAddresses: async () => [{ address: '93.184.216.34', family: 4 }],
+  async request(options) {
+    const url = `${options.protocol}//${options.headers.Host}${options.path}`
+    const response = await fetch(url, { headers: options.headers, signal: options.signal, redirect: 'manual' })
+    return {
+      statusCode: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      body: response.body ?? emptyBody(),
+      cancel: () => {
+        void response.body?.cancel()
+      },
+    }
+  },
+}
+
+async function* emptyBody(): AsyncIterable<Uint8Array> {}
+
+type BufferedResponse = {
+  body: Uint8Array
+  headers: PublicHttpResponse['headers']
+  statusCode: number
+  finalUrl: string
+}
+
+async function fetchOnce(
+  url: string,
+  signal: AbortSignal,
+  network: WebFetchNetworkDependencies,
+  headers: Record<string, string>,
+  cookieJar?: WarmupCookieJar,
+  visitedUrls?: Set<string>,
+): Promise<BufferedResponse> {
+  const { response, finalUrl } = await requestPublicHttpUrl(url, {
+    signal,
+    headers,
+    dependencies: network,
+    headersForUrl(currentUrl): Record<string, string> {
+      visitedUrls?.add(currentUrl)
+      const cookie = cookieJar?.header(currentUrl)
+      if (cookie === undefined) return {}
+      return { Cookie: cookie }
+    },
+    onResponse(response, responseUrl) {
+      cookieJar?.store(response.headers, responseUrl)
+    },
+  })
+  try {
+    const declared = Number(headerValue(response.headers, 'content-length') ?? '')
+    if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
+      throw tooLarge(declared)
+    }
+    const chunks: Uint8Array[] = []
+    let total = 0
+    for await (const chunk of response.body) {
+      total += chunk.byteLength
+      if (total > MAX_RESPONSE_BYTES) throw tooLarge(total)
+      chunks.push(chunk)
+    }
+    return { body: Buffer.concat(chunks), headers: response.headers, statusCode: response.statusCode, finalUrl }
+  } finally {
+    response.cancel()
+  }
+}
+
+function toFetchResult(response: BufferedResponse, antibotWarmup?: AntibotWarmupInfo): FetchResult {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new WebFetchError(`Fetch failed: HTTP ${response.statusCode}`)
+  }
+  return {
+    body: new TextDecoder('utf-8', { fatal: false }).decode(response.body),
+    contentType: headerValue(response.headers, 'content-type') ?? '',
+    finalUrl: response.finalUrl,
+    httpStatus: response.statusCode,
+    bytesIn: response.body.byteLength,
+    ...(antibotWarmup !== undefined ? { antibotWarmup } : {}),
+  }
+}
+
+function setCookieValues(headers: PublicHttpResponse['headers']): string[] {
+  const value = headers['set-cookie']
+  if (Array.isArray(value)) return value
+  return value === undefined ? [] : [value]
+}
+
+class WarmupCookieJar {
+  readonly #jar = new CookieJar()
+  readonly #names = new Set<string>()
+
+  store(headers: PublicHttpResponse['headers'], responseUrl: string): void {
+    for (const value of setCookieValues(headers)) {
+      const cookie = this.#jar.setCookieSync(value, responseUrl, { ignoreError: true })
+      if (cookie !== undefined) this.#names.add(cookie.key)
+    }
+  }
+
+  names(): string[] {
+    return [...this.#names]
+  }
+
+  hasMatching(rawUrl: string, namePattern: RegExp): boolean {
+    return this.#jar.getCookiesSync(rawUrl).some((cookie) => namePattern.test(cookie.key))
+  }
+
+  header(rawUrl: string): string | undefined {
+    const header = this.#jar.getCookieStringSync(rawUrl)
+    return header === '' ? undefined : header
+  }
+}
+
+function tooLarge(bytes: number): WebFetchError {
+  return new WebFetchError(
+    `Response too large (${formatBytes(bytes)} exceeds ${formatBytes(MAX_RESPONSE_BYTES)} limit)`,
+  )
 }
 
 export function parseMimeType(contentType: string): string {

--- a/src/agent/tools/webfetch/tool.test.ts
+++ b/src/agent/tools/webfetch/tool.test.ts
@@ -57,7 +57,7 @@ describe('webfetch: URL handling', () => {
 
     await webFetchTool.execute('id', { url: 'example.com' }, undefined, undefined, ctx)
 
-    expect(fetchCalls[0]?.url).toBe('https://example.com')
+    expect(fetchCalls[0]?.url).toBe('https://example.com/')
   })
 
   test('rejects non-http(s) schemes without a network call', async () => {

--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -25,8 +25,7 @@ export const webFetchTool = defineTool({
     'Fetch a single HTTP(S) URL and return the body, optionally compacted by a strategy. ' +
     'Use this when the user references a specific URL or when web_search surfaced a result you need to read in full. ' +
     'If `spawn_subagent` is available to you, PREFER delegating to the `scout` subagent by default: spawn it whenever you expect more than one fetch, an "across multiple sources" task, or any search-then-fetch loop. Scout runs the noisy fetching in its own context window and returns a distilled, citation-backed answer, keeping bulky page bodies out of yours. Only call this tool directly for a single known URL whose content you will cite immediately — or whenever you cannot spawn subagents (e.g. you are yourself a subagent), in which case fetch here. ' +
-    'Outbound requests impersonate Chrome 136 at the TLS, HTTP/2, and header layers ' +
-    '(via curl-impersonate), which helps with TLS/header fingerprint gates on sites behind Cloudflare/Akamai. ' +
+    'Outbound requests use a DNS-rebinding-safe transport that validates and pins every redirect hop. ' +
     'For Akamai Bot Manager specifically, it auto-warms the session: a first-request 403 that sets bot-manager ' +
     'cookies (_abck/bm_sz/…) is absorbed and replayed once, which returns 200 on many Akamai-fronted sites ' +
     '(disable with `antibotWarmup: "off"`). It still does NOT solve JavaScript challenges, behavioural ' +
@@ -40,7 +39,7 @@ export const webFetchTool = defineTool({
     '- "snapshot": indented semantic tree of the page (forms, headings, links).\n' +
     '- "raw": no processing.\n' +
     'If `strategy` is omitted, it is inferred from content-type. JSON responses require explicit `strategy: "jq"` (or "raw"). ' +
-    'No SSRF protection is applied; do not use on untrusted user-supplied URLs without an outer guard.',
+    'Private, mixed-address, and non-HTTP(S) targets are rejected.',
   parameters: Type.Object({
     url: Type.String({
       description: 'URL to fetch (http:// or https://). Bare hostnames are rewritten to https://.',

--- a/src/bundled-plugins/security/policies/ssrf.test.ts
+++ b/src/bundled-plugins/security/policies/ssrf.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { GUARD_SSRF, checkSsrfGuard, classifyUrl } from './ssrf'
+import { GUARD_SSRF, checkSsrfGuard, classifyIpAddress, classifyUrl } from './ssrf'
 
 describe('SSRF classifier', () => {
   test('blocks AWS IMDS metadata endpoint', () => {
@@ -50,6 +50,14 @@ describe('SSRF classifier', () => {
     expect(classifyUrl('http://100.128.0.1/').blocked).toBe(false)
   })
 
+  test('blocks the full 198.18.0.0/15 benchmarking range', () => {
+    expect(classifyUrl('http://198.18.0.1/').blocked).toBe(true)
+    expect(classifyUrl('http://198.19.42.7/internal').blocked).toBe(true)
+    expect(classifyUrl('http://198.19.255.255/').blocked).toBe(true)
+    expect(classifyUrl('http://198.17.255.255/').blocked).toBe(false)
+    expect(classifyUrl('http://198.20.0.0/').blocked).toBe(false)
+  })
+
   test('blocks decimal-encoded loopback (127.0.0.1 = 2130706433)', () => {
     expect(classifyUrl('http://2130706433/').blocked).toBe(true)
   })
@@ -73,6 +81,24 @@ describe('SSRF classifier', () => {
 
   test('blocks IPv4-mapped IPv6 loopback', () => {
     expect(classifyUrl('http://[::ffff:127.0.0.1]/').blocked).toBe(true)
+  })
+
+  test.each([
+    '0:0:0:0:0:ffff:7f00:1',
+    '0:0:0::ffff:7f00:1',
+    '0000:0000:0000:0000:0000:ffff:7f00:0001',
+    '::ffff:7f00:1',
+    '::ffff:127.0.0.1',
+  ])('blocks semantically equivalent IPv4-mapped IPv6 loopback %s', (address) => {
+    expect(classifyIpAddress(address)).toEqual({
+      blocked: true,
+      category: 'loopback',
+      reason: 'IPv4-mapped IPv6: IPv4 loopback (127.0.0.1)',
+    })
+  })
+
+  test('allows an IPv4-mapped public address', () => {
+    expect(classifyIpAddress('0:0:0:0:0:ffff:808:808')).toEqual({ blocked: false })
   })
 
   test('blocks .internal / .local / .corp / .home suffixes', () => {

--- a/src/bundled-plugins/security/policies/ssrf.ts
+++ b/src/bundled-plugins/security/policies/ssrf.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net'
+
 import type { SecuritySeverity } from '../permissions'
 import { ACKNOWLEDGE_GUARDS, type SecurityBlock, isGuardAcknowledged } from '../policy'
 
@@ -84,18 +86,35 @@ export function classifyUrl(rawUrl: string): SsrfClassification {
     }
   }
 
+  const addressClassification = classifyIpAddress(decoded)
+  if (addressClassification.blocked) return addressClassification
+
+  return { blocked: false }
+}
+
+export function classifyIpAddress(address: string): SsrfClassification {
+  const decoded = decodeBracketedIpv6(address.toLowerCase().split('%')[0] ?? '')
   const ipv4 = parseIpv4Loose(decoded)
   if (ipv4) {
     const cls = classifyIpv4(ipv4)
     if (cls) return { blocked: true, category: cls.category, reason: cls.reason }
+    return { blocked: false }
   }
-
-  if (looksLikeIpv6(decoded)) {
-    const cls = classifyIpv6(decoded)
+  const normalizedIpv6 = normalizeIpv6(decoded)
+  if (normalizedIpv6 !== undefined) {
+    const cls = classifyIpv6(normalizedIpv6)
     if (cls) return { blocked: true, category: cls.category, reason: cls.reason }
   }
-
   return { blocked: false }
+}
+
+function normalizeIpv6(address: string): string | undefined {
+  if (isIP(address) !== 6) return undefined
+  try {
+    return decodeBracketedIpv6(new URL(`http://[${address}]/`).hostname).toLowerCase()
+  } catch {
+    return undefined
+  }
 }
 
 export function checkSsrfGuard(options: { tool: string; args: Record<string, unknown> }): SecurityBlock | undefined {
@@ -162,21 +181,22 @@ function classifyIpv4(
     return { category: 'cloud_metadata', reason: `link-local / cloud metadata 169.254.0.0/16 (${ip.join('.')})` }
   if (a === 100 && b >= 64 && b <= 127)
     return { category: 'shared_cgnat', reason: `CGNAT 100.64.0.0/10 (${ip.join('.')})` }
+  if (a === 198 && (b === 18 || b === 19))
+    return { category: 'private_ipv4', reason: `benchmarking-only 198.18.0.0/15 (${ip.join('.')})` }
   if (a === 0) return { category: 'unspecified', reason: `unspecified 0.0.0.0/8 (${ip.join('.')})` }
   if (a >= 224) return { category: 'private_ipv4', reason: `multicast/reserved (${ip.join('.')})` }
   return undefined
-}
-
-function looksLikeIpv6(host: string): boolean {
-  return host.includes(':') && /^[0-9a-f:]+$/i.test(host)
 }
 
 function classifyIpv6(host: string): { category: SsrfClassification['category']; reason: string } | undefined {
   const lower = host.toLowerCase()
   if (lower === '::1' || lower === '0:0:0:0:0:0:0:1') return { category: 'loopback', reason: 'IPv6 loopback ::1' }
   if (lower === '::' || lower === '0:0:0:0:0:0:0:0') return { category: 'unspecified', reason: 'IPv6 unspecified ::' }
-  if (lower.startsWith('fe80:') || lower.startsWith('fe80::'))
+  const firstHextet = Number.parseInt(lower.split(':')[0] ?? '', 16)
+  if (Number.isFinite(firstHextet) && firstHextet >= 0xfe80 && firstHextet <= 0xfebf)
     return { category: 'link_local', reason: 'IPv6 link-local fe80::/10' }
+  if (Number.isFinite(firstHextet) && firstHextet >= 0xfec0 && firstHextet <= 0xfeff)
+    return { category: 'ipv6_internal', reason: 'IPv6 site-local fec0::/10' }
   if (lower.startsWith('fc') || lower.startsWith('fd'))
     return { category: 'ipv6_internal', reason: 'IPv6 unique-local fc00::/7' }
   if (lower.startsWith('ff')) return { category: 'ipv6_internal', reason: 'IPv6 multicast ff00::/8' }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -456,6 +456,7 @@ export type ListCallback = (args: ListChannelsArgs) => Promise<ListChannelsResul
 export type FetchAttachmentArgs = {
   ref: string
   filename?: string
+  maxBytes?: number
 }
 
 export type FetchAttachmentResult =


### PR DESCRIPTION
## Background

Extracted from #1201 to make the work reviewable. Slice 5/11.

## Summary

Adds DNS-pinned public HTTP transport, rewires web fetch, and bounds multimodal response bodies.

## Review notes

The bounded response helper was reordered before its consumers so this slice builds independently.