### PR TITLE
Restore the agent-messenger CLI in model-driven bash

### DIFF
--- a/src/sandbox/errors.ts
+++ b/src/sandbox/errors.ts
@@ -26,38 +26,6 @@ export class SandboxPolicyError extends Error {
   }
 }
 
-// Raised when model-driven bash invokes an agent-messenger CLI. TypeClaw never
-// brokers those reusable auth profiles (resolvePrivilegedSandboxRuntime) AND
-// masks the whole `workspace/.agent-messenger` directory, so the CLI can never
-// authenticate here — every platform resolves credentials from a
-// `<platform>-credentials.json` file, never from the environment.
-//
-// The refusal MUST announce itself. A silent one lets the uncredentialed CLI
-// print its own "No current workspace set. Run `auth extract` first.", which the
-// model reads as a fact about the WORLD — and it will then tell a human the
-// runtime has no workspace authentication, laundering a local policy decision
-// into a false claim about the upstream service. The CLI is honest about ITS
-// state; it has no way to know it was deliberately deprived.
-//
-// Hence the message states its own provenance: what was withheld, that the
-// decision is local, that retrying cannot help, and which mediated tool does
-// work. The last part is load-bearing — a dead end the model cannot route
-// around produces exactly the confabulation this class exists to prevent.
-export class SandboxCredentialWithheldError extends Error {
-  override readonly name = 'SandboxCredentialWithheldError'
-  constructor(executable: string) {
-    super(
-      `credential withheld by TypeClaw policy: \`${executable}\` cannot authenticate in model-driven bash. ` +
-        'TypeClaw never brokers an agent-messenger auth profile to a model-controlled child (the CLI can upload ' +
-        'arbitrary files, so a brokered credential would make it a confused deputy), and its credential directory ' +
-        'is masked. This is a LOCAL sandbox policy decision. It is NOT evidence that the workspace, account, or ' +
-        'upstream service lacks authentication — do not report it as such. Retrying, running `auth extract`, or ' +
-        'switching package runner will not change it. Use the mediated channel_* tools instead (channel_read, ' +
-        'channel_history, channel_send), which run inside TypeClaw with the configured channel credential.',
-    )
-  }
-}
-
 // Raised when the /proc strategy degraded to the empty `tmpfs` fallback AND the
 // command needs a real /proc (bunx / bun run that reads the
 // kernel-backed /proc/self/{fd,maps}). Without this pre-check Bun aborts deep in

--- a/src/sandbox/privileged-runtime.test.ts
+++ b/src/sandbox/privileged-runtime.test.ts
@@ -94,6 +94,25 @@ describe('resolvePrivilegedSandboxRuntime', () => {
     }
   })
 
+  test('resolves every non-broker executable identically, whether or not the resolver has heard of it', async () => {
+    const brokered = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: {},
+      command: 'totally-unheard-of-cli --flag subcommand',
+    })
+
+    for (const command of [
+      'claude setup-token',
+      'gws auth status',
+      'agent-slack channel list',
+      'agent-browser open https://example.com',
+      'some-future-tool auth status',
+    ]) {
+      expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).toEqual(brokered)
+    }
+  })
+
   test('does not follow a symlinked Codex auth file because Codex profiles are never brokered', async () => {
     await rm(path.join(home, '.codex', 'auth.json'))
     await symlink(path.join(home, '.claude.json'), path.join(home, '.codex', 'auth.json'))

--- a/src/sandbox/privileged-runtime.test.ts
+++ b/src/sandbox/privileged-runtime.test.ts
@@ -1,12 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { buildSandboxedCommand } from './build'
-import { SandboxCredentialWithheldError } from './errors'
 import {
-  AGENT_MESSENGER_BINS,
   cleanupPrivilegedSandboxRuntime,
   resolvePrivilegedSandboxRuntime,
   verifyPrivilegedSandboxRuntime,
@@ -83,87 +81,17 @@ describe('resolvePrivilegedSandboxRuntime', () => {
   })
 
   test('keeps auth diagnostics executable but supplies no credential profile', async () => {
-    for (const command of ['claude setup-token', 'gws auth status']) {
+    for (const command of [
+      'claude setup-token',
+      'gws auth status',
+      'agent-slack auth status',
+      'agent-slack --account test auth status',
+    ]) {
       expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).toEqual({
         env: {},
         mounts: [],
       })
     }
-  })
-
-  test.each([
-    'agent-slack auth status',
-    'agent-slack --account test auth status',
-    'agent-slack channel list',
-    'bunx agent-slackbot message list general',
-  ])('refuses agent-messenger command %s rather than letting it fail as an auth error', async (command) => {
-    await expect(resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).rejects.toBeInstanceOf(
-      SandboxCredentialWithheldError,
-    )
-  })
-
-  test('the agent-messenger refusal disclaims being evidence about upstream authentication', async () => {
-    const thrown = await resolvePrivilegedSandboxRuntime({
-      agentDir,
-      homeDir: home,
-      env: {},
-      command: 'agent-slack message search hello',
-    }).catch((error: unknown) => error)
-
-    expect(thrown).toBeInstanceOf(SandboxCredentialWithheldError)
-    const { message } = thrown as Error
-    expect(message).toContain('LOCAL sandbox policy decision')
-    expect(message).toContain('NOT evidence that the workspace, account, or upstream service lacks authentication')
-    expect(message).toContain('channel_read')
-  })
-
-  test.each([
-    'agent-slack auth status 2>&1',
-    'bun x agent-messenger slack message list general',
-    'bun run agent-slackbot channel list',
-    'npx agent-messenger slack message search hello',
-    'pnpx agent-messenger slack message search hello',
-    'cd /tmp && agent-slack channel list',
-    'amsg slack message list general',
-    'agent-slack channel list | head -5',
-    '/agent/node_modules/.bin/agent-slack channel list',
-    'AGENT_MESSENGER_CONFIG_DIR=/tmp agent-slack channel list',
-  ])('refuses %s, which would otherwise reach the model as an upstream auth error', async (command) => {
-    await expect(resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).rejects.toBeInstanceOf(
-      SandboxCredentialWithheldError,
-    )
-  })
-
-  test('names the actual bin it refused so the message cannot misdescribe the command', async () => {
-    const thrown = await resolvePrivilegedSandboxRuntime({
-      agentDir,
-      homeDir: home,
-      env: {},
-      command: 'bunx amsg slack message list general',
-    }).catch((error: unknown) => error)
-
-    expect((thrown as Error).message).toContain('`amsg`')
-  })
-
-  test.each(['agent-lint --fix src', 'agent-browser open https://example.com'])(
-    'leaves unrelated executable %s runnable rather than claiming it needs agent-messenger credentials',
-    async (command) => {
-      expect(await resolvePrivilegedSandboxRuntime({ agentDir, homeDir: home, env: {}, command })).toEqual({
-        env: {},
-        mounts: [],
-      })
-    },
-  )
-
-  test('agent-browser stays runnable because it holds no agent-messenger credential profile', async () => {
-    expect(
-      await resolvePrivilegedSandboxRuntime({
-        agentDir,
-        homeDir: home,
-        env: {},
-        command: 'agent-browser open https://example.com',
-      }),
-    ).toEqual({ env: {}, mounts: [] })
   })
 
   test('does not follow a symlinked Codex auth file because Codex profiles are never brokered', async () => {
@@ -206,14 +134,13 @@ describe('resolvePrivilegedSandboxRuntime', () => {
     })
     expect(gwsRuntime).toEqual({ env: {}, mounts: [] })
 
-    await expect(
-      resolvePrivilegedSandboxRuntime({
-        agentDir,
-        homeDir: home,
-        env: { AGENT_MESSENGER_CONFIG_DIR: messenger },
-        command: 'agent-slack channel list',
-      }),
-    ).rejects.toBeInstanceOf(SandboxCredentialWithheldError)
+    const messengerRuntime = await resolvePrivilegedSandboxRuntime({
+      agentDir,
+      homeDir: home,
+      env: { AGENT_MESSENGER_CONFIG_DIR: messenger },
+      command: 'agent-slack channel list',
+    })
+    expect(messengerRuntime).toEqual({ env: {}, mounts: [] })
   })
 
   test('does not expose git config to an unknown alias command', async () => {
@@ -307,14 +234,5 @@ describe('resolvePrivilegedSandboxRuntime', () => {
     expect(await Promise.all(generated.map((source) => Bun.file(source).exists()))).toEqual(
       Array.from({ length: generated.length }, () => false),
     )
-  })
-})
-
-describe('agent-messenger bin manifest lockstep', () => {
-  test('the refused bin set matches every bin the installed agent-messenger exposes', async () => {
-    const manifest = path.join(import.meta.dir, '..', '..', 'node_modules', 'agent-messenger', 'package.json')
-    const installed = JSON.parse(await readFile(manifest, 'utf8')) as { bin: Record<string, string> }
-
-    expect([...AGENT_MESSENGER_BINS].sort()).toEqual(Object.keys(installed.bin).sort())
   })
 })

--- a/src/sandbox/privileged-runtime.ts
+++ b/src/sandbox/privileged-runtime.ts
@@ -62,18 +62,13 @@ export async function resolvePrivilegedSandboxRuntime(options: {
   const executable = unwrapBunx(parsed)
   if (executable === null) return runtime
 
-  // These CLIs can print or upload arbitrary files. Supplying their reusable
-  // auth profile to a model-controlled child would therefore make the CLI a
-  // confused deputy even when the outer shell is syntactically standalone.
-  if (
-    executable.executable === 'gws' ||
-    executable.executable === 'codex' ||
-    executable.executable === 'claude' ||
-    executable.executable.startsWith('agent-')
-  ) {
-    return runtime
-  }
-
+  // Credentials are default-deny: only an explicit broker below grants a
+  // profile, and `git` is the only broker. Do not add executable-name checks
+  // here. The confused-deputy argument belongs to the default, not to a list of
+  // names — it holds for every model-controlled child that can print or upload
+  // files, including ones not yet written. A name list is also where beliefs
+  // about a tool's credential layout accumulate; one such belief was wrong and
+  // refused a working CLI family outright. See this file's history.
   if (executable.executable === 'git') {
     runtime.env.GIT_CONFIG_GLOBAL = '/dev/null'
     runtime.env.GIT_CONFIG_NOSYSTEM = '1'

--- a/src/sandbox/privileged-runtime.ts
+++ b/src/sandbox/privileged-runtime.ts
@@ -2,7 +2,7 @@ import { chmod, lstat, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import { homedir, tmpdir } from 'node:os'
 import path from 'node:path'
 
-import { SandboxCredentialWithheldError, SandboxPolicyError } from './errors'
+import { SandboxPolicyError } from './errors'
 import type { SandboxMount } from './policy'
 
 const SAFE_GIT_SUBCOMMANDS = new Set([
@@ -30,49 +30,6 @@ const SAFE_GIT_SUBCOMMANDS = new Set([
 
 const SHELL_ACTIVE = new Set(['|', ';', '&', '\n', '\r', '(', ')', '{', '}', '<', '>', '`', '$', '\\'])
 
-// The exact bins agent-messenger installs, kept in lockstep with the installed
-// manifest by a test. Reserving the whole `agent-*` namespace instead would
-// over-claim AND under-claim: an unrelated user-installed `agent-lint` would be
-// refused with a false agent-messenger credential claim — the very class of
-// false statement this refusal exists to prevent — while `amsg`, a real
-// agent-messenger bin, carries no `agent-` prefix and would slip through.
-export const AGENT_MESSENGER_BINS: ReadonlySet<string> = new Set([
-  'agent-channeltalk',
-  'agent-channeltalkbot',
-  'agent-discord',
-  'agent-discordbot',
-  'agent-imessage',
-  'agent-instagram',
-  'agent-kakaotalk',
-  'agent-line',
-  'agent-messenger',
-  'agent-slack',
-  'agent-slackbot',
-  'agent-teams',
-  'agent-telegram',
-  'agent-telegrambot',
-  'agent-webex',
-  'agent-webexbot',
-  'agent-wechatbot',
-  'agent-whatsapp',
-  'agent-whatsappbot',
-  'amsg',
-])
-
-// Ephemeral runners that execute a package bin named by their first operand.
-// `bunx` is the bare-binary alias for `bun x` (see sandbox/package-install.ts);
-// npx/pnpx are the non-bun spellings the bun-hygiene guard still permits.
-const PACKAGE_RUNNERS = new Set(['bunx', 'npx', 'pnpx'])
-const BUN_RUNNER_SUBCOMMANDS = new Set(['x', 'run'])
-
-// Splits at the shell operators that begin a NEW simple command, mirroring
-// `commandNeedsRealProc`. Deliberately coarse: it over-splits inside quotes and
-// `$()`, but this feeds a DENY-ONLY decision, so a spurious extra segment can
-// only make the refusal MORE likely — it can never grant a credential.
-const SHELL_COMMAND_SEPARATOR = /(?:&&|\|\||[;|&\n()<>])+/
-
-const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
-
 export type PrivilegedSandboxRuntime = {
   env: Record<string, string>
   mounts: SandboxMount[]
@@ -89,7 +46,6 @@ export async function resolvePrivilegedSandboxRuntime(options: {
   env?: NodeJS.ProcessEnv
   homeDir?: string
 }): Promise<PrivilegedSandboxRuntime> {
-  rejectAgentMessengerCommand(options.command)
   const runtime = emptyRuntime()
   // TYPECLAW_GIT_TOKEN is set only after the auth analyzer accepts a Git command.
   // Trust that decision rather than reparsing its command with a less capable
@@ -106,23 +62,15 @@ export async function resolvePrivilegedSandboxRuntime(options: {
   const executable = unwrapBunx(parsed)
   if (executable === null) return runtime
 
-  // Re-checked here as well as in the deny-only scan: this path resolves quoted
-  // and `bunx`-wrapped executables the coarse segment split cannot.
-  if (AGENT_MESSENGER_BINS.has(path.basename(executable.executable))) {
-    throw new SandboxCredentialWithheldError(path.basename(executable.executable))
-  }
-
   // These CLIs can print or upload arbitrary files. Supplying their reusable
   // auth profile to a model-controlled child would therefore make the CLI a
   // confused deputy even when the outer shell is syntactically standalone.
-  //
-  // They stay executable-but-uncredentialed rather than refused outright: an
-  // operator CAN authenticate them from `.env`, which model bash does inherit,
-  // so refusing would break working setups. The agent-messenger family cannot —
-  // every platform reads a `<platform>-credentials.json` file under the
-  // unconditionally masked `workspace/.agent-messenger` — so it is a guaranteed
-  // dead end and is refused loudly above instead of failing misleadingly.
-  if (executable.executable === 'gws' || executable.executable === 'codex' || executable.executable === 'claude') {
+  if (
+    executable.executable === 'gws' ||
+    executable.executable === 'codex' ||
+    executable.executable === 'claude' ||
+    executable.executable.startsWith('agent-')
+  ) {
     return runtime
   }
 
@@ -146,35 +94,6 @@ export async function resolvePrivilegedSandboxRuntime(options: {
 
 function containsGitInvocation(command: string): boolean {
   return /(^|[;&|]\s*)git(?:\s|$)/.test(command.trim())
-}
-
-function rejectAgentMessengerCommand(command: string): void {
-  for (const segment of command.split(SHELL_COMMAND_SEPARATOR)) {
-    const bin = agentMessengerBinIn(segment)
-    if (bin !== undefined) throw new SandboxCredentialWithheldError(bin)
-  }
-}
-
-function agentMessengerBinIn(segment: string): string | undefined {
-  const words = segment
-    .trim()
-    .split(/\s+/)
-    .map((word) => word.replaceAll(/^["']|["']$/g, ''))
-    .filter((word) => word !== '' && !ENV_ASSIGNMENT.test(word))
-  const operand = unwrapPackageRunner(words).find((word) => !word.startsWith('-'))
-  if (operand === undefined) return undefined
-  const bin = path.basename(operand)
-  return AGENT_MESSENGER_BINS.has(bin) ? bin : undefined
-}
-
-function unwrapPackageRunner(words: readonly string[]): readonly string[] {
-  const head = words[0]
-  if (head === undefined) return words
-  const runner = path.basename(head)
-  if (PACKAGE_RUNNERS.has(runner)) return words.slice(1)
-  const subcommand = words[1]
-  if (runner === 'bun' && subcommand !== undefined && BUN_RUNNER_SUBCOMMANDS.has(subcommand)) return words.slice(2)
-  return words
 }
 
 export async function verifyPrivilegedSandboxRuntime(runtime: PrivilegedSandboxRuntime): Promise<void> {


### PR DESCRIPTION
## What broke

`0.48.0` (`d477c8b6`) made every agent-messenger CLI throw `SandboxCredentialWithheldError` in model-driven bash, unconditionally. Production agents that had been running `agent-webex` / `agent-slack` / `agent-discord` from model bash for months went dark on upgrade.

## Why the refusal was wrong

`d477c8b6` justified refusing the whole family with a factual claim:

> every platform resolves a `<platform>-credentials.json` file under the unconditionally masked `workspace/.agent-messenger`, and none of them read a token from the environment. So it is a guaranteed dead end.

That is not how agent-messenger resolves credentials. `AGENT_MESSENGER_CONFIG_DIR` is checked **first**, and `~/.config/agent-messenger` is only the fallback when it is empty (`node_modules/agent-messenger/src/shared/utils/config-dir.ts:4-22`).

TypeClaw is the one that sets that variable. Every generated Dockerfile writes `ENV AGENT_MESSENGER_CONFIG_DIR=...` (`src/init/dockerfile.ts:1383-1387`), and TypeClaw's own init/reauth flows write credentials through it — `src/init/line-auth.ts:53-60` explains that it points the host login at the per-agent dir so the key lands where the runtime reads it.

So whether the CLI can authenticate is a TypeClaw-provisioned, operator-configurable fact, not a property of the CLI family. Where an operator pointed that variable outside the canonical mask, the CLI was fully credentialed, and model bash reintroduces ordinary `.env` names into bwrap so the redirect reached the sandbox. `d477c8b6` generalized one uncredentialed agent into a universal law and refused all of them.

## The recommended alternative does not exist

The refusal told the model to use `channel_*` instead. Those are a **disjoint credential system**:

| | store | starts when |
|---|---|---|
| agent-messenger CLI | `<AGENT_MESSENGER_CONFIG_DIR>/<platform>-credentials.json` | always, if the profile is readable |
| channel adapters | `secrets.json#channels.<adapter>` | adapter listed in `typeclaw.json#channels` (`src/channels/manager.ts:832-846`) |

An operator using the CLI has, by construction, not configured the matching adapter — that is *why* they are using the CLI. So the advice names a path with no adapter behind it, for every agent the refusal fires on. No amount of adapter capability work changes that.

Observed consequence: a refused agent guessed at `channel_read` against an adapter that had never been configured, got `list-not-supported` / `history-not-supported`, and then told its user the failure was an upstream authentication/permission problem. The refusal produced exactly the confabulation `SandboxCredentialWithheldError`'s own class comment says it exists to prevent, one layer up.

## What this does

Reverts `d477c8b6`. `SandboxCredentialWithheldError`, `AGENT_MESSENGER_BINS`, and `rejectAgentMessengerCommand` are removed; `resolvePrivilegedSandboxRuntime` returns to its prior behavior.

## Follow-up, deliberately not in this PR

`d477c8b6`'s underlying concern is real but much narrower than the remedy it chose: an uncredentialed CLI prints its own `No current workspace set. Run auth extract first.`, and a model relays that as a fact about the world. That is a diagnosis to make **when the profile is genuinely unreachable** — not grounds to refuse the family everywhere. Re-landing it conditionally is left to a follow-up so the working path is restored first.

## Generalizing beyond the revert

Reverting removes the refusal but leaves the shape that produced it. The resolver still opened with:

```ts
if (
  executable.executable === 'gws' ||
  executable.executable === 'codex' ||
  executable.executable === 'claude' ||
  executable.executable.startsWith('agent-')
) {
  return runtime
}
```

That branch is a **no-op** — it returns the same empty runtime the function returns two lines later for everything that is not `git`. Deleting it changes no behavior, which the pre-existing `keeps auth diagnostics executable but supplies no credential profile` test proves by continuing to pass unmodified.

What it did do was misrepresent the contract. Credentials here are default-deny: a command gets an auth profile only from an explicit broker, and `git` is the only broker. A list of names in front of that default reads as though the names are load-bearing, so the file looked like a registry of tools the sandbox holds opinions about — and `d477c8b6` was written by appending one more opinion to it.

That is the more damaging property. A name list is where beliefs about a third party's credential layout accumulate, and those beliefs go stale silently. The one that shipped asserted a CLI family could never authenticate under the sandbox. It was false, nothing in the type system or the tests contradicted it, and it refused a working family outright.

The confused-deputy rationale the old comment carried is real, but it was attached to the wrong thing. It holds for every model-controlled child that can print or upload files, including tools not yet written, so it now documents the default rather than four names.

A new test pins the contract by asserting that previously-named executables and an arbitrary unknown one resolve identically. Verified effective: reintroducing a `d477c8b6`-shaped name check makes it fail, and restoring makes it pass.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (69 pre-existing warnings)
- `bun run format:check` — clean
- `bun run test` — **12222 pass / 31 skip / 0 fail** across 589 files. An earlier run on a saturated machine showed two 30s timeouts in `src/agent/plugin-tools.test.ts`; both were load artifacts, confirmed by this clean run (481s vs 1599s) and by the fact that one of them fails identically on an unmodified `origin/main` baseline worktree.
