### PR TITLE
Defer the willingness-ack empty-turn fallback until the continuation runs

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -24,6 +24,7 @@ import { waitFor } from '@/test-helpers/wait-for'
 
 import type { ChannelSessionRecord } from './persistence'
 import { channelsSessionsPath, loadChannelSessions, saveChannelSessions } from './persistence'
+import type { CreateChannelRouterOptions } from './router'
 import {
   CHANNEL_EMPTY_TURN_RETRY_MAX_OUTPUT_TOKENS,
   CHANNEL_MAX_OUTPUT_TOKENS,
@@ -376,6 +377,7 @@ function makeRouter(
     saveChannelSessions?: (agentDir: string, sessions: readonly ChannelSessionRecord[]) => Promise<void>
     newestRunningChildSubagentStartedAt?: (sessionId: string) => number | null
     listRunningBackgroundSubagentNames?: (sessionId: string) => string[]
+    runIdleContinuation?: CreateChannelRouterOptions['runIdleContinuation']
   } = {},
 ): { router: ChannelRouter; sessions: FakeSession[]; origins: SessionOrigin[] } {
   const sessions: FakeSession[] = options.sessions ?? []
@@ -399,6 +401,7 @@ function makeRouter(
     ...(options.listRunningBackgroundSubagentNames !== undefined
       ? { listRunningBackgroundSubagentNames: options.listRunningBackgroundSubagentNames }
       : {}),
+    ...(options.runIdleContinuation !== undefined ? { runIdleContinuation: options.runIdleContinuation } : {}),
     permissions: options.permissions ?? grantAllPermissions,
     now: () => nowRef.value,
     logger: {
@@ -13931,6 +13934,284 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     expect(
       logs.some((m) => m.includes('empty_turn_fallback cause=empty_stop_after_continue_reply_nudges_exhausted')),
     ).toBe(true)
+  })
+
+  test('self-recovery: a continuation that lands the real answer after willingness exhaustion discards the staged fallback', async () => {
+    // Reproduces the production Discord false alarm: the model acked continue:true,
+    // did tool work, stranded on an empty stop, exhausted the single willingness
+    // nudge — then the idle/todo continuation re-prompted the SAME logical turn and
+    // delivered the real answer. The staged fallback must be discarded, never posted.
+    //
+    // The continuation is delivered through the injected runIdleContinuation seam
+    // (fired by maybeContinueTodosChannel AFTER validateChannelTurn stages), NOT
+    // pre-seeded from onPrompt. This locks in the load-bearing drain ordering: the
+    // fallback is still staged (not resolved) when validation runs; only the later
+    // maybeContinueTodosChannel → resolveStagedFallback sequence discards it. If the
+    // resolver ran ahead of the continuation, the stage would resolve to a POST here
+    // (no reminder queued yet) and the test would fail.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    // One-shot continuation: delivers a reminder the FIRST time the post-validation
+    // maybeContinueTodosChannel runs while a fallback is staged, mirroring the idle
+    // continuation re-prompting the stranded turn.
+    let continuationDelivered = false
+    const runIdleContinuationSeam: NonNullable<CreateChannelRouterOptions['runIdleContinuation']> = async ({
+      deliver,
+    }) => {
+      if (continuationDelivered) return false
+      continuationDelivered = true
+      deliver('continue your work')
+      return true
+    }
+    const { router, sessions } = makeRouter(dir, { logs, runIdleContinuation: runIdleContinuationSeam })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: 'A 회의실 예약해줘' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      if (attempt <= 1 + MAX_WILLINGNESS_NUDGES) {
+        // ack+strand until exhaustion stages (not posts) the fallback. The continuation
+        // is NOT queued here — it arrives post-validation via the seam above.
+        await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${attempt})`, String(attempt))
+        return
+      }
+      // the continuation iteration (driven by the seam's reminder) delivers the answer
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '스페이스 A1 예약 완료' })
+      sessions[0]!.setAssistantText('')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).not.toContain(EMPTY_TURN_FALLBACK_TEXT)
+    expect(sent.some((s) => s.includes('예약 완료'))).toBe(true)
+    expect(logs.some((m) => m.includes('empty_turn_fallback_staged'))).toBe(true)
+    expect(
+      logs.some((m) => m.includes('empty_turn_fallback_deferred') && m.includes('reason=continuation_queued')),
+    ).toBe(true)
+    expect(logs.some((m) => m.includes('empty_turn_fallback_discarded') && m.includes('reason=reply_landed'))).toBe(
+      true,
+    )
+    expect(logs.some((m) => m.includes('empty_turn_fallback cause='))).toBe(false)
+  })
+
+  test('no continuation available: willingness exhaustion still posts the fallback exactly once', async () => {
+    // The genuine-strand invariant. No continuation is queued after exhaustion, so
+    // the staged fallback resolves to a single visible post — the human is never
+    // left on dead air.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '확인해줘' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${attempt})`, String(attempt))
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.filter((s) => s === EMPTY_TURN_FALLBACK_TEXT)).toHaveLength(1)
+    expect(logs.some((m) => m.includes('empty_turn_fallback_staged'))).toBe(true)
+    expect(
+      logs.some((m) => m.includes('empty_turn_fallback cause=empty_stop_after_continue_reply_nudges_exhausted')),
+    ).toBe(true)
+  })
+
+  test('continuation also strands: the deferred fallback posts exactly once once no continuation remains', async () => {
+    // Stage the fallback, defer it while a continuation is queued, then let that
+    // continuation finish WITHOUT a genuine reply and without queuing another. The
+    // deferred fallback must eventually post — exactly once.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '확인해줘' }))
+    let attempt = 0
+    sessions[0]!.onPrompt = async () => {
+      attempt++
+      if (attempt <= 1 + MAX_WILLINGNESS_NUDGES) {
+        await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${attempt})`, String(attempt))
+        if (attempt === 1 + MAX_WILLINGNESS_NUDGES) {
+          // Defer: a continuation is queued at exhaustion time.
+          router.__testing!.injectContinuationReminder(KEY, 'continue your work')
+        }
+        return
+      }
+      // The continuation iteration produces NO reply and no further continuation →
+      // the deferred fallback resolves to a single post.
+      sessions[0]!.setAssistantText('')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(
+      logs.some((m) => m.includes('empty_turn_fallback_deferred') && m.includes('reason=continuation_queued')),
+    ).toBe(true)
+    expect(sent.filter((s) => s === EMPTY_TURN_FALLBACK_TEXT)).toHaveLength(1)
+  })
+
+  test('cross-turn escalation: a willingness-exhaustion staged fallback question turn does not seed the next turn', async () => {
+    // Mirrors the retry-exhausted fallback question-turn test through the STAGED
+    // willingness path. given: turn A is a question whose continue:true ack strands
+    // on every attempt until the willingness budget is exhausted and — with NO
+    // continuation queued — the staged fallback posts (no usable reply). turn B is a
+    // question. The staged-then-posted fallback must NOT commit A's question signal,
+    // so B has no question predecessor and must NOT mode-3 escalate. Before staging
+    // deferred the signal commit, the progress ack read as a usable reply and B
+    // wrongly escalated.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // turn A — a question that acks continue:true then re-strands until exhaustion
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    let aAttempt = 0
+    sessions[0]!.onPrompt = async () => {
+      aAttempt++
+      await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${aAttempt})`, String(aAttempt))
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent.filter((s) => s === EMPTY_TURN_FALLBACK_TEXT)).toHaveLength(1)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn B — a question; predecessor A only produced a fallback → no escalation
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('B')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'and how do i actually fix it properly now?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn B did not escalate — A's staged-fallback turn never seeded the signal.
+    expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
+  })
+
+  test('cross-turn escalation: a willingness strand that self-recovers via continuation DOES seed the next turn', async () => {
+    // The discard counterpart: when the staged fallback is discarded because the
+    // continuation genuinely answers, the logical turn ended as a usable reply, so
+    // A's question signal IS committed and turn B escalates. Proves the discard path
+    // commits the deferred signal rather than dropping it.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // turn A — a question that strands, exhausts the nudge, then a continuation
+    // re-prompt delivers the real answer (staged fallback discarded)
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    let aAttempt = 0
+    sessions[0]!.onPrompt = async () => {
+      aAttempt++
+      if (aAttempt <= 1 + MAX_WILLINGNESS_NUDGES) {
+        await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${aAttempt})`, String(aAttempt))
+        if (aAttempt === 1 + MAX_WILLINGNESS_NUDGES) {
+          router.__testing!.injectContinuationReminder(KEY, 'continue your work')
+        }
+        return
+      }
+      sessions[0]!.setAssistantText('recovered')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'it failed because of X' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent).not.toContain(EMPTY_TURN_FALLBACK_TEXT)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn B — a question; predecessor A ended in a genuine recovery reply → escalate
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('B')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'and how do i actually fix it properly now?' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: turn B escalated — A's self-recovered question signal survived the stage.
+    expect(sessions[0]!.thinkingLevels).toContain('xhigh')
+  })
+
+  test('cross-turn escalation: a fresh batch superseding a staged fallback clears the prior signal (A → staged B → queued C)', async () => {
+    // The supersession hole. given: turn A is a question that replies (commits its
+    // question signal). turn B is a question whose willingness ack strands and stages
+    // the fallback; a fresh inbound C is queued WHILE staged, so the fresh batch
+    // supersedes B before the fallback posts. turn C must NOT inherit A's stale
+    // lastQuestionSignal across the superseded (failed) B — clearing only the stage
+    // would leak A's signal and wrongly escalate C.
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    // turn A — a question that replies → commits A's question signal
+    await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
+    sessions[0]!.onPrompt = async () => {
+      sessions[0]!.setAssistantText('A')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'because of X' })
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    sessions[0]!.thinkingLevels.length = 0
+
+    // turn B — a STATEMENT (so B itself never escalates, isolating the assertion to
+    // C's inheritance of A's stale signal). It strands+stages (willingness branch
+    // needs an empty promptQueue), a continuation reminder forces the resolver to
+    // DEFER so the stage PERSISTS, then on the deferred iteration a fresh inbound C is
+    // queued so the FOLLOWING iteration's fresh batch supersedes the still-staged
+    // fallback — the exact A → staged B → queued C path.
+    let bAttempt = 0
+    sessions[0]!.onPrompt = async () => {
+      bAttempt++
+      if (bAttempt <= 1 + MAX_WILLINGNESS_NUDGES) {
+        await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${bAttempt})`, `b${bAttempt}`)
+        if (bAttempt === 1 + MAX_WILLINGNESS_NUDGES) {
+          router.__testing!.injectContinuationReminder(KEY, 'continue your work')
+        }
+        return
+      }
+      if (bAttempt === 2 + MAX_WILLINGNESS_NUDGES) {
+        router.__testing!.enqueueUserInbound(
+          KEY,
+          inbound({ text: 'and how do i actually fix it now?', externalMessageId: 'c1' }),
+        )
+        sessions[0]!.setAssistantText('')
+        return
+      }
+      // turn C (the superseding fresh batch) — a question that replies
+      sessions[0]!.setAssistantText('C')
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: 'here you go' })
+    }
+    await router.route(inbound({ text: 'please go ahead and reserve the room.', externalMessageId: 'b1' }))
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: the staged fallback never posted (C superseded it) AND C did not escalate —
+    // A's stale signal was cleared when the fresh batch superseded the staged turn.
+    // Without the supersession clear, C inherits A's dominant question signal and
+    // mode-3 escalates to xhigh.
+    expect(sent).not.toContain(EMPTY_TURN_FALLBACK_TEXT)
+    expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
   })
 
   test('retries once after a continue:true progress reply and suppresses the warning when the final reply succeeds', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1085,6 +1085,26 @@ type LiveSession = {
   // question escalation. Compared by `turnSeq` so a stale value can't leak across
   // turns.
   emptyTurnFallbackTurn: number | null
+  // Set when a WILLINGNESS-ACK exhaustion path (empty_stop_after_continue_reply /
+  // empty_stop_after_send_ack) would post EMPTY_TURN_FALLBACK_TEXT, but the model
+  // just made a machine-readable promise to keep working (`continue: true` /
+  // willingness phrase) and did post-ack tool work. Rather than posting the scary
+  // "I got stuck" notice synchronously at validateChannelTurn — BEFORE the drain
+  // loop runs maybeContinueTodosChannel, which can re-prompt the same logical turn
+  // and land the real answer seconds later (the observed production false alarm) —
+  // the cause is STAGED here and resolved after that continuation gets its chance:
+  // discarded if a genuine reply lands or a continuation is queued, posted exactly
+  // once if the turn genuinely stranded. Only the two willingness branches stage;
+  // every other fallback path posts immediately as before (they carry no
+  // continue-promise). Persists across reminder-only iterations (reset only on a
+  // fresh user batch, beside the willingness/retry budgets) so a stage in one
+  // iteration survives to the resolution after the next. `sendCountAtStage` is
+  // `successfulChannelSends` at stage time — the resolver treats ONLY a send PAST
+  // this baseline as a genuine recovery reply, because the willingness-ack that
+  // triggered staging already bumped the turn-start count (the empty stop follows
+  // a progress ack by definition), so a turn-start baseline would always read as
+  // "already replied" and wrongly discard the fallback.
+  stagedFallbackCause: { cause: string; sendCountAtStage: number } | null
   // Stamped with `turnSeq` when a formal GitHub review (APPROVE / REQUEST_CHANGES /
   // COMMENT) lands during this LOGICAL turn, via noteGithubReviewOutput off the
   // review-output observer. On a github PR channel the agent's real deliverable is
@@ -1464,6 +1484,17 @@ export type ChannelRouter = {
           lastTurnAuthorIds: readonly string[]
         }
       | undefined
+    // Pushes a reminder onto the live session's `pendingSystemReminders`, the same
+    // seam `runIdleContinuation`'s `deliver` callback uses when the todo/idle
+    // continuation fires. Lets a test reproduce the production self-recovery race
+    // (a continuation re-prompt queued after a willingness-ack strand) at the
+    // channels layer, without coupling to todo-file persistence formats.
+    injectContinuationReminder: (key: ChannelKey, text: string) => void
+    // Enqueues a real user batch onto the live session's promptQueue via the same
+    // `enqueue` path route() uses, letting a test reproduce a fresh inbound that
+    // supersedes a still-pending staged fallback mid-drain (the A → staged B →
+    // queued C question-signal supersession case) without the debounce timing dance.
+    enqueueUserInbound: (key: ChannelKey, event: InboundMessage) => void
     // Returns a shallow copy of `live.originRef.current` for the live
     // session matching `key`, or undefined when no live session exists.
     // Exists so tests can assert on the per-turn origin that tool.before
@@ -1505,6 +1536,14 @@ export type CreateChannelRouterOptions = {
   // decision. Defaults to a stat()-based reader returning 0 for a missing or
   // unreadable file (grace then fails closed to roll-over-at-soft-TTL).
   measureTranscriptBytes?: (path: string) => number
+  // Test seam: the idle/todo continuation driver, invoked from
+  // maybeContinueTodosChannel AFTER validateChannelTurn. Defaults to the real
+  // runIdleContinuation. Injecting it lets a test deliver the continuation at the
+  // exact production phase (post-validation) so the drain-loop ordering —
+  // resolveStagedFallback runs AFTER this delivery — is actually asserted, rather
+  // than pre-seeding pendingSystemReminders from onPrompt (which would pass even if
+  // the resolver moved ahead of the continuation).
+  runIdleContinuation?: typeof runIdleContinuation
   // Test seam: override the ensureLive watchdog ceiling so the timeout path
   // is exercisable in <100ms instead of the 30s production default.
   ensureLiveTimeoutMs?: number
@@ -2227,6 +2266,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         skipLockedSendTurn: null,
         disengagedTurn: null,
         emptyTurnFallbackTurn: null,
+        stagedFallbackCause: null,
         githubReviewOutputTurn: null,
         pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
@@ -2733,7 +2773,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live.destroyed) return
     if (live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) return
     try {
-      await runIdleContinuation({
+      await (options.runIdleContinuation ?? runIdleContinuation)({
         agentDir: options.agentDir,
         origin: buildLiveOrigin(live),
         deliver: (text) => {
@@ -2743,6 +2783,69 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     } catch (err) {
       logger.warn(`[channels] ${live.keyId}: todo continuation failed: ${describe(err)}`)
     }
+  }
+
+  const postEmptyTurnFallback = async (live: LiveSession, cause: string): Promise<void> => {
+    logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)
+    live.emptyTurnFallbackTurn = live.turnSeq
+    const result = await send(
+      {
+        adapter: live.key.adapter,
+        workspace: live.key.workspace,
+        chat: live.key.chat,
+        thread: live.key.thread,
+        text: EMPTY_TURN_FALLBACK_TEXT,
+      },
+      { source: 'system' },
+    )
+    if (!result.ok) {
+      logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
+    }
+  }
+
+  // Resolve a fallback STAGED by a willingness-ack exhaustion path, run AFTER
+  // maybeContinueTodosChannel so the idle/todo continuation has already had its
+  // chance to queue a re-prompt (the mechanism that self-recovers the promised
+  // work). Three outcomes, in precedence order:
+  //   1. A genuine reply landed this logical turn (successfulChannelSends moved
+  //      past the turn-start baseline; the staged path never posts, so any bump
+  //      is real prose) → the model self-recovered, discard the stage silently.
+  //   2. A re-prompt is queued (pendingSystemReminders from the continuation, or a
+  //      fresh user inbound in promptQueue) → recovery is still in flight or a new
+  //      turn supersedes; carry the stage forward to the next resolution (or let
+  //      the fresh turn's reset clear it) — do NOT post yet.
+  //   3. Neither → the turn genuinely stranded with nothing following it; post the
+  //      visible fallback exactly once. This preserves the never-strand-on-silence
+  //      invariant for the true-stuck case while killing the production false alarm
+  //      where the continuation landed the real answer seconds after the stage.
+  const resolveStagedFallback = async (live: LiveSession): Promise<void> => {
+    const staged = live.stagedFallbackCause
+    if (staged === null) return
+    if (live.successfulChannelSends > staged.sendCountAtStage) {
+      logger.info(`[channels] ${live.keyId} empty_turn_fallback_discarded cause=${staged.cause} reason=reply_landed`)
+      live.stagedFallbackCause = null
+      // Recovery genuinely answered the user, so the logical turn ends as a usable
+      // reply — commit the question signal the try-block deferred while staged.
+      if (live.pendingUserTurnSignal !== null) {
+        live.lastQuestionSignal = live.pendingUserTurnSignal.signal
+        live.pendingUserTurnSignal = null
+      }
+      return
+    }
+    if (live.promptQueue.length > 0 || live.pendingSystemReminders.length > 0) {
+      // A re-prompt is still queued: keep both the stage and the pending signal for
+      // the next resolution — the turn hasn't finished.
+      logger.info(
+        `[channels] ${live.keyId} empty_turn_fallback_deferred cause=${staged.cause} reason=continuation_queued`,
+      )
+      return
+    }
+    live.stagedFallbackCause = null
+    // The fallback IS the turn's terminal (non-usable) output — clear both signals
+    // so an older question can't leak the xhigh escalation across this failed turn.
+    live.pendingUserTurnSignal = null
+    live.lastQuestionSignal = null
+    await postEmptyTurnFallback(live, staged.cause)
   }
 
   const fireSessionTurnStart = async (live: LiveSession, userPrompt: string): Promise<{ results: string }> => {
@@ -2965,6 +3068,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.toolLeakRetries = 0
           live.emptyStopAfterToolWorkArmed = false
           live.willingnessNudges = 0
+          // A fresh batch supersedes a still-pending staged fallback. That staged
+          // turn produced no usable reply, so it must not leave the PRIOR turn's
+          // committed lastQuestionSignal behind — otherwise the new question would
+          // inherit an xhigh escalation across the superseded (failed) turn. Clear
+          // the stale signal only when a stage was actually pending; a normal prior
+          // turn's legitimately-committed signal is left intact.
+          if (live.stagedFallbackCause !== null) {
+            live.lastQuestionSignal = null
+            live.stagedFallbackCause = null
+          }
           live.abortReasonThisTurn = null
           live.nextPromptMaxTokens = undefined
           // Cleared with the retry budgets (NOT beside resetReviewTurn below) so a
@@ -3090,7 +3203,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           const fallbackPostedThisTurn = live.emptyTurnFallbackTurn === live.turnSeq
           const sentReplyThisTurn = live.successfulChannelSends > successfulSendsBeforePrompt
           const usableReplyThisTurn = sentReplyThisTurn && !fallbackPostedThisTurn && !providerErrorThisTurn
-          if (live.pendingUserTurnSignal !== null && !retryQueuedThisTurn) {
+          // A staged (not-yet-posted) willingness fallback keeps the logical turn
+          // OPEN, exactly like a queued retry: the progress ack that triggered
+          // staging would otherwise read as `usableReplyThisTurn` and commit the
+          // question signal, so a fallback turn would leak the `xhigh` escalation it
+          // is meant to suppress. Leave the pending signal untouched here;
+          // resolveStagedFallback finalizes it (commit on genuine recovery, clear on
+          // fallback-post) once the continuation has run.
+          if (live.pendingUserTurnSignal !== null && !retryQueuedThisTurn && live.stagedFallbackCause === null) {
             live.lastQuestionSignal = usableReplyThisTurn ? live.pendingUserTurnSignal.signal : null
             live.pendingUserTurnSignal = null
           }
@@ -3165,6 +3285,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         await fireSessionIdle(live)
         await recordTodoTurnStart(live, isRealUserTurn)
         await maybeContinueTodosChannel(live)
+        await resolveStagedFallback(live)
         live.lastTurnAuthorIds = new Set(live.currentTurnAuthorIds)
         if (live.currentTurnAuthorId !== null) {
           live.lastTurnAuthorId = live.currentTurnAuthorId
@@ -4531,22 +4652,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.skippedTurn = null
       logger.info(`[channels] ${live.keyId} skip_contested_by_send recovering reply`)
     }
-    const postEmptyTurnFallback = async (cause: string): Promise<void> => {
-      logger.warn(`[channels] ${live.keyId} empty_turn_fallback cause=${cause}`)
-      live.emptyTurnFallbackTurn = live.turnSeq
-      const result = await send(
-        {
-          adapter: live.key.adapter,
-          workspace: live.key.workspace,
-          chat: live.key.chat,
-          thread: live.key.thread,
-          text: EMPTY_TURN_FALLBACK_TEXT,
-        },
-        { source: 'system' },
-      )
-      if (!result.ok) {
-        logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
-      }
+    const stageEmptyTurnFallback = (cause: string): void => {
+      logger.warn(`[channels] ${live.keyId} empty_turn_fallback_staged cause=${cause}`)
+      live.stagedFallbackCause = { cause, sendCountAtStage: live.successfulChannelSends }
     }
 
     // A formal GitHub review already landed this logical turn (APPROVE /
@@ -4637,7 +4745,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           )
           live.pendingSystemReminders.push(SEND_WILLINGNESS_NUDGE)
         } else {
-          await postEmptyTurnFallback('empty_stop_after_continue_reply_nudges_exhausted')
+          stageEmptyTurnFallback('empty_stop_after_continue_reply_nudges_exhausted')
         }
         return
       }
@@ -4673,7 +4781,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           )
           live.pendingSystemReminders.push(SEND_WILLINGNESS_NUDGE)
         } else {
-          await postEmptyTurnFallback('empty_stop_after_send_ack_nudges_exhausted')
+          stageEmptyTurnFallback('empty_stop_after_send_ack_nudges_exhausted')
         }
         return
       }
@@ -4710,7 +4818,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             )
             live.pendingSystemReminders.push(STRANDED_TOOLUSE_CONTINUATION_NUDGE)
           } else {
-            await postEmptyTurnFallback('stranded_toolUse_retries_exhausted')
+            await postEmptyTurnFallback(live, 'stranded_toolUse_retries_exhausted')
           }
         }
         return
@@ -4826,7 +4934,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         live.pendingSystemReminders.push(EMPTY_TURN_RETRY_NUDGE)
         return
       }
-      await postEmptyTurnFallback(attemptedSendThisTurn ? 'send_thrash' : 'retries_exhausted')
+      await postEmptyTurnFallback(live, attemptedSendThisTurn ? 'send_thrash' : 'retries_exhausted')
       return
     }
 
@@ -4861,7 +4969,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.pendingSystemReminders.push(COLD_START_REPLY_NUDGE)
           return
         }
-        await postEmptyTurnFallback('cold_start_solo_bare_empty_retries_exhausted')
+        await postEmptyTurnFallback(live, 'cold_start_solo_bare_empty_retries_exhausted')
         return
       }
       // Deliberately AFTER the cold-start guard (that path has its own nudge). A
@@ -4897,7 +5005,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           live.pendingSystemReminders.push(EMPTY_STOP_AFTER_TOOL_WORK_NUDGE)
           return
         }
-        await postEmptyTurnFallback('empty_stop_after_tool_work_retries_exhausted')
+        await postEmptyTurnFallback(live, 'empty_stop_after_tool_work_retries_exhausted')
         return
       }
       const leakedReasoning = !isNoReplySignal(assistantText)
@@ -5953,6 +6061,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           lastTurnAuthorId: live.lastTurnAuthorId,
           lastTurnAuthorIds: Array.from(live.lastTurnAuthorIds),
         }
+      },
+      injectContinuationReminder: (key: ChannelKey, text: string): void => {
+        const live = liveSessions.get(channelKeyId(key))
+        if (!live) return
+        live.pendingSystemReminders.push(text)
+      },
+      enqueueUserInbound: (key: ChannelKey, event: InboundMessage): void => {
+        const live = liveSessions.get(channelKeyId(key))
+        if (!live) return
+        enqueue(live, event, null)
       },
     },
   }


### PR DESCRIPTION
## Background

The channel router's empty-turn recovery posts `EMPTY_TURN_FALLBACK_TEXT` — "⚠️ I got stuck putting together a reply and couldn't finish. Could you rephrase or try again?" — when a turn degenerates to an empty completion and retries are exhausted. Two of its branches key on a **willingness ack**: the model sent a `channel_reply({ continue: true })` progress reply (or a natural-language willingness phrase), did post-ack tool work, then ended on a fresh empty `stop` leaf (the Kimi/Fireworks empty-completion flake).

Observed in production (a Discord channel booking a meeting room):

```
send_willingness_nudge attempt=1/1 cause=empty_stop_after_continue_reply
empty_turn_fallback  cause=empty_stop_after_continue_reply_nudges_exhausted
```

- `05:55:55` agent: "checking A-series rooms now, I'll tell you when done" (`continue: true` ack landed)
- `05:55:59` **⚠️ "I got stuck… rephrase?" posted** (nudge exhausted → fallback)
- `05:56:18` agent: "Booked Space A1 15:00–17:00" (the **real answer**, 19s later)

The `continue: true` flag is the strongest possible "self-recovery in progress" signal, yet the fallback fired one nudge later. The root cause is a **drain-loop ordering defect**: `validateChannelTurn` posts the fallback *before* `maybeContinueTodosChannel` runs — and that continuation re-prompts the same logical turn and lands the real answer moments later. The user sees a scary system-failure notice immediately followed by success. A false alarm.

## Summary

- Add `LiveSession.stagedFallbackCause`. On the two willingness-ack exhaustion branches (`empty_stop_after_continue_reply`, `empty_stop_after_send_ack`), **stage** the fallback (`empty_turn_fallback_staged`) instead of posting it.
- Add `resolveStagedFallback(live)`, run in the drain loop **after** `maybeContinueTodosChannel` so the idle/todo continuation has already had its chance to queue a re-prompt. Three outcomes, in precedence order:
  1. **A genuine reply landed** → discard silently (`empty_turn_fallback_discarded reason=reply_landed`). Tracked against the send count **at stage time**, not turn-start — the willingness ack already bumped the turn-start count, so a turn-start baseline would always read as "already replied" and wrongly discard.
  2. **A re-prompt is queued** (continuation reminder or a fresh inbound) → defer (`empty_turn_fallback_deferred reason=continuation_queued`); carry the stage forward.
  3. **Neither** → the turn genuinely stranded → post the visible fallback exactly once (preserves the never-strand-on-silence invariant).
- `stagedFallbackCause` persists across reminder-only iterations and resets only on a fresh user batch (beside the willingness/retry budgets).
- Hoist `postEmptyTurnFallback` to the router-closure scope (took `live` as a param) so both the immediate-post paths and the resolver can call it.

## What this does NOT do

- Does **not** change any other fallback path. Stranded-toolUse, cold-start-solo, empty-stop-after-tool-work, send-thrash, and retries-exhausted still post immediately as before — they carry no continue-promise.
- Does **not** change the provider-error, skip-locked, or GitHub-review-suppression paths.
- Does **not** raise `MAX_WILLINGNESS_NUDGES` or add any wall-clock debounce (a timer would guess how long recovery takes and still fail past the timeout).
- Does **not** touch the fallback text.

## Review notes

Load-bearing ordering: `resolveStagedFallback` MUST run after `maybeContinueTodosChannel` — moving it before would recreate the exact false alarm this fixes. The `sendCountAtStage` baseline (not turn-start) is the subtle bit; it's documented at the field declaration.

New regression tests (`router.test.ts`):
- **self-recovery discards the staged fallback** — the production sequence: ack → tool work → empty stop → nudge exhausted → continuation re-prompt lands the answer. Asserts `EMPTY_TURN_FALLBACK_TEXT` is never sent and the discard is logged.
- **no continuation → posts once** — the genuine-strand invariant; asserts a single visible post.
- **continuation also strands → deferred then posts once** — asserts the deferred fallback resolves to exactly one post.

Tests reproduce the continuation via a minimal `__testing.injectContinuationReminder` seam (the same `pendingSystemReminders` push `runIdleContinuation`'s `deliver` uses), keeping the test at the channels layer without coupling to todo-file persistence formats. Non-English (Korean) input is asserted per the repo's multi-language testing rule.

`bun run typecheck`, `bun run lint` (0 errors), `bun run format:check`, and the full `bun run test` (12023 pass, 0 fail) all pass on this branch.