### PR TITLE
Rename channel_reply `continue` param to `more_work_this_turn`

### DIFF
--- a/src/agent/session-origin.test.ts
+++ b/src/agent/session-origin.test.ts
@@ -467,7 +467,7 @@ describe('renderSessionOrigin', () => {
       chat: 'C0',
       thread: '1700000000.000100',
     })
-    expect(out).toContain('channel_reply({ text })')
+    expect(out).toContain('channel_reply({ text, more_work_this_turn })')
     expect(out).toContain("don't")
     expect(out).toMatch(/post somewhere else/i)
     const replyIdx = out.indexOf('`channel_reply`')

--- a/src/agent/session-origin.ts
+++ b/src/agent/session-origin.ts
@@ -486,15 +486,17 @@ function renderChannelOrigin(
     ...(origin.adapter === 'github'
       ? [
           'tool call, keep working and post the answer with a single final',
-          '`channel_reply`. Do not post an "On it" ack comment first — the runtime',
+          '`channel_reply({ text, more_work_this_turn: false })`.',
+          'Do not post an "On it" ack comment first — the runtime',
           'already added an :eyes: reaction; use `channel_react` for explicit ack.',
         ]
       : [
           'tool call, send a one-line ack first via `channel_reply({ text: "On it.",',
-          'continue: true })`, keep working, then send the answer with a final',
-          '`channel_reply`. The ack is not your reply; the answer is. Once the answer',
-          'lands, end your turn. `continue: true` is mandatory or the turn ends at',
-          'the ack and drops the fetch/subagent/actual answer.',
+          'more_work_this_turn: true })`, keep working, then send the answer with a',
+          'final `channel_reply({ text, more_work_this_turn: false })`.',
+          'The ack is not your reply; the answer is. Once the answer lands, end your turn.',
+          '`more_work_this_turn: true` is mandatory on the ack or the turn ends there',
+          'and drops the fetch/subagent/actual answer.',
         ]),
     '',
     '**Backgrounded work does not end the obligation.** If you spawn a',
@@ -508,7 +510,7 @@ function renderChannelOrigin(
     '',
     'Do not send a second reply just to rephrase, restate, or "confirm" what you already said.',
     '',
-    'To reply here, call `channel_reply({ text })`. Addressing (including the',
+    'To reply here, call `channel_reply({ text, more_work_this_turn })`. Addressing (including the',
     `thread${origin.thread !== null ? '' : ' — none here, this is a channel-root session'}) is filled in; you don't need`,
     'to copy these fields:',
     '',

--- a/src/agent/tools/channel-reply.false-receipt.test.ts
+++ b/src/agent/tools/channel-reply.false-receipt.test.ts
@@ -86,7 +86,7 @@ const prOrigin: ChannelReplyOrigin = { adapter: 'github', workspace: WS, chat: '
 type ChannelReplyParams = {
   text?: string
   attachments?: { path: string; filename?: string }[]
-  continue: boolean
+  more_work_this_turn: boolean
   resolve_review_thread?: boolean
 }
 
@@ -98,11 +98,17 @@ function tool(onSend?: (msg: OutboundMessage) => SendResult, origin: ChannelRepl
 
 async function run(
   t: ReturnType<typeof createChannelReplyTool>,
-  params: Omit<ChannelReplyParams, 'continue'> & {
-    continue?: boolean
+  params: Omit<ChannelReplyParams, 'more_work_this_turn'> & {
+    more_work_this_turn?: boolean
   },
 ) {
-  return t.execute('id', { ...params, continue: params.continue ?? false }, undefined, undefined, fakeCtx)
+  return t.execute(
+    'id',
+    { ...params, more_work_this_turn: params.more_work_this_turn ?? false },
+    undefined,
+    undefined,
+    fakeCtx,
+  )
 }
 
 describe('channel_reply false-receipt guard', () => {

--- a/src/agent/tools/channel-reply.test.ts
+++ b/src/agent/tools/channel-reply.test.ts
@@ -106,21 +106,27 @@ const slackChannelRootOrigin: ChannelReplyOrigin = {
 type ChannelReplyParams = {
   text?: string
   attachments?: { path: string; filename?: string }[]
-  continue: boolean
+  more_work_this_turn: boolean
   resolve_review_thread?: boolean
 }
 
 const fakeCtx = {} as Parameters<ReturnType<typeof createChannelReplyTool>['execute']>[4]
 
-// `continue` is schema-required; this helper defaults it to `false` (terminal) so
-// tests not exercising the continue path stay terse. Keep the divergence.
+// `more_work_this_turn` is schema-required; this helper defaults it to `false` (terminal) so
+// tests not exercising the more_work_this_turn path stay terse. Keep the divergence.
 async function runTool(
   tool: ReturnType<typeof createChannelReplyTool>,
-  params: Omit<ChannelReplyParams, 'continue'> & {
-    continue?: boolean
+  params: Omit<ChannelReplyParams, 'more_work_this_turn'> & {
+    more_work_this_turn?: boolean
   },
 ) {
-  return tool.execute('id', { ...params, continue: params.continue ?? false }, undefined, undefined, fakeCtx)
+  return tool.execute(
+    'id',
+    { ...params, more_work_this_turn: params.more_work_this_turn ?? false },
+    undefined,
+    undefined,
+    fakeCtx,
+  )
 }
 
 describe('createChannelReplyTool', () => {
@@ -172,13 +178,13 @@ describe('createChannelReplyTool', () => {
     expect(result.details).toMatchObject({ ok: true })
   })
 
-  test('combines continue with messageId when a mid-turn ack carries an id', async () => {
+  test('combines more_work_this_turn with messageId when a mid-turn ack carries an id', async () => {
     const tool = createChannelReplyTool({
       router: fakeRouter(async () => ({ ok: true, messageId: 'ts9', messageIds: ['ts9'] })),
       origin: slackThreadOrigin,
     })
-    const result = await runTool(tool, { text: 'working on it', continue: true })
-    expect(result.details).toEqual({ ok: true, continue: true, messageId: 'ts9', messageIds: ['ts9'] })
+    const result = await runTool(tool, { text: 'working on it', more_work_this_turn: true })
+    expect(result.details).toEqual({ ok: true, more_work_this_turn: true, messageId: 'ts9', messageIds: ['ts9'] })
   })
 
   test('passes thread=null verbatim when origin is a channel-root session', async () => {
@@ -428,17 +434,17 @@ describe('createChannelReplyTool', () => {
     expect(tool.description).toContain('default way to respond')
   })
 
-  describe('continue flag (mid-turn status reply)', () => {
-    test('surfaces continue: true in details so the router keeps the turn alive', async () => {
+  describe('more_work_this_turn flag (mid-turn status reply)', () => {
+    test('surfaces more_work_this_turn: true in details so the router keeps the turn alive', async () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: true })),
         origin: slackThreadOrigin,
       })
-      const result = await runTool(tool, { text: 'working on it…', continue: true })
-      expect(result.details).toEqual({ ok: true, continue: true })
+      const result = await runTool(tool, { text: 'working on it…', more_work_this_turn: true })
+      expect(result.details).toEqual({ ok: true, more_work_this_turn: true })
     })
 
-    test('omits continue from details by default so the reply stays terminal', async () => {
+    test('omits more_work_this_turn from details by default so the reply stays terminal', async () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: true })),
         origin: slackThreadOrigin,
@@ -447,30 +453,30 @@ describe('createChannelReplyTool', () => {
       expect(result.details).toEqual({ ok: true })
     })
 
-    test('continue: false stays terminal (only true keeps the turn alive)', async () => {
+    test('more_work_this_turn: false stays terminal (only true keeps the turn alive)', async () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: true })),
         origin: slackThreadOrigin,
       })
-      const result = await runTool(tool, { text: 'done', continue: false })
+      const result = await runTool(tool, { text: 'done', more_work_this_turn: false })
       expect(result.details).toEqual({ ok: true })
     })
 
-    test('a denied reply never carries continue (no turn to keep alive)', async () => {
+    test('a denied reply never carries more_work_this_turn (no turn to keep alive)', async () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: false, error: 'denied by allow rules' })),
         origin: slackThreadOrigin,
       })
-      const result = await runTool(tool, { text: 'nope', continue: true })
+      const result = await runTool(tool, { text: 'nope', more_work_this_turn: true })
       expect(result.details).toEqual({ ok: false, error: 'denied by allow rules' })
     })
 
-    test('continue is the one required parameter (so the schema rejects a reply that omits it)', () => {
+    test('more_work_this_turn is the one required parameter (so the schema rejects a reply that omits it)', () => {
       const tool = createChannelReplyTool({
         router: fakeRouter(async () => ({ ok: true })),
         origin: slackThreadOrigin,
       })
-      expect((tool.parameters as { required?: readonly string[] }).required).toEqual(['continue'])
+      expect((tool.parameters as { required?: readonly string[] }).required).toEqual(['more_work_this_turn'])
     })
   })
 
@@ -969,7 +975,7 @@ describe('channel_reply resolve_review_thread required-choice enforcement', () =
     expect(result.details).toEqual({ ok: true })
   })
 
-  test('exempts a mid-turn status reply (continue:true) from the required choice', async () => {
+  test('exempts a mid-turn status reply (more_work_this_turn:true) from the required choice', async () => {
     const calls: OutboundMessage[] = []
     const tool = createChannelReplyTool({
       router: fakeRouter(async (msg) => {
@@ -979,10 +985,10 @@ describe('channel_reply resolve_review_thread required-choice enforcement', () =
       origin: githubThreadOrigin,
     })
 
-    const result = await runTool(tool, { text: 'On it — checking the diff now.', continue: true })
+    const result = await runTool(tool, { text: 'On it — checking the diff now.', more_work_this_turn: true })
 
     expect(calls).toHaveLength(1)
-    expect(result.details).toEqual({ ok: true, continue: true })
+    expect(result.details).toEqual({ ok: true, more_work_this_turn: true })
   })
 
   test('exempts an attachments-only github review-thread reply (no text to acknowledge)', async () => {

--- a/src/agent/tools/channel-reply.ts
+++ b/src/agent/tools/channel-reply.ts
@@ -83,17 +83,17 @@ export function createChannelReplyTool({
           },
         ),
       ),
-      continue: Type.Boolean({
+      more_work_this_turn: Type.Boolean({
         description:
-          'REQUIRED on every channel_reply — you must explicitly choose, there is no default. Set `true` when this reply is a mid-turn status update (e.g. "working on it…") and you still have work to do THIS turn — fetching data, running a tool, spawning a subagent, then replying again; `true` keeps the turn alive so that follow-up actually runs. ' +
+          'REQUIRED on every channel_reply — you must explicitly choose, there is no default. Set `true` when this reply is a mid-turn status update (e.g. "working on it…") and you still have MORE WORK to do THIS turn — fetching data, running a tool, spawning a subagent, then replying again; `true` keeps the turn alive so that follow-up actually runs. ' +
           'Set `false` when this reply is your final message for the turn (the common case). ' +
-          'This choice is mandatory precisely because a missing value used to default to ending the turn silently: a successful reply ends the turn unless `continue` is `true`, so a `false` on an ack you meant to keep working from drops the work you promised. ' +
+          'This choice is mandatory precisely because a missing value used to default to ending the turn silently: a successful reply ends the turn unless `more_work_this_turn` is `true`, so a `false` on an ack you meant to keep working from drops the work you promised. ' +
           'Do not set `true` just to seem responsive; only when genuine multi-step work follows in the same turn.',
       }),
       resolve_review_thread: Type.Optional(
         Type.Boolean({
           description:
-            'GitHub PR review threads ONLY. On a TERMINAL (`continue:false`) github PR review-thread reply that carries `text`, this is REQUIRED: you must set it to `true` or `false` and omitting it is rejected — you will be told to re-call with an explicit choice. (It stays a normal optional field everywhere else: ignored on Slack/Discord/Telegram/KakaoTalk and any non-github session, on github replies outside a review thread, on attachments-only replies, and on mid-turn `continue:true` status updates — leave it unset there.) ' +
+            'GitHub PR review threads ONLY. On a TERMINAL (`more_work_this_turn:false`) github PR review-thread reply that carries `text`, this is REQUIRED: you must set it to `true` or `false` and omitting it is rejected — you will be told to re-call with an explicit choice. (It stays a normal optional field everywhere else: ignored on Slack/Discord/Telegram/KakaoTalk and any non-github session, on github replies outside a review thread, on attachments-only replies, and on mid-turn `more_work_this_turn:true` status updates — leave it unset there.) ' +
             'Set `true` when your `text` acknowledges the concern is fixed/verified/addressed (e.g. "verified at <sha>", "thanks, that resolves it"): the runtime resolves the thread BEFORE posting, so the close-out actually happens in this same turn — a successful reply ends the turn, so a resolve deferred to "later" never runs. ' +
             "Set `false` when the thread should stay open (partial fix, disagreement, mid-discussion). It is safe to set `true` by default: the runtime resolves ONLY if the thread's root comment is yours — it refuses (and blocks the reply) on a human reviewer's thread, so you never close someone else's open question. You need not pre-check authorship; let the runtime enforce ownership.",
         }),
@@ -103,7 +103,7 @@ export function createChannelReplyTool({
     async execute(_toolCallId, params) {
       let text = params.text
       const attachments = params.attachments
-      const keepTurnAlive = params.continue === true
+      const keepTurnAlive = params.more_work_this_turn === true
       if ((text === undefined || text === '') && (attachments === undefined || attachments.length === 0)) {
         logger.warn(formatChannelToolFailure('channel_reply', 'missing text and attachments'))
         return {
@@ -164,7 +164,7 @@ export function createChannelReplyTool({
       const missingResolveChoice = missingReviewThreadResolveChoiceError({
         origin,
         text,
-        isContinue: keepTurnAlive,
+        moreWorkThisTurn: keepTurnAlive,
         resolveReviewThread: params.resolve_review_thread,
       })
       if (missingResolveChoice) {
@@ -185,7 +185,7 @@ export function createChannelReplyTool({
         chat: origin.chat,
         thread: origin.thread,
         text,
-        isContinue: keepTurnAlive,
+        moreWorkThisTurn: keepTurnAlive,
         resolveReviewThread: params.resolve_review_thread === true,
       })
       if (falseReceipt.kind === 'block') {
@@ -208,7 +208,7 @@ export function createChannelReplyTool({
         thread: origin.thread,
         text,
         wantsResolve: params.resolve_review_thread === true,
-        isContinue: keepTurnAlive,
+        moreWorkThisTurn: keepTurnAlive,
         getReviewState: (req) => router.getReviewState(req),
       })
       if (rereview.block) {
@@ -259,19 +259,19 @@ export function createChannelReplyTool({
           ),
         )
       }
-      // `continue` is read by the router's terminal hook (installChannelReplyTerminalHook),
+      // `more_work_this_turn` is read by the router's terminal hook (installChannelReplyTerminalHook),
       // not by this tool — it suppresses the post-reply abort so a multi-step turn
       // keeps going. Success-only: a denied reply never ran, so there is no turn to keep.
       const details: {
         ok: boolean
         error?: string
-        continue?: boolean
+        more_work_this_turn?: boolean
         messageId?: string
         messageIds?: readonly string[]
       } = result.ok
         ? {
             ok: true,
-            ...(keepTurnAlive ? { continue: true } : {}),
+            ...(keepTurnAlive ? { more_work_this_turn: true } : {}),
             ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
             ...(result.messageIds !== undefined ? { messageIds: result.messageIds } : {}),
           }
@@ -329,13 +329,13 @@ export function createChannelReplyTool({
 function missingReviewThreadResolveChoiceError(input: {
   origin: ChannelReplyOrigin
   text: string | undefined
-  isContinue: boolean
+  moreWorkThisTurn: boolean
   resolveReviewThread: boolean | undefined
 }): string {
   const isGithubPrReviewThread =
     input.origin.adapter === 'github' && /^pr:\d+$/.test(input.origin.chat) && input.origin.thread !== null
   const hasText = input.text !== undefined && input.text.trim() !== ''
-  if (!isGithubPrReviewThread || !hasText || input.isContinue || input.resolveReviewThread !== undefined) {
+  if (!isGithubPrReviewThread || !hasText || input.moreWorkThisTurn || input.resolveReviewThread !== undefined) {
     return ''
   }
   return (

--- a/src/agent/tools/channel-send.ts
+++ b/src/agent/tools/channel-send.ts
@@ -185,7 +185,7 @@ export function createChannelSendTool({
       // via channel_send, and the model kept acknowledging "addressed" without
       // the flag, stranding the thread — channel_reply forced the choice but
       // channel_send did not, so the most-used resolve path was the least
-      // guarded. A send is always terminal, so there is no continue exemption.
+      // guarded. A send is always terminal, so there is no more-work exemption.
       const missingResolveChoice = missingReviewThreadResolveChoiceError({
         adapter,
         chat: params.chat,
@@ -209,7 +209,7 @@ export function createChannelSendTool({
         chat: params.chat,
         thread: params.thread ?? null,
         text: bodyText,
-        isContinue: false,
+        moreWorkThisTurn: false,
         resolveReviewThread: wantsResolve,
       })
       if (falseReceipt.kind === 'block') {
@@ -231,7 +231,7 @@ export function createChannelSendTool({
         thread: params.thread ?? null,
         text: bodyText,
         wantsResolve,
-        isContinue: false,
+        moreWorkThisTurn: false,
         getReviewState: (req) => router.getReviewState(req),
       })
       if (rereview.block) {

--- a/src/agent/tools/channel-tool-logging.test.ts
+++ b/src/agent/tools/channel-tool-logging.test.ts
@@ -183,21 +183,21 @@ describe('channel_reply failure logging', () => {
       origin,
       logger,
     })
-    await tool.execute('id', { text: 'hi', continue: false }, undefined, undefined, fakeCtx)
+    await tool.execute('id', { text: 'hi', more_work_this_turn: false }, undefined, undefined, fakeCtx)
     expect(logger.warnings).toEqual(['[channels] channel_reply failed: slack-bot:T0/C0: channel_not_found'])
   })
 
   test('logs early validation when text and attachments are both missing', async () => {
     const logger = captureLogger()
     const tool = createChannelReplyTool({ router: fakeRouter(), origin, logger })
-    await tool.execute('id', { continue: false }, undefined, undefined, fakeCtx)
+    await tool.execute('id', { more_work_this_turn: false }, undefined, undefined, fakeCtx)
     expect(logger.warnings).toEqual(['[channels] channel_reply failed: missing text and attachments'])
   })
 
   test('does NOT log on a successful reply', async () => {
     const logger = captureLogger()
     const tool = createChannelReplyTool({ router: fakeRouter({ send: async () => ({ ok: true }) }), origin, logger })
-    await tool.execute('id', { text: 'ok', continue: false }, undefined, undefined, fakeCtx)
+    await tool.execute('id', { text: 'ok', more_work_this_turn: false }, undefined, undefined, fakeCtx)
     expect(logger.warnings).toEqual([])
   })
 })

--- a/src/channels/adapters/github/line-comment-thread.test.ts
+++ b/src/channels/adapters/github/line-comment-thread.test.ts
@@ -186,7 +186,7 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
 
     const result = await tool.execute(
       'id',
-      { text: 'sure, here is the rationale', continue: false, resolve_review_thread: false },
+      { text: 'sure, here is the rationale', more_work_this_turn: false, resolve_review_thread: false },
       undefined,
       undefined,
       fakeCtx,
@@ -232,7 +232,7 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
     })
     await tool.execute(
       'id',
-      { text: 'got it', continue: false, resolve_review_thread: false },
+      { text: 'got it', more_work_this_turn: false, resolve_review_thread: false },
       undefined,
       undefined,
       fakeCtx,
@@ -270,7 +270,7 @@ describe('PR line comment → channel_reply → /pulls/{N}/comments/{T}/replies'
     })
     await tool.execute(
       'id',
-      { text: 'reply', continue: false, resolve_review_thread: false },
+      { text: 'reply', more_work_this_turn: false, resolve_review_thread: false },
       undefined,
       undefined,
       fakeCtx,

--- a/src/channels/continuation-willingness.ts
+++ b/src/channels/continuation-willingness.ts
@@ -1,7 +1,7 @@
 // A channel turn ends after a successful `channel_reply` (the terminal-reply
 // abort in router.ts). When the model's reply PROMISES to keep working this
 // turn ("바로 확인해볼게요", "let me check", "I'll continue now") but it forgot
-// to set `channel_reply({ continue: true })`, the turn aborts and the promised
+// to set `channel_reply({ more_work_this_turn: true })`, the turn aborts and the promised
 // follow-up never runs. The router uses this detector to inject ONE bounded
 // reminder nudge so the model gets a second chance. See the empty-turn retry
 // (router.ts) for the sibling mechanism this mirrors.
@@ -73,7 +73,7 @@ const EN_PHRASES: readonly string[] = [
   // Action/config verb family. The retrieval verbs above ("check/look/look up")
   // miss the much larger class of "I'll DO X" promises — update/configure/set up/
   // schedule/fix/apply/create — which is exactly the class that silently truncates
-  // when the model forgets `continue: true` (the cron-update production miss).
+  // when the model forgets `more_work_this_turn: true` (the cron-update production miss).
   "i'll update",
   "i'll set up",
   "i'll set it up",

--- a/src/channels/github-false-receipt.test.ts
+++ b/src/channels/github-false-receipt.test.ts
@@ -16,7 +16,7 @@ function base(over: Partial<Parameters<typeof checkFalseReceipt>[0]> = {}): Para
     chat: 'pr:12',
     thread: null,
     text: '',
-    isContinue: false,
+    moreWorkThisTurn: false,
     resolveReviewThread: false,
     ...over,
   }
@@ -51,8 +51,8 @@ describe('checkFalseReceipt — verdict false receipts', () => {
     expect(checkFalseReceipt(base({ text: 'Requesting changes here.' })).kind).toBe('block')
   })
 
-  test('continue:true downgrades a hard verdict claim to a warn', () => {
-    expect(checkFalseReceipt(base({ text: 'Approved!', isContinue: true })).kind).toBe('warn')
+  test('more_work_this_turn:true downgrades a hard verdict claim to a warn', () => {
+    expect(checkFalseReceipt(base({ text: 'Approved!', moreWorkThisTurn: true })).kind).toBe('warn')
   })
 
   test('soft signal warns, never blocks', () => {

--- a/src/channels/github-false-receipt.ts
+++ b/src/channels/github-false-receipt.ts
@@ -19,7 +19,7 @@ export type FalseReceiptInput = {
   chat: string
   thread: string | null
   text: string | undefined
-  isContinue: boolean
+  moreWorkThisTurn: boolean
   resolveReviewThread: boolean
 }
 
@@ -32,9 +32,9 @@ export function checkFalseReceipt(input: FalseReceiptInput): FalseReceiptDecisio
   if (claim === 'ignore') return { kind: 'allow' }
   if (claim === 'warn') return { kind: 'warn', notice: SOFT_NOTICE }
 
-  // A turn the agent explicitly keeps alive (continue:true) is not yet a receipt
-  // — the real action may still be coming. Never block; nudge instead.
-  if (input.isContinue) return { kind: 'warn', notice: SOFT_NOTICE }
+  // A turn the agent explicitly keeps alive (more_work_this_turn:true) is not yet
+  // a receipt — the real action may still be coming. Never block; nudge instead.
+  if (input.moreWorkThisTurn) return { kind: 'warn', notice: SOFT_NOTICE }
 
   if (claim === 'block-resolve') {
     if (input.thread === null) return { kind: 'allow' }

--- a/src/channels/github-rereview-guard.test.ts
+++ b/src/channels/github-rereview-guard.test.ts
@@ -9,7 +9,7 @@ function input(overrides: Partial<RereviewGuardInput> = {}): RereviewGuardInput 
     thread: '12345',
     text: 'Verified — that closes it, thanks!',
     wantsResolve: true,
-    isContinue: false,
+    moreWorkThisTurn: false,
     workspace: 'acme/widgets',
     getReviewState: async () => ({ ok: true, selfBlocking: true, approve: true }),
     ...overrides,
@@ -172,13 +172,13 @@ describe('re-review stranding guard', () => {
     if (decision.block) expect(decision.reason).toContain('Could not verify')
   })
 
-  it('exempts a mid-turn warn-tier status reply (continue:true) from the state query', async () => {
+  it('exempts a mid-turn warn-tier status reply (more_work_this_turn:true) from the state query', async () => {
     let queried = false
     const decision = await evaluateRereviewGuard(
       input({
         thread: null,
         wantsResolve: false,
-        isContinue: true,
+        moreWorkThisTurn: true,
         text: 'Looks good so far — spawning the reviewer now, back shortly.',
         getReviewState: async () => {
           queried = true
@@ -190,9 +190,15 @@ describe('re-review stranding guard', () => {
     expect(queried).toBe(false)
   })
 
-  it('still resolves-blocks an explicit thread resolve even mid-turn (continue:true)', async () => {
+  it('still resolves-blocks an explicit thread resolve even mid-turn (more_work_this_turn:true)', async () => {
     const decision = await evaluateRereviewGuard(
-      input({ thread: '999', wantsResolve: true, isContinue: true, text: 'one sec', getReviewState: stateOk(true) }),
+      input({
+        thread: '999',
+        wantsResolve: true,
+        moreWorkThisTurn: true,
+        text: 'one sec',
+        getReviewState: stateOk(true),
+      }),
     )
     expect(decision.block).toBe(true)
   })

--- a/src/channels/github-rereview-guard.ts
+++ b/src/channels/github-rereview-guard.ts
@@ -17,10 +17,10 @@ export type RereviewGuardInput = {
   thread: string | null
   text: string | undefined
   wantsResolve: boolean
-  // A mid-turn status reply (continue:true) is not the turn's receipt, so it
-  // suppresses the warn-tier escalation below — but never the explicit resolve,
-  // which is a real mutation. Mirrors the false-receipt guard's continue rule.
-  isContinue: boolean
+  // A mid-turn status reply (more_work_this_turn:true) is not the turn's receipt,
+  // so it suppresses the warn-tier escalation below — but never the explicit
+  // resolve, which is a real mutation. Mirrors the false-receipt guard's rule.
+  moreWorkThisTurn: boolean
   getReviewState: (req: { adapter: 'github'; workspace: string; chat: string }) => Promise<ReviewStateResult>
   workspace: string
 }
@@ -62,14 +62,14 @@ export async function evaluateRereviewGuard(input: RereviewGuardInput): Promise<
 // live CHANGES_REQUESTED, so casual approval-shaped chatter on an unblocked PR
 // still posts. Only POSITIVE warn phrases escalate — negative ones ("needs
 // changes", "still needs work") re-assert a block rather than strand it, so they
-// stay non-firing. `continue:true` exempts the warn escalation (mid-turn
-// planning, not the receipt), but never the explicit resolve action. Plain
-// `ignore` text never fires.
+// stay non-firing. `more_work_this_turn:true` exempts the warn escalation
+// (mid-turn planning, not the receipt), but never the explicit resolve action.
+// Plain `ignore` text never fires.
 function isCloseoutAttempt(input: RereviewGuardInput): boolean {
   if (input.wantsResolve && input.thread !== null) return true
   const claim = classifyReviewClaim(input.text ?? '')
   if (claim === 'block-resolve' || claim === 'block-approve') return true
-  return !input.isContinue && isPositiveWarnCloseout(input.text ?? '')
+  return !input.moreWorkThisTurn && isPositiveWarnCloseout(input.text ?? '')
 }
 
 function unverifiableReason(error: string): string {

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -6625,7 +6625,7 @@ describe('ChannelRouter channel-turn protocol', () => {
   })
 
   test('leaf recovery: DOES fire when a progress reply landed but the final answer ended as plain prose', async () => {
-    // The production bug: a `continue: true` progress reply lands, the model
+    // The production bug: a `more_work_this_turn: true` progress reply lands, the model
     // keeps working, then ENDS the turn with its conclusion as plain assistant
     // text (a `stopReason: 'stop'` leaf) and never calls a channel tool again.
     // The conclusion must be recovered and delivered, not dropped.
@@ -6954,7 +6954,7 @@ describe('ChannelRouter channel-turn protocol', () => {
   })
 
   // Regression for the "I'll check right now" → silence bug (Discord channel,
-  // 2026-06-15). The model posted a `continue: true` status reply ("지금 바로
+  // 2026-06-15). The model posted a `more_work_this_turn: true` status reply ("지금 바로
   // 확인할게"), kept working through several tool calls, then its post-tool
   // follow-up stream was aborted before it could conclude. The session leaf was
   // a toolResult under an unanswered `stopReason: 'toolUse'` assistant carrying
@@ -7028,7 +7028,7 @@ describe('ChannelRouter channel-turn protocol', () => {
     sessions[0]!.onPrompt = async (text) => {
       attempt++
       if (attempt === 1) {
-        // The status reply (the `continue: true` "I'll check now") lands as a
+        // The status reply (the `more_work_this_turn: true` "I'll check now") lands as a
         // real send, then the turn strands on the unanswered toolUse.
         await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '지금 바로 확인할게.' })
         strandOnUnansweredToolUse()
@@ -13500,7 +13500,7 @@ describe('ChannelRouter per-turn live role anchor', () => {
 describe('ChannelRouter post-tool follow-up suppression', () => {
   function afterToolContext(
     toolName: string,
-    result: { ok: boolean; continue?: boolean },
+    result: { ok: boolean; more_work_this_turn?: boolean },
     isError: boolean,
     replyText?: string,
   ): AfterToolCallContext {
@@ -13538,9 +13538,9 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     expect(agent.signal.aborted).toBe(true)
   })
 
-  test('does NOT abort when channel_reply opts out with continue: true', async () => {
+  test('does NOT abort when channel_reply opts out with more_work_this_turn: true', async () => {
     const agent = await liveAgentAfterRoute(await tempDir())
-    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true, continue: true }, false))
+    await agent.afterToolCall!(afterToolContext('channel_reply', { ok: true, more_work_this_turn: true }, false))
     expect(agent.signal.aborted).toBe(false)
   })
 
@@ -13574,10 +13574,10 @@ describe('ChannelRouter post-tool follow-up suppression', () => {
     expect(agent.signal.aborted).toBe(true)
   })
 
-  test('does NOT stash when continue:true (the turn stays alive, no nudge needed)', async () => {
+  test('does NOT stash when more_work_this_turn:true (the turn stays alive, no nudge needed)', async () => {
     const agent = await liveAgentAfterRoute(await tempDir())
     await agent.afterToolCall!(
-      afterToolContext('channel_reply', { ok: true, continue: true }, false, '바로 계속 확인하겠습니다'),
+      afterToolContext('channel_reply', { ok: true, more_work_this_turn: true }, false, '바로 계속 확인하겠습니다'),
     )
     expect(agent.signal.aborted).toBe(false)
   })
@@ -13612,7 +13612,7 @@ describe('ChannelRouter continuation willingness nudge', () => {
     session.setAssistantMidTurn(replyText, 'aborted')
   }
 
-  test('queues a nudge when a terminal reply promises to continue without continue:true', async () => {
+  test('queues a nudge when a terminal reply promises to continue without more_work_this_turn:true', async () => {
     const dir = await tempDir()
     const sent: string[] = []
     const { router, sessions } = makeRouter(dir)
@@ -13625,7 +13625,7 @@ describe('ChannelRouter continuation willingness nudge', () => {
     let attempt = 0
     sessions[0]!.onPrompt = async (text) => {
       attempt++
-      // given: first turn replies with a continuation promise (no continue:true)
+      // given: first turn replies with a continuation promise (no more_work_this_turn:true)
       if (attempt === 1) {
         await replyTurn(sessions[0]!, router, '바로 계속 확인하겠습니다')
         return
@@ -13660,7 +13660,7 @@ describe('ChannelRouter continuation willingness nudge', () => {
 
     await router.route(inbound({ text: '확인해봐' }))
     sessions[0]!.onPrompt = async () => {
-      // Every turn promises to continue without continue:true. Bound = 1, so
+      // Every turn promises to continue without more_work_this_turn:true. Bound = 1, so
       // only the first reply turn may queue a nudge; the nudge turn's own reply
       // must NOT queue a second one.
       await replyTurn(sessions[0]!, router, '바로 계속 확인하겠습니다')
@@ -13838,7 +13838,7 @@ describe('ChannelRouter channel_send willingness nudge', () => {
   })
 })
 
-describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)', () => {
+describe('ChannelRouter more_work_this_turn:true empty-stop recovery (phrase-independent)', () => {
   function continueReplyContext(replyText: string): AfterToolCallContext {
     return {
       assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
@@ -13851,14 +13851,14 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
       args: { text: replyText },
       result: {
         content: [{ type: 'text' as const, text: 'ignored' }],
-        details: { ok: true, continue: true },
+        details: { ok: true, more_work_this_turn: true },
       } as AfterToolCallContext['result'],
       isError: false,
       context: { systemPrompt: '', messages: [], tools: [] },
     }
   }
 
-  // Reproduce the production order for a channel_reply({ continue: true }): the tool's
+  // Reproduce the production order for a channel_reply({ more_work_this_turn: true }): the tool's
   // execute() calls router.send() (which bumps successfulChannelSends) BEFORE the
   // runtime fires afterToolCall (which stamps continueReplyTurn with that post-send
   // count). Then install a fresh empty-stop-after-tool-work leaf — the degeneration.
@@ -13873,7 +13873,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     emptyStopAfterToolWork(session, id)
   }
 
-  test('recovers a continue:true ack whose phrasing is OUTSIDE the willingness table', async () => {
+  test('recovers a more_work_this_turn:true ack whose phrasing is OUTSIDE the willingness table', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
@@ -13888,7 +13888,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     sessions[0]!.onPrompt = async (text) => {
       attempt++
       if (attempt === 1) {
-        // given: a continue:true progress ack with NO willingness phrase (casual
+        // given: a more_work_this_turn:true progress ack with NO willingness phrase (casual
         // Korean "훑어볼게" is not in the phrase table), then tool work, then a
         // fresh empty stop — the phrase-gated path can't see this promise.
         await continueReplyThenStrand(sessions[0]!, router, '응 persona 흔적 파일들 훑어볼게', String(attempt))
@@ -13908,7 +13908,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     ).toBe(true)
   })
 
-  test('posts the fallback instead of looping when the continue:true retry re-strands', async () => {
+  test('posts the fallback instead of looping when the more_work_this_turn:true retry re-strands', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
@@ -13922,7 +13922,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     let attempt = 0
     sessions[0]!.onPrompt = async () => {
       attempt++
-      // Every turn re-acks continue:true (distinct text to dodge the send dup-guard)
+      // Every turn re-acks more_work_this_turn:true (distinct text to dodge the send dup-guard)
       // and re-strands on an empty stop. Bound = MAX_WILLINGNESS_NUDGES: one nudge,
       // then the visible fallback instead of silence.
       await continueReplyThenStrand(sessions[0]!, router, `바로 볼게 (${attempt})`, String(attempt))
@@ -13937,7 +13937,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
   })
 
   test('self-recovery: a continuation that lands the real answer after willingness exhaustion discards the staged fallback', async () => {
-    // Reproduces the production Discord false alarm: the model acked continue:true,
+    // Reproduces the production Discord false alarm: the model acked more_work_this_turn:true,
     // did tool work, stranded on an empty stop, exhausted the single willingness
     // nudge — then the idle/todo continuation re-prompted the SAME logical turn and
     // delivered the real answer. The staged fallback must be discarded, never posted.
@@ -14065,7 +14065,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
 
   test('cross-turn escalation: a willingness-exhaustion staged fallback question turn does not seed the next turn', async () => {
     // Mirrors the retry-exhausted fallback question-turn test through the STAGED
-    // willingness path. given: turn A is a question whose continue:true ack strands
+    // willingness path. given: turn A is a question whose more_work_this_turn:true ack strands
     // on every attempt until the willingness budget is exhausted and — with NO
     // continuation queued — the staged fallback posts (no usable reply). turn B is a
     // question. The staged-then-posted fallback must NOT commit A's question signal,
@@ -14080,7 +14080,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
       return { ok: true }
     })
 
-    // turn A — a question that acks continue:true then re-strands until exhaustion
+    // turn A — a question that acks more_work_this_turn:true then re-strands until exhaustion
     await router.route(inbound({ text: 'why did the deployment fail on the staging cluster?' }))
     let aAttempt = 0
     sessions[0]!.onPrompt = async () => {
@@ -14214,7 +14214,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     expect(sessions[0]!.thinkingLevels).not.toContain('xhigh')
   })
 
-  test('retries once after a continue:true progress reply and suppresses the warning when the final reply succeeds', async () => {
+  test('retries once after a more_work_this_turn:true progress reply and suppresses the warning when the final reply succeeds', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
@@ -14254,7 +14254,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
   })
 
-  test('/stop during post-tool retry backoff invalidates the continue:true authorization', async () => {
+  test('/stop during post-tool retry backoff invalidates the more_work_this_turn:true authorization', async () => {
     const dir = await tempDir()
     const sent: string[] = []
     let signalBackoffStart: () => void = () => {}
@@ -14398,7 +14398,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     expect(sent.some((text) => text.startsWith('⚠️'))).toBe(false)
   })
 
-  test('suppresses a provider error after a final reply follows the continue:true progress reply', async () => {
+  test('suppresses a provider error after a final reply follows the more_work_this_turn:true progress reply', async () => {
     const dir = await tempDir()
     const sent: string[] = []
     const { router, sessions } = makeRouter(dir)
@@ -14425,7 +14425,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     expect(sent).toEqual(['찾아볼게.', '지난 기록은 이 내용이야.'])
   })
 
-  test('does NOT recover when the continue:true ack leaf is unchanged since the send (ack-then-await-user)', async () => {
+  test('does NOT recover when the more_work_this_turn:true ack leaf is unchanged since the send (ack-then-await-user)', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const { router, sessions } = makeRouter(dir, { logs })
@@ -14434,7 +14434,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     await router.route(inbound({ text: '확인 좀' }))
     sessions[0]!.onPrompt = async () => {
       // Install the leaf BEFORE the send so lastSendLeafId === the turn-end leaf:
-      // the model acked continue:true and stopped to await the user, no post-ack
+      // the model acked more_work_this_turn:true and stopped to await the user, no post-ack
       // work — must stay on the historical no_reply path, not recover.
       const entry: SessionEntry = {
         type: 'message',
@@ -14454,7 +14454,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
     expect(logs.some((m) => m.includes('send_willingness_nudge'))).toBe(false)
   })
 
-  test('does NOT recover when a substantive channel_send answered the user after the continue:true ack', async () => {
+  test('does NOT recover when a substantive channel_send answered the user after the more_work_this_turn:true ack', async () => {
     const dir = await tempDir()
     const logs: string[] = []
     const sent: string[] = []
@@ -14466,7 +14466,7 @@ describe('ChannelRouter continue:true empty-stop recovery (phrase-independent)',
 
     await router.route(inbound({ text: '레포 확인해줘' }))
     sessions[0]!.onPrompt = async () => {
-      // given: continue:true ack (stamps continueReplyTurn with the ack's send count),
+      // given: more_work_this_turn:true ack (stamps continueReplyTurn with the ack's send count),
       // tool work, then a SUBSTANTIVE channel_send final answer — which bumps
       // successfulChannelSends past the stamped count — and finally a fresh empty stop.
       // The user was already answered, so the trailing empty stop must NOT be nudged.

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -371,7 +371,7 @@ export const EMPTY_TURN_RETRY_NUDGE = [
 // Reminder-only nudge for the stranded-toolUse-after-send retry. Distinct from
 // EMPTY_TURN_RETRY_NUDGE: that one diagnoses output-budget exhaustion and tells
 // the model to "answer directly", which makes a stranded investigation RE-RUN
-// its tools and strand again. Here the model already sent a `continue: true`
+// its tools and strand again. Here the model already sent a `more_work_this_turn: true`
 // status ack and did real tool work; the turn just ended on an unanswered
 // toolUse before final prose. The prior toolUse/toolResult entries are still in
 // this session's branch on the re-prompt, so the recovery is to STOP, read what
@@ -424,8 +424,9 @@ export const COLD_START_REPLY_NUDGE = [
 // Reminder-only nudge for the empty-stop-after-tool-work retry. Distinct from
 // both EMPTY_TURN_RETRY_NUDGE (which misdiagnoses a clean `stop` as output-budget
 // exhaustion and, per its own docstring, makes the model RE-RUN its tools and
-// strand again) and STRANDED_TOOLUSE_CONTINUATION_NUDGE (which assumes a `continue:
-// true` status reply already landed). Here NO send landed, the model gathered real
+// strand again) and STRANDED_TOOLUSE_CONTINUATION_NUDGE (which assumes a
+// `more_work_this_turn: true` status reply already landed). Here NO send landed,
+// the model gathered real
 // tool results, then the final completion came back as a bare empty `stop` — the
 // Fireworks/gpt empty-completion degeneration. The recovery is to READ the results
 // already in this branch, summarize, and reply — NOT to re-investigate. The
@@ -452,7 +453,7 @@ export const EMPTY_STOP_AFTER_TOOL_WORK_NUDGE = [
 // is a one-shot correction offer, not recovery from no output.
 export const MAX_WILLINGNESS_NUDGES = 1
 // Injected when a reply that ended the turn (terminal-reply abort) promised to
-// keep working but omitted `continue: true`. Reminder-only, SYSTEM MESSAGE
+// keep working but omitted `more_work_this_turn: true`. Reminder-only, SYSTEM MESSAGE
 // framing so persona-rich models do not reply to the notice itself.
 export const WILLINGNESS_NUDGE = [
   '---',
@@ -460,14 +461,14 @@ export const WILLINGNESS_NUDGE = [
   '',
   'Your last reply said you would keep working this turn, but it ended right',
   'after sending — a successful channel reply ends the turn unless you set',
-  '`continue: true` on it. This is an automated signal from the channel router,',
-  'not a message from anyone in the chat. **Do not acknowledge or reply to this',
-  'notice itself.**',
+  '`more_work_this_turn: true` on it. This is an automated signal from the channel',
+  'router, not a message from anyone in the chat. **Do not acknowledge or reply to',
+  'this notice itself.**',
   '',
   'If you still have work to do (fetch data, run a tool, spawn a subagent, then',
   'reply with the result), do it now — and on the status reply that precedes more',
-  'work this turn, set `continue: true`. If there is nothing left to do, reply',
-  'with `NO_REPLY`.',
+  'work this turn, set `more_work_this_turn: true`. If there is nothing left to do,',
+  'reply with `NO_REPLY`.',
   '',
   '---',
 ].join('\n')
@@ -475,7 +476,7 @@ export const WILLINGNESS_NUDGE = [
 // did fresh work after it, then ended on an EMPTY `stop` leaf — the answer was
 // computed but never sent (the Kimi/Fireworks empty-completion flake). Distinct
 // from WILLINGNESS_NUDGE: that path is a `channel_reply` that ended the turn and
-// needs `continue: true`; this path is a `channel_send` (which never ends the
+// needs `more_work_this_turn: true`; this path is a `channel_send` (which never ends the
 // turn) whose follow-up degenerated, so the model just needs to emit the reply it
 // already worked out. Shares MAX_WILLINGNESS_NUDGES so a turn can't double-nudge.
 export const SEND_WILLINGNESS_NUDGE = [
@@ -945,7 +946,7 @@ type LiveSession = {
   // channel send landed this turn. `validateChannelTurn` compares it to the
   // turn-end leaf: a DIFFERENT assistant `stop` leaf means the model replied,
   // kept working, then ended with FRESH final prose it forgot to deliver
-  // (the `continue: true` progress-reply bug) — recover it. A leaf that still
+  // (the `more_work_this_turn: true` progress-reply bug) — recover it. A leaf that still
   // matches is narration the model emitted BEFORE/with the reply that already
   // landed, so it stays suppressed. Reset to null on every new prompt batch.
   lastSendLeafId: string | null
@@ -1017,14 +1018,14 @@ type LiveSession = {
   // nudge itself queues — same anti-reloop discipline as the empty-turn budget.
   willingnessNudges: number
   // Stashed by `installChannelReplyTerminalHook` just before it aborts the turn
-  // after a successful `channel_reply` that omitted `continue: true`. Read once
+  // after a successful `channel_reply` that omitted `more_work_this_turn: true`. Read once
   // by `validateChannelTurn` to decide the continuation nudge. `turnSeq`-stamped
   // (like `skippedTurn`/`skipLockedSendTurn`) so a stale record from an earlier
   // turn can never trigger a nudge on a later one. `null` when no such reply
   // ended this turn.
   lastTerminalReplyAbort: { turnSeq: number; text: string } | null
   // Stamped by `installChannelReplyTerminalHook` when a successful `channel_reply`
-  // set `continue: true` — the machine-readable "I'll keep working this turn"
+  // set `more_work_this_turn: true` — the machine-readable "I'll keep working this turn"
   // promise. `validateChannelTurn` reads it to recover a turn that made that promise,
   // did more work, then ended on a fresh empty `stop` (dropped its conclusion) —
   // independent of what natural-language phrase the ack used, so a persona speaking
@@ -1087,7 +1088,7 @@ type LiveSession = {
   emptyTurnFallbackTurn: number | null
   // Set when a WILLINGNESS-ACK exhaustion path (empty_stop_after_continue_reply /
   // empty_stop_after_send_ack) would post EMPTY_TURN_FALLBACK_TEXT, but the model
-  // just made a machine-readable promise to keep working (`continue: true` /
+  // just made a machine-readable promise to keep working (`more_work_this_turn: true` /
   // willingness phrase) and did post-ack tool work. Rather than posting the scary
   // "I got stuck" notice synchronously at validateChannelTurn — BEFORE the drain
   // loop runs maybeContinueTodosChannel, which can re-prompt the same logical turn
@@ -2635,20 +2636,21 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   // continue. A prior non-typeclaw `afterToolCall` (none today) would be
   // composed, not clobbered.
   //
-  // `channel_reply({ continue: true })` is the explicit opt-out: a mid-turn
-  // status reply ("working on it…") that the model follows with more work this
-  // turn. The tool surfaces that intent as `details.continue === true`, and we
-  // keep the follow-up so the turn proceeds. The kimi 32k loop only recurs when
-  // the model genuinely has nothing left to say after a reply, which `continue`
-  // asserts is not the case; Layer 2's maxTokens cap still bounds any misuse.
+  // `channel_reply({ more_work_this_turn: true })` is the explicit opt-out: a
+  // mid-turn status reply ("working on it…") that the model follows with more
+  // work this turn. The tool surfaces that intent as
+  // `details.more_work_this_turn === true`, and we keep the follow-up so the turn
+  // proceeds. The kimi 32k loop only recurs when the model genuinely has nothing
+  // left to say after a reply, which `more_work_this_turn` asserts is not the
+  // case; Layer 2's maxTokens cap still bounds any misuse.
   const installChannelReplyTerminalHook = (live: LiveSession): void => {
     const { agent } = live.session
     const prior = agent.afterToolCall
     agent.afterToolCall = async (context, signal) => {
       const result = prior ? await prior(context, signal) : undefined
-      const details = context.result.details as { ok?: unknown; continue?: unknown } | undefined
+      const details = context.result.details as { ok?: unknown; more_work_this_turn?: unknown } | undefined
       const succeeded = context.toolCall.name === 'channel_reply' && !context.isError && details?.ok === true
-      const keepTurnAlive = details?.continue === true
+      const keepTurnAlive = details?.more_work_this_turn === true
       if (succeeded && keepTurnAlive) {
         live.continueReplyTurn = { turnSeq: live.turnSeq, sendCount: live.successfulChannelSends }
       }
@@ -4607,7 +4609,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
   }
 
   // The turn ended via the terminal-reply abort. If that reply promised to keep
-  // working but omitted `continue: true`, queue ONE reminder-only re-prompt so
+  // working but omitted `more_work_this_turn: true`, queue ONE reminder-only re-prompt so
   // the model gets a second chance to actually do it. The abort already fired
   // (safe default preserved); this only adds an optional nudge. Bounded by
   // MAX_WILLINGNESS_NUDGES and gated on `promptQueue` being empty so a real
@@ -4696,10 +4698,10 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       )
     }
 
-    // A send landed this turn, but the model may have posted a `continue: true`
+    // A send landed this turn, but the model may have posted a `more_work_this_turn: true`
     // progress reply, kept working, then ENDED with its final answer as plain
     // prose — never calling a channel tool again. The terminal-reply abort fires
-    // only for a `channel_reply` WITHOUT `continue: true`, so that `stopReason:
+    // only for a `channel_reply` WITHOUT `more_work_this_turn: true`, so that `stopReason:
     // 'stop'` text leaf is left undelivered and unguarded (the false-receipt
     // guard is github-only). The discriminator is leaf IDENTITY: only when the
     // turn-end `stop` leaf is a DIFFERENT entry than the one in place at the last
@@ -4709,17 +4711,17 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
     if (live.successfulChannelSends > successfulSendsBeforePrompt) {
       maybeNudgeContinuationWillingness(live)
 
-      // A `channel_reply({ continue: true })` progress ack landed this turn (the
+      // A `channel_reply({ more_work_this_turn: true })` progress ack landed this turn (the
       // machine-readable "I'll keep working" promise — `continueReplyTurn` is stamped
       // by installChannelReplyTerminalHook), the model did more work, then ended on a
       // FRESH empty `stop` — dropping its conclusion. This is the SAME degeneration as
-      // the phrase-gated `channel_send` branch below, but keyed on the `continue: true`
+      // the phrase-gated `channel_send` branch below, but keyed on the `more_work_this_turn: true`
       // FLAG instead of a natural-language willingness phrase. The flag is the robust
       // signal: it fires regardless of the ack's language or register, closing the gap
       // where a persona speaking a phrasing outside the willingness table (e.g. casual
       // Korean "확인해볼게") stranded the user in silence. The `attemptMadeToolCall`
       // half ties the first trigger to real post-ack work; `willingnessNudges > 0`
-      // lets a retry that re-emitted `continue: true` and re-stranded spend the shared
+      // lets a retry that re-emitted `more_work_this_turn: true` and re-stranded spend the shared
       // budget toward the visible fallback instead of bailing silent. Same
       // MAX_WILLINGNESS_NUDGES bound, same empty-`promptQueue` gate (a coalesced live
       // inbound supersedes this turn's silence), and same nudge/fallback path as the
@@ -4788,7 +4790,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
       const trailing = recoverableAssistantText(live.session)
       if (trailing === null || trailing.source !== 'leaf') {
-        // A `continue: true` status reply landed, then the turn stranded on an
+        // A `more_work_this_turn: true` status reply landed, then the turn stranded on an
         // unanswered `toolUse` (the post-tool follow-up never produced an
         // assistant message — aborted loop / cancelled stream). The promised
         // work never finished, so the user is left with a bare "checking now…"
@@ -5169,7 +5171,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       chat: live.key.chat,
       thread: live.key.thread,
       text,
-      isContinue: false,
+      moreWorkThisTurn: false,
       resolveReviewThread: false,
     })
     if (falseReceipt.kind === 'block') return falseReceipt.reason
@@ -5181,7 +5183,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       thread: live.key.thread,
       text,
       wantsResolve: false,
-      isContinue: false,
+      moreWorkThisTurn: false,
       getReviewState: (req) => getReviewState(req),
     })
     if (rereview.block) return rereview.reason
@@ -6976,7 +6978,7 @@ function assistantLeafStopReason(session: AgentSession): 'length' | 'error' | 'a
 // alongside its tool call and DID land a real send this turn (that trailing
 // `toolUse` is delivered narration, not a stranded promise — leave it alone).
 // Keys on the model having INTENDED to keep working with nothing yet said; used
-// to re-prompt a turn that strands mid-work after a `continue: true` status
+// to re-prompt a turn that strands mid-work after a `more_work_this_turn: true` status
 // reply instead of ending in silence.
 function leafIsStrandedToolUse(session: AgentSession): boolean {
   const leaf = session.sessionManager.getLeafEntry()
@@ -7006,7 +7008,7 @@ function leafIsStrandedToolUse(session: AgentSession): boolean {
 // (the model did more work, then dropped its conclusion) from a legitimate
 // ack-then-stop where the model meant to wait for the user (leaf unchanged since
 // the send). The two willingness paths below layer their own promise-signal on top
-// of this shape: `channel_reply({ continue: true })` via `continueReplyTurn`, and
+// of this shape: `channel_reply({ more_work_this_turn: true })` via `continueReplyTurn`, and
 // `channel_send` acks via the willingness phrase table.
 function isFreshEmptyStopAfterSend(live: LiveSession): boolean {
   const leaf = live.session.sessionManager.getLeafEntry()
@@ -7016,10 +7018,10 @@ function isFreshEmptyStopAfterSend(live: LiveSession): boolean {
   return leaf.id !== live.lastSendLeafId
 }
 
-// The `channel_send` analogue of the `continue: true` recovery: the most recent
+// The `channel_send` analogue of the `more_work_this_turn: true` recovery: the most recent
 // send to this target was a continuation-willingness ack (by phrase), then the
 // model produced a fresh empty stop. `channel_send` keeps the turn alive without a
-// `continue: true` flag and stamps no semantic marker, so the phrase table is the
+// `more_work_this_turn: true` flag and stamps no semantic marker, so the phrase table is the
 // only "I promised to keep working" signal available for that shape.
 function isEmptyStopAfterWillingnessAck(live: LiveSession): boolean {
   if (!isFreshEmptyStopAfterSend(live)) return false

--- a/src/skills/typeclaw-channel-github/SKILL.md
+++ b/src/skills/typeclaw-channel-github/SKILL.md
@@ -10,9 +10,9 @@ GitHub renders normal Markdown in issues, PRs, discussions, and review comments.
 - For PR review threads, keep `thread` set to reply in-place. Omit `thread` for a top-level PR/issue comment.
 - When a review comment **you authored** has been addressed, resolve its thread by replying with `channel_reply({ …, resolve_review_thread: true })` — see "Resolving review threads you authored" below. The base principle is **whoever opened the thread closes it**: you resolve only the threads you started, never a human's (the runtime enforces this).
 
-## Mid-turn status replies need `continue: true`
+## Mid-turn status replies need `more_work_this_turn: true`
 
-A successful `channel_reply` ends your turn by default — the runtime stops the model right after the reply lands. That is correct for a final answer, but it will **silently truncate** a turn that still has work to do. If you post a status line like "Reviewing now, I'll be back with findings" and then expect to keep working (fetch the diff, spawn the reviewer, post the review) in the **same** turn, you must call `channel_reply({ text: "…", continue: true })`. Without `continue: true`, the turn ends at that status reply and the review never runs. Reserve `continue: true` for genuine multi-step turns; the final reply that wraps up the turn omits it.
+A successful `channel_reply` ends your turn by default — the runtime stops the model right after the reply lands. That is correct for a final answer, but it will **silently truncate** a turn that still has work to do. If you post a status line like "Reviewing now, I'll be back with findings" and then expect to keep working (fetch the diff, spawn the reviewer, post the review) in the **same** turn, you must call `channel_reply({ text: "…", more_work_this_turn: true })`. Without `more_work_this_turn: true`, the turn ends at that status reply and the review never runs. Reserve `more_work_this_turn: true` for genuine multi-step turns; the final reply that wraps up the turn sets `more_work_this_turn: false`. The field is required — every `channel_reply` must set it explicitly, so never omit it.
 
 ## Inbound triage — do this first, every time
 
@@ -259,10 +259,10 @@ If the author merely **replied** without pushing (e.g. "this is intentional beca
 Once you have verified the fix, **acknowledge and resolve in one call**: pass `resolve_review_thread: true` to your `channel_reply`. The runtime resolves the thread you're replying in **before** it posts your acknowledgement, then posts the reply:
 
 ```
-channel_reply({ text: "Verified — the fix addresses the concern. Thanks!", resolve_review_thread: true })
+channel_reply({ text: "Verified — the fix addresses the concern. Thanks!", more_work_this_turn: false, resolve_review_thread: true })
 ```
 
-This is the correct path and it removes a footgun. A bare `channel_reply` ends your turn the moment it lands, so a resolve attempted _after_ the acknowledgement would never run — the thread would stay open even though you "handled" it. The flag resolves first, so a normal final reply still closes the thread. You do **not** need `continue: true` for this: resolution happens inside the same call, before the turn ends.
+This is the correct path and it removes a footgun. A bare `channel_reply` ends your turn the moment it lands, so a resolve attempted _after_ the acknowledgement would never run — the thread would stay open even though you "handled" it. The flag resolves first, so a normal final reply still closes the thread. You do **not** need `more_work_this_turn: true` for this: resolution happens inside the same call, before the turn ends.
 
 Two guarantees make the flag safe to use as your default:
 


### PR DESCRIPTION
## Background

`channel_reply` ends the current turn on success by default. A boolean overrides that: set it and the turn stays alive so mid-turn work (fetch data, run a tool, spawn a subagent, reply again) actually runs. That boolean was named `continue`, and the name is hard for a model to reason about:

- It collides with the `continue` control-flow keyword the model is heavily primed on.
- It's directionally ambiguous — "continue" *what*? The turn? The conversation? A model can read `continue: false` as "end the conversation."

The cost of the ambiguity is visible in the codebase: the dominant production failure is the model *forgetting* to set the flag after it promised more work ("I'll check now") — the turn dies and the promised follow-up never runs. That single failure mode is why `continuation-willingness.ts` exists as a 735-line, 15-language phrase/morpheme detector that injects a recovery nudge. The name should carry its own weight instead of leaning on a description that spends three sentences disambiguating it.

## Summary

Rename the wire field to `more_work_this_turn`. It reads as an active "more work is coming this turn" commitment — precisely the intent the willingness detector is trying to recover — and it matches house style for boolean intent flags (descriptive snake_case verb phrase, like `run_in_foreground` / `resolve_review_thread`).

**Why keep the polarity (`true` = keep the turn alive) instead of inverting to a `final`/`done` flag:** the terminal (`false`) branch is where the safety guards fire — false-receipt, rereview-stranding, resolve-before-post. Today an omission/default lands on that terminal branch, so the guards run: fail-safe. Inverting so that absence means "keep working" would let an omission *skip* those guards and silently strand a PR or drop promised work: fail-unsafe. So polarity stays, and the field stays required with no default.

This is behavior-preserving — a pure rename, no logic or polarity change. Candidate naming and the keep-polarity/keep-required decision were reviewed by an independent reasoning pass before implementation.

## What this does NOT do

- Does **not** change any runtime behavior, polarity, or the required-with-no-default contract.
- Does **not** touch the internal `continueReplyTurn` marker, the `agent.continue()` SDK method, or any loop-`continue` keyword.
- `channel_send` is unaffected (it has no equivalent param; it hardcodes the terminal case).
- No published-docs changes were needed — the reference docs never named this param; only the in-repo github channel skill did.

## Review notes

- **Load-bearing change:** both ends of the tool→router wire contract move together — `channel_reply` emits `details.more_work_this_turn` and `router.ts`'s terminal hook reads it. If only one side were renamed, the keep-turn-alive signal would silently break. Verify these two stay in sync.
- The internal guard-input field `isContinue` is renamed to `moreWorkThisTurn` in lockstep across the false-receipt guard, the rereview guard, and their callers (`channel_reply`, `channel_send`, router recovery), so the rename is coherent end to end.
- Model-facing prose that teaches the flag (`WILLINGNESS_NUDGE`, the `session-origin` prompt, the github skill) was updated so the runtime actually tells the model the new name.
- The loop-`continue` keyword and the English verb "continue" in test names/comments were deliberately left alone; only field-name references changed.