### PR TITLE
fix(slack-bot): render GFM in file captions and edits, not literal markdown

### DIFF
--- a/src/channels/adapters/slack-bot-edit.test.ts
+++ b/src/channels/adapters/slack-bot-edit.test.ts
@@ -4,12 +4,6 @@ import type { EditMessageRequest } from '@/channels/types'
 
 import { createSlackEditMessageCallback } from './slack-bot-edit'
 
-class FakeSlackError extends Error {
-  constructor(public code: string) {
-    super(code)
-  }
-}
-
 const req = (over: Partial<EditMessageRequest> = {}): EditMessageRequest => ({
   adapter: 'slack-bot',
   workspace: 'T1',
@@ -20,28 +14,65 @@ const req = (over: Partial<EditMessageRequest> = {}): EditMessageRequest => ({
   ...over,
 })
 
-describe('createSlackEditMessageCallback', () => {
-  it('calls updateMessage with (channel, ts, text) and returns ok', async () => {
-    const calls: Array<{ channel: string; ts: string; text: string }> = []
-    const cb = createSlackEditMessageCallback({
-      client: {
-        updateMessage: async (channel, ts, text) => {
-          calls.push({ channel, ts, text })
-          return { ts, text, type: 'message' }
-        },
-      },
-    })
+type Captured = { url: string; body: URLSearchParams }
 
-    const result = await cb(req())
+type FakeResponse = { body?: { ok?: boolean; error?: string }; status?: number; retryAfter?: string }
+
+function fakeFetch(response: { ok?: boolean; error?: string }, capture?: Captured[]): typeof fetch {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    capture?.push({ url: String(url), body: new URLSearchParams(String(init?.body ?? '')) })
+    return new Response(JSON.stringify(response), { status: 200 }) as unknown as Response
+  }) as unknown as typeof fetch
+}
+
+// Returns a fetch that replays the given responses in order (last one repeats),
+// so a retry sequence like [429, 429, ok] can be exercised deterministically.
+function sequenceFetch(responses: FakeResponse[], capture?: Captured[]): typeof fetch {
+  let call = 0
+  return (async (_url: string | URL | Request, _init?: RequestInit) => {
+    const spec = responses[Math.min(call, responses.length - 1)]!
+    call++
+    capture?.push({ url: String(_url), body: new URLSearchParams(String(_init?.body ?? '')) })
+    const headers = spec.retryAfter !== undefined ? { 'retry-after': spec.retryAfter } : undefined
+    return new Response(JSON.stringify(spec.body ?? {}), {
+      status: spec.status ?? 200,
+      ...(headers !== undefined ? { headers } : {}),
+    }) as unknown as Response
+  }) as unknown as typeof fetch
+}
+
+const noSleep = async () => {}
+
+describe('createSlackEditMessageCallback', () => {
+  it('calls chat.update with markdown_text (raw GFM) and returns ok', async () => {
+    const calls: Captured[] = []
+    const cb = createSlackEditMessageCallback({ token: 'xoxb-1', fetchImpl: fakeFetch({ ok: true }, calls) })
+
+    const result = await cb(req({ text: '**bold** update' }))
 
     expect(result).toEqual({ ok: true })
-    expect(calls).toEqual([{ channel: 'C1', ts: '1700000000.000100', text: 'edited body' }])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toContain('/chat.update')
+    expect(calls[0]!.body.get('channel')).toBe('C1')
+    expect(calls[0]!.body.get('ts')).toBe('1700000000.000100')
+    // Raw GFM: Slack's markdown_text renders it natively — no hand-conversion.
+    expect(calls[0]!.body.get('markdown_text')).toBe('**bold** update')
+    // markdown_text must not be combined with text/blocks (markdown_text_conflict).
+    expect(calls[0]!.body.get('text')).toBeNull()
+    expect(calls[0]!.body.get('blocks')).toBeNull()
+  })
+
+  it('preserves a non-Latin (CJK) GFM body verbatim in markdown_text', async () => {
+    const calls: Captured[] = []
+    const cb = createSlackEditMessageCallback({ token: 'xoxb-1', fetchImpl: fakeFetch({ ok: true }, calls) })
+
+    await cb(req({ text: '**状態の分布** 更新' }))
+
+    expect(calls[0]!.body.get('markdown_text')).toBe('**状態の分布** 更新')
   })
 
   it('rejects a mismatched adapter as not-supported', async () => {
-    const cb = createSlackEditMessageCallback({
-      client: { updateMessage: async () => ({ ts: 'x', text: 'x', type: 'message' }) },
-    })
+    const cb = createSlackEditMessageCallback({ token: 'xoxb-1', fetchImpl: fakeFetch({ ok: true }) })
 
     const result = await cb(req({ adapter: 'discord-bot' }))
 
@@ -50,11 +81,8 @@ describe('createSlackEditMessageCallback', () => {
 
   it('maps message_not_found to not-found', async () => {
     const cb = createSlackEditMessageCallback({
-      client: {
-        updateMessage: async () => {
-          throw new FakeSlackError('message_not_found')
-        },
-      },
+      token: 'xoxb-1',
+      fetchImpl: fakeFetch({ ok: false, error: 'message_not_found' }),
     })
 
     const result = await cb(req())
@@ -65,11 +93,8 @@ describe('createSlackEditMessageCallback', () => {
 
   it('maps cant_update_message (not the author) to permission-denied', async () => {
     const cb = createSlackEditMessageCallback({
-      client: {
-        updateMessage: async () => {
-          throw new FakeSlackError('cant_update_message')
-        },
-      },
+      token: 'xoxb-1',
+      fetchImpl: fakeFetch({ ok: false, error: 'cant_update_message' }),
     })
 
     const result = await cb(req())
@@ -80,11 +105,8 @@ describe('createSlackEditMessageCallback', () => {
 
   it('appends the scope hint on missing_scope', async () => {
     const cb = createSlackEditMessageCallback({
-      client: {
-        updateMessage: async () => {
-          throw new FakeSlackError('missing_scope')
-        },
-      },
+      token: 'xoxb-1',
+      fetchImpl: fakeFetch({ ok: false, error: 'missing_scope' }),
     })
 
     const result = await cb(req())
@@ -94,5 +116,84 @@ describe('createSlackEditMessageCallback', () => {
       expect(result.code).toBe('permission-denied')
       expect(result.error).toContain('chat:write')
     }
+  })
+
+  it('maps a network throw to a transient (adapter-unavailable) failure without crashing', async () => {
+    const throwingFetch = (async () => {
+      throw new Error('socket hang up')
+    }) as unknown as typeof fetch
+    const cb = createSlackEditMessageCallback({ token: 'xoxb-1', fetchImpl: throwingFetch })
+
+    const result = await cb(req())
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('socket hang up')
+      expect(result.code).toBe('adapter-unavailable')
+    }
+  })
+
+  describe('rate limiting', () => {
+    it('retries an HTTP 429 and succeeds on a later attempt', async () => {
+      const calls: Captured[] = []
+      const cb = createSlackEditMessageCallback({
+        token: 'xoxb-1',
+        fetchImpl: sequenceFetch([{ status: 429, retryAfter: '0' }, { status: 429 }, { body: { ok: true } }], calls),
+        sleep: noSleep,
+      })
+
+      const result = await cb(req())
+
+      expect(result).toEqual({ ok: true })
+      expect(calls).toHaveLength(3)
+    })
+
+    it('retries a 200 body ratelimited error, then succeeds', async () => {
+      const cb = createSlackEditMessageCallback({
+        token: 'xoxb-1',
+        fetchImpl: sequenceFetch([{ body: { ok: false, error: 'ratelimited' } }, { body: { ok: true } }]),
+        sleep: noSleep,
+      })
+
+      const result = await cb(req())
+
+      expect(result).toEqual({ ok: true })
+    })
+
+    it('honors the Retry-After header (seconds) when computing backoff', async () => {
+      const sleeps: number[] = []
+      const cb = createSlackEditMessageCallback({
+        token: 'xoxb-1',
+        fetchImpl: sequenceFetch([{ status: 429, retryAfter: '2' }, { body: { ok: true } }]),
+        sleep: async (ms) => {
+          sleeps.push(ms)
+        },
+      })
+
+      await cb(req())
+
+      // Retry-After: 2s, first retry (attempt 0) -> 2 * 1000 * 1.
+      expect(sleeps).toEqual([2000])
+    })
+
+    it('gives up after the retry budget and reports transient, never not-found', async () => {
+      const calls: Captured[] = []
+      const cb = createSlackEditMessageCallback({
+        token: 'xoxb-1',
+        fetchImpl: sequenceFetch([{ status: 429, retryAfter: '0' }], calls),
+        sleep: noSleep,
+      })
+
+      const result = await cb(req())
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.code).toBe('adapter-unavailable')
+        expect(result.code).not.toBe('not-found')
+        expect(result.error).toContain('rate-limited')
+      }
+      // Initial attempt + 3 retries.
+      expect(calls).toHaveLength(4)
+    })
   })
 })

--- a/src/channels/adapters/slack-bot-edit.ts
+++ b/src/channels/adapters/slack-bot-edit.ts
@@ -1,30 +1,92 @@
-import type { SlackBotClient } from 'agent-messenger/slackbot'
-
 import type { EditMessageCallback, EditMessageResult } from '@/channels/types'
 
+import { describeError } from './describe-error'
+
+const SLACK_API_BASE = 'https://slack.com/api'
+
+// Mirrors the agent-messenger SlackBotClient.withRetry budget (3 retries on
+// `ratelimited`), which this direct chat.update call replaces. Without it, a
+// transient 429 during a burst would surface as a hard edit failure.
+const MAX_RATE_LIMIT_RETRIES = 3
+const DEFAULT_RETRY_AFTER_SECONDS = 1
+
+type EditErrorCode = NonNullable<(EditMessageResult & { ok: false })['code']>
+
+// The agent emits GitHub-Flavored Markdown. Slack's `chat.update` accepts a
+// native `markdown_text` field that renders GFM correctly (bold `**` -> `*`,
+// headings, tables), so edits reuse Slack's own renderer with no lossy
+// hand-conversion — mirroring the `markdown` block used on the post path.
+// `markdown_text` must not be combined with `text`/`blocks` or Slack returns
+// `markdown_text_conflict`. The `agent-messenger` SDK's updateMessage only
+// forwards `text`, so we call chat.update directly with the adapter token —
+// and re-implement the SDK's rate-limit retry here (see MAX_RATE_LIMIT_RETRIES).
 export function createSlackEditMessageCallback(deps: {
-  client: Pick<SlackBotClient, 'updateMessage'>
+  token: string
+  fetchImpl?: typeof fetch
+  sleep?: (ms: number) => Promise<void>
 }): EditMessageCallback {
+  const fetchFn = deps.fetchImpl ?? fetch
+  const sleep = deps.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
   return async (req): Promise<EditMessageResult> => {
     if (req.adapter !== 'slack-bot') {
       return { ok: false, error: `unknown adapter: ${req.adapter}`, code: 'not-supported' }
     }
-    try {
-      await deps.client.updateMessage(req.chat, req.messageId, req.text)
-    } catch (err) {
-      const code = slackErrorCode(err)
-      return { ok: false, error: withScopeHint(code, describe(err)), code: classifyEditError(code) }
+    const body = new URLSearchParams({
+      channel: req.chat,
+      ts: req.messageId,
+      markdown_text: req.text,
+    }).toString()
+
+    for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+      let response: Response
+      try {
+        response = await fetchFn(`${SLACK_API_BASE}/chat.update`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${deps.token}`,
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          },
+          body,
+        })
+      } catch (err) {
+        // Network throw is transient, not a missing target — surface as
+        // adapter-unavailable so the caller can distinguish it from a 404.
+        return { ok: false, error: describeError(err), code: 'adapter-unavailable' }
+      }
+
+      const raw = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string }
+      if (raw.ok === true) return { ok: true }
+      const code = raw.error ?? null
+
+      // Slack signals throttling with HTTP 429 (+ Retry-After header) and/or a
+      // `ratelimited` body error. Retry within budget honoring Retry-After;
+      // once exhausted, surface as transient (adapter-unavailable), never 404.
+      if (response.status === 429 || code === 'ratelimited') {
+        if (attempt < MAX_RATE_LIMIT_RETRIES) {
+          await sleep(retryAfterMs(response, attempt))
+          continue
+        }
+        return {
+          ok: false,
+          error: `Slack rate-limited chat.update after ${MAX_RATE_LIMIT_RETRIES} retries (ratelimited)`,
+          code: 'adapter-unavailable',
+        }
+      }
+
+      return { ok: false, error: withScopeHint(code, code ?? 'unknown slack error'), code: classifyEditError(code) }
     }
-    return { ok: true }
+    // Unreachable: the loop returns on every path, but TS needs a terminal.
+    return { ok: false, error: 'unreachable', code: 'adapter-unavailable' }
   }
 }
 
-function slackErrorCode(err: unknown): string | null {
-  if (typeof err === 'object' && err !== null && 'code' in err) {
-    const code = (err as { code: unknown }).code
-    if (typeof code === 'string') return code
-  }
-  return null
+// Retry-After is in seconds per Slack's docs; fall back to a 1s base and grow
+// it linearly per attempt (matching the SDK's `retryAfter * (attempt+1)`).
+function retryAfterMs(response: Response, attempt: number): number {
+  const header = response.headers.get('retry-after')
+  const seconds = header !== null && header !== '' ? Number.parseInt(header, 10) : DEFAULT_RETRY_AFTER_SECONDS
+  const base = Number.isFinite(seconds) && seconds > 0 ? seconds : DEFAULT_RETRY_AFTER_SECONDS
+  return base * 1000 * (attempt + 1)
 }
 
 // `chat:write` is the scope the bot token needs to edit its own messages;
@@ -35,7 +97,7 @@ function withScopeHint(code: string | null, error: string): string {
   return `${error} (Slack bot token needs the \`chat:write\` scope; reinstall/reauthorize the app with that scope.)`
 }
 
-function classifyEditError(code: string | null): NonNullable<(EditMessageResult & { ok: false })['code']> {
+function classifyEditError(code: string | null): EditErrorCode {
   switch (code) {
     case 'message_not_found':
     case 'channel_not_found':
@@ -48,11 +110,14 @@ function classifyEditError(code: string | null): NonNullable<(EditMessageResult 
     case 'not_authed':
     case 'invalid_auth':
       return 'permission-denied'
+    // Transient Slack-side failures the agent should treat as retryable, not
+    // as a missing/forbidden target.
+    case 'ratelimited':
+    case 'service_unavailable':
+    case 'fatal_error':
+    case 'internal_error':
+      return 'adapter-unavailable'
     default:
       return 'not-found'
   }
-}
-
-function describe(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
 }

--- a/src/channels/adapters/slack-bot.test.ts
+++ b/src/channels/adapters/slack-bot.test.ts
@@ -1800,6 +1800,23 @@ describe('slack-bot createOutboundCallback', () => {
     expect(uploads).toEqual([{ channel: 'C0', bytes: 10, filename: 'a.png', options: { initial_comment: 'caption' } }])
   })
 
+  test('attachment caption converts GFM to Slack mrkdwn (initial_comment cannot carry a markdown block)', async () => {
+    // given
+    const { client, uploads } = makeFakeClient()
+    const cb = createOutboundCallback({
+      client,
+      logger: silentLogger(),
+      formatChannelTag: tag,
+      readFile: fakeRead,
+    })
+    // when
+    await cb(
+      makeMsg({ text: '**Status Distribution**\n- Planned: 235', attachments: [{ path: '/agent/report.xlsx' }] }),
+    )
+    // then
+    expect(uploads[0]!.options?.initial_comment).toBe('*Status Distribution*\n- Planned: 235')
+  })
+
   test('multi-attachment puts caption only on the FIRST upload; rest are bare', async () => {
     const { client, uploads } = makeFakeClient()
     const cb = createOutboundCallback({

--- a/src/channels/adapters/slack-bot.ts
+++ b/src/channels/adapters/slack-bot.ts
@@ -67,6 +67,7 @@ import {
   type ThreadCommandInput,
 } from './slack-bot-slash-commands'
 import { slackTsToMillis } from './slack-bot-time'
+import { toSlackMrkdwn } from './slack-format'
 
 // One slash command per logical agent gesture. Mirrors the discord-bot
 // SLASH_COMMANDS constant so the cross-platform set stays consistent — when
@@ -1027,7 +1028,11 @@ export function createOutboundCallback(deps: {
       const isFirst = index === 0
       const uploadOptions: { thread_ts?: string; initial_comment?: string } = {}
       if (threadTs !== undefined) uploadOptions.thread_ts = threadTs
-      if (isFirst && text !== '') uploadOptions.initial_comment = text
+      // A file caption cannot carry a `markdown` block (files.uploadV2 has no
+      // `blocks` param), so it is parsed as Slack mrkdwn. Convert the agent's
+      // GFM (`**bold**`) to mrkdwn (`*bold*`) here — the text-only path above
+      // relies on the native markdown block and needs no conversion.
+      if (isFirst && text !== '') uploadOptions.initial_comment = toSlackMrkdwn(text)
       try {
         const file = await client.uploadFile(msg.chat, buffer, filename, uploadOptions)
         logger.info(`[slack-bot] uploaded id=${file.id} filename=${file.name} size=${file.size} ${tag}`)
@@ -1199,7 +1204,7 @@ export function createSlackBotAdapter(options: SlackBotAdapterOptions): SlackBot
 
   const reactionCallback = createSlackReactionCallback({ client })
   const removeReactionCallback = createSlackRemoveReactionCallback({ client })
-  const editMessageCallback = createSlackEditMessageCallback({ client })
+  const editMessageCallback = createSlackEditMessageCallback({ token: options.token, fetchImpl })
 
   const dedupe = createSlackDedupe()
 

--- a/src/channels/adapters/slack-format.test.ts
+++ b/src/channels/adapters/slack-format.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'bun:test'
+
+import { toSlackMrkdwn } from './slack-format'
+
+describe('toSlackMrkdwn', () => {
+  describe('bold', () => {
+    it('converts **bold** to *bold*', () => {
+      expect(toSlackMrkdwn('**bold**')).toBe('*bold*')
+    })
+
+    it('converts __bold__ to *bold*', () => {
+      expect(toSlackMrkdwn('__bold__')).toBe('*bold*')
+    })
+
+    it('converts multiple bold spans on one line', () => {
+      expect(toSlackMrkdwn('**a** and **b**')).toBe('*a* and *b*')
+    })
+
+    it('handles bold spanning the whole heading-style line', () => {
+      expect(toSlackMrkdwn('**Status Distribution**')).toBe('*Status Distribution*')
+    })
+
+    it('leaves an unbalanced ** as a literal', () => {
+      expect(toSlackMrkdwn('a ** b')).toBe('a ** b')
+    })
+
+    it('does not treat snake_case __ as bold', () => {
+      expect(toSlackMrkdwn('my__var__name')).toBe('my__var__name')
+    })
+  })
+
+  describe('italic', () => {
+    it('converts *italic* to _italic_', () => {
+      expect(toSlackMrkdwn('*italic*')).toBe('_italic_')
+    })
+
+    it('keeps _italic_ as _italic_', () => {
+      expect(toSlackMrkdwn('_italic_')).toBe('_italic_')
+    })
+
+    it('does not italicize a lone asterisk mid-word', () => {
+      expect(toSlackMrkdwn('a*b*c')).toBe('a*b*c')
+    })
+
+    it('does not italicize inside identifiers', () => {
+      expect(toSlackMrkdwn('var_name_here')).toBe('var_name_here')
+    })
+
+    it('converts bold+italic combination', () => {
+      expect(toSlackMrkdwn('**bold** and *italic*')).toBe('*bold* and _italic_')
+    })
+  })
+
+  describe('strikethrough', () => {
+    it('converts ~~strike~~ to ~strike~', () => {
+      expect(toSlackMrkdwn('~~strike~~')).toBe('~strike~')
+    })
+  })
+
+  describe('links', () => {
+    it('converts [label](url) to <url|label>', () => {
+      expect(toSlackMrkdwn('[Docs](https://example.com)')).toBe('<https://example.com|Docs>')
+    })
+
+    it('converts a bold label inside a link', () => {
+      expect(toSlackMrkdwn('[**Docs**](https://example.com)')).toBe('<https://example.com|*Docs*>')
+    })
+
+    it('leaves an autolink-style bare url untouched', () => {
+      expect(toSlackMrkdwn('see https://example.com now')).toBe('see https://example.com now')
+    })
+  })
+
+  describe('headings', () => {
+    it('renders # heading as bold line', () => {
+      expect(toSlackMrkdwn('# Title')).toBe('*Title*')
+    })
+
+    it('renders ## heading as bold line', () => {
+      expect(toSlackMrkdwn('## Status')).toBe('*Status*')
+    })
+
+    it('renders ### heading as bold line', () => {
+      expect(toSlackMrkdwn('### Deep')).toBe('*Deep*')
+    })
+
+    it('flattens inner bold inside a heading (no nested bold in mrkdwn)', () => {
+      expect(toSlackMrkdwn('## Status **live**')).toBe('*Status live*')
+    })
+
+    it('keeps italic inside a heading', () => {
+      expect(toSlackMrkdwn('## Report *(draft)*')).toBe('*Report _(draft)_*')
+    })
+
+    it('preserves inline code inside a heading (bold-flatten must not touch code spans)', () => {
+      expect(toSlackMrkdwn('# Formula `a*b*c`')).toBe('*Formula `a*b*c`*')
+    })
+
+    it('flattens bold but preserves adjacent inline code in a heading', () => {
+      expect(toSlackMrkdwn('## Run **now** with `x*y`')).toBe('*Run now with `x*y`*')
+    })
+
+    it('does not treat a mid-line hash as a heading', () => {
+      expect(toSlackMrkdwn('issue #42 is open')).toBe('issue #42 is open')
+    })
+  })
+
+  describe('code protection', () => {
+    it('leaves inline code contents untouched', () => {
+      expect(toSlackMrkdwn('`**not bold**`')).toBe('`**not bold**`')
+    })
+
+    it('leaves fenced code block contents untouched', () => {
+      const input = '```\n**still literal** _here_\n```'
+      expect(toSlackMrkdwn(input)).toBe(input)
+    })
+
+    it('preserves a fenced block with a language hint verbatim', () => {
+      const input = '```ts\nconst x = a ** b\n```'
+      expect(toSlackMrkdwn(input)).toBe(input)
+    })
+
+    it('converts markdown around a fenced block but not inside it', () => {
+      const input = '**before**\n```\n**inside**\n```\n**after**'
+      expect(toSlackMrkdwn(input)).toBe('*before*\n```\n**inside**\n```\n*after*')
+    })
+  })
+
+  describe('blockquotes and lists', () => {
+    it('preserves blockquote markers and converts inline markdown', () => {
+      expect(toSlackMrkdwn('> **quoted**')).toBe('> *quoted*')
+    })
+
+    it('preserves list markers and converts inline markdown', () => {
+      expect(toSlackMrkdwn('- **item**')).toBe('- *item*')
+    })
+  })
+
+  describe('tables', () => {
+    it('degrades a GFM table to plain pipe-separated rows without the alignment row', () => {
+      const input = ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n')
+      const out = toSlackMrkdwn(input)
+      expect(out).not.toContain('---')
+      expect(out).toContain('A')
+      expect(out).toContain('B')
+      expect(out).toContain('1')
+      expect(out).toContain('2')
+    })
+  })
+
+  describe('non-Latin script (CJK bold headers)', () => {
+    it('converts bold markers wrapping CJK text', () => {
+      const input = ['**状態の分布**', '- 予定: 235', '', '**スプリント W2**', '16 チケット'].join('\n')
+      const out = toSlackMrkdwn(input)
+      expect(out).toContain('*状態の分布*')
+      expect(out).toContain('*スプリント W2*')
+      expect(out).not.toContain('**')
+    })
+  })
+
+  describe('idempotency-ish', () => {
+    it('leaves already-valid mrkdwn bold unchanged', () => {
+      expect(toSlackMrkdwn('*already*')).toBe('_already_')
+    })
+
+    it('returns empty string for empty input', () => {
+      expect(toSlackMrkdwn('')).toBe('')
+    })
+  })
+})

--- a/src/channels/adapters/slack-format.ts
+++ b/src/channels/adapters/slack-format.ts
@@ -1,0 +1,245 @@
+// Convert the model's common-Markdown (GFM) output to Slack mrkdwn.
+//
+// Why this exists: the agent writes GitHub-Flavored Markdown the way a
+// human types it (`**bold**`, `## heading`, `[text](url)`, tables). For a
+// normal chat post the slack-bot adapter wraps that GFM in a Slack
+// `markdown` block and Slack renders it natively — so no conversion is
+// needed there. But two outbound fields cannot carry a `markdown` block:
+// a file upload's `initial_comment` (files.uploadV2 has no `blocks`
+// param). That field is parsed as Slack *mrkdwn*, where bold is a SINGLE
+// `*`, so raw GFM `**bold**` renders as literal double asterisks. This
+// converter bridges GFM -> mrkdwn for exactly those constrained fields.
+//
+// Slack mrkdwn is forgiving (unlike Telegram MarkdownV2, there is no
+// escaping that can crash the parser), so this is a best-effort semantic
+// translation, not a safety escape. Constructs mrkdwn cannot represent
+// (headings, tables) degrade to the closest readable form.
+//
+// Slack mrkdwn spec (https://docs.slack.dev/messaging/formatting-message-text):
+//   - bold:   *text*
+//   - italic: _text_
+//   - strike: ~text~
+//   - link:   <url|label>
+//   - code:   `code`, ```block```
+//   - quote:  > line
+//   No native heading or table syntax exists.
+
+export function toSlackMrkdwn(input: string): string {
+  if (input === '') return ''
+  const lines = input.split('\n')
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+
+    if (isFenceOpen(line)) {
+      // Emit the fence and its body verbatim — a `*` inside a code block is
+      // literal, never italic. Scan to the closing fence (or EOF).
+      out.push(line)
+      i++
+      while (i < lines.length && !isFenceClose(lines[i]!)) {
+        out.push(lines[i]!)
+        i++
+      }
+      if (i < lines.length) {
+        out.push(lines[i]!)
+        i++
+      }
+      continue
+    }
+
+    if (isTableSeparatorRow(line) && out.length > 0 && isTableRow(lines[i - 1])) {
+      // GFM alignment row (`| --- | :--: |`) has no mrkdwn equivalent; drop
+      // it. The header row above and the data rows below stay as plain
+      // pipe-separated text, which reads fine in monospace-free mrkdwn.
+      i++
+      continue
+    }
+
+    out.push(renderLine(line))
+    i++
+  }
+  return out.join('\n')
+}
+
+function isFenceOpen(line: string): boolean {
+  return /^\s*```/.test(line)
+}
+
+function isFenceClose(line: string): boolean {
+  return /^\s*```\s*$/.test(line)
+}
+
+function isTableRow(line: string | undefined): boolean {
+  if (line === undefined) return false
+  return /^\s*\|.*\|\s*$/.test(line)
+}
+
+function isTableSeparatorRow(line: string): boolean {
+  return /^\s*\|(\s*:?-+:?\s*\|)+\s*$/.test(line)
+}
+
+// A heading line (`#`..`######` then space) has no mrkdwn equivalent, so
+// render its inline-converted text as a bold line. A `#` that is not at the
+// line start (e.g. `issue #42`) is not a heading and falls through. Inner
+// bold is flattened to plain (`flattenBold`) because mrkdwn has no
+// bold-inside-bold — the whole heading line is already bold, so a nested
+// `*..*` would just emit a stray unbalanced `*`. Flattening happens INSIDE
+// the tokenizer so code spans stay protected: a global post-pass regex
+// would corrupt a `*` that lives inside a heading's inline code.
+const HEADING = /^(#{1,6})\s+(.*)$/
+
+function renderLine(line: string): string {
+  const heading = HEADING.exec(line)
+  if (heading !== null) {
+    const body = renderInline(heading[2]!, { flattenBold: true })
+    return body === '' ? '' : `*${body}*`
+  }
+  return renderInline(line)
+}
+
+type InlineOptions = { flattenBold: boolean }
+
+// Inline tokenizer. Recognizes, in priority order:
+//   1. inline code:  `code`
+//   2. link:         [label](url)   -> <url|label>
+//   3. bold:         **text** / __text__ -> *text*  (or plain when flattenBold)
+//   4. strike:       ~~text~~       -> ~text~
+//   5. italic:       *text* / _text_ -> _text_
+//
+// Italic is last so `**` is consumed as bold, not two italics. Everything
+// unrecognized is emitted verbatim — Slack mrkdwn needs no escaping.
+function renderInline(text: string, options: InlineOptions = { flattenBold: false }): string {
+  const out: string[] = []
+  let i = 0
+  while (i < text.length) {
+    const ch = text[i]!
+
+    if (ch === '`') {
+      const close = text.indexOf('`', i + 1)
+      if (close !== -1) {
+        out.push(text.slice(i, close + 1))
+        i = close + 1
+        continue
+      }
+    }
+
+    if (ch === '[') {
+      const link = parseLink(text, i)
+      if (link !== null) {
+        out.push(`<${link.url}|${renderInline(link.label, options)}>`)
+        i = link.end
+        continue
+      }
+    }
+
+    if (ch === '*' && text[i + 1] === '*') {
+      const close = findClose(text, i + 2, '**')
+      if (close > i + 2) {
+        const inner = renderInline(text.slice(i + 2, close), options)
+        out.push(options.flattenBold ? inner : `*${inner}*`)
+        i = close + 2
+        continue
+      }
+    }
+
+    // `__bold__` only when not adjacent to a word char on either side, so a
+    // snake_case identifier the model wrote (`my__var__name`) is left alone.
+    if (ch === '_' && text[i + 1] === '_' && !isWordChar(text[i - 1])) {
+      const close = findClose(text, i + 2, '__')
+      if (close > i + 2 && !isWordChar(text[close + 2])) {
+        const inner = renderInline(text.slice(i + 2, close), options)
+        out.push(options.flattenBold ? inner : `*${inner}*`)
+        i = close + 2
+        continue
+      }
+    }
+
+    if (ch === '~' && text[i + 1] === '~') {
+      const close = findClose(text, i + 2, '~~')
+      if (close > i + 2) {
+        out.push(`~${renderInline(text.slice(i + 2, close), options)}~`)
+        i = close + 2
+        continue
+      }
+    }
+
+    // Italic: word-boundary guard on both sides so `a*b*c` and identifiers
+    // don't italicize. The guards are ASCII word chars by design — they
+    // gate on the model's Latin identifier/math usage; CJK/Korean text has
+    // no such tokens, so bold/italic markers around Korean still convert.
+    if (ch === '*' && !isWordChar(text[i - 1])) {
+      const close = findInlineClose(text, i + 1, '*')
+      if (close !== -1 && !isWordChar(text[close + 1])) {
+        const inner = text.slice(i + 1, close)
+        if (inner !== '' && !/^\s|\s$/.test(inner)) {
+          out.push(`_${renderInline(inner, options)}_`)
+          i = close + 1
+          continue
+        }
+      }
+    }
+    if (ch === '_' && !isWordChar(text[i - 1])) {
+      const close = findInlineClose(text, i + 1, '_')
+      if (close !== -1 && !isWordChar(text[close + 1])) {
+        const inner = text.slice(i + 1, close)
+        if (inner !== '' && !/^\s|\s$/.test(inner)) {
+          out.push(`_${renderInline(inner, options)}_`)
+          i = close + 1
+          continue
+        }
+      }
+    }
+
+    out.push(ch)
+    i++
+  }
+  return out.join('')
+}
+
+function findClose(text: string, from: number, marker: string): number {
+  let i = from
+  while (i <= text.length - marker.length) {
+    if (text.slice(i, i + marker.length) === marker) return i
+    i++
+  }
+  return -1
+}
+
+function findInlineClose(text: string, from: number, marker: string): number {
+  let i = from
+  while (i < text.length) {
+    if (text[i] === '\n') return -1
+    if (text[i] === marker) return i
+    i++
+  }
+  return -1
+}
+
+function parseLink(text: string, start: number): { label: string; url: string; end: number } | null {
+  let i = start + 1
+  const labelStart = i
+  while (i < text.length) {
+    const c = text[i]!
+    if (c === ']') break
+    if (c === '\n') return null
+    i++
+  }
+  if (text[i] !== ']' || text[i + 1] !== '(') return null
+  const label = text.slice(labelStart, i)
+  const urlStart = i + 2
+  let j = urlStart
+  while (j < text.length) {
+    const c = text[j]!
+    if (c === ')') break
+    if (c === '(' || c === '\n') return null
+    j++
+  }
+  if (text[j] !== ')') return null
+  return { label, url: text.slice(urlStart, j), end: j + 1 }
+}
+
+function isWordChar(ch: string | undefined): boolean {
+  if (ch === undefined) return false
+  return /[A-Za-z0-9_]/.test(ch)
+}


### PR DESCRIPTION
## Background

In the `slack-bot` adapter, a production message rendered its bold section headers as literal `**...**` instead of bold text. That message was a spreadsheet **file upload**, and the file path is the tell.

The agent emits GitHub-flavored Markdown (`**bold**`). Since c6ecf174, text-only replies wrap that GFM in Slack's `markdown` block, which Slack parses natively — verified on the wire (Slack stores it as `rich_text` + `table` blocks with real bold). That commit also deleted the old skill that told the agent to hand-translate `**`→`*`, on the premise that the block now handles it. But two outbound paths were never migrated to the block and still fed raw GFM into **mrkdwn-only** fields, where bold is a single `*`, so `**bold**` shows verbatim:

- **File captions** — `files.uploadV2`'s `initial_comment` has no `blocks` param and is parsed as mrkdwn. This is the reported bug.
- **Edits** — the SDK's `updateMessage(channel, ts, text)` only forwards `text` (raw GFM, mrkdwn-parsed).

So the divergence was a partial migration: the "let Slack parse GFM" upgrade was only wireable on the `chat.postMessage` block path, while the compensating skill was removed for everyone.

## Summary

Fix each broken path with the highest-fidelity option Slack actually supports, rather than one blanket converter:

- **Edits → native `chat.update` `markdown_text`.** Slack renders GFM itself (lossless: headings, tables, bold all survive), mirroring the post path's block. The pinned `@slack/web-api` doesn't type this field and the SDK's `updateMessage` doesn't forward it, so the callback now calls `chat.update` directly with the adapter token. `markdown_text` must not be combined with `text`/`blocks` (`markdown_text_conflict`), so we send it alone.
- **File captions → `toSlackMrkdwn()` converter.** `initial_comment` genuinely cannot carry a block, so this is the one place a converter is warranted. New `slack-format.ts` is a code-aware GFM→mrkdwn tokenizer (bold/italic/strike/links, headings→bold line, tables→plain rows, code spans/fences protected), modeled on the existing `telegram-bot-format.ts`.

**Why not one converter everywhere (post + edit + caption)?** It would needlessly discard Slack's native heading/table rendering on the paths that support blocks, and re-adopt the exact "translate everything" contract c6ecf174 retired because it was failing in production. The converter is confined to the single field that has no alternative.

**Why not post-text-then-upload-bare?** It changes message topology (two notifications, caption detaches from the file) and does nothing for edits.

## What this does NOT do

- Does not touch the text-only post path — it already renders correctly via the `markdown` block.
- Does not aim for full GFM→mrkdwn fidelity in the caption converter; headings and tables degrade (bold line / plain pipe rows) because mrkdwn has no equivalent.
- Does not change the raw-GFM notification `text` fallback on posts (separate concern).
- Does not add a `blocks`-carrying upload path — if a future `agent-messenger`/`@slack/web-api` bump forwards `blocks` through `files.uploadV2`, the caption converter can be dropped in favor of a block there too.

## Review notes

- Load-bearing: `slack-bot-edit.ts` now sends **only** `markdown_text` (no `text`/`blocks`) — combining them returns `markdown_text_conflict`. Error-code→result mapping is preserved from the old SDK path.
- The converter's word-boundary guards for italic (`a*b*c`, `snake_case`) are ASCII-only **by design** — they gate on the model's Latin identifier/math usage; CJK has no such tokens, so bold/italic around CJK text still converts. Tests assert a non-Latin (CJK) case per the repo's multi-language rule.
- `initial_comment` is not chunked (one upload = one caption); oversized captions are out of scope until observed.
- Full suite green (11669 pass, 0 fail); new `slack-format.test.ts` covers the tokenizer including a non-Latin bold-header case.
