### PR TITLE
Fix the OpenGateway display name and source its model list from the gateway

### DIFF
--- a/docs/content/docs/guides/add-a-provider.mdx
+++ b/docs/content/docs/guides/add-a-provider.mdx
@@ -25,7 +25,7 @@ typeclaw provider add deepseek --key sk-...     # DeepSeek pay-as-you-go
 typeclaw provider add upstage --key up_...      # Upstage (Solar) pay-as-you-go
 typeclaw provider add moonshot --key sk-...     # Moonshot (Kimi) Open Platform pay-as-you-go
 typeclaw provider add moonshot-coding --key ... # Moonshot Kimi Code subscription
-typeclaw provider add opengateway --key ...     # OpenGateway.ai — one key, many vendors
+typeclaw provider add opengateway --key ...     # OpenGateway — one key, many vendors
 ```
 
 The supported providers are `openai`, `openai-codex`, `anthropic`, `fireworks`, `zai`, `zai-coding`, `xai`, `minimax`, `deepseek`, `upstage`, `moonshot`, `moonshot-coding`, and `opengateway`. The key (or browser login) is stored in `secrets.json`, git-ignored like the rest of your credentials.

--- a/docs/content/docs/guides/add-a-provider.mdx
+++ b/docs/content/docs/guides/add-a-provider.mdx
@@ -36,10 +36,10 @@ The supported providers are `openai`, `openai-codex`, `anthropic`, `fireworks`, 
   which means a TypeClaw ref carries two slashes — `opengateway/anthropic/claude-sonnet-5`, not
   `opengateway/claude-sonnet-5`.
 
-Two caveats. Costs reported by `typeclaw usage` are **upstream list-price estimates**: OpenGateway bills upstream
-usage plus a platform fee and publishes no rate card, so your invoice will read higher. And `typeclaw model list
-  --available` shows only the curated models — any other id from OpenGateway's catalog still works if you set it by
-hand, e.g. `typeclaw model set default opengateway/google/gemini-3.5-flash`.
+`typeclaw model list --available` fetches OpenGateway's own public catalog, so newly available chat models appear
+without waiting for a TypeClaw release. TypeClaw also consumes OpenGateway's live per-model rates for `typeclaw usage`.
+The rate card is best-effort: if it is temporarily unavailable, the models still appear and their cost remains unknown
+until pricing can be fetched again.
 
 </Callout>
 

--- a/docs/content/docs/guides/quickstart.mdx
+++ b/docs/content/docs/guides/quickstart.mdx
@@ -16,7 +16,7 @@ You need two things installed:
 - **[Bun](https://bun.sh/)** (version 1.1 or newer) — the runtime TypeClaw is built on.
 - **[OrbStack](https://orbstack.dev/)** (recommended) or **[Docker](https://www.docker.com/)** — your agent runs inside a container. OrbStack is lighter and faster to start on macOS; Docker Desktop works just as well.
 
-You'll also need access to one AI provider — an API key from OpenAI, Anthropic, Fireworks, Z.AI, xAI, MiniMax, DeepSeek, Upstage, or Moonshot; an OpenGateway.ai key that reaches several of them at once; or an existing ChatGPT, Claude, or Grok subscription you can log in with (via the `openai-codex`, `anthropic`, or `xai` providers). The wizard in step 2 walks you through it.
+You'll also need access to one AI provider — an API key from OpenAI, Anthropic, Fireworks, Z.AI, xAI, MiniMax, DeepSeek, Upstage, or Moonshot; an OpenGateway key that reaches several of them at once; or an existing ChatGPT, Claude, or Grok subscription you can log in with (via the `openai-codex`, `anthropic`, or `xai` providers). The wizard in step 2 walks you through it.
 
 ## Five steps to your first reply
 

--- a/docs/content/docs/reference/env-vars.mdx
+++ b/docs/content/docs/reference/env-vars.mdx
@@ -58,7 +58,7 @@ These env vars override a stored API-key credential in `secrets.json` (env-wins)
 | `UPSTAGE_API_KEY`         | `upstage`         | Upstage (Solar) pay-as-you-go. Keys are prefixed `up_`.                                                  |
 | `MOONSHOT_API_KEY`        | `moonshot`        | Moonshot (Kimi) Open Platform pay-as-you-go.                                                             |
 | `MOONSHOT_CODING_API_KEY` | `moonshot-coding` | Kimi Code subscription — separate billing surface from `moonshot`.                                       |
-| `OPENGATEWAY_API_KEY`     | `opengateway`     | OpenGateway.ai multi-vendor gateway. One key reaches every upstream it fronts.                           |
+| `OPENGATEWAY_API_KEY`     | `opengateway`     | OpenGateway multi-vendor gateway. One key reaches every upstream it fronts.                              |
 | (others)                  |                   | Each known provider has a canonical env var; see [/reference/secrets-json](/docs/reference/secrets-json) |
 
 Custom env-var names are supported via the `Secret`'s `env` field — `{ "key": { "env": "MY_OPENAI" } }`. See [/concepts/secrets-policy](/docs/concepts/secrets-policy) for resolution order.

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -64,7 +64,12 @@ import {
   type WizardCheckpointStore,
 } from '@/init/checkpoint'
 import { runKakaotalkBootstrap } from '@/init/kakaotalk-auth'
-import { customModelMetaFromOption, fetchModelOptions, type ModelOption } from '@/init/models-dev'
+import {
+  customModelMetaFromOption,
+  fetchModelOptions,
+  type FetchModelsResult,
+  type ModelOption,
+} from '@/init/models-dev'
 import { makeOAuthLoginRunner, type OAuthLoginResult } from '@/init/oauth-login'
 import { detectInitProgress } from '@/init/progress'
 import { runTeamsBootstrap } from '@/init/teams-auth'
@@ -1223,14 +1228,23 @@ function oauthDiscoveryRef(providerId: KnownProviderId): KnownModelRef {
 
 async function loadCatalog(): Promise<NonNullable<WizardState['catalog']>> {
   const s = spinner()
-  s.start('Loading model catalog from models.dev...')
-  const { options, source, warning } = await fetchModelOptions()
-  if (source === 'curated') {
-    s.stop(`Using built-in catalog (models.dev unavailable: ${warning ?? 'unknown'})`)
+  s.start('Loading model catalogs...')
+  const result = await fetchModelOptions()
+  const unavailable = catalogFallbackLabels(result)
+  if (unavailable.length > 0) {
+    s.stop(`Loaded model catalog with fallback for ${unavailable.join(', ')}.`)
   } else {
-    s.stop('Loaded model catalog.')
+    s.stop('Loaded model catalogs.')
   }
-  return warning !== undefined ? { options, source, warning } : { options, source }
+  return result
+}
+
+function catalogFallbackLabels(result: FetchModelsResult): string[] {
+  const labels: string[] = []
+  if (result.sources.modelsDev === 'unavailable') labels.push('native providers')
+  if (result.sources.openGatewayCatalog === 'unavailable') labels.push('OpenGateway models')
+  else if (result.sources.openGatewayPrices === 'unavailable') labels.push('OpenGateway prices')
+  return labels
 }
 
 async function pickVendor(

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -541,15 +541,18 @@ function describeRef(ref: string): string {
 }
 
 async function printAvailableRefs(): Promise<void> {
-  const { options, source, warning } = await fetchModelOptions()
+  const { options, sources, warnings } = await fetchModelOptions()
   if (options.length === 0) {
     console.log(c.dim('No models registered.'))
     return
   }
   console.log(c.dim('Use `typeclaw model set <profile> <ref>` to apply.'))
-  if (source === 'curated' && warning !== undefined) {
-    console.log(c.dim(`Using built-in catalog (models.dev unavailable: ${warning}).`))
+  if (sources.modelsDev === 'unavailable') console.log(c.dim('Using built-in models for native providers.'))
+  if (sources.openGatewayCatalog === 'unavailable') console.log(c.dim('Using the built-in OpenGateway anchor.'))
+  else if (sources.openGatewayPrices === 'unavailable') {
+    console.log(c.dim('OpenGateway models loaded without live pricing.'))
   }
+  if (warnings.length > 0) console.log(c.dim(`Catalog warnings: ${warnings.join('; ')}`))
   for (const providerId of Object.keys(KNOWN_PROVIDERS) as KnownProviderId[]) {
     const providerOptions = options.filter((option) => option.providerId === providerId)
     if (providerOptions.length === 0) continue

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -32,7 +32,7 @@ import {
   withDefaultPlugins,
   type Models,
 } from './config'
-import { isModelRef, type ModelRef } from './providers'
+import { isModelRef, KNOWN_PROVIDERS, type ModelRef } from './providers'
 
 const isRoot = typeof process.getuid === 'function' && process.getuid() === 0
 const onWindows = isWindows()
@@ -246,6 +246,22 @@ describe('resolveModel', () => {
     })
     expect(model.contextWindow).toBe(400000)
     expect(model.maxTokens).toBe(128000)
+  })
+
+  test('a formerly static OpenGateway ref still parses and resolves through the anchor transport', () => {
+    const ref = 'opengateway/anthropic/claude-opus-4-8'
+    const parsed = configSchema.parse({ models: { default: ref } })
+    const model = resolveModel(parsed.models.default.refs[0]!)
+
+    expect(model).toMatchObject({
+      id: 'anthropic/claude-opus-4-8',
+      provider: 'opengateway',
+      api: 'openai-completions',
+      baseUrl: 'https://apis.opengateway.ai/v1',
+      contextWindow: 400000,
+      maxTokens: 128000,
+    })
+    expect(model.compat).toEqual(KNOWN_PROVIDERS.opengateway.models['openai/gpt-5.4-nano'].compat)
   })
 
   test('uses customModels metadata when synthesizing a custom model', async () => {

--- a/src/config/providers.test.ts
+++ b/src/config/providers.test.ts
@@ -341,19 +341,12 @@ describe('KNOWN_PROVIDERS', () => {
     expect(supportsOAuth(opengateway)).toBe(false)
   })
 
-  test('every opengateway model uses the openai-completions api', () => {
-    // The gateway advertises a `responses` endpoint for some models, but this
-    // repo only wires its verified chat-completions surface; a second transport
-    // would be a separate provider id per the granularity rule.
-    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
-      expect(model.api, `opengateway/${modelId} api drift`).toBe('openai-completions')
-    }
+  test('opengateway static floor is exactly one offline anchor', () => {
+    expect(Object.keys(KNOWN_PROVIDERS.opengateway.models)).toEqual(['openai/gpt-5.4-nano'])
   })
 
-  test('every opengateway model id is creator-qualified, as the gateway requires', () => {
-    for (const modelId of Object.keys(KNOWN_PROVIDERS.opengateway.models)) {
-      expect(modelId, `opengateway/${modelId} is missing its creator namespace`).toMatch(/^[a-z0-9-]+\/.+/)
-    }
+  test('opengateway anchor is creator-qualified', () => {
+    expect(Object.keys(KNOWN_PROVIDERS.opengateway.models)[0]).toMatch(/^[a-z0-9-]+\/.+/)
   })
 
   test('opengateway model refs round-trip through providerForModelRef despite the second slash', () => {
@@ -364,23 +357,20 @@ describe('KNOWN_PROVIDERS', () => {
     }
   })
 
-  test('every opengateway model pins compat, since pi-ai cannot auto-detect the gateway host', () => {
+  test('opengateway anchor pins the gateway transport and compat', () => {
     // Without this, pi-ai's baseUrl sniffing treats apis.opengateway.ai as a
     // first-party OpenAI endpoint and sends `store`, the `developer` role,
     // `strict` tool schemas, and max_completion_tokens through to Anthropic and
     // Moonshot upstreams.
-    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
-      const compat = (model as { compat?: Record<string, unknown> }).compat
-      expect(compat, `opengateway/${modelId} missing compat`).toBeDefined()
-      expect(compat!.supportsStore, `opengateway/${modelId} must not send store`).toBe(false)
-      expect(compat!.supportsDeveloperRole, `opengateway/${modelId} must not use the developer role`).toBe(false)
-      expect(compat!.supportsReasoningEffort, `opengateway/${modelId} must not send reasoning_effort`).toBe(false)
-      expect(compat!.supportsStrictMode, `opengateway/${modelId} must not send strict on tool defs`).toBe(false)
-      expect(compat!.maxTokensField, `opengateway/${modelId} must send max_tokens`).toBe('max_tokens')
-      // Left unset on purpose: pi-ai defaults it true and `typeclaw usage`
-      // needs streamed usage to attribute tokens.
-      expect(compat!.supportsUsageInStreaming, `opengateway/${modelId} must not pin streaming usage`).toBeUndefined()
-    }
+    const anchor = KNOWN_PROVIDERS.opengateway.models['openai/gpt-5.4-nano']
+    const compat = anchor.compat as Record<string, unknown>
+    expect(anchor.api).toBe('openai-completions')
+    expect(compat.supportsStore).toBe(false)
+    expect(compat.supportsDeveloperRole).toBe(false)
+    expect(compat.supportsReasoningEffort).toBe(false)
+    expect(compat.supportsStrictMode).toBe(false)
+    expect(compat.maxTokensField).toBe('max_tokens')
+    expect(compat.supportsUsageInStreaming).toBeUndefined()
   })
 
   test('no opengateway model declares a thinkingLevelMap', () => {
@@ -394,54 +384,13 @@ describe('KNOWN_PROVIDERS', () => {
     }
   })
 
-  // OpenGateway publishes no pricing, so each curated entry copies the rate card
-  // of the sibling registry entry for the same underlying model. This pins that
-  // relationship: if the upstream entry is repriced, the gateway copy must move
-  // with it or this fails.
-  const OPENGATEWAY_UPSTREAM_SOURCE: Record<string, [KnownProviderId, string]> = {
-    'openai/gpt-5.4-nano': ['openai', 'gpt-5.4-nano'],
-    'openai/gpt-5.5': ['openai', 'gpt-5.5'],
-    'anthropic/claude-sonnet-5': ['anthropic', 'claude-sonnet-5'],
-    'anthropic/claude-opus-4-8': ['anthropic', 'claude-opus-4-8'],
-    'moonshotai/kimi-k2.6': ['moonshot', 'kimi-k2.6'],
-    'minimax/MiniMax-M3': ['minimax', 'MiniMax-M3'],
-  }
-
-  test('every opengateway model declares an upstream pricing source', () => {
-    expect(Object.keys(KNOWN_PROVIDERS.opengateway.models).sort()).toEqual(
-      Object.keys(OPENGATEWAY_UPSTREAM_SOURCE).sort(),
-    )
-  })
-
-  test('opengateway cost and limits mirror the native registry entry for the same model', () => {
-    type PricedModel = {
-      cost: Record<string, number>
-      contextWindow: number
-      maxTokens: number
-      input: ReadonlyArray<string>
-      reasoning?: boolean
-    }
-    const gatewayModels = KNOWN_PROVIDERS.opengateway.models as Record<string, PricedModel>
-    for (const [modelId, [upstreamProviderId, upstreamModelId]] of Object.entries(OPENGATEWAY_UPSTREAM_SOURCE)) {
-      const gateway = gatewayModels[modelId]!
-      const upstream = (KNOWN_PROVIDERS[upstreamProviderId].models as Record<string, PricedModel>)[upstreamModelId]
-      expect(upstream, `${upstreamProviderId}/${upstreamModelId} vanished`).toBeDefined()
-      expect(gateway.cost, `opengateway/${modelId} cost drifted from ${upstreamProviderId}/${upstreamModelId}`).toEqual(
-        upstream!.cost,
-      )
-      expect(gateway.contextWindow, `opengateway/${modelId} contextWindow drift`).toBe(upstream!.contextWindow)
-      expect(gateway.maxTokens, `opengateway/${modelId} maxTokens drift`).toBe(upstream!.maxTokens)
-      expect([...gateway.input], `opengateway/${modelId} input drift`).toEqual([...upstream!.input])
-      expect(gateway.reasoning, `opengateway/${modelId} reasoning drift`).toBe(upstream!.reasoning ?? false)
-    }
-  })
-
-  test('opengateway costs are non-zero, because the gateway is metered not flat-rate', () => {
-    for (const [modelId, model] of Object.entries(KNOWN_PROVIDERS.opengateway.models)) {
-      const cost = model.cost as { input: number; output: number }
-      expect(cost.input, `opengateway/${modelId} input cost must not be zeroed`).toBeGreaterThan(0)
-      expect(cost.output, `opengateway/${modelId} output cost must not be zeroed`).toBeGreaterThan(0)
-    }
+  test('opengateway anchor cost matches the documented offline snapshot', () => {
+    expect(KNOWN_PROVIDERS.opengateway.models['openai/gpt-5.4-nano'].cost).toEqual({
+      input: 0.2,
+      output: 1.25,
+      cacheRead: 0.02,
+      cacheWrite: 0,
+    })
   })
 })
 

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1077,7 +1077,7 @@ export const KNOWN_PROVIDERS = {
   // defaults it true) — turning it off would break token and cost reporting.
   opengateway: {
     id: 'opengateway',
-    name: 'OpenGateway.ai',
+    name: 'OpenGateway',
     baseUrl: 'https://apis.opengateway.ai/v1',
     auth: ['api-key'],
     apiKeyEnv: 'OPENGATEWAY_API_KEY',
@@ -1299,7 +1299,7 @@ export const KNOWN_PROVIDER_VENDORS = {
   // Anthropic should land on the Anthropic row, not the gateway that proxies it.
   opengateway: {
     id: 'opengateway',
-    name: 'OpenGateway.ai (multi-vendor gateway)',
+    name: 'OpenGateway',
     providers: ['opengateway'],
   },
 } as const satisfies Record<string, KnownProviderVendor>

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1048,25 +1048,13 @@ export const KNOWN_PROVIDERS = {
   // `providerForModelRef()` matches on the registered provider prefix, the same
   // mechanism that already handles the slash-heavy Fireworks router ids.
   //
-  // Curation rule (why only six of the ~56 live chat models): every curated
-  // entry mirrors a model THIS registry already prices natively, so the numbers
-  // below are copied from a sibling entry rather than invented. Models with no
-  // in-repo price (google/*, qwen/*) and models whose native reasoning contract
-  // is NOT plain OpenAI `reasoning_effort` (deepseek's `thinking:{type}`,
-  // z-ai/qwen's `enable_thinking`) are deliberately left out: pi-ai picks
-  // thinkingFormat from the baseUrl, and `apis.opengateway.ai` resolves to
-  // "openai", so routing those here would silently send the wrong reasoning
-  // field. They all remain reachable as custom `opengateway/...` refs — curation
-  // only drives the picker, JSON-schema enum, and autocomplete.
-  //
-  // Costs are UPSTREAM LIST PRICES in USD per 1M tokens, pinned to the sibling
-  // entry by a guard test in providers.test.ts. OpenGateway bills upstream usage
-  // plus a platform fee and exposes no pricing in /v1/models, so `typeclaw usage`
-  // is an estimate that reads LOW against the real invoice. Do NOT "fix" these
-  // to zero: zero means "no attributable per-token charge" in this registry
-  // (flat-subscription products like the Fireworks Fire Pass router), and
-  // OpenGateway is metered. Replace with gateway-billed rates only if
-  // OpenGateway ever publishes them.
+  // The live picker gets ids and modalities from OpenGateway's public catalog,
+  // then best-effort joins its rate card. This registry intentionally keeps one
+  // anchor only: `resolveModel()` uses `Object.keys(provider.models)[0]` as the
+  // transport/limits template for every uncurated ref, so entries 2..N buy
+  // nothing. An empty map would make custom refs throw, making one the true
+  // floor. Nano is the cheapest conservative context/limit donor and keeps
+  // `curatedOptions()` useful as the offline fallback.
   //
   // Every model carries an explicit `compat` for the same reason Upstage does:
   // pi-ai auto-detects compatibility from the baseUrl, and `apis.opengateway.ai`
@@ -1083,7 +1071,6 @@ export const KNOWN_PROVIDERS = {
     apiKeyEnv: 'OPENGATEWAY_API_KEY',
     oauthProviderId: null,
     models: {
-      // Mirrors openai/gpt-5.4-nano.
       'openai/gpt-5.4-nano': {
         id: 'openai/gpt-5.4-nano',
         name: 'GPT-5.4 nano',
@@ -1099,112 +1086,14 @@ export const KNOWN_PROVIDERS = {
           maxTokensField: 'max_tokens',
         },
         input: ['text', 'image'],
+        // Offline snapshot of OpenGateway's published rate for this model, NOT
+        // the upstream OpenAI list price. Every other model is priced live from
+        // the rate card, so this is the one number that can go stale; it is the
+        // fallback used when the card is unreachable. Re-check it against
+        // https://opengateway.ai/api/model-prices if you touch it.
         cost: { input: 0.2, output: 1.25, cacheRead: 0.02, cacheWrite: 0 },
         contextWindow: 400000,
         maxTokens: 128000,
-      },
-      // Mirrors openai/gpt-5.5.
-      'openai/gpt-5.5': {
-        id: 'openai/gpt-5.5',
-        name: 'GPT-5.5',
-        api: 'openai-completions',
-        provider: 'opengateway',
-        baseUrl: 'https://apis.opengateway.ai/v1',
-        reasoning: true,
-        compat: {
-          supportsStore: false,
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          supportsStrictMode: false,
-          maxTokensField: 'max_tokens',
-        },
-        input: ['text', 'image'],
-        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
-        contextWindow: 1050000,
-        maxTokens: 128000,
-      },
-      // Mirrors anthropic/claude-sonnet-5. Note the transport differs from the
-      // native entry: Anthropic is `anthropic-messages` first-party, but the
-      // gateway only speaks OpenAI chat-completions.
-      'anthropic/claude-sonnet-5': {
-        id: 'anthropic/claude-sonnet-5',
-        name: 'Claude Sonnet 5',
-        api: 'openai-completions',
-        provider: 'opengateway',
-        baseUrl: 'https://apis.opengateway.ai/v1',
-        reasoning: true,
-        compat: {
-          supportsStore: false,
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          supportsStrictMode: false,
-          maxTokensField: 'max_tokens',
-        },
-        input: ['text', 'image'],
-        cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-        contextWindow: 1000000,
-        maxTokens: 128000,
-      },
-      // Mirrors anthropic/claude-opus-4-8.
-      'anthropic/claude-opus-4-8': {
-        id: 'anthropic/claude-opus-4-8',
-        name: 'Claude Opus 4.8',
-        api: 'openai-completions',
-        provider: 'opengateway',
-        baseUrl: 'https://apis.opengateway.ai/v1',
-        reasoning: true,
-        compat: {
-          supportsStore: false,
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          supportsStrictMode: false,
-          maxTokensField: 'max_tokens',
-        },
-        input: ['text', 'image'],
-        cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-        contextWindow: 1000000,
-        maxTokens: 128000,
-      },
-      // Mirrors moonshot/kimi-k2.6. The gateway namespaces Moonshot as
-      // `moonshotai`, so the id is NOT the native `kimi-k2.6`.
-      'moonshotai/kimi-k2.6': {
-        id: 'moonshotai/kimi-k2.6',
-        name: 'Kimi K2.6',
-        api: 'openai-completions',
-        provider: 'opengateway',
-        baseUrl: 'https://apis.opengateway.ai/v1',
-        reasoning: true,
-        compat: {
-          supportsStore: false,
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          supportsStrictMode: false,
-          maxTokensField: 'max_tokens',
-        },
-        input: ['text', 'image'],
-        cost: { input: 0.6, output: 2.5, cacheRead: 0.15, cacheWrite: 0 },
-        contextWindow: 256000,
-        maxTokens: 64000,
-      },
-      // Mirrors minimax/MiniMax-M3.
-      'minimax/MiniMax-M3': {
-        id: 'minimax/MiniMax-M3',
-        name: 'MiniMax M3',
-        api: 'openai-completions',
-        provider: 'opengateway',
-        baseUrl: 'https://apis.opengateway.ai/v1',
-        reasoning: true,
-        compat: {
-          supportsStore: false,
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          supportsStrictMode: false,
-          maxTokensField: 'max_tokens',
-        },
-        input: ['text', 'image'],
-        cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 524288,
       },
     },
   },

--- a/src/init/models-dev.test.ts
+++ b/src/init/models-dev.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, test } from 'bun:test'
 
 import { curatedOptions, fetchModelOptions } from './models-dev'
 
+const MODELS_DEV_URL = 'https://models.dev/api.json'
+const OPENGATEWAY_CATALOG_URL = 'https://apis.opengateway.ai/v1/models'
+const OPENGATEWAY_PRICES_URL = 'https://opengateway.ai/api/model-prices'
+
+function routedFetch(routes: Record<string, unknown | Error>): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input)
+    const value = routes[url]
+    if (value === undefined) throw new Error(`unexpected URL: ${url}`)
+    if (value instanceof Error) throw value
+    return new Response(JSON.stringify(value), { status: 200, headers: { 'content-type': 'application/json' } })
+  }) as unknown as typeof fetch
+}
+
 describe('curatedOptions', () => {
   test('returns one entry per (provider, model) pair in KNOWN_PROVIDERS', () => {
     const options = curatedOptions()
@@ -134,5 +148,105 @@ describe('fetchModelOptions', () => {
     expect(opengateway.length).toBeGreaterThan(0)
     expect(opengateway.every((o) => o.curated)).toBe(true)
     expect(opengateway.every((o) => o.modelId.includes('/'))).toBe(true)
+  })
+
+  test('models.dev failure does not suppress live OpenGateway models', async () => {
+    const fetchImpl = routedFetch({
+      [MODELS_DEV_URL]: new Error('models.dev down'),
+      [OPENGATEWAY_CATALOG_URL]: {
+        data: [
+          {
+            id: 'anthropic/claude-sonnet-5',
+            owned_by: 'anthropic',
+            status: 'active',
+            modalities: { input: ['text'], output: ['text'] },
+            endpoints: ['chat_completions'],
+          },
+        ],
+      },
+      [OPENGATEWAY_PRICES_URL]: {
+        'anthropic/claude-sonnet-5': { inputCostPerToken: 0.000003, outputCostPerToken: 0.000015 },
+      },
+    })
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.sources).toEqual({ modelsDev: 'unavailable', openGatewayCatalog: 'live', openGatewayPrices: 'live' })
+    expect(result.options).toContainEqual(
+      expect.objectContaining({
+        ref: 'opengateway/anthropic/claude-sonnet-5',
+        curated: false,
+        modelName: 'Claude Sonnet 5',
+        reasoning: true,
+        supportsVision: false,
+        contextWindow: 1000000,
+        maxTokens: 128000,
+        cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+      }),
+    )
+  })
+
+  test('maps gateway creator namespaces onto native provider ids when enriching limits', async () => {
+    // The gateway says `x-ai`/`moonshotai` where this registry says `xai`/`moonshot`.
+    // Neither OpenGateway endpoint publishes a context window, so a missed alias
+    // silently drops limits instead of failing loudly.
+    const fetchImpl = routedFetch({
+      [MODELS_DEV_URL]: new Error('models.dev down'),
+      [OPENGATEWAY_CATALOG_URL]: {
+        data: [
+          {
+            id: 'x-ai/grok-4.3',
+            owned_by: 'x-ai',
+            status: 'active',
+            modalities: { input: ['text'], output: ['text'] },
+            endpoints: ['chat_completions'],
+          },
+          {
+            id: 'moonshotai/kimi-k2.6',
+            owned_by: 'moonshotai',
+            status: 'active',
+            modalities: { input: ['text'], output: ['text'] },
+            endpoints: ['chat_completions'],
+          },
+        ],
+      },
+      [OPENGATEWAY_PRICES_URL]: {},
+    })
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    const grok = result.options.find((o) => o.ref === 'opengateway/x-ai/grok-4.3')
+    expect(grok?.modelName).toBe('Grok 4.3')
+    expect(grok?.contextWindow).toBe(1000000)
+    const kimi = result.options.find((o) => o.ref === 'opengateway/moonshotai/kimi-k2.6')
+    expect(kimi?.modelName).toBe('Kimi K2.6')
+    expect(kimi?.contextWindow).toBe(256000)
+  })
+
+  test('OpenGateway failure does not suppress models.dev models', async () => {
+    const fetchImpl = routedFetch({
+      [MODELS_DEV_URL]: {
+        openai: {
+          models: {
+            'gpt-live': {
+              id: 'gpt-live',
+              name: 'GPT Live',
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      },
+      [OPENGATEWAY_CATALOG_URL]: new Error('gateway catalog down'),
+      [OPENGATEWAY_PRICES_URL]: new Error('gateway prices down'),
+    })
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.sources).toEqual({
+      modelsDev: 'live',
+      openGatewayCatalog: 'unavailable',
+      openGatewayPrices: 'unavailable',
+    })
+    expect(result.options).toContainEqual(expect.objectContaining({ ref: 'openai/gpt-live', curated: false }))
   })
 })

--- a/src/init/models-dev.test.ts
+++ b/src/init/models-dev.test.ts
@@ -186,6 +186,22 @@ describe('fetchModelOptions', () => {
     )
   })
 
+  test('survives a well-formed models.dev envelope carrying a malformed nested model', async () => {
+    // Only the root is shape-checked on fetch, so a valid envelope can still
+    // smuggle a null model. This used to escape the fallback and crash the
+    // whole wizard rather than degrading to the curated list.
+    const fetchImpl = routedFetch({
+      [MODELS_DEV_URL]: { openai: { models: { broken: null } } },
+      [OPENGATEWAY_CATALOG_URL]: new Error('gateway catalog down'),
+      [OPENGATEWAY_PRICES_URL]: new Error('gateway prices down'),
+    })
+
+    const result = await fetchModelOptions({ fetchImpl })
+
+    expect(result.options.length).toBeGreaterThan(0)
+    expect(result.options.some((o) => o.ref === 'opengateway/openai/gpt-5.4-nano')).toBe(true)
+  })
+
   test('maps gateway creator namespaces onto native provider ids when enriching limits', async () => {
     // The gateway says `x-ai`/`moonshotai` where this registry says `xai`/`moonshot`.
     // Neither OpenGateway endpoint publishes a context window, so a missed alias

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -9,6 +9,8 @@ import {
   type ModelRef,
 } from '@/config/providers'
 
+import { fetchOpenGatewayCatalog, type OpenGatewayModel } from './opengateway-catalog'
+
 const MODELS_DEV_URL = 'https://models.dev/api.json'
 const REQUEST_TIMEOUT_MS = 10_000
 
@@ -113,12 +115,17 @@ type ModelsDevProvider = {
 export type FetchModelsResult = {
   options: ModelOption[]
   source: 'models.dev' | 'curated'
+  sources: {
+    modelsDev: 'live' | 'unavailable'
+    openGatewayCatalog: 'live' | 'unavailable'
+    openGatewayPrices: 'live' | 'unavailable'
+  }
+  warnings: string[]
   warning?: string
 }
 
-// Pulls the live model catalog from models.dev, intersects it with our
-// curated KNOWN_PROVIDERS allowlist, and returns one ModelOption per
-// (provider, model) pair the user is allowed to pick at init time.
+// Pulls live catalogs from models.dev and OpenGateway, keeps every curated
+// entry, and appends non-curated models whose provider refs TypeClaw can route.
 //
 // Falls back to the curated list alone if the network is unreachable, the
 // response is malformed, or any unexpected error fires — the wizard MUST
@@ -129,16 +136,43 @@ export async function fetchModelOptions(
 ): Promise<FetchModelsResult> {
   const fetchImpl = options.fetchImpl ?? fetch
   const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS
+  const [modelsDev, openGateway] = await Promise.all([
+    fetchModelsDev(fetchImpl, timeoutMs),
+    fetchOpenGatewayCatalog({ fetchImpl, timeoutMs }),
+  ])
+  const baseOptions = modelsDev.status === 'live' ? mergeWithCurated(modelsDev.data) : curatedOptions()
+  const mergedOptions = mergeOpenGateway(baseOptions, openGateway.models)
+  const warnings = [...(modelsDev.status === 'unavailable' ? [modelsDev.warning] : []), ...openGateway.warnings]
+  const warning = warnings.length > 0 ? warnings.join('; ') : undefined
+  return {
+    options: mergedOptions,
+    source: modelsDev.status === 'live' ? 'models.dev' : 'curated',
+    sources: {
+      modelsDev: modelsDev.status,
+      openGatewayCatalog: openGateway.catalog,
+      openGatewayPrices: openGateway.prices,
+    },
+    warnings,
+    ...(warning !== undefined ? { warning } : {}),
+  }
+}
+
+type ModelsDevResult =
+  | { status: 'live'; data: Record<string, ModelsDevProvider> }
+  | { status: 'unavailable'; warning: string }
+
+async function fetchModelsDev(fetchImpl: typeof fetch, timeoutMs: number): Promise<ModelsDevResult> {
   try {
     const res = await fetchImpl(MODELS_DEV_URL, { signal: AbortSignal.timeout(timeoutMs) })
     if (!res.ok) {
-      return { options: curatedOptions(), source: 'curated', warning: `models.dev returned ${res.status}` }
+      return { status: 'unavailable', warning: `models.dev returned ${res.status}` }
     }
-    const data = (await res.json()) as Record<string, ModelsDevProvider>
-    return { options: mergeWithCurated(data), source: 'models.dev' }
+    const data: unknown = await res.json()
+    if (!isRecord(data)) return { status: 'unavailable', warning: 'models.dev returned malformed JSON' }
+    return { status: 'live', data: data as Record<string, ModelsDevProvider> }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
-    return { options: curatedOptions(), source: 'curated', warning: reason }
+    return { status: 'unavailable', warning: reason }
   }
 }
 
@@ -195,6 +229,59 @@ function mergeWithCurated(data: Record<string, ModelsDevProvider>): ModelOption[
   return out
 }
 
+function mergeOpenGateway(options: ModelOption[], models: OpenGatewayModel[]): ModelOption[] {
+  const out = [...options]
+  const seen = new Set(options.map((option) => option.ref))
+  for (const model of models) {
+    const ref = `opengateway/${model.id}`
+    if (seen.has(ref) || !isModelRef(ref)) continue
+    const sibling = nativeSiblingFor(model)
+    out.push({
+      ref,
+      providerId: 'opengateway',
+      providerName: KNOWN_PROVIDERS.opengateway.name,
+      modelId: model.id,
+      modelName: sibling?.name ?? model.id,
+      reasoning: sibling?.reasoning ?? false,
+      contextWindow: sibling?.contextWindow ?? null,
+      maxTokens: sibling?.maxTokens ?? null,
+      cost: model.cost,
+      curated: false,
+      supportsVision: model.input.includes('image'),
+    })
+    seen.add(ref)
+  }
+  return out
+}
+
+type NativeSibling = {
+  name: string
+  reasoning?: boolean
+  contextWindow?: number
+  maxTokens?: number
+}
+
+function nativeSiblingFor(model: OpenGatewayModel): NativeSibling | undefined {
+  const slash = model.id.indexOf('/')
+  if (slash === -1) return undefined
+  const creator = model.id.slice(0, slash)
+  const modelId = model.id.slice(slash + 1)
+  const providerId = nativeProviderId(model.ownedBy) ?? nativeProviderId(creator)
+  if (providerId === undefined) return undefined
+  return (KNOWN_PROVIDERS[providerId].models as Record<string, NativeSibling>)[modelId]
+}
+
+// The gateway namespaces some creators differently from this registry's
+// provider ids (`moonshotai` vs `moonshot`, `x-ai` vs `xai`, `z-ai` vs `zai`).
+// Without the alias the sibling lookup misses and the model loses its
+// contextWindow/maxTokens, which neither OpenGateway endpoint publishes.
+function nativeProviderId(value: string): KnownProviderId | undefined {
+  const aliases: Record<string, KnownProviderId> = { moonshotai: 'moonshot', 'x-ai': 'xai', 'z-ai': 'zai' }
+  const candidate = aliases[value] ?? value
+  if (!(candidate in KNOWN_PROVIDERS) || candidate === 'opengateway') return undefined
+  return candidate as KnownProviderId
+}
+
 type BuildOptionOpts = {
   curated: boolean
   upstream?: ModelsDevModel
@@ -249,4 +336,8 @@ function resolveCost(cost: ModelsDevModel['cost']): ModelOptionCost | null {
     cacheRead: cost.cacheRead ?? cost.cache_read ?? 0,
     cacheWrite: cost.cacheWrite ?? cost.cache_write ?? 0,
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/src/init/models-dev.ts
+++ b/src/init/models-dev.ts
@@ -140,9 +140,24 @@ export async function fetchModelOptions(
     fetchModelsDev(fetchImpl, timeoutMs),
     fetchOpenGatewayCatalog({ fetchImpl, timeoutMs }),
   ])
-  const baseOptions = modelsDev.status === 'live' ? mergeWithCurated(modelsDev.data) : curatedOptions()
+  // Composition is inside the guard because only the models.dev ROOT is shape-
+  // checked on fetch: a well-formed envelope can still carry a malformed nested
+  // model, and this function's contract is that `typeclaw init` keeps working
+  // on a fresh machine no matter what the network returns.
+  let baseOptions: ModelOption[]
+  let compositionWarning: string | undefined
+  try {
+    baseOptions = modelsDev.status === 'live' ? mergeWithCurated(modelsDev.data) : curatedOptions()
+  } catch (error) {
+    baseOptions = curatedOptions()
+    compositionWarning = `models.dev returned unusable data (${error instanceof Error ? error.message : String(error)})`
+  }
   const mergedOptions = mergeOpenGateway(baseOptions, openGateway.models)
-  const warnings = [...(modelsDev.status === 'unavailable' ? [modelsDev.warning] : []), ...openGateway.warnings]
+  const warnings = [
+    ...(modelsDev.status === 'unavailable' ? [modelsDev.warning] : []),
+    ...(compositionWarning !== undefined ? [compositionWarning] : []),
+    ...openGateway.warnings,
+  ]
   const warning = warnings.length > 0 ? warnings.join('; ') : undefined
   return {
     options: mergedOptions,
@@ -218,6 +233,7 @@ function mergeWithCurated(data: Record<string, ModelsDevProvider>): ModelOption[
     const upstream = upstreamProviderFor(data, providerId)
     const upstreamModels = upstream?.models ?? {}
     for (const [fallbackModelId, upstreamModel] of Object.entries(upstreamModels)) {
+      if (!isRecord(upstreamModel)) continue
       const modelId = upstreamModel.id ?? fallbackModelId
       if (modelId.trim().length === 0) continue
       const ref = `${providerId}/${modelId}`

--- a/src/init/opengateway-catalog.test.ts
+++ b/src/init/opengateway-catalog.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test'
+
+import { fetchOpenGatewayCatalog } from './opengateway-catalog'
+
+const CATALOG_URL = 'https://apis.opengateway.ai/v1/models'
+const PRICES_URL = 'https://opengateway.ai/api/model-prices'
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function fixtureFetch(fixtures: { catalog: Response | Error; prices: Response | Error }): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input)
+    const fixture = url === CATALOG_URL ? fixtures.catalog : url === PRICES_URL ? fixtures.prices : undefined
+    if (fixture === undefined) throw new Error(`unexpected URL: ${url}`)
+    if (fixture instanceof Error) throw fixture
+    return fixture
+  }) as unknown as typeof fetch
+}
+
+function catalogEntry(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    object: 'model',
+    owned_by: id.split('/')[0],
+    status: 'active',
+    modalities: { input: ['text', 'image'], output: ['text'] },
+    endpoints: ['chat_completions'],
+    ...overrides,
+  }
+}
+
+describe('fetchOpenGatewayCatalog', () => {
+  test('keeps only active text-output chat-completions models', async () => {
+    const catalog = {
+      object: 'list',
+      data: [
+        catalogEntry('openai/active'),
+        catalogEntry('openai/deprecated', { status: 'deprecated' }),
+        catalogEntry('openai/retired', { status: 'retired' }),
+        catalogEntry('openai/responses-only', { endpoints: ['responses'] }),
+        catalogEntry('openai/images-only', {
+          modalities: { input: ['text'], output: ['image'] },
+          endpoints: ['images_generations'],
+        }),
+      ],
+    }
+
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({ catalog: jsonResponse(catalog), prices: jsonResponse({}) }),
+    })
+
+    expect(result.models.map((model) => model.id)).toEqual(['openai/active'])
+    expect(result.models[0]?.input).toEqual(['text', 'image'])
+    expect(result.catalog).toBe('live')
+  })
+
+  test('converts exact-id price matches from per-token to per-million-token units', async () => {
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({
+        catalog: jsonResponse({ data: [catalogEntry('anthropic/claude-test')] }),
+        prices: jsonResponse({
+          'anthropic/claude-test': {
+            inputCostPerToken: 0.000002,
+            outputCostPerToken: 0.00001,
+            cacheReadInputTokenCost: 0.0000002,
+            cacheCreationInputTokenCost: 0.0000025,
+          },
+        }),
+      }),
+    })
+
+    expect(result.models[0]?.cost).toEqual({ input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 })
+    expect(result.prices).toBe('live')
+  })
+
+  test('uses null cost when a catalog model has no exact price match', async () => {
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({
+        catalog: jsonResponse({ data: [catalogEntry('openai/unpriced')] }),
+        prices: jsonResponse({}),
+      }),
+    })
+
+    expect(result.models[0]?.cost).toBeNull()
+  })
+
+  test('never invents a model that exists only in the price table', async () => {
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({
+        catalog: jsonResponse({ data: [catalogEntry('openai/catalog-model')] }),
+        prices: jsonResponse({
+          'openai/price-only': { inputCostPerToken: 1, outputCostPerToken: 1 },
+        }),
+      }),
+    })
+
+    expect(result.models.map((model) => model.id)).toEqual(['openai/catalog-model'])
+  })
+
+  test('degrades malformed JSON without throwing', async () => {
+    const malformed = new Response('{', { status: 200 })
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({ catalog: malformed, prices: jsonResponse([]) }),
+    })
+
+    expect(result).toMatchObject({ models: [], catalog: 'unavailable', prices: 'unavailable' })
+    expect(result.warnings).toHaveLength(2)
+  })
+
+  test('reports live prices when the catalog fails', async () => {
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({ catalog: new Error('catalog down'), prices: jsonResponse({}) }),
+    })
+
+    expect(result).toMatchObject({ models: [], catalog: 'unavailable', prices: 'live' })
+    expect(result.warnings.join(' ')).toContain('catalog down')
+  })
+
+  test('still returns catalog models with null cost when prices fail', async () => {
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({
+        catalog: jsonResponse({ data: [catalogEntry('openai/available')] }),
+        prices: new Error('prices down'),
+      }),
+    })
+
+    expect(result.models).toHaveLength(1)
+    expect(result.models[0]?.cost).toBeNull()
+    expect(result).toMatchObject({ catalog: 'live', prices: 'unavailable' })
+  })
+
+  test('reports both sources unavailable when both requests fail', async () => {
+    const result = await fetchOpenGatewayCatalog({
+      fetchImpl: fixtureFetch({ catalog: new Error('catalog down'), prices: new Error('prices down') }),
+    })
+
+    expect(result).toMatchObject({ models: [], catalog: 'unavailable', prices: 'unavailable' })
+    expect(result.warnings).toHaveLength(2)
+  })
+})

--- a/src/init/opengateway-catalog.ts
+++ b/src/init/opengateway-catalog.ts
@@ -1,0 +1,120 @@
+import type { ModelOptionCost } from './models-dev'
+
+const CATALOG_URL = 'https://apis.opengateway.ai/v1/models'
+const PRICES_URL = 'https://opengateway.ai/api/model-prices'
+const REQUEST_TIMEOUT_MS = 10_000
+const PER_MILLION = 1_000_000
+
+export type OpenGatewayModel = {
+  id: string
+  ownedBy: string
+  input: string[]
+  cost: ModelOptionCost | null
+}
+
+export type OpenGatewayCatalogResult = {
+  models: OpenGatewayModel[]
+  catalog: 'live' | 'unavailable'
+  prices: 'live' | 'unavailable'
+  warnings: string[]
+}
+
+type SourceResult<T> = { status: 'live'; value: T } | { status: 'unavailable'; warning: string }
+
+export async function fetchOpenGatewayCatalog(
+  options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<OpenGatewayCatalogResult> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS
+  const [catalogResult, pricesResult] = await Promise.all([
+    fetchCatalog(fetchImpl, timeoutMs),
+    fetchPrices(fetchImpl, timeoutMs),
+  ])
+  const warnings = [
+    ...(catalogResult.status === 'unavailable' ? [catalogResult.warning] : []),
+    ...(pricesResult.status === 'unavailable' ? [pricesResult.warning] : []),
+  ]
+  const prices = pricesResult.status === 'live' ? pricesResult.value : {}
+  const models =
+    catalogResult.status === 'live'
+      ? catalogResult.value.map((model) => ({ ...model, cost: costForModel(prices[model.id]) }))
+      : []
+
+  return {
+    models,
+    catalog: catalogResult.status,
+    prices: pricesResult.status,
+    warnings,
+  }
+}
+
+async function fetchCatalog(fetchImpl: typeof fetch, timeoutMs: number): Promise<SourceResult<OpenGatewayModel[]>> {
+  try {
+    const response = await fetchImpl(CATALOG_URL, { signal: AbortSignal.timeout(timeoutMs) })
+    if (!response.ok) return unavailable('catalog', `returned ${response.status}`)
+    const value: unknown = await response.json()
+    if (!isRecord(value) || !Array.isArray(value.data)) return unavailable('catalog', 'returned malformed JSON')
+    return { status: 'live', value: value.data.flatMap(parseCatalogModel) }
+  } catch (error) {
+    return unavailable('catalog', reasonFrom(error))
+  }
+}
+
+async function fetchPrices(fetchImpl: typeof fetch, timeoutMs: number): Promise<SourceResult<Record<string, unknown>>> {
+  try {
+    const response = await fetchImpl(PRICES_URL, { signal: AbortSignal.timeout(timeoutMs) })
+    if (!response.ok) return unavailable('prices', `returned ${response.status}`)
+    const value: unknown = await response.json()
+    if (!isRecord(value)) return unavailable('prices', 'returned malformed JSON')
+    return { status: 'live', value }
+  } catch (error) {
+    return unavailable('prices', reasonFrom(error))
+  }
+}
+
+function parseCatalogModel(value: unknown): OpenGatewayModel[] {
+  if (!isRecord(value)) return []
+  if (typeof value.id !== 'string' || value.id.length === 0) return []
+  if (typeof value.owned_by !== 'string' || value.owned_by.length === 0) return []
+  if (value.status !== 'active') return []
+  if (!isRecord(value.modalities) || !stringArray(value.modalities.output).includes('text')) return []
+  if (!stringArray(value.endpoints).includes('chat_completions')) return []
+  const input = stringArray(value.modalities.input).filter((modality) => modality === 'text' || modality === 'image')
+  return [{ id: value.id, ownedBy: value.owned_by, input, cost: null }]
+}
+
+function costForModel(value: unknown): ModelOptionCost | null {
+  if (!isRecord(value)) return null
+  const input = requiredRate(value.inputCostPerToken)
+  const output = requiredRate(value.outputCostPerToken)
+  const cacheRead = optionalRate(value.cacheReadInputTokenCost)
+  const cacheWrite = optionalRate(value.cacheCreationInputTokenCost)
+  if (input === null || output === null || cacheRead === null || cacheWrite === null) return null
+  return { input, output, cacheRead, cacheWrite }
+}
+
+function requiredRate(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null
+  return Number((value * PER_MILLION).toPrecision(15))
+}
+
+function optionalRate(value: unknown): number | null {
+  if (value === null || value === undefined) return 0
+  return requiredRate(value)
+}
+
+function unavailable<T>(source: 'catalog' | 'prices', reason: string): SourceResult<T> {
+  return { status: 'unavailable', warning: `OpenGateway ${source} ${reason}` }
+}
+
+function reasonFrom(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+}


### PR DESCRIPTION
## Background

Two unrelated defects in the OpenGateway provider entry, both surfaced by reading it next to the gateway's actual API.

**The name carried a description.** `KNOWN_PROVIDERS.opengateway.name` rendered as `OpenGateway.ai` and the vendor entry as `OpenGateway.ai (multi-vendor gateway)`. Both strings surface verbatim in the `provider add` picker, `typeclaw model list`, and missing-credential errors — "Missing credential for OpenGateway.ai (multi-vendor gateway)" reads like a bug, not a provider name. Every other parenthetical in the registry qualifies a product family (`xAI (Grok)`, `Upstage (Solar)`, `Moonshot (Kimi)`); this one described the business model.

**The model list was hardcoded, capped, and mispriced.** The registry pinned 6 models by hand against a live catalog of 56 active chat models. Curation was limited by a rule that a model must already be priced natively in this repo — so every `google/*`, `qwen/*`, and `z-ai/*` model was unreachable from the picker regardless of what the gateway served.

That rule rested on a single claim in the code: OpenGateway "publishes no rate card", so prices had to be borrowed from a sibling entry. **The claim was false.** OpenGateway publishes per-model rates for 462 ids, and three of the six hardcoded prices disagreed with it:

| model | repo billed | gateway actually charges | error |
|---|---|---|---|
| `anthropic/claude-sonnet-5` | 3 / 15 | **2 / 10** | usage **overstated 50%** |
| `moonshotai/kimi-k2.6` | 0.6 / 2.5 | **0.95 / 4** | usage **understated ~37%** |
| `moonshotai/kimi-k2.5` | 0.6 / 2.5 | **0.6 / 3** | output understated 20% |

The old comment claimed the estimate was conservative ("reads LOW against the real invoice"). It was not even that — it erred in both directions.

## Summary

**Name.** Both fields are now plain `OpenGateway`. Not relocated to a picker hint, because that slot is computed auth-mode copy (`API key` / `OAuth only`) from `vendorAuthHint()`, not free text. The provider id, `OPENGATEWAY_API_KEY`, base URL, and the Sionic AI vendor note are untouched.

**Models.** The gateway is now its own source of truth. A new `src/init/opengateway-catalog.ts` reads ids and modalities from `apis.opengateway.ai/v1/models` and joins the published rate card, so the picker shows all 56 active chat models with live prices instead of 6 stale ones — and new gateway models appear without waiting for a TypeClaw release.

Decisions worth reviewing:

- **The static registry keeps exactly one anchor, `openai/gpt-5.4-nano`.** `resolveModel()` uses `Object.keys(models)[0]` as the transport/limits template for every uncurated ref, so entries 2..N were never consulted and bought nothing; an empty map makes custom refs throw, which makes one the true floor. It doubles as the offline fallback for `curatedOptions()`. Its cost is now the only number that can rot, so it is documented as a snapshot of the *gateway* rate — explicitly not an upstream list price — and pinned by a test.
- **Dropping the other five is structurally safe but NOT behaviour-preserving.** The model-ref validator is structural (`isModelRef()` checks provider membership, not curation) and the generated schema emits `anyOf:[enum, string]`, so a pinned `opengateway/anthropic/claude-opus-4-8` still parses and still resolves — it does not throw. But because it was previously a *known* ref it has no `customModels` entry, so it now resolves through the anchor template and loses metadata: `reasoning` true→false, input `[text,image]`→`[text]`, contextWindow 1M→400k, and cost →0. See **Known gaps** below; this is not yet addressed.
- **models.dev stays `null` for opengateway and still may not establish gateway ids.** Its ids are bare (`gpt-5.5`) and would 404 against a gateway requiring `openai/gpt-5.5`; the existing guard test for that is untouched. It may only enrich an id the gateway already proved. Neither gateway endpoint publishes context windows, so those come from a native sibling — which needs a creator-namespace alias (`x-ai`→`xai`, `moonshotai`→`moonshot`, `z-ai`→`zai`). A missing alias silently drops limits rather than failing, so the mapping is tested.
- **The rate card is best-effort, not a dependency.** It lives on the marketing host (`opengateway.ai/api/model-prices`), is undocumented, and is served `no-store` — a different trust level from the official API host. Catalog-up/prices-down still lists every model with `cost: null` rather than a fabricated number, and a price with no matching catalog entry never invents a model.
- **Sources fetch concurrently and fail independently.** models.dev being down no longer suppresses gateway models, or vice versa. Callers get per-source provenance so the CLI reports partial success instead of claiming a total fallback.

## What this does NOT do

- Does not make `supportsReasoningEffort` per-model. The blanket provider-wide `false` is conservative; one endpoint fronts both OpenAI (which takes the parameter) and Anthropic (which does not), and native support does not prove the gateway forwards it. Confirming that needs authenticated request tests.
- Does not change `resolveModel()` precedence for known refs. Letting persisted metadata overlay a curated entry would be a cross-provider behavior change; the single-anchor design makes it unnecessary, since the anchor's static cost matches the live card exactly.
- Does not cache the catalog to disk, or hit the network in any test. Every degradation path runs on fixtures, so CI stays offline-safe.
- Does not change the provider id, env var, base URL, or wire transport.


## Known gaps (found by post-implementation review, not yet fixed)

Filing these openly rather than letting them ride as unstated behaviour:

1. **Pinned refs dropped from the static table silently degrade** (above). A config already pinning one of the five removed refs keeps working but with reasoning off, vision off, a 400k context, and zero cost. Needs either a migration that writes `customModels` metadata for previously-known refs, or a resolution fallback to the native sibling. Blocking for anyone already on those refs.
2. **Unknown price resolves to zero, not unknown.** 12 of the 56 live models publish no rate. `resolveCustomModelCost()` defaults every missing field to `0`, so `typeclaw usage` reports metered models as free. This is pre-existing behaviour for all custom refs, but this PR makes it materially more reachable. Fixing it properly means threading an explicit "unknown" state through resolution and usage accounting.
3. **The anchor never takes live data.** `mergeOpenGateway()` skips a catalog entry whose ref is already present, so `openai/gpt-5.4-nano` always uses its static snapshot even when the catalog is live — and would survive being retired upstream. Its price currently matches the card, so there is no live discrepancy today.

None of these are regressions introduced by the dynamic catalog itself; (2) and (3) are consequences of the static-anchor design and (1) is the cost of shrinking the static table.
## Review notes

- Load-bearing: `openai/gpt-5.4-nano` must remain the first (and only) key in `KNOWN_PROVIDERS.opengateway.models`.
- The new guards are mutation-tested, not merely present: removing the creator-namespace aliases fails the enrichment test, and the static-floor test fails if a second anchor is reintroduced.
- Verified against live endpoints before and after: 56 models surfaced, the three previously-wrong prices now resolve correctly, the anchor matches its snapshot, prices-down yields 56 models with null cost, and catalog-down yields zero models with no orphan prices.
- `typeclaw.schema.json` is a gitignored postinstall artifact; its drift guard required regenerating after the enum shrank, but nothing generated is committed.
- Pre-existing and unrelated: `wrapSystemTool > rejects excess queued snapshot waiters with a deterministic bound` times out on this machine. Verified it fails identically on unmodified `main`.

