### PR TITLE
Warn on a low macOS open-files limit in doctor

### DIFF
--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -152,6 +152,12 @@ typeclaw doctor --only docker,config               # narrow to categories
 
 Categories: `docker`, `config`, `secrets`, `network`, `git`, plus per-plugin checks.
 
+### macOS open-files limit
+
+On macOS, `doctor` warns (category `hostd`, check `hostd.macos-maxfiles`) when the login session's open-files **soft** limit is low. macOS ships a per-process default of 256 (`launchctl limit maxfiles`), and GUI apps launched by launchd — including **OrbStack** and **Docker Desktop** — inherit it. Under load the runtime can exhaust that limit and fail with `too many open files` on its control socket (e.g. `accept unix …/vmcontrol.sock: too many open files`), which surfaces as the runtime being killed (SIGKILL), often alongside DNS lookups failing with `no memory`.
+
+This is a **risk indicator**, not proof the running runtime inherited that exact limit — the kernel ceiling (`kern.maxfiles`, `kern.maxfilesperproc`) and per-container limits are separate. typeclaw does **not** change this limit for you. To clear the warning: update your container runtime to the latest version and fully quit + relaunch it (a well-behaved runtime raises its own soft limit on start); if it recurs, raise the login-session limit using your organization's supported macOS administration method, then relaunch the runtime. If you collect diagnostics for an OrbStack/Docker report, capture `launchctl limit maxfiles`, the runtime's log around the `vmcontrol.sock` errors, and `~/.orbstack/log/` (OrbStack).
+
 ## Update
 
 ```sh

--- a/src/doctor/checks.test.ts
+++ b/src/doctor/checks.test.ts
@@ -11,9 +11,12 @@ import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
 import {
   buildStaticChecks,
   detectWindowsBindMountIssues,
+  macosMaxFiles,
+  parseLaunchctlMaxFilesSoft,
   windowsBindMount,
   windowsSecretPerms,
   wslDriveMount,
+  type MacosMaxFilesDeps,
   type WindowsBindMountDeps,
   type WindowsSecretPermsDeps,
   type WslDriveMountDeps,
@@ -102,6 +105,84 @@ describe('windowsSecretPerms', () => {
 
   test('is registered in the static check set', () => {
     expect(buildStaticChecks().some((c) => c.name === 'hostd.windows-secret-perms')).toBe(true)
+  })
+})
+
+describe('macosMaxFiles', () => {
+  const hostCtx: CheckContext = { cwd: '/tmp/agent', hasAgentFolder: true }
+
+  function macDeps(overrides: Partial<MacosMaxFilesDeps> = {}): MacosMaxFilesDeps {
+    return {
+      isMacOS: () => true,
+      readLaunchctlMaxFiles: async () => '\tmaxfiles    256            unlimited      \n',
+      ...overrides,
+    }
+  }
+
+  test('passes when not running on macOS', async () => {
+    const check = macosMaxFiles(macDeps({ isMacOS: () => false }))
+    const result = await check.run(hostCtx)
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('not running on macOS')
+  })
+
+  test('warns on the macOS default 256 soft limit', async () => {
+    const check = macosMaxFiles(macDeps())
+    const result = await check.run(hostCtx)
+    expect(result.status).toBe('warning')
+    expect(result.message).toContain('256')
+    expect(result.details?.some((d) => d.includes('too many open files'))).toBe(true)
+    expect(result.fix?.description).toContain('relaunch')
+  })
+
+  test('passes when the soft limit is comfortably high', async () => {
+    const check = macosMaxFiles(macDeps({ readLaunchctlMaxFiles: async () => '\tmaxfiles    10240    unlimited\n' }))
+    const result = await check.run(hostCtx)
+    expect(result.status).toBe('ok')
+    expect(result.message).toContain('10240')
+  })
+
+  test('passes when the soft limit is unlimited', async () => {
+    const check = macosMaxFiles(
+      macDeps({ readLaunchctlMaxFiles: async () => '\tmaxfiles    unlimited    unlimited\n' }),
+    )
+    const result = await check.run(hostCtx)
+    expect(result.status).toBe('ok')
+  })
+
+  test('degrades to info when the limit cannot be read', async () => {
+    const check = macosMaxFiles(macDeps({ readLaunchctlMaxFiles: async () => null }))
+    const result = await check.run(hostCtx)
+    expect(result.status).toBe('info')
+    expect(result.status).not.toBe('error')
+  })
+
+  test('degrades to info on unparseable output', async () => {
+    const check = macosMaxFiles(macDeps({ readLaunchctlMaxFiles: async () => 'garbage output\n' }))
+    const result = await check.run(hostCtx)
+    expect(result.status).toBe('info')
+  })
+
+  test('is registered in the static check set', () => {
+    expect(buildStaticChecks().some((c) => c.name === 'hostd.macos-maxfiles')).toBe(true)
+  })
+})
+
+describe('parseLaunchctlMaxFilesSoft', () => {
+  test('parses the real launchctl output shape', () => {
+    expect(parseLaunchctlMaxFilesSoft('\tmaxfiles    256            unlimited      \n')).toBe(256)
+  })
+
+  test('parses unlimited as Infinity', () => {
+    expect(parseLaunchctlMaxFilesSoft('\tmaxfiles    unlimited    unlimited\n')).toBe(Number.POSITIVE_INFINITY)
+  })
+
+  test('returns null when there is no maxfiles line', () => {
+    expect(parseLaunchctlMaxFilesSoft('\tcpu    unlimited    unlimited\n')).toBeNull()
+  })
+
+  test('returns null on a non-numeric soft field', () => {
+    expect(parseLaunchctlMaxFilesSoft('\tmaxfiles    notanumber    unlimited\n')).toBeNull()
   })
 })
 

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -20,7 +20,7 @@ import { resolveBaseImageVersion } from '@/init/cli-version'
 import { buildDockerfile, DOCKERFILE } from '@/init/dockerfile'
 import { detectMissingDeps } from '@/init/ensure-deps'
 import { buildGitignore, GITIGNORE_FILE } from '@/init/gitignore'
-import { detectWsl, isWindows, isWindowsDriveMount, type WslInfo } from '@/shared'
+import { detectWsl, isMacOS, isWindows, isWindowsDriveMount, type WslInfo } from '@/shared'
 
 import { buildChannelChecks } from './channel-checks'
 import { agentFileOwnership, type FileOwnershipDeps } from './file-ownership'
@@ -40,6 +40,7 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } & FileOwners
     agentFileOwnership(opts),
     configValid(),
     hostdHomeWritable(),
+    macosMaxFiles(),
     wslDriveMount(),
     windowsSecretPerms(),
     hostdReachable(),
@@ -255,6 +256,98 @@ function hostdHomeWritable(): DoctorCheck {
         }
       }
     },
+  }
+}
+
+export type MacosMaxFilesDeps = {
+  isMacOS: () => boolean
+  // Returns the raw `launchctl limit maxfiles` stdout, or null when the command
+  // is unavailable / errors. Injected so tests never shell out.
+  readLaunchctlMaxFiles: () => Promise<string | null>
+}
+
+// macOS ships a per-process RLIMIT_NOFILE *soft* limit of 256 by default (the
+// legacy OPEN_MAX), and GUI apps launched by launchd — including OrbStack —
+// inherit it unless something raises it (a /Library/LaunchDaemons plist, or the
+// app calling setrlimit itself). Under load, OrbStack's host-side vmgr can
+// accumulate enough FDs to cross 256 and start failing `accept()` on its
+// control socket with "too many open files", which manifests to the user as
+// OrbStack crashing (SIGKILL). This is a RISK INDICATOR, not proof the live
+// runtime inherited exactly this limit: the kernel ceiling (kern.maxfiles*) and
+// per-container limits are separate, and a well-behaved runtime raises its own
+// soft limit. We only surface the measured value and non-privileged
+// remediation; we never edit launchd files or run privileged commands.
+const MACOS_MAXFILES_RISK_THRESHOLD = 1024
+
+export function macosMaxFiles(deps: Partial<MacosMaxFilesDeps> = {}): DoctorCheck {
+  const onMacOS = deps.isMacOS ?? isMacOS
+  const readLimit = deps.readLaunchctlMaxFiles ?? readLaunchctlMaxFiles
+
+  return {
+    name: 'hostd.macos-maxfiles',
+    category: 'hostd',
+    description: 'macOS open-files soft limit is high enough for the container runtime',
+    async run() {
+      if (!onMacOS()) return { status: 'ok', message: 'not running on macOS' }
+
+      const raw = await readLimit()
+      const soft = raw === null ? null : parseLaunchctlMaxFilesSoft(raw)
+      if (soft === null) {
+        return {
+          status: 'info',
+          message: 'could not read the macOS open-files limit (launchctl limit maxfiles)',
+          details: ['Skipping the open-files check; this does not affect the agent.'],
+        }
+      }
+
+      if (soft >= MACOS_MAXFILES_RISK_THRESHOLD) {
+        return { status: 'ok', message: `open-files soft limit is ${soft}` }
+      }
+
+      return {
+        status: 'warning',
+        message: `macOS open-files soft limit is low (${soft})`,
+        details: [
+          `launchctl limit maxfiles soft limit = ${soft} (macOS default is 256).`,
+          'GUI apps launched by launchd — including OrbStack/Docker Desktop — inherit this soft limit.',
+          'Under load the runtime can exhaust it and fail with "too many open files" on its control socket (vmcontrol.sock), which surfaces as the runtime crashing (SIGKILL).',
+          'This is a risk indicator, not proof: the kernel ceiling (kern.maxfiles*) and per-container limits are separate.',
+        ],
+        fix: {
+          description:
+            "Update your container runtime to the latest version and fully quit + relaunch it (a well-behaved runtime raises its own soft limit on start). If it recurs, raise the login-session open-files limit using your organization's supported macOS administration method, then relaunch the runtime. typeclaw does not change this limit for you.",
+        },
+      }
+    },
+  }
+}
+
+// `launchctl limit maxfiles` prints `\tmaxfiles    <soft>    <hard>\n`, where
+// each field may be a number or the literal `unlimited`. We only need the soft
+// limit; return null on any shape we don't recognize so the check degrades to
+// `info` rather than a false warning.
+export function parseLaunchctlMaxFilesSoft(raw: string): number | null {
+  const line = raw.split('\n').find((l) => l.includes('maxfiles'))
+  if (line === undefined) return null
+  const fields = line.trim().split(/\s+/)
+  const soft = fields[1]
+  if (soft === undefined) return null
+  if (soft === 'unlimited') return Number.POSITIVE_INFINITY
+  const parsed = Number.parseInt(soft, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+async function readLaunchctlMaxFiles(): Promise<string | null> {
+  const bun = (globalThis as { Bun?: { spawn: typeof Bun.spawn } }).Bun
+  if (bun === undefined) return null
+  try {
+    const proc = bun.spawn(['launchctl', 'limit', 'maxfiles'], { stdout: 'pipe', stderr: 'ignore' })
+    const stdout = await new Response(proc.stdout).text()
+    const exitCode = await proc.exited
+    if (exitCode !== 0) return null
+    return stdout
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
## Background

A user reported OrbStack crashing with a **"Stopped unexpectedly: killed (SIGKILL)"** dialog while running typeclaw agents. The log excerpt showed, on repeat:

```
http: Accept error: accept unix ~/.orbstack/run/vmcontrol.sock: accept: too many open files; retrying in {5ms…1s}
vmgr | level=warning msg="DNS query failed" error="no memory" name=slack.com./chatgpt.com./api.github.com. type=A
```

Investigating the affected host directly established the root cause is **host-side OrbStack resource exhaustion, not a typeclaw FD leak inside the container**:

- `launchctl limit maxfiles` = **256** (soft) — the untouched macOS default. There is no `/Library/LaunchDaemons/limit.maxfiles.plist` raising it, and no shell rc lowering it. GUI apps launched by launchd (OrbStack, Docker Desktop) inherit this 256 soft limit unless they raise it themselves.
- The kernel ceiling is fine (`kern.maxfilesperproc` = 61440); only the per-process launchd soft limit is 256.
- OrbStack's `vmgr` helper was at **6.4–6.6 GB RSS** with the host under heavy memory pressure (~200 MB free). Under that load, `vmgr` accumulates FDs, crosses 256, and fails `accept()` on `vmcontrol.sock` with `EMFILE` → the backoff storm → SIGKILL. The DNS `error="no memory"` is OrbStack's gVisor netstack returning `ENOMEM` under the same host memory pressure.
- The typeclaw containers themselves were healthy internally (~28 FDs each), and the code is already FD-hardened (Teams adapter avoids reconnect storms; `tool-file-safety.ts` destroys ReadStreams; `session-list.ts` bounds concurrency).

## Summary

typeclaw can't raise the host's launchd limit or fix OrbStack itself, so this surfaces the risk where operators already look: `doctor`.

A macOS-only check (`hostd.macos-maxfiles`) parses `launchctl limit maxfiles` and **warns when the soft limit is below 1024**, following the existing host-environment-warning pattern (`wslDriveMount`, `windowsSecretPerms`, `windowsBindMount`).

Key decisions:
- **Framed as a risk indicator, not proof.** The check can't read OrbStack's live `RLIMIT_NOFILE`, so the wording says the session default is inherited-and-suspicious, not that the runtime definitely hit it. The kernel ceiling and per-container limits are called out as separate.
- **Non-privileged remediation only.** The fix guidance is "update + relaunch the runtime; if it recurs, raise the login-session limit via your org's supported method." It never edits launchd files or runs privileged commands.
- **Fails safe.** Unreadable/unparseable `launchctl` output degrades to `info`, never `error` — so a non-macOS host or a locked-down box never turns this into a red check.
- The `launchctl` runner is injected as a dependency so tests never shell out; the output parser is a pure exported function with its own table of cases.

## What this does NOT do

- Does **not** add a per-container `--memory` cap or `--ulimit nofile`. Per the investigation, a container `nofile` bump is a non-fix (the container side is already fine; it doesn't touch the host `vmgr` limit), and a default memory cap risks OOM-killing Chrome/embeddings. Those belong in a separate resource-governance proposal, not this bug fix.
- Does **not** attempt to change any host limit automatically.
- Does **not** claim a specific required threshold as fact — 1024 is a conservative "well above the 256 default" line, not a measured OrbStack requirement.

## Review notes

- Load-bearing file: `src/doctor/checks.ts` — `macosMaxFiles()` + `parseLaunchctlMaxFilesSoft()`. The parser is the piece to scrutinize: it targets the exact `\tmaxfiles    <soft>    <hard>\n` shape, maps `unlimited` → `Infinity`, and returns `null` on anything unrecognized (→ `info`).
- Registered in `buildStaticChecks()` alongside the other `hostd` host-environment checks.
- Tests cover: non-macOS (ok), the 256 default (warning), a high limit (ok), `unlimited` (ok), unreadable (info), unparseable (info), registration, plus four parser cases including a non-numeric soft field.
- Docs: a "macOS open-files limit" subsection under the doctor CLI reference documents the check and the `vmcontrol.sock` / `ENOMEM` symptom + what to capture for an OrbStack report.
