### PR TITLE
fix(secrets): proactively refresh provider OAuth at boot

### DIFF
--- a/src/run/index.test.ts
+++ b/src/run/index.test.ts
@@ -8,6 +8,7 @@ import { __resetForwardRequestForTesting as resetDashboardForwardRequest } from 
 import { createChannelRouter, type ChannelManager, type ChannelManagerOptions } from '@/channels'
 import { __resetConfigForTesting, reloadConfig } from '@/config/config'
 import type { CronFile, CronJob, LoadCronResult, Scheduler } from '@/cron'
+import { SecretsBackend } from '@/secrets'
 import type { SessionFactory } from '@/sessions'
 import { rmTempDir } from '@/test-helpers/rm-temp-dir'
 import type { TuiOptions } from '@/tui'
@@ -68,6 +69,70 @@ describe('startAgent', () => {
     const res = await fetch(`http://localhost:${running.server.port}`)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('typeclaw agent')
+  })
+
+  test('awaits provider-OAuth refresh before any session consumer starts, so a lock-holding refresh cannot ELOCKED a boot auth read', async () => {
+    // given a refresh that acquires the REAL secrets lock and blocks on a gate,
+    // and a channel manager whose start() does a real synchronous secrets read
+    // (the same lock path getAuthFor() uses; it ELOCKEDs if the lock is held)
+    const order: string[] = []
+    let releaseGate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve
+    })
+    let lockAcquired: () => void = () => {}
+    const lockAcquiredSignal = new Promise<void>((resolve) => {
+      lockAcquired = resolve
+    })
+
+    const refreshProviderOAuth = async ({ agentDir }: { agentDir: string }): Promise<unknown> => {
+      const backend = new SecretsBackend(join(agentDir, 'secrets.json'))
+      return backend.withLockAsync(async () => {
+        order.push('refresh:lock-acquired')
+        lockAcquired()
+        await gate
+        order.push('refresh:lock-released')
+        return { result: undefined }
+      })
+    }
+
+    const createChannelManagerFor = (): ChannelManager => ({
+      router: createChannelRouter({ agentDir: testCwd, configForAdapter: () => undefined }),
+      start: async () => {
+        // A real sync read on the same lock — throws ELOCKED if the refresh
+        // still owns the lock, which is exactly the boot race under test.
+        new SecretsBackend(join(testCwd, 'secrets.json')).tryReadProvidersSync()
+        order.push('channel:start')
+        order.push('auth:sync-read')
+      },
+      stop: async () => {},
+      reload: async () => ({ started: [], stopped: [], restartRequired: [] }),
+      restartAdapter: async () => {},
+    })
+
+    // when startAgent boots WITHOUT being awaited yet
+    const booting = startAgent({
+      port: 0,
+      attachTui: false,
+      cwd: testCwd,
+      loadCron: noCron,
+      createChannelManager: createChannelManagerFor,
+      refreshProviderOAuth,
+    })
+
+    await lockAcquiredSignal
+
+    // then the refresh owns the lock and NO consumer has started
+    expect(order).toEqual(['refresh:lock-acquired'])
+    expect(order).not.toContain('channel:start')
+
+    // when the gate releases, boot completes with the lock free
+    releaseGate()
+    running = await booting
+
+    // then ordering is exact: refresh settles fully before the channel start
+    // (and its synchronous auth read, which did not ELOCKED)
+    expect(order).toEqual(['refresh:lock-acquired', 'refresh:lock-released', 'channel:start', 'auth:sync-read'])
   })
 
   test('installs a process crash guard so an escaped channel rejection does not crash', async () => {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -68,6 +68,7 @@ import {
   exportClaudeCredentialsFileForAgent,
   exportCodexAuthFileForAgent,
   hydrateChannelEnvFromSecrets,
+  refreshProviderOAuthForAgent,
 } from '@/secrets'
 import { createServer, type Server } from '@/server'
 import {
@@ -121,6 +122,10 @@ export type StartAgentOptions = {
   // over the real env + <cwd>/secrets.json. Injectable so tests can supply a
   // fake secrets provider without touching process.env.
   caps?: RuntimeCapabilities
+  // Boot-time proactive provider-OAuth refresh. Injectable so a test can supply
+  // a refresh that holds the real secrets lock on a gate, proving the boot
+  // barrier settles this before any session-producing consumer starts.
+  refreshProviderOAuth?: (options: { agentDir: string; log: (message: string) => void }) => Promise<unknown>
 }
 
 export type StartAgentResult = {
@@ -181,6 +186,7 @@ async function startAgentRuntime(
     createChannelManager: createChannelManagerFor = createChannelManager,
     createTunnelManager: createTunnelManagerFor = createTunnelManager,
     caps = createRuntimeCapabilities(process.env, join(cwd, 'secrets.json')),
+    refreshProviderOAuth = refreshProviderOAuthForAgent,
   }: StartAgentOptions,
   registerBootCleanup: (cleanup: () => void | Promise<void>) => void,
 ): Promise<StartAgentResult> {
@@ -372,6 +378,29 @@ async function startAgentRuntime(
   exportClaudeCredentialsFileForAgent({
     agentDir: cwd,
     claudeCodeEnabled: cwdConfig.docker.file.claudeCode,
+    log: (message) => console.warn(message),
+  })
+
+  // Proactively refresh any stored provider-OAuth token now. The SDK's own
+  // refresh is lazy (fires on the first LLM call), so a container that restarts
+  // with an already-expired access token otherwise discovers the staleness —
+  // and any refresh failure — mid-turn, surfacing a generic provider-error
+  // notice into a live thread. Doing it here moves that to a boot-time operator
+  // log. Channel-adapter OAuth already has host-side renewal crons; this is the
+  // provider-OAuth equivalent.
+  //
+  // MUST be awaited, and MUST run before the first session-producing consumer
+  // (subagentConsumer.start / cronConsumer.start / channelManager.start / the
+  // websocket server). The SDK refresh holds SecretsBackend's async file lock
+  // across its network request; getAuthFor()'s synchronous lock read gives up
+  // after ~200ms and process.exit(1)s on ELOCKED. Fire-and-forget here would let
+  // a slow refresh still own the lock when a consumer creates a session — worse
+  // than the lazy path. Awaiting behind this barrier guarantees no synchronous
+  // auth reader exists while the refresh owns the lock. Never throws (the
+  // wrapper swallows and logs), so a probe failure can't block boot; a refresh
+  // that hangs on a wedged network hangs the first turn today anyway.
+  await refreshProviderOAuth({
+    agentDir: cwd,
     log: (message) => console.warn(message),
   })
 

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -21,3 +21,11 @@ export {
   exportClaudeCredentialsFileIfApplicable,
   resolveClaudeCredentialsPath,
 } from './export-claude-credentials-file'
+
+export {
+  type ProviderRefreshEntry,
+  type ProviderRefreshOutcome,
+  type RefreshProviderOAuthResult,
+  refreshProviderOAuthCredentials,
+  refreshProviderOAuthForAgent,
+} from './refresh-provider-oauth'

--- a/src/secrets/refresh-provider-oauth.test.ts
+++ b/src/secrets/refresh-provider-oauth.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { registerOAuthProvider, unregisterOAuthProvider } from '@mariozechner/pi-ai/oauth'
+import type { OAuthCredentials, OAuthProviderInterface } from '@mariozechner/pi-ai/oauth'
+import { AuthStorage } from '@mariozechner/pi-coding-agent'
+import type { AuthCredential } from '@mariozechner/pi-coding-agent'
+
+import { refreshProviderOAuthCredentials } from './refresh-provider-oauth'
+
+const STUB_PROVIDER_ID = 'stub-oauth'
+const registered = new Set<string>()
+
+function installStubProvider(overrides: Partial<OAuthProviderInterface> & { id?: string } = {}): string {
+  const id = overrides.id ?? STUB_PROVIDER_ID
+  const provider: OAuthProviderInterface = {
+    id,
+    name: 'Stub OAuth',
+    login: async () => {
+      throw new Error('login not used in tests')
+    },
+    refreshToken: overrides.refreshToken ?? (async (creds) => creds),
+    getApiKey: overrides.getApiKey ?? ((creds) => creds.access),
+  }
+  registerOAuthProvider(provider)
+  registered.add(id)
+  return id
+}
+
+afterEach(() => {
+  for (const id of registered) unregisterOAuthProvider(id)
+  registered.clear()
+})
+
+function oauthCred(access: string, expires: number, refresh = 'refresh-token'): OAuthCredentials & { type: 'oauth' } {
+  return { type: 'oauth', access, refresh, expires }
+}
+
+function storageWith(data: Record<string, AuthCredential>): AuthStorage {
+  return AuthStorage.inMemory(data)
+}
+
+const FUTURE = Date.now() + 60 * 60 * 1000
+const PAST = Date.now() - 60 * 60 * 1000
+
+describe('refreshProviderOAuthCredentials', () => {
+  test('no oauth providers → empty result, no work', async () => {
+    const storage = storageWith({ openai: { type: 'api_key', key: 'sk-test' } })
+
+    const result = await refreshProviderOAuthCredentials({ authStorage: storage })
+
+    expect(result.entries).toEqual([])
+  })
+
+  test('valid (unexpired) token → valid-or-refreshed without invoking refresh', async () => {
+    const id = installStubProvider({
+      refreshToken: async () => {
+        throw new Error('refresh must not run for an unexpired token')
+      },
+    })
+    const storage = storageWith({ [id]: oauthCred('valid-access', FUTURE) })
+
+    const result = await refreshProviderOAuthCredentials({ authStorage: storage })
+
+    expect(result.entries).toEqual([{ providerId: id, outcome: 'valid-or-refreshed' }])
+  })
+
+  test('expired token → refresh runs, new credential persists, outcome valid-or-refreshed', async () => {
+    let refreshCalls = 0
+    const id = installStubProvider({
+      refreshToken: async (creds): Promise<OAuthCredentials> => {
+        refreshCalls += 1
+        return { access: 'fresh-access', refresh: creds.refresh, expires: FUTURE }
+      },
+    })
+    const storage = storageWith({ [id]: oauthCred('stale-access', PAST) })
+
+    const result = await refreshProviderOAuthCredentials({ authStorage: storage })
+
+    expect(refreshCalls).toBe(1)
+    expect(result.entries).toEqual([{ providerId: id, outcome: 'valid-or-refreshed' }])
+    const persisted = storage.getAll()[id]
+    expect(persisted).toMatchObject({ type: 'oauth', access: 'fresh-access', expires: FUTURE })
+  })
+
+  test('expired token + failing refresh → refresh-failed with surfaced error', async () => {
+    const logs: string[] = []
+    const id = installStubProvider({
+      refreshToken: async () => {
+        throw new Error('token endpoint 400: invalid_grant')
+      },
+    })
+    const storage = storageWith({ [id]: oauthCred('stale-access', PAST) })
+
+    const result = await refreshProviderOAuthCredentials({
+      authStorage: storage,
+      log: (m) => logs.push(m),
+    })
+
+    expect(result.entries).toHaveLength(1)
+    expect(result.entries[0]!.providerId).toBe(id)
+    expect(result.entries[0]!.outcome).toBe('refresh-failed')
+    // The SDK wraps the underlying cause into "Failed to refresh OAuth token
+    // for <id>"; the raw cause (invalid_grant) is not propagated to drainErrors,
+    // so we assert on the operator-actionable wrapper we actually surface.
+    expect(result.entries[0]!.error).toContain('Failed to refresh OAuth token')
+    expect(result.entries[0]!.error).toContain(id)
+    expect(logs.some((m) => m.includes(id) && m.includes('refresh failed'))).toBe(true)
+  })
+
+  test('one failing provider does not stop others from being probed', async () => {
+    const good = installStubProvider({
+      id: 'stub-good',
+      refreshToken: async (creds): Promise<OAuthCredentials> => ({
+        access: 'good-fresh',
+        refresh: creds.refresh,
+        expires: FUTURE,
+      }),
+    })
+    const bad = installStubProvider({
+      id: 'stub-bad',
+      refreshToken: async () => {
+        throw new Error('boom')
+      },
+    })
+    const storage = storageWith({
+      [bad]: oauthCred('bad-stale', PAST),
+      [good]: oauthCred('good-stale', PAST),
+    })
+
+    const result = await refreshProviderOAuthCredentials({ authStorage: storage })
+
+    const byId = Object.fromEntries(result.entries.map((e) => [e.providerId, e.outcome]))
+    expect(byId[good]).toBe('valid-or-refreshed')
+    expect(byId[bad]).toBe('refresh-failed')
+  })
+
+  test('unknown oauth provider (not registered) → refresh-failed, no throw', async () => {
+    const storage = storageWith({ 'never-registered': oauthCred('x', PAST) })
+
+    const result = await refreshProviderOAuthCredentials({ authStorage: storage })
+
+    expect(result.entries).toEqual([
+      { providerId: 'never-registered', outcome: 'refresh-failed', error: expect.any(String) },
+    ])
+  })
+
+  test('one failing provider does not leak its error onto the next provider', async () => {
+    const bad = installStubProvider({
+      id: 'stub-bad-first',
+      refreshToken: async () => {
+        throw new Error('first-failure')
+      },
+    })
+    const good = installStubProvider({
+      id: 'stub-good-second',
+      refreshToken: async (creds): Promise<OAuthCredentials> => ({
+        access: 'ok',
+        refresh: creds.refresh,
+        expires: FUTURE,
+      }),
+    })
+    const storage = storageWith({
+      [bad]: oauthCred('a', PAST),
+      [good]: oauthCred('b', PAST),
+    })
+
+    const result = await refreshProviderOAuthCredentials({ authStorage: storage })
+
+    const goodEntry = result.entries.find((e) => e.providerId === good)
+    expect(goodEntry?.outcome).toBe('valid-or-refreshed')
+    expect(goodEntry?.error).toBeUndefined()
+  })
+})

--- a/src/secrets/refresh-provider-oauth.ts
+++ b/src/secrets/refresh-provider-oauth.ts
@@ -1,0 +1,128 @@
+import { join } from 'node:path'
+
+import type { AuthStorage } from '@mariozechner/pi-coding-agent'
+
+import { createSecretsStoreForAgent } from './storage'
+
+// Outcome for a single provider's proactive-refresh probe. `valid-or-refreshed`
+// collapses "token was still good" and "token was expired and we refreshed it"
+// on purpose — from the caller's view both mean "this provider can serve a turn
+// now", and the SDK doesn't tell us which of the two happened. `refresh-failed`
+// is the only actionable state: the token was expired and the refresh POST (or
+// the lookup of the OAuth provider) did not yield a usable key.
+export type ProviderRefreshOutcome = 'valid-or-refreshed' | 'refresh-failed'
+
+export type ProviderRefreshEntry = {
+  providerId: string
+  outcome: ProviderRefreshOutcome
+  // Populated only for `refresh-failed`, drained from AuthStorage's internal
+  // error log so operators see WHY the refresh failed (network, 400 from the
+  // token endpoint, revoked refresh token, unknown OAuth provider).
+  error?: string
+}
+
+export type RefreshProviderOAuthResult = {
+  entries: ProviderRefreshEntry[]
+}
+
+export type RefreshProviderOAuthOptions = {
+  authStorage: AuthStorage
+  log?: (message: string) => void
+}
+
+// Proactively resolves every stored OAuth provider credential once, forcing the
+// SDK's lazy refresh-and-persist path to run at boot instead of on the first
+// user-facing turn.
+//
+// WHY THIS EXISTS. `AuthStorage.getApiKey()` is the SDK's only refresh trigger,
+// and it is lazy: it fires on the first LLM call for a provider. A container
+// that restarts with an already-expired access token therefore doesn't refresh
+// until a real turn runs — and if that refresh then fails (a wedged network
+// stack, a rotated refresh token), the failure surfaces as a generic
+// provider-error notice posted into a live channel/PR thread. Channel-adapter
+// OAuth already has host-side renewal crons (Kakao/Webex/Teams); provider OAuth
+// had nothing. This closes that gap by paying the refresh cost at boot, where a
+// failure is logged for the operator rather than shown to end users.
+//
+// Reuses the SDK path verbatim rather than re-implementing token refresh: a
+// single `getApiKey()` call per provider runs the exact locked
+// refresh-then-persist-to-secrets.json flow the runtime uses on every turn, so
+// a boot-refreshed token is written back through the same atomic writer and no
+// second refresh implementation can drift from it. `includeFallback: false`
+// keeps an unrelated env var from masking an OAuth refresh failure as success.
+//
+// Never throws: a boot-time credential probe must not block the agent from
+// starting. Each provider is isolated — one provider's failure doesn't stop the
+// others from being probed — and every failure is returned for the caller to
+// log.
+export async function refreshProviderOAuthCredentials(
+  options: RefreshProviderOAuthOptions,
+): Promise<RefreshProviderOAuthResult> {
+  const { authStorage } = options
+  const entries: ProviderRefreshEntry[] = []
+
+  const oauthProviderIds = Object.entries(authStorage.getAll())
+    .filter(([, cred]) => cred.type === 'oauth')
+    .map(([providerId]) => providerId)
+
+  for (const providerId of oauthProviderIds) {
+    // getApiKey drives the locked refresh-and-persist internally. A non-empty
+    // return means the provider can serve a turn now (token was valid, or was
+    // expired and got refreshed + written back). `undefined` means the refresh
+    // truly failed — the SDK deliberately does NOT fall back to the stale token.
+    const apiKey = await resolveApiKeySafely(authStorage, providerId)
+    // Always drain so one provider's recorded error can't leak into the next
+    // provider's outcome. drainErrors clears the buffer as it reads.
+    const drained = authStorage.drainErrors()
+
+    if (apiKey !== undefined && apiKey !== '') {
+      entries.push({ providerId, outcome: 'valid-or-refreshed' })
+      continue
+    }
+
+    const error = drained.length > 0 ? drained.map((e) => e.message).join('; ') : 'refresh returned no API key'
+    options.log?.(`refreshProviderOAuth: ${providerId} refresh failed: ${error}`)
+    entries.push({ providerId, outcome: 'refresh-failed', error })
+  }
+
+  return { entries }
+}
+
+// getApiKey already swallows refresh errors into drainErrors and returns
+// undefined, but guard the call itself so an unexpected throw (e.g. a corrupt
+// credential shape the SDK doesn't expect) degrades to a failed entry instead
+// of aborting the whole boot-time sweep.
+async function resolveApiKeySafely(authStorage: AuthStorage, providerId: string): Promise<string | undefined> {
+  try {
+    return await authStorage.getApiKey(providerId, { includeFallback: false })
+  } catch {
+    return undefined
+  }
+}
+
+export type RefreshProviderOAuthForAgentOptions = {
+  agentDir: string
+  log?: (message: string) => void
+}
+
+// Boot-time convenience wrapper for src/run/index.ts, mirroring
+// exportCodexAuthFileForAgent's contract: takes agentDir, never throws, returns
+// a result the caller can log or ignore. Builds the same AuthStorage the run
+// stage uses per provider (createSecretsStoreForAgent) so the refresh writes
+// back through the bind-mounted secrets.json exactly as a live turn would.
+export async function refreshProviderOAuthForAgent(
+  options: RefreshProviderOAuthForAgentOptions,
+): Promise<RefreshProviderOAuthResult> {
+  let authStorage: AuthStorage
+  try {
+    authStorage = createSecretsStoreForAgent(join(options.agentDir, 'secrets.json'))
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    options.log?.(`refreshProviderOAuth: ${reason}`)
+    return { entries: [] }
+  }
+  return refreshProviderOAuthCredentials({
+    authStorage,
+    ...(options.log !== undefined ? { log: options.log } : {}),
+  })
+}


### PR DESCRIPTION
## Background

An agent (`typeey`) posted `⚠️ The upstream LLM provider failed. Operators can check `typeclaw logs` for details.` onto a live GitHub PR thread ([typeclaw/typeclaw#1242](https://github.com/typeclaw/typeclaw/pull/1242#issuecomment-5003602448)) and into Discord/cron turns. Container logs showed the real error on every turn:

```
[channels] github:typeclaw/typeclaw:pr:1242:: LLM call failed: No API key for provider: openai-codex
[channels] github:typeclaw/typeclaw:pr:1242: provider_error_turn deferring to provider-error notice
```

That string (`No API key for provider: …`) is emitted by the model SDK, not typeclaw. Root cause: the container **restarted holding an `openai-codex` OAuth access token that had already expired ~17 min earlier**, and the token was never refreshed — so the SDK had no usable credential.

The refresh path is entirely SDK-side (`AuthStorage.getApiKey` → locked refresh → persist to `secrets.json`) and it is **lazy**: it only fires on the first LLM call for a provider. So a container that boots with an already-expired token doesn't discover the staleness — nor any refresh failure — until a real turn runs. When that refresh then fails (a wedged egress stack, a rotated refresh token), the failure is shown to end users as the generic provider-error notice instead of being logged for the operator. Channel-adapter OAuth (Kakao/Webex/Teams) already has host-side renewal crons that keep tokens fresh out-of-band; **provider OAuth had no equivalent**.

This is not a regression of any recent change (I ruled out #1224, which only refines error *classification* and never touches the credential path). It's a long-standing gap.

## Summary

Add a boot-time sweep that resolves every stored OAuth provider credential once, driving the SDK's existing locked refresh-and-persist path **before channels start serving turns** — moving a refresh failure from a live thread to a boot-time operator log.

- **`refreshProviderOAuthCredentials`** — for each `type: 'oauth'` provider, call `getApiKey(id, { includeFallback: false })`. A non-empty return means the provider can serve a turn now (token valid, or expired-and-refreshed + written back); `undefined` means the refresh truly failed. Errors are drained per-provider (so one provider's recorded error can't leak into the next) and returned as a structured result. **Why reuse `getApiKey` instead of re-implementing refresh:** it runs the *exact* locked refresh → atomic write-back flow the runtime uses on every turn, so a boot-refreshed token can't drift from a turn-refreshed one. **Why `includeFallback: false`:** an unrelated env var must not mask an OAuth refresh failure as success.
- **`refreshProviderOAuthForAgent`** — boot wrapper mirroring `exportCodexAuthFileForAgent`'s contract (takes `agentDir`, never throws).
- **Wiring** — `startAgentRuntime`, right after the codex/claude exporters. **Fire-and-forget (`void`)** so a wedged network can't hang boot: the refresh starts early (well before a human sends a message in the common case), and even in the worst race the behavior is no worse than today's lazy refresh.

## What this does NOT do

- Does not add a host-side renewal *cron* for provider OAuth (like Kakao/Webex/Teams). This is a boot-time one-shot; a periodic refresher for very-long-lived containers is a possible follow-up.
- Does not change the generic provider-error notice or its classification (that's #1224's territory).
- Does not surface the underlying refresh cause to end users — the SDK collapses the cause into `Failed to refresh OAuth token for <id>` before it reaches us; we log that operator-actionable wrapper.
- Does not re-auth on its own when the *refresh token* itself is revoked/rotated — that still needs an operator `typeclaw init` re-login (the incident was resolved that way).

## Review notes

- Load-bearing: the refresh is a side effect of `getApiKey`; the function's value is (a) forcing it at boot and (b) draining errors **between** providers so failures are isolated. See `src/secrets/refresh-provider-oauth.ts`.
- Boot ordering: placed after the codex/claude auth-file exporters and before `channelManager.start()`, so a refreshed token is written back through the same atomic writer the exporters and live turns use.
- Tests (`refresh-provider-oauth.test.ts`, 7 cases) use `AuthStorage.inMemory` + a registered/unregistered stub OAuth provider to assert observable behavior: valid token → no refresh call; expired → refresh runs and the new credential persists; failing refresh → `refresh-failed` + surfaced error; one failure doesn't stop or contaminate other providers; unknown provider degrades without throwing.
- Checks: `typecheck`, `lint` (0 errors, none in changed files), `format:check`, and the full suite (`bun run test`, 11538 pass / 0 fail) all green.