### PR TITLE
Split the cron-list connect timeout from the reply timeout

### DIFF
--- a/src/cron/bridge.test.ts
+++ b/src/cron/bridge.test.ts
@@ -34,11 +34,27 @@ function startFakeAgent(reply: (msg: ClientMessage) => ServerMessage | null): nu
   return bun.port
 }
 
-// Generous bound for happy-path WS round-trips under parallel-test
-// contention. Tests that deliberately exercise the timeout path (e.g.
-// "ignores replies whose requestId does not match") still use a tight
-// bound — those tests' contract IS the timeout, and bumping them would
-// just make the suite slower without making it more reliable.
+// Accepts TCP + HTTP but never completes the WebSocket upgrade (the fetch
+// handler hangs), so the client sees no 'open'/'error' — the deterministic
+// wedged-handshake case the connect timer exists to bound.
+function startStalledUpgradePeer(): number {
+  const bun = Bun.serve({
+    port: 0,
+    async fetch() {
+      await new Promise<Response>(() => {})
+      return new Response('unreachable')
+    },
+  })
+  server = bun
+  if (bun.port === undefined) throw new Error('Bun.serve returned no port')
+  return bun.port
+}
+
+// Generous bound for the WS handshake under parallel-test contention. Used
+// as the whole budget for happy-path round-trips, and as the connect-only
+// budget for the reply-timeout test — that test keeps a tight *reply* budget
+// (its contract IS the reply timeout) but must not let a slow handshake under
+// load trip the connect timeout first and surface as `unreachable`.
 const HAPPY_PATH_TIMEOUT_MS = 10_000
 
 describe('cron list bridge', () => {
@@ -112,8 +128,44 @@ describe('cron list bridge', () => {
       return { type: 'cron_list_result', requestId: 'wrong-id', result: { ok: true, jobs: [], nowMs: 0 } }
     })
 
-    const result = await fetchCronList({ cwd: process.cwd(), url: `ws://127.0.0.1:${port}`, timeoutMs: 300 })
+    const result = await fetchCronList({
+      cwd: process.cwd(),
+      url: `ws://127.0.0.1:${port}`,
+      connectTimeoutMs: HAPPY_PATH_TIMEOUT_MS,
+      timeoutMs: 300,
+    })
     expect(result.kind).toBe('timeout')
+  })
+
+  test('bounds a wedged handshake by connectTimeoutMs, not timeoutMs', async () => {
+    // given: a peer that stalls the upgrade forever, a tight connect budget,
+    // and a reply budget large enough that firing it instead would hang ~30x
+    // longer — so this only passes if the handshake timer uses connectTimeoutMs
+    const port = startStalledUpgradePeer()
+
+    const started = performance.now()
+    const result = await fetchCronList({
+      cwd: process.cwd(),
+      url: `ws://127.0.0.1:${port}`,
+      connectTimeoutMs: 300,
+      timeoutMs: HAPPY_PATH_TIMEOUT_MS,
+    })
+    const elapsedMs = performance.now() - started
+
+    expect(result.kind).toBe('unreachable')
+    if (result.kind !== 'unreachable') throw new Error('expected unreachable result')
+    expect(result.reason).toContain('after 300ms')
+    expect(elapsedMs).toBeLessThan(HAPPY_PATH_TIMEOUT_MS)
+  })
+
+  test('falls back to timeoutMs for the handshake when connectTimeoutMs is omitted', async () => {
+    const port = startStalledUpgradePeer()
+
+    const result = await fetchCronList({ cwd: process.cwd(), url: `ws://127.0.0.1:${port}`, timeoutMs: 300 })
+
+    expect(result.kind).toBe('unreachable')
+    if (result.kind !== 'unreachable') throw new Error('expected unreachable result')
+    expect(result.reason).toContain('after 300ms')
   })
 })
 

--- a/src/cron/bridge.ts
+++ b/src/cron/bridge.ts
@@ -5,6 +5,12 @@ export type CronListBridgeOptions = {
   cwd: string
   url?: string
   timeoutMs?: number
+  // Budget for the WS handshake only. Defaults to timeoutMs so production
+  // behavior is unchanged. Split out so the reply-timeout path can be tested
+  // with a tight reply budget while giving the connect phase enough slack to
+  // survive CPU contention under parallel tests — a slow handshake must not
+  // masquerade as a reply timeout (or, worse, surface as `unreachable`).
+  connectTimeoutMs?: number
   // Injected for tests so the in-container short-circuit can be exercised
   // without polluting process.env. Production callers omit this and the
   // bridge reads from process.env directly.
@@ -35,6 +41,7 @@ type DialResult = { kind: 'ok'; ws: WebSocket; timeoutMs: number } | { kind: 'un
 
 async function dial(opts: CronListBridgeOptions): Promise<DialResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const connectTimeoutMs = opts.connectTimeoutMs ?? timeoutMs
   let url = opts.url
   if (url === undefined) {
     try {
@@ -74,8 +81,8 @@ async function dial(opts: CronListBridgeOptions): Promise<DialResult> {
         try {
           ws.close()
         } catch {}
-        reject(new Error(`timed out connecting to ${displayUrl} after ${timeoutMs}ms`))
-      }, timeoutMs)
+        reject(new Error(`timed out connecting to ${displayUrl} after ${connectTimeoutMs}ms`))
+      }, connectTimeoutMs)
       ws.addEventListener('open', onOpen, { once: true })
       ws.addEventListener('error', onError, { once: true })
       ws.addEventListener('close', onClose, { once: true })


### PR DESCRIPTION
## What

`fetchCronList` (the `typeclaw cron list` bridge) drove a single `timeoutMs` through **two** sequential phases: the WebSocket handshake in `dial()` and the reply wait in `awaitReply()`. This splits out an optional `connectTimeoutMs` so the two phases can be budgeted independently.

## Why

The test `cron list bridge > ignores replies whose requestId does not match` was flaky under `bun test --parallel` (reported: `(fail) ... ignores replies whose requestId does not match [448.28ms]`). It passed in isolation and only failed under full-suite CPU contention.

Root cause: the test uses `timeoutMs: 300` and asserts the result is `timeout` (the fake agent always replies with a mismatched `requestId`, so every reply is ignored and the reply phase must time out). But that same 300ms was also the **connect** budget. Under parallel-test CPU oversubscription the localhost WS handshake occasionally exceeded 300ms, so `dial()` timed out **first** and returned `{ kind: 'unreachable' }` instead of the `{ kind: 'timeout' }` the test asserts — a load-only flake, not a real regression.

## How

- `CronListBridgeOptions` gains an optional `connectTimeoutMs`.
- `dial()` computes `connectTimeoutMs = opts.connectTimeoutMs ?? timeoutMs` and gates **only** the handshake timer (and its error message) on it. `awaitReply()` still receives the unchanged `timeoutMs` reply budget.
- Production behavior is unchanged: callers that omit `connectTimeoutMs` get the old single-budget semantics via the `?? timeoutMs` default.
- The flaky test now passes `connectTimeoutMs: HAPPY_PATH_TIMEOUT_MS` (10s connect slack) while keeping its tight `timeoutMs: 300` reply budget — so its real contract (mismatched replies are ignored → reply-phase timeout) is preserved and it stays mutation-strong (accepting the mismatched reply would return `ok`, not `timeout`).

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (68 pre-existing warnings, none in changed files)
- `bun run format:check` — clean
- `bun run test` (full suite, `--parallel`) — **11837 pass, 0 fail** across 571 files, run repeatedly; the previously-flaky test passes under full contention.

## Notes for reviewers

- The reply-timeout test still inherently costs ~`timeoutMs` (300ms) of wall-clock — that's unavoidable when proving a terminal timeout through the public API; the fix does not make it slower, it makes it *correct* under load.
- This mirrors the existing precedent `Stabilize concurrent secrets-patch test under CI oversubscription`.