### PR TITLE
fix(compose): use rmTempDir helper to end Windows flaky teardown

### DIFF
--- a/src/compose/discover.test.ts
+++ b/src/compose/discover.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { discoverAgents } from './discover'
 
@@ -12,7 +14,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(root, { recursive: true, force: true })
+  await rmTempDir(root)
 })
 
 async function makeAgent(parent: string, name: string, config: Record<string, unknown> = {}): Promise<string> {

--- a/src/compose/restart.test.ts
+++ b/src/compose/restart.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { composeRestart, type ComposeRestartEvent } from './restart'
 
@@ -12,7 +14,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(root, { recursive: true, force: true })
+  await rmTempDir(root)
 })
 
 // Malformed JSON so validateConfig short-circuits before real Docker calls;

--- a/src/compose/start.test.ts
+++ b/src/compose/start.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { composeStart, type ComposeStartEvent } from './start'
 
@@ -12,7 +14,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(root, { recursive: true, force: true })
+  await rmTempDir(root)
 })
 
 // validateConfig rejects malformed JSON before any Docker call, which is

--- a/src/compose/stop.test.ts
+++ b/src/compose/stop.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { composeStop, type ComposeStopEvent } from './stop'
 
@@ -12,7 +14,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(root, { recursive: true, force: true })
+  await rmTempDir(root)
 })
 
 // Malformed JSON so validateConfig short-circuits before real Docker calls;

--- a/src/compose/usage.test.ts
+++ b/src/compose/usage.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { composeUsage } from './usage'
 
@@ -12,7 +14,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(root, { recursive: true, force: true })
+  await rmTempDir(root)
 })
 
 async function makeAgent(name: string): Promise<string> {


### PR DESCRIPTION
## Background

The Windows CI leg flakes intermittently in the compose test suites. A recent run failed at `src/compose/stop.test.ts:15` — the `afterEach` teardown, not any assertion:

```
at async <anonymous> (D:\a\typeclaw\typeclaw\src\compose\stop.test.ts:15:9)
```

Root cause: all five compose test files tore down their `mkdtemp` scratch dir with a raw `rm(root, { recursive: true, force: true })`. On Windows, a just-exited child process (the compose suites spawn/mock Docker controller calls) or a sibling Bun test worker can still hold an open handle on a file inside the temp dir when `afterEach` runs. `rm` then throws `EBUSY` / `EPERM` / `ENOTEMPTY`. The `force: true` flag only suppresses `ENOENT` — it does nothing for a pinned-handle race — so the teardown surfaces as a hard test failure. POSIX unlinks an open file happily, which is why this only ever bites the Windows job.

## Summary

The repo already has the exact fix as a shared helper: `src/test-helpers/rm-temp-dir.ts` (`rmTempDir`). It forces a GC to run finalizers that release lingering handles (notably the `bun:sqlite` handle from Bun #25964) and retries with a short backoff on the Windows-transient codes (`EBUSY`/`EPERM`/`ENOTEMPTY`). It's already used across the `run/`, `cli/`, and `memory/` suites.

This PR simply routes the five compose suites through that helper instead of the raw `rm`:

- `src/compose/stop.test.ts` — the one that flaked
- `src/compose/start.test.ts`, `restart.test.ts`, `discover.test.ts`, `usage.test.ts` — same anti-pattern, fixed together so the flake can't just resurface under a different filename

Why fix all five rather than only `stop`: they are byte-identical teardowns in the same module. Fixing one and leaving four is a half-fix that reappears on the next unlucky Windows run.

## What this does NOT do

- No production/runtime code touched — test teardown only.
- Doesn't change what the tests assert or how temp dirs are created.
- Doesn't introduce a new helper — reuses the existing `rmTempDir`.

## Review notes

- The load-bearing change is `afterEach` now calling `rmTempDir(root)` instead of `rm(root, …)`; the `rm` import is dropped from each file since it's no longer used.
- Rationale for the retry/GC approach is documented in `src/test-helpers/rm-temp-dir.ts` — this PR just adopts it.
- Verified locally: `bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full `bun run test` (11436 pass / 0 fail) all green.