### PR TITLE
Add memory observability logging for OOM diagnosis

### DIFF
--- a/src/bundled-plugins/memory/dreaming.ts
+++ b/src/bundled-plugins/memory/dreaming.ts
@@ -26,6 +26,7 @@ import {
 } from './dreaming-state'
 import { parseShard, renderShard, type ShardFrontmatter } from './frontmatter'
 import { listShardSlugs, loadAllShards, loadShard, type TopicShard } from './load-shards'
+import { formatMemorySnapshot } from './memory-snapshot'
 import { referencesDir, streamFilePath, streamsDir, topicShardPath, topicsDir } from './paths'
 import { renderReference } from './references/frontmatter'
 import { loadAllReferences, type Reference } from './references/load-references'
@@ -1477,7 +1478,7 @@ export function createDreamingSubagent(options: CreateDreamingSubagentOptions = 
       try {
         await commit(ctx.payload.agentDir)
         logger.info(
-          `[dreaming] done topics_created=${metrics.topicsCreated} topics_removed=${metrics.topicsRemoved} superseded_new=${metrics.supersededDelta} fragments_dropped=${compaction.fragmentsDropped} over_budget=${overBudget.length} references_demoted=${referencesDemoted} references_evicted=${referencesEvicted} elapsed_ms=${Date.now() - start}`,
+          `[dreaming] done topics_created=${metrics.topicsCreated} topics_removed=${metrics.topicsRemoved} superseded_new=${metrics.supersededDelta} fragments_dropped=${compaction.fragmentsDropped} over_budget=${overBudget.length} references_demoted=${referencesDemoted} references_evicted=${referencesEvicted} elapsed_ms=${Date.now() - start} ${formatMemorySnapshot()}`,
         )
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -6,6 +6,7 @@ import { formatLocalDate } from '@/shared'
 
 import { advanceWatermarkTool, createAppendTool, type FragmentsAppendedHook } from './append-tool'
 import { findEntryTool } from './find-entry-tool'
+import { formatMemorySnapshot } from './memory-snapshot'
 import { streamFilePath, streamsDir } from './paths'
 import { listReferenceSlugs } from './references/load-references'
 import { createStoreReferenceTool, type ReferenceStoredHook } from './references/store-reference-tool'
@@ -352,7 +353,7 @@ export function createMemoryLoggerSubagent(
         await runSession({ userPrompt: buildInitialPrompt(ctx.payload, streamFile, watermark) })
         const fragmentsWritten = (await countFragments(streamFile)) - fragmentsBefore
         logger.info(
-          `[memory-logger] ${ctx.payload.parentSessionId} done fragments_written=${fragmentsWritten} elapsed_ms=${Date.now() - start}`,
+          `[memory-logger] ${ctx.payload.parentSessionId} done fragments_written=${fragmentsWritten} elapsed_ms=${Date.now() - start} ${formatMemorySnapshot()}`,
         )
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/bundled-plugins/memory/memory-snapshot.test.ts
+++ b/src/bundled-plugins/memory/memory-snapshot.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatMemorySnapshot } from './memory-snapshot'
+
+describe('formatMemorySnapshot', () => {
+  test('renders rss/heap/external as MB key=value pairs', () => {
+    const line = formatMemorySnapshot({
+      rss: 512 * 1024 * 1024,
+      heapUsed: 128 * 1024 * 1024,
+      heapTotal: 256 * 1024 * 1024,
+      external: 64 * 1024 * 1024,
+      arrayBuffers: 32 * 1024 * 1024,
+    })
+
+    expect(line).toBe('rss_mb=512 heapUsed_mb=128 external_mb=64 arrayBuffers_mb=32')
+  })
+
+  test('rounds to whole MB', () => {
+    const line = formatMemorySnapshot({
+      rss: 512.7 * 1024 * 1024,
+      heapUsed: 0,
+      heapTotal: 0,
+      external: 0,
+      arrayBuffers: 0,
+    })
+
+    expect(line).toBe('rss_mb=513 heapUsed_mb=0 external_mb=0 arrayBuffers_mb=0')
+  })
+})

--- a/src/bundled-plugins/memory/memory-snapshot.ts
+++ b/src/bundled-plugins/memory/memory-snapshot.ts
@@ -1,0 +1,8 @@
+export type MemorySample = Pick<NodeJS.MemoryUsage, 'rss' | 'heapUsed' | 'heapTotal' | 'external' | 'arrayBuffers'>
+
+const BYTES_PER_MB = 1024 * 1024
+
+export function formatMemorySnapshot(sample: MemorySample = process.memoryUsage()): string {
+  const mb = (bytes: number): number => Math.round(bytes / BYTES_PER_MB)
+  return `rss_mb=${mb(sample.rss)} heapUsed_mb=${mb(sample.heapUsed)} external_mb=${mb(sample.external)} arrayBuffers_mb=${mb(sample.arrayBuffers)}`
+}

--- a/src/bundled-plugins/memory/vector/embedder.ts
+++ b/src/bundled-plugins/memory/vector/embedder.ts
@@ -17,6 +17,7 @@ import {
 import { getResolvedTransformersVersion } from '@/models/transformers-version'
 
 import { homeRoot } from '../../../hostd/paths'
+import { formatMemorySnapshot } from '../memory-snapshot'
 import { resolveEmbedThreadCount } from './embed-threads'
 import { type BoundedText, boundEmbeddableText, MAX_MODEL_TOKENS } from './truncation'
 
@@ -231,7 +232,7 @@ function warnIfBounded(results: readonly BoundedText[], type: EmbedType): void {
 const LARGE_EMBED = 256
 
 function logEmbedBatch(count: number, type: EmbedType): void {
-  const line = `[memory] vector embedding: ${count} ${type} input(s) (chunked at ${EMBED_BATCH_SIZE}/pass)`
+  const line = `[memory] vector embedding: ${count} ${type} input(s) (chunked at ${EMBED_BATCH_SIZE}/pass) ${formatMemorySnapshot()}`
   if (count >= LARGE_EMBED) {
     console.info(`${line} — large build, this may take a while`)
   } else {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -88,6 +88,7 @@ import { buildChannelSessionFactory } from './channel-session-factory'
 import { installFatalGuard } from './fatal-guard'
 import { installLlmFetchObserver } from './llm-fetch-observer'
 import { createPluginRuntime, type PluginRuntime, type PluginSubagentEntry } from './plugin-runtime'
+import { logResourceReport } from './resource-report'
 
 type BunServer = ReturnType<Server['start']>
 
@@ -302,6 +303,10 @@ async function startAgentRuntime(
     getGithubAppSelfLogin: githubTokenBridge.getAppSelfLogin,
     ...(cwdConfig.roles !== undefined ? { roles: cwdConfig.roles } : {}),
   })
+  // Emit the container's fixed resource limits BEFORE vector startup. The
+  // startup index build is itself an OOM path; if it kills the process, this
+  // line must already be in the log so the ceiling is still recorded.
+  logResourceReport(cwd)
   const vectorStartupPromise = runVectorStartup(cwd)
   let pluginsLoaded: LoadPluginsResult
   try {

--- a/src/run/resource-report.test.ts
+++ b/src/run/resource-report.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  formatCgroupMemory,
+  formatCpuMax,
+  parseCgroupMemory,
+  parseCpuMax,
+  resolveCgroupV1File,
+  resolveCgroupV1Path,
+} from './resource-report'
+
+describe('parseCgroupMemory', () => {
+  test('parses a numeric byte limit (v2 memory.max) as finite', () => {
+    expect(parseCgroupMemory('536870912\n')).toEqual({ kind: 'finite', value: 536870912 })
+  })
+
+  test('treats "max" (v2 unlimited) as unlimited', () => {
+    expect(parseCgroupMemory('max\n')).toEqual({ kind: 'unlimited' })
+  })
+
+  test('treats the 4 KiB-page v1 unlimited sentinel as unlimited', () => {
+    expect(parseCgroupMemory('9223372036854771712\n')).toEqual({ kind: 'unlimited' })
+  })
+
+  test('treats the 64 KiB-page v1 unlimited sentinel as unlimited (page-size independent)', () => {
+    // given: LONG_MAX rounded to a 64 KiB boundary — smaller than the 4 KiB value
+    expect(parseCgroupMemory('9223372036854710272\n')).toEqual({ kind: 'unlimited' })
+  })
+
+  test('treats the 16 KiB-page v1 unlimited sentinel as unlimited', () => {
+    // given: LONG_MAX rounded to a 16 KiB boundary
+    expect(parseCgroupMemory('9223372036854759424\n')).toEqual({ kind: 'unlimited' })
+  })
+
+  test('still treats a real (astronomically smaller) limit as finite', () => {
+    expect(parseCgroupMemory('536870912')).toEqual({ kind: 'finite', value: 536870912 })
+  })
+
+  test('treats missing/unreadable (null) as unknown', () => {
+    expect(parseCgroupMemory(null)).toEqual({ kind: 'unknown' })
+  })
+
+  test('treats malformed content as unknown, NOT unlimited', () => {
+    expect(parseCgroupMemory('')).toEqual({ kind: 'unknown' })
+    expect(parseCgroupMemory('garbage')).toEqual({ kind: 'unknown' })
+  })
+})
+
+describe('formatCgroupMemory', () => {
+  test('renders a finite limit in MB', () => {
+    expect(formatCgroupMemory({ kind: 'finite', value: 512 * 1024 * 1024 })).toBe('mem_limit_mb=512')
+  })
+
+  test('renders genuine unlimited', () => {
+    expect(formatCgroupMemory({ kind: 'unlimited' })).toBe('mem_limit_mb=unlimited')
+  })
+
+  test('renders unknown as ? (a read failure is not a claim of unlimited)', () => {
+    expect(formatCgroupMemory({ kind: 'unknown' })).toBe('mem_limit_mb=?')
+  })
+})
+
+describe('parseCpuMax', () => {
+  test('parses "quota period" into a finite fractional cpu count', () => {
+    // given: 150000us quota per 100000us period → 1.5 CPUs
+    expect(parseCpuMax('150000 100000\n')).toEqual({ kind: 'finite', value: 1.5 })
+  })
+
+  test('treats "max" quota as unlimited (v2)', () => {
+    expect(parseCpuMax('max 100000\n')).toEqual({ kind: 'unlimited' })
+  })
+
+  test('treats the v1 "-1" quota sentinel as unlimited, not a negative cpu count', () => {
+    // given: cpu.cfs_quota_us=-1 means no limit; passed as "-1 100000"
+    expect(parseCpuMax('-1 100000\n')).toEqual({ kind: 'unlimited' })
+  })
+
+  test('treats a zero quota as unknown, NOT unlimited', () => {
+    // given: 0 is not a genuine no-limit sentinel (only max / -1 are)
+    expect(parseCpuMax('0 100000')).toEqual({ kind: 'unknown' })
+  })
+
+  test('validates shape BEFORE the max sentinel: a malformed max record is unknown', () => {
+    // given: `max` must not short-circuit to unlimited past a broken period/arity
+    expect(parseCpuMax('max garbage')).toEqual({ kind: 'unknown' })
+    expect(parseCpuMax('max 100000 extra')).toEqual({ kind: 'unknown' })
+    expect(parseCpuMax('max 0')).toEqual({ kind: 'unknown' })
+  })
+
+  test('rejects more than two fields', () => {
+    expect(parseCpuMax('150000 100000 extra')).toEqual({ kind: 'unknown' })
+  })
+
+  test('treats missing (null) as unknown', () => {
+    expect(parseCpuMax(null)).toEqual({ kind: 'unknown' })
+  })
+
+  test('treats malformed content as unknown, NOT unlimited', () => {
+    expect(parseCpuMax('')).toEqual({ kind: 'unknown' })
+    expect(parseCpuMax('nope')).toEqual({ kind: 'unknown' })
+  })
+})
+
+describe('formatCpuMax', () => {
+  test('renders a finite cpu quota', () => {
+    expect(formatCpuMax({ kind: 'finite', value: 1.5 })).toBe('cpu_quota=1.5')
+  })
+
+  test('renders genuine unlimited', () => {
+    expect(formatCpuMax({ kind: 'unlimited' })).toBe('cpu_quota=unlimited')
+  })
+
+  test('renders unknown as ?', () => {
+    expect(formatCpuMax({ kind: 'unknown' })).toBe('cpu_quota=?')
+  })
+})
+
+describe('resolveCgroupV1Path', () => {
+  test('resolves the container mount+sub-path for a cgroupfs docker layout', () => {
+    // given: /proc/self/cgroup line for the memory controller under docker
+    const proc = '12:memory:/docker/abc123\n11:cpu,cpuacct:/docker/abc123\n'
+    expect(resolveCgroupV1Path(proc, 'memory')).toEqual({ mount: 'memory', subPath: '/docker/abc123' })
+  })
+
+  test('resolves a systemd-slice docker layout', () => {
+    const proc = '9:memory:/system.slice/docker-abc123.scope\n'
+    expect(resolveCgroupV1Path(proc, 'memory')).toEqual({
+      mount: 'memory',
+      subPath: '/system.slice/docker-abc123.scope',
+    })
+  })
+
+  test('returns the combined mount name (cpu,cpuacct) for a controller in a shared mount', () => {
+    // given: cpu is mounted under the combined dir `cpu,cpuacct`, not a bare `cpu`
+    const proc = '11:cpu,cpuacct:/docker/abc123\n'
+    expect(resolveCgroupV1Path(proc, 'cpu')).toEqual({ mount: 'cpu,cpuacct', subPath: '/docker/abc123' })
+    expect(resolveCgroupV1Path(proc, 'cpuacct')).toEqual({ mount: 'cpu,cpuacct', subPath: '/docker/abc123' })
+  })
+
+  test('returns root sub-path when the controller sits at the hierarchy root', () => {
+    const proc = '12:memory:/\n'
+    expect(resolveCgroupV1Path(proc, 'memory')).toEqual({ mount: 'memory', subPath: '/' })
+  })
+
+  test('returns null when the controller is absent', () => {
+    expect(resolveCgroupV1Path('12:pids:/docker/abc\n', 'memory')).toBeNull()
+    expect(resolveCgroupV1Path(null, 'memory')).toBeNull()
+  })
+})
+
+describe('resolveCgroupV1File', () => {
+  test('maps a subtree-mounted hierarchy to the mountpoint (membership == mount root)', () => {
+    // given: hierarchy root /docker/abc123 is bind-mounted AT /sys/fs/cgroup/memory,
+    // so the file sits directly at the mountpoint, not under the membership path
+    const cgroup = '12:memory:/docker/abc123\n'
+    const mountinfo = '31 30 0:27 /docker/abc123 /sys/fs/cgroup/memory rw,nosuid - cgroup cgroup rw,memory\n'
+    expect(resolveCgroupV1File(cgroup, mountinfo, 'memory', 'memory.limit_in_bytes')).toBe(
+      '/sys/fs/cgroup/memory/memory.limit_in_bytes',
+    )
+  })
+
+  test('joins the sub-path when the whole hierarchy is mounted (root /)', () => {
+    // given: root=/ mount, membership /docker/abc123 → mountpoint + sub-path
+    const cgroup = '12:memory:/docker/abc123\n'
+    const mountinfo = '31 30 0:27 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n'
+    expect(resolveCgroupV1File(cgroup, mountinfo, 'memory', 'memory.limit_in_bytes')).toBe(
+      '/sys/fs/cgroup/memory/docker/abc123/memory.limit_in_bytes',
+    )
+  })
+
+  test('resolves a controller in a combined cpu,cpuacct mount via its super-options', () => {
+    const cgroup = '11:cpu,cpuacct:/docker/abc123\n'
+    const mountinfo = '33 30 0:29 /docker/abc123 /sys/fs/cgroup/cpu,cpuacct rw - cgroup cgroup rw,cpu,cpuacct\n'
+    expect(resolveCgroupV1File(cgroup, mountinfo, 'cpu', 'cpu.cfs_quota_us')).toBe(
+      '/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us',
+    )
+  })
+
+  test('returns null when no cgroup mount carries the controller', () => {
+    const cgroup = '12:memory:/docker/abc123\n'
+    const mountinfo = '31 30 0:27 / /sys/fs/cgroup/pids rw - cgroup cgroup rw,pids\n'
+    expect(resolveCgroupV1File(cgroup, mountinfo, 'memory', 'memory.limit_in_bytes')).toBeNull()
+  })
+
+  test('returns null when membership or mountinfo is missing', () => {
+    expect(resolveCgroupV1File(null, 'x', 'memory', 'f')).toBeNull()
+    expect(resolveCgroupV1File('12:memory:/x\n', null, 'memory', 'f')).toBeNull()
+  })
+})

--- a/src/run/resource-report.ts
+++ b/src/run/resource-report.ts
@@ -1,0 +1,226 @@
+import { readFileSync, statfsSync } from 'node:fs'
+import { totalmem } from 'node:os'
+
+import { formatMemorySnapshot } from '@/bundled-plugins/memory/memory-snapshot'
+
+// The container's memory/cpu ceiling is fixed at `docker run` and never changes
+// while the process lives, so this reports once at boot. It is the missing half
+// of an OOM post-mortem: the per-operation RSS lines show usage climbing, but
+// only this line names the ceiling it climbed toward. Read from INSIDE the
+// container (cgroup + statfs) because the container stage cannot call the host's
+// `docker inspect`.
+//
+// Every read is a tri-state: `finite` (a real limit), `unlimited` (a genuine
+// no-limit sentinel — v2 `max`, v1 `-1`/`LONG_MAX`), or `unknown` (missing,
+// unreadable, or malformed). The distinction is load-bearing: collapsing
+// `unknown` into `unlimited` would turn an unsupported cgroup layout or a read
+// error into a false "no ceiling" claim, which is exactly the wrong signal in an
+// OOM investigation. `unknown` renders as `?`.
+
+export type Limit = { kind: 'finite'; value: number } | { kind: 'unlimited' } | { kind: 'unknown' }
+
+// v1 writes "unlimited" as LONG_MAX rounded DOWN to a page boundary, so the
+// exact value is page-size dependent: 4 KiB pages → 9223372036854771712,
+// 64 KiB pages → 9223372036854710272. Hard-coding the 4 KiB value would let the
+// 64 KiB sentinel slip through as a ~8 EiB finite limit. Instead treat the whole
+// near-LONG_MAX family as unlimited: any value within one max-page (64 KiB) of
+// LONG_MAX. Real container limits are astronomically smaller, so the band is safe.
+const LONG_MAX = 9223372036854775807n
+const MAX_PAGE_SIZE = 65536n
+const CGROUP_V1_UNLIMITED_FLOOR = LONG_MAX - MAX_PAGE_SIZE
+
+export function parseCgroupMemory(raw: string | null): Limit {
+  if (raw === null) return { kind: 'unknown' }
+  const trimmed = raw.trim()
+  if (trimmed === 'max') return { kind: 'unlimited' }
+  if (trimmed === '') return { kind: 'unknown' }
+  let value: bigint
+  try {
+    value = BigInt(trimmed)
+  } catch {
+    return { kind: 'unknown' }
+  }
+  if (value >= CGROUP_V1_UNLIMITED_FLOOR) return { kind: 'unlimited' }
+  if (value <= 0n) return { kind: 'unknown' }
+  return { kind: 'finite', value: Number(value) }
+}
+
+export function parseCpuMax(raw: string | null): Limit {
+  if (raw === null) return { kind: 'unknown' }
+  const parts = raw.trim().split(/\s+/)
+  // Shape first: exactly two fields with a finite, positive period. A malformed
+  // record (`max garbage`, `max 100000 extra`, empty) is `unknown`, never
+  // `unlimited` — an unreadable ceiling must not masquerade as "no ceiling".
+  if (parts.length !== 2) return { kind: 'unknown' }
+  const [quota, period] = parts
+  if (quota === undefined || period === undefined) return { kind: 'unknown' }
+  const periodN = Number(period)
+  if (!Number.isFinite(periodN) || periodN <= 0) return { kind: 'unknown' }
+  // Only genuine no-limit sentinels are unlimited: v2 `max`, v1 `-1`.
+  if (quota === 'max') return { kind: 'unlimited' }
+  const quotaN = Number(quota)
+  if (quotaN === -1) return { kind: 'unlimited' }
+  if (!Number.isFinite(quotaN) || quotaN <= 0) return { kind: 'unknown' }
+  return { kind: 'finite', value: quotaN / periodN }
+}
+
+const BYTES_PER_MB = 1024 * 1024
+
+function renderLimit(limit: Limit, label: string, render: (value: number) => string): string {
+  if (limit.kind === 'unknown') return `${label}=?`
+  if (limit.kind === 'unlimited') return `${label}=unlimited`
+  return `${label}=${render(limit.value)}`
+}
+
+export function formatCgroupMemory(limit: Limit): string {
+  return renderLimit(limit, 'mem_limit_mb', (v) => String(Math.round(v / BYTES_PER_MB)))
+}
+
+export function formatCpuMax(limit: Limit): string {
+  return renderLimit(limit, 'cpu_quota', (v) => String(v))
+}
+
+// The controller's cgroup membership for THIS process, parsed from
+// /proc/self/cgroup. A container is not at the v1 hierarchy root: Docker places
+// it under `/docker/<id>` (cgroupfs) or `/system.slice/docker-<id>.scope`
+// (systemd), so reading the root file would report the HOST limit (usually
+// unlimited) instead of the container's.
+//
+// `mount` is the controller FIELD verbatim (e.g. `cpu,cpuacct`) — the directory
+// name the controller is actually mounted under in /sys/fs/cgroup, which for a
+// combined controller is NOT the bare controller name. `subPath` is the
+// per-process path within that hierarchy. The requested controller is matched as
+// one comma-separated entry, not whole-field equality. Returns null when the
+// controller is absent (e.g. a pure cgroup-v2 host, whose /proc/self/cgroup has
+// a single `0::` line).
+export type CgroupV1Membership = { mount: string; subPath: string }
+
+export function resolveCgroupV1Path(procSelfCgroup: string | null, controller: string): CgroupV1Membership | null {
+  if (procSelfCgroup === null) return null
+  for (const line of procSelfCgroup.split('\n')) {
+    if (line === '') continue
+    const firstColon = line.indexOf(':')
+    const secondColon = line.indexOf(':', firstColon + 1)
+    if (firstColon === -1 || secondColon === -1) continue
+    const field = line.slice(firstColon + 1, secondColon)
+    if (field.split(',').includes(controller)) return { mount: field, subPath: line.slice(secondColon + 1) }
+  }
+  return null
+}
+
+// The absolute path to a v1 controller file for THIS process, resolved through
+// BOTH /proc/self/cgroup (membership) and /proc/self/mountinfo (the actual
+// mountpoint + mount root). The membership path from /proc/self/cgroup is
+// relative to the cgroup HIERARCHY root, which is NOT necessarily the mountpoint:
+// a container commonly has its subtree bind-mounted so hierarchy root
+// `/docker/<id>` appears AT `/sys/fs/cgroup/memory`. Appending the full
+// membership path onto the mountpoint (the previous approach) then reads a
+// non-existent `/sys/fs/cgroup/memory/docker/<id>/...` and reports `?`.
+//
+// mountinfo gives, per mount: field[3]=root, field[4]=mountpoint, and after the
+// ` - ` separator, fstype=`cgroup` with the controller in its super-options. The
+// file lives at `mountpoint + (membershipPath relative to mount root)`.
+export function resolveCgroupV1File(
+  procSelfCgroup: string | null,
+  mountinfo: string | null,
+  controller: string,
+  file: string,
+): string | null {
+  const membership = resolveCgroupV1Path(procSelfCgroup, controller)
+  if (membership === null || mountinfo === null) return null
+
+  for (const line of mountinfo.split('\n')) {
+    if (line === '') continue
+    const sep = line.indexOf(' - ')
+    if (sep === -1) continue
+    const pre = line.slice(0, sep).split(/\s+/)
+    const post = line.slice(sep + 3).split(/\s+/)
+    const [fstype, , superOptions] = post
+    if (fstype !== 'cgroup') continue
+    if (superOptions === undefined || !superOptions.split(',').includes(controller)) continue
+    const mountRoot = pre[3]
+    const mountPoint = pre[4]
+    if (mountRoot === undefined || mountPoint === undefined) continue
+    const rel = relativeToMountRoot(membership.subPath, mountRoot)
+    if (rel === null) continue
+    return joinCgroupPath(joinCgroupPath(mountPoint, rel), file)
+  }
+  return null
+}
+
+// The membership sub-path expressed relative to the mount's root. When the mount
+// root IS the membership path (subtree mount), the file sits directly at the
+// mountpoint (rel = ''). When root is `/` (whole-hierarchy mount), rel is the
+// full sub-path. A membership outside the mount root is unreachable → null.
+function relativeToMountRoot(subPath: string, mountRoot: string): string | null {
+  if (mountRoot === '/') return subPath === '/' ? '' : subPath
+  if (subPath === mountRoot) return ''
+  if (subPath.startsWith(`${mountRoot}/`)) return subPath.slice(mountRoot.length)
+  return null
+}
+
+function joinCgroupPath(base: string, segment: string): string {
+  if (segment === '' || segment === '/') return base
+  return `${base.replace(/\/$/, '')}/${segment.replace(/^\//, '')}`
+}
+
+function readOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+function readV1ControllerFile(controller: string, file: string): string | null {
+  const path = resolveCgroupV1File(
+    readOrNull('/proc/self/cgroup'),
+    readOrNull('/proc/self/mountinfo'),
+    controller,
+    file,
+  )
+  return path === null ? null : readOrNull(path)
+}
+
+function readCgroupMemoryLimit(): Limit {
+  const v2 = readOrNull('/sys/fs/cgroup/memory.max')
+  if (v2 !== null) return parseCgroupMemory(v2)
+  return parseCgroupMemory(readV1ControllerFile('memory', 'memory.limit_in_bytes'))
+}
+
+function readCgroupCpuQuota(): Limit {
+  const v2 = readOrNull('/sys/fs/cgroup/cpu.max')
+  if (v2 !== null) return parseCpuMax(v2)
+  const quota = readV1ControllerFile('cpu', 'cpu.cfs_quota_us')
+  const period = readV1ControllerFile('cpu', 'cpu.cfs_period_us')
+  if (quota === null || period === null) return { kind: 'unknown' }
+  return parseCpuMax(`${quota.trim()} ${period.trim()}`)
+}
+
+function formatStorage(path: string): string {
+  try {
+    const fs = statfsSync(path)
+    const totalMb = Math.round((fs.blocks * fs.bsize) / BYTES_PER_MB)
+    const freeMb = Math.round((fs.bavail * fs.bsize) / BYTES_PER_MB)
+    return `disk_total_mb=${totalMb} disk_free_mb=${freeMb}`
+  } catch {
+    return 'disk_total_mb=? disk_free_mb=?'
+  }
+}
+
+export function logResourceReport(agentDir = '/agent'): void {
+  try {
+    const memLimit = formatCgroupMemory(readCgroupMemoryLimit())
+    const cpuQuota = formatCpuMax(readCgroupCpuQuota())
+    // The host/VM total is the OOM ceiling when no cgroup --memory is set (the
+    // default `docker run`): the kernel can still kill the process at host RAM
+    // exhaustion even with mem_limit=unlimited, so this gives the RSS lines a
+    // real comparison point instead of only an "unlimited" that isn't.
+    const hostMem = `host_total_mb=${Math.round(totalmem() / BYTES_PER_MB)}`
+    const cores = `cpus_visible=${globalThis.navigator?.hardwareConcurrency ?? '?'}`
+    const storage = formatStorage(agentDir)
+    console.info(`[resource-report] ${memLimit} ${hostMem} ${cpuQuota} ${cores} ${storage} ${formatMemorySnapshot()}`)
+  } catch (err) {
+    console.warn(`[resource-report] failed: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}


### PR DESCRIPTION
## Why

A field agent OOM-died mid-run with **no stack trace** — the log just stops. The reason it was undiagnosable: there was **zero process-memory observability** anywhere in the tree, so nothing recorded RSS climbing toward the container's ceiling, and nothing recorded what that ceiling even was. A SIGKILL leaves no JS trace, so the app log was the only evidence — and it said nothing about memory.

This is the observability half of the fix. The concurrency cap that bounds the actual spike is #1301; this PR makes the *next* incident confirmable from logs alone.

## What

**1. Per-operation RSS on the memory hot paths** (`Log RSS on the memory hot paths`)
- New `formatMemorySnapshot()` → `rss_mb=… heapUsed_mb=… external_mb=… arrayBuffers_mb=…` (whole MB, `key=value`, matching the existing `[plugin:memory]` log convention).
- Appended to the three lines whose workloads overlap during the crash window: the embed batch line, the dreaming `done` line, and the memory-logger `done` line.

**2. Boot-time container resource report** (`Report container resource limits once at boot`)
- New `logResourceReport()` emits ONE `[resource-report] …` line at startup with the container's fixed limits, read from **inside** the container (cgroup + statfs — `docker inspect` is a host-stage call the container can't make):
  - memory limit (cgroup v2 `memory.max`, v1 `memory.limit_in_bytes` fallback)
  - cpu quota (cgroup v2 `cpu.max`, v1 `cfs_quota_us`/`cfs_period_us` fallback)
  - visible cpus, `/agent` disk total/free, and a memory snapshot
- Logged once because these are fixed at `docker run` and never change while the process lives.
- Wired in `run/index.ts` after plugins load, before the server accepts connections. Fully guarded/non-fatal: cgroup + statfs paths are absent in dev/test outside Docker, so every read degrades to `unlimited`/`?` instead of throwing.

## Testing

- New `memory-snapshot.test.ts` (formatter: MB rounding, key=value shape).
- New `resource-report.test.ts` (cgroup v2/v1 parse, `max`/v1-unlimited sentinels, malformed input, cpu quota math, MB formatting).
- `bun run typecheck` / `bun run lint` (0 errors) / `bun run format:check` all pass.
- Full suite: **11979 pass, 0 fail** (`bun run test`).

## Example output

```
[resource-report] mem_limit_mb=unlimited cpu_quota=unlimited cpus_visible=11 disk_total_mb=… disk_free_mb=… rss_mb=… heapUsed_mb=… external_mb=… arrayBuffers_mb=…
[memory] vector embedding: 1 passage input(s) (chunked at 64/pass) rss_mb=352 heapUsed_mb=85 external_mb=29 arrayBuffers_mb=0
```