### PR TITLE
cli: add botfather deep link to telegram setup notes

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -1518,7 +1518,7 @@ async function promptSlackAppToken(): Promise<string> {
 async function promptTelegramToken(): Promise<string> {
   note(
     [
-      'Open Telegram and message @BotFather.',
+      'Open Telegram and message @BotFather or visit https://t.me/BotFather.',
       '/newbot → pick a name and username, copy the HTTP API token',
       '  (looks like 1234567890:ABCdef...).',
       'In @BotFather: /setprivacy → Disable, so the bot can see group messages.',

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1882,7 +1882,7 @@ function validatePositiveInteger(v: string, requiredMessage: string): string | u
 async function runTelegramFlow(): Promise<StepResult<CollectedInputs['channelSecrets']>> {
   note(
     [
-      'Open Telegram and message @BotFather.',
+      'Open Telegram and message @BotFather or visit https://t.me/BotFather.',
       '/newbot → pick a name and username, copy the HTTP API token',
       '  (looks like 1234567890:ABCdef...).',
       'In @BotFather: /setprivacy → Disable, so the bot can see group messages.',


### PR DESCRIPTION
## Background

The Telegram setup instructions (in both `typeclaw init` and `typeclaw channel add`) tell the user to "message @BotFather" but give no way to jump there directly. On desktop, `@BotFather` in plain text isn't clickable outside the Telegram app itself, so a user setting up a bot from a terminal has to manually search for the bot inside Telegram.

## Summary

Added the `https://t.me/BotFather` deep link alongside the existing `@BotFather` mention in both places this instruction is duplicated:

- `src/cli/init.ts` (`runTelegramFlow`)
- `src/cli/channel.ts` (`promptTelegramToken`)

No logic changes — text only.

## Preview

Before:
```
Open Telegram and message @BotFather.
```

After:
```
Open Telegram and message @BotFather or visit https://t.me/BotFather.
```

## What this does NOT do

- Does not touch the bot-token validation logic or the `/setprivacy` step that follows.
- Does not deduplicate the two copies of this instruction block (`init.ts` and `channel.ts` diverged before this change and are left as-is).

## Review notes

The same instruction string is duplicated in `init.ts` and `channel.ts` — this PR updates both identically to keep them in sync. If either flow gets refactored later, note the other should be updated too.
