### PR TITLE
Memoize role resolution with fail-safe invalidation

### DIFF
--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import type { SessionOrigin } from '@/agent/session-origin'
 
 import { BUILTIN_ROLES, expandOwnerWildcard } from './builtins'
-import { createPermissionService } from './permissions'
+import { createBoundedCache, createPermissionService } from './permissions'
 import { rolesConfigSchema, type RolesConfig } from './schema'
 
 function parseRoles(raw: unknown): RolesConfig {
@@ -248,6 +248,164 @@ describe('PermissionService — cron/subagent provenance', () => {
       parentSessionId: 'p',
     }
     expect(svc.resolveRole(sub)).toBe('guest')
+  })
+})
+
+describe('PermissionService — role resolution cache', () => {
+  test('repeated resolveRole/has calls for the same origin stay correct', () => {
+    const roles = parseRoles({ trusted: { match: ['slack:T0123 author:U_ME'] } })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    for (let i = 0; i < 5; i++) {
+      expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+      expect(svc.has(slackOwnerChat, 'channel.respond')).toBe(true)
+      expect(svc.resolveRole(slackStrangerChat)).toBe('guest')
+      expect(svc.has(slackStrangerChat, 'channel.respond')).toBe(false)
+    }
+  })
+
+  test('replaceRoles reflects a PROMOTION (no stale under-privileged read)', () => {
+    const svc = createPermissionService({ pluginPermissions: PLUGIN_PERMS })
+    // given: warms the cache with the pre-grant verdict
+    expect(svc.resolveRole(slackOwnerChat)).toBe('guest')
+    // when: the operator grants trusted to this author
+    svc.replaceRoles(parseRoles({ trusted: { match: ['slack:T0123 author:U_ME'] } }))
+    // then: the new grant is visible immediately, not the cached guest
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    expect(svc.has(slackOwnerChat, 'channel.respond')).toBe(true)
+  })
+
+  test('replaceRoles reflects a DEMOTION (no stale OVER-privileged read — the security case)', () => {
+    const svc = createPermissionService({
+      roles: parseRoles({ trusted: { match: ['slack:T0123 author:U_ME'] } }),
+      pluginPermissions: PLUGIN_PERMS,
+    })
+    // given: warms the cache while the author is trusted
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    expect(svc.has(slackOwnerChat, 'security.bypass.low')).toBe(true)
+    // when: the operator revokes the grant
+    svc.replaceRoles(parseRoles({}))
+    // then: the cache must NOT keep handing back trusted
+    expect(svc.resolveRole(slackOwnerChat)).toBe('guest')
+    expect(svc.has(slackOwnerChat, 'channel.respond')).toBe(false)
+    expect(svc.has(slackOwnerChat, 'security.bypass.low')).toBe(false)
+  })
+
+  test('replacePluginPermissions reflects owner-wildcard expansion changes', () => {
+    const svc = createPermissionService({ roles: parseRoles({ owner: { match: ['slack:T0123 author:U_ME'] } }) })
+    // given: no plugin perms yet, so owner has no bypass; warm the cache via has()
+    expect(svc.resolveRole(slackOwnerChat)).toBe('owner')
+    expect(svc.has(slackOwnerChat, 'security.bypass.gitExfil')).toBe(false)
+    // when: a plugin registers a bypass permission the owner wildcard expands to
+    svc.replacePluginPermissions?.({
+      pluginPermissions: ['security.bypass.gitExfil'],
+      ownerWildcardExclusions: [],
+    })
+    // then: the owner now holds it (role name cached OR not, the permission set is fresh)
+    expect(svc.resolveRole(slackOwnerChat)).toBe('owner')
+    expect(svc.has(slackOwnerChat, 'security.bypass.gitExfil')).toBe(true)
+  })
+
+  test('two authors in the same chat resolve independently (key includes authorId — no cross-author leak)', () => {
+    const roles = parseRoles({ trusted: { match: ['slack:T0123 author:U_ME'] } })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    // given: warm the trusted author first
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    // then: a different author in the SAME workspace+chat must not inherit the cached trusted verdict
+    expect(svc.resolveRole(slackStrangerChat)).toBe('guest')
+    // and repeated interleaving stays correct
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    expect(svc.resolveRole(slackStrangerChat)).toBe('guest')
+  })
+
+  test('workspace is part of the key (same author in another workspace is not trusted)', () => {
+    const roles = parseRoles({ trusted: { match: ['slack:T0123 author:U_ME'] } })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    // the rule pins workspace T0123, so the same author in T9999 is NOT trusted;
+    // this fails if `workspace` is dropped from the cache key
+    expect(svc.resolveRole({ ...slackOwnerChat, workspace: 'T9999' })).toBe('guest')
+  })
+
+  test('chat is part of the key (a chat-scoped grant does not leak to a sibling chat)', () => {
+    // A chat-CONSTRAINED rule: only C_GEN is trusted. If `chat` were omitted
+    // from the cache key, the warmed C_GEN verdict would leak to C_OTHER.
+    const roles = parseRoles({ trusted: { match: ['slack:T0123/C_GEN author:U_ME'] } })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    expect(svc.resolveRole({ ...slackOwnerChat, chat: 'C_OTHER' })).toBe('guest')
+  })
+
+  test('adapter is part of the key (identical coordinates under discord-bot do not inherit slack verdict)', () => {
+    // Same workspace/chat/author, different adapter. Only slack is trusted;
+    // if `adapter` were omitted from the key, the discord origin would inherit
+    // the warmed slack `trusted` verdict.
+    const roles = parseRoles({ trusted: { match: ['slack:T0123 author:U_ME'] } })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    const discordSameCoords: SessionOrigin = { ...slackOwnerChat, adapter: 'discord-bot' }
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    expect(svc.resolveRole(discordSameCoords)).toBe('guest')
+  })
+
+  test('cache stays bounded under a flood of distinct external coordinates', () => {
+    // Channel keys come from externally-controlled ids; a flood of distinct
+    // chats must not grow the cache without limit. Resolve far more distinct
+    // origins than the internal cap, then assert the warm hot entry and a fresh
+    // cold entry both still resolve correctly — eviction must not corrupt
+    // verdicts, only bound memory.
+    const roles = parseRoles({ trusted: { match: ['slack:T0123/C_GEN author:U_ME'] } })
+    const svc = createPermissionService({ roles, pluginPermissions: PLUGIN_PERMS })
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    for (let i = 0; i < 10_000; i++) {
+      expect(svc.resolveRole({ ...slackStrangerChat, chat: `C_FLOOD_${i}` })).toBe('guest')
+    }
+    // A chat that was evicted recomputes to the same correct verdict
+    expect(svc.resolveRole(slackOwnerChat)).toBe('trusted')
+    expect(svc.resolveRole({ ...slackOwnerChat, chat: 'C_OTHER' })).toBe('guest')
+  })
+})
+
+describe('createBoundedCache', () => {
+  test('never exceeds the cap, evicting the oldest insertion', () => {
+    const cache = createBoundedCache<number>(3)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('c', 3)
+    expect(cache.size).toBe(3)
+    // inserting a 4th key evicts 'a' (oldest), size stays at the cap
+    cache.set('d', 4)
+    expect(cache.size).toBe(3)
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBe(2)
+    expect(cache.get('d')).toBe(4)
+  })
+
+  test('stays bounded under a flood far exceeding the cap', () => {
+    const cache = createBoundedCache<number>(8)
+    for (let i = 0; i < 1000; i++) cache.set(`k${i}`, i)
+    expect(cache.size).toBe(8)
+    // only the most-recent `max` insertions survive
+    expect(cache.get('k999')).toBe(999)
+    expect(cache.get('k0')).toBeUndefined()
+  })
+
+  test('re-setting an existing key updates in place without evicting', () => {
+    const cache = createBoundedCache<number>(2)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('a', 10)
+    // 'a' was already present, so 'b' must not have been evicted
+    expect(cache.size).toBe(2)
+    expect(cache.get('a')).toBe(10)
+    expect(cache.get('b')).toBe(2)
+  })
+
+  test('clear empties the cache', () => {
+    const cache = createBoundedCache<number>(4)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.clear()
+    expect(cache.size).toBe(0)
+    expect(cache.get('a')).toBeUndefined()
   })
 })
 

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -129,6 +129,40 @@ function levenshtein(a: string, b: string): number {
   return prev[lb]!
 }
 
+// Cap on the memoized role-resolution cache. Channel keys derive from
+// externally-controlled coordinates, so the cache must be bounded — see the
+// roleCache comment in createPermissionService.
+export const ROLE_CACHE_MAX = 4096
+
+export type BoundedCache<V> = {
+  get(key: string): V | undefined
+  set(key: string, value: V): void
+  clear(): void
+  readonly size: number
+}
+
+// Insertion-ordered cache with a hard capacity. On overflow it evicts the
+// oldest inserted entry (JS Map preserves insertion order), so size never
+// exceeds `max`. Extracted as a standalone factory so the bound is unit-testable
+// in isolation — the in-service cache is otherwise unobservable.
+export function createBoundedCache<V>(max: number): BoundedCache<V> {
+  const store = new Map<string, V>()
+  return {
+    get: (key) => store.get(key),
+    set(key, value) {
+      if (!store.has(key) && store.size >= max) {
+        const oldest = store.keys().next().value
+        if (oldest !== undefined) store.delete(oldest)
+      }
+      store.set(key, value)
+    },
+    clear: () => store.clear(),
+    get size() {
+      return store.size
+    },
+  }
+}
+
 export function createPermissionService(opts: CreatePermissionServiceOptions = {}): PermissionService {
   let pluginPermissions = opts.pluginPermissions ?? []
   let ownerWildcardExclusions = opts.ownerWildcardExclusions ?? []
@@ -136,9 +170,24 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
   let resolved = buildRoleTable(lastRoles, pluginPermissions, ownerWildcardExclusions)
   let byName = new Map(resolved.map((r) => [r.name, r]))
 
-  function resolveRole(origin: SessionOrigin | undefined): string {
-    if (origin === undefined) return 'guest'
+  // resolveRole is called several times per tool invocation (the bash sandbox
+  // alone resolves it up to 6x through resolveHiddenPaths) and once per channel
+  // admission, and each call re-scans the whole role table via matchesOrigin.
+  // The result is a pure function of (role table, resolved origin fields), so
+  // memoize it. The cache holds only the CURRENT role table's verdicts; both
+  // role-table rebuilds (replaceRoles / replacePluginPermissions) drop it, so a
+  // stale entry can never survive a config change and hand back a now-wrong
+  // (e.g. over-privileged) role. See roleCacheKey for exactly which fields the
+  // key covers — it must stay a superset of what computeRole reads.
+  //
+  // Bounded because channel cache keys derive from externally-controlled
+  // coordinates (workspace/chat/author): a stream of distinct GitHub issue or
+  // chat ids — even denied traffic that resolves to guest — would otherwise
+  // grow the map without limit until the next role-table rebuild. See
+  // createBoundedCache for the eviction policy.
+  const roleCache = createBoundedCache<string>(ROLE_CACHE_MAX)
 
+  function computeRole(origin: SessionOrigin): string {
     // Runtime-owned infrastructure (memory, backup) acts on the operator's
     // behalf over operator-owned state. It is constructed only by runtime/
     // bundled code — inbound channel/cron content cannot produce this kind —
@@ -166,6 +215,21 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
       }
     }
     return 'guest'
+  }
+
+  function resolveRole(origin: SessionOrigin | undefined): string {
+    if (origin === undefined) return 'guest'
+    const key = roleCacheKey(origin)
+    if (key === null) return computeRole(origin)
+    const cached = roleCache.get(key)
+    if (cached !== undefined) return cached
+    const role = computeRole(origin)
+    roleCache.set(key, role)
+    return role
+  }
+
+  function invalidateRoleCache(): void {
+    roleCache.clear()
   }
 
   function roleSeverity(name: string): number | undefined {
@@ -214,12 +278,14 @@ export function createPermissionService(opts: CreatePermissionServiceOptions = {
       lastRoles = roles ?? {}
       resolved = buildRoleTable(lastRoles, pluginPermissions, ownerWildcardExclusions)
       byName = new Map(resolved.map((r) => [r.name, r]))
+      invalidateRoleCache()
     },
     replacePluginPermissions(next) {
       pluginPermissions = next.pluginPermissions
       ownerWildcardExclusions = next.ownerWildcardExclusions
       resolved = buildRoleTable(lastRoles, pluginPermissions, ownerWildcardExclusions)
       byName = new Map(resolved.map((r) => [r.name, r]))
+      invalidateRoleCache()
     },
   }
 }
@@ -291,6 +357,31 @@ function resolveOne(
     name,
     match: user?.match ?? [],
     permissions: user?.permissions ?? [],
+  }
+}
+
+// Cache key for the memoized role resolution. It MUST enumerate exactly the
+// origin fields that computeRole/matchesOrigin consult, and NOTHING that varies
+// turn-to-turn without changing the verdict (participants, membership, thread,
+// reactionRef, *Name display fields). Returning null opts an origin OUT of the
+// cache — used for kinds where the answer is already O(1) (system/cron/subagent,
+// which read only a role string off the origin) so there is no scan to save and
+// no reason to risk an under-specified key. tui and channel are the scan-heavy
+// kinds worth caching:
+//   - tui: verdict depends only on kind (matchesOrigin's tui rule ignores
+//     sessionId), so every tui origin shares one entry.
+//   - channel: verdict depends on adapter + workspace + chat + lastInboundAuthorId
+//     (the exact inputs matchesChannel/matchesBucket/matchesAuthor read).
+// The `c` prefix + NUL separators keep channel keys unambiguous even if a field
+// contained the delimiter of another.
+function roleCacheKey(origin: SessionOrigin): string | null {
+  switch (origin.kind) {
+    case 'tui':
+      return 'tui'
+    case 'channel':
+      return ['c', origin.adapter, origin.workspace, origin.chat, origin.lastInboundAuthorId ?? ''].join('\u0000')
+    default:
+      return null
   }
 }
 


### PR DESCRIPTION
## Background

`resolveRole` re-scans the entire role table (each role's match rules, via
`matchesOrigin`) on every call — and it is called *several times per tool
invocation*. The bash sandbox alone resolves it up to 6× through
`resolveHiddenPaths` (the private-surface masking decision), and channel
admission resolves it once per inbound. On a busy channel or a bash-heavy turn
that adds up to a lot of redundant table walks, all returning the same answer.

The verdict is a pure function of `(role table, a few origin fields)`, so it is
a natural memoization target. This came out of a security-guard performance
sweep; it was the single highest-cumulative-cost item because of the 6×
fan-out on the bash path.

## Summary

Split `resolveRole` into `computeRole` (the existing logic) plus a memoizing
wrapper backed by a per-service `Map<key, roleName>`.

**The cache is only correct because it can never outlive the role table it was
computed against.** Two things make it fail-safe:

- **Invalidation on every role-table rebuild.** Both `replaceRoles` (fired by
  the config reloadable on live `typeclaw.json` / `typeclaw role claim` edits,
  `src/config/reloadable.ts`) and `replacePluginPermissions` drop the cache. A
  stale entry therefore cannot survive a config change and hand back a
  now-wrong — possibly *over-privileged* — role.
- **A key that is a strict superset of what resolution reads.** `roleCacheKey`
  enumerates exactly the fields `computeRole`/`matchesOrigin` consult:
  - `tui` → `kind` only (the tui match rule ignores `sessionId`).
  - `channel` → `adapter + workspace + chat + lastInboundAuthorId` (the exact
    inputs of `matchesChannel`/`matchesBucket`/`matchesAuthor`).
  Turn-varying, verdict-irrelevant fields (`participants`, `membership`,
  `thread`, `reactionRef`, display `*Name`s) are deliberately excluded.

`system` / `cron` / `subagent` origins opt out of the cache (`roleCacheKey`
returns `null`): their resolution is already an O(1) role-string read off the
origin, so there is nothing to save and no reason to risk an under-specified key.

## What this does NOT do

- Does not cache `has()` verdicts or permission sets — only the role *name*.
  `has()` still reads the live permission set from the current role table, which
  is why `replacePluginPermissions` (which changes permission sets but not match
  rules) is safe even before its cache drop.
- Does not touch the sandbox filesystem-I/O costs from the same audit (deferred,
  higher risk).
- No change to how any origin resolves — purely a caching layer.

## Review notes

- **The load-bearing invariant is in the `roleCacheKey` comment**: if anyone
  later adds a new origin field to role matching in `resolve.ts`, they MUST add
  it to the key or risk a stale-verdict privilege bug. Please sanity-check that
  the key currently covers everything `matchesOrigin` reads.
- Tests assert both invalidation directions, including the **security-critical
  demotion** (a revoked grant must not keep resolving to the cached higher role)
  and **cross-author isolation** (two authors in the same chat must not share a
  cached verdict). I verified these fail if either `invalidateRoleCache()` call
  is removed.