### PR TITLE
Notify a thread when a restart lost its background subagent

### DIFF
--- a/src/agent/restart-handoff/index.test.ts
+++ b/src/agent/restart-handoff/index.test.ts
@@ -5,7 +5,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  acquireRestartHandoffLock,
   consumeRestartHandoff,
+  peekRestartHandoff,
   RESTART_HANDOFF_TTL_MS,
   type RestartHandoff,
   restartHandoffPath,
@@ -68,14 +70,38 @@ describe('writeRestartHandoff', () => {
     expect(result?.triggeringAuthorId).toBe('U_OWNER')
   })
 
+  test('round-trips interruptedSubagents so the resumed session can name the lost work', async () => {
+    await writeRestartHandoff(agentDir, channelHandoff({ interruptedSubagents: ['researcher', 'scout'] }))
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result?.interruptedSubagents).toEqual(['researcher', 'scout'])
+  })
+
+  test('omits interruptedSubagents from the persisted JSON when absent', async () => {
+    await writeRestartHandoff(agentDir, channelHandoff())
+
+    const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
+
+    expect(Object.hasOwn(JSON.parse(raw), 'interruptedSubagents')).toBe(false)
+  })
+
   test('creates the .typeclaw/ directory on demand', async () => {
     expect(existsSync(join(agentDir, '.typeclaw'))).toBe(false)
     await writeRestartHandoff(agentDir, tuiHandoff())
     expect(existsSync(join(agentDir, '.typeclaw'))).toBe(true)
   })
 
-  test('does not throw when the agent directory does not exist (best-effort)', async () => {
-    await expect(writeRestartHandoff('/nonexistent/path/that/does/not/exist', tuiHandoff())).resolves.toBeUndefined()
+  test('returns true when the handoff is written', async () => {
+    expect(await writeRestartHandoff(agentDir, tuiHandoff())).toBe(true)
+  })
+
+  test('returns false (does not throw) when the write fails (best-effort)', async () => {
+    // given: a path under a file, so mkdir/write cannot succeed
+    const notADir = join(agentDir, 'blocker')
+    await writeFile(notADir, 'x', 'utf8')
+
+    expect(await writeRestartHandoff(join(notADir, 'nested'), tuiHandoff())).toBe(false)
   })
 
   test('overwrites a prior handoff file', async () => {
@@ -87,6 +113,82 @@ describe('writeRestartHandoff', () => {
 
     const raw = await readFile(restartHandoffPath(agentDir), 'utf8')
     expect(JSON.parse(raw).originatingSessionId).toBe('ses-second')
+  })
+})
+
+describe('acquireRestartHandoffLock', () => {
+  test('serializes holders: a second acquire waits until the first releases', async () => {
+    // given: one holder of the lock for this agentDir
+    const release1 = await acquireRestartHandoffLock(agentDir)
+    let secondAcquired = false
+    const second = acquireRestartHandoffLock(agentDir).then((r) => {
+      secondAcquired = true
+      return r
+    })
+
+    // when: we let microtasks flush WITHOUT releasing the first
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // then: the second is still blocked
+    expect(secondAcquired).toBe(false)
+
+    // when: the first releases
+    release1()
+    const release2 = await second
+
+    // then: the second acquires
+    expect(secondAcquired).toBe(true)
+    release2()
+  })
+
+  test('distinct agent dirs do not contend', async () => {
+    const other = await mkdtemp(join(tmpdir(), 'typeclaw-handoff-lock-'))
+    try {
+      const releaseA = await acquireRestartHandoffLock(agentDir)
+      // a different dir's lock is immediately available even while agentDir is held
+      const releaseB = await acquireRestartHandoffLock(other)
+      releaseA()
+      releaseB()
+      expect(true).toBe(true)
+    } finally {
+      await rm(other, { recursive: true, force: true })
+    }
+  })
+
+  test('double release is a no-op (does not free a later holder early)', async () => {
+    const release1 = await acquireRestartHandoffLock(agentDir)
+    release1()
+    release1() // second call must not corrupt the queue
+    const release2 = await acquireRestartHandoffLock(agentDir)
+    release2()
+    expect(true).toBe(true)
+  })
+})
+
+describe('peekRestartHandoff', () => {
+  test('returns null when no handoff file exists', async () => {
+    expect(await peekRestartHandoff(agentDir)).toBeNull()
+  })
+
+  test('reads the handoff WITHOUT deleting it or applying the TTL', async () => {
+    // given: a handoff far older than the TTL — consume would drop it, peek must not
+    await writeRestartHandoff(
+      agentDir,
+      channelHandoff({ restartedAt: new Date(Date.now() - (RESTART_HANDOFF_TTL_MS + 60_000)).toISOString() }),
+    )
+
+    const peeked = await peekRestartHandoff(agentDir)
+
+    expect(peeked?.origin.kind).toBe('channel')
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(true)
+  })
+
+  test('returns null on malformed JSON without deleting the file', async () => {
+    await Bun.write(restartHandoffPath(agentDir), '{ not json')
+
+    expect(await peekRestartHandoff(agentDir)).toBeNull()
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(true)
   })
 })
 
@@ -183,6 +285,39 @@ describe('consumeRestartHandoff', () => {
 
     expect(result?.origin.kind).toBe('channel')
     expect(result?.triggeringAuthorId).toBeUndefined()
+  })
+
+  test('ignores a non-array interruptedSubagents instead of rejecting the handoff', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(path, JSON.stringify({ ...channelHandoff(), interruptedSubagents: 'researcher' }))
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result?.origin.kind).toBe('channel')
+    expect(result?.interruptedSubagents).toBeUndefined()
+  })
+
+  test('drops non-string entries and an empty interruptedSubagents array', async () => {
+    const path = restartHandoffPath(agentDir)
+    await Bun.write(path, JSON.stringify({ ...channelHandoff(), interruptedSubagents: ['researcher', 7, '', 'scout'] }))
+
+    const result = await consumeRestartHandoff(agentDir, { now: Date.parse('2026-05-26T10:00:30.000Z') })
+
+    expect(result?.interruptedSubagents).toEqual(['researcher', 'scout'])
+  })
+
+  test('a >60s-old handoff carrying interruptedSubagents is dropped (stop→idle→start stays quiet)', async () => {
+    await writeRestartHandoff(
+      agentDir,
+      channelHandoff({
+        restartedAt: new Date(Date.now() - (RESTART_HANDOFF_TTL_MS + 60_000)).toISOString(),
+        interruptedSubagents: ['researcher'],
+      }),
+    )
+
+    const result = await consumeRestartHandoff(agentDir, { accept: (h) => h.origin.kind === 'channel' })
+
+    expect(result).toBeNull()
   })
 
   test('returns null when a v2 channel handoff is missing its key', async () => {

--- a/src/agent/restart-handoff/index.ts
+++ b/src/agent/restart-handoff/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
@@ -8,6 +9,39 @@ import { restartHandoffPath } from './paths'
 export { restartHandoffPath } from './paths'
 
 export const RESTART_HANDOFF_TTL_MS = 60_000
+
+// Process-local serialization of the two same-process handoff producers that
+// race during a restart: the in-session `/restart` tool (which writes the
+// originating handoff post-ACK) and the SIGTERM writer (which peek-augments it).
+// hostd fires `docker stop` → SIGTERM before its ACK reaches the container, so
+// without this the SIGTERM read-modify-write can interleave with `/restart`'s
+// write and drop the originating session's origin/author or its interrupted
+// children. This is NOT a cross-process lock — both producers live in this one
+// container process; the event loop yields at every await, so a promise-chain
+// mutex is all that's needed. Keyed by handoff path so distinct agent dirs
+// (tests) never contend.
+const handoffLocks = new Map<string, Promise<void>>()
+
+export async function acquireRestartHandoffLock(agentDir: string): Promise<() => void> {
+  const key = restartHandoffPath(agentDir)
+  const prior = handoffLocks.get(key) ?? Promise.resolve()
+  let release!: () => void
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const chained = prior.then(() => held)
+  handoffLocks.set(key, chained)
+  await prior
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    // Drop the map entry only if we are still the tail, so a later waiter that
+    // already chained onto `chained` is not orphaned.
+    if (handoffLocks.get(key) === chained) handoffLocks.delete(key)
+    release()
+  }
+}
 
 // The channel coordinates needed to reopen and wake the originating session
 // on the channel side after a restart. Mirrors ChannelKey (src/channels/types)
@@ -42,6 +76,12 @@ export type RestartHandoff = {
   // whatever bare-channel rule matches on every "I'm back" turn. Optional and
   // additive: pre-field v2 handoffs and tui handoffs omit it.
   triggeringAuthorId?: string
+  // Names of background subagents still running when the restart fired, so the
+  // resumed session can tell the thread its promised result was lost. Absent
+  // (never an empty array) when nothing was in flight. Rides the handoff's 60s
+  // TTL, so a stop→idle-for-hours→start drops it instead of replaying a stale
+  // notice into a moved-on conversation.
+  interruptedSubagents?: string[]
 }
 
 // Atomic write via `.tmp` + rename so a crash mid-write never leaves the
@@ -50,16 +90,36 @@ export type RestartHandoff = {
 // half-written one. Errors are swallowed: handoff is best-effort. A failed
 // write means the next boot cold-starts (no greeting), which is the same
 // graceful degradation as the dying container being SIGKILL'd before the
-// write could run.
-export async function writeRestartHandoff(agentDir: string, handoff: RestartHandoff): Promise<void> {
+// write could run. Returns whether the file was actually written, so a caller
+// whose contract depends on the write landing can react to the swallowed
+// failure instead of assuming success.
+export async function writeRestartHandoff(agentDir: string, handoff: RestartHandoff): Promise<boolean> {
   const path = restartHandoffPath(agentDir)
+  // Per-write unique tmp name so two producers staging concurrently never share
+  // a staging file or race a rename against a tmp the other already renamed
+  // away. The final rename stays atomic; last rename wins, ordered by the lock.
+  const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`
   try {
     await mkdir(dirname(path), { recursive: true })
-    const tmp = `${path}.tmp`
     await writeFile(tmp, JSON.stringify(handoff), 'utf8')
     await rename(tmp, path)
+    return true
   } catch {
-    return
+    await rm(tmp, { force: true }).catch(() => undefined)
+    return false
+  }
+}
+
+// Non-consuming read of the pending handoff, for a caller that must decide
+// whether one already exists before writing its own (so an accepted in-session
+// restart's handoff is preserved rather than clobbered). Unlike consumeRestartHandoff
+// this never deletes, never applies the TTL, and never restores — it is a pure
+// peek. Returns null when absent or malformed.
+export async function peekRestartHandoff(agentDir: string): Promise<RestartHandoff | null> {
+  try {
+    return parseHandoff(await readFile(restartHandoffPath(agentDir), 'utf8'))
+  } catch {
+    return null
   }
 }
 
@@ -168,7 +228,16 @@ function parseHandoff(raw: string): RestartHandoff | null {
     ...(typeof obj.triggeringAuthorId === 'string' && obj.triggeringAuthorId !== ''
       ? { triggeringAuthorId: obj.triggeringAuthorId }
       : {}),
+    ...(() => {
+      const names = parseInterruptedSubagents(obj.interruptedSubagents)
+      return names.length > 0 ? { interruptedSubagents: names } : {}
+    })(),
   }
+}
+
+function parseInterruptedSubagents(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter((entry): entry is string => typeof entry === 'string' && entry !== '')
 }
 
 function parseOrigin(raw: unknown): RestartHandoffOrigin | null {

--- a/src/agent/restart/index.test.ts
+++ b/src/agent/restart/index.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { restartHandoffPath } from '@/agent/restart-handoff'
+import { acquireRestartHandoffLock, restartHandoffPath } from '@/agent/restart-handoff'
 import { createStream, type StreamMessage } from '@/stream'
 
 import { requestContainerRestart } from './index'
@@ -140,6 +140,62 @@ describe('requestContainerRestart', () => {
       originatingSessionFile: 'ses-origin.jsonl',
       origin: { kind: 'tui' },
     })
+  })
+
+  test('holds the handoff lock across the ACK so a concurrent handoff producer waits for the commit', async () => {
+    // given: a hostd whose ACK is withheld until we release it — the window where
+    //   SIGTERM (docker stop) can fire before requestContainerRestart's write lands
+    let releaseAck!: () => void
+    const ackGate = new Promise<void>((resolve) => {
+      releaseAck = resolve
+    })
+    server = Bun.serve({
+      port: 0,
+      async fetch() {
+        await ackGate
+        return Response.json({ ok: true, result: { containerName: 'coder', scheduled: true } })
+      },
+    })
+
+    const restartDone = requestContainerRestart({
+      containerName: 'coder',
+      hostdUrl: `http://127.0.0.1:${server.port}`,
+      hostdToken: 'secret',
+      ackTimeoutMs: TEST_ACK_TIMEOUT_MS,
+      agentDir,
+      originatingSessionId: 'ses-origin',
+      originatingSessionFile: '/tmp/sessions/ses-origin.jsonl',
+      handoffOrigin: { kind: 'channel', key: { adapter: 'discord-bot', workspace: 'g', chat: 'c', thread: null } },
+      triggeringAuthorId: 'U_OWNER',
+      restartedAt: '2026-01-02T03:04:05.000Z',
+    })
+
+    // when: a second producer tries to take the handoff lock while the ACK is withheld
+    let secondAcquired = false
+    const second = acquireRestartHandoffLock(agentDir).then((r) => {
+      secondAcquired = true
+      return r
+    })
+    await new Promise((r) => setTimeout(r, 20))
+
+    // then: it is blocked — requestContainerRestart holds the lock from before the ACK
+    expect(secondAcquired).toBe(false)
+    expect(existsSync(restartHandoffPath(agentDir))).toBe(false)
+
+    // when: the ACK lands, requestContainerRestart writes and releases the lock
+    releaseAck()
+    await restartDone
+    const release2 = await second
+
+    // then: the second producer only proceeds AFTER the committed handoff exists,
+    //   and that handoff carries requestContainerRestart's origin + author
+    expect(secondAcquired).toBe(true)
+    expect(JSON.parse(await readFile(restartHandoffPath(agentDir), 'utf8'))).toMatchObject({
+      originatingSessionId: 'ses-origin',
+      triggeringAuthorId: 'U_OWNER',
+      origin: { kind: 'channel' },
+    })
+    release2()
   })
 
   test('writes triggeringAuthorId into the handoff so the resumed session re-seeds the requester', async () => {

--- a/src/agent/restart/index.ts
+++ b/src/agent/restart/index.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path'
 
-import { type RestartHandoffOrigin, writeRestartHandoff } from '@/agent/restart-handoff'
+import { acquireRestartHandoffLock, type RestartHandoffOrigin, writeRestartHandoff } from '@/agent/restart-handoff'
 import { sendHttp } from '@/hostd/client'
 import type { Stream } from '@/stream'
 
@@ -77,52 +77,73 @@ export async function requestContainerRestart({
         'host daemon control endpoint unavailable (TYPECLAW_HOSTD_URL/TYPECLAW_HOSTD_TOKEN not set); cannot request restart',
     }
   }
-  const reply = await sendHttp(request, { timeoutMs: ackBudget, url: httpUrl, token: httpToken })
+  const url = httpUrl
+  const token = httpToken
 
-  if (!reply.ok) return { ok: false, containerName, reason: reply.reason }
-
-  const restartTimestamp = restartedAt ?? new Date().toISOString()
-
-  // Fan out the restart notice to every live session BEFORE writing the handoff.
-  // The originating session's subscribeRestartNotice appends the
-  // typeclaw.restart-self entry synchronously (broker delivery + the JSONL
-  // append are both synchronous), so the handoff below points at a JSONL that
-  // already carries the "I'm back" instruction the rebooted container hydrates.
-  // Only after an accepted ACK, never on a failed/timed-out restart.
-  if (stream !== undefined && originatingSessionId !== undefined) {
-    const broadcast: ContainerRestartingBroadcast = {
-      kind: 'container-restarting',
-      restartedAt: restartTimestamp,
-      originatingSessionId,
-    }
-    stream.publish({ target: { kind: 'broadcast' }, payload: broadcast })
-  }
-
-  // Post-ACK: hostd has committed the restart, so a handoff-write failure must
-  // never demote it to a failure — that would render a false error in the TUI
-  // and swallow the accepted response. The handoff is a best-effort resume hint
-  // only; a missing one just cold-starts the rebooted container without the
-  // "I'm back" greeting. writeRestartHandoff swallows its own errors today, but
-  // guard here too so this contract survives the writer being changed later.
-  if (
+  const handoffTarget =
     agentDir !== undefined &&
     originatingSessionId !== undefined &&
     originatingSessionFile !== undefined &&
     handoffOrigin !== undefined
-  ) {
-    try {
-      await writeRestartHandoff(agentDir, {
-        schemaVersion: 2,
-        restartedAt: restartTimestamp,
-        originatingSessionId,
-        originatingSessionFile: basename(originatingSessionFile),
-        origin: handoffOrigin,
-        ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
-      })
-    } catch {
-      // intentional swallow — see the post-ACK rationale above
-    }
+      ? { agentDir, originatingSessionId, originatingSessionFile, handoffOrigin }
+      : undefined
+
+  // Hold the handoff lock from BEFORE the ACK through our post-ACK write. hostd
+  // fires `docker stop` → SIGTERM the instant it accepts, so the container's
+  // SIGTERM writer can run while we are still mid-flight; the lock makes it wait
+  // and then augment the exact handoff we commit here, instead of synthesizing
+  // one for another session in the gap before our write lands.
+  const releaseHandoffLock =
+    handoffTarget !== undefined ? await acquireRestartHandoffLock(handoffTarget.agentDir) : undefined
+  try {
+    return await performRestart()
+  } finally {
+    releaseHandoffLock?.()
   }
 
-  return { ok: true, containerName, restartedAt: restartTimestamp }
+  async function performRestart(): Promise<RequestContainerRestartResult> {
+    const reply = await sendHttp(request, { timeoutMs: ackBudget, url, token })
+
+    if (!reply.ok) return { ok: false, containerName, reason: reply.reason }
+
+    const restartTimestamp = restartedAt ?? new Date().toISOString()
+
+    // Fan out the restart notice to every live session BEFORE writing the handoff.
+    // The originating session's subscribeRestartNotice appends the
+    // typeclaw.restart-self entry synchronously (broker delivery + the JSONL
+    // append are both synchronous), so the handoff below points at a JSONL that
+    // already carries the "I'm back" instruction the rebooted container hydrates.
+    // Only after an accepted ACK, never on a failed/timed-out restart.
+    if (stream !== undefined && originatingSessionId !== undefined) {
+      const broadcast: ContainerRestartingBroadcast = {
+        kind: 'container-restarting',
+        restartedAt: restartTimestamp,
+        originatingSessionId,
+      }
+      stream.publish({ target: { kind: 'broadcast' }, payload: broadcast })
+    }
+
+    // Post-ACK: hostd has committed the restart, so a handoff-write failure must
+    // never demote it to a failure — that would render a false error in the TUI
+    // and swallow the accepted response. The handoff is a best-effort resume hint
+    // only; a missing one just cold-starts the rebooted container without the
+    // "I'm back" greeting. writeRestartHandoff swallows its own errors today, but
+    // guard here too so this contract survives the writer being changed later.
+    if (handoffTarget !== undefined) {
+      try {
+        await writeRestartHandoff(handoffTarget.agentDir, {
+          schemaVersion: 2,
+          restartedAt: restartTimestamp,
+          originatingSessionId: handoffTarget.originatingSessionId,
+          originatingSessionFile: basename(handoffTarget.originatingSessionFile),
+          origin: handoffTarget.handoffOrigin,
+          ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
+        })
+      } catch {
+        // intentional swallow — see the post-ACK rationale above
+      }
+    }
+
+    return { ok: true, containerName, restartedAt: restartTimestamp }
+  }
 }

--- a/src/agent/tools/channel-edit.test.ts
+++ b/src/agent/tools/channel-edit.test.ts
@@ -58,6 +58,7 @@ function fakeRouter(handler: (req: EditMessageRequest) => Promise<EditMessageRes
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-fetch-attachment.test.ts
+++ b/src/agent/tools/channel-fetch-attachment.test.ts
@@ -92,6 +92,7 @@ function makeRouter(options: FakeRouterOptions = {}): ChannelRouter {
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
   }
 }

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -68,6 +68,7 @@ function fakeRouter(onSend: (msg: OutboundMessage) => SendResult = () => ({ ok: 
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -76,6 +76,7 @@ function fakeRouter(
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-send.resolve.test.ts
+++ b/src/agent/tools/channel-send.resolve.test.ts
@@ -77,6 +77,7 @@ function fakeRouter(handlers: {
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-send.test.ts
+++ b/src/agent/tools/channel-send.test.ts
@@ -66,6 +66,7 @@ function fakeRouter(
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -94,6 +94,7 @@ function fakeRouter(overrides: RouterOverrides = {}): ChannelRouter {
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/agent/tools/skip-response.test.ts
+++ b/src/agent/tools/skip-response.test.ts
@@ -71,6 +71,7 @@ function fakeRouter(
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -85,6 +85,7 @@ function fakeRouter(handler: (msg: OutboundMessage) => Promise<SendResult>): Cha
     stop: async () => {},
     tearDownAllLive: async () => {},
     markRestartAbortForAllLive: async () => {},
+    writeInterruptedSubagentHandoff: async () => false,
     liveCount: () => 0,
     executeCommand: async () => ({ kind: 'no-live-session' }),
     injectSubagentCompletionReminder: () => ({ kind: 'no-live-session' }),

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -134,6 +134,10 @@ export type ChannelManagerOptions = {
   // otherwise spawn a duplicate child). Production wiring (src/run/index.ts)
   // supplies it from the LiveSubagentRegistry; tests omit it.
   newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
+  // Forwarded to the router so the graceful-restart handoff can name the
+  // background subagents a session was still awaiting. Same wiring shape as
+  // newestRunningChildSubagentStartedAt; tests omit it.
+  listRunningBackgroundSubagentNames?: (sessionId: string) => string[]
   // Persistent messenger SDKs usually reconnect themselves, but a host sleep/offline
   // cycle can leave a socket half-dead forever. The manager watches live adapters
   // and restarts one that stays disconnected past this grace period. Test seams are
@@ -199,6 +203,9 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     ...(options.onRestart ? { onRestart: options.onRestart } : {}),
     ...(options.newestRunningChildSubagentStartedAt
       ? { newestRunningChildSubagentStartedAt: options.newestRunningChildSubagentStartedAt }
+      : {}),
+    ...(options.listRunningBackgroundSubagentNames
+      ? { listRunningBackgroundSubagentNames: options.listRunningBackgroundSubagentNames }
       : {}),
   })
   const createDiscordBot = options.createDiscordAdapter ?? createDiscordBotAdapter

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -8,7 +8,13 @@ import type { AssistantMessage } from '@mariozechner/pi-ai'
 import type { SessionEntry } from '@mariozechner/pi-coding-agent'
 
 import type { AgentSession, SessionOriginRef } from '@/agent'
-import type { RestartHandoff } from '@/agent/restart-handoff'
+import {
+  consumeRestartHandoff,
+  peekRestartHandoff,
+  RESTART_HANDOFF_TTL_MS,
+  type RestartHandoff,
+  writeRestartHandoff,
+} from '@/agent/restart-handoff'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { readContinuationState } from '@/agent/todo/continuation-state'
 import { resolveTodoScope } from '@/agent/todo/scope'
@@ -45,7 +51,10 @@ import {
   isGraceWorthReusing,
   SESSION_GC_INTERVAL_MS,
   SESSION_FRESHNESS_TTL_MS,
+  buildInterruptedSubagentNotice,
+  buildRestartResumeWakeReminder,
   OBSERVED_MESSAGE_MAX_CHARS,
+  RESTART_RESUME_WAKE_REMINDER,
   SESSION_GRACE_HARD_TTL_MS,
   SESSION_IDLE_MS,
   SESSION_CHILD_STUCK_BACKSTOP_MS,
@@ -366,6 +375,7 @@ function makeRouter(
     onRestart?: (ctx?: RestartCommandContext) => Promise<string>
     saveChannelSessions?: (agentDir: string, sessions: readonly ChannelSessionRecord[]) => Promise<void>
     newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
+    listRunningBackgroundSubagentNames?: (sessionId: string) => string[]
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -385,6 +395,9 @@ function makeRouter(
     ...(options.saveChannelSessions !== undefined ? { saveChannelSessions: options.saveChannelSessions } : {}),
     ...(options.newestRunningChildSubagentStartedAt !== undefined
       ? { newestRunningChildSubagentStartedAt: options.newestRunningChildSubagentStartedAt }
+      : {}),
+    ...(options.listRunningBackgroundSubagentNames !== undefined
+      ? { listRunningBackgroundSubagentNames: options.listRunningBackgroundSubagentNames }
       : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
@@ -11448,6 +11461,231 @@ describe('ChannelRouter idle session GC', () => {
   })
 })
 
+describe('ChannelRouter writeInterruptedSubagentHandoff', () => {
+  async function liveRouterWithNames(
+    dir: string,
+    names: (sessionId: string) => string[],
+    nowRef?: { value: number },
+  ): Promise<ReturnType<typeof makeRouter>['router']> {
+    const { router } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/fake/${sessionId}.jsonl`,
+      listRunningBackgroundSubagentNames: names,
+      ...(nowRef !== undefined ? { nowRef } : {}),
+    })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    return router
+  }
+
+  test('writes a channel handoff naming the running background subagents', async () => {
+    // given: a live session whose only background child is a running researcher
+    const dir = await tempDir()
+    const router = await liveRouterWithNames(dir, (sessionId) => (sessionId === 'ses_fake_1' ? ['researcher'] : []))
+
+    // when
+    const wrote = await router.writeInterruptedSubagentHandoff()
+
+    // then
+    expect(wrote).toBe(true)
+    const handoff = await consumeRestartHandoff(dir, { now: 1000, accept: (h) => h.origin.kind === 'channel' })
+    expect(handoff?.interruptedSubagents).toEqual(['researcher'])
+    expect(handoff?.origin).toEqual({ kind: 'channel', key: KEY })
+    expect(handoff?.originatingSessionId).toBe('ses_fake_1')
+    expect(handoff?.originatingSessionFile).toBe('ses_fake_1.jsonl')
+  })
+
+  test('writes no handoff and returns false when no session has running background subagents', async () => {
+    // given: a live session with no background children
+    const dir = await tempDir()
+    const router = await liveRouterWithNames(dir, () => [])
+
+    // when
+    const wrote = await router.writeInterruptedSubagentHandoff()
+
+    // then
+    expect(wrote).toBe(false)
+    expect(await consumeRestartHandoff(dir, { accept: (h) => h.origin.kind === 'channel' })).toBeNull()
+  })
+
+  test('returns false when the registry callback is not wired', async () => {
+    // given: a live session but no listRunningBackgroundSubagentNames option
+    const dir = await tempDir()
+    const { router } = makeRouter(dir, { transcriptPathFor: (sessionId) => `/fake/${sessionId}.jsonl` })
+    await router.route(inbound({ text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when / then
+    expect(await router.writeInterruptedSubagentHandoff()).toBe(false)
+  })
+
+  test('augments an existing handoff with ITS session names, not another live conversation', async () => {
+    // given: an accepted in-session restart handoff for ses_in_session (with an
+    //   author), plus a DIFFERENT live session ses_fake_1 that has its own
+    //   background child. The augment must use ses_in_session's children only —
+    //   attaching ses_fake_1's would tell the restarting thread about unrelated work.
+    const dir = await tempDir()
+    const nowRef = { value: 50_000 }
+    await writeRestartHandoff(dir, {
+      schemaVersion: 2,
+      restartedAt: new Date(1000).toISOString(),
+      originatingSessionId: 'ses_in_session',
+      originatingSessionFile: 'ses_in_session.jsonl',
+      origin: { kind: 'channel', key: KEY },
+      triggeringAuthorId: 'U_OWNER',
+    })
+    const namesFor = (sessionId: string): string[] => {
+      if (sessionId === 'ses_in_session') return ['planner']
+      if (sessionId === 'ses_fake_1') return ['researcher']
+      return []
+    }
+    const router = await liveRouterWithNames(dir, namesFor, nowRef)
+
+    // when
+    const wrote = await router.writeInterruptedSubagentHandoff()
+
+    // then: origin/session/author preserved; names are ses_in_session's, NOT ses_fake_1's;
+    //   restartedAt refreshed to now() so the boot consumer doesn't discard the added note
+    expect(wrote).toBe(true)
+    const handoff = await peekRestartHandoff(dir)
+    expect(handoff?.originatingSessionId).toBe('ses_in_session')
+    expect(handoff?.triggeringAuthorId).toBe('U_OWNER')
+    expect(handoff?.interruptedSubagents).toEqual(['planner'])
+    expect(Date.parse(handoff!.restartedAt)).toBe(nowRef.value)
+  })
+
+  test('returns false and leaves an existing handoff untouched when its own session has no running children', async () => {
+    // given: a handoff for ses_in_session (no children), plus an unrelated live
+    //   session with children — which must NOT be pulled onto the handoff
+    const dir = await tempDir()
+    await writeRestartHandoff(dir, {
+      schemaVersion: 2,
+      restartedAt: new Date(1000).toISOString(),
+      originatingSessionId: 'ses_in_session',
+      originatingSessionFile: 'ses_in_session.jsonl',
+      origin: { kind: 'channel', key: KEY },
+    })
+    const router = await liveRouterWithNames(dir, (sessionId) => (sessionId === 'ses_fake_1' ? ['researcher'] : []))
+
+    // when
+    const wrote = await router.writeInterruptedSubagentHandoff()
+
+    // then
+    expect(wrote).toBe(false)
+    const handoff = await peekRestartHandoff(dir)
+    expect(handoff?.originatingSessionId).toBe('ses_in_session')
+    expect(handoff?.interruptedSubagents).toBeUndefined()
+  })
+
+  test('ignores a stale (expired) handoff and writes a fresh one from current live sessions', async () => {
+    // given: an unclaimed TUI handoff older than the 60s TTL left on disk, plus a
+    //   live channel session with a running background child. peekRestartHandoff
+    //   applies no TTL, so the stale one would otherwise suppress the current
+    //   restart's note (or preserve its old restartedAt so boot discards it).
+    const dir = await tempDir()
+    const nowRef = { value: RESTART_HANDOFF_TTL_MS + 10_000 }
+    await writeRestartHandoff(dir, {
+      schemaVersion: 2,
+      restartedAt: new Date(0).toISOString(),
+      originatingSessionId: 'ses_stale_tui',
+      originatingSessionFile: 'ses_stale_tui.jsonl',
+      origin: { kind: 'tui' },
+    })
+    const router = await liveRouterWithNames(
+      dir,
+      (sessionId) => (sessionId === 'ses_fake_1' ? ['researcher'] : []),
+      nowRef,
+    )
+
+    // when
+    const wrote = await router.writeInterruptedSubagentHandoff()
+
+    // then: the stale TUI handoff is discarded; a FRESH channel handoff is written
+    //   for the current live session, timestamped now() so boot won't drop it
+    expect(wrote).toBe(true)
+    const handoff = await peekRestartHandoff(dir)
+    expect(handoff?.origin).toEqual({ kind: 'channel', key: KEY })
+    expect(handoff?.originatingSessionId).toBe('ses_fake_1')
+    expect(handoff?.interruptedSubagents).toEqual(['researcher'])
+    expect(Date.parse(handoff!.restartedAt)).toBe(nowRef.value)
+    // and the fresh handoff is within TTL of now(), so the boot consumer keeps it
+    expect(
+      await consumeRestartHandoff(dir, { now: nowRef.value, accept: (h) => h.origin.kind === 'channel' }),
+    ).not.toBeNull()
+  })
+
+  test('a fresh operator-restart handoff retains the live session author (author-scoped role survives boot)', async () => {
+    // given: a live channel session whose turn author is U_OWNER (from the routed
+    //   inbound) with a running background child, and no pre-existing handoff —
+    //   the external `typeclaw restart` path with no in-session /restart, no race
+    const dir = await tempDir()
+    const { router } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/fake/${sessionId}.jsonl`,
+      listRunningBackgroundSubagentNames: (sessionId) => (sessionId === 'ses_fake_1' ? ['researcher'] : []),
+    })
+    await router.route(inbound({ isBotMention: true, authorId: 'U_OWNER', authorName: 'owner', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // when
+    const wrote = await router.writeInterruptedSubagentHandoff()
+
+    // then: the handoff carries triggeringAuthorId so boot re-seeds the author and
+    //   the author-scoped role (hence channel.send) survives the reminder-only resume
+    expect(wrote).toBe(true)
+    expect((await peekRestartHandoff(dir))?.triggeringAuthorId).toBe('U_OWNER')
+  })
+})
+
+describe('buildRestartResumeWakeReminder', () => {
+  test('returns the plain wake reminder when no subagents were interrupted', () => {
+    expect(buildRestartResumeWakeReminder()).toBe(RESTART_RESUME_WAKE_REMINDER)
+    expect(buildRestartResumeWakeReminder([])).toBe(RESTART_RESUME_WAKE_REMINDER)
+  })
+
+  test('names the interrupted subagents and directs a language-adaptive notice', () => {
+    const reminder = buildRestartResumeWakeReminder(['researcher', 'scout'])
+
+    expect(reminder).toContain('researcher, scout')
+    expect(reminder).toContain('lost when the container')
+    // the directive tells the model to reply in the audience's language, so it
+    // is not English-locked — assert that instruction survives
+    expect(reminder).toContain('in their own language')
+    // never auto-re-run: the human re-asks
+    expect(reminder).toContain('Do not silently')
+  })
+
+  test('renders a non-ASCII (Korean) subagent name intact', () => {
+    // AGENTS.md multi-language rule: text handling must not corrupt non-Latin scripts
+    const reminder = buildRestartResumeWakeReminder(['연구원'])
+
+    expect(reminder).toContain('연구원')
+  })
+
+  test('embeds the standalone interrupted-subagent notice', () => {
+    // the reminder composes the plain wake with the reusable notice, so the
+    // sawInbound path (which uses the notice alone) stays in sync
+    const reminder = buildRestartResumeWakeReminder(['researcher'])
+
+    expect(reminder).toContain(RESTART_RESUME_WAKE_REMINDER)
+    expect(reminder).toContain(buildInterruptedSubagentNotice(['researcher']))
+  })
+})
+
+describe('buildInterruptedSubagentNotice', () => {
+  test('names the lost subagents and forbids auto-re-run, language-adaptively', () => {
+    const notice = buildInterruptedSubagentNotice(['researcher', 'scout'])
+
+    expect(notice).toContain('researcher, scout')
+    expect(notice).toContain('lost when the container')
+    expect(notice).toContain('in their own language')
+    expect(notice).toContain('Do not silently')
+  })
+
+  test('does not include the generic "session was resumed" wake line', () => {
+    // standalone use rides a real inbound's turn, so the "resumed" framing would be wrong
+    expect(buildInterruptedSubagentNotice(['researcher'])).not.toContain('this session was resumed')
+  })
+})
+
 describe('ChannelRouter channel.respond gate', () => {
   type PermissionTable = Record<string, readonly string[]>
 
@@ -14290,6 +14528,57 @@ describe('resumeRestartHandoff', () => {
     // then: the synthetic wake turn fired
     expect(reservation.sawInbound).toBe(false)
     expect(sessions[0]?.prompts.some((p) => p.includes('container just restarted'))).toBe(true)
+  })
+
+  test('delivers the interrupted-subagent notice even when a real inbound coalesced', async () => {
+    // given: a handoff carrying interrupted names AND a racing inbound. The
+    //   generic wake is skipped, but the lost-work directive must still land or
+    //   the thread is never told its result was lost (the review-flagged gap).
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const { router, sessions } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+    const reservation = router.reserveRestartHandoff(channelHandoff({ interruptedSubagents: ['researcher'] }))!
+    const inboundDone = router.route(inbound({ authorId: 'alice', authorName: 'alice', text: 'hi there' }))
+    await waitFor(() => reservation.sawInbound)
+
+    // when
+    await reservation.resume()
+    await inboundDone
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: no generic synthetic wake, but the lost-work directive rode a turn
+    expect(sessions).toHaveLength(1)
+    const prompts = sessions[0]!.prompts
+    expect(prompts.some((p) => p.includes('container just restarted'))).toBe(false)
+    expect(prompts.some((p) => p.includes('researcher') && p.includes('lost when the container'))).toBe(true)
+  })
+
+  test('delivers the notice even when the racing inbound is observe-only (never engages)', async () => {
+    // given: a handoff with interrupted names and a racing inbound that will NOT
+    //   engage (not a mention, not a reply, mentions no one). sawInbound flips
+    //   before that decision, so without an explicit drain the queued notice is
+    //   stranded — the review-flagged observe-only gap.
+    const dir = await tempDir()
+    await seedMapping(dir, 'ses_origin', '2026-05-02T16-56-52-380Z_ses_origin.jsonl')
+    const { router, sessions } = makeRouter(dir, {
+      transcriptPathFor: (sessionId) => `/tmp/fake/2026-05-02T16-56-52-380Z_${sessionId}.jsonl`,
+    })
+    const reservation = router.reserveRestartHandoff(channelHandoff({ interruptedSubagents: ['researcher'] }))!
+    const inboundDone = router.route(
+      inbound({ authorId: 'alice', authorName: 'alice', text: 'just chatting', isBotMention: false }),
+    )
+    await waitFor(() => reservation.sawInbound)
+
+    // when
+    await reservation.resume()
+    await inboundDone
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the notice still reached a prompt via the explicit drain
+    await waitFor(() => sessions.length > 0 && sessions[0]!.prompts.some((p) => p.includes('lost when the container')))
+    expect(sessions[0]!.prompts.some((p) => p.includes('container just restarted'))).toBe(false)
   })
 
   test('resume wake turn re-seeds the handoff author so author-scoped roles survive restart', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -5257,16 +5257,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // still running, record their names in the restart handoff so the boot resume
   // can tell that thread its promised result was lost. Only one handoff exists
   // on disk, so the FIRST session with running background children wins; the
-  // rare "two threads mid-research at once" case notifies one.
-  //
-  // An accepted in-session restart may have ALREADY written a handoff (with its
-  // own origin, session, and triggeringAuthorId). We must not clobber it, and we
-  // must attach the names of ITS session's children — not some other live
-  // conversation's — or the resumed thread is told about work it never asked
-  // for. So peek first: when a handoff exists, augment it with the interrupted
-  // children of exactly `existing.originatingSessionId`. Only when no handoff
-  // exists do we scan live sessions and write a fresh channel handoff for the
-  // first one with running background children.
+  // rare "two threads mid-research at once" case notifies one. The fresh/stale
+  // and augment-vs-fresh-write decision is documented inline below.
   //
   // Returns whether the handoff now carries interrupted names, propagated from
   // the writer's real result so a swallowed filesystem failure reports false.

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -10,7 +10,13 @@ import { resolveFallbackChain } from '@/agent/model-fallback'
 import { applyModelRuntimeOverrides } from '@/agent/model-overrides'
 import { forgetSharedLoopGuardTool } from '@/agent/plugin-tools'
 import { detectHardProviderError, isFailoverWorthy, subscribeProviderErrors } from '@/agent/provider-error'
-import type { RestartHandoff } from '@/agent/restart-handoff'
+import {
+  acquireRestartHandoffLock,
+  peekRestartHandoff,
+  RESTART_HANDOFF_TTL_MS,
+  type RestartHandoff,
+  writeRestartHandoff,
+} from '@/agent/restart-handoff'
 import type { ChannelParticipant, SessionOrigin } from '@/agent/session-origin'
 import { renderSubagentCompletionReminder } from '@/agent/subagent-completion-reminder'
 import {
@@ -215,6 +221,38 @@ export const RESTART_RESUME_WAKE_REMINDER = [
   '',
   '---',
 ].join('\n')
+
+// The lost-work directive: names the interrupted subagents and tells the model
+// to inform the thread, in the audience's language, that the result was lost —
+// never to re-run it automatically (the human decides whether to re-ask). Used
+// standalone when a racing inbound already provides the wake turn, and embedded
+// in the fuller resume reminder when the synthetic wake fires. Rendered as plain
+// text so a non-Latin subagent name survives intact.
+export function buildInterruptedSubagentNotice(interruptedSubagents: readonly string[]): string {
+  const names = interruptedSubagents.join(', ')
+  return [
+    '---',
+    '**[SYSTEM MESSAGE — not from a human]**',
+    '',
+    `A background task you had promised a result for was lost when the container`,
+    `restarted (interrupted subagent(s): ${names}). Briefly tell the people in`,
+    `this conversation, in their own language, that the result was lost to a`,
+    `restart and they can ask again if they still want it. Do not silently`,
+    `re-run it. Do not acknowledge or reply to this notice itself.`,
+    '',
+    '---',
+  ].join('\n')
+}
+
+// The synthetic "I'm back" wake, optionally carrying the lost-work directive
+// when the restart interrupted background subagents this session had promised
+// results for. With none, it is the plain wake reminder unchanged.
+export function buildRestartResumeWakeReminder(interruptedSubagents?: readonly string[]): string {
+  if (interruptedSubagents === undefined || interruptedSubagents.length === 0) {
+    return RESTART_RESUME_WAKE_REMINDER
+  }
+  return `${RESTART_RESUME_WAKE_REMINDER}\n\n${buildInterruptedSubagentNotice(interruptedSubagents)}`
+}
 // Ceiling on tool-source channel sends that a same-turn router policy DENIED
 // without delivering — `skip-locked`, `turn-cap`, or `duplicate`. Such denials
 // return a soft error and do NOT increment `consecutiveSends`, so a model that
@@ -1388,6 +1426,10 @@ export type ChannelRouter = {
   // Graceful-restart shutdown: mark + abort every live channel session so each
   // scope's incomplete todos auto-continue on the next boot. See the impl.
   markRestartAbortForAllLive: () => Promise<void>
+  // Graceful-restart shutdown: persist a channel handoff naming the background
+  // subagents a live session was still awaiting, so the resume greeting can tell
+  // that thread the promised result was lost. Resolves true iff one was written.
+  writeInterruptedSubagentHandoff: () => Promise<boolean>
   liveCount: () => number
   __testing?: {
     flushDebounce: (key: ChannelKey) => Promise<void>
@@ -1521,6 +1563,11 @@ export type CreateChannelRouterOptions = {
   // spawned child is still inside its window. Production wiring forwards the
   // LiveSubagentRegistry; omitted (tests, no-subagent setups) means no pin.
   newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
+  // Names of the still-running BACKGROUND subagents for a parent session, used
+  // by writeInterruptedSubagentHandoff on graceful restart to name the lost
+  // work in the resume greeting. Background-only: a foreground child returns its
+  // result inline, so it is not orphaned by the bounce. Omitted means none.
+  listRunningBackgroundSubagentNames?: (sessionId: string) => string[]
 }
 
 export type RestartCommandContext = {
@@ -5206,6 +5253,81 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     }
   }
 
+  // Graceful-restart hint: if a live channel session has background subagents
+  // still running, record their names in the restart handoff so the boot resume
+  // can tell that thread its promised result was lost. Only one handoff exists
+  // on disk, so the FIRST session with running background children wins; the
+  // rare "two threads mid-research at once" case notifies one.
+  //
+  // An accepted in-session restart may have ALREADY written a handoff (with its
+  // own origin, session, and triggeringAuthorId). We must not clobber it, and we
+  // must attach the names of ITS session's children — not some other live
+  // conversation's — or the resumed thread is told about work it never asked
+  // for. So peek first: when a handoff exists, augment it with the interrupted
+  // children of exactly `existing.originatingSessionId`. Only when no handoff
+  // exists do we scan live sessions and write a fresh channel handoff for the
+  // first one with running background children.
+  //
+  // Returns whether the handoff now carries interrupted names, propagated from
+  // the writer's real result so a swallowed filesystem failure reports false.
+  const writeInterruptedSubagentHandoff = async (): Promise<boolean> => {
+    const listNames = options.listRunningBackgroundSubagentNames
+    if (listNames === undefined) return false
+
+    // Take the same lock `/restart` holds so our peek→select→write is atomic
+    // relative to its post-ACK write: either it commits first and we augment the
+    // exact handoff, or we commit first and it overwrites with its own origin —
+    // never an interleaved read-modify-write that drops one producer's data.
+    const release = await acquireRestartHandoffLock(options.agentDir)
+    try {
+      // A FRESH existing handoff is authoritative: it is the accepted in-session
+      // restart's, so we augment it (never clobber its origin/author with a
+      // different live session's) — or, if its own session has no running
+      // children, leave it untouched and record nothing. A STALE handoff is not
+      // authoritative: peekRestartHandoff applies no TTL, so an unclaimed TUI
+      // handoff left on disk by kind-aware consume can surface here; honoring it
+      // would suppress THIS restart's note or preserve its old restartedAt so the
+      // next boot discards the note as stale — so we ignore it and write fresh
+      // from the current live sessions. When we augment, stamp restartedAt=now()
+      // so the note survives the boot TTL.
+      const existing = await peekRestartHandoff(options.agentDir)
+      const existingIsFresh = existing !== null && now() - Date.parse(existing.restartedAt) <= RESTART_HANDOFF_TTL_MS
+      if (existing !== null && existingIsFresh) {
+        const names = listNames(existing.originatingSessionId)
+        if (names.length === 0) return false
+        return await writeRestartHandoff(options.agentDir, {
+          ...existing,
+          restartedAt: new Date(now()).toISOString(),
+          interruptedSubagents: names,
+        })
+      }
+
+      for (const live of Array.from(liveSessions.values())) {
+        const names = listNames(live.sessionId)
+        if (names.length === 0) continue
+        const sessionFile = live.getTranscriptPath?.()
+        if (sessionFile === undefined) continue
+        // Carry the session's author (same precedence as buildRestartCommandContext)
+        // so boot re-seeds lastTurnAuthorId. Without it an author-scoped role demotes
+        // on resume and the reminder-only turn can lose channel.send — i.e. fail to
+        // deliver the very lost-work notice this handoff exists for.
+        const triggeringAuthorId = live.currentTurnAuthorId ?? live.lastTurnAuthorId ?? undefined
+        return await writeRestartHandoff(options.agentDir, {
+          schemaVersion: 2,
+          restartedAt: new Date(now()).toISOString(),
+          originatingSessionId: live.sessionId,
+          origin: { kind: 'channel', key: live.key },
+          originatingSessionFile: basename(sessionFile),
+          interruptedSubagents: names,
+          ...(triggeringAuthorId !== undefined ? { triggeringAuthorId } : {}),
+        })
+      }
+      return false
+    } finally {
+      release()
+    }
+  }
+
   // Boot-time resume for a restart that originated from a channel session, in
   // two phases to close the race with adapters that begin receiving inbounds.
   //
@@ -5299,8 +5421,25 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         // A real inbound coalesced onto the reservation during boot: it is the
         // wake. Adding the synthetic "I'm back" turn on top would duplicate
         // work / stack a spurious turn, so skip it and let the inbound drain.
+        // The interrupted-subagent directive is NOT part of that generic wake,
+        // though: it is the only signal that a promised result was lost, and the
+        // boot already consumed the handoff, so if we drop it here no later turn
+        // re-delivers it. Queue it AND drain ourselves: `sawInbound` is set
+        // before engagement is decided, so an observe-only inbound returns
+        // without draining and would strand the reminder. drain() is guarded
+        // (`draining || destroyed` no-ops) so if the inbound WILL engage this is
+        // a harmless second call, and its loop consumes pendingSystemReminders
+        // either way. Still skip the generic synthetic wake.
         if (reservation.sawInbound) {
-          logger.info(`[channels] ${keyId}: restart-resume coalesced with a real inbound; skipping synthetic wake`)
+          if (handoff.interruptedSubagents !== undefined && handoff.interruptedSubagents.length > 0) {
+            live.pendingSystemReminders.push(buildInterruptedSubagentNotice(handoff.interruptedSubagents))
+            logger.info(
+              `[channels] ${keyId}: restart-resume coalesced with a real inbound; delivering interrupted-subagent notice`,
+            )
+            void drain(live)
+          } else {
+            logger.info(`[channels] ${keyId}: restart-resume coalesced with a real inbound; skipping synthetic wake`)
+          }
           return
         }
 
@@ -5314,7 +5453,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           logger.error(`[channels] ${keyId}: restart-resume clear abort suppression failed: ${describe(err)}`),
         )
 
-        live.pendingSystemReminders.push(RESTART_RESUME_WAKE_REMINDER)
+        live.pendingSystemReminders.push(buildRestartResumeWakeReminder(handoff.interruptedSubagents))
         logger.info(`[channels] ${keyId}: restart-resume waking session ${live.sessionId}`)
         void drain(live)
       },
@@ -5741,6 +5880,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     stop,
     tearDownAllLive,
     markRestartAbortForAllLive,
+    writeInterruptedSubagentHandoff,
     liveCount: () => liveSessions.size,
     __testing: {
       flushDebounce: async (key: ChannelKey) => {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -430,6 +430,11 @@ async function startAgentRuntime(
             child.status === 'running' && (newest === null || child.startedAt > newest) ? child.startedAt : newest,
           null,
         ),
+    listRunningBackgroundSubagentNames: (sessionId) =>
+      liveSubagentRegistry
+        .list({ parentSessionId: sessionId })
+        .filter((child) => child.status === 'running' && child.background === true)
+        .map((child) => child.subagentName),
     onReload: async () => {
       const { results } = await reloadRegistry.reloadAll()
       return formatChannelReloadSummary(results)
@@ -1040,6 +1045,10 @@ async function startAgentRuntime(
     forceExit.unref()
     void (async () => {
       if (containerName !== undefined) {
+        // Persist the interrupted-subagent handoff BEFORE markRestartAbortForAllLive
+        // aborts the sessions and stop() tears them down — both read the same live
+        // set this write depends on.
+        await channelManager.router.writeInterruptedSubagentHandoff().catch(() => undefined)
         await markRestartAbortPendingForOrigin(cwd, { kind: 'tui', sessionId: 'tui' }).catch(() => undefined)
         await channelManager.router.markRestartAbortForAllLive().catch(() => undefined)
       }


### PR DESCRIPTION
## Background

An operator `typeclaw restart` (or `stop`/`restart` via the host) while a channel session was awaiting a **backgrounded `spawn_subagent`** result silently strands that thread. The container goes down (SIGTERM), the in-memory subagent tree dies with it, and the session that promised "I'll post when it's done" never wakes again.

Observed in production: a `researcher` fact-check was kicked off in a Slack thread. The agent replied "researcher 돌려놨음 ㅇㅇ … 나오면 올림" (kicked off the researcher, will post when it's done), then delivered **nothing**. The user asked "뒤짐?" (did it die?) repeatedly over ~2.5 hours and got only silence, until a container restart wiped the whole in-flight tree for good.

Root cause is a gap in the graceful-restart path, not the subagent runtime: the SIGTERM handler (`src/run/index.ts`) already marks live todo scopes for auto-continuation, but it wrote **no handoff** and **ignored in-flight subagents**. So the one session that knew a thread was still waiting had no way to say so after the bounce. (The related indefinite-*hang*-without-restart is bounded separately by the per-child subagent timeout work; this PR closes only the restart-loses-the-work window.)

## Summary

Reuse the existing single-file `RestartHandoff` — **no new persistence file** — to carry a breadcrumb across the bounce:

- **`RestartHandoff` gains an optional, additive `interruptedSubagents: string[]`** (schema v2, parsed defensively). **Why reuse the handoff and not a new ledger:** the handoff already has the atomic write, the boot-consume path, the channel-resume machinery, and — critically — a **60s TTL**. Riding that TTL means a `stop → idle-for-hours → start` drops the notice instead of replaying it into a conversation that has moved on. A new file would have had to re-implement that freshness gate.
- **`writeInterruptedSubagentHandoff()`** (router) writes one channel handoff for the first live session with running **background** children. **Why background-only:** a foreground child returns its result inline as the tool result, so it isn't orphaned by the bounce.
- **`buildRestartResumeWakeReminder()`** folds the interrupted subagent names into the "I'm back" reminder as a **language-adaptive** directive that names the lost work and **explicitly does not auto-re-run** — the human decides whether to re-ask.

**Why single-channel coverage:** one handoff exists on disk, so the first live session with running background children wins. The rare "two threads mid-research at the same instant" case notifies one; the per-child timeout work bounds the indefinite hang for the rest regardless. This matches how `RestartHandoff` already resumes exactly one session.

## What this does NOT do

- Does **not** resurrect the subagent tree — notice only, the human re-asks.
- Does **not** add a new state file or a durable subagent registry.
- Does **not** cover a hard `SIGKILL`/crash (the handoff is written in the SIGTERM grace window, same as the existing resume greeting).
- Does **not** change the researcher/scout prompts or delegation shape.

## Review notes

- **Load-bearing ordering** (`src/run/index.ts`): `writeInterruptedSubagentHandoff()` runs **before** `markRestartAbortForAllLive()` and `stop()` — all three consume the same live-session set, and the abort/teardown would empty it first.
- **Freshness invariant**: the notice rides the handoff's existing 60s TTL (`consumeRestartHandoff`). Test `a >60s-old handoff carrying interruptedSubagents is dropped` pins the stop→idle→start behavior.
- **Additive parse**: `interruptedSubagents` is dropped when non-array, and empty/non-string entries are filtered, so an empty array never persists — mirrors the `triggeringAuthorId` additive-field pattern.
- **Multi-language** (per `AGENTS.md`): the reminder instructs the model to reply in the audience's language, and a test asserts a non-ASCII (Korean) subagent name renders intact.
- Commits are split: (1) the additive handoff field + parser, (2) the router mechanism + the 9 required fake-router stubs, (3) the restart-path wiring that triggers it.
- Checks: `typecheck`, `lint` (0 errors), `format:check`, and full `bun run test` (11520 pass, 0 fail) all green.
