### PR TITLE
Stop laundering environment defects into memory

### DIFF
--- a/docs/content/docs/internals/memory.mdx
+++ b/docs/content/docs/internals/memory.mdx
@@ -24,6 +24,16 @@ Memory is split across two on-disk surfaces and two subagents that move data bet
 
 The loop is **observe → dream → apply**: `memory-logger` observes, `dreaming` consolidates, and the next prompt applies the updated shards automatically.
 
+## Boundary with operational incidents
+
+Memory is not a repair system. A deterministic environment defect that TypeClaw can classify mechanically is owned by the [operational incident subsystem](/docs/internals/operational-incidents), never solely by a remembered workaround. This boundary is enforced before consolidation:
+
+1. `tool.after` classifies exact failure shapes and appends a `TYPECLAW_OPERATIONAL_INCIDENT` marker to the tool error that reaches the transcript. Marker rendering is independent of ledger persistence; if recurrence tracking cannot be written, the privacy-safe marker says so and the fence remains closed.
+2. `memory-logger` skips the marked failure turn and its immediately following user correction or workaround.
+3. `append` reads the parent transcript and mechanically validates the full model-claimed interval from `entry` through `latestEntryId`. It rejects a fragment when that interval contains the incident result or a response/correction owned by it, even if the model selects an earlier pre-incident request as `entry`. Prompt compliance and a model-selected anchor are therefore not the only fences.
+
+Topic frontmatter has an optional `kind` field: `belief | procedure | environmental-incident`. Legacy shards without it parse as `belief`. `environmental-incident` shards remain available for explicit inspection but are excluded from automatic heading injection, hybrid retrieval, and vector passage construction. Existing workaround shards are not deleted or bulk-migrated; citation history stays intact.
+
 ## Dreaming: the consolidation run
 
 `createDreamingSubagent` (`src/bundled-plugins/memory/dreaming.ts`) builds the subagent; the `handler` is the orchestrator. The order of operations is load-bearing — each step depends on the previous one's on-disk state.
@@ -119,7 +129,7 @@ Why a bad LLM run can't corrupt memory:
 - **Snapshot/restore** — byte-exact rollback anchor; a bad run leaves zero trace.
 - **Fragment-GC gating** — fragments are deleted only on a fresh citation judgment, never on stale citations.
 - **Dreamed-ids advance even on revert** — conscious anti-loop tradeoff; a repeatedly-failing LLM can't wedge the system.
-- **Runtime owns frontmatter** — the LLM can't corrupt the strength signals; they're re-derived from citations every run.
+- **Runtime owns frontmatter** — the LLM can't corrupt the strength signals; they're re-derived from citations every run. Legacy `kind` defaults to `belief`.
 - **Atomic writes** — tmp+rename for streams, byte-comparison for shards; crash-safe mid-loop.
 - **Origin enrichment is runtime-only** — no provenance file is written; historical stream JSONL is never rewritten, and timeout/failure leaves raw IDs usable.
 - **`inFlightKey: agentDir`** — per-agent coalescing collapses concurrent cron fires into one run.

--- a/docs/content/docs/internals/meta.json
+++ b/docs/content/docs/internals/meta.json
@@ -5,6 +5,7 @@
     "index",
     "skills",
     "memory",
+    "operational-incidents",
     "secrets",
     "permissions",
     "capabilities",

--- a/docs/content/docs/internals/operational-incidents.mdx
+++ b/docs/content/docs/internals/operational-incidents.mdx
@@ -1,0 +1,59 @@
+---
+title: Operational incidents
+description: Deterministic tool-failure classification, recurrence ledger, repair allowlist, and the memory boundary
+icon: Siren
+---
+
+The operational incident subsystem keeps mechanically reproducible TypeClaw environment defects out of semantic memory. Its governing rule is: **memory must never be the sole remediation path for a deterministic defect TypeClaw can reproduce or validate mechanically.**
+
+## Outcome pipeline
+
+The observation point is the existing `tool.after` path in `src/agent/plugin-tools.ts`. Pi's bash tool throws on non-zero exit, and TypeClaw already turns thrown errors into an after-hook result; the incident path extends that funnel rather than creating a second tool stack.
+
+1. `src/operations/classify-tool-outcome.ts` applies exact classifiers. Initial classes are bash exit 127 with an anchored `command not found` line (including bounded positive `bash: line N:` prefixes), a typed declared-skill-bin resolution error, and the permanent degraded `/proc` sandbox error. Near matches and credential-shaped executable tokens remain ordinary tool failures.
+2. `src/operations/incidents.ts` records the normalized fingerprint in `<agentDir>/.typeclaw/incidents.json`, increments the occurrence count, and maintains first/last timestamps, status, and the last session identity. An incident becomes recurrent only after the same fingerprint appears in a different session; retries in one session do not escalate it.
+3. The tool error receives one machine-readable line beginning `TYPECLAW_OPERATIONAL_INCIDENT`. The marker is rendered from the already-classified fact even when ledger persistence fails; that fallback reports `recurrenceTracking: "unavailable"` rather than failing the memory boundary open. On recurrence its action is `escalate-recurrent-environment-issue-to-operator`; it explicitly says not to delegate the original task to the user.
+4. `src/operations/remediations.ts` looks up repairs by classifier kind in an explicit, idempotently populated registry. The production builtin-tool funnel records the failure, invokes a matching handler, reconstructs the tool boundary, and retries the original operation once. Unknown incidents receive no automatic action, a failed repair receives no retry, and a failed retry stops after that one attempt. A successful retry resolves the recorded fingerprint only when the shared mechanical-success derivation includes that exact fingerprint.
+5. A later successful builtin invocation also closes manually repaired incidents. `deriveMechanicallyVerifiedIncidentFingerprints()` converts mechanically verified success signals into normalized candidate fingerprints for both resolution entry points. Only exact matching open fingerprints are resolved.
+
+The default registry intentionally has no skill-bin repair and never installs packages. Skill-bin capability and PATH repair belong to their owning subsystem; adding one later requires an explicit registry entry rather than a heuristic catch-all.
+
+Resolution signals are defined for every classifier fact kind:
+
+| Fact kind                       | Mechanically verified success signal                                                                                                                                                                                                                                                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bash-command-not-found`        | The command word from one unconditional invocation in the original, pre-sandbox bash arguments executes successfully. The word passes the same `isSafeBin()` basename and secret-shape rejection as failure classification.                                                                                                                    |
+| `declared-skill-bin-unresolved` | The same successful safe command-word signal. One successful `<bin>` therefore produces both bin-scoped candidate fingerprints and clears either or both open classes for that bin.                                                                                                                                                            |
+| `sandbox-proc-unavailable`      | One unconditional real-`/proc`-dependent invocation (`commandNeedsRealProc`) succeeds after `applyBashSandbox()` returned a prepared runtime, runtime verification completed, and the wrapped bash execution returned successfully. A tmpfs fallback would fail before execution, so this proves the missing sandbox capability is functional. |
+
+Resolution deliberately under-resolves: a stale warning remains visible and recoverable, while false resolution can silently make `doctor` green on a broken environment. Both successful remediation retries and later observed successes use the same mechanical fingerprint derivation; aggregate retry success alone never resolves an incident. Aggregate exit zero counts only for a single invocation with optional leading environment assignments. Derivation rejects shell control operators (`||`, `&&`, `;`, `|`, `&`, or multiple lines), subshells and command substitutions (`(...)`, `$(...)`, or backticks), redirections, comments, unmatched quoting, assignment-only commands, and shell constructs such as `if`, `while`, `for`, `case`, and function bodies. The same gate applies to bin and sandbox candidates. Leading assignments are retained because, absent rejected command substitution or control syntax, the shell executes the following command directly and preserves its exit status.
+
+`OPERATIONAL_INCIDENT_RESOLUTION_SIGNAL_BY_KIND` is declared with `satisfies Record<OperationalIncidentFact['kind'], ...>`. Adding a fourth fact kind therefore fails typechecking until its resolution signal is explicitly mapped; the mapping also has a value-level guard test.
+
+## Fingerprints and persistence safety
+
+Fingerprints contain structured facts only:
+
+```text
+bash:command-not-found:<normalized-bin>
+sandbox:proc-unavailable
+skill-bin:declared-but-unresolved:<normalized-bin>
+```
+
+`<normalized-bin>` must match a bounded executable-basename grammar and is lowercased. Before classification, the basename also passes the shared memory secret detector plus token-only guards for JWT-shaped and long opaque hex/base64 values. A credential-shaped command name therefore never reaches fingerprint construction. The ledger never receives the command string, arguments, stdout, arbitrary stderr, paths, or environment values; only classifier-owned fields are serialized. Writes use a private `.typeclaw/` directory, an inter-process `proper-lockfile` critical section around read-modify-rename, an atomic temporary-file rename, and mode `0600`.
+
+Operational metadata is a separate runtime-private surface (`CANONICAL_AGENT_RUNTIME_PRIVATE_FILES`), not a canonical secret or credential directory. It is masked from model-driven tools without distorting the credential model. `.typeclaw/` is already truly ignored and never enters agent git history.
+
+## Recurrence and doctor
+
+Recurrence comes only from the ledger's exact fingerprint and persisted last-session identity. The raw count remains diagnostic, but only an occurrence from a different session flips `recurrent` to true. Memory `cites`, `days`, and `lastReinforced` are LLM-selected consolidation statistics and never influence repair or escalation.
+
+`src/doctor/operational-incidents.ts` reports unresolved incidents and elevates recurrent unresolved incidents to an error requiring operator repair. `IncidentLedger.resolve()` is the atomic lifecycle transition used after a mechanically verified automatic remediation retry; `resolveObservedSuccess()` uses the same locked transition when a later invocation mechanically proves a manual repair. Both consume `deriveMechanicallyVerifiedIncidentFingerprints()`, are idempotent, leave unrelated entries unchanged, and make doctor return to healthy only after verified repair. Doctor reports fingerprints and ledger timing/count metadata, not captured tool output.
+
+The observed-success check is gated for the success-path hot loop. Calls with no bin or verified-sandbox candidate return before filesystem I/O. Otherwise the process performs one ledger-file metadata inspection; adding the sandbox candidate is only an in-memory boolean check and does not add I/O. A missing or zero-byte mask target returns without parsing or locking. A process-local snapshot caches the ledger file identity plus its unresolved fingerprint set, so an unchanged file with no matching open incident also returns without parsing or locking. The ledger is parsed only when a non-empty file is first seen or its atomic-rename identity changes, and the inter-process lock is acquired only when the cached/refreshed open set contains an exact candidate fingerprint.
+
+## Memory fence
+
+The transcript marker makes ownership visible to both the model and the memory logger. The append tool does not trust the model-selected anchor: it validates every transcript entry from `entry` through `latestEntryId`, including incident ownership inherited from a preceding marker. A marker, its response, or the following correction anywhere in that evaluated interval is rejected before a stream fragment can be written. This prevents the failure → correction → workaround sequence from becoming a reinforced belief or procedure even if the logger disregards its prompt.
+
+Shard frontmatter may still use `kind: environmental-incident` for explicit historical material. Those shards are excluded from automatic retrieval and vector indexing but remain readable through explicit memory inspection. No destructive migration is performed on legacy shards.

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -26,7 +26,9 @@ import { z } from 'zod'
 import { createDreamingSubagent } from '@/bundled-plugins/memory/dreaming'
 import { createWriteReportTool } from '@/bundled-plugins/researcher/write-report'
 import { checkPrivateSurfaceReadGuard } from '@/bundled-plugins/security/policies/private-surface-read'
+import { buildOperationalIncidentChecks } from '@/doctor/operational-incidents'
 import { hooklessGitArgs } from '@/git/hookless'
+import { DeclaredSkillBinUnresolvedError, IncidentLedger, readIncidentLedger, RemediationRegistry } from '@/operations'
 import { createPermissionService } from '@/permissions/permissions'
 import { createHookBus, defineTool, type PluginRegistry, type ToolResult } from '@/plugin'
 import {
@@ -35,6 +37,7 @@ import {
   _resetBwrapAvailabilityCacheForTests,
   _resetRealProcProbeCacheForTests,
   resolveProtectedZones,
+  SandboxDegradedProcError,
   SESSION_TMP_ROOT,
   resolvePrivilegedSandboxRuntime,
 } from '@/sandbox'
@@ -3659,6 +3662,486 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     expect(afterResults).toHaveLength(1)
     expect(afterResults[0]?.details).toEqual({ error: 'execution failed' })
     await rm(agentDir, { recursive: true, force: true })
+  })
+
+  test('classified failures keep the transcript marker when incident persistence is unavailable', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-persistence-'))
+    const afterResults: ToolResult[] = []
+    const hooks = createHookBus()
+    hooks.registerAll('observer', agentDir, noopLogger, {
+      'tool.after': (event) => {
+        afterResults.push(event.result)
+      },
+    })
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      await rm(path.join(agentDir, '.typeclaw'), { recursive: true, force: true })
+      await writeFile(path.join(agentDir, '.typeclaw'), 'not-a-directory')
+      throw new Error('/bin/bash: opensoma: command not found\n\n\nCommand exited with code 127')
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-persistence',
+      hooks,
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await expect(wrapped.execute('c', { command: 'opensoma' }, undefined, undefined, {} as never)).rejects.toThrow(
+        /TYPECLAW_OPERATIONAL_INCIDENT.*"recurrenceTracking":"unavailable"/,
+      )
+      expect(afterResults).toHaveLength(1)
+      expect(afterResults[0]?.details).toEqual({
+        error: expect.stringMatching(/TYPECLAW_OPERATIONAL_INCIDENT.*"recurrenceTracking":"unavailable"/),
+      })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('registered operational remediation repairs and retries a classified builtin failure once', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-remediation-'))
+    const registry = new RemediationRegistry()
+    class TrackingIncidentLedger extends IncidentLedger {
+      automaticResolveCalls = 0
+
+      override async resolve(fingerprint: string): Promise<boolean> {
+        this.automaticResolveCalls += 1
+        return super.resolve(fingerprint)
+      }
+    }
+    const incidentLedger = new TrackingIncidentLedger(agentDir)
+    const repairedBins: string[] = []
+    registry.register('bash-command-not-found', async (fact) => {
+      if (fact.kind === 'bash-command-not-found') repairedBins.push(fact.bin)
+      return { repaired: true }
+    })
+    let attempts = 0
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      attempts += 1
+      if (attempts === 1) {
+        throw new Error('/bin/bash: opensoma: command not found\n\n\nCommand exited with code 127')
+      }
+      return { content: [{ type: 'text' as const, text: 'ran after repair' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-remediation',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      remediations: registry,
+      incidentLedger,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      const result = await wrapped.execute('c', { command: 'opensoma --version' }, undefined, undefined, {} as never)
+      expect(textOfFirstContent(result)).toBe('ran after repair')
+      expect(attempts).toBe(2)
+      expect(repairedBins).toEqual(['opensoma'])
+      expect(incidentLedger.automaticResolveCalls).toBe(1)
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'bash:command-not-found:opensoma', count: 1, status: 'resolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.each([
+    { name: 'masked aggregate success', command: 'opensoma || true' },
+    { name: 'success for a different executable', command: 'another-cli' },
+  ])('a remediation retry with $name does not resolve the recorded bin incident', async ({ command }) => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-unverified-remediation-'))
+    const registry = new RemediationRegistry()
+    registry.register('bash-command-not-found', async () => ({ repaired: true }))
+    let attempts = 0
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      attempts += 1
+      if (attempts === 1) {
+        throw new Error('/bin/bash: opensoma: command not found\n\n\nCommand exited with code 127')
+      }
+      return { content: [{ type: 'text' as const, text: 'aggregate retry succeeded' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-unverified-remediation',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      remediations: registry,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await wrapped.execute('retry', { command }, undefined, undefined, {} as never)
+
+      expect(attempts).toBe(2)
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'bash:command-not-found:opensoma', status: 'unresolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a masked successful sandbox remediation retry does not resolve the sandbox incident', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-unverified-sandbox-remediation-'))
+    const registry = new RemediationRegistry()
+    registry.register('sandbox-proc-unavailable', async () => ({ repaired: true }))
+    let attempts = 0
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      attempts += 1
+      if (attempts === 1) throw new SandboxDegradedProcError()
+      return { content: [{ type: 'text' as const, text: 'masked sandbox retry succeeded' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-unverified-sandbox-remediation',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      remediations: registry,
+      realProcDependencyCheck: () => true,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await wrapped.execute('retry', { command: 'package-cli || true' }, undefined, undefined, {} as never)
+
+      expect(attempts).toBe(2)
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'sandbox:proc-unavailable', status: 'unresolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a later successful invocation resolves an unhandled incident after manual repair', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-manual-repair-'))
+    const registry = new RemediationRegistry()
+    let attempts = 0
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      attempts += 1
+      if (attempts === 1) {
+        throw new Error('/bin/bash: opensoma: command not found\n\n\nCommand exited with code 127')
+      }
+      return { content: [{ type: 'text' as const, text: 'ran after manual repair' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-manual-repair',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      remediations: registry,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await expect(
+        wrapped.execute('failure', { command: 'opensoma' }, undefined, undefined, {} as never),
+      ).rejects.toThrow('TYPECLAW_OPERATIONAL_INCIDENT')
+      expect((await buildOperationalIncidentChecks()[0]!.run({ cwd: agentDir, hasAgentFolder: true })).status).toBe(
+        'warning',
+      )
+
+      const result = await wrapped.execute(
+        'success',
+        { command: 'opensoma --version' },
+        undefined,
+        undefined,
+        {} as never,
+      )
+
+      expect(textOfFirstContent(result)).toBe('ran after manual repair')
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'bash:command-not-found:opensoma', status: 'resolved' },
+      ])
+      expect(await buildOperationalIncidentChecks()[0]!.run({ cwd: agentDir, hasAgentFolder: true })).toEqual({
+        status: 'ok',
+        message: 'no unresolved operational incidents',
+      })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test.each([
+    { name: 'an OR-list that swallows failure', command: 'opensoma --version || true' },
+    { name: 'a short-circuited AND-list', command: 'a && opensoma' },
+    { name: 'a pipeline whose last segment succeeds', command: 'opensoma | tee out' },
+    { name: 'a conditional that negates failure', command: 'if ! opensoma; then echo skip; fi' },
+  ])('aggregate success from $name does not resolve the executable incident', async ({ command }) => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-ambiguous-success-'))
+    const incidentLedger = new IncidentLedger(agentDir)
+    await incidentLedger.record({ kind: 'bash-command-not-found', bin: 'opensoma' }, 'failure')
+    const wrapped = wrapBuiltinToolDefinition(fakeBash({}), {
+      agentDir,
+      sessionId: 'incident-ambiguous-success',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      incidentLedger,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await wrapped.execute('success', { command }, undefined, undefined, {} as never)
+
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'bash:command-not-found:opensoma', status: 'unresolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a later successful real-proc sandbox execution resolves a sandbox incident', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-sandbox-repair-'))
+    let attempts = 0
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      attempts += 1
+      if (attempts === 1) throw new SandboxDegradedProcError()
+      return { content: [{ type: 'text' as const, text: 'sandbox package runner succeeded' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-sandbox-repair',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      remediations: new RemediationRegistry(),
+      realProcDependencyCheck: () => true,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await expect(
+        wrapped.execute('failure', { command: 'package-cli' }, undefined, undefined, {} as never),
+      ).rejects.toThrow('TYPECLAW_OPERATIONAL_INCIDENT')
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'sandbox:proc-unavailable', status: 'unresolved' },
+      ])
+
+      await wrapped.execute('success', { command: 'package-cli' }, undefined, undefined, {} as never)
+
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'sandbox:proc-unavailable', status: 'resolved' },
+      ])
+      expect(await buildOperationalIncidentChecks()[0]!.run({ cwd: agentDir, hasAgentFolder: true })).toEqual({
+        status: 'ok',
+        message: 'no unresolved operational incidents',
+      })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('aggregate success from a chained sandbox command does not resolve a sandbox incident', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-ambiguous-sandbox-success-'))
+    const incidentLedger = new IncidentLedger(agentDir)
+    await incidentLedger.record({ kind: 'sandbox-proc-unavailable' }, 'failure')
+    const wrapped = wrapBuiltinToolDefinition(fakeBash({}), {
+      agentDir,
+      sessionId: 'incident-ambiguous-sandbox-success',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      incidentLedger,
+      realProcDependencyCheck: () => true,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await wrapped.execute('success', { command: 'package-cli || true' }, undefined, undefined, {} as never)
+
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'sandbox:proc-unavailable', status: 'unresolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a later successful bin invocation resolves a declared skill-bin incident', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-skill-bin-repair-'))
+    let attempts = 0
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      attempts += 1
+      if (attempts === 1) throw new DeclaredSkillBinUnresolvedError('opensoma')
+      return { content: [{ type: 'text' as const, text: 'declared bin succeeded' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-skill-bin-repair',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      remediations: new RemediationRegistry(),
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await expect(
+        wrapped.execute('failure', { command: 'opensoma' }, undefined, undefined, {} as never),
+      ).rejects.toThrow('TYPECLAW_OPERATIONAL_INCIDENT')
+      await wrapped.execute('success', { command: 'opensoma' }, undefined, undefined, {} as never)
+
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'skill-bin:declared-but-unresolved:opensoma', status: 'resolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('one successful bin invocation resolves command-not-found and skill-bin incidents together', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-dual-bin-repair-'))
+    const incidentLedger = new IncidentLedger(agentDir)
+    await incidentLedger.record({ kind: 'bash-command-not-found', bin: 'opensoma' }, 'command-failure')
+    await incidentLedger.record({ kind: 'declared-skill-bin-unresolved', bin: 'opensoma' }, 'skill-bin-failure')
+    const wrapped = wrapBuiltinToolDefinition(fakeBash({}), {
+      agentDir,
+      sessionId: 'incident-dual-bin-repair',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      incidentLedger,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await wrapped.execute('success', { command: 'opensoma' }, undefined, undefined, {} as never)
+
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'bash:command-not-found:opensoma', status: 'resolved' },
+        { fingerprint: 'skill-bin:declared-but-unresolved:opensoma', status: 'resolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a successful unrelated command does not resolve another executable incident', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-unrelated-success-'))
+    const registry = new RemediationRegistry()
+    let attempts = 0
+    const tool = fakeBash({})
+    tool.execute = async () => {
+      attempts += 1
+      if (attempts === 1) {
+        throw new Error('/bin/bash: opensoma: command not found\n\n\nCommand exited with code 127')
+      }
+      return { content: [{ type: 'text' as const, text: 'unrelated command succeeded' }], details: undefined }
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'incident-unrelated-success',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      remediations: registry,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      await expect(
+        wrapped.execute('failure', { command: 'opensoma' }, undefined, undefined, {} as never),
+      ).rejects.toThrow('TYPECLAW_OPERATIONAL_INCIDENT')
+      await wrapped.execute('success', { command: 'another-cli' }, undefined, undefined, {} as never)
+
+      expect((await readIncidentLedger(agentDir)).incidents).toMatchObject([
+        { fingerprint: 'bash:command-not-found:opensoma', status: 'unresolved' },
+      ])
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('a successful invocation with no open incidents performs no ledger read or lock', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-incident-empty-fast-path-'))
+    let inspections = 0
+    let reads = 0
+    let locks = 0
+    const incidentLedger = new IncidentLedger(agentDir, {
+      inspect: async () => {
+        inspections += 1
+        return { kind: 'missing' }
+      },
+      read: async () => {
+        reads += 1
+        throw new Error('empty-ledger gate read unexpectedly')
+      },
+      serialize: async () => {
+        locks += 1
+        throw new Error('empty-ledger gate locked unexpectedly')
+      },
+    })
+    const wrapped = wrapBuiltinToolDefinition(fakeBash({}), {
+      agentDir,
+      sessionId: 'incident-empty-fast-path',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      incidentLedger,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        buildCommand: buildSandboxedCommand,
+      },
+    })
+
+    try {
+      const result = await wrapped.execute('success', { command: 'echo healthy' }, undefined, undefined, {} as never)
+
+      expect(textOfFirstContent(result)).toBe('ran')
+      expect({ inspections, reads, locks }).toEqual({ inspections: 1, reads: 0, locks: 0 })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
   })
 
   test('without a permission service bash fails closed and never reaches the underlying tool', async () => {

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -25,6 +25,16 @@ import {
 } from '@/bundled-plugins/guard/policy'
 import { config, getSandboxWritablePathSpecs } from '@/config/config'
 import { readEnvFile } from '@/init/env-file'
+import {
+  classifyToolOutcome,
+  deriveMechanicallyVerifiedIncidentFingerprints,
+  IncidentLedger,
+  operationalRemediations,
+  renderIncidentHint,
+  renderUntrackedIncidentHint,
+  repairAndRetryOnce,
+} from '@/operations'
+import type { RemediationRegistry } from '@/operations'
 import type { PermissionService } from '@/permissions/permissions'
 import type {
   BuiltinToolRef,
@@ -284,6 +294,9 @@ export type WrapSystemToolOptions = {
   // `src/agent/reviewer-bash-policy.ts`.
   bashPolicy?: SubagentBashPolicy
   bashSandboxBoundary?: BashSandboxBoundary
+  realProcDependencyCheck?: typeof commandNeedsRealProc
+  remediations?: RemediationRegistry
+  incidentLedger?: IncidentLedger
 }
 
 // Zod 4 emits a top-level `"$schema": "https://json-schema.org/draft/2020-12/schema"`
@@ -574,59 +587,81 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
       let rawResult: ToolResult | undefined
       let executionError: unknown
       let cleanupError: unknown
+      let sandboxedRealProcSucceeded = false
       const sandboxBoundary = opts.bashSandboxBoundary ?? DEFAULT_BASH_SANDBOX_BOUNDARY
-      try {
-        if (tool.name === 'bash') {
-          if (opts.permissions === undefined) {
-            throw new SandboxPolicyError('model-driven bash has no permission service; refusing unsandboxed execution')
+      const incidentLedger = opts.incidentLedger ?? new IncidentLedger(opts.agentDir)
+      const originalArgs = { ...mutableArgs }
+      const executeAttempt = async (): Promise<void> => {
+        preparedSandboxRuntime = undefined
+        pinnedFiles = undefined
+        tmpRedirect = undefined
+        rawResult = undefined
+        executionError = undefined
+        cleanupError = undefined
+        sandboxedRealProcSucceeded = false
+        const attemptArgs = { ...originalArgs }
+        try {
+          if (tool.name === 'bash') {
+            if (opts.permissions === undefined) {
+              throw new SandboxPolicyError(
+                'model-driven bash has no permission service; refusing unsandboxed execution',
+              )
+            }
+            preparedSandboxRuntime = await applyBashSandbox(
+              attemptArgs,
+              opts.permissions,
+              liveOrigin,
+              opts.agentDir,
+              opts.sessionId,
+              bashEnvOverlay,
+              sandboxBoundary,
+            )
           }
-          preparedSandboxRuntime = await applyBashSandbox(
-            mutableArgs,
-            opts.permissions,
-            liveOrigin,
-            opts.agentDir,
-            opts.sessionId,
-            bashEnvOverlay,
-            sandboxBoundary,
-          )
-        }
 
-        tmpRedirect =
-          TMP_REDIRECT_TOOLS.has(tool.name) && opts.permissions !== undefined
-            ? await applyTmpPathRedirect(mutableArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId)
-            : undefined
-        pinnedFiles = await enforceAndPinToolFiles({
-          tool: tool.name,
-          args: mutableArgs,
-          agentDir: opts.agentDir,
-          ...(opts.permissions !== undefined
-            ? { hidden: resolveHiddenPaths(opts.permissions, liveOrigin, opts.agentDir) }
-            : {}),
-          signal,
-        })
-        await preparedSandboxRuntime?.verify()
-        const spawnEnvContext: BashSpawnEnvContext | undefined =
-          bashEnvOverlay !== undefined || preparedSandboxRuntime?.spawnEnv !== undefined
-            ? {
-                ...(bashEnvOverlay !== undefined ? { overlay: bashEnvOverlay } : {}),
-                ...(preparedSandboxRuntime?.spawnEnv !== undefined
-                  ? { sandboxSpawnEnv: preparedSandboxRuntime.spawnEnv }
-                  : {}),
-              }
-            : undefined
-        rawResult = await bashEnvStore.run(spawnEnvContext, () =>
-          tool.execute(toolCallId, mutableArgs as Static<TParams>, signal, onUpdate, ctx),
-        )
-      } catch (error) {
-        executionError = error
-      } finally {
-        const cleanup = [pinnedFiles?.cleanup(), preparedSandboxRuntime?.cleanup()].filter(
-          (task): task is Promise<void> => task !== undefined,
-        )
-        const outcomes = await Promise.allSettled(cleanup)
-        const failed = outcomes.find((outcome) => outcome.status === 'rejected')
-        if (failed?.status === 'rejected') cleanupError = failed.reason
+          tmpRedirect =
+            TMP_REDIRECT_TOOLS.has(tool.name) && opts.permissions !== undefined
+              ? await applyTmpPathRedirect(attemptArgs, opts.permissions, liveOrigin, opts.agentDir, opts.sessionId)
+              : undefined
+          pinnedFiles = await enforceAndPinToolFiles({
+            tool: tool.name,
+            args: attemptArgs,
+            agentDir: opts.agentDir,
+            ...(opts.permissions !== undefined
+              ? { hidden: resolveHiddenPaths(opts.permissions, liveOrigin, opts.agentDir) }
+              : {}),
+            signal,
+          })
+          await preparedSandboxRuntime?.verify()
+          const spawnEnvContext: BashSpawnEnvContext | undefined =
+            bashEnvOverlay !== undefined || preparedSandboxRuntime?.spawnEnv !== undefined
+              ? {
+                  ...(bashEnvOverlay !== undefined ? { overlay: bashEnvOverlay } : {}),
+                  ...(preparedSandboxRuntime?.spawnEnv !== undefined
+                    ? { sandboxSpawnEnv: preparedSandboxRuntime.spawnEnv }
+                    : {}),
+                }
+              : undefined
+          rawResult = await bashEnvStore.run(spawnEnvContext, () =>
+            tool.execute(toolCallId, attemptArgs as Static<TParams>, signal, onUpdate, ctx),
+          )
+          const originalCommand = originalArgs.command
+          sandboxedRealProcSucceeded =
+            preparedSandboxRuntime !== undefined &&
+            typeof originalCommand === 'string' &&
+            (opts.realProcDependencyCheck ?? commandNeedsRealProc)(originalCommand)
+        } catch (error) {
+          executionError = error
+        } finally {
+          const cleanup = [pinnedFiles?.cleanup(), preparedSandboxRuntime?.cleanup()].filter(
+            (task): task is Promise<void> => task !== undefined,
+          )
+          const outcomes = await Promise.allSettled(cleanup)
+          const failed = outcomes.find((outcome) => outcome.status === 'rejected')
+          if (failed?.status === 'rejected') cleanupError = failed.reason
+        }
       }
+
+      await executeAttempt()
       // Decorate genuine, user-correctable builtin file-tool failures with a
       // recovery hint so weaker models retry correctly. Only executionError (not
       // cleanupError) and only non-aborted Error instances; remediation is a
@@ -635,6 +670,46 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
       // preserves the error's subclass and stack for the rethrow.
       if (executionError instanceof Error && signal?.aborted !== true) {
         executionError.message = remediateToolErrorMessage(tool.name, executionError.message)
+        const incidentFact = classifyToolOutcome({ tool: tool.name, error: executionError })
+        if (incidentFact !== null) {
+          const initialError = executionError
+          let recordedFingerprint: string | undefined
+          let incidentHint = renderUntrackedIncidentHint(incidentFact)
+          try {
+            const incident = await incidentLedger.record(incidentFact, opts.sessionId)
+            recordedFingerprint = incident.fingerprint
+            incidentHint = renderIncidentHint(incident)
+          } catch {
+            // Incident persistence must never hide the originating tool failure.
+          }
+          const remediation = await repairAndRetryOnce(
+            opts.remediations ?? operationalRemediations,
+            incidentFact,
+            initialError,
+            async () => {
+              await executeAttempt()
+              const retryError = executionError ?? cleanupError
+              if (retryError !== undefined) throw retryError
+            },
+          )
+          if (remediation.outcome === 'retried') {
+            const retrySuccessFingerprints = deriveMechanicallyVerifiedIncidentFingerprints({
+              tool: tool.name,
+              args: originalArgs,
+              sandboxedRealProcSucceeded,
+            })
+            if (recordedFingerprint !== undefined && retrySuccessFingerprints.has(recordedFingerprint)) {
+              await incidentLedger.resolve(recordedFingerprint).catch(() => false)
+            }
+          } else {
+            const failedError = remediation.outcome === 'retry-failed' ? remediation.error : initialError
+            const finalIncidentError = failedError instanceof Error ? failedError : new Error(String(failedError))
+            finalIncidentError.message = remediateToolErrorMessage(tool.name, finalIncidentError.message)
+            finalIncidentError.message = `${finalIncidentError.message}\n\n${incidentHint}`
+            executionError = finalIncidentError
+            cleanupError = undefined
+          }
+        }
       }
       const finalError = executionError ?? cleanupError
       if (finalError !== undefined) {
@@ -657,6 +732,12 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
         callId: toolCallId,
         result: hookResult,
       })
+      const successFingerprints = deriveMechanicallyVerifiedIncidentFingerprints({
+        tool: tool.name,
+        args: originalArgs,
+        sandboxedRealProcSucceeded,
+      })
+      await incidentLedger.resolveObservedSuccess(successFingerprints).catch(() => 0)
       return {
         content: hookResult.content as ContentPart[],
         details: hookResult.details as TDetails,

--- a/src/bundled-plugins/memory/append-tool.test.ts
+++ b/src/bundled-plugins/memory/append-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -51,6 +51,41 @@ async function callExpectingThrow(root: string, input: Partial<AppendInput>): Pr
 }
 
 describe('appendTool', () => {
+  test('mechanically rejects every evaluated interval that belongs to an operational incident', async () => {
+    const root = tmpRoot()
+    const transcript = join(root, 'sessions', 'session.jsonl')
+    mkdirSync(join(root, 'sessions'), { recursive: true })
+    writeFileSync(
+      transcript,
+      [
+        { type: 'message', id: 'user-request', message: { role: 'user', content: 'Book a room' } },
+        {
+          type: 'message',
+          id: 'tool-failure',
+          message: {
+            role: 'toolResult',
+            content: [
+              { type: 'text', text: 'TYPECLAW_OPERATIONAL_INCIDENT {"fingerprint":"bash:command-not-found:opensoma"}' },
+            ],
+          },
+        },
+        { type: 'message', id: 'assistant-gave-up', message: { role: 'assistant', content: 'Please do it manually.' } },
+        { type: 'message', id: 'user-correction', message: { role: 'user', content: 'Use bunx opensoma.' } },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join('\n'),
+    )
+    const fenced = createAppendTool({ transcriptPathProvider: () => transcript })
+
+    await expect(
+      fenced.execute({ ...baseInput, entry: 'user-correction', latestEntryId: 'user-correction' }, ctx(root)),
+    ).rejects.toThrow('operational incident')
+    await expect(
+      fenced.execute({ ...baseInput, entry: 'user-request', latestEntryId: 'user-correction' }, ctx(root)),
+    ).rejects.toThrow('operational incident')
+    expect(existsSync(streamPath(root))).toBe(false)
+  })
+
   test('preserves thread parent coordinates in runtime-stamped provenance', () => {
     const origin: SessionOrigin = {
       kind: 'channel',

--- a/src/bundled-plugins/memory/append-tool.ts
+++ b/src/bundled-plugins/memory/append-tool.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
 import { z } from 'zod'
@@ -28,11 +28,13 @@ export type OriginProvider = () => SessionOrigin | undefined
 // is already on disk by append time). Lets the append tool strip hallucinated
 // slugs the model invents without ever calling `store_reference`.
 export type ReferenceSlugResolver = (agentDir: string) => Promise<Iterable<string>>
+export type TranscriptPathProvider = () => string | undefined
 
 export type CreateAppendToolOptions = {
   onFragmentsAppended?: FragmentsAppendedHook
   originProvider?: OriginProvider
   referenceSlugResolver?: ReferenceSlugResolver
+  transcriptPathProvider?: TranscriptPathProvider
 }
 
 // Stamped fields are the stable channel coordinates only. Author identity is
@@ -64,7 +66,7 @@ export function provenanceFromOrigin(origin: SessionOrigin | undefined): Fragmen
 }
 
 export function createAppendTool(options: CreateAppendToolOptions = {}) {
-  const { onFragmentsAppended, originProvider, referenceSlugResolver } = options
+  const { onFragmentsAppended, originProvider, referenceSlugResolver, transcriptPathProvider } = options
   return defineTool({
     description:
       "Append a memory fragment to today's JSONL daily stream and advance the watermark. The runtime serializes your call into a JSON line and chooses the filename — do not emit raw JSON and do not pass a path. `topic`/`body` are the fragment's substance; `source` is the parent session id; `entry` is the transcript-entry-id this fragment anchors to; `latestEntryId` is the latest transcript-entry-id you evaluated in this run (advances the watermark, may equal `entry` or be later). `references` may ONLY contain slugs returned by `store_reference` (it returns the slug it wrote) — never topic ids, PR names, stream paths, or invented labels; unknown slugs are dropped. `who` is the display name/handle of the person the fragment's evidence is attributable to — set it ONLY when one transcript speaker clearly owns the evidence; omit it when the fact is the user's own, spans multiple speakers, or is not attributable. The channel/room/platform (`where`) is stamped automatically from the session origin — do not pass it and do not restate it in the body. Refuses content with recognized credential patterns and refuses byte-equivalent topic+body within the same daily stream.",
@@ -87,6 +89,16 @@ export function createAppendTool(options: CreateAppendToolOptions = {}) {
     async execute({ topic, body, source, entry, latestEntryId, references, who }, ctx) {
       const streamPath = dailyStreamPath(ctx.agentDir)
       const where = provenanceFromOrigin(originProvider?.())
+      const transcriptPath = transcriptPathProvider?.()
+      if (
+        transcriptPath !== undefined &&
+        (await anchorBelongsToOperationalIncident(transcriptPath, entry, latestEntryId))
+      ) {
+        throw new Error(
+          'Refusing to append: the transcript anchor belongs to a deterministic operational incident sequence. ' +
+            'Operational defects are owned by the incident ledger, not semantic memory.',
+        )
+      }
       // `who` is LLM-supplied and force-committed to memory, so it clears the
       // same secret guard as topic/body — a token-shaped display name is refused
       // with the same retryable error. (`where` names are origin-derived and the
@@ -153,6 +165,67 @@ export function createAppendTool(options: CreateAppendToolOptions = {}) {
       }
     },
   })
+}
+
+const OPERATIONAL_INCIDENT_MARKER = 'TYPECLAW_OPERATIONAL_INCIDENT '
+
+export async function anchorBelongsToOperationalIncident(
+  transcriptPath: string,
+  entryId: string,
+  latestEntryId = entryId,
+): Promise<boolean> {
+  let raw: string
+  try {
+    raw = await readFile(transcriptPath, 'utf8')
+  } catch {
+    return false
+  }
+  const entries = raw
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .flatMap((line): unknown[] => {
+      try {
+        return [JSON.parse(line) as unknown]
+      } catch {
+        return []
+      }
+    })
+  const anchorIndex = entries.findIndex((entry) => entryIdOf(entry) === entryId)
+  const latestIndex = entries.findIndex((entry) => entryIdOf(entry) === latestEntryId)
+  if (anchorIndex < 0 || latestIndex < anchorIndex) return false
+
+  for (let i = anchorIndex; i <= latestIndex; i++) {
+    if (entryBelongsToOperationalIncident(entries, i)) return true
+  }
+  return false
+}
+
+function entryBelongsToOperationalIncident(entries: unknown[], entryIndex: number): boolean {
+  if (containsIncidentMarker(entries[entryIndex])) return true
+  for (let i = entryIndex - 1; i >= 0; i--) {
+    const entry = entries[i]
+    if (containsIncidentMarker(entry)) return true
+    if (messageRole(entry) === 'user') return false
+  }
+  return false
+}
+
+function entryIdOf(entry: unknown): string | undefined {
+  if (typeof entry !== 'object' || entry === null) return undefined
+  const id = (entry as { id?: unknown }).id
+  return typeof id === 'string' ? id : undefined
+}
+
+function messageRole(entry: unknown): string | undefined {
+  if (typeof entry !== 'object' || entry === null) return undefined
+  const message = (entry as { message?: unknown }).message
+  if (typeof message !== 'object' || message === null) return undefined
+  const role = (message as { role?: unknown }).role
+  return typeof role === 'string' ? role : undefined
+}
+
+function containsIncidentMarker(entry: unknown): boolean {
+  return JSON.stringify(entry).includes(OPERATIONAL_INCIDENT_MARKER)
 }
 
 export const appendTool = createAppendTool()

--- a/src/bundled-plugins/memory/frontmatter.test.ts
+++ b/src/bundled-plugins/memory/frontmatter.test.ts
@@ -3,11 +3,28 @@ import { describe, expect, test } from 'bun:test'
 import { parseShard, renderShard, updateFrontmatter, type ShardFrontmatter } from './frontmatter'
 
 describe('parseShard', () => {
+  test('legacy shards default to belief and explicit kinds round-trip', () => {
+    const legacy = '---\nheading: Foo\ncites: 1\ndays: 1\nlastReinforced: 2026-05-20\n---\nbody\n'
+    expect(parseShard(legacy).frontmatter.kind).toBe('belief')
+
+    const procedure = '---\nheading: Foo\nkind: procedure\ncites: 1\ndays: 1\nlastReinforced: 2026-05-20\n---\nbody\n'
+    const parsed = parseShard(procedure)
+    expect(parsed.frontmatter.kind).toBe('procedure')
+    expect(renderShard(parsed.frontmatter, parsed.body)).toBe(procedure)
+  })
+
+  test('rejects an unknown shard kind', () => {
+    expect(() =>
+      parseShard('---\nheading: Foo\nkind: workaround\ncites: 1\ndays: 1\nlastReinforced: 2026-05-20\n---\nbody\n'),
+    ).toThrow("frontmatter field 'kind'")
+  })
+
   test('round-trip canonical input', () => {
     const input = `---\nheading: Design system tokens\ncites: 5\ndays: 3\nlastReinforced: 2026-05-20\ntags: [design, css]\n---\nBody text here.\n`
     const parsed = parseShard(input)
     expect(parsed.frontmatter).toEqual({
       heading: 'Design system tokens',
+      kind: 'belief',
       cites: 5,
       days: 3,
       lastReinforced: '2026-05-20',

--- a/src/bundled-plugins/memory/frontmatter.ts
+++ b/src/bundled-plugins/memory/frontmatter.ts
@@ -1,10 +1,13 @@
 export type ShardFrontmatter = {
   heading: string
+  kind?: ShardKind
   cites: number
   days: number
   lastReinforced: string
   tags?: string[]
 }
+
+export type ShardKind = 'belief' | 'procedure' | 'environmental-incident'
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
 
@@ -111,7 +114,8 @@ function parseFrontmatterBlock(text: string): ShardFrontmatter {
     throw new Error(`frontmatter field 'lastReinforced': expected YYYY-MM-DD, got '${values.lastReinforced}'`)
   }
 
-  const result: ShardFrontmatter = { heading, cites, days, lastReinforced }
+  const kind = values.kind ?? 'belief'
+  const result: ShardFrontmatter = { heading, kind: kind as ShardKind, cites, days, lastReinforced }
   if ('tags' in values) {
     result.tags = values.tags as string[]
   }
@@ -120,9 +124,15 @@ function parseFrontmatterBlock(text: string): ShardFrontmatter {
 }
 
 const FRONTMATTER_PARSERS: {
-  [K in keyof Omit<ShardFrontmatter, 'tags'>]: (value: string) => unknown
+  [K in keyof Required<Omit<ShardFrontmatter, 'tags'>>]: (value: string) => unknown
 } = {
   heading: (v) => v,
+  kind: (v) => {
+    if (v !== 'belief' && v !== 'procedure' && v !== 'environmental-incident') {
+      throw new Error(`expected belief, procedure, or environmental-incident, got '${v}'`)
+    }
+    return v
+  },
   cites: parseNonNegativeInt,
   days: parseNonNegativeInt,
   lastReinforced: (v) => v,
@@ -140,6 +150,7 @@ function parseNonNegativeInt(value: string): number {
 export function renderShard(frontmatter: ShardFrontmatter, body: string): string {
   const lines = ['---']
   lines.push(`heading: ${frontmatter.heading}`)
+  if (frontmatter.kind !== undefined && frontmatter.kind !== 'belief') lines.push(`kind: ${frontmatter.kind}`)
   lines.push(`cites: ${frontmatter.cites}`)
   lines.push(`days: ${frontmatter.days}`)
   lines.push(`lastReinforced: ${frontmatter.lastReinforced}`)

--- a/src/bundled-plugins/memory/index-vector.test.ts
+++ b/src/bundled-plugins/memory/index-vector.test.ts
@@ -124,6 +124,29 @@ describe('vector session.turn.start hook', () => {
     expect(infos.some((line) => line.includes('suppressed=1') && line.includes('fallback=topic-index'))).toBe(true)
   })
 
+  test('environmental-incident shards are excluded from automatic retrieval', async () => {
+    const emptySearch = mock(async () => [])
+    await writeTopic(agentDir, 'ordinary-belief', 'Ordinary belief', 'ordinary body')
+    await writeTopic(
+      agentDir,
+      'environment-failure',
+      'Environment failure',
+      'historical workaround body',
+      'environmental-incident',
+    )
+    const exports = await bootVectorPluginWith(emptySearch, 16384)
+    const retrievalContext = { results: '' }
+
+    await exports.hooks!['session.turn.start']!(
+      { sessionId: 'ses_environment_fence', agentDir, userPrompt: 'anything', retrievalContext },
+      { agentDir, pluginName: 'memory', logger: createPluginLogger('memory') },
+    )
+
+    expect(retrievalContext.results).toContain('ordinary-belief')
+    expect(retrievalContext.results).not.toContain('environment-failure')
+    expect(retrievalContext.results).not.toContain('historical workaround body')
+  })
+
   test('zero-shard turn still logs suppression without falling back to an empty index', async () => {
     const emptySearch = mock(async () => [])
     const infos: string[] = []
@@ -748,11 +771,20 @@ function errorCapturingLogger(errors: string[]) {
   }
 }
 
-async function writeTopic(dir: string, slug: string, heading: string, body: string): Promise<void> {
+async function writeTopic(
+  dir: string,
+  slug: string,
+  heading: string,
+  body: string,
+  kind?: 'belief' | 'procedure' | 'environmental-incident',
+): Promise<void> {
   await mkdir(topicsDir(dir), { recursive: true })
   await writeFile(
     topicShardPath(dir, slug),
-    renderShard({ heading, cites: 1, days: 1, lastReinforced: '2026-06-11' }, body),
+    renderShard(
+      { heading, ...(kind === undefined ? {} : { kind }), cites: 1, days: 1, lastReinforced: '2026-06-11' },
+      body,
+    ),
   )
 }
 

--- a/src/bundled-plugins/memory/load-memory.ts
+++ b/src/bundled-plugins/memory/load-memory.ts
@@ -50,7 +50,7 @@ export async function loadMemoryInjectionPlan(
   if (rootMemory.content !== null && !hasTopicsDir) {
     return buildInjectionPlan([rootFallbackEntry(rootMemory)], { budgetBytes: options.injectionBudgetBytes })
   }
-  const shards = await loadAllShards(agentDir)
+  const shards = (await loadAllShards(agentDir)).filter((shard) => shard.frontmatter.kind !== 'environmental-incident')
   return buildInjectionPlan(shards, { budgetBytes: options.injectionBudgetBytes })
 }
 

--- a/src/bundled-plugins/memory/load-shards.test.ts
+++ b/src/bundled-plugins/memory/load-shards.test.ts
@@ -102,6 +102,7 @@ describe('loadShard', () => {
       slug: 'design-tokens',
       frontmatter: {
         heading: 'Design tokens',
+        kind: 'belief',
         cites: 2,
         days: 1,
         lastReinforced: '2026-05-20',

--- a/src/bundled-plugins/memory/memory-logger.ts
+++ b/src/bundled-plugins/memory/memory-logger.ts
@@ -68,7 +68,7 @@ export function isMemoryLoggerPayload(value: unknown): value is MemoryLoggerPayl
 
 export const MEMORY_LOGGER_SYSTEM_PROMPT = `You are typeclaw's memory-extraction subagent.
 
-Read the parent session transcript past the watermark and write zero or more durable memory fragments to today's stream, then exit. Capture only operational facts a future agent would concretely need: explicit user instructions, stable identity/role/tool facts, decisions with reasoning, reproducible workarounds, corrections, changed minds, and content the user explicitly taught the agent or asked it to remember. Most runs produce zero or one fragment; that is expected.
+Read the parent session transcript past the watermark and write zero or more durable memory fragments to today's stream, then exit. Capture only facts a future agent would concretely need: explicit user instructions, stable identity/role/tool facts, decisions with reasoning, reproducible user-domain procedures, corrections, changed minds, and content the user explicitly taught the agent or asked it to remember. Most runs produce zero or one fragment; that is expected.
 
 A separate \`dreaming\` subagent later consolidates fragments into \`memory/topics/\`, dedupes across days, resolves contradictions, and decides what generalizes. **Dreaming is downstream consolidation, not permission to over-capture upstream.** You do not read \`memory/topics/\`; cross-shard reasoning is dreaming's job. Your inputs are the transcript past the watermark and, optionally, today's daily stream for local dedup. Recurrence across days is useful evidence for dreaming, so a repeated durable fact anchored to new evidence is not a duplicate.
 
@@ -118,6 +118,7 @@ Capture-worthy categories:
 - **Stable collaborator/contact facts.** Durable facts about non-user people the agent is likely to encounter again: name/handle, active-participant status in this context, role, responsibility, project relationship, durable working preference, or coordination/contact context. When a person actively participates in the conversation — recurring presence, multiple messages, or a back-and-forth exchange, not a single drive-by line — capture one compact identity fragment recording who they are (name/handle) and that they are an active participant here, even if they did not state a durable role or preference. A stated role/preference strengthens the fragment but is no longer required. A name appearing inside active back-and-forth can be a capture signal; a name merely mentioned in passing by someone else, especially an absent third party, is not. Keep one introduction to one compact fragment that bundles the person's core durable context (e.g. "Alex is an active participant in this project chat" or "Alex is the frontend lead for Project X and prefers GitHub issues over Slack for bug triage"), never a separate fragment per attribute. True single drive-by participants still do not earn memory. Third-party facts must come from the user/owner, or from that person describing their own role/preference in normal collaboration; do not persist one participant's reputational claims about another unless the user confirms or operationally relies on them.
 - **Decisions with reasoning.** "We chose X over Y because Z" when future sessions must honor X.
 - **Reproducible workarounds and debugging insights.** A config that worked, flag combination, procedure, root cause, or non-obvious fix.
+- **Deterministic operational incidents are excluded.** A transcript tool result containing \`TYPECLAW_OPERATIONAL_INCIDENT\` and the immediately following user correction/workaround belong to TypeClaw's incident ledger. Skip the whole failure → response → correction sequence. Do not turn an environment repair into a belief or procedure, even when it recurs; the append tool mechanically rejects incident-owned anchors.
 - **In-transcript changed minds.** Capture "actually, scratch that" only when the prior position is explicit. Do not compare against \`memory/topics/\`.
 - **Corrections the user made to the agent.** Especially when the agent confidently asserted something false that future sessions may repeat. When the agent stated a factual claim and the user corrected it, capture the corrected fact as a distinct, evidence-anchored fragment EVEN IF it sounds like something memory may already know — you cannot inspect \`memory/topics/\`, so your job is to preserve this later correction occurrence so dreaming can reinforce and sharpen the stored belief (repeated corrections are how a contested fact gets stronger, not noise to skip). Anchor the body to the correction: what the agent said, what the user corrected it to. This is semantic and **language-independent** — recognize corrections in any language (Korean, Japanese, Chinese, Arabic, and every Latin-script language), not from English cue phrases.
 - **Content the user explicitly taught, trained on, or asked the agent to remember.** Capture the substance taught, not merely that teaching happened. Treat these six intent families as representative, not exhaustive:
@@ -304,10 +305,12 @@ export function createMemoryLoggerSubagent(
   // The handler runs one logger spawn at a time per agentDir (inFlightKey), so a
   // single mutable cell safely carries this spawn's origin to the append tool.
   let currentOrigin: SessionOrigin | undefined
+  let currentTranscriptPath: string | undefined
   const appendTool = createAppendTool({
     onFragmentsAppended: options.onFragmentsAppended,
     originProvider: () => currentOrigin,
     referenceSlugResolver: (agentDir) => listReferenceSlugs(agentDir),
+    transcriptPathProvider: () => currentTranscriptPath,
   })
   const storeReferenceTool = createStoreReferenceTool(options.onReferenceStored)
   const customTools = [findEntryTool, appendTool, storeReferenceTool, advanceWatermarkTool]
@@ -340,6 +343,7 @@ export function createMemoryLoggerSubagent(
     },
     handler: async (ctx, runSession) => {
       currentOrigin = ctx.payload.origin
+      currentTranscriptPath = ctx.payload.parentTranscriptPath
       const today = formatLocalDate()
       const memoryDir = streamsDir(ctx.payload.agentDir)
       const streamFile = streamFilePath(ctx.payload.agentDir, today)

--- a/src/bundled-plugins/memory/secret-detector.ts
+++ b/src/bundled-plugins/memory/secret-detector.ts
@@ -29,6 +29,7 @@ export const SECRET_RULES: readonly SecretRule[] = [
   { name: 'google-api-key', pattern: /\bAIza[0-9A-Za-z_-]{35}\b/ },
   { name: 'stripe-secret', pattern: /\bsk_live_[0-9A-Za-z]{24,}\b/ },
   { name: 'stripe-restricted', pattern: /\brk_live_[0-9A-Za-z]{24,}\b/ },
+  { name: 'jwt', pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: 'rsa-private-key', pattern: /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY-----/ },
 ]
 
@@ -46,4 +47,10 @@ export function detectSecrets(content: string): SecretMatch[] {
     }
   }
   return matches
+}
+
+export function isSecretShapedToken(token: string): boolean {
+  if (detectSecrets(token).length > 0) return true
+  if (/^[A-Fa-f0-9]{48,}$/.test(token)) return true
+  return /^[A-Za-z0-9_+-]{48,}$/.test(token)
 }

--- a/src/bundled-plugins/memory/vector/hybrid.ts
+++ b/src/bundled-plugins/memory/vector/hybrid.ts
@@ -94,7 +94,9 @@ export async function hybridSearch(
     })
     return events.length === 0 ? [] : [{ ...day, events }]
   })
-  const eligibleShards = shards.filter((shard) => provenanceIndex.topicEligible(shard.slug, scope))
+  const eligibleShards = shards.filter(
+    (shard) => shard.frontmatter.kind !== 'environmental-incident' && provenanceIndex.topicEligible(shard.slug, scope),
+  )
   const eligibleReferences = scoped ? [] : references
 
   const { supersededFragmentIds } = buildParentLinks(shards)

--- a/src/bundled-plugins/memory/vector/passages.ts
+++ b/src/bundled-plugins/memory/vector/passages.ts
@@ -72,7 +72,11 @@ export function findMissingPassages(store: VectorStore, passages: Passage[]): Pa
 function buildPassages(shards: TopicShard[], streamDays: UndreamedStreamDay[]): Passage[] {
   const { supersededFragmentIds } = buildParentLinks(shards)
   return [
-    ...shards.map((shard): Passage => topicPassage(shard.slug, shard.frontmatter.heading, shard.body)),
+    ...shards.flatMap((shard): Passage[] =>
+      shard.frontmatter.kind === 'environmental-incident'
+        ? []
+        : [topicPassage(shard.slug, shard.frontmatter.heading, shard.body)],
+    ),
     ...streamDays.flatMap((day) =>
       day.events.flatMap((event): Passage[] => {
         if (event.type === 'watermark') return []

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -24,6 +24,7 @@ import { detectWsl, isWindows, isWindowsDriveMount, type WslInfo } from '@/share
 
 import { buildChannelChecks } from './channel-checks'
 import { agentFileOwnership, type FileOwnershipDeps } from './file-ownership'
+import { buildOperationalIncidentChecks } from './operational-incidents'
 import type { DoctorCheck } from './types'
 
 export function buildStaticChecks(opts: { dockerExec?: DockerExec } & FileOwnershipDeps = {}): DoctorCheck[] {
@@ -47,6 +48,7 @@ export function buildStaticChecks(opts: { dockerExec?: DockerExec } & FileOwners
     windowsBindMount(),
     containerState(dockerExec),
     containerHostPort(),
+    ...buildOperationalIncidentChecks(),
     ...buildChannelChecks(),
   ]
 }

--- a/src/doctor/operational-incidents.test.ts
+++ b/src/doctor/operational-incidents.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { IncidentLedger } from '@/operations'
+
+import { buildOperationalIncidentChecks } from './operational-incidents'
+
+describe('operational incident doctor check', () => {
+  test('reports a recurrent unresolved incident as an operator-facing error', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-doctor-incidents-'))
+    const ledger = new IncidentLedger(cwd)
+    const fact = { kind: 'bash-command-not-found' as const, bin: 'opensoma' }
+    await ledger.record(fact, 'session-a', new Date('2026-08-01T00:00:00.000Z'))
+    await ledger.record(fact, 'session-b', new Date('2026-08-02T00:00:00.000Z'))
+
+    const result = await buildOperationalIncidentChecks()[0]!.run({ cwd, hasAgentFolder: true })
+
+    expect(result.status).toBe('error')
+    expect(result.message).toContain('recurrent TypeClaw environment issue')
+    expect(result.details).toEqual([
+      'bash:command-not-found:opensoma count=2 first=2026-08-01T00:00:00.000Z last=2026-08-02T00:00:00.000Z',
+    ])
+  })
+
+  test.each([
+    { sessions: ['session-a'], unhealthyStatus: 'warning' },
+    { sessions: ['session-a', 'session-b'], unhealthyStatus: 'error' },
+  ])('returns to ok after a $unhealthyStatus incident is repaired', async ({ sessions, unhealthyStatus }) => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-doctor-repaired-incidents-'))
+    const ledger = new IncidentLedger(cwd)
+    const fact = { kind: 'bash-command-not-found' as const, bin: 'opensoma' }
+    let fingerprint = ''
+    for (const [index, sessionId] of sessions.entries()) {
+      fingerprint = (await ledger.record(fact, sessionId, new Date(`2026-08-0${index + 1}T00:00:00.000Z`))).fingerprint
+    }
+
+    const check = buildOperationalIncidentChecks()[0]!
+    expect((await check.run({ cwd, hasAgentFolder: true })).status).toBe(unhealthyStatus)
+    expect(await ledger.resolve(fingerprint)).toBe(true)
+    expect(await check.run({ cwd, hasAgentFolder: true })).toEqual({
+      status: 'ok',
+      message: 'no unresolved operational incidents',
+    })
+  })
+})

--- a/src/doctor/operational-incidents.ts
+++ b/src/doctor/operational-incidents.ts
@@ -1,0 +1,32 @@
+import { readIncidentLedger } from '@/operations'
+
+import type { DoctorCheck } from './types'
+
+export function buildOperationalIncidentChecks(): DoctorCheck[] {
+  return [
+    {
+      name: 'operations.incidents',
+      category: 'operations',
+      description: 'deterministic operational incidents are resolved',
+      applies: (ctx) => ctx.hasAgentFolder,
+      async run(ctx) {
+        const ledger = await readIncidentLedger(ctx.cwd)
+        const unresolved = ledger.incidents.filter((incident) => incident.status === 'unresolved')
+        if (unresolved.length === 0) return { status: 'ok', message: 'no unresolved operational incidents' }
+        const recurrent = unresolved.filter((incident) => incident.recurrent)
+        return {
+          status: recurrent.length > 0 ? 'error' : 'warning',
+          message:
+            recurrent.length > 0
+              ? `${recurrent.length} recurrent TypeClaw environment issue(s) require operator repair`
+              : `${unresolved.length} unresolved operational incident(s)`,
+          details: unresolved.map(
+            (incident) =>
+              `${incident.fingerprint} count=${incident.count} first=${incident.firstSeenAt} last=${incident.lastSeenAt}`,
+          ),
+          fix: { description: 'Repair the TypeClaw environment defect, then retry the failed operation.' },
+        }
+      },
+    },
+  ]
+}

--- a/src/operations/classify-tool-outcome.test.ts
+++ b/src/operations/classify-tool-outcome.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  classifyToolOutcome,
+  DeclaredSkillBinUnresolvedError,
+  deriveOperationalIncidentFactsForSuccess,
+  OPERATIONAL_INCIDENT_RESOLUTION_SIGNAL_BY_KIND,
+} from './classify-tool-outcome'
+
+describe('classifyToolOutcome', () => {
+  test.each([
+    '/bin/bash: opensoma: command not found\n\n\nCommand exited with code 127',
+    'bash: line 1: opensoma: command not found\n\nCommand exited with code 127',
+    'bash: line 27: opensoma: command not found\n\nCommand exited with code 127',
+  ])('classifies an exact bash command-not-found result', (message) => {
+    expect(classifyToolOutcome({ tool: 'bash', error: new Error(message) })).toEqual({
+      kind: 'bash-command-not-found',
+      bin: 'opensoma',
+    })
+  })
+
+  test('classifies a declared skill bin that failed deterministic resolution', () => {
+    expect(classifyToolOutcome({ tool: 'bash', error: new DeclaredSkillBinUnresolvedError('opensoma') })).toEqual({
+      kind: 'declared-skill-bin-unresolved',
+      bin: 'opensoma',
+    })
+  })
+
+  test('derives a successful single invocation through the classifier-owned safe-bin gate', () => {
+    const credentialShaped = 's' + 'k-' + 'X'.repeat(32)
+
+    expect(
+      deriveOperationalIncidentFactsForSuccess({
+        tool: 'bash',
+        args: { command: 'MODE=test OpenSoma --version' },
+        sandboxedRealProcSucceeded: false,
+      }),
+    ).toEqual([
+      { kind: 'bash-command-not-found', bin: 'OpenSoma' },
+      { kind: 'declared-skill-bin-unresolved', bin: 'OpenSoma' },
+    ])
+    expect(
+      deriveOperationalIncidentFactsForSuccess({
+        tool: 'bash',
+        args: { command: credentialShaped },
+        sandboxedRealProcSucceeded: false,
+      }),
+    ).toEqual([])
+    expect(
+      deriveOperationalIncidentFactsForSuccess({
+        tool: 'read',
+        args: { command: 'opensoma' },
+        sandboxedRealProcSucceeded: false,
+      }),
+    ).toEqual([])
+  })
+
+  test.each([
+    'opensoma --version || true',
+    'a && opensoma',
+    'opensoma | tee out',
+    'if ! opensoma; then echo skip; fi',
+    'opensoma; true',
+    'opensoma &',
+    'true\nopensoma',
+    '(opensoma)',
+    'echo $(opensoma)',
+    'echo `opensoma`',
+    'opensoma >out',
+    'while opensoma; do true; done',
+    'for item in opensoma; do true; done',
+    'case value in opensoma) true;; esac',
+    'function opensoma { true; }',
+  ])('derives no success evidence from ambiguous shell command %s', (command) => {
+    expect(
+      deriveOperationalIncidentFactsForSuccess({
+        tool: 'bash',
+        args: { command },
+        sandboxedRealProcSucceeded: true,
+      }),
+    ).toEqual([])
+  })
+
+  test('maps every incident fact kind to a mechanical resolution signal', () => {
+    expect(OPERATIONAL_INCIDENT_RESOLUTION_SIGNAL_BY_KIND).toEqual({
+      'bash-command-not-found': 'successful-bin',
+      'declared-skill-bin-unresolved': 'successful-bin',
+      'sandbox-proc-unavailable': 'successful-sandbox-real-proc',
+    })
+  })
+
+  test.each([
+    's' + 'k-' + 'X'.repeat(32),
+    'gh' + 'p_' + 'X'.repeat(36),
+    'xo' + 'xb-' + '1234567890-1234567890-' + 'X'.repeat(16),
+    `eyJ${'A'.repeat(20)}.eyJ${'B'.repeat(20)}.${'C'.repeat(40)}`,
+    'deadbeef'.repeat(8),
+    'Ab3_'.repeat(16),
+  ])('does not classify credential-shaped executable token %s', (bin) => {
+    const message = `/bin/bash: ${bin}: command not found\n\n\nCommand exited with code 127`
+
+    expect(classifyToolOutcome({ tool: 'bash', error: new Error(message) })).toBeNull()
+    expect(classifyToolOutcome({ tool: 'bash', error: new DeclaredSkillBinUnresolvedError(bin) })).toBeNull()
+  })
+
+  test.each([
+    { tool: 'read', message: '/bin/bash: opensoma: command not found\n\n\nCommand exited with code 127' },
+    { tool: 'bash', message: '/bin/bash: opensoma: command not found\n\n\nCommand exited with code 126' },
+    { tool: 'bash', message: 'documentation says opensoma: command not found\nCommand exited with code 127' },
+    { tool: 'bash', message: '/bin/bash: /tmp/opensoma: command not found\n\n\nCommand exited with code 127' },
+    { tool: 'bash', message: '/bin/bash: TOKEN=value: command not found\n\n\nCommand exited with code 127' },
+    { tool: 'bash', message: 'bash: line 0: opensoma: command not found\n\nCommand exited with code 127' },
+    { tool: 'bash', message: 'bash: line 0002: opensoma: command not found\n\nCommand exited with code 127' },
+    { tool: 'bash', message: 'bash: line 1234567: opensoma: command not found\n\nCommand exited with code 127' },
+  ])('does not classify near-match $tool / $message', ({ tool, message }) => {
+    expect(classifyToolOutcome({ tool, error: new Error(message) })).toBeNull()
+  })
+})

--- a/src/operations/classify-tool-outcome.ts
+++ b/src/operations/classify-tool-outcome.ts
@@ -1,0 +1,151 @@
+import { isSecretShapedToken } from '@/bundled-plugins/memory/secret-detector'
+
+export type OperationalIncidentFact =
+  | { kind: 'bash-command-not-found'; bin: string }
+  | { kind: 'declared-skill-bin-unresolved'; bin: string }
+  | { kind: 'sandbox-proc-unavailable' }
+
+export type OperationalIncidentResolutionSignal = 'successful-bin' | 'successful-sandbox-real-proc'
+
+export type OperationalIncidentSuccessInput = {
+  tool: string
+  args: Record<string, unknown>
+  sandboxedRealProcSucceeded: boolean
+}
+
+export const OPERATIONAL_INCIDENT_RESOLUTION_SIGNAL_BY_KIND = {
+  'bash-command-not-found': 'successful-bin',
+  'declared-skill-bin-unresolved': 'successful-bin',
+  'sandbox-proc-unavailable': 'successful-sandbox-real-proc',
+} as const satisfies Record<OperationalIncidentFact['kind'], OperationalIncidentResolutionSignal>
+
+export class DeclaredSkillBinUnresolvedError extends Error {
+  override readonly name = 'DeclaredSkillBinUnresolvedError'
+
+  constructor(readonly bin: string) {
+    super(`declared skill bin could not be resolved: ${bin}`)
+  }
+}
+
+const SAFE_BIN = '[A-Za-z0-9][A-Za-z0-9._+-]{0,127}'
+const COMMAND_NOT_FOUND = new RegExp(
+  `^(?:/bin/bash: |bash: line [1-9][0-9]{0,5}: )(${SAFE_BIN}): command not found\\n(?:\\n){1,2}Command exited with code 127$`,
+)
+
+export function classifyToolOutcome(input: { tool: string; error: unknown }): OperationalIncidentFact | null {
+  if (input.error instanceof DeclaredSkillBinUnresolvedError && isSafeBin(input.error.bin)) {
+    return { kind: 'declared-skill-bin-unresolved', bin: input.error.bin }
+  }
+  if (input.tool !== 'bash' || !(input.error instanceof Error)) return null
+  if (input.error.name === 'SandboxDegradedProcError') return { kind: 'sandbox-proc-unavailable' }
+
+  const match = COMMAND_NOT_FOUND.exec(input.error.message)
+  const bin = match?.[1]
+  return bin === undefined ? null : bashCommandNotFoundFact(bin)
+}
+
+export function deriveOperationalIncidentFactsForSuccess(
+  input: OperationalIncidentSuccessInput,
+): OperationalIncidentFact[] {
+  if (input.tool !== 'bash') return []
+  const command = input.args.command
+  if (typeof command !== 'string') return []
+  // False resolution hides a live defect; under-resolution only leaves a visible stale warning.
+  // Accept only syntax where aggregate exit zero proves this exact invocation succeeded.
+  const commandWord = parseSingleUnconditionalInvocation(command)
+  if (commandWord === null) return []
+
+  const facts = successfulBinFacts(commandWord)
+  if (input.sandboxedRealProcSucceeded) facts.push({ kind: 'sandbox-proc-unavailable' })
+  return facts
+}
+
+function bashCommandNotFoundFact(bin: string): OperationalIncidentFact | null {
+  return isSafeBin(bin) ? { kind: 'bash-command-not-found', bin } : null
+}
+
+function successfulBinFacts(bin: string): OperationalIncidentFact[] {
+  if (!isSafeBin(bin)) return []
+  return [
+    { kind: 'bash-command-not-found', bin },
+    { kind: 'declared-skill-bin-unresolved', bin },
+  ]
+}
+
+function isSafeBin(bin: string): boolean {
+  return new RegExp(`^${SAFE_BIN}$`).test(bin) && !isSecretShapedToken(bin)
+}
+
+const SHELL_CONSTRUCTS = new Set([
+  '!',
+  'case',
+  'coproc',
+  'do',
+  'done',
+  'elif',
+  'else',
+  'esac',
+  'fi',
+  'for',
+  'function',
+  'if',
+  'in',
+  'select',
+  'then',
+  'time',
+  'until',
+  'while',
+])
+
+function parseSingleUnconditionalInvocation(command: string): string | null {
+  const words: string[] = []
+  let word = ''
+  let quote: '"' | "'" | null = null
+  let active = false
+  const endWord = (): void => {
+    if (!active) return
+    words.push(word)
+    word = ''
+    active = false
+  }
+
+  for (let i = 0; i < command.length; i++) {
+    const character = command[i]!
+    if (quote !== null) {
+      if (character === quote) {
+        quote = null
+      } else {
+        if (quote === '"' && (character === '`' || (character === '$' && command[i + 1] === '('))) return null
+        if (character === '\\' && quote === '"' && i + 1 < command.length) word += command[++i]
+        else word += character
+      }
+      active = true
+      continue
+    }
+    if (character === '"' || character === "'") {
+      quote = character
+      active = true
+      continue
+    }
+    if (character === '\\') {
+      if (i + 1 >= command.length) return null
+      word += command[++i]
+      active = true
+      continue
+    }
+    if (';&|<>\n\r()'.includes(character) || character === '`' || (character === '$' && command[i + 1] === '('))
+      return null
+    if (character === '#' && !active) return null
+    if (character === ' ' || character === '\t') {
+      endWord()
+      continue
+    }
+    word += character
+    active = true
+  }
+  if (quote !== null) return null
+  endWord()
+  const commandWord = words.find((candidate) => !/^[A-Za-z_][A-Za-z0-9_]*=/.test(candidate))
+  if (commandWord === undefined || SHELL_CONSTRUCTS.has(commandWord)) return null
+  return commandWord
+}

--- a/src/operations/incidents.test.ts
+++ b/src/operations/incidents.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import lockfile from 'proper-lockfile'
+
+import { fingerprintIncident, IncidentLedger, incidentsPath, renderIncidentHint } from './incidents'
+
+describe('operational incident ledger', () => {
+  test('fingerprints structured facts only and normalizes bin casing', () => {
+    expect(fingerprintIncident({ kind: 'bash-command-not-found', bin: 'OpenSoma' })).toBe(
+      'bash:command-not-found:opensoma',
+    )
+    expect(fingerprintIncident({ kind: 'sandbox-proc-unavailable' })).toBe('sandbox:proc-unavailable')
+    expect(fingerprintIncident({ kind: 'declared-skill-bin-unresolved', bin: 'OpenSoma' })).toBe(
+      'skill-bin:declared-but-unresolved:opensoma',
+    )
+  })
+
+  test('marks recurrence only after the fingerprint appears in a different session', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-incidents-'))
+    const ledger = new IncidentLedger(agentDir)
+    const fact = { kind: 'bash-command-not-found' as const, bin: 'opensoma' }
+
+    const first = await ledger.record(fact, 'session-a', new Date('2026-08-01T00:00:00.000Z'))
+    const sameSessionRetry = await ledger.record(fact, 'session-a', new Date('2026-08-01T00:01:00.000Z'))
+    const secondSession = await ledger.record(fact, 'session-b', new Date('2026-08-02T00:00:00.000Z'))
+
+    expect(first).toMatchObject({ count: 1, recurrent: false, status: 'unresolved' })
+    expect(sameSessionRetry).toMatchObject({ count: 2, recurrent: false, lastSessionId: 'session-a' })
+    expect(secondSession).toMatchObject({
+      fingerprint: 'bash:command-not-found:opensoma',
+      count: 3,
+      recurrent: true,
+      firstSeenAt: '2026-08-01T00:00:00.000Z',
+      lastSeenAt: '2026-08-02T00:00:00.000Z',
+      lastSessionId: 'session-b',
+    })
+    const persisted = await readFile(incidentsPath(agentDir), 'utf8')
+    expect(persisted).not.toContain('/tmp/private')
+    expect(persisted).not.toContain('--password')
+    expect(JSON.parse(persisted)).toEqual({ version: 1, incidents: [secondSession] })
+    expect(renderIncidentHint(secondSession)).toBe(
+      'TYPECLAW_OPERATIONAL_INCIDENT {"fingerprint":"bash:command-not-found:opensoma","occurrence":3,"recurrent":true,"status":"unresolved","automaticRepair":"unavailable","provenance":"typeclaw-environment","action":"escalate-recurrent-environment-issue-to-operator","doNot":"delegate-the-original-task-to-the-user"}',
+    )
+  })
+
+  test('serializes read-modify-write updates against a lock held by another process', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-incidents-contention-'))
+    const ledger = new IncidentLedger(agentDir)
+    const fact = { kind: 'bash-command-not-found' as const, bin: 'opensoma' }
+    await ledger.record(fact, 'parent-session')
+
+    const path = incidentsPath(agentDir)
+    const startedPath = join(agentDir, 'worker-started')
+    const donePath = join(agentDir, 'worker-done')
+    const release = await lockfile.lock(path, { realpath: false })
+    const source = [
+      `import { IncidentLedger } from ${JSON.stringify(new URL('./incidents.ts', import.meta.url).href)}`,
+      `await Bun.write(process.env.STARTED_PATH, 'started')`,
+      `await new IncidentLedger(process.env.AGENT_DIR).record({ kind: 'bash-command-not-found', bin: 'opensoma' }, 'worker-session')`,
+      `await Bun.write(process.env.DONE_PATH, 'done')`,
+    ].join(';')
+    const child = Bun.spawn([process.execPath, '-e', source], {
+      env: {
+        ...process.env,
+        AGENT_DIR: agentDir,
+        STARTED_PATH: startedPath,
+        DONE_PATH: donePath,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    try {
+      expect(await waitForFile(startedPath, 2_000)).toBe(true)
+      expect(await waitForFile(donePath, 300)).toBe(false)
+    } finally {
+      await release()
+    }
+
+    const stderr = await new Response(child.stderr).text()
+    expect(await child.exited).toBe(0)
+    expect(stderr).toBe('')
+    expect(await waitForFile(donePath, 2_000)).toBe(true)
+    expect((await ledger.record(fact, 'parent-session')).count).toBe(3)
+  })
+
+  test('atomically resolves a recorded fingerprint', async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), 'typeclaw-incidents-resolve-'))
+    const ledger = new IncidentLedger(agentDir)
+    const incident = await ledger.record(
+      { kind: 'sandbox-proc-unavailable' },
+      'repair-session',
+      new Date('2026-08-03T00:00:00.000Z'),
+    )
+
+    expect(await ledger.resolve(incident.fingerprint)).toBe(true)
+    expect(JSON.parse(await readFile(incidentsPath(agentDir), 'utf8'))).toMatchObject({
+      incidents: [{ fingerprint: 'sandbox:proc-unavailable', status: 'resolved' }],
+    })
+  })
+})
+
+async function waitForFile(path: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await Bun.file(path).exists()) return true
+    await Bun.sleep(10)
+  }
+  return Bun.file(path).exists()
+}

--- a/src/operations/incidents.ts
+++ b/src/operations/incidents.ts
@@ -1,0 +1,274 @@
+import { chmod, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import lockfile from 'proper-lockfile'
+
+import { deriveOperationalIncidentFactsForSuccess } from './classify-tool-outcome'
+import type { OperationalIncidentFact, OperationalIncidentSuccessInput } from './classify-tool-outcome'
+
+export type IncidentStatus = 'unresolved' | 'resolved'
+
+export type OperationalIncident = {
+  fingerprint: string
+  kind: OperationalIncidentFact['kind']
+  bin?: string
+  count: number
+  firstSeenAt: string
+  lastSeenAt: string
+  lastSessionId: string
+  status: IncidentStatus
+  recurrent: boolean
+}
+
+export type IncidentLedgerFile = { version: 1; incidents: OperationalIncident[] }
+
+type LedgerInspection = { kind: 'missing' } | { kind: 'unknown' } | { kind: 'present'; version: string; size: number }
+
+export type IncidentLedgerIo = {
+  inspect: (path: string) => Promise<LedgerInspection>
+  read: (agentDir: string) => Promise<IncidentLedgerFile>
+  serialize: (path: string, operation: () => Promise<void>) => Promise<void>
+}
+
+type OpenIncidentSnapshot = { version?: string; fingerprints: Set<string> }
+
+const LOCK_RETRIES = { retries: 600, factor: 1, minTimeout: 10, maxTimeout: 10, randomize: false } as const
+const openIncidentSnapshots = new Map<string, OpenIncidentSnapshot>()
+
+export function incidentsPath(agentDir: string): string {
+  return join(agentDir, '.typeclaw', 'incidents.json')
+}
+
+export function fingerprintIncident(fact: OperationalIncidentFact): string {
+  if (fact.kind === 'sandbox-proc-unavailable') return 'sandbox:proc-unavailable'
+  const bin = normalizeBin(fact.bin)
+  return fact.kind === 'bash-command-not-found'
+    ? `bash:command-not-found:${bin}`
+    : `skill-bin:declared-but-unresolved:${bin}`
+}
+
+export function deriveMechanicallyVerifiedIncidentFingerprints(input: OperationalIncidentSuccessInput): Set<string> {
+  return new Set(deriveOperationalIncidentFactsForSuccess(input).map(fingerprintIncident))
+}
+
+export async function readIncidentLedger(agentDir: string): Promise<IncidentLedgerFile> {
+  try {
+    const parsed = JSON.parse(await readFile(incidentsPath(agentDir), 'utf8')) as unknown
+    return parseLedger(parsed)
+  } catch {
+    return { version: 1, incidents: [] }
+  }
+}
+
+const DEFAULT_INCIDENT_LEDGER_IO: IncidentLedgerIo = {
+  inspect: inspectLedger,
+  read: readIncidentLedger,
+  serialize,
+}
+
+export class IncidentLedger {
+  constructor(
+    private readonly agentDir: string,
+    private readonly io: IncidentLedgerIo = DEFAULT_INCIDENT_LEDGER_IO,
+  ) {}
+
+  async record(fact: OperationalIncidentFact, sessionId: string, now = new Date()): Promise<OperationalIncident> {
+    const path = incidentsPath(this.agentDir)
+    let recorded: OperationalIncident | undefined
+    await this.io.serialize(path, async () => {
+      const ledger = await this.io.read(this.agentDir)
+      const fingerprint = fingerprintIncident(fact)
+      const timestamp = now.toISOString()
+      const existing = ledger.incidents.find((incident) => incident.fingerprint === fingerprint)
+      if (existing === undefined) {
+        recorded = {
+          fingerprint,
+          kind: fact.kind,
+          ...(fact.kind === 'sandbox-proc-unavailable' ? {} : { bin: normalizeBin(fact.bin) }),
+          count: 1,
+          firstSeenAt: timestamp,
+          lastSeenAt: timestamp,
+          lastSessionId: sessionId,
+          status: 'unresolved',
+          recurrent: false,
+        }
+        ledger.incidents.push(recorded)
+      } else {
+        existing.count += 1
+        existing.lastSeenAt = timestamp
+        existing.status = 'unresolved'
+        existing.recurrent ||= existing.lastSessionId !== sessionId
+        existing.lastSessionId = sessionId
+        recorded = existing
+      }
+      ledger.incidents.sort((a, b) => a.fingerprint.localeCompare(b.fingerprint))
+      await persistLedger(path, ledger)
+      rememberOpenIncidents(path, ledger, await this.io.inspect(path))
+    })
+    if (recorded === undefined) throw new Error('incident ledger record was not created')
+    return { ...recorded }
+  }
+
+  async resolve(fingerprint: string): Promise<boolean> {
+    return (await this.resolveCandidates(new Set([fingerprint]))).found > 0
+  }
+
+  async resolveObservedSuccess(fingerprints: Iterable<string>): Promise<number> {
+    const candidates = new Set(fingerprints)
+    if (candidates.size === 0) return 0
+    const path = incidentsPath(this.agentDir)
+    const cached = openIncidentSnapshots.get(path)
+    if (cached !== undefined && intersects(cached.fingerprints, candidates)) {
+      return (await this.resolveCandidates(candidates)).resolved
+    }
+
+    const inspection = await this.io.inspect(path)
+    if (inspection.kind === 'unknown') return 0
+    if (inspection.kind === 'missing' || inspection.size === 0) {
+      openIncidentSnapshots.set(path, {
+        ...(inspection.kind === 'present' ? { version: inspection.version } : {}),
+        fingerprints: new Set(),
+      })
+      return 0
+    }
+    if (cached?.version === inspection.version) return 0
+
+    const ledger = await this.io.read(this.agentDir)
+    rememberOpenIncidents(path, ledger, inspection)
+    if (!intersects(openIncidentSnapshots.get(path)?.fingerprints ?? new Set(), candidates)) return 0
+    return (await this.resolveCandidates(candidates)).resolved
+  }
+
+  private async resolveCandidates(candidates: Set<string>): Promise<{ found: number; resolved: number }> {
+    const path = incidentsPath(this.agentDir)
+    let found = 0
+    let resolved = 0
+    await this.io.serialize(path, async () => {
+      const ledger = await this.io.read(this.agentDir)
+      for (const incident of ledger.incidents) {
+        if (!candidates.has(incident.fingerprint)) continue
+        found += 1
+        if (incident.status === 'resolved') continue
+        incident.status = 'resolved'
+        resolved += 1
+      }
+      if (resolved > 0) await persistLedger(path, ledger)
+      rememberOpenIncidents(path, ledger, await this.io.inspect(path))
+    })
+    return { found, resolved }
+  }
+}
+
+export function renderIncidentHint(incident: OperationalIncident): string {
+  return `TYPECLAW_OPERATIONAL_INCIDENT ${JSON.stringify({
+    fingerprint: incident.fingerprint,
+    occurrence: incident.count,
+    recurrent: incident.recurrent,
+    status: incident.status,
+    automaticRepair: 'unavailable',
+    provenance: 'typeclaw-environment',
+    action: incident.recurrent
+      ? 'escalate-recurrent-environment-issue-to-operator'
+      : 'report-environment-issue-to-operator',
+    doNot: 'delegate-the-original-task-to-the-user',
+  })}`
+}
+
+export function renderUntrackedIncidentHint(fact: OperationalIncidentFact): string {
+  return `TYPECLAW_OPERATIONAL_INCIDENT ${JSON.stringify({
+    fingerprint: fingerprintIncident(fact),
+    recurrenceTracking: 'unavailable',
+    status: 'unresolved',
+    automaticRepair: 'unavailable',
+    provenance: 'typeclaw-environment',
+    action: 'report-environment-issue-to-operator',
+    doNot: 'delegate-the-original-task-to-the-user',
+  })}`
+}
+
+function normalizeBin(bin: string): string {
+  return bin.toLocaleLowerCase('en-US')
+}
+
+function parseLedger(value: unknown): IncidentLedgerFile {
+  if (typeof value !== 'object' || value === null) return { version: 1, incidents: [] }
+  const incidents = (value as { incidents?: unknown }).incidents
+  if (!Array.isArray(incidents)) return { version: 1, incidents: [] }
+  return { version: 1, incidents: incidents.filter(isIncident) }
+}
+
+function isIncident(value: unknown): value is OperationalIncident {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Partial<OperationalIncident>
+  return (
+    typeof candidate.fingerprint === 'string' &&
+    typeof candidate.kind === 'string' &&
+    typeof candidate.count === 'number' &&
+    Number.isInteger(candidate.count) &&
+    candidate.count > 0 &&
+    typeof candidate.firstSeenAt === 'string' &&
+    typeof candidate.lastSeenAt === 'string' &&
+    typeof candidate.lastSessionId === 'string' &&
+    (candidate.status === 'unresolved' || candidate.status === 'resolved') &&
+    typeof candidate.recurrent === 'boolean'
+  )
+}
+
+function rememberOpenIncidents(path: string, ledger: IncidentLedgerFile, inspection: LedgerInspection): void {
+  openIncidentSnapshots.set(path, {
+    ...(inspection.kind === 'present' ? { version: inspection.version } : {}),
+    fingerprints: new Set(
+      ledger.incidents.filter((incident) => incident.status === 'unresolved').map((incident) => incident.fingerprint),
+    ),
+  })
+}
+
+function intersects(left: Set<string>, right: Set<string>): boolean {
+  for (const value of left) {
+    if (right.has(value)) return true
+  }
+  return false
+}
+
+async function inspectLedger(path: string): Promise<LedgerInspection> {
+  try {
+    const info = await stat(path)
+    if (!info.isFile()) return { kind: 'missing' }
+    return {
+      kind: 'present',
+      version: `${info.dev}:${info.ino}:${info.size}:${info.mtimeMs}`,
+      size: info.size,
+    }
+  } catch (error) {
+    const code = errorCode(error)
+    return code === 'ENOENT' || code === 'ENOTDIR' ? { kind: 'missing' } : { kind: 'unknown' }
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return undefined
+  return typeof error.code === 'string' ? error.code : undefined
+}
+
+async function persistLedger(path: string, ledger: IncidentLedgerFile): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  const temporary = `${path}.${process.pid}.${crypto.randomUUID()}.tmp`
+  await writeFile(temporary, `${JSON.stringify(ledger, null, 2)}\n`, { mode: 0o600 })
+  await rename(temporary, path)
+  await chmod(path, 0o600)
+}
+
+async function serialize(path: string, operation: () => Promise<void>): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+  const release = await lockfile.lock(path, {
+    realpath: false,
+    stale: 10_000,
+    update: 2_000,
+    retries: LOCK_RETRIES,
+  })
+  try {
+    await operation()
+  } finally {
+    await release().catch(() => undefined)
+  }
+}

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,0 +1,3 @@
+export * from './classify-tool-outcome'
+export * from './incidents'
+export * from './remediations'

--- a/src/operations/remediations.test.ts
+++ b/src/operations/remediations.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+
+import { RemediationRegistry, repairAndRetryOnce } from './remediations'
+
+describe('repairAndRetryOnce', () => {
+  test('runs an allowlisted handler and retries exactly once', async () => {
+    const registry = new RemediationRegistry()
+    let repairs = 0
+    let attempts = 0
+    const fact = { kind: 'sandbox-proc-unavailable' as const }
+    registry.register('sandbox-proc-unavailable', async () => {
+      repairs += 1
+      return { repaired: true }
+    })
+
+    const result = await repairAndRetryOnce(registry, fact, new Error('first failure'), async () => {
+      attempts += 1
+      return 'ok'
+    })
+
+    expect(result).toEqual({ outcome: 'retried', value: 'ok' })
+    expect(repairs).toBe(1)
+    expect(attempts).toBe(1)
+  })
+
+  test('unknown incidents receive no action and no retry', async () => {
+    const registry = new RemediationRegistry()
+    let attempts = 0
+    const original = new Error('failure')
+    const result = await repairAndRetryOnce(
+      registry,
+      { kind: 'bash-command-not-found', bin: 'opensoma' },
+      original,
+      async () => {
+        attempts += 1
+        throw new Error('retry should not run')
+      },
+    )
+
+    expect(result).toEqual({ outcome: 'unhandled', error: original })
+    expect(attempts).toBe(0)
+  })
+
+  test('one classifier registration handles every normalized fingerprint in that class', async () => {
+    const registry = new RemediationRegistry()
+    const repairedBins: string[] = []
+    registry.register('bash-command-not-found', async (fact) => {
+      if (fact.kind === 'bash-command-not-found') repairedBins.push(fact.bin)
+      return { repaired: true }
+    })
+
+    for (const bin of ['opensoma', 'another-cli']) {
+      const result = await repairAndRetryOnce(
+        registry,
+        { kind: 'bash-command-not-found', bin },
+        new Error('failure'),
+        async () => 'ok',
+      )
+      expect(result.outcome).toBe('retried')
+    }
+
+    expect(repairedBins).toEqual(['opensoma', 'another-cli'])
+  })
+
+  test('registration is idempotent for session setup and uses the latest handler', async () => {
+    const registry = new RemediationRegistry()
+    const handlers: string[] = []
+    registry.register('sandbox-proc-unavailable', async () => {
+      handlers.push('first')
+      return { repaired: true }
+    })
+    expect(() =>
+      registry.register('sandbox-proc-unavailable', async () => {
+        handlers.push('second')
+        return { repaired: true }
+      }),
+    ).not.toThrow()
+
+    await repairAndRetryOnce(registry, { kind: 'sandbox-proc-unavailable' }, new Error('failure'), async () => 'ok')
+
+    expect(handlers).toEqual(['second'])
+  })
+
+  test('a failed retry returns the retry failure without another attempt', async () => {
+    const registry = new RemediationRegistry()
+    registry.register('sandbox-proc-unavailable', async () => ({ repaired: true }))
+    let attempts = 0
+    const result = await repairAndRetryOnce(
+      registry,
+      { kind: 'sandbox-proc-unavailable' },
+      new Error('initial failure'),
+      async () => {
+        attempts += 1
+        throw new Error('retry failure')
+      },
+    )
+
+    expect(result).toEqual({ outcome: 'retry-failed', error: expect.objectContaining({ message: 'retry failure' }) })
+    expect(attempts).toBe(1)
+  })
+
+  test('a failed repair does not retry the operation', async () => {
+    const registry = new RemediationRegistry()
+    registry.register('sandbox-proc-unavailable', async () => ({ repaired: false }))
+    let attempts = 0
+    const original = new Error('failure')
+    const result = await repairAndRetryOnce(registry, { kind: 'sandbox-proc-unavailable' }, original, async () => {
+      attempts += 1
+      throw new Error('retry should not run')
+    })
+
+    expect(result).toEqual({ outcome: 'repair-failed', error: original })
+    expect(attempts).toBe(0)
+  })
+})

--- a/src/operations/remediations.ts
+++ b/src/operations/remediations.ts
@@ -1,0 +1,41 @@
+import type { OperationalIncidentFact } from './classify-tool-outcome'
+
+export type RemediationResult = { repaired: boolean }
+export type RemediationHandler = (fact: OperationalIncidentFact) => Promise<RemediationResult>
+
+export class RemediationRegistry {
+  private readonly handlers = new Map<OperationalIncidentFact['kind'], RemediationHandler>()
+
+  register(kind: OperationalIncidentFact['kind'], handler: RemediationHandler): void {
+    this.handlers.set(kind, handler)
+  }
+
+  get(fact: OperationalIncidentFact): RemediationHandler | undefined {
+    return this.handlers.get(fact.kind)
+  }
+}
+
+export const operationalRemediations = new RemediationRegistry()
+
+export type RepairAndRetryResult<T> =
+  | { outcome: 'retried'; value: T }
+  | { outcome: 'unhandled'; error: unknown }
+  | { outcome: 'repair-failed'; error: unknown }
+  | { outcome: 'retry-failed'; error: unknown }
+
+export async function repairAndRetryOnce<T>(
+  registry: RemediationRegistry,
+  fact: OperationalIncidentFact,
+  originalError: unknown,
+  retry: () => Promise<T>,
+): Promise<RepairAndRetryResult<T>> {
+  const handler = registry.get(fact)
+  if (handler === undefined) return { outcome: 'unhandled', error: originalError }
+  const repaired = await handler(fact).catch(() => ({ repaired: false }))
+  if (!repaired.repaired) return { outcome: 'repair-failed', error: originalError }
+  try {
+    return { outcome: 'retried', value: await retry() }
+  } catch (retryError) {
+    return { outcome: 'retry-failed', error: retryError }
+  }
+}

--- a/src/sandbox/hidden-paths.test.ts
+++ b/src/sandbox/hidden-paths.test.ts
@@ -14,6 +14,7 @@ import {
   resolveHiddenPaths,
   verifyHiddenMaskTargets,
 } from './hidden-paths'
+import { CANONICAL_AGENT_RUNTIME_PRIVATE_FILES } from './runtime-private'
 
 const AGENT = '/agent'
 const hiddenDirs = (agentDir: string) => [
@@ -35,6 +36,7 @@ const secretFiles = (agentDir: string) => [
   join(agentDir, '.env'),
   join(agentDir, 'secrets.json'),
   join(agentDir, 'auth.json'),
+  join(agentDir, '.typeclaw', 'incidents.json'),
 ]
 
 function parseRoles(raw: unknown): RolesConfig {
@@ -53,9 +55,14 @@ describe('resolveHiddenPaths — builtin tiers', () => {
   test('canonical secret masks have one non-empty source of truth', () => {
     expect(CANONICAL_AGENT_SECRET_DIRS.length).toBeGreaterThan(0)
     expect(CANONICAL_AGENT_SECRET_FILES.length).toBeGreaterThan(0)
+    expect(CANONICAL_AGENT_RUNTIME_PRIVATE_FILES).toEqual(['.typeclaw/incidents.json'])
+    expect(CANONICAL_AGENT_SECRET_FILES).not.toContain('.typeclaw/incidents.json')
     const resolved = resolveHiddenPaths(createPermissionService(), tui, AGENT)
     expect(resolved.dirs).toEqual(CANONICAL_AGENT_SECRET_DIRS.map((entry) => join(AGENT, entry)))
-    expect(resolved.files).toEqual(CANONICAL_AGENT_SECRET_FILES.map((entry) => join(AGENT, entry)))
+    expect(resolved.files).toEqual([
+      ...CANONICAL_AGENT_SECRET_FILES.map((entry) => join(AGENT, entry)),
+      ...CANONICAL_AGENT_RUNTIME_PRIVATE_FILES.map((entry) => join(AGENT, entry)),
+    ])
   })
 
   test('owner (tui) still masks canonical agent secret files', () => {

--- a/src/sandbox/hidden-paths.ts
+++ b/src/sandbox/hidden-paths.ts
@@ -7,6 +7,7 @@ import type { PermissionService } from '@/permissions/permissions'
 
 import { CANONICAL_AGENT_SECRET_DIRS, CANONICAL_AGENT_SECRET_FILES } from './canonical-secrets'
 import { SandboxMaskTargetError } from './errors'
+import { CANONICAL_AGENT_RUNTIME_PRIVATE_FILES } from './runtime-private'
 
 export type HiddenPaths = {
   dirs: string[]
@@ -38,7 +39,9 @@ export function resolveHiddenPaths(
     ...CANONICAL_AGENT_SECRET_DIRS.map((dir) => join(agentDir, dir)),
     ...(seesPrivate ? [] : PRIVATE_DIRS.map((dir) => join(agentDir, dir))),
   ]
-  const files = CANONICAL_AGENT_SECRET_FILES.map((f) => join(agentDir, f))
+  const files = [...CANONICAL_AGENT_SECRET_FILES, ...CANONICAL_AGENT_RUNTIME_PRIVATE_FILES].map((f) =>
+    join(agentDir, f),
+  )
   return { dirs, files }
 }
 

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -6,6 +6,7 @@ export {
   CANONICAL_HOME_SECRET_FILES,
   CONTAINER_RUNTIME_HOME,
 } from './canonical-secrets'
+export { CANONICAL_AGENT_RUNTIME_PRIVATE_FILES } from './runtime-private'
 export {
   buildProcBindProbeScript,
   canBindProcSafely,

--- a/src/sandbox/runtime-private.ts
+++ b/src/sandbox/runtime-private.ts
@@ -1,0 +1,4 @@
+// Runtime-owned operational state is private to TypeClaw, but is not a
+// credential. Keep this category separate from canonical-secrets so security
+// diagnostics never mislabel incident metadata as secret material.
+export const CANONICAL_AGENT_RUNTIME_PRIVATE_FILES = ['.typeclaw/incidents.json'] as const


### PR DESCRIPTION
## Problem

A user asked the agent to book a room. The agent ran `opensoma …`, got `command not found` (exit 127), gave up, and told the user to do it by hand. The user replied `bunx opensoma`. The agent succeeded immediately.

That exact exchange repeated for **months**.

Memory was not broken. It was working perfectly, and that is *why* it failed:

1. `memory-logger` is explicitly prompted to capture "reproducible workarounds" and user corrections — so the correction **was** recorded, as a prose shard (`cites: 5, days: 5`).
2. Dreaming then reinforced it every cycle, so the shard got **stronger** while the defect stayed unrepaired.
3. Retrieval runs once per turn over the user prompt. The shard is keyed to the **failure mode** ("when opensoma is missing from PATH"), so a room-booking request never retrieves it. It could only surface *after* the user typed the magic words — i.e. exactly when it was no longer needed.

The system turned a bug report into a habit. `cites` going up was the system congratulating itself for a wound it refused to close.

## Governing principle

> Memory must never be the sole remediation path for a deterministic defect that TypeClaw can reproduce or validate mechanically.

Enforced at **tool-outcome classification, before the memory loop** — not in the dreaming prompt.

## What is wired and active

- **Exact classifiers** for deterministic failures (bash exit 127, typed unresolved skill bin, permanent sandbox `/proc` failure). No fuzzy or model-driven matching; negative cases are tested.
- **An incident ledger** keyed on structured fingerprints (`bash:command-not-found:<bin>`), recording only fingerprint/kind/bin/count/timestamps/status/recurrence. It accepts a *classified fact*, not a command or tool result, so stdout, arguments, paths and env values **cannot** reach disk. Atomic write, mode `0600`.
- **A mechanical memory fence** — not prompt wording. `append` reads the real parent transcript and rejects an anchor carrying the incident marker, plus the immediately following correction turn.
- **Doctor escalation** — a defect that reproduced across sessions becomes an operator-facing error.

These run through the existing `tool.after` error funnel (`plugin-tools.ts`), so the tool stack is not re-plumbed.

## What is scaffolding, NOT yet active

`RemediationRegistry` / `operationalRemediations` / `repairAndRetryOnce` ship with tests but are **not called from production code**. With zero registered handlers every incident is `unhandled`, so wiring them now would be dead weight. Two known gaps a future handler must close:

- `register()` keys on an **exact fingerprint**, so it expresses "this bin", not "this incident class". A skill-bin handler must register per *declared* bin (correct anyway — an undeclared typo has no repair).
- `operationalRemediations` is a module-level singleton and `register()` throws on duplicate, so per-session registration needs an idempotent or per-session registry first.

So the skill-bin repair follow-up is **three steps, not one**: make registration idempotent, register per declared bin at session creation, and wire `repairAndRetryOnce` into the tool path.

Recurrence detection and operator escalation do **not** depend on any of that — they are live in this PR.

## Why the ledger, not memory statistics

Recurrence is driven by the ledger's own count and timestamps. Memory `cites`/`days`/`lastReinforced` are model-selected statistics and must not drive operational behavior.

## Deliberately not done

- **No pinning of high-`cites` shards.** High recurrence means *important*, not *relevant now*; pinning is permanent prompt tax and entrenches the defect.
- **No semantic re-retrieval on tool errors.** A deterministic tool error is already an exact trigger; embeddings add latency and uncertainty for nothing.
- **No skill-bin repair handler.** #1319 owns skill bins and PATH.
- **No shard migration or deletion.** The citation-superset invariant makes automatic destructive cleanup dangerous.
- **No config field**, no auto-install.

## Backwards compatibility

`kind` is optional and defaults to `belief` on parse, and is **only rendered when it is not `belief`** — so existing shards keep working and are not rewritten en masse on the next dreaming pass. The one existing exact-equality expectation in `load-shards.test.ts` was updated for the materialized default.

## Verification

`lint` 0 errors · `format:check` clean · `typecheck` clean · full suite **12099 pass / 31 skip / 0 fail**. All CI green including Windows.

**Merge order with #1319:** verified by local trial merge — auto-merges with **no conflicts**, and the merged tree is green (`typecheck`/`lint`/`format` clean, **12087 pass / 0 fail**). No rebase required in either order.