### PR TITLE
Surface local sandbox withholding on failures

### DIFF
--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -37,6 +37,7 @@ import {
   _resetBwrapAvailabilityCacheForTests,
   _resetRealProcProbeCacheForTests,
   resolveProtectedZones,
+  resolveHiddenPaths,
   SandboxDegradedProcError,
   SESSION_TMP_ROOT,
   resolvePrivilegedSandboxRuntime,
@@ -3201,6 +3202,153 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
   const member: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'member' }
   const guest: SessionOrigin = { kind: 'subagent', subagent: 'x', parentSessionId: 'p', spawnedByRole: 'guest' }
 
+  test('annotates only nonzero exits with the local sandbox policy', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-policy-provenance-'))
+    const plantedSecret = 'planted-secret-value'
+    const permissions = createPermissionService()
+    await writeFile(path.join(agentDir, '.env'), `NODE_OPTIONS=${plantedSecret}\nVISIBLE_NAME=visible-value\n`)
+    const boundary = {
+      ensureAvailable: async () => {},
+      resolveRuntime: async () => ({ env: {}, mounts: [] }),
+      buildCommand(command: string, options: SandboxPolicy | undefined) {
+        return { ...buildSandboxedCommand(command, options), commandString: command }
+      },
+    }
+    const makeTool = (exitCode: number) => ({
+      name: 'bash',
+      label: 'bash',
+      description: '',
+      parameters: Type.Object({ command: Type.String() }),
+      async execute() {
+        return {
+          content: [{ type: 'text' as const, text: exitCode === 0 ? 'unchanged success' : 'ordinary failure' }],
+          details: { exitCode },
+        }
+      },
+    })
+
+    try {
+      const failing = wrapBuiltinToolDefinition(makeTool(9), {
+        agentDir,
+        sessionId: 'policy-provenance-failure',
+        hooks: createHookBus(),
+        getOrigin: () => guest,
+        permissions,
+        bashSandboxBoundary: boundary,
+      })
+      const failure = await failing.execute('failure', { command: 'false' }, undefined, undefined, {} as never)
+      const hidden = resolveHiddenPaths(permissions, guest, agentDir)
+      const maskedPaths = [...hidden.dirs, ...hidden.files].map((target) => `agent/${path.relative(agentDir, target)}`)
+      const expectedNote =
+        `[TypeClaw sandbox policy (LOCAL): masked credential/private paths: ${maskedPaths.join(', ')}; ` +
+        'withheld env names: NODE_OPTIONS. This may be unrelated to this failure; it is NOT evidence about ' +
+        'authentication of any account, workspace, or upstream service and must not be reported as such.]'
+      expect(failure.content).toEqual([
+        { type: 'text', text: 'ordinary failure' },
+        { type: 'text', text: expectedNote },
+      ])
+      expect(JSON.stringify(failure)).not.toContain(plantedSecret)
+
+      const succeeding = wrapBuiltinToolDefinition(makeTool(0), {
+        agentDir,
+        sessionId: 'policy-provenance-success',
+        hooks: createHookBus(),
+        getOrigin: () => guest,
+        permissions,
+        bashSandboxBoundary: boundary,
+      })
+      expect(await succeeding.execute('success', { command: 'true' }, undefined, undefined, {} as never)).toEqual({
+        content: [{ type: 'text', text: 'unchanged success' }],
+        details: { exitCode: 0 },
+      })
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('annotates a sandboxed builtin execution error', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-policy-error-provenance-'))
+    const plantedSecret = 'planted-secret-value'
+    const permissions = createPermissionService()
+    await writeFile(path.join(agentDir, '.env'), `NODE_OPTIONS=${plantedSecret}\n`)
+    const builtin = defaultBuiltinPiToolDefinitions(agentDir).find((tool) => tool.name === 'bash')
+    if (builtin === undefined) throw new Error('bash tool definition not found')
+    const wrapped = wrapBuiltinToolDefinition(builtin, {
+      agentDir,
+      sessionId: 'policy-error-provenance',
+      hooks: createHookBus(),
+      getOrigin: () => guest,
+      permissions,
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        resolveRuntime: async () => ({ env: {}, mounts: [] }),
+        buildCommand(command, options) {
+          return { ...buildSandboxedCommand(command, options), commandString: command }
+        },
+      },
+    })
+
+    try {
+      const hidden = resolveHiddenPaths(permissions, guest, agentDir)
+      const maskedPaths = [...hidden.dirs, ...hidden.files].map((target) => `agent/${path.relative(agentDir, target)}`)
+      const expectedNote =
+        `[TypeClaw sandbox policy (LOCAL): masked credential/private paths: ${maskedPaths.join(', ')}; ` +
+        'withheld env names: NODE_OPTIONS. This may be unrelated to this failure; it is NOT evidence about ' +
+        'authentication of any account, workspace, or upstream service and must not be reported as such.]'
+      const thrown = await wrapped
+        .execute('failure', { command: 'exit 9' }, undefined, undefined, {} as never)
+        .catch((error: unknown) => error)
+
+      if (!(thrown instanceof Error)) throw new Error('expected command failure')
+      expect(thrown.message).toEndWith(`\n\n${expectedNote}`)
+      expect(thrown.message).not.toContain(plantedSecret)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  test('the annotation is independent of command identity', async () => {
+    const agentDir = await mkdtemp(path.join(tmpdir(), 'typeclaw-policy-command-agnostic-'))
+    const tool = {
+      name: 'bash',
+      label: 'bash',
+      description: '',
+      parameters: Type.Object({ command: Type.String() }),
+      async execute() {
+        return { content: [{ type: 'text' as const, text: 'failed' }], details: { exitCode: 1 } }
+      },
+    }
+    const wrapped = wrapBuiltinToolDefinition(tool, {
+      agentDir,
+      sessionId: 'policy-command-agnostic',
+      hooks: createHookBus(),
+      getOrigin: () => tui,
+      permissions: createPermissionService(),
+      bashSandboxBoundary: {
+        ensureAvailable: async () => {},
+        resolveRuntime: async () => ({ env: {}, mounts: [] }),
+        buildCommand(command, options) {
+          return { ...buildSandboxedCommand(command, options), commandString: command }
+        },
+      },
+    })
+
+    try {
+      const firstCommand = 'false'
+      const secondCommand = '(exit 7)'
+      const first = await wrapped.execute('first', { command: firstCommand }, undefined, undefined, {} as never)
+      const second = await wrapped.execute('second', { command: secondCommand }, undefined, undefined, {} as never)
+      const firstAnnotation = first.content[1]
+      const secondAnnotation = second.content[1]
+
+      expect(firstAnnotation).toEqual(secondAnnotation)
+      expect(JSON.stringify(firstAnnotation)).not.toContain(firstCommand)
+      expect(JSON.stringify(firstAnnotation)).not.toContain(secondCommand)
+    } finally {
+      await rm(agentDir, { recursive: true, force: true })
+    }
+  })
+
   test('owner bash keeps the agent root writable while canonical secrets stay read-only masked and env stays cleared', () => {
     const permissions = createPermissionService()
     const policy = buildBashFilesystemPolicy({
@@ -3747,7 +3895,9 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
     )
     expect(order).toEqual(['execute', 'cleanup', 'after'])
     expect(afterResults).toHaveLength(1)
-    expect(afterResults[0]?.details).toEqual({ error: 'execution failed' })
+    expect(afterResults[0]?.details).toEqual({
+      error: expect.stringContaining('[TypeClaw sandbox policy (LOCAL)'),
+    })
     await rm(agentDir, { recursive: true, force: true })
   })
 

--- a/src/agent/plugin-tools.test.ts
+++ b/src/agent/plugin-tools.test.ts
@@ -3238,7 +3238,9 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
       })
       const failure = await failing.execute('failure', { command: 'false' }, undefined, undefined, {} as never)
       const hidden = resolveHiddenPaths(permissions, guest, agentDir)
-      const maskedPaths = [...hidden.dirs, ...hidden.files].map((target) => `agent/${path.relative(agentDir, target)}`)
+      const maskedPaths = [...hidden.dirs, ...hidden.files].map(
+        (target) => `agent/${path.relative(agentDir, target).split(path.sep).join('/')}`,
+      )
       const expectedNote =
         `[TypeClaw sandbox policy (LOCAL): masked credential/private paths: ${maskedPaths.join(', ')}; ` +
         'withheld env names: NODE_OPTIONS. This may be unrelated to this failure; it is NOT evidence about ' +
@@ -3290,7 +3292,9 @@ describe('wrapBuiltinToolDefinition bash sandbox (role-derived path hiding)', ()
 
     try {
       const hidden = resolveHiddenPaths(permissions, guest, agentDir)
-      const maskedPaths = [...hidden.dirs, ...hidden.files].map((target) => `agent/${path.relative(agentDir, target)}`)
+      const maskedPaths = [...hidden.dirs, ...hidden.files].map(
+        (target) => `agent/${path.relative(agentDir, target).split(path.sep).join('/')}`,
+      )
       const expectedNote =
         `[TypeClaw sandbox policy (LOCAL): masked credential/private paths: ${maskedPaths.join(', ')}; ` +
         'withheld env names: NODE_OPTIONS. This may be unrelated to this failure; it is NOT evidence about ' +

--- a/src/agent/plugin-tools.ts
+++ b/src/agent/plugin-tools.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { mkdir } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, relative, sep } from 'node:path'
 
 import {
   createBashToolDefinition as piCreateBashToolDefinition,
@@ -633,7 +633,11 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
             args: attemptArgs,
             agentDir: opts.agentDir,
             ...(opts.permissions !== undefined
-              ? { hidden: resolveHiddenPaths(opts.permissions, liveOrigin, opts.agentDir) }
+              ? {
+                  hidden:
+                    preparedSandboxRuntime?.withheld.paths ??
+                    resolveHiddenPaths(opts.permissions, liveOrigin, opts.agentDir),
+                }
               : {}),
             signal,
           })
@@ -717,8 +721,18 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
           }
         }
       }
-      const finalError = executionError ?? cleanupError
+      let finalError = executionError ?? cleanupError
       if (finalError !== undefined) {
+        // The builtin reports command failures as execution errors rather than
+        // result details. Once the sandbox was prepared, annotate every such
+        // error without parsing its arbitrary or localized text. Cleanup-only
+        // failures are not command failures and remain unchanged.
+        if (executionError !== undefined && preparedSandboxRuntime !== undefined) {
+          finalError = appendErrorText(
+            finalError,
+            renderSandboxPolicyNote(preparedSandboxRuntime.withheld, opts.agentDir),
+          )
+        }
         await runToolAfterSafely(opts, tool.name, toolCallId, toErrorResult(finalError))
         throw finalError
       }
@@ -733,6 +747,9 @@ export function wrapBuiltinToolDefinition<TParams extends TSchema, TDetails = un
       ) {
         const hint = dependencyBinUnavailableHint(originalBashCommand, preparedSandboxRuntime.dependencyBins)
         if (hint !== undefined) result = appendTextResult(result, hint)
+      }
+      if (preparedSandboxRuntime !== undefined && bashResultHasNonzeroExit(result)) {
+        result = appendTextResult(result, renderSandboxPolicyNote(preparedSandboxRuntime.withheld, opts.agentDir))
       }
       const resolved = loopGate.resolve({ content: result.content as ContentPart[], details: result.details })
       if ('deferredBlock' in resolved) {
@@ -801,6 +818,10 @@ type PreparedBashSandbox = {
   cleanup: () => Promise<void>
   spawnEnv?: Record<string, string>
   dependencyBins?: DependencyBinReconciliation
+  withheld: {
+    paths: { dirs: string[]; files: string[] }
+    envNames: string[]
+  }
 }
 
 export function buildBashFilesystemPolicy(options: BashFilesystemPolicyOptions) {
@@ -826,9 +847,16 @@ async function applyBashSandbox(
   boundary: BashSandboxBoundary,
 ): Promise<PreparedBashSandbox> {
   const command = mutableArgs.command
-  if (typeof command !== 'string') return { verify: async () => {}, cleanup: async () => {} }
+  if (typeof command !== 'string') {
+    return {
+      verify: async () => {},
+      cleanup: async () => {},
+      withheld: { paths: { dirs: [], files: [] }, envNames: [] },
+    }
+  }
 
   const { dirs, files } = resolveHiddenPaths(permissions, origin, agentDir)
+  const envNames = resolveExposableBashEnvNames(agentDir)
   const sandboxEnvOverlay = buildRoleScopedConfigEnv(agentDir, dirs, envOverlay)
   const maskTargets = await ensureHiddenMaskTargets({ dirs, files })
   await boundary.ensureAvailable()
@@ -883,9 +911,7 @@ async function applyBashSandbox(
       cwd: agentDir,
       proc,
       procSelfExe: resolveProcSelfExe(),
-      ...spreadSandboxEnv(
-        buildSandboxEnvPolicy(sandboxEnvOverlay, privilegedRuntime?.env, resolveExposableBashEnvNames(agentDir)),
-      ),
+      ...spreadSandboxEnv(buildSandboxEnvPolicy(sandboxEnvOverlay, privilegedRuntime?.env, envNames.exposable)),
     })
     mutableArgs.command = commandString
     // The overlay carries command-scoped secret VALUES (e.g. a per-repo GH_TOKEN)
@@ -899,6 +925,7 @@ async function applyBashSandbox(
       cleanup,
       spawnEnv: mergedSpawnEnv,
       dependencyBins,
+      withheld: { paths: maskTargets, envNames: envNames.withheld },
     }
   } catch (error) {
     await cleanup()
@@ -911,6 +938,32 @@ function bashResultIsCommandNotFound(result: ToolResult): boolean {
   return (result.content as ContentPart[]).some(
     (part) => part.type === 'text' && /command not found(?:\s|$)/i.test(part.text),
   )
+}
+
+function bashResultHasNonzeroExit(result: ToolResult): boolean {
+  // A numeric nonzero exit is the command's tool-agnostic failure signal. Do
+  // not infer failure from arbitrary or localized output text.
+  return isRecord(result.details) && typeof result.details.exitCode === 'number' && result.details.exitCode !== 0
+}
+
+function renderSandboxPolicyNote(withheld: PreparedBashSandbox['withheld'], agentDir: string): string {
+  const maskedPaths = [...withheld.paths.dirs, ...withheld.paths.files].map(
+    (target) => `agent/${relative(agentDir, target).split(sep).join('/')}`,
+  )
+  return (
+    `[TypeClaw sandbox policy (LOCAL): masked credential/private paths: ${maskedPaths.join(', ') || 'none'}; ` +
+    `withheld env names: ${withheld.envNames.join(', ') || 'none'}. This may be unrelated to this failure; ` +
+    'it is NOT evidence about authentication of any account, workspace, or upstream service and must not be ' +
+    'reported as such.]'
+  )
+}
+
+function appendErrorText(error: unknown, text: string): Error {
+  if (error instanceof Error) {
+    error.message = `${error.message}\n\n${text}`
+    return error
+  }
+  return new Error(`${String(error)}\n\n${text}`)
 }
 
 function appendTextResult(result: ToolResult, text: string): ToolResult {
@@ -962,8 +1015,14 @@ function spreadSandboxEnv(policy: ReturnType<typeof buildSandboxEnvPolicy>): {
   return Object.keys(policy).length > 0 ? { env: policy } : {}
 }
 
-function resolveExposableBashEnvNames(agentDir: string): string[] {
-  return resolveExposableEnvNames(readEnvFile(agentDir))
+function resolveExposableBashEnvNames(agentDir: string): { exposable: string[]; withheld: string[] } {
+  const declaredEnv = readEnvFile(agentDir)
+  const exposable = resolveExposableEnvNames(declaredEnv)
+  const exposableSet = new Set(exposable)
+  const withheld = [...declaredEnv]
+    .filter(([name, value]) => value.length > 0 && !exposableSet.has(name))
+    .map(([name]) => name)
+  return { exposable, withheld }
 }
 
 function buildRoleScopedConfigEnv(


### PR DESCRIPTION
## Background

Sandboxed bash calls mask credential-bearing paths and environment variables before a command runs, then execute it. That masking is invisible to the model: when the command fails, the result carries only the command's own exit code and output. Nothing tells the model that local policy touched the invocation at all, so a masking-caused failure can be misread as evidence about something it never was — most concretely, as evidence about whether an upstream account or service is authenticated. Once relayed to a user, a local masking decision becomes a false claim about the outside world.

The base commit this PR stacks on is a worked example of exactly that failure landing in production: a command's own self-reported failure was relayed as an upstream authentication fact, when the real cause was local policy. Fixing that one refusal does not fix the general defect — any sandboxed command that fails while credentials are withheld can produce the same confabulation, regardless of which command it is.

## Summary

An earlier way to frame this problem enumerated executables/bins and reasoned about where a given tool family stores its credentials, then special-cased the response for that family. That shape is wrong twice over, and the reverted commit's own account of it explains why: it "generalized a single uncredentialed agent into a universal law and refused every one of them," resting on an assumption that "Where the profile lives is therefore a TypeClaw-provisioned, operator-configurable fact -- not a property of the CLI family, and not something the sandbox can assume." Enumerating by executable is:

- **Incomplete** — it only ever covers the tools someone thought to enumerate, never the next one added to the sandbox.
- **Assumption-laden** — it bakes in a guess about *where* a tool keeps its credentials, which is operator-configurable and not a fact the sandbox is entitled to assume.

This PR fixes the general defect at the general layer instead: sandbox preparation, not command identity.

- `applyBashSandbox` already computes the exact masked directories/files and the exact withheld env names (declared in `.env` but not exposed) before spawning the command. Both are now threaded out on the prepared-sandbox result instead of being discarded after use.
- On a nonzero exit, or on an execution error once the sandbox was prepared, `wrapBuiltinToolDefinition` appends one terse note built only from those exact names — which paths were masked, which env names were withheld. No values, no recomputation from live permissions state, no matching against the command's error text.
- Successful results (exit 0, no execution error) are untouched: no note, no behavior change.
- The note depends only on withheld state, not on which binary ran or what it printed, so it applies uniformly to every sandboxed bash call.

Because the trigger is "a sandboxed command failed" rather than "this specific command failed," the note covers every tool that goes through the masked-credential sandbox path today, and every tool added to it in the future, without needing to name any of them.

## What this does NOT do

- Does not change success-path behavior, output, or exit codes.
- Does not recompute or re-derive withheld state from anything other than what sandbox preparation already produced — no live permission lookups at annotation time.
- Does not parse or pattern-match the command's own error text or output.
- Does not name or special-case any specific command, executable, or credential store.
- Does not reintroduce or modify the reverted executable refusal; that is the base commit's concern, not this one's.

## Testing

- Typecheck passes.
- Lint passes with 0 errors and 69 pre-existing warnings.
- Formatting check passes.
- Full suite: 12,224 pass, 31 skip, 0 fail.
- The known pre-existing plugin-tools timeout case was checked and did not reproduce on this branch; it was not touched by this change.

## Review notes

- Stacked on the requested restore base — review only the top commit, `Explain local sandbox withholding on failures`; the restore work underneath already landed there.
- Load-bearing: the note is built exclusively from the withheld paths/env names captured at sandbox-prep time, never from live permissions/origin lookups at annotation time, and never from the command string or its output.
- The nonzero-exit check reads only the numeric exit code in the result details; it does not special-case any error string.
