### PR TITLE
Lazy-load heavy web_fetch parser deps to cut idle RSS

### DIFF
--- a/src/agent/tools/webfetch/strategies/jq.ts
+++ b/src/agent/tools/webfetch/strategies/jq.ts
@@ -1,5 +1,3 @@
-import { raw } from 'jq-wasm'
-
 export class JqError extends Error {
   constructor(message: string) {
     super(message)
@@ -17,6 +15,7 @@ export async function applyJq(content: string, query: string): Promise<string> {
   }
 
   try {
+    const { raw } = await import('jq-wasm')
     const result = await raw(parsed as string | object, query)
     if (result.exitCode !== 0 || result.stderr) {
       const detail = result.stderr.trim() || `exit code ${result.exitCode}`

--- a/src/agent/tools/webfetch/strategies/lazy-load.test.ts
+++ b/src/agent/tools/webfetch/strategies/lazy-load.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test'
+
+// Regression guard for the idle-load contract this PR establishes: the heavy
+// HTML/JSON parsers (jsdom + readability + turndown, cheerio, jq-wasm) must NOT
+// be pulled into the process at module-evaluation time. agent/index.ts statically
+// imports webfetch/tool.ts, which imports every strategy, so a top-level `import`
+// of any parser would drag it onto every agent boot even when web_fetch is never
+// called. Making the existing behavior tests async does not catch that: they would
+// still pass with the imports restored to eager. Each case runs in a child bun
+// process that mock.modules the heavy specifiers — a child process avoids Bun's
+// process-global mock.module leakage into sibling tests. Mirrors
+// vector/embedder-lazy-load.test.ts.
+
+const HEAVY_SPECIFIERS = ['jsdom', '@mozilla/readability', 'turndown', 'cheerio', 'jq-wasm'] as const
+
+function runChild(script: string): { exitCode: number | null; output: string } {
+  const result = Bun.spawnSync({ cmd: [process.execPath, '--eval', script], stdout: 'pipe', stderr: 'pipe' })
+  const output = new TextDecoder().decode(result.stderr) || new TextDecoder().decode(result.stdout)
+  return { exitCode: result.exitCode, output }
+}
+
+function moduleUrl(relative: string): string {
+  return `${new URL(relative, import.meta.url).href}?lazy=${crypto.randomUUID()}`
+}
+
+// Each heavy specifier is mocked to record its request into `requested` and then
+// throw on any property access, so a dependency that is merely imported (deferred
+// or eager) is recorded, while nothing downstream can actually use the fake.
+function recordingMocks(): string {
+  return HEAVY_SPECIFIERS.map(
+    (spec) => `
+      mock.module(${JSON.stringify(spec)}, () => {
+        requested.add(${JSON.stringify(spec)})
+        return new Proxy({}, { get: () => { throw new Error(${JSON.stringify(`${spec} used`)}) } })
+      })`,
+  ).join('\n')
+}
+
+describe('web_fetch strategy lazy loading', () => {
+  test('importing the web_fetch tool evaluates none of the heavy parser modules', () => {
+    const toolUrl = moduleUrl('../tool.ts')
+    const script = `
+      import { mock } from 'bun:test'
+      const requested = new Set()
+      ${recordingMocks()}
+      await import(${JSON.stringify(toolUrl)})
+      if (requested.size > 0) {
+        console.error('eagerly requested: ' + [...requested].join(', '))
+        process.exit(1)
+      }
+    `
+    const { exitCode, output } = runChild(script)
+    expect(exitCode, output).toBe(0)
+  })
+
+  test('applyReadability lazily loads jsdom/readability/turndown and nothing else', () => {
+    const { exitCode, output } = runChild(
+      strategyProbe(
+        './readability.ts',
+        'applyReadability',
+        ['<html><body><p>hi</p></body></html>', 'https://example.com'],
+        {
+          expected: ['jsdom', '@mozilla/readability', 'turndown'],
+          forbidden: ['cheerio', 'jq-wasm'],
+        },
+      ),
+    )
+    expect(exitCode, output).toBe(0)
+  })
+
+  test('applySelector lazily loads cheerio and nothing else', () => {
+    const { exitCode, output } = runChild(
+      strategyProbe('./selector.ts', 'applySelector', ['<html><body><p>hi</p></body></html>', 'p'], {
+        expected: ['cheerio'],
+        forbidden: ['jsdom', '@mozilla/readability', 'turndown', 'jq-wasm'],
+      }),
+    )
+    expect(exitCode, output).toBe(0)
+  })
+
+  test('applySnapshot lazily loads cheerio and nothing else', () => {
+    const { exitCode, output } = runChild(
+      strategyProbe('./snapshot.ts', 'applySnapshot', ['<html><body><main><h1>hi</h1></main></body></html>'], {
+        expected: ['cheerio'],
+        forbidden: ['jsdom', '@mozilla/readability', 'turndown', 'jq-wasm'],
+      }),
+    )
+    expect(exitCode, output).toBe(0)
+  })
+
+  test('applyJq lazily loads jq-wasm and nothing else', () => {
+    const { exitCode, output } = runChild(
+      strategyProbe('./jq.ts', 'applyJq', ['{"a":1}', '.a'], {
+        expected: ['jq-wasm'],
+        forbidden: ['jsdom', '@mozilla/readability', 'turndown', 'cheerio'],
+      }),
+    )
+    expect(exitCode, output).toBe(0)
+  })
+})
+
+// Proves two things per strategy: (1) importing the strategy module requests no
+// heavy specifier (laziness), and (2) invoking the function requests exactly its
+// own dependencies and none of the others. The fake parsers throw when used, so
+// the invocation is wrapped in try/catch — we assert on which specifiers were
+// requested, not on the parse result.
+function strategyProbe(
+  relativeModule: string,
+  fn: string,
+  args: readonly string[],
+  contract: { expected: readonly string[]; forbidden: readonly string[] },
+): string {
+  const strategyUrl = moduleUrl(relativeModule)
+  return `
+    import { mock } from 'bun:test'
+    const requested = new Set()
+    ${recordingMocks()}
+    const mod = await import(${JSON.stringify(strategyUrl)})
+    if (requested.size > 0) {
+      console.error('requested during module import: ' + [...requested].join(', '))
+      process.exit(1)
+    }
+    try { await mod[${JSON.stringify(fn)}](${args.map((a) => JSON.stringify(a)).join(', ')}) } catch {}
+    const expected = ${JSON.stringify(contract.expected)}
+    const forbidden = ${JSON.stringify(contract.forbidden)}
+    for (const spec of expected) {
+      if (!requested.has(spec)) { console.error('expected but not loaded: ' + spec); process.exit(1) }
+    }
+    for (const spec of forbidden) {
+      if (requested.has(spec)) { console.error('forbidden but loaded: ' + spec); process.exit(1) }
+    }
+  `
+}

--- a/src/agent/tools/webfetch/strategies/readability.test.ts
+++ b/src/agent/tools/webfetch/strategies/readability.test.ts
@@ -18,8 +18,8 @@ const ARTICLE = `
 </body></html>`
 
 describe('applyReadability', () => {
-  test('extracts the article body and renders markdown headings, paragraphs, and lists', () => {
-    const result = applyReadability(ARTICLE, 'https://example.com/post')
+  test('extracts the article body and renders markdown headings, paragraphs, and lists', async () => {
+    const result = await applyReadability(ARTICLE, 'https://example.com/post')
 
     expect(result).toMatch(/^# The Sample Article/)
     expect(result).toContain('paragraph of body text')
@@ -29,14 +29,14 @@ describe('applyReadability', () => {
     expect(result).toContain('[an example link](https://example.com/x)')
   })
 
-  test('does not include navigation or footer chrome', () => {
-    const result = applyReadability(ARTICLE, 'https://example.com/post')
+  test('does not include navigation or footer chrome', async () => {
+    const result = await applyReadability(ARTICLE, 'https://example.com/post')
     expect(result).not.toContain('Home')
     expect(result).not.toContain('copyright')
   })
 
-  test('returns a clear message when there is nothing to extract', () => {
-    const result = applyReadability('<html><body></body></html>', 'https://example.com/empty')
+  test('returns a clear message when there is nothing to extract', async () => {
+    const result = await applyReadability('<html><body></body></html>', 'https://example.com/empty')
     expect(result).toBe('Readability extracted no content from this page.')
   })
 })

--- a/src/agent/tools/webfetch/strategies/readability.ts
+++ b/src/agent/tools/webfetch/strategies/readability.ts
@@ -1,19 +1,42 @@
-import { Readability } from '@mozilla/readability'
-import { JSDOM } from 'jsdom'
-import TurndownService from 'turndown'
+import type { Readability as ReadabilityClass } from '@mozilla/readability'
+import type TurndownService from 'turndown'
 
-const turndown = new TurndownService({
-  headingStyle: 'atx',
-  codeBlockStyle: 'fenced',
-  bulletListMarker: '-',
-  emDelimiter: '*',
-  hr: '---',
-})
-turndown.remove(['script', 'style', 'meta', 'link', 'noscript', 'iframe'])
+// Perf: jsdom (+readability+turndown) costs ~40-60MB RSS at import time. Keep it
+// lazy so idle agents that never call web_fetch don't pay for it. Do NOT hoist to
+// a top-level import.
+type ReadabilityDeps = {
+  Readability: typeof ReadabilityClass
+  JSDOM: typeof import('jsdom').JSDOM
+  turndown: TurndownService
+}
 
-type ReadabilityDocument = ConstructorParameters<typeof Readability>[0]
+let depsPromise: Promise<ReadabilityDeps> | undefined
 
-export function applyReadability(html: string, url: string): string {
+async function loadDeps(): Promise<ReadabilityDeps> {
+  depsPromise ??= (async () => {
+    const [{ Readability }, { JSDOM }, { default: TurndownCtor }] = await Promise.all([
+      import('@mozilla/readability'),
+      import('jsdom'),
+      import('turndown'),
+    ])
+    const turndown = new TurndownCtor({
+      headingStyle: 'atx',
+      codeBlockStyle: 'fenced',
+      bulletListMarker: '-',
+      emDelimiter: '*',
+      hr: '---',
+    })
+    turndown.remove(['script', 'style', 'meta', 'link', 'noscript', 'iframe'])
+    return { Readability, JSDOM, turndown }
+  })()
+  return depsPromise
+}
+
+type ReadabilityDocument = ConstructorParameters<typeof ReadabilityClass>[0]
+
+export async function applyReadability(html: string, url: string): Promise<string> {
+  const { Readability, JSDOM, turndown } = await loadDeps()
+
   const dom = new JSDOM(html, { url })
   const document = dom.window.document.cloneNode(true) as unknown as ReadabilityDocument
   const article = new Readability(document).parse()

--- a/src/agent/tools/webfetch/strategies/selector.test.ts
+++ b/src/agent/tools/webfetch/strategies/selector.test.ts
@@ -14,24 +14,24 @@ const HTML = `
 </body></html>`
 
 describe('applySelector', () => {
-  test('extracts text from matching elements', () => {
-    const result = applySelector(HTML, '.item')
+  test('extracts text from matching elements', async () => {
+    const result = await applySelector(HTML, '.item')
     expect(result).toContain('Matched 3 element(s) for ".item"')
     expect(result).toContain('[1] Apple')
     expect(result).toContain('[2] Banana')
     expect(result).toContain('[3] Cherry')
   })
 
-  test('returns no-match message when selector finds nothing', () => {
-    expect(applySelector(HTML, '.nope')).toBe('No elements matched selector: .nope')
+  test('returns no-match message when selector finds nothing', async () => {
+    expect(await applySelector(HTML, '.nope')).toBe('No elements matched selector: .nope')
   })
 
-  test('targets a single element', () => {
-    const result = applySelector(HTML, '.price')
+  test('targets a single element', async () => {
+    const result = await applySelector(HTML, '.price')
     expect(result).toContain('[1] $9.99')
   })
 
-  test('throws SelectorError on invalid CSS selector', () => {
-    expect(() => applySelector(HTML, ':::')).toThrow(SelectorError)
+  test('throws SelectorError on invalid CSS selector', async () => {
+    await expect(applySelector(HTML, ':::')).rejects.toThrow(SelectorError)
   })
 })

--- a/src/agent/tools/webfetch/strategies/selector.ts
+++ b/src/agent/tools/webfetch/strategies/selector.ts
@@ -1,4 +1,4 @@
-import * as cheerio from 'cheerio'
+import type * as cheerio from 'cheerio'
 
 export class SelectorError extends Error {
   constructor(message: string) {
@@ -7,7 +7,9 @@ export class SelectorError extends Error {
   }
 }
 
-export function applySelector(html: string, selector: string): string {
+export async function applySelector(html: string, selector: string): Promise<string> {
+  const cheerio = await import('cheerio')
+
   let $: cheerio.CheerioAPI
   try {
     $ = cheerio.load(html)

--- a/src/agent/tools/webfetch/strategies/snapshot.test.ts
+++ b/src/agent/tools/webfetch/strategies/snapshot.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { applySnapshot } from './snapshot'
 
 describe('applySnapshot', () => {
-  test('emits an indented semantic tree of headings, links, and forms', () => {
+  test('emits an indented semantic tree of headings, links, and forms', async () => {
     const html = `
 <html><body>
   <header><h1>Welcome</h1></header>
@@ -18,7 +18,7 @@ describe('applySnapshot', () => {
   </main>
 </body></html>`
 
-    const result = applySnapshot(html)
+    const result = await applySnapshot(html)
 
     expect(result).toContain('- banner')
     expect(result).toContain('- heading: Welcome')
@@ -34,15 +34,15 @@ describe('applySnapshot', () => {
     expect(result).toContain('- button: Submit')
   })
 
-  test('returns a clear message when no semantic structure exists', () => {
-    expect(applySnapshot('<html><body><script>void 0</script></body></html>')).toBe(
+  test('returns a clear message when no semantic structure exists', async () => {
+    expect(await applySnapshot('<html><body><script>void 0</script></body></html>')).toBe(
       'Page contains no semantic structure.',
     )
   })
 
-  test('produces hierarchical indentation', () => {
+  test('produces hierarchical indentation', async () => {
     const html = '<html><body><main><section><h1>Inside</h1></section></main></body></html>'
-    const result = applySnapshot(html)
+    const result = await applySnapshot(html)
     const lines = result.split('\n')
     const main = lines.find((l) => l.includes('main'))
     const section = lines.find((l) => l.includes('section'))

--- a/src/agent/tools/webfetch/strategies/snapshot.ts
+++ b/src/agent/tools/webfetch/strategies/snapshot.ts
@@ -1,4 +1,4 @@
-import * as cheerio from 'cheerio'
+import type * as cheerio from 'cheerio'
 import type { AnyNode, Element } from 'domhandler'
 
 const SEMANTIC_TAGS = new Set([
@@ -65,7 +65,8 @@ const ROLE_FOR_TAG: Record<string, string> = {
   label: 'label',
 }
 
-export function applySnapshot(html: string): string {
+export async function applySnapshot(html: string): Promise<string> {
+  const cheerio = await import('cheerio')
   const $ = cheerio.load(html)
   const lines: string[] = []
   const body = $('body').get(0)

--- a/src/agent/tools/webfetch/tool.ts
+++ b/src/agent/tools/webfetch/tool.ts
@@ -226,7 +226,7 @@ async function runStrategy(
     case 'raw':
       return applyRaw(body)
     case 'readability':
-      return applyReadability(body, url)
+      return await applyReadability(body, url)
     case 'jq':
       try {
         return await applyJq(body, params.query ?? '')
@@ -236,7 +236,7 @@ async function runStrategy(
       }
     case 'selector':
       try {
-        return applySelector(body, params.selector ?? '')
+        return await applySelector(body, params.selector ?? '')
       } catch (error) {
         if (error instanceof SelectorError) throw new Error(error.message)
         throw error
@@ -255,7 +255,7 @@ async function runStrategy(
         throw error
       }
     case 'snapshot':
-      return applySnapshot(body)
+      return await applySnapshot(body)
   }
 }
 


### PR DESCRIPTION
## Summary

Web-fetch strategy modules imported their HTML/JSON parsers (`jsdom`, `cheerio`, `jq-wasm`) at **module top level**. Because `agent/index.ts → webfetch/tool.ts` statically imports every strategy, these heavy parsers were pulled into the V8 heap **at agent boot — unconditionally, even when `web_fetch` is never called**.

`jsdom` alone initializes a full DOM implementation and is the single largest of the eager deps. Live introspection of a running agent container showed the main `bun` process holding ~1 GB RSS; this eager-import chain is an estimated **~40–60 MB RSS per container** that idle agents pay for and never use.

This PR moves each parser behind a lazy `import()` inside its strategy function, so a dependency loads only on first use of the strategy that needs it.

## Changes

- **`jq.ts`** — `jq-wasm` behind `import()`. Function was already `async`; no signature change.
- **`selector.ts` / `snapshot.ts`** — `cheerio` behind `import()`. Both become `async`.
- **`readability.ts`** — `jsdom` + `@mozilla/readability` + `turndown` behind `import()`. Becomes `async`. Loaded deps and the `TurndownService` instance are cached in a module-level promise so repeated fetches don't re-import.
- **`tool.ts`** — `runStrategy` now `await`s the strategy branches (it was already `async` and awaited `jq`, so the production path is unchanged).
- **Tests** — strategy unit tests updated to `await`; `selector`'s invalid-selector case switches to `.rejects.toThrow`.

## Why it's safe

- The only production caller is `runStrategy` in `tool.ts`, which is `async` and awaits every branch. No behavior change — same output, just deferred module load.
- Type-only imports are retained where types are needed (`cheerio.CheerioAPI`, `Readability` ctor types), so type-checking is unaffected.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (68 pre-existing warnings, none in changed files)
- `bun run format:check` — clean
- `bun run test` — **11825 pass / 0 fail** (58 web-fetch tests included)

## Notes

This is the first of two independent memory-reduction changes from a broader investigation. The larger consumer (the in-process ONNX embedder, ~300 MB) and the per-turn O(N) vector-table decode are tracked separately.
