### PR TITLE
Run the agent runtime with bun --smol to bound RSS

### DIFF
--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -1486,7 +1486,7 @@ describe('network egress entrypoint shim', () => {
     expect(runtimeBranch).toContain('link_persistent_home_files')
     expect(runtimeBranch).toContain('link_configured_symlinks')
     expect(runtimeBranch).toContain('start_xvfb')
-    expect(runtimeBranch).toContain(`exec bun run ${TYPECLAW_CLI_ENTRY} "$@"`)
+    expect(runtimeBranch).toContain(`exec bun --smol run ${TYPECLAW_CLI_ENTRY} "$@"`)
   })
 
   test('off-switch path (network.blockInternal=false) installs no iptables rules and reaches the runtime phase before bun starts', () => {
@@ -1501,7 +1501,7 @@ describe('network egress entrypoint shim', () => {
     // then
     expect(offBranch).not.toContain('iptables -A OUTPUT')
     expect(offBranch).toContain('TYPECLAW_ENTRYPOINT_RUNTIME=1')
-    expect(offBranch).toContain(`exec bun run ${TYPECLAW_CLI_ENTRY} "$@"`)
+    expect(offBranch).toContain(`exec bun --smol run ${TYPECLAW_CLI_ENTRY} "$@"`)
   })
 
   test('shim self-heals on Xvfb presence: spawns Xvfb directly (not xvfb-run, which hangs as PID 1) and exports DISPLAY', () => {
@@ -1591,7 +1591,7 @@ describe('network egress entrypoint shim', () => {
   test('drops NET_ADMIN from bounding+inheritable+ambient sets before exec-ing (matches setpriv(1) warning)', () => {
     const shim = buildEntrypointShim()
     expect(shim).toContain(
-      `exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- bun run ${TYPECLAW_CLI_ENTRY} "$@"`,
+      `exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- bun --smol run ${TYPECLAW_CLI_ENTRY} "$@"`,
     )
   })
 
@@ -1607,7 +1607,7 @@ describe('network egress entrypoint shim', () => {
 
     // then
     expect(runtimeBranch.indexOf('start_xvfb\n')).toBeLessThan(
-      runtimeBranch.indexOf(`exec bun run ${TYPECLAW_CLI_ENTRY}`),
+      runtimeBranch.indexOf(`exec bun --smol run ${TYPECLAW_CLI_ENTRY}`),
     )
     expect(networkOnTail.indexOf('start_xvfb\n')).toBeLessThan(networkOnTail.indexOf(`exec setpriv --bounding-set`))
   })
@@ -1655,8 +1655,8 @@ describe('network egress entrypoint shim', () => {
     expect(offBranchEnd).toBeGreaterThan(-1)
     const offBranch = shim.slice(0, offBranchEnd)
     expect(offBranch).not.toContain('iptables -A OUTPUT')
-    expect(offBranch).toContain(`exec bun run ${TYPECLAW_CLI_ENTRY} "$@"`)
-    expect(offBranch).not.toMatch(/exec setpriv [^\n]*-- bun run/)
+    expect(offBranch).toContain(`exec bun --smol run ${TYPECLAW_CLI_ENTRY} "$@"`)
+    expect(offBranch).not.toMatch(/exec setpriv [^\n]*-- bun --smol run/)
   })
 
   test('per-agent Dockerfile wires ENTRYPOINT to the shim path, not directly to bun run', () => {
@@ -1818,7 +1818,7 @@ describe('network egress entrypoint shim', () => {
 
     // then
     expect(runtimeBranch.indexOf('link_persistent_home_files\n')).toBeLessThan(
-      runtimeBranch.indexOf(`exec bun run ${TYPECLAW_CLI_ENTRY}`),
+      runtimeBranch.indexOf(`exec bun --smol run ${TYPECLAW_CLI_ENTRY}`),
     )
     expect(networkOnTail.indexOf('link_persistent_home_files\n')).toBeLessThan(
       networkOnTail.indexOf(`exec setpriv --bounding-set`),

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -138,6 +138,13 @@ export const TYPECLAW_ENTRYPOINT_PATH = '/usr/local/bin/typeclaw-entrypoint'
 // a path, and resolves `/agent/typeclaw.json` (`Cannot run json files`).
 export const TYPECLAW_CLI_ENTRY = '/agent/node_modules/typeclaw/src/cli/index.ts'
 
+// Perf: `--smol` selects JSC's small-heap profile (grows slower, GCs more often),
+// trading a little CPU for lower resident memory. The agent runtime is a
+// burst-then-idle workload, so temporary allocations get reclaimed instead of
+// settling into a high-water RSS. Flag goes before `run`. Used at every exec site
+// below so the runtime phase inherits it on every network-policy path.
+const RUNTIME_BUN = 'bun --smol run'
+
 // IPv4 networks the container is forbidden to egress to when
 // `network.blockInternal` is true. Loopback (127/8) is NOT here — loopback
 // traffic uses the `lo` interface, which the shim's first ACCEPT rule
@@ -574,7 +581,7 @@ if [ "\${TYPECLAW_ENTRYPOINT_RUNTIME:-0}" = "1" ]; then
   link_persistent_home_files
   link_configured_symlinks
   start_xvfb
-  exec bun run ${TYPECLAW_CLI_ENTRY} "$@"
+  exec ${RUNTIME_BUN} ${TYPECLAW_CLI_ENTRY} "$@"
 fi
 
 persist_root="\${TYPECLAW_PERSIST_HOME_ROOT:-/agent/.typeclaw/home}"
@@ -602,7 +609,7 @@ if [ "\${TYPECLAW_NETWORK_BLOCK_INTERNAL:-0}" != "1" ]; then
   link_persistent_home_files
   link_configured_symlinks
   start_xvfb
-  exec bun run ${TYPECLAW_CLI_ENTRY} "$@"
+  exec ${RUNTIME_BUN} ${TYPECLAW_CLI_ENTRY} "$@"
 fi
 
 iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
@@ -657,7 +664,7 @@ fi
 link_persistent_home_files
 link_configured_symlinks
 start_xvfb
-exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- bun run ${TYPECLAW_CLI_ENTRY} "$@"
+exec setpriv --bounding-set -net_admin --inh-caps -net_admin --ambient-caps -net_admin -- ${RUNTIME_BUN} ${TYPECLAW_CLI_ENTRY} "$@"
 `
 }
 


### PR DESCRIPTION
## Summary

The container entrypoint exec'd the long-running agent as bare `bun run`, leaving JavaScriptCore on its default large-heap profile. The runtime is a **burst-then-idle** workload — an in-process ONNX embedder plus per-turn vector-decode and message allocation spikes — so the default heap lets transient allocations settle into a persistent high-water RSS. Live introspection of running containers showed the main `bun` process holding ~1 GB RSS with no memory flags set.

This PR adds `--smol` at every entrypoint exec site so JSC uses its small-heap profile: the heap grows more slowly and GC runs more often, reclaiming burst allocations instead of banking them into resident memory.

## Changes

- New `RUNTIME_BUN = 'bun --smol run'` constant in `dockerfile.ts`, used at all three exec sites (runtime-phase, network-off, and network-on `setpriv` paths) so they can't drift apart.
- Entrypoint-shim tests updated to assert the new exec line on every branch.

## Expected impact

Per an Oracle consult on the tradeoff: **~100–250 MB RSS reduction (10–25%)**, plausibly 5–30% depending on how much of the observed high-water mark is JSC heap slack vs. genuinely live data. `--smol` targets **JS-heap-reclaimable memory only** — the ~300 MB native ONNX residency is unaffected and is tracked separately.

## Why this trade is acceptable

For an intermittent chat agent, ONNX inference and network/LLM latency dominate turn time, so the modest extra GC cost of `--smol` is a good trade for lower steady-state memory. This is a throughput-tolerant workload, not a latency-critical server.

Deliberately **not** paired with a JS heap hard-cap: Bun/JSC has no reliable equivalent of V8's `--max-old-space-size`, and `BUN_JSC_forceRAMSize` is a sizing heuristic, not a ceiling.

## Scope notes

- Only the agent runtime (`typeclaw run`) exec is changed. The agent-browser shim (`bundled-plugins/agent-browser/shim.ts`) is a separate short-lived subprocess and is intentionally left as-is.
- `sandbox` is `restart-required`, and the Dockerfile/entrypoint is rewritten on every `typeclaw start`, so this takes effect on the next start — no re-`init` needed.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — **11825 pass / 0 fail** (246 dockerfile-shim tests included)
- Rendered shim inspected: all 3 exec sites emit `bun --smol run`, zero bare `bun run` remain.

## Follow-ups (separate work, from the same memory investigation)

1. Cache decoded vectors to kill the per-turn O(N) full-table decode in `vector/store.ts` (the most direct removable source of burst RSS + GC pressure).
2. Evaluate moving the ONNX embedder to a shared sidecar if duplicated model residency across co-located agents becomes the dominant host cost.
