### PR TITLE
test(server): fix drain re-entrancy flake under oversubscription

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -453,8 +453,11 @@ describe('createServer todo continuation (drain re-entrancy)', () => {
     // The continuation must be consumed by the SAME drain loop — a second
     // prompt() call lands without any further user input. If the old
     // publish-through-stream path were still in place, draining would already
-    // be true and this would hang until timeout.
-    await waitForState(() => session.promptCalls.length === 2, { timeoutMs: 2000 })
+    // be true and this would hang until timeout: the stranded item generates
+    // no further wake-up, so no tight deadline is needed to prove the fix.
+    // Use the shared contention-tolerant default (30s) rather than a fixed
+    // short timeout, which starves and false-fails under oversubscription.
+    await waitForState(() => session.promptCalls.length === 2)
     expect(session.promptCalls[1]).toContain('Incomplete todo items remain')
     session.resolvePrompt()
     ws.close()


### PR DESCRIPTION
## Problem

The `flake guard (oversubscribed parallel)` CI job failed on `createServer todo continuation (drain re-entrancy) > consumes an idle continuation in the same drain pass instead of stalling`, taking 4378.53ms: https://github.com/typeclaw/typeclaw/actions/runs/29710902980/job/88254510675

That job deliberately runs two full `bun test --parallel` suites concurrently on one runner to oversubscribe the worker pool (more in-flight workers than cores), turning a rare contention flake into a deterministic pre-merge signal (see `.github/workflows/ci.yml`, `flake-guard` job). The flake surfaced on an unrelated PR (#1250, a pure test-rename change); the same flaky test exists identically on `main`, so this is a pre-existing contention flake, not something introduced by that branch. This PR fixes it independently off `main`.

## Root cause

The test at `src/server/index.test.ts:457` overrode the `waitFor` helper's timeout with a hardcoded `{ timeoutMs: 2000 }`. Every other `waitForState` call in the file uses the default.

The helper's default (`src/test-helpers/wait-for.ts`, `DEFAULT_TIMEOUT_MS = 30_000`) is documented as sized to absorb realistic 18-worker contention, matching the global `setDefaultTimeout(30_000)`. Under the flake-guard's deliberate oversubscription, legitimate continuation consumption (WS message -> server drain loop -> re-enqueue -> second prompt call, spanning several event-loop hops) exceeded the arbitrary 2000ms budget — CI observed 4378ms — producing a false failure. The 2000ms value was an arbitrary choice from when the regression test was first added (03497ff2, "address review: consume idle continuation inside the drain loop").

The regression this test guards is "the continuation is never consumed": the old publish-through-stream path re-entered `drain()` (`src/server/index.ts`) while `state.draining` was still true, hit the `if (state.draining) return` guard, and stranded the continuation until an unrelated wake. In this test, that stranded item generates no further wake-up — `session.resolvePrompt()` only resolves a fake promise, there are no heartbeat/drain timers, and `ws.close()` runs only after prompt #2 is already observed. So the guard only needs to distinguish "consumed" from "never consumed", which the 30s contention-tolerant default does exactly as well as 2000ms, without the flake. The 2000ms override was the sole outlier in the file. Cross-checked with an Oracle review of the production drain loop.

## Fix

Remove the `{ timeoutMs: 2000 }` override so the call uses the shared 30s contention-tolerant default like every other `waitForState` in the file. Updated the comment to document why there is deliberately no tight override, so a future reviewer doesn't reintroduce the flake.

## What this does NOT do

- No production code changed — test-only.
- Does not alter drain-loop / continuation semantics.
- Does not touch the `waitFor` helper or its 30s default.
- Does not add hooks or switch to an event-driven wait — an event-driven wait would still need a contention-safe timeout and wouldn't strengthen this behavior test.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (67 pre-existing warnings, none new / none in the changed region)
- `bun run format:check` — clean
- `bun run test` — 11619 pass, 0 fail, 25 skip
- Reproduced the oversubscription locally: 6 concurrent runs of this test while a full `--parallel` suite churned all cores — all pass, 0 fail.
