### PR TITLE
Decode the vector corpus once per hybrid search, not per chunk

### DIFF
--- a/src/bundled-plugins/memory/vector/hybrid.test.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.test.ts
@@ -1215,6 +1215,36 @@ describe('hybridSearch query chunking', () => {
       store.close()
     }
   })
+
+  it('decodes the corpus once per search regardless of chunk count', async () => {
+    const { agentDir, store } = createFixture()
+    try {
+      writeTopic(agentDir, 'noise', 'Noise', 'Unrelated.')
+      store.upsert(row('topic:noise', 'noise', vector({ 1: 1 })))
+
+      const loadRows = store.loadRows.bind(store)
+      let loadRowsCalls = 0
+      store.loadRows = (modelId, dims) => {
+        loadRowsCalls += 1
+        return loadRows(modelId, dims)
+      }
+
+      // An over-budget prompt that fans out to the 10-chunk cap.
+      const query = `${'word '.repeat(TEXT_TOKEN_BUDGET * 40)} FINAL-TAIL`
+      let seenChunks = 0
+      const embedPerChunk: EmbedFn = async (texts) => {
+        seenChunks = texts.length
+        return texts.map(() => vector({ 1: 1 }))
+      }
+
+      await hybridSearch(query, store, agentDir, 3, embedPerChunk)
+
+      expect(seenChunks).toBe(10)
+      expect(loadRowsCalls).toBe(1)
+    } finally {
+      store.close()
+    }
+  })
 })
 
 function createFixture(): { agentDir: string; store: VectorStore } {

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -24,7 +24,7 @@ import { embed, EMBEDDING_MODEL_ID, type EmbedType } from './embedder'
 import type { Passage } from './passages'
 import { clearsBaseline, gateRelevance, MARGIN, streamAdmissionBaseline } from './relevance-gate'
 import { crossScriptMarginScale, dominantScript, type ScriptClass } from './script'
-import { VectorStore, type ScoredVectorRow, type VectorRow } from './store'
+import { scoreRows, VectorStore, type ScoredVectorRow, type VectorRow } from './store'
 import { chunkEmbeddableText } from './truncation'
 
 export { collectPassages, findMissingPassages, type Passage } from './passages'
@@ -241,9 +241,17 @@ function maxScoreAcrossChunks(
   queryEmbeddings: Float32Array[],
   store: VectorStore,
 ): { scored: ScoredVectorRow[]; winnerChunkByRowId: Map<string, number> } {
+  // Decode the compatible corpus ONCE and score every chunk against it, instead
+  // of re-reading and re-decoding the whole table per chunk (queryScored did a
+  // full SELECT + BLOB decode on each call). Same MAX-across-chunks result, but
+  // the O(rows) decode runs once per turn instead of once per chunk.
+  const dims = queryEmbeddings[0]?.length
+  if (dims === undefined) return { scored: [], winnerChunkByRowId: new Map() }
+  const rows = store.loadRows(EMBEDDING_MODEL_ID, dims)
+
   const best = new Map<string, { scored: ScoredVectorRow; chunkIndex: number }>()
   queryEmbeddings.forEach((embedding, chunkIndex) => {
-    for (const scoredRow of store.queryScored(embedding, EMBEDDING_MODEL_ID)) {
+    for (const scoredRow of scoreRows(rows, embedding)) {
       const existing = best.get(scoredRow.row.id)
       if (existing === undefined || scoredRow.score > existing.scored.score) {
         best.set(scoredRow.row.id, { scored: scoredRow, chunkIndex })

--- a/src/bundled-plugins/memory/vector/store.test.ts
+++ b/src/bundled-plugins/memory/vector/store.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { withGitLock } from '@/git/mutex'
 
 import { EMBEDDING_MODEL_ID } from './embedder'
-import { VectorStore, type VectorRow } from './store'
+import { scoreRows, VectorStore, type VectorRow } from './store'
 
 const MODEL = EMBEDDING_MODEL_ID
 const testDirs: string[] = []
@@ -51,6 +51,43 @@ describe('VectorStore', () => {
       const orthogonal = scored.find((s) => s.row.id === 'topic:orthogonal')
       expect(aligned?.score).toBeCloseTo(Math.SQRT1_2, 6)
       expect(orthogonal?.score).toBeCloseTo(0, 6)
+    } finally {
+      store.close()
+    }
+  })
+
+  it('decode-once: scoreRows(loadRows) matches queryScored for every embedding', () => {
+    // The multi-chunk retrieval path decodes the corpus once via loadRows and
+    // scores each chunk with scoreRows; this must equal the per-embedding
+    // queryScored it replaced, or MAX-across-chunks ranking would drift.
+    const store = openTestStore()
+    try {
+      store.upsert(row('topic:a', embedding(768, { 0: 1 })))
+      store.upsert(row('topic:b', embedding(768, { 1: 1 })))
+      store.upsert(row('stream:c', embedding(768, { 0: 0.5, 2: 0.5 })))
+
+      const rows = store.loadRows(MODEL, 768)
+      const queries = [embedding(768, { 0: 1, 1: 1 }), embedding(768, { 2: 1 })]
+
+      for (const q of queries) {
+        const viaLoad = scoreRows(rows, q)
+          .map(({ row: r, score }) => ({ id: r.id, score }))
+          .sort((a, b) => b.score - a.score)
+        const viaQuery = store.queryScored(q, MODEL).map(({ row: r, score }) => ({ id: r.id, score }))
+        expect(viaLoad).toEqual(viaQuery)
+      }
+    } finally {
+      store.close()
+    }
+  })
+
+  it('decode-once: loadRows excludes rows from a different model/dtype variant', () => {
+    const store = openTestStore()
+    try {
+      store.upsert({ ...row('topic:stale', embedding(768, { 0: 1 })), model: 'Xenova/multilingual-e5-base@fp32' })
+      store.upsert(row('topic:current', embedding(768, { 0: 1 })))
+
+      expect(store.loadRows(MODEL, 768).map((r) => r.id)).toEqual(['topic:current'])
     } finally {
       store.close()
     }

--- a/src/bundled-plugins/memory/vector/store.ts
+++ b/src/bundled-plugins/memory/vector/store.ts
@@ -95,24 +95,28 @@ export class VectorStore {
   // Same cosine scan as `query` but returns every compatible row WITH its score
   // and unsliced, so a caller can reason about the full score distribution (the
   // relevance gate's per-query baseline) before deciding how many to keep.
+  queryScored(embedding: Float32Array, modelId: string): ScoredVectorRow[] {
+    return scoreRows(this.loadRows(modelId, embedding.length), embedding).sort((a, b) => b.score - a.score)
+  }
+
+  // Decodes every compatible row's embedding BLOB into a Float32Array ONCE. A
+  // multi-chunk query scores many embeddings against the SAME corpus, so callers
+  // that decode here once and reuse the result across chunks avoid re-reading and
+  // re-decoding the whole table per chunk (the per-turn allocation hot path). The
+  // returned rows are transient — held only for the current search, never cached
+  // across turns (that would trade collectable garbage for permanent resident
+  // memory, the opposite of what we want).
   //
   // Filter by embedding identity, not dims alone: a stale row from a different
   // model/dtype variant can share the same dims but lives in an incompatible
   // vector space, so cosine against it is garbage. Excluding it here keeps a
   // partial re-embed (mixed variants mid-rebuild) at reduced recall, never
   // wrong scores.
-  queryScored(embedding: Float32Array, modelId: string): ScoredVectorRow[] {
-    // The query vector's magnitude is identical for every row in this scan, so
-    // hoist it out of the per-row cosine instead of recomputing N times (each
-    // recompute is 768 multiply-adds + a sqrt). Behavior is unchanged — same
-    // cosine values, fewer operations on the brute-force hot path.
-    const queryMagnitude = magnitude(embedding)
+  loadRows(modelId: string, dims: number): VectorRow[] {
     return this.db
       .query<StoredVectorRow, [string, number]>('SELECT * FROM vectors WHERE model = ? AND dims = ?')
-      .all(modelId, embedding.length)
+      .all(modelId, dims)
       .map(toVectorRow)
-      .map((row) => ({ row, score: cosineSimilarity(embedding, queryMagnitude, row.embedding) }))
-      .sort((a, b) => b.score - a.score)
   }
 
   deleteOtherModels(modelId: string): void {
@@ -158,6 +162,14 @@ export class VectorStore {
   close(): void {
     this.db.close()
   }
+}
+
+// Scores pre-decoded rows against one query embedding. The query vector's
+// magnitude is identical for every row, so hoist it out of the per-row cosine
+// instead of recomputing N times (each recompute is 768 multiply-adds + a sqrt).
+export function scoreRows(rows: VectorRow[], embedding: Float32Array): ScoredVectorRow[] {
+  const queryMagnitude = magnitude(embedding)
+  return rows.map((row) => ({ row, score: cosineSimilarity(embedding, queryMagnitude, row.embedding) }))
 }
 
 function toVectorRow(row: StoredVectorRow): VectorRow {


### PR DESCRIPTION
## Summary

Per-turn memory retrieval (`hybridSearch`) embeds an over-budget prompt as up to 10 query chunks (`MAX_QUERY_CHUNKS`) and scores each chunk against the vector corpus. `maxScoreAcrossChunks` did this by calling `store.queryScored` **once per chunk** — and each `queryScored` ran a full `SELECT * FROM vectors` plus a `BLOB → Float32Array` decode of the **entire** compatible corpus. So a 10-chunk turn read and decoded the whole table up to **10 times**, producing tens-to-hundreds of MB of transient `Float32Array` garbage per turn at a mature corpus.

This PR decodes the corpus **once per search** and scores every chunk against the shared decoded rows. Same MAX-across-chunks ranking; the O(rows) decode runs once per turn instead of once per chunk.

## What this is (and isn't)

This is the **within-turn** decode-once refactor — deliberately **not** a cross-turn cache. An Oracle analysis of a process-lifetime decoded-vector cache showed it would trade collectable garbage for *permanent resident memory* (+3–22 MB idle RSS depending on corpus size) for a latency win the LLM call makes invisible — i.e. it would move steady-state RSS the wrong way. The decode-once set here **dies at end of search**, so it cuts allocation/GC pressure with zero residency cost. `loadRows`' doc comment records the "never cache across turns" decision so it isn't "optimized" into that regression later.

## Changes

**`store.ts`** — extract two seams out of `queryScored`:
- `loadRows(modelId, dims)` — decode a model/dims-compatible corpus from SQLite once. Keeps the model-**identity** filter (not dims alone), so a stale dtype variant sharing dims is never cosine-scored.
- `scoreRows(rows, embedding)` — cosine-score pre-decoded rows against one embedding (with the existing query-magnitude hoist).
- `queryScored` now delegates through both — unchanged public behavior.

**`hybrid.ts`** — `maxScoreAcrossChunks` calls `loadRows` once, then `scoreRows` per chunk.

## Expected impact

Per the Oracle estimate: primarily a **CPU/allocation/GC** reduction. Removes ~9/10 of the per-turn decode work on multi-chunk turns (roughly 60→6 MB transient garbage at N=1,000 rows, 300→30 MB at N=5,000). Latency saving is small relative to the embed + LLM call and larger corpora benefit most; the real value is fewer throwaway allocations feeding GC. No steady-state RSS increase (nothing retained across turns).

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — **11848 pass / 0 fail**
- **Equivalence test** (`store.test.ts`): `scoreRows(loadRows(...))` matches `queryScored` per embedding, so MAX-across-chunks ranking can't drift.
- **Decode-once guard** (`hybrid.test.ts`): asserts `loadRows` is called exactly once for a 10-chunk query. Verified failing (`Received: 10`) on the old per-chunk path, so the guard has teeth.
