### PR TITLE
fix(compose): stop composeStop test from shelling out to real Docker

### DIFF
--- a/src/compose/stop.test.ts
+++ b/src/compose/stop.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { Controller } from '@/container'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 
 import { composeStop, type ComposeStopEvent } from './stop'
@@ -17,12 +18,29 @@ afterEach(async () => {
   await rmTempDir(root)
 })
 
-// Malformed JSON so validateConfig short-circuits before real Docker calls;
-// see src/compose/start.test.ts for the full rationale.
 async function makeAgent(parent: string, name: string): Promise<void> {
+  await writeAgent(parent, name, '{}\n')
+}
+
+async function makeMalformedAgent(parent: string, name: string): Promise<void> {
+  await writeAgent(parent, name, 'this is not json\n')
+}
+
+async function writeAgent(parent: string, name: string, config: string): Promise<void> {
   const dir = join(parent, name)
   await mkdir(dir, { recursive: true })
-  await writeFile(join(dir, 'typeclaw.json'), 'this is not json\n')
+  await writeFile(join(dir, 'typeclaw.json'), config)
+}
+
+// Replaces the real Docker shell-out so these tests stay deterministic; records
+// each cwd it saw for the composition assertions.
+function fakeStop(): { stop: Controller['stop']; cwds: string[] } {
+  const cwds: string[] = []
+  const stop: Controller['stop'] = async ({ cwd }) => {
+    cwds.push(cwd)
+    return { ok: true, containerName: 'x', running: false }
+  }
+  return { stop, cwds }
 }
 
 describe('composeStop events', () => {
@@ -30,13 +48,12 @@ describe('composeStop events', () => {
     await makeAgent(root, 'alpha')
     await makeAgent(root, 'bravo')
 
+    const { stop, cwds } = fakeStop()
     const events: ComposeStopEvent[] = []
-    const { results } = await composeStop({
-      rootCwd: root,
-      onProgress: (event) => events.push(event),
-    })
+    const { results } = await composeStop({ rootCwd: root, onProgress: (event) => events.push(event) }, { stop })
 
     expect(results).toHaveLength(2)
+    expect(new Set(cwds)).toEqual(new Set([join(root, 'alpha'), join(root, 'bravo')]))
 
     const starts = events.filter((e) => e.kind === 'agent-start').map((e) => e.name)
     const dones = events.filter((e) => e.kind === 'agent-done').map((e) => e.name)
@@ -47,11 +64,9 @@ describe('composeStop events', () => {
   test('agent-start precedes agent-done for each agent name', async () => {
     await makeAgent(root, 'solo')
 
+    const { stop } = fakeStop()
     const events: ComposeStopEvent[] = []
-    await composeStop({
-      rootCwd: root,
-      onProgress: (event) => events.push(event),
-    })
+    await composeStop({ rootCwd: root, onProgress: (event) => events.push(event) }, { stop })
 
     const startIdx = events.findIndex((e) => e.kind === 'agent-start' && e.name === 'solo')
     const doneIdx = events.findIndex((e) => e.kind === 'agent-done' && e.name === 'solo')
@@ -62,11 +77,9 @@ describe('composeStop events', () => {
   test('agent-done carries the same AgentResult as the returned results', async () => {
     await makeAgent(root, 'alpha')
 
+    const { stop } = fakeStop()
     const events: ComposeStopEvent[] = []
-    const { results } = await composeStop({
-      rootCwd: root,
-      onProgress: (event) => events.push(event),
-    })
+    const { results } = await composeStop({ rootCwd: root, onProgress: (event) => events.push(event) }, { stop })
 
     const done = events.find((e) => e.kind === 'agent-done')
     expect(done).toBeDefined()
@@ -74,12 +87,47 @@ describe('composeStop events', () => {
     expect(done.result).toEqual(results[0]!)
   })
 
+  // The cleanup contract: a corrupted typeclaw.json must NOT stop composeStop
+  // from reaching the controller, or a broken config strands a container. This
+  // locks it in so a future validateConfig short-circuit (as start/restart have)
+  // fails here instead of silently regressing the contract.
+  test('stops an agent whose typeclaw.json is malformed (no config guard)', async () => {
+    await makeMalformedAgent(root, 'broken')
+
+    const { stop, cwds } = fakeStop()
+    const { results } = await composeStop({ rootCwd: root }, { stop })
+
+    expect(cwds).toEqual([join(root, 'broken')])
+    expect(results).toEqual([{ name: 'broken', ok: true, data: { ok: true, containerName: 'x', running: false } }])
+  })
+
+  test('maps a controller failure to a failed AgentResult', async () => {
+    await makeAgent(root, 'alpha')
+
+    const stop: Controller['stop'] = async () => ({ ok: false, reason: 'docker down' })
+    const { results } = await composeStop({ rootCwd: root }, { stop })
+
+    expect(results).toEqual([{ name: 'alpha', ok: false, reason: 'docker down' }])
+  })
+
+  test('maps a thrown controller error to a failed AgentResult', async () => {
+    await makeAgent(root, 'alpha')
+
+    const stop: Controller['stop'] = async () => {
+      throw new Error('boom')
+    }
+    const { results } = await composeStop({ rootCwd: root }, { stop })
+
+    expect(results).toEqual([{ name: 'alpha', ok: false, reason: 'boom' }])
+  })
+
   test('emits no events when no agents are discovered', async () => {
+    const { stop } = fakeStop()
     const events: ComposeStopEvent[] = []
-    const { agents, results } = await composeStop({
-      rootCwd: root,
-      onProgress: (event) => events.push(event),
-    })
+    const { agents, results } = await composeStop(
+      { rootCwd: root, onProgress: (event) => events.push(event) },
+      { stop },
+    )
 
     expect(agents).toEqual([])
     expect(results).toEqual([])
@@ -88,7 +136,8 @@ describe('composeStop events', () => {
 
   test('runs without onProgress', async () => {
     await makeAgent(root, 'alpha')
-    const { results } = await composeStop({ rootCwd: root })
+    const { stop } = fakeStop()
+    const { results } = await composeStop({ rootCwd: root }, { stop })
     expect(results).toHaveLength(1)
   })
 })

--- a/src/compose/stop.ts
+++ b/src/compose/stop.ts
@@ -1,4 +1,4 @@
-import { resolveController, type StopResult } from '@/container'
+import { type Controller, resolveController, type StopResult } from '@/container'
 
 import { discoverAgents, type AgentEntry } from './discover'
 import type { AgentResult } from './start'
@@ -14,17 +14,29 @@ export type ComposeStopOptions = {
   onProgress?: (event: ComposeStopEvent) => void
 }
 
+// Injectable so tests drive orchestration without real Docker. Note the
+// deliberate absence of the validateConfig guard that composeStart/Restart
+// have: container identity derives from cwd, not a valid typeclaw.json, so a
+// corrupted config must never block cleanup or a broken config strands a
+// container that can only be removed by hand.
+export type ComposeStopDeps = {
+  stop?: Controller['stop']
+}
+
 export type ComposeStopResult = {
   agents: AgentEntry[]
   results: AgentResult<StopSuccess>[]
 }
 
-export async function composeStop({ rootCwd, onProgress }: ComposeStopOptions): Promise<ComposeStopResult> {
+export async function composeStop(
+  { rootCwd, onProgress }: ComposeStopOptions,
+  { stop = (options) => resolveController().stop(options) }: ComposeStopDeps = {},
+): Promise<ComposeStopResult> {
   const agents = discoverAgents(rootCwd)
   const results = await Promise.all(
     agents.map(async (agent): Promise<AgentResult<StopSuccess>> => {
       onProgress?.({ kind: 'agent-start', name: agent.name })
-      const result = await runOne(agent.name, agent.cwd)
+      const result = await runOne(agent.name, agent.cwd, stop)
       onProgress?.({ kind: 'agent-done', name: agent.name, result })
       return result
     }),
@@ -32,9 +44,9 @@ export async function composeStop({ rootCwd, onProgress }: ComposeStopOptions): 
   return { agents, results }
 }
 
-async function runOne(name: string, cwd: string): Promise<AgentResult<StopSuccess>> {
+async function runOne(name: string, cwd: string, stop: Controller['stop']): Promise<AgentResult<StopSuccess>> {
   try {
-    const data = await resolveController().stop({ cwd })
+    const data = await stop({ cwd })
     if (!data.ok) return { name, ok: false, reason: data.reason }
     return { name, ok: true, data }
   } catch (error) {


### PR DESCRIPTION
## Background

The `composeStop events > emits agent-start then agent-done for every discovered agent` test flakes on the Windows CI job (`windows checks`), timing out after 30 000 ms ([run 29510636323](https://github.com/typeclaw/typeclaw/actions/runs/29510636323/job/87662862012)). It passes on Linux and locally, which is what made it look flaky rather than broken.

The root cause is not timing — it's a real Docker shell-out the test never intended to make. `composeStop` calls `resolveController().stop({ cwd })`, and `container/stop.ts`'s `stop()` shells out to the real Docker CLI: `docker inspect`, then on a non–"no such container" error it falls into the `docker rm -f` + `waitForRemoval` recovery path, which polls `docker inspect` for up to 10 s. On the Windows runner `docker.exe` resolves but the daemon is down/slow, so every probe errors into that 10 s recovery path — and with two agents (`alpha`, `bravo`) running under `Promise.all`, the wall-clock blows past the 30 s test budget.

The test *thought* it was avoiding Docker by writing a malformed `typeclaw.json`. That trick only works for `composeStart`/`composeRestart`, whose `runOne` calls `validateConfig(cwd)` and returns early on invalid JSON before any Docker call. `composeStop.runOne` has no such guard, so the malformed-JSON comment there was simply wrong — the stop path reached real Docker every time.

## Summary

`composeStop` now takes a narrow, injectable `stop` dependency (`ComposeStopDeps.stop`), defaulting to `resolveController().stop`. The test injects a deterministic fake and asserts discovery, orchestration, and event/result propagation with zero real-Docker dependency. This mirrors the functional-DI convention already used elsewhere (e.g. `cli/status.ts`'s `deps.preflight`, and `container/stop.ts`'s own injectable `exec`).

**Why inject a dep and not add a `validateConfig` guard like start/restart?** Because skipping stop on invalid config would be *wrong product behavior*. A container's identity derives from its `cwd`, not from a valid `typeclaw.json`, so a corrupted config must never block cleanup — otherwise a broken config strands a container that can only be removed by hand. The asymmetry with start/restart is intentional and now documented at the type.

Production behavior is unchanged: the default still resolves and calls the real controller, and `cli/compose.ts` (which runs `requireDockerOrExit()` before `composeStop`) needs no change.

## What this does NOT do

- Does not touch `composeStart`/`composeRestart` — their `validateConfig` short-circuit is legitimate start-time behavior and their tests are already Docker-free for the right reason.
- Does not change `container/stop.ts` or any production stop semantics.
- Does not add a `validateConfig` guard to `composeStop` (see rationale above).

## Review notes

- Load-bearing change: `composeStop({ ... }, { stop = resolveController().stop })`. Verify the default still routes to the real controller so production is untouched.
- The new tests also cover the failure and thrown-error mapping paths in `runOne`, which were previously unreachable because the real Docker path couldn't be steered.
- The comment on `ComposeStopDeps` intentionally documents *why* there's no `validateConfig` guard here — please keep it; it's the guard against a future "symmetry fix" that would re-introduce the container-stranding bug.
