### PR TITLE
Stop warning about a provider drop the turn already worked through

### DIFF
--- a/src/agent/turn-runner.test.ts
+++ b/src/agent/turn-runner.test.ts
@@ -166,6 +166,53 @@ describe('promptPersistentTurnWithFallback', () => {
     expect(fake.setModels).toEqual([])
   })
 
+  test('reports tool execution to the caller on the turn that then fails', async () => {
+    // given: the same non-advancing shape as above. Callers need the signal on
+    // exactly this path — the turn is unrecoverable AND may have already
+    // committed a side effect — so it is delivered by callback rather than on
+    // the result, which the hard-throw path never returns.
+    const fake = fakeSession(['tool-then-throttle'])
+    let toolStarts = 0
+    const result = await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => /overloaded/i.test(err.message),
+      setModelForRef: async (ref) => {
+        fake.setModels.push(ref)
+      },
+      onToolExecutionStarted: () => {
+        toolStarts++
+      },
+    })
+
+    expect(result.success).toBe(false)
+    expect(toolStarts).toBe(1)
+  })
+
+  test('leaves the caller unaware of tool execution when no tool ran', async () => {
+    const fake = fakeSession(['soft-throttle'])
+    let toolStarts = 0
+    await promptPersistentTurnWithFallback({
+      refs: [REF_A],
+      currentModelRef: REF_A,
+      session: fake.session,
+      text: 'hello',
+      circuit: new ThrottleCircuit(),
+      shouldFailover: (err) => /overloaded/i.test(err.message),
+      setModelForRef: async (ref) => {
+        fake.setModels.push(ref)
+      },
+      onToolExecutionStarted: () => {
+        toolStarts++
+      },
+    })
+
+    expect(toolStarts).toBe(0)
+  })
+
   test('does not advance for non-throttle soft errors', async () => {
     const fake = fakeSession(['soft-billing'])
     const result = await promptPersistentTurnWithFallback({

--- a/src/agent/turn-runner.ts
+++ b/src/agent/turn-runner.ts
@@ -61,6 +61,10 @@ export async function promptPersistentTurnWithFallback(opts: {
   onRetryBackoffStart?: () => void
   beforeAttempt?: (ref: ModelRef) => void
   onAttemptFailed?: (attempt: PersistentTurnAttempt) => void
+  // Fired the first time an attempt starts executing a tool. Callers use it to
+  // learn that the turn stopped being silent even when the turn ultimately
+  // fails — including the hard-throw path, where no result is ever returned.
+  onToolExecutionStarted?: () => void
   now?: () => number
 }): Promise<PersistentTurnResult> {
   if (opts.refs.length === 0) throw new Error('promptPersistentTurnWithFallback: refs[] must be non-empty')
@@ -106,7 +110,7 @@ export async function promptPersistentTurnWithFallback(opts: {
     // subagents. `skipProviderErrorSubscription` only suppresses the soft-error
     // listener (subagents capture their final message off the leaf instead, via
     // detectSoftErrorFromLeaf, so a second listener would race that capture).
-    const unsubActivity = subscribeAttemptActivity(opts.session, activity)
+    const unsubActivity = subscribeAttemptActivity(opts.session, activity, opts.onToolExecutionStarted)
     const unsubProvider = opts.skipProviderErrorSubscription
       ? () => {}
       : subscribeProviderErrorsIfAvailable(opts.session, (err) => {
@@ -291,13 +295,19 @@ function isRefUsable(
   return !circuit.isProviderOpen({ profile, ref })
 }
 
-function subscribeAttemptActivity(session: AgentSession, activity: AttemptActivity): () => void {
+function subscribeAttemptActivity(
+  session: AgentSession,
+  activity: AttemptActivity,
+  onToolExecutionStarted?: () => void,
+): () => void {
   const subscribe = (session as { subscribe?: unknown }).subscribe
   if (typeof subscribe !== 'function') return () => {}
   return session.subscribe((event: unknown) => {
     if (!isRecord(event)) return
     if (event.type === 'tool_execution_start' || event.type === 'tool_execution_end') {
+      const alreadyStarted = activity.startedToolExecution
       activity.startedToolExecution = true
+      if (!alreadyStarted) onToolExecutionStarted?.()
       return
     }
     if (event.type !== 'message_update') return

--- a/src/channels/router.test.ts
+++ b/src/channels/router.test.ts
@@ -13927,6 +13927,25 @@ describe('ChannelRouter more_work_this_turn:true empty-stop recovery (phrase-ind
     }
   }
 
+  function channelSendContext(text: string): AfterToolCallContext {
+    return {
+      assistantMessage: assistantMessage('') as AfterToolCallContext['assistantMessage'],
+      toolCall: {
+        type: 'toolCall',
+        id: 'tc-status',
+        name: 'channel_send',
+        arguments: { text },
+      } as AfterToolCallContext['toolCall'],
+      args: { text },
+      result: {
+        content: [{ type: 'text' as const, text: 'ignored' }],
+        details: { ok: true },
+      } as AfterToolCallContext['result'],
+      isError: false,
+      context: { systemPrompt: '', messages: [], tools: [] },
+    }
+  }
+
   // Reproduce the production order for a channel_reply({ more_work_this_turn: true }): the tool's
   // execute() calls router.send() (which bumps successfulChannelSends) BEFORE the
   // runtime fires afterToolCall (which stamps continueReplyTurn with that post-send
@@ -14418,6 +14437,240 @@ describe('ChannelRouter more_work_this_turn:true empty-stop recovery (phrase-ind
     expect(sent[1]).toMatch(/connection to the upstream LLM provider dropped/i)
     expect(sent[1]).not.toContain('raw-detail')
     expect(sent[1]).not.toContain('second-raw-detail')
+  })
+
+  test('surfaces one redacted warning when a promised continuation fails in a reminder-only iteration', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    let promptAttempt = 0
+    sessions[0]!.onPrompt = async (text) => {
+      promptAttempt++
+      if (promptAttempt === 1) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+        await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+        sessions[0]!.emit({ type: 'tool_execution_start' })
+        emptyStopAfterToolWork(sessions[0]!, 'promised-reminder')
+        return
+      }
+
+      expect(text).toContain(SEND_WILLINGNESS_NUDGE)
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000 reminder-raw-detail' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent[0]).toBe('찾아볼게.')
+    expect(sent.filter((text) => text.startsWith('⚠️'))).toHaveLength(1)
+    expect(sent[1]).toMatch(/connection to the upstream LLM provider dropped/i)
+    expect(sent[1]).not.toContain('reminder-raw-detail')
+  })
+
+  test('surfaces one redacted warning when a channel_send status follows a promised reply before failure', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+      const status = "Still checking… I'll keep checking."
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: status })
+      await sessions[0]!.agent.afterToolCall!(channelSendContext(status))
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.agent.state.messages = [{ role: 'toolResult' }, { role: 'assistant', stopReason: 'error' }]
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1000 status-raw-detail' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.slice(0, 2)).toEqual(['찾아볼게.', "Still checking… I'll keep checking."])
+    expect(sent.filter((text) => text.startsWith('⚠️'))).toHaveLength(1)
+    expect(sent[2]).toMatch(/connection to the upstream LLM provider dropped/i)
+    expect(sent[2]).not.toContain('status-raw-detail')
+  })
+
+  test('suppresses the warning when system recovery fulfills a promised reply', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir)
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    sessions[0]!.onPrompt = async () => {
+      await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+      await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'transient server_is_overloaded' },
+      })
+      sessions[0]!.setAssistantText('Recovered answer from the existing tool results.')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent).toContain('Recovered answer from the existing tool results.')
+    expect(sent.filter((text) => text.startsWith('⚠️'))).toHaveLength(0)
+  })
+
+  test('provider notices preserve an outstanding promise across a reminder-only iteration', async () => {
+    const dir = await tempDir()
+    const sent: string[] = []
+    let continuationDelivered = false
+    const runIdleContinuationSeam: NonNullable<CreateChannelRouterOptions['runIdleContinuation']> = async ({
+      deliver,
+    }) => {
+      if (continuationDelivered) return false
+      continuationDelivered = true
+      deliver('continue after the provider notice')
+      return true
+    }
+    const { router, sessions } = makeRouter(dir, { runIdleContinuation: runIdleContinuationSeam })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '지난 기록 찾아줘' }))
+    let promptAttempt = 0
+    sessions[0]!.onPrompt = async () => {
+      promptAttempt++
+      if (promptAttempt === 1) {
+        await router.send({ adapter: 'discord-bot', workspace: 'g1', chat: 'c1', text: '찾아볼게.' })
+        await sessions[0]!.agent.afterToolCall!(continueReplyContext('찾아볼게.'))
+        sessions[0]!.emit({ type: 'tool_execution_start' })
+      }
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'transient server_is_overloaded' },
+      })
+      sessions[0]!.setAssistantText('NO_REPLY')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sessions[0]!.prompts).toHaveLength(2)
+    expect(sent.filter((text) => text.startsWith('⚠️'))).toHaveLength(2)
+  })
+
+  test('stays quiet when the dropped turn already ran tools and promised nothing further', async () => {
+    // given: the production shape — a github PR turn published a review-thread
+    // reply through the GitHub API (a tool, never a channel send, so
+    // `successfulChannelSends` stays 0) and only then lost its websocket. The
+    // notice exists so a dead turn doesn't leave the human with silence; this
+    // turn was not silent, so posting it would strand a "connection dropped"
+    // warning above the agent's own successful review.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '이 PR 다시 봐줘' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1006 Connection ended' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    // then: nothing public, but the operator keeps both the raw cause and an
+    // explicit record that a notice was withheld.
+    expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(0)
+    expect(logs.some((m) => /LLM call failed: WebSocket closed 1006/.test(m))).toBe(true)
+    expect(logs.some((m) => /provider_error_notice_suppressed reason=tool_activity_this_turn/.test(m))).toBe(true)
+  })
+
+  test('still warns when the dropped turn was genuinely silent', async () => {
+    // given: the same provider drop, but the turn never executed a tool, so
+    // nothing reached the user by any route. This is the case the notice was
+    // written for and must keep firing.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '이 PR 다시 봐줘' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1006 Connection ended' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(1)
+    expect(sent.some((t) => /connection to the upstream LLM provider dropped/i.test(t))).toBe(true)
+    expect(logs.some((m) => /provider_error_notice_suppressed reason=tool_activity_this_turn/.test(m))).toBe(false)
+  })
+
+  test('does not carry tool activity across into the next user turn', async () => {
+    // given: a first turn that ran tools (suppressed), then a fresh user batch
+    // whose turn dies without touching a tool. The suppression must not leak
+    // across the logical-turn boundary and silence the second failure.
+    const dir = await tempDir()
+    const logs: string[] = []
+    const sent: string[] = []
+    const { router, sessions } = makeRouter(dir, { logs })
+    router.registerOutbound('discord-bot', async (msg) => {
+      sent.push(msg.text ?? '')
+      return { ok: true }
+    })
+
+    await router.route(inbound({ text: '이 PR 다시 봐줘', externalMessageId: 'm-first' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({ type: 'tool_execution_start' })
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1006 Connection ended' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+    expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(0)
+
+    await router.route(inbound({ text: '다시 시도해줘', externalMessageId: 'm-second' }))
+    sessions[0]!.onPrompt = () => {
+      sessions[0]!.emit({
+        type: 'message_end',
+        message: { role: 'assistant', stopReason: 'error', errorMessage: 'WebSocket closed 1006 Connection ended' },
+      })
+      sessions[0]!.setAssistantMidTurn('', 'error')
+    }
+    await router.__testing!.flushDebounce(KEY)
+
+    expect(sent.filter((t) => t.startsWith('⚠️'))).toHaveLength(1)
   })
 
   test('keeps the deferred warning latched when recovery queues an empty-continuation nudge', async () => {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -1120,6 +1120,29 @@ type LiveSession = {
   // EARLIER iteration than the fallback; resetting per-iteration (beside
   // resetReviewTurn) would recreate the bug.
   githubReviewOutputTurn: number | null
+  // True once this LOGICAL turn executed any tool. Read only by
+  // `maybePostDeferredProviderError`: the provider-error notice exists so a
+  // dead turn doesn't leave the human with silence, and a turn that ran tools
+  // was not silent — it may already have published a review, a review-thread
+  // reply, or any other out-of-band write that never bumps
+  // `successfulChannelSends`. Approximating "produced durable output" with
+  // "executed a tool" deliberately over-suppresses: an operator log records
+  // every suppressed notice, whereas a public "connection dropped" comment
+  // stranded above the agent's own successful review cannot be taken back. A
+  // boolean rather than a `turnSeq` stamp so it survives the reminder-only
+  // retry iterations that end the turn. Reset ONLY on a real user batch,
+  // beside `githubReviewOutputTurn`.
+  toolExecutionThisLogicalTurn: boolean
+  // True while a successful `channel_reply({ more_work_this_turn: true })`
+  // promise remains unfulfilled in this LOGICAL turn. Unlike the per-iteration
+  // `continueReplyTurn` stamp used by retry authorization and empty-stop
+  // recovery, this survives reminder-only iterations so a provider failure
+  // cannot mistake earlier tool activity for completed user-visible work after
+  // the promise stamp is cleared before the next prompt. A successful terminal
+  // `channel_reply` clears it authoritatively; a substantive tool-source send
+  // also fulfills it, while a continuation-willingness/status send preserves
+  // it. A real user batch resets it beside `toolExecutionThisLogicalTurn`.
+  promisedWorkOutstandingThisLogicalTurn: boolean
   // Captured by drain() at batch dequeue; read+cleared by send() on the
   // first tool-source send of the turn. The anchor decision (delay
   // threshold + intervening-observed check) is evaluated at SEND time
@@ -1218,6 +1241,12 @@ export type SendSource = 'tool' | 'system'
 
 export type SendOptions = {
   source?: SendSource
+  // Classifies what the human saw, independently of which router path sent it.
+  // Tool calls omit this: substantive text is the default, while the shared
+  // multilingual willingness detector recognizes status updates. System paths
+  // set it explicitly because recovery prose fulfills promised work whereas
+  // provider/fallback/control notices are meta output and must not.
+  outputKind?: 'substantive' | 'status' | 'meta'
 }
 
 export const DUPLICATE_SEND_ERROR =
@@ -2270,6 +2299,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         emptyTurnFallbackTurn: null,
         stagedFallbackCause: null,
         githubReviewOutputTurn: null,
+        toolExecutionThisLogicalTurn: false,
+        promisedWorkOutstandingThisLogicalTurn: false,
         pendingQuoteCandidate: null,
         recentEngagedPeerBotTurns: [],
         consecutiveEngagedPeerBotTurns: 0,
@@ -2652,8 +2683,15 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       const details = context.result.details as { ok?: unknown; more_work_this_turn?: unknown } | undefined
       const succeeded = context.toolCall.name === 'channel_reply' && !context.isError && details?.ok === true
       const keepTurnAlive = details?.more_work_this_turn === true
-      if (succeeded && keepTurnAlive) {
-        live.continueReplyTurn = { turnSeq: live.turnSeq, sendCount: live.successfulChannelSends }
+      if (succeeded) {
+        // This hook is authoritative for channel_reply semantics: the send path
+        // cannot distinguish channel_reply from channel_send, but here the
+        // explicit more_work_this_turn flag tells us whether the delivered reply
+        // renewed the promise or terminally fulfilled it.
+        live.promisedWorkOutstandingThisLogicalTurn = keepTurnAlive
+        if (keepTurnAlive) {
+          live.continueReplyTurn = { turnSeq: live.turnSeq, sendCount: live.successfulChannelSends }
+        }
       }
       if (succeeded && !keepTurnAlive && agent.signal?.aborted !== true) {
         logger.info(`[channels] ${live.keyId} terminal_after_channel_reply`)
@@ -2799,7 +2837,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         thread: live.key.thread,
         text: EMPTY_TURN_FALLBACK_TEXT,
       },
-      { source: 'system' },
+      { source: 'system', outputKind: 'meta' },
     )
     if (!result.ok) {
       logger.warn(`[channels] ${live.keyId}: empty-turn fallback send failed: ${result.error}`)
@@ -2973,6 +3011,22 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.pendingProviderError = null
       return
     }
+    // The turn ran tools and promised nothing further, so it was not silent —
+    // the very condition that makes recovery unsafe (`canAdvance` refuses to
+    // fail over once `startedToolExecution` is set) also means a side effect
+    // may already be public. Surfacing the notice here strands a "connection
+    // dropped" warning above the agent's own successful work. A logical turn
+    // holding an outstanding continue-reply promise is the opposite case: it
+    // explicitly told the user more was coming, so dying silently WOULD leave
+    // them waiting and the notice must still fire. Operators still get the
+    // failure from the `LLM call failed` line plus this suppression record.
+    if (live.toolExecutionThisLogicalTurn && !live.promisedWorkOutstandingThisLogicalTurn) {
+      live.pendingProviderError = null
+      logger.warn(
+        `[channels] ${live.keyId}: provider_error_notice_suppressed reason=tool_activity_this_turn notice="${pending.safeMessage}"`,
+      )
+      return
+    }
     // An empty-turn retry was queued (validateChannelTurn pushed
     // EMPTY_TURN_RETRY_NUDGE): the same logical turn re-prompts in the next
     // drain iteration and may yet recover. Carry the pending error forward,
@@ -2997,7 +3051,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         thread: live.key.thread,
         text: `⚠️ ${pending.safeMessage}`,
       },
-      { source: 'system' },
+      { source: 'system', outputKind: 'meta' },
     ).catch((sendErr) => {
       logger.warn(`[channels] ${live.keyId}: provider-error notice send threw: ${describeError(sendErr)}`)
       return null
@@ -3087,6 +3141,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           // review landed earlier in this logical turn keeps suppressing the
           // empty-turn fallback across the reminder-only retry iterations.
           live.githubReviewOutputTurn = null
+          live.toolExecutionThisLogicalTurn = false
+          live.promisedWorkOutstandingThisLogicalTurn = false
         } else if (live.lastTurnAuthorId !== null) {
           live.currentTurnEngageReactions = []
           // Reminder-only turn (batch.length === 0, reminders.length > 0):
@@ -3178,6 +3234,9 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
               logger.warn(
                 `[channels] ${live.keyId}: ${attempt.outcome} failure on ${attempt.ref}: ${attempt.errorMessage ?? 'unknown'}; falling back`,
               )
+            },
+            onToolExecutionStarted: () => {
+              live.toolExecutionThisLogicalTurn = true
             },
           })
           if (result.success) live.activeModelRef = result.refUsed
@@ -3280,7 +3339,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             live.willingnessNudges > willingnessNudgesBeforePrompt
           await maybePostDeferredProviderError(
             live,
-            sentReplyThisTurn && !hasPendingContinueReply(live),
+            sentReplyThisTurn && !live.promisedWorkOutstandingThisLogicalTurn,
             retryQueuedThisTurn,
           )
           await fireSessionTurnEnd(live)
@@ -3447,7 +3506,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
           thread: event.thread,
           text: result.reply,
         },
-        { source: 'system' },
+        { source: 'system', outputKind: 'meta' },
       )
     }
     return result
@@ -3494,7 +3553,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
             thread: event.thread,
             text: outcome.reply,
           },
-          { source: 'system' },
+          { source: 'system', outputKind: 'meta' },
         )
         return
       }
@@ -4432,6 +4491,8 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
       live.pendingQuoteCandidate = null
     }
     const text = normalizeSendText(msg.text)
+    const outputKind =
+      opts?.outputKind ?? (text !== undefined && detectContinuationWillingness(text) ? 'status' : 'substantive')
 
     // Central enforcement. Tool-initiated sends are subject to two policies:
     // a per-turn count cap (kills runaway loops regardless of content) and
@@ -4564,6 +4625,16 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
 
     if (live) {
       live.successfulChannelSends++
+      // Promise fulfillment follows OUTPUT KIND, never source:
+      //   (a) ordinary substantive tool output clears;
+      //   (b) multilingual continuation-willingness/status output preserves;
+      //   (c) recovery prose explicitly marked substantive clears even though
+      //       it uses the system bypass;
+      //   (d) provider-error, empty-turn-fallback, and control notices are
+      //       explicitly meta and preserve, so a warning can never self-clear.
+      // The channel_reply afterToolCall hook above remains authoritative for its
+      // machine-readable more_work_this_turn flag.
+      if (outputKind === 'substantive') live.promisedWorkOutstandingThisLogicalTurn = false
       live.lastSendLeafId = live.session.sessionManager.getLeafEntry()?.id ?? null
       live.policyDeniedToolSendsThisTurn.delete(sendKey)
       // Don't stop the heartbeat here: the agent may still be mid-turn and
@@ -5163,7 +5234,7 @@ export function createChannelRouter(options: CreateChannelRouterOptions): Channe
         thread: live.key.thread,
         text: assistantText,
       },
-      { source: 'system' },
+      { source: 'system', outputKind: 'substantive' },
     )
     if (!result.ok) {
       logger.warn(`[channels] ${live.keyId}: recovery send failed: ${result.error}`)


### PR DESCRIPTION
## Background

A github PR turn published a review-thread reply on `typeclaw/typeclaw#1316`, lost its websocket seven seconds later, and posted "the connection to the upstream LLM provider dropped" directly above its own successful review.

The notice exists so a dead turn does not leave the human with silence. It decides that with `sentReplyThisTurn`, which derives from `successfulChannelSends` — and a formal review or a review-thread reply goes out through the GitHub API, never through `channel_reply`, so the counter stays at zero. A turn that published to GitHub is indistinguishable from a turn that did nothing.

The fix: suppress the notice when the turn executed a tool and holds no pending continue-reply. The first half means the turn was not silent; the second keeps the notice firing when the agent explicitly promised more work and then died, which does leave the user waiting.

Worth noting the inversion this removes: `canAdvance` already refuses to fail over once `startedToolExecution` is set, so the exact condition that made recovery unsafe was also the one permitting the notice.

## Summary

**`src/agent/turn-runner.ts`** — the turn runner already tracked per-attempt tool activity privately (to gate failover safety). This exposes it to callers as `onToolExecutionStarted`, fired once per attempt on the first tool event — including on the hard-throw path, which never returns a result for callers to inspect.

**`src/channels/router.ts`** — a new `toolExecutionThisLogicalTurn` boolean on `LiveSession`, set from `onToolExecutionStarted` and reset only on a real user batch (beside the existing `githubReviewOutputTurn` reset, not on reminder-only retry iterations). `maybePostDeferredProviderError` now checks it: if the logical turn ran a tool and has no pending continue-reply, the notice is dropped instead of sent. Every suppressed notice is still recorded for operators as `provider_error_notice_suppressed`, alongside the existing `LLM call failed` line.

## What this does NOT do

The exact fix would be a confirmed-external-output signal reported by the GitHub review tool and the `gh` review recorder — a positive assertion that a review or reply actually landed. This PR does not build that signal. It uses tool execution as a cheap, adapter-generic approximation instead, which deliberately over-suppresses: any tool call, not just a confirmed GitHub write, silences the notice. The operator log line (`provider_error_notice_suppressed`) exists specifically to make every withheld notice auditable until that stronger signal lands.

## Verification

- `bun run lint` (0 errors), `bun run format:check`, `bun run typecheck` all pass.
- `src/channels` + `src/agent` suites pass (4730 pass / 27 skip).
- The sole failure, `wrapSystemTool > rejects excess queued snapshot waiters with a deterministic bound`, reproduces on unmodified `main` on the same machine and is timing-sensitive, not related to this change.

## Review notes

- The reset boundary matters: `toolExecutionThisLogicalTurn` is cleared only on a real user batch, so suppression from one logical turn cannot leak into the next turn's failure and silence a genuinely-silent death. Covered by "does not carry tool activity across into the next user turn" in `router.test.ts`.
- The pending-continue-reply carve-out is the other load-bearing branch: a turn that ran tools but also queued a continue-reply still gets the notice, since it explicitly told the user more was coming.