### PR TITLE
fix(run): adapt LLM TTFB deadline to slow-but-healthy providers

### DIFF
--- a/src/run/llm-fetch-observer.test.ts
+++ b/src/run/llm-fetch-observer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
 import {
+  AdaptiveTtfbTracker,
   defaultLlmFetchEndpoints,
   installLlmFetchObserver,
   LLM_FETCH_OBSERVER_TIMEOUTS,
@@ -1363,5 +1364,248 @@ describe('installLlmFetchObserver', () => {
     expect(observed.length).toBe(1)
     expect(observed[0]!.msg).toContain('status=200')
     expect(observed[0]!.msg).toContain('provider=openai-compatible')
+  })
+})
+
+describe('AdaptiveTtfbTracker', () => {
+  const FLOOR = 15_000
+  const CEIL = 30_000
+  const KEY = 'openai-compatible|https://api.z.ai'
+  const OTHER = 'openai-compatible|https://api.fireworks.ai'
+  // 2x16s = 32s clamps to the 30s ceil, so this seed reliably exercises the cap.
+  const CEIL_SEED = 16_000
+
+  function seedSamples(tracker: AdaptiveTtfbTracker, key: string, count: number, headersMs: number): void {
+    for (let i = 0; i < count; i++) tracker.recordHeaders(key, headersMs)
+  }
+
+  test('stays at floor with fewer than the minimum samples', () => {
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    seedSamples(tracker, KEY, 7, 12_000)
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+  })
+
+  test('raises the budget from p95 once enough samples exist, capped at ceil', () => {
+    // given: 8 fast samples + one 10s spike → p95 is the spike, 2x = 20s
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    seedSamples(tracker, KEY, 8, 1_000)
+    tracker.recordHeaders(KEY, 10_000)
+    expect(tracker.resolve(KEY)).toBe(20_000)
+  })
+
+  test('never widens above the ceil even for a very slow p95', () => {
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    seedSamples(tracker, KEY, 12, CEIL_SEED)
+    expect(tracker.resolve(KEY)).toBe(CEIL)
+  })
+
+  test('samples expire after the rolling window and the budget returns to floor', () => {
+    let now = 0
+    const tracker = new AdaptiveTtfbTracker(() => now)
+    seedSamples(tracker, KEY, 12, CEIL_SEED)
+    expect(tracker.resolve(KEY)).toBe(CEIL)
+    now = 5 * 60_000 + 1
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+  })
+
+  test('does not share state across origins', () => {
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    seedSamples(tracker, KEY, 12, CEIL_SEED)
+    expect(tracker.resolve(KEY)).toBe(CEIL)
+    expect(tracker.resolve(OTHER)).toBe(FLOOR)
+  })
+
+  test('a below-ceil timeout grants exactly one ceil recovery probe', () => {
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    tracker.recordTimeout(KEY, FLOOR)
+    expect(tracker.resolve(KEY)).toBe(CEIL)
+    // grant consumed: the next resolve falls back to the learned floor
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+  })
+
+  test('a probe success becomes a real sample that can widen the budget', () => {
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    seedSamples(tracker, KEY, 8, 1_000)
+    tracker.recordTimeout(KEY, FLOOR)
+    expect(tracker.resolve(KEY)).toBe(CEIL) // probe granted
+    tracker.recordHeaders(KEY, 16_000) // probe observed a genuinely-slow header
+    expect(tracker.resolve(KEY)).toBe(CEIL) // 2x16s clamped to ceil, now learned
+  })
+
+  test('a ceil timeout fails closed to floor and suppresses widening', () => {
+    let now = 0
+    const tracker = new AdaptiveTtfbTracker(() => now)
+    seedSamples(tracker, KEY, 12, CEIL_SEED)
+    expect(tracker.resolve(KEY)).toBe(CEIL)
+    tracker.recordTimeout(KEY, CEIL)
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+    // still suppressed within the cooldown window even with a fresh slow sample
+    now = 4 * 60_000
+    tracker.recordHeaders(KEY, CEIL_SEED)
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+    // cooldown elapsed and the origin is still measurably slow → widening resumes
+    now = 5 * 60_000 + 1
+    seedSamples(tracker, KEY, 8, CEIL_SEED)
+    expect(tracker.resolve(KEY)).toBe(CEIL)
+  })
+
+  test('a ceil timeout revokes an outstanding probe grant', () => {
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    tracker.recordTimeout(KEY, FLOOR) // grant a probe
+    tracker.recordTimeout(KEY, CEIL) // ...then fail closed
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+  })
+
+  test('a sub-floor success clears fail-closed suppression early', () => {
+    let now = 0
+    const tracker = new AdaptiveTtfbTracker(() => now)
+    seedSamples(tracker, KEY, 12, CEIL_SEED)
+    tracker.recordTimeout(KEY, CEIL)
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+    now = 1_000
+    tracker.recordHeaders(KEY, 900) // provider recovered
+    expect(tracker.resolve(KEY)).toBe(CEIL)
+  })
+
+  test('reset clears all learned state', () => {
+    const tracker = new AdaptiveTtfbTracker(() => 0)
+    seedSamples(tracker, KEY, 12, 14_000)
+    tracker.reset()
+    expect(tracker.resolve(KEY)).toBe(FLOOR)
+  })
+})
+
+describe('adaptive TTFB integration through installLlmFetchObserver', () => {
+  const URL = 'https://api.z.ai/api/coding/paas/v4/chat/completions'
+  const FLOOR = 15_000
+
+  const clearAdaptiveEnv = () => {
+    delete process.env.TYPECLAW_LLM_TTFB_MS
+    delete process.env.TYPECLAW_LLM_TIMEOUTS
+    delete process.env.TYPECLAW_LLM_FETCH_OBSERVER
+  }
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+    clearAdaptiveEnv()
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    clearAdaptiveEnv()
+  })
+
+  test('arms the adaptive budget (not the floor) when the origin is known-slow', async () => {
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const tracker = new AdaptiveTtfbTracker(clock.now)
+    for (let i = 0; i < 12; i++) tracker.recordHeaders('openai-compatible|https://api.z.ai', 16_000)
+
+    let signal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      signal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        signal?.addEventListener('abort', () => reject(signal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      idleMs: 0,
+      adaptiveTracker: tracker,
+    })
+    let caught: Error | null = null
+    try {
+      clock.set(0)
+      const pending = fetch(URL, { method: 'POST' })
+      // floor (15s) must NOT fire; only the widened 30s budget aborts
+      clock.set(FLOOR)
+      await scheduler.fire(FLOOR)
+      expect(signal?.aborted).toBe(false)
+      clock.set(30_000)
+      await scheduler.fire(30_000)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('30000ms')
+  })
+
+  test('records a successful headers sample so the origin can later widen', async () => {
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const tracker = new AdaptiveTtfbTracker(clock.now)
+
+    let ctrl = makeControllableBody()
+    globalThis.fetch = (async () => {
+      clock.set(16_000)
+      return new Response(ctrl.body, { status: 200 })
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      idleMs: 0,
+      adaptiveTracker: tracker,
+    })
+    try {
+      for (let i = 0; i < 12; i++) {
+        ctrl = makeControllableBody()
+        clock.set(0)
+        const response = await fetch(URL, { method: 'POST' })
+        const drainPromise = drainQuiet(response.body)
+        clock.set(16_000)
+        await ctrl.close()
+        await drainPromise
+      }
+      expect(tracker.resolve('openai-compatible|https://api.z.ai')).toBe(30_000)
+    } finally {
+      uninstall()
+    }
+  })
+
+  test('an explicit static TTFB override disables adaptation entirely', async () => {
+    const { logger } = captureLogger()
+    const clock = makeClock()
+    const scheduler = makeScheduler()
+    const tracker = new AdaptiveTtfbTracker(clock.now)
+    for (let i = 0; i < 12; i++) tracker.recordHeaders('openai-compatible|https://api.z.ai', 14_000)
+
+    let signal: AbortSignal | undefined
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      signal = init?.signal ?? undefined
+      return new Promise<never>((_, reject) => {
+        signal?.addEventListener('abort', () => reject(signal!.reason), { once: true })
+      }) as unknown as Response
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({
+      logger,
+      now: clock.now,
+      scheduler,
+      idleMs: 0,
+      ttfbMs: 5_000,
+      adaptiveTracker: tracker,
+    })
+    let caught: Error | null = null
+    try {
+      clock.set(0)
+      const pending = fetch(URL, { method: 'POST' })
+      clock.set(5_000)
+      await scheduler.fire(5_000)
+      await pending.catch((e) => {
+        caught = e
+      })
+    } finally {
+      uninstall()
+    }
+    expect(caught).not.toBeNull()
+    expect(caught!.message).toContain('5000ms')
   })
 })

--- a/src/run/llm-fetch-observer.ts
+++ b/src/run/llm-fetch-observer.ts
@@ -77,6 +77,9 @@ export type LlmFetchObserverOptions = {
   // Schedule fn for tests. Receives (delayMs, callback) and returns a handle
   // the wrapper can pass to `clear`. Default: `setTimeout`/`clearTimeout`.
   scheduler?: TimeoutScheduler
+  // Test-only: inject a pre-seeded adaptive tracker to assert widening/probe/
+  // cooldown behaviour deterministically. Production always constructs its own.
+  adaptiveTracker?: AdaptiveTtfbTracker
 }
 
 export type TimeoutScheduler = {
@@ -102,6 +105,124 @@ const DEFAULT_TTFB_MS = 15_000
 const DEFAULT_IDLE_MS = 120_000
 const DEFAULT_OVERALL_MS = 300_000
 const LOG_PREFIX = '[llm-fetch]'
+
+// Adaptive TTFB: give a provider that is OBSERVED to be slow-but-healthy more
+// pre-headers room, without blunting silent-hang detection for fast providers.
+// A fixed 15s guillotine kills legitimately-slow providers (e.g. GLM cold-start
+// TTFB ~16.5s while its p50 is ~1s); a uniform higher default would let a truly
+// hung FAST provider stall for the same widened window. So widening is scoped to
+// the specific origin whose recent successful header latency is actually high.
+//
+// Signal: rolling p95 of successful header latency (not EWMA — the distributions
+// are bimodal, mostly-1s with occasional 10–16s, so a mean-tracker sits low and
+// never widens for the spike). Nearest-rank p95 over the last ADAPTIVE_WINDOW_MS
+// of samples reacts to the current upper tail and forgets stale slowness.
+const ADAPTIVE_TTFB_FLOOR_MS = 15_000
+const ADAPTIVE_TTFB_CEIL_MS = 30_000
+const ADAPTIVE_TTFB_MULTIPLIER = 2
+const ADAPTIVE_MIN_SAMPLES = 8
+const ADAPTIVE_MAX_SAMPLES = 32
+const ADAPTIVE_WINDOW_MS = 5 * 60_000
+// After a timeout at the CEIL budget, the origin is treated as slow-then-hung:
+// suppress all widening (learned + probe) and fail closed to the floor for this
+// long, so five rapid retries can't each inherit the 30s budget. A sub-floor
+// success clears the suppression early.
+const ADAPTIVE_COOLDOWN_MS = 5 * 60_000
+
+function clampMs(value: number, floor: number, ceil: number): number {
+  return Math.min(ceil, Math.max(floor, value))
+}
+
+function p95(samples: readonly number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const rank = Math.ceil(0.95 * sorted.length)
+  return sorted[Math.min(rank, sorted.length) - 1]!
+}
+
+type AdaptiveSample = { at: number; headersMs: number }
+
+// Per-origin adaptive-TTFB state. One instance lives in the first-installed
+// observer's closure and is shared across every in-flight fetch in the process
+// (single-threaded event loop → plain mutable maps are safe, no locking). Keyed
+// by `${label}|${origin}` so unrelated OpenAI-compatible providers/proxies never
+// inherit each other's latency budget.
+export class AdaptiveTtfbTracker {
+  private readonly samples = new Map<string, AdaptiveSample[]>()
+  // Whether the origin's next request may spend one CEIL-budget recovery probe.
+  // Granted after a below-CEIL timeout (the killed request yielded only a
+  // right-censored "≥floor" bound, never a usable sample — a bounded probe is
+  // the only way to observe a genuinely-slow header latency past the floor).
+  private readonly probeGrant = new Set<string>()
+  // Origin → wall-clock time until which widening is suppressed (fail-closed).
+  private readonly cooldownUntil = new Map<string, number>()
+
+  constructor(private readonly now: () => number) {}
+
+  // Consumes the probe grant atomically so exactly one request gets the ceil.
+  resolve(key: string): number {
+    if (this.isInCooldown(key)) return ADAPTIVE_TTFB_FLOOR_MS
+    const learned = this.learnedTtfb(key)
+    if (this.probeGrant.has(key)) {
+      this.probeGrant.delete(key)
+      return Math.max(learned, ADAPTIVE_TTFB_CEIL_MS)
+    }
+    return learned
+  }
+
+  recordHeaders(key: string, headersMs: number): void {
+    // Any arrived-headers response (200/429/500) proves the origin is
+    // responsive, so it's a valid latency sample and clears fail-closed state.
+    if (headersMs < ADAPTIVE_TTFB_FLOOR_MS) this.cooldownUntil.delete(key)
+    const list = this.samples.get(key) ?? []
+    list.push({ at: this.now(), headersMs })
+    this.prune(list)
+    if (list.length > ADAPTIVE_MAX_SAMPLES) list.splice(0, list.length - ADAPTIVE_MAX_SAMPLES)
+    this.samples.set(key, list)
+  }
+
+  // A TTFB timeout at `usedMs`. Below the ceil → grant one recovery probe.
+  // At/above the ceil → the widened budget already failed; fail closed.
+  recordTimeout(key: string, usedMs: number): void {
+    if (usedMs >= ADAPTIVE_TTFB_CEIL_MS) {
+      this.probeGrant.delete(key)
+      this.cooldownUntil.set(key, this.now() + ADAPTIVE_COOLDOWN_MS)
+      return
+    }
+    this.probeGrant.add(key)
+  }
+
+  reset(): void {
+    this.samples.clear()
+    this.probeGrant.clear()
+    this.cooldownUntil.clear()
+  }
+
+  private learnedTtfb(key: string): number {
+    const list = this.samples.get(key)
+    if (list === undefined) return ADAPTIVE_TTFB_FLOOR_MS
+    this.prune(list)
+    if (list.length < ADAPTIVE_MIN_SAMPLES) return ADAPTIVE_TTFB_FLOOR_MS
+    const target = Math.ceil(ADAPTIVE_TTFB_MULTIPLIER * p95(list.map((s) => s.headersMs)))
+    return clampMs(target, ADAPTIVE_TTFB_FLOOR_MS, ADAPTIVE_TTFB_CEIL_MS)
+  }
+
+  private isInCooldown(key: string): boolean {
+    const until = this.cooldownUntil.get(key)
+    if (until === undefined) return false
+    if (this.now() >= until) {
+      this.cooldownUntil.delete(key)
+      return false
+    }
+    return true
+  }
+
+  private prune(list: AdaptiveSample[]): void {
+    const cutoff = this.now() - ADAPTIVE_WINDOW_MS
+    let drop = 0
+    while (drop < list.length && list[drop]!.at < cutoff) drop++
+    if (drop > 0) list.splice(0, drop)
+  }
+}
 
 const defaultScheduler: TimeoutScheduler = {
   set: (delayMs, cb) => setTimeout(cb, delayMs),
@@ -153,6 +274,7 @@ type InstallState = {
   originalFetch: typeof fetch
   wrapped: typeof fetch
   claimants: number
+  adaptive: AdaptiveTtfbTracker
 }
 
 // Ref-counted so multiple agents in one process (compose, tests) share one
@@ -169,7 +291,7 @@ function matchEndpoint(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
   endpoints: readonly LlmFetchEndpoint[],
-): LlmFetchEndpoint | null {
+): { endpoint: LlmFetchEndpoint; origin: string } | null {
   const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase()
   let urlString: string
   if (typeof input === 'string') urlString = input
@@ -182,7 +304,7 @@ function matchEndpoint(
     return null
   }
   for (const endpoint of endpoints) {
-    if (endpoint.match(parsed, method)) return endpoint
+    if (endpoint.match(parsed, method)) return { endpoint, origin: parsed.origin }
   }
   return null
 }
@@ -454,6 +576,15 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
     overallMs: readEnvMs(process.env, ENV_OVERALL_MS, DEFAULT_OVERALL_MS),
   }
   const originalFetch = globalThis.fetch
+  const adaptive = opts.adaptiveTracker ?? new AdaptiveTtfbTracker(now)
+  // Adaptation is a property of the built-in floor default only. Any explicit
+  // static TTFB (observer opt, per-endpoint value, or a set TYPECLAW_*_TTFB_MS)
+  // means the operator pinned a deadline — honour it verbatim, no widening.
+  const adaptiveEligible =
+    timeoutsEnabled &&
+    opts.ttfbMs === undefined &&
+    readEnvMsOptional(process.env, ENV_TTFB_MS) === undefined &&
+    envDefaults.ttfbMs === DEFAULT_TTFB_MS
 
   // Precedence per timer: explicit observer-level option wins over the endpoint's
   // own value, which wins over the generic env/default. An explicit `opts.*` means
@@ -476,25 +607,29 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ): Promise<Response> => {
-    const endpoint = matchEndpoint(input, init, endpoints)
-    if (endpoint === null) {
+    const matched = matchEndpoint(input, init, endpoints)
+    if (matched === null) {
       return originalFetch(input, init)
     }
+    const { endpoint, origin } = matched
     const perRequest = (init as LlmFetchObservedRequestInit | undefined)?.[LLM_FETCH_OBSERVER_TIMEOUTS]
     const timeouts = resolveTimeouts(endpoint, perRequest)
     const provider = endpoint.label
+    const adaptiveKey = `${provider}|${origin}`
+    const usesAdaptiveTtfb = adaptiveEligible && perRequest?.ttfbMs === undefined && endpoint.ttfbMs === undefined
+    const effectiveTtfbMs = usesAdaptiveTtfb ? adaptive.resolve(adaptiveKey) : timeouts.ttfbMs
     const start = now()
 
     let ttfbCause: 'ttfb_timeout' | null = null
     let ttfbHandle: unknown = null
     let initWithSignal: RequestInit | undefined = init
-    if (timeouts.ttfbMs > 0) {
+    if (effectiveTtfbMs > 0) {
       const ttfbController = new AbortController()
-      ttfbHandle = scheduler.set(timeouts.ttfbMs, () => {
+      ttfbHandle = scheduler.set(effectiveTtfbMs, () => {
         ttfbCause = 'ttfb_timeout'
         ttfbController.abort(
           new Error(
-            `${provider} fetch timed out before response headers after ${timeouts.ttfbMs}ms (typeclaw observer timeout)`,
+            `${provider} fetch timed out before response headers after ${effectiveTtfbMs}ms (typeclaw observer timeout)`,
           ),
         )
       })
@@ -508,9 +643,10 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
     } catch (err) {
       if (ttfbHandle !== null) scheduler.clear(ttfbHandle)
       const isTtfbAbort = ttfbCause === 'ttfb_timeout'
+      if (isTtfbAbort && usesAdaptiveTtfb) adaptive.recordTimeout(adaptiveKey, effectiveTtfbMs)
       const surfacedError = isTtfbAbort
         ? new Error(
-            `${provider} fetch timed out before response headers after ${timeouts.ttfbMs}ms (typeclaw observer timeout)`,
+            `${provider} fetch timed out before response headers after ${effectiveTtfbMs}ms (typeclaw observer timeout)`,
           )
         : err
       const message = surfacedError instanceof Error ? surfacedError.message : String(surfacedError)
@@ -532,6 +668,7 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
     }
     if (ttfbHandle !== null) scheduler.clear(ttfbHandle)
     const headersMs = now() - start
+    if (usesAdaptiveTtfb) adaptive.recordHeaders(adaptiveKey, headersMs)
     const retryAfter = response.headers.get('retry-after')
     const requestId = response.headers.get('x-request-id')
     return attachBodyTimingTap(response, start, headersMs, response.status, retryAfter, requestId, now, logger, {
@@ -550,7 +687,7 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
 
   globalThis.fetch = wrapped
 
-  installed = { originalFetch, wrapped, claimants: 1 }
+  installed = { originalFetch, wrapped, claimants: 1, adaptive }
   return makeRelease(wrapped)
 }
 
@@ -564,6 +701,7 @@ function makeRelease(wrapped: typeof fetch): () => void {
     released = true
     installed.claimants--
     if (installed.claimants > 0) return
+    installed.adaptive.reset()
     if (globalThis.fetch === installed.wrapped) {
       globalThis.fetch = installed.originalFetch
     }


### PR DESCRIPTION
## Background

**Problem.** TypeClaw's LLM fetch observer aborts any request that doesn't return response headers within a fixed time-to-first-byte (TTFB) deadline (`DEFAULT_TTFB_MS = 15_000`). This exists to catch the "silent hang" failure mode, where a provider accepts a request and never sends headers — Bun's OS socket deadline is only reached at ~268s, far too late to be useful on its own. But an OpenAI-compatible GLM endpoint has bimodal header latency: p50 ~1s, with cold-start/slow-phase spikes to ~16.5s. During a provider slow-phase, healthy-but-slow calls crossed the fixed 15s deadline and were aborted, surfacing to end users as "The upstream LLM provider failed."

**Root cause.** A multi-step agentic turn makes on the order of 20 sequential LLM calls. A per-call tail risk that looks tolerable in isolation compounds into a near-certain per-turn failure — one observed production turn burned 139.7s across retries before finally failing outright. The deadline itself wasn't wrong for the silent-hang case; it was simply uniform across providers that have very different tail behavior.

## Summary

Add `AdaptiveTtfbTracker` to the fetch observer module: a per-origin rolling p95 of successful header latency widens the TTFB deadline for the specific origin observed to be slow, up to a 30s ceiling, without loosening silent-hang detection for fast providers.

- **Signal — rolling p95, not EWMA.** The distributions are bimodal (mostly ~1s, occasional 10–16s spikes), so a mean-tracker sits near 1s and never widens for the spike that actually matters. Nearest-rank p95 over the last 32 samples within a 5-minute rolling window reacts to the current upper tail and forgets stale slowness.
- **Formula.** `effectiveTtfb = clamp(2 * p95, 15s floor, 30s ceil)`, active only once an origin has accumulated at least 8 fresh samples; below that, the 15s floor holds unchanged.
- **Recovery probe.** A request killed at the deadline yields only a right-censored "≥floor" bound — never a usable latency sample — so a below-ceiling timeout grants exactly one 30s probe on the next request to that origin, letting a genuinely-slow call complete and become observable. Without this, an origin whose true latency sits past the floor could never accumulate the samples needed to widen in the first place.
- **Fail-closed.** A timeout at the 30s ceiling means the already-widened budget failed too (slow-then-hung, not just slow), so widening is suppressed for 5 minutes and the origin falls back to the 15s floor. This bounds retry amplification — five rapid retries can't each inherit a fresh 30s budget, worst case is ~90s of accumulated waiting, not 150s. A sub-floor success clears the suppression early.
- **Scoping.** Tracked state is keyed by label and origin together, so unrelated OpenAI-compatible providers or proxies never inherit each other's latency budget.
- **Precedence.** Any explicit static TTFB — an observer option, a per-endpoint value, or the `TYPECLAW_LLM_TTFB_MS` env var — disables adaptation entirely. Operator intent always wins over the learned value.

Tracker state lives in the ref-counted observer's closure and resets on final claimant release. The clock source and the tracker itself are both injectable, so the window, probe, cooldown, and clamp behavior are deterministically testable without real timers.

**Backwards compatibility.** This is a pure widening of an existing timeout under observed-slow conditions. Fast providers are unaffected — they never accumulate p95 samples above the floor, so they keep the same 15s deadline as before. There is no config, schema, or CLI surface change, and no new env var. Silent-hang protection is preserved by construction: the 30s ceiling is still far inside the 120s idle timeout, the 300s overall timeout, and Bun's ~268s socket deadline, and only origins with actually-observed slow-but-successful headers ever widen at all.

## What this does NOT do

- Does not change behavior for any origin that hasn't demonstrated real (non-timed-out) slow header latency — the floor stays at 15s until 8 samples justify otherwise.
- Does not weaken the eventual silent-hang cutoff — the ceiling (30s) is still well below the idle/overall/socket timeouts.
- Does not add any new configuration surface; adaptation is purely internal and opt-out only via existing static-TTFB precedence.

## Review notes

- Load-bearing invariant: adaptation only applies when no explicit static TTFB is set anywhere in the precedence chain — observer option, per-endpoint value, the env var, or a non-default generic default. Verify this can't accidentally widen a deadline the operator explicitly pinned.
- Load-bearing invariant: `recordTimeout` only grants a probe below the ceiling and fails closed at/above it. Verify the boundary condition lines up with the probe's own returned budget so the two paths agree on where the ceiling sits.
- Load-bearing invariant: `recordHeaders` clears cooldown on any sub-floor success, so a genuinely-recovered origin isn't stuck fail-closed for the full 5 minutes.
- Test plan: 14 new tests — unit coverage of the tracker's state machine (window pruning, p95 computation, probe grant/consumption, cooldown fail-closed/clear) plus 3 integration tests through the observer's install path exercising widen → probe → ceiling-timeout → cooldown → recovery end to end.
- Verification: full suite green (11034 pass, 0 fail, 1 skip across 551 files); typecheck, lint (0 errors), and format check all clean.
