### PR TITLE
fix(test): make pinned-budget growth test deterministic on Windows CI

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1956,42 +1956,61 @@ describe('wrapSystemTool', () => {
 
   test('charges streamed file growth against the process-wide byte budget', async () => {
     const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-growing-snapshot-budget-'))
-    const firstFile = path.join(agentDir, 'first.bin')
+    const holderFile = path.join(agentDir, 'holder.bin')
     const growingFile = path.join(agentDir, 'growing.bin')
-    const secondFile = path.join(agentDir, 'second.bin')
-    await Promise.all([writeFile(firstFile, ''), writeFile(growingFile, ''), writeFile(secondFile, '')])
-    await Promise.all([
-      truncate(firstFile, 41 * 1024 * 1024),
-      truncate(growingFile, 60 * 1024 * 1024),
-      truncate(secondFile, 38 * 1024 * 1024),
-    ])
-    let first: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
-    let second: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
+    await Promise.all([writeFile(holderFile, ''), writeFile(growingFile, '')])
+    await Promise.all([truncate(holderFile, 40 * 1024 * 1024), truncate(growingFile, 60 * 1024 * 1024)])
+
+    let acquiredResolve!: () => void
+    const acquired = new Promise<void>((resolve) => {
+      acquiredResolve = resolve
+    })
+    let streamResolve!: () => void
+    const allowStreaming = new Promise<void>((resolve) => {
+      streamResolve = resolve
+    })
+
+    type GrowingOutcome =
+      | { ok: true; pinned: Awaited<ReturnType<typeof enforceAndPinToolFiles>> }
+      | { ok: false; error: unknown }
+    let holder: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
     let unexpected: Awaited<ReturnType<typeof enforceAndPinToolFiles>> | undefined
     try {
-      first = await enforceAndPinToolFiles({
+      // 40MiB holder stays leased for the whole test, so any stream past the
+      // growing file's declared 60MiB pushes the global total over 100MiB.
+      holder = await enforceAndPinToolFiles({
         tool: 'channel_send',
-        args: { attachments: [{ path: firstFile }] },
+        args: { attachments: [{ path: holderFile }] },
         agentDir,
       })
-      const growing = enforceAndPinToolFiles({ tool: 'read', args: { path: growingFile }, agentDir }).then((value) => {
-        unexpected = value
-        return value
-      })
-      const queuedSecond = enforceAndPinToolFiles({
-        tool: 'channel_send',
-        args: { attachments: [{ path: secondFile }] },
-        agentDir,
-      })
-      await Bun.sleep(10)
-      await truncate(growingFile, 64 * 1024 * 1024)
-      await first.cleanup()
-      first = undefined
-      second = await queuedSecond
-      await expect(growing).rejects.toThrow(/process-wide pinned byte budget|snapshot growth/i)
+      const outcome = enforceAndPinToolFiles(
+        { tool: 'read', args: { path: growingFile }, agentDir },
+        {
+          async afterBudgetAcquire() {
+            acquiredResolve()
+            await allowStreaming
+          },
+        },
+      ).then<GrowingOutcome, GrowingOutcome>(
+        (pinned) => {
+          unexpected = pinned
+          return { ok: true, pinned }
+        },
+        (error: unknown) => ({ ok: false, error }),
+      )
+
+      await acquired
+      await truncate(growingFile, 61 * 1024 * 1024)
+      streamResolve()
+      const result = await outcome
+      expect(result.ok).toBeFalse()
+      if (!result.ok) {
+        expect(result.error).toBeInstanceOf(Error)
+        expect((result.error as Error).message).toMatch(/process-wide pinned byte budget|snapshot growth/i)
+      }
     } finally {
-      await first?.cleanup()
-      await second?.cleanup()
+      streamResolve()
+      await holder?.cleanup()
       await unexpected?.cleanup()
       await rm(agentDir, { recursive: true, force: true })
     }

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -56,16 +56,26 @@ export type PinnedToolFiles = {
   cleanup(): Promise<void>
 }
 
-export async function enforceAndPinToolFiles(options: {
-  tool: string
-  args: Record<string, unknown>
-  agentDir: string
-  tempRoot?: string
-  genericInputs?: boolean
-  fileOperands?: ToolFileOperands
-  hidden?: HiddenPaths
-  signal?: AbortSignal
-}): Promise<PinnedToolFiles> {
+// Test-only seam: pauses between budget acquisition and source open/stream so a
+// test can grow a file post-authorization deterministically, without racing the
+// scheduler. Production never passes hooks.
+export type EnforceAndPinToolFilesHooks = {
+  afterBudgetAcquire?(): void | Promise<void>
+}
+
+export async function enforceAndPinToolFiles(
+  options: {
+    tool: string
+    args: Record<string, unknown>
+    agentDir: string
+    tempRoot?: string
+    genericInputs?: boolean
+    fileOperands?: ToolFileOperands
+    hidden?: HiddenPaths
+    signal?: AbortSignal
+  },
+  hooks: EnforceAndPinToolFilesHooks = {},
+): Promise<PinnedToolFiles> {
   if (options.signal?.aborted === true) throw abortError(options.signal)
   const maxCount = maxInputCount(options.tool)
   const targets = fileTargets(
@@ -111,6 +121,7 @@ export async function enforceAndPinToolFiles(options: {
     }
 
     lease = await pinnedSnapshotBudget.acquire(declaredBytes, verified.length, options.signal)
+    await hooks.afterBudgetAcquire?.()
 
     dir = await mkdtemp(path.join(options.tempRoot ?? tmpdir(), TOOL_INPUT_TEMP_PREFIX))
     let copiedBytes = 0


### PR DESCRIPTION
## Background

The `charges streamed file growth against the process-wide byte budget` test in `plugin-tools.test.ts` failed intermittently on Windows CI (observed on [run 29758637449](https://github.com/typeclaw/typeclaw/actions/runs/29758637449), "windows checks" job, surfacing at `tool-file-safety.ts:676` in `processBudgetGrowthExceeded`).

The test verifies that a file which grows after authorization (between stat and streaming) is caught by the per-chunk `lease.resize()` check against the process-wide 100MiB pinned-snapshot byte budget. The old setup used three files (41MiB + 60MiB + 38MiB) and relied on `Bun.sleep(10)` plus a FIFO queue-admission assumption to arrange a specific interleaving of two concurrent snapshot leases competing for the shared module-level budget singleton. Under parallel CI (`bun test --parallel`), Windows scheduling/fs timing differed enough that the growing `read` could stream past its declared size before the competing lease was admitted — `lease.resize()` stayed under the global cap, the request resolved instead of rejecting, and `expect(growing).rejects...` failed. `Bun.sleep(10)` was a non-deterministic synchronization assumption, not a real guarantee.

## Summary

Add a minimal test-only synchronization seam to `enforceAndPinToolFiles`: an optional second `hooks: EnforceAndPinToolFilesHooks` parameter with `afterBudgetAcquire?()`, invoked right after `pinnedSnapshotBudget.acquire()` and before the source is opened/streamed. Production callers never pass hooks, so the default `{}` keeps runtime behavior unchanged.

Rewrote the test around that seam to remove all timing dependence:

- A single stable 40MiB holder lease stays leased for the whole test.
- The growing file is declared at 60MiB (40 + 60 = 100MiB, exactly at the cap), then the hook pauses it and the file is grown on disk to 61MiB before resuming.
- With the 40MiB holder still leased, streaming past the growing file's declared 60MiB is the only way to push the global total over 100MiB — deterministic on every platform, no scheduler race.
- 61MiB stays under `read`'s 64MiB per-file limit, so `inputTooLarge` can't mask the growth path, and it's a single-operand read, so the aggregate-input check can't mask `lease.resize()`.
- The outcome is captured synchronously (both fulfill/reject branches handled at promise creation) to avoid a floating unhandled rejection or assert-ordering deadlock.

This keeps it a genuine behavior test of the after-authorization growth-rejection path (`lease.resize()` returning `false` leads to `processBudgetGrowthExceeded`), just without the scheduler race.

## What this does NOT do

- Does not change production behavior — `hooks` defaults to `{}` and no production caller passes it.
- Does not touch the pinned-snapshot budget mechanism itself (`lease.resize()`, the 100MiB cap, or the acquisition/release lifecycle).
- Does not add any new production dependency on test hooks outside this one seam.

## Review notes

- Load-bearing change: `afterBudgetAcquire` fires strictly between `pinnedSnapshotBudget.acquire()` and `mkdtemp`/`openInput`. Invariant to verify: every production call site of `enforceAndPinToolFiles` still passes only one argument.
- Verified locally: `bun run typecheck`, `bun run lint` (0 errors; 67 pre-existing warnings, none in changed files), `bun run format:check`, and `bun run test` (11639 pass, 0 fail). Ran the specific test 5x in parallel mode — 5/5 pass (previously intermittent).