### PR TITLE
Cap concurrent embeds to bound peak memory

### DIFF
--- a/src/bundled-plugins/memory/vector/embedder-concurrency.test.ts
+++ b/src/bundled-plugins/memory/vector/embedder-concurrency.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+
+import { EMBEDDING_DIMS } from '@/models/embedding-model'
+
+type EmbedderModule = typeof import('./embedder')
+type TransformersImporter = NonNullable<Parameters<EmbedderModule['__setTransformersImporterForTests']>[0]>
+type TransformersModule = Awaited<ReturnType<TransformersImporter>>
+
+type Deferred = { promise: Promise<void>; resolve: () => void }
+
+function deferred(): Deferred {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+// A pipeline whose forward pass BLOCKS until the test releases it, so the test
+// can observe how many embeds are inside inference at once. `started` fires each
+// time a forward pass enters; `gate` holds it there until resolved.
+async function gatedEmbedderModule(gate: Deferred, onStart: () => void): Promise<EmbedderModule> {
+  const mod = await import(`./embedder?concurrency=${crypto.randomUUID()}`)
+  mod.__setModelCacheCheckForTests(() => Promise.resolve())
+  const pipeline = (async () => {
+    return async (texts: string[]) => {
+      const count = Array.isArray(texts) ? texts.length : 1
+      onStart()
+      await gate.promise
+      return { data: new Float32Array(count * EMBEDDING_DIMS) }
+    }
+  }) as TransformersModule['pipeline']
+  mod.__setTransformersImporterForTests(async () => ({ env: {} as never, pipeline }))
+  return mod
+}
+
+describe('embedder concurrency cap', () => {
+  test('runs at most 2 embeds in inference at once; a 3rd waits for a slot', async () => {
+    const gate = deferred()
+    let inFlight = 0
+    let peakInFlight = 0
+    const onStart = (): void => {
+      inFlight++
+      peakInFlight = Math.max(peakInFlight, inFlight)
+    }
+
+    const { embed } = await gatedEmbedderModule(gate, onStart)
+
+    // given: three concurrent embed() calls, each a single-batch input
+    const calls = [embed(['a'], 'passage'), embed(['b'], 'passage'), embed(['c'], 'passage')]
+
+    // when: the gate is still closed, let the event loop settle so every
+    // admitted call has entered its forward pass
+    await new Promise((r) => setTimeout(r, 20))
+
+    // then: only 2 are inside inference; the 3rd is queued on the semaphore
+    expect(peakInFlight).toBe(2)
+
+    gate.resolve()
+    await Promise.all(calls)
+  })
+})

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 // values are pulled lazily via `loadTransformers()` below.
 import type { env as TransformersEnvValue, pipeline as TransformersPipeline } from '@huggingface/transformers'
 
+import { createKeyedSemaphore } from '@/agent/tools/keyed-semaphore'
 import {
   assertModelCacheCompatible,
   EMBEDDING_DIMS,
@@ -35,6 +36,21 @@ export type EmbedType = 'query' | 'passage'
 // caps peak memory at one batch's worth regardless of corpus size; the model is
 // loaded once and reused across chunks, so the only cost is sequential passes.
 const EMBED_BATCH_SIZE = 64
+
+// Concurrent embeds inside inference at once, process-wide. The intra-op thread
+// cap (embed-threads.ts) bounds ONE embed's footprint, but nothing bounded how
+// MANY embeds run at once: a busy channel turn's hybridSearch, a dreaming pass,
+// and a memory-logger append can all be inside the shared ONNX session
+// simultaneously (concurrent `Run()` is allowed on the Node backend), stacking
+// their activation memory into one RSS spike that the OOM killer takes with a
+// bare SIGKILL. This caps that stack. Chosen 2, not 1: the workload is
+// latency-sensitive per-turn query embeds, so a hard serial would park a live
+// turn behind a whole dreaming batch; 2 keeps one lane free while still bounding
+// the worst-case multiplier. Single fixed key — the limit is global, not
+// per-key.
+const EMBED_CONCURRENCY = 2
+const EMBED_SEMAPHORE_KEY = 'embed'
+const embedSemaphore = createKeyedSemaphore({ concurrency: EMBED_CONCURRENCY })
 
 type TransformersEnv = typeof TransformersEnvValue
 type FeatureExtractor = Awaited<ReturnType<typeof TransformersPipeline<'feature-extraction'>>>
@@ -154,14 +170,16 @@ export class Embedder {
     // upserts) finish in a pass or two and would only spam the logs.
     const reportProgress = prefixed.length >= LARGE_EMBED
 
-    const embeddings: Float32Array[] = []
-    for (let start = 0; start < prefixed.length; start += EMBED_BATCH_SIZE) {
-      const batch = prefixed.slice(start, start + EMBED_BATCH_SIZE)
-      const output = await this.extractor(batch, { pooling: 'mean', normalize: true })
-      embeddings.push(...toEmbeddings(output.data, batch.length))
-      if (reportProgress) logEmbedProgress(embeddings.length, prefixed.length, type)
-    }
-    return embeddings
+    return embedSemaphore.run(EMBED_SEMAPHORE_KEY, async () => {
+      const embeddings: Float32Array[] = []
+      for (let start = 0; start < prefixed.length; start += EMBED_BATCH_SIZE) {
+        const batch = prefixed.slice(start, start + EMBED_BATCH_SIZE)
+        const output = await this.extractor(batch, { pooling: 'mean', normalize: true })
+        embeddings.push(...toEmbeddings(output.data, batch.length))
+        if (reportProgress) logEmbedProgress(embeddings.length, prefixed.length, type)
+      }
+      return embeddings
+    })
   }
 }
 


### PR DESCRIPTION
## Problem

A field agent (Slack, private beta) died mid-run with **no stack trace** in the log — the log just stops mid-heartbeat, then two empty `open`/`close` sessions appear (a restart). The crash happened while three memory workloads overlapped:

- a busy channel session running over-budget `hybridSearch` turns (each embeds the query),
- the `dreaming` cron (`undreamed_fragments=138`),
- a `session-end` `memory-logger` on a large transcript (`transcript_bytes=318019`).

**Why no trace:** `src/run/fatal-guard.ts` logs `[fatal-guard] …` on *every* uncaught exception / unhandled rejection before requesting a restart. The log contains **zero** `[fatal-guard]` lines. That rules out a JS-level fault and points squarely at an **OOM SIGKILL** (or native abort) — a hard kill the JS runtime can't intercept.

## Root cause

We already cap **one** embed's footprint via the intra-op thread cap (`embed-threads.ts`) and arena-off. But nothing capped **how many** embeds run at once. The transformers.js Node backend allows concurrent `session.run()`, so a channel `hybridSearch` + a `dreaming` pass + a `memory-logger` append can all be inside the shared onnxruntime session simultaneously, **stacking their activation memory into a single RSS spike**. On a container with no memory headroom, the OOM killer takes that spike as a bare SIGKILL.

The existing per-fix work (thread cap, decode-once, arena-off — all in 0.46.2) each bounds *one dimension*; none establishes a process-wide bound on **concurrent** embeds, which is the actual multiplier here.

## Fix

Wrap the batch inference loop in `Embedder.embed()` with a process-wide keyed semaphore (`createKeyedSemaphore`, reused from `src/agent/tools/keyed-semaphore.ts`), **concurrency = 2**, single fixed key.

- The whole multi-batch loop holds one slot, so the cap limits **concurrent distinct `embed()` calls** — the RSS multiplier — not merely batches within a call.
- **2, not hard-serial:** per-turn query embeds are latency-sensitive; hard-serial would park a live channel turn behind a whole dreaming batch. Two keeps one lane free while still bounding the worst-case stack.
- The up-front `logEmbedBatch` breadcrumb stays *outside* the critical section, so a queued embed still logs what it's about to do.

This reuses an existing, tested primitive; no new concurrency machinery.

## Testing

- New `embedder-concurrency.test.ts`: a gated (blocking) pipeline proves at most 2 embeds are inside inference at once and a 3rd waits for a slot. Verified **red before / green after** the change (was `Received: 3`).
- `bun run typecheck` passes; `bun run lint` (0 errors); `bun run format:check` clean.
- Full suite: **11897 pass, 0 fail** (`bun run test`).

## Notes

- This is the first of two PRs. A follow-up adds **memory observability logging** (per-op RSS/heap around embed/hybridSearch/dreaming/logger, plus a boot-time dump of container limits: cgroup memory/cpu, ulimits, storage) so the *next* incident is confirmable from logs alone.
- To 100%-confirm this exact crash was OOM, the stopped container would show `OOMKilled=true` / `ExitCode=137` (`docker inspect`); this PR is the correct fix regardless, since the concurrent-embed stack is an unbounded RSS surface either way.
