### PR TITLE
Destroy the tool-input snapshot read stream so it can't leak an fd

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { randomUUID } from 'node:crypto'
+import { readdirSync } from 'node:fs'
 import {
   link,
   mkdir,
@@ -678,6 +679,36 @@ describe('wrapPluginTool', () => {
     } finally {
       await rm(agentDir, { recursive: true, force: true })
     }
+  })
+
+  test.skipIf(lacksInodeAnchoring)('repeatedly pinning a file operand does not leak file descriptors', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-pin-fd-leak-'))
+    await writeFile(path.join(agentDir, 'input.txt'), 'x'.repeat(4096))
+    const fdCount = () => readdirSync('/proc/self/fd').length
+
+    // Warm one cycle so lazy one-time descriptors are allocated before baseline.
+    await (
+      await enforceAndPinToolFiles({
+        tool: 'reader',
+        args: { path: 'input.txt' },
+        agentDir,
+        fileOperands: { input: ['path'] },
+      })
+    ).cleanup()
+
+    const baseline = fdCount()
+    for (let i = 0; i < 50; i++) {
+      const pinned = await enforceAndPinToolFiles({
+        tool: 'reader',
+        args: { path: 'input.txt' },
+        agentDir,
+        fileOperands: { input: ['path'] },
+      })
+      await pinned.cleanup()
+    }
+
+    expect(fdCount()).toBeLessThanOrEqual(baseline)
+    await rm(agentDir, { recursive: true, force: true })
   })
 
   test('researcher write_report preserves its absent O_EXCL output through the production plugin wrapper', async () => {

--- a/src/agent/tool-file-safety.ts
+++ b/src/agent/tool-file-safety.ts
@@ -861,15 +861,24 @@ async function streamSnapshot(
       callback(null, chunk)
     },
   })
-  await pipeline(
-    source.createReadStream({ autoClose: false, start: 0 }),
-    limiter,
-    createWriteStream(destination, {
-      flags: 'wx',
-      mode: 0o400,
-    }),
-    { signal },
-  )
+  // `autoClose: false` leaves the FileHandle to the caller, but the ReadStream
+  // opens its OWN fd that `source.close()` never releases and GC never reclaims
+  // — one leaked fd per snapshotted file, reaching EMFILE on a long-running
+  // agent. Destroy the stream explicitly to free that fd deterministically.
+  const readStream = source.createReadStream({ autoClose: false, start: 0 })
+  try {
+    await pipeline(
+      readStream,
+      limiter,
+      createWriteStream(destination, {
+        flags: 'wx',
+        mode: 0o400,
+      }),
+      { signal },
+    )
+  } finally {
+    readStream.destroy()
+  }
   return copied
 }
 


### PR DESCRIPTION
## Background

A long-running agent (a company-wide PR reviewer, reviewing across several repos) began failing mid-review with `EMFILE: too many open files`. Once file descriptors are exhausted, everything in the same turn starts failing together — ordinary file reads (`EMFILE … open '/agent/…'`), the local git-metadata scan (`fatal: not a git repository`), and DNS (`getaddrinfo`). On the reviewer this surfaced as it concluding the review environment was broken and leaving a stale, un-clearable review.

The process's fd count grew monotonically under review load (measured climbing past 16k toward the container's `RLIMIT_NOFILE` of 20480), never receding, and a restart reset it to baseline — i.e. accumulated in-process state, not a config limit.

## Root cause

`streamSnapshot` in `src/agent/tool-file-safety.ts` (the tool-input pinning path — it snapshots each file operand a tool references into an immutable copy) created its read stream with:

```ts
source.createReadStream({ autoClose: false, start: 0 })
```

`autoClose: false` is deliberate: the caller owns the `FileHandle` and closes it in its own `finally`. But the `ReadStream` created over that handle allocates **its own** descriptor, and `source.close()` does not release it. Nothing destroyed the stream, so that descriptor leaked — and GC never reclaimed it (a hard ownership leak, not finalizer lag).

Every file snapshotted during a tool call leaked exactly one fd. A reviewer walking a checked-out PR tree snapshots many files per turn, so the count climbed until `EMFILE`.

### How it was pinned

Ruled out the usual suspects by in-process `/proc/self/fd` census under the real runtime (embedding pipeline, session-list I/O, the vector SQLite store, `curl-impersonate`, `git status` spawns, the pi bash temp-file path, the `SessionManager` writer, and the hardlink-identity scanner — all release cleanly). A live fd-target trace then attributed the leaked descriptors to the pinned tool-input snapshot files, pointing straight at the `autoClose: false` stream. A forced-GC probe confirmed the descriptors are never reclaimed (hard leak).

## Fix

Hold the stream and destroy it in a `finally`, so its fd is freed deterministically while the caller keeps ownership of the `FileHandle`:

```ts
const readStream = source.createReadStream({ autoClose: false, start: 0 })
try {
  await pipeline(readStream, limiter, createWriteStream(destination, { flags: 'wx', mode: 0o400 }), { signal })
} finally {
  readStream.destroy()
}
```

## Tests

Adds a Linux-only regression test (`plugin-tools.test.ts`) that pins a file operand 50 times through the public `enforceAndPinToolFiles` API and asserts the `/proc/self/fd` count stays at baseline. It is skipped on non-Linux because the snapshot path is Linux inode-anchored (`skipIf(lacksInodeAnchoring)`).

Verified Red/Green on Linux at the mechanism level: the `autoClose: false`-without-destroy shape leaks +50 fds over 50 iterations (test fails); the fix holds the count flat (test passes).

## Checks

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — `plugin-tools.test.ts` 147 pass / 0 fail. The 8 failing tests in the full suite are pre-existing checked-in schema-drift/scaffold guards on `main` (they fail identically at the base commit with these changes reverted) and are unrelated to this change, which touches no schema.

## Scope

Does not change `streamSnapshot`'s public shape, the `autoClose: false` ownership contract, or any snapshot behavior — it only frees the stream's descriptor. Orthogonal defense-in-depth (a container `--ulimit nofile`, fd-high-watermark recycling) is out of scope.