### PR TITLE
Honor MCP tool-declared fileOperands in mcp_call

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -7,12 +7,17 @@ import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { CallToolResultSchema, type CallToolResult, type ListToolsRequest } from '@modelcontextprotocol/sdk/types.js'
 
 import type { McpServer } from '@/config/config'
+import type { ToolFileOperands } from '@/plugin'
 import { resolveSecret } from '@/secrets/resolve'
 
 export type McpToolInfo = {
   name: string
   description: string
   inputSchema: unknown
+  // Declared by MCP servers via the tool's `_meta['x-file-operands']`; consumed
+  // by the mcp_call dispatcher so the file-operand scanner honors tool-authored
+  // nonFile operand paths instead of rejecting free-text args that look path-shaped.
+  fileOperands?: ToolFileOperands
 }
 
 // The SDK defaults each request to 60s; typeclaw boot should fail fast enough
@@ -28,12 +33,19 @@ export type McpConnection = {
   close(): Promise<void>
 }
 
+function readDeclaredFileOperands(meta: Record<string, unknown> | undefined): ToolFileOperands | undefined {
+  if (typeof meta !== 'object' || meta === null) return undefined
+  const declared = meta['x-file-operands']
+  if (typeof declared !== 'object' || declared === null) return undefined
+  return declared as ToolFileOperands
+}
+
 export type McpSdkClient = {
   listTools(
     params?: ListToolsRequest['params'],
     options?: RequestOptions,
   ): Promise<{
-    tools: { name: string; description?: string; inputSchema: unknown }[]
+    tools: { name: string; description?: string; inputSchema: unknown; _meta?: Record<string, unknown> }[]
     nextCursor?: string
   }>
   callTool(
@@ -112,6 +124,7 @@ export function createMcpConnection(
           name: tool.name,
           description: tool.description ?? '',
           inputSchema: tool.inputSchema,
+          fileOperands: readDeclaredFileOperands(tool._meta),
         })),
       )
       cursor = result.nextCursor

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -234,6 +234,28 @@ describe('createMcpDispatcherTools', () => {
     expect(received).toEqual(args)
   })
 
+  test('mcp_call honors the target tool\'s declared fileOperands.nonFile operands', async () => {
+    let received: Record<string, unknown> | undefined
+    const connection = fakeConnection('search', [
+      {
+        name: 'search_web',
+        description: 'Web search',
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+        fileOperands: { nonFile: ['query'] },
+      },
+    ])
+    connection.callTool = async (_tool, args) => {
+      received = args
+      return { content: [{ type: 'text', text: 'ok' }] }
+    }
+    const [, , callTool] = createMcpDispatcherTools(fakeManager({ search: connection }))
+    await callTool.execute(
+      { server: 'search', tool: 'search_web', args: { query: 'SPPN 3/2017' } },
+      toolContext(),
+    )
+    expect(received).toEqual({ query: 'SPPN 3/2017' })
+  })
+
   test.each(['/v1/../../tmp/result.txt', '/v1/%2e%2e/tmp/result.txt', '/v1\\..\\tmp', '/v1//repos'])(
     'mcp_call rejects traversal-shaped API route %s before invoking the server',
     async (route) => {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -94,11 +94,21 @@ function createCallTool(manager: McpManager): Tool<McpCallArgs> {
       if (connection === undefined) return textResult(unknownServerMessage(manager, resolved.server))
 
       const toolArgs = args.args ?? {}
+      // Honor the target tool's own `_meta['x-file-operands']` declaration
+      // (e.g. nonFile free-text args) instead of scanning every string as a
+      // potential local file operand.
+      let targetFileOperands: McpToolInfo['fileOperands']
+      try {
+        targetFileOperands = (await safeListTools(connection)).find((item) => item.name === resolved.tool)?.fileOperands
+      } catch {
+        targetFileOperands = undefined
+      }
       const pinned = await enforceAndPinToolFiles({
         tool: 'mcp_call',
         args: toolArgs,
         agentDir: ctx.agentDir,
         genericInputs: true,
+        fileOperands: targetFileOperands,
         logger: ctx.logger,
         signal: ctx.signal,
       })


### PR DESCRIPTION
Fixes #1322

## Problem

`mcp_call` scans every string argument as a potential local file operand. Free-text values that look path-shaped — e.g. a search query containing a slash, `"SPPN 3/2017"` — are rejected before the request reaches the MCP server:

```
ambiguous local file operand at key "query"; the tool author must declare fileOperands.input or the caller must use a file: URI
```

The error message tells MCP tool authors to declare `fileOperands`, and the docs in `src/skills/typeclaw-plugins/SKILL.md` state "Plugin/MCP tools declare their own via `fileOperands.nonFile`" — but the `mcp_call` dispatcher never reads the target tool's declaration, so MCP tool authors have no way to exempt free-text parameters (search queries, document numbers, regexes, paths-as-data).

## Fix

Two changes:

1. **`src/mcp/client.ts`** — `McpToolInfo` now carries `fileOperands`, read from the tool's `_meta['x-file-operands']`. `_meta` is an arbitrary record in the MCP spec and survives the server → wire → client round-trip through the official SDK (verified against `@modelcontextprotocol/sdk@1.29`).
2. **`src/mcp/tools.ts`** — `mcp_call` resolves the target tool from the connection's (cached) tool list and passes its `fileOperands` into `enforceAndPinToolFiles`, so declared `nonFile` operand paths are skipped by the scanner.

The fail-closed boundary is unchanged: tools that declare nothing are scanned exactly as before — undeclared path-shaped args are still rejected, and explicit `file:` URIs still get pinned/snapshotted.

## Test

Added `mcp_call honors the target tool's declared fileOperands.nonFile operands`: a tool declaring `fileOperands: { nonFile: ['query'] }` receives `"SPPN 3/2017"` unchanged; the existing reject tests for undeclared path-like operands still pass.

## Verification

- `bun test src/mcp/tools.test.ts src/mcp/client.test.ts` — 39 pass, 0 fail
- Reproduced the original error with the scanner directly; confirmed the declared path passes and undeclared paths still throw
