### PR TITLE
fix(subagent): stop a wedged child from hanging its parent forever

### DIFF
--- a/src/agent/live-subagents.test.ts
+++ b/src/agent/live-subagents.test.ts
@@ -212,6 +212,36 @@ describe('LiveSubagentRegistry', () => {
     reg.recordCompletion('bg_a', { ok: true, durationMs: 1 })
     expect(reg.hasLiveForSession('ses_x')).toBe(false)
   })
+
+  test('recordCompletionIfRunning: the first writer wins and returns true', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+    expect(reg.recordCompletionIfRunning('bg_t1', { ok: false, error: 'timeout', durationMs: 100 })).toBe(true)
+    expect(reg.get('bg_t1')?.status).toBe('failed')
+    expect(reg.get('bg_t1')?.completion?.error).toBe('timeout')
+  })
+
+  test('recordCompletionIfRunning: a second writer loses, returns false, and does NOT overwrite', () => {
+    const reg = new LiveSubagentRegistry()
+    reg.register(makeLive())
+
+    // given: the timeout path settled first
+    reg.recordCompletionIfRunning('bg_t1', { ok: false, error: 'timeout', durationMs: 100 })
+
+    // when: the real completion arrives afterwards
+    const won = reg.recordCompletionIfRunning('bg_t1', { ok: true, finalMessage: 'late success', durationMs: 200 })
+
+    // then: it loses and the first (timeout) outcome stays canonical
+    expect(won).toBe(false)
+    expect(reg.get('bg_t1')?.status).toBe('failed')
+    expect(reg.get('bg_t1')?.completion?.error).toBe('timeout')
+    expect(reg.get('bg_t1')?.completion?.finalMessage).toBeUndefined()
+  })
+
+  test('recordCompletionIfRunning: returns false for an unknown taskId', () => {
+    const reg = new LiveSubagentRegistry()
+    expect(reg.recordCompletionIfRunning('nope', { ok: true, durationMs: 1 })).toBe(false)
+  })
 })
 
 describe('snapshot.statusSummary rendering', () => {

--- a/src/agent/live-subagents.ts
+++ b/src/agent/live-subagents.ts
@@ -143,6 +143,24 @@ export class LiveSubagentRegistry {
     entry.status = completion.ok ? 'completed' : 'failed'
   }
 
+  // First-writer-wins settlement, returning whether THIS caller won. A subagent
+  // has two racing settlement producers — its real completion (spawn_subagent's
+  // `completion.then`) and the parent drain's timeout ceiling — and both must
+  // not overwrite each other's terminal state, or the registry/broadcast would
+  // disagree with a reminder already delivered. There is no `await` between the
+  // status check and the mutation, so under JS run-to-completion this compare-
+  // and-set is atomic: a promise `.then` producer that races in on a later
+  // microtask sees `status !== 'running'` and loses. Production settlement paths
+  // MUST use this, not the unconditional `recordCompletion` (which stays for
+  // tests that seed terminal state directly).
+  recordCompletionIfRunning(taskId: string, completion: SubagentCompletion): boolean {
+    const entry = this.entries.get(taskId)
+    if (entry === undefined || entry.status !== 'running') return false
+    entry.completion = completion
+    entry.status = completion.ok ? 'completed' : 'failed'
+    return true
+  }
+
   snapshot(taskId: string, now: number = Date.now()): StatusSnapshot | undefined {
     const entry = this.entries.get(taskId)
     if (entry === undefined) return undefined

--- a/src/agent/subagent-drain.test.ts
+++ b/src/agent/subagent-drain.test.ts
@@ -3,24 +3,66 @@ import { describe, expect, test } from 'bun:test'
 import { createStream } from '@/stream'
 
 import { LiveSubagentRegistry } from './live-subagents'
-import { beginSubagentDrainWatch, runSubagentDrain, type SubagentBackgroundDrain } from './subagent-drain'
+import {
+  beginSubagentDrainWatch,
+  runSubagentDrain,
+  type SubagentBackgroundDrain,
+  type TimerScheduler,
+} from './subagent-drain'
 
 const PARENT = 'ses_subagent'
+
+// A controllable timer scheduler: records set/clear so tests can assert
+// cancellation deterministically, and lets a test fire the pending timer by hand.
+function makeFakeScheduler(): TimerScheduler & {
+  setCount: () => number
+  clearCount: () => number
+  fire: () => void
+  hasPending: () => boolean
+} {
+  let pending: (() => void) | null = null
+  let handle = 0
+  let sets = 0
+  let clears = 0
+  return {
+    set: (fn) => {
+      sets++
+      pending = fn
+      return ++handle
+    },
+    clear: () => {
+      clears++
+      pending = null
+    },
+    setCount: () => sets,
+    clearCount: () => clears,
+    hasPending: () => pending !== null,
+    fire: () => {
+      const fn = pending
+      pending = null
+      fn?.()
+    },
+  }
+}
 
 function noopAbort(): Promise<void> {
   return Promise.resolve()
 }
 
-function registerChild(reg: LiveSubagentRegistry, taskId: string): void {
+function registerChild(
+  reg: LiveSubagentRegistry,
+  taskId: string,
+  opts?: { startedAt?: number; abort?: () => Promise<void> },
+): void {
   reg.register({
     taskId,
     sessionId: `ses_${taskId}`,
     subagentName: 'scout',
     parentSessionId: PARENT,
     background: true,
-    startedAt: 0,
+    startedAt: opts?.startedAt ?? 0,
     status: 'running',
-    abort: noopAbort,
+    abort: opts?.abort ?? noopAbort,
   })
 }
 
@@ -260,5 +302,278 @@ describe('runSubagentDrain — termination', () => {
     expect(prompts.length).toBe(1)
     expect(prompts[0]).toContain('FAILED')
     expect(prompts[0]).toContain('boom')
+  })
+})
+
+describe('runSubagentDrain — maxChildWaitMs (wedged-child ceiling)', () => {
+  test('expires a child that stays running past the ceiling, then terminates', async () => {
+    // given: a child that started at t=0 and never completes
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_wedged', { startedAt: 0 })
+
+    // when: the clock is already past the 5000ms ceiling
+    const watch = beginSubagentDrainWatch(drain)
+    const prompts: string[] = []
+    await runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 5000,
+      now: () => 6000,
+    })
+
+    // then: the wedged child is abandoned (FAILED reminder) and the loop returns
+    expect(prompts.length).toBe(1)
+    expect(prompts[0]).toContain('bg_wedged')
+    expect(prompts[0]).toContain('FAILED')
+    expect(reg.get('bg_wedged')?.status).toBe('failed')
+  })
+
+  test('aborts the wedged child when expiring it', async () => {
+    // given: a child whose abort we can observe
+    const { drain, reg } = makeDrain()
+    let aborted = false
+    registerChild(reg, 'bg_wedged', { startedAt: 0, abort: async () => void (aborted = true) })
+
+    // when
+    const watch = beginSubagentDrainWatch(drain)
+    await runSubagentDrain(watch, {
+      drain,
+      prompt: async () => {},
+      maxChildWaitMs: 5000,
+      now: () => 6000,
+    })
+
+    // then
+    expect(aborted).toBe(true)
+  })
+
+  test('does NOT expire a child still within the ceiling (parks on wakeup)', async () => {
+    // given: a child started at t=0, clock at 3000ms, ceiling 5000ms
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_young', { startedAt: 0 })
+
+    const watch = beginSubagentDrainWatch(drain)
+    const prompts: string[] = []
+    const done = runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 5000,
+      now: () => 3000,
+    })
+
+    // then: still running, not expired — no reminder yet
+    await new Promise((r) => setTimeout(r, 5))
+    expect(prompts).toEqual([])
+    expect(reg.get('bg_young')?.status).toBe('running')
+
+    // when: the child completes normally and wakes the loop
+    reg.recordCompletion('bg_young', { ok: true, durationMs: 3000 })
+    drain.stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'subagent.completed',
+        taskId: 'bg_young',
+        subagent: 'scout',
+        parentSessionId: PARENT,
+        ok: true,
+        durationMs: 3000,
+      },
+    })
+
+    await done
+    expect(prompts.length).toBe(1)
+    expect(prompts[0]).toContain('bg_young')
+    expect(prompts[0]).not.toContain('FAILED')
+  })
+
+  test('expires only the overdue child, leaving a healthy sibling to complete', async () => {
+    // given: one child wedged since t=0 and one that will complete normally
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_wedged', { startedAt: 0 })
+    registerChild(reg, 'bg_ok', { startedAt: 5000 })
+    reg.recordCompletion('bg_ok', { ok: true, durationMs: 100 })
+
+    // when: clock past the ceiling for bg_wedged but not bg_ok
+    const watch = beginSubagentDrainWatch(drain)
+    const prompts: string[] = []
+    await runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 5000,
+      now: () => 6000,
+    })
+
+    // then: both are delivered — ok as success, wedged as FAILED — and loop ends
+    expect(prompts.length).toBe(2)
+    expect(prompts.some((p) => p.includes('bg_ok') && !p.includes('FAILED'))).toBe(true)
+    expect(prompts.some((p) => p.includes('bg_wedged') && p.includes('FAILED'))).toBe(true)
+  })
+
+  test("still terminates when the wedged child's abort() never settles", async () => {
+    // given: a child whose abort hangs forever — awaiting it would wedge the drain
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_wedged', { startedAt: 0, abort: () => new Promise<void>(() => {}) })
+
+    // when: clock past the ceiling
+    const watch = beginSubagentDrainWatch(drain)
+    const prompts: string[] = []
+    await runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 5000,
+      now: () => 6000,
+    })
+
+    // then: the timeout was recorded and reminder delivered despite the hung abort
+    expect(prompts.length).toBe(1)
+    expect(prompts[0]).toContain('bg_wedged')
+    expect(prompts[0]).toContain('FAILED')
+    expect(reg.get('bg_wedged')?.status).toBe('failed')
+  })
+
+  test('a real completion racing the timeout does not double-settle (first writer wins)', async () => {
+    // given: the timeout path settles the child first (clock past the ceiling)
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_race', { startedAt: 0 })
+
+    const watch = beginSubagentDrainWatch(drain)
+    const prompts: string[] = []
+    await runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 5000,
+      now: () => 6000,
+    })
+
+    // when: the child's real (success) completion arrives afterwards
+    const late = reg.recordCompletionIfRunning('bg_race', { ok: true, durationMs: 6000, finalMessage: 'late' })
+
+    // then: it loses; the timeout outcome the model already saw stays canonical
+    expect(late).toBe(false)
+    expect(reg.get('bg_race')?.status).toBe('failed')
+    expect(prompts.length).toBe(1)
+    expect(prompts[0]).toContain('FAILED')
+  })
+
+  test('a timer expiry (no broadcast) wakes the loop and expires the child at the boundary', async () => {
+    // given: a fake scheduler so the expiry timer fires on demand — deterministic,
+    // no real clock. The child is within the ceiling at loop entry (clock=30 <
+    // deadline=50), so the loop parks on the expiry TIMER, not on a broadcast.
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_timer', { startedAt: 0 })
+    let clock = 30
+    const sched = makeFakeScheduler()
+
+    const watch = beginSubagentDrainWatch(drain, sched)
+    const prompts: string[] = []
+    const done = runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 50,
+      now: () => clock,
+    })
+
+    // the loop is parked on the expiry timer, no broadcast, no reminder yet
+    await Promise.resolve()
+    expect(sched.setCount()).toBeGreaterThan(0)
+    expect(prompts).toEqual([])
+
+    // when: the deadline passes and the timer fires (returns true); re-derive expires it
+    clock = 100
+    sched.fire()
+
+    // then: the timer-driven path (not a broadcast) drove expiry
+    await done
+    expect(prompts.length).toBe(1)
+    expect(prompts[0]).toContain('bg_timer')
+    expect(prompts[0]).toContain('FAILED')
+  })
+
+  test('a completion-broadcast wake CLEARS the pending expiry timer', async () => {
+    // given: a child within the ceiling, so the loop parks on the expiry timer
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_wake', { startedAt: 0 })
+    const sched = makeFakeScheduler()
+
+    const watch = beginSubagentDrainWatch(drain, sched)
+    const prompts: string[] = []
+    const done = runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 50,
+      now: () => 30,
+    })
+    await Promise.resolve()
+    expect(sched.setCount()).toBe(1)
+    expect(sched.hasPending()).toBe(true)
+
+    // when: the child completes and a broadcast wake arrives before the timer
+    reg.recordCompletion('bg_wake', { ok: true, durationMs: 30 })
+    drain.stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'subagent.completed',
+        taskId: 'bg_wake',
+        subagent: 'scout',
+        parentSessionId: PARENT,
+        ok: true,
+        durationMs: 30,
+      },
+    })
+    await done
+
+    // then: the wake cleared the pending timer (no leaked timer, no double-wake)
+    expect(sched.clearCount()).toBe(1)
+    expect(sched.hasPending()).toBe(false)
+  })
+})
+
+describe('runSubagentDrain — stop() with a running child', () => {
+  test('a stopped watch terminates instead of spinning forever on a still-running child', async () => {
+    // given: a background child that never completes
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_stuck', { startedAt: 0 })
+
+    const watch = beginSubagentDrainWatch(drain)
+    const prompts: string[] = []
+    const done = runSubagentDrain(watch, { drain, prompt: async (t) => void prompts.push(t) })
+
+    // the loop parks on waitForWakeup (no ceiling, child still running)
+    await new Promise((r) => setTimeout(r, 5))
+    expect(prompts).toEqual([])
+
+    // when: the watch is stopped (waitForWakeup resolves false)
+    watch.stop()
+
+    // then: the loop returns rather than busy-looping on the running child
+    await done
+    expect(prompts).toEqual([])
+  })
+
+  test('stop() CLEARS a pending expiry timer', async () => {
+    // given: a child within the ceiling, so the loop parks on the expiry timer
+    const { drain, reg } = makeDrain()
+    registerChild(reg, 'bg_stuck', { startedAt: 0 })
+    const sched = makeFakeScheduler()
+
+    const watch = beginSubagentDrainWatch(drain, sched)
+    const prompts: string[] = []
+    const done = runSubagentDrain(watch, {
+      drain,
+      prompt: async (t) => void prompts.push(t),
+      maxChildWaitMs: 50,
+      now: () => 30,
+    })
+    await Promise.resolve()
+    expect(sched.hasPending()).toBe(true)
+
+    // when: the watch is stopped while the expiry timer is still pending
+    watch.stop()
+    await done
+
+    // then: stop() cancelled the pending timer (it never fires after teardown)
+    expect(sched.clearCount()).toBe(1)
+    expect(sched.hasPending()).toBe(false)
+    expect(prompts).toEqual([])
   })
 })

--- a/src/agent/subagent-drain.ts
+++ b/src/agent/subagent-drain.ts
@@ -22,6 +22,16 @@ export type RunSubagentDrainOptions = {
   // Cooperative cancellation: when this returns true the loop stops re-prompting
   // and returns, letting the caller's timeout/abort path dispose the session.
   cancelled?: () => boolean
+  // Wall-clock ceiling on how long a single background child may stay `running`
+  // before the drain gives up on it. A child without its own `timeoutMs` can
+  // wedge forever (a hung `session.prompt`), and the drain would otherwise wait
+  // on it indefinitely — stranding the parent's whole report. When a child
+  // exceeds this, we abort it and record a timeout completion so its reminder is
+  // delivered and the loop can reach its fixed point with partial results.
+  // Undefined keeps the legacy unbounded behavior.
+  maxChildWaitMs?: number
+  // Injectable clock + abort-await seam for tests; production uses real time.
+  now?: () => number
 }
 
 // Re-prompts a subagent with its children's completion reminders until a fixed
@@ -35,16 +45,22 @@ export type RunSubagentDrainOptions = {
 // "spawned nothing" flag is needed. The watch MUST have been started before the
 // initial prompt (see `beginSubagentDrainWatch`) to close the lost-wakeup race.
 export async function runSubagentDrain(watch: SubagentDrainWatch, options: RunSubagentDrainOptions): Promise<void> {
-  const { drain, prompt, cancelled } = options
+  const { drain, prompt, cancelled, maxChildWaitMs, now = Date.now } = options
   const delivered = new Set<string>()
   try {
     while (cancelled === undefined || !cancelled()) {
+      expireOverdueChildren(drain, maxChildWaitMs, now)
       const pending = collectPendingReminders(drain, delivered)
       if (pending.length === 0) {
         if (!hasRunningChildren(drain)) return
         // Children still running but none newly completed: wait for the next
-        // wakeup, then re-derive from the registry.
-        const woke = await watch.waitForWakeup()
+        // wakeup, then re-derive. A `maxChildWaitMs` bounds this wait (via a
+        // timer) so a child that never broadcasts still gets expired next
+        // iteration. `waitForWakeup` returns true on a completion OR a timer
+        // expiry, and false ONLY when the watch is stopped — which must always
+        // terminate the loop, else a stopped watch with a still-running child
+        // spins synchronously forever.
+        const woke = await watch.waitForWakeup(nextExpiryDelayMs(drain, maxChildWaitMs, now))
         if (!woke) return
         continue
       }
@@ -57,6 +73,64 @@ export async function runSubagentDrain(watch: SubagentDrainWatch, options: RunSu
   } finally {
     watch.stop()
   }
+}
+
+// Records a timeout completion (then fires abort) for any background child that
+// has been `running` past the ceiling. Recording a (failed) completion is what
+// lets the child surface as a delivered reminder and drop out of
+// `hasRunningChildren`, so the loop reaches its fixed point with partial results
+// rather than hanging on a wedged child. Synchronous by design — see the
+// record-before-abort note inside.
+function expireOverdueChildren(
+  drain: SubagentBackgroundDrain,
+  maxChildWaitMs: number | undefined,
+  now: () => number,
+): void {
+  if (maxChildWaitMs === undefined) return
+  const deadline = now() - maxChildWaitMs
+  for (const child of drain.liveRegistry.list({ parentSessionId: drain.sessionId })) {
+    if (child.background !== true || child.status !== 'running') continue
+    if (child.startedAt > deadline) continue
+    const durationMs = now() - child.startedAt
+    const error = `subagent ${child.subagentName} exceeded the ${maxChildWaitMs}ms drain wait and was abandoned`
+    // Claim the settlement BEFORE aborting. If the child's real completion
+    // already won, skip — no double-settle, no broadcast. Awaiting abort here
+    // would be the bug the ceiling exists to prevent: a wedged `session.abort()`
+    // that never reaches idle would hang the drain, so fire-and-forget instead.
+    // Logical settlement can precede physical teardown; startSubagent still
+    // disposes the session when its own work settles.
+    if (!drain.liveRegistry.recordCompletionIfRunning(child.taskId, { ok: false, durationMs, error })) continue
+    drain.stream.publish({
+      target: { kind: 'broadcast' },
+      payload: {
+        kind: 'subagent.completed',
+        taskId: child.taskId,
+        subagent: child.subagentName,
+        parentSessionId: drain.sessionId,
+        ok: false,
+        durationMs,
+        error,
+      },
+    })
+    void child.abort().catch(() => {})
+  }
+}
+
+// The soonest a still-running child will cross the ceiling, so waitForWakeup can
+// wake the loop to expire it even if no completion broadcast ever arrives.
+// Undefined when there is no ceiling or no running child (wait indefinitely).
+function nextExpiryDelayMs(
+  drain: SubagentBackgroundDrain,
+  maxChildWaitMs: number | undefined,
+  now: () => number,
+): number | undefined {
+  if (maxChildWaitMs === undefined) return undefined
+  const running = drain.liveRegistry
+    .list({ parentSessionId: drain.sessionId })
+    .filter((c) => c.background === true && c.status === 'running')
+  if (running.length === 0) return undefined
+  const oldestStart = Math.min(...running.map((c) => c.startedAt))
+  return Math.max(0, oldestStart + maxChildWaitMs - now())
 }
 
 type PendingReminder = { taskId: string; text: string }
@@ -97,20 +171,47 @@ function hasRunningChildren(drain: SubagentBackgroundDrain): boolean {
 export type SubagentDrainWatch = {
   // Resolves true on a child-completion wakeup, false once stopped. A wakeup
   // that arrives before anyone waits is latched (pendingWake), so a completion
-  // during the subagent's prompt is not lost.
-  waitForWakeup: () => Promise<boolean>
+  // during the subagent's prompt is not lost. An optional `timeoutMs` resolves
+  // true when it elapses (a spurious wake) so the loop re-derives and can expire
+  // a child that never broadcast a completion.
+  waitForWakeup: (timeoutMs?: number) => Promise<boolean>
   stop: () => void
 }
 
-export function beginSubagentDrainWatch(drain: SubagentBackgroundDrain): SubagentDrainWatch {
+// Injectable timer seam so tests can assert timer cancellation deterministically
+// (a real setTimeout cancellation is invisible without racing the clock). `set`
+// returns an opaque handle; `clear` cancels it. Production uses node timers.
+export type TimerScheduler = {
+  set: (fn: () => void, ms: number) => unknown
+  clear: (handle: unknown) => void
+}
+
+const realTimerScheduler: TimerScheduler = {
+  set: (fn, ms) => setTimeout(fn, ms),
+  clear: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+}
+
+export function beginSubagentDrainWatch(
+  drain: SubagentBackgroundDrain,
+  scheduler: TimerScheduler = realTimerScheduler,
+): SubagentDrainWatch {
   let stopped = false
   let pendingWake = false
   let resolveWaiter: ((woke: boolean) => void) | null = null
+  let waiterTimer: unknown = null
+
+  const clearWaiterTimer = (): void => {
+    if (waiterTimer !== null) {
+      scheduler.clear(waiterTimer)
+      waiterTimer = null
+    }
+  }
 
   const wake = (): void => {
     if (resolveWaiter !== null) {
       const r = resolveWaiter
       resolveWaiter = null
+      clearWaiterTimer()
       r(true)
       return
     }
@@ -125,7 +226,7 @@ export function beginSubagentDrainWatch(drain: SubagentBackgroundDrain): Subagen
   })
 
   return {
-    waitForWakeup: () =>
+    waitForWakeup: (timeoutMs?: number) =>
       new Promise<boolean>((resolve) => {
         if (stopped) {
           resolve(false)
@@ -137,11 +238,20 @@ export function beginSubagentDrainWatch(drain: SubagentBackgroundDrain): Subagen
           return
         }
         resolveWaiter = resolve
+        if (timeoutMs !== undefined) {
+          waiterTimer = scheduler.set(() => {
+            if (resolveWaiter === null) return
+            resolveWaiter = null
+            waiterTimer = null
+            resolve(true)
+          }, timeoutMs)
+        }
       }),
     stop: () => {
       if (stopped) return
       stopped = true
       unsubscribe()
+      clearWaiterTimer()
       if (resolveWaiter !== null) {
         const r = resolveWaiter
         resolveWaiter = null

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -381,6 +381,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
             throwIfLoopGuardAborted(session)
           },
           cancelled: () => aborted,
+          maxChildWaitMs: DRAIN_MAX_CHILD_WAIT_MS,
         })
       }
       throwIfLoopGuardAborted(session)
@@ -641,6 +642,13 @@ function lastTaggedBlock(text: string, tag: FinalBlockTag): string | null {
 // for the reviewer the GitHub flow has no `<review>` to post and silently
 // `skip_response`s — the stranded-review bug. This gate gives both a bounded
 // re-prompt then an honest low-confidence fallback instead of the silent drop.
+// Backstop ceiling for the background drain: a running child that never settles
+// is abandoned after this so the parent can synthesize partial results instead
+// of hanging forever. Deliberately larger than the per-child `timeoutMs`
+// (scout = 5 min) so that a child's own timeout is the primary release and this
+// only catches children that declare none.
+const DRAIN_MAX_CHILD_WAIT_MS = 600_000
+
 const REQUIRED_FINAL_BLOCK: Readonly<Record<string, FinalBlockTag>> = { researcher: 'report', reviewer: 'review' }
 
 // Bounded re-prompt budget for the required-block guard, mirroring the channel

--- a/src/agent/tools/ddg.test.ts
+++ b/src/agent/tools/ddg.test.ts
@@ -6,12 +6,15 @@ import { join } from 'node:path'
 import { isWindows } from '@/shared'
 import { waitFor } from '@/test-helpers/wait-for'
 
+import { CurlImpersonateError } from './curl-impersonate'
 import {
   _setCurlBinaryForTest,
   _setSearchRetryForTest,
   DDG_CONCURRENCY,
+  DdgCaptchaError,
   ddgSearch,
   fetchDdgHtml,
+  isTransientSearchError,
   parseDdgHtml,
 } from './ddg'
 
@@ -298,6 +301,52 @@ describe.skipIf(onWindows)('ddgSearch (retry + concurrency)', () => {
     expect(results[0]?.url).toBe('https://ok.example/')
   })
 
+  test('retries past a transient connection timeout (curl exit 28) and returns results', async () => {
+    // given: first spawn exits 28 (curl connection timeout), the next serves a SERP
+    const counter = join(scratchDir, 'count')
+    installFakeBinary(`
+WTPL=""
+i=1
+for arg in "$@"; do
+  if [ "$arg" = "-w" ]; then j=$((i + 1)); eval "WTPL=\\"\\\${$j}\\""; break; fi
+  i=$((i + 1))
+done
+N=$(cat ${counter} 2>/dev/null || echo 0)
+echo $((N + 1)) > ${counter}
+if [ "$N" -lt 1 ]; then echo "curl: (28) Connection timed out after 30000 milliseconds" >&2; exit 28; fi
+RENDERED=$(printf '%s' "$WTPL" | sed -e 's/%{http_code}/200/' -e 's|%{url_effective}|https://lite.duckduckgo.com/lite/|' -e 's|%{content_type}|text/html|' -e 's/%{size_download}/0/')
+printf '%s' '${RESULT_SERP}'
+printf '%s' "$RENDERED"
+`)
+
+    // when
+    const results = await ddgSearch('q', 10)
+
+    // then
+    expect(results).toHaveLength(1)
+    expect(results[0]?.url).toBe('https://ok.example/')
+  })
+
+  test('gives up after the bounded attempts when the timeout never clears', async () => {
+    // given: every spawn exits 28, so no attempt ever succeeds
+    installFakeBinary('echo "curl: (28) Connection timed out after 30000 milliseconds" >&2; exit 28')
+
+    // when / then: the error propagates (bounded, not an infinite loop) as a curl timeout
+    await expect(ddgSearch('q', 10)).rejects.toThrow(/exited 28/)
+  })
+
+  test('does NOT retry a hard network failure (non-timeout exit code)', async () => {
+    // given: a fake binary that fails with a non-timeout code on every call
+    const counter = join(scratchDir, 'count-hard')
+    installFakeBinary(
+      `N=$(cat ${counter} 2>/dev/null || echo 0); echo $((N + 1)) > ${counter}; echo "boom" >&2; exit 7`,
+    )
+
+    // when / then: surfaces immediately without burning the retry budget
+    await expect(ddgSearch('q', 10)).rejects.toThrow(/exited 7/)
+    expect(await Bun.file(join(scratchDir, 'count-hard')).text()).toBe('1\n')
+  })
+
   test('caps concurrent ddgSearch calls at DDG_CONCURRENCY across the process', async () => {
     // given: each spawn marks itself with a per-pid file and holds the slot
     // until released. Per-spawn marker files make the live count race-free —
@@ -400,5 +449,25 @@ printf '%s' "$RENDERED"
     // cleanup: release the held slots so the saturating calls finish
     writeFileSync(releaseFile, 'go', 'utf8')
     await Promise.all(saturating)
+  })
+})
+
+describe('isTransientSearchError', () => {
+  test('a CAPTCHA is transient', () => {
+    expect(isTransientSearchError(new DdgCaptchaError())).toBe(true)
+  })
+
+  test('a curl connection timeout (exit 28) is transient', () => {
+    const err = new CurlImpersonateError('curl-impersonate exited 28: timed out', 28, 'timed out')
+    expect(isTransientSearchError(err)).toBe(true)
+  })
+
+  test('a hard curl failure (non-timeout exit) is NOT transient', () => {
+    const err = new CurlImpersonateError('curl-impersonate exited 7: refused', 7, 'refused')
+    expect(isTransientSearchError(err)).toBe(false)
+  })
+
+  test('an arbitrary error is NOT transient', () => {
+    expect(isTransientSearchError(new Error('parse failed'))).toBe(false)
   })
 })

--- a/src/agent/tools/ddg.ts
+++ b/src/agent/tools/ddg.ts
@@ -12,7 +12,7 @@
 // TLS handshake + HTTP/2 settings + header ordering. See that file's header
 // for the full rationale and AGENTS.md §"Web search" for the original story.
 
-import { curlImpersonate } from './curl-impersonate'
+import { CurlImpersonateError, curlImpersonate, isCurlExitTimeout } from './curl-impersonate'
 import { createKeyedSemaphore } from './keyed-semaphore'
 import { type SearchRetryOptions, withSearchRetry } from './search-retry'
 
@@ -61,10 +61,24 @@ export async function ddgSearch(query: string, limit: number, signal?: AbortSign
           }
           return parseDdgHtml(html).slice(0, limit)
         },
-        { ...retryOverride, shouldRetry: (error) => error instanceof DdgCaptchaError, signal },
+        { ...retryOverride, shouldRetry: isTransientSearchError, signal },
       ),
     signal,
   )
+}
+
+// Both a tripped CAPTCHA and a bare connection timeout are transient: DDG's
+// gate lifts after a cooldown, and an egress timeout is almost always a
+// momentary network blip (the incident that motivated this: an agent's egress
+// timed out for a few minutes, then recovered). Retrying both under the bounded
+// `withSearchRetry` backoff turns an otherwise-unbounded model-driven retry
+// loop into at most `attempts` code-level tries that then surface a single
+// terminal error. A hard network failure (DNS, refused, TLS) is NOT retried —
+// it won't fix itself on a re-run and would just burn the budget.
+export function isTransientSearchError(error: unknown): boolean {
+  if (error instanceof DdgCaptchaError) return true
+  if (error instanceof CurlImpersonateError && isCurlExitTimeout(error)) return true
+  return false
 }
 
 export class DdgCaptchaError extends Error {

--- a/src/agent/tools/spawn-subagent.ts
+++ b/src/agent/tools/spawn-subagent.ts
@@ -176,24 +176,27 @@ export function createSpawnSubagentTool(options: CreateSpawnSubagentToolOptions)
 
       void completion.then((c) => {
         const durationMs = now() - startedAt
-        liveRegistry.recordCompletion(taskId, completionToFinalShape(c, durationMs))
-        if (stream && background) {
-          const hasRecoverableOutput = !c.ok && c.finalMessage !== undefined
-          stream.publish({
-            target: { kind: 'broadcast' },
-            payload: {
-              kind: 'subagent.completed',
-              taskId,
-              subagent: subagentName,
-              parentSessionId,
-              ok: c.ok,
-              durationMs,
-              ...(c.ok ? {} : { error: c.error }),
-              ...(hasRecoverableOutput ? { hasRecoverableOutput: true } : {}),
-              ...(channelKey !== undefined ? { channelKey } : {}),
-            },
-          })
-        }
+        // First-writer-wins: if the parent drain already settled this child by
+        // timeout, our real completion lost — skip both the overwrite and the
+        // broadcast so exactly one canonical completed-event is emitted (the
+        // winner's).
+        const won = liveRegistry.recordCompletionIfRunning(taskId, completionToFinalShape(c, durationMs))
+        if (!won || !stream || !background) return
+        const hasRecoverableOutput = !c.ok && c.finalMessage !== undefined
+        stream.publish({
+          target: { kind: 'broadcast' },
+          payload: {
+            kind: 'subagent.completed',
+            taskId,
+            subagent: subagentName,
+            parentSessionId,
+            ok: c.ok,
+            durationMs,
+            ...(c.ok ? {} : { error: c.error }),
+            ...(hasRecoverableOutput ? { hasRecoverableOutput: true } : {}),
+            ...(channelKey !== undefined ? { channelKey } : {}),
+          },
+        })
       })
 
       if (background) {

--- a/src/agent/tools/websearch.test.ts
+++ b/src/agent/tools/websearch.test.ts
@@ -109,16 +109,33 @@ printf '%s' "$RENDERED"
     expect(details.count).toBe(1)
   })
 
-  test('returns a clear error when DuckDuckGo serves a CAPTCHA page', async () => {
-    // given: stdout contains the challenge-form marker isCaptcha checks for
+  test('an exhausted CAPTCHA returns the terminal "do not retry" contract (no "try again")', async () => {
+    // given: every attempt serves the challenge-form CAPTCHA marker
     installFakePrintingBinary('<form id="challenge-form">Please verify you are a human</form>')
 
     // when
     const result = await webSearchTool.execute('id', { query: 'spam' }, undefined, undefined, ctx)
 
+    // then: unified terminal contract — tells the model to stop, not to vary queries
+    const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
+    expect(text).toContain('Do not retry this tool now')
+    expect(text).toContain('report what you already have')
+    expect(text).not.toMatch(/try again/i)
+    expect((result.details as { error?: boolean }).error).toBe(true)
+  })
+
+  test('an exhausted connection timeout (curl exit 28) returns the same terminal contract', async () => {
+    // given: every attempt times out at the curl layer
+    installFakeBinary('echo "curl: (28) Connection timed out after 30000 milliseconds" >&2; exit 28')
+
+    // when
+    const result = await webSearchTool.execute('id', { query: 'x' }, undefined, undefined, ctx)
+
     // then
     const text = result.content[0]?.type === 'text' ? result.content[0].text : ''
-    expect(text).toMatch(/CAPTCHA/i)
+    expect(text).toContain('Do not retry this tool now')
+    expect(text).toContain('report what you already have')
+    expect(text).not.toMatch(/try again/i)
     expect((result.details as { error?: boolean }).error).toBe(true)
   })
 

--- a/src/agent/tools/websearch.ts
+++ b/src/agent/tools/websearch.ts
@@ -1,6 +1,7 @@
 import { Type } from '@mariozechner/pi-ai'
 import { defineTool } from '@mariozechner/pi-coding-agent'
 
+import { CurlImpersonateError, isCurlExitTimeout } from './curl-impersonate'
 import { ddgSearch, DdgCaptchaError, type DdgResult } from './ddg'
 import { wikipediaSearch, type WikipediaResult } from './wikipedia'
 
@@ -51,14 +52,34 @@ export const webSearchTool = defineTool({
         source === 'wikipedia' ? await wikipediaSearch(query, limit, signal) : await ddgSearch(query, limit, signal)
       return successResult(query, source, results)
     } catch (error) {
-      if (error instanceof DdgCaptchaError) {
-        return errorResult(error.message)
+      // Both a CAPTCHA and a connection timeout are transient failures that
+      // ddgSearch already retried under a bounded backoff. The model has no
+      // visibility into those spent retries, so any message that hints "try
+      // again" (the old CAPTCHA text did) invites it to loop the tool with
+      // varied queries — the exact churn this change removes. Give both the same
+      // terminal "do not retry now" contract so an exhausted transient failure
+      // ends the turn with partial results instead.
+      if (isExhaustedTransientSearchError(error)) {
+        return errorResult(
+          `Search unavailable for "${query}" after retries (${transientReason(error)}). Do not retry this tool now — report what you already have and note the search was unreachable.`,
+        )
       }
       const message = error instanceof Error ? error.message : String(error)
       return errorResult(`Search failed: ${message}`)
     }
   },
 })
+
+function isExhaustedTransientSearchError(error: unknown): boolean {
+  if (error instanceof DdgCaptchaError) return true
+  if (error instanceof CurlImpersonateError && isCurlExitTimeout(error)) return true
+  return false
+}
+
+function transientReason(error: unknown): string {
+  if (error instanceof DdgCaptchaError) return 'rate-limited'
+  return 'network timeout'
+}
 
 function clampLimit(value: number | undefined): number {
   if (value === undefined) return DEFAULT_LIMIT

--- a/src/bundled-plugins/scout/scout.test.ts
+++ b/src/bundled-plugins/scout/scout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { SCOUT_SYSTEM_PROMPT, createScoutSubagent, scoutPayloadSchema } from './scout'
+import { SCOUT_SYSTEM_PROMPT, SCOUT_TIMEOUT_MS, createScoutSubagent, scoutPayloadSchema } from './scout'
 
 describe('scout subagent — load-bearing prompt phrases', () => {
   test.each(
@@ -69,6 +69,14 @@ describe('scout subagent declaration', () => {
   test('uses the fast model profile (cheap and parallelizable for read-only research)', () => {
     const sub = createScoutSubagent()
     expect(sub.profile).toBe('fast')
+  })
+
+  test('declares a timeoutMs so a wedged run cannot block its parent forever', () => {
+    // startSubagent only arms its timeout guard when timeoutMs is set; a scout
+    // without one deadlocks a researcher that spawned it (the incident this fixes).
+    const sub = createScoutSubagent()
+    expect(sub.timeoutMs).toBe(SCOUT_TIMEOUT_MS)
+    expect(sub.timeoutMs).toBeGreaterThan(0)
   })
 
   test('tools list is exactly [web_search, web_fetch] and NO filesystem tools', () => {

--- a/src/bundled-plugins/scout/scout.ts
+++ b/src/bundled-plugins/scout/scout.ts
@@ -83,10 +83,18 @@ export const scoutPayloadSchema = z
 
 export type ScoutPayload = z.infer<typeof scoutPayloadSchema>
 
+// Ceiling for a wedged scout run. `startSubagent`'s timeout guard only engages
+// when `timeoutMs` is set, so without this a scout whose `session.prompt` never
+// settles (e.g. the model looping on a transient network error) blocks its
+// parent — the researcher especially — forever. 5 min is generous headroom over
+// the normal seconds-to-low-minutes path while still bounding the hang.
+export const SCOUT_TIMEOUT_MS = 300_000
+
 export function createScoutSubagent(): Subagent<ScoutPayload> {
   return {
     systemPrompt: SCOUT_SYSTEM_PROMPT,
     profile: 'fast',
+    timeoutMs: SCOUT_TIMEOUT_MS,
     tools: [webSearchTool, webFetchTool],
     payloadSchema: scoutPayloadSchema,
     visibility: 'public',


### PR DESCRIPTION
## Background

A `researcher` subagent that fanned out parallel `scout` children could deadlock and strand the chat thread that asked for the work. Observed in production: a fact-check ran, the agent replied "researcher 돌려놨음 ㅇㅇ … 나오면 올림" (kicked off the researcher, will post when it's done), and then **never delivered a result** — the user asked "뒤짐?" (did it die?) three times over ~2.5 hours and got nothing, until the container was restarted and the whole in-flight tree was lost.

Root cause, from the session transcripts, was two compounding defects:

1. **Trigger — an unbounded model-driven retry loop.** `web_search` → `ddgSearch` → `curl-impersonate`. A bare connection timeout surfaces as `curl-impersonate exited 28: Connection timed out`. The retry predicate (`withSearchRetry`'s `shouldRetry`) only matched `DdgCaptchaError`, so a timeout was re-thrown on the first attempt and returned to the model as a plain `Search failed: …` string. During a transient egress outage, 2 of 5 scouts looped on timeouts/403/404 forever. The loop-guard didn't catch it because the queries differ each iteration.

2. **Amplifier — no timeout on the hung children.** `scout` never declared `timeoutMs`, and `startSubagent`'s anti-hang guard (`raceSubagentCompletion`) is **skipped entirely when `timeoutMs` is undefined** — so a wedged `session.prompt` had no ceiling. The researcher's background drain loop (`runSubagentDrain`) also had no wall-clock ceiling: it returned only when zero background children were `running`, and its sole escape hatch (`cancelled: () => aborted`) only fires when someone calls the session `abort()` — which, for a no-`timeoutMs` child, never happened. Result: the drain waited on the two stuck scouts forever, the researcher never emitted its `<report>`, and the parent channel agent never got `subagent.completed`.

## Summary

Defense-in-depth across the three points where the hang could form — any one alone leaves a gap:

- **`websearch`/`ddg` (trigger):** retry a bare connection timeout (`curl` exit 28) under the *existing* bounded `withSearchRetry` backoff, not just a CAPTCHA (new `isTransientSearchError`). Once retries are spent, `web_search` returns a single terminal "do not retry — report what you have" message so the model stops re-calling the tool. **Why not retry everything:** a hard network failure (DNS/refused/TLS) won't fix itself on a re-run and would just burn the budget, so those still surface immediately.

- **`scout` (per-child ceiling):** declare `timeoutMs` (5 min). This is the smallest, highest-leverage change — it *activates* `startSubagent`'s already-built guard, so a wedged scout settles `ok:false` and aborts instead of hanging. 5 min is generous over the normal seconds-to-low-minutes path.

- **`subagent-drain` (backstop):** add an optional `maxChildWaitMs`. A background child stuck `running` past the ceiling is aborted and recorded as a timeout completion, so its reminder is delivered and the loop reaches its fixed point with **partial results** instead of blocking on a wedged child. `waitForWakeup` gained an optional timeout so a child that never broadcasts still gets expired. Wired at 10 min in `invokeSubagent` — deliberately above the per-child 5-min `timeoutMs`, so a child's own timeout is the primary release and the drain ceiling only catches children that declare none.

## What this does NOT do

- Does not change the researcher/scout prompts or their delegation shape.
- Does not add a universal default `timeoutMs` to every subagent — only `scout` gets one here; the drain backstop covers the general case.
- Does not touch `web_fetch`'s transport (the same bounded-retry idea could extend there later, but it wasn't the trigger for this incident).
- Does not attempt to resume a subagent tree killed by a container restart.

## Review notes

- Load-bearing invariant: **recording a *failed* completion (not just calling `abort`) is what lets an expired child drop out of `hasRunningChildren` and be delivered as a reminder** — that's how the fixed-point loop terminates with partial results. See `expireOverdueChildren` in `src/agent/subagent-drain.ts`.
- The two timeout layers are ordered on purpose: `DRAIN_MAX_CHILD_WAIT_MS` (10 min) **must stay larger** than a child's own `timeoutMs` (`SCOUT_TIMEOUT_MS`, 5 min). A guard comment documents this.
- Tests use an injectable `now()` clock in the drain and a fake `curl` binary that exits 28 then serves a SERP, so the timeout/retry paths are exercised without real timers or network. Existing researcher report-recovery tests (`subagents.test.ts`) still pass unchanged.
- Checks: `typecheck`, `lint` (0 errors), `format:check`, and the affected suites (`ddg`, `websearch`, `scout`, `subagent-drain`, `subagents`, full `src/agent/`) all green.
