### PR TITLE
Cap concurrent live channel sessions to bound memory

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -53,6 +53,7 @@ import {
   SESSION_FRESHNESS_TTL_MS,
   buildInterruptedSubagentNotice,
   buildRestartResumeWakeReminder,
+  MAX_LIVE_SESSIONS,
   OBSERVED_MESSAGE_MAX_CHARS,
   RESTART_RESUME_WAKE_REMINDER,
   SESSION_GRACE_HARD_TTL_MS,
@@ -376,6 +377,9 @@ function makeRouter(
     saveChannelSessions?: (agentDir: string, sessions: readonly ChannelSessionRecord[]) => Promise<void>
     newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
     listRunningBackgroundSubagentNames?: (sessionId: string) => string[]
+    onCreateSession?: () => Promise<void>
+    onRouteMembership?: (keyId: string) => Promise<void>
+    onEnsuredForRoute?: (live: unknown) => void
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -399,6 +403,8 @@ function makeRouter(
     ...(options.listRunningBackgroundSubagentNames !== undefined
       ? { listRunningBackgroundSubagentNames: options.listRunningBackgroundSubagentNames }
       : {}),
+    ...(options.onRouteMembership !== undefined ? { onRouteMembership: options.onRouteMembership } : {}),
+    ...(options.onEnsuredForRoute !== undefined ? { onEnsuredForRoute: options.onEnsuredForRoute } : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
     logger: {
@@ -407,6 +413,7 @@ function makeRouter(
       error: (m) => options.logs?.push(`error:${m}`),
     },
     createSessionForChannel: async ({ origin, originRef, existingSessionId, existingSessionFile }) => {
+      if (options.onCreateSession !== undefined) await options.onCreateSession()
       options.factoryCalls?.push({
         ...(existingSessionId !== undefined ? { existingSessionId } : {}),
         ...(existingSessionFile !== undefined ? { existingSessionFile } : {}),
@@ -11612,6 +11619,453 @@ describe('ChannelRouter idle session GC', () => {
     // then
     expect(router.liveCount()).toBe(0)
     expect(logs.some((l) => l.includes('dispose'))).toBe(true)
+  })
+})
+
+// A hard ceiling on concurrently-warm LiveSessions. Each LiveSession pins a
+// full in-memory AgentSession (~50-200MB RSS); without a count cap a burst of
+// active conversations across many channels/threads stacks RSS with no limit
+// (the idle GC only reclaims after 30min of inactivity). When at cap and a new
+// session must be created, the router evicts the least-recently-active ELIGIBLE
+// session (by lastInboundAt), mirroring the idle GC's skip-conditions so a
+// draining / queued / child-pinned session is never the victim. These tests
+// drive creation via distinct-channel inbounds and observe eviction via
+// liveCount(), the FakeSession dispose/abort counters, and the capacity_gc log.
+describe('ChannelRouter max-live-session capacity cap', () => {
+  // Create one engaged session per channel c1..cN, each at a strictly
+  // increasing clock so lastInboundAt is ordered oldest→newest by index.
+  // Returns the keys so callers can assert which one was evicted.
+  async function fillChannels(
+    router: ChannelRouter,
+    nowRef: { value: number },
+    count: number,
+    startAt = 1000,
+  ): Promise<ChannelKey[]> {
+    const keys: ChannelKey[] = []
+    for (let i = 0; i < count; i++) {
+      nowRef.value = startAt + i
+      const chat = `c${i + 1}`
+      const key: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat, thread: null }
+      keys.push(key)
+      await router.route(inbound({ chat, externalMessageId: `m-${chat}` }))
+      await router.__testing!.flushDebounce(key)
+    }
+    return keys
+  }
+
+  test('MAX_LIVE_SESSIONS is a sane, non-trivial default', () => {
+    // guards against a future edit that accidentally cripples multi-channel use
+    expect(MAX_LIVE_SESSIONS).toBeGreaterThanOrEqual(8)
+  })
+
+  test('creating one session past the cap evicts the LRU-by-lastInboundAt session', async () => {
+    // given: exactly MAX_LIVE_SESSIONS warm sessions, c1 the least-recently-active
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: a NEW channel forces a session over the cap
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    const overflowKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-overflow', thread: null }
+    await router.route(inbound({ chat: 'c-overflow', externalMessageId: 'm-overflow' }))
+    await router.__testing!.flushDebounce(overflowKey)
+
+    // then: still at cap (one evicted, one added), and the LRU victim (c1 =
+    // sessions[0]) was disposed the same way the idle GC disposes — abort+dispose
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+    expect(sessions[0]!.aborted).toBe(1)
+    expect(sessions[0]!.disposed).toBe(1)
+    // the second-oldest and the newcomer are untouched
+    expect(sessions[1]!.aborted).toBe(0)
+    expect(sessions[1]!.disposed).toBe(0)
+  })
+
+  test('capacity eviction is logged in the idle_gc style', async () => {
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router } = makeRouter(dir, { nowRef, logs })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    const overflowKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-overflow', thread: null }
+    await router.route(inbound({ chat: 'c-overflow', externalMessageId: 'm-overflow' }))
+    await router.__testing!.flushDebounce(overflowKey)
+
+    expect(logs.some((l) => l.includes('capacity_gc evicting'))).toBe(true)
+  })
+
+  test('a draining session is never the eviction victim even when it is the LRU', async () => {
+    // given: c1 is the oldest (LRU) AND mid-turn (draining). c2..cN are newer.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+
+    // c1 first, at the oldest clock, with a prompt held open so it stays draining
+    nowRef.value = 1000
+    const c1: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null }
+    await router.route(inbound({ chat: 'c1', externalMessageId: 'm-c1' }))
+    let releaseC1: () => void = () => {}
+    const c1Held = new Promise<void>((r) => {
+      releaseC1 = r
+    })
+    sessions[0]!.onPrompt = async () => {
+      await c1Held
+    }
+    const c1Draining = router.__testing!.flushDebounce(c1)
+    await waitFor(() => sessions[0]!.prompts.length > 0)
+    expect(router.liveCount()).toBe(1)
+
+    // fill the rest of the cap with newer channels (c2..c{MAX})
+    for (let i = 1; i < MAX_LIVE_SESSIONS; i++) {
+      nowRef.value = 1000 + i
+      const chat = `c${i + 1}`
+      const key: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat, thread: null }
+      await router.route(inbound({ chat, externalMessageId: `m-${chat}` }))
+      await router.__testing!.flushDebounce(key)
+    }
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: overflow forces an eviction
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    const overflowKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-overflow', thread: null }
+    await router.route(inbound({ chat: 'c-overflow', externalMessageId: 'm-overflow' }))
+    await router.__testing!.flushDebounce(overflowKey)
+
+    // then: the draining c1 (the LRU) is skipped; the next-LRU eligible (c2 =
+    // sessions[1]) is evicted instead. c1 is never aborted/disposed.
+    expect(sessions[0]!.aborted).toBe(0)
+    expect(sessions[0]!.disposed).toBe(0)
+    expect(sessions[1]!.aborted).toBe(1)
+    expect(sessions[1]!.disposed).toBe(1)
+
+    // cleanup: release the held turn so the process can exit
+    releaseC1()
+    await c1Draining
+  })
+
+  test('a child-pinned session is never the eviction victim even when it is the LRU', async () => {
+    // given: c1 (the oldest) has a still-running background subagent → pinned
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      newestRunningChildSubagentStartedAt: (sessionId) => (sessionId === 'ses_fake_1' ? 1000 : null),
+    })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: overflow forces an eviction
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    const overflowKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-overflow', thread: null }
+    await router.route(inbound({ chat: 'c-overflow', externalMessageId: 'm-overflow' }))
+    await router.__testing!.flushDebounce(overflowKey)
+
+    // then: the pinned c1 (LRU) is skipped; the next-LRU eligible (c2) is evicted
+    expect(sessions[0]!.aborted).toBe(0)
+    expect(sessions[0]!.disposed).toBe(0)
+    expect(sessions[1]!.aborted).toBe(1)
+    expect(sessions[1]!.disposed).toBe(1)
+  })
+
+  test('when every at-cap session is ineligible, the inbound is served over-cap with a warn (never dropped)', async () => {
+    // given: ALL sessions are child-pinned → nothing is evictable
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      logs,
+      newestRunningChildSubagentStartedAt: () => 1000, // every session pinned
+    })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: a new inbound arrives with no evictable victim
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    const overflowKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-overflow', thread: null }
+    await router.route(inbound({ chat: 'c-overflow', externalMessageId: 'm-overflow' }))
+    await router.__testing!.flushDebounce(overflowKey)
+
+    // then: the message is served (a real session exists, temporarily over cap),
+    // nobody was evicted, and the over-cap condition is warned — never dropped.
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS + 1)
+    expect(sessions.every((s) => s.aborted === 0)).toBe(true)
+    expect(logs.some((l) => l.includes('warn:') && l.includes('capacity_gc') && l.includes('over cap'))).toBe(true)
+    // and the newcomer actually processed the inbound
+    expect(sessions[MAX_LIVE_SESSIONS]!.prompts.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('reusing an existing warm session never triggers capacity eviction', async () => {
+    // given: exactly at cap
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    const { router, sessions } = makeRouter(dir, { nowRef })
+    const keys = await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: a follow-up lands on an EXISTING channel (no new session needed)
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    await router.route(inbound({ chat: 'c1', externalMessageId: 'm-c1-again', text: 'still here?' }))
+    await router.__testing!.flushDebounce(keys[0]!)
+
+    // then: nothing was evicted — the warm session was reused
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+    expect(sessions.every((s) => s.aborted === 0)).toBe(true)
+    expect(sessions).toHaveLength(MAX_LIVE_SESSIONS)
+  })
+
+  test('concurrent distinct-channel admissions from size 9 never exceed the cap', async () => {
+    // given: 9 warm evictable sessions (one under cap). The 10th+11th creations
+    // (the two concurrent newcomers) are gated so they suspend mid-creation and
+    // then resume back-to-back into the capacity choke-point.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    let unblock: () => void = () => {}
+    const gate = new Promise<void>((r) => {
+      unblock = r
+    })
+    const { router } = makeRouter(dir, {
+      nowRef,
+      onCreateSession: async () => {
+        if (router.liveCount() >= MAX_LIVE_SESSIONS - 1) await gate
+      },
+    })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS - 1)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS - 1)
+
+    // when: two NEW channels admitted concurrently
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    const a: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-a', thread: null }
+    const b: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-b', thread: null }
+    const p1 = router.route(inbound({ chat: 'c-a', externalMessageId: 'm-a' }))
+    const p2 = router.route(inbound({ chat: 'c-b', externalMessageId: 'm-b' }))
+    unblock()
+    await Promise.all([p1, p2])
+    await router.__testing!.flushDebounce(a)
+    await router.__testing!.flushDebounce(b)
+
+    // then: the cap is never exceeded — the second admission saw the first's
+    // reservation and evicted to make room
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+  })
+
+  test('concurrent distinct-channel admissions from exactly cap never exceed the cap', async () => {
+    // given: exactly MAX_LIVE_SESSIONS warm evictable sessions; the two newcomers
+    // are gated so they resume into the choke-point back-to-back.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    let unblock: () => void = () => {}
+    const gate = new Promise<void>((r) => {
+      unblock = r
+    })
+    const { router } = makeRouter(dir, {
+      nowRef,
+      onCreateSession: async () => {
+        if (router.liveCount() >= MAX_LIVE_SESSIONS) await gate
+      },
+    })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: two more NEW channels admitted concurrently
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 100
+    const a: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-a', thread: null }
+    const b: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-b', thread: null }
+    const p1 = router.route(inbound({ chat: 'c-a', externalMessageId: 'm-a' }))
+    const p2 = router.route(inbound({ chat: 'c-b', externalMessageId: 'm-b' }))
+    unblock()
+    await Promise.all([p1, p2])
+    await router.__testing!.flushDebounce(a)
+    await router.__testing!.flushDebounce(b)
+
+    // then: each admission evicted one LRU to make room; still exactly at cap
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+  })
+
+  test('a session mid-route (past ensureLive, before enqueue) is never the eviction victim', async () => {
+    // given: c1 is the oldest (LRU). We hold ITS route in the membership window
+    // (post-ensureLive, pre-enqueue) via onRouteMembership, so it is neither
+    // draining nor queued — exactly the window the `routing` pin protects.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    let releaseMembership: () => void = () => {}
+    const membershipHeld = new Promise<void>((r) => {
+      releaseMembership = r
+    })
+    let c1AtMembership = false
+    let holdNext = false
+    const logs: string[] = []
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      logs,
+      onRouteMembership: async (keyId) => {
+        if (holdNext && keyId === 'discord-bot:g1:c1:') {
+          c1AtMembership = true
+          await membershipHeld
+        }
+      },
+    })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: a follow-up on c1 (the LRU) enters route() and blocks at membership
+    // (confirmed via the flag), so it is mid-route — not draining, not queued,
+    // lastInboundAt not yet bumped — hence still the LRU. Then a NEW channel
+    // forces capacity eviction WHILE c1 is held, and we only release c1 after
+    // the eviction has fired.
+    holdNext = true
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 50
+    const c1: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c1', thread: null }
+    const c1Route = router.route(inbound({ chat: 'c1', externalMessageId: 'm-c1-again', text: 'still here?' }))
+    await waitFor(() => c1AtMembership)
+
+    const overflowKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-overflow', thread: null }
+    const overflowRoute = router.route(inbound({ chat: 'c-overflow', externalMessageId: 'm-overflow' }))
+    await waitFor(() => logs.some((l) => l.includes('capacity_gc evicting')))
+
+    // now that the eviction has run against the held c1, let c1 finish
+    releaseMembership()
+    await Promise.all([c1Route, overflowRoute])
+    await router.__testing!.flushDebounce(c1)
+    await router.__testing!.flushDebounce(overflowKey)
+
+    // then: c1 (the mid-route LRU) was NEVER the victim — the next-LRU eligible
+    // session (c2) was evicted instead
+    expect(sessions[0]!.aborted).toBe(0)
+    expect(sessions[0]!.disposed).toBe(0)
+    expect(sessions[1]!.disposed).toBe(1)
+  })
+
+  test('recovers to the ceiling from an over-cap state on the next evictable creation', async () => {
+    // given: cap+1 sessions, all evictable (drive it there by admitting one over
+    // cap while everything was momentarily pinned, then unpin)
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    let allPinned = true
+    const { router } = makeRouter(dir, {
+      nowRef,
+      newestRunningChildSubagentStartedAt: () => (allPinned ? 1000 : null),
+    })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    // admit one over cap while everything is pinned → size cap+1
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 10
+    const over: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-over', thread: null }
+    await router.route(inbound({ chat: 'c-over', externalMessageId: 'm-over' }))
+    await router.__testing!.flushDebounce(over)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS + 1)
+
+    // when: sessions become evictable and a new channel is created
+    allPinned = false
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 200
+    const fresh: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-fresh', thread: null }
+    await router.route(inbound({ chat: 'c-fresh', externalMessageId: 'm-fresh' }))
+    await router.__testing!.flushDebounce(fresh)
+
+    // then: the over-cap creation evicted ENOUGH victims to land back at the
+    // ceiling (cap+1 → evict 2, insert 1 → cap), not merely one (which would
+    // plateau at cap+1)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+  })
+
+  test('a cold-starting session is never evicted during its own prefetch window', async () => {
+    // given: a cold channel install exposes the new session in liveSessions
+    // BEFORE its history prefetch await (channel prefetch tail defaults to 10),
+    // so a blocking history callback holds the brand-new session in the map
+    // while its triggering inbound is not yet queued. All the pre-existing
+    // sessions are child-pinned, so the cold-starter is the ONLY session a
+    // concurrent capacity sweep could pick — the exact window the fix guards.
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    let releaseHistory: () => void = () => {}
+    const historyHeld = new Promise<void>((r) => {
+      releaseHistory = r
+    })
+    let holdHistory = false
+    let coldStartInPrefetch = false
+    // pin every already-established filler (ses_fake_1..N) but NOT the cold
+    // starter (ses_fake_{N+1}), so the sweep's only eligible candidate is the
+    // cold-starting session unless its prefetch-window `routing` pin protects it.
+    const pinnedIds = new Set<string>()
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      newestRunningChildSubagentStartedAt: (sessionId) => (pinnedIds.has(sessionId) ? 1000 : null),
+    })
+    router.registerHistory('discord-bot', async () => {
+      if (holdHistory) {
+        coldStartInPrefetch = true
+        await historyHeld
+      }
+      return { ok: true, messages: [] }
+    })
+    await fillChannels(router, nowRef, MAX_LIVE_SESSIONS)
+    for (let i = 1; i <= MAX_LIVE_SESSIONS; i++) pinnedIds.add(`ses_fake_${i}`)
+    expect(router.liveCount()).toBe(MAX_LIVE_SESSIONS)
+
+    // when: a NEW channel cold-starts and blocks in prefetch (now in the map,
+    // over cap since every filler is pinned), then ANOTHER new channel forces a
+    // capacity sweep while the cold-starter is held mid-prefetch
+    holdHistory = true
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 50
+    const coldKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-cold', thread: null }
+    const coldRoute = router.route(inbound({ chat: 'c-cold', externalMessageId: 'm-cold' }))
+    await waitFor(() => coldStartInPrefetch)
+
+    holdHistory = false
+    nowRef.value = 1000 + MAX_LIVE_SESSIONS + 60
+    const overflowKey: ChannelKey = { adapter: 'discord-bot', workspace: 'g1', chat: 'c-overflow', thread: null }
+    const overflowRoute = router.route(inbound({ chat: 'c-overflow', externalMessageId: 'm-overflow' }))
+    await waitFor(() => sessions.length > MAX_LIVE_SESSIONS + 1)
+
+    releaseHistory()
+    await Promise.all([coldRoute, overflowRoute])
+    await router.__testing!.flushDebounce(coldKey)
+    await router.__testing!.flushDebounce(overflowKey)
+
+    // then: the cold-starting session (sessions[MAX], the c-cold one) was never
+    // aborted/disposed — it was pinned against eviction throughout its prefetch
+    const coldSession = sessions[MAX_LIVE_SESSIONS]!
+    expect(coldSession.aborted).toBe(0)
+    expect(coldSession.disposed).toBe(0)
+  })
+
+  test('re-acquires when the ensured session is evicted in the pre-pin handoff gap', async () => {
+    // given: ensureLive releases its install pin in its own finally, so there is
+    // a microtask gap between ensureLive resolving and route() taking the
+    // `routing` pin. onEnsuredForRoute fires synchronously in exactly that gap;
+    // on the FIRST acquisition it simulates a concurrent capacity sweep by
+    // destroying the just-resolved session, so revalidation must fail and
+    // acquireLiveForRoute must re-acquire a fresh, live session rather than
+    // enqueue onto the dead one (whose drain() would no-op → stranded inbound).
+    const dir = await tempDir()
+    const nowRef = { value: 1000 }
+    let evictNext = true
+    const evicted: unknown[] = []
+    const { router, sessions } = makeRouter(dir, {
+      nowRef,
+      onEnsuredForRoute: (live) => {
+        if (!evictNext) return
+        evictNext = false
+        const l = live as { destroyed: boolean }
+        l.destroyed = true
+        evicted.push(live)
+      },
+    })
+
+    // when
+    await router.route(inbound({ chat: 'c1', externalMessageId: 'm1', text: 'hi bot' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the first session was rejected (destroyed in the gap), a second was
+    // acquired, and the inbound reached THAT live session's prompt — not stranded
+    expect(evicted).toHaveLength(1)
+    expect(sessions.length).toBeGreaterThanOrEqual(2)
+    const delivered = sessions.find((s) => s.prompts.length > 0)
+    expect(delivered).toBeDefined()
+    expect(delivered!.disposed).toBe(0)
+    expect(router.liveCount()).toBe(1)
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -187,6 +187,17 @@ export const MAX_TYPING_HEARTBEAT_MS = 2 * 60 * 1000
 export const SESSION_IDLE_MS = 30 * 60 * 1000
 export const SESSION_GC_INTERVAL_MS = 60 * 1000
 
+// Hard ceiling on concurrently-warm LiveSessions. Each one pins a full
+// in-memory AgentSession (open SessionManager + transcript, ~50-200MB RSS),
+// so without a count cap a burst of active conversations across many
+// channels/threads stacks RSS with no limit — the idle GC only reclaims after
+// SESSION_IDLE_MS of inactivity, which is far too late under load. When at cap
+// and a new session must be created, the router first evicts the
+// least-recently-active *evictable* session (same skip-conditions as the idle
+// GC). 10 comfortably covers normal multi-channel use while capping the worst
+// case; bump this if a deployment legitimately runs more simultaneous rooms.
+export const MAX_LIVE_SESSIONS = 10
+
 // Hard cap on tool-initiated outbound sends per (chat:thread) per turn.
 // The original loop-incident emitted ~50 sends in one turn; even
 // legitimate split replies rarely cross 8. 10 leaves headroom for
@@ -830,6 +841,12 @@ type LiveSession = {
   // soft-TTL grace decision against the current transcript size to weigh reuse
   // vs rollover. 0 when no transcript path is available, which disables grace.
   baseContextBytes: number
+  // Count of route() calls currently between obtaining this session and
+  // enqueuing their inbound. A routing inbound in that window is neither
+  // draining nor queued yet, so without this guard capacity eviction could
+  // tear the session down and strand the inbound (drain() no-ops on a
+  // destroyed session). Non-zero pins the session against eviction.
+  routing: number
   firstUnprocessedAt: number
   currentTurnAuthorId: string | null
   currentTurnAuthorIds: Set<string>
@@ -1576,6 +1593,17 @@ export type CreateChannelRouterOptions = {
   // work in the resume greeting. Background-only: a foreground child returns its
   // result inline, so it is not orphaned by the bounce. Omitted means none.
   listRunningBackgroundSubagentNames?: (sessionId: string) => string[]
+  // Test seam: awaited inside route() at the membership-resolution point, i.e.
+  // exactly the window where a session is obtained but its inbound is not yet
+  // enqueued. Lets tests hold a session mid-route to exercise the `routing`
+  // eviction pin. Omitted (production) is a no-op.
+  onRouteMembership?: (keyId: string) => Promise<void>
+  // Test seam: fired synchronously inside acquireLiveForRoute right after
+  // ensureLive resolves and BEFORE the `routing` pin is taken — the exact
+  // microtask gap in which a concurrent capacity sweep could evict the freshly
+  // resolved session. Lets a test deterministically simulate that eviction to
+  // prove the pin-then-revalidate retry. Omitted (production) is a no-op.
+  onEnsuredForRoute?: (live: LiveSession) => void
 }
 
 export type RestartCommandContext = {
@@ -1634,6 +1662,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   const onReload = options.onReload
   const onRestart = options.onRestart
   const newestRunningChildSubagentStartedAt = options.newestRunningChildSubagentStartedAt ?? (() => null)
+  const onRouteMembership = options.onRouteMembership
+  const onEnsuredForRoute = options.onEnsuredForRoute
   const liveSessions = new Map<string, LiveSession>()
   const creating = new Map<string, Promise<LiveSession>>()
   // Restart-resume reservations, keyed by channelKeyId. Installed by
@@ -2182,6 +2212,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         promptInFlight: false,
         lastInboundAt: now(),
         baseContextBytes: 0,
+        routing: 0,
         firstUnprocessedAt: 0,
         currentTurnAuthorId: null,
         currentTurnAuthorIds: new Set(),
@@ -2284,33 +2315,63 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         await persistPromise
         throw new StaleLiveSessionError(keyId)
       }
-      if (isColdStart) {
-        // Install before the slow prefetch so a concurrent teardown/shutdown can
-        // see and dispose this session during the network fetch.
-        liveSessions.set(keyId, live)
-        const adapterConfig = options.configForAdapter(key.adapter)
-        // Overlap the disk mapping-write with the network history prefetch —
-        // they are independent. allSettled lets a persist failure take priority
-        // (and unwind the install) even if prefetch also rejects.
-        const prefetchPromise = adapterConfig
-          ? prefetchChannelContext(live, adapterConfig, triggeringMessageId)
-          : Promise.resolve()
-        const [persistResult, prefetchResult] = await Promise.allSettled([persistPromise, prefetchPromise])
-        if (persistResult.status === 'rejected') {
-          await unwindInstalledLive(keyId, live)
-          throw persistResult.reason
+      // Single choke-point both install branches flow through: reserve a live
+      // slot (evicting LRU sessions if at cap) BEFORE the awaits below, so the
+      // count ceiling holds atomically across concurrent distinct-key
+      // creations. The reservation is released the instant this session lands in
+      // `liveSessions` (from then on `liveSessions.size` accounts for it — a
+      // reservation held past the insert would double-count against a concurrent
+      // creator) and in the finally as a backstop for the throw-before-insert
+      // paths (stale rollover / rehydrate persist failure), which release() no-ops.
+      //
+      // Once installed, the session is pinned with `routing` for the rest of
+      // ensureLive: the cold-start install exposes it in `liveSessions` BEFORE
+      // the prefetch await (so a concurrent teardown can dispose it during the
+      // fetch), which is exactly the window a concurrent capacity sweep could
+      // otherwise pick this brand-new session — routing=0, not yet queued — as
+      // its LRU victim and strand the triggering inbound. route() re-pins with
+      // its own routing++ the instant ensureLive returns (no await between), so
+      // the pin never lapses between here and the membership window.
+      const releaseCapacitySlot = makeCapacityRoom()
+      let pinnedForInstall = false
+      try {
+        if (isColdStart) {
+          // Install before the slow prefetch so a concurrent teardown/shutdown can
+          // see and dispose this session during the network fetch.
+          liveSessions.set(keyId, live)
+          live.routing++
+          pinnedForInstall = true
+          releaseCapacitySlot()
+          const adapterConfig = options.configForAdapter(key.adapter)
+          // Overlap the disk mapping-write with the network history prefetch —
+          // they are independent. allSettled lets a persist failure take priority
+          // (and unwind the install) even if prefetch also rejects.
+          const prefetchPromise = adapterConfig
+            ? prefetchChannelContext(live, adapterConfig, triggeringMessageId)
+            : Promise.resolve()
+          const [persistResult, prefetchResult] = await Promise.allSettled([persistPromise, prefetchPromise])
+          if (persistResult.status === 'rejected') {
+            await unwindInstalledLive(keyId, live)
+            throw persistResult.reason
+          }
+          if (prefetchResult.status === 'rejected') {
+            await unwindInstalledLive(keyId, live)
+            throw prefetchResult.reason
+          }
+          if (adapterConfig) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
+        } else {
+          // Rehydrate has no prefetch to overlap, so settle the mapping write
+          // before installing — a failed persist must fail ensureLive without
+          // leaving a warm session behind for later inbounds to reuse.
+          await persistPromise
+          liveSessions.set(keyId, live)
+          live.routing++
+          pinnedForInstall = true
+          releaseCapacitySlot()
         }
-        if (prefetchResult.status === 'rejected') {
-          await unwindInstalledLive(keyId, live)
-          throw prefetchResult.reason
-        }
-        if (adapterConfig) logger.info(`[channels] ${keyId}: ensureLive prefetched-context`)
-      } else {
-        // Rehydrate has no prefetch to overlap, so settle the mapping write
-        // before installing — a failed persist must fail ensureLive without
-        // leaving a warm session behind for later inbounds to reuse.
-        await persistPromise
-        liveSessions.set(keyId, live)
+      } finally {
+        if (pinnedForInstall) live.routing--
+        releaseCapacitySlot()
       }
 
       // Snapshot the rendered base context size now, after prefetch and before
@@ -3329,6 +3390,31 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     return result
   }
 
+  // Resolve the live session for an inbound and hand it back with its
+  // capacity-eviction `routing` pin already held. ensureLive releases its
+  // install-time pin in its own finally, so between ensureLive resolving and
+  // this caller running there is a microtask gap in which the (idle, unqueued)
+  // session is a valid LRU victim for a concurrent creation's capacity sweep —
+  // it could be destroyed before we pin it, leaving route() to enqueue onto a
+  // dead session whose drain() no-ops. The warm-reuse return path never pinned
+  // at all, so the same gap applies there. Guard uniformly: increment `routing`
+  // and, in the SAME synchronous tick (no await between), revalidate that this
+  // exact object is still the installed, non-destroyed session. If it was
+  // evicted in the gap, release and re-acquire. Each retry crosses `await
+  // ensureLive`, so this never spins synchronously; capacity admission bounds
+  // the loop (a genuinely over-capacity system with everything else pinned
+  // admits over cap rather than looping forever).
+  const acquireLiveForRoute = async (key: ChannelKey, event: InboundMessage): Promise<LiveSession> => {
+    const keyId = channelKeyId(key)
+    for (;;) {
+      const live = await ensureLive(key, event.externalMessageId, event.authorId, undefined, event.room)
+      onEnsuredForRoute?.(live)
+      live.routing++
+      if (liveSessions.get(keyId) === live && !live.destroyed) return live
+      live.routing--
+    }
+  }
+
   const route = async (event: InboundMessage): Promise<void> => {
     const adapterConfig = options.configForAdapter(event.adapter)
     if (!adapterConfig) return
@@ -3444,100 +3530,112 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     const reservation = restartReservations.get(channelKeyId(key))
     if (reservation !== undefined) reservation.sawInbound = true
 
-    const live = await ensureLive(key, event.externalMessageId, event.authorId, undefined, event.room)
-    live.room = event.room
+    // Acquire the session with its capacity-eviction pin already held (see
+    // acquireLiveForRoute): the pin covers the whole membership-resolution
+    // window below, where the session is not yet draining or queued and would
+    // otherwise be a valid LRU victim for a concurrent creation's capacity
+    // sweep. The finally releases it once routing reaches the enqueue
+    // (promptQueue then keeps it un-evictable) or an early return. drain() and
+    // rollover for THIS inbound run after route() returns, so the pin never
+    // straddles them.
+    const live = await acquireLiveForRoute(key, event)
+    try {
+      live.room = event.room
+      const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
+      live.participants = updateParticipants(
+        live.participants,
+        event.authorId,
+        event.authorName,
+        now(),
+        event.authorIsBot,
+      )
+      void persistParticipants(live)
 
-    const isNewAuthor = !live.participants.some((p) => p.authorId === event.authorId)
-    live.participants = updateParticipants(
-      live.participants,
-      event.authorId,
-      event.authorName,
-      now(),
-      event.authorIsBot,
-    )
-    void persistParticipants(live)
-
-    // A previously-unseen author just spoke. The cached membership count
-    // (from /members or history-derived) was computed without them, so
-    // invalidate and warm in the background. We don't await — the warmup
-    // runs alongside this turn's `membershipForEngagement` call so the
-    // *next* turn sees fresh data, but the current turn still gets a
-    // fast answer (cache miss → cold fetch with timeout, or stale-ok).
-    if (isNewAuthor && live.key.workspace !== '@dm') {
-      const scoped = membershipScopeKey(live.key, live.room)
-      const cache = membershipCaches.get(scoped.adapter)
-      if (cache !== undefined) {
-        cache.invalidate(scoped)
-        void cache.warmUp(scoped).catch((err) => {
-          logger.warn(`[channels] membership warmup after new author failed for ${live.keyId}: ${describe(err)}`)
-        })
+      // A previously-unseen author just spoke. The cached membership count
+      // (from /members or history-derived) was computed without them, so
+      // invalidate and warm in the background. We don't await — the warmup
+      // runs alongside this turn's `membershipForEngagement` call so the
+      // *next* turn sees fresh data, but the current turn still gets a
+      // fast answer (cache miss → cold fetch with timeout, or stale-ok).
+      if (isNewAuthor && live.key.workspace !== '@dm') {
+        const scoped = membershipScopeKey(live.key, live.room)
+        const cache = membershipCaches.get(scoped.adapter)
+        if (cache !== undefined) {
+          cache.invalidate(scoped)
+          void cache.warmUp(scoped).catch((err) => {
+            logger.warn(`[channels] membership warmup after new author failed for ${live.keyId}: ${describe(err)}`)
+          })
+        }
       }
+
+      if (onRouteMembership !== undefined) await onRouteMembership(live.keyId)
+      const membership = await membershipForEngagement(live)
+
+      const effectiveHumans = countEffectiveHumans(live.participants, membership, now())
+      live.multiHumanGroup = isMultiHumanGroup(event.isDm, effectiveHumans)
+
+      const decision: EngagementDecision = decideEngagement({
+        message: event,
+        config: adapterConfig.engagement,
+        key: live.keyId,
+        ledger: stickyLedger,
+        now: now(),
+        participants: live.participants,
+        membership,
+        selfAliases: computeSelfAliases(),
+        botInThread: hasBotParticipated(live),
+      })
+
+      if (decision === 'observe') {
+        publishInbound(event, 'observe', live.sessionId)
+        // Log every observe so an unanswered mention is diagnosable from logs
+        // alone instead of "routed but no prompting" silence. The bracketed
+        // shape mirrors `prompting batch=` so log scraping can pair them.
+        logger.info(`[channels] ${live.keyId} observed id=${event.externalMessageId}`)
+        observe(live, event)
+        return
+      }
+
+      publishInbound(event, 'engage', live.sessionId)
+
+      // Arm cold-start bare-empty recovery only for the exact incident shape: the
+      // FIRST prompt (`turnSeq === 0`) of a freshly cold-started session that
+      // engaged via the solo-human answer-everything fallback — a lone human, no
+      // explicit mention/reply/DM, not a multi-human group. Recomputed on every
+      // engage so it self-clears once the first turn advances `turnSeq`; explicit
+      // address (mention/reply/DM) keeps the historical silent-on-empty path.
+      live.coldStartSoloFallbackTurnActive =
+        live.createdFromColdStart &&
+        live.turnSeq === 0 &&
+        effectiveHumans <= 1 &&
+        !event.authorIsBot &&
+        !event.isDm &&
+        !event.isBotMention &&
+        event.replyToBotMessageId === null &&
+        !live.multiHumanGroup
+
+      const engageReaction = autoReactOnEngage(event)
+
+      updateLoopGuard(live, event)
+
+      enqueue(live, event, engageReaction)
+
+      // Start showing "typing..." the moment we know we're going to engage,
+      // so users see the indicator during the debounce window — not just
+      // during LLM generation. drain() will keep it alive across iterations
+      // and the finally-block will stop it when the queue empties.
+      startTypingHeartbeat(live)
+
+      if (live.draining) {
+        // In-flight turn; let coalesce-on-drain pick it up. Same-author abort
+        // is a v0.2 enhancement once we have safe abort semantics through
+        // pi-coding-agent for in-flight tool calls.
+        return
+      }
+      scheduleDebouncedDrain(live)
+    } finally {
+      live.routing--
     }
-
-    const membership = await membershipForEngagement(live)
-
-    const effectiveHumans = countEffectiveHumans(live.participants, membership, now())
-    live.multiHumanGroup = isMultiHumanGroup(event.isDm, effectiveHumans)
-
-    const decision: EngagementDecision = decideEngagement({
-      message: event,
-      config: adapterConfig.engagement,
-      key: live.keyId,
-      ledger: stickyLedger,
-      now: now(),
-      participants: live.participants,
-      membership,
-      selfAliases: computeSelfAliases(),
-      botInThread: hasBotParticipated(live),
-    })
-
-    if (decision === 'observe') {
-      publishInbound(event, 'observe', live.sessionId)
-      // Log every observe so an unanswered mention is diagnosable from logs
-      // alone instead of "routed but no prompting" silence. The bracketed
-      // shape mirrors `prompting batch=` so log scraping can pair them.
-      logger.info(`[channels] ${live.keyId} observed id=${event.externalMessageId}`)
-      observe(live, event)
-      return
-    }
-
-    publishInbound(event, 'engage', live.sessionId)
-
-    // Arm cold-start bare-empty recovery only for the exact incident shape: the
-    // FIRST prompt (`turnSeq === 0`) of a freshly cold-started session that
-    // engaged via the solo-human answer-everything fallback — a lone human, no
-    // explicit mention/reply/DM, not a multi-human group. Recomputed on every
-    // engage so it self-clears once the first turn advances `turnSeq`; explicit
-    // address (mention/reply/DM) keeps the historical silent-on-empty path.
-    live.coldStartSoloFallbackTurnActive =
-      live.createdFromColdStart &&
-      live.turnSeq === 0 &&
-      effectiveHumans <= 1 &&
-      !event.authorIsBot &&
-      !event.isDm &&
-      !event.isBotMention &&
-      event.replyToBotMessageId === null &&
-      !live.multiHumanGroup
-
-    const engageReaction = autoReactOnEngage(event)
-
-    updateLoopGuard(live, event)
-
-    enqueue(live, event, engageReaction)
-
-    // Start showing "typing..." the moment we know we're going to engage,
-    // so users see the indicator during the debounce window — not just
-    // during LLM generation. drain() will keep it alive across iterations
-    // and the finally-block will stop it when the queue empties.
-    startTypingHeartbeat(live)
-
-    if (live.draining) {
-      // In-flight turn; let coalesce-on-drain pick it up. Same-author abort
-      // is a v0.2 enhancement once we have safe abort semantics through
-      // pi-coding-agent for in-flight tool calls.
-      return
-    }
-    scheduleDebouncedDrain(live)
   }
 
   const inboundAuthorOrigin = (event: InboundMessage): SessionOrigin => ({
@@ -5159,23 +5257,37 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (!live.destroyed) await tearDownLive(live)
   }
 
+  // Shared eviction-eligibility gate for both the idle GC and the capacity cap:
+  // a session with buffered work (queued prompts / pending reminders), a turn in
+  // flight (draining), an already-running teardown (destroyed), or a still-live
+  // background child (pinned) must never be torn down out from under that work.
+  // `label` only annotates the stuck-child override log. Single source of truth
+  // so the two eviction paths can't drift apart.
+  const isEvictable = (live: LiveSession, label: string): boolean => {
+    if (live.destroyed) return false
+    if (live.draining) return false
+    // A route() call has obtained this session but not yet enqueued its inbound
+    // (it may be awaiting membership); evicting now would strand that inbound.
+    if (live.routing > 0) return false
+    if (live.promptQueue.length > 0) return false
+    // pendingSystemReminders is checked alongside promptQueue because both
+    // represent pending work that drain() will process. Today's only
+    // populator (injectSubagentCompletionReminder) also fires drain()
+    // synchronously, which sets draining=true and shadows this guard via
+    // the line above — but the guard exists to keep the invariant honest
+    // for any future caller that queues a reminder without immediately
+    // waking the drain loop.
+    if (live.pendingSystemReminders.length > 0) return false
+    if (isPinnedByRunningChild(live.sessionId, live.keyId, label)) return false
+    return true
+  }
+
   const runIdleGc = async (): Promise<void> => {
     const t = now()
     const victims: LiveSession[] = []
     for (const live of liveSessions.values()) {
-      if (live.destroyed) continue
-      if (live.draining) continue
-      if (live.promptQueue.length > 0) continue
-      // pendingSystemReminders is checked alongside promptQueue because both
-      // represent pending work that drain() will process. Today's only
-      // populator (injectSubagentCompletionReminder) also fires drain()
-      // synchronously, which sets draining=true and shadows this guard via
-      // the line above — but the guard exists to keep the invariant honest
-      // for any future caller that queues a reminder without immediately
-      // waking the drain loop.
-      if (live.pendingSystemReminders.length > 0) continue
       if (t - live.lastInboundAt <= SESSION_IDLE_MS) continue
-      if (isPinnedByRunningChild(live.sessionId, live.keyId, 'idle_gc evicting')) continue
+      if (!isEvictable(live, 'idle_gc evicting')) continue
       victims.push(live)
     }
     for (const live of victims) {
@@ -5183,6 +5295,63 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       logger.info(`[channels] ${live.keyId} idle_gc evicting after ${t - live.lastInboundAt}ms idle`)
       await tearDownLive(live)
     }
+  }
+
+  // Slots claimed by callers that have decided to admit a new session but have
+  // not yet inserted it into `liveSessions`. Effective occupancy is
+  // `liveSessions.size + reservedSlots`. The reservation is taken in the
+  // SYNCHRONOUS prefix of makeCapacityRoom() (before any await) and released at
+  // the caller's insert, so two concurrent distinct-key creations cannot both
+  // observe room and overshoot the cap (check-then-act across an await gap).
+  let reservedSlots = 0
+
+  // Reserve one slot for a session about to be installed, evicting
+  // least-recently-active EVICTABLE sessions first so that
+  // `liveSessions.size + reservedSlots` stays within MAX_LIVE_SESSIONS. Victim
+  // selection, map delete, and the reservation happen synchronously up front
+  // (no yield); teardown is then awaited out-of-band, matching the idle GC's
+  // ordering where a session leaves the map before its teardown settles (a
+  // concurrent inbound for that key cold-recreates, which is fine). When too
+  // few sessions are evictable (all busy/pinned/routing), the slot is still
+  // reserved and the newcomer is admitted OVER cap with a warn — never drop the
+  // user's inbound, never block. The returned release() must run once the
+  // caller has inserted (or abandoned) its session.
+  const makeCapacityRoom = (): (() => void) => {
+    // Victims are deleted from the map as they're picked, so `liveSessions.size`
+    // already reflects each removal — the loop just re-checks it plus the
+    // outstanding reservations against the ceiling until the new slot fits.
+    const victims: LiveSession[] = []
+    while (liveSessions.size + reservedSlots + 1 > MAX_LIVE_SESSIONS) {
+      let victim: LiveSession | undefined
+      for (const live of liveSessions.values()) {
+        if (!isEvictable(live, 'capacity_gc evicting')) continue
+        if (victim === undefined || live.lastInboundAt < victim.lastInboundAt) victim = live
+      }
+      if (victim === undefined) {
+        logger.warn(
+          `[channels] capacity_gc: admitting new session over cap (${liveSessions.size + reservedSlots} live/reserved, insufficient evictable sessions — all busy/pinned/routing)`,
+        )
+        break
+      }
+      victims.push(victim)
+      liveSessions.delete(victim.keyId)
+    }
+    reservedSlots++
+    let released = false
+    const release = (): void => {
+      if (released) return
+      released = true
+      reservedSlots--
+    }
+    void (async () => {
+      for (const victim of victims) {
+        logger.info(
+          `[channels] ${victim.keyId} capacity_gc evicting LRU session (at MAX_LIVE_SESSIONS=${MAX_LIVE_SESSIONS})`,
+        )
+        await tearDownLive(victim)
+      }
+    })()
+    return release
   }
 
   let gcTimer: ReturnType<typeof setInterval> | null = setInterval(() => {


### PR DESCRIPTION
## Why

`liveSessions` (`src/channels/router.ts`) had **no count ceiling**. It was reclaimed only by the 30-minute idle GC sweep (`SESSION_IDLE_MS` / `SESSION_GC_INTERVAL_MS`), so a burst of *active* conversations across many channels/threads could each pin a full in-memory `AgentSession` (open `SessionManager` + transcript, ~50–200 MB RSS) with no upper bound. N active conversations = N sessions in RAM, and the idle sweep never fires on any of them while they stay busy — collectively enough to OOM the container.

This is the **#2 memory multiplier after the embedder** (capped in #1301 / `612065bb`, the confirmed crash cause). This PR is defense-in-depth for heavy multi-channel deployments (the reporting customer runs several active Slack channels simultaneously).

## What

- **New exported constant `MAX_LIVE_SESSIONS = 10`** — a hard ceiling on concurrently-warm sessions. Comfortably covers normal multi-channel use; documented and trivial to bump.
- **Capacity eviction at the `ensureLive` creation choke-point.** Before a *new* session is inserted into `liveSessions`, if we're at cap the router evicts the **least-recently-active** eligible session (smallest `lastInboundAt`). The check sits at the single point both the cold-start and rehydrate `liveSessions.set` branches flow through, and only fires when a genuinely new session is being created — reusing an existing warm session never triggers eviction.
- **Shared eligibility predicate `isEvictable`**, extracted from `runIdleGc` (the one allowed refactor). Both the idle sweep and capacity eviction now call it, so they can't drift apart. A session that is `draining`, `destroyed`, has a non-empty `promptQueue`/`pendingSystemReminders`, or is pinned by a running child subagent (`isPinnedByRunningChild`) is **never** the victim — the LRU scan skips to the next eligible session.
- **Identical teardown.** Eviction reuses the idle GC's exact `tearDownLive` (abort → `session.end` hook → dispose → timer/subscription cleanup). No second disposal path, so no leaked timers/sockets/subscriptions.
- **Logged** in the idle-GC style: `capacity_gc evicting LRU session (at MAX_LIVE_SESSIONS=10)`.

### No-evictable-victim policy (justified)

When every at-cap session is ineligible (all busy/pinned), the newcomer is **admitted over-cap with a `warn`** rather than dropping the inbound or blocking:

- **Never drops a message** — the user's inbound is served immediately by a real session.
- **Never deadlocks** — queueing the inbound would need a wakeup tied to a future eviction, but eviction only happens on new-session creation or the 30-min idle sweep, so a queued inbound could stall for up to 30 min (or indefinitely if the pinning child never finishes and no new inbound arrives). Over-cap admission is self-correcting: the next idle sweep or the next evictable creation restores the ceiling. This mirrors how the idle GC already tolerates "can't evict pinned sessions right now."

## Testing

TDD, failing-first. Seven new tests in `router.test.ts` under `ChannelRouter max-live-session capacity cap`, driven through the existing router harness (distinct-channel inbounds, injected clock for `lastInboundAt` ordering, `FakeSession` dispose/abort counters, captured log buffer):

- cap+1 evicts the **LRU-by-`lastInboundAt`** session; victim is aborted+disposed, others untouched.
- eviction is logged in the `capacity_gc evicting` style.
- a **draining** session is never the victim even when it's the LRU → next-LRU eligible is evicted (asserted with ≥2 sessions to prove LRU ordering).
- a **child-pinned** session is never the victim even when it's the LRU → next-LRU eligible is evicted.
- when **all** sessions are ineligible → newcomer served over-cap with a warn, nobody evicted, message processed (never dropped).
- reusing an **existing warm** session never triggers capacity eviction.
- `MAX_LIVE_SESSIONS` sanity guard (≥ 8) against a future crippling edit.

Checks (all green): `bun run typecheck`, `bun run lint` (0 errors, 0 warnings in changed files), `bun run format:check`, full suite **12026 pass / 0 fail**. The 12 existing idle-GC tests still pass, confirming the `isEvictable` extraction is behavior-preserving.

## What this does NOT do

- Does **not** change `SESSION_IDLE_MS` / `SESSION_GC_INTERVAL_MS` or the idle-GC cadence.
- Does **not** introduce a second disposal/teardown path — eviction reuses `tearDownLive`.
- Does **not** drop or lose an inbound under any cap condition, and does **not** block/deadlock.
- Does **not** evict a `draining` / `destroyed` / queued / child-pinned session, even when it's the LRU.
- No refactor beyond extracting the shared `isEvictable` predicate (single source of truth for both eviction paths).
