### PR TITLE
fix(agent): stop treating channel message text as a file operand

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1059,6 +1059,92 @@ describe('wrapSystemTool', () => {
     await rm(agentDir, { recursive: true, force: true })
   })
 
+  test.each(['channel_send', 'channel_reply'] as const)(
+    '%s text-only message with slashes is never treated as a file operand',
+    async (tool) => {
+      const slashyMessages = [
+        '☀️ 사당동 날씨 (7/16 목) 27°C 맑음 | 강수확률 30%',
+        'S&P 500 up 2/3 of a point today',
+        'See https://example.com/report for details',
+        'ratio 16/9 and path-like word src/index.ts in prose',
+      ]
+      for (const text of slashyMessages) {
+        const pinned = await enforceAndPinToolFiles({
+          tool,
+          args: { adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHAN', text },
+          agentDir: '/agent',
+          genericInputs: true,
+        })
+        const result: ToolResult = { content: [{ type: 'text', text }], details: { echoed: text } }
+        expect(pinned.restoreResult(result)).toEqual(result)
+        await pinned.cleanup()
+      }
+    },
+  )
+
+  test('channel_send text-only send with a slash reaches the tool unchanged through the wrapper', async () => {
+    const text = '뉴스 요약 (7/16): S&P +2/3, https://example.com/a'
+    let received: string | undefined
+    const tool = definePiTool({
+      name: 'channel_send',
+      label: 'channel_send',
+      description: '',
+      parameters: Type.Any(),
+      async execute(_id, params) {
+        received = (params as { text: string }).text
+        return { content: [{ type: 'text' as const, text: 'ok' }], details: undefined }
+      },
+    })
+    const wrapped = wrapSystemTool(tool, { agentDir: '/agent', sessionId: 'slash-text', hooks: createHookBus() })
+    const result = await wrapped.execute(
+      'c',
+      { adapter: 'slack-bot', workspace: 'T0ACME', chat: 'C0CHAN', text },
+      undefined,
+      undefined,
+      {} as never,
+    )
+    expect(received).toBe(text)
+    expect(textOfFirstContent(result)).toBe('ok')
+  })
+
+  test('channel_send with slash-bearing text still pins the attachment path', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-channel-text-attach-'))
+    const file = path.join(agentDir, 'report.txt')
+    await writeFile(file, 'report body')
+    try {
+      let seenAttachmentPath: string | undefined
+      const tool = definePiTool({
+        name: 'channel_send',
+        label: 'channel_send',
+        description: '',
+        parameters: Type.Any(),
+        async execute(_id, params) {
+          seenAttachmentPath = (params as { attachments: Array<{ path: string }> }).attachments[0]?.path
+          const body = await readFile(seenAttachmentPath as string, 'utf8')
+          return { content: [{ type: 'text' as const, text: body }], details: undefined }
+        },
+      })
+      const wrapped = wrapSystemTool(tool, { agentDir, sessionId: 'text-attach', hooks: createHookBus() })
+      const result = await wrapped.execute(
+        'c',
+        {
+          adapter: 'slack-bot',
+          workspace: 'T0ACME',
+          chat: 'C0CHAN',
+          text: 'here (7/16)',
+          attachments: [{ path: file }],
+        },
+        undefined,
+        undefined,
+        {} as never,
+      )
+      expect(seenAttachmentPath).not.toBe(file)
+      expect(textOfFirstContent(result)).toBe('report body')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
   test('parallel read, look_at, and channel upload calls consume pinned bytes across symlink swaps', async () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-pinned-read-'))
     const safe = path.join(agentDir, 'safe.txt')

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -228,12 +228,16 @@ function fileTargets(
     targets.push(propertyTarget(value, 'path'))
     if (targets.length > maxCount) throw inputCountTooLarge(targets.length, maxCount)
   }
-  if (tool === 'look_at' && Array.isArray(args.images)) {
-    for (const image of args.images) addPath(image)
+  if (tool === 'look_at') {
+    if (Array.isArray(args.images)) for (const image of args.images) addPath(image)
     return targets
   }
-  if ((tool === 'channel_send' || tool === 'channel_reply') && Array.isArray(args.attachments)) {
-    for (const attachment of args.attachments) addPath(attachment)
+  // The only file operand for these tools is `attachments[].path`; `text` is free-form
+  // prose (dates like "7/16", URLs, fractions) that must never reach the generic scan,
+  // which rejects any value carrying a `/` or `\`. Return early even without attachments
+  // so a text-only message is never misread as a path. Attachment pinning is unchanged.
+  if (tool === 'channel_send' || tool === 'channel_reply') {
+    if (Array.isArray(args.attachments)) for (const attachment of args.attachments) addPath(attachment)
     return targets
   }
   if (tool === 'channel_fetch_attachment') return targets


### PR DESCRIPTION
## Background

A Slack agent running from `main` (the file-operand security stack, PRs #1201-#1222) suddenly started posting broken messages, reported in three symptoms:

1. a stray literal **"test message"** leaked to the channel;
2. **broken formatting** - literal `**bold**`, `S&amp;P`, `:emoji:` shortcodes, and markdown tables shown as flat pipes;
3. **unintended `.md`/`.txt` file attachments** carrying the message body instead of inline text.

All three trace to a single false-positive in the generic file-operand scanner.

## Root cause

`enforceAndPinToolFiles` (`e478c37c`) runs the generic undeclared-operand scan on every system tool except `mcp_call`. In `fileTargets`, the `channel_send`/`channel_reply` special-case only returned early **when `attachments` was a present array**:

```ts
if ((tool === 'channel_send' || tool === 'channel_reply') && Array.isArray(args.attachments)) { ... return targets }
```

So a **text-only** message (no `attachments` key) fell through to `collectGenericFileTargets`, which calls `isAmbiguousUndeclaredLocalOperand`. That predicate treats **any string containing a slash or backslash character** as an ambiguous local file path and throws:

```
ambiguous local file operand at key 'text'; the tool author must declare fileOperands.input or the caller must use a file: URI
```

Ordinary message prose trips this constantly - a date like `7/16`, a URL, a fraction `2/3`, or a path-shaped word. It affects **every language**, but CJK news/weather bulletins hit it on nearly every message because they carry dates.

### Confirmed from the production session transcript

The agent fought the guard in real time: rich text rejected -> retried plain Korean (still contained `7/16`, still rejected) -> sent an ASCII-only `"test message"` that passed (symptom 1) -> degraded to ASCII-only prose dropping markdown/emoji (symptom 2) -> finally wrote the body to a file and attached it (symptom 3). The tool result stream contains 15+ `ambiguous local file operand` errors and the model's own note *"Korean text causes the issue but English doesn't."*

## Fix

Scope the `channel_send`/`channel_reply` (and `look_at`) special-cases to their declared operands and **return early even when the operand array is absent**, so free-form `text` never reaches the generic path scan. `attachments[].path` is the only file operand for these tools; attachment pinning, canonical-secret denial, and size/count limits are unchanged.

This is the same mechanism and reasoning as #1226 (`post_github_review`), which fixes the sibling instance of this exact root cause - the `ToolFileOperands` API has no "these fields are not operands" list and `wrapSystemTool` doesn't thread `fileOperands` for system tools, so the `fileTargets` early-return is the minimal, consistent fix rather than a new API surface.

## What this does NOT do

- Does not weaken file-operand pinning for any other tool - scoped to `channel_send`/`channel_reply`/`look_at`.
- Does not touch `isAmbiguousUndeclaredLocalOperand` or the `plugin-tools.ts` genericInputs gating (per security review, both would broadly weaken the fail-closed contract for undeclared operands).
- Does not change the outbound adapter, markdown-block rendering, or attachment upload path.

## Tests

`plugin-tools.test.ts` adds regression coverage that fails with the exact production error when the fix is reverted:

- text-only `channel_send`/`channel_reply` carrying `/` (Korean date, `S&P 2/3`, `https://...`, `src/index.ts` in prose) survive `enforceAndPinToolFiles` unchanged;
- a slash-bearing text still reaches the tool through the `wrapSystemTool` wrapper;
- a text-plus-attachment send still pins the `attachments[].path`.

Checks: `typecheck`, `lint` (0 errors), `format:check`, and full `test` (11412 pass, 0 fail) all green.
<!-- OMO_INTERNAL_INITIATOR -->
