### PR TITLE
Nudge the bot to answer prior messages on a bare-mention wake

### DIFF
--- a/src/channels/adapters/telegram-bot-classify.test.ts
+++ b/src/channels/adapters/telegram-bot-classify.test.ts
@@ -81,6 +81,7 @@ describe('telegram-bot classifyInbound — routing', () => {
       authorName: 'alice',
       authorIsBot: false,
       isBotMention: false,
+      isBotMentionOnly: false,
       replyToBotMessageId: null,
       mentionsOthers: false,
       replyToOtherMessageId: null,
@@ -152,6 +153,69 @@ describe('telegram-bot classifyInbound — routing', () => {
     expect(verdict.kind).toBe('route')
     if (verdict.kind !== 'route') throw new Error('expected route')
     expect(verdict.payload.isBotMention).toBe(false)
+  })
+
+  test('a bare @-username mention (whole message) is isBotMentionOnly', () => {
+    const event = buildMessage({ text: '@typeclaw_bot', entities: [{ type: 'mention', offset: 0, length: 13 }] })
+
+    const verdict = classifyInbound(event, baseConfig, BOT)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMentionOnly).toBe(true)
+  })
+
+  test('a newline-padded bare @-username mention is isBotMentionOnly', () => {
+    const event = buildMessage({ text: '\n @typeclaw_bot \n', entities: [{ type: 'mention', offset: 2, length: 13 }] })
+
+    const verdict = classifyInbound(event, baseConfig, BOT)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMentionOnly).toBe(true)
+  })
+
+  test('a bare text_mention (rendered as a display name) is isBotMentionOnly', () => {
+    const botNoUsername: TelegramBotUser = { id: 999, is_bot: true, first_name: 'TypeClaw' }
+    const event = buildMessage({
+      text: '  TypeClaw  ',
+      entities: [{ type: 'text_mention', offset: 2, length: 8, user: botNoUsername }],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, botNoUsername)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMentionOnly).toBe(true)
+  })
+
+  test('a mention with extra text is not isBotMentionOnly', () => {
+    const event = buildMessage({
+      text: '@typeclaw_bot please help',
+      entities: [{ type: 'mention', offset: 0, length: 13 }],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMentionOnly).toBe(false)
+  })
+
+  test('the bot mention plus another mention is not isBotMentionOnly', () => {
+    const event = buildMessage({
+      text: '@typeclaw_bot @alice',
+      entities: [
+        { type: 'mention', offset: 0, length: 13 },
+        { type: 'mention', offset: 14, length: 6 },
+      ],
+    })
+
+    const verdict = classifyInbound(event, baseConfig, BOT)
+
+    expect(verdict.kind).toBe('route')
+    if (verdict.kind !== 'route') throw new Error('expected route')
+    expect(verdict.payload.isBotMentionOnly).toBe(false)
   })
 
   test('reply to bot message surfaces replyToBotMessageId, not replyToOtherMessageId', () => {

--- a/src/channels/adapters/telegram-bot-classify.ts
+++ b/src/channels/adapters/telegram-bot-classify.ts
@@ -62,6 +62,8 @@ export function classifyInbound(
 
   const thread = event.message_thread_id !== undefined ? String(event.message_thread_id) : null
 
+  const isBotMentionOnly = attachments.length === 0 && isOnlyBotMention(entities, fullText, bot.id, botUsername)
+
   return {
     kind: 'route',
     payload: {
@@ -76,6 +78,7 @@ export function classifyInbound(
       authorName: formatAuthorName(author),
       authorIsBot: author.is_bot === true,
       isBotMention,
+      isBotMentionOnly,
       replyToBotMessageId,
       mentionsOthers,
       replyToOtherMessageId,
@@ -83,6 +86,32 @@ export function classifyInbound(
       ts: event.date * 1000,
     },
   }
+}
+
+// A "bare ping" is a message whose entire body (ignoring surrounding
+// whitespace) is a SINGLE mention of the bot. The router cannot detect this
+// from `text` because a `text_mention` renders as the target's display name,
+// not `<@id>` markup, so the adapter must decide it here where the structured
+// entities are still available. Offsets are UTF-16 code units in both Telegram
+// entities and JS strings, so slicing lines up. Multiple mentions, any extra
+// words, or a mention that does not span the whole trimmed text are not bare.
+function isOnlyBotMention(
+  entities: readonly TelegramMessageEntity[],
+  fullText: string,
+  botId: number,
+  botUsername: string | undefined,
+): boolean {
+  const userMentions = entities.filter(isUserMentionEntity)
+  if (userMentions.length !== 1) return false
+  const entity = userMentions[0]!
+  const start = fullText.length - fullText.trimStart().length
+  const end = fullText.trimEnd().length
+  return (
+    start < end &&
+    entity.offset === start &&
+    entity.offset + entity.length === end &&
+    isUserMentionForBot(entity, fullText, botId, botUsername)
+  )
 }
 
 function formatAuthorName(user: TelegramBotUser): string {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -1456,6 +1456,160 @@ describe('ChannelRouter engagement and prompt composition', () => {
     expect(prompt.indexOf('unrelated')).toBeLessThan(prompt.indexOf('hey bot'))
   })
 
+  test('nudges to answer the preceding message when a bare mention wakes the bot', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    // Prime carol as a second human so bob's non-mention message observes
+    // (multi-human strict-mention) instead of tripping the solo fallback.
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+    await router.route(
+      inbound({
+        isBotMention: false,
+        authorId: 'bob',
+        authorName: 'bob',
+        text: '3분기에 종료한다는 내용을 3분기에 보내는게 말이 돼?',
+      }),
+    )
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', text: '<@bot>' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('wake up')
+    expect(prompt).toContain('Do not ask "what do you need?"')
+    // the real question is still visible above under Recent context
+    expect(prompt).toContain('3분기에 종료한다는 내용을 3분기에 보내는게 말이 돼?')
+  })
+
+  // A bare ping is still bare when the mention is padded with whitespace,
+  // wrapped in newlines, or repeated — stripping the markup leaves only
+  // whitespace, which trims to empty.
+  test.each([
+    ['leading/trailing spaces', '  <@bot>  '],
+    ['surrounding newlines', '\n<@bot>\n'],
+    ['a tab before the mention', '\t<@bot>'],
+    ['the mention repeated', '<@bot> <@bot>'],
+  ])('fires the wake nudge for a whitespace-padded bare mention (%s)', async (_label, pingText) => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+    await router.route(
+      inbound({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: 'the staging deploy is failing' }),
+    )
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', text: pingText }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('wake up')
+    expect(prompt).toContain('the staging deploy is failing')
+  })
+
+  test('fires the wake nudge when a DIFFERENT author pings about a message', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+    // alice drops a message (observed); bob pings the bot to loop it in
+    await router.route(
+      inbound({ isBotMention: false, authorId: 'alice', authorName: 'alice', text: 'anyone know the Q3 MRR?' }),
+    )
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', text: '<@bot>' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('wake up')
+    expect(prompt).toContain('anyone know the Q3 MRR?')
+  })
+
+  test('fires the wake nudge on a Telegram bare mention the router text cannot strip', async () => {
+    const dir = await tempDir()
+    const TG: ChannelKey = { adapter: 'telegram-bot', workspace: 't1', chat: 'c1', thread: null }
+    const { router, sessions } = makeRouter(dir)
+    const tg = (over: Partial<InboundMessage> = {}): InboundMessage =>
+      inbound({ adapter: 'telegram-bot', workspace: 't1', chat: 'c1', ...over })
+    await router.route(tg({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(TG)
+    sessions[0]!.prompts.length = 0
+    await router.route(
+      tg({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: 'the deploy is stuck, can someone look?' }),
+    )
+    // A Telegram text_mention renders as the bot's display name ("TypeClaw"),
+    // which stripMentionMarkup cannot recognize — the adapter-set boolean is the
+    // only signal that this is a bare ping.
+    await router.route(tg({ isBotMentionOnly: true, authorId: 'bob', authorName: 'bob', text: 'TypeClaw' }))
+    await router.__testing!.flushDebounce(TG)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('wake up')
+    expect(prompt).toContain('the deploy is stuck, can someone look?')
+  })
+
+  test('does not fire the wake nudge for a bare mention with no recent context', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', text: '<@bot>' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).not.toContain('wake up')
+  })
+
+  test('does not fire the wake nudge for a message that arrived AFTER the ping (debounce-window race)', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+    // the bare mention lands first; a non-mention message from bob arrives
+    // DURING the debounce window (later receivedAt) and coalesces into the same
+    // drain — it came after the ping, so it is not what the ping points back at.
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', text: '<@bot>' }))
+    nowRef.value = 2000
+    await router.route(
+      inbound({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: 'oh wait here is the thing' }),
+    )
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).not.toContain('wake up')
+  })
+
+  test('does not fire the wake nudge when the mention carries its own text', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    await router.route(inbound({ isBotMention: true, authorId: 'carol', authorName: 'carol', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+    sessions[0]!.prompts.length = 0
+    await router.route(
+      inbound({ isBotMention: false, authorId: 'bob', authorName: 'bob', text: 'some earlier chatter' }),
+    )
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', text: '<@bot> 이거 봐줘' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).not.toContain('wake up')
+  })
+
+  test('does not fire the wake nudge when the only recent context is prefetched scrollback', async () => {
+    const dir = await tempDir()
+    const { router, sessions } = makeRouter(dir)
+    router.registerHistory('discord-bot', async () => ({
+      ok: true,
+      messages: [historyMessage({ externalMessageId: 'h1', text: 'old scrollback line' })],
+    }))
+    await router.route(inbound({ authorId: 'bob', authorName: 'bob', text: '<@bot>' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    const prompt = sessions[0]!.prompts[0]!
+    expect(prompt).toContain('old scrollback line')
+    expect(prompt).not.toContain('wake up')
+  })
+
   test('caps observed Recent-context message text but never the addressed current message', async () => {
     const dir = await tempDir()
     const { router, sessions } = makeRouter(dir)

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -137,6 +137,13 @@ export const CONTEXT_BUFFER_SIZE = 20
 // subsequent turn until it ages out. Cap each observed message's text; the
 // addressed current message is never capped (it's the actual request).
 export const OBSERVED_MESSAGE_MAX_CHARS = 800
+// A bare @mention (no text of its own) is a "wake up and look" ping, not a
+// question — the user is signalling that a recent un-responded message is what
+// they want a reply to. The wake-request nudge only fires when such a ping
+// lands within this window of a recent observed message, so a mention that
+// arrives long after the channel went quiet does not misread stale scrollback
+// as the thing to answer.
+export const WAKE_REQUEST_LOOKBACK_MS = 60_000
 // Discord's typing indicator expires after ~10s; an 8s heartbeat keeps it
 // continuously visible while we debounce + generate without spamming the API.
 // This is the default; an adapter whose platform expires the indicator sooner
@@ -705,6 +712,7 @@ type QueuedInbound = {
   reactionRef?: ReactionRef
   engageReaction?: Promise<ReactionRef | null>
   isBotMention: boolean
+  isBotMentionOnly?: boolean
   replyToBotMessageId: string | null
   isDm: boolean
   typingThread?: string
@@ -3637,6 +3645,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       ...(event.reactionRef !== undefined ? { reactionRef: event.reactionRef } : {}),
       ...(engageReaction !== null ? { engageReaction } : {}),
       isBotMention: event.isBotMention,
+      ...(event.isBotMentionOnly !== undefined ? { isBotMentionOnly: event.isBotMentionOnly } : {}),
       replyToBotMessageId: event.replyToBotMessageId,
       isDm: event.isDm,
       ...(event.typingThread !== undefined ? { typingThread: event.typingThread } : {}),
@@ -5967,6 +5976,56 @@ function findAttachmentById(attachments: readonly InboundAttachment[], id: numbe
   return null
 }
 
+// Strips the platform's user/group-mention markup so a bare ping can be told
+// from a mention that also carries real text. Slack and Discord both encode
+// mentions as `<@id>` / `<@id|name>` (users) and `<!subteam^ID>` / `<!channel>`
+// (groups); GitHub and the plain-name adapters have no wrapping syntax to strip,
+// so their text is returned as-is and a mention there is never classified thin.
+// Content-blind and script-agnostic: it removes only fixed markup, never words,
+// so it works identically for Korean, CJK, Arabic, or any other input.
+function stripMentionMarkup(text: string, adapter: AdapterId): string {
+  switch (adapter) {
+    case 'slack':
+    case 'slack-bot':
+    case 'discord':
+    case 'discord-bot':
+      return text.replace(/<[@!][^>]*>/g, ' ')
+    default:
+      return text
+  }
+}
+
+// A "wake request" is a mention whose only payload IS the mention: once the
+// markup is stripped the remainder is empty. That shape means "wake up and look
+// at what was just said", not a self-contained question, so the caller nudges
+// the model toward the recent conversation instead of asking "what do you need?".
+function isThinMention(trigger: QueuedInbound, adapter: AdapterId): boolean {
+  if (!trigger.isBotMention) return false
+  if (trigger.attachments !== undefined && trigger.attachments.length > 0) return false
+  // Adapters whose visible text cannot reveal a bare ping (Telegram text_mention
+  // renders as a display name) carry the authoritative signal; trust it. Others
+  // fall back to stripping the platform's mention markup from the text.
+  if (trigger.isBotMentionOnly !== undefined) return trigger.isBotMentionOnly
+  return stripMentionMarkup(trigger.text, adapter).trim() === ''
+}
+
+// True when the engaged trigger is a bare ping AND a real (non-prefetch) message
+// was observed within the lookback window. Author-agnostic on purpose: in a group
+// one person can drop a message and a DIFFERENT teammate can ping the bot to loop
+// it in, so the recent message need not come from the pinger. The age must be
+// non-negative: a message that arrives DURING the mention's debounce window is
+// appended to contextBuffer after the ping, so `receivedAt - o.receivedAt` goes
+// negative — that message came AFTER the ping and is not what the user was
+// pointing back at, so it must not satisfy the "recent PRECEDING message" test.
+function isWakeRequest(observed: readonly ObservedInbound[], trigger: QueuedInbound, adapter: AdapterId): boolean {
+  if (!isThinMention(trigger, adapter)) return false
+  return observed.some((o) => {
+    if (o.source !== 'observed') return false
+    const age = trigger.receivedAt - o.receivedAt
+    return age >= 0 && age <= WAKE_REQUEST_LOOKBACK_MS
+  })
+}
+
 function composeTurnPrompt(
   observed: readonly ObservedInbound[],
   batch: readonly QueuedInbound[],
@@ -6079,6 +6138,45 @@ function composeTurnPrompt(
       'conversation, banter, or anything not actually waiting on you — reply with',
       '`NO_REPLY` (or call `skip_response`) to stay silent and keep watching.',
       'When unsure, prefer silence.',
+      '',
+      '---',
+      '',
+    )
+  }
+  // Wake-request nudge: same SYSTEM MESSAGE convention as the loop guard and
+  // group nudge. The trigger is a bare ping (mention with no text of its own),
+  // which the model would otherwise answer with "what do you need?" while the
+  // real request sits under "Recent context (not addressed to you)". This
+  // re-licenses the model to act on that recent conversation. Placed
+  // immediately BEFORE the Recent context block, and the nudge text points at
+  // that section BY NAME ("the Recent context section below") rather than by
+  // position, so the reference is unambiguous regardless of render order.
+  // Cache-neutral (user-turn suffix), and skipped when the loop guard already
+  // fired to avoid stacking two notices in one turn.
+  if (batch.length === 1 && !state.loopGuardActive && isWakeRequest(observed, batch[0]!, adapter)) {
+    parts.push(
+      '---',
+      '**[SYSTEM MESSAGE — not from a human]**',
+      '',
+      'You were just @-mentioned with little or no text — effectively a "wake up',
+      'and look" ping, not a question in itself. This is an automated signal from',
+      'the channel router, not a message from anyone in the chat. **Do not',
+      'acknowledge or reply to this notice.**',
+      '',
+      'A bare ping like this almost always means: "respond to what was just',
+      'said." Look at the "Recent context" section below (it shows who sent each',
+      'message):',
+      '- If a recent message clearly wants a response and is relevant to you —',
+      '  whether the person who pinged you sent it, or someone else did and the',
+      '  pinger is looping you in — treat THAT message as the real request and',
+      '  answer it directly. Do not ask "what do you need?" when the answer is',
+      '  already in that recent context.',
+      '- If several recent messages are relevant, address the substantive one(s).',
+      '- If nothing in that recent context actually needs you (the ping was a',
+      '  mistake, or the conversation moved on), a brief "what\'s up?" is fine.',
+      '',
+      'When in doubt, prefer answering the most recent substantive message over',
+      'asking what they meant.',
       '',
       '---',
       '',

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -80,6 +80,13 @@ export type InboundMessage = {
   // bounded loop guard so two or more bots cannot ping-pong forever.
   authorIsBot: boolean
   isBotMention: boolean
+  // Adapter-authoritative "this inbound is a bare ping — the mention IS the whole
+  // message" signal. Set only by adapters whose visible `text` cannot reveal it:
+  // Telegram renders a `text_mention` as the target's display NAME (not `<@id>`),
+  // so the router's markup-stripping cannot tell a bare ping from real text. When
+  // present the wake-request detector trusts it; when absent (Slack/Discord) the
+  // router falls back to stripping the platform's mention markup from `text`.
+  isBotMentionOnly?: boolean
   // When true, engagement treats this inbound as explicit-only: it skips
   // content-blind sticky credit AND plain-text alias matching, leaving only
   // structural DM / @mention / reply triggers. Used for GitHub PR review-thread


### PR DESCRIPTION
## Background

In a busy multi-human Slack thread running strict-mention mode, a user posts a substantive message without @-mentioning the bot. The bot correctly stays unengaged (`observe`), but the message still lands in the in-memory `contextBuffer` and is rendered on the next turn under the heading `## Recent context (not addressed to you, for awareness only)`.

A moment later, someone sends a follow-up that is *only* a bare mention (`@bot`) to wake it up. The bot engages — but because the real question is framed under "not addressed to you, for awareness only," the model reads it as ignorable and answers with "what do you need?" instead of the actual message sitting right above.

This is a **framing bug**, not a data-availability bug: the message was already in the prompt, just labeled in a way that told the model to ignore it.

## Summary

Treat a bare @mention — one whose text is empty once the platform's mention markup is stripped — as a "wake up and look" ping rather than a question. When such a ping engages the bot and a recent (≤60s) non-prefetch observed message exists in the `contextBuffer`, `composeTurnPrompt` emits a `SYSTEM MESSAGE` nudge (same convention as the existing loop-guard and group-chat nudges) telling the model: you were pinged, look at the recent messages above, and answer the substantive one — don't ask "what do you need?" when the answer is already there. New constant: `WAKE_REQUEST_LOOKBACK_MS = 60_000`.

This is a **framing-only fix**: no promotion of data between queues, no adapter or type changes, no retrieval changes. It lives entirely in `composeTurnPrompt`, in the non-cached user-turn suffix, so it's cache-neutral.

Two properties worth calling out for review:

- **Author-agnostic by design.** In a group, one person can post a message and a *different* teammate can ping the bot to loop it in — the nudge fires and the referenced message need not come from the pinger. Covered by a dedicated test.
- **Content-blind and multilingual.** "Thinness" is detected by stripping fixed mention markup (`<@id>`, `<@id|name>`, `<!...>` for Slack/Discord) and checking the remainder is empty — no keyword lists, so it works identically for Korean, CJK, Arabic, or any other script (per this repo's multi-language rules in `AGENTS.md`).

## What this does NOT do

- Does not fire on a mention that carries its own text (e.g. `@bot 이거 봐줘`) — that's a real question, not a wake ping.
- Does not fire on a bare mention with no recent context to point at.
- Does not fire when the only recent context is prefetched scrollback (`source: 'prefetch'`) rather than something actually observed live.
- Does not stack with the loop-guard notice — skipped when the loop guard already fired, to avoid two system notices in one turn.

## Review notes

- Load-bearing logic is `isThinMention` / `isWakeRequest` / `WAKE_REQUEST_LOOKBACK_MS` in `src/channels/router.ts`; the nudge block itself is inserted immediately before the `## Recent context` block in `composeTurnPrompt` so the model reads "you were pinged, look above" before it sees the messages being pointed at.
- `stripMentionMarkup` is intentionally a fixed-syntax strip (Slack/Discord mention wrappers), not a language-aware parser — verify it stays that way if another adapter is added.
- Six new tests in `src/channels/router.test.ts`, written TDD-first (verified failing without the production change): bare-mention wake with a Korean message still visible, a different-author ping referencing someone else's message, no-recent-context (no nudge), mention-with-own-text (no nudge, Korean case), and prefetch-only scrollback (no nudge).

## Testing

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (70 pre-existing warnings in unrelated files)
- `bun run format:check` — clean
- `bun run test` — 11901 pass, 0 fail, 31 skip
