### PR TITLE
Stop two runtime guards from silencing the work they were meant to protect

### DIFF
--- a/src/agent/loop-guard.test.ts
+++ b/src/agent/loop-guard.test.ts
@@ -205,6 +205,61 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
     if (last.kind === 'block') expect(last.reason).toBe('windowed')
   })
 
+  test('allows parallel grep fan-out with distinct patterns against one path', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const patterns = [
+      "const source =|source: 'tool'|source === 'tool'",
+      'async function send|const send = async|source =',
+      'live.promisedWorkOutstandingThisLogicalTurn = keepTurnAlive',
+      'sentReplyThisTurn && !live.promisedWorkOutstandingThisLogicalTurn',
+      'live.toolExecutionThisLogicalTurn && !live.promisedWorkOutstandingThisLogicalTurn',
+      "source === 'tool' && text !== undefined && !detectContinuationWillingness(text)",
+    ]
+
+    const decisions = patterns.map((pattern) =>
+      guard.check('s1', 'grep', { path: '/agent/router.ts', pattern }, { turnId: 1 }),
+    )
+
+    expect(decisions.every((decision) => decision.kind === 'ok')).toBe(true)
+    expect(decisions.every((decision) => decision.receipt.recorded)).toBe(true)
+  })
+
+  test('records one same-target grep observation per model turn', () => {
+    const guard = createLoopGuard()
+    const args = { path: '/agent/router.ts', pattern: 'source === "tool"' }
+
+    const decisions = Array.from({ length: 6 }, () => guard.check('s1', 'grep', args, { turnId: 1 }))
+
+    expect(decisions.every((decision) => decision.kind === 'ok')).toBe(true)
+    expect(decisions.map((decision) => decision.receipt.recorded)).toEqual([true, false, false, false, false, false])
+  })
+
+  test('still blocks the same grep target repeated across model turns', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const decisions = Array.from({ length: 6 }, (_, index) =>
+      guard.check(
+        's1',
+        'grep',
+        { path: '/agent/router.ts', pattern: 'source === "tool"', limit: index + 1 },
+        { turnId: index + 1 },
+      ),
+    )
+
+    expect(decisions[3]?.kind).toBe('warn')
+    expect(decisions[5]?.kind).toBe('block')
+    if (decisions[5]?.kind === 'block') expect(decisions[5].reason).toBe('windowed')
+  })
+
   test('records one same-path read observation per model turn', () => {
     const guard = createLoopGuard({
       ...noConsecutive,
@@ -484,27 +539,18 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
     expect(() => createLoopGuard({ windowSize: 4, windowHardBlock: 5 })).toThrow()
   })
 
-  // grep/find/ls have an OPTIONAL path that defaults to cwd. Omitting it and
-  // varying only non-target args (pattern/limit) still hits the same directory,
-  // so those calls must coarsen to a single default-target signature.
-  for (const tool of ['grep', 'find', 'ls'] as const) {
-    test(`coarsens omitted-path ${tool} calls to the default target so non-target args cannot evade the guard`, () => {
+  // Search limits only change result presentation. They must not let a repeated
+  // query evade the detector when its optional path still resolves to cwd.
+  for (const tool of ['grep', 'find'] as const) {
+    test(`coarsens omitted-path ${tool} calls with the same query so limits cannot evade the guard`, () => {
       const guard = createLoopGuard({
         ...noConsecutive,
         windowSize: 16,
         windowSoftWarn: 4,
         windowHardBlock: 6,
       })
-      const varyingArgs = [
-        { pattern: 'a*' },
-        { pattern: 'b*', limit: 10 },
-        { pattern: 'c*' },
-        { pattern: 'd*', limit: 50 },
-        { pattern: 'e*' },
-        { pattern: 'f*', limit: 5 },
-      ]
       let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
-      for (const args of varyingArgs) last = guard.check('s1', tool, args)
+      for (let limit = 1; limit <= 6; limit++) last = guard.check('s1', tool, { pattern: 'source*', limit })
       expect(last.kind).toBe('block')
       if (last.kind === 'block') expect(last.reason).toBe('windowed')
     })
@@ -517,7 +563,10 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
         windowHardBlock: 6,
       })
       let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
-      for (let i = 0; i < 6; i++) last = guard.check('s1', tool, { path: '', pattern: `p${i}*` })
+      for (let i = 0; i < 6; i++) {
+        const path = i % 2 === 0 ? {} : { path: '' }
+        last = guard.check('s1', tool, { ...path, pattern: 'source*', limit: i + 1 })
+      }
       expect(last.kind).toBe('block')
     })
 
@@ -534,6 +583,45 @@ describe('createLoopGuard — windowed multi-signature detection', () => {
       }
     })
   }
+
+  test('coarsens omitted-path ls calls to the default target so limits cannot evade the guard', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
+    for (let limit = 1; limit <= 6; limit++) last = guard.check('s1', 'ls', { limit })
+    expect(last.kind).toBe('block')
+    if (last.kind === 'block') expect(last.reason).toBe('windowed')
+  })
+
+  test('treats an empty-string path for ls the same as an omitted path', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    let last: ReturnType<typeof guard.check> | { kind: 'ok' } = { kind: 'ok' }
+    for (let i = 0; i < 6; i++) {
+      const path = i % 2 === 0 ? {} : { path: '' }
+      last = guard.check('s1', 'ls', { ...path, limit: i + 1 })
+    }
+    expect(last.kind).toBe('block')
+  })
+
+  test('does not flag ls calls against genuinely distinct explicit targets', () => {
+    const guard = createLoopGuard({
+      ...noConsecutive,
+      windowSize: 16,
+      windowSoftWarn: 4,
+      windowHardBlock: 6,
+    })
+    const dirs = ['src', 'test', 'docs', 'scripts', 'lib', 'bin']
+    for (const path of dirs) expect(guard.check('s1', 'ls', { path }).kind).toBe('ok')
+  })
 
   // read/write/edit require an explicit path, so absence is malformed input, not
   // a cwd default — they must NOT be coarsened to a shared default target.

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -11,9 +11,10 @@ import { posix } from 'node:path'
 //    consecutive detector cannot see, e.g. read(a)→edit(b)→read(a)→edit(b)…, or
 //    re-reading one file with drifting offsets. Over a sliding window of the
 //    last WINDOW_SIZE calls, if one signature recurs WINDOW_SOFT_WARN times it
-//    warns and WINDOW_HARD_BLOCK times it blocks. Path-bearing tools coarsen
-//    their signature to the path alone. Read calls additionally recognize one
-//    assistant tool batch and successfully-observed forward pagination so
+//    warns and WINDOW_HARD_BLOCK times it blocks. Path-only tools coarsen their
+//    signature to the path, while search tools retain the query as part of the
+//    target. Read and search calls additionally recognize one assistant tool
+//    batch, and reads recognize successfully-observed forward pagination, so
 //    productive inspection does not look like a reactive cycle.
 //
 // Both warn/block decisions carry the byte-identical or coarsened nudge text.
@@ -33,23 +34,25 @@ export const WINDOW_SIZE = 16
 export const WINDOW_SOFT_WARN = 4
 export const WINDOW_HARD_BLOCK = 6
 
-// Tools whose first path-like argument identifies the target. Their windowed
-// signature keys on that path alone so paging one file with drifting
-// offset/limit collapses to a single signature. Two classes, because the
-// builtins differ in whether the path is required:
+// Path-bearing tools need coarser window signatures so presentation-only args
+// cannot disguise repeated work. The target differs by tool class:
 //
 //   - REQUIRED-path tools (read/write/edit): path is mandatory. Coarsen only
 //     when a path key is present; an absent path is malformed input, not a
 //     default, so we must NOT collapse such calls to a shared target.
-//   - DEFAULT-path tools (grep/find/ls): path is OPTIONAL and defaults to the
-//     cwd ("."). Omitting the path and varying only non-target args (pattern,
-//     limit) still hits the same directory, so an omitted/empty path coarsens
-//     to `${tool}#path:.` — otherwise those calls would evade the detector.
+//   - DEFAULT-path tools (ls): path is OPTIONAL and defaults to the cwd (".").
+//     Omitting the path and varying only non-target args still hits the same
+//     directory, so an omitted/empty path coarsens to `${tool}#path:.` —
+//     otherwise those calls would evade the detector.
+//   - SEARCH-path tools (grep/find): path is also optional, but the pattern and
+//     matching controls are part of the research target. Different queries on
+//     one large file are legitimate fan-out, not repeated work.
 //
 // `glob` is intentionally absent: pi-coding-agent has no `glob` builtin (the
 // glob-pattern arg lives inside grep/find), so listing it here matched nothing.
 const REQUIRED_PATH_TOOLS = new Set(['read', 'write', 'edit'])
-const DEFAULT_PATH_TOOLS = new Set(['grep', 'find', 'ls'])
+const DEFAULT_PATH_TOOLS = new Set(['ls'])
+const SEARCH_PATH_TOOLS = new Set(['grep', 'find'])
 const PATH_ARG_KEYS = ['path', 'file', 'filePath', 'filename']
 const DEFAULT_PATH_TARGET = '.'
 
@@ -116,7 +119,7 @@ export type LoopGuard = {
   // Undoes the one observation a prior `check` recorded, identified by its
   // receipt. Pops that signature from the windowed history and, when the
   // current consecutive streak is the call this receipt named, rewinds the
-  // streak by one. Suppressed same-batch read receipts are explicit no-ops so
+  // streak by one. Suppressed same-batch target receipts are explicit no-ops so
   // parallel sibling completion cannot retract the recorded observation. Used
   // post-execution for a
   // `subagent_output` poll that returned `status: 'running'` — a still-pending
@@ -147,11 +150,11 @@ type SessionState = {
   // A block on such a signature is enforced pre-execute (not deferred), so a
   // completed task is not re-polled forever just to re-learn it is done.
   termKnown: Set<string>
-  // A model turn may emit several tool calls in one assistant message. Those
-  // calls cannot react to one another's results, so same-path reads in that
-  // batch count as one loop observation rather than a reactive cycle.
-  readTurnId: number | undefined
-  readPathsThisTurn: Set<string>
+  // Parallel research siblings cannot react to one another's results. Counting
+  // a duplicated target within that batch toward a session-aborting threshold
+  // gives the model no chance to heed the warning and choose another approach.
+  targetTurnId: number | undefined
+  targetsThisTurn: Set<string>
   // Observed contiguous line progress per recently-read canonical path.
   // Suppressed siblings may wait here for earlier siblings to complete, but
   // only exact adjacency advances the frontier.
@@ -263,20 +266,22 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
         window: [],
         windowWarned: new Set(),
         termKnown: new Set(),
-        readTurnId: undefined,
-        readPathsThisTurn: new Set(),
+        targetTurnId: undefined,
+        targetsThisTurn: new Set(),
         readFrontiers: new Map(),
       }
 
       const readTarget = parseReadTarget(tool, args, context?.cwd)
       const readPage = parseReadPage(tool, args, context?.cwd)
-      if (readTarget !== undefined && context?.turnId !== undefined) {
-        if (readPathSeenThisTurn(state, readTarget.path, context.turnId, windowSize)) {
+      const turnTarget =
+        readTarget !== undefined ? readPathSignature(readTarget.path) : makeSearchTargetSignature(tool, args)
+      if (turnTarget !== undefined && context?.turnId !== undefined) {
+        if (targetSeenThisTurn(state, turnTarget, context.turnId, windowSize)) {
           const receipt: LoopGuardReceipt = {
             sessionId,
             tool,
             signature,
-            windowSignature: readPathSignature(readTarget.path),
+            windowSignature: turnTarget,
             recorded: false,
             ...(readPage !== undefined ? { readPage } : {}),
           }
@@ -348,11 +353,11 @@ export function createLoopGuard(options: CreateLoopGuardOptions = {}): LoopGuard
       for (const sig of state.termKnown) {
         if (signatureBelongsToTool(sig, tool)) state.termKnown.delete(sig)
       }
-      if (tool === 'read') {
-        state.readTurnId = undefined
-        state.readPathsThisTurn.clear()
-        state.readFrontiers.clear()
+      for (const target of state.targetsThisTurn) {
+        if (signatureBelongsToTool(target, tool)) state.targetsThisTurn.delete(target)
       }
+      if (state.targetsThisTurn.size === 0) state.targetTurnId = undefined
+      if (tool === 'read') state.readFrontiers.clear()
     },
     retract(receipt) {
       if (!receipt.recorded) return
@@ -449,10 +454,10 @@ function makeCallSignature(tool: string, args: unknown): string {
   }
 }
 
-// Coarsened signature for windowed detection: path-bearing tools key on their
-// target path alone so re-reading one target with drifting non-path args
-// collapses to a single signature. All other tools fall back to the exact
-// signature.
+// Coarsened signature for windowed detection: path-only tools key on their
+// target path, while searches keep semantic query arguments so parallel
+// investigation of one large file does not look like repeated work. All other
+// tools fall back to the exact signature.
 function makeWindowSignature(tool: string, args: unknown, state: SessionState, cwd: string | undefined): string {
   const readPage = parseReadPage(tool, args, cwd)
   if (readPage !== undefined) {
@@ -462,6 +467,10 @@ function makeWindowSignature(tool: string, args: unknown, state: SessionState, c
       ? `${coarse}#frontier:${readPage.offset}`
       : coarse
   }
+
+  const searchTarget = makeSearchTargetSignature(tool, args)
+  if (searchTarget !== undefined) return searchTarget
+  if (SEARCH_PATH_TOOLS.has(tool)) return makeCallSignature(tool, args)
 
   const isRequiredPath = REQUIRED_PATH_TOOLS.has(tool)
   const isDefaultPath = DEFAULT_PATH_TOOLS.has(tool)
@@ -512,18 +521,39 @@ function readPathSignature(path: string): string {
   return `read#path:${path}`
 }
 
-function readPathSeenThisTurn(state: SessionState, path: string, turnId: number, maxReadPaths: number): boolean {
-  if (state.readTurnId !== turnId) {
-    state.readTurnId = turnId
-    state.readPathsThisTurn.clear()
+function makeSearchTargetSignature(tool: string, args: unknown): string | undefined {
+  if (!SEARCH_PATH_TOOLS.has(tool) || args === null || typeof args !== 'object') return undefined
+  const record = args as Record<string, unknown>
+  const { pattern } = record
+  if (typeof pattern !== 'string') return undefined
+
+  const path = PATH_ARG_KEYS.map((key) => record[key]).find(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  )
+  const query =
+    tool === 'grep'
+      ? {
+          pattern,
+          ...(typeof record.glob === 'string' && record.glob.length > 0 ? { glob: record.glob } : {}),
+          ...(record.ignoreCase === true ? { ignoreCase: true } : {}),
+          ...(record.literal === true ? { literal: true } : {}),
+        }
+      : { pattern }
+  return `${tool}#search:${stableStringify({ path: path ?? DEFAULT_PATH_TARGET, query })}`
+}
+
+function targetSeenThisTurn(state: SessionState, target: string, turnId: number, maxTargets: number): boolean {
+  if (state.targetTurnId !== turnId) {
+    state.targetTurnId = turnId
+    state.targetsThisTurn.clear()
   }
-  const seen = state.readPathsThisTurn.has(path)
-  if (seen) state.readPathsThisTurn.delete(path)
-  state.readPathsThisTurn.add(path)
-  while (state.readPathsThisTurn.size > maxReadPaths) {
-    const oldest = state.readPathsThisTurn.values().next().value
+  const seen = state.targetsThisTurn.has(target)
+  if (seen) state.targetsThisTurn.delete(target)
+  state.targetsThisTurn.add(target)
+  while (state.targetsThisTurn.size > maxTargets) {
+    const oldest = state.targetsThisTurn.values().next().value
     if (oldest === undefined) break
-    state.readPathsThisTurn.delete(oldest)
+    state.targetsThisTurn.delete(oldest)
   }
   return seen
 }

--- a/src/channels/github-rereview-guard.test.ts
+++ b/src/channels/github-rereview-guard.test.ts
@@ -60,6 +60,32 @@ describe('re-review stranding guard', () => {
     expect(decision.block).toBe(true)
   })
 
+  it('allows a mixed verdict that keeps the thread open while the bot still blocks the PR', async () => {
+    const decision = await evaluateRereviewGuard(
+      input({
+        wantsResolve: false,
+        text:
+          'Verified: the original status-send latch issue is fixed at `2290b80`. ' +
+          'I can’t resolve this thread yet because the PR still has a blocking issue in the recovered-final-prose path.',
+        getReviewState: stateOk(true),
+      }),
+    )
+
+    expect(decision).toEqual({ block: false })
+  })
+
+  it('still blocks a genuine close-out while the bot holds a live CHANGES_REQUESTED', async () => {
+    const decision = await evaluateRereviewGuard(
+      input({
+        wantsResolve: false,
+        text: 'Verified, all fixed. Resolving this thread.',
+        getReviewState: stateOk(true),
+      }),
+    )
+
+    expect(decision.block).toBe(true)
+  })
+
   it('does not fire on ordinary discussion replies', async () => {
     let queried = false
     const decision = await evaluateRereviewGuard(

--- a/src/channels/github-review-claim.test.ts
+++ b/src/channels/github-review-claim.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, test } from 'bun:test'
 
 import { classifyReviewClaim, isPositiveWarnCloseout, type ReviewClaim } from './github-review-claim'
 
+const PRODUCTION_FIXED_SEGMENT = 'Verified: the original status-send latch issue is fixed at `2290b80`.'
+const PRODUCTION_HOLD_OPEN_SEGMENT =
+  'I can’t resolve this thread yet because the PR still has a blocking issue in the recovered-final-prose path.'
+const PRODUCTION_KEEP_OPEN_SEGMENT =
+  'Keeping this thread open while the remaining recovery-path blocker is addressed, so the PR can receive one clean re-review verdict afterward.'
+
 const cases: ReadonlyArray<[string, ReviewClaim]> = [
   ['Approved!', 'block-approve'],
   ['**Approved** — nice work', 'block-approve'],
@@ -22,6 +28,7 @@ const cases: ReadonlyArray<[string, ReviewClaim]> = [
   ['That resolves it — closing this out.', 'block-resolve'],
   ['Verified — that closes it, thanks!', 'block-resolve'],
   ['Confirmed fixed.', 'block-resolve'],
+  [PRODUCTION_FIXED_SEGMENT, 'block-resolve'],
 
   // warn: soft signals, allowed through with a nudge
   ['LGTM', 'warn'],
@@ -46,6 +53,7 @@ const cases: ReadonlyArray<[string, ReviewClaim]> = [
   ['Who approved this?', 'ignore'],
   ['The pre-approved template text is unrelated.', 'ignore'],
   ['I confirmed the issue is not resolved yet.', 'ignore'],
+  [PRODUCTION_HOLD_OPEN_SEGMENT, 'ignore'],
   ['Can you clarify the second point?', 'ignore'],
   ['', 'ignore'],
 
@@ -59,6 +67,7 @@ const cases: ReadonlyArray<[string, ReviewClaim]> = [
   // A bare `to address` clause must NOT demote a hard claim in the same sentence (PR #675).
   ['Approved — thanks for updating the docs to address my feedback.', 'block-approve'],
   ['Requesting changes; please update the tests to address the leak.', 'block-request-changes'],
+  [PRODUCTION_KEEP_OPEN_SEGMENT, 'warn'],
 ]
 
 describe('classifyReviewClaim', () => {
@@ -82,6 +91,42 @@ describe('classifyReviewClaim', () => {
   test('separate non-negated sentence can still carry the receipt', () => {
     expect(classifyReviewClaim("I didn't approve the previous revision. This one is approved.")).toBe('block-approve')
     expect(classifyReviewClaim("I haven't approved yet. LGTM on the current diff.")).toBe('warn')
+  })
+
+  test('lets a later refusal to close the thread veto an earlier resolved finding', () => {
+    const text = `${PRODUCTION_FIXED_SEGMENT} ${PRODUCTION_HOLD_OPEN_SEGMENT}`
+
+    expect(classifyReviewClaim(text)).not.toBe('block-resolve')
+    expect(isPositiveWarnCloseout(text)).toBe(false)
+  })
+
+  test.each([
+    ['Verified: the original issue is fixed. One issue remains.'],
+    ['Verified: the original issue is fixed. 하지만 차단 문제가 남아 있어 이 스레드는 열어 둡니다.'],
+  ])('applies the hold-open veto across the whole multilingual reply: %p', (text) => {
+    expect(classifyReviewClaim(text)).not.toBe('block-resolve')
+    expect(isPositiveWarnCloseout(text)).toBe(false)
+  })
+
+  test('does not let a hold-open marker veto a formal approval receipt', () => {
+    expect(classifyReviewClaim('Approved. One minor issue remains.')).toBe('block-approve')
+    expect(classifyReviewClaim('Requesting changes. One issue remains.')).toBe('block-request-changes')
+  })
+
+  test.each([
+    ['The issue remained, but it is now fixed. Resolving this thread.'],
+    ['One concern remained and has been addressed. Closing this out.'],
+    ["Confirmed fixed. The issue that remained is now fixed, so I'm closing this out."],
+    ['問題が残っていたが、今は修正済みです。 Confirmed fixed. Closing this out.'],
+  ])('keeps completed remnant history in the close-out tier: %p', (text) => {
+    expect(classifyReviewClaim(text)).toBe('block-resolve')
+  })
+
+  test('still vetoes a close-out when present work remains and the thread stays open', () => {
+    const text = 'Confirmed fixed. One issue remains. Keeping this thread open.'
+
+    expect(classifyReviewClaim(text)).not.toBe('block-resolve')
+    expect(isPositiveWarnCloseout(text)).toBe(false)
   })
 })
 
@@ -164,4 +209,8 @@ describe('isPositiveWarnCloseout', () => {
       expect(isPositiveWarnCloseout(text)).toBe(false)
     },
   )
+
+  test('treats keeping the thread open as negative despite neighbouring positive-closeout words', () => {
+    expect(isPositiveWarnCloseout(PRODUCTION_KEEP_OPEN_SEGMENT)).toBe(false)
+  })
 })

--- a/src/channels/github-review-claim.ts
+++ b/src/channels/github-review-claim.ts
@@ -94,6 +94,7 @@ const BLOCK_RESOLVE: readonly RegExp[] = [
   /\bthis resolves it\b/,
   /\b(that|this) closes it\b/,
   /\bclosing this out\b/,
+  /\bresolving (?:this|the) thread\b/,
   /\bconfirmed fixed\b/,
   // verify clause + a fix/resolve verb, allowing a short gap ("verified at <sha>, that fixes it").
   /\b(verified|confirmed)\b[^.!?]*\b(fix(es|ed)|resolv)/,
@@ -134,9 +135,84 @@ const WARN_POSITIVE_CLOSEOUT: readonly RegExp[] = [
   /\btampaknya (?:baik|oke)\b/, // id seems good
 ]
 
+// A hold-open statement reverses neighbouring resolve-shaped prose. Blocking the
+// whole reply in that case strands neither review state nor thread; it silences
+// the new blocker the reply is trying to preserve (PR #1320). Keep these precise
+// enough to assert unfinished work, not merely mention a blocker that was fixed.
+const HOLD_OPEN: readonly RegExp[] = [
+  /\bkeep(?:ing)? (?:this |the )?(?:review )?thread open\b/,
+  /\bkeep(?:ing)? (?:this|it) open\b/,
+  /\bleav(?:e|ing) (?:(?:this|it) open|(?:this |the )?(?:review )?thread open)\b/,
+  /\bstill (?:blocks?|blocking)\b/,
+  /\bremaining\b[^.!?]{0,80}\bblockers?\b(?![^.!?]*\b(?:(?:is|are|was|were) (?:now )?|(?:has|have) (?:now )?been )(?:fixed|resolved|addressed)\b)/,
+  /\bblockers? remain(?:s|ing)?\b(?![^.!?]*\b(?:(?:is|are|was|were) (?:now )?|(?:has|have) (?:now )?been )(?:fixed|resolved|addressed)\b)/,
+  /\bstill (?:has|have) (?:an? )?blocking (?:issue|problem|concern)\b/,
+  /\bnot resolv(?:e|ed|ing)\b/,
+  /\b(?:can(?:not|'?t|\s+t)|unable to) resolve\b[^.!?]*\byet\b/,
+  /\b(?:(?:one|an?|the) )?(?:issue|problem|concern)s? remain(?:s|ing)?\b(?![^.!?]*\b(?:(?:is|are|was|were) (?:now )?|(?:has|have) (?:now )?been )(?:fixed|resolved|addressed)\b)/,
+  /\b(?:work|changes?|fix(?:es)?) remain(?:s|ing)?\b(?![^.!?]*\b(?:(?:is|are|was|were) (?:now )?|(?:has|have) (?:now )?been )(?:fixed|resolved|addressed)\b)/,
+  // es
+  /\b(?:dejo|dejando|mantengo|manteniendo) (?:este |el )?hilo abierto\b/,
+  /\b(?:todav[íi]a|a[úu]n) (?:bloquea|hay (?:un )?(?:problema|bloqueo))\b/,
+  /\b(?:queda|permanece) (?:un )?(?:bloqueo|problema)\b/,
+  // fr
+  /\b(?:je laisse|laissant|je garde) (?:ce |le )?fil ouvert\b/,
+  /\bbloque encore\b/,
+  /\bil reste (?:un )?(?:blocage|probl[èe]me)\b/,
+  // it
+  /\b(?:lascio|lasciando|mantengo) (?:questo |il )?(?:thread|filo) apert[oa]\b/,
+  /\bblocca ancora\b/,
+  /\brimane (?:un )?(?:blocco|problema)\b/,
+  // pt
+  /\b(?:deixo|deixando|mantenho|mantendo) (?:este |o )?(?:t[óo]pico|fio) aberto\b/,
+  /\bainda (?:bloqueia|h[áa] (?:um )?(?:bloqueio|problema))\b/,
+  /\b(?:resta|permanece) (?:um )?(?:bloqueio|problema)\b/,
+  // de
+  /\b(?:diesen |den )?thread offen (?:lassen|halten)\b/,
+  /\b(?:blockiert|sperrt) (?:noch|weiterhin|immer noch)\b/,
+  /\b(?:ein )?(?:blocker|problem) bleibt\b/,
+  // ru: оставляю ветку открытой / пока не могу решить / блокер или проблема остаётся
+  /\u043E\u0441\u0442\u0430\u0432\u043B\u044F\u044E[^.!?]*(?:\u0432\u0435\u0442\u043A\u0443|\u0442\u0435\u043C\u0443)[^.!?]*\u043E\u0442\u043A\u0440\u044B\u0442/,
+  /\u043F\u043E\u043A\u0430 \u043D\u0435 \u043C\u043E\u0433\u0443[^.!?]*(?:\u0440\u0435\u0448\u0438\u0442\u044C|\u0437\u0430\u043A\u0440\u044B\u0442\u044C)/,
+  /(?:\u0431\u043B\u043E\u043A\u0435\u0440|\u043F\u0440\u043E\u0431\u043B\u0435\u043C\u0430)[^.!?]*(?:\u043E\u0441\u0442\u0430\u0451\u0442\u0441\u044F|\u043E\u0441\u0442\u0430\u0435\u0442\u0441\u044F)/,
+  // ko: 스레드를 열어 둠 / 차단 문제가 남음 / 아직 해결할 수 없음
+  /\uC2A4\uB808\uB4DC(?:\uB97C|\uB294)?[^.!?]*(?:\uC5F4\uC5B4 \uB450|\uC5F4\uB9B0 \uCC44)/,
+  /(?:\uCC28\uB2E8 (?:\uBB38\uC81C|\uC774\uC288)|\uBE14\uB85C\uCEE4)[^.!?]*\uB0A8\uC544 \uC788(?:\uC5B4|\uC2B5\uB2C8\uB2E4|\uB2E4|\uB294|\uACE0|\uC9C0\uB9CC|\uC74C)/,
+  /\uC544\uC9C1[^.!?]*\uD574\uACB0\uD560 \uC218 \uC5C6/,
+  // zh: 保持线程开启 / 还不能解决 / 问题仍然存在
+  /\u4FDD\u6301[^.!?]*\u7EBF\u7A0B[^.!?]*\u5F00\u542F/,
+  /\u8FD8\u4E0D\u80FD[^.!?]*\u89E3\u51B3/,
+  /(?:\u95EE\u9898|\u963B\u585E)[^.!?]*\u4ECD\u7136[^.!?]*\u5B58\u5728/,
+  /\u4ECD\u6709[^.!?]*(?:\u95EE\u9898|\u963B\u585E)/,
+  // ja: スレッドを開いたまま / まだ解決できない / 問題が残っている
+  /\u30B9\u30EC\u30C3\u30C9[^.!?]*\u958B\u3044\u305F\u307E\u307E/,
+  /\u307E\u3060[^.!?]*\u89E3\u6C7A\u3067\u304D(?:\u306A\u3044|\u307E\u305B\u3093)/,
+  /(?:\u554F\u984C|\u30D6\u30ED\u30C3\u30AB\u30FC)[^.!?]*\u6B8B\u3063\u3066\u3044(?:\u308B|\u307E\u3059)/,
+  // ar: إبقاء النقاش مفتوحاً / لا يمكنني الحل بعد / لا تزال مشكلة
+  /\u0625\u0628\u0642\u0627\u0621[^.!?]*\u0645\u0641\u062A\u0648\u062D/,
+  /\u0644\u0627 \u064A\u0645\u0643\u0646\u0646\u064A[^.!?]*\u062D\u0644[^.!?]*\u0628\u0639\u062F/,
+  /\u0644\u0627 \u062A\u0632\u0627\u0644[^.!?]*\u0645\u0634\u0643\u0644\u0629/,
+  // hi: समस्या/अवरोधक अभी बाकी है / अभी हल नहीं हुआ
+  /(?:\u0938\u092E\u0938\u094D\u092F\u093E|\u0905\u0935\u0930\u094B\u0927\u0915)[^.!?]*\u092C\u093E\u0915\u0940 \u0939\u0948\u0902?/,
+  /\u0905\u092D\u0940[^.!?]*\u0939\u0932[^.!?]*\u0928\u0939\u0940\u0902/,
+  // tr
+  /\b(?:bu )?(?:konuyu|ba\u015Fl\u0131\u011F\u0131) a[çc]\u0131k (?:tutuyorum|b\u0131rak\u0131yorum)\b/,
+  /\bh[âa]l[âa] (?:engelliyor|bir (?:engel|sorun) var)\b/,
+  /\b(?:engel|sorun) devam ediyor\b/,
+  // vi — no \b after accented characters: JS boundaries are ASCII-only.
+  /gi\u1EEF lu\u1ED3ng n\u00E0y m\u1EDF/,
+  /v\u1EABn ch\u1EB7n/,
+  /v\u1EABn c\u00F2n[^.!?]*(?:v\u1EA5n \u0111\u1EC1|tr\u1EDF ng\u1EA1i)/,
+  // id
+  /\b(?:membiarkan|menjaga) utas ini tetap terbuka\b/,
+  /\bmasih memblokir\b/,
+  /\bmasalah masih ada\b/,
+  /\bpemblokir tersisa\b(?![^.!?]*\b(?:sudah|telah) (?:diperbaiki|diselesaikan|ditangani)\b)/,
+]
+
 // Negative warn phrases re-assert a block ("not done yet") instead of closing it
 // out, so they are NOT close-out attempts — the re-review guard must ignore them.
-const WARN_NEGATIVE: readonly RegExp[] = [/\bneeds changes\b/, /\bstill needs work\b/]
+const WARN_NEGATIVE: readonly RegExp[] = [/\bneeds changes\b/, /\bstill needs work\b/, ...HOLD_OPEN]
 
 const WARN: readonly RegExp[] = [...WARN_POSITIVE_CLOSEOUT, ...WARN_NEGATIVE]
 
@@ -145,7 +221,7 @@ const WARN: readonly RegExp[] = [...WARN_POSITIVE_CLOSEOUT, ...WARN_NEGATIVE]
 // (answering a question) is the worst false-positive class, so it is checked first.
 const DEMOTE_TO_IGNORE: readonly RegExp[] = [
   /\b(haven'?t|have not|did ?n'?t|did not|not yet|never)\b[^.!?]*\b(approv|request|resolv|block|address)/,
-  /\b(can'?t|cannot|won'?t|will not|wouldn'?t)\b[^.!?]*\b(approv|request|resolv|block|address)/,
+  /\b(can(?:not|'?t|\s+t)|won(?:'?t|\s+t)|will not|wouldn(?:'?t|\s+t))\b[^.!?]*\b(approv|request|resolv|block|address)/,
   /\bnot (approved|resolved|blocked|requesting|addressed)\b/,
   /\b(not|no longer|hardly|barely)\b[^.!?]*\b(lgtm|looks good|looks fine|seems fine|should be (fine|good)|looks resolved|seems resolved)\b/,
   /\b(i'?ll|i will|going to|gonna|about to|planning to)\b[^.!?]*\b(approv|review|request|resolv)/,
@@ -200,9 +276,12 @@ export function classifyReviewClaim(rawText: string): ReviewClaim {
 
   const claims = segments.map(classifySegment)
 
+  // Formal-verdict receipts remain load-bearing even in a mixed message; unlike
+  // resolve chatter, letting a fabricated APPROVE/REQUEST_CHANGES through can
+  // falsify GitHub state. The hold-open veto is therefore deliberately narrower.
   if (claims.includes('block-approve')) return 'block-approve'
   if (claims.includes('block-request-changes')) return 'block-request-changes'
-  if (claims.includes('block-resolve')) return 'block-resolve'
+  if (claims.includes('block-resolve') && !hasHoldOpenClaim(segments)) return 'block-resolve'
   if (claims.includes('warn')) return 'warn'
   return 'ignore'
 }
@@ -213,7 +292,9 @@ export function classifyReviewClaim(rawText: string): ReviewClaim {
 // escalate just the stranding-shaped warns, not the whole warn bucket.
 export function isPositiveWarnCloseout(rawText: string): boolean {
   if (classifyReviewClaim(rawText) !== 'warn') return false
-  return claimSegments(rawText).some((segment) => WARN_POSITIVE_CLOSEOUT.some((re) => re.test(segment)))
+  const segments = claimSegments(rawText)
+  if (hasHoldOpenClaim(segments)) return false
+  return segments.some((segment) => WARN_POSITIVE_CLOSEOUT.some((re) => re.test(segment)))
 }
 
 function classifySegment(text: string): ReviewClaim {
@@ -227,6 +308,10 @@ function classifySegment(text: string): ReviewClaim {
   if (BLOCK_RESOLVE.some((re) => re.test(text))) return 'block-resolve'
   if (WARN.some((re) => re.test(text))) return 'warn'
   return 'ignore'
+}
+
+function hasHoldOpenClaim(segments: readonly string[]): boolean {
+  return segments.some((segment) => HOLD_OPEN.some((re) => re.test(segment)))
 }
 
 function claimSegments(text: string): string[] {


### PR DESCRIPTION
## Background

A review turn on #1320 ended with the bot posting "I couldn't complete the verification: the review worker was aborted before it returned a result," leaving a thread open. Session forensics traced that to two runtime guards, each of which silenced work it was meant to protect. This PR fixes both. It is independent of #1320 and touches none of its files.

Two `reviewer` subagents ran concurrently against the same PR head, one per review thread.

**The first was killed by the loop guard.** It grepped one 10k-line file six times with six different patterns — four of them issued in a single parallel batch — and tripped `WINDOW_HARD_BLOCK`. The windowed detector coarsened every path-bearing tool to its path alone, so distinct queries collapsed to one signature; and `read` had a per-turn same-target exemption that searches did not, so a parallel batch could cross the threshold inside one model turn with no chance to heed the warning. The penalty is a whole-subagent abort, so 92 seconds of review work was discarded.

**The second completed, found a real blocker, and could not report it.** Three publication attempts were denied in a cycle: the stranding guard demanded a formal verdict rather than a reply, the verdict coordinator refused a second `REQUEST_CHANGES` and pointed back at a thread reply, and the reply was then denied as a close-out. `classifyReviewClaim` segments a reply by sentence and takes the strongest claim, so a refusal to close out could not veto a neighbouring positive sentence — "I can't resolve this thread yet because a blocking issue remains" read as `block-resolve`, and "Keeping this thread open while the remaining blocker is addressed" matched the positive-closeout pattern. The finding was dropped through `skip_response`.

## Summary

**`src/agent/loop-guard.ts`** — split `grep`/`find` out of `DEFAULT_PATH_TOOLS` into a search class whose window target retains the query, and generalized the `read` per-turn exemption to any coarsened target so parallel siblings that cannot observe each other count once. Repeated identical queries and cross-turn cycling still warn and block; `ls` keeps its default-target coarsening.

**`src/channels/github-review-claim.ts`** — added hold-open markers across the 15 languages the rest of the channel heuristics cover, vetoing `block-resolve` and positive-closeout across the whole reply. The veto is scoped to present-tense unfinished work: past-tense "remained" describes a state that ended, and a clause that goes on to say `fixed` / `resolved` / `addressed` is excluded, so a genuine close-out is not downgraded into stranding a live `CHANGES_REQUESTED`. It deliberately stops short of `block-approve` and `block-request-changes` — a fabricated formal receipt falsifies GitHub state, so it stays load-bearing even inside a mixed message.

## Preview

Not applicable — no UI change.

## What this does NOT do

The loop guard's penalty is unchanged: a genuine block still aborts the whole subagent rather than refusing the single call. That is a larger behavioral question and is left alone here.

This PR does **not** touch `src/channels/router.ts` and does not supersede or replace #1320, which stays open on its own branch. The recovery-latch gap found during this investigation was fixed independently on #1320 via `outputKind: 'substantive'`.

## Review notes

- The hold-open veto's scoping is the load-bearing part. It must fire for present unfinished work ("one issue remains, keeping this thread open") and must NOT fire for completed remnant history ("the issue remained, but it is now fixed. Resolving this thread"), because the latter would let a close-out through while a blocking review is still live. Both directions are pinned, in English and in non-Latin scripts.
- The loop-guard per-turn exemption counts a duplicated target once per model turn, not once ever — cross-turn cycling still reaches the windowed block at six observations. Covered by `still blocks the same grep target repeated across model turns`.

## Verification

- `bun run lint` (0 errors), `bun run format:check`, `bun run typecheck` all pass on current `main`.
- Full suite: **12184 pass / 31 skip / 0 fail** across 586 files.
