### PR TITLE
fix(run): pin codex TTFB to 13s and log per-origin fetch seq

### DIFF
--- a/src/run/llm-fetch-observer.test.ts
+++ b/src/run/llm-fetch-observer.test.ts
@@ -219,12 +219,70 @@ describe('installLlmFetchObserver', () => {
     expect(observed.length).toBe(1)
     const line = observed[0]!.msg
     expect(line).toContain('status=200')
+    expect(line).toContain('seq=1')
     expect(line).toContain('headers_ms=50')
     expect(line).toContain('first_byte_ms=200')
     expect(line).toContain('total_ms=2000')
     expect(line).toContain('request_id=req_abc123')
     expect(line).toContain('retry_after=null')
     expect(line).toContain('error=null')
+  })
+
+  test('seq increments per provider|origin so retry multiplication is countable', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+
+    globalThis.fetch = (async () => {
+      const ctrl = makeControllableBody()
+      queueMicrotask(() => void ctrl.close())
+      return new Response(ctrl.body, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+    }) as unknown as typeof fetch
+
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now })
+    try {
+      for (let i = 0; i < 3; i++) {
+        const response = await fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
+        await drainQuiet(response.body)
+      }
+    } finally {
+      uninstall()
+    }
+
+    const lines = entries.filter((e) => e.msg.startsWith('[llm-fetch]')).map((e) => e.msg)
+    expect(lines.map((m) => Number(m.match(/ seq=(\d+)/)![1]))).toEqual([1, 2, 3])
+    for (const line of lines) expect(line).toContain('origin=https://chatgpt.com')
+  })
+
+  test('seq is scoped per origin so a shared provider label does not collide', async () => {
+    const { logger, entries } = captureLogger()
+    const clock = makeClock()
+
+    globalThis.fetch = (async () => {
+      const ctrl = makeControllableBody()
+      queueMicrotask(() => void ctrl.close())
+      return new Response(ctrl.body, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+    }) as unknown as typeof fetch
+
+    // Two distinct proxy origins that both match the `openai-compatible` label.
+    // Interleaved, each origin must keep its OWN seq (1,2), not a shared 1..4.
+    const urlA = 'https://proxy-a.example/v1/chat/completions'
+    const urlB = 'https://proxy-b.example/v1/chat/completions'
+    const uninstall = installLlmFetchObserver({ logger, now: clock.now })
+    try {
+      for (const url of [urlA, urlB, urlA, urlB]) {
+        const response = await fetch(url, { method: 'POST' })
+        await drainQuiet(response.body)
+      }
+    } finally {
+      uninstall()
+    }
+
+    const parse = (host: string) =>
+      entries
+        .filter((e) => e.msg.startsWith('[llm-fetch]') && e.msg.includes(`origin=https://${host}`))
+        .map((e) => Number(e.msg.match(/ seq=(\d+)/)![1]))
+    expect(parse('proxy-a.example')).toEqual([1, 2])
+    expect(parse('proxy-b.example')).toEqual([1, 2])
   })
 
   test('logs retry_after header when present (throttling signal)', async () => {
@@ -1169,10 +1227,12 @@ describe('installLlmFetchObserver', () => {
     expect(observed[0]!.msg).toContain('cause=overall_timeout')
   })
 
-  test('an unset TYPECLAW_CODEX_*_MS leaves the codex endpoint timeouts undefined (defers to generic/default)', () => {
+  test('an unset TYPECLAW_CODEX_*_MS pins codex ttfb to 13s and leaves idle/overall deferring', () => {
     const codex = defaultLlmFetchEndpoints({}).find((e) => e.label === 'codex')
     expect(codex).toBeDefined()
-    expect(codex!.ttfbMs).toBeUndefined()
+    // ttfb is pinned to the codex-specific 13s default (fast silent-hang detection,
+    // adaptation bypassed); idle/overall still defer to generic/built-in defaults.
+    expect(codex!.ttfbMs).toBe(13_000)
     expect(codex!.idleMs).toBeUndefined()
     expect(codex!.overallMs).toBeUndefined()
   })
@@ -1188,10 +1248,11 @@ describe('installLlmFetchObserver', () => {
     expect(codex!.overallMs).toBe(333)
   })
 
-  test('generic TYPECLAW_LLM_TTFB_MS applies to Codex when TYPECLAW_CODEX_TTFB_MS is unset', async () => {
-    // given: only the generic var is set; the Codex-specific var is unset, so it
-    // must NOT mask the generic one (the review bug).
-    process.env.TYPECLAW_LLM_TTFB_MS = '70'
+  test('codex ttfb 13s default wins over a generic TYPECLAW_LLM_TTFB_MS when codex var is unset', async () => {
+    // given: only the generic var is set (to a LONGER 20s). Codex must NOT defer to
+    // it — the codex-specific 13s pin is what protects against silent hangs, so it
+    // fires first regardless of a longer generic value.
+    process.env.TYPECLAW_LLM_TTFB_MS = '20000'
     const { logger, entries } = captureLogger()
     const clock = makeClock()
     const scheduler = makeScheduler()
@@ -1209,8 +1270,8 @@ describe('installLlmFetchObserver', () => {
     try {
       clock.set(0)
       const pending = fetch('https://chatgpt.com/backend-api/codex/responses', { method: 'POST' })
-      clock.set(70)
-      await scheduler.fire(70)
+      clock.set(13_000)
+      await scheduler.fire(13_000)
       await pending.catch((e) => {
         caught = e
       })
@@ -1218,9 +1279,9 @@ describe('installLlmFetchObserver', () => {
       uninstall()
     }
 
-    // then: the 70ms generic TTFB fired for Codex
+    // then: the 13s codex TTFB fired, not the 20s generic one
     expect(caught).not.toBeNull()
-    expect(caught!.message).toContain('70ms')
+    expect(caught!.message).toContain('13000ms')
     expect(entries.find((e) => e.msg.startsWith('[llm-fetch]'))!.msg).toContain('cause=ttfb_timeout')
   })
 

--- a/src/run/llm-fetch-observer.ts
+++ b/src/run/llm-fetch-observer.ts
@@ -104,6 +104,14 @@ const ENV_CODEX_OVERALL_MS = 'TYPECLAW_CODEX_OVERALL_MS'
 const DEFAULT_TTFB_MS = 15_000
 const DEFAULT_IDLE_MS = 120_000
 const DEFAULT_OVERALL_MS = 300_000
+// Codex is healthy-FAST but silently hangs: observed header latency p50~1s /
+// p99~8s / max~10.8s, yet hung requests wait out the generic 15s floor. Pinning
+// 13s detects hangs ~2s sooner with ~2.2s margin over the healthy max. Pinned,
+// not adaptive: codex's p95 (~5.6s) never crosses the floor so widening is a
+// no-op, and a longer deadline only makes each silent hang costlier to recover.
+// A concrete per-endpoint `ttfbMs` also disables adaptive eligibility for codex
+// (see `usesAdaptiveTtfb`). Operator-set TYPECLAW_CODEX_TTFB_MS still overrides.
+const DEFAULT_CODEX_TTFB_MS = 13_000
 const LOG_PREFIX = '[llm-fetch]'
 
 // Adaptive TTFB: give a provider that is OBSERVED to be slow-but-healthy more
@@ -248,10 +256,12 @@ export function defaultLlmFetchEndpoints(env: NodeJS.ProcessEnv = process.env): 
       // GETs to the same host (auth probes, etc.) are deliberately ignored.
       match: (url, method) =>
         method === 'POST' && url.hostname === 'chatgpt.com' && url.pathname.includes('/codex/responses'),
-      // Only pin a per-endpoint value when the operator explicitly set the
-      // Codex-specific var; unset falls through to the generic TYPECLAW_LLM_*
-      // (or built-in default) so it isn't masked. See readEnvMsOptional.
-      ttfbMs: readEnvMsOptional(env, ENV_CODEX_TTFB_MS),
+      // TTFB is pinned to the codex-specific default (not the generic 15s) so a
+      // silent hang is caught fast and adaptation is bypassed for this endpoint;
+      // an operator-set TYPECLAW_CODEX_TTFB_MS still wins. Idle/overall keep the
+      // fall-through shape (unset → generic TYPECLAW_LLM_* / built-in default) so
+      // they aren't masked. See readEnvMsOptional and DEFAULT_CODEX_TTFB_MS.
+      ttfbMs: readEnvMsOptional(env, ENV_CODEX_TTFB_MS) ?? DEFAULT_CODEX_TTFB_MS,
       idleMs: readEnvMsOptional(env, ENV_CODEX_IDLE_MS),
       overallMs: readEnvMsOptional(env, ENV_CODEX_OVERALL_MS),
     },
@@ -316,6 +326,18 @@ function quote(value: string | null): string {
 
 function formatLine(fields: {
   provider: string
+  // The request origin (scheme+host, no path/query — non-sensitive) that scopes
+  // `seq`. `provider` alone is ambiguous: `openai-compatible` accepts arbitrary
+  // proxy origins and the observer is shared across agents, so two origins can
+  // each emit `provider=openai-compatible seq=1`. The origin disambiguates them
+  // so seq is attributable per stream.
+  origin: string
+  // Per-(provider,origin) monotonic fetch sequence. A tight run of increasing seq
+  // on one provider|origin is the observable signature of retry MULTIPLICATION (the
+  // pi-ai codex provider's internal loop stacked under typeclaw's own retries):
+  // it makes the physical-fetch count per logical turn countable from logs alone.
+  // Observability only — nothing reads this back to drive behavior.
+  seq: number
   status: number | null
   headersMs: number | null
   firstByteMs: number | null
@@ -329,6 +351,8 @@ function formatLine(fields: {
   return [
     LOG_PREFIX,
     `provider=${fields.provider}`,
+    `origin=${fields.origin}`,
+    `seq=${fields.seq}`,
     `status=${fields.status === null ? 'null' : fields.status}`,
     `headers_ms=${fields.headersMs === null ? 'null' : fields.headersMs}`,
     `first_byte_ms=${fields.firstByteMs === null ? 'null' : fields.firstByteMs}`,
@@ -367,6 +391,8 @@ type ResolvedTimeouts = {
 
 type BodyTapConfig = {
   provider: string
+  origin: string
+  seq: number
   idleMs: number
   overallMs: number
   scheduler: TimeoutScheduler
@@ -387,6 +413,8 @@ function attachBodyTimingTap(
     logger.info(
       formatLine({
         provider: config.provider,
+        origin: config.origin,
+        seq: config.seq,
         status,
         headersMs,
         firstByteMs: null,
@@ -412,6 +440,8 @@ function attachBodyTimingTap(
     logger.info(
       formatLine({
         provider: config.provider,
+        origin: config.origin,
+        seq: config.seq,
         status,
         headersMs,
         firstByteMs,
@@ -577,6 +607,7 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
   }
   const originalFetch = globalThis.fetch
   const adaptive = opts.adaptiveTracker ?? new AdaptiveTtfbTracker(now)
+  const fetchSeqByKey = new Map<string, number>()
   // Adaptation is a property of the built-in floor default only. Any explicit
   // static TTFB (observer opt, per-endpoint value, or a set TYPECLAW_*_TTFB_MS)
   // means the operator pinned a deadline — honour it verbatim, no widening.
@@ -616,6 +647,8 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
     const timeouts = resolveTimeouts(endpoint, perRequest)
     const provider = endpoint.label
     const adaptiveKey = `${provider}|${origin}`
+    const seq = (fetchSeqByKey.get(adaptiveKey) ?? 0) + 1
+    fetchSeqByKey.set(adaptiveKey, seq)
     const usesAdaptiveTtfb = adaptiveEligible && perRequest?.ttfbMs === undefined && endpoint.ttfbMs === undefined
     const effectiveTtfbMs = usesAdaptiveTtfb ? adaptive.resolve(adaptiveKey) : timeouts.ttfbMs
     const start = now()
@@ -653,6 +686,8 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
       logger.info(
         formatLine({
           provider,
+          origin,
+          seq,
           status: null,
           headersMs: null,
           firstByteMs: null,
@@ -673,6 +708,8 @@ export function installLlmFetchObserver(opts: LlmFetchObserverOptions = {}): () 
     const requestId = response.headers.get('x-request-id')
     return attachBodyTimingTap(response, start, headersMs, response.status, retryAfter, requestId, now, logger, {
       provider,
+      origin,
+      seq,
       idleMs: timeouts.idleMs,
       overallMs: timeouts.overallMs,
       scheduler,


### PR DESCRIPTION
## Problem

The OpenAI Codex / GPT-5.x family (POST `chatgpt.com/backend-api/codex/responses`) has a chronic **silent-hang** failure: the provider accepts a request but never sends response headers. The fetch observer aborts these at a fixed **15s TTFB** deadline.

Production data (one agent, one day, 385 successful codex samples):

| p50 | p90 | p95 | p99 | max |
|-----|-----|-----|-----|-----|
| 1023ms | 3054ms | 5586ms | 8037ms | **10841ms** |

Every healthy codex response arrived under **~11s**, yet 44 requests were killed at exactly 15000ms. Codex is **healthy-FAST but silently hangs** — the opposite of the healthy-SLOW case that adaptive TTFB was built for. Because codex's p95 (~5.6s) is far below the 15s floor, `clamp(2×p95, 15s, 30s)` never widens it, so the fixed floor is also the worst case.

## Changes

1. **Pin the codex endpoint to a 13s TTFB.** ~2s faster silent-hang detection with ~2.2s margin over the observed healthy max, so false positives are near-zero. A concrete per-endpoint `ttfbMs` also disables adaptive eligibility for codex (a pinned deadline, per the existing contract). Operator-set `TYPECLAW_CODEX_TTFB_MS` still overrides; `idle`/`overall` keep deferring to the generic defaults. The global `DEFAULT_TTFB_MS = 15_000` and the anthropic / openai-compatible endpoints (with adaptation) are unchanged.

2. **Add a per-`provider|origin` monotonic `seq=` field to the `[llm-fetch]` log line.** A tight run of increasing `seq` on one origin is the observable signature of **retry multiplication** (the pi-ai codex provider's internal retry loop stacked under typeclaw's own retries), making the physical fetch count per logical turn countable from `typeclaw logs`. **Observability only** — nothing reads it back to drive behavior.

## Why not just widen the TTFB

Widening codex's deadline is wrong: healthy codex never needs >11s, so a longer deadline only makes each silent hang cost more before recovery. This PR is the fast-detection + diagnosis half of a larger effort; the `seq` telemetry exists to confirm the retry-multiplication hypothesis in production before any retry-count change.

## Testing

- `bun test src/run/llm-fetch-observer.test.ts` — updated the codex-default contract tests (unset env → 13s pin, not `undefined`; 13s pin wins over a longer generic `TYPECLAW_LLM_TTFB_MS`) and added a `seq` increment test. 52/52 pass.
- Full suite: **11035 pass, 0 fail**. `typecheck` clean, `lint` 0 errors, `format:check` clean.

## Scope

Part 1 of 3 (codex silent-hang resilience). Follow-ups: origin-scoped circuit breaker + non-codex fallback requirement; per-turn no-progress recovery envelope. Full retry-ownership (codex `maxRetries=0`) is deferred — it requires an upstream `pi-ai` change since the codex provider hardcodes `MAX_RETRIES=3`.