### PR TITLE
Add typeclaw stats and compose stats commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@
 - 📊 **usage** — reports token and dollar spend by day, model, session, or origin
 - 🔍 **inspect** — replays a session transcript and tails live activity
 - 📜 **logs** — streams container logs with local-time prefixes
+- 📈 **stats** — a live cpu / memory / pid snapshot of the agent container
 
 ## Compose — manage a fleet from the CLI
 
-- 🎼 **Fleet operations** — discover agent folders and start, stop, restart, check status, tail logs, report usage, and run diagnostics across them from the command line
+- 🎼 **Fleet operations** — discover agent folders and start, stop, restart, check status, snapshot resource stats, tail logs, report usage, and run diagnostics across them from the command line
 
 Memory loop and subagent architecture are covered in detail in the [Internals docs](https://typeclaw.dev/docs/internals) and [`src/bundled-plugins/memory/README.md`](./src/bundled-plugins/memory/README.md).
 

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -15,6 +15,7 @@ TypeClaw runs code in three stages with different filesystems ([/concepts/archit
 | `typeclaw restart` | `stop` + `start` with the same flag set as `start`.                                                                              |
 | `typeclaw stop`    | `docker stop` then `docker rm` so a clean stop leaves no trace.                                                                  |
 | `typeclaw status`  | Container + daemon registration state.                                                                                           |
+| `typeclaw stats`   | Live resource snapshot for the container: cpu %, memory usage, and pid count (a `docker stats --no-stream` for this one agent).  |
 | `typeclaw logs`    | Print container stdout/stderr with reformatted local timestamps. `-f` / `--follow` to stream; `-n` / `--tail <N\|all>` to limit. |
 | `typeclaw shell`   | Drop into a shell inside the running container. `--shell` to pick (defaults to `bash` if present, else `sh`).                    |
 | `typeclaw tui`     | Attach an interactive TUI. Takes an optional one-shot prompt argument; `--url` to override the websocket URL.                    |

--- a/docs/content/docs/reference/compose.mdx
+++ b/docs/content/docs/reference/compose.mdx
@@ -23,19 +23,20 @@ Cwd is scanned **one directory deep**. A subdirectory is treated as an agent whe
 - the name does not start with `_` (park disabled or in-progress agents as `_archived-coder/`, `_wip-foo/` without compose touching them)
 - the directory contains a `typeclaw.json`
 
-Agents are sorted by folder name so output across `start` / `stop` / `status` / `restart` / `logs` is stable regardless of filesystem readdir order. When zero agents are discovered, every subcommand exits 0 with a `No typeclaw agents found in immediate subdirectories of cwd.` notice — discovery is not a failure.
+Agents are sorted by folder name so output across `start` / `stop` / `status` / `stats` / `restart` / `logs` is stable regardless of filesystem readdir order. When zero agents are discovered, every subcommand exits 0 with a `No typeclaw agents found in immediate subdirectories of cwd.` notice — discovery is not a failure.
 
 ## Subcommands
 
-| Command                    | Per-agent equivalent | Parallel | Notes                                                                                       |
-| -------------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `typeclaw compose start`   | `typeclaw start`     | yes      | host port collisions fall back to ephemeral per agent                                       |
-| `typeclaw compose stop`    | `typeclaw stop`      | yes      | already-stopped agents report `not running`, not failure                                    |
-| `typeclaw compose restart` | `typeclaw restart`   | yes      | `stop` then `start` per agent; surfaces both phases on the progress board                   |
-| `typeclaw compose status`  | (inspects Docker)    | yes      | running / stopped / absent + resolved host port for running agents                          |
-| `typeclaw compose logs`    | `typeclaw logs`      | yes      | multiplexed; each line prefixed with the agent name and a deterministic color               |
-| `typeclaw compose usage`   | `typeclaw usage`     | yes      | aggregates per-agent token usage; one corrupt `sessions/` dir does not blank out the report |
-| `typeclaw compose doctor`  | `typeclaw doctor`    | yes      | per-agent `doctor` plus cross-agent checks (port collisions, container-name collisions)     |
+| Command                    | Per-agent equivalent | Parallel | Notes                                                                                         |
+| -------------------------- | -------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `typeclaw compose start`   | `typeclaw start`     | yes      | host port collisions fall back to ephemeral per agent                                         |
+| `typeclaw compose stop`    | `typeclaw stop`      | yes      | already-stopped agents report `not running`, not failure                                      |
+| `typeclaw compose restart` | `typeclaw restart`   | yes      | `stop` then `start` per agent; surfaces both phases on the progress board                     |
+| `typeclaw compose status`  | (inspects Docker)    | yes      | running / stopped / absent + resolved host port for running agents                            |
+| `typeclaw compose stats`   | `typeclaw stats`     | yes      | cpu %, memory usage, and pid count per running agent; stopped / absent agents show no metrics |
+| `typeclaw compose logs`    | `typeclaw logs`      | yes      | multiplexed; each line prefixed with the agent name and a deterministic color                 |
+| `typeclaw compose usage`   | `typeclaw usage`     | yes      | aggregates per-agent token usage; one corrupt `sessions/` dir does not blank out the report   |
+| `typeclaw compose doctor`  | `typeclaw doctor`    | yes      | per-agent `doctor` plus cross-agent checks (port collisions, container-name collisions)       |
 
 ## Flags
 
@@ -73,7 +74,7 @@ Agents without a running container are skipped with a `compose: skipping <name> 
 | `--only <a,b,c>`  | (none)  | comma-separated category filter forwarded to each agent's `doctor` run                                                                                  |
 | `--shallow`       | `false` | run cross-agent checks only; skip per-agent `doctor` runs                                                                                               |
 
-`status`, `stop` take no flags.
+`status`, `stats`, `stop` take no flags.
 
 ## Cross-agent checks (`compose doctor`)
 

--- a/src/cli/command-meta.test.ts
+++ b/src/cli/command-meta.test.ts
@@ -17,6 +17,7 @@ const COMMAND_LOADERS: Record<BuiltinCommandName, () => Promise<MetaCarrier>> = 
   stop: () => import('./stop').then((m) => m.stopCommand),
   restart: () => import('./restart').then((m) => m.restartCommand),
   status: () => import('./status').then((m) => m.statusCommand),
+  stats: () => import('./stats').then((m) => m.statsCommand),
   reload: () => import('./reload').then((m) => m.reload),
   logs: () => import('./logs').then((m) => m.logsCommand),
   inspect: () => import('./inspect').then((m) => m.inspectCommand),

--- a/src/cli/command-meta.ts
+++ b/src/cli/command-meta.ts
@@ -16,6 +16,7 @@ export type BuiltinCommandName =
   | 'stop'
   | 'restart'
   | 'status'
+  | 'stats'
   | 'reload'
   | 'logs'
   | 'inspect'
@@ -50,6 +51,7 @@ export const BUILTIN_COMMANDS: readonly BuiltinCommandMeta[] = [
   { name: 'stop', description: 'stop the agent container (host stage)' },
   { name: 'restart', description: 'stop and relaunch the agent container (host stage)' },
   { name: 'status', description: 'show the agent container and host daemon status (host stage)' },
+  { name: 'stats', description: 'show the agent container resource usage: cpu, memory, pids (host stage)' },
   { name: 'reload', description: "reload the running agent's reloadable subsystems (cron, ...)" },
   { name: 'logs', description: 'show the agent container logs (host stage)' },
   { name: 'inspect', description: 'session viewer: a session, the live TUI, or container logs' },

--- a/src/cli/compose-stats.test.ts
+++ b/src/cli/compose-stats.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { AgentStatsEntry, ComposeStatsResult } from '@/compose'
+
+import { formatComposeStats } from './compose-stats'
+
+function entry(overrides: Partial<AgentStatsEntry> & Pick<AgentStatsEntry, 'name'>): AgentStatsEntry {
+  const { name } = overrides
+  return {
+    name,
+    cwd: overrides.cwd ?? `/agents/${name}`,
+    containerName: overrides.containerName ?? name,
+    state: overrides.state ?? 'running',
+    cpuPercent: overrides.cpuPercent ?? (overrides.state && overrides.state !== 'running' ? null : '3.16%'),
+    memUsage: overrides.memUsage ?? (overrides.state && overrides.state !== 'running' ? null : '919.8MiB / 15.65GiB'),
+    memPercent: overrides.memPercent ?? (overrides.state && overrides.state !== 'running' ? null : '5.74%'),
+    pids: overrides.pids ?? (overrides.state && overrides.state !== 'running' ? null : '57'),
+  }
+}
+
+function result(entries: AgentStatsEntry[], rootCwd = '/agents'): ComposeStatsResult {
+  return { rootCwd, entries }
+}
+
+describe('formatComposeStats', () => {
+  test('empty fleet renders a dim "no agents" line including the cwd', () => {
+    const out = formatComposeStats(result([], '/somewhere'))
+    expect(out).toContain('No typeclaw agents in /somewhere.')
+  })
+
+  test('renders agent count, cwd, and per-agent resource rows', () => {
+    const out = formatComposeStats(
+      result([entry({ name: 'coder' }), entry({ name: 'planner', state: 'stopped' })], '/agents'),
+    )
+    expect(out).toContain('2 agents in /agents')
+    expect(out).toContain('coder')
+    expect(out).toContain('3.16%')
+    expect(out).toContain('919.8MiB / 15.65GiB')
+    expect(out).toContain('57 pids')
+  })
+
+  test('uses singular "1 agent" when there is one entry', () => {
+    const out = formatComposeStats(result([entry({ name: 'solo' })]))
+    expect(out).toContain('1 agent in /agents')
+    expect(out).not.toContain('1 agents')
+  })
+
+  test('shows resource columns only for running agents', () => {
+    const out = formatComposeStats(
+      result([
+        entry({ name: 'coder', state: 'running' }),
+        entry({ name: 'planner', state: 'stopped' }),
+        entry({ name: 'scratchpad', state: 'absent' }),
+      ]),
+    )
+    const lines = out.split('\n')
+    const stoppedLine = lines.find((l) => l.includes('planner'))
+    const absentLine = lines.find((l) => l.includes('scratchpad'))
+    expect(stoppedLine).toBeDefined()
+    expect(absentLine).toBeDefined()
+    expect(stoppedLine).not.toContain('pids')
+    expect(absentLine).not.toContain('pids')
+  })
+
+  test('shows lowercase state words, not docker-style upper-case', () => {
+    const out = formatComposeStats(
+      result([
+        entry({ name: 'coder', state: 'running' }),
+        entry({ name: 'planner', state: 'stopped' }),
+        entry({ name: 'scratchpad', state: 'absent' }),
+      ]),
+    )
+    expect(out).toContain('running')
+    expect(out).toContain('stopped')
+    expect(out).toContain('not started')
+    expect(out).not.toContain('RUNNING')
+  })
+
+  test('uses status glyphs (●/○/·), not text symbols', () => {
+    const out = formatComposeStats(
+      result([
+        entry({ name: 'a', state: 'running' }),
+        entry({ name: 'b', state: 'stopped' }),
+        entry({ name: 'c', state: 'absent' }),
+      ]),
+    )
+    expect(out).toContain('●')
+    expect(out).toContain('○')
+    expect(out).toContain('·')
+  })
+
+  test('pads agent names so the state column aligns', () => {
+    const out = formatComposeStats(result([entry({ name: 'a' }), entry({ name: 'longer-name' })]))
+    const lines = out.split('\n')
+    const aLine = lines.find((l) => l.includes(' a '))
+    const longLine = lines.find((l) => l.includes('longer-name'))
+    expect(aLine).toBeDefined()
+    expect(longLine).toBeDefined()
+    expect(aLine!.indexOf('running')).toBe(longLine!.indexOf('running'))
+  })
+
+  test('emits ANSI color escapes under useColor=true', () => {
+    const out = formatComposeStats(
+      result([entry({ name: 'coder', state: 'running' }), entry({ name: 'planner', state: 'stopped' })]),
+      { useColor: true },
+    )
+    expect(out).toContain('\u001b[32m')
+    expect(out).toContain('\u001b[33m')
+  })
+
+  test('emits no ANSI escapes when useColor is unset', () => {
+    const out = formatComposeStats(result([entry({ name: 'coder', state: 'running' })]))
+    expect(out).not.toContain('\u001b[')
+  })
+})

--- a/src/cli/compose-stats.ts
+++ b/src/cli/compose-stats.ts
@@ -1,0 +1,103 @@
+import { styleText } from 'node:util'
+
+import type { AgentStatsState, ComposeStatsResult } from '@/compose'
+
+export type FormatComposeStatsOptions = { useColor?: boolean }
+
+type ColorFn = (s: string) => string
+type Palette = {
+  bold: ColorFn
+  dim: ColorFn
+  green: ColorFn
+  yellow: ColorFn
+  cyan: ColorFn
+}
+
+const identity: ColorFn = (s) => s
+const NO_PALETTE: Palette = {
+  bold: identity,
+  dim: identity,
+  green: identity,
+  yellow: identity,
+  cyan: identity,
+}
+
+const COLOR_PALETTE: Palette = {
+  bold: (s) => styleText('bold', s),
+  dim: (s) => styleText('dim', s),
+  green: (s) => styleText('green', s),
+  yellow: (s) => styleText('yellow', s),
+  cyan: (s) => styleText('cyan', s),
+}
+
+const STATE_LABELS: Record<AgentStatsState, string> = {
+  running: 'running',
+  stopped: 'stopped',
+  absent: 'not started',
+}
+
+const STATE_LABEL_WIDTH = Math.max(...Object.values(STATE_LABELS).map((l) => l.length))
+
+export function formatComposeStats(result: ComposeStatsResult, opts: FormatComposeStatsOptions = {}): string {
+  const useColor = opts.useColor ?? false
+  const p: Palette = useColor ? COLOR_PALETTE : NO_PALETTE
+
+  if (result.entries.length === 0) {
+    return p.dim(`No typeclaw agents in ${result.rootCwd}.`)
+  }
+
+  const nameWidth = result.entries.reduce((w, e) => Math.max(w, e.name.length), 0)
+  const cpuWidth = result.entries.reduce((w, e) => Math.max(w, (e.cpuPercent ?? '').length), 'cpu'.length)
+  const memWidth = result.entries.reduce((w, e) => Math.max(w, (e.memUsage ?? '').length), 'memory'.length)
+
+  const header = p.dim(
+    `${result.entries.length} ${result.entries.length === 1 ? 'agent' : 'agents'} in ${result.rootCwd}`,
+  )
+
+  const lines = [header, '']
+  for (const entry of result.entries) {
+    lines.push(renderRow(entry, { nameWidth, cpuWidth, memWidth }, p))
+  }
+  return lines.join('\n')
+}
+
+type Widths = { nameWidth: number; cpuWidth: number; memWidth: number }
+
+function renderRow(entry: ComposeStatsResult['entries'][number], w: Widths, p: Palette): string {
+  const glyph = renderGlyph(entry.state, p)
+  const name = p.bold(entry.name.padEnd(w.nameWidth))
+  const state = renderState(entry.state, p)
+
+  if (entry.state !== 'running') {
+    return `  ${glyph}  ${name}  ${state}`
+  }
+
+  const cpu = p.cyan((entry.cpuPercent ?? '-').padStart(w.cpuWidth))
+  const mem = p.cyan((entry.memUsage ?? '-').padEnd(w.memWidth))
+  const memPct = p.dim(`(${entry.memPercent ?? '-'})`)
+  const pids = p.dim(`${entry.pids ?? '-'} pids`)
+  return `  ${glyph}  ${name}  ${state}  ${cpu}  ${mem} ${memPct}  ${pids}`
+}
+
+function renderGlyph(state: AgentStatsState, p: Palette): string {
+  switch (state) {
+    case 'running':
+      return p.green('●')
+    case 'stopped':
+      return p.yellow('○')
+    case 'absent':
+      return p.dim('·')
+  }
+}
+
+function renderState(state: AgentStatsState, p: Palette): string {
+  const label = STATE_LABELS[state].padEnd(STATE_LABEL_WIDTH)
+  switch (state) {
+    case 'running':
+      return p.green(label)
+    case 'stopped':
+      return p.yellow(label)
+    case 'absent':
+      return p.dim(label)
+  }
+}

--- a/src/cli/compose.ts
+++ b/src/cli/compose.ts
@@ -5,6 +5,7 @@ import {
   composeLogs,
   composeRestart,
   composeStart,
+  composeStats,
   composeStatus,
   composeStop,
   composeUsage,
@@ -15,6 +16,7 @@ import { config } from '@/config'
 import { parseTailValue } from '@/container'
 import { formatJson, formatReport } from '@/doctor'
 
+import { formatComposeStats } from './compose-stats'
 import { formatComposeStatus } from './compose-status'
 import { formatComposeUsage, formatComposeUsageJson } from './compose-usage'
 import { preflightDocker, printDockerGuidance } from './docker-preflight'
@@ -154,6 +156,16 @@ const statusSub = defineCommand({
   },
 })
 
+const statsSub = defineCommand({
+  meta: { name: 'stats', description: 'show cpu, memory, and pids for every agent in immediate subdirectories of cwd' },
+  async run() {
+    await requireDockerOrExit()
+    const result = await composeStats(process.cwd())
+    const useColor = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined
+    process.stdout.write(`${formatComposeStats(result, { useColor })}\n`)
+  },
+})
+
 const logsSub = defineCommand({
   meta: { name: 'logs', description: 'multiplex docker logs for every running agent in immediate subdirectories' },
   args: {
@@ -284,6 +296,7 @@ export const composeCommand = defineCommand({
     stop: stopSub,
     restart: restartSub,
     status: statusSub,
+    stats: statsSub,
     logs: logsSub,
     usage: usageSub,
     doctor: doctorSub,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ const main = defineCommand({
     stop: () => import('./stop').then((m) => m.stopCommand),
     restart: () => import('./restart').then((m) => m.restartCommand),
     status: () => import('./status').then((m) => m.statusCommand),
+    stats: () => import('./stats').then((m) => m.statsCommand),
     reload: () => import('./reload').then((m) => m.reload),
     logs: () => import('./logs').then((m) => m.logsCommand),
     inspect: () => import('./inspect').then((m) => m.inspectCommand),

--- a/src/cli/stats.test.ts
+++ b/src/cli/stats.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { DockerExecResult } from '@/container'
+import { rmTempDir } from '@/test-helpers/rm-temp-dir'
+
+import { formatDuration, formatStats, runStats, type StatsReport } from './stats'
+
+function baseReport(overrides: Partial<StatsReport> = {}): StatsReport {
+  return {
+    cwd: '/agents/coder',
+    container: { kind: 'missing', containerName: 'coder', imageTag: 'typeclaw-coder' },
+    ...overrides,
+  }
+}
+
+describe('formatStats', () => {
+  test('renders container header, cwd, image, and missing state', () => {
+    const out = formatStats(baseReport())
+
+    expect(out).toContain('Container  coder')
+    expect(out).toContain('  cwd     /agents/coder')
+    expect(out).toContain('  image   typeclaw-coder')
+    expect(out).toContain('  state   missing')
+    expect(out).not.toContain('  cpu ')
+  })
+
+  test('renders stopped state without resource rows', () => {
+    const out = formatStats(
+      baseReport({ container: { kind: 'stopped', containerName: 'coder', imageTag: 'typeclaw-coder' } }),
+    )
+
+    expect(out).toContain('  state   stopped')
+    expect(out).not.toContain('  cpu ')
+    expect(out).not.toContain('  memory ')
+    expect(out).not.toContain('  pids ')
+  })
+
+  test('renders running state with cpu, memory, and pids rows', () => {
+    const out = formatStats(
+      baseReport({
+        container: {
+          kind: 'running',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          startedAt: null,
+          cpuPercent: '3.16%',
+          memUsage: '919.8MiB / 15.65GiB',
+          memPercent: '5.74%',
+          pids: '57',
+        },
+      }),
+    )
+
+    expect(out).toContain('  state   running')
+    expect(out).toContain('  cpu     3.16%')
+    expect(out).toContain('  memory  919.8MiB / 15.65GiB (5.74%)')
+    expect(out).toContain('  pids    57')
+  })
+
+  test('appends an uptime suffix when startedAt is a recent timestamp', () => {
+    const startedAt = new Date(Date.now() - 90_000).toISOString()
+    const out = formatStats(
+      baseReport({
+        container: {
+          kind: 'running',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          startedAt,
+          cpuPercent: '1%',
+          memUsage: '10MiB / 1GiB',
+          memPercent: '1%',
+          pids: '3',
+        },
+      }),
+    )
+
+    expect(out).toContain('running up 1m')
+  })
+
+  test('omits uptime when startedAt is unparseable', () => {
+    const out = formatStats(
+      baseReport({
+        container: {
+          kind: 'running',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          startedAt: 'not-a-date',
+          cpuPercent: '1%',
+          memUsage: '10MiB / 1GiB',
+          memPercent: '1%',
+          pids: '3',
+        },
+      }),
+    )
+
+    expect(out).toContain('  state   running')
+    expect(out).not.toContain(' up ')
+  })
+
+  test('useColor=true wraps the container header with ANSI escapes', () => {
+    const out = formatStats(baseReport(), { useColor: true })
+    const ESC = '\u001b'
+    expect(out).toContain(`${ESC}[1mContainer`)
+  })
+
+  test('useColor=false produces output free of ANSI escape codes', () => {
+    const out = formatStats(
+      baseReport({
+        container: {
+          kind: 'running',
+          containerName: 'coder',
+          imageTag: 'typeclaw-coder',
+          startedAt: new Date().toISOString(),
+          cpuPercent: '3.16%',
+          memUsage: '919.8MiB / 15.65GiB',
+          memPercent: '5.74%',
+          pids: '57',
+        },
+      }),
+    )
+
+    expect(out).not.toContain('\u001b[')
+  })
+})
+
+describe('formatDuration', () => {
+  test('renders days and hours for multi-day durations', () => {
+    expect(formatDuration((2 * 86400 + 5 * 3600) * 1000)).toBe('2d 5h')
+  })
+
+  test('renders hours and minutes under a day', () => {
+    expect(formatDuration((3 * 3600 + 12 * 60) * 1000)).toBe('3h 12m')
+  })
+
+  test('renders minutes and seconds under an hour', () => {
+    expect(formatDuration((4 * 60 + 9) * 1000)).toBe('4m 9s')
+  })
+
+  test('renders seconds under a minute', () => {
+    expect(formatDuration(42 * 1000)).toBe('42s')
+  })
+})
+
+describe('typeclaw stats render flow', () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'typeclaw-stats-render-'))
+  })
+
+  afterEach(async () => {
+    await rmTempDir(cwd)
+  })
+
+  const runningExec = async (args: string[]): Promise<DockerExecResult> => {
+    if (args[0] === 'inspect') return { exitCode: 0, stdout: 'true|2026-07-22T08:28:42Z\n', stderr: '' }
+    if (args[0] === 'stats') return { exitCode: 0, stdout: '3.16%|919.8MiB / 15.65GiB|5.74%|57\n', stderr: '' }
+    return { exitCode: 1, stdout: '', stderr: `unexpected: ${args.join(' ')}` }
+  }
+
+  async function captureStats(): Promise<string> {
+    let out = ''
+    await runStats({
+      cwd,
+      preflight: async () => ({ ok: true }),
+      exec: runningExec,
+      write: (text) => {
+        out += text
+      },
+    })
+    return out
+  }
+
+  test('renders the resource snapshot for a running container', async () => {
+    const out = await captureStats()
+    expect(out).toContain('Container')
+    expect(out).toContain('cpu')
+    expect(out).toContain('919.8MiB / 15.65GiB')
+    expect(out).toContain('57')
+  })
+
+  test('does not exit the process when Docker is available', async () => {
+    await expect(captureStats()).resolves.toBeString()
+  })
+})

--- a/src/cli/stats.ts
+++ b/src/cli/stats.ts
@@ -1,0 +1,134 @@
+import { styleText } from 'node:util'
+
+import { defineCommand } from 'citty'
+
+import { type ContainerStats, type DockerExec, resolveController } from '@/container'
+import { findAgentDir } from '@/init'
+
+import { type DockerPreflightResult, preflightDocker, printDockerGuidance } from './docker-preflight'
+
+export const statsCommand = defineCommand({
+  meta: {
+    name: 'stats',
+    description: 'show the agent container resource usage: cpu, memory, pids (host stage)',
+  },
+  async run() {
+    await runStats()
+  },
+})
+
+export type RunStatsDeps = {
+  cwd?: string
+  preflight?: () => Promise<DockerPreflightResult>
+  exec?: DockerExec
+  write?: (text: string) => void
+  onDockerUnavailable?: (failure: Extract<DockerPreflightResult, { ok: false }>) => void
+}
+
+export async function runStats(deps: RunStatsDeps = {}): Promise<void> {
+  const cwd = deps.cwd ?? findAgentDir(process.cwd()) ?? process.cwd()
+
+  const preflight = await (deps.preflight ?? preflightDocker)()
+  if (!preflight.ok) {
+    ;(deps.onDockerUnavailable ?? defaultOnDockerUnavailable)(preflight)
+    return
+  }
+
+  const container = await resolveController().stats({ cwd, exec: deps.exec })
+
+  const useColor = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined
+  const write = deps.write ?? ((text: string) => process.stdout.write(text))
+  write(`${formatStats({ cwd, container }, { useColor })}\n`)
+}
+
+function defaultOnDockerUnavailable(failure: Extract<DockerPreflightResult, { ok: false }>): never {
+  printDockerGuidance(failure)
+  process.exit(1)
+}
+
+export type StatsReport = {
+  cwd: string
+  container: ContainerStats
+}
+
+export type FormatOptions = { useColor?: boolean }
+
+type ColorFn = (s: string) => string
+type Palette = {
+  bold: ColorFn
+  dim: ColorFn
+  green: ColorFn
+  yellow: ColorFn
+  cyan: ColorFn
+}
+
+const identity: ColorFn = (s) => s
+const NO_PALETTE: Palette = {
+  bold: identity,
+  dim: identity,
+  green: identity,
+  yellow: identity,
+  cyan: identity,
+}
+
+const COLOR_PALETTE: Palette = {
+  bold: (s) => styleText('bold', s),
+  dim: (s) => styleText('dim', s),
+  green: (s) => styleText('green', s),
+  yellow: (s) => styleText('yellow', s),
+  cyan: (s) => styleText('cyan', s),
+}
+
+export function formatStats(report: StatsReport, opts: FormatOptions = {}): string {
+  const useColor = opts.useColor ?? false
+  const p: Palette = useColor ? COLOR_PALETTE : NO_PALETTE
+
+  const container = report.container
+  const lines: string[] = []
+  lines.push(`${p.bold('Container')}  ${container.containerName}`)
+  lines.push(row('cwd', report.cwd))
+  lines.push(row('image', container.imageTag))
+
+  if (container.kind === 'missing') {
+    lines.push(row('state', p.dim('missing')))
+    return lines.join('\n')
+  }
+
+  if (container.kind === 'stopped') {
+    lines.push(row('state', p.yellow('stopped')))
+    return lines.join('\n')
+  }
+
+  lines.push(row('state', `${p.green('running')}${formatUptime(container.startedAt, p)}`))
+  lines.push('')
+  lines.push(row('cpu', p.cyan(container.cpuPercent)))
+  lines.push(row('memory', `${p.cyan(container.memUsage)} ${p.dim(`(${container.memPercent})`)}`))
+  lines.push(row('pids', p.cyan(container.pids)))
+  return lines.join('\n')
+}
+
+function formatUptime(startedAt: string | null, p: Palette): string {
+  if (startedAt === null) return ''
+  const started = Date.parse(startedAt)
+  if (Number.isNaN(started)) return ''
+  const elapsedMs = Date.now() - started
+  if (elapsedMs < 0) return ''
+  return ` ${p.dim(`up ${formatDuration(elapsedMs)}`)}`
+}
+
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const days = Math.floor(totalSeconds / 86400)
+  const hours = Math.floor((totalSeconds % 86400) / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  if (days > 0) return `${days}d ${hours}h`
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}
+
+function row(label: string, value: string): string {
+  return `  ${label.padEnd(8)}${value}`
+}

--- a/src/compose/index.ts
+++ b/src/compose/index.ts
@@ -8,6 +8,7 @@ export {
   type ComposeDoctorReport,
 } from './doctor'
 export { colorFor, composeLogs, makeLinePrefixer, type ComposeLogsOptions, type ComposeLogsResult } from './logs'
+export { composeStats, type AgentStatsEntry, type AgentStatsState, type ComposeStatsResult } from './stats'
 export { composeStatus, type AgentRuntimeState, type AgentStatusEntry, type ComposeStatusResult } from './status'
 export {
   composeRestart,

--- a/src/compose/stats.test.ts
+++ b/src/compose/stats.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ContainerStats } from '@/container'
+
+import type { AgentEntry } from './discover'
+import { composeStats, type StatsProbe } from './stats'
+
+function agent(name: string): AgentEntry {
+  return { name, cwd: `/agents/${name}`, containerName: name }
+}
+
+function running(
+  containerName: string,
+  over: Partial<Extract<ContainerStats, { kind: 'running' }>> = {},
+): ContainerStats {
+  return {
+    kind: 'running',
+    containerName,
+    imageTag: `typeclaw-${containerName}`,
+    startedAt: '2026-07-22T08:28:42Z',
+    cpuPercent: '3.16%',
+    memUsage: '919.8MiB / 15.65GiB',
+    memPercent: '5.74%',
+    pids: '57',
+    ...over,
+  }
+}
+
+function stopped(containerName: string): ContainerStats {
+  return { kind: 'stopped', containerName, imageTag: `typeclaw-${containerName}` }
+}
+
+function missing(containerName: string): ContainerStats {
+  return { kind: 'missing', containerName, imageTag: `typeclaw-${containerName}` }
+}
+
+function probeFrom(byCwd: Record<string, ContainerStats>): StatsProbe {
+  return async (cwd) => {
+    const stat = byCwd[cwd]
+    if (stat === undefined) throw new Error(`no probe stub for ${cwd}`)
+    return stat
+  }
+}
+
+describe('composeStats', () => {
+  test('fans out over discovered agents and preserves discovery order', async () => {
+    const discovered = [agent('alpha'), agent('mango'), agent('zebra')]
+    const result = await composeStats('/agents', {
+      discover: () => discovered,
+      probe: probeFrom({
+        '/agents/alpha': running('alpha'),
+        '/agents/mango': stopped('mango'),
+        '/agents/zebra': missing('zebra'),
+      }),
+    })
+
+    expect(result.rootCwd).toBe('/agents')
+    expect(result.entries.map((e) => e.name)).toEqual(['alpha', 'mango', 'zebra'])
+  })
+
+  test('classifies running / stopped / absent from the container stats kind', async () => {
+    const result = await composeStats('/agents', {
+      discover: () => [agent('run'), agent('stop'), agent('gone')],
+      probe: probeFrom({
+        '/agents/run': running('run'),
+        '/agents/stop': stopped('stop'),
+        '/agents/gone': missing('gone'),
+      }),
+    })
+
+    const byName = new Map(result.entries.map((e) => [e.name, e.state]))
+    expect(byName.get('run')).toBe('running')
+    expect(byName.get('stop')).toBe('stopped')
+    expect(byName.get('gone')).toBe('absent')
+  })
+
+  test('propagates cpu, memory, and pid metrics for running agents', async () => {
+    const result = await composeStats('/agents', {
+      discover: () => [agent('coder')],
+      probe: probeFrom({
+        '/agents/coder': running('coder', {
+          cpuPercent: '47.06%',
+          memUsage: '1.494GiB / 15.65GiB',
+          memPercent: '9.55%',
+          pids: '31',
+        }),
+      }),
+    })
+
+    expect(result.entries[0]).toMatchObject({
+      name: 'coder',
+      state: 'running',
+      cpuPercent: '47.06%',
+      memUsage: '1.494GiB / 15.65GiB',
+      memPercent: '9.55%',
+      pids: '31',
+    })
+  })
+
+  test('reports null metrics for stopped and absent agents', async () => {
+    const result = await composeStats('/agents', {
+      discover: () => [agent('stop'), agent('gone')],
+      probe: probeFrom({ '/agents/stop': stopped('stop'), '/agents/gone': missing('gone') }),
+    })
+
+    for (const entry of result.entries) {
+      expect(entry.cpuPercent).toBeNull()
+      expect(entry.memUsage).toBeNull()
+      expect(entry.memPercent).toBeNull()
+      expect(entry.pids).toBeNull()
+    }
+  })
+
+  test('returns an empty result when no agents are discovered', async () => {
+    const result = await composeStats('/agents', { discover: () => [], probe: probeFrom({}) })
+    expect(result).toEqual({ rootCwd: '/agents', entries: [] })
+  })
+})

--- a/src/compose/stats.ts
+++ b/src/compose/stats.ts
@@ -1,0 +1,51 @@
+import { type ContainerStats, resolveController } from '@/container'
+
+import { discoverAgents, type AgentEntry } from './discover'
+
+export type AgentStatsState = 'running' | 'stopped' | 'absent'
+
+export type AgentStatsEntry = AgentEntry & {
+  state: AgentStatsState
+  cpuPercent: string | null
+  memUsage: string | null
+  memPercent: string | null
+  pids: string | null
+}
+
+export type ComposeStatsResult = {
+  rootCwd: string
+  entries: AgentStatsEntry[]
+}
+
+export type StatsProbe = (cwd: string) => Promise<ContainerStats>
+
+export type ComposeStatsDeps = {
+  discover?: (rootCwd: string) => AgentEntry[]
+  probe?: StatsProbe
+}
+
+export async function composeStats(rootCwd: string, deps: ComposeStatsDeps = {}): Promise<ComposeStatsResult> {
+  const discover = deps.discover ?? discoverAgents
+  const probe = deps.probe ?? ((cwd) => resolveController().stats({ cwd }))
+
+  const agents = discover(rootCwd)
+  const entries = await Promise.all(agents.map(async (agent) => classify(agent, await probe(agent.cwd))))
+  return { rootCwd, entries }
+}
+
+function classify(agent: AgentEntry, container: ContainerStats): AgentStatsEntry {
+  if (container.kind === 'missing') {
+    return { ...agent, state: 'absent', cpuPercent: null, memUsage: null, memPercent: null, pids: null }
+  }
+  if (container.kind === 'stopped') {
+    return { ...agent, state: 'stopped', cpuPercent: null, memUsage: null, memPercent: null, pids: null }
+  }
+  return {
+    ...agent,
+    state: 'running',
+    cpuPercent: container.cpuPercent,
+    memUsage: container.memUsage,
+    memPercent: container.memPercent,
+    pids: container.pids,
+  }
+}

--- a/src/container/controller.ts
+++ b/src/container/controller.ts
@@ -2,6 +2,7 @@ import { logs, type LogsOptions, type LogsResult } from './logs'
 import { containerNameFromCwd, imageTagFromCwd } from './shared'
 import { shell, type ShellResult } from './shell'
 import { start, type StartOptions, type StartResult } from './start'
+import { stats, type ContainerStats, type StatsOptions } from './stats'
 import { status, type ContainerStatus, type StatusOptions } from './status'
 import { stop, type StopOptions, type StopResult } from './stop'
 
@@ -17,6 +18,7 @@ export interface Controller {
   start(options: StartOptions): Promise<StartResult>
   stop(options: StopOptions): Promise<StopResult>
   status(options: StatusOptions): Promise<ContainerStatus>
+  stats(options: StatsOptions): Promise<ContainerStats>
   logs(options: LogsOptions): Promise<LogsResult>
   shell(options: { cwd: string; shell?: string }): Promise<ShellResult>
 }
@@ -30,6 +32,7 @@ export function createLocalDockerController(): Controller {
     start: (options) => start(options),
     stop: (options) => stop(options),
     status: (options) => status(options),
+    stats: (options) => stats(options),
     logs: (options) => logs(options),
     shell: (options) => shell(options),
   }
@@ -51,6 +54,9 @@ export function createNoopController(): Controller {
       return { ok: false, reason: unsupported('stop', cwd) }
     },
     async status({ cwd }) {
+      return { kind: 'missing', containerName: containerNameFromCwd(cwd), imageTag: imageTagFromCwd(cwd) }
+    },
+    async stats({ cwd }) {
       return { kind: 'missing', containerName: containerNameFromCwd(cwd), imageTag: imageTagFromCwd(cwd) }
     },
     async logs({ cwd }) {

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -24,6 +24,7 @@ export {
   type RequireContainerRunningResult,
 } from './require-running'
 export { planShell, shell, type ShellPlan, type ShellResult } from './shell'
+export { parseStatsLine, stats, type ContainerStats, type StatsOptions, type StatsSnapshot } from './stats'
 export { status, type ContainerStatus, type StatusOptions } from './status'
 export {
   checkDockerAvailable,

--- a/src/container/stats.test.ts
+++ b/src/container/stats.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { DockerExec, DockerExecResult } from './shared'
+import { parseStatsLine, stats } from './stats'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-container-stats-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+type FakeDockerOptions = {
+  inspect?: DockerExecResult
+  stats?: DockerExecResult
+}
+
+type RecordingExec = DockerExec & { calls: string[] }
+
+// Records the docker subcommand of every call and THROWS on any subcommand the
+// test didn't stub, so a spurious `docker stats` on the missing/stopped path is
+// a hard failure instead of a silently-swallowed benign error. Callers assert on
+// `.calls` to pin the exact inspect-vs-stats sequence.
+function recordingExec(opts: FakeDockerOptions): RecordingExec {
+  const calls: string[] = []
+  const exec = (async (args) => {
+    const sub = args[0] ?? ''
+    calls.push(sub)
+    if (sub === 'inspect') {
+      return opts.inspect ?? { exitCode: 1, stdout: '', stderr: 'no inspect stub' }
+    }
+    if (sub === 'stats') {
+      if (opts.stats === undefined) throw new Error(`unexpected docker stats call: ${args.join(' ')}`)
+      return opts.stats
+    }
+    throw new Error(`unexpected docker call: ${args.join(' ')}`)
+  }) as RecordingExec
+  exec.calls = calls
+  return exec
+}
+
+describe('stats', () => {
+  test('reports missing and probes only inspect when docker inspect exits non-zero', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const exec = recordingExec({ inspect: { exitCode: 1, stdout: '', stderr: 'No such object' } })
+
+    const result = await stats({ cwd: folder, exec })
+
+    expect(result).toEqual({ kind: 'missing', containerName: 'coder', imageTag: 'typeclaw-coder' })
+    expect(exec.calls).toEqual(['inspect'])
+  })
+
+  test('reports stopped and probes only inspect when Running is false', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const exec = recordingExec({ inspect: { exitCode: 0, stdout: 'false|0001-01-01T00:00:00Z\n', stderr: '' } })
+
+    const result = await stats({ cwd: folder, exec })
+
+    expect(result).toEqual({ kind: 'stopped', containerName: 'coder', imageTag: 'typeclaw-coder' })
+    expect(exec.calls).toEqual(['inspect'])
+  })
+
+  test('reports running with parsed cpu, memory, and pids after inspect then stats', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const exec = recordingExec({
+      inspect: { exitCode: 0, stdout: 'true|2026-07-22T08:28:42.217286468Z\n', stderr: '' },
+      stats: { exitCode: 0, stdout: '3.16%|919.8MiB / 15.65GiB|5.74%|57\n', stderr: '' },
+    })
+
+    const result = await stats({ cwd: folder, exec })
+
+    expect(result).toEqual({
+      kind: 'running',
+      containerName: 'coder',
+      imageTag: 'typeclaw-coder',
+      startedAt: '2026-07-22T08:28:42.217286468Z',
+      cpuPercent: '3.16%',
+      memUsage: '919.8MiB / 15.65GiB',
+      memPercent: '5.74%',
+      pids: '57',
+    })
+    expect(exec.calls).toEqual(['inspect', 'stats'])
+  })
+
+  test('reports running with dashes when docker stats has no row for the container', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const exec = recordingExec({
+      inspect: { exitCode: 0, stdout: 'true|2026-07-22T08:28:42Z\n', stderr: '' },
+      stats: { exitCode: 1, stdout: '', stderr: 'no such container' },
+    })
+
+    const result = await stats({ cwd: folder, exec })
+
+    expect(result).toMatchObject({
+      kind: 'running',
+      cpuPercent: '-',
+      memUsage: '-',
+      memPercent: '-',
+      pids: '-',
+    })
+    expect(exec.calls).toEqual(['inspect', 'stats'])
+  })
+
+  test('reports running with null startedAt when inspect omits it', async () => {
+    const folder = join(root, 'coder')
+    await mkdir(folder)
+    const exec = recordingExec({
+      inspect: { exitCode: 0, stdout: 'true|\n', stderr: '' },
+      stats: { exitCode: 0, stdout: '1.0%|10MiB / 1GiB|1.0%|3\n', stderr: '' },
+    })
+
+    const result = await stats({ cwd: folder, exec })
+
+    expect(result).toMatchObject({ kind: 'running', startedAt: null })
+  })
+})
+
+describe('parseStatsLine', () => {
+  test('parses a pipe-delimited stats row preserving the mem-usage field', () => {
+    expect(parseStatsLine('47.06%|1.494GiB / 15.65GiB|9.55%|31\n')).toEqual({
+      cpuPercent: '47.06%',
+      memUsage: '1.494GiB / 15.65GiB',
+      memPercent: '9.55%',
+      pids: '31',
+    })
+  })
+
+  test('returns null for empty output', () => {
+    expect(parseStatsLine('')).toBeNull()
+    expect(parseStatsLine('\n  \n')).toBeNull()
+  })
+})

--- a/src/container/stats.ts
+++ b/src/container/stats.ts
@@ -1,0 +1,86 @@
+import { containerNameFromCwd, defaultDockerExec, imageTagFromCwd, type DockerExec } from './shared'
+
+export type ContainerStats =
+  | { kind: 'missing'; containerName: string; imageTag: string }
+  | { kind: 'stopped'; containerName: string; imageTag: string }
+  | {
+      kind: 'running'
+      containerName: string
+      imageTag: string
+      startedAt: string | null
+      cpuPercent: string
+      memUsage: string
+      memPercent: string
+      pids: string
+    }
+
+export type StatsOptions = {
+  cwd: string
+  exec?: DockerExec
+}
+
+// `docker stats --no-stream` only emits a row for a RUNNING container; a stopped
+// or absent one yields no line at all, so it cannot by itself distinguish the two.
+// Probe `docker inspect` first to classify missing vs stopped vs running (and to
+// pull StartedAt for an uptime line), then read the live resource snapshot from
+// `docker stats` for the running case.
+export async function stats({ cwd, exec = defaultDockerExec }: StatsOptions): Promise<ContainerStats> {
+  const containerName = containerNameFromCwd(cwd)
+  const imageTag = imageTagFromCwd(cwd)
+
+  const inspect = await exec(['inspect', '--format', '{{.State.Running}}|{{.State.StartedAt}}', containerName])
+  if (inspect.exitCode !== 0) {
+    return { kind: 'missing', containerName, imageTag }
+  }
+
+  const [runningRaw = '', startedAtRaw = ''] = inspect.stdout.trim().split('|')
+  if (runningRaw.trim() !== 'true') {
+    return { kind: 'stopped', containerName, imageTag }
+  }
+
+  const snapshot = await queryStats(exec, containerName)
+  return {
+    kind: 'running',
+    containerName,
+    imageTag,
+    startedAt: startedAtRaw.trim() === '' ? null : startedAtRaw.trim(),
+    cpuPercent: snapshot?.cpuPercent ?? '-',
+    memUsage: snapshot?.memUsage ?? '-',
+    memPercent: snapshot?.memPercent ?? '-',
+    pids: snapshot?.pids ?? '-',
+  }
+}
+
+export type StatsSnapshot = {
+  cpuPercent: string
+  memUsage: string
+  memPercent: string
+  pids: string
+}
+
+// Pipe-delimited so a mem-usage field like "919.8MiB / 15.65GiB" (which contains
+// spaces and slashes) survives intact — a space or comma separator would split it.
+const STATS_FORMAT = '{{.CPUPerc}}|{{.MemUsage}}|{{.MemPerc}}|{{.PIDs}}'
+
+async function queryStats(exec: DockerExec, containerName: string): Promise<StatsSnapshot | null> {
+  const result = await exec(['stats', '--no-stream', '--format', STATS_FORMAT, containerName])
+  if (result.exitCode !== 0) return null
+  return parseStatsLine(result.stdout)
+}
+
+export function parseStatsLine(stdout: string): StatsSnapshot | null {
+  const line = stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0)
+  if (line === undefined) return null
+
+  const [cpuPercent = '', memUsage = '', memPercent = '', pids = ''] = line.split('|').map((f) => f.trim())
+  if (cpuPercent === '' && memUsage === '' && memPercent === '' && pids === '') return null
+  return {
+    cpuPercent: cpuPercent || '-',
+    memUsage: memUsage || '-',
+    memPercent: memPercent || '-',
+    pids: pids || '-',
+  }
+}


### PR DESCRIPTION
## Background

Operators running a fleet of agents have no first-class way to see how much each container is actually consuming. `typeclaw status` answers *is it up and is it registered*, but not *is it healthy* — the cpu, memory, and pid-count signals you need to spot a runaway turn or a slow pid leak. Today the only recourse is dropping to raw `docker stats` on the host and mapping cryptic container names back to agent folders by hand.

This adds the missing resource-visibility verb at both scopes: `typeclaw stats` for one agent, `typeclaw compose stats` for the whole fleet.

## Summary

Two commands, one shared domain probe:

- **`typeclaw stats`** — a `docker stats --no-stream` snapshot for the current agent: cpu %, memory usage/limit + %, and pid count, plus an uptime line.
- **`typeclaw compose stats`** — the same snapshot fanned out across every discovered agent folder, with per-agent resource columns, matching the existing `compose status` fan-out and progress conventions.

Key decisions a reviewer would otherwise have to ask about:

- **Why probe `docker inspect` before `docker stats`.** `docker stats --no-stream` emits *no row at all* for a stopped or absent container, so it cannot by itself tell missing from stopped from running. The domain layer (`src/container/stats.ts`) runs `inspect` first to classify state (and to read `StartedAt` for the uptime suffix), then reads the live snapshot only for the running case. A stopped/absent agent renders cleanly with no metrics rather than an empty/confusing line.
- **Why pipe-delimited `--format`.** The `MemUsage` field (`"1.028GiB / 15.65GiB"`) contains spaces and a slash, so any space/comma separator would shred it. The format string is `{{.CPUPerc}}|{{.MemUsage}}|{{.MemPerc}}|{{.PIDs}}` and parsing splits on `|`.
- **Reused the established seams.** `stats` rides the existing `Controller` interface (Local + Noop), the `DockerExec` injection seam (so the domain + render flow are tested without spawning Docker), and the compose `discoverAgents` → `Promise.all` fan-out. No new infrastructure.

## Preview

```
$ typeclaw stats

Container  coder
  cwd     /agents/coder
  image   typeclaw-coder
  state   running up 1d 2h

  cpu     5.37%
  memory  1.028GiB / 15.65GiB (6.57%)
  pids    41


$ typeclaw compose stats

4 agents in /agents

  ●  coder       running      3.60%  853.4MiB / 15.65GiB (5.33%)  52 pids
  ●  researcher  running      5.37%  1.028GiB / 15.65GiB (6.57%)  41 pids
  ○  planner     stopped
  ·  scratch     not started
```

## What this does NOT do

- No `--watch` / streaming mode — this is a one-shot snapshot only (`docker stats --no-stream`). Live refresh can come later behind a flag.
- No JSON output. `compose usage` has `--json`; `stats` does not yet. Easy to add if there's demand.
- No historical/timeseries data or thresholds/alerting — it's a point-in-time read, nothing persisted.

## Review notes

- Load-bearing file is `src/container/stats.ts`. The invariant to verify: the `inspect`-first ordering (a non-running container never reaches the `docker stats` call), and the pipe-delimited parse that keeps `MemUsage` intact.
- Registration is the usual three-site dance for a new builtin command: `src/cli/index.ts` (lazy subcommand), `src/cli/command-meta.ts` (union + table), and the matching loader in `command-meta.test.ts` — the guard test asserts the table description is byte-identical to the command's `meta.description`.
- `compose stats` state classification (`running`/`stopped`/`absent`) mirrors `compose status` exactly, so the two fleet views stay consistent.
- Docs land in the same PR: `cli.mdx`, `compose.mdx`, and the README operator-CLI + compose bullets.
