### PR TITLE
fix(agent): exempt post_github_review from file-operand scanning

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1040,6 +1040,25 @@ describe('wrapSystemTool', () => {
     ).rejects.toThrow(/virtual|process-backed|not available/i)
   })
 
+  test('post_github_review args are not scanned as local file operands', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-review-operands-'))
+    await mkdir(path.join(agentDir, 'src'), { recursive: true })
+    await writeFile(path.join(agentDir, 'src', 'router.ts'), 'export const x = 1\n')
+
+    const args: Record<string, unknown> = {
+      event: 'REQUEST_CHANGES',
+      body: 'router.ts introduces a risky path.',
+      comments: [{ path: 'src/router.ts', line: 10, body: 'Anchored at a real repo file.' }],
+    }
+
+    const pinned = await enforceAndPinToolFiles({ tool: 'post_github_review', args, agentDir, genericInputs: true })
+    await pinned.cleanup()
+
+    expect(args.body).toBe('router.ts introduces a risky path.')
+    expect((args.comments as Array<{ path: string }>)[0]?.path).toBe('src/router.ts')
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
   test('parallel read, look_at, and channel upload calls consume pinned bytes across symlink swaps', async () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-pinned-read-'))
     const safe = path.join(agentDir, 'safe.txt')

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -237,6 +237,11 @@ function fileTargets(
     return targets
   }
   if (tool === 'channel_fetch_attachment') return targets
+  // post_github_review has no local file operands: `comments[].path` are remote
+  // GitHub diff anchors and the `body` fields are markdown. Scanning them as
+  // generic operands either pins a real-repo anchor into a /tmp file:// path that
+  // leaks into the posted review, or throws "ambiguous local file operand".
+  if (tool === 'post_github_review') return targets
   if (genericInputs) collectGenericFileTargets(args, targets, maxCount, fileOperands, agentDir)
   return targets
 }


### PR DESCRIPTION
## Background

Formal GitHub PR reviews broke in two related ways after the file-operand security stack landed:

- **Leaked temp path in the review body** — a posted review carried `file:///tmp/typeclaw-tool-input-XXXX/0` as its entire body instead of the review text ([observed on #1223](https://github.com/typeclaw/typeclaw/pull/1223#pullrequestreview-4707447825)).
- **Review blocked outright** — the agent refused to review, reporting the PR-metadata lookup was "blocked by a repository-integrity check in this environment" that "an operator needs to clear" ([observed on #1224](https://github.com/typeclaw/typeclaw/pull/1224#issuecomment-4984812561)). No such check exists — that was the model paraphrasing an opaque tool error.

Root cause: the generic file-operand scanner (`e478c37c`) in `enforceAndPinToolFiles` runs on every system tool except `mcp_call`. It treats any arg that looks like a local path as an input to snapshot-and-pin, and throws `ambiguous local file operand` for undeclared path-shaped strings. `post_github_review` (`621c5130`) has **no local file operands** — `comments[].path` are remote GitHub diff anchors and `body`/`comments[].body` are markdown — but the scanner didn't know that:

- A `comments[].path` naming a real repo file (e.g. `src/router.ts`) matched the file-shaped-key heuristic → got pinned and rewritten to a `/tmp/typeclaw-tool-input` `file://` path, which then posted verbatim (the #1223 symptom).
- A filename-shaped `body` (or an undeclared path anchor) tripped the `ambiguous local file operand` throw → surfaced to the model as an opaque block it narrated as a "repository-integrity check" (the #1224 symptom).

The two tools shipped in the same recent security stack and collided.

## Summary

Exempt `post_github_review` from generic file-operand scanning in `fileTargets`, right beside the existing `channel_fetch_attachment` exemption — the established precedent for a tool whose `path`-shaped args are not local files. Its args now pass through the safety layer untouched.

Why this and not `fileOperands`: the `ToolFileOperands` API only has `input`/`output`/`destructive` allowlists — there's no "these fields are not operands" list — and `wrapSystemTool` doesn't even thread `fileOperands` for system tools. The `fileTargets` early-return is the same mechanism already used for the other non-file channel tools, so it's the minimal, consistent fix rather than a new API surface.

## What this does NOT do

- Does not weaken the file-operand pinning for any other tool — the exemption is scoped to `post_github_review` only, which performs zero local file reads.
- Does not touch the review-submission adapter, verdict coordination, or the `gh` CLI auth broker.
- Does not add a new `fileOperands` opt-out API (left for a follow-up if more tools need it).

## Review notes

Load-bearing change is the single `if (tool === 'post_github_review') return targets` line in `src/agent/tool-file-safety.ts`. Invariant to verify: `post_github_review` never reads a local file, so skipping the snapshot/pin path is safe — `comments[].path` is sent to GitHub as a remote diff anchor, never opened.

The regression test in `plugin-tools.test.ts` asserts the real failure directly: a `body` plus a `comments[].path` anchoring a real repo file survive `enforceAndPinToolFiles` unchanged (no `file://` temp rewrite, no throw). The pre-existing `post-github-review.test.ts` unit tests call the tool's `execute` directly and so never exercised the file-safety wrapper — which is exactly why this slipped through.
