### PR TITLE
Recover from EACCES when canonicalizing guarded paths

### DIFF
--- a/src/bundled-plugins/guard/policies/managed-config.ts
+++ b/src/bundled-plugins/guard/policies/managed-config.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { parseConfigJson } from '@/config'
 import { validateCronEdit } from '@/cron'
+import { RECOVER_MISSING, realIntendedPath } from '@/path-safety/real-intended-path'
 
 import type { GuardBlock } from '../policy'
 
@@ -161,25 +162,11 @@ function blockReason(tool: string, targetPath: string, reason: string): GuardBlo
   }
 }
 
+// RECOVER_MISSING only: this policy decides whether a write is ALLOWED, so an
+// ancestor that cannot be resolved must never widen the permitted surface.
 async function resolveRealIntendedPath(absolutePath: string): Promise<string> {
-  const pending: string[] = []
-  let current = absolutePath
-
-  while (true) {
-    try {
-      const realCurrent = await realpath(current)
-      return path.join(realCurrent, ...pending.reverse())
-    } catch (err) {
-      if (!isNotFoundError(err)) throw err
-    }
-
-    const parent = path.dirname(current)
-    if (parent === current) throw new Error(`could not resolve existing parent for ${absolutePath}`)
-    pending.push(path.basename(current))
-    current = parent
-  }
-}
-
-function isNotFoundError(err: unknown): boolean {
-  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
+  return await realIntendedPath(absolutePath, realpath, {
+    recoverable: RECOVER_MISSING,
+    onExhausted: 'throw',
+  })
 }

--- a/src/bundled-plugins/guard/policies/non-workspace-write.ts
+++ b/src/bundled-plugins/guard/policies/non-workspace-write.ts
@@ -2,6 +2,7 @@ import { realpath } from 'node:fs/promises'
 import path from 'node:path'
 
 import type { SessionOrigin } from '@/agent/session-origin'
+import { RECOVER_MISSING, realIntendedPath } from '@/path-safety/real-intended-path'
 
 import { ACKNOWLEDGE_GUARDS, type GuardBlock, isGuardAcknowledged } from '../policy'
 import { isMemoryTopicsWriteAllowed } from './memory-topics-write'
@@ -132,25 +133,11 @@ function isInside(parent: string, child: string): boolean {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
 }
 
+// RECOVER_MISSING only: this policy decides whether a write is ALLOWED, so an
+// ancestor that cannot be resolved must never widen the permitted surface.
 async function resolveRealIntendedPath(absolutePath: string): Promise<string> {
-  const pending: string[] = []
-  let current = absolutePath
-
-  while (true) {
-    try {
-      const realCurrent = await realpath(current)
-      return path.join(realCurrent, ...pending.reverse())
-    } catch (err) {
-      if (!isNotFoundError(err)) throw err
-    }
-
-    const parent = path.dirname(current)
-    if (parent === current) throw new Error(`could not resolve existing parent for ${absolutePath}`)
-    pending.push(path.basename(current))
-    current = parent
-  }
-}
-
-function isNotFoundError(err: unknown): boolean {
-  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
+  return await realIntendedPath(absolutePath, realpath, {
+    recoverable: RECOVER_MISSING,
+    onExhausted: 'throw',
+  })
 }

--- a/src/bundled-plugins/guard/policies/skill-authoring.ts
+++ b/src/bundled-plugins/guard/policies/skill-authoring.ts
@@ -1,6 +1,8 @@
 import { readFile, realpath } from 'node:fs/promises'
 import path from 'node:path'
 
+import { RECOVER_MISSING, realIntendedPath } from '@/path-safety/real-intended-path'
+
 import type { GuardBlock } from '../policy'
 
 export const GUARD_SKILL_AUTHORING = 'skillAuthoring'
@@ -161,25 +163,11 @@ function isInside(parent: string, child: string): boolean {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
 }
 
+// RECOVER_MISSING only: this policy decides whether a write is ALLOWED, so an
+// ancestor that cannot be resolved must never widen the permitted surface.
 async function resolveRealIntendedPath(absolutePath: string): Promise<string> {
-  const pending: string[] = []
-  let current = absolutePath
-
-  while (true) {
-    try {
-      const realCurrent = await realpath(current)
-      return path.join(realCurrent, ...pending.reverse())
-    } catch (err) {
-      if (!isNotFoundError(err)) throw err
-    }
-
-    const parent = path.dirname(current)
-    if (parent === current) throw new Error(`could not resolve existing parent for ${absolutePath}`)
-    pending.push(path.basename(current))
-    current = parent
-  }
-}
-
-function isNotFoundError(err: unknown): boolean {
-  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
+  return await realIntendedPath(absolutePath, realpath, {
+    recoverable: RECOVER_MISSING,
+    onExhausted: 'throw',
+  })
 }

--- a/src/bundled-plugins/security/policies/private-surface-read.test.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.test.ts
@@ -63,10 +63,89 @@ describe('private-surface-read guard — builtin file tools', () => {
 })
 
 describe('private-surface-read guard — fail-closed across ALL tools (not a whitelist)', () => {
-  test('blocks with a generic reason when realpathSync.native reports EACCES', () => {
-    // Must resolve like the guard does: a POSIX literal would not match on Windows.
+  test('allows an EACCES-shadowed path that is NOT on the denied surface', () => {
+    // given a runtime uid that cannot traverse an ancestor (container /root is
+    // mode 700 while the agent runs as uid 501), so realpath reports EACCES
+    // rather than ENOENT for every component under it.
+    // The child must NOT be a canonical secret dir: when this test process runs
+    // as root, homedir() is /root and `.config/agent-messenger` would be denied
+    // lexically, short-circuiting before realpath and testing nothing.
+    const barrier = path.resolve(path.sep, 'root')
+    const target = path.join(barrier, '.config', 'example-service', 'state.json')
+    const internalErrors: unknown[] = []
+
+    // when a tool reads that path
+    const result = checkPrivateSurfaceReadGuard(
+      { tool: 'read', args: { path: target }, agentDir: AGENT, hidden: guestHidden },
+      {
+        realpathNative(candidate) {
+          if (candidate === barrier || candidate.startsWith(`${barrier}${path.sep}`)) {
+            throw Object.assign(new Error('permission denied'), { code: 'EACCES' })
+          }
+          return realpathSync.native(candidate)
+        },
+        onInternalError: (error) => internalErrors.push(error),
+      },
+    )
+
+    // then it is allowed: the path is neither a secret nor on the deny list, and
+    // canonicalization failure alone must not deny it
+    expect(result).toBeUndefined()
+    expect(internalErrors).toEqual([])
+  })
+
+  test('still blocks when the EACCES leaf resolves under a denied directory', () => {
+    // given a leaf that cannot be statted but whose parent resolves into memory/
+    const parent = path.resolve(AGENT, 'public/gate')
+    const leaf = path.join(parent, 'stolen.md')
+
+    const result = checkPrivateSurfaceReadGuard(
+      { tool: 'read', args: { path: leaf }, agentDir: AGENT, hidden: guestHidden },
+      {
+        realpathNative(candidate) {
+          if (candidate === leaf) throw Object.assign(new Error('permission denied'), { code: 'EACCES' })
+          if (candidate === parent) return path.resolve(AGENT, 'memory')
+          return realpathSync.native(candidate)
+        },
+      },
+    )
+
+    // then the deny-list match still fires — EACCES recovery is not a bypass
+    expect(result?.block).toBe(true)
+    expect(result?.reason).toMatch(/memory/)
+    expect(result?.reason).not.toMatch(/internal guard error/i)
+  })
+
+  for (const code of ['ELOOP', 'ENOTDIR', 'EPERM', 'ENAMETOOLONG', 'EIO']) {
+    test(`blocks with a generic reason when realpathSync.native reports ${code}`, () => {
+      // Must resolve like the guard does: a POSIX literal would not match on Windows.
+      const inaccessible = path.resolve(AGENT, 'public/protected.md')
+      const error = Object.assign(new Error(`failure while resolving protected path`), { code })
+      const internalErrors: unknown[] = []
+
+      const result = checkPrivateSurfaceReadGuard(
+        { tool: 'read', args: { path: inaccessible }, agentDir: AGENT, hidden: guestHidden },
+        {
+          realpathNative(candidate) {
+            if (candidate === inaccessible) throw error
+            return realpathSync.native(candidate)
+          },
+          onInternalError: (thrown) => internalErrors.push(thrown),
+        },
+      )
+
+      expect(result?.block).toBe(true)
+      expect(result?.reason).toMatch(/internal guard error/i)
+      expect(result?.reason).not.toContain(inaccessible)
+      expect(result?.reason).not.toContain(error.message)
+      expect(result?.reason).not.toContain(code)
+      expect(internalErrors).toEqual([error])
+    })
+  }
+
+  test('blocks with a generic reason when realpath throws a non-errno error', () => {
     const inaccessible = path.resolve(AGENT, 'public/protected.md')
-    const error = Object.assign(new Error('permission denied while resolving protected path'), { code: 'EACCES' })
+    const error = new Error('bare failure')
 
     const result = checkPrivateSurfaceReadGuard(
       { tool: 'read', args: { path: inaccessible }, agentDir: AGENT, hidden: guestHidden },
@@ -80,9 +159,6 @@ describe('private-surface-read guard — fail-closed across ALL tools (not a whi
 
     expect(result?.block).toBe(true)
     expect(result?.reason).toMatch(/internal guard error/i)
-    expect(result?.reason).not.toContain(inaccessible)
-    expect(result?.reason).not.toContain(error.message)
-    expect(result?.reason).not.toContain(error.code)
   })
 
   test('blocks find_entry reading a hidden transcript via top-level path', () => {

--- a/src/bundled-plugins/security/policies/private-surface-read.ts
+++ b/src/bundled-plugins/security/policies/private-surface-read.ts
@@ -16,6 +16,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { TOOLS_WITHOUT_LOCAL_FILE_OPERANDS } from '@/agent/tools-without-local-file-operands'
+import { RECOVER_MISSING_OR_UNSEARCHABLE, realIntendedPathSync } from '@/path-safety/real-intended-path'
 import type { ToolFileOperands } from '@/plugin'
 import {
   CANONICAL_AGENT_SECRET_DIRS,
@@ -959,30 +960,16 @@ function hasSameFileIdentity(candidate: string, deniedFile: string): boolean {
   }
 }
 
-// Resolves symlinks on the longest existing prefix of an absolute path, then
-// re-appends the non-existent tail. A bare realpathSync throws on a path that
-// does not exist yet (a write target, or a read of a not-yet-created file), so
-// we walk up to the nearest existing ancestor, realpath THAT (collapsing any
-// symlinked component including a planted symlink), and rejoin the remainder.
-// This catches `public/leak/x` where `public/leak` is a symlink into a hidden
-// dir even though `public/leak/x` itself does not exist. Sync (realpathSync)
-// keeps the guard synchronous; the cost is one syscall per existing component,
-// negligible at the tool-call boundary. Sync mirror of resolveRealIntendedPath
-// in the guard plugin's non-workspace-write policy.
+// Sync keeps the guard synchronous; the cost is one syscall per existing
+// component, negligible at the tool-call boundary. EACCES is recoverable here
+// (but NOT in the guard plugin's write policies): this is denylist matching, so
+// a path under an unsearchable ancestor must still be matched rather than
+// aborting the whole guard. See @/path-safety/real-intended-path.
 function realpathRealIntendedPath(absolutePath: string, realpath: (candidate: string) => string): string {
-  const pending: string[] = []
-  let current = absolutePath
-  while (true) {
-    try {
-      return path.join(realpath(current), ...pending.reverse())
-    } catch (err) {
-      if (!isNotFoundError(err)) throw err
-    }
-    const parent = path.dirname(current)
-    if (parent === current) return absolutePath
-    pending.push(path.basename(current))
-    current = parent
-  }
+  return realIntendedPathSync(absolutePath, realpath, {
+    recoverable: RECOVER_MISSING_OR_UNSEARCHABLE,
+    onExhausted: 'return-input',
+  })
 }
 
 function isNotFoundError(err: unknown): boolean {

--- a/src/path-safety/real-intended-path.test.ts
+++ b/src/path-safety/real-intended-path.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from 'node:fs'
+import { realpath } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  RECOVER_MISSING,
+  RECOVER_MISSING_OR_UNSEARCHABLE,
+  realIntendedPath,
+  realIntendedPathSync,
+} from './real-intended-path'
+
+function errno(code: string): Error {
+  return Object.assign(new Error(`synthetic ${code}`), { code })
+}
+
+const FILESYSTEM_ROOT = path.parse(path.resolve(path.sep)).root
+
+// Mimics a barrier the runtime cannot search: every candidate fails with `code`
+// until the walk reaches the filesystem root, which always resolves.
+function unsearchableUntilRoot(code: string): (candidate: string) => string {
+  return (candidate) => {
+    if (candidate === FILESYSTEM_ROOT) return FILESYSTEM_ROOT
+    throw errno(code)
+  }
+}
+
+describe('realIntendedPathSync — resolvable prefix', () => {
+  test('resolves a symlinked ancestor and reattaches a non-existent tail', () => {
+    // given a symlink whose target exists but whose child does not
+    const root = realpathSync.native(mkdtempSync(path.join(tmpdir(), 'typeclaw-intended-path-')))
+    mkdirSync(path.join(root, 'real', 'target'), { recursive: true })
+    symlinkSync(path.join(root, 'real', 'target'), path.join(root, 'link'), 'dir')
+
+    // when the tail does not exist
+    const resolved = realIntendedPathSync(path.join(root, 'link', 'missing.txt'), realpathSync.native)
+
+    // then the symlink is collapsed and the tail reattached to the real target
+    expect(resolved).toBe(path.join(root, 'real', 'target', 'missing.txt'))
+  })
+})
+
+describe('realIntendedPathSync — unsearchable ancestor (the /root regression)', () => {
+  test('EACCES walks to the root and returns the lexical path when opted in', () => {
+    // given a mode-700 ancestor the runtime uid cannot traverse
+    const target = path.join(path.resolve(path.sep, 'root'), '.config', 'agent-messenger', 'MEMORY.md')
+
+    // when the denylist caller opts into EACCES recovery
+    const resolved = realIntendedPathSync(target, unsearchableUntilRoot('EACCES'), {
+      recoverable: RECOVER_MISSING_OR_UNSEARCHABLE,
+    })
+
+    // then canonicalization degrades to the lexical path instead of throwing
+    expect(resolved).toBe(target)
+  })
+
+  test('EACCES on the leaf still resolves a denied symlinked parent', () => {
+    // given a leaf that cannot be statted but a parent that resolves into a denied dir
+    const parent = path.resolve(path.sep, 'agent', 'public', 'gate')
+    const deniedReal = path.resolve(path.sep, 'agent', 'memory')
+    const leaf = path.join(parent, 'MEMORY.md')
+
+    // when the guard canonicalizes the leaf
+    const resolved = realIntendedPathSync(
+      leaf,
+      (candidate) => {
+        if (candidate === leaf) throw errno('EACCES')
+        if (candidate === parent) return deniedReal
+        throw errno('ENOENT')
+      },
+      { recoverable: RECOVER_MISSING_OR_UNSEARCHABLE },
+    )
+
+    // then the result lands under the denied directory, so the deny-list still matches
+    expect(resolved).toBe(path.join(deniedReal, 'MEMORY.md'))
+  })
+
+  test('EACCES is NOT recoverable under the default (allowlist) set', () => {
+    const target = path.join(path.resolve(path.sep, 'root'), 'secret')
+
+    expect(() => realIntendedPathSync(target, unsearchableUntilRoot('EACCES'))).toThrow(/synthetic EACCES/)
+    expect(() =>
+      realIntendedPathSync(target, unsearchableUntilRoot('EACCES'), { recoverable: RECOVER_MISSING }),
+    ).toThrow(/synthetic EACCES/)
+  })
+})
+
+describe('realIntendedPathSync — non-recoverable errors stay fatal', () => {
+  for (const code of ['ELOOP', 'ENOTDIR', 'EPERM', 'ENAMETOOLONG', 'EIO']) {
+    test(`${code} rethrows even with the broadest recoverable set`, () => {
+      const target = path.resolve(path.sep, 'agent', 'public', 'x')
+      expect(() =>
+        realIntendedPathSync(target, unsearchableUntilRoot(code), {
+          recoverable: RECOVER_MISSING_OR_UNSEARCHABLE,
+        }),
+      ).toThrow(new RegExp(`synthetic ${code}`))
+    })
+  }
+
+  test('a non-errno throw rethrows', () => {
+    const target = path.resolve(path.sep, 'agent', 'public', 'x')
+    expect(() =>
+      realIntendedPathSync(
+        target,
+        () => {
+          throw new Error('bare failure')
+        },
+        { recoverable: RECOVER_MISSING_OR_UNSEARCHABLE },
+      ),
+    ).toThrow(/bare failure/)
+  })
+})
+
+describe('realIntendedPathSync — exhaustion behavior', () => {
+  test('onExhausted "throw" reports an unresolvable path', () => {
+    const target = path.resolve(path.sep, 'agent', 'x')
+    expect(() =>
+      realIntendedPathSync(
+        target,
+        () => {
+          throw errno('ENOENT')
+        },
+        { onExhausted: 'throw' },
+      ),
+    ).toThrow(/could not resolve existing parent/)
+  })
+
+  test('onExhausted "return-input" falls back to the lexical input', () => {
+    const target = path.resolve(path.sep, 'agent', 'x')
+    const resolved = realIntendedPathSync(
+      target,
+      () => {
+        throw errno('ENOENT')
+      },
+      { onExhausted: 'return-input' },
+    )
+    expect(resolved).toBe(target)
+  })
+})
+
+describe('realIntendedPath (async) mirrors the sync variant', () => {
+  test('resolves a symlinked ancestor and reattaches a non-existent tail', async () => {
+    const root = realpathSync.native(mkdtempSync(path.join(tmpdir(), 'typeclaw-intended-path-async-')))
+    mkdirSync(path.join(root, 'real', 'target'), { recursive: true })
+    symlinkSync(path.join(root, 'real', 'target'), path.join(root, 'link'), 'dir')
+
+    const resolved = await realIntendedPath(path.join(root, 'link', 'missing.txt'), realpath)
+
+    expect(resolved).toBe(path.join(root, 'real', 'target', 'missing.txt'))
+  })
+
+  test('EACCES rejects under the default set and recovers under the opt-in set', async () => {
+    const target = path.join(path.resolve(path.sep, 'root'), '.config', 'x')
+    const failing = async (candidate: string) => unsearchableUntilRoot('EACCES')(candidate)
+
+    await expect(realIntendedPath(target, failing)).rejects.toThrow(/synthetic EACCES/)
+    await expect(realIntendedPath(target, failing, { recoverable: RECOVER_MISSING_OR_UNSEARCHABLE })).resolves.toBe(
+      target,
+    )
+  })
+})

--- a/src/path-safety/real-intended-path.ts
+++ b/src/path-safety/real-intended-path.ts
@@ -1,0 +1,111 @@
+import path from 'node:path'
+
+// Canonicalizes the longest RESOLVABLE prefix of an absolute path, then re-appends
+// the remainder lexically. A bare realpath throws on a path that does not exist yet
+// (a write target, or a read of a not-yet-created file), so we walk up to the nearest
+// resolvable ancestor, realpath THAT — collapsing every symlinked component, including
+// a planted one — and rejoin the tail. This is what catches `public/leak/x` where
+// `public/leak` is a symlink into a hidden dir even though `public/leak/x` itself does
+// not exist.
+//
+// Which errnos may be walked past is the security-sensitive part, so it is the
+// CALLER's decision, not a default. See the two exported sets below.
+
+// The historical, strictest set: only a missing component is walked past.
+// Correct for allowlist/authorization policies, where an unresolvable component must
+// never widen what is permitted.
+export const RECOVER_MISSING: ReadonlySet<string> = new Set(['ENOENT'])
+
+// Adds EACCES for denylist matching. A realpath of a path under a directory the
+// runtime cannot search fails with EACCES, not ENOENT — e.g. resolving
+// `/root/.config/...` while running as a non-root uid when `/root` is mode 700.
+// Treating that as fatal blocks reads of paths that are neither secret nor denied.
+// Walking past it is sound for a DENYLIST because the tail is still matched against
+// the denied surface after rejoining: a masked directory still matches lexically and
+// still blocks. It is NOT sound for an allowlist — see RECOVER_MISSING.
+export const RECOVER_MISSING_OR_UNSEARCHABLE: ReadonlySet<string> = new Set(['ENOENT', 'EACCES'])
+
+export type RealIntendedPathOptions = {
+  // Defaults to RECOVER_MISSING: callers must opt in to the broader set.
+  readonly recoverable?: ReadonlySet<string>
+  // What to do when even the filesystem root is unresolvable. Callers that treat an
+  // unresolvable path as a hard failure use 'throw'; callers that fall back to the
+  // lexical input use 'return-input'.
+  readonly onExhausted?: 'throw' | 'return-input'
+}
+
+export function realIntendedPathSync(
+  absolutePath: string,
+  realpath: (candidate: string) => string,
+  options: RealIntendedPathOptions = {},
+): string {
+  const walk = createAncestorWalk(absolutePath, options)
+  while (true) {
+    let resolved: string
+    try {
+      resolved = realpath(walk.target())
+    } catch (error) {
+      const exhausted = walk.retreat(error)
+      if (exhausted !== undefined) return exhausted
+      continue
+    }
+    return walk.rejoin(resolved)
+  }
+}
+
+export async function realIntendedPath(
+  absolutePath: string,
+  realpath: (candidate: string) => Promise<string>,
+  options: RealIntendedPathOptions = {},
+): Promise<string> {
+  const walk = createAncestorWalk(absolutePath, options)
+  while (true) {
+    let resolved: string
+    try {
+      resolved = await realpath(walk.target())
+    } catch (error) {
+      const exhausted = walk.retreat(error)
+      if (exhausted !== undefined) return exhausted
+      continue
+    }
+    return walk.rejoin(resolved)
+  }
+}
+
+type AncestorWalk = {
+  target(): string
+  rejoin(resolvedTarget: string): string
+  // Returns the final result when the walk cannot retreat further, or undefined to
+  // keep walking. Rethrows anything the caller did not declare recoverable.
+  retreat(error: unknown): string | undefined
+}
+
+function createAncestorWalk(absolutePath: string, options: RealIntendedPathOptions): AncestorWalk {
+  const recoverable = options.recoverable ?? RECOVER_MISSING
+  const onExhausted = options.onExhausted ?? 'return-input'
+  const pending: string[] = []
+  let current = absolutePath
+
+  return {
+    target: () => current,
+    // Copy before reversing: the caller may hold this array across iterations.
+    rejoin: (resolvedTarget) => path.join(resolvedTarget, ...[...pending].reverse()),
+    retreat(error) {
+      if (!isRecoverableErrno(error, recoverable)) throw error
+      const parent = path.dirname(current)
+      if (parent === current) {
+        if (onExhausted === 'throw') throw new Error(`could not resolve existing parent for ${absolutePath}`)
+        return absolutePath
+      }
+      pending.push(path.basename(current))
+      current = parent
+      return undefined
+    },
+  }
+}
+
+function isRecoverableErrno(error: unknown, recoverable: ReadonlySet<string>): boolean {
+  if (!(error instanceof Error) || !('code' in error)) return false
+  const code = (error as { code: unknown }).code
+  return typeof code === 'string' && recoverable.has(code)
+}


### PR DESCRIPTION
## Background

A containerized agent running a scheduled job reported that it could not read a
credential-adjacent file and posted a degraded, contentless summary to its
channel. The credentials were fine — the read never happened, because a security
guard crashed.

`privateSurfaceRead` canonicalizes every path argument of every non-bash tool.
Its ancestor walk tolerated only `ENOENT`. But the agent runtime runs as a
non-root uid while the container's `/root` is mode 700, so resolving a path
under it fails with `EACCES`, not `ENOENT`:

```
realpath('/root/.config/<redacted>/MEMORY.md')
  as uid 0    -> ENOENT   (tolerated, walk continues, guard passes)
  as uid 501  -> EACCES   (rethrown -> fail-closed boundary -> BLOCKED)
```

So the guard blocked a path that is neither a secret nor on the deny list, and
the model only saw `an internal guard error prevented safe path validation`.
Any tool call touching a path under an untraversable ancestor hits this.

This is the second half of c5bdba40, which correctly identified the `EACCES`
rethrow and closed the resulting *bypass* by making guard exceptions fail
closed — while deliberately leaving the ancestor walk `ENOENT`-only. That
converted a silent escape into a hard false positive. This PR fixes the walk.

The same walk had been copy-pasted into four policies, so the latent bug exists
in all of them, and the copies had already drifted apart.

## Summary

One canonicalizer (`src/path-safety/`) replacing four copies, with the
recoverable-errno set as an explicit **caller decision** instead of a hardcoded
default:

| Caller | Set | Why |
|---|---|---|
| `privateSurfaceRead` (denylist) | `ENOENT` + `EACCES` | Must still *match* a path under an unsearchable ancestor, not abort |
| the three write policies (allowlists) | `ENOENT` only | These decide whether a write is ALLOWED; an unresolvable ancestor must never *widen* the permitted surface |

**Why `EACCES` is safe for a denylist and not for an allowlist.** After walking
up, the tail is rejoined and still matched against the denied surface, so a
masked directory still matches and still blocks. Widening a denylist match is
fail-safe; widening an allowlist grant is not.

**Why not `ELOOP` / `ENOTDIR` / `EPERM` / `ENAMETOOLONG` / `EIO`.** My first
draft recovered from all of them. `ELOOP` means an attacker-controlled symlink
graph and `ENOTDIR` means a plantable mid-path file — walking above either
discards exactly the identity information the guard needs, and neither occurred
in the production case. `EPERM` is tempting but Linux reports missing search
permission as `EACCES`; broadening it should require an observed case. These
stay fail-closed.

The unification also resolved a real divergence: the read guard returned its
input on exhaustion while the three write guards threw. That is now the
explicit `onExhausted` option rather than an accident of which copy you read.

## What this does NOT do

- Does not change write-policy behavior. Same errno set, same exhaustion throw.
- Does not touch the ~30 ad-hoc `ENOENT` checks elsewhere in `src/`. Only the
  four longest-existing-prefix canonicalizers are unified; the rest are
  unrelated file-IO fallbacks and folding them in would risk behavior changes
  for no benefit.
- Does not replace string-based guarding with descriptor/inode authorization.
  `enforceAndPinToolFiles` remains the definitive boundary for declared inputs;
  this guard is one layer, not the credential boundary.
- Does not change the sandbox masking design. Model-driven `agent-messenger`
  CLIs still cannot authenticate — that is intentional, and unrelated to this
  false positive.

## Review notes

The load-bearing change is the errno asymmetry between the two call sites. If
you read one comment, read the `RECOVER_MISSING` vs
`RECOVER_MISSING_OR_UNSEARCHABLE` pair — collapsing them into one set is the
plausible future mistake, and it would silently widen write authorization.

The invariant to verify is **no false negatives**: `still blocks when the
EACCES leaf resolves under a denied directory` proves recovery is not a bypass.
Reverting the production line to `ENOENT`-only fails two of the new tests, so
they test behavior rather than restating it. That test also documents a second
symptom of the old bug: genuinely denied paths were being reported as generic
internal errors instead of proper denials.

Unrelated: the `typeclaw.schema.json` drift-guard test already fails on `main`
(reproduced with this branch stashed). Not addressed here to keep the diff
scoped.