### PR TITLE
fix(agent): stop file-operand scanner rejecting prose in prompt/query/reason fields

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1145,6 +1145,48 @@ describe('wrapSystemTool', () => {
     }
   })
 
+  test('free-text prose fields with path-shaped values are never pinned or rejected', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-freetext-'))
+    await mkdir(path.join(agentDir, 'src'), { recursive: true })
+    await writeFile(path.join(agentDir, 'src', 'router.ts'), 'x')
+    await writeFile(path.join(agentDir, 'status.txt'), 'done')
+    const bodyUrl = pathToFileURL(path.join(agentDir, 'status.txt')).href
+
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ['spawn_subagent', { subagent_type: 'explore', prompt: 'Look at src/router.ts and summarize.' }],
+      ['spawn_subagent', { subagent_type: 'explore', prompt: bodyUrl }],
+      ['skip_response', { reason: 'nothing to do, see notes.md' }],
+      ['web_search', { query: 'how to configure vite.config.ts' }],
+      ['todo_write', { todos: [{ content: 'edit src/router.ts', status: 'pending', priority: 'high' }] }],
+    ]
+    for (const [tool, args] of cases) {
+      const before = JSON.stringify(args)
+      const pinned = await enforceAndPinToolFiles({ tool, args, agentDir, genericInputs: true })
+      await pinned.cleanup()
+      expect(JSON.stringify(args)).toBe(before)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('a url field still pins an explicit file: URI (symlink-swap defense preserved)', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-url-pin-'))
+    await writeFile(path.join(agentDir, 'src.txt'), 'real')
+    const args: Record<string, unknown> = { url: pathToFileURL(path.join(agentDir, 'src.txt')).href }
+    const pinned = await enforceAndPinToolFiles({ tool: 'custom_reader', args, agentDir, genericInputs: true })
+    await pinned.cleanup()
+    expect(String(args.url)).toContain('typeclaw-tool-input')
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('undeclared path-shaped operand on an unknown key still fails closed', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-failclosed-'))
+    await writeFile(path.join(agentDir, 'data.bin'), 'd')
+    await expect(
+      enforceAndPinToolFiles({ tool: 'some_plugin_tool', args: { value: 'data.bin' }, agentDir, genericInputs: true }),
+    ).rejects.toThrow(/ambiguous local file operand/)
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
   test('parallel read, look_at, and channel upload calls consume pinned bytes across symlink swaps', async () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-pinned-read-'))
     const safe = path.join(agentDir, 'safe.txt')

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1145,25 +1145,57 @@ describe('wrapSystemTool', () => {
     }
   })
 
-  test('free-text prose fields with path-shaped values are never pinned or rejected', async () => {
-    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-freetext-'))
+  test('first-party prose operands with path-shaped values are never pinned or rejected', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-prose-'))
     await mkdir(path.join(agentDir, 'src'), { recursive: true })
     await writeFile(path.join(agentDir, 'src', 'router.ts'), 'x')
-    await writeFile(path.join(agentDir, 'status.txt'), 'done')
-    const bodyUrl = pathToFileURL(path.join(agentDir, 'status.txt')).href
 
     const cases: Array<[string, Record<string, unknown>]> = [
       ['spawn_subagent', { subagent_type: 'explore', prompt: 'Look at src/router.ts and summarize.' }],
-      ['spawn_subagent', { subagent_type: 'explore', prompt: bodyUrl }],
+      ['spawn_subagent', { subagent_type: 'explore', description: 'check src/app.ts' }],
       ['skip_response', { reason: 'nothing to do, see notes.md' }],
       ['web_search', { query: 'how to configure vite.config.ts' }],
+      ['web_fetch', { url: 'https://example.com/a', query: '.data[0].path', selector: 'div.a/b', pattern: 'a/b\\d' }],
       ['todo_write', { todos: [{ content: 'edit src/router.ts', status: 'pending', priority: 'high' }] }],
+      ['channel_edit', { workspace: 'W', chat: 'C', message_id: '1', text: 'fixed in src/router.ts (7/16)' }],
     ]
     for (const [tool, args] of cases) {
       const before = JSON.stringify(args)
       const pinned = await enforceAndPinToolFiles({ tool, args, agentDir, genericInputs: true })
       await pinned.cleanup()
       expect(JSON.stringify(args)).toBe(before)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('prose exemption is tool-scoped: an undeclared reader with a common key still fails closed', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-toolscoped-'))
+    await writeFile(path.join(agentDir, 'data.json'), 'SENSITIVE')
+    // `content`, `body`, `prompt`, `name` are opaque prose ONLY for their declared
+    // first-party tools. An undeclared plugin/MCP reader must not inherit that.
+    for (const key of ['content', 'body', 'prompt', 'name']) {
+      await expect(
+        enforceAndPinToolFiles({
+          tool: 'plugin_reader',
+          args: { [key]: `${agentDir}/data.json` },
+          agentDir,
+          genericInputs: true,
+        }),
+      ).rejects.toThrow(/ambiguous local file operand/)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('a whitespace- or case-varied file: URI is pinned, never passed through', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-ws-uri-'))
+    await writeFile(path.join(agentDir, 'data.json'), 'SENSITIVE')
+    const href = pathToFileURL(path.join(agentDir, 'data.json')).href
+    const variants = [`  ${href}`, `\t${href}`, `\n${href}`, href.replace(/^file:/, 'FILE:')]
+    for (const value of variants) {
+      const args: Record<string, unknown> = { url: value }
+      const pinned = await enforceAndPinToolFiles({ tool: 'web_fetch', args, agentDir, genericInputs: true })
+      await pinned.cleanup()
+      expect(String(args.url)).toContain('typeclaw-tool-input')
     }
     await rm(agentDir, { recursive: true, force: true })
   })

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -6,10 +6,7 @@ import { Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-import {
-  checkPrivateSurfaceReadGuard,
-  classifyFreeTextField,
-} from '@/bundled-plugins/security/policies/private-surface-read'
+import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
 import type { ToolFileOperands, ToolResult } from '@/plugin'
 import { CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
 import type { HiddenPaths } from '@/sandbox/hidden-paths'
@@ -253,6 +250,35 @@ function fileTargets(
   return targets
 }
 
+// Exact tool + operand-path pairs whose string values are first-party PROSE
+// (message bodies, prompts, queries, regex/CSS/jq strings) — never a local file,
+// so the generic path scan must skip them. Scoped per full operand path, NOT by
+// key name: an undeclared plugin/MCP reader that happens to use `content` or
+// `prompt` must still fail closed. `url` is deliberately absent (web_fetch.url is
+// a real reference — an explicit file: URI there still pins). channel_send/
+// _reply/_fetch_attachment and post_github_review are exempt via earlier returns.
+const PROSE_OPERANDS: Readonly<Record<string, ReadonlySet<string>>> = {
+  spawn_subagent: new Set(['prompt', 'description']),
+  skip_response: new Set(['reason']),
+  web_search: new Set(['query']),
+  web_fetch: new Set(['query', 'selector', 'pattern']),
+  todo_write: new Set(['todos.content']),
+  channel_edit: new Set(['text']),
+}
+
+function isProseOperand(tool: string, operandPath: string): boolean {
+  return PROSE_OPERANDS[tool]?.has(operandPath) === true
+}
+
+// Detection trims first: a leading-whitespace `  file://…` is still a file
+// reference to any consumer that trims before parsing, so it must be pinned or
+// denied, never passed through untouched. The original untrimmed string is
+// preserved on the target for result restoration; the trimmed URI is what gets
+// normalized and snapshotted.
+function isFileUri(value: string): boolean {
+  return value.trim().toLocaleLowerCase().startsWith('file:')
+}
+
 function propertyTarget(object: Record<string, unknown>, key: string): FileTarget {
   const raw = object[key] as string
   return {
@@ -261,7 +287,7 @@ function propertyTarget(object: Record<string, unknown>, key: string): FileTarge
     set: (value) => {
       object[key] = value
     },
-    uri: raw.toLocaleLowerCase().startsWith('file:'),
+    uri: isFileUri(raw),
   }
 }
 
@@ -273,7 +299,7 @@ function arrayTarget(array: unknown[], index: number): FileTarget {
     set: (value) => {
       array[index] = value
     },
-    uri: raw.toLocaleLowerCase().startsWith('file:'),
+    uri: isFileUri(raw),
   }
 }
 
@@ -337,20 +363,19 @@ function collectGenericFileTargets(
     const nonInput =
       operands?.output?.includes(parentPath) === true || operands?.destructive?.includes(parentPath) === true
     const key = parentPath.split('.').at(-1) ?? parentPath
-    // Declared inputs win over any naming convention; otherwise a known free-text
-    // field suppresses inference: 'opaque' skips even a file: URI (message/prose
-    // payload), 'file-uri' skips only the path-shape heuristic but still pins a
-    // real file: URI (e.g. a url the tool dereferences).
-    const freeText = declaredInput ? undefined : classifyFreeTextField(tool, key)
+    // Precedence: declared input pins; declared output/destructive is not an
+    // input; a first-party prose operand is opaque (skipped, even a file: URI);
+    // otherwise an explicit file: URI pins and an undeclared path-shaped value
+    // fails closed. `isProseOperand` is tool+operand-path scoped, so an unknown
+    // tool never inherits an exemption from a common key name.
+    const prose = !declaredInput && isProseOperand(tool, parentPath)
     for (const [index, item] of value.entries()) {
       if (typeof item === 'string') {
-        if (freeText === 'opaque') continue
-        const fileUrl = item.toLocaleLowerCase().startsWith('file:')
-        if (!nonInput && (fileUrl || declaredInput)) {
+        if (prose) continue
+        if (!nonInput && (isFileUri(item) || declaredInput)) {
           out.push(arrayTarget(value, index))
           if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
         } else if (
-          freeText === undefined &&
           !nonInput &&
           !isSemanticGenericString(key, item) &&
           isAmbiguousUndeclaredLocalOperand(item, agentDir, key)
@@ -372,20 +397,18 @@ function collectGenericFileTargets(
       const declaredInput = operands?.input?.includes(operandPath) === true
       const nonInput =
         operands?.output?.includes(operandPath) === true || operands?.destructive?.includes(operandPath) === true
-      // Declared inputs win; an 'opaque' prose field (text/body/prompt/query/…)
-      // is left untouched even when its value is a file: URI, so a message body
-      // or subagent prompt is never pinned or rejected. A 'file-uri' field (url)
-      // still pins a real file: URI below but skips the path-shape heuristic.
-      const freeText = declaredInput ? undefined : classifyFreeTextField(tool, childKey)
-      if (freeText === 'opaque') continue
-      const fileUrl = item.toLocaleLowerCase().startsWith('file:')
-      if (!nonInput && (fileUrl || declaredInput)) {
+      // Declared input wins; a first-party prose operand (spawn_subagent.prompt,
+      // web_search.query, channel_edit.text, …) is opaque and skipped even when
+      // its value is a file: URI; everything else falls to the file:/heuristic
+      // scan below. Scoped by exact tool+operand-path so an undeclared plugin
+      // reader using `content`/`prompt` still fails closed.
+      if (!declaredInput && isProseOperand(tool, operandPath)) continue
+      if (!nonInput && (isFileUri(item) || declaredInput)) {
         out.push(propertyTarget(value, childKey))
         if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
         continue
       }
       if (
-        freeText === undefined &&
         !nonInput &&
         !isSemanticGenericString(childKey, item) &&
         isAmbiguousUndeclaredLocalOperand(item, agentDir, childKey)
@@ -816,10 +839,14 @@ function isSemanticGenericString(key: string, value: string): boolean {
 }
 
 function isExplicitNonFileUrl(value: string): boolean {
-  if (/^[A-Za-z]:[\\/]/.test(value)) return false
-  if (!/^[A-Za-z][A-Za-z0-9+.-]*:/.test(value) || value.toLocaleLowerCase().startsWith('file:')) return false
+  // Trim to match the file:/URL detection elsewhere: a leading-whitespace
+  // "  https://…" is still a non-file URL, and a "  file://…" must NOT be
+  // treated as one (it pins). Windows-drive and file: exclusions run on trimmed.
+  const trimmed = value.trim()
+  if (/^[A-Za-z]:[\\/]/.test(trimmed)) return false
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed) || trimmed.toLocaleLowerCase().startsWith('file:')) return false
   try {
-    return new URL(value).protocol !== 'file:'
+    return new URL(trimmed).protocol !== 'file:'
   } catch {
     return false
   }
@@ -863,9 +890,10 @@ function isDeniedSnapshotPath(
 }
 
 function normalizeFileReference(value: string): string {
-  if (!value.toLocaleLowerCase().startsWith('file:')) return value
+  const trimmed = value.trim()
+  if (!trimmed.toLocaleLowerCase().startsWith('file:')) return value
   try {
-    return fileURLToPath(value)
+    return fileURLToPath(trimmed)
   } catch {
     throw new Error(`invalid file URI: ${value}`)
   }

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -6,7 +6,10 @@ import { Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
+import {
+  checkPrivateSurfaceReadGuard,
+  classifyFreeTextField,
+} from '@/bundled-plugins/security/policies/private-surface-read'
 import type { ToolFileOperands, ToolResult } from '@/plugin'
 import { CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
 import type { HiddenPaths } from '@/sandbox/hidden-paths'
@@ -246,7 +249,7 @@ function fileTargets(
   // generic operands either pins a real-repo anchor into a /tmp file:// path that
   // leaks into the posted review, or throws "ambiguous local file operand".
   if (tool === 'post_github_review') return targets
-  if (genericInputs) collectGenericFileTargets(args, targets, maxCount, fileOperands, agentDir)
+  if (genericInputs) collectGenericFileTargets(tool, args, targets, maxCount, fileOperands, agentDir)
   return targets
 }
 
@@ -321,6 +324,7 @@ function collectDeclaredOutputTargets(
 }
 
 function collectGenericFileTargets(
+  tool: string,
   value: unknown,
   out: FileTarget[],
   maxCount: number,
@@ -333,13 +337,20 @@ function collectGenericFileTargets(
     const nonInput =
       operands?.output?.includes(parentPath) === true || operands?.destructive?.includes(parentPath) === true
     const key = parentPath.split('.').at(-1) ?? parentPath
+    // Declared inputs win over any naming convention; otherwise a known free-text
+    // field suppresses inference: 'opaque' skips even a file: URI (message/prose
+    // payload), 'file-uri' skips only the path-shape heuristic but still pins a
+    // real file: URI (e.g. a url the tool dereferences).
+    const freeText = declaredInput ? undefined : classifyFreeTextField(tool, key)
     for (const [index, item] of value.entries()) {
       if (typeof item === 'string') {
+        if (freeText === 'opaque') continue
         const fileUrl = item.toLocaleLowerCase().startsWith('file:')
         if (!nonInput && (fileUrl || declaredInput)) {
           out.push(arrayTarget(value, index))
           if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
         } else if (
+          freeText === undefined &&
           !nonInput &&
           !isSemanticGenericString(key, item) &&
           isAmbiguousUndeclaredLocalOperand(item, agentDir, key)
@@ -350,7 +361,7 @@ function collectGenericFileTargets(
         }
         continue
       }
-      collectGenericFileTargets(item, out, maxCount, operands, agentDir, parentPath)
+      collectGenericFileTargets(tool, item, out, maxCount, operands, agentDir, parentPath)
     }
     return
   }
@@ -358,16 +369,23 @@ function collectGenericFileTargets(
   for (const [childKey, item] of Object.entries(value)) {
     const operandPath = parentPath === '' ? childKey : `${parentPath}.${childKey}`
     if (typeof item === 'string') {
-      const fileUrl = item.toLocaleLowerCase().startsWith('file:')
       const declaredInput = operands?.input?.includes(operandPath) === true
       const nonInput =
         operands?.output?.includes(operandPath) === true || operands?.destructive?.includes(operandPath) === true
+      // Declared inputs win; an 'opaque' prose field (text/body/prompt/query/…)
+      // is left untouched even when its value is a file: URI, so a message body
+      // or subagent prompt is never pinned or rejected. A 'file-uri' field (url)
+      // still pins a real file: URI below but skips the path-shape heuristic.
+      const freeText = declaredInput ? undefined : classifyFreeTextField(tool, childKey)
+      if (freeText === 'opaque') continue
+      const fileUrl = item.toLocaleLowerCase().startsWith('file:')
       if (!nonInput && (fileUrl || declaredInput)) {
         out.push(propertyTarget(value, childKey))
         if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
         continue
       }
       if (
+        freeText === undefined &&
         !nonInput &&
         !isSemanticGenericString(childKey, item) &&
         isAmbiguousUndeclaredLocalOperand(item, agentDir, childKey)
@@ -377,7 +395,7 @@ function collectGenericFileTargets(
         )
       }
     }
-    collectGenericFileTargets(item, out, maxCount, operands, agentDir, operandPath)
+    collectGenericFileTargets(tool, item, out, maxCount, operands, agentDir, operandPath)
   }
 }
 

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -148,25 +148,13 @@ const FREE_TEXT_KEYS_BY_TOOL: Record<string, ReadonlySet<string>> = {
   channel_fetch_attachment: new Set(['filename']),
 }
 
-// `url` is free text for THIS policy (a web_fetch/web_search URL is not a local
-// path to block) but is NOT pure prose: an explicit `file:` URI under `url` is a
-// real file the tool dereferences, so the pinning scanner must still snapshot it
-// (symlink-swap TOCTOU defense). Everything else in NON_PATH_KEYS is payload the
-// tool logs/sends/searches and never opens.
-const FILE_URI_CAPABLE_KEYS = new Set(['url'])
-
-// Field classification shared with the file-operand pinning scanner
-// (tool-file-safety.ts) so both guards agree on which arg values are prose.
-// Without this the two disagreed: this policy skipped `text`/`prompt` while the
-// pinning scanner treated the same values as paths, rejecting a subagent prompt
-// that named a file or pinning a query into a /tmp/typeclaw-tool-input path.
-//   - 'opaque'   : pure payload; never a file, even a whole-string file: URI.
-//   - 'file-uri' : suppresses path-shape heuristics but a file: URI still pins.
-//   - undefined  : unknown key; fall through to the value heuristic.
-export function classifyFreeTextField(tool: string, key: string): 'opaque' | 'file-uri' | undefined {
-  const known = NON_PATH_KEYS.has(key) || (FREE_TEXT_KEYS_BY_TOOL[tool]?.has(key) ?? false)
-  if (!known) return undefined
-  return FILE_URI_CAPABLE_KEYS.has(key) ? 'file-uri' : 'opaque'
+// Trim before the `file:` test: an exempt prose key otherwise lets a
+// leading-whitespace `file:  file://…/memory` URI slip past the scan (the value
+// is not path-shaped and `isFileUrl` misses it), reaching a fetcher that trims
+// before parsing. Returns the trimmed URI so callers scan the real target.
+function trimmedFileUri(value: string): string | undefined {
+  const trimmed = value.trim()
+  return trimmed.toLocaleLowerCase().startsWith('file:') ? trimmed : undefined
 }
 
 // Recursively collects strings that could be paths, skipping values under a
@@ -186,7 +174,7 @@ function collectPathCandidates(value: unknown, tool: string): string[] {
 
 function walk(value: unknown, out: string[], tool: string, underExempt: boolean, key?: string): void {
   if (typeof value === 'string') {
-    const isFileUrl = value.toLocaleLowerCase().startsWith('file:')
+    const isFileUrl = trimmedFileUri(value) !== undefined
     if (underExempt && !isPathKey(key) && !isFileUrl) return
     const normalized = normalizeCandidate(value)
     if (normalized !== undefined) out.push(normalized)
@@ -333,16 +321,17 @@ function isPathKey(key: string | undefined): boolean {
 }
 
 function normalizeCandidate(value: string): string | undefined {
-  if (!value.toLocaleLowerCase().startsWith('file:')) return value
+  const uri = trimmedFileUri(value)
+  if (uri === undefined) return value
   try {
-    const url = new URL(value)
+    const url = new URL(uri)
     const pathname = decodeURIComponent(url.pathname)
     if (url.hostname !== '') return `//${url.hostname}${pathname}`
     if (/^\/[A-Za-z]:\//.test(pathname)) return pathname.slice(1)
     // Keep synthetic POSIX container paths platform-independent. fileURLToPath
     // would reinterpret file:///agent/... through the Windows host grammar.
     if (pathname.startsWith('/agent/') || pathname === '/agent') return pathname
-    return fileURLToPath(value)
+    return fileURLToPath(uri)
   } catch {
     return value
   }

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -148,6 +148,27 @@ const FREE_TEXT_KEYS_BY_TOOL: Record<string, ReadonlySet<string>> = {
   channel_fetch_attachment: new Set(['filename']),
 }
 
+// `url` is free text for THIS policy (a web_fetch/web_search URL is not a local
+// path to block) but is NOT pure prose: an explicit `file:` URI under `url` is a
+// real file the tool dereferences, so the pinning scanner must still snapshot it
+// (symlink-swap TOCTOU defense). Everything else in NON_PATH_KEYS is payload the
+// tool logs/sends/searches and never opens.
+const FILE_URI_CAPABLE_KEYS = new Set(['url'])
+
+// Field classification shared with the file-operand pinning scanner
+// (tool-file-safety.ts) so both guards agree on which arg values are prose.
+// Without this the two disagreed: this policy skipped `text`/`prompt` while the
+// pinning scanner treated the same values as paths, rejecting a subagent prompt
+// that named a file or pinning a query into a /tmp/typeclaw-tool-input path.
+//   - 'opaque'   : pure payload; never a file, even a whole-string file: URI.
+//   - 'file-uri' : suppresses path-shape heuristics but a file: URI still pins.
+//   - undefined  : unknown key; fall through to the value heuristic.
+export function classifyFreeTextField(tool: string, key: string): 'opaque' | 'file-uri' | undefined {
+  const known = NON_PATH_KEYS.has(key) || (FREE_TEXT_KEYS_BY_TOOL[tool]?.has(key) ?? false)
+  if (!known) return undefined
+  return FILE_URI_CAPABLE_KEYS.has(key) ? 'file-uri' : 'opaque'
+}
+
 // Recursively collects strings that could be paths, skipping values under a
 // universally-free-text key or a tool-scoped free-text key. Explicit path-like
 // keys still win, and file:// values are normalized before matching. matchHidden then


### PR DESCRIPTION
## Background

A Discord agent running from `main` posted `file:///tmp/typeclaw-tool-input-XpwgiL/0` as a chat message (followed by an empty message) instead of a status update. That specific symptom was the `channel_reply` text leak fixed in #1227 — but it's one face of a broader regression in the generic file-operand scanner (`e478c37c`), and #1227 only closed the channel surface.

`enforceAndPinToolFiles` runs the undeclared-operand scan on every system tool except `mcp_call`. In `collectGenericFileTargets`, `isAmbiguousUndeclaredLocalOperand` treats any string that is path-shaped (contains a slash, starts with `./`, matches `name.ext`, or resolves to a real file) as a file operand — pinning it to a `/tmp/typeclaw-tool-input` copy, or throwing `ambiguous local file operand`. That is correct for `read`/`look_at`/attachments, but wrong for **prose** args.

Reproduced on `main` (post-#1227), still broken:

- `spawn_subagent({ prompt: "Look at src/router.ts and summarize." })` → **throws** `ambiguous local file operand at key "prompt"` — a subagent prompt that names a file is rejected, breaking the core delegation flow.
- `skip_response({ reason: "…notes.md" })`, `web_search({ query: "configure vite.config.ts" })`, `todo_write({ todos: [{ content: "edit src/router.ts" }] }])` all fail the same way whenever the value carries a path-shaped token.

## Summary

The root problem is that `tool-file-safety.ts` re-derives file-ness from a value's *spelling*, while the `private-surface-read` guard already classifies the same keys (`text`/`body`/`prompt`/`query`/`reason`/…) as prose. The two guards disagreed. I export that knowledge as `classifyFreeTextField` and consult it in `collectGenericFileTargets` before the value heuristic.

Precedence (per an Oracle design pass on the security intent):

1. declared `output`/`destructive` → ignore
2. declared `input` → pin (tool-author metadata always wins)
3. **`opaque` prose field** (`text`/`body`/`content`/`prompt`/`query`/`reason`/…) → skip, **even a whole-string `file:` URI** (it's a message payload, not a file to open)
4. **`file-uri` field** (`url`) → skip the path-shape heuristic but **still pin an explicit `file:` URI**
5. explicit `file:` URI on an unknown key → pin
6. unknown key, path-shaped value → still throw (fail-closed preserved)

**Why `url` is split out (not just lumped with prose):** an existing security test pins a `file://` URL passed to a reader tool so a concurrent symlink swap can't change the bytes read (TOCTOU defense). Blanket-skipping `file:` URIs on every free-text key would silently disable that. `url` is the one free-text key whose `file:` value the tool actually dereferences, so it keeps pinning; pure-prose keys never do.

## What this does NOT do

- Does not re-touch `channel_send`/`channel_reply`/`look_at` — #1227 already scopes those to `attachments[].path` and is the strongest contract for them. This generalizes the same idea to the rest of the prose surface.
- Does not weaken fail-closed behavior for undeclared operands on unknown keys (`value: "data.bin"` still throws).
- Does not add a new `fileOperands` opt-out API; it reuses the existing `private-surface-read` key knowledge so the two guards stop disagreeing.

## Review notes

Load-bearing change: the new `classifyFreeTextField(tool, key)` in `private-surface-read.ts` (returns `'opaque' | 'file-uri' | undefined`) and its two consult sites in `collectGenericFileTargets`. Verify the precedence: an `opaque` field short-circuits before the `file:` check; a `file-uri` field (`url`) does not.

Invariant to confirm still holds: the pre-existing "ambiguous system tools execute explicit file URLs against an immutable pinned copy" test still passes — a `file://` under `url` is pinned, so the symlink-swap defense is intact. New regression tests assert prose fields (`spawn_subagent.prompt`, `skip_response.reason`, `web_search.query`, `todo_write.todos[].content`) survive unchanged, `url`+`file:` still pins, and an unknown-key path-shaped operand still fails closed.
