### PR TITLE
feat(agent): append recovery hints to builtin file-tool errors

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -2479,6 +2479,53 @@ describe('wrapBuiltinToolDefinition (hook + guard pipeline)', () => {
     }
   })
 
+  test('missing-path builtin file tool: rethrown error and tool.after both carry the recovery hint', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-missing-path-'))
+    const missing = path.join(agentDir, 'does-not-exist.txt')
+    const afterResults: unknown[] = []
+    let executed = false
+    const tool = {
+      name: 'read',
+      label: 'read',
+      description: '',
+      parameters: Type.Object({ path: Type.String() }),
+      async execute() {
+        executed = true
+        return { content: [{ type: 'text' as const, text: 'unreachable' }], details: {} }
+      },
+    }
+    const hooks = createHookBus()
+    hooks.registerAll('p1', agentDir, noopLogger, {
+      'tool.after': (event) => {
+        afterResults.push(event.result)
+      },
+    })
+
+    const wrapped = wrapBuiltinToolDefinition(tool, { agentDir, sessionId: 's', hooks })
+
+    try {
+      // enforceAndPinToolFiles throws the authorization error BEFORE execute
+      const thrown = await wrapped
+        .execute('c', { path: missing } as never, undefined, undefined, {} as never)
+        .then(() => undefined)
+        .catch((error: unknown) => (error instanceof Error ? error : new Error(String(error))))
+
+      expect(executed).toBe(false)
+      expect(thrown?.message).toContain('tool input did not exist while being authorized')
+      expect(thrown?.message).toContain('the path does not exist')
+
+      expect(afterResults).toHaveLength(1)
+      const afterText = ((afterResults[0] as ToolResult).content as Array<{ type: string; text?: string }>)
+        .filter((p) => p.type === 'text')
+        .map((p) => p.text)
+        .join('\n')
+      expect(afterText).toContain('tool input did not exist while being authorized')
+      expect(afterText).toContain('the path does not exist')
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
   test.skipIf(lacksInodeAnchoring)(
     'edit built-in agent tool exposes and strips guard acknowledgements before execution',
     async () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -70,6 +70,7 @@ import { createLoopGuard, type LoopGuard, type LoopGuardDecision } from './loop-
 import { checkImageReadRedirect } from './multimodal/read-redirect'
 import { enforceSubagentBashPolicy, type SubagentBashPolicy } from './reviewer-bash-policy'
 import type { SessionOrigin } from './session-origin'
+import { remediateToolErrorMessage } from './tool-error-remediation'
 import { enforceAndPinToolFiles, writeToolOutputNoFollow } from './tool-file-safety'
 import { SUBAGENT_OUTPUT_TOOL_NAME, type SubagentOutputToolDetails } from './tools/subagent-output'
 import { webFetchTool } from './tools/webfetch'
@@ -625,6 +626,15 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
         const outcomes = await Promise.allSettled(cleanup)
         const failed = outcomes.find((outcome) => outcome.status === 'rejected')
         if (failed?.status === 'rejected') cleanupError = failed.reason
+      }
+      // Decorate genuine, user-correctable builtin file-tool failures with a
+      // recovery hint so weaker models retry correctly. Only executionError (not
+      // cleanupError) and only non-aborted Error instances; remediation is a
+      // no-op for every message/tool outside the allowlist, so abort, sandbox,
+      // and policy errors pass through untouched. Mutating the message in place
+      // preserves the error's subclass and stack for the rethrow.
+      if (executionError instanceof Error && signal?.aborted !== true) {
+        executionError.message = remediateToolErrorMessage(tool.name, executionError.message)
       }
       const finalError = executionError ?? cleanupError
       if (finalError !== undefined) {

--- a/src/agent/tool-error-remediation.test.ts
+++ b/src/agent/tool-error-remediation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'bun:test'
+
+import { remediateToolErrorMessage } from './tool-error-remediation'
+
+describe('remediateToolErrorMessage', () => {
+  it('appends a read-first hint to an edit oldText-mismatch error', () => {
+    const message =
+      'Could not find edits[0] in src/foo.ts. The oldText must match exactly including all whitespace and newlines.'
+
+    const result = remediateToolErrorMessage('edit', message)
+
+    expect(result.startsWith(message)).toBe(true)
+    expect(result).toContain('Re-read the file with the `read` tool')
+  })
+
+  it('appends a no-op hint to an identical-content edit error', () => {
+    const message =
+      'No changes made to src/foo.ts. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected.'
+
+    const result = remediateToolErrorMessage('edit', message)
+
+    expect(result).toContain('the edit is a no-op')
+  })
+
+  it('appends a path hint to the file-safety authorization error the wrapper actually surfaces', () => {
+    // enforceAndPinToolFiles throws THIS (not upstream `File not found:`) for a
+    // missing input path, before tool.execute runs — the common missing-path case.
+    const message = 'tool input did not exist while being authorized: src/missing.ts'
+
+    expect(remediateToolErrorMessage('read', message)).toContain('the path does not exist')
+    expect(remediateToolErrorMessage('grep', message)).toContain('the path does not exist')
+    expect(remediateToolErrorMessage('find', message)).toContain('the path does not exist')
+    expect(remediateToolErrorMessage('ls', message)).toContain('the path does not exist')
+  })
+
+  it('still appends a path-verification hint to the raw upstream not-found fallback', () => {
+    expect(remediateToolErrorMessage('read', 'File not found: src/missing.ts')).toContain(
+      'verify the path before retrying',
+    )
+    expect(remediateToolErrorMessage('ls', 'Path not found: src/missing/')).toContain('verify the path before retrying')
+    expect(remediateToolErrorMessage('grep', 'Path not found: src/missing/')).toContain(
+      'verify the path before retrying',
+    )
+    expect(remediateToolErrorMessage('find', 'Path not found: src/missing/')).toContain(
+      'verify the path before retrying',
+    )
+  })
+
+  it('appends an offset hint to a read beyond-end-of-file error', () => {
+    const result = remediateToolErrorMessage('read', 'Offset 5000 is beyond end of file (120 lines total)')
+
+    expect(result).toContain('fewer lines than the offset')
+  })
+
+  it('does not fire a rule for a tool it is not scoped to', () => {
+    // the offset rule is `read`-only: the same text under another tool is left alone
+    const offset = 'Offset 5000 is beyond end of file (120 lines total)'
+    expect(remediateToolErrorMessage('edit', offset)).toBe(offset)
+
+    // the edit not-found rule must not fire for `read`
+    const editNotFound = 'Could not find edits[0] in src/foo.ts. The oldText must match exactly.'
+    expect(remediateToolErrorMessage('read', editNotFound)).toBe(editNotFound)
+  })
+
+  it('leaves unrecognized errors untouched', () => {
+    const message = 'Some entirely unrelated failure that has no remediation rule'
+
+    expect(remediateToolErrorMessage('edit', message)).toBe(message)
+  })
+
+  it('does not decorate bash sandbox / subagent-policy errors', () => {
+    // given: bash-only internal control errors (bash is in no rule's tool set)
+    const sandbox = 'model-driven bash has no permission service; refusing unsandboxed execution'
+    const subagentPolicy = 'blocked: command `rm` is not permitted for a read-only subagent'
+
+    // then: never decorated
+    expect(remediateToolErrorMessage('bash', sandbox)).toBe(sandbox)
+    expect(remediateToolErrorMessage('bash', subagentPolicy)).toBe(subagentPolicy)
+  })
+
+  it('does not decorate an abort error on a file tool', () => {
+    const abort = 'Operation aborted'
+
+    expect(remediateToolErrorMessage('edit', abort)).toBe(abort)
+    expect(remediateToolErrorMessage('read', abort)).toBe(abort)
+  })
+
+  it('is idempotent — a message already carrying the hint is not double-decorated', () => {
+    const once = remediateToolErrorMessage('read', 'File not found: src/missing.ts')
+    const twice = remediateToolErrorMessage('read', once)
+
+    expect(twice).toBe(once)
+  })
+
+  it('preserves a non-ASCII path in the decorated message', () => {
+    // typeclaw is multi-language: paths may be non-Latin. The original message
+    // (including its path) must survive verbatim ahead of the hint.
+    const message = 'File not found: 문서/보고서.txt'
+
+    const result = remediateToolErrorMessage('read', message)
+
+    expect(result.startsWith('File not found: 문서/보고서.txt')).toBe(true)
+    expect(result).toContain('verify the path before retrying')
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(remediateToolErrorMessage('read', '')).toBe('')
+  })
+})

--- a/src/agent/tool-error-remediation.ts
+++ b/src/agent/tool-error-remediation.ts
@@ -1,0 +1,72 @@
+// SECURITY/CORRECTNESS: rules are gated on BOTH the emitting tool name and a
+// verbatim upstream pi-coding-agent error substring. `bash` (the only tool that
+// raises sandbox/subagent-policy errors) is never in a rule's tool set, and
+// abort/cleanup/guard failures never match any pattern, so internal control
+// errors are never decorated with a nonsensical "read the file first" hint. A
+// wording drift upstream simply stops decorating (fails safe) rather than
+// mis-firing on the wrong error class.
+
+const HINT_PREFIX = 'Hint:'
+
+type RemediationRule = {
+  // Built-in tool names whose thrown errors this rule may decorate.
+  tools: readonly string[]
+  // `upstream` is the exact substring the matching pi tool emits, kept next to
+  // the pattern so the regex can be re-verified against the dependency on bumps.
+  upstream: string
+  test: RegExp
+  hint: string
+}
+
+// First matching rule wins; keep the most specific patterns first. Upstream
+// sources: node_modules/@mariozechner/pi-coding-agent/dist/core/tools/{edit,read,ls,grep}.js
+const RULES: readonly RemediationRule[] = [
+  {
+    tools: ['edit'],
+    upstream: 'Could not find edits[0] in <path>. / Could not find the exact text in <path>.',
+    test: /Could not find (the exact text|edits\[\d+\]) in /i,
+    hint: `${HINT_PREFIX} the oldText must match the file byte-for-byte. Re-read the file with the \`read\` tool to copy the exact current text — including all whitespace, indentation, and newlines — then retry \`edit\` with that exact oldText. Do not hand-type or reformat it.`,
+  },
+  {
+    tools: ['edit'],
+    upstream: 'No changes made to <path>. The replacement(s) produced identical content',
+    test: /No changes made to .+\. The replacements? produced identical content/i,
+    hint: `${HINT_PREFIX} the newText is identical to the oldText, so the edit is a no-op. If you intended a change, make oldText and newText differ; if the file is already correct, do not retry this edit.`,
+  },
+  {
+    tools: ['read'],
+    upstream: 'Offset N is beyond end of file (M lines total)',
+    test: /Offset \d+ is beyond end of file/i,
+    hint: `${HINT_PREFIX} the file has fewer lines than the offset you requested. Read from a smaller offset, or read the whole file without an offset first to see its length.`,
+  },
+  {
+    // typeclaw-owned: enforceAndPinToolFiles (src/agent/tool-file-safety.ts,
+    // throws at :95 and :451) runs BEFORE tool.execute inside the builtin
+    // wrapper, so a missing input path surfaces THIS string — not the upstream
+    // `File not found:` — for every input-pinning tool. This is the common
+    // missing-path case for read/grep/find/ls.
+    tools: ['read', 'ls', 'grep', 'find'],
+    upstream: 'tool input did not exist while being authorized: <path>',
+    test: /tool input did not exist while being authorized: /i,
+    hint: `${HINT_PREFIX} the path does not exist. Verify it before retrying — use \`ls\` on the parent directory or \`find\` to locate the file. Paths are relative to the agent root unless absolute.`,
+  },
+  {
+    // Fallback for the raw upstream not-found strings some tools still emit when
+    // a path resolves at pin time but disappears before the tool reads it.
+    tools: ['read', 'ls', 'grep', 'find'],
+    upstream: 'File not found: <path> / Path not found: <path>',
+    test: /(File|Path) not found: /i,
+    hint: `${HINT_PREFIX} verify the path before retrying — use \`ls\` on the parent directory or \`find\` to locate the file. Paths are relative to the agent root unless absolute.`,
+  },
+]
+
+export function remediateToolErrorMessage(toolName: string, message: string): string {
+  if (typeof message !== 'string' || message.length === 0) return message
+  for (const rule of RULES) {
+    if (!rule.tools.includes(toolName)) continue
+    if (!rule.test.test(message)) continue
+    if (message.includes(rule.hint)) return message
+    return `${message}\n\n${rule.hint}`
+  }
+  return message
+}


### PR DESCRIPTION
## Background

Weaker LLMs repeatedly fail the same builtin file-tool calls — an `edit` whose `oldText` doesn't match byte-for-byte, an `edit` on a file the model never `read`, a stale path passed to `read`/`ls`/`grep`/`find` — and then retry the identical broken call. The upstream `@mariozechner/pi-coding-agent` tool error messages say WHAT went wrong but not HOW to recover, so a low-capability model has nothing actionable to change on the next attempt.

## Summary

Add `remediateToolErrorMessage(toolName, message)` in a new `src/agent/tool-error-remediation.ts`: an allowlist keyed to BOTH the emitting builtin tool name and a verbatim upstream error substring. On a match it appends a short imperative recovery hint in typeclaw's existing guard voice (e.g. for an `edit` `oldText` mismatch: "re-read the file with `read` to copy the exact current text, then retry `edit`"). Rules cover: `edit` `oldText`-not-found, `edit` identical-content no-op, `read` offset-beyond-EOF, and File/Path-not-found for `read`/`ls`/`grep`/`find`. Any message/tool outside the allowlist is returned unchanged.

Wired into `src/agent/plugin-tools.ts` `wrapBuiltinToolDefinition` only: decorates `executionError` (never `cleanupError`) for non-aborted `Error` instances, mutating `.message` in place before the existing rethrow so the error's subclass and stack survive. Throw semantics are unchanged.

Design decisions:

- **Kept throw semantics rather than returning a result** — `pi-agent-core` 0.73.1 only flags a tool result `isError` when `execute()` throws; returning a result instead would silently mark file errors as successes.
- **Tool-name + message allowlist, not `instanceof` exclusions** — fails closed on upstream wording drift; `bash` is in no rule's tool set, so sandbox/subagent-policy errors are never decorated.
- **Managed-config and write guards throw before builtin execution** and already carry their own guidance, so there's no double-annotation.
- **Does not touch `tool-not-found-nudge.ts`** — a different error class, already handled via session events.

## What this does NOT do

- Not a blanket "hint on every error" — intentionally narrow, covering only the ~5 known model-tripping builtin file-tool errors, to avoid token noise on transient/environmental failures and double-guidance on already-good guard reasons.
- Does not change `bash`, sandbox, or subagent-policy error handling.
- Does not decorate `cleanupError` or aborted errors.

## Review notes

- Load-bearing: the allowlist match is on `(toolName, verbatim upstream substring)` pairs, so a wording change upstream fails closed (no decoration) rather than mis-firing on an unrelated tool.
- `src/agent/tool-error-remediation.test.ts` has 11 tests: one per rule, tool-scoping negatives, `bash`/sandbox/abort non-decoration, idempotency (re-running remediation doesn't double-append), non-ASCII path preservation, and the empty-string case.
- Verification: `bun run typecheck` (0 errors), `bun run lint` (0 errors; 67 pre-existing warnings in unrelated github-adapter test files), `bun run format` (clean), full `bun run test` — 11591 pass / 0 fail, including the 11 new tests.
