### PR TITLE
server: serialize command logger writes so consecutive lines survive

### DIFF
--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -87,7 +87,7 @@ function makeSessionFactoryForTest(): { sessionFactory: SessionFactory; agentDir
   return { sessionFactory: createSessionFactory({ agentDir }), agentDir }
 }
 
-function makeRunner(commands: RegisteredCommand[]) {
+function makeRunner(commands: RegisteredCommand[], wrapOutbound?: (outbound: CommandOutbound) => CommandOutbound) {
   const { outbound, frames, decodeStdout } = makeOutboundCapture()
   const runtime = makeRuntime(commands)
   const { sessionFactory, agentDir } = makeSessionFactoryForTest()
@@ -98,7 +98,7 @@ function makeRunner(commands: RegisteredCommand[]) {
     agentDir,
     runtimeVersion: '0.0.0-test',
     containerName: 'test-agent',
-    outbound,
+    outbound: wrapOutbound === undefined ? outbound : wrapOutbound(outbound),
     sessionFactory,
     channelRouter: undefined,
   })
@@ -358,7 +358,7 @@ describe('CommandRunner', () => {
     expect(pluginWarnings.length).toBe(0)
   })
 
-  test('consecutive ctx.logger calls all reach stderr', async () => {
+  test('consecutive ctx.logger lines reach stderr in order, all before command_exit', async () => {
     const cmd = defineCommand({
       surface: 'container',
       description: 'chatty',
@@ -373,18 +373,48 @@ describe('CommandRunner', () => {
     runner.start({ callId: 'chatty', name: 'chatty', args: undefined }, null)
     await waitForExit(frames, 'chatty')
 
-    // The logger writes every line to one shared stderr sink. Acquiring a
-    // writer per line without serializing them leaves the stream locked when
-    // the next line arrives, so the second call throws out of ctx.run and the
-    // line is lost. All three must survive, in order.
+    // One shared sink backs all three lines, so they must arrive whole and in
+    // call order — asserting the exact payload, not just membership.
     const stderrText = frames
       .filter((f) => f.kind === 'stderr')
       .map((f) => (f as { chunk: string }).chunk)
       .join('')
-    expect(stderrText).toContain('info: first')
-    expect(stderrText).toContain('warn: second')
-    expect(stderrText).toContain('error: third')
+    expect(stderrText).toBe(
+      '[command:test-plugin] info: first\n[command:test-plugin] warn: second\n[command:test-plugin] error: third\n',
+    )
+
+    // And every one of them must precede command_exit: the server drops the
+    // call's websocket route as it emits exit, so a later frame is discarded.
+    const kinds = frames.map((f) => f.kind)
+    expect(kinds.lastIndexOf('stderr')).toBeLessThan(kinds.indexOf('exit'))
     expect(frames.filter((f) => f.kind === 'error').length).toBe(0)
+  })
+
+  test('a throwing stderr sink still reaches command_exit instead of stranding the call', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'chatty',
+      run: async (ctx) => {
+        ctx.logger.info('first')
+        ctx.logger.warn('second')
+        return 0
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('chatty', cmd)], (outbound) => ({
+      ...outbound,
+      stderr() {
+        throw new Error('sink failure')
+      },
+    }))
+    runner.start({ callId: 'boom', name: 'chatty', args: undefined }, null)
+    const exit = await waitForExit(frames, 'boom')
+
+    // A throwing sink errors the stream, and per the Streams standard it stays
+    // errored — those lines cannot be delivered by any amount of retrying, and
+    // this pins that we do not pretend otherwise. What must still hold is that
+    // the write lock is released and the drain settles, so the command reports
+    // its own exit code rather than hanging behind a stuck queue.
+    expect((exit as { code: number }).code).toBe(0)
   })
 
   test('ctx.origin is subagent-shaped with parent TUI origin in spawnedByOrigin', async () => {

--- a/src/server/command-runner.test.ts
+++ b/src/server/command-runner.test.ts
@@ -358,6 +358,35 @@ describe('CommandRunner', () => {
     expect(pluginWarnings.length).toBe(0)
   })
 
+  test('consecutive ctx.logger calls all reach stderr', async () => {
+    const cmd = defineCommand({
+      surface: 'container',
+      description: 'chatty',
+      run: async (ctx) => {
+        ctx.logger.info('first')
+        ctx.logger.warn('second')
+        ctx.logger.error('third')
+        return 0
+      },
+    })
+    const { runner, frames } = makeRunner([registerCommand('chatty', cmd)])
+    runner.start({ callId: 'chatty', name: 'chatty', args: undefined }, null)
+    await waitForExit(frames, 'chatty')
+
+    // The logger writes every line to one shared stderr sink. Acquiring a
+    // writer per line without serializing them leaves the stream locked when
+    // the next line arrives, so the second call throws out of ctx.run and the
+    // line is lost. All three must survive, in order.
+    const stderrText = frames
+      .filter((f) => f.kind === 'stderr')
+      .map((f) => (f as { chunk: string }).chunk)
+      .join('')
+    expect(stderrText).toContain('info: first')
+    expect(stderrText).toContain('warn: second')
+    expect(stderrText).toContain('error: third')
+    expect(frames.filter((f) => f.kind === 'error').length).toBe(0)
+  })
+
   test('ctx.origin is subagent-shaped with parent TUI origin in spawnedByOrigin', async () => {
     const cmd = defineCommand({
       surface: 'container',

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -359,9 +359,33 @@ function makeWritable(onChunk: (chunk: Uint8Array) => void): WritableStream<Uint
   })
 }
 
+// One sink backs every logger line for a command, and `getWriter()` throws
+// while another writer holds the lock. Releasing in a `.then()` returns the
+// lock a microtask too late: the next `logger.*` call runs synchronously from
+// `ctx.run` and finds the stream still locked, so the line is lost and the
+// throw escapes into the command. Chain each line onto the previous write so
+// only one writer exists at a time, and release in `finally` so a rejected
+// write can't strand the lock permanently.
+//
+// Keyed per stream rather than held for the run because the same sink is also
+// handed to plugins as `ctx.stderr`; the lock has to be dropped between lines
+// or a plugin writing to it directly would be locked out.
+const writeTails = new WeakMap<WritableStream<Uint8Array>, Promise<void>>()
+
 function writeLine(stream: WritableStream<Uint8Array>, line: string): void {
-  const writer = stream.getWriter()
-  void writer.write(new TextEncoder().encode(`${line}\n`)).then(() => writer.releaseLock())
+  const bytes = new TextEncoder().encode(`${line}\n`)
+  const tail = (writeTails.get(stream) ?? Promise.resolve()).then(async () => {
+    const writer = stream.getWriter()
+    try {
+      await writer.write(bytes)
+    } finally {
+      writer.releaseLock()
+    }
+  })
+  writeTails.set(
+    stream,
+    tail.catch(() => {}),
+  )
 }
 
 export type CreateSessionForCommand = (options: CreateSessionOptions) => Promise<CreateSessionResult>

--- a/src/server/command-runner.ts
+++ b/src/server/command-runner.ts
@@ -214,8 +214,14 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
       return (command as EitherCommand<unknown>).run(ctx, argsParse.value)
     })()
 
+    // Logger lines are queued, not written inline, so they can still be in
+    // flight when `run` returns. `command_exit` is terminal for the call —
+    // `src/server/index.ts` drops the callId's websocket route as it sends it —
+    // so any frame emitted after exit is discarded. Drain the sink first on
+    // BOTH paths, or the last lines a command logs never reach the caller.
     const done = ctxPromise
-      .then((code) => {
+      .then(async (code) => {
+        await drainWrites(stderrSink)
         if (typeof code !== 'number' || !Number.isFinite(code)) {
           opts.outbound.error(callId, `command "${name}" returned a non-numeric exit code`)
           opts.outbound.exit(callId, 1)
@@ -223,7 +229,8 @@ export function createCommandRunner(opts: CommandRunnerOptions): CommandRunner {
         }
         opts.outbound.exit(callId, code)
       })
-      .catch((err: unknown) => {
+      .catch(async (err: unknown) => {
+        await drainWrites(stderrSink)
         const detail = err instanceof Error ? err.message : String(err)
         opts.outbound.error(callId, detail)
         opts.outbound.exit(callId, 1)
@@ -370,6 +377,13 @@ function makeWritable(onChunk: (chunk: Uint8Array) => void): WritableStream<Uint
 // Keyed per stream rather than held for the run because the same sink is also
 // handed to plugins as `ctx.stderr`; the lock has to be dropped between lines
 // or a plugin writing to it directly would be locked out.
+//
+// Scope of the `.catch()` on the stored tail: it keeps ONE failed write from
+// rejecting the promise every later line chains onto, and it keeps the lock
+// released. It does NOT restore delivery — per the Streams standard a sink
+// that throws leaves the stream errored, and every subsequent `write()`
+// rejects with that same error. Recovering delivery would mean replacing the
+// sink, which is out of scope here.
 const writeTails = new WeakMap<WritableStream<Uint8Array>, Promise<void>>()
 
 function writeLine(stream: WritableStream<Uint8Array>, line: string): void {
@@ -386,6 +400,12 @@ function writeLine(stream: WritableStream<Uint8Array>, line: string): void {
     stream,
     tail.catch(() => {}),
   )
+}
+
+// Settles once every line queued on `stream` so far has been handed to the
+// sink. The stored tail already absorbs rejections, so this never throws.
+function drainWrites(stream: WritableStream<Uint8Array>): Promise<void> {
+  return writeTails.get(stream) ?? Promise.resolve()
 }
 
 export type CreateSessionForCommand = (options: CreateSessionOptions) => Promise<CreateSessionResult>


### PR DESCRIPTION
## Background

A plugin command that logs twice in a row loses every line after the first, and
the loss surfaces as a `TypeError` thrown out of the command's own `run`.

```ts
run: async (ctx) => {
  ctx.logger.info('starting')     // reaches stderr
  ctx.logger.warn('no config')    // lost — and throws
  return 0
}
```

### Where it comes from

All three logger methods write to a single shared sink
(`command-runner.ts:153-159`), and `writeLine` took a fresh writer for every
line:

```ts
function writeLine(stream: WritableStream<Uint8Array>, line: string): void {
  const writer = stream.getWriter()
  void writer.write(new TextEncoder().encode(`${line}\n`)).then(() => writer.releaseLock())
}
```

`getWriter()` is synchronous, but `releaseLock()` sits inside a `.then()`, so it
runs a microtask later. Meanwhile `logger.*` calls are plain synchronous calls
from `ctx.run` — nothing yields between them. The second call therefore arrives
while the first still owns the lock:

```mermaid
sequenceDiagram
    autonumber
    participant Cmd as ctx.run
    participant WL as writeLine
    participant Sink as stderrSink

    Cmd->>WL: logger.info("starting")
    WL->>Sink: getWriter()
    Sink-->>WL: lock acquired
    WL->>WL: queue write().then(releaseLock) as a microtask
    WL-->>Cmd: return (void, fire-and-forget)

    Note over Cmd,Sink: no await in between — the microtask has not run yet

    Cmd->>WL: logger.warn("no config")
    WL->>Sink: getWriter()
    Sink-->>WL: TypeError - WritableStream is locked
    WL-->>Cmd: throw escapes into the command

    Note over Sink: releaseLock() finally runs here, long after it mattered
```

### Second, worse failure mode

If `write()` ever rejects, the `.then()` callback never runs at all, so
`releaseLock()` never happens. The stream stays locked **for the rest of the
command**, and every later log line on it fails the same way. A single transient
write error turns into total, silent log loss for that command.

### Observed

A command emitting three lines produced exactly one:

```
received: "[command:test-plugin] info: first\n"
          (warn: second and error: third never arrived)
```

---

## Summary

Serialize the writes instead of racing them: each line waits for the previous
line's write to finish before acquiring the lock, and the lock is released in
`finally`.

```mermaid
flowchart LR
    T["tail<br/>(Promise.resolve)"] --> A["acquire → write 'first' → release"]
    A --> B["acquire → write 'second' → release"]
    B --> C["acquire → write 'third' → release"]
```

Only one writer exists at any moment, so `getWriter()` never finds the stream
locked.

### Why a per-stream `WeakMap`, and not one writer held for the whole run

Holding a single long-lived writer would be simpler, but the same sink object is
also handed to the plugin as `ctx.stderr` (`command-runner.ts:180`):

```mermaid
flowchart LR
    S["stderrSink<br/>one WritableStream"]
    S --> L["logger.info / warn / error<br/>via writeLine()"]
    S --> P["ctx.stderr<br/>passed to the plugin"]
```

If `writeLine` kept the lock for the command's lifetime, any plugin writing to
its own `ctx.stderr` would be locked out. So the lock has to be dropped between
lines, which means the ordering has to live outside the writer — hence a promise
tail keyed by stream. `WeakMap` so a finished command's entry can be collected
with its sink.

### Draining before `command_exit`

Serializing alone fixes the lock contention but **not** delivery. The queued
lines settle after `run` returns, while `command_exit` is emitted from the same
microtask turn, so the measured frame order was:

```
stderr-1 , exit , stderr-2 , stderr-3
```

And `exit` is terminal for the call — `src/server/index.ts:347-349` drops the
callId's websocket route as it sends the frame:

```ts
exit(callId, code) {
  const ws = callIdToWs.get(callId)
  callIdToWs.delete(callId)          // route gone
  if (ws) safeWsSend(ws, { type: 'command_exit', callId, code })
}
```

So anything behind `exit` is discarded, and the same lines would still be lost —
silently this time instead of by a thrown `TypeError`. `drainWrites(stderrSink)`
is therefore awaited before emitting exit on **both** the success and the failure
branch. Logger calls themselves stay synchronous and `writeLine` still returns
`void`.

### Why `finally`, and the limits of the caught tail

`finally` releases the lock even when the write rejects, so a failed write cannot
strand the lock for the rest of the command.

The tail is stored as `tail.catch(() => {})` so one failed write does not reject
the promise every later line chains onto, and so the drain always settles.

To be precise about what that does **not** buy: per the Streams standard, a sink
that throws leaves the stream errored, and every subsequent `write()` rejects
with that same error. Verified directly — writes 2 and 3 to an errored stream
both reject with the original failure. So later lines are not recoverable by
retrying; the guarantee here is lock release and drain progress, not delivery.
Recovering delivery would mean swapping the sink, which the plugin already holds
a reference to as `ctx.stderr`, so that is left out of scope.

---

## What this does NOT do

- **No contract change.** `writeLine` still returns `void` and callers still do
  not await it. Logging stays fire-and-forget.
- **Does not touch** `makeWritable`, the outbound frame protocol, `ctx.stdout`,
  or any other call path.
- **Does not fix plugins that hold a writer themselves.** If a plugin calls
  `ctx.stderr.getWriter()` and keeps it, the logger is still locked out by
  construction. That is inherent to sharing one `WritableStream` between the
  runtime and the plugin, and would need a contract change rather than a fix
  here.
- **Does not add ordering guarantees between `stdout` and `stderr`.** Each sink
  has its own tail; the two remain independent, as before. The pre-exit drain
  covers `stderrSink` only, since that is the sink `writeLine` queues onto —
  writes a plugin makes to `ctx.stdout` are its own to await.
- **Does not recover delivery on an errored sink** — see the note in Summary.

---

## Review notes

The load-bearing parts are small:

1. `releaseLock()` moved into `finally`, so a rejected write cannot strand the
   lock.
2. The tail is stored **with `.catch()` already attached**, so a failed write
   does not poison later lines and the drain always settles.
3. `await drainWrites(stderrSink)` before `outbound.exit` on **both** branches of
   the `done` chain — this is the part that actually gets the lines to the caller.

Invariants to check: at most one writer is outstanding on a given sink at any
time; the sink is unlocked between lines so `ctx.stderr` stays usable by the
plugin; and no logger frame is emitted after `command_exit`.

Both tests guard observable behavior rather than implementation shape:

- The ordering test fails on `main` (only the first of three lines arrives) and
  also fails if the two `await drainWrites(stderrSink)` lines are removed —
  checked by commenting them out.
- The rejection-path test pins the narrowed contract: a throwing sink still
  reaches `command_exit` with the command's own code instead of hanging.

### Verification, and its limits

Run locally with `TYPECLAW_ALLOW_SERIAL_TESTS=1`, comparing the full suite
against an unmodified checkout of the same commit:

| | pass | skip | fail |
|---|---|---|---|
| `main` | 11611 | 25 | 7 |
| this branch | 11613 | 25 | 7 |

Identical failure set before and after; the two extra passes are the new tests.
`typecheck`, `oxlint`, and `oxfmt --check` are all clean on the changed files.

Two things I could **not** verify locally, flagged so a maintainer can decide
whether to re-run them:

- The `wrapBuiltinToolDefinition bash sandbox` tests do not run on macOS (no
  bwrap). They are in the pre-existing failure set above, identical on both
  sides.
- `bun test --parallel` is refused by the `require-parallel` preload on **bun
  1.3.11**: that version does not set `BUN_TEST_WORKER_ID`, so the guard's
  detection fails closed and denies the run. CONTRIBUTING.md says "any 1.3.x
  works locally", so this may be worth a separate look — I did not touch it
  here, since it is unrelated to this fix.
