### PR TITLE
Fail closed when a security guard errors internally

### DIFF
--- a/src/bundled-plugins/security/index.test.ts
+++ b/src/bundled-plugins/security/index.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 
+import { z } from 'zod'
+
+import { wrapPluginTool } from '@/agent/plugin-tools'
 import type { SessionOrigin } from '@/agent/session-origin'
 import { createInternalDestinationPolicy } from '@/network/internal-destinations'
 import { createPermissionService, noopPermissionService, type PermissionService, type RolesConfig } from '@/permissions'
-import type { HookContext, PluginContext, SessionPromptEvent, ToolBeforeEvent } from '@/plugin'
+import { createHookBus, defineTool } from '@/plugin'
+import type { HookContext, PluginContext, PluginLogger, SessionPromptEvent, ToolBeforeEvent } from '@/plugin'
 
 import securityPlugin from './index'
 import { HIGH_TIER_PER_GUARD_PERMISSIONS, SECURITY_PERMISSIONS } from './permissions'
@@ -267,6 +271,80 @@ describe('security plugin wiring', () => {
     const hook = await toolBeforeHook()
     const result = await hook(toolEvent('bash', { command: 'env' }), hookContext('/agent'))
     expect(result?.reason).toContain('secretExfilBash')
+  })
+
+  test('returns an earlier block without evaluating a later check that throws', async () => {
+    let evaluatedLaterCheck = false
+    const permissions: PermissionService = {
+      ...noopPermissionService,
+      has: (_origin, permission) => {
+        if (permission === SECURITY_PERMISSIONS.bypassSecretExfilRead) {
+          evaluatedLaterCheck = true
+          throw new Error('later check failed')
+        }
+        return false
+      },
+    }
+    const hook = await toolBeforeHookWith(permissions)
+
+    const result = await hook(toolEvent('bash', { command: 'env' }), hookContext('/agent'))
+
+    expect(result?.reason).toContain('secretExfilBash')
+    expect(evaluatedLaterCheck).toBe(false)
+  })
+
+  test('blocks a wrapped tool through HookBus when security evaluation throws internally', async () => {
+    const inaccessible = '/agent/protected/MEMORY.md'
+    const errors: string[] = []
+    const logger: PluginLogger = {
+      info: () => {},
+      warn: () => {},
+      error: (message) => errors.push(message),
+    }
+    const permissions: PermissionService = {
+      ...noopPermissionService,
+      has: () => {
+        throw Object.assign(new Error(`permission denied while inspecting ${inaccessible}`), { code: 'EACCES' })
+      },
+    }
+    const exports = await securityPlugin.plugin({ ...pluginContext('/agent'), logger, permissions })
+    const hooks = createHookBus()
+    hooks.registerAll('security', '/agent', logger, exports.hooks ?? {})
+    let executed = false
+    const wrapped = wrapPluginTool(
+      defineTool({
+        description: '',
+        parameters: z.object({}),
+        async execute() {
+          executed = true
+          return { content: [{ type: 'text', text: 'executed' }] }
+        },
+      }),
+      {
+        pluginName: 'fixture',
+        toolName: 'fixture_tool',
+        agentDir: '/agent',
+        sessionId: 's',
+        logger,
+        hooks,
+      },
+    )
+
+    const result = (await wrapped.execute('c', {}, undefined, undefined, {} as never)) as {
+      content: Array<{ type: string; text?: string }>
+      isError?: boolean
+    }
+    const modelText = result.content.map((part) => part.text ?? '').join('\n')
+
+    expect(executed).toBe(false)
+    expect(result.isError).toBe(true)
+    expect(modelText).toMatch(/internal security guard error/i)
+    expect(modelText).not.toContain(inaccessible)
+    expect(modelText).not.toContain('EACCES')
+    expect(modelText).not.toContain('permission denied')
+    expect(errors.join('\n')).toContain(inaccessible)
+    expect(errors.join('\n')).toContain('EACCES')
+    expect(errors.join('\n')).toContain('permission denied')
   })
 
   test('two-step attack end-to-end: tool.before+tool.before in same session double-gates the push', async () => {

--- a/src/bundled-plugins/security/index.ts
+++ b/src/bundled-plugins/security/index.ts
@@ -1,4 +1,4 @@
-import { definePlugin } from '@/plugin'
+import { definePlugin, type PluginLogger } from '@/plugin'
 import { resolveHiddenPaths } from '@/sandbox'
 
 import { HIGH_TIER_PER_GUARD_PERMISSIONS, SECURITY_PERMISSIONS, SEVERITY_PERMISSION } from './permissions'
@@ -87,6 +87,15 @@ function withPermissionHint(
   }
 }
 
+const INTERNAL_SECURITY_GUARD_REASON =
+  'The tool call was blocked because an internal security guard error prevented safe evaluation.'
+
+function reportInternalGuardError(logger: PluginLogger, guard: string, error: unknown): void {
+  const detail = error instanceof Error ? (error.stack ?? error.message) : String(error)
+  const code = error instanceof Error && 'code' in error && typeof error.code === 'string' ? ` code=${error.code}` : ''
+  logger.error(`internal security guard error guard=${guard}${code}: ${detail}`)
+}
+
 export default definePlugin({
   permissions: Object.values(SECURITY_PERMISSIONS),
   // No wildcard exclusions: owner bypasses every security tier by default
@@ -102,148 +111,189 @@ export default definePlugin({
         applyPromptInjectionDefense(event)
       },
       'tool.before': async (event) => {
-        const can = (perm: string) => ctx.permissions.has(event.origin, perm)
-        const canBypass = (severity: SecuritySeverity, perGuardPerm: string): boolean =>
-          can(SEVERITY_PERMISSION[severity]) || can(perGuardPerm)
+        try {
+          const can = (perm: string) => ctx.permissions.has(event.origin, perm)
+          const canBypass = (severity: SecuritySeverity, perGuardPerm: string): boolean =>
+            can(SEVERITY_PERMISSION[severity]) || can(perGuardPerm)
 
-        // The cron guard blocks deferred work that fires as a role granting
-        // permissions the caller lacks. Capability dominance — target's
-        // permission set must be a SUBSET of the caller's — not the coarse
-        // `compareRoleSeverity` tower: every configured custom role ranks
-        // equal there, so rank `>= 0` would let one custom role schedule as a
-        // different custom role (or `trusted` schedule as a custom role with
-        // an extra grant), laundering permissions the caller never had. Unknown
-        // caller/target role => undefined permissions => fail closed.
-        const callerRole = ctx.permissions.resolveRole(event.origin)
-        const canScheduleAs = (targetRole: string | undefined): boolean => {
-          if (targetRole === undefined) return false
-          const callerPermissions = ctx.permissions.permissionsForRole(callerRole)
-          const targetPermissions = ctx.permissions.permissionsForRole(targetRole)
-          if (callerPermissions === undefined || targetPermissions === undefined) return false
-          const callerSet = new Set(callerPermissions)
-          return targetPermissions.every((permission) => callerSet.has(permission))
-        }
+          // The cron guard blocks deferred work that fires as a role granting
+          // permissions the caller lacks. Capability dominance — target's
+          // permission set must be a SUBSET of the caller's — not the coarse
+          // `compareRoleSeverity` tower: every configured custom role ranks
+          // equal there, so rank `>= 0` would let one custom role schedule as a
+          // different custom role (or `trusted` schedule as a custom role with
+          // an extra grant), laundering permissions the caller never had. Unknown
+          // caller/target role => undefined permissions => fail closed.
+          const callerRole = ctx.permissions.resolveRole(event.origin)
+          const canScheduleAs = (targetRole: string | undefined): boolean => {
+            if (targetRole === undefined) return false
+            const callerPermissions = ctx.permissions.permissionsForRole(callerRole)
+            const targetPermissions = ctx.permissions.permissionsForRole(targetRole)
+            if (callerPermissions === undefined || targetPermissions === undefined) return false
+            const callerSet = new Set(callerPermissions)
+            return targetPermissions.every((permission) => callerSet.has(permission))
+          }
 
-        const rolePromotionResult = canBypass(GUARD_ROLE_PROMOTION_SEVERITY, SECURITY_PERMISSIONS.bypassRolePromotion)
-          ? undefined
-          : withPermissionHint(
-              await checkRolePromotionGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir }),
-              SECURITY_PERMISSIONS.bypassRolePromotion,
-              GUARD_ROLE_PROMOTION_SEVERITY,
-            )
-        if (rolePromotionResult) return rolePromotionResult
+          const rolePromotionResult = canBypass(GUARD_ROLE_PROMOTION_SEVERITY, SECURITY_PERMISSIONS.bypassRolePromotion)
+            ? undefined
+            : withPermissionHint(
+                await checkRolePromotionGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir }),
+                SECURITY_PERMISSIONS.bypassRolePromotion,
+                GUARD_ROLE_PROMOTION_SEVERITY,
+              )
+          if (rolePromotionResult) return rolePromotionResult
 
-        const cronPromotionResult = canBypass(GUARD_CRON_PROMOTION_SEVERITY, SECURITY_PERMISSIONS.bypassCronPromotion)
-          ? undefined
-          : withPermissionHint(
-              await checkCronPromotionGuard({
-                tool: event.tool,
-                args: event.args,
-                agentDir: ctx.agentDir,
-                canScheduleAs,
-              }),
-              SECURITY_PERMISSIONS.bypassCronPromotion,
-              GUARD_CRON_PROMOTION_SEVERITY,
-            )
-        if (cronPromotionResult) return cronPromotionResult
+          const cronPromotionResult = canBypass(GUARD_CRON_PROMOTION_SEVERITY, SECURITY_PERMISSIONS.bypassCronPromotion)
+            ? undefined
+            : withPermissionHint(
+                await checkCronPromotionGuard({
+                  tool: event.tool,
+                  args: event.args,
+                  agentDir: ctx.agentDir,
+                  canScheduleAs,
+                }),
+                SECURITY_PERMISSIONS.bypassCronPromotion,
+                GUARD_CRON_PROMOTION_SEVERITY,
+              )
+          if (cronPromotionResult) return cronPromotionResult
 
-        const pluginAdditionResult = canBypass(
-          GUARD_PLUGIN_ADDITION_SEVERITY,
-          SECURITY_PERMISSIONS.bypassPluginAddition,
-        )
-          ? undefined
-          : withPermissionHint(
-              await checkPluginAdditionGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir }),
-              SECURITY_PERMISSIONS.bypassPluginAddition,
-              GUARD_PLUGIN_ADDITION_SEVERITY,
-            )
-        if (pluginAdditionResult) return pluginAdditionResult
+          const pluginAdditionResult = canBypass(
+            GUARD_PLUGIN_ADDITION_SEVERITY,
+            SECURITY_PERMISSIONS.bypassPluginAddition,
+          )
+            ? undefined
+            : withPermissionHint(
+                await checkPluginAdditionGuard({ tool: event.tool, args: event.args, agentDir: ctx.agentDir }),
+                SECURITY_PERMISSIONS.bypassPluginAddition,
+                GUARD_PLUGIN_ADDITION_SEVERITY,
+              )
+          if (pluginAdditionResult) return pluginAdditionResult
 
-        // Taint-recording runs FIRST, independently of the gitExfil guard.
-        // The gitRemoteTainted defense depends on it. We pass through
-        // `permittedBypass` for actors who can skip gitExfil (via either the
-        // per-guard permission or the medium-tier permission) so the
-        // recorder still fires for them — an acked or permission-bypassed
-        // command will actually run, so its remote change must be remembered.
-        recordGitRemoteTaintIfAny({
-          tool: event.tool,
-          args: event.args,
-          sessionId: event.sessionId,
-          permittedBypass: canBypass(GUARD_GIT_EXFIL_SEVERITY, SECURITY_PERMISSIONS.bypassGitExfil),
-        })
+          // Taint-recording runs FIRST, independently of the gitExfil guard.
+          // The gitRemoteTainted defense depends on it. We pass through
+          // `permittedBypass` for actors who can skip gitExfil (via either the
+          // per-guard permission or the medium-tier permission) so the
+          // recorder still fires for them — an acked or permission-bypassed
+          // command will actually run, so its remote change must be remembered.
+          recordGitRemoteTaintIfAny({
+            tool: event.tool,
+            args: event.args,
+            sessionId: event.sessionId,
+            permittedBypass: canBypass(GUARD_GIT_EXFIL_SEVERITY, SECURITY_PERMISSIONS.bypassGitExfil),
+          })
 
-        const checks: (SecurityBlock | undefined)[] = [
-          canBypass(GUARD_GIT_REMOTE_TAINTED_SEVERITY, SECURITY_PERMISSIONS.bypassGitRemoteTainted)
+          const gitRemoteTaintedResult = canBypass(
+            GUARD_GIT_REMOTE_TAINTED_SEVERITY,
+            SECURITY_PERMISSIONS.bypassGitRemoteTainted,
+          )
             ? undefined
             : withPermissionHint(
                 checkGitRemoteTaintedGuard({ tool: event.tool, args: event.args, sessionId: event.sessionId }),
                 SECURITY_PERMISSIONS.bypassGitRemoteTainted,
                 GUARD_GIT_REMOTE_TAINTED_SEVERITY,
-              ),
-          canBypass(GUARD_SECRET_EXFIL_BASH_SEVERITY, SECURITY_PERMISSIONS.bypassSecretExfilBash)
+              )
+          if (gitRemoteTaintedResult) return gitRemoteTaintedResult
+
+          const secretExfilBashResult = canBypass(
+            GUARD_SECRET_EXFIL_BASH_SEVERITY,
+            SECURITY_PERMISSIONS.bypassSecretExfilBash,
+          )
             ? undefined
             : withPermissionHint(
                 checkSecretExfilBashGuard({ tool: event.tool, args: event.args }),
                 SECURITY_PERMISSIONS.bypassSecretExfilBash,
                 GUARD_SECRET_EXFIL_BASH_SEVERITY,
-              ),
-          canBypass(GUARD_GIT_EXFIL_SEVERITY, SECURITY_PERMISSIONS.bypassGitExfil)
+              )
+          if (secretExfilBashResult) return secretExfilBashResult
+
+          const gitExfilResult = canBypass(GUARD_GIT_EXFIL_SEVERITY, SECURITY_PERMISSIONS.bypassGitExfil)
             ? undefined
             : withPermissionHint(
                 checkGitExfilGuard({ tool: event.tool, args: event.args, sessionId: event.sessionId }),
                 SECURITY_PERMISSIONS.bypassGitExfil,
                 GUARD_GIT_EXFIL_SEVERITY,
-              ),
-          canBypass(GUARD_SECRET_EXFIL_READ_SEVERITY, SECURITY_PERMISSIONS.bypassSecretExfilRead)
+              )
+          if (gitExfilResult) return gitExfilResult
+
+          const secretExfilReadResult = canBypass(
+            GUARD_SECRET_EXFIL_READ_SEVERITY,
+            SECURITY_PERMISSIONS.bypassSecretExfilRead,
+          )
             ? undefined
             : withPermissionHint(
                 checkSecretExfilReadGuard({ tool: event.tool, args: event.args }),
                 SECURITY_PERMISSIONS.bypassSecretExfilRead,
                 GUARD_SECRET_EXFIL_READ_SEVERITY,
-              ),
+              )
+          if (secretExfilReadResult) return secretExfilReadResult
+
           // Not severity-bypassed: private directories remain role-derived,
           // while canonical credential-store denial is unconditional. Mirrors
           // the bash masks onto every non-bash path-bearing tool.
-          checkPrivateSurfaceReadGuard({
-            tool: event.tool,
-            args: event.args,
-            agentDir: ctx.agentDir,
-            hidden: resolveHiddenPaths(ctx.permissions, event.origin, ctx.agentDir),
-            ...(event.fileOperands !== undefined ? { fileOperands: event.fileOperands } : {}),
-          }),
-          canBypass(GUARD_SSRF_SEVERITY, SECURITY_PERMISSIONS.bypassSsrf)
+          const privateSurfaceReadResult = checkPrivateSurfaceReadGuard(
+            {
+              tool: event.tool,
+              args: event.args,
+              agentDir: ctx.agentDir,
+              hidden: resolveHiddenPaths(ctx.permissions, event.origin, ctx.agentDir),
+              ...(event.fileOperands !== undefined ? { fileOperands: event.fileOperands } : {}),
+            },
+            {
+              onInternalError: (error) => reportInternalGuardError(ctx.logger, 'privateSurfaceRead', error),
+            },
+          )
+          if (privateSurfaceReadResult) return privateSurfaceReadResult
+
+          const ssrfResult = canBypass(GUARD_SSRF_SEVERITY, SECURITY_PERMISSIONS.bypassSsrf)
             ? undefined
             : withPermissionHint(
                 checkSsrfGuard({ tool: event.tool, args: event.args }),
                 SECURITY_PERMISSIONS.bypassSsrf,
                 GUARD_SSRF_SEVERITY,
-              ),
-          canBypass(GUARD_SESSION_SEARCH_SECRETS_SEVERITY, SECURITY_PERMISSIONS.bypassSessionSearchSecrets)
+              )
+          if (ssrfResult) return ssrfResult
+
+          const sessionSearchSecretsResult = canBypass(
+            GUARD_SESSION_SEARCH_SECRETS_SEVERITY,
+            SECURITY_PERMISSIONS.bypassSessionSearchSecrets,
+          )
             ? undefined
             : withPermissionHint(
                 checkSessionSearchSecretsGuard({ tool: event.tool, args: event.args }),
                 SECURITY_PERMISSIONS.bypassSessionSearchSecrets,
                 GUARD_SESSION_SEARCH_SECRETS_SEVERITY,
-              ),
-          canBypass(GUARD_SYSTEM_PROMPT_LEAK_SEVERITY, SECURITY_PERMISSIONS.bypassSystemPromptLeak)
+              )
+          if (sessionSearchSecretsResult) return sessionSearchSecretsResult
+
+          const systemPromptLeakResult = canBypass(
+            GUARD_SYSTEM_PROMPT_LEAK_SEVERITY,
+            SECURITY_PERMISSIONS.bypassSystemPromptLeak,
+          )
             ? undefined
             : withPermissionHint(
                 checkSystemPromptLeakGuard({ tool: event.tool, args: event.args }),
                 SECURITY_PERMISSIONS.bypassSystemPromptLeak,
                 GUARD_SYSTEM_PROMPT_LEAK_SEVERITY,
-              ),
-          canBypass(GUARD_OUTBOUND_SECRET_SEVERITY, SECURITY_PERMISSIONS.bypassOutboundSecret)
+              )
+          if (systemPromptLeakResult) return systemPromptLeakResult
+
+          const outboundSecretResult = canBypass(
+            GUARD_OUTBOUND_SECRET_SEVERITY,
+            SECURITY_PERMISSIONS.bypassOutboundSecret,
+          )
             ? undefined
             : withPermissionHint(
                 checkOutboundSecretGuard({ tool: event.tool, args: event.args }),
                 SECURITY_PERMISSIONS.bypassOutboundSecret,
                 GUARD_OUTBOUND_SECRET_SEVERITY,
-              ),
-        ]
-        for (const result of checks) {
-          if (result) return result
+              )
+          if (outboundSecretResult) return outboundSecretResult
+
+          return undefined
+        } catch (error) {
+          reportInternalGuardError(ctx.logger, 'tool.before', error)
+          return { block: true, reason: INTERNAL_SECURITY_GUARD_REASON }
         }
-        return undefined
       },
       'session.end': async (event) => {
         clearSessionTaints(event.sessionId)

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -64,7 +64,8 @@ describe('private-surface-read guard — builtin file tools', () => {
 
 describe('private-surface-read guard — fail-closed across ALL tools (not a whitelist)', () => {
   test('blocks with a generic reason when realpathSync.native reports EACCES', () => {
-    const inaccessible = '/agent/public/protected.md'
+    // Must resolve like the guard does: a POSIX literal would not match on Windows.
+    const inaccessible = path.resolve(AGENT, 'public/protected.md')
     const error = Object.assign(new Error('permission denied while resolving protected path'), { code: 'EACCES' })
 
     const result = checkPrivateSurfaceReadGuard(

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -63,6 +63,27 @@ describe('private-surface-read guard — builtin file tools', () => {
 })
 
 describe('private-surface-read guard — fail-closed across ALL tools (not a whitelist)', () => {
+  test('blocks with a generic reason when realpathSync.native reports EACCES', () => {
+    const inaccessible = '/agent/public/protected.md'
+    const error = Object.assign(new Error('permission denied while resolving protected path'), { code: 'EACCES' })
+
+    const result = checkPrivateSurfaceReadGuard(
+      { tool: 'read', args: { path: inaccessible }, agentDir: AGENT, hidden: guestHidden },
+      {
+        realpathNative(candidate) {
+          if (candidate === inaccessible) throw error
+          return realpathSync.native(candidate)
+        },
+      },
+    )
+
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toMatch(/internal guard error/i)
+    expect(result?.reason).not.toContain(inaccessible)
+    expect(result?.reason).not.toContain(error.message)
+    expect(result?.reason).not.toContain(error.code)
+  })
+
   test('blocks find_entry reading a hidden transcript via top-level path', () => {
     expect(check('find_entry', { path: '/agent/sessions/s.jsonl', entryId: 'x' })?.block).toBe(true)
   })

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -81,24 +81,33 @@ export function checkPrivateSurfaceReadGuard(
 ): SecurityBlock | undefined {
   const { tool, args, agentDir, hidden, fileOperands } = options
   if (UNSCANNED_TOOLS.has(tool)) return undefined
-  const { deniedDirs, deniedFiles } = deniedSurface(agentDir, hidden)
-  if (deniedDirs.length === 0 && deniedFiles.length === 0) return undefined
-  const identityScanner = createHardlinkIdentityScanner(agentDir, deniedDirs, deniedFiles, hooks)
+  try {
+    const { deniedDirs, deniedFiles } = deniedSurface(agentDir, hidden)
+    if (deniedDirs.length === 0 && deniedFiles.length === 0) return undefined
+    const identityScanner = createHardlinkIdentityScanner(agentDir, deniedDirs, deniedFiles, hooks)
+    const realpath = hooks.realpathNative ?? realpathSync.native
 
-  const nonFile = fileOperands?.nonFile === undefined ? undefined : new Set(fileOperands.nonFile)
-  for (const candidate of collectPathCandidates(args, tool, nonFile)) {
-    const hit = matchHidden(candidate, agentDir, deniedDirs, deniedFiles, identityScanner)
-    if (hit !== undefined) {
-      return {
-        block: true,
-        reason: [
-          `Guard \`${GUARD_PRIVATE_SURFACE_READ}\` blocked ${tool}: argument \`${candidate}\` resolves to ${hit}, which is not available to LLM tools.`,
-          'The bash sandbox masks the same path. Privileged roles cannot bypass canonical agent credential files; use host-side redacted diagnostics such as `typeclaw doctor`, `typeclaw provider list`, or `typeclaw channel list` instead.',
-        ].join(' '),
+    const nonFile = fileOperands?.nonFile === undefined ? undefined : new Set(fileOperands.nonFile)
+    for (const candidate of collectPathCandidates(args, tool, nonFile)) {
+      const hit = matchHidden(candidate, agentDir, deniedDirs, deniedFiles, identityScanner, realpath)
+      if (hit !== undefined) {
+        return {
+          block: true,
+          reason: [
+            `Guard \`${GUARD_PRIVATE_SURFACE_READ}\` blocked ${tool}: argument \`${candidate}\` resolves to ${hit}, which is not available to LLM tools.`,
+            'The bash sandbox masks the same path. Privileged roles cannot bypass canonical agent credential files; use host-side redacted diagnostics such as `typeclaw doctor`, `typeclaw provider list`, or `typeclaw channel list` instead.',
+          ].join(' '),
+        }
       }
     }
+    return undefined
+  } catch (error) {
+    hooks.onInternalError?.(error)
+    return {
+      block: true,
+      reason: `Guard \`${GUARD_PRIVATE_SURFACE_READ}\` blocked ${tool}: an internal guard error prevented safe path validation.`,
+    }
   }
-  return undefined
 }
 
 type PrivateSurfaceIdentityOptions = {
@@ -111,6 +120,8 @@ export type PrivateSurfaceIdentityScanHooks = {
   maxEntries?: number
   openDirectory?(directory: string): Pick<Dir, 'readSync' | 'closeSync'>
   lstat?(candidate: string): Stats
+  realpathNative?(candidate: string): string
+  onInternalError?(error: unknown): void
   afterEntryLstat?(candidate: string, stats: Stats): void
 }
 
@@ -157,6 +168,7 @@ function createHardlinkIdentityScanner(
         ? openDescriptorAnchoredDirectory
         : createPathDirectoryOpener(hooks.openDirectory, lstat),
     lstat,
+    realpath: hooks.realpathNative ?? realpathSync.native,
     afterEntryLstat: hooks.afterEntryLstat,
   })
 }
@@ -341,18 +353,19 @@ function matchHidden(
   deniedDirs: string[],
   deniedFiles: string[],
   identityScanner: HardlinkIdentityScanner,
+  realpath: (candidate: string) => string,
 ): string | undefined {
   const lexicalHit = matchLexicallyDenied(candidate, agentDir, deniedDirs, deniedFiles)
   if (lexicalHit !== undefined) return lexicalHit
   const lexical = path.resolve(agentDir, candidate)
-  const resolved = realpathRealIntendedPath(lexical)
+  const resolved = realpathRealIntendedPath(lexical, realpath)
   const virtualRoot = virtualFilesystemRoot(lexical) ?? virtualFilesystemRoot(resolved)
   if (virtualRoot !== undefined) return `${virtualRoot}, a virtual or process-backed filesystem`
   for (const file of deniedFiles) {
-    if (resolved === realpathRealIntendedPath(file) || hasSameFileIdentity(resolved, file)) return file
+    if (resolved === realpathRealIntendedPath(file, realpath) || hasSameFileIdentity(resolved, file)) return file
   }
   for (const dir of deniedDirs) {
-    const realDir = realpathRealIntendedPath(dir)
+    const realDir = realpathRealIntendedPath(dir, realpath)
     // realpathRealIntendedPath joins with the platform separator, so the
     // under-dir test must use path.sep too — a hardcoded "/" never matches the
     // "\"-joined paths a win32 test runner produces.
@@ -510,6 +523,7 @@ type HardlinkIdentityScannerOptions = {
   maxEntries: number
   openDirectory(directory: string): HardlinkDirectory
   lstat(candidate: string): Stats
+  realpath(candidate: string): string
   afterEntryLstat?(candidate: string, stats: Stats): void
 }
 
@@ -565,9 +579,11 @@ class HardlinkIdentityScanner {
   private scanVisibleTree(): void {
     if (this.visibleScanned) return
     this.visibleScanned = true
-    const root = realpathRealIntendedPath(this.options.agentDir)
-    const deniedRoots = this.options.deniedDirs.map(realpathRealIntendedPath)
-    const deniedFiles = new Set(this.options.deniedFiles.map(realpathRealIntendedPath))
+    const root = realpathRealIntendedPath(this.options.agentDir, this.options.realpath)
+    const deniedRoots = this.options.deniedDirs.map((dir) => realpathRealIntendedPath(dir, this.options.realpath))
+    const deniedFiles = new Set(
+      this.options.deniedFiles.map((file) => realpathRealIntendedPath(file, this.options.realpath)),
+    )
     const rootStats = this.readRootStats(root, 'visible')
     if (rootStats === undefined) return
     const rootDirectory = this.openVerifiedDirectory(root, rootStats, 'visible')
@@ -619,7 +635,7 @@ class HardlinkIdentityScanner {
       let rootStats: Stats
       let root: string
       try {
-        root = realpathRealIntendedPath(deniedDir)
+        root = realpathRealIntendedPath(deniedDir, this.options.realpath)
         rootStats = this.options.lstat(root)
       } catch (error) {
         if (isNotFoundError(error)) continue
@@ -950,16 +966,15 @@ function hasSameFileIdentity(candidate: string, deniedFile: string): boolean {
 // symlinked component including a planted symlink), and rejoin the remainder.
 // This catches `public/leak/x` where `public/leak` is a symlink into a hidden
 // dir even though `public/leak/x` itself does not exist. Sync (realpathSync)
-// keeps the guard synchronous so the security tool.before check array stays
-// non-async; the cost is one syscall per existing component, negligible at the
-// tool-call boundary. Sync mirror of resolveRealIntendedPath in the guard
-// plugin's non-workspace-write policy.
-function realpathRealIntendedPath(absolutePath: string): string {
+// keeps the guard synchronous; the cost is one syscall per existing component,
+// negligible at the tool-call boundary. Sync mirror of resolveRealIntendedPath
+// in the guard plugin's non-workspace-write policy.
+function realpathRealIntendedPath(absolutePath: string, realpath: (candidate: string) => string): string {
   const pending: string[] = []
   let current = absolutePath
   while (true) {
     try {
-      return path.join(realpathSync.native(current), ...pending.reverse())
+      return path.join(realpath(current), ...pending.reverse())
     } catch (err) {
       if (!isNotFoundError(err)) throw err
     }

--- a/src/plugin/hooks.test.ts
+++ b/src/plugin/hooks.test.ts
@@ -82,6 +82,29 @@ describe('HookBus tool.before', () => {
     const result = await bus.runToolBefore({ tool: 't', sessionId: 's', callId: 'c', args: {} })
     expect(result).toBeUndefined()
   })
+
+  test('logs a throwing handler and continues to a later plugin', async () => {
+    const errors: string[] = []
+    const bus = createHookBus()
+    bus.registerAll(
+      'broken-plugin',
+      '/agent',
+      { info: () => {}, warn: () => {}, error: (message) => errors.push(message) },
+      {
+        'tool.before': () => {
+          throw new Error('broken guard')
+        },
+      },
+    )
+    bus.registerAll('blocking-plugin', '/agent', noopLogger, {
+      'tool.before': () => ({ block: true, reason: 'denied by healthy plugin' }),
+    })
+
+    const result = await bus.runToolBefore({ tool: 't', sessionId: 's', callId: 'c', args: {} })
+
+    expect(result).toEqual({ block: true, reason: 'denied by healthy plugin' })
+    expect(errors).toEqual(['hook tool.before threw: broken guard'])
+  })
 })
 
 describe('HookBus session.idle / session.start / session.end', () => {


### PR DESCRIPTION
## Problem

A single unreadable path could silently disarm the entire bundled security `tool.before` hook.

Three things compounded:

1. `realpathRealIntendedPath` catches `ENOENT` and walks up to the nearest existing ancestor, but **rethrows every other errno** — including `EACCES`.
2. The security handler built much of its check set **eagerly into one array**, so an exception raised while constructing a *later* check discarded an *earlier* check's already-computed `block` and skipped every remaining guard.
3. `HookBus.runToolBefore` catches handler exceptions, logs, and `continue`s — so the tool then **ran unguarded**.

Observed in production:

```
[plugin:security] hook tool.before threw: EACCES: permission denied, realpath '<redacted>/MEMORY.md'
```

The agent was running as a non-root uid with `HOME` pointing at a `0700` root-owned directory, so *every* `~/…` path the model touched threw `EACCES` — and each one skipped the private-surface read guard.

## Fix

- Evaluate guards **sequentially and lazily**, returning on the first block. No check is constructed before its predecessors are decided.
- Wrap **both** the handler and the private-surface-read policy in fail-closed boundaries: any internal exception becomes a `block`.
- Model-facing reason is **generic**. The errno, stack, and offending path go to the operator log only.
- `realpathRealIntendedPath`'s `ENOENT` ancestor traversal is **unchanged**.

## Deliberately not done

`HookBus` is **not** changed to fail closed globally. Ordinary plugins stay isolated by design (`src/plugin/manager.ts`) so a broken third-party plugin cannot brick the agent. Security is a trusted *bundled* hook and gets its own stricter policy. A test now pins that distinction.

## Operator-visible behavior change

Paths whose validation raises `EACCES` (or any internal guard exception) now **block** instead of silently allowing the tool through. This converts a silent fail-open into a loud fail-closed, but an environment with a misconfigured `HOME` will see blocks where it previously saw errors. That misconfiguration is real and worth surfacing.

## Tests

| Test | Guards | Failed before fix |
|---|---|---|
| `blocks with a generic reason when realpathSync.native reports EACCES` | policy fail-closed boundary | threw `EACCES` |
| `returns an earlier block without evaluating a later check that throws` | sequential-lazy early return | earlier block was discarded |
| `blocks a wrapped tool through HookBus when security evaluation throws internally` | handler boundary, via the **real** HookBus + wrapped tool | HookBus swallowed it and the tool executed |
| `logs a throwing handler and continues to a later plugin` | HookBus isolation intentionally unchanged | n/a (pins the non-change) |

`lint` 0 errors, `format:check` clean, `typecheck` clean.

Full suite `12084 pass / 31 skip / 1 fail` — the one failure is a pre-existing 30s timeout in the untouched `src/agent/plugin-tools.test.ts`, reproduced identically on clean `main`.