### PR TITLE
fix(agent): stop file-operand scanner rejecting control-token operands

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1219,6 +1219,69 @@ describe('wrapSystemTool', () => {
     await rm(agentDir, { recursive: true, force: true })
   })
 
+  test('reload scope collides with a real agent-dir directory but is not scanned as a file operand', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-reload-scope-'))
+    await mkdir(path.join(agentDir, 'cron'), { recursive: true })
+    await mkdir(path.join(agentDir, 'channels'), { recursive: true })
+
+    for (const scope of ['cron', 'channels', 'config', 'plugins', 'skills']) {
+      const args: Record<string, unknown> = { scope }
+      const pinned = await enforceAndPinToolFiles({ tool: 'reload', args, agentDir, genericInputs: true })
+      await pinned.cleanup()
+      expect(args.scope).toBe(scope)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('stream_snapshot target_kind "cron" is not scanned as a file operand despite a cron/ directory', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-stream-kind-'))
+    await mkdir(path.join(agentDir, 'cron'), { recursive: true })
+
+    const args: Record<string, unknown> = { target_kind: 'cron' }
+    const pinned = await enforceAndPinToolFiles({ tool: 'stream_snapshot', args, agentDir, genericInputs: true })
+    await pinned.cleanup()
+    expect(args.target_kind).toBe('cron')
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('grant_role permission "channel.respond" is not scanned as a file operand (word.ext shape)', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-grant-perm-'))
+
+    const args: Record<string, unknown> = { role: 'guest', permission: 'channel.respond' }
+    const pinned = await enforceAndPinToolFiles({ tool: 'grant_role', args, agentDir, genericInputs: true })
+    await pinned.cleanup()
+    expect(args.permission).toBe('channel.respond')
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('non-file exemption is tool-scoped: an unknown tool reusing scope/target_kind still fails closed', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-nonfile-scoped-'))
+    await mkdir(path.join(agentDir, 'cron'), { recursive: true })
+
+    for (const [tool, key] of [
+      ['plugin_reloader', 'scope'],
+      ['plugin_streamer', 'target_kind'],
+    ] as const) {
+      await expect(
+        enforceAndPinToolFiles({ tool, args: { [key]: 'cron' }, agentDir, genericInputs: true }),
+      ).rejects.toThrow(/ambiguous local file operand/)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('the fs-existence probe still rejects an extensionless file or directory under a non-file key', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-probe-preserved-'))
+    await writeFile(path.join(agentDir, 'credentials'), 'SECRET')
+    await mkdir(path.join(agentDir, 'memory'), { recursive: true })
+
+    for (const value of ['credentials', 'memory']) {
+      await expect(
+        enforceAndPinToolFiles({ tool: 'some_plugin_tool', args: { source: value }, agentDir, genericInputs: true }),
+      ).rejects.toThrow(/ambiguous local file operand/)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
   test('parallel read, look_at, and channel upload calls consume pinned bytes across symlink swaps', async () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-pinned-read-'))
     const safe = path.join(agentDir, 'safe.txt')

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -250,24 +250,38 @@ function fileTargets(
   return targets
 }
 
-// Exact tool + operand-path pairs whose string values are first-party PROSE
-// (message bodies, prompts, queries, regex/CSS/jq strings) — never a local file,
-// so the generic path scan must skip them. Scoped per full operand path, NOT by
-// key name: an undeclared plugin/MCP reader that happens to use `content` or
-// `prompt` must still fail closed. `url` is deliberately absent (web_fetch.url is
-// a real reference — an explicit file: URI there still pins). channel_send/
-// _reply/_fetch_attachment and post_github_review are exempt via earlier returns.
-const PROSE_OPERANDS: Readonly<Record<string, ReadonlySet<string>>> = {
+// Exact tool + operand-path pairs whose string values are first-party operands
+// statically known never to reference a local file, so the generic path scan
+// must skip them. Two families: PROSE (message bodies, prompts, queries, regex/
+// CSS/jq) and CONTROL/API tokens (reload scope, role capability, stream filter
+// kind) consumed as registry keys or remote identifiers, never as a path.
+//
+// Scoped by full operand path, NOT key name — this is the fail-closed invariant:
+// an undeclared plugin/MCP reader that reuses `content`/`prompt`/`scope` must
+// still hit the scan. `url` is deliberately absent (web_fetch.url is a real
+// reference; a file: URI there still pins). channel_send/_reply/
+// _fetch_attachment and post_github_review are exempt via earlier returns.
+//
+// The control-token entries are here because the classifier's fs-existence probe
+// and `word.ext` rule promote bare words to operands: `reload`/`stream_snapshot`
+// "cron" collides with an agent-root `cron/` dir, and grant_role's
+// "channel.respond" matches `word.ext` unconditionally. The probe is load-bearing
+// (catches extensionless files/dirs under non-file keys), so it stays; these
+// provably-non-FS operands are exempted at the source instead.
+const NON_FILE_OPERANDS: Readonly<Record<string, ReadonlySet<string>>> = {
   spawn_subagent: new Set(['prompt', 'description']),
   skip_response: new Set(['reason']),
   web_search: new Set(['query']),
   web_fetch: new Set(['query', 'selector', 'pattern']),
   todo_write: new Set(['todos.content']),
   channel_edit: new Set(['text']),
+  reload: new Set(['scope']),
+  grant_role: new Set(['permission']),
+  stream_snapshot: new Set(['target_kind']),
 }
 
-function isProseOperand(tool: string, operandPath: string): boolean {
-  return PROSE_OPERANDS[tool]?.has(operandPath) === true
+function isKnownNonFileOperand(tool: string, operandPath: string): boolean {
+  return NON_FILE_OPERANDS[tool]?.has(operandPath) === true
 }
 
 // Detection trims first: a leading-whitespace `  file://…` is still a file
@@ -364,14 +378,14 @@ function collectGenericFileTargets(
       operands?.output?.includes(parentPath) === true || operands?.destructive?.includes(parentPath) === true
     const key = parentPath.split('.').at(-1) ?? parentPath
     // Precedence: declared input pins; declared output/destructive is not an
-    // input; a first-party prose operand is opaque (skipped, even a file: URI);
+    // input; a known non-file operand is opaque (skipped, even a file: URI);
     // otherwise an explicit file: URI pins and an undeclared path-shaped value
-    // fails closed. `isProseOperand` is tool+operand-path scoped, so an unknown
-    // tool never inherits an exemption from a common key name.
-    const prose = !declaredInput && isProseOperand(tool, parentPath)
+    // fails closed. `isKnownNonFileOperand` is tool+operand-path scoped, so an
+    // unknown tool never inherits an exemption from a common key name.
+    const knownNonFile = !declaredInput && isKnownNonFileOperand(tool, parentPath)
     for (const [index, item] of value.entries()) {
       if (typeof item === 'string') {
-        if (prose) continue
+        if (knownNonFile) continue
         if (!nonInput && (isFileUri(item) || declaredInput)) {
           out.push(arrayTarget(value, index))
           if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)
@@ -397,12 +411,12 @@ function collectGenericFileTargets(
       const declaredInput = operands?.input?.includes(operandPath) === true
       const nonInput =
         operands?.output?.includes(operandPath) === true || operands?.destructive?.includes(operandPath) === true
-      // Declared input wins; a first-party prose operand (spawn_subagent.prompt,
-      // web_search.query, channel_edit.text, …) is opaque and skipped even when
-      // its value is a file: URI; everything else falls to the file:/heuristic
-      // scan below. Scoped by exact tool+operand-path so an undeclared plugin
-      // reader using `content`/`prompt` still fails closed.
-      if (!declaredInput && isProseOperand(tool, operandPath)) continue
+      // Declared input wins; a known non-file operand (spawn_subagent.prompt,
+      // web_search.query, channel_edit.text, reload.scope, …) is opaque and
+      // skipped even when its value is a file: URI; everything else falls to the
+      // file:/heuristic scan below. Scoped by exact tool+operand-path so an
+      // undeclared plugin reader using `content`/`prompt` still fails closed.
+      if (!declaredInput && isKnownNonFileOperand(tool, operandPath)) continue
       if (!nonInput && (isFileUri(item) || declaredInput)) {
         out.push(propertyTarget(value, childKey))
         if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)


### PR DESCRIPTION
## Background

Reported from a live agent (running HEAD of `main`): calling the `reload` tool with a scope failed with `ambiguous local file operand at key "scope"`, so the agent couldn't hot-reload its `cron` scope and had to defer to a container restart.

Root cause is in the file-operand safety scanner (`src/agent/tool-file-safety.ts`, from the "pin file operands across tool execution" security work). The scanner rejects any *undeclared* string argument that looks like a local file path, to stop an undeclared plugin/MCP reader from silently exfiltrating a file. Its `isAmbiguousUndeclaredLocalOperand` heuristic promotes bare words to file operands two ways that misfire on first-party **control tokens**:

1. **Filesystem-existence probe** — `lstatSync(agentDir/value)`. `reload({scope:"cron"})` passes the value `"cron"`, which has no separator and no extension, but the agent folder contains a real `cron/` directory, so the probe "confirms" it as a file and the call is rejected. Verified on the reporting agent that `cron/`, `channels/`, and `memory/` all exist as agent-root dirs — so `reload` for any of those scopes (and `stream_snapshot({target_kind:"cron"})`) breaks, depending purely on the agent folder's layout.
2. **`word.ext` shape rule** — `grant_role({permission:"channel.respond"})` matches `^word\.ext$` **unconditionally** (no filesystem collision needed), so role capability grants are *always* rejected at HEAD.

None of these values is ever a file: `reload.scope` is a reload-registry key, `stream_snapshot.target_kind` is a stream filter enum, and `grant_role.permission` is a role capability string. They are consumed as registry keys / remote identifiers and never reach a filesystem API.

## Summary

Exempt the three provably-non-FS control operands at the source, via the existing per-tool operand table:

```
reload:          scope
grant_role:      permission
stream_snapshot: target_kind
```

**Why exempt, not weaken the probe:** the filesystem-existence probe is load-bearing. It's the only rule that catches an extensionless file (`Dockerfile`, `credentials`, `id_rsa`) or a directory passed under a non-file-shaped key (`source`, `scope`) — dropping it would let an undeclared plugin/MCP reader exfiltrate exactly those. So the probe stays; the specific control tokens are allow-listed instead. The exemption is scoped by **exact tool + full operand path**, so an unknown tool reusing `scope`/`target_kind`/`permission` still fails closed.

`PROSE_OPERANDS`/`isProseOperand` are renamed to `NON_FILE_OPERANDS`/`isKnownNonFileOperand`: the table now unifies two families (first-party prose *and* control/API tokens) under the single property that both are statically known never to reference a local file.

Fix scope was reviewed against the whole first-party system-tool surface. Other enum/identifier operands (`channel_read.*`, `channel_history.cursor`, `channel_react.emoji`) are also provably non-FS but have no demonstrated collision under normal values, so they're intentionally left out to keep this a tight regression hotfix (see non-goals).

## What this does NOT do

- Does not touch `isAmbiguousUndeclaredLocalOperand` or the filesystem-existence probe — undeclared readers still fail closed exactly as before.
- Does not broadly exempt generic key *names* (`scope`, `name`, `mode`, `input`) — that would let unknown plugin/MCP tools smuggle relative file operands. Exemptions are exact tool + operand-path only.
- Does not exempt speculative channel identifier/cursor/emoji operands — deferred to a follow-up if a concrete adapter value is shown to trip the classifier.
- Unrelated to the earlier git-secret-history `gh`-blocking reports — that path already passes at HEAD (the merged dangling-object narrowing fixes cover it); this PR is only the file-operand false positive.

## Review notes

- Load-bearing change: the three new entries in `NON_FILE_OPERANDS` and the invariant that the fs-probe is untouched.
- Regression tests are in `src/agent/plugin-tools.test.ts` and exercise the real scanner path (`enforceAndPinToolFiles`, what `wrapSystemTool` calls):
  - `reload` scope and `stream_snapshot` target_kind pass **with a real `cron/`/`channels/` directory present** (the exact repro).
  - `grant_role` `permission: "channel.respond"` passes (the `word.ext` case).
  - Fail-closed counterpart: an unknown tool reusing `scope`/`target_kind` with a `cron/` dir still rejects.
  - Probe preserved: an extensionless file `credentials` and a directory `memory` under an unknown key still reject.
  - All five were red-green verified (they fail with the exemptions removed).
