### PR TITLE
Add OpenGateway.ai provider support

### DIFF
--- a/docs/content/docs/guides/add-a-provider.mdx
+++ b/docs/content/docs/guides/add-a-provider.mdx
@@ -23,9 +23,25 @@ typeclaw provider add xai --key xai-...        # xAI (Grok) — also supports --
 typeclaw provider add minimax --key ...        # pay-as-you-go API key or Token Plan key (sk-cp-…)
 typeclaw provider add deepseek --key sk-...     # DeepSeek pay-as-you-go
 typeclaw provider add upstage --key up_...      # Upstage (Solar) pay-as-you-go
+typeclaw provider add moonshot --key sk-...     # Moonshot (Kimi) Open Platform pay-as-you-go
+typeclaw provider add moonshot-coding --key ... # Moonshot Kimi Code subscription
+typeclaw provider add opengateway --key ...     # OpenGateway.ai — one key, many vendors
 ```
 
-The supported providers are `openai`, `openai-codex`, `anthropic`, `fireworks`, `zai`, `zai-coding`, `xai`, `minimax`, `deepseek`, and `upstage`. The key (or browser login) is stored in `secrets.json`, git-ignored like the rest of your credentials.
+The supported providers are `openai`, `openai-codex`, `anthropic`, `fireworks`, `zai`, `zai-coding`, `xai`, `minimax`, `deepseek`, `upstage`, `moonshot`, `moonshot-coding`, and `opengateway`. The key (or browser login) is stored in `secrets.json`, git-ignored like the rest of your credentials.
+
+<Callout type="info" title="OpenGateway: one key, many vendors">
+  `opengateway` is a **gateway**, not a lab: a single OpenAI-compatible endpoint that routes to OpenAI, Anthropic,
+  Moonshot, MiniMax, and more, so one `OPENGATEWAY_API_KEY` reaches all of them. Its model ids are creator-qualified,
+  which means a TypeClaw ref carries two slashes — `opengateway/anthropic/claude-sonnet-5`, not
+  `opengateway/claude-sonnet-5`.
+
+Two caveats. Costs reported by `typeclaw usage` are **upstream list-price estimates**: OpenGateway bills upstream
+usage plus a platform fee and publishes no rate card, so your invoice will read higher. And `typeclaw model list
+  --available` shows only the curated models — any other id from OpenGateway's catalog still works if you set it by
+hand, e.g. `typeclaw model set default opengateway/google/gemini-3.5-flash`.
+
+</Callout>
 
 <Callout type="info" title="MiniMax: pay-as-you-go or Token Plan">
   MiniMax sells one `minimax` provider under two billing surfaces — pay-as-you-go API keys and Token Plan Subscription

--- a/docs/content/docs/guides/quickstart.mdx
+++ b/docs/content/docs/guides/quickstart.mdx
@@ -16,7 +16,7 @@ You need two things installed:
 - **[Bun](https://bun.sh/)** (version 1.1 or newer) — the runtime TypeClaw is built on.
 - **[OrbStack](https://orbstack.dev/)** (recommended) or **[Docker](https://www.docker.com/)** — your agent runs inside a container. OrbStack is lighter and faster to start on macOS; Docker Desktop works just as well.
 
-You'll also need access to one AI provider — an API key from OpenAI, Anthropic, Fireworks, Z.AI, xAI, MiniMax, or DeepSeek, or an existing ChatGPT, Claude, or Grok subscription you can log in with (via the `openai-codex`, `anthropic`, or `xai` providers). The wizard in step 2 walks you through it.
+You'll also need access to one AI provider — an API key from OpenAI, Anthropic, Fireworks, Z.AI, xAI, MiniMax, DeepSeek, Upstage, or Moonshot; an OpenGateway.ai key that reaches several of them at once; or an existing ChatGPT, Claude, or Grok subscription you can log in with (via the `openai-codex`, `anthropic`, or `xai` providers). The wizard in step 2 walks you through it.
 
 ## Five steps to your first reply
 
@@ -67,7 +67,7 @@ The provider step asks, in order: **which provider**, **which model**, then **AP
 Add a provider and pick a default model by hand:
 
 ```sh
-typeclaw provider add openai --key sk-...       # or anthropic, fireworks, zai, zai-coding, xai, minimax, deepseek, upstage
+typeclaw provider add openai --key sk-...       # or anthropic, fireworks, zai, zai-coding, xai, minimax, deepseek, upstage, moonshot, moonshot-coding, opengateway
 typeclaw provider add openai-codex --oauth      # log in with a ChatGPT subscription
 typeclaw provider add anthropic --oauth         # log in with a Claude subscription
 typeclaw provider add xai --oauth               # log in with a Grok subscription

--- a/docs/content/docs/reference/env-vars.mdx
+++ b/docs/content/docs/reference/env-vars.mdx
@@ -45,18 +45,21 @@ Set in the host stage; injected into the container via `--env-file .env`.
 
 These env vars override a stored API-key credential in `secrets.json` (env-wins). The exception is dual-auth providers (`anthropic`, `xai`): a stored OAuth credential takes precedence over the env var, since OAuth is stateful and refreshed on disk. See [/concepts/secrets-policy](/docs/concepts/secrets-policy) for the full resolution order.
 
-| Variable             | Provider     | Notes                                                                                                    |
-| -------------------- | ------------ | -------------------------------------------------------------------------------------------------------- |
-| `FIREWORKS_API_KEY`  | `fireworks`  |                                                                                                          |
-| `OPENAI_API_KEY`     | `openai`     |                                                                                                          |
-| `ANTHROPIC_API_KEY`  | `anthropic`  | OAuth credential on disk wins over this env var (dual-auth provider).                                    |
-| `ZAI_API_KEY`        | `zai`        | Z.AI pay-as-you-go.                                                                                      |
-| `ZAI_CODING_API_KEY` | `zai-coding` | Z.AI GLM Coding Plan — separate billing surface from `zai`.                                              |
-| `XAI_API_KEY`        | `xai`        | xAI (Grok). OAuth credential on disk wins over this env var (dual-auth provider).                        |
-| `MINIMAX_API_KEY`    | `minimax`    | Accepts either a pay-as-you-go API key or a Token Plan Subscription Key (`sk-cp-…`) — same slot.         |
-| `DEEPSEEK_API_KEY`   | `deepseek`   | DeepSeek pay-as-you-go.                                                                                  |
-| `UPSTAGE_API_KEY`    | `upstage`    | Upstage (Solar) pay-as-you-go. Keys are prefixed `up_`.                                                  |
-| (others)             |              | Each known provider has a canonical env var; see [/reference/secrets-json](/docs/reference/secrets-json) |
+| Variable                  | Provider          | Notes                                                                                                    |
+| ------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------- |
+| `FIREWORKS_API_KEY`       | `fireworks`       |                                                                                                          |
+| `OPENAI_API_KEY`          | `openai`          |                                                                                                          |
+| `ANTHROPIC_API_KEY`       | `anthropic`       | OAuth credential on disk wins over this env var (dual-auth provider).                                    |
+| `ZAI_API_KEY`             | `zai`             | Z.AI pay-as-you-go.                                                                                      |
+| `ZAI_CODING_API_KEY`      | `zai-coding`      | Z.AI GLM Coding Plan — separate billing surface from `zai`.                                              |
+| `XAI_API_KEY`             | `xai`             | xAI (Grok). OAuth credential on disk wins over this env var (dual-auth provider).                        |
+| `MINIMAX_API_KEY`         | `minimax`         | Accepts either a pay-as-you-go API key or a Token Plan Subscription Key (`sk-cp-…`) — same slot.         |
+| `DEEPSEEK_API_KEY`        | `deepseek`        | DeepSeek pay-as-you-go.                                                                                  |
+| `UPSTAGE_API_KEY`         | `upstage`         | Upstage (Solar) pay-as-you-go. Keys are prefixed `up_`.                                                  |
+| `MOONSHOT_API_KEY`        | `moonshot`        | Moonshot (Kimi) Open Platform pay-as-you-go.                                                             |
+| `MOONSHOT_CODING_API_KEY` | `moonshot-coding` | Kimi Code subscription — separate billing surface from `moonshot`.                                       |
+| `OPENGATEWAY_API_KEY`     | `opengateway`     | OpenGateway.ai multi-vendor gateway. One key reaches every upstream it fronts.                           |
+| (others)                  |                   | Each known provider has a canonical env var; see [/reference/secrets-json](/docs/reference/secrets-json) |
 
 Custom env-var names are supported via the `Secret`'s `env` field — `{ "key": { "env": "MY_OPENAI" } }`. See [/concepts/secrets-policy](/docs/concepts/secrets-policy) for resolution order.
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -839,6 +839,16 @@ export function resolveModel(ref: KnownModelRef | ModelRef | string): Model<Know
     provider: providerId,
     baseUrl: provider.baseUrl ?? template.baseUrl,
     api: template.api,
+    // Carried from the template for the same reason `api` and `baseUrl` are:
+    // it describes the PROVIDER's wire dialect, not the model. pi-ai infers
+    // compat from the baseUrl and only recognises first-party hosts, so a
+    // custom ref on a provider that pins compat (OpenGateway, Upstage) would
+    // otherwise fall back to OpenAI-native defaults and send `store`, the
+    // `developer` role, `strict` tool schemas and `max_completion_tokens` to
+    // an endpoint that never accepts them. `thinkingLevelMap` is deliberately
+    // NOT carried: it varies per model even within one provider, so copying
+    // the template's would be a guess.
+    ...(template.compat !== undefined ? { compat: template.compat } : {}),
     name: meta?.name ?? modelId,
     reasoning: meta?.reasoning ?? false,
     input: resolveCustomModelInput(meta?.input),

--- a/src/config/opengateway-payload.test.ts
+++ b/src/config/opengateway-payload.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { Context, Model } from '@mariozechner/pi-ai'
+import { streamSimple } from '@mariozechner/pi-ai'
+
+import { resolveModel } from './config'
+import { KNOWN_PROVIDERS } from './providers'
+
+// End-to-end payload guard, same shape as upstage-payload.test.ts: drive pi-ai's
+// real openai-completions adapter and capture the request body via the public
+// `onPayload` hook, which fires before any HTTP call.
+//
+// The point here is the UNCURATED path. pi-ai infers compat from the baseUrl and
+// does not recognise apis.opengateway.ai, so it assumes a first-party OpenAI
+// endpoint. The curated models pin compat to stop that; a custom ref only gets
+// the same treatment because `resolveModel` copies the template's compat. These
+// tests assert the resulting wire payload for both, so the guarantee is proven
+// where it is actually observable rather than by inspecting model objects.
+
+type CapturedPayload = Record<string, unknown>
+
+async function buildPayload(model: Model<'openai-completions'>): Promise<CapturedPayload> {
+  const context: Context = {
+    systemPrompt: 'You are a helpful assistant.',
+    messages: [{ role: 'user', content: 'Hi', timestamp: Date.now() }],
+    tools: [
+      {
+        name: 'get_weather',
+        description: 'Get weather',
+        parameters: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] },
+      },
+    ],
+  }
+
+  let captured: CapturedPayload | undefined
+  const stopMarker = new Error('payload-captured')
+
+  const s = streamSimple(model, context, {
+    apiKey: 'og-test-key',
+    onPayload: (payload) => {
+      captured = payload as CapturedPayload
+      throw stopMarker
+    },
+  })
+
+  for await (const _event of s) {
+    if (captured !== undefined) break
+  }
+
+  if (captured === undefined) throw new Error('onPayload never fired — adapter path changed')
+  return captured
+}
+
+function expectNoOpenAiNativeFields(payload: CapturedPayload, label: string): void {
+  expect(payload.max_completion_tokens, `${label} must not send max_completion_tokens`).toBeUndefined()
+  expect('max_tokens' in payload, `${label} should send max_tokens`).toBe(true)
+  expect('store' in payload, `${label} must not send store`).toBe(false)
+
+  const messages = (payload.messages ?? []) as Array<{ role: string }>
+  for (const m of messages) {
+    expect(m.role, `${label} emitted the unsupported developer role`).not.toBe('developer')
+  }
+
+  const tools = (payload.tools ?? []) as Array<{ function?: { strict?: unknown } }>
+  for (const t of tools) {
+    expect(t.function?.strict, `${label} must not send strict on tool defs`).toBeUndefined()
+  }
+}
+
+// Documented in add-a-provider.mdx as a supported custom ref, and present in the
+// live catalog, but deliberately not curated — exactly the path that regressed.
+const UNCURATED_REF = 'opengateway/google/gemini-3.5-flash'
+
+describe('opengateway openai-completions payload', () => {
+  test('curated models omit every OpenAI-native field the gateway does not accept', async () => {
+    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
+      const payload = await buildPayload(model as Model<'openai-completions'>)
+      expectNoOpenAiNativeFields(payload, `opengateway/${modelId}`)
+    }
+  })
+
+  test('an uncurated custom ref inherits the same guarantees through resolveModel', async () => {
+    // `reasoning` is forced on because pi-ai gates the developer role on
+    // `model.reasoning && compat.supportsDeveloperRole`. A custom ref with no
+    // `customModels` metadata resolves to `reasoning: false`, which suppresses
+    // the role on its own and would make that assertion pass even if compat
+    // stopped propagating. Enabling it here keeps the pin load-bearing.
+    const resolved = resolveModel(UNCURATED_REF) as Model<'openai-completions'>
+    const model: Model<'openai-completions'> = { ...resolved, reasoning: true }
+
+    const payload = await buildPayload(model)
+
+    expectNoOpenAiNativeFields(payload, UNCURATED_REF)
+  })
+
+  test('resolveModel carries the provider compat onto an uncurated ref', () => {
+    // The mechanism behind the payload test above. Asserted separately so a
+    // regression names the cause, not just the symptom.
+    const model = resolveModel(UNCURATED_REF)
+
+    const compat = (model as { compat?: Record<string, unknown> }).compat
+    expect(compat, `${UNCURATED_REF} lost the provider compat`).toBeDefined()
+    expect(compat!.supportsStore).toBe(false)
+    expect(compat!.supportsDeveloperRole).toBe(false)
+    expect(compat!.supportsStrictMode).toBe(false)
+    expect(compat!.maxTokensField).toBe('max_tokens')
+  })
+
+  test('the uncurated ref keeps the gateway transport and creator-qualified id', () => {
+    const model = resolveModel(UNCURATED_REF)
+
+    expect(model.id).toBe('google/gemini-3.5-flash')
+    expect(model.provider).toBe('opengateway')
+    expect(model.api).toBe('openai-completions')
+    expect(model.baseUrl).toBe('https://apis.opengateway.ai/v1')
+  })
+})

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -332,6 +332,117 @@ describe('KNOWN_PROVIDERS', () => {
       expect(model.api, `xai/${modelId} api drift`).toBe('openai-completions')
     }
   })
+
+  test('opengateway is a single api-key provider on the OpenAI-compatible gateway endpoint', () => {
+    const opengateway = KNOWN_PROVIDERS.opengateway
+    expect(opengateway.baseUrl).toBe('https://apis.opengateway.ai/v1')
+    expect(opengateway.apiKeyEnv).toBe('OPENGATEWAY_API_KEY')
+    expect(supportsApiKey(opengateway)).toBe(true)
+    expect(supportsOAuth(opengateway)).toBe(false)
+  })
+
+  test('every opengateway model uses the openai-completions api', () => {
+    // The gateway advertises a `responses` endpoint for some models, but this
+    // repo only wires its verified chat-completions surface; a second transport
+    // would be a separate provider id per the granularity rule.
+    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
+      expect(model.api, `opengateway/${modelId} api drift`).toBe('openai-completions')
+    }
+  })
+
+  test('every opengateway model id is creator-qualified, as the gateway requires', () => {
+    for (const modelId of Object.keys(KNOWN_PROVIDERS.opengateway.models)) {
+      expect(modelId, `opengateway/${modelId} is missing its creator namespace`).toMatch(/^[a-z0-9-]+\/.+/)
+    }
+  })
+
+  test('opengateway model refs round-trip through providerForModelRef despite the second slash', () => {
+    for (const modelId of Object.keys(KNOWN_PROVIDERS.opengateway.models)) {
+      const ref = `opengateway/${modelId}`
+      expect(providerForModelRef(ref), `${ref} misrouted`).toBe('opengateway')
+      expect(isModelRef(ref), `${ref} rejected by isModelRef`).toBe(true)
+    }
+  })
+
+  test('every opengateway model pins compat, since pi-ai cannot auto-detect the gateway host', () => {
+    // Without this, pi-ai's baseUrl sniffing treats apis.opengateway.ai as a
+    // first-party OpenAI endpoint and sends `store`, the `developer` role,
+    // `strict` tool schemas, and max_completion_tokens through to Anthropic and
+    // Moonshot upstreams.
+    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
+      const compat = (model as { compat?: Record<string, unknown> }).compat
+      expect(compat, `opengateway/${modelId} missing compat`).toBeDefined()
+      expect(compat!.supportsStore, `opengateway/${modelId} must not send store`).toBe(false)
+      expect(compat!.supportsDeveloperRole, `opengateway/${modelId} must not use the developer role`).toBe(false)
+      expect(compat!.supportsReasoningEffort, `opengateway/${modelId} must not send reasoning_effort`).toBe(false)
+      expect(compat!.supportsStrictMode, `opengateway/${modelId} must not send strict on tool defs`).toBe(false)
+      expect(compat!.maxTokensField, `opengateway/${modelId} must send max_tokens`).toBe('max_tokens')
+      // Left unset on purpose: pi-ai defaults it true and `typeclaw usage`
+      // needs streamed usage to attribute tokens.
+      expect(compat!.supportsUsageInStreaming, `opengateway/${modelId} must not pin streaming usage`).toBeUndefined()
+    }
+  })
+
+  test('no opengateway model declares a thinkingLevelMap', () => {
+    // supportsReasoningEffort is false, so a level map would advertise a
+    // control contract the gateway never receives.
+    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
+      expect(
+        (model as { thinkingLevelMap?: unknown }).thinkingLevelMap,
+        `opengateway/${modelId} maps thinking levels it cannot send`,
+      ).toBeUndefined()
+    }
+  })
+
+  // OpenGateway publishes no pricing, so each curated entry copies the rate card
+  // of the sibling registry entry for the same underlying model. This pins that
+  // relationship: if the upstream entry is repriced, the gateway copy must move
+  // with it or this fails.
+  const OPENGATEWAY_UPSTREAM_SOURCE: Record<string, [KnownProviderId, string]> = {
+    'openai/gpt-5.4-nano': ['openai', 'gpt-5.4-nano'],
+    'openai/gpt-5.5': ['openai', 'gpt-5.5'],
+    'anthropic/claude-sonnet-5': ['anthropic', 'claude-sonnet-5'],
+    'anthropic/claude-opus-4-8': ['anthropic', 'claude-opus-4-8'],
+    'moonshotai/kimi-k2.6': ['moonshot', 'kimi-k2.6'],
+    'minimax/MiniMax-M3': ['minimax', 'MiniMax-M3'],
+  }
+
+  test('every opengateway model declares an upstream pricing source', () => {
+    expect(Object.keys(KNOWN_PROVIDERS.opengateway.models).sort()).toEqual(
+      Object.keys(OPENGATEWAY_UPSTREAM_SOURCE).sort(),
+    )
+  })
+
+  test('opengateway cost and limits mirror the native registry entry for the same model', () => {
+    type PricedModel = {
+      cost: Record<string, number>
+      contextWindow: number
+      maxTokens: number
+      input: ReadonlyArray<string>
+      reasoning?: boolean
+    }
+    const gatewayModels = KNOWN_PROVIDERS.opengateway.models as Record<string, PricedModel>
+    for (const [modelId, [upstreamProviderId, upstreamModelId]] of Object.entries(OPENGATEWAY_UPSTREAM_SOURCE)) {
+      const gateway = gatewayModels[modelId]!
+      const upstream = (KNOWN_PROVIDERS[upstreamProviderId].models as Record<string, PricedModel>)[upstreamModelId]
+      expect(upstream, `${upstreamProviderId}/${upstreamModelId} vanished`).toBeDefined()
+      expect(gateway.cost, `opengateway/${modelId} cost drifted from ${upstreamProviderId}/${upstreamModelId}`).toEqual(
+        upstream!.cost,
+      )
+      expect(gateway.contextWindow, `opengateway/${modelId} contextWindow drift`).toBe(upstream!.contextWindow)
+      expect(gateway.maxTokens, `opengateway/${modelId} maxTokens drift`).toBe(upstream!.maxTokens)
+      expect([...gateway.input], `opengateway/${modelId} input drift`).toEqual([...upstream!.input])
+      expect(gateway.reasoning, `opengateway/${modelId} reasoning drift`).toBe(upstream!.reasoning ?? false)
+    }
+  })
+
+  test('opengateway costs are non-zero, because the gateway is metered not flat-rate', () => {
+    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
+      const cost = model.cost as { input: number; output: number }
+      expect(cost.input, `opengateway/${modelId} input cost must not be zeroed`).toBeGreaterThan(0)
+      expect(cost.output, `opengateway/${modelId} output cost must not be zeroed`).toBeGreaterThan(0)
+    }
+  })
 })
 
 describe('KNOWN_PROVIDER_VENDORS', () => {
@@ -411,6 +522,17 @@ describe('KNOWN_PROVIDER_VENDORS', () => {
   test('Upstage is a single-provider vendor (no variant step)', () => {
     expect(providerIdsForVendor('upstage')).toEqual(['upstage'])
     expect(vendorForProviderId('upstage')).toBe('upstage')
+  })
+
+  test('OpenGateway is a single-provider vendor listed after the labs it proxies', () => {
+    expect(providerIdsForVendor('opengateway')).toEqual(['opengateway'])
+    expect(vendorForProviderId('opengateway')).toBe('opengateway')
+    const vendorIds = listKnownProviderVendorIds()
+    expect(vendorIds[vendorIds.length - 1]).toBe('opengateway')
+  })
+
+  test('opengateway does not join the OpenAI family even though it proxies OpenAI models', () => {
+    expect(isOpenAiFamilyRef('opengateway/openai/gpt-5.5')).toBe(false)
   })
 
   test('Moonshot vendor splits paygo (moonshot) from Coding Plan (moonshot-coding)', () => {

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1036,6 +1036,178 @@ export const KNOWN_PROVIDERS = {
       },
     },
   },
+  // OpenGateway.ai (Sionic AI) — a multi-vendor LLM GATEWAY, not a lab. One
+  // OpenAI-compatible surface (Bearer + /chat/completions) fronts OpenAI,
+  // Anthropic, Google, Moonshot, MiniMax, DeepSeek, Z.AI, xAI, and Qwen, so by
+  // the granularity rule above it is ONE provider id: one endpoint, one wire
+  // transport, one key.
+  //
+  // Model ids are creator-qualified (`openai/gpt-5.5`, not `gpt-5.5`) — the
+  // namespace is mandatory upstream. TypeClaw refs therefore carry two slashes:
+  // `opengateway/anthropic/claude-sonnet-5`. That parses fine because
+  // `providerForModelRef()` matches on the registered provider prefix, the same
+  // mechanism that already handles the slash-heavy Fireworks router ids.
+  //
+  // Curation rule (why only six of the ~56 live chat models): every curated
+  // entry mirrors a model THIS registry already prices natively, so the numbers
+  // below are copied from a sibling entry rather than invented. Models with no
+  // in-repo price (google/*, qwen/*) and models whose native reasoning contract
+  // is NOT plain OpenAI `reasoning_effort` (deepseek's `thinking:{type}`,
+  // z-ai/qwen's `enable_thinking`) are deliberately left out: pi-ai picks
+  // thinkingFormat from the baseUrl, and `apis.opengateway.ai` resolves to
+  // "openai", so routing those here would silently send the wrong reasoning
+  // field. They all remain reachable as custom `opengateway/...` refs — curation
+  // only drives the picker, JSON-schema enum, and autocomplete.
+  //
+  // Costs are UPSTREAM LIST PRICES in USD per 1M tokens, pinned to the sibling
+  // entry by a guard test in providers.test.ts. OpenGateway bills upstream usage
+  // plus a platform fee and exposes no pricing in /v1/models, so `typeclaw usage`
+  // is an estimate that reads LOW against the real invoice. Do NOT "fix" these
+  // to zero: zero means "no attributable per-token charge" in this registry
+  // (flat-subscription products like the Fireworks Fire Pass router), and
+  // OpenGateway is metered. Replace with gateway-billed rates only if
+  // OpenGateway ever publishes them.
+  //
+  // Every model carries an explicit `compat` for the same reason Upstage does:
+  // pi-ai auto-detects compatibility from the baseUrl, and `apis.opengateway.ai`
+  // matches none of its known hosts, so it would otherwise assume a first-party
+  // OpenAI endpoint and send `store`, the `developer` role, `strict` tool
+  // schemas, and `max_completion_tokens` to a gateway fronting Anthropic and
+  // Moonshot. `supportsUsageInStreaming` is deliberately left unset (pi-ai
+  // defaults it true) — turning it off would break token and cost reporting.
+  opengateway: {
+    id: 'opengateway',
+    name: 'OpenGateway.ai',
+    baseUrl: 'https://apis.opengateway.ai/v1',
+    auth: ['api-key'],
+    apiKeyEnv: 'OPENGATEWAY_API_KEY',
+    oauthProviderId: null,
+    models: {
+      // Mirrors openai/gpt-5.4-nano.
+      'openai/gpt-5.4-nano': {
+        id: 'openai/gpt-5.4-nano',
+        name: 'GPT-5.4 nano',
+        api: 'openai-completions',
+        provider: 'opengateway',
+        baseUrl: 'https://apis.opengateway.ai/v1',
+        reasoning: true,
+        compat: {
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStrictMode: false,
+          maxTokensField: 'max_tokens',
+        },
+        input: ['text', 'image'],
+        cost: { input: 0.2, output: 1.25, cacheRead: 0.02, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      },
+      // Mirrors openai/gpt-5.5.
+      'openai/gpt-5.5': {
+        id: 'openai/gpt-5.5',
+        name: 'GPT-5.5',
+        api: 'openai-completions',
+        provider: 'opengateway',
+        baseUrl: 'https://apis.opengateway.ai/v1',
+        reasoning: true,
+        compat: {
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStrictMode: false,
+          maxTokensField: 'max_tokens',
+        },
+        input: ['text', 'image'],
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        contextWindow: 1050000,
+        maxTokens: 128000,
+      },
+      // Mirrors anthropic/claude-sonnet-5. Note the transport differs from the
+      // native entry: Anthropic is `anthropic-messages` first-party, but the
+      // gateway only speaks OpenAI chat-completions.
+      'anthropic/claude-sonnet-5': {
+        id: 'anthropic/claude-sonnet-5',
+        name: 'Claude Sonnet 5',
+        api: 'openai-completions',
+        provider: 'opengateway',
+        baseUrl: 'https://apis.opengateway.ai/v1',
+        reasoning: true,
+        compat: {
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStrictMode: false,
+          maxTokensField: 'max_tokens',
+        },
+        input: ['text', 'image'],
+        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      },
+      // Mirrors anthropic/claude-opus-4-8.
+      'anthropic/claude-opus-4-8': {
+        id: 'anthropic/claude-opus-4-8',
+        name: 'Claude Opus 4.8',
+        api: 'openai-completions',
+        provider: 'opengateway',
+        baseUrl: 'https://apis.opengateway.ai/v1',
+        reasoning: true,
+        compat: {
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStrictMode: false,
+          maxTokensField: 'max_tokens',
+        },
+        input: ['text', 'image'],
+        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      },
+      // Mirrors moonshot/kimi-k2.6. The gateway namespaces Moonshot as
+      // `moonshotai`, so the id is NOT the native `kimi-k2.6`.
+      'moonshotai/kimi-k2.6': {
+        id: 'moonshotai/kimi-k2.6',
+        name: 'Kimi K2.6',
+        api: 'openai-completions',
+        provider: 'opengateway',
+        baseUrl: 'https://apis.opengateway.ai/v1',
+        reasoning: true,
+        compat: {
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStrictMode: false,
+          maxTokensField: 'max_tokens',
+        },
+        input: ['text', 'image'],
+        cost: { input: 0.6, output: 2.5, cacheRead: 0.15, cacheWrite: 0 },
+        contextWindow: 256000,
+        maxTokens: 64000,
+      },
+      // Mirrors minimax/MiniMax-M3.
+      'minimax/MiniMax-M3': {
+        id: 'minimax/MiniMax-M3',
+        name: 'MiniMax M3',
+        api: 'openai-completions',
+        provider: 'opengateway',
+        baseUrl: 'https://apis.opengateway.ai/v1',
+        reasoning: true,
+        compat: {
+          supportsStore: false,
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStrictMode: false,
+          maxTokensField: 'max_tokens',
+        },
+        input: ['text', 'image'],
+        cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 524288,
+      },
+    },
+  },
 } as const satisfies Record<string, KnownProvider>
 
 export type KnownProviderId = keyof typeof KNOWN_PROVIDERS
@@ -1122,6 +1294,13 @@ export const KNOWN_PROVIDER_VENDORS = {
       moonshot: { label: 'Pay-as-you-go', hint: 'Moonshot Open Platform API billing' },
       'moonshot-coding': { label: 'Coding Plan', hint: 'Kimi Code subscription' },
     },
+  },
+  // Listed last because it is a reseller, not a lab: a user who knows they want
+  // Anthropic should land on the Anthropic row, not the gateway that proxies it.
+  opengateway: {
+    id: 'opengateway',
+    name: 'OpenGateway.ai (multi-vendor gateway)',
+    providers: ['opengateway'],
   },
 } as const satisfies Record<string, KnownProviderVendor>
 

--- a/src/init/models-dev.test.ts
+++ b/src/init/models-dev.test.ts
@@ -112,4 +112,27 @@ describe('fetchModelOptions', () => {
     // kimi-k2p6-turbo is curated-only; must still appear even though models.dev didn't list it.
     expect(result.options.some((o) => o.modelId === 'accounts/fireworks/routers/kimi-k2p6-turbo')).toBe(true)
   })
+
+  test('never synthesizes bare models.dev ids onto opengateway, which requires a creator prefix', async () => {
+    // given: models.dev listing an openai model that opengateway would only
+    // accept as `openai/gpt-6-live`.
+    const stub = {
+      openai: {
+        id: 'openai',
+        name: 'OpenAI',
+        models: { 'gpt-6-live': { id: 'gpt-6-live', name: 'GPT-6 Live' } },
+      },
+    }
+    const fetchImpl = (async () => new Response(JSON.stringify(stub), { status: 200 })) as unknown as typeof fetch
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.source).toBe('models.dev')
+    expect(result.options.some((o) => o.ref === 'openai/gpt-6-live')).toBe(true)
+    expect(result.options.some((o) => o.ref === 'opengateway/gpt-6-live')).toBe(false)
+    const opengateway = result.options.filter((o) => o.providerId === 'opengateway')
+    expect(opengateway.length).toBeGreaterThan(0)
+    expect(opengateway.every((o) => o.curated)).toBe(true)
+    expect(opengateway.every((o) => o.modelId.includes('/'))).toBe(true)
+  })
 })

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -46,6 +46,7 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string | null> = {
   // metadata under `moonshot`, so we route lookups there; the curated
   // `kimi-for-coding` alias is surfaced regardless of upstream membership.
   'moonshot-coding': 'moonshot',
+  opengateway: null,
 }
 
 function upstreamProviderFor(

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -16,7 +16,11 @@ const REQUEST_TIMEOUT_MS = 10_000
 // KnownProviderId. Specifically, they ship Fireworks under `fireworks-ai`.
 // This map is the single place that bridges the two namespaces; every other
 // helper in this file works in OUR namespace.
-const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
+// `null` means "never merge upstream models into this provider". Reserved for
+// gateways whose ids are creator-qualified: models.dev lists bare ids like
+// `gpt-5.5`, but OpenGateway only accepts `openai/gpt-5.5`, so merging would
+// synthesize refs that pass `isModelRef()` and then 404 at request time.
+const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string | null> = {
   openai: 'openai',
   // openai-codex models live under the `openai` namespace on models.dev too
   // (Codex is a backend, not a separate provider in their taxonomy). Curated
@@ -42,6 +46,15 @@ const PROVIDER_TO_MODELS_DEV: Record<KnownProviderId, string> = {
   // metadata under `moonshot`, so we route lookups there; the curated
   // `kimi-for-coding` alias is surfaced regardless of upstream membership.
   'moonshot-coding': 'moonshot',
+}
+
+function upstreamProviderFor(
+  data: Record<string, ModelsDevProvider>,
+  providerId: KnownProviderId,
+): ModelsDevProvider | undefined {
+  const modelsDevId = PROVIDER_TO_MODELS_DEV[providerId]
+  if (modelsDevId === null) return undefined
+  return data[modelsDevId]
 }
 
 export type ModelOption = {
@@ -156,7 +169,7 @@ function mergeWithCurated(data: Record<string, ModelsDevProvider>): ModelOption[
   const seen = new Set<string>()
   for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
     const known = KNOWN_PROVIDERS[providerId]
-    const upstream = data[PROVIDER_TO_MODELS_DEV[providerId]]
+    const upstream = upstreamProviderFor(data, providerId)
     const upstreamModels = upstream?.models ?? {}
     for (const modelId of Object.keys(known.models)) {
       const upstreamModel = upstreamModels[modelId]
@@ -167,7 +180,7 @@ function mergeWithCurated(data: Record<string, ModelsDevProvider>): ModelOption[
   }
 
   for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
-    const upstream = data[PROVIDER_TO_MODELS_DEV[providerId]]
+    const upstream = upstreamProviderFor(data, providerId)
     const upstreamModels = upstream?.models ?? {}
     for (const [fallbackModelId, upstreamModel] of Object.entries(upstreamModels)) {
       const modelId = upstreamModel.id ?? fallbackModelId

--- a/src/init/validate-api-key.test.ts
+++ b/src/init/validate-api-key.test.ts
@@ -217,6 +217,60 @@ describe('validateApiKey', () => {
     }
   })
 
+  test('probes the opengateway /v1/me endpoint, never the publicly readable /v1/models', async () => {
+    // OpenGateway serves /v1/models without auth, so probing it would validate
+    // any garbage string. /me is the endpoint that actually rejects a bad key.
+    let seenUrl: string | null = null
+    const result = await validateApiKey(
+      'opengateway',
+      'og-test',
+      fakeFetch((url, init) => {
+        seenUrl = url
+        expect((init.headers as Record<string, string>).Authorization).toBe('Bearer og-test')
+        return new Response('{"id":"team_1","name":"Acme"}', { status: 200 })
+      }),
+    )
+    expect(seenUrl!).toBe('https://apis.opengateway.ai/v1/me')
+    expect(seenUrl!).not.toContain('/models')
+    expect(result).toEqual({ kind: 'ok' })
+  })
+
+  test('rejects an invalid opengateway key on 401', async () => {
+    const result = await validateApiKey(
+      'opengateway',
+      'og-bad',
+      fakeFetch(() => new Response('{"error":{"code":"invalid_api_key"}}', { status: 401 })),
+    )
+    expect(result).toEqual({ kind: 'rejected', status: 401 })
+  })
+
+  test('opengateway still rejects a captive-portal HTML 200 despite the looser shape check', async () => {
+    const result = await validateApiKey(
+      'opengateway',
+      'og-test',
+      fakeFetch(() => new Response('<html><body>Login required</body></html>', { status: 200 })),
+    )
+    expect(result).toEqual({ kind: 'skipped', reason: 'network-error', detail: 'unexpected response shape' })
+  })
+
+  test('the json-object shape does not accept a top-level array', async () => {
+    const result = await validateApiKey(
+      'opengateway',
+      'og-test',
+      fakeFetch(() => new Response('[{"id":"team_1"}]', { status: 200 })),
+    )
+    expect(result.kind).toBe('skipped')
+  })
+
+  test('models-list providers still require {data:[...]}, unaffected by the json-object shape', async () => {
+    const result = await validateApiKey(
+      'openai',
+      'sk-test',
+      fakeFetch(() => new Response('{"id":"acct_1"}', { status: 200 })),
+    )
+    expect(result).toEqual({ kind: 'skipped', reason: 'network-error', detail: 'unexpected response shape' })
+  })
+
   test('skips OAuth-only providers without contacting the network', async () => {
     let called = false
     const result = await validateApiKey('openai-codex', 'whatever', async () => {

--- a/src/init/validate-api-key.ts
+++ b/src/init/validate-api-key.ts
@@ -1,7 +1,20 @@
 import { effectiveBaseUrl } from '@/agent/model-overrides'
 import { KNOWN_PROVIDERS, type KnownProviderId } from '@/config/providers'
 
-const PROVIDER_PROBE: Partial<Record<KnownProviderId, { url: string; authHeader: 'bearer' | 'x-api-key' }>> = {
+// `successShape` is what a 200 must look like to count as a validated key.
+// Default `models-list` requires `{ data: [...] }`, which every /v1/models probe
+// below returns. `json-object` is the weaker check for probes that answer with a
+// bare object instead of a list — it still rejects the captive-portal HTML case
+// that motivated shape-checking in the first place.
+type ProbeSuccessShape = 'models-list' | 'json-object'
+
+type Probe = {
+  url: string
+  authHeader: 'bearer' | 'x-api-key'
+  successShape?: ProbeSuccessShape
+}
+
+const PROVIDER_PROBE: Partial<Record<KnownProviderId, Probe>> = {
   openai: { url: 'https://api.openai.com/v1/models', authHeader: 'bearer' },
   anthropic: { url: 'https://api.anthropic.com/v1/models', authHeader: 'x-api-key' },
   fireworks: { url: 'https://api.fireworks.ai/inference/v1/models', authHeader: 'bearer' },
@@ -75,7 +88,7 @@ export async function validateApiKey(
       // Treat the response as "ok" only if it parses as the expected
       // JSON shape (`{ data: [...] }` for /v1/models on every probed
       // provider).
-      const shapeOk = await isModelsListShape(res)
+      const shapeOk = await hasExpectedShape(res, probe.successShape ?? 'models-list')
       if (shapeOk) return { kind: 'ok' }
       return { kind: 'skipped', reason: 'network-error', detail: 'unexpected response shape' }
     }
@@ -125,12 +138,14 @@ function isFireworksFirePassForbidden(body: string): boolean {
   }
 }
 
-async function isModelsListShape(res: Response): Promise<boolean> {
+async function hasExpectedShape(res: Response, shape: ProbeSuccessShape): Promise<boolean> {
   const text = await readCapped(res, MAX_BODY_BYTES)
   if (text === null) return false
   try {
     const parsed = JSON.parse(text) as unknown
-    return typeof parsed === 'object' && parsed !== null && Array.isArray((parsed as { data?: unknown }).data)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return false
+    if (shape === 'json-object') return true
+    return Array.isArray((parsed as { data?: unknown }).data)
   } catch {
     return false
   }

--- a/src/init/validate-api-key.ts
+++ b/src/init/validate-api-key.ts
@@ -26,6 +26,12 @@ const PROVIDER_PROBE: Partial<Record<KnownProviderId, Probe>> = {
   upstage: { url: 'https://api.upstage.ai/v1/models', authHeader: 'bearer' },
   moonshot: { url: 'https://api.moonshot.ai/v1/models', authHeader: 'bearer' },
   'moonshot-coding': { url: 'https://api.kimi.com/coding/v1/models', authHeader: 'bearer' },
+  // NOT /v1/models: OpenGateway serves its catalog PUBLICLY (verified — HTTP 200
+  // with `{data:[...]}` for a missing key and for a garbage key), so probing it
+  // would hand back `ok` for any string the user pastes. That is worse than no
+  // validation, because init would vouch for a key that cannot complete a single
+  // request. /v1/me is the cheapest endpoint that actually 401s on a bad key.
+  opengateway: { url: 'https://apis.opengateway.ai/v1/me', authHeader: 'bearer', successShape: 'json-object' },
 }
 
 // When a base-URL override (ANTHROPIC_BASE_URL / OPENAI_BASE_URL) points at a
@@ -187,6 +193,7 @@ export const API_KEY_DASHBOARD_URL: Partial<Record<KnownProviderId, string>> = {
   upstage: 'https://console.upstage.ai/api-keys',
   moonshot: 'https://platform.moonshot.ai/console/api-keys',
   'moonshot-coding': 'https://www.kimi.com/code/console',
+  opengateway: 'https://opengateway.ai/docs/reference/guides/authentication',
 }
 
 // MiniMax sells the same `minimax` provider under two billing surfaces that


### PR DESCRIPTION
## Background

TypeClaw supports twelve providers, each of which is a single lab. That works
until someone wants breadth: to reach OpenAI, Anthropic, Moonshot and MiniMax
today you need four accounts, four keys and four billing relationships.

[OpenGateway.ai](https://opengateway.ai/) (Sionic AI) is a gateway that removes
that: one OpenAI-compatible endpoint and one key route to every upstream it
fronts. This registers it as a first-class provider.

## Summary

The registry is pure data, so the interesting part is not the entry — it is the
three places where a gateway violates an assumption the registry was built on.

**A gateway is one provider id, not one per vendor.** The granularity rule in
`providers.ts` keys on the runtime API surface, not the brand. OpenGateway is
one endpoint, one transport, one key, so it is one id. The consequence is that
its creator-qualified model ids give refs with two slashes
(`opengateway/anthropic/claude-sonnet-5`). That already works —
`providerForModelRef` matches on the registered provider prefix, the mechanism
added for Fireworks' slash-heavy router ids.

**Why `/v1/me` and not `/v1/models` for the key probe.** Every other provider
probes its models endpoint. OpenGateway serves that endpoint publicly — verified
against the live API, it answers `200 {"data":[…]}` with no key and with a
deliberately invalid key. Probing it would make `validateApiKey` return `ok` for
any string a user pastes, which is worse than not validating: init would vouch
for a key that cannot complete a single request. `/v1/me` genuinely 401s. It
answers with a bare object rather than a list, so probes now declare the shape
they expect; the default is unchanged and the captive-portal guard still fires.

**Why every model pins `compat`.** pi-ai infers OpenAI compatibility from the
baseUrl and does not recognise `apis.opengateway.ai`, so it would treat it as a
first-party OpenAI endpoint and send `store`, the `developer` role, `strict` tool
schemas and `max_completion_tokens` through to Anthropic and Moonshot upstreams.
Upstage already hit this and solved it the same way.

**Why the gateway opts out of the models.dev merge.** That mapping is total, so
every provider inherits an upstream namespace. models.dev lists bare ids
(`gpt-5.5`), which are invalid here — the creator prefix is mandatory — so
merging would synthesize refs that pass `isModelRef` and then 404. The mapping is
now nullable.

**Why six models, and why their costs are not zero.** The live catalog has 56
active chat models; shipping all of them bloats the schema enum and the picker
for no benefit, since any uncurated id still works as a custom ref. The six are
the ones this registry *already prices natively*, so every rate is copied from a
sibling entry rather than invented, and a guard test pins them there. Zero would
have been easier, but zero already means "flat-rate subscription" in this
registry (the Fireworks Fire Pass router), and this gateway is metered — zeroing
it would make `typeclaw usage` silently under-report real spend.

## What this does NOT do

- **No live-key smoke test.** I have no OpenGateway account, so streaming +
  usage, a tool-call round trip, and image input are unverified against the real
  API. Everything here is derived from the public catalog, the published docs and
  pi-ai's resolver — worth one manual run before anyone relies on it.
- **No `OPENGATEWAY_BASE_URL` override.** This is already the gateway endpoint;
  an override for a gateway is a gateway for a gateway.
- **No Responses-API transport.** Some models advertise a `responses` endpoint;
  only the verified chat-completions surface is wired. A second transport would
  be a separate provider id under the granularity rule.
- **No models whose reasoning contract is not plain `reasoning_effort`.**
  DeepSeek (`thinking:{type}`) and Z.AI/Qwen (`enable_thinking`) are excluded
  from curation, because pi-ai picks thinkingFormat from the baseUrl and would
  resolve `openai` for them here. They remain reachable as custom refs.

## Review notes

The load-bearing change is `PROVIDER_PROBE.opengateway` pointing at `/v1/me`.
If a future cleanup "normalizes" it to `/v1/models` for consistency with its
eleven neighbours, key validation silently starts accepting garbage. That is
why the deviation is commented at the call site.

The invariant worth checking is the cost pin: `opengateway cost and limits mirror
the native registry entry for the same model` fails if either side is repriced
independently. I verified it bites by mutating a rate and watching it fail.

Two drive-bys, both in lists this PR already had to edit: the provider docs and
the env-var table were missing `moonshot` and `moonshot-coding`, which landed
earlier without docs. Leaving a list I was editing knowingly incomplete seemed
worse than the small scope creep.
