### PR TITLE
Bound session-file I/O so a large sessions/ folder can't EMFILE

### DIFF
--- a/src/inspect/replay.test.ts
+++ b/src/inspect/replay.test.ts
@@ -607,4 +607,37 @@ describe('replayJsonl (real file in tmpdir)', () => {
     const events = await collect(replayJsonl('/this/path/does/not/exist.jsonl', { onWarn: (m) => warnings.push(m) }))
     expect(events).toEqual([])
   })
+
+  test('breaking early many times releases the stream each time (no FD leak, no throw)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'typeclaw-inspect-replay-'))
+    try {
+      const file = join(dir, 'big.jsonl')
+      const lines = [
+        JSON.stringify({
+          type: 'custom',
+          customType: 'typeclaw.session-meta',
+          data: { origin: { kind: 'tui' } },
+          timestamp: 0,
+        }),
+      ]
+      for (let i = 0; i < 5000; i++) {
+        lines.push(JSON.stringify({ type: 'message', message: { role: 'user', content: `m${i}`, timestamp: i } }))
+      }
+      await writeFile(file, lines.join('\n') + '\n')
+
+      // given a consumer that reads only the first event then breaks — the same
+      // shape peekSession uses. Repeated far past a 256-FD ceiling, each iteration
+      // must free its descriptor via the reader's finally-cancel, or this EMFILEs.
+      for (let iter = 0; iter < 500; iter++) {
+        let first: InspectEvent | undefined
+        for await (const ev of replayJsonl(file)) {
+          first = ev
+          break
+        }
+        expect(first?.cat).toBe('meta')
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/inspect/replay.ts
+++ b/src/inspect/replay.ts
@@ -311,18 +311,30 @@ function describeErr(err: unknown): string {
   return String(err)
 }
 
+// Explicit reader + `finally` cancel so a consumer that breaks early (peekSession
+// stops after the first meta + a few user turns) releases the file descriptor
+// deterministically, not relying on async-iterator finalization. Load-bearing when
+// tens of thousands of session files are peeked under a low `ulimit -n`.
 async function* streamLines(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = stream.getReader()
   const decoder = new TextDecoder()
   let buf = ''
-  for await (const chunk of stream) {
-    buf += decoder.decode(chunk, { stream: true })
-    let nl = buf.indexOf('\n')
-    while (nl !== -1) {
-      const line = buf.slice(0, nl)
-      buf = buf.slice(nl + 1)
-      yield line
-      nl = buf.indexOf('\n')
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      let nl = buf.indexOf('\n')
+      while (nl !== -1) {
+        const line = buf.slice(0, nl)
+        buf = buf.slice(nl + 1)
+        yield line
+        nl = buf.indexOf('\n')
+      }
     }
+    if (buf.length > 0) yield buf
+  } finally {
+    await reader.cancel().catch(() => {})
+    reader.releaseLock()
   }
-  if (buf.length > 0) yield buf
 }

--- a/src/inspect/session-list.test.ts
+++ b/src/inspect/session-list.test.ts
@@ -270,6 +270,57 @@ describe('resolveSession', () => {
     if (out.ok) throw new Error('unreachable')
     expect(out.reason).toBe('not-found')
   })
+
+  test('an exact id match peeks ONLY the matched file, not every session on disk', async () => {
+    // given the target session plus a decoy whose body is malformed JSONL: if
+    // resolveSession peeked every file (the old FD-exhausting behavior) the decoy
+    // would surface a parse warning. Reading only the matched candidate stays silent.
+    await writeSession(`a_${UUID_A}.jsonl`, [metaLine({ kind: 'tui' }), userLine('target')], 2000)
+    await writeSession(`b_${UUID_B}.jsonl`, ['{ this is not valid json'], 1000)
+
+    const warnings: string[] = []
+    const out = await resolveSession(dir, UUID_A, (m) => warnings.push(m))
+
+    expect(out.ok).toBe(true)
+    if (!out.ok) throw new Error('unreachable')
+    expect(out.summary.sessionId).toBe(UUID_A)
+    expect(out.summary.firstPrompt).toBe('target')
+    expect(warnings).toEqual([])
+  })
+
+  test('a not-found id peeks no files (all bodies stay unread)', async () => {
+    await writeSession(`a_${UUID_A}.jsonl`, ['{ malformed'], 1000)
+    await writeSession(`b_${UUID_B}.jsonl`, ['{ malformed too'], 2000)
+
+    const warnings: string[] = []
+    const out = await resolveSession(dir, 'deadbeef-0000-7000-9000-000000000000', (m) => warnings.push(m))
+
+    expect(out.ok).toBe(false)
+    expect(warnings).toEqual([])
+  })
+
+  test('scales past the FD ceiling: a large directory resolves without EMFILE', async () => {
+    // given far more sessions than a low `ulimit -n` (256) would allow if each were
+    // opened concurrently — the bug this guards is an unbounded open() fan-out.
+    const ids: string[] = []
+    for (let i = 0; i < 400; i++) {
+      const id = `019e0000-0000-7000-9000-${i.toString().padStart(12, '0')}`
+      ids.push(id)
+      await writeSession(
+        `2026-05-22T00-00-00-000Z_${id}.jsonl`,
+        [metaLine({ kind: 'tui' }), userLine(`s${i}`)],
+        1000 + i,
+      )
+    }
+
+    const target = ids[200]!
+    const out = await resolveSession(dir, target)
+
+    expect(out.ok).toBe(true)
+    if (!out.ok) throw new Error('unreachable')
+    expect(out.summary.sessionId).toBe(target)
+    expect(out.summary.firstPrompt).toBe('s200')
+  })
 })
 
 describe('mergeLiveSessions', () => {

--- a/src/inspect/session-list.ts
+++ b/src/inspect/session-list.ts
@@ -39,36 +39,68 @@ export type ListSessionsOptions = {
 // character so empty-id filenames like `_.jsonl` don't slip through.
 const FILENAME_PATTERN = /^(?:.*_)?([^_/\\\s][^/\\\s]*)\.jsonl$/
 
-export async function listSessions(opts: ListSessionsOptions): Promise<SessionSummary[]> {
-  const entries = await readSessionFiles(opts.sessionsDir, opts.onWarn)
-  const withStats = await Promise.all(
-    entries.map(async (entry) => {
-      const s = await safeStat(entry.path)
-      if (s === null) return null
-      const mtimeMs = s.mtimeMs
-      if (opts.sinceMs !== undefined && mtimeMs < opts.sinceMs) return null
-      return { ...entry, mtimeMs }
-    }),
-  )
-  const valid = withStats.filter(
-    (v): v is { path: string; basename: string; sessionId: string; mtimeMs: number } => v !== null,
-  )
-  valid.sort((a, b) => b.mtimeMs - a.mtimeMs)
-  const limited = opts.limit !== undefined ? valid.slice(0, opts.limit) : valid
+// Bounds concurrent per-file I/O. An agent folder can hold tens of thousands of
+// session files, and an unbounded `Promise.all` over them opens one file
+// descriptor per concurrent stat/stream — enough to blow past a 256 `ulimit -n`
+// and crash the process with EMFILE. 32 keeps throughput high while staying well
+// under any sane FD ceiling.
+const SESSION_IO_CONCURRENCY = 32
 
-  return Promise.all(
-    limited.map(async ({ path, basename, sessionId, mtimeMs }) => {
-      const peek = await peekSession(path, opts.onWarn)
-      return {
-        sessionId,
-        sessionFile: path,
-        basename,
-        mtimeMs,
-        origin: peek.origin,
-        firstPrompt: peek.firstPrompt,
-      }
-    }),
-  )
+// A dependency-free bounded worker pool: `concurrency` workers pull from a shared
+// cursor until the list is drained, preserving input order in the result.
+async function mapConcurrent<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = next++
+      if (index >= items.length) return
+      results[index] = await fn(items[index]!, index)
+    }
+  }
+  const workerCount = Math.min(concurrency, items.length)
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
+  return results
+}
+
+type StatEntry = { path: string; basename: string; sessionId: string; mtimeMs: number }
+
+// Split from listSessions so resolveSession can match ids first and peek only the
+// candidates, instead of reading every file body on disk. Reads no file content.
+async function statSessionFiles(opts: ListSessionsOptions): Promise<StatEntry[]> {
+  const entries = await readSessionFiles(opts.sessionsDir, opts.onWarn)
+  const withStats = await mapConcurrent(entries, SESSION_IO_CONCURRENCY, async (entry) => {
+    const s = await safeStat(entry.path)
+    if (s === null) return null
+    const mtimeMs = s.mtimeMs
+    if (opts.sinceMs !== undefined && mtimeMs < opts.sinceMs) return null
+    return { ...entry, mtimeMs }
+  })
+  const valid = withStats.filter((v): v is StatEntry => v !== null)
+  valid.sort((a, b) => b.mtimeMs - a.mtimeMs)
+  return valid
+}
+
+async function summarizeEntry(entry: StatEntry, onWarn?: (msg: string) => void): Promise<SessionSummary> {
+  const peek = await peekSession(entry.path, onWarn)
+  return {
+    sessionId: entry.sessionId,
+    sessionFile: entry.path,
+    basename: entry.basename,
+    mtimeMs: entry.mtimeMs,
+    origin: peek.origin,
+    firstPrompt: peek.firstPrompt,
+  }
+}
+
+export async function listSessions(opts: ListSessionsOptions): Promise<SessionSummary[]> {
+  const valid = await statSessionFiles(opts)
+  const limited = opts.limit !== undefined ? valid.slice(0, opts.limit) : valid
+  return mapConcurrent(limited, SESSION_IO_CONCURRENCY, (entry) => summarizeEntry(entry, opts.onWarn))
 }
 
 // Overlay container-registry sessions onto the disk listing. A live session
@@ -105,17 +137,23 @@ export async function resolveSession(
   sessionIdOrPrefix: string,
   onWarn?: (msg: string) => void,
 ): Promise<ResolveResult> {
-  const all = await listSessions({ sessionsDir, ...(onWarn !== undefined ? { onWarn } : {}) })
-  const exact = all.find((s) => s.sessionId === sessionIdOrPrefix)
-  if (exact !== undefined) return { ok: true, summary: exact }
+  // Match on stat-only metadata (filename-derived id + mtime) first, then peek
+  // ONLY the matched candidates. Peeking every session to find one by id/prefix
+  // opened a file descriptor per file — tens of thousands at once on a busy agent,
+  // which crashes with EMFILE. Id resolution never needs a file's body.
+  const entries = await statSessionFiles({ sessionsDir, ...(onWarn !== undefined ? { onWarn } : {}) })
+
+  const exact = entries.find((e) => e.sessionId === sessionIdOrPrefix)
+  if (exact !== undefined) return { ok: true, summary: await summarizeEntry(exact, onWarn) }
 
   if (sessionIdOrPrefix.length < MIN_PREFIX_LENGTH || !isSessionIdShape(sessionIdOrPrefix)) {
     return { ok: false, reason: 'not-found', matches: [] }
   }
-  const prefixMatches = all.filter((s) => s.sessionId.startsWith(sessionIdOrPrefix))
+  const prefixMatches = entries.filter((e) => e.sessionId.startsWith(sessionIdOrPrefix))
   if (prefixMatches.length === 0) return { ok: false, reason: 'not-found', matches: [] }
-  if (prefixMatches.length === 1) return { ok: true, summary: prefixMatches[0]! }
-  return { ok: false, reason: 'ambiguous', matches: prefixMatches }
+  if (prefixMatches.length === 1) return { ok: true, summary: await summarizeEntry(prefixMatches[0]!, onWarn) }
+  const matches = await mapConcurrent(prefixMatches, SESSION_IO_CONCURRENCY, (e) => summarizeEntry(e, onWarn))
+  return { ok: false, reason: 'ambiguous', matches }
 }
 
 const SESSION_ID_SHAPE = /^[^_/\\\s][^/\\\s]*$/

--- a/src/usage/scan.ts
+++ b/src/usage/scan.ts
@@ -82,9 +82,15 @@ async function* readSessionFile(file: string, opts: ScanOptions): AsyncGenerator
   // Stays 'unknown' for legacy files (no stamp at all) so usage attribution
   // surfaces them as a distinct bucket rather than dropping the rows.
   const ctx: ParseCtx = { originKind: 'unknown', originPinned: false }
+  // Explicit reader + `finally` cancel so a consumer that abandons the generator
+  // early (or an exception mid-scan) releases the file descriptor deterministically
+  // instead of leaking it until GC — the scan runs over every session file on disk.
+  const reader = stream.getReader()
   try {
-    for await (const chunk of stream) {
-      buf += decoder.decode(chunk, { stream: true })
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
       let nl = buf.indexOf('\n')
       while (nl !== -1) {
         const line = buf.slice(0, nl)
@@ -97,6 +103,9 @@ async function* readSessionFile(file: string, opts: ScanOptions): AsyncGenerator
   } catch (err) {
     opts.onWarn?.(`error reading ${basename}: ${describeFileError(err)}`)
     return
+  } finally {
+    await reader.cancel().catch(() => {})
+    reader.releaseLock()
   }
   // Tail line with no terminating \n: only emit if it parses cleanly so a
   // half-written record from a live writer is silently skipped (parseLine


### PR DESCRIPTION
## Background

On a long-running agent (the PR-reviewer, ~920 session-list/inspect operations/day over a `sessions/` folder that had grown to ~23.7k `.jsonl` files) the process began failing with `EMFILE: too many open files` under a soft `ulimit -n` of 256. The failure is not cosmetic: once FDs are exhausted, ordinary file reads (`EMFILE … open '/agent/AGENTS.md'`), the local git-metadata scan (`fatal: not a git repository`), and DNS (`getaddrinfo ESERVFAIL`) all start failing in the same turn. On the reviewer agent this cascaded into it concluding *"the review environment cannot read the repository"* and leaving a stale blocking review it couldn't clear.

Root cause is an **unbounded concurrent open() fan-out over the session directory**, not a slow leak:

- `listSessions` did `Promise.all(entries.map(stat))` **and** `Promise.all(limited.map(peekSession))` with no concurrency cap.
- `resolveSession` called `listSessions` with **no limit**, so resolving a single session by id/prefix `peek`ed *every* file on disk — opening one `Bun.file().stream()` (and thus one FD) per file, all at once. Tens of thousands of simultaneous opens trivially exceed a 256-FD ceiling.

The scaling is why "it used to work": the code shape was always O(files) in concurrent FDs; it only crossed the limit once the folder grew large enough.

## Summary

Two independent fixes, one per commit:

1. **Bound the concurrency and stop over-peeking.** A dependency-free worker pool (`mapConcurrent`, 32 workers) caps both the `stat` fan-out and the `peek` fan-out. Enumeration is split from body-peeking so `resolveSession` matches ids from stat-only metadata first and peeks **only the matched candidate(s)** — id resolution never needs a file body. This is the primary EMFILE fix.

2. **Release the descriptor on early break.** `replayJsonl` / `usage/scan` drove `Bun.file().stream()` with a bare `for await`. `peekSession` stops after the first meta + a few user turns, abandoning the stream mid-flight. The readers now use an explicit `getReader()` with a `finally { reader.cancel(); releaseLock() }`, so an early break frees the FD deterministically instead of relying on async-iterator finalization. Defense-in-depth (the async-iterator protocol *should* cancel, but this makes it explicit and robust under load).

**Why a worker pool and not `p-limit`:** no new dependency for a 15-line shared-cursor pool that preserves input order.

**Why not just raise `ulimit`:** that only defers the crash; the code was fundamentally O(files) in concurrent FDs. Raising the limit is still worthwhile as defense-in-depth on the container, but it is not the fix.

## What this does NOT do

- Does not change the public shape of `listSessions` / `resolveSession` (same signatures, same results, ordering preserved).
- Does not prune or GC `sessions/` — reducing the file count is an orthogonal operational concern.
- Does not set a container `--ulimit nofile` — worth doing separately as defense-in-depth, but out of scope here.

## Review notes

- Load-bearing change: `mapConcurrent` + the `statSessionFiles`/`summarizeEntry` split in `session-list.ts`, and the candidate-only path in `resolveSession`. The invariant: **no code path peeks a file it hasn't matched by id/prefix**, and no fan-out exceeds `SESSION_IO_CONCURRENCY`.
- Tests assert behavior, not implementation: `resolveSession` for an exact id / a not-found id leaves a malformed **decoy** file unread (verified via absence of any parse warning — the old peek-everything path would have warned); a 400-session directory resolves without EMFILE; and 500 early-break replays over a 5000-line file stay under the FD ceiling (guards commit 2).
- Full suite green locally (`typecheck` / `lint` 0 errors / `format:check` / `test` 11828 pass, 0 fail).