### PR TITLE
Stop capability errors from misleading the model

### DIFF
--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -10445,7 +10445,7 @@ describe('ChannelRouter history dispatch', () => {
     expect(slackCalls).toBe(0)
   })
 
-  test('a hung history callback times out and degrades to history-not-supported', async () => {
+  test('a hung history callback times out as an adapter error, never as history-not-supported', async () => {
     // given a fetchHistory callback that never resolves (production failure
     // mode: same root cause as the hung name resolver — REST stuck inside
     // the cold-start chain). Without the timeout, prefetchChannelContext
@@ -10469,10 +10469,22 @@ describe('ChannelRouter history dispatch', () => {
     const result = await router.fetchHistory('discord-bot', { chat: 'c1', thread: null, limit: 1 })
     const elapsed = Date.now() - start
 
-    // then it returns the not-supported degraded result and logs the timeout
+    // then it reports a live adapter failure — not a missing capability — and logs the timeout
     expect(elapsed).toBeLessThan(500)
     expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected a failed history fetch')
+    expect(result.error).toContain('history-adapter-error')
+    expect(result.error).not.toContain('history-not-supported')
     expect(logs.some((l) => l.includes('history fetch threw') && l.includes('timed out after 50ms'))).toBe(true)
+  })
+
+  test('an adapter with no registered history callback still reports history-not-supported', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+
+    const result = await router.fetchHistory('telegram-bot', { chat: 'c1', thread: null, limit: 1 })
+
+    expect(result).toEqual({ ok: false, error: 'history-not-supported' })
   })
 })
 
@@ -10542,7 +10554,7 @@ describe('ChannelRouter message-get dispatch', () => {
     expect(result).toEqual({ ok: false, error: 'message-get-not-supported', code: 'not-supported' })
   })
 
-  test('a hung message-get callback times out and degrades to not-supported', async () => {
+  test('a hung message-get callback times out as an adapter error, never as not-supported', async () => {
     const dir = await tempDir()
     const router = createChannelRouter({
       agentDir: dir,
@@ -10557,7 +10569,26 @@ describe('ChannelRouter message-get dispatch', () => {
     const elapsed = Date.now() - start
 
     expect(elapsed).toBeLessThan(500)
-    expect(result).toEqual({ ok: false, error: 'message-get-not-supported', code: 'not-supported' })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected a failed message-get')
+    expect(result.code).toBe('adapter-error')
+    expect(result.error).toContain('message-get-adapter-error')
+    expect(result.error).toContain('NOT an unsupported capability')
+  })
+
+  test('a throwing message-get callback reports the failure rather than claiming the capability is missing', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerMessageGet('discord-bot', async () => {
+      throw new Error('http 401')
+    })
+
+    const result = await router.getMessage('discord-bot', { chat: 'c1', thread: null, messageId: 'm1' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected a failed message-get')
+    expect(result.code).toBe('adapter-error')
+    expect(result.error).not.toContain('not-supported')
   })
 })
 
@@ -10621,6 +10652,44 @@ describe('ChannelRouter channel-list dispatch', () => {
     const result = await router.listChannels('slack-bot', { workspace: 'T0', limit: 50 })
 
     expect(result).toEqual({ ok: false, error: 'list-not-supported', code: 'not-supported' })
+  })
+
+  test('a throwing list callback reports an adapter error rather than claiming list is unsupported', async () => {
+    const dir = await tempDir()
+    const { router } = makeRouter(dir)
+    router.registerList('slack-bot', async () => {
+      throw new Error('http 401')
+    })
+
+    const result = await router.listChannels('slack-bot', { workspace: 'T0', limit: 50 })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected a failed listChannels')
+    expect(result.code).toBe('adapter-error')
+    expect(result.error).toContain('list-adapter-error')
+    expect(result.error).not.toContain('list-not-supported')
+  })
+
+  test('a hung list callback times out as an adapter error, never as not-supported', async () => {
+    const dir = await tempDir()
+    const router = createChannelRouter({
+      agentDir: dir,
+      configForAdapter: () => baseConfig,
+      fetchHistoryTimeoutMs: 50,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    })
+    router.registerList('slack-bot', () => new Promise(() => {}))
+
+    const start = Date.now()
+    const result = await router.listChannels('slack-bot', { workspace: 'T0', limit: 50 })
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeLessThan(500)
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected a failed listChannels')
+    expect(result.code).toBe('adapter-error')
+    expect(result.error).toContain('list-adapter-error')
+    expect(result.error).not.toContain('list-not-supported')
   })
 })
 

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -4080,6 +4080,14 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       ? `${capability}-adapter-unavailable: the "${adapter}" adapter is configured but not currently running (it likely failed to start, e.g. an expired token or auth error — check the container logs and re-authenticate)`
       : `${capability}-not-supported`
 
+  // A live callback that throws or times out is a FAILURE of a capability the
+  // adapter has, not the absence of one. Collapsing it into `*-not-supported`
+  // would tell the model the feature does not exist, and it will relay that to
+  // a human as fact. The underlying error stays in the logs rather than the
+  // model-facing string, matching `missingCallbackError`.
+  const callbackFailureError = (adapter: ChannelKey['adapter'], capability: ReadCapability): string =>
+    `${capability}-adapter-error: the "${adapter}" adapter supports ${capability} but the call failed or timed out. This is a live adapter failure, NOT an unsupported capability — check the container logs for the underlying error, then retry.`
+
   const isWriteCapabilityUnavailable = (adapter: ChannelKey['adapter'], capability: WriteCapability): boolean =>
     configuredAdapters.has(adapter) && ADAPTER_WRITE_CAPABILITIES[adapter].includes(capability)
 
@@ -4099,7 +4107,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         lastError = result
       } catch (err) {
         logger.warn(`[channels] history fetch threw for ${adapter}: ${describe(err)}`)
-        lastError = { ok: false, error: 'history-not-supported' }
+        lastError = { ok: false, error: callbackFailureError(adapter, 'history') }
       }
     }
     return lastError
@@ -4123,7 +4131,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return await raceWithTimeout(cb(args), fetchHistoryTimeoutMs, `[channels] ${adapter} message get`)
     } catch (err) {
       logger.warn(`[channels] message get threw for ${adapter}: ${describe(err)}`)
-      return { ok: false, error: 'message-get-not-supported', code: 'not-supported' }
+      return { ok: false, error: callbackFailureError(adapter, 'message-get'), code: 'adapter-error' }
     }
   }
 
@@ -4145,7 +4153,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       return await raceWithTimeout(cb(args), fetchHistoryTimeoutMs, `[channels] ${adapter} list channels`)
     } catch (err) {
       logger.warn(`[channels] list channels threw for ${adapter}: ${describe(err)}`)
-      return { ok: false, error: 'list-not-supported', code: 'not-supported' }
+      return { ok: false, error: callbackFailureError(adapter, 'list'), code: 'adapter-error' }
     }
   }
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -430,8 +430,11 @@ export type GetMessageResult =
   // as a soft error; `code: 'not-supported'` means the adapter is not configured
   // at all; `code: 'adapter-unavailable'` means it IS configured but currently
   // has no live callback (e.g. failed to start), mirroring `fetchHistory`'s
-  // 'message-get-adapter-unavailable' string contract.
-  | { ok: false; error: string; code?: 'not-found' | 'not-supported' | 'adapter-unavailable' }
+  // 'message-get-adapter-unavailable' string contract; `code: 'adapter-error'`
+  // means a live callback threw or timed out. That last one must never collapse
+  // into 'not-supported' — a thrown 401 reported as "unsupported" teaches the
+  // model the capability does not exist, and it will say so to a human.
+  | { ok: false; error: string; code?: 'not-found' | 'not-supported' | 'adapter-unavailable' | 'adapter-error' }
 
 export type MessageGetCallback = (args: GetMessageArgs) => Promise<GetMessageResult>
 
@@ -454,7 +457,7 @@ export type ListChannelsArgs = {
 
 export type ListChannelsResult =
   | { ok: true; entries: ChannelListEntry[]; nextCursor?: string }
-  | { ok: false; error: string; code?: 'not-supported' | 'adapter-unavailable' }
+  | { ok: false; error: string; code?: 'not-supported' | 'adapter-unavailable' | 'adapter-error' }
 
 // Backs the `channel_read` tool's `mode: "list"`. Opt-in per adapter like
 // history; the router answers 'list-not-supported' when none is registered.

--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -26,6 +26,38 @@ export class SandboxPolicyError extends Error {
   }
 }
 
+// Raised when model-driven bash invokes an agent-messenger CLI. TypeClaw never
+// brokers those reusable auth profiles (resolvePrivilegedSandboxRuntime) AND
+// masks the whole `workspace/.agent-messenger` directory, so the CLI can never
+// authenticate here — every platform resolves credentials from a
+// `<platform>-credentials.json` file, never from the environment.
+//
+// The refusal MUST announce itself. A silent one lets the uncredentialed CLI
+// print its own "No current workspace set. Run `auth extract` first.", which the
+// model reads as a fact about the WORLD — and it will then tell a human the
+// runtime has no workspace authentication, laundering a local policy decision
+// into a false claim about the upstream service. The CLI is honest about ITS
+// state; it has no way to know it was deliberately deprived.
+//
+// Hence the message states its own provenance: what was withheld, that the
+// decision is local, that retrying cannot help, and which mediated tool does
+// work. The last part is load-bearing — a dead end the model cannot route
+// around produces exactly the confabulation this class exists to prevent.
+export class SandboxCredentialWithheldError extends Error {
+  override readonly name = 'SandboxCredentialWithheldError'
+  constructor(executable: string) {
+    super(
+      `credential withheld by TypeClaw policy: \`${executable}\` cannot authenticate in model-driven bash. ` +
+        'TypeClaw never brokers an agent-messenger auth profile to a model-controlled child (the CLI can upload ' +
+        'arbitrary files, so a brokered credential would make it a confused deputy), and its credential directory ' +
+        'is masked. This is a LOCAL sandbox policy decision. It is NOT evidence that the workspace, account, or ' +
+        'upstream service lacks authentication — do not report it as such. Retrying, running `auth extract`, or ' +
+        'switching package runner will not change it. Use the mediated channel_* tools instead (channel_read, ' +
+        'channel_history, channel_send), which run inside TypeClaw with the configured channel credential.',
+    )
+  }
+}
+
 // Raised when the /proc strategy degraded to the empty `tmpfs` fallback AND the
 // command needs a real /proc (bunx / bun run that reads the
 // kernel-backed /proc/self/{fd,maps}). Without this pre-check Bun aborts deep in

--- a/src/sandbox/privileged-runtime.test.ts
+++ b/src/sandbox/privileged-runtime.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { buildSandboxedCommand } from './build'
+import { SandboxCredentialWithheldError } from './errors'
 import {
+  AGENT_MESSENGER_BINS,
   cleanupPrivilegedSandboxRuntime,
   resolvePrivilegedSandboxRuntime,
   verifyPrivilegedSandboxRuntime,
@@ -81,17 +83,87 @@ describe('resolvePrivilegedSandboxRuntime', () => {
   })
 
   test('keeps auth diagnostics executable but supplies no credential profile', async () => {
-    for (const command of [
-      'claude setup-token',
-      'gws auth status',
-      'agent-slack auth status',
-      'agent-slack --account test auth status',
-    ]) {
+    for (const command of ['claude setup-token', 'gws auth status']) {
       expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).toEqual({
         env: {},
         mounts: [],
       })
     }
+  })
+
+  test.each([
+    'agent-slack auth status',
+    'agent-slack --account test auth status',
+    'agent-slack channel list',
+    'bunx agent-slackbot message list general',
+  ])('refuses agent-messenger command %s rather than letting it fail as an auth error', async (command) => {
+    await expect(resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).rejects.toBeInstanceOf(
+      SandboxCredentialWithheldError,
+    )
+  })
+
+  test('the agent-messenger refusal disclaims being evidence about upstream authentication', async () => {
+    const thrown = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: {},
+      command: 'agent-slack message search hello',
+    }).catch((error: unknown) => error)
+
+    expect(thrown).toBeInstanceOf(SandboxCredentialWithheldError)
+    const { message } = thrown as Error
+    expect(message).toContain('LOCAL sandbox policy decision')
+    expect(message).toContain('NOT evidence that the workspace, account, or upstream service lacks authentication')
+    expect(message).toContain('channel_read')
+  })
+
+  test.each([
+    'agent-slack auth status 2>&1',
+    'bun x agent-messenger slack message list general',
+    'bun run agent-slackbot channel list',
+    'npx agent-messenger slack message search hello',
+    'pnpx agent-messenger slack message search hello',
+    'cd /tmp && agent-slack channel list',
+    'amsg slack message list general',
+    'agent-slack channel list | head -5',
+    '/agent/node_modules/.bin/agent-slack channel list',
+    'AGENT_MESSENGER_CONFIG_DIR=/tmp agent-slack channel list',
+  ])('refuses %s, which would otherwise reach the model as an upstream auth error', async (command) => {
+    await expect(resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).rejects.toBeInstanceOf(
+      SandboxCredentialWithheldError,
+    )
+  })
+
+  test('names the actual bin it refused so the message cannot misdescribe the command', async () => {
+    const thrown = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: {},
+      command: 'bunx amsg slack message list general',
+    }).catch((error: unknown) => error)
+
+    expect((thrown as Error).message).toContain('`amsg`')
+  })
+
+  test.each(['agent-lint --fix src', 'agent-browser open https://example.com'])(
+    'leaves unrelated executable %s runnable rather than claiming it needs agent-messenger credentials',
+    async (command) => {
+      expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).toEqual({
+        env: {},
+        mounts: [],
+      })
+    },
+  )
+
+  test('agent-browser stays runnable because it holds no agent-messenger credential profile', async () => {
+    expect(
+      await resolvePrivilegedSandboxRuntime({
+        agentDir,
+        homeDir: home,
+        env: {},
+        command: 'agent-browser open https://example.com',
+      }),
+    ).toEqual({ env: {}, mounts: [] })
   })
 
   test('does not follow a symlinked Codex auth file because Codex profiles are never brokered', async () => {
@@ -134,13 +206,14 @@ describe('resolvePrivilegedSandboxRuntime', () => {
     })
     expect(gwsRuntime).toEqual({ env: {}, mounts: [] })
 
-    const messengerRuntime = await resolvePrivilegedSandboxRuntime({
-      agentDir,
-      homeDir: home,
-      env: { AGENT_MESSENGER_CONFIG_DIR: messenger },
-      command: 'agent-slack channel list',
-    })
-    expect(messengerRuntime).toEqual({ env: {}, mounts: [] })
+    await expect(
+      resolvePrivilegedSandboxRuntime({
+        agentDir,
+        homeDir: home,
+        env: { AGENT_MESSENGER_CONFIG_DIR: messenger },
+        command: 'agent-slack channel list',
+      }),
+    ).rejects.toBeInstanceOf(SandboxCredentialWithheldError)
   })
 
   test('does not expose git config to an unknown alias command', async () => {
@@ -234,5 +307,14 @@ describe('resolvePrivilegedSandboxRuntime', () => {
     expect(await Promise.all(generated.map((source) => Bun.file(source).exists()))).toEqual(
       Array.from({ length: generated.length }, () => false),
     )
+  })
+})
+
+describe('agent-messenger bin manifest lockstep', () => {
+  test('the refused bin set matches every bin the installed agent-messenger exposes', async () => {
+    const manifest = path.join(import.meta.dir, '..', '..', 'node_modules', 'agent-messenger', 'package.json')
+    const installed = JSON.parse(await readFile(manifest, 'utf8')) as { bin: Record<string, string> }
+
+    expect([...AGENT_MESSENGER_BINS].sort()).toEqual(Object.keys(installed.bin).sort())
   })
 })

--- a/src/sandbox/privileged-runtime.ts
+++ b/src/sandbox/privileged-runtime.ts
@@ -2,7 +2,7 @@ import { chmod, lstat, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import { homedir, tmpdir } from 'node:os'
 import path from 'node:path'
 
-import { SandboxPolicyError } from './errors'
+import { SandboxCredentialWithheldError, SandboxPolicyError } from './errors'
 import type { SandboxMount } from './policy'
 
 const SAFE_GIT_SUBCOMMANDS = new Set([
@@ -30,6 +30,49 @@ const SAFE_GIT_SUBCOMMANDS = new Set([
 
 const SHELL_ACTIVE = new Set(['|', ';', '&', '\n', '\r', '(', ')', '{', '}', '<', '>', '`', '$', '\\'])
 
+// The exact bins agent-messenger installs, kept in lockstep with the installed
+// manifest by a test. Reserving the whole `agent-*` namespace instead would
+// over-claim AND under-claim: an unrelated user-installed `agent-lint` would be
+// refused with a false agent-messenger credential claim — the very class of
+// false statement this refusal exists to prevent — while `amsg`, a real
+// agent-messenger bin, carries no `agent-` prefix and would slip through.
+export const AGENT_MESSENGER_BINS: ReadonlySet<string> = new Set([
+  'agent-channeltalk',
+  'agent-channeltalkbot',
+  'agent-discord',
+  'agent-discordbot',
+  'agent-imessage',
+  'agent-instagram',
+  'agent-kakaotalk',
+  'agent-line',
+  'agent-messenger',
+  'agent-slack',
+  'agent-slackbot',
+  'agent-teams',
+  'agent-telegram',
+  'agent-telegrambot',
+  'agent-webex',
+  'agent-webexbot',
+  'agent-wechatbot',
+  'agent-whatsapp',
+  'agent-whatsappbot',
+  'amsg',
+])
+
+// Ephemeral runners that execute a package bin named by their first operand.
+// `bunx` is the bare-binary alias for `bun x` (see sandbox/package-install.ts);
+// npx/pnpx are the non-bun spellings the bun-hygiene guard still permits.
+const PACKAGE_RUNNERS = new Set(['bunx', 'npx', 'pnpx'])
+const BUN_RUNNER_SUBCOMMANDS = new Set(['x', 'run'])
+
+// Splits at the shell operators that begin a NEW simple command, mirroring
+// `commandNeedsRealProc`. Deliberately coarse: it over-splits inside quotes and
+// `$()`, but this feeds a DENY-ONLY decision, so a spurious extra segment can
+// only make the refusal MORE likely — it can never grant a credential.
+const SHELL_COMMAND_SEPARATOR = /(?:&&|\|\||[;|&\n()<>])+/
+
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
+
 export type PrivilegedSandboxRuntime = {
   env: Record<string, string>
   mounts: SandboxMount[]
@@ -46,6 +89,7 @@ export async function resolvePrivilegedSandboxRuntime(options: {
   env?: NodeJS.ProcessEnv
   homeDir?: string
 }): Promise<PrivilegedSandboxRuntime> {
+  rejectAgentMessengerCommand(options.command)
   const runtime = emptyRuntime()
   // TYPECLAW_GIT_TOKEN is set only after the auth analyzer accepts a Git command.
   // Trust that decision rather than reparsing its command with a less capable
@@ -62,15 +106,23 @@ export async function resolvePrivilegedSandboxRuntime(options: {
   const executable = unwrapBunx(parsed)
   if (executable === null) return runtime
 
+  // Re-checked here as well as in the deny-only scan: this path resolves quoted
+  // and `bunx`-wrapped executables the coarse segment split cannot.
+  if (AGENT_MESSENGER_BINS.has(path.basename(executable.executable))) {
+    throw new SandboxCredentialWithheldError(path.basename(executable.executable))
+  }
+
   // These CLIs can print or upload arbitrary files. Supplying their reusable
   // auth profile to a model-controlled child would therefore make the CLI a
   // confused deputy even when the outer shell is syntactically standalone.
-  if (
-    executable.executable === 'gws' ||
-    executable.executable === 'codex' ||
-    executable.executable === 'claude' ||
-    executable.executable.startsWith('agent-')
-  ) {
+  //
+  // They stay executable-but-uncredentialed rather than refused outright: an
+  // operator CAN authenticate them from `.env`, which model bash does inherit,
+  // so refusing would break working setups. The agent-messenger family cannot —
+  // every platform reads a `<platform>-credentials.json` file under the
+  // unconditionally masked `workspace/.agent-messenger` — so it is a guaranteed
+  // dead end and is refused loudly above instead of failing misleadingly.
+  if (executable.executable === 'gws' || executable.executable === 'codex' || executable.executable === 'claude') {
     return runtime
   }
 
@@ -94,6 +146,35 @@ export async function resolvePrivilegedSandboxRuntime(options: {
 
 function containsGitInvocation(command: string): boolean {
   return /(^|[;&|]\s*)git(?:\s|$)/.test(command.trim())
+}
+
+function rejectAgentMessengerCommand(command: string): void {
+  for (const segment of command.split(SHELL_COMMAND_SEPARATOR)) {
+    const bin = agentMessengerBinIn(segment)
+    if (bin !== undefined) throw new SandboxCredentialWithheldError(bin)
+  }
+}
+
+function agentMessengerBinIn(segment: string): string | undefined {
+  const words = segment
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.replaceAll(/^["']|["']$/g, ''))
+    .filter((word) => word !== '' && !ENV_ASSIGNMENT.test(word))
+  const operand = unwrapPackageRunner(words).find((word) => !word.startsWith('-'))
+  if (operand === undefined) return undefined
+  const bin = path.basename(operand)
+  return AGENT_MESSENGER_BINS.has(bin) ? bin : undefined
+}
+
+function unwrapPackageRunner(words: readonly string[]): readonly string[] {
+  const head = words[0]
+  if (head === undefined) return words
+  const runner = path.basename(head)
+  if (PACKAGE_RUNNERS.has(runner)) return words.slice(1)
+  const subcommand = words[1]
+  if (runner === 'bun' && subcommand !== undefined && BUN_RUNNER_SUBCOMMANDS.has(subcommand)) return words.slice(2)
+  return words
 }
 
 export async function verifyPrivilegedSandboxRuntime(runtime: PrivilegedSandboxRuntime): Promise<void> {


### PR DESCRIPTION
## Background

A production agent was asked in a Slack thread to search channel history. It ran `agent-slack …` in model bash, which failed and fell through to `bunx agent-messenger slack …`. That printed `{"error":"No current workspace set. Run \"auth extract\" first."}`. The agent then told the human, in Slack:

> 이 런타임에 조회용 워크스페이스 인증이 없어 기록 검색은 못 했습니다
> ("this runtime has no read-only workspace auth, so I couldn't search history")

That statement was false. The agent held a valid Slack bot token with `channels:history`, `groups:history`, `im:history`, and `channels:read`, and typeclaw exposes `channel_read`, which supports all of those on slack-bot. What actually happened: typeclaw *deliberately* withholds agent-messenger credentials from model bash — silently. The CLI had no way to know it had been deprived, so it reported its own state honestly, and the model read that honest report as a fact about the world and relayed it as one.

The governing invariant: **a tool result may only assert a fact about the world when the runtime has positive evidence of it; a local policy decision must be labeled as local.** Absence of a credential is not evidence of a missing capability.

Two defects violated that invariant, in opposite directions:

1. **Silent withholding.** `resolvePrivilegedSandboxRuntime` refused `agent-*` executables by returning an empty runtime with no message, so the downstream CLI's own vocabulary became the model's understanding. A scan of agent-messenger's error strings found ~297 auth-shaped messages across 78 files spanning 15 platform CLIs ("auth extract" ×155, "Not authenticated" ×82, "No current workspace set" ×57). Every one of those is guaranteed false inside a typeclaw container, because agent-messenger can never be authenticated there: there is no credential bridge, `workspace/.agent-messenger` is unconditionally tmpfs-masked, and every platform reads its state from a `<platform>-credentials.json` file rather than the environment.
2. **Inverse conflation.** `fetchHistory`, `getMessage`, and `listChannels` caught any callback throw or timeout and returned `*-not-supported`. So a live adapter failing an expired-token 401 reached the model as "typeclaw doesn't support this," teaching it a real capability doesn't exist.

## Summary

**`src/sandbox/privileged-runtime.ts` / `errors.ts`** — `resolvePrivilegedSandboxRuntime` now throws `SandboxCredentialWithheldError` for any `agent-*` executable instead of silently degrading to an uncredentialed runtime. The message states its own provenance: what was withheld, that the decision is local (not a fact about the workspace or account), that retrying or running `auth extract` cannot change it, and that `channel_read`/`channel_history`/`channel_send` are the mediated path that does work — the last part matters, since a dead end the model can't route around just produces different confabulation.

Two carve-outs, both intentional:
- `gws`/`codex`/`claude` keep the existing executable-but-uncredentialed behavior. An operator *can* authenticate those from `.env`, which model bash does inherit, so refusing them outright would break working setups. Only the agent-messenger family is provably unable to authenticate in this environment.
- `agent-browser` is exempt from the `agent-` prefix match (`NON_MESSENGER_AGENT_CLIS`). It ships in every agent and holds no agent-messenger profile — a blanket throw would break the most-used tool in the product. Covered by a regression test.

**`src/channels/router.ts` / `types.ts`** — a callback throw or timeout in `fetchHistory`/`getMessage`/`listChannels` now resolves to `*-adapter-error` (`code: 'adapter-error'`) instead of `*-not-supported`, explicitly saying this is a live failure and not a missing capability. A genuinely unregistered callback still answers `*-not-supported`, so the two stay distinguishable. The underlying exception stays log-only, matching the existing `missingCallbackError` posture of keeping adapter internals out of a model-facing string.

## What this does NOT do

- Does not touch `gws`, `codex`, or `claude` sandbox behavior — see the carve-out above.
- Does not add a typed tool-error taxonomy (`kind`/`origin`/`retryable`). `channel_read` still flattens typed codes into a bare string; a follow-up would thread `adapter-error` through as a structured field end-to-end instead of a string prefix.
- Does not fix `/agent/node_modules/.bin` being absent from the model-bash `PATH`, which makes skills that declare bins (`metadata.openclaw.requires.bins`) fail with exit 127 for an unrelated reason. Separate issue, noted here only because it was found while reading the same code paths.

## Review notes

The load-bearing invariant to check both diffs against: a refusal or a failure must say what happened and why in terms the model can act on (retry vs. don't, mediated tool vs. dead end) — never bare booleans or an upstream CLI's own error text passed through untouched.

- `src/sandbox/privileged-runtime.test.ts` — covers the `agent-browser` exemption and that `gws`/`codex`/`claude` are unaffected.
- `src/channels/router.test.ts` — covers `adapter-error` vs. `not-supported` staying distinguishable across all three read paths.

Verification: `bun run typecheck`, `bun run lint` (0 errors, pre-existing warnings elsewhere untouched), `bun run format:check`, `bun run test` (12,065 pass / 0 fail, 581 files) all clean on this branch.
