### PR TITLE
init: add Slack confirmation-code login for 2FA workspaces

### DIFF
--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -41,7 +41,7 @@ import { runDiscordBootstrap } from '@/init/discord-auth'
 import { runInstagramBootstrap, type InstagramLoginCallbacks } from '@/init/instagram-auth'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
 import { runLineBootstrap } from '@/init/line-auth'
-import { runSlackBootstrap } from '@/init/slack-auth'
+import { runSlackConfirmationBootstrap } from '@/init/slack-auth'
 import { runTeamsBootstrap, type TeamsDeviceCodeCallbacks } from '@/init/teams-auth'
 import { runWebexBootstrap } from '@/init/webex-auth'
 import { SecretsKakaoCredentialStore } from '@/secrets/kakao-store'
@@ -1061,10 +1061,18 @@ async function collectCredentials(
     }
     case 'slack': {
       const qrDataUrl = await promptSlackQrDataUrl()
+      const email = await promptSlackEmail()
+      const spinnerControl = lineSpinnerHolder ? holderSpinnerControl(lineSpinnerHolder) : undefined
       return {
         channel,
         slackQrDataUrl: qrDataUrl,
-        runSlackAuth: ({ cwd: agentDir, qrDataUrl }) => runSlackBootstrap({ qrDataUrl, agentDir }),
+        runSlackAuth: ({ cwd: agentDir, qrDataUrl }) =>
+          runSlackConfirmationBootstrap({
+            qrDataUrl,
+            agentDir,
+            email,
+            requestCode: () => promptSlackConfirmationCode(spinnerControl),
+          }),
       }
     }
     case 'telegram-bot':
@@ -1466,6 +1474,9 @@ async function promptSlackQrDataUrl(): Promise<string> {
       '3. Paste it below (a long data:image/png;base64,... string).',
       '',
       'Generate a fresh QR each time — the sign-in link expires quickly.',
+      '',
+      'If your workspace requires a confirmation code, you will be asked for',
+      'your email next, then for the code Slack sends to your phone.',
     ].join('\n'),
     'Sign in to Slack (user account)',
   )
@@ -1479,6 +1490,33 @@ async function promptSlackQrDataUrl(): Promise<string> {
     process.exit(0)
   }
   return qrDataUrl
+}
+
+async function promptSlackEmail(): Promise<string> {
+  const email = await text({
+    message: 'Slack account email (used to request the confirmation code)',
+    validate: (value) =>
+      value && /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value) ? undefined : 'Enter a valid email address',
+  })
+  if (isCancel(email)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  return email
+}
+
+async function promptSlackConfirmationCode(spinnerControl?: LineAuthSpinnerControl): Promise<string> {
+  spinnerControl?.pause()
+  const code = await text({
+    message: 'Enter the Slack confirmation code sent to your phone',
+    validate: (value) => (value && value.trim().length > 0 ? undefined : 'Confirmation code is required'),
+  })
+  if (isCancel(code)) {
+    cancel('Aborted.')
+    process.exit(0)
+  }
+  spinnerControl?.resume('Confirming Slack sign-in...')
+  return code.trim()
 }
 
 async function promptSlackBotToken(): Promise<string> {
@@ -1874,7 +1912,10 @@ function reportProgress(
       const s = spinner()
       s.start(START_MESSAGES[event.step])
       spinners[event.step] = s
-      if ((event.step === 'line-auth' || event.step === 'instagram-auth') && lineSpinnerHolder) {
+      if (
+        (event.step === 'line-auth' || event.step === 'instagram-auth' || event.step === 'slack-auth') &&
+        lineSpinnerHolder
+      ) {
         lineSpinnerHolder.current = s
       }
       return
@@ -1905,6 +1946,7 @@ function reportProgress(
         s.stop(reportDiscordAuth(event.result))
         break
       case 'slack-auth':
+        if (lineSpinnerHolder) lineSpinnerHolder.current = null
         s.stop(reportSlackAuth(event.result))
         break
       case 'config':

--- a/src/init/slack-auth.test.ts
+++ b/src/init/slack-auth.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
 
-import { runSlackBootstrap, slackSecretsPath } from './slack-auth'
+import { runSlackBootstrap, runSlackConfirmationBootstrap, slackSecretsPath } from './slack-auth'
 
 const tmp = async (): Promise<string> => mkdtemp(join(tmpdir(), 'typeclaw-slack-auth-'))
 
@@ -43,6 +43,54 @@ describe('runSlackBootstrap', () => {
       })
 
       expect(result).toEqual({ ok: false, reason: 'invalid qr' })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('runSlackConfirmationBootstrap', () => {
+  test('logs in with a confirmation code and writes slack account secrets', async () => {
+    const dir = await tmp()
+    try {
+      let requestedCode = false
+      const result = await runSlackConfirmationBootstrap({
+        agentDir: dir,
+        qrDataUrl: 'data:image/png;base64,AAAA',
+        email: 'user@acme.com',
+        requestCode: async () => {
+          requestedCode = true
+          return '123456'
+        },
+        loginWithConfirmationCode: async () => ({ token: 'xoxc-code', cookie: 'xoxd-code', workspace: 'Acme' }),
+      })
+
+      expect(result).toEqual({ ok: true })
+      expect(requestedCode).toBe(false)
+      const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: join(dir, 'secrets.json') })
+      const account = await store.getAccount()
+      expect(account?.token).toBe('xoxc-code')
+      expect(account?.cookie).toBe('xoxd-code')
+      expect(account?.workspace_name).toBe('Acme')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns a failure result when confirmation login throws', async () => {
+    const dir = await tmp()
+    try {
+      const result = await runSlackConfirmationBootstrap({
+        agentDir: dir,
+        qrDataUrl: 'data:image/png;base64,AAAA',
+        email: 'user@acme.com',
+        requestCode: async () => '000000',
+        loginWithConfirmationCode: async () => {
+          throw new Error('session_not_issued')
+        },
+      })
+
+      expect(result).toEqual({ ok: false, reason: 'session_not_issued' })
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/src/init/slack-auth.ts
+++ b/src/init/slack-auth.ts
@@ -5,14 +5,27 @@ import { loginWithQr as upstreamLoginWithQr, type QrSession } from 'agent-messen
 import type { SlackAccountRecord } from '@/secrets/schema'
 import { SecretsSlackCredentialStore } from '@/secrets/slack-store'
 
+import { loginWithConfirmationCode as defaultLoginWithConfirmationCode } from './slack-confirmation-login'
+
 export type SlackBootstrapStatus = { ok: true } | { ok: false; reason: string }
 
 export type LoginWithQrFn = typeof upstreamLoginWithQr
+export type LoginWithConfirmationCodeFn = typeof defaultLoginWithConfirmationCode
 
 export type SlackLoginInput = {
   qrDataUrl: string
   agentDir: string
   loginWithQr?: LoginWithQrFn
+}
+
+export type SlackConfirmationLoginInput = {
+  qrDataUrl: string
+  agentDir: string
+  email: string
+  /** Called once Slack has sent the confirmation code; returns the code the user received. */
+  requestCode: () => Promise<string>
+  loginWithConfirmationCode?: LoginWithConfirmationCodeFn
+  debug?: (message: string) => void
 }
 
 export function slackSecretsPath(agentDir: string): string {
@@ -24,6 +37,35 @@ export async function runSlackBootstrap(input: SlackLoginInput): Promise<SlackBo
     const loginWithQr = input.loginWithQr ?? upstreamLoginWithQr
     const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: slackSecretsPath(input.agentDir) })
     const result = await loginWithQr(input.qrDataUrl)
+    const now = new Date().toISOString()
+    const accountId = workspaceId(result)
+    const account: SlackAccountRecord = {
+      account_id: accountId,
+      token: result.token,
+      cookie: result.cookie,
+      workspace_id: accountId,
+      workspace_name: result.workspace,
+      created_at: now,
+      updated_at: now,
+    }
+    await store.setAccount(account)
+    await store.setCurrentAccount(accountId)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+export async function runSlackConfirmationBootstrap(input: SlackConfirmationLoginInput): Promise<SlackBootstrapStatus> {
+  try {
+    const login = input.loginWithConfirmationCode ?? defaultLoginWithConfirmationCode
+    const store = new SecretsSlackCredentialStore({ mode: 'host', secretsPath: slackSecretsPath(input.agentDir) })
+    const result = await login({
+      qrDataUrl: input.qrDataUrl,
+      email: input.email,
+      requestCode: input.requestCode,
+      debug: input.debug,
+    })
     const now = new Date().toISOString()
     const accountId = workspaceId(result)
     const account: SlackAccountRecord = {

--- a/src/init/slack-confirmation-login.test.ts
+++ b/src/init/slack-confirmation-login.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test'
+
+import { loginWithConfirmationCode, SlackConfirmationLoginError } from './slack-confirmation-login'
+
+const WS = 'acme'
+const QR_PATH = 'z-app-1563306880084-11602666734978-abcdef'
+const MAGIC = 'z-app-1563306880084-11630999195424-ghijkl'
+const QR_URL = `https://app.slack.com/t/${WS}/login/${QR_PATH}?src=qr_code&user_id=U1&team_id=T1`
+const WS_PAGE_URL = `https://${WS}.slack.com/${QR_PATH}?src=qr_code&user_id=U1&team_id=T1`
+
+function html(body: string): Response {
+  return new Response(body, { status: 200, headers: { 'content-type': 'text/html' } })
+}
+
+function redirect(location: string, setCookie?: string[]): Response {
+  const res = new Response('', { status: 302, headers: new Headers({ location }) })
+  if (setCookie) for (const c of setCookie) res.headers.append('set-cookie', c)
+  return res
+}
+
+function enterCodePage(): Response {
+  const props = {
+    teamName: 'Acme',
+    error: null,
+    twoFactorType: 'sms',
+    emailAddress: 'user@acme.com',
+    action: 'request_primary',
+    magicLogin: MAGIC,
+    remember: false,
+    hasRemember: false,
+  }
+  const escaped = JSON.stringify(props).replace(/"/g, '&quot;')
+  return html(`<div id="enter_code_app_root"><div id="props_node" data-props="${escaped}"></div></div>`)
+}
+
+describe('loginWithConfirmationCode', () => {
+  test('reads magicLogin from data-props, submits the code, and retrieves the token', async () => {
+    const submitted: { url: string; body: string }[] = []
+    let sawSession = false
+
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = init?.method ?? 'GET'
+      const body = typeof init?.body === 'string' ? init.body : ''
+
+      if (method === 'GET' && url === QR_URL) return redirect(WS_PAGE_URL)
+      if (method === 'GET' && url === WS_PAGE_URL) return enterCodePage()
+      if (method === 'POST' && url.includes(QR_PATH)) {
+        submitted.push({ url, body })
+        sawSession = true
+        return redirect('https://slack.com/checkcookie?redir=https%3A%2F%2Facme.slack.com%2Fssb%2Fredirect', [
+          'd=xoxd-secret; path=/; domain=.slack.com; secure; httponly',
+          'd-s=1784; path=/; domain=.slack.com; secure; httponly',
+        ])
+      }
+      if (method === 'GET' && url.startsWith('https://slack.com/checkcookie')) {
+        return redirect('https://acme.slack.com/ssb/redirect')
+      }
+      if (url === 'https://acme.slack.com/ssb/redirect') {
+        return html(`<script>var boot = {"api_token":"xoxc-fresh-token"};</script>`)
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`)
+    }) as typeof fetch
+
+    const result = await loginWithConfirmationCode({
+      qrDataUrl: 'ignored',
+      email: 'user@acme.com',
+      requestCode: async () => '123456',
+      fetchImpl,
+      decodeQr: () => ({ url: QR_URL, workspace: WS }),
+    })
+
+    expect(sawSession).toBe(true)
+    expect(result.token).toBe('xoxc-fresh-token')
+    expect(result.cookie).toBe('xoxd-secret')
+    expect(result.workspace).toBe(WS)
+
+    const submit = submitted[0]
+    expect(submit?.url).toContain(`https://${WS}.slack.com/${QR_PATH}`)
+    expect(submit?.url).toContain('domain=acme')
+    expect(submit?.url).toContain('domainLogin=1')
+    expect(submit?.url).toContain('email=user%40acme.com')
+    expect(submit?.url).not.toContain('src=qr_code')
+    expect(submit?.body).toContain(`2fa_magiclogin=${encodeURIComponent(MAGIC)}`)
+    expect(submit?.body).toContain('2fa_code=123456')
+    expect(submit?.body).toContain('2fa_action=submit_primary')
+  })
+
+  test('throws magic_login_not_found when the page has no data-props', async () => {
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === QR_URL) return redirect(WS_PAGE_URL)
+      if (url === WS_PAGE_URL) return html('<div>Link Expired</div>')
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as unknown as typeof fetch
+
+    await expect(
+      loginWithConfirmationCode({
+        qrDataUrl: 'ignored',
+        email: 'user@acme.com',
+        requestCode: async () => '000000',
+        fetchImpl,
+        decodeQr: () => ({ url: QR_URL, workspace: WS }),
+      }),
+    ).rejects.toMatchObject({ reason: 'magic_login_not_found' })
+  })
+
+  test('throws session_not_issued when no session cookie is set', async () => {
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && url === QR_URL) return redirect(WS_PAGE_URL)
+      if (method === 'GET' && url === WS_PAGE_URL) return enterCodePage()
+      if (method === 'POST' && url.includes(QR_PATH)) return html('<div>Invalid code</div>')
+      throw new Error(`unexpected fetch: ${method} ${url}`)
+    }) as typeof fetch
+
+    const result = loginWithConfirmationCode({
+      qrDataUrl: 'ignored',
+      email: 'user@acme.com',
+      requestCode: async () => '999999',
+      fetchImpl,
+      decodeQr: () => ({ url: QR_URL, workspace: WS }),
+    })
+    await expect(result).rejects.toBeInstanceOf(SlackConfirmationLoginError)
+    await expect(result).rejects.toMatchObject({ reason: 'session_not_issued' })
+  })
+})

--- a/src/init/slack-confirmation-login.ts
+++ b/src/init/slack-confirmation-login.ts
@@ -1,0 +1,305 @@
+import { decodeSlackQr, type QrSession } from 'agent-messenger/slack'
+
+// Slack's "Sign in on mobile" QR encodes a URL of the form:
+//   https://app.slack.com/t/<workspace>/login/z-app-<app_id>-<secret>?src=qr_code&...
+// For workspaces that enforce a confirmation code (a code delivered to the
+// user's phone/email), completing the sign-in is a two-step HTTP flow:
+//
+//   1. GET the QR sign-in URL. It redirects onto the workspace host and renders
+//      the "Enter your authentication code" React page. The page has no <form>;
+//      instead it embeds a JSON blob in
+//        <div id="props_node" data-props="{...}">
+//      containing the fields needed to complete sign-in, most importantly
+//      `magicLogin` (a second z-app secret) and `action` (`request_primary`
+//      once the code has been sent). Reaching this page sends the code.
+//   2. POST the confirmation code back to the workspace-host z-app path:
+//        POST https://<ws>.slack.com/<z-app-path>?domain=<ws>&domainLogin=1&email=<email>
+//        body: 2fa_magiclogin=<magicLogin>&remember=0&has_remember=false
+//              &2fa_code=<code>&2fa_action=submit_primary
+//      Slack responds 302 and sets the `d=xoxd-...` session cookie.
+//
+// The magicLogin secret and email are read from the server-rendered data-props,
+// never guessed. Only the user's confirmation code is injected. Both the code
+// submit contract and the data-props shape were captured from a real login.
+
+const BROWSER_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36'
+const DEFAULT_MAX_REDIRECTS = 10
+const TOKEN_REGEX = /"api_token":"(xoxc-[a-zA-Z0-9-]+)"/
+
+export type ConfirmationLoginError =
+  | 'qr_decode_failed'
+  | 'signin_page_not_found'
+  | 'magic_login_not_found'
+  | 'session_not_issued'
+  | 'token_failed'
+
+export class SlackConfirmationLoginError extends Error {
+  readonly reason: ConfirmationLoginError
+  constructor(reason: ConfirmationLoginError, message: string) {
+    super(message)
+    this.name = 'SlackConfirmationLoginError'
+    this.reason = reason
+  }
+}
+
+export type DecodedQr = { url: string; workspace: string }
+
+export type ConfirmationLoginInput = {
+  qrDataUrl: string
+  email: string
+  /** Called after Slack has sent the confirmation code; returns the code the user received. */
+  requestCode: () => Promise<string>
+  fetchImpl?: typeof fetch
+  decodeQr?: (dataUrl: string) => DecodedQr
+  maxRedirects?: number
+  debug?: (message: string) => void
+}
+
+type SigninProps = {
+  magicLogin: string
+  emailAddress?: string
+  twoFactorType?: string
+  action?: string
+}
+
+export async function loginWithConfirmationCode(input: ConfirmationLoginInput): Promise<QrSession> {
+  const doFetch = input.fetchImpl ?? fetch
+  const debug = input.debug
+  const decode = input.decodeQr ?? ((dataUrl: string) => decodeSlackQr(dataUrl) as DecodedQr)
+  let login: DecodedQr
+  try {
+    login = decode(input.qrDataUrl.trim())
+  } catch (err) {
+    throw new SlackConfirmationLoginError('qr_decode_failed', err instanceof Error ? err.message : String(err))
+  }
+  debug?.(`Decoded QR for workspace ${login.workspace}`)
+
+  const workspaceHost = `${login.workspace}.slack.com`
+  const jar = new CookieJar()
+
+  const page = await followToPage(doFetch, login.url, jar, input.maxRedirects ?? DEFAULT_MAX_REDIRECTS, debug)
+  if (!page.html) {
+    throw new SlackConfirmationLoginError(
+      'signin_page_not_found',
+      'Could not load the Slack sign-in page after opening the QR link. The link may have expired.',
+    )
+  }
+
+  const props = parseSigninProps(page.html)
+  if (!props?.magicLogin) {
+    throw new SlackConfirmationLoginError(
+      'magic_login_not_found',
+      'Slack did not present a confirmation-code page. The QR link may have expired, or this workspace uses a different sign-in step.',
+    )
+  }
+  debug?.(
+    `Sign-in page loaded (twoFactorType=${props.twoFactorType ?? 'unknown'}, action=${props.action ?? 'unknown'})`,
+  )
+
+  const code = (await input.requestCode()).trim()
+
+  const postUrl = new URL(page.finalUrl)
+  postUrl.search = ''
+  postUrl.searchParams.set('domain', login.workspace)
+  postUrl.searchParams.set('domainLogin', '1')
+  postUrl.searchParams.set('email', props.emailAddress ?? input.email)
+
+  const body = encodeForm({
+    '2fa_magiclogin': props.magicLogin,
+    remember: '0',
+    has_remember: 'false',
+    '2fa_code': code,
+    '2fa_action': 'submit_primary',
+  })
+
+  const cookie = await submitCode(
+    doFetch,
+    postUrl.toString(),
+    body,
+    jar,
+    input.maxRedirects ?? DEFAULT_MAX_REDIRECTS,
+    debug,
+  )
+  if (!cookie) {
+    throw new SlackConfirmationLoginError(
+      'session_not_issued',
+      'The confirmation code was submitted but Slack did not issue a session cookie. The code may be wrong or expired.',
+    )
+  }
+  debug?.('Captured session cookie')
+
+  const token = await refreshTokenFromWeb(workspaceHost, cookie, doFetch)
+  if (!token) {
+    throw new SlackConfirmationLoginError(
+      'token_failed',
+      'Slack session was established but the client token could not be retrieved.',
+    )
+  }
+  debug?.('Retrieved client token')
+
+  return { token, cookie, workspace: login.workspace }
+}
+
+class CookieJar {
+  private readonly map = new Map<string, string>()
+  applySetCookies(headers: Headers): void {
+    for (const raw of getSetCookies(headers)) {
+      const pair = raw.split(';')[0]?.trim()
+      if (!pair) continue
+      const eq = pair.indexOf('=')
+      if (eq <= 0) continue
+      this.map.set(pair.slice(0, eq), pair.slice(eq + 1))
+    }
+  }
+  header(): string {
+    return [...this.map.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+  }
+  dCookie(): string | null {
+    const d = this.map.get('d')
+    return d && d.startsWith('xoxd-') ? d : null
+  }
+}
+
+async function followToPage(
+  doFetch: typeof fetch,
+  startUrl: string,
+  jar: CookieJar,
+  maxRedirects: number,
+  debug?: (m: string) => void,
+): Promise<{ html: string; finalUrl: string }> {
+  let url = startUrl
+  for (let hop = 0; hop < maxRedirects; hop++) {
+    if (!isSlackHost(url)) {
+      debug?.(`hop ${hop}: refusing non-Slack host`)
+      break
+    }
+    const res = await doFetch(url, { redirect: 'manual', headers: baseHeaders(jar) })
+    jar.applySetCookies(res.headers)
+    const location = res.status >= 300 && res.status < 400 ? res.headers.get('location') : null
+    debug?.(`hop ${hop}: ${res.status}${location ? ` -> ${location}` : ''}`)
+    if (!location) {
+      return { html: await res.text(), finalUrl: url }
+    }
+    const next = new URL(location, url).toString()
+    if (!isSlackHost(next)) {
+      debug?.(`hop ${hop}: redirect leaves Slack (${new URL(next).hostname}); stopping`)
+      break
+    }
+    url = next
+  }
+  return { html: '', finalUrl: url }
+}
+
+async function submitCode(
+  doFetch: typeof fetch,
+  postUrl: string,
+  body: string,
+  jar: CookieJar,
+  maxRedirects: number,
+  debug?: (m: string) => void,
+): Promise<string | null> {
+  let url = postUrl
+  const res = await doFetch(url, {
+    method: 'POST',
+    redirect: 'manual',
+    headers: { ...baseHeaders(jar), 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  jar.applySetCookies(res.headers)
+  debug?.(`code submit: ${res.status}`)
+  if (jar.dCookie()) return jar.dCookie()
+
+  // Follow post-login redirects (checkcookie -> ssb/redirect) collecting cookies.
+  let location = res.status >= 300 && res.status < 400 ? res.headers.get('location') : null
+  for (let hop = 0; hop < maxRedirects && location; hop++) {
+    const next = new URL(location, url).toString()
+    if (!isSlackHost(next)) break
+    url = next
+    const hopRes = await doFetch(url, { redirect: 'manual', headers: baseHeaders(jar) })
+    jar.applySetCookies(hopRes.headers)
+    debug?.(`post-login hop ${hop}: ${hopRes.status}`)
+    if (jar.dCookie()) return jar.dCookie()
+    location = hopRes.status >= 300 && hopRes.status < 400 ? hopRes.headers.get('location') : null
+  }
+  return jar.dCookie()
+}
+
+async function refreshTokenFromWeb(host: string, cookie: string, doFetch: typeof fetch): Promise<string | null> {
+  try {
+    const res = await doFetch(`https://${host}/ssb/redirect`, {
+      headers: { Cookie: `d=${cookie}`, 'User-Agent': BROWSER_USER_AGENT },
+      redirect: 'follow',
+    })
+    if (!res.ok) return null
+    const html = await res.text()
+    return html.match(TOKEN_REGEX)?.[1] ?? null
+  } catch {
+    return null
+  }
+}
+
+// The "Enter your authentication code" page embeds sign-in state as an
+// HTML-escaped JSON blob inside <div id="props_node" data-props="{...}">.
+function parseSigninProps(html: string): SigninProps | null {
+  const match = html.match(/id="props_node"[^>]*\bdata-props="([^"]*)"/i)
+  if (!match?.[1]) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(decodeHtml(match[1]))
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const record = parsed as Record<string, unknown>
+  const magicLogin = typeof record.magicLogin === 'string' ? record.magicLogin : ''
+  if (!magicLogin) return null
+  return {
+    magicLogin,
+    emailAddress: typeof record.emailAddress === 'string' ? record.emailAddress : undefined,
+    twoFactorType: typeof record.twoFactorType === 'string' ? record.twoFactorType : undefined,
+    action: typeof record.action === 'string' ? record.action : undefined,
+  }
+}
+
+function decodeHtml(s: string): string {
+  return s
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+}
+
+function encodeForm(fields: Record<string, string>): string {
+  return Object.entries(fields)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&')
+}
+
+function baseHeaders(jar: CookieJar): Record<string, string> {
+  const cookie = jar.header()
+  return {
+    'User-Agent': BROWSER_USER_AGENT,
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-US,en;q=0.9',
+    ...(cookie ? { Cookie: cookie } : {}),
+  }
+}
+
+function isSlackHost(rawUrl: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(rawUrl)
+    if (protocol !== 'https:') return false
+    return hostname === 'slack.com' || hostname === 'app.slack.com' || hostname.endsWith('.slack.com')
+  } catch {
+    return false
+  }
+}
+
+function getSetCookies(headers: Headers): string[] {
+  const withGetter = headers as Headers & { getSetCookie?: () => string[] }
+  if (typeof withGetter.getSetCookie === 'function') return withGetter.getSetCookie()
+  const single = headers.get('set-cookie')
+  return single ? [single] : []
+}


### PR DESCRIPTION

## Background

Slack user-account sign-in uses the "Sign in on mobile" QR: the CLI takes a QR data URL, follows the redirect chain over HTTP, and captures the `d=xoxd-` session cookie. That works for open workspaces, but on a workspace that enforces a confirmation code the QR flow dead-ends: the redirect chain reaches an "Enter your authentication code" page and no session cookie is ever issued.
The upstream `loginWithQr` classifies this as `awaiting_device_confirmation` and throws with "use `agent-slack auth extract` on an already-authenticated device."

The catch: the code *is* delivered to the user's phone. Opening the QR sign-in URL already sends it.
So the sign-in is completable over HTTP — the missing step is submitting that code. The previous flow just never asked for it.

Root cause, confirmed by reverse-engineering a real login (HAR capture + live probe): the "Enter your authentication code" page is a React app with no `<form>`.
It embeds sign-in state as an HTML-escaped JSON blob in `<div id="props_node" data-props="{...}">`, most importantly a second z-app secret `magicLogin`.
Completing sign-in is a POST of that secret plus the user's code back to the workspace-host z-app path, which returns 302 with the `d=xoxd-` cookie.

## Summary

Add `loginWithConfirmationCode` (`src/init/slack-confirmation-login.ts`): open the QR sign-in URL, follow redirects onto the workspace host, parse `magicLogin` + `emailAddress` from the page's `data-props`, then POST the user-entered code to obtain the session cookie and reuse the existing `/ssb/redirect` scrape for the `xoxc-` token. `runSlackConfirmationBootstrap` wraps it to persist secrets, mirroring `runSlackBootstrap`. The `channel add` slack case now prompts for email then the code.

Key decisions:

- **Why read `magicLogin` from `data-props` and not hardcode a request shape.**
  The code-submit contract (query params, `2fa_*` body fields) is captured from a real login and is stable, but the `magicLogin` secret is per-attempt and server-issued.
  Reading it from the server-rendered page means only the user's email and code are ever injected — nothing about the secret is guessed.
- **Why a new typeclaw module instead of patching upstream.** 
  The login primitive lives in the `agent-messenger` dependency, which exposes only `loginWithQr`/`decodeSlackQr` and has no code-entry flow or patch mechanism.
  The small `/ssb/redirect` → `xoxc-` token step is reimplemented locally rather than reaching into a non-exported deep path.
- **Why the code prompt pauses the spinner.** 
  `runSlackAuth` runs inside the `channel add` progress spinner.
  The `requestCode` callback pauses it via the existing `LineAuthSpinnerHolder` (the same pattern LINE/Instagram use for mid-auth prompts), takes the code, then resumes.

## What this does NOT do

- Does not remove or change the existing QR-only path (`runSlackBootstrap`) or the bot-token path; both are untouched.
- Does not handle SSO/IdP workspaces — those still can't complete over HTTP and keep pointing at `agent-slack auth extract`.
- Does not add a "resend code" step or backup-code (`twoFactorBackupType`) entry; it consumes the code Slack sends when the sign-in page is opened.
- Does not rewire the `typeclaw init` wizard's `SlackAuthRunner` signature; only the `channel add` closure opts into the code flow.

## Review notes

- Load-bearing change is `parseSigninProps` + the code-submit POST in `loginWithConfirmationCode`. Invariant to verify: the POST targets the workspace-host z-app path with `?domain&domainLogin=1&email`, body carries the server-issued `2fa_magiclogin` (not the QR's own secret) plus `2fa_action=submit_primary`, and the flow only succeeds once a `d=xoxd-`
  cookie is present.
- `decodeHtml` intentionally decodes `&amp;` last so `&amp;quot;` doesn't collapse into a stray quote.
- Cookies are only ever sent to Slack hosts (`isSlackHost`); a redirect off Slack stops the flow without leaking the session cookie.
- Verified end-to-end against a real 2FA workspace: session cookie and `xoxc-` token both issued. Unit tests replay the redirect → data-props → code-submit chain with a mock `fetch`.
