### PR TITLE
Let deep subagents ride out a provider capacity outage

### DIFF
--- a/src/agent/retry-same-ref.ts
+++ b/src/agent/retry-same-ref.ts
@@ -1,5 +1,5 @@
 import type { AgentSession } from './index'
-import { isRetryableSameRef, subscribeProviderErrors } from './provider-error'
+import { isRetryableSameRef, isThrottleOrOverload, subscribeProviderErrors } from './provider-error'
 
 // Same-ref retry policy. Conservative on purpose: the pi-ai provider layer ALSO
 // retries transport/5xx blips underneath us (WebSocket→SSE fallback + its own
@@ -11,6 +11,45 @@ import { isRetryableSameRef, subscribeProviderErrors } from './provider-error'
 export const RETRIES_PER_REF = 1
 const BASE_DELAY_MS = 1_000
 const MAX_DELAY_MS = 5_000
+
+// How much added latency a call site can absorb before the caller would rather
+// see a failure. Deliberately NOT the model-profile name: the retry layer cares
+// about latency tolerance, not which tier the operator configured. 'responsive'
+// is every interactive path (channel chat, TUI, slash commands, cron) and keeps
+// the historical fast-fail behavior; 'patient' is a background path where a
+// human is already waiting minutes for a considered answer. Today the only
+// producer is a subagent whose REQUESTED profile is `deep` (reviewer,
+// researcher) — see resolveRetryPolicy in subagents.ts.
+export type RetryPolicy = 'responsive' | 'patient'
+
+// Capacity backoff, used ONLY for throttle/overload under the 'patient' policy.
+// Kept separate from retryBackoffMs above on purpose: that curve (1–5s) is sized
+// for a one-off socket blip, and widening it globally would add dead air to the
+// TUI, slash commands, multimodal look-at, cron, and ordinary network errors.
+// An overload is a capacity outage measured in minutes, not milliseconds — the
+// incident that motivated this burned every retry in 4 seconds against a ~60s
+// outage — so it gets its own, much longer curve.
+//
+// Nominal delays are 10s, 20s, 30s, 30s, 30s, 30s (±20% jitter), so six retries
+// span roughly 120–180s of waiting and place the last attempt late enough to
+// outlive a two-minute blip.
+export const PATIENT_OVERLOAD_RETRIES = 6
+const PATIENT_OVERLOAD_BASE_MS = 10_000
+const PATIENT_OVERLOAD_CAP_MS = 30_000
+// Ceiling on when the LAST retry may START, not a hard wall on total elapsed
+// time: an attempt already in flight still runs to the observer's own 300s
+// overall deadline. The pathological upper bound is therefore ~8m, comfortably
+// inside the 30m reviewer/researcher spawn timeout.
+export const PATIENT_OVERLOAD_WINDOW_MS = 180_000
+
+// Proportional (±20%) rather than full jitter: full jitter can return ~0ms,
+// which against a capacity outage means retrying instantly into the same wall.
+// The floor keeps every wait meaningful while still decorrelating concurrent
+// subagents recovering from one upstream blip.
+export function patientOverloadBackoffMs(attempt: number, random: () => number = Math.random): number {
+  const nominal = Math.min(PATIENT_OVERLOAD_CAP_MS, PATIENT_OVERLOAD_BASE_MS * 2 ** attempt)
+  return Math.floor(nominal * (0.8 + random() * 0.4))
+}
 
 // Full-jitter exponential backoff: random in [0, min(cap, base·2^attempt)].
 // Jitter decorrelates concurrent turns (multiple channels/subagents recovering
@@ -58,7 +97,7 @@ type ContinuableAgent = {
 // no `agent.continue`) fails CLOSED — the caller falls back / surfaces instead.
 export async function retryTurnOnPersistentSession(
   session: AgentSession,
-  opts: { attempt: number; signal?: AbortSignal; random?: () => number } = { attempt: 0 },
+  opts: { attempt: number; signal?: AbortSignal; random?: () => number; delayMs?: number } = { attempt: 0 },
 ): Promise<boolean> {
   const agent = (session as { agent?: ContinuableAgent }).agent
   if (!agent || typeof agent.continue !== 'function') return false
@@ -67,7 +106,7 @@ export async function retryTurnOnPersistentSession(
   const leafRole = (messages[messages.length - 1] as { role?: unknown }).role
   if (leafRole !== 'assistant' && leafRole !== 'user') return false
 
-  await sleep(retryBackoffMs(opts.attempt, opts.random), opts.signal)
+  await sleep(opts.delayMs ?? retryBackoffMs(opts.attempt, opts.random), opts.signal)
   if (opts.signal?.aborted) return false
 
   // Drop only a trailing assistant error leaf; a trailing user message is already
@@ -153,11 +192,20 @@ function hasSameEntries(messages: unknown, expected: unknown[]): boolean {
 // WITHOUT the race (typeclaw owns the soft-error signal). On a non-retryable
 // failure it does exactly what a bare prompt() did: the throw propagates, or the
 // soft error stays on the leaf for the caller to read.
+export type SameRefPromptResult = { success: boolean; lastError?: Error }
+
 export async function promptWithSameRefRetryOnly(
   session: AgentSession,
   text: string,
   promptOpts?: Parameters<AgentSession['prompt']>[1],
-): Promise<void> {
+  opts: {
+    retryPolicy?: RetryPolicy
+    random?: () => number
+    now?: () => number
+    patientBackoffMs?: (attempt: number) => number
+  } = {},
+): Promise<SameRefPromptResult> {
+  const now = opts.now ?? (() => performance.now())
   let softError: Error | undefined
   // Feature-detect subscribe: some lightweight call sites / test fakes pass a
   // session without an event stream. Without it we simply can't observe soft
@@ -173,29 +221,61 @@ export async function promptWithSameRefRetryOnly(
     // transcript shape → retryTurnOnPersistentSession returns false) still
     // surfaces the original failure instead of resolving as a phantom success.
     let priorHardError: Error | undefined
+    let lastError: Error | undefined
+    let overloadRetries = 0
+    let patientWindowStartedAt: number | undefined
+    let nextDelayMs: number | undefined
     for (let attempt = 0; ; attempt++) {
       softError = undefined
       let hardError: Error | undefined
       try {
         if (attempt === 0) {
           await session.prompt(text, promptOpts)
-        } else if (!(await retryTurnOnPersistentSession(session, { attempt: attempt - 1 }))) {
+        } else if (
+          !(await retryTurnOnPersistentSession(session, {
+            attempt: attempt - 1,
+            ...(nextDelayMs !== undefined ? { delayMs: nextDelayMs } : {}),
+          }))
+        ) {
           // Continue-recipe not applicable: replay never happened, so the prior
           // failure stands — re-throw a hard error, or return to leave a soft
           // error on the leaf (bare-prompt() semantics).
           if (priorHardError !== undefined) throw priorHardError
-          return
+          return { success: false, ...(lastError !== undefined ? { lastError } : {}) }
         }
       } catch (err) {
         hardError = err instanceof Error ? err : new Error(String(err))
       }
       const error = hardError ?? softError
-      if (error === undefined) return
-      if (attempt >= RETRIES_PER_REF || !isRetryableSameRef(error.message)) {
+      if (error === undefined) return { success: true }
+      lastError = error
+      // A patient call site rides out a capacity outage on the same ref: there is
+      // no cross-ref failover on this path, so declining to retry an overload
+      // (isRetryableSameRef excludes it, expecting failover to handle it) would
+      // leave it with no recovery at all.
+      // The delay is budgeted BEFORE the retry is accepted: an elapsed-only check
+      // would let a retry taken just under the deadline sleep past it.
+      const nowMs = now()
+      const patientDelayMs =
+        opts.retryPolicy === 'patient' && isThrottleOrOverload(error.message)
+          ? (opts.patientBackoffMs ?? ((n: number) => patientOverloadBackoffMs(n, opts.random)))(overloadRetries)
+          : undefined
+      const patientElapsedMs = patientWindowStartedAt === undefined ? 0 : nowMs - patientWindowStartedAt
+      const patientOverload =
+        patientDelayMs !== undefined &&
+        overloadRetries < PATIENT_OVERLOAD_RETRIES &&
+        patientElapsedMs + patientDelayMs <= PATIENT_OVERLOAD_WINDOW_MS
+      if (patientOverload) {
+        patientWindowStartedAt ??= nowMs
+        nextDelayMs = patientDelayMs
+        overloadRetries++
+      } else if (attempt < RETRIES_PER_REF && isRetryableSameRef(error.message)) {
+        nextDelayMs = undefined
+      } else {
         // Out of budget or not retryable: preserve bare-prompt() semantics — a
         // hard error throws; a soft error stays on the leaf for the caller.
         if (hardError !== undefined) throw hardError
-        return
+        return { success: false, lastError: error }
       }
       priorHardError = hardError
     }

--- a/src/agent/subagents.test.ts
+++ b/src/agent/subagents.test.ts
@@ -1475,6 +1475,157 @@ describe('startSubagent', () => {
     expect(result.finalMessage).toContain(`<verdict>${INCOMPLETE_REVIEW_VERDICT}</verdict>`)
   })
 
+  type FailingTurn =
+    | { role?: string; content?: unknown; stopReason?: string; errorMessage?: string }
+    | { throws: string }
+
+  function providerFailingSession(turns: FailingTurn[][]) {
+    const prompts: string[] = []
+    const listeners = new Set<(event: unknown) => void>()
+    let turnIndex = 0
+    let leafMessage: unknown
+    const session = {
+      prompt: async (text: string) => {
+        prompts.push(text)
+        const messages = turns[turnIndex] ?? []
+        turnIndex++
+        for (const message of messages) {
+          if ('throws' in message) throw new Error(message.throws)
+          leafMessage = message
+          for (const l of listeners) l({ type: 'message_end', message })
+        }
+      },
+      dispose: () => {},
+      subscribe: (l: (event: unknown) => void) => {
+        listeners.add(l)
+        return () => {
+          listeners.delete(l)
+        }
+      },
+      abort: async () => {},
+      sessionManager: {
+        getLeafEntry: () => (leafMessage === undefined ? undefined : { type: 'message', message: leafMessage }),
+      },
+    } as unknown as AgentSession
+    return { session, prompts }
+  }
+
+  async function runReviewerOn(session: AgentSession) {
+    const registry = { reviewer: { systemPrompt: 'X' } satisfies Subagent }
+    const { completion } = startSubagent('reviewer', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_reviewer_provider',
+    })
+    return completion
+  }
+
+  const OVERLOADED = { role: 'assistant', stopReason: 'error', errorMessage: 'Overloaded' }
+
+  test('reviewer: an upstream provider failure spends ZERO nudges (re-prompting a dead provider is pointless)', async () => {
+    const { session, prompts } = providerFailingSession([[OVERLOADED]])
+
+    const result = await runReviewerOn(session)
+
+    if (!result.ok) throw new Error(`expected ok=true (guard, not silent drop), got error: ${result.error}`)
+    expect(prompts).toHaveLength(1)
+    expect(result.finalMessage).toContain('UPSTREAM PROVIDER FAILURE')
+    expect(result.finalMessage).toContain(`<verdict>${INCOMPLETE_REVIEW_VERDICT}</verdict>`)
+  })
+
+  test('reviewer: a provider failure is not reported as the reviewer failing to reach a verdict', async () => {
+    const { session } = providerFailingSession([[OVERLOADED]])
+
+    const result = await runReviewerOn(session)
+
+    if (!result.ok) throw new Error('expected ok=true')
+    expect(result.finalMessage).not.toContain('INCOMPLETE REVIEW')
+    expect(result.finalMessage).toContain('infrastructure failure')
+  })
+
+  test('reviewer: a model that merely omits the block still gets the full nudge budget and the model-fault wording', async () => {
+    const { session, prompts } = providerFailingSession([
+      [{ role: 'assistant', content: 'reading the files' }],
+      [{ role: 'assistant', content: 'still nothing' }],
+      [{ role: 'assistant', content: 'still nothing' }],
+    ])
+
+    const result = await runReviewerOn(session)
+
+    if (!result.ok) throw new Error('expected ok=true')
+    expect(prompts).toHaveLength(3)
+    expect(result.finalMessage).toContain('INCOMPLETE REVIEW')
+    expect(result.finalMessage).not.toContain('UPSTREAM PROVIDER FAILURE')
+  })
+
+  test('reviewer: a nudge that dies on the provider stops the loop instead of burning the last attempt', async () => {
+    const { session, prompts } = providerFailingSession([
+      [{ role: 'assistant', content: 'reading the files' }],
+      [OVERLOADED],
+      [{ role: 'assistant', content: 'never reached' }],
+    ])
+
+    const result = await runReviewerOn(session)
+
+    if (!result.ok) throw new Error('expected ok=true')
+    expect(prompts).toHaveLength(2)
+    expect(result.finalMessage).toContain('UPSTREAM PROVIDER FAILURE')
+  })
+
+  test('reviewer: a THROWN overload on the initial turn still reaches the provider-failure fallback', async () => {
+    const { session, prompts } = providerFailingSession([[{ throws: '429 Too Many Requests' }]])
+
+    const result = await runReviewerOn(session)
+
+    if (!result.ok) throw new Error(`expected ok=true, got error: ${result.error}`)
+    expect(prompts).toHaveLength(1)
+    expect(result.finalMessage).toContain('UPSTREAM PROVIDER FAILURE')
+    expect(result.finalMessage).toContain(`<verdict>${INCOMPLETE_REVIEW_VERDICT}</verdict>`)
+  })
+
+  test('reviewer: a THROWN overload on a nudge turn stops the loop and names the provider', async () => {
+    const { session, prompts } = providerFailingSession([
+      [{ role: 'assistant', content: 'reading the files' }],
+      [{ throws: 'Overloaded' }],
+      [{ role: 'assistant', content: 'never reached' }],
+    ])
+
+    const result = await runReviewerOn(session)
+
+    if (!result.ok) throw new Error(`expected ok=true, got error: ${result.error}`)
+    expect(prompts).toHaveLength(2)
+    expect(result.finalMessage).toContain('UPSTREAM PROVIDER FAILURE')
+  })
+
+  test('reviewer: an unrecognized exception still fails the subagent instead of being masked as an outage', async () => {
+    const { session } = providerFailingSession([[{ throws: 'TypeError: cannot read property of undefined' }]])
+
+    const result = await runReviewerOn(session)
+
+    expect(result.ok).toBe(false)
+  })
+
+  test('a subagent with no required block still FAILS on a thrown overload (no fallback to render it)', async () => {
+    // given: explorer has no requiredBlockTag, so there is no synthetic-result
+    // surface -- absorbing the throw here would report a clean run for a turn
+    // that never happened
+    const { session } = providerFailingSession([[{ throws: 'Overloaded' }]])
+    const registry = { explorer: { systemPrompt: 'X' } satisfies Subagent }
+
+    const { completion } = startSubagent('explorer', {
+      registry,
+      createSessionForSubagent: async () => session,
+      agentDir: '/agent',
+      userPrompt: 'q',
+      taskId: 'bg_explorer_overload',
+    })
+    const result = await completion
+
+    expect(result.ok).toBe(false)
+  })
+
   test('reviewer: the incomplete-review fallback can never carry a decisive verdict (re-review upgrade safety)', async () => {
     // given: a reviewer that exhausts its retries without reaching a verdict
     const { result } = await runReviewer([

--- a/src/agent/subagents.ts
+++ b/src/agent/subagents.ts
@@ -10,8 +10,8 @@ import { applyTurnThinkingLevel } from './attention-escalation'
 import { type AgentSession, createSession, type PluginSessionWiring } from './index'
 import { resolveFallbackChain } from './model-fallback'
 import { applyModelRuntimeOverrides } from './model-overrides'
-import { isFailoverWorthy, subscribeProviderErrors } from './provider-error'
-import { promptWithSameRefRetryOnly } from './retry-same-ref'
+import { detectHardProviderError, isFailoverWorthy, subscribeProviderErrors } from './provider-error'
+import { promptWithSameRefRetryOnly, type RetryPolicy } from './retry-same-ref'
 import type { SubagentBashPolicy } from './reviewer-bash-policy'
 import type { SessionOrigin } from './session-origin'
 import {
@@ -300,8 +300,35 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
       normalizeSubagentSession(await createSessionForSubagent(subagent, sessionOptions))
     let aborted = false
     let activeModelRef = resolveFallbackChain(getConfig().models, resolveSubagentProfile(subagent, sessionOptions))[0]!
-    let drainWatch: SubagentDrainWatch | undefined
+    // Latency tolerance is decided ONCE here, from the REQUESTED profile — not the
+    // one resolveProfile() landed on. A `deep` subagent whose operator never
+    // configured `models.deep` still runs on a background path nobody is watching
+    // live, so it stays patient; a spawn explicitly overridden onto `fast` is an
+    // explicit request for responsiveness and loses it.
+    const retryPolicy: RetryPolicy =
+      resolveSubagentProfile(subagent, sessionOptions) === 'deep' ? 'patient' : 'responsive'
+    // MUST be updated after every turn — initial, drain, and nudge — so a later
+    // success clears an earlier failure and the guard below reads the true state.
+    let latestTurnFailure: Error | undefined
     const requiredBlockTag = REQUIRED_FINAL_BLOCK[name]
+    // A provider failure reaches us as EITHER a soft leaf error or a hard throw
+    // (the turn runner rethrows a hard outcome once the chain is spent, and
+    // promptWithSameRefRetryOnly rethrows an exhausted hard error). Recording only
+    // the soft shape would let a thrown outage escape as a subagent crash and skip
+    // the required-block fallback entirely.
+    //
+    // Absorbing the throw is only safe where that fallback exists to turn it into
+    // an honest synthetic result. A subagent with no required block has no such
+    // surface, so swallowing there would report a clean ok:true for a turn that
+    // never ran. Those keep failing, as does anything unrecognized — loop-guard
+    // aborts, spawn timeouts, real bugs.
+    const recordHardProviderFailure = (err: unknown): void => {
+      if (requiredBlockTag === undefined) throw err
+      const detected = detectHardProviderError(err)
+      if (detected === null) throw err
+      latestTurnFailure = new Error(detected.message)
+    }
+    let drainWatch: SubagentDrainWatch | undefined
     const capture = attachFinalMessageCapture(session, requiredBlockTag, options.onFinalMessageCaptured ?? (() => {}))
     if (options.onSessionCreated !== undefined) {
       options.onSessionCreated({
@@ -346,6 +373,7 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           refs: resolveFallbackChain(getConfig().models, resolveSubagentProfile(subagent, sessionOptions)),
           currentModelRef: activeModelRef,
           profile: resolveSubagentProfile(subagent, sessionOptions),
+          retryPolicy,
           session,
           text: turnText,
           skipProviderErrorSubscription: true,
@@ -367,7 +395,10 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
           },
         })
         if (result.success) activeModelRef = result.refUsed
+        latestTurnFailure = result.success ? undefined : result.lastError
         throwIfLoopGuardAborted(session)
+      } catch (err) {
+        recordHardProviderFailure(err)
       } finally {
         if (hooks && turnEvent !== undefined) {
           await hooks.runSessionTurnEnd(turnEvent)
@@ -377,7 +408,17 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
         await runSubagentDrain(drainWatch, {
           drain: backgroundDrain,
           prompt: async (text) => {
-            await promptWithSameRefRetryOnly(session, `${renderTurnTimeAnchor()}\n\n${text}`)
+            try {
+              const drained = await promptWithSameRefRetryOnly(
+                session,
+                `${renderTurnTimeAnchor()}\n\n${text}`,
+                undefined,
+                { retryPolicy },
+              )
+              latestTurnFailure = drained.success ? undefined : drained.lastError
+            } catch (err) {
+              recordHardProviderFailure(err)
+            }
             throwIfLoopGuardAborted(session)
           },
           cancelled: () => aborted,
@@ -392,23 +433,39 @@ export async function invokeSubagent(name: string, options: InvokeSubagentOption
       // final contract-repair pass, not another research phase; it deliberately
       // does NOT re-run the drain.
       if (requiredBlockTag !== undefined) {
+        // `latestTurnFailure` set means the last turn died on an upstream provider
+        // error rather than finishing without the block. Nudging is then pointless
+        // — the nudge is itself a model call, so it hits the same failing provider
+        // and returns in ms, burning the whole budget in seconds against an outage
+        // that outlives it. Skip straight to a fallback that names the real cause.
         for (
           let attempt = 1;
-          !aborted && !capture.hasRequiredBlock() && attempt <= MAX_REQUIRED_BLOCK_RETRIES;
+          !aborted &&
+          !capture.hasRequiredBlock() &&
+          latestTurnFailure === undefined &&
+          attempt <= MAX_REQUIRED_BLOCK_RETRIES;
           attempt++
         ) {
           console.warn(
             `[subagent] ${name} required_block_retry attempt=${attempt}/${MAX_REQUIRED_BLOCK_RETRIES} tag=${requiredBlockTag}`,
           )
-          await promptWithSameRefRetryOnly(
-            session,
-            `${renderTurnTimeAnchor()}\n\n${renderRequiredBlockRetryNudge(requiredBlockTag)}`,
-          )
+          try {
+            const nudge = await promptWithSameRefRetryOnly(
+              session,
+              `${renderTurnTimeAnchor()}\n\n${renderRequiredBlockRetryNudge(requiredBlockTag)}`,
+              undefined,
+              { retryPolicy },
+            )
+            if (!nudge.success) latestTurnFailure = nudge.lastError
+          } catch (err) {
+            recordHardProviderFailure(err)
+          }
           throwIfLoopGuardAborted(session)
         }
         if (!aborted && !capture.hasRequiredBlock()) {
-          console.warn(`[subagent] ${name} required_block_fallback tag=${requiredBlockTag}`)
-          capture.setSyntheticFinalMessage(renderMissingRequiredBlockFallback(name, requiredBlockTag))
+          const reason: MissingBlockReason = latestTurnFailure !== undefined ? 'provider-failure' : 'missing-block'
+          console.warn(`[subagent] ${name} required_block_fallback tag=${requiredBlockTag} reason=${reason}`)
+          capture.setSyntheticFinalMessage(renderMissingRequiredBlockFallback(name, requiredBlockTag, reason))
         }
       }
       if (hooks && sessionId !== undefined) {
@@ -686,14 +743,26 @@ Output exactly one <${tag}> block and nothing else.`
 // src/skills/typeclaw-channel-github/SKILL.md.
 export const INCOMPLETE_REVIEW_VERDICT = 'incomplete-review-not-a-verdict'
 
+// Why the block is missing. 'missing-block' is the model's own doing — it ended
+// its turn without emitting the block. 'provider-failure' is an upstream outage:
+// the turn never ran to completion at all. Both produce the SAME sentinel verdict
+// (the downstream contract is identical — no analysis landed), but the prose must
+// name the real cause, or an operator reading a capacity outage is told the
+// subagent misbehaved and re-runs it straight into the same wall.
+type MissingBlockReason = 'missing-block' | 'provider-failure'
+
 // The terminal graceful fallback when the nudges are exhausted. It fabricates NO
 // findings — only a structured "could not complete" notice — so the parent gets
 // a usable result instead of stale `<analysis>` or a hard error.
-function renderMissingRequiredBlockFallback(name: string, tag: FinalBlockTag): string {
+function renderMissingRequiredBlockFallback(name: string, tag: FinalBlockTag, reason: MissingBlockReason): string {
+  const providerFailed = reason === 'provider-failure'
+  const cause = providerFailed
+    ? `the upstream model provider kept failing (capacity/outage), so the turn never completed`
+    : `it ended without emitting the required <${tag}> block`
   if (tag === 'report') {
     return `<report>
 <summary>
-The ${name} subagent could not complete a research report in this run: it ended without emitting the required <report> block (a known cause is the report tool not completing). Do not treat any earlier analysis text as findings — rerun the researcher or gather the sources directly if the answer is still needed.
+The ${name} subagent could not complete a research report in this run: ${cause}${providerFailed ? '' : ' (a known cause is the report tool not completing)'}. Do not treat any earlier analysis text as findings — rerun the researcher or gather the sources directly if the answer is still needed.
 </summary>
 <report_file>
 none
@@ -707,16 +776,20 @@ The original research request remains unresolved; rerun the ${name} subagent or 
 </report>`
   }
   if (tag === 'review') {
+    const headline = providerFailed ? 'UPSTREAM PROVIDER FAILURE — NOT A VERDICT' : 'INCOMPLETE REVIEW — NOT A VERDICT'
+    const remedy = providerFailed
+      ? 'This is an infrastructure failure, not a judgement on the code. Re-request the review once the provider recovers; do not report it as a review that found nothing.'
+      : 'Re-request the review; if it still cannot complete, post an honest "review could not be completed" note and leave existing review state unchanged.'
     return `<review>
 <summary>
-INCOMPLETE REVIEW — NOT A VERDICT. The ${name} subagent could not complete a review in this run: it ended without emitting the required <review> block. No findings were produced and no verdict was reached — do not treat any earlier text as a verdict, and do NOT map this to APPROVE/REQUEST_CHANGES/COMMENT (including on a re-review). Re-request the review; if it still cannot complete, post an honest "review could not be completed" note and leave existing review state unchanged.
+${headline}. The ${name} subagent could not complete a review in this run: ${cause}. No findings were produced and no verdict was reached — do not treat any earlier text as a verdict, and do NOT map this to APPROVE/REQUEST_CHANGES/COMMENT (including on a re-review). ${remedy}
 </summary>
 <findings>
 </findings>
 <verdict>${INCOMPLETE_REVIEW_VERDICT}</verdict>
 </review>`
   }
-  return `<${tag}>\nThe ${name} subagent ended without emitting the required <${tag}> block and could not recover; rerun it or inspect the transcript.\n</${tag}>`
+  return `<${tag}>\nThe ${name} subagent could not produce the required <${tag}> block (${cause}) and could not recover; rerun it or inspect the transcript.\n</${tag}>`
 }
 
 type SubagentCapture = {

--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -4,6 +4,7 @@ import type { ModelRef } from '@/config/providers'
 
 import type { AgentSession } from './index'
 import { isFailoverWorthy } from './provider-error'
+import { PATIENT_OVERLOAD_RETRIES, PATIENT_OVERLOAD_WINDOW_MS } from './retry-same-ref'
 import { ThrottleCircuit } from './throttle-circuit'
 import { promptPersistentTurnWithFallback } from './turn-runner'
 
@@ -1082,5 +1083,162 @@ describe('promptPersistentTurnWithFallback same-ref retry', () => {
     // one throttle record would need THRESHOLD(2) to open; a single turn must not
     // reach it — the circuit stays closed for REF_A.
     expect(circuit.isOpen({ profile: 'default', ref: REF_A })).toBe(false)
+  })
+})
+
+describe('promptPersistentTurnWithFallback patient overload retry', () => {
+  const patientOpts = {
+    circuit: new ThrottleCircuit(),
+    shouldFailover: (err: Error) => isFailoverWorthy(err.message),
+    setModelForRef: async () => {},
+    patientBackoffMs: () => 0,
+  }
+
+  test('rides out a capacity outage on a single-ref chain and recovers', async () => {
+    const fake = retryableFakeSession(['soft-throttle', 'soft-throttle', 'soft-throttle', 'success'])
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'review this',
+      retryPolicy: 'patient',
+    })
+
+    expect(result.success).toBe(true)
+    expect(fake.attempts()).toBe(4)
+  })
+
+  test('a responsive call site still fails fast on the same outage', async () => {
+    const fake = retryableFakeSession(['soft-throttle', 'soft-throttle', 'soft-throttle', 'success'])
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'hi',
+      retryPolicy: 'responsive',
+    })
+
+    expect(result.success).toBe(false)
+    expect(fake.attempts()).toBe(1)
+  })
+
+  test('omitting retryPolicy keeps the historical fast-fail behavior', async () => {
+    const fake = retryableFakeSession(['soft-throttle', 'success'])
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'hi',
+    })
+
+    expect(result.success).toBe(false)
+    expect(fake.attempts()).toBe(1)
+  })
+
+  test('gives up once the patient retry budget is exhausted', async () => {
+    const fake = retryableFakeSession(['soft-throttle'])
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'review this',
+      retryPolicy: 'patient',
+    })
+
+    expect(result.success).toBe(false)
+    expect(fake.attempts()).toBe(PATIENT_OVERLOAD_RETRIES + 1)
+  })
+
+  test('stops retrying once the patient window has elapsed', async () => {
+    const fake = retryableFakeSession(['soft-throttle'])
+    let clock = 0
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'review this',
+      retryPolicy: 'patient',
+      now: () => {
+        clock += PATIENT_OVERLOAD_WINDOW_MS
+        return clock
+      },
+    })
+
+    expect(result.success).toBe(false)
+    expect(fake.attempts()).toBeLessThan(PATIENT_OVERLOAD_RETRIES + 1)
+  })
+
+  test('rejects a retry whose backoff would start after the advertised window', async () => {
+    // given: a clock that lands 50ms inside the window, leaving no room for the
+    // 100ms backoff -- elapsed alone still passes, elapsed + backoff does not
+    const BACKOFF_MS = 100
+    const STEP_MS = PATIENT_OVERLOAD_WINDOW_MS - 50
+    let clock = 0
+    const fake = retryableFakeSession(['soft-throttle'], () => {
+      clock += STEP_MS
+    })
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'review this',
+      retryPolicy: 'patient',
+      patientBackoffMs: () => BACKOFF_MS,
+      now: () => clock,
+    })
+
+    // then: only the first retry is taken. A window check that ignored the
+    // backoff would have accepted a second one and started it past the deadline.
+    expect(result.success).toBe(false)
+    expect(fake.attempts()).toBe(2)
+  })
+
+  test('a non-terminal ref fails OVER immediately instead of waiting patiently', async () => {
+    const fake = retryableFakeSession(['soft-throttle', 'soft-throttle', 'success'])
+    const attemptedRefs: ModelRef[] = []
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [REF_A, ANTHROPIC_REF],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'review this',
+      retryPolicy: 'patient',
+      beforeAttempt: (ref) => {
+        attemptedRefs.push(ref)
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(attemptedRefs).toEqual([REF_A, ANTHROPIC_REF])
+    expect(fake.attempts()).toBe(3)
+  })
+
+  test('refuses a patient replay after the model already produced output', async () => {
+    const fake = fakeSession(['text-then-throttle', 'success'])
+
+    const result = await promptPersistentTurnWithFallback({
+      ...patientOpts,
+      refs: [ANTHROPIC_REF],
+      currentModelRef: ANTHROPIC_REF,
+      session: fake.session,
+      text: 'review this',
+      retryPolicy: 'patient',
+    })
+
+    expect(result.success).toBe(false)
+    expect(fake.prompted).toHaveLength(1)
   })
 })

--- a/src/agent/turn-runner.ts
+++ b/src/agent/turn-runner.ts
@@ -5,9 +5,18 @@ import {
   detectProviderError,
   isObserverTtfbTimeout,
   isRetryableSameRef,
+  isThrottleOrOverload,
   subscribeProviderErrors,
 } from './provider-error'
-import { RETRIES_PER_REF, retryTurnAfterCompletedToolResult, retryTurnOnPersistentSession } from './retry-same-ref'
+import {
+  PATIENT_OVERLOAD_RETRIES,
+  PATIENT_OVERLOAD_WINDOW_MS,
+  patientOverloadBackoffMs,
+  RETRIES_PER_REF,
+  retryTurnAfterCompletedToolResult,
+  retryTurnOnPersistentSession,
+  type RetryPolicy,
+} from './retry-same-ref'
 import { modelThrottleCircuit, type ThrottleCircuit } from './throttle-circuit'
 
 export type PersistentTurnAttempt = {
@@ -42,11 +51,13 @@ export async function promptPersistentTurnWithFallback(opts: {
   shouldFailover: (err: Error) => boolean
   setModelForRef: (ref: ModelRef) => Promise<void>
   profile?: string
+  retryPolicy?: RetryPolicy
   circuit?: ThrottleCircuit
   skipProviderErrorSubscription?: boolean
   detectSoftErrorFromLeaf?: boolean
   authorizeRetryAfterCompletedToolResult?: () => boolean
   retryRandom?: () => number
+  patientBackoffMs?: (attempt: number) => number
   onRetryBackoffStart?: () => void
   beforeAttempt?: (ref: ModelRef) => void
   onAttemptFailed?: (attempt: PersistentTurnAttempt) => void
@@ -107,6 +118,9 @@ export async function promptPersistentTurnWithFallback(opts: {
       // later iterations resume via agent.continue() (no user-message re-append).
       let outcome: AttemptOutcome | undefined
       let retryAfterCompletedToolResult = false
+      let overloadRetries = 0
+      let patientWindowStartedAt: number | undefined
+      let nextDelayMs: number | undefined
       for (let retry = 0; ; retry++) {
         softError = undefined
         const attemptStartedAt = now()
@@ -119,10 +133,14 @@ export async function promptPersistentTurnWithFallback(opts: {
               ? await retryTurnAfterCompletedToolResult(opts.session, {
                   attempt: retry - 1,
                   authorize: () => opts.authorizeRetryAfterCompletedToolResult?.() === true,
+                  ...(nextDelayMs !== undefined ? { delayMs: nextDelayMs } : {}),
                   ...(opts.retryRandom !== undefined ? { random: opts.retryRandom } : {}),
                   ...(opts.onRetryBackoffStart !== undefined ? { onBackoffStart: opts.onRetryBackoffStart } : {}),
                 })
-              : await retryTurnOnPersistentSession(opts.session, { attempt: retry - 1 })
+              : await retryTurnOnPersistentSession(opts.session, {
+                  attempt: retry - 1,
+                  ...(nextDelayMs !== undefined ? { delayMs: nextDelayMs } : {}),
+                })
             // The safe continue-recipe couldn't apply: keep the PREVIOUS failure
             // outcome (never cleared) and let it drive the advance/return below.
             if (!retried) break
@@ -145,7 +163,27 @@ export async function promptPersistentTurnWithFallback(opts: {
         // Retry within budget only when the failure is same-ref retryable and
         // either no visible/tool activity occurred, or the caller explicitly
         // authorizes the strict post-tool-result resume recipe.
-        const retryableWithinBudget = retry < RETRIES_PER_REF && isRetryableSameRef(outcome.error.message)
+        // Overload means "this ref is out of capacity NOW", so the standing policy
+        // is to fail OVER rather than burn same-ref retries — which is why
+        // isRetryableSameRef excludes it. But on the LAST usable ref there is
+        // nothing to fail over to, and a single-ref chain is all last, so that
+        // policy leaves a capacity outage with no recovery whatsoever. A patient
+        // call site rides it out here instead; a responsive one still fails fast.
+        // Budget the delay BEFORE accepting the retry. Testing only the elapsed
+        // window lets a retry accepted just under the deadline sleep past it, so
+        // the next provider attempt would START after the window we advertise.
+        const nowMs = now()
+        const patientDelayMs =
+          opts.retryPolicy === 'patient' && isLast && isThrottleOrOverload(outcome.error.message)
+            ? (opts.patientBackoffMs ?? ((n: number) => patientOverloadBackoffMs(n, opts.retryRandom)))(overloadRetries)
+            : undefined
+        const patientElapsedMs = patientWindowStartedAt === undefined ? 0 : nowMs - patientWindowStartedAt
+        const patientOverload =
+          patientDelayMs !== undefined &&
+          overloadRetries < PATIENT_OVERLOAD_RETRIES &&
+          patientElapsedMs + patientDelayMs <= PATIENT_OVERLOAD_WINDOW_MS
+        const retryableWithinBudget =
+          patientOverload || (retry < RETRIES_PER_REF && isRetryableSameRef(outcome.error.message))
         const mayRetryWithoutActivity = !activity.producedAssistantOutput && !activity.startedToolExecution
         retryAfterCompletedToolResult =
           retryableWithinBudget &&
@@ -153,6 +191,13 @@ export async function promptPersistentTurnWithFallback(opts: {
           opts.authorizeRetryAfterCompletedToolResult?.() === true
         const mayRetry = retryableWithinBudget && (mayRetryWithoutActivity || retryAfterCompletedToolResult)
         if (!mayRetry) break
+        if (patientOverload) {
+          patientWindowStartedAt ??= nowMs
+          nextDelayMs = patientDelayMs
+          overloadRetries++
+        } else {
+          nextDelayMs = undefined
+        }
       }
 
       if (outcome === undefined) {


### PR DESCRIPTION
## Background

A PR auto-review posted "the reviewer subagent terminated twice without a verdict" and left the PR unreviewed. The reviewer had not misbehaved — the model provider was returning `overloaded_error` for about a minute. Both reviewer attempts made **3 model calls each and gave up in ~4 seconds**; the session 90 seconds later worked fine.

Two independent defects turned a transient capacity blip into a user-visible review failure.

**1. An overload gets no retry at all on a single-ref chain.**

`isRetryableSameRef` excludes throttle/overload on the stated premise that failover should handle it. But `promptWithFallback` is a documented no-op once there is no ref left to advance to — and `models.deep` is commonly one ref, so every ref is the last one. The two policies each defer to the other and nobody retries. Confirmed in production logs: zero `falling back` lines, because `onAttemptFailed` is never even reached on a length-1 chain.

**2. The required-block guard could not tell an outage from a bad answer.**

It only checked `hasRequiredBlock()`, so a turn that died upstream looked identical to a model that declined to emit `<review>`. It spent both recovery nudges re-prompting the same dead provider — each returning in ~1.4s — then installed a fallback blaming the subagent. Total budget burned: ~4s against a ~60s outage.

Worth noting the outage is invisible in logs: the upstream returns it as **HTTP 200 with a ~157-byte SSE error frame**, so the fetch observer records `status=200 error=null`.

## Changes

Add a `RetryPolicy` (`'responsive' | 'patient'`) to the turn runner.

- On the **last usable ref, and only there**, a patient caller retries an overload on a capacity-sized curve (10/20/30/30/30/30s, ±20% jitter, 180s window) instead of the 1–5s transport curve. Gating on the terminal ref matters: without it a 3-ref chain could wait ~9 minutes before exhausting failover.
- Earlier refs still fail over immediately. The activity fence is unchanged — a turn that already produced output or started a tool is still never replayed.
- `promptWithSameRefRetryOnly` now reports `{ success, lastError }` so the drain and nudge turns feed the same signal.
- The required-block guard tracks the latest turn outcome across the initial prompt, the drain, and the nudges. On an upstream failure it skips nudging entirely, stops early if a nudge dies the same way, and names the real cause in the fallback.

**Only `deep` subagents are patient**, per the latency requirement: the default profile exists to be responsive and a chat user will not wait. Keying off the **requested** profile (not the resolved one) keeps reviewer/researcher patient when `models.deep` is unconfigured, while an explicit `profileOverride` onto a responsive tier opts back out. Channel chat, the TUI, and cron pass no profile, so interactive latency is unchanged.

The verdict sentinel stays `incomplete-review-not-a-verdict` for both causes — the downstream contract is identical (no analysis landed), and a second sentinel would have to be taught to every policy branch in `typeclaw-channel-github/SKILL.md` that keys off the first.

## Testing

`bun run lint` / `format:check` / `typecheck` / `test` all pass (12044 pass, 0 fail).

New coverage:
- Patient caller rides out an outage and recovers; a responsive caller on the **same input** stops after 1 attempt (this pair is the mutation-proof that the new branch is doing the work).
- Omitting the policy preserves historical behavior.
- Retry budget and the 180s window both terminate the loop.
- A non-terminal ref fails over immediately instead of waiting.
- No patient replay after the model produced output.
- Provider failure spends **zero** nudges and renders `UPSTREAM PROVIDER FAILURE`; a model that merely omits the block still gets the full budget and the old wording; a nudge that dies upstream stops the loop.

## Review notes

- The 180s window bounds when the last retry may *start*, not total elapsed time — an in-flight attempt still runs to the observer's 300s deadline, so the pathological ceiling is ~8m, well inside the 30m reviewer/researcher spawn timeout.
- `patientBackoffMs` is a test seam, consistent with the existing `now` / `retryRandom` / `circuit` injection in the same file.
- The circuit breaker cannot self-trip from this: `recordThrottle` already fires once per ref after same-ref retries are exhausted, not per internal retry.
- `Retry-After` is not honored yet. The observer only logs the header today and the incident carried `retry_after=null`, so plumbing it through was not worth the cross-request state in this change.
<!-- OMO_INTERNAL_INITIATOR -->
