### PR TITLE
Fix agent-messenger audit follow-ups from #1332

### DIFF
--- a/docs/content/docs/guides/add-a-channel.mdx
+++ b/docs/content/docs/guides/add-a-channel.mdx
@@ -238,7 +238,7 @@ GitHub delivers events over webhooks, so it needs a public URL to reach your con
 
 <Accordion title="LINE — a personal account, not a bot">
 
-LINE logs in as a real user account by QR or email/PIN and stores the resulting account record in `secrets.json`. It sends plain text only — no outbound attachments, stickers, rich formatting, or bot-style mentions. See the [LINE adapter reference](/docs/reference/line) for the rest.
+LINE logs in as a real user account by QR or email/PIN and stores the resulting account record in `secrets.json`. Letter-Sealing (E2EE) key material lands separately under `workspace/.config/agent-messenger/line-storage/` and is not recoverable by logging in again, so back that directory up too. It sends plain text only — no outbound attachments, stickers, rich formatting, or bot-style mentions. See the [LINE adapter reference](/docs/reference/line) for the rest.
 
 </Accordion>
 

--- a/docs/content/docs/reference/line.mdx
+++ b/docs/content/docs/reference/line.mdx
@@ -19,6 +19,14 @@ Transport: **LINE protocol** (no public URL required). Setup walkthrough: [Add a
 
 Sub-device login using QR code or email/password plus PIN. Credentials are stored in `secrets.json#channels.line` as one or more account records.
 
+<Callout type="warn" title="E2EE keys live outside secrets.json">
+  The SDK persists Letter-Sealing (end-to-end encryption) key material under
+  `workspace/.config/agent-messenger/line-storage/`, not in `secrets.json`. Back up that directory alongside
+  `secrets.json` — losing it leaves inbound Letter-Sealing messages permanently undecryptable, and no re-login recovers
+  the old keys. TypeClaw masks the directory from every model-driven tool, and moves it automatically on `typeclaw
+  start` if it is still at the older `workspace/.agent-messenger/` location.
+</Callout>
+
 Unlike bot-token adapters, `secrets.json#channels.line` is not a flat credential object — it wraps one or more account records:
 
 ```json

--- a/src/agent-messenger/config-dir.test.ts
+++ b/src/agent-messenger/config-dir.test.ts
@@ -194,6 +194,22 @@ describe('migrateAgentMessengerConfigDir', () => {
     expect(existsSync(join(outside, 'agent-messenger'))).toBe(false)
   })
 
+  // The post-migration steady state has no legacy tree, yet callers still write
+  // credentials to the destination — so the parent must be rejected here too.
+  test('rejects a symlinked destination parent even when there is nothing to migrate', async () => {
+    const outside = join(agentDir, 'outside')
+    await mkdir(outside)
+    await mkdir(join(agentDir, 'workspace'), { recursive: true })
+    await symlink(outside, join(agentDir, 'workspace', '.config'))
+
+    const result = await migrateAgentMessengerConfigDir(agentDir)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('symbolic link')
+    expect(existsSync(join(outside, 'agent-messenger'))).toBe(false)
+  })
+
   test('rejects a non-directory new path without modifying legacy data', async () => {
     await mkdir(legacyAgentMessengerConfigDir(agentDir), { recursive: true })
     await writeFile(join(legacyAgentMessengerConfigDir(agentDir), 'credential'), 'secret')

--- a/src/agent-messenger/config-dir.ts
+++ b/src/agent-messenger/config-dir.ts
@@ -51,12 +51,18 @@ export async function migrateAgentMessengerConfigDir(agentDir: string): Promise<
   const current = await inspectDirectory(configDir)
   if (legacy.exists && !legacy.directory) return invalidDirectoryResult(legacyDir, legacy.kind)
   if (current.exists && !current.directory) return invalidDirectoryResult(configDir, current.kind)
-  if (!legacy.exists) return { ok: true, migrated: false }
 
+  // Validated before the nothing-to-migrate return below: callers use the
+  // destination for host-stage credential writes even when no legacy tree
+  // exists, and lstat on the leaf follows a symlinked parent. Checking this
+  // only on the migrating path would leave the common post-migration state
+  // writing E2EE key material through an unvalidated symlink.
   const configParent = await inspectDirectory(dirname(configDir))
   if (configParent.exists && !configParent.directory) {
     return invalidDirectoryResult(dirname(configDir), configParent.kind)
   }
+
+  if (!legacy.exists) return { ok: true, migrated: false }
 
   if (!current.exists) {
     await mkdir(dirname(configDir), { recursive: true })

--- a/src/init/env-file.test.ts
+++ b/src/init/env-file.test.ts
@@ -154,4 +154,29 @@ describe('appendOrReplaceEnvKey', () => {
     expect(out).toBe('EXISTING=keep\nFRESH=value\n')
     expect(out.split('\n').filter((line) => line === '').length).toBe(1)
   })
+
+  test('replaces an indented key instead of appending a duplicate', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), '   TARGET=old\nOTHER=keep\n', 'utf8')
+    appendOrReplaceEnvKey(cwd, 'TARGET', 'new')
+    const out = await readFile(join(cwd, '.env'), 'utf8')
+    expect(out).toBe('TARGET=new\nOTHER=keep\n')
+    expect(readEnvFile(cwd).get('TARGET')).toBe('new')
+  })
+
+  test('replaces a BOM-prefixed first key and keeps the BOM', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), '\uFEFFTARGET=old\nOTHER=keep\n', 'utf8')
+    appendOrReplaceEnvKey(cwd, 'TARGET', 'new')
+    const out = await readFile(join(cwd, '.env'), 'utf8')
+    expect(out).toBe('\uFEFFTARGET=new\nOTHER=keep\n')
+    expect(readEnvFile(cwd).get('TARGET')).toBe('new')
+  })
+
+  test('leaves an indented comment untouched when replacing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'typeclaw-envfile-'))
+    await writeFile(join(cwd, '.env'), '   # TARGET=commented\nTARGET=old\n', 'utf8')
+    appendOrReplaceEnvKey(cwd, 'TARGET', 'new')
+    expect(await readFile(join(cwd, '.env'), 'utf8')).toBe('   # TARGET=commented\nTARGET=new\n')
+  })
 })

--- a/src/init/env-file.ts
+++ b/src/init/env-file.ts
@@ -24,22 +24,31 @@ export function readEnvFile(cwd: string): Map<string, string> {
   }
   const lines = raw.split(/\r?\n/)
   for (const [index, rawLine] of lines.entries()) {
-    const withoutBom = index === 0 ? rawLine.replace(/^\uFEFF/, '') : rawLine
-    // \p{White_Space}, not \s: JS \s also matches U+FEFF (and misses U+0085),
-    // so \s would strip a BOM on EVERY line while Go's unicode.IsSpace — which
-    // Docker uses — strips it on line 1 only.
-    const line = withoutBom.replace(/^\p{White_Space}+/u, '')
-    if (line.length === 0) continue
-    if (line.startsWith('#')) continue
-    const eq = line.indexOf('=')
-    if (eq <= 0) continue
-    const key = line.slice(0, eq)
-    // Docker rejects the whole file when a key contains a space or tab, so such
-    // a line can never reach a container; skip it rather than inventing a key.
-    if (/[ \t]/.test(key)) continue
-    out.set(key, line.slice(eq + 1))
+    const parsed = parseEnvLine(rawLine, index)
+    if (parsed === null) continue
+    out.set(parsed.key, parsed.value)
   }
   return out
+}
+
+// Shared by the reader and the writer so a declaration one of them recognizes
+// can never be invisible to the other — an indented key that parsed as declared
+// but did not match on write would append a duplicate instead of replacing.
+function parseEnvLine(rawLine: string, index: number): { key: string; value: string } | null {
+  const withoutBom = index === 0 ? rawLine.replace(/^\uFEFF/, '') : rawLine
+  // \p{White_Space}, not \s: JS \s also matches U+FEFF (and misses U+0085),
+  // so \s would strip a BOM on EVERY line while Go's unicode.IsSpace — which
+  // Docker uses — strips it on line 1 only.
+  const line = withoutBom.replace(/^\p{White_Space}+/u, '')
+  if (line.length === 0) return null
+  if (line.startsWith('#')) return null
+  const eq = line.indexOf('=')
+  if (eq <= 0) return null
+  const key = line.slice(0, eq)
+  // Docker rejects the whole file when a key contains a space or tab, so such
+  // a line can never reach a container; skip it rather than inventing a key.
+  if (/[ \t]/.test(key)) return null
+  return { key, value: line.slice(eq + 1) }
 }
 
 export function hasEnvKey(cwd: string, key: string): boolean {
@@ -66,13 +75,14 @@ export function appendOrReplaceEnvKey(cwd: string, key: string, value: string): 
   // regardless of replace-vs-append path.
   if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
   let replaced = false
-  const next = lines.map((line) => {
-    if (line.startsWith('#')) return line
-    const eq = line.indexOf('=')
-    if (eq <= 0) return line
-    if (line.slice(0, eq) !== key) return line
+  const next = lines.map((line, index) => {
+    const parsed = parseEnvLine(line, index)
+    if (parsed === null || parsed.key !== key) return line
     replaced = true
-    return `${key}=${value}`
+    // Re-emit the BOM so replacing the first line does not silently strip the
+    // file's encoding marker.
+    const bom = index === 0 && line.startsWith('\uFEFF') ? '\uFEFF' : ''
+    return `${bom}${key}=${value}`
   })
   if (!replaced) next.push(`${key}=${value}`)
   const out = `${next.join('\n')}\n`


### PR DESCRIPTION
## Background

Post-merge audit of #1332 (merged as ee116bec) turned up three independent gaps — each is its own commit here, not new work.

## Summary

### `fcd0c7c9` — Validate the destination parent even with nothing to migrate

In `src/agent-messenger/config-dir.ts`, the destination-parent symlink check ran only when a migration was pending, because it sat after the `!legacy.exists` early return. But the post-migration steady state has no legacy tree — and that's exactly when host auth still resolves the destination and writes LINE Letter-Sealing keys into it. `lstat` on the leaf follows intermediate symlinks, so a symlinked `workspace/.config` went unvalidated in that state. Moved the check above the early return. The new regression test failed without the fix and passes with it.

### `3bf18dff` — Share one line parser between the env-file reader and writer

`readEnvFile` normalizes BOM and leading indentation (matching docker/cli's `pkg/kvfile.parseKeyValueFile`), but `appendOrReplaceEnvKey` still compared raw, unnormalized text. An indented `KEY=old` line was read as declared but never matched on write, so the write path appended a duplicate line instead of replacing it. Both functions now share `parseEnvLine`. Replacing the first line re-emits a leading BOM instead of silently stripping the file's encoding marker. Impact was contained in production — every writer gates on `hasEnvKey` first, and Docker's own env-file parsing is last-wins — so this is a consistency fix, not a live bug.

### `650a5f07` — Document where LINE keeps its Letter-Sealing keys

Instagram's docs already name its SDK config directory; LINE's never did, even though LINE is the one adapter whose key material is unrecoverable — losing `workspace/.config/agent-messenger/line-storage/` leaves inbound Letter-Sealing messages permanently undecryptable, and re-login does not mint the old keys back. Added a warn `Callout` to `reference/line.mdx` and a sentence to the LINE accordion in `guides/add-a-channel.mdx`.

## Preview

Not applicable — no UI change; two of the three commits are docs/behavior fixes with no visual surface.

## What this does NOT do

- Does not touch the migration's crash-recovery or concurrency behavior — both were audited and found sound (rename is atomic, no copy/merge, every reachable kill state is safe).
- Does not change the sandbox env-exposure withhold matching in `src/sandbox/env-exposure.ts` — the audit confirmed BOM/indentation normalization only strengthens matching, since withhold checks are exact `Set.has()` plus prefix matching, unaffected by the parser change.
- Does not fix the lifecycle TOCTOU the same audit found: nothing serializes Docker inspect → migrate → `docker run`, and nothing spans host auth's prepare → interactive login → persist, so a restart during an interactive LINE login can migrate the directory after the path was already chosen and strand freshly minted keys. That needs a per-agent cross-process lock and is tracked as a separate PR.

## Review notes

- `fcd0c7c9` is the one with a security-invariant angle — confirm the new `rejects a symlinked destination parent even when there is nothing to migrate` test in `config-dir.test.ts` actually fails before the fix and passes here.
- `3bf18dff`: `parseEnvLine` is now the single source of truth for what counts as a declared key; grep for any other raw-text key comparisons in `src/init/env-file.ts` before adding a new writer there.
- The audit also cleared: no stale `.agent-messenger` references, no dead exports, no `.gitignore` change needed, and the empty-legacy-directory case correctly hits the `rmdir` branch rather than the both-populated conflict.

## Verification

- `bun run typecheck` — 0 errors.
- `bun run lint` — 0 errors, 69 pre-existing warnings.
- `bun run format:check` — clean.
- `bun run test` — 12282 pass, 31 skip, 0 fail.
