### PR TITLE
fix(sandbox): stop blocking bash on a root ref left dangling by gc

### DIFF
--- a/src/git/secret-history.test.ts
+++ b/src/git/secret-history.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { appendFile, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, isAbsolute, join } from 'node:path'
+import { delimiter, dirname, isAbsolute, join } from 'node:path'
+
+import { isWindows } from '@/shared'
 
 import {
   GitSecretHistoryError,
@@ -299,6 +301,35 @@ describe('canonical Git secret history guard', () => {
     await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
   })
 
+  test('allows an ORIG_HEAD left dangling by garbage collection', async () => {
+    // Real-world regression: `git gc --prune=now` deletes the object a reset/rebase left in
+    // ORIG_HEAD but never rewrites the pseudoref, so ORIG_HEAD points at an object that is now
+    // absent from the object DB. peeling it (`rev-parse <gone>^{}`) exits non-zero — the object
+    // is gone, so it cannot conceal a secret and must not fail the whole scan closed.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await commitFile(repo, 'docs/guide.md', 'more safe content')
+    await git(repo, 'reset', '--hard', 'HEAD^')
+    const origHead = await gitOutput(repo, 'rev-parse', 'ORIG_HEAD')
+    await git(repo, 'reflog', 'expire', '--expire=now', '--all')
+    await git(repo, 'gc', '--prune=now')
+
+    await expect(gitOutput(repo, 'cat-file', '-t', origHead)).rejects.toThrow()
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+  })
+
+  test('allows a single-oid root ref that points at a missing object', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    // A nonzero absent oid: the all-zero oid is filtered before the object probe, so it would not
+    // exercise the missing-object path.
+    const missing = '1'.repeat(40)
+    const origHeadPath = await gitOutput(repo, 'rev-parse', '--git-path', 'ORIG_HEAD')
+    await writeFile(join(repo, origHeadPath), `${missing}\n`)
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+  })
+
   test('handles linked worktrees whose .git entry is a file', async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'auth.json', '{"credential":"placeholder"}')
@@ -395,7 +426,64 @@ describe('canonical Git secret history guard', () => {
 
     await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
   })
+
+  // Skipped on Windows: the old-Git emulation relies on a POSIX `/bin/sh` shim shadowing `git`.
+  test.skipIf(isWindows())('denies every transport so a promisor probe never reaches the network', async () => {
+    // Emulate unpatched Git <2.45 (silently ignores GIT_NO_LAZY_FETCH) with a `git` shim on PATH
+    // that strips the var and routes GIT_TRACE to a file before exec'ing the real git. Probing the
+    // missing ORIG_HEAD object on this promisor-configured repo would lazy-fetch the remote; the
+    // scan's GIT_ALLOW_PROTOCOL='' fence must deny the `file` transport so `git upload-pack` against
+    // the remote never runs. The trace is the observable proof the network stayed untouched.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+
+    const promisor = join(repo, 'promisor.git')
+    roots.push(promisor)
+    await git(repo, 'init', '--bare', promisor)
+    await appendFile(
+      join(repo, '.git', 'config'),
+      `[extensions]\n\tpartialClone = origin\n[remote "origin"]\n\turl = file://${promisor}\n\tpromisor = true\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`,
+    )
+    const missing = '1'.repeat(40)
+    const origHeadPath = await gitOutput(repo, 'rev-parse', '--git-path', 'ORIG_HEAD')
+    await writeFile(join(repo, origHeadPath), `${missing}\n`)
+
+    // Resolve the real git absolutely: the shim shadows `git` on PATH, so it must exec the real
+    // binary by full path or it would re-invoke itself forever.
+    const realGit = await resolveGitBinary()
+    const shimDir = await mkdtemp(join(tmpdir(), 'typeclaw-git-shim-'))
+    roots.push(shimDir)
+    const trace = join(shimDir, 'git-trace.log')
+    const shim = join(shimDir, 'git')
+    await writeFile(
+      shim,
+      `#!/bin/sh\nunset GIT_NO_LAZY_FETCH\nexport GIT_TRACE=${JSON.stringify(trace)}\nexec ${realGit} "$@"\n`,
+    )
+    await chmod(shim, 0o755)
+
+    const originalPath = process.env.PATH
+    process.env.PATH = `${shimDir}${delimiter}${originalPath ?? ''}`
+    try {
+      await assertNoCanonicalSecretsInGit(repo).catch(() => undefined)
+    } finally {
+      process.env.PATH = originalPath
+    }
+
+    const traceLog = (await Bun.file(trace).exists()) ? await Bun.file(trace).text() : ''
+    // The lazy fetch is attempted (proves the promisor path is exercised) but the transport fence
+    // denies it before `git upload-pack` ever contacts the remote. Without GIT_ALLOW_PROTOCOL=''
+    // this same trace contains upload-pack.
+    expect(traceLog).toContain('fetch origin')
+    expect(traceLog).not.toContain('upload-pack')
+  })
 })
+
+async function resolveGitBinary(): Promise<string> {
+  const proc = Bun.spawn(['sh', '-c', 'command -v git'], { stdout: 'pipe', stderr: 'pipe' })
+  const stdout = await new Response(proc.stdout).text()
+  if ((await proc.exited) !== 0) throw new Error('git binary not found')
+  return stdout.trim()
+}
 
 async function makeRepo(): Promise<string> {
   const repo = await mkdtemp(join(tmpdir(), 'typeclaw-git-secret-history-'))

--- a/src/git/secret-history.ts
+++ b/src/git/secret-history.ts
@@ -107,6 +107,11 @@ async function scanNonCommitRefRoots(agentDir: string, gitArgs: readonly string[
   )
 
   for (const root of roots) {
+    // A pruning `git gc` deletes the object a reset/rebase left in a pseudoref (ORIG_HEAD, etc.) but
+    // never rewrites the ref, so it dangles at an oid that is now absent from the object DB. A gone
+    // object cannot conceal a secret, so skip it rather than failing the whole scan closed on the
+    // peel error. Only a root whose object still EXISTS and is a non-commit remains blocking.
+    if (!(await objectExists(agentDir, gitArgs, root))) continue
     const target = await peelTag(agentDir, gitArgs, root)
     if (target.type !== 'commit') return { ok: false, paths: ['unattributable dangling Git objects'] }
   }
@@ -199,6 +204,16 @@ async function scanUnreachableObjects(agentDir: string, gitArgs: readonly string
   }
 
   return matches.length > 0 ? { ok: false, paths: [...new Set(matches)].sort() } : { ok: true, paths: [] }
+}
+
+// `cat-file -e` exits 0 when the object is present and exactly 1 when it is absent. Any other exit
+// code is an operational Git error (corruption, bad invocation), which must fail closed like every
+// other scan step rather than being misread as a benign "object gone".
+async function objectExists(agentDir: string, gitArgs: readonly string[], oid: string): Promise<boolean> {
+  const { exitCode, stderr } = await spawnGit(agentDir, gitArgs, ['cat-file', '-e', oid])
+  if (exitCode === 0) return true
+  if (exitCode === 1) return false
+  throw new GitSecretHistoryError([`Git metadata scan failed (cat-file): ${redactGitError(stderr)}`])
 }
 
 type PeeledTag = { type: 'commit' | 'tree' | 'blob' | 'unknown'; oid: string }
@@ -317,6 +332,12 @@ async function spawnGit(
       GIT_CONFIG_GLOBAL: '/dev/null',
       GIT_CONFIG_SYSTEM: '/dev/null',
       GIT_NO_REPLACE_OBJECTS: '1',
+      // Keep the scan strictly local. GIT_NO_LAZY_FETCH stops a promisor/partial-clone fetch on
+      // Git >=2.45 (and backported maints), but is silently ignored on older Git; the empty
+      // GIT_ALLOW_PROTOCOL whitelist (a since-2.20 control) denies every transport, so even the
+      // internal lazy `git fetch` those versions still attempt fails closed before touching a remote.
+      GIT_NO_LAZY_FETCH: '1',
+      GIT_ALLOW_PROTOCOL: '',
     },
   })
   const [stdout, stderr, exitCode] = await Promise.all([


### PR DESCRIPTION
## Background

On a live agent, the canonical-secret Git guard (`src/git/secret-history.ts`) disabled **all** model-driven bash — PR review, channel snapshots, everything — and kept doing so even after the operator ran the exact `git gc --prune=now` the error message tells them to run. The bot repeated the same refusal every turn ("the integrity scan blocks on unreachable Git object `909aefd…^{}`; purge history, expire reflogs, run gc, restart").

Root cause is a stale pseudoref, not a real secret. A reset/rebase writes the previous tip into `.git/ORIG_HEAD`; a later pruning `git gc` **deletes that object but never rewrites `ORIG_HEAD`**, leaving it dangling at an oid now absent from the object DB. `scanNonCommitRefRoots` enumerates that oid (via `for-each-ref --include-root-refs`, which on Git ≥ 2.45 lists `ORIG_HEAD`) and peels it with `git rev-parse <gone>^{}`. That exits non-zero, `runGit` throws `GitSecretHistoryError`, and the **entire** scan fails closed. `git gc` is what *creates* the dangling ref, so the suggested operator sequence can't fix it — only a full history rewrite of `ORIG_HEAD` would, which no operator does.

## Summary

Probe `git cat-file -e <oid>` before peeling each root ref, and skip a root whose object is **absent** instead of failing the whole scan closed on the peel error. This is the same benign-history-rewrite-debris class the unreachable tree/blob fixes (#1229, #1231) already carved out: a gone object has no content and no tree, so it cannot conceal a canonical secret path.

**Why only exit code 1 counts as "absent":** `cat-file -e` exits `0` for present, exactly `1` for a valid-but-missing oid, and `128` for operational errors (corruption, bad invocation). Collapsing every non-zero into "absent" would let a corrupt object read as benign — so any exit code other than `0`/`1` still throws and fails closed, like every other scan step.

**Why `GIT_NO_LAZY_FETCH=1`:** `cat-file -e` on a partial clone can trigger a promisor network fetch. The scan is a point-in-time local check; it must never reach out to a remote. The env is added to the shared `spawnGit` so the whole scan is fetch-free.

## What this does NOT do

- **Does not weaken the non-commit invariant.** A root ref/HEAD/pseudoref whose object still **exists** and is a non-commit (tree/blob, or a tag peeling to one) still fails closed — the existence probe returns `true` and control falls through to the unchanged `peelTag` check. Only genuinely-missing objects are skipped.
- **Does not touch the reachable / reflog / unreachable-commit path scans** that attribute real canonical secrets by their root tree.
- **Does not add per-agent state or clear the in-memory `contaminatedCache`.** The cache still fail-closes for the process lifetime; this fixes the *scan* so a clean repo is no longer misclassified in the first place.

## Review notes

- Load-bearing change is the single `if (!(await objectExists(...))) continue` guard in `scanNonCommitRefRoots`, plus the exit-code-1-only semantics of `objectExists`. Verify: an **existing** non-commit root still returns `{ ok: false, paths: ['unattributable dangling Git objects'] }` (existing tests at `secret-history.test.ts:241-374` cover live refs, FETCH_HEAD, linked worktrees, and CUSTOM_HEAD).
- New regression test reproduces the production failure with a real `git reset --hard HEAD^` → `reflog expire` → `git gc --prune=now`, asserting `ORIG_HEAD` now dangles (`cat-file -t` rejects) and the scan passes.
- The all-zero oid is filtered before the probe, so the second test uses a nonzero absent oid (`'1'.repeat(40)`) to actually exercise `objectExists`.
- Full suite green: 11438 pass / 0 fail; typecheck, lint (0 errors), format:check clean.