### PR TITLE
Fix the lifecycle race that can strand LINE keys

### DIFF
--- a/src/agent-messenger/host-config-dir.test.ts
+++ b/src/agent-messenger/host-config-dir.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 
 import type { DockerExec } from '@/container/shared'
 
@@ -33,6 +33,33 @@ describe('prepareAgentMessengerHostConfigDir', () => {
     expect(await readFile(join(agentDir, 'workspace', '.config', 'agent-messenger', 'session.json'), 'utf8')).toBe(
       'legacy-session',
     )
+  })
+
+  test('re-probes before migration and refuses when the container became running', async () => {
+    const legacy = join(agentDir, 'workspace', '.agent-messenger')
+    const canonical = join(agentDir, 'workspace', '.config', 'agent-messenger')
+    await mkdir(legacy, { recursive: true })
+    await writeFile(join(legacy, 'session.json'), 'legacy-session')
+    let inspections = 0
+    const exec: DockerExec = async () => {
+      inspections += 1
+      return inspections === 1
+        ? { exitCode: 0, stdout: 'false\n[]\n', stderr: '' }
+        : {
+            exitCode: 0,
+            stdout: 'true\n["AGENT_MESSENGER_CONFIG_DIR=/agent/workspace/.config/agent-messenger"]\n',
+            stderr: '',
+          }
+    }
+
+    const result = await prepareAgentMessengerHostConfigDir(agentDir, { exec })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: `Container ${basename(agentDir)} became running while authentication was being prepared. No credentials were written; retry authentication.`,
+    })
+    expect(await readFile(join(legacy, 'session.json'), 'utf8')).toBe('legacy-session')
+    expect(existsSync(canonical)).toBe(false)
   })
 
   test('uses a running container legacy env without changing either filesystem location', async () => {

--- a/src/agent-messenger/host-config-dir.ts
+++ b/src/agent-messenger/host-config-dir.ts
@@ -1,5 +1,6 @@
 import { join, posix } from 'node:path'
 
+import type { WithAgentOperationLock } from '@/container/agent-operation-lock'
 import { containerNameFromCwd, defaultDockerExec, type DockerExec, isGenuineMissingContainer } from '@/container/shared'
 
 import { migrateAgentMessengerConfigDir, resolveAgentMessengerConfigPolicy } from './config-dir'
@@ -9,14 +10,15 @@ const CONFIG_ENV_PREFIX = 'AGENT_MESSENGER_CONFIG_DIR='
 
 export type HostAgentMessengerConfigResult = { ok: true; hostDir: string } | { ok: false; reason: string }
 
-export type HostAgentMessengerConfigDeps = { exec?: DockerExec }
+export type HostAgentMessengerConfigDeps = { exec?: DockerExec; operationLock?: WithAgentOperationLock }
 
 export async function prepareAgentMessengerHostConfigDir(
   agentDir: string,
   deps: HostAgentMessengerConfigDeps = {},
 ): Promise<HostAgentMessengerConfigResult> {
   const exec = deps.exec ?? defaultDockerExec
-  const inspected = await inspectRunningConfig(exec, containerNameFromCwd(agentDir))
+  const containerName = containerNameFromCwd(agentDir)
+  const inspected = await inspectRunningConfig(exec, containerName)
   if (!inspected.ok) return inspected
 
   if (inspected.state === 'running') {
@@ -26,6 +28,14 @@ export async function prepareAgentMessengerHostConfigDir(
   try {
     const policy = resolveAgentMessengerConfigPolicy(agentDir)
     if (policy.migrate) {
+      const reprobed = await inspectRunningConfig(exec, containerName)
+      if (!reprobed.ok) return reprobed
+      if (reprobed.state === 'running') {
+        return {
+          ok: false,
+          reason: `Container ${containerName} became running while authentication was being prepared. No credentials were written; retry authentication.`,
+        }
+      }
       const migration = await migrateAgentMessengerConfigDir(agentDir)
       if (!migration.ok) return migration
     }

--- a/src/cli/channel.ts
+++ b/src/cli/channel.ts
@@ -654,16 +654,12 @@ async function maybePromptCredentialRefresh(
     return
   }
 
-  const stopped = await controller.stop({ cwd })
-  if (!stopped.ok) {
-    console.error(errorLine(`Restart failed during stop: ${stopped.reason}`))
+  const restarted = await controller.restart({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
+  if (!restarted.ok) {
+    console.error(errorLine(formatRestartFailure(restarted.reason)))
     process.exit(1)
   }
-  const started = await controller.start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
-  if (!started.ok) {
-    console.error(errorLine(`Restart failed during start: ${started.reason}`))
-    process.exit(1)
-  }
+  const started = restarted.start
   done({
     title: c.green(`${label} ${verbPast}. Restarted ${started.plan.containerName} on host port ${started.hostPort}.`),
     hints: [
@@ -2002,16 +1998,12 @@ async function maybePromptRestart(
     return
   }
 
-  const stopped = await controller.stop({ cwd })
-  if (!stopped.ok) {
-    console.error(errorLine(`Restart failed during stop: ${stopped.reason}`))
+  const restarted = await controller.restart({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
+  if (!restarted.ok) {
+    console.error(errorLine(formatRestartFailure(restarted.reason)))
     process.exit(1)
   }
-  const started = await controller.start({ cwd, preferredHostPort: config.port, cliEntry: process.argv[1] })
-  if (!started.ok) {
-    console.error(errorLine(`Restart failed during start: ${started.reason}`))
-    process.exit(1)
-  }
+  const started = restarted.start
   done({
     title: c.green(
       `${label} channel ${verb}. Restarted ${started.plan.containerName} on host port ${started.hostPort}.`,
@@ -2021,4 +2013,11 @@ async function maybePromptRestart(
       { label: 'Follow logs:', command: 'typeclaw logs -f' },
     ],
   })
+}
+
+function formatRestartFailure(reason: string): string {
+  if (reason.startsWith('stop failed: ')) return `Restart failed during stop: ${reason.slice('stop failed: '.length)}`
+  if (reason.startsWith('start failed: '))
+    return `Restart failed during start: ${reason.slice('start failed: '.length)}`
+  return `Restart failed: ${reason}`
 }

--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -2,20 +2,19 @@ import { describe, expect, test } from 'bun:test'
 import { join } from 'node:path'
 
 import { configSchema } from '@/config'
-import type { StartOptions, StartResult } from '@/container'
+import type { RestartOptions, RestartResult, StartOptions, StartResult } from '@/container'
 
 import { buildHostdRestart, buildHostdRestartPreflight } from './hostd'
 
 describe('buildHostdRestart', () => {
   test('restarts through the already-running hostd instead of triggering drift respawn', async () => {
-    const starts: StartOptions[] = []
+    const starts: RestartOptions[] = []
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {
       validateConfig: () => ({ ok: true }),
-      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
       loadConfigSync: () => configSchema.parse({ port: 61234 }),
-      start: async (opts) => {
+      restart: async (opts) => {
         starts.push(opts)
-        return startOk(opts)
+        return restartOk(opts)
       },
     })
 
@@ -33,14 +32,13 @@ describe('buildHostdRestart', () => {
   })
 
   test('forwards build:true to start() as forceBuild', async () => {
-    const starts: StartOptions[] = []
+    const starts: RestartOptions[] = []
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {
       validateConfig: () => ({ ok: true }),
-      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
       loadConfigSync: () => configSchema.parse({ port: 61234 }),
-      start: async (opts) => {
+      restart: async (opts) => {
         starts.push(opts)
-        return startOk(opts)
+        return restartOk(opts)
       },
     })
 
@@ -52,16 +50,15 @@ describe('buildHostdRestart', () => {
   })
 
   test('refuses daemon-owned restart when hostd source has drifted', async () => {
-    const starts: StartOptions[] = []
+    const starts: RestartOptions[] = []
     const restart = buildHostdRestart(
       join(process.cwd(), 'src/cli/index.ts'),
       {
         validateConfig: () => ({ ok: true }),
-        stop: async () => ({ ok: true, containerName: 'agent', running: true }),
         loadConfigSync: () => configSchema.parse({ port: 61234 }),
-        start: async (opts) => {
+        restart: async (opts) => {
           starts.push(opts)
-          return startOk(opts)
+          return restartOk(opts)
         },
       },
       'stale-version',
@@ -131,15 +128,14 @@ describe('buildHostdRestart', () => {
   })
 
   test('forwards the daemon-supplied currentHostDaemon into start()', async () => {
-    const starts: StartOptions[] = []
+    const starts: RestartOptions[] = []
     const register = async (): Promise<{ ok: true }> => ({ ok: true })
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {
       validateConfig: () => ({ ok: true }),
-      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
       loadConfigSync: () => configSchema.parse({ port: 61234 }),
-      start: async (opts) => {
+      restart: async (opts) => {
         starts.push(opts)
-        return startOk(opts)
+        return restartOk(opts)
       },
     })
 
@@ -154,14 +150,13 @@ describe('buildHostdRestart', () => {
   })
 
   test('omits currentHostDaemon when the daemon does not supply one', async () => {
-    const starts: StartOptions[] = []
+    const starts: RestartOptions[] = []
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {
       validateConfig: () => ({ ok: true }),
-      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
       loadConfigSync: () => configSchema.parse({ port: 61234 }),
-      start: async (opts) => {
+      restart: async (opts) => {
         starts.push(opts)
-        return startOk(opts)
+        return restartOk(opts)
       },
     })
 
@@ -171,14 +166,13 @@ describe('buildHostdRestart', () => {
   })
 
   test('omitted build defaults to forceBuild:false', async () => {
-    const starts: StartOptions[] = []
+    const starts: RestartOptions[] = []
     const restart = buildHostdRestart('/repo/src/cli/index.ts', {
       validateConfig: () => ({ ok: true }),
-      stop: async () => ({ ok: true, containerName: 'agent', running: true }),
       loadConfigSync: () => configSchema.parse({ port: 61234 }),
-      start: async (opts) => {
+      restart: async (opts) => {
         starts.push(opts)
-        return startOk(opts)
+        return restartOk(opts)
       },
     })
 
@@ -189,7 +183,7 @@ describe('buildHostdRestart', () => {
   })
 })
 
-function startOk(opts: StartOptions): StartResult {
+function startOk(opts: StartOptions): Extract<StartResult, { ok: true }> {
   return {
     ok: true,
     plan: {
@@ -211,5 +205,13 @@ function startOk(opts: StartOptions): StartResult {
     autoUpgrade: { kind: 'skipped-no-dep' },
     skippedPlugins: [],
     dockerfileWarnings: [],
+  }
+}
+
+function restartOk(opts: RestartOptions): RestartResult {
+  return {
+    ok: true,
+    stop: { ok: true, containerName: 'agent', running: true },
+    start: startOk({ cwd: opts.cwd, preferredHostPort: opts.preferredHostPort }),
   }
 }

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -5,9 +5,8 @@ import {
   resolveController,
   resolveHostPort,
   resolveTuiToken,
-  type StartOptions,
-  type StartResult,
-  type StopResult,
+  type RestartOptions,
+  type RestartResult,
 } from '@/container'
 import {
   applyCredentialRotation,
@@ -116,17 +115,15 @@ export const hostdCommand = defineCommand({
 
 export type HostdRestartDeps = {
   validateConfig: (cwd: string) => ValidateConfigResult
-  stop: (opts: { cwd: string }) => Promise<StopResult>
   loadConfigSync: (cwd: string) => Config
-  start: (opts: StartOptions) => Promise<StartResult>
+  restart: (opts: RestartOptions) => Promise<RestartResult>
 }
 
 const controller = resolveController()
 const defaultRestartDeps: HostdRestartDeps = {
   validateConfig,
-  stop: (opts) => controller.stop(opts),
   loadConfigSync,
-  start: (opts) => controller.start(opts),
+  restart: (opts) => controller.restart(opts),
 }
 
 export function buildHostdRestart(
@@ -134,7 +131,7 @@ export function buildHostdRestart(
   deps: HostdRestartDeps = defaultRestartDeps,
   daemonVersion?: string,
 ): SupervisorRestart {
-  return async ({ containerName, cwd, build = false, currentHostDaemon }) => {
+  return async ({ containerName, cwd, build = false, currentHostDaemon, operationLease }) => {
     const drift = await detectSourceDrift(cliEntry, daemonVersion)
     if (drift) return { ok: false, reason: drift }
 
@@ -142,19 +139,17 @@ export function buildHostdRestart(
     if (!validated.ok) {
       return { ok: false, reason: `invalid config for ${containerName}: ${validated.reason}` }
     }
-    const stopResult = await deps.stop({ cwd })
-    if (!stopResult.ok) return { ok: false, reason: `stop failed: ${stopResult.reason}` }
-
     const cfg = deps.loadConfigSync(cwd)
-    const startResult = await deps.start({
+    const restartResult = await deps.restart({
       cwd,
       preferredHostPort: cfg.port,
       forceBuild: build,
       cliEntry,
       reuseCurrentHostDaemon: true,
+      operationLease,
       ...(currentHostDaemon ? { currentHostDaemon } : {}),
     })
-    if (!startResult.ok) return { ok: false, reason: `start failed: ${startResult.reason}` }
+    if (!restartResult.ok) return restartResult
     return { ok: true }
   }
 }

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -74,28 +74,26 @@ export const restartCommand = defineCommand({
 
     const stopSpin = spinner()
     stopSpin.start('Stopping container...')
-    const stopped = await controller.stop({ cwd })
-    if (!stopped.ok) {
-      stopSpin.error(stopped.reason)
-      process.exit(1)
-    }
-    stopSpin.stop(stopped.running ? `Stopped ${c.cyan(stopped.containerName)}.` : 'Already stopped.')
-
-    const startSpin = spinner()
-    startSpin.start('Starting container...')
-    const started = await controller.start({
+    let startSpin: ReturnType<typeof spinner> | undefined
+    const restarted = await controller.restart({
       cwd,
       preferredHostPort: Number(args.port),
       forceBuild: args.build,
       cliEntry: process.argv[1],
+      onStopped: (stopped) => {
+        stopSpin.stop(stopped.running ? `Stopped ${c.cyan(stopped.containerName)}.` : 'Already stopped.')
+        startSpin = spinner()
+        startSpin.start('Starting container...')
+      },
     })
-    if (!started.ok) {
-      startSpin.error(started.reason)
+    if (!restarted.ok) {
+      if (startSpin === undefined) stopSpin.error(restarted.reason)
+      else startSpin.error(restarted.reason)
       process.exit(1)
     }
-    startSpin.stop('Started.')
+    startSpin?.stop('Started.')
 
-    reportConfigWarnings(started.dockerfileWarnings)
-    console.log(renderStartSuccess(started))
+    reportConfigWarnings(restarted.start.dockerfileWarnings)
+    console.log(renderStartSuccess(restarted.start))
   },
 })

--- a/src/compose/restart.ts
+++ b/src/compose/restart.ts
@@ -58,12 +58,20 @@ async function runOne(
   if (!validated.ok) return { name, ok: false, reason: validated.reason }
   try {
     const controller = resolveController()
-    const stopped = await controller.stop({ cwd })
-    if (!stopped.ok) return { name, ok: false, reason: stopped.reason }
-    onStopped()
-    const started = await controller.start({ cwd, preferredHostPort, forceBuild, cliEntry })
-    if (!started.ok) return { name, ok: false, reason: started.reason }
-    return { name, ok: true, data: { stop: stopped, start: started }, warnings: validated.warnings }
+    const restarted = await controller.restart({
+      cwd,
+      preferredHostPort,
+      forceBuild,
+      cliEntry,
+      onStopped,
+    })
+    if (!restarted.ok) return { name, ok: false, reason: restarted.reason }
+    return {
+      name,
+      ok: true,
+      data: { stop: restarted.stop, start: restarted.start },
+      warnings: validated.warnings,
+    }
   } catch (error) {
     return { name, ok: false, reason: error instanceof Error ? error.message : String(error) }
   }

--- a/src/container/agent-operation-lock.test.ts
+++ b/src/container/agent-operation-lock.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+
+import { reserveAgentOperationLock, withAgentOperationLock } from './agent-operation-lock'
+import { containerNameFromCwd } from './shared'
+
+let root: string
+let previousHome: string | undefined
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'typeclaw-agent-lock-'))
+  previousHome = process.env.TYPECLAW_HOME
+  process.env.TYPECLAW_HOME = join(root, 'home')
+})
+
+afterEach(async () => {
+  if (previousHome === undefined) delete process.env.TYPECLAW_HOME
+  else process.env.TYPECLAW_HOME = previousHome
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('withAgentOperationLock', () => {
+  test('contends for the same agent while allowing a different agent', async () => {
+    const firstAgent = join(root, 'alpha')
+    const secondAgent = join(root, 'bravo')
+    await mkdir(firstAgent)
+    await mkdir(secondAgent)
+    const holder = deferred<void>()
+    const entered = deferred<void>()
+
+    const first = withAgentOperationLock({ agentDir: firstAgent, operation: 'line-auth' }, async () => {
+      entered.resolve()
+      await holder.promise
+      return 'first'
+    })
+    await entered.promise
+
+    const different = await withAgentOperationLock({ agentDir: secondAgent, operation: 'start' }, async () => 'second')
+    const contended = await withAgentOperationLock({ agentDir: firstAgent, operation: 'stop' }, async () => 'never')
+
+    expect(different).toEqual({ ok: true, value: 'second' })
+    expect(contended).toEqual({
+      ok: false,
+      reason: `Another TypeClaw lifecycle or channel-auth operation is already in progress for agent \`${containerNameFromCwd(firstAgent)}\`. Wait for it to finish, then retry. If the previous process was killed, the lock is reclaimed within 30 seconds.`,
+    })
+
+    holder.resolve()
+    expect(await first).toEqual({ ok: true, value: 'first' })
+  })
+
+  test('a matching lease skips reacquisition', async () => {
+    const agentDir = join(root, 'alpha')
+    await mkdir(agentDir)
+
+    const result = await withAgentOperationLock({ agentDir, operation: 'restart' }, async (lease) => {
+      return await withAgentOperationLock({ agentDir, operation: 'start', lease }, async (innerLease) => innerLease)
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        ok: true,
+        value: { containerName: containerNameFromCwd(agentDir), agentDir: resolve(agentDir) },
+      },
+    })
+  })
+
+  test('a mismatched lease fails without running the operation', async () => {
+    const agentDir = join(root, 'alpha')
+    await mkdir(agentDir)
+    let ran = false
+
+    const result = await withAgentOperationLock(
+      {
+        agentDir,
+        operation: 'start',
+        lease: { containerName: `typeclaw-${basename(root)}`, agentDir: root },
+      },
+      async () => {
+        ran = true
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(ran).toBe(false)
+    if (result.ok) throw new Error('expected mismatched lease failure')
+    expect(result.reason).toContain('does not match')
+  })
+})
+
+describe('reserveAgentOperationLock', () => {
+  test('holds one agent lock until release while allowing a different agent', async () => {
+    const firstAgent = join(root, 'alpha')
+    const secondAgent = join(root, 'bravo')
+    await mkdir(firstAgent)
+    await mkdir(secondAgent)
+
+    const first = await reserveAgentOperationLock({ agentDir: firstAgent, operation: 'line-auth' })
+    expect(first.ok).toBe(true)
+    if (!first.ok) throw new Error('expected first reservation to succeed')
+
+    const different = await reserveAgentOperationLock({ agentDir: secondAgent, operation: 'restart' })
+    expect(different.ok).toBe(true)
+    if (!different.ok) throw new Error('expected different agent reservation to succeed')
+
+    const contended = await reserveAgentOperationLock({ agentDir: firstAgent, operation: 'restart' })
+    expect(contended).toEqual({
+      ok: false,
+      reason: `Another TypeClaw lifecycle or channel-auth operation is already in progress for agent \`${containerNameFromCwd(firstAgent)}\`. Wait for it to finish, then retry. If the previous process was killed, the lock is reclaimed within 30 seconds.`,
+    })
+
+    await first.release()
+    const subsequent = await reserveAgentOperationLock({ agentDir: firstAgent, operation: 'stop' })
+    expect(subsequent.ok).toBe(true)
+    if (!subsequent.ok) throw new Error('expected reservation after release to succeed')
+
+    await subsequent.release()
+    await different.release()
+  })
+})
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolvePromise: (value: T) => void = () => {}
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}

--- a/src/container/agent-operation-lock.ts
+++ b/src/container/agent-operation-lock.ts
@@ -1,0 +1,85 @@
+import { resolve } from 'node:path'
+
+import lockfile from 'proper-lockfile'
+
+import { agentOperationLockPath, ensureAgentOperationLocksDir } from '@/hostd/paths'
+
+import { containerNameFromCwd } from './shared'
+
+export type AgentOperation = 'start' | 'stop' | 'restart' | 'line-auth' | 'instagram-auth'
+export type AgentOperationLease = { readonly containerName: string; readonly agentDir: string }
+export type AgentOperationReservation =
+  | { ok: true; lease: AgentOperationLease; release: () => Promise<void> }
+  | { ok: false; reason: string }
+export type ReserveAgentOperationLock = (input: {
+  agentDir: string
+  operation: AgentOperation
+}) => Promise<AgentOperationReservation>
+export type AgentOperationLockResult<T> = { ok: true; value: T } | { ok: false; reason: string }
+export type WithAgentOperationLock = <T>(
+  input: { agentDir: string; operation: AgentOperation; lease?: AgentOperationLease },
+  run: (lease: AgentOperationLease) => Promise<T>,
+) => Promise<AgentOperationLockResult<T>>
+
+export const withAgentOperationLock: WithAgentOperationLock = async (input, run) => {
+  const agentDir = resolve(input.agentDir)
+  const containerName = containerNameFromCwd(agentDir)
+
+  if (input.lease !== undefined) {
+    if (input.lease.containerName !== containerName || resolve(input.lease.agentDir) !== agentDir) {
+      return {
+        ok: false,
+        reason: `Agent operation lease does not match agent ${containerName} at ${agentDir}.`,
+      }
+    }
+    return { ok: true, value: await run(input.lease) }
+  }
+
+  // Acquisition is deliberately outside the try that runs the operation: an
+  // ELOCKED thrown from inside `run` (a nested lifecycle call) must not be
+  // reported as contention for THIS lock.
+  const reservation = await reserveAgentOperationLock(input)
+  if (!reservation.ok) return reservation
+
+  try {
+    return { ok: true, value: await run(reservation.lease) }
+  } finally {
+    await reservation.release()
+  }
+}
+
+export const reserveAgentOperationLock: ReserveAgentOperationLock = async (input) => {
+  const agentDir = resolve(input.agentDir)
+  const containerName = containerNameFromCwd(agentDir)
+  const lease = { containerName, agentDir }
+  await ensureAgentOperationLocksDir()
+  const path = agentOperationLockPath(containerName)
+
+  let releaseLock: () => Promise<void>
+  try {
+    // Interactive QR and checkpoint prompts can hold this lease for minutes, so
+    // contenders fail after a bounded wait instead of queueing behind a human.
+    releaseLock = await lockfile.lock(path, {
+      lockfilePath: path,
+      realpath: false,
+      stale: 30_000,
+      retries: { retries: 20, factor: 1, minTimeout: 100, maxTimeout: 100, randomize: false },
+    })
+  } catch (error) {
+    if (errorCode(error) === 'ELOCKED') {
+      return {
+        ok: false,
+        reason: `Another TypeClaw lifecycle or channel-auth operation is already in progress for agent \`${containerName}\`. Wait for it to finish, then retry. If the previous process was killed, the lock is reclaimed within 30 seconds.`,
+      }
+    }
+    throw error
+  }
+
+  return { ok: true, lease, release: async () => await releaseLock().catch(() => {}) }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined
+}

--- a/src/container/controller.ts
+++ b/src/container/controller.ts
@@ -1,4 +1,5 @@
 import { logs, type LogsOptions, type LogsResult } from './logs'
+import { restart, type RestartOptions, type RestartResult } from './restart'
 import { containerNameFromCwd, imageTagFromCwd } from './shared'
 import { shell, type ShellResult } from './shell'
 import { start, type StartOptions, type StartResult } from './start'
@@ -17,6 +18,7 @@ import { stop, type StopOptions, type StopResult } from './stop'
 export interface Controller {
   start(options: StartOptions): Promise<StartResult>
   stop(options: StopOptions): Promise<StopResult>
+  restart(options: RestartOptions): Promise<RestartResult>
   status(options: StatusOptions): Promise<ContainerStatus>
   stats(options: StatsOptions): Promise<ContainerStats>
   logs(options: LogsOptions): Promise<LogsResult>
@@ -31,6 +33,7 @@ export function createLocalDockerController(): Controller {
   return {
     start: (options) => start(options),
     stop: (options) => stop(options),
+    restart: (options) => restart(options),
     status: (options) => status(options),
     stats: (options) => stats(options),
     logs: (options) => logs(options),
@@ -52,6 +55,9 @@ export function createNoopController(): Controller {
     },
     async stop({ cwd }) {
       return { ok: false, reason: unsupported('stop', cwd) }
+    },
+    async restart({ cwd }) {
+      return { ok: false, reason: unsupported('restart', cwd) }
     },
     async status({ cwd }) {
       return { kind: 'missing', containerName: containerNameFromCwd(cwd), imageTag: imageTagFromCwd(cwd) }

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -54,3 +54,11 @@ export {
   type StartResult,
 } from './start'
 export { planStop, stop, type StopOptions, type StopPlan, type StopResult } from './stop'
+export { restart, type RestartOptions, type RestartResult } from './restart'
+export {
+  type AgentOperation,
+  type AgentOperationLease,
+  type AgentOperationLockResult,
+  type WithAgentOperationLock,
+  withAgentOperationLock,
+} from './agent-operation-lock'

--- a/src/container/restart.test.ts
+++ b/src/container/restart.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+import { resolve } from 'node:path'
+
+import type { AgentOperation, AgentOperationLease, WithAgentOperationLock } from './agent-operation-lock'
+import { restart } from './restart'
+
+describe('restart', () => {
+  test('threads one lease through stop and start without reacquiring', async () => {
+    const cwd = '/tmp/test-agent'
+    const lease = { containerName: 'test-agent', agentDir: resolve(cwd) }
+    const calls: Array<{ operation: string; lease?: AgentOperationLease }> = []
+    const operationLock: WithAgentOperationLock = async <T>(
+      input: { agentDir: string; operation: AgentOperation; lease?: AgentOperationLease },
+      run: (lease: AgentOperationLease) => Promise<T>,
+    ) => {
+      calls.push({ operation: input.operation, lease: input.lease })
+      if (input.operation === 'restart') return { ok: true, value: await run(lease) }
+      if (input.operation === 'stop') {
+        const value = { ok: true, containerName: lease.containerName, running: true }
+        return { ok: true, value: value as T }
+      }
+      return { ok: true, value: successfulStart(lease.containerName) as T }
+    }
+
+    const result = await restart({ cwd, preferredHostPort: 8973, operationLock })
+
+    expect(result.ok).toBe(true)
+    expect(calls).toEqual([
+      { operation: 'restart', lease: undefined },
+      { operation: 'stop', lease },
+      { operation: 'start', lease },
+    ])
+  })
+
+  test('short-circuits start when stop fails', async () => {
+    const operations: string[] = []
+    const operationLock: WithAgentOperationLock = async <T>(
+      input: { agentDir: string; operation: AgentOperation; lease?: AgentOperationLease },
+      run: (lease: AgentOperationLease) => Promise<T>,
+    ) => {
+      operations.push(input.operation)
+      if (input.operation === 'restart') {
+        return {
+          ok: true,
+          value: await run({ containerName: 'test-agent', agentDir: resolve(input.agentDir) }),
+        }
+      }
+      return { ok: true, value: { ok: false, reason: 'cannot stop' } as T }
+    }
+
+    const result = await restart({ cwd: '/tmp/test-agent', preferredHostPort: 8973, operationLock })
+
+    expect(result).toEqual({ ok: false, reason: 'stop failed: cannot stop' })
+    expect(operations).toEqual(['restart', 'stop'])
+  })
+})
+
+function successfulStart(containerName: string) {
+  return {
+    ok: true as const,
+    plan: {
+      containerName,
+      imageTag: `${containerName}:latest`,
+      buildContext: '/tmp/test-agent',
+      dockerfile: '/tmp/test-agent/Dockerfile',
+      runArgs: [],
+      needsBuild: false,
+      hostPort: 8973,
+      tuiToken: null,
+    },
+    containerId: 'a'.repeat(64),
+    built: false,
+    hostPort: 8973,
+    tuiToken: null,
+    hostd: { state: 'disabled' as const },
+    alreadyRunning: false,
+    autoUpgrade: { kind: 'up-to-date' as const, installedVersion: '0.48.0' },
+    skippedPlugins: [],
+    dockerfileWarnings: [],
+  }
+}

--- a/src/container/restart.ts
+++ b/src/container/restart.ts
@@ -1,0 +1,55 @@
+import { type AgentOperationLease, type WithAgentOperationLock, withAgentOperationLock } from './agent-operation-lock'
+import { type CurrentHostDaemon, start, type StartResult } from './start'
+import { stop, type StopResult } from './stop'
+
+export type RestartOptions = {
+  cwd: string
+  preferredHostPort: number
+  forceBuild?: boolean
+  cliEntry?: string
+  reuseCurrentHostDaemon?: boolean
+  currentHostDaemon?: CurrentHostDaemon
+  onStopped?: (result: Extract<StopResult, { ok: true }>) => void
+  operationLock?: WithAgentOperationLock
+  operationLease?: AgentOperationLease
+}
+
+export type RestartResult =
+  | { ok: true; stop: Extract<StopResult, { ok: true }>; start: Extract<StartResult, { ok: true }> }
+  | { ok: false; reason: string }
+
+export async function restart(options: RestartOptions): Promise<RestartResult> {
+  const operationLock = options.operationLock ?? withAgentOperationLock
+  try {
+    const locked = await operationLock(
+      { agentDir: options.cwd, operation: 'restart', lease: options.operationLease },
+      async (lease) => await restartWithLease(options, lease, operationLock),
+    )
+    return locked.ok ? locked.value : { ok: false, reason: locked.reason }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+async function restartWithLease(
+  options: RestartOptions,
+  lease: AgentOperationLease,
+  operationLock: WithAgentOperationLock,
+): Promise<RestartResult> {
+  const stopped = await stop({ cwd: options.cwd, operationLock, operationLease: lease })
+  if (!stopped.ok) return { ok: false, reason: `stop failed: ${stopped.reason}` }
+  options.onStopped?.(stopped)
+
+  const started = await start({
+    cwd: options.cwd,
+    preferredHostPort: options.preferredHostPort,
+    forceBuild: options.forceBuild,
+    cliEntry: options.cliEntry,
+    reuseCurrentHostDaemon: options.reuseCurrentHostDaemon,
+    currentHostDaemon: options.currentHostDaemon,
+    operationLock,
+    operationLease: lease,
+  })
+  if (!started.ok) return { ok: false, reason: `start failed: ${started.reason}` }
+  return { ok: true, stop: stopped, start: started }
+}

--- a/src/container/start.test.ts
+++ b/src/container/start.test.ts
@@ -15,6 +15,7 @@ import { buildDockerfile } from '@/init/dockerfile'
 import { buildGitignore } from '@/init/gitignore'
 import { isWindows } from '@/shared'
 
+import type { WithAgentOperationLock } from './agent-operation-lock'
 import type { DockerExec } from './shared'
 import {
   commitSystemFile,
@@ -1640,6 +1641,108 @@ function fakeDockerExec(scenario: {
 }
 
 describe('start (composition)', () => {
+  test('holds the operation lock from inspection through migration, launch, and verification', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const legacy = join(root, 'workspace', '.agent-messenger')
+    const canonical = join(root, 'workspace', '.config', 'agent-messenger')
+    await mkdir(legacy, { recursive: true })
+    await writeFile(join(legacy, 'key'), 'material')
+    const docker = fakeDockerExec({ imageExists: true, container: { exists: false } })
+    const events: string[] = []
+    let recordedInspect = false
+    const exec: DockerExec = async (args, options) => {
+      if (args[0] === 'inspect' && !recordedInspect) {
+        recordedInspect = true
+        events.push('inspect')
+      }
+      if (args[0] === 'run') {
+        if (!existsSync(legacy) && existsSync(join(canonical, 'key'))) events.push('migration')
+        events.push('docker-run')
+      }
+      return await docker.exec(args, options)
+    }
+    const operationLock: WithAgentOperationLock = async (input, run) => {
+      events.push('lock-enter')
+      const value = await run({ containerName: basename(input.agentDir), agentDir: input.agentDir })
+      events.push('lock-exit')
+      return { ok: true, value }
+    }
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      exec,
+      operationLock,
+      allocatePort: deterministicAllocator,
+      ensureDeps: noEnsureDeps,
+      ensureModels: noEnsureModels,
+      autoUpgrade: noAutoUpgrade,
+      verifyRunning: async () => {
+        events.push('verify')
+        return { ok: true }
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(events).toEqual(['lock-enter', 'inspect', 'migration', 'docker-run', 'verify', 'lock-exit'])
+  })
+
+  test('contention prevents Docker and agent-messenger migration side effects', async () => {
+    const legacy = join(root, 'workspace', '.agent-messenger')
+    const canonical = join(root, 'workspace', '.config', 'agent-messenger')
+    await mkdir(legacy, { recursive: true })
+    await writeFile(join(legacy, 'key'), 'material')
+    const calls: string[][] = []
+    const operationLock: WithAgentOperationLock = async () => ({ ok: false, reason: 'contended' })
+
+    const result = await start({
+      cwd: root,
+      preferredHostPort: 8973,
+      operationLock,
+      exec: async (args) => {
+        calls.push(args)
+        return { exitCode: 0, stdout: '', stderr: '' }
+      },
+      ensureModels: noEnsureModels,
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'contended' })
+    expect(calls).toEqual([])
+    expect(await readFile(join(legacy, 'key'), 'utf8')).toBe('material')
+    expect(existsSync(canonical)).toBe(false)
+  })
+
+  test('re-probes immediately before migration and refuses a container that became running', async () => {
+    await writeDockerfile(root)
+    await writePackageJson(root, { typeclaw: '^0.1.0' })
+    const legacy = join(root, 'workspace', '.agent-messenger')
+    const canonical = join(root, 'workspace', '.config', 'agent-messenger')
+    await mkdir(legacy, { recursive: true })
+    await writeFile(join(legacy, 'key'), 'material')
+    let inspections = 0
+    const calls: string[][] = []
+    const exec: DockerExec = async (args) => {
+      calls.push(args)
+      if (args[0] === 'inspect') {
+        inspections += 1
+        if (inspections === 1) return { exitCode: 1, stdout: '', stderr: 'No such container' }
+        return { exitCode: 0, stdout: `${'a'.repeat(64)}|true\n`, stderr: '' }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' }
+    }
+
+    const result = await start({ cwd: root, preferredHostPort: 8973, exec, ensureModels: noEnsureModels })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: `Container ${basename(root)} became running during start preflight; refusing to migrate agent-messenger credentials or launch a replacement.`,
+    })
+    expect(await readFile(join(legacy, 'key'), 'utf8')).toBe('material')
+    expect(existsSync(canonical)).toBe(false)
+    expect(calls.some((args) => args[0] === 'run')).toBe(false)
+  })
+
   test('fails closed before migration or launch when Docker container state is indeterminate', async () => {
     await writeDockerfile(root)
     await writePackageJson(root, { typeclaw: '^0.1.0' })
@@ -3359,7 +3462,7 @@ describe('start (composition)', () => {
     })
 
     expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.reason).toMatch(/became running.*preserving/i)
+    if (!result.ok) expect(result.reason).toMatch(/became running.*refusing to migrate/i)
     expect(archived).toBe(false)
     expect(calls.some((call) => call.args[0] === 'rm' || call.args[0] === 'run')).toBe(false)
   })
@@ -3489,7 +3592,7 @@ describe('start (composition)', () => {
     })
 
     expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.reason).toMatch(/safely inspected.*preserving/i)
+    if (!result.ok) expect(result.reason).toMatch(/malformed.*preserving/i)
     expect(archived).toBe(false)
     expect(calls.some((call) => call.args[0] === 'rm' || call.args[0] === 'run')).toBe(false)
   })
@@ -3731,7 +3834,7 @@ describe('start (composition)', () => {
       if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
       if (args[0] === 'inspect') {
         inspectCalls++
-        if (inspectCalls === 1) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+        if (inspectCalls <= 2) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
         return { exitCode: 0, stdout: `${corpseId}|false\n`, stderr: '' }
       }
       if (args[0] === 'run') {
@@ -3781,8 +3884,8 @@ describe('start (composition)', () => {
       if (args[0] === 'image' && args[1] === 'inspect') return { exitCode: 0, stdout: '', stderr: '' }
       if (args[0] === 'inspect') {
         probeAttempts++
-        // First inspect (start's preflight) reports gone so we proceed to docker run.
-        if (probeAttempts === 1) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+        // Both start preflight probes report gone so we proceed to docker run.
+        if (probeAttempts <= 2) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
         // Subsequent inspect (the retry-path corpse probe) reports running=true.
         // cleanupRunCorpse uses `{{.Id}}|{{.State.Running}}`; non-cleanupRunCorpse
         // callers use just State.Running. Emit both formats so either parser works.
@@ -3922,10 +4025,10 @@ describe('start (composition)', () => {
       if (args[0] === 'inspect') {
         if (!rmReturned) {
           inspectsBeforeRm++
-          // First inspect is start's preflight (name is free); second is
-          // cleanupRunCorpse's pre-rm probe AFTER the failed docker run
+          // First two inspects are start's preflight probes (name is free);
+          // third is cleanupRunCorpse's pre-rm probe AFTER the failed docker run
           // has populated the corpse — it must see the corpse to issue rm.
-          if (inspectsBeforeRm === 1) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
+          if (inspectsBeforeRm <= 2) return { exitCode: 1, stdout: '', stderr: 'Error: No such container' }
           if (args.includes('{{.Id}}|{{.State.Running}}')) {
             return { exitCode: 0, stdout: `${corpseId}|false\n`, stderr: '' }
           }

--- a/src/container/start.ts
+++ b/src/container/start.ts
@@ -33,6 +33,7 @@ import { linkWindowsDevTypeclaw, resolveBunLinkedPackage, type RunBunLink } from
 import { isWindows } from '@/shared'
 import { hostLocaleIsCjk } from '@/shared/host-locale'
 
+import { type AgentOperationLease, type WithAgentOperationLock, withAgentOperationLock } from './agent-operation-lock'
 import { archiveContainerLogs, type DockerLogArchiver } from './log-archive'
 import { CONTAINER_PORT, TUI_TOKEN_LABEL, findFreePort, isPortAllocatedError, resolveTuiToken } from './port'
 import {
@@ -178,6 +179,8 @@ export type StartOptions = {
   // Test seam for the host-stage writable-config preflight.
   assertConfigWritable?: (cwd: string) => void
   archiveLogs?: DockerLogArchiver
+  operationLock?: WithAgentOperationLock
+  operationLease?: AgentOperationLease
 }
 
 export type HostDaemonStatus =
@@ -212,7 +215,20 @@ export type StartResult =
     }
   | { ok: false; reason: string }
 
-export async function start({
+export async function start(options: StartOptions): Promise<StartResult> {
+  const operationLock = options.operationLock ?? withAgentOperationLock
+  try {
+    const locked = await operationLock(
+      { agentDir: options.cwd, operation: 'start', lease: options.operationLease },
+      async () => await runStart(options),
+    )
+    return locked.ok ? locked.value : { ok: false, reason: locked.reason }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+async function runStart({
   cwd,
   preferredHostPort,
   forceBuild = false,
@@ -248,7 +264,7 @@ export async function start({
     // side effects (template writes, .gitignore commits, package.json migration)
     // that would surprise a user invoking `compose start` against a partially-up
     // tree.
-    const state = await inspectContainer(exec, containerName)
+    let state = await inspectContainer(exec, containerName)
 
     // Bound gc/repack memory even when start() is an already-running no-op below:
     // the running agent's backup keeps committing, so it must not keep using the
@@ -279,6 +295,25 @@ export async function start({
     assertConfigWritable(cwd)
 
     const agentMessengerPolicy = resolveAgentMessengerConfigPolicy(cwd)
+    state = await inspectContainer(exec, containerName)
+    if (state.kind === 'malformed') {
+      return {
+        ok: false,
+        reason: `docker inspect returned malformed container identity/state (${state.reason}); preserving container ${containerName} and its logs.`,
+      }
+    }
+    if (state.kind === 'indeterminate') {
+      return {
+        ok: false,
+        reason: `Docker state could not be determined for container ${containerName}; TypeClaw is refusing to migrate or launch while the container may be live. Resolve Docker access and retry. ${state.reason}`,
+      }
+    }
+    if (state.kind === 'present' && state.running) {
+      return {
+        ok: false,
+        reason: `Container ${containerName} became running during start preflight; refusing to migrate agent-messenger credentials or launch a replacement.`,
+      }
+    }
     if (agentMessengerPolicy.migrate) {
       const agentMessengerMigration = await migrateAgentMessengerConfigDir(cwd)
       if (!agentMessengerMigration.ok) return { ok: false, reason: agentMessengerMigration.reason }

--- a/src/container/stop.ts
+++ b/src/container/stop.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_LOG_RETENTION_DAYS, loadConfigSync } from '@/config'
 import { isDaemonReachable, send as sendToDaemon } from '@/hostd/client'
 
+import { type AgentOperationLease, type WithAgentOperationLock, withAgentOperationLock } from './agent-operation-lock'
 import { archiveContainerLogs, type DockerLogArchiver } from './log-archive'
 import {
   classifyRmStderr,
@@ -22,9 +23,24 @@ export type StopOptions = {
   cwd: string
   exec?: DockerExec
   archiveLogs?: DockerLogArchiver
+  operationLock?: WithAgentOperationLock
+  operationLease?: AgentOperationLease
 }
 
-export async function stop({
+export async function stop(options: StopOptions): Promise<StopResult> {
+  const operationLock = options.operationLock ?? withAgentOperationLock
+  try {
+    const locked = await operationLock(
+      { agentDir: options.cwd, operation: 'stop', lease: options.operationLease },
+      async () => await runStop(options),
+    )
+    return locked.ok ? locked.value : { ok: false, reason: locked.reason }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+async function runStop({
   cwd,
   exec = defaultDockerExec,
   archiveLogs = archiveContainerLogs,

--- a/src/hostd/daemon.ts
+++ b/src/hostd/daemon.ts
@@ -527,7 +527,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<Daemon> {
       ? await opts.restartPreflight({ containerName: req.containerName, cwd, build: req.build })
       : null
     if (preflight) return preflight
-    const ack = supervisor.scheduleRestart({
+    const ack = await supervisor.scheduleRestart({
       containerName: req.containerName,
       cwd,
       build: req.build,

--- a/src/hostd/paths.ts
+++ b/src/hostd/paths.ts
@@ -8,6 +8,7 @@ import { isWindows } from '@/shared'
 const SOCKET_FILE = 'hostd.sock'
 const REGISTRATIONS_DIR = 'registrations'
 const KEYS_DIR = 'keys'
+const AGENT_OPERATION_LOCKS_DIR = 'agent-locks'
 
 // Defense-in-depth: containerName arrives from RPC payloads (some of which
 // originate inside the container). Docker already forbids slashes and most
@@ -67,6 +68,17 @@ export function registrationsDir(): string {
   return join(runDir(), REGISTRATIONS_DIR)
 }
 
+export function agentOperationLocksDir(): string {
+  return join(runDir(), AGENT_OPERATION_LOCKS_DIR)
+}
+
+export function agentOperationLockPath(containerName: string): string {
+  if (!SAFE_NAME.test(containerName)) {
+    throw new Error(`invalid container name for agent operation lock: ${JSON.stringify(containerName)}`)
+  }
+  return join(agentOperationLocksDir(), `${containerName}.lock`)
+}
+
 export function keysDir(): string {
   return join(homeRoot(), KEYS_DIR)
 }
@@ -100,4 +112,9 @@ export async function ensureDirs(): Promise<void> {
   await chmod(registrationsDir(), 0o700).catch(() => {})
   await chmod(keysDir(), 0o700).catch(() => {})
   await chmod(modelsDir(), 0o700).catch(() => {})
+}
+
+export async function ensureAgentOperationLocksDir(): Promise<void> {
+  await mkdir(agentOperationLocksDir(), { recursive: true })
+  await chmod(agentOperationLocksDir(), 0o700).catch(() => {})
 }

--- a/src/hostd/supervisor.test.ts
+++ b/src/hostd/supervisor.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import {
+  type AgentOperationLease,
+  reserveAgentOperationLock,
+  type ReserveAgentOperationLock,
+} from '@/container/agent-operation-lock'
+
+import { buildSupervisor, type SupervisorLogEvent, type SupervisorRestart } from './supervisor'
+
+describe('buildSupervisor', () => {
+  test('rejects before scheduling when reservation fails', async () => {
+    const logs: SupervisorLogEvent[] = []
+    let restartCalls = 0
+    const supervisor = buildSupervisor({
+      restart: async () => {
+        restartCalls += 1
+        return { ok: true }
+      },
+      reserveLock: async () => ({ ok: false, reason: 'lock contended' }),
+      onLog: (event) => logs.push(event),
+      isStopped: () => false,
+    })
+
+    const result = await supervisor.scheduleRestart({ containerName: 'agent', cwd: '/agent' })
+
+    expect(result).toEqual({ ok: false, reason: 'lock contended' })
+    expect(restartCalls).toBe(0)
+    expect(logs).not.toContainEqual({ kind: 'restart-scheduled', containerName: 'agent', build: false })
+  })
+
+  test.each([
+    ['success', { ok: true } as const],
+    ['failure', { ok: false, reason: 'restart failed' } as const],
+  ])('passes the reserved lease and releases it once after %s', async (_name, restartResult) => {
+    const lease: AgentOperationLease = { containerName: 'agent', agentDir: resolve('/agent') }
+    const restartSettled = deferred<void>()
+    const released = deferred<void>()
+    const restartCalls: AgentOperationLease[] = []
+    let releaseCalls = 0
+    const restart: SupervisorRestart = async (input) => {
+      if (input.operationLease) restartCalls.push(input.operationLease)
+      await restartSettled.promise
+      return restartResult
+    }
+    const reserveLock: ReserveAgentOperationLock = async () => ({
+      ok: true,
+      lease,
+      release: async () => {
+        releaseCalls += 1
+        released.resolve()
+      },
+    })
+    const supervisor = buildSupervisor({ restart, reserveLock, onLog: () => {}, isStopped: () => false })
+
+    expect(await supervisor.scheduleRestart({ containerName: 'agent', cwd: '/agent' })).toEqual({ ok: true })
+    expect(restartCalls).toEqual([lease])
+    expect(restartCalls[0]).toBe(lease)
+    expect(releaseCalls).toBe(0)
+
+    restartSettled.resolve()
+    await released.promise
+    expect(releaseCalls).toBe(1)
+  })
+
+  test('short-circuits a stopped daemon before reservation', async () => {
+    let reservationCalls = 0
+    const supervisor = buildSupervisor({
+      restart: async () => ({ ok: true }),
+      reserveLock: async () => {
+        reservationCalls += 1
+        return { ok: false, reason: 'unexpected' }
+      },
+      onLog: () => {},
+      isStopped: () => true,
+    })
+
+    expect(await supervisor.scheduleRestart({ containerName: 'agent', cwd: '/agent' })).toEqual({
+      ok: false,
+      reason: 'daemon stopping',
+    })
+    expect(reservationCalls).toBe(0)
+  })
+})
+
+describe('restart lock orchestration', () => {
+  let root: string
+  let previousHome: string | undefined
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'typeclaw-supervisor-lock-'))
+    previousHome = process.env.TYPECLAW_HOME
+    process.env.TYPECLAW_HOME = join(root, 'home')
+  })
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env.TYPECLAW_HOME
+    else process.env.TYPECLAW_HOME = previousHome
+    await rm(root, { recursive: true, force: true })
+  })
+
+  test('rejects the ACK while an auth operation holds the agent lock', async () => {
+    const agentDir = join(root, 'agent')
+    await mkdir(agentDir)
+    const authReservation = await reserveAgentOperationLock({ agentDir, operation: 'instagram-auth' })
+    expect(authReservation.ok).toBe(true)
+    if (!authReservation.ok) throw new Error('expected auth reservation to succeed')
+    let restartCalls = 0
+    const supervisor = buildSupervisor({
+      restart: async () => {
+        restartCalls += 1
+        return { ok: true }
+      },
+      onLog: () => {},
+      isStopped: () => false,
+    })
+
+    const ack = await supervisor.scheduleRestart({ containerName: 'agent', cwd: agentDir })
+
+    expect(ack.ok).toBe(false)
+    expect(restartCalls).toBe(0)
+    await authReservation.release()
+  })
+})
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolvePromise: (value: T) => void = () => {}
+  const promise = new Promise<T>((resolvePromiseValue) => {
+    resolvePromise = resolvePromiseValue
+  })
+  return { promise, resolve: resolvePromise }
+}

--- a/src/hostd/supervisor.ts
+++ b/src/hostd/supervisor.ts
@@ -1,4 +1,9 @@
 import type { CurrentHostDaemon } from '@/container'
+import {
+  type AgentOperationLease,
+  reserveAgentOperationLock,
+  type ReserveAgentOperationLock,
+} from '@/container/agent-operation-lock'
 
 import type { Response } from './protocol'
 
@@ -13,6 +18,7 @@ export type SupervisorRestart = (input: {
   // Injected by the daemon so the restart registers the container in-process
   // instead of over the socket — see CurrentHostDaemon docs in src/container.
   currentHostDaemon?: CurrentHostDaemon
+  operationLease?: AgentOperationLease
 }) => Promise<{ ok: true } | { ok: false; reason: string }>
 
 export type SupervisorOptions = {
@@ -30,34 +36,43 @@ export type Supervisor = {
     cwd: string
     build?: boolean
     currentHostDaemon?: CurrentHostDaemon
-  }) => Response
+  }) => Promise<Response>
 }
 
 export type SupervisorBuildOptions = {
   restart: SupervisorRestart
   onLog: (event: SupervisorLogEvent) => void
   isStopped: () => boolean
+  reserveLock?: ReserveAgentOperationLock
 }
 
-// The daemon ACKs the agent immediately so the container can exit cleanly,
-// then runs stop+start in the background. If we ran them inline the agent's
-// own RPC connection would die when its container stopped — guaranteed to
-// race because `docker stop` is the very thing we're about to do. Errors are
-// surfaced via the log channel; there is no connected client to receive them.
-export function buildSupervisor({ restart, onLog, isStopped }: SupervisorBuildOptions): Supervisor {
+// The daemon reserves the lifecycle lock before ACKing, then runs stop+start in
+// the background so the agent's RPC connection can close before `docker stop`.
+// The requester exits about 500 ms after the ACK, so a lock failure discovered
+// later would be invisible; rejecting the ACK lets the agent surface and retry
+// the error. Failures after scheduling are still surfaced through the log channel.
+export function buildSupervisor({
+  restart,
+  onLog,
+  isStopped,
+  reserveLock = reserveAgentOperationLock,
+}: SupervisorBuildOptions): Supervisor {
   return {
-    scheduleRestart: ({ containerName, cwd, build = false, currentHostDaemon }): Response => {
+    scheduleRestart: async ({ containerName, cwd, build = false, currentHostDaemon }): Promise<Response> => {
       if (isStopped()) return { ok: false, reason: 'daemon stopping' }
+      const reservation = await reserveLock({ agentDir: cwd, operation: 'restart' })
+      if (!reservation.ok) return { ok: false, reason: reservation.reason }
       onLog({ kind: 'restart-scheduled', containerName, build })
-      void runRestart()
+      void runRestart(reservation.lease, reservation.release)
       return { ok: true }
 
-      async function runRestart(): Promise<void> {
+      async function runRestart(lease: AgentOperationLease, release: () => Promise<void>): Promise<void> {
         try {
           const result = await restart({
             containerName,
             cwd,
             build,
+            operationLease: lease,
             ...(currentHostDaemon ? { currentHostDaemon } : {}),
           })
           if (result.ok) onLog({ kind: 'restart-completed', containerName })
@@ -68,6 +83,8 @@ export function buildSupervisor({ restart, onLog, isStopped }: SupervisorBuildOp
             containerName,
             reason: error instanceof Error ? error.message : String(error),
           })
+        } finally {
+          await release().catch(() => {})
         }
       }
     },

--- a/src/init/instagram-auth.test.ts
+++ b/src/init/instagram-auth.test.ts
@@ -7,6 +7,8 @@ import { join } from 'node:path'
 import type { InstagramAccount } from 'agent-messenger/instagram'
 
 import { prepareAgentMessengerHostConfigDir } from '@/agent-messenger/host-config-dir'
+import type { WithAgentOperationLock } from '@/container/agent-operation-lock'
+import { FakeAgentOperationCoordinator } from '@/test-helpers/fake-agent-operation-lock'
 
 import {
   runInstagramBootstrap,
@@ -15,7 +17,13 @@ import {
   type InstagramLoginCredentialManager,
 } from './instagram-auth'
 
+const unlockedOperationLock: WithAgentOperationLock = async (input, run) => ({
+  ok: true,
+  value: await run({ containerName: input.agentDir, agentDir: input.agentDir }),
+})
+
 const managedConfigDeps = {
+  operationLock: unlockedOperationLock,
   prepareConfigDir: async (agentDir: string) => ({
     ok: true as const,
     hostDir: join(agentDir, 'workspace', '.config', 'agent-messenger'),
@@ -108,6 +116,68 @@ function observingClient(result: InstagramAuthenticateResult, onAuthenticate: ()
 }
 
 describe('runInstagramBootstrap', () => {
+  test('holds the agent operation lock through the interactive checkpoint callback', async () => {
+    await withDir(async (dir) => {
+      const legacy = join(dir, 'workspace', '.agent-messenger')
+      const canonical = join(dir, 'workspace', '.config', 'agent-messenger')
+      await mkdir(legacy, { recursive: true })
+      await mkdir(canonical, { recursive: true })
+      await writeFile(join(legacy, 'device.key'), Buffer.from([1, 3, 5, 7]))
+      await writeFile(join(canonical, 'session.json'), Buffer.from([2, 4, 6, 8]))
+      const beforeLegacy = await readFile(join(legacy, 'device.key'))
+      const beforeCanonical = await readFile(join(canonical, 'session.json'))
+      const coordinator = new FakeAgentOperationCoordinator('lifecycle contended')
+      const parked = coordinator.park()
+      const { manager } = fakeManagerWithSession(join(canonical, 'sdk-session.json'))
+      const client: InstagramLoginClient = {
+        authenticate: async () => ({ userId: '', challengeRequired: true, challengePath: '/challenge/' }),
+        challengeSendCode: async () => ({ contactPoint: 'u***@example.com', stepName: 'verify' }),
+        challengeSubmitCode: async () => ({ userId: '123' }),
+        twoFactorLogin: async () => ({ userId: '' }),
+        setSessionPath: () => {},
+        getUserId: () => null,
+      }
+
+      const auth = runInstagramBootstrap(
+        {
+          username: 'alice',
+          password: 'password',
+          agentDir: dir,
+          client,
+          credentialManager: manager,
+          callbacks: {
+            onChallengeCode: async () => {
+              await parked.wait()
+              return { code: '123456' }
+            },
+          },
+        },
+        {
+          operationLock: coordinator.operationLock,
+          prepareConfigDir: async () => ({ ok: true, hostDir: legacy }),
+        },
+      )
+      await parked.entered
+
+      let lifecycleRan = false
+      const competing = await coordinator.operationLock({ agentDir: dir, operation: 'restart' }, async () => {
+        lifecycleRan = true
+      })
+
+      expect(competing).toEqual({ ok: false, reason: 'lifecycle contended' })
+      expect(lifecycleRan).toBe(false)
+      expect(await readFile(join(legacy, 'device.key'))).toEqual(beforeLegacy)
+      expect(await readFile(join(canonical, 'session.json'))).toEqual(beforeCanonical)
+      parked.release()
+      expect(await auth).toEqual({ ok: true })
+      expect(coordinator.events).toEqual([
+        'lock-enter:instagram-auth',
+        'lock-contention:restart',
+        'lock-exit:instagram-auth',
+      ])
+    })
+  })
+
   test('uses a stale running container legacy path without creating the managed tree', async () => {
     await withDir(async (dir) => {
       const legacy = join(dir, 'workspace', '.agent-messenger')

--- a/src/init/instagram-auth.ts
+++ b/src/init/instagram-auth.ts
@@ -12,12 +12,14 @@ import {
   prepareAgentMessengerHostConfigDir,
   type HostAgentMessengerConfigResult,
 } from '@/agent-messenger/host-config-dir'
+import { type WithAgentOperationLock, withAgentOperationLock } from '@/container/agent-operation-lock'
 import { SecretsInstagramCredentialStore } from '@/secrets/instagram-store'
 
 export type InstagramBootstrapStatus = { ok: true } | { ok: false; reason: string }
 
 export type AgentMessengerHostConfigDeps = {
   prepareConfigDir?: (agentDir: string) => Promise<HostAgentMessengerConfigResult>
+  operationLock?: WithAgentOperationLock
 }
 
 // Instagram gates a fresh login behind one of two interactive second factors:
@@ -89,6 +91,21 @@ export function instagramSecretsPath(agentDir: string): string {
 export async function runInstagramBootstrap(
   input: InstagramLoginInput,
   deps: AgentMessengerHostConfigDeps = {},
+): Promise<InstagramBootstrapStatus> {
+  const operationLock = deps.operationLock ?? withAgentOperationLock
+  try {
+    const locked = await operationLock({ agentDir: input.agentDir, operation: 'instagram-auth' }, async () => {
+      return await runInstagramBootstrapLocked(input, deps)
+    })
+    return locked.ok ? locked.value : { ok: false, reason: locked.reason }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+async function runInstagramBootstrapLocked(
+  input: InstagramLoginInput,
+  deps: AgentMessengerHostConfigDeps,
 ): Promise<InstagramBootstrapStatus> {
   try {
     const prepared = await (deps.prepareConfigDir ?? prepareAgentMessengerHostConfigDir)(input.agentDir)

--- a/src/init/line-auth.test.ts
+++ b/src/init/line-auth.test.ts
@@ -7,11 +7,19 @@ import { join } from 'node:path'
 import type { LineLoginResult } from 'agent-messenger/line'
 
 import { prepareAgentMessengerHostConfigDir } from '@/agent-messenger/host-config-dir'
+import type { WithAgentOperationLock } from '@/container/agent-operation-lock'
 import { SecretsLineCredentialStore } from '@/secrets/line-store'
+import { FakeAgentOperationCoordinator } from '@/test-helpers/fake-agent-operation-lock'
 
 import { runLineBootstrap, type LineLoginClient } from './line-auth'
 
+const unlockedOperationLock: WithAgentOperationLock = async (input, run) => ({
+  ok: true,
+  value: await run({ containerName: input.agentDir, agentDir: input.agentDir }),
+})
+
 const managedConfigDeps = {
+  operationLock: unlockedOperationLock,
   prepareConfigDir: async (agentDir: string) => ({
     ok: true as const,
     hostDir: join(agentDir, 'workspace', '.config', 'agent-messenger'),
@@ -147,6 +155,55 @@ function throwingLoggingClient(): LineLoginClient {
 }
 
 describe('runLineBootstrap', () => {
+  test('holds the agent operation lock through the interactive QR callback', async () => {
+    await withDir(async (dir) => {
+      const legacy = join(dir, 'workspace', '.agent-messenger')
+      const canonical = join(dir, 'workspace', '.config', 'agent-messenger')
+      await mkdir(legacy, { recursive: true })
+      await mkdir(canonical, { recursive: true })
+      await writeFile(join(legacy, 'letter-sealing.key'), Buffer.from([0, 1, 2, 255]))
+      await writeFile(join(canonical, 'session.json'), Buffer.from([9, 8, 7]))
+      const beforeLegacy = await readFile(join(legacy, 'letter-sealing.key'))
+      const beforeCanonical = await readFile(join(canonical, 'session.json'))
+      const coordinator = new FakeAgentOperationCoordinator('lifecycle contended')
+      const parked = coordinator.park()
+      const client: LineLoginClient = {
+        loginWithQR: async ({ onQRUrl }) => {
+          await onQRUrl('https://example.com/qr')
+          return { authenticated: false, error: 'cancelled' }
+        },
+        loginWithEmail: async () => ({ authenticated: false, error: 'unused' }),
+      }
+
+      const auth = runLineBootstrap(
+        {
+          method: 'qr',
+          agentDir: dir,
+          callbacks: { onPincode: () => {}, onQRUrl: parked.wait },
+          client,
+        },
+        {
+          operationLock: coordinator.operationLock,
+          prepareConfigDir: async () => ({ ok: true, hostDir: legacy }),
+        },
+      )
+      await parked.entered
+
+      let lifecycleRan = false
+      const competing = await coordinator.operationLock({ agentDir: dir, operation: 'start' }, async () => {
+        lifecycleRan = true
+      })
+
+      expect(competing).toEqual({ ok: false, reason: 'lifecycle contended' })
+      expect(lifecycleRan).toBe(false)
+      expect(await readFile(join(legacy, 'letter-sealing.key'))).toEqual(beforeLegacy)
+      expect(await readFile(join(canonical, 'session.json'))).toEqual(beforeCanonical)
+      parked.release()
+      expect(await auth).toEqual({ ok: false, reason: 'cancelled' })
+      expect(coordinator.events).toEqual(['lock-enter:line-auth', 'lock-contention:start', 'lock-exit:line-auth'])
+    })
+  })
+
   test('prepares a stopped legacy install before login and exposes the migrated host path to the client', async () => {
     await withDir(async (dir) => {
       const legacy = join(dir, 'workspace', '.agent-messenger')

--- a/src/init/line-auth.ts
+++ b/src/init/line-auth.ts
@@ -6,12 +6,14 @@ import {
   prepareAgentMessengerHostConfigDir,
   type HostAgentMessengerConfigResult,
 } from '@/agent-messenger/host-config-dir'
+import { type WithAgentOperationLock, withAgentOperationLock } from '@/container/agent-operation-lock'
 import { SecretsLineCredentialStore } from '@/secrets/line-store'
 
 export type LineBootstrapStatus = { ok: true } | { ok: false; reason: string }
 
 export type AgentMessengerHostConfigDeps = {
   prepareConfigDir?: (agentDir: string) => Promise<HostAgentMessengerConfigResult>
+  operationLock?: WithAgentOperationLock
 }
 
 export type LineLoginCallbacks = {
@@ -61,6 +63,21 @@ export function lineSecretsPath(agentDir: string): string {
 export async function runLineBootstrap(
   input: LineLoginInput,
   deps: AgentMessengerHostConfigDeps = {},
+): Promise<LineBootstrapStatus> {
+  const operationLock = deps.operationLock ?? withAgentOperationLock
+  try {
+    const locked = await operationLock({ agentDir: input.agentDir, operation: 'line-auth' }, async () => {
+      return await runLineBootstrapLocked(input, deps)
+    })
+    return locked.ok ? locked.value : { ok: false, reason: locked.reason }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+async function runLineBootstrapLocked(
+  input: LineLoginInput,
+  deps: AgentMessengerHostConfigDeps,
 ): Promise<LineBootstrapStatus> {
   try {
     const prepared = await (deps.prepareConfigDir ?? prepareAgentMessengerHostConfigDir)(input.agentDir)

--- a/src/test-helpers/fake-agent-operation-lock.ts
+++ b/src/test-helpers/fake-agent-operation-lock.ts
@@ -1,0 +1,66 @@
+import { resolve } from 'node:path'
+
+import type {
+  AgentOperation,
+  AgentOperationLease,
+  AgentOperationLockResult,
+  WithAgentOperationLock,
+} from '@/container/agent-operation-lock'
+import { containerNameFromCwd } from '@/container/shared'
+
+export class FakeAgentOperationCoordinator {
+  readonly events: string[] = []
+  readonly operationLock: WithAgentOperationLock
+
+  private readonly active = new Set<string>()
+
+  constructor(private readonly contentionReason = 'contended') {
+    this.operationLock = async <T>(
+      input: { agentDir: string; operation: AgentOperation; lease?: AgentOperationLease },
+      run: (lease: AgentOperationLease) => Promise<T>,
+    ): Promise<AgentOperationLockResult<T>> => {
+      const agentDir = resolve(input.agentDir)
+      const containerName = containerNameFromCwd(agentDir)
+      const lease = { containerName, agentDir }
+      if (input.lease !== undefined) {
+        if (input.lease.containerName !== containerName || resolve(input.lease.agentDir) !== agentDir) {
+          return { ok: false, reason: 'mismatched lease' }
+        }
+        return { ok: true, value: await run(input.lease) }
+      }
+      if (this.active.has(containerName)) {
+        this.events.push(`lock-contention:${input.operation}`)
+        return { ok: false, reason: this.contentionReason }
+      }
+      this.active.add(containerName)
+      this.events.push(`lock-enter:${input.operation}`)
+      try {
+        return { ok: true, value: await run(lease) }
+      } finally {
+        this.events.push(`lock-exit:${input.operation}`)
+        this.active.delete(containerName)
+      }
+    }
+  }
+
+  park(): { entered: Promise<void>; wait: () => Promise<void>; release: () => void } {
+    const entered = deferred()
+    const released = deferred()
+    return {
+      entered: entered.promise,
+      wait: async () => {
+        entered.resolve()
+        await released.promise
+      },
+      release: () => released.resolve(),
+    }
+  }
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolvePromise: () => void = () => {}
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}


### PR DESCRIPTION
## Background

Follow-up from a post-merge audit of #1332 (merged as ee116bec). #1333 fixed three smaller findings from the same audit; this is the fourth and most serious one — a lifecycle TOCTOU that #1333 explicitly called out as needing its own PR.

Docker inspection, agent-messenger credential migration, container launch, and host channel auth were never serialized against each other. Concrete sequence:

1. `prepareAgentMessengerHostConfigDir()` inspects Docker, sees a running container on the legacy config dir, and returns the legacy host path.
2. A concurrent `typeclaw restart` stops that container, migrates legacy to canonical, and relaunches on canonical.
3. The in-flight LINE login writes freshly minted Letter-Sealing (E2EE) keys into the now-abandoned legacy tree.
4. The next `start` sees both trees populated and hard-aborts.

LINE's Letter-Sealing keys cannot be reminted by logging in again, so step 3 strands them permanently and step 4 wedges startup until someone merges the trees by hand.

## Summary

- **New per-agent host lifecycle lock** (`src/container/agent-operation-lock.ts`), built on `proper-lockfile` (already a dependency; same options shape as `src/hostd/spawn.ts`). The lock file lives at `~/.typeclaw/run/agent-locks/<containerName>.lock` via new helpers in `src/hostd/paths.ts` — deliberately outside the agent folder, which is bind-mounted into the container with a model-writable `workspace/`, so a container process can't obstruct the host's own lock. Reuses `paths.ts`'s existing `SAFE_NAME` guard and 0700 dir permissions. Contention waits roughly 2s then fails rather than queueing, because a LINE QR or Instagram checkpoint prompt can hold the lease for minutes and a `start` blocking that long behind a human is its own failure mode. A caller can pass in an already-held lease instead of reacquiring, so one transaction can span several operations.
- **`start()` and `stop()` hold the lock for their full duration**, and `start()` re-probes the container immediately before migrating. That second probe matters because the first probe runs before dependency install and the image build, so it can be minutes stale by the time the credential move happens — and a manual `docker start` or an older binary isn't covered by the lock at all, so a stale first probe is still possible even under the lock.
- **New atomic `restart()`** (`src/container/restart.ts`, exposed on `Controller`) acquires the lock once and threads the same lease through `stop` then `start`, closing the gap between them where a channel auth could previously pick a path that the following start then migrates away from.
- **Every restart caller now goes through it**: `typeclaw restart`, `typeclaw compose restart`, hostd's scheduled restart (`buildHostdRestart` now takes a single `restart` dependency instead of separate `stop`/`start`), and the channel-credential-refresh/reauth prompts. A single caller left on the old stop-then-start pattern would keep the window open, which is why this commit touches every caller.
- **Host auth re-probes right before migrating**: the container state used to pick the config path is read once, then read again immediately before the move, and the move is refused if the container went live in between.
- **LINE and Instagram hold the lock across the whole login transaction** — preparation, SDK login, read-back, and the credential write — not just path selection, because the LINE SDK can create Letter-Sealing material during login itself, before typeclaw's own persist step. Only these two adapters take the lock; they're the ones whose filesystem destination is chosen from live container state, so they're the ones that can strand something.

## Preview

Not applicable — no UI change.

## What this does NOT do

- Does not fix container-name collisions between two different agent directories that share a basename (one can currently report or stop the other's container). That's a separate pre-existing bug — validating the compose project-working-dir label to fix it risks refusing containers created before that label existed — and is tracked separately.
- Does not add ENOENT retry logic to the migration. With every TypeClaw path now under the lock, a stale rmdir/rename is no longer an expected internal race; a remaining one means external interference and should surface rather than be silently retried.

## Review notes

- The lock file's location outside the agent folder, and the fail-fast-on-contention behavior instead of queueing, are both load-bearing — see `src/container/agent-operation-lock.ts` for why.
- `start()`'s second container-inspect call, immediately before the credential migration, is the fix for the stale-first-probe window; the first probe (for the already-running no-op check) is intentionally left alone.
- `restart()` threading one lease into both `stop` and `start` is what makes the transaction atomic; the restart and auth tests exercise contention through an injected lock fake rather than mocking `proper-lockfile`, so the event ordering is asserted directly.

## Verification

- `bun run typecheck` — 0 errors.
- `bun run lint` — 0 errors, 69 pre-existing warnings.
- `bun run format:check` — clean.
- `bun run test` — 12289 pass, 31 skip, 0 fail.

New/updated coverage: `agent-operation-lock.test.ts` exercises the real lockfile against a tmp `TYPECLAW_HOME` (same-agent contention fails, different agents don't contend, a matching lease skips reacquisition, a mismatched one fails). `start.test.ts` and `restart.test.ts` assert the lock-enter → inspect → migration → run ordering, that contention makes no Docker call and no filesystem migration, and that restart passes one lease to both halves. `line-auth.test.ts` / `instagram-auth.test.ts` assert that parking mid-login (e.g. mid-QR) leaves both the legacy and canonical trees byte-for-byte unchanged.
