### PR TITLE
fix(agent): trip a provider-scoped circuit on codex silent-hangs

### DIFF
--- a/src/agent/provider-error.ts
+++ b/src/agent/provider-error.ts
@@ -32,6 +32,7 @@ const GENERIC_SAFE_NOTICE = 'The upstream LLM provider failed. Operators can che
 // reaches `detectProviderError`; the marker lets the hard-throw path recognize
 // and surface it. The literal is the system's own token — English by design.
 const OBSERVER_TIMEOUT = /\(typeclaw observer timeout\)/i
+const OBSERVER_TTFB_TIMEOUT = /timed out before response headers/i
 
 // Transport-layer failure: the request died at the connection/session before a
 // usable response — an expired live session, a WebSocket upgrade that never
@@ -128,6 +129,10 @@ const CONTEXT_OVERFLOW = /\bcontext[_ -]?length[_ -]?exceeded\b/i
 export function isThrottleOrOverload(raw: string): boolean {
   if (NON_FAILOVER_FAULT.test(raw)) return false
   return THROTTLE_OR_OVERLOAD.test(raw)
+}
+
+export function isObserverTtfbTimeout(raw: string): boolean {
+  return OBSERVER_TIMEOUT.test(raw) && OBSERVER_TTFB_TIMEOUT.test(raw)
 }
 
 // Failover predicate for turn-drivers' `shouldFailover`: rotate to the next model

--- a/src/agent/throttle-circuit.test.ts
+++ b/src/agent/throttle-circuit.test.ts
@@ -6,6 +6,9 @@ import { COOLDOWN_MS, THROTTLE_THRESHOLD, THROTTLE_WINDOW_MS, ThrottleCircuit } 
 
 const REF_A = 'openai/gpt-5.4-nano' as ModelRef
 const REF_B = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' as ModelRef
+const CODEX_TERRA_REF = 'openai-codex/gpt-5.5' as ModelRef
+const CODEX_SOL_REF = 'openai-codex/gpt-5.4' as ModelRef
+const CODEX_LUNA_REF = 'openai-codex/gpt-5.4-mini' as ModelRef
 
 describe('ThrottleCircuit', () => {
   test('opens after threshold throttles in the sliding window', () => {
@@ -44,5 +47,31 @@ describe('ThrottleCircuit', () => {
     expect(circuit.isOpen({ profile: 'default', ref: REF_A })).toBe(true)
     expect(circuit.isOpen({ profile: 'default', ref: REF_B })).toBe(false)
     expect(circuit.isOpen({ profile: 'fast', ref: REF_A })).toBe(false)
+  })
+
+  test('shares provider circuit state across refs without opening their ref circuits', () => {
+    const circuit = new ThrottleCircuit({ now: () => 1_000 })
+
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_TERRA_REF })
+    expect(circuit.isProviderOpen({ profile: 'default', ref: CODEX_SOL_REF })).toBe(false)
+
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_SOL_REF })
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_LUNA_REF })
+
+    expect(circuit.isProviderOpen({ profile: 'default', ref: CODEX_TERRA_REF })).toBe(true)
+    expect(circuit.isProviderOpen({ profile: 'default', ref: CODEX_LUNA_REF })).toBe(true)
+    expect(circuit.isOpen({ profile: 'default', ref: CODEX_TERRA_REF })).toBe(false)
+    expect(circuit.isOpen({ profile: 'default', ref: CODEX_SOL_REF })).toBe(false)
+    expect(circuit.isOpen({ profile: 'default', ref: CODEX_LUNA_REF })).toBe(false)
+  })
+
+  test('provider success clears sub-threshold failures shared by its refs', () => {
+    const circuit = new ThrottleCircuit({ now: () => 1_000 })
+
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_TERRA_REF })
+    circuit.recordSuccess({ profile: 'default', ref: CODEX_SOL_REF })
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_LUNA_REF })
+
+    expect(circuit.isProviderOpen({ profile: 'default', ref: CODEX_TERRA_REF })).toBe(false)
   })
 })

--- a/src/agent/throttle-circuit.ts
+++ b/src/agent/throttle-circuit.ts
@@ -23,13 +23,33 @@ export class ThrottleCircuit {
   }
 
   isOpen(key: ThrottleCircuitKey): boolean {
-    const entry = this.entries.get(this.keyId(key))
+    return this.isEntryOpen(this.keyId(key))
+  }
+
+  isProviderOpen(key: ThrottleCircuitKey): boolean {
+    return this.isEntryOpen(this.providerKeyId(key))
+  }
+
+  recordThrottle(key: ThrottleCircuitKey): void {
+    this.recordFailure(this.keyId(key))
+  }
+
+  recordProviderTrip(key: ThrottleCircuitKey): void {
+    this.recordFailure(this.providerKeyId(key))
+  }
+
+  recordSuccess(key: ThrottleCircuitKey): void {
+    this.entries.delete(this.keyId(key))
+    this.entries.delete(this.providerKeyId(key))
+  }
+
+  private isEntryOpen(id: string): boolean {
+    const entry = this.entries.get(id)
     if (entry === undefined) return false
     return this.now() < entry.openUntil
   }
 
-  recordThrottle(key: ThrottleCircuitKey): void {
-    const id = this.keyId(key)
+  private recordFailure(id: string): void {
     const now = this.now()
     const entry = this.entries.get(id) ?? { failures: [], openUntil: 0 }
     entry.failures = entry.failures.filter((ts) => now - ts <= THROTTLE_WINDOW_MS)
@@ -38,8 +58,8 @@ export class ThrottleCircuit {
     this.entries.set(id, entry)
   }
 
-  recordSuccess(key: ThrottleCircuitKey): void {
-    this.entries.delete(this.keyId(key))
+  private providerKeyId(key: ThrottleCircuitKey): string {
+    return `${key.profile ?? 'default'}:${providerForModelRef(key.ref)}`
   }
 
   private keyId(key: ThrottleCircuitKey): string {

--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -9,12 +9,24 @@ import { promptPersistentTurnWithFallback } from './turn-runner'
 
 const REF_A = 'openai/gpt-5.4-nano' as ModelRef
 const REF_B = 'fireworks/accounts/fireworks/routers/kimi-k2p6-turbo' as ModelRef
+const CODEX_TERRA_REF = 'openai-codex/gpt-5.5' as ModelRef
+const CODEX_SOL_REF = 'openai-codex/gpt-5.4' as ModelRef
+const CODEX_LUNA_REF = 'openai-codex/gpt-5.4-mini' as ModelRef
+const ANTHROPIC_REF = 'anthropic/claude-sonnet-5' as ModelRef
 
 type FakeEvent = { type: string; message?: unknown; assistantMessageEvent?: { type: string; delta?: string } }
 
 function fakeSession(
   behaviors: Array<
-    'soft-throttle' | 'soft-billing' | 'text-then-throttle' | 'tool-then-throttle' | 'hard-observer-timeout' | 'success'
+    | 'soft-throttle'
+    | 'soft-503'
+    | 'soft-billing'
+    | 'text-then-throttle'
+    | 'tool-then-throttle'
+    | 'hard-observer-timeout'
+    | 'hard-observer-ttfb-timeout'
+    | 'soft-observer-ttfb-timeout'
+    | 'success'
   >,
 ) {
   const events: Array<(event: FakeEvent) => void> = []
@@ -27,6 +39,9 @@ function fakeSession(
       if (behavior === 'hard-observer-timeout') {
         throw new Error('anthropic SSE body idle for 120000ms (typeclaw observer timeout)')
       }
+      if (behavior === 'hard-observer-ttfb-timeout') {
+        throw new Error('openai-codex timed out before response headers after 30000ms (typeclaw observer timeout)')
+      }
       if (behavior === 'text-then-throttle') {
         for (const cb of events)
           cb({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'hi' } })
@@ -35,7 +50,14 @@ function fakeSession(
         for (const cb of events) cb({ type: 'tool_execution_start' })
       }
       if (behavior !== 'success') {
-        const message = behavior === 'soft-billing' ? 'billing required' : 'server_is_overloaded'
+        const message =
+          behavior === 'soft-billing'
+            ? 'billing required'
+            : behavior === 'soft-503'
+              ? '503 Service Unavailable'
+              : behavior === 'soft-observer-ttfb-timeout'
+                ? 'openai-codex timed out before response headers after 30000ms (typeclaw observer timeout)'
+                : 'server_is_overloaded'
         for (const cb of events) {
           cb({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: message } })
         }
@@ -215,6 +237,186 @@ describe('promptPersistentTurnWithFallback', () => {
 
     expect(probed.refUsed).toBe(REF_A)
     expect(probe.setModels).toEqual([])
+  })
+
+  test('records codex observer TTFB timeouts against one provider circuit across refs', async () => {
+    const circuit = new ThrottleCircuit()
+
+    for (const ref of [CODEX_TERRA_REF, CODEX_SOL_REF]) {
+      const fake = fakeSession(['hard-observer-ttfb-timeout', 'success'])
+      const result = await promptPersistentTurnWithFallback({
+        refs: [ref, ANTHROPIC_REF],
+        currentModelRef: ref,
+        profile: 'default',
+        session: fake.session,
+        text: 'hello',
+        circuit,
+        shouldFailover: (err) => isFailoverWorthy(err.message),
+        setModelForRef: async (nextRef) => {
+          fake.setModels.push(nextRef)
+        },
+      })
+      expect(result.success).toBe(true)
+    }
+
+    expect(circuit.isProviderOpen({ profile: 'default', ref: CODEX_LUNA_REF })).toBe(true)
+    expect(circuit.isOpen({ profile: 'default', ref: CODEX_TERRA_REF })).toBe(false)
+    expect(circuit.isOpen({ profile: 'default', ref: CODEX_SOL_REF })).toBe(false)
+  })
+
+  test('attempts terra, sol, then routes to anthropic in one turn as the codex provider breaker opens mid-chain', async () => {
+    const circuit = new ThrottleCircuit({ now: () => 1_000 })
+    const fake = fakeSession(['soft-observer-ttfb-timeout', 'soft-observer-ttfb-timeout', 'success'])
+    const attemptedRefs: ModelRef[] = []
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [CODEX_TERRA_REF, CODEX_SOL_REF, ANTHROPIC_REF],
+      currentModelRef: CODEX_TERRA_REF,
+      profile: 'default',
+      session: fake.session,
+      text: 'hello',
+      circuit,
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async (ref) => {
+        fake.setModels.push(ref)
+      },
+      beforeAttempt: (ref) => {
+        attemptedRefs.push(ref)
+      },
+    })
+
+    expect(attemptedRefs).toEqual([CODEX_TERRA_REF, CODEX_SOL_REF, ANTHROPIC_REF])
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(ANTHROPIC_REF)
+  })
+
+  test('attempts only terra and sol (not luna) for a codex-only chain when the breaker opens mid-chain', async () => {
+    const circuit = new ThrottleCircuit({ now: () => 1_000 })
+    const fake = fakeSession(['soft-observer-ttfb-timeout', 'soft-observer-ttfb-timeout'])
+    const attemptedRefs: ModelRef[] = []
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [CODEX_TERRA_REF, CODEX_SOL_REF, CODEX_LUNA_REF],
+      currentModelRef: CODEX_TERRA_REF,
+      profile: 'default',
+      session: fake.session,
+      text: 'hello',
+      circuit,
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async (ref) => {
+        fake.setModels.push(ref)
+      },
+      beforeAttempt: (ref) => {
+        attemptedRefs.push(ref)
+      },
+    })
+
+    expect(attemptedRefs).toEqual([CODEX_TERRA_REF, CODEX_SOL_REF])
+    expect(result.success).toBe(false)
+  })
+
+  test('surfaces on the last attempted ref when a mid-chain trip strands trailing codex refs', async () => {
+    // [anthropic, terra, sol, luna]: anthropic fails over, terra+sol TTFB-timeout
+    // and open the breaker at sol. luna would now be skipped, so the turn must
+    // surface on sol (the last ATTEMPTED ref) — not fall through and report luna,
+    // which was never attempted.
+    const circuit = new ThrottleCircuit({ now: () => 1_000 })
+    const fake = fakeSession(['soft-throttle', 'soft-observer-ttfb-timeout', 'soft-observer-ttfb-timeout'])
+    const attemptedRefs: ModelRef[] = []
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [ANTHROPIC_REF, CODEX_TERRA_REF, CODEX_SOL_REF, CODEX_LUNA_REF],
+      currentModelRef: ANTHROPIC_REF,
+      profile: 'default',
+      session: fake.session,
+      text: 'hello',
+      circuit,
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async (ref) => {
+        fake.setModels.push(ref)
+      },
+      beforeAttempt: (ref) => {
+        attemptedRefs.push(ref)
+      },
+    })
+
+    expect(attemptedRefs).toEqual([ANTHROPIC_REF, CODEX_TERRA_REF, CODEX_SOL_REF])
+    expect(result.success).toBe(false)
+    expect(result.refUsed).toBe(CODEX_SOL_REF)
+  })
+
+  test('skips every codex ref while its provider circuit is open and uses the first non-codex fallback', async () => {
+    const circuit = new ThrottleCircuit()
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_TERRA_REF })
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_SOL_REF })
+    const fake = fakeSession(['success'])
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [CODEX_TERRA_REF, CODEX_SOL_REF, ANTHROPIC_REF, CODEX_LUNA_REF],
+      currentModelRef: CODEX_TERRA_REF,
+      profile: 'default',
+      session: fake.session,
+      text: 'hello',
+      circuit,
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async (ref) => {
+        fake.setModels.push(ref)
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(ANTHROPIC_REF)
+    expect(result.attempts).toEqual([{ ref: ANTHROPIC_REF, outcome: 'success' }])
+    expect(fake.prompted).toEqual(['hello'])
+    expect(fake.setModels).toEqual([ANTHROPIC_REF])
+  })
+
+  test('an open codex provider circuit surfaces a codex-only chain after one attempt', async () => {
+    const circuit = new ThrottleCircuit()
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_TERRA_REF })
+    circuit.recordProviderTrip({ profile: 'default', ref: CODEX_SOL_REF })
+    const fake = fakeSession(['hard-observer-ttfb-timeout'])
+
+    await expect(
+      promptPersistentTurnWithFallback({
+        refs: [CODEX_TERRA_REF, CODEX_SOL_REF, CODEX_LUNA_REF],
+        currentModelRef: CODEX_TERRA_REF,
+        profile: 'default',
+        session: fake.session,
+        text: 'hello',
+        circuit,
+        shouldFailover: (err) => isFailoverWorthy(err.message),
+        setModelForRef: async (ref) => {
+          fake.setModels.push(ref)
+        },
+      }),
+    ).rejects.toThrow('timed out before response headers')
+
+    expect(fake.prompted).toEqual(['hello'])
+    expect(fake.setModels).toEqual([])
+  })
+
+  test('a codex 503 opens only the existing per-ref circuit', async () => {
+    const circuit = new ThrottleCircuit()
+
+    for (let turn = 0; turn < 2; turn++) {
+      const fake = fakeSession(['soft-503', 'success'])
+      await promptPersistentTurnWithFallback({
+        refs: [CODEX_TERRA_REF, ANTHROPIC_REF],
+        currentModelRef: CODEX_TERRA_REF,
+        profile: 'default',
+        session: fake.session,
+        text: 'hello',
+        circuit,
+        shouldFailover: (err) => isFailoverWorthy(err.message),
+        setModelForRef: async (ref) => {
+          fake.setModels.push(ref)
+        },
+      })
+    }
+
+    expect(circuit.isOpen({ profile: 'default', ref: CODEX_TERRA_REF })).toBe(true)
+    expect(circuit.isProviderOpen({ profile: 'default', ref: CODEX_TERRA_REF })).toBe(false)
   })
 
   test('detects a soft error from the leaf entry when event subscriptions are skipped', async () => {

--- a/src/agent/turn-runner.ts
+++ b/src/agent/turn-runner.ts
@@ -1,7 +1,12 @@
-import type { ModelRef } from '@/config/providers'
+import { providerForModelRef, type ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
-import { detectProviderError, isRetryableSameRef, subscribeProviderErrors } from './provider-error'
+import {
+  detectProviderError,
+  isObserverTtfbTimeout,
+  isRetryableSameRef,
+  subscribeProviderErrors,
+} from './provider-error'
 import { RETRIES_PER_REF, retryTurnAfterCompletedToolResult, retryTurnOnPersistentSession } from './retry-same-ref'
 import { modelThrottleCircuit, type ThrottleCircuit } from './throttle-circuit'
 
@@ -44,6 +49,7 @@ export async function promptPersistentTurnWithFallback(opts: {
   const attempts: PersistentTurnAttempt[] = []
   let lastError: Error | undefined
   const circuit = opts.circuit ?? modelThrottleCircuit
+  const hasNonCodexFallback = opts.refs.some((ref) => !isCodexRef(ref))
   // The model the session currently has loaded; only call setModel when the
   // chosen ref differs from it. Tracked locally so successive setModel calls
   // within a single turn stay coherent.
@@ -55,9 +61,13 @@ export async function promptPersistentTurnWithFallback(opts: {
   // re-test the primary.
   for (let i = 0; i < opts.refs.length; i++) {
     const ref = opts.refs[i]!
-    const isLast = i === opts.refs.length - 1
-    // Skip a ref whose circuit is open, but never skip the last one — there is
-    // nowhere left to fall, so we try it regardless and let the result speak.
+    const codexProviderOpen = isCodexRef(ref) && circuit.isProviderOpen({ profile: opts.profile, ref })
+    if (codexProviderOpen && hasNonCodexFallback) continue
+    const isLast = !opts.refs
+      .slice(i + 1)
+      .some((candidate) => isRefUsable(candidate, opts.profile, circuit, hasNonCodexFallback))
+    // The last usable ref remains a safety probe. Codex refs stop being usable
+    // together only when the chain has transport-diverse credentials to use.
     if (!isLast && circuit.isOpen({ profile: opts.profile, ref })) continue
     if (ref !== loadedRef) {
       await opts.setModelForRef(ref)
@@ -133,7 +143,31 @@ export async function promptPersistentTurnWithFallback(opts: {
       attempts.push(attempt)
       lastError = outcome.error
       if (opts.shouldFailover(outcome.error)) circuit.recordThrottle({ profile: opts.profile, ref })
-      if (isLast || !canAdvance(outcome.error, activity, opts.shouldFailover)) {
+      if (isCodexRef(ref) && isObserverTtfbTimeout(outcome.error.message)) {
+        circuit.recordProviderTrip({ profile: opts.profile, ref })
+      }
+      // A codex-only chain surfaces after one attempt once its breaker is open
+      // (no transport-diverse ref to fall to). isRefUsable can't express this —
+      // with no non-codex fallback every codex ref reads as "usable" — so it stays
+      // an explicit condition.
+      const codexOnlyProviderOpen =
+        !hasNonCodexFallback && isCodexRef(ref) && circuit.isProviderOpen({ profile: opts.profile, ref })
+      // `isLast` was computed BEFORE this attempt, but recordProviderTrip above
+      // may have just opened the codex breaker and made every trailing candidate
+      // unusable (all remaining refs are codex the loop would now skip). Re-derive
+      // "is there a ref left worth advancing to" from the post-trip circuit state,
+      // so we finish on the CURRENT outcome (throw hard / return soft) instead of
+      // falling through the loop and returning success:false for a ref that was
+      // skipped and never attempted.
+      const noUsableCandidateRemains = !opts.refs
+        .slice(i + 1)
+        .some((next) => isRefUsable(next, opts.profile, circuit, hasNonCodexFallback))
+      if (
+        isLast ||
+        codexOnlyProviderOpen ||
+        noUsableCandidateRemains ||
+        !canAdvance(outcome.error, activity, opts.shouldFailover)
+      ) {
         if (outcome.kind === 'hard') throw outcome.error
         return { success: false, refUsed: ref, attempts, lastError }
       }
@@ -164,6 +198,26 @@ function classifySoftOutcome(
 
 function canAdvance(error: Error, activity: AttemptActivity, shouldFailover: (err: Error) => boolean): boolean {
   return shouldFailover(error) && !activity.producedAssistantOutput && !activity.startedToolExecution
+}
+
+function isCodexRef(ref: ModelRef): boolean {
+  return providerForModelRef(ref) === 'openai-codex'
+}
+
+// A ref is still worth advancing to iff the loop wouldn't skip it at the top: a
+// codex ref is dropped only once the codex provider breaker is open AND the chain
+// has a transport-diverse (non-codex) fallback to use instead. Shared by the
+// `isLast` safety-probe check and the post-trip terminal decision so both read
+// the SAME circuit state and can't diverge.
+function isRefUsable(
+  ref: ModelRef,
+  profile: string | undefined,
+  circuit: ThrottleCircuit,
+  hasNonCodexFallback: boolean,
+): boolean {
+  if (!isCodexRef(ref)) return true
+  if (!hasNonCodexFallback) return true
+  return !circuit.isProviderOpen({ profile, ref })
 }
 
 function subscribeAttemptActivity(session: AgentSession, activity: AttemptActivity): () => void {


### PR DESCRIPTION
## Problem

Codex models (`openai-codex/gpt-5.6-terra`, `-sol`, `-luna`) share one **provider, endpoint, account, and transport** (`chatgpt.com/codex/responses`). During a codex silent-hang phase, failing over terra→sol→luna buys **zero transport diversity** — it just re-hits the same hung origin.

The existing `ThrottleCircuit` was keyed per model ref (`profile:provider:ref`), so the three refs never shared health: a hang tripped each ref separately, letting a single turn walk the whole codex chain before surfacing. This is the mechanism behind the observed multi-minute PR-review turns that eventually died on `WebSocket 1006` — failover was churning through equivalent codex variants against a hung origin.

## Changes

1. **Provider-scoped breaker dimension** in `ThrottleCircuit`: `isProviderOpen` / `recordProviderTrip`, keyed `${profile}:${provider}` (no ref), **alongside the untouched per-ref path**. The per-ref `keyId` format is unchanged, so existing entries and semantics are unaffected.

2. **Trigger discrimination** (`provider-error.ts`): the provider trip fires only on a codex **observer TTFB timeout** (`isObserverTtfbTimeout` — both the `(typeclaw observer timeout)` marker and `timed out before response headers`), NOT on a generic 429/503. Real capacity signals keep the existing per-ref throttle path.

3. **Routing** (`turn-runner.ts`): while the codex provider breaker is open, skip **every** codex ref and route to the first configured **non-codex** fallback. A **codex-only chain** (no transport-diverse fallback) makes one safety attempt and surfaces promptly instead of walking every variant.

## Correctness

Routing was reviewed against 4 requirements and traced iteration-by-iteration for four scenarios (multi-provider mid-chain, codex-only fresh, codex-only already-open, per-ref 429). No silent no-attempt path, no stale-ordering bug, per-ref 429/503 preserved. Two same-turn regression tests encode the subtle mid-chain behaviors explicitly:
- `[terra, sol, anthropic]` closed breaker → attempts exactly `[terra, sol, anthropic]`, breaker opens after sol's second trip, reaches the non-codex fallback **within the same turn**.
- `[terra, sol, luna]` codex-only → attempts exactly `[terra, sol]`, **luna is never attempted**.

## Testing

- `bun test src/agent/throttle-circuit.test.ts src/agent/turn-runner.test.ts` → 30 pass, 0 fail.
- Full suite: **11042 pass, 0 fail**. `typecheck` clean, `lint` 0 errors, `format:check` clean.

## Scope

Part 2 of 3 (codex silent-hang resilience). Builds on #1220 (13s codex TTFB + `seq` telemetry). Follow-up: per-turn no-progress recovery envelope. Full retry-ownership (codex `maxRetries=0`) remains deferred pending an upstream `pi-ai` change (its codex provider hardcodes `MAX_RETRIES=3`).