### PR TITLE
agent-browser: avoid runtime shim replacement

### DIFF
--- a/src/bundled-plugins/agent-browser/index.ts
+++ b/src/bundled-plugins/agent-browser/index.ts
@@ -27,9 +27,8 @@ let unsubscribeForwardResult: (() => void) | null = null
 
 export default definePlugin({
   plugin: async (ctx) => {
-    for (const binPath of Object.values(KNOWN_BIN_PATHS)) {
-      logInstallResult(ctx.logger, safeInstallShim(binPath))
-    }
+    logInstallResult(ctx.logger, safeInstallShim(KNOWN_BIN_PATHS.global))
+    logInstallResult(ctx.logger, safeInstallShim(KNOWN_BIN_PATHS.local, KNOWN_BIN_PATHS.global))
 
     requestDashboardForward(ctx.logger)
 
@@ -86,9 +85,9 @@ async function recordProxyPort(contents: string, logger: { warn: (msg: string) =
   }
 }
 
-function safeInstallShim(binPath: string): SafeResult {
+function safeInstallShim(binPath: string, delegateTarget?: string): SafeResult {
   try {
-    return installShim({ binPath })
+    return installShim({ binPath, delegateTarget })
   } catch (error) {
     return { kind: 'error', binPath, error }
   }
@@ -100,6 +99,10 @@ function logInstallResult(
 ): void {
   if (result.kind === 'installed') {
     logger.info(`installed agent-browser shim at ${result.binPath} (real bin stashed at ${result.stashTarget})`)
+    return
+  }
+  if (result.kind === 'delegated') {
+    logger.info(`installed agent-browser alias at ${result.binPath} (delegates to ${result.delegateTarget})`)
     return
   }
   if (result.kind === 'already-installed') {

--- a/src/bundled-plugins/agent-browser/shim-install.test.ts
+++ b/src/bundled-plugins/agent-browser/shim-install.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import { resolve as resolvePath } from 'node:path'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve as resolvePath } from 'node:path'
 
 import { isWindows } from '@/shared'
 
@@ -198,6 +200,20 @@ describe.skipIf(onWindows)('installShim', () => {
     expect(fake.events).toEqual([])
   })
 
+  test('leaves the image-owned global wrapper untouched without a runtime stash', () => {
+    const fake = new FakeFs()
+    fake.files.set('/usr/local/bin/agent-browser', {
+      kind: 'file',
+      data: '#!/bin/sh\n# typeclaw-agent-browser-image-wrapper\nexec /usr/local/bin/agent-browser.real "$@"\n',
+      mode: 0o755,
+    })
+
+    const result = installShim({ binPath: '/usr/local/bin/agent-browser', shimEntry: '/x/shim.ts', fs: fake.fs() })
+
+    expect(result).toEqual({ kind: 'already-installed', binPath: '/usr/local/bin/agent-browser' })
+    expect(fake.events).toEqual([])
+  })
+
   test('returns no-upstream when nothing is at the bin path', () => {
     const fake = new FakeFs()
 
@@ -265,5 +281,83 @@ describe.skipIf(onWindows)('installShim', () => {
     expect(second.kind).toBe('no-upstream')
     expect(fake.events).toEqual(['unlink:/agent/node_modules/.bin/agent-browser'])
     expect(fake.files.has('/agent/node_modules/.bin/agent-browser')).toBe(false)
+  })
+
+  test('delegates the local npx entrypoint through the global wrapper without a stash', () => {
+    const root = mkdtempSync(join(tmpdir(), 'typeclaw-agent-browser-'))
+    try {
+      const globalBin = join(root, 'global-agent-browser')
+      const localBin = join(root, 'node_modules', '.bin', 'agent-browser')
+      const log = join(root, 'calls.log')
+      mkdirSync(dirname(localBin), { recursive: true })
+      writeFileSync(globalBin, '#!/bin/sh\nprintf "args=[%s]\\n" "$*" > "$LOGFILE"\n', { mode: 0o755 })
+      writeFileSync(localBin, '#!/bin/sh\nexit 99\n', { mode: 0o755 })
+      chmodSync(globalBin, 0o755)
+      chmodSync(localBin, 0o755)
+
+      const result = installShim({ binPath: localBin, delegateTarget: globalBin })
+
+      expect(result).toEqual({ kind: 'delegated', binPath: localBin, delegateTarget: globalBin })
+      const child = Bun.spawnSync([localBin, 'snapshot'], { env: { ...process.env, LOGFILE: log } })
+      expect(child.exitCode).toBe(0)
+      expect(readFileSync(log, 'utf-8')).toBe('args=[snapshot]\n')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('upgrades a stale local runtime shim into a global-wrapper alias', () => {
+    const root = mkdtempSync(join(tmpdir(), 'typeclaw-agent-browser-'))
+    try {
+      const globalBin = join(root, 'global-agent-browser')
+      const localBin = join(root, 'node_modules', '.bin', 'agent-browser')
+      const log = join(root, 'calls.log')
+      mkdirSync(dirname(localBin), { recursive: true })
+      writeFileSync(globalBin, '#!/bin/sh\nprintf "args=[%s]\\n" "$*" > "$LOGFILE"\n', { mode: 0o755 })
+      writeFileSync(localBin, '#!/bin/sh\n# typeclaw-agent-browser-shim\nexec /missing/agent-browser-real "$@"\n', {
+        mode: 0o755,
+      })
+      chmodSync(globalBin, 0o755)
+      chmodSync(localBin, 0o755)
+
+      const result = installShim({ binPath: localBin, delegateTarget: globalBin })
+
+      expect(result).toEqual({ kind: 'delegated', binPath: localBin, delegateTarget: globalBin })
+      const child = Bun.spawnSync([localBin, 'snapshot'], { env: { ...process.env, LOGFILE: log } })
+      expect(child.exitCode).toBe(0)
+      expect(readFileSync(log, 'utf-8')).toBe('args=[snapshot]\n')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('upgrades a local runtime shim whose stash still exists into a global-wrapper alias', () => {
+    const root = mkdtempSync(join(tmpdir(), 'typeclaw-agent-browser-'))
+    try {
+      const globalBin = join(root, 'global-agent-browser')
+      const localBin = join(root, 'node_modules', '.bin', 'agent-browser')
+      const stashDir = join(root, 'stash')
+      const log = join(root, 'calls.log')
+      mkdirSync(dirname(localBin), { recursive: true })
+      mkdirSync(stashDir, { recursive: true })
+      writeFileSync(globalBin, '#!/bin/sh\nprintf "args=[%s]\\n" "$*" > "$LOGFILE"\n', { mode: 0o755 })
+      writeFileSync(join(stashDir, 'agent-browser-real'), '#!/bin/sh\nexit 99\n', { mode: 0o755 })
+      writeFileSync(
+        localBin,
+        `#!/bin/sh\n# typeclaw-agent-browser-shim\nexec ${join(stashDir, 'agent-browser-real')} "$@"\n`,
+        { mode: 0o755 },
+      )
+      chmodSync(globalBin, 0o755)
+      chmodSync(localBin, 0o755)
+
+      const result = installShim({ binPath: localBin, stashDir, delegateTarget: globalBin })
+
+      expect(result).toEqual({ kind: 'delegated', binPath: localBin, delegateTarget: globalBin })
+      const child = Bun.spawnSync([localBin, 'open', 'https://x'], { env: { ...process.env, LOGFILE: log } })
+      expect(child.exitCode).toBe(0)
+      expect(readFileSync(log, 'utf-8')).toBe('args=[open https://x]\n')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/src/bundled-plugins/agent-browser/shim-install.ts
+++ b/src/bundled-plugins/agent-browser/shim-install.ts
@@ -16,11 +16,14 @@ const DEFAULT_GLOBAL_BIN_PATH = '/usr/local/bin/agent-browser'
 const DEFAULT_LOCAL_BIN_PATH = '/agent/node_modules/.bin/agent-browser'
 const STASH_ROOT = '/usr/local/lib/typeclaw-agent-browser'
 const SHIM_MARKER = '# typeclaw-agent-browser-shim'
+const IMAGE_WRAPPER_MARKER = '# typeclaw-agent-browser-image-wrapper'
+const LOCAL_ALIAS_MARKER = '# typeclaw-agent-browser-local-alias'
 
 export type InstallShimOptions = {
   binPath?: string
   stashDir?: string
   shimEntry?: string
+  delegateTarget?: string
   fs?: ShimFs
 }
 
@@ -42,6 +45,7 @@ export type ShimFs = {
 
 export type InstallShimResult =
   | { kind: 'installed'; realBin: string; binPath: string; stashTarget: string }
+  | { kind: 'delegated'; binPath: string; delegateTarget: string }
   | { kind: 'already-installed'; binPath: string }
   | { kind: 'no-upstream'; binPath: string }
 
@@ -55,13 +59,15 @@ export function installShim(opts: InstallShimOptions = {}): InstallShimResult {
   const stat = fs.lstat(binPath)
   if (stat === null) return { kind: 'no-upstream', binPath }
 
-  if (isAlreadyShim(binPath, fs)) {
+  const wrapperKind = getWrapperKind(binPath, fs)
+  if (wrapperKind === 'image' || wrapperKind === 'local-alias') {
+    return { kind: 'already-installed', binPath }
+  }
+  if (wrapperKind === 'runtime' && opts.delegateTarget === undefined) {
     if (fs.statExists(stashTarget)) return { kind: 'already-installed', binPath }
-    // Wrapper survived a container restart but the image-owned stash did not
-    // (STASH_ROOT lives outside the bind-mount). The wrapper now points at a
-    // non-existent stashTarget, so executing it would ENOENT. Drop it and
-    // report no-upstream — there is nothing valid here to preserve, and the
-    // global-path shim (if it exists) stands on its own.
+    // The stash this wrapper points at is gone (STASH_ROOT lives outside the
+    // bind-mount), so executing it would ENOENT. Nothing here is worth
+    // preserving; drop it and report no-upstream.
     fs.unlink(binPath)
     return { kind: 'no-upstream', binPath }
   }
@@ -72,6 +78,11 @@ export function installShim(opts: InstallShimOptions = {}): InstallShimResult {
   // anything — otherwise we'd stash a broken symlink and write a wrapper
   // pointing at a target that never resolves.
   if (!fs.statExists(binPath)) return { kind: 'no-upstream', binPath }
+  if (opts.delegateTarget !== undefined) {
+    fs.unlink(binPath)
+    fs.writeFile(binPath, renderDelegatingWrapper(opts.delegateTarget), 0o755)
+    return { kind: 'delegated', binPath, delegateTarget: opts.delegateTarget }
+  }
 
   const realBin = resolveCurrentTarget(binPath, stat, fs)
   fs.mkdirp(stashDir)
@@ -102,11 +113,14 @@ function defaultStashDir(binPath: string): string {
   return join(STASH_ROOT, slug)
 }
 
-function isAlreadyShim(binPath: string, fs: ShimFs): boolean {
+function getWrapperKind(binPath: string, fs: ShimFs): 'image' | 'local-alias' | 'runtime' | null {
   try {
-    return fs.readFile(binPath).includes(SHIM_MARKER)
+    const contents = fs.readFile(binPath)
+    if (contents.includes(IMAGE_WRAPPER_MARKER)) return 'image'
+    if (contents.includes(LOCAL_ALIAS_MARKER)) return 'local-alias'
+    return contents.includes(SHIM_MARKER) ? 'runtime' : null
   } catch {
-    return false
+    return null
   }
 }
 
@@ -121,6 +135,13 @@ function renderWrapper(shimEntry: string, stashTarget: string): string {
 ${SHIM_MARKER}
 export ${REAL_BIN_ENV}="\${${REAL_BIN_ENV}:-${stashTarget}}"
 exec bun run ${shimEntry} "$@"
+`
+}
+
+function renderDelegatingWrapper(delegateTarget: string): string {
+  return `#!/bin/sh
+${LOCAL_ALIAS_MARKER}
+exec "${delegateTarget}" "$@"
 `
 }
 

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -2423,6 +2423,17 @@ describe('agent-browser headed-mode wrapper (Layer 4.5)', () => {
     expect(installIdx).toBeLessThan(wrapperIdx)
   })
 
+  test('build-time wrapper marks its image ownership and applies the default user agent', () => {
+    const wrapper = extractWrapperBody(buildBaseDockerfile())
+    expect(wrapper).toContain('# typeclaw-agent-browser-image-wrapper')
+    expect(wrapper).toContain('has_user_agent=0')
+    expect(wrapper).toContain('--user-agent|--user-agent=*) has_user_agent=1; break ;;')
+    expect(wrapper).toContain(
+      "export AGENT_BROWSER_USER_AGENT='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'",
+    )
+    expect(wrapper).not.toContain('bundled-plugins/agent-browser/shim.ts')
+  })
+
   test('versioned per-agent Dockerfile omits the wrapper RUN block — the base image already carries it (paired with the install layer) so re-applying would mv a non-existent .real file and break the build', () => {
     const out = buildDockerfile(dockerfileSchema.parse({}), { baseImageVersion: '0.1.1' })
     expect(out).not.toContain('mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser.real')
@@ -2466,6 +2477,7 @@ describe.skipIf(onWindows)('agent-browser headed-mode wrapper — executable beh
 {
   echo "args=[$*]"
   echo "HEADED=\${AGENT_BROWSER_HEADED-unset}"
+  echo "USER_AGENT=\${AGENT_BROWSER_USER_AGENT-unset}"
   echo "handled=\${_TYPECLAW_AGENT_BROWSER_HEADED_HANDLED-unset}"
   echo "---"
 } >> "${logfile}"
@@ -2510,6 +2522,22 @@ exit 0
     expect(calls).toHaveLength(1)
     expect(calls[0]).toContain('args=[snapshot]')
     expect(calls[0]).toContain('handled=unset')
+  })
+
+  test('injects the desktop Linux user agent when neither CLI nor environment selects one', async () => {
+    const { calls } = await runWrapper(['snapshot'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain(
+      'USER_AGENT=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    )
+  })
+
+  test('preserves explicit user-agent flag and environment precedence', async () => {
+    const fromFlag = await runWrapper(['snapshot', '--user-agent=FlagAgent/1.0'])
+    expect(fromFlag.calls[0]).toContain('USER_AGENT=unset')
+
+    const fromEnv = await runWrapper(['snapshot'], { AGENT_BROWSER_USER_AGENT: 'EnvAgent/1.0' })
+    expect(fromEnv.calls[0]).toContain('USER_AGENT=EnvAgent/1.0')
   })
 
   test('AGENT_BROWSER_HEADED=1 + open: allowlist hit, pre-closes first then exec-passes through', async () => {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1692,6 +1692,7 @@ RUN mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser.real \\
  && cat > /usr/local/bin/agent-browser <<'TYPECLAW_AGENT_BROWSER_WRAPPER_EOF' \\
  && chmod +x /usr/local/bin/agent-browser
 #!/bin/sh
+# typeclaw-agent-browser-image-wrapper
 # typeclaw wrapper for agent-browser — see src/init/dockerfile.ts.
 set -e
 real="\${TYPECLAW_AGENT_BROWSER_REAL:-/usr/local/bin/agent-browser.real}"
@@ -1700,6 +1701,17 @@ real="\${TYPECLAW_AGENT_BROWSER_REAL:-/usr/local/bin/agent-browser.real}"
 # agent-browser while AGENT_BROWSER_HEADED is still set.
 if [ "\${_TYPECLAW_AGENT_BROWSER_HEADED_HANDLED:-}" = "1" ]; then
   exec "$real" "$@"
+fi
+# Match upstream precedence: an explicit --user-agent flag or non-empty
+# AGENT_BROWSER_USER_AGENT wins; otherwise use a current desktop Linux UA.
+has_user_agent=0
+for arg in "$@"; do
+  case "$arg" in
+    --user-agent|--user-agent=*) has_user_agent=1; break ;;
+  esac
+done
+if [ -z "\${AGENT_BROWSER_USER_AGENT:-}" ] && [ "$has_user_agent" = "0" ]; then
+  export AGENT_BROWSER_USER_AGENT='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
 fi
 # Pre-close is only needed when the caller is requesting headed mode.
 # Match upstream's env_var_is_truthy contract (cli/src/flags.rs:183):


### PR DESCRIPTION
## Background

The image build and the runtime plugin both had an `agent-browser` wrapper contract, but they did not recognize each other. This change repairs that ownership boundary while preserving the supported local `npx agent-browser` entrypoint.

## Related work and contracts

- [#264](https://github.com/typeclaw/typeclaw/pull/264) introduced UA protection for callers that cannot be trusted to supply `--user-agent`.
- [#268](https://github.com/typeclaw/typeclaw/pull/268) introduced the **image-build-owned** global Xvfb/`--headed` wrapper.
- [#847](https://github.com/typeclaw/typeclaw/pull/847) documents the global/local shim paths.
- [`cd3917e6`](https://github.com/typeclaw/typeclaw/commit/cd3917e69f668678cd3fb40a3389cf036326cb28) drops to the invoking host UID before bundled plugins start.

## Root cause

The global wrapper from #268 had no marker recognized by the #264 runtime installer. After privilege drop, the plugin treated the root-owned `/usr/local/bin/agent-browser` wrapper as upstream and attempted a second stash-and-replace under `/usr/local`, causing `EACCES`/missing-real-binary failures.

## Resolution

- Mark the image-build-owned global wrapper and recognize it before any runtime mutation.
- Keep `/usr/local/bin` and `/usr/local/lib` image-owned; the unprivileged runtime never writes either path.
- Replace a real local `agent-browser` only in its writable local path with an executable alias to the global image wrapper, so `npx agent-browser` receives the same UA default and headed-mode lifecycle handling.
- Migrate every runtime-marked local shim to that alias, whether or not its legacy stash still exists. The stash-based short-circuit and self-heal now apply only when no delegation target is supplied.
- Preserve the headed-mode allowlist, reentrancy guard, and explicit UA precedence.

## Regression coverage

- Image-owned global wrapper: skipped with no runtime stash or filesystem mutation.
- Fresh local `npx` entrypoint: executable alias delegates arguments to the global wrapper.
- Upgrade with a missing legacy stash: local runtime shim becomes the executable alias.
- Upgrade with an intact legacy stash: local runtime shim still becomes the executable alias.
- Existing UA precedence, dangling-symlink, stale-runtime-stash, and headed-wrapper suites remain covered.

## Verification

- Focused browser shim suites: **281 pass, 0 fail**.
- `bun run format` and `bun run typecheck`: clean. `bun run lint`: **0 errors** (pre-existing warnings unchanged).
- Full suite: **12,040 pass, 31 skip, 0 fail**.

## Non-goals

- No permission widening under `/usr/local`.
- No root runtime after bootstrap.
- No Xvfb, `DISPLAY`, Chromium-installation, or headed-mode behavior change.