### PR TITLE
Keep a failed adapter under supervision instead of dropping it

### DIFF
--- a/src/channels/manager.test.ts
+++ b/src/channels/manager.test.ts
@@ -54,6 +54,15 @@ function makeFakeAdapter(): FakeAdapter & { connected: boolean } {
   return adapter
 }
 
+function makeStartFailingAdapter(message = '401: Unauthorized'): FakeAdapter & { connected: boolean } {
+  const adapter = makeFakeAdapter()
+  adapter.start = async () => {
+    adapter.startCalls++
+    throw new Error(message)
+  }
+  return adapter
+}
+
 function makeRecordingAdapter(
   events: string[],
   name: string,
@@ -165,6 +174,69 @@ function recordingLogger(): {
     error: (msg) => messages.push(`error:${msg}`),
     messages,
   }
+}
+
+function fakeRecoveryClock(
+  options: {
+    startMs?: number
+    checkIntervalMs?: number
+    disconnectedGraceMs?: number
+    retryBaseMs?: number
+    random?: () => number
+  } = {},
+): {
+  connectionRecovery: {
+    checkIntervalMs: number
+    disconnectedGraceMs: number
+    retryBaseMs: number
+    now: () => number
+    random: () => number
+    setInterval: (fn: () => void) => string
+    clearInterval: () => void
+  }
+  advanceBy: (ms: number) => boolean
+  fire: () => boolean
+  isArmed: () => boolean
+  intervalRegistrations: () => number
+  now: () => number
+} {
+  let nowMs = options.startMs ?? 0
+  let tick: (() => void) | null = null
+  let registrations = 0
+  const fire = (): boolean => {
+    if (tick === null) return false
+    tick()
+    return true
+  }
+  return {
+    connectionRecovery: {
+      checkIntervalMs: options.checkIntervalMs ?? 30_000,
+      disconnectedGraceMs: options.disconnectedGraceMs ?? 90_000,
+      retryBaseMs: options.retryBaseMs ?? options.checkIntervalMs ?? 30_000,
+      now: () => nowMs,
+      random: options.random ?? (() => 0.5),
+      setInterval: (fn) => {
+        tick = fn
+        registrations++
+        return `timer-${registrations}`
+      },
+      clearInterval: () => {
+        tick = null
+      },
+    },
+    advanceBy: (ms) => {
+      nowMs += ms
+      return fire()
+    },
+    fire,
+    isArmed: () => tick !== null,
+    intervalRegistrations: () => registrations,
+    now: () => nowMs,
+  }
+}
+
+const flushManagerWork = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 describe('channel manager — connection recovery', () => {
@@ -283,6 +355,542 @@ describe('channel manager — connection recovery', () => {
 
     await mgr.stop()
   })
+
+  test('retries a failed disconnect replacement until the adapter is live again', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock({ startMs: 1_000, checkIntervalMs: 10, disconnectedGraceMs: 100 })
+    const firstAdapter = makeFakeAdapter()
+    const failedReplacement = makeStartFailingAdapter()
+    const recoveredAdapter = makeFakeAdapter()
+    const adapters = [firstAdapter, failedReplacement, recoveredAdapter]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => adapters.shift()!,
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    firstAdapter.connected = false
+    clock.fire()
+    clock.advanceBy(101)
+    await flushManagerWork()
+
+    expect(firstAdapter.stopCalls).toBe(1)
+    expect(failedReplacement.startCalls).toBe(1)
+    expect(failedReplacement.stopCalls).toBe(1)
+    expect(recoveredAdapter.startCalls).toBe(0)
+
+    clock.advanceBy(9)
+    await flushManagerWork()
+    expect(recoveredAdapter.startCalls).toBe(0)
+
+    clock.advanceBy(1)
+    await flushManagerWork()
+    expect(recoveredAdapter.startCalls).toBe(1)
+
+    await mgr.stop()
+    expect(recoveredAdapter.stopCalls).toBe(1)
+  })
+
+  test('heals a boot-time start failure only when its retry deadline is due', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock()
+    const failedAdapter = makeStartFailingAdapter()
+    const recoveredAdapter = makeFakeAdapter()
+    const adapters = [failedAdapter, recoveredAdapter]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => adapters.shift()!,
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    expect(failedAdapter.startCalls).toBe(1)
+
+    clock.advanceBy(29_999)
+    await flushManagerWork()
+    expect(recoveredAdapter.startCalls).toBe(0)
+
+    clock.advanceBy(1)
+    await flushManagerWork()
+    expect(recoveredAdapter.startCalls).toBe(1)
+
+    await mgr.stop()
+  })
+
+  test('uses exponential retry deadlines capped at fifteen minutes and never fires early', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock()
+    const attemptTimes: number[] = []
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => {
+        const adapter = makeStartFailingAdapter()
+        adapter.start = async () => {
+          adapter.startCalls++
+          attemptTimes.push(clock.now())
+          throw new Error('still unavailable')
+        }
+        return adapter
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    const nominals = [30_000, 60_000, 120_000, 240_000, 480_000, 900_000, 900_000]
+    let expectedAttempts = 1
+    for (const nominal of nominals) {
+      const floor = nominal * 0.8
+      clock.advanceBy(floor - 1)
+      await flushManagerWork()
+      expect(attemptTimes).toHaveLength(expectedAttempts)
+
+      clock.advanceBy(nominal * 1.2 - (floor - 1))
+      await flushManagerWork()
+      expectedAttempts++
+      expect(attemptTimes).toHaveLength(expectedAttempts)
+    }
+
+    // every observed gap sits inside its own ±20% window, and the last two
+    // share the 15-minute cap rather than continuing to double
+    const gaps = attemptTimes.slice(1).map((at, i) => at - attemptTimes[i]!)
+    expect(gaps).toHaveLength(nominals.length)
+    for (const [i, nominal] of nominals.entries()) {
+      expect(gaps[i]!).toBeGreaterThanOrEqual(nominal * 0.8)
+      expect(gaps[i]!).toBeLessThanOrEqual(nominal * 1.2)
+    }
+    expect(nominals.at(-1)).toBe(900_000)
+    await mgr.stop()
+  })
+
+  test('claims a due retry before enqueue so repeated ticks cannot construct duplicates', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock()
+    const startGate = deferred()
+    const failedAdapter = makeStartFailingAdapter()
+    const retryAdapter = makeRecordingAdapter([], 'retry', { start: startGate.promise })
+    let constructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => {
+        constructions++
+        return constructions === 1 ? failedAdapter : retryAdapter
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    clock.advanceBy(30_000)
+    await Promise.resolve()
+    expect(retryAdapter.startCalls).toBe(1)
+
+    for (let i = 0; i < 5; i++) clock.fire()
+    await flushManagerWork()
+    expect(constructions).toBe(2)
+    expect(retryAdapter.startCalls).toBe(1)
+
+    startGate.resolve()
+    await flushManagerWork()
+    await mgr.stop()
+  })
+
+  test('clears failed supervision after recovery succeeds', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock()
+    const failedAdapter = makeStartFailingAdapter()
+    const recoveredAdapter = makeFakeAdapter()
+    let constructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => {
+        constructions++
+        return constructions === 1 ? failedAdapter : recoveredAdapter
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    clock.advanceBy(30_000)
+    await flushManagerWork()
+    expect(recoveredAdapter.startCalls).toBe(1)
+
+    for (let i = 0; i < 20; i++) {
+      clock.advanceBy(900_000)
+      await flushManagerWork()
+    }
+    expect(constructions).toBe(2)
+    expect(recoveredAdapter.startCalls).toBe(1)
+
+    await mgr.stop()
+  })
+
+  test('retries missing credentials and starts once the credential block appears', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const env: NodeJS.ProcessEnv = {}
+    const clock = fakeRecoveryClock()
+    const adapter = makeFakeAdapter()
+    let constructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env,
+      createDiscordAdapter: () => {
+        constructions++
+        return adapter
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    expect(constructions).toBe(0)
+    env.DISCORD_BOT_TOKEN = 'token-added-later'
+
+    clock.advanceBy(30_000)
+    await flushManagerWork()
+    expect(constructions).toBe(1)
+    expect(adapter.startCalls).toBe(1)
+
+    await mgr.stop()
+  })
+
+  test('reload keeps a credential-stripped live adapter supervised so restoring the token revives it', async () => {
+    // given: a live adapter whose token is then removed from env
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'token' }
+    const clock = fakeRecoveryClock()
+    const first = makeFakeAdapter()
+    const revived = makeFakeAdapter()
+    const adapters = [first, revived]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env,
+      createDiscordAdapter: () => adapters.shift()!,
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    expect(first.startCalls).toBe(1)
+
+    // when: the credential disappears and the operator reloads
+    delete env.DISCORD_BOT_TOKEN
+    const result = await mgr.reload()
+    expect(result.stopped).toContain('discord-bot')
+    expect(first.stopCalls).toBe(1)
+
+    // then: it stays under supervision rather than dropping out entirely
+    env.DISCORD_BOT_TOKEN = 'token-restored'
+    clock.advanceBy(30_000)
+    await flushManagerWork()
+    expect(revived.startCalls).toBe(1)
+
+    await mgr.stop()
+  })
+
+  test('reload reconciles credentials on an adapter a retry brought live, not just a boot start', async () => {
+    // given: boot fails, so the adapter only becomes live via the retry path
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'token-old' }
+    const clock = fakeRecoveryClock()
+    const revived = makeFakeAdapter()
+    const adapters = [makeStartFailingAdapter(), revived]
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env,
+      createDiscordAdapter: () => adapters.shift()!,
+      connectionRecovery: clock.connectionRecovery,
+    })
+    await mgr.start()
+    clock.advanceBy(30_000)
+    await flushManagerWork()
+    expect(revived.startCalls).toBe(1)
+
+    // when: the token rotates under an adapter that never went through boot start
+    env.DISCORD_BOT_TOKEN = 'token-rotated'
+    const reloaded = await mgr.reload()
+
+    // then: rotation is reported rather than silently skipped
+    expect(reloaded.restartRequired).toEqual(['discord-bot (token rotation)'])
+    expect(reloaded.started).toEqual([])
+
+    await mgr.stop()
+  })
+
+  test('retry deadlines stay within the jitter window at both extremes on production-cadence ticks', async () => {
+    // given: a 5s supervision tick against a 30s retry base, at both jitter ends
+    const base = 30_000
+    const windowMin = base * 0.8
+    const windowMax = base * 1.2
+    for (const random of [0, 0.5, 0.999] as const) {
+      cfg['discord-bot'] = enabledAdapterCfg()
+      const clock = fakeRecoveryClock({ checkIntervalMs: 5_000, retryBaseMs: 30_000, random: () => random })
+      let constructions = 0
+      const mgr = createChannelManager({
+        agentDir,
+        channelsConfigRef: () => cfg,
+        env: { DISCORD_BOT_TOKEN: 'token' },
+        createDiscordAdapter: () => {
+          constructions++
+          return makeStartFailingAdapter()
+        },
+        connectionRecovery: clock.connectionRecovery,
+      })
+      await mgr.start()
+      expect(constructions).toBe(1)
+
+      // when: ticking at the production 5s cadence until the retry fires
+      let elapsed = 0
+      while (constructions < 2 && elapsed < 120_000) {
+        clock.advanceBy(5_000)
+        await flushManagerWork()
+        elapsed += 5_000
+      }
+      // then: the OBSERVED retry time honours the advertised window, tick
+      // quantization included — not merely the unobservable computed deadline
+      expect(constructions).toBe(2)
+      expect(elapsed).toBeGreaterThanOrEqual(windowMin)
+      expect(elapsed).toBeLessThanOrEqual(windowMax)
+
+      await mgr.stop()
+    }
+  })
+
+  test('does not retry disabled or permanently unconstructable adapters', async () => {
+    cfg['discord-bot'] = { ...enabledAdapterCfg(), enabled: false }
+    cfg.slack = enabledAdapterCfg()
+    await writeSlackSecrets(agentDir)
+    const clock = fakeRecoveryClock()
+    const logger = recordingLogger()
+    let discordConstructions = 0
+    let slackConstructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      logger,
+      createDiscordAdapter: () => {
+        discordConstructions++
+        return makeFakeAdapter()
+      },
+      createSlackUserAdapter: () => {
+        slackConstructions++
+        return makeFakeAdapter()
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    for (let i = 0; i < 20; i++) {
+      clock.advanceBy(900_000)
+      await flushManagerWork()
+    }
+
+    expect(discordConstructions).toBe(0)
+    expect(slackConstructions).toBe(0)
+    expect(logger.messages.filter((message) => message.includes('could not be constructed'))).toHaveLength(1)
+    await mgr.stop()
+  })
+
+  test('throttles capped retry logs to one heartbeat every six hours', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock()
+    const logger = recordingLogger()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      logger,
+      createDiscordAdapter: () => makeStartFailingAdapter(),
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    for (const delay of [30_000, 60_000, 120_000, 240_000, 480_000]) {
+      clock.advanceBy(delay)
+      await flushManagerWork()
+    }
+    for (let i = 0; i < 48; i++) {
+      clock.advanceBy(900_000)
+      await flushManagerWork()
+    }
+
+    const retryLogs = logger.messages.filter((message) => message.includes('retrying in'))
+    expect(retryLogs).toHaveLength(8)
+    expect(retryLogs.filter((message) => message.startsWith('error:'))).toHaveLength(1)
+    expect(retryLogs.filter((message) => message.startsWith('warn:'))).toHaveLength(7)
+    expect(
+      retryLogs.filter((message) => message.includes('attempt 30') || message.includes('attempt 54')),
+    ).toHaveLength(2)
+    await mgr.stop()
+  })
+
+  test('stop is a hard barrier against an in-flight retry resurrection', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock()
+    const startGate = deferred()
+    const failedAdapter = makeStartFailingAdapter()
+    const retryAdapter = makeRecordingAdapter([], 'retry', { start: startGate.promise })
+    let constructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => {
+        constructions++
+        return constructions === 1 ? failedAdapter : retryAdapter
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    clock.advanceBy(30_000)
+    await Promise.resolve()
+    expect(retryAdapter.startCalls).toBe(1)
+
+    const stopCall = mgr.stop()
+    expect(clock.isArmed()).toBe(false)
+    startGate.resolve()
+    await stopCall
+
+    expect(retryAdapter.stopCalls).toBe(1)
+    expect(clock.fire()).toBe(false)
+    expect(constructions).toBe(2)
+  })
+
+  test('reload serializes behind a queued retry without leaking a second current adapter', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const env: NodeJS.ProcessEnv = { DISCORD_BOT_TOKEN: 'old-token' }
+    const clock = fakeRecoveryClock()
+    const failedAdapter = makeStartFailingAdapter()
+    const recoveredAdapter = makeFakeAdapter()
+    const leakedAdapter = makeFakeAdapter()
+    const adapters = [failedAdapter, recoveredAdapter, leakedAdapter]
+    const constructedWithTokens: string[] = []
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env,
+      createDiscordAdapter: (adapterOptions) => {
+        constructedWithTokens.push(adapterOptions.token)
+        return adapters.shift()!
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    clock.advanceBy(30_000)
+    env.DISCORD_BOT_TOKEN = 'new-token'
+    cfg['discord-bot'] = enabledAdapterCfg()
+    await mgr.reload()
+
+    expect(constructedWithTokens).toEqual(['old-token', 'new-token'])
+    expect(recoveredAdapter.startCalls).toBe(1)
+    expect(leakedAdapter.startCalls).toBe(0)
+
+    await mgr.stop()
+    expect(recoveredAdapter.stopCalls).toBe(1)
+    expect(leakedAdapter.stopCalls).toBe(0)
+  })
+
+  test('restartAdapter revives a failed adapter immediately but skips missing or disabled config', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock()
+    const failedAdapter = makeStartFailingAdapter()
+    const recoveredAdapter = makeFakeAdapter()
+    let constructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => {
+        constructions++
+        return constructions === 1 ? failedAdapter : recoveredAdapter
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    await mgr.restartAdapter('discord-bot')
+    expect(recoveredAdapter.startCalls).toBe(1)
+    expect(constructions).toBe(2)
+
+    delete cfg['discord-bot']
+    await mgr.restartAdapter('discord-bot')
+    cfg['discord-bot'] = { ...enabledAdapterCfg(), enabled: false }
+    await mgr.restartAdapter('discord-bot')
+    clock.advanceBy(30_000)
+    await flushManagerWork()
+    expect(constructions).toBe(2)
+
+    await mgr.stop()
+  })
+
+  test('does not start a replacement when recovery cannot stop the disconnected adapter', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const clock = fakeRecoveryClock({ startMs: 1_000, checkIntervalMs: 10, disconnectedGraceMs: 100 })
+    const firstAdapter = makeFakeAdapter()
+    firstAdapter.stop = async () => {
+      firstAdapter.stopCalls++
+      throw new Error('SDK stop failed')
+    }
+    const replacement = makeFakeAdapter()
+    let constructions = 0
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => {
+        constructions++
+        return constructions === 1 ? firstAdapter : replacement
+      },
+      connectionRecovery: clock.connectionRecovery,
+    })
+
+    await mgr.start()
+    firstAdapter.connected = false
+    clock.fire()
+    clock.advanceBy(101)
+    await flushManagerWork()
+
+    expect(firstAdapter.stopCalls).toBe(1)
+    expect(replacement.startCalls).toBe(0)
+    expect(constructions).toBe(1)
+
+    clock.fire()
+    await flushManagerWork()
+    expect(firstAdapter.stopCalls).toBe(2)
+    expect(replacement.startCalls).toBe(0)
+
+    await mgr.stop()
+  })
+
+  test('best-effort stops a partially initialized adapter after start throws', async () => {
+    cfg['discord-bot'] = enabledAdapterCfg()
+    const failedAdapter = makeStartFailingAdapter()
+    const mgr = createChannelManager({
+      agentDir,
+      channelsConfigRef: () => cfg,
+      env: { DISCORD_BOT_TOKEN: 'token' },
+      createDiscordAdapter: () => failedAdapter,
+    })
+
+    await mgr.start()
+
+    expect(failedAdapter.startCalls).toBe(1)
+    expect(failedAdapter.stopCalls).toBe(1)
+    await mgr.stop()
+  })
 })
 
 describe('channel manager — restartAdapter serialization', () => {
@@ -373,13 +981,13 @@ describe('channel manager — restartAdapter serialization', () => {
     await mgr.stop()
   })
 
-  test('restartAdapter is a no-op when the adapter is not live', async () => {
+  test('restartAdapter is a no-op when the adapter config is missing', async () => {
     const logger = recordingLogger()
     const mgr = createChannelManager({ agentDir, channelsConfigRef: () => cfg, logger })
 
     await mgr.restartAdapter('github')
 
-    expect(logger.messages).toContain("info:[channels] restartAdapter('github'): adapter not live, skipping")
+    expect(logger.messages).toContain("info:[channels] restartAdapter('github'): adapter config missing, skipping")
     await mgr.stop()
   })
 
@@ -445,8 +1053,9 @@ describe('channel manager — restartAdapter serialization', () => {
     await mgr.stop()
   })
 
-  test('start() rejects when adapter construction throws outside startAdapter catch', async () => {
+  test('start() preserves construction fail-fast and does not arm supervision', async () => {
     cfg['slack-bot'] = enabledAdapterCfg()
+    let timerArmCalls = 0
     const mgr = createChannelManager({
       agentDir,
       channelsConfigRef: () => cfg,
@@ -454,9 +1063,16 @@ describe('channel manager — restartAdapter serialization', () => {
       createSlackAdapter: () => {
         throw new Error('hostd env missing')
       },
+      connectionRecovery: {
+        setInterval: () => {
+          timerArmCalls++
+          return 'timer'
+        },
+      },
     })
 
     await expect(mgr.start()).rejects.toThrow('hostd env missing')
+    expect(timerArmCalls).toBe(0)
     await mgr.stop()
   })
 

--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -146,7 +146,14 @@ export type ChannelManagerOptions = {
   connectionRecovery?: {
     checkIntervalMs?: number
     disconnectedGraceMs?: number
+    // Base delay for the failed-adapter retry backoff (`retryBaseMs * 2^(n-1)`,
+    // capped at 15 minutes, jittered). Deliberately independent of
+    // `checkIntervalMs`: a retry deadline is only observed on a tick, so a tick
+    // as coarse as the base would round a jittered 30-36s deadline up to the
+    // 60s tick and silently double every early delay.
+    retryBaseMs?: number
     now?: () => number
+    random?: () => number
     setInterval?: (fn: () => void, ms: number) => unknown
     clearInterval?: (handle: unknown) => void
   }
@@ -188,6 +195,27 @@ type AdapterEntry = {
   recoveryRestartQueued: boolean
 }
 
+type FailedAdapter = {
+  kind: 'start-failed' | 'missing-credentials'
+  attempts: number
+  failedSinceMs: number
+  nextAttemptAtMs: number
+  retryQueued: boolean
+  nextLogAtMs: number
+}
+
+type StartAdapterResult =
+  | { status: 'started' }
+  | { status: 'disabled' }
+  | { status: 'blocked' }
+  | { status: 'aborted' }
+  | {
+      status: 'failed'
+      kind: FailedAdapter['kind']
+      detail: string
+      inputSignature: string
+    }
+
 export function createChannelManager(options: ChannelManagerOptions): ChannelManager {
   const logger = options.logger ?? consoleLogger
   const env = options.env ?? process.env
@@ -223,15 +251,20 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
   const createWebexBot = options.createWebexBotAdapter ?? createWebexBotAdapter
 
   const live = new Map<AdapterId, AdapterEntry>()
+  const failed = new Map<AdapterId, FailedAdapter>()
+  const failedInputSignatures = new WeakMap<FailedAdapter, string>()
   const perAdapterSerial = new Map<AdapterId, Promise<unknown>>()
   const recovery = options.connectionRecovery ?? {}
-  const recoveryCheckIntervalMs = recovery.checkIntervalMs ?? 30_000
+  const recoveryCheckIntervalMs = recovery.checkIntervalMs ?? 5_000
   const recoveryDisconnectedGraceMs = recovery.disconnectedGraceMs ?? 90_000
   const recoveryNow = recovery.now ?? (() => Date.now())
+  const recoveryRandom = recovery.random ?? Math.random
   const recoverySetInterval = recovery.setInterval ?? ((fn: () => void, ms: number) => setInterval(fn, ms))
   const recoveryClearInterval =
     recovery.clearInterval ?? ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>))
   let recoveryTimer: unknown = null
+  let running = false
+  let lifecycleEpoch = 0
 
   const runSerially = <T>(name: AdapterId, op: () => Promise<T>): Promise<T> => {
     const prev = perAdapterSerial.get(name) ?? Promise.resolve()
@@ -408,50 +441,218 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
     return null
   }
 
-  const startAdapter = async (name: AdapterId, cfg: ChannelAdapterConfig): Promise<boolean> => {
+  const buildFailedInputSignature = (
+    name: AdapterId,
+    cfg: ChannelAdapterConfig,
+    credentials = buildCredentialSignature(name),
+  ): string => JSON.stringify([cfg, credentials.signature, credentials.missing])
+
+  const cleanupPartialStart = async (adapter: AnyAdapter): Promise<void> => {
+    try {
+      await adapter.stop()
+    } catch {}
+  }
+
+  const startAdapter = async (
+    name: AdapterId,
+    cfg: ChannelAdapterConfig,
+    canCommit: () => boolean,
+  ): Promise<StartAdapterResult> => {
+    if (!canCommit()) return { status: 'aborted' }
     if (cfg.enabled === false) {
       logger.info(`[channels] adapter "${name}" is disabled; skipping`)
-      return false
+      return { status: 'disabled' }
     }
-    const { signature, missing } = buildCredentialSignature(name)
+    const credentials = buildCredentialSignature(name)
+    const { signature, missing } = credentials
     if (missing.length > 0) {
-      logger.error(`[channels] adapter "${name}" missing credentials: ${missing.join(', ')}; skipping`)
-      return false
+      return {
+        status: 'failed',
+        kind: 'missing-credentials',
+        detail: `missing credentials: ${missing.join(', ')}`,
+        inputSignature: buildFailedInputSignature(name, cfg, credentials),
+      }
     }
     const adapter = buildAdapter(name, cfg)
     if (adapter === null) {
       logger.error(`[channels] adapter "${name}" could not be constructed; skipping`)
-      return false
+      return { status: 'blocked' }
     }
     try {
       await adapter.start()
+      if (!canCommit()) {
+        await cleanupPartialStart(adapter)
+        return { status: 'aborted' }
+      }
       live.set(name, {
         adapter,
         credentialSignature: signature,
         disconnectedSinceMs: adapter.isConnected() ? null : recoveryNow(),
         recoveryRestartQueued: false,
       })
-      logger.info(`[channels] adapter "${name}" started`)
+      return { status: 'started' }
+    } catch (err) {
+      await cleanupPartialStart(adapter)
+      if (!canCommit()) return { status: 'aborted' }
+      return {
+        status: 'failed',
+        kind: 'start-failed',
+        detail: `failed to start: ${describeError(err)}`,
+        inputSignature: buildFailedInputSignature(name, cfg, credentials),
+      }
+    }
+  }
+
+  const retryCapMs = 15 * 60 * 1_000
+  const retryHeartbeatMs = 6 * 60 * 60 * 1_000
+  const retryBaseMs = Math.max(1, recovery.retryBaseMs ?? 30_000)
+
+  const nominalRetryDelayMs = (attempts: number): number =>
+    Math.min(retryCapMs, retryBaseMs * 2 ** Math.min(30, attempts - 1))
+
+  const retryDelayMs = (attempts: number): number => {
+    const nominal = nominalRetryDelayMs(attempts)
+    const spread = nominal * 0.4
+    // A deadline is only ever observed on a supervision tick, which rounds it
+    // UP by as much as one interval. Narrow the jitter spread by that interval
+    // so the OBSERVED retry still lands inside the advertised ±20% window
+    // instead of up to a tick beyond it. When the tick is coarser than the
+    // window there is no room to compensate, so fall back to plain jitter and
+    // let quantization dominate rather than collapsing every delay to the floor.
+    const usableSpread = recoveryCheckIntervalMs < spread ? spread - recoveryCheckIntervalMs : spread
+    return Math.min(retryCapMs, Math.floor(nominal * 0.8 + recoveryRandom() * usableSpread))
+  }
+
+  const recordFailure = (
+    name: AdapterId,
+    cfg: ChannelAdapterConfig,
+    failure: Extract<StartAdapterResult, { status: 'failed' }>,
+    previous?: FailedAdapter,
+  ): FailedAdapter => {
+    const now = recoveryNow()
+    const continuing = previous !== undefined && failed.get(name) === previous
+    const attempts = continuing ? previous.attempts + 1 : 1
+    const delayMs = retryDelayMs(attempts)
+    const nominalDelayMs = nominalRetryDelayMs(attempts)
+    const previousNominalDelayMs = attempts > 1 ? nominalRetryDelayMs(attempts - 1) : 0
+    const entry: FailedAdapter = continuing
+      ? previous
+      : {
+          kind: failure.kind,
+          attempts,
+          failedSinceMs: now,
+          nextAttemptAtMs: now + delayMs,
+          retryQueued: false,
+          nextLogAtMs: Number.POSITIVE_INFINITY,
+        }
+
+    entry.kind = failure.kind
+    entry.attempts = attempts
+    entry.nextAttemptAtMs = now + delayMs
+    entry.retryQueued = false
+
+    const reachedCap = nominalDelayMs === retryCapMs
+    const justReachedCap = reachedCap && previousNominalDelayMs < retryCapMs
+    if (justReachedCap) entry.nextLogAtMs = now + retryHeartbeatMs
+
+    if (attempts === 1) {
+      if (reachedCap) entry.nextLogAtMs = now + retryHeartbeatMs
+      logger.error(`[channels] adapter "${name}" ${failure.detail} (attempt ${attempts}); retrying in ${delayMs}ms`)
+    } else if (nominalDelayMs > previousNominalDelayMs) {
+      logger.warn(
+        `[channels] adapter "${name}" still unavailable after ${Math.round(now - entry.failedSinceMs)}ms (attempt ${attempts}; ${failure.detail}); retrying in ${delayMs}ms`,
+      )
+    } else if (reachedCap && now >= entry.nextLogAtMs) {
+      logger.warn(
+        `[channels] adapter "${name}" still unavailable after ${Math.round(now - entry.failedSinceMs)}ms (attempt ${attempts}; ${failure.detail}); retrying in ${delayMs}ms`,
+      )
+      entry.nextLogAtMs = now + retryHeartbeatMs
+    }
+
+    failed.set(name, entry)
+    failedInputSignatures.set(entry, failure.inputSignature)
+    return entry
+  }
+
+  const applyStartResult = (
+    name: AdapterId,
+    cfg: ChannelAdapterConfig,
+    result: StartAdapterResult,
+    previousFailure?: FailedAdapter,
+  ): boolean => {
+    if (result.status === 'started') {
+      const recoveryState = failed.get(name) ?? previousFailure
+      failed.delete(name)
+      if (recoveryState === undefined) {
+        logger.info(`[channels] adapter "${name}" started`)
+      } else {
+        logger.info(
+          `[channels] adapter "${name}" recovered after ${Math.round(recoveryNow() - recoveryState.failedSinceMs)}ms (${recoveryState.attempts} failed attempts)`,
+        )
+      }
+      return true
+    }
+    if (result.status === 'failed') {
+      recordFailure(name, cfg, result, previousFailure)
+    } else if (previousFailure !== undefined && failed.get(name) === previousFailure) {
+      failed.delete(name)
+    }
+    return false
+  }
+
+  const recordMissingCredentialFailure = (
+    name: AdapterId,
+    cfg: ChannelAdapterConfig,
+    credentials: { signature: string; missing: string[] },
+  ): void => {
+    recordFailure(
+      name,
+      cfg,
+      {
+        status: 'failed',
+        kind: 'missing-credentials',
+        detail: `missing credentials: ${credentials.missing.join(', ')}`,
+        inputSignature: buildFailedInputSignature(name, cfg, credentials),
+      },
+      failed.get(name),
+    )
+  }
+
+  const recordUnexpectedStartFailure = (
+    name: AdapterId,
+    cfg: ChannelAdapterConfig,
+    err: unknown,
+    previous?: FailedAdapter,
+  ): void => {
+    recordFailure(
+      name,
+      cfg,
+      {
+        status: 'failed',
+        kind: 'start-failed',
+        detail: `failed to start: ${describeError(err)}`,
+        inputSignature: buildFailedInputSignature(name, cfg),
+      },
+      previous,
+    )
+  }
+
+  const stopAdapter = async (name: AdapterId): Promise<boolean> => {
+    const entry = live.get(name)
+    if (!entry) return true
+    try {
+      await entry.adapter.stop()
+      if (live.get(name) === entry) live.delete(name)
+      logger.info(`[channels] adapter "${name}" stopped`)
       return true
     } catch (err) {
-      logger.error(`[channels] adapter "${name}" failed to start: ${describeError(err)}`)
+      logger.error(`[channels] adapter "${name}" failed to stop: ${describeError(err)}`)
       return false
     }
   }
 
-  const stopAdapter = async (name: AdapterId): Promise<void> => {
-    const entry = live.get(name)
-    if (!entry) return
-    try {
-      await entry.adapter.stop()
-      live.delete(name)
-      logger.info(`[channels] adapter "${name}" stopped`)
-    } catch (err) {
-      logger.error(`[channels] adapter "${name}" failed to stop: ${describeError(err)}`)
-    }
-  }
-
-  const checkConnectionRecovery = (): void => {
+  const superviseAdapters = (): void => {
+    if (!running) return
     const now = recoveryNow()
     for (const [name, entry] of live) {
       if (entry.adapter.isConnected()) {
@@ -470,27 +671,88 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       logger.warn(
         `[channels] adapter "${name}" disconnected for ${Math.round(disconnectedForMs)}ms; restarting adapter`,
       )
+      const queuedEpoch = lifecycleEpoch
       void runSerially(name, async () => {
         try {
           const current = live.get(name)
-          if (current !== entry) return
+          if (!running || queuedEpoch !== lifecycleEpoch || current !== entry) return
           const currentCfg = options.channelsConfigRef()[name]
           if (currentCfg === undefined || currentCfg.enabled === false) {
             logger.info(`[channels] recovery restart for "${name}" skipped; adapter no longer enabled`)
             return
           }
-          await stopAdapter(name)
-          await startAdapter(name, currentCfg)
+          const stopped = await stopAdapter(name)
+          if (!stopped || !running || queuedEpoch !== lifecycleEpoch) return
+          const latestCfg = options.channelsConfigRef()[name]
+          if (latestCfg === undefined || latestCfg.enabled === false) return
+          try {
+            const result = await startAdapter(name, latestCfg, () => {
+              const cfg = options.channelsConfigRef()[name]
+              return running && queuedEpoch === lifecycleEpoch && cfg !== undefined && cfg.enabled !== false
+            })
+            applyStartResult(name, latestCfg, result)
+          } catch (err) {
+            const cfg = options.channelsConfigRef()[name]
+            if (running && queuedEpoch === lifecycleEpoch && cfg !== undefined && cfg.enabled !== false) {
+              recordUnexpectedStartFailure(name, cfg, err)
+            }
+          }
         } finally {
           if (live.get(name) === entry) entry.recoveryRestartQueued = false
         }
+      }).catch((err) => {
+        logger.error(`[channels] adapter "${name}" recovery supervision failed: ${describeError(err)}`)
+      })
+    }
+
+    for (const [name, entry] of failed) {
+      if (entry.nextAttemptAtMs > now || entry.retryQueued) continue
+      entry.retryQueued = true
+      const queuedEpoch = lifecycleEpoch
+      void runSerially(name, async () => {
+        try {
+          if (!running || queuedEpoch !== lifecycleEpoch || failed.get(name) !== entry) return
+          const currentCfg = options.channelsConfigRef()[name]
+          if (currentCfg === undefined || currentCfg.enabled === false) {
+            if (failed.get(name) === entry) failed.delete(name)
+            return
+          }
+          try {
+            const result = await startAdapter(name, currentCfg, () => {
+              const cfg = options.channelsConfigRef()[name]
+              return (
+                running &&
+                queuedEpoch === lifecycleEpoch &&
+                failed.get(name) === entry &&
+                cfg !== undefined &&
+                cfg.enabled !== false
+              )
+            })
+            applyStartResult(name, currentCfg, result, entry)
+          } catch (err) {
+            const cfg = options.channelsConfigRef()[name]
+            if (
+              running &&
+              queuedEpoch === lifecycleEpoch &&
+              failed.get(name) === entry &&
+              cfg !== undefined &&
+              cfg.enabled !== false
+            ) {
+              recordUnexpectedStartFailure(name, cfg, err, entry)
+            }
+          }
+        } finally {
+          if (failed.get(name) === entry) entry.retryQueued = false
+        }
+      }).catch((err) => {
+        logger.error(`[channels] adapter "${name}" retry supervision failed: ${describeError(err)}`)
       })
     }
   }
 
   const startRecoveryTimer = (): void => {
     if (recoveryTimer !== null) return
-    recoveryTimer = recoverySetInterval(checkConnectionRecovery, recoveryCheckIntervalMs)
+    recoveryTimer = recoverySetInterval(superviseAdapters, recoveryCheckIntervalMs)
   }
 
   const stopRecoveryTimer = (): void => {
@@ -504,6 +766,8 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 
     async start(): Promise<void> {
       const cfg = options.channelsConfigRef()
+      running = true
+      const startedEpoch = lifecycleEpoch
       // Safe to fan out: `live` and every router registry are keyed by adapter
       // name, so concurrent starts never collide. Serial start would otherwise pay
       // the sum of each adapter's connect latency instead of just the slowest.
@@ -515,7 +779,12 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
         // uses this flag to answer "configured but unavailable" instead of the
         // misleading "not supported".
         router.setAdapterConfigured(name, adapterCfg.enabled !== false)
-        return [runSerially(name, () => startAdapter(name, adapterCfg))]
+        return [
+          runSerially(name, async () => {
+            const result = await startAdapter(name, adapterCfg, () => running && startedEpoch === lifecycleEpoch)
+            return applyStartResult(name, adapterCfg, result)
+          }),
+        ]
       })
       // Await every launched start to settle BEFORE surfacing a failure.
       // `startAdapter` converts expected per-adapter failures to `false`, so a
@@ -525,29 +794,48 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
       // that the caller's subsequent `stop()` never sees. Settle all, then rethrow.
       const results = await Promise.allSettled(starts)
       const failure = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+      // An unexpected throw leaves the manager half-built, so arming supervision
+      // would retry against a state the caller is about to tear down.
       if (failure !== undefined) throw failure.reason
       startRecoveryTimer()
     },
 
     async stop(): Promise<void> {
+      // Everything that gates a queued start must flip BEFORE the first await,
+      // or a retry already sitting in `perAdapterSerial` re-registers an adapter
+      // after teardown and leaks it past the caller's stop().
+      running = false
+      lifecycleEpoch += 1
       stopRecoveryTimer()
-      for (const name of Array.from(live.keys())) await runSerially(name, () => stopAdapter(name))
+      failed.clear()
+      // Drain every id, not just the live ones: an in-flight retry for a
+      // currently-dead adapter has to be awaited too, and its `canCommit` will
+      // have aborted it by the time this barrier runs.
+      await Promise.all(ADAPTER_IDS.map((name) => runSerially(name, () => stopAdapter(name))))
       await router.stop()
     },
 
     async restartAdapter(name: AdapterId): Promise<void> {
       await runSerially(name, async () => {
-        if (!live.has(name)) {
-          logger.info(`[channels] restartAdapter('${name}'): adapter not live, skipping`)
-          return
-        }
         const currentCfg = options.channelsConfigRef()[name]
         if (currentCfg === undefined) {
           logger.info(`[channels] restartAdapter('${name}'): adapter config missing, skipping`)
           return
         }
-        await stopAdapter(name)
-        await startAdapter(name, currentCfg)
+        if (currentCfg.enabled === false) {
+          logger.info(`[channels] restartAdapter('${name}'): adapter is disabled, skipping`)
+          return
+        }
+        // Deliberately not gated on `live.has(name)`: the whole point is to let
+        // an operator revive an adapter that failed to start and is therefore
+        // absent from `live`.
+        const previousFailure = failed.get(name)
+        failed.delete(name)
+        const stopped = await stopAdapter(name)
+        if (!stopped) return
+        const queuedEpoch = lifecycleEpoch
+        const result = await startAdapter(name, currentCfg, () => running && queuedEpoch === lifecycleEpoch)
+        applyStartResult(name, currentCfg, result, previousFailure)
       })
     },
 
@@ -559,43 +847,82 @@ export function createChannelManager(options: ChannelManagerOptions): ChannelMan
 
       for (const name of ADAPTER_IDS) {
         const desired = cfg[name]
-        const current = live.get(name)
         if (desired === undefined || desired.enabled === false) {
           router.setAdapterConfigured(name, false)
-          if (current) {
+          failed.delete(name)
+          if (live.has(name)) {
             await runSerially(name, () => stopAdapter(name))
             stopped.push(name)
           }
-        } else if (!current) {
-          router.setAdapterConfigured(name, true)
-          const ok = await runSerially(name, () => startAdapter(name, desired))
-          if (ok) started.push(name)
-        } else {
-          const { signature, missing } = buildCredentialSignature(name)
+          continue
+        }
+        router.setAdapterConfigured(name, true)
+        // The whole decision runs inside the barrier. Choosing a branch from
+        // `live.has(name)` out here races a queued retry: it can go live (or
+        // die) before the barrier admits us, and the branch we picked would
+        // then either start a second instance or skip credential
+        // reconciliation on an adapter that is now live with a stale token.
+        const outcome = await runSerially(name, async (): Promise<'started' | 'stopped' | 'rotated' | null> => {
+          const latest = options.channelsConfigRef()[name]
+          if (latest === undefined || latest.enabled === false) return null
+          const credentials = buildCredentialSignature(name)
+          const { signature, missing } = credentials
+          const current = live.get(name)
+
           if (missing.length > 0) {
             // Required credentials disappeared (env vars removed from .env, or
             // KakaoTalk credentials removed from secrets.json). Continuing to use the
             // in-memory credentials would silently honor a credential the
             // operator explicitly removed, so stop the adapter instead of
             // waiting for a manual restart.
+            if (current === undefined) {
+              recordMissingCredentialFailure(name, latest, credentials)
+              return null
+            }
             logger.warn(
               `[channels] adapter "${name}" missing credentials after reload (${missing.join(', ')}); stopping`,
             )
-            await runSerially(name, () => stopAdapter(name))
-            stopped.push(name)
-          } else if (signature !== current.credentialSignature) {
-            const reason =
-              name === 'kakaotalk' ||
-              name === 'line' ||
-              name === 'instagram' ||
-              name === 'webex' ||
-              name === 'teams' ||
-              name === 'slack' ||
-              name === 'discord'
-                ? 'credential rotation'
-                : 'token rotation'
-            restartRequired.push(`${name} (${reason})`)
+            if (!(await stopAdapter(name))) return null
+            // Without this the adapter leaves `live` and never enters `failed`,
+            // so supervision loses it entirely and restoring the credential
+            // could not revive it without another manual reload.
+            recordMissingCredentialFailure(name, latest, credentials)
+            return 'stopped'
           }
+
+          if (current !== undefined) {
+            return signature === current.credentialSignature ? null : 'rotated'
+          }
+
+          // A reload is the operator's signal that inputs changed, so a
+          // pending backoff timer is stale — retry now rather than making
+          // them wait out up to fifteen minutes.
+          const previousFailure = failed.get(name)
+          if (previousFailure !== undefined) {
+            const changed =
+              failedInputSignatures.get(previousFailure) !== buildFailedInputSignature(name, latest, credentials)
+            if (changed) failed.delete(name)
+            else if (previousFailure.retryQueued) return null
+          }
+          const queuedEpoch = lifecycleEpoch
+          const result = await startAdapter(name, latest, () => running && queuedEpoch === lifecycleEpoch)
+          return applyStartResult(name, latest, result, previousFailure) ? 'started' : null
+        })
+
+        if (outcome === 'started') started.push(name)
+        else if (outcome === 'stopped') stopped.push(name)
+        else if (outcome === 'rotated') {
+          const reason =
+            name === 'kakaotalk' ||
+            name === 'line' ||
+            name === 'instagram' ||
+            name === 'webex' ||
+            name === 'teams' ||
+            name === 'slack' ||
+            name === 'discord'
+              ? 'credential rotation'
+              : 'token rotation'
+          restartRequired.push(`${name} (${reason})`)
         }
       }
 


### PR DESCRIPTION
> Stacked on #1316. Review that one first; this PR's diff is against it.

## The outage

An agent went silent for **28 hours 47 minutes**. The container never crashed — `RestartCount=0`, `OOMKilled=false`, host up 15 days. Cron kept firing the whole time. What died was the Discord adapter:

```
23:08:12Z [discord-bot] disconnected; SDK will reconnect with backoff
23:08:13Z [channels] adapter "discord-bot" is disconnected; waiting for SDK recovery
23:09:43Z [channels] adapter "discord-bot" disconnected for 90019ms; restarting adapter
23:09:43Z [channels] adapter "discord-bot" stopped
23:09:43Z [channels] adapter "discord-bot" failed to start: <reason>
   ... then nothing for 28h47m
```

Every send after that: `no adapter registered for "discord-bot"`. It only came back when a human restarted the container.

## Root cause

`checkConnectionRecovery` iterated **only** `live`. Its restart path did `stopAdapter(name)` — which does `live.delete(name)` — then `startAdapter(name, cfg)`. When that start threw, nothing put the entry back. The adapter was evicted from the supervision set **permanently**: no retry, no backoff, no re-arm.

The watchdog whose entire job is healing a disconnect is what turned a transient gateway blip into a terminal outage. A boot-time start failure (expired token) had the identical fate — two other agents on the same host were sitting in exactly that state, silently dead since boot.

## Fix

Failed adapters stay in a `failed` map that the **same** interval walks. No new timers — the existing `connectionRecovery` seams already make one timer fully testable, and 12 independent timers would add cancellation races for nothing.

- **Backoff** `retryBaseMs * 2^(n-1)`, capped at 15 min, ±20% jitter (seeded via a `random` seam).
- **`retryBaseMs` is independent of `checkIntervalMs`** (30s base, 5s tick). A deadline is only observed on a tick, so a tick as coarse as the base rounded a jittered 30–36s delay up to the 60s tick and silently doubled every early retry.
- **Unbounded retries.** Credentials and config are re-read every attempt, so a rotated token or repaired `secrets.json` heals with no restart.
- **Outcomes are classified, not collapsed to a boolean.** `disabled` is not a failure. `missing-credentials` is retryable — the block can appear later. A `null` from `buildAdapter` is permanent, because the secrets provider is captured once at construction.
- **Log throttling** — first failure at `error`, a `warn` each time backoff ramps, one heartbeat per 6 hours at the cap, one `info` on recovery with total downtime.

### Lifecycle hardening this forced

- `retryQueued` is claimed **before** enqueue — otherwise repeated ticks stack starts behind one slow op and construct duplicates.
- `stop()` flips `running`/`lifecycleEpoch` **synchronously before its first await**, then drains a barrier across *every* adapter id. Queued starts re-validate running + epoch + entry identity + config *inside* the serialized callback before constructing anything.
- `restartAdapter()` no longer early-returns on `!live.has(name)` — that gate made it impossible to revive a failed adapter, the exact thing you'd want during this outage.
- **`reload()` now makes its entire per-adapter decision inside the barrier.** It previously chose a branch from `live.has(name)` *outside* `runSerially`, so a retry could invalidate that choice before the barrier admitted it — either starting a second instance or skipping credential reconciliation on an adapter that had just gone live with a stale token.

### Three further bugs found and fixed

1. **`stopAdapter` swallowed failures**, and recovery started a replacement anyway — overwriting `live` and leaking the still-running old adapter. It now reports success, and no replacement starts unless the stop succeeded.
2. **`reload()` read `live.get(name)` before awaiting.** Stale once retries exist; yields two starts and one orphan.
3. **Credential removal during reload dropped an adapter out of supervision entirely** — it left `live` but never entered `failed`, so restoring the credential could not revive it without another manual reload. The same class of bug as the headline one.

## Tests

17 cases. The headline one replays the outage: live adapter disconnects → replacement fails to start → a later due retry brings it back. Others pin backoff deadlines at both jitter extremes on production-cadence ticks, duplicate-construction prevention, `stop()` as a hard barrier against in-flight resurrection, reload reconciling an adapter a retry brought live, credential-removal staying supervised, and log throttling.

Every fix is verified by reverting it: disabling the retry loop fails 8 tests; removing the missing-credential registration fails 1; re-coupling `retryBaseMs` to the tick fails 1.

## Verification

`bun run lint` · `bun run format:check` · `bun run typecheck` · `bun run test` — 12100 pass, 31 skip, 0 fail.

## Deliberately out of scope

No `listAdapterHealth()` / `doctor` surfacing. That changes the public `ChannelManager` type and needs container→host wiring; it deserves its own PR. This one restores self-healing first.