### PR TITLE
Re-scan Git secret history each call so a purge lifts the block

### DIFF
--- a/src/git/secret-history.test.ts
+++ b/src/git/secret-history.test.ts
@@ -1,20 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 import { appendFile, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { delimiter, dirname, isAbsolute, join } from 'node:path'
 
 import { isWindows } from '@/shared'
 
-import {
-  GitSecretHistoryError,
-  assertNoCanonicalSecretsInGit,
-  resetGitSecretHistoryCacheForTests,
-  scanCanonicalSecretsInGit,
-} from './secret-history'
+import { GitSecretHistoryError, assertNoCanonicalSecretsInGit, scanCanonicalSecretsInGit } from './secret-history'
 
 let roots: string[] = []
 
-beforeEach(() => resetGitSecretHistoryCacheForTests())
 afterEach(async () => {
   await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })))
   roots = []
@@ -579,14 +573,30 @@ describe('canonical Git secret history guard', () => {
     await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
   })
 
-  test('caches contamination fail-closed for the process lifetime', async () => {
+  test('lifts the block on the next call once the operator purges the contaminated history', async () => {
+    // The guard runs before every bash call and must re-scan the live repo, not latch a verdict: a
+    // cached failure trapped bash until process restart even after the prescribed purge, and the
+    // remediation itself runs through the blocked bash. A real purge rewinds past the secret commit
+    // then expires reflogs and prunes, so the offending objects are unreachable AND deleted — the
+    // full path a ref/index-only cache signature would miss.
     const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
     await commitFile(repo, 'secrets.json', '{"token":"example-placeholder"}')
-    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow()
-    await git(repo, 'rm', 'secrets.json')
-    await git(repo, 'commit', '-m', 'remove example credential')
+    await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
+
+    await git(repo, 'reset', '--hard', 'HEAD^')
     await git(repo, 'reflog', 'expire', '--expire=now', '--all')
     await git(repo, 'gc', '--prune=now')
+
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+  })
+
+  test('re-detects contamination introduced after an earlier clean scan', async () => {
+    const repo = await makeRepo()
+    await commitFile(repo, 'README.md', 'safe')
+    await expect(assertNoCanonicalSecretsInGit(repo)).resolves.toBeUndefined()
+
+    await commitFile(repo, 'auth.json', '{"credential":"placeholder"}')
 
     await expect(assertNoCanonicalSecretsInGit(repo)).rejects.toThrow(GitSecretHistoryError)
   })

--- a/src/git/secret-history.ts
+++ b/src/git/secret-history.ts
@@ -9,15 +9,13 @@ import { resolveAgentGit } from './resolve-agent-git'
 
 type ScanResult = { ok: true } | { ok: false; paths: string[] }
 
-const contaminatedCache = new Map<string, string[]>()
-
 export class GitSecretHistoryError extends Error {
   constructor(paths: readonly string[]) {
     super(
       [
         `Model-driven Git/bash is disabled because Git metadata is contaminated or can conceal objects: ${paths.join(', ')}.`,
         'Assume credentials in the repository were exposed and rotate them first. Purge canonical secret paths and every refs/replace entry, expire all reflogs, and run Git garbage collection to remove unreachable objects before retrying.',
-        'Suggested operator sequence: rewrite/purge the affected history and replacement refs, run `git reflog expire --expire=now --all`, then `git gc --prune=now`, and restart TypeClaw before retrying.',
+        'Suggested operator sequence: rewrite/purge the affected history and replacement refs, run `git reflog expire --expire=now --all`, then `git gc --prune=now`; the next bash call re-scans and lifts the block automatically once the repository is clean.',
         'TypeClaw inspects path names and object reachability without reading blob contents. Reachable, reflog-referenced, and unreachable commits are path-attributable via their root tree and block only when a canonical secret path is present; standalone dangling trees and blobs are not path-attributable and are ignored; a live ref, worktree HEAD, or pseudoref (including FETCH_HEAD) pointing at a non-commit still fails closed.',
       ].join(' '),
     )
@@ -25,15 +23,13 @@ export class GitSecretHistoryError extends Error {
   }
 }
 
+// Never cache the verdict. A cached failure trapped bash until process restart even after the
+// operator purged the history the error prescribes purging; a cached success would silently bypass
+// the guard after a new secret appears. The clean path is uncached either way, so re-scanning every
+// call costs nothing on success and correctly re-checks the repo while blocked.
 export async function assertNoCanonicalSecretsInGit(agentDir: string): Promise<void> {
-  const contaminated = contaminatedCache.get(agentDir)
-  if (contaminated !== undefined) throw new GitSecretHistoryError(contaminated)
-
   const scan = await scanCanonicalSecretsInGit(agentDir)
-  if (!scan.ok) {
-    contaminatedCache.set(agentDir, scan.paths)
-    throw new GitSecretHistoryError(scan.paths)
-  }
+  if (!scan.ok) throw new GitSecretHistoryError(scan.paths)
 }
 
 export async function scanCanonicalSecretsInGit(agentDir: string): Promise<ScanResult> {
@@ -354,10 +350,6 @@ function decodeGitPath(raw: string): string {
     bytes.push(...encoder.encode(next))
   }
   return new TextDecoder().decode(Uint8Array.from(bytes))
-}
-
-export function resetGitSecretHistoryCacheForTests(): void {
-  contaminatedCache.clear()
 }
 
 function matchingCanonicalPaths(paths: readonly string[]): string[] {


### PR DESCRIPTION
## Problem

`assertNoCanonicalSecretsInGit` (`src/git/secret-history.ts`) runs at the top of `applyBashSandbox` before **every** model-driven bash call. On a contamination hit it cached the blocked verdict per `agentDir` in a process-lifetime `Map`:

```ts
const contaminated = contaminatedCache.get(agentDir)
if (contaminated !== undefined) throw new GitSecretHistoryError(contaminated) // forever
...
contaminatedCache.set(agentDir, scan.paths)
```

So once a canonical secret (`secrets.json` / `auth.json` / a canonical secret dir) was found reachable in history, **every later bash call threw the cached error until the container restarted** — even after the operator ran the exact purge the error prescribes (`git rm`, `git reflog expire`, `git gc --prune=now`). Worse, that remediation itself runs through the now-blocked bash, so the agent could not self-recover: a permanent trap until a manual host teardown.

This is the `contaminatedCache`, not the `.env`-in-history trigger that #1256 fixed — #1256 changed *what* trips the scan; this changes the *latch-until-restart* behavior, which #1256 left in place (its own body even describes the symptom: "a permanent trap until a manual host teardown").

## Fix

Remove the cache; re-scan the live repository on every call.

- The cache **only ever stored the blocked verdict** — a clean repo always paid the full scan — so this adds **no overhead to the healthy path**. It only re-scans while already blocked, which is exactly when a just-completed purge must be observed.
- A cached **success** is deliberately **not** introduced. A stale `ok` after a new secret appears would silently **bypass** the guard, and no cheap git-state signature can detect `gc --prune`d unreachable objects without approaching the scan's own cost (unreachable-object pruning changes the scan result while ref/index tips stay identical).

## What still blocks (unchanged)

Every existing detection path is untouched — reachable/reflog/unreachable-commit attribution, `refs/replace`, non-commit pseudorefs, per-worktree indexes. The only behavior change is that the block is now **re-evaluated per call** instead of latched for the process.

## Changes

- Drop `contaminatedCache` and the test-only `resetGitSecretHistoryCacheForTests`.
- Reword the remediation message: the block lifts automatically on the next bash call once the repo is clean — no restart required.
- Replace the `caches contamination fail-closed for the process lifetime` test (which asserted the bug) with two behavioral tests:
  - the block lifts after a real purge (`reset --hard` + `reflog expire` + `gc --prune=now`), and
  - a secret introduced after an earlier clean scan is still detected.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅ (0 errors)
- `bun run format:check` ✅
- `bun run test` ✅ (11640 pass, 0 fail)
