### PR TITLE
Generalize .env exposure test names

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -3582,17 +3582,15 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
 
 describe('buildSandboxEnvPolicy exposable .env names', () => {
   test('adds exposable names to inherit so values stay out of argv', () => {
-    const policy = buildSandboxEnvPolicy(undefined, undefined, ['AGENT_MESSENGER_CONFIG_DIR', 'OPENSOMA_CONFIG_DIR'])
-    expect(policy.inherit).toEqual(['AGENT_MESSENGER_CONFIG_DIR', 'OPENSOMA_CONFIG_DIR'])
+    const policy = buildSandboxEnvPolicy(undefined, undefined, ['SERVICE_CONFIG_DIR', 'DATABASE_URL'])
+    expect(policy.inherit).toEqual(['SERVICE_CONFIG_DIR', 'DATABASE_URL'])
     expect(policy.set).toBeUndefined()
   })
 
   test('does not inherit a name already provided by the privileged runtime set', () => {
-    const policy = buildSandboxEnvPolicy(undefined, { AGENT_MESSENGER_CONFIG_DIR: '/runtime' }, [
-      'AGENT_MESSENGER_CONFIG_DIR',
-    ])
-    expect(policy.inherit ?? []).not.toContain('AGENT_MESSENGER_CONFIG_DIR')
-    expect(policy.set?.AGENT_MESSENGER_CONFIG_DIR).toBe('/runtime')
+    const policy = buildSandboxEnvPolicy(undefined, { SERVICE_CONFIG_DIR: '/runtime' }, ['SERVICE_CONFIG_DIR'])
+    expect(policy.inherit ?? []).not.toContain('SERVICE_CONFIG_DIR')
+    expect(policy.set?.SERVICE_CONFIG_DIR).toBe('/runtime')
   })
 
   test('deduplicates a name that is both a secret-pattern overlay and an exposable name', () => {

--- a/src/sandbox/env-exposure.test.ts
+++ b/src/sandbox/env-exposure.test.ts
@@ -8,12 +8,12 @@ describe('resolveExposableEnvNames', () => {
   test('exposes every operator-declared .env var by default', () => {
     const names = resolveExposableEnvNames(
       env({
-        AGENT_MESSENGER_CONFIG_DIR: '/agent/workspace/.config/agent-messenger',
+        SERVICE_CONFIG_DIR: '/agent/workspace/.config/service',
         DATABASE_URL: 'postgres://u:p@host/db',
         OPENAI_API_KEY: 'sk-x',
       }),
     )
-    expect(names).toEqual(['AGENT_MESSENGER_CONFIG_DIR', 'DATABASE_URL', 'OPENAI_API_KEY'])
+    expect(names).toEqual(['SERVICE_CONFIG_DIR', 'DATABASE_URL', 'OPENAI_API_KEY'])
   })
 
   test('withholds sandbox-owned names (PATH/HOME/BUN_*/LANG)', () => {
@@ -65,12 +65,5 @@ describe('resolveExposableEnvNames', () => {
     // from the parsed FILE value, so the empty declaration stays withheld.
     const names = resolveExposableEnvNames(env({ DISCORD_BOT_TOKEN: '', REAL: 'v' }))
     expect(names).toEqual(['REAL'])
-  })
-
-  test('exposes AGENT_MESSENGER_CONFIG_DIR pointing at the real cred dir (the original bug)', () => {
-    const names = resolveExposableEnvNames(
-      env({ AGENT_MESSENGER_CONFIG_DIR: '/agent/workspace/.config/agent-messenger' }),
-    )
-    expect(names).toEqual(['AGENT_MESSENGER_CONFIG_DIR'])
   })
 })


### PR DESCRIPTION
Follow-up to #1244.

## What

The tests added in #1244 for `.env` exposure used the messenger-specific `AGENT_MESSENGER_CONFIG_DIR` (and `OPENSOMA_CONFIG_DIR`) as stand-ins for "an ordinary operator-declared var." `resolveExposableEnvNames`/`buildSandboxEnvPolicy` treat every non-withheld name identically, so those concrete names carried no test meaning beyond "not withheld" — they just tied the cases to a specific adapter.

This swaps them for neutral placeholders and trims a distracting aside:

- `src/sandbox/env-exposure.test.ts`
  - Default-exposure case now uses `SERVICE_CONFIG_DIR` instead of `AGENT_MESSENGER_CONFIG_DIR`.
  - Dropped the `exposes AGENT_MESSENGER_CONFIG_DIR ... (the original bug)` case: it duplicated the generalized default-exposure assertion and the "original bug" narration read oddly out of context.
- `src/agent/plugin-tools.test.ts`
  - `buildSandboxEnvPolicy` inherit/dedup cases use `SERVICE_CONFIG_DIR` / `DATABASE_URL`.

Withhold-path cases (sandbox-owned, runtime/broker-owned, outer-shell, loader-hijack, empty-declaration) are unchanged — those names are load-bearing (they name what's actually withheld), so only the "ordinary var" placeholders were generalized.

## Why

Test names should describe the behavior under test, not a coincidental caller. Generic placeholders make the cases self-explanatory and keep them from looking adapter-specific.

## Testing

- `bun run typecheck` clean
- `bun run lint` 0 errors
- `bun run format:check` clean
- `src/sandbox/env-exposure.test.ts` + `src/agent/plugin-tools.test.ts` pass