### PR TITLE
Bound git gc/repack memory on the agent repo

### DIFF
--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -2999,6 +2999,41 @@ describe('start (composition)', () => {
     expect(onDisk).toBe('FROM stale\n')
   })
 
+  test('bounds gc/repack memory even when the container is already running', async () => {
+    // given: a real initialized repo, an already-running container, and a stale
+    // Dockerfile so we can prove the git keys land while template/docker ops no-op
+    await gitInit(root)
+    await writeFile(join(root, 'Dockerfile'), 'FROM stale\n')
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const { exec, calls } = fakeDockerExec({
+      imageExists: true,
+      container: { exists: true, running: true },
+    })
+
+    // when
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      autoUpgrade: noAutoUpgrade,
+      ...bypassVerify,
+    })
+
+    // then: the memory bounds are written to the running agent's repo
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.alreadyRunning).toBe(true)
+    expect(await runGit(root, ['config', '--local', 'gc.auto'])).toBe('0')
+    expect(await runGit(root, ['config', '--local', 'pack.windowMemory'])).toBe('64m')
+    expect(await runGit(root, ['config', '--local', 'core.bigFileThreshold'])).toBe('10m')
+    // and: docker/template operations stayed no-ops on the already-running path
+    expect(calls.find((c) => c.args[0] === 'run')).toBeUndefined()
+    expect(calls.find((c) => isBuildCall(c.args))).toBeUndefined()
+    expect(await readFile(join(root, 'Dockerfile'), 'utf8')).toBe('FROM stale\n')
+  })
+
   test('reports an error when an already-running container has no published host port', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { isAbsolute, join, relative, resolve } from 'node:path'
 
 import { expandMountPath, loadConfigSync, withDefaultPlugins, type Config, type PortForward } from '@/config'
+import { applyBoundGcConfig } from '@/git/bound-gc-config'
 import { commitGitignoreWithUntracks, untrackTrulyIgnoredFiles } from '@/git/reconcile-ignored'
 import { commitSystemFile as commitSystemFileShared } from '@/git/system-commit'
 import { send as sendToDaemon } from '@/hostd/client'
@@ -238,6 +239,15 @@ export async function start({
     // that would surprise a user invoking `compose start` against a partially-up
     // tree.
     const state = await inspectContainer(exec, containerName)
+
+    // Bound gc/repack memory even when start() is an already-running no-op below:
+    // the running agent's backup keeps committing, so it must not keep using the
+    // unbounded Git defaults until a full stop/restart. This is a machine-local
+    // `git config` write (never committed, no template/side effect), so unlike the
+    // Dockerfile/.gitignore/package.json refreshes it is safe before the running
+    // return — no surprise for `compose start` against a partially-up tree.
+    await applyBoundGcConfig(cwd)
+
     if (state.exists && state.running) {
       return await reportAlreadyRunning(exec, cwd, containerName)
     }
@@ -262,6 +272,9 @@ export async function start({
     // refreshGitignore call below reads typeclaw.json and will incidentally
     // trigger the migration commit if the file was legacy.
     await refreshGitignore(cwd)
+    // Machine-local `git config` that bounds gc/repack memory on the agent repo.
+    // Runs alongside the other managed-file refreshes; not committed (local scope).
+    await applyBoundGcConfig(cwd)
     const pkgRefresh = await refreshPackageJson(cwd)
     const { untracked } = await untrackTrulyIgnoredFiles(cwd, (await loadTypeclawConfig(cwd)).git.ignore.append)
     if (untracked.length > 0) {

--- a/src/git/bound-gc-config.test.ts
+++ b/src/git/bound-gc-config.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, rename, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { applyBoundGcConfig, BOUND_GC_CONFIG } from './bound-gc-config'
+
+async function gitInit(cwd: string): Promise<void> {
+  const proc = Bun.spawn({ cmd: ['git', 'init', '-b', 'main'], cwd, stdout: 'pipe', stderr: 'pipe' })
+  await proc.exited
+}
+
+async function readConfig(cwd: string, key: string): Promise<string> {
+  const gitArgs = existsSync(join(cwd, '.gitstore')) ? ['--git-dir', join(cwd, '.gitstore'), '--work-tree', cwd] : []
+  const proc = Bun.spawn({ cmd: ['git', ...gitArgs, 'config', '--local', key], cwd, stdout: 'pipe', stderr: 'pipe' })
+  await proc.exited
+  return (await new Response(proc.stdout).text()).trim()
+}
+
+async function makeDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), 'bound-gc-config-'))
+}
+
+describe('applyBoundGcConfig', () => {
+  test('writes every bounding key into the repo local config', async () => {
+    const dir = await makeDir()
+    try {
+      await gitInit(dir)
+
+      const { applied } = await applyBoundGcConfig(dir)
+
+      expect(applied).toBe(BOUND_GC_CONFIG.length)
+      for (const [key, value] of BOUND_GC_CONFIG) {
+        expect(await readConfig(dir, key)).toBe(value)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('caps the delta pipeline: threads=1, unlimited window bounded, big files skip delta', async () => {
+    const dir = await makeDir()
+    try {
+      await gitInit(dir)
+
+      await applyBoundGcConfig(dir)
+
+      expect(await readConfig(dir, 'gc.auto')).toBe('0')
+      expect(await readConfig(dir, 'pack.threads')).toBe('1')
+      expect(await readConfig(dir, 'pack.windowMemory')).toBe('64m')
+      expect(await readConfig(dir, 'core.bigFileThreshold')).toBe('10m')
+      expect(await readConfig(dir, 'core.multiPackIndex')).toBe('true')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('is idempotent across repeated starts', async () => {
+    const dir = await makeDir()
+    try {
+      await gitInit(dir)
+
+      await applyBoundGcConfig(dir)
+      const { applied } = await applyBoundGcConfig(dir)
+
+      expect(applied).toBe(BOUND_GC_CONFIG.length)
+      expect(await readConfig(dir, 'pack.windowMemory')).toBe('64m')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('supports the relocated .gitstore layout', async () => {
+    const dir = await makeDir()
+    try {
+      await gitInit(dir)
+      await rename(join(dir, '.git'), join(dir, '.gitstore'))
+
+      const { applied } = await applyBoundGcConfig(dir)
+
+      expect(applied).toBe(BOUND_GC_CONFIG.length)
+      expect(await readConfig(dir, 'gc.auto')).toBe('0')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('no-ops on a folder that is not a git repo', async () => {
+    const dir = await makeDir()
+    try {
+      const { applied } = await applyBoundGcConfig(dir)
+      expect(applied).toBe(0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/git/bound-gc-config.ts
+++ b/src/git/bound-gc-config.ts
@@ -1,0 +1,82 @@
+import { hooklessGitArgs } from './hookless'
+import { resolveAgentGit } from './resolve-agent-git'
+
+// Machine-local `git config` written into the agent repo on every `typeclaw
+// start` to bound git's gc/repack/pack-objects memory. Agents force-commit
+// sessions/ + memory/, so packs grow to GB scale; on such a repo git's default
+// auto-gc was measured at ~1.8GB RSS and OOM-killed the container. These keys cap
+// the peak (git-config(1): peak ≈ pack.threads × pack.windowMemory + overhead).
+// Do NOT "modernize" any back to a git default without re-checking the OOM:
+//   gc.auto/autoPackLimit=0   no surprise full repack from the backup's `git
+//                             commit`; reclamation moves to the idle backup path
+//                             (see bound-git-maintenance / Fix 2).
+//   pack.threads=1            default auto-detects to CPU count; windowMemory is
+//                             PER THREAD, so N cores = N× the spike.
+//   pack.windowMemory=64m     default is UNLIMITED — the primary per-thread bound.
+//   pack.deltaCacheSize=1     virtually disables the 256MB write-phase delta cache.
+//   core.bigFileThreshold=10m load-bearing for append-only JSONL: bigger objects
+//                             store plain-deflated with NO delta attempt, keeping
+//                             transcripts out of the memory-heavy delta pipeline.
+//   core.multiPackIndex=true  required for Fix 2's `maintenance incremental-repack`.
+export const BOUND_GC_CONFIG: ReadonlyArray<readonly [key: string, value: string]> = [
+  ['gc.auto', '0'],
+  ['gc.autoPackLimit', '0'],
+  ['gc.bigPackThreshold', '100m'],
+  ['pack.threads', '1'],
+  ['pack.windowMemory', '64m'],
+  ['pack.deltaCacheSize', '1'],
+  ['pack.window', '5'],
+  ['pack.depth', '10'],
+  ['core.bigFileThreshold', '10m'],
+  ['core.deltaBaseCacheLimit', '16m'],
+  ['core.multiPackIndex', 'true'],
+] as const
+
+// Writes BOUND_GC_CONFIG into the agent repo's machine-local git config.
+//
+// Best-effort, exactly like untrackTrulyIgnoredFiles / commitSystemFile: no-ops
+// when the folder is not a git repo or Bun is missing, and NEVER throws — start()
+// hygiene must not block boot. These are `git config` (local scope) writes: they
+// live in .git/config, are not tracked, not committed, and are idempotent —
+// re-running just re-sets the same values.
+//
+// Returns the number of keys successfully written (0 when skipped) so callers /
+// tests can assert the write happened without coupling to git internals.
+export async function applyBoundGcConfig(cwd: string): Promise<{ applied: number }> {
+  const bun = getBun()
+  if (!bun) return { applied: 0 }
+  const repo = resolveAgentGit(cwd)
+  if (!repo) return { applied: 0 }
+
+  let applied = 0
+  for (const [key, value] of BOUND_GC_CONFIG) {
+    if (await setLocalConfig(bun, cwd, repo.gitArgs, key, value)) applied += 1
+  }
+  return { applied }
+}
+
+async function setLocalConfig(
+  bun: BunLike,
+  cwd: string,
+  gitArgs: readonly string[],
+  key: string,
+  value: string,
+): Promise<boolean> {
+  try {
+    const proc = bun.spawn({
+      cmd: ['git', ...hooklessGitArgs([...gitArgs, 'config', '--local', key, value])],
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    return (await proc.exited) === 0
+  } catch {
+    return false
+  }
+}
+
+type BunLike = { spawn: typeof Bun.spawn }
+
+function getBun(): BunLike | undefined {
+  return (globalThis as { Bun?: BunLike }).Bun
+}


### PR DESCRIPTION
## Problem

Agents force-commit `sessions/` + `memory/` (system-managed, force-added by the backup plugin), so agent repos grow to **GB-scale packs** over time. On such a repo, git's **default** gc/repack behavior is a memory bomb:

- `pack.windowMemory` defaults to **unlimited**
- `pack.threads` defaults to **CPU count**, and window memory is consumed **per thread**
- auto-gc fires opportunistically after porcelain commands (the backup runner's commit)

A `git repack` on a ~1.2 GB pack was **measured at ~1.76 GB RSS** (even with a minimal window). Since containers run with **no `--memory` limit**, this OOM-killed the agent — and because agents share one VM, one agent's spike can take down its siblings via the VM kernel's OOM-killer (`OOMKilled=true`, exit 137).

## Fix

Write machine-local settings into the agent repo on every `typeclaw start`, alongside the existing managed-file refreshes (`refreshGitignore`, etc.), that cap git's peak memory:

| Key | Value | Why |
|---|---|---|
| `gc.auto` / `gc.autoPackLimit` | `0` | No surprise full repack from the backup's commit mid-turn |
| `gc.bigPackThreshold` | `100m` | If gc runs, never rewrite the large established pack |
| `pack.threads` | `1` | Default auto-detects to CPU count; window memory is per-thread |
| `pack.windowMemory` | `64m` | Default is **unlimited** — the primary per-thread bound |
| `pack.deltaCacheSize` | `1` | Virtually disable the 256 MB write-phase delta cache |
| `pack.window` / `pack.depth` | `5` / `10` | Smaller window + shallower chains |
| `core.bigFileThreshold` | `10m` | **Load-bearing for append-only session JSONL** — larger objects store plain-deflated with no delta attempt, keeping transcripts out of the memory-heavy delta pipeline (and stopping the pack from ballooning from delta churn in the first place) |
| `core.deltaBaseCacheLimit` | `16m` | Per-thread base-object read cache (default 96m) |
| `core.multiPackIndex` | `true` | Enables the follow-up idle-path `git maintenance incremental-repack` (Fix 2) to reclaim without a full gc |

Values sized for a ~512 MB budget; per `git-config(1)`, peak is approx `pack.threads * pack.windowMemory + overhead`, bringing the ~1.8 GB spike down to ~130-180 MB.

## Notes

- Writes are **local scope** (`.git/config`): not tracked, not committed, idempotent.
- **Best-effort** like the other `start()` hygiene (`untrackTrulyIgnoredFiles`, `commitSystemFile`): no-ops when the folder isn't a git repo or Bun is missing, and **never throws**, so it can't block boot. Supports both `.git` and the relocated `.gitstore` layout.
- Applies to **every existing and future agent** on next `start` — no re-init, no schema change.

## Follow-up

This disables auto-gc, so reclamation moves to a **bounded, idle-path `git maintenance incremental-repack`** in the backup runner (Fix 2, stacked PR). `core.multiPackIndex=true` here is the prerequisite for that. This PR is prevention of the spike; the existing 1.2 GB pack on an already-bloated repo still needs a one-off history shrink (separate, not in scope here).

## Test

`src/git/bound-gc-config.test.ts` — real git repos in tmp dirs (per the repo's testing philosophy): asserts every key is written, the delta-pipeline caps are set, idempotency across repeated starts, the `.gitstore` layout, and a no-op on a non-repo folder. Full suite: 11,842 pass / 0 fail.
