### PR TITLE
Stop claiming Docker is stopped when it is only unreachable

### DIFF
--- a/src/container/docker-app.test.ts
+++ b/src/container/docker-app.test.ts
@@ -161,9 +161,35 @@ describe('renderDockerUnavailableGuidance', () => {
       { ok: false, reason: 'daemon-down', detail: 'unix:///home/user/.orbstack/run/docker.sock' },
       { platform: 'darwin', nudge: 'orbstack', installed: ['orbstack'] },
     )
-    expect(result.summary).toBe('Docker is not running. OrbStack is installed but not started.')
+    expect(result.summary).toBe(
+      "Docker daemon is not reachable. Start OrbStack, or check its connection if it's already running.",
+    )
     expect(result.lines.join('\n')).toContain('Open OrbStack')
     expect(result.lines.join('\n')).toContain('orb start')
+  })
+
+  // The dead-end this PR fixes: OrbStack IS running but `docker info` fails
+  // because the CLI is pointed at a stale context / DOCKER_HOST (the SSH case).
+  // The message must NOT claim the app is stopped, and must surface the
+  // context/endpoint recovery path plus the sanitized Docker error.
+  test('daemon-down never claims the runtime is stopped and offers a context recovery path', () => {
+    const detail = 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?'
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail },
+      { platform: 'darwin', nudge: 'orbstack', installed: ['orbstack'] },
+    )
+    const body = result.lines.join('\n')
+    expect(result.summary).not.toContain('not started')
+    expect(result.summary).not.toContain('is not running')
+    // The summary must itself tell the user how to reach the desired state,
+    // not just diagnose — it names the start action AND the already-running fork.
+    expect(result.summary).toContain('Start OrbStack')
+    expect(result.summary).toContain('already running')
+    expect(body).toContain('already running')
+    expect(body).toContain('docker context ls')
+    expect(body).toContain('DOCKER_HOST')
+    expect(body).toContain('DOCKER_CONTEXT')
+    expect(body).toContain('Cannot connect to the Docker daemon')
   })
 
   test('daemon-down with docker-desktop nudge on macOS', () => {
@@ -171,7 +197,9 @@ describe('renderDockerUnavailableGuidance', () => {
       { ok: false, reason: 'daemon-down', detail: '' },
       { platform: 'darwin', nudge: 'docker-desktop', installed: ['docker-desktop'] },
     )
-    expect(result.summary).toBe('Docker is not running. Docker Desktop is installed but not started.')
+    expect(result.summary).toBe(
+      "Docker daemon is not reachable. Start Docker Desktop, or check its connection if it's already running.",
+    )
     expect(result.lines.join('\n')).toContain('open -a Docker')
   })
 
@@ -180,7 +208,9 @@ describe('renderDockerUnavailableGuidance', () => {
       { ok: false, reason: 'daemon-down', detail: 'npipe:////./pipe/docker_engine' },
       { platform: 'win32', nudge: 'docker-desktop', installed: ['docker-desktop'] },
     )
-    expect(result.summary).toBe('Docker is not running. Docker Desktop is installed but not started.')
+    expect(result.summary).toBe(
+      "Docker daemon is not reachable. Start Docker Desktop, or check its connection if it's already running.",
+    )
     expect(result.lines.join('\n')).toContain('Start menu')
   })
 
@@ -197,7 +227,9 @@ describe('renderDockerUnavailableGuidance', () => {
       { ok: false, reason: 'daemon-down', detail: '' },
       { platform: 'darwin', nudge: null, installed: ['docker-desktop', 'orbstack'] },
     )
-    expect(result.summary).toBe('Docker is not running.')
+    expect(result.summary).toBe(
+      "Docker daemon is not reachable. Start Docker Desktop, OrbStack, or check your docker connection if it's already running.",
+    )
     expect(result.lines.join('\n')).toContain('Docker Desktop, OrbStack')
   })
 
@@ -207,6 +239,14 @@ describe('renderDockerUnavailableGuidance', () => {
       { platform: 'linux', nudge: null, installed: [] },
     )
     expect(result.lines.join('\n')).toContain('sudo systemctl start docker')
+  })
+
+  test('daemon-down omits the "Docker reported" line when the detail is empty', () => {
+    const result = renderDockerUnavailableGuidance(
+      { ok: false, reason: 'daemon-down', detail: '' },
+      { platform: 'darwin', nudge: 'orbstack', installed: ['orbstack'] },
+    )
+    expect(result.lines.join('\n')).not.toContain('Docker reported:')
   })
 
   test('retryHint is appended when provided', () => {

--- a/src/container/docker-app.ts
+++ b/src/container/docker-app.ts
@@ -1,18 +1,22 @@
 import { existsSync } from 'node:fs'
 
-import { getBun } from './shared'
+import { getBun, sanitizeDockerStderr } from './shared'
 import type { DockerAvailability } from './shared'
 
 // Detection + friendly guidance for "Docker is not reachable".
 //
 // `checkDockerAvailable` (in ./shared) already tells us WHETHER docker works and
 // discriminates `binary-missing` (no `docker` on PATH) from `daemon-down` (CLI
-// present, daemon refused the connection — the common "Docker Desktop / OrbStack
-// installed but not started" case on macOS). What it does NOT do is tell the
-// user WHICH runtime to nudge. This module fills that gap: it classifies the
-// likely runtime and renders a short, copy-pasteable instruction instead of
-// leaking the raw daemon error (which on OrbStack embeds a per-user socket path
-// under the user's home dir — noise the user can't act on).
+// present, the selected Docker endpoint refused the connection). That covers the
+// common "Docker Desktop / OrbStack installed but not started" case on macOS —
+// but `docker info` failing proves only that the CONFIGURED ENDPOINT is
+// unreachable, NOT that the runtime process is stopped: a running OrbStack whose
+// CLI is pointed at a stale `desktop-linux` context (or an SSH session missing
+// the interactive shell's DOCKER_HOST) produces the exact same connection error.
+// So this module must not assert the app is "not started" — it nudges the likely
+// runtime to start AND surfaces the context/endpoint recovery path plus the raw
+// (sanitized) Docker error, so a user who knows the runtime is already up isn't
+// sent into a dead-end "start it" loop.
 //
 // Classification priority (most → least authoritative):
 //   1. The configured socket: `DOCKER_HOST` or the socket path inside the raw
@@ -121,8 +125,8 @@ export function detectInstalledDockerApps(probes: DockerAppProbes = {}): DockerA
 // Docker Desktop's GUI launcher (`Docker Desktop.exe`) across the MSI, 32-bit,
 // and per-user install layouts confirmed by the Docker Desktop installer and
 // PowerShell's own probing scripts. Probing the exe (not just `docker` on PATH)
-// is what lets us say "Docker Desktop is installed but not started" when the
-// daemon is down — a stale PATH can hide the CLI even when Desktop is present.
+// is what lets us name Docker Desktop as the runtime to nudge when the daemon is
+// unreachable — a stale PATH can hide the CLI even when Desktop is present.
 function windowsDockerDesktopInstalled(env: NodeJS.ProcessEnv, exists: (path: string) => boolean): boolean {
   const programFiles = env.ProgramW6432 ?? env.ProgramFiles ?? 'C:\\Program Files'
   const programFilesX86 = env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)'
@@ -231,23 +235,48 @@ export function renderDockerUnavailableGuidance(
     return { summary: 'Docker is not installed.', lines }
   }
 
-  // daemon-down
+  // daemon-down: the configured Docker endpoint refused the connection. We can
+  // nudge the likely runtime to start, but must NOT claim it's stopped — the
+  // same error fires when the runtime is up and the CLI is on the wrong context.
   const lines: string[] = []
   let summary: string
   if (nudge !== null) {
-    summary = `Docker is not running. ${dockerAppLabel(nudge)} is installed but not started.`
+    const label = dockerAppLabel(nudge)
+    summary = `Docker daemon is not reachable. Start ${label}, or check its connection if it's already running.`
     lines.push(...startInstructions(nudge, platform))
   } else if (installed.length > 1) {
     const names = installed.map(dockerAppLabel).join(', ')
-    summary = 'Docker is not running.'
+    summary = `Docker daemon is not reachable. Start ${names}, or check your docker connection if it's already running.`
     lines.push(`Detected: ${names}. Start whichever one you use, then retry.`)
   } else {
-    summary = 'Docker is installed but the daemon is not reachable.'
+    summary =
+      "Docker daemon is not reachable. Start your Docker runtime, or check your docker connection if it's already running."
     lines.push(...genericStartInstructions(platform))
   }
+
+  lines.push('', ...alreadyRunningRecovery(availability.detail))
 
   if (retryHint) {
     lines.push('', retryHint)
   }
   return { summary, lines }
+}
+
+// The recovery path for the case the start-instructions can't fix: the runtime
+// is already running but `docker info` still fails because the CLI is pointed at
+// an unreachable endpoint (stale `docker context`, a leftover `DOCKER_HOST`, or
+// a non-interactive/SSH shell missing the interactive env). We surface the
+// configuration knobs to check plus the sanitized Docker error so the endpoint
+// stays visible instead of being hidden as "noise".
+function alreadyRunningRecovery(detail: string): string[] {
+  const lines = [
+    'If it is already running, your docker CLI may be pointed at the wrong endpoint',
+    '(common over SSH or in non-interactive shells).',
+    'Check `docker context ls`, `DOCKER_CONTEXT`, and `DOCKER_HOST`.',
+  ]
+  const reported = sanitizeDockerStderr(detail)
+  if (reported !== '') {
+    lines.push(`Docker reported: ${reported}`)
+  }
+  return lines
 }

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -61,12 +61,15 @@ function dockerDaemon(exec: DockerExec): DoctorCheck {
       if (result.ok) return { status: 'ok', message: 'docker info responded' }
       return {
         status: 'error',
-        message: result.reason === 'binary-missing' ? 'docker binary missing on $PATH' : 'docker daemon down',
+        message: result.reason === 'binary-missing' ? 'docker binary missing on $PATH' : 'docker daemon not reachable',
         details: [result.detail],
         fix:
           result.reason === 'binary-missing'
             ? { description: 'Install Docker (Docker Desktop, OrbStack, or docker-ce).' }
-            : { description: 'Start the Docker daemon (Docker Desktop, OrbStack, or `systemctl start docker`).' },
+            : {
+                description:
+                  'Start the Docker runtime (Docker Desktop, OrbStack, or `systemctl start docker`). If it is already running, check `docker context ls`, `DOCKER_CONTEXT`, and `DOCKER_HOST`.',
+              },
       }
     },
   }


### PR DESCRIPTION
## Problem

`typeclaw status` (and every Docker-preflight command) prints:

```
✖ Docker is not running. OrbStack is installed but not started.
Open OrbStack (from Applications or Spotlight), then retry.
Or from a terminal: `orb start`
```

…even when OrbStack **is** running. The user is sent into a dead-end loop: told to start OrbStack, but `orb start` reports *"OrbStack is already running. Docker engine is ready to use."*

## Root cause

`checkDockerAvailable` probes `docker info --format {{.ServerVersion}}` and collapses every non-zero exit into `daemon-down`. But `docker info` failing proves only that the **configured endpoint is unreachable**, *not* that the runtime process is stopped. The same connection error fires when:

- the docker CLI is pointed at a stale `docker context` (e.g. a leftover `desktop-linux`), or
- a `DOCKER_HOST` points at a dead socket, or
- the command runs over **SSH / a non-interactive shell** that never loaded the interactive shell's OrbStack env.

The old guidance then asserted *"OrbStack is installed but not started"* purely from install-state (`/Applications/OrbStack.app` exists). That claim is a guess presented as fact, and the one actionable signal — the raw daemon error containing the socket/endpoint — was deliberately discarded as "noise."

## Fix

Keep the single `daemon-down` state (per design review: `docker info` can't distinguish *stopped* from *misconfigured*, so a new state would be a guess), but make the message honest:

- **Evidence-based summary**: `Docker daemon is not reachable. OrbStack was detected.` — no more false "not started" claim.
- **Start instructions stay first** — the common case (runtime genuinely down) still gets the direct `orb start` / `open -a Docker` step as the primary action.
- **Append a recovery path** for the SSH/context case: check `docker context ls`, `DOCKER_CONTEXT`, and `DOCKER_HOST`, plus the **sanitized** Docker error (via the existing `sanitizeDockerStderr`) so the endpoint is visible instead of hidden.
- **`doctor` aligned**: `docker.daemon-reachable` now reports "docker daemon not reachable" with the same context/endpoint recovery hint.

## Why not split into two reasons

`docker info` failing is not evidence about whether the process is running — a non-default `orbstack`/`desktop-linux`/`colima` context can be entirely correct while its runtime is stopped, and a stopped daemon and a stale socket commonly emit the identical connection error. A second `docker context` probe wouldn't establish causality either. So we keep one failure state and simply stop over-claiming, which fixes the dead-end without inventing a guessed state.

## Tests

- Reworked the `renderDockerUnavailableGuidance` daemon-down assertions to the new honest phrasing.
- **New regression test** pinning the exact dead-end this PR fixes: OrbStack-running-but-unreachable must NOT claim the app is stopped, MUST surface `docker context ls` / `DOCKER_HOST` / `DOCKER_CONTEXT`, and MUST echo the sanitized Docker error.
- New test that the `Docker reported:` line is omitted when the detail is empty.

`bun run typecheck` / `lint` / `format:check` clean; full `bun run test` green (11801 pass, 0 fail).

## Note

Docker CLI stderr, env-var names, context names, and socket paths are machine-generated protocol/tool output — English matching is correct here (same rationale as the existing credential-helper detection), so the multi-language rule does not apply.