### PR TITLE
feat(github): broker authenticated git for channel repos in model bash

### DIFF
--- a/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, readFile, stat } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -91,6 +91,19 @@ describe.skipIf(onWindows)('ensureGitAskPassHelper', () => {
     expect(await ensureGitAskPassHelper(pathB)).toBe(pathB)
     expect((await stat(pathA)).isFile()).toBe(true)
     expect((await stat(pathB)).isFile()).toBe(true)
+  })
+
+  test('a pre-existing executable helper in a read-only dir is returned without a write (no EACCES)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-askpass-baked-'))
+    const path = join(dir, 'typeclaw-git-askpass')
+    await writeFile(path, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    await chmod(dir, 0o555) // read-only dir: any temp-write+rename would EACCES
+    try {
+      resetGitAskPassHelperForTests()
+      expect(await ensureGitAskPassHelper(path)).toBe(path)
+    } finally {
+      await chmod(dir, 0o755)
+    }
   })
 })
 

--- a/src/bundled-plugins/github-cli-auth/git-askpass.ts
+++ b/src/bundled-plugins/github-cli-auth/git-askpass.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto'
-import { chmod, mkdir, mkdtemp, rename, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { access, chmod, mkdir, mkdtemp, rename, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 // A GIT_ASKPASS helper git invokes for username/password prompts. The token
@@ -25,7 +26,7 @@ import { dirname, join } from 'node:path'
 // \`github.com.evil/\`, or \`x@github.com.evil/\`. Without the userinfo arm the
 // password prompt falls through to \`exit 1\` and every HTTPS clone/fetch fails
 // with "unable to read askpass response".
-const ASKPASS_SCRIPT = `#!/bin/sh
+export const ASKPASS_SCRIPT = `#!/bin/sh
 case "$1" in
   *//github.com/*|*//github.com\\'*|*//*@github.com/*|*//*@github.com\\'*) : ;;
   *) exit 1 ;;
@@ -36,26 +37,27 @@ case "$1" in
 esac
 `
 
-// The consumers that call this today (reviewer checkout, backup push) run git via
-// Node `execFile`, NOT sandboxed bash, so the helper only needs to be runtime
-// writable+readable — it does NOT need to sit under a sandbox-visible mount. The
-// old default `/usr/local/bin` assumed a root-writable /usr and EACCES'd whenever
-// the runtime ran as a non-root user, breaking the checkout with an opaque
-// permission-denied.
-//
+// The sandboxed-bash consumer (the github-cli-auth broker's authenticated git)
+// runs INSIDE the per-tool bwrap sandbox, which `--ro-bind`s /usr but masks /tmp
+// with a tmpfs (src/sandbox/build.ts). So its helper must live under /usr, baked
+// into the image at build time (dockerfile.ts) — the read-only /usr is why
+// ensureGitAskPassHelper early-returns when the file already exists rather than
+// rewriting it. TYPECLAW_GIT_ASKPASS_PATH overrides it for tests/CI.
+export const TYPECLAW_GIT_ASKPASS_PATH = '/usr/local/bin/typeclaw-git-askpass'
+
 // The base is the FIXED real `/tmp`, NOT `os.tmpdir()`: os.tmpdir() honors
-// TMPDIR/TMP/TEMP, so an env pointing it at a model-writable location (e.g. a
-// workspace path) would let a sandboxed tool replace the cached helper before a
-// later reviewer checkout / backup push executes it UNSANDBOXED with
-// TYPECLAW_GIT_TOKEN in env. bwrap binds a fresh tmpfs over `/tmp` per session
-// (see SESSION_TMP_ROOT), so the runtime's real `/tmp/typeclaw-git-askpass-*` is
-// NOT visible to model bash and cannot be pre-planted. A random `mkdtemp` subdir
-// (mode 0700) keeps the name unpredictable. TYPECLAW_GIT_ASKPASS_PATH remains the
-// trusted operator/CI/sandbox-consumer override, used verbatim with NO fallback
-// so an unusable configured path surfaces loudly.
+// TMPDIR/TMP/TEMP, so an env pointing it at a model-writable location would let a
+// sandboxed tool replace the cached helper before a later UNSANDBOXED reviewer
+// checkout / backup push executes it with TYPECLAW_GIT_TOKEN in env. A random
+// `mkdtemp` subdir (mode 0700) keeps the name unpredictable.
 const ASKPASS_DIR_BASE = '/tmp/typeclaw-git-askpass-'
 
 let defaultDirPromise: Promise<string> | null = null
+
+function configuredPath(): string | undefined {
+  const path = process.env.TYPECLAW_GIT_ASKPASS_PATH
+  return path !== undefined && path !== '' ? path : undefined
+}
 
 function resolveDefaultDir(): Promise<string> {
   if (defaultDirPromise === null) defaultDirPromise = mkdtemp(ASKPASS_DIR_BASE)
@@ -65,15 +67,23 @@ function resolveDefaultDir(): Promise<string> {
   })
 }
 
+// The path the SANDBOXED-bash consumer must use: the baked, sandbox-visible /usr
+// helper (or the test/CI override). Unlike the unsandboxed default, this never
+// falls back to /tmp, which the sandbox's tmpfs would hide from model bash.
+export function resolveSandboxGitAskPassPath(): string {
+  return configuredPath() ?? TYPECLAW_GIT_ASKPASS_PATH
+}
+
+// The path UNSANDBOXED execFile consumers (reviewer checkout, backup push) use:
+// a runtime-writable, unpredictable real-/tmp path. They don't run under bwrap, so
+// /tmp masking doesn't apply, and a non-root runtime can write here.
 async function defaultPath(): Promise<string> {
-  const override = process.env.TYPECLAW_GIT_ASKPASS_PATH
-  if (override !== undefined && override !== '') return override
-  return join(await resolveDefaultDir(), 'typeclaw-git-askpass')
+  return configuredPath() ?? join(await resolveDefaultDir(), 'typeclaw-git-askpass')
 }
 
 // Keyed by resolved path: a single shared promise would let the first caller's
 // path win even when a later caller explicitly asks for a different one (the
-// reviewer and backup consumers can legitimately request distinct paths).
+// sandbox /usr path and the unsandboxed /tmp path are legitimately distinct).
 const ensurePromises = new Map<string, Promise<string>>()
 
 export function resetGitAskPassHelperForTests(): void {
@@ -81,16 +91,23 @@ export function resetGitAskPassHelperForTests(): void {
   defaultDirPromise = null
 }
 
-// Writes the helper once per path (idempotent, race-safe via the per-path
-// promise) and returns its absolute path. The temp name is unpredictable and
-// opened with `wx` (exclusive create, fails on an existing file/symlink) so a
-// planted symlink cannot redirect the write; then atomically renamed so a
-// concurrent reader never sees a partial file.
+// Returns the helper's absolute path, creating it once per path if needed. When
+// an executable file already exists at the resolved path (the baked /usr helper),
+// we return it WITHOUT writing — the read-only /usr would EACCES a rewrite. Only
+// creates when absent: dev, the unsandboxed /tmp path, or a writable test
+// override. Idempotent + race-safe via the per-path promise; the create uses an
+// unpredictable temp opened `wx` (fails on an existing file/symlink) then renamed.
 export async function ensureGitAskPassHelper(path?: string): Promise<string> {
   const resolved = path ?? (await defaultPath())
   const existing = ensurePromises.get(resolved)
   if (existing !== undefined) return existing
   const pending = (async () => {
+    try {
+      await access(resolved, constants.X_OK)
+      return resolved
+    } catch {
+      // not present (or not executable) — fall through to create it
+    }
     await mkdir(dirname(resolved), { recursive: true })
     const tmp = join(dirname(resolved), `.typeclaw-git-askpass.${randomBytes(8).toString('hex')}.tmp`)
     await writeFile(tmp, ASKPASS_SCRIPT, { mode: 0o755, flag: 'wx' })

--- a/src/bundled-plugins/github-cli-auth/git-command.test.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.test.ts
@@ -30,8 +30,8 @@ describe('parseGithubRepoFromGitUrl', () => {
   test('parses ssh url', () => {
     expect(parseGithubRepoFromGitUrl('ssh://git@github.com/acme/widgets.git')).toBe('acme/widgets')
   })
-  test('parses ssh url with port', () => {
-    expect(parseGithubRepoFromGitUrl('ssh://git@github.com:22/acme/widgets.git')).toBe('acme/widgets')
+  test('rejects an ssh url with explicit port (insteadOf rewrites only the port-less form)', () => {
+    expect(parseGithubRepoFromGitUrl('ssh://git@github.com:22/acme/widgets.git')).toBeNull()
   })
   test('rejects scp-like url with #/? suffix (would yield a malformed slug)', () => {
     expect(parseGithubRepoFromGitUrl('git@github.com:acme/widgets.git#main')).toBeNull()
@@ -247,15 +247,72 @@ describe('analyzeGitCommand — multi-remote resolution', () => {
     expect((await analyze('git fetch --multiple origin upstream', r)).kind).toBe('block')
   })
 
-  test('fetch --multiple across one owner injects', async () => {
+  test('fetch --multiple across two distinct repos blocks (one minted token is repo-scoped)', async () => {
     const r = resolvers({
       resolveRemoteUrl: async (_cwd, remote) =>
         remote === 'origin' ? 'https://github.com/acme/widgets.git' : 'https://github.com/acme/tools.git',
     })
-    expect(await analyze('git fetch --multiple origin upstream', r)).toEqual({
-      kind: 'inject',
-      repoSlug: 'acme/widgets',
+    expect((await analyze('git fetch --multiple origin upstream', r)).kind).toBe('block')
+  })
+
+  test('fetch --multiple with two explicit URLs enumerates BOTH and blocks (not just the first)', async () => {
+    const result = await analyze(
+      'git fetch --multiple https://github.com/acme/widgets.git https://github.com/acme/tools.git',
+    )
+    expect(result.kind).toBe('block')
+  })
+
+  test('fetch --multiple with a mixed named-remote + URL blocks when they resolve to distinct repos', async () => {
+    const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+    const result = await analyze('git fetch --multiple origin https://github.com/acme/tools.git', r)
+    expect(result.kind).toBe('block')
+  })
+
+  test('fetch --multiple where every target resolves to the same repo still injects', async () => {
+    const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
+    const result = await analyze('git fetch --multiple origin https://github.com/acme/widgets.git', r)
+    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+  })
+
+  test('repeated -C is cumulative: a relative second -C resolves under the first (git semantics)', async () => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (cwd) => {
+        seen.push(cwd)
+        return 'https://github.com/acme/widgets.git'
+      },
     })
+    await analyze('git -C /trusted -C child fetch origin main', r)
+    expect(seen).toContain('/trusted/child')
+    expect(seen).not.toContain('/agent/child')
+  })
+
+  test('an absolute later -C resets the cumulative base', async () => {
+    const seen: string[] = []
+    const r = resolvers({
+      resolveRemoteUrl: async (cwd) => {
+        seen.push(cwd)
+        return 'https://github.com/acme/widgets.git'
+      },
+    })
+    await analyze('git -C /trusted -C /elsewhere fetch origin main', r)
+    expect(seen).toContain('/elsewhere')
+    expect(seen).not.toContain('/trusted')
+  })
+
+  test('fetch --multiple fails closed (pass-through, no mint) when any target is unresolvable', async () => {
+    const r = resolvers({
+      resolveRemoteUrl: async (_cwd, remote) => (remote === 'origin' ? 'https://github.com/acme/widgets.git' : null),
+    })
+    // `bogusgroup` resolves to no url (e.g. a remotes.<group> we can't expand) →
+    // we must NOT mint for `origin` alone while git contacts the group's remotes.
+    expect((await analyze('git fetch --multiple origin bogusgroup', r)).kind).toBe('pass-through')
+  })
+
+  test('an explicit-port ssh URL is not recognized as github (no mint; would bypass https askpass)', async () => {
+    expect(parseGithubRepoFromGitUrl('ssh://git@github.com:22/acme/widgets.git')).toBeNull()
+    expect(parseGithubRepoFromGitUrl('ssh://git@github.com/acme/widgets.git')).toBe('acme/widgets')
+    expect((await analyze('git clone ssh://git@github.com:22/acme/widgets.git')).kind).toBe('pass-through')
   })
 
   test('push origin main treats main as a refspec, not a second remote', async () => {
@@ -346,19 +403,19 @@ describe('analyzeGitCommand — resolver errors fail safe', () => {
 describe('analyzeGitCommand — &&-joined git chains', () => {
   const ghRemote = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/widgets.git' })
 
-  test('REGRESSION: clone && fetch (same owner) injects instead of passing through tokenless', async () => {
-    // given: a compound clone+fetch that previously ran in the sandbox with no
-    // credential because the multi-git chain silently passed through.
+  test('token-bearing clone && fetch (same owner) BLOCKS: a later git segment would inherit the token', async () => {
+    // A repo could alias a git subcommand to `!<shell>` and read TYPECLAW_GIT_TOKEN
+    // from the shared chain env — so a minted chain must be a single bare git.
     const result = await analyze(
       'git clone --depth 1 https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch origin main',
       ghRemote,
     )
-    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+    expect(result.kind).toBe('block')
   })
 
-  test('clone && checkout (only first targets a remote) injects for the remote owner', async () => {
+  test('token-bearing clone && checkout blocks (single bare git only, even if segment 2 is local)', async () => {
     const result = await analyze('git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x checkout main')
-    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+    expect(result.kind).toBe('block')
   })
 
   test('non-remote chain (status && log) passes through (nothing to authenticate)', async () => {
@@ -411,13 +468,13 @@ describe('analyzeGitCommand — &&-joined git chains', () => {
     ).toBe('block')
   })
 
-  test('two single-owner remotes across the chain inject', async () => {
+  test('two remotes across the chain block (multi-segment token-bearing git)', async () => {
     const r = resolvers({ resolveRemoteUrl: async () => 'https://github.com/acme/tools.git' })
     const result = await analyze(
       'git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch upstream',
       r,
     )
-    expect(result).toEqual({ kind: 'inject', repoSlug: 'acme/widgets' })
+    expect(result.kind).toBe('block')
   })
 
   test('non-github chain passes through (no token to mint)', async () => {

--- a/src/bundled-plugins/github-cli-auth/git-command.ts
+++ b/src/bundled-plugins/github-cli-auth/git-command.ts
@@ -57,9 +57,9 @@ export const defaultGitResolvers: GitResolvers = {
 const REMOTE_SUBCOMMANDS = new Set(['push', 'fetch', 'pull', 'clone', 'ls-remote'])
 
 const MULTI_OWNER_REASON =
-  'This git command targets repos under more than one owner; a single minted ' +
-  'GitHub App token cannot authenticate all of them. Split it into separate ' +
-  'commands, one owner each.'
+  'This git command targets more than one repository; a single minted GitHub App ' +
+  'token is scoped to one repo and cannot authenticate all of them. Split it into ' +
+  'separate commands, one repository each.'
 
 const COMPOSITION_REASON =
   'A repo-targeting `git` command receives a minted GitHub App token via ' +
@@ -119,9 +119,8 @@ export async function analyzeGitCommand(
   // authenticate, so pass through and let git run with no token.
   if (remoteSegments.length === 0) return { kind: 'pass-through' }
 
-  // Every segment — even non-remote ones like `git status` that ride along in
-  // the chain — must pass the redirect screen: a token lives in the shared env
-  // the whole chain inherits, so a `-c`/env-assignment on ANY git could steer
+  // Every segment must pass the redirect screen: a token would live in the shared
+  // env the whole chain inherits, so a `-c`/env-assignment on ANY git could steer
   // auth or destination.
   for (const seg of chain) {
     if (seg.hasLeadingEnvAssignment || hasDangerousGitConfig(seg.args)) {
@@ -133,11 +132,10 @@ export async function analyzeGitCommand(
     }
   }
 
-  const owners = new Set<string>()
-  let representativeSlug: string | null = null
+  const repos = new Set<string>()
   for (const seg of remoteSegments) {
     const sub = findSubcommand(seg.args) as string
-    const effectiveCwd = resolveCwd(options.cwd, extractDashCDir(seg.args))
+    const effectiveCwd = resolveEffectiveCwd(options.cwd, seg.args)
     // A resolver that throws is treated as "couldn't resolve" → pass-through, so
     // a git/subprocess failure never crashes the hook or guesses a repo.
     let slugs: string[]
@@ -146,19 +144,23 @@ export async function analyzeGitCommand(
     } catch {
       return { kind: 'pass-through' }
     }
-    for (const slug of slugs) {
-      owners.add(slug.split('/')[0] as string)
-      representativeSlug ??= slug
-    }
+    for (const slug of slugs) repos.add(slug)
   }
 
-  // A GitHub remote subcommand whose target owner we could not resolve: we must
-  // not mint a possibly-wrong-owner token, and silently passing through would
-  // reproduce the credential-less failure. Block with an actionable reason.
-  if (representativeSlug === null) return { kind: 'pass-through' }
-  if (owners.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
+  // No github remote resolved (e.g. a gitlab chain): no token to mint, so pass
+  // through and let git run tokenless — do NOT block a legitimate non-github chain.
+  if (repos.size === 0) return { kind: 'pass-through' }
 
-  return { kind: 'inject', repoSlug: representativeSlug }
+  // A token WILL be minted. It must ride a SINGLE bare git: the shared chain env
+  // means a later segment — even `git leak` where the repo aliased `leak` to a
+  // shell command — would read it. The only multi-segment token-bearing form is
+  // `cd <path> && git …`, handled by analyzeSingleCdGit (rewritten to one git -C).
+  if (chain.length > 1) return { kind: 'block', reason: COMPOSITION_REASON }
+  // One minted token is repo-scoped, so more than one distinct repo (e.g.
+  // `fetch --multiple origin upstream`) can't authenticate.
+  if (repos.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
+
+  return { kind: 'inject', repoSlug: [...repos][0] as string }
 }
 
 // The single-git `cd <path> && git …` shortcut. Kept separate (and single-git
@@ -180,8 +182,8 @@ async function analyzeSingleCdGit(
   if ((subcommand === 'fetch' || subcommand === 'pull') && args.includes('--all')) {
     return { kind: 'block', reason: FETCH_ALL_REASON }
   }
-  const dashCDir = extractDashCDir(args)
-  const effectiveCwd = resolveCwd(resolveCwd(options.cwd, stripped.cdDir), dashCDir)
+  const hasDashC = args.includes('-C')
+  const effectiveCwd = resolveEffectiveCwd(resolveCwd(options.cwd, stripped.cdDir), args)
   let slugs: string[]
   try {
     slugs = await resolveRepoSlugs(subcommand, args, effectiveCwd, options.resolvers)
@@ -189,12 +191,11 @@ async function analyzeSingleCdGit(
     return { kind: 'pass-through' }
   }
   if (slugs.length === 0) return { kind: 'pass-through' }
-  const owners = new Set(slugs.map((s) => s.split('/')[0]))
-  if (owners.size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
+  if (new Set(slugs).size > 1) return { kind: 'block', reason: MULTI_OWNER_REASON }
   const repoSlug = slugs[0] as string
   // The rewrite cannot stack two `-C` (the git part must not already carry one)
   // and the rest must be a single bare git (no further composition).
-  if (containsShellActiveMetachar(stripped.rest) || dashCDir !== null) {
+  if (containsShellActiveMetachar(stripped.rest) || hasDashC) {
     return { kind: 'block', reason: COMPOSITION_REASON }
   }
   return { kind: 'inject', repoSlug, rewrittenCommand: rewriteCdToDashC(effectiveCwd, stripped.rest) }
@@ -225,6 +226,25 @@ async function resolveRepoSlugs(
   cwd: string,
   resolvers: GitResolvers,
 ): Promise<string[]> {
+  // `fetch --multiple` contacts EVERY positional target — remotes AND raw URLs,
+  // mixed, and a target may even be a `remotes.<group>` that expands to several.
+  // Enumerate them all (not just the first URL) so the distinct-repo guard sees
+  // the full set. FAIL CLOSED: if ANY target can't be resolved to a github slug
+  // (an unknown remote, a config remote-group we can't expand, a non-github URL),
+  // throw so the caller passes through tokenless — never mint for a subset while
+  // git contacts the rest. Non-`--multiple` keeps the single-target path.
+  const forPush = subcommand === 'push'
+  if (subcommand === 'fetch' && args.includes('--multiple')) {
+    const slugs: string[] = []
+    for (const pos of positionalsAfterSubcommand('fetch', args)) {
+      const url = looksLikeUrl(pos) ? pos : await resolvers.resolveRemoteUrl(cwd, pos, forPush)
+      const slug = url === null ? null : parseGithubRepoFromGitUrl(url)
+      if (slug === null) throw new Error('unresolved --multiple target')
+      slugs.push(slug)
+    }
+    return slugs
+  }
+
   const explicitUrl = extractExplicitUrl(subcommand, args)
   if (explicitUrl !== null) {
     const slug = parseGithubRepoFromGitUrl(explicitUrl)
@@ -234,12 +254,6 @@ async function resolveRepoSlugs(
   // clone needs an explicit URL; it has no configured-remote fallback.
   if (subcommand === 'clone') return []
 
-  // Only `push` consults the push url; fetch/pull/ls-remote use the fetch url.
-  const forPush = subcommand === 'push'
-
-  // EVERY named remote must be resolved, not just the first: `git fetch
-  // --multiple origin upstream` touches both, and feeding only one to the
-  // multi-owner guard would let a second-owner remote slip past and still mint.
   const remoteNames = extractRemoteNames(args)
   // The branch.pushRemote/pushDefault/origin chain is a PUSH default; applying it
   // to a bare `fetch`/`pull`/`ls-remote` could mint for the wrong (push) remote,
@@ -284,7 +298,11 @@ export async function resolveGhDefaultRepoFromCwd(cwd: string, resolvers: GitRes
 
 const HTTPS_GITHUB_RE = /^https:\/\/github\.com\/([^/\s:@]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
 const SCP_GITHUB_RE = /^git@github\.com:([^/\s:?#]+)\/([^/\s?#]+?)(?:\.git)?$/i
-const SSH_GITHUB_RE = /^ssh:\/\/git@github\.com(?::\d+)?\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
+// No explicit port: the forced insteadOf only rewrites `ssh://git@github.com/`, so
+// a ported form (`ssh://git@github.com:22/…`) would keep ssh transport and bypass
+// the https askpass. We therefore do NOT recognize the ported spelling as github —
+// it resolves to no slug, so no token is minted and git fails honestly.
+const SSH_GITHUB_RE = /^ssh:\/\/git@github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?\/?(?:[?#].*)?$/i
 
 // Parses a github.com remote URL into an `owner/name` slug. Returns null for
 // non-github.com hosts, credential-bearing https URLs (https://tok@github.com/…
@@ -392,15 +410,20 @@ function positionalsAfterSubcommand(subcommand: string, args: readonly string[])
   return out
 }
 
-function extractDashCDir(args: readonly string[]): string | null {
+// git applies repeated `-C` CUMULATIVELY: each value is resolved relative to the
+// result of the previous one, and an absolute value resets the base. So `-C
+// /trusted -C child` operates in `/trusted/child`, not `child`. We fold them the
+// same way from `base` so we resolve the repo of the checkout git actually uses —
+// resolving only the last `-C` from cwd would mint against a different tree.
+function resolveEffectiveCwd(base: string, args: readonly string[]): string {
+  let cwd = base
   for (let i = 0; i < args.length; i++) {
-    const arg = args[i]
-    if (arg === '-C') {
+    if (args[i] === '-C') {
       const v = args[i + 1]
-      if (v !== undefined) return stripQuotes(v)
+      if (v !== undefined) cwd = resolveCwd(cwd, stripQuotes(v))
     }
   }
-  return null
+  return cwd
 }
 
 type GitInvocation = { args: string[]; hasLeadingEnvAssignment: boolean }

--- a/src/bundled-plugins/github-cli-auth/index.test.ts
+++ b/src/bundled-plugins/github-cli-auth/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -15,6 +15,7 @@ import { noopPermissionService, type PermissionService } from '@/permissions'
 import { createHookBus, type PluginContext, type PluginLogger, type ToolBeforeEvent } from '@/plugin'
 import { buildSandboxedCommand } from '@/sandbox'
 
+import { resetGitAskPassHelperForTests } from './git-askpass'
 import githubCliAuthPlugin from './index'
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} }
@@ -1146,40 +1147,81 @@ describe('github-cli-auth plugin — .env PAT role gating (gh path)', () => {
 })
 
 describe('github-cli-auth plugin — git path', () => {
-  test('App auth: blocks explicit-URL git clone without exposing a token', async () => {
-    process.env.GH_TOKEN = 'ghs_seeded'
-    const hook = await hookFor(tokenResolver('ghs_minted'))
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+  let askpassPath: string
 
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(event.args.command).toBe('git clone https://github.com/acme/widgets.git')
-    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
+  beforeEach(() => {
+    askpassPath = join(mkdtempSync(join(tmpdir(), 'tc-askpass-')), 'typeclaw-git-askpass')
+    process.env.TYPECLAW_GIT_ASKPASS_PATH = askpassPath
+    resetGitAskPassHelperForTests()
   })
 
-  test('authenticated git is blocked without minting a repo token', async () => {
+  afterEach(() => {
+    delete process.env.TYPECLAW_GIT_ASKPASS_PATH
+    resetGitAskPassHelperForTests()
+    rmSync(askpassPath, { force: true })
+  })
+
+  const gitEnv = (event: ToolBeforeEvent): Record<string, string> =>
+    (event.args[TYPECLAW_INTERNAL_BASH_ENV] ?? {}) as Record<string, string>
+
+  test('App auth: mints a per-repo token into git via the askpass overlay, never the command', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const seen: string[] = []
     const hook = await hookFor(async (slug) => {
       seen.push(slug)
       return { kind: 'token', token: 'ghs_minted' }
     })
+    const event = bashEvent('git fetch https://github.com/acme/widgets.git main')
 
-    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git'), hookCtx)
+    const result = await hook(event, hookCtx)
 
-    expect(result).toMatchObject({ block: true })
-    expect(seen).toEqual([])
+    expect(result).toBeUndefined()
+    expect(seen).toEqual(['acme/widgets'])
+    const env = gitEnv(event)
+    expect(env.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(env.GIT_ASKPASS).toBe(askpassPath)
+    // The secret rides ONLY in the env overlay, never in the command string.
+    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
   })
 
-  test('multi-owner App auth blocks git push rather than minting into git', async () => {
-    // given: the reported #733 failure — a push under a multi-owner App where
-    // GH_TOKEN is never seeded, so the old `classifyGhToken(GH_TOKEN) === app`
-    // gate dropped the credential and git died with "could not read Username".
-    delete process.env.GH_TOKEN
-    const hook = await hookFor(tokenResolver('ghs_minted'), true)
-    const event = bashEvent('git push https://github.com/acme/widgets.git main')
+  test('minted git carries hooksPath=/dev/null and an empty credential.helper', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    await hook(event, hookCtx)
+
+    const env = gitEnv(event)
+    const count = Number(env.GIT_CONFIG_COUNT ?? '0')
+    const pairs: Array<[string, string]> = []
+    for (let i = 0; i < count; i++)
+      pairs.push([env[`GIT_CONFIG_KEY_${i}`] as string, env[`GIT_CONFIG_VALUE_${i}`] as string])
+    expect(pairs).toContainEqual(['core.hooksPath', '/dev/null'])
+    expect(pairs).toContainEqual(['credential.helper', ''])
+    // Both ssh remote spellings are rewritten to https so the askpass credential applies.
+    expect(pairs).toContainEqual(['url.https://github.com/.insteadOf', 'git@github.com:'])
+    expect(pairs).toContainEqual(['url.https://github.com/.insteadOf', 'ssh://git@github.com/'])
+    expect(env.GIT_TERMINAL_PROMPT).toBe('0')
+  })
+
+  test('composition blocks before minting (no sibling inherits the token env)', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent('git clone https://github.com/acme/widgets.git && cat .env')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toMatchObject({ block: true })
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
+  })
+
+  test('multi-owner git blocks rather than minting a single-repo token', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    const hook = await hookFor(tokenResolver('ghs_minted'))
+    const event = bashEvent(
+      'git fetch https://github.com/acme/widgets.git && git fetch https://github.com/other/thing.git',
+    )
 
     const result = await hook(event, hookCtx)
 
@@ -1187,7 +1229,7 @@ describe('github-cli-auth plugin — git path', () => {
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
-  test('no App auth (GH_TOKEN unseeded, no minter): git push passes through without minting', async () => {
+  test('no App minter: authenticated git passes through so git fails honestly', async () => {
     delete process.env.GH_TOKEN
     let resolverCalled = false
     const hook = await hookFor(async () => {
@@ -1203,123 +1245,45 @@ describe('github-cli-auth plugin — git path', () => {
     expect(resolverCalled).toBe(false)
   })
 
-  test('App auth: blocks before consulting an unavailable bridge', async () => {
+  test('unavailable bridge (repo not in repos[]) blocks with the adapter reason', async () => {
     process.env.GH_TOKEN = 'ghs_seeded'
     const hook = await hookFor(unavailableResolver)
-
-    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git'), hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect((result as { reason: string }).reason).toContain('Authenticated git')
-  })
-
-  test('App auth: blocks a compound (token-leaking) git command', async () => {
-    process.env.GH_TOKEN = 'ghs_seeded'
-    const hook = await hookFor(tokenResolver('ghs_minted'))
-
-    const result = await hook(bashEvent('git clone https://github.com/acme/widgets.git && cat .env'), hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-  })
-
-  test('App auth: blocks an all-git chain because hooks/helpers inherit credentials', async () => {
-    process.env.GH_TOKEN = 'ghs_seeded'
-    const hook = await hookFor(tokenResolver('ghs_minted'))
-    const event = bashEvent('git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch origin main')
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
     const result = await hook(event, hookCtx)
 
     expect(result).toMatchObject({ block: true })
+    expect((result as { reason: string }).reason).toContain('adapter down')
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(event.args.command).toBe(
-      'git clone https://github.com/acme/widgets.git /tmp/x && git -C /tmp/x fetch origin main',
-    )
-    expect(JSON.stringify(event.args.command)).not.toContain('ghs_minted')
   })
 
-  test('classic PAT is never injected into git, even for a credential-entitled role', async () => {
+  test('classic PAT is never brokered to git; an App token is minted instead', async () => {
+    process.env.GH_TOKEN = 'ghp_classic'
+    const hook = await hookFor(tokenResolver('ghs_minted'), true, { permissions: privilegedPermissions })
+    const event = bashEvent('git clone https://github.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    const env = gitEnv(event)
+    expect(env.TYPECLAW_GIT_TOKEN).toBe('ghs_minted')
+    expect(JSON.stringify(env)).not.toContain('ghp_classic')
+  })
+
+  test('PAT with no App minter: authenticated git passes through, PAT never reaches git', async () => {
     process.env.GH_TOKEN = 'ghp_classic'
     let resolverCalled = false
-    const hook = await hookFor(
-      async () => {
-        resolverCalled = true
-        return { kind: 'token', token: 'ghs_minted' }
-      },
-      true,
-      { permissions: privilegedPermissions },
-    )
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    }, false)
     const event = bashEvent('git clone https://github.com/acme/widgets.git')
 
     const result = await hook(event, hookCtx)
 
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(JSON.stringify(event.args.command)).not.toContain('ghp_classic')
-    expect(resolverCalled).toBe(false)
-  })
-
-  test('fine-grained PAT is never injected into git, even for a credential-entitled role', async () => {
-    process.env.GH_TOKEN = 'github_pat_xyz'
-    let resolverCalled = false
-    const hook = await hookFor(
-      async () => {
-        resolverCalled = true
-        return { kind: 'token', token: 'ghs_minted' }
-      },
-      true,
-      { permissions: privilegedPermissions },
-    )
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
+    expect(result).toBeUndefined()
     expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
     expect(resolverCalled).toBe(false)
-  })
-
-  test('git does not receive GITHUB_TOKEN when GH_TOKEN is absent', async () => {
-    delete process.env.GH_TOKEN
-    process.env.GITHUB_TOKEN = 'github_pat_fallback'
-    let resolverCalled = false
-    const hook = await hookFor(
-      async () => {
-        resolverCalled = true
-        return { kind: 'token', token: 'ghs_minted' }
-      },
-      true,
-      { permissions: privilegedPermissions },
-    )
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-    expect(resolverCalled).toBe(false)
-  })
-
-  test('PAT plus App minter still does not place a reusable token in git', async () => {
-    process.env.GH_TOKEN = 'ghp_classic'
-    const hook = await hookFor(tokenResolver('ghs_minted'), true)
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
-  })
-
-  test('PAT without App minter blocks git with confused-deputy guidance', async () => {
-    process.env.GH_TOKEN = 'ghp_classic'
-    const hook = await hookFor(tokenResolver('ghs_minted'), false)
-    const event = bashEvent('git clone https://github.com/acme/widgets.git')
-
-    const result = await hook(event, hookCtx)
-
-    expect(result).toMatchObject({ block: true })
-    expect((result as { reason: string }).reason).toContain('credential helpers')
-    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
   })
 
   test('non-github explicit-URL git command passes through without minting', async () => {
@@ -1330,6 +1294,22 @@ describe('github-cli-auth plugin — git path', () => {
       return { kind: 'token', token: 'ghs_minted' }
     })
     const event = bashEvent('git clone https://gitlab.com/acme/widgets.git')
+
+    const result = await hook(event, hookCtx)
+
+    expect(result).toBeUndefined()
+    expect(event.args[TYPECLAW_INTERNAL_BASH_ENV]).toBeUndefined()
+    expect(resolverCalled).toBe(false)
+  })
+
+  test('local (non-network) git passes through without minting', async () => {
+    process.env.GH_TOKEN = 'ghs_seeded'
+    let resolverCalled = false
+    const hook = await hookFor(async () => {
+      resolverCalled = true
+      return { kind: 'token', token: 'ghs_minted' }
+    })
+    const event = bashEvent('git status')
 
     const result = await hook(event, hookCtx)
 

--- a/src/bundled-plugins/github-cli-auth/index.ts
+++ b/src/bundled-plugins/github-cli-auth/index.ts
@@ -15,6 +15,7 @@ import {
   effectiveGhTokensForAuthenticatedUserEndpoint,
   usesGhApiGraphqlEndpoint,
 } from './gh-command'
+import { ensureGitAskPassHelper, resolveSandboxGitAskPassPath } from './git-askpass'
 import { analyzeGitCommand, defaultGitResolvers, resolveGhDefaultRepoFromCwd } from './git-command'
 import { checkGraphqlAuthNudge } from './graphql-auth-nudge'
 import { commitReviewIfSucceeded, noteReviewCommand } from './review-recorder'
@@ -346,18 +347,54 @@ export default definePlugin({
       return
     }
 
-    const handleGitCommand = async (params: { command: string; agentDir: string }): Promise<HookResult> => {
-      const { command, agentDir } = params
+    const handleGitCommand = async (params: {
+      event: { args: Record<string, unknown> }
+      command: string
+      agentDir: string
+    }): Promise<HookResult> => {
+      const { event, command, agentDir } = params
       const decision = await analyzeGitCommand(command, { cwd: agentDir, resolvers: defaultGitResolvers })
       if (decision.kind === 'pass-through') return
       if (decision.kind === 'block') return { block: true, reason: decision.reason }
-      const token = effectiveProcessToken()
-      if (token === undefined && !hasAppTokenResolver()) return
-      return {
-        block: true,
-        reason:
-          'Authenticated git is unavailable to model-driven bash because git can invoke repository hooks and credential helpers that inherit reusable credentials. Local git commands still work; use a first-class GitHub action or run network git host-side.',
+
+      // Only a per-repo GitHub App token is brokered to git — never a PAT (git,
+      // unlike gh, runs repo-local hooks/helpers, and a PAT is not repo-confined).
+      // With no App minter, pass through so git fails honestly.
+      if (!hasAppTokenResolver()) return
+      const result = await resolveTokenForRepo(decision.repoSlug)
+      if (result.kind === 'unavailable') return { block: true, reason: result.reason }
+
+      // Deliver the token via GIT_ASKPASS (env, never argv/config). The analyzer
+      // already constrained this to a single bare github git command, so the token
+      // env reaches only this git. hooksPath=/dev/null + credential.helper= stop the
+      // two highest-value ways a repo could capture the token; insteadOf folds
+      // ssh/scp remotes to https so the credential applies. This is defense-in-depth
+      // WITHIN one trust domain, not a wall against a hostile repo — untrusted repos
+      // belong in a separate agent (see docs/internals/sandbox.mdx).
+      // Sandboxed bash: the helper must be on a sandbox-visible path (baked /usr),
+      // not the unsandboxed /tmp default the tmpfs would hide.
+      const askpass = await ensureGitAskPassHelper(resolveSandboxGitAskPassPath())
+      const existing = event.args[TYPECLAW_INTERNAL_BASH_ENV]
+      const overlay = existing !== null && typeof existing === 'object' ? (existing as Record<string, string>) : {}
+      event.args[TYPECLAW_INTERNAL_BASH_ENV] = {
+        ...overlay,
+        GIT_ASKPASS: askpass,
+        TYPECLAW_GIT_TOKEN: result.token,
+        GIT_TERMINAL_PROMPT: '0',
+        GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'core.hooksPath',
+        GIT_CONFIG_VALUE_0: '/dev/null',
+        GIT_CONFIG_KEY_1: 'credential.helper',
+        GIT_CONFIG_VALUE_1: '',
+        // Both ssh remote spellings fold to https so the askpass credential applies:
+        // the scp short form (git@github.com:owner/repo) and the ssh:// URL form.
+        GIT_CONFIG_KEY_2: 'url.https://github.com/.insteadOf',
+        GIT_CONFIG_VALUE_2: 'git@github.com:',
+        GIT_CONFIG_KEY_3: 'url.https://github.com/.insteadOf',
+        GIT_CONFIG_VALUE_3: 'ssh://git@github.com/',
       }
+      if (decision.rewrittenCommand !== undefined) event.args.command = decision.rewrittenCommand
+      return
     }
 
     return {
@@ -373,7 +410,7 @@ export default definePlugin({
           }
 
           if (command.includes('git')) {
-            return await handleGitCommand({ command, agentDir: ctx.agentDir })
+            return await handleGitCommand({ event, command, agentDir: ctx.agentDir })
           }
           return
         },

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1061,6 +1061,18 @@ describe('transformers native-deps layer (sharp + onnxruntime linux binaries)', 
     })
   }
 
+  for (const [label, render] of [
+    ['inline (dev)', () => buildDockerfile()],
+    ['versioned (base-image)', () => buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' })],
+    ['base', () => buildBaseDockerfile()],
+  ] as const) {
+    test(`${label} form bakes the git-askpass helper at /usr/local/bin/typeclaw-git-askpass, chmod 755 (non-root runtime cannot write it at runtime)`, () => {
+      const out = render()
+      expect(out).toContain('> /usr/local/bin/typeclaw-git-askpass')
+      expect(out).toContain('chmod 755 /usr/local/bin/typeclaw-git-askpass')
+    })
+  }
+
   test('TRANSFORMERS_VERSION matches the @huggingface/transformers pin in package.json — host download (models.ts) and container install (Layer 7) must resolve the same library, and the package.json pin is exact (no caret) so the repo install agrees', () => {
     const pkg = JSON.parse(readFileSync(join(import.meta.dir, '..', '..', 'package.json'), 'utf8')) as {
       dependencies: Record<string, string>

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1,3 +1,4 @@
+import { ASKPASS_SCRIPT, TYPECLAW_GIT_ASKPASS_PATH } from '@/bundled-plugins/github-cli-auth/git-askpass'
 import { validateDockerfileAppendLine } from '@/config/config'
 import type { DockerfileConfig, DockerfileFeatureToggle } from '@/config/config'
 import {
@@ -671,6 +672,15 @@ function renderEntrypointShimLayer(): string {
 # The shim is a no-op unless \`network.blockInternal\` is true at runtime.
 RUN echo "${encoded}" | base64 -d > ${TYPECLAW_ENTRYPOINT_PATH} \\
  && chmod +x ${TYPECLAW_ENTRYPOINT_PATH}`
+}
+
+// Bake the secret-free git-askpass helper (github-cli-auth broker delivers the
+// token to it via env). Root-owned at build time so the non-root runtime, which
+// cannot write the read-only /usr, still finds it.
+function renderGitAskPassLayer(): string {
+  const encoded = Buffer.from(ASKPASS_SCRIPT, 'utf8').toString('base64')
+  return `RUN echo "${encoded}" | base64 -d > ${TYPECLAW_GIT_ASKPASS_PATH} \\
+ && chmod 755 ${TYPECLAW_GIT_ASKPASS_PATH}`
 }
 
 // Layer 7: install @huggingface/transformers with its linux-native binaries.
@@ -1418,6 +1428,7 @@ WORKDIR /agent
 ARG TARGETARCH
 
 ${ghKeyringLayer}${toggleAptLayer}${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderEntrypointShimLayer()}
+${renderGitAskPassLayer()}
 
 ${LAYER_TRANSFORMERS_INSTALL}
 
@@ -1481,6 +1492,7 @@ ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 ${renderChromeForTestingLayer(buildKit)}
 
 ${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderEntrypointShimLayer()}
+${renderGitAskPassLayer()}
 
 ${LAYER_TRANSFORMERS_INSTALL}
 
@@ -1558,6 +1570,7 @@ ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 ${renderChromeForTestingLayer(true)}
 
 ${renderEntrypointShimLayer()}
+${renderGitAskPassLayer()}
 
 ${LAYER_TRANSFORMERS_INSTALL}
 `


### PR DESCRIPTION
Supersedes #1259.

## Background

A TypeClaw agent could not run authenticated `git fetch`/`pull`/`clone` against its own channel-configured repo from model-driven bash. The `github-cli-auth` broker blocked all network git (since 0.46.0), so an on-disk reference clone drifted stale and the agent had no in-band way to refresh it. Restoring that fetch is the whole point of this PR.

#1259 tried to harden the in-bash path against a hostile repo's local config and became an unwinnable arms race — hooks → signing → `--signed=yes` → `clone --config` → `http.<url>.proxy` … The `http.*` finding made it concrete: per git's `urlmatch` semantics a repo-local `[http "https://github.com/owner/repo"]` entry is a longer match than any host-level forced key, so forced `GIT_CONFIG_*` can't fully neutralize it. Enumerating keys/flags can't win against a config-driven process launcher.

Per TypeClaw's own threat model (`docs/internals/sandbox.mdx` — the boundary is one agent per trust domain, and the per-tool sandbox is defense-in-depth against a hostile command within a domain, not a wall between domains), the honest framing is: authenticated git in model bash is in-trust-domain defense-in-depth, not a wall against a malicious repo. This path assumes the agent's own repos are trusted — which is exactly the case it exists to serve.

## Summary

When a GitHub App minter is available, `handleGitCommand` mints a per-repo installation token and delivers it via the existing `GIT_ASKPASS` helper (env, never argv/config), reusing the analyzer's existing guarantees:

- single bare git only (no `&&`/`;`/pipe/subshell composition — so no sibling process inherits the token env)
- single owner, no dangerous global flags (`-c`, `--git-dir`, …), github.com only
- a PAT is never brokered to git — App auth only (a PAT isn't repo-confined; git runs repo-local hooks/helpers)

Forced config is deliberately limited to the two highest-value neutralizers — `core.hooksPath=/dev/null` and an empty `credential.helper` — plus the ssh→https `insteadOf` rewrite. Authenticated `fetch`/`pull`/`clone`/`push` on a channel repo work again; everyday local git is untouched pass-through.

The secret-free askpass helper is baked into the image (`/usr/local/bin/typeclaw-git-askpass`, root-owned) across all build paths, so the non-root runtime — which can't write the read-only `/usr` — finds it. This also fixes a latent EACCES for the existing `review-checkout` path.

So this PR keeps the core fix plus the cheap structural guards, and drops the flag/key micro-controls that were the arms race, documenting the trust-domain expectation in the code instead.

## What this does NOT do

- Does not attempt to fully neutralize a hostile repo's local git config — untrusted repos belong in a separate agent, not this path.
- Does not broker a PAT to git under any circumstance — App auth only.

## Review notes

- git-path suite rewritten to the mint behavior: mints per-repo token into the askpass overlay (token never in the command string); asserts forced `core.hooksPath=/dev/null` + empty `credential.helper`; composition and multi-owner block; PAT never reaches git; no-minter / non-github / local git pass through.
- Dockerfile install assertions (helper baked, chmod 755) across inline/versioned/base build forms.
- Full suite green: typecheck / lint (0 errors) / format:check / test (11680 pass, 0 fail).