### PR TITLE
Hoist per-message guard regexes to module scope

### DIFF
--- a/src/bundled-plugins/security/policies/outbound-secret-scan.test.ts
+++ b/src/bundled-plugins/security/policies/outbound-secret-scan.test.ts
@@ -166,6 +166,21 @@ NODE=X HOME=X SLACK_APP_TOKEN=X TYPECLAW_HOSTD_BROKER_TOKEN=X TYPECLAW_CONTAINER
     expect(matches.length).toBeGreaterThanOrEqual(3)
     expect(matches.every((m) => m.source === 'env_key_recon')).toBe(true)
   })
+
+  test('repeated calls yield identical recon matches (module-scoped regexes carry no lastIndex state)', () => {
+    const text = 'Available env vars: FIREWORKS_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY'
+    const first = findOutboundSecrets(text, {})
+      .filter((m) => m.source === 'env_key_recon')
+      .map((m) => m.kind)
+      .sort()
+    for (let i = 0; i < 3; i++) {
+      const again = findOutboundSecrets(text, {})
+        .filter((m) => m.source === 'env_key_recon')
+        .map((m) => m.kind)
+        .sort()
+      expect(again).toEqual(first)
+    }
+  })
 })
 
 describe('checkOutboundSecretGuard', () => {

--- a/src/bundled-plugins/security/policies/outbound-secret-scan.ts
+++ b/src/bundled-plugins/security/policies/outbound-secret-scan.ts
@@ -88,6 +88,12 @@ const ENV_KEY_RECON_TARGETS: ReadonlyArray<string> = [
 
 const ENV_KEY_RECON_THRESHOLD = 3
 
+// Names are fixed literals, so these boundary regexes are constant. Compile
+// once at module load, not ~30 RegExps per outbound message (guard is per-send).
+const ENV_KEY_RECON_MATCHERS: ReadonlyArray<readonly [name: string, pattern: RegExp]> = ENV_KEY_RECON_TARGETS.map(
+  (name) => [name, new RegExp(`\\b${name}\\b`)] as const,
+)
+
 const TEXT_KEYS = ['text', 'message', 'content', 'body']
 
 export type OutboundSecretMatch = {
@@ -137,9 +143,8 @@ export function findOutboundSecrets(text: string, env: NodeJS.ProcessEnv = proce
 
 function findReconEnvKeys(text: string): string[] {
   const out: string[] = []
-  for (const name of ENV_KEY_RECON_TARGETS) {
-    const re = new RegExp(`\\b${name}\\b`)
-    if (re.test(text)) out.push(name)
+  for (const [name, pattern] of ENV_KEY_RECON_MATCHERS) {
+    if (pattern.test(text)) out.push(name)
   }
   return out
 }

--- a/src/role-claim/code.test.ts
+++ b/src/role-claim/code.test.ts
@@ -42,6 +42,21 @@ describe('extractClaimCode', () => {
     expect(extractClaimCode('claim-toolong-2x3r')).toBeNull()
     expect(extractClaimCode('claim-7K9M')).toBeNull()
   })
+
+  test('consecutive successful extractions stay stable (shared regex carries no lastIndex state)', () => {
+    // Two back-to-back positive calls on the SAME input model the production
+    // sequence (router precheck then claim handler). With a stateful `g` flag
+    // the first exec would advance lastIndex past the match and the second
+    // would miss — so no intervening non-match call may reset it.
+    expect(extractClaimCode('claim-7K9M-2X3R')).toBe('claim-7K9M-2X3R')
+    expect(extractClaimCode('claim-7K9M-2X3R')).toBe('claim-7K9M-2X3R')
+    expect(extractClaimCode('claim-7K9M-2X3R')).toBe('claim-7K9M-2X3R')
+    // And a mixed run stays correct across many iterations.
+    for (let i = 0; i < 5; i++) {
+      expect(extractClaimCode('claim-7K9M-2X3R')).toBe('claim-7K9M-2X3R')
+      expect(extractClaimCode('no code here')).toBeNull()
+    }
+  })
 })
 
 describe('normalizeClaimCode', () => {

--- a/src/role-claim/code.ts
+++ b/src/role-claim/code.ts
@@ -19,6 +19,14 @@ const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
 const BLOCK_SIZE = 4
 const BLOCK_COUNT = 2
 
+// Shape is fixed by the block constants, so compile once at module load rather
+// than per inbound message — extractClaimCode runs on every channel message
+// carrying a potential claim.
+const CLAIM_CODE_RE = new RegExp(
+  `${CLAIM_CODE_PREFIX}([0-9a-zA-Z]{${BLOCK_SIZE}}(?:-[0-9a-zA-Z]{${BLOCK_SIZE}}){${BLOCK_COUNT - 1}})`,
+  'i',
+)
+
 export function generateClaimCode(): string {
   const bytes = randomBytes(BLOCK_SIZE * BLOCK_COUNT)
   const chars: string[] = []
@@ -37,11 +45,7 @@ export function generateClaimCode(): string {
 // whitespace, punctuation, and case — chat clients may auto-correct case
 // or surround pastes with quotes/backticks.
 export function extractClaimCode(text: string): string | null {
-  const pattern = new RegExp(
-    `${CLAIM_CODE_PREFIX}([0-9a-zA-Z]{${BLOCK_SIZE}}(?:-[0-9a-zA-Z]{${BLOCK_SIZE}}){${BLOCK_COUNT - 1}})`,
-    'i',
-  )
-  const match = pattern.exec(text)
+  const match = CLAIM_CODE_RE.exec(text)
   if (!match) return null
   return `${CLAIM_CODE_PREFIX}${match[1]!.toUpperCase()}`
 }


### PR DESCRIPTION
## Background

Two hot-path guards recompiled constant regexes on every invocation:

- **`outbound-secret-scan`'s env-key recon scan** built one `RegExp` per known
  env-var name (~30 of them) on *every* `channel_send`/`channel_reply`. This
  guard runs on every outbound channel message, so the allocations recur per
  reply for the lifetime of the process.
- **`role-claim`'s `extractClaimCode`** rebuilt its claim-code `RegExp` on every
  inbound channel message that might carry a claim.

In both cases the pattern is fully determined by module-level string constants —
there is nothing dynamic to justify per-call compilation. This came out of a
sweep for security-guard overhead on the per-message / per-turn / per-tool-call
paths; these two were the clearest "recompile a constant" cases.

## Summary

Compile both regexes once at module load and reuse the instances.

- `ENV_KEY_RECON_MATCHERS` precomputes `[name, /\bNAME\b/]` pairs from the
  existing `ENV_KEY_RECON_TARGETS`; `findReconEnvKeys` iterates the precompiled
  pairs instead of `new RegExp(...)` in the loop.
- `CLAIM_CODE_RE` is built once from the block constants; `extractClaimCode`
  calls `.exec()` on the shared instance.

**Safety:** both regexes are non-`g` (no `lastIndex` state), so a single shared
instance is safe to reuse across calls — sharing an instance changes nothing
observable. Each change ships an idempotency regression test that runs the
scan/extraction repeatedly and asserts identical results, so a future edit that
reintroduces a stateful (`g`-flag) shared regex would fail.

## What this does NOT do

- No change to detection semantics, thresholds, or which strings match — purely
  a compile-once refactor.
- Does not touch the other guards surfaced in the same audit (the permission
  `resolveRole` memoization and the per-bash-call sandbox FS I/O are separate,
  higher-risk changes handled elsewhere).

## Review notes

- Load-bearing invariant: the shared regexes must stay non-`g`. The two new
  "repeated calls are stable / yield identical matches" tests pin this.
- The precompile comments are kept deliberately (performance-optimization
  rationale) so the loop isn't "simplified" back into per-call `new RegExp`.