### PR TITLE
fix(git): scan linked worktrees by admin gitdir so a deleted checkout can't brick the secret scan

### DIFF
--- a/src/git/secret-history.test.ts
+++ b/src/git/secret-history.test.ts
@@ -350,6 +350,52 @@ describe('canonical Git secret history guard', () => {
     await expect(assertNoCanonicalSecretsInGit(worktree)).resolves.toBeUndefined()
   })
 
+  test("detects a canonical secret staged in the main worktree's index when scanning from a linked worktree", async () => {
+    // The main worktree's private index lives in the common gitdir, NOT under `worktrees/`, so a scan
+    // initiated from a linked checkout must probe the common gitdir too or it would miss a secret
+    // staged in the main index.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const worktree = `${repo}-linked-caller-index`
+    roots.push(worktree)
+    await git(repo, 'worktree', 'add', worktree)
+
+    await writeFile(join(repo, 'secrets.json'), '{"credential":"placeholder"}')
+    await git(repo, 'add', 'secrets.json')
+
+    expect(await scanCanonicalSecretsInGit(worktree)).toEqual({ ok: false, paths: ['secrets.json'] })
+  })
+
+  test("rejects a non-commit pinned by the main worktree's FETCH_HEAD when scanning from a linked worktree", async () => {
+    // The main worktree's private FETCH_HEAD lives in the common gitdir; scanning from a linked
+    // checkout must probe it or a non-commit it pins would go unseen.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const worktree = `${repo}-linked-caller-fetchhead`
+    roots.push(worktree)
+    await git(repo, 'worktree', 'add', worktree)
+
+    const blob = await gitStdin(repo, 'notes', 'hash-object', '-w', '--stdin')
+    const tree = await gitStdin(repo, `100644 blob ${blob}\tNOTES.md\n`, 'mktree')
+    const tag = await gitStdin(
+      repo,
+      `object ${tree}\ntype tree\ntag treetag\ntagger t <test@example.com> 0 +0000\n\nx\n`,
+      'hash-object',
+      '-w',
+      '-t',
+      'tag',
+      '--stdin',
+    )
+    const mainFetchHead = await gitOutput(repo, 'rev-parse', '--git-path', 'FETCH_HEAD')
+    const fetchHeadPath = isAbsolute(mainFetchHead) ? mainFetchHead : join(repo, mainFetchHead)
+    await writeFile(fetchHeadPath, `${tag}\t\tbranch x of somewhere\n`)
+
+    expect(await scanCanonicalSecretsInGit(worktree)).toEqual({
+      ok: false,
+      paths: ['unattributable dangling Git objects'],
+    })
+  })
+
   test("rejects a non-commit pinned only by a linked worktree's FETCH_HEAD, scanning from the main worktree", async () => {
     const repo = await makeRepo()
     await commitFile(repo, 'README.md', 'safe')
@@ -378,6 +424,102 @@ describe('canonical Git secret history guard', () => {
       ok: false,
       paths: ['unattributable dangling Git objects'],
     })
+  })
+
+  test('allows a prunable linked worktree with a commit-only HEAD whose working directory was deleted', async () => {
+    // Real-world regression: a subagent added a worktree under /tmp, then /tmp reaped the directory.
+    // `worktree list` still lists it as prunable, so the old path-based probe (`git -C <gone path>`)
+    // failed "cannot change to '<path>'" and bricked the whole scan closed. A commit-only HEAD hides
+    // nothing, so it must now be allowed rather than failing closed on the deleted working dir.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const worktree = `${repo}-prunable`
+    await git(repo, 'worktree', 'add', worktree)
+    await rm(worktree, { recursive: true, force: true })
+
+    const listing = await gitOutput(repo, 'worktree', 'list', '--porcelain')
+    expect(listing).toContain('prunable')
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+  })
+
+  test("rejects a non-commit pinned by a prunable worktree's FETCH_HEAD after its working dir is deleted", async () => {
+    // The concealment path Oracle flagged: a prunable worktree's per-worktree FETCH_HEAD can pin a
+    // tag peeling to a tree that `fsck`/`rev-list` deliberately ignore, so the admin-gitdir probe is
+    // the only signal. It must survive the deleted working dir and still block.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const worktree = `${repo}-prunable-fetchhead`
+    await git(repo, 'worktree', 'add', worktree)
+    const adminDir = await worktreeAdminDir(repo, worktree)
+
+    const blob = await gitStdin(repo, '{"credential":"placeholder"}', 'hash-object', '-w', '--stdin')
+    const tree = await gitStdin(repo, `100644 blob ${blob}\tsecrets.json\n`, 'mktree')
+    const tag = await gitStdin(
+      repo,
+      `object ${tree}\ntype tree\ntag treetag\ntagger t <test@example.com> 0 +0000\n\nx\n`,
+      'hash-object',
+      '-w',
+      '-t',
+      'tag',
+      '--stdin',
+    )
+    await writeFile(join(adminDir, 'FETCH_HEAD'), `${tag}\t\tbranch x of somewhere\n`)
+    await rm(worktree, { recursive: true, force: true })
+
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({
+      ok: false,
+      paths: ['unattributable dangling Git objects'],
+    })
+  })
+
+  test("detects a canonical secret staged in a prunable worktree's retained index", async () => {
+    // The second concealment path Oracle flagged: a linked worktree's own index keeps a staged
+    // canonical blob reachable while remaining invisible to the main index and to `fsck`, even after
+    // the working dir is deleted. The per-worktree index must be scanned via its admin gitdir.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    const worktree = `${repo}-prunable-index`
+    await git(repo, 'worktree', 'add', worktree)
+    const adminDir = await worktreeAdminDir(repo, worktree)
+
+    await writeFile(join(worktree, 'secrets.json'), '{"credential":"placeholder"}')
+    await git(worktree, 'add', 'secrets.json')
+    const staged = await gitOutput(repo, `--git-dir=${adminDir}`, 'ls-files', '--cached')
+    expect(staged).toContain('secrets.json')
+    await rm(worktree, { recursive: true, force: true })
+
+    expect(await scanCanonicalSecretsInGit(repo)).toEqual({ ok: false, paths: ['secrets.json'] })
+  })
+
+  // Skipped on Windows: `chmod 0o000` does not remove directory read permission there, so `readdir`
+  // still succeeds and the unreadable-directory path this test exercises never triggers.
+  test.skipIf(isWindows())('fails closed when the worktrees admin directory cannot be enumerated', async () => {
+    // A permission/IO failure on `worktrees/` means the scan cannot prove no linked worktree hides a
+    // secret, so it must block rather than silently skip every per-worktree ref store and index.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await git(repo, 'worktree', 'add', `${repo}-wt`)
+    roots.push(`${repo}-wt`)
+    const worktreesDir = join(repo, '.git', 'worktrees')
+    await chmod(worktreesDir, 0o000)
+
+    try {
+      await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
+    } finally {
+      await chmod(worktreesDir, 0o755)
+    }
+  })
+
+  test('fails closed on an unexpected non-directory entry under the worktrees admin directory', async () => {
+    // The scanner treats Git metadata as adversarial; an entry under `worktrees/` that is not a valid
+    // admin directory cannot be classified and must block rather than be silently ignored.
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await git(repo, 'worktree', 'add', `${repo}-wt`)
+    roots.push(`${repo}-wt`)
+    await writeFile(join(repo, '.git', 'worktrees', 'stray-file'), 'not a worktree admin dir')
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
   })
 
   test('rejects an arbitrary unlisted root ref (CUSTOM_HEAD) whose tag peels to a tree', async () => {
@@ -483,6 +625,14 @@ async function resolveGitBinary(): Promise<string> {
   const stdout = await new Response(proc.stdout).text()
   if ((await proc.exited) !== 0) throw new Error('git binary not found')
   return stdout.trim()
+}
+
+async function worktreeAdminDir(repo: string, worktree: string): Promise<string> {
+  const commonDir = await gitOutput(repo, 'rev-parse', '--path-format=absolute', '--git-common-dir')
+  const gitFile = await Bun.file(join(worktree, '.git')).text()
+  const id = gitFile.replace('gitdir:', '').trim().split('/worktrees/')[1]?.split('/')[0]
+  if (id === undefined) throw new Error('could not resolve worktree admin dir')
+  return join(commonDir, 'worktrees', id)
 }
 
 async function makeRepo(): Promise<string> {

--- a/src/git/secret-history.ts
+++ b/src/git/secret-history.ts
@@ -1,3 +1,5 @@
+import { type Dirent, type Stats } from 'node:fs'
+import { readdir, stat } from 'node:fs/promises'
 import { isAbsolute, join } from 'node:path'
 
 import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from '@/sandbox/canonical-secrets'
@@ -44,11 +46,22 @@ export async function scanCanonicalSecretsInGit(agentDir: string): Promise<ScanR
   const replacements = await runGit(agentDir, gitArgs, ['for-each-ref', '--format=%(refname)', 'refs/replace'])
   if (replacements.trim() !== '') return { ok: false, paths: ['replacement refs exist under refs/replace'] }
 
-  const nonCommitRoots = await scanNonCommitRefRoots(agentDir, gitArgs)
+  const otherGitDirs = await collectOtherWorktreeGitDirs(agentDir, gitArgs)
+
+  const nonCommitRoots = await scanNonCommitRefRoots(agentDir, gitArgs, otherGitDirs)
   if (!nonCommitRoots.ok) return nonCommitRoots
 
   const index = await runGit(agentDir, gitArgs, ['ls-files', '--cached', '-z'])
   const reachablePaths = matchingCanonicalPaths(splitNul(index))
+
+  // Every other worktree keeps its own index under its gitdir; a canonical secret staged there (e.g.
+  // `git add -f secrets.json` in a linked worktree whose working dir was later deleted, or in the main
+  // worktree when the caller is a linked one) keeps the blob reachable but is invisible to the caller's
+  // own index and to `fsck`, so scan each one.
+  for (const otherGitDir of otherGitDirs) {
+    const otherIndex = await runGit(agentDir, gitArgs, [`--git-dir=${otherGitDir}`, 'ls-files', '--cached', '-z'])
+    reachablePaths.push(...matchingCanonicalPaths(splitNul(otherIndex)))
+  }
 
   const objects = await runGit(agentDir, gitArgs, ['rev-list', '--objects', '--all', '--reflog'])
   for (const line of objects.split('\n')) {
@@ -89,20 +102,14 @@ const GIT_FALLBACK_ROOT_REFS = [
 // that tree/blob live, so neither fsck mode reports it and rev-list cannot root-anchor its path.
 // Such a live root has no repository path prefix, so it fails closed exactly like an orphan tree.
 // Ordinary commit-ish roots are handled by the reachable/reflog path scans.
-async function scanNonCommitRefRoots(agentDir: string, gitArgs: readonly string[]): Promise<UnreachableScan> {
-  const listing = await runGit(agentDir, gitArgs, ['worktree', 'list', '--porcelain'])
-  const headRefs: string[] = []
-  const linkedWorktrees: string[] = []
-  for (const line of listing.split('\n')) {
-    if (line.startsWith('HEAD ')) headRefs.push(line.slice('HEAD '.length).trim())
-    else if (line.startsWith('worktree ')) {
-      const path = line.slice('worktree '.length).trim()
-      if (path !== '' && path !== agentDir) linkedWorktrees.push(path)
-    }
-  }
+async function scanNonCommitRefRoots(
+  agentDir: string,
+  gitArgs: readonly string[],
+  otherGitDirs: readonly string[],
+): Promise<UnreachableScan> {
   const refs = await runGit(agentDir, gitArgs, ['for-each-ref', '--format=%(objectname)'])
-  const rootRefOids = await collectRootRefOids(agentDir, gitArgs, linkedWorktrees)
-  const roots = [...new Set([...headRefs, ...refs.split('\n'), ...rootRefOids].map((oid) => oid.trim()))].filter(
+  const rootRefOids = await collectRootRefOids(agentDir, gitArgs, otherGitDirs)
+  const roots = [...new Set([...refs.split('\n'), ...rootRefOids].map((oid) => oid.trim()))].filter(
     (oid) => oid !== '' && !/^0+$/.test(oid),
   )
 
@@ -118,11 +125,66 @@ async function scanNonCommitRefRoots(agentDir: string, gitArgs: readonly string[
   return { ok: true, paths: [] }
 }
 
-// Collects every oid pinned by a top-level root ref across the main worktree AND every linked one
-// (each linked worktree owns its own root-ref files under `$GIT_COMMON_DIR/worktrees/<id>/`, so a
-// non-commit pinned only there must be probed too). The main worktree keeps the caller's gitArgs so
-// the .gitstore --git-dir/--work-tree layout still resolves (that layout reports no linked
-// worktrees); linked worktrees are discovered from their own path.
+// Every gitdir that owns per-worktree metadata (HEAD, FETCH_HEAD/MERGE_HEAD, root refs, index) OTHER
+// than the caller's own, so the top-level scan can probe each via `--git-dir` without re-covering the
+// caller. Two coverage gaps are closed here:
+//
+//  - Linked worktrees are enumerated by their admin gitdir (`$GIT_COMMON_DIR/worktrees/<id>`), not by
+//    working-dir path. A worktree whose working dir was deleted out from under Git (e.g. a subagent's
+//    `/tmp/<branch>` checkout that `/tmp` later reaped) is still registered and still owns ref files
+//    and a retained index that can conceal a secret; probing it by path (`git -C <gone path>`) failed
+//    "cannot change to '<path>'" and bricked the scan closed, while dropping it would lose the only
+//    signal that its pseudoref pins a non-commit. The admin gitdir survives the deleted working dir.
+//  - When the CALLER is itself a linked worktree, the main worktree's private HEAD/pseudorefs/index
+//    live directly in the common gitdir (NOT under `worktrees/`), so the common gitdir must be probed
+//    too or a secret staged in the main index would go unseen. It is skipped when the caller already
+//    IS the main worktree (its own gitdir equals the common gitdir), which the top-level scan covers.
+async function collectOtherWorktreeGitDirs(agentDir: string, gitArgs: readonly string[]): Promise<string[]> {
+  const [gitDir, commonDir] = (
+    await runGit(agentDir, gitArgs, ['rev-parse', '--path-format=absolute', '--git-dir', '--git-common-dir'])
+  )
+    .split('\n')
+    .map((line) => line.trim())
+  if (commonDir === undefined || commonDir === '') return []
+
+  const gitDirs = new Set<string>()
+  if (commonDir !== gitDir) gitDirs.add(commonDir)
+
+  const worktreesDir = join(commonDir, 'worktrees')
+  let entries: Dirent[]
+  try {
+    entries = await readdir(worktreesDir, { withFileTypes: true })
+  } catch (error) {
+    // Only a genuinely absent `worktrees/` dir means "no linked worktrees" and is safe to treat as
+    // empty. A permission/IO/not-a-dir failure means we CANNOT prove no worktree hides a secret, so
+    // fail closed rather than silently skipping every per-worktree ref store and index.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [...gitDirs]
+    throw new GitSecretHistoryError([`Git metadata scan failed (worktrees): ${redactFsError(error)}`])
+  }
+  // Resolve each entry through `stat` (follows symlinks): a real admin gitdir is a directory, and a
+  // symlinked one must still be scanned, but anything that cannot be confirmed a directory is an
+  // unexpected entry under adversarially-treated metadata and fails closed.
+  for (const entry of entries) {
+    const adminDir = join(worktreesDir, entry.name)
+    let info: Stats
+    try {
+      info = await stat(adminDir)
+    } catch (error) {
+      throw new GitSecretHistoryError([`Git metadata scan failed (worktrees): ${redactFsError(error)}`])
+    }
+    if (!info.isDirectory()) {
+      throw new GitSecretHistoryError([`Git metadata scan failed (worktrees): unexpected entry ${entry.name}`])
+    }
+    if (adminDir !== gitDir) gitDirs.add(adminDir)
+  }
+  return [...gitDirs]
+}
+
+// Collects every oid pinned by a top-level root ref across the caller's own worktree AND every other
+// one (each worktree owns its own root-ref files under its gitdir, so a non-commit pinned only there
+// must be probed too). The caller keeps its gitArgs so the .gitstore --git-dir/--work-tree layout
+// still resolves; other worktrees are probed through their gitdir via `--git-dir` so a deleted working
+// dir cannot break the probe.
 //
 // Enumeration is exhaustive rather than a fixed allowlist: `for-each-ref --include-root-refs` lists
 // ALL root refs Git recognizes — including arbitrary `*_HEAD`-style ones like CUSTOM_HEAD — so no
@@ -132,11 +194,11 @@ async function scanNonCommitRefRoots(agentDir: string, gitArgs: readonly string[
 async function collectRootRefOids(
   agentDir: string,
   gitArgs: readonly string[],
-  linkedWorktrees: readonly string[],
+  otherGitDirs: readonly string[],
 ): Promise<string[]> {
   const probes: { cwd: string; args: readonly string[] }[] = [
     { cwd: agentDir, args: gitArgs },
-    ...linkedWorktrees.map((path) => ({ cwd: path, args: [] as readonly string[] })),
+    ...otherGitDirs.map((gitDir) => ({ cwd: agentDir, args: [`--git-dir=${gitDir}`] as readonly string[] })),
   ]
   const oids: string[] = []
   for (const probe of probes) {
@@ -368,4 +430,9 @@ async function tryGit(
 function redactGitError(stderr: string): string {
   const firstLine = stderr.split(/\r?\n/, 1)[0]?.trim()
   return firstLine === undefined || firstLine === '' ? 'unknown Git error' : firstLine.slice(0, 200)
+}
+
+function redactFsError(error: unknown): string {
+  const code = (error as NodeJS.ErrnoException).code
+  return code !== undefined && code !== '' ? code : 'unknown filesystem error'
 }


### PR DESCRIPTION
## Problem

The canonical-secret Git-history guard (`src/git/secret-history.ts`) enumerated linked worktrees by their **working-directory path** and probed each with `git -C <path>`. When a worktree's working directory was deleted out from under Git — e.g. a subagent creates a worktree under `/tmp/<branch>` and `/tmp` later reaps the directory — the worktree stays registered as `prunable`, `git -C <gone path>` fails with `fatal: cannot change to '<path>': No such file or directory`, and the `runGit` helper turns that into a `GitSecretHistoryError`. Because the guard fails **closed** on any git error, the entire scan aborts and **all model-driven git/bash (and `gh`) is disabled** until an operator manually prunes the stale worktree.

This is a real incident: an agent's PR-review run was bricked mid-review by a leftover `/tmp` worktree, with the only remedy being manual `git worktree prune` + restart.

## Fix

Enumerate linked worktrees by their **administrative gitdir** (`$GIT_COMMON_DIR/worktrees/<id>`) and probe them via `--git-dir=<admin>` instead of `git -C <working-dir>`. The admin gitdir survives a deleted working directory, so the same root-ref / pseudoref / index inspection works for **live and prunable worktrees alike**, and a reaped `/tmp` checkout can no longer break the scan.

Simply dropping a prunable worktree from the scan would be **unsafe** — a linked worktree's own metadata is a genuine concealment surface:

- Its per-worktree pseudorefs (`HEAD` / `FETCH_HEAD` / `MERGE_HEAD`) can pin a **non-commit** (e.g. a tag peeling to a tree carrying `secrets.json`) that `fsck --unreachable` / `rev-list` deliberately ignore — the pseudoref is the only signal that makes that tree a blocking live root.
- Its **retained index** can keep a staged canonical secret reachable while remaining invisible to the main worktree's index and to `fsck`.

So both are now scanned through the admin gitdir: per-worktree root refs (via the existing `--include-root-refs` + fallback path) and the per-worktree index (`ls-files --cached`).

Enumeration itself **fails closed**: only a genuinely absent `worktrees/` directory (`ENOENT`) is treated as "no linked worktrees"; a permission/IO error or an unexpected non-directory entry under `worktrees/` raises `GitSecretHistoryError` rather than silently skipping every per-worktree ref store and index.

## Tests

Added regressions (each Red without the fix, Green with it):

1. Prunable worktree with a commit-only `HEAD` whose working dir was deleted → **allowed** (no false brick — the original bug).
2. Prunable worktree whose admin `FETCH_HEAD` → tag → tree carries `secrets.json` → **blocked** (`unattributable dangling Git objects`).
3. `secrets.json` staged in a prunable worktree's retained index → **blocked** (`["secrets.json"]`).
4. Unreadable `worktrees/` directory → **fails closed**.
5. Unexpected non-directory entry under `worktrees/` → **fails closed**.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅ (0 errors)
- `bun run format:check` ✅
- `bun run test` ✅ (11625 pass, 0 fail)

Design reviewed with the Oracle consultant across two rounds; this fix incorporates its findings on both the concealment-surface and fail-open-enumeration edge cases.
