### PR TITLE
fix(github): bound reconcile replay with a durable per-PR cooldown

### DIFF
--- a/src/channels/adapters/github/index.ts
+++ b/src/channels/adapters/github/index.ts
@@ -21,6 +21,7 @@ import {
   parseListHooksPermissionStatus,
 } from './permission-guidance'
 import { createGithubReactionCallback, createGithubRemoveReactionCallback } from './reactions'
+import { loadReconcileCooldownStore, type ReconcileCooldownStore } from './reconcile-cooldown-store'
 import { reconcileOpenPrs } from './reconcile-open-prs'
 import { createRecoveredGuidLog, recoverFailedGithubDeliveries } from './recover-failed-deliveries'
 import { createGithubReviewStateResolver } from './review-state'
@@ -73,6 +74,11 @@ export type GithubAdapterOptions = {
   // inbound delivery failed (and that GitHub never redelivered), re-injecting
   // them through the live event path. Zero disables the sweep. Default: 5 min.
   deliveryRecoveryIntervalMs?: number
+  // How often to re-run the open-PR reconcile pass after the initial start()
+  // pass, so a genuinely-missed PR recovers without another restart. Per-PR
+  // replay is bounded by the durable cooldown store. Zero disables the periodic
+  // re-run (the start() pass still fires). Default: 30 min.
+  reconcileIntervalMs?: number
   // Write-side of the GithubTokenBridge. On App-auth start the adapter
   // registers a per-repo minter here so plugin hooks can resolve a token for
   // ad-hoc `gh` commands; it unregisters on stop and on start rollback. PAT
@@ -101,6 +107,10 @@ const DEFAULT_DELIVERY_RECOVERY_INTERVAL_MS = 5 * 60 * 1000
 const DELIVERY_RECOVERY_LOOKBACK_MS = 70 * 60 * 60 * 1000
 // Bounds an LLM-session storm if a bad tunnel window drops a large burst.
 const MAX_RECOVERED_PER_SWEEP = 50
+// The reconcile pass reruns on this cadence so a genuinely-missed `opened`
+// recovers without waiting for another restart. Per-PR replay is bounded by the
+// durable cooldown store, so a tick is cheap when nothing new needs review.
+const DEFAULT_RECONCILE_INTERVAL_MS = 30 * 60 * 1000
 
 export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapter {
   const logger = options.logger ?? consoleLogger
@@ -118,6 +128,7 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
   let managedHooks: ReadonlyArray<{ repo: string; hookId: number }> = []
   let tokenRefreshTimer: { clear: () => void } | null = null
   let deliveryRecoveryTimer: { clear: () => void } | null = null
+  let reconcileTimer: { clear: () => void } | null = null
   let unregisterTokenBridge: (() => void) | null = null
   const workspaceByChat = new Map<string, string>()
   const setIntervalFn =
@@ -361,13 +372,21 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       }
       // Catch up on PRs whose opened/ready_for_review/review_requested delivery
       // was missed (tunnel-URL churn, dropped delivery, downtime). Best-effort
-      // and last so a failure here never blocks the adapter from coming up; the
-      // helper swallows per-repo errors internally. Runs on every start(), so a
-      // tunnel-driven restart re-checks too. `off` short-circuits inside.
-      if (repos.length > 0) {
-        await reconcileOpenPrs({
+      // so a failure here never blocks the adapter from coming up; the helper
+      // swallows per-repo errors internally. `off` short-circuits inside. A
+      // durable per-PR cooldown store bounds replay to at most once per window,
+      // so the many restarts a churning tunnel causes don't re-review the same
+      // PRs; the periodic tick below retries genuinely-missed PRs after the
+      // cooldown without needing a restart.
+      const reconcileCooldownStore =
+        repos.length > 0 ? await loadReconcileCooldownStore(options.agentDir, logger) : null
+      // Resolve review.on per call, not from the captured startup cfg: review.on
+      // is live-reloadable, so a periodic tick must honor a change to `off`
+      // (reconcileOpenPrs short-circuits on `off`) instead of scanning forever.
+      const runReconcile = (store: ReconcileCooldownStore): Promise<unknown> =>
+        reconcileOpenPrs({
           repos,
-          reviewOn: cfg.review.on,
+          reviewOn: options.configRef().review.on,
           selfLogin,
           authType: options.secrets.auth.type,
           token: authToken,
@@ -375,9 +394,16 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
           logger,
           isBotInTeam,
           fetchImpl,
+          cooldownStore: store,
         }).catch((err: unknown) => {
           logger.warn(`[github] reconcile pass failed: ${err instanceof Error ? err.message : String(err)}`)
         })
+      if (reconcileCooldownStore !== null) {
+        await runReconcile(reconcileCooldownStore)
+        const reconcileIntervalMs = options.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS
+        if (reconcileIntervalMs > 0) {
+          reconcileTimer = setIntervalFn(() => void runReconcile(reconcileCooldownStore), reconcileIntervalMs)
+        }
       }
       // Periodically recover inbound deliveries that failed at the tunnel and
       // were never redelivered (the cloudflare-quick 502 loss). Registered only
@@ -417,6 +443,10 @@ export function createGithubAdapter(options: GithubAdapterOptions): GithubAdapte
       if (deliveryRecoveryTimer !== null) {
         deliveryRecoveryTimer.clear()
         deliveryRecoveryTimer = null
+      }
+      if (reconcileTimer !== null) {
+        reconcileTimer.clear()
+        reconcileTimer = null
       }
       options.router.unregisterOutbound('github', outbound)
       options.router.unregisterReaction('github', reaction)

--- a/src/channels/adapters/github/lifecycle.test.ts
+++ b/src/channels/adapters/github/lifecycle.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import { generateKeyPairSync } from 'node:crypto'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { createChannelRouter, type ChannelRouter } from '@/channels/router'
 import type { ChannelAdapterConfig, GithubAdapterConfig } from '@/channels/schema'
@@ -928,13 +931,16 @@ describe('createGithubAdapter lifecycle', () => {
       httpListenImpl: () => ({ stop: async () => {} }),
       webhookRegistrationDelayMs: 0,
       tokenRefreshIntervalMs: 100,
+      reconcileIntervalMs: 0,
       setInterval: fakeInterval,
     })
 
     await adapter.start()
     // Two timers register through the injected setInterval: the token refresh
     // (index 0, registered first in the seed block) and the delivery-recovery
-    // sweep (index 1, registered last once managedHooks is populated).
+    // sweep (index 1, registered last once managedHooks is populated). The
+    // periodic reconcile tick is disabled here (reconcileIntervalMs: 0) to keep
+    // this assertion about the token-refresh + sweep timers only.
     expect(refreshHandlers.length).toBe(2)
     expect(process.env.GH_TOKEN).toBe('ghs_fresh')
 
@@ -995,12 +1001,14 @@ describe('createGithubAdapter lifecycle', () => {
       httpListenImpl: () => ({ stop: async () => {} }),
       webhookRegistrationDelayMs: 0,
       tokenRefreshIntervalMs: 0,
+      reconcileIntervalMs: 0,
       setInterval: fakeInterval,
     })
 
     await adapter.start()
-    // tokenRefreshIntervalMs: 0 disables the refresh timer, so the only timer is
-    // the recovery sweep — proving it registers independently of token refresh.
+    // tokenRefreshIntervalMs: 0 and reconcileIntervalMs: 0 disable those timers,
+    // so the only timer is the recovery sweep — proving it registers
+    // independently of the token refresh and reconcile ticks.
     expect(handlers.length).toBe(1)
 
     handlers[0]!()
@@ -1345,6 +1353,163 @@ describe('createGithubAdapter lifecycle', () => {
       await adapter.stop()
 
       expect(calls.some((c) => c.url.includes('/pulls'))).toBe(false)
+    })
+
+    function unreviewedPrFetch(): { fetch: typeof fetch; routedPrs: () => number } {
+      let routed = 0
+      const { fetch: fetchImpl } = fakeFetchRecording(({ url, method }) => {
+        if (url.endsWith('/user') && method === 'GET') return Response.json({ login: 'bot', id: 1 })
+        const hooks = url.match(/\/repos\/[^/]+\/[^/]+\/hooks\b/)
+        if (hooks) {
+          if (method === 'GET') return Response.json([])
+          if (method === 'POST') return Response.json({ id: 1 }, { status: 201 })
+        }
+        if (url.match(/\/pulls\/7\/reviews/)) return Response.json([])
+        if (url.includes('/pulls?')) {
+          routed += 1
+          return Response.json([
+            {
+              number: 7,
+              id: 700,
+              title: 'Add thing',
+              draft: false,
+              updated_at: '2026-01-01T00:00:00Z',
+              user: { login: 'alice', id: 10, type: 'User' },
+              head: { ref: 'feature' },
+              base: { ref: 'main' },
+              requested_reviewers: [],
+            },
+          ])
+        }
+        return new Response('unexpected', { status: 500 })
+      })
+      return { fetch: fetchImpl, routedPrs: () => routed }
+    }
+
+    test('a restart within the cooldown does NOT replay the same unreviewed PR twice', async () => {
+      const agentDir = await mkdtemp(join(tmpdir(), 'gh-reconcile-lifecycle-'))
+      try {
+        const routes: string[] = []
+        const router = freshRouter()
+        const originalRoute = router.route.bind(router)
+        router.route = (m) => {
+          routes.push(m.chat)
+          return originalRoute(m)
+        }
+
+        const build = () => {
+          const { fetch: fetchImpl } = unreviewedPrFetch()
+          return createGithubAdapter({
+            router,
+            configRef: reviewConfig('opened'),
+            secrets: patSecrets(),
+            agentDir,
+            logger: silentLogger(),
+            fetchImpl,
+            httpListenImpl: () => ({ stop: async () => {} }),
+            webhookRegistrationDelayMs: 0,
+            tokenRefreshIntervalMs: 0,
+            reconcileIntervalMs: 0,
+          })
+        }
+
+        const first = build()
+        await first.start()
+        await first.stop()
+
+        const second = build()
+        await second.start()
+        await second.stop()
+
+        expect(routes.filter((c) => c === 'pr:7')).toHaveLength(1)
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    })
+
+    test('the periodic reconcile tick fires the pass again after start()', async () => {
+      const agentDir = await mkdtemp(join(tmpdir(), 'gh-reconcile-lifecycle-'))
+      try {
+        const { fetch: fetchImpl, routedPrs } = unreviewedPrFetch()
+        const handlers: Array<() => void> = []
+        const fakeInterval = (handler: () => void) => {
+          handlers.push(handler)
+          return { clear: () => {} }
+        }
+
+        const adapter = createGithubAdapter({
+          router: freshRouter(),
+          configRef: reviewConfig('opened'),
+          secrets: patSecrets(),
+          agentDir,
+          logger: silentLogger(),
+          fetchImpl,
+          httpListenImpl: () => ({ stop: async () => {} }),
+          webhookRegistrationDelayMs: 0,
+          tokenRefreshIntervalMs: 0,
+          deliveryRecoveryIntervalMs: 0,
+          setInterval: fakeInterval,
+        })
+
+        await adapter.start()
+        const afterStart = routedPrs()
+        expect(afterStart).toBe(1)
+        expect(handlers).toHaveLength(1)
+
+        handlers[0]!()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(routedPrs()).toBe(2)
+        await adapter.stop()
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
+    })
+
+    test('a live review.on change to off stops the periodic reconcile tick from scanning', async () => {
+      const agentDir = await mkdtemp(join(tmpdir(), 'gh-reconcile-lifecycle-'))
+      try {
+        const { fetch: fetchImpl, routedPrs } = unreviewedPrFetch()
+        let reviewOn: 'opened' | 'off' = 'opened'
+        const configRef = (): ChannelAdapterConfig & GithubAdapterConfig => {
+          const config = githubConfig(['acme/widgets'])
+          config.review = { on: reviewOn, approve: true }
+          return config
+        }
+        const handlers: Array<() => void> = []
+        const fakeInterval = (handler: () => void) => {
+          handlers.push(handler)
+          return { clear: () => {} }
+        }
+
+        const adapter = createGithubAdapter({
+          router: freshRouter(),
+          configRef,
+          secrets: patSecrets(),
+          agentDir,
+          logger: silentLogger(),
+          fetchImpl,
+          httpListenImpl: () => ({ stop: async () => {} }),
+          webhookRegistrationDelayMs: 0,
+          tokenRefreshIntervalMs: 0,
+          deliveryRecoveryIntervalMs: 0,
+          setInterval: fakeInterval,
+        })
+
+        await adapter.start()
+        expect(routedPrs()).toBe(1)
+
+        reviewOn = 'off'
+        handlers[0]!()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(routedPrs()).toBe(1)
+        await adapter.stop()
+      } finally {
+        await rm(agentDir, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/src/channels/adapters/github/reconcile-cooldown-store.test.ts
+++ b/src/channels/adapters/github/reconcile-cooldown-store.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  DEFAULT_RECONCILE_COOLDOWN_MS,
+  loadReconcileCooldownStore,
+  reconcileCooldownPath,
+} from './reconcile-cooldown-store'
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {} }
+
+let agentDir: string
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), 'reconcile-cooldown-'))
+})
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true })
+})
+
+describe('ReconcileCooldownStore', () => {
+  test('a fresh store reports no PR as cooling down', async () => {
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    expect(store.isCoolingDown('acme/widgets', 700, 1_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+  })
+
+  test('a marked PR cools down within the window and clears after it', async () => {
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    await store.markReplayed('acme/widgets', 700, 1_000)
+    expect(
+      store.isCoolingDown(
+        'acme/widgets',
+        700,
+        1_000 + DEFAULT_RECONCILE_COOLDOWN_MS - 1,
+        DEFAULT_RECONCILE_COOLDOWN_MS,
+      ),
+    ).toBe(true)
+    expect(
+      store.isCoolingDown('acme/widgets', 700, 1_000 + DEFAULT_RECONCILE_COOLDOWN_MS, DEFAULT_RECONCILE_COOLDOWN_MS),
+    ).toBe(false)
+  })
+
+  test('markers survive a reload (persist to disk)', async () => {
+    const first = await loadReconcileCooldownStore(agentDir, silentLogger)
+    await first.markReplayed('acme/widgets', 700, 5_000)
+
+    const reloaded = await loadReconcileCooldownStore(agentDir, silentLogger)
+    expect(reloaded.isCoolingDown('acme/widgets', 700, 5_000 + 1, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(true)
+  })
+
+  test('markers are keyed per repo and per PR id', async () => {
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    await store.markReplayed('acme/widgets', 700, 1_000)
+    expect(store.isCoolingDown('acme/other', 700, 1_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+    expect(store.isCoolingDown('acme/widgets', 701, 1_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+  })
+
+  test('prune drops markers for PRs no longer open in that repo', async () => {
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    await store.markReplayed('acme/widgets', 700, 1_000)
+    await store.markReplayed('acme/widgets', 800, 1_000)
+    await store.prune('acme/widgets', new Set([800]), 2_000)
+    expect(store.isCoolingDown('acme/widgets', 700, 2_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+    expect(store.isCoolingDown('acme/widgets', 800, 2_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(true)
+  })
+
+  test('prune does not touch markers from other repos', async () => {
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    await store.markReplayed('acme/widgets', 700, 1_000)
+    await store.markReplayed('acme/other', 700, 1_000)
+    await store.prune('acme/widgets', new Set<number>(), 2_000)
+    expect(store.isCoolingDown('acme/other', 700, 2_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(true)
+  })
+
+  test('prune drops markers older than the retention window even if still open', async () => {
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    await store.markReplayed('acme/widgets', 700, 0)
+    const wayLater = 8 * 24 * 60 * 60 * 1000
+    await store.prune('acme/widgets', new Set([700]), wayLater)
+    expect(store.isCoolingDown('acme/widgets', 700, wayLater, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+  })
+
+  test('a corrupted store file is ignored and starts fresh', async () => {
+    await writeFile(reconcileCooldownPath(agentDir).replace(/[^/]+$/, ''), '', 'utf8').catch(() => {})
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(join(agentDir, 'channels'), { recursive: true })
+    await writeFile(reconcileCooldownPath(agentDir), '{ not json', 'utf8')
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    expect(store.isCoolingDown('acme/widgets', 700, 1_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+  })
+
+  test('an unknown file version is ignored', async () => {
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(join(agentDir, 'channels'), { recursive: true })
+    await writeFile(
+      reconcileCooldownPath(agentDir),
+      JSON.stringify({ version: 999, markers: [{ repo: 'acme/widgets', prId: 700, lastReplayAt: 1_000 }] }),
+      'utf8',
+    )
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    expect(store.isCoolingDown('acme/widgets', 700, 1_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+  })
+
+  test('markReplayed rolls back the in-memory marker and rethrows when the write fails', async () => {
+    const { writeFile: realWriteFile } = await import('node:fs/promises')
+    await realWriteFile(join(agentDir, 'channels'), 'not a directory', 'utf8')
+
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    let threw = false
+    try {
+      await store.markReplayed('acme/widgets', 700, 1_000)
+    } catch {
+      threw = true
+    }
+    expect(threw).toBe(true)
+    expect(store.isCoolingDown('acme/widgets', 700, 1_000, DEFAULT_RECONCILE_COOLDOWN_MS)).toBe(false)
+  })
+
+  test('the persisted file is valid JSON with a version and markers array', async () => {
+    const store = await loadReconcileCooldownStore(agentDir, silentLogger)
+    await store.markReplayed('acme/widgets', 700, 1_000)
+    const raw = await readFile(reconcileCooldownPath(agentDir), 'utf8')
+    const parsed = JSON.parse(raw) as { version: number; markers: unknown[] }
+    expect(parsed.version).toBe(1)
+    expect(parsed.markers).toEqual([{ repo: 'acme/widgets', prId: 700, lastReplayAt: 1_000 }])
+  })
+})

--- a/src/channels/adapters/github/reconcile-cooldown-store.ts
+++ b/src/channels/adapters/github/reconcile-cooldown-store.ts
@@ -1,0 +1,178 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+// Durable per-PR replay cooldown for the open-PR reconcile pass.
+//
+// The reconcile pass (reconcile-open-prs.ts) runs on every adapter start() and
+// replays every open PR that has no POSTED review yet. That predicate is wrong
+// under two real conditions:
+//   1. Review work happens in a subagent that a container restart can kill
+//      before it posts — the PR still reads "unreviewed" and gets replayed on
+//      the NEXT start, re-triggering the exact work the restart just lost.
+//   2. `updatedAt`-keyed message dedup breaks the moment any activity bumps the
+//      PR's updatedAt, so an in-progress review is replayed again.
+// With a churning tunnel (cloudflare-quick mints a fresh URL every restart) the
+// adapter restarts many times a day, turning a rare-event "floor" into a
+// re-review storm.
+//
+// This store decouples replay eligibility from adapter lifecycle: a PR is
+// replayed at most once per cooldown window, keyed by a durable
+// `repo#prId` marker that survives restarts. A genuinely-missed `opened` is
+// still recovered — the periodic reconcile tick retries after the cooldown
+// expires — without a restart being required. The marker records when a replay
+// was LAUNCHED (not when a review completed): posted-review suppression stays
+// the authoritative "done" signal in reconcile-open-prs.ts; this store only
+// bounds retry frequency.
+
+const FILE_VERSION = 1
+
+// A PR that still needs review is replayed at most once per this window. Long
+// enough that ~20 restarts/day collapse to a single daily retry, short enough
+// that an interrupted review is retried the same day.
+export const DEFAULT_RECONCILE_COOLDOWN_MS = 24 * 60 * 60 * 1000
+
+// Markers older than this are pruned on save even if their PR is still open, so
+// a long-lived PR that was reviewed once cannot pin its marker forever. Any PR
+// that still needs review re-earns a fresh marker on the next eligible tick.
+const MARKER_RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+
+export type ReconcileMarker = {
+  repo: string
+  prId: number
+  lastReplayAt: number
+}
+
+type FileV1 = {
+  version: 1
+  markers: ReconcileMarker[]
+}
+
+export type ReconcileCooldownLogger = {
+  info: (msg: string) => void
+  warn: (msg: string) => void
+  error: (msg: string) => void
+}
+
+const consoleLogger: ReconcileCooldownLogger = {
+  info: (m) => console.log(m),
+  warn: (m) => console.warn(m),
+  error: (m) => console.error(m),
+}
+
+export function reconcileCooldownPath(agentDir: string): string {
+  return join(agentDir, 'channels', 'github-reconcile.json')
+}
+
+function markerKey(repo: string, prId: number): string {
+  return `${repo}#${prId}`
+}
+
+export type ReconcileCooldownStore = {
+  isCoolingDown: (repo: string, prId: number, now: number, cooldownMs: number) => boolean
+  // Flush BEFORE routing the synthetic inbound: a crash between marking and
+  // session creation must not re-trigger a replay on the next restart.
+  markReplayed: (repo: string, prId: number, now: number) => Promise<void>
+  prune: (repo: string, openPrIds: ReadonlySet<number>, now: number) => Promise<void>
+}
+
+export async function loadReconcileCooldownStore(
+  agentDir: string,
+  logger: ReconcileCooldownLogger = consoleLogger,
+): Promise<ReconcileCooldownStore> {
+  const path = reconcileCooldownPath(agentDir)
+  const markers = new Map<string, ReconcileMarker>()
+  for (const marker of await readMarkers(path, logger)) {
+    markers.set(markerKey(marker.repo, marker.prId), marker)
+  }
+
+  const flush = async (): Promise<void> => {
+    const payload: FileV1 = { version: FILE_VERSION, markers: Array.from(markers.values()) }
+    await mkdir(dirname(path), { recursive: true })
+    const tmp = `${path}.tmp`
+    await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+    await rename(tmp, path)
+  }
+
+  return {
+    isCoolingDown(repo, prId, now, cooldownMs): boolean {
+      const marker = markers.get(markerKey(repo, prId))
+      if (marker === undefined) return false
+      return now - marker.lastReplayAt < cooldownMs
+    },
+    // Roll the in-memory marker back and rethrow if the disk write fails, so the
+    // caller skips routing rather than replaying a PR with no durable record —
+    // otherwise a restart would replay it immediately, defeating the cooldown.
+    async markReplayed(repo, prId, now): Promise<void> {
+      const key = markerKey(repo, prId)
+      const previous = markers.get(key)
+      markers.set(key, { repo, prId, lastReplayAt: now })
+      try {
+        await flush()
+      } catch (err) {
+        if (previous === undefined) markers.delete(key)
+        else markers.set(key, previous)
+        throw err
+      }
+    },
+    async prune(repo, openPrIds, now): Promise<void> {
+      let changed = false
+      for (const [key, marker] of markers) {
+        const stale = now - marker.lastReplayAt >= MARKER_RETENTION_MS
+        const closed = marker.repo === repo && !openPrIds.has(marker.prId)
+        if (stale || closed) {
+          markers.delete(key)
+          changed = true
+        }
+      }
+      if (changed) {
+        try {
+          await flush()
+        } catch (err) {
+          logger.error(`[github] failed to persist reconcile cooldown: ${describe(err)}`)
+        }
+      }
+    },
+  }
+}
+
+async function readMarkers(path: string, logger: ReconcileCooldownLogger): Promise<ReconcileMarker[]> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    logger.error(`[github] ${path} corrupted: ${describe(err)}; starting fresh`)
+    return []
+  }
+  if (!isObject(parsed)) {
+    logger.warn(`[github] ${path} not an object; ignored`)
+    return []
+  }
+  const version = (parsed as { version?: unknown }).version
+  if (version !== FILE_VERSION) {
+    logger.warn(`[github] ${path} version ${String(version)} not supported (expected ${FILE_VERSION}); ignored`)
+    return []
+  }
+  const file = parsed as FileV1
+  if (!Array.isArray(file.markers)) return []
+  return file.markers.filter(isValidMarker)
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+function isValidMarker(v: unknown): v is ReconcileMarker {
+  if (!isObject(v)) return false
+  const r = v as Record<string, unknown>
+  return typeof r.repo === 'string' && typeof r.prId === 'number' && typeof r.lastReplayAt === 'number'
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/src/channels/adapters/github/reconcile-open-prs.test.ts
+++ b/src/channels/adapters/github/reconcile-open-prs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { InboundMessage } from '@/channels/types'
 
+import { DEFAULT_RECONCILE_COOLDOWN_MS, type ReconcileCooldownStore } from './reconcile-cooldown-store'
 import { reconcileOpenPrs, type ReconcileOpenPrsOptions } from './reconcile-open-prs'
 import type { TeamMembershipChecker } from './team-membership'
 
@@ -228,5 +229,143 @@ describe('reconcileOpenPrs', () => {
     const outcomes = await reconcileOpenPrs(baseOptions({ routed, repos: ['not-a-slug'], fetchImpl: spyFetch }))
     expect(fetched).toBe(false)
     expect(outcomes[0]).toMatchObject({ repo: 'not-a-slug', error: 'malformed repo slug' })
+  })
+})
+
+function fakeCooldownStore(initial: ReadonlyArray<{ repo: string; prId: number; lastReplayAt: number }> = []): {
+  store: ReconcileCooldownStore
+  markers: Map<string, number>
+  pruned: Array<{ repo: string; ids: number[] }>
+} {
+  const markers = new Map<string, number>()
+  for (const m of initial) markers.set(`${m.repo}#${m.prId}`, m.lastReplayAt)
+  const pruned: Array<{ repo: string; ids: number[] }> = []
+  const store: ReconcileCooldownStore = {
+    isCoolingDown: (repo, prId, now, cooldownMs) => {
+      const at = markers.get(`${repo}#${prId}`)
+      return at !== undefined && now - at < cooldownMs
+    },
+    markReplayed: async (repo, prId, now) => {
+      markers.set(`${repo}#${prId}`, now)
+    },
+    prune: async (repo, openPrIds) => {
+      pruned.push({ repo, ids: Array.from(openPrIds) })
+    },
+  }
+  return { store, markers, pruned }
+}
+
+describe('reconcileOpenPrs cooldown', () => {
+  test('replays a never-reconciled PR and records the marker before routing', async () => {
+    const routed: InboundMessage[] = []
+    const { store, markers } = fakeCooldownStore()
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        cooldownStore: store,
+        now: () => 1_000,
+        fetchImpl: fakeGithub([{ number: 7, id: 700 }]),
+      }),
+    )
+    expect(routed.map((m) => m.chat)).toEqual(['pr:7'])
+    expect(markers.get('acme/widgets#700')).toBe(1_000)
+  })
+
+  test('skips a PR replayed within the cooldown window (restart within cooldown)', async () => {
+    const routed: InboundMessage[] = []
+    const { store } = fakeCooldownStore([{ repo: 'acme/widgets', prId: 700, lastReplayAt: 1_000 }])
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        cooldownStore: store,
+        now: () => 1_000 + DEFAULT_RECONCILE_COOLDOWN_MS - 1,
+        fetchImpl: fakeGithub([{ number: 7, id: 700 }]),
+      }),
+    )
+    expect(routed).toHaveLength(0)
+  })
+
+  test('an updatedAt change within the cooldown does NOT re-trigger a replay', async () => {
+    const routed: InboundMessage[] = []
+    const { store } = fakeCooldownStore([{ repo: 'acme/widgets', prId: 700, lastReplayAt: 1_000 }])
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        cooldownStore: store,
+        now: () => 1_000 + 60_000,
+        fetchImpl: fakeGithub([{ number: 7, id: 700, updatedAt: '2026-02-02T00:00:00Z' }]),
+      }),
+    )
+    expect(routed).toHaveLength(0)
+  })
+
+  test('retries a still-unreviewed PR after the cooldown expires', async () => {
+    const routed: InboundMessage[] = []
+    const { store, markers } = fakeCooldownStore([{ repo: 'acme/widgets', prId: 700, lastReplayAt: 1_000 }])
+    const now = 1_000 + DEFAULT_RECONCILE_COOLDOWN_MS + 1
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        cooldownStore: store,
+        now: () => now,
+        fetchImpl: fakeGithub([{ number: 7, id: 700 }]),
+      }),
+    )
+    expect(routed.map((m) => m.chat)).toEqual(['pr:7'])
+    expect(markers.get('acme/widgets#700')).toBe(now)
+  })
+
+  test('a posted review suppresses replay even when the cooldown has expired', async () => {
+    const routed: InboundMessage[] = []
+    const { store } = fakeCooldownStore([{ repo: 'acme/widgets', prId: 700, lastReplayAt: 1_000 }])
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        cooldownStore: store,
+        now: () => 1_000 + DEFAULT_RECONCILE_COOLDOWN_MS + 1,
+        fetchImpl: fakeGithub([{ number: 7, id: 700, selfReviewed: true }]),
+      }),
+    )
+    expect(routed).toHaveLength(0)
+  })
+
+  test('prunes the cooldown store with the currently-open PR ids', async () => {
+    const routed: InboundMessage[] = []
+    const { store, pruned } = fakeCooldownStore()
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        cooldownStore: store,
+        now: () => 1_000,
+        fetchImpl: fakeGithub([
+          { number: 7, id: 700 },
+          { number: 8, id: 800, selfReviewed: true },
+        ]),
+      }),
+    )
+    expect(pruned).toEqual([{ repo: 'acme/widgets', ids: [700, 800] }])
+  })
+
+  test('does NOT route when persisting the cooldown marker fails', async () => {
+    const routed: InboundMessage[] = []
+    const { store } = fakeCooldownStore()
+    const failingStore: ReconcileCooldownStore = {
+      ...store,
+      markReplayed: async () => {
+        throw new Error('ENOSPC: disk full')
+      },
+    }
+    const warnings: string[] = []
+    await reconcileOpenPrs(
+      baseOptions({
+        routed,
+        cooldownStore: failingStore,
+        now: () => 1_000,
+        logger: { info: () => {}, warn: (m) => warnings.push(m) },
+        fetchImpl: fakeGithub([{ number: 7, id: 700 }]),
+      }),
+    )
+    expect(routed).toHaveLength(0)
+    expect(warnings.some((w) => w.includes('cooldown persist failed'))).toBe(true)
   })
 })

--- a/src/channels/adapters/github/reconcile-open-prs.ts
+++ b/src/channels/adapters/github/reconcile-open-prs.ts
@@ -3,6 +3,7 @@ import type { InboundMessage } from '@/channels/types'
 
 import type { GithubAuthContext } from './auth'
 import { GITHUB_API_BASE, githubJsonHeaders } from './auth-pat'
+import { DEFAULT_RECONCILE_COOLDOWN_MS, type ReconcileCooldownStore } from './reconcile-cooldown-store'
 import type { TeamMembershipChecker } from './team-membership'
 
 // Catches up on review work that a live webhook delivery missed. The github
@@ -32,6 +33,12 @@ export type ReconcileOpenPrsOptions = {
   // tests that don't exercise team requests; treated as "not a member".
   isBotInTeam?: TeamMembershipChecker
   fetchImpl?: typeof fetch
+  // When provided, a PR that still needs review is replayed at most once per
+  // `cooldownMs`, keyed durably by `repo#prId` so restarts don't re-trigger it.
+  // Omitted in tests that assert the raw replay decision.
+  cooldownStore?: ReconcileCooldownStore
+  cooldownMs?: number
+  now?: () => number
 }
 
 export type ReconcileOutcome = { repo: string; scanned: number; replayed: number } | { repo: string; error: string }
@@ -79,12 +86,36 @@ async function reconcileRepo(
   const token = await options.token({ repoSlug: repo })
   const prs = await fetchOpenPrs(fetchImpl, token, target)
 
+  const cooldownStore = options.cooldownStore
+  const cooldownMs = options.cooldownMs ?? DEFAULT_RECONCILE_COOLDOWN_MS
+  const now = options.now ?? Date.now
+
   let replayed = 0
   for (const pr of prs) {
     const needs = await prNeedsReview({ pr, options, target, token, selfLogin, decoyLogin, fetchImpl })
     if (!needs) continue
+    if (cooldownStore !== undefined) {
+      if (cooldownStore.isCoolingDown(repo, pr.id, now(), cooldownMs)) continue
+      try {
+        // Persist the marker before routing: if the write fails the marker is
+        // rolled back and this throws, so we skip the route rather than replay a
+        // PR with no durable record (a restart would otherwise replay it again).
+        await cooldownStore.markReplayed(repo, pr.id, now())
+      } catch (err) {
+        options.logger.warn(
+          `[github] reconcile ${repo}: skipping PR #${pr.number} replay, cooldown persist failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        )
+        continue
+      }
+    }
     options.route(buildSyntheticInbound(pr, target))
     replayed += 1
+  }
+
+  if (cooldownStore !== undefined) {
+    await cooldownStore.prune(repo, new Set(prs.map((pr) => pr.id)), now())
   }
   return { repo, scanned: prs.length, replayed }
 }


### PR DESCRIPTION
## Background

The GitHub adapter's open-PR reconcile pass (`reconcile-open-prs.ts`, #650) runs on **every** adapter `start()` and replays every open PR that has no *posted* review as a synthetic inbound. It was designed as a rare-event reliability floor for missed `pull_request.opened` webhooks, assuming restarts are infrequent.

On a production agent watching 6 repos with `review.on: 'opened'` over a `cloudflare-quick` tunnel, that assumption breaks. The agent restarted ~20×/day (the tunnel mints a fresh `*.trycloudflare.com` URL on every restart, which restarts the adapter — so reconcile fires **twice per boot**). One day's session log: **107 channel wake sessions → 378 subagent sessions → 1,847 bash calls**, with hours-old PRs showing as "running / recently ran" in `typeclaw inspect` because reconcile kept minting fresh sessions for them.

Two root causes turn the floor into a storm:

1. **`botAlreadyReviewed()` only counts a posted review object.** Review work runs in a subagent a restart can kill before it posts, so the PR still reads "unreviewed" and is replayed on the next `start()` — re-triggering the exact work the restart just lost.
2. **The `pr-<id>-reconcile-<updatedAt>` dedup breaks the moment any activity bumps `updatedAt`,** so an in-progress review is replayed again with a fresh id.

## Summary

Decouple replay *eligibility* from adapter lifecycle with a durable per-PR cooldown marker (`channels/github-reconcile.json`), keyed by `repo#prId`, recording when a replay was **launched**:

- A PR that still needs review is replayed **at most once per cooldown window (24h)** across restarts. ~20 restarts/day collapse to a single daily retry.
- The marker is written **before** routing the synthetic inbound, so a crash between marking and session creation can't re-trigger on the next restart.
- The reconcile pass now also runs on a **30-min periodic tick** (bounded by the same cooldown), so a genuinely-missed `opened` recovers **without needing another restart** — the previous behavior depended on a restart to re-scan.

**Why a cooldown marker and not existing state?** There is no suitable durable "review in progress / recently handled" store to reuse: `channels/sessions.json` records last-*engaged* time (not review intent) and is wiped on stale-rollover; the verdict coordinator, delivery dedup, and turn ledger are all in-memory and gone on restart. Posted-review suppression stays the authoritative "done" signal; the marker only *bounds retry frequency*.

**Why keep reconcile at all (vs. relying on `recover-failed-deliveries`)?** The delivery-recovery sweep can only recover events GitHub attempted to deliver to a *registered* hook, within its ~3-day delivery-log retention. It cannot cover a PR opened before any hook existed (first boot / new repo) or older than retention. Reconcile remains the only floor for those.

## What this does NOT do

- Does **not** make review work durable across restarts. If a review subagent is killed mid-flight, the PR is retried after the cooldown — not resumed. That deeper durability work is intentionally out of scope (it would turn a bounded fix into a large workflow-resumption project).
- Does **not** change the live webhook path, the delivery-recovery sweep, or posted-review suppression semantics.
- Does **not** address the underlying ~20-restarts/day / tunnel-URL-churn amplifier — that's a separate operational investigation.

## Review notes

- **Load-bearing:** `reconcile-cooldown-store.ts` — markers persist to `channels/github-reconcile.json` (atomic tmp+rename, versioned, corrupt/unknown-version tolerated by starting fresh). The `markReplayed`-before-`route` ordering in `reconcile-open-prs.ts` is a crash-safety invariant; don't reorder it.
- **Eligibility signal:** `updatedAt` is now informational only — it no longer determines replay eligibility or replay identity. The durable `repo#prId` marker does.
- **Pruning:** markers for closed PRs (not in the current open set) and markers past a 7-day retention are dropped on each successful scan, keeping the store bounded.
- **Periodic tick:** the 30-min re-run is what preserves the missed-webhook floor without a restart; `reconcileIntervalMs: 0` disables it (the `start()` pass still fires). Existing timer-count lifecycle tests set `reconcileIntervalMs: 0` to isolate their subject timer.
- **Tests:** cooldown-store unit tests (persist/reload, per-repo/per-PR keying, prune, retention, corrupt/unknown-version); reconcile cooldown behavior (first replay, restart-within-cooldown, `updatedAt`-change, retry-after-expiry, posted-review-suppresses, prune); lifecycle integration (restart within cooldown doesn't double-replay; periodic tick re-runs the pass).
