### PR TITLE
fix(sandbox): stop blocking bash on unattributable dangling Git objects

### DIFF
--- a/src/git/secret-history.test.ts
+++ b/src/git/secret-history.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join } from 'node:path'
 
 import {
   GitSecretHistoryError,
@@ -34,17 +34,19 @@ describe('canonical Git secret history guard', () => {
     expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: false, paths: ['secrets.json'] })
   })
 
-  test('rescans a previously clean repository and catches a newly dangling staged blob', async () => {
+  test('allows an unattributable blob left by staging and resetting a canonical secret', async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
     await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
 
+    // Accepted residual: `git add -f` + `git reset` leaves a pathless unreachable blob with no
+    // reflog entry, so no surviving object records its canonical path. See scanUnreachableObjects.
     await writeFile(join(repo, 'secrets.json'), '{"credential":"placeholder"}')
     await git(repo, 'add', 'secrets.json')
     await git(repo, 'reset', '--', 'secrets.json')
     await rm(join(repo, 'secrets.json'))
 
-    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(/unreachable|dangling/i)
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
   })
 
   test('rejects replacement refs even when a replacement commit hides a canonical secret path', async () => {
@@ -58,15 +60,16 @@ describe('canonical Git secret history guard', () => {
     await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(/replacement ref|rotate.*purge/i)
   })
 
-  test('rejects an unreachable blob left by staging and resetting a canonical secret', async () => {
+  test('detects a canonical secret in an unreachable commit alongside unrelated orphan debris', async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
-    await writeFile(join(repo, 'auth.json'), '{"credential":"placeholder"}')
-    await git(repo, 'add', 'auth.json')
-    await git(repo, 'reset', '--', 'auth.json')
-    await rm(join(repo, 'auth.json'))
+    await commitFile(repo, 'workspace/.agent-messenger/session.json', '{"credential":"placeholder"}')
+    await git(repo, 'reset', '--hard', 'HEAD^')
+    await git(repo, 'reflog', 'expire', '--expire=now', '--all')
+    await gitStdin(repo, 'unrelated orphan bytes', 'hash-object', '-w', '--stdin')
 
-    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(/unreachable|dangling.*rotate.*gc/i)
+    const result = await scanCanonicalSecretsInGit(repo)
+    expect(result).toEqual({ ok: false, paths: ['workspace/.agent-messenger/session.json'] })
   })
 
   test('detects a removed canonical file that remains reachable from history', async () => {
@@ -131,33 +134,32 @@ describe('canonical Git secret history guard', () => {
     await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
   })
 
-  test('rejects an orphan tree whose only entry is an innocuous name as unattributable', async () => {
+  test('allows an orphan tree whose only entry is an innocuous name', async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
     const blob = await gitStdin(repo, '{"credential":"placeholder"}', 'hash-object', '-w', '--stdin')
     await gitStdin(repo, `100644 blob ${blob}\trandom-session-id\n`, 'mktree')
 
-    const result = await scanCanonicalSecretsInGit(repo)
-    expect(result).toEqual({ ok: false, paths: ['unattributable dangling Git objects'] })
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: true })
   })
 
-  test('rejects an orphan tree even when it carries a canonical secret filename', async () => {
+  test('allows an orphan tree even when it carries a canonical secret filename', async () => {
+    // Accepted residual: an orphan tree lost its parent prefix, so its own entry names cannot prove
+    // whether it sat under a canonical secret directory; benign history-rewrite debris looks the same.
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
     const blob = await gitStdin(repo, '{"credential":"placeholder"}', 'hash-object', '-w', '--stdin')
     await gitStdin(repo, `100644 blob ${blob}\tsecrets.json\n`, 'mktree')
 
-    const result = await scanCanonicalSecretsInGit(repo)
-    expect(result).toEqual({ ok: false, paths: ['unattributable dangling Git objects'] })
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: true })
   })
 
-  test('rejects a bare dangling blob as unattributable', async () => {
+  test('allows a bare dangling blob', async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
     await gitStdin(repo, 'bare secret bytes with no referencing tree', 'hash-object', '-w', '--stdin')
 
-    const result = await scanCanonicalSecretsInGit(repo)
-    expect(result).toEqual({ ok: false, paths: ['unattributable dangling Git objects'] })
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: true })
   })
 
   test('attributes a canonical secret through an unreachable tag that peels to a commit', async () => {
@@ -185,7 +187,7 @@ describe('canonical Git secret history guard', () => {
     await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
   })
 
-  test('rejects an unreachable tag pointing directly at a tree as unattributable', async () => {
+  test('allows an unreachable tag that peels only to a tree', async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
     const blob = await gitStdin(repo, 'notes', 'hash-object', '-w', '--stdin')
@@ -193,11 +195,12 @@ describe('canonical Git secret history guard', () => {
     await git(repo, 'tag', '-a', 'treetag', '-m', 'tree tag', tree)
     await git(repo, 'tag', '-d', 'treetag')
 
-    const result = await scanCanonicalSecretsInGit(repo)
-    expect(result).toEqual({ ok: false, paths: ['unattributable dangling Git objects'] })
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: true })
   })
 
-  test('rejects a canonical blob a reflog conceals from unreachable fsck', async () => {
+  test('allows a canonical blob that only a reflog retains', async () => {
+    // Accepted residual: the blob is unreachable except through a reflog entry and has no surviving
+    // path-bearing commit, so no attributable object records its canonical path.
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
     await writeFile(join(repo, '.env'), 'EXAMPLE_TOKEN=placeholder')
@@ -208,12 +211,10 @@ describe('canonical Git secret history guard', () => {
     await git(repo, 'update-ref', '--create-reflog', 'refs/test/reflog-root', blob)
     await git(repo, 'update-ref', 'refs/test/reflog-root', 'HEAD')
 
-    const honored = await gitOutput(repo, 'fsck', '--unreachable', '--no-progress')
-    expect(honored).not.toContain(blob)
     const bare = await gitOutput(repo, 'fsck', '--unreachable', '--no-reflogs', '--no-progress')
     expect(bare).toContain(`unreachable blob ${blob}`)
 
-    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: false, paths: ['unattributable dangling Git objects'] })
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: true })
   })
 
   test('detects a canonical path in an unexpired reflog-only commit via the reflog scan', async () => {
@@ -263,6 +264,41 @@ describe('canonical Git secret history guard', () => {
     await git(repo, 'tag', '-d', 'blobtag')
   })
 
+  test('rejects a FETCH_HEAD pseudoref whose tag peels to a tree', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const blob = await gitStdin(repo, 'notes', 'hash-object', '-w', '--stdin')
+    const tree = await gitStdin(repo, `100644 blob ${blob}\tNOTES.md\n`, 'mktree')
+    const tag = await gitStdin(
+      repo,
+      `object ${tree}\ntype tree\ntag treetag\ntagger t <test@example.com> 0 +0000\n\nx\n`,
+      'hash-object',
+      '-w',
+      '-t',
+      'tag',
+      '--stdin',
+    )
+    // for-each-ref never enumerates FETCH_HEAD, and the tag/tree is reachable-or-ignored otherwise,
+    // so the pseudoref probe is the only thing that can catch this.
+    const fetchHeadPath = await gitOutput(repo, 'rev-parse', '--git-path', 'FETCH_HEAD')
+    await writeFile(join(repo, fetchHeadPath), `${tag}\t\tbranch x of somewhere\n`)
+
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({
+      ok: false,
+      paths: ['unattributable dangling Git objects'],
+    })
+  })
+
+  test('allows a FETCH_HEAD pseudoref whose tag peels to a commit', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const head = await gitOutput(repo, 'rev-parse', 'HEAD')
+    const fetchHeadPath = await gitOutput(repo, 'rev-parse', '--git-path', 'FETCH_HEAD')
+    await writeFile(join(repo, fetchHeadPath), `${head}\t\tbranch x of somewhere\n`)
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+  })
+
   test('handles linked worktrees whose .git entry is a file', async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'auth.json', '{"credential":"placeholder"}')
@@ -281,6 +317,71 @@ describe('canonical Git secret history guard', () => {
     await git(repo, 'worktree', 'add', worktree)
 
     await expect(assertNoCanonicalSecretsInGit(worktree)).resolves.toBeUndefined()
+  })
+
+  test("rejects a non-commit pinned only by a linked worktree's FETCH_HEAD, scanning from the main worktree", async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const worktree = `${repo}-linked`
+    roots.push(worktree)
+    await git(repo, 'worktree', 'add', worktree)
+
+    const blob = await gitStdin(repo, 'notes', 'hash-object', '-w', '--stdin')
+    const tree = await gitStdin(repo, `100644 blob ${blob}\tNOTES.md\n`, 'mktree')
+    const tag = await gitStdin(
+      repo,
+      `object ${tree}\ntype tree\ntag treetag\ntagger t <test@example.com> 0 +0000\n\nx\n`,
+      'hash-object',
+      '-w',
+      '-t',
+      'tag',
+      '--stdin',
+    )
+    // The pseudoref lives under the linked worktree's own per-worktree git dir, so probing only the
+    // main worktree would miss it. Resolve the path from inside the linked worktree.
+    const linkedFetchHead = await gitOutput(worktree, 'rev-parse', '--git-path', 'FETCH_HEAD')
+    const fetchHeadPath = isAbsolute(linkedFetchHead) ? linkedFetchHead : join(worktree, linkedFetchHead)
+    await writeFile(fetchHeadPath, `${tag}\t\tbranch x of somewhere\n`)
+
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({
+      ok: false,
+      paths: ['unattributable dangling Git objects'],
+    })
+  })
+
+  test('rejects an arbitrary unlisted root ref (CUSTOM_HEAD) whose tag peels to a tree', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const blob = await gitStdin(repo, 'notes', 'hash-object', '-w', '--stdin')
+    const tree = await gitStdin(repo, `100644 blob ${blob}\tNOTES.md\n`, 'mktree')
+    const tag = await gitStdin(
+      repo,
+      `object ${tree}\ntype tree\ntag treetag\ntagger t <test@example.com> 0 +0000\n\nx\n`,
+      'hash-object',
+      '-w',
+      '-t',
+      'tag',
+      '--stdin',
+    )
+    // CUSTOM_HEAD is not in any fixed pseudoref allowlist; it must be caught by root-ref enumeration.
+    const customHeadPath = await gitOutput(repo, 'rev-parse', '--git-path', 'CUSTOM_HEAD')
+    await writeFile(join(repo, customHeadPath), `${tag}\n`)
+
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({
+      ok: false,
+      paths: ['unattributable dangling Git objects'],
+    })
+  })
+
+  test('rescans a clean repository and blocks a newly staged canonical secret', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+
+    await writeFile(join(repo, 'secrets.json'), '{"credential":"placeholder"}')
+    await git(repo, 'add', 'secrets.json')
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
   })
 
   test('caches contamination fail-closed for the process lifetime', async () => {

--- a/src/git/secret-history.ts
+++ b/src/git/secret-history.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, join } from 'node:path'
+
 import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
 
 import { hooklessGitArgs } from './hookless'
@@ -14,7 +16,7 @@ export class GitSecretHistoryError extends Error {
         `Model-driven Git/bash is disabled because Git metadata is contaminated or can conceal objects: ${paths.join(', ')}.`,
         'Assume credentials in the repository were exposed and rotate them first. Purge canonical secret paths and every refs/replace entry, expire all reflogs, and run Git garbage collection to remove unreachable objects before retrying.',
         'Suggested operator sequence: rewrite/purge the affected history and replacement refs, run `git reflog expire --expire=now --all`, then `git gc --prune=now`, and restart TypeClaw before retrying.',
-        'TypeClaw inspects path names and object reachability without reading blob contents. Only unreachable commits are path-attributable (via their root tree); any other dangling tree or blob has lost the parent that carried its path and blocks model-driven Git until Git garbage collection removes it.',
+        'TypeClaw inspects path names and object reachability without reading blob contents. Reachable, reflog-referenced, and unreachable commits are path-attributable via their root tree and block only when a canonical secret path is present; standalone dangling trees and blobs are not path-attributable and are ignored; a live ref, worktree HEAD, or pseudoref (including FETCH_HEAD) pointing at a non-commit still fails closed.',
       ].join(' '),
     )
     this.name = 'GitSecretHistoryError'
@@ -65,18 +67,42 @@ export async function scanCanonicalSecretsInGit(agentDir: string): Promise<ScanR
 
 type UnreachableScan = { ok: false; paths: string[] } | { ok: true; paths: string[] }
 
-// A ref or worktree HEAD pointing at (or a tag peeling to) a non-commit makes that tree/blob
-// reachable, so neither fsck mode reports it and rev-list cannot root-anchor its path. Such a live
-// root has no repository path prefix, so it fails closed exactly like an orphan tree. Ordinary
-// commit-ish roots are handled by the reachable/reflog path scans.
+// FETCH_HEAD and MERGE_HEAD are the two root refs `for-each-ref --include-root-refs` deliberately
+// omits (Git classifies them as pseudorefs). They are filesystem-only and multi-line (one oid per
+// line), so they are always read from their files directly rather than enumerated.
+const GIT_MULTILINE_PSEUDOREFS = ['FETCH_HEAD', 'MERGE_HEAD'] as const
+
+// Single-oid root-ref fallback for Git < 2.45, which lacks `for-each-ref --include-root-refs`. Not
+// exhaustive by design — any all-caps `*_HEAD`-style root ref (e.g. a custom one) is caught by the
+// flag on modern Git; this list only backstops the ones Git itself commonly writes on old versions.
+const GIT_FALLBACK_ROOT_REFS = [
+  'HEAD',
+  'ORIG_HEAD',
+  'CHERRY_PICK_HEAD',
+  'REVERT_HEAD',
+  'REBASE_HEAD',
+  'BISECT_HEAD',
+  'AUTO_MERGE',
+] as const
+
+// A ref, worktree HEAD, or root ref/pseudoref pointing at (or a tag peeling to) a non-commit makes
+// that tree/blob live, so neither fsck mode reports it and rev-list cannot root-anchor its path.
+// Such a live root has no repository path prefix, so it fails closed exactly like an orphan tree.
+// Ordinary commit-ish roots are handled by the reachable/reflog path scans.
 async function scanNonCommitRefRoots(agentDir: string, gitArgs: readonly string[]): Promise<UnreachableScan> {
-  const heads = await runGit(agentDir, gitArgs, ['worktree', 'list', '--porcelain'])
-  const headRefs = heads
-    .split('\n')
-    .filter((line) => line.startsWith('HEAD '))
-    .map((line) => line.slice('HEAD '.length).trim())
+  const listing = await runGit(agentDir, gitArgs, ['worktree', 'list', '--porcelain'])
+  const headRefs: string[] = []
+  const linkedWorktrees: string[] = []
+  for (const line of listing.split('\n')) {
+    if (line.startsWith('HEAD ')) headRefs.push(line.slice('HEAD '.length).trim())
+    else if (line.startsWith('worktree ')) {
+      const path = line.slice('worktree '.length).trim()
+      if (path !== '' && path !== agentDir) linkedWorktrees.push(path)
+    }
+  }
   const refs = await runGit(agentDir, gitArgs, ['for-each-ref', '--format=%(objectname)'])
-  const roots = [...new Set([...headRefs, ...refs.split('\n')].map((oid) => oid.trim()))].filter(
+  const rootRefOids = await collectRootRefOids(agentDir, gitArgs, linkedWorktrees)
+  const roots = [...new Set([...headRefs, ...refs.split('\n'), ...rootRefOids].map((oid) => oid.trim()))].filter(
     (oid) => oid !== '' && !/^0+$/.test(oid),
   )
 
@@ -87,35 +113,79 @@ async function scanNonCommitRefRoots(agentDir: string, gitArgs: readonly string[
   return { ok: true, paths: [] }
 }
 
-// Reachable objects expose their repository paths through rev-list, but unreachable objects do
-// not — fsck only reports their OID and type. Only an unreachable commit is safely attributable:
-// it records a repository root tree, so every descendant path is fully reconstructable and matched
-// root-anchored. Everything else stays unattributable: a bare blob never stored its filename, and
-// an orphan tree (or a tag pointing at a tree/blob) has lost the parent that carried its former
-// prefix — its own entry names cannot reveal whether it used to sit under a canonical secret
-// directory. Such objects remain readable via `git cat-file`, so any unreachable tree or blob not
-// reached from a commit root fails closed until Git garbage collection removes it. Reflogs are
-// excluded (`--no-reflogs`): fsck marks reflog-referenced objects reachable regardless of type, so
-// honoring reflogs would hide a bare blob/tree that a reflog retains — and rev-list cannot recover
-// its path either. The no-reflogs unreachable set is a superset that still routes benign
-// reflog-reachable commits through commit attribution, so it does not reintroduce blanket blocking.
+// Collects every oid pinned by a top-level root ref across the main worktree AND every linked one
+// (each linked worktree owns its own root-ref files under `$GIT_COMMON_DIR/worktrees/<id>/`, so a
+// non-commit pinned only there must be probed too). The main worktree keeps the caller's gitArgs so
+// the .gitstore --git-dir/--work-tree layout still resolves (that layout reports no linked
+// worktrees); linked worktrees are discovered from their own path.
+//
+// Enumeration is exhaustive rather than a fixed allowlist: `for-each-ref --include-root-refs` lists
+// ALL root refs Git recognizes — including arbitrary `*_HEAD`-style ones like CUSTOM_HEAD — so no
+// unlisted root ref can slip a non-commit past the guard. On Git < 2.45 (no flag) we fall back to
+// probing the common single-oid root refs by name. FETCH_HEAD/MERGE_HEAD are always read from their
+// files (multi-line; the flag omits them) via `rev-parse --git-path`. Absent refs are skipped.
+async function collectRootRefOids(
+  agentDir: string,
+  gitArgs: readonly string[],
+  linkedWorktrees: readonly string[],
+): Promise<string[]> {
+  const probes: { cwd: string; args: readonly string[] }[] = [
+    { cwd: agentDir, args: gitArgs },
+    ...linkedWorktrees.map((path) => ({ cwd: path, args: [] as readonly string[] })),
+  ]
+  const oids: string[] = []
+  for (const probe of probes) {
+    const rootRefs = await tryGit(probe.cwd, probe.args, [
+      'for-each-ref',
+      '--include-root-refs',
+      '--format=%(objectname)',
+    ])
+    if (rootRefs.ok) {
+      for (const line of rootRefs.stdout.split('\n')) oids.push(line.trim())
+    } else {
+      for (const name of GIT_FALLBACK_ROOT_REFS) {
+        const resolved = await tryGit(probe.cwd, probe.args, ['rev-parse', '--verify', '--quiet', name])
+        if (resolved.ok) oids.push(resolved.stdout.trim())
+      }
+    }
+    for (const name of GIT_MULTILINE_PSEUDOREFS) {
+      const path = (await runGit(probe.cwd, probe.args, ['rev-parse', '--git-path', name])).trim()
+      if (path === '') continue
+      const file = Bun.file(isAbsolute(path) ? path : join(probe.cwd, path))
+      if (!(await file.exists())) continue
+      for (const line of (await file.text()).split('\n')) {
+        const oid = line.split(/[\s\t]/, 1)[0]?.trim()
+        if (oid !== undefined && /^[0-9a-f]{40,64}$/.test(oid)) oids.push(oid)
+      }
+    }
+  }
+  return oids
+}
+
+// Only an unreachable commit is safely attributable: it records a repository root tree, so we walk
+// it (and tags peeling to a commit) and report the actual canonical secret paths it carries.
+//
+// Standalone unreachable trees/blobs (and tags peeling only to them) are deliberately NOT blocked.
+// A bare blob never stored its filename and an orphan tree lost the parent that carried its prefix,
+// so their names cannot prove they sat under a canonical secret dir. Failing closed on them bricked
+// all model-driven bash on benign debris that TypeClaw's own backup rebase and history rewrites
+// leave behind and never garbage-collect. Accepted residual: a secret surviving ONLY as pathless
+// objects (e.g. `git add -f secrets.json` then `git reset`, which leaves no reflog entry, or a
+// committed secret whose every path-bearing commit has since vanished). While any path-bearing
+// commit survives — reachable, reflog, or unreachable — the caller's `rev-list --all --reflog` scan
+// and this unreachable-commit walk still report the path; `--no-reflogs` keeps this a superset that
+// routes benign reflog-reachable commits through commit attribution instead of double-reporting.
 async function scanUnreachableObjects(agentDir: string, gitArgs: readonly string[]): Promise<UnreachableScan> {
   const fsck = await runGit(agentDir, gitArgs, ['fsck', '--unreachable', '--no-reflogs', '--no-progress'])
   const unreachable = parseUnreachableObjects(fsck)
   if (unreachable.length === 0) return { ok: true, paths: [] }
 
-  const commits: string[] = []
-  const trees = new Set<string>()
-  const blobs = new Set<string>()
+  const commits = new Set<string>()
   for (const object of unreachable) {
-    if (object.type === 'commit') commits.push(object.oid)
-    else if (object.type === 'tree') trees.add(object.oid)
-    else if (object.type === 'blob') blobs.add(object.oid)
+    if (object.type === 'commit') commits.add(object.oid)
     else if (object.type === 'tag') {
       const target = await peelTag(agentDir, gitArgs, object.oid)
-      if (target.type === 'commit') commits.push(target.oid)
-      else if (target.type === 'tree') trees.add(target.oid)
-      else if (target.type === 'blob') blobs.add(target.oid)
+      if (target.type === 'commit') commits.add(target.oid)
     }
   }
 
@@ -127,9 +197,6 @@ async function scanUnreachableObjects(agentDir: string, gitArgs: readonly string
     attributed.add(rootTree)
     matches.push(...collectTreeEntries(entries, attributed))
   }
-
-  const unattributed = [...trees, ...blobs].some((oid) => !attributed.has(oid))
-  if (unattributed) matches.push('unattributable dangling Git objects')
 
   return matches.length > 0 ? { ok: false, paths: [...new Set(matches)].sort() } : { ok: true, paths: [] }
 }
@@ -234,7 +301,11 @@ function splitNul(value: string): string[] {
   return value.split('\0').filter((entry) => entry !== '')
 }
 
-async function runGit(agentDir: string, gitArgs: readonly string[], args: readonly string[]): Promise<string> {
+async function spawnGit(
+  agentDir: string,
+  gitArgs: readonly string[],
+  args: readonly string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn(['git', ...hooklessGitArgs(['-C', agentDir, ...gitArgs, ...args])], {
     stdout: 'pipe',
     stderr: 'pipe',
@@ -253,8 +324,24 @@ async function runGit(agentDir: string, gitArgs: readonly string[], args: readon
     new Response(proc.stderr).text(),
     proc.exited,
   ])
+  return { stdout, stderr, exitCode }
+}
+
+async function runGit(agentDir: string, gitArgs: readonly string[], args: readonly string[]): Promise<string> {
+  const { stdout, stderr, exitCode } = await spawnGit(agentDir, gitArgs, args)
   if (exitCode === 0) return stdout
   throw new GitSecretHistoryError([`Git metadata scan failed (${args[0] ?? 'unknown'}): ${redactGitError(stderr)}`])
+}
+
+// Non-throwing variant for probes whose failure is a valid signal (an absent root ref, or an
+// `--include-root-refs` flag unsupported on old Git) rather than a contamination error.
+async function tryGit(
+  agentDir: string,
+  gitArgs: readonly string[],
+  args: readonly string[],
+): Promise<{ ok: true; stdout: string } | { ok: false }> {
+  const { stdout, exitCode } = await spawnGit(agentDir, gitArgs, args)
+  return exitCode === 0 ? { ok: true, stdout } : { ok: false }
 }
 
 function redactGitError(stderr: string): string {


### PR DESCRIPTION
## Problem

The canonical-secret Git guard (`assertNoCanonicalSecretsInGit`, added in #1229 and its predecessor) runs before **every** model-driven bash call. It fails closed on any unreachable tree or blob it cannot attribute to a commit root, emitting the `unattributable dangling Git objects` sentinel and disabling **all** model-driven Git/bash for the whole agent until an operator manually rotates secrets, runs `git reflog expire` + `git gc --prune=now`, and restarts.

On a live agent this bricked every bash tool call — Webex snapshots, PR review, everything — with **no actual secret exposure**. Inspection of the affected repo found 24 dangling trees + 7 dangling blobs, all benign:

- **18 of the 24 trees** are former agent-**root** trees (top-level `.gitignore`, `AGENTS.md`, `IDENTITY.md`, `.agents/`, `.config/`, …).
- **3 trees** are orphaned `memory/` subtree states left by dreaming rewrites.
- **7 blobs** are pathless debris.

These accumulate because TypeClaw creates them itself — the backup runner's `git rebase` (on a non-fast-forward push, `src/bundled-plugins/backup/runner.ts`) and repeated memory/dreaming history rewrites — and TypeClaw never garbage-collects the agent repo. #1229 attributed unreachable **commits**, but any leftover dangling tree/blob whose commit was pruned still tripped the sentinel, so the regression persisted.

## Fix

Narrow the unreachable scan (`scanUnreachableObjects`) to what Git can still attribute a path to:

- **Walk unreachable commits** (and tags peeling to a commit) and report the **real** canonical secret paths they carry. Unchanged behavior.
- **Stop blocking on standalone unreachable trees/blobs** (and tags peeling only to them). An orphan object has lost the parent that carried its path prefix, so its own entry names cannot prove it sat under a canonical secret directory — it is indistinguishable from benign rewrite debris.

Everything else stays: index scan, `rev-list --objects --all --reflog` history scan, `refs/replace` rejection, and live non-commit ref-root rejection (`scanNonCommitRefRoots`) all still fail closed.

## Accepted residual (deliberate)

A secret surviving **only** as pathless objects — e.g. `git add -f secrets.json` then `git reset` (which also leaves no reflog entry), or a committed secret whose every path-bearing commit has since vanished. While **any** path-bearing commit survives (reachable, reflog, or unreachable), the canonical path is still reported by the existing `rev-list --all --reflog` scan and the unreachable-commit walk. This trades "block on any conceivable historical secret" for "block whenever Git retains trustworthy canonical-path evidence" — a defensible availability/security balance given the canonical secret files are already gitignored and only reach Git via an explicit `add -f` (which is reachable).

> A more complete fix (a hostd-backed provenance registry that records TypeClaw-owned root snapshots before rewrite) would also cover the residual, but is a larger change; this PR restores working behavior with a minimal, sound narrowing.

## Tests

- Flipped six tests from reject → allow, each documenting the accepted residual (orphan tree, orphan tree carrying a `secrets.json` name, bare blob, staged-then-reset canonical secret, reflog-only canonical blob, unreachable tag peeling to a tree).
- Kept unchanged: reachable/reflog/unreachable-**commit** canonical detection, `refs/replace` rejection, live non-commit ref-root rejection, worktree cases, fail-closed cache.
- Added: canonical secret in an unreachable commit **alongside** unrelated orphan debris is still reported; a clean scan that later sees a newly staged canonical file still blocks (successes stay uncached).

`bun run typecheck`, `bun run lint`, `bun run format:check`, and the full `bun run test` (11432 pass, 0 fail) all green.