### PR TITLE
fix(channels): catch JSON-object serialized tool-call leaks

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -5026,6 +5026,49 @@ describe('ChannelRouter channel-turn protocol', () => {
     expect(logs.some((m) => m.includes('recovering assistant_text_without_channel_tool'))).toBe(false)
   })
 
+  test('suppresses a fenced JSON-object skip_response leak instead of posting it (solar-open2 shape)', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'hello' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText(
+        '```json\n{\n  "method": "skip_response",\n  "params": {\n    "reason": "not addressed to me"\n  }\n}\n```',
+      )
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(0)
+    expect(logs.some((m) => m.includes('suppressed plain_text_tool_call_leak (silent)'))).toBe(true)
+  })
+
+  test('recovers the user text from a JSON-object channel_reply leak', async () => {
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: Array<{ text: string }> = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push({ text: msg.text ?? '' })
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'say hi' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.setAssistantText('{"method":"channel_reply","params":{"text":"hi there"}}')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.text).toBe('hi there')
+    expect(sent[0]!.text).not.toContain('method')
+  })
+
   test('posts only the prose when a real reply is followed by a trailing skip_response leak', async () => {
     const dir = await tempDir()
     const logs: string[] = []
@@ -5214,6 +5257,79 @@ describe('ChannelRouter channel-turn protocol', () => {
       expect(getPlainTextChannelToolCallKind('read({ path: "x" }) loads a file for you')).toBeNull()
       expect(getPlainTextChannelToolCallKind('You can use bash("ls") to list files')).toBeNull()
       expect(getPlainTextChannelToolCallKind('channel_disengagement is the noun')).toBeNull()
+    })
+
+    // The JSON-RPC-object serialization shape observed against `solar-open2`
+    // (Upstage): the whole message is `{"method":"<tool>","params":{...}}`,
+    // not a `tool(...)` call expression, so it slips past the call-expression
+    // parser. It routes through the SAME name->kind disposition.
+    test('suppresses a bare JSON-object skip_response leak SILENTLY', () => {
+      expect(getPlainTextChannelToolCallKind('{"method":"skip_response","params":{"reason":"not for me"}}')).toBe(
+        'suppress-silent',
+      )
+    })
+
+    test('suppresses a FENCED JSON-object skip_response leak SILENTLY (the reported shape)', () => {
+      const leak =
+        '```json\n{\n  "method": "skip_response",\n  "params": {\n    "reason": "not addressed to me"\n  }\n}\n```'
+      expect(getPlainTextChannelToolCallKind(leak)).toBe('suppress-silent')
+    })
+
+    test('suppresses a plain-fenced JSON-object skip_response leak SILENTLY', () => {
+      const leak = '```\n{"method":"skip_response","params":{"reason":"x"}}\n```'
+      expect(getPlainTextChannelToolCallKind(leak)).toBe('suppress-silent')
+    })
+
+    test('recovers JSON-object channel_reply/channel_send serializations', () => {
+      expect(getPlainTextChannelToolCallKind('{"method":"channel_reply","params":{"text":"hi"}}')).toBe('reply')
+      expect(getPlainTextChannelToolCallKind('{"method":"channel_send","params":{"text":"hi"}}')).toBe('send')
+    })
+
+    test('suppresses every OTHER JSON-object tool call with a WARN', () => {
+      expect(getPlainTextChannelToolCallKind('{"method":"channel_react","params":{"emoji":"eyes"}}')).toBe(
+        'suppress-warn',
+      )
+      expect(getPlainTextChannelToolCallKind('{"method":"bash","params":{"cmd":"ls -la"}}')).toBe('suppress-warn')
+    })
+
+    test('requires EXACTLY method + params keys (a real JSON reply the user asked for is delivered)', () => {
+      // A canonical JSON-RPC frame carries extra keys (`jsonrpc`, `id`); a
+      // user-requested JSON document has arbitrary keys. Neither is the leak
+      // shape, so both reach the user.
+      expect(
+        getPlainTextChannelToolCallKind('{"jsonrpc":"2.0","method":"skip_response","params":{"reason":"x"},"id":1}'),
+      ).toBeNull()
+      expect(getPlainTextChannelToolCallKind('{"method":"skip_response","params":{},"extra":true}')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('{"method":"skip_response"}')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('{"name":"skip_response","arguments":{}}')).toBeNull()
+    })
+
+    test('requires an object-shaped params and identifier-shaped method', () => {
+      expect(getPlainTextChannelToolCallKind('{"method":"skip_response","params":null}')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('{"method":"skip_response","params":[1,2]}')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('{"method":"","params":{}}')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('{"method":"has space","params":{}}')).toBeNull()
+    })
+
+    test('leaves malformed JSON and JSON embedded in prose untouched', () => {
+      expect(getPlainTextChannelToolCallKind('{"method":"skip_response","params":{')).toBeNull()
+      expect(
+        getPlainTextChannelToolCallKind('here is one: {"method":"skip_response","params":{"reason":"x"}}'),
+      ).toBeNull()
+      expect(
+        getPlainTextChannelToolCallKind('{"method":"skip_response","params":{"reason":"x"}} is the shape'),
+      ).toBeNull()
+    })
+
+    test('handles a CRLF-newline fenced JSON leak', () => {
+      const leak = '```json\r\n{"method":"skip_response","params":{"reason":"x"}}\r\n```'
+      expect(getPlainTextChannelToolCallKind(leak)).toBe('suppress-silent')
+    })
+
+    test('does NOT unwrap tilde fences, 4+ backtick runs, or foreign language tags', () => {
+      expect(getPlainTextChannelToolCallKind('~~~\n{"method":"skip_response","params":{}}\n~~~')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('````\n{"method":"skip_response","params":{}}\n````')).toBeNull()
+      expect(getPlainTextChannelToolCallKind('```python\n{"method":"skip_response","params":{}}\n```')).toBeNull()
     })
   })
 
@@ -5508,6 +5624,43 @@ describe('ChannelRouter channel-turn protocol', () => {
 
     test('returns null when "text" exists only inside a nested object', () => {
       expect(extractPlainTextChannelToolCallText('channel_reply({ meta: { text: "only nested" } })')).toBeNull()
+    })
+
+    test('recovers params.text from a bare JSON-object reply/send serialization', () => {
+      expect(extractPlainTextChannelToolCallText('{"method":"channel_reply","params":{"text":"hi there"}}')).toBe(
+        'hi there',
+      )
+      expect(extractPlainTextChannelToolCallText('{"method":"channel_send","params":{"chat":"c1","text":"hi"}}')).toBe(
+        'hi',
+      )
+    })
+
+    test('recovers params.text from a FENCED JSON-object reply serialization', () => {
+      const leak = '```json\n{\n  "method": "channel_reply",\n  "params": {\n    "text": "hello world"\n  }\n}\n```'
+      expect(extractPlainTextChannelToolCallText(leak)).toBe('hello world')
+    })
+
+    test('recovers a non-Latin params.text (multi-language)', () => {
+      expect(extractPlainTextChannelToolCallText('{"method":"channel_reply","params":{"text":"확인해볼게요"}}')).toBe(
+        '확인해볼게요',
+      )
+    })
+
+    test('returns null for a JSON reply/send whose params carries no usable text', () => {
+      expect(extractPlainTextChannelToolCallText('{"method":"channel_reply","params":{"reason":"nope"}}')).toBeNull()
+      expect(extractPlainTextChannelToolCallText('{"method":"channel_reply","params":{"text":"  "}}')).toBeNull()
+    })
+
+    test('returns null for a JSON skip_response (no salvageable user text)', () => {
+      expect(extractPlainTextChannelToolCallText('{"method":"skip_response","params":{"reason":"x"}}')).toBeNull()
+    })
+
+    test('ignores an inherited (non-own) text property on the JSON params', () => {
+      // A `__proto__` payload must not surface `Object.prototype.text` as recovered
+      // channel output — only an OWN `text` property is recoverable.
+      expect(
+        extractPlainTextChannelToolCallText('{"method":"channel_reply","params":{"__proto__":{"text":"pollution"}}}'),
+      ).toBeNull()
     })
   })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -6929,8 +6929,9 @@ export function getPlainTextChannelToolCallKind(text: string): PlainTextChannelT
   // dropping the explanation. `isWholeMessageToolCall` returns the tool name
   // only when the entire trimmed message is the call (or a truncated one), so a
   // reply/send leak still recovers while a mention-with-trailing-prose falls
-  // through to the user.
-  const toolName = isWholeMessageToolCall(text)
+  // through to the user. The JSON-object serialization shape (see
+  // `parseWholeMessageJsonToolCall`) feeds the SAME name->kind mapping below.
+  const toolName = isWholeMessageToolCall(text) ?? parseWholeMessageJsonToolCall(text)?.toolName ?? null
   if (toolName === null) return null
   if (toolName === 'channel_reply') return 'reply'
   if (toolName === 'channel_send') return 'send'
@@ -6984,6 +6985,74 @@ export function isWholeMessageToolCall(text: string): string | null {
   const rest = trimmed.slice(i + 1).trim()
   if (rest === '' || rest === ';') return name
   return null
+}
+
+export type JsonToolCallLeak = { toolName: string; params: Record<string, unknown> }
+
+const JSON_TOOL_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+// Detects the JSON-RPC-object serialization of a leaked tool call — the sibling
+// of `isWholeMessageToolCall`'s call-expression shape. Observed against
+// `solar-open2` (Upstage) on channel deployments: the entire assistant message
+// body is the object `{"method":"<tool>","params":{...}}`, optionally wrapped in
+// a single ```json (or bare ```) fence, so the call-expression parser (which
+// requires `identifier(`) never fires and the plumbing ships verbatim.
+//
+// The boundary is deliberately STRICT because a legitimate reply that IS this
+// exact object is byte-for-byte indistinguishable from a leak — the tightest
+// practical rule keeps that false positive to the narrowest possible shape:
+//   1. the fenced-or-bare object is the ENTIRE trimmed message (nothing before
+//      or after the single optional fence), parsed by strict `JSON.parse` so
+//      truncated/malformed serializations are NOT treated as leaks;
+//   2. the parsed value is a plain object whose own top-level keys are EXACTLY
+//      `method` and `params` — a canonical JSON-RPC frame (`jsonrpc`/`id`) or a
+//      user-requested JSON document carries extra keys and falls through;
+//   3. `method` is a non-empty identifier-shaped string (the tool grammar), and
+//      `params` is a non-null, non-array object.
+// A match returns the tool name so the caller reuses the existing name->kind
+// disposition (reply/send recover, skip_response silent, else warn).
+export function parseWholeMessageJsonToolCall(text: string): JsonToolCallLeak | null {
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim()
+  const body = stripSingleWholeMessageJsonFence(normalized)
+  if (body === null) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null
+
+  const keys = Object.keys(parsed)
+  if (keys.length !== 2 || !keys.includes('method') || !keys.includes('params')) return null
+
+  const record = parsed as Record<string, unknown>
+  const method = record.method
+  if (typeof method !== 'string' || !JSON_TOOL_NAME_RE.test(method)) return null
+
+  const params = record.params
+  if (typeof params !== 'object' || params === null || Array.isArray(params)) return null
+
+  return { toolName: method, params: params as Record<string, unknown> }
+}
+
+// Unwraps a single whole-message ```` ``` ```` or ```` ```json ```` fence around
+// a JSON object, returning the inner body, or the input unchanged when there is
+// no fence. Returns null when a fence opens but the message is not JUST that one
+// fenced block (leading/trailing prose, unterminated fence) so a fenced example
+// embedded in prose is never mistaken for the whole-message shape. The opener is
+// held to EXACTLY three backticks with an optional lowercase `json` info string —
+// tilde fences, longer runs, and other language tags stay out of the boundary so
+// the false-positive surface matches only the reported production shape.
+function stripSingleWholeMessageJsonFence(trimmed: string): string | null {
+  if (!trimmed.startsWith('```')) return trimmed
+
+  const open = /^```(json)?\n/.exec(trimmed)
+  if (open === null) return null
+  const close = /\n```$/.exec(trimmed)
+  if (close === null || close.index < open[0].length) return null
+  return trimmed.slice(open[0].length, close.index)
 }
 
 export type TrailingToolCallLeak = { text: string; toolName: string; leakedCall: string }
@@ -7223,6 +7292,14 @@ function columnWidth(s: string): number {
 // model-supplied destination. Returns null when no recoverable, non-empty
 // `text` value is present so the caller can fall back to suppression.
 export function extractPlainTextChannelToolCallText(text: string): string | null {
+  const jsonCall = parseWholeMessageJsonToolCall(text)
+  if (jsonCall !== null) {
+    if (jsonCall.toolName !== 'channel_reply' && jsonCall.toolName !== 'channel_send') return null
+    if (!Object.hasOwn(jsonCall.params, 'text')) return null
+    const value = jsonCall.params.text
+    return typeof value === 'string' && value.trim().length > 0 ? value : null
+  }
+
   const trimmed = text.trim()
   if (!/^(?:channel_reply|channel_send)\s*\(/.test(trimmed)) return null
 


### PR DESCRIPTION
## Background

The channel router's plain-text tool-call-leak guard (`src/channels/router.ts`) exists to catch cases where the model serializes an internal tool call as visible message text instead of emitting a real tool call — so the plumbing never reaches Slack/Discord/KakaoTalk/etc. Before this PR it recognized only two shapes: the call-expression form `skip_response({...})` (`isWholeMessageToolCall`), and the Kimi delimiter form `<|tool_call_begin|>...` (`isLikelyKimiChannelToolLeak`).

A production leak was reported (Slack thread) from `solar-open2` (Upstage), which serializes a leaked tool call as a JSON-RPC-style object instead — the entire assistant message body was, fenced in a json code block:

```json
{"method":"skip_response","params":{"reason":"..."}}
```

This shape has no Kimi delimiters and isn't an `identifier(...)` call expression, so every existing detector missed it and the raw JSON shipped straight to the channel — confirming to probing users it's a bot and exposing an internal tool name, the exact opposite of the intended silent no-op.

## Summary

- New `parseWholeMessageJsonToolCall(text)` returns `{ toolName, params } | null`, composed into the existing `getPlainTextChannelToolCallKind` via `isWholeMessageToolCall(text) ?? parseWholeMessageJsonToolCall(text)?.toolName`. This reuses the existing name->kind disposition unchanged: `channel_reply`/`channel_send` recover their user text (now from `params.text`), `skip_response` suppresses silently (no nudge — the model already got the silence it wanted), every other tool suppresses with a bounded self-correction nudge.
- `extractPlainTextChannelToolCallText` learns to pull `params.text` (own-property only) from the JSON reply/send shape.

**Why a separate JSON parser composed into the same disposition, and not broadening `isWholeMessageToolCall` or forking a second disposition function:** keeps `isWholeMessageToolCall` narrowly about call expressions (including its truncated-call handling), and avoids drifting/duplicating the name->kind mapping. Both serialization formats feed one mapping.

**Why the boundary is strict (the load-bearing safety decision):** a legitimate reply that IS exactly `{"method":"x","params":{...}}` is byte-for-byte indistinguishable from a leak — that false positive can't be eliminated structurally, so the rule is drawn as tight as possible: the fenced-or-bare object must be the entire trimmed message; strict `JSON.parse` (so truncated/malformed serializations are NOT treated as leaks — the opposite bias from the call-expression parser, which treats truncation AS a leak, because a broken JSON doc is more likely a real partial reply); the parsed object's own top-level keys must be exactly `method` + `params` (a canonical JSON-RPC frame carrying `jsonrpc`/`id`, or a user-requested JSON document with other keys, falls through to the user); `method` must be an identifier-shaped string; `params` must be a non-null non-array object.

**Why only bare and json triple-backtick fences are unwrapped (not `~~~`, not 4+ backtick runs, not other language tags):** narrowing the fence keeps the false-positive surface to exactly the reported production shape.

**Why `params.text` recovery uses an own-property check (`Object.hasOwn`):** a `__proto__` payload must not surface `Object.prototype.text` as recovered channel output.

CRLF is normalized before fence parsing so a `\r\n`-fenced leak is still caught.

## What this does NOT do

- No trailing-JSON-block stripping (the analog of the existing `stripTrailingLeakedToolCall` for call expressions) — only the reported whole-message shape is covered in v1; widen only if a "prose then trailing JSON block" leak is observed.
- Does not add support for omitted `params`, canonical JSON-RPC `jsonrpc`/`id` keys, or truncated JSON — each materially expands collisions with legitimate developer-facing JSON and needs independent justification.
- Does not touch the Kimi or call-expression detectors, or the recovery/suppression wiring in `validateChannelTurn` beyond feeding them the new shape.

## Review notes

- Load-bearing change: the strict predicate in `parseWholeMessageJsonToolCall` (exactly `method`+`params` own keys, object `params`, identifier `method`) and the single-fence unwrap in `stripSingleWholeMessageJsonFence`. The invariant to verify: a legitimate user-facing JSON reply with any extra top-level key, a tilde/long/foreign-tag fence, or malformed/truncated JSON must all still reach the user.
- Design was reviewed by an internal reasoning pass (strict-parse, own-property `params.text`, CRLF normalization, and fence-narrowing were all applied from that review).
- Tests: unit coverage for both bare and fenced forms, all four dispositions (reply/send/suppress-silent/suppress-warn), recovery incl. a non-Latin `params.text` (multi-language repo rule), the exact-keys boundary, prototype-pollution defense, CRLF, and rejected fence variants; plus end-to-end router tests asserting the fenced skip_response leak is suppressed and a JSON channel_reply is recovered. Full suite green (0 fail).