### PR TITLE
fix(sandbox): pass DISPLAY through to sandboxed bash for agent-browser --headed

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -3554,6 +3554,39 @@ describe('buildSandboxEnvPolicy exposable .env names', () => {
   })
 })
 
+describe('buildSandboxEnvPolicy DISPLAY passthrough (agent-browser --headed)', () => {
+  const originalDisplay = process.env['DISPLAY']
+
+  afterEach(() => {
+    if (originalDisplay === undefined) delete process.env['DISPLAY']
+    else process.env['DISPLAY'] = originalDisplay
+  })
+
+  test('passes the runtime DISPLAY into set so sandboxed Chrome finds the X server', () => {
+    process.env['DISPLAY'] = ':99'
+    const policy = buildSandboxEnvPolicy(undefined, undefined, [])
+    expect(policy.set?.DISPLAY).toBe(':99')
+  })
+
+  test('omits DISPLAY when the runtime has none (docker.file.xvfb=false)', () => {
+    delete process.env['DISPLAY']
+    const policy = buildSandboxEnvPolicy(undefined, undefined, [])
+    expect(policy.set?.DISPLAY).toBeUndefined()
+  })
+
+  test('omits DISPLAY when set to an empty string', () => {
+    process.env['DISPLAY'] = ''
+    const policy = buildSandboxEnvPolicy(undefined, undefined, [])
+    expect(policy.set?.DISPLAY).toBeUndefined()
+  })
+
+  test('does not overwrite a DISPLAY already provided by the privileged runtime set', () => {
+    process.env['DISPLAY'] = ':99'
+    const policy = buildSandboxEnvPolicy(undefined, { DISPLAY: ':1' }, [])
+    expect(policy.set?.DISPLAY).toBe(':1')
+  })
+})
+
 describe('wrapBuiltinToolDefinition subagent bash policy (capability fence, role-independent)', () => {
   function fakeBash(record: { command?: string }) {
     return {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -814,6 +814,17 @@ export function buildSandboxEnvPolicy(
   // out of the rendered bwrap argv. Sandbox-integrity names were already dropped
   // in resolveExposableEnvNames — these are the survivors.
   for (const key of exposableEnvNames) pushInherit(key)
+  // Pass the entrypoint-exported Xvfb display (start_xvfb: `export DISPLAY=:99`)
+  // through --clearenv, else sandboxed `agent-browser --headed` dies with
+  // "Missing X server or $DISPLAY". Passing the runtime's OWN value (not a fixed
+  // ":99") keeps `docker.file.xvfb=false` advertising no display. Rendered via
+  // `set` (a display number is neither a credential nor shell-injectable), and no
+  // /tmp/.X11-unix bind is needed: Chrome reaches Xvfb over the netns-scoped
+  // abstract X11 socket while bash keeps network:'inherit'.
+  const display = process.env['DISPLAY']
+  if (display !== undefined && display !== '' && !Object.hasOwn(set, 'DISPLAY') && !inheritSeen.has('DISPLAY')) {
+    set['DISPLAY'] = display
+  }
   return {
     ...(inherit.length > 0 ? { inherit } : {}),
     ...(Object.keys(set).length > 0 ? { set } : {}),


### PR DESCRIPTION
## Background

An agent running in a container reported over Slack that its browser tool was broken: `agent-browser open <url> --headed` launched Chrome that died instantly with:

```
Missing X server or $DISPLAY
Chrome exited before providing DevTools URL
```

Reproduced in a live container: setting `DISPLAY=:99` explicitly makes `agent-browser open` succeed. Xvfb *is* running on `:99`.

Root cause: the container entrypoint (`src/init/dockerfile.ts`, `start_xvfb()`) starts `Xvfb :99` and `export DISPLAY=:99`, so the **unsandboxed** agent runtime (PID 1) has `DISPLAY=:99` — verified via `/proc/1/environ`. But every **model-driven bash call** runs in a bwrap sandbox that does `--clearenv` and only re-introduces `DEFAULT_SANDBOX_ENV` (`PATH`/`HOME`/`LANG`/`BUN_TMPDIR`/`BUN_INSTALL`). `DISPLAY` is not in that allowlist, so it's stripped before `agent-browser --headed` runs — Chrome finds no X server and dies. This is exactly the failure path the agent hit, since its browser invocations go through the sandboxed bash tool.

## Summary

`buildSandboxEnvPolicy` (`src/agent/plugin-tools.ts`) now passes the runtime's **own** `DISPLAY` value into the sandbox `set` map when it is present and non-empty.

Key decisions:

- **Pass the runtime value, not a hardcoded `:99`.** `docker.file.xvfb` is an opt-out toggle; with `xvfb=false` there is no Xvfb and `DISPLAY` is unset. Hardcoding `:99` in `DEFAULT_SANDBOX_ENV` would falsely advertise a display that doesn't exist. Sourcing from the entrypoint-exported value keeps the entrypoint authoritative and correct in both modes.
- **`set` (`--setenv`), not the secret-safe `inherit` path.** A display number (`:99`) is neither a credential nor shell-injectable as an env value, so rendering it directly in argv is safe — no reason to route it through the value-hiding `inherit` machinery.
- **No `/tmp/.X11-unix` bind needed.** Production bash keeps `network: 'inherit'`, so Chrome reaches Xvfb over the netns-scoped **abstract** X11 socket even though the sandbox's `/tmp` is a fresh tmpfs that hides the pathname socket. Confirmed by the explicit-`DISPLAY` reproduction.

Validated by Oracle review of the sandbox env boundary before implementing.

## What this does NOT do

- Does **not** detect `agent-browser`/browser commands — DISPLAY is passed generically for any sandboxed bash call. Command detection would be brittle and offers no security boundary (model bash can set `DISPLAY` itself anyway).
- Does **not** bind-mount the X11 socket (unnecessary while bash shares the container netns).
- Does **not** change Xvfb startup, the headed-mode pre-close wrapper, or the `docker.file.xvfb` default.
- Does **not** address the pre-existing zombie-process accumulation observed in the container (separate concern, not part of this failure).

## Review notes

- Load-bearing change: the `DISPLAY` block in `buildSandboxEnvPolicy`. Invariant to verify: (1) present-and-non-empty runtime `DISPLAY` reaches the child via `set`; (2) unset/empty `DISPLAY` yields no `DISPLAY` in the policy (preserves `xvfb=false`); (3) a runtime-provided `set.DISPLAY` is not overwritten.
- The `set` -> `--setenv` render path is already covered generically in `src/sandbox/build.test.ts`; the 4 new tests in `src/agent/plugin-tools.test.ts` cover the DISPLAY-specific policy logic and restore `process.env.DISPLAY` in `afterEach`.
- Security note (from Oracle): X11 with `-ac` provides no inter-client isolation, but this is a pre-existing property under TypeClaw's single-tenant container boundary (sandboxed bash could already set `DISPLAY=:99` manually). A multi-tenant design would need Xauthority / per-session X servers. If a future change stops sharing the container netns, the abstract socket disappears and an explicit read-only `/tmp/.X11-unix` bind (after the session `/tmp` bind) becomes necessary.