### PR TITLE
Self-heal a missing topics dir in listShardSlugs

### DIFF
--- a/src/bundled-plugins/memory/load-shards.test.ts
+++ b/src/bundled-plugins/memory/load-shards.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, mkdir, rm, unlink, utimes, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, stat, unlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -161,15 +161,31 @@ describe('listShardSlugs', () => {
     await expect(loadAllShards(agentDir)).resolves.toHaveLength(1)
   })
 
-  test('topics path that is a regular file (ENOTDIR) degrades to empty', async () => {
+  test('missing topics dir self-heals: returns empty AND creates the directory', async () => {
+    // A fresh agent (or a wiped memory tree) has no memory/topics yet. Rather
+    // than merely swallowing the ENOENT, listShardSlugs recreates the dir so
+    // downstream readers see a real empty directory instead of a missing one.
+    const agentDir = await makeAgentDir()
+
+    await expect(listShardSlugs(agentDir)).resolves.toEqual([])
+
+    const created = await stat(topicsDir(agentDir))
+    expect(created.isDirectory()).toBe(true)
+  })
+
+  test('topics path that is a regular file (ENOTDIR) degrades to empty without self-healing', async () => {
     // A bind-mount/tmpfs coherency hiccup can momentarily replace memory/topics
-    // with a non-directory; readdir then throws ENOTDIR. It must degrade like a
-    // missing/empty topics dir rather than propagate a hard error.
+    // with a non-directory; readdir then throws ENOTDIR. mkdir can't safely heal
+    // a file-shaped path, so it must degrade like an empty topics dir rather
+    // than propagate a hard error -- and must NOT clobber the operator's file.
     const agentDir = await makeAgentDir()
     await mkdir(join(agentDir, 'memory'), { recursive: true })
     await writeFile(topicsDir(agentDir), 'not a directory', 'utf8')
 
     await expect(listShardSlugs(agentDir)).resolves.toEqual([])
+
+    const untouched = await stat(topicsDir(agentDir))
+    expect(untouched.isFile()).toBe(true)
   })
 
   test('a non-ENOENT/non-ENOTDIR readdir error still propagates', async () => {

--- a/src/bundled-plugins/memory/load-shards.ts
+++ b/src/bundled-plugins/memory/load-shards.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { mkdir, readdir, readFile, stat } from 'node:fs/promises'
 
 import { parseShard, type ShardFrontmatter } from './frontmatter'
 import { topicShardPath, topicsDir } from './paths'
@@ -117,14 +117,23 @@ export async function loadShard(
 }
 
 export async function listShardSlugs(agentDir: string): Promise<string[]> {
+  const dir = topicsDir(agentDir)
   let names: string[]
   try {
-    names = await readdir(topicsDir(agentDir))
+    names = await readdir(dir)
   } catch (err) {
+    // ENOENT: the topics dir doesn't exist yet (fresh agent, or a wiped memory
+    // tree). Self-heal by recreating it so every downstream reader -- per-turn
+    // injection, memory_search, dreaming, the startup index build, and the
+    // doctor vector-index check -- sees a real, empty directory instead of a
+    // missing one. mkdir is idempotent, so a lost race just no-ops.
+    if (isEnoent(err)) return healMissingTopicsDir(dir)
     // ENOTDIR: a bind-mount/tmpfs coherency hiccup can momentarily replace the
-    // topics dir with a non-directory. Treat it like ENOENT -- not a readable
-    // directory right now -- and degrade to empty instead of hard-erroring.
-    if (isEnoent(err) || isEnotdir(err)) return []
+    // topics dir (or a parent path component) with a non-directory; readdir
+    // then throws ENOTDIR. We can't self-heal this -- mkdir over a regular file
+    // would either fail or clobber operator data -- so degrade to empty and let
+    // the transient host state resolve itself, exactly as before.
+    if (isEnotdir(err)) return []
     throw err
   }
 
@@ -132,6 +141,18 @@ export async function listShardSlugs(agentDir: string): Promise<string[]> {
     .filter((name) => name.endsWith('.md'))
     .map((name) => name.slice(0, -'.md'.length))
     .sort()
+}
+
+async function healMissingTopicsDir(dir: string): Promise<string[]> {
+  try {
+    await mkdir(dir, { recursive: true })
+  } catch (err) {
+    // A concurrent healer already created it, or the parent briefly became a
+    // non-directory. Either way the empty-list contract still holds; never let
+    // the heal attempt turn a self-healing state into a hard error.
+    if (!isEnotdir(err)) throw err
+  }
+  return []
 }
 
 // Test-only helper. Clears the in-memory shard cache so tests that exercise


### PR DESCRIPTION
## Background

Follow-up to #1303 ("Degrade `listShardSlugs` to empty on ENOTDIR"), which made `listShardSlugs` (`src/bundled-plugins/memory/load-shards.ts`) degrade to `[]` on both `ENOENT` (missing dir) and `ENOTDIR` (topics path is momentarily a non-directory from a bind-mount/tmpfs coherency hiccup). That stopped the hard error, but merely swallowing the missing-dir case leaves `memory/topics/` absent for every downstream reader -- per-turn injection, `memory_search`, dreaming, the startup index build, and the `typeclaw doctor` vector-index check -- until something else happens to recreate it.

This follow-up self-heals the `ENOENT` case instead of just swallowing it.

## Summary

- On `ENOENT`: recreate the directory via `mkdir(dir, { recursive: true })` (idempotent) and return `[]`, so readers see a real empty directory rather than a missing one. Extracted into a small `healMissingTopicsDir` helper.
- `ENOTDIR` keeps its prior behavior (degrade to `[]`, no heal): a file-shaped path can't be safely healed by `mkdir` -- doing so would either fail or clobber operator data -- so it degrades to empty and lets the transient host state resolve itself. This is deliberate and is the key design boundary: `ENOENT` self-heals, `ENOTDIR` does not.
- The heal itself is failure-tolerant: a lost `mkdir` race, or a parent path component that briefly became a non-directory (`ENOTDIR` from `mkdir`), still returns `[]` rather than turning a self-healing state into a hard error. Any non-`ENOTDIR` mkdir error still propagates.
- The invariant from #1303 -- exactly `ENOENT` and `ENOTDIR` degrade to `[]`; every other errno still throws -- is preserved.

## What this does NOT do

- Does **not** fix the root-cause host-side bind-mount/tmpfs disappearance (same non-goal as #1303).
- Does **not** change `ENOTDIR` behavior -- still degrades to `[]`, no heal.
- Does **not** broaden the catch -- every other errno still throws.
- Does **not** touch `loadAllShards`, `statShard`, `readAndParseShard`, or any caller.

## Review notes

Load-bearing invariant: exactly `ENOENT` and `ENOTDIR` degrade to `[]`; `ENOENT` additionally self-heals the directory, `ENOTDIR` never does.

Tests updated in `load-shards.test.ts` (TDD):
- `missing topics dir self-heals: returns empty AND creates the directory` -- asserts the directory is actually created, not just that `listShardSlugs` returns `[]`.
- `topics path that is a regular file (ENOTDIR) degrades to empty without self-healing` -- asserts it degrades to `[]` without clobbering the operator's file (`stat().isFile()` still true afterward).
- The non-`ENOENT`/non-`ENOTDIR` propagation guard test is unchanged.

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full `bun run test` (12020 pass, 0 fail) all pass on this branch.