### PR TITLE
Bump the bundled agent-browser pin to 0.33.0

### DIFF
--- a/docs/content/docs/internals/xvfb.mdx
+++ b/docs/content/docs/internals/xvfb.mdx
@@ -60,7 +60,7 @@ Container Chrome uses SwiftShader (CPU WebGL). WebGL renderer reports `"ANGLE (G
 
 ## Layer 4.5: agent-browser headed-mode wrapper
 
-Works around [vercel-labs/agent-browser#1083](https://github.com/vercel-labs/agent-browser/issues/1083) ("headed silently ignored on existing session"). When a headless daemon is already running and a command requests headed, the existing browser is reused. Three upstream PRs (#660, #370, #387) have been open for months as of agent-browser 0.27.0.
+Works around [vercel-labs/agent-browser#1083](https://github.com/vercel-labs/agent-browser/issues/1083) ("headed silently ignored on existing session"). When a headless daemon is already running and a command requests headed, the existing browser is reused. Three upstream PRs (#660, #370, #387) have been open for months as of agent-browser 0.33.0.
 
 Patch: `mv` the real binary to `/usr/local/bin/agent-browser.real`; drop a POSIX shell wrapper at the original path. When headed mode is requested and the subcommand is `open`/`goto`/`navigate`, the wrapper runs `"$real" close` then exec-passes through to `.real`. Forces a clean relaunch.
 

--- a/docs/content/docs/internals/xvfb.mdx
+++ b/docs/content/docs/internals/xvfb.mdx
@@ -72,6 +72,6 @@ Patch: `mv` the real binary to `/usr/local/bin/agent-browser.real`; drop a POSIX
 
 **Pre-close failure is non-fatal.** `"$real" close >/dev/null 2>&1 || true`. Wrapper still exec-passes.
 
-**Layer ordering.** 4.5 must run before Layer 5's `agent-browser install --with-deps` so the `mv` doesn't race the Chrome install. Wrapper is present in `buildBaseDockerfile` and the inline per-agent path, but NOT the versioned per-agent path (which FROMs the base image carrying the wrapper).
+**Layer ordering.** 4.5 must run before Layer 5's `agent-browser install` so the `mv` doesn't race the Chrome install. Wrapper is present in `buildBaseDockerfile` and the inline per-agent path, but NOT the versioned per-agent path (which FROMs the base image carrying the wrapper).
 
 **Removing when upstream merges.** Bump Layer 4 pin to the version with the fix, delete `LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER` + matching test block (search `#1083`), `typeclaw start --build`. Version bump alone removes it from existing agents because the Dockerfile regenerates on every `start`.

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -937,7 +937,7 @@ describe('Chrome runtime deps (amd64)', () => {
   test('Chrome runtime deps are installed in Layer 2 (before agent-browser CLI install in Layer 4), not only via the Layer 5 --with-deps backstop', () => {
     const out = buildDockerfile()
     const layer2Idx = out.indexOf('libglib2.0-0t64')
-    const layer4Idx = out.indexOf('bun install -g agent-browser@^0.27.0')
+    const layer4Idx = out.indexOf('bun install -g agent-browser@^0.33.0')
     expect(layer2Idx).toBeGreaterThan(-1)
     expect(layer4Idx).toBeGreaterThan(-1)
     expect(layer2Idx).toBeLessThan(layer4Idx)
@@ -1141,7 +1141,7 @@ describe('curl-impersonate layer', () => {
     const out = buildDockerfile()
     const aptIdx = out.indexOf('libglib2.0-0t64') // marker for Layer 2's else-branch (last apt thing in that block)
     const curlImpersonateIdx = out.indexOf('curl-impersonate.tar.gz')
-    const agentBrowserIdx = out.indexOf('bun install -g agent-browser@^0.27.0')
+    const agentBrowserIdx = out.indexOf('bun install -g agent-browser@^0.33.0')
     expect(aptIdx).toBeGreaterThan(-1)
     expect(curlImpersonateIdx).toBeGreaterThan(-1)
     expect(agentBrowserIdx).toBeGreaterThan(-1)
@@ -1215,7 +1215,7 @@ describe('base ↔ per-agent Dockerfile drift guard', () => {
 
   test('base Dockerfile installs the agent-browser CLI to the same global location the per-agent Dockerfile expects', () => {
     const base = buildBaseDockerfile()
-    expect(base).toContain('bun install -g agent-browser@^0.27.0')
+    expect(base).toContain('bun install -g agent-browser@^0.33.0')
   })
 
   test('base Dockerfile downloads Chrome for Testing on amd64 — without it the per-agent image would FROM a base that lacks the browser binary and `agent-browser install` would have to redo it', () => {
@@ -1301,7 +1301,7 @@ describe('versioned per-agent Dockerfile (base-image-pinning)', () => {
     // gated by docker.file.cloudflared; the per-agent versioned Dockerfile still emits
     // it when the toggle is on, so this regex deliberately excludes its sha256sum line)
     expect(countRunBlocksMatching(out, /curl-impersonate/)).toBe(0)
-    expect(countRunBlocksMatching(out, /bun install -g agent-browser@\^0\.27\.0/)).toBe(0)
+    expect(countRunBlocksMatching(out, /bun install -g agent-browser@\^0\.33\.0/)).toBe(0)
     expect(countRunBlocksMatching(out, /agent-browser install --with-deps/)).toBe(0)
     expect(countRunBlocksMatching(out, /apt-keep-cache|Keep-Downloaded-Packages/)).toBe(0)
     // and: no apt-get install line that also installs baseline packages
@@ -2407,7 +2407,7 @@ async function symlinkHostBinaries(targetDir: string, names: string[]): Promise<
 describe('agent-browser headed-mode wrapper (Layer 4.5)', () => {
   test('per-agent inline Dockerfile installs the wrapper after the agent-browser bun install — pre-close depends on the real binary existing at the path the wrapper mv-aliases', () => {
     const out = buildDockerfile()
-    const installIdx = out.indexOf('bun install -g agent-browser@^0.27.0')
+    const installIdx = out.indexOf('bun install -g agent-browser@^0.33.0')
     const wrapperIdx = out.indexOf('mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser.real')
     expect(installIdx).toBeGreaterThan(-1)
     expect(wrapperIdx).toBeGreaterThan(-1)
@@ -2418,7 +2418,7 @@ describe('agent-browser headed-mode wrapper (Layer 4.5)', () => {
     const base = buildBaseDockerfile()
     expect(base).toContain('mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser.real')
     expect(base).toContain('TYPECLAW_AGENT_BROWSER_WRAPPER_EOF')
-    const installIdx = base.indexOf('bun install -g agent-browser@^0.27.0')
+    const installIdx = base.indexOf('bun install -g agent-browser@^0.33.0')
     const wrapperIdx = base.indexOf('mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser.real')
     expect(installIdx).toBeLessThan(wrapperIdx)
   })

--- a/src/init/dockerfile.test.ts
+++ b/src/init/dockerfile.test.ts
@@ -934,7 +934,7 @@ describe('Chrome runtime deps (amd64)', () => {
     for (const p of CHROME_RUNTIME_APT_PACKAGES_AMD64) expect(pkgs).not.toContain(p)
   })
 
-  test('Chrome runtime deps are installed in Layer 2 (before agent-browser CLI install in Layer 4), not only via the Layer 5 --with-deps backstop', () => {
+  test('Chrome runtime deps are installed in Layer 2 (before agent-browser CLI install in Layer 4) — nothing else in the image installs them', () => {
     const out = buildDockerfile()
     const layer2Idx = out.indexOf('libglib2.0-0t64')
     const layer4Idx = out.indexOf('bun install -g agent-browser@^0.33.0')
@@ -1220,7 +1220,12 @@ describe('base ↔ per-agent Dockerfile drift guard', () => {
 
   test('base Dockerfile downloads Chrome for Testing on amd64 — without it the per-agent image would FROM a base that lacks the browser binary and `agent-browser install` would have to redo it', () => {
     const base = buildBaseDockerfile()
-    expect(base).toContain('agent-browser install --with-deps')
+    expect(base).toContain('agent-browser install')
+  })
+
+  test('no Dockerfile passes --with-deps: it shells out to sudo, which the image does not have, and agent-browser >=0.33 exits 1 instead of no-oping', () => {
+    expect(buildBaseDockerfile()).not.toContain('--with-deps')
+    expect(buildDockerfile()).not.toContain('--with-deps')
   })
 
   test('base Dockerfile points agent-browser at the apt chromium on arm64 (no Chrome for Testing download path on that arch)', () => {
@@ -1302,7 +1307,7 @@ describe('versioned per-agent Dockerfile (base-image-pinning)', () => {
     // it when the toggle is on, so this regex deliberately excludes its sha256sum line)
     expect(countRunBlocksMatching(out, /curl-impersonate/)).toBe(0)
     expect(countRunBlocksMatching(out, /bun install -g agent-browser@\^0\.33\.0/)).toBe(0)
-    expect(countRunBlocksMatching(out, /agent-browser install --with-deps/)).toBe(0)
+    expect(countRunBlocksMatching(out, /agent-browser install/)).toBe(0)
     expect(countRunBlocksMatching(out, /apt-keep-cache|Keep-Downloaded-Packages/)).toBe(0)
     // and: no apt-get install line that also installs baseline packages
     expect(out).not.toMatch(/apt-get install[^\n]*\bgit\b[^\n]*\bca-certificates\b/)
@@ -2443,7 +2448,7 @@ describe('agent-browser headed-mode wrapper (Layer 4.5)', () => {
   test('wrapper appears before the Chrome-for-Testing download — pre-close behavior cannot depend on whether the browser binary is present, and the layer ordering is the only thing that guarantees a clean mv+rewrite without racing the install step', () => {
     const out = buildDockerfile()
     const wrapperIdx = out.indexOf('mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser.real')
-    const chromeIdx = out.indexOf('agent-browser install --with-deps')
+    const chromeIdx = out.indexOf('agent-browser install')
     expect(wrapperIdx).toBeGreaterThan(-1)
     expect(chromeIdx).toBeGreaterThan(-1)
     expect(wrapperIdx).toBeLessThan(chromeIdx)
@@ -2451,7 +2456,7 @@ describe('agent-browser headed-mode wrapper (Layer 4.5)', () => {
 
   test('Chrome-for-Testing download in Layer 5 invokes the shimmed agent-browser binary — `agent-browser install` is not on the allowlist so the wrapper passes through unchanged at build time', () => {
     const out = buildDockerfile()
-    expect(out).toContain('agent-browser install --with-deps')
+    expect(out).toContain('agent-browser install')
     const wrapperBody = extractWrapperBody(out)
     expect(wrapperBody).toContain('open|goto|navigate')
   })

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1265,15 +1265,14 @@ RUN chmod +x ${TYPECLAW_CX_SESSION_START_HOOK_PATH} ${TYPECLAW_CX_STOP_HOOK_PATH
 }
 
 // Shared-library runtime deps Chrome for Testing needs to launch on amd64
-// Debian trixie (base of `oven/bun:1-slim`). `agent-browser install
-// --with-deps` (still true at v0.33.0) is supposed to install these but
-// silently no-ops:
-// its hardcoded list omits `libglib2.0-0t64`, so Chrome dies on launch
-// with `libglib-2.0.so.0: cannot open shared object file` even though the
-// binary download and `--with-deps` both exit 0. We install the full
-// Playwright-tested chromium dep set here in Layer 2 so the bug doesn't
-// recur if upstream omits another package; Layer 5 still calls
-// `--with-deps` as a no-op-on-cache-hit backstop for future deps.
+// Debian trixie (base of `oven/bun:1-slim`). This layer is the ONLY thing
+// that installs them. `agent-browser install --with-deps` looks like it
+// would, but it cannot: it shells out to `sudo apt-get` and there is no
+// sudo in the image. Its hardcoded list also omits `libglib2.0-0t64`
+// (still true at 0.33.0), so even where apt worked Chrome would die on
+// launch with `libglib-2.0.so.0: cannot open shared object file`. We
+// install the full Playwright-tested chromium dep set here so the bug
+// doesn't recur if upstream omits another package.
 //
 // Package list mirrors Playwright's `debian13-x64` chromium deps in
 // nativeDeps.ts (https://github.com/microsoft/playwright). t64-suffixed
@@ -1489,7 +1488,7 @@ ${renderAgentBrowserInstallLayer(buildKit)}
 
 ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 
-${renderChromeForTestingLayer(buildKit)}
+${renderChromeForTestingLayer()}
 
 ${cloudflaredBlock}${claudeCodeBlock}${codexCliBlock}${renderEntrypointShimLayer()}
 ${renderGitAskPassLayer()}
@@ -1567,7 +1566,7 @@ ${renderAgentBrowserInstallLayer(true)}
 
 ${LAYER_4_5_AGENT_BROWSER_HEADED_WRAPPER}
 
-${renderChromeForTestingLayer(true)}
+${renderChromeForTestingLayer()}
 
 ${renderEntrypointShimLayer()}
 ${renderGitAskPassLayer()}
@@ -1766,14 +1765,20 @@ TYPECLAW_AGENT_BROWSER_WRAPPER_EOF`
 
 // Layer 5: download the pinned Chrome for Testing build into
 // ~/.agent-browser/browsers/. NO cache mount on that path because the
-// runtime needs the binary in the image. System shared libraries are
-// already installed in Layer 2; --with-deps is a defense-in-depth backstop
-// so a future agent-browser bump that adds new deps installs them
-// automatically (near-no-op when Layer 2 already covers them).
-const renderChromeForTestingLayer = (buildKit: boolean): string =>
+// runtime needs the binary in the image, and no apt cache mount either
+// because nothing in this layer runs apt.
+//
+// Deliberately NOT `--with-deps`. That flag shells out to `sudo apt-get`
+// and there is no sudo in the image, so it could never install anything
+// here. Through 0.27.x it failed silently and still exited 0, which is
+// why it looked like a working backstop; 0.33.0 made it fail-closed
+// ("fails if deps fail" in its own --help) and turned that dead no-op
+// into a hard build failure. Chrome's shared libraries are installed for
+// real in Layer 2.
+const renderChromeForTestingLayer = (): string =>
   `# Layer 5 (heavy, amd64 only): Chrome for Testing download.
-RUN ${aptCacheMount(buildKit)}if [ "$TARGETARCH" != "arm64" ]; then \\
-      agent-browser install --with-deps; \\
+RUN if [ "$TARGETARCH" != "arm64" ]; then \\
+      agent-browser install; \\
     fi`
 
 function defaultConfig(): DockerfileConfig {

--- a/src/init/dockerfile.ts
+++ b/src/init/dockerfile.ts
@@ -1266,7 +1266,8 @@ RUN chmod +x ${TYPECLAW_CX_SESSION_START_HOOK_PATH} ${TYPECLAW_CX_STOP_HOOK_PATH
 
 // Shared-library runtime deps Chrome for Testing needs to launch on amd64
 // Debian trixie (base of `oven/bun:1-slim`). `agent-browser install
-// --with-deps` (v0.27.0) is supposed to install these but silently no-ops:
+// --with-deps` (still true at v0.33.0) is supposed to install these but
+// silently no-ops:
 // its hardcoded list omits `libglib2.0-0t64`, so Chrome dies on launch
 // with `libglib-2.0.so.0: cannot open shared object file` even though the
 // binary download and `--with-deps` both exit 0. We install the full
@@ -1641,7 +1642,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \\
 const renderAgentBrowserInstallLayer = (buildKit: boolean): string =>
   `# Layer 4 (volatile): install agent-browser globally so it survives the
 # runtime bind-mount over /agent/node_modules.
-RUN ${bunCacheMount(buildKit)}bun install -g agent-browser@^0.27.0`
+RUN ${bunCacheMount(buildKit)}bun install -g agent-browser@^0.33.0`
 
 // Layer 4.5: shim the agent-browser binary with a wrapper that calls
 // \`agent-browser close\` before \`open\`/\`goto\`/\`navigate\` when headed

--- a/src/init/index.test.ts
+++ b/src/init/index.test.ts
@@ -1293,7 +1293,7 @@ describe('writeDockerAssets', () => {
     // continuation slop + the actual install command. Lazy quantifier prevents
     // crossing into the next RUN block.
     expect(dockerfile).toMatch(/^RUN[\s\S]+?\bbun install -g agent-browser\b/m)
-    expect(dockerfile).toMatch(/^[^#\n]*\bagent-browser install --with-deps\b/m)
+    expect(dockerfile).toMatch(/^[^#\n]*\bagent-browser install\b/m)
   })
 
   test('Dockerfile bundles tmux for long-running detachable agent sessions', async () => {

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -769,7 +769,7 @@ function addCustomModel(
 // Must match the Dockerfile Layer 4 global install (dockerfile.ts); they are
 // two installs of the same CLI and a skew is silent. Enforced by a guard test
 // in packagejson.test.ts.
-export const AGENT_BROWSER_VERSION = '^0.27.0'
+export const AGENT_BROWSER_VERSION = '^0.33.0'
 function buildPackageJson(root: string, name: string, platform: NodeJS.Platform): Record<string, unknown> {
   return {
     name,

--- a/src/skills/typeclaw-monorepo/SKILL.md
+++ b/src/skills/typeclaw-monorepo/SKILL.md
@@ -89,7 +89,7 @@ To depend on a workspace package from the **agent root** (e.g. so cron `exec` jo
 {
   "dependencies": {
     "typeclaw": "file:../typeclaw",
-    "agent-browser": "^0.26.0",
+    "agent-browser": "^0.33.0",
     "my-utility": "workspace:*"
   }
 }


### PR DESCRIPTION
## Background

Every typeclaw agent ships `agent-browser` twice — as a dep in the scaffolded agent `package.json` and as a global `bun install -g` in Dockerfile Layer 4 — and both were pinned at `^0.27.0`. Because that's a caret range on a `0.x` version, npm/bun semantics stop it at `0.27.x`; it never picked up `0.28.0` and later on its own. Upstream has published 14 releases since (`0.28.0` → `0.33.0`), so the pin had silently drifted almost three months behind.

The version is load-bearing beyond "newer is nicer". Three Dockerfile layers encode assumptions about agent-browser's behavior, and each is a silent breakage if upstream moved underneath it:

- **Layer 4.5** wraps the binary to `close` before `open`/`goto`/`navigate` in headed mode, working around upstream [#1083](https://github.com/vercel-labs/agent-browser/issues/1083).
- **Layer 2** installs the full Playwright chromium dep set by hand.
- **Layer 3** (arm64) writes `{"executablePath":"/usr/bin/chromium"}` to `~/.agent-browser/config.json`.

Bumping the pin surfaced a fourth thing nobody knew was broken — see below.

## Summary

Moves both installs to `^0.33.0` in lockstep, and **removes `--with-deps` from Layer 5**, which turned out to have never worked.

### The `--with-deps` discovery

The first push failed the amd64 base-image build:

```
Running: sudo apt-get update
⚠ Could not run apt-get update: No such file or directory (os error 2)
✗ Aborting: apt could not install the required browser dependencies.
```

`agent-browser install --with-deps` shells out to **`sudo apt-get`**, and there is **no sudo in the image**. So the dep install could never have succeeded here — not at 0.33.0, and not at 0.27.0 either. What actually changed is that upstream made the flag fail-closed, which is visible in its own help text:

```
0.27.0:  -d, --with-deps   Also install system dependencies (Linux only)
0.33.0:  -d, --with-deps   Also install system dependencies (Linux only; fails if deps fail)
```

So this was a **dead no-op that had been quietly exiting 0 for as long as it's been in the Dockerfile**, and 0.33.0 only made the existing breakage visible. The old Layer 2 comment described it as "a no-op-on-cache-hit backstop for future deps" — that was wrong in a way that mattered: anyone relying on it to pick up new Chrome deps automatically would have been silently unprotected.

Verified directly on a `linux/amd64` container:

| Command | Exit |
| --- | --- |
| `command -v sudo` | absent |
| `agent-browser install` | **0** |
| `agent-browser install --with-deps` | **1** |

The fix is to drop the flag. Layer 2 is, and always actually was, the only thing installing Chrome's shared libraries. Confirmed by building the base image for `linux/amd64` and launching the Chrome it downloaded: every shared library resolves (`ldd` reports no `not found`) and `--dump-dom about:blank` exits 0.

I also dropped the layer's apt cache mount, since nothing in it runs apt anymore, and added a guard test so the flag can't come back.

**Why not keep `--with-deps` and install sudo?** That would add a setuid binary to a container that deliberately drops privileges, to serve an apt call whose package list is worse than the one Layer 2 already applies. **Why not `--with-deps || true`?** It would restore the silent-failure behavior this PR exists to remove.

### The rest of the bump

The other three assumptions were checked against the actual 0.33.0 artifacts rather than the release notes:

| Assumption | Status at 0.33.0 | Consequence |
| --- | --- | --- |
| #1083 open, fix PRs unmerged | Issue **open**; #660/#370/#387 all **open** | Layer 4.5 wrapper stays |
| `--with-deps` list omits libglib | Confirmed — no libglib package in its list at all | Layer 2 stays the sole dep source |
| `executablePath` + `.agent-browser` honored | Both **still present** in the CLI | Layer 3 config stays valid |

I also diffed the full `--help` subcommand surface between the 0.27.0 and 0.33.0 binaries: **no subcommand present in 0.27.0 was removed**. The delta is purely additive (`mcp` server, plugin system, `read`, `--webgpu`, HAR response bodies), so the wrapper's `open|goto|navigate` allowlist and its `close` pre-step are unaffected.

**Why the `^0.27.0` fixtures in `packagejson.test.ts` are untouched.** They assert `refreshPackageJson` *preserves* an operator-authored pin. Keeping the fixture different from `AGENT_BROWSER_VERSION` is what makes that test non-vacuous — syncing it would let the constant leak in and the test would pass even if the function started overwriting operator pins.

## What this does NOT do

- **Does not remove the Layer 4.5 headed-mode wrapper.** #1083 is still open upstream. When it lands, the wrapper, its tests, and the xvfb docs section can all go.
- **Does not change Layer 2's package list.** Removing `--with-deps` removes an install that was never happening; the real dep set is untouched.
- **Does not adopt any 0.28–0.33 feature.** No wiring for `mcp`, plugins, `read`, `--webgpu`, or HAR bodies.
- **Does not touch the base image tag.** `typeclaw-base` is rebuilt from `buildBaseDockerfile()` at release time.

## Review notes

Two load-bearing things:

1. **The lockstep between the two installs.** `AGENT_BROWSER_VERSION` (`src/init/index.ts`) and the Layer 4 literal (`src/init/dockerfile.ts`) are two installs of the same CLI, and a skew is silent at runtime. They can't share a constant — `index.ts` already imports `dockerfile.ts`, so importing back would be circular — hence the duplicated literal fenced by the guard test in `packagejson.test.ts`.

2. **Layer 2 is now documented as the sole provider of Chrome's shared libraries.** If someone later trims that package list because "`--with-deps` will catch it", Chrome dies at launch. The new guard test plus the rewritten comments are what protect that.

Verification beyond CI: base image built for `linux/amd64` locally, Chrome launched from inside it, all libraries resolved. Full suite 12057 pass / 0 fail.

The `wrapSystemTool` flake I flagged in the first revision passed on the re-run, which confirms it was load-related and unrelated to this branch.
