### PR TITLE
Release stream and subprocess-pipe fds on every path (resource-cleanup hardening)

### DIFF
--- a/src/bundled-plugins/backup/index.ts
+++ b/src/bundled-plugins/backup/index.ts
@@ -299,8 +299,11 @@ async function resolveBackupAuthEnv(
   }
 }
 
-export async function resolveOriginPushUrl(cwd: string): Promise<string | null> {
-  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+export async function resolveOriginPushUrl(
+  cwd: string,
+  bunOverride?: { spawn: typeof Bun.spawn },
+): Promise<string | null> {
+  const bun = bunOverride ?? (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
   if (!bun) return null
   const repo = resolveAgentGit(cwd)
   if (!repo) return null
@@ -311,8 +314,22 @@ export async function resolveOriginPushUrl(cwd: string): Promise<string | null> 
       stderr: 'ignore',
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_OPTIONAL_LOCKS: '0' },
     })
-    if ((await proc.exited) !== 0) return null
-    const out = (await new Response(proc.stdout).text()).trim()
+    const exited = proc.exited
+    const stdoutDrain = new Response(proc.stdout).text()
+    let exitCode: number
+    let stdout: string
+    try {
+      ;[exitCode, stdout] = await Promise.all([exited, stdoutDrain])
+    } catch {
+      // A stdout-drain rejection must not leave the git child running: kill it
+      // and await exit + drain before returning, so `Promise.all`'s early reject
+      // can't orphan the subprocess or its pipe.
+      proc.kill()
+      await Promise.allSettled([exited, stdoutDrain])
+      return null
+    }
+    if (exitCode !== 0) return null
+    const out = stdout.trim()
     return out === '' ? null : out
   } catch {
     return null

--- a/src/bundled-plugins/backup/resolve-origin-push-url.test.ts
+++ b/src/bundled-plugins/backup/resolve-origin-push-url.test.ts
@@ -65,4 +65,33 @@ describe('resolveOriginPushUrl', () => {
   test('no repo at all (neither .git nor .gitstore): returns null', async () => {
     expect(await resolveOriginPushUrl(root)).toBeNull()
   })
+
+  test('kills and reaps the git child when the stdout drain rejects', async () => {
+    await git(root, ['init', '-b', 'main'])
+    await git(root, ['remote', 'add', 'origin', 'https://github.com/acme/standalone.git'])
+
+    let killed = false
+    let resolveExited: (code: number) => void = () => {}
+    const exited = new Promise<number>((resolve) => {
+      resolveExited = resolve
+    })
+    const stubbedSpawn = (() => ({
+      exited,
+      stdout: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error('stdout drain failed'))
+        },
+      }),
+      // kill() settling `exited` proves resolveOriginPushUrl reaped the child on
+      // the drain-failure path instead of returning null while it lived on.
+      kill() {
+        killed = true
+        resolveExited(137)
+      },
+    })) as unknown as typeof Bun.spawn
+
+    expect(await resolveOriginPushUrl(root, { spawn: stubbedSpawn })).toBeNull()
+    expect(killed).toBe(true)
+    expect(await exited).toBe(137)
+  })
 })

--- a/src/bundled-plugins/backup/runner.test.ts
+++ b/src/bundled-plugins/backup/runner.test.ts
@@ -758,3 +758,40 @@ describe('runMaintenance', () => {
     }
   })
 })
+
+describe('makeDefaultGitSpawn', () => {
+  test('aborts and reaps the git child when a pipe drain rejects', async () => {
+    let aborted = false
+    const stubbedSpawn = ((opts: { signal?: AbortSignal }) => {
+      // `exited` only settles when the abort signal fires, so the test proves
+      // the drain-failure path aborts the child and waits for it rather than
+      // letting the outer timer clear while a stuck git process lives on.
+      const exited = new Promise<number>((resolve) => {
+        opts.signal?.addEventListener('abort', () => {
+          aborted = true
+          resolve(137)
+        })
+      })
+      return {
+        exited,
+        stdout: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.error(new Error('stdout drain failed'))
+          },
+        }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close()
+          },
+        }),
+      }
+    }) as unknown as typeof Bun.spawn
+
+    const spawn = makeDefaultGitSpawn({ spawn: stubbedSpawn })
+    const result = await spawn(['status'], { cwd: '/tmp', timeoutMs: 10_000 })
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toBe('stdout drain failed')
+    expect(aborted).toBe(true)
+  })
+})

--- a/src/bundled-plugins/backup/runner.ts
+++ b/src/bundled-plugins/backup/runner.ts
@@ -399,9 +399,9 @@ function sanitizeCommitMessage(raw: string): string {
   return rest.length > 0 ? `${subject}\n\n${rest}` : subject
 }
 
-export function makeDefaultGitSpawn(): GitSpawn {
+export function makeDefaultGitSpawn(bunOverride?: { spawn: typeof Bun.spawn }): GitSpawn {
   return withIndexLockRetry(async (args, { cwd, timeoutMs, env }) => {
-    const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+    const bun = bunOverride ?? (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
     if (!bun) {
       return { exitCode: 127, stdout: '', stderr: 'Bun runtime not available', timedOut: false }
     }
@@ -419,9 +419,23 @@ export function makeDefaultGitSpawn(): GitSpawn {
         env: { ...process.env, ...NONINTERACTIVE_ENV, ...env },
         signal: controller.signal,
       })
-      const exitCode = await proc.exited
-      const stdout = await new Response(proc.stdout).text()
-      const stderr = await new Response(proc.stderr).text()
+      const exitedDrain = proc.exited
+      const stdoutDrain = new Response(proc.stdout).text()
+      const stderrDrain = new Response(proc.stderr).text()
+      let exitCode: number
+      let stdout: string
+      let stderr: string
+      try {
+        ;[exitCode, stdout, stderr] = await Promise.all([exitedDrain, stdoutDrain, stderrDrain])
+      } catch (drainErr) {
+        // A pipe-read rejection must not escape while the git child is still
+        // running (the outer `finally` would clear the abort timer and leave a
+        // stuck child unbounded). Abort to kill it, then wait for exit and both
+        // drains to settle before surfacing the error.
+        controller.abort()
+        await Promise.allSettled([exitedDrain, stdoutDrain, stderrDrain])
+        throw drainErr
+      }
       const timedOut = controller.signal.aborted
       return { exitCode, stdout, stderr, timedOut }
     } catch (err) {

--- a/src/container/shared.test.ts
+++ b/src/container/shared.test.ts
@@ -22,6 +22,7 @@ import {
   resolveDockerBinary,
   sanitizeDockerConfigJson,
   sanitizeDockerStderr,
+  spawnInheritTeeStderr,
   waitForRemoval,
 } from './shared'
 
@@ -706,5 +707,46 @@ describe('dockerBindMount', () => {
 
   test('throws on a comma in a path because --mount cannot express it', () => {
     expect(() => dockerBindMount({ src: '/srv/a,b', dst: '/agent' })).toThrow(/comma/)
+  })
+})
+
+describe('spawnInheritTeeStderr', () => {
+  test('kills the child and awaits its exit when a stderr read throws', async () => {
+    let killed = false
+    let resolveExited: (code: number) => void = () => {}
+    const exited = new Promise<number>((resolve) => {
+      resolveExited = resolve
+    })
+    let firstRead = true
+    const stderr = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (firstRead) {
+          firstRead = false
+          controller.enqueue(new TextEncoder().encode('some build output'))
+          return
+        }
+        throw new Error('stderr read failed')
+      },
+    })
+    const proc = {
+      stderr,
+      exited,
+      kill() {
+        killed = true
+        resolveExited(137)
+      },
+    }
+    const bun = { spawn: () => proc } as unknown as Parameters<typeof spawnInheritTeeStderr>[0]
+
+    await expect(spawnInheritTeeStderr(bun, ['docker', 'build'], undefined, undefined, undefined)).rejects.toThrow(
+      'stderr read failed',
+    )
+
+    // kill() resolving `exited` is what proves spawnInheritTeeStderr awaited the
+    // child rather than orphaning it — the promise below only settles once kill
+    // fires resolveExited.
+    expect(killed).toBe(true)
+    expect(await exited).toBe(137)
+    expect(stderr.locked).toBe(false)
   })
 })

--- a/src/container/shared.ts
+++ b/src/container/shared.ts
@@ -92,7 +92,7 @@ export const defaultDockerExec: DockerExec = async (args, options) => {
 // needs both: the user watches the build, and start() inspects the captured
 // stderr to detect a missing credential helper and retry under a sanitized
 // DOCKER_CONFIG.
-async function spawnInheritTeeStderr(
+export async function spawnInheritTeeStderr(
   bun: NonNullable<ReturnType<typeof getBun>>,
   cmd: string[],
   cwd: string | undefined,
@@ -102,11 +102,24 @@ async function spawnInheritTeeStderr(
   const proc = bun.spawn({ cmd, cwd, stdout: 'inherit', stderr: 'pipe', signal, env })
   const chunks: Uint8Array[] = []
   const reader = proc.stderr.getReader()
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (done) break
-    process.stderr.write(value)
-    chunks.push(value)
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      process.stderr.write(value)
+      chunks.push(value)
+    }
+  } catch (err) {
+    // A read/write throw skips the normal drain: cancel (not just releaseLock,
+    // which leaves the pipe live per the Streams contract), kill the child, and
+    // await its exit so neither the stderr pipe nor the docker subprocess is
+    // orphaned. releaseLock is handled in `finally` for both paths.
+    await reader.cancel().catch(() => {})
+    proc.kill()
+    await proc.exited.catch(() => {})
+    throw err
+  } finally {
+    reader.releaseLock()
   }
   const exitCode = await proc.exited
   return { exitCode, stdout: '', stderr: Buffer.concat(chunks).toString('utf8') }

--- a/src/init/run-bun-install.test.ts
+++ b/src/init/run-bun-install.test.ts
@@ -5,6 +5,38 @@ import { join } from 'node:path'
 
 import { runBunInstall, runBunUpdate } from './run-bun-install'
 
+// A child whose stdout drain rejects and whose exit only settles after kill(),
+// so the test can prove the drain-failure path reaps the process instead of
+// disarming the timeout and leaking it.
+function spawnRejectingDrain(): {
+  spawn: typeof Bun.spawn
+  killed: () => boolean
+} {
+  let resolveExited: (code: number) => void = () => {}
+  const exited = new Promise<number>((resolve) => {
+    resolveExited = resolve
+  })
+  let killed = false
+  const proc = {
+    exited,
+    stdout: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error('stdout drain failed'))
+      },
+    }),
+    stderr: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    }),
+    kill() {
+      killed = true
+      resolveExited(137)
+    },
+  }
+  return { spawn: (() => proc) as unknown as typeof Bun.spawn, killed: () => killed }
+}
+
 describe('runBunInstall', () => {
   test('times out a hung install process', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'tc-bun-install-timeout-'))
@@ -16,6 +48,48 @@ describe('runBunInstall', () => {
       const result = await runBunInstall(cwd, { timeoutMs: 50, spawn: spawnHungProcess })
 
       expect(result).toEqual({ ok: false, reason: 'bun install timed out after 0.05s' })
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('kills and reaps the child when a pipe drain rejects', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-bun-install-drain-'))
+    try {
+      await writeFile(join(cwd, 'package.json'), '{}\n')
+      const { spawn, killed } = spawnRejectingDrain()
+
+      const result = await runBunInstall(cwd, { timeoutMs: 10_000, spawn })
+
+      expect(result).toEqual({ ok: false, reason: 'stdout drain failed' })
+      expect(killed()).toBe(true)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('reports stderr (not stdout) in the failure reason on a non-zero exit', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'tc-bun-install-fail-'))
+    try {
+      await writeFile(join(cwd, 'package.json'), '{}\n')
+      const spawnFailing: typeof Bun.spawn = () =>
+        Bun.spawn({
+          cmd: [
+            'bun',
+            '-e',
+            'process.stdout.write("STDOUT_MARKER"); process.stderr.write("STDERR_MARKER"); process.exit(3)',
+          ],
+          cwd,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        })
+
+      const result = await runBunInstall(cwd, { timeoutMs: 10_000, spawn: spawnFailing })
+
+      expect(result.ok).toBe(false)
+      const reason = result.ok ? '' : result.reason
+      expect(reason).toContain('STDERR_MARKER')
+      expect(reason).not.toContain('STDOUT_MARKER')
     } finally {
       await rm(cwd, { recursive: true, force: true })
     }

--- a/src/init/run-bun-install.ts
+++ b/src/init/run-bun-install.ts
@@ -107,10 +107,24 @@ async function runTimedBunProcess({
     proc.kill('SIGKILL')
   }, timeoutMs)
   try {
-    const code = await proc.exited
+    // Drain both pipes alongside exit: an undrained 'pipe' stdout/stderr holds
+    // its fd (and can deadlock a child that fills the buffer) until GC. A drain
+    // that rejects must not escape before the child is reaped — otherwise the
+    // `finally` clears the timeout while the process is still alive. Kill and
+    // await exit on any drain failure so the timer never disarms a live child.
+    const stdoutDrain = new Response(proc.stdout).text()
+    const stderrDrain = new Response(proc.stderr).text()
+    let code: number
+    let stderr: string
+    try {
+      ;[code, , stderr] = await Promise.all([proc.exited, stdoutDrain, stderrDrain])
+    } catch (err) {
+      proc.kill('SIGKILL')
+      await Promise.allSettled([proc.exited, stdoutDrain, stderrDrain])
+      throw err
+    }
     if (timedOut) return { ok: false, reason: timeoutReason(timeoutMs / 1000) }
     if (code === 0) return { ok: true }
-    const stderr = await new Response(proc.stderr).text()
     return { ok: false, reason: failureReason(code, stderr) }
   } finally {
     clearTimeout(timeout)

--- a/src/init/validate-api-key.ts
+++ b/src/init/validate-api-key.ts
@@ -156,6 +156,7 @@ async function readCapped(res: Response, maxBytes: number): Promise<string | nul
     return null
   } finally {
     await reader.cancel().catch(() => undefined)
+    reader.releaseLock()
   }
 }
 


### PR DESCRIPTION
## Background

A follow-up to the tool-input snapshot fd leak (#1295). An exhaustive audit of every `createReadStream`/`open`/`getReader`/`Bun.spawn`/stream site in `src/` found the snapshot bug was the only *hard, unbounded, long-running-agent* leak — but it also surfaced five smaller resource-cleanup gaps where a stream reader or subprocess pipe can be left unreleased on a specific path. None are as severe as #1295 (they're host-stage/init or transient/GC-reclaimed), but each is a real "resource not freed on this branch" and cheap to harden.

Each fix also covers the **failure/abort branch**, not just the happy path: a pipe-read rejection must never escape while the child is still running, or the surrounding timeout/`finally` can disarm while a stuck subprocess lives on.

## Fixes

**Backup git subprocess pipes** (`bundled-plugins/backup/`) — the backup runner spawns `git` per operation on the idle path:
- `resolveOriginPushUrl` returned on a non-zero exit without ever draining the piped `stdout`. Now retains the exit and drain promises, and on a drain rejection `kill()`s the child and awaits `Promise.allSettled` before returning, so the git subprocess can't be orphaned.
- `makeDefaultGitSpawn` awaited exit, then read `stdout`/`stderr` sequentially, so an abort that rejected before the reads left both pipes undrained. Now reads exit and both pipes together with `Promise.all`; on a drain rejection it `controller.abort()`s the child and awaits all three settle before surfacing the error, so the outer `finally` can't clear the abort timer while a stuck child is live.

**Init-stage streams** (`init/`):
- `runBunInstall` left `stdout`/`stderr` as unconsumed `'pipe'`s and returned on a clean exit without draining them (an undrained pipe holds its fd and can deadlock a child that fills the buffer). Now drains both alongside exit, and on a drain rejection `kill('SIGKILL')`s and awaits the child before rethrowing so the timeout can't disarm a live process. The failure reason correctly reports `stderr` (the third `Promise.all` element), covered by a non-zero-exit test with distinct stdout/stderr markers.
- `readCapped` cancelled its response-body reader but never called `releaseLock()` (every other reader site in the codebase does both). Added the missing `releaseLock()`.

**Docker-exec stderr reader** (`container/shared.ts`):
- `spawnInheritTeeStderr` read `proc.stderr` in a bare loop with no `try/finally`, so a throw from `reader.read()`/`process.stderr.write()` leaked the reader and its stderr pipe. The failure branch now `cancel()`s the reader (which `releaseLock()` alone does not do per the Streams contract), `kill()`s the docker child, and awaits `proc.exited` before rethrowing; `releaseLock()` lives in a `finally` spanning both the success and failure paths.

## Tests

Each fix ships a failure-path regression test (Linux/injected-spawn where needed), asserting the child is killed/aborted and reaped and — for the reader paths — that the stream is unlocked (`stderr.locked === false`) after a mid-stream read failure. A couple of small injectable-spawn seams (an optional `bunOverride` on `resolveOriginPushUrl`/`makeDefaultGitSpawn`, exporting `spawnInheritTeeStderr`) were added purely so these failure branches can be exercised, since `globalThis.Bun` is read-only.

## Not changed

The audit confirmed all other reader/stream/spawn/timer sites already release deterministically (`response-body.ts`, `llm-fetch-observer.ts`, `replay.ts`, `scan.ts`, `webfetch/fetch.ts`, `curl-impersonate.ts`, and every `setInterval`/`setTimeout` handle). No production behavior changes on the success path — only guaranteed cleanup, now including the failure/abort branches.

## Checks

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run format:check` — clean
- `bun run test` — the affected test files (`run-bun-install`, `validate-api-key`, `container/shared`, `backup/runner`, `backup/index`, `resolve-origin-push-url`) pass 159/159. The remaining full-suite failures are pre-existing checked-in schema-drift/scaffold guards on `main` (they fail identically at the base commit) and are unrelated to this change, which touches no schema.
