### PR TITLE
fix(agent): bound cumulative no-progress recovery within a turn

### DIFF
--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -26,8 +26,10 @@ function fakeSession(
     | 'hard-observer-timeout'
     | 'hard-observer-ttfb-timeout'
     | 'soft-observer-ttfb-timeout'
+    | 'text-then-success'
     | 'success'
   >,
+  onPrompt?: () => void,
 ) {
   const events: Array<(event: FakeEvent) => void> = []
   const prompted: string[] = []
@@ -36,6 +38,7 @@ function fakeSession(
     prompt: async (text: string) => {
       prompted.push(text)
       const behavior = behaviors.shift() ?? 'success'
+      onPrompt?.()
       if (behavior === 'hard-observer-timeout') {
         throw new Error('anthropic SSE body idle for 120000ms (typeclaw observer timeout)')
       }
@@ -46,10 +49,14 @@ function fakeSession(
         for (const cb of events)
           cb({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'hi' } })
       }
+      if (behavior === 'text-then-success') {
+        for (const cb of events)
+          cb({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'still working' } })
+      }
       if (behavior === 'tool-then-throttle') {
         for (const cb of events) cb({ type: 'tool_execution_start' })
       }
-      if (behavior !== 'success') {
+      if (behavior !== 'success' && behavior !== 'text-then-success') {
         const message =
           behavior === 'soft-billing'
             ? 'billing required'
@@ -521,15 +528,22 @@ describe('promptPersistentTurnWithFallback', () => {
 // `prompt` runs the first behavior; `continue` runs subsequent ones WITHOUT
 // re-appending a user message — mirroring the real SDK recipe we depend on.
 // `userMessages` lets tests assert the user message is never duplicated.
-type RetryBehavior = 'throw-transient' | 'throw-before-assistant' | 'soft-transient' | 'success'
+type RetryBehavior =
+  | 'throw-transient'
+  | 'throw-before-assistant'
+  | 'soft-transient'
+  | 'soft-throttle'
+  | 'soft-observer-ttfb-timeout'
+  | 'success'
 
-function retryableFakeSession(behaviors: RetryBehavior[]) {
+function retryableFakeSession(behaviors: RetryBehavior[], onAttempt?: () => void) {
   const listeners: Array<(event: FakeEvent) => void> = []
   const messages: Array<{ role: string; stopReason?: string }> = []
   let idx = 0
   const run = (viaContinue: boolean) => {
     const behavior = behaviors[Math.min(idx, behaviors.length - 1)]!
     idx++
+    onAttempt?.()
     if (!viaContinue) messages.push({ role: 'user' })
     if (behavior === 'throw-before-assistant') {
       // provider dies before writing any assistant message: trailing leaf stays 'user'
@@ -539,10 +553,16 @@ function retryableFakeSession(behaviors: RetryBehavior[]) {
       messages.push({ role: 'assistant', stopReason: 'error' })
       throw new Error('socket hang up')
     }
-    if (behavior === 'soft-transient') {
+    if (behavior === 'soft-transient' || behavior === 'soft-throttle' || behavior === 'soft-observer-ttfb-timeout') {
       messages.push({ role: 'assistant', stopReason: 'error' })
+      const errorMessage =
+        behavior === 'soft-throttle'
+          ? '429 Too Many Requests'
+          : behavior === 'soft-observer-ttfb-timeout'
+            ? 'openai-codex timed out before response headers after 30000ms (typeclaw observer timeout)'
+            : 'ECONNRESET'
       for (const cb of listeners)
-        cb({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: 'ECONNRESET' } })
+        cb({ type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage } })
       return
     }
     messages.push({ role: 'assistant', stopReason: 'stop' })
@@ -572,6 +592,189 @@ function retryableFakeSession(behaviors: RetryBehavior[]) {
   } as unknown as AgentSession
   return { session, userMessages: () => messages.filter((m) => m.role === 'user').length, attempts: () => idx }
 }
+
+describe('promptPersistentTurnWithFallback no-progress envelope', () => {
+  test('surfaces after three logical no-header attempts without starting another attempt', async () => {
+    const fake = retryableFakeSession([
+      'soft-observer-ttfb-timeout',
+      'soft-observer-ttfb-timeout',
+      'soft-observer-ttfb-timeout',
+      'success',
+    ])
+    const attemptedRefs: ModelRef[] = []
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A, REF_B, ANTHROPIC_REF],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      beforeAttempt: (ref) => {
+        attemptedRefs.push(ref)
+      },
+      now: () => 0,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.refUsed).toBe(REF_B)
+    expect(fake.attempts()).toBe(3)
+    expect(attemptedRefs).toEqual([REF_A, REF_B])
+  })
+
+  test('surfaces at 60 seconds of cumulative no-progress before three attempts', async () => {
+    let nowMs = 0
+    const fake = retryableFakeSession(['soft-observer-ttfb-timeout', 'soft-observer-ttfb-timeout', 'success'], () => {
+      nowMs += 30_000
+    })
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A, REF_B],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      now: () => nowMs,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.refUsed).toBe(REF_A)
+    expect(fake.attempts()).toBe(2)
+  })
+
+  test('accrues only per-attempt elapsed, so a backward clock jump cannot prematurely exhaust the cap', async () => {
+    // A large backward jump between attempts (simulating an NTP/system-clock
+    // correction) must not inflate cumulativeNoProgressMs: each attempt only
+    // contributes its own positive elapsed, clamped at 0 by max(0, ...).
+    const elapsedPerAttempt = [10_000, 10_000, 10_000]
+    let nowMs = 1_000_000_000
+    let idx = 0
+    const fake = retryableFakeSession(
+      ['soft-observer-ttfb-timeout', 'soft-observer-ttfb-timeout', 'soft-observer-ttfb-timeout'],
+      () => {
+        nowMs += elapsedPerAttempt[idx]!
+        idx++
+        nowMs -= 500_000_000
+      },
+    )
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A, REF_B],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      now: () => nowMs,
+    })
+
+    // Surfaces on the 3-attempt cap, not the time cap (each attempt's real
+    // elapsed is 10s; the backward jumps must not have accrued negative or
+    // inflated time that would trip the 60s cap early or hide the count cap).
+    expect(result.success).toBe(false)
+    expect(fake.attempts()).toBe(3)
+  })
+
+  test('does not abort a progressing stream that runs past 60 seconds', async () => {
+    let nowMs = 0
+    const fake = fakeSession(['text-then-success'], () => {
+      nowMs = 60_001
+    })
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      now: () => nowMs,
+    })
+
+    expect(nowMs).toBeGreaterThan(60_000)
+    expect(result.success).toBe(true)
+    expect(fake.prompted).toEqual(['hello'])
+  })
+
+  test('keeps post-tool observer-timeout replay blocked', async () => {
+    const listeners = new Set<(event: FakeEvent) => void>()
+    const messages: Array<{ role: string; stopReason?: string }> = []
+    let continueCalls = 0
+    const setModels: ModelRef[] = []
+    const session = {
+      prompt: async () => {
+        messages.push({ role: 'user' }, { role: 'assistant', stopReason: 'error' })
+        for (const cb of listeners) cb({ type: 'tool_execution_start' })
+        for (const cb of listeners) {
+          cb({
+            type: 'message_end',
+            message: {
+              role: 'assistant',
+              stopReason: 'error',
+              errorMessage: 'openai-codex timed out before response headers after 30000ms (typeclaw observer timeout)',
+            },
+          })
+        }
+      },
+      subscribe: (cb: (event: FakeEvent) => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      },
+      agent: {
+        state: { messages },
+        continue: async () => {
+          continueCalls++
+        },
+      },
+    } as unknown as AgentSession
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A, REF_B],
+      currentModelRef: REF_A,
+      session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async (ref) => {
+        setModels.push(ref)
+      },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.refUsed).toBe(REF_A)
+    expect(continueCalls).toBe(0)
+    expect(setModels).toEqual([])
+  })
+
+  test('does not count a 429 toward the no-progress attempt limit', async () => {
+    const fake = retryableFakeSession([
+      'soft-throttle',
+      'soft-observer-ttfb-timeout',
+      'soft-observer-ttfb-timeout',
+      'success',
+    ])
+
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A, REF_B, ANTHROPIC_REF],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => isFailoverWorthy(err.message),
+      setModelForRef: async () => {},
+      now: () => 0,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.refUsed).toBe(ANTHROPIC_REF)
+    expect(fake.attempts()).toBe(4)
+  })
+})
 
 describe('promptPersistentTurnWithFallback same-ref retry', () => {
   test('an authorized retry resumes from a completed tool result despite tool activity', async () => {

--- a/src/agent/turn-runner.ts
+++ b/src/agent/turn-runner.ts
@@ -28,6 +28,12 @@ type AttemptActivity = {
   startedToolExecution: boolean
 }
 
+// SDK-level attempts already contain pi-ai's internal fetch recovery. Bounding
+// only repeated no-header outcomes limits dead air without timing out healthy
+// reasoning or tool execution.
+const MAX_NO_PROGRESS_ATTEMPTS = 3
+const MAX_CUMULATIVE_NO_PROGRESS_MS = 60_000
+
 export async function promptPersistentTurnWithFallback(opts: {
   refs: ModelRef[]
   currentModelRef: ModelRef
@@ -44,12 +50,21 @@ export async function promptPersistentTurnWithFallback(opts: {
   onRetryBackoffStart?: () => void
   beforeAttempt?: (ref: ModelRef) => void
   onAttemptFailed?: (attempt: PersistentTurnAttempt) => void
+  now?: () => number
 }): Promise<PersistentTurnResult> {
   if (opts.refs.length === 0) throw new Error('promptPersistentTurnWithFallback: refs[] must be non-empty')
   const attempts: PersistentTurnAttempt[] = []
   let lastError: Error | undefined
   const circuit = opts.circuit ?? modelThrottleCircuit
+  // Monotonic clock for the no-progress budget: it only ever measures elapsed
+  // (now() - attemptStartedAt), and performance.now() can't jump backward on an
+  // NTP/system-clock correction the way Date.now() can, which would otherwise
+  // prematurely trip or stall the 60s cap.
+  const now = opts.now ?? (() => performance.now())
   const hasNonCodexFallback = opts.refs.some((ref) => !isCodexRef(ref))
+  let noHeaderAttempts = 0
+  let cumulativeNoProgressMs = 0
+  let noProgressEnvelopeExhausted = false
   // The model the session currently has loaded; only call setModel when the
   // chosen ref differs from it. Tracked locally so successive setModel calls
   // within a single turn stay coherent.
@@ -94,6 +109,7 @@ export async function promptPersistentTurnWithFallback(opts: {
       let retryAfterCompletedToolResult = false
       for (let retry = 0; ; retry++) {
         softError = undefined
+        const attemptStartedAt = now()
         let outcomeThisAttempt: AttemptOutcome | undefined
         try {
           if (retry === 0) {
@@ -117,6 +133,15 @@ export async function promptPersistentTurnWithFallback(opts: {
         }
         outcome = outcomeThisAttempt
         if (outcome === undefined) break
+        if (isObserverTtfbTimeout(outcome.error.message)) {
+          noHeaderAttempts++
+          cumulativeNoProgressMs += Math.max(0, now() - attemptStartedAt)
+          noProgressEnvelopeExhausted =
+            noHeaderAttempts >= MAX_NO_PROGRESS_ATTEMPTS || cumulativeNoProgressMs >= MAX_CUMULATIVE_NO_PROGRESS_MS
+        }
+        // A fallback reached before the cap may still recover; once the cap is
+        // reached, no same-ref replay or later ref may start.
+        if (noProgressEnvelopeExhausted) break
         // Retry within budget only when the failure is same-ref retryable and
         // either no visible/tool activity occurred, or the caller explicitly
         // authorizes the strict post-tool-result resume recipe.
@@ -163,6 +188,7 @@ export async function promptPersistentTurnWithFallback(opts: {
         .slice(i + 1)
         .some((next) => isRefUsable(next, opts.profile, circuit, hasNonCodexFallback))
       if (
+        noProgressEnvelopeExhausted ||
         isLast ||
         codexOnlyProviderOpen ||
         noUsableCandidateRemains ||


### PR DESCRIPTION
> **Stacked on #1221** (`fix/codex-origin-circuit-breaker`). Base is that branch, so this diff shows only the envelope. Merge #1221 first, or this retargets to `main` automatically once #1221 lands.

## Problem

A codex silent-hang could keep a single turn alive for minutes. Each no-header failure was retried same-ref and then walked across refs, so a hang phase surfaced only after the whole chain drained — the observed **~338s of dead air** before a terminal failure on a PR-review turn.

## Changes

Add a **per-turn no-progress envelope** to `promptPersistentTurnWithFallback`:

- Count **logical attempts** that fail with an observer TTFB timeout (`isObserverTtfbTimeout`) and the wall-clock they consumed. *(Logical, not physical: this layer sits above the pi-ai SDK and sees one result per `session.prompt()`; it cannot count pi-ai's internal fetches.)*
- Stop **starting** new attempts (same-ref replay or cross-ref advance) once **3 no-header attempts** OR **60s cumulative no-progress** is reached, then surface the terminal result.

### Safety properties (Oracle-verified)

- **Cap is on NO-PROGRESS, not total turn time.** A successful attempt never increments the counter, so healthy long reasoning/tool turns are never capped.
- **Never aborts in-flight.** The check runs *after* an attempt resolves; it only gates *starting* the next one. A progressing/streaming attempt always completes.
- **Fail-closed preserved.** The existing activity guards (`producedAssistantOutput` / `startedToolExecution` → replay blocked) are unchanged; the envelope is purely additive and never enables an unsafe replay.
- **Single cumulative budget** across same-ref retries and cross-ref fallback.
- **Monotonic clock** default (`performance.now()`) so an NTP/system-clock correction can't prematurely trip or stall the time cap.

### Design note

Reaching the 3-attempt cap on a codex-only-so-far chain surfaces *before* trying a later non-codex fallback — this is correct-by-design: the envelope is a deterministic bound, and preferring recovery over the bound would be an explicit policy change, not a hidden exception.

## Testing

- `bun test src/agent/turn-runner.test.ts` → 31 pass, 0 fail. New tests: 3-attempt cap surfaces without another attempt; 60s cumulative cap surfaces before 3 attempts; a progressing stream past 60s is **not** aborted; post-tool replay stays blocked; a 429 does **not** count toward the cap; a backward clock jump can't prematurely exhaust the cap (elapsed-only accounting).
- Full suite: **11048 pass, 0 fail**. `typecheck` clean, `lint` 0 errors, `format:check` clean.

## Scope

Part 3 of 3 (codex silent-hang resilience): #1220 (13s TTFB + `seq` telemetry) → #1221 (provider-scoped circuit breaker) → this (no-progress envelope). Full retry-ownership (codex `maxRetries=0`) remains deferred pending an upstream `pi-ai` change (its codex provider hardcodes `MAX_RETRIES=3`).