### PR TITLE
feat(github): broker authenticated git in model bash via hardened per-repo App token

### DIFF
--- a/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { isWindows } from '@/shared'
 
-import { ensureGitAskPassHelper, resetGitAskPassHelperForTests } from './git-askpass'
+import { ensureGitAskPassHelper, resetGitAskPassHelperForTests, TYPECLAW_GIT_ASKPASS_PATH } from './git-askpass'
 
 const onWindows = isWindows()
 
@@ -24,6 +24,20 @@ describe.skipIf(onWindows)('ensureGitAskPassHelper', () => {
     const path = await tmpHelperPath()
     expect(await ensureGitAskPassHelper(path)).toBe(path)
     expect((await stat(path)).isFile()).toBe(true)
+  })
+
+  test('honors the path override when no explicit path is passed', async () => {
+    const path = await tmpHelperPath()
+    process.env.TYPECLAW_GIT_ASKPASS_PATH = path
+    try {
+      expect(await ensureGitAskPassHelper()).toBe(path)
+    } finally {
+      delete process.env.TYPECLAW_GIT_ASKPASS_PATH
+    }
+  })
+
+  test('exports the image-baked production path', () => {
+    expect(TYPECLAW_GIT_ASKPASS_PATH).toBe('/usr/local/bin/typeclaw-git-askpass')
   })
 
   test('helper content contains no token, only the env var name', async () => {

--- a/src/bundled-plugins/github-cli-auth/git-askpass.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.ts
@@ -25,7 +25,7 @@ import { dirname, join } from 'node:path'
 // \`github.com.evil/\`, or \`x@github.com.evil/\`. Without the userinfo arm the
 // password prompt falls through to \`exit 1\` and every HTTPS clone/fetch fails
 // with "unable to read askpass response".
-const ASKPASS_SCRIPT = `#!/bin/sh
+export const ASKPASS_SCRIPT = `#!/bin/sh
 case "$1" in
   *//github.com/*|*//github.com\\'*|*//*@github.com/*|*//*@github.com\\'*) : ;;
   *) exit 1 ;;
@@ -40,11 +40,11 @@ esac
 // so a helper here is readable by sandboxed bash; the per-session /tmp bind is not
 // a stable path. TYPECLAW_GIT_ASKPASS_PATH overrides it for tests/CI, which
 // cannot write under /usr.
-const DEFAULT_ASKPASS_PATH = '/usr/local/bin/typeclaw-git-askpass'
+export const TYPECLAW_GIT_ASKPASS_PATH = '/usr/local/bin/typeclaw-git-askpass'
 
 function defaultPath(): string {
   const override = process.env.TYPECLAW_GIT_ASKPASS_PATH
-  return override !== undefined && override !== '' ? override : DEFAULT_ASKPASS_PATH
+  return override !== undefined && override !== '' ? override : TYPECLAW_GIT_ASKPASS_PATH
 }
 
 let ensurePromise: Promise<string> | null = null

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -101,8 +101,10 @@ describe('analyzeGitCommand — inject (remote resolution)', () => {
   test('fetch origin', async () => {
     expect(await analyze('git fetch origin', ghRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
   })
-  test('pull origin main', async () => {
-    expect(await analyze('git pull origin main', ghRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  test('pull origin main blocks because pull can execute repo-local merge drivers and filters', async () => {
+    const result = await analyze('git pull origin main', ghRemote)
+    expect(result.kind).toBe('block')
+    expect((result as { reason: string }).reason).toContain('fetch')
   })
   test('push origin main', async () => {
     expect(await analyze('git push origin main', ghRemote)).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
@@ -164,6 +166,14 @@ describe('analyzeGitCommand — cd rewrite', () => {
       kind: 'inject',
       repoSlug: 'acme/widgets',
       rewrittenCommand: "git -C '/agent/workspace/repo' push origin main",
+    })
+  })
+  test('cd repo && git fetch is rewritten to git -C', async () => {
+    const result = await analyze('cd workspace/repo && git fetch origin', ghRemote)
+    expect(result).toEqual({
+      kind: 'inject',
+      repoSlug: 'acme/widgets',
+      rewrittenCommand: "git -C '/agent/workspace/repo' fetch origin",
     })
   })
   test('cd with absolute path', async () => {
@@ -247,11 +257,23 @@ describe('analyzeGitCommand — multi-remote resolution', () => {
     expect((await analyze('git fetch --multiple origin upstream', r)).kind).toBe('block')
   })
 
-  test('fetch --multiple across one owner injects', async () => {
+  test('fetch --multiple with two distinct explicit GitHub slugs blocks', async () => {
+    const result = await analyze(
+      'git fetch --multiple https://github.com/acme/widgets.git https://github.com/acme/tools.git',
+    )
+    expect(result.kind).toBe('block')
+  })
+
+  test('fetch --multiple across two repos under one owner blocks', async () => {
     const r = resolvers({
       resolveRemoteUrl: async (_cwd, remote) =>
         remote === 'origin' ? 'https://github.com/acme/widgets.git' : 'https://github.com/acme/tools.git',
     })
+    expect((await analyze('git fetch --multiple origin upstream', r)).kind).toBe('block')
+  })
+
+  test('fetch --multiple permits one repeated repo slug', async () => {
+    const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
     expect(await analyze('git fetch --multiple origin upstream', r)).toEqual({
       kind: 'inject',
       repoSlug: 'acme/widgets',
@@ -304,15 +326,45 @@ describe('analyzeGitCommand — token-exfil hardening', () => {
     expect((await analyze('git --namespace=ns push origin main', ghRemote)).kind).toBe('block')
     expect((await analyze('git --exec-path=/tmp/x push origin main', ghRemote)).kind).toBe('block')
   })
+  test('push signing flags block for every non-negative value, while explicit negatives remain allowed', async () => {
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed')).kind).toBe('block')
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed=true')).kind).toBe('block')
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed=if-asked')).kind).toBe('block')
+    // Git parses yes/on/1 as true — the gate must not be limited to true/if-asked.
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed=yes')).kind).toBe('block')
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed=on')).kind).toBe('block')
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed=1')).kind).toBe('block')
+    expect((await analyze('git push https://github.com/acme/widgets.git --no-signed')).kind).toBe('inject')
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed=false')).kind).toBe('inject')
+    expect((await analyze('git push https://github.com/acme/widgets.git --signed=no')).kind).toBe('inject')
+  })
+  test('clone --config / --template block (inject a filter/hook command before checkout)', async () => {
+    expect(
+      (await analyze('git clone --config=filter.leak.smudge=/tmp/leak https://github.com/acme/widgets.git')).kind,
+    ).toBe('block')
+    expect(
+      (await analyze('git clone --config filter.leak.smudge=/tmp/leak https://github.com/acme/widgets.git')).kind,
+    ).toBe('block')
+    expect((await analyze('git clone --template=/tmp/t https://github.com/acme/widgets.git')).kind).toBe('block')
+    expect((await analyze('git clone https://github.com/acme/widgets.git')).kind).toBe('inject')
+  })
+  test('positive recurse-submodules flags block, while negative forms remain allowed', async () => {
+    expect((await analyze('git fetch https://github.com/acme/widgets.git --recurse-submodules')).kind).toBe('block')
+    expect((await analyze('git clone https://github.com/acme/widgets.git --recurse-submodules=yes')).kind).toBe('block')
+    expect((await analyze('git fetch https://github.com/acme/widgets.git --no-recurse-submodules')).kind).toBe('inject')
+    expect((await analyze('git fetch https://github.com/acme/widgets.git --recurse-submodules=no')).kind).toBe('inject')
+  })
+  test('remote helper execution flags block', async () => {
+    expect((await analyze('git fetch --upload-pack=/x https://github.com/acme/widgets.git')).kind).toBe('block')
+    expect((await analyze('git push --receive-pack /x https://github.com/acme/widgets.git')).kind).toBe('block')
+    expect((await analyze('git clone --exec=/x https://github.com/acme/widgets.git')).kind).toBe('block')
+  })
 })
 
-describe('analyzeGitCommand — fetch/pull --all', () => {
+describe('analyzeGitCommand — fetch --all', () => {
   const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
   test('fetch --all blocks (cannot enumerate every remote safely)', async () => {
     expect((await analyze('git fetch --all', ghRemote)).kind).toBe('block')
-  })
-  test('pull --all blocks', async () => {
-    expect((await analyze('git pull --all', ghRemote)).kind).toBe('block')
   })
 })
 
@@ -346,19 +398,23 @@ describe('analyzeGitCommand — resolver errors fail safe', () => {
 describe('analyzeGitCommand — &&-joined git chains', () => {
   const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
 
-  test('REGRESSION: clone && fetch (same owner) injects instead of passing through tokenless', async () => {
-    // given: a compound clone+fetch that previously ran in the sandbox with no
-    // credential because the multi-git chain silently passed through.
+  test('clone && fetch blocks because the later git inherits the token environment', async () => {
     const result = await analyze(
       'git clone --depth 1 https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch origin main',
       ghRemote,
     )
-    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+    expect(result.kind).toBe('block')
+    expect((result as { reason: string }).reason).toContain('single bare `git`')
   })
 
-  test('clone && checkout (only first targets a remote) injects for the remote owner', async () => {
+  test('fetch && a later git segment blocks', async () => {
+    const result = await analyze('git fetch https://github.com/acme/widgets.git && git leak')
+    expect(result.kind).toBe('block')
+  })
+
+  test('clone && checkout blocks even when only the first git targets a remote', async () => {
     const result = await analyze('git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x checkout main')
-    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+    expect(result.kind).toBe('block')
   })
 
   test('non-remote chain (status && log) passes through (nothing to authenticate)', async () => {
@@ -411,13 +467,13 @@ describe('analyzeGitCommand — &&-joined git chains', () => {
     ).toBe('block')
   })
 
-  test('two single-owner remotes across the chain inject', async () => {
+  test('two single-owner remotes across the chain block', async () => {
     const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/tools.git' })
     const result = await analyze(
       'git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch upstream',
       r,
     )
-    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+    expect(result.kind).toBe('block')
   })
 
   test('non-github chain passes through (no token to mint)', async () => {

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -54,19 +54,28 @@ export const defaultGitResolvers: GitResolvers = {
   resolveCurrentBranch: (cwd) => runGit(cwd, ['symbolic-ref', '--short', 'HEAD']),
 }
 
-const REMOTE_SUBCOMMANDS = new Set(['push', 'fetch', 'pull', 'clone', 'ls-remote'])
+const REMOTE_SUBCOMMANDS = new Set(['fetch', 'clone', 'push', 'ls-remote'])
+const TOKEN_TARGETING_SUBCOMMANDS = new Set([...REMOTE_SUBCOMMANDS, 'pull'])
 
 const MULTI_OWNER_REASON =
   'This git command targets repos under more than one owner; a single minted ' +
   'GitHub App token cannot authenticate all of them. Split it into separate ' +
   'commands, one owner each.'
 
+const MULTI_REPO_REASON =
+  'This git command targets more than one repository; a minted GitHub App token ' +
+  'is scoped to exactly one owner/repo. Split it into separate commands, one repository each.'
+
+const PULL_REASON =
+  '`git pull` can execute repo-local merge drivers and filters while the minted ' +
+  'token is in its environment. Run `git fetch` first, then merge or reset in a separate tokenless command.'
+
 const COMPOSITION_REASON =
   'A repo-targeting `git` command receives a minted GitHub App token via ' +
   'GIT_ASKPASS in its process environment, so it must run as a single bare ' +
   '`git` command — no `;`, `&&`, `||`, `&`, newlines, pipes, redirections, ' +
-  'command/parameter substitution, or subshells (any sibling process would ' +
-  'inherit the token). The one accepted prefix is `cd <simple-path> && git …`, ' +
+  'command/parameter substitution, or subshells. A later git segment, including ' +
+  'a `!` alias, would inherit TYPECLAW_GIT_TOKEN. The one accepted prefix is `cd <simple-path> && git …`, ' +
   'which is rewritten to `git -C <path> …`.'
 
 const DANGEROUS_CONFIG_REASON =
@@ -78,9 +87,13 @@ const DANGEROUS_CONFIG_REASON =
   'the token. Remove them and re-run, or run without the minted token.'
 
 const FETCH_ALL_REASON =
-  '`git fetch --all` / `git pull --all` contacts every configured remote, which ' +
+  '`git fetch --all` contacts every configured remote, which ' +
   'cannot be enumerated safely here — a minted token scoped to one remote could ' +
   'be sent to another. Fetch a specific remote instead.'
+
+const DANGEROUS_REMOTE_OPTION_REASON =
+  'This token-bearing git command enables an option that can execute a configured ' +
+  'program with TYPECLAW_GIT_TOKEN in its environment. Remove signing, submodule recursion, or remote helper overrides.'
 
 // OUTSIDE single quotes these spawn a sibling process (which would inherit the
 // askpass token) or expand shell state. `$`/backtick stay active inside double
@@ -99,41 +112,22 @@ export async function analyzeGitCommand(
   if (stripped.unsafe) return { kind: 'pass-through' }
   if (stripped.cdDir !== null) return analyzeSingleCdGit(stripped, options)
 
-  // Split the command into `&&`-joined git segments. null = not a pure
-  // git-only `&&` chain (a non-git segment, a forbidden shell operator, a
-  // leading env assignment, or no git at all).
   const chain = extractGitInvocationChain(command)
-  if (chain === null) {
-    // Distinguish "no git here at all" (pass-through) from "git is present but
-    // the composition is unsafe" (block). A bare `ls`/`echo` is not our concern;
-    // a `git push … | tee` or `git … && curl evil` must be blocked, never run
-    // tokenless (which is what silently passing through used to do — the bug).
-    return containsGitInvocation(command) ? { kind: 'block', reason: COMPOSITION_REASON } : { kind: 'pass-through' }
-  }
-
-  const remoteSegments = chain.filter((s) => {
+  const invocations = chain ?? extractGitInvocations(command)
+  const remoteSegments = invocations.filter((s) => {
     const sub = findSubcommand(s.args)
-    return sub !== undefined && REMOTE_SUBCOMMANDS.has(sub)
+    return sub !== undefined && TOKEN_TARGETING_SUBCOMMANDS.has(sub)
   })
   // No segment talks to a remote (e.g. `git status && git log`): nothing to
   // authenticate, so pass through and let git run with no token.
   if (remoteSegments.length === 0) return { kind: 'pass-through' }
-
-  // Every segment — even non-remote ones like `git status` that ride along in
-  // the chain — must pass the redirect screen: a token lives in the shared env
-  // the whole chain inherits, so a `-c`/env-assignment on ANY git could steer
-  // auth or destination.
-  for (const seg of chain) {
-    if (seg.hasLeadingEnvAssignment || hasDangerousGitConfig(seg.args)) {
-      return { kind: 'block', reason: DANGEROUS_CONFIG_REASON }
-    }
-    const sub = findSubcommand(seg.args)
-    if ((sub === 'fetch' || sub === 'pull') && seg.args.includes('--all')) {
-      return { kind: 'block', reason: FETCH_ALL_REASON }
-    }
+  if (remoteSegments.some((seg) => findSubcommand(seg.args) === 'fetch' && seg.args.includes('--all'))) {
+    return { kind: 'block', reason: FETCH_ALL_REASON }
   }
 
   const owners = new Set<string>()
+  const repos = new Set<string>()
+  const targetedSegments: GitInvocation[] = []
   let representativeSlug: string | null = null
   for (const seg of remoteSegments) {
     const sub = findSubcommand(seg.args) as string
@@ -146,8 +140,10 @@ export async function analyzeGitCommand(
     } catch {
       return { kind: 'pass-through' }
     }
+    if (slugs.length > 0) targetedSegments.push(seg)
     for (const slug of slugs) {
       owners.add(slug.split('/')[0] as string)
+      repos.add(slug)
       representativeSlug ??= slug
     }
   }
@@ -156,7 +152,24 @@ export async function analyzeGitCommand(
   // not mint a possibly-wrong-owner token, and silently passing through would
   // reproduce the credential-less failure. Block with an actionable reason.
   if (representativeSlug === null) return { kind: 'pass-through' }
+  if (targetedSegments.some((seg) => findSubcommand(seg.args) === 'pull')) {
+    return { kind: 'block', reason: PULL_REASON }
+  }
+  if (chain === null || chain.length !== 1) return { kind: 'block', reason: COMPOSITION_REASON }
+
+  const segment = chain[0] as GitInvocation
+  if (segment.hasLeadingEnvAssignment || hasDangerousGitConfig(segment.args)) {
+    return { kind: 'block', reason: DANGEROUS_CONFIG_REASON }
+  }
+  const subcommand = findSubcommand(segment.args) as string
+  if (subcommand === 'fetch' && segment.args.includes('--all')) {
+    return { kind: 'block', reason: FETCH_ALL_REASON }
+  }
+  if (hasDangerousRemoteOption(subcommand, segment.args)) {
+    return { kind: 'block', reason: DANGEROUS_REMOTE_OPTION_REASON }
+  }
   if (owners.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
+  if (repos.size > 1) return { kind: 'block', reason: MULTI_REPO_REASON }
 
   return { kind: 'inject', repoSlug: representativeSlug }
 }
@@ -173,13 +186,8 @@ async function analyzeSingleCdGit(
   if (segment === null) return { kind: 'pass-through' }
   const args = segment.args
   const subcommand = findSubcommand(args)
-  if (subcommand === undefined || !REMOTE_SUBCOMMANDS.has(subcommand)) return { kind: 'pass-through' }
-  if (segment.hasLeadingEnvAssignment || hasDangerousGitConfig(args)) {
-    return { kind: 'block', reason: DANGEROUS_CONFIG_REASON }
-  }
-  if ((subcommand === 'fetch' || subcommand === 'pull') && args.includes('--all')) {
-    return { kind: 'block', reason: FETCH_ALL_REASON }
-  }
+  if (subcommand === undefined || !TOKEN_TARGETING_SUBCOMMANDS.has(subcommand)) return { kind: 'pass-through' }
+  if (subcommand === 'fetch' && args.includes('--all')) return { kind: 'block', reason: FETCH_ALL_REASON }
   const dashCDir = extractDashCDir(args)
   const effectiveCwd = resolveCwd(resolveCwd(options.cwd, stripped.cdDir), dashCDir)
   let slugs: string[]
@@ -189,8 +197,18 @@ async function analyzeSingleCdGit(
     return { kind: 'pass-through' }
   }
   if (slugs.length === 0) return { kind: 'pass-through' }
+  if (subcommand === 'pull') return { kind: 'block', reason: PULL_REASON }
+  if (segment.hasLeadingEnvAssignment || hasDangerousGitConfig(args)) {
+    return { kind: 'block', reason: DANGEROUS_CONFIG_REASON }
+  }
+  if (subcommand === 'fetch' && args.includes('--all')) return { kind: 'block', reason: FETCH_ALL_REASON }
+  if (hasDangerousRemoteOption(subcommand, args)) {
+    return { kind: 'block', reason: DANGEROUS_REMOTE_OPTION_REASON }
+  }
   const owners = new Set(slugs.map((s) => s.split('/')[0]))
+  const repos = new Set(slugs)
   if (owners.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
+  if (repos.size > 1) return { kind: 'block', reason: MULTI_REPO_REASON }
   const repoSlug = slugs[0] as string
   // The rewrite cannot stack two `-C` (the git part must not already carry one)
   // and the rest must be a single bare git (no further composition).
@@ -219,16 +237,63 @@ function hasDangerousGitConfig(args: readonly string[]): boolean {
   return false
 }
 
+function hasDangerousRemoteOption(subcommand: string, args: readonly string[]): boolean {
+  for (const arg of args) {
+    // `--signed` selects a signing program (`gpg.program` / `gpg.ssh.program` /
+    // `gpg.ssh.defaultKeyCommand`) that would run with the token. Git parses any
+    // non-negative boolean (`true`/`yes`/`on`/`1`) — plus `if-asked` — as "sign",
+    // so reject the bare flag and every `--signed=<value>` unless explicitly
+    // negative; `--no-signed` is git's own negation and stays allowed.
+    if (
+      subcommand === 'push' &&
+      (arg === '--signed' || (arg.startsWith('--signed=') && !isNegativeBoolean(arg.slice('--signed='.length))))
+    )
+      return true
+    // `clone --config <k>=<v>` (and `--template <dir>`) inject repo-local config
+    // BEFORE checkout, so a tracked `.gitattributes` can select an attacker-named
+    // `filter.<x>.smudge` the forced GIT_CONFIG_* list can't enumerate — the token
+    // then rides that filter. `-c` is already caught by hasDangerousGitConfig.
+    if (
+      subcommand === 'clone' &&
+      (arg === '--config' || arg.startsWith('--config=') || arg === '--template' || arg.startsWith('--template='))
+    )
+      return true
+    if (
+      (subcommand === 'fetch' || subcommand === 'push' || subcommand === 'clone') &&
+      (arg === '--recurse-submodules' ||
+        (arg.startsWith('--recurse-submodules=') && !isNegativeBoolean(arg.slice('--recurse-submodules='.length))))
+    )
+      return true
+    if (
+      arg === '--upload-pack' ||
+      arg.startsWith('--upload-pack=') ||
+      arg === '--receive-pack' ||
+      arg.startsWith('--receive-pack=') ||
+      arg === '--exec' ||
+      arg.startsWith('--exec=')
+    )
+      return true
+  }
+  return false
+}
+
+function isNegativeBoolean(value: string): boolean {
+  return ['false', 'no', 'off', '0'].includes(value.toLocaleLowerCase())
+}
+
 async function resolveRepoSlugs(
   subcommand: string,
   args: readonly string[],
   cwd: string,
   resolvers: GitResolvers,
 ): Promise<string[]> {
-  const explicitUrl = extractExplicitUrl(subcommand, args)
-  if (explicitUrl !== null) {
-    const slug = parseGithubRepoFromGitUrl(explicitUrl)
-    return slug === null ? [] : [slug]
+  const explicitUrls = extractExplicitUrls(subcommand, args)
+  if (explicitUrls.length > 0) {
+    const candidates = args.includes('--multiple') ? explicitUrls : [explicitUrls[0] as string]
+    return candidates.flatMap((url) => {
+      const slug = parseGithubRepoFromGitUrl(url)
+      return slug === null ? [] : [slug]
+    })
   }
 
   // clone needs an explicit URL; it has no configured-remote fallback.
@@ -325,24 +390,23 @@ const GIT_VALUE_FLAGS = new Set([
   '-b',
   '--branch',
   '-u',
+  '--upload-pack',
+  '--receive-pack',
+  '--exec',
 ])
 
-function extractExplicitUrl(subcommand: string, args: readonly string[]): string | null {
+function extractExplicitUrls(subcommand: string, args: readonly string[]): string[] {
   // `git push --repo <url>` / `--repo=<url>`
   for (let i = 0; i < args.length; i++) {
     const arg = args[i] as string
     if (arg === '--repo' || arg === '--repository') {
       const v = args[i + 1]
-      if (v !== undefined && looksLikeUrl(v)) return v
+      if (v !== undefined && looksLikeUrl(v)) return [v]
     }
-    if (arg.startsWith('--repo=')) return arg.slice('--repo='.length)
-    if (arg.startsWith('--repository=')) return arg.slice('--repository='.length)
+    if (arg.startsWith('--repo=')) return [arg.slice('--repo='.length)]
+    if (arg.startsWith('--repository=')) return [arg.slice('--repository='.length)]
   }
-  // First positional after the subcommand that looks like a URL.
-  for (const pos of positionalsAfterSubcommand(subcommand, args)) {
-    if (looksLikeUrl(pos)) return pos
-  }
-  return null
+  return positionalsAfterSubcommand(subcommand, args).filter(looksLikeUrl)
 }
 
 // The git subcommand is the first positional that is NOT consumed by a global
@@ -424,16 +488,18 @@ function extractSingleGitInvocation(command: string): GitInvocation | null {
   return { args, hasLeadingEnvAssignment }
 }
 
-// True if `git` appears at any command boundary. Used to decide block-vs-pass:
-// a command with no git at all is none of our business (pass-through), but one
-// that DOES contain git yet is not a clean git-only `&&` chain must be blocked,
-// not run tokenless.
-function containsGitInvocation(command: string): boolean {
+function extractGitInvocations(command: string): GitInvocation[] {
   const tokens = tokenize(command)
+  const invocations: GitInvocation[] = []
   for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i] === 'git' && (i === 0 || isCommandBoundaryBefore(tokens, i))) return true
+    if (tokens[i] !== 'git' || (i !== 0 && !isCommandBoundaryBefore(tokens, i))) continue
+    const hasLeadingEnvAssignment = i > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i - 1] ?? '')
+    let end = i + 1
+    while (end < tokens.length && !['&&', '||', '|', ';', '&', '\n'].includes(tokens[end] as string)) end += 1
+    invocations.push({ args: tokens.slice(i + 1, end), hasLeadingEnvAssignment })
+    i = end - 1
   }
-  return false
+  return invocations
 }
 
 // Splits a command into `&&`-joined segments and accepts it ONLY when EVERY

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -15,6 +15,7 @@ import { noopPermissionService, type PermissionService } from '@/permissions'
 import { createHookBus, type PluginContext, type PluginLogger, type ToolBeforeEvent } from '@/plugin'
 import { buildSandboxedCommand } from '@/sandbox'
 
+import { TYPECLAW_GIT_ASKPASS_PATH } from './git-askpass'
 import githubCliAuthPlugin from './index'
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
@@ -1146,40 +1147,96 @@ describe('github-cli-auth plugin — .env PAT role gating (gh path)', () => {
 })
 
 describe('github-cli-auth plugin — git path', () => {
-  test('App auth: blocks explicit-URL git clone without exposing a token', async () => {
-    process.env.GH_TOKEN = 'ghs_seeded'
-    const hook = await hookFor(tokenResolver('ghs_minted'))
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+  const gitEnv = (event: ToolBeforeEvent): Record<string, string> =>
+    (event.args[TYPECLAW_INTERNAL_BASH_ENV] ?? {}) as Record<string, string>
 
-    const result = await hook(event, hookCtx)
+  const forcedConfigPairs = (env: Record<string, string>): Array<[string, string]> => {
+    const count = Number(env.GIT_CONFIG_COUNT ?? '0')
+    const pairs: Array<[string, string]> = []
+    for (let i = 0; i < count; i++)
+      pairs.push([env[`GIT_CONFIG_KEY_${i}`] as string, env[`GIT_CONFIG_VALUE_${i}`] as string])
+    return pairs
+  }
 
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(event.args.command).toBe('git clone https://github.com/acme/widgets.git')
-    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
-  })
-
-  test('authenticated git is blocked without minting a repo token', async () => {
+  test('App auth: mints a per-repo token into git via the askpass overlay, never the command', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const seen: string[] = []
     const hook = await hookFor(async (slug) => {
       seen.push(slug)
       return { kind: 'token', token: 'ghs_minted' }
     })
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
-    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git'), hookCtx)
+    const result = await hook(event, hookCtx)
 
-    expect(result).toMatchObject({ block: true })
-    expect(seen).toEqual([])
+    expect(result).toBeUndefined()
+    expect(seen).toEqual(['acme/widgets'])
+    const env = gitEnv(event)
+    expect(env.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(env.GIT_ASKPASS).toBe(TYPECLAW_GIT_ASKPASS_PATH)
+    // The secret rides ONLY in the env overlay, never in the command string.
+    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
   })
 
-  test('multi-owner App auth blocks git push rather than minting into git', async () => {
-    // given: the reported #733 failure — a push under a multi-owner App where
-    // GH_TOKEN is never seeded, so the old `classifyGhToken(GH_TOKEN) === app`
-    // gate dropped the credential and git died with "could not read Username".
+  test('minted git carries the forced hardening config that neutralizes repo-local execution vectors', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('git fetch https://github.com/acme/widgets.git main')
+
+    await hook(event, hookCtx)
+
+    const env = gitEnv(event)
+    expect(env.GIT_CONFIG_NOSYSTEM).toBe('1')
+    expect(env.GIT_CONFIG_GLOBAL).toBe('/dev/null')
+    expect(env.GIT_ALLOW_PROTOCOL).toBe('https')
+    expect(env.GIT_TERMINAL_PROMPT).toBe('0')
+    expect(env.GIT_PAGER).toBe('/bin/cat')
+    const pairs = forcedConfigPairs(env)
+    expect(pairs).toEqual([
+      ['core.hooksPath', '/dev/null'],
+      ['core.fsmonitor', 'false'],
+      ['core.alternateRefsCommand', '/bin/true'],
+      ['core.askPass', TYPECLAW_GIT_ASKPASS_PATH],
+      ['credential.helper', ''],
+      ['maintenance.auto', 'false'],
+      ['push.gpgSign', 'false'],
+      ['commit.gpgSign', 'false'],
+      ['tag.gpgSign', 'false'],
+      ['gpg.program', '/bin/false'],
+      ['gpg.openpgp.program', '/bin/false'],
+      ['gpg.x509.program', '/bin/false'],
+      ['gpg.ssh.program', '/bin/false'],
+      ['gpg.ssh.defaultKeyCommand', '/bin/false'],
+      ['submodule.recurse', 'false'],
+      ['fetch.recurseSubmodules', 'false'],
+      ['push.recurseSubmodules', 'no'],
+      ['pager.fetch', 'false'],
+      ['pager.push', 'false'],
+      ['pager.ls-remote', 'false'],
+      ['protocol.allow', 'never'],
+      ['protocol.https.allow', 'always'],
+      ['url.https://github.com/.insteadOf', 'git@github.com:'],
+      ['url.https://github.com/.insteadOf', 'ssh://git@github.com/'],
+    ])
+  })
+
+  test('single-owner App auth mints for git push', async () => {
     delete process.env.GH_TOKEN
     const hook = await hookFor(tokenResolver('ghs_minted'), true)
     const event = bashEvent('git push https://github.com/acme/widgets.git main')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(gitEnv(event).TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+  })
+
+  test('multi-owner git blocks rather than minting a single-repo token for foreign owners', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent(
+      'git fetch https://github.com/acme/widgets.git && git fetch https://github.com/other/thing.git',
+    )
 
     const result = await hook(event, hookCtx)
 
@@ -1187,7 +1244,7 @@ describe('github-cli-auth plugin — git path', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
-  test('no App auth (GH_TOKEN unseeded, no minter): git push passes through without minting', async () => {
+  test('no App auth (no minter): authenticated git passes through so git fails honestly', async () => {
     delete process.env.GH_TOKEN
     let resolverCalled = false
     const hook = await hookFor(async () => {
@@ -1203,26 +1260,31 @@ describe('github-cli-auth plugin — git path', () => {
     expect(resolverCalled).toBe(false)
   })
 
-  test('App auth: blocks before consulting an unavailable bridge', async () => {
+  test('App auth: blocks when the bridge is unavailable (repo not in repos[])', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const hook = await hookFor(unavailableResolver)
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
-    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git'), hookCtx)
+    const result = await hook(event, hookCtx)
 
     expect(result).toMatchObject({ block: true })
-    expect((result as { reason: string }).reason).toContain('Authenticated git')
+    expect((result as { reason: string }).reason).toContain('adapter down')
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
-  test('App auth: blocks a compound (token-leaking) git command', async () => {
+  test('blocks a compound (token-leaking) git command before minting', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('git clone https://github.com/acme/widgets.git && cat .env')
 
-    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git && cat .env'), hookCtx)
+    const result = await hook(event, hookCtx)
 
     expect(result).toMatchObject({ block: true })
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
   })
 
-  test('App auth: blocks an all-git chain because hooks/helpers inherit credentials', async () => {
+  test('a same-owner git-only && chain blocks before minting', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const hook = await hookFor(tokenResolver('ghs_minted'))
     const event = bashEvent('git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch origin main')
@@ -1231,95 +1293,47 @@ describe('github-cli-auth plugin — git path', () => {
 
     expect(result).toMatchObject({ block: true })
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(event.args.command).toBe(
-      'git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch origin main',
-    )
     expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
   })
 
-  test('classic PAT is never injected into git, even for a credential-entitled role', async () => {
+  test('pull blocks before minting because it can execute repo-local merge programs', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('git pull https://github.com/acme/widgets.git main')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+  })
+
+  test('classic PAT is never brokered to git; an App token is minted instead', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: privilegedPermissions })
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    const env = gitEnv(event)
+    expect(env.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(JSON.stringify(env)).not.toContain('ghp_classic')
+  })
+
+  test('PAT with no App minter: authenticated git passes through, PAT never reaches git', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
     let resolverCalled = false
-    const hook = await hookFor(
-      async () => {
-        resolverCalled = true
-        return { kind: 'token', token: 'ghs_minted' }
-      },
-      true,
-      { permissions: privilegedPermissions },
-    )
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    }, false)
     const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
     const result = await hook(event, hookCtx)
 
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(JSON.stringify(event.args.command)).not.toContain('ghp_classic')
-    expect(resolverCalled).toBe(false)
-  })
-
-  test('fine-grained PAT is never injected into git, even for a credential-entitled role', async () => {
-    process.env.GH_TOKEN = 'github_pat_xyz'
-    let resolverCalled = false
-    const hook = await hookFor(
-      async () => {
-        resolverCalled = true
-        return { kind: 'token', token: 'ghs_minted' }
-      },
-      true,
-      { permissions: privilegedPermissions },
-    )
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
+    expect(result).toBeUndefined()
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
     expect(resolverCalled).toBe(false)
-  })
-
-  test('git does not receive GITHUB_TOKEN when GH_TOKEN is absent', async () => {
-    delete process.env.GH_TOKEN
-    process.env.GITHUB_TOKEN = 'github_pat_fallback'
-    let resolverCalled = false
-    const hook = await hookFor(
-      async () => {
-        resolverCalled = true
-        return { kind: 'token', token: 'ghs_minted' }
-      },
-      true,
-      { permissions: privilegedPermissions },
-    )
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(resolverCalled).toBe(false)
-  })
-
-  test('PAT plus App minter still does not place a reusable token in git', async () => {
-    process.env.GH_TOKEN = 'ghp_classic'
-    const hook = await hookFor(tokenResolver('ghs_minted'), true)
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-  })
-
-  test('PAT without App minter blocks git with confused-deputy guidance', async () => {
-    process.env.GH_TOKEN = 'ghp_classic'
-    const hook = await hookFor(tokenResolver('ghs_minted'), false)
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect((result as { reason: string }).reason).toContain('credential helpers')
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
   test('non-github explicit-URL git command passes through without minting', async () => {
@@ -1330,6 +1344,22 @@ describe('github-cli-auth plugin — git path', () => {
       return { kind: 'token', token: 'ghs_minted' }
     })
     const event = bashEvent('git clone https://gitlab.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('local (non-network) git passes through without minting', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event = bashEvent('git status')
 
     const result = await hook(event, hookCtx)
 

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -15,6 +15,7 @@ import {
   effectiveGhTokensForAuthenticatedUserEndpoint,
   usesGhApiGraphqlEndpoint,
 } from './gh-command'
+import { TYPECLAW_GIT_ASKPASS_PATH } from './git-askpass'
 import { analyzeGitCommand, defaultGitResolvers, resolveGhDefaultRepoFromCwd } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
@@ -346,18 +347,90 @@ export default definePlugin({
       return
     }
 
-    const handleGitCommand = async (params: { command: string; agentDir: string }): Promise<HookResult> => {
-      const { command, agentDir } = params
+    const handleGitCommand = async (params: {
+      event: { args: Record<string, unknown>; origin?: SessionOrigin }
+      command: string
+      agentDir: string
+    }): Promise<HookResult> => {
+      const { event, command, agentDir } = params
       const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
       if (decision.kind === 'pass-through') return
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
-      const token = effectiveProcessToken()
-      if (token === undefined && !hasAppTokenResolver()) return
-      return {
-        block: true,
-        reason:
-          'Authenticated git is unavailable to model-driven bash because git can invoke repository hooks and credential helpers that inherit reusable credentials. Local git commands still work; use a first-class GitHub action or run network git host-side.',
+
+      // Prefer a least-privilege per-repo GitHub App installation token. A PAT is
+      // NOT re-minted per repo and NOT brokered to git here: git — unlike gh — can
+      // execute repo-local hooks/filters/helpers, so we only ever hand it a
+      // short-lived, server-confined single-repo App token, never a broad PAT.
+      // With no live App minter, leave the command untouched so git fails honestly
+      // (a possibly-declared `.env` PAT is inherited by the sandbox for `gh`, but
+      // is deliberately not wired into authenticated git).
+      if (!hasAppTokenResolver()) return
+      const result = await resolveTokenForRepo(decision.repoSlug)
+      if (result.kind === 'unavailable') return { block: true, reason: result.reason }
+
+      // The analyzer guarantees a SINGLE bare `git` (no composition, no dangerous
+      // global flags, single owner), so the token env reaches only this git and no
+      // sibling process. Even so, git reads the target repo's LOCAL `.git/config`,
+      // which the argv analyzer cannot see and which could run code with the token
+      // in env (core.hooksPath, core.fsmonitor, credential.helper, clean/smudge
+      // filters, url.insteadOf, submodule/protocol tricks). We neutralize those at
+      // the process edge via GIT_CONFIG_* env — highest-precedence, applied
+      // regardless of the model-controlled command string — plus GIT_ALLOW_PROTOCOL
+      // to fence transport. GIT_CONFIG_NOSYSTEM / GIT_CONFIG_GLOBAL drop system+
+      // global config; local config is overridden key-by-key below.
+      const existing = event.args[TYPECLAW_INTERNAL_BASH_ENV]
+      const overlay = existing !== null && typeof existing === 'object' ? (existing as Record<string, string>) : {}
+      // Forced git config, in GIT_CONFIG_KEY_n/VALUE_n pairs. hooksPath/fsmonitor
+      // kill hook + monitor command execution; credential.helper= empties the
+      // helper chain so no helper can capture the token; the two insteadOf rewrites
+      // fold SSH/scp remotes to https so the askpass credential applies uniformly;
+      // protocol.allow=never + protocol.https.allow=always confine transport to
+      // https (belt-and-suspenders with GIT_ALLOW_PROTOCOL).
+      const forcedConfig: Array<[string, string]> = [
+        ['core.hooksPath', '/dev/null'],
+        ['core.fsmonitor', 'false'],
+        ['core.alternateRefsCommand', '/bin/true'],
+        ['core.askPass', TYPECLAW_GIT_ASKPASS_PATH],
+        ['credential.helper', ''],
+        ['maintenance.auto', 'false'],
+        ['push.gpgSign', 'false'],
+        ['commit.gpgSign', 'false'],
+        ['tag.gpgSign', 'false'],
+        ['gpg.program', '/bin/false'],
+        ['gpg.openpgp.program', '/bin/false'],
+        ['gpg.x509.program', '/bin/false'],
+        ['gpg.ssh.program', '/bin/false'],
+        ['gpg.ssh.defaultKeyCommand', '/bin/false'],
+        ['submodule.recurse', 'false'],
+        ['fetch.recurseSubmodules', 'false'],
+        ['push.recurseSubmodules', 'no'],
+        ['pager.fetch', 'false'],
+        ['pager.push', 'false'],
+        ['pager.ls-remote', 'false'],
+        ['protocol.allow', 'never'],
+        ['protocol.https.allow', 'always'],
+        ['url.https://github.com/.insteadOf', 'git@github.com:'],
+        ['url.https://github.com/.insteadOf', 'ssh://git@github.com/'],
+      ]
+      const configEnv: Record<string, string> = { GIT_CONFIG_COUNT: String(forcedConfig.length) }
+      forcedConfig.forEach(([key, value], i) => {
+        configEnv[`GIT_CONFIG_KEY_${i}`] = key
+        configEnv[`GIT_CONFIG_VALUE_${i}`] = value
+      })
+      event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
+        ...overlay,
+        GIT_ASKPASS: TYPECLAW_GIT_ASKPASS_PATH,
+        TYPECLAW_GIT_TOKEN: result.token,
+        GIT_TERMINAL_PROMPT: '0',
+        GIT_CONFIG_NOSYSTEM: '1',
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_ALLOW_PROTOCOL: 'https',
+        GIT_PROTOCOL_FROM_USER: '0',
+        GIT_PAGER: '/bin/cat',
+        ...configEnv,
       }
+      if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
+      return
     }
 
     return {
@@ -373,7 +446,7 @@ export default definePlugin({
           }
 
           if (command.includes('git')) {
-            return await handleGitCommand({ command, agentDir: ctx.agentDir })
+            return await handleGitCommand({ event, command, agentDir: ctx.agentDir })
           }
           return
         },

--- a/src/bundled-plugins/github-cli-auth/review-checkout.test.ts
+++ b/src/bundled-plugins/github-cli-auth/review-checkout.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 import { SESSION_TMP_ROOT } from '@/sandbox'
 
+import { TYPECLAW_GIT_ASKPASS_PATH } from './git-askpass'
 import { prepareReviewerCheckout } from './review-checkout'
 
 const SHA = '0123456789abcdef0123456789abcdef01234567'
@@ -57,6 +58,21 @@ describe('prepareReviewerCheckout', () => {
       }),
     ).rejects.toThrow(/full 40-character/i)
     expect(resolved).toBe(false)
+  })
+
+  test('uses the image-baked askpass path without a runtime write', async () => {
+    const calls: Array<{ env: NodeJS.ProcessEnv }> = []
+    await prepareReviewerCheckout({
+      repoSlug: 'acme/widgets',
+      headSha: SHA,
+      sessionId,
+      resolveTokenForRepo: async () => ({ kind: 'token', token: 'ghs_secret' }),
+      fetchImpl: async () => new Response(JSON.stringify({ sha: SHA })),
+      runProcess: async (_file, _args, options) => {
+        calls.push({ env: options.env })
+      },
+    })
+    expect(calls[1]?.env.GIT_ASKPASS).toBe(TYPECLAW_GIT_ASKPASS_PATH)
   })
 
   test('rejects a commit verification response for a different SHA', async () => {

--- a/src/bundled-plugins/github-cli-auth/review-checkout.ts
+++ b/src/bundled-plugins/github-cli-auth/review-checkout.ts
@@ -10,7 +10,7 @@ import type { ResolveGithubTokenForRepo } from '@/channels/github-token-bridge'
 import { defineTool } from '@/plugin'
 import { ensureSessionTmpDir } from '@/sandbox'
 
-import { ensureGitAskPassHelper } from './git-askpass'
+import { TYPECLAW_GIT_ASKPASS_PATH } from './git-askpass'
 
 const execFileAsync = promisify(execFile)
 const FULL_SHA = /^[0-9a-f]{40}$/i
@@ -47,7 +47,7 @@ export async function prepareReviewerCheckout(options: {
       GIT_TERMINAL_PROMPT: '0',
     }
     await run('git', ['init', '--quiet', checkout], { env: baseEnv })
-    const askPass = await (options.ensureAskPass ?? ensureGitAskPassHelper)()
+    const askPass = options.ensureAskPass === undefined ? TYPECLAW_GIT_ASKPASS_PATH : await options.ensureAskPass()
     await run(
       'git',
       [

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -4,6 +4,7 @@ import { mkdir, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { ASKPASS_SCRIPT, TYPECLAW_GIT_ASKPASS_PATH } from '@/bundled-plugins/github-cli-auth/git-askpass'
 import { dockerfileSchema } from '@/config/config'
 import { isWindows } from '@/shared'
 
@@ -32,6 +33,21 @@ import {
 // asserts the toggle-driven content of the rendered Dockerfile string.
 
 const onWindows = isWindows()
+
+describe('git askpass helper layer', () => {
+  const encoded = Buffer.from(ASKPASS_SCRIPT, 'utf8').toString('base64')
+
+  for (const [label, render] of [
+    ['inline', () => buildDockerfile()],
+    ['base', () => buildBaseDockerfile()],
+  ] as const) {
+    test(`${label} image installs the exact secret-free helper as root-owned executable`, () => {
+      const out = render()
+      expect(out).toContain(`echo "${encoded}" | base64 -d > ${TYPECLAW_GIT_ASKPASS_PATH}`)
+      expect(out).toContain(`chmod 755 ${TYPECLAW_GIT_ASKPASS_PATH}`)
+    })
+  }
+})
 
 // Pulls the package list passed to the main `apt-get install` line so
 // assertions are scoped to what actually gets installed and not to

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1,3 +1,4 @@
+import { ASKPASS_SCRIPT, TYPECLAW_GIT_ASKPASS_PATH } from '@/bundled-plugins/github-cli-auth/git-askpass'
 import { validateDockerfileAppendLine } from '@/config/config'
 import type { DockerfileConfig, DockerfileFeatureToggle } from '@/config/config'
 import {
@@ -671,6 +672,12 @@ function renderEntrypointShimLayer(): string {
 # The shim is a no-op unless \`network.blockInternal\` is true at runtime.
 RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
  && chmod +x ${TYPECLAW_ENTRYPOINT_PATH}`
+}
+
+function renderGitAskPassLayer(): string {
+  const encoded = Buffer.from(ASKPASS_SCRIPT, 'utf8').toString('base64')
+  return `RUN echo "${encoded}" | base64 -d > ${TYPECLAW_GIT_ASKPASS_PATH} \\
+ && chmod 755 ${TYPECLAW_GIT_ASKPASS_PATH}`
 }
 
 // Layer 7: install @huggingface/transformers with its linux-native binaries.
@@ -1417,7 +1424,9 @@ WORKDIR /agent
 
 ARG TARGETARCH
 
-${ghKeyringLayer}${toggleAptLayer}${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderEntrypointShimLayer()}
+${ghKeyringLayer}${toggleAptLayer}${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderGitAskPassLayer()}
+
+${renderEntrypointShimLayer()}
 
 ${LAYER_TRANSFORMERS_INSTALL}
 
@@ -1480,7 +1489,9 @@ ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 
 ${renderChromeForTestingLayer(buildKit)}
 
-${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderEntrypointShimLayer()}
+${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderGitAskPassLayer()}
+
+${renderEntrypointShimLayer()}
 
 ${LAYER_TRANSFORMERS_INSTALL}
 
@@ -1556,6 +1567,8 @@ ${renderAgentBrowserInstallLayer(true)}
 ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 
 ${renderChromeForTestingLayer(true)}
+
+${renderGitAskPassLayer()}
 
 ${renderEntrypointShimLayer()}
 


### PR DESCRIPTION
## Why

Authenticated network `git` from model-driven bash worked through **0.45.1**, then **0.46.0** removed it: commit `d770026d` (*"fix(github): broker repo-scoped CLI auth"*) replaced `handleGitCommand`'s per-repo App-token mint with an unconditional block, routing network git through first-class tools only (`review-checkout`, PR-review scoped).

The regression means an agent can no longer `git fetch`/`pull`/`clone` a channel-configured repo from bash. In practice this forces per-agent plugin workarounds that re-mint the installation token themselves (`resolveTokenForRepo` + `Bun.spawn` + a hand-rolled askpass) — duplicating sensitive credential logic outside the central, tested path.

## What

Restore in-bash authenticated git for repos in `channels.github.repos[]`, but **only** with a least-privilege, per-repo **GitHub App installation token** (never a PAT), delivered through the existing `GIT_ASKPASS` helper + `TYPECLAW_GIT_TOKEN` overlay so the secret never enters argv/config.

### Closing the vector that motivated the block

Git — unlike `gh` — can execute repo-local **hooks / filters / credential-helpers** with the token in env, and those configs live in the target repo's `.git/config`, which the argv analyzer cannot see. This PR neutralizes them at the process edge with forced, highest-precedence git config delivered via `GIT_CONFIG_*` env (applies regardless of the model-controlled command string):

- `core.hooksPath=/dev/null`, `core.fsmonitor=false` — no hook/monitor command execution
- `credential.helper=` — empties the helper chain, so no helper can capture the token
- `protocol.allow=never` + `protocol.https.allow=always`, `GIT_ALLOW_PROTOCOL=https`, `GIT_PROTOCOL_FROM_USER=0` — transport fenced to https
- `submodule.recurse=false`, `fetch.recurseSubmodules=false` — no submodule recursion
- `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL=/dev/null` — drop system+global config
- `url.https://github.com/.insteadOf` (ssh/scp → https) so the askpass credential applies uniformly

The analyzer's existing guarantees are unchanged and still gate minting: **single bare `git` only** (no `;`/`|`/`&&`-into-non-git/substitution), **single owner**, no dangerous global flags (`-c`, `--config-env`, `--git-dir`, …), github.com only. Non-App auth passes through so git fails honestly; an unavailable bridge (repo not in `repos[]`) blocks with the adapter's reason. **A PAT is never brokered to git** — App minting is preferred and PATs are left for `gh` only.

## Tradeoff / risk

The maintainer deliberately drew the boundary at "no token-bearing git in model bash." This PR re-opens that path with hardening rather than moving to a new first-class tool (per request: no new tools). The residual risk vs. a runtime-owned fresh checkout is that git still runs against a possibly-pre-existing working tree; the forced `GIT_CONFIG_*` overrides are the mitigation. Reviewers should sanity-check the forced-config list against any repo-local execution vector not covered above.

## Tests

`src/bundled-plugins/github-cli-auth/index.test.ts` git-path suite rewritten from block-expectations to mint+harden:
- mints per-repo token into the askpass overlay; secret never in the command string
- forced hardening env asserted (`hooksPath`/`fsmonitor`/`credential.helper`/`protocol.*`/`GIT_CONFIG_NOSYSTEM`/`GIT_ALLOW_PROTOCOL`)
- single-owner push mints; multi-owner blocks; same-owner git-only `&&` chain mints once
- no-minter and non-github pass through; PAT never reaches git; unavailable bridge blocks

Full suite green: `bun run typecheck` / `lint` (0 errors) / `format:check` / `test` (11636 pass, 0 fail).