### PR TITLE
fix(github): drop body-less COMMENTED review inbound to stop self-reply churn

### DIFF
--- a/src/channels/adapters/github/inbound.test.ts
+++ b/src/channels/adapters/github/inbound.test.ts
@@ -633,7 +633,11 @@ describe('classifyGithubInbound — review traffic on the bot-authored PR engage
   // silently observed and the bot could not address the review. Self-PR review
   // traffic must force the engagement trigger while staying sticky-free, so
   // reviews on OTHER people's PRs remain observe-only (the PR #672 fix).
-  function reviewOnSelfPr(reviewer: Record<string, unknown>, state = 'COMMENTED', body = ''): Record<string, unknown> {
+  function reviewOnSelfPr(
+    reviewer: Record<string, unknown>,
+    state = 'COMMENTED',
+    body = 'take a look at this',
+  ): Record<string, unknown> {
     return {
       action: 'submitted',
       repository: repo(),
@@ -661,6 +665,15 @@ describe('classifyGithubInbound — review traffic on the bot-authored PR engage
   it('engages a human review on the bot-authored PR', () => {
     const msg = classifyGithubInbound('pull_request_review', reviewOnSelfPr(user()), 'typeclaw-bot')
     expect(msg?.isBotMention).toBe(true)
+  })
+
+  it('drops a body-less COMMENTED review on the bot-authored PR (inline-reply container, no thanks churn)', () => {
+    const msg = classifyGithubInbound(
+      'pull_request_review',
+      reviewOnSelfPr({ login: 'peer-bot', id: 20, type: 'Bot' }, 'COMMENTED', ''),
+      'typeclaw-bot',
+    )
+    expect(msg).toBe(null)
   })
 
   it('keeps a review on someone else PR observe-only (no forced mention)', () => {
@@ -759,10 +772,14 @@ describe('classifyGithubInbound — empty-body handling', () => {
       expect(msg?.text).toBe('@alice requested changes on PR #7: "Add the thing".')
     })
 
-    it('synthesizes neutral text for a body-less COMMENTED review without implying a review was requested', () => {
+    it('drops a body-less COMMENTED review (inline-reply container delivered as separate comment events)', () => {
       const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('COMMENTED'), 'typeclaw-bot')
-      expect(msg?.text).toBe('@alice submitted a review on PR #7: "Add the thing".')
-      expect(msg?.text).not.toContain('Please review')
+      expect(msg).toBe(null)
+    })
+
+    it('drops a body-less COMMENTED review case-insensitively (lowercase state from webhook payloads)', () => {
+      const msg = classifyGithubInbound('pull_request_review', reviewSubmitted('commented'), 'typeclaw-bot')
+      expect(msg).toBe(null)
     })
 
     it('matches the state case-insensitively (REST returns uppercase, some payloads lowercase)', () => {

--- a/src/channels/adapters/github/inbound.ts
+++ b/src/channels/adapters/github/inbound.ts
@@ -566,6 +566,13 @@ export function classifyGithubInbound(
     const reviewer = readUser(review.user)
     const body = readString(review, 'body')
     const hasBody = body !== null && body.trim() !== ''
+    // A body-less COMMENTED review is the container GitHub submits when a user
+    // replies inline to a review thread; those replies arrive separately as
+    // pull_request_review_comment events. Synthesizing "@x submitted a review"
+    // here duplicates that traffic with a contentless line that trips the
+    // solo-human engagement fallback into a reflexive "Thanks for the review!".
+    // APPROVED / CHANGES_REQUESTED are real verdicts, so their synthesis stays.
+    if (!hasBody && isCommentedReviewState(readString(review, 'state'))) return null
     const text = hasBody
       ? body
       : reviewer !== null
@@ -910,6 +917,10 @@ function synthesizeReviewStateText(
 // varies by payload source (webhook vs REST), so normalize before matching.
 function isActionableReviewState(state: string | null): boolean {
   return state?.toLowerCase() !== 'approved'
+}
+
+function isCommentedReviewState(state: string | null): boolean {
+  return state?.toLowerCase() === 'commented'
 }
 
 async function resolveTeamMembership(


### PR DESCRIPTION
## Background

On [#1256](https://github.com/typeclaw/typeclaw/pull/1256#issuecomment-5024214699) the bot posted a top-level **"Thanks for the review! ✨"** on a PR — a reply to nothing, reading as if it answered itself.

Root cause is in the GitHub inbound classifier, not the engagement layer. When a reviewer replies **inline to a review thread**, GitHub records that single action as two things: the reply itself (a `pull_request_review_comment`) *and* a `pull_request_review` submission with `state: COMMENTED` and an **empty body**. Per GitHub's own docs a review is "a group of review comments, a body comment, and a state" — so a body-less COMMENTED review is just the *container* for inline replies that already arrive as separate `pull_request_review_comment` events.

`classifyGithubInbound` was synthesizing `@x submitted a review on PR #N` for that empty container. Two failures compound:

1. **Duplication** — the reviewer's one thread reply is delivered twice: once correctly as the thread inbound (handled substantively), once as this contentless "submitted a review" top-level inbound.
2. **Reflexive engage** — the synthesized line has no actionable content, and in a solo-human PR session it falls straight through the solo-human engagement fallback (`engagement.ts`), so the agent replies with a bare "Thanks for the review!" aimed at nothing.

Confirmed from the runtime transcript on #1256: the `pr:1256` `thread=null` session's only inbound was the synthesized "…submitted a review" line, and the sole tool call was `channel_reply({ text: "Thanks for the review! ✨" })`. The substantive reply went out correctly in the *separate* thread session.

## Summary

Drop the empty-body COMMENTED review at the classifier: `if (!hasBody && isCommentedReviewState(state)) return null`.

**Why COMMENTED only, and not all empty reviews** — APPROVED and CHANGES_REQUESTED are genuine verdicts whose synthesized line ("approved" / "requested changes on") *is* the signal the agent needs; those still engage exactly as before. COMMENTED is the one state the codebase already treats as non-deciding (`review-state.ts`: "COMMENTED and PENDING are non-deciding"), and it's the state GitHub uses for the inline-reply container.

**Why at the classifier, not the engagement layer** — killing the duplicate at its source is narrower than teaching the fallback to ignore synthesized-awareness inbounds, and it removes the redundant traffic entirely rather than just suppressing the reply.

## What this does NOT do

- Does not change engagement for reviews that carry a real body (those still engage).
- Does not touch APPROVED / CHANGES_REQUESTED synthesis or the self-PR force-engage path (PR #672).
- Does not alter the separate `pull_request_review_comment` thread-reply handling — that path was already correct.
- No change to the solo-human fallback itself.

## Review notes

- Load-bearing change: `inbound.ts` `pull_request_review` branch — the new early `return null`. Invariant to verify: a body-less COMMENTED review yields `null`; APPROVED/CHANGES_REQUESTED (and any COMMENTED *with* a body) are unchanged.
- Tests: `inbound.test.ts` now asserts the drop (both uppercase and lowercase `commented`), and the self-PR engage tests were updated to carry a real body so they keep exercising the PR #672 force-engage path rather than silently hitting the new drop.
- Full suite green locally (11637 pass, 0 fail); typecheck / lint / format:check clean.