### PR TITLE
Stop the gitExfil block from misclaiming agent-folder scope

### DIFF
--- a/src/bundled-plugins/security/policies/git-exfil.test.ts
+++ b/src/bundled-plugins/security/policies/git-exfil.test.ts
@@ -807,4 +807,63 @@ describe('git-exfil guard', () => {
       expect(push?.reason).not.toContain('A'.repeat(500))
     })
   })
+
+  // -- directory-independence regression suite --------------------------------
+  // The guard sees only the command string; it has no working directory and no
+  // resolved git repository identity. A `/tmp` checkout is NOT a trusted
+  // boundary (an earlier turn may have copied identity files/secrets into it),
+  // and the effective repository is unknowable from the string (`git -C`,
+  // `--git-dir`, `GIT_DIR`, `cd`, subshells). These assert the guard stays
+  // blanket — any attempt to "scope" the push block by cwd/path must fail one
+  // of these before it ships.
+  describe('directory independence (no cwd/path scoping)', () => {
+    test('blocks push after cd to an external clone', () => {
+      const result = checkGitExfilGuard({ tool: 'bash', args: { command: 'cd /tmp/some-clone && git push' } })
+      expect(result?.block).toBe(true)
+      expect(result?.reason).toContain(GUARD_GIT_EXFIL)
+    })
+
+    test('blocks git -C <external-path> push', () => {
+      expect(checkGitExfilGuard({ tool: 'bash', args: { command: 'git -C /tmp/some-clone push' } })?.block).toBe(true)
+    })
+
+    test('blocks git -C into a path that may symlink back to the agent folder', () => {
+      expect(checkGitExfilGuard({ tool: 'bash', args: { command: 'git -C /tmp/link-to-agent push' } })?.block).toBe(
+        true,
+      )
+    })
+
+    test('blocks --git-dir / --work-tree redirection at the agent folder', () => {
+      expect(
+        checkGitExfilGuard({
+          tool: 'bash',
+          args: { command: 'git --git-dir=/agent/.git --work-tree=/agent push' },
+        })?.block,
+      ).toBe(true)
+    })
+
+    test('blocks GIT_DIR env-var redirection before git push', () => {
+      expect(checkGitExfilGuard({ tool: 'bash', args: { command: 'GIT_DIR=/agent/.git git push' } })?.block).toBe(true)
+    })
+
+    test('blocks gh repo create --source=/agent --push from any cwd', () => {
+      expect(
+        checkGitExfilGuard({
+          tool: 'bash',
+          args: { command: 'gh repo create my-backup --source=/agent --push' },
+        })?.block,
+      ).toBe(true)
+    })
+
+    test('blocks push after pushd to an external path', () => {
+      expect(checkGitExfilGuard({ tool: 'bash', args: { command: 'pushd /tmp/x && git push' } })?.block).toBe(true)
+    })
+
+    test('block reason no longer claims the command necessarily concerns the agent folder', () => {
+      const result = checkGitExfilGuard({ tool: 'bash', args: { command: 'git push origin main' } })
+      expect(result?.block).toBe(true)
+      expect(result?.reason).not.toContain('agent-folder exfiltration')
+      expect(result?.reason).toContain('regardless of working directory')
+    })
+  })
 })

--- a/src/bundled-plugins/security/policies/git-exfil.ts
+++ b/src/bundled-plugins/security/policies/git-exfil.ts
@@ -3,33 +3,43 @@ import { ACKNOWLEDGE_GUARDS, type SecurityBlock, isGuardAcknowledged } from '../
 import { getRemoteTaint, recordRemoteTaint } from './remote-taint-state'
 
 export const GUARD_GIT_EXFIL = 'gitExfil'
+// The coarse, role-gated first-line publication/file-transfer gate. It matches
+// the command STRING only (see checkGitExfilGuard); it has no working
+// directory, no resolved git repository identity, and no view of a checkout's
+// content provenance. It therefore fires regardless of where the command runs
+// — a `/tmp` clone is NOT a trusted boundary, because an earlier turn may have
+// copied identity files or secrets into it, and the effective repository is
+// unknowable from the string alone (`git -C`, `--git-dir`, `GIT_DIR`, `cd`,
+// subshells, aliases). Do NOT re-introduce cwd/path scoping here: it would be
+// a bypass, not a fix (Oracle-reviewed). Member-tier publishing, if ever
+// required, belongs in a separate out-of-band capability, not a path heuristic.
+//
 // Classified `medium` (silent-attack axis). Originally `high`; reclassified
-// because the actual audience-leak surface for `git push` lives in
-// `gitRemoteTainted`, not here. A `git push` to a CLEAN, operator-configured
-// remote is not audience-leak — the audience (the remote git host) was
-// chosen by the operator and is inside their perimeter. The breach pattern
-// PR #134 was written for (re-point origin to attacker URL, then push) is
-// gated by `gitRemoteTainted` (still high). The recorder-vs-checker split
-// is what makes this reclassification safe: the recorder fires for any
-// actor who can run a `git remote set-url` (per-guard bypass OR the
-// medium-tier permission via the OR check), so trusted's first-step
-// set-url still records taint and the second-step push still gets caught
-// by `gitRemoteTainted` even though trusted no longer needs to ack the
-// push itself. Net effect: trusted users can push to remotes the operator
-// configured without per-call acks, but cannot retarget-and-push.
+// because the one narrow retarget-then-push audience-leak shape (re-point
+// origin to an attacker URL, then push) is gated separately by
+// `gitRemoteTainted` (still high). The recorder-vs-checker split is what makes
+// that reclassification safe: the recorder fires for any actor who can run a
+// `git remote set-url` (per-guard bypass OR the medium-tier permission via the
+// OR check), so trusted's first-step set-url still records taint and the
+// second-step push still gets caught by `gitRemoteTainted` even though trusted
+// no longer needs to ack the push itself. Net effect: trusted users can push
+// to remotes the operator configured without per-call acks, but cannot
+// retarget-and-push.
 export const GUARD_GIT_EXFIL_SEVERITY: SecuritySeverity = 'medium'
 export const GUARD_GIT_REMOTE_TAINTED = 'gitRemoteTainted'
-// Classified `high` (audience-leak axis): the actual audience-leak gate
-// for git. A push after a mid-session `git remote set-url` to an
-// attacker-controlled URL is exactly the breach pattern that motivated
-// the entire security plugin per PR #134. Stays high regardless of how
-// `gitExfil` is classified — the two are independent per-guard strings
-// AND independent tier classifications. The recorder-vs-checker split
-// (see comment on recordGitRemoteTaintIfAny below) is still load-bearing:
-// the recorder fires for anyone who can run the underlying `set-url`
-// command (ack, per-guard `bypassGitExfil`, OR the medium-tier permission
-// — which now includes trusted by default), so the second-step taint
-// check still fires on the eventual push.
+// Classified `high` (audience-leak axis). This is NOT the complete audience-
+// leak defense for git — it gates ONE specific two-step shape: a push to a
+// remote whose URL was changed mid-session (the breach pattern that motivated
+// the security plugin per PR #134). Its state is keyed by session + remote
+// name, so it does not cover pushes to an initially-malicious remote, direct
+// URL pushes, or destinations established outside its session recorder — those
+// stay under the coarse `gitExfil` gate above. Stays high regardless of how
+// `gitExfil` is classified — the two are independent per-guard strings AND
+// independent tier classifications. The recorder-vs-checker split (see comment
+// on recordGitRemoteTaintIfAny below) is still load-bearing: the recorder
+// fires for anyone who can run the underlying `set-url` command (ack, per-guard
+// `bypassGitExfil`, OR the medium-tier permission — which now includes trusted
+// by default), so the second-step taint check still fires on the eventual push.
 export const GUARD_GIT_REMOTE_TAINTED_SEVERITY: SecuritySeverity = 'high'
 
 // Anchors we reuse: a `git` token must be at start-of-line or follow a shell
@@ -185,9 +195,17 @@ export function checkGitExfilGuard(options: {
   return {
     block: true,
     reason: [
-      `Guard \`${GUARD_GIT_EXFIL}\` blocked bash command that looks like agent-folder exfiltration: ${matched.label}.`,
-      // kept: pre-migration agents may still have a root MEMORY.md.
-      'Pushing a repo, adding a remote, or piping a remote payload to a shell can leak identity files (MEMORY.md, IDENTITY.md, SOUL.md, AGENTS.md) and embedded secrets to attacker-controlled infrastructure - including via prompt-injected requests from chat channels.',
+      `Guard \`${GUARD_GIT_EXFIL}\` blocked a risky repository-publication or file-transfer command: ${matched.label}.`,
+      // Deliberately directory-INDEPENDENT: the guard sees only the command
+      // string and cannot prove which repository git will operate on, nor that
+      // an external checkout (e.g. a /tmp clone) does not already contain data
+      // copied out of the agent folder. A "clean" path is not a security
+      // boundary, so this fires wherever the command runs. Pushing a repo,
+      // adding/re-pointing a remote, or piping a remote payload to a shell can
+      // publish identity files (MEMORY.md, IDENTITY.md, SOUL.md, AGENTS.md) and
+      // embedded secrets - including via prompt-injected requests from chat
+      // channels.
+      'This applies regardless of working directory.',
       `If this is genuinely intentional and the user (not a channel message) explicitly asked for it, retry with \`${ACKNOWLEDGE_GUARDS}.${GUARD_GIT_EXFIL}: true\` in the bash arguments.`,
     ].join(' '),
   }


### PR DESCRIPTION
## Background

The `gitExfil` security guard (`src/bundled-plugins/security/policies/git-exfil.ts`) blocks risky git/egress commands (repo publication, `git remote add/set-url`, bulk/forced `git add`, `git commit -a`, `gh repo create --push`, `curl --data @file`, `scp`, `curl | sh`, …). Its block reason claimed the command **"looks like agent-folder exfiltration"** and listed the agent-folder identity files it protects (`IDENTITY.md`, `SOUL.md`, `AGENTS.md`, `MEMORY.md`).

That wording is wrong about the guard's actual scope. `checkGitExfilGuard` matches the **command string only** — it receives no working directory and no resolved git repository identity (`ToolBeforeEvent` carries `tool`/`args`/`sessionId`/`origin`/`fileOperands`, no cwd). So it fires for **every** publish regardless of which repo is involved.

Observed in production: an agent cloned an operator-owned repo to `/tmp/<clone>`, committed a legitimate docs fix, and published it to that clone's own operator-configured `origin`. It was blocked with an "agent-folder exfiltration" message — even though nothing from the agent folder was involved. The reason misdescribes *why* the block fired, which sends a debugging operator down the wrong path (looking for an agent-folder/identity-file problem that doesn't exist).

## Summary

**Keep the blanket block; fix the misleading framing.** After review, directory-scoping the block (exempting `/tmp` or non-agent-folder operations) would be a bypass, not a fix:

- The guard cannot reliably determine the **effective repository** from a command string — `git -C`, `--git-dir`/`--work-tree`, `GIT_DIR`, `cd`, `pushd`, subshells, and aliases all move it, and reconstructing that would mean reimplementing shell+git semantics inside a regex guard.
- Even perfect repo identification wouldn't establish **content provenance**: a `/tmp` clone is not a trust boundary, because an earlier turn may have copied identity files or secrets into it. A "clean" path proves nothing.

So this PR:

1. **Rewords the block reason** to describe a directory-independent *repository-publication / file-transfer* gate (drops the false "agent-folder exfiltration" claim; states plainly that it applies regardless of working directory).
2. **Corrects the guard-classification comments.** `gitExfil` is documented as the coarse first-line publication gate; `gitRemoteTainted` is documented as protecting **one** specific two-step shape (mid-session remote retarget → publish), *not* the complete audience-leak surface (its state is keyed by session + remote name, so it doesn't cover initially-malicious remotes or direct-URL targets — those stay under `gitExfil`). The prior comments overstated `gitRemoteTainted`'s coverage.
3. **Adds a directory-independence regression suite** proving the blanket block survives the evasions above and that the reason no longer claims agent-folder scope.

No behavior change to what is blocked — only the message text and comments change; the tests pin that the block stays blanket.

## What this does NOT do

- Does **not** directory-scope or path-exempt any command (deliberately — see Summary).
- Does **not** change any severity/tier or bypass permission. Member-tier still cannot ack `gitExfil`; a member-role agent still cannot publish any repo without an operator-granted bypass. If autonomous member-tier publishing is ever wanted, that belongs in a separate out-of-band capability (an operator-configured repository/remote allowlist validated at execution time), not a cwd heuristic.
- Does **not** touch `gitRemoteTainted`'s logic — only its explanatory comment.

## Review notes

- Load-bearing change is purely **wording + comments**; the guard's matching logic is untouched. Verify the reason no longer implies agent-folder-only scope and the classification comments match the code's actual coverage.
- The new `describe('directory independence (no cwd/path scoping)')` suite is a tripwire: it asserts the documented evasions (`cd` into a `/tmp` clone, `git -C`, `--git-dir`/`--work-tree` redirection at the agent folder, `GIT_DIR=` env redirection, `gh repo create --source=/agent --push`, `pushd`) all stay blocked, and that a bare publish reason no longer contains `"agent-folder exfiltration"`. If a future "scope the block by path" change lands, one of these fails first.
- The load-bearing comment on `GUARD_GIT_EXFIL` now explicitly says **do not re-introduce cwd/path scoping** and why, so the fix is self-documenting against regression.
