### PR TITLE
Cap concurrent sandboxed bash to bound peak memory

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 import { randomUUID } from 'node:crypto'
 import { readdirSync } from 'node:fs'
 import {
@@ -47,6 +47,7 @@ import {
   buildSandboxEnvPolicy,
   defaultBuiltinPiToolDefinitions,
   forgetSharedLoopGuardTool,
+  MAX_CONCURRENT_SANDBOXED_BASH,
   TYPECLAW_INTERNAL_BASH_ENV,
   wrapBuiltinToolDefinition,
   wrapPluginTool,
@@ -73,6 +74,14 @@ const lacksInodeAnchoring = process.platform !== 'linux'
 function textOfFirstContent(result: { content: { type: string; text?: string }[] }): string | undefined {
   const first = result.content[0]
   return first?.type === 'text' ? first.text : undefined
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
 }
 
 describe('zodToToolParameters', () => {
@@ -3780,6 +3789,239 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     )
     expect(seenInHook).toBeUndefined()
   })
+})
+
+// Linux-only (like the inode-anchoring tests): these drive REAL bwrap sandbox
+// setup, whose proc-bind safety probe only returns a cacheable definitive
+// verdict on a Linux userns host. On macOS/Windows it stays 'inconclusive' and
+// re-probes (seconds) on every call, blowing the timeout — the semaphore logic
+// under test is platform-independent, but the setup it wraps is not. CI runs the
+// suite on ubuntu, where the probe caches once and every call is fast.
+//
+// Separate from the role-derived-path-hiding block above because that block's
+// beforeEach resets the bwrap/proc caches, which would force a fresh probe on
+// every call here. This block warms the probe ONCE in beforeAll so the many
+// concurrent calls reuse the cached verdict — matching production, where a
+// container probes once at boot.
+describe.skipIf(lacksInodeAnchoring)('wrapBuiltinToolDefinition sandboxed bash concurrency cap (OOM guard)', () => {
+  const capTui: SessionOrigin = { kind: 'tui', sessionId: 'cap' }
+
+  function capBash(state: { active: number; peak: number; started: number }, gate: Promise<void>) {
+    return {
+      name: 'bash',
+      label: 'bash',
+      description: '',
+      parameters: Type.Object({ command: Type.String() }),
+      async execute() {
+        state.active++
+        state.started++
+        state.peak = Math.max(state.peak, state.active)
+        try {
+          await gate
+          return { content: [{ type: 'text' as const, text: 'ran' }], details: undefined }
+        } finally {
+          state.active--
+        }
+      },
+    }
+  }
+
+  const capBoundary = {
+    ensureAvailable: async () => {},
+    buildCommand: buildSandboxedCommand,
+    resolveRuntime: async () => ({ env: {}, mounts: [] }),
+  }
+
+  async function capAgentDir(prefix: string): Promise<string> {
+    const agentDir = await mkdtemp(path.join(tmpdir(), prefix))
+    for (const dir of ['workspace/.config/gws', 'workspace/.agent-messenger', '.typeclaw/home', '.typeclaw/logs']) {
+      await mkdir(path.join(agentDir, dir), { recursive: true })
+    }
+    for (const file of ['.env', 'secrets.json', 'auth.json']) {
+      await writeFile(path.join(agentDir, file), '')
+    }
+    return agentDir
+  }
+
+  function wrapCapBash(
+    tool: ReturnType<typeof capBash> | ReturnType<typeof fakeCapBash>,
+    agentDir: string,
+    sessionId: string,
+  ): ReturnType<typeof wrapBuiltinToolDefinition> {
+    return wrapBuiltinToolDefinition(tool as never, {
+      agentDir,
+      sessionId,
+      hooks: createHookBus(),
+      getOrigin: () => capTui,
+      permissions: createPermissionService(),
+      bashSandboxBoundary: capBoundary,
+    })
+  }
+
+  function fakeCapBash(record: { command?: string }) {
+    return {
+      name: 'bash',
+      label: 'bash',
+      description: '',
+      parameters: Type.Object({ command: Type.String() }),
+      async execute(_id: string, params: { command: string }) {
+        record.command = params.command
+        return { content: [{ type: 'text' as const, text: 'ran' }], details: undefined }
+      },
+    }
+  }
+
+  // Real-time poll: sandbox setup does real filesystem I/O, so admission into
+  // execute() lands over milliseconds; a microtask spin would sample too early.
+  async function waitFor(predicate: () => boolean, timeoutMs = 15000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (!predicate()) {
+      if (Date.now() > deadline) throw new Error('waitFor timed out')
+      await new Promise((r) => setTimeout(r, 5))
+    }
+  }
+
+  let warmDir: string
+
+  beforeAll(async () => {
+    // Populate the process-global bwrap/proc probe cache once so the concurrent
+    // batches below reach execute() promptly instead of racing slow probes.
+    warmDir = await capAgentDir('typeclaw-bash-cap-warm-')
+    await wrapCapBash(fakeCapBash({}), warmDir, 'cap-warm').execute(
+      'warm',
+      { command: 'echo warm' },
+      undefined,
+      undefined,
+      {} as never,
+    )
+  })
+
+  afterAll(async () => {
+    if (warmDir !== undefined) await rm(warmDir, { recursive: true, force: true })
+  })
+
+  test(`caps concurrent sandboxed bash executions at MAX_CONCURRENT_SANDBOXED_BASH (${MAX_CONCURRENT_SANDBOXED_BASH})`, async () => {
+    const n = MAX_CONCURRENT_SANDBOXED_BASH
+    const dirs = await Promise.all(Array.from({ length: n + 1 }, () => capAgentDir('typeclaw-bash-cap-')))
+    try {
+      const state = { active: 0, peak: 0, started: 0 }
+      const gate = deferred<void>()
+      const wrapped = dirs.map((dir, i) => wrapCapBash(capBash(state, gate.promise), dir, `bash-cap-${i}`))
+
+      // when: fire cap + 1 concurrent calls, all sharing the same gate
+      const runs = wrapped.map((w, i) =>
+        w.execute(`call-${i}`, { command: 'sleep 1' }, undefined, undefined, {} as never),
+      )
+      // wait until the cap is saturated, then let any straggler setup settle
+      await waitFor(() => state.started >= n)
+      await new Promise((r) => setTimeout(r, 200))
+
+      // then: at most `n` are inside execute at once; the (n+1)th is queued
+      expect(state.started).toBe(n)
+      expect(state.peak).toBe(n)
+
+      gate.resolve()
+      await Promise.all(runs)
+
+      // and: the queued call ran after a slot freed — nothing was dropped
+      expect(state.started).toBe(n + 1)
+      expect(state.peak).toBe(n)
+    } finally {
+      await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+    }
+  }, 60000)
+
+  test('releases a concurrency slot when a sandboxed bash call throws', async () => {
+    // `n` calls that all throw run CONCURRENTLY: they saturate the cap, then each
+    // must release its slot on the throw. A fresh call afterwards proves the cap
+    // freed up — if any throw leaked its slot, the semaphore would still be full
+    // and the fresh call would block forever. (Concurrent, not sequential, so the
+    // calls share one in-flight bwrap probe instead of each paying it in series.)
+    const n = MAX_CONCURRENT_SANDBOXED_BASH
+    const failDirs = await Promise.all(Array.from({ length: n }, () => capAgentDir('typeclaw-bash-cap-throw-')))
+    const okDir = await capAgentDir('typeclaw-bash-cap-throw-ok-')
+    try {
+      // given: cap-many concurrent calls that each throw. Unique commands per
+      // call so the loop guard never trips on a repeat.
+      const failures = failDirs.map((dir, i) => {
+        const failing = fakeCapBash({})
+        failing.execute = async () => {
+          throw new Error('boom')
+        }
+        return expect(
+          wrapCapBash(failing, dir, `bash-cap-throw-${i}`).execute(
+            `fail-${i}`,
+            { command: `echo throw-${i}` },
+            undefined,
+            undefined,
+            {} as never,
+          ),
+        ).rejects.toThrow('boom')
+      })
+      await Promise.all(failures)
+
+      // when: a fresh call runs after all slots should have been released
+      const record: { command?: string } = {}
+      const result = await wrapCapBash(fakeCapBash(record), okDir, 'bash-cap-throw-ok').execute(
+        'ok',
+        { command: 'echo throw-ok' },
+        undefined,
+        undefined,
+        {} as never,
+      )
+
+      // then: the throwing calls did not leak their slots
+      expect(textOfFirstContent(result)).toBe('ran')
+    } finally {
+      await Promise.all([...failDirs, okDir].map((dir) => rm(dir, { recursive: true, force: true })))
+    }
+  }, 60000)
+
+  test('a queued sandboxed bash call that aborts before admission does not hold a slot', async () => {
+    const n = MAX_CONCURRENT_SANDBOXED_BASH
+    const heldDirs = await Promise.all(Array.from({ length: n }, () => capAgentDir('typeclaw-bash-cap-abort-')))
+    const queuedDir = await capAgentDir('typeclaw-bash-cap-abort-q-')
+    try {
+      const state = { active: 0, peak: 0, started: 0 }
+      const gate = deferred<void>()
+
+      // given: cap slots saturated by blocking calls
+      const held = heldDirs.map((dir, i) =>
+        wrapCapBash(capBash(state, gate.promise), dir, `bash-cap-abort-${i}`).execute(
+          `held-${i}`,
+          { command: 'sleep 1' },
+          undefined,
+          undefined,
+          {} as never,
+        ),
+      )
+      await waitFor(() => state.started >= n)
+      await new Promise((r) => setTimeout(r, 200))
+      expect(state.started).toBe(n)
+
+      // when: a further call queues (setup completes, then it blocks on the full
+      // semaphore), then aborts before a slot frees
+      const controller = new AbortController()
+      const queued = wrapCapBash(capBash(state, gate.promise), queuedDir, 'bash-cap-abort-q').execute(
+        'queued',
+        { command: 'sleep 1' },
+        controller.signal,
+        undefined,
+        {} as never,
+      )
+      await new Promise((r) => setTimeout(r, 200))
+      controller.abort()
+      await expect(queued).rejects.toThrow()
+
+      // then: the aborted call never entered execute
+      expect(state.started).toBe(n)
+
+      gate.resolve()
+      await Promise.all(held)
+    } finally {
+      await Promise.all([...heldDirs, queuedDir].map((dir) => rm(dir, { recursive: true, force: true })))
+    }
+  }, 60000)
 })
 
 describe('buildSandboxEnvPolicy exposable .env names', () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -71,6 +71,7 @@ import { enforceSubagentBashPolicy, type SubagentBashPolicy } from './reviewer-b
 import type { SessionOrigin } from './session-origin'
 import { remediateToolErrorMessage } from './tool-error-remediation'
 import { enforceAndPinToolFiles, writeToolOutputNoFollow } from './tool-file-safety'
+import { createKeyedSemaphore } from './tools/keyed-semaphore'
 import { SUBAGENT_OUTPUT_TOOL_NAME, type SubagentOutputToolDetails } from './tools/subagent-output'
 import { webFetchTool } from './tools/webfetch'
 import { webSearchTool } from './tools/websearch'
@@ -81,6 +82,32 @@ import { webSearchTool } from './tools/websearch'
 // detector covers every tool category — plugin tools, TypeClaw system tools,
 // and pi-coding-agent builtins — through one chokepoint.
 let sharedLoopGuard: LoopGuard = createLoopGuard()
+
+// Process-wide cap on how many sandboxed bash calls run their subprocess at
+// once. Each sandboxed bash spawns a bwrap child, and a single model tool-call
+// can fan that out into a heavy Node process (`bunx agent-browser` /
+// `bunx agent-messenger`) or a Chromium instance. The container runs with NO
+// docker `--memory` limit, so peak RSS is bounded only by the host/VM budget:
+// a burst of unbounded parallel tool-calls stacks their children into one RSS
+// spike that the OOM killer takes as a bare SIGKILL — no fatal-guard log, and a
+// restart into empty open/close sessions. Capping the concurrent spawns bounds
+// that worst-case multiplier. This is the parallel-bash sibling of the embedder
+// cap (612065bb, EMBED_CONCURRENCY).
+//
+// Chosen 4, not 1: the cap must stay >1 or independent read/grep/write/build
+// calls the model fired in parallel would serialize behind one slow build,
+// hurting latency for no memory reason (those are cheap). 4 keeps enough lanes
+// for latency-sensitive parallelism while still bounding the heavy-child stack;
+// a burst of browser/messenger spawns can pile at most 4 deep instead of
+// however many the model requested at once. Queue-and-wait, never skip — the
+// model asked for every command, so an over-cap call blocks for a slot rather
+// than being dropped.
+//
+// Single fixed key — the OOM budget is the whole PROCESS/VM, so the limit is
+// global, not per-session or per-key (mirrors EMBED_SEMAPHORE_KEY).
+export const MAX_CONCURRENT_SANDBOXED_BASH = 4
+const SANDBOXED_BASH_SEMAPHORE_KEY = 'sandboxed-bash'
+const sandboxedBashSemaphore = createKeyedSemaphore({ concurrency: MAX_CONCURRENT_SANDBOXED_BASH })
 
 // Internal, non-model-facing contract: a tool.before hook may set this key on
 // a bash call's args to inject env vars into the spawned process WITHOUT
@@ -614,9 +641,19 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
                   : {}),
               }
             : undefined
-        rawResult = await bashEnvStore.run(spawnEnvContext, () =>
-          tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx),
-        )
+        const runSpawn = (): Promise<ToolResult> =>
+          bashEnvStore.run(spawnEnvContext, () =>
+            tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx),
+          )
+        // Only bash spawns a sandboxed subprocess; the other builtins run
+        // in-process and cheaply, so they bypass the OOM concurrency cap. `run`
+        // is finally-safe, releasing the slot on success, throw, or timeout;
+        // threading the turn's signal means a queued call that aborts before
+        // admission never holds a slot.
+        rawResult =
+          tool.name === 'bash'
+            ? await sandboxedBashSemaphore.run(SANDBOXED_BASH_SEMAPHORE_KEY, runSpawn, signal)
+            : await runSpawn()
       } catch (error) {
         executionError = error
       } finally {


### PR DESCRIPTION
## Background

The container runs with no docker `--memory` limit, so peak RSS is bounded only by the host/VM budget. Each sandboxed bash tool call spawns a bwrap child, and a single model tool-call can fan that child out into a heavy Node process (bunx agent-browser / bunx agent-messenger) or a Chromium instance. A burst of parallel model tool-calls therefore stacks many heavy children into one RSS spike that the Linux OOM killer takes as a bare SIGKILL — no fatal-guard log, just a restart into empty open/close sessions.

This is the same failure class the embedder was already capped for in 612065bb ("Cap concurrent embeds to bound peak memory"). This PR closes the parallel-bash multiplier.

## Summary

- Gate the sandboxed bash subprocess spawn in `wrapBuiltinToolDefinition` (src/agent/plugin-tools.ts) behind a process-wide concurrency cap.
- Reuses the existing `createKeyedSemaphore` (src/agent/tools/keyed-semaphore.ts) — the same queue-and-wait limiter the embedder uses.
- Uses a single global semaphore key, SANDBOXED_BASH_SEMAPHORE_KEY — the OOM budget is process/VM-wide, not per-session or per-key.
- New exported constant `MAX_CONCURRENT_SANDBOXED_BASH = 4`, documented in-code with the rationale below.
- Kept above 1 so independent read/grep/write/build calls fired in parallel aren't serialized behind one slow build; 4 bounds the heavy-child stack while preserving latency-sensitive parallelism.
- Queue-and-wait, never skip — the model asked for every command, so an over-cap call blocks for a slot instead of being dropped.
- The semaphore's `run` is finally-safe, releasing the slot on success, throw, or timeout.
- The turn's AbortSignal is threaded into the run call so a queued call that aborts before admission never holds a slot.
- Only the bash builtin is gated — it's the only one that spawns a subprocess. The other in-process builtins (read/grep/edit/write/find/ls) bypass the cap entirely.

## What this does NOT do

- Does not add a docker `--memory` limit or otherwise change container resource limits — this bounds the multiplier, not the ceiling.
- Does not touch the embedder cap (612065bb) or any other concurrency limiter.
- Does not gate non-bash builtins; they run in-process and are cheap.

## Review notes

- Load-bearing invariant: the semaphore slot is held only around the actual subprocess spawn, and only when `tool.name === 'bash'`.
- Tests (TDD, written first) live in plugin-tools.test.ts.
- New describe block: "sandboxed bash concurrency cap (OOM guard)", three cases.
- Case 1: N+1 concurrent sandboxed bash calls where N = cap run at most N at once — peak equals N, the N+1th queues and only runs after a slot frees, nothing dropped.
- Case 2: a slot is released when a wrapped bash call throws — cap-many throwing calls, then a fresh call still admits.
- Case 3: a queued call that aborts before admission does not hold a slot.
- These tests drive the real bwrap sandbox path, whose proc-bind safety probe only returns a cacheable definitive verdict on a Linux userns host (it re-probes per call on macOS/Windows).
- Gated Linux-only via a skipIf on the repo's existing inode-anchoring platform check. CI runs the suite on ubuntu.
- Verified as a true TDD guard inside a Linux (ubuntu/bun) container: bypassing the semaphore wiring makes the peak test fail (started equals 5, not 4).

## Testing

- `bun run typecheck`
- `bun run lint` (0 errors)
- `bun run format:check`
- `bun run test` — full suite: 12019 pass, 0 fail