### PR TITLE
Degrade listShardSlugs to empty on ENOTDIR

### DIFF
--- a/src/bundled-plugins/memory/load-shards.test.ts
+++ b/src/bundled-plugins/memory/load-shards.test.ts
@@ -160,6 +160,24 @@ describe('listShardSlugs', () => {
     await expect(listShardSlugs(agentDir)).resolves.toEqual(['apple'])
     await expect(loadAllShards(agentDir)).resolves.toHaveLength(1)
   })
+
+  test('topics path that is a regular file (ENOTDIR) degrades to empty', async () => {
+    // A bind-mount/tmpfs coherency hiccup can momentarily replace memory/topics
+    // with a non-directory; readdir then throws ENOTDIR. It must degrade like a
+    // missing/empty topics dir rather than propagate a hard error.
+    const agentDir = await makeAgentDir()
+    await mkdir(join(agentDir, 'memory'), { recursive: true })
+    await writeFile(topicsDir(agentDir), 'not a directory', 'utf8')
+
+    await expect(listShardSlugs(agentDir)).resolves.toEqual([])
+  })
+
+  test('a non-ENOENT/non-ENOTDIR readdir error still propagates', async () => {
+    // Guards against over-broadening the catch: only ENOENT and ENOTDIR return
+    // []. A NUL byte in the path makes readdir throw a real, deterministic
+    // ERR_INVALID_ARG_VALUE (no mock, no leak); it must still propagate.
+    await expect(listShardSlugs('/tmp/typeclaw-\u0000-bad')).rejects.toThrow('null bytes')
+  })
 })
 
 describe('loadAllShards shard cache', () => {

--- a/src/bundled-plugins/memory/load-shards.ts
+++ b/src/bundled-plugins/memory/load-shards.ts
@@ -121,7 +121,10 @@ export async function listShardSlugs(agentDir: string): Promise<string[]> {
   try {
     names = await readdir(topicsDir(agentDir))
   } catch (err) {
-    if (isEnoent(err)) return []
+    // ENOTDIR: a bind-mount/tmpfs coherency hiccup can momentarily replace the
+    // topics dir with a non-directory. Treat it like ENOENT -- not a readable
+    // directory right now -- and degrade to empty instead of hard-erroring.
+    if (isEnoent(err) || isEnotdir(err)) return []
     throw err
   }
 
@@ -179,4 +182,8 @@ function getOrCreateCache(agentDir: string): Map<string, ShardCacheEntry> {
 
 function isEnoent(err: unknown): boolean {
   return typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT'
+}
+
+function isEnotdir(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOTDIR'
 }


### PR DESCRIPTION
## Background

`listShardSlugs` (`src/bundled-plugins/memory/load-shards.ts`) reads `memory/topics/` with `readdir` inside a try/catch that only special-cases `ENOENT` (missing dir → return `[]`) and rethrows everything else. On some hosts a bind-mount / tmpfs coherency hiccup momentarily replaces `/agent/memory/topics` with a **non-directory** (a regular file, or a path whose parent component becomes a file). `readdir` on a non-directory throws `ENOTDIR`, which fell through to the rethrow — turning a transient, self-healing filesystem state into a hard error.

That hard error surfaced downstream: `typeclaw doctor`'s `vector-index` check reported a failure, and the `dreaming` cron failed, whenever `topics` was briefly not a directory. Semantically `ENOTDIR` is the same situation as `ENOENT` here — "topics is not a readable directory right now" — so it should degrade to an empty slug list exactly like a missing/empty dir.

This is deliberately **only** the hygiene fix for the symptom. The underlying disappearance (a host-side bind-mount/tmpfs problem) is not addressed here.

## Summary

- Added an `isEnotdir(err)` helper that mirrors the existing `isEnoent(err)` exactly (`err.code === 'ENOTDIR'`).
- Changed the `listShardSlugs` catch to `if (isEnoent(err) || isEnotdir(err)) return []`; every other errno still propagates unchanged.

Why treat `ENOTDIR` as empty rather than retrying or repairing: the callers (`loadAllShards` → per-turn injection, `memory_search`, `hybridSearch`, dreaming, startup index build) already handle an empty topics dir as valid graceful degradation and are all wrapped in try/catch. Returning `[]` gives them the shape they already expect; a retry/repair loop would be over-engineering a transient host condition this layer can't fix.

## What this does NOT do

- Does **not** fix the root-cause bind-mount/tmpfs disappearance (not a crash fix).
- Does **not** broaden the catch — only `ENOENT` and `ENOTDIR` return `[]`; all other errno values still throw.
- Does **not** touch `loadAllShards`, `statShard`, `readAndParseShard`, or any caller. `statShard`/`readAndParseShard` use `stat`/`readFile` (not `readdir`) and their `ENOENT` semantics are already correct, so they're intentionally left alone.
- No refactor, rename, or reorganization of surrounding code.

## Review notes

Load-bearing change is the one-line catch condition in `listShardSlugs`. Invariant to verify: **exactly** `ENOENT` and `ENOTDIR` degrade to `[]`, nothing else.

Two tests added (TDD, failing-first):
- `topics path that is a regular file (ENOTDIR) degrades to empty` — writes `memory/topics` as a real file so `readdir` throws a genuine `ENOTDIR`, asserts `[]`.
- `a non-ENOENT/non-ENOTDIR readdir error still propagates` — uses a NUL-byte path to force a real, deterministic `ERR_INVALID_ARG_VALUE` (no mock, no cross-test leak), asserts it still throws. This guards against over-broadening the catch.