### PR TITLE
Allow git stash in the privileged sandbox

### DIFF
--- a/src/sandbox/privileged-runtime.test.ts
+++ b/src/sandbox/privileged-runtime.test.ts
@@ -208,6 +208,19 @@ describe('resolvePrivilegedSandboxRuntime', () => {
     expect(runtime.env.GIT_CONFIG_NOSYSTEM).toBe('1')
   })
 
+  test('supplies sanitized identity for local git stash operations', async () => {
+    const runtime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: {},
+      command: 'git stash push',
+    })
+
+    expect(runtime.mounts.some((mount) => mount.type === 'ro-bind')).toBe(true)
+    expect(runtime.env.GIT_CONFIG_GLOBAL).toBe('/tmp/.gitconfig')
+    await cleanupPrivilegedSandboxRuntime(runtime)
+  })
+
   test('removes every generated identity directory across repeated calls', async () => {
     const generated: string[] = []
     for (let i = 0; i < 32; i++) {

--- a/src/sandbox/privileged-runtime.ts
+++ b/src/sandbox/privileged-runtime.ts
@@ -20,6 +20,7 @@ const SAFE_GIT_SUBCOMMANDS = new Set([
   'restore',
   'rev-parse',
   'show',
+  'stash',
   'status',
   'switch',
   'symbolic-ref',


### PR DESCRIPTION
## Background

`SAFE_GIT_SUBCOMMANDS` in `src/sandbox/privileged-runtime.ts` gates which `git` subcommands get a sanitized, sandboxed identity (a generated `.gitconfig` + read-only mount) when the agent's bash sandbox launches a privileged git invocation. `stash` was missing from the list, so `git stash` and `git stash push` fell through to the default (unprivileged) runtime — no sanitized identity, no read-only credential mount — even though `stash` is a purely local, no-network git operation with the same trust profile as `commit`, `restore`, or `reset`, which are already allowed.

## Summary

Add `stash` to `SAFE_GIT_SUBCOMMANDS`. This grants the sanitized identity + read-only mount runtime to local `git stash` operations without touching network-auth-capable subcommands (`push`, `pull`, `clone`, `fetch` stay excluded) — the allowlist stays scoped to local repository operations.

## What this does NOT do

- Does not grant `git stash` (or any subcommand) access to network credentials or remote auth. The allowlist only governs sanitized-identity/mount provisioning for local operations.
- Does not change the allowlist for any other subcommand.

## Review notes

- Load-bearing line: `src/sandbox/privileged-runtime.ts` — `stash` added to `SAFE_GIT_SUBCOMMANDS`.
- New test: `src/sandbox/privileged-runtime.test.ts` — `supplies sanitized identity for local git stash operations` directly exercises `git stash push` through `resolvePrivilegedSandboxRuntime` and asserts the ro-bind mount and `GIT_CONFIG_GLOBAL` are present.
- Verification: full guard suite 11702 passed, 25 skipped, 0 failed; focused sandbox suite 16 passed; `bun run typecheck` / `bun run lint` / `bun run format` all clean.