### PR TITLE
fix(agent): exempt identifier-only tool operands from the file-operand scanner

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -156,6 +156,55 @@ describe('wrapPluginTool', () => {
     expect(result).toMatchObject({ isError: true })
   })
 
+  test('a nonFile-declared identifier colliding with a hidden dir passes the private-surface guard, undeclared still blocks', async () => {
+    // Reproduces the guard-ordering the runtime uses: private-surface-read runs
+    // in tool.before, BEFORE the file-operand scanner, and must honor the tool's
+    // trusted `fileOperands.nonFile` (threaded through the event) or a declared
+    // identifier equal to a hidden dir name is wrongly blocked.
+    const seen: Array<Record<string, unknown>> = []
+    const makeTool = () =>
+      defineTool({
+        description: '',
+        parameters: z.object({ tenant: z.string(), region: z.string() }),
+        fileOperands: { nonFile: ['tenant'] },
+        async execute(args) {
+          seen.push(args)
+          return { content: [{ type: 'text', text: 'ok' }] }
+        },
+      })
+    const hooks = createHookBus()
+    hooks.registerAll('security', '/agent', noopLogger, {
+      'tool.before': (event) =>
+        checkPrivateSurfaceReadGuard({
+          tool: event.tool,
+          args: event.args,
+          agentDir: '/agent',
+          hidden: { dirs: ['/agent/memory'], files: [] },
+          ...(event.fileOperands !== undefined ? { fileOperands: event.fileOperands } : {}),
+        }),
+    })
+    const wrap = () =>
+      wrapPluginTool(makeTool(), {
+        pluginName: 'multi',
+        toolName: 'tenant_status',
+        agentDir: '/agent',
+        sessionId: 's',
+        logger: noopLogger,
+        hooks,
+      })
+
+    // Declared nonFile operand equal to a hidden dir → allowed through the guard.
+    const ok = await wrap().execute('c', { tenant: 'memory', region: 'us' }, undefined, undefined, {} as never)
+    expect(textOfFirstContent(ok)).toBe('ok')
+    expect(seen).toEqual([{ tenant: 'memory', region: 'us' }])
+
+    // Undeclared operand equal to a hidden dir → still blocked (fail-closed).
+    seen.length = 0
+    const blocked = await wrap().execute('c', { tenant: 'ok', region: 'memory' }, undefined, undefined, {} as never)
+    expect(blocked).toMatchObject({ isError: true })
+    expect(seen).toEqual([])
+  })
+
   test('passes parsed args to plugin execute and exposes ToolContext', async () => {
     const seen: { args: unknown; ctx: { sessionId: string; agentDir: string } }[] = []
     const tool = defineTool({
@@ -1279,6 +1328,138 @@ describe('wrapSystemTool', () => {
         enforceAndPinToolFiles({ tool: 'some_plugin_tool', args: { source: value }, agentDir, genericInputs: true }),
       ).rejects.toThrow(/ambiguous local file operand/)
     }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('identifier-only system tools accept remote ids that trip the word.ext, cursor, and fs-probe rules', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-whole-tool-'))
+    for (const dir of ['memory', 'channels', 'sessions', 'workspace']) {
+      await mkdir(path.join(agentDir, dir), { recursive: true })
+    }
+
+    // Slack message/thread ids are always epoch.micros (word.ext); cursors carry
+    // "/"; workspace/target_id/subagent_type/task_id can equal an agent-root dir.
+    const cases: Array<[string, Record<string, unknown>]> = [
+      [
+        'channel_read',
+        { mode: 'message', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', message_id: '1699999999.000100' },
+      ],
+      [
+        'channel_read',
+        { mode: 'history', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', thread: '1699999999.000100' },
+      ],
+      [
+        'channel_read',
+        { mode: 'history', adapter: 'slack-bot', workspace: 'T0', chat: 'C0', cursor: 'dGVhbTpU/bmV4dA==' },
+      ],
+      ['channel_read', { mode: 'list', adapter: 'slack-bot', workspace: 'memory' }],
+      ['channel_history', { cursor: '1699999999.000100', scope: 'channel' }],
+      [
+        'channel_edit',
+        { adapter: 'slack-bot', workspace: 'T0', chat: 'C0', message_id: '1699999999.000100', text: 'x' },
+      ],
+      ['channel_react', { emoji: 'party.parrot' }],
+      ['stream_snapshot', { target_kind: 'session', target_id: 'memory' }],
+      ['grant_role', { role: 'guest', permission: 'channel.respond' }],
+      ['spawn_subagent', { subagent_type: 'memory', prompt: 'hi' }],
+      ['subagent_output', { task_id: 'sessions' }],
+      ['subagent_cancel', { task_id: 'sessions' }],
+      ['look_at_channel_attachment', { attachment_id: 1, prompt: 'describe /agent/workspace' }],
+    ]
+    for (const [tool, args] of cases) {
+      const before = JSON.stringify(args)
+      const pinned = await enforceAndPinToolFiles({ tool, args, agentDir, genericInputs: true })
+      await pinned.cleanup()
+      expect(JSON.stringify(args)).toBe(before)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('whole-tool exemption is scoped: an unknown tool with the same id-shaped args still fails closed', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-wholetool-scoped-'))
+    await mkdir(path.join(agentDir, 'memory'), { recursive: true })
+    for (const args of [{ message_id: '1699999999.000100' }, { workspace: 'memory' }, { cursor: 'a/b/c' }]) {
+      await expect(
+        enforceAndPinToolFiles({ tool: 'plugin_channel_like', args, agentDir, genericInputs: true }),
+      ).rejects.toThrow(/ambiguous local file operand/)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('reviewer_checkout repoSlug passes via its own nonFile declaration, not a global key exemption', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-reposlug-'))
+    const declared = { nonFile: ['repoSlug', 'headSha'] } as const
+
+    // The tool declares repoSlug/headSha as non-file; the "/" in owner/repo is
+    // then not misread as a path separator. (The tool's own REPO_SLUG regex
+    // rejects traversal downstream — the scanner no longer second-guesses it.)
+    const ok: Record<string, unknown> = { repoSlug: 'typeclaw/typeclaw', headSha: 'a'.repeat(40) }
+    const pinned = await enforceAndPinToolFiles({
+      tool: 'reviewer_checkout',
+      args: ok,
+      agentDir,
+      genericInputs: true,
+      fileOperands: declared,
+    })
+    await pinned.cleanup()
+    expect(ok.repoSlug).toBe('typeclaw/typeclaw')
+
+    // An UNDECLARED tool passing a valid-looking repoSlug must STILL fail closed:
+    // repoSlug is no longer exempt globally by key name.
+    for (const value of ['typeclaw/typeclaw', 'public/notes', '../etc/passwd']) {
+      await expect(
+        enforceAndPinToolFiles({ tool: 'unknown_plugin', args: { repoSlug: value }, agentDir, genericInputs: true }),
+      ).rejects.toThrow(/ambiguous local file operand/)
+    }
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('a plugin fileOperands.nonFile declaration exempts its operands but stays tool+path scoped', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-nonfile-decl-'))
+    await mkdir(path.join(agentDir, 'sessions'), { recursive: true })
+
+    // Runtime prefixes subagent custom-tool names, so a static in-scanner table
+    // keyed by "memory_append" would miss it; the declaration travels with the tool.
+    const operands = { nonFile: ['topic', 'body'] } as const
+    const ok: Record<string, unknown> = { topic: 'sessions', body: 'see a/b/c for detail' }
+    const pinned = await enforceAndPinToolFiles({
+      tool: '__plugin_memory_memory-logger_3',
+      args: ok,
+      agentDir,
+      genericInputs: true,
+      fileOperands: operands,
+    })
+    await pinned.cleanup()
+    expect(ok).toEqual({ topic: 'sessions', body: 'see a/b/c for detail' })
+
+    // An UNDECLARED operand on the same tool must still fail closed.
+    await expect(
+      enforceAndPinToolFiles({
+        tool: '__plugin_memory_memory-logger_3',
+        args: { topic: 'ok', attachment: 'sessions' },
+        agentDir,
+        genericInputs: true,
+        fileOperands: operands,
+      }),
+    ).rejects.toThrow(/ambiguous local file operand/)
+    await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('a declared real-file input is pinned to an immutable snapshot, not rejected', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-input-pin-'))
+    await mkdir(path.join(agentDir, 'sessions'), { recursive: true })
+    await writeFile(path.join(agentDir, 'sessions', 'ses_x.jsonl'), '{"id":"e1"}\n')
+
+    const args: Record<string, unknown> = { path: 'sessions/ses_x.jsonl', entryId: 'e1' }
+    const pinned = await enforceAndPinToolFiles({
+      tool: '__plugin_memory_find_0',
+      args,
+      agentDir,
+      genericInputs: true,
+      fileOperands: { input: ['path'] },
+    })
+    expect(String(args.path)).toContain('typeclaw-tool-input')
+    await pinned.cleanup()
     await rm(agentDir, { recursive: true, force: true })
   })
 

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -310,6 +310,7 @@ export function wrapPluginTool(tool: Tool<any>, opts: WrapToolOptions): ToolDefi
         callId: toolCallId,
         args: mutableArgs,
         ...(liveOrigin !== undefined ? { origin: liveOrigin } : {}),
+        ...(tool.fileOperands !== undefined ? { fileOperands: tool.fileOperands } : {}),
       }
       const blockResult = await opts.hooks.runToolBefore(before)
       if (blockResult !== undefined) {

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -11,6 +11,10 @@ import type { ToolFileOperands, ToolResult } from '@/plugin'
 import { CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
 import type { HiddenPaths } from '@/sandbox/hidden-paths'
 
+import { TOOLS_WITHOUT_LOCAL_FILE_OPERANDS } from './tools-without-local-file-operands'
+
+export { TOOLS_WITHOUT_LOCAL_FILE_OPERANDS }
+
 type Rewrite = { original: string; pinned: string }
 type FileTarget = { get(): string; original: string; set(value: string): void; uri: boolean }
 type VerifiedInput = {
@@ -217,6 +221,7 @@ function fileTargets(
   agentDir: string,
 ): FileTarget[] {
   if (isOutputTool(tool)) return []
+  if (TOOLS_WITHOUT_LOCAL_FILE_OPERANDS.has(tool)) return []
   if (tool === 'read' && typeof args.path === 'string') return [propertyTarget(args, 'path')]
   if (isTreeInputTool(tool)) {
     if (typeof args.path !== 'string') args.path = '.'
@@ -250,34 +255,24 @@ function fileTargets(
   return targets
 }
 
-// Exact tool + operand-path pairs whose string values are first-party operands
-// statically known never to reference a local file, so the generic path scan
-// must skip them. Two families: PROSE (message bodies, prompts, queries, regex/
-// CSS/jq) and CONTROL/API tokens (reload scope, role capability, stream filter
-// kind) consumed as registry keys or remote identifiers, never as a path.
+// Exact tool + operand-path pairs for first-party PROSE operands (message
+// bodies, prompts, queries, regex/CSS/jq strings) that are never a local file.
+// This table is for tools that ALSO have a real file operand and so cannot be
+// whole-tool exempt via TOOLS_WITHOUT_LOCAL_FILE_OPERANDS: web_fetch pins its
+// `url` (a file: URI there still snapshots) while `query`/`selector`/`pattern`
+// are prose. Pure control-token tools (reload, grant_role, stream_snapshot,
+// channel_edit, …) live in that set instead, so they are absent here.
 //
 // Scoped by full operand path, NOT key name — this is the fail-closed invariant:
-// an undeclared plugin/MCP reader that reuses `content`/`prompt`/`scope` must
-// still hit the scan. `url` is deliberately absent (web_fetch.url is a real
-// reference; a file: URI there still pins). channel_send/_reply/
-// _fetch_attachment and post_github_review are exempt via earlier returns.
-//
-// The control-token entries are here because the classifier's fs-existence probe
-// and `word.ext` rule promote bare words to operands: `reload`/`stream_snapshot`
-// "cron" collides with an agent-root `cron/` dir, and grant_role's
-// "channel.respond" matches `word.ext` unconditionally. The probe is load-bearing
-// (catches extensionless files/dirs under non-file keys), so it stays; these
-// provably-non-FS operands are exempted at the source instead.
+// an undeclared plugin/MCP reader that reuses `content`/`prompt`/`query` must
+// still hit the scan and cannot inherit an exemption from a common key name.
+// Plugin/MCP tools declare their own via `fileOperands.nonFile` (survives the
+// runtime `__plugin_*` name prefix, which a static table here would not).
 const NON_FILE_OPERANDS: Readonly<Record<string, ReadonlySet<string>>> = {
-  spawn_subagent: new Set(['prompt', 'description']),
   skip_response: new Set(['reason']),
   web_search: new Set(['query']),
   web_fetch: new Set(['query', 'selector', 'pattern']),
   todo_write: new Set(['todos.content']),
-  channel_edit: new Set(['text']),
-  reload: new Set(['scope']),
-  grant_role: new Set(['permission']),
-  stream_snapshot: new Set(['target_kind']),
 }
 
 function isKnownNonFileOperand(tool: string, operandPath: string): boolean {
@@ -380,9 +375,11 @@ function collectGenericFileTargets(
     // Precedence: declared input pins; declared output/destructive is not an
     // input; a known non-file operand is opaque (skipped, even a file: URI);
     // otherwise an explicit file: URI pins and an undeclared path-shaped value
-    // fails closed. `isKnownNonFileOperand` is tool+operand-path scoped, so an
-    // unknown tool never inherits an exemption from a common key name.
-    const knownNonFile = !declaredInput && isKnownNonFileOperand(tool, parentPath)
+    // fails closed. Both the static first-party table and a plugin's declared
+    // `fileOperands.nonFile` are tool+operand-path scoped, so an unknown tool
+    // never inherits an exemption from a common key name.
+    const knownNonFile =
+      !declaredInput && (operands?.nonFile?.includes(parentPath) === true || isKnownNonFileOperand(tool, parentPath))
     for (const [index, item] of value.entries()) {
       if (typeof item === 'string') {
         if (knownNonFile) continue
@@ -411,12 +408,18 @@ function collectGenericFileTargets(
       const declaredInput = operands?.input?.includes(operandPath) === true
       const nonInput =
         operands?.output?.includes(operandPath) === true || operands?.destructive?.includes(operandPath) === true
-      // Declared input wins; a known non-file operand (spawn_subagent.prompt,
-      // web_search.query, channel_edit.text, reload.scope, …) is opaque and
-      // skipped even when its value is a file: URI; everything else falls to the
-      // file:/heuristic scan below. Scoped by exact tool+operand-path so an
-      // undeclared plugin reader using `content`/`prompt` still fails closed.
-      if (!declaredInput && isKnownNonFileOperand(tool, operandPath)) continue
+      // Declared input wins; a known non-file operand (web_search.query,
+      // web_fetch.selector, a plugin's declared `fileOperands.nonFile`, …) is
+      // opaque and skipped even when its value is a file: URI; everything else
+      // falls to the file:/heuristic scan below. Scoped by exact tool+operand-
+      // path so an undeclared plugin reader using `content`/`prompt` still
+      // fails closed.
+      if (
+        !declaredInput &&
+        (operands?.nonFile?.includes(operandPath) === true || isKnownNonFileOperand(tool, operandPath))
+      ) {
+        continue
+      }
       if (!nonInput && (isFileUri(item) || declaredInput)) {
         out.push(propertyTarget(value, childKey))
         if (out.length > maxCount) throw inputCountTooLarge(out.length, maxCount)

--- a/src/agent/tools-without-local-file-operands.ts
+++ b/src/agent/tools-without-local-file-operands.ts
@@ -1,0 +1,27 @@
+// First-party system tools whose EVERY argument is a control token or a remote
+// identifier (channel/workspace/message/thread/cursor ids, subagent names, task
+// ids, role capabilities, reload/stream scopes) — none is ever dereferenced as a
+// local path. Listing the whole tool is more robust than enumerating each
+// operand: these schemas gain new id/enum fields often, and every such field
+// hits the same false positives (a Slack `ts` like "1699999999.000100" matches
+// the `word.ext` rule; a value equal to an agent-root dir like "memory" hits the
+// fs-existence probe; a base64 cursor carries a "/"). The security cost is zero
+// TODAY because none reads a local file; the risk is future drift, so this set
+// is the single fence, shared by BOTH enforcement points — the file-operand
+// scanner (tool-file-safety) and the private-surface-read guard. It lives in
+// this leaf module (no imports) so those two modules, which import each other,
+// can both read it without a circular-init TDZ. Add a tool here ONLY after
+// confirming it dereferences no argument as a local path.
+export const TOOLS_WITHOUT_LOCAL_FILE_OPERANDS: ReadonlySet<string> = new Set([
+  'channel_read',
+  'channel_history',
+  'channel_edit',
+  'channel_react',
+  'look_at_channel_attachment',
+  'stream_snapshot',
+  'grant_role',
+  'spawn_subagent',
+  'subagent_cancel',
+  'subagent_output',
+  'reload',
+])

--- a/src/bundled-plugins/github-cli-auth/review-checkout.ts
+++ b/src/bundled-plugins/github-cli-auth/review-checkout.ts
@@ -92,6 +92,13 @@ export function createReviewerCheckoutTool(resolveTokenForRepo: ResolveGithubTok
     description:
       'Prepare a runtime-owned token-safe scratch checkout of one allowlisted GitHub repository at an exact full commit SHA.',
     parameters: z.object({ repoSlug: z.string(), headSha: z.string() }),
+    // `repoSlug` ("owner/repo") and `headSha` (40-hex) are remote GitHub
+    // coordinates, never local paths — repoSlug is only ever interpolated into
+    // `https://github.com/<slug>.git` and prepareReviewerCheckout rejects
+    // anything not matching /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/. Declared so the
+    // required "/" in a slug isn't misread as a path separator. Scoped to THIS
+    // tool: an undeclared reader passing a slug-shaped value still fails closed.
+    fileOperands: { nonFile: ['repoSlug', 'headSha'] },
     async execute(args, ctx) {
       try {
         const receipt = await prepareReviewerCheckout({

--- a/src/bundled-plugins/memory/append-tool.ts
+++ b/src/bundled-plugins/memory/append-tool.ts
@@ -77,6 +77,13 @@ export function createAppendTool(options: CreateAppendToolOptions = {}) {
       references: z.array(z.string()).optional(),
       who: z.string().min(1).optional(),
     }),
+    // None of these is a local path — topic/body are prose, the rest are session/
+    // entry/reference ids. The runtime chooses the stream filename; the tool never
+    // opens a caller path. Declared so a body carrying "/" or a slug/id that
+    // collides with an agent-root dir name is not misread as a file operand.
+    fileOperands: {
+      nonFile: ['topic', 'body', 'source', 'entry', 'latestEntryId', 'references', 'who'],
+    },
     async execute({ topic, body, source, entry, latestEntryId, references, who }, ctx) {
       const streamPath = dailyStreamPath(ctx.agentDir)
       const where = provenanceFromOrigin(originProvider?.())

--- a/src/bundled-plugins/memory/find-entry-tool.ts
+++ b/src/bundled-plugins/memory/find-entry-tool.ts
@@ -19,6 +19,10 @@ export const findEntryTool = defineTool({
       .min(1)
       .describe('The entry id to locate (matches the JSONL row whose own `id` field equals this value).'),
   }),
+  // `path` is a real local file this tool reads; declaring it pins an immutable
+  // snapshot before readFile (and restores the original path in the result)
+  // instead of the scanner rejecting the bare `sessions/...jsonl` path.
+  fileOperands: { input: ['path'] },
   async execute({ path, entryId }) {
     if (entryId.length === 0) {
       throw new Error('find_entry requires a non-empty entryId; an empty needle would match every line.')

--- a/src/bundled-plugins/memory/references/store-reference-tool.ts
+++ b/src/bundled-plugins/memory/references/store-reference-tool.ts
@@ -23,6 +23,10 @@ export function createStoreReferenceTool(onReferenceStored?: ReferenceStoredHook
       origin: z.enum(['episode', 'curated', 'external']),
       tags: z.array(z.string()).optional(),
     }),
+    // title/body/tags are prose the tool writes under a runtime-computed slug
+    // path; none is a caller-supplied file path. Declared so a title like
+    // "README.md" or a body carrying "/" is not misread as a file operand.
+    fileOperands: { nonFile: ['title', 'body', 'tags'] },
     async execute({ title, body, origin, tags }, ctx) {
       const existingSlugs = new Set(await listReferenceSlugs(ctx.agentDir))
       const slug = headingToSlug(title, existingSlugs)

--- a/src/bundled-plugins/memory/search-tool.ts
+++ b/src/bundled-plugins/memory/search-tool.ts
@@ -76,6 +76,14 @@ export function createMemorySearchTool() {
       chat: z.string().optional(),
       thread: z.string().optional(),
     }),
+    // Every string field is a search term, an exact topic/reference slug, an ISO
+    // date, or an origin id/name — none is a local path (the tool reads memory/
+    // internally, never a caller path). Declared so a `topic` slug that collides
+    // with an agent-root dir, or a `since` date like "2026-01-01", is not
+    // misread as a file operand.
+    fileOperands: {
+      nonFile: ['query', 'topic', 'since', 'before', 'where', 'workspace', 'chat', 'thread'],
+    },
     async execute({ query, topic, asRegex, full, maxResults, since, before, where, workspace, chat, thread }, ctx) {
       if ((query === undefined) === (topic === undefined)) {
         return resultToToolResult({ error: 'provide exactly one of `query` or `topic`' })

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -209,6 +209,7 @@ export default definePlugin({
             args: event.args,
             agentDir: ctx.agentDir,
             hidden: resolveHiddenPaths(ctx.permissions, event.origin, ctx.agentDir),
+            ...(event.fileOperands !== undefined ? { fileOperands: event.fileOperands } : {}),
           }),
           canBypass(GUARD_SSRF_SEVERITY, SECURITY_PERMISSIONS.bypassSsrf)
             ? undefined

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { homedir } from 'node:os'
 import path from 'node:path'
 
+import { TOOLS_WITHOUT_LOCAL_FILE_OPERANDS } from '@/agent/tools-without-local-file-operands'
 import type { HiddenPaths } from '@/sandbox'
 
 import { checkPrivateSurfaceReadGuard } from './private-surface-read'
@@ -65,6 +66,23 @@ describe('private-surface-read guard — free-text field scoping (no false posit
     expect(check('web_search', { query: 'workspace' })).toBeUndefined()
     expect(check('grep', { pattern: 'sessions', path: 'public' })).toBeUndefined()
     expect(check('look_at_channel_attachment', { prompt: 'sessions' })).toBeUndefined()
+  })
+
+  test('does not block an identifier-only tool whose remote id equals a hidden dir name', () => {
+    // These tools read no local path (shared TOOLS_WITHOUT_LOCAL_FILE_OPERANDS
+    // set); an id like workspace/target_id/task_id="memory" must not resolve to
+    // /agent/memory and get blocked, mirroring the file-operand scanner's skip.
+    expect(check('channel_read', { mode: 'list', adapter: 'slack-bot', workspace: 'memory' })).toBeUndefined()
+    expect(
+      check('channel_read', { mode: 'history', adapter: 'slack-bot', workspace: 'T0', chat: 'sessions' }),
+    ).toBeUndefined()
+    expect(check('stream_snapshot', { target_kind: 'session', target_id: 'workspace' })).toBeUndefined()
+    expect(check('subagent_output', { task_id: 'memory' })).toBeUndefined()
+    expect(check('spawn_subagent', { subagent_type: 'memory', prompt: 'x' })).toBeUndefined()
+  })
+
+  test('the shared exemption is tool-scoped: an unknown tool with the same key still fails closed', () => {
+    expect(check('plugin_reader', { workspace: 'memory' })?.block).toBe(true)
   })
 
   test('does not block a path-LIKE value in a free-text field', () => {
@@ -395,5 +413,58 @@ describe('private-surface-read guard — symlink bypass defense', () => {
     writeFileSync(path.join(agentDir, 'public', 'real.md'), 'shareable')
     const result = checkPrivateSurfaceReadGuard({ tool: 'read', args: { path: 'public/real.md' }, agentDir, hidden })
     expect(result).toBeUndefined()
+  })
+})
+
+describe('private-surface-read guard — honors a tool author fileOperands.nonFile declaration', () => {
+  test('skips a declared nonFile operand colliding with a hidden dir', () => {
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'plugin_reader',
+        args: { tenant: 'memory' },
+        agentDir: AGENT,
+        hidden: guestHidden,
+        fileOperands: { nonFile: ['tenant'] },
+      }),
+    ).toBeUndefined()
+  })
+
+  test('is scoped by exact operand path: an undeclared key still blocks', () => {
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'plugin_reader',
+        args: { tenant: 'ok', region: 'memory' },
+        agentDir: AGENT,
+        hidden: guestHidden,
+        fileOperands: { nonFile: ['tenant'] },
+      })?.block,
+    ).toBe(true)
+  })
+
+  test('never exempts input/output/destructive: a declared real-file input under a hidden dir still blocks', () => {
+    // nonFile skips the scan; input is a REAL file that must still be blocked
+    // when it resolves into the private surface — otherwise a declared input
+    // becomes a read-back channel for exactly what the bash masks deny.
+    expect(
+      checkPrivateSurfaceReadGuard({
+        tool: 'plugin_reader',
+        args: { path: 'memory/secret.md' },
+        agentDir: AGENT,
+        hidden: guestHidden,
+        fileOperands: { input: ['path'], nonFile: ['tenant'] },
+      })?.block,
+    ).toBe(true)
+  })
+})
+
+describe('private-surface-read guard — shared exemption set stays in sync with the file-operand scanner', () => {
+  test('every TOOLS_WITHOUT_LOCAL_FILE_OPERANDS tool is skipped here too', () => {
+    // Drift fence: the two enforcement points share one set. If a tool is added
+    // to the scanner's exempt set but this guard still resolved its id args as
+    // paths, a value equal to a hidden dir would be blocked here — the exact
+    // divergence this coupling prevents.
+    for (const tool of TOOLS_WITHOUT_LOCAL_FILE_OPERANDS) {
+      expect(check(tool, { workspace: 'memory', target_id: 'sessions', task_id: 'workspace' })).toBeUndefined()
+    }
   })
 })

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -3,6 +3,8 @@ import { homedir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { TOOLS_WITHOUT_LOCAL_FILE_OPERANDS } from '@/agent/tools-without-local-file-operands'
+import type { ToolFileOperands } from '@/plugin'
 import {
   CANONICAL_AGENT_SECRET_DIRS,
   CANONICAL_AGENT_SECRET_FILES,
@@ -20,7 +22,14 @@ export const GUARD_PRIVATE_SURFACE_READ = 'privateSurfaceRead'
 // scanned, so a new file-reading tool — bundled or third-party — is covered
 // the day it ships without a whitelist edit. web_search/web_fetch take URLs, not
 // local paths, and the path-plausibility filter keeps their args from matching.
-const UNSCANNED_TOOLS = new Set(['bash'])
+//
+// TOOLS_WITHOUT_LOCAL_FILE_OPERANDS is the SAME set the file-operand scanner
+// skips: first-party tools whose args are only remote ids/control tokens
+// (channel/stream/subagent/role reads). Without this, an id equal to a working
+// dir — channel_read({ workspace: "memory" }) — would resolve to /agent/memory
+// and be wrongly blocked here even after the scanner cleared it. Sharing one set
+// keeps both enforcement points agreeing on which tools read no local path.
+const UNSCANNED_TOOLS = new Set(['bash', ...TOOLS_WITHOUT_LOCAL_FILE_OPERANDS])
 const VIRTUAL_FILESYSTEM_ROOTS = ['/proc', '/sys', '/dev', '/run'] as const
 
 // The bash sandbox hides the role's private surface — the working DIRECTORIES
@@ -51,8 +60,9 @@ export function checkPrivateSurfaceReadGuard(options: {
   args: Record<string, unknown>
   agentDir: string
   hidden: HiddenPaths
+  fileOperands?: ToolFileOperands
 }): SecurityBlock | undefined {
-  const { tool, args, agentDir, hidden } = options
+  const { tool, args, agentDir, hidden, fileOperands } = options
   if (UNSCANNED_TOOLS.has(tool)) return undefined
   const deniedDirs = [
     ...new Set([
@@ -73,7 +83,8 @@ export function checkPrivateSurfaceReadGuard(options: {
   ]
   if (deniedDirs.length === 0 && deniedFiles.length === 0) return undefined
 
-  for (const candidate of collectPathCandidates(args, tool)) {
+  const nonFile = fileOperands?.nonFile === undefined ? undefined : new Set(fileOperands.nonFile)
+  for (const candidate of collectPathCandidates(args, tool, nonFile)) {
     const hit = matchHidden(candidate, agentDir, deniedDirs, deniedFiles)
     if (hit !== undefined) {
       return {
@@ -166,14 +177,32 @@ function trimmedFileUri(value: string): string | undefined {
 // propagates so nested values under an exempt key (e.g. a structured pattern)
 // stay exempt; top-level strings and array elements carry no key and are always
 // scanned (so attachments[].path is collected).
-function collectPathCandidates(value: unknown, tool: string): string[] {
+//
+// `nonFile` holds the tool author's declared control-token operand PATHS
+// (`fileOperands.nonFile`, trusted metadata). A string at exactly one of those
+// operand paths is skipped, mirroring the file-operand scanner so the two
+// enforcement points agree — an id like `{ tenant: "memory" }` on a tool that
+// declared `nonFile: ['tenant']` is not blocked here. Scoped by EXACT operand
+// path (not key name), so an undeclared key still fails closed; `input`/
+// `output`/`destructive` are deliberately NOT honored (a declared real-file path
+// that resolves under a hidden dir must still block).
+function collectPathCandidates(value: unknown, tool: string, nonFile?: ReadonlySet<string>): string[] {
   const out: string[] = []
-  walk(value, out, tool, false)
+  walk(value, out, tool, false, nonFile, '')
   return out
 }
 
-function walk(value: unknown, out: string[], tool: string, underExempt: boolean, key?: string): void {
+function walk(
+  value: unknown,
+  out: string[],
+  tool: string,
+  underExempt: boolean,
+  nonFile: ReadonlySet<string> | undefined,
+  operandPath: string,
+  key?: string,
+): void {
   if (typeof value === 'string') {
+    if (nonFile?.has(operandPath) === true) return
     const isFileUrl = trimmedFileUri(value) !== undefined
     if (underExempt && !isPathKey(key) && !isFileUrl) return
     const normalized = normalizeCandidate(value)
@@ -181,14 +210,15 @@ function walk(value: unknown, out: string[], tool: string, underExempt: boolean,
     return
   }
   if (Array.isArray(value)) {
-    for (const item of value) walk(item, out, tool, underExempt, key)
+    for (const item of value) walk(item, out, tool, underExempt, nonFile, operandPath, key)
     return
   }
   if (value !== null && typeof value === 'object') {
     const toolFreeText = FREE_TEXT_KEYS_BY_TOOL[tool]
-    for (const [key, item] of Object.entries(value)) {
-      const keyIsExempt = NON_PATH_KEYS.has(key) || (toolFreeText?.has(key) ?? false)
-      walk(item, out, tool, underExempt || keyIsExempt, key)
+    for (const [childKey, item] of Object.entries(value)) {
+      const keyIsExempt = NON_PATH_KEYS.has(childKey) || (toolFreeText?.has(childKey) ?? false)
+      const childPath = operandPath === '' ? childKey : `${operandPath}.${childKey}`
+      walk(item, out, tool, underExempt || keyIsExempt, nonFile, childPath, childKey)
     }
   }
 }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -29,6 +29,13 @@ export type ToolFileOperands = {
   input?: readonly string[]
   output?: readonly string[]
   destructive?: readonly string[]
+  // Operand paths whose string values are control tokens or remote identifiers,
+  // never a local file — the file-operand scanner skips them (like a first-party
+  // prose operand) instead of rejecting a `word.ext`-shaped id or a value that
+  // collides with an agent-root dir name. Scoped per operand path and survives
+  // the runtime `__plugin_*` tool-name prefix that a static in-scanner table
+  // cannot. Declare a real file input under `input` (it gets pinned), not here.
+  nonFile?: readonly string[]
 }
 
 export type Tool<P = unknown> = {
@@ -218,6 +225,12 @@ export type ToolBeforeEvent = {
   callId: string
   args: Record<string, unknown>
   origin?: SessionOrigin
+  // The tool author's operand declarations (never model-controlled — set on the
+  // static Tool definition at registration). Carried so a guard that runs before
+  // the file-operand scanner (private-surface-read) can honor the same
+  // `nonFile` exemptions and not block a declared remote identifier that happens
+  // to collide with a hidden dir name. Present only for plugin tools.
+  fileOperands?: ToolFileOperands
 }
 
 export type ToolBeforeResult = void | undefined | { block: true; reason: string }


### PR DESCRIPTION
## Background

PR #1236 fixed `reload({scope:"cron"})`, but that was one instance of a systemic class. The file-operand scanner (`src/agent/tool-file-safety.ts`) rejects any *undeclared* string argument that looks like a local path, and a large set of first-party tools pass **control tokens or remote identifiers** that trip its heuristics:

- **`word.ext` rule** — a Slack message/thread `ts` is *always* `epoch.micros` (`1699999999.000100`), and a role capability is always `domain.action` (`channel.respond`).
- **path-separator rule** — a GitHub repo slug is always `owner/repo`; a base64 pagination cursor carries `/`.
- **fs-existence probe** — an id equal to an agent-root dir (`memory`, `workspace`, `sessions`) resolves to a real path.

I hunted for every instance (probing the live scanner against a temp agent dir with real `cron/`, `memory/`, … dirs). The highest-impact ones are **100% broken, not edge cases**:

- **`channel_read(mode:"message")` / `channel_edit` on Slack** — every Slack message/thread id has the `ts` shape → rejected on every call.
- **`reviewer_checkout`** — `repoSlug` is always `owner/repo` → rejected on every call (likely the reviewer-checkout regression seen in the field).

Also reachable: `channel_read`/`channel_history` cursors, `channel_react` custom emoji (`party.parrot`), `stream_snapshot.target_id`, `grant_role.match`/`permission`, `spawn_subagent.subagent_type`, `subagent_cancel`/`subagent_output.task_id`, `look_at_channel_attachment.prompt`, and the memory tools (`memory_search.topic`, `memory_append.topic`/`body`, `store_reference.title`).

A second guard, `private-surface-read`, independently resolves these same id args as paths, so a fix in only the scanner would still leave `channel_read({workspace:"memory"})` blocked there.

## Summary

Three complementary fixes, keeping the scanner **fail-closed for unknown readers**:

1. **`TOOLS_WITHOUT_LOCAL_FILE_OPERANDS`** — first-party tools that dereference *no* argument as a local path get a whole-tool early return. Whole-tool is sturdier than per-operand entries because these schemas keep gaining id/enum fields, and every such field hits the same false positives. It lives in its own **leaf module** so the scanner and the `private-surface-read` guard — which import each other — can both read it without a circular-init TDZ, and **both share the one set** so an id equal to a hidden dir isn't cleared by one guard and blocked by the other. This subsumes the per-operand `reload`/`grant_role`/`stream_snapshot`/`spawn_subagent`/`channel_edit` entries added in #1236.
2. **`isSemanticGenericString` accepts a `repoSlug` key** with the same strict `owner/repo` grammar as `repository`. Traversal, extra segments, absolute paths, and `file:` URIs still reject.
3. **`fileOperands.nonFile`** — a new plugin-contract field letting a plugin/MCP tool declare an operand as a control token/identifier. Unlike a static in-scanner table it survives the runtime `__plugin_*` tool-name prefix that subagent custom tools get, and it stays scoped by exact operand path. The memory tools use it; `find_entry.path` is a *real* file so it declares `fileOperands.input` (pinned, not exempted).

**Why not gate the `word.ext`/fs-probe rules to file-shaped keys?** That's the tempting root-cause fix, but it fails open: an undeclared reader could then read `{ id: "package.json" }` or `{ value: "memory" }` with no declaration. Consistent with #1236, first-party false positives are resolved by *positive knowledge of tool schemas*, never by weakening the unknown-tool default. (Consulted the Oracle on this trade-off.)

## What this does NOT do

- Does not weaken the `word.ext` rule or the fs-existence probe — undeclared plugin/MCP readers still fail closed exactly as before (covered by tests).
- Does not broadly unify the two guards' exemption systems — only the tool-level set is shared; `private-surface-read`'s key-name free-text list stays separate (unifying it would weaken the undeclared-reader scan).
- Does not touch the **other** over-broad guards surfaced during the audit (`secret-exfil-bash` regex over-matching `.config/**/token`, `session-search-secrets` blocking any query containing "password"/"token"). Those are a different classifier class (regex over-match on bash/search text) with a different threat model — deferred to separate PRs.

## Review notes

- **Load-bearing:** the shared `TOOLS_WITHOUT_LOCAL_FILE_OPERANDS` set and the invariant that a tool is added there *only* if it dereferences no argument as a local path. The leaf-module placement is deliberate — importing the set from `tool-file-safety` into `private-surface-read` reintroduces a circular-init TDZ (a test proved this before the module was extracted).
- **`nonFile` is a new plugin-contract field**, so this is a **minor**-worthy public-surface addition.
- Tests exercise the *real* scanner (`enforceAndPinToolFiles`) and the *real* guard (`checkPrivateSurfaceReadGuard`), not just internals:
  - identifier-only tools accept Slack `ts`, `/`-cursors, and dir-colliding ids; an unknown tool with the same args still fails closed.
  - `repoSlug` owner/repo passes; traversal/absolute reject.
  - `fileOperands.nonFile` exempts declared operands but stays tool+path scoped; a declared real-file `input` is pinned.
  - a drift-fence test asserts `private-surface-read` honors the shared set.
  - whole-tool and repoSlug fixes were red-green verified (tests fail without the change).
- Full suite green (11476 pass / 0 fail), typecheck/lint(0 errors)/format:check clean.
